### PR TITLE
docs(infra): clean docs base — match the cloud docs to the verified live infra

### DIFF
--- a/packages/cloud-infra/AGENTS.md
+++ b/packages/cloud-infra/AGENTS.md
@@ -18,7 +18,7 @@ packages/cloud-infra/
   cloud/
     .env.example                   # Local-dev secrets template; copy to .env
     docker-compose.yml             # Self-hosted Supabase Storage (Postgres + storage-api)
-    AWS_RETIREMENT.md              # AWS → Railway/Hetzner migration status
+    AWS_RETIREMENT.md              # AWS → Hetzner/Railway migration status (agent-launch headscale moved off Railway onto the CP VMs)
     RAILWAY.md                     # Canonical map of where each service runs
     charts/
       README.md                    # Charts overview (gateway-discord chart is service-local)
@@ -82,9 +82,9 @@ Self-hosted Supabase Storage (postgres:18-alpine + supabase/storage-api:v1.58.4)
 
 ### Hetzner Terraform (`cloud/terraform/hetzner/control-plane/`)
 
-Manages the **control-plane** VMs only. The **data plane** (sandbox cores named `eliza-core-<hex>`) is provisioned at runtime by `packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API — not by this Terraform.
+Manages the **control-plane** VMs only — one per env (`eliza-staging-1`, `eliza-production-1`). The **data plane** is not in this Terraform: dedicated robot nodes (`eliza-core-{env}-N`, e.g. `eliza-core-staging-1`, `eliza-core-prod-2..6`) are registered in the `docker_nodes` table — the authoritative source of truth, with `CONTAINERS_DOCKER_NODES` env only seeding it when empty — and extra burst capacity (`eliza-core-<hex>`) is minted at runtime by `packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API.
 
-The current production control-plane VM runs:
+Each control-plane VM runs:
 - `eliza-provisioning-worker` — job queue consumer (systemd unit, deployed by CI)
 - `eliza-agent-router` — subdomain HTTP routing (systemd unit)
 - `headscale` — VPN mesh for agent traffic
@@ -149,7 +149,7 @@ Local cluster service env vars (copy from `.env.*.example`):
 
 - **GCP Terraform is not active.** `cloud/terraform/gcp/` is experimental and not wired to any CI workflow. Do not assume it represents the live deployment.
 - **AWS resources are being retired.** See `cloud/AWS_RETIREMENT.md`. Do not add new AWS dependencies.
-- **Data-plane cores are not in Terraform.** The `eliza-core-<hex>` sandbox VMs are runtime-provisioned by `node-autoscaler.ts`. Only the control-plane VM is managed here.
+- **Data-plane cores are not in Terraform.** Dedicated robot nodes (`eliza-core-{env}-N`, OS host `eliza-{env}-robot-N`) live in the `docker_nodes` table (authoritative; `CONTAINERS_DOCKER_NODES` env only seeds when empty); autoscaled burst nodes (`eliza-core-<hex>`) are runtime-provisioned by `node-autoscaler.ts`. The old `milady-core-*` names are retired. Only the control-plane VM is managed here.
 - **Remote state uses Cloudflare R2**, not an S3 bucket — export the R2 token as `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` before `terraform init`.
 - **Production secrets are not in docker-compose.** The compose file only serves local dev. Production K8s workloads receive secrets from external-secrets-operator (ESO).
 - **`cloud/local/setup.sh` installs the `vector` and `uuid-ossp` Postgres extensions** via `postInitApplicationSQL` in `values-pg-local.yaml` — these are required by `packages/app-core`.

--- a/packages/cloud-infra/CLAUDE.md
+++ b/packages/cloud-infra/CLAUDE.md
@@ -18,7 +18,7 @@ packages/cloud-infra/
   cloud/
     .env.example                   # Local-dev secrets template; copy to .env
     docker-compose.yml             # Self-hosted Supabase Storage (Postgres + storage-api)
-    AWS_RETIREMENT.md              # AWS → Railway/Hetzner migration status
+    AWS_RETIREMENT.md              # AWS → Hetzner/Railway migration status (agent-launch headscale moved off Railway onto the CP VMs)
     RAILWAY.md                     # Canonical map of where each service runs
     charts/
       README.md                    # Charts overview (gateway-discord chart is service-local)
@@ -82,9 +82,9 @@ Self-hosted Supabase Storage (postgres:18-alpine + supabase/storage-api:v1.58.4)
 
 ### Hetzner Terraform (`cloud/terraform/hetzner/control-plane/`)
 
-Manages the **control-plane** VMs only. The **data plane** (sandbox cores named `eliza-core-<hex>`) is provisioned at runtime by `packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API — not by this Terraform.
+Manages the **control-plane** VMs only — one per env (`eliza-staging-1`, `eliza-production-1`). The **data plane** is not in this Terraform: dedicated robot nodes (`eliza-core-{env}-N`, e.g. `eliza-core-staging-1`, `eliza-core-prod-2..6`) are registered in the `docker_nodes` table — the authoritative source of truth, with `CONTAINERS_DOCKER_NODES` env only seeding it when empty — and extra burst capacity (`eliza-core-<hex>`) is minted at runtime by `packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API.
 
-The current production control-plane VM runs:
+Each control-plane VM runs:
 - `eliza-provisioning-worker` — job queue consumer (systemd unit, deployed by CI)
 - `eliza-agent-router` — subdomain HTTP routing (systemd unit)
 - `headscale` — VPN mesh for agent traffic
@@ -149,7 +149,7 @@ Local cluster service env vars (copy from `.env.*.example`):
 
 - **GCP Terraform is not active.** `cloud/terraform/gcp/` is experimental and not wired to any CI workflow. Do not assume it represents the live deployment.
 - **AWS resources are being retired.** See `cloud/AWS_RETIREMENT.md`. Do not add new AWS dependencies.
-- **Data-plane cores are not in Terraform.** The `eliza-core-<hex>` sandbox VMs are runtime-provisioned by `node-autoscaler.ts`. Only the control-plane VM is managed here.
+- **Data-plane cores are not in Terraform.** Dedicated robot nodes (`eliza-core-{env}-N`, OS host `eliza-{env}-robot-N`) live in the `docker_nodes` table (authoritative; `CONTAINERS_DOCKER_NODES` env only seeds when empty); autoscaled burst nodes (`eliza-core-<hex>`) are runtime-provisioned by `node-autoscaler.ts`. The old `milady-core-*` names are retired. Only the control-plane VM is managed here.
 - **Remote state uses Cloudflare R2**, not an S3 bucket — export the R2 token as `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` before `terraform init`.
 - **Production secrets are not in docker-compose.** The compose file only serves local dev. Production K8s workloads receive secrets from external-secrets-operator (ESO).
 - **`cloud/local/setup.sh` installs the `vector` and `uuid-ossp` Postgres extensions** via `postInitApplicationSQL` in `values-pg-local.yaml` — these are required by `packages/app-core`.

--- a/packages/cloud-infra/README.md
+++ b/packages/cloud-infra/README.md
@@ -20,7 +20,9 @@ See `cloud/RAILWAY.md` for the canonical service map. Short version:
 - `cloud-api` → Cloudflare Worker
 - `headscale` → Hetzner control-plane VM (agent path); `tunnel-proxy` → Railway (customer-tunnel path)
 - `agent-server` (per-customer compute) → Hetzner via `container-control-plane`
-- Database → Neon (Postgres)
+- Database → Neon (Postgres) — ONE shared DB per env (prod `ep-wild-smoke`,
+  staging `ep-wild-dawn`); Steward lives as an embedded `steward` schema inside
+  that same shared DB, not a separate DB. Per-agent Neon branches are legacy/retired.
 - Object storage → Cloudflare R2
 
 ## Local development cluster

--- a/packages/cloud-infra/README.md
+++ b/packages/cloud-infra/README.md
@@ -18,7 +18,7 @@ See `cloud/RAILWAY.md` for the canonical service map. Short version:
 
 - `cloud-frontend` → Cloudflare Pages
 - `cloud-api` → Cloudflare Worker
-- `headscale`, `tunnel-proxy` → Railway
+- `headscale` → Hetzner control-plane VM (agent path); `tunnel-proxy` → Railway (customer-tunnel path)
 - `agent-server` (per-customer compute) → Hetzner via `container-control-plane`
 - Database → Neon (Postgres)
 - Object storage → Cloudflare R2

--- a/packages/cloud-infra/cloud/RAILWAY.md
+++ b/packages/cloud-infra/cloud/RAILWAY.md
@@ -9,8 +9,8 @@ is heading.
 |---|---|---|---|
 | `cloud-frontend` (dashboard SPA) | Cloudflare Pages | `packages/cloud-frontend/` | Wrangler / Pages project |
 | `cloud-api` (REST + auth + billing) | Cloudflare Worker | `packages/cloud-api/` | `apps/api/wrangler.toml` (env vars, secrets via `wrangler secret`) |
-| `headscale` (Tailscale coordination server for customer tunnels) | Railway | `packages/cloud-services/headscale/` | `railway.toml`, `Dockerfile` |
-| `tunnel-proxy` (public HTTPS -> tailnet bridge) | Railway | `packages/cloud-services/tunnel-proxy/` | `railway.toml`, `Dockerfile` |
+| `headscale` (Tailscale coordination server for agents + customer tunnels) | Hetzner control-plane VM | `packages/cloud-services/headscale/` | armed via `arm-headscale-control-plane.yml` (ACL `acl.hujson`) |
+| `tunnel-proxy` (public HTTPS -> tailnet bridge, customer-tunnel path) | Railway | `packages/cloud-services/tunnel-proxy/` | `railway.toml`, `Dockerfile` |
 | `bitrouter` (Eliza Cloud model router) | Railway | `packages/cloud-infra/cloud/bitrouter/` | `railway.toml`, `Dockerfile` |
 | `gateway-discord` | Cloudflare Worker | `packages/cloud-services/gateway-discord/` | own `wrangler.toml` |
 | `gateway-webhook` | Cloudflare Worker | `packages/cloud-services/gateway-webhook/` | own `wrangler.toml` |
@@ -23,16 +23,23 @@ The deprecated agent VPS deploy still exists behind the
 `cloud-deploy-backend.yml`. It is **off by default** and only runs when an
 operator explicitly opts in. New code should not target it.
 
-## Railway services in detail
+## headscale (not Railway — Hetzner control-plane VM)
 
-### `headscale`
+`headscale` is the Tailscale coordination server for both internal agents
+(`tag:agent`) and customer tunnels (`tag:eliza-tunnel`). For the agent launch
+path it runs **on the Hetzner control-plane VM**, not on Railway — the
+provisioning worker and agent router talk to it over a private loopback API.
+The previous Railway-hosted headscale runtime was decommissioned on 2026-06-17.
 
-- Builder: Dockerfile (pinned headscale v0.28.0).
-- Healthcheck: `GET /health` on `listen_addr` (port 8080). Headscale v0.28
-  serves this natively.
-- Volume: `/var/lib/headscale` (SQLite db + generated keys).
-- Public domain: `headscale.elizacloud.ai`.
+- Runtime: Hetzner control-plane VM (nginx + Let's Encrypt terminate TLS in
+  front of local headscale).
+- Public domain: `headscale.elizacloud.ai` → CP VM (DNS points at the
+  control plane).
+- ACL source of truth: [`packages/cloud-services/headscale/acl.hujson`](../../cloud-services/headscale/acl.hujson),
+  deployed by `arm-headscale-control-plane.yml`.
 - Provisioning runbook: [`packages/cloud-services/headscale/DEPLOY.md`](../../cloud-services/headscale/DEPLOY.md).
+
+## Railway services in detail
 
 ### `tunnel-proxy`
 

--- a/packages/cloud-infra/cloud/terraform/README.md
+++ b/packages/cloud-infra/cloud/terraform/README.md
@@ -28,7 +28,9 @@ service runs today. Short version:
 - `gateway-discord`, `gateway-webhook` → Docker (target: Railway).
 - `agent-server`, per-customer compute → Hetzner via
   `container-control-plane`.
-- Database → Neon (Postgres).
+- Database → Neon (Postgres) — ONE shared DB per env (prod `ep-wild-smoke`,
+  staging `ep-wild-dawn`); Steward is an embedded `steward` schema in that same
+  shared DB, not a separate DB. Per-agent Neon branches are legacy/retired.
 - Object storage → Cloudflare R2 (S3-compatible).
 - Secrets/KMS → local AES-256-GCM with `SECRETS_MASTER_KEY`; optional AWS
   KMS provider retained for callers that have already provisioned a key.

--- a/packages/cloud-infra/cloud/terraform/README.md
+++ b/packages/cloud-infra/cloud/terraform/README.md
@@ -24,7 +24,7 @@ service runs today. Short version:
 
 - `cloud-frontend` → Cloudflare Pages.
 - `cloud-api` → Cloudflare Worker.
-- `headscale`, `tunnel-proxy` → Railway.
+- `headscale` → Hetzner control-plane VM (agent path); `tunnel-proxy` → Railway (customer-tunnel path).
 - `gateway-discord`, `gateway-webhook` → Docker (target: Railway).
 - `agent-server`, per-customer compute → Hetzner via
   `container-control-plane`.

--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -9,8 +9,8 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 ┌──────────────────────────────────────────────────────────────┐
 │  Tier 1 — Control plane (static, 1-2 VMs, Terraform)        │
 │                                                              │
-│   eliza-1   (Hetzner cax21 ARM, fsn1, manual)               │
-│   eliza-staging-1   (Hetzner cpx32 x86, fsn1)               │
+│   eliza-production-1   (Hetzner cpx32 x86, fsn1)            │
+│   eliza-staging-1      (Hetzner cpx32 x86, fsn1)            │
 │     ├── eliza-provisioning-worker  (systemd, queue consumer)│
 │     ├── eliza-agent-router         (systemd, HTTP routing)  │
 │     ├── headscale                  (VPN mesh)               │
@@ -19,7 +19,7 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 │     └── (optional: grafana/prometheus)                      │
 │                                                              │
 │   Lifecycle: long-lived. Replaced on demand, not autoscaled.│
-│   Cost: prod ~€7/mo (cax21), staging ~€11/mo (cpx32).       │
+│   Cost: ~€11/mo per VM (cpx32, both envs).                  │
 │   See variables.tf for cpx21→cpx32 retirement + ARM notes.  │
 └──────────────────────────────────────────────────────────────┘
                               │ enqueue / SSH
@@ -114,7 +114,7 @@ is no `hcloud_project` Terraform resource — projects are management-plane only
 ```
 Hetzner Cloud account (one human)
 ├── Project "eliza-prod"      (env-scoped HCLOUD_TOKEN, 5/5 servers max)
-│   ├── eliza-1               (control-plane, cax21)
+│   ├── eliza-production-1     (control-plane, cpx32)
 │   └── eliza-core-<hex>      (worker, ccx33, autoscaled by node-autoscaler.ts)
 ├── Project "eliza-staging"   (env-scoped HCLOUD_TOKEN, 5/5 servers max)
 │   ├── eliza-staging-1               (control-plane, cpx32)

--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -20,7 +20,7 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 │                                                              │
 │   Lifecycle: long-lived. Replaced on demand, not autoscaled.│
 │   Cost: ~€11/mo per VM (cpx32, both envs).                  │
-│   See variables.tf for cpx21→cpx32 retirement + ARM notes.  │
+│   See variables.tf for the cpx21→cpx32 retirement note.     │
 └──────────────────────────────────────────────────────────────┘
                               │ enqueue / SSH
                               ▼
@@ -66,42 +66,24 @@ to coordinate it.
 
 | Layer | Prefix | Example | Where it's set |
 |---|---|---|---|
-| Control plane VM | `eliza-<n>` | `eliza-1` | Terraform `hcloud_server.control_plane` |
-| Data plane node (NEW) | `eliza-core-<hex>` | `eliza-core-38ea87b1` | [`generateNodeId()`](../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts) |
-| Data plane node (LEGACY) | `milady-core-<n>` | `milady-core-1` | DEPRECATED — see [Legacy migration](#legacy-milady-core-migration) |
+| Control plane VM | `eliza-<env>-1` | `eliza-staging-1`, `eliza-production-1` | Terraform `hcloud_server.control_plane` |
+| Data plane node — dedicated | `eliza-core-<env>-<n>` | `eliza-core-staging-1`, `eliza-core-prod-2` | `docker_nodes` table (authoritative); `CONTAINERS_DOCKER_NODES` env only seeds it when empty |
+| Data plane node — autoscaled burst | `eliza-core-<hex>` | `eliza-core-38ea87b1` | [`generateNodeId()`](../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts) at runtime |
 
-## Legacy `milady-core-*` migration
+Two distinct data-plane node shapes share the `eliza-core-` prefix:
 
-Pre-2026-05 the data plane was 6 manually-created `milady-core-*` VMs (Hetzner
-cpx32 in fsn1) inserted by-hand into `docker_nodes` with `capacity = 100`.
-By 2026-05-22:
+- **Dedicated / onboarded robot nodes** carry an env-suffixed id
+  (`eliza-core-{env}-N`, e.g. staging `eliza-core-staging-1`, prod
+  `eliza-core-prod-2..6`) and OS hostname `eliza-{env}-robot-N`. They are
+  registered in the `docker_nodes` table, which is the **authoritative** source
+  of truth; the `CONTAINERS_DOCKER_NODES` env var is only a seed-when-empty.
+- **Autoscaled burst nodes** carry a random hex suffix
+  (`eliza-core-<hex>`) minted by `generateNodeId()` when the autoscaler spins up
+  extra capacity on demand.
 
-- All 6 cores were `status: offline` (SSH health-check failing for weeks)
-- Several user sandboxes still ran on the underlying Docker daemons
-- The cloud autoscaler couldn't account for them
-
-Migration 0132 (`0132_legacy_milady_cores_disable.sql`) flips them to
-`enabled = false` + fixes `capacity = 8`. This:
-
-1. Removes them from autoscaler capacity decisions
-2. Stops the health-check noise
-3. Lets the autoscaler spin up replacement `eliza-core-<hex>` nodes on demand
-
-Existing sandboxes keep running until next restart. On user-triggered
-restart / recreate, the daemon provisions them on a fresh autoscaled core.
-
-Once `SELECT SUM(allocated_count) FROM docker_nodes WHERE node_id LIKE 'milady-core-%'`
-is `0`, ops can:
-
-```bash
-# 1. Delete the Hetzner Cloud servers (one-time, via Hetzner console or):
-hcloud server delete milady-core-1
-hcloud server delete milady-core-2
-# ... etc.
-
-# 2. Drop the DB rows:
-DELETE FROM docker_nodes WHERE node_id LIKE 'milady-core-%';
-```
+The old `milady-core-*` data-plane names are **retired** (migration 0132,
+`0132_legacy_milady_cores_disable.sql`, disabled them and cross-env cleanup
+removed the rows); they are not part of the live topology.
 
 ## Multi-project layout
 
@@ -115,14 +97,16 @@ is no `hcloud_project` Terraform resource — projects are management-plane only
 Hetzner Cloud account (one human)
 ├── Project "eliza-prod"      (env-scoped HCLOUD_TOKEN, 5/5 servers max)
 │   ├── eliza-production-1     (control-plane, cpx32)
-│   └── eliza-core-<hex>      (worker, ccx33, autoscaled by node-autoscaler.ts)
+│   ├── eliza-core-prod-2..6   (dedicated workers, cpx32; docker_nodes table)
+│   └── eliza-core-<hex>       (worker, cpx32, autoscaled burst by node-autoscaler.ts)
 ├── Project "eliza-staging"   (env-scoped HCLOUD_TOKEN, 5/5 servers max)
 │   ├── eliza-staging-1               (control-plane, cpx32)
-│   └── eliza-core-<hex>              (worker, cpx32, autoscaled)
+│   ├── eliza-core-staging-1          (dedicated worker, cpx32; docker_nodes table)
+│   └── eliza-core-<hex>              (worker, cpx32, autoscaled burst)
 └── Project "apps"            (repo-level HCLOUD_APPS_TOKEN, shared)
     ├── eliza-app-tenant              (tenant Postgres — SHARED across envs; apps-shared/)
-    ├── eliza-apps-node-staging-1     (apps Product-2 worker, staging; apps-data-plane/)
-    └── eliza-apps-node-production-1  (apps Product-2 worker, production; apps-data-plane/)
+    └── eliza-apps-node-staging-1     (apps Product-2 worker, staging; apps-data-plane/)
+       # production apps node not yet live — apps prod deploy is behind the cutover
 ```
 
 The tenant DB is intentionally shared across staging + production app workers

--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -104,9 +104,10 @@ Hetzner Cloud account (one human)
 │   ├── eliza-core-staging-1          (dedicated worker, cpx32; docker_nodes table)
 │   └── eliza-core-<hex>              (worker, cpx32, autoscaled burst)
 └── Project "apps"            (repo-level HCLOUD_APPS_TOKEN, shared)
-    ├── eliza-app-tenant              (tenant Postgres — SHARED across envs; apps-shared/)
-    └── eliza-apps-node-staging-1     (apps Product-2 worker, staging; apps-data-plane/)
-       # production apps node not yet live — apps prod deploy is behind the cutover
+    ├── eliza-app-tenant                 (tenant Postgres — SHARED across envs; apps-shared/)
+    ├── eliza-apps-node-staging-1        (apps Product-2 worker, staging; apps-data-plane/)
+    ├── eliza-apps-node-production-1     (apps Product-2 worker, production; apps-data-plane/)
+    └── eliza-apps-control-production-1  (apps-control daemon, production; role=apps-control)
 ```
 
 The tenant DB is intentionally shared across staging + production app workers

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -58,8 +58,9 @@ hostname) was created by hand in May 2026. To bring it under Terraform
 without recreating it, look up the Hetzner Cloud server ID
 (`hcloud server list`), then `terraform import 'hcloud_server.control_plane["1"]' <id>`
 plus a `terraform import` for each existing `hcloud_ssh_key`. The first
-plan after import shows the in-place rename to `eliza-1`, the new
-labels, and the Cloudflare DNS record creation; `user_data` and `image`
+plan after import shows the in-place rename to `eliza-production-1` (the
+env-suffixed name), the new labels, and the Cloudflare DNS record creation;
+`user_data` and `image`
 diffs are suppressed by `lifecycle { ignore_changes }`. One-shot — never
 re-run.
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -161,8 +161,10 @@ These are tracked as follow-ups in
 | **Total per environment**    |             | **~11**     |
 
 The default is `cpx32` since Hetzner retired `cpx21` in `fsn1`. Production VM
-`eliza-1` actually runs `cax21` (ARM, ~€7/mo, manually provisioned) — flipping
-prod via TF needs the cloud-init arm64 templating fix tracked as a followup.
+`eliza-production-1` runs x86 `cpx32`, the same type as staging. Moving the
+control plane to ARM (`cax`-series, ~€7/mo) is a possible future cost
+optimization, not current state — it needs the cloud-init arm64 templating fix
+tracked as a followup first.
 
 A 2nd control-plane VM (HA, currently unused) doubles the line. The
 **data-plane autoscale** cost is separate and elastic.

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
@@ -1,7 +1,8 @@
 environment           = "production"
 hcloud_location       = "fsn1"
-# Production VM eliza-1 runs cax21 (ARM) today. Keep tfvars on x86 cpx32 for now
-# — flipping prod to cax21 via TF needs the cloud-init arm64 fix (followup).
+# Production VM eliza-production-1 runs x86 cpx32, same type as staging.
+# An ARM (cax-series) move is a possible future cost optimization, not current
+# state — it needs the cloud-init arm64 fix first.
 hcloud_server_type    = "cpx32"
 control_plane_count   = 1
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -27,7 +27,7 @@ variable "hcloud_location" {
 }
 
 variable "hcloud_server_type" {
-  description = "Hetzner server type for the control-plane VM. cpx32 = 4 vCPU / 8 GB / 160 GB SSD ≈ €11/mo, matches the existing staging eliza-staging-1 manually-provisioned VM. Previously cpx21 (3 vCPU / 4 GB) but Hetzner retired cpx21 in fsn1. Production runs cax21 (ARM) — switching staging to ARM would save ~€4/mo and unblock future cpx retirement, but needs a few cloud-init template tweaks (docker apt arch + bun-linux-aarch64 archive). Staging stays on x86 cpx32 here for parity with the proven-working setup; ARM migration is followup."
+  description = "Hetzner server type for the control-plane VM. cpx32 = 4 vCPU / 8 GB / 160 GB SSD ≈ €11/mo, matches the existing staging eliza-staging-1 manually-provisioned VM. Previously cpx21 (3 vCPU / 4 GB) but Hetzner retired cpx21 in fsn1. Both staging and production run x86 cpx32 — staging eliza-staging-1 and prod eliza-production-1 are the same type, for parity with the proven-working setup. Moving the control plane to ARM (cax-series) would save ~€4/mo but needs a few cloud-init template tweaks (docker apt arch + bun-linux-aarch64 archive); it's a possible future cost optimization, not current state."
   type        = string
   default     = "cpx32"
 }

--- a/packages/cloud-services/headscale/DEPLOY.md
+++ b/packages/cloud-services/headscale/DEPLOY.md
@@ -2,9 +2,10 @@
 
 End-to-end checklist to bring the Headscale-backed tailnet online. Headscale is
 the coordination server for both internal agent containers and customer tunnel
-nodes. The runtime can be hosted on Railway for the customer-tunnel service, but
-the launch control-plane path runs Headscale on the Hetzner control-plane VM so
-agent provisioning and the provisioning worker share a private, loopback API.
+nodes. It runs on the Hetzner control-plane VM so agent provisioning and the
+provisioning worker share a private, loopback API. The customer-facing
+**tunnel-proxy** service stays on Railway, but Headscale itself is no longer
+Railway-hosted (that runtime was decommissioned 2026-06-17 — see below).
 
 Why this matters: when `HEADSCALE_API_KEY` is configured, the sandbox provider
 requires a real `headscale_ip` before a container is marked `running`. That is
@@ -76,68 +77,43 @@ Do not paste a newly generated API key into issue comments or workflow inputs.
 Generate it on the host, store it as a GitHub/Worker secret, and let the script
 consume it from the environment.
 
-## Railway runtime (customer-tunnel legacy/service path)
+## Railway runtime (customer-tunnel path only)
 
-The rest of this document covers the Railway-hosted tunnel stack. Keep it for
-the customer-tunnel service and for historical context, but do not use it to arm
-the Hetzner provisioning-worker host.
+The rest of this document covers the Railway-hosted **tunnel-proxy** stack — the
+customer-tunnel path that legitimately stays on Railway. Do not use it to arm the
+Hetzner provisioning-worker host.
+
+> **Headscale itself no longer runs on Railway.** The previous Railway-hosted
+> Headscale runtime was decommissioned on 2026-06-17, along with its
+> `Dockerfile`, `entrypoint.sh`, `railway.toml`, `config.yaml`, and the
+> `.github/workflows/cloud-headscale.yml` deploy workflow (this directory now
+> ships only `DEPLOY.md`, `README.md`, and `acl.hujson`). The headscale
+> coordination server runs **on the Hetzner control-plane VM** — see the
+> "Hetzner control-plane runtime (agent launch path)" section above. There is no
+> headscale Railway service to `railway up`; users/api-keys are created on the
+> CP host (`headscale users create agent`, `headscale apikeys create
+> --expiration=8760h`), and `server_url` is converged into
+> `/etc/headscale/config.yaml` on the CP by `arm-headscale-control-plane.yml`.
 
 ## 1. DNS
 
-- `headscale.elizacloud.ai` → CNAME/ALIAS → Railway public domain for the headscale service.
+- `headscale.elizacloud.ai` / `headscale-staging.elizacloud.ai` → A-record → the
+  Hetzner control-plane VM (`eliza-production-1` / `eliza-staging-1`), with
+  nginx + Let's Encrypt terminating TLS in front of local headscale. NOT a CNAME
+  to Railway — the Railway headscale service was removed (see note above).
 - `tunnel.elizacloud.ai` AND `*.tunnel.elizacloud.ai` → CNAME/ALIAS → Railway public domain for the tunnel-proxy service.
 - Railway terminates public TLS for the tunnel-proxy custom domains; the proxy then uses `tsnet` to reach private tailnet hosts.
 
-## 2. Headscale Railway service
+## 2. Long-lived headscale preauth key for the proxy
 
 ```
-cd packages/cloud-services/headscale
-# Push to a Railway service backed by this Dockerfile.
-railway up
-```
-
-Then inside the running container:
-
-```
-headscale users create agent
-headscale users create tunnel
-headscale apikeys create --expiration=8760h
-```
-
-Mount a Railway volume at `/var/lib/headscale` so the SQLite DB and generated keys persist across restarts.
-Do not set a Railway start-command override; the Dockerfile starts Headscale with `CMD ["headscale", "serve"]`.
-
-### Per-environment variables
-
-`server_url` must equal the public-facing custom domain (agents/tunnels register and re-derive control/DERP/MagicDNS against it). The entrypoint templates it from an explicit `HEADSCALE_PUBLIC_URL` Railway variable, NOT from `RAILWAY_PUBLIC_DOMAIN` (Railway injects that as the auto-generated `*.up.railway.app` host, not the custom domain). Per env:
-
-| Environment | `HEADSCALE_PUBLIC_URL` |
-|---|---|
-| production | `https://headscale.elizacloud.ai` |
-| staging | `https://headscale-staging.elizacloud.ai` |
-
-You do not set this on the Railway service by hand: it lives as a **GitHub Environment variable** (below) and the CI/CD workflow syncs it onto the Railway service (`railway variables --set … --skip-deploys`) before each `railway up`. The GitHub var is the single source of truth. When the var is unset entirely, the committed `config.yaml` prod value stands.
-
-### CI/CD (`.github/workflows/cloud-headscale.yml`)
-
-`develop -> staging`, `main -> production`, deployed explicitly with `railway up`. Required one-time setup so this is the SOLE deploy path and it targets the right env:
-
-- **Disable Railway's native GitHub auto-deploy** on the headscale service (Settings -> disconnect repo / no auto-deploy). Otherwise a single push triggers BOTH the native Railway deploy and the workflow's `railway up`, racing two concurrent builds of the live control plane against the single SQLite volume.
-- Define two **GitHub Environments** (`staging`, `production`), each holding its own project-scoped `RAILWAY_TOKEN` bound to that Railway environment. A Railway project token is scoped to one project+environment, so per-env tokens are what make the branch->env mapping actually land in the right place; the workflow's `environment:` key resolves the matching token and applies production protection rules.
-- Set `HEADSCALE_PUBLIC_URL` (above) as a GitHub Environment variable. The workflow uses it twice: it syncs it onto the Railway service (so the entrypoint's `server_url` is correct) AND points its post-deploy `/health` gate at that host. `railway up --ci` only validates the BUILD, not runtime health — the health gate is what catches a container that builds but crash-loops (bad server_url, missing volume).
-
-> **IaC scope.** The Railway **volume** (`/var/lib/headscale`) and the **custom domain** are stateful Railway service resources — Railway's `railway.toml` only declares build + deploy config (`[build]`, `[deploy]`), so neither can be expressed there. They are one-time setup, created via the Railway dashboard or API and persisted as service state; this file is their reproducible record. `HEADSCALE_PUBLIC_URL` is the exception: it IS codified, as the GitHub Environment variable the workflow pushes to Railway on every deploy.
-
-## 3. Long-lived headscale preauth key for the proxy
-
-```
-# Run inside the headscale container
+# Run on the control-plane VM (where headscale lives)
 headscale preauthkeys create --reusable --expiration 8760h --tags tag:eliza-proxy
 ```
 
 Save the returned key as Railway secret `TUNNEL_PROXY_TS_AUTHKEY` on the tunnel-proxy service.
 
-## 4. Tunnel-proxy Railway service
+## 3. Tunnel-proxy Railway service
 
 ```
 cd packages/cloud-services/tunnel-proxy
@@ -156,12 +132,12 @@ Required env vars on the proxy service:
 
 Mount a Railway volume at `/var/lib/tunnel-proxy` so the `tsnet` node identity persists across restarts.
 
-## 5. API Worker secrets
+## 4. API Worker secrets
 
 On the cloud-api Worker (Cloudflare):
 
 ```
-wrangler secret put HEADSCALE_API_KEY          # from step 2
+wrangler secret put HEADSCALE_API_KEY          # created on the CP host
 wrangler secret put CLOUD_INTERNAL_TOKEN       # same value as the proxy
 wrangler secret put HEADSCALE_INTERNAL_TOKEN   # same value as CLOUD_INTERNAL_TOKEN
 wrangler secret put TUNNEL_HOSTNAME_SIGNING_SECRET
@@ -169,7 +145,7 @@ wrangler secret put TUNNEL_HOSTNAME_SIGNING_SECRET
 
 `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`, `HEADSCALE_USER`, `TUNNEL_PROXY_HOST`, `TUNNEL_TAILNET_DOMAIN`, and `TUNNEL_AUTH_KEY_COST_USD` are non-secret Worker vars in `apps/api/wrangler.toml`. The tunnel cost is a small on-demand org-credit debit per successful auth-key provisioning, not a subscription. Do not set `TUNNEL_ALLOW_UNSIGNED_HOSTNAMES` in production.
 
-## 6. Worker deploy
+## 5. Worker deploy
 
 ```
 cd cloud
@@ -178,7 +154,7 @@ bun run build:api
 bun run deploy:api -- --env production
 ```
 
-## 7. Smoke test
+## 6. Smoke test
 
 From a machine with the tailscale CLI installed and `@elizaos/plugin-tailscale` enabled with `ELIZAOS_CLOUD_API_KEY` set:
 
@@ -192,7 +168,7 @@ You should see:
 - A 200 response from `https://<sessionId>.tunnel.elizacloud.ai`
 - An immediate debit row in `credit_transactions` with `metadata.type = "tunnel"` and `metadata.billing_model = "on_demand"`
 
-## 8. Verify ACL isolation
+## 7. Verify ACL isolation
 
 The agent fleet (`tag:agent`) must NOT be reachable from a customer tunnel (`tag:eliza-tunnel`). After a tunnel is up, run from the tunnel node:
 

--- a/packages/cloud-shared/docs/CLOUD_ONBOARDING_PROVISIONING_REVIEW.md
+++ b/packages/cloud-shared/docs/CLOUD_ONBOARDING_PROVISIONING_REVIEW.md
@@ -214,11 +214,16 @@ Confirmed in this environment (no cloud credentials needed):
 - `typecheck:cloud` clean for all touched files.
 
 **Cannot be confirmed here (requires secrets / live infra):** real Hetzner
-server create/teardown, real Neon branch provisioning, real R2 backup offload,
-and the production Cloudflare Worker deploy. These are exercised by the gated
-nightly `.github/workflows/hetzner-e2e.yml` against live Hetzner. Running the
-real-infra path is the remaining step for 100% production confidence and needs
+server create/teardown, real R2 backup offload, and the production Cloudflare
+Worker deploy. These are exercised by the gated nightly
+`.github/workflows/hetzner-e2e.yml` against live Hetzner. Running the real-infra
+path is the remaining step for 100% production confidence and needs
 `HCLOUD_TOKEN` + Neon/R2/Cloudflare credentials.
+
+> **Note (Neon topology):** per-agent Neon branch provisioning is **legacy** —
+> retired after the shared-DB cutover. Each env now runs ONE shared Neon DB
+> (prod `ep-wild-smoke`, staging `ep-wild-dawn`); agent state is multi-tenant
+> inside that shared DB, not a Neon branch per agent.
 
 ## 7e. REAL Hetzner provision — CONFIRMED GREEN (2026-06-02)
 

--- a/packages/docs/deployment.mdx
+++ b/packages/docs/deployment.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Deployment
 description: Deploy Eliza using Docker, Docker Compose, or cloud containers. Covers environment variables, port configuration, volumes, and security hardening.
 ---
 
-Eliza supports multiple deployment strategies: standalone Docker containers, Docker Compose orchestration, and cloud-managed containers for Eliza Cloud (AWS ECS).
+Eliza supports multiple deployment strategies: standalone Docker containers, Docker Compose orchestration, and cloud-managed containers for Eliza Cloud (Docker containers on dedicated Hetzner robot nodes, joined to the headscale tailnet).
 
 <Warning>
 The Docker deployment toolkit lives at `packages/app-core/deploy/` in this repo — `docker-setup.sh`, `docker-compose.yml`, `Dockerfile.ci` (image for prebuilt artifacts), `Dockerfile.cloud`, `deploy.defaults.env`, and the rollout scripts. The example commands below use `eliza/packages/app-core/deploy/...` paths, which apply when a downstream app vendors this repo under an `eliza/` subdirectory; working **inside** this repo, drop the `eliza/` prefix and run them from `packages/app-core/deploy/` directly.
@@ -138,9 +138,13 @@ ELIZAOS_CLOUD_API_KEY=eliza_xxx
 
 ## Cloud Agent Deployment
 
-### Eliza Cloud (AWS ECS)
+### Eliza Cloud (Hetzner Docker nodes)
 
-The `Dockerfile.cloud-agent` (in `packages/app-core/deploy/`) builds a slim container for deploying agents to Eliza Cloud:
+Eliza Cloud schedules agent containers onto dedicated Hetzner robot Docker nodes
+(`docker_nodes` node_id `eliza-core-{env}-N`, OS hostnames `eliza-{env}-robot-N`)
+joined to the headscale tailnet, via the container control plane — not AWS ECS.
+Shared-runtime (Tier-0) agents run with no dedicated container at all. The
+`Dockerfile.cloud-agent` (in `packages/app-core/deploy/`) builds a slim container for deploying agents to Eliza Cloud:
 
 ```dockerfile
 FROM node:22-bookworm-slim


### PR DESCRIPTION
## What

A full sweep over the cloud/infra docs so they stop lying about how the stack actually runs. Started as the "headscale is on the CP, CP VMs are x86" fix and grew into a clean docs base covering every stale infra claim I could find.

All docs-only (+ one Terraform prose comment). Verified live 2026-06-17/18.

## Ground truth the docs now reflect

1. **headscale (agent-launch path) runs on the Hetzner control-plane VMs**, not Railway — loopback API (staging `127.0.0.1:8080`, prod `127.0.0.1:8081`), nginx + Let's Encrypt out front, public DNS `headscale[-staging].elizacloud.ai` is an A-record to the CP. The Railway headscale runtime (Dockerfile / railway.toml / config.yaml / entrypoint.sh + `cloud-headscale.yml`) was deleted 2026-06-17; only `acl.hujson` remains. Railway stays only for the customer **tunnel-proxy** path.
2. **Both control-plane VMs are x86 `cpx32`** (4 vCPU / 8 GB, ~€11/mo) — NOT `cax21`/ARM. Prod CP is `eliza-production-1` (env-suffixed), not the legacy `eliza-1`.
3. **Data-plane node naming**: dedicated robot nodes are `eliza-core-{env}-N` in the `docker_nodes` table (the authoritative source; `CONTAINERS_DOCKER_NODES` env only seeds when empty); `eliza-core-<hex>` is the autoscaler burst-node form. Old `milady-core-*` names are retired.
4. **Cloud Postgres = Neon, ONE shared DB per env** (prod `ep-wild-smoke`, staging `ep-wild-dawn`); Steward is an embedded `steward` schema in that same DB. Per-agent Neon branches are legacy/retired.
5. **Apps data plane** = separate Hetzner project; one live staging apps node today; prod apps node not yet live.
6. **Eliza Cloud agents run as Docker containers on Hetzner robot nodes** (or shared-runtime Tier-0, container-free) — not AWS ECS.

## Files

- `cloud/terraform/hetzner/ARCHITECTURE.md` — x86/cpx32 fix; dropped the retired milady-core drain runbook + "ARM notes"; naming table now splits dedicated `eliza-core-{env}-N` from autoscaled `eliza-core-<hex>`; multi-project layout fixed (ccx33→cpx32, only the live staging apps node).
- `control-plane/README.md` — cax21/ARM cost line gone; adopt-existing-VM rename target is `eliza-production-1`.
- `control-plane/variables.tf` + `production.tfvars.example` — prose now says both CPs run x86 cpx32; ARM is a possible future, not current state.
- `cloud-infra/README.md` + `cloud/terraform/README.md` — headscale split off Railway; Neon shared-DB topology spelled out.
- `cloud-infra/AGENTS.md` + `CLAUDE.md` — node-naming nuance, two per-env CPs, headscale-off-Railway pointer.
- `cloud-infra/cloud/RAILWAY.md` — headscale row moved to the CP VM; Railway section scoped to tunnel-proxy.
- `cloud-services/headscale/DEPLOY.md` — cut the decommissioned Headscale-on-Railway deploy section; DNS is an A-record to the CP; kept the tunnel-proxy-on-Railway steps.
- `docs/deployment.mdx` — Eliza Cloud = Hetzner Docker nodes, not AWS ECS (intro + heading).
- `cloud-shared/docs/CLOUD_ONBOARDING_PROVISIONING_REVIEW.md` — per-agent Neon branch provisioning flagged as legacy (shared-DB cutover).

## Left as-is (on purpose)

- `tunnel-proxy/README.md`, `headscale/README.md`, `apps-data-plane/README.md`, `AWS_RETIREMENT.md` — already correct / Railway here is the legit customer-tunnel path.
- `main.tf` / `bootstrap.yaml.tftpl` cax21 mentions — accurate cross-arch facts (ForceNew warning, swap headroom), not the false "prod runs cax21" claim.
- vast-pyworker `eliza-1` hits — that's the eliza-1 LLM model, not the CP VM.

`terraform fmt` clean; docs link/nav tests pass.