### PR TITLE
fix(cloud): heartbeat cycle skips shared-runtime agents (no container to dial)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -26,8 +26,18 @@ const set = mock((values: Record<string, unknown>) => {
 const update = mock(() => ({ set }));
 const ensureAgentSandboxSchema = mock(async () => {});
 
+// Read-side select() chain: select(...).from(...).where(clause) -> rows.
+// `where` captures the clause into the shared `capturedWhere` so a test can
+// assert on the generated SQL, mirroring the write-side capture above.
+const selectWhere = mock((clause: SQL) => {
+  capturedWhere = clause;
+  return [] as unknown[];
+});
+const selectFrom = mock(() => ({ where: selectWhere }));
+const select = mock(() => ({ from: selectFrom }));
+
 mock.module("../helpers", () => ({
-  dbRead: {},
+  dbRead: { select },
   dbWrite: { update },
 }));
 
@@ -46,6 +56,28 @@ describe("AgentSandboxesRepository", () => {
     expect(ensureAgentSandboxSchema).toHaveBeenCalled();
     if (!capturedWhere) throw new Error("trySetProvisioning did not build a where clause");
     expect(new PgDialect().sqlToQuery(capturedWhere).sql).toContain("'sleeping'");
+  });
+
+  test("heartbeat selection excludes shared-runtime agents (no container to dial)", async () => {
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().listRunning();
+
+    if (!capturedWhere) throw new Error("listRunning did not build a where clause");
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    const sql = query.sql.toLowerCase();
+    // Only running rows are heartbeated...
+    expect(sql).toContain("status");
+    // ...and shared-tier rows are filtered out: they run container-free in the
+    // hosted shared runtime, so dialing them over Headscale always fails. The
+    // `<>` keeps that exclusion (NOT just `= 'shared'`).
+    expect(sql).toContain("execution_tier");
+    expect(sql).toContain("<>");
+    // eq/ne bind their operands, so the values land in `params`, not the SQL.
+    expect(query.params).toContain("running");
+    expect(query.params).toContain("shared");
   });
 
   test("marks only orphaned user-owned pending rows with no provision job as error", async () => {

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, desc, eq, gte, inArray, isNotNull, lt, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNotNull, lt, ne, notInArray, sql } from "drizzle-orm";
 import {
   applyBackupDelta,
   type BackupChainNode,
@@ -188,6 +188,13 @@ export class AgentSandboxesRepository {
       );
   }
 
+  /**
+   * Running sandboxes the heartbeat cycle should dial. Excludes the `shared`
+   * execution tier: those run container-free in the hosted shared runtime
+   * (node_id / container_name are NULL by design), so there is nothing to
+   * dial over the Headscale tunnel — heartbeating them only ever fails and
+   * spams the logs. Only dedicated/custom tiers have a real container.
+   */
   async listRunning(): Promise<Array<{ id: string; organization_id: string }>> {
     return dbRead
       .select({
@@ -195,7 +202,9 @@ export class AgentSandboxesRepository {
         organization_id: agentSandboxes.organization_id,
       })
       .from(agentSandboxes)
-      .where(eq(agentSandboxes.status, "running"));
+      .where(
+        and(eq(agentSandboxes.status, "running"), ne(agentSandboxes.execution_tier, "shared")),
+      );
   }
 
   /**


### PR DESCRIPTION
## What

The prod provisioning daemon spams this every ~20s:

```
[provisioning-worker] heartbeat cycle complete { total: 41, succeeded: 0, failed: 41 }
```

All 41 of those `agent_sandboxes` are `execution_tier=shared` (Tier-0 / shared-runtime). They run container-free in the hosted shared runtime, so `node_id` and `container_name` are NULL **by design** — there's no dedicated container to dial. The heartbeat path fetches the agent over the Headscale tunnel, which never applies to shared agents, so it always fails. Pure log noise, no actual downtime.

## Fix

`processHeartbeatCycle` -> `provisioningJobService.processRunningHeartbeats` -> `agentSandboxesRepository.listRunning()`. That selection was `status = 'running'` with no tier filter, so it scooped up every shared agent too.

Added `ne(execution_tier, 'shared')` to `listRunning()` so only dedicated/custom tiers — the ones with a real container — get heartbeated. The `shared` discriminator is confirmed in `schemas/agent-sandboxes.ts` (`AgentExecutionTier = "shared" | "dedicated-lazy" | "dedicated-always" | "custom"`, shared = container-free).

## Test

Extended `agent-sandboxes.test.ts` with a sociable test that captures the `listRunning()` where-clause and asserts it keeps `status='running'` AND excludes `execution_tier <> 'shared'` (eq/ne bind their operands, so it checks both the SQL shape and the bound params). All 3 tests in the file green.

## Scope

Two files, minimal. No migration, no behavior change for dedicated agents.