### PR TITLE
fix(scenario): app-control delete uninstalls via /api/plugins/uninstall

### DIFF
--- a/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
@@ -72,7 +72,9 @@ function shouldHandle(url: URL | null): url is URL {
     url !== null &&
     url.hostname === "127.0.0.1" &&
     (url.pathname.startsWith("/api/views") ||
-      url.pathname.startsWith("/api/apps"))
+      url.pathname.startsWith("/api/apps") ||
+      // VIEWS/delete now uninstalls via POST /api/plugins/uninstall.
+      url.pathname.startsWith("/api/plugins"))
   );
 }
 

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -323,6 +323,19 @@ export default scenario({
             return jsonResponse(unloadPluginResponse("@elizaos/plugin-feed"));
           }
 
+          // VIEWS/delete now performs a real uninstall via POST
+          // /api/plugins/uninstall (unloadPlugin checks `resp.ok && body.ok`),
+          // replacing the old /api/apps/stop teardown.
+          if (
+            request.method === "POST" &&
+            request.pathname === "/api/plugins/uninstall"
+          ) {
+            return jsonResponse({
+              ok: true,
+              message: "Plugin @elizaos/plugin-feed unloaded.",
+            });
+          }
+
           return undefined;
         });
 
@@ -1236,9 +1249,9 @@ export default scenario({
           {
             body: { name: "@elizaos/plugin-feed" },
             method: "POST",
-            pathname: "/api/apps/stop",
+            pathname: "/api/plugins/uninstall",
             response: {
-              body: unloadPluginResponse("@elizaos/plugin-feed"),
+              body: { ok: true, message: "Plugin @elizaos/plugin-feed unloaded." },
               status: 200,
             },
             search: "",
@@ -1253,9 +1266,9 @@ export default scenario({
           {
             body: { name: "@elizaos/plugin-feed" },
             method: "POST",
-            pathname: "/api/apps/stop",
+            pathname: "/api/plugins/uninstall",
             response: {
-              body: unloadPluginResponse("@elizaos/plugin-feed"),
+              body: { ok: true, message: "Plugin @elizaos/plugin-feed unloaded." },
               status: 200,
             },
             search: "",

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -601,6 +601,21 @@ export default scenario({
             return jsonResponse(unloadPluginResponse(pluginName));
           }
 
+          // VIEWS/delete now uninstalls via POST /api/plugins/uninstall
+          // (unloadPlugin checks `resp.ok && body.ok`).
+          if (
+            request.method === "POST" &&
+            request.pathname === "/api/plugins/uninstall"
+          ) {
+            const pluginName = String(
+              toRecord(request.body).name ?? "@elizaos/plugin-remote-ledger",
+            );
+            return jsonResponse({
+              ok: true,
+              message: `Plugin ${pluginName} unloaded.`,
+            });
+          }
+
           return undefined;
         });
 
@@ -915,9 +930,12 @@ export default scenario({
           {
             body: { name: "@elizaos/plugin-remote-ledger" },
             method: "POST",
-            pathname: "/api/apps/stop",
+            pathname: "/api/plugins/uninstall",
             response: {
-              body: unloadPluginResponse("@elizaos/plugin-remote-ledger"),
+              body: {
+                ok: true,
+                message: "Plugin @elizaos/plugin-remote-ledger unloaded.",
+              },
               status: 200,
             },
             search: "",


### PR DESCRIPTION
Fixes the Zero-Key scenario e2e failures (deterministic-app-control-actions + nl-routing). The 'real uninstall' code change moved teardown to POST /api/plugins/uninstall; the scenarios still mocked /api/apps/stop, so delete reported 'Deletion partially failed'. Intercept /api/plugins/*, add the uninstall handler, and update the exact HTTP ledger. Verified: 2/2 scenarios pass under strict LLM proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)