### PR TITLE
fix(test): main shared-agent webUiUrl assertion (Client Tests green)

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -933,7 +933,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       agentId: "shared-agent",
       bridgeUrl:
         "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent/bridge",
-      webUiUrl: null,
+      webUiUrl: "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent",
       executionTier: "shared",
     });
     expect(capacitorMocks.request).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
main's only Tests failure was one stale assertion: the shared-agent REST adapter normalizes `webUiUrl` (code identical to develop), but the native-auth test still expected `webUiUrl: null`. Updated to match the code. Verified on main: cloud-auth + shared-agent 24/24, deep-link/mobile-lifecycle 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)