### PR TITLE
feat(cloud-infra): codify headscale-on-CP cutover into IaC

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -57,6 +57,11 @@ jobs:
       HEADSCALE_PUBLIC_URL_VAR: ${{ vars.HEADSCALE_PUBLIC_URL }}
       HEADSCALE_API_URL: ${{ github.event.inputs.headscale_api_url }}
       HEADSCALE_LISTEN_ADDR: ${{ github.event.inputs.listen_addr }}
+      # Let's Encrypt account / expiry-notice email for the headscale vhost cert
+      # the arm script provisions. Optional GitHub Environment var; the script
+      # falls back to ops@elizalabs.ai when unset (so existing envs need no new
+      # var to keep working).
+      CERTBOT_EMAIL: ${{ vars.CERTBOT_EMAIL }}
     steps:
       - uses: actions/checkout@v4
 
@@ -100,6 +105,8 @@ jobs:
             echo "- Environment: \`${{ github.event.inputs.environment }}\`"
             echo "- Public URL: \`$HEADSCALE_PUBLIC_URL\`"
             echo "- Daemon API URL: \`$HEADSCALE_API_URL\`"
+            echo ""
+            echo "Also converged on the CP (idempotent): nginx vhost + Let's Encrypt cert for the public headscale URL, and the cp-<env>-router tailscale self-enrollment (tag:eliza-proxy)."
             echo ""
             echo "Next: set matching Cloudflare Worker secrets, then run the provision E2E."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -111,7 +111,24 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main 
 That workflow installs the committed ACL, converges `server_url` and
 `listen_addr`, ensures the `agent`/`tunnel` users exist, upserts the daemon's
 Headscale env in `/opt/eliza/cloud/.env.local`, restarts both services, and
-checks local `/health`. See
+checks local `/health`. It also converges the last-mile public-edge bits that
+used to be hand-run on every CP (and lost on a rebuild — a DR gap):
+
+- the **nginx vhost + Let's Encrypt cert** that front the public headscale URL
+  (`/etc/nginx/conf.d/headscale.conf` → `127.0.0.1:<listen-port>`), as a
+  no-http2 vhost with `Upgrade`/`Connection` passthrough + 86400s timeouts (the
+  TS2021/noise control protocol needs it). Renewal rides certbot's own
+  `certbot.timer`. Cert issuance is idempotent (`certbot certonly`, skipped when
+  a valid cert already exists).
+- the **`cp-<env>-router` tailscale self-enrollment** (`tag:eliza-proxy`, owned
+  by the `tunnel` user) so the daemon on the CP can reach agent `tag:agent`
+  `100.64.x` IPs. Idempotent (skips if already enrolled).
+
+The matching **DNS record** (`headscale[-staging].elizacloud.ai` → CP ipv4,
+`proxied=false`) is managed by this Terraform module (`cloudflare_dns_record.headscale`
+in `main.tf`), set the env's FQDN via the `headscale_hostname` tfvar. So the
+full chain — DNS, nginx, cert, cp-router — now reproduces from IaC on a clean CP
+rebuild (`terraform apply` for DNS, then the arm workflow for the rest). See
 [`../../../../../cloud-services/headscale/DEPLOY.md`](../../../../../cloud-services/headscale/DEPLOY.md)
 for the required GitHub Environment secrets and the "why" behind each one.
 
@@ -140,8 +157,10 @@ the exact "node registers against the wrong service" failure mode.
 ## What this module does NOT manage (yet)
 
 - Headscale state (preauth keys/API key rotation) — manual via `headscale`
-  CLI; config + ACL + daemon env are converged by
-  `arm-headscale-control-plane.yml`.
+  CLI; config + ACL + daemon env + the public nginx vhost / LE cert / the
+  `cp-<env>-router` self-enrollment are all converged by
+  `arm-headscale-control-plane.yml`. The headscale public **DNS record** IS
+  managed here (`cloudflare_dns_record.headscale`).
 - Cloudflared tunnels — config lives at `/root/.cloudflared/` on the VM and
   is created via `cloudflared tunnel create` one-shot.
 - The systemd units — installed by `deploy-eliza-provisioning-worker.yml`

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/import.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/import.tf
@@ -1,0 +1,21 @@
+# One-shot adoption of the headscale A record that was created by hand during
+# the 2026-06 headscale-on-CP cutover, before cloudflare_dns_record.headscale
+# (in main.tf) existed. Without this, the first apply after this PR would try to
+# CREATE an A record that already exists. Cloudflare record IDs are not secrets.
+#
+# Flow: staging imports on the next develop apply, production on the next
+# (reviewer-gated) main apply. Post-import the block is a no-op, so it is safe to
+# leave; remove this whole file in a follow-up once both envs' state has it.
+locals {
+  # CF DNS record IDs of the existing headscale A records, keyed by env.
+  adopt_headscale_record_id = {
+    staging    = "ca868231e69510b28761bb7fb60d2fb6"
+    production = "c7eb58d332bec9a14e470a00966d932b"
+  }
+}
+
+import {
+  for_each = { "1" = local.adopt_headscale_record_id[var.environment] }
+  to       = cloudflare_dns_record.headscale[each.key]
+  id       = "${var.cloudflare_zone_id}/${each.value}"
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -130,3 +130,45 @@ resource "cloudflare_dns_record" "control_plane" {
     ignore_changes = [content]
   }
 }
+
+# Headscale coordination-server DNS record. SIBLING of control_plane above —
+# same CP ipv4, different (stable) hostname. This is part 1 of codifying the
+# headscale-on-CP cutover that was previously a manual `dig`/dashboard step on
+# every CP rebuild (a DR gap). The nginx vhost + Let's Encrypt cert that serve
+# this hostname are provisioned by the arm-headscale-control-plane workflow
+# (packages/scripts/cloud/admin/arm-headscale-control-plane.mjs) — that script
+# runs AFTER this record exists, so HTTP-01 issuance can resolve the name.
+#
+# Headscale is singular per env (one coordination server), so this binds to the
+# first control-plane VM ("1"). A multi-CP HA topology would need a different
+# strategy (LB / floating IP) and is out of scope here.
+#
+# proxied=false (unlike the agent-router record): the headscale TS2021/noise
+# control protocol needs a raw HTTP/1.1 Upgrade passthrough that the Cloudflare
+# proxy edge mangles, and the CP terminates real TLS via a Let's Encrypt cert.
+# Routing through CF would both break the Upgrade handshake AND hide the origin
+# from the HTTP-01 challenge. ttl=300 is a normal DNS-only TTL (ttl=1/"Auto" is
+# only valid when proxied=true).
+resource "cloudflare_dns_record" "headscale" {
+  for_each = { for k, v in hcloud_server.control_plane : k => v if k == "1" }
+
+  zone_id = var.cloudflare_zone_id
+  name    = var.headscale_hostname
+  type    = "A"
+  content = each.value.ipv4_address
+  ttl     = 300
+  proxied = false
+  comment = "eliza headscale coordination server on ${each.value.name} (managed by terraform/hetzner/control-plane)"
+
+  # Same cutover-decoupling rationale as control_plane above: an apply that
+  # spawns a replacement CP must NOT atomically flip this A record to the new
+  # IP before the arm workflow has stood up nginx + the LE cert on the new box
+  # (agent nodes would fail their noise handshake mid-cutover). TF keeps the
+  # record's name/type/ttl/proxied/comment managed but never touches `content`;
+  # the operator cuts over deliberately (dashboard edit, or
+  # `terraform apply -replace=cloudflare_dns_record.headscale["1"]`) once the
+  # new CP's headscale is armed and healthy.
+  lifecycle {
+    ignore_changes = [content]
+  }
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
@@ -17,6 +17,11 @@ output "ssh_login_commands" {
   }
 }
 
+output "headscale_url" {
+  description = "Public headscale coordination URL for this env's CP. Wire this as HEADSCALE_PUBLIC_URL (workflow var) + the tailscale --login-server for agent nodes. The arm-headscale-control-plane workflow serves it via nginx + a Let's Encrypt cert on the CP."
+  value       = "https://${var.headscale_hostname}"
+}
+
 output "data_plane_network_id" {
   description = "Hetzner ID of the private network the autoscaler attaches workers to. Set this as CONTAINERS_HCLOUD_NETWORK_IDS in /opt/eliza/cloud/.env.local on the CP."
   value       = hcloud_network.data_plane.id

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
@@ -6,6 +6,11 @@ hcloud_server_type    = "cpx32"
 control_plane_count   = 1
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
 
+# Public headscale coordination hostname for this env's CP. Prod drops the
+# `-staging` suffix. Must match HEADSCALE_PUBLIC_URL in the
+# arm-headscale-control-plane workflow.
+headscale_hostname    = "headscale.elizacloud.ai"
+
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
@@ -6,6 +6,11 @@ hcloud_server_type    = "cpx32"
 control_plane_count   = 1
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
 
+# Public headscale coordination hostname for this env's CP. Staging keeps the
+# `-staging` suffix; prod drops it (headscale.elizacloud.ai). Must match
+# HEADSCALE_PUBLIC_URL in the arm-headscale-control-plane workflow.
+headscale_hostname    = "headscale-staging.elizacloud.ai"
+
 # Operator SSH public keys (NEVER paste private keys here).
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -78,6 +78,27 @@ variable "control_plane_hostname_prefix" {
   default     = "eliza"
 }
 
+# ── Headscale public hostname ────────────────────────────────────────────────
+# The headscale coordination server is reachable at a SEPARATE, stable hostname
+# from the agent-router VM record — agent nodes + the daemon bake this URL into
+# their tailscale `--login-server`, so it must NOT follow the per-VM-index
+# `eliza-<env>-N` naming (that changes on a CP rebuild). The convention is also
+# NOT a simple `headscale-<environment>` because prod drops the suffix:
+#   - production → headscale.elizacloud.ai
+#   - staging    → headscale-staging.elizacloud.ai
+# so it's an explicit variable rather than derived from var.environment. This
+# record points at the CP's public ipv4 with proxied=false (Let's Encrypt
+# HTTP-01 on the box needs to terminate TLS itself for the headscale TS2021/
+# noise protocol — a proxied CF record would break the Upgrade handshake).
+variable "headscale_hostname" {
+  description = "Public FQDN for the headscale coordination server on this env's CP (prod: headscale.elizacloud.ai, staging: headscale-staging.elizacloud.ai). Must match HEADSCALE_PUBLIC_URL in the arm-headscale-control-plane workflow and the nginx vhost / LE cert that script provisions."
+  type        = string
+  validation {
+    condition     = endswith(var.headscale_hostname, ".elizacloud.ai")
+    error_message = "headscale_hostname must be a subdomain of elizacloud.ai (the zone this module manages)"
+  }
+}
+
 variable "deploy_branch" {
   description = "Git branch the host's auto-deploy workflow follows. Staging defaults to 'develop'; production MUST be 'main' (enforced by the validation below) so a staging fix doesn't accidentally land in prod via the wrong branch pin."
   type        = string

--- a/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
+++ b/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
@@ -6,8 +6,18 @@
  *   - converge /etc/headscale/config.yaml to the public URL + loopback listener
  *   - install the committed ACL policy
  *   - ensure the `agent` and `tunnel` users exist
+ *   - provision the nginx vhost + Let's Encrypt cert that fronts the public
+ *     Headscale URL (TS2021/noise needs a no-http2 vhost with Upgrade/Connection
+ *     passthrough + long timeouts — a CF-proxied or h2 origin breaks it)
+ *   - enroll the CP itself as a tailscale node (cp-<env>-router, tag:eliza-proxy)
+ *     against its local Headscale, so the daemon can reach agent 100.64.x IPs
  *   - upsert the daemon env that makes sandbox provisioning require Headscale
  *   - restart Headscale and the provisioning worker, then health-check both
+ *
+ * These last-mile bits (nginx vhost, LE cert, cp-router enrollment) were
+ * previously hand-run on every CP and lost on a rebuild — that DR gap is what
+ * this script + the control-plane Terraform headscale DNS record now close.
+ * Every step here is idempotent: a re-arm is a no-op if the box is converged.
  *
  * The API key is treated as pre-existing secret material. Generate or rotate it
  * on the box with `headscale apikeys create --expiration=8760h`, then pass it
@@ -36,7 +46,13 @@ const aclPath = resolve(
 // Only these flags take no value. Every other flag consumes the next token as
 // its value — even one that starts with "--" (a PEM begins with "-----BEGIN"),
 // which a naive next.startsWith("--") check would silently drop.
-const BOOL_FLAGS = new Set(["dry-run", "help", "h"]);
+const BOOL_FLAGS = new Set([
+  "dry-run",
+  "help",
+  "h",
+  "skip-nginx-cert",
+  "skip-cp-router",
+]);
 
 function parseArgs(argv) {
   const out = {};
@@ -110,6 +126,14 @@ Optional:
   --headscale-api-url <url>            Daemon API URL (default http://127.0.0.1:8081).
   --listen-addr <addr:port>            Headscale listen_addr (default 127.0.0.1:8081).
   --headscale-user <user>              User for agent preauth keys (default agent).
+  --cp-router-hostname <name>          Tailscale hostname the CP enrolls itself as
+                                       (default derived from the public URL, e.g.
+                                       cp-staging-router). tag:eliza-proxy, owned
+                                       by the 'tunnel' headscale user.
+  --certbot-email <email>              Email for the Let's Encrypt account / expiry
+                                       notices (default ops@elizalabs.ai).
+  --skip-nginx-cert                    Skip the nginx vhost + LE cert step.
+  --skip-cp-router                     Skip the CP self-enrollment step.
   --agent-token-private-key-pem <pem>  Upsert daemon env when already generated.
   --eliza-local-root-key <key>         Upsert daemon env when already generated.
   --dry-run                            Print remote script, do not SSH.
@@ -145,6 +169,15 @@ const localRootKey = readArg(
   "eliza-local-root-key",
   "ELIZA_LOCAL_ROOT_KEY",
 );
+const certbotEmail =
+  readArg(args, "certbot-email", "CERTBOT_EMAIL") ?? "ops@elizalabs.ai";
+const cpRouterHostnameArg = readArg(
+  args,
+  "cp-router-hostname",
+  "CP_ROUTER_HOSTNAME",
+);
+const skipNginxCert = args["skip-nginx-cert"] === true;
+const skipCpRouter = args["skip-cp-router"] === true;
 
 if (!host) die("--host or DEPLOY_HOST is required");
 if (!sshKey) die("--ssh-key or DEPLOY_SSH_KEY is required");
@@ -154,6 +187,34 @@ if (!publicUrl)
 if (!apiKey) die("--headscale-api-key or HEADSCALE_API_KEY is required");
 if (!existsSync(aclPath)) die(`ACL file not found: ${aclPath}`);
 validateHttpsUrl("HEADSCALE_PUBLIC_URL", publicUrl);
+
+// The nginx vhost fronts the public hostname (host part of the URL) and proxies
+// to the loopback port headscale listens on (port part of listen_addr). Both
+// are already env-correct on the workflow inputs — staging is :8080, prod :8081
+// — so the vhost upstream tracks listen_addr automatically with no extra flag.
+const headscaleHostname = new URL(publicUrl).hostname;
+const headscalePort = listenAddr.includes(":")
+  ? listenAddr.split(":").pop()
+  : listenAddr;
+if (!/^\d+$/.test(headscalePort ?? ""))
+  die(`could not derive headscale port from listen_addr '${listenAddr}'`);
+
+// CP router hostname: cp-<env>-router. Derive <env> from the public hostname
+// when not given explicitly: headscale-staging.elizacloud.ai → staging,
+// headscale.elizacloud.ai → production. Falls back to the literal first DNS
+// label otherwise, so an unexpected hostname still yields a deterministic name
+// rather than throwing.
+function deriveCpRouterHostname(fqdn) {
+  const firstLabel = fqdn.split(".")[0]; // "headscale-staging" | "headscale"
+  const suffix = firstLabel.startsWith("headscale-")
+    ? firstLabel.slice("headscale-".length)
+    : firstLabel === "headscale"
+      ? "production"
+      : firstLabel;
+  return `cp-${suffix}-router`;
+}
+const cpRouterHostname =
+  cpRouterHostnameArg ?? deriveCpRouterHostname(headscaleHostname);
 
 const aclBase64 = Buffer.from(readFileSync(aclPath, "utf8"), "utf8").toString(
   "base64",
@@ -179,6 +240,154 @@ const upserts = Object.entries(daemonEnv)
     ].join("\n");
   })
   .join("\n");
+
+// ── nginx vhost + Let's Encrypt cert for the public Headscale URL ────────────
+// Reproduces the proven-good /etc/nginx/conf.d/headscale.conf that was hand-
+// written on each CP (the DR gap). The vhost MUST be no-http2 with Upgrade/
+// Connection passthrough + 86400s timeouts — the headscale TS2021/noise control
+// protocol rides a long-lived HTTP/1.1 Upgrade that an h2 origin (RFC 7540) or
+// a short proxy timeout drops. Upstream port tracks the headscale listen_addr.
+//
+// Cert flow: write an HTTP-only bootstrap vhost so certbot's nginx authenticator
+// can solve HTTP-01, run `certbot certonly` (idempotent — no-op if a valid cert
+// already exists), THEN drop the final TLS vhost referencing the LE cert paths.
+// `certonly` (not `--nginx` install) keeps the final vhost fully deterministic
+// here instead of letting certbot rewrite it. Renewal is certbot's own
+// systemd certbot.timer (installed by the certbot package) — no cron added.
+const nginxCertSteps = skipNginxCert
+  ? `echo "skip-nginx-cert set: leaving nginx vhost + LE cert untouched"`
+  : `
+echo "--- nginx vhost + Let's Encrypt cert for ${headscaleHostname} ---"
+HS_HOST=${shellQuote(headscaleHostname)}
+HS_PORT=${shellQuote(headscalePort)}
+CERTBOT_EMAIL=${shellQuote(certbotEmail)}
+HS_VHOST=/etc/nginx/conf.d/headscale.conf
+LE_LIVE=/etc/letsencrypt/live/$HS_HOST
+
+command -v certbot >/dev/null 2>&1 || sudo apt-get install -y certbot python3-certbot-nginx
+
+# 1. Bootstrap HTTP-only vhost so certbot --nginx can answer the HTTP-01
+#    challenge on :80. Overwritten by the final vhost below once the cert
+#    exists. Idempotent: re-running just rewrites the same bytes.
+sudo tee "$HS_VHOST" >/dev/null <<NGINX
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $HS_HOST;
+    location / { return 404; }
+}
+NGINX
+sudo nginx -t
+sudo systemctl reload nginx
+
+# 2. Obtain the cert if absent / not yet valid. certonly is idempotent and
+#    exits 0 when a live cert is already present and not near expiry, so a
+#    re-arm never re-issues (and never trips LE rate limits). --nginx
+#    authenticator reuses the running nginx for the HTTP-01 challenge.
+if sudo test -d "$LE_LIVE"; then
+  echo "LE cert already present for $HS_HOST; skipping issuance"
+else
+  sudo certbot certonly --nginx --non-interactive --agree-tos \\
+    -m "$CERTBOT_EMAIL" -d "$HS_HOST"
+fi
+
+# 3. Final no-http2 TLS vhost: 80→443 redirect + 443 proxy to the headscale
+#    loopback listener, with the Upgrade/Connection map + long timeouts the
+#    noise protocol needs. This is the byte-for-byte proven-good prod/staging
+#    vhost, templated for env hostname + port.
+sudo tee "$HS_VHOST" >/dev/null <<NGINX
+# headscale control-protocol (TS2021/noise) needs the Upgrade header passed
+# through on HTTP/1.1. NO http2 on this vhost: an h2 client connection would
+# drop the Upgrade header (RFC 7540), which is exactly what broke headscale
+# on Railway.
+map \\$http_upgrade \\$hs_connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $HS_HOST;
+    return 301 https://\\$host\\$request_uri;
+}
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name $HS_HOST;
+    ssl_certificate     /etc/letsencrypt/live/$HS_HOST/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$HS_HOST/privkey.pem;
+    location / {
+        proxy_pass http://127.0.0.1:$HS_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \\$http_upgrade;
+        proxy_set_header Connection \\$hs_connection_upgrade;
+        proxy_set_header Host \\$host;
+        proxy_set_header X-Real-IP \\$remote_addr;
+        proxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \\$scheme;
+        proxy_buffering off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+}
+NGINX
+sudo nginx -t
+sudo systemctl reload nginx
+
+# Confirm the cert renewal timer is active (renewal is certbot's own systemd
+# timer, not a cron entry we manage). Non-fatal: surfaces a warning if the
+# distro shipped certbot without the timer.
+sudo systemctl is-active certbot.timer >/dev/null 2>&1 \\
+  && echo "certbot.timer active (auto-renewal wired)" \\
+  || echo "WARN: certbot.timer not active — check auto-renewal on this host"
+`;
+
+// ── CP self-enrollment as a tailscale node (cp-<env>-router) ─────────────────
+// The CP enrolls ITSELF against its local headscale as cp-<env>-router with
+// tag:eliza-proxy (owned by the 'tunnel' user in acl.hujson). This is what lets
+// the daemon on the CP reach agent tag:agent 100.64.x IPs. Previously a manual
+// `tailscale up` per CP (the DR gap). Idempotent: skips if a node with this
+// hostname is already enrolled. headscale v0.28's `preauthkeys create -u` takes
+// a numeric USER ID, not a username, so we resolve tunnel→id from users list.
+const cpRouterSteps = skipCpRouter
+  ? `echo "skip-cp-router set: leaving CP tailscale enrollment untouched"`
+  : `
+echo "--- CP self-enrollment: ${cpRouterHostname} (tag:eliza-proxy) ---"
+CP_ROUTER_HOST=${shellQuote(cpRouterHostname)}
+LOGIN_SERVER=${shellQuote(publicUrl)}
+
+command -v tailscale >/dev/null 2>&1 || curl -fsSL https://tailscale.com/install.sh | sh
+sudo systemctl enable --now tailscaled
+
+# Already enrolled under this hostname? (matches the live cp-router node by
+# headscale node 'name'). If so, this whole step is a no-op.
+if sudo headscale nodes list -o json 2>/dev/null \\
+    | jq -e --arg h "$CP_ROUTER_HOST" 'any(.[]; .name == $h)' >/dev/null 2>&1; then
+  echo "$CP_ROUTER_HOST already enrolled in headscale; skipping tailscale up"
+else
+  # Resolve the 'tunnel' user id (preauthkeys create -u wants a uint in v0.28).
+  TUNNEL_UID=$(sudo headscale users list -o json 2>/dev/null \\
+    | jq -r '.[] | select(.name == "tunnel") | .id')
+  [ -n "$TUNNEL_UID" ] || { echo "tunnel user not found; cannot mint preauth key"; exit 1; }
+
+  # Short-lived, single-use, pre-tagged preauth key. Tagged tag:eliza-proxy so
+  # the node lands tagged at join (ownership enforced by acl.hujson tagOwners).
+  PREAUTH_KEY=$(sudo headscale preauthkeys create -u "$TUNNEL_UID" \\
+    --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
+  [ -n "$PREAUTH_KEY" ] || { echo "failed to mint preauth key for cp-router"; exit 1; }
+
+  sudo tailscale up \\
+    --login-server="$LOGIN_SERVER" \\
+    --authkey="$PREAUTH_KEY" \\
+    --hostname="$CP_ROUTER_HOST" \\
+    --advertise-tags=tag:eliza-proxy \\
+    --accept-routes
+  echo "$CP_ROUTER_HOST enrolled"
+fi
+
+sudo tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" \\
+  || echo "WARN: $CP_ROUTER_HOST not visible in tailscale status yet"
+`;
 
 const remote = `
 set -euo pipefail
@@ -283,6 +492,14 @@ for user in agent tunnel; do
     sudo headscale users create "$user"
   fi
 done
+
+# jq is needed by the cp-router enrollment below (and is already a cloud-init
+# package on the CP); guard so a stripped host still fails loud, not silent.
+command -v jq >/dev/null 2>&1 || sudo apt-get install -y jq
+
+${nginxCertSteps}
+
+${cpRouterSteps}
 
 sudo test -f "$F" || { echo "env file $F not found on host"; exit 1; }
 sudo cp -n "$F" "$F.bak.arm-headscale" 2>/dev/null || true

--- a/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
+++ b/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
@@ -193,9 +193,9 @@ validateHttpsUrl("HEADSCALE_PUBLIC_URL", publicUrl);
 // are already env-correct on the workflow inputs — staging is :8080, prod :8081
 // — so the vhost upstream tracks listen_addr automatically with no extra flag.
 const headscaleHostname = new URL(publicUrl).hostname;
-const headscalePort = listenAddr.includes(":")
-  ? listenAddr.split(":").pop()
-  : listenAddr;
+// .pop() on the colon-split yields the port for "addr:port" and the whole
+// string for a bare "port" — no need to branch on includes(":").
+const headscalePort = listenAddr.split(":").pop();
 if (!/^\d+$/.test(headscalePort ?? ""))
   die(`could not derive headscale port from listen_addr '${listenAddr}'`);
 


### PR DESCRIPTION
## What & why

The headscale-on-control-plane cutover was, until now, partly **manual on the box** — so a clean CP rebuild (`terraform apply` + the arm workflow) would *not* bring headscale back to a working state. That's a DR gap. This PR closes it for the 3 things that weren't codified.

The `arm-headscale-control-plane` workflow + `.mjs` already codified: headscale `server_url`/`listen_addr`, the committed ACL install, the daemon `.env.local` headscale keys, and the `agent`/`tunnel` users. The 3 missing pieces — and now reproducible from IaC:

1. **Cloudflare DNS record** `headscale[-staging].elizacloud.ai` → CP ipv4 (`proxied=false`).
2. **nginx vhost + Let's Encrypt cert** on the CP fronting that hostname → `127.0.0.1:<headscale-port>`.
3. **`cp-<env>-router` tailscale self-enrollment** (`tag:eliza-proxy`) so the daemon can reach agent `tag:agent` `100.64.x` IPs.

## Now reproducible from IaC

| Piece | Where it's codified | Notes |
|---|---|---|
| Public headscale DNS record | `terraform/hetzner/control-plane/main.tf` (`cloudflare_dns_record.headscale`) | `proxied=false`, `ttl=300`. New `headscale_hostname` tfvar drives the per-env FQDN. |
| nginx vhost (no-http2, Upgrade passthrough, 86400s timeouts) | `arm-headscale-control-plane.mjs` | Byte-for-byte the proven-good live staging/prod vhost, templated for env hostname + port. |
| Let's Encrypt cert + renewal | `arm-headscale-control-plane.mjs` | `certbot certonly --nginx` (idempotent); renewal via certbot's own `certbot.timer`. |
| `cp-<env>-router` enrollment | `arm-headscale-control-plane.mjs` | Mints a 1h `tunnel`-user preauth key tagged `tag:eliza-proxy`, runs `tailscale up`. Skips if already enrolled. |

Everything is **idempotent**: a re-arm / re-apply on an already-converged CP is a no-op. Existing staging+prod arm runs keep working unchanged (the new env var `CERTBOT_EMAIL` is optional and falls back to `ops@elizalabs.ai`; the cp-router hostname is auto-derived from the public URL).

## Insertion-point decisions (and why)

- **DNS → Terraform.** Lowest-risk, cleanest: a sibling of the existing `cloudflare_dns_record.control_plane`, same CP ipv4, different stable hostname. I added an explicit `headscale_hostname` tfvar rather than deriving from `var.environment`, because the convention is *not* a simple `headscale-<environment>`: prod **drops** the suffix (`headscale.elizacloud.ai`) while staging keeps it (`headscale-staging.elizacloud.ai`). Kept the same `ignore_changes = [content]` cutover-decoupling as the sibling record so a replacement-CP apply can't atomically flip the A record before the new box's headscale is armed + healthy.
- **nginx + cert → the arm `.mjs`, NOT cloud-init.** Cert issuance is inherently **post-DNS and post-boot**: certbot's HTTP-01 needs the `headscale.*` A record to already resolve to the box, which isn't guaranteed at first-boot (DNS may not have propagated, and certbot would hard-fail). The arm workflow runs *after* the VM is up and the DNS record exists, is already the "converge headscale" step, and already has the public hostname + listen port in scope. cloud-init is the wrong home. Used `certbot certonly` (obtain-only) rather than `--nginx` install so the final vhost stays fully deterministic in-repo instead of being rewritten by certbot.
- **cp-router → the arm `.mjs`.** Needs headscale running + the `tunnel` user, both of which the arm script already ensures earlier in the same run. headscale v0.28's `preauthkeys create -u` takes a **numeric user id**, not a username, so the script resolves `tunnel`→id from `users list -o json` (the task's suggested `--user tunnel` would fail on v0.28 — verified live on the staging CP).

## Validation done

- `terraform fmt -check` + `terraform validate` clean on the touched module (no apply).
- `node --check` on the `.mjs`; `--dry-run` output piped through `bash -n` (staging + prod + skip-flags variants) — all valid bash.
- The nginx vhost, listen ports (staging `:8080` / prod `:8081`), `cp-<env>-router` hostname, `tag:eliza-proxy` ownership, certbot `nginx` authenticator + active `certbot.timer`, and headscale v0.28 `preauthkeys` syntax were all read **live off the staging CP** and matched.

## ⚠️ DR test still needed (not done in this PR)

This is correctness-first; the real proof is a throwaway-CP rebuild. A reviewer/operator should:

- [ ] Stand up a **throwaway CP** from the control-plane TF (new Hetzner project or scratch VM) with `headscale_hostname` set.
- [ ] `terraform apply` → confirm `cloudflare_dns_record.headscale` creates and `headscale.*` resolves to the new CP ipv4 (`proxied=false`).
- [ ] Run `arm-headscale-control-plane.yml` against it and verify, on the box:
  - [ ] `/etc/nginx/conf.d/headscale.conf` exists, `nginx -t` passes, and `curl -sf https://<headscale-host>/health` returns green **through nginx** (not just loopback `:8080/8081`).
  - [ ] `/etc/letsencrypt/live/<headscale-host>/fullchain.pem` exists and `certbot.timer` is active.
  - [ ] `tailscale status` shows `cp-<env>-router` with `tag:eliza-proxy`; `sudo headscale nodes list` shows it enrolled under the `tunnel` user.
  - [ ] A **re-run** of the arm workflow is a clean no-op (cert not re-issued, cp-router not re-enrolled).
- [ ] Confirm `certbot certonly --nginx` HTTP-01 actually succeeds end-to-end on a fresh box (the one path provable only on a real rebuild — locally we could only verify the generated script + the live already-issued cert).
- [ ] Decide whether to add a post-cutover check that the daemon can reach an agent `100.64.x` IP via the cp-router (would catch an ACL/tag regression).

## Out of scope

- Multi-CP HA for headscale (the DNS record binds to CP `"1"`; an HA topology needs an LB/floating-IP strategy).
- headscale state copy (db.sqlite/noise key) on CP replacement — already documented in the module README's "replacing a CP" runbook.