### PR TITLE
fix(ui): default conversation updatedAt so Cloud chat sends aren't dropped

### DIFF
--- a/packages/ui/src/api/client-chat-conversation-defaults.test.ts
+++ b/packages/ui/src/api/client-chat-conversation-defaults.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false, getPlatform: () => "web" },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+import { ElizaClient } from "./client-base";
+import "./client-chat";
+
+/**
+ * A serverless / shared-runtime Cloud agent returns conversation objects
+ * WITHOUT `updatedAt` (`{id,title,roomId,createdAt}`). The shared
+ * `isConversationRecord` guard requires `updatedAt`, so without boundary
+ * normalization the conversation list filters to empty and chat sends are
+ * dropped (no active conversation, and createConversation's result is rejected).
+ * The client defaults `updatedAt` to `createdAt` at the API boundary.
+ */
+function jsonTransport(body: unknown) {
+  return {
+    request: async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  };
+}
+
+const BASE = "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1";
+const CREATED = "2026-06-18T00:00:00.000Z";
+
+describe("conversation updatedAt boundary normalization", () => {
+  it("createConversation defaults updatedAt to createdAt when the server omits it", async () => {
+    const client = new ElizaClient(BASE);
+    client.setRequestTransport(
+      jsonTransport({
+        conversation: {
+          id: "c1",
+          title: "Chat",
+          roomId: "c1",
+          createdAt: CREATED,
+        },
+      }),
+    );
+    const res = await client.createConversation();
+    expect(res.conversation.updatedAt).toBe(CREATED);
+  });
+
+  it("listConversations defaults updatedAt for each item", async () => {
+    const client = new ElizaClient(BASE);
+    client.setRequestTransport(
+      jsonTransport({
+        conversations: [
+          { id: "c1", title: "Chat", roomId: "c1", createdAt: CREATED },
+        ],
+      }),
+    );
+    const res = await client.listConversations();
+    expect(res.conversations[0]?.updatedAt).toBe(CREATED);
+  });
+
+  it("preserves a server-provided updatedAt (no clobber)", async () => {
+    const client = new ElizaClient(BASE);
+    const updated = "2026-06-19T12:00:00.000Z";
+    client.setRequestTransport(
+      jsonTransport({
+        conversation: {
+          id: "c1",
+          title: "Chat",
+          roomId: "c1",
+          createdAt: CREATED,
+          updatedAt: updated,
+        },
+      }),
+    );
+    const res = await client.createConversation();
+    expect(res.conversation.updatedAt).toBe(updated);
+  });
+});

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -810,6 +810,42 @@ ElizaClient.prototype.sendChatStream = async function (
   }
 };
 
+// A serverless / shared-runtime agent may omit `updatedAt` from conversation
+// objects (a never-updated conversation legitimately has updatedAt == createdAt).
+// The shared `isConversationRecord` guard requires the standard shape, so without
+// this the conversation list filters to empty and chat sends are dropped for want
+// of an active conversation (createConversation's result is rejected too). Default
+// the field at the API boundary — clean DTO completion, not a server-specific
+// special case.
+function withConversationDefaults<T>(conversation: T): T {
+  if (
+    conversation &&
+    typeof conversation === "object" &&
+    typeof (conversation as Record<string, unknown>).updatedAt !== "string"
+  ) {
+    const createdAt = (conversation as Record<string, unknown>).createdAt;
+    if (typeof createdAt === "string") {
+      return {
+        ...(conversation as Record<string, unknown>),
+        updatedAt: createdAt,
+      } as T;
+    }
+  }
+  return conversation;
+}
+
+function withConversationListDefaults<T extends { conversations?: unknown }>(
+  response: T,
+): T {
+  if (response && Array.isArray(response.conversations)) {
+    return {
+      ...response,
+      conversations: response.conversations.map(withConversationDefaults),
+    };
+  }
+  return response;
+}
+
 ElizaClient.prototype.listConversations = async function (this: ElizaClient) {
   // Prefer typed Electrobun RPC. The bun-side composer throws
   // AgentNotReadyError if the agent has no port yet; we catch and
@@ -819,11 +855,13 @@ ElizaClient.prototype.listConversations = async function (this: ElizaClient) {
     const viaRpc = await invokeDesktopBridgeRequest<{
       conversations: Conversation[];
     }>({ rpcMethod: "listConversations", ipcChannel: "agent" });
-    if (viaRpc) return viaRpc;
+    if (viaRpc) return withConversationListDefaults(viaRpc);
   } catch {
     /* AgentNotReadyError or any RPC failure → fall through to HTTP */
   }
-  return this.fetch("/api/conversations");
+  return withConversationListDefaults(
+    await this.fetch<{ conversations: Conversation[] }>("/api/conversations"),
+  );
 };
 
 ElizaClient.prototype.createConversation = async function (
@@ -848,11 +886,13 @@ ElizaClient.prototype.createConversation = async function (
       ...(options?.metadata ? { metadata: options.metadata } : {}),
     }),
   });
+  const conversation = withConversationDefaults(response.conversation);
   if (!response.greeting) {
-    return response;
+    return { ...response, conversation };
   }
   return {
     ...response,
+    conversation,
     greeting: {
       ...response.greeting,
       text: this.normalizeGreetingText(response.greeting.text),


### PR DESCRIPTION
## Summary
In-app chat against a serverless / shared-runtime Cloud agent **silently drops every send** — no user bubble, no network POST. Found via on-device (Seeker) testing + logcat.

## Root cause
The Cloud REST adapter returns conversation objects as `{id,title,roomId,createdAt}` — **without `updatedAt`**. The shared `isConversationRecord` guard requires the full standard shape (incl. `updatedAt`), so for these agents:
- `GET /api/conversations` filters to an empty list → no active conversation, and
- `createConversation`'s result is rejected (throws),

which makes `runQueuedChatSend` hit its `catch { return }` and drop the turn before the optimistic bubble or the message POST.

## Fix
Normalize at the API client boundary: default `updatedAt` to `createdAt` (a never-updated conversation legitimately has them equal) in `listConversations` and `createConversation`. Clean DTO completion, not a server-specific special case; a server-provided `updatedAt` is preserved untouched. Adds regression tests.

## Verification
- On Seeker (cloud agent): before → send dropped (0 `POST /messages`); after → user bubble renders + `POST /messages → 200` fires.
- `packages/ui` typecheck clean for this change (pre-existing `src/spatial/tui` errors are an unbuilt `@elizaos/tui` dep, unrelated); 3 new regression tests pass.

## Note for cloud
Cloud adapters should also emit `updatedAt` on conversation objects for full conformance with every elizaOS client (web/desktop/CLI); this PR keeps the app correct regardless.