### PR TITLE
fix(cloud): shared conversations carry updatedAt + status reports canRespond

### DIFF
--- a/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -68,6 +68,7 @@ describe("shared-rest-adapter — conversation surface", () => {
       title: "Eliza",
       roomId: AGENT,
       createdAt: CREATED,
+      updatedAt: CREATED,
     });
   });
 
@@ -84,7 +85,11 @@ describe("shared-rest-adapter — conversation surface", () => {
 
 describe("shared-rest-adapter — startup shell surface", () => {
   test("status is the first gate: running + agent name", () => {
-    expect(sharedRestStatus("Nova")).toEqual({ state: "running", agentName: "Nova" });
+    expect(sharedRestStatus("Nova")).toEqual({
+      state: "running",
+      agentName: "Nova",
+      canRespond: true,
+    });
   });
 
   test("status falls back to a name when the agent has none", () => {

--- a/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -27,6 +27,13 @@ export interface SharedRestConversation {
   title: string;
   roomId: string;
   createdAt: string;
+  /**
+   * The client's `isConversationRecord()` guard REQUIRES `updatedAt` — without
+   * it the record is rejected, so there is no active conversation and every send
+   * is silently dropped. A shared agent's canonical conversation is never
+   * renamed/moved, so `updatedAt` === `createdAt`.
+   */
+  updatedAt: string;
 }
 
 /** Minimal subset of the agent-server REST `ConversationMessage`. */
@@ -53,7 +60,8 @@ function makeConversation(
   createdAt: string,
 ): SharedRestConversation {
   const id = canonicalConversationId(agentId);
-  return { id, title: agentName || "Chat", roomId: id, createdAt };
+  // updatedAt === createdAt: the canonical conversation is never renamed/moved.
+  return { id, title: agentName || "Chat", roomId: id, createdAt, updatedAt: createdAt };
 }
 
 /** GET .../api/health — the agent is in-Worker; if it resolves, it's up. */
@@ -61,19 +69,28 @@ export function sharedRestHealth(): { status: "ok" } {
   return { status: "ok" };
 }
 
-/** The agent-status shape the chat client reads; only `state` is load-bearing. */
+/** The agent-status shape the chat client reads; `state` + `canRespond` gate UI. */
 export interface SharedRestStatus {
   state: "running";
   agentName: string;
+  /**
+   * The composer's send-gate is `canRespond ?? (running && model)`. A shared
+   * agent has no LOCAL model (inference is hosted in-Worker), so `running &&
+   * model` is false and the box would stay disabled. We're only here for a
+   * provisioned + running shared agent, so it CAN respond — declare it
+   * explicitly so the client doesn't fall back to the model check.
+   */
+  canRespond: true;
 }
 
 /**
  * GET .../api/status — the startup-coordinator's FIRST hard gate: it calls
  * `getStatus()` before anything else and bails unless `state === "running"`.
- * A shared agent runs in-Worker, so if this resolves it is by definition up.
+ * A shared agent runs in-Worker, so if this resolves it is by definition up and
+ * able to respond (its inference is hosted, not a local model).
  */
 export function sharedRestStatus(agentName: string): SharedRestStatus {
-  return { state: "running", agentName: agentName || "Eliza" };
+  return { state: "running", agentName: agentName || "Eliza", canRespond: true };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Prod ship of #8570 (also on develop). Adds `updatedAt` to shared conversation objects (the client's isConversationRecord() guard requires it — else sends were silently dropped) and `canRespond:true` to /api/status (the composer's send-gate is `canRespond ?? (running && model)`; a shared agent has no local model). typecheck 0, 17/17 tests, lint clean. Related history-persistence issue (CACHE_ENABLED=false on the prod Worker) flagged to @standujar separately.