### PR TITLE
registry: add @human.tech/plugin-waap (third-party)

### DIFF
--- a/packages/registry/entries/third-party/human.tech__plugin-waap.json
+++ b/packages/registry/entries/third-party/human.tech__plugin-waap.json
@@ -1,0 +1,9 @@
+{
+  "package": "@human.tech/plugin-waap",
+  "repository": "github:holonym-foundation/eliza-plugin-waap",
+  "kind": "plugin",
+  "description": "WaaP wallet plugin for ElizaOS — 2-of-2 MPC signing for EVM and Sui, with native 2FA and server-enforced spending policies; the agent never holds private keys.",
+  "homepage": "https://github.com/holonym-foundation/eliza-plugin-waap",
+  "version": "0.1.3",
+  "tags": ["wallet", "mpc", "2pc", "evm", "sui", "2fa"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -92,6 +92,52 @@
       "registryKind": "plugin",
       "directory": "eliza-plugin-agentradar"
     },
+    "@human.tech/plugin-waap": {
+      "git": {
+        "repo": "holonym-foundation/eliza-plugin-waap",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@human.tech/plugin-waap",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.3"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "WaaP wallet plugin for ElizaOS — 2-of-2 MPC signing for EVM and Sui, with native 2FA and server-enforced spending policies; the agent never holds private keys.",
+      "homepage": "https://github.com/holonym-foundation/eliza-plugin-waap",
+      "topics": [
+        "wallet",
+        "mpc",
+        "2pc",
+        "evm",
+        "sui",
+        "2fa"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@thecolony/elizaos-plugin": {
       "git": {
         "repo": "TheColonyCC/elizaos-plugin",


### PR DESCRIPTION
## Relates to

Community plugin registry listing for `@human.tech/plugin-waap`. No specific issue.

## Background

`@human.tech/plugin-waap` is a wallet plugin for ElizaOS agents — 2-of-2 MPC signing for EVM and Sui, native 2FA approval flows, and server-enforced spending policies. The agent process never holds a private key. It is published on npm and lives in a public repo.

- npm: https://www.npmjs.com/package/@human.tech/plugin-waap (latest `0.1.3`, published with provenance)
- Repo: https://github.com/holonym-foundation/eliza-plugin-waap (public)

## What does this PR do?

Adds the third-party registry entry for `@human.tech/plugin-waap` and regenerates `generated-registry.json`. Touches only `packages/registry/`:

- adds `packages/registry/entries/third-party/human.tech__plugin-waap.json`
- regenerates `packages/registry/generated-registry.json` (no other entries modified)

The package has `agentConfig` (`pluginType: elizaos:plugin:1.0.0`), `images/logo.jpg` (400×400) + `images/banner.jpg` (1280×640), and the `elizaos` keyword.

## What kind of change is this?

Registry / content addition (additive, non-breaking; no source code changed).

## Documentation changes needed?

No.

## Risks

Low — additive only. One new entry file plus the regenerated index; no other registry entries or code touched.

## Testing

- `bun run --cwd packages/registry validate` → passes (11 third-party entries).
- `bun run --cwd packages/registry generate` → regenerated the index cleanly (single additive diff).

## Where should a reviewer start?

`packages/registry/entries/third-party/human.tech__plugin-waap.json`, plus the public npm package and repo linked above.

## Detailed testing steps

1. `bun run --cwd packages/registry validate` — entry passes the schema.
2. Cross-check the entry fields against the published npm package `@human.tech/plugin-waap@0.1.3` and the linked public repository.
