### PR TITLE
fix(cloud): persist shared-runtime chat history in Postgres (durable, cache-independent)

### DIFF
--- a/packages/cloud-shared/src/db/migrations/0146_shared_runtime_history.sql
+++ b/packages/cloud-shared/src/db/migrations/0146_shared_runtime_history.sql
@@ -1,0 +1,12 @@
+-- Durable conversation history for Tier-0 "shared" agents (run in-Worker, no
+-- container). Previously stored only in the request cache, which is disabled on
+-- the prod Worker (CACHE_ENABLED=false) so history never persisted. One row per
+-- (agent_id, channel_id) holds the capped, ordered message list. Additive +
+-- idempotent (IF NOT EXISTS) so it is safe to apply out of band.
+CREATE TABLE IF NOT EXISTS "shared_runtime_history" (
+	"agent_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"messages" jsonb NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "shared_runtime_history_agent_id_channel_id_pk" PRIMARY KEY("agent_id","channel_id")
+);

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -1009,6 +1009,13 @@
       "when": 1779495600000,
       "tag": "0145_drop_api_key_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 144,
+      "version": "7",
+      "when": 1779582000000,
+      "tag": "0146_shared_runtime_history",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/repositories/shared-runtime-history.ts
+++ b/packages/cloud-shared/src/db/repositories/shared-runtime-history.ts
@@ -1,0 +1,53 @@
+import { and, eq } from "drizzle-orm";
+
+import { dbRead, dbWrite } from "../client";
+import {
+  type SharedRuntimeHistoryMessage,
+  sharedRuntimeHistory,
+} from "../schemas/shared-runtime-history";
+import { jsonbParam } from "../utils/jsonb";
+
+/**
+ * Durable persistence for shared-runtime (Tier-0) conversation history. Replaces
+ * the request-cache store (a no-op when `CACHE_ENABLED=false` on the Worker) so
+ * a shared agent keeps cross-turn memory and `GET .../messages` returns history.
+ * One canonical row per `(agentId, channelId)`, upserted with the capped list.
+ */
+export class SharedRuntimeHistoryRepository {
+  async get(agentId: string, channelId: string): Promise<SharedRuntimeHistoryMessage[]> {
+    const row = await dbRead.query.sharedRuntimeHistory.findFirst({
+      where: and(
+        eq(sharedRuntimeHistory.agent_id, agentId),
+        eq(sharedRuntimeHistory.channel_id, channelId),
+      ),
+    });
+    return Array.isArray(row?.messages) ? row.messages : [];
+  }
+
+  async upsert(
+    agentId: string,
+    channelId: string,
+    messages: SharedRuntimeHistoryMessage[],
+  ): Promise<void> {
+    const now = new Date();
+    await dbWrite
+      .insert(sharedRuntimeHistory)
+      .values({
+        agent_id: agentId,
+        channel_id: channelId,
+        // Bind JSONB explicitly as a JSON string + cast (Neon serverless driver
+        // can mis-bind raw JS arrays/objects as query params).
+        messages: jsonbParam(messages) as unknown as SharedRuntimeHistoryMessage[],
+        updated_at: now,
+      })
+      .onConflictDoUpdate({
+        target: [sharedRuntimeHistory.agent_id, sharedRuntimeHistory.channel_id],
+        set: {
+          messages: jsonbParam(messages) as unknown as SharedRuntimeHistoryMessage[],
+          updated_at: now,
+        },
+      });
+  }
+}
+
+export const sharedRuntimeHistoryRepository = new SharedRuntimeHistoryRepository();

--- a/packages/cloud-shared/src/db/schemas/index.ts
+++ b/packages/cloud-shared/src/db/schemas/index.ts
@@ -75,6 +75,7 @@ export * from "./retention-cohorts";
 export * from "./secrets";
 export * from "./seo";
 export * from "./service-pricing";
+export * from "./shared-runtime-history";
 export * from "./telegram-chats";
 export * from "./tenant-db-clusters";
 export * from "./token-redemptions";

--- a/packages/cloud-shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud-shared/src/db/schemas/shared-runtime-history.ts
@@ -1,0 +1,38 @@
+import { jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+
+/** One persisted turn in a shared-runtime conversation. Mirrors `SharedTurnMessage`. */
+export type SharedRuntimeHistoryMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+/**
+ * Durable conversation history for Tier-0 "shared" agents (which run in-Worker
+ * with no container, so they have no per-agent database of their own).
+ *
+ * Previously this history lived ONLY in the request cache, which is disabled on
+ * the prod Worker (`CACHE_ENABLED=false`, no KV backend) — so `cache.set` was a
+ * silent no-op, history never persisted, and the agent had no cross-turn memory
+ * (and `GET .../messages` always returned `[]`). This table makes it durable in
+ * the same Postgres the Worker already uses, independent of any cache config.
+ *
+ * One row per `(agent_id, channel_id)` holds the capped, ordered message list,
+ * upserted each turn. Kept deliberately isolated from the encrypted/billed
+ * `conversations`/`conversation_messages` tables (the chat-completions product)
+ * so the lightweight shared tier stays decoupled, as designed.
+ */
+export const sharedRuntimeHistory = pgTable(
+  "shared_runtime_history",
+  {
+    agent_id: text("agent_id").notNull(),
+    channel_id: text("channel_id").notNull(),
+    messages: jsonb("messages").$type<SharedRuntimeHistoryMessage[]>().notNull(),
+    updated_at: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.agent_id, table.channel_id] }),
+  }),
+);
+
+export type SharedRuntimeHistoryRow = typeof sharedRuntimeHistory.$inferSelect;
+export type NewSharedRuntimeHistoryRow = typeof sharedRuntimeHistory.$inferInsert;

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:te
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
-import { cache } from "../cache/client";
+import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import * as realAiBillingNs from "./ai-billing";
 import * as realAiBillingRecordsNs from "./ai-billing-records";
@@ -192,8 +192,10 @@ describe("ElizaSandboxService shared runtime billing", () => {
       agentSandboxesRepository,
       "findRunningSandbox",
     ).mockResolvedValue(sandbox);
-    const cacheGetSpy = spyOn(cache, "get").mockResolvedValue([]);
-    const cacheSetSpy = spyOn(cache, "set").mockResolvedValue(undefined);
+    const historyGetSpy = spyOn(sharedRuntimeHistoryRepository, "get").mockResolvedValue([]);
+    const historyUpsertSpy = spyOn(sharedRuntimeHistoryRepository, "upsert").mockResolvedValue(
+      undefined,
+    );
 
     try {
       const response = await runWithCloudBindings(
@@ -254,12 +256,12 @@ describe("ElizaSandboxService shared runtime billing", () => {
           }),
         }),
       );
-      expect(cacheGetSpy).toHaveBeenCalled();
-      expect(cacheSetSpy).toHaveBeenCalled();
+      expect(historyGetSpy).toHaveBeenCalled();
+      expect(historyUpsertSpy).toHaveBeenCalled();
     } finally {
       findRunningSandboxSpy.mockRestore();
-      cacheGetSpy.mockRestore();
-      cacheSetSpy.mockRestore();
+      historyGetSpy.mockRestore();
+      historyUpsertSpy.mockRestore();
     }
   });
 });

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -16,6 +16,7 @@ import {
 } from "../../db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "../../db/repositories/characters";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
+import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
 import {
   type AgentBackupStateData,
   type AgentExecutionTier,
@@ -25,7 +26,6 @@ import {
   type NewAgentSandboxBackup,
 } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
-import { cache } from "../cache/client";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
@@ -119,7 +119,6 @@ export interface SnapshotResult {
 }
 
 const MAX_BACKUPS = 10;
-const SHARED_RUNTIME_HISTORY_TTL_SECONDS = 60 * 60 * 24 * 30;
 const SHARED_RUNTIME_HISTORY_MAX_MESSAGES = 40;
 // Heartbeat probes the agent over the headscale tailnet. When idle the path
 // goes cold, so the first probe after a quiet period can fail while it
@@ -1348,10 +1347,6 @@ export class ElizaSandboxService {
     );
   }
 
-  private sharedRuntimeHistoryCacheKey(agentId: string, channelId: string): string {
-    return `shared-runtime:${agentId}:${channelId}:history:v1`;
-  }
-
   private isSharedTurnMessage(value: unknown): value is SharedTurnMessage {
     const message = this.nestedBridgeRecord(value);
     return (
@@ -1365,11 +1360,11 @@ export class ElizaSandboxService {
     agentId: string,
     channelId: string,
   ): Promise<SharedTurnMessage[]> {
-    const cached = await cache.get<SharedTurnMessage[]>(
-      this.sharedRuntimeHistoryCacheKey(agentId, channelId),
-    );
-    if (!Array.isArray(cached)) return [];
-    return cached.filter((message): message is SharedTurnMessage =>
+    // Durable source of truth is Postgres (the cache is disabled on the prod
+    // Worker, CACHE_ENABLED=false, so it never persisted). See
+    // db/schemas/shared-runtime-history.ts.
+    const stored = await sharedRuntimeHistoryRepository.get(agentId, channelId);
+    return stored.filter((message): message is SharedTurnMessage =>
       this.isSharedTurnMessage(message),
     );
   }
@@ -1383,11 +1378,7 @@ export class ElizaSandboxService {
       history.length > SHARED_RUNTIME_HISTORY_MAX_MESSAGES
         ? history.slice(history.length - SHARED_RUNTIME_HISTORY_MAX_MESSAGES)
         : history;
-    await cache.set(
-      this.sharedRuntimeHistoryCacheKey(agentId, channelId),
-      capped,
-      SHARED_RUNTIME_HISTORY_TTL_SECONDS,
-    );
+    await sharedRuntimeHistoryRepository.upsert(agentId, channelId, capped);
   }
 
   private sharedRuntimeBillingPrompt(


### PR DESCRIPTION
Prod ship of #8575 (also on develop). Shared agents stored chat history only in the request cache, which is disabled on the prod Worker (`CACHE_ENABLED=false`) → history never persisted + no cross-turn memory. Moves it to an isolated Postgres table (`shared_runtime_history`), independent of the cache flag. Migration 0146 (additive `CREATE TABLE IF NOT EXISTS`) **already applied to the prod Neon DB out of band**, so the table exists before this deploys. typecheck 0 errors, 27/27 tests. cc @standujar.