### PR TITLE
fix(cloud): enable Worker cache via Upstash REST

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -72,9 +72,10 @@ crons = [
 binding = "BLOB"
 bucket_name = "eliza-cloud-blob"
 
-# Cache + rate-limit storage runs through Upstash Redis REST in cloud (set
-# KV_REST_API_URL / KV_REST_API_TOKEN as Wrangler secrets). Local dev uses
-# embedded Wadis (CACHE_BACKEND=auto with no creds → wadis fallback).
+# Cache + rate-limit storage runs through Upstash Redis REST in Worker envs
+# (set KV_REST_API_URL / KV_REST_API_TOKEN as Wrangler secrets). Shared-runtime
+# chat history depends on this being durable across Worker requests. Local dev
+# still uses embedded Wadis by default when no Redis credentials are present.
 
 # Vectorize — embeddings (uncomment after `wrangler vectorize create`)
 # [[vectorize]]
@@ -131,8 +132,8 @@ CRYPTO_DIRECT_SOLANA_SECURE_ADDRESS = "97oFR38EpWEaLuKc13AnyL6GrqBZTBCVCh9rAHAXW
 CRYPTO_DIRECT_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 CRYPTO_DIRECT_SOLANA_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 CRYPTO_DIRECT_SOLANA_TOKEN_DECIMALS = "6"
-CACHE_ENABLED = "false"
-CACHE_DISABLE_REASON = "CF Workers cross-request I/O isolation: CacheClient module-level singleton is incompatible until refactored to per-request scope"
+CACHE_ENABLED = "true"
+CACHE_BACKEND = "redis-rest"
 REDIS_RATE_LIMITING = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
@@ -291,8 +292,8 @@ CRYPTO_DIRECT_SOLANA_SECURE_ADDRESS = "97oFR38EpWEaLuKc13AnyL6GrqBZTBCVCh9rAHAXW
 CRYPTO_DIRECT_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 CRYPTO_DIRECT_SOLANA_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 CRYPTO_DIRECT_SOLANA_TOKEN_DECIMALS = "6"
-CACHE_ENABLED = "false"
-CACHE_DISABLE_REASON = "CF Workers cross-request I/O isolation: CacheClient module-level singleton is incompatible until refactored to per-request scope"
+CACHE_ENABLED = "true"
+CACHE_BACKEND = "redis-rest"
 REDIS_RATE_LIMITING = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
@@ -376,8 +377,8 @@ CRYPTO_DIRECT_SOLANA_SECURE_ADDRESS = "97oFR38EpWEaLuKc13AnyL6GrqBZTBCVCh9rAHAXW
 CRYPTO_DIRECT_SOLANA_RPC_URL = "https://api.mainnet-beta.solana.com"
 CRYPTO_DIRECT_SOLANA_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 CRYPTO_DIRECT_SOLANA_TOKEN_DECIMALS = "6"
-CACHE_ENABLED = "false"
-CACHE_DISABLE_REASON = "CF Workers cross-request I/O isolation: CacheClient module-level singleton is incompatible until refactored to per-request scope"
+CACHE_ENABLED = "true"
+CACHE_BACKEND = "redis-rest"
 REDIS_RATE_LIMITING = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"

--- a/packages/cloud-shared/src/lib/cache/__tests__/client-worker-rest.test.ts
+++ b/packages/cloud-shared/src/lib/cache/__tests__/client-worker-rest.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const constructedClients: Array<{ url: string; token: string }> = [];
+const store = new Map<string, string>();
+
+const realUpstash = await import("@upstash/redis");
+
+class MockUpstashRedis {
+  constructor(options: { url: string; token: string }) {
+    constructedClients.push(options);
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    return (store.get(key) ?? null) as T | null;
+  }
+
+  async setex(key: string, _ttlSeconds: number, value: string): Promise<"OK"> {
+    store.set(key, value);
+    return "OK";
+  }
+
+  async set(key: string, value: string, options?: { nx?: boolean }): Promise<"OK" | null> {
+    if (options?.nx && store.has(key)) return null;
+    store.set(key, value);
+    return "OK";
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = Number(store.get(key) ?? "0") + 1;
+    store.set(key, String(next));
+    return next;
+  }
+
+  async expire(): Promise<number> {
+    return 1;
+  }
+
+  async pexpire(): Promise<number> {
+    return 1;
+  }
+
+  async pttl(): Promise<number> {
+    return 60_000;
+  }
+
+  async getdel<T>(key: string): Promise<T | null> {
+    const value = store.get(key) ?? null;
+    store.delete(key);
+    return value as T | null;
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let count = 0;
+    for (const key of keys) {
+      if (store.delete(key)) count++;
+    }
+    return count;
+  }
+
+  async scan(): Promise<[number, string[]]> {
+    return [0, Array.from(store.keys())];
+  }
+
+  async mget<T extends unknown[]>(...keys: string[]): Promise<T> {
+    return keys.map((key) => store.get(key) ?? null) as T;
+  }
+
+  async lpush(): Promise<number> {
+    return 1;
+  }
+
+  async rpop<T>(): Promise<T | null> {
+    return null;
+  }
+
+  async llen(): Promise<number> {
+    return 0;
+  }
+}
+
+mock.module("@upstash/redis", () => ({ Redis: MockUpstashRedis }));
+
+const { CacheClient } = await import("../client");
+const { runWithCloudBindings } = await import("../../runtime/cloud-bindings");
+
+afterAll(() => {
+  mock.module("@upstash/redis", () => realUpstash);
+});
+
+beforeEach(() => {
+  constructedClients.length = 0;
+  store.clear();
+});
+
+describe("CacheClient in Worker envs", () => {
+  test("uses Upstash REST bindings for durable shared-runtime history", async () => {
+    await runWithCloudBindings(
+      {
+        CACHE_ENABLED: "true",
+        CACHE_BACKEND: "redis-rest",
+        ENVIRONMENT: "staging",
+        KV_REST_API_URL: "https://upstash.example.test",
+        KV_REST_API_TOKEN: "test-token",
+        NODE_ENV: "production",
+      },
+      async () => {
+        const cache = new CacheClient();
+        const key = "shared-runtime:agent-1:conversation-1:history:v1";
+        const history = [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi there" },
+        ];
+
+        expect(cache.isAvailable()).toBe(true);
+
+        await cache.set(key, history, 60);
+
+        expect(constructedClients).toEqual([
+          {
+            url: "https://upstash.example.test",
+            token: "test-token",
+          },
+        ]);
+        expect(store.has(`staging:${key}`)).toBe(true);
+        expect(await cache.get(key)).toEqual(history);
+      },
+    );
+  });
+});

--- a/packages/cloud-shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud-shared/src/types/cloud-worker-env.ts
@@ -114,6 +114,7 @@ export interface Bindings {
   // ---- Feature flags ----
   REDIS_RATE_LIMITING?: string;
   CACHE_ENABLED?: string;
+  CACHE_BACKEND?: string;
   APPS_DEPLOY_ENABLED?: string;
   APPS_DEPLOY_ALLOWED_ORG_IDS?: string;
   RATE_LIMIT_DISABLED?: string;


### PR DESCRIPTION
## Summary
- enables the Cloud API Worker cache in default, staging, and production Wrangler vars
- pins the Worker cache backend to `redis-rest` so it uses `KV_REST_API_URL` / `KV_REST_API_TOKEN` instead of a cross-request socket client
- adds a focused regression test proving Worker bindings initialize the Upstash REST adapter and persist the shared-runtime history key with the environment prefix
- types `CACHE_BACKEND` on the Worker bindings interface

## Why
Shared-runtime chat history is stored through the generic cache client under keys like `shared-runtime:<agentId>:<conversationId>:history:v1`. With `CACHE_ENABLED=false`, `GET .../messages` can only return an empty transcript even after a successful turn because `cache.set` silently no-ops. The old disable reason was about Cloudflare Worker cross-request I/O isolation for a module-level socket singleton; forcing `CACHE_BACKEND=redis-rest` avoids that socket path and uses Upstash over fetch instead.

## Validation
- `bun run --cwd packages/cloud-shared test src/lib/cache/__tests__/client-worker-rest.test.ts src/lib/cache/__tests__/client-mock.test.ts`
- `bunx @biomejs/biome check packages/cloud-api/wrangler.toml packages/cloud-shared/src/types/cloud-worker-env.ts packages/cloud-shared/src/lib/cache/__tests__/client-worker-rest.test.ts`
- `bun run --cwd packages/cloud-shared typecheck`
- `git diff --check`