### PR TITLE
plugin-matrix: persistent rust-crypto store, cross-signing & multi-account roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,6 +427,8 @@ apps/*/src/**/*.d.ts
 apps/*/src/**/*.d.ts.map
 !apps/app-companion/src/three-subpath.d.ts
 plugins/*/src/**/*.d.ts
+# hand-written ambient declaration for fake-indexeddb/auto (untyped subpath), not a build artifact
+!plugins/plugin-matrix/src/fake-indexeddb-auto.d.ts
 plugins/*/src/**/*.d.ts.map
 !apps/app-companion/src/types/three-vrm-shim.d.ts
 !apps/app-lifeops/src/website-blocker/elizaos-core-roles.ts

--- a/bun.lock
+++ b/bun.lock
@@ -4180,6 +4180,7 @@
       "version": "2.0.3-beta.14",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "fake-indexeddb": "^6.2.5",
         "matrix-js-sdk": "^41.4.0",
       },
       "devDependencies": {
@@ -11215,6 +11216,7 @@
 
     "face-api.js": ["face-api.js@0.22.2", "", { "dependencies": { "@tensorflow/tfjs-core": "1.7.0", "tslib": "^1.11.1" } }, "sha512-9Bbv/yaBRTKCXjiDqzryeKhYxmgSjJ7ukvOvEBy6krA0Ah/vNBlsf7iBNfJljWiPA8Tys1/MnB3lyP2Hfmsuyw=="],
 
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
     "fancy-canvas": ["fancy-canvas@2.1.0", "", {}, "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="],
 
     "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],

--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { buildCharacterFromConfig } from "./build-character-config.ts";
+
+// Locks the secret/settings boundary for Matrix connector env vars. Putting a
+// public identifier (e.g. MATRIX_VERIFY_ALLOWLIST = a user id) into
+// character.settings.secrets makes the runtime's redaction layer blank its value
+// out of all output — which once rendered a DM room name as
+// "[REDACTED:MATRIX_VERIFY_ALLOWLIST]". Only genuine credentials may be secrets.
+const MATRIX_ENV_KEYS = [
+  "MATRIX_HOMESERVER",
+  "MATRIX_USER_ID",
+  "MATRIX_DEVICE_ID",
+  "MATRIX_ACCESS_TOKEN",
+  "MATRIX_PASSWORD",
+  "MATRIX_VERIFY_ALLOWLIST",
+  "MATRIX_ACCOUNTS",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(
+    MATRIX_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+});
+
+afterEach(() => {
+  for (const key of MATRIX_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+const CONFIG: ElizaConfig = {
+  agents: { list: [{ name: "Tester", system: "x" }] },
+} as ElizaConfig;
+
+describe("Matrix connector secret/settings boundary", () => {
+  it("routes public identifiers to settings and credentials to secrets", () => {
+    process.env.MATRIX_HOMESERVER = "https://hs.example";
+    process.env.MATRIX_USER_ID = "@bot:hs.example";
+    process.env.MATRIX_DEVICE_ID = "DEVID";
+    process.env.MATRIX_ACCESS_TOKEN = "tok-secret";
+    process.env.MATRIX_PASSWORD = "pw-secret";
+    process.env.MATRIX_VERIFY_ALLOWLIST = "@owner:matrix.org";
+    process.env.MATRIX_ACCOUNTS = '[{"accountId":"work","accessToken":"t2"}]';
+
+    const character = buildCharacterFromConfig(CONFIG);
+    const settings = (character.settings ?? {}) as Record<string, unknown>;
+    const secrets = (character.secrets ?? {}) as Record<string, unknown>;
+
+    // Public identifiers are plain settings — resolvable by the plugin, never redacted.
+    expect(settings.MATRIX_HOMESERVER).toBe("https://hs.example");
+    expect(settings.MATRIX_USER_ID).toBe("@bot:hs.example");
+    expect(settings.MATRIX_DEVICE_ID).toBe("DEVID");
+    expect(settings.MATRIX_VERIFY_ALLOWLIST).toBe("@owner:matrix.org");
+
+    // Public identifiers must NOT be secrets (else their values get redacted in output).
+    expect("MATRIX_VERIFY_ALLOWLIST" in secrets).toBe(false);
+    expect("MATRIX_USER_ID" in secrets).toBe(false);
+    expect("MATRIX_HOMESERVER" in secrets).toBe(false);
+
+    // Genuine credentials are secrets (redacted, never plain settings).
+    expect(secrets.MATRIX_ACCESS_TOKEN).toBe("tok-secret");
+    expect(secrets.MATRIX_PASSWORD).toBe("pw-secret");
+    // MATRIX_ACCOUNTS JSON embeds per-account tokens, so it stays a secret.
+    expect("MATRIX_ACCOUNTS" in secrets).toBe(true);
+    expect("MATRIX_ACCESS_TOKEN" in settings).toBe(false);
+    expect("MATRIX_PASSWORD" in settings).toBe(false);
+  });
+
+  it("omits absent Matrix env vars from both settings and secrets", () => {
+    for (const key of MATRIX_ENV_KEYS) delete process.env[key];
+    const character = buildCharacterFromConfig(CONFIG);
+    const settings = (character.settings ?? {}) as Record<string, unknown>;
+    const secrets = (character.secrets ?? {}) as Record<string, unknown>;
+    expect("MATRIX_VERIFY_ALLOWLIST" in settings).toBe(false);
+    expect("MATRIX_ACCESS_TOKEN" in secrets).toBe(false);
+  });
+});

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -129,6 +129,16 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     "MSTEAMS_APP_PASSWORD",
     "MATTERMOST_BOT_TOKEN",
     "MATTERMOST_BASE_URL",
+    // Matrix connector — only the genuine credentials live here (redactable
+    // secrets). The homeserver URL, user/room/device IDs, the verify-allowlist,
+    // and the behaviour flags are PUBLIC identifiers and are bridged as plain
+    // settings below (matrixPublicConfigKeys) — putting them in secrets makes the
+    // redaction layer blank them out wherever they appear in output (e.g. a DM
+    // room name "remilio ↔ @user:server" rendered as "[REDACTED:...]").
+    // MATRIX_ACCOUNTS stays a secret because its JSON embeds per-account tokens.
+    "MATRIX_ACCESS_TOKEN",
+    "MATRIX_PASSWORD",
+    "MATRIX_ACCOUNTS",
     // ElizaCloud secrets
     "ELIZAOS_CLOUD_API_KEY",
     "ELIZAOS_CLOUD_BASE_URL",
@@ -158,6 +168,31 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     const value = process.env[key];
     if (value?.trim()) {
       secrets[key] = value;
+    }
+  }
+
+  // Public connector identifiers + behaviour flags: bridged as plain settings so
+  // getSetting() still resolves them (settings is checked before env in
+  // getSetting), but the secrets-redaction layer — which only scans
+  // character.settings.secrets — leaves them intact. These are not credentials
+  // (homeserver URL, user/room/device IDs, the verify allow-list, on/off flags),
+  // so redacting them only corrupted output (room names, the agent's own id).
+  const matrixPublicConfigKeys = [
+    "MATRIX_HOMESERVER",
+    "MATRIX_USER_ID",
+    "MATRIX_DEVICE_ID",
+    "MATRIX_ROOMS",
+    "MATRIX_AUTO_JOIN",
+    "MATRIX_AUTO_REPLY",
+    "MATRIX_ENCRYPTION",
+    "MATRIX_REQUIRE_MENTION",
+    "MATRIX_VERIFY_ALLOWLIST",
+    "MATRIX_PERSONAL",
+  ];
+  for (const key of matrixPublicConfigKeys) {
+    const value = process.env[key];
+    if (value?.trim()) {
+      settings[key] = value;
     }
   }
 

--- a/plugins/plugin-matrix/package.json
+++ b/plugins/plugin-matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-matrix",
-  "version": "2.0.3-beta.14",
+  "version": "2.0.3-beta.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,7 +49,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@elizaos/core": "workspace:*",
+    "fake-indexeddb": "^6.2.5",
     "matrix-js-sdk": "^41.4.0"
   },
   "peerDependencies": {

--- a/plugins/plugin-matrix/src/__tests__/connector.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/connector.test.ts
@@ -1,6 +1,39 @@
-import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
+import type { Content, IAgentRuntime, Memory, TargetInfo } from "@elizaos/core";
+import { createUniqueUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MatrixService } from "../service.js";
+
+type QueryContext = { runtime: IAgentRuntime; target?: TargetInfo };
+type ReadParams = { target?: TargetInfo; limit?: number; query?: string };
+
+// The canonical `read_channel "<room>"` path resolves a Matrix target that
+// carries the raw room id ONLY in `channelId` (no core `roomId` UUID). These
+// tests lock that the connector still reaches the live read instead of gating
+// it behind a field Matrix targets never set.
+function memory(id: string, text: string, createdAt: number): Memory {
+  return {
+    id: createUniqueUuid({} as IAgentRuntime, id),
+    entityId: createUniqueUuid({} as IAgentRuntime, `entity:${id}`),
+    agentId: createUniqueUuid({} as IAgentRuntime, "agent"),
+    roomId: createUniqueUuid({} as IAgentRuntime, "room"),
+    content: { text, source: "matrix" },
+    createdAt,
+  } as Memory;
+}
+
+function registerAndGetConnector(service: MatrixService) {
+  const runtime = {
+    registerMessageConnector: vi.fn(),
+    registerSendHandler: vi.fn(),
+    getSetting: vi.fn(() => null),
+    character: { settings: {} },
+    getRoom: vi.fn(),
+    getMemories: vi.fn().mockResolvedValue([]),
+  } as unknown as IAgentRuntime;
+  MatrixService.registerSendHandlers(runtime, service, "work");
+  const registration = vi.mocked(runtime.registerMessageConnector).mock.calls[0][0];
+  return { runtime, registration };
+}
 
 describe("Matrix message connector", () => {
   it("registers connector metadata and routes sends through Matrix rooms", async () => {
@@ -100,5 +133,179 @@ describe("Matrix message connector", () => {
       "hi",
       expect.objectContaining({ accountId: "personal", roomId: "!personal:matrix.org" })
     );
+  });
+});
+
+describe("Matrix connector read path (channelId-only targets)", () => {
+  function createService() {
+    const service = Object.create(MatrixService.prototype) as MatrixService;
+    (service as { settings: { accountId: string } }).settings = { accountId: "work" };
+    return service;
+  }
+
+  // A realistic resolved Matrix target from the canonical read_channel path:
+  // source + accountId + channelId (raw matrix id), and NO target.roomId UUID.
+  const channelOnlyTarget: TargetInfo = {
+    source: "matrix",
+    accountId: "work",
+    channelId: "!abc:server",
+  } as TargetInfo;
+
+  it("fetchMessages reaches getRoomMessages for a channelId-only target", async () => {
+    const service = createService();
+    const live = [memory("$2", "newer", 200), memory("$1", "older", 100)];
+    const getRoomMessages = vi.spyOn(service, "getRoomMessages").mockResolvedValue(live);
+    const { runtime, registration } = registerAndGetConnector(service);
+
+    const result = await registration.fetchMessages?.(
+      { runtime } as QueryContext,
+      { target: channelOnlyTarget, limit: 50 } as ReadParams
+    );
+
+    expect(getRoomMessages).toHaveBeenCalledWith("!abc:server", 50, "work");
+    expect(result).toEqual(live);
+    // The dead getRoom-gated branch must not run for a channelId-only target.
+    expect(runtime.getRoom).not.toHaveBeenCalled();
+  });
+
+  it("searchMessages reaches getRoomMessages for a channelId-only target", async () => {
+    const service = createService();
+    const live = [memory("$2", "deploy failed", 200), memory("$1", "all green", 100)];
+    const getRoomMessages = vi.spyOn(service, "getRoomMessages").mockResolvedValue(live);
+    const { runtime, registration } = registerAndGetConnector(service);
+
+    const result = await registration.searchMessages?.(
+      { runtime } as QueryContext,
+      { target: channelOnlyTarget, limit: 50, query: "deploy" } as ReadParams & { query: string }
+    );
+
+    // scanLimit is max(limit, 100).
+    expect(getRoomMessages).toHaveBeenCalledWith("!abc:server", 100, "work");
+    expect(result?.map((m) => m.content.text)).toEqual(["deploy failed"]);
+    expect(runtime.getRoom).not.toHaveBeenCalled();
+  });
+
+  it("falls back to stored memories keyed by the core UUID derived from the raw matrix id", async () => {
+    const service = createService();
+    // Live timeline empty -> the stored-memory fallback must key by
+    // createUniqueUuid(runtime, "!abc:server"), matching how inbound Matrix
+    // memories are stored (matrixMessageToMemory).
+    vi.spyOn(service, "getRoomMessages").mockResolvedValue([]);
+    const { runtime, registration } = registerAndGetConnector(service);
+    const stored = [memory("$s", "stored", 50)];
+    vi.mocked(runtime.getMemories).mockResolvedValue(stored);
+
+    const result = await registration.fetchMessages?.(
+      { runtime } as QueryContext,
+      { target: channelOnlyTarget, limit: 50 } as ReadParams
+    );
+
+    expect(runtime.getMemories).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "messages",
+        roomId: createUniqueUuid(runtime, "!abc:server"),
+        limit: 50,
+      })
+    );
+    expect(result).toEqual(stored);
+  });
+
+  it("surfaces the encrypted placeholder end-to-end through fetchMessages", async () => {
+    const service = createService();
+    // Room timeline holds one undecryptable m.room.encrypted event. The real
+    // getRoomMessages converts it to the placeholder memory; drive it through
+    // the live SDK client (not a getRoomMessages spy) to lock the full path.
+    const encryptedEvent = {
+      getContent: vi.fn(() => ({})),
+      getType: vi.fn(() => "m.room.encrypted"),
+      isDecryptionFailure: vi.fn(() => false),
+      getSender: vi.fn(() => "@alice:server"),
+      getRoomId: vi.fn(() => "!abc:server"),
+      getId: vi.fn(() => "$enc"),
+      getTs: vi.fn(() => 999),
+    };
+    const room = {
+      getJoinedMemberCount: vi.fn(() => 3),
+      getMember: vi.fn(() => ({ name: "Alice" })),
+      getLiveTimeline: vi.fn(() => ({ getEvents: vi.fn(() => [encryptedEvent]) })),
+    };
+    const runtimeForService = {
+      agentId: createUniqueUuid({} as IAgentRuntime, "agent"),
+    } as unknown as IAgentRuntime;
+    Object.assign(service as unknown as { runtime: IAgentRuntime; defaultAccountId: string }, {
+      runtime: runtimeForService,
+      defaultAccountId: "work",
+    });
+    (service as unknown as { states: Map<string, { accountId: string; client: unknown }> }).states =
+      new Map([
+        [
+          "work",
+          {
+            accountId: "work",
+            client: { getRoom: vi.fn(() => room) },
+            connected: true,
+            syncing: true,
+          },
+        ],
+      ]) as never;
+
+    const { runtime, registration } = registerAndGetConnector(service);
+    const result = await registration.fetchMessages?.(
+      { runtime } as QueryContext,
+      { target: channelOnlyTarget, limit: 50 } as ReadParams
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0].content.text).toContain("end-to-end encrypted message");
+    expect(result?.[0].content.name).toBe("Alice");
+  });
+});
+
+describe("Matrix connector account roles (agent vs personal)", () => {
+  function runtimeWith(matrix: Record<string, unknown>): IAgentRuntime {
+    const env: Record<string, string> = {
+      MATRIX_HOMESERVER: "https://hs.example",
+      MATRIX_USER_ID: "@bot:hs.example",
+      MATRIX_ACCESS_TOKEN: "tok",
+    };
+    return {
+      character: { settings: { matrix } },
+      getSetting: (k: string) => env[k] ?? null,
+    } as unknown as IAgentRuntime;
+  }
+
+  it("exposes the agent's own account as an open AGENT account", async () => {
+    const { createMatrixConnectorAccountProvider } = await import(
+      "../connector-account-provider.js"
+    );
+    const provider = createMatrixConnectorAccountProvider(runtimeWith({}));
+    const accounts = await provider.listAccounts({} as never);
+    const def = accounts[0];
+    expect(def.role).toBe("AGENT");
+    expect(def.accessGate).toBe("open");
+    expect(def.metadata?.personal).toBe(false);
+  });
+
+  it("exposes a personal account as an owner_binding-gated OWNER account", async () => {
+    const { createMatrixConnectorAccountProvider } = await import(
+      "../connector-account-provider.js"
+    );
+    const provider = createMatrixConnectorAccountProvider(
+      runtimeWith({
+        accounts: {
+          nubs: {
+            homeserver: "https://hs.example",
+            userId: "@nubs:hs.example",
+            accessToken: "tok2",
+            personal: true,
+          },
+        },
+      })
+    );
+    const accounts = await provider.listAccounts({} as never);
+    const personal = accounts.find((a) => a.displayHandle === "@nubs:hs.example");
+    expect(personal?.role).toBe("OWNER");
+    expect(personal?.accessGate).toBe("owner_binding");
+    expect(personal?.purpose).toContain("reading");
   });
 });

--- a/plugins/plugin-matrix/src/__tests__/crypto-store.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/crypto-store.test.ts
@@ -1,0 +1,243 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deserialize as v8Deserialize, serialize as v8Serialize } from "node:v8";
+import type { IAgentRuntime } from "@elizaos/core";
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { type CryptoStoreSnapshot, MatrixService, restoreDb, snapshotDb } from "../service.js";
+import type { MatrixSettings } from "../types.js";
+
+const ACCOUNT_ID = "work";
+// Non-default accounts get a per-account IndexedDB prefix so multiple encrypted
+// accounts in one process don't collide on a single crypto store.
+const CRYPTO_DB_NAME = `matrix-js-sdk-${ACCOUNT_ID}::matrix-sdk-crypto`;
+
+type StoreTestState = {
+  accountId: string;
+  settings: MatrixSettings;
+  client: Record<string, never>;
+  connected: boolean;
+  syncing: boolean;
+  cryptoSnapshotTimer?: ReturnType<typeof setInterval>;
+};
+
+let stateRoot: string;
+
+function openDb(
+  name: string,
+  version?: number,
+  upgrade?: (db: IDBDatabase) => void
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = version ? indexedDB.open(name, version) : indexedDB.open(name);
+    if (upgrade) {
+      request.onupgradeneeded = (event) => upgrade((event.target as IDBOpenDBRequest).result);
+    }
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function getRecord(store: IDBObjectStore, key: IDBValidKey): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const request = store.get(key);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function resetIndexedDb(): void {
+  (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+}
+
+function settings(accessToken = "token-aaa"): MatrixSettings {
+  return {
+    accountId: ACCOUNT_ID,
+    homeserver: "https://matrix.example",
+    userId: "@bot:example",
+    accessToken,
+    rooms: [],
+    autoJoin: false,
+    encryption: true,
+    requireMention: false,
+    enabled: true,
+  };
+}
+
+function createService(accessToken = "token-aaa") {
+  const runtime = { agentId: "00000000-0000-0000-0000-000000000001" } as unknown as IAgentRuntime;
+  const state: StoreTestState = {
+    accountId: ACCOUNT_ID,
+    settings: settings(accessToken),
+    client: {},
+    connected: true,
+    syncing: true,
+  };
+  const service = Object.create(MatrixService.prototype) as MatrixService;
+  Object.assign(service as unknown as { runtime: IAgentRuntime; defaultAccountId: string }, {
+    runtime,
+    defaultAccountId: ACCOUNT_ID,
+  });
+  (service as unknown as { states: Map<string, StoreTestState> }).states = new Map([
+    [ACCOUNT_ID, state],
+  ]);
+  return { service, state };
+}
+
+function callSave(service: MatrixService, state: StoreTestState): Promise<void> {
+  return (
+    service as unknown as { saveCryptoStore: (s: StoreTestState) => Promise<void> }
+  ).saveCryptoStore(state);
+}
+
+function callRestore(service: MatrixService, state: StoreTestState): Promise<void> {
+  return (
+    service as unknown as { restoreCryptoStore: (s: StoreTestState) => Promise<void> }
+  ).restoreCryptoStore(state);
+}
+
+function storeFilePath(): string {
+  return join(stateRoot, "matrix-keys", `${ACCOUNT_ID}.enc`);
+}
+
+/** Seed the crypto db with a keyPath store (+ index) and a keyless store. */
+async function seedCryptoDb(): Promise<void> {
+  const db = await openDb(CRYPTO_DB_NAME, 1, (upgradeDb) => {
+    const identities = upgradeDb.createObjectStore("identities", { keyPath: "id" });
+    identities.createIndex("byUser", "user", { unique: false });
+    upgradeDb.createObjectStore("core");
+  });
+  const tx = db.transaction(["identities", "core"], "readwrite");
+  tx.objectStore("identities").put({
+    id: "@bot:example",
+    user: "@bot:example",
+    ed25519: new Uint8Array([1, 2, 3, 4]),
+  });
+  tx.objectStore("core").put({ version: 7 }, "schema");
+  await txDone(tx);
+  db.close();
+}
+
+beforeEach(async () => {
+  await import("fake-indexeddb/auto");
+  resetIndexedDb();
+  stateRoot = mkdtempSync(join(tmpdir(), "matrix-crypto-test-"));
+  process.env.MILADY_STATE_DIR = stateRoot;
+});
+
+afterEach(() => {
+  delete process.env.MILADY_STATE_DIR;
+  rmSync(stateRoot, { recursive: true, force: true });
+  resetIndexedDb();
+});
+
+describe("snapshotDb / restoreDb round-trip", () => {
+  it("round-trips schema (keyPath + index) and records through a v8 + fresh-factory restart", async () => {
+    await seedCryptoDb();
+
+    const snapshot = await snapshotDb(CRYPTO_DB_NAME);
+    // v8 round-trip mirrors the on-disk serialization path.
+    const restored = v8Deserialize(v8Serialize(snapshot)) as CryptoStoreSnapshot;
+
+    // Simulate a process restart: brand-new IndexedDB factory, empty.
+    resetIndexedDb();
+
+    await restoreDb(CRYPTO_DB_NAME, restored);
+
+    const db = await openDb(CRYPTO_DB_NAME);
+    const tx = db.transaction(["identities", "core"], "readonly");
+    const identity = (await getRecord(tx.objectStore("identities"), "@bot:example")) as {
+      id: string;
+      ed25519: Uint8Array;
+    };
+    const core = (await getRecord(tx.objectStore("core"), "schema")) as { version: number };
+    const indexNames = [...tx.objectStore("identities").indexNames];
+    db.close();
+
+    expect(identity.id).toBe("@bot:example");
+    expect([...identity.ed25519]).toEqual([1, 2, 3, 4]);
+    // Keyless store record keyed by its out-of-line key survives.
+    expect(core.version).toBe(7);
+    expect(indexNames).toContain("byUser");
+  });
+});
+
+describe("Matrix crypto-store persistence", () => {
+  it("saveCryptoStore writes an encrypted, non-plaintext, v1:-prefixed file atomically", async () => {
+    await seedCryptoDb();
+    const { service, state } = createService();
+
+    await callSave(service, state);
+
+    expect(existsSync(storeFilePath())).toBe(true);
+    const onDisk = readFileSync(storeFilePath(), "utf8");
+    expect(onDisk.startsWith("v1:")).toBe(true);
+    expect(onDisk.split(":")).toHaveLength(4);
+    // The private device key material must never appear in plaintext on disk.
+    expect(onDisk).not.toContain("ed25519");
+    expect(onDisk).not.toContain("@bot:example");
+  });
+
+  it("restoreCryptoStore round-trips a file written by saveCryptoStore back into IndexedDB", async () => {
+    await seedCryptoDb();
+    const writer = createService();
+    await callSave(writer.service, writer.state);
+
+    // Restart: fresh, empty IndexedDB factory.
+    resetIndexedDb();
+
+    const reader = createService();
+    await callRestore(reader.service, reader.state);
+
+    const db = await openDb(CRYPTO_DB_NAME);
+    const identity = (await getRecord(
+      db.transaction("identities", "readonly").objectStore("identities"),
+      "@bot:example"
+    )) as { id: string; ed25519: Uint8Array };
+    db.close();
+    expect(identity.id).toBe("@bot:example");
+    expect([...identity.ed25519]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("restoreCryptoStore with a missing file does not throw", async () => {
+    const { service, state } = createService();
+    await expect(callRestore(service, state)).resolves.toBeUndefined();
+  });
+
+  it("restoreCryptoStore is non-fatal on a corrupt/garbage file", async () => {
+    const { service, state } = createService();
+    mkdirSync(join(stateRoot, "matrix-keys"), { recursive: true });
+    writeFileSync(storeFilePath(), "not-a-valid-ciphertext-at-all");
+    await expect(callRestore(service, state)).resolves.toBeUndefined();
+  });
+
+  it("restoreCryptoStore is non-fatal when the token rotated (decrypt fails)", async () => {
+    await seedCryptoDb();
+    const writer = createService("token-aaa");
+    await callSave(writer.service, writer.state);
+
+    const reader = createService("token-bbb-rotated");
+    await expect(callRestore(reader.service, reader.state)).resolves.toBeUndefined();
+  });
+
+  it("saveCryptoStore is a silent no-op when no global IndexedDB is present", async () => {
+    const original = (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+    (globalThis as { indexedDB?: IDBFactory }).indexedDB = undefined;
+    try {
+      const { service, state } = createService();
+      await callSave(service, state);
+      expect(existsSync(storeFilePath())).toBe(false);
+    } finally {
+      (globalThis as { indexedDB?: IDBFactory }).indexedDB = original;
+    }
+  });
+});

--- a/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
@@ -1,7 +1,38 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import type { Content, HandlerCallback, IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+
+// The vitest @elizaos/core shim (packages/test/vitest/shims) is a curated subset
+// and omits lifeOpsPassiveConnectorsEnabled, which service.ts imports. The real
+// runtime export exists; mirror its semantics here (default ON; explicit-false
+// disables via the ELIZA_LIFEOPS_PASSIVE_CONNECTORS / LIFEOPS_PASSIVE_CONNECTORS
+// setting) so the auto-reply gate is exercised deterministically under test.
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const isExplicitFalse = (value: unknown): boolean => {
+    if (value === false || value === 0) return true;
+    if (typeof value !== "string") return false;
+    const v = value.trim().toLowerCase();
+    return v === "0" || v === "false" || v === "off" || v === "no" || v === "disabled";
+  };
+  return {
+    ...actual,
+    lifeOpsPassiveConnectorsEnabled: (runtime?: { getSetting?: (k: string) => unknown } | null) => {
+      const value =
+        runtime?.getSetting?.("ELIZA_LIFEOPS_PASSIVE_CONNECTORS") ??
+        runtime?.getSetting?.("LIFEOPS_PASSIVE_CONNECTORS");
+      return value === undefined || value === null ? true : !isExplicitFalse(value);
+    },
+  };
+});
+
 import { MatrixService } from "../service.js";
-import { MatrixEventTypes, MatrixNotConnectedError, type MatrixSettings } from "../types.js";
+import {
+  MatrixEventTypes,
+  type MatrixMessage,
+  MatrixNotConnectedError,
+  type MatrixRoom,
+  type MatrixSettings,
+} from "../types.js";
 
 type TestState = {
   accountId: string;
@@ -17,16 +48,24 @@ type TestState = {
   syncing: boolean;
 };
 
-function createRuntime(): IAgentRuntime {
+function createRuntime(settings: Record<string, unknown> = {}): IAgentRuntime {
   return {
+    agentId: "00000000-0000-0000-0000-000000000001",
     emitEvent: vi.fn(),
-    getSetting: vi.fn(),
+    // ELIZA_LIFEOPS_PASSIVE_CONNECTORS defaults to undefined (passive ON) unless overridden.
+    getSetting: vi.fn((key: string) => settings[key]),
+    ensureConnection: vi.fn().mockResolvedValue(undefined),
+    createMemory: vi.fn().mockResolvedValue(undefined),
+    messageService: { handleMessage: vi.fn() },
     character: { settings: {} },
   } as unknown as IAgentRuntime;
 }
 
-function createService(stateOverrides: Partial<TestState> = {}) {
-  const runtime = createRuntime();
+function createService(
+  stateOverrides: Partial<TestState> = {},
+  runtimeSettings: Record<string, unknown> = {}
+) {
+  const runtime = createRuntime(runtimeSettings);
   const settings: MatrixSettings = {
     accountId: "work",
     homeserver: "https://matrix.example",
@@ -82,11 +121,49 @@ function createEvent(content: Record<string, unknown>) {
   return {
     getContent: vi.fn(() => content),
     getType: vi.fn(() => "m.room.message"),
+    isDecryptionFailure: vi.fn(() => false),
     getSender: vi.fn(() => "@alice:example"),
     getRoomId: vi.fn(() => "!ops:example"),
     getId: vi.fn(() => "$event"),
     getTs: vi.fn(() => 123),
   };
+}
+
+function createMatrixMessage(overrides: Partial<MatrixMessage> = {}): MatrixMessage {
+  return {
+    eventId: "$inbound",
+    roomId: "!ops:example",
+    sender: "@alice:example",
+    senderInfo: { userId: "@alice:example", displayName: "Alice" },
+    content: "hello bot",
+    msgType: "m.text",
+    timestamp: 123,
+    ...overrides,
+  };
+}
+
+function createMatrixRoom(overrides: Partial<MatrixRoom> = {}): MatrixRoom {
+  return {
+    roomId: "!ops:example",
+    name: "Ops",
+    isEncrypted: false,
+    isDirect: false,
+    memberCount: 3,
+    ...overrides,
+  };
+}
+
+function callDispatch(
+  service: MatrixService,
+  state: TestState,
+  message: MatrixMessage,
+  room: MatrixRoom
+) {
+  return (
+    service as unknown as {
+      dispatchToAgent: (s: TestState, m: MatrixMessage, r: MatrixRoom) => Promise<void>;
+    }
+  ).dispatchToAgent(state, message, room);
 }
 
 describe("Matrix service hardening", () => {
@@ -204,5 +281,288 @@ describe("Matrix service hardening", () => {
     expect(state.client.sendMessage).not.toHaveBeenCalled();
     expect(state.client.sendEvent).not.toHaveBeenCalled();
     expect(state.client.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it("persists the inbound message but does not run the agent when auto-reply is off", async () => {
+    // MATRIX_AUTO_REPLY unset -> gate off; passive mode is irrelevant here.
+    const { runtime, service, state } = createService();
+
+    await callDispatch(service, state, createMatrixMessage(), createMatrixRoom());
+
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.objectContaining({ text: "hello bot" }) }),
+      "messages"
+    );
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+    expect(state.client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("runs the agent and round-trips the reply when auto-reply is on and passive mode is off", async () => {
+    // Auto-reply ON requires BOTH the gate set true AND passive connectors explicitly disabled.
+    const { runtime, service, state } = createService(
+      {},
+      { MATRIX_AUTO_REPLY: "true", ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false" }
+    );
+
+    await callDispatch(service, state, createMatrixMessage(), createMatrixRoom());
+
+    expect(runtime.messageService.handleMessage).toHaveBeenCalledTimes(1);
+    // Inbound is not separately persisted in the auto-reply path; only the agent's outbound is.
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+
+    // Invoke the callback the service handed to messageService, simulating the agent's reply.
+    const callback = runtime.messageService.handleMessage.mock.calls[0][2] as HandlerCallback;
+    const result = await callback({ text: "  hi back  " } as Content);
+
+    expect(state.client.sendMessage).toHaveBeenCalledWith(
+      "!ops:example",
+      expect.objectContaining({ body: "hi back" })
+    );
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.objectContaining({ text: "hi back" }) }),
+      "messages"
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("still suppresses auto-reply when passive mode is on even if the gate is true", async () => {
+    // Gate true but passive connectors left at default (on) -> no agent run.
+    const { runtime, service, state } = createService({}, { MATRIX_AUTO_REPLY: "true" });
+
+    await callDispatch(service, state, createMatrixMessage(), createMatrixRoom());
+
+    expect(runtime.messageService.handleMessage).not.toHaveBeenCalled();
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("bypasses the mention gate in 1:1 DMs but honors it in group rooms", () => {
+    const settings: MatrixSettings = {
+      accountId: "work",
+      homeserver: "https://matrix.example",
+      userId: "@bot.name:example",
+      accessToken: "token",
+      rooms: [],
+      autoJoin: false,
+      encryption: false,
+      requireMention: true,
+      enabled: true,
+    };
+
+    // DM: 2 members, body lacks the mention -> still dispatched (mention gate bypassed).
+    const dm = createService({ settings });
+    const dmRoom = createRoom();
+    dmRoom.getJoinedMemberCount = vi.fn(() => 2);
+    (
+      dm.service as unknown as {
+        handleRoomMessage: (s: TestState, e: unknown, r: unknown) => void;
+      }
+    ).handleRoomMessage(
+      dm.state,
+      createEvent({ msgtype: "m.text", body: "no mention here" }),
+      dmRoom
+    );
+    expect(dm.runtime.emitEvent).toHaveBeenCalledWith(
+      MatrixEventTypes.MESSAGE_RECEIVED,
+      expect.anything()
+    );
+
+    // Group: 3 members, same body without the mention -> gate honored, not dispatched.
+    const group = createService({ settings });
+    const groupRoom = createRoom();
+    groupRoom.getJoinedMemberCount = vi.fn(() => 3);
+    (
+      group.service as unknown as {
+        handleRoomMessage: (s: TestState, e: unknown, r: unknown) => void;
+      }
+    ).handleRoomMessage(
+      group.state,
+      createEvent({ msgtype: "m.text", body: "no mention here" }),
+      groupRoom
+    );
+    expect(group.runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("reads live timeline messages newest-first, attaches the name, and skips non-text events", async () => {
+    const { runtime, service, state } = createService();
+
+    const makeEvent = (over: {
+      body?: unknown;
+      msgtype?: string;
+      sender?: string;
+      id?: string;
+      ts?: number;
+    }) => ({
+      getContent: vi.fn(() => ({ msgtype: over.msgtype ?? "m.text", body: over.body })),
+      getType: vi.fn(() => "m.room.message"),
+      isDecryptionFailure: vi.fn(() => false),
+      getSender: vi.fn(() => over.sender ?? "@alice:example"),
+      getRoomId: vi.fn(() => "!ops:example"),
+      getId: vi.fn(() => over.id ?? "$e"),
+      getTs: vi.fn(() => over.ts ?? 0),
+    });
+
+    // Timeline order is oldest -> newest; an image event sits between the two text ones.
+    const events = [
+      makeEvent({ body: "older", sender: "@alice:example", id: "$1", ts: 100 }),
+      makeEvent({ body: "ignored", msgtype: "m.image", id: "$img", ts: 150 }),
+      makeEvent({ body: "newer", sender: "@bob:example", id: "$2", ts: 200 }),
+    ];
+
+    const room = {
+      getJoinedMemberCount: vi.fn(() => 3),
+      getMember: vi.fn((userId: string) => ({
+        name: userId === "@bob:example" ? "Bob" : "Alice",
+        getMxcAvatarUrl: vi.fn(() => undefined),
+      })),
+      getLiveTimeline: vi.fn(() => ({ getEvents: vi.fn(() => events) })),
+    };
+    (state.client as unknown as { getRoom: ReturnType<typeof vi.fn> }).getRoom = vi.fn(
+      (id: string) => (id === "!ops:example" ? room : null)
+    );
+
+    const result = await service.getRoomMessages("!ops:example", 50, "work");
+
+    // Two text events only (image skipped), newest-first.
+    expect(result).toHaveLength(2);
+    expect(result[0].content.text).toBe("newer");
+    expect(result[0].content.name).toBe("Bob");
+    expect(result[1].content.text).toBe("older");
+    expect(result[1].content.name).toBe("Alice");
+    expect(result[0].content.source).toBe("matrix");
+
+    // Unknown room id -> empty.
+    expect(await service.getRoomMessages("!missing:example", 50, "work")).toEqual([]);
+
+    expect(runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("respects the limit when reading the live timeline, keeping the newest", async () => {
+    const { service, state } = createService();
+    const makeEvent = (id: string, body: string, ts: number) => ({
+      getContent: vi.fn(() => ({ msgtype: "m.text", body })),
+      getType: vi.fn(() => "m.room.message"),
+      isDecryptionFailure: vi.fn(() => false),
+      getSender: vi.fn(() => "@alice:example"),
+      getRoomId: vi.fn(() => "!ops:example"),
+      getId: vi.fn(() => id),
+      getTs: vi.fn(() => ts),
+    });
+    const events = [
+      makeEvent("$1", "first", 100),
+      makeEvent("$2", "second", 200),
+      makeEvent("$3", "third", 300),
+    ];
+    const room = {
+      getJoinedMemberCount: vi.fn(() => 2),
+      getMember: vi.fn(() => ({ name: "Alice", getMxcAvatarUrl: vi.fn(() => undefined) })),
+      getLiveTimeline: vi.fn(() => ({ getEvents: vi.fn(() => events) })),
+    };
+    (state.client as unknown as { getRoom: ReturnType<typeof vi.fn> }).getRoom = vi.fn(() => room);
+
+    const result = await service.getRoomMessages("!ops:example", 2, "work");
+    expect(result.map((m) => m.content.text)).toEqual(["third", "second"]);
+  });
+
+  it("skips crypto init when encryption is off and warns when initRustCrypto is unavailable", async () => {
+    const { service } = createService();
+    const initCrypto = (
+      service as unknown as {
+        initCrypto: (state: { settings: MatrixSettings; client: unknown }) => Promise<void>;
+      }
+    ).initCrypto.bind(service);
+
+    // Encryption off -> no-op, never touches the client.
+    const initRustCrypto = vi.fn().mockResolvedValue(undefined);
+    await initCrypto({
+      settings: { encryption: false } as MatrixSettings,
+      client: { initRustCrypto },
+    });
+    expect(initRustCrypto).not.toHaveBeenCalled();
+
+    // Encryption on but client lacks initRustCrypto -> warns, does not throw.
+    const { logger } = await import("@elizaos/core");
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    await expect(
+      initCrypto({
+        settings: { encryption: true, userId: "@bot:example" } as MatrixSettings,
+        client: {},
+      })
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("initRustCrypto is unavailable"));
+    warn.mockRestore();
+  });
+
+  it("degrades and continues when initRustCrypto rejects instead of crashing the connection", async () => {
+    const { service } = createService();
+    const initCrypto = (
+      service as unknown as {
+        initCrypto: (state: { settings: MatrixSettings; client: unknown }) => Promise<void>;
+      }
+    ).initCrypto.bind(service);
+
+    const { logger } = await import("@elizaos/core");
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const initRustCrypto = vi.fn().mockRejectedValue(new Error("wasm init failed"));
+
+    // A rejecting rust-crypto init must NOT throw out of initialize()/start();
+    // it should warn and let the Matrix connection continue.
+    await expect(
+      initCrypto({
+        settings: { encryption: true, userId: "@bot:example" } as MatrixSettings,
+        client: { initRustCrypto },
+      })
+    ).resolves.toBeUndefined();
+
+    // First the persistent (IndexedDB) path is attempted; when it rejects the
+    // in-memory path is attempted as a fallback. Both reject here.
+    expect(initRustCrypto).toHaveBeenCalledTimes(2);
+    expect(initRustCrypto).toHaveBeenNthCalledWith(1, {
+      useIndexedDB: true,
+      cryptoDatabasePrefix: "matrix-js-sdk",
+    });
+    expect(initRustCrypto).toHaveBeenNthCalledWith(2, { useIndexedDB: false });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Matrix encryption failed to initialize")
+    );
+    warn.mockRestore();
+  });
+
+  it("falls back to the in-memory store when only the persistent (IndexedDB) init fails", async () => {
+    const { service } = createService();
+    const initCrypto = (
+      service as unknown as {
+        initCrypto: (state: { settings: MatrixSettings; client: unknown }) => Promise<void>;
+      }
+    ).initCrypto.bind(service);
+
+    const { logger } = await import("@elizaos/core");
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const info = vi.spyOn(logger, "info").mockImplementation(() => {});
+    // Reject the persistent attempt, accept the in-memory fallback.
+    const initRustCrypto = vi
+      .fn()
+      .mockImplementation((opts: { useIndexedDB: boolean }) =>
+        opts.useIndexedDB ? Promise.reject(new Error("idb blocked")) : Promise.resolve(undefined)
+      );
+
+    await expect(
+      initCrypto({
+        settings: { encryption: true, userId: "@bot:example" } as MatrixSettings,
+        client: { initRustCrypto },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(initRustCrypto).toHaveBeenNthCalledWith(1, {
+      useIndexedDB: true,
+      cryptoDatabasePrefix: "matrix-js-sdk",
+    });
+    expect(initRustCrypto).toHaveBeenNthCalledWith(2, { useIndexedDB: false });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("falling back to in-memory crypto"));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("in-memory rust-crypto"));
+    warn.mockRestore();
+    info.mockRestore();
   });
 });

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -171,6 +171,10 @@ export function resolveMatrixAccountSettings(
       base.accessToken ??
       (allowEnv ? stringSetting(runtime, "MATRIX_ACCESS_TOKEN") : undefined) ??
       "",
+    password:
+      account.password ??
+      base.password ??
+      (allowEnv ? stringSetting(runtime, "MATRIX_PASSWORD") : undefined),
     deviceId:
       account.deviceId ??
       base.deviceId ??
@@ -178,20 +182,31 @@ export function resolveMatrixAccountSettings(
     rooms: roomsValue(
       account.rooms ?? base.rooms ?? (allowEnv ? stringSetting(runtime, "MATRIX_ROOMS") : undefined)
     ),
+    verifyAllowlist: roomsValue(
+      account.verifyAllowlist ??
+        base.verifyAllowlist ??
+        (allowEnv ? stringSetting(runtime, "MATRIX_VERIFY_ALLOWLIST") : undefined)
+    ),
+    // boolean flags: read raw via getSetting (NOT stringSetting, which drops real booleans)
     autoJoin: boolValue(
       account.autoJoin ??
         base.autoJoin ??
-        (allowEnv ? stringSetting(runtime, "MATRIX_AUTO_JOIN") : undefined)
+        (allowEnv ? runtime.getSetting("MATRIX_AUTO_JOIN") : undefined)
     ),
     encryption: boolValue(
       account.encryption ??
         base.encryption ??
-        (allowEnv ? stringSetting(runtime, "MATRIX_ENCRYPTION") : undefined)
+        (allowEnv ? runtime.getSetting("MATRIX_ENCRYPTION") : undefined)
     ),
     requireMention: boolValue(
       account.requireMention ??
         base.requireMention ??
-        (allowEnv ? stringSetting(runtime, "MATRIX_REQUIRE_MENTION") : undefined)
+        (allowEnv ? runtime.getSetting("MATRIX_REQUIRE_MENTION") : undefined)
+    ),
+    personal: boolValue(
+      account.personal ??
+        base.personal ??
+        (allowEnv ? runtime.getSetting("MATRIX_PERSONAL") : undefined)
     ),
     enabled: boolValue(account.enabled ?? base.enabled, true),
   };

--- a/plugins/plugin-matrix/src/connector-account-provider.ts
+++ b/plugins/plugin-matrix/src/connector-account-provider.ts
@@ -8,9 +8,13 @@
  * Source of truth for accounts is character settings (`character.settings.matrix`)
  * + MATRIX_ACCOUNTS JSON env var + single-account env vars (MATRIX_HOMESERVER,
  * MATRIX_USER_ID, MATRIX_ACCESS_TOKEN). AccountKey is `<homeserver>/<userId>`
- * by convention; role is `OWNER` since matrix access tokens authenticate the
- * user, not a bot. E2EE keys are scoped per account by the matrix client and
- * are NOT shared between accounts.
+ * by convention. Role is derived from the account's `personal` flag: the agent's
+ * own Matrix identity is an `AGENT` account behind the `open` gate (acting as the
+ * bot is frictionless), while an account flagged `personal: true` — the human
+ * owner's account the agent acts THROUGH — is an `OWNER` account behind the
+ * `owner_binding` gate (acting as the user requires a verified binding). A Matrix
+ * access token authenticates a user either way; what differs is whose identity it
+ * is. E2EE keys are scoped per account by the matrix client and are NOT shared.
  */
 
 import type {
@@ -41,13 +45,17 @@ function accountKey(settings: MatrixSettings): string {
 function toConnectorAccount(settings: MatrixSettings): ConnectorAccount {
   const now = Date.now();
   const configured = Boolean(settings.homeserver && settings.userId && settings.accessToken);
+  // The agent's own identity (default) is an open AGENT account; the human
+  // owner's personal account is an OWNER account gated on a verified binding so
+  // "act as the user" can't fire until the user has proven the account is theirs.
+  const personal = settings.personal === true;
   return {
     id: normalizeMatrixAccountId(settings.accountId),
     provider: MATRIX_PROVIDER_ID,
     label: settings.userId || settings.accountId,
-    role: "OWNER",
-    purpose: ["messaging"],
-    accessGate: "open",
+    role: personal ? "OWNER" : "AGENT",
+    purpose: personal ? ["messaging", "reading"] : ["messaging"],
+    accessGate: personal ? "owner_binding" : "open",
     status: settings.enabled !== false && configured ? "connected" : "disabled",
     externalId: accountKey(settings),
     displayHandle: settings.userId || undefined,
@@ -59,6 +67,7 @@ function toConnectorAccount(settings: MatrixSettings): ConnectorAccount {
       deviceId: settings.deviceId ?? "",
       encryption: settings.encryption ?? false,
       autoJoin: settings.autoJoin ?? false,
+      personal,
     },
   };
 }
@@ -82,7 +91,7 @@ export function createMatrixConnectorAccountProvider(
       return {
         ...input,
         provider: MATRIX_PROVIDER_ID,
-        role: input.role ?? "OWNER",
+        role: input.role ?? "AGENT",
         purpose: input.purpose ?? ["messaging"],
         accessGate: input.accessGate ?? "open",
         status: input.status ?? "pending",

--- a/plugins/plugin-matrix/src/fake-indexeddb-auto.d.ts
+++ b/plugins/plugin-matrix/src/fake-indexeddb-auto.d.ts
@@ -1,0 +1,6 @@
+// fake-indexeddb's package.json maps the "./auto" subpath without a `types`
+// field, so under bundler module resolution TypeScript can't locate its bundled
+// declaration. service.ts imports it only for its side effect (it installs the
+// global IndexedDB constructors so the rust-crypto store can persist under
+// Node/Bun), so a bare ambient declaration is all that's needed.
+declare module "fake-indexeddb/auto";

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -4,10 +4,20 @@
  * This service provides Matrix messaging capabilities using matrix-js-sdk.
  */
 
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { deserialize as v8Deserialize, serialize as v8Serialize } from "node:v8";
 import {
+  ChannelType,
   type Content,
+  createUniqueUuid,
   type EventPayload,
+  type HandlerCallback,
   type IAgentRuntime,
+  lifeOpsPassiveConnectorsEnabled,
   logger,
   type Memory,
   type MessageConnectorChatContext,
@@ -18,6 +28,16 @@ import {
 } from "@elizaos/core";
 import * as sdk from "matrix-js-sdk";
 import type { RoomMessageEventContent } from "matrix-js-sdk/lib/@types/events";
+import {
+  CryptoEvent,
+  canAcceptVerificationRequest,
+  type ShowSasCallbacks,
+  VerificationPhase,
+  type VerificationRequest,
+  VerificationRequestEvent,
+  type Verifier,
+  VerifierEvent,
+} from "matrix-js-sdk/lib/crypto-api";
 import {
   DEFAULT_MATRIX_ACCOUNT_ID,
   listMatrixAccountIds,
@@ -158,13 +178,310 @@ type MatrixAccountState = {
   client: sdk.MatrixClient;
   connected: boolean;
   syncing: boolean;
+  cryptoSnapshotTimer?: ReturnType<typeof setInterval>;
 };
+
+/**
+ * Serialized form of an IndexedDB database: object-store schemas plus their
+ * records. v8.serialize handles the structured-clone values (typed arrays,
+ * Maps, etc.) the rust-crypto store writes, so this shape round-trips losslessly.
+ */
+export type CryptoStoreSnapshot = {
+  version: number;
+  stores: Record<
+    string,
+    {
+      schema: {
+        keyPath: IDBObjectStore["keyPath"];
+        autoIncrement: boolean;
+        indexes: {
+          name: string;
+          keyPath: IDBIndex["keyPath"];
+          unique: boolean;
+          multiEntry: boolean;
+        }[];
+      };
+      records: { key: IDBValidKey; value: unknown }[];
+    }
+  >;
+};
+
+// The matrix-js-sdk rust-crypto backend persists its entire state — device
+// identity, cross-signing, and inbound megolm sessions — in an IndexedDB
+// database named `${prefix}::matrix-sdk-crypto` when initRustCrypto({
+// useIndexedDB: true }) is used. With multiple encrypted accounts in one
+// process the prefix MUST differ per account or they collide on one store; the
+// default account keeps the SDK's default prefix so its existing persisted
+// device is unaffected.
+const DEFAULT_CRYPTO_DB_PREFIX = "matrix-js-sdk";
+
+function cryptoDbPrefix(accountId: string): string {
+  if (!accountId || accountId === DEFAULT_MATRIX_ACCOUNT_ID) {
+    return DEFAULT_CRYPTO_DB_PREFIX;
+  }
+  const safeId = accountId.replace(/[^a-zA-Z0-9._-]/g, "_") || "account";
+  return `${DEFAULT_CRYPTO_DB_PREFIX}-${safeId}`;
+}
+
+function cryptoDbName(accountId: string): string {
+  return `${cryptoDbPrefix(accountId)}::matrix-sdk-crypto`;
+}
+
+const CRYPTO_SNAPSHOT_INTERVAL_MS = 60 * 1000;
+// Grace period before the bot starts SAS itself, letting the initiator's start
+// win the race so the two sides don't compute the SAS over different events.
+const VERIFICATION_START_FALLBACK_MS = 4000;
+const ROOM_KEY_SCRYPT_SALT = "matrix.roomKeys.v1";
+const ROOM_KEY_BYTES = 32;
+const ROOM_KEY_NONCE_BYTES = 12;
+
+/**
+ * Resolve the per-user state root the runtime already uses for on-disk state.
+ * Matches the MILADY_STATE_DIR / ELIZA_STATE_DIR convention so the encrypted
+ * room-key files land next to the rest of the agent's persistent state.
+ */
+function resolveStateDir(): string {
+  return (
+    process.env.MILADY_STATE_DIR ||
+    process.env.ELIZA_STATE_DIR ||
+    join(homedir(), ".local/state/milady")
+  );
+}
+
+/**
+ * Derive the encrypted crypto-store file path for an account. The account id is
+ * sanitized so an arbitrary configured id can never escape the keys directory.
+ * The file holds the full serialized rust-crypto IndexedDB snapshot (device
+ * identity, cross-signing, and inbound megolm sessions), not just room keys.
+ */
+function cryptoStoreFilePath(accountId: string): string {
+  const safeId = accountId.replace(/[^a-zA-Z0-9._-]/g, "_") || "default";
+  return join(resolveStateDir(), "matrix-keys", `${safeId}.enc`);
+}
+
+/**
+ * AES-256-GCM envelope matching the vault wire format
+ * (`v1:<nonce_b64>:<tag_b64>:<ct_b64>`). The key is derived per-account from the
+ * access token via scrypt, so the at-rest file never contains usable crypto
+ * state without the live token. Operates on Buffers: the crypto-store snapshot
+ * is a v8-serialized binary blob, so there is no intermediate string form.
+ */
+function encryptCryptoStore(accessToken: string, plaintext: Buffer): string {
+  const key = scryptSync(accessToken, ROOM_KEY_SCRYPT_SALT, ROOM_KEY_BYTES);
+  const nonce = randomBytes(ROOM_KEY_NONCE_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `v1:${nonce.toString("base64")}:${tag.toString("base64")}:${ct.toString("base64")}`;
+}
+
+function decryptCryptoStore(accessToken: string, ciphertext: string): Buffer {
+  const parts = ciphertext.split(":");
+  if (parts.length !== 4 || parts[0] !== "v1") {
+    throw new Error("malformed crypto-store ciphertext");
+  }
+  const key = scryptSync(accessToken, ROOM_KEY_SCRYPT_SALT, ROOM_KEY_BYTES);
+  const nonce = Buffer.from(parts[1], "base64");
+  const tag = Buffer.from(parts[2], "base64");
+  const ct = Buffer.from(parts[3], "base64");
+  const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]);
+}
+
+/**
+ * Open an IndexedDB database. With a version + upgrade callback this triggers a
+ * schema upgrade; without, it opens at the current version. Resolves the
+ * IDBDatabase or rejects with the request error.
+ */
+function openIndexedDb(
+  name: string,
+  version?: number,
+  upgrade?: (db: IDBDatabase) => void
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = version ? indexedDB.open(name, version) : indexedDB.open(name);
+    if (upgrade) {
+      request.onupgradeneeded = (event) => upgrade((event.target as IDBOpenDBRequest).result);
+    }
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function transactionDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+/**
+ * Read every object store of an IndexedDB database into a serializable snapshot:
+ * each store's schema (keyPath, autoIncrement, indexes) plus all of its records.
+ * Pure over the global `indexedDB`, so it is unit-testable with fake-indexeddb.
+ */
+export async function snapshotDb(name: string): Promise<CryptoStoreSnapshot> {
+  const db = await openIndexedDb(name);
+  const snapshot: CryptoStoreSnapshot = { version: db.version, stores: {} };
+  for (const storeName of [...db.objectStoreNames]) {
+    const store = db.transaction(storeName, "readonly").objectStore(storeName);
+    const records: { key: IDBValidKey; value: unknown }[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const cursorRequest = store.openCursor();
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (cursor) {
+          records.push({ key: cursor.primaryKey, value: cursor.value });
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+      cursorRequest.onerror = () => reject(cursorRequest.error);
+    });
+    snapshot.stores[storeName] = {
+      schema: {
+        keyPath: store.keyPath,
+        autoIncrement: store.autoIncrement,
+        indexes: [...store.indexNames].map((indexName) => {
+          const index = store.index(indexName);
+          return {
+            name: indexName,
+            keyPath: index.keyPath,
+            unique: index.unique,
+            multiEntry: index.multiEntry,
+          };
+        }),
+      },
+      records,
+    };
+  }
+  db.close();
+  return snapshot;
+}
+
+/**
+ * Recreate an IndexedDB database from a snapshot: delete any existing db, build
+ * the stores + indexes in an upgrade transaction, then replay the records.
+ * Keyless stores re-supply the out-of-line key; keyPath stores derive it.
+ * Pure over the global `indexedDB`, so it is unit-testable with fake-indexeddb.
+ */
+export async function restoreDb(name: string, snapshot: CryptoStoreSnapshot): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+  const db = await openIndexedDb(name, snapshot.version, (upgradeDb) => {
+    for (const [storeName, { schema }] of Object.entries(snapshot.stores)) {
+      const store = upgradeDb.createObjectStore(storeName, {
+        keyPath: schema.keyPath ?? undefined,
+        autoIncrement: schema.autoIncrement,
+      });
+      for (const index of schema.indexes) {
+        store.createIndex(index.name, index.keyPath, {
+          unique: index.unique,
+          multiEntry: index.multiEntry,
+        });
+      }
+    }
+  });
+  for (const [storeName, { schema, records }] of Object.entries(snapshot.stores)) {
+    const tx = db.transaction(storeName, "readwrite");
+    const store = tx.objectStore(storeName);
+    for (const { key, value } of records) {
+      if (schema.keyPath) {
+        store.put(value);
+      } else {
+        store.put(value, key);
+      }
+    }
+    await transactionDone(tx);
+  }
+  db.close();
+}
 
 function normalizeConnectorLimit(limit: number | undefined, fallback = 50): number {
   if (!Number.isFinite(limit) || !limit || limit <= 0) {
     return fallback;
   }
   return Math.min(Math.floor(limit), 200);
+}
+
+/**
+ * Map a raw Matrix timeline event to a MatrixMessage. Returns null for events
+ * we don't surface as chat: non-text msgtypes, non-string bodies, and events
+ * without a room id (this also naturally skips state events and still-encrypted
+ * events whose type stays "m.room.encrypted").
+ */
+function buildMatrixMessage(event: sdk.MatrixEvent, room: sdk.Room): MatrixMessage | null {
+  const content = event.getContent();
+  const msgType = content.msgtype;
+  if (msgType !== "m.text") return null;
+  if (typeof content.body !== "string") return null;
+
+  const roomId = event.getRoomId();
+  if (!roomId) return null;
+
+  const sender = event.getSender();
+  const senderMember = room.getMember(sender || "");
+
+  const senderInfo: MatrixUserInfo = {
+    userId: sender || "",
+    displayName: senderMember?.name,
+    avatarUrl: senderMember?.getMxcAvatarUrl() || undefined,
+  };
+
+  const relatesTo = content["m.relates_to"];
+  const isEdit = relatesTo?.rel_type === "m.replace";
+  const threadId = relatesTo?.rel_type === "m.thread" ? relatesTo.event_id : undefined;
+  const replyTo = relatesTo?.["m.in_reply_to"]?.event_id;
+
+  return {
+    eventId: event.getId() || "",
+    roomId,
+    sender: sender || "",
+    senderInfo,
+    content: content.body,
+    msgType,
+    formattedBody: typeof content.formatted_body === "string" ? content.formatted_body : undefined,
+    timestamp: event.getTs(),
+    threadId,
+    replyTo,
+    isEdit,
+    replacesEventId: isEdit ? relatesTo?.event_id : undefined,
+  };
+}
+
+/**
+ * Build a core Memory from a MatrixMessage, deriving deterministic ids the same
+ * way the inbound dispatch path does so reads and the live message loop agree.
+ */
+function matrixMessageToMemory(
+  runtime: IAgentRuntime,
+  message: Pick<
+    MatrixMessage,
+    "roomId" | "eventId" | "timestamp" | "sender" | "content" | "replyTo"
+  >,
+  channelType: ChannelType
+): Memory {
+  const roomId = message.roomId;
+  return {
+    id: createUniqueUuid(runtime, message.eventId || `${roomId}:${message.timestamp}`),
+    entityId: createUniqueUuid(runtime, message.sender || roomId),
+    agentId: runtime.agentId,
+    roomId: createUniqueUuid(runtime, message.roomId),
+    content: {
+      text: message.content,
+      source: MATRIX_SERVICE_NAME,
+      channelType,
+      ...(message.replyTo ? { inReplyTo: createUniqueUuid(runtime, message.replyTo) } : {}),
+    },
+    createdAt: message.timestamp,
+  };
 }
 
 async function readStoredMessageMemories(
@@ -181,21 +498,65 @@ async function readStoredMessageMemories(
   });
 }
 
-async function readStoredMessagesForTargets(
+/**
+ * Resolve the raw Matrix room id (e.g. "!abc:server") for a connector target.
+ * The canonical `read_channel "<room>"` path sets the room only in
+ * `target.channelId`; older resolved targets may instead carry the core room
+ * UUID in `target.roomId`, from which the raw id is recoverable via getRoom().
+ */
+async function resolveMatrixRoomId(
   runtime: IAgentRuntime,
-  targets: MessageConnectorTarget[],
+  target: TargetInfo | undefined
+): Promise<string> {
+  return String(
+    target?.channelId ??
+      (target?.roomId ? (await runtime.getRoom(target.roomId))?.channelId : "") ??
+      ""
+  ).trim();
+}
+
+/**
+ * Read recent messages across the account's joined rooms, newest-first. Uses
+ * the live SDK timeline (and encrypted placeholders) per room — the same source
+ * as the single-room branch — so the multi-room/recent case stays consistent.
+ */
+async function readJoinedRoomMessages(
+  service: MatrixService,
+  accountId: string,
   limit: number
 ): Promise<Memory[]> {
-  const roomIds = Array.from(
-    new Set(targets.map((target) => target.target.roomId).filter((id): id is UUID => Boolean(id)))
-  );
+  const rooms = (await service.getJoinedRooms(accountId)).slice(0, 10);
   const chunks = await Promise.all(
-    roomIds.map((roomId) => readStoredMessageMemories(runtime, roomId, limit))
+    rooms.map((room) => service.getRoomMessages(room.roomId, limit, accountId))
   );
   return chunks
     .flat()
     .sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0))
     .slice(0, limit);
+}
+
+/**
+ * Read up to `limit` messages for a connector target: resolve the target to a
+ * Matrix room and read its live timeline (falling back to stored memories when
+ * the live read is empty), or read across all joined rooms when the target names
+ * no specific room. Shared by the fetchMessages and searchMessages hooks.
+ */
+async function readMessagesForTarget(
+  service: MatrixService,
+  runtime: IAgentRuntime,
+  accountId: string,
+  target: TargetInfo | undefined,
+  limit: number
+): Promise<Memory[]> {
+  const matrixRoomId = await resolveMatrixRoomId(runtime, target);
+  if (!matrixRoomId) {
+    return readJoinedRoomMessages(service, accountId, limit);
+  }
+  const live = await service.getRoomMessages(matrixRoomId, limit, accountId);
+  if (live.length > 0) {
+    return live;
+  }
+  return readStoredMessageMemories(runtime, createUniqueUuid(runtime, matrixRoomId), limit);
 }
 
 function filterMemoriesByQuery(memories: Memory[], query: string, limit: number): Memory[] {
@@ -314,26 +675,19 @@ export class MatrixService extends Service implements IMatrixService {
         fetchMessages: async (context, params) => {
           const limit = normalizeConnectorLimit(params?.limit);
           const target = params?.target ?? context.target;
-          if (target?.roomId) {
-            return readStoredMessageMemories(context.runtime, target.roomId, limit);
-          }
-          const targets = (await service.getJoinedRooms(accountId))
-            .slice(0, 10)
-            .map((room) => matrixRoomToConnectorTarget(room, 0.5, accountId));
-          return readStoredMessagesForTargets(context.runtime, targets, limit);
+          return readMessagesForTarget(service, context.runtime, accountId, target, limit);
         },
         searchMessages: async (context, params) => {
           const limit = normalizeConnectorLimit(params?.limit);
           const target = params?.target ?? context.target;
-          const messages = target?.roomId
-            ? await readStoredMessageMemories(context.runtime, target.roomId, Math.max(limit, 100))
-            : await readStoredMessagesForTargets(
-                context.runtime,
-                (await service.getJoinedRooms(accountId))
-                  .slice(0, 10)
-                  .map((room) => matrixRoomToConnectorTarget(room, 0.5, accountId)),
-                Math.max(limit, 100)
-              );
+          // Scan wider than the requested limit so the query filter has candidates.
+          const messages = await readMessagesForTarget(
+            service,
+            context.runtime,
+            accountId,
+            target,
+            Math.max(limit, 100)
+          );
           return filterMemoriesByQuery(messages, params.query, limit);
         },
         reactHandler: async (handlerRuntime, params) => {
@@ -454,12 +808,15 @@ export class MatrixService extends Service implements IMatrixService {
           userId: settings.userId,
           accessToken: settings.accessToken,
           deviceId: settings.deviceId,
+          verificationMethods: ["m.sas.v1"],
         }),
         connected: false,
         syncing: false,
       };
 
       this.states.set(state.accountId, state);
+      await this.initCrypto(state);
+      this.startCryptoSnapshot(state);
       this.setupEventHandlers(state);
       await this.connect(state);
       MatrixService.registerSendHandlers(runtime, this, state.accountId);
@@ -498,6 +855,223 @@ export class MatrixService extends Service implements IMatrixService {
   }
 
   /**
+   * Initialize end-to-end encryption for an account when MATRIX_ENCRYPTION is
+   * enabled. Most homeservers (including Continuwuity) encrypt rooms by
+   * default, so without crypto the client can neither decrypt inbound nor
+   * encrypt outbound messages — it would silently drop everything.
+   *
+   * The rust-crypto store persists in IndexedDB. This runtime (Bun/Node) has no
+   * native IndexedDB, so `fake-indexeddb/auto` installs a global one and the
+   * whole crypto state — device identity, cross-signing, and inbound megolm
+   * sessions — is snapshotted to an encrypted file via saveCryptoStore and
+   * restored before init via restoreCryptoStore. A stable device keeps the
+   * curve25519/ed25519 identity across restarts, so senders treat it as the
+   * same trusted device and keep sharing room keys (including forwarded history
+   * keys at join), which is what makes history decryptable.
+   *
+   * Non-fatal by construction: if anything in the persistence path fails we fall
+   * back to an in-memory store so the Matrix connection still comes up. Never
+   * throws.
+   */
+  private async initCrypto(state: MatrixAccountState): Promise<void> {
+    if (!state.settings.encryption) {
+      return;
+    }
+    if (typeof state.client.initRustCrypto !== "function") {
+      logger.warn(
+        "Matrix encryption requested but initRustCrypto is unavailable in this matrix-js-sdk build; messages in encrypted rooms will be unreadable."
+      );
+      return;
+    }
+    let cryptoUp = false;
+    try {
+      await import("fake-indexeddb/auto");
+      await this.restoreCryptoStore(state);
+      await state.client.initRustCrypto({
+        useIndexedDB: true,
+        cryptoDatabasePrefix: cryptoDbPrefix(state.accountId),
+      });
+      logger.info(
+        `Matrix E2EE initialized (persistent rust-crypto via IndexedDB) for ${state.settings.userId}`
+      );
+      cryptoUp = true;
+    } catch (err) {
+      logger.warn(
+        `Matrix persistent crypto init failed (${err instanceof Error ? err.message : String(err)}); falling back to in-memory crypto (device will re-key on restart).`
+      );
+    }
+    if (!cryptoUp) {
+      try {
+        await state.client.initRustCrypto({ useIndexedDB: false });
+        logger.info(`Matrix E2EE initialized (in-memory rust-crypto) for ${state.settings.userId}`);
+        cryptoUp = true;
+      } catch (err) {
+        logger.warn(
+          `Matrix encryption failed to initialize (${err instanceof Error ? err.message : String(err)}); encrypted rooms will be unreadable, but the Matrix connection will continue.`
+        );
+      }
+    }
+    // Cross-signing makes strict senders share keys; it must run regardless of
+    // which crypto backend came up, so do it once here after either path.
+    if (cryptoUp) {
+      await this.ensureCrossSigning(state);
+    }
+  }
+
+  /**
+   * Self-cross-sign this device so cohort senders running "exclude insecure
+   * devices" (MSC4153) share megolm room keys to it — the thing that makes
+   * encrypted cohort messages decryptable. The device otherwise carries an empty
+   * cross-signing identity and is structurally skipped by those senders.
+   *
+   * Works with only an access token: MSC3967 (implemented by the homeserver) lets
+   * the FIRST device-signing-key upload through with no UIA, so we send auth=null
+   * and soft-fail (log, never throw) if the server still demands a password we
+   * don't have. Idempotent + non-fatal: the signing keys persist in the
+   * snapshotted rust store, so isCrossSigningReady() short-circuits this on every
+   * later boot, and any failure leaves the Matrix connection untouched.
+   */
+  private async ensureCrossSigning(state: MatrixAccountState): Promise<void> {
+    const crypto =
+      typeof state.client.getCrypto === "function" ? state.client.getCrypto() : undefined;
+    if (!crypto) {
+      return;
+    }
+    try {
+      // Never be the side that withholds: encrypt to unverified cohort devices
+      // and trust owner-cross-signed devices (both SDK defaults, set explicitly
+      // so a future default change can't silently gate us).
+      crypto.globalBlacklistUnverifiedDevices = false;
+      crypto.setTrustCrossSignedDevices(true);
+
+      if (await crypto.isCrossSigningReady()) {
+        return;
+      }
+
+      await crypto.bootstrapCrossSigning({
+        authUploadDeviceSigningKeys: async (makeRequest) => {
+          // First try the no-auth upload (MSC3967). Homeservers that don't
+          // implement it answer 401 with a UIA challenge; satisfy m.login.password
+          // with the challenge session when MATRIX_PASSWORD is configured,
+          // otherwise soft-fail so the connection is unaffected.
+          try {
+            return await makeRequest(null);
+          } catch (err) {
+            const data = (err as { data?: { session?: string; flows?: unknown } })?.data;
+            if (!data?.flows) {
+              throw err;
+            }
+            if (!state.settings.password || !data.session) {
+              logger.warn(
+                `Matrix cross-signing upload for ${state.settings.userId} needs password UIA but ${state.settings.password ? "the server returned no challenge session" : "no MATRIX_PASSWORD is set"}; device ${state.settings.deviceId ?? "?"} stays uncross-signed, so exclude-insecure-devices senders will withhold keys.`
+              );
+              throw err;
+            }
+            return await makeRequest({
+              type: "m.login.password",
+              identifier: { type: "m.id.user", user: state.settings.userId },
+              password: state.settings.password,
+              session: data.session,
+            });
+          }
+        },
+      });
+      logger.info(
+        `Matrix cross-signing bootstrapped for ${state.settings.userId}; senders should now share megolm keys to this device.`
+      );
+      await crypto.checkKeyBackupAndEnable().catch(() => {});
+    } catch (err) {
+      logger.warn(
+        `Matrix cross-signing bootstrap skipped (${err instanceof Error ? err.message : String(err)}); cohort senders in exclude-insecure-devices mode may withhold keys until this device is verified once from an operator's Matrix client.`
+      );
+    }
+  }
+
+  /**
+   * Restore the persisted rust-crypto IndexedDB store from the encrypted at-rest
+   * file into the live (fake-indexeddb) global, replacing whatever is there.
+   * Must run BEFORE initRustCrypto so the store is populated when the crypto
+   * stack opens it.
+   *
+   * Strictly additive and non-fatal: any failure (missing file, corrupt data,
+   * token rotation making decrypt impossible) only warns and returns, leaving an
+   * empty store so the device starts fresh.
+   */
+  private async restoreCryptoStore(state: MatrixAccountState): Promise<void> {
+    try {
+      const filePath = cryptoStoreFilePath(state.accountId);
+      if (!existsSync(filePath)) {
+        return;
+      }
+      const ciphertext = await readFile(filePath, "utf8");
+      let snapshot: CryptoStoreSnapshot;
+      try {
+        snapshot = v8Deserialize(decryptCryptoStore(state.settings.accessToken, ciphertext));
+      } catch {
+        // Corrupt file or rotated token — start fresh rather than blocking init.
+        logger.warn(
+          `Matrix crypto-store restore skipped for ${state.accountId}: stored state could not be decrypted (token may have rotated).`
+        );
+        return;
+      }
+      await restoreDb(cryptoDbName(state.accountId), snapshot);
+      logger.info(`Matrix restored persisted crypto store for ${state.accountId}`);
+    } catch (err) {
+      logger.warn(
+        `Matrix crypto-store restore failed for ${state.accountId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
+   * Snapshot the live rust-crypto IndexedDB store and persist it, encrypted at
+   * rest, so the device identity and room keys survive a process restart. The
+   * snapshot contains PRIVATE device keys, so it is written 0600 and encrypted
+   * under a token-derived key. Atomic (tmp + rename) so a crash mid-write can
+   * never truncate the live file. Strictly additive and non-fatal: failures only
+   * warn and never affect the Matrix connection.
+   */
+  private async saveCryptoStore(state: MatrixAccountState): Promise<void> {
+    // No global IndexedDB means initCrypto fell back to the in-memory store
+    // (nothing to snapshot). Skip silently rather than warn every tick.
+    if (typeof indexedDB === "undefined") {
+      return;
+    }
+    try {
+      const snapshot = await snapshotDb(cryptoDbName(state.accountId));
+      const ciphertext = encryptCryptoStore(state.settings.accessToken, v8Serialize(snapshot));
+      const filePath = cryptoStoreFilePath(state.accountId);
+      const tmpPath = `${filePath}.${randomBytes(6).toString("hex")}.tmp`;
+      await mkdir(join(resolveStateDir(), "matrix-keys"), { recursive: true, mode: 0o700 });
+      await writeFile(tmpPath, ciphertext, { mode: 0o600 });
+      // mode on writeFile only applies on create; chmod enforces 0o600 even when
+      // an existing temp name somehow had looser permissions.
+      await chmod(tmpPath, 0o600);
+      await rename(tmpPath, filePath);
+    } catch (err) {
+      logger.warn(
+        `Matrix crypto-store save failed for ${state.accountId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
+   * Start the periodic crypto-store snapshot for an account. The interval is
+   * unref'd so it never keeps the process alive on its own, and its handle is
+   * stored on the account state so stop() can clear it.
+   */
+  private startCryptoSnapshot(state: MatrixAccountState): void {
+    if (!state.settings.encryption) {
+      return;
+    }
+    const timer = setInterval(() => {
+      void this.saveCryptoStore(state);
+    }, CRYPTO_SNAPSHOT_INTERVAL_MS);
+    timer.unref?.();
+    state.cryptoSnapshotTimer = timer;
+  }
+
+  /**
    * Set up event handlers for the Matrix client.
    */
   private setupEventHandlers(state: MatrixAccountState): void {
@@ -516,9 +1090,25 @@ export class MatrixService extends Service implements IMatrixService {
     // Room timeline events (messages)
     state.client.on(sdk.RoomEvent.Timeline, (event, room, toStartOfTimeline) => {
       if (toStartOfTimeline) return;
-      if (event.getType() !== "m.room.message") return;
       if (event.getSender() === state.settings.userId) return;
 
+      // In E2EE rooms the event surfaces as m.room.encrypted until the crypto
+      // stack decrypts it. If decryption is still pending, wait for the
+      // Decrypted event before dispatching; otherwise dispatch immediately.
+      if (event.isEncrypted() && event.getType() === "m.room.encrypted") {
+        event.once(sdk.MatrixEventEvent.Decrypted, () => {
+          if (event.getType() === "m.room.message") {
+            this.handleRoomMessage(state, event, room);
+          } else if (event.isDecryptionFailure()) {
+            logger.warn(
+              `Matrix could not decrypt event ${event.getId()} in ${event.getRoomId()} — the sender has not shared the megolm key with this device yet.`
+            );
+          }
+        });
+        return;
+      }
+
+      if (event.getType() !== "m.room.message") return;
       this.handleRoomMessage(state, event, room);
     });
 
@@ -536,6 +1126,102 @@ export class MatrixService extends Service implements IMatrixService {
         }
       }
     });
+
+    this.setupVerificationAutoAccept(state);
+  }
+
+  /**
+   * Let allow-listed users verify this device via SAS (emoji) verification from
+   * their own Matrix client. On homeservers where the bot can't self-cross-sign
+   * (no MSC3967 + no password), this is how senders come to trust the device and
+   * start sharing megolm keys to it — and the verifying user's client also
+   * gossips the room keys it already holds, backfilling history.
+   *
+   * Fail-closed: with no MATRIX_VERIFY_ALLOWLIST nothing is accepted, so this is
+   * inert unless explicitly configured. The verified trust persists in the
+   * snapshotted crypto store, so it is a one-time action per user.
+   */
+  private setupVerificationAutoAccept(state: MatrixAccountState): void {
+    const crypto = state.client.getCrypto();
+    if (!crypto || state.settings.verifyAllowlist.length === 0) {
+      return;
+    }
+    state.client.on(CryptoEvent.VerificationRequestReceived, (request) => {
+      void this.handleVerificationRequest(state, request);
+    });
+  }
+
+  private async handleVerificationRequest(
+    state: MatrixAccountState,
+    request: VerificationRequest
+  ): Promise<void> {
+    const other = request.otherUserId;
+    if (!state.settings.verifyAllowlist.includes(other)) {
+      logger.warn(`Matrix rejecting verification request from non-allowlisted ${other}`);
+      await request.cancel().catch(() => {});
+      return;
+    }
+    logger.info(`Matrix auto-accepting SAS verification from ${other}`);
+    try {
+      if (canAcceptVerificationRequest(request)) {
+        await request.accept();
+      }
+      const verifier = request.verifier ?? (await this.awaitVerifier(request));
+      if (!verifier) {
+        await request.cancel().catch(() => {});
+        return;
+      }
+      verifier.on(VerifierEvent.ShowSas, (callbacks: ShowSasCallbacks) => {
+        logger.info(`Matrix auto-confirming SAS with ${other}`);
+        void callbacks.confirm().catch(() => {});
+      });
+      await verifier.verify();
+      logger.info(
+        `Matrix device verification with ${other} complete; megolm keys should now flow.`
+      );
+    } catch (err) {
+      logger.warn(
+        `Matrix verification with ${other} failed or was cancelled (${err instanceof Error ? err.message : String(err)}).`
+      );
+    }
+  }
+
+  /**
+   * Wait for the verifier to materialize. The bot is a pure responder: the
+   * initiator (e.g. Element) sends the m.key.verification.start, which creates
+   * the verifier on our side. We only start SAS ourselves as a fallback, after a
+   * short grace period, for the rare initiator that waits for the responder to
+   * start — starting eagerly would race the initiator's start ("glare") and the
+   * two sides would compute the SAS over different start events, failing the
+   * match. Resolves undefined if the request is cancelled or completes first.
+   */
+  private awaitVerifier(request: VerificationRequest): Promise<Verifier | undefined> {
+    return new Promise((resolve) => {
+      let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (value: Verifier | undefined) => {
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        request.off(VerificationRequestEvent.Change, onChange);
+        resolve(value);
+      };
+      const onChange = () => {
+        if (request.verifier) {
+          settle(request.verifier);
+        } else if (
+          request.phase === VerificationPhase.Cancelled ||
+          request.phase === VerificationPhase.Done
+        ) {
+          settle(undefined);
+        } else if (request.phase === VerificationPhase.Ready && !fallbackTimer) {
+          fallbackTimer = setTimeout(() => {
+            if (!request.verifier) {
+              request.startVerification("m.sas.v1").then(settle, () => settle(undefined));
+            }
+          }, VERIFICATION_START_FALLBACK_MS);
+        }
+      };
+      request.on(VerificationRequestEvent.Change, onChange);
+      onChange();
+    });
   }
 
   /**
@@ -546,55 +1232,24 @@ export class MatrixService extends Service implements IMatrixService {
     event: sdk.MatrixEvent,
     room: sdk.Room | undefined
   ): void {
-    const content = event.getContent();
-    const msgType = content.msgtype;
+    if (!room) return;
 
-    // Only handle text messages for now
-    if (msgType !== "m.text") return;
-    if (typeof content.body !== "string") return;
+    const message = buildMatrixMessage(event, room);
+    if (!message) return;
 
-    const roomId = event.getRoomId();
-    if (!roomId || !room) return;
+    const roomId = message.roomId;
 
-    // Check mention requirement
-    if (state.settings.requireMention) {
+    // Check mention requirement. Skipped in 1:1 DMs: a direct message is
+    // inherently addressed to the bot, so requiring an @mention there would
+    // make it ignore the user. Group rooms still honor the gate.
+    const isDirectRoom = room.getJoinedMemberCount() <= 2;
+    if (state.settings.requireMention && !isDirectRoom) {
       const localpart = getMatrixLocalpart(state.settings.userId);
       const mentionPattern = new RegExp(`@?${escapeRegExp(localpart)}`, "i");
-      if (!mentionPattern.test(content.body)) {
+      if (!mentionPattern.test(message.content)) {
         return;
       }
     }
-
-    const sender = event.getSender();
-    const senderMember = room.getMember(sender || "");
-
-    const senderInfo: MatrixUserInfo = {
-      userId: sender || "",
-      displayName: senderMember?.name,
-      avatarUrl: senderMember?.getMxcAvatarUrl() || undefined,
-    };
-
-    // Check for reply/thread
-    const relatesTo = content["m.relates_to"];
-    const isEdit = relatesTo?.rel_type === "m.replace";
-    const threadId = relatesTo?.rel_type === "m.thread" ? relatesTo.event_id : undefined;
-    const replyTo = relatesTo?.["m.in_reply_to"]?.event_id;
-
-    const message: MatrixMessage = {
-      eventId: event.getId() || "",
-      roomId,
-      sender: sender || "",
-      senderInfo,
-      content: content.body,
-      msgType,
-      formattedBody:
-        typeof content.formatted_body === "string" ? content.formatted_body : undefined,
-      timestamp: event.getTs(),
-      threadId,
-      replyTo,
-      isEdit,
-      replacesEventId: isEdit ? relatesTo?.event_id : undefined,
-    };
 
     const matrixRoom: MatrixRoom = {
       roomId,
@@ -606,20 +1261,136 @@ export class MatrixService extends Service implements IMatrixService {
         state.client
           .getAccountData(sdk.EventType.Direct)
           ?.getContent()
-          ?.[sender || ""]?.includes(roomId) || false,
+          ?.[message.sender || ""]?.includes(roomId) || false,
       memberCount: room.getJoinedMemberCount(),
     };
 
     logger.debug(
-      `Matrix message from ${senderInfo.displayName || sender} in ${room.name || roomId}: ${message.content.slice(0, 50)}...`
+      `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${message.content.slice(0, 50)}...`
     );
 
+    // Plugin-local event (kept for backward compatibility — other code may
+    // listen for the MatrixMessage/MatrixRoom payload).
     this.runtime.emitEvent(MatrixEventTypes.MESSAGE_RECEIVED, {
       message,
       room: matrixRoom,
       runtime: this.runtime,
       accountId: state.accountId,
     } as EventPayload);
+
+    // Drive the core message loop so the agent actually reads and replies.
+    void this.dispatchToAgent(state, message, matrixRoom).catch((err) =>
+      logger.error(
+        `Matrix dispatchToAgent failed: ${err instanceof Error ? err.message : String(err)}`
+      )
+    );
+  }
+
+  /**
+   * Feed an inbound Matrix message into the core message loop and wire a
+   * callback that posts the agent's reply back to the same room. Mirrors the
+   * connector pattern used by plugin-discord: emit EventType.MESSAGE_RECEIVED
+   * with a core Memory and a HandlerCallback. The bootstrap message handler
+   * runs the agent, decides whether to respond, and invokes the callback.
+   */
+  private async dispatchToAgent(
+    state: MatrixAccountState,
+    message: MatrixMessage,
+    room: MatrixRoom
+  ): Promise<void> {
+    const roomId = room.roomId;
+    const entityId = createUniqueUuid(this.runtime, message.sender || roomId);
+    const coreRoomId = createUniqueUuid(this.runtime, roomId);
+    const worldId = createUniqueUuid(this.runtime, roomId);
+    // Member count is the reliable DM signal (m.direct account data is often
+    // unset for a bot) and matches the mention-gate check in handleRoomMessage.
+    const channelType = room.memberCount <= 2 ? ChannelType.DM : ChannelType.GROUP;
+    const displayName = message.senderInfo.displayName || message.sender || "Matrix user";
+
+    await this.runtime.ensureConnection({
+      entityId,
+      roomId: coreRoomId,
+      roomName: room.name || roomId,
+      userName: displayName,
+      name: displayName,
+      source: MATRIX_SERVICE_NAME,
+      channelId: roomId,
+      type: channelType,
+      worldId,
+      worldName: room.name,
+      // Preserve the raw Matrix user id for role / allowlist checks.
+      userId: (message.sender || roomId) as UUID,
+      metadata: { accountId: state.accountId },
+    });
+
+    const coreMessage = matrixMessageToMemory(this.runtime, message, channelType);
+
+    // Auto-reply is gated (default off, matching plugin-discord/telegram) so the
+    // agent never speaks unprompted; passive LifeOps mode also suppresses it.
+    // When gated off, the inbound message is still persisted to memory.
+    const autoReplyRaw = this.runtime.getSetting("MATRIX_AUTO_REPLY");
+    const autoReply =
+      !lifeOpsPassiveConnectorsEnabled(this.runtime) &&
+      (autoReplyRaw === true || autoReplyRaw === "true");
+
+    if (!autoReply) {
+      try {
+        await this.runtime.createMemory(coreMessage, "messages");
+      } catch (err) {
+        logger.warn(
+          `Matrix inbound memory persist failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return;
+    }
+
+    if (!this.runtime.messageService) {
+      logger.error("Matrix: runtime.messageService is unavailable; cannot process inbound message");
+      return;
+    }
+
+    const callback: HandlerCallback = async (responseContent: Content) => {
+      const text = typeof responseContent.text === "string" ? responseContent.text.trim() : "";
+      if (!text) {
+        return [];
+      }
+      const result = await this.sendMessage(text, {
+        accountId: state.accountId,
+        roomId,
+        threadId: message.threadId,
+        replyTo: message.eventId,
+      });
+      if (!result.success) {
+        logger.warn(`Matrix reply send failed in ${roomId}: ${result.error}`);
+        return [];
+      }
+      const outbound: Memory = {
+        id: createUniqueUuid(this.runtime, result.eventId ?? `${roomId}:reply:${Date.now()}`),
+        entityId: this.runtime.agentId,
+        agentId: this.runtime.agentId,
+        roomId: coreRoomId,
+        content: {
+          text,
+          source: MATRIX_SERVICE_NAME,
+          channelType,
+          inReplyTo: coreMessage.id,
+        },
+        createdAt: Date.now(),
+      };
+      try {
+        await this.runtime.createMemory(outbound, "messages");
+      } catch (err) {
+        logger.warn(
+          `Matrix outbound memory persist failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return [outbound];
+    };
+
+    // Canonical dispatch: the core message loop runs through
+    // messageService.handleMessage (mirrors plugin-discord/telegram), not a
+    // bare EventType.MESSAGE_RECEIVED emit, which has no default handler.
+    await this.runtime.messageService.handleMessage(this.runtime, coreMessage, callback);
   }
 
   /**
@@ -655,6 +1426,17 @@ export class MatrixService extends Service implements IMatrixService {
    */
   async stop(): Promise<void> {
     for (const state of this.states.values()) {
+      if (state.cryptoSnapshotTimer) {
+        clearInterval(state.cryptoSnapshotTimer);
+        state.cryptoSnapshotTimer = undefined;
+      }
+      // Best-effort final flush so crypto state accumulated since the last tick
+      // survives the restart. Non-fatal: saveCryptoStore swallows its own
+      // failures. Guarded on encryption so a non-encrypted account doesn't
+      // touch the (possibly absent) IndexedDB global.
+      if (state.settings.encryption) {
+        await this.saveCryptoStore(state);
+      }
       state.client.stopClient();
       state.connected = false;
       state.syncing = false;
@@ -712,6 +1494,63 @@ export class MatrixService extends Service implements IMatrixService {
         isDirect: false,
         memberCount: room.getJoinedMemberCount(),
       }));
+  }
+
+  /**
+   * Read recent messages straight from the SDK's live room timeline (kept in
+   * sync by the RoomEvent.Timeline listener), newest-first. Unlike the agent's
+   * own memory DB, this surfaces room activity the agent never persisted —
+   * e.g. a busy room where the bot was never mentioned.
+   */
+  async getRoomMessages(
+    matrixRoomId: string,
+    limit: number,
+    accountId?: string
+  ): Promise<Memory[]> {
+    const state = this.getState(accountId);
+    const room = state.client.getRoom(matrixRoomId);
+    if (!room) {
+      return [];
+    }
+
+    const channelType = room.getJoinedMemberCount() <= 2 ? ChannelType.DM : ChannelType.GROUP;
+    const events = room.getLiveTimeline().getEvents();
+    const out: Memory[] = [];
+    for (let i = events.length - 1; i >= 0 && out.length < limit; i -= 1) {
+      const event = events[i];
+      const message = buildMatrixMessage(event, room);
+      if (message) {
+        const memory = matrixMessageToMemory(this.runtime, message, channelType);
+        memory.content.name = message.senderInfo.displayName || message.sender;
+        out.push(memory);
+        continue;
+      }
+      // Faithfully surface an encrypted message the agent can't read, so the
+      // agent reports real encrypted activity (who/when) rather than treating the
+      // room as empty. Two shapes must both be caught: a still-undecrypted event
+      // keeps wire type "m.room.encrypted", but once decryption has FAILED the SDK
+      // flips getType() to "m.room.message" with a "m.bad.encrypted" body and only
+      // isDecryptionFailure() stays true — the original bug was checking type
+      // alone, so failed-decrypt events fell through and the room looked empty.
+      if (event.getType() === "m.room.encrypted" || event.isDecryptionFailure()) {
+        const sender = event.getSender() || "unknown";
+        const placeholder = matrixMessageToMemory(
+          this.runtime,
+          {
+            eventId: event.getId() || "",
+            roomId: matrixRoomId,
+            sender,
+            content:
+              "🔒 [end-to-end encrypted message this device can't read — its device isn't cross-signed, so senders withhold the decryption keys. This needs a one-time device verification (or the account password) to unblock; it is NOT a sync or pagination issue.]",
+            timestamp: event.getTs(),
+          },
+          channelType
+        );
+        placeholder.content.name = room.getMember(sender)?.name || sender;
+        out.push(placeholder);
+      }
+    }
+    return out;
   }
 
   async sendMessage(text: string, options?: MatrixMessageSendOptions): Promise<MatrixSendResult> {

--- a/plugins/plugin-matrix/src/types.ts
+++ b/plugins/plugin-matrix/src/types.ts
@@ -46,6 +46,13 @@ export interface MatrixSettings {
   userId: string;
   /** Access token for authentication */
   accessToken: string;
+  /**
+   * Account password — only used to satisfy user-interactive auth when
+   * self-cross-signing on homeservers that require it for the device-signing-key
+   * upload (i.e. no MSC3967). Absent ⇒ cross-signing is attempted token-only and
+   * skipped if the server demands a password.
+   */
+  password?: string;
   /** Device ID for this session */
   deviceId?: string;
   /** Rooms to auto-join */
@@ -56,6 +63,22 @@ export interface MatrixSettings {
   encryption: boolean;
   /** Require mention to respond in rooms */
   requireMention: boolean;
+  /**
+   * Matrix user IDs allowed to verify this device via SAS (emoji) verification.
+   * When one of them starts a verification from their own client, the bot auto-
+   * accepts and auto-confirms, so their client then shares megolm room keys to
+   * this now-trusted device. Fail-closed: empty ⇒ no verification is accepted.
+   */
+  verifyAllowlist: string[];
+  /**
+   * Whether this account is the HUMAN owner's personal account (acting as the
+   * user) rather than the agent's own identity. A personal account is exposed as
+   * an OWNER connector behind the owner_binding access gate (acting as the user
+   * requires a verified binding); the default account — the agent's own Matrix
+   * identity — is an AGENT connector with the open gate (acting as the bot is
+   * frictionless).
+   */
+  personal: boolean;
   /** Whether this configuration is enabled */
   enabled: boolean;
 }

--- a/plugins/plugin-matrix/tsconfig.json
+++ b/plugins/plugin-matrix/tsconfig.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["bun"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## What

Makes the Matrix connector work for **encrypted rooms across restarts** and for **multi-account / personal-agent** setups.

- **Persist the rust-crypto store across restarts.** matrix-js-sdk's crypto store is in-memory under Node/Bun (no IndexedDB), so the device re-keys every boot, is treated as a new untrusted device, and can't decrypt anything in E2EE rooms. This provides a Node IndexedDB via `fake-indexeddb`, snapshots the store with `node:v8`, encrypts it at rest (AES-256-GCM, atomic write), and restores it before `initRustCrypto` — with a per-account database prefix so multiple encrypted accounts don't collide. Any failure falls back to the previous in-memory path, so the connection is never blocked.
- **Self-cross-sign the device** so senders running "exclude insecure devices" (MSC4153) share megolm keys with it: token-only where the homeserver implements MSC3967, or via an optional `MATRIX_PASSWORD` UIA otherwise. Allow-listed SAS device verification (`MATRIX_VERIFY_ALLOWLIST`) as a no-password fallback.
- **Read undecryptable messages honestly.** Once decryption fails, matrix-js-sdk flips the event to type `m.room.message` with only `isDecryptionFailure()` true, so a type-only check made encrypted rooms read *empty*. They now surface a clear "device not cross-signed" placeholder instead of looking empty. Also reads the live room timeline in `fetchMessages`/`searchMessages`.
- **Derive connector role from a `personal` flag.** The agent's own identity is an `AGENT` account on the `open` gate; a personal account is an `OWNER` account on the `owner_binding` gate (acting as the user requires a verified binding).
- **Bridge public Matrix identifiers as plain settings, not redacted secrets.** Homeserver URL, user/room/device ids, the verify-allowlist, and behaviour flags are public — only the access token / password / accounts-JSON stay secret. (A public id placed in secrets gets blanked out of all output, e.g. a rendered room name.)

## Testing

- Unit tests added/updated: secret↔settings boundary, crypto-store snapshot round-trip, connector role derivation, crypto-init hardening (typecheck + build + tests green).
- Verified end-to-end on a Continuwuity homeserver: a cross-signed device decrypts a strict-isolation (`OnlySignedDevicesIsolationMode`) sender's message, and a non-cross-signed control does **not** — confirming cross-signing is the causal unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
