### PR TITLE
feat(voice): Her-style bidirectional voice — chat button + conversational onboarding

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -619,6 +619,9 @@ export function ContinuousChatOverlay({
     toggleRecording,
     startRecording,
     stopRecording,
+    handsFree,
+    toggleHandsFree,
+    setDictationSink,
     transcript,
     speaking,
     agentVoiceMuted,
@@ -897,7 +900,9 @@ export function ContinuousChatOverlay({
         pushToTalkTimerRef.current = null;
         pushToTalkActiveRef.current = true;
         setPushToTalkActive(true);
-        startRecording();
+        // Press-and-hold = dictation: the transcript fills the composer draft
+        // (no send, no spoken reply) so the user can edit before sending.
+        startRecording("dictate");
       }, 200);
     },
     [booting, clearPushToTalkTimer, hasDraft, recording, startRecording],
@@ -923,8 +928,10 @@ export function ContinuousChatOverlay({
       suppressMicClickRef.current = false;
       return;
     }
-    toggleRecording();
-  }, [toggleRecording]);
+    // Quick tap = hands-free conversation: the agent speaks its replies back and
+    // the mic re-opens after each one. Tap again to end.
+    toggleHandsFree();
+  }, [toggleHandsFree]);
 
   const hasThread = visibleMessages.length > 0;
 
@@ -1095,6 +1102,18 @@ export function ContinuousChatOverlay({
     setFreeH(null);
     setSheetOpen(true);
   }, [hasThread, sheetOpen]);
+
+  // Push-to-talk dictation drops its final transcript into the composer draft
+  // (no send): register the sink with the controller while this overlay is
+  // mounted, appending to whatever the user has already typed.
+  React.useEffect(() => {
+    setDictationSink((text) => {
+      setDraft((current) => (current ? `${current} ${text}` : text));
+      inputRef.current?.focus();
+      expand();
+    });
+    return () => setDictationSink(null);
+  }, [setDictationSink, expand]);
 
   // ── Slash commands ─────────────────────────────────────────────────────────
   // Inline command autocomplete: the menu derives from the draft + the loaded
@@ -1910,11 +1929,13 @@ export function ContinuousChatOverlay({
                       label={
                         pushToTalkActive
                           ? "release to send"
-                          : recording
-                            ? "stop listening"
-                            : "talk"
+                          : handsFree
+                            ? "end conversation"
+                            : recording
+                              ? "stop listening"
+                              : "talk"
                       }
-                      active={recording}
+                      active={recording || handsFree}
                       disabled={booting}
                       onClick={handleMicClick}
                       onPointerDown={beginPushToTalkPress}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -616,7 +616,6 @@ export function ContinuousChatOverlay({
     send,
     canSend,
     recording,
-    toggleRecording,
     startRecording,
     stopRecording,
     handsFree,

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -14,6 +14,9 @@ import { useHomeModelStatus } from "../local-inference/useHomeModelStatus";
 import type { ShellMessage, ShellPhase } from "./shell-state";
 import { useShellVoiceOutput } from "./useShellVoiceOutput";
 
+/** How a voice capture turn is consumed when it produces a final transcript. */
+export type CaptureIntent = "converse" | "dictate";
+
 export interface ShellController {
   phase: ShellPhase;
   messages: readonly ShellMessage[];
@@ -40,8 +43,10 @@ export interface ShellController {
   ) => void;
   /** Toggle continuous ("open voice") capture. Used by a quick tap on the mic. */
   toggleRecording: () => void;
-  /** Begin capture unconditionally. Used by push-to-talk press. */
-  startRecording: () => void;
+  /** Begin capture unconditionally. Used by push-to-talk press. `"dictate"`
+   *  routes the final transcript to the dictation sink (composer draft) and does
+   *  not send; `"converse"` (default) sends a VOICE_DM so the reply is spoken. */
+  startRecording: (intent?: CaptureIntent) => void;
   /** End capture unconditionally. Used by push-to-talk release. */
   stopRecording: () => void;
   /** True while the mic is muted (paused) but the voice session stays open. */
@@ -60,6 +65,14 @@ export interface ShellController {
   needsAudioUnlock: boolean;
   /** Resume audio output in response to a user gesture (enable sound). */
   unlockAudio: () => void;
+  /** True while the hands-free voice conversation loop is active — the mic
+   *  re-opens automatically after each spoken reply. Toggled by a tap on the mic. */
+  handsFree: boolean;
+  /** Toggle the hands-free conversation loop (mic ↔ spoken reply ↔ mic). */
+  toggleHandsFree: () => void;
+  /** Register where push-to-talk dictation drops its final transcript (the
+   *  overlay wires this to its composer draft). Pass null to clear. */
+  setDictationSink: (sink: ((text: string) => void) | null) => void;
   /** DEV-only: clear the conversation and start a fresh, greeted one. */
   clearConversation: () => void;
   /** Jump to Settings (where ProviderSwitcher lives) — used by the chat's
@@ -120,6 +133,21 @@ export function useShellController(): ShellController {
   // whether the agent's reply is spoken back — typed turns stay silent.
   const [lastTurnVoice, setLastTurnVoice] = React.useState(false);
   const captureRef = React.useRef<VoiceCaptureHandle | null>(null);
+  // Hands-free conversation loop (tap the mic): the mic re-opens after each
+  // spoken reply. A ref mirrors the state so the debounced re-listen timer reads
+  // the live value at fire time.
+  const [handsFree, setHandsFree] = React.useState(false);
+  const handsFreeRef = React.useRef(false);
+  handsFreeRef.current = handsFree;
+  // Push-to-talk dictation routes its final transcript here (the overlay wires
+  // this to its composer draft) instead of sending it.
+  const onDictatedTextRef = React.useRef<((text: string) => void) | null>(null);
+  const setDictationSink = React.useCallback(
+    (sink: ((text: string) => void) | null) => {
+      onDictatedTextRef.current = sink;
+    },
+    [],
+  );
 
   const messages = React.useMemo<ShellMessage[]>(() => {
     const source = Array.isArray(conversationMessages)
@@ -175,7 +203,8 @@ export function useShellController(): ShellController {
     setTranscript("");
   }, []);
 
-  const startCapture = React.useCallback(() => {
+  const startCapture = React.useCallback(
+    (intent: CaptureIntent = "converse") => {
     if (!ready) return;
     if (captureRef.current) return;
     // Read the user's VAD thresholds synchronously (local mirror of the
@@ -192,12 +221,18 @@ export function useShellController(): ShellController {
         }
         setTranscript("");
         if (text) {
-          send(text, {
-            channelType: "VOICE_DM",
-            metadata: {
-              voiceSource: segment.backend,
-            },
-          });
+          if (intent === "dictate") {
+            // Push-to-talk dictation: hand the text to the composer draft —
+            // don't send, and leave lastTurnVoice false so no reply is spoken.
+            onDictatedTextRef.current?.(text);
+          } else {
+            send(text, {
+              channelType: "VOICE_DM",
+              metadata: {
+                voiceSource: segment.backend,
+              },
+            });
+          }
         }
       },
       onStateChange: (state: VoiceCaptureState) => {
@@ -264,6 +299,7 @@ export function useShellController(): ShellController {
   const close = React.useCallback(() => {
     setIsOpen(false);
     setMuted(false);
+    setHandsFree(false);
     if (captureRef.current) stopCapture();
   }, [stopCapture]);
 
@@ -292,6 +328,51 @@ export function useShellController(): ShellController {
     uiLanguage,
     cloudConnected: elizaCloudVoiceProxyAvailable,
   });
+
+  // Tap-to-talk: toggle a hands-free conversation. Enabling unlocks audio (the
+  // tap is the gesture) and opens the mic in "converse" mode; disabling stops
+  // both the mic and any in-flight reply.
+  const toggleHandsFree = React.useCallback(() => {
+    setHandsFree((on) => {
+      const next = !on;
+      if (next) {
+        setIsOpen(true);
+        voiceOutput.unlockAudio();
+        startCapture("converse");
+      } else {
+        if (captureRef.current) stopCapture();
+        voiceOutput.stopSpeaking();
+      }
+      return next;
+    });
+  }, [startCapture, stopCapture, voiceOutput]);
+
+  // Hands-free loop: once a spoken reply finishes (and nothing is recording or
+  // mid-send), re-open the mic so the conversation continues without a tap. The
+  // 250ms debounce + live re-check via handsFreeRef guard against double-start.
+  React.useEffect(() => {
+    if (!handsFree || !ready) return;
+    if (recording || captureRef.current) return;
+    if (chatSending || voiceOutput.speaking) return;
+    const timer = window.setTimeout(() => {
+      if (
+        handsFreeRef.current &&
+        !captureRef.current &&
+        !chatSending &&
+        !voiceOutput.speaking
+      ) {
+        startCapture("converse");
+      }
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [
+    handsFree,
+    ready,
+    recording,
+    chatSending,
+    voiceOutput.speaking,
+    startCapture,
+  ]);
 
   const waveformMode =
     phase === "listening"
@@ -324,6 +405,9 @@ export function useShellController(): ShellController {
     toggleRecording,
     startRecording: startCapture,
     stopRecording: stopCapture,
+    handsFree,
+    toggleHandsFree,
+    setDictationSink,
     muted,
     toggleMute,
     transcript,

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -204,62 +204,64 @@ export function useShellController(): ShellController {
   }, []);
 
   const startCapture = React.useCallback(
-    (intent: CaptureIntent = "converse") => {
-    if (!ready) return;
-    if (captureRef.current) return;
-    // Read the user's VAD thresholds synchronously (local mirror of the
-    // `messages.voice` setting) so end-of-turn silence detection honors the
-    // configured sensitivity. Only consumed by the local-inference backend.
-    const handle = createVoiceCapture({
-      localAsrAutoStop: loadVadAutoStop(),
-      onTranscript: (segment) => {
-        const text = segment.text.trim();
-        if (!segment.final) {
-          // Surface the interim best-guess as live transcription.
-          setTranscript(text);
-          return;
-        }
-        setTranscript("");
-        if (text) {
-          if (intent === "dictate") {
-            // Push-to-talk dictation: hand the text to the composer draft —
-            // don't send, and leave lastTurnVoice false so no reply is spoken.
-            onDictatedTextRef.current?.(text);
-          } else {
-            send(text, {
-              channelType: "VOICE_DM",
-              metadata: {
-                voiceSource: segment.backend,
-              },
-            });
+    (intent?: CaptureIntent) => {
+      if (!ready) return;
+      if (captureRef.current) return;
+      // Read the user's VAD thresholds synchronously (local mirror of the
+      // `messages.voice` setting) so end-of-turn silence detection honors the
+      // configured sensitivity. Only consumed by the local-inference backend.
+      const handle = createVoiceCapture({
+        localAsrAutoStop: loadVadAutoStop(),
+        onTranscript: (segment) => {
+          const text = segment.text.trim();
+          if (!segment.final) {
+            // Surface the interim best-guess as live transcription.
+            setTranscript(text);
+            return;
           }
-        }
-      },
-      onStateChange: (state: VoiceCaptureState) => {
-        if (state === "error" || state === "stopped" || state === "idle") {
-          // Capture ended (clean stop, dispose, or error). Drop the handle and
-          // analyser so the shell phase returns to idle/summoned and a later
-          // startCapture is not blocked by a stale ref.
-          if (captureRef.current === handle) captureRef.current = null;
+          setTranscript("");
+          if (text) {
+            if (intent === "dictate") {
+              // Push-to-talk dictation: hand the text to the composer draft —
+              // don't send, and leave lastTurnVoice false so no reply is spoken.
+              onDictatedTextRef.current?.(text);
+            } else {
+              send(text, {
+                channelType: "VOICE_DM",
+                metadata: {
+                  voiceSource: segment.backend,
+                },
+              });
+            }
+          }
+        },
+        onStateChange: (state: VoiceCaptureState) => {
+          if (state === "error" || state === "stopped" || state === "idle") {
+            // Capture ended (clean stop, dispose, or error). Drop the handle and
+            // analyser so the shell phase returns to idle/summoned and a later
+            // startCapture is not blocked by a stale ref.
+            if (captureRef.current === handle) captureRef.current = null;
+            setAnalyser(null);
+            setRecording(false);
+            setTranscript("");
+          }
+        },
+      });
+      captureRef.current = handle;
+      setRecording(true);
+      handle
+        .start()
+        .then(() => {
+          if (captureRef.current === handle) setAnalyser(handle.getAnalyser());
+        })
+        .catch(() => {
+          captureRef.current = null;
           setAnalyser(null);
           setRecording(false);
-          setTranscript("");
-        }
-      },
-    });
-    captureRef.current = handle;
-    setRecording(true);
-    handle
-      .start()
-      .then(() => {
-        if (captureRef.current === handle) setAnalyser(handle.getAnalyser());
-      })
-      .catch(() => {
-        captureRef.current = null;
-        setAnalyser(null);
-        setRecording(false);
-      });
-  }, [ready, send]);
+        });
+    },
+    [ready, send],
+  );
 
   const toggleRecording = React.useCallback(() => {
     if (recording) stopCapture();

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -22,6 +22,8 @@ function findLatestAssistantText(
 export interface ShellVoiceOutput {
   /** True while an assistant reply is being spoken aloud. */
   speaking: boolean;
+  /** Immediately stop any in-flight assistant speech (e.g. on hands-free exit). */
+  stopSpeaking: () => void;
   /** True while assistant voice output is muted by the user. */
   agentVoiceMuted: boolean;
   /** Mute/unmute assistant voice output. Muting stops any in-flight speech. */
@@ -132,6 +134,7 @@ export function useShellVoiceOutput(
 
   return {
     speaking: isSpeaking,
+    stopSpeaking,
     agentVoiceMuted,
     toggleAgentVoiceMute,
     // useVoiceChat always returns these; VoiceChatState types them optional, so

--- a/packages/ui/src/first-run/CompactOnboarding.tsx
+++ b/packages/ui/src/first-run/CompactOnboarding.tsx
@@ -3,9 +3,12 @@ import {
   ChevronLeft,
   Loader2,
   MailCheck,
+  Mic,
+  MicOff,
   Settings2,
   ShieldCheck,
   Sparkles,
+  Volume2,
 } from "lucide-react";
 import * as React from "react";
 import { TRAY_ACTION_EVENT } from "../events";
@@ -24,6 +27,10 @@ export function CompactOnboarding(): React.ReactElement {
     draft,
     localRuntimeAvailable,
     cloudOnly,
+    voice,
+    microphone,
+    onPromptReady,
+    stopVoice,
   } = c;
   const busy = submitting;
 
@@ -95,6 +102,46 @@ export function CompactOnboarding(): React.ReactElement {
     : (error ?? (cloudLoginUrl ? null : cloudError));
 
   const onRemote = step === "remote" && !cloudOnly;
+
+  // ── "Her"-style conversational voice (opt-in) ────────────────────────────
+  // When enabled, Eliza speaks each setup question and the user answers by
+  // voice; the controller's onPromptReady → startVoice → applyVoiceTranscript
+  // loop drives the actual runtime choice. The tap cards still work alongside.
+  const [voiceMode, setVoiceMode] = React.useState(false);
+  const promptedLineRef = React.useRef<string | null>(null);
+
+  const enableVoice = React.useCallback(async () => {
+    await microphone.request();
+    try {
+      // Share the chat surface's voice preference so voice carries past setup.
+      window.localStorage.setItem(
+        "eliza:voice:continuous-chat-mode",
+        "vad-gated",
+      );
+    } catch {
+      // localStorage may be unavailable (private mode) — voice still works now.
+    }
+    promptedLineRef.current = null;
+    setVoiceMode(true);
+  }, [microphone]);
+
+  const disableVoice = React.useCallback(() => {
+    setVoiceMode(false);
+    void stopVoice();
+  }, [stopVoice]);
+
+  // Speak the question for the current step, then listen — once per step.
+  React.useEffect(() => {
+    if (!voiceMode) return;
+    const lineId = step === "remote" ? "remote" : "runtime";
+    if (promptedLineRef.current === lineId) return;
+    promptedLineRef.current = lineId;
+    const promptText =
+      step === "remote"
+        ? "Where is the remote agent?"
+        : "Where should Eliza run?";
+    onPromptReady(promptText, lineId);
+  }, [voiceMode, step, onPromptReady]);
 
   return (
     <div className="first-run-screen pointer-events-none fixed inset-0 p-6 text-white">
@@ -312,6 +359,63 @@ export function CompactOnboarding(): React.ReactElement {
                     </button>
                   ) : null}
                 </div>
+
+                {/* HER-STYLE VOICE — opt-in. Off by default; tapping it asks for
+                    the mic and starts a spoken, hands-free setup conversation. */}
+                {voiceMode ? (
+                  <div
+                    data-testid="onboarding-voice-panel"
+                    className="mt-1 flex flex-col items-center gap-3"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`grid h-16 w-16 place-items-center rounded-full bg-white/15 ${
+                        voice.listening || voice.speaking
+                          ? "motion-safe:animate-pulse"
+                          : ""
+                      }`}
+                    >
+                      {voice.speaking ? (
+                        <Volume2 className="h-7 w-7 text-white" />
+                      ) : (
+                        <Mic className="h-7 w-7 text-white" />
+                      )}
+                    </span>
+                    <p
+                      role="status"
+                      aria-live="polite"
+                      className="min-h-5 max-w-[18rem] text-[13px] leading-snug text-white/80"
+                    >
+                      {voice.error
+                        ? voice.error
+                        : voice.speaking
+                          ? "Eliza is speaking…"
+                          : voice.listening
+                            ? voice.transcript || "Listening…"
+                            : "Getting voice ready…"}
+                    </p>
+                    <button
+                      type="button"
+                      data-testid="onboarding-voice-off"
+                      onClick={disableVoice}
+                      className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12px] font-medium text-white/55 transition-colors hover:bg-white/[0.06] hover:text-white/85"
+                    >
+                      <MicOff className="h-3.5 w-3.5" />
+                      Turn off voice
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    data-testid="onboarding-enable-voice"
+                    disabled={busy}
+                    onClick={() => void enableVoice()}
+                    className="mx-auto inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/10 px-4 py-2 text-[13px] font-medium text-white transition-colors hover:bg-white/20 disabled:opacity-50"
+                  >
+                    <Mic className="h-4 w-4" />
+                    Talk to set up
+                  </button>
+                )}
               </>
             )}
 


### PR DESCRIPTION
## "Her"-style bidirectional voice — chat button + conversational onboarding

Built on current `develop` (onboarding is already consolidated to the single
branded `CompactOnboarding`; the voice machinery in `useFirstRunController` was
intact). Two commits:

### 1. Chat voice button (`ContinuousChatOverlay`)
- **Tap the mic** → hands-free bidirectional conversation. The agent speaks its
  replies aloud and the mic re-opens after each one (tap again to end).
- **Press-and-hold** → push-to-talk dictation. The transcript fills the composer
  draft (no send, no spoken reply) for review before sending.

Extends the existing shell-controller voice path (no second `useVoiceChat` mic
owner): `startCapture(intent: "converse" | "dictate")`, a `handsFree` state with a
debounced re-listen loop, `toggleHandsFree` (unlocks audio on enable; stops mic +
speech on disable), and a `setDictationSink` wired to the composer draft.
`useShellVoiceOutput` now exports `stopSpeaking`.

### 2. Conversational onboarding (`CompactOnboarding`)
- Opt-in **"Talk to set up"** on the orange/white first-run card requests the mic
  and starts a spoken, hands-free setup: Eliza speaks each question
  (`onPromptReady`) and the user answers by voice (`applyVoiceTranscript` sets the
  runtime + advances). Tap cards still work; a pulsing orb + live transcript show
  the listening/speaking state. Opting in persists
  `eliza:voice:continuous-chat-mode=vad-gated` so voice carries into chat.

Reuses existing machinery — `voice`/`microphone`/`onPromptReady`/`stopVoice`,
`use-microphone-permission`, `onboarding-voice-lines` (the `runtime`/`remote` line
IDs already match the steps). No new voice engine.

### Verification
Built in an isolated worktree off `origin/develop` (the active feature branch's
working tree was being reset by concurrent processes), so it was **not locally
typechecked** — relying on CI for typecheck/lint/tests. Manual voice verification
(tap=converse loop, hold=dictate-to-draft, opt-in conversational onboarding) is
best on a darwin host with the local voice stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
