### PR TITLE
fix(facewear): update smartglasses completion gate for refactored sources

### DIFF
--- a/scripts/check-smartglasses-completion-gate.mjs
+++ b/scripts/check-smartglasses-completion-gate.mjs
@@ -217,7 +217,7 @@ function softwareGateFailures() {
   }
   const typecheckScript = String(scripts.typecheck ?? "");
   if (
-    !typecheckScript.includes("turbo run build") ||
+    !typecheckScript.includes("run-turbo.mjs run build") ||
     !typecheckScript.includes("--filter=@elizaos/plugin-facewear") ||
     !typecheckScript.includes("hardware-local-bluetooth.ts")
   ) {
@@ -321,15 +321,19 @@ function softwareGateFailures() {
       [
         "missingViewEvidence",
         "buildViewDisplayPackets",
-        "viewStreamingStatus",
         "displaySeqRef",
         "scanDiagnosis",
         "physicalBlocker",
         "onAudio",
         "callWifiBridge",
-        "does not support Wi-Fi command",
         "Guide",
       ],
+    ),
+  );
+  failures.push(
+    ...sourceTokenFailures(
+      "plugins/plugin-facewear/src/ui/SmartglassesView.helpers.ts",
+      ["viewStreamingStatus", "does not support Wi-Fi command"],
     ),
   );
   failures.push(
@@ -368,8 +372,8 @@ function softwareGateFailures() {
   failures.push(
     ...sourceTokenFailures("plugins/plugin-facewear/src/routes/views.ts", [
       'path: "/xr/views"',
-      "plugin.views",
-      "views.push",
+      "listViews(",
+      'viewType: "xr"',
     ]),
   );
   failures.push(


### PR DESCRIPTION
## What

`check-smartglasses-completion-gate.mjs --self-test` reported **5 failures** on develop. All were **stale assertions** — the source legitimately evolved and the gate wasn't updated. No functionality is missing.

| Gate assertion | Reality |
|---|---|
| typecheck must include `turbo run build` | example uses `run-turbo.mjs run build` (repo-standard wrapper) |
| `routes/views.ts` must contain `plugin.views` / `views.push` | refactored to centralized `listViews({viewType:"xr"})` registry |
| `SmartglassesView.tsx` must contain `viewStreamingStatus` / `"does not support Wi-Fi command"` | both moved into `SmartglassesView.helpers.ts` during a file split |

Updates each assertion to the current real tokens (and adds a `SmartglassesView.helpers.ts` block for the two moved tokens).

## Verification
- `node scripts/check-smartglasses-completion-gate.mjs --self-test` → `{ "ok": true, "software": true }`
- Only `scripts/check-smartglasses-completion-gate.mjs` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)