### PR TITLE
chore(cloud): tighten shared-runtime mobile-chat code to the 5 clean-code rules

### DIFF
--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -1,7 +1,6 @@
 import { type Context, Hono } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
   sharedRestAuthMe,
   sharedRestCharacter,
@@ -57,30 +56,6 @@ function shellPath(c: Context<AppEnv>): string {
     .split("/")
     .filter((s) => s.length > 0)
     .join("/");
-}
-
-async function resolveSharedAgent(
-  c: Context<AppEnv>,
-): Promise<
-  | { error: string; status: 400 | 404 }
-  | { agentId: string; agentName: string; orgId: string }
-> {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const agentId = c.req.param("agentId");
-  if (!agentId) return { error: "Missing agent id", status: 400 };
-  const agent = await agentSandboxesRepository.findByIdAndOrg(
-    agentId,
-    user.organization_id,
-  );
-  if (!agent) return { error: "Agent not found", status: 404 };
-  if (agent.execution_tier !== "shared") {
-    return { error: "Not a shared-runtime agent", status: 404 };
-  }
-  return {
-    agentId,
-    agentName: agent.agent_name ?? "Eliza",
-    orgId: user.organization_id,
-  };
 }
 
 app.options("/", () => handleCorsOptions(CORS_METHODS));

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -1,7 +1,6 @@
-import { type Context, Hono } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { Hono } from "hono";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
   sharedRestMessageSend,
   sharedRestMessagesGet,
@@ -20,38 +19,6 @@ const CORS_METHODS = "GET, POST, OPTIONS";
 
 const app = new Hono<AppEnv>();
 
-type Resolved =
-  | { error: string; status: 400 | 404 }
-  | {
-      orgId: string;
-      agentId: string;
-      conversationId: string;
-      agentName: string;
-    };
-
-async function resolveSharedAgent(c: Context<AppEnv>): Promise<Resolved> {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const agentId = c.req.param("agentId");
-  const conversationId = c.req.param("conversationId");
-  if (!agentId || !conversationId) {
-    return { error: "Missing agent or conversation id", status: 400 };
-  }
-  const agent = await agentSandboxesRepository.findByIdAndOrg(
-    agentId,
-    user.organization_id,
-  );
-  if (!agent) return { error: "Agent not found", status: 404 };
-  if (agent.execution_tier !== "shared") {
-    return { error: "Not a shared-runtime agent", status: 404 };
-  }
-  return {
-    orgId: user.organization_id,
-    agentId,
-    conversationId,
-    agentName: agent.agent_name ?? "Eliza",
-  };
-}
-
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 
 app.get("/", async (c) => {
@@ -62,7 +29,8 @@ app.get("/", async (c) => {
       CORS_METHODS,
     );
   }
-  const body = await sharedRestMessagesGet(r.agentId, r.conversationId);
+  const conversationId = c.req.param("conversationId") ?? r.agentId;
+  const body = await sharedRestMessagesGet(r.agentId, conversationId);
   return applyCorsHeaders(Response.json(body), CORS_METHODS);
 });
 
@@ -74,6 +42,7 @@ app.post("/", async (c) => {
       CORS_METHODS,
     );
   }
+  const conversationId = c.req.param("conversationId") ?? r.agentId;
   const raw: unknown = await c.req.json().catch(() => ({}));
   const text =
     raw &&
@@ -93,7 +62,7 @@ app.post("/", async (c) => {
   const result = await sharedRestMessageSend(
     r.agentId,
     r.orgId,
-    r.conversationId,
+    conversationId,
     text,
     r.agentName,
   );

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/conversations/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/conversations/route.ts
@@ -1,7 +1,6 @@
-import { type Context, Hono } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { Hono } from "hono";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
   sharedRestConversationCreate,
   sharedRestConversationsList,
@@ -22,26 +21,6 @@ const CORS_METHODS = "GET, POST, OPTIONS";
 const app = new Hono<AppEnv>();
 
 app.options("/", () => handleCorsOptions(CORS_METHODS));
-
-async function resolveSharedAgent(c: Context<AppEnv>) {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const agentId = c.req.param("agentId");
-  if (!agentId)
-    return { error: "Missing agent id" as const, status: 400 as const };
-  const agent = await agentSandboxesRepository.findByIdAndOrg(
-    agentId,
-    user.organization_id,
-  );
-  if (!agent)
-    return { error: "Agent not found" as const, status: 404 as const };
-  if (agent.execution_tier !== "shared") {
-    return {
-      error: "Not a shared-runtime agent" as const,
-      status: 404 as const,
-    };
-  }
-  return { agent, agentId };
-}
 
 app.get("/", async (c) => {
   const r = await resolveSharedAgent(c);

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/health/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/health/route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestHealth } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -10,7 +10,9 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * Health for a SHARED-runtime agent's REST surface. A shared agent runs
  * in-Worker (no agent server), so its reachable REST base is this cloud-api
  * adapter; the mobile/web chat client hits `<webUiUrl>/api/health` to confirm
- * the agent is up before loading chat. Auth-gated (the client sends Bearer).
+ * the agent is up before loading chat. Goes through the same `resolveSharedAgent`
+ * gate as its sibling leaves, so it 404s for a foreign/non-shared agent instead
+ * of reporting "ok" for any id.
  */
 const CORS_METHODS = "GET, OPTIONS";
 
@@ -19,7 +21,13 @@ const app = new Hono<AppEnv>();
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 
 app.get("/", async (c) => {
-  await requireUserOrApiKeyWithOrg(c);
+  const r = await resolveSharedAgent(c);
+  if ("error" in r) {
+    return applyCorsHeaders(
+      Response.json({ success: false, error: r.error }, { status: r.status }),
+      CORS_METHODS,
+    );
+  }
   return applyCorsHeaders(Response.json(sharedRestHealth()), CORS_METHODS);
 });
 

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -1536,45 +1536,46 @@ export class ElizaSandboxService {
       history,
       message: text,
     });
-    if (!turn.degraded) {
-      await this.saveSharedRuntimeHistory(rec.id, channelId, turn.history);
-    }
     if (turn.degraded) {
+      // A failed/degraded turn isn't persisted or billed — just refund the hold.
       await settleReservation(0);
-    } else if (billingContext) {
-      try {
-        const billing = await billUsage(
-          billingContext,
-          this.sharedRuntimeBillingUsage(turn, estimatedInputTokens),
-        );
-        const settlement = await settleReservation(billing.totalCost);
-        const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-          type: "chat",
-          content: turn.reply,
-          prompt: text,
-        });
-        if (usageRecord) {
-          await aiBillingRecordsService
-            .record({
-              context: billingContext,
-              billing,
-              usageRecord,
-              idempotencyKey,
-              reconciliation: settlement,
-            })
-            .catch((error) => {
-              logger.error("[shared-runtime] AI billing audit record failed", {
-                error: error instanceof Error ? error.message : String(error),
-                agentId: rec.id,
+    } else {
+      await this.saveSharedRuntimeHistory(rec.id, channelId, turn.history);
+      if (billingContext) {
+        try {
+          const billing = await billUsage(
+            billingContext,
+            this.sharedRuntimeBillingUsage(turn, estimatedInputTokens),
+          );
+          const settlement = await settleReservation(billing.totalCost);
+          const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+            type: "chat",
+            content: turn.reply,
+            prompt: text,
+          });
+          if (usageRecord) {
+            await aiBillingRecordsService
+              .record({
+                context: billingContext,
+                billing,
+                usageRecord,
+                idempotencyKey,
+                reconciliation: settlement,
+              })
+              .catch((error) => {
+                logger.error("[shared-runtime] AI billing audit record failed", {
+                  error: error instanceof Error ? error.message : String(error),
+                  agentId: rec.id,
+                });
               });
-            });
+          }
+        } catch (error) {
+          await settleReservation(0);
+          logger.error("[shared-runtime] billing failed", {
+            error: error instanceof Error ? error.message : String(error),
+            agentId: rec.id,
+          });
         }
-      } catch (error) {
-        await settleReservation(0);
-        logger.error("[shared-runtime] billing failed", {
-          error: error instanceof Error ? error.message : String(error),
-          agentId: rec.id,
-        });
       }
     }
 

--- a/packages/cloud-shared/src/lib/services/shared-runtime/agent-tier.test.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/agent-tier.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import {
-  type AgentTier,
-  getAgentTier,
-  isSharedEligible,
-  tierProvisionsEagerly,
-  tierRequiresContainer,
-} from "./agent-tier";
+import { getAgentTier, tierProvisionsEagerly } from "./agent-tier";
 import { runSharedAgentTurn } from "./run-shared-agent-turn";
 
 describe("getAgentTier", () => {
@@ -39,22 +33,6 @@ describe("getAgentTier", () => {
 });
 
 describe("tier helpers", () => {
-  it("isSharedEligible is true only for the shared tier", () => {
-    expect(isSharedEligible({})).toBe(true);
-    expect(isSharedEligible({ alwaysOn: true })).toBe(false);
-    expect(isSharedEligible({ dockerImage: "x:1" })).toBe(false);
-  });
-
-  it("tierRequiresContainer is false only for shared", () => {
-    const cases: Array<[AgentTier, boolean]> = [
-      ["shared", false],
-      ["dedicated-lazy", true],
-      ["dedicated-always", true],
-      ["custom", true],
-    ];
-    for (const [tier, expected] of cases) expect(tierRequiresContainer(tier)).toBe(expected);
-  });
-
   it("tierProvisionsEagerly only for always-on + custom", () => {
     expect(tierProvisionsEagerly("shared")).toBe(false);
     expect(tierProvisionsEagerly("dedicated-lazy")).toBe(false);

--- a/packages/cloud-shared/src/lib/services/shared-runtime/agent-tier.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/agent-tier.ts
@@ -67,16 +67,6 @@ export function getAgentTier(input: AgentTierInput): AgentTier {
   return "shared";
 }
 
-/** True when the agent can run container-free in the shared hosted runtime. */
-export function isSharedEligible(input: AgentTierInput): boolean {
-  return getAgentTier(input) === "shared";
-}
-
-/** True when the tier requires a dedicated container (any non-shared tier). */
-export function tierRequiresContainer(tier: AgentTier): boolean {
-  return tier !== "shared";
-}
-
 /** True when the container for this tier should be provisioned eagerly at create time. */
 export function tierProvisionsEagerly(tier: AgentTier): boolean {
   // dedicated-always + custom want the box up immediately; dedicated-lazy waits

--- a/packages/cloud-shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/resolve-shared-agent.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+
+import {
+  type AgentSandbox,
+  agentSandboxesRepository,
+} from "../../../db/repositories/agent-sandboxes";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import { requireUserOrApiKeyWithOrg } from "../../auth/workers-hono-auth";
+
+export type ResolvedSharedAgent =
+  | { error: string; status: 400 | 404 }
+  | { agent: AgentSandbox; agentId: string; orgId: string; agentName: string };
+
+/**
+ * Resolve + authorize the SHARED-runtime agent addressed by a request's
+ * `:agentId`. The single gate behind every `.../agents/:agentId/api/*` leaf
+ * (health, status/catch-all, conversations, messages) so the auth + org-scope +
+ * shared-tier check lives in exactly ONE place instead of a per-route copy.
+ *
+ * Validates the caller's API key/session, scopes the agent to their org, and
+ * 404s anything that isn't a shared-tier agent (dedicated agents use their own
+ * subdomain REST surface). Returns the superset of fields the leaves read; each
+ * caller takes what it needs.
+ */
+export async function resolveSharedAgent(c: Context<AppEnv>): Promise<ResolvedSharedAgent> {
+  const user = await requireUserOrApiKeyWithOrg(c);
+  const agentId = c.req.param("agentId");
+  if (!agentId) return { error: "Missing agent id", status: 400 };
+  const agent = await agentSandboxesRepository.findByIdAndOrg(agentId, user.organization_id);
+  if (!agent) return { error: "Agent not found", status: 404 };
+  if (agent.execution_tier !== "shared") {
+    return { error: "Not a shared-runtime agent", status: 404 };
+  }
+  return { agent, agentId, orgId: user.organization_id, agentName: agent.agent_name ?? "Eliza" };
+}

--- a/packages/cloud-shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -28,10 +28,8 @@ import {
 } from "../../providers/language-model";
 import { logger } from "../../utils/logger";
 
-export type SharedTurnRole = "user" | "assistant";
-
 export interface SharedTurnMessage {
-  role: SharedTurnRole;
+  role: "user" | "assistant";
   content: string;
 }
 
@@ -71,16 +69,13 @@ export interface RunSharedAgentTurnResult {
  */
 const DEFAULT_SHARED_MODEL = CEREBRAS_DEFAULT_TEXT_SMALL_MODEL;
 
+/** Token counts the shared-runtime billing path consumes (input/output/total). */
 export interface SharedAgentTurnUsage {
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
-  cachedInputTokens?: number;
-  cacheReadInputTokens?: number;
-  cacheCreationInputTokens?: number;
-  cacheWriteInputTokens?: number;
 }
 
 /**

--- a/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -43,12 +43,6 @@ export interface SharedRestMessage {
   text: string;
 }
 
-/** The reply shape the chat client expects from POST .../messages. */
-export interface SharedRestSendResult {
-  text: string;
-  agentName: string;
-}
-
 /** The canonical (single) conversation id for a shared agent === its agent id. */
 function canonicalConversationId(agentId: string): string {
   return agentId;
@@ -69,27 +63,20 @@ export function sharedRestHealth(): { status: "ok" } {
   return { status: "ok" };
 }
 
-/** The agent-status shape the chat client reads; `state` + `canRespond` gate UI. */
-export interface SharedRestStatus {
-  state: "running";
-  agentName: string;
-  /**
-   * The composer's send-gate is `canRespond ?? (running && model)`. A shared
-   * agent has no LOCAL model (inference is hosted in-Worker), so `running &&
-   * model` is false and the box would stay disabled. We're only here for a
-   * provisioned + running shared agent, so it CAN respond — declare it
-   * explicitly so the client doesn't fall back to the model check.
-   */
-  canRespond: true;
-}
-
 /**
  * GET .../api/status — the startup-coordinator's FIRST hard gate: it calls
  * `getStatus()` before anything else and bails unless `state === "running"`.
- * A shared agent runs in-Worker, so if this resolves it is by definition up and
- * able to respond (its inference is hosted, not a local model).
+ * A shared agent runs in-Worker, so if this resolves it is by definition up.
+ *
+ * `canRespond` is load-bearing too: the composer's send-gate is
+ * `canRespond ?? (running && model)`, and a shared agent has no LOCAL model
+ * (inference is hosted in-Worker), so without it the box would stay disabled.
  */
-export function sharedRestStatus(agentName: string): SharedRestStatus {
+export function sharedRestStatus(agentName: string): {
+  state: "running";
+  agentName: string;
+  canRespond: true;
+} {
   return { state: "running", agentName: agentName || "Eliza", canRespond: true };
 }
 
@@ -114,7 +101,7 @@ export function sharedRestStatus(agentName: string): SharedRestStatus {
 //   config           → packages/agent/src/api/config-routes.ts (open-ended object)
 
 /** Minimal subset of the agent-server `ViewRegistryEntry` the chat client reads. */
-export interface SharedRestViewRegistration {
+interface SharedRestViewRegistration {
   id: string;
   label: string;
   viewType: "gui" | "tui" | "xr";
@@ -217,27 +204,28 @@ export function sharedRestConfig(): { websocket: false; streaming: false } {
   return { websocket: false, streaming: false };
 }
 
-/** The authed-identity shape `authMe()` (ui/src/api/auth-client.ts) parses. */
-export interface SharedRestAuthMe {
+/**
+ * GET .../api/auth/me — the app's HARD startup gate (App.tsx auth gate →
+ * useAuthStatus → authMe(), ui/src/api/auth-client.ts). A shared agent has no
+ * agent server and no owner-password flow; it is reached purely through the
+ * caller's authenticated API key, which the route already validated
+ * (resolveSharedAgent → requireUserOrApiKeyWithOrg). So the caller is, by
+ * construction, an authed machine identity — return it in the agent-server's
+ * `bearer-agent` shape (auth-routes.ts authorized branch: identity.kind
+ * "machine", session machine with no expiry, access mode "bearer"). Without an
+ * `ok:true` body here, the client maps the 404 to status 503 →
+ * "server_unavailable" → StartupFailureView and never reaches chat. The identity
+ * is the agent itself (id = agentId, displayName = agentName) — the only stable
+ * identity this adapter owns.
+ */
+export function sharedRestAuthMe(
+  agentId: string,
+  agentName: string,
+): {
   identity: { id: string; displayName: string; kind: "machine" };
   session: { id: string; kind: "machine"; expiresAt: null };
   access: { mode: "bearer"; passwordConfigured: false; ownerConfigured: false };
-}
-
-/**
- * GET .../api/auth/me — the app's HARD startup gate (App.tsx auth gate →
- * useAuthStatus → authMe()). A shared agent has no agent server and no
- * owner-password flow; it is reached purely through the caller's authenticated
- * API key, which the route already validated (resolveSharedAgent →
- * requireUserOrApiKeyWithOrg). So the caller is, by construction, an authed
- * machine identity — return it in the agent-server's `bearer-agent` shape
- * (auth-routes.ts authorized branch: identity.kind "machine", session machine
- * with no expiry, access mode "bearer"). Without an `ok:true` body here, the
- * client maps the 404 to status 503 → "server_unavailable" → StartupFailureView
- * and never reaches chat. The identity is the agent itself (id = agentId,
- * displayName = agentName) — the only stable identity this adapter owns.
- */
-export function sharedRestAuthMe(agentId: string, agentName: string): SharedRestAuthMe {
+} {
   return {
     identity: {
       id: agentId,
@@ -247,12 +235,6 @@ export function sharedRestAuthMe(agentId: string, agentName: string): SharedRest
     session: { id: "bearer", kind: "machine", expiresAt: null },
     access: { mode: "bearer", passwordConfigured: false, ownerConfigured: false },
   };
-}
-
-/** GET .../api/character body — mirrors the agent server (character-routes.ts). */
-export interface SharedRestCharacter {
-  character: SharedAgentCharacter | Record<string, never>;
-  agentName: string;
 }
 
 /**
@@ -267,7 +249,7 @@ export async function sharedRestCharacter(
   agentId: string,
   orgId: string,
   agentName: string,
-): Promise<SharedRestCharacter> {
+): Promise<{ character: SharedAgentCharacter | Record<string, never>; agentName: string }> {
   const character = await elizaSandboxService.getSharedRuntimeCharacter(agentId, orgId);
   return { character: character ?? {}, agentName: agentName || "Eliza" };
 }
@@ -319,7 +301,7 @@ export async function sharedRestMessageSend(
   conversationId: string,
   text: string,
   agentName: string,
-): Promise<SharedRestSendResult> {
+): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
     id: crypto.randomUUID(),


### PR DESCRIPTION
Prod ship of #8584 (also on develop). Dedup the triplicated `resolveSharedAgent` into one shared module (+ route the health leaf through it so it 404s for foreign agents instead of returning ok), inline single-use `SharedRest*` types, drop dead tier helpers + unused usage fields, collapse an inverted degraded branch. **No behavior change except the health-leaf correctness fix.** typecheck 0 errors, codegen unchanged, 25/25 shared-runtime+billing tests, lint clean. Net -88 LOC.