### PR TITLE
plugin-telegram: derive connector role from a personal user identity

### DIFF
--- a/plugins/plugin-telegram/src/accounts.ts
+++ b/plugins/plugin-telegram/src/accounts.ts
@@ -141,3 +141,48 @@ export function listEnabledTelegramAccounts(
     .map((accountId) => resolveTelegramAccount(runtime, accountId))
     .filter((account) => account.enabled && account.botToken);
 }
+
+/**
+ * Whether an account declares a usable personal (MTProto user-account) identity:
+ * a personal block that isn't explicitly disabled and carries at least a phone
+ * number or a saved session. This is the OWNER signal — the human user the agent
+ * can act through — distinct from the bot identity (botToken) it acts AS.
+ */
+export function isTelegramPersonalEnabled(
+  account: ResolvedTelegramAccount,
+): boolean {
+  const personal = account.config.personal;
+  if (!personal || personal.enabled === false) {
+    return false;
+  }
+  return Boolean(
+    readNonEmptyString(personal.phone) || readNonEmptyString(personal.session),
+  );
+}
+
+/**
+ * Stable external id for an account's personal identity, used as the binding key
+ * the owner-binding access gate matches against. Derived from the phone number;
+ * undefined when no phone is configured (the gate then can't resolve a binding,
+ * which correctly keeps the account blocked).
+ */
+export function telegramPersonalExternalId(
+  account: ResolvedTelegramAccount,
+): string | undefined {
+  const phone = readNonEmptyString(account.config.personal?.phone);
+  return phone ? `tg-user:${phone}` : undefined;
+}
+
+/**
+ * Accounts that declare a personal (user-account) identity. Separate from
+ * listEnabledTelegramAccounts (which is the bot-service's view — accounts with a
+ * botToken to long-poll); a personal-only account has no botToken and must never
+ * reach the bot service, only the connector-account provider.
+ */
+export function listPersonalTelegramAccounts(
+  runtime: IAgentRuntime,
+): ResolvedTelegramAccount[] {
+  return listTelegramAccountIds(runtime)
+    .map((accountId) => resolveTelegramAccount(runtime, accountId))
+    .filter((account) => account.enabled && isTelegramPersonalEnabled(account));
+}

--- a/plugins/plugin-telegram/src/connector-account-provider.test.ts
+++ b/plugins/plugin-telegram/src/connector-account-provider.test.ts
@@ -1,0 +1,90 @@
+import type {
+  ConnectorAccount,
+  ConnectorAccountManager,
+  IAgentRuntime,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramConnectorAccountProvider } from "./connector-account-provider";
+
+type TelegramConfig = Record<string, unknown>;
+
+function runtimeWith(telegram: TelegramConfig): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    character: { name: "Agent", settings: { telegram } },
+    getSetting: () => undefined,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+// Minimal manager whose storage returns no persisted accounts, so listAccounts
+// reflects only the synthesized (config-derived) accounts under test.
+function emptyManager(): ConnectorAccountManager {
+  return {
+    getStorage: () => ({ listAccounts: async () => [] as ConnectorAccount[] }),
+  } as unknown as ConnectorAccountManager;
+}
+
+async function list(telegram: TelegramConfig): Promise<ConnectorAccount[]> {
+  const provider = createTelegramConnectorAccountProvider(
+    runtimeWith(telegram),
+  );
+  return provider.listAccounts?.(emptyManager()) ?? [];
+}
+
+describe("Telegram connector account roles (agent bot vs personal user)", () => {
+  it("surfaces a bot-token account as an open AGENT account", async () => {
+    const accounts = await list({ botToken: "123:abc" });
+    expect(accounts).toHaveLength(1);
+    const bot = accounts[0];
+    expect(bot.role).toBe("AGENT");
+    expect(bot.accessGate).toBe("open");
+    expect(bot.metadata?.personal).toBe(false);
+  });
+
+  it("surfaces a personal account as an owner_binding-gated OWNER account with a stable externalId", async () => {
+    const accounts = await list({
+      accounts: {
+        me: { personal: { phone: "+15551234567", enabled: true } },
+      },
+    });
+    const owner = accounts.find((a) => a.role === "OWNER");
+    expect(owner).toBeDefined();
+    expect(owner?.accessGate).toBe("owner_binding");
+    expect(owner?.purpose).toContain("reading");
+    // Load-bearing: the owner-binding gate matches on externalId, so it must be set.
+    expect(owner?.externalId).toBe("tg-user:+15551234567");
+    expect(owner?.id).toBe("me:personal");
+    expect(owner?.metadata?.personal).toBe(true);
+  });
+
+  it("surfaces both a bot and a personal identity from one config as two distinct accounts", async () => {
+    const accounts = await list({
+      accounts: {
+        me: {
+          botToken: "123:abc",
+          personal: { phone: "+15551234567", enabled: true },
+        },
+      },
+    });
+    const bot = accounts.find((a) => a.role === "AGENT");
+    const owner = accounts.find((a) => a.role === "OWNER");
+    expect(bot?.id).toBe("me");
+    expect(owner?.id).toBe("me:personal");
+    expect(accounts).toHaveLength(2);
+  });
+
+  it("ignores a disabled or credential-less personal block", async () => {
+    const disabled = await list({
+      accounts: {
+        me: { botToken: "1:a", personal: { phone: "+1", enabled: false } },
+      },
+    });
+    expect(disabled.some((a) => a.role === "OWNER")).toBe(false);
+
+    const credless = await list({
+      accounts: { me: { botToken: "1:a", personal: { enabled: true } } },
+    });
+    expect(credless.some((a) => a.role === "OWNER")).toBe(false);
+  });
+});

--- a/plugins/plugin-telegram/src/connector-account-provider.ts
+++ b/plugins/plugin-telegram/src/connector-account-provider.ts
@@ -13,39 +13,71 @@
  */
 import type {
   ConnectorAccount,
+  ConnectorAccountAccessGate,
   ConnectorAccountManager,
   ConnectorAccountPatch,
   ConnectorAccountProvider,
+  ConnectorAccountRole,
   IAgentRuntime,
 } from "@elizaos/core";
 import {
   DEFAULT_ACCOUNT_ID,
   listEnabledTelegramAccounts,
+  listPersonalTelegramAccounts,
   resolveTelegramAccount,
+  telegramPersonalExternalId,
 } from "./accounts";
 import { TELEGRAM_SERVICE_NAME } from "./constants";
+
+// Suffix for the synthesized OWNER (user-account) entry so the agent's bot
+// identity and the human owner's personal identity for the same config never
+// collide on a single ConnectorAccount id.
+const PERSONAL_ACCOUNT_SUFFIX = ":personal";
 
 function nowMs(): number {
   return Date.now();
 }
 
 /**
- * Build a synthetic ConnectorAccount for a resolved Telegram account that has
- * a usable bot token (i.e. a working single-account config from environment
- * variables or character.settings.telegram).
+ * Derive the role and access gate for a Telegram identity. The agent's own bot
+ * identity is an open AGENT account (acting as the bot is frictionless); the
+ * human owner's personal account is an OWNER account behind the owner_binding
+ * gate, so "act as the user" can't fire until the user has proven the account is
+ * theirs (via the /eliza_pair owner-binding flow).
+ */
+function deriveAccountRole(personal: boolean): {
+  role: ConnectorAccountRole;
+  accessGate: ConnectorAccountAccessGate;
+  purpose: string[];
+} {
+  return personal
+    ? {
+        role: "OWNER",
+        accessGate: "owner_binding",
+        purpose: ["messaging", "reading"],
+      }
+    : { role: "AGENT", accessGate: "open", purpose: ["messaging"] };
+}
+
+/**
+ * Build a synthetic ConnectorAccount for a resolved Telegram identity — either
+ * the agent's bot account (from a bot token) or the owner's personal account
+ * (from an MTProto user identity). Role/gate are derived from `personal`.
  */
 function synthesizeAccount(
   accountId: string,
   name: string | undefined,
   externalId: string | undefined,
+  personal: boolean,
 ): ConnectorAccount {
+  const { role, accessGate, purpose } = deriveAccountRole(personal);
   return {
     id: accountId,
     provider: TELEGRAM_SERVICE_NAME,
     label: name ?? `Telegram (${accountId})`,
-    role: "AGENT",
-    purpose: ["messaging"],
-    accessGate: "open",
+    role,
+    purpose,
+    accessGate,
     status: "connected",
     externalId,
     displayHandle: name,
@@ -54,6 +86,7 @@ function synthesizeAccount(
     metadata: {
       synthesized: true,
       source: "env",
+      personal,
     },
   };
 }
@@ -76,12 +109,31 @@ export function createTelegramConnectorAccountProvider(
         .listAccounts(TELEGRAM_SERVICE_NAME);
       const persistedById = new Map(persisted.map((a) => [a.id, a]));
 
+      // Agent's own bot identities (AGENT, open gate).
       const enabled = listEnabledTelegramAccounts(runtime);
       const synthesized: ConnectorAccount[] = enabled
         .filter((account) => !persistedById.has(account.accountId))
         .map((account) =>
-          synthesizeAccount(account.accountId, account.name, undefined),
+          synthesizeAccount(account.accountId, account.name, undefined, false),
         );
+
+      // Owner's personal identities (OWNER, owner_binding gate) — a distinct
+      // account id (<accountId>:personal) so a config declaring both a bot and a
+      // user surfaces two accounts.
+      for (const account of listPersonalTelegramAccounts(runtime)) {
+        const id = `${account.accountId}${PERSONAL_ACCOUNT_SUFFIX}`;
+        if (persistedById.has(id)) {
+          continue;
+        }
+        synthesized.push(
+          synthesizeAccount(
+            id,
+            account.name,
+            telegramPersonalExternalId(account),
+            true,
+          ),
+        );
+      }
 
       // If env-only single-account flow is configured but the resolved
       // accounts list is empty (e.g. token not yet validated), fall back to
@@ -90,7 +142,12 @@ export function createTelegramConnectorAccountProvider(
         const fallback = resolveTelegramAccount(runtime, DEFAULT_ACCOUNT_ID);
         if (fallback.botToken) {
           synthesized.push(
-            synthesizeAccount(DEFAULT_ACCOUNT_ID, fallback.name, undefined),
+            synthesizeAccount(
+              DEFAULT_ACCOUNT_ID,
+              fallback.name,
+              undefined,
+              false,
+            ),
           );
         }
       }


### PR DESCRIPTION
## What

Gives the Telegram connector the same account-role model as the owner-binding gate expects, so a personal agent can have its **own bot identity** and act **through the user's own Telegram account** without conflating the two.

Today `connector-account-provider.ts` surfaces every account as `role: AGENT` / `accessGate: open` and passes `externalId: undefined` — so the core owner-binding gate (which matches a verified binding by `externalId`) could never resolve one, and the user's account would be indistinguishable from the bot.

- A **bot-token** account stays an `AGENT` account on the `open` gate (acting as the bot is frictionless).
- A configured **personal block** (an MTProto user identity, signalled by a phone or saved session that isn't explicitly disabled) is surfaced as a separate `OWNER` account on the `owner_binding` gate, with a stable `externalId` (`tg-user:<phone>`) so the gate can match the binding the existing `/eliza_pair` flow already creates. A config declaring both yields two distinct accounts (`<id>` and `<id>:personal`).

The bot service's account list (`listEnabledTelegramAccounts`, which needs a bot token to long-poll) is deliberately left untouched — personal accounts are enumerated separately so a phone-only account never reaches the Telegraf path.

## Scope

This is the **role model only**. The live MTProto connector that actually reads/sends as the user (re-instantiating a persistent `TelegramClient` from the saved session and registering it as a `MessageConnector`) is a follow-up — it requires a real authenticated session to build and verify.

## Testing

New `connector-account-provider.test.ts`: bot → `AGENT`/open; personal → `OWNER`/`owner_binding` with the stable `externalId`; both → two distinct accounts; disabled / credential-less personal ignored. Full plugin-telegram suite green (33 tests), strict typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
