### PR TITLE
fix(agent-image): @elizaos/ui depends on @capacitor/core (not devDep)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -271,6 +271,7 @@
     "@elizaos/capacitor-camera": "workspace:*"
   },
   "dependencies": {
+    "@capacitor/core": "8.4.0",
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/logger": "workspace:*",
@@ -331,7 +332,6 @@
     "ws": "^8.19.0"
   },
   "devDependencies": {
-    "@capacitor/core": "8.4.0",
     "@capacitor/haptics": "8.0.2",
     "@capacitor/keyboard": "8.0.3",
     "@capacitor/preferences": "^8.0.1",


### PR DESCRIPTION
Fixes the Build Agent Image boot crash (image serves /api/health then crashes 'NOT bootable'). Crash signature (from the untruncated CI log):
```
Could not load plugin @elizaos/plugin-inbox: Cannot find package '@capacitor/core' imported from packages/ui/dist/first-run/local-agent-token.js
```
plugin-inbox loads the @elizaos/ui barrel in the Node agent; @capacitor/core is statically imported by 19 ui files for `Capacitor.isNativePlatform()` (must stay static — it gates the dynamic native plugins and its Node shim returns false safely), but it was a **devDependency**, so the production install (NODE_ENV=production) omitted it. It's a genuine runtime dep of @elizaos/ui — moved to `dependencies`. The agent image's `--no-frozen-lockfile` install reads package.json, so it now resolves. (#8577 correctly handled the native-only plugins keyboard/haptics/preferences via dynamic import; core is the always-present platform shim, different case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)