### PR TITLE
docs(test): drop stale advanceOnSend reference in tutorial walkthrough header

### DIFF
--- a/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
@@ -8,7 +8,7 @@ import {
 /**
  * Full, screenshot-driven verification of the Tutorial + Help.
  *  - Runs the ENTIRE tutorial to completion, screenshotting every step.
- *  - Verifies "ask to navigate" actually switches to Settings (advanceOnSend).
+ *  - Verifies the tour navigates to the real Settings view mid-run (reachedSettings).
  *  - Verifies Help is driven by the floating chat (placeholder override + live
  *    filter + auto-expanded best match + deep-link).
  * Screenshots land in /tmp/tut-shots for manual review.


### PR DESCRIPTION
Cleanup follow-up to #8554. The `advanceOnSend` mechanism was removed during that work, but a single file-header comment in `tutorial-help-walkthrough.spec.ts` still named it. The test now verifies Settings navigation via the `reachedSettings` assertion — this updates the comment to match.

The last dangling reference to the removed symbol; comment-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)