### PR TITLE
test(ui/voice): fix mic-gesture tests for the merged hands-free/dictation change

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -830,7 +830,7 @@ test.describe("assistant home app flow", () => {
     });
   });
 
-  test("push-to-talk records while the mic is held and submits on release", async ({
+  test("push-to-talk dictates the held transcript into the composer on release (no auto-send)", async ({
     page,
   }) => {
     await seedAssistantFlowStorage(page);
@@ -866,21 +866,21 @@ test.describe("assistant home app flow", () => {
     });
     expect(accepted, "home voice shim must receive the held turn").toBe(true);
 
-    // Releasing the held mic ends capture. The final transcript is submitted
-    // by the voice pipeline itself.
+    // Releasing the held mic ends capture. Push-to-talk now DICTATES: the final
+    // transcript lands in the composer draft (it is NOT auto-submitted), so the
+    // user edits and sends it themselves — no turn is streamed, no spoken reply.
     await releaseHandle.dispatchEvent("pointerup", {
       button: 0,
       pointerId: 1,
       pointerType: "mouse",
     });
+    const composer = page.locator('[data-testid="chat-composer-textarea"]');
     await expect
-      .poll(() => assistantApi.streamRequests, { timeout: 10_000 })
-      .toEqual(["push to talk works"]);
-    await expect(
-      page
-        .getByText("Opening the right view now and keeping voice ready.")
-        .first(),
-    ).toBeVisible();
-    expect(assistantApi.streamRequests).toEqual(["push to talk works"]);
+      .poll(async () => (await composer.inputValue()).trim(), {
+        timeout: 10_000,
+      })
+      .toContain("push to talk works");
+    // Dictation must not submit a turn.
+    expect(assistantApi.streamRequests).toEqual([]);
   });
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -30,6 +30,9 @@ function makeController(
     transcript: "",
     send: vi.fn(),
     toggleRecording: vi.fn(),
+    handsFree: false,
+    toggleHandsFree: vi.fn(),
+    setDictationSink: vi.fn(),
     clearConversation: vi.fn(),
     ...overrides,
   } as unknown as ShellController;

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -49,6 +49,9 @@ function makeController(
     transcript: "",
     send: vi.fn(),
     toggleRecording: vi.fn(),
+    handsFree: false,
+    toggleHandsFree: vi.fn(),
+    setDictationSink: vi.fn(),
     ...overrides,
   } as unknown as ShellController;
 }
@@ -337,11 +340,11 @@ describe("ContinuousChatOverlay", () => {
     );
   });
 
-  it("toggles recording when the mic is pressed", () => {
+  it("toggles hands-free conversation when the mic is tapped", () => {
     const controller = makeController();
     render(<ContinuousChatOverlay controller={controller} />);
     fireEvent.click(screen.getByLabelText("talk"));
-    expect(controller.toggleRecording).toHaveBeenCalled();
+    expect(controller.toggleHandsFree).toHaveBeenCalled();
   });
 
   it("shows a waking-up placeholder while booting (typing allowed)", () => {


### PR DESCRIPTION
Follow-up to the Her-style voice change merged in #8581. That PR changed the chat
mic behavior (tap = hands-free conversation, hold = dictation-into-draft) but the
mic-gesture tests still asserted the old behavior, so develop's test lanes went
red after the merge. This updates them:

- **assistant-home-flow.spec.ts**: push-to-talk now dictates the held transcript
  into the composer draft (no auto-send) — assert the composer value, not a
  submitted turn.
- **ContinuousChatOverlay.test.tsx / .slash.test.tsx**: add
  `handsFree`/`toggleHandsFree`/`setDictationSink` to the mock `ShellController`
  (the overlay's dictation-sink mount effect calls `setDictationSink`, which
  threw on the partial mock and crashed the overlay tests); the tap test now
  asserts `toggleHandsFree` (was `toggleRecording`).

Pure test update — no production code change. biome-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)