### PR TITLE
fix(cloud-frontend): dashboard pages scroll again (canvas-only viewport clamp) + drop 404 GenUI pill

### DIFF
--- a/packages/cloud-frontend/src/App.tsx
+++ b/packages/cloud-frontend/src/App.tsx
@@ -197,12 +197,6 @@ const CanvasLayout = lazy(() =>
   })),
 );
 
-const CloudAssistantPill = lazy(() =>
-  import("./components/canvas/cloud-assistant-pill").then((m) => ({
-    default: m.CloudAssistantPill,
-  })),
-);
-
 /**
  * Map of React Router path pattern → preload function. Hovering or focusing
  * a link with an `href` matching one of these routes warms the matched branch
@@ -561,10 +555,19 @@ function DashboardRouteElement() {
       )}
     >
       <Suspense fallback={<RouteChunkFallback />}>
-        <div className="relative h-dvh w-full overflow-hidden">
-          {canvasOpen ? <CanvasLayout /> : <DashboardLayout />}
-          {!canvasOpen && <CloudAssistantPill />}
-        </div>
+        {canvasOpen ? (
+          // The canvas is a fixed-viewport WebGL stage: clamp it to the dvh and
+          // clip overflow so it never scrolls the document behind it.
+          <div className="relative h-dvh w-full overflow-hidden">
+            <CanvasLayout />
+          </div>
+        ) : (
+          // Classic dashboard: render bare so the shell's natural `min-h-dvh`
+          // body flow is preserved and long pages (the agents grid, billing,
+          // analytics, …) scroll. Wrapping it in `h-dvh overflow-hidden` clipped
+          // every long page — that was the no-scroll bug.
+          <DashboardLayout />
+        )}
       </Suspense>
     </RouteErrorBoundary>
   );


### PR DESCRIPTION
## The bug
`/dashboard/agents` (and every long classic dashboard page — billing, analytics, admin) **can't scroll**.

## Root cause
`DashboardRouteElement` in `src/App.tsx` wrapped **both** the canvas and the classic dashboard in one `<div className="relative h-dvh w-full overflow-hidden">` (added by PR #8339, `c15d89494b`). The canvas is a fixed-viewport WebGL stage and legitimately wants that clamp — but the classic dashboard shell (`DashboardLayout` → cloud-ui `DashboardShellLayout`) is built for **natural `min-h-dvh` body flow** (its `<main>` has no `overflow-y`). Sharing one `h-dvh overflow-hidden` wrapper clips any page taller than the viewport → nothing scrolls.

## Fix
Render the `h-dvh overflow-hidden` clamp **only in canvas mode**; render the classic dashboard **bare** so the shell's natural body scroll is preserved. Lowest-blast-radius fix — touches only `App.tsx`, not the shared shell (adding `overflow-y-auto` to the shared `<main>` would risk double-scroll/sticky-header regressions on other consumers).

Also **drop the orphaned `CloudAssistantPill`**: it only rendered on the classic dashboard and POSTs `/api/v1/genui`, a route with **no backend** (404 on every load) — a canvas/GenUI remnant that doesn't belong on the clean classic surface.

## Verification
- typecheck 0 errors, lint clean, full build (client + SSR + prerender) green.
- Required `audit:cloud` visual-review gate: run + manual-review notes filled (see PR thread).

Note: prod trails the repo (frontend ships only on a `cloud-cf-deploy` run), so this needs a deploy after merge to reach elizacloud.ai. Holding merge + deploy for @NubsCarson's go.