### PR TITLE
feat(ui): make the floating chat the search box across page views

### DIFF
--- a/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
@@ -54,10 +54,14 @@ test("plugins view loads plugins and search filters the list", async ({
   });
   await expect.poll(pluginReqs).toBeGreaterThan(0);
 
-  // The stub serves openai + anthropic + plugin-browser. A specific search must
-  // narrow the visible set; clearing it must restore.
-  const search = page.getByTestId("plugins-search");
-  await expect(search).toBeVisible({ timeout: 15_000 });
+  // Search now runs through the floating chat composer — the plugins view takes
+  // over its placeholder + live draft (no in-page search box). The stub serves
+  // openai + anthropic + plugin-browser: a specific search must narrow the
+  // visible set; clearing it must restore.
+  const search = page.getByTestId("chat-composer-textarea");
+  await expect(search).toHaveAttribute("placeholder", /search plugins/i, {
+    timeout: 15_000,
+  });
   const cardsAll = await page.locator("[data-plugin-toggle]").count();
   await search.fill("browser");
   await expect

--- a/packages/ui/src/components/pages/DocumentsView.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.tsx
@@ -6,10 +6,8 @@ import {
   Globe2,
   Layers,
   Lock,
-  Search,
   Shield,
   User,
-  X,
 } from "lucide-react";
 import {
   type ChangeEvent,
@@ -28,6 +26,7 @@ import type {
 } from "../../api/client-types-chat";
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { useApp } from "../../state/useApp";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { confirmDesktopAction } from "../../utils/desktop-dialogs";
 import {
   isDocumentImageFile,
@@ -425,6 +424,21 @@ export function DocumentsView({
   setActionNoticeRef.current = setActionNotice;
   const [searchQuery, setSearchQuery] = useState("");
   const [scopeFilter, setScopeFilter] = useState<DocumentScopeFilter>("all");
+  // The active view drives the one floating chat composer as its search box:
+  // each keystroke flows in via onQuery, filtering documents in place.
+  const handleSearchQuery = useCallback((value: string) => {
+    setSearchQuery(value);
+    // Clearing the draft drops out of any live search-results view.
+    setSearchResults((prev) => (prev !== null ? null : prev));
+  }, []);
+  const searchBinding = useMemo(
+    () => ({
+      placeholder: t("documents.ui.searchPlaceholder"),
+      onQuery: handleSearchQuery,
+    }),
+    [t, handleSearchQuery],
+  );
+  useRegisterViewChatBinding(searchBinding);
   // Seed from the shared cache so a revisit paints the last-known documents
   // instantly and revalidates silently, instead of flashing a spinner.
   const documentsCacheKey = `documents:list:${scopeFilter}`;
@@ -442,7 +456,6 @@ export function DocumentsView({
     total: number;
     filename: string;
   } | null>(null);
-  const [searching, setSearching] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [internalSelectedDocId, setInternalSelectedDocId] = useState<
     string | null
@@ -988,7 +1001,6 @@ export function DocumentsView({
 
   const handleSearch = useCallback(
     async (query: string) => {
-      setSearching(true);
       try {
         const result = await client.searchDocuments(query, {
           threshold: 0.3,
@@ -1012,8 +1024,6 @@ export function DocumentsView({
           4000,
         );
         setSearchResults([]);
-      } finally {
-        setSearching(false);
       }
     },
     [scopeFilter, setActionNotice, t],
@@ -1130,66 +1140,6 @@ export function DocumentsView({
     </div>
   );
 
-  /* ── Search input ──────────────────────────────────────────────── */
-
-  const { ref: searchRef, agentProps: searchAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "documents-search",
-      role: "text-input",
-      label: t("documents.ui.searchPlaceholder"),
-      group: "documents-toolbar",
-      description: "Search documents by filename, topic, or body text",
-      getValue: () => searchQuery,
-      onFill: (value) => {
-        setSearchQuery(value);
-        if (isShowingSearchResults) {
-          setSearchResults(null);
-        }
-      },
-    });
-
-  const searchInput = (
-    <div className="relative">
-      <input
-        ref={searchRef}
-        {...searchAgentProps}
-        type="text"
-        placeholder={t("documents.ui.searchPlaceholder")}
-        value={searchQuery}
-        onChange={(e) => {
-          setSearchQuery(e.target.value);
-          if (isShowingSearchResults) {
-            setSearchResults(null);
-          }
-        }}
-        autoComplete="off"
-        spellCheck={false}
-        className="w-full rounded-sm border border-border/50 bg-bg px-3 py-2 pl-9 text-sm text-txt placeholder:text-muted/50 focus:border-accent/50 focus:outline-none focus:ring-1 focus:ring-accent/30"
-      />
-      <Search
-        className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted/50"
-        aria-hidden
-      />
-      {(searchQuery || searching) && (
-        <button
-          type="button"
-          aria-label={t("common.clear", { defaultValue: "Clear" })}
-          onClick={() => {
-            setSearchQuery("");
-            setSearchResults(null);
-          }}
-          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-medium text-muted hover:text-txt"
-        >
-          {searching ? (
-            <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-accent border-t-transparent" />
-          ) : (
-            <X className="h-3.5 w-3.5" aria-hidden />
-          )}
-        </button>
-      )}
-    </div>
-  );
-
   const documentContent = (
     <div className="order-2 flex min-w-0 flex-1 lg:order-1">
       <DocumentViewer
@@ -1248,7 +1198,11 @@ export function DocumentsView({
                 })}
           </div>
         </div>
-        {searchInput}
+        <p className="px-1 text-2xs text-muted/70">
+          {t("documents.ui.searchHint", {
+            defaultValue: "Search your documents from the chat below.",
+          })}
+        </p>
         <div className="mt-2">{scopeFilterStrip}</div>
 
         <div className="custom-scrollbar mt-2 flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-0.5 py-0.5">
@@ -1324,7 +1278,11 @@ export function DocumentsView({
       className="flex shrink-0 flex-col gap-2 px-0 py-0 !rounded-none !border-0 !bg-transparent !shadow-none !ring-0"
     >
       <div className="flex flex-col gap-2 md:flex-row md:items-center">
-        <div className="min-w-0 flex-1">{searchInput}</div>
+        <p className="min-w-0 flex-1 text-2xs text-muted/70">
+          {t("documents.ui.searchHint", {
+            defaultValue: "Search your documents from the chat below.",
+          })}
+        </p>
         {fileInputId ? (
           <label
             htmlFor={fileInputId}

--- a/packages/ui/src/components/pages/LogsView.tsx
+++ b/packages/ui/src/components/pages/LogsView.tsx
@@ -2,10 +2,10 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import type { LogEntry } from "../../api";
 import { ContentLayout } from "../../layouts/content-layout/content-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { formatTime } from "../../utils/format";
 import { PagePanel } from "../composites/page-panel";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 import {
   Select,
   SelectContent,
@@ -57,6 +57,16 @@ function LogsViewBody() {
     setState,
     t,
   } = useApp();
+
+  // The floating chat composer becomes this view's search box: while Logs is
+  // open it takes over the composer placeholder and feeds the live draft into
+  // searchQuery via onQuery. setSearchQuery is a stable useState setter.
+  const searchPlaceholder = t("logsview.SearchLogs");
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setSearchQuery }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
 
   useEffect(() => {
     let cancelled = false;
@@ -118,15 +128,6 @@ function LogsViewBody() {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Input
-            type="text"
-            className="min-w-[15rem] flex-1 h-10 rounded-sm border-border/50 bg-bg/80 text-sm text-txt "
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder={t("logsview.SearchLogs")}
-            aria-label={t("aria.searchLogs")}
-          />
-
           <Select
             value={logLevelFilter === "" ? "all" : logLevelFilter}
             onValueChange={(val: string) => {

--- a/packages/ui/src/components/pages/MediaGalleryView.tsx
+++ b/packages/ui/src/components/pages/MediaGalleryView.tsx
@@ -4,6 +4,7 @@ import { useAgentElement } from "../../agent-surface";
 import { client, type QueryResult } from "../../api";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import type { TranslateFn } from "../../types";
 import { resolveAppAssetUrl } from "../../utils";
 import { PagePanel } from "../composites/page-panel";
@@ -13,7 +14,6 @@ import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 
 type MediaType = "all" | "image" | "video" | "audio";
 
@@ -272,15 +272,14 @@ export function MediaGalleryView({
   const [search, setSearch] = useState("");
   const [selectedMediaUrl, setSelectedMediaUrl] = useState<string | null>(null);
 
-  const searchField = useAgentElement<HTMLInputElement>({
-    id: "search",
-    role: "text-input",
-    label: t("mediagalleryview.SearchMedia"),
-    group: "media-filters",
-    description: "Search media by filename or URL",
-    getValue: () => search,
-    onFill: (value) => setSearch(value),
-  });
+  // The floating chat IS the search box for this view. Stable binding
+  // (setSearch is a stable useState setter; placeholder changes only on locale).
+  const searchPlaceholder = t("mediagalleryview.SearchMedia");
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setSearch }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
 
   const loadMedia = useCallback(async () => {
     setLoading(true);
@@ -426,16 +425,6 @@ export function MediaGalleryView({
         </div>
 
         <div className="space-y-3 pt-4">
-          <Input
-            ref={searchField.ref}
-            type="search"
-            placeholder={t("mediagalleryview.SearchMedia")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-10 rounded-sm border-border/40 bg-card/50 text-sm placeholder:text-muted/65 focus-visible:ring-accent/30"
-            {...searchField.agentProps}
-          />
-
           <div className="grid grid-cols-2 gap-1.5">
             {FILTER_CHIPS.map((chip) => (
               <MediaFilterChip

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -11,6 +11,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -29,6 +30,7 @@ import {
   type TranslationContextValue,
   useTranslation,
 } from "../../state/TranslationContext.hooks";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { formatDateTime } from "../../utils/format";
 import { PagePanel } from "../composites/page-panel";
 import { MetaPill } from "../composites/page-panel/page-panel-header";
@@ -380,6 +382,21 @@ function MemoryBrowserPanel({
   const { t } = useTranslation();
   const [searchInput, setSearchInput] = useState("");
   const deferredSearch = useDeferredValue(searchInput);
+
+  // The floating chat IS the memory-text search box while Browse is open (and
+  // not scoped to a person — entity mode has no free-text search). Typing in the
+  // composer drives `searchInput`; the binding clears when the view unmounts.
+  const searchPlaceholder = t("memoryviewer.searchMemoryText", {
+    defaultValue: "Search memory text…",
+  });
+  const chatBinding = useMemo(
+    () =>
+      entityId
+        ? null
+        : { placeholder: searchPlaceholder, onQuery: setSearchInput },
+    [entityId, searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
   // Cache key spans every fetch parameter so each filter/search/page combo
   // revisits instantly without colliding. Offset is appended per-call below.
   const browseKeyBase = entityId
@@ -449,22 +466,6 @@ function MemoryBrowserPanel({
 
   return (
     <div className="space-y-3" data-testid="memory-browser">
-      {!entityId ? (
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted/50" />
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder={t("memoryviewer.searchMemoryText", {
-              defaultValue: "Search memory text…",
-            })}
-            className="h-9 w-full rounded-sm border border-border/32 bg-card/40 pl-9 pr-3 text-sm text-txt placeholder:text-muted/50 focus:border-accent/50 focus:outline-none"
-            data-testid="memory-browser-search"
-          />
-        </div>
-      ) : null}
-
       {loading && !result ? (
         <ListSkeleton rows={6} />
       ) : error ? (

--- a/packages/ui/src/components/pages/PluginsView.tsx
+++ b/packages/ui/src/components/pages/PluginsView.tsx
@@ -14,10 +14,10 @@ import { useLinkedSidebarSelection } from "../../hooks/useLinkedSidebarSelection
 import { useRenderGuard } from "../../hooks/useRenderGuard";
 import { PageLayoutHeader } from "../../layouts/page-layout/page-layout-header";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { openExternalUrl } from "../../utils";
 import { PagePanel } from "../composites/page-panel";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 import { PluginCard } from "./PluginCard";
 import {
   buildPluginListState,
@@ -76,6 +76,23 @@ function PluginListView({
     setState,
     t,
   } = useApp();
+
+  // The floating chat composer is this view's search box. While Plugins is the
+  // active view it takes over the composer (placeholder + live draft) and feeds
+  // each keystroke into the shared `pluginSearch` filter — there's no in-page
+  // search input.
+  const searchPlaceholder = t("pluginsview.SearchPlaceholder", {
+    defaultValue: "Search plugins…",
+  });
+  const handleSearchQuery = useCallback(
+    (value: string) => setState("pluginSearch", value),
+    [setState],
+  );
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: handleSearchQuery }),
+    [searchPlaceholder, handleSearchQuery],
+  );
+  useRegisterViewChatBinding(chatBinding);
 
   const [pluginConfigs, setPluginConfigs] = useState<
     Record<string, Record<string, string>>
@@ -1284,18 +1301,11 @@ function PluginListView({
                 </span>
               </div>
 
-              <div className="mt-4 max-w-md">
-                <Input
-                  type="search"
-                  value={pluginSearch}
-                  onChange={(e) => setState("pluginSearch", e.target.value)}
-                  placeholder={t("pluginsview.SearchPlaceholder", {
-                    defaultValue: "Search plugins…",
-                  })}
-                  className="h-9 rounded-full border-border/50 bg-card/50 px-4 text-sm backdrop-blur-sm"
-                  data-testid="plugins-search"
-                />
-              </div>
+              <p className="mt-2 text-xs-tight text-muted">
+                {t("pluginsview.SearchHint", {
+                  defaultValue: "Type in the chat below to search plugins.",
+                })}
+              </p>
 
               {showSubgroupFilters && subgroupTags.length > 1 && (
                 <div

--- a/packages/ui/src/components/pages/ViewCatalog.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.tsx
@@ -20,7 +20,6 @@ import {
   Pin,
   Plus,
   RefreshCw,
-  Search,
   Sparkles,
   Trash2,
 } from "lucide-react";
@@ -46,6 +45,7 @@ import {
 } from "../../platform/platform-guards";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useIsDeveloperMode } from "../../state/useDeveloperMode";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import {
   readRecentViewIds,
   recordRecentViewId,
@@ -794,17 +794,20 @@ export function ViewCatalog() {
   const [searchLoading, setSearchLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const searchInput = useAgentElement<HTMLInputElement>({
-    id: "views-search-input",
-    role: "text-input",
-    label: t("viewmanager.searchPlaceholder", {
-      defaultValue: "Search views…",
-    }),
-    group: "views-toolbar",
-    description: "Search the registered views by name, description, or tag",
-    getValue: () => query,
-    onFill: (value) => setQuery(value),
+  // The floating chat composer IS the search box for this view: while it's open
+  // it takes over the composer placeholder and receives the live draft via
+  // onQuery, feeding the same `query` state the filtering below reads. setQuery
+  // (a useState setter) is stable, so the binding only re-registers if the
+  // localized placeholder string changes.
+  const searchPlaceholder = t("viewmanager.searchPlaceholder", {
+    defaultValue: "Search views…",
   });
+  const chatSearchBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setQuery }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatSearchBinding);
+
   const formIdInput = useAgentElement<HTMLInputElement>({
     id: "views-form-id",
     role: "text-input",
@@ -1184,20 +1187,11 @@ export function ViewCatalog() {
               </div>
             </div>
 
-            <div className="relative min-w-0">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
-              <input
-                ref={searchInput.ref}
-                type="search"
-                placeholder={t("viewmanager.searchPlaceholder", {
-                  defaultValue: "Search views…",
-                })}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                className="h-12 w-full rounded-lg border border-border bg-card py-2 pl-10 pr-3 text-base text-txt placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-ring"
-                {...searchInput.agentProps}
-              />
-            </div>
+            <p className="text-sm text-muted">
+              {t("viewmanager.searchHint", {
+                defaultValue: "Type in the chat below to search your views.",
+              })}
+            </p>
           </div>
         </div>
 

--- a/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
@@ -1,17 +1,10 @@
-import {
-  Filter,
-  Network,
-  RefreshCw,
-  Search,
-  Sparkles,
-  UserRound,
-  X,
-} from "lucide-react";
+import { Filter, Network, RefreshCw, Sparkles, UserRound } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -23,6 +16,7 @@ import type {
 } from "../../../api/client-types-relationships";
 import { PageLayout } from "../../../layouts/page-layout/page-layout";
 import { useApp } from "../../../state/useApp";
+import { useRegisterViewChatBinding } from "../../../state/view-chat-binding";
 import { PagePanel } from "../../composites/page-panel";
 import { Button } from "../../ui/button";
 import { RelationshipsGraphPanel } from "../RelationshipsGraphPanel";
@@ -65,6 +59,15 @@ export function RelationshipsWorkspaceView({
   const [detail, setDetail] = useState<RelationshipsPersonDetail | null>(null);
   const graphRequestId = useRef(0);
   const deferredSearch = useDeferredValue(search);
+
+  const searchPlaceholder = t("relationships.searchPlaceholder", {
+    defaultValue: "Search",
+  });
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setSearch }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
 
   const loadGraph = useCallback(
     async (query = buildRelationshipsGraphQuery("", "all")) => {
@@ -182,7 +185,7 @@ export function RelationshipsWorkspaceView({
     void loadGraph(buildRelationshipsGraphQuery(deferredSearch, platform));
   };
 
-  const searchAgent = useAgentElement<HTMLInputElement>({
+  useAgentElement<HTMLInputElement>({
     id: "relationships-search",
     role: "text-input",
     label: t("relationships.searchLabel", {
@@ -194,7 +197,7 @@ export function RelationshipsWorkspaceView({
     getValue: () => search,
     onFill: (value) => setSearch(value),
   });
-  const clearSearchAgent = useAgentElement<HTMLButtonElement>({
+  useAgentElement<HTMLButtonElement>({
     id: "relationships-clear-search",
     role: "button",
     label: t("relationships.clearSearch", {
@@ -232,51 +235,10 @@ export function RelationshipsWorkspaceView({
         <div
           className={
             embedded
-              ? "grid min-w-0 gap-2 md:grid-cols-[minmax(16rem,1fr)_minmax(12rem,14rem)_auto]"
+              ? "grid min-w-0 gap-2 md:grid-cols-[minmax(12rem,14rem)_auto]"
               : "flex min-w-0 flex-col gap-2 sm:flex-row sm:justify-end"
           }
         >
-          {embedded ? (
-            <>
-              <label className="sr-only" htmlFor="relationships-search">
-                {t("relationships.searchLabel", {
-                  defaultValue: "Search people, aliases, handles",
-                })}
-              </label>
-              <div className="relative min-w-0 flex-1">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
-                <input
-                  ref={searchAgent.ref}
-                  id="relationships-search"
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  placeholder={t("relationships.searchPlaceholder", {
-                    defaultValue: "Search",
-                  })}
-                  aria-label={t("relationships.searchLabel", {
-                    defaultValue: "Search people, aliases, handles",
-                  })}
-                  className="h-9 w-full rounded-sm border border-border/35 bg-card/45 pl-9 pr-10 text-sm text-txt outline-none transition focus:border-accent/55"
-                  {...searchAgent.agentProps}
-                />
-                {search ? (
-                  <button
-                    ref={clearSearchAgent.ref}
-                    type="button"
-                    className="absolute right-1.5 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted transition hover:bg-bg-hover hover:text-txt"
-                    onClick={() => setSearch("")}
-                    aria-label={t("relationships.clearSearch", {
-                      defaultValue: "Clear relationship search",
-                    })}
-                    {...clearSearchAgent.agentProps}
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-
           <div className="relative min-w-0">
             <label className="sr-only" htmlFor="relationships-platform">
               {t("relationships.platformFilter", {

--- a/packages/ui/src/components/pages/skill-detail-panel.tsx
+++ b/packages/ui/src/components/pages/skill-detail-panel.tsx
@@ -10,6 +10,7 @@ import { useAgentElement } from "../../agent-surface";
 import type { SkillInfo } from "../../api";
 import { client } from "../../api";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import {
   AdminCodeEditor,
   AdminDialogContent,
@@ -18,7 +19,6 @@ import {
 } from "../ui/admin-dialog";
 import { Button } from "../ui/button";
 import { Dialog, DialogDescription, DialogTitle } from "../ui/dialog";
-import { Input } from "../ui/input";
 import { InstallModal } from "./skill-marketplace";
 
 const BINANCE_SKILL_IDS = new Set([
@@ -289,6 +289,15 @@ export function SkillsModalView() {
   const [editingSkill, setEditingSkill] = useState<SkillInfo | null>(null);
   const [installModalOpen, setInstallModalOpen] = useState(false);
 
+  const searchPlaceholder = t("skillsview.SearchSkills", {
+    defaultValue: "Search skills...",
+  });
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setFilterText }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
+
   useEffect(() => {
     void loadSkills();
   }, [loadSkills]);
@@ -346,18 +355,6 @@ export function SkillsModalView() {
         </div>
         <div className="plugins-game-list-search">
           <div className="plugins-game-list-search-row">
-            <Input
-              type="text"
-              placeholder={t("skillsview.SearchSkills", {
-                defaultValue: "Search skills...",
-              })}
-              aria-label={t("skillsview.SearchSkills", {
-                defaultValue: "Search skills",
-              })}
-              value={filterText}
-              onChange={(e) => setFilterText(e.target.value)}
-              className="plugins-game-search-input"
-            />
             <Button
               variant="default"
               size="sm"


### PR DESCRIPTION
Extends the view→chat-binding pattern (introduced for Help) to **every page view that had its own in-page search box**. When one of these views is active it takes over the floating chat composer — overriding the placeholder and receiving the live draft via `onQuery` — so a single, consistent surface drives search instead of a per-view input box.

## Migrated (8) — in-page search input removed, binding registered, filtering kept
`ViewCatalog` · `LogsView` · `MemoryViewerView` · `MediaGalleryView` · `PluginsView` · `skill-detail-panel` (skills list) · `RelationshipsWorkspaceView` · `DocumentsView`

## Deliberately NOT migrated (a single global chat binding doesn't fit)
- **SecretsView** — its only text input is the add-secret *form*, not a list filter.
- **ElizaOsAppsView** — three independently-routed AOSP page views (Phone/Messages/Contacts), each with its own search context.
- **skill-marketplace** — its keyword search lives inside a transient Install **Dialog**, not an in-shell list.

## Preserved everywhere
Form fields and dropdown/select filters are untouched: level/source/tag/scope/platform filters, the file-upload input, add-secret, view-id, and github-url fields.

## Verification
- `packages/ui` typecheck: **clean** (zero errors in the migrated files).
- Biome: **clean** on all 9 changed files.
- Each migration was **adversarially reviewed** by an independent agent (binding stability/no re-registration loop, onQuery wired to the original setter, input fully removed, filtering intact, other inputs preserved, no unused imports).
- Updated the plugins e2e (`apps-builtin-pages-interactions.spec.ts`) to drive search through the chat composer (the `plugins-search` testid is gone); the chat-driven-search pattern itself is already e2e-proven by the Help walkthrough.

Net −84 lines (search boxes replaced by compact bindings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)