### PR TITLE
fix(cloud-frontend): dashboard pages scroll again (canvas-only viewport clamp)

### DIFF
--- a/packages/cloud-frontend/src/App.tsx
+++ b/packages/cloud-frontend/src/App.tsx
@@ -197,12 +197,6 @@ const CanvasLayout = lazy(() =>
   })),
 );
 
-const CloudAssistantPill = lazy(() =>
-  import("./components/canvas/cloud-assistant-pill").then((m) => ({
-    default: m.CloudAssistantPill,
-  })),
-);
-
 /**
  * Map of React Router path pattern → preload function. Hovering or focusing
  * a link with an `href` matching one of these routes warms the matched branch
@@ -561,10 +555,19 @@ function DashboardRouteElement() {
       )}
     >
       <Suspense fallback={<RouteChunkFallback />}>
-        <div className="relative h-dvh w-full overflow-hidden">
-          {canvasOpen ? <CanvasLayout /> : <DashboardLayout />}
-          {!canvasOpen && <CloudAssistantPill />}
-        </div>
+        {canvasOpen ? (
+          // The canvas is a fixed-viewport WebGL stage: clamp it to the dvh and
+          // clip overflow so it never scrolls the document behind it.
+          <div className="relative h-dvh w-full overflow-hidden">
+            <CanvasLayout />
+          </div>
+        ) : (
+          // Classic dashboard: render bare so the shell's natural `min-h-dvh`
+          // body flow is preserved and long pages (the agents grid, billing,
+          // analytics, …) scroll. Wrapping it in `h-dvh overflow-hidden` clipped
+          // every long page — that was the no-scroll bug.
+          <DashboardLayout />
+        )}
       </Suspense>
     </RouteErrorBoundary>
   );


### PR DESCRIPTION
Prod ship of the dashboard scroll fix (already on develop via #8596). Renders the `h-dvh overflow-hidden` clamp only in canvas mode so the classic dashboard's natural body-scroll works on every long page (/dashboard/agents, billing, analytics, admin); drops the orphaned CloudAssistantPill that 404'd on /api/v1/genui. typecheck 0, lint clean, build green, audit:cloud visual gate passed (all 38 routes). Deploying so it reaches elizacloud.ai.