### PR TITLE
feat(ui): chat-driven search for the remaining views (sidebars + standalone)

### DIFF
--- a/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-builtin-pages-interactions.spec.ts
@@ -126,11 +126,13 @@ test("trajectories view loads and search re-queries", async ({ page }) => {
   });
   await expect.poll(trajReqs).toBeGreaterThan(0);
 
+  // Search runs through the floating chat composer now (the view overrides its
+  // placeholder); typing re-queries the trajectories list.
   const before = trajReqs();
-  const search = page
-    .getByTestId("trajectories-sidebar")
-    .getByRole("textbox")
-    .first();
+  const search = page.getByTestId("chat-composer-textarea");
+  await expect(search).toHaveAttribute("placeholder", /search/i, {
+    timeout: 15_000,
+  });
   await search.fill("smoke-query");
   await expect.poll(trajReqs).toBeGreaterThan(before);
 });

--- a/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
@@ -1066,9 +1066,9 @@ test("trajectory viewer route refreshes, filters, and changes selected detail", 
   ).toBeVisible();
 
   sidebar = await openVisiblePageSidebar(page, "trajectories-sidebar");
-  await sidebar
-    .getByPlaceholder(uiLabelPattern("Search", "trajectoriesview.Search"))
-    .fill("beta");
+  // The trajectories search moved to the floating chat composer; the sidebar
+  // stays open to show the (re-queried) list.
+  await page.getByTestId("chat-composer-textarea").fill("beta");
   await expect.poll(() => recorder.listRequests().at(-1)?.search).toBe("beta");
   await expect(sidebar.getByText("scenario-beta")).toBeVisible();
   await expect(sidebar.getByText("scenario-alpha")).toHaveCount(0);

--- a/packages/ui/src/components/pages/DatabaseView.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.tsx
@@ -20,15 +20,14 @@ import {
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { PagePanel } from "../composites/page-panel";
 import { MetaPill } from "../composites/page-panel/page-panel-header";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 import { SegmentedControl } from "../ui/segmented-control";
 import { TableSkeleton } from "../ui/skeleton-layouts";
 import {
@@ -319,6 +318,16 @@ export function DatabaseView({
     [tables, sidebarSearch],
   );
 
+  // The floating chat composer is this view's table filter. While Database is
+  // the active view it takes over the composer (placeholder + live draft) and
+  // feeds each keystroke into `sidebarSearch` — there's no in-page filter input.
+  const filterPlaceholder = t("databaseview.FilterTables");
+  const chatBinding = useMemo(
+    () => ({ placeholder: filterPlaceholder, onQuery: setSidebarSearch }),
+    [filterPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
+
   const handleRefresh = useCallback(async () => {
     const status = await loadStatus();
     if (status?.connected) {
@@ -333,16 +342,6 @@ export function DatabaseView({
     group: "database-actions",
     description: "Reload the database status and table list",
     onActivate: handleRefresh,
-  });
-
-  const filterSearch = useAgentElement<HTMLInputElement>({
-    id: "filter-tables",
-    role: "text-input",
-    label: t("databaseview.FilterTables"),
-    group: "database-actions",
-    description: "Filter the table list by name",
-    getValue: () => sidebarSearch,
-    onFill: (value) => setSidebarSearch(value),
   });
 
   const editorModes: Array<{ value: DbView; label: string }> = [
@@ -443,15 +442,6 @@ export function DatabaseView({
           </SidebarContent.RailItem>
         ))}
       >
-        <SidebarHeader
-          search={{
-            value: sidebarSearch,
-            onChange: (e) => setSidebarSearch(e.target.value),
-            placeholder: t("databaseview.FilterTables"),
-            "aria-label": t("databaseview.FilterTables"),
-            onClear: () => setSidebarSearch(""),
-          }}
-        />
         <SidebarPanel>
           <div className="space-y-3 pt-1">
             {leftNav}
@@ -800,17 +790,6 @@ export function DatabaseView({
                   </>
                 )}
 
-                <div className="relative">
-                  <Input
-                    ref={filterSearch.ref}
-                    {...filterSearch.agentProps}
-                    type="text"
-                    placeholder={t("databaseview.FilterTables")}
-                    value={sidebarSearch}
-                    onChange={(e) => setSidebarSearch(e.target.value)}
-                    className="w-full pr-8 text-xs h-10 rounded-sm border-border/34 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_84%,transparent),color-mix(in_srgb,var(--bg)_95%,transparent))] text-sm focus-visible:border-accent/28 focus-visible:ring-1 focus-visible:ring-accent/24 "
-                  />
-                </div>
                 <div className="text-2xs text-muted uppercase font-bold tracking-widest px-2 bg-bg/50 py-1.5 rounded-sm border border-border/30 inline-flex items-center ">
                   {t("databaseview.Tables")} ({filteredTables.length})
                 </div>

--- a/packages/ui/src/components/pages/HeartbeatsView.tsx
+++ b/packages/ui/src/components/pages/HeartbeatsView.tsx
@@ -13,6 +13,7 @@ import { useAgentElement } from "../../agent-surface";
 import type { TriggerSummary } from "../../api/client";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { confirmDesktopAction } from "../../utils";
 import { formatDateTime, formatDurationMs } from "../../utils/format";
 import { detectUiHostCapabilities } from "../../utils/host-capabilities";
@@ -22,7 +23,6 @@ import { WidgetHost } from "../../widgets/WidgetHost";
 import { PagePanel } from "../composites/page-panel";
 import { SidebarCollapsedActionButton } from "../composites/sidebar/sidebar-collapsed-rail";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
@@ -478,6 +478,14 @@ function HeartbeatsLayout() {
   const searchLabel = t("heartbeatsview.searchHeartbeats", {
     defaultValue: "Search heartbeats",
   });
+  // The floating chat composer is this view's search box. While Heartbeats is
+  // the active view it takes over the composer (placeholder + live draft) and
+  // feeds each keystroke into the `searchQuery` filter — no in-page search input.
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchLabel, onQuery: setSearchQuery }),
+    [searchLabel],
+  );
+  useRegisterViewChatBinding(chatBinding);
   const noMatchingHeartbeatsLabel = t("heartbeatsview.noMatchingHeartbeats", {
     defaultValue: "No matching heartbeats",
   });
@@ -617,19 +625,6 @@ function HeartbeatsLayout() {
       expandButtonTestId="heartbeats-sidebar-expand-toggle"
       collapseButtonAriaLabel="Collapse heartbeats"
       expandButtonAriaLabel="Expand heartbeats"
-      header={
-        <SidebarHeader
-          search={{
-            value: searchQuery,
-            onChange: (event) => setSearchQuery(event.target.value),
-            onClear: () => setSearchQuery(""),
-            placeholder: searchLabel,
-            "aria-label": searchLabel,
-            autoComplete: "off",
-            spellCheck: false,
-          }}
-        />
-      }
       collapsedRailAction={
         <SidebarCollapsedActionButton
           aria-label={newHeartbeatLabel}

--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -15,11 +16,11 @@ import {
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { formatDateTime } from "../../utils/format";
 import { PagePanel } from "../composites/page-panel";
 import { MetaPill } from "../composites/page-panel/page-panel-header";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
@@ -499,25 +500,24 @@ export function RuntimeView({
       )
     : SECTION_TAB_KEYS;
 
+  // The floating chat composer becomes this view's section filter: while Runtime
+  // is open it takes over the composer placeholder and feeds the live draft into
+  // sidebarSearch via onQuery. setSidebarSearch is a stable useState setter.
+  const filterPlaceholder = t("runtimeview.filterSections", {
+    defaultValue: "Filter sections",
+  });
+  const chatBinding = useMemo(
+    () => ({ placeholder: filterPlaceholder, onQuery: setSidebarSearch }),
+    [filterPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
+
   const runtimeSidebar = (
     <AppPageSidebar
       testId="runtime-sidebar"
       collapsible
       contentIdentity="runtime"
     >
-      <SidebarHeader
-        search={{
-          value: sidebarSearch,
-          onChange: (e) => setSidebarSearch(e.target.value),
-          placeholder: t("runtimeview.filterSections", {
-            defaultValue: "Filter sections",
-          }),
-          "aria-label": t("runtimeview.filterSections", {
-            defaultValue: "Filter sections",
-          }),
-          onClear: () => setSidebarSearch(""),
-        }}
-      />
       <SidebarPanel>
         <PagePanel.SummaryCard compact className="mt-2 space-y-2">
           <label

--- a/packages/ui/src/components/pages/SkillsView.test.tsx
+++ b/packages/ui/src/components/pages/SkillsView.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -9,6 +10,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillInfo } from "../../api";
+import { getViewChatBinding } from "../../state/view-chat-binding";
 import { SkillsView } from "./SkillsView";
 
 // SkillsView reads all of its data + handlers from the app context (useApp).
@@ -147,8 +149,11 @@ describe("SkillsView", () => {
 
     render(<SkillsView />);
 
-    const search = screen.getByLabelText("skillsview.filterSkills");
-    fireEvent.change(search, { target: { value: "zzz-no-match" } });
+    // Search is driven by the floating chat composer now (SkillsView registers a
+    // view→chat binding); drive its onQuery the way the composer would.
+    act(() => {
+      getViewChatBinding()?.onQuery?.("zzz-no-match");
+    });
 
     expect(screen.queryByTestId("skill-row-skill-alpha")).toBeNull();
     expect(screen.getByTestId("skills-filter-empty")).toBeTruthy();

--- a/packages/ui/src/components/pages/SkillsView.tsx
+++ b/packages/ui/src/components/pages/SkillsView.tsx
@@ -4,9 +4,9 @@ import { useAgentElement } from "../../agent-surface";
 import type { SkillInfo } from "../../api";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { PagePanel } from "../composites/page-panel";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { SkillSidebarItem } from "../composites/skills/skill-sidebar-item";
@@ -168,6 +168,18 @@ function SkillsFullView({ contentHeader }: { contentHeader?: ReactNode } = {}) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [editingSkill, setEditingSkill] = useState<SkillInfo | null>(null);
 
+  // The floating chat composer is this view's search box. While Skills is the
+  // active view it takes over the composer (placeholder + live draft) and feeds
+  // each keystroke into the `filterText` filter — there's no in-page search input.
+  const searchPlaceholder = t("skillsview.SearchSkills", {
+    defaultValue: "Search skills…",
+  });
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery: setFilterText }),
+    [searchPlaceholder],
+  );
+  useRegisterViewChatBinding(chatBinding);
+
   useEffect(() => {
     void loadSkills();
   }, [loadSkills]);
@@ -230,16 +242,6 @@ function SkillsFullView({ contentHeader }: { contentHeader?: ReactNode } = {}) {
     selectedSkill?.scanStatus === "warning" ||
     selectedSkill?.scanStatus === "critical" ||
     selectedSkill?.scanStatus === "blocked";
-
-  const filterSearch = useAgentElement<HTMLInputElement>({
-    id: "filter-search",
-    role: "text-input",
-    label: t("skillsview.filterSkills", { defaultValue: "Filter skills" }),
-    group: "skills-toolbar",
-    description: "Filter the skills list by name or description",
-    getValue: () => filterText,
-    onFill: (value) => setFilterText(value),
-  });
 
   const newSkillButton = useAgentElement<HTMLButtonElement>({
     id: "new-skill",
@@ -361,16 +363,6 @@ function SkillsFullView({ contentHeader }: { contentHeader?: ReactNode } = {}) {
         );
       })}
     >
-      <SidebarHeader
-        search={{
-          value: filterText,
-          onChange: (event) => setFilterText(event.target.value),
-          placeholder: t("skillsview.filterSkills"),
-          "aria-label": t("skillsview.filterSkills"),
-          onClear: () => setFilterText(""),
-          ...filterSearch.agentProps,
-        }}
-      />
       <SidebarScrollRegion>
         <SidebarPanel>
           <SidebarContent.Toolbar className="mb-3">

--- a/packages/ui/src/components/pages/TrajectoriesView.tsx
+++ b/packages/ui/src/components/pages/TrajectoriesView.tsx
@@ -24,6 +24,7 @@ import type {
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useApp } from "../../state/useApp";
+import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import {
   formatTrajectoryDuration,
   formatTrajectoryTimestamp,
@@ -31,7 +32,6 @@ import {
 } from "../../utils/trajectory-format";
 import { PagePanel } from "../composites/page-panel";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { TrajectorySidebarItem } from "../composites/trajectories/trajectory-sidebar-item";
@@ -115,6 +115,22 @@ export function TrajectoriesView({
   const [page, setPage] = useState(0);
   const pageSize = 50;
   const previousSearchQueryRef = useRef(searchQuery);
+
+  // The one floating chat composer is this view's search box: typing in it
+  // drives `searchQuery` (which re-queries via `loadTrajectories`) and resets
+  // pagination. The binding clears when the view unmounts.
+  const searchPlaceholder = t("trajectoriesview.Search", {
+    defaultValue: "Search...",
+  });
+  const onQuery = useCallback((value: string) => {
+    setSearchQuery(value);
+    setPage(0);
+  }, []);
+  const chatBinding = useMemo(
+    () => ({ placeholder: searchPlaceholder, onQuery }),
+    [searchPlaceholder, onQuery],
+  );
+  useRegisterViewChatBinding(chatBinding);
 
   // Seed from the shared cache so a revisit paints the last-known page
   // instantly and revalidates silently, instead of flashing a spinner. The
@@ -373,23 +389,6 @@ export function TrajectoriesView({
       aria-label={t("trajectoriesview.Entries", {
         defaultValue: "Entries",
       })}
-      header={
-        <SidebarHeader
-          search={{
-            value: searchQuery,
-            onChange: (event) => {
-              setSearchQuery(event.target.value);
-              setPage(0);
-            },
-            onClear: () => {
-              setSearchQuery("");
-              setPage(0);
-            },
-            placeholder: t("trajectoriesview.Search"),
-            "aria-label": t("trajectoriesview.Search"),
-          }}
-        />
-      }
     >
       <SidebarScrollRegion>
         <SidebarPanel>

--- a/packages/ui/src/components/pages/plugin-view-sidebar.tsx
+++ b/packages/ui/src/components/pages/plugin-view-sidebar.tsx
@@ -3,7 +3,6 @@ import type { ReactNode, RefCallback, RefObject } from "react";
 import { useAgentElement } from "../../agent-surface";
 import type { PluginInfo } from "../../api";
 import { SidebarContent } from "../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../composites/sidebar/sidebar-scroll-region";
 import { getBrandIcon } from "../conversations/brand-icons";
@@ -217,8 +216,6 @@ interface ConnectorDesktopSidebarProps {
   visiblePlugins: PluginInfo[];
   onConnectorSelect: (pluginId: string) => void;
   onConnectorSectionToggle: (pluginId: string) => void;
-  onSearchChange: (value: string) => void;
-  onSearchClear: () => void;
   onSubgroupFilterChange: (value: string) => void;
   onTogglePlugin: (pluginId: string, enabled: boolean) => Promise<void>;
 }
@@ -244,8 +241,6 @@ export function ConnectorSidebar({
   visiblePlugins,
   onConnectorSelect,
   onConnectorSectionToggle,
-  onSearchChange,
-  onSearchClear,
   onSubgroupFilterChange,
   onTogglePlugin,
 }: ConnectorDesktopSidebarProps) {
@@ -265,8 +260,6 @@ export function ConnectorSidebar({
 
   if (!desktopConnectorLayout) return null;
 
-  const sidebarSearchLabel =
-    mode === "social" ? "Search connectors" : "Search plugins";
   const filterSelectLabel =
     subgroupTags.find((tag) => tag.id === subgroupFilter)?.label ?? "All";
   const hasActivePluginFilters =
@@ -278,17 +271,6 @@ export function ConnectorSidebar({
       testId="connectors-settings-sidebar"
       collapsible
       contentIdentity={mode === "social" ? "connectors" : "plugins"}
-      header={
-        <SidebarHeader
-          search={{
-            value: pluginSearch,
-            onChange: (event) => onSearchChange(event.target.value),
-            onClear: onSearchClear,
-            placeholder: sidebarSearchLabel,
-            "aria-label": sidebarSearchLabel,
-          }}
-        />
-      }
       collapsedRailItems={visiblePlugins.map((plugin) => {
         const isSelected = connectorSelectedId === plugin.id;
         const RailBrandIcon = getBrandIcon(plugin.id);

--- a/packages/ui/src/components/pages/relationships/RelationshipsSidebar.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsSidebar.tsx
@@ -1,24 +1,17 @@
 import { Crown } from "lucide-react";
 import type { RelationshipsGraphSnapshot } from "../../../api/client-types-relationships";
 import { SidebarContent } from "../../composites/sidebar/sidebar-content";
-import { SidebarHeader } from "../../composites/sidebar/sidebar-header";
 import { SidebarPanel } from "../../composites/sidebar/sidebar-panel";
 import { SidebarScrollRegion } from "../../composites/sidebar/sidebar-scroll-region";
 import { AppPageSidebar } from "../../shared/AppPageSidebar";
 
 export function RelationshipsSidebar({
-  search,
   graph,
   selectedPersonId,
-  onSearchChange,
-  onSearchClear,
   onSelectPersonId,
 }: {
-  search: string;
   graph: RelationshipsGraphSnapshot | null;
   selectedPersonId: string | null;
-  onSearchChange: (value: string) => void;
-  onSearchClear: () => void;
   onSelectPersonId: (personId: string) => void;
 }) {
   return (
@@ -27,15 +20,6 @@ export function RelationshipsSidebar({
       collapsible
       contentIdentity="relationships"
     >
-      <SidebarHeader
-        search={{
-          value: search,
-          onChange: (event) => onSearchChange(event.target.value),
-          placeholder: "Search",
-          "aria-label": "Search people",
-          onClear: onSearchClear,
-        }}
-      />
       <SidebarPanel>
         <SidebarScrollRegion className="mt-2">
           <div className="space-y-1">

--- a/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
@@ -61,7 +61,7 @@ export function RelationshipsWorkspaceView({
   const deferredSearch = useDeferredValue(search);
 
   const searchPlaceholder = t("relationships.searchPlaceholder", {
-    defaultValue: "Search",
+    defaultValue: "Search people, aliases, handles…",
   });
   const chatBinding = useMemo(
     () => ({ placeholder: searchPlaceholder, onQuery: setSearch }),
@@ -185,27 +185,6 @@ export function RelationshipsWorkspaceView({
     void loadGraph(buildRelationshipsGraphQuery(deferredSearch, platform));
   };
 
-  useAgentElement<HTMLInputElement>({
-    id: "relationships-search",
-    role: "text-input",
-    label: t("relationships.searchLabel", {
-      defaultValue: "Search people, aliases, handles",
-    }),
-    group: "relationships-toolbar",
-    description:
-      "Search people, aliases, and handles in the relationships graph",
-    getValue: () => search,
-    onFill: (value) => setSearch(value),
-  });
-  useAgentElement<HTMLButtonElement>({
-    id: "relationships-clear-search",
-    role: "button",
-    label: t("relationships.clearSearch", {
-      defaultValue: "Clear relationship search",
-    }),
-    group: "relationships-toolbar",
-    onActivate: () => setSearch(""),
-  });
   const platformAgent = useAgentElement<HTMLSelectElement>({
     id: "relationships-platform",
     role: "select",
@@ -471,11 +450,8 @@ export function RelationshipsWorkspaceView({
     <PageLayout
       sidebar={
         <RelationshipsSidebar
-          search={search}
           graph={graph}
           selectedPersonId={selectedPersonId}
-          onSearchChange={setSearch}
-          onSearchClear={() => setSearch("")}
           onSelectPersonId={setSelectedPersonId}
         />
       }

--- a/packages/ui/src/state/view-chat-binding.ts
+++ b/packages/ui/src/state/view-chat-binding.ts
@@ -41,6 +41,11 @@ export function setViewChatBinding(binding: ViewChatBinding | null): void {
   for (const l of s.listeners) l();
 }
 
+/** Read the active binding imperatively (for tests / non-React callers). */
+export function getViewChatBinding(): ViewChatBinding | null {
+  return store().current;
+}
+
 export function useViewChatBinding(): ViewChatBinding | null {
   const s = store();
   return React.useSyncExternalStore(


### PR DESCRIPTION
Round 2 / follow-up to #8597 — finishes making the floating chat the single search surface, covering views whose search was rendered via the shared `SidebarHeader search={{…}}` prop (which the first pass, looking only for raw `<input>`s, missed).

## Completed parent/child pairs (search state now *only* chat-driven)
- **PluginsView / plugin-view-sidebar** and **RelationshipsWorkspaceView / RelationshipsSidebar** — the child sidebars no longer render a search input; the now-unused `search`/`onSearchChange` props and dead `useAgentElement` search instrumentation were removed. The parent (already registering the binding in #8597) is the single owner.

## Migrated standalone views
- **DatabaseView** (table filter — both the SidebarHeader search *and* the duplicate Input), **TrajectoriesView** (server re-query), **HeartbeatsView**, **RuntimeView**, **SkillsView**.

Each registers exactly one stable view→chat binding wired to its existing setter. Filtering/re-query and every non-search control (SQL editor, platform/type/scope selects, create forms, file upload) are preserved.

## Tests
- Added `getViewChatBinding()` so non-React callers/tests can drive the binding; updated `SkillsView.test` to use it (**5/5 green**).
- Re-pointed the two trajectories e2e specs (`apps-builtin-pages-interactions`, `apps-model-training-interactions`) at the chat composer — the removed `trajectories-sidebar` search selectors are gone.
- `packages/ui` typecheck clean, biome clean, each migration adversarially reviewed.

Net −81 lines. Reverted an incidental unrelated reformat the migration touched in `plugin-trajectory-logger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)