### PR TITLE
fix(plugin-commands): complete connector-catalog API so build:core passes (unblocks prod deploy)

### DIFF
--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -7,7 +7,14 @@
  * plugin file should clone before mutating to avoid cross-agent contamination.
  */
 
-import type { CommandDefinition } from "./types";
+import { NAVIGATION_COMMANDS } from "./navigation-commands";
+import type {
+	CommandCategory,
+	CommandDefinition,
+	CommandScope,
+	CommandSurface,
+	CommandTarget,
+} from "./types";
 
 // Default command definitions (frozen reference — never mutate these directly)
 export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
@@ -97,6 +104,10 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "session",
 		acceptsArgs: false,
+		// Client-side action (new conversation in the UI) — no agent round-trip,
+		// and no connector surface, so chat connectors don't expose it.
+		surfaces: ["gui", "tui"],
+		target: { kind: "client", clientAction: "new-conversation" },
 	},
 	{
 		key: "compact",
@@ -332,7 +343,11 @@ let activeStore: CommandStore = fallbackStore;
  */
 export function initForRuntime(agentId: string): void {
 	const store: CommandStore = {
-		commands: DEFAULT_COMMANDS.map((c) => ({ ...c })),
+		// Agent-capability commands + the surface-agnostic navigation/client
+		// catalog form one registry (keys are disjoint between the two sets).
+		commands: [...DEFAULT_COMMANDS, ...NAVIGATION_COMMANDS].map((c) => ({
+			...c,
+		})),
 		aliasMap: null,
 	};
 	runtimeStores.set(agentId, store);
@@ -466,4 +481,96 @@ export function startsWithCommand(text: string): CommandDefinition | undefined {
 	}
 
 	return undefined;
+}
+
+/** A command arg projected to a JSON-safe shape (function choices resolved out). */
+export interface SerializedCommandArg {
+	name: string;
+	description: string;
+	required: boolean;
+	/** Static choices only; `undefined` for function-resolved (`dynamicChoices`) args. */
+	choices: string[] | undefined;
+	dynamicChoices: string | undefined;
+	captureRemaining: boolean | undefined;
+}
+
+/** A command projected to a plain, JSON-round-trippable shape connectors read. */
+export interface SerializedCommand {
+	key: string;
+	nativeName: string;
+	description: string;
+	textAliases: string[];
+	scope: CommandScope;
+	category: CommandCategory | undefined;
+	acceptsArgs: boolean;
+	args: SerializedCommandArg[];
+	argsParsing: "none" | "positional" | undefined;
+	requiresAuth: boolean;
+	requiresElevated: boolean;
+	enabled: boolean;
+	surfaces: CommandSurface[] | undefined;
+	target: CommandTarget;
+	icon: string | undefined;
+}
+
+/**
+ * Enabled commands available on a given surface. A command with no `surfaces`
+ * is available everywhere; one with an explicit list is restricted to it (so a
+ * GUI-only command is never returned for `discord`/`telegram`).
+ */
+export function getCommandsForSurface(
+	surface: CommandSurface,
+): CommandDefinition[] {
+	return activeStore.commands.filter(
+		(cmd) =>
+			cmd.enabled !== false &&
+			(cmd.surfaces === undefined || cmd.surfaces.includes(surface)),
+	);
+}
+
+/**
+ * Project a command to a connector-neutral, JSON-safe descriptor: native name,
+ * static arg choices (function-valued choices resolve to `undefined`; the
+ * `dynamicChoices` hint is preserved for in-app surfaces), the boolean flags
+ * defaulted, and the routing target (defaulting to the agent). Each connector
+ * adapts this to its native command API.
+ */
+export function serializeCommand(command: CommandDefinition): SerializedCommand {
+	return {
+		key: command.key,
+		nativeName: command.nativeName ?? command.key,
+		description: command.description,
+		textAliases: command.textAliases,
+		scope: command.scope,
+		category: command.category,
+		acceptsArgs: command.acceptsArgs ?? false,
+		args: (command.args ?? []).map((arg) => ({
+			name: arg.name,
+			description: arg.description,
+			required: arg.required ?? false,
+			choices: Array.isArray(arg.choices) ? arg.choices : undefined,
+			dynamicChoices: arg.dynamicChoices,
+			captureRemaining: arg.captureRemaining,
+		})),
+		argsParsing: command.argsParsing,
+		requiresAuth: command.requiresAuth ?? false,
+		requiresElevated: command.requiresElevated ?? false,
+		enabled: command.enabled !== false,
+		surfaces: command.surfaces,
+		target: command.target ?? { kind: "agent" },
+		icon: command.icon,
+	};
+}
+
+/**
+ * Serialize the whole enabled catalog, optionally filtered to a surface. The
+ * data source for navigation/connector clients building a command list.
+ */
+export function serializeCommands(
+	surface?: CommandSurface,
+): SerializedCommand[] {
+	const commands = surface
+		? getCommandsForSurface(surface)
+		: getEnabledCommands();
+	return commands.map(serializeCommand);
 }

--- a/plugins/plugin-commands/src/types.ts
+++ b/plugins/plugin-commands/src/types.ts
@@ -13,13 +13,41 @@ export type CommandCategory =
 	| "media"
 	| "tools"
 	| "docks"
-	| "skills";
+	| "skills"
+	| "navigation";
+
+/**
+ * Where a command can appear. `gui`/`tui` are the in-app surfaces; `discord`/
+ * `telegram` are the chat connectors. A command with no `surfaces` is available
+ * everywhere; one with an explicit list is restricted to those surfaces (e.g. a
+ * GUI-only `/fullscreen` is never exposed to Discord/Telegram).
+ */
+export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
+
+/**
+ * How a command is handled once matched:
+ *   - `agent`    → routed to the agent's message pipeline (the default).
+ *   - `navigate` → an in-app deep link (a tab/view + a stable route path); chat
+ *                  connectors reply with the link instead of running it.
+ *   - `client`   → a pure client-side behavior (e.g. clear the chat), no agent
+ *                  round-trip; has no connector surface.
+ */
+export type CommandTarget =
+	| { kind: "agent" }
+	| { kind: "navigate"; tab?: string; viewId?: string; path: string }
+	| { kind: "client"; clientAction: string };
 
 export interface CommandArgDefinition {
 	name: string;
 	description: string;
 	required?: boolean;
 	choices?: string[] | ((ctx: CommandArgChoiceContext) => string[]);
+	/**
+	 * Key for a surface-resolved choice list (e.g. "settings-sections", "views")
+	 * the UI fills in at render time. Static `choices` are used for connectors;
+	 * this is the dynamic hint for the in-app surfaces.
+	 */
+	dynamicChoices?: string;
 	captureRemaining?: boolean;
 }
 
@@ -42,6 +70,12 @@ export interface CommandDefinition {
 	requiresAuth?: boolean;
 	requiresElevated?: boolean;
 	enabled?: boolean;
+	/** Surfaces this command appears on; omit for "everywhere". */
+	surfaces?: CommandSurface[];
+	/** How the command is handled when matched; defaults to `{ kind: "agent" }`. */
+	target?: CommandTarget;
+	/** Optional icon id (lucide name) for surfaces that render a command list. */
+	icon?: string;
 }
 
 export interface CommandContext {


### PR DESCRIPTION
## Why

`main` carries the new `navigation-commands.ts` + rewritten `connector-catalog.ts` (the universal slash-command catalog) which reference a registry/types API that `registry.ts`/`types.ts` never gained. Result: `@elizaos/plugin-commands#build` exits 2, so `bun run build:core` — the cloud deploy's **"Build linked elizaOS workspaces"** step — fails and **every production deploy off `main` is blocked** (including the already-merged dashboard scroll fix #8598 and all the recent cloud-backend work, which are sitting on `main` unable to ship).

`develop` is *not* affected — it still has the older self-consistent `connector-catalog.ts` and no `navigation-commands.ts`, so it builds. This break is specific to `main`'s newer files.

## What

Completes the API the already-landed files expect, using the package's own tests (`__tests__/catalog.test.ts`, `__tests__/connector-commands.test.ts`) as the spec.

**`types.ts`**
- `"navigation"` added to `CommandCategory`
- `CommandSurface` = `"gui" | "tui" | "discord" | "telegram"`
- `CommandTarget` = `agent | navigate | client` — declarative per-surface handling
- `CommandArgDefinition.dynamicChoices`; `surfaces` / `target` / `icon` on `CommandDefinition`

**`registry.ts`**
- merge `NAVIGATION_COMMANDS` into the per-runtime store in `initForRuntime`
- `getCommandsForSurface(surface)` — filter enabled cmds by surface
- `serializeCommand` / `serializeCommands(surface?)` — wire-safe JSON (drops fn-valued `choices`, defaults `target`→`agent`, fills required booleans)
- `/new` marked as a client `new-conversation` command

## Verification
- `bun run build:core` → **52/52 tasks successful** (plugin-commands built fresh, "Build complete!")
- `plugins/plugin-commands` build **0 errs** · typecheck **0 errs** · **42/42 tests pass**
- consumers typecheck clean: `plugin-discord` 0 · `plugin-telegram` 0

## Note for the squash
`develop` will need this same 2-file completion *whenever it adopts the new `connector-catalog.ts` + `navigation-commands.ts`* (currently it doesn't). Folding that into the in-flight catalog squash is the clean way to keep develop↔main convergent.