### PR TITLE
feat(cloud): make cache + DB Railway-ready (Upstash→TCP Redis, Neon→Railway Postgres TLS)

### DIFF
--- a/packages/cloud-services/gateway-discord/package.json
+++ b/packages/cloud-services/gateway-discord/package.json
@@ -26,7 +26,8 @@
     "@upstash/redis": "^1.37.0",
     "discord.js": "^14.26.4",
     "hashring": "^3.2.0",
-    "hono": "4.12.25"
+    "hono": "4.12.25",
+    "ioredis": "^5.10.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",

--- a/packages/cloud-services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud-services/gateway-discord/src/gateway-manager.ts
@@ -19,7 +19,7 @@ import {
   type User,
 } from "discord.js";
 import { logger } from "./logger";
-import { MockUpstashRedis } from "./mock-redis";
+import { createMockRedis, createNativeRedis } from "./redis-adapter";
 import {
   forwardToServer,
   refreshKedaActivity,
@@ -311,24 +311,32 @@ export class GatewayManager {
     this.config = config;
     this.voiceHandler = new VoiceMessageHandler();
 
-    // Initialize Redis for failover coordination
+    // Initialize Redis for failover coordination.
     // MOCK_REDIS=1 is an explicit opt-in for tests/CI; never silently used
     // when unset, so real credentials are still honored when present.
+    const isTcpRedisUrl = (u: string): boolean => /^rediss?:\/\//i.test(u);
     if (process.env.MOCK_REDIS === "1") {
-      this.redis = new MockUpstashRedis() as unknown as Redis;
+      this.redis = createMockRedis() as unknown as Redis;
       logger.info("[GatewayManager] using in-memory mock Redis (MOCK_REDIS=1)");
+    } else if (config.redisUrl && isTcpRedisUrl(config.redisUrl)) {
+      // Railway (and any TCP Redis): RESP over ioredis, wrapped in the
+      // Upstash-compatible adapter so call sites stay unchanged.
+      this.redis = createNativeRedis(config.redisUrl) as unknown as Redis;
+      logger.info("[GatewayManager] using native TCP Redis client");
     } else if (config.redisUrl && config.redisToken) {
+      // Upstash REST (https URL + token) — legacy fallback.
       this.redis = new Redis({
         url: config.redisUrl,
         token: config.redisToken,
       });
+      logger.info("[GatewayManager] using Upstash REST Redis client");
     } else if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
       // Fall back to environment variables if explicit config not provided
       this.redis = Redis.fromEnv();
     } else if (config.redisUrl) {
       // URL provided but no token - log warning and skip Redis
       logger.warn(
-        "Redis URL provided without token - failover disabled. Set KV_REST_API_TOKEN or redisToken.",
+        "Redis URL provided without token - failover disabled. Set REDIS_URL (TCP) or KV_REST_API_TOKEN/redisToken (Upstash).",
       );
     }
   }

--- a/packages/cloud-services/gateway-discord/src/redis-adapter.ts
+++ b/packages/cloud-services/gateway-discord/src/redis-adapter.ts
@@ -1,13 +1,18 @@
 /**
- * Tiny in-memory mock that mirrors the subset of the `@upstash/redis` client
- * surface used by the Discord gateway. Selected only when `MOCK_REDIS=1` is
- * set in the environment — never used as a silent fallback.
+ * Adapts an `ioredis`-shaped client to the subset of the `@upstash/redis`
+ * surface the Discord gateway uses (`get`/`set`/`setex`/`del`/`expire`/
+ * `sadd`/`srem`/`smembers`), so the same call sites work against either:
+ *   - a real TCP Redis (Railway) via `ioredis` — `createNativeRedis(url)`, or
+ *   - the in-memory `ioredis-mock` for tests/CI — `createMockRedis()`.
  *
- * Backed by `ioredis-mock`; methods are normalized so callers can keep using
- * Upstash-style option objects (e.g. `set(key, value, { ex, nx })`).
+ * Upstash's REST client exposes the same Upstash-style option objects (e.g.
+ * `set(key, value, { ex, nx })`); this adapter normalizes those to the
+ * positional RESP arguments `ioredis` expects, and returns the same values
+ * (`"OK"`/`null` for `set NX`) the gateway's leader-election code compares on.
  */
 
 import { createRequire } from "node:module";
+import IORedis from "ioredis";
 
 let _requireCJS: NodeJS.Require | null = null;
 function getRequireCJS(): NodeJS.Require {
@@ -15,7 +20,7 @@ function getRequireCJS(): NodeJS.Require {
   const url = import.meta.url;
   if (!url) {
     throw new Error(
-      "mock-redis: import.meta.url is undefined; cannot resolve ioredis-mock via createRequire",
+      "redis-adapter: import.meta.url is undefined; cannot resolve ioredis-mock via createRequire",
     );
   }
   _requireCJS = createRequire(url);
@@ -50,14 +55,14 @@ interface SetOptions {
 }
 
 /**
- * Drop-in mock for the subset of `@upstash/redis` methods the Discord
- * gateway uses. Not exhaustive — extend only as new call sites appear.
+ * Upstash-compatible facade over an `ioredis`-shaped client. Not exhaustive —
+ * extend only as new call sites appear.
  */
-export class MockUpstashRedis {
+export class UpstashCompatRedis {
   private readonly client: IoRedisLike;
 
-  constructor(client?: IoRedisLike) {
-    this.client = client ?? createIoRedisMock();
+  constructor(client: IoRedisLike) {
+    this.client = client;
   }
 
   async get<T = string>(key: string): Promise<T | null> {
@@ -70,13 +75,8 @@ export class MockUpstashRedis {
     }
   }
 
-  async set(
-    key: string,
-    value: unknown,
-    options?: SetOptions,
-  ): Promise<string | null> {
-    const serialized =
-      typeof value === "string" ? value : JSON.stringify(value);
+  async set(key: string, value: unknown, options?: SetOptions): Promise<string | null> {
+    const serialized = typeof value === "string" ? value : JSON.stringify(value);
     const args: Array<string | number> = [key, serialized];
     if (options?.ex !== undefined) args.push("EX", options.ex);
     if (options?.px !== undefined) args.push("PX", options.px);
@@ -127,4 +127,16 @@ export class MockUpstashRedis {
       // ignore
     }
   }
+}
+
+/** In-memory adapter for tests/CI (`MOCK_REDIS=1`). */
+export function createMockRedis(): UpstashCompatRedis {
+  return new UpstashCompatRedis(createIoRedisMock());
+}
+
+/** Real TCP Redis adapter (e.g. Railway `redis://` / `rediss://`). */
+export function createNativeRedis(url: string): UpstashCompatRedis {
+  // lazyConnect: defer the socket until the first command (the gateway issues
+  // one immediately) so construction never throws on a transient outage.
+  return new UpstashCompatRedis(new IORedis(url, { lazyConnect: true }) as unknown as IoRedisLike);
 }

--- a/packages/cloud-services/gateway-discord/tests/redis-adapter.test.ts
+++ b/packages/cloud-services/gateway-discord/tests/redis-adapter.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { UpstashCompatRedis, createMockRedis, createNativeRedis } from "../src/redis-adapter";
 
 const PREV_MOCK = process.env.MOCK_REDIS;
 
@@ -14,16 +15,15 @@ afterAll(() => {
   }
 });
 
-describe("MockUpstashRedis (MOCK_REDIS=1)", () => {
+describe("UpstashCompatRedis (mock client)", () => {
   test("round-trip across the gateway-discord call surface", async () => {
-    const { MockUpstashRedis } = await import("../src/mock-redis");
-    const redis = new MockUpstashRedis();
+    const redis = createMockRedis();
 
     // set + get round-trip
     await redis.set("hello", "world");
     expect(await redis.get<string>("hello")).toBe("world");
 
-    // set with {ex, nx}
+    // set with {ex, nx} — same option mapping the native (Railway TCP) path uses
     await redis.set("once", "first", { nx: true, ex: 60 });
     await redis.set("once", "second", { nx: true, ex: 60 });
     expect(await redis.get<string>("once")).toBe("first");
@@ -44,5 +44,15 @@ describe("MockUpstashRedis (MOCK_REDIS=1)", () => {
     expect(await redis.smembers("active_pods")).toEqual(["pod-b"]);
 
     await redis.quit();
+  });
+});
+
+describe("createNativeRedis (Railway TCP)", () => {
+  test("builds an UpstashCompatRedis without connecting eagerly", () => {
+    // lazyConnect-style: constructing must not throw or require a live server.
+    const redis = createNativeRedis("redis://default:pw@127.0.0.1:6390");
+    expect(redis).toBeInstanceOf(UpstashCompatRedis);
+    // close the idle ioredis socket so the test process can exit cleanly.
+    void redis.quit();
   });
 });

--- a/packages/cloud-shared/src/db/__tests__/client-tls.test.ts
+++ b/packages/cloud-shared/src/db/__tests__/client-tls.test.ts
@@ -11,20 +11,26 @@ describe("shouldSkipTlsVerification", () => {
   test("default (no flag, no sslmode) keeps strict verification", () => {
     delete process.env.DATABASE_SSL_NO_VERIFY;
     expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db")).toBe(false);
-    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(false);
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(
+      false,
+    );
   });
 
   test("?sslmode=no-verify opts out of verification (e.g. Railway self-signed proxy)", () => {
     delete process.env.DATABASE_SSL_NO_VERIFY;
     expect(
-      shouldSkipTlsVerification("postgresql://u:p@switchback.proxy.rlwy.net:49295/railway?sslmode=no-verify"),
+      shouldSkipTlsVerification(
+        "postgresql://u:p@switchback.proxy.rlwy.net:49295/railway?sslmode=no-verify",
+      ),
     ).toBe(true);
   });
 
   test("DATABASE_SSL_NO_VERIFY=true opts out regardless of URL", () => {
     process.env.DATABASE_SSL_NO_VERIFY = "true";
     expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db")).toBe(true);
-    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(true);
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(
+      true,
+    );
   });
 
   test("any other DATABASE_SSL_NO_VERIFY value stays strict", () => {

--- a/packages/cloud-shared/src/db/__tests__/client-tls.test.ts
+++ b/packages/cloud-shared/src/db/__tests__/client-tls.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { shouldSkipTlsVerification } from "../client";
+
+const PREV = process.env.DATABASE_SSL_NO_VERIFY;
+afterEach(() => {
+  if (PREV === undefined) delete process.env.DATABASE_SSL_NO_VERIFY;
+  else process.env.DATABASE_SSL_NO_VERIFY = PREV;
+});
+
+describe("shouldSkipTlsVerification", () => {
+  test("default (no flag, no sslmode) keeps strict verification", () => {
+    delete process.env.DATABASE_SSL_NO_VERIFY;
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db")).toBe(false);
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(false);
+  });
+
+  test("?sslmode=no-verify opts out of verification (e.g. Railway self-signed proxy)", () => {
+    delete process.env.DATABASE_SSL_NO_VERIFY;
+    expect(
+      shouldSkipTlsVerification("postgresql://u:p@switchback.proxy.rlwy.net:49295/railway?sslmode=no-verify"),
+    ).toBe(true);
+  });
+
+  test("DATABASE_SSL_NO_VERIFY=true opts out regardless of URL", () => {
+    process.env.DATABASE_SSL_NO_VERIFY = "true";
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db")).toBe(true);
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db?sslmode=require")).toBe(true);
+  });
+
+  test("any other DATABASE_SSL_NO_VERIFY value stays strict", () => {
+    process.env.DATABASE_SSL_NO_VERIFY = "false";
+    expect(shouldSkipTlsVerification("postgresql://u:p@host.example.com/db")).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/db/client.ts
+++ b/packages/cloud-shared/src/db/client.ts
@@ -125,13 +125,36 @@ function parsePositiveInteger(value: string | undefined, fallback: number): numb
 }
 
 /**
+ * Whether to keep TLS but skip server-certificate verification.
+ *
+ * Managed providers like Railway terminate the public TCP proxy with a
+ * self-signed certificate, so strict CA verification fails even though the
+ * connection is fully encrypted. Opt in — per the provider's own guidance —
+ * with `DATABASE_SSL_NO_VERIFY=true` or `?sslmode=no-verify` on the URL. The
+ * default stays strict; this never disables encryption (only verification).
+ */
+export function shouldSkipTlsVerification(url: string): boolean {
+  if (process.env.DATABASE_SSL_NO_VERIFY === "true") {
+    return true;
+  }
+  try {
+    return new URL(url).searchParams.get("sslmode") === "no-verify";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Enforce TLS on remote Postgres connections (D-2 / SOC2 CC6.7).
  *
  * Local (127.0.0.1 / localhost) connections may run without TLS for dev.
- * Anything else must use sslmode=require — both via URL parameter (so it
- * survives external connection-pool configs) AND via the `ssl` option on
- * the pg driver (so the handshake is enforced even if the parameter is
- * dropped by a proxy). We fail closed by setting `rejectUnauthorized: true`.
+ * Anything else must use TLS — both via the URL `sslmode` parameter (so it
+ * survives external connection-pool configs) AND via the `ssl` option on the
+ * pg driver (so the handshake is enforced even if the parameter is dropped by
+ * a proxy). We fail closed: `sslmode=disable`/`allow` is rejected outright, and
+ * certificate verification stays on (`rejectUnauthorized: true`) unless the
+ * operator explicitly opts into `no-verify` for a self-signed managed proxy
+ * (the connection remains encrypted; only CA verification is relaxed).
  */
 function enforceTlsForRemote(url: string): {
   url: string;
@@ -140,19 +163,19 @@ function enforceTlsForRemote(url: string): {
   if (isLocalTcpPostgresUrl(url)) {
     return { url, ssl: undefined };
   }
+  const skipVerify = shouldSkipTlsVerification(url);
   let normalized = url;
   try {
     const parsed = new URL(url);
-    if (!parsed.searchParams.has("sslmode")) {
-      parsed.searchParams.set("sslmode", "require");
-      normalized = parsed.toString();
-    } else if (
-      parsed.searchParams.get("sslmode") === "disable" ||
-      parsed.searchParams.get("sslmode") === "allow"
-    ) {
+    const sslmode = parsed.searchParams.get("sslmode");
+    if (sslmode === "disable" || sslmode === "allow") {
       throw new Error(
-        `Refusing to connect: remote DATABASE_URL has sslmode=${parsed.searchParams.get("sslmode")}. Remote Postgres connections must use sslmode=require (SOC2 CC6.7).`,
+        `Refusing to connect: remote DATABASE_URL has sslmode=${sslmode}. Remote Postgres connections must use TLS (SOC2 CC6.7).`,
       );
+    }
+    if (!sslmode) {
+      parsed.searchParams.set("sslmode", skipVerify ? "no-verify" : "require");
+      normalized = parsed.toString();
     }
   } catch (err) {
     if (err instanceof Error && err.message.startsWith("Refusing to connect")) {
@@ -162,7 +185,7 @@ function enforceTlsForRemote(url: string): {
   }
   return {
     url: normalized,
-    ssl: { rejectUnauthorized: true },
+    ssl: { rejectUnauthorized: !skipVerify },
   };
 }
 

--- a/packages/cloud-shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
+++ b/packages/cloud-shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
@@ -63,3 +63,25 @@ describe("buildRedisClient (MOCK_REDIS=1)", () => {
     expect(members.sort()).toEqual(["alice", "bob"]);
   });
 });
+
+describe("hasRedisConfig", () => {
+  test("mirrors buildRedisClient resolution (incl. TCP REDIS_URL)", async () => {
+    const { hasRedisConfig } = await import("../redis-factory");
+    // no config -> false
+    expect(hasRedisConfig({})).toBe(false);
+    // TCP REDIS_URL (Railway) -> true  [the B1 fix: was previously Upstash-only]
+    expect(hasRedisConfig({ REDIS_URL: "redis://default:pw@host:6379" })).toBe(true);
+    // legacy Upstash REST creds -> true
+    expect(
+      hasRedisConfig({ KV_REST_API_URL: "https://x.upstash.io", KV_REST_API_TOKEN: "tok" }),
+    ).toBe(true);
+    // Upstash alias creds -> true
+    expect(
+      hasRedisConfig({ UPSTASH_REDIS_REST_URL: "https://x.upstash.io", UPSTASH_REDIS_REST_TOKEN: "tok" }),
+    ).toBe(true);
+    // half-configured Upstash -> false
+    expect(hasRedisConfig({ KV_REST_API_URL: "https://x.upstash.io" })).toBe(false);
+    // explicit mock -> true
+    expect(hasRedisConfig({ MOCK_REDIS: "1" })).toBe(true);
+  });
+});

--- a/packages/cloud-shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
+++ b/packages/cloud-shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
@@ -77,7 +77,10 @@ describe("hasRedisConfig", () => {
     ).toBe(true);
     // Upstash alias creds -> true
     expect(
-      hasRedisConfig({ UPSTASH_REDIS_REST_URL: "https://x.upstash.io", UPSTASH_REDIS_REST_TOKEN: "tok" }),
+      hasRedisConfig({
+        UPSTASH_REDIS_REST_URL: "https://x.upstash.io",
+        UPSTASH_REDIS_REST_TOKEN: "tok",
+      }),
     ).toBe(true);
     // half-configured Upstash -> false
     expect(hasRedisConfig({ KV_REST_API_URL: "https://x.upstash.io" })).toBe(false);

--- a/packages/cloud-shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud-shared/src/lib/cache/redis-factory.ts
@@ -48,3 +48,18 @@ export function buildRedisClient(env?: RedisFactoryEnv): CompatibleRedis | null 
 
   return null;
 }
+
+/**
+ * True when {@link buildRedisClient} would return a real client for this env —
+ * i.e. a Redis backend is configured. Mirrors the resolution order above so
+ * callers gate on the same condition the factory uses, instead of hard-coding
+ * an Upstash-only `KV_REST_API_*` check that misses a TCP `REDIS_URL` deploy.
+ */
+export function hasRedisConfig(env?: RedisFactoryEnv): boolean {
+  const e = env ?? (process.env as RedisFactoryEnv);
+  if (e.MOCK_REDIS === "1") return true;
+  if (e.REDIS_URL) return true;
+  const restUrl = e.KV_REST_API_URL || e.UPSTASH_REDIS_REST_URL;
+  const restToken = e.KV_REST_API_TOKEN || e.UPSTASH_REDIS_REST_TOKEN;
+  return !!(restUrl && restToken);
+}

--- a/packages/cloud-shared/src/lib/events/credit-events.ts
+++ b/packages/cloud-shared/src/lib/events/credit-events.ts
@@ -5,6 +5,7 @@
  */
 
 import { EventEmitter } from "events";
+import { hasRedisConfig } from "../cache/redis-factory";
 import { assertPersistentCloudStateConfigured } from "../utils/persistence-guard";
 import type { CreditUpdateEvent } from "./credit-events-redis";
 import { redisCreditEventEmitter } from "./credit-events-redis";
@@ -63,7 +64,10 @@ class CreditEventEmitter {
     const isServerless =
       process.env.NODE_ENV === "production" || process.env.FORCE_REDIS_EVENTS === "true";
 
-    const redisConfigured = !!(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
+    // Accept a TCP `REDIS_URL` (Railway) as well as the legacy Upstash REST
+    // creds — mirrors `buildRedisClient` so a Railway-only deploy doesn't
+    // silently degrade credit events to a single-process in-memory emitter.
+    const redisConfigured = hasRedisConfig();
     assertPersistentCloudStateConfigured("credit-events", redisConfigured);
 
     const useRedis = isServerless && redisConfigured;


### PR DESCRIPTION
## What

Prep for migrating the cloud cache+DB off Upstash/Neon onto **Railway** (TCP Redis + Postgres). Two cloud consumers still assumed **Upstash REST** and would break — or silently degrade — against a `REDIS_URL`-only (Railway TCP) deploy. This PR fixes both and adds coverage. **No infra is cut over by this PR**; it only makes the code Railway-ready so the cutover is a config flip.

## Changes

### 1. `credit-events` — accept TCP `REDIS_URL` (correctness)
`CreditEventEmitter.shouldUseRedis()` gated on `KV_REST_API_URL && KV_REST_API_TOKEN` only. On a Railway deploy that sets `REDIS_URL` (and no `KV_REST_*`), it silently fell back to a **single-process in-memory `EventEmitter`**, breaking multi-instance credit-update propagation.

- Added `hasRedisConfig(env?)` to `lib/cache/redis-factory.ts` — mirrors `buildRedisClient()`'s resolution (`MOCK_REDIS` / `REDIS_URL` / Upstash REST / Upstash alias), so callers gate on the same condition the factory builds on.
- `credit-events.ts` now gates on `hasRedisConfig()`. The underlying `redisCreditEventEmitter` already used `buildRedisClient()` (REDIS_URL-aware); this aligns the gate with it.

### 2. `gateway-discord` — speak TCP to Railway Redis
Failover/leader-election used the `@upstash/redis` REST client, which cannot talk to Railway's TCP Redis. With `REDIS_URL` aliased to a `redis://` URL, the old constructor tried to build an Upstash REST client from a TCP URL — broken.

- `mock-redis.ts` → `redis-adapter.ts`: the existing `ioredis`-backed, Upstash-shaped adapter is generalized to wrap **either** the in-memory `ioredis-mock` (`createMockRedis()`) **or** a real `ioredis` client (`createNativeRedis(url)`, `lazyConnect`).
- `gateway-manager.ts` constructor now prefers a `redis(s)://` `REDIS_URL` → native TCP adapter, before the Upstash REST fallback. Call sites unchanged (same `get/set{ex,nx}/setex/del/expire/sadd/srem/smembers` surface; `set` returns `"OK"`/`null` exactly as the leader-election code compares).
- Adds `ioredis` dependency (already used by sibling `gateway-webhook`).

### 3. `cloud-shared` DB client — opt-in TLS no-verify for self-signed managed Postgres
Railway terminates its **public TCP proxy with a self-signed cert**. The remote-TLS policy (`enforceTlsForRemote`, SOC2 CC6.7) hardcoded `rejectUnauthorized: true`, so the production `createConnection` path fails with `SELF_SIGNED_CERT_IN_CHAIN` against Railway (Neon used valid public-CA certs, so this only surfaces at cutover). pg 8.21 also treats `sslmode=require` as `verify-full`, so even `?sslmode=require` fails.

- `DATABASE_SSL_NO_VERIFY=true` **or** `?sslmode=no-verify` keeps TLS (encrypted) but skips CA verification. **Defaults unchanged** — strict verification stays on; `sslmode=disable`/`allow` is still rejected outright (no plaintext). Encryption-in-transit (CC6.7) is preserved; only CA verification is relaxed, and only when the operator opts in for the known endpoint.
- Verified end-to-end against an 8 GB Neon→Railway restored copy: the production path (pg + drizzle, reads / typed select / DDL+DML / tx-rollback) passes **7/7** with the flag and **fails closed** without it.

## Tests
- `redis-factory-mock.test.ts`: new `hasRedisConfig` cases (TCP `REDIS_URL` true; half-configured Upstash false; aliases; mock).
- `gateway-discord` `redis-adapter.test.ts`: existing mock round-trip retained + `createNativeRedis` constructs without eager connect. **56/56 pass.**
- `client-tls.test.ts`: `shouldSkipTlsVerification` env/URL matrix (**4/4**).
- Verified end-to-end against **live Railway Redis + an 8 GB Neon→Railway restored copy**: SocketRedis TCP round-trip (4/4) and the full pg/drizzle path (7/7). Row parity Neon↔Railway: 284/284 tables, drizzle journal @137 identical.

## Not in this PR (tracked for the cutover)
- Worker DB path (`worker-neon-http.ts`) `pg`-over-`nodejs_compat` / Hyperdrive validation; deleting the dead Neon-HTTP branch + `@neondatabase/serverless`/`ws` deps after cutover.
- `sandbox-registry` (agent + app-core) and opt-in `mcp` schema-cache Upstash-REST consumers.
- Stale Upstash comments in `cloud-api/wrangler.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
