### PR TITLE
fix(plugin-commands): align registry/types with develop (unbreak main build:core)

### DIFF
--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -7,14 +7,7 @@
  * plugin file should clone before mutating to avoid cross-agent contamination.
  */
 
-import { NAVIGATION_COMMANDS } from "./navigation-commands";
-import type {
-	CommandCategory,
-	CommandDefinition,
-	CommandScope,
-	CommandSurface,
-	CommandTarget,
-} from "./types";
+import type { CommandDefinition } from "./types";
 
 // Default command definitions (frozen reference — never mutate these directly)
 export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
@@ -104,10 +97,6 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "session",
 		acceptsArgs: false,
-		// Client-side action (new conversation in the UI) — no agent round-trip,
-		// and no connector surface, so chat connectors don't expose it.
-		surfaces: ["gui", "tui"],
-		target: { kind: "client", clientAction: "new-conversation" },
 	},
 	{
 		key: "compact",
@@ -343,11 +332,7 @@ let activeStore: CommandStore = fallbackStore;
  */
 export function initForRuntime(agentId: string): void {
 	const store: CommandStore = {
-		// Agent-capability commands + the surface-agnostic navigation/client
-		// catalog form one registry (keys are disjoint between the two sets).
-		commands: [...DEFAULT_COMMANDS, ...NAVIGATION_COMMANDS].map((c) => ({
-			...c,
-		})),
+		commands: DEFAULT_COMMANDS.map((c) => ({ ...c })),
 		aliasMap: null,
 	};
 	runtimeStores.set(agentId, store);
@@ -481,96 +466,4 @@ export function startsWithCommand(text: string): CommandDefinition | undefined {
 	}
 
 	return undefined;
-}
-
-/** A command arg projected to a JSON-safe shape (function choices resolved out). */
-export interface SerializedCommandArg {
-	name: string;
-	description: string;
-	required: boolean;
-	/** Static choices only; `undefined` for function-resolved (`dynamicChoices`) args. */
-	choices: string[] | undefined;
-	dynamicChoices: string | undefined;
-	captureRemaining: boolean | undefined;
-}
-
-/** A command projected to a plain, JSON-round-trippable shape connectors read. */
-export interface SerializedCommand {
-	key: string;
-	nativeName: string;
-	description: string;
-	textAliases: string[];
-	scope: CommandScope;
-	category: CommandCategory | undefined;
-	acceptsArgs: boolean;
-	args: SerializedCommandArg[];
-	argsParsing: "none" | "positional" | undefined;
-	requiresAuth: boolean;
-	requiresElevated: boolean;
-	enabled: boolean;
-	surfaces: CommandSurface[] | undefined;
-	target: CommandTarget;
-	icon: string | undefined;
-}
-
-/**
- * Enabled commands available on a given surface. A command with no `surfaces`
- * is available everywhere; one with an explicit list is restricted to it (so a
- * GUI-only command is never returned for `discord`/`telegram`).
- */
-export function getCommandsForSurface(
-	surface: CommandSurface,
-): CommandDefinition[] {
-	return activeStore.commands.filter(
-		(cmd) =>
-			cmd.enabled !== false &&
-			(cmd.surfaces === undefined || cmd.surfaces.includes(surface)),
-	);
-}
-
-/**
- * Project a command to a connector-neutral, JSON-safe descriptor: native name,
- * static arg choices (function-valued choices resolve to `undefined`; the
- * `dynamicChoices` hint is preserved for in-app surfaces), the boolean flags
- * defaulted, and the routing target (defaulting to the agent). Each connector
- * adapts this to its native command API.
- */
-export function serializeCommand(command: CommandDefinition): SerializedCommand {
-	return {
-		key: command.key,
-		nativeName: command.nativeName ?? command.key,
-		description: command.description,
-		textAliases: command.textAliases,
-		scope: command.scope,
-		category: command.category,
-		acceptsArgs: command.acceptsArgs ?? false,
-		args: (command.args ?? []).map((arg) => ({
-			name: arg.name,
-			description: arg.description,
-			required: arg.required ?? false,
-			choices: Array.isArray(arg.choices) ? arg.choices : undefined,
-			dynamicChoices: arg.dynamicChoices,
-			captureRemaining: arg.captureRemaining,
-		})),
-		argsParsing: command.argsParsing,
-		requiresAuth: command.requiresAuth ?? false,
-		requiresElevated: command.requiresElevated ?? false,
-		enabled: command.enabled !== false,
-		surfaces: command.surfaces,
-		target: command.target ?? { kind: "agent" },
-		icon: command.icon,
-	};
-}
-
-/**
- * Serialize the whole enabled catalog, optionally filtered to a surface. The
- * data source for navigation/connector clients building a command list.
- */
-export function serializeCommands(
-	surface?: CommandSurface,
-): SerializedCommand[] {
-	const commands = surface
-		? getCommandsForSurface(surface)
-		: getEnabledCommands();
-	return commands.map(serializeCommand);
 }

--- a/plugins/plugin-commands/src/types.ts
+++ b/plugins/plugin-commands/src/types.ts
@@ -13,41 +13,13 @@ export type CommandCategory =
 	| "media"
 	| "tools"
 	| "docks"
-	| "skills"
-	| "navigation";
-
-/**
- * Where a command can appear. `gui`/`tui` are the in-app surfaces; `discord`/
- * `telegram` are the chat connectors. A command with no `surfaces` is available
- * everywhere; one with an explicit list is restricted to those surfaces (e.g. a
- * GUI-only `/fullscreen` is never exposed to Discord/Telegram).
- */
-export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
-
-/**
- * How a command is handled once matched:
- *   - `agent`    → routed to the agent's message pipeline (the default).
- *   - `navigate` → an in-app deep link (a tab/view + a stable route path); chat
- *                  connectors reply with the link instead of running it.
- *   - `client`   → a pure client-side behavior (e.g. clear the chat), no agent
- *                  round-trip; has no connector surface.
- */
-export type CommandTarget =
-	| { kind: "agent" }
-	| { kind: "navigate"; tab?: string; viewId?: string; path: string }
-	| { kind: "client"; clientAction: string };
+	| "skills";
 
 export interface CommandArgDefinition {
 	name: string;
 	description: string;
 	required?: boolean;
 	choices?: string[] | ((ctx: CommandArgChoiceContext) => string[]);
-	/**
-	 * Key for a surface-resolved choice list (e.g. "settings-sections", "views")
-	 * the UI fills in at render time. Static `choices` are used for connectors;
-	 * this is the dynamic hint for the in-app surfaces.
-	 */
-	dynamicChoices?: string;
 	captureRemaining?: boolean;
 }
 
@@ -70,12 +42,6 @@ export interface CommandDefinition {
 	requiresAuth?: boolean;
 	requiresElevated?: boolean;
 	enabled?: boolean;
-	/** Surfaces this command appears on; omit for "everywhere". */
-	surfaces?: CommandSurface[];
-	/** How the command is handled when matched; defaults to `{ kind: "agent" }`. */
-	target?: CommandTarget;
-	/** Optional icon id (lucide name) for surfaces that render a command list. */
-	icon?: string;
 }
 
 export interface CommandContext {


### PR DESCRIPTION
## Why (regression from the develop→main promote)

The promote `df839729c6` ("promote/develop-to-main-5") reverted most of plugin-commands to develop's canonical version — restored the old `connector-catalog.ts` and **deleted `navigation-commands.ts`** — but kept `registry.ts`/`types.ts` from #8600 (the 3-way merge took main's side for those two files). Net result: `registry.ts` still does `import { NAVIGATION_COMMANDS } from "./navigation-commands"` for a file that no longer exists → `@elizaos/plugin-commands#build` fails → `bun run build:core` (the deploy's "Build linked elizaOS workspaces" step) fails → **every main→prod deploy is blocked again**.

## Fix: converge to develop, don't re-diverge

The team is consolidating main onto **develop** (source of truth). The universal slash-command catalog (navigation-commands + the new registry/types API) is **not** on develop. The only plugin-commands files where main differed from develop were these exact two. So the durable fix is to revert `registry.ts` + `types.ts` to develop's versions — **not** to forward-restore `navigation-commands.ts` (which would re-diverge and re-break on the next promote). This supersedes the registry/types half of #8600.

## Verification
- `git diff origin/develop -- plugins/plugin-commands/` → **empty** (main's plugin-commands now byte-identical to develop)
- `plugins/plugin-commands` build → **"Build complete!"**, typecheck **0**
- consumers typecheck **0**: `plugin-discord`, `plugin-telegram`, `packages/agent`
- `bun run build:core` (the literal deploy gate) → running, will confirm green