### PR TITLE
plugin-telegram: fail fast on a rejected bot token + guard the typing action

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -444,3 +444,29 @@ describe("MessageManager send resilience (sendWithRetry)", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("MessageManager typing-indicator resilience", () => {
+  it("still sends the reply when the typing action fails", async () => {
+    const sendMessage = vi.fn(
+      async (chatId: number | string, text: string) => ({
+        message_id: 1,
+        date: 1,
+        text,
+        chat: { id: chatId, type: "private" },
+      }),
+    );
+    const sendChatAction = vi.fn(async () => {
+      throw new Error("typing action failed");
+    });
+    const manager = new MessageManager(
+      { telegram: { sendMessage, sendChatAction } } as never,
+      { agentId: "agent-1" } as never,
+    );
+    const sent = await manager.sendMessageInChunks(
+      { chat: { id: 123 }, telegram: { sendMessage, sendChatAction } } as never,
+      { text: "hi" },
+    );
+    expect(sent).toHaveLength(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -670,7 +670,20 @@ export class MessageManager {
         );
         return [];
       }
-      await ctx.telegram.sendChatAction(ctx.chat.id, "typing");
+      // The typing indicator is cosmetic and best-effort — a failure here must
+      // never abort the actual reply on the critical path below.
+      try {
+        await ctx.telegram.sendChatAction(ctx.chat.id, "typing");
+      } catch (error) {
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "sendChatAction (typing) failed; continuing",
+        );
+      }
 
       for (let i = 0; i < chunks.length; i++) {
         const chunk = convertMarkdownToTelegram(chunks[i]);

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -551,6 +551,23 @@ export class TelegramService extends Service {
           break;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
+          const errorCode = (error as { response?: { error_code?: number } })
+            .response?.error_code;
+          // A revoked/malformed bot token (401/404) is permanent — don't burn
+          // ~30s of exponential backoff retrying it; fail fast with a clear
+          // operator message.
+          if (errorCode === 401 || errorCode === 404) {
+            logger.error(
+              {
+                src: "plugin:telegram",
+                agentId: runtime.agentId,
+                accountId: state.accountId,
+                errorCode,
+              },
+              "Telegram bot token rejected — check TELEGRAM_BOT_TOKEN for this account",
+            );
+            break;
+          }
           logger.error(
             {
               src: "plugin:telegram",


### PR DESCRIPTION
## What

Two small bot-connector resilience follow-ups (after #8603).

- **Fail fast on a rejected bot token.** The boot retry loop retried any `initializeBot`/`getMe` failure 5× with exponential backoff (~30s). A revoked or malformed token returns 401 (or 404) — permanent — so it burned ~30s and five error logs per account before giving up. Now classifies the Telegram `error_code` and fails fast on 401/404 with a clear "token rejected — check TELEGRAM_BOT_TOKEN" message, keeping the backoff for transient/network errors.
- **Guard the typing indicator.** `sendChatAction` ("typing") was an unguarded `await` on the critical path, so a transient typing-action failure aborted the whole reply. Wrapped in a best-effort try/catch — the cosmetic indicator must never block the actual message.

## Testing

plugin-telegram suite: my 5 test files pass (38 tests, incl. a new test that the reply still sends when the typing action throws); lint clean. (Note: `command-registration.test.ts` is failing on develop independent of this PR — it imports `buildTelegramSetMyCommands`, which the source renamed to `buildTelegramCommandDescriptors`; out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
