### PR TITLE
feat(plugin-commands): complete + correct the slash-command navigation catalog

### DIFF
--- a/packages/agent/src/api/commands-routes.ts
+++ b/packages/agent/src/api/commands-routes.ts
@@ -18,6 +18,7 @@
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 import {
+  type ClientCommandAction,
   type ConnectorCommand,
   type ConnectorCommandOption,
   getConnectorCommands,
@@ -49,8 +50,14 @@ interface SlashCommandArg {
 
 type SlashCommandTarget =
   | { kind: "agent" }
-  | { kind: "navigate"; tab?: string; viewId?: string; path?: string }
-  | { kind: "client" };
+  | {
+      kind: "navigate";
+      tab?: string;
+      viewId?: string;
+      path?: string;
+      section?: string;
+    }
+  | { kind: "client"; clientAction: ClientCommandAction };
 
 interface SlashCommandCatalogItem {
   key: string;
@@ -93,14 +100,20 @@ function mapOption(option: ConnectorCommandOption): SlashCommandArg {
 /** Map the connector-neutral target onto the client target shape. */
 function mapTarget(target: ConnectorCommand["target"]): SlashCommandTarget {
   if (target.kind === "navigate") {
-    // The settings hub is special: the client opens the settings tab and
-    // focuses the section sub-argument. Other navigations are deep-link paths.
-    if (target.path === "/settings") {
-      return { kind: "navigate", tab: "settings", path: target.path };
-    }
-    return { kind: "navigate", path: target.path };
+    // Pass the catalog's routing hints through verbatim: the GUI opens `tab`
+    // (or `viewId`) directly; `path` is the connector deep link; `section`
+    // focuses a settings sub-section.
+    return {
+      kind: "navigate",
+      path: target.path,
+      ...(target.tab ? { tab: target.tab } : {}),
+      ...(target.viewId ? { viewId: target.viewId } : {}),
+      ...(target.section ? { section: target.section } : {}),
+    };
   }
-  if (target.kind === "client") return { kind: "client" };
+  if (target.kind === "client") {
+    return { kind: "client", clientAction: target.clientAction };
+  }
   return { kind: "agent" };
 }
 

--- a/plugins/plugin-commands/__tests__/connector-catalog.test.ts
+++ b/plugins/plugin-commands/__tests__/connector-catalog.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { getConnectorCommands } from "../src/connector-catalog";
+
+/**
+ * The navigation half of the catalog must point at real app routes and expose
+ * the in-app destinations on every surface, while keeping GUI/TUI-only client
+ * commands off the chat connectors.
+ */
+describe("connector catalog — navigation surface", () => {
+	const gui = getConnectorCommands("gui");
+	const byName = (name: string) => gui.find((c) => c.name === name);
+
+	it("exposes the full set of in-app navigation destinations", () => {
+		const names = new Set(gui.map((c) => c.name));
+		for (const expected of [
+			"settings",
+			"chat",
+			"views",
+			"orchestrator",
+			"character",
+			"knowledge",
+			"wallet",
+			"automations",
+			"tasks",
+			"skills",
+			"plugins",
+			"logs",
+			"database",
+		]) {
+			expect(names.has(expected)).toBe(true);
+		}
+	});
+
+	it("points navigation commands at canonical TAB_PATHS routes", () => {
+		// These mirror @elizaos/ui navigation/index.ts TAB_PATHS.
+		const expectedPaths: Record<string, string> = {
+			settings: "/settings",
+			chat: "/chat",
+			views: "/views",
+			character: "/character",
+			knowledge: "/character/documents",
+			wallet: "/wallet",
+			automations: "/automations",
+			tasks: "/apps/tasks",
+			skills: "/apps/skills",
+			plugins: "/apps/plugins",
+			logs: "/apps/logs",
+			database: "/apps/database",
+		};
+		for (const [name, path] of Object.entries(expectedPaths)) {
+			const cmd = byName(name);
+			expect(cmd?.target.kind).toBe("navigate");
+			expect(
+				cmd?.target.kind === "navigate" ? cmd.target.path : undefined,
+			).toBe(path);
+		}
+	});
+
+	it("carries a tab/viewId routing hint on every navigation command", () => {
+		for (const cmd of gui) {
+			if (cmd.target.kind !== "navigate") continue;
+			expect(Boolean(cmd.target.tab || cmd.target.viewId)).toBe(true);
+		}
+	});
+
+	it("keeps /settings's section option", () => {
+		const settings = byName("settings");
+		expect(settings?.options.some((o) => o.name === "section")).toBe(true);
+	});
+
+	it("never emits duplicate command names on any surface", () => {
+		for (const surface of ["gui", "tui", "discord", "telegram"]) {
+			const names = getConnectorCommands(surface).map((c) => c.name);
+			expect(new Set(names).size).toBe(names.length);
+		}
+	});
+});
+
+describe("connector catalog — client command surface filtering", () => {
+	it("emits client commands to the in-app surfaces (gui/tui)", () => {
+		for (const surface of ["gui", "tui"]) {
+			const names = new Set(getConnectorCommands(surface).map((c) => c.name));
+			expect(names.has("clear")).toBe(true);
+			expect(names.has("fullscreen")).toBe(true);
+		}
+	});
+
+	it("filters client commands off chat connectors (discord/telegram)", () => {
+		for (const surface of ["discord", "telegram"]) {
+			const cmds = getConnectorCommands(surface);
+			expect(cmds.some((c) => c.target.kind === "client")).toBe(false);
+			const names = new Set(cmds.map((c) => c.name));
+			expect(names.has("clear")).toBe(false);
+			expect(names.has("fullscreen")).toBe(false);
+		}
+	});
+
+	it("tags client commands with a concrete clientAction", () => {
+		const clear = getConnectorCommands("gui").find((c) => c.name === "clear");
+		expect(clear?.target.kind === "client" ? clear.target.clientAction : null).toBe(
+			"clear-chat",
+		);
+	});
+});

--- a/plugins/plugin-commands/src/connector-catalog.ts
+++ b/plugins/plugin-commands/src/connector-catalog.ts
@@ -23,11 +23,24 @@ import { DEFAULT_COMMANDS } from "./registry";
 import { getSettingsSectionChoices } from "./settings-sections";
 import type { CommandArgDefinition, CommandDefinition } from "./types";
 
+/**
+ * Client-only behaviors the in-app surfaces (GUI/TUI) run directly, with no
+ * agent round-trip and no remote surface. Mirrors the GUI's `ClientCommandAction`
+ * (packages/ui `client-types-commands.ts`); kept here so the catalog stays
+ * connector-neutral without depending on the UI package.
+ */
+export type ClientCommandAction =
+	| "clear-chat"
+	| "new-conversation"
+	| "toggle-fullscreen"
+	| "open-command-palette"
+	| "show-commands";
+
 /** Where a connector command executes. */
 export type ConnectorCommandTarget =
 	| { kind: "agent" }
-	| { kind: "navigate"; path: string }
-	| { kind: "client" };
+	| { kind: "navigate"; path: string; tab?: string; viewId?: string; section?: string }
+	| { kind: "client"; clientAction: ClientCommandAction };
 
 /** A single argument of a connector command. */
 export interface ConnectorCommandOption {
@@ -86,16 +99,21 @@ function mapRegistryCommand(command: CommandDefinition): ConnectorCommand {
 }
 
 /**
- * Navigation commands the app surfaces in addition to the agent capabilities.
- * These open a destination in the Eliza app rather than routing through the
- * agent. `path` is the in-app deep link the connector can advertise.
+ * Navigation + client commands the app surfaces in addition to the agent
+ * capabilities. Navigation commands open a destination in the Eliza app rather
+ * than routing through the agent; `path` is the in-app deep link a connector can
+ * advertise, and `tab`/`viewId` are routing hints the GUI/TUI use to open the
+ * destination deterministically. Client commands run a GUI/TUI-only behavior.
+ *
+ * The `path`/`tab` values mirror the canonical route table in
+ * `@elizaos/ui` (`navigation/index.ts` `TAB_PATHS`); keep them in sync there.
  */
 function navigationCommands(): ConnectorCommand[] {
 	return [
 		{
 			name: "settings",
 			description: "Open agent settings",
-			target: { kind: "navigate", path: "/settings" },
+			target: { kind: "navigate", path: "/settings", tab: "settings" },
 			options: [
 				{
 					name: "section",
@@ -106,49 +124,117 @@ function navigationCommands(): ConnectorCommand[] {
 			],
 		},
 		{
+			name: "chat",
+			description: "Return to the chat",
+			target: { kind: "navigate", path: "/chat", tab: "chat" },
+			options: [],
+		},
+		{
 			name: "views",
 			description: "Open the agent's views",
-			target: { kind: "navigate", path: "/views" },
+			target: { kind: "navigate", path: "/views", tab: "views" },
 			options: [],
 		},
 		{
 			name: "orchestrator",
 			description: "Open the agent orchestrator",
-			target: { kind: "navigate", path: "/orchestrator" },
+			target: { kind: "navigate", path: "/orchestrator", viewId: "orchestrator" },
+			options: [],
+		},
+		{
+			name: "character",
+			description: "Open the character editor",
+			target: { kind: "navigate", path: "/character", tab: "character" },
 			options: [],
 		},
 		{
 			name: "knowledge",
 			description: "Open the knowledge base",
-			target: { kind: "navigate", path: "/knowledge" },
+			target: { kind: "navigate", path: "/character/documents", tab: "documents" },
+			options: [],
+		},
+		{
+			name: "wallet",
+			description: "Open the wallet & inventory",
+			target: { kind: "navigate", path: "/wallet", tab: "inventory" },
+			options: [],
+		},
+		{
+			name: "automations",
+			description: "Open automations",
+			target: { kind: "navigate", path: "/automations", tab: "automations" },
+			options: [],
+		},
+		{
+			name: "tasks",
+			description: "Open tasks",
+			target: { kind: "navigate", path: "/apps/tasks", tab: "tasks" },
+			options: [],
+		},
+		{
+			name: "skills",
+			description: "Open the skills library",
+			target: { kind: "navigate", path: "/apps/skills", tab: "skills" },
 			options: [],
 		},
 		{
 			name: "plugins",
 			description: "Open installed plugins",
-			target: { kind: "navigate", path: "/plugins" },
+			target: { kind: "navigate", path: "/apps/plugins", tab: "plugins" },
+			options: [],
+		},
+		{
+			name: "logs",
+			description: "Open the logs",
+			target: { kind: "navigate", path: "/apps/logs", tab: "logs" },
+			options: [],
+		},
+		{
+			name: "database",
+			description: "Open the database browser",
+			target: { kind: "navigate", path: "/apps/database", tab: "database" },
+			options: [],
+		},
+		// Client-only behaviors — run in the GUI/TUI, filtered off chat connectors
+		// (a Discord/Telegram user has nothing to clear or full-screen).
+		{
+			name: "clear",
+			description: "Clear the current chat",
+			target: { kind: "client", clientAction: "clear-chat" },
+			options: [],
+		},
+		{
+			name: "fullscreen",
+			description: "Toggle full-screen chat",
+			target: { kind: "client", clientAction: "toggle-fullscreen" },
 			options: [],
 		},
 	];
 }
 
 /**
- * Build the connector command catalog for a given connector.
+ * Build the connector command catalog for a given surface.
  *
  * The catalog is the union of:
  *   - agent-capability commands derived from the enabled, connector-scoped text
  *     command registry, and
- *   - the app navigation commands.
+ *   - the app navigation + client commands.
  *
- * @param _connector the connector key (e.g. "discord"). Reserved for
- *   per-connector filtering; the current catalog is uniform across connectors.
+ * Client-only commands (GUI/TUI behaviors like clear / full-screen) are emitted
+ * to the in-app surfaces but filtered off chat connectors, which have no surface
+ * to run them on.
+ *
+ * @param surface the target surface ("gui" | "tui" | "discord" | "telegram").
  */
-export function getConnectorCommands(_connector: string): ConnectorCommand[] {
+export function getConnectorCommands(surface: string): ConnectorCommand[] {
 	const agentCommands = DEFAULT_COMMANDS.filter(
 		(command) => command.enabled !== false && isConnectorScoped(command),
 	).map(mapRegistryCommand);
 
-	const navigation = navigationCommands();
+	const isChatConnector = surface === "discord" || surface === "telegram";
+	const navigation = navigationCommands().filter(
+		(command) => !(isChatConnector && command.target.kind === "client"),
+	);
 
 	// Navigation commands win on name collisions (they own those surfaces).
 	const navigationNames = new Set(navigation.map((command) => command.name));


### PR DESCRIPTION
Enriches the **wired** connector-catalog (`getConnectorCommands` → `/api/commands` → GUI/TUI/Discord/Telegram) — not the dead `serializeCommands` path (which has zero consumers).

## Fixes
- **2 dead deep-links**: `knowledge` `/knowledge`→`/character/documents`, `plugins` `/plugins`→`/apps/plugins` (canonical `@elizaos/ui` `TAB_PATHS`). On Discord/Telegram these were 404 links.

## Adds
- 8 real nav destinations (chat, character, wallet→inventory, automations, tasks, skills, logs, database) + 2 GUI/TUI-only client commands (clear, fullscreen).
- `tab`/`viewId`/`section` routing hints (deterministic GUI routing) + typed `ClientCommandAction` on `ConnectorCommandTarget`.
- `getConnectorCommands(surface)` now uses its arg to filter client commands off chat connectors (the documented-but-unimplemented intent).
- Agent `/api/commands` `mapTarget` passes the hints + `clientAction` through.
- `connector-catalog.test.ts` covering nav set, path correctness, routing hints, per-surface filtering.

## Verified
- plugin-commands: build + **23/23 tests**
- plugin-discord: typecheck 0 + **101/101 tests**
- agent: `commands-routes.ts` typecheck **0 errors**

## Note
The 10 `plugin-telegram/command-registration.test.ts` failures + the 1 `DynamicViewLoader.tsx` `plugin-health` error are **pre-existing on develop** (telegram = a half-landed refactor where the test imports `buildTelegramSetMyCommands`/`buildNavigateReply` the source doesn't export), unrelated to this change.