### PR TITLE
feat(cloud-api): PATCH /agents/:id — rename + in-place edit

### DIFF
--- a/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
@@ -2,7 +2,9 @@
  * /api/v1/eliza/agents/:agentId
  *
  * GET    — agent detail (with admin slice when caller is org admin).
- * PATCH  — { action: "shutdown" | "suspend" } lifecycle action.
+ * PATCH  — { action: "shutdown" | "suspend" } lifecycle action, OR
+ *          { agentName?, agentConfig? } to edit the agent in place (rename /
+ *          system-prompt edit). A body without `action` is treated as an edit.
  * DELETE — delete sandbox + cleanup linked character.
  */
 
@@ -34,6 +36,15 @@ const app = new Hono<AppEnv>();
 const patchAgentSchema = z.object({
   action: z.enum(["shutdown", "suspend"]),
 });
+
+const editAgentSchema = z
+  .object({
+    agentName: z.string().trim().min(1).max(100).optional(),
+    agentConfig: z.record(z.string(), z.unknown()).optional(),
+  })
+  .refine((d) => d.agentName !== undefined || d.agentConfig !== undefined, {
+    message: "Provide agentName and/or agentConfig",
+  });
 
 type Agent = NonNullable<
   Awaited<ReturnType<typeof elizaSandboxService.getAgent>>
@@ -208,6 +219,49 @@ app.patch("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
     const body = await c.req.json().catch(() => null);
+
+    // A body without `action` is an in-place profile edit (rename / config
+    // edit), not a lifecycle operation. Works for both shared and dedicated
+    // agents; dedicated config edits take effect on the next provision/restart.
+    if (body && typeof body === "object" && !("action" in body)) {
+      const edit = editAgentSchema.safeParse(body);
+      if (!edit.success) {
+        return c.json(
+          {
+            success: false,
+            error: "Invalid request data",
+            details: edit.error.issues,
+          },
+          400,
+        );
+      }
+
+      const updated = await elizaSandboxService.updateAgentProfile(
+        agentId,
+        user.organization_id,
+        { agentName: edit.data.agentName, agentConfig: edit.data.agentConfig },
+      );
+      if (!updated) {
+        return c.json({ success: false, error: "Agent not found" }, 404);
+      }
+
+      logger.info("[agent-api] Agent profile updated", {
+        agentId,
+        orgId: user.organization_id,
+        renamed: edit.data.agentName !== undefined,
+        configEdited: edit.data.agentConfig !== undefined,
+      });
+
+      return c.json({
+        success: true,
+        data: {
+          id: updated.id,
+          agentName: updated.agent_name,
+          executionTier: updated.execution_tier,
+          updatedAt: toIsoString(updated.updated_at),
+        },
+      });
+    }
 
     const parsed = patchAgentSchema.safeParse(body);
     if (!parsed.success) {

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -620,6 +620,41 @@ export class ElizaSandboxService {
     });
   }
 
+  /**
+   * Edit an agent's profile in place — its display name and/or its persisted
+   * `agent_config` (system prompt / character fields). `agentConfig` is merged
+   * into the existing config so a partial edit never drops other keys. A name
+   * edit applies immediately (cloud agent name + shared-runtime character);
+   * dedicated-container config edits take effect on the next provision/restart.
+   */
+  async updateAgentProfile(
+    agentId: string,
+    orgId: string,
+    input: { agentName?: string; agentConfig?: Record<string, unknown> },
+  ): Promise<AgentSandbox | undefined> {
+    const rec = await agentSandboxesRepository.findByIdAndOrgForWrite(
+      agentId,
+      orgId,
+    );
+    if (!rec) return undefined;
+
+    const updates: { agent_name?: string; agent_config?: Record<string, unknown> } =
+      {};
+    if (input.agentName !== undefined) updates.agent_name = input.agentName;
+    if (input.agentConfig !== undefined) {
+      const existing =
+        rec.agent_config &&
+        typeof rec.agent_config === "object" &&
+        !Array.isArray(rec.agent_config)
+          ? (rec.agent_config as Record<string, unknown>)
+          : {};
+      updates.agent_config = { ...existing, ...input.agentConfig };
+    }
+    if (Object.keys(updates).length === 0) return rec;
+
+    return agentSandboxesRepository.update(rec.id, updates);
+  }
+
   async getAgentForWrite(agentId: string, orgId: string) {
     return agentSandboxesRepository.findByIdAndOrgForWrite(agentId, orgId);
   }


### PR DESCRIPTION
Adds in-place agent edit (the app had no rename endpoint; `PATCH /agents/:id` was lifecycle-only).

A PATCH body **without** `action` is an edit: `{ agentName?, agentConfig? }`.
- `elizaSandboxService.updateAgentProfile` — `findByIdAndOrgForWrite` → set `agent_name` and/or **merge** `agent_config` (partial edit never drops keys) → `repository.update`.
- Route branches on `action` presence; lifecycle path unchanged; `editAgentSchema` (name 1-100, config object, ≥1 required).
- Shared + dedicated. Name edits apply immediately; dedicated container config edits apply on next provision/restart.

Closes the rename ask in `ELIZA_CLOUD_DEDICATED_AGENT_ENABLEMENT_SPEC.md`. Typecheck: cloud-shared 0 / cloud-api route 0.