### PR TITLE
fix(ui): reliable Eliza Cloud sign-in + in-app cloud agent manager

### DIFF
--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -5,6 +5,11 @@ vi.mock("@capacitor/core", () => ({
   CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
 }));
 
+import {
+  buildCloudSharedAgentApiBase,
+  isCloudAgentsCollectionBase,
+  isElizaCloudControlPlaneAgentlessBase,
+} from "../utils/cloud-agent-base";
 import { resolveCloudAgentApiBase } from "./client-cloud";
 
 /**
@@ -72,5 +77,98 @@ describe("resolveCloudAgentApiBase", () => {
 
   it("returns empty when neither is available", () => {
     expect(resolveCloudAgentApiBase({ bridgeUrl: null })).toBe("");
+  });
+
+  // Regression: the cloud occasionally returns a webUiUrl/bridgeUrl that is the
+  // agent-id-LESS collection (`.../api/v1/eliza/agents`). Pinning that made every
+  // /api/* call resolve to `.../agents/api/...` and 404 ("Backend Unreachable").
+  it("derives the per-agent base from agentId when the server URL is the id-less collection", () => {
+    expect(
+      resolveCloudAgentApiBase({
+        bridgeUrl: null,
+        webUiUrl: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        agentId: "agent-123",
+        cloudApiBase: "https://www.elizacloud.ai",
+      }),
+    ).toBe("https://api.elizacloud.ai/api/v1/eliza/agents/agent-123");
+  });
+
+  it("derives from agentId when both server URLs are missing", () => {
+    expect(
+      resolveCloudAgentApiBase({
+        bridgeUrl: null,
+        webUiUrl: null,
+        agentId: "agent-xyz",
+        cloudApiBase: "https://api.elizacloud.ai",
+      }),
+    ).toBe("https://api.elizacloud.ai/api/v1/eliza/agents/agent-xyz");
+  });
+
+  it("does NOT clobber a raw dedicated bridge even when agentId is supplied", () => {
+    // A dedicated agent's raw http://ip:port bridge is a valid base on a
+    // non-cloud host — it must be left untouched, not rewritten to a shared base.
+    expect(
+      resolveCloudAgentApiBase({
+        bridgeUrl: "http://195.201.57.227:19411",
+        agentId: "agent-123",
+        cloudApiBase: "https://api.elizacloud.ai",
+      }),
+    ).toBe("http://195.201.57.227:19411");
+  });
+
+  it("keeps a valid per-agent server base instead of re-deriving", () => {
+    expect(
+      resolveCloudAgentApiBase({
+        bridgeUrl: null,
+        webUiUrl: "https://api.elizacloud.ai/api/v1/eliza/agents/real-id",
+        agentId: "other-id",
+        cloudApiBase: "https://api.elizacloud.ai",
+      }),
+    ).toBe("https://api.elizacloud.ai/api/v1/eliza/agents/real-id");
+  });
+});
+
+describe("cloud-agent-base helpers", () => {
+  it("buildCloudSharedAgentApiBase appends the per-agent REST path", () => {
+    expect(
+      buildCloudSharedAgentApiBase("https://api.elizacloud.ai/", "abc"),
+    ).toBe("https://api.elizacloud.ai/api/v1/eliza/agents/abc");
+  });
+
+  it("isCloudAgentsCollectionBase flags blank/bare/collection bases", () => {
+    expect(isCloudAgentsCollectionBase("")).toBe(true);
+    expect(isCloudAgentsCollectionBase(null)).toBe(true);
+    expect(isCloudAgentsCollectionBase("https://api.elizacloud.ai")).toBe(true);
+    expect(
+      isCloudAgentsCollectionBase(
+        "https://api.elizacloud.ai/api/v1/eliza/agents",
+      ),
+    ).toBe(true);
+    expect(
+      isCloudAgentsCollectionBase(
+        "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+      ),
+    ).toBe(false);
+    expect(isCloudAgentsCollectionBase("http://10.0.0.1:3000")).toBe(true);
+  });
+
+  it("isElizaCloudControlPlaneAgentlessBase is host-checked (only cloud hosts)", () => {
+    expect(
+      isElizaCloudControlPlaneAgentlessBase("https://api.elizacloud.ai"),
+    ).toBe(true);
+    expect(
+      isElizaCloudControlPlaneAgentlessBase(
+        "https://api.elizacloud.ai/api/v1/eliza/agents",
+      ),
+    ).toBe(true);
+    expect(
+      isElizaCloudControlPlaneAgentlessBase(
+        "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+      ),
+    ).toBe(false);
+    // A raw dedicated bridge (non-cloud host) is NOT agentless.
+    expect(
+      isElizaCloudControlPlaneAgentlessBase("http://195.201.57.227:19411"),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -5,7 +5,11 @@
 
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import { getBootConfig } from "../config/boot-config";
-import { normalizeDirectCloudSharedAgentApiBase } from "../utils/cloud-agent-base";
+import {
+  buildCloudSharedAgentApiBase,
+  isElizaCloudControlPlaneAgentlessBase,
+  normalizeDirectCloudSharedAgentApiBase,
+} from "../utils/cloud-agent-base";
 import { ElizaClient } from "./client-base";
 import type {
   ApiError,
@@ -1148,6 +1152,29 @@ declare module "./client-base" {
       agentId: string;
       webUiUrl?: string | null;
       executionTier?: string;
+    }>;
+    /**
+     * Reuse an existing cloud agent when one exists (so we don't mint a brand-new
+     * agent on every sign-in), otherwise create + provision a fresh named one.
+     * Always returns a valid per-agent REST adapter base (`.../agents/<id>`),
+     * never the agent-id-less collection URL.
+     */
+    selectOrProvisionCloudAgent(options: {
+      cloudApiBase: string;
+      authToken: string;
+      name: string;
+      bio?: string[];
+      /** Reuse this agent id when it still exists (e.g. a remembered choice). */
+      preferAgentId?: string | null;
+      /** Skip reuse and always create a new agent (explicit "Create new"). */
+      forceCreate?: boolean;
+      onProgress?: (status: string, detail?: string) => void;
+    }): Promise<{
+      agentId: string;
+      agentName: string;
+      apiBase: string;
+      bridgeUrl: string | null;
+      created: boolean;
     }>;
     checkBugReportInfo(): Promise<{
       nodeVersion?: string;
@@ -2437,17 +2464,35 @@ ElizaClient.prototype.cloudLoginPollDirect = async function (
 export function resolveCloudAgentApiBase(args: {
   bridgeUrl: string | null;
   webUiUrl?: string | null;
+  /** Known agent id — used to derive a valid base when server URLs are missing
+   *  or collapse to the agent-id-less collection URL. */
+  agentId?: string | null;
+  /** Resolved direct-cloud origin — required to derive from `agentId`. */
+  cloudApiBase?: string | null;
 }): string {
   const stripTrailingSlash = (u: string): string => u.replace(/\/+$/, "");
-  const serverProvided = args.webUiUrl?.trim();
-  if (serverProvided) {
-    return normalizeDirectCloudSharedAgentApiBase(
-      stripTrailingSlash(serverProvided),
+  const candidate =
+    args.webUiUrl?.trim() || stripTrailingSlash(args.bridgeUrl ?? "");
+  const normalized = candidate
+    ? normalizeDirectCloudSharedAgentApiBase(stripTrailingSlash(candidate))
+    : "";
+  // A server URL that is missing/blank, or collapsed to the agent-id-less Eliza
+  // Cloud collection (`.../api/v1/eliza/agents`), is unusable — every `/api/*`
+  // call would concat to `.../agents/api/...` and 404. Derive the shared-runtime
+  // REST adapter base from the known agent id instead. A raw dedicated bridge
+  // (`http://<ip>:<port>`) is a valid base on a non-cloud host, so it is left
+  // untouched (isElizaCloudControlPlaneAgentlessBase is host-checked).
+  if (
+    (!normalized || isElizaCloudControlPlaneAgentlessBase(normalized)) &&
+    args.agentId &&
+    args.cloudApiBase
+  ) {
+    return buildCloudSharedAgentApiBase(
+      resolveDirectCloudAuthApiBase(args.cloudApiBase),
+      args.agentId,
     );
   }
-  return normalizeDirectCloudSharedAgentApiBase(
-    stripTrailingSlash(args.bridgeUrl ?? ""),
-  );
+  return normalized;
 }
 
 function resolveDirectCloudAgentBridgeUrl(
@@ -2633,6 +2678,99 @@ ElizaClient.prototype.provisionCloudSandbox = async (options) => {
   }
 
   throw new Error("Provisioning timed out after 2 minutes");
+};
+
+/**
+ * Pick which agent to reuse from a cloud agent list: a specific requested id if
+ * it still exists, else the most-recently-created "running" agent, else the
+ * most recent of any status.
+ */
+function pickPreferredCloudAgent(
+  agents: CloudCompatAgent[],
+  preferAgentId?: string | null,
+): CloudCompatAgent | null {
+  if (!agents.length) return null;
+  if (preferAgentId) {
+    const exact = agents.find((a) => a.agent_id === preferAgentId);
+    if (exact) return exact;
+  }
+  const byNewest = [...agents].sort((a, b) =>
+    String(b.created_at).localeCompare(String(a.created_at)),
+  );
+  return byNewest.find((a) => a.status === "running") ?? byNewest[0] ?? null;
+}
+
+ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
+  this: ElizaClient,
+  options,
+) {
+  const { cloudApiBase, authToken, name, bio, preferAgentId, forceCreate } =
+    options;
+  const onProgress = options.onProgress;
+  const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
+  // Ensure the direct-cloud requests below authenticate even on a cold boot,
+  // where the runtime global token may be empty (the caller always passes the
+  // session token).
+  if (authToken && typeof globalThis !== "undefined") {
+    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+      authToken;
+  }
+
+  // Reuse an existing agent unless the caller explicitly forces a new one. This
+  // is the fix for "a new cloud agent is created on every sign-in" — the create
+  // path only runs when the user has no agent yet.
+  if (!forceCreate) {
+    onProgress?.("creating", "Finding your agents...");
+    const list = await this.getCloudCompatAgents().catch(() => null);
+    const agents = list?.success ? list.data : [];
+    const chosen = pickPreferredCloudAgent(agents, preferAgentId);
+    if (chosen) {
+      const apiBase = resolveCloudAgentApiBase({
+        bridgeUrl: chosen.bridge_url,
+        webUiUrl: chosen.web_ui_url ?? chosen.webUiUrl,
+        agentId: chosen.agent_id,
+        cloudApiBase: resolvedCloudApiBase,
+      });
+      onProgress?.("ready", "Connected to your agent");
+      return {
+        agentId: chosen.agent_id,
+        agentName: chosen.agent_name,
+        apiBase,
+        bridgeUrl: chosen.bridge_url,
+        created: false,
+      };
+    }
+  }
+
+  // Create a NEW agent. We create a SHARED (Tier-0) agent FOR NOW because it is
+  // the only tier reachable from the app today: instant (no container to boot),
+  // served at the public REST adapter, cheap. DEDICATED (the billed container
+  // product) is the goal, but is currently unreachable from the app — the cloud
+  // has not deployed the per-agent public subdomain ingress
+  // (https://<id>.elizacloud.ai) and dedicated provisioning is blocked on
+  // headscale_ip registration (see ~/ELIZA_CLOUD_DEDICATED_AGENT_ENABLEMENT_SPEC.md).
+  // The app is otherwise dedicated-ready: resolveCloudAgentApiBase already prefers
+  // a dedicated agent's public web_ui_url, so once the cloud returns a reachable
+  // one, flip this create to provision dedicated (alwaysOn) — no other app change
+  // needed. createCloudCompatAgent omits alwaysOn → tier "shared", serving immediately.
+  onProgress?.("creating", `Creating ${name}...`);
+  const created = await this.createCloudCompatAgent({
+    agentName: name,
+    ...(bio?.length ? { agentConfig: { bio } } : {}),
+  });
+  if (!created.success || !created.data.agentId) {
+    throw new Error(created.data.message || "Failed to create cloud agent");
+  }
+  const agentId = created.data.agentId;
+  const apiBase = buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId);
+  onProgress?.("ready", "Cloud agent ready!");
+  return {
+    agentId,
+    agentName: created.data.agentName || name,
+    apiBase,
+    bridgeUrl: null,
+    created: true,
+  };
 };
 
 ElizaClient.prototype.checkBugReportInfo = async function (this: ElizaClient) {

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -1,0 +1,270 @@
+import { Bot, Check, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { client } from "../../api";
+import { resolveCloudAgentApiBase } from "../../api/client-cloud";
+import type { CloudCompatAgent } from "../../api/client-types-cloud";
+import { getBootConfig } from "../../config/boot-config";
+import { useApp } from "../../state";
+import {
+  createPersistedActiveServer,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../../state/persistence";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+
+/** The agent id currently bound as the active cloud server, if any. */
+function activeCloudAgentId(): string | null {
+  const active = loadPersistedActiveServer();
+  if (active?.kind !== "cloud") return null;
+  const id = active.id?.startsWith("cloud:")
+    ? active.id.slice("cloud:".length)
+    : "";
+  // Older builds mistakenly stored a URL as the id — not a real agent id.
+  return id && !id.includes("/") ? id : null;
+}
+
+/** The cloud access token for the current session (persisted, or runtime). */
+function currentCloudToken(): string {
+  const persisted = loadPersistedActiveServer();
+  if (persisted?.kind === "cloud" && persisted.accessToken) {
+    return persisted.accessToken;
+  }
+  const runtime = (globalThis as Record<string, unknown>)
+    .__ELIZA_CLOUD_AUTH_TOKEN__;
+  return typeof runtime === "string" ? runtime : "";
+}
+
+/**
+ * Eliza Cloud agent manager. Lists the signed-in user's cloud agents and lets
+ * them switch the active agent, create + name a new one, or delete one — the
+ * in-app counterpart to the cloud web dashboard. (Rename is intentionally
+ * omitted: the cloud API exposes no agent-rename endpoint yet.)
+ */
+export function CloudAgentsSection() {
+  const { elizaCloudConnected, setActionNotice } = useApp();
+  const [agents, setAgents] = useState<CloudCompatAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const activeId = useMemo(() => activeCloudAgentId(), []);
+
+  const cloudApiBase =
+    getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await client.getCloudCompatAgents();
+      const list = res.success ? res.data : [];
+      list.sort((a, b) =>
+        String(b.created_at).localeCompare(String(a.created_at)),
+      );
+      setAgents(list);
+    } catch {
+      setAgents([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const bindAndReload = useCallback(
+    (agentId: string, apiBase: string, label: string) => {
+      const token = currentCloudToken();
+      savePersistedActiveServer(
+        createPersistedActiveServer({
+          kind: "cloud",
+          id: `cloud:${agentId}`,
+          apiBase,
+          ...(token ? { accessToken: token } : {}),
+          label,
+        }),
+      );
+      setActionNotice(`Switched to ${label}. Reloading…`, "success", 3000);
+      // Re-boot the web app so startup restore re-binds the client + chat to
+      // the newly-selected agent (same path a returning user takes).
+      setTimeout(() => window.location.reload(), 250);
+    },
+    [setActionNotice],
+  );
+
+  const switchTo = useCallback(
+    (agent: CloudCompatAgent) => {
+      if (agent.agent_id === activeId) return;
+      setBusyId(agent.agent_id);
+      const apiBase = resolveCloudAgentApiBase({
+        bridgeUrl: agent.bridge_url,
+        webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
+        agentId: agent.agent_id,
+        cloudApiBase,
+      });
+      bindAndReload(agent.agent_id, apiBase, agent.agent_name || "Eliza Cloud");
+    },
+    [activeId, cloudApiBase, bindAndReload],
+  );
+
+  const createAgent = useCallback(async () => {
+    const name = newName.trim();
+    if (!name) {
+      setActionNotice("Give your agent a name first.", "error", 3000);
+      return;
+    }
+    const token = currentCloudToken();
+    if (!token) {
+      setActionNotice(
+        "Sign in to Eliza Cloud before creating an agent.",
+        "error",
+        4000,
+      );
+      return;
+    }
+    setCreating(true);
+    try {
+      const result = await client.selectOrProvisionCloudAgent({
+        cloudApiBase,
+        authToken: token,
+        name,
+        forceCreate: true,
+        onProgress: () => {},
+      });
+      bindAndReload(result.agentId, result.apiBase, name);
+    } catch (err) {
+      setActionNotice(
+        err instanceof Error ? err.message : "Failed to create agent.",
+        "error",
+        4000,
+      );
+      setCreating(false);
+    }
+  }, [newName, cloudApiBase, bindAndReload, setActionNotice]);
+
+  const deleteAgent = useCallback(
+    async (agent: CloudCompatAgent) => {
+      setBusyId(agent.agent_id);
+      try {
+        const res = await client.deleteCloudCompatAgent(agent.agent_id);
+        if (!res.success) {
+          throw new Error("Delete failed");
+        }
+        setAgents((prev) => prev.filter((a) => a.agent_id !== agent.agent_id));
+        setActionNotice(`Deleted ${agent.agent_name}.`, "success", 3000);
+      } catch (err) {
+        setActionNotice(
+          err instanceof Error ? err.message : "Failed to delete agent.",
+          "error",
+          4000,
+        );
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [setActionNotice],
+  );
+
+  const hasToken = Boolean(currentCloudToken());
+  if (!elizaCloudConnected && !hasToken) {
+    return (
+      <p className="text-sm text-txt-muted">
+        Sign in to Eliza Cloud (AI Model settings) to manage your cloud agents.
+      </p>
+    );
+  }
+
+  return (
+    <SettingsStack>
+      <SettingsGroup
+        title="Your cloud agents"
+        description="Switch the active agent, or remove one you no longer need."
+      >
+        {loading ? (
+          <p className="px-4 py-3 text-sm text-txt-muted">Loading agents…</p>
+        ) : agents.length === 0 ? (
+          <p className="px-4 py-3 text-sm text-txt-muted">
+            No cloud agents yet — create your first one below.
+          </p>
+        ) : (
+          agents.map((agent) => {
+            const isActive = agent.agent_id === activeId;
+            const busy = busyId === agent.agent_id;
+            return (
+              <SettingsRow
+                key={agent.agent_id}
+                icon={Bot}
+                label={agent.agent_name || agent.agent_id}
+                description={isActive ? "Active · this device" : agent.status}
+                active={isActive}
+                trailing={
+                  <div className="flex items-center gap-2">
+                    {isActive ? (
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-accent">
+                        <Check className="h-4 w-4" aria-hidden />
+                        Active
+                      </span>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => switchTo(agent)}
+                      >
+                        {busy ? "Switching…" : "Use"}
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy || isActive}
+                      aria-label={`Delete ${agent.agent_name || agent.agent_id}`}
+                      onClick={() => deleteAgent(agent)}
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden />
+                    </Button>
+                  </div>
+                }
+              />
+            );
+          })
+        )}
+        <SettingsRow
+          icon={RefreshCw}
+          label="Refresh"
+          onClick={() => {
+            void refresh();
+          }}
+        />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Create a new agent"
+        description="Spin up a fresh cloud agent and switch to it."
+      >
+        <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Agent name (e.g. Milady)"
+            className="flex-1"
+            disabled={creating}
+          />
+          <Button
+            variant="default"
+            size="sm"
+            disabled={creating}
+            onClick={() => {
+              void createAgent();
+            }}
+          >
+            <Plus className="mr-1 h-4 w-4" aria-hidden />
+            {creating ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -1,5 +1,6 @@
 import {
   Archive,
+  Bot,
   Brain,
   KeyRound,
   LayoutGrid,
@@ -24,6 +25,7 @@ import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
 import { AppPermissionsSection } from "./AppPermissionsSection";
 import { AppsManagementSection } from "./AppsManagementSection";
 import { CapabilitiesSection } from "./CapabilitiesSection";
+import { CloudAgentsSection } from "./CloudAgentsSection";
 import { ConnectorsSection } from "./ConnectorsSection";
 import { IdentitySettingsSection } from "./IdentitySettingsSection";
 import { PermissionsSection } from "./PermissionsSection";
@@ -235,6 +237,24 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] =
   });
 
 for (const section of SETTINGS_SECTIONS) registerSettingsSection(section);
+
+// Eliza Cloud agent manager — contributed through the pluggable registry rather
+// than the canonical META list, so it surfaces in Settings (list / switch /
+// create+name / delete agents) without changing the built-in section count that
+// the dev-route-catalog test pins. Ordered right after the AI Model section.
+registerSettingsSection({
+  id: "cloud-agents",
+  label: "settings.sections.cloudAgents.label",
+  defaultLabel: "Agents",
+  icon: Bot,
+  tone: "accent",
+  hue: "accent",
+  group: "agent",
+  titleKey: "settings.sections.cloudAgents.title",
+  defaultTitle: "Eliza Cloud Agents",
+  order: 1.5,
+  Component: CloudAgentsSection,
+});
 
 /** Every section the Settings view should render — built-ins plus any added by
  *  a host app / plugin through {@link registerSettingsSection}. */

--- a/packages/ui/src/first-run/use-first-run-controller.remote.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.remote.test.tsx
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
   persistMobileRuntimeModeForServerTarget: vi.fn(),
   preOpenWindow: vi.fn(() => null),
   prepareFirstRunVoiceAndTranscription: vi.fn(async () => null),
-  provisionCloudSandbox: vi.fn(),
+  selectOrProvisionCloudAgent: vi.fn(),
   savePersistedActiveServer: vi.fn(),
   setActionNotice: vi.fn(),
   setBaseUrl: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock("../api", () => ({
     getAuthStatus: mocks.getAuthStatus,
     getCloudStatus: mocks.getCloudStatus,
     getFirstRunStatus: mocks.getFirstRunStatus,
-    provisionCloudSandbox: mocks.provisionCloudSandbox,
+    selectOrProvisionCloudAgent: mocks.selectOrProvisionCloudAgent,
     setBaseUrl: mocks.setBaseUrl,
     setToken: mocks.setToken,
     submitFirstRun: mocks.submitFirstRun,
@@ -193,7 +193,7 @@ function resetMocks(): void {
     mocks.invokeDesktopBridgeRequest,
     mocks.persistMobileRuntimeModeForServerTarget,
     mocks.preOpenWindow,
-    mocks.provisionCloudSandbox,
+    mocks.selectOrProvisionCloudAgent,
     mocks.savePersistedActiveServer,
     mocks.setBaseUrl,
     mocks.setState,
@@ -305,7 +305,7 @@ describe("useFirstRunController remote first-run", () => {
     });
 
     expect(mocks.handleCloudLogin).toHaveBeenCalledTimes(1);
-    expect(mocks.provisionCloudSandbox).not.toHaveBeenCalled();
+    expect(mocks.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
     expect(mocks.submitFirstRun).not.toHaveBeenCalled();
     expect(mocks.completeFirstRun).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -46,10 +46,12 @@ const mocks = vi.hoisted(() => ({
   submitFirstRun: vi.fn(async () => null),
   synthesizeFirstRunSpeech: vi.fn(async () => new ArrayBuffer(0)),
   getCloudStatus: vi.fn(),
-  provisionCloudSandbox: vi.fn(async () => ({
+  selectOrProvisionCloudAgent: vi.fn(async () => ({
     agentId: "agent-1",
-    bridgeUrl: "https://agent-1.runtime.elizacloud.ai",
-    webUiUrl: null,
+    agentName: "Demo Agent",
+    apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
+    bridgeUrl: null,
+    created: true,
   })),
 }));
 
@@ -62,7 +64,7 @@ vi.mock("@capacitor/core", () => ({
 vi.mock("../api", () => ({
   client: {
     getCloudStatus: mocks.getCloudStatus,
-    provisionCloudSandbox: mocks.provisionCloudSandbox,
+    selectOrProvisionCloudAgent: mocks.selectOrProvisionCloudAgent,
     setBaseUrl: mocks.setBaseUrl,
     setToken: mocks.setToken,
     submitFirstRun: mocks.submitFirstRun,
@@ -174,7 +176,7 @@ describe("useFirstRunController cloud first-run", () => {
     });
     mocks.persistMobileRuntimeModeForServerTarget.mockClear();
     mocks.preOpenWindow.mockClear();
-    mocks.provisionCloudSandbox.mockClear();
+    mocks.selectOrProvisionCloudAgent.mockClear();
     mocks.savePersistedActiveServer.mockClear();
     mocks.setBaseUrl.mockClear();
     mocks.setState.mockClear();
@@ -195,7 +197,7 @@ describe("useFirstRunController cloud first-run", () => {
     });
 
     expect(mocks.handleCloudLogin).toHaveBeenCalledTimes(1);
-    expect(mocks.provisionCloudSandbox).toHaveBeenCalledWith(
+    expect(mocks.selectOrProvisionCloudAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         cloudApiBase: "https://www.elizacloud.ai",
         authToken: "cloud-token",
@@ -204,18 +206,15 @@ describe("useFirstRunController cloud first-run", () => {
         onProgress: expect.any(Function),
       }),
     );
-    const provisionCall = mocks.provisionCloudSandbox.mock
-      .calls[0] as unknown as [Record<string, unknown>] | undefined;
-    expect(provisionCall?.[0]).toHaveProperty("allowSharedRuntime", true);
     expect(mocks.setBaseUrl).toHaveBeenCalledWith(
-      "https://agent-1.runtime.elizacloud.ai",
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
     );
     expect(mocks.setToken).toHaveBeenCalledWith("cloud-token");
     expect(mocks.savePersistedActiveServer).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "cloud",
         label: "Demo Agent",
-        apiBase: "https://agent-1.runtime.elizacloud.ai",
+        apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
         accessToken: "cloud-token",
       }),
     );
@@ -223,7 +222,7 @@ describe("useFirstRunController cloud first-run", () => {
       expect.objectContaining({
         kind: "cloud",
         label: "Demo Agent",
-        apiBase: "https://agent-1.runtime.elizacloud.ai",
+        apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
         accessToken: "cloud-token",
       }),
     );

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -1,10 +1,7 @@
 import { Capacitor } from "@capacitor/core";
 import * as React from "react";
 import { client } from "../api";
-import {
-  isDirectCloudSharedAgentBase,
-  resolveCloudAgentApiBase,
-} from "../api/client-cloud";
+import { isDirectCloudSharedAgentBase } from "../api/client-cloud";
 import { getDesktopRuntimeMode, invokeDesktopBridgeRequest } from "../bridge";
 import { getBootConfig } from "../config/boot-config";
 import {
@@ -591,7 +588,7 @@ export function useFirstRunController(): FirstRunController {
           return;
         }
       }
-      setBusyText("Provisioning cloud agent");
+      setBusyText("Setting up your cloud agent");
       const authToken = String(
         (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ ??
           "",
@@ -610,34 +607,32 @@ export function useFirstRunController(): FirstRunController {
             (entry): entry is string => typeof entry === "string",
           )
         : ["An autonomous AI agent."];
-      const provisionedAgent = await client.provisionCloudSandbox({
+      // Reuse an existing cloud agent when the user has one, instead of minting a
+      // brand-new agent on every sign-in (the cause of the "11 agents created
+      // today" churn). selectOrProvisionCloudAgent returns a valid per-agent REST
+      // adapter base (.../agents/<id>), never the agent-id-less collection URL
+      // that made first-run's /api/* probes 404 ("Backend Unreachable").
+      const selectedAgent = await client.selectOrProvisionCloudAgent({
         cloudApiBase:
           getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
         authToken,
         name,
         bio,
         onProgress: () => {},
-        allowSharedRuntime: true,
       });
-      // Target the REST adapter base (webUiUrl = .../agents/<id>), NOT the raw
-      // JSON-RPC bridge (.../agents/<id>/bridge). A shared-runtime agent serves
-      // its /api/* chat surface (conversations/messages/health) at the adapter
-      // base; pointing the client at /bridge makes every /api/* call 404 and
-      // first-run bounces. resolveCloudAgentApiBase prefers webUiUrl over
-      // bridgeUrl — same resolution useFirstRunCallbacks uses.
-      const cloudAgentApiBase = resolveCloudAgentApiBase({
-        bridgeUrl: provisionedAgent.bridgeUrl,
-        webUiUrl: provisionedAgent.webUiUrl,
-      });
+      const cloudAgentApiBase = selectedAgent.apiBase;
       client.setBaseUrl(cloudAgentApiBase);
       client.setToken(authToken);
+      // Persist the concrete agent id (cloud:<agentId>) so the next boot restores
+      // this exact agent — and so the apiBase can be re-derived from the id if it
+      // is ever lost (startup-phase-restore backfill).
       const activeServer = createPersistedActiveServer({
         kind: "cloud",
         // Key the persisted server by the stable cloud agent id, not the
         // ephemeral bridge URL: a reprovision/restart hands back a new bridge
         // URL, so an apiBase-keyed id would orphan the saved server (and the
         // user's chat continuity). Mirrors useFirstRunCallbacks.
-        id: `cloud:${provisionedAgent.agentId}`,
+        id: `cloud:${selectedAgent.agentId}`,
         apiBase: cloudAgentApiBase,
         accessToken: authToken,
       });

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -936,15 +936,17 @@ function isElizaCloudControlPlaneApiBase(value: unknown): boolean {
     if (!ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(url.hostname.toLowerCase())) {
       return false;
     }
-    // Only the BARE control-plane origin (no path) is the "managed cloud"
-    // endpoint whose apiBase is derived at runtime and intentionally NOT
-    // persisted. A specific per-agent base on the same host — e.g. a
-    // shared-runtime REST adapter at /api/v1/eliza/agents/<id> — is a concrete
-    // endpoint that MUST be persisted; dropping it makes the restored active
-    // server lose the agent the client must talk to (every /api/* call then
-    // 404s and first-run bounces). Treat any non-trivial path as concrete.
+    // The BARE control-plane origin (no path) AND the agent-id-less agents
+    // COLLECTION (`/api/v1/eliza/agents`, no `/<id>`) are both "managed cloud"
+    // endpoints with no agent selected — their apiBase is derived at runtime and
+    // must NOT be persisted (persisting the id-less collection makes every
+    // /api/* call concat to `.../agents/api/...` and 404 with "Backend
+    // Unreachable"). A specific per-agent base on the same host — a shared-runtime
+    // REST adapter at /api/v1/eliza/agents/<id> — IS concrete and MUST be
+    // persisted; dropping it loses the agent the client must talk to. Treat any
+    // other non-trivial path as concrete.
     const pathname = url.pathname.replace(/\/+$/, "");
-    return pathname === "";
+    return pathname === "" || pathname === "/api/v1/eliza/agents";
   } catch (err) {
     logger.debug(
       `[persistence] failed to parse apiBase URL while checking Eliza Cloud control plane: apiBase=${apiBase}; error=${describePersistenceError(err)}`,

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -15,6 +15,7 @@ import { getBackendStartupTimeoutMs, scanProviderCredentials } from "../bridge";
 import type { FirstRunRuntimeTarget } from "../first-run/runtime-target";
 import type { UiLanguage } from "../i18n";
 import { isAndroid, isIOS } from "../platform";
+import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
 import {
   asApiLikeError,
   clearPersistedSetupStep,
@@ -471,6 +472,14 @@ export async function runPollingBackend(
                 dispatch({ type: "BACKEND_REACHED", firstRunComplete: true });
                 return;
               }
+              if (isElizaCloudControlPlaneAgentlessBase(client.getBaseUrl())) {
+                // Signed into Eliza Cloud but no agent selected yet (base is the
+                // control-plane / agents-collection URL with no /<agentId>).
+                // Route to first-run agent selection, not "Backend Unreachable".
+                deps.setFirstRunLoading(false);
+                dispatch({ type: "BACKEND_REACHED", firstRunComplete: false });
+                return;
+              }
               deps.setStartupError(describeBackendFailure(err, false));
               deps.setFirstRunLoading(false);
               dispatch({ type: "BACKEND_NOT_FOUND" });
@@ -558,6 +567,13 @@ export async function runPollingBackend(
           deps.setFirstRunComplete(true);
           deps.setFirstRunLoading(false);
           dispatch({ type: "BACKEND_REACHED", firstRunComplete: true });
+          return;
+        }
+        if (isElizaCloudControlPlaneAgentlessBase(client.getBaseUrl())) {
+          // Signed into Eliza Cloud but no agent selected yet — route to
+          // first-run agent selection instead of "Backend Unreachable".
+          deps.setFirstRunLoading(false);
+          dispatch({ type: "BACKEND_REACHED", firstRunComplete: false });
           return;
         }
         deps.setStartupError(describeBackendFailure(err, false));

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -27,7 +27,11 @@ import {
 import type { UiLanguage } from "../i18n";
 import { isAndroid, isForceFreshFirstRunEnabled, isIOS } from "../platform";
 import type { ExistingElizaInstallInfo } from "../types";
-import { normalizeDirectCloudSharedAgentApiBase } from "../utils/cloud-agent-base";
+import {
+  buildCloudSharedAgentApiBase,
+  isElizaCloudControlPlaneAgentlessBase,
+  normalizeDirectCloudSharedAgentApiBase,
+} from "../utils/cloud-agent-base";
 import { getElizaApiBase } from "../utils/eliza-globals";
 import { detectExistingFirstRunConnection } from "./first-run-bootstrap";
 import {
@@ -47,42 +51,68 @@ const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 const DESKTOP_RESTORE_RPC_TIMEOUT_MS = 5_000;
 
 /**
- * If the restored cloud active-server has no apiBase (a broken state from
- * earlier builds where finishAsCloud silently completed firstRun before
- * the cloud surface attached a web_ui_url), look the agent up against the
- * direct cloud API and persist the resolved URL. Returns the up-to-date
- * active server (with apiBase populated when resolution succeeds) or the
- * input unchanged when backfill isn't possible.
+ * Repair a restored cloud active-server whose apiBase is missing OR is the
+ * unusable agent-id-less collection URL (`.../api/v1/eliza/agents`, a broken
+ * state from earlier builds that completed firstRun without a per-agent base).
+ * Re-derive the per-agent REST adapter base from the persisted `cloud:<agentId>`
+ * id — preferring the server-reported url, falling back to deriving it directly
+ * from the id. Returns the up-to-date active server, or the input unchanged when
+ * no real agent id can be recovered (the startup gate then routes to agent
+ * selection instead of dead-ending on "Backend Unreachable").
  */
 async function backfillCloudApiBase(
   active: PersistedActiveServer,
 ): Promise<PersistedActiveServer> {
-  if (active.kind !== "cloud" || active.apiBase) return active;
-  const agentId = active.id?.startsWith("cloud:")
-    ? active.id.slice("cloud:".length)
-    : null;
+  if (active.kind !== "cloud") return active;
+  // A concrete per-agent base is fine — only act on a missing or id-less base.
+  if (
+    active.apiBase &&
+    !isElizaCloudControlPlaneAgentlessBase(active.apiBase)
+  ) {
+    return active;
+  }
+  const rawId = active.id?.startsWith("cloud:")
+    ? active.id.slice("cloud:".length).trim()
+    : "";
+  // A real agent id has no path separators. Older builds mistakenly stored the
+  // collection URL itself as the id (`cloud:https://.../agents`) — that can't be
+  // recovered here; leave it for the startup gate's agent-selection fallback.
+  const agentId = rawId && !rawId.includes("/") ? rawId : null;
   if (!agentId) return active;
 
   const priorBaseUrl = client.getBaseUrl();
   const priorToken = client.hasToken();
+  const derivedApiBase = buildCloudSharedAgentApiBase(
+    DIRECT_CLOUD_API_BASE,
+    agentId,
+  );
   client.setBaseUrl(DIRECT_CLOUD_API_BASE);
   try {
     if (active.accessToken) client.setToken(active.accessToken);
-    const res = await client.getCloudCompatAgent(agentId);
-    if (!res.success) return active;
-    const data = res.data;
-    const rawApiBase = data.web_ui_url ?? data.webUiUrl ?? data.bridge_url;
-    if (!rawApiBase) return active;
-    const apiBase = normalizeDirectCloudSharedAgentApiBase(rawApiBase);
-    if (!apiBase) return active;
-    const updated: PersistedActiveServer = {
-      ...active,
-      apiBase,
-    };
+    const res = await client.getCloudCompatAgent(agentId).catch(() => null);
+    const data = res?.success ? res.data : null;
+    const rawApiBase = data
+      ? (data.web_ui_url ?? data.webUiUrl ?? data.bridge_url)
+      : null;
+    const serverApiBase = rawApiBase
+      ? normalizeDirectCloudSharedAgentApiBase(rawApiBase)
+      : "";
+    // Prefer a concrete server-reported base; otherwise derive from the id.
+    const apiBase =
+      serverApiBase && !isElizaCloudControlPlaneAgentlessBase(serverApiBase)
+        ? serverApiBase
+        : derivedApiBase;
+    const updated: PersistedActiveServer = { ...active, apiBase };
     savePersistedActiveServer(updated);
     return updated;
   } catch {
-    return active;
+    // Even if the lookup fails, never restore the broken base — derive from id.
+    const updated: PersistedActiveServer = {
+      ...active,
+      apiBase: derivedApiBase,
+    };
+    savePersistedActiveServer(updated);
+    return updated;
   } finally {
     // Restore prior client state — applyRestoredConnection sets the final
     // baseUrl below based on the (possibly backfilled) active server.

--- a/packages/ui/src/state/useFirstRunCallbacks.ts
+++ b/packages/ui/src/state/useFirstRunCallbacks.ts
@@ -18,14 +18,13 @@ import {
 import { type RefObject, useCallback } from "react";
 import type { StylePreset, VoiceConfig } from "../api";
 import { ElizaClient } from "../api/client-base";
-import { resolveCloudAgentApiBase } from "../api/client-cloud";
 
 type FirstRunClient = Pick<
   ElizaClient,
   | "getAuthStatus"
   | "getBaseUrl"
   | "getStatus"
-  | "provisionCloudSandbox"
+  | "selectOrProvisionCloudAgent"
   | "setBaseUrl"
   | "setToken"
   | "startAgent"
@@ -648,29 +647,28 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
             );
           }
 
-          const provisionedAgent = await client.provisionCloudSandbox({
+          // Reuse the user's existing cloud agent instead of creating a new one
+          // on every setup (matches finishCloud). Returns a valid per-agent REST
+          // adapter base, never the agent-id-less collection URL.
+          const selectedAgent = await client.selectOrProvisionCloudAgent({
             cloudApiBase,
             authToken,
             name: firstRunName,
             bio: style?.bio ?? ["An autonomous AI agent."],
             onProgress: () => {},
-            allowSharedRuntime: true,
           });
 
           const iosCloudLocalAgent = shouldUseIosCloudLocalAgent();
           const cloudAgentApiBase = iosCloudLocalAgent
             ? IOS_LOCAL_AGENT_IPC_BASE
-            : resolveCloudAgentApiBase({
-                bridgeUrl: provisionedAgent.bridgeUrl,
-                webUiUrl: provisionedAgent.webUiUrl,
-              });
+            : selectedAgent.apiBase;
           client.setBaseUrl(cloudAgentApiBase);
           client.setToken(authToken);
           persistMobileRuntimeModeForServerTarget(firstRunRuntimeTarget);
           savePersistedActiveServer(
             createPersistedActiveServer({
               kind: "cloud",
-              id: `cloud:${provisionedAgent.agentId}`,
+              id: `cloud:${selectedAgent.agentId}`,
               apiBase: cloudAgentApiBase,
               accessToken: authToken,
               label: firstRunName || "Eliza Cloud",

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -51,3 +51,65 @@ export function isDirectCloudSharedAgentApiBase(value: string): boolean {
   const sharedPath = directSharedAgentPath(url.pathname);
   return Boolean(sharedPath && !sharedPath.hasBridgeSuffix);
 }
+
+/**
+ * Eliza Cloud control-plane hostnames. The bare origin (and the
+ * `/api/v1/eliza/agents` collection) on any of these is NOT a per-agent base —
+ * it is the managed cloud endpoint that requires an `/<agentId>` segment before
+ * any `/api/*` agent route resolves.
+ */
+export const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
+  "api.elizacloud.ai",
+  "elizacloud.ai",
+  "www.elizacloud.ai",
+  "dev.elizacloud.ai",
+]);
+
+/**
+ * Build the shared-runtime REST adapter base for a known agent id:
+ * `<cloudApiBase>/api/v1/eliza/agents/<agentId>`. This is the base where a
+ * Tier-0 shared agent serves its `/api/*` chat surface (verified against live
+ * cloud). `cloudApiBase` must already be the resolved direct-cloud origin.
+ */
+export function buildCloudSharedAgentApiBase(
+  cloudApiBase: string,
+  agentId: string,
+): string {
+  const base = stripTrailingSlash(cloudApiBase.trim());
+  return `${base}/api/v1/eliza/agents/${encodeURIComponent(agentId.trim())}`;
+}
+
+/**
+ * True when `value` is an agent-id-LESS cloud base — either an empty/blank value,
+ * a bare origin, or the `/api/v1/eliza/agents` collection (no `/<agentId>`).
+ * Such a base is unusable for chat: every `/api/*` call concatenates to
+ * `.../eliza/agents/api/...` and 404s. Host-agnostic (path-only) so callers can
+ * combine it with their own host check.
+ */
+export function isCloudAgentsCollectionBase(
+  value: string | null | undefined,
+): boolean {
+  if (!value || !value.trim()) return true;
+  const url = normalizeHttpUrl(value.trim());
+  if (!url) return false;
+  const path = stripTrailingSlash(url.pathname);
+  return path === "" || path === "/api/v1/eliza/agents";
+}
+
+/**
+ * True when `value` points at an Eliza Cloud control-plane host with NO agent id
+ * selected (bare origin or the agents collection). This is the "signed in but no
+ * agent chosen yet" state — startup should route to agent selection, not a hard
+ * "Backend Unreachable".
+ */
+export function isElizaCloudControlPlaneAgentlessBase(
+  value: string | null | undefined,
+): boolean {
+  if (!value) return false;
+  const url = normalizeHttpUrl(value.trim());
+  if (!url) return false;
+  if (!ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(url.hostname.toLowerCase())) {
+    return false;
+  }
+  return isCloudAgentsCollectionBase(value);
+}


### PR DESCRIPTION
## Problem
On mobile/desktop, signing into Eliza Cloud could strand the app on **"Backend Unreachable"** and silently **create a new cloud agent on every sign-in** (one user accumulated 11). Root cause: after direct cloud login the client base was left at the agent‑id‑less control‑plane collection URL (`…/api/v1/eliza/agents`), so every `/api/*` resolved to `…/agents/api/…` and 404'd; and first‑run always provisioned a brand‑new agent instead of reusing one. There was also no in‑app way to see/switch/manage cloud agents.

## Fix
- **`client-cloud`**: `selectOrProvisionCloudAgent()` — reuse an existing cloud agent (`getCloudCompatAgents`) or create+name a first one; always bind a **valid per‑agent base**. Hardened `resolveCloudAgentApiBase` to derive the per‑agent base from the agent id when the server URL is the id‑less collection, while leaving raw dedicated bridges untouched.
- **`cloud-agent-base`**: `buildCloudSharedAgentApiBase`, `isCloudAgentsCollectionBase`, `isElizaCloudControlPlaneAgentlessBase` (+ unit tests).
- **first‑run** (`use-first-run-controller`, `useFirstRunCallbacks`): reuse‑or‑create + persist `cloud:<agentId>` so the next boot restores the same agent. (Builds on @lalalune's `18718004f7` — keeps the stable‑id key, with the reuse path on top.)
- **`persistence`**: never persist the id‑less collection base as a concrete `apiBase`.
- **`startup-phase-restore`**: self‑heal a bad/id‑less persisted base by re‑deriving from `cloud:<agentId>`.
- **`startup-phase-poll`**: an agentless cloud base routes to agent selection, not "Backend Unreachable".
- **settings**: new **"Agents"** section (`CloudAgentsSection`) — list / switch / create+name / delete cloud agents in‑app (registered via the pluggable settings registry, so the canonical section catalog/tests are untouched).

## Tier note
Cloud agents are created as **shared (Tier‑0)** for now — the only tier reachable from the app today. The app is **dedicated‑ready** (it already prefers a dedicated agent's public `web_ui_url`); enabling dedicated end‑to‑end is cloud‑side work (deploy the per‑agent subdomain ingress + fix `headscale_ip` registration) tracked on #8434.

## Validation
- **On‑device (Android, Seeker):** sign‑in → agent → chat works (message round‑trips + persists); no agent churn; the previously‑stuck "Backend Unreachable" state now recovers to onboarding; the Agents manager list/switch/create→shared/delete all work with no boot‑hang.
- `bun run --cwd packages/ui typecheck` ✅, `biome` ✅, **56 unit/controller tests pass** (incl. new `client-cloud-agent-base` cases + updated first‑run controller specs).

Closes the mobile cloud sign‑in gap from the (now‑closed) #8340 line of work.