### PR TITLE
fix(cloud): heartbeat dials the bridge port, not the dead web_ui_port (dedicated agents stay running)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3239,7 +3239,16 @@ export class ElizaSandboxService {
     // probe (the first attempt re-warms the path), then apply hysteresis before
     // giving up — seen live: a freshly-running agent was marked disconnected
     // ~1 min after boot by one transient "fetch failed".
-    const heartbeatEndpoint = await this.getAgentApiEndpoint(rec, "/");
+    // Liveness must dial the BRIDGE port over the headscale tailnet. The
+    // container serves its full HTTP API there (and `/api/health` unauthed —
+    // the same endpoint provisioning's health probe passes on); `web_ui_port`
+    // is a host-only docker port mapping that is NOT reachable over the tailnet,
+    // so the web-base-url path `getAgentApiEndpoint` prefers is a dead poll for
+    // the on-prem worker and was flipping every running agent to `disconnected`.
+    const heartbeatEndpoint = await this.getSafeBridgeEndpoint(
+      rec,
+      "/api/health",
+    );
     let res: Response | null = null;
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {


### PR DESCRIPTION
Every running **dedicated** agent flips to `disconnected` → 404s at its public subdomain (agent-router only routes `running`). The heartbeat built its URL via `getAgentApiEndpoint` → `http://<headscale_ip>:<web_ui_port>`, but **web_ui_port is a host-only docker mapping, not reachable over the headscale tailnet** (`000`); the container serves its full API on the **bridge** port (`/api/health` → `200`, the same endpoint provisioning's health probe uses). So every cycle: `{ succeeded: 0, failed: 38 }` → all agents disconnected. Fix: heartbeat dials `getSafeBridgeEndpoint(rec, '/api/health')`. Verified live on the prod CP. This is the last blocker for the monetized dedicated-agent product (per #8434 / the dedicated-agent enablement spec).