### PR TITLE
fix(plugin-openai): gate media model registration on endpoint capability

### DIFF
--- a/plugins/plugin-discord/__tests__/attachments.test.ts
+++ b/plugins/plugin-discord/__tests__/attachments.test.ts
@@ -71,6 +71,32 @@ describe("AttachmentManager", () => {
 		);
 	});
 
+	it("falls back without calling the model when IMAGE_DESCRIPTION is not registered", async () => {
+		// 2026-06-10 incident: Cerebras-mode deploys register no IMAGE_DESCRIPTION
+		// handler; the graceful-skip path must produce the fallback media (empty
+		// text) instead of attempting a doomed vision call.
+		const runtime = makeRuntime();
+		(runtime.getModel as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+		const manager = new AttachmentManager(runtime);
+
+		const media = await manager.processAttachment(
+			attachment({
+				id: "image-2",
+				url: "https://cdn.discordapp.com/image.png",
+				name: "image.png",
+				contentType: "image/png",
+			}),
+		);
+
+		expect(runtime.useModel).not.toHaveBeenCalled();
+		expect(media).toMatchObject({
+			id: "image-2",
+			contentType: ContentType.IMAGE,
+			description: "An image attachment (recognition failed)",
+			text: "",
+		});
+	});
+
 	it("uses the image description model for normal remote image URLs", async () => {
 		const runtime = makeRuntime();
 		const manager = new AttachmentManager(runtime);

--- a/plugins/plugin-openai/__tests__/cerebras-capability-gating.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-capability-gating.shape.test.ts
@@ -1,0 +1,126 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import openaiPlugin from "../index";
+
+const MEDIA_MODEL_TYPES = [
+  ModelType.IMAGE_DESCRIPTION,
+  ModelType.TRANSCRIPTION,
+  ModelType.TEXT_TO_SPEECH,
+  ModelType.IMAGE,
+] as const;
+
+const ENV_KEYS = [
+  "ELIZA_PROVIDER",
+  "OPENAI_BASE_URL",
+  "OPENAI_API_KEY",
+  "CEREBRAS_API_KEY",
+  "CEREBRAS_BASE_URL",
+  "OPENAI_IMAGE_DESCRIPTION_BASE_URL",
+  "OPENAI_IMAGE_DESCRIPTION_API_KEY",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  // init() fires a background API-key validation request; keep it off the wire.
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as Response);
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+  vi.restoreAllMocks();
+});
+
+function buildRuntime(settings: Record<string, string | undefined>): {
+  runtime: IAgentRuntime;
+  registeredModelTypes: () => string[];
+} {
+  const registerModel = vi.fn();
+  const runtime = {
+    getSetting: vi.fn((key: string) => (key in settings ? (settings[key] ?? null) : null)),
+    registerModel,
+  } as unknown as IAgentRuntime;
+  return {
+    runtime,
+    registeredModelTypes: () => registerModel.mock.calls.map((call) => String(call[0])),
+  };
+}
+
+describe("plugin-openai media capability gating", () => {
+  it("keeps the gated media capabilities out of the static models map", () => {
+    for (const modelType of MEDIA_MODEL_TYPES) {
+      expect(openaiPlugin.models?.[modelType]).toBeUndefined();
+    }
+    expect(openaiPlugin.models?.[ModelType.TEXT_SMALL]).toBeTypeOf("function");
+  });
+
+  it("registers no media capabilities in Cerebras mode (2026-06-10 incident config)", async () => {
+    const { runtime, registeredModelTypes } = buildRuntime({
+      OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
+      CEREBRAS_API_KEY: "csk-cerebras-fake",
+    });
+
+    await openaiPlugin.init?.({}, runtime);
+
+    for (const modelType of MEDIA_MODEL_TYPES) {
+      expect(registeredModelTypes()).not.toContain(modelType);
+    }
+  });
+
+  it("registers IMAGE_DESCRIPTION in Cerebras mode when an explicit vision base URL is set", async () => {
+    const { runtime, registeredModelTypes } = buildRuntime({
+      OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
+      CEREBRAS_API_KEY: "csk-cerebras-fake",
+      OPENAI_IMAGE_DESCRIPTION_BASE_URL: "https://api.openai.com/v1",
+      OPENAI_IMAGE_DESCRIPTION_API_KEY: "sk-vision-fake",
+    });
+
+    await openaiPlugin.init?.({}, runtime);
+
+    expect(registeredModelTypes()).toContain(ModelType.IMAGE_DESCRIPTION);
+    // The override is per-capability: the un-overridable endpoints stay gated.
+    expect(registeredModelTypes()).not.toContain(ModelType.TRANSCRIPTION);
+    expect(registeredModelTypes()).not.toContain(ModelType.TEXT_TO_SPEECH);
+    expect(registeredModelTypes()).not.toContain(ModelType.IMAGE);
+  });
+
+  it("does not treat a vision API key alone as an override", async () => {
+    // getImageDescriptionBaseURL falls back to getBaseURL when only the key is
+    // set, so the capability would still POST to Cerebras and 400 per image.
+    const { runtime, registeredModelTypes } = buildRuntime({
+      ELIZA_PROVIDER: "cerebras",
+      CEREBRAS_API_KEY: "csk-cerebras-fake",
+      OPENAI_IMAGE_DESCRIPTION_API_KEY: "sk-vision-fake",
+    });
+
+    await openaiPlugin.init?.({}, runtime);
+
+    expect(registeredModelTypes()).not.toContain(ModelType.IMAGE_DESCRIPTION);
+  });
+
+  it("registers all media capabilities in OpenAI mode", async () => {
+    const { runtime, registeredModelTypes } = buildRuntime({
+      OPENAI_API_KEY: "sk-openai-fake",
+    });
+
+    await openaiPlugin.init?.({}, runtime);
+
+    for (const modelType of MEDIA_MODEL_TYPES) {
+      expect(registeredModelTypes()).toContain(modelType);
+    }
+  });
+});

--- a/plugins/plugin-openai/index.ts
+++ b/plugins/plugin-openai/index.ts
@@ -33,7 +33,7 @@ import {
   handleTranscription,
 } from "./models";
 import type { ImageGenerationResult, OpenAIPluginConfig, TextStreamResult } from "./types";
-import { getAuthHeader, getBaseURL } from "./utils/config";
+import { getAuthHeader, getBaseURL, getSetting, isCerebrasMode } from "./utils/config";
 
 function getProcessEnv(): ProcessEnvLike {
   if (typeof process === "undefined") {
@@ -48,6 +48,83 @@ const TEXT_MEDIUM_MODEL_TYPE = ModelType.TEXT_MEDIUM as string;
 const TEXT_MEGA_MODEL_TYPE = ModelType.TEXT_MEGA as string;
 const RESPONSE_HANDLER_MODEL_TYPE = ModelType.RESPONSE_HANDLER as string;
 const ACTION_PLANNER_MODEL_TYPE = ModelType.ACTION_PLANNER as string;
+
+function hasExplicitCapabilityOverride(
+  runtime: IAgentRuntime,
+  overrideKeys: readonly string[]
+): boolean {
+  return overrideKeys.some((key) => {
+    const value = getSetting(runtime, key);
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+// Per-capability endpoint overrides: when set, the capability does not POST to
+// getBaseURL, so it stays registered even in Cerebras mode. Only the base URL
+// counts: OPENAI_IMAGE_DESCRIPTION_API_KEY alone still posts to getBaseURL
+// (getImageDescriptionBaseURL falls back to it), i.e. straight at Cerebras.
+// TRANSCRIPTION, TEXT_TO_SPEECH, and IMAGE have no such override today.
+const mediaModelOverrideKeys: Record<string, readonly string[]> = {
+  [ModelType.IMAGE_DESCRIPTION]: ["OPENAI_IMAGE_DESCRIPTION_BASE_URL"],
+};
+
+const mediaModels: NonNullable<Plugin["models"]> = {
+  [ModelType.IMAGE]: async (
+    runtime: IAgentRuntime,
+    params: ImageGenerationParams
+  ): Promise<ImageGenerationResult[]> => {
+    return handleImageGeneration(runtime, params);
+  },
+
+  [ModelType.IMAGE_DESCRIPTION]: async (
+    runtime: IAgentRuntime,
+    params: ImageDescriptionParams | string
+  ): Promise<{ title: string; description: string }> => {
+    return handleImageDescription(runtime, params);
+  },
+
+  [ModelType.TRANSCRIPTION]: async (
+    runtime: IAgentRuntime,
+    input: CoreTranscriptionParams | Buffer | string
+  ): Promise<string> => {
+    return handleTranscription(runtime, input);
+  },
+
+  [ModelType.TEXT_TO_SPEECH]: async (
+    runtime: IAgentRuntime,
+    input: CoreTextToSpeechParams | string
+  ): Promise<ArrayBuffer> => {
+    return handleTextToSpeech(runtime, input);
+  },
+};
+
+// Cerebras serves text models only: vision chat completions, /audio/transcriptions,
+// /audio/speech, and /images/generations all fail against its endpoint. Mirror the
+// embedding shouldUseLocalEmbeddingFallback gate (models/embedding.ts): in Cerebras
+// mode these capabilities stay unregistered unless an explicit per-capability
+// override points them at an endpoint that serves them, so consumers (e.g.
+// plugin-discord's isImageDescriptionEnabled) skip gracefully instead of failing
+// on every attachment.
+function registerMediaModels(runtime: IAgentRuntime): void {
+  const cerebras = isCerebrasMode(runtime);
+  for (const [modelType, handler] of Object.entries(mediaModels)) {
+    if (
+      cerebras &&
+      !hasExplicitCapabilityOverride(runtime, mediaModelOverrideKeys[modelType] ?? [])
+    ) {
+      logger.info(
+        `[OpenAI] Not registering ${modelType}: the Cerebras endpoint does not serve it`
+      );
+      continue;
+    }
+    runtime.registerModel(
+      modelType,
+      handler as Parameters<IAgentRuntime["registerModel"]>[1],
+      openaiPlugin.name,
+      openaiPlugin.priority
+    );
+  }
+}
 
 export const openaiPlugin: Plugin = {
   name: "openai",
@@ -95,6 +172,7 @@ export const openaiPlugin: Plugin = {
 
   async init(config: Record<string, string>, runtime: IAgentRuntime): Promise<void> {
     initializeOpenAI(config as OpenAIPluginConfig | undefined, runtime);
+    registerMediaModels(runtime);
   },
 
   models: {
@@ -168,33 +246,9 @@ export const openaiPlugin: Plugin = {
       return handleActionPlanner(runtime, params);
     },
 
-    [ModelType.IMAGE]: async (
-      runtime: IAgentRuntime,
-      params: ImageGenerationParams
-    ): Promise<ImageGenerationResult[]> => {
-      return handleImageGeneration(runtime, params);
-    },
-
-    [ModelType.IMAGE_DESCRIPTION]: async (
-      runtime: IAgentRuntime,
-      params: ImageDescriptionParams | string
-    ): Promise<{ title: string; description: string }> => {
-      return handleImageDescription(runtime, params);
-    },
-
-    [ModelType.TRANSCRIPTION]: async (
-      runtime: IAgentRuntime,
-      input: CoreTranscriptionParams | Buffer | string
-    ): Promise<string> => {
-      return handleTranscription(runtime, input);
-    },
-
-    [ModelType.TEXT_TO_SPEECH]: async (
-      runtime: IAgentRuntime,
-      input: CoreTextToSpeechParams | string
-    ): Promise<ArrayBuffer> => {
-      return handleTextToSpeech(runtime, input);
-    },
+    // IMAGE / IMAGE_DESCRIPTION / TRANSCRIPTION / TEXT_TO_SPEECH are registered
+    // in init() via registerMediaModels so registration can be gated on the
+    // resolved endpoint actually serving them (see Cerebras gate above).
 
     [ModelType.RESEARCH]: async (
       runtime: IAgentRuntime,


### PR DESCRIPTION
## Problem

When `plugin-openai` runs against **Cerebras** (or any OpenAI-compatible endpoint that serves text models only), the media capabilities are still registered and point at that endpoint. Cerebras 400s/404s on vision chat completions, `/audio/transcriptions`, `/audio/speech`, and `/images/generations`. So every image attachment, transcription, or TTS request fails — e.g. an agent on a Cerebras base URL returns **HTTP 400 on every image** a user sends, instead of degrading gracefully.

The embedding path already handles this (`shouldUseLocalEmbeddingFallback` in `models/embedding.ts`), but `IMAGE`, `IMAGE_DESCRIPTION`, `TRANSCRIPTION`, and `TEXT_TO_SPEECH` were registered unconditionally from the static `models` map.

## Fix

Register the four media models from `init()` via `registerMediaModels(runtime)` instead of the static map, and **skip them in Cerebras mode** unless an explicit per-capability **base-URL** override points the capability at an endpoint that actually serves it (e.g. `OPENAI_IMAGE_DESCRIPTION_BASE_URL`). This mirrors the existing embedding gate.

Important subtlety: only the **base URL** counts. `OPENAI_IMAGE_DESCRIPTION_API_KEY` alone does **not** keep the capability registered, because `getImageDescriptionBaseURL()` falls back to `getBaseURL()` — i.e. straight back at Cerebras. An API key with no base URL would just fail again.

With no handler registered, downstream consumers take their graceful-skip path instead of failing — e.g. `plugin-discord`'s `isImageDescriptionEnabled()` skips image description rather than erroring on every attachment.

## Changes

- `plugins/plugin-openai/index.ts` — `registerMediaModels()` + `hasExplicitCapabilityOverride()`; media models move out of the static `models` map and register conditionally from `init()`.
- `plugins/plugin-openai/__tests__/cerebras-capability-gating.shape.test.ts` — new: asserts which capabilities register in Cerebras mode, with and without per-capability base-URL overrides.
- `plugins/plugin-discord/__tests__/attachments.test.ts` — adds coverage for the graceful-skip path when no `IMAGE_DESCRIPTION` handler is registered.

## Notes

- General: applies to any text-only OpenAI-compatible endpoint, not just Cerebras.
- Behavior-preserving for standard OpenAI deployments — when the base URL serves these capabilities, all four register exactly as before.
- Verified live: an agent on a Cerebras base URL now degrades gracefully on image attachments instead of 400-ing.
