### PR TITLE
feat(ui): rename cloud agents in-app (Settings → Agents)

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1041,6 +1041,18 @@ declare module "./client-base" {
       success: boolean;
       data: { jobId: string; status: string; message: string };
     }>;
+    /**
+     * Edit a cloud agent in place — rename and/or update its config
+     * (e.g. system prompt / bio). Backed by `PATCH /api/v1/eliza/agents/:id`.
+     */
+    updateCloudCompatAgent(
+      agentId: string,
+      edit: { agentName?: string; agentConfig?: Record<string, unknown> },
+    ): Promise<{
+      success: boolean;
+      error?: string;
+      data: { agentId: string; agentName: string };
+    }>;
     getCloudCompatAgentStatus(agentId: string): Promise<{
       success: boolean;
       data: CloudCompatAgentStatus;
@@ -1944,6 +1956,61 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
 
   return this.fetch(`/api/cloud/compat/agents/${encodeURIComponent(agentId)}`, {
     method: "DELETE",
+  });
+};
+
+ElizaClient.prototype.updateCloudCompatAgent = async function (
+  this: ElizaClient,
+  agentId,
+  edit,
+) {
+  const path = `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`;
+  const body = JSON.stringify({
+    ...(edit.agentName !== undefined ? { agentName: edit.agentName } : {}),
+    ...(edit.agentConfig !== undefined
+      ? { agentConfig: edit.agentConfig }
+      : {}),
+  });
+  const normalize = (response: {
+    success?: boolean;
+    data?: { agentId?: string; agentName?: string };
+    error?: string;
+  }) => ({
+    success: response.success === true,
+    ...(response.error ? { error: response.error } : {}),
+    data: {
+      agentId: response.data?.agentId ?? agentId,
+      agentName: response.data?.agentName ?? edit.agentName ?? "",
+    },
+  });
+
+  const direct = await directCloudRequest<{
+    success: boolean;
+    data?: { agentId?: string; agentName?: string };
+    error?: string;
+  }>(this, path, { method: "PATCH", body });
+  if (direct) return normalize(direct);
+
+  if (isNativeDirectCloudAuthMissing(this)) {
+    return {
+      success: false,
+      error: nativeDirectCloudAuthMissingMessage(),
+      data: { agentId, agentName: edit.agentName ?? "" },
+    };
+  }
+
+  if (isDirectCloudBase(this)) {
+    const response = await this.fetch<{
+      success: boolean;
+      data?: { agentId?: string; agentName?: string };
+      error?: string;
+    }>(path, { method: "PATCH", body }, { allowNonOk: true });
+    return normalize(response);
+  }
+
+  return this.fetch(`/api/cloud/compat/agents/${encodeURIComponent(agentId)}`, {
+    method: "PATCH",
+    body,
   });
 };
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -1,4 +1,4 @@
-import { Bot, Check, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Bot, Check, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../api";
 import { resolveCloudAgentApiBase } from "../../api/client-cloud";
@@ -38,9 +38,8 @@ function currentCloudToken(): string {
 
 /**
  * Eliza Cloud agent manager. Lists the signed-in user's cloud agents and lets
- * them switch the active agent, create + name a new one, or delete one — the
- * in-app counterpart to the cloud web dashboard. (Rename is intentionally
- * omitted: the cloud API exposes no agent-rename endpoint yet.)
+ * them switch the active agent, create + name a new one, rename one, or delete
+ * one — the in-app counterpart to the cloud web dashboard.
  */
 export function CloudAgentsSection() {
   const { elizaCloudConnected, setActionNotice } = useApp();
@@ -49,6 +48,8 @@ export function CloudAgentsSection() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
   const activeId = useMemo(() => activeCloudAgentId(), []);
 
   const cloudApiBase =
@@ -167,6 +168,46 @@ export function CloudAgentsSection() {
     [setActionNotice],
   );
 
+  const startRename = useCallback((agent: CloudCompatAgent) => {
+    setEditingId(agent.agent_id);
+    setEditName(agent.agent_name || "");
+  }, []);
+
+  const saveRename = useCallback(
+    async (agent: CloudCompatAgent) => {
+      const name = editName.trim();
+      if (!name || name === agent.agent_name) {
+        setEditingId(null);
+        return;
+      }
+      setBusyId(agent.agent_id);
+      try {
+        const res = await client.updateCloudCompatAgent(agent.agent_id, {
+          agentName: name,
+        });
+        if (!res.success) {
+          throw new Error(res.error || "Rename failed");
+        }
+        setAgents((prev) =>
+          prev.map((a) =>
+            a.agent_id === agent.agent_id ? { ...a, agent_name: name } : a,
+          ),
+        );
+        setActionNotice(`Renamed to ${name}.`, "success", 3000);
+        setEditingId(null);
+      } catch (err) {
+        setActionNotice(
+          err instanceof Error ? err.message : "Failed to rename agent.",
+          "error",
+          4000,
+        );
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [editName, setActionNotice],
+  );
+
   const hasToken = Boolean(currentCloudToken());
   if (!elizaCloudConnected && !hasToken) {
     return (
@@ -192,6 +233,48 @@ export function CloudAgentsSection() {
           agents.map((agent) => {
             const isActive = agent.agent_id === activeId;
             const busy = busyId === agent.agent_id;
+            if (editingId === agent.agent_id) {
+              return (
+                <div
+                  key={agent.agent_id}
+                  className="flex items-center gap-2 px-4 py-3"
+                >
+                  <Bot
+                    className="h-5 w-5 shrink-0 text-txt-muted"
+                    aria-hidden
+                  />
+                  {/* biome-ignore lint/a11y/noAutofocus: focus the rename field on open */}
+                  <Input
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") void saveRename(agent);
+                      if (e.key === "Escape") setEditingId(null);
+                    }}
+                    className="flex-1"
+                    aria-label="Agent name"
+                    disabled={busy}
+                    autoFocus
+                  />
+                  <Button
+                    variant="default"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => void saveRename(agent)}
+                  >
+                    {busy ? "Saving…" : "Save"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => setEditingId(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              );
+            }
             return (
               <SettingsRow
                 key={agent.agent_id}
@@ -216,6 +299,15 @@ export function CloudAgentsSection() {
                         {busy ? "Switching…" : "Use"}
                       </Button>
                     )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy}
+                      aria-label={`Rename ${agent.agent_name || agent.agent_id}`}
+                      onClick={() => startRename(agent)}
+                    >
+                      <Pencil className="h-4 w-4" aria-hidden />
+                    </Button>
                     <Button
                       variant="ghost"
                       size="sm"


### PR DESCRIPTION
Builds on #8608 (`PATCH /api/v1/eliza/agents/:id` — rename + edit in place) and #8609 (the in-app agent manager).

- **`client-cloud`**: `updateCloudCompatAgent(agentId, { agentName?, agentConfig? })` → PATCHes the agent (same direct/native/fetch fallback shape as `deleteCloudCompatAgent`).
- **`CloudAgentsSection`**: a pencil action per agent opens an **inline rename** field (Enter saves, Esc cancels); on save it PATCHes and updates the list in place.

Completes the manage/edit story: list / switch / create+name / **rename** / delete. The client method also accepts `agentConfig`, so an in-app **system-prompt editor** is a small follow-up on the same endpoint.

typecheck + biome + ui tests green. Follows the proven manager pattern (delete/create already verified on-device).