### PR TITLE
fix(core): gate attachment read hints on stored text, not failure prose

### DIFF
--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Media, Memory, UUID } from "../types/index.ts";
+import { formatMessages } from "../utils.ts";
+
+const roomId = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function messageWithAttachment(attachment: Media): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000011" as UUID,
+		entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+		roomId,
+		createdAt: 1765381653000,
+		content: {
+			text: "How can I max profit from this",
+			attachments: [attachment],
+		},
+	} as Memory;
+}
+
+describe("formatMessages", () => {
+	it("does not advertise a stored-content read for a failure-prose description without text", () => {
+		// 2026-06-10 incident shape: mp4 ingest failed (no ffprobe), leaving
+		// placeholder prose in description and empty text; conversation history
+		// must not advertise an unsatisfiable ATTACHMENT read.
+		const rendered = formatMessages({
+			messages: [
+				messageWithAttachment({
+					id: "generated-video",
+					url: "https://cdn.discordapp.test/attachments/1/2/Generated_Video.mp4",
+					title: "Generated_Video.mp4",
+					source: "Video",
+					contentType: "video",
+					description: "An audio/video attachment (transcription failed)",
+					text: "",
+				}),
+			],
+			entities: [],
+		});
+
+		expect(rendered).toContain("Generated_Video.mp4");
+		expect(rendered).not.toContain(
+			"Stored content available via ATTACHMENT action=read",
+		);
+	});
+
+	it("advertises a stored-content read when readable text is stored", () => {
+		const rendered = formatMessages({
+			messages: [
+				messageWithAttachment({
+					id: "generated-video",
+					url: "https://cdn.discordapp.test/attachments/1/2/Generated_Video.mp4",
+					title: "Generated_Video.mp4",
+					source: "Video",
+					contentType: "video",
+					description: "A clip about the coffee shop",
+					text: "welcome to the coffee shop, home of the $50 latte",
+				}),
+			],
+			entities: [],
+		});
+
+		expect(rendered).toContain(
+			"Stored content available via ATTACHMENT action=read",
+		);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
+import {
+	type IAgentRuntime,
+	type Memory,
+	ModelType,
+	type UUID,
+} from "../../../types/index.ts";
 import { attachmentsProvider } from "./attachments.ts";
 
 const roomId = "00000000-0000-0000-0000-000000000001" as UUID;
@@ -26,10 +31,18 @@ function attachmentMemory(createdAt = 1): Memory {
 	} as Memory;
 }
 
-function makeRuntime(recentMessages: Memory[]): IAgentRuntime {
+function makeRuntime(
+	recentMessages: Memory[],
+	options: { hasImageDescriptionModel?: boolean } = {},
+): IAgentRuntime {
 	return {
 		getConversationLength: () => 20,
 		getMemories: async () => recentMessages,
+		getModel: (modelType: string) =>
+			options.hasImageDescriptionModel &&
+			modelType === ModelType.IMAGE_DESCRIPTION
+				? async () => ({ title: "", description: "" })
+				: undefined,
 	} as unknown as IAgentRuntime;
 }
 
@@ -91,5 +104,105 @@ describe("attachmentsProvider", () => {
 
 		expect(result.text).toBe("");
 		expect(result.data?.visibleAttachments).toHaveLength(1);
+	});
+
+	it("does not advertise an ATTACHMENT read for a failure-prose description without stored text", async () => {
+		// 2026-06-10 incident: mp4 transcription failed (no ffprobe) so the
+		// attachment carried only placeholder prose in description with empty
+		// text; the advertised read was unsatisfiable and the turn died in a
+		// forced-tool IGNORE loop.
+		const result = await attachmentsProvider.get(
+			makeRuntime([]),
+			makeMessage({
+				text: "How can I max profit from this",
+				attachments: [
+					{
+						id: "generated-video",
+						url: "https://cdn.discordapp.test/attachments/1/2/Generated_Video.mp4",
+						title: "Generated_Video.mp4",
+						source: "Video",
+						contentType: "video",
+						description: "An audio/video attachment (transcription failed)",
+						text: "",
+					},
+				],
+			}),
+		);
+
+		expect(result.text).toContain("Stored Content: none");
+		expect(result.text).not.toContain("available via ATTACHMENT action=read");
+	});
+
+	it("advertises an ATTACHMENT read when readable text is stored", async () => {
+		const result = await attachmentsProvider.get(
+			makeRuntime([]),
+			makeMessage({
+				text: "How can I max profit from this",
+				attachments: [
+					{
+						id: "generated-video",
+						url: "https://cdn.discordapp.test/attachments/1/2/Generated_Video.mp4",
+						title: "Generated_Video.mp4",
+						source: "Video",
+						contentType: "video",
+						description: "A clip about the coffee shop",
+						text: "welcome to the coffee shop, home of the $50 latte",
+					},
+				],
+			}),
+		);
+
+		expect(result.text).toContain(
+			"Stored Content: available via ATTACHMENT action=read",
+		);
+	});
+
+	it("advertises a read for a failed-ingest image when a vision model is registered", async () => {
+		// The read action re-describes IMAGEs at read time, so a working-vision
+		// deploy can satisfy the read even though ingest stored only the
+		// failure placeholder.
+		const result = await attachmentsProvider.get(
+			makeRuntime([], { hasImageDescriptionModel: true }),
+			makeMessage({
+				text: "what is in this image?",
+				attachments: [
+					{
+						id: "failed-ingest-image",
+						url: "https://cdn.discordapp.test/attachments/1/3/photo.png",
+						title: "photo.png",
+						source: "Image",
+						contentType: "image",
+						description: "An image attachment (recognition failed)",
+						text: "",
+					},
+				],
+			}),
+		);
+
+		expect(result.text).toContain(
+			"Stored Content: available via ATTACHMENT action=read",
+		);
+	});
+
+	it("does not advertise a read for a failed-ingest image without a vision model", async () => {
+		const result = await attachmentsProvider.get(
+			makeRuntime([], { hasImageDescriptionModel: false }),
+			makeMessage({
+				text: "what is in this image?",
+				attachments: [
+					{
+						id: "failed-ingest-image",
+						url: "https://cdn.discordapp.test/attachments/1/3/photo.png",
+						title: "photo.png",
+						source: "Image",
+						contentType: "image",
+						description: "An image attachment (recognition failed)",
+						text: "",
+					},
+				],
+			}),
+		);
+
+		expect(result.text).toContain("Stored Content: none");
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/attachments.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.ts
@@ -1,10 +1,12 @@
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
-import type {
-	IAgentRuntime,
-	Media,
-	Memory,
-	Provider,
-	ProviderResult,
+import {
+	ContentType,
+	type IAgentRuntime,
+	type Media,
+	type Memory,
+	ModelType,
+	type Provider,
+	type ProviderResult,
 } from "../../../types/index.ts";
 import { addHeader } from "../../../utils.ts";
 
@@ -154,7 +156,15 @@ export const attachmentsProvider: Provider = {
     Type: ${attachment.source}
     Content Type: ${attachment.contentType ?? "unknown"}
     Stored Content: ${
-			attachment.text || attachment.description
+			// Keyed on text (the canonical readable-content field) only: failed
+			// processing leaves text empty but stores failure prose in description,
+			// which must not advertise an unsatisfiable ATTACHMENT read. Images are
+			// the exception: the read action re-describes them at read time
+			// (working-memory/attachmentContext), so the read is satisfiable
+			// whenever an IMAGE_DESCRIPTION model is registered.
+			attachment.text ||
+			(attachment.contentType === ContentType.IMAGE &&
+				typeof runtime.getModel(ModelType.IMAGE_DESCRIPTION) === "function")
 				? "available via ATTACHMENT action=read"
 				: "none"
 		}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -526,7 +526,10 @@ export const formatMessages = ({
 							if (media.contentType) {
 								lines.push(`Type: ${media.contentType}`);
 							}
-							if (media.text || media.description) {
+							// Keyed on text only: failed processing leaves text empty but
+							// stores failure prose in description, which must not advertise
+							// an unsatisfiable ATTACHMENT read.
+							if (media.text) {
 								lines.push(
 									"Stored content available via ATTACHMENT action=read",
 								);


### PR DESCRIPTION
## Problem

When attachment processing fails (no `ffprobe`, a vision endpoint 400s, etc.), the failure prose is stored in the attachment's `description` field with an **empty `text`**. But both render sites — the `ATTACHMENTS` provider and `formatMessages` (the `RECENT_MESSAGES` history) — advertised *"available via ATTACHMENT action=read"* for **any truthy `text || description`**.

The `read` action filters exactly those placeholder/failure descriptions, so the hint was **unsatisfiable**: the model is told it can read content that the read action then refuses. On 2026-06-10 this drove a forced-tool `IGNORE` loop into `TrajectoryLimitExceeded` — the agent kept trying to satisfy a read hint that could never succeed.

## Fix

Key both read hints on `attachment.text` — the canonical readable-content field — instead of `text || description`. A failure-prose-only attachment (empty `text`) no longer advertises a read it can't fulfill.

**Images are the documented exception** in the provider: the `read` action re-describes an image at read time via the `IMAGE_DESCRIPTION` model, so a registered image-description model keeps the read satisfiable even without stored text. That branch is preserved.

## Changes

- `packages/core/src/features/basic-capabilities/providers/attachments.ts` — gate the provider hint on `text` (image exception preserved).
- `packages/core/src/utils.ts` — same gate in `formatMessages` (history render site).
- `packages/core/src/features/basic-capabilities/providers/attachments.test.ts` + `packages/core/src/__tests__/messages-format.test.ts` — cover failure-prose, empty-text, and image-exception cases.

## Notes

- Pairs with #8614: that PR stops the vision-endpoint 400 at the source (don't register a vision model the endpoint can't serve); this PR stops the *downstream* unsatisfiable-read loop when an attachment ends up with no readable text for any reason.
- Behavior-preserving for attachments that actually have readable `text`.
