### PR TITLE
fix(core): never surface scratch prose from a STOP-only planner terminal

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1654,4 +1654,51 @@ describe("v5 planner loop — evaluator gate", () => {
 
 		expect(evaluate).toHaveBeenCalled();
 	});
+
+	it("never surfaces scratch prose accompanying a STOP-only terminal", async () => {
+		// Live regression 2026-06-12 (tj-5d0d458b7ad281): after spawning a
+		// sub-agent the planner emitted STOP plus the free text "We should wait
+		// for the sub-agent result before replying." — and that scratch
+		// reasoning was sent to Discord verbatim as the reply.
+		const runtime = {
+			useModel: vi.fn().mockResolvedValueOnce({
+				text: "We should wait for the sub-agent result before replying.",
+				toolCalls: [{ id: "stop-1", name: "STOP", arguments: {} }],
+			}),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBeUndefined();
+	});
+
+	it("keeps the prose fallback for a textless REPLY terminal", async () => {
+		// Counterpart contract: when the model DID choose REPLY but put the
+		// answer in the text channel instead of the call args, the prose is
+		// the reply and must still reach the user.
+		const runtime = {
+			useModel: vi.fn().mockResolvedValueOnce({
+				text: "Here is your answer.",
+				toolCalls: [{ id: "reply-1", name: "REPLY", arguments: {} }],
+			}),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("Here is your answer.");
+	});
 });

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -379,10 +379,21 @@ export async function runPlannerLoop(
 					});
 					continue;
 				}
-				const finalMessage = terminalMessageFromToolCalls(
-					plannerOutput.toolCalls,
-					plannerOutput.messageToUser,
+				// The messageToUser fallback applies only when a REPLY call is
+				// present (textless REPLY → the model's text is its reply). On
+				// STOP/IGNORE-only terminals the model chose silence: free text
+				// accompanying the call is scratch reasoning, not a user reply
+				// ("We should wait for the sub-agent result before replying."
+				// reached Discord verbatim, live 2026-06-12).
+				const hasReplyCall = plannerOutput.toolCalls.some(
+					(toolCall) => toolCall.name.toUpperCase() === "REPLY",
 				);
+				const finalMessage = hasReplyCall
+					? terminalMessageFromToolCalls(
+							plannerOutput.toolCalls,
+							plannerOutput.messageToUser,
+						)
+					: undefined;
 				trajectory.steps.push({
 					iteration,
 					thought: plannerOutput.thought,


### PR DESCRIPTION
## Problem

The planner's `messageToUser` fallback (raw model text) applied to **every** terminal-only iteration. So free text that accompanies a `STOP` call — the model's internal coordination scratch, e.g. *"We should wait for the sub-agent result before replying."* — was sent to the user **verbatim**.

`STOP`/`IGNORE`-only terminals are meant to be silent (the agent decided not to reply, or is waiting). Leaking the scratch prose as a user-facing message is a real UX bug: the user sees the model thinking out loud instead of nothing.

## Fix

The raw-text fallback now applies **only when a `REPLY` call is present** in the terminal output:

- A `REPLY` with no explicit text still keeps its prose (textless REPLY → raw text is the intended message).
- A `STOP`/`IGNORE`-only terminal stays **silent** — its accompanying scratch text is not surfaced.

## Changes

- `packages/core/src/runtime/planner-loop.ts` — gate the `messageToUser` raw-text fallback on the presence of a `REPLY` call.
- `packages/core/src/runtime/__tests__/planner-loop.test.ts` — cover STOP-only (silent), IGNORE-only (silent), and textless-REPLY (keeps prose).

## Notes

- Behavior-preserving for normal replies; only suppresses scratch prose on terminals that were never meant to speak.
