### PR TITLE
fix(cloud): heartbeat builds bridge health URL directly (prod-verified form)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3280,10 +3280,10 @@ export class ElizaSandboxService {
     // is a host-only docker port mapping that is NOT reachable over the tailnet,
     // so the web-base-url path `getAgentApiEndpoint` prefers is a dead poll for
     // the on-prem worker and was flipping every running agent to `disconnected`.
-    const heartbeatEndpoint = await this.getSafeBridgeEndpoint(
-      rec,
-      "/api/health",
-    );
+    // `bridge_url` is the trusted tailnet bridge (verified non-null above); build
+    // the health URL from it directly (this exact form is verified live in prod —
+    // a dedicated-always agent holds `running` and its subdomain proxies 200/401).
+    const heartbeatEndpoint = new URL("/api/health", rec.bridge_url).toString();
     let res: Response | null = null;
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {


### PR DESCRIPTION
Follow-up to #8611. The form **proven live on the prod daemon** is the direct `new URL('/api/health', rec.bridge_url)` — with it running, a fresh `dedicated-always` agent held `running` for 6+ min (heartbeat updating every ~20s) and `https://<id>.elizacloud.ai/api/status` → 401 (proxied to the container, not 404). #8611 had merged the `getSafeBridgeEndpoint` variant before this landed; aligning develop with the verified form so a redeploy can't regress the dedicated-agent product.