### PR TITLE
fix(ui): sort ViewCatalog.test.tsx import names for biome organizeImports

### DIFF
--- a/packages/ui/src/components/pages/ViewCatalog.test.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.test.tsx
@@ -20,8 +20,8 @@ import { useViewCatalog } from "../../hooks/useViewCatalog";
 import { getActiveViewModality } from "../../platform/platform-guards";
 import { useIsDeveloperMode } from "../../state/useDeveloperMode";
 import {
-  type ViewChatBinding,
   useViewChatBinding,
+  type ViewChatBinding,
 } from "../../state/view-chat-binding";
 import { ViewCatalog } from "./ViewCatalog";
 


### PR DESCRIPTION
## What

`biome check` flags `assist/source/organizeImports` at `packages/ui/src/components/pages/ViewCatalog.test.tsx:22` — the `view-chat-binding` import lists `type ViewChatBinding` before the value import `useViewChatBinding`, which biome's import sorter rejects. This fails the `ci` **lint-and-format** job (`@elizaos/ui#lint`) and the **Code Quality** lane on a deterministic, every-push basis.

Reproduced locally against the current `develop`/`main` baseline (`1a7f8fe1c1`):
```
src/components/pages/ViewCatalog.test.tsx:22:1 assist/source/organizeImports  FIXABLE
  × Sort the imported names.
```

## Change

Apply biome's safe fix — sort the value import before the type import. One line.

## Verification

`bunx @biomejs/biome check src/components/pages/ViewCatalog.test.tsx` → No fixes applied (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)