### PR TITLE
feat(app): provision dedicated agents from the Eliza app (ditch shared default)

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1530,6 +1530,11 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
     method: "POST",
     body: JSON.stringify({
       agentName: opts.agentName,
+      // The Eliza app provisions a DEDICATED (own-container, always-on) agent —
+      // the full experience, and the paid tier. New users have the signup credit
+      // grant so they get a real agent; out-of-credit users get the cloud's
+      // 402 add-credits prompt (the monetization path) rather than a shared agent.
+      alwaysOn: true,
       ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
       ...(opts.environmentVars
         ? { environmentVars: opts.environmentVars }
@@ -1574,6 +1579,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       method: "POST",
       body: JSON.stringify({
         agentName: opts.agentName,
+        // Dedicated (own-container, always-on) agent — see the direct-path note.
+        alwaysOn: true,
         ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
         ...(opts.environmentVars
           ? { environmentVars: opts.environmentVars }


### PR DESCRIPTION
The Eliza app now requests `alwaysOn: true` on agent create → users get a **dedicated** (own-container, always-on) agent (the paid/full experience) instead of shared. New users have the signup credit grant; out-of-credit users get the 402 add-credits prompt (monetization), not a silent shared downgrade. The app already prefers the dedicated `web_ui_url`, and the dedicated path is **verified live on prod** (agent holds `running`, subdomain proxies 401/200). Product decision per nubs (ditch shared, make people pay, full experience).