### PR TITLE
fix(cloud): green Cloud Tests lint + auto-recover disconnected dedicated agents (#8434)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -80,6 +80,30 @@ describe("AgentSandboxesRepository", () => {
     expect(query.params).toContain("shared");
   });
 
+  test("reconcile selection targets recent disconnected dedicated agents with a bridge", async () => {
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().listReconcilableDisconnected();
+
+    if (!capturedWhere)
+      throw new Error("listReconcilableDisconnected did not build a where clause");
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    const sql = query.sql.toLowerCase();
+    // Only disconnected, non-shared rows are reconcile candidates...
+    expect(sql).toContain("status");
+    expect(sql).toContain("execution_tier");
+    expect(sql).toContain("<>");
+    // ...that still have a tailnet bridge to dial, are not soft-deleted, and
+    // dropped recently enough to plausibly still be alive.
+    expect(sql).toContain("bridge_url");
+    expect(sql).toContain("deleted_at");
+    expect(sql).toContain("updated_at");
+    expect(query.params).toContain("disconnected");
+    expect(query.params).toContain("shared");
+  });
+
   test("marks only orphaned user-owned pending rows with no provision job as error", async () => {
     capturedWhere = undefined;
     set.mockClear();

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -270,6 +270,53 @@ export class AgentSandboxesRepository {
     return r;
   }
 
+  /**
+   * `disconnected` dedicated agents that are candidates for auto-recovery: they
+   * still have a tailnet bridge to dial, are not soft-deleted, and dropped
+   * recently enough (`updated_at` within `maxAgeMs`) that the container is
+   * plausibly still alive. The reconcile cycle re-probes these and restores
+   * reachable ones to `running` — the heartbeat cycle only dials `running` rows,
+   * so this is the sole automatic path back from a transient drop. Bounding by
+   * recency stops the worker re-dialing long-dead agents every cycle forever.
+   */
+  async listReconcilableDisconnected(
+    maxAgeMs = 24 * 60 * 60 * 1000,
+  ): Promise<Array<{ id: string; organization_id: string }>> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+    return dbRead
+      .select({
+        id: agentSandboxes.id,
+        organization_id: agentSandboxes.organization_id,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.status, "disconnected"),
+          ne(agentSandboxes.execution_tier, "shared"),
+          sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+          sql`${agentSandboxes.updated_at} > ${cutoff}`,
+        ),
+      );
+  }
+
+  async findDisconnectedSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    // Primary read: the reconcile worker must see its own status writes.
+    const [r] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, orgId),
+          eq(agentSandboxes.status, "disconnected"),
+        ),
+      )
+      .limit(1);
+    return r;
+  }
+
   async findByManagedDiscordGuildId(guildId: string): Promise<AgentSandbox[]> {
     await ensureAgentSandboxSchema();
     const trimmedGuildId = guildId.trim();

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -391,3 +391,99 @@ describe("ElizaSandboxService wake", () => {
     },
   );
 });
+
+describe("ElizaSandboxService reconcileDisconnected", () => {
+  function disconnectedSandbox(): AgentSandbox {
+    return { ...customSandbox(), status: "disconnected" };
+  }
+
+  test("restores a reachable disconnected agent to running and bumps heartbeat", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const probed: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      probed.push(fetchUrl(input));
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(true);
+      expect(probed).toEqual(["https://legacy-bridge.example/api/health"]);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [updatedId, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(updatedId).toBe(sandbox.id);
+      expect(patch.status).toBe("running");
+      expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("leaves an unreachable disconnected agent untouched", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch failed");
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("no-ops when the agent is no longer disconnected", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      undefined,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    let fetched = false;
+    globalThis.fetch = mock(async () => {
+      fetched = true;
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+        "22222222-2222-4222-8222-222222222222",
+      );
+
+      expect(recovered).toBe(false);
+      expect(fetched).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3259,48 +3259,55 @@ export class ElizaSandboxService {
 
   // Heartbeat
 
-  async heartbeat(agentId: string, orgId: string): Promise<boolean> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
-    if (!rec?.bridge_url) return false;
-
-    // The agent is reached over the headscale tailnet, where an idle path goes
-    // cold; a single cold-path miss must not evict a healthy agent. Retry the
-    // probe (the first attempt re-warms the path), then apply hysteresis before
-    // giving up — seen live: a freshly-running agent was marked disconnected
-    // ~1 min after boot by one transient "fetch failed".
-    // Liveness must dial the BRIDGE port over the headscale tailnet. The
-    // container serves its full HTTP API there (and `/api/health` unauthed —
-    // the same endpoint provisioning's health probe passes on); `web_ui_port`
-    // is a host-only docker port mapping that is NOT reachable over the tailnet,
-    // so the web-base-url path `getAgentApiEndpoint` prefers is a dead poll for
-    // the on-prem worker and was flipping every running agent to `disconnected`.
-    // `bridge_url` is the trusted tailnet bridge (verified non-null above); build
-    // the health URL from it directly (this exact form is verified live in prod —
-    // a dedicated-always agent holds `running` and its subdomain proxies 200/401).
-    const heartbeatEndpoint = new URL("/api/health", rec.bridge_url).toString();
-    let res: Response | null = null;
+  /**
+   * Dial an agent's bridge health endpoint over the headscale tailnet, with
+   * retry. The tailnet path goes cold when idle, so a single miss must not be
+   * read as "down" — the first attempt re-warms the path. Returns true on the
+   * first `2xx`.
+   *
+   * Liveness must dial the BRIDGE port: the container serves its full HTTP API
+   * there (and `/api/health` unauthed — the same endpoint provisioning's health
+   * probe passes on). `web_ui_port` is a host-only docker port mapping NOT
+   * reachable over the tailnet, so the web-base-url path `getAgentApiEndpoint`
+   * prefers is a dead poll for the on-prem worker and was flipping every
+   * running agent to `disconnected`. `bridge_url` is the trusted tailnet bridge
+   * (callers verify it is non-null); this exact form is verified live in prod —
+   * a dedicated-always agent holds `running` and its subdomain proxies 200/401.
+   */
+  private async probeBridgeHealth(
+    rec: Pick<AgentSandbox, "id" | "environment_vars" | "bridge_url">,
+  ): Promise<boolean> {
+    if (!rec.bridge_url) return false;
+    const endpoint = new URL("/api/health", rec.bridge_url).toString();
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {
         await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
       }
       try {
-        res = await fetch(heartbeatEndpoint, {
+        const res = await fetch(endpoint, {
           method: "GET",
           headers: this.getAgentJsonHeaders(rec),
           signal: AbortSignal.timeout(10_000),
         });
-        if (res.ok) break;
+        if (res.ok) return true;
       } catch (error) {
-        logger.debug("[agent-sandbox] Heartbeat probe attempt failed, retrying", {
-          agentId,
+        logger.debug("[agent-sandbox] Bridge health probe attempt failed, retrying", {
+          agentId: rec.id,
           attempt,
           error: error instanceof Error ? error.message : String(error),
         });
-        res = null;
       }
     }
+    return false;
+  }
 
-    if (!res?.ok) {
+  async heartbeat(agentId: string, orgId: string): Promise<boolean> {
+    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    if (!rec?.bridge_url) return false;
+
+    const alive = await this.probeBridgeHealth(rec);
+
+    if (!alive) {
       // Hysteresis: one failed cycle is not enough to evict. last_heartbeat_at
       // is bumped only on success, so its age is how long the agent has been
       // continuously unreachable. Stay running inside the grace window (the next
@@ -3328,6 +3335,31 @@ export class ElizaSandboxService {
     }
     await agentSandboxesRepository.update(rec.id, {
       last_heartbeat_at: new Date(),
+    });
+    return true;
+  }
+
+  /**
+   * Re-probe a single `disconnected` dedicated agent and, if its bridge answers
+   * again, restore it to `running`. The heartbeat cycle only dials `running`
+   * rows, so without this an always-on agent that drops past the grace window
+   * (a transient tailnet blip, a node reboot) would stay `disconnected` forever:
+   * its public subdomain 404s and the only recovery was a manual re-provision.
+   * Returns true when the agent was recovered.
+   */
+  async reconcileDisconnected(agentId: string, orgId: string): Promise<boolean> {
+    const rec = await agentSandboxesRepository.findDisconnectedSandbox(agentId, orgId);
+    if (!rec?.bridge_url) return false;
+
+    const alive = await this.probeBridgeHealth(rec);
+    if (!alive) return false;
+
+    await agentSandboxesRepository.update(rec.id, {
+      status: "running",
+      last_heartbeat_at: new Date(),
+    });
+    logger.info("[agent-sandbox] Disconnected agent reachable again, restored to running", {
+      agentId,
     });
     return true;
   }

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -2214,6 +2214,43 @@ export class ProvisioningJobService {
     return { total, succeeded, failed };
   }
 
+  /**
+   * Re-probe `disconnected` dedicated agents and restore reachable ones to
+   * `running`. Complements processRunningHeartbeats (which only dials `running`
+   * rows): an always-on agent that drops past the grace window would otherwise
+   * stay disconnected forever, with no automatic path back. Runs from the
+   * on-prem worker only (HTTP over the Headscale tunnel).
+   */
+  async processDisconnectedReconcile(concurrency = 5): Promise<ReconcileResult> {
+    const candidates = await agentSandboxesRepository.listReconcilableDisconnected();
+    const total = candidates.length;
+    if (total === 0) return { total: 0, recovered: 0, stillDown: 0 };
+
+    let recovered = 0;
+    let stillDown = 0;
+    const queue = [...candidates];
+    const workers = Array.from({ length: Math.min(concurrency, total) }, async () => {
+      while (true) {
+        const r = queue.shift();
+        if (!r) break;
+        const ok = await elizaSandboxService
+          .reconcileDisconnected(r.id, r.organization_id)
+          .catch((error: unknown) => {
+            logger.warn("[provisioning-jobs] reconcile threw", {
+              agentId: r.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return false;
+          });
+        if (ok) recovered += 1;
+        else stillDown += 1;
+      }
+    });
+    await Promise.all(workers);
+
+    return { total, recovered, stillDown };
+  }
+
   private async recoverStaleJobs(
     jobTypes: readonly ProvisioningJobType[] = Object.values(JOB_TYPES),
   ): Promise<number> {
@@ -2341,6 +2378,12 @@ export interface HeartbeatResult {
   total: number;
   succeeded: number;
   failed: number;
+}
+
+export interface ReconcileResult {
+  total: number;
+  recovered: number;
+  stillDown: number;
 }
 
 export interface ProcessingResult {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -21,6 +21,7 @@ import {
 import type {
   HeartbeatResult,
   ProcessingResult,
+  ReconcileResult,
 } from "@elizaos/cloud-shared/lib/services/provisioning-jobs";
 import { loadLocalEnv } from "./shared/load-env";
 
@@ -232,6 +233,13 @@ async function processHeartbeatCycle(
 ): Promise<HeartbeatResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processRunningHeartbeats(concurrency);
+}
+
+async function processReconcileCycle(
+  concurrency = 5,
+): Promise<ReconcileResult> {
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.processDisconnectedReconcile(concurrency);
 }
 
 interface NodeHealthSummary {
@@ -656,6 +664,21 @@ async function pollCycle(
     }
   } catch (error) {
     logger.error("[provisioning-worker] heartbeat cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const reconcile = await processReconcileCycle();
+    if (reconcile.recovered > 0) {
+      logger.info("[provisioning-worker] disconnect reconcile cycle complete", {
+        total: reconcile.total,
+        recovered: reconcile.recovered,
+        stillDown: reconcile.stillDown,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] disconnect reconcile cycle failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
Closes out the remaining items on the #8434 dedicated-agent path. The dedicated-agent product is otherwise verified working end-to-end on prod (provision → holds `running` → `<id>.elizacloud.ai` proxies). Two parts, separable commits:

## 1. Green develop's Cloud Tests (`fix(cloud): format …`)
Two Biome **formatter** violations were live on develop because their PRs merged under churn-cancelled CI:
- `eliza-sandbox.ts` — agent rename/edit block (from #8608)
- `worker-neon-http.ts` — Hyperdrive `skipVerify` expression (from #8623)

Both fail `verify:cloud` → the Cloud Tests `lint-and-types` job was red on **every** develop run. Pure whitespace re-wrapping, no behavior change.

## 2. Auto-recover disconnected dedicated agents (the last #8434 hardening gap)
The heartbeat cycle only dials `running` rows, so a dedicated/always-on agent that drops past the 120s grace window (a transient tailnet blip, a node reboot) was marked `disconnected` and **stayed there forever** — its public subdomain 404s and the only recovery was a manual re-provision. Flagged as a follow-up on the prod E2E ("a `disconnected` agent never returns to `running`").

Adds a reconcile pass that complements the heartbeat:
- **repo** — `listReconcilableDisconnected()` selects disconnected, non-shared rows that still have a tailnet bridge, aren't soft-deleted, and dropped within the last 24h (recency bound stops re-dialing long-dead containers forever); `findDisconnectedSandbox()` reads primary for read-after-write consistency.
- **service** — extract the heartbeat probe into `probeBridgeHealth()` (behaviour-preserving) and add `reconcileDisconnected()`: re-probe the bridge, and if it answers flip the agent back to `running` + bump `last_heartbeat_at`.
- **jobs** — `processDisconnectedReconcile()` mirrors `processRunningHeartbeats`.
- **daemon** — run a reconcile cycle each tick, right after the heartbeat cycle.

### Verification
- `bun run --cwd packages/cloud-shared lint` ✅ (1072 files, 0 errors)
- `bun run --cwd packages/cloud-shared typecheck` ✅ (exit 0)
- `bun test eliza-sandbox.test.ts` ✅ 8/8 (3 new reconcile tests)
- `bun test agent-sandboxes.test.ts` ✅ 4/4 (new reconcile-selection where-clause test)
- daemon (`provisioning-worker.ts`) bundles clean with the new imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)