### PR TITLE
feat(cloud): unified cloud-token auth for dedicated agents (no agent password screen)

### DIFF
--- a/packages/cloud-api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud-api/__tests__/dedicated-agent-proxy.test.ts
@@ -1,0 +1,143 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+/**
+ * Security tests for the dedicated-agent unified-auth proxy. The single
+ * invariant under test: the agent's `ELIZA_API_TOKEN` is injected ONLY for a
+ * validated owner of a RUNNING dedicated agent; every other path proxies
+ * UNCHANGED (so the container's own auth stays the backstop).
+ */
+
+let authResult: { user: { id: string; organization_id: string } } | "throw" =
+  "throw";
+let sandboxResult: Record<string, unknown> | null = null;
+
+mock.module("@/lib/runtime/cloud-bindings", () => ({
+  runWithCloudBindingsAsync: (_b: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => {
+    if (authResult === "throw") throw new Error("unauthorized");
+    return authResult;
+  },
+}));
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { findByIdAndOrg: async () => sandboxResult },
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentProvisionOnce: async () => ({
+      job: { id: "job-1" },
+      created: true,
+    }),
+  },
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => ({ ok: true }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn() {}, error() {}, info() {}, debug() {} },
+}));
+
+let captured: Request | null = null;
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  captured = input instanceof Request ? input : new Request(input);
+  return new Response("ok", { status: 200 });
+}) as typeof fetch;
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const { handleDedicatedAgentProxy } = await import(
+  "../src/dedicated-agent-proxy"
+);
+
+const AGENT = "11111111-1111-1111-1111-111111111111";
+const ENV = { AGENT_ROUTER_ORIGIN_HOST: "cp.example.test" } as never;
+
+function makeRequest(cloudToken?: string): Request {
+  const headers = new Headers();
+  if (cloudToken) headers.set("authorization", `Bearer ${cloudToken}`);
+  return new Request(`https://${AGENT}.elizacloud.ai/api/status`, { headers });
+}
+const urlOf = (r: Request) => new URL(r.url);
+
+const runningDedicated = {
+  id: AGENT,
+  execution_tier: "dedicated-always",
+  status: "running",
+  environment_vars: { ELIZA_API_TOKEN: "agent-secret-token" },
+  agent_name: "qa",
+  updated_at: new Date(),
+};
+
+beforeEach(() => {
+  captured = null;
+  authResult = "throw";
+  sandboxResult = null;
+});
+
+describe("dedicated-agent-proxy — unified auth", () => {
+  test("validated OWNER of a RUNNING agent → injects the agent token, strips the cloud token, targets the CP", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = runningDedicated;
+
+    const r = makeRequest("cloud-token-abc");
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(res.status).toBe(200);
+    expect(captured).not.toBeNull();
+    // The container gets the agent's own token, NOT the cloud token.
+    expect(captured?.headers.get("authorization")).toBe(
+      "Bearer agent-secret-token",
+    );
+    expect(captured?.headers.get("x-api-key")).toBeNull();
+    expect(new URL(captured?.url ?? "").hostname).toBe("cp.example.test");
+  });
+
+  test("NO cloud token → pass through unchanged (never injects the agent token)", async () => {
+    authResult = "throw";
+    const r = makeRequest();
+    await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(captured?.headers.get("authorization")).toBeNull();
+  });
+
+  test("authenticated NON-OWNER (findByIdAndOrg → null) → pass through, agent token NEVER injected", async () => {
+    authResult = { user: { id: "att", organization_id: "attacker-org" } };
+    sandboxResult = null; // attacker's org does not own this agent
+    const r = makeRequest("attacker-cloud-token");
+    await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    // forwarded verbatim — the container's own auth rejects it; the secret leaks nowhere
+    expect(captured?.headers.get("authorization")).toBe(
+      "Bearer attacker-cloud-token",
+    );
+  });
+
+  test("shared-tier agent → pass through, no injection", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = {
+      ...runningDedicated,
+      execution_tier: "shared",
+    };
+    const r = makeRequest("cloud-token");
+    await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(captured?.headers.get("authorization")).toBe("Bearer cloud-token");
+  });
+
+  test("owner of a NON-RUNNING agent → 202 resume, does NOT proxy to the container", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, status: "stopped" };
+    const r = makeRequest("cloud-token");
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(202);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(captured).toBeNull();
+  });
+});

--- a/packages/cloud-api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud-api/src/dedicated-agent-proxy.ts
@@ -1,0 +1,226 @@
+/**
+ * Unified cloud-token auth + proxy for DEDICATED (container) agents reached at
+ * `https://<agentId>.elizacloud.ai/*`.
+ *
+ * A dedicated agent's container runs a full agent-server with its OWN auth: it
+ * requires that agent's per-container `ELIZA_API_TOKEN` as a Bearer (the cloud
+ * provisions that token; `ELIZA_DISABLE_AUTO_API_TOKEN=1`). The mobile/desktop
+ * app, however, only holds the user's CLOUD session/API key. Forwarding the
+ * cloud token verbatim → the container 401s → the agent's "sign in with your
+ * password" screen.
+ *
+ * This unifies auth so a dedicated agent is reachable with the SAME cloud token
+ * as a shared agent (zero dedicated-specific app code, since the app already
+ * prefers `web_ui_url`): we validate the cloud token, confirm the caller's org
+ * OWNS the agent, then swap the cloud token for the agent's `ELIZA_API_TOKEN`
+ * before proxying over the tailnet.
+ *
+ * SECURITY — the token swap (which grants container access) happens ONLY after a
+ * validated owner of a running dedicated agent. Every other path is proxied
+ * UNCHANGED, so the container's own `ELIZA_API_TOKEN` auth stays the backstop
+ * (an attacker never holds that per-agent secret):
+ *   - no / invalid cloud token  → pass through (web UI assets, the pairing
+ *     exchange, the agent's own token all keep working);
+ *   - valid token but NOT the owner (or shared / not found) → pass through;
+ *   - any unexpected error during validation → pass through (fail-closed: we
+ *     never inject on an error path).
+ * We only ever narrow access here, never widen it.
+ *
+ * Lazy-imported from `index.ts` only on a UUID-subdomain request, so the Worker
+ * entrypoint stays thin (Cloudflare startup-CPU budget).
+ */
+
+import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import { checkProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+type Bindings = AppEnv["Bindings"];
+
+const DEFAULT_AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai";
+
+/** Non-`running` statuses we auto-resume on (mirrors the pairing endpoint). */
+const RESUMABLE_STATUSES = new Set(["pending", "stopped", "disconnected"]);
+const RETRY_AFTER_SECONDS = 5;
+
+function resolveOriginHost(env: Bindings): string {
+  const raw = env.AGENT_ROUTER_ORIGIN_HOST?.trim().toLowerCase();
+  return raw && raw.length > 0 ? raw : DEFAULT_AGENT_ROUTER_ORIGIN_HOST;
+}
+
+/**
+ * Forward the request to the agent-router origin (the CP), preserving
+ * path / method / body. When `injectBearer` is provided, the inbound auth is
+ * REPLACED with the agent's own `ELIZA_API_TOKEN` (so the container accepts it);
+ * otherwise headers pass through unchanged and the container's own auth applies.
+ */
+function proxyToOrigin(
+  request: Request,
+  env: Bindings,
+  url: URL,
+  injectBearer?: string,
+): Promise<Response> {
+  const targetUrl = new URL(request.url);
+  targetUrl.hostname = resolveOriginHost(env);
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.set("x-forwarded-host", url.host);
+  headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
+  if (injectBearer) {
+    headers.set("authorization", `Bearer ${injectBearer}`);
+    headers.delete("x-api-key");
+  }
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "manual",
+  };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+  }
+  return fetch(new Request(targetUrl, init));
+}
+
+type Sandbox = NonNullable<
+  Awaited<ReturnType<typeof agentSandboxesRepository.findByIdAndOrg>>
+>;
+
+/**
+ * A non-`running` dedicated agent can't be reached. Kick off (or detect an
+ * in-flight) resume and tell the client to retry — the same self-healing flow
+ * the pairing endpoint exposes, so the app drives one resume+poll loop for both.
+ */
+async function resumeAndRespond(
+  sandbox: Sandbox,
+  agentId: string,
+  orgId: string,
+  userId: string,
+): Promise<Response> {
+  if (sandbox.status === "error") {
+    return Response.json(
+      {
+        success: false,
+        error:
+          "Agent is in an error state. Resolve the failure before connecting.",
+        data: { status: sandbox.status },
+      },
+      { status: 503 },
+    );
+  }
+
+  let jobId: string | undefined;
+  let alreadyInProgress = false;
+  if (RESUMABLE_STATUSES.has(sandbox.status)) {
+    const workerHealth = await checkProvisioningWorkerHealth();
+    if (workerHealth.ok) {
+      try {
+        const { job, created } =
+          await provisioningJobService.enqueueAgentProvisionOnce({
+            agentId,
+            organizationId: orgId,
+            userId,
+            agentName: sandbox.agent_name ?? agentId,
+            expectedUpdatedAt: sandbox.updated_at,
+          });
+        jobId = job.id;
+        alreadyInProgress = !created;
+      } catch (error) {
+        logger.warn("[dedicated-proxy] auto-resume enqueue failed", {
+          agentId,
+          orgId,
+          status: sandbox.status,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } else {
+      logger.warn("[dedicated-proxy] auto-resume blocked: worker unavailable", {
+        agentId,
+        orgId,
+        status: sandbox.status,
+        code: workerHealth.code,
+      });
+    }
+  }
+
+  const response = Response.json(
+    {
+      success: true,
+      data: {
+        agentId,
+        status: "starting",
+        jobId,
+        alreadyInProgress,
+        retryAfterMs: RETRY_AFTER_SECONDS * 1000,
+        message:
+          "Agent is starting. Resume has been requested; retry after the suggested interval.",
+      },
+    },
+    { status: 202 },
+  );
+  response.headers.set("Retry-After", String(RETRY_AFTER_SECONDS));
+  return response;
+}
+
+/**
+ * Auth-unify + proxy a request bound for `https://<agentId>.elizacloud.ai/*`.
+ */
+export function handleDedicatedAgentProxy(
+  request: Request,
+  env: Bindings,
+  url: URL,
+  agentId: string,
+): Promise<Response> {
+  return runWithCloudBindingsAsync(env, async () => {
+    try {
+      // 1. Validate the CLOUD token. No valid cloud token → pass through
+      //    unchanged (web UI assets, the pairing exchange, the agent's own
+      //    token); the container's auth is the backstop.
+      let orgId: string;
+      let userId: string;
+      try {
+        const { user } = await requireAuthOrApiKeyWithOrg(request);
+        orgId = user.organization_id;
+        userId = user.id;
+      } catch {
+        return proxyToOrigin(request, env, url);
+      }
+
+      // 2. Ownership — the caller's org MUST own this dedicated agent. Not
+      //    owned / not found / shared → pass through unchanged (never widen
+      //    access here; the container's own token auth rejects non-owners).
+      const sandbox = await agentSandboxesRepository.findByIdAndOrg(
+        agentId,
+        orgId,
+      );
+      if (!sandbox || sandbox.execution_tier === "shared") {
+        return proxyToOrigin(request, env, url);
+      }
+
+      // 3. Lifecycle — a non-running agent isn't reachable; resume + 202.
+      if (sandbox.status !== "running") {
+        return resumeAndRespond(sandbox, agentId, orgId, userId);
+      }
+
+      // 4. Unified auth — swap the validated owner's cloud token for the agent's
+      //    own ELIZA_API_TOKEN so the container accepts the request.
+      const envVars = (sandbox.environment_vars ?? {}) as Record<string, string>;
+      const agentToken = envVars.ELIZA_API_TOKEN?.trim();
+      // No managed token (older / not-yet-provisioned agent) → pass through.
+      return proxyToOrigin(request, env, url, agentToken || undefined);
+    } catch (error) {
+      // Fail-closed: any unexpected error → pass through WITHOUT injecting, so
+      // the container's own auth still gates access.
+      logger.error(
+        "[dedicated-proxy] unexpected error; passing through unauthenticated",
+        {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return proxyToOrigin(request, env, url);
+    }
+  });
+}

--- a/packages/cloud-api/src/index.ts
+++ b/packages/cloud-api/src/index.ts
@@ -20,7 +20,6 @@ let appPromise: Promise<Hono<AppEnv>> | undefined;
 const AGENT_ID_RE =
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 const DEFAULT_AGENT_BASE_DOMAIN = "elizacloud.ai";
-const DEFAULT_AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai";
 const FRONTEND_ALIAS_TARGETS: Record<
   string,
   { appHost: string; apiHost: string }
@@ -141,27 +140,15 @@ function proxyGeneratedAgentRequest(
   env: AppEnv["Bindings"],
   url: URL,
 ): Promise<Response> | null {
-  if (!getGeneratedAgentId(url, env)) return null;
+  const agentId = getGeneratedAgentId(url, env);
+  if (!agentId) return null;
 
-  const originHost =
-    normalizeHostname(env.AGENT_ROUTER_ORIGIN_HOST) ??
-    DEFAULT_AGENT_ROUTER_ORIGIN_HOST;
-  const targetUrl = new URL(request.url);
-  targetUrl.hostname = originHost;
-  const headers = new Headers(request.headers);
-  headers.delete("host");
-  headers.set("x-forwarded-host", url.host);
-  headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    redirect: "manual",
-  };
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    init.body = request.body;
-  }
-
-  return fetch(new Request(targetUrl, init));
+  // Unified cloud-token auth + tailnet proxy for dedicated agents. Lazy-imported
+  // so this entrypoint stays thin (Cloudflare startup-CPU budget) — the auth/DB
+  // module only loads on an actual UUID-subdomain request.
+  return import("./dedicated-agent-proxy").then((m) =>
+    m.handleDedicatedAgentProxy(request, env, url, agentId),
+  );
 }
 
 const scheduled = makeCronHandler(async (request, env, ctx) =>


### PR DESCRIPTION
Closes the auth blocker on #8621 (exposed by the dedicated-default app flip #8622).

**Problem:** a dedicated agent's container has its OWN auth (per-agent `ELIZA_API_TOKEN` Bearer; `ELIZA_DISABLE_AUTO_API_TOKEN=1`). The Worker's `proxyGeneratedAgentRequest` forwarded the app's *cloud* token verbatim → container 401 → the agent's "sign in with your password" screen.

**Fix:** the UUID-subdomain proxy (lazy-imported to keep the entrypoint thin) now validates the cloud token, confirms the caller's org **owns** the agent, then swaps in the agent's `ELIZA_API_TOKEN` before proxying over the tailnet. The app uses the **same cloud token as shared** → zero dedicated app code.

**Security — token swap happens ONLY for a validated owner of a RUNNING dedicated agent.** Every other path proxies UNCHANGED (container's own token auth is the backstop; the per-agent secret leaks nowhere):
- no/invalid cloud token → pass through (web UI assets, the pairing exchange keep working)
- authenticated **non-owner** → pass through (never inject)
- shared / not-found → pass through
- any unexpected error → pass through (**fail-closed**)

Reuses `requireAuthOrApiKeyWithOrg` + `findByIdAndOrg` + the pairing flow's token lookup + auto-resume (`202 retry-after` for non-running agents — also solves the lifecycle/resume ask). **5 security unit tests** (owner+running→inject+strip, no-token→passthrough, non-owner→never-inject, shared→passthrough, not-running→202). typecheck 0.