### PR TITLE
fix(cloud): use Hyperdrive in the Worker's real DB path (client.ts)

### DIFF
--- a/packages/cloud-shared/src/db/client.ts
+++ b/packages/cloud-shared/src/db/client.ts
@@ -17,7 +17,7 @@ import { drizzle as drizzlePGlite, type PgliteDatabase } from "drizzle-orm/pglit
 import type { ExtractTablesWithRelations } from "drizzle-orm/relations";
 import { Pool as PgPool, type PoolConfig } from "pg";
 import ws from "ws";
-import { getCloudAwareEnv } from "../lib/runtime/cloud-bindings";
+import { getCloudAwareEnv, getCloudBinding } from "../lib/runtime/cloud-bindings";
 import { applyDatabaseUrlFallback } from "./database-url";
 import { disableLocalPreparedStatements } from "./local-pg-query";
 import * as schema from "./schemas";
@@ -189,11 +189,13 @@ function enforceTlsForRemote(url: string): {
   };
 }
 
-function createPgPool(url: string): PgPool {
+function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   const env = getCloudAwareEnv();
   const inWorkerRuntime = isCloudflareWorkerRuntime();
   const isLocalTcp = isLocalTcpPostgresUrl(url);
-  const tls = enforceTlsForRemote(url);
+  // Hyperdrive proxies to the origin (pooling + TLS); the Worker connects to its
+  // local plaintext endpoint, so bypass the remote-TLS enforcement.
+  const tls = hyperdriveUrl ? { url: hyperdriveUrl, ssl: undefined } : enforceTlsForRemote(url);
   const options: PoolConfig = { connectionString: tls.url };
   if (tls.ssl) options.ssl = tls.ssl;
 
@@ -245,7 +247,11 @@ function createConnection(url: string): Database {
     return registerDatabaseCloser(drizzleNeon(pool, { schema }) as Database, () => pool.end());
   }
 
-  const pool = createPgPool(url);
+  // Non-Neon remote Postgres (e.g. Railway): on workerd a direct node-pg TCP
+  // connection terminates mid-query, so prefer a Cloudflare Hyperdrive binding
+  // when present and let it proxy to the origin.
+  const hyperdriveUrl = getCloudBinding<{ connectionString?: string }>("HYPERDRIVE")?.connectionString;
+  const pool = createPgPool(url, hyperdriveUrl);
   return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () => pool.end());
 }
 

--- a/packages/cloud-shared/src/lib/runtime/cloud-bindings.ts
+++ b/packages/cloud-shared/src/lib/runtime/cloud-bindings.ts
@@ -55,3 +55,12 @@ export function getCloudAwareEnv(): NodeJS.ProcessEnv {
     },
   }) as NodeJS.ProcessEnv;
 }
+
+/**
+ * Read a non-string Worker binding (e.g. a Hyperdrive config) from the current
+ * request store. `getCloudAwareEnv` only exposes string secrets, so object
+ * bindings must be read here. Returns `undefined` outside a Worker request.
+ */
+export function getCloudBinding<T = unknown>(name: string): T | undefined {
+  return als.getStore()?.[name] as T | undefined;
+}


### PR DESCRIPTION
The Worker repositories use client.ts (via db/helpers), not worker-neon-http.ts. client.ts did direct node-pg to Railway -> 'Connection terminated unexpectedly' on workerd. Route the non-Neon pool through the HYPERDRIVE binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)