### PR TITLE
fix(cloud): auto-recover disconnected dedicated agents + green Cloud Tests lint (#8434)

### DIFF
--- a/packages/cloud-shared/src/db/client.ts
+++ b/packages/cloud-shared/src/db/client.ts
@@ -250,7 +250,9 @@ function createConnection(url: string): Database {
   // Non-Neon remote Postgres (e.g. Railway): on workerd a direct node-pg TCP
   // connection terminates mid-query, so prefer a Cloudflare Hyperdrive binding
   // when present and let it proxy to the origin.
-  const hyperdriveUrl = getCloudBinding<{ connectionString?: string }>("HYPERDRIVE")?.connectionString;
+  const hyperdriveUrl = getCloudBinding<{ connectionString?: string }>(
+    "HYPERDRIVE",
+  )?.connectionString;
   const pool = createPgPool(url, hyperdriveUrl);
   return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () => pool.end());
 }

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -80,6 +80,30 @@ describe("AgentSandboxesRepository", () => {
     expect(query.params).toContain("shared");
   });
 
+  test("reconcile selection targets recent disconnected dedicated agents with a bridge", async () => {
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().listReconcilableDisconnected();
+
+    if (!capturedWhere)
+      throw new Error("listReconcilableDisconnected did not build a where clause");
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    const sql = query.sql.toLowerCase();
+    // Only disconnected, non-shared rows are reconcile candidates...
+    expect(sql).toContain("status");
+    expect(sql).toContain("execution_tier");
+    expect(sql).toContain("<>");
+    // ...that still have a tailnet bridge to dial, are not soft-deleted, and
+    // dropped recently enough to plausibly still be alive.
+    expect(sql).toContain("bridge_url");
+    expect(sql).toContain("deleted_at");
+    expect(sql).toContain("updated_at");
+    expect(query.params).toContain("disconnected");
+    expect(query.params).toContain("shared");
+  });
+
   test("marks only orphaned user-owned pending rows with no provision job as error", async () => {
     capturedWhere = undefined;
     set.mockClear();

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -26,12 +26,18 @@ const set = mock((values: Record<string, unknown>) => {
 const update = mock(() => ({ set }));
 const ensureAgentSandboxSchema = mock(async () => {});
 
-// Read-side select() chain: select(...).from(...).where(clause) -> rows.
-// `where` captures the clause into the shared `capturedWhere` so a test can
-// assert on the generated SQL, mirroring the write-side capture above.
+// Read-side select() chain: select(...).from(...).where(clause) -> rows, with an
+// optional trailing .limit(n) (e.g. listReconcilableDisconnected). `where`
+// captures the clause into the shared `capturedWhere` so a test can assert on
+// the generated SQL, mirroring the write-side capture above. The returned value
+// is an empty array (so a `.where(...)`-terminated query awaits to `[]`) that
+// also carries a `.limit()` returning `[]` (so a `.where(...).limit(n)` query
+// resolves the same).
 const selectWhere = mock((clause: SQL) => {
   capturedWhere = clause;
-  return [] as unknown[];
+  const rows = [] as unknown[] & { limit: (n: number) => unknown[] };
+  rows.limit = () => [];
+  return rows;
 });
 const selectFrom = mock(() => ({ where: selectWhere }));
 const select = mock(() => ({ from: selectFrom }));
@@ -96,10 +102,14 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("execution_tier");
     expect(sql).toContain("<>");
     // ...that still have a tailnet bridge to dial, are not soft-deleted, and
-    // dropped recently enough to plausibly still be alive.
-    expect(sql).toContain("bridge_url");
-    expect(sql).toContain("deleted_at");
-    expect(sql).toContain("updated_at");
+    // dropped recently enough to plausibly still be alive. Pin the rendered
+    // operators, not just column names: a sign flip (IS NULL <-> IS NOT NULL,
+    // > <-> <) would keep every column-name substring green while re-probing
+    // deleted agents or inverting the recency window.
+    expect(sql).toContain('bridge_url" is not null');
+    expect(sql).toContain('deleted_at" is null');
+    expect(sql).not.toContain('deleted_at" is not null');
+    expect(sql).toMatch(/updated_at"?\s*>/);
     expect(query.params).toContain("disconnected");
     expect(query.params).toContain("shared");
   });

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -270,6 +270,53 @@ export class AgentSandboxesRepository {
     return r;
   }
 
+  /**
+   * `disconnected` dedicated agents that are candidates for auto-recovery: they
+   * still have a tailnet bridge to dial, are not soft-deleted, and dropped
+   * recently enough (`updated_at` within `maxAgeMs`) that the container is
+   * plausibly still alive. The reconcile cycle re-probes these and restores
+   * reachable ones to `running` — the heartbeat cycle only dials `running` rows,
+   * so this is the sole automatic path back from a transient drop. Bounding by
+   * recency stops the worker re-dialing long-dead agents every cycle forever.
+   */
+  async listReconcilableDisconnected(
+    maxAgeMs = 24 * 60 * 60 * 1000,
+  ): Promise<Array<{ id: string; organization_id: string }>> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+    return dbRead
+      .select({
+        id: agentSandboxes.id,
+        organization_id: agentSandboxes.organization_id,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.status, "disconnected"),
+          ne(agentSandboxes.execution_tier, "shared"),
+          sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+          sql`${agentSandboxes.updated_at} > ${cutoff}`,
+        ),
+      );
+  }
+
+  async findDisconnectedSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    // Primary read: the reconcile worker must see its own status writes.
+    const [r] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.organization_id, orgId),
+          eq(agentSandboxes.status, "disconnected"),
+        ),
+      )
+      .limit(1);
+    return r;
+  }
+
   async findByManagedDiscordGuildId(guildId: string): Promise<AgentSandbox[]> {
     await ensureAgentSandboxSchema();
     const trimmedGuildId = guildId.trim();

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -281,23 +281,31 @@ export class AgentSandboxesRepository {
    */
   async listReconcilableDisconnected(
     maxAgeMs = 24 * 60 * 60 * 1000,
+    limit = 20,
   ): Promise<Array<{ id: string; organization_id: string }>> {
     const cutoff = new Date(Date.now() - maxAgeMs);
-    return dbRead
-      .select({
-        id: agentSandboxes.id,
-        organization_id: agentSandboxes.organization_id,
-      })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.status, "disconnected"),
-          ne(agentSandboxes.execution_tier, "shared"),
-          sql`${agentSandboxes.bridge_url} IS NOT NULL`,
-          sql`${agentSandboxes.deleted_at} IS NULL`,
-          sql`${agentSandboxes.updated_at} > ${cutoff}`,
-        ),
-      );
+    return (
+      dbRead
+        .select({
+          id: agentSandboxes.id,
+          organization_id: agentSandboxes.organization_id,
+        })
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.status, "disconnected"),
+            ne(agentSandboxes.execution_tier, "shared"),
+            sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+            sql`${agentSandboxes.deleted_at} IS NULL`,
+            sql`${agentSandboxes.updated_at} > ${cutoff}`,
+          ),
+        )
+        // Bound the per-cycle candidate set (mirrors listRunningWithDigestOtherThan):
+        // disconnected rows are the most likely to hit full probe timeouts, so an
+        // unbounded set could make one reconcile cycle run long. Self-draining —
+        // recovered rows leave the set and dead rows age out at maxAgeMs.
+        .limit(limit)
+    );
   }
 
   async findDisconnectedSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
@@ -314,6 +322,34 @@ export class AgentSandboxesRepository {
         ),
       )
       .limit(1);
+    return r;
+  }
+
+  /**
+   * Atomically restore a still-disconnected agent to `running` after a
+   * successful bridge re-probe. The reconcile read→probe→write window spans
+   * seconds, during which the row may move to `deletion_pending` (delete
+   * enqueue), `stopped` (shutdown nulls `bridge_url`), or `provisioning`
+   * (re-provision). This compare-and-set only flips a row that is STILL
+   * `disconnected` with a live bridge and not soft-deleted, so a blind write
+   * can never resurrect a being-deleted agent or wedge a stopped one at
+   * `running` with a dead bridge. Returns the row when it won, undefined when
+   * it lost the race.
+   */
+  async markReconnectedFromDisconnected(id: string): Promise<AgentSandbox | undefined> {
+    await ensureAgentSandboxSchema();
+    const [r] = await dbWrite
+      .update(agentSandboxes)
+      .set({ status: "running", last_heartbeat_at: new Date(), updated_at: new Date() })
+      .where(
+        and(
+          eq(agentSandboxes.id, id),
+          eq(agentSandboxes.status, "disconnected"),
+          sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+        ),
+      )
+      .returning();
     return r;
   }
 

--- a/packages/cloud-shared/src/db/worker-neon-http.ts
+++ b/packages/cloud-shared/src/db/worker-neon-http.ts
@@ -101,8 +101,7 @@ function createPgPool(env: WorkerNeonEnvSlice): PgPool {
     // `DATABASE_SSL_NO_VERIFY=true` or `?sslmode=no-verify` — the connection
     // stays encrypted; only CA verification is skipped. (Hyperdrive terminates
     // origin TLS itself, so its local endpoint needs no `ssl` option here.)
-    const skipVerify =
-      env.DATABASE_SSL_NO_VERIFY === "true" || /[?&]sslmode=no-verify\b/.test(url);
+    const skipVerify = env.DATABASE_SSL_NO_VERIFY === "true" || /[?&]sslmode=no-verify\b/.test(url);
     options.ssl = { rejectUnauthorized: !skipVerify };
   }
   const pool = new PgPool(options);

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -397,15 +397,17 @@ describe("ElizaSandboxService reconcileDisconnected", () => {
     return { ...customSandbox(), status: "disconnected" };
   }
 
-  test("restores a reachable disconnected agent to running and bumps heartbeat", async () => {
+  test("restores a reachable disconnected agent to running via guarded compare-and-set", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();
     const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
       sandbox,
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
+    // CAS wins: the row is still disconnected, so the guarded update returns it.
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue({ ...sandbox, status: "running" });
     const probed: string[] = [];
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       probed.push(fetchUrl(input));
@@ -420,26 +422,52 @@ describe("ElizaSandboxService reconcileDisconnected", () => {
 
       expect(recovered).toBe(true);
       expect(probed).toEqual(["https://legacy-bridge.example/api/health"]);
-      expect(updateSpy).toHaveBeenCalledTimes(1);
-      const [updatedId, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
-      expect(updatedId).toBe(sandbox.id);
-      expect(patch.status).toBe("running");
-      expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
+      expect(casSpy).toHaveBeenCalledTimes(1);
+      expect(casSpy.mock.calls[0]?.[0]).toBe(sandbox.id);
     } finally {
       findSpy.mockRestore();
-      updateSpy.mockRestore();
+      casSpy.mockRestore();
     }
   });
 
-  test("leaves an unreachable disconnected agent untouched", async () => {
+  test("does NOT revive when the row left disconnected during the probe (CAS loses)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();
     const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
       sandbox,
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
+    // The agent was deleted/stopped/re-provisioned mid-probe → guarded update
+    // matches 0 rows. Reconcile must report not-recovered, never resurrect it.
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue(undefined);
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(false);
+      expect(casSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+    }
+  });
+
+  test("leaves an unreachable disconnected agent untouched (probe throws)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
     );
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue(undefined);
     globalThis.fetch = mock(async () => {
       throw new Error("fetch failed");
     });
@@ -451,21 +479,49 @@ describe("ElizaSandboxService reconcileDisconnected", () => {
       );
 
       expect(recovered).toBe(false);
-      expect(updateSpy).not.toHaveBeenCalled();
+      expect(casSpy).not.toHaveBeenCalled();
     } finally {
       findSpy.mockRestore();
-      updateSpy.mockRestore();
+      casSpy.mockRestore();
     }
   });
 
-  test("no-ops when the agent is no longer disconnected", async () => {
+  test("leaves a responding-but-unhealthy disconnected agent untouched (non-200, no throw)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue(undefined);
+    // The bridge answers, but unhealthy (404). Only a real 200 may revive.
+    globalThis.fetch = mock(async () => new Response("not found", { status: 404 }));
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(false);
+      expect(casSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+    }
+  });
+
+  test("no-ops when the agent is no longer disconnected (never probes)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
       undefined,
     );
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
-      undefined as never,
-    );
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue(undefined);
     let fetched = false;
     globalThis.fetch = mock(async () => {
       fetched = true;
@@ -480,7 +536,102 @@ describe("ElizaSandboxService reconcileDisconnected", () => {
 
       expect(recovered).toBe(false);
       expect(fetched).toBe(false);
+      expect(casSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+    }
+  });
+});
+
+describe("ElizaSandboxService heartbeat", () => {
+  // Pins the behaviour the probeBridgeHealth() extraction must preserve on the
+  // prod-critical heartbeat path: grace-window hysteresis and the exact DB
+  // writes. A regression here flips healthy agents to disconnected (the bug the
+  // bridge-port fix already cost us once).
+
+  test("probe miss inside the grace window keeps the agent running with no DB write", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    // last_heartbeat_at 30s ago < 120s grace → stay running.
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      last_heartbeat_at: new Date(Date.now() - 30_000),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch failed");
+    });
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
       expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("probe miss past the grace window marks disconnected without bumping heartbeat", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    // last_heartbeat_at 200s ago > 120s grace → disconnect.
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      last_heartbeat_at: new Date(Date.now() - 200_000),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch failed");
+    });
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.status).toBe("disconnected");
+      // last_heartbeat_at is bumped ONLY on success — its age is the liveness clock.
+      expect(Object.hasOwn(patch, "last_heartbeat_at")).toBe(false);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("probe that succeeds on a retry bumps last_heartbeat_at and leaves status alone", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = customSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("cold path"); // first attempt re-warms
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+      expect(calls).toBe(2); // retry semantics preserved
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
+      expect(patch.status).toBeUndefined();
     } finally {
       findSpy.mockRestore();
       updateSpy.mockRestore();

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -391,3 +391,99 @@ describe("ElizaSandboxService wake", () => {
     },
   );
 });
+
+describe("ElizaSandboxService reconcileDisconnected", () => {
+  function disconnectedSandbox(): AgentSandbox {
+    return { ...customSandbox(), status: "disconnected" };
+  }
+
+  test("restores a reachable disconnected agent to running and bumps heartbeat", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const probed: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      probed.push(fetchUrl(input));
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(true);
+      expect(probed).toEqual(["https://legacy-bridge.example/api/health"]);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [updatedId, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(updatedId).toBe(sandbox.id);
+      expect(patch.status).toBe("running");
+      expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("leaves an unreachable disconnected agent untouched", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = disconnectedSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    globalThis.fetch = mock(async () => {
+      throw new Error("fetch failed");
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+
+      expect(recovered).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("no-ops when the agent is no longer disconnected", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const findSpy = spyOn(agentSandboxesRepository, "findDisconnectedSandbox").mockResolvedValue(
+      undefined,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    let fetched = false;
+    globalThis.fetch = mock(async () => {
+      fetched = true;
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const recovered = await new ElizaSandboxService().reconcileDisconnected(
+        "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+        "22222222-2222-4222-8222-222222222222",
+      );
+
+      expect(recovered).toBe(false);
+      expect(fetched).toBe(false);
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3354,10 +3354,13 @@ export class ElizaSandboxService {
     const alive = await this.probeBridgeHealth(rec);
     if (!alive) return false;
 
-    await agentSandboxesRepository.update(rec.id, {
-      status: "running",
-      last_heartbeat_at: new Date(),
-    });
+    // Guarded compare-and-set, not a blind update: the row can move to
+    // deletion_pending / stopped / provisioning during the multi-second probe.
+    // Only flip it back if it is STILL disconnected — otherwise we'd resurrect a
+    // being-deleted agent or wedge a stopped one at `running` with a dead bridge.
+    const restored = await agentSandboxesRepository.markReconnectedFromDisconnected(rec.id);
+    if (!restored) return false;
+
     logger.info("[agent-sandbox] Disconnected agent reachable again, restored to running", {
       agentId,
     });

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -632,20 +632,14 @@ export class ElizaSandboxService {
     orgId: string,
     input: { agentName?: string; agentConfig?: Record<string, unknown> },
   ): Promise<AgentSandbox | undefined> {
-    const rec = await agentSandboxesRepository.findByIdAndOrgForWrite(
-      agentId,
-      orgId,
-    );
+    const rec = await agentSandboxesRepository.findByIdAndOrgForWrite(agentId, orgId);
     if (!rec) return undefined;
 
-    const updates: { agent_name?: string; agent_config?: Record<string, unknown> } =
-      {};
+    const updates: { agent_name?: string; agent_config?: Record<string, unknown> } = {};
     if (input.agentName !== undefined) updates.agent_name = input.agentName;
     if (input.agentConfig !== undefined) {
       const existing =
-        rec.agent_config &&
-        typeof rec.agent_config === "object" &&
-        !Array.isArray(rec.agent_config)
+        rec.agent_config && typeof rec.agent_config === "object" && !Array.isArray(rec.agent_config)
           ? (rec.agent_config as Record<string, unknown>)
           : {};
       updates.agent_config = { ...existing, ...input.agentConfig };

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3259,48 +3259,55 @@ export class ElizaSandboxService {
 
   // Heartbeat
 
-  async heartbeat(agentId: string, orgId: string): Promise<boolean> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
-    if (!rec?.bridge_url) return false;
-
-    // The agent is reached over the headscale tailnet, where an idle path goes
-    // cold; a single cold-path miss must not evict a healthy agent. Retry the
-    // probe (the first attempt re-warms the path), then apply hysteresis before
-    // giving up — seen live: a freshly-running agent was marked disconnected
-    // ~1 min after boot by one transient "fetch failed".
-    // Liveness must dial the BRIDGE port over the headscale tailnet. The
-    // container serves its full HTTP API there (and `/api/health` unauthed —
-    // the same endpoint provisioning's health probe passes on); `web_ui_port`
-    // is a host-only docker port mapping that is NOT reachable over the tailnet,
-    // so the web-base-url path `getAgentApiEndpoint` prefers is a dead poll for
-    // the on-prem worker and was flipping every running agent to `disconnected`.
-    // `bridge_url` is the trusted tailnet bridge (verified non-null above); build
-    // the health URL from it directly (this exact form is verified live in prod —
-    // a dedicated-always agent holds `running` and its subdomain proxies 200/401).
-    const heartbeatEndpoint = new URL("/api/health", rec.bridge_url).toString();
-    let res: Response | null = null;
+  /**
+   * Dial an agent's bridge health endpoint over the headscale tailnet, with
+   * retry. The tailnet path goes cold when idle, so a single miss must not be
+   * read as "down" — the first attempt re-warms the path. Returns true on the
+   * first `2xx`.
+   *
+   * Liveness must dial the BRIDGE port: the container serves its full HTTP API
+   * there (and `/api/health` unauthed — the same endpoint provisioning's health
+   * probe passes on). `web_ui_port` is a host-only docker port mapping NOT
+   * reachable over the tailnet, so the web-base-url path `getAgentApiEndpoint`
+   * prefers is a dead poll for the on-prem worker and was flipping every
+   * running agent to `disconnected`. `bridge_url` is the trusted tailnet bridge
+   * (callers verify it is non-null); this exact form is verified live in prod —
+   * a dedicated-always agent holds `running` and its subdomain proxies 200/401.
+   */
+  private async probeBridgeHealth(
+    rec: Pick<AgentSandbox, "id" | "environment_vars" | "bridge_url">,
+  ): Promise<boolean> {
+    if (!rec.bridge_url) return false;
+    const endpoint = new URL("/api/health", rec.bridge_url).toString();
     for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
       if (attempt > 0) {
         await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
       }
       try {
-        res = await fetch(heartbeatEndpoint, {
+        const res = await fetch(endpoint, {
           method: "GET",
           headers: this.getAgentJsonHeaders(rec),
           signal: AbortSignal.timeout(10_000),
         });
-        if (res.ok) break;
+        if (res.ok) return true;
       } catch (error) {
-        logger.debug("[agent-sandbox] Heartbeat probe attempt failed, retrying", {
-          agentId,
+        logger.debug("[agent-sandbox] Bridge health probe attempt failed, retrying", {
+          agentId: rec.id,
           attempt,
           error: error instanceof Error ? error.message : String(error),
         });
-        res = null;
       }
     }
+    return false;
+  }
 
-    if (!res?.ok) {
+  async heartbeat(agentId: string, orgId: string): Promise<boolean> {
+    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    if (!rec?.bridge_url) return false;
+
+    const alive = await this.probeBridgeHealth(rec);
+
+    if (!alive) {
       // Hysteresis: one failed cycle is not enough to evict. last_heartbeat_at
       // is bumped only on success, so its age is how long the agent has been
       // continuously unreachable. Stay running inside the grace window (the next
@@ -3328,6 +3335,31 @@ export class ElizaSandboxService {
     }
     await agentSandboxesRepository.update(rec.id, {
       last_heartbeat_at: new Date(),
+    });
+    return true;
+  }
+
+  /**
+   * Re-probe a single `disconnected` dedicated agent and, if its bridge answers
+   * again, restore it to `running`. The heartbeat cycle only dials `running`
+   * rows, so without this an always-on agent that drops past the grace window
+   * (a transient tailnet blip, a node reboot) would stay `disconnected` forever:
+   * its public subdomain 404s and the only recovery was a manual re-provision.
+   * Returns true when the agent was recovered.
+   */
+  async reconcileDisconnected(agentId: string, orgId: string): Promise<boolean> {
+    const rec = await agentSandboxesRepository.findDisconnectedSandbox(agentId, orgId);
+    if (!rec?.bridge_url) return false;
+
+    const alive = await this.probeBridgeHealth(rec);
+    if (!alive) return false;
+
+    await agentSandboxesRepository.update(rec.id, {
+      status: "running",
+      last_heartbeat_at: new Date(),
+    });
+    logger.info("[agent-sandbox] Disconnected agent reachable again, restored to running", {
+      agentId,
     });
     return true;
   }

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-reconcile.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-reconcile.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Accounting + fault-isolation of the disconnected-agent reconcile wrapper
+ * (ProvisioningJobService.processDisconnectedReconcile), the on-prem daemon's
+ * per-cycle entry point. The wrapper mirrors processRunningHeartbeats: it must
+ * call reconcileDisconnected exactly once per candidate, tally
+ * {recovered, stillDown} correctly, and never let one throwing candidate abort
+ * the rest of the cycle.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { elizaSandboxService } from "./eliza-sandbox";
+import { provisioningJobService } from "./provisioning-jobs";
+
+describe("processDisconnectedReconcile", () => {
+  test("tallies recovered/stillDown and isolates a throwing candidate", async () => {
+    const candidates = [
+      { id: "11111111-1111-4111-8111-111111111111", organization_id: "o1" },
+      { id: "22222222-2222-4222-8222-222222222222", organization_id: "o2" },
+      { id: "33333333-3333-4333-8333-333333333333", organization_id: "o3" },
+    ];
+    const listSpy = spyOn(
+      agentSandboxesRepository,
+      "listReconcilableDisconnected",
+    ).mockResolvedValue(candidates);
+    const reconcileSpy = spyOn(elizaSandboxService, "reconcileDisconnected").mockImplementation(
+      async (id: string) => {
+        if (id === candidates[0].id) return true; // recovered
+        if (id === candidates[1].id) return false; // still down
+        throw new Error("probe blew up"); // must be caught -> stillDown
+      },
+    );
+
+    try {
+      const result = await provisioningJobService.processDisconnectedReconcile(5);
+
+      expect(result).toEqual({ total: 3, recovered: 1, stillDown: 2 });
+      // exactly once per candidate, no double-drain of the queue
+      expect(reconcileSpy).toHaveBeenCalledTimes(3);
+      const calledIds = reconcileSpy.mock.calls.map((c) => c[0]).sort();
+      expect(calledIds).toEqual(candidates.map((c) => c.id).sort());
+    } finally {
+      listSpy.mockRestore();
+      reconcileSpy.mockRestore();
+    }
+  });
+
+  test("no candidates -> no probes, zeroed result", async () => {
+    const listSpy = spyOn(
+      agentSandboxesRepository,
+      "listReconcilableDisconnected",
+    ).mockResolvedValue([]);
+    const reconcileSpy = spyOn(elizaSandboxService, "reconcileDisconnected").mockResolvedValue(
+      true,
+    );
+
+    try {
+      const result = await provisioningJobService.processDisconnectedReconcile(5);
+      expect(result).toEqual({ total: 0, recovered: 0, stillDown: 0 });
+      expect(reconcileSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      reconcileSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -2214,6 +2214,43 @@ export class ProvisioningJobService {
     return { total, succeeded, failed };
   }
 
+  /**
+   * Re-probe `disconnected` dedicated agents and restore reachable ones to
+   * `running`. Complements processRunningHeartbeats (which only dials `running`
+   * rows): an always-on agent that drops past the grace window would otherwise
+   * stay disconnected forever, with no automatic path back. Runs from the
+   * on-prem worker only (HTTP over the Headscale tunnel).
+   */
+  async processDisconnectedReconcile(concurrency = 5): Promise<ReconcileResult> {
+    const candidates = await agentSandboxesRepository.listReconcilableDisconnected();
+    const total = candidates.length;
+    if (total === 0) return { total: 0, recovered: 0, stillDown: 0 };
+
+    let recovered = 0;
+    let stillDown = 0;
+    const queue = [...candidates];
+    const workers = Array.from({ length: Math.min(concurrency, total) }, async () => {
+      while (true) {
+        const r = queue.shift();
+        if (!r) break;
+        const ok = await elizaSandboxService
+          .reconcileDisconnected(r.id, r.organization_id)
+          .catch((error: unknown) => {
+            logger.warn("[provisioning-jobs] reconcile threw", {
+              agentId: r.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return false;
+          });
+        if (ok) recovered += 1;
+        else stillDown += 1;
+      }
+    });
+    await Promise.all(workers);
+
+    return { total, recovered, stillDown };
+  }
+
   private async recoverStaleJobs(
     jobTypes: readonly ProvisioningJobType[] = Object.values(JOB_TYPES),
   ): Promise<number> {
@@ -2341,6 +2378,12 @@ export interface HeartbeatResult {
   total: number;
   succeeded: number;
   failed: number;
+}
+
+export interface ReconcileResult {
+  total: number;
+  recovered: number;
+  stillDown: number;
 }
 
 export interface ProcessingResult {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -21,6 +21,7 @@ import {
 import type {
   HeartbeatResult,
   ProcessingResult,
+  ReconcileResult,
 } from "@elizaos/cloud-shared/lib/services/provisioning-jobs";
 import { loadLocalEnv } from "./shared/load-env";
 
@@ -232,6 +233,13 @@ async function processHeartbeatCycle(
 ): Promise<HeartbeatResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processRunningHeartbeats(concurrency);
+}
+
+async function processReconcileCycle(
+  concurrency = 5,
+): Promise<ReconcileResult> {
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.processDisconnectedReconcile(concurrency);
 }
 
 interface NodeHealthSummary {
@@ -656,6 +664,21 @@ async function pollCycle(
     }
   } catch (error) {
     logger.error("[provisioning-worker] heartbeat cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const reconcile = await processReconcileCycle();
+    if (reconcile.recovered > 0) {
+      logger.info("[provisioning-worker] disconnect reconcile cycle complete", {
+        total: reconcile.total,
+        recovered: reconcile.recovered,
+        stillDown: reconcile.stillDown,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] disconnect reconcile cycle failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
Re-delivers the #8434 dedicated-agent follow-up work. **Supersedes #8627**, which was merged but dropped when develop was re-curated — so the reconcile feature is currently NOT on develop. This branch is rebased onto the live develop tip and, critically, includes the **TOCTOU guard** that an adversarial review flagged after #8627 had already merged (so #8627's content would have shipped the unguarded version).

The dedicated-agent path is otherwise verified working end-to-end on prod (provision → holds `running` → `<id>.elizacloud.ai` proxies). This closes the last hardening gap + greens the cloud lint gate.

## 1. Green Cloud Tests lint (3 files)
Biome **formatter** violations live on develop from PRs merged under churn-cancelled CI — `eliza-sandbox.ts` (#8608), `worker-neon-http.ts` (#8623), and `db/client.ts`. All fail `verify:cloud` → the Cloud Tests `lint-and-types` job is red on every develop run. Pure whitespace.

## 2. Auto-recover disconnected dedicated agents (the last #8434 gap)
The heartbeat cycle only dials `running` rows, so a dropped always-on agent stayed `disconnected` forever (subdomain 404s; manual re-provision was the only fix). Adds a reconcile pass:
- **repo** — `listReconcilableDisconnected()` (disconnected, non-shared, has bridge, not soft-deleted, dropped <24h, **bounded `.limit(20)`**) + `findDisconnectedSandbox()`.
- **service** — `probeBridgeHealth()` extracted from `heartbeat()` (behaviour-preserving) + `reconcileDisconnected()`.
- **jobs** — `processDisconnectedReconcile()`; **daemon** runs a reconcile cycle each tick after the heartbeat cycle.

## 3. TOCTOU guard (HIGH — found by adversarial review)
The reconcile read→probe→write window spans ~34s. An unconditional `status='running'` write could clobber a concurrent `deletion_pending` / `stopped` (which nulls `bridge_url`) / `provisioning` transition — the `stopped` case would **wedge the agent at `running` with a dead bridge forever**, i.e. *create* the exact permanent-disconnect class #8434 exists to kill. Fixed with a guarded compare-and-set (`markReconnectedFromDisconnected`, mirrors `trySetProvisioning`) that only flips a row still `disconnected` with a live bridge; 0 rows ⇒ "lost the race, not recovered".

### Verification (rebased onto current develop)
- `bun run --cwd packages/cloud-shared lint` ✅ (1073 files, 0 errors)
- `bun run --cwd packages/cloud-shared typecheck` ✅ (exit 0)
- `bun test` ✅ **19/19** across eliza-sandbox (heartbeat regression + reconcile + guarded-CAS + non-200 cases), agent-sandboxes (operator-pinned where-clause), provisioning-jobs-reconcile (wrapper accounting + throw isolation)
- daemon bundles clean with the new imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)