### PR TITLE
fix(shared): unwrap bare {"reply":...} reply objects so cloud replies render clean

### DIFF
--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -50,4 +50,41 @@ describe("assistant text helpers", () => {
     ).toBe("hello");
     expect(stripAssistantStageDirections("*waves* hello").trim()).toBe("hello");
   });
+
+  it('unwraps a bare {"reply":...} object the model emitted as text', () => {
+    expect(extractAssistantReplyText('{"reply":"107"}')).toBe("107");
+    expect(
+      extractAssistantReplyText('{"reply":"Red, blue, and yellow."}'),
+    ).toBe("Red, blue, and yellow.");
+  });
+
+  it('unwraps {"reply":...} alongside known response-shape siblings', () => {
+    expect(
+      extractAssistantReplyText('{"reply":"hi there","action":"NONE"}'),
+    ).toBe("hi there");
+    expect(
+      extractAssistantReplyText(
+        JSON.stringify({ thought: "x", reply: "done", actions: ["REPLY"] }),
+      ),
+    ).toBe("done");
+  });
+
+  it("strips stage directions from an unwrapped reply object", () => {
+    expect(extractAssistantReplyText('{"reply":"*waves* hello"}')).toBe(
+      "hello",
+    );
+  });
+
+  it("does NOT unwrap a reply object carrying unrelated data (preserve content)", () => {
+    expect(
+      extractAssistantReplyText('{"reply":"hi","userData":{"id":1}}'),
+    ).toBeNull();
+    expect(extractAssistantReplyText('{"reply":42}')).toBeNull();
+  });
+
+  it("does not rewrite ordinary chat text that merely contains the word reply", () => {
+    expect(
+      extractAssistantReplyText("Sure — my reply is that the sky is blue."),
+    ).toBeNull();
+  });
 });

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -199,6 +199,36 @@ function isResponseHandlerPayload(
   );
 }
 
+// Structural keys an elizaOS reply object may legitimately carry alongside the
+// user-facing `reply`. When a parsed object's keys are ALL within this set and
+// it has a string `reply`, the model emitted its whole response object as text
+// (e.g. `{"reply":"107"}` or `{"reply":"…","action":"NONE"}`) — unwrap it. The
+// allow-list keeps us from stripping real chat content that merely happens to be
+// JSON with a `reply` field plus unrelated data.
+const REPLY_PAYLOAD_KEYS = new Set([
+  "reply",
+  "text",
+  "message",
+  "thought",
+  "action",
+  "actions",
+  "simple",
+  "providers",
+  "evaluators",
+  "inReplyTo",
+  "attachments",
+]);
+
+function isSimpleReplyPayload(
+  value: Record<string, unknown>,
+): value is Record<string, unknown> & { reply: string } {
+  if (typeof value.reply !== "string") return false;
+  for (const key of Object.keys(value)) {
+    if (!REPLY_PAYLOAD_KEYS.has(key)) return false;
+  }
+  return true;
+}
+
 /**
  * Extracts the user-facing reply from a response-handler payload that leaked as
  * plain text. Local models can emit tool arguments as text when function-call
@@ -211,22 +241,43 @@ function isResponseHandlerPayload(
  */
 export function extractAssistantReplyText(input: string): string | null {
   const trimmed = input.trim();
-  if (!trimmed.includes("replyText")) return null;
 
-  const candidates = [trimmed];
-  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
-    candidates.push(`{"shouldRespond":${trimmed}}`);
-    if (trimmed.endsWith("}")) {
-      candidates.push(`{"shouldRespond":${trimmed.slice(0, -1)}}`);
+  // Shape 1: a leaked response-handler payload keyed by `replyText` — either the
+  // full object or a bare argument fragment (`"RESPOND", "replyText": "Hi"`).
+  if (trimmed.includes("replyText")) {
+    const candidates = [trimmed];
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+      candidates.push(`{"shouldRespond":${trimmed}}`);
+      if (trimmed.endsWith("}")) {
+        candidates.push(`{"shouldRespond":${trimmed.slice(0, -1)}}`);
+      }
+    }
+
+    for (const candidate of candidates) {
+      const parsed = tryParseObject(candidate);
+      if (!parsed || !isResponseHandlerPayload(parsed)) continue;
+      const replyText = parsed.replyText.trim();
+      if (!replyText) return null;
+      return stripAssistantStageDirections(replyText).trim() || null;
     }
   }
 
-  for (const candidate of candidates) {
-    const parsed = tryParseObject(candidate);
-    if (!parsed || !isResponseHandlerPayload(parsed)) continue;
-    const replyText = parsed.replyText.trim();
-    if (!replyText) return null;
-    return stripAssistantStageDirections(replyText).trim() || null;
+  // Shape 2: the model emitted its whole reply object as text, e.g.
+  // `{"reply":"107"}` or `{"reply":"…","action":"NONE"}` (observed from
+  // gpt-oss/glm on cloud agents). Only unwrap a well-formed object whose keys
+  // are all known response-shape keys, so ordinary chat text that merely
+  // contains JSON is never rewritten.
+  if (
+    trimmed.startsWith("{") &&
+    trimmed.endsWith("}") &&
+    trimmed.includes('"reply"')
+  ) {
+    const parsed = tryParseObject(trimmed);
+    if (parsed && isSimpleReplyPayload(parsed)) {
+      const reply = parsed.reply.trim();
+      if (!reply) return null;
+      return stripAssistantStageDirections(reply).trim() || null;
+    }
   }
 
   return null;


### PR DESCRIPTION
## What
`extractAssistantReplyText` (used by the chat UI's `normalizeAssistantText`) now unwraps a bare `{"reply":"..."}` object that a model emitted as its reply text — in addition to the existing `replyText`+`shouldRespond` response-handler shape.

## Why
Dedicated Eliza Cloud agents (gpt-oss/glm) intermittently return their whole response object **as the reply text**, e.g. `{"reply":"107"}` or `{"reply":"Red, blue, and yellow."}`. Because the previous logic only matched the `replyText` shape, these leaked **verbatim into the chat UI** — the user saw literal JSON instead of the answer.

**Reproduced live** on a real dedicated cloud agent both on-device (Android) and via direct REST:
```
Q: What is my favorite color?      A: {"reply":"teal"}
Q: Name three primary colors.      A: {"reply":"Red, blue, and yellow."}
```

> Note: the *root cause* (cloud agents running `openai/gpt-oss-120b:nitro` instead of the Cerebras defaults, tracked in #8434) is being fixed cloud-side. This PR is defense-in-depth so the UI is robust to any model that leaks structured output.

## How
Unwrap only a **well-formed object whose keys are all in a known response-shape allow-list** (`reply`, `text`, `thought`, `action`, `actions`, `simple`, ...). Ordinary chat text that merely contains a `reply` field plus unrelated data is left untouched, and stage directions are still stripped from the unwrapped reply.

## Tests
Added cases for: bare `{"reply":...}`, reply + allowed siblings, stage-direction stripping inside the object, and the **preserve-content boundary** (non-allow-listed keys / non-string reply → not unwrapped). `bun run --cwd packages/shared test assistant-text` → 10/10 green; lint + typecheck clean.

Refs #8434.