### PR TITLE
fix(cloud): dedicated agent chat — embeddings 503 + wrong-model (:nitro) default

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -384,16 +384,21 @@ export function getLanguageModel(model: string) {
 }
 
 export function getTextEmbeddingModel(model: string) {
-  if (getBitRouterApiKey()) {
-    return getBitRouterClient().textEmbeddingModel(toBitRouterModelId(model));
-  }
-
+  // BitRouter serves chat-completions ONLY (no `/v1/embeddings` route) — routing
+  // embeddings through it 404s ("Not Found" → 503 provider_error), which breaks
+  // every memory/RAG turn on agents that use cloud embeddings. So try the real
+  // embeddings providers (Vercel AI Gateway, then OpenAI native) FIRST, and only
+  // fall back to BitRouter as a last resort when nothing else is configured.
   if (getVercelAIGatewayApiKey()) {
     return getVercelAIGatewayClient().embeddingModel(model as never);
   }
 
-  if (isOpenAINativeModel(model) && getProviderKey("OPENAI_API_KEY")) {
+  if (getProviderKey("OPENAI_API_KEY")) {
     return getOpenAIClient().textEmbeddingModel(normalizeOpenAIModelId(model));
+  }
+
+  if (getBitRouterApiKey()) {
+    return getBitRouterClient().textEmbeddingModel(toBitRouterModelId(model));
   }
 
   throw new Error("AI text embedding provider is not configured");
@@ -456,16 +461,18 @@ export function resolveAiProviderSource(
 }
 
 export function resolveEmbeddingProviderSource(): "bitrouter" | "gateway" | "openai" | null {
-  if (getBitRouterApiKey()) {
-    return "bitrouter";
-  }
-
+  // Mirror getTextEmbeddingModel's order so billing attributes the embedding to
+  // the provider that actually served it. BitRouter is last (no embeddings route).
   if (getVercelAIGatewayApiKey()) {
     return "gateway";
   }
 
   if (getProviderKey("OPENAI_API_KEY")) {
     return "openai";
+  }
+
+  if (getBitRouterApiKey()) {
+    return "bitrouter";
   }
 
   return null;

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -1,5 +1,9 @@
 import crypto from "node:crypto";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
+import {
+  CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
+  CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
+} from "../models";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { apiKeysService } from "./api-keys";
 
@@ -220,6 +224,15 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZAOS_CLOUD_API_KEY: agentApiKey,
       ELIZAOS_CLOUD_ENABLED: "true",
       ELIZAOS_CLOUD_BASE_URL: resolveCloudApiBaseUrl(),
+      // Pin the cloud's healthy Cerebras-direct models so the container never
+      // resolves a tier to the `:nitro` default (which has no Cerebras route →
+      // BitRouter→OpenRouter → 503 / wrong model). Mirrors the shared + eliza-app
+      // model config; `ELIZAOS_CLOUD_{SMALL,LARGE}_MODEL` are the highest-priority
+      // settings the plugin reads. An explicit per-agent override still wins.
+      ELIZAOS_CLOUD_SMALL_MODEL:
+        existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
+      ELIZAOS_CLOUD_LARGE_MODEL:
+        existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
       ELIZA_CLOUD_AGENT_ID: params.agentSandboxId,
       PUBLIC_BASE_URL: mergeManagedPublicBaseUrl(
         existingEnv.PUBLIC_BASE_URL,


### PR DESCRIPTION
Two cloud-side config bugs that break chat on dedicated (paid) containers, found via live agent logs (every app user gets a dedicated agent per #8622). BUG A: embeddings routed through BitRouter (no /v1/embeddings) → 503 on every memory turn; fix prefers OpenAI/gateway. BUG B: containers ran openai/gpt-oss-120b:nitro (→OpenRouter) for all tiers; fix pins ELIZAOS_CLOUD_{SMALL,LARGE}_MODEL to the healthy Cerebras ids. Found + co-debugged with the mobile agent (#8434).