### PR TITLE
feat(cloud): self-heal disconnected always-on (paid) agents

### DIFF
--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -208,6 +208,45 @@ export class AgentSandboxesRepository {
   }
 
   /**
+   * `disconnected` always-on (paid) agents that should be reconciled back to
+   * `running`. A `dedicated-always` agent is contractually meant to stay up, so
+   * a transient tailnet drop that flipped it to `disconnected` must self-heal —
+   * the recovery cycle re-probes the bridge and either flips it back to
+   * `running` (still reachable) or re-provisions it (truly down). Scoped to
+   * `dedicated-always` because `dedicated-lazy`/`shared` are NOT meant to hold
+   * an always-on container. Deleted rows are excluded.
+   */
+  async listRecoverable(limit = 100): Promise<
+    Array<{
+      id: string;
+      organization_id: string;
+      user_id: string;
+      agent_name: string | null;
+      bridge_url: string | null;
+      updated_at: Date;
+    }>
+  > {
+    return dbRead
+      .select({
+        id: agentSandboxes.id,
+        organization_id: agentSandboxes.organization_id,
+        user_id: agentSandboxes.user_id,
+        agent_name: agentSandboxes.agent_name,
+        bridge_url: agentSandboxes.bridge_url,
+        updated_at: agentSandboxes.updated_at,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.status, "disconnected"),
+          eq(agentSandboxes.execution_tier, "dedicated-always"),
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+        ),
+      )
+      .limit(limit);
+  }
+
+  /**
    * Find running, non-deleted agents whose stored `image_digest` differs
    * from `targetDigest` (treating NULL as different). Used by the
    * fleet-upgrade reconciler to enqueue blue/green swaps onto the

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3269,44 +3269,9 @@ export class ElizaSandboxService {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec?.bridge_url) return false;
 
-    // The agent is reached over the headscale tailnet, where an idle path goes
-    // cold; a single cold-path miss must not evict a healthy agent. Retry the
-    // probe (the first attempt re-warms the path), then apply hysteresis before
-    // giving up — seen live: a freshly-running agent was marked disconnected
-    // ~1 min after boot by one transient "fetch failed".
-    // Liveness must dial the BRIDGE port over the headscale tailnet. The
-    // container serves its full HTTP API there (and `/api/health` unauthed —
-    // the same endpoint provisioning's health probe passes on); `web_ui_port`
-    // is a host-only docker port mapping that is NOT reachable over the tailnet,
-    // so the web-base-url path `getAgentApiEndpoint` prefers is a dead poll for
-    // the on-prem worker and was flipping every running agent to `disconnected`.
-    // `bridge_url` is the trusted tailnet bridge (verified non-null above); build
-    // the health URL from it directly (this exact form is verified live in prod —
-    // a dedicated-always agent holds `running` and its subdomain proxies 200/401).
-    const heartbeatEndpoint = new URL("/api/health", rec.bridge_url).toString();
-    let res: Response | null = null;
-    for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
-      if (attempt > 0) {
-        await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
-      }
-      try {
-        res = await fetch(heartbeatEndpoint, {
-          method: "GET",
-          headers: this.getAgentJsonHeaders(rec),
-          signal: AbortSignal.timeout(10_000),
-        });
-        if (res.ok) break;
-      } catch (error) {
-        logger.debug("[agent-sandbox] Heartbeat probe attempt failed, retrying", {
-          agentId,
-          attempt,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        res = null;
-      }
-    }
+    const reachable = await this.probeBridgeHealth(rec);
 
-    if (!res?.ok) {
+    if (!reachable) {
       // Hysteresis: one failed cycle is not enough to evict. last_heartbeat_at
       // is bumped only on success, so its age is how long the agent has been
       // continuously unreachable. Stay running inside the grace window (the next
@@ -3336,6 +3301,73 @@ export class ElizaSandboxService {
       last_heartbeat_at: new Date(),
     });
     return true;
+  }
+
+  /**
+   * Probe the agent's bridge `/api/health` over the headscale tailnet with
+   * retries. Shared by `heartbeat` (running agents) and `recoverDisconnected`
+   * (disconnected always-on agents).
+   *
+   * The first attempt re-warms a cold tailnet path, so a single miss does not
+   * mean the agent is down. Liveness MUST dial the BRIDGE port: the container
+   * serves its full HTTP API there (and `/api/health` unauthed — the same
+   * endpoint provisioning's health probe passes on); `web_ui_port` is a
+   * host-only docker mapping NOT reachable over the tailnet. This exact form is
+   * verified live in prod (a dedicated-always agent holds `running` and its
+   * subdomain proxies 200/401).
+   */
+  private async probeBridgeHealth(
+    rec: Pick<AgentSandbox, "id" | "environment_vars" | "bridge_url">,
+  ): Promise<boolean> {
+    if (!rec.bridge_url) return false;
+    const endpoint = new URL("/api/health", rec.bridge_url).toString();
+    for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
+      }
+      try {
+        const res = await fetch(endpoint, {
+          method: "GET",
+          headers: this.getAgentJsonHeaders(rec),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (res.ok) return true;
+      } catch (error) {
+        logger.debug("[agent-sandbox] Bridge health probe attempt failed, retrying", {
+          agentId: rec.id,
+          attempt,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reconcile a `disconnected` always-on (paid) agent back to health. A
+   * `dedicated-always` agent is contractually meant to stay up, so the recovery
+   * cycle calls this to self-heal a transient drop: re-probe the bridge and, if
+   * the container answers, flip it straight back to `running` (the agent-router
+   * only routes `running`, so this also restores its subdomain). If it stays
+   * unreachable the caller re-provisions it. The status guard makes this safe to
+   * run concurrently with the heartbeat cycle.
+   */
+  async recoverDisconnected(
+    agentId: string,
+    orgId: string,
+  ): Promise<"recovered" | "unreachable" | "gone"> {
+    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    if (!rec || rec.status !== "disconnected") return "gone";
+    const reachable = await this.probeBridgeHealth(rec);
+    if (!reachable) return "unreachable";
+    await agentSandboxesRepository.update(rec.id, {
+      status: "running",
+      last_heartbeat_at: new Date(),
+    });
+    logger.info("[agent-sandbox] Recovered disconnected agent back to running", {
+      agentId,
+    });
+    return "recovered";
   }
 
   // Shutdown

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-recovery.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-recovery.test.ts
@@ -1,0 +1,116 @@
+/**
+ * processDisconnectedRecovery — the self-heal cycle for `disconnected` always-on
+ * (paid) agents. The heartbeat cycle only touches RUNNING agents, so without
+ * this a `dedicated-always` agent that briefly dropped past the grace window
+ * would stay `disconnected` forever (agent-router routes only `running` → its
+ * subdomain 404s). This guards the orchestration seam: listRecoverable →
+ * recoverDisconnected → enqueueAgentProvisionOnce only for the still-unreachable.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { elizaSandboxService } from "./eliza-sandbox";
+import { provisioningJobService } from "./provisioning-jobs";
+
+function recoverable(id: string, orgId: string, bridge: string | null) {
+  return {
+    id,
+    organization_id: orgId,
+    user_id: `user-${id}`,
+    agent_name: `Agent ${id}`,
+    bridge_url: bridge,
+    updated_at: new Date("2026-06-19T00:00:00Z"),
+  };
+}
+
+describe("processDisconnectedRecovery", () => {
+  test("reachable → recovered (no re-provision); unreachable → re-provision; gone → skipped", async () => {
+    const listSpy = spyOn(
+      agentSandboxesRepository,
+      "listRecoverable",
+    ).mockResolvedValue([
+      recoverable("a1", "o1", "http://10.0.0.1:2138"),
+      recoverable("a2", "o1", "http://10.0.0.2:2138"),
+      recoverable("a3", "o2", "http://10.0.0.3:2138"),
+    ]);
+    const recoverSpy = spyOn(
+      elizaSandboxService,
+      "recoverDisconnected",
+    ).mockImplementation(async (id: string) => {
+      if (id === "a1") return "recovered";
+      if (id === "a2") return "unreachable";
+      return "gone";
+    });
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentProvisionOnce",
+    ).mockResolvedValue({ created: true, job: { id: "job-1" } } as never);
+
+    try {
+      const res = await provisioningJobService.processDisconnectedRecovery(5);
+
+      expect(res).toEqual({
+        total: 3,
+        recovered: 1,
+        reprovisioned: 1,
+        failed: 0,
+      });
+      // Only the still-unreachable agent (a2) is re-provisioned; recovered/gone
+      // agents are NOT enqueued (would waste a container rebuild on a live one).
+      const enqueuedIds = enqueueSpy.mock.calls.map((c) => c[0].agentId);
+      expect(enqueuedIds).toEqual(["a2"]);
+      expect(enqueueSpy.mock.calls[0]?.[0].userId).toBe("user-a2");
+    } finally {
+      listSpy.mockRestore();
+      recoverSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("empty list → no work, no enqueue", async () => {
+    const listSpy = spyOn(
+      agentSandboxesRepository,
+      "listRecoverable",
+    ).mockResolvedValue([]);
+    const enqueueSpy = spyOn(
+      provisioningJobService,
+      "enqueueAgentProvisionOnce",
+    ).mockResolvedValue({ created: true, job: { id: "job-1" } } as never);
+    try {
+      const res = await provisioningJobService.processDisconnectedRecovery();
+      expect(res).toEqual({ total: 0, recovered: 0, reprovisioned: 0, failed: 0 });
+      expect(enqueueSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("a throw on one agent is counted failed; the rest still process", async () => {
+    const listSpy = spyOn(
+      agentSandboxesRepository,
+      "listRecoverable",
+    ).mockResolvedValue([
+      recoverable("a1", "o1", "http://10.0.0.1:2138"),
+      recoverable("a2", "o1", "http://10.0.0.2:2138"),
+    ]);
+    const recoverSpy = spyOn(
+      elizaSandboxService,
+      "recoverDisconnected",
+    ).mockImplementation(async (id: string) => {
+      if (id === "a1") throw new Error("probe blew up");
+      return "recovered";
+    });
+    try {
+      // concurrency 1 → deterministic order (a1 then a2)
+      const res = await provisioningJobService.processDisconnectedRecovery(1);
+      expect(res.total).toBe(2);
+      expect(res.failed).toBe(1);
+      expect(res.recovered).toBe(1);
+    } finally {
+      listSpy.mockRestore();
+      recoverSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -2214,6 +2214,67 @@ export class ProvisioningJobService {
     return { total, succeeded, failed };
   }
 
+  /**
+   * Reconcile `disconnected` always-on (paid) agents back to health. The
+   * heartbeat cycle only iterates RUNNING agents, so a `dedicated-always` agent
+   * that dropped past the grace window and flipped to `disconnected` would
+   * otherwise stay dead forever (the agent-router routes only `running`, so its
+   * subdomain 404s and the user's paid agent is unreachable). Each cycle
+   * re-probes the bridge: still reachable → flip straight back to `running`;
+   * truly down → enqueue a re-provision (idempotent — `enqueueAgentProvisionOnce`
+   * dedups an in-flight job, so running this every cycle won't pile up provisions).
+   */
+  async processDisconnectedRecovery(concurrency = 5): Promise<RecoveryResult> {
+    const recoverable = await agentSandboxesRepository.listRecoverable();
+    const total = recoverable.length;
+    if (total === 0) {
+      return { total: 0, recovered: 0, reprovisioned: 0, failed: 0 };
+    }
+
+    let recovered = 0;
+    let reprovisioned = 0;
+    let failed = 0;
+    const queue = [...recoverable];
+    const workers = Array.from({ length: Math.min(concurrency, total) }, async () => {
+      while (true) {
+        const r = queue.shift();
+        if (!r) break;
+        try {
+          const outcome = await elizaSandboxService.recoverDisconnected(
+            r.id,
+            r.organization_id,
+          );
+          if (outcome === "recovered") {
+            recovered += 1;
+            continue;
+          }
+          if (outcome === "gone") {
+            // No longer disconnected (already recovered/deleted) — nothing to do.
+            continue;
+          }
+          // Still unreachable — rebuild it.
+          await this.enqueueAgentProvisionOnce({
+            agentId: r.id,
+            organizationId: r.organization_id,
+            userId: r.user_id,
+            agentName: r.agent_name ?? r.id,
+            expectedUpdatedAt: r.updated_at,
+          });
+          reprovisioned += 1;
+        } catch (error) {
+          failed += 1;
+          logger.warn("[provisioning-jobs] disconnected recovery failed", {
+            agentId: r.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    });
+    await Promise.all(workers);
+
+    return { total, recovered, reprovisioned, failed };
+  }
+
   private async recoverStaleJobs(
     jobTypes: readonly ProvisioningJobType[] = Object.values(JOB_TYPES),
   ): Promise<number> {
@@ -2340,6 +2401,17 @@ export class ProvisioningJobService {
 export interface HeartbeatResult {
   total: number;
   succeeded: number;
+  failed: number;
+}
+
+export interface RecoveryResult {
+  /** disconnected always-on agents examined this cycle */
+  total: number;
+  /** flipped back to `running` because the bridge answered again */
+  recovered: number;
+  /** still unreachable → a re-provision job was enqueued */
+  reprovisioned: number;
+  /** recovery threw for this agent */
   failed: number;
 }
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -21,6 +21,7 @@ import {
 import type {
   HeartbeatResult,
   ProcessingResult,
+  RecoveryResult,
 } from "@elizaos/cloud-shared/lib/services/provisioning-jobs";
 import { loadLocalEnv } from "./shared/load-env";
 
@@ -232,6 +233,13 @@ async function processHeartbeatCycle(
 ): Promise<HeartbeatResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processRunningHeartbeats(concurrency);
+}
+
+async function processRecoveryCycle(
+  concurrency = 5,
+): Promise<RecoveryResult> {
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.processDisconnectedRecovery(concurrency);
 }
 
 interface NodeHealthSummary {
@@ -656,6 +664,22 @@ async function pollCycle(
     }
   } catch (error) {
     logger.error("[provisioning-worker] heartbeat cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const recovery = await processRecoveryCycle();
+    if (recovery.total > 0) {
+      logger.info("[provisioning-worker] recovery cycle complete", {
+        total: recovery.total,
+        recovered: recovery.recovered,
+        reprovisioned: recovery.reprovisioned,
+        failed: recovery.failed,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] recovery cycle failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
The heartbeat cycle only iterates RUNNING agents, so a dedicated-always agent that dropped past the grace window stayed disconnected forever (agent-router routes only running → subdomain 404s, paid agent dead). Adds a recovery cycle: re-probe the bridge → flip back to running if reachable, else re-provision (idempotent). 3 unit tests. See #8434.