### PR TITLE
feat(cloud): unified cloud-token auth on the WebSocket upgrade (no 'Lost backend connection')

### DIFF
--- a/packages/cloud-api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud-api/__tests__/dedicated-agent-proxy.test.ts
@@ -140,4 +140,41 @@ describe("dedicated-agent-proxy — unified auth", () => {
     expect(res.headers.get("Retry-After")).toBe("5");
     expect(captured).toBeNull();
   });
+
+  // A browser `new WebSocket()` can't set headers, so the app passes the cloud
+  // token as `?token=`. The proxy must validate it the same way and rewrite it
+  // to the agent token (the container reads `?token=` via ELIZA_ALLOW_WS_QUERY_TOKEN).
+  function makeWsRequest(cloudToken?: string): Request {
+    const u = new URL(`https://${AGENT}.elizacloud.ai/ws`);
+    if (cloudToken) u.searchParams.set("token", cloudToken);
+    return new Request(u.toString()); // no Authorization header
+  }
+
+  test("WS upgrade with ?token= (owner, running) → rewrites ?token= to the agent token + sets header", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = runningDedicated;
+
+    const r = makeWsRequest("cloud-token-abc");
+    await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(captured).not.toBeNull();
+    expect(new URL(captured?.url ?? "").searchParams.get("token")).toBe(
+      "agent-secret-token",
+    );
+    expect(captured?.headers.get("authorization")).toBe(
+      "Bearer agent-secret-token",
+    );
+  });
+
+  test("WS ?token= from a NON-OWNER → pass through, ?token= NOT rewritten (agent token never leaks)", async () => {
+    authResult = { user: { id: "att", organization_id: "attacker-org" } };
+    sandboxResult = null; // attacker's org does not own this agent
+
+    const r = makeWsRequest("attacker-cloud-token");
+    await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(new URL(captured?.url ?? "").searchParams.get("token")).toBe(
+      "attacker-cloud-token",
+    );
+  });
 });

--- a/packages/cloud-api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud-api/src/dedicated-agent-proxy.ts
@@ -62,6 +62,7 @@ function proxyToOrigin(
   env: Bindings,
   url: URL,
   injectBearer?: string,
+  injectQueryToken = false,
 ): Promise<Response> {
   const targetUrl = new URL(request.url);
   targetUrl.hostname = resolveOriginHost(env);
@@ -72,6 +73,13 @@ function proxyToOrigin(
   if (injectBearer) {
     headers.set("authorization", `Bearer ${injectBearer}`);
     headers.delete("x-api-key");
+    // The realtime WebSocket carries the token as `?token=` (browsers can't set
+    // headers on `new WebSocket()`); the container reads it via
+    // ELIZA_ALLOW_WS_QUERY_TOKEN. Rewrite that query param to the agent token
+    // too so the upgrade authenticates the same way the header does.
+    if (injectQueryToken) {
+      targetUrl.searchParams.set("token", injectBearer);
+    }
   }
   const init: RequestInit = {
     method: request.method,
@@ -165,6 +173,21 @@ async function resumeAndRespond(
 }
 
 /**
+ * The cloud token arrives in the Authorization header (or `x-api-key`) for HTTP
+ * requests, but the realtime WebSocket can't set headers on `new WebSocket()` —
+ * so the app passes it as a `?token=` query param (gated on the container by
+ * ELIZA_ALLOW_WS_QUERY_TOKEN). Detect a query-only token so we validate it the
+ * same way and inject the swapped agent token back on the same channel.
+ */
+function extractQueryToken(request: Request, url: URL): string | null {
+  // A header already carries auth → let the normal request validation handle it.
+  if (request.headers.get("authorization") || request.headers.get("x-api-key")) {
+    return null;
+  }
+  return url.searchParams.get("token")?.trim() || null;
+}
+
+/**
  * Auth-unify + proxy a request bound for `https://<agentId>.elizacloud.ai/*`.
  */
 export function handleDedicatedAgentProxy(
@@ -175,13 +198,23 @@ export function handleDedicatedAgentProxy(
 ): Promise<Response> {
   return runWithCloudBindingsAsync(env, async () => {
     try {
-      // 1. Validate the CLOUD token. No valid cloud token → pass through
-      //    unchanged (web UI assets, the pairing exchange, the agent's own
-      //    token); the container's auth is the backstop.
+      // 1. Validate the CLOUD token. It rides in the Authorization header for
+      //    HTTP, or as `?token=` for the WebSocket upgrade. No valid token →
+      //    pass through unchanged (web UI assets, the pairing exchange, the
+      //    agent's own token); the container's auth is the backstop.
+      const queryToken = extractQueryToken(request, url);
+      // Header/cookie auth validates the ORIGINAL request (preserves every
+      // existing auth method); a query-only (WS) token validates through a
+      // synthetic header request so it takes the exact same path.
+      const authRequest = queryToken
+        ? new Request(request.url, {
+            headers: { authorization: `Bearer ${queryToken}` },
+          })
+        : request;
       let orgId: string;
       let userId: string;
       try {
-        const { user } = await requireAuthOrApiKeyWithOrg(request);
+        const { user } = await requireAuthOrApiKeyWithOrg(authRequest);
         orgId = user.organization_id;
         userId = user.id;
       } catch {
@@ -205,11 +238,18 @@ export function handleDedicatedAgentProxy(
       }
 
       // 4. Unified auth — swap the validated owner's cloud token for the agent's
-      //    own ELIZA_API_TOKEN so the container accepts the request.
+      //    own ELIZA_API_TOKEN so the container accepts the request. For a WS
+      //    upgrade the token rode in `?token=`, so rewrite that too.
       const envVars = (sandbox.environment_vars ?? {}) as Record<string, string>;
       const agentToken = envVars.ELIZA_API_TOKEN?.trim();
       // No managed token (older / not-yet-provisioned agent) → pass through.
-      return proxyToOrigin(request, env, url, agentToken || undefined);
+      return proxyToOrigin(
+        request,
+        env,
+        url,
+        agentToken || undefined,
+        queryToken !== null,
+      );
     } catch (error) {
       // Fail-closed: any unexpected error → pass through WITHOUT injecting, so
       // the container's own auth still gates access.


### PR DESCRIPTION
Extends #8628 to the WS path. Browsers can't set headers on new WebSocket(), so the app sends the cloud token as ?token=; the proxy now validates it (same ownership check) and rewrites it to the agent's ELIZA_API_TOKEN. Fail-closed: non-owner ?token= never rewritten. 2 new security tests. On-device root-caused with the mobile agent (#8434).