### PR TITLE
fix(ui): honor dedicated-agent 202 + Retry-After (transparent resume)

### DIFF
--- a/packages/ui/src/api/client-base-resume.test.ts
+++ b/packages/ui/src/api/client-base-resume.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-chat";
+import type { AgentRequestTransport } from "./transport";
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function makeClient(request: AgentRequestTransport["request"]) {
+  const client = new ElizaClient("http://agent.example:2138", "token");
+  client.setRequestTransport({ request });
+  return client;
+}
+
+describe("ElizaClient 202 dedicated-agent resume handling", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits Retry-After and retries a 202 until the agent resumes", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValueOnce(
+        jsonResponse(202, { resuming: true }, { "retry-after": "1" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(202, { resuming: true }, { "retry-after": "1" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { agentName: "Eliza", ok: true }),
+      );
+
+    const client = makeClient(request);
+    const pending = client.fetch<{ ok: boolean }>("/api/status");
+    await vi.runAllTimersAsync();
+    const out = await pending;
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(out).toEqual(expect.objectContaining({ ok: true }));
+  });
+
+  it("does not retry a normal 200 response (ordinary requests unaffected)", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(jsonResponse(200, { ok: true }));
+
+    const client = makeClient(request);
+    await client.fetch("/api/status");
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after a bounded number of retries if still resuming", async () => {
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(202, { resuming: true }, { "retry-after": "1" }),
+      );
+
+    const client = makeClient(request);
+    const pending = client.fetch("/api/status").catch(() => undefined);
+    await vi.runAllTimersAsync();
+    await pending;
+
+    // 1 initial attempt + 6 bounded retries = 7 total; it does not loop forever.
+    expect(request).toHaveBeenCalledTimes(7);
+  });
+
+  it("stops waiting when the caller aborts mid-resume", async () => {
+    const controller = new AbortController();
+    const request = vi
+      .fn<AgentRequestTransport["request"]>()
+      .mockResolvedValue(
+        jsonResponse(202, { resuming: true }, { "retry-after": "5" }),
+      );
+
+    const client = makeClient(request);
+    const pending = client
+      .fetch("/api/status", { signal: controller.signal })
+      .catch(() => undefined);
+    // abort while waiting on the first Retry-After delay
+    controller.abort();
+    await vi.runAllTimersAsync();
+    await pending;
+
+    // initial attempt happened; the abort prevents further resume retries
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -297,6 +297,60 @@ export function __getLastKnownNetworkConnected(): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Dedicated-agent resume (HTTP 202) handling
+// ---------------------------------------------------------------------------
+
+// A non-running dedicated cloud agent answers with `202 Accepted` + `Retry-After`
+// while it auto-resumes (the unified-auth Worker, #8628). The client honours that
+// contract: it waits the advertised delay and re-issues the request a bounded
+// number of times, so callers see the eventual real response instead of a 202
+// placeholder body — which otherwise surfaced as an empty reply on the first
+// message sent after a dedicated agent had idled.
+const RESUME_MAX_RETRIES = 6;
+const RESUME_DEFAULT_DELAY_MS = 5_000;
+const RESUME_MIN_DELAY_MS = 500;
+const RESUME_MAX_DELAY_MS = 10_000;
+
+/** Clamp the agent's advertised `Retry-After` (seconds) into a sane wait (ms). */
+function resumeRetryDelayMs(res: Response): number {
+  const header = res.headers.get("Retry-After");
+  const seconds =
+    header !== null && Number.isFinite(Number(header))
+      ? Number(header)
+      : Number.NaN;
+  const ms = Number.isFinite(seconds)
+    ? seconds * 1_000
+    : RESUME_DEFAULT_DELAY_MS;
+  return Math.min(RESUME_MAX_DELAY_MS, Math.max(RESUME_MIN_DELAY_MS, ms));
+}
+
+/** Resolve after `ms`, or early if `signal` aborts. Never rejects. */
+function sleepUnlessAborted(
+  ms: number,
+  signal?: AbortSignal | null,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
 
@@ -536,6 +590,18 @@ export class ElizaClient {
           retryToken,
         );
       }
+    }
+    // 202 Accepted: a non-running dedicated cloud agent is auto-resuming (#8628).
+    // Wait the advertised Retry-After and re-issue, bounded, so callers see the
+    // eventual response instead of a 202 placeholder. Non-202 responses skip this
+    // loop entirely, so ordinary requests are byte-for-byte unaffected.
+    let resumeRetries = 0;
+    while (res.status === 202 && resumeRetries < RESUME_MAX_RETRIES) {
+      if (init?.signal?.aborted) break;
+      await sleepUnlessAborted(resumeRetryDelayMs(res), init?.signal);
+      if (init?.signal?.aborted) break;
+      resumeRetries += 1;
+      res = await this.rawRequestOnce(path, requestUrl, init, options, token);
     }
     if (!res.ok && !options?.allowNonOk) {
       const body = (await this.readBodyText(res, path, options?.timeoutMs, init)


### PR DESCRIPTION
## What
`rawRequest` now honors the **`202 Accepted` + `Retry-After`** contract that the unified-auth Worker (#8628) returns when a **non-running dedicated cloud agent is auto-resuming**: it waits the advertised delay and re-issues the request a bounded number of times, so callers get the eventual real response.

## Why
Previously a `202` was treated as a successful response (it's a 2xx, so `res.ok` is true) and its placeholder body was returned to the caller. For a chat send that meant the **first message after a dedicated agent had idled surfaced as an empty/null reply** — the user had to resend. #8628 explicitly added the 202+auto-resume contract; this completes it on the client.

## How
- In `rawRequest`, after the existing 401-retry, a bounded loop: while `res.status === 202`, wait `resumeRetryDelayMs(res)` (Retry-After seconds, clamped 0.5–10s, default 5s) then re-issue, up to `RESUME_MAX_RETRIES` (6). Abort-aware (stops waiting if the caller's `AbortSignal` fires).
- **Non-202 responses skip the loop entirely** — ordinary requests are byte-for-byte unaffected (near-zero blast radius on the shared request path).

## Tests
New `client-base-resume.test.ts` (fake timers, mock transport): retries-until-resumed, **no-retry-on-200**, bounded give-up (1 + 6 = 7 attempts, never loops forever), and abort-mid-resume. Existing `client-base-timeout` / `client-base-websocket` suites still green. Lint + typecheck clean.

Refs #8434.