### PR TITLE
style(plugin-app-control): biome-format views-switching.test.ts

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -370,18 +370,17 @@ describe("view switching — VIEWS action resolver", () => {
 			["muéstrame mi calendario", "wallet", "calendar"],
 			["我的钱包", "calendar", "wallet"],
 		];
-		it.each(HALLUCINATION_CASES)(
-			'"%s" + bogus view param "%s" still navigates to "%s"',
-			async (phrase, bogusView, expected) => {
-				const { navigated } = installNavigateCapture();
-				const { result } = await runShow(REGISTRY, phrase, {
-					action: "show",
-					view: bogusView,
-				});
-				expect(result?.success).toBe(true);
-				expect(navigated).toEqual([expected]);
-			},
-		);
+		it.each(
+			HALLUCINATION_CASES,
+		)('"%s" + bogus view param "%s" still navigates to "%s"', async (phrase, bogusView, expected) => {
+			const { navigated } = installNavigateCapture();
+			const { result } = await runShow(REGISTRY, phrase, {
+				action: "show",
+				view: bogusView,
+			});
+			expect(result?.success).toBe(true);
+			expect(navigated).toEqual([expected]);
+		});
 
 		// But when the intent maps to a surface this deployment does NOT have, the
 		// planner's explicit, registered target is honored (no over-correction).


### PR DESCRIPTION
`it.each(HALLUCINATION_CASES)` in `plugins/plugin-app-control/src/actions/views-switching.test.ts` landed unformatted, failing **Quality (Extended) → Format Check (biome)** and **ci → lint-and-format** on main (`4a9119a6b2`). Apply biome's formatting.

Verified: `bunx @biomejs/biome format <file>` → "No fixes applied" (clean) after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)