### PR TITLE
feat(views): self-contained branded hero icons for plugin views

### DIFF
--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -17,6 +17,7 @@ import {
   type ViewDeclaration,
   type ViewType,
 } from "@elizaos/core";
+import { generateViewHeroSvgFor } from "@elizaos/shared";
 import type { AgentPlatform } from "./platform-detect.ts";
 
 export type { ViewRegistryEntry } from "./view-registry-types.ts";
@@ -36,15 +37,6 @@ const HERO_CONTENT_TYPES: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".svg": "image/svg+xml",
 };
-
-function escapeSvgText(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
-}
 
 const DEFAULT_VIEW_TYPE: ViewType = "gui";
 
@@ -208,29 +200,14 @@ export async function findHeroOnDisk(
 }
 
 /**
- * Build a minimal generated SVG fallback when no hero image is available.
+ * Build a branded generated SVG fallback when no hero image is on disk. Shares
+ * the exact art (frame, no-blue palette, line-icon glyph) used for the heroes
+ * committed into plugins, so a view without a packaged hero still renders a
+ * cohesive card instead of a placeholder. `icon` is the view's Lucide icon name,
+ * used as a hint to pick the matching glyph.
  */
 export function generateViewHeroSvg(label: string, icon?: string): string {
-  const displayIcon = escapeSvgText(icon ?? label.slice(0, 2).toUpperCase());
-  const displayLabel = escapeSvgText(label);
-  // Use a simple gradient tile — readable at any size.
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <defs>
-    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1a1a2e;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#16213e;stop-opacity:1" />
-    </linearGradient>
-  </defs>
-  <rect width="400" height="300" fill="url(#g)" rx="12"/>
-  <text x="200" y="130" font-family="system-ui,sans-serif" font-size="64"
-        text-anchor="middle" dominant-baseline="middle" fill="#6c63ff" opacity="0.85">
-    ${displayIcon}
-  </text>
-  <text x="200" y="210" font-family="system-ui,sans-serif" font-size="20"
-        text-anchor="middle" dominant-baseline="middle" fill="#e0e0e0" opacity="0.7">
-    ${displayLabel}
-  </text>
-</svg>`;
+  return generateViewHeroSvgFor({ label, icon });
 }
 
 /**

--- a/packages/elizaos/templates/min-plugin/package.json
+++ b/packages/elizaos/templates/min-plugin/package.json
@@ -21,6 +21,7 @@
     }
   },
   "files": [
+    "assets",
     "dist"
   ],
   "dependencies": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -297,6 +297,7 @@ export * from "./utils/subscription-auth.js";
 export * from "./utils/trajectory-format.js";
 export * from "./utils/tts-debug.js";
 export * from "./validation-keywords.js";
+export * from "./view-hero-art.js";
 export * from "./voice/first-sentence-snip.js";
 export * from "./voice/voice-cancellation-token.js";
 export * from "./voice.js";

--- a/packages/shared/src/view-hero-art.test.ts
+++ b/packages/shared/src/view-hero-art.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateViewHeroSvgFor,
+  hueForViewKey,
+  pickViewHeroIcon,
+  renderViewHeroSvg,
+  VIEW_HERO_ICONS,
+  type ViewHeroIconKind,
+} from "./view-hero-art.js";
+
+describe("view-hero-art", () => {
+  it("renders a deterministic, valid square SVG", () => {
+    const a = generateViewHeroSvgFor({ id: "calendar", label: "Calendar" });
+    const b = generateViewHeroSvgFor({ id: "calendar", label: "Calendar" });
+    expect(a).toBe(b); // deterministic
+    expect(a.startsWith("<svg")).toBe(true);
+    expect(a).toContain('viewBox="0 0 1024 1024"');
+    expect(a.trimEnd().endsWith("</svg>")).toBe(true);
+  });
+
+  it("embeds the label and escapes XML-significant characters", () => {
+    const svg = generateViewHeroSvgFor({ label: "Tom & <Jerry>" });
+    expect(svg).toContain("Tom &amp; &lt;Jerry&gt;");
+    expect(svg).not.toContain("<Jerry>");
+  });
+
+  it("never picks a hue in the pure-blue band (~200–260)", () => {
+    const keys = [
+      "calendar",
+      "wallet",
+      "relationships",
+      "blue",
+      "blueprint",
+      "ocean",
+      "sky",
+      "navy view",
+      "azure dashboard",
+      "a",
+      "zzzzz",
+      "plugin-foo-bar",
+    ];
+    for (const key of keys) {
+      const hue = hueForViewKey(key);
+      expect(hue >= 200 && hue < 260).toBe(false);
+    }
+  });
+
+  it("picks a stable hue for the same key", () => {
+    expect(hueForViewKey("calendar")).toBe(hueForViewKey("calendar"));
+  });
+
+  it("maps keywords to the right icon glyph, defaulting to the grid", () => {
+    const cases: Array<[string, ViewHeroIconKind]> = [
+      ["calendar", "calendar"],
+      ["health", "health"],
+      ["wallet", "finances"],
+      ["relationships", "vectorBrowser"],
+      ["my messages", "messages"],
+      ["todo list", "todos"],
+      ["focus mode", "focus"],
+      ["something-unknown", "views"],
+    ];
+    for (const [label, expected] of cases) {
+      expect(pickViewHeroIcon({ label })).toBe(expected);
+    }
+  });
+
+  it("uses the Lucide icon name and tags as keyword hints", () => {
+    expect(pickViewHeroIcon({ label: "Money Tracker", icon: "Wallet" })).toBe(
+      "finances",
+    );
+    expect(
+      pickViewHeroIcon({ label: "People", tags: ["graph", "entities"] }),
+    ).toBe("vectorBrowser");
+  });
+
+  it("renders every catalogued icon glyph without throwing", () => {
+    for (const key of Object.keys(VIEW_HERO_ICONS) as ViewHeroIconKind[]) {
+      const svg = renderViewHeroSvg({
+        id: key,
+        hue: hueForViewKey(key),
+        iconSvg: VIEW_HERO_ICONS[key],
+        label: key,
+      });
+      expect(svg).toContain("<svg");
+    }
+  });
+
+  it("namespaces SVG element ids from the slug so two heroes don't collide", () => {
+    const svg = generateViewHeroSvgFor({ id: "My View!", label: "My View" });
+    // Slugified id used in gradient ids.
+    expect(svg).toContain("bg-my-view");
+  });
+});

--- a/packages/shared/src/view-hero-art.ts
+++ b/packages/shared/src/view-hero-art.ts
@@ -1,0 +1,406 @@
+/**
+ * Branded hero-image generator for plugin **views**.
+ *
+ * A view is a mini-app contributed by a plugin (`Plugin.views`). Each one is
+ * served a square hero image at `/api/views/<id>/hero`. Real heroes live in the
+ * plugin at `assets/hero.<ext>`; when a plugin ships none, the agent serves a
+ * generated SVG produced here so the catalog never shows a broken or ugly tile.
+ *
+ * The composition is intentionally **no-blue-dominant** (the app surface forbids
+ * blue accents — orange/jewel tones only) and **deterministic**: the same input
+ * always yields byte-identical output, so `scripts/generate-view-heroes.mjs`
+ * (which commits real heroes into plugins) and the runtime fallback render the
+ * exact same art. This is the single source of truth for that art — the script
+ * and the agent both import `renderViewHeroSvg` from here.
+ *
+ * Pure string generation only: no Node APIs, so this module stays importable
+ * from the runtime-agnostic `@elizaos/shared` barrel (browser + server).
+ */
+
+const W = 1024;
+const CX = W / 2;
+
+/**
+ * Convert an HSL triple to a hex color string. Deterministic, no rounding
+ * surprises across runs.
+ */
+function hsl(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp >= 0 && hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = lN - c / 2;
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/**
+ * A palette derived from a single accent hue, kept in a dark, modern register.
+ * Background tones are deep neutrals shifted slightly toward the accent so each
+ * card reads distinct without ever looking like a flat blue panel.
+ */
+function palette(hue: number) {
+  return {
+    bgTop: hsl(hue, 32, 12),
+    bgBottom: hsl(hue + 14, 40, 7),
+    blobA: hsl(hue, 70, 52),
+    blobB: hsl(hue + 28, 66, 46),
+    accent: hsl(hue, 82, 60),
+    accentSoft: hsl(hue, 70, 70),
+    line: hsl(hue, 30, 88),
+  };
+}
+
+export interface ViewHeroFrameInput {
+  /** Stable slug used to namespace SVG gradient/filter ids. */
+  id: string;
+  /** Accent hue (0–359). Keep out of the pure-blue band for the app surface. */
+  hue: number;
+  /** Inline SVG markup for the centered line-icon glyph. */
+  iconSvg: string;
+  /** Display label rendered along the bottom. */
+  label: string;
+}
+
+/**
+ * Render the full branded hero SVG. Shared chrome (defs, background, depth
+ * blobs, faint grid, accent arc, bottom label + vignette) with the icon glyph
+ * slotted in. Output is deterministic and byte-identical for identical input.
+ */
+export function renderViewHeroSvg({
+  id,
+  hue,
+  iconSvg,
+  label,
+}: ViewHeroFrameInput): string {
+  const p = palette(hue);
+  const safeLabel = escapeXml(label);
+  // Two large blurred blobs placed off-center for asymmetric depth, plus a thin
+  // accent arc sweeping behind the icon.
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${W}" width="${W}" height="${W}" role="img" aria-label="${safeLabel}">
+  <defs>
+    <linearGradient id="bg-${id}" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="${p.bgTop}"/>
+      <stop offset="1" stop-color="${p.bgBottom}"/>
+    </linearGradient>
+    <radialGradient id="blobA-${id}" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="${p.blobA}" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="${p.blobA}" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-${id}" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="${p.blobB}" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="${p.blobB}" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-${id}" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-${id}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-${id}" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-${id}" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="${p.accent}" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="${W}" height="${W}" fill="url(#bg-${id})"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-${id})" filter="url(#soft-${id})"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-${id})" filter="url(#soft-${id})"/>
+  </g>
+
+  <g stroke="${p.line}" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="${W}" y2="256"/>
+    <line x1="0" y1="512" x2="${W}" y2="512"/>
+    <line x1="0" y1="768" x2="${W}" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="${W}"/>
+    <line x1="512" y1="0" x2="512" y2="${W}"/>
+    <line x1="768" y1="0" x2="768" y2="${W}"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="${p.accent}" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(${CX} 432)" filter="url(#iglow-${id})"
+     color="${p.line}" stroke="${p.line}" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+${iconSvg}
+  </g>
+
+  <rect x="0" y="784" width="${W}" height="240" fill="url(#label-${id})"/>
+  <text x="${CX}" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="${p.line}">${safeLabel}</text>
+  <rect x="${CX - 52}" y="924" width="104" height="6" rx="3" fill="${p.accent}"/>
+
+  <rect width="${W}" height="${W}" fill="url(#vig-${id})"/>
+</svg>`;
+}
+
+/**
+ * Hand-drawn vector line-icons, centered at (0,0) spanning roughly -150..150.
+ * Each inherits stroke styling from the parent <g>; fills are set explicitly
+ * where a filled glyph reads better. Keyed names map to the catalog below.
+ */
+export const VIEW_HERO_ICONS = {
+  // cpu / chip with a beaker spark — Model Tester
+  modelTester: `    <rect x="-110" y="-110" width="220" height="220" rx="28"/>
+    <rect x="-58" y="-58" width="116" height="116" rx="14"/>
+    <line x1="-110" y1="-66" x2="-150" y2="-66"/>
+    <line x1="-110" y1="0" x2="-150" y2="0"/>
+    <line x1="-110" y1="66" x2="-150" y2="66"/>
+    <line x1="110" y1="-66" x2="150" y2="-66"/>
+    <line x1="110" y1="0" x2="150" y2="0"/>
+    <line x1="110" y1="66" x2="150" y2="66"/>
+    <line x1="-66" y1="-110" x2="-66" y2="-150"/>
+    <line x1="0" y1="-110" x2="0" y2="-150"/>
+    <line x1="66" y1="-110" x2="66" y2="-150"/>
+    <line x1="-66" y1="110" x2="-66" y2="150"/>
+    <line x1="0" y1="110" x2="0" y2="150"/>
+    <line x1="66" y1="110" x2="66" y2="150"/>
+    <circle cx="0" cy="0" r="14" stroke-width="0" fill="currentColor"/>`,
+
+  // overlapping panels — Views (layout grid)
+  views: `    <rect x="-150" y="-150" width="130" height="130" rx="18"/>
+    <rect x="20" y="-150" width="130" height="130" rx="18"/>
+    <rect x="-150" y="20" width="130" height="130" rx="18"/>
+    <rect x="20" y="20" width="130" height="130" rx="18"/>`,
+
+  // shield with an eye-off slash — Focus / blocker
+  focus: `    <path d="M0 -150 L130 -100 L130 24 C130 110 70 152 0 175 C-70 152 -130 110 -130 24 L-130 -100 Z"/>
+    <circle cx="0" cy="-2" r="34"/>
+    <line x1="-92" y1="-96" x2="96" y2="120"/>`,
+
+  // calendar grid — Calendar
+  calendar: `    <rect x="-140" y="-118" width="280" height="248" rx="24"/>
+    <line x1="-140" y1="-52" x2="140" y2="-52"/>
+    <line x1="-78" y1="-150" x2="-78" y2="-92"/>
+    <line x1="78" y1="-150" x2="78" y2="-92"/>
+    <circle cx="-66" cy="6" r="11" stroke-width="0" fill="currentColor"/>
+    <circle cx="0" cy="6" r="11" stroke-width="0" fill="currentColor"/>
+    <circle cx="66" cy="6" r="11" stroke-width="0" fill="currentColor"/>
+    <circle cx="-66" cy="72" r="11" stroke-width="0" fill="currentColor"/>
+    <circle cx="0" cy="72" r="11" stroke-width="0" fill="currentColor"/>`,
+
+  // headphones — Facewear
+  headphones: `    <path d="M-140 30 V-10 A140 140 0 0 1 140 -10 V30"/>
+    <rect x="-160" y="26" width="58" height="110" rx="26" fill="currentColor" stroke-width="0"/>
+    <rect x="102" y="26" width="58" height="110" rx="26" fill="currentColor" stroke-width="0"/>
+    <rect x="-160" y="26" width="58" height="110" rx="26"/>
+    <rect x="102" y="26" width="58" height="110" rx="26"/>`,
+
+  // glasses — Smartglasses
+  glasses: `    <circle cx="-86" cy="20" r="68"/>
+    <circle cx="86" cy="20" r="68"/>
+    <path d="M-18 20 Q0 -2 18 20"/>
+    <line x1="-154" y1="-12" x2="-180" y2="-44"/>
+    <line x1="154" y1="-12" x2="180" y2="-44"/>`,
+
+  // line chart rising with axis — Finances
+  finances: `    <polyline points="-150,-150 -150,150 150,150"/>
+    <polyline points="-118,86 -50,-2 6,52 76,-62 132,-104" fill="none"/>
+    <circle cx="-50" cy="-2" r="13" stroke-width="0" fill="currentColor"/>
+    <circle cx="76" cy="-62" r="13" stroke-width="0" fill="currentColor"/>
+    <circle cx="132" cy="-104" r="13" stroke-width="0" fill="currentColor"/>`,
+
+  // target with center dot and a flag — Goals
+  goals: `    <circle cx="0" cy="0" r="150"/>
+    <circle cx="0" cy="0" r="92"/>
+    <circle cx="0" cy="0" r="34"/>
+    <circle cx="0" cy="0" r="9" stroke-width="0" fill="currentColor"/>`,
+
+  // heart with a pulse line through it — Health
+  health: `    <path d="M0 150 C-180 18 -120 -120 0 -52 C120 -120 180 18 0 150 Z"/>
+    <polyline points="-150,-10 -64,-10 -28,-58 14,52 48,-10 150,-10" fill="none"/>`,
+
+  // inbox tray — Inbox
+  inbox: `    <path d="M-150 -40 L-110 -130 H110 L150 -40 V120 A20 20 0 0 1 130 140 H-130 A20 20 0 0 1 -150 120 Z"/>
+    <path d="M-150 -40 H-44 L-10 24 H10 L44 -40 H150"/>`,
+
+  // chat bubble with lines — Messages
+  messages: `    <path d="M-150 -120 H150 A24 24 0 0 1 174 -96 V60 A24 24 0 0 1 150 84 H-30 L-100 150 V84 H-150 A24 24 0 0 1 -174 60 V-96 A24 24 0 0 1 -150 -120 Z"/>
+    <line x1="-100" y1="-44" x2="100" y2="-44"/>
+    <line x1="-100" y1="16" x2="40" y2="16"/>`,
+
+  // trending up arrow over people dots — Social Alpha
+  socialAlpha: `    <polyline points="-150,80 -54,-22 6,38 150,-110" fill="none"/>
+    <polyline points="92,-110 150,-110 150,-52" fill="none"/>
+    <circle cx="-110" cy="128" r="26"/>
+    <circle cx="0" cy="128" r="26"/>
+    <circle cx="110" cy="128" r="26"/>`,
+
+  // checklist square — Todos
+  todos: `    <rect x="-150" y="-150" width="300" height="300" rx="36"/>
+    <polyline points="-92,-6 -36,52 92,-78" fill="none"/>`,
+
+  // network graph nodes — Vector Browser / Relationships
+  vectorBrowser: `    <line x1="-110" y1="-96" x2="0" y2="0"/>
+    <line x1="120" y1="-110" x2="0" y2="0"/>
+    <line x1="-130" y1="86" x2="0" y2="0"/>
+    <line x1="110" y1="104" x2="0" y2="0"/>
+    <circle cx="0" cy="0" r="30" fill="currentColor" stroke-width="0"/>
+    <circle cx="0" cy="0" r="30"/>
+    <circle cx="-110" cy="-96" r="22"/>
+    <circle cx="120" cy="-110" r="22"/>
+    <circle cx="-130" cy="86" r="22"/>
+    <circle cx="110" cy="104" r="22"/>`,
+} as const;
+
+export type ViewHeroIconKind = keyof typeof VIEW_HERO_ICONS;
+
+/**
+ * Curated, non-blue accent hues spread across warm/jewel tones. Deliberately
+ * excludes the pure-blue band (~200–250) so a generated hero never reads as a
+ * flat blue panel on the app surface.
+ */
+const VIEW_HERO_HUES = [
+  12, 25, 38, 52, 96, 130, 150, 168, 190, 270, 286, 300, 332, 348,
+] as const;
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+/** Deterministically pick a non-blue accent hue for an arbitrary view key. */
+export function hueForViewKey(key: string): number {
+  const trimmed = key.trim() || "view";
+  return VIEW_HERO_HUES[hashString(trimmed) % VIEW_HERO_HUES.length];
+}
+
+/**
+ * Keyword → icon-glyph rules, checked in order. The first rule whose keyword is
+ * present in the view's id/label/tags/Lucide-icon name wins; otherwise the
+ * generic overlapping-panels glyph is used.
+ */
+const ICON_KEYWORD_RULES: ReadonlyArray<[ViewHeroIconKind, readonly string[]]> =
+  [
+    ["calendar", ["calendar", "schedule", "event", "agenda"]],
+    ["health", ["health", "fitness", "heart", "wellness", "medical"]],
+    [
+      "finances",
+      [
+        "finance",
+        "wallet",
+        "money",
+        "payment",
+        "budget",
+        "bank",
+        "trade",
+        "invest",
+      ],
+    ],
+    ["goals", ["goal", "target", "objective", "habit", "routine"]],
+    ["inbox", ["inbox", "mail", "email"]],
+    ["messages", ["message", "chat", "dm", "conversation", "sms"]],
+    [
+      "socialAlpha",
+      ["social", "leaderboard", "trust", "alpha", "feed", "follow"],
+    ],
+    ["todos", ["todo", "task", "checklist", "todos"]],
+    [
+      "vectorBrowser",
+      [
+        "vector",
+        "graph",
+        "relationship",
+        "network",
+        "entity",
+        "embedding",
+        "people",
+        "contact",
+      ],
+    ],
+    [
+      "focus",
+      ["focus", "block", "shield", "guard", "screen-time", "screentime"],
+    ],
+    [
+      "headphones",
+      ["headphone", "audio", "facewear", "wear", "sound", "voice"],
+    ],
+    ["glasses", ["glass", "smartglass", "xr", "spatial", "vision"]],
+    ["modelTester", ["model", "test", "chip", "cpu", "bench", "eval", "train"]],
+  ];
+
+export interface ViewHeroSource {
+  id?: string;
+  label: string;
+  /** Lucide icon name declared by the view, used as a keyword hint. */
+  icon?: string;
+  tags?: readonly string[];
+}
+
+/** Pick the best-matching icon glyph for a view, defaulting to the grid. */
+export function pickViewHeroIcon(source: ViewHeroSource): ViewHeroIconKind {
+  const haystack = [
+    source.id ?? "",
+    source.label,
+    source.icon ?? "",
+    ...(source.tags ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  for (const [icon, keywords] of ICON_KEYWORD_RULES) {
+    if (keywords.some((keyword) => haystack.includes(keyword))) return icon;
+  }
+  return "views";
+}
+
+/** Lowercase slug safe to embed in SVG element ids. */
+function slugifyViewId(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "view";
+}
+
+/**
+ * High-level entry point: render a branded hero SVG for a view, choosing the
+ * accent hue and icon glyph automatically from the view's metadata. Used by the
+ * agent's hero fallback and by view scaffolding/icon-regeneration so a generated
+ * hero looks the same everywhere.
+ */
+export function generateViewHeroSvgFor(source: ViewHeroSource): string {
+  const slug = slugifyViewId(source.id ?? source.label);
+  return renderViewHeroSvg({
+    id: slug,
+    hue: hueForViewKey(source.id ?? source.label),
+    iconSvg: VIEW_HERO_ICONS[pickViewHeroIcon(source)],
+    label: source.label,
+  });
+}

--- a/plugins/app-model-tester/package.json
+++ b/plugins/app-model-tester/package.json
@@ -50,6 +50,7 @@
     "test:e2e": "node scripts/model-tester-e2e.mjs"
   },
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-app-control/package.json
+++ b/plugins/plugin-app-control/package.json
@@ -29,6 +29,7 @@
 		}
 	},
 	"files": [
+		"assets",
 		"dist"
 	],
 	"scripts": {

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -26,6 +26,8 @@ import { logger, ModelType, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import { isRestrictedPlatform } from "./views.js";
 import type { ViewSummary } from "./views-client.js";
+import { writeViewHeroAsset } from "./views-hero.js";
+import { locatePluginSourceDir } from "./views-plugin-source.js";
 
 export const VIEWS_CREATE_INTENT_TAG = "views-create-intent";
 
@@ -452,6 +454,7 @@ function buildCreatePrompt(
 		"workspaceRule: work in sourceDir, not the task agent scratch directory",
 		"referenceDocs: read SCAFFOLD.md for layout and conventions",
 		"viewRequirement: add a Plugin.views entry with a compiled view bundle so the view appears in the Eliza view registry",
+		"iconAsset: a branded assets/hero.svg is already seeded and is served as the view hero — keep it (or replace it with a real image at assets/hero.<ext>); do not delete it",
 		"implementation: edit and add files needed for the intent",
 		"verificationCommands[3]:",
 		"  bun run typecheck",
@@ -609,28 +612,6 @@ export function isChoiceReply(text: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Locate plugin source from a view entry
-// ---------------------------------------------------------------------------
-
-async function locatePluginSourceDir(
-	repoRoot: string,
-	view: ViewSummary,
-): Promise<string | null> {
-	const pluginBasename = view.pluginName.replace(/^@[^/]+\//, "").trim();
-	const candidates = [
-		...PLUGINS_DIR_CANDIDATES.map((d) =>
-			path.join(repoRoot, d, pluginBasename),
-		),
-		path.join(repoRoot, "eliza", "apps", pluginBasename),
-	];
-	for (const candidate of candidates) {
-		const stat = await fs.stat(candidate).catch(() => null);
-		if (stat?.isDirectory()) return candidate;
-	}
-	return null;
-}
-
-// ---------------------------------------------------------------------------
 // Create / edit helpers
 // ---------------------------------------------------------------------------
 
@@ -672,6 +653,17 @@ async function createNewViewPlugin({
 		[NAME_PLACEHOLDER]: name,
 		[DISPLAY_NAME_PLACEHOLDER]: displayName,
 	});
+
+	// Seed a self-contained branded hero icon so the scaffolded view has an image
+	// from the moment it registers — before the coding agent runs. Best-effort:
+	// a missing icon must not abort scaffolding.
+	try {
+		await writeViewHeroAsset(workdir, { id: name, label: displayName });
+	} catch (err) {
+		logger.warn(
+			`[plugin-app-control] VIEWS/create could not seed hero icon for ${name}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
 
 	const prompt = buildCreatePrompt(intent, name, displayName, workdir);
 	const dispatch = await dispatchCodingAgent({

--- a/plugins/plugin-app-control/src/actions/views-edit.ts
+++ b/plugins/plugin-app-control/src/actions/views-edit.ts
@@ -12,8 +12,6 @@
  * changes, which are outside this coding sub-agent dispatch path.
  */
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import type {
 	ActionResult,
 	HandlerCallback,
@@ -25,9 +23,8 @@ import { logger, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import { isRestrictedPlatform } from "./views.js";
 import type { ViewSummary } from "./views-client.js";
+import { locatePluginSourceDir } from "./views-plugin-source.js";
 import { scoreView } from "./views-search.js";
-
-const PLUGINS_DIR_CANDIDATES = ["eliza/plugins", "plugins"] as const;
 
 export interface ViewsEditInput {
 	runtime: IAgentRuntime;
@@ -42,7 +39,7 @@ export interface ViewsEditInput {
 // View resolution
 // ---------------------------------------------------------------------------
 
-function resolveTargetView(
+export function resolveTargetView(
 	target: string,
 	views: readonly ViewSummary[],
 ):
@@ -118,28 +115,6 @@ function extractTargetFromText(text: string): string | null {
 		while (i < tokens.length && FILLER.has(tokens[i].toLowerCase())) i++;
 		const candidate = tokens.slice(i).join(" ").toLowerCase();
 		if (candidate && !FILLER.has(candidate)) return candidate;
-	}
-	return null;
-}
-
-// ---------------------------------------------------------------------------
-// Source dir lookup
-// ---------------------------------------------------------------------------
-
-async function locatePluginSourceDir(
-	repoRoot: string,
-	view: ViewSummary,
-): Promise<string | null> {
-	const pluginBasename = view.pluginName.replace(/^@[^/]+\//, "").trim();
-	const candidates = [
-		...PLUGINS_DIR_CANDIDATES.map((d) =>
-			path.join(repoRoot, d, pluginBasename),
-		),
-		path.join(repoRoot, "eliza", "apps", pluginBasename),
-	];
-	for (const candidate of candidates) {
-		const stat = await fs.stat(candidate).catch(() => null);
-		if (stat?.isDirectory()) return candidate;
 	}
 	return null;
 }

--- a/plugins/plugin-app-control/src/actions/views-hero.ts
+++ b/plugins/plugin-app-control/src/actions/views-hero.ts
@@ -1,0 +1,123 @@
+/**
+ * @module plugin-app-control/actions/views-hero
+ *
+ * Self-contained hero/icon assets for view plugins. A view's hero lives in its
+ * own plugin at `assets/hero.svg` and is served by the agent at
+ * `/api/views/<id>/hero`. This module writes that asset using the shared,
+ * deterministic, no-blue branded generator (`@elizaos/shared`) — the same art
+ * the agent's runtime fallback and `scripts/generate-view-heroes.mjs` produce —
+ * so a scaffolded or regenerated view always ships a cohesive icon.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { generateViewHeroSvgFor, type ViewHeroSource } from "@elizaos/shared";
+
+/** Hero extensions the agent's registry probes, in its preference order. */
+const HERO_EXTENSIONS = [".webp", ".png", ".jpg", ".jpeg", ".svg"] as const;
+
+/** Relative path of the generated SVG hero within a plugin. */
+export const HERO_SVG_RELPATH = path.join("assets", "hero.svg");
+
+/** Return the absolute path of the first existing `assets/hero.*` file, if any. */
+async function findExistingHero(pluginDir: string): Promise<string | null> {
+	const assetsDir = path.join(pluginDir, "assets");
+	for (const ext of HERO_EXTENSIONS) {
+		const candidate = path.join(assetsDir, `hero${ext}`);
+		try {
+			await fs.access(candidate);
+			return candidate;
+		} catch {
+			// Not present — try the next extension.
+		}
+	}
+	return null;
+}
+
+export interface WriteViewHeroResult {
+	/** Whether a new hero SVG was written. */
+	written: boolean;
+	/** Absolute path of the resolved hero asset. */
+	absPath: string;
+}
+
+/**
+ * Write a generated branded hero SVG to `<pluginDir>/assets/hero.svg`.
+ *
+ * - With `overwrite: false` (default): no-op when the plugin already has any
+ *   `assets/hero.*` file, preserving a hand-authored hero.
+ * - With `overwrite: true`: regenerates `hero.svg` and removes any other
+ *   `assets/hero.*` variants so the freshly generated icon is the one served
+ *   (the registry probes `.webp/.png/.jpg/.jpeg` ahead of `.svg`).
+ *
+ * Also lists `assets` in the plugin's npm `files` so the hero ships with the
+ * published package, not just in the source tree.
+ */
+export async function writeViewHeroAsset(
+	pluginDir: string,
+	source: ViewHeroSource,
+	opts: { overwrite?: boolean } = {},
+): Promise<WriteViewHeroResult> {
+	if (!opts.overwrite) {
+		const existing = await findExistingHero(pluginDir);
+		if (existing) return { written: false, absPath: existing };
+	}
+
+	const svgPath = path.join(pluginDir, HERO_SVG_RELPATH);
+	await fs.mkdir(path.dirname(svgPath), { recursive: true });
+	await fs.writeFile(svgPath, generateViewHeroSvgFor(source), "utf8");
+
+	if (opts.overwrite) {
+		// Drop higher-priority variants so the regenerated SVG is what gets served.
+		for (const ext of HERO_EXTENSIONS) {
+			if (ext === ".svg") continue;
+			await fs.rm(path.join(pluginDir, "assets", `hero${ext}`), {
+				force: true,
+			});
+		}
+	}
+
+	await ensureViewHeroAssetsPublished(pluginDir);
+	return { written: true, absPath: svgPath };
+}
+
+/**
+ * Ensure the plugin's `package.json` `files` array lists `assets`, so the hero
+ * is included in the published npm tarball. Returns true when a change was made.
+ * Touches only the `files` array region to keep the diff minimal; returns false
+ * when there is no `files` array or `assets` is already present.
+ */
+export async function ensureViewHeroAssetsPublished(
+	pluginDir: string,
+): Promise<boolean> {
+	const pkgPath = path.join(pluginDir, "package.json");
+	const raw = await fs.readFile(pkgPath, "utf8");
+	const match = raw.match(/(\n([ \t]*)"files"\s*:\s*\[)([\s\S]*?)(\n\2\])/);
+	if (!match) return false;
+
+	const [whole, head, baseIndent, body, tail] = match;
+	const values = body
+		.split("\n")
+		.map((line) => line.trim().replace(/,$/, ""))
+		.filter(Boolean)
+		.map((line) => {
+			try {
+				return JSON.parse(line) as unknown;
+			} catch {
+				return null;
+			}
+		})
+		.filter((value): value is string => typeof value === "string");
+
+	if (values.includes("assets")) return false;
+
+	const itemIndent = `${baseIndent}  `;
+	const rebuiltBody = `\n${["assets", ...values]
+		.map((value) => `${itemIndent}${JSON.stringify(value)}`)
+		.join(",\n")}`;
+	await fs.writeFile(
+		pkgPath,
+		raw.replace(whole, `${head}${rebuiltBody}${tail}`),
+	);
+	return true;
+}

--- a/plugins/plugin-app-control/src/actions/views-icon.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-icon.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the VIEWS `icon` sub-mode: intent detection, target extraction, and
+ * the direct hero-asset regeneration (no coding agent).
+ */
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreMock = vi.hoisted(() => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+	resolveServerOnlyPort: vi.fn(() => 3456),
+	hasOwnerAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@elizaos/core", () => coreMock);
+
+import type { ViewSummary } from "./views-client.js";
+import {
+	extractIconTarget,
+	isViewIconRequest,
+	runViewsIcon,
+} from "./views-icon.js";
+
+function message(text: string) {
+	return {
+		entityId: "user-1",
+		roomId: "room-1",
+		agentId: "agent-1",
+		content: { text },
+	} as never;
+}
+
+describe("isViewIconRequest", () => {
+	it("matches mutate-verb + icon-noun phrasings", () => {
+		expect(isViewIconRequest("regenerate the wallet view icon")).toBe(true);
+		expect(isViewIconRequest("change the calendar image")).toBe(true);
+		expect(isViewIconRequest("give relationships a new hero")).toBe(true);
+		expect(isViewIconRequest("make a logo for the goals view")).toBe(true);
+	});
+
+	it("matches an explicit action=icon option even without an icon noun", () => {
+		expect(isViewIconRequest("the wallet view", { action: "icon" })).toBe(true);
+	});
+
+	it("does not match navigation or unrelated requests", () => {
+		expect(isViewIconRequest("show the calendar")).toBe(false);
+		expect(isViewIconRequest("open the wallet view")).toBe(false);
+		expect(isViewIconRequest("list views")).toBe(false);
+		// 'icon' noun but no mutate verb.
+		expect(isViewIconRequest("which view has the nicest icon?")).toBe(false);
+	});
+});
+
+describe("extractIconTarget", () => {
+	it("prefers an explicit option", () => {
+		expect(
+			extractIconTarget(message("regenerate the icon"), { view: "wallet" }),
+		).toBe("wallet");
+	});
+
+	it("strips verbs, icon nouns, and filler to recover the view name", () => {
+		expect(
+			extractIconTarget(message("regenerate the wallet view icon"), undefined),
+		).toBe("wallet");
+		expect(
+			extractIconTarget(
+				message("give the social alpha view a new image"),
+				undefined,
+			),
+		).toBe("social alpha");
+	});
+});
+
+describe("runViewsIcon", () => {
+	let repoRoot: string;
+	let pluginDir: string;
+
+	const views: ViewSummary[] = [
+		{
+			id: "foo",
+			label: "Foo",
+			pluginName: "@elizaos/plugin-foo",
+			available: true,
+			icon: "Calendar",
+			tags: ["calendar"],
+		},
+	];
+
+	beforeEach(async () => {
+		repoRoot = await mkdtemp(path.join(tmpdir(), "views-icon-"));
+		pluginDir = path.join(repoRoot, "plugins", "plugin-foo");
+		await mkdir(pluginDir, { recursive: true });
+		await writeFile(
+			path.join(pluginDir, "package.json"),
+			`${JSON.stringify({ name: "@elizaos/plugin-foo", files: ["dist"] }, null, 2)}\n`,
+			"utf8",
+		);
+	});
+
+	afterEach(async () => {
+		await rm(repoRoot, { recursive: true, force: true });
+	});
+
+	it("writes a branded hero SVG and publishes assets in package.json", async () => {
+		const callback = vi.fn(async () => []);
+		const result = await runViewsIcon({
+			runtime: { agentId: "agent-1" } as never,
+			message: message("regenerate the foo view icon"),
+			views,
+			callback,
+			repoRoot,
+		});
+
+		expect(result.success).toBe(true);
+		const heroPath = path.join(pluginDir, "assets", "hero.svg");
+		const svg = await readFile(heroPath, "utf8");
+		expect(svg).toContain('viewBox="0 0 1024 1024"');
+		expect(svg).toContain(">Foo<");
+
+		const pkg = JSON.parse(
+			await readFile(path.join(pluginDir, "package.json"), "utf8"),
+		);
+		expect(pkg.files).toContain("assets");
+	});
+
+	it("overwrites and removes a higher-priority hero variant", async () => {
+		await mkdir(path.join(pluginDir, "assets"), { recursive: true });
+		const pngPath = path.join(pluginDir, "assets", "hero.png");
+		await writeFile(pngPath, "not-a-real-png", "utf8");
+
+		const result = await runViewsIcon({
+			runtime: { agentId: "agent-1" } as never,
+			message: message("regenerate the foo view icon"),
+			views,
+			callback: vi.fn(async () => []),
+			repoRoot,
+		});
+
+		expect(result.success).toBe(true);
+		// The png must be gone so the freshly generated svg is the one served.
+		await expect(readFile(pngPath, "utf8")).rejects.toThrow();
+		const svg = await readFile(
+			path.join(pluginDir, "assets", "hero.svg"),
+			"utf8",
+		);
+		expect(svg).toContain("<svg");
+	});
+
+	it("reports when the target view does not exist", async () => {
+		const result = await runViewsIcon({
+			runtime: { agentId: "agent-1" } as never,
+			message: message("regenerate the nonexistent view icon"),
+			views,
+			callback: vi.fn(async () => []),
+			repoRoot,
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views-icon.ts
+++ b/plugins/plugin-app-control/src/actions/views-icon.ts
@@ -1,0 +1,188 @@
+/**
+ * @module plugin-app-control/actions/views-icon
+ *
+ * icon sub-mode of the VIEWS action.
+ *
+ * Regenerates a view's self-contained hero/icon directly — no coding agent.
+ * Resolves the target view, locates its plugin source, and writes a fresh
+ * branded `assets/hero.svg` (served at `/api/views/<id>/hero`). Owner-gated by
+ * the VIEWS action like create/edit/delete.
+ */
+
+import type {
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { readStringOption } from "../params.js";
+import { isRestrictedPlatform } from "./views.js";
+import type { ViewSummary } from "./views-client.js";
+import { resolveTargetView } from "./views-edit.js";
+import { writeViewHeroAsset } from "./views-hero.js";
+import { locatePluginSourceDir } from "./views-plugin-source.js";
+
+export interface ViewsIconInput {
+	runtime: IAgentRuntime;
+	message: Memory;
+	options?: Record<string, unknown>;
+	views: ViewSummary[];
+	callback?: HandlerCallback;
+	repoRoot: string;
+}
+
+const ICON_NOUNS =
+	/\b(icons?|images?|heroes?|hero|thumbnails?|pictures?|avatars?|logos?|artworks?|art)\b/gi;
+const ICON_VERBS =
+	/\b(set|change|update|regenerate|generate|make|create|give|replace|new|redo|refresh|add|render)\b/gi;
+const FILLER = new Set([
+	"the",
+	"a",
+	"an",
+	"view",
+	"views",
+	"plugin",
+	"plugins",
+	"app",
+	"for",
+	"of",
+	"to",
+	"on",
+	"its",
+	"it",
+	"my",
+	"please",
+	"new",
+	"with",
+	"and",
+]);
+
+/**
+ * Pull the target view name from explicit options, else from the free text by
+ * stripping the icon nouns, mutate verbs, and filler words and keeping the rest
+ * (e.g. "regenerate the wallet view icon" → "wallet").
+ */
+export function extractIconTarget(
+	message: Memory,
+	options: Record<string, unknown> | undefined,
+): string | null {
+	const explicit =
+		readStringOption(options, "view") ??
+		readStringOption(options, "viewId") ??
+		readStringOption(options, "id") ??
+		readStringOption(options, "name") ??
+		readStringOption(options, "target");
+	if (explicit) return explicit;
+
+	const text = message.content.text ?? "";
+	const stripped = text
+		.replace(ICON_NOUNS, " ")
+		.replace(ICON_VERBS, " ")
+		.replace(/['']s\b/gi, " ");
+	const tokens = stripped
+		.split(/[^a-z0-9-]+/i)
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0 && !FILLER.has(token.toLowerCase()));
+	const candidate = tokens.join(" ").trim();
+	return candidate.length > 0 ? candidate : null;
+}
+
+/** Detect whether a request is asking to (re)generate a view's icon/image. */
+export function isViewIconRequest(
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	const explicit = (
+		readStringOption(options, "action") ??
+		readStringOption(options, "mode") ??
+		""
+	)
+		.trim()
+		.toLowerCase();
+	if (explicit === "icon") return true;
+	const verbMatch =
+		/\b(set|change|update|regenerate|generate|make|create|give|replace|new|redo|refresh|render)\b/i;
+	const nounMatch =
+		/\b(icon|image|hero|thumbnail|picture|avatar|logo|artwork)\b/i;
+	return verbMatch.test(text) && nounMatch.test(text);
+}
+
+export async function runViewsIcon({
+	message,
+	options,
+	views,
+	callback,
+	repoRoot,
+}: ViewsIconInput): Promise<ActionResult> {
+	if (isRestrictedPlatform()) {
+		const text = "Regenerating view icons is not available on this platform.";
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const target = extractIconTarget(message, options);
+	if (!target) {
+		const text =
+			'Which view\'s icon should I regenerate? Try: "regenerate the wallet view icon".';
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const resolution = resolveTargetView(target, views);
+	if (resolution.kind === "none") {
+		const text = `No view matches "${target}". Try \`action=list\` to see available views.`;
+		await callback?.({ text });
+		return { success: false, text, data: { target } };
+	}
+	if (resolution.kind === "ambiguous") {
+		const list = resolution.candidates
+			.map((view) => `- ${view.label} (${view.id})`)
+			.join("\n");
+		const text = `"${target}" matches multiple views:\n${list}\nWhich one's icon should I regenerate?`;
+		await callback?.({ text });
+		return {
+			success: false,
+			text,
+			data: { candidates: resolution.candidates },
+		};
+	}
+
+	const view = resolution.view;
+	const workdir = await locatePluginSourceDir(repoRoot, view);
+	if (!workdir) {
+		const text = `Could not locate the source directory for ${view.label} (${view.pluginName}); its icon can only be regenerated from a local plugin source.`;
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const result = await writeViewHeroAsset(
+		workdir,
+		{
+			id: view.id,
+			label: view.label,
+			icon: view.icon,
+			tags: view.tags,
+		},
+		{ overwrite: true },
+	);
+
+	const heroUrl = `/api/views/${encodeURIComponent(view.id)}/hero`;
+	const text = `Regenerated a fresh branded icon for ${view.label}. It is served at ${heroUrl}.`;
+	await callback?.({ text });
+	logger.info(
+		`[plugin-app-control] VIEWS/icon viewId=${view.id} wrote ${result.absPath}`,
+	);
+
+	return {
+		success: true,
+		text,
+		values: { mode: "icon", viewId: view.id, label: view.label },
+		data: {
+			viewId: view.id,
+			heroUrl,
+			heroPath: result.absPath,
+			suppressActionResultClipboard: true,
+		},
+	};
+}

--- a/plugins/plugin-app-control/src/actions/views-plugin-source.ts
+++ b/plugins/plugin-app-control/src/actions/views-plugin-source.ts
@@ -1,0 +1,37 @@
+/**
+ * @module plugin-app-control/actions/views-plugin-source
+ *
+ * Resolve a view's on-disk plugin source directory from its registry summary.
+ * Shared by the create, edit, and icon sub-handlers so plugin-path resolution
+ * lives in one place.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { ViewSummary } from "./views-client.js";
+
+/** Where plugin sources live relative to the repo root, in lookup order. */
+const PLUGIN_SOURCE_DIR_CANDIDATES = ["eliza/plugins", "plugins"] as const;
+
+/**
+ * Locate the source directory for `view`'s owning plugin under `repoRoot`.
+ * Returns the absolute path, or `null` when the plugin is not present as local
+ * source (e.g. installed only from npm).
+ */
+export async function locatePluginSourceDir(
+	repoRoot: string,
+	view: ViewSummary,
+): Promise<string | null> {
+	const pluginBasename = view.pluginName.replace(/^@[^/]+\//, "").trim();
+	const candidates = [
+		...PLUGIN_SOURCE_DIR_CANDIDATES.map((dir) =>
+			path.join(repoRoot, dir, pluginBasename),
+		),
+		path.join(repoRoot, "eliza", "apps", pluginBasename),
+	];
+	for (const candidate of candidates) {
+		const stat = await fs.stat(candidate).catch(() => null);
+		if (stat?.isDirectory()) return candidate;
+	}
+	return null;
+}

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -38,6 +38,7 @@ import {
 	runViewsDelete,
 } from "./views-delete.js";
 import { runViewsEdit } from "./views-edit.js";
+import { isViewIconRequest, runViewsIcon } from "./views-icon.js";
 import { runViewsList } from "./views-list.js";
 import { runViewsSearch, scoreView } from "./views-search.js";
 import { resolveIntentView, runViewsShow } from "./views-show.js";
@@ -54,6 +55,7 @@ export type ViewsMode =
 	| "interact"
 	| "create"
 	| "edit"
+	| "icon"
 	| "delete"
 	| "remove"
 	| "pin"
@@ -73,6 +75,7 @@ const MODES: readonly ViewsMode[] = [
 	"interact",
 	"create",
 	"edit",
+	"icon",
 	"delete",
 	"remove",
 	"pin",
@@ -297,6 +300,21 @@ function inferMode(
 		readStringOption(options, "action") ?? readStringOption(options, "mode");
 	const trimmed = viewRequestText(text).trim();
 	const normalizedExplicit = explicit?.trim().toLowerCase().replace(/-/g, "_");
+	// An explicit request to (re)generate a view's icon/image wins over the
+	// generic edit/create/update verbs that share its phrasing — regenerating an
+	// icon is a direct asset write, not a coding-agent edit.
+	if (
+		isViewIconRequest(trimmed, options) &&
+		(!normalizedExplicit ||
+			normalizedExplicit === "icon" ||
+			normalizedExplicit === "edit" ||
+			normalizedExplicit === "create" ||
+			normalizedExplicit === "update" ||
+			normalizedExplicit === "modify" ||
+			normalizedExplicit === "change")
+	) {
+		return "icon";
+	}
 	if (
 		normalizedExplicit === "close" ||
 		normalizedExplicit === "close_view" ||
@@ -1801,6 +1819,11 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			"MAKE_VIEW",
 			"EDIT_VIEW",
 			"UPDATE_VIEW",
+			"SET_VIEW_ICON",
+			"CHANGE_VIEW_ICON",
+			"GENERATE_VIEW_ICON",
+			"REGENERATE_VIEW_ICON",
+			"UPDATE_VIEW_IMAGE",
 			"DELETE_VIEW",
 			"REMOVE_VIEW",
 			"REMOVE_PLUGIN",
@@ -1820,9 +1843,9 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			"events",
 		],
 		description:
-			"Manage and navigate UI views. List available views, report the current view, open a specific view, close/hide a view without deleting its plugin, search views by name or capability, show the view manager, broadcast events to views, invoke registered capabilities on plugin views for view-backed content such as notes, calendar events, dashboards, and records, pin a view as a desktop tab, open a view in a separate window, request split/tiled layouts across multiple views, create a new view plugin (scaffolds + coding agent), edit an existing view plugin (coding agent), or delete/uninstall a view plugin.",
+			"Manage and navigate UI views. List available views, report the current view, open a specific view, close/hide a view without deleting its plugin, search views by name or capability, show the view manager, broadcast events to views, invoke registered capabilities on plugin views for view-backed content such as notes, calendar events, dashboards, and records, pin a view as a desktop tab, open a view in a separate window, request split/tiled layouts across multiple views, create a new view plugin (scaffolds + coding agent), edit an existing view plugin (coding agent), regenerate a view's icon/hero image, or delete/uninstall a view plugin.",
 		descriptionCompressed:
-			"views list|current|show|open|close|search|manager|broadcast|interact|pin|window|split|tile|create|edit|delete; navigate/close UI views; invoke registered view capabilities for notes/events/dashboards/records; click/read/focus elements; split/tile layouts; scaffold/edit/remove view plugins",
+			"views list|current|show|open|close|search|manager|broadcast|interact|pin|window|split|tile|create|edit|icon|delete; navigate/close UI views; invoke registered view capabilities for notes/events/dashboards/records; click/read/focus elements; split/tile layouts; scaffold/edit/remove view plugins; regenerate a view icon/hero",
 		routingHint:
 			"UI view/window/panel/app navigation and layout -> VIEWS. View switching is a COMMON, DEFAULT, PROACTIVE response while the user is in the app chat — strongly prefer opening the relevant view (action=show) whenever the user names an app surface, asks to see/check/open something, or expresses an intent that has a matching view, even when they don't say the word 'view'. Treat 'can you show me <X>', 'I want to <do X>', 'let me see <X>', 'pull up <X>', 'take me to <X>', 'go to <X>', 'open my <X>', and any reference to a domain (calendar, email/messages/inbox, wallet/balance/portfolio, finances/money/spending, focus/distractions, goals/routines/reminders, health/sleep/screen-time, todos/tasks, documents/files/notes, contacts/relationships/people, companion, the app builder/coding) as a navigation request and switch to that view by default. When in doubt and a matching view exists, action=show it rather than only answering in text. Use VIEWS for open/show/switch/close/hide view requests, view manager, list views, split/tile views, pin view, open view in a separate window, or invoking a capability declared by a registered plugin view, including view-backed content operations like creating/listing notes or calendar events. For add/create calendar-event requests, use action=interact view=calendar capability=create-calendar-event; do not answer by opening or splitting the calendar unless the user asked for layout. For an implicit request to SEE a domain surface — 'what's on my calendar', 'check my messages'/'my email', 'show my wallet'/'my balance', 'how much did I spend', 'I need to focus', 'take me to my goals', 'show my todos', 'pull up my documents', 'who do I know at X', or 'I want to add a new feature to my app' — open that surface with action=show and the matching view id (calendar, inbox, wallet, finances, focus, goals, health, todos, documents, relationships, companion, task-coordinator). This applies in ANY language: a navigation/see request in Spanish, French, German, Chinese, Japanese, Korean, etc. routes to VIEWS the same way. Opening a surface to view it is action=show, only adding or creating a record inside it is action=interact. Close/hide means VIEWS action=close, not delete/remove. For view capabilities use action=interact with view=<view id> and capability=<capability id>, or pass a generated capability action name that can be resolved from the view catalog. Pass capability data as params={...} or top-level keys such as title/body/date/time/notes/color; never use dotted keys such as params.title.",
 		allowAdditionalParameters: true,
@@ -1832,7 +1855,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			{
 				name: "action",
 				description:
-					"Operation: list | current | show | open | close | search | manager | broadcast | interact | pin | window | split | tile | create | edit | delete | remove, or a registered/generated view capability name to resolve through the view catalog.",
+					"Operation: list | current | show | open | close | search | manager | broadcast | interact | pin | window | split | tile | create | edit | icon | delete | remove, or a registered/generated view capability name to resolve through the view catalog.",
 				required: true,
 				schema: {
 					type: "string",
@@ -2057,6 +2080,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			if (
 				mode === "create" ||
 				mode === "edit" ||
+				mode === "icon" ||
 				mode === "delete" ||
 				mode === "remove"
 			) {
@@ -2370,6 +2394,18 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 					case "edit": {
 						const views = await client.listViews();
 						return runViewsEdit({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
+					}
+
+					case "icon": {
+						const views = await client.listViews();
+						return runViewsIcon({
 							runtime,
 							message,
 							options: actionOptions,

--- a/plugins/plugin-blocker/package.json
+++ b/plugins/plugin-blocker/package.json
@@ -75,6 +75,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-calendar/package.json
+++ b/plugins/plugin-calendar/package.json
@@ -115,6 +115,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ]
 }

--- a/plugins/plugin-facewear/package.json
+++ b/plugins/plugin-facewear/package.json
@@ -131,6 +131,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist",
     "docs"
   ]

--- a/plugins/plugin-finances/package.json
+++ b/plugins/plugin-finances/package.json
@@ -76,6 +76,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-goals/package.json
+++ b/plugins/plugin-goals/package.json
@@ -86,6 +86,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ]
 }

--- a/plugins/plugin-health/package.json
+++ b/plugins/plugin-health/package.json
@@ -52,6 +52,7 @@
     }
   },
   "files": [
+    "assets",
     "dist"
   ],
   "scripts": {

--- a/plugins/plugin-hyperliquid-app/package.json
+++ b/plugins/plugin-hyperliquid-app/package.json
@@ -57,6 +57,7 @@
     "build:types": "tsc --noCheck -p tsconfig.build.json"
   },
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-inbox/package.json
+++ b/plugins/plugin-inbox/package.json
@@ -86,6 +86,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ]
 }

--- a/plugins/plugin-messages/package.json
+++ b/plugins/plugin-messages/package.json
@@ -69,6 +69,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-polymarket-app/package.json
+++ b/plugins/plugin-polymarket-app/package.json
@@ -57,6 +57,7 @@
     "build:types": "tsc --noCheck -p tsconfig.build.json"
   },
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-relationships/assets/hero.svg
+++ b/plugins/plugin-relationships/assets/hero.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="Relationships">
+  <defs>
+    <linearGradient id="bg-relationships" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#241528"/>
+      <stop offset="1" stop-color="#190b19"/>
+    </linearGradient>
+    <radialGradient id="blobA-relationships" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#b22fda" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#b22fda" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="blobB-relationships" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#c3289f" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#c3289f" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="vig-relationships" cx="0.5" cy="0.42" r="0.75">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
+    </radialGradient>
+    <linearGradient id="label-relationships" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </linearGradient>
+    <filter id="soft-relationships" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="46"/>
+    </filter>
+    <filter id="iglow-relationships" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#c645ed" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="1024" fill="url(#bg-relationships)"/>
+
+  <g opacity="0.9">
+    <circle cx="232" cy="220" r="300" fill="url(#blobA-relationships)" filter="url(#soft-relationships)"/>
+    <circle cx="840" cy="800" r="340" fill="url(#blobB-relationships)" filter="url(#soft-relationships)"/>
+  </g>
+
+  <g stroke="#e5d7ea" stroke-width="1.4" opacity="0.06">
+    <line x1="0" y1="256" x2="1024" y2="256"/>
+    <line x1="0" y1="512" x2="1024" y2="512"/>
+    <line x1="0" y1="768" x2="1024" y2="768"/>
+    <line x1="256" y1="0" x2="256" y2="1024"/>
+    <line x1="512" y1="0" x2="512" y2="1024"/>
+    <line x1="768" y1="0" x2="768" y2="1024"/>
+  </g>
+
+  <g opacity="0.5">
+    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="#c645ed" stroke-width="3" opacity="0.35"/>
+  </g>
+
+  <g transform="translate(512 432)" filter="url(#iglow-relationships)"
+     color="#e5d7ea" stroke="#e5d7ea" stroke-width="20"
+     stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <line x1="-110" y1="-96" x2="0" y2="0"/>
+    <line x1="120" y1="-110" x2="0" y2="0"/>
+    <line x1="-130" y1="86" x2="0" y2="0"/>
+    <line x1="110" y1="104" x2="0" y2="0"/>
+    <circle cx="0" cy="0" r="30" fill="currentColor" stroke-width="0"/>
+    <circle cx="0" cy="0" r="30"/>
+    <circle cx="-110" cy="-96" r="22"/>
+    <circle cx="120" cy="-110" r="22"/>
+    <circle cx="-130" cy="86" r="22"/>
+    <circle cx="110" cy="104" r="22"/>
+  </g>
+
+  <rect x="0" y="784" width="1024" height="240" fill="url(#label-relationships)"/>
+  <text x="512" y="892" text-anchor="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="76" font-weight="600" letter-spacing="0.5"
+        fill="#e5d7ea">Relationships</text>
+  <rect x="460" y="924" width="104" height="6" rx="3" fill="#c645ed"/>
+
+  <rect width="1024" height="1024" fill="url(#vig-relationships)"/>
+</svg>

--- a/plugins/plugin-relationships/package.json
+++ b/plugins/plugin-relationships/package.json
@@ -36,6 +36,7 @@
     }
   },
   "files": [
+    "assets",
     "dist"
   ],
   "keywords": [

--- a/plugins/plugin-screenshare/package.json
+++ b/plugins/plugin-screenshare/package.json
@@ -78,6 +78,7 @@
     "build:types": "tsc --noCheck -p tsconfig.build.json"
   },
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/plugins/plugin-social-alpha/package.json
+++ b/plugins/plugin-social-alpha/package.json
@@ -19,7 +19,8 @@
 		}
 	},
 	"files": [
-		"dist"
+	  "assets",
+	  "dist"
 	],
 	"scripts": {
 		"build": "bun run build:js && bun run build:views && bun run build:types",

--- a/plugins/plugin-todos/package.json
+++ b/plugins/plugin-todos/package.json
@@ -36,6 +36,7 @@
     }
   },
   "files": [
+    "assets",
     "dist"
   ],
   "keywords": [

--- a/plugins/plugin-vector-browser/package.json
+++ b/plugins/plugin-vector-browser/package.json
@@ -75,6 +75,7 @@
     "test": "vitest run --config ./vitest.config.ts"
   },
   "files": [
+    "assets",
     "dist"
   ],
   "devDependencies": {

--- a/scripts/generate-view-heroes.mjs
+++ b/scripts/generate-view-heroes.mjs
@@ -3,267 +3,24 @@
  * Generate clean, brand-consistent SVG hero images for plugin views that lack
  * one. Heroes are probed at request time from `<pluginDir>/assets/hero.<ext>`
  * by `packages/agent/src/api/views-registry.ts` (`.svg` is a supported hero
- * extension). All existing real heroes are 1024x1024, so these are authored
- * with `viewBox="0 0 1024 1024"`.
+ * extension). All existing real heroes are 1024x1024.
  *
- * Each hero shares one cohesive dark, modern composition: a soft diagonal mesh
- * gradient, large blurred geometric shapes for depth, one accent hue per view
- * (no pure-blue dominant — app context forbids blue accents), a hand-drawn
- * vector line-icon, the view label in a system sans, and a subtle vignette.
+ * The art itself (frame, palette, icon glyphs) is the shared, single source of
+ * truth in `@elizaos/shared` (`view-hero-art.ts`) — the same generator the
+ * agent uses for its runtime hero fallback and that view scaffolding uses to
+ * seed a new plugin's icon. This script only owns the per-view config (which
+ * plugin, hue, and glyph) and writes the committed asset files.
  *
  * Output is deterministic: re-running produces byte-identical files. Run with
- * `node scripts/generate-view-heroes.mjs`.
+ * `node scripts/generate-view-heroes.mjs` (requires `@elizaos/shared` built).
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { VIEW_HERO_ICONS, renderViewHeroSvg } from "@elizaos/shared";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-
-const W = 1024;
-const CX = W / 2;
-
-/**
- * Convert an HSL triple to a hex color string. Deterministic, no rounding
- * surprises across runs.
- */
-function hsl(h, s, l) {
-  const sN = s / 100;
-  const lN = l / 100;
-  const c = (1 - Math.abs(2 * lN - 1)) * sN;
-  const hp = (((h % 360) + 360) % 360) / 60;
-  const x = c * (1 - Math.abs((hp % 2) - 1));
-  let r = 0;
-  let g = 0;
-  let b = 0;
-  if (hp >= 0 && hp < 1) [r, g, b] = [c, x, 0];
-  else if (hp < 2) [r, g, b] = [x, c, 0];
-  else if (hp < 3) [r, g, b] = [0, c, x];
-  else if (hp < 4) [r, g, b] = [0, x, c];
-  else if (hp < 5) [r, g, b] = [x, 0, c];
-  else [r, g, b] = [c, 0, x];
-  const m = lN - c / 2;
-  const toHex = (v) =>
-    Math.round((v + m) * 255)
-      .toString(16)
-      .padStart(2, "0");
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-}
-
-function escapeXml(value) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
-}
-
-/**
- * A palette derived from a single accent hue, kept in a dark, modern register.
- * Background tones are deep neutrals shifted slightly toward the accent so each
- * card reads distinct without ever looking like a flat blue panel.
- */
-function palette(hue) {
-  return {
-    bgTop: hsl(hue, 32, 12),
-    bgBottom: hsl(hue + 14, 40, 7),
-    blobA: hsl(hue, 70, 52),
-    blobB: hsl(hue + 28, 66, 46),
-    accent: hsl(hue, 82, 60),
-    accentSoft: hsl(hue, 70, 70),
-    line: hsl(hue, 30, 88),
-  };
-}
-
-/**
- * Shared chrome: defs (gradients, blur, vignette), background, depth blobs,
- * a faint dotted grid, and the bottom vignette. The icon and label are slotted
- * in by the caller.
- */
-function frame({ id, hue, iconSvg, label }) {
-  const p = palette(hue);
-  const safeLabel = escapeXml(label);
-  // Two large blurred blobs placed off-center for asymmetric depth, plus a thin
-  // accent arc sweeping behind the icon.
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${W}" width="${W}" height="${W}" role="img" aria-label="${safeLabel}">
-  <defs>
-    <linearGradient id="bg-${id}" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="${p.bgTop}"/>
-      <stop offset="1" stop-color="${p.bgBottom}"/>
-    </linearGradient>
-    <radialGradient id="blobA-${id}" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0" stop-color="${p.blobA}" stop-opacity="0.55"/>
-      <stop offset="1" stop-color="${p.blobA}" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="blobB-${id}" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0" stop-color="${p.blobB}" stop-opacity="0.5"/>
-      <stop offset="1" stop-color="${p.blobB}" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="vig-${id}" cx="0.5" cy="0.42" r="0.75">
-      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
-      <stop offset="0.72" stop-color="#000000" stop-opacity="0"/>
-      <stop offset="1" stop-color="#000000" stop-opacity="0.5"/>
-    </radialGradient>
-    <linearGradient id="label-${id}" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#000000" stop-opacity="0"/>
-      <stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
-    </linearGradient>
-    <filter id="soft-${id}" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="46"/>
-    </filter>
-    <filter id="iglow-${id}" x="-40%" y="-40%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="${p.accent}" flood-opacity="0.45"/>
-    </filter>
-  </defs>
-
-  <rect width="${W}" height="${W}" fill="url(#bg-${id})"/>
-
-  <g opacity="0.9">
-    <circle cx="232" cy="220" r="300" fill="url(#blobA-${id})" filter="url(#soft-${id})"/>
-    <circle cx="840" cy="800" r="340" fill="url(#blobB-${id})" filter="url(#soft-${id})"/>
-  </g>
-
-  <g stroke="${p.line}" stroke-width="1.4" opacity="0.06">
-    <line x1="0" y1="256" x2="${W}" y2="256"/>
-    <line x1="0" y1="512" x2="${W}" y2="512"/>
-    <line x1="0" y1="768" x2="${W}" y2="768"/>
-    <line x1="256" y1="0" x2="256" y2="${W}"/>
-    <line x1="512" y1="0" x2="512" y2="${W}"/>
-    <line x1="768" y1="0" x2="768" y2="${W}"/>
-  </g>
-
-  <g opacity="0.5">
-    <path d="M120 470 A 400 400 0 0 1 904 470" fill="none" stroke="${p.accent}" stroke-width="3" opacity="0.35"/>
-  </g>
-
-  <g transform="translate(${CX} 432)" filter="url(#iglow-${id})"
-     color="${p.line}" stroke="${p.line}" stroke-width="20"
-     stroke-linecap="round" stroke-linejoin="round" fill="none">
-${iconSvg}
-  </g>
-
-  <rect x="0" y="784" width="${W}" height="240" fill="url(#label-${id})"/>
-  <text x="${CX}" y="892" text-anchor="middle"
-        font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
-        font-size="76" font-weight="600" letter-spacing="0.5"
-        fill="${p.line}">${safeLabel}</text>
-  <rect x="${CX - 52}" y="924" width="104" height="6" rx="3" fill="${p.accent}"/>
-
-  <rect width="${W}" height="${W}" fill="url(#vig-${id})"/>
-</svg>`;
-}
-
-/**
- * Icons are drawn on a canvas centered at (0,0) with the icon group translated
- * to the upper-mid of the card. Coordinates roughly span -150..150. Each icon
- * inherits stroke styling from the parent <g>; fills are set explicitly where
- * a filled glyph reads better.
- */
-const icons = {
-  // cpu / chip with a beaker spark — Model Tester
-  modelTester: `    <rect x="-110" y="-110" width="220" height="220" rx="28"/>
-    <rect x="-58" y="-58" width="116" height="116" rx="14"/>
-    <line x1="-110" y1="-66" x2="-150" y2="-66"/>
-    <line x1="-110" y1="0" x2="-150" y2="0"/>
-    <line x1="-110" y1="66" x2="-150" y2="66"/>
-    <line x1="110" y1="-66" x2="150" y2="-66"/>
-    <line x1="110" y1="0" x2="150" y2="0"/>
-    <line x1="110" y1="66" x2="150" y2="66"/>
-    <line x1="-66" y1="-110" x2="-66" y2="-150"/>
-    <line x1="0" y1="-110" x2="0" y2="-150"/>
-    <line x1="66" y1="-110" x2="66" y2="-150"/>
-    <line x1="-66" y1="110" x2="-66" y2="150"/>
-    <line x1="0" y1="110" x2="0" y2="150"/>
-    <line x1="66" y1="110" x2="66" y2="150"/>
-    <circle cx="0" cy="0" r="14" stroke-width="0" fill="currentColor"/>`,
-
-  // overlapping panels — Views (layout grid)
-  views: `    <rect x="-150" y="-150" width="130" height="130" rx="18"/>
-    <rect x="20" y="-150" width="130" height="130" rx="18"/>
-    <rect x="-150" y="20" width="130" height="130" rx="18"/>
-    <rect x="20" y="20" width="130" height="130" rx="18"/>`,
-
-  // shield with an eye-off slash — Focus / blocker
-  focus: `    <path d="M0 -150 L130 -100 L130 24 C130 110 70 152 0 175 C-70 152 -130 110 -130 24 L-130 -100 Z"/>
-    <circle cx="0" cy="-2" r="34"/>
-    <line x1="-92" y1="-96" x2="96" y2="120"/>`,
-
-  // calendar grid — Calendar
-  calendar: `    <rect x="-140" y="-118" width="280" height="248" rx="24"/>
-    <line x1="-140" y1="-52" x2="140" y2="-52"/>
-    <line x1="-78" y1="-150" x2="-78" y2="-92"/>
-    <line x1="78" y1="-150" x2="78" y2="-92"/>
-    <circle cx="-66" cy="6" r="11" stroke-width="0" fill="currentColor"/>
-    <circle cx="0" cy="6" r="11" stroke-width="0" fill="currentColor"/>
-    <circle cx="66" cy="6" r="11" stroke-width="0" fill="currentColor"/>
-    <circle cx="-66" cy="72" r="11" stroke-width="0" fill="currentColor"/>
-    <circle cx="0" cy="72" r="11" stroke-width="0" fill="currentColor"/>`,
-
-  // headphones — Facewear
-  headphones: `    <path d="M-140 30 V-10 A140 140 0 0 1 140 -10 V30"/>
-    <rect x="-160" y="26" width="58" height="110" rx="26" fill="currentColor" stroke-width="0"/>
-    <rect x="102" y="26" width="58" height="110" rx="26" fill="currentColor" stroke-width="0"/>
-    <rect x="-160" y="26" width="58" height="110" rx="26"/>
-    <rect x="102" y="26" width="58" height="110" rx="26"/>`,
-
-  // glasses — Smartglasses
-  glasses: `    <circle cx="-86" cy="20" r="68"/>
-    <circle cx="86" cy="20" r="68"/>
-    <path d="M-18 20 Q0 -2 18 20"/>
-    <line x1="-154" y1="-12" x2="-180" y2="-44"/>
-    <line x1="154" y1="-12" x2="180" y2="-44"/>`,
-
-  // line chart rising with axis — Finances
-  finances: `    <polyline points="-150,-150 -150,150 150,150"/>
-    <polyline points="-118,86 -50,-2 6,52 76,-62 132,-104" fill="none"/>
-    <circle cx="-50" cy="-2" r="13" stroke-width="0" fill="currentColor"/>
-    <circle cx="76" cy="-62" r="13" stroke-width="0" fill="currentColor"/>
-    <circle cx="132" cy="-104" r="13" stroke-width="0" fill="currentColor"/>`,
-
-  // target with center dot and a flag — Goals
-  goals: `    <circle cx="0" cy="0" r="150"/>
-    <circle cx="0" cy="0" r="92"/>
-    <circle cx="0" cy="0" r="34"/>
-    <circle cx="0" cy="0" r="9" stroke-width="0" fill="currentColor"/>`,
-
-  // heart with a pulse line through it — Health
-  health: `    <path d="M0 150 C-180 18 -120 -120 0 -52 C120 -120 180 18 0 150 Z"/>
-    <polyline points="-150,-10 -64,-10 -28,-58 14,52 48,-10 150,-10" fill="none"/>`,
-
-  // inbox tray — Inbox
-  inbox: `    <path d="M-150 -40 L-110 -130 H110 L150 -40 V120 A20 20 0 0 1 130 140 H-130 A20 20 0 0 1 -150 120 Z"/>
-    <path d="M-150 -40 H-44 L-10 24 H10 L44 -40 H150"/>`,
-
-  // chat bubble with lines — Messages
-  messages: `    <path d="M-150 -120 H150 A24 24 0 0 1 174 -96 V60 A24 24 0 0 1 150 84 H-30 L-100 150 V84 H-150 A24 24 0 0 1 -174 60 V-96 A24 24 0 0 1 -150 -120 Z"/>
-    <line x1="-100" y1="-44" x2="100" y2="-44"/>
-    <line x1="-100" y1="16" x2="40" y2="16"/>`,
-
-  // trending up arrow over people dots — Social Alpha
-  socialAlpha: `    <polyline points="-150,80 -54,-22 6,38 150,-110" fill="none"/>
-    <polyline points="92,-110 150,-110 150,-52" fill="none"/>
-    <circle cx="-110" cy="128" r="26"/>
-    <circle cx="0" cy="128" r="26"/>
-    <circle cx="110" cy="128" r="26"/>`,
-
-  // checklist square — Todos
-  todos: `    <rect x="-150" y="-150" width="300" height="300" rx="36"/>
-    <polyline points="-92,-6 -36,52 92,-78" fill="none"/>`,
-
-  // network graph nodes — Vector Browser
-  vectorBrowser: `    <line x1="-110" y1="-96" x2="0" y2="0"/>
-    <line x1="120" y1="-110" x2="0" y2="0"/>
-    <line x1="-130" y1="86" x2="0" y2="0"/>
-    <line x1="110" y1="104" x2="0" y2="0"/>
-    <circle cx="0" cy="0" r="30" fill="currentColor" stroke-width="0"/>
-    <circle cx="0" cy="0" r="30"/>
-    <circle cx="-110" cy="-96" r="22"/>
-    <circle cx="120" cy="-110" r="22"/>
-    <circle cx="-130" cy="86" r="22"/>
-    <circle cx="110" cy="104" r="22"/>`,
-};
 
 /**
  * Per-view config. Hues are hand-spread across warm/jewel tones (orange, amber,
@@ -271,26 +28,27 @@ const icons = {
  * while staying cohesive. None lands on pure blue (~210–250) as the dominant.
  */
 const views = [
-  { out: "plugins/app-model-tester/assets/hero.svg", id: "model-tester", label: "Model Tester", hue: 25, icon: icons.modelTester },
-  { out: "plugins/plugin-app-control/assets/hero.svg", id: "views", label: "Views", hue: 270, icon: icons.views },
-  { out: "plugins/plugin-blocker/assets/hero.svg", id: "focus", label: "Focus", hue: 348, icon: icons.focus },
-  { out: "plugins/plugin-calendar/assets/hero.svg", id: "calendar", label: "Calendar", hue: 12, icon: icons.calendar },
-  { out: "plugins/plugin-facewear/assets/hero-facewear.svg", id: "facewear", label: "Facewear", hue: 190, icon: icons.headphones },
-  { out: "plugins/plugin-facewear/assets/hero-smartglasses.svg", id: "smartglasses", label: "Smartglasses", hue: 300, icon: icons.glasses },
-  { out: "plugins/plugin-finances/assets/hero.svg", id: "finances", label: "Finances", hue: 150, icon: icons.finances },
-  { out: "plugins/plugin-goals/assets/hero.svg", id: "goals", label: "Goals", hue: 38, icon: icons.goals },
-  { out: "plugins/plugin-health/assets/hero.svg", id: "health", label: "Health", hue: 332, icon: icons.health },
-  { out: "plugins/plugin-inbox/assets/hero.svg", id: "inbox", label: "Inbox", hue: 168, icon: icons.inbox },
-  { out: "plugins/plugin-messages/assets/hero.svg", id: "messages", label: "Messages", hue: 256, icon: icons.messages },
-  { out: "plugins/plugin-social-alpha/assets/hero.svg", id: "social-alpha", label: "Social Alpha", hue: 130, icon: icons.socialAlpha },
-  { out: "plugins/plugin-todos/assets/hero.svg", id: "todos", label: "Todos", hue: 52, icon: icons.todos },
-  { out: "plugins/plugin-vector-browser/assets/hero.svg", id: "vector-browser", label: "Vector Browser", hue: 286, icon: icons.vectorBrowser },
+  { out: "plugins/app-model-tester/assets/hero.svg", id: "model-tester", label: "Model Tester", hue: 25, icon: VIEW_HERO_ICONS.modelTester },
+  { out: "plugins/plugin-app-control/assets/hero.svg", id: "views", label: "Views", hue: 270, icon: VIEW_HERO_ICONS.views },
+  { out: "plugins/plugin-blocker/assets/hero.svg", id: "focus", label: "Focus", hue: 348, icon: VIEW_HERO_ICONS.focus },
+  { out: "plugins/plugin-calendar/assets/hero.svg", id: "calendar", label: "Calendar", hue: 12, icon: VIEW_HERO_ICONS.calendar },
+  { out: "plugins/plugin-facewear/assets/hero-facewear.svg", id: "facewear", label: "Facewear", hue: 190, icon: VIEW_HERO_ICONS.headphones },
+  { out: "plugins/plugin-facewear/assets/hero-smartglasses.svg", id: "smartglasses", label: "Smartglasses", hue: 300, icon: VIEW_HERO_ICONS.glasses },
+  { out: "plugins/plugin-finances/assets/hero.svg", id: "finances", label: "Finances", hue: 150, icon: VIEW_HERO_ICONS.finances },
+  { out: "plugins/plugin-goals/assets/hero.svg", id: "goals", label: "Goals", hue: 38, icon: VIEW_HERO_ICONS.goals },
+  { out: "plugins/plugin-health/assets/hero.svg", id: "health", label: "Health", hue: 332, icon: VIEW_HERO_ICONS.health },
+  { out: "plugins/plugin-inbox/assets/hero.svg", id: "inbox", label: "Inbox", hue: 168, icon: VIEW_HERO_ICONS.inbox },
+  { out: "plugins/plugin-messages/assets/hero.svg", id: "messages", label: "Messages", hue: 256, icon: VIEW_HERO_ICONS.messages },
+  { out: "plugins/plugin-relationships/assets/hero.svg", id: "relationships", label: "Relationships", hue: 286, icon: VIEW_HERO_ICONS.vectorBrowser },
+  { out: "plugins/plugin-social-alpha/assets/hero.svg", id: "social-alpha", label: "Social Alpha", hue: 130, icon: VIEW_HERO_ICONS.socialAlpha },
+  { out: "plugins/plugin-todos/assets/hero.svg", id: "todos", label: "Todos", hue: 52, icon: VIEW_HERO_ICONS.todos },
+  { out: "plugins/plugin-vector-browser/assets/hero.svg", id: "vector-browser", label: "Vector Browser", hue: 286, icon: VIEW_HERO_ICONS.vectorBrowser },
 ];
 
 async function main() {
   const written = [];
   for (const view of views) {
-    const svg = frame({
+    const svg = renderViewHeroSvg({
       id: view.id,
       hue: view.hue,
       iconSvg: view.icon,


### PR DESCRIPTION
## What

Each plugin **view** is a mini-app served a hero image at `/api/views/<id>/hero`. This makes that image **self-contained in the plugin, branded, and never missing or ugly**, and adds the ability to generate/regenerate a view's icon.

## Changes

- **One branded generator** — extracted the no-blue view-hero SVG art from `scripts/generate-view-heroes.mjs` into [`packages/shared/src/view-hero-art.ts`](../blob/shaw/view-hero-icons/packages/shared/src/view-hero-art.ts) as the single source of truth. The runtime fallback, view scaffolding, icon regeneration, and the script all render the same deterministic art. The 14 committed heroes stay **byte-identical**.
- **Branded fallback** — `views-registry.ts` `generateViewHeroSvg` now delegates to it, so a view without a packaged hero renders a cohesive card instead of a 2-letter `#1a1a2e` placeholder. (Covers built-in shell views and any hero-less plugin view.)
- **Filled the one coverage gap** — generated + committed the missing `plugin-relationships` hero.
- **Heroes now ship** — added `"assets"` to the npm `files[]` of every hero-bearing view plugin (+ the `min-plugin` template), so heroes are included in the published package, not just local/dev mode.
- **Creation seeds an icon** — `VIEWS create` writes `assets/hero.svg` on scaffold, before the coding agent runs.
- **Icon update mode** — new owner-gated `VIEWS icon` mode: *"regenerate the wallet view icon"* rewrites `assets/hero.svg` directly (no coding agent), via [`views-icon.ts`](../blob/shaw/view-hero-icons/plugins/plugin-app-control/src/actions/views-icon.ts).
- **Dedup** — collapsed the triplicated `locatePluginSourceDir` into `views-plugin-source.ts`.

## Assessment (no dedup needed)

Catalogued all view declarations: no true duplicate views. The clusters that look similar (games, finance, messaging) are legitimately distinct, and `gui`/`xr`/`tui` sharing one id is the intended multi-surface pattern.

## Tests / verification (run on this `develop` base)

- `@elizaos/shared` `view-hero-art` — **8/8**
- `plugin-app-control` `views-icon` — **8/8**
- `shared` + `plugin-app-control` typecheck — **clean**
- `shared` + `plugin-app-control` lint — **clean**
- `scripts/generate-view-heroes.mjs` regenerates the 14 committed heroes byte-identically + the new relationships hero

## Notes

- Scoped to the hero/icon system. develop's view plugins that still lack a committed hero now get a branded generated fallback (and always had a Lucide `icon`), so nothing is missing or 404s; their real PNG heroes can land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)