### PR TITLE
fix: dedicated-agent client review follow-ups (202 resume, null-safety, create-branch base)

### DIFF
--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -87,4 +87,16 @@ describe("assistant text helpers", () => {
       extractAssistantReplyText("Sure — my reply is that the sky is blue."),
     ).toBeNull();
   });
+
+  it("is null/undefined-safe (e.g. a 202 placeholder body with no text)", () => {
+    // Non-string input must not throw — degrade gracefully.
+    expect(
+      extractAssistantReplyText(undefined as unknown as string),
+    ).toBeNull();
+    expect(extractAssistantReplyText(null as unknown as string)).toBeNull();
+    expect(stripAssistantStageDirections(undefined as unknown as string)).toBe(
+      "",
+    );
+    expect(stripAssistantStageDirections(null as unknown as string)).toBe("");
+  });
 });

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -240,6 +240,7 @@ function isSimpleReplyPayload(
  * `shouldRespond`, so parse that shape without touching ordinary chat text.
  */
 export function extractAssistantReplyText(input: string): string | null {
+  if (typeof input !== "string") return null;
   const trimmed = input.trim();
 
   // Shape 1: a leaked response-handler payload keyed by `replyText` — either the
@@ -284,6 +285,7 @@ export function extractAssistantReplyText(input: string): string | null {
 }
 
 export function stripAssistantStageDirections(input: string): string {
+  if (typeof input !== "string") return "";
   let normalized = input;
   normalized = stripWrappedStageDirections(normalized, /\*([^*\n]+)\*/g);
   normalized = stripWrappedStageDirections(normalized, /_([^_\n]+)_/g);

--- a/packages/ui/src/api/client-base-resume.test.ts
+++ b/packages/ui/src/api/client-base-resume.test.ts
@@ -63,7 +63,7 @@ describe("ElizaClient 202 dedicated-agent resume handling", () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  it("gives up after a bounded number of retries if still resuming", async () => {
+  it("throws a distinguishable agent_resuming error after the bounded retries", async () => {
     const request = vi
       .fn<AgentRequestTransport["request"]>()
       .mockResolvedValue(
@@ -71,12 +71,20 @@ describe("ElizaClient 202 dedicated-agent resume handling", () => {
       );
 
     const client = makeClient(request);
-    const pending = client.fetch("/api/status").catch(() => undefined);
+    let caught: unknown;
+    const pending = client.fetch("/api/status").catch((e) => {
+      caught = e;
+    });
     await vi.runAllTimersAsync();
     await pending;
 
     // 1 initial attempt + 6 bounded retries = 7 total; it does not loop forever.
     expect(request).toHaveBeenCalledTimes(7);
+    // ...and it surfaces a typed 202 "resuming" error instead of returning the
+    // empty 202 placeholder as a (silent) success.
+    expect(caught).toBeTruthy();
+    expect((caught as { status?: number }).status).toBe(202);
+    expect((caught as { code?: string }).code).toBe("agent_resuming");
   });
 
   it("stops waiting when the caller aborts mid-resume", async () => {

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -18,6 +18,36 @@ function stubWebSocket(): string[] {
   return createdUrls;
 }
 
+interface FakeWs {
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+}
+
+// Stub that captures each created socket so a test can drive its lifecycle
+// events (e.g. simulate the WS never staying open through all reconnects).
+function stubWebSocketWithInstances(): FakeWs[] {
+  const instances: FakeWs[] = [];
+  class WebSocketStub {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    readyState = WebSocketStub.CONNECTING;
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    constructor(_url: string) {
+      instances.push(this);
+    }
+    send(): void {}
+    close(): void {}
+  }
+  vi.stubGlobal("WebSocket", WebSocketStub);
+  return instances;
+}
+
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -66,5 +96,49 @@ describe("ElizaClient websocket connection policy", () => {
     expect(createdUrls).toHaveLength(1);
     expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
     expect(createdUrls[0]).toContain("token=agent-token");
+  });
+
+  it("degrades a dedicated cloud agent to connected-over-REST after WS exhaustion (no disconnect overlay)", () => {
+    vi.useFakeTimers();
+    try {
+      const instances = stubWebSocketWithInstances();
+      const client = new ElizaClient(
+        "https://abc123def456.elizacloud.ai",
+        "cloud-token",
+      );
+      client.connectWs();
+      // It DID attempt a websocket (dedicated agents have a usable /ws).
+      expect(instances).toHaveLength(1);
+      // Simulate the socket never staying open through every reconnect attempt.
+      for (let i = 0; i < 15; i++) {
+        instances[instances.length - 1].onclose?.();
+      }
+      const state = client.getConnectionState();
+      expect(state.reconnectAttempt).toBeGreaterThanOrEqual(15);
+      // Instead of "failed" (which drives the full-screen "Lost backend
+      // connection" overlay) it degrades to a non-fatal connected state so REST
+      // chat keeps working and the WS keeps probing in the background.
+      expect(state.state).toBe("connected");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still goes failed for a non-cloud agent base after WS exhaustion (overlay preserved)", () => {
+    vi.useFakeTimers();
+    try {
+      const instances = stubWebSocketWithInstances();
+      const client = new ElizaClient(
+        "https://agent.example.test",
+        "agent-token",
+      );
+      client.connectWs();
+      for (let i = 0; i < 15; i++) {
+        instances[instances.length - 1].onclose?.();
+      }
+      expect(client.getConnectionState().state).toBe("failed");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -234,6 +234,27 @@ function shouldTreatAsConnectedWithoutWebSocket(
   );
 }
 
+// A dedicated cloud agent lives on its own subdomain (<id>.elizacloud.ai) and
+// serves chat over REST as well as the realtime WS. Unlike the shared-runtime
+// adapter it DOES have a usable `/ws`, so we still attempt the WebSocket — but
+// if it can't connect (cold start, resume window, a slow backend) the agent is
+// still usable over REST. So on WS-reconnect exhaustion we degrade to a
+// non-fatal connected-over-REST state instead of raising the catastrophic
+// full-screen "Lost backend connection" overlay (see connectWs.onclose).
+function isDedicatedCloudAgentBase(value: string | null | undefined): boolean {
+  const normalized = normalizeBaseUrl(value);
+  if (!normalized) return false;
+  try {
+    const host = new URL(normalized).hostname.toLowerCase();
+    return (
+      host.endsWith(".elizacloud.ai") &&
+      !ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(host)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function getInjectedWsBase(): string | undefined {
   if (typeof window === "undefined") return undefined;
   const values = [
@@ -1020,7 +1041,17 @@ export class ElizaClient {
       this.reconnectAttempt++;
       // Update state based on attempt count
       if (this.reconnectAttempt >= this.maxReconnectAttempts) {
-        this.connectionState = "failed";
+        // A dedicated cloud agent serves chat over REST independently of the
+        // realtime WS, so a WS that can't connect must NOT raise the fatal
+        // full-screen "Lost backend connection" overlay. Degrade to a non-fatal
+        // connected-over-REST state and keep probing in the background (see
+        // scheduleReconnect's 30s loop) so live updates resume on WS recovery.
+        if (isDedicatedCloudAgentBase(this.baseUrl)) {
+          this.connectionState = "connected";
+          this.disconnectedAt = null;
+        } else {
+          this.connectionState = "failed";
+        }
       } else {
         this.connectionState = "reconnecting";
       }

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -603,6 +603,20 @@ export class ElizaClient {
       resumeRetries += 1;
       res = await this.rawRequestOnce(path, requestUrl, init, options, token);
     }
+    // Resume budget exhausted while the agent is still 202 (resuming): surface a
+    // distinguishable error instead of returning the empty 202 placeholder as a
+    // success — otherwise the chat/stream path renders an empty reply. allowNonOk
+    // callers and aborted requests still get the raw response.
+    if (res.status === 202 && !options?.allowNonOk && !init?.signal?.aborted) {
+      throw new ApiError({
+        kind: "http",
+        path,
+        status: 202,
+        message: "Agent is still starting up — please try again in a moment.",
+        code: "agent_resuming",
+        retryAfter: resumeRetryDelayMs(res) / 1000,
+      });
+    }
     if (!res.ok && !options?.allowNonOk) {
       const body = (await this.readBodyText(res, path, options?.timeoutMs, init)
         .then((text) => JSON.parse(text) as Record<string, unknown>)
@@ -1201,6 +1215,7 @@ export class ElizaClient {
   // --- Text normalization helpers (used by chat domain methods) ---
 
   normalizeAssistantText(text: string): string {
+    if (typeof text !== "string") return GENERIC_NO_RESPONSE_TEXT;
     const stripped = stripAssistantStageDirections(
       extractAssistantReplyText(text) ?? text,
     );

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -2889,17 +2889,15 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     }
   }
 
-  // Create a NEW agent. We create a SHARED (Tier-0) agent FOR NOW because it is
-  // the only tier reachable from the app today: instant (no container to boot),
-  // served at the public REST adapter, cheap. DEDICATED (the billed container
-  // product) is the goal, but is currently unreachable from the app — the cloud
-  // has not deployed the per-agent public subdomain ingress
-  // (https://<id>.elizacloud.ai) and dedicated provisioning is blocked on
-  // headscale_ip registration (see ~/ELIZA_CLOUD_DEDICATED_AGENT_ENABLEMENT_SPEC.md).
-  // The app is otherwise dedicated-ready: resolveCloudAgentApiBase already prefers
-  // a dedicated agent's public web_ui_url, so once the cloud returns a reachable
-  // one, flip this create to provision dedicated (alwaysOn) — no other app change
-  // needed. createCloudCompatAgent omits alwaysOn → tier "shared", serving immediately.
+  // Create a NEW agent. createCloudCompatAgent provisions a DEDICATED (alwaysOn)
+  // agent — the billed container product served at its own public subdomain
+  // (https://<id>.elizacloud.ai), reached with the cloud token via the
+  // unified-auth Worker. A dedicated agent's reachable base is that subdomain,
+  // NOT the shared REST adapter (which 404s for non-shared agents), so resolve
+  // the base from the agent's web_ui_url exactly like the reuse branch above.
+  // The subdomain is returned as soon as the agent record exists (before the
+  // container finishes booting), so re-read the created agent to pick it up;
+  // if that lookup fails or has no URL yet, fall back to the shared-adapter base.
   onProgress?.("creating", `Creating ${name}...`);
   const created = await this.createCloudCompatAgent({
     agentName: name,
@@ -2909,13 +2907,23 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     throw new Error(created.data.message || "Failed to create cloud agent");
   }
   const agentId = created.data.agentId;
-  const apiBase = buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId);
+  const detail = await this.getCloudCompatAgent(agentId).catch(() => null);
+  const detailAgent = detail?.success ? detail.data : null;
+  const apiBase =
+    detailAgent?.web_ui_url || detailAgent?.bridge_url
+      ? resolveCloudAgentApiBase({
+          bridgeUrl: detailAgent.bridge_url,
+          webUiUrl: detailAgent.web_ui_url ?? detailAgent.webUiUrl,
+          agentId,
+          cloudApiBase: resolvedCloudApiBase,
+        })
+      : buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId);
   onProgress?.("ready", "Cloud agent ready!");
   return {
     agentId,
     agentName: created.data.agentName || name,
     apiBase,
-    bridgeUrl: null,
+    bridgeUrl: detailAgent?.bridge_url ?? null,
     created: true,
   };
 };


### PR DESCRIPTION
Three confirmed findings from a multi-agent review of the app's **cloud/dedicated-agent client path**, each adversarially verified against the code and fixed + tested.

### 1. 202 resume exhaustion returned the empty placeholder as success *(follow-up to #8641)*
When a dedicated agent stays `202` (resuming) past the bounded retries, `rawRequest` previously returned the 202 — which `res.ok` treats as success, so the chat/stream path rendered an **empty reply** (and `streamChatEndpoint` could throw the misleading "Streaming not supported"). Now it throws a **distinguishable `agent_resuming` ApiError** (`status: 202` + `retryAfter`) so callers can show "agent is starting, try again". `allowNonOk` and aborted requests are unaffected.

### 2. assistant-text helpers threw on non-string input
`extractAssistantReplyText` / `stripAssistantStageDirections` / `normalizeAssistantText` did `input.trim()` with no guard, so a `202` placeholder body (no `text` field) → crash. Now **null/undefined-safe** at the boundary.

### 3. create-branch bound a new DEDICATED agent to the SHARED adapter base
`selectOrProvisionCloudAgent`'s create branch set `apiBase = buildCloudSharedAgentApiBase(...)` (the shared REST adapter, which **404s for non-shared agents**) and carried a stale comment claiming it provisions a *shared* agent. Since `createCloudCompatAgent` provisions **dedicated** (`alwaysOn`), this hit the **new-user flow**. It now re-reads the created agent and resolves the base from its `web_ui_url` via `resolveCloudAgentApiBase` (same as the reuse branch), falling back to the shared base only if no URL is available yet. Comment corrected.

## Tests
- assistant-text: null/undefined-safety cases
- resume: exhaustion now asserts the typed `agent_resuming` throw (no silent empty success)
- Green: shared + ui (`client-base-resume` / `-timeout` / `-websocket` / `client-cloud` / `use-first-run`); lint + typecheck clean on all changed files

Refs #8434.

### 4. dedicated cloud agent showed a false "Lost backend connection" overlay
A dedicated agent (`<id>.elizacloud.ai`) serves chat over **REST** as well as the realtime WS. `shouldTreatAsConnectedWithoutWebSocket` covered the shared adapter + local/iOS bases but **not** a dedicated subdomain, so when the WS couldn't connect (cold start / resume / slow-backend window) the 15-attempt backoff exhausted → state `failed` → the **full-screen "Lost backend connection" overlay**, even though REST chat worked. Now it still attempts the WS, but on exhaustion for a dedicated cloud base it **degrades to a non-fatal connected-over-REST state** (mirroring the shared adapter) and keeps the 30s background probe so live updates resume on WS recovery. Non-cloud bases still go `failed`. Tests added (dedicated→connected, non-cloud→failed). *(This is the 'Lost backend connection' users were hitting on dedicated agents during the DB-restore window.)*