### PR TITLE
feat(cloud): dedicated-agent registry over Railway Redis + pairing primitive (#8621)

### DIFF
--- a/packages/agent/src/runtime/__tests__/sandbox-registry.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-registry.test.ts
@@ -4,6 +4,7 @@
  * commands that would be sent. Everything else runs the real production code.
  */
 
+import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildSandboxRegistryFromEnv,
@@ -157,5 +158,184 @@ describe("buildSandboxRegistryFromEnv", () => {
       SANDBOX_PUBLIC_URL: "http://1.2.3.4:1999/api",
     });
     expect(reg).not.toBeNull();
+  });
+
+  it("accepts a redis:// URL with NO token (TCP transport carries auth inline)", () => {
+    const reg = buildSandboxRegistryFromEnv({
+      SANDBOX_REGISTRY_REDIS_URL: "redis://default:pw@host:6379",
+      // no SANDBOX_REGISTRY_REDIS_TOKEN
+      SANDBOX_AGENT_ID: "sandbox-id",
+      SANDBOX_SERVER_NAME: "sandbox-name",
+      SANDBOX_PUBLIC_URL: "http://1.2.3.4:1999/api",
+    });
+    expect(reg).not.toBeNull();
+  });
+
+  it("still requires a token for an https:// (Upstash REST) URL", () => {
+    expect(
+      buildSandboxRegistryFromEnv({
+        SANDBOX_REGISTRY_REDIS_URL: "https://example.upstash.io",
+        // no token
+        SANDBOX_AGENT_ID: "sandbox-id",
+        SANDBOX_SERVER_NAME: "sandbox-name",
+        SANDBOX_PUBLIC_URL: "http://1.2.3.4:1999/api",
+      }),
+    ).toBeNull();
+  });
+});
+
+/**
+ * In-process RESP server: parses the client's RESP2 command stream against a
+ * real `node:net` socket and replies like Redis (SET/GET/DEL/AUTH/SELECT),
+ * exercising the registry's native TCP transport end-to-end without an external
+ * Redis. `requirePassword` + `fragmentReplies` let tests assert auth and the
+ * partial-read parser.
+ */
+interface FakeRedis {
+  port: number;
+  store: Map<string, string>;
+  authedWith: string[][];
+  close: () => Promise<void>;
+}
+
+async function startFakeRedis(opts?: {
+  requirePassword?: string;
+  fragmentReplies?: boolean;
+}): Promise<FakeRedis> {
+  const store = new Map<string, string>();
+  const authedWith: string[][] = [];
+
+  const server = net.createServer((socket) => {
+    let buf = Buffer.alloc(0);
+    let authed = !opts?.requirePassword;
+
+    const send = (s: string): void => {
+      if (opts?.fragmentReplies) {
+        // Write one byte at a time to force the client's incremental parser.
+        for (const byte of Buffer.from(s)) socket.write(Buffer.from([byte]));
+      } else {
+        socket.write(s);
+      }
+    };
+
+    const tryParseCommand = (): string[] | null => {
+      if (buf.length === 0 || buf[0] !== 0x2a) return null; // '*'
+      const headerEnd = buf.indexOf("\r\n");
+      if (headerEnd === -1) return null;
+      const argc = Number(buf.toString("utf8", 1, headerEnd));
+      let offset = headerEnd + 2;
+      const args: string[] = [];
+      for (let i = 0; i < argc; i++) {
+        if (buf[offset] !== 0x24) return null; // '$'
+        const lenEnd = buf.indexOf("\r\n", offset);
+        if (lenEnd === -1) return null;
+        const len = Number(buf.toString("utf8", offset + 1, lenEnd));
+        const dataStart = lenEnd + 2;
+        const dataEnd = dataStart + len;
+        if (buf.length < dataEnd + 2) return null;
+        args.push(buf.toString("utf8", dataStart, dataEnd));
+        offset = dataEnd + 2;
+      }
+      buf = buf.subarray(offset);
+      return args;
+    };
+
+    socket.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      let cmd = tryParseCommand();
+      while (cmd) {
+        const verb = cmd[0]?.toUpperCase();
+        if (verb === "AUTH") {
+          authedWith.push(cmd.slice(1));
+          authed = cmd[cmd.length - 1] === opts?.requirePassword;
+          send(authed ? "+OK\r\n" : "-WRONGPASS invalid password\r\n");
+        } else if (!authed) {
+          send("-NOAUTH Authentication required.\r\n");
+        } else if (verb === "SELECT") {
+          send("+OK\r\n");
+        } else if (verb === "SET") {
+          store.set(cmd[1], cmd[2]);
+          send("+OK\r\n");
+        } else if (verb === "GET") {
+          const v = store.get(cmd[1]);
+          send(
+            v === undefined
+              ? "$-1\r\n"
+              : `$${Buffer.byteLength(v)}\r\n${v}\r\n`,
+          );
+        } else if (verb === "DEL") {
+          let n = 0;
+          for (const k of cmd.slice(1)) if (store.delete(k)) n++;
+          send(`:${n}\r\n`);
+        } else {
+          send("-ERR unknown command\r\n");
+        }
+        cmd = tryParseCommand();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as net.AddressInfo;
+  return {
+    port: addr.port,
+    store,
+    authedWith,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe("SandboxRegistry (native TCP transport)", () => {
+  let fake: FakeRedis;
+  afterEach(async () => {
+    await fake?.close();
+    vi.restoreAllMocks();
+  });
+
+  const tcpConfig = (port: number, auth = "") => ({
+    redisUrl: `redis://${auth}127.0.0.1:${port}`,
+    agentId: "char-tcp",
+    serverName: "sandbox-tcp",
+    serverUrl: "http://5.6.7.8:1999/api",
+    ttlSeconds: 90,
+  });
+
+  it("register() writes both keys over a redis:// socket", async () => {
+    fake = await startFakeRedis();
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+    await reg.register();
+    expect(fake.store.get("server:sandbox-tcp:url")).toBe(
+      "http://5.6.7.8:1999/api",
+    );
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
+  });
+
+  it("authenticates with the URL password before writing", async () => {
+    fake = await startFakeRedis({ requirePassword: "s3cret" });
+    const reg = new SandboxRegistry(tcpConfig(fake.port, "default:s3cret@"));
+    await reg.register();
+    expect(fake.authedWith).toContainEqual(["default", "s3cret"]);
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
+  });
+
+  it("unregister() deletes only keys still pointing at this sandbox", async () => {
+    fake = await startFakeRedis();
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+    await reg.register();
+    fake.store.set("agent:char-tcp:server", "sandbox-other");
+    await reg.unregister();
+    // agent key was overwritten -> kept; server url still ours -> deleted.
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-other");
+    expect(fake.store.has("server:sandbox-tcp:url")).toBe(false);
+  });
+
+  it("parses replies that arrive one byte at a time (fragmented reads)", async () => {
+    fake = await startFakeRedis({ fragmentReplies: true });
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+    await reg.register();
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
   });
 });

--- a/packages/agent/src/runtime/sandbox-registry.ts
+++ b/packages/agent/src/runtime/sandbox-registry.ts
@@ -1,6 +1,6 @@
 /**
  * SandboxRegistry (agent runtime) — self-registers a cloud-provisioned
- * container in the shared Upstash Redis so the multi-tenant gateways
+ * container in the shared Redis so the multi-tenant gateways
  * (`gateway-discord`, `gateway-webhook`) can resolve `agent_id -> server URL`
  * and forward inbound platform messages to THIS container.
  *
@@ -12,7 +12,8 @@
  * which CANNOT import `@elizaos/app-core` without creating an
  * `agent -> app-core -> agent` workspace cycle. The app-core copy therefore
  * never executes in a provisioned container. This is a deliberate, minimal
- * backport scoped to the container self-registration seam (Path A).
+ * backport scoped to the container self-registration seam (Path A). Keep the
+ * two copies in lock-step.
  *
  * It writes two Redis keys with a short TTL; a periodic heartbeat refreshes
  * the TTL while the container is alive, and `unregister()` deletes them on
@@ -23,21 +24,40 @@
  *   server:<serverName>:url = <serverUrl>   (resolver address)
  *   agent:<agentId>:server  = <serverName>  (agent -> server pointer)
  *
- * Implementation note: this uses the Upstash REST API directly via `fetch`
- * instead of the `@upstash/redis` SDK so it adds no new dependency to the
- * agent package (which is also bundled for mobile). The pipeline endpoint
- * applies both SET-with-EX commands atomically server-side.
+ * Two transports are supported, selected by the URL scheme so the same
+ * registry works before and after the managed Redis is migrated off Upstash:
+ *   - `http(s)://` — Upstash REST API via `fetch` (the pipeline endpoint
+ *     applies both SET-with-EX commands atomically server-side).
+ *   - `redis(s)://` — native RESP over a TCP socket (e.g. a Railway Redis
+ *     public proxy). Auth is carried inline in the URL, so no separate token
+ *     is required. This mirrors what the gateways already do
+ *     (`gateway-discord` / `gateway-webhook` both speak native TCP Redis).
+ * Neither path adds a runtime dependency to the agent package (which is also
+ * bundled for mobile): REST uses `fetch`, TCP uses the `node:net` builtin.
  */
 
+import net from "node:net";
+
 import { logger } from "@elizaos/core";
+
+/** Hard cap on a single TCP register/refresh round-trip. */
+const REGISTRY_TCP_TIMEOUT_MS = 10_000;
 
 function formatErr(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function isTcpRedisUrl(url: string): boolean {
+  return /^rediss?:\/\//i.test(url);
+}
+
 export interface SandboxRegistryConfig {
   redisUrl: string;
-  redisToken: string;
+  /**
+   * Bearer token for the Upstash REST transport. Not required (and ignored)
+   * for a `redis://` / `rediss://` URL, which carries auth inline.
+   */
+  redisToken?: string;
   agentId: string;
   serverName: string;
   serverUrl: string;
@@ -50,13 +70,16 @@ export interface SandboxRegistryConfig {
 
 export class SandboxRegistry {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly tcp: boolean;
 
-  constructor(private readonly config: SandboxRegistryConfig) {}
+  constructor(private readonly config: SandboxRegistryConfig) {
+    this.tcp = isTcpRedisUrl(config.redisUrl);
+  }
 
   async register(): Promise<void> {
     await this.writeKeys();
     logger.info(
-      `[sandbox-registry] Registered ${this.config.serverName} -> ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s)`,
+      `[sandbox-registry] Registered ${this.config.serverName} -> ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s, transport ${this.tcp ? "tcp" : "rest"})`,
     );
   }
 
@@ -110,10 +133,10 @@ export class SandboxRegistry {
   }
 
   /**
-   * Atomic two-key write via the Upstash REST pipeline endpoint. Both keys
-   * must succeed together — partial state would let gateways resolve
-   * `agent:X:server` to a stale `server:Y:url` value or miss a routing entry
-   * whose other half was just renewed.
+   * Atomic two-key write. Both keys must succeed together — partial state
+   * would let gateways resolve `agent:X:server` to a stale `server:Y:url`
+   * value or miss a routing entry whose other half was just renewed. REST uses
+   * the Upstash pipeline endpoint; TCP pipelines both commands on one socket.
    */
   private async writeKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
@@ -130,6 +153,10 @@ export class SandboxRegistry {
   }
 
   private async command(args: string[]): Promise<unknown> {
+    if (this.tcp) {
+      const [reply] = await this.tcpExec([args]);
+      return reply;
+    }
     const res = await fetch(this.config.redisUrl, {
       method: "POST",
       headers: {
@@ -149,6 +176,10 @@ export class SandboxRegistry {
   }
 
   private async pipeline(commands: string[][]): Promise<void> {
+    if (this.tcp) {
+      await this.tcpExec(commands);
+      return;
+    }
     const res = await fetch(`${this.config.redisUrl}/pipeline`, {
       method: "POST",
       headers: {
@@ -169,6 +200,162 @@ export class SandboxRegistry {
       }
     }
   }
+
+  /**
+   * Execute one or more commands over a native RESP/TCP connection and return
+   * the per-command replies (AUTH/SELECT preamble replies are stripped). One
+   * short-lived connection per call keeps the lifecycle trivial — the registry
+   * only writes twice per heartbeat (every 30s), so connection churn is
+   * negligible and there is no socket to leak if the container is killed.
+   */
+  private async tcpExec(commands: string[][]): Promise<unknown[]> {
+    const url = new URL(this.config.redisUrl);
+    const secure = url.protocol === "rediss:";
+    const host = url.hostname;
+    const port = url.port ? Number(url.port) : 6379;
+    const username = decodeURIComponent(url.username || "");
+    const password = decodeURIComponent(url.password || "");
+    const db = url.pathname.length > 1 ? url.pathname.slice(1) : "";
+
+    const preamble: string[][] = [];
+    if (password) {
+      // Redis 6+ ACL AUTH takes an optional username; the default user accepts
+      // the single-arg form too. Send the username only when it is explicit.
+      preamble.push(
+        username ? ["AUTH", username, password] : ["AUTH", password],
+      );
+    }
+    if (db) preamble.push(["SELECT", db]);
+    const all = [...preamble, ...commands];
+
+    // `node:tls` is imported lazily (only for `rediss://`) so the mobile
+    // bundle — which never reaches the TCP path — stays free of it.
+    const socket: net.Socket = secure
+      ? (await import("node:tls")).connect({ host, port, servername: host })
+      : net.connect({ host, port });
+
+    return new Promise<unknown[]>((resolve, reject) => {
+      let settled = false;
+      let buffer = Buffer.alloc(0);
+
+      const finish = (err: Error | null, replies?: unknown[]): void => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        if (err) reject(err);
+        else resolve(replies ?? []);
+      };
+
+      socket.setTimeout(REGISTRY_TCP_TIMEOUT_MS, () =>
+        finish(new Error("Redis TCP timeout")),
+      );
+      socket.on("error", (err) => finish(err));
+      const onConnect = (): void => {
+        socket.write(encodeRespCommands(all));
+      };
+      socket.once(secure ? "secureConnect" : "connect", onConnect);
+
+      socket.on("data", (chunk: Buffer) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        const parsed = parseRespReplies(buffer, all.length);
+        if (!parsed) return; // need more bytes
+        const firstErr = parsed.replies.find((r) => r instanceof RespError) as
+          | RespError
+          | undefined;
+        if (firstErr) {
+          finish(new Error(`Redis error: ${firstErr.message}`));
+          return;
+        }
+        // Strip the AUTH/SELECT preamble replies; return only command results.
+        finish(null, parsed.replies.slice(preamble.length));
+      });
+    });
+  }
+}
+
+/** A RESP `-ERR ...` reply, kept distinct so callers can detect failures. */
+class RespError {
+  constructor(public readonly message: string) {}
+}
+
+/** Encode commands as a single RESP2 buffer (inline pipelining). */
+function encodeRespCommands(commands: string[][]): Buffer {
+  const parts: Buffer[] = [];
+  for (const args of commands) {
+    parts.push(Buffer.from(`*${args.length}\r\n`));
+    for (const arg of args) {
+      const bytes = Buffer.from(arg);
+      parts.push(Buffer.from(`$${bytes.length}\r\n`));
+      parts.push(bytes);
+      parts.push(Buffer.from("\r\n"));
+    }
+  }
+  return Buffer.concat(parts);
+}
+
+/**
+ * Parse exactly `expected` top-level RESP replies from `buffer`. Returns the
+ * replies (with `-ERR` mapped to {@link RespError}) once all are present, or
+ * `null` when more bytes are still needed. Supports the reply types Redis
+ * returns for SET/GET/DEL/AUTH/SELECT: simple string, error, integer, bulk
+ * string (and null bulk), plus RESP3 null.
+ */
+function parseRespReplies(
+  buffer: Buffer,
+  expected: number,
+): { replies: unknown[] } | null {
+  const replies: unknown[] = [];
+  let offset = 0;
+
+  const parseOne = (): { value: unknown; next: number } | null => {
+    if (offset >= buffer.length) return null;
+    const type = buffer[offset];
+    const lineEnd = buffer.indexOf("\r\n", offset);
+    if (lineEnd === -1) return null;
+    const line = buffer.toString("utf8", offset + 1, lineEnd);
+    const afterLine = lineEnd + 2;
+    switch (type) {
+      case 0x2b: // '+' simple string
+        return { value: line, next: afterLine };
+      case 0x2d: // '-' error
+        return { value: new RespError(line), next: afterLine };
+      case 0x3a: // ':' integer
+        return { value: Number(line), next: afterLine };
+      case 0x5f: // '_' RESP3 null
+        return { value: null, next: afterLine };
+      case 0x24: {
+        // '$' bulk string
+        const len = Number(line);
+        if (len === -1) return { value: null, next: afterLine };
+        const end = afterLine + len;
+        if (buffer.length < end + 2) return null; // bulk + trailing CRLF
+        return {
+          value: buffer.toString("utf8", afterLine, end),
+          next: end + 2,
+        };
+      }
+      default:
+        // Unexpected/array reply — not produced by the registry's commands.
+        return {
+          value: new RespError(
+            `unsupported RESP type ${String.fromCharCode(type)}`,
+          ),
+          next: afterLine,
+        };
+    }
+  };
+
+  while (replies.length < expected) {
+    const savedOffset = offset;
+    const one = parseOne();
+    if (!one) {
+      offset = savedOffset;
+      return null;
+    }
+    replies.push(one.value);
+    offset = one.next;
+  }
+  return { replies };
 }
 
 /**
@@ -177,10 +364,11 @@ export class SandboxRegistry {
  * (e.g. local dev, non-Hetzner deployment). Caller must call `register()` and
  * `startHeartbeat(...)` after a successful boot.
  *
- * This is the FEATURE FLAG for container self-registration: when the five env
- * vars are absent (every non-provisioned runtime), this returns null and the
- * runtime behaves exactly as before. Only a cloud-provisioned container
- * carrying the full SANDBOX_REGISTRY_* set will register.
+ * This is the FEATURE FLAG for container self-registration: when the required
+ * env vars are absent (every non-provisioned runtime), this returns null and
+ * the runtime behaves exactly as before. Only a cloud-provisioned container
+ * carrying the full SANDBOX_REGISTRY_* set will register. A `redis://` URL
+ * needs no token (auth is inline); a `http(s)://` Upstash URL requires one.
  */
 export function buildSandboxRegistryFromEnv(
   env: NodeJS.ProcessEnv = process.env,
@@ -196,7 +384,14 @@ export function buildSandboxRegistryFromEnv(
   const serverName = env.SANDBOX_SERVER_NAME?.trim();
   const serverUrl = env.SANDBOX_PUBLIC_URL?.trim();
 
-  if (!redisUrl || !redisToken || !agentId || !serverName || !serverUrl) {
+  const tcp = !!redisUrl && isTcpRedisUrl(redisUrl);
+  if (
+    !redisUrl ||
+    (!tcp && !redisToken) ||
+    !agentId ||
+    !serverName ||
+    !serverUrl
+  ) {
     return null;
   }
 

--- a/packages/app-core/src/services/__tests__/sandbox-registry.test.ts
+++ b/packages/app-core/src/services/__tests__/sandbox-registry.test.ts
@@ -1,87 +1,71 @@
 /**
- * Unit tests for SandboxRegistry. The Upstash REST client is mocked at the
- * module boundary (`@upstash/redis`) so we can record the exact key/value/TTL
- * triples that would be sent to Redis. Everything else runs the real
- * production code path.
+ * Unit tests for SandboxRegistry. The registry speaks two transports selected
+ * by URL scheme: Upstash REST (`https://`, exercised via a mocked `fetch`) and
+ * native RESP/TCP (`redis://`, exercised against an in-process fake Redis).
+ * Everything else runs the real production code path. Mirrors the agent-copy
+ * test (`packages/agent/src/runtime/__tests__/sandbox-registry.test.ts`).
  */
 
+import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface PipelineCall {
-  type: "set";
-  key: string;
-  value: string;
-  opts?: { ex?: number };
-}
-
-interface DelCall {
-  type: "del";
-  keys: string[];
-}
-
-type RedisCall = PipelineCall | DelCall;
-
-const mocks = vi.hoisted(() => ({
-  calls: [] as RedisCall[],
-  values: new Map<string, string>(),
-  nextPipelineFails: false,
-}));
-
-vi.mock("@upstash/redis", () => {
-  class FakePipeline {
-    private willThrow: boolean;
-    constructor(willThrow: boolean) {
-      this.willThrow = willThrow;
-    }
-    set(key: string, value: string, opts?: { ex?: number }): this {
-      if (!this.willThrow) {
-        mocks.calls.push({ type: "set", key, value, opts });
-        mocks.values.set(key, value);
-      }
-      return this;
-    }
-    async exec(): Promise<unknown[]> {
-      if (this.willThrow) {
-        throw new Error("simulated upstash failure");
-      }
-      return [];
-    }
-  }
-
-  class FakeRedis {
-    pipeline(): FakePipeline {
-      const willThrow = mocks.nextPipelineFails;
-      mocks.nextPipelineFails = false;
-      return new FakePipeline(willThrow);
-    }
-    async del(...keys: string[]): Promise<number> {
-      mocks.calls.push({ type: "del", keys });
-      for (const key of keys) {
-        mocks.values.delete(key);
-      }
-      return keys.length;
-    }
-    async get(key: string): Promise<string | null> {
-      return mocks.values.get(key) ?? null;
-    }
-  }
-
-  return { Redis: FakeRedis };
-});
-
 vi.mock("@elizaos/core", () => ({
-  logger: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 import {
   buildSandboxRegistryFromEnv,
   SandboxRegistry,
 } from "../sandbox-registry";
+
+interface Recorded {
+  url: string;
+  body: unknown;
+}
+
+const recorded: Recorded[] = [];
+const store = new Map<string, string>();
+let failNextFetch = false;
+
+function installFetch(): void {
+  recorded.length = 0;
+  store.clear();
+  failNextFetch = false;
+  global.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    if (failNextFetch) {
+      failNextFetch = false;
+      throw new Error("simulated upstash failure");
+    }
+    const url = String(input);
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    recorded.push({ url, body });
+
+    if (url.endsWith("/pipeline")) {
+      for (const cmd of body as string[][]) {
+        if (cmd[0] === "SET") store.set(cmd[1], cmd[2]);
+      }
+      return {
+        ok: true,
+        json: async () => (body as unknown[]).map(() => ({ result: "OK" })),
+      } as unknown as Response;
+    }
+    const cmd = body as string[];
+    if (cmd[0] === "GET") {
+      return {
+        ok: true,
+        json: async () => ({ result: store.get(cmd[1]) ?? null }),
+      } as unknown as Response;
+    }
+    if (cmd[0] === "DEL") {
+      for (const k of cmd.slice(1)) store.delete(k);
+      return {
+        ok: true,
+        json: async () => ({ result: cmd.length - 1 }),
+      } as unknown as Response;
+    }
+    return { ok: true, json: async () => ({ result: null }) } as Response;
+  }) as unknown as typeof fetch;
+}
 
 const CONFIG = {
   redisUrl: "https://example.upstash.io",
@@ -92,83 +76,60 @@ const CONFIG = {
   ttlSeconds: 60,
 };
 
-describe("SandboxRegistry", () => {
-  beforeEach(() => {
-    mocks.calls.length = 0;
-    mocks.values.clear();
-    mocks.nextPipelineFails = false;
-  });
-
+describe("SandboxRegistry (Upstash REST transport)", () => {
+  beforeEach(() => installFetch());
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("register() writes both routing keys with the configured TTL", async () => {
     const registry = new SandboxRegistry(CONFIG);
     await registry.register();
 
-    const sets = mocks.calls.filter((c) => c.type === "set") as PipelineCall[];
-    expect(sets).toHaveLength(2);
-    expect(sets[0]).toEqual({
-      type: "set",
-      key: "server:sandbox-agent-42:url",
-      value: "http://10.0.0.7:18791",
-      opts: { ex: 60 },
-    });
-    expect(sets[1]).toEqual({
-      type: "set",
-      key: "agent:agent-42:server",
-      value: "sandbox-agent-42",
-      opts: { ex: 60 },
-    });
-  });
-
-  it("refresh() reissues the same two writes (idempotent)", async () => {
-    const registry = new SandboxRegistry(CONFIG);
-    await registry.register();
-    mocks.calls.length = 0;
-
-    await registry.refresh();
-
-    const sets = mocks.calls.filter((c) => c.type === "set") as PipelineCall[];
-    expect(sets).toHaveLength(2);
-    expect(sets.map((s) => s.key)).toEqual([
+    const pipe = recorded.find((r) => r.url.endsWith("/pipeline"));
+    const cmds = pipe?.body as string[][];
+    expect(cmds).toContainEqual([
+      "SET",
       "server:sandbox-agent-42:url",
-      "agent:agent-42:server",
+      "http://10.0.0.7:18791",
+      "EX",
+      "60",
     ]);
-    expect(sets.every((s) => s.opts?.ex === 60)).toBe(true);
+    expect(cmds).toContainEqual([
+      "SET",
+      "agent:agent-42:server",
+      "sandbox-agent-42",
+      "EX",
+      "60",
+    ]);
   });
 
   it("unregister() deletes only keys that still point at this sandbox", async () => {
     const registry = new SandboxRegistry(CONFIG);
     await registry.register();
-    mocks.values.set("agent:agent-42:server", "sandbox-agent-42-replacement");
-    mocks.calls.length = 0;
-
+    store.set("agent:agent-42:server", "sandbox-agent-42-replacement");
     await registry.unregister();
-
-    const dels = mocks.calls.filter((c) => c.type === "del") as DelCall[];
-    expect(dels).toHaveLength(1);
-    expect(dels[0]?.keys).toEqual(["server:sandbox-agent-42:url"]);
+    expect(store.has("server:sandbox-agent-42:url")).toBe(false);
+    expect(store.get("agent:agent-42:server")).toBe(
+      "sandbox-agent-42-replacement",
+    );
   });
 
   it("startHeartbeat() refreshes on the interval; errors do not kill the timer", async () => {
     vi.useFakeTimers();
     const registry = new SandboxRegistry(CONFIG);
     await registry.register();
-    mocks.calls.length = 0;
+    recorded.length = 0;
 
     registry.startHeartbeat(30_000);
 
-    mocks.nextPipelineFails = true;
+    failNextFetch = true;
     await vi.advanceTimersByTimeAsync(30_000);
-    // Failing tick: the FakePipeline.set short-circuits without recording when
-    // willThrow is set, and exec() then rejects. The handler in
-    // startHeartbeat caught the error so the next tick still runs.
-    expect(mocks.calls.filter((c) => c.type === "set")).toHaveLength(0);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(30_000);
-    expect(mocks.calls.filter((c) => c.type === "set")).toHaveLength(2);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
 
     registry.stopHeartbeat();
   });
@@ -177,16 +138,18 @@ describe("SandboxRegistry", () => {
     vi.useFakeTimers();
     const registry = new SandboxRegistry(CONFIG);
     await registry.register();
-    mocks.calls.length = 0;
+    recorded.length = 0;
 
     registry.startHeartbeat(30_000);
     registry.stopHeartbeat();
 
     await vi.advanceTimersByTimeAsync(120_000);
-    expect(mocks.calls).toHaveLength(0);
+    expect(recorded).toHaveLength(0);
   });
+});
 
-  it("buildSandboxRegistryFromEnv() returns null when any required var is missing", () => {
+describe("buildSandboxRegistryFromEnv", () => {
+  it("returns null when any required var is missing (REST URL needs a token)", () => {
     const complete = {
       SANDBOX_REGISTRY_REDIS_URL: "https://x.upstash.io",
       SANDBOX_REGISTRY_REDIS_TOKEN: "t",
@@ -202,15 +165,119 @@ describe("SandboxRegistry", () => {
     }
   });
 
-  it("buildSandboxRegistryFromEnv() trims whitespace and rejects whitespace-only values", () => {
+  it("accepts a redis:// URL with no token (TCP carries auth inline)", () => {
+    expect(
+      buildSandboxRegistryFromEnv({
+        SANDBOX_REGISTRY_REDIS_URL: "redis://default:pw@host:6379",
+        SANDBOX_AGENT_ID: "a",
+        SANDBOX_SERVER_NAME: "s",
+        SANDBOX_PUBLIC_URL: "http://1.2.3.4:1",
+      }),
+    ).not.toBeNull();
+  });
+
+  it("trims whitespace and rejects whitespace-only values", () => {
     expect(
       buildSandboxRegistryFromEnv({
         SANDBOX_REGISTRY_REDIS_URL: "https://x.upstash.io",
         SANDBOX_REGISTRY_REDIS_TOKEN: "t",
         SANDBOX_AGENT_ID: "a",
         SANDBOX_SERVER_NAME: "s",
-        SANDBOX_PUBLIC_URL: "   ", // whitespace only
+        SANDBOX_PUBLIC_URL: "   ",
       }),
     ).toBeNull();
+  });
+});
+
+/**
+ * In-process RESP server: parses the client's RESP2 command stream and replies
+ * like Redis, exercising the native TCP transport end-to-end without an
+ * external Redis.
+ */
+interface FakeRedis {
+  port: number;
+  store: Map<string, string>;
+  close: () => Promise<void>;
+}
+
+async function startFakeRedis(): Promise<FakeRedis> {
+  const store = new Map<string, string>();
+  const server = net.createServer((socket) => {
+    let buf = Buffer.alloc(0);
+    const tryParseCommand = (): string[] | null => {
+      if (buf.length === 0 || buf[0] !== 0x2a) return null;
+      const headerEnd = buf.indexOf("\r\n");
+      if (headerEnd === -1) return null;
+      const argc = Number(buf.toString("utf8", 1, headerEnd));
+      let offset = headerEnd + 2;
+      const args: string[] = [];
+      for (let i = 0; i < argc; i++) {
+        if (buf[offset] !== 0x24) return null;
+        const lenEnd = buf.indexOf("\r\n", offset);
+        if (lenEnd === -1) return null;
+        const len = Number(buf.toString("utf8", offset + 1, lenEnd));
+        const dataStart = lenEnd + 2;
+        const dataEnd = dataStart + len;
+        if (buf.length < dataEnd + 2) return null;
+        args.push(buf.toString("utf8", dataStart, dataEnd));
+        offset = dataEnd + 2;
+      }
+      buf = buf.subarray(offset);
+      return args;
+    };
+    socket.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      let cmd = tryParseCommand();
+      while (cmd) {
+        const verb = cmd[0]?.toUpperCase();
+        if (verb === "AUTH" || verb === "SELECT") socket.write("+OK\r\n");
+        else if (verb === "SET") {
+          store.set(cmd[1], cmd[2]);
+          socket.write("+OK\r\n");
+        } else if (verb === "GET") {
+          const v = store.get(cmd[1]);
+          socket.write(
+            v === undefined
+              ? "$-1\r\n"
+              : `$${Buffer.byteLength(v)}\r\n${v}\r\n`,
+          );
+        } else if (verb === "DEL") {
+          let n = 0;
+          for (const k of cmd.slice(1)) if (store.delete(k)) n++;
+          socket.write(`:${n}\r\n`);
+        } else socket.write("-ERR unknown\r\n");
+        cmd = tryParseCommand();
+      }
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as net.AddressInfo;
+  return {
+    port: addr.port,
+    store,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe("SandboxRegistry (native TCP transport)", () => {
+  let fake: FakeRedis;
+  afterEach(async () => {
+    await fake?.close();
+  });
+
+  it("register()/unregister() round-trip over a redis:// socket", async () => {
+    fake = await startFakeRedis();
+    const reg = new SandboxRegistry({
+      ...CONFIG,
+      redisUrl: `redis://default:pw@127.0.0.1:${fake.port}`,
+      redisToken: undefined,
+    });
+    await reg.register();
+    expect(fake.store.get("agent:agent-42:server")).toBe("sandbox-agent-42");
+    await reg.unregister();
+    expect(fake.store.has("agent:agent-42:server")).toBe(false);
   });
 });

--- a/packages/app-core/src/services/sandbox-registry.ts
+++ b/packages/app-core/src/services/sandbox-registry.ts
@@ -1,8 +1,13 @@
 /**
- * SandboxRegistry — self-registers the sandbox container in the shared
- * Upstash Redis so the multi-tenant gateways (`gateway-discord`,
- * `gateway-webhook`) can resolve `agent_id → server URL` and forward inbound
- * platform messages here.
+ * SandboxRegistry — self-registers the sandbox container in the shared Redis
+ * so the multi-tenant gateways (`gateway-discord`, `gateway-webhook`) can
+ * resolve `agent_id -> server URL` and forward inbound platform messages here.
+ *
+ * This is a deliberate duplicate of `packages/agent/src/runtime/sandbox-registry.ts`:
+ * the published cloud image runs the agent runtime entrypoint, which cannot
+ * import `@elizaos/app-core` without an `agent -> app-core -> agent` cycle, so
+ * the agent copy is the one that executes in a provisioned container. Keep the
+ * two copies in lock-step.
  *
  * Two Redis keys are written with a short TTL; a periodic heartbeat refreshes
  * the TTL while the sandbox is alive, and `unregister()` deletes them on
@@ -11,19 +16,39 @@
  * address.
  *
  *   server:<serverName>:url = <serverUrl>   (resolver address)
- *   agent:<agentId>:server  = <serverName>  (agent → server pointer)
+ *   agent:<agentId>:server  = <serverName>  (agent -> server pointer)
  *
- * The write pattern mirrors `packages/cloud-services/agent-server/src/agent-manager.ts:refreshRedisState`
- * but is stripped to a single-tenant sandbox: one agent, one server, no
- * capacity bookkeeping.
+ * Two transports are supported, selected by the URL scheme so the same
+ * registry works before and after the managed Redis is migrated off Upstash:
+ *   - `http(s)://` — Upstash REST API via `fetch` (the pipeline endpoint
+ *     applies both SET-with-EX commands atomically server-side).
+ *   - `redis(s)://` — native RESP over a TCP socket (e.g. a Railway Redis
+ *     public proxy). Auth is carried inline in the URL, so no separate token
+ *     is required.
  */
 
+import net from "node:net";
+
 import { logger } from "@elizaos/core";
-import { Redis } from "@upstash/redis";
+
+/** Hard cap on a single TCP register/refresh round-trip. */
+const REGISTRY_TCP_TIMEOUT_MS = 10_000;
+
+function formatErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isTcpRedisUrl(url: string): boolean {
+  return /^rediss?:\/\//i.test(url);
+}
 
 export interface SandboxRegistryConfig {
   redisUrl: string;
-  redisToken: string;
+  /**
+   * Bearer token for the Upstash REST transport. Not required (and ignored)
+   * for a `redis://` / `rediss://` URL, which carries auth inline.
+   */
+  redisToken?: string;
   agentId: string;
   serverName: string;
   serverUrl: string;
@@ -32,17 +57,17 @@ export interface SandboxRegistryConfig {
 }
 
 export class SandboxRegistry {
-  private readonly redis: Redis;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly tcp: boolean;
 
   constructor(private readonly config: SandboxRegistryConfig) {
-    this.redis = new Redis({ url: config.redisUrl, token: config.redisToken });
+    this.tcp = isTcpRedisUrl(config.redisUrl);
   }
 
   async register(): Promise<void> {
     await this.writeKeys();
     logger.info(
-      `[sandbox-registry] Registered ${this.config.serverName} → ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s)`,
+      `[sandbox-registry] Registered ${this.config.serverName} -> ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s, transport ${this.tcp ? "tcp" : "rest"})`,
     );
   }
 
@@ -55,14 +80,14 @@ export class SandboxRegistry {
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
     const [registeredUrl, registeredServer] = await Promise.all([
-      this.redis.get<string>(serverUrlKey),
-      this.redis.get<string>(agentServerKey),
+      this.get(serverUrlKey),
+      this.get(agentServerKey),
     ]);
     const keysToDelete: string[] = [];
     if (registeredUrl === serverUrl) keysToDelete.push(serverUrlKey);
     if (registeredServer === serverName) keysToDelete.push(agentServerKey);
     if (keysToDelete.length > 0) {
-      await this.redis.del(...keysToDelete);
+      await this.command(["DEL", ...keysToDelete]);
     }
     logger.info(
       `[sandbox-registry] Unregistered ${serverName} (agent ${agentId})`,
@@ -75,7 +100,7 @@ export class SandboxRegistry {
     this.heartbeatTimer = setInterval(() => {
       void this.refresh().catch((err) => {
         logger.warn(
-          `[sandbox-registry] Heartbeat refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+          `[sandbox-registry] Heartbeat refresh failed: ${formatErr(err)}`,
         );
       });
     }, intervalMs);
@@ -96,26 +121,231 @@ export class SandboxRegistry {
   }
 
   /**
-   * Atomic two-key write via Upstash pipeline. Both keys must succeed
-   * together — partial state would let gateways resolve `agent:X:server` to
-   * a stale `server:Y:url` value or miss a routing entry whose other half
-   * was just renewed.
+   * Atomic two-key write. Both keys must succeed together — partial state
+   * would let gateways resolve `agent:X:server` to a stale `server:Y:url`
+   * value or miss a routing entry whose other half was just renewed. REST uses
+   * the Upstash pipeline endpoint; TCP pipelines both commands on one socket.
    */
   private async writeKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
-    await this.redis
-      .pipeline()
-      .set(`server:${serverName}:url`, serverUrl, { ex: ttlSeconds })
-      .set(`agent:${agentId}:server`, serverName, { ex: ttlSeconds })
-      .exec();
+    const ttl = String(ttlSeconds);
+    await this.pipeline([
+      ["SET", `server:${serverName}:url`, serverUrl, "EX", ttl],
+      ["SET", `agent:${agentId}:server`, serverName, "EX", ttl],
+    ]);
   }
+
+  private async get(key: string): Promise<string | null> {
+    const result = await this.command(["GET", key]);
+    return typeof result === "string" ? result : null;
+  }
+
+  private async command(args: string[]): Promise<unknown> {
+    if (this.tcp) {
+      const [reply] = await this.tcpExec([args]);
+      return reply;
+    }
+    const res = await fetch(this.config.redisUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.redisToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(args),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Upstash command failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const json = (await res.json()) as { result?: unknown; error?: string };
+    if (json.error) throw new Error(`Upstash error: ${json.error}`);
+    return json.result;
+  }
+
+  private async pipeline(commands: string[][]): Promise<void> {
+    if (this.tcp) {
+      await this.tcpExec(commands);
+      return;
+    }
+    const res = await fetch(`${this.config.redisUrl}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.redisToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(commands),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Upstash pipeline failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const json = (await res.json()) as Array<{ error?: string }>;
+    if (Array.isArray(json)) {
+      for (const entry of json) {
+        if (entry?.error) throw new Error(`Upstash error: ${entry.error}`);
+      }
+    }
+  }
+
+  /**
+   * Execute one or more commands over a native RESP/TCP connection and return
+   * the per-command replies (AUTH/SELECT preamble replies are stripped). One
+   * short-lived connection per call keeps the lifecycle trivial — the registry
+   * only writes twice per heartbeat, so connection churn is negligible.
+   */
+  private async tcpExec(commands: string[][]): Promise<unknown[]> {
+    const url = new URL(this.config.redisUrl);
+    const secure = url.protocol === "rediss:";
+    const host = url.hostname;
+    const port = url.port ? Number(url.port) : 6379;
+    const username = decodeURIComponent(url.username || "");
+    const password = decodeURIComponent(url.password || "");
+    const db = url.pathname.length > 1 ? url.pathname.slice(1) : "";
+
+    const preamble: string[][] = [];
+    if (password) {
+      preamble.push(
+        username ? ["AUTH", username, password] : ["AUTH", password],
+      );
+    }
+    if (db) preamble.push(["SELECT", db]);
+    const all = [...preamble, ...commands];
+
+    // `node:tls` is imported lazily (only for `rediss://`) so the mobile
+    // bundle — which never reaches the TCP path — stays free of it.
+    const socket: net.Socket = secure
+      ? (await import("node:tls")).connect({ host, port, servername: host })
+      : net.connect({ host, port });
+
+    return new Promise<unknown[]>((resolve, reject) => {
+      let settled = false;
+      let buffer = Buffer.alloc(0);
+
+      const finish = (err: Error | null, replies?: unknown[]): void => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        if (err) reject(err);
+        else resolve(replies ?? []);
+      };
+
+      socket.setTimeout(REGISTRY_TCP_TIMEOUT_MS, () =>
+        finish(new Error("Redis TCP timeout")),
+      );
+      socket.on("error", (err) => finish(err));
+      const onConnect = (): void => {
+        socket.write(encodeRespCommands(all));
+      };
+      socket.once(secure ? "secureConnect" : "connect", onConnect);
+
+      socket.on("data", (chunk: Buffer) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        const parsed = parseRespReplies(buffer, all.length);
+        if (!parsed) return; // need more bytes
+        const firstErr = parsed.replies.find((r) => r instanceof RespError) as
+          | RespError
+          | undefined;
+        if (firstErr) {
+          finish(new Error(`Redis error: ${firstErr.message}`));
+          return;
+        }
+        // Strip the AUTH/SELECT preamble replies; return only command results.
+        finish(null, parsed.replies.slice(preamble.length));
+      });
+    });
+  }
+}
+
+/** A RESP `-ERR ...` reply, kept distinct so callers can detect failures. */
+class RespError {
+  constructor(public readonly message: string) {}
+}
+
+/** Encode commands as a single RESP2 buffer (inline pipelining). */
+function encodeRespCommands(commands: string[][]): Buffer {
+  const parts: Buffer[] = [];
+  for (const args of commands) {
+    parts.push(Buffer.from(`*${args.length}\r\n`));
+    for (const arg of args) {
+      const bytes = Buffer.from(arg);
+      parts.push(Buffer.from(`$${bytes.length}\r\n`));
+      parts.push(bytes);
+      parts.push(Buffer.from("\r\n"));
+    }
+  }
+  return Buffer.concat(parts);
+}
+
+/**
+ * Parse exactly `expected` top-level RESP replies from `buffer`. Returns the
+ * replies (with `-ERR` mapped to {@link RespError}) once all are present, or
+ * `null` when more bytes are still needed.
+ */
+function parseRespReplies(
+  buffer: Buffer,
+  expected: number,
+): { replies: unknown[] } | null {
+  const replies: unknown[] = [];
+  let offset = 0;
+
+  const parseOne = (): { value: unknown; next: number } | null => {
+    if (offset >= buffer.length) return null;
+    const type = buffer[offset];
+    const lineEnd = buffer.indexOf("\r\n", offset);
+    if (lineEnd === -1) return null;
+    const line = buffer.toString("utf8", offset + 1, lineEnd);
+    const afterLine = lineEnd + 2;
+    switch (type) {
+      case 0x2b: // '+' simple string
+        return { value: line, next: afterLine };
+      case 0x2d: // '-' error
+        return { value: new RespError(line), next: afterLine };
+      case 0x3a: // ':' integer
+        return { value: Number(line), next: afterLine };
+      case 0x5f: // '_' RESP3 null
+        return { value: null, next: afterLine };
+      case 0x24: {
+        // '$' bulk string
+        const len = Number(line);
+        if (len === -1) return { value: null, next: afterLine };
+        const end = afterLine + len;
+        if (buffer.length < end + 2) return null; // bulk + trailing CRLF
+        return {
+          value: buffer.toString("utf8", afterLine, end),
+          next: end + 2,
+        };
+      }
+      default:
+        return {
+          value: new RespError(
+            `unsupported RESP type ${String.fromCharCode(type)}`,
+          ),
+          next: afterLine,
+        };
+    }
+  };
+
+  while (replies.length < expected) {
+    const savedOffset = offset;
+    const one = parseOne();
+    if (!one) {
+      offset = savedOffset;
+      return null;
+    }
+    replies.push(one.value);
+    offset = one.next;
+  }
+  return { replies };
 }
 
 /**
  * Reads the SANDBOX_REGISTRY_* and SANDBOX_* env vars and returns a fully
  * wired `SandboxRegistry`, or `null` if the sandbox context is not
  * configured (e.g. local dev, non-Hetzner deployment). Caller must call
- * `register()` and `startHeartbeat(...)` after a successful boot.
+ * `register()` and `startHeartbeat(...)` after a successful boot. A `redis://`
+ * URL needs no token (auth is inline); a `http(s)://` Upstash URL requires one.
  */
 export function buildSandboxRegistryFromEnv(
   env: NodeJS.ProcessEnv = process.env,
@@ -127,7 +357,14 @@ export function buildSandboxRegistryFromEnv(
   const serverName = env.SANDBOX_SERVER_NAME?.trim();
   const serverUrl = env.SANDBOX_PUBLIC_URL?.trim();
 
-  if (!redisUrl || !redisToken || !agentId || !serverName || !serverUrl) {
+  const tcp = !!redisUrl && isTcpRedisUrl(redisUrl);
+  if (
+    !redisUrl ||
+    (!tcp && !redisToken) ||
+    !agentId ||
+    !serverName ||
+    !serverUrl
+  ) {
     return null;
   }
 

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1055,17 +1055,34 @@ export class DockerSandboxProvider implements SandboxProvider {
         stewardTenant.apiKey,
       );
 
-      // Pass the shared Upstash credentials through to the sandbox so it can
-      // self-register `agent:<id>:server` + `server:<name>:url` keys that
-      // gateway-discord / gateway-webhook resolve for inbound platform
-      // messages. Omit when the orchestrator env doesn't carry them — the
-      // sandbox will skip registration silently in that case.
-      const registryRedisUrl = process.env.KV_REST_API_URL?.trim() ?? "";
-      const registryRedisToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
-      const canSelfRegister = registryRedisUrl !== "" && registryRedisToken !== "";
+      // Pass a registry backend through to the sandbox so it can self-register
+      // `agent:<id>:server` + `server:<name>:url` keys that gateway-discord /
+      // gateway-webhook resolve for inbound platform messages. The sandbox runs
+      // on a Hetzner core node, so the URL must be reachable FROM THERE — a
+      // public-proxy `redis://` URL (e.g. Railway) or an Upstash REST endpoint,
+      // never a `*.railway.internal` host. Resolution order:
+      //   1. SANDBOX_REGISTRY_REDIS_URL (+ optional _TOKEN): explicit operator
+      //      override. A `redis://` / `rediss://` URL carries its own auth, so
+      //      no token is needed; an `https://` Upstash URL needs the token.
+      //   2. KV_REST_API_URL + KV_REST_API_TOKEN: legacy Upstash REST.
+      // Omit when neither is configured — the sandbox skips registration.
+      const explicitRegistryUrl = process.env.SANDBOX_REGISTRY_REDIS_URL?.trim() ?? "";
+      const explicitRegistryToken = process.env.SANDBOX_REGISTRY_REDIS_TOKEN?.trim() ?? "";
+      const kvRestUrl = process.env.KV_REST_API_URL?.trim() ?? "";
+      const kvRestToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
+      const registryRedisUrl = explicitRegistryUrl || kvRestUrl;
+      const registryRedisToken = explicitRegistryUrl ? explicitRegistryToken : kvRestToken;
+      const registryIsTcp = /^rediss?:\/\//i.test(registryRedisUrl);
+      // TCP URLs carry auth inline; REST endpoints require a bearer token.
+      const canSelfRegister =
+        registryRedisUrl !== "" && (registryIsTcp || registryRedisToken !== "");
       if (!canSelfRegister) {
         logger.warn(
-          "[docker-sandbox] KV_REST_API_URL / KV_REST_API_TOKEN missing from orchestrator env — sandbox will not register in Redis and gateways will not route inbound platform messages to it",
+          "[docker-sandbox] No sandbox registry backend configured — set SANDBOX_REGISTRY_REDIS_URL to a sandbox-reachable redis:// proxy, or KV_REST_API_URL/KV_REST_API_TOKEN to an Upstash REST endpoint. Sandbox will not register in Redis and gateways will not route inbound platform (Discord/Telegram) messages to it",
+        );
+      } else if (!registryIsTcp && !/^https?:\/\//i.test(registryRedisUrl)) {
+        logger.warn(
+          `[docker-sandbox] Sandbox registry URL has an unexpected scheme (${registryRedisUrl.split(":")[0]}:) — expected redis(s):// or http(s)://. Registration may fail`,
         );
       }
 
@@ -1119,7 +1136,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         ...(canSelfRegister
           ? {
               SANDBOX_REGISTRY_REDIS_URL: registryRedisUrl,
-              SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken,
+              // Only the REST transport needs a token; a redis:// URL omits it.
+              ...(registryRedisToken ? { SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken } : {}),
               SANDBOX_AGENT_ID: agentId,
               // The gateways route by the platform character_id, so the
               // container must register under (and answer as) that id, not

--- a/packages/ui/src/api/client-cloud-pairing.test.ts
+++ b/packages/ui/src/api/client-cloud-pairing.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the dedicated-agent pairing flow (`pairDedicatedCloudAgent`).
+ * The native CapacitorHttp transport is mocked and routed by URL so we exercise
+ * the real client chain: mint pairing-token (auto-resume 202 loop) -> exchange
+ * at /api/auth/pair (origin-bound) -> bind target. Mirrors the harness in
+ * `client-cloud-direct-auth.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const capacitorMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  request: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => true },
+  CapacitorHttp: {
+    get: capacitorMocks.get,
+    post: capacitorMocks.post,
+    request: capacitorMocks.request,
+  },
+}));
+
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-cloud";
+
+interface NativeReq {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  data?: unknown;
+}
+
+const VALID_TOKEN = "A".repeat(43);
+const AGENT_ORIGIN = "https://abc123.elizacloud.ai";
+
+function makeClient(): ElizaClient {
+  const client = new ElizaClient();
+  // Bind to a direct-cloud base so resolveDirectCloudClientApiBase resolves.
+  client.setBaseUrl("https://api.elizacloud.ai");
+  return client;
+}
+
+describe("pairDedicatedCloudAgent", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {}, cloudApiBase: "https://www.elizacloud.ai" });
+    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+      "cloud-tok";
+    capacitorMocks.request.mockReset();
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("pairs a running agent and returns the bind target with the agent key", async () => {
+    const seen: NativeReq[] = [];
+    capacitorMocks.request.mockImplementation(async (req: NativeReq) => {
+      seen.push(req);
+      if (req.url.endsWith("/pairing-token")) {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              token: VALID_TOKEN,
+              redirectUrl: `${AGENT_ORIGIN}/pair?token=${VALID_TOKEN}`,
+              expiresIn: 60,
+            },
+          },
+        };
+      }
+      if (req.url.endsWith("/api/auth/pair")) {
+        return {
+          status: 200,
+          data: { apiKey: "agent-secret-key", agentName: "Nyx" },
+        };
+      }
+      throw new Error(`unexpected url ${req.url}`);
+    });
+
+    const client = makeClient();
+    const result = await client.pairDedicatedCloudAgent("agent-1");
+
+    expect(result).toEqual({
+      status: "paired",
+      apiBase: AGENT_ORIGIN,
+      agentToken: "agent-secret-key",
+      agentName: "Nyx",
+    });
+
+    // The exchange MUST be origin-bound to the agent web UI origin.
+    const exchange = seen.find((r) => r.url.endsWith("/api/auth/pair"));
+    expect(exchange?.headers?.Origin).toBe(AGENT_ORIGIN);
+    expect(exchange?.data).toEqual({ token: VALID_TOKEN });
+  });
+
+  it("waits through a 202 'starting' (cold boot) before pairing", async () => {
+    vi.useFakeTimers();
+    let pairingCalls = 0;
+    const progress: string[] = [];
+    capacitorMocks.request.mockImplementation(async (req: NativeReq) => {
+      if (req.url.endsWith("/pairing-token")) {
+        pairingCalls++;
+        if (pairingCalls === 1) {
+          return {
+            status: 202,
+            data: {
+              success: true,
+              data: {
+                status: "starting",
+                jobId: "job-1",
+                retryAfterMs: 5000,
+                message: "Resuming…",
+              },
+            },
+          };
+        }
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              token: VALID_TOKEN,
+              redirectUrl: `${AGENT_ORIGIN}/pair?token=${VALID_TOKEN}`,
+              expiresIn: 60,
+            },
+          },
+        };
+      }
+      return { status: 200, data: { apiKey: "k", agentName: "A" } };
+    });
+
+    const client = makeClient();
+    const promise = client.pairDedicatedCloudAgent("agent-1", {
+      onProgress: (s) => progress.push(s),
+    });
+    // Let the first poll resolve, then advance past the retry wait.
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(pairingCalls).toBe(2);
+    expect(progress).toContain("starting");
+    expect(result.status).toBe("paired");
+  });
+
+  it("returns manual_auth when the agent only offers its own password screen", async () => {
+    capacitorMocks.request.mockImplementation(async (req: NativeReq) => {
+      if (req.url.endsWith("/pairing-token")) {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            // No /pair?token= — bare web UI URL signals password-only auth.
+            data: {
+              token: VALID_TOKEN,
+              redirectUrl: AGENT_ORIGIN,
+              expiresIn: 60,
+            },
+          },
+        };
+      }
+      throw new Error("exchange should not be attempted for manual_auth");
+    });
+
+    const client = makeClient();
+    const result = await client.pairDedicatedCloudAgent("agent-1");
+    expect(result).toEqual({ status: "manual_auth", webUiUrl: AGENT_ORIGIN });
+  });
+
+  it("throws when the agent never finishes starting before the deadline", async () => {
+    capacitorMocks.request.mockImplementation(async (req: NativeReq) => {
+      if (req.url.endsWith("/pairing-token")) {
+        return {
+          status: 202,
+          data: {
+            success: true,
+            data: { status: "starting", retryAfterMs: 5000 },
+          },
+        };
+      }
+      throw new Error("exchange should not run");
+    });
+
+    const client = makeClient();
+    await expect(
+      // timeoutMs:0 -> deadline already passed, throws after the first 202.
+      client.pairDedicatedCloudAgent("agent-1", { timeoutMs: 0 }),
+    ).rejects.toThrow(/Timed out waiting/);
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1162,11 +1162,54 @@ declare module "./client-base" {
       data?: CloudCompatLaunchResult;
       error?: string;
     }>;
-    /** Fetch a pairing token for a cloud agent (for opening Web UI in a new tab). */
+    /**
+     * Fetch a pairing token for a cloud agent. When the agent is not running,
+     * the server kicks off a resume and returns a 202 `{ status: "starting",
+     * jobId, retryAfterMs }` body instead of a token — poll again after the
+     * suggested interval. See `pairDedicatedCloudAgent` for the full loop.
+     */
     getCloudCompatPairingToken(agentId: string): Promise<{
       success: boolean;
-      data: { token: string; redirectUrl: string; expiresIn: number };
+      data: {
+        token?: string;
+        redirectUrl?: string;
+        expiresIn?: number;
+        status?: string;
+        jobId?: string;
+        retryAfterMs?: number;
+        message?: string;
+      };
+      error?: string;
     }>;
+    /**
+     * Resume (if needed), wait until running, then pair with a DEDICATED cloud
+     * agent and return the bind target. A dedicated agent is a full app-server
+     * with its own auth, so binding needs the agent's own API token (obtained by
+     * exchanging a one-time pairing token), not the cloud token. Drives the
+     * self-healing `pairing-token` endpoint: polls through the cold-boot
+     * (~5 min) `202 starting` responses, then exchanges the token at the cloud
+     * `/api/auth/pair` relay for the agent's API key.
+     *
+     * Resolves to `{ status: "paired", apiBase, agentToken }` to bind, or
+     * `{ status: "manual_auth", webUiUrl }` when the agent only offers its own
+     * password screen (no token pairing). Throws on timeout / hard failure.
+     */
+    pairDedicatedCloudAgent(
+      agentId: string,
+      options?: {
+        onProgress?: (status: string, detail?: string) => void;
+        timeoutMs?: number;
+        signal?: AbortSignal;
+      },
+    ): Promise<
+      | {
+          status: "paired";
+          apiBase: string;
+          agentToken: string;
+          agentName?: string;
+        }
+      | { status: "manual_auth"; webUiUrl: string }
+    >;
     getCloudCompatAvailability(): Promise<{
       success: boolean;
       data: {
@@ -2917,6 +2960,150 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     apiBase,
     bridgeUrl: null,
     created: true,
+  };
+};
+
+/** Strip a `/pair?token=…` redirect down to the agent's own origin. */
+function dedicatedAgentOriginFromRedirect(redirectUrl: string): string {
+  return new URL(redirectUrl).origin;
+}
+
+/**
+ * Exchange a one-time pairing token for the dedicated agent's API key via the
+ * cloud `/api/auth/pair` relay. The token is origin-bound, so the request MUST
+ * carry an `Origin` header matching the agent web UI origin. A browser `fetch`
+ * cannot set `Origin` (forbidden header), so the native path calls
+ * `CapacitorHttp` directly (it preserves the header); on the web the browser
+ * supplies its own origin, which only matches when the SPA is served from the
+ * agent origin. The exchange itself is unauthenticated — the pairing token is
+ * the credential.
+ */
+async function exchangeCloudPairingToken(args: {
+  cloudApiBase: string;
+  token: string;
+  agentOrigin: string;
+}): Promise<{ apiKey: string; agentName?: string }> {
+  const url = `${args.cloudApiBase.replace(/\/+$/, "")}/api/auth/pair`;
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Origin: args.agentOrigin,
+  };
+  const bodyObj = { token: args.token };
+
+  let status: number;
+  let parsed: { apiKey?: string | null; agentName?: string; error?: string };
+  if (shouldUseNativeCloudHttp()) {
+    const res = await withDirectCloudHttpTimeout(
+      CapacitorHttp.request({
+        url,
+        method: "POST",
+        headers,
+        data: bodyObj,
+        responseType: "json",
+        connectTimeout: 15_000,
+        readTimeout: 15_000,
+      }),
+      { method: "POST", url },
+    );
+    status = res.status;
+    parsed = (parseDirectCloudJsonSafe(res.data) ?? {}) as typeof parsed;
+  } else {
+    const res = await fetchDirectCloudWithTimeout(
+      url,
+      { method: "POST", headers, body: JSON.stringify(bodyObj) },
+      { method: "POST", url },
+    );
+    status = res.status;
+    parsed = (await res.json().catch(() => ({}))) as typeof parsed;
+  }
+
+  if (status === 401 || status === 403 || status === 410) {
+    throw new Error(
+      "Pairing link expired before sign-in completed. Try connecting again.",
+    );
+  }
+  if (status < 200 || status >= 300) {
+    throw new Error(
+      parsed.error || `Agent pairing exchange failed (${status}).`,
+    );
+  }
+  const apiKey = parsed.apiKey;
+  if (typeof apiKey !== "string" || !apiKey) {
+    throw new Error(
+      "Eliza Cloud accepted the pairing link but returned no agent key.",
+    );
+  }
+  return { apiKey, agentName: parsed.agentName };
+}
+
+ElizaClient.prototype.pairDedicatedCloudAgent = async function (
+  this: ElizaClient,
+  agentId,
+  options,
+) {
+  const onProgress = options?.onProgress;
+  // Cold boot of a dedicated container is ~5 min; give it headroom.
+  const deadline = Date.now() + (options?.timeoutMs ?? 6 * 60_000);
+  const cloudApiBase = resolveDirectCloudClientApiBase(this);
+  if (!cloudApiBase) {
+    throw new Error("Not signed in to Eliza Cloud.");
+  }
+
+  let token = "";
+  let redirectUrl = "";
+
+  // Phase 1: resume (server-side, automatic) + wait until the agent is running.
+  // The pairing-token endpoint returns a 202 `starting` body while the agent
+  // boots and a token once it is running.
+  for (;;) {
+    options?.signal?.throwIfAborted?.();
+    const res = await this.getCloudCompatPairingToken(agentId);
+    if (!res.success) {
+      throw new Error(res.error || "Failed to start the cloud agent.");
+    }
+    const data = res.data ?? {};
+    if (data.token && data.redirectUrl) {
+      token = data.token;
+      redirectUrl = data.redirectUrl;
+      break;
+    }
+    onProgress?.(
+      data.status || "starting",
+      data.message || "Waking your agent…",
+    );
+    if (Date.now() >= deadline) {
+      throw new Error(
+        "Timed out waiting for the cloud agent to start. Try again in a moment.",
+      );
+    }
+    const waitMs = Math.min(Math.max(data.retryAfterMs ?? 5000, 1000), 15_000);
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+
+  const agentOrigin = dedicatedAgentOriginFromRedirect(redirectUrl);
+
+  // When the agent has no UI-token pairing configured the server returns the
+  // bare web UI URL (no `/pair?token=`). That agent uses its own password
+  // screen — we cannot bind headlessly, so hand the URL back to the caller.
+  if (!/\/pair\b/.test(new URL(redirectUrl).pathname)) {
+    onProgress?.("manual_auth", "This agent uses its own sign-in.");
+    return { status: "manual_auth", webUiUrl: agentOrigin };
+  }
+
+  // Phase 2: trade the one-time token for the agent's own API key and bind.
+  onProgress?.("pairing", "Signing in to your agent…");
+  const exchanged = await exchangeCloudPairingToken({
+    cloudApiBase,
+    token,
+    agentOrigin,
+  });
+  onProgress?.("ready", "Connected.");
+  return {
+    status: "paired",
+    apiBase: agentOrigin,
+    agentToken: exchanged.apiKey,
+    agentName: exchanged.agentName,
   };
 };
 


### PR DESCRIPTION
Addresses the remaining **dedicated cloud-agent** pieces tracked in #8621 (the KV/registry repoint and the app auth+lifecycle gap). Two self-contained commits off `develop`.

## 1. Sandbox registry speaks native TCP Redis (Railway), not just Upstash REST
`SandboxRegistry` (the writer that self-registers `agent:<id>:server` + `server:<name>:url` so `gateway-discord`/`gateway-webhook` route inbound Discord/Telegram) was hard-coded to the Upstash REST HTTP protocol. The managed cache is migrating off the now-**throttled** Upstash `apt-bass` onto Railway Redis (TCP-only).

- Adds a transport selected by URL scheme — `http(s)://` keeps the Upstash REST path **unchanged**; `redis(s)://` speaks native RESP over `node:net` (auth inline in the URL, no token), mirroring what the gateways already do.
- No new dependency (REST = `fetch`, TCP = `node:net` builtin; `tls` lazily imported for `rediss://` so the mobile bundle stays lean).
- `docker-sandbox-provider` resolves the backend from `SANDBOX_REGISTRY_REDIS_URL` (+optional `_TOKEN`) before falling back to `KV_REST_API_*`, so the provisioning worker can point sandboxes at a sandbox-reachable `redis://` proxy. Clearer diagnostics when none is configured.
- Agent + app-core copies kept in lock-step.

**Verified end-to-end against the live Railway Redis public proxy** (register → readback → unregister), plus 20 unit tests (REST preserved + TCP/auth/fragmented-read paths).

## 2. `ElizaClient.pairDedicatedCloudAgent` — resume + pair a dedicated agent
A dedicated agent is a full app-server with its own auth, so binding it with the cloud token hits its own password screen. The cloud already ships a self-healing `pairing-token` endpoint (auto-resumes a stopped/sleeping agent, returns `202 {status:"starting", retryAfterMs}` + `Retry-After`, then mints a one-time token) — but nothing in the app drove it.

This adds the client primitive that drives it: polls through the ~5 min cold-boot `202`s, then exchanges the token at the cloud `/api/auth/pair` relay for the agent's own API key. The exchange is **origin-bound**, so it sends `Origin = agent web UI origin` via the native `CapacitorHttp` path (a browser `fetch` can't set `Origin`). Resolves to `{ paired, apiBase, agentToken }` to bind, or `{ manual_auth, webUiUrl }` for password-only agents.

Unit-tested: cold-boot `202` loop, origin-bound exchange, `manual_auth` fallback, timeout. **Wiring** this into first-run / the agent manager binds against develop's `selectOrProvisionCloudAgent` reuse-or-create flow and is a follow-up (needs on-device e2e with a live dedicated agent).

## Operator follow-up (not in this PR)
The live registry cutover (throttled Upstash → Railway Redis) is a **lockstep** infra flip — writer (container-control-plane on Hetzner) + readers (gateways on Railway) must move together. Runbook + a gated Railway-side script are staged; it needs the new agent image + CP redeployed and CP env set before the gateways flip. Tracking with @standujar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)