### PR TITLE
fix(cloud): harden login DB path + unblock deploys during a DB incident

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -301,29 +301,40 @@ jobs:
         env:
           API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
         run: |
-          check_json() {
-            local label="$1"
-            local url="$2"
-            local expected="$3"
-            local tmp
-            tmp="$(mktemp)"
-            local code
-            code="$(curl -sS -o "$tmp" -w '%{http_code}' -m 20 "$url" || echo "000")"
-            local content_type
-            content_type="$(file -b --mime-type "$tmp" 2>/dev/null || true)"
-            if [ "$code" != "$expected" ]; then
-              echo "::error::$label returned HTTP $code, expected $expected: $url"
-              head -c 500 "$tmp" || true
-              echo
-              exit 1
-            fi
-            if ! head -c 1 "$tmp" | grep -q '[{[]'; then
-              echo "::error::$label did not return JSON-looking content ($content_type): $url"
-              head -c 500 "$tmp" || true
-              echo
-              exit 1
-            fi
+          # Probe an endpoint up to 5 times (transient blips right after a deploy
+          # shouldn't fail the gate). Echoes "PASS"/"FAIL" on the last line.
+          # Diagnostics go to stderr (visible in the job log); only PASS/FAIL is
+          # written to stdout so the caller can capture it.
+          probe_json() {
+            local label="$1" url="$2" expected="$3"
+            local tmp code content_type
+            for attempt in 1 2 3 4 5; do
+              tmp="$(mktemp)"
+              code="$(curl -sS -o "$tmp" -w '%{http_code}' -m 20 "$url" || echo "000")"
+              content_type="$(file -b --mime-type "$tmp" 2>/dev/null || true)"
+              if [ "$code" = "$expected" ] && head -c 1 "$tmp" | grep -q '[{[]'; then
+                echo "$label OK ($code)" >&2
+                rm -f "$tmp"; echo PASS; return 0
+              fi
+              echo "$label attempt $attempt: HTTP $code ($content_type): $url" >&2
+              head -c 300 "$tmp" >&2 2>/dev/null || true; echo >&2
+              rm -f "$tmp"
+              [ "$attempt" -lt 5 ] && sleep 8
+            done
+            echo FAIL; return 0
           }
 
-          check_json "direct API health" "${API_URL%/}/api/health" 200
-          check_json "direct Steward providers" "${API_URL%/}/steward/auth/providers" 200
+          # Worker liveness is what THIS deploy is responsible for: hard-fail.
+          if [ "$(probe_json 'direct API health' "${API_URL%/}/api/health" 200 | tail -1)" != "PASS" ]; then
+            echo "::error::API health check failed after retries — the deployed Worker is not responding."
+            exit 1
+          fi
+
+          # The Steward providers endpoint is DB-backed. A failure here usually
+          # means a downstream database/infra incident, NOT a bad Worker deploy —
+          # so do NOT block the deploy on it (that turns any DB incident into an
+          # undeployable state, exactly when a fix needs to ship). Warn loudly.
+          if [ "$(probe_json 'direct Steward providers' "${API_URL%/}/steward/auth/providers" 200 | tail -1)" != "PASS" ]; then
+            echo "::warning::Steward providers (DB-backed) check failed after retries. The Worker deployed; this points at a database/infra issue — investigate the DB, do not assume the deploy is bad."
+            echo "⚠️ Steward providers (DB-backed) health check failed post-deploy — likely a downstream DB incident, not this deploy." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/packages/cloud-shared/src/db/retry-transient.test.ts
+++ b/packages/cloud-shared/src/db/retry-transient.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { isTransientDbError, retryOnTransientDbError } from "./retry-transient";
+
+const pgError = (code: string, message = "boom") =>
+  Object.assign(new Error(message), { code });
+
+describe("isTransientDbError", () => {
+  it("classifies connection-class SQLSTATEs as transient", () => {
+    expect(isTransientDbError(pgError("08006"))).toBe(true);
+    expect(isTransientDbError(pgError("57P01"))).toBe(true);
+    expect(isTransientDbError(pgError("53300"))).toBe(true);
+  });
+
+  it("classifies node socket error codes as transient", () => {
+    expect(isTransientDbError(pgError("ECONNRESET"))).toBe(true);
+    expect(isTransientDbError(pgError("ETIMEDOUT"))).toBe(true);
+  });
+
+  it("classifies connection-failure messages as transient", () => {
+    expect(isTransientDbError(new Error("Connection terminated unexpectedly"))).toBe(true);
+    expect(
+      isTransientDbError(new Error("could not accept SSL connection: unexpected eof while reading")),
+    ).toBe(true);
+  });
+
+  it("walks the cause chain", () => {
+    const wrapped = Object.assign(new Error("query failed"), { cause: pgError("08006") });
+    expect(isTransientDbError(wrapped)).toBe(true);
+  });
+
+  it("does NOT classify query/constraint errors as transient", () => {
+    expect(isTransientDbError(pgError("23505", "duplicate key"))).toBe(false); // unique_violation
+    expect(isTransientDbError(pgError("42P01", "relation does not exist"))).toBe(false);
+    expect(isTransientDbError(new Error("syntax error"))).toBe(false);
+    expect(isTransientDbError(undefined)).toBe(false);
+    expect(isTransientDbError("nope")).toBe(false);
+  });
+});
+
+describe("retryOnTransientDbError", () => {
+  const noSleep = async () => {};
+
+  it("returns immediately on success without retrying", async () => {
+    let calls = 0;
+    const result = await retryOnTransientDbError(async () => {
+      calls++;
+      return "ok";
+    }, { sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries transient errors and succeeds within the attempt budget", async () => {
+    let calls = 0;
+    const result = await retryOnTransientDbError(
+      async () => {
+        calls++;
+        if (calls < 3) throw pgError("08006", "Connection terminated unexpectedly");
+        return "recovered";
+      },
+      { attempts: 3, sleep: noSleep },
+    );
+    expect(result).toBe("recovered");
+    expect(calls).toBe(3);
+  });
+
+  it("does NOT retry non-transient errors", async () => {
+    let calls = 0;
+    await expect(
+      retryOnTransientDbError(
+        async () => {
+          calls++;
+          throw pgError("23505", "duplicate key");
+        },
+        { attempts: 5, sleep: noSleep },
+      ),
+    ).rejects.toMatchObject({ code: "23505" });
+    expect(calls).toBe(1);
+  });
+
+  it("rethrows the last error after exhausting attempts", async () => {
+    let calls = 0;
+    await expect(
+      retryOnTransientDbError(
+        async () => {
+          calls++;
+          throw pgError("08006", "down");
+        },
+        { attempts: 3, sleep: noSleep },
+      ),
+    ).rejects.toMatchObject({ code: "08006" });
+    expect(calls).toBe(3);
+  });
+});

--- a/packages/cloud-shared/src/db/retry-transient.ts
+++ b/packages/cloud-shared/src/db/retry-transient.ts
@@ -1,0 +1,111 @@
+/**
+ * Bounded retry for transient database connection failures.
+ *
+ * Remote Postgres reached from a Cloudflare Worker (via Hyperdrive / a managed
+ * TCP proxy) can drop a connection mid-query or refuse a fresh handshake under
+ * load — surfacing as `Connection terminated unexpectedly`, an SSL handshake
+ * EOF, or a connection-class SQLSTATE. On the auth hot path a single such blip
+ * would otherwise turn a valid session into a 500. Retrying ONLY genuinely
+ * transient connection errors (never query/constraint errors) with a small
+ * backoff lets these recover; a sustained outage still surfaces the real error
+ * after the attempts are exhausted.
+ *
+ * @module db/retry-transient
+ */
+
+/** Connection-class SQLSTATEs (class 08) + admin-shutdown / overload codes. */
+const TRANSIENT_PG_CODES = new Set([
+  "08000", // connection_exception
+  "08001", // sqlclient_unable_to_establish_sqlconnection
+  "08003", // connection_does_not_exist
+  "08004", // sqlserver_rejected_establishment_of_sqlconnection
+  "08006", // connection_failure
+  "08007", // transaction_resolution_unknown
+  "08P01", // protocol_violation
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+  "53300", // too_many_connections
+]);
+
+/** Node socket-level error codes that mean "try again". */
+const TRANSIENT_NODE_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+]);
+
+const TRANSIENT_MESSAGE_RE =
+  /connection terminated|could not accept ssl connection|connection (reset|closed|refused|timeout)|terminating connection|server closed the connection|socket hang ?up|read econnreset|timeout expired/i;
+
+/**
+ * Whether an error represents a transient DB *connection* failure (safe to
+ * retry), as opposed to a query/constraint/logic error (which must not retry).
+ * Walks `cause` so wrapped driver errors are still classified.
+ */
+export function isTransientDbError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  if (
+    typeof code === "string" &&
+    (TRANSIENT_PG_CODES.has(code) || TRANSIENT_NODE_CODES.has(code))
+  ) {
+    return true;
+  }
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === "string" && TRANSIENT_MESSAGE_RE.test(message)) {
+    return true;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  return cause && cause !== error ? isTransientDbError(cause) : false;
+}
+
+export interface RetryTransientOptions {
+  /** Total attempts including the first call. Default 3. */
+  attempts?: number;
+  /** Base backoff in ms (doubles per attempt). Default 50. */
+  baseDelayMs?: number;
+  /** Backoff ceiling in ms. Default 500. */
+  maxDelayMs?: number;
+  /** Sleeper override for tests (defaults to setTimeout). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying only on transient DB connection errors with exponential
+ * backoff + jitter. Non-transient errors are rethrown immediately; the last
+ * error is rethrown once attempts are exhausted.
+ */
+export async function retryOnTransientDbError<T>(
+  fn: () => Promise<T>,
+  options: RetryTransientOptions = {},
+): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  const baseDelayMs = options.baseDelayMs ?? 50;
+  const maxDelayMs = options.maxDelayMs ?? 500;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || !isTransientDbError(error)) {
+        throw error;
+      }
+      const backoff = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+      const jitter = Math.floor(backoff * 0.25 * Math.random());
+      await sleep(backoff + jitter);
+    }
+  }
+  throw lastError;
+}

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -9,6 +9,7 @@ import {
   type UserWithOrganization,
   usersRepository,
 } from "../../db/repositories";
+import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
@@ -93,7 +94,15 @@ export class UsersService {
     }
 
     try {
-      const user = await usersRepository.findByStewardIdWithOrganization(stewardUserId);
+      // Auth hot path: this resolves on every authenticated request. A transient
+      // DB connection blip (a Worker→Hyperdrive connection terminated mid-query,
+      // an SSL-handshake EOF under load) must not turn a valid session into a
+      // 500 — retry transient connection failures with bounded backoff before
+      // surfacing. Non-transient errors are not retried.
+      const user = await retryOnTransientDbError(
+        () => usersRepository.findByStewardIdWithOrganization(stewardUserId),
+        { attempts: 3 },
+      );
       if (user) {
         await cache.set(cacheKey, user, CacheTTL.user.byStewardId);
         logger.debug("[UsersService] Cached user data by stewardId");
@@ -108,7 +117,9 @@ export class UsersService {
       });
 
       try {
-        return await this.getByStewardIdForWrite(stewardUserId);
+        return await retryOnTransientDbError(() => this.getByStewardIdForWrite(stewardUserId), {
+          attempts: 2,
+        });
       } catch (fallbackError) {
         logger.error("[UsersService] Primary Steward lookup retry failed", {
           stewardUserId,


### PR DESCRIPTION
## Why

Surfaced by the **2026-06-19 prod login outage**: prod `DATABASE_URL` was cut over to Railway Postgres (via Cloudflare Hyperdrive) **while a `pg_restore` backfill was still running**. The DB itself was healthy (direct auth queries ~80ms) and Hyperdrive connected fine, but the restore saturated new-connection setup on the prod side, so the Worker's per-request connection churn intermittently failed the TLS handshake (`could not accept SSL connection: unexpected eof`) → **~70% of authenticated requests (all login/auth routes) hung or 500'd**. Staging was unaffected (no active restore).

Two things made it worse, and this PR fixes both:

## 1. Auth hot path turned a transient DB blip into a hard 500

`getCurrentUser → usersService.getByStewardId` runs on **every** authenticated request and had no retry for transient connection errors — a single dropped connection became a 500 for an otherwise-valid session.

- New `packages/cloud-shared/src/db/retry-transient.ts`: `isTransientDbError` (connection-class SQLSTATEs 08*/57P0*/53300, node socket codes, and connection-failure messages incl. the SSL-EOF one — walks `cause`) + `retryOnTransientDbError` (bounded, exponential backoff + jitter).
- Wired into the steward-id read and its primary fallback. **Non-transient (query/constraint) errors are never retried; a sustained outage still surfaces the real error after attempts are exhausted** — no masking.
- Unit test covers classification + retry/no-retry/exhaustion (9 cases, green).

## 2. Deploy pipeline was undeployable during a DB incident (catch-22)

`cloud-cf-deploy.yml` → 'Verify API Worker health' **hard-failed** on the DB-backed `/steward/auth/providers` check, so any DB incident blocked shipping the very fix needed.

- Probes now retry transient blips (5×, 8s).
- `/api/health` (worker liveness — what the deploy actually controls) stays a **hard gate**.
- The DB-backed Steward check now **warns loudly** (job summary + `::warning::`) instead of failing the deploy.

## Risk
Low. Retry is bounded and transient-only; deploy still hard-fails on worker liveness. No behavior change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)