### PR TITLE
fix(cloud): MCP registration SSRF guard must be synchronous (no DNS)

### DIFF
--- a/packages/cloud-api/test/e2e/group-g2-mcp-registry.test.ts
+++ b/packages/cloud-api/test/e2e/group-g2-mcp-registry.test.ts
@@ -119,7 +119,7 @@ describe("Group G2 — user MCP registry CRUD", () => {
     const mcp = await createMcp({ creatorSharePercentage: 70 });
     expect(mcp.status).toBe("draft");
     expect(mcp.creator_share_percentage).toBe("70.00");
-    expect(mcp.platform_share_percentage).toBe("30");
+    expect(mcp.platform_share_percentage).toBe("30.00");
     expect(mcp.tools).toHaveLength(1);
   });
 
@@ -197,8 +197,8 @@ describe("Group G2 — user MCP registry CRUD", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { mcp?: McpDto };
     expect(body.mcp?.name).toBe("Renamed MCP");
-    expect(body.mcp?.creator_share_percentage).toBe("90");
-    expect(body.mcp?.platform_share_percentage).toBe("10");
+    expect(body.mcp?.creator_share_percentage).toBe("90.00");
+    expect(body.mcp?.platform_share_percentage).toBe("10.00");
   });
 
   test("publish -> moves the MCP to live and into the public catalog", async () => {

--- a/packages/cloud-shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud-shared/src/lib/security/outbound-url.ts
@@ -163,6 +163,19 @@ function validateUrlSyntax(rawUrl: string): URL {
 }
 
 /**
+ * Synchronous SSRF guard: validates URL syntax, requires http(s), and rejects
+ * credentials, localhost, and private/reserved IP *literals* — WITHOUT resolving
+ * DNS. Use at registration time (storing a URL), where a momentarily
+ * unresolvable host must not block the write and the Worker runtime is not a
+ * reliable place for outbound DNS. Full DNS-based SSRF enforcement (which also
+ * defeats DNS rebinding) must still run at fetch/proxy time via
+ * {@link assertSafeOutboundUrl}.
+ */
+export function assertSafeOutboundUrlSync(rawUrl: string): URL {
+  return validateUrlSyntax(rawUrl);
+}
+
+/**
  * Validates an outbound URL against SSRF-sensitive destinations.
  * For hostnames, DNS is resolved at call time so rebinding to private ranges
  * cannot bypass creation-time validation.

--- a/packages/cloud-shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud-shared/src/lib/services/user-mcps.ts
@@ -9,7 +9,7 @@ import crypto from "crypto";
 import { mcpUsageRepository, type UserMcp, userMcpsRepository } from "../../db/repositories";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
-import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { assertSafeOutboundUrlSync } from "../security/outbound-url";
 import { logger } from "../utils/logger";
 import { containersService } from "./containers";
 import { creditsService } from "./credits";
@@ -141,7 +141,10 @@ class UserMcpsService {
     }
 
     if (params.endpointType === "external" && params.externalEndpoint) {
-      await assertSafeOutboundUrl(params.externalEndpoint);
+      // Synchronous-only guard at registration (no DNS): a momentarily
+      // unresolvable host must not 500 a write. Full DNS-based SSRF enforcement
+      // runs at fetch time in mcp/proxy/[mcpId] via assertSafeOutboundUrl.
+      assertSafeOutboundUrlSync(params.externalEndpoint);
     }
 
     // Check slug uniqueness
@@ -322,7 +325,8 @@ class UserMcpsService {
       throw new Error("External MCP must have an endpoint URL");
     }
     if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
-      await assertSafeOutboundUrl(mcp.external_endpoint);
+      // Synchronous-only guard (no DNS) — see create(). DNS SSRF runs at fetch.
+      assertSafeOutboundUrlSync(mcp.external_endpoint);
     }
 
     const updated = await userMcpsRepository.updateStatus(id, "live");


### PR DESCRIPTION
## Why
`group-g2-mcp-registry` e2e fails on **develop and main**, which blocks the cloud deploy pipeline (the deploy job's pre-deploy 'Run Worker e2e' step). Surfaced while debugging why a fix couldn't be shipped during the 2026-06-19 prod incident.

## Root cause (real regression)
A prior fix made the registration-time SSRF check synchronous in the **route** (`v1/mcps/route.ts`) — no DNS — but `userMcpsService.create()` (`user-mcps.ts:144`) and `publish()` (`:325`) still called the **DNS-resolving** `assertSafeOutboundUrl()`. Registering an external MCP whose hostname is momentarily unresolvable (the test's `mcp.example.com`, an RFC-2606 reserved name with no A record) threw `Unable to resolve endpoint hostname` → **500** instead of registering. `failureResponse` swallowed it with no log, so CI showed only a bare 500.

## Fix
- Add `assertSafeOutboundUrlSync()` (existing `validateUrlSyntax`: require http(s), reject credentials, localhost, and private/reserved **IP literals** — **no DNS**) and use it in `create()`/`publish()`.
- **SSRF protection is preserved**: full DNS-based enforcement (incl. DNS-rebinding defense) still runs at fetch/proxy time in `mcp/proxy/[mcpId]/route.ts:185` via `assertSafeOutboundUrl` — unchanged.
- Fix 3 stale fixture assertions: `numeric(5,2)` share columns serialize as `30.00`/`90.00`/`10.00`, not `30`/`90`/`10`.

With both, g2 goes 14/14 green (verified 8→2 via the service fix; the remaining 2 are the deterministic fixture-string corrections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)