### PR TITLE
fix(cloud): stop steward login bouncing valid sessions back to /login

### DIFF
--- a/packages/cloud-api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud-api/auth/steward-nonce-exchange/route.ts
@@ -111,15 +111,16 @@ function shouldReturnClientToken(
 ): boolean {
   const origin =
     originHost(c.req.header("origin")) ?? originHost(c.req.header("referer"));
+  const host = (c.req.header("host") ?? "").split(":")[0]?.toLowerCase() ?? "";
   if (!origin) return false;
   // The SPA reads localStorage to decide `isAuthenticated` on /dashboard
   // mount. Without returning the JWT here, OAuth users bounce back to /login.
-  // All permitted CSRF origins are trusted to receive the token.
-  if (PERMITTED_ORIGIN_HOSTS.has(origin)) return true;
-  if (origin.endsWith(".elizacloud.ai") || origin.endsWith(".elizaos.ai")) {
-    return true;
-  }
-  return !isProduction && LOCAL_DEV_ORIGIN_HOSTS.has(origin);
+  // Mirror the token for every origin the CSRF check already accepted — incl.
+  // same-origin custom hosts via `origin === host`. Diverging from the CSRF
+  // gate (as the static-set-only check did) silently dropped the token on hosts
+  // that are accepted by Origin-match, so a valid login bounced to /login.
+  // Matches steward-refresh's shouldReturnClientToken.
+  return isPermittedOrigin(origin, host, isProduction);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -460,7 +461,7 @@ app.post("/", async (c) => {
     sameSite: "Lax",
     path: "/",
     ...(domain ? { domain } : {}),
-    maxAge: 60 * 60 * 24 * 7,
+    maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
   });
 
   logExchange("ok");

--- a/packages/cloud-api/auth/steward-refresh/route.ts
+++ b/packages/cloud-api/auth/steward-refresh/route.ts
@@ -362,7 +362,7 @@ app.post("/", async (c) => {
     sameSite: "Lax",
     path: "/",
     ...(domain ? { domain } : {}),
-    maxAge: 60 * 60 * 24 * 7,
+    maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
   });
 
   logRefresh("ok");

--- a/packages/cloud-api/auth/steward-session/route.ts
+++ b/packages/cloud-api/auth/steward-session/route.ts
@@ -257,7 +257,7 @@ app.post("/", async (c) => {
       sameSite: "Lax",
       path: "/",
       ...(domain ? { domain } : {}),
-      maxAge: 60 * 60 * 24 * 7,
+      maxAge: STEWARD_REFRESH_COOKIE_MAX_AGE,
     });
 
     logStewardAuth("ok", ttl);


### PR DESCRIPTION
## Why
Found while auditing the login flow end-to-end (alongside the 2026-06-19 prod login work). Two server-side cloud-api bugs produce the classic *'login succeeds, then lands back on /login'* and *'logged out too early'* symptoms — independent of which frontend.

## 1. `steward-nonce-exchange` drops the token mirror for same-origin custom hosts
`shouldReturnClientToken` only matched the static `PERMITTED_ORIGIN_HOSTS` set + `*.elizacloud.ai`/`*.elizaos.ai`, **ignoring the `origin === host` rule** that the CSRF gate (`isPermittedOrigin`) and `steward-refresh`'s own `shouldReturnClientToken` both honor. So on any same-origin host accepted by Origin-match, the OAuth code exchange **set the HttpOnly cookies but omitted the `{ token }`** the SPA mirrors into localStorage for synchronous `isAuthenticated` → the user **bounced to /login despite a valid session**. Fix: delegate to `isPermittedOrigin`, exactly matching `steward-refresh`. (The CSRF gate already accepted the origin, so returning the token to it is safe.)

## 2. `steward-authed` marker (7d) is shorter than the refresh cookie (30d)
The non-HttpOnly marker the SPA's cookie-recovery branch keys off was hardcoded to a **7-day** maxAge, while `steward-refresh-token` lives **30 days**. Between day 7 and 30, a user with a valid refresh session had **no marker** → recovery never fired → appeared logged out though a refresh would have succeeded. Aligned the marker TTL to `STEWARD_REFRESH_COOKIE_MAX_AGE` in all three steward routes, so the marker means 'a refresh might succeed' and never outlives the refresh cookie.

## Risk
Low, server-side only. (1) only widens the token mirror to origins the CSRF check already trusts (matching refresh); (2) extends a non-credential marker cookie to match the refresh cookie. No change to the HttpOnly tokens or the verification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)