### PR TITLE
fix(ci/gitleaks): allowlist YOUR_API_KEY curl-example placeholder

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,6 +43,13 @@ regexes = [
   '''sk-test_''',
   '''AKIAIOSFODNN7EXAMPLE''',
   '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY''',
+  # `Authorization: Bearer YOUR_API_KEY` placeholders in documented curl
+  # examples (affiliates monetization page, API route explorer, etc.). The
+  # curl-auth-header rule flags the literal placeholder token; it is the
+  # documentation stand-in, never a real key (a real key would be a different
+  # match and would not contain this literal).
+  '''YOUR_API_KEY''',
+  '''YOUR_CODE_HERE''',
 ]
 
 [[allowlists]]


### PR DESCRIPTION
## What

On a normal develop→main merge, gitleaks (correctly scanning incrementally now, post-#8631) flags **one** real finding: `RuleID: curl-auth-header` in `packages/ui/src/cloud/monetization/affiliates/AffiliatesPageClient.tsx`.

It's a **documented example**, not a secret:
```
curl -X POST https://api.elizacloud.ai/v1/chat/completions \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -H "X-Affiliate-Code: ${affiliateData?.code || "YOUR_CODE_HERE"}"
```
`YOUR_API_KEY` is a literal placeholder the user replaces — same family as the existing `sk-XXXX` / `AKIAIOSFODNN7EXAMPLE` placeholder allowlist.

## Change

Add `YOUR_API_KEY` and `YOUR_CODE_HERE` to the "Documented placeholder strings" allowlist (`regexTarget = "match"`). A real key would be a different match string and would not contain this literal, so detection of actual credentials is unaffected.

## Verification

`gitleaks 8.30.1 detect --no-git` on the file: **1 leak without** the allowlist, **0 with** it. Config loads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)