### PR TITLE
fix(cloud): robust logout teardown + self-heal on a 401 (no stale-session blips)

### DIFF
--- a/packages/cloud-api/auth/logout/route.ts
+++ b/packages/cloud-api/auth/logout/route.ts
@@ -23,16 +23,28 @@ const app = new Hono<AppEnv>();
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
+  const stewardToken = getCookie(c, "steward-token");
+
+  // Clear cookies FIRST. Clearing them is what actually logs the user out, and
+  // it must happen even if the server-side teardown below fails (a transient DB
+  // error during logout must not leave the session cookies in place — that was
+  // the prior behavior, which left users "still logged in" after a failed
+  // logout). The session-record teardown + cache invalidation are best-effort
+  // hygiene (caches expire on their own TTL).
+  const domain = cookieDomainForHost(c.req.header("host"));
+  const stewardOpts = domain ? { path: "/", domain } : { path: "/" };
+  deleteCookie(c, "steward-token", stewardOpts);
+  deleteCookie(c, "steward-refresh-token", stewardOpts);
+  deleteCookie(c, "steward-authed", stewardOpts);
+  deleteCookie(c, "eliza-anon-session", { path: "/" });
+
   try {
-    const stewardToken = getCookie(c, "steward-token");
-
-    const user = await getCurrentUser(c);
-
     if (stewardToken) {
       await invalidateSessionCaches(stewardToken);
       logger.debug("[Logout] Invalidated session caches for token");
     }
 
+    const user = await getCurrentUser(c);
     if (user) {
       await userSessionsService.endAllUserSessions(user.id);
       await getAuditDispatcher()
@@ -54,25 +66,16 @@ app.post("/", async (c) => {
           });
         });
     }
-
-    const domain = cookieDomainForHost(c.req.header("host"));
-    const stewardOpts = domain ? { path: "/", domain } : { path: "/" };
-    deleteCookie(c, "steward-token", stewardOpts);
-    deleteCookie(c, "steward-refresh-token", stewardOpts);
-    deleteCookie(c, "steward-authed", stewardOpts);
-    deleteCookie(c, "eliza-anon-session", { path: "/" });
-
-    return c.json({ success: true, message: "Logged out successfully" });
   } catch (error) {
-    logger.error("Error during logout:", error);
-    return c.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to logout",
-      },
-      500,
-    );
+    // Cookies are already cleared, so the user is logged out client-side; a
+    // failed server-side teardown must not turn logout into a 500 that strands
+    // stale cookies.
+    logger.warn("[Logout] server-side teardown failed (cookies already cleared)", {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
+
+  return c.json({ success: true, message: "Logged out successfully" });
 });
 
 export default app;

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -173,6 +173,19 @@ export async function apiFetch(
   });
 
   if (!res.ok) {
+    // A 401 on an authed call means our session was rejected (token revoked or
+    // expired out from under the proactive refresh). Nudge the Steward runtime
+    // to refresh-or-clear so a stale session self-heals instead of leaving the
+    // UI "authed" until the next interaction. Purely additive — the call still
+    // throws ApiError exactly as before; the listener is single-flight and never
+    // retries the request.
+    if (res.status === 401 && !skipAuth && typeof window !== "undefined") {
+      try {
+        window.dispatchEvent(new CustomEvent("steward-unauthorized"));
+      } catch {
+        // no-op: event dispatch is best-effort
+      }
+    }
     const payload = await readPayload(res, false);
     const { code, message } = errorDetails(payload, res.status);
     throw new ApiError(res.status, code, message, payload);

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -101,46 +101,57 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
         );
     };
 
-    const checkAndRefresh = async () => {
+    // Single-flight: never run two refreshes at once. The refresh-token rotation
+    // is not concurrency-safe, so overlapping refreshes (the timer plus a 401
+    // nudge, say) would race and one would invalidate the other's refresh token.
+    let refreshInFlight: Promise<void> | null = null;
+
+    const checkAndRefresh = async (force = false): Promise<void> => {
       const token = readStoredToken();
-      if (token) {
+      if (!token) return;
+      if (!force) {
         const secs = tokenSecsRemaining(token);
         if (secs !== null && secs >= REFRESH_AHEAD_SECS) return;
-      } else {
-        return;
       }
+      if (refreshInFlight) return refreshInFlight;
 
-      try {
-        const res = await fetch(configuredRefreshEndpoint(), {
-          method: "POST",
-          credentials: "include",
-        });
-        if (res.ok) {
-          const body = (await res.json().catch(() => null)) as {
-            token?: string;
-          } | null;
-          if (body?.token) {
-            writeStoredStewardToken(body.token);
-            lastSyncedToken.current = body.token;
-            wasAuthenticated.current = true;
+      refreshInFlight = (async () => {
+        try {
+          const res = await fetch(configuredRefreshEndpoint(), {
+            method: "POST",
+            credentials: "include",
+          });
+          if (res.ok) {
+            const body = (await res.json().catch(() => null)) as {
+              token?: string;
+            } | null;
+            if (body?.token) {
+              writeStoredStewardToken(body.token);
+              lastSyncedToken.current = body.token;
+              wasAuthenticated.current = true;
+            }
+            try {
+              window.dispatchEvent(new CustomEvent("steward-token-sync"));
+            } catch {
+              // ignore
+            }
+            return;
           }
-          try {
-            window.dispatchEvent(new CustomEvent("steward-token-sync"));
-          } catch {
-            // ignore
+          if (res.status === 401) {
+            if (wasAuthenticated.current && lastSyncedToken.current) {
+              lastSyncedToken.current = null;
+              wasAuthenticated.current = false;
+            }
+            clearStaleStewardSession();
           }
-          return;
+        } catch (err) {
+          console.warn("[steward] Auto-refresh failed", err);
         }
-        if (res.status === 401) {
-          if (wasAuthenticated.current && lastSyncedToken.current) {
-            lastSyncedToken.current = null;
-            wasAuthenticated.current = false;
-          }
-          clearStaleStewardSession();
-        }
-      } catch (err) {
-        console.warn("[steward] Auto-refresh failed", err);
-      }
+      })().finally(() => {
+        refreshInFlight = null;
+      });
+
+      return refreshInFlight;
     };
 
     syncToken();
@@ -166,11 +177,20 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
     };
     window.addEventListener("online", onlineHandler);
 
+    // A 401 from any authed API call (dispatched by api-client) means the server
+    // rejected our session — force a refresh-or-clear so a revoked/expired token
+    // self-heals instead of leaving the UI "authed" until the next interaction.
+    const unauthorizedHandler = () => {
+      void checkAndRefresh(true);
+    };
+    window.addEventListener("steward-unauthorized", unauthorizedHandler);
+
     return () => {
       clearInterval(refreshInterval);
       window.removeEventListener("storage", handler);
       document.removeEventListener("visibilitychange", visibilityHandler);
       window.removeEventListener("online", onlineHandler);
+      window.removeEventListener("steward-unauthorized", unauthorizedHandler);
     };
   }, [isAuthenticated, user]);
 


### PR DESCRIPTION
Part of the login state/refresh/blip cleanup pass.

## 1. Logout always clears cookies (clean teardown)
The logout handler cleared cookies **after** the DB writes (`getCurrentUser` + `endAllUserSessions`), so a transient DB error → **500 with the session cookies still set** → user 'logged out' server-side but 'still logged in' in the browser. Now: clear cookies **first**, then best-effort server-side teardown inside a try/catch. Logout is idempotent and always 200s with cookies cleared (matches the public-path comment's intent).

## 2. Self-heal on a 401 (no 'authed until next interaction' blip)
A 401 from any authed call now dispatches a `steward-unauthorized` event; the Steward runtime **force-refreshes** the session (or clears it if refresh fails). A revoked / out-from-under token self-heals immediately instead of leaving stale 'authed' UI. **Purely additive** — `api-client` still throws `ApiError` exactly as before and never retries the request, so no behavior change for the 72 call sites.

## 3. Single-flight refresh (latent rotation race)
The runtime's refresh is now single-flight, closing a latent refresh-token rotation race (the proactive timer refresh and an on-demand refresh could overlap and invalidate each other's refresh token).

## Verification
`cloud-api` + `packages/ui` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)