### PR TITLE
fix(cloud): pin dedicated-agent embeddings to the elizacloud Worker (no more 503)

### DIFF
--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
@@ -134,4 +134,43 @@ describe("managed Eliza environment", () => {
       "https://waifu.fun https://staging.waifu.fun",
     );
   });
+
+  test("pins embeddings to the elizacloud Worker base so /embeddings never 503s", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import(
+      "./managed-eliza-config"
+    );
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+    });
+
+    // Embeddings must target the elizacloud Worker base (which has a working
+    // /embeddings route), NOT fall back to the BitRouter text base (no
+    // /embeddings → 503). By default it matches the general cloud API base.
+    expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_URL).toBeTruthy();
+    expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_URL).toBe(
+      result.environmentVars.ELIZAOS_CLOUD_BASE_URL,
+    );
+  });
+
+  test("honors an explicit per-agent embedding URL override", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import(
+      "./managed-eliza-config"
+    );
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+      existingEnv: {
+        ELIZAOS_CLOUD_EMBEDDING_URL: "https://custom.example.com/api/v1",
+      },
+    });
+
+    expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_URL).toBe(
+      "https://custom.example.com/api/v1",
+    );
+  });
 });

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -221,6 +221,17 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZAOS_CLOUD_API_KEY: agentApiKey,
       ELIZAOS_CLOUD_ENABLED: "true",
       ELIZAOS_CLOUD_BASE_URL: resolveCloudApiBaseUrl(),
+      // Pin embeddings to the elizacloud Worker (api.elizacloud.ai/api/v1), whose
+      // POST /embeddings serves OpenAI text-embedding-3-small (200, 1536-dim).
+      // Without this, the plugin's getEmbeddingBaseURL() falls back to the
+      // general/text base, which resolves to the Cerebras/BitRouter endpoint that
+      // has NO /embeddings route → 404→503 on every RAG/memory turn. No separate
+      // key is needed: getEmbeddingApiKey falls back to ELIZAOS_CLOUD_API_KEY (set
+      // above), which authenticates to the Worker route. The plugin appends
+      // "/embeddings", so this must end at /api/v1 (resolveCloudApiBaseUrl already
+      // normalizes that). An explicit per-agent override still wins.
+      ELIZAOS_CLOUD_EMBEDDING_URL:
+        existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
       // Pin the cloud's healthy Cerebras-direct models so the container never
       // resolves a tier to the `:nitro` default (which has no Cerebras route →
       // BitRouter→OpenRouter → 503 / wrong model). Mirrors the shared + eliza-app


### PR DESCRIPTION
## What
Pin `ELIZAOS_CLOUD_EMBEDDING_URL` in the dedicated-agent provisioning env builder so embeddings hit the healthy elizacloud Worker route instead of the BitRouter base that has no `/embeddings`.

## Why
Verified live on a fresh Railway-backed dedicated agent: **every embedding (RAG/memory) turn 503s** —
```
[ELIZAOS_CLOUD] Falling back to general base URL for embeddings.
[BatchEmbeddings] API error: 503 - Service Unavailable
```
`prepareManagedElizaBaseEnvironment()` (`managed-eliza-config.ts`) sets `ELIZAOS_CLOUD_BASE_URL` + pins the model tiers, but **never sets `ELIZAOS_CLOUD_EMBEDDING_URL`**. Unset → `plugin-elizacloud`'s `getEmbeddingBaseURL()` falls back to the general/text base → the Cerebras/BitRouter endpoint, which has **no `/embeddings` route → 404→503**. The cloud Worker's `POST /api/v1/embeddings` works (200, OpenAI `text-embedding-3-small`, 1536-dim) — embeddings just weren't pointed at it.

This is the embeddings half that **#8636 missed** (#8636 pinned the `:nitro`→Cerebras models but not the embedding URL).

## How
```ts
ELIZAOS_CLOUD_EMBEDDING_URL:
  existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
```
- `resolveCloudApiBaseUrl()` → `https://api.elizacloud.ai/api/v1` (prod); the plugin appends `/embeddings`.
- No key needed — `getEmbeddingApiKey` falls back to `ELIZAOS_CLOUD_API_KEY` (the per-agent key, already set), which authenticates to the Worker route.
- Per-agent override still wins (`existingEnv ??`), matching the model-tier pattern right below it.

## Tests
Added: default pins `ELIZAOS_CLOUD_EMBEDDING_URL` to the cloud API base; explicit override is honored. `bun test managed-eliza-config` → 9/9 green; lint + typecheck clean.

## Deploy note
Already-running containers predate this — they must be **re-provisioned** (and the provisioning worker redeployed for #8636's model pins too) to pick it up.

Refs #8434, #8636.