### PR TITLE
feat(cloud): route GLM 5.2 (zai/glm-5.2) into the model catalog

### DIFF
--- a/packages/cloud-shared/src/lib/models/catalog.ts
+++ b/packages/cloud-shared/src/lib/models/catalog.ts
@@ -241,7 +241,7 @@ const DEEPSEEK_TEXT_MODEL_IDS = [
   "deepseek/deepseek-v3.2",
   "deepseek/deepseek-r1",
 ] as const;
-const ZAI_TEXT_MODEL_IDS = ["zai/glm-5.1", "zai/glm-5-turbo"] as const;
+const ZAI_TEXT_MODEL_IDS = ["zai/glm-5.2", "zai/glm-5.1", "zai/glm-5-turbo"] as const;
 const MOONSHOT_TEXT_MODEL_IDS = ["moonshotai/kimi-k2.6"] as const;
 const BYTEDANCE_TEXT_MODEL_IDS = ["bytedance/seed-1.8", "bytedance/seed-1.6"] as const;
 const AMAZON_TEXT_MODEL_IDS = [

--- a/packages/cloud-shared/src/lib/models/model-tiers.ts
+++ b/packages/cloud-shared/src/lib/models/model-tiers.ts
@@ -381,9 +381,16 @@ export const ADDITIONAL_MODELS: AdditionalModel[] = [
   },
   // Z.AI (Zhipu)
   {
+    id: "glm-5.2",
+    name: "GLM-5.2",
+    description: "Z.AI (Zhipu) latest flagship",
+    modelId: "zai/glm-5.2",
+    provider: "zai",
+  },
+  {
     id: "glm-5.1",
     name: "GLM-5.1",
-    description: "Z.AI (Zhipu) latest flagship",
+    description: "Z.AI (Zhipu) previous flagship",
     modelId: "zai/glm-5.1",
     provider: "zai",
   },


### PR DESCRIPTION
Routes `zai/glm-5.2` into the eliza cloud model catalog so it's selectable as an agent model.

## Changes
- `catalog.ts` — `ZAI_TEXT_MODEL_IDS` now leads with `zai/glm-5.2`
- `model-tiers.ts` — adds a `glm-5.2` tier entry (Z.AI latest flagship); GLM-5.1 demoted to 'previous flagship'

Pricing auto-derives from BitRouter (no hardcoded price map for zai models).

## Note
This routes 5.2 on the catalog side. It resolves end-to-end only if the **BitRouter gateway serves `zai/glm-5.2`** upstream — harmless catalog entry until then, flips live the moment the gateway adds it. Worth a quick confirm that BitRouter has the model.

Context: waifu agents (starting with the Sol prototype) will run on GLM 5.2 per the agent-web-UI direction (#8434).

Co-authored-by: wakesync <shadow@shad0w.xyz>