### PR TITLE
fix(cloud-api/e2e): reclaim orphaned PGlite port instead of hard-failing CF Deploy

### DIFF
--- a/packages/cloud-api/test/e2e/run-e2e-batches.mjs
+++ b/packages/cloud-api/test/e2e/run-e2e-batches.mjs
@@ -122,6 +122,48 @@ async function waitForTcp(processRef, host, port) {
   );
 }
 
+function listenerPidsOnPort(port) {
+  const lsof = spawnSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
+    encoding: "utf8",
+  });
+  if (lsof.status === 0 && lsof.stdout.trim()) {
+    return lsof.stdout.trim().split(/\s+/);
+  }
+  const fuser = spawnSync("fuser", [`${port}/tcp`], { encoding: "utf8" });
+  const fuserOut = `${fuser.stdout ?? ""} ${fuser.stderr ?? ""}`.trim();
+  if (fuserOut) return fuserOut.split(/\s+/);
+  return [];
+}
+
+// Reclaim a port held by an orphaned listener. Self-hosted CI runners are
+// persistent: when Actions cancels a run mid-flight it SIGKILLs the job, so the
+// `finally` cleanup below never runs and the spawned pglite-server child is left
+// holding the port — wedging every subsequent run with "already running".
+// Kill the orphan and wait for the port to free so the next run self-heals.
+async function reclaimPort(host, port) {
+  const pids = listenerPidsOnPort(port);
+  for (const pid of pids) {
+    const numeric = Number(pid);
+    if (!Number.isInteger(numeric) || numeric <= 0) continue;
+    try {
+      process.kill(numeric, "SIGKILL");
+      console.log(
+        `[api-e2e] killed orphan PGlite listener pid=${numeric} on ${host}:${port}`,
+      );
+    } catch (error) {
+      console.warn(
+        `[api-e2e] could not kill pid=${numeric} on ${host}:${port}: ${error?.message ?? error}`,
+      );
+    }
+  }
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (!(await tcpOk(host, port))) return true;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+  }
+  return false;
+}
+
 async function ensurePGliteBridge() {
   const usingPGliteBridge =
     !configuredDatabaseUrl || configuredDatabaseUrl.startsWith("pglite://");
@@ -132,13 +174,19 @@ async function ensurePGliteBridge() {
     !configuredDatabaseUrl &&
     process.env.TEST_PGLITE_PERSIST !== "1" &&
     Boolean(dataDir);
-  const alreadyRunning = await tcpOk(pgliteHost, pglitePort);
+  let alreadyRunning = await tcpOk(pgliteHost, pglitePort);
 
   if (shouldResetDefaultPGlite) {
     if (alreadyRunning) {
-      throw new Error(
-        `[api-e2e] default PGlite server is already running at ${pgliteHost}:${pglitePort}; stop it before running isolated tests, or set TEST_PGLITE_PERSIST=1 to reuse it.`,
+      console.warn(
+        `[api-e2e] default PGlite server already running at ${pgliteHost}:${pglitePort}; reclaiming the port before reset`,
       );
+      alreadyRunning = !(await reclaimPort(pgliteHost, pglitePort));
+      if (alreadyRunning) {
+        throw new Error(
+          `[api-e2e] default PGlite server is already running at ${pgliteHost}:${pglitePort} and could not be reclaimed; stop it before running isolated tests, or set TEST_PGLITE_PERSIST=1 to reuse it.`,
+        );
+      }
     }
     rmSync(resolve(repoRoot, dataDir), { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

**Cloud CF Deploy** has been red on `main`/`develop` at **Deploy API Worker → Run Worker e2e**, with:

```
Error: [api-e2e] default PGlite server is already running at 127.0.0.1:55433;
       stop it before running isolated tests, or set TEST_PGLITE_PERSIST=1 to reuse it.
error: script "test:e2e" exited with code 1
```

### Root cause

The `Deploy API Worker` job runs on **persistent self-hosted runners** (`["self-hosted","Linux","X64","hetzner-robot"]`, see `cloud-cf-deploy.yml:69`). The branch is under heavy merge churn, so deploy runs are frequently `cancel-in-progress`-cancelled mid-flight. When Actions cancels a run it **SIGKILLs the job**, so the `finally { stopServer(pgliteServer) }` cleanup in `run-e2e-batches.mjs` never runs — the spawned `pglite-server` child is **orphaned and keeps holding `:55433`**. The *next* run then trips the "already running" guard and hard-fails before any test executes. The churn manufactures the collision, and it wedges every subsequent run until someone manually kills the orphan.

This is independent of the recent Railway DB/cache migration — it's a harness-robustness gap exposed by the self-hosted runner + churn.

## Fix

`ensurePGliteBridge()` now **reclaims** the port before resetting instead of hard-throwing: kill the orphan listener (`lsof -ti tcp:<port> -sTCP:LISTEN`, with a `fuser` fallback for Linux), wait for the port to free, then proceed with the data-dir reset and a fresh server. It only throws if the port genuinely can't be reclaimed. This makes the run **self-healing** on persistent runners.

The non-reset paths (configured `DATABASE_URL`, `TEST_PGLITE_PERSIST=1`, reuse-existing) are unchanged.

## Verification

- `node --check` clean; biome check clean.
- Reclaim mechanism verified locally end-to-end: spawned a detached orphan listener on a port, confirmed it was occupied, ran `reclaimPort()` → it located the PID via `lsof -ti`, SIGKILLed it, and the port was freed (`RESULT: PASS`).
- The `fuser` fallback's non-numeric token (`<port>/tcp:`) is safely skipped by the `Number.isInteger` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)