### PR TITLE
ci(cloud-deploy): don't cancel manual production deploys

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -53,8 +53,12 @@ on:
           - production
 
 concurrency:
-  group: cloud-cf-deploy-${{ github.ref }}
-  cancel-in-progress: true
+  # Manual production deploys (workflow_dispatch) must run to completion: they
+  # are intentional and must NOT be cancelled by routine pushes. Give them a
+  # per-run-unique group + no cancel-in-progress. Push/PR runs keep the
+  # dedupe-to-latest behavior (a new push cancels the older in-progress run).
+  group: cloud-cf-deploy-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # Default to least privilege. Override per-job where needed.
 permissions:


### PR DESCRIPTION
Manual workflow_dispatch deploys get a per-run-unique concurrency group + cancel-in-progress=false so they run to completion (the cloud-api Worker deploy was never finishing — cancelled by churn before the cold build:core). Push/PR keep dedupe-to-latest. Cherry-picked onto main only (1-file workflow change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)