### PR TITLE
fix(cloud): frontend crypto-chunk crash + KV Worker cache (prod hotfix)

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -331,6 +331,13 @@ bucket_name = "eliza-cloud-blob-staging"
 binding = "HYPERDRIVE"
 id = "ef65eb94c74144a3a3848ad1945571fb"
 
+# KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
+# TCP to an external Redis (Railway's public proxy hangs under load), so the Worker
+# caches auth/api-key/model-catalog in KV instead of Redis.
+[[env.staging.kv_namespaces]]
+binding = "CACHE_KV"
+id = "f7e24faaff734e7c8cd8e12b093c3571"
+
 [env.production]
 name = "eliza-cloud-api-prod"
 workers_dev = false
@@ -431,3 +438,10 @@ bucket_name = "eliza-cloud-blob"
 [[env.production.hyperdrive]]
 binding = "HYPERDRIVE"
 id = "9f59e4ec65f048f7b87e29e7b9c5d728"
+
+# KV is the Worker's cache backend (CacheClient). Workers can't reliably open raw
+# TCP to an external Redis (Railway's public proxy hangs under load), so the Worker
+# caches auth/api-key/model-catalog in KV instead of Redis.
+[[env.production.kv_namespaces]]
+binding = "CACHE_KV"
+id = "1dafabf1293d4b6b97f61c5cc22d6fec"

--- a/packages/cloud-frontend/vite.config.ts
+++ b/packages/cloud-frontend/vite.config.ts
@@ -548,6 +548,21 @@ export default defineConfig(({ mode }) => {
           codeSplitting: {
             groups: [
               {
+                // Crypto / big-number graph (bn.js, elliptic, secp256k1, the
+                // hash + cipher libs, and the `buffer` polyfill they call into).
+                // Must be its own chunk: Rolldown's recursive dep-inclusion
+                // otherwise non-deterministically folds this graph into an
+                // eagerly-initialized app chunk (e.g. an i18n locale chunk),
+                // where bn.js runs `Buffer.allocUnsafe` at module-init before
+                // the chunk's CJS Buffer wrapper is hoisted — throwing
+                // "Class constructor cannot be invoked without 'new'" and
+                // killing the whole React tree. Extracting it (highest
+                // priority) keeps the graph + its Buffer together and lazy.
+                name: "vendor-crypto",
+                test: /[\\/]node_modules[\\/](bn\.js|elliptic|secp256k1|@noble[\\/][^\\/]+|hash-base|create-hash|create-hmac|create-ecdh|browserify-sign|browserify-aes|browserify-cipher|browserify-rsa|diffie-hellman|asn1\.js|des\.js|ripemd160|sha\.js|md5\.js|hash\.js|cipher-base|evp_bytestokey|pbkdf2|public-encrypt|randombytes|randomfill|miller-rabin|brorand|hmac-drbg|minimalistic-crypto-utils|minimalistic-assert|safe-buffer|buffer)([\\/]|$)/,
+                priority: 40,
+              },
+              {
                 name: "vendor-wallet",
                 test: /[\\/]node_modules[\\/](wagmi|@wagmi[\\/]|viem[\\/]|@rainbow-me[\\/]|@walletconnect[\\/]|@reown[\\/]|@coinbase[\\/]wallet|mipd|eventemitter3)([\\/]|$)/,
                 priority: 30,

--- a/packages/cloud-shared/src/lib/cache/adapters/kv-cache-adapter.ts
+++ b/packages/cloud-shared/src/lib/cache/adapters/kv-cache-adapter.ts
@@ -1,0 +1,175 @@
+import type { CacheRedisClient } from "./types";
+
+/**
+ * Minimal structural type for a Cloudflare KV namespace binding — only the
+ * methods this adapter uses. Avoids pulling `@cloudflare/workers-types` into
+ * `cloud-shared` (which is also consumed by the browser frontend).
+ */
+export interface KvNamespaceLike {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+    keys: Array<{ name: string }>;
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+}
+
+// Cloudflare KV rejects expirationTtl < 60s.
+const KV_MIN_TTL_SECONDS = 60;
+
+function clampTtlSeconds(ttlSeconds: number): number {
+  return Math.max(Math.ceil(ttlSeconds), KV_MIN_TTL_SECONDS);
+}
+
+/**
+ * Cloudflare KV-backed cache adapter for the Cloudflare Worker.
+ *
+ * KV is the only Worker-reachable cache backend: the Worker cannot reliably
+ * open raw TCP (`cloudflare:sockets`) to an external Redis (e.g. Railway's
+ * public proxy), so it falls back to KV's HTTP-native API.
+ *
+ * KV is a key/value store with TTLs, **eventually consistent**, and has **no
+ * atomic operations, lists, or TTL introspection**. This adapter therefore
+ * serves the read-through caches (auth, api-key, model catalog, …) faithfully
+ * and provides best-effort, non-atomic emulation for the rest:
+ *   - `set …{nx}` / `incr` are NOT atomic (racy under concurrency); callers that
+ *     need atomicity gate on `CacheClient.supportsAtomicOperations()`, which
+ *     returns false for this backend, so distributed locks use dummy locks.
+ *   - list ops (`lpush`/`rpop`/`llen`) are emulated via a JSON array value.
+ *   - `pttl` cannot be derived from KV and returns -1 (present, ttl unknown).
+ *
+ * KV's 60s minimum TTL is clamped transparently.
+ */
+export class KvCacheAdapter implements CacheRedisClient {
+  readonly backend = "cloudflare-kv";
+
+  constructor(private readonly kv: KvNamespaceLike) {}
+
+  async get(key: string): Promise<string | null> {
+    return this.kv.get(key);
+  }
+
+  async setex(key: string, ttlSeconds: number, value: string): Promise<unknown> {
+    await this.kv.put(key, value, { expirationTtl: clampTtlSeconds(ttlSeconds) });
+    return "OK";
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options?: { nx?: boolean; px?: number },
+  ): Promise<string | null> {
+    // Non-atomic NX: a best-effort existence check. Real atomicity is gated by
+    // supportsAtomicOperations() (false here), so the lock path never relies on
+    // this; setIfNotExists callers accept the weaker guarantee.
+    if (options?.nx) {
+      const existing = await this.kv.get(key);
+      if (existing !== null) return null;
+    }
+    const putOptions =
+      options?.px !== undefined ? { expirationTtl: clampTtlSeconds(options.px / 1000) } : undefined;
+    await this.kv.put(key, value, putOptions);
+    return "OK";
+  }
+
+  async incr(key: string): Promise<number> {
+    // Non-atomic; acceptable for approximate counters (rate limiting). Loses
+    // increments under concurrency / eventual consistency.
+    const next = Number.parseInt((await this.kv.get(key)) ?? "0", 10) + 1;
+    await this.kv.put(key, String(next));
+    return next;
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<unknown> {
+    return this.reput(key, clampTtlSeconds(ttlSeconds));
+  }
+
+  async pexpire(key: string, ttlMs: number): Promise<unknown> {
+    return this.reput(key, clampTtlSeconds(ttlMs / 1000));
+  }
+
+  /** Re-write the value to apply a new TTL (KV can't mutate TTL in place). */
+  private async reput(key: string, ttlSeconds: number): Promise<number> {
+    const value = await this.kv.get(key);
+    if (value === null) return 0;
+    await this.kv.put(key, value, { expirationTtl: ttlSeconds });
+    return 1;
+  }
+
+  async pttl(): Promise<number | null> {
+    // KV exposes no remaining-TTL. -1 = "exists, ttl unknown" in Redis terms.
+    return -1;
+  }
+
+  async getdel(key: string): Promise<string | null> {
+    const value = await this.kv.get(key);
+    if (value !== null) await this.kv.delete(key);
+    return value;
+  }
+
+  async del(...keys: string[]): Promise<unknown> {
+    await Promise.all(keys.map((key) => this.kv.delete(key)));
+    return keys.length;
+  }
+
+  async scan(
+    cursor: string | number,
+    options: { match: string; count: number },
+  ): Promise<[string | number, string[]]> {
+    // KV list is prefix-based, not glob. Use the literal prefix up to the first
+    // wildcard, then filter the page against the full glob for correctness.
+    const wildcardAt = options.match.indexOf("*");
+    const prefix = wildcardAt === -1 ? options.match : options.match.slice(0, wildcardAt);
+    const startCursor = cursor === "0" || cursor === 0 ? undefined : String(cursor);
+    const page = await this.kv.list({
+      prefix,
+      limit: options.count,
+      cursor: startCursor,
+    });
+    const regex = this.globToRegExp(options.match);
+    const keys = page.keys.map((k) => k.name).filter((name) => regex.test(name));
+    const nextCursor = page.list_complete ? "0" : (page.cursor ?? "0");
+    return [nextCursor, keys];
+  }
+
+  async mget(...keys: string[]): Promise<Array<string | null>> {
+    return Promise.all(keys.map((key) => this.kv.get(key)));
+  }
+
+  // List emulation via a JSON-array value. Non-atomic; for low-contention use.
+  async lpush(key: string, ...values: string[]): Promise<number> {
+    const list = await this.readList(key);
+    list.unshift(...values);
+    await this.kv.put(key, JSON.stringify(list));
+    return list.length;
+  }
+
+  async rpop(key: string): Promise<string | null> {
+    const list = await this.readList(key);
+    const value = list.pop() ?? null;
+    if (value !== null) await this.kv.put(key, JSON.stringify(list));
+    return value;
+  }
+
+  async llen(key: string): Promise<number> {
+    return (await this.readList(key)).length;
+  }
+
+  private async readList(key: string): Promise<string[]> {
+    const raw = await this.kv.get(key);
+    if (raw === null) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? (parsed as string[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private globToRegExp(pattern: string): RegExp {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+    return new RegExp(`^${escaped}$`);
+  }
+}

--- a/packages/cloud-shared/src/lib/cache/client.ts
+++ b/packages/cloud-shared/src/lib/cache/client.ts
@@ -11,8 +11,9 @@
 import { randomUUID } from "node:crypto";
 import { Redis as UpstashRedis } from "@upstash/redis";
 import { createClient } from "redis";
-import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { getCloudAwareEnv, getCloudBinding } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
+import { KvCacheAdapter, type KvNamespaceLike } from "./adapters/kv-cache-adapter";
 import { MemoryCacheAdapter } from "./adapters/memory-cache-adapter";
 import { NodeRedisAdapter } from "./adapters/node-redis-adapter";
 import { SocketRedisAdapter } from "./adapters/socket-redis-adapter";
@@ -120,7 +121,7 @@ export class CacheClient {
     );
   }
 
-  private getBackendPreference(): "auto" | "redis" | "redis-rest" | "wadis" | "memory" {
+  private getBackendPreference(): "auto" | "redis" | "redis-rest" | "wadis" | "kv" | "memory" {
     const env = getCloudAwareEnv();
     const raw = (env.CACHE_BACKEND || env.CACHE_ADAPTER || env.CACHE_DRIVER || "auto")
       .trim()
@@ -129,8 +130,19 @@ export class CacheClient {
     if (raw === "native-redis" || raw === "redis-native") return "redis";
     if (raw === "upstash" || raw === "rest" || raw === "redis-rest") return "redis-rest";
     if (raw === "wadis" || raw === "wasm-redis" || raw === "wasm_redis") return "wadis";
+    if (raw === "kv" || raw === "cloudflare-kv" || raw === "workers-kv") return "kv";
     if (raw === "memory" || raw === "in-memory" || raw === "in_memory") return "memory";
     return "auto";
+  }
+
+  /**
+   * The Cloudflare KV namespace bound as `CACHE_KV`, if present. KV is the only
+   * Worker-reachable cache backend (the Worker can't reliably open raw TCP to an
+   * external Redis), so we prefer it inside the Worker. Object bindings aren't
+   * exposed by `getCloudAwareEnv()`; read it from the request binding store.
+   */
+  private getKvBinding(): KvNamespaceLike | undefined {
+    return getCloudBinding<KvNamespaceLike>("CACHE_KV");
   }
 
   private initializeWadis(): void {
@@ -227,6 +239,23 @@ export class CacheClient {
     if (!inWorker && (backendPreference === "wadis" || redisUrl === "wadis://local")) {
       this.initializeWadis();
       return;
+    }
+
+    // Cloudflare Workers cannot reliably open raw TCP to an external Redis: the
+    // `cloudflare:sockets` connection to Railway's public proxy hangs under load
+    // (no connect timeout → the whole request stalls). So when a KV namespace is
+    // bound (`CACHE_KV`), prefer it for the Worker's cache — KV is HTTP-native
+    // and reliable from Workers. Atomic/list ops degrade (see KvCacheAdapter);
+    // supportsAtomicOperations() reports false so locks use the dummy path.
+    if (inWorker && backendPreference !== "redis-rest" && backendPreference !== "redis") {
+      const kv = this.getKvBinding();
+      if (kv) {
+        this.redis = new KvCacheAdapter(kv);
+        this.nativeRedisConnectPromise = null;
+        this.nativeRedisReady = true;
+        logger.info("[Cache] ✓ Cache client initialized with Cloudflare KV");
+        return;
+      }
     }
 
     // Workers can't speak raw TCP via the `redis` package, but `cloudflare:sockets`
@@ -351,7 +380,10 @@ export class CacheClient {
    */
   supportsAtomicOperations(): boolean {
     this.initialize();
-    return this.enabled !== false;
+    if (this.enabled === false) return false;
+    // Cloudflare KV is eventually consistent with no atomic SET NX / INCR, so
+    // callers (distributed locks) must fall back to their non-distributed path.
+    return this.redis?.backend !== "cloudflare-kv";
   }
 
   /**

--- a/packages/cloud-shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud-shared/src/types/cloud-worker-env.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Context } from "hono";
+import type { KvNamespaceLike } from "../lib/cache/adapters/kv-cache-adapter";
 import type { RuntimeR2Bucket } from "../lib/storage/r2-runtime-binding";
 
 export interface Bindings {
@@ -16,6 +17,14 @@ export interface Bindings {
   // ---- Cloudflare R2 ----
   /** Object storage for voice samples, avatars, and other binary blobs. */
   BLOB: RuntimeR2Bucket;
+
+  // ---- Cloudflare KV (Worker cache backend) ----
+  /**
+   * The Worker's cache store. KV is the only Worker-reachable cache backend
+   * (raw TCP to an external Redis is unreliable from Workers), so CacheClient
+   * prefers it when bound. Read via getCloudBinding("CACHE_KV").
+   */
+  CACHE_KV?: KvNamespaceLike;
 
   // ---- Cloudflare Registrar/DNS ----
   CLOUDFLARE_ACCOUNT_ID?: string;


### PR DESCRIPTION
Two changes bundled so a single main deploy lands both correctly (cloud-cf-deploy deploys the Worker **and** the frontend from main; shipping the frontend fix alone would redeploy the Worker from main without the KV cache).

## 1. cloud-frontend crash (the dashboard outage)
elizacloud.ai crashed on load across all recent prod builds: `Class constructor u cannot be invoked without 'new'` (blank "Something went wrong"). Rolldown non-deterministically folded the crypto/bn.js graph into an eagerly-initialized `en_US` locale chunk, where `bn.js` runs `Buffer.allocUnsafe` at module-init before the bundled Buffer wrapper is hoisted → V8 throws and kills the React tree on every route.

Fix: a highest-priority `codeSplitting` group extracts the crypto graph (`bn.js`, `elliptic`, `secp256k1`, hash/cipher libs, `buffer`) into a dedicated lazy `vendor-crypto` chunk. Deterministic — the eager-merge can't recur.

**Verified**: the fixed build renders `/` and `/login` cleanly on a CF Pages preview (vs. the blank crash on unfixed builds); `vendor-crypto` chunk is extracted with bn.js, not in any locale chunk.

## 2. Cloudflare KV Worker cache (#8665, already on develop + live on prod)
The CF Worker can't reliably reach Railway's TCP Redis (hangs, no connect timeout). KV is the Worker-native cache backend. Already deployed + validated on prod/staging; included here so the main Worker deploy keeps the KV cache instead of regressing to cacheless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)