### PR TITLE
fix(ci/provisioning-worker): raise build:core heap to 8GB (stop plugin-local-inference OOM) [main]

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -244,6 +244,14 @@ jobs:
             # The daemons run under Node/tsx rather than Bun. Node resolves
             # linked workspace packages through their built `node` exports, so
             # refresh linked package dist files after installing dependencies.
+            #
+            # The `git clean -fdx` above wipes `.turbo`, so every deploy does a
+            # cold `build:core` (0 cached). Building the full graph includes
+            # `@elizaos/plugin-local-inference`, whose tsc/bundler step exceeds
+            # V8's default ~2 GB old-space and aborts the deploy with
+            # `FATAL ERROR: ... JavaScript heap out of memory` (exit 134). Raise
+            # the heap ceiling to match the repo's typecheck lane (8 GB).
+            export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192"
             bun run build:core
             mkdir -p plugins/plugin-sql/node_modules/@elizaos
             rm -rf plugins/plugin-sql/node_modules/@elizaos/core


### PR DESCRIPTION
## Problem

`Deploy Eliza Provisioning Worker` fails with **`FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory`** (exit 134) while building `@elizaos/plugin-local-inference` during the remote `bun run build:core` step on the Hetzner host.

The deploy step runs `git clean -fdx` (which wipes `.turbo`), so **every deploy does a cold full-graph build** (`0 cached, 52 total`). `plugin-local-inference`'s tsc/bundler step exceeds V8's default ~2 GB old-space ceiling and aborts the whole deploy. The daemon is pure Node/tsx and does not even need that plugin at runtime, but `build:core` builds the full graph.

## Fix

Raise the build heap ceiling to 8 GB (matching the repo's typecheck lane, which already runs at 8 GB) via `NODE_OPTIONS=--max-old-space-size=8192` immediately before `bun run build:core`. One-line, idiomatic, low-risk; `NODE_OPTIONS` propagates to the Node subprocesses (tsc/bundler) that actually OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Forward-port to `main` (the deploy workflow runs on both branches).