### PR TITLE
feat(cloud): observable cache breaker open + steward URL parse failures

### DIFF
--- a/packages/cloud-api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud-api/auth/steward-nonce-exchange/route.ts
@@ -147,8 +147,11 @@ function logExchange(outcome: string): void {
 }
 
 function resolveStewardBaseUrl(env: AppEnv["Bindings"]): string | null {
-  const candidates = [env.STEWARD_API_URL, env.NEXT_PUBLIC_STEWARD_API_URL];
-  for (const candidate of candidates) {
+  const candidates: Array<[string, string | undefined]> = [
+    ["STEWARD_API_URL", env.STEWARD_API_URL],
+    ["NEXT_PUBLIC_STEWARD_API_URL", env.NEXT_PUBLIC_STEWARD_API_URL],
+  ];
+  for (const [key, candidate] of candidates) {
     if (typeof candidate !== "string") continue;
     const trimmed = candidate.trim().replace(/\/+$/, "");
     if (trimmed.length === 0) continue;
@@ -156,7 +159,15 @@ function resolveStewardBaseUrl(env: AppEnv["Bindings"]): string | null {
       const url = new URL(trimmed);
       if (url.protocol !== "https:" && url.protocol !== "http:") continue;
       return trimmed;
-    } catch {}
+    } catch (error) {
+      // A non-empty candidate that fails to parse is a misconfiguration, not a
+      // missing value. Name the env var so the resulting 503 is debuggable; never
+      // log the value itself (it may contain credentials).
+      logger.warn("[StewardAuth] Ignoring unparseable Steward base URL", {
+        envVar: key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
   return null;
 }

--- a/packages/cloud-api/auth/steward-refresh/route.ts
+++ b/packages/cloud-api/auth/steward-refresh/route.ts
@@ -142,8 +142,11 @@ function logRefresh(outcome: string): void {
 }
 
 function resolveStewardBaseUrl(env: AppEnv["Bindings"]): string | null {
-  const candidates = [env.STEWARD_API_URL, env.NEXT_PUBLIC_STEWARD_API_URL];
-  for (const candidate of candidates) {
+  const candidates: Array<[string, string | undefined]> = [
+    ["STEWARD_API_URL", env.STEWARD_API_URL],
+    ["NEXT_PUBLIC_STEWARD_API_URL", env.NEXT_PUBLIC_STEWARD_API_URL],
+  ];
+  for (const [key, candidate] of candidates) {
     if (typeof candidate !== "string") continue;
     const trimmed = candidate.trim().replace(/\/+$/, "");
     if (trimmed.length === 0) continue;
@@ -151,7 +154,15 @@ function resolveStewardBaseUrl(env: AppEnv["Bindings"]): string | null {
       const url = new URL(trimmed);
       if (url.protocol !== "https:" && url.protocol !== "http:") continue;
       return trimmed;
-    } catch {}
+    } catch (error) {
+      // A non-empty candidate that fails to parse is a misconfiguration, not a
+      // missing value. Name the env var so the resulting 503 is debuggable; never
+      // log the value itself (it may contain credentials).
+      logger.warn("[StewardAuth] Ignoring unparseable Steward base URL", {
+        envVar: key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
   return null;
 }

--- a/packages/cloud-shared/src/lib/cache/client.ts
+++ b/packages/cloud-shared/src/lib/cache/client.ts
@@ -939,9 +939,8 @@ export class CacheClient {
       return false;
     }
 
-    logger.warn(
-      `[Cache] Circuit breaker OPEN (${this.failureCount} failures, retry in ${Math.ceil((this.CIRCUIT_BREAKER_TIMEOUT - timeSinceLastFailure) / 1000)}s)`,
-    );
+    // Breaker is open: degrade to cache-miss silently. The closed->open transition
+    // is logged once in recordFailure(); logging on every blocked call would spam.
     return true;
   }
 
@@ -949,8 +948,14 @@ export class CacheClient {
     this.failureCount++;
     this.lastFailureTime = Date.now();
 
+    // Log exactly on the closed->open transition (failureCount keeps climbing past
+    // MAX_FAILURES while open, so `=== MAX_FAILURES` fires once per open). Include the
+    // failure count + cooldown so a Redis brownout is distinguishable from a DB one.
     if (this.failureCount === this.MAX_FAILURES) {
-      logger.error(`[Cache] Circuit breaker OPENED after ${this.MAX_FAILURES} failures`);
+      logger.warn("[Cache] Circuit breaker OPENED - degrading to cache-miss", {
+        failureCount: this.failureCount,
+        cooldownMs: this.CIRCUIT_BREAKER_TIMEOUT,
+      });
     }
   }
 


### PR DESCRIPTION
Two small observability/cleanup fixes so infra incidents are diagnosable from logs alone.

## Fix 1 — Cache circuit-breaker opening is no longer silent
`packages/cloud-shared/src/lib/cache/client.ts`

The `CacheClient` circuit breaker silently degrades Redis errors to cache misses when it opens. Previously the only transition signal was a bare `logger.error("... OPENED after N failures")` with no structured context, while `isCircuitOpen()` logged a `logger.warn` on **every** blocked call (log spam during a brownout).

- The closed→open transition is now logged **once** in `recordFailure()` at the `=== MAX_FAILURES` boundary (it fires once per open because `failureCount` keeps climbing past the threshold while open and is only cleared by `resetFailures()`/timeout). The log now carries structured `failureCount` + `cooldownMs`, so a Redis brownout is distinguishable from a DB one during an incident.
- Removed the per-blocked-call `logger.warn` in `isCircuitOpen()`.
- **Breaker behavior is unchanged** — same `MAX_FAILURES`, same `CIRCUIT_BREAKER_TIMEOUT`, same `return true`. Logging only.

## Fix 2 — Steward URL parse failures are no longer swallowed
`packages/cloud-api/auth/steward-nonce-exchange/route.ts` and `packages/cloud-api/auth/steward-refresh/route.ts`

`resolveStewardBaseUrl(env)` had an empty `catch {}` around `new URL(trimmed)`. A non-empty but malformed `STEWARD_API_URL` / `NEXT_PUBLIC_STEWARD_API_URL` degraded to an unexplained `503` ("upstream not configured") with no clue which env var was bad.

- Added a `logger.warn` in the catch naming the offending **env var key** + the parse **error message**. The value itself is never logged (it could contain credentials).
- Control flow is identical — still `continue`s to the next candidate. The candidate list was restructured into `[key, value]` tuples so the key can be named without logging the value.
- Both files share the same function and were fixed consistently. This change is scoped to `resolveStewardBaseUrl` only — it does **not** touch `shouldReturnClientToken` / cookie `maxAge`, which are owned by open PR #8656, so this should auto-merge.

## Verification
`bun install --no-save --ignore-scripts` at the worktree root, then:
- `bun run --cwd packages/cloud-shared typecheck` — no errors in `lib/cache/client.ts`
- `bun run --cwd packages/cloud-api typecheck` — no errors in either steward route

Remaining typecheck errors are pre-existing environmental issues on the develop tip (unbuilt generated i18n data in `@elizaos/core`/`@elizaos/shared`, unbuilt `@elizaos/security`/`@elizaos/logger`), unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)