### PR TITLE
refactor(ui/cloud): consolidate duplicated JWT-payload decoding (10 copies → 1)

### DIFF
--- a/packages/ui/src/cloud/account-security/data/use-session-auth.ts
+++ b/packages/ui/src/cloud/account-security/data/use-session-auth.ts
@@ -10,6 +10,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import { LocalStewardAuthContext } from "../../shell/StewardProvider";
 
 type SessionAuthSource = "none" | "steward";
@@ -35,24 +36,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 /** Read a valid non-expired Steward session directly from localStorage. */

--- a/packages/ui/src/cloud/api-explorer/use-session-auth.ts
+++ b/packages/ui/src/cloud/api-explorer/use-session-auth.ts
@@ -12,6 +12,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../lib/jwt";
 import { LocalStewardAuthContext } from "../shell/StewardProvider";
 
 type SessionAuthSource = "none" | "steward";
@@ -74,24 +75,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 /** Read a valid non-expired Steward session directly from localStorage. */

--- a/packages/ui/src/cloud/applications/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/applications/lib/use-session-auth.ts
@@ -16,6 +16,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
@@ -42,24 +43,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 /** Read a valid non-expired Steward session directly from localStorage. */

--- a/packages/ui/src/cloud/approvals/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/approvals/lib/use-session-auth.ts
@@ -16,6 +16,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
@@ -42,24 +43,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 /** Read a valid non-expired Steward session directly from localStorage. */

--- a/packages/ui/src/cloud/billing/use-session-auth.ts
+++ b/packages/ui/src/cloud/billing/use-session-auth.ts
@@ -17,6 +17,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../lib/jwt";
 import { LocalStewardAuthContext } from "../shell/StewardProvider";
 
 type SessionAuthSource = "none" | "steward";
@@ -76,24 +77,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 function readStewardSessionFromStorage(): StewardSessionUser {

--- a/packages/ui/src/cloud/documents/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/documents/lib/use-session-auth.ts
@@ -15,6 +15,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
@@ -41,24 +42,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 /** Read a valid non-expired Steward session directly from localStorage. */

--- a/packages/ui/src/cloud/instances/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/instances/lib/use-session-auth.ts
@@ -13,6 +13,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import { LocalStewardAuthContext } from "../../shell/StewardProvider";
 
 type SessionAuthSource = "none" | "steward";
@@ -74,24 +75,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 function readStewardSessionFromStorage(): StewardSessionUser {

--- a/packages/ui/src/cloud/join/lib/use-join-session.ts
+++ b/packages/ui/src/cloud/join/lib/use-join-session.ts
@@ -11,6 +11,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import { LocalStewardAuthContext } from "../../shell/StewardProvider";
 
 function isPlaywrightTestAuthEnabled(): boolean {
@@ -25,22 +26,12 @@ function isPlaywrightTestAuthEnabled(): boolean {
 }
 
 function tokenIsLive(token: string): boolean {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return false;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded)) as { exp?: number };
-    if (typeof payload.exp === "number" && payload.exp * 1000 < Date.now()) {
-      return false;
-    }
-    return true;
-  } catch {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return false;
+  if (typeof payload.exp === "number" && payload.exp * 1000 < Date.now()) {
     return false;
   }
+  return true;
 }
 
 function readStoredAuthenticated(): boolean {

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -30,6 +30,13 @@ export class ApiError extends Error {
 }
 
 function getApiBaseUrl(): string {
+  // Deliberately same-origin-only in the browser: every `/api/*` call rides the
+  // page's own origin so the steward-token cookie + Bearer header stay scoped to
+  // Eliza Cloud. There is intentionally NO cross-origin fetch bridge here (the
+  // legacy cloud-frontend SPA had one — `installApiFetchBridge` — alongside its
+  // Pages proxy, which created two transports with contradictory cookie scoping;
+  // the app never adopted that, so that dual-path concern does not exist here).
+  // `resolveApiUrl` below enforces this by throwing on any cross-origin URL.
   if (typeof window !== "undefined") return "";
 
   const fromEnv =

--- a/packages/ui/src/cloud/lib/jwt.test.ts
+++ b/packages/ui/src/cloud/lib/jwt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { decodeJwtPayload, jwtExpiryMs } from "./jwt";
+
+/** Build a JWT-shaped string with the given payload object (signature is junk). */
+function makeToken(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const body = base64url(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+/** Standard-then-url base64 encode (mirrors a real JWT segment, no padding). */
+function base64url(input: string): string {
+  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+describe("decodeJwtPayload", () => {
+  it("decodes a well-formed token's payload", () => {
+    const token = makeToken({
+      userId: "u_123",
+      email: "a@b.com",
+      address: "0xabc",
+      exp: 1234567890,
+    });
+    expect(decodeJwtPayload(token)).toEqual({
+      userId: "u_123",
+      email: "a@b.com",
+      address: "0xabc",
+      exp: 1234567890,
+    });
+  });
+
+  it("decodes base64url payloads containing - and _ chars", () => {
+    // Pick a payload whose base64 contains both + and / (→ - and _ after url-encode).
+    const payload = { sub: "ÿÿÿ?>?>", exp: 42 };
+    const token = makeToken(payload);
+    expect(token.split(".")[1]).toMatch(/[-_]/);
+    expect(decodeJwtPayload(token)).toEqual(payload);
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["wrong segment count", "a.b"],
+    ["too many segments", "a.b.c.d"],
+    ["non-base64 payload", "a.!!!.c"],
+    ["payload is not JSON", `a.${base64url("not json")}.c`],
+  ])("returns null for %s", (_label, token) => {
+    expect(decodeJwtPayload(token)).toBeNull();
+  });
+});
+
+describe("jwtExpiryMs", () => {
+  it("returns exp in milliseconds", () => {
+    expect(jwtExpiryMs(makeToken({ exp: 1_000 }))).toBe(1_000_000);
+  });
+
+  it("returns null when exp is absent", () => {
+    expect(jwtExpiryMs(makeToken({ userId: "u" }))).toBeNull();
+  });
+
+  it("returns null when exp is not a number", () => {
+    expect(jwtExpiryMs(makeToken({ exp: "soon" }))).toBeNull();
+  });
+
+  it("returns null for a malformed token", () => {
+    expect(jwtExpiryMs("garbage")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/lib/jwt.ts
+++ b/packages/ui/src/cloud/lib/jwt.ts
@@ -1,0 +1,45 @@
+/**
+ * Single source of truth for decoding a Steward JWT payload in the browser.
+ *
+ * The cloud surfaces only ever inspect the *unverified* payload (its `exp` plus
+ * a few identity claims) to decide whether a locally stored session still looks
+ * live before the server confirms it. Signature verification is the server's
+ * job. Every cloud domain previously reimplemented the same base64url decode;
+ * they all delegate here now so the null/expired semantics stay identical.
+ */
+
+/** Claims the cloud surfaces read off a Steward session token. */
+export interface StewardTokenClaims {
+  exp?: number;
+  userId?: string;
+  sub?: string;
+  email?: string;
+  address?: string;
+}
+
+/**
+ * Base64url-decode and JSON-parse the payload (second segment) of a JWT.
+ * Returns `null` for any malformed token (wrong segment count, bad base64,
+ * invalid JSON) so callers treat "can't read it" as "no session".
+ */
+export function decodeJwtPayload(token: string): StewardTokenClaims | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(
+      base64.length + ((4 - (base64.length % 4)) % 4),
+      "=",
+    );
+    return JSON.parse(atob(padded)) as StewardTokenClaims;
+  } catch {
+    return null;
+  }
+}
+
+/** Milliseconds-since-epoch the token expires, or `null` when it has no `exp`. */
+export function jwtExpiryMs(token: string): number | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload.exp !== "number") return null;
+  return payload.exp * 1000;
+}

--- a/packages/ui/src/cloud/monetization/auth-gate.ts
+++ b/packages/ui/src/cloud/monetization/auth-gate.ts
@@ -15,6 +15,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../lib/jwt";
 import { LocalStewardAuthContext } from "../shell/StewardProvider";
 
 export interface MonetizationAuthState {
@@ -24,28 +25,12 @@ export interface MonetizationAuthState {
   authenticated: boolean;
 }
 
-function decodeStewardTokenExpAndUser(token: string): { exp?: number } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return { exp: payload.exp };
-  } catch {
-    return null;
-  }
-}
-
 function hasValidStoredStewardToken(): boolean {
   if (typeof window === "undefined") return false;
   try {
     const token = localStorage.getItem(STEWARD_TOKEN_KEY);
     if (!token) return false;
-    const decoded = decodeStewardTokenExpAndUser(token);
+    const decoded = decodeJwtPayload(token);
     if (!decoded) return false;
     if (decoded.exp && decoded.exp * 1000 < Date.now()) return false;
     return true;

--- a/packages/ui/src/cloud/public-pages/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/public-pages/lib/use-session-auth.ts
@@ -11,6 +11,7 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { decodeJwtPayload } from "../../lib/jwt";
 import { LocalStewardAuthContext } from "../../shell/StewardProvider";
 
 type SessionAuthSource = "none" | "steward";
@@ -72,24 +73,14 @@ function decodeStewardToken(token: string): {
   walletAddress?: string;
   exp?: number;
 } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    return {
-      id: payload.userId ?? payload.sub ?? "",
-      email: payload.email ?? "",
-      walletAddress: payload.address ?? undefined,
-      exp: payload.exp,
-    };
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return {
+    id: payload.userId ?? payload.sub ?? "",
+    email: payload.email ?? "",
+    walletAddress: payload.address ?? undefined,
+    exp: payload.exp,
+  };
 }
 
 function readStewardSessionFromStorage(): StewardSessionUser {

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -28,6 +28,7 @@ import {
   useRef,
 } from "react";
 import { useLocation } from "react-router-dom";
+import { decodeJwtPayload } from "../lib/jwt";
 import { resolveBrowserStewardApiUrl } from "./steward-url";
 
 export function isPlaceholderValue(value: string | undefined): boolean {
@@ -171,37 +172,18 @@ export function readStoredToken(): string | null {
 }
 
 export function tokenIsExpired(token: string): boolean {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return true;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    if (!payload.exp) return false;
-    return payload.exp * 1000 < Date.now();
-  } catch {
-    return true;
-  }
+  const payload = decodeJwtPayload(token);
+  // A token we can't read is treated as expired; a readable token without an
+  // `exp` claim never expires locally.
+  if (!payload) return true;
+  if (!payload.exp) return false;
+  return payload.exp * 1000 < Date.now();
 }
 
 export function tokenSecsRemaining(token: string): number | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padded = base64.padEnd(
-      base64.length + ((4 - (base64.length % 4)) % 4),
-      "=",
-    );
-    const payload = JSON.parse(atob(padded));
-    if (!payload.exp) return null;
-    return payload.exp - Date.now() / 1000;
-  } catch {
-    return null;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return null;
+  return payload.exp - Date.now() / 1000;
 }
 
 /**


### PR DESCRIPTION
## Summary

Client-side login cleanup for the **live** cloud frontend (`packages/app` consuming `packages/ui/src/cloud/*`).

### FIX 1 — Consolidate duplicated JWT-payload decoding (10 copies → 1)

The same base64url-decode + `JSON.parse(atob(...))` of a Steward JWT payload (`split('.')` → url-decode → pad → `atob` → `JSON.parse`, wrapped in try/catch) was copy-pasted across **10 files**. The audit named 3 (`StewardProvider`, `use-join-session`); a `grep` for `atob(` / `replace(/-/g` in `packages/ui/src/cloud` surfaced the full set:

- `shell/StewardProvider.tsx` — `tokenIsExpired` + `tokenSecsRemaining`
- `join/lib/use-join-session.ts` — `tokenIsLive`
- `monetization/auth-gate.ts` — `decodeStewardTokenExpAndUser`
- 7 per-domain `use-session-auth.ts` (`account-security`, `api-explorer`, `applications`, `approvals`, `billing`, `documents`, `instances`, `public-pages`) — each an identical `decodeStewardToken`

New single helper **`packages/ui/src/cloud/lib/jwt.ts`**:
- `decodeJwtPayload(token): StewardTokenClaims | null` — the shared primitive (null on any malformed token)
- `jwtExpiryMs(token): number | null` — convenience

Every site routes through it. The per-domain hooks keep their own claim-mapping shapes (`{ id, email, walletAddress, exp }`); only the decode primitive is shared.

**Behavior is identical** — same null/expired semantics, same clock units. The exported signatures of `tokenIsExpired` / `tokenSecsRemaining` (imported by `StewardProviderRuntime.tsx`) are unchanged. Net **−107 lines** of duplicated decode logic.

A unit test (`lib/jwt.test.ts`, 11 cases) covers the happy path, url-safe `-`/`_` chars, malformed-token null handling, and `exp` extraction.

### FIX 2 — Dual API-transport (L-1) finding: moot for the live app

The prior audit flagged that the legacy `cloud-frontend` SPA had BOTH a Pages same-origin proxy AND a cross-origin `installApiFetchBridge` with contradictory cookie scoping.

**Verified the live app does NOT have this problem:**
- `grep installApiFetchBridge|api-fetch-bridge` across `packages/ui` + `packages/app` → **zero hits**.
- `packages/ui/src/cloud/lib/api-client.ts` `getApiBaseUrl()` returns `""` in the browser (same-origin), and `resolveApiUrl()` actively **throws** `CROSS_ORIGIN_API_URL` for any cross-origin absolute URL in the browser.

So L-1 is **structurally impossible** in the live app — a cloud-frontend-legacy-only concern, moot for prod. Added a one-line clarifying comment in `api-client.ts` documenting the deliberate same-origin-only design and the absence of any fetch bridge. No transport change made.

## Verification

- `bun install --no-save --ignore-scripts` at worktree root.
- `bunx vitest run src/cloud/lib/jwt.test.ts` → **11/11 pass**.
- `bun run --cwd packages/ui typecheck` → **no errors in any changed/new file** (grep-confirmed). Remaining errors are pre-existing and environmental: unbuilt workspace deps in the fresh worktree (`@elizaos/logger`, `@elizaos/tui`, `@elizaos/capacitor-camera`) and unrelated type drift (`AccountList.tsx`, `useAccounts.ts`, `agent-orchestrator.tsx`).
- `biome check` clean on all changed files (one remaining warning is on a pre-existing, untouched line).
- Cloud auth-hook test suites that loaded all passed (33/33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)