### PR TITLE
fix(cloud-frontend): isolate crypto/bn.js graph into its own chunk

### DIFF
--- a/packages/cloud-frontend/vite.config.ts
+++ b/packages/cloud-frontend/vite.config.ts
@@ -548,6 +548,21 @@ export default defineConfig(({ mode }) => {
           codeSplitting: {
             groups: [
               {
+                // Crypto / big-number graph (bn.js, elliptic, secp256k1, the
+                // hash + cipher libs, and the `buffer` polyfill they call into).
+                // Must be its own chunk: Rolldown's recursive dep-inclusion
+                // otherwise non-deterministically folds this graph into an
+                // eagerly-initialized app chunk (e.g. an i18n locale chunk),
+                // where bn.js runs `Buffer.allocUnsafe` at module-init before
+                // the chunk's CJS Buffer wrapper is hoisted — throwing
+                // "Class constructor cannot be invoked without 'new'" and
+                // killing the whole React tree. Extracting it (highest
+                // priority) keeps the graph + its Buffer together and lazy.
+                name: "vendor-crypto",
+                test: /[\\/]node_modules[\\/](bn\.js|elliptic|secp256k1|@noble[\\/][^\\/]+|hash-base|create-hash|create-hmac|create-ecdh|browserify-sign|browserify-aes|browserify-cipher|browserify-rsa|diffie-hellman|asn1\.js|des\.js|ripemd160|sha\.js|md5\.js|hash\.js|cipher-base|evp_bytestokey|pbkdf2|public-encrypt|randombytes|randomfill|miller-rabin|brorand|hmac-drbg|minimalistic-crypto-utils|minimalistic-assert|safe-buffer|buffer)([\\/]|$)/,
+                priority: 40,
+              },
+              {
                 name: "vendor-wallet",
                 test: /[\\/]node_modules[\\/](wagmi|@wagmi[\\/]|viem[\\/]|@rainbow-me[\\/]|@walletconnect[\\/]|@reown[\\/]|@coinbase[\\/]wallet|mipd|eventemitter3)([\\/]|$)/,
                 priority: 30,


### PR DESCRIPTION
Forward-port of the cloud-frontend crash fix that landed on main in #8682 (KV worker cache is already on develop via #8665).

Rolldown non-deterministically folded the crypto/bn.js graph into an eager en_US locale chunk where bn.js runs Buffer.allocUnsafe before the bundled Buffer is hoisted → 'Class constructor cannot be invoked without new' → blank dashboard. A highest-priority codeSplitting group extracts the crypto graph into a dedicated lazy vendor-crypto chunk. Verified on a CF Pages preview (renders / and /login cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)