### PR TITLE
fix(cloud): harden provisioning-job failure write-back, idempotency, and lane pinning

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -286,6 +286,17 @@ jobs:
             # "HEADSCALE_API_KEY is not configured" when a route is required).
             ENV_FILE=/opt/eliza/cloud/.env.local
             sudo touch "$ENV_FILE"
+            # Pin this control-plane daemon to the AGENT lane. Unset, a single
+            # daemon claims ALL job types (agent + apps); it would claim
+            # APP_DEPLOY / CONTAINER_* jobs it can't run (no apps backend wired
+            # here) and burn them down through retries. The dedicated apps
+            # daemon (apps-provisioning-worker.ts) owns the apps lane. Reconciled
+            # here so CI is the single source of truth and the box self-heals on
+            # every deploy (same mechanism as the HEADSCALE_* keys below). This
+            # value is constant — not a GH var — so it's reconciled directly,
+            # never blanked.
+            sudo sed -i "/^PROVISIONING_JOB_LANES=/d" "$ENV_FILE"
+            printf 'PROVISIONING_JOB_LANES=%s\n' "agent" | sudo tee -a "$ENV_FILE" >/dev/null
             for kv in \
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -467,9 +467,13 @@ app.post("/", async (c) => {
         }
       } catch (err) {
         // Don't block on claim errors — fall through to the async job path.
+        // Emit a stable `event` so a persistently broken warm pool is
+        // observable in aggregate (otherwise every claim silently degrades to
+        // the slow async path with no signal that the fast path is dead).
         logger.warn(
           "[agent-api] Warm pool claim threw on create; falling back",
           {
+            event: "warm_pool.claim_failed",
             agentId: agent.id,
             orgId: user.organization_id,
             error: err instanceof Error ? err.message : String(err),

--- a/packages/cloud-shared/src/db/repositories/jobs.ts
+++ b/packages/cloud-shared/src/db/repositories/jobs.ts
@@ -7,6 +7,7 @@ import {
   offloadJsonField,
   offloadTextField,
 } from "../../lib/storage/object-store";
+import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import type { Job, NewJob } from "../schemas/jobs";
@@ -500,12 +501,28 @@ export class JobsRepository {
    * Marks as failed if max attempts reached.
    * Implements exponential backoff for retries.
    *
+   * When the increment exhausts retries (status flips to `failed`), an optional
+   * `onFailedInTx` callback runs INSIDE the same transaction as the job-status
+   * write. This lets callers flip dependent rows (e.g. an agent sandbox to
+   * `error`, or an app deployment to `failed`) atomically with the job failure,
+   * so a partial commit can never leave the sandbox stuck in `provisioning`
+   * after the job is already `failed` (the 10-min stuck-recovery cron is the
+   * backstop, not the primary signal).
+   *
    * @param id - Job ID to update.
    * @param error - Error message.
    * @param maxAttempts - Maximum allowed attempts.
+   * @param onFailedInTx - Optional callback run in-transaction when the job
+   *   flips to `failed`. Receives the transaction handle and the hydrated job.
+   *   Throwing rolls back BOTH the job-status flip and the dependent write.
    * @returns Updated job record or undefined if not found.
    */
-  async incrementAttempt(id: string, error: string, maxAttempts: number): Promise<Job | undefined> {
+  async incrementAttempt(
+    id: string,
+    error: string,
+    maxAttempts: number,
+    onFailedInTx?: (tx: DbTransaction, job: Job) => Promise<void>,
+  ): Promise<Job | undefined> {
     const job = await this.findById(id);
     if (!job) return undefined;
 
@@ -516,26 +533,42 @@ export class JobsRepository {
     const backoffMs = isFailed ? 0 : 4 ** (newAttempts - 1) * 30 * 1000;
     const scheduledFor = new Date(Date.now() + backoffMs);
 
-    const [updated] = await dbWrite
-      .update(jobs)
-      .set({
-        status: isFailed ? "failed" : "pending",
-        ...(await prepareJobPayload(
-          { error },
-          {
-            id: job.id,
-            organization_id: job.organization_id,
-            created_at: job.created_at,
-          },
-        )),
-        attempts: newAttempts,
-        updated_at: new Date(),
-        scheduled_for: isFailed ? job.scheduled_for : scheduledFor,
-      })
-      .where(eq(jobs.id, id))
-      .returning();
+    const payload = await prepareJobPayload(
+      { error },
+      {
+        id: job.id,
+        organization_id: job.organization_id,
+        created_at: job.created_at,
+      },
+    );
 
-    return updated ? await hydrateJob(updated) : undefined;
+    const hydrated = await dbWrite.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(jobs)
+        .set({
+          status: isFailed ? "failed" : "pending",
+          ...payload,
+          attempts: newAttempts,
+          updated_at: new Date(),
+          scheduled_for: isFailed ? job.scheduled_for : scheduledFor,
+        })
+        .where(eq(jobs.id, id))
+        .returning();
+
+      if (!updated) return undefined;
+
+      const result = await hydrateJob(updated);
+
+      // Same-transaction dependent write on permanent failure: commits
+      // atomically with the `failed` flip above.
+      if (isFailed && onFailedInTx) {
+        await onFailedInTx(tx, result);
+      }
+
+      return result;
+    });
+
+    return hydrated;
   }
 
   /**

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -14,6 +14,7 @@
  */
 
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import {
@@ -24,6 +25,7 @@ import {
   prepareJobInsertData,
 } from "../../db/repositories/jobs";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { apps } from "../../db/schemas/apps";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
@@ -1393,84 +1395,109 @@ export class ProvisioningJobService {
         const errorMsg = err instanceof Error ? err.message : String(err);
         result.errors.push({ jobId: job.id, error: errorMsg });
 
-        // Increment attempt; will auto-fail if max_attempts reached
-        const updated = await jobsRepository.incrementAttempt(job.id, errorMsg, job.max_attempts);
+        // When retries are exhausted (permanent failure) the dependent
+        // status row must flip too — and it must flip ATOMICALLY with the
+        // job-status `failed` write, not in a best-effort follow-up that can
+        // silently swallow. A separate write that fails leaves the sandbox
+        // stuck in "provisioning" until the 10-min stuck-recovery cron
+        // (markStuckProvisioningWithoutActiveJobAsError) catches it. Folding
+        // the dependent flip into incrementAttempt's transaction via
+        // `onFailedInTx` makes both commit together (or roll back together,
+        // so the recovery cron re-runs the whole thing). The cron stays as
+        // the backstop, never the primary signal.
+        const onFailedInTx = this.buildPermanentFailureWriteback(job, errorMsg);
+        const updated = await jobsRepository.incrementAttempt(
+          job.id,
+          errorMsg,
+          job.max_attempts,
+          onFailedInTx,
+        );
 
-        // When retries are exhausted (permanent failure), mark the
-        // sandbox as "error" immediately so the UI reflects reality
-        // instead of staying stuck in "provisioning".
-        if (updated?.status === "failed" && job.type === JOB_TYPES.AGENT_PROVISION) {
-          const data = readAgentProvisionJobData(job);
-          try {
-            await agentSandboxesRepository.update(data.agentId, {
-              status: "error",
-              error_message: `Provisioning permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
-            });
-            logger.warn("[provisioning-jobs] Marked sandbox as error after permanent failure", {
-              jobId: job.id,
-              agentId: data.agentId,
-            });
-          } catch (sandboxErr) {
-            logger.error("[provisioning-jobs] Failed to mark sandbox as error", {
-              jobId: job.id,
-              agentId: data.agentId,
-              error: sandboxErr instanceof Error ? sandboxErr.message : String(sandboxErr),
-            });
-          }
-        }
-
-        // Symmetric handling for app_deploy (Apps / Product 2): a permanently
-        // failed deploy must flip the app off `building`, or the deploy-status
-        // route (which echoes `apps.deployment_status`) reports BUILDING forever
-        // — the CLI/dashboard never sees the failure. Mirrors the createDeployment
-        // enqueue-side catch, which only covers the synchronous enqueue, not this
-        // async daemon execution. Especially relevant during the lane-migration
-        // window, when the agent CP worker (still default=all lanes) claims an
-        // APP_DEPLOY it can't run and exhausts retries.
+        // app_deploy keeps a post-commit cache invalidation (the apps read
+        // cache is invalidated outside the DB transaction); the row flip
+        // itself already committed atomically inside onFailedInTx above.
         if (updated?.status === "failed" && job.type === JOB_TYPES.APP_DEPLOY) {
           const { appId } = readAppDeployJobData(job);
-          try {
-            await appsService.update(appId, { deployment_status: "failed" });
-            logger.warn(
-              "[provisioning-jobs] Marked app deployment as failed after permanent failure",
-              {
-                jobId: job.id,
-                appId,
-              },
-            );
-          } catch (appErr) {
-            logger.error("[provisioning-jobs] Failed to mark app deployment as failed", {
-              jobId: job.id,
-              appId,
-              error: appErr instanceof Error ? appErr.message : String(appErr),
-            });
-          }
-        }
-
-        // Symmetric handling for agent_delete: when the daemon gives up,
-        // flip the row to `deletion_failed` so ops can see the stuck
-        // sandboxes (and the container that probably survived on the core)
-        // instead of leaving the row stuck in `deletion_pending` forever.
-        if (updated?.status === "failed" && job.type === JOB_TYPES.AGENT_DELETE) {
-          const data = readAgentDeleteJobData(job);
-          try {
-            await agentSandboxesRepository.update(data.agentId, {
-              status: "deletion_failed",
-              error_message: `Deletion permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
-            });
-            logger.warn(
-              "[provisioning-jobs] Marked sandbox as deletion_failed after permanent failure",
-              { jobId: job.id, agentId: data.agentId },
-            );
-          } catch (sandboxErr) {
-            logger.error("[provisioning-jobs] Failed to mark sandbox as deletion_failed", {
-              jobId: job.id,
-              agentId: data.agentId,
-              error: sandboxErr instanceof Error ? sandboxErr.message : String(sandboxErr),
-            });
-          }
+          await appsService.invalidateCache(appId);
         }
       }
+    }
+  }
+
+  /**
+   * Builds the in-transaction dependent-row writeback for a job that has just
+   * exhausted its retries. Returned callback runs INSIDE incrementAttempt's
+   * transaction (atomic with the job-status `failed` flip). Returns undefined
+   * for job types that have no dependent status row to flip.
+   */
+  private buildPermanentFailureWriteback(
+    job: Job,
+    errorMsg: string,
+  ): ((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined {
+    switch (job.type) {
+      // Mark the sandbox "error" so the UI reflects reality instead of staying
+      // stuck in "provisioning".
+      case JOB_TYPES.AGENT_PROVISION: {
+        const { agentId } = readAgentProvisionJobData(job);
+        return async (tx) => {
+          await tx
+            .update(agentSandboxes)
+            .set({
+              status: "error",
+              error_message: `Provisioning permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
+              updated_at: new Date(),
+            })
+            .where(eq(agentSandboxes.id, agentId));
+          logger.warn("[provisioning-jobs] Marked sandbox as error after permanent failure", {
+            jobId: job.id,
+            agentId,
+          });
+        };
+      }
+      // Apps / Product 2: a permanently failed deploy must flip the app off
+      // `building`, or the deploy-status route (which echoes
+      // `apps.deployment_status`) reports BUILDING forever — the CLI/dashboard
+      // never sees the failure. The read-cache invalidation runs post-commit
+      // in the caller (cache work must not live inside a DB transaction).
+      // Especially relevant during the lane-migration window, when the agent
+      // CP worker (still default=all lanes) claims an APP_DEPLOY it can't run
+      // and exhausts retries.
+      case JOB_TYPES.APP_DEPLOY: {
+        const { appId } = readAppDeployJobData(job);
+        return async (tx) => {
+          await tx
+            .update(apps)
+            .set({ deployment_status: "failed", updated_at: new Date() })
+            .where(eq(apps.id, appId));
+          logger.warn(
+            "[provisioning-jobs] Marked app deployment as failed after permanent failure",
+            { jobId: job.id, appId },
+          );
+        };
+      }
+      // agent_delete: when the daemon gives up, flip the row to
+      // `deletion_failed` so ops can see the stuck sandboxes (and the container
+      // that probably survived on the core) instead of leaving the row stuck in
+      // `deletion_pending` forever.
+      case JOB_TYPES.AGENT_DELETE: {
+        const { agentId } = readAgentDeleteJobData(job);
+        return async (tx) => {
+          await tx
+            .update(agentSandboxes)
+            .set({
+              status: "deletion_failed",
+              error_message: `Deletion permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
+              updated_at: new Date(),
+            })
+            .where(eq(agentSandboxes.id, agentId));
+          logger.warn(
+            "[provisioning-jobs] Marked sandbox as deletion_failed after permanent failure",
+            { jobId: job.id, agentId },
+          );
+        };
+      }
+      default:
+        return undefined;
     }
   }
 
@@ -1512,12 +1539,23 @@ export class ProvisioningJobService {
       // Apps lane (Product 2): generic app-container lifecycle. Routed to the
       // standalone container-job-service (kept out of the agent-coupled paths
       // above); the executor backend is wired at boot via setContainerExecutorDeps.
+      //
+      // Self-mark completed on success so recoverStaleJobs() can't re-sweep a
+      // slow-but-successful job back to `pending` (the same foot-gun the
+      // AGENT_* arms and APP_DB_DEPROVISION already close): a CONTAINER_PROVISION
+      // that crosses PER_JOB_TIMEOUT_MS while the provider is still creating the
+      // container would, without a terminal row, get re-claimed and provision a
+      // SECOND container. The dispatchers are NOT all idempotent across separate
+      // successful runs; a terminal row is the only safe gate.
       case JOB_TYPES.CONTAINER_PROVISION:
       case JOB_TYPES.CONTAINER_DELETE:
       case JOB_TYPES.CONTAINER_RESTART:
       case JOB_TYPES.CONTAINER_UPGRADE:
       case JOB_TYPES.CONTAINER_LOGS:
         await dispatchContainerJob(job, getContainerExecutorDeps());
+        await jobsRepository.updateStatus(job.id, "completed", {
+          completed_at: new Date(),
+        });
         break;
       // Billing-suspend stop (#8342): the container-billing cron (Worker, no SSH)
       // enqueues this when an org runs out of credit; the daemon runs the real
@@ -1538,8 +1576,19 @@ export class ProvisioningJobService {
       }
       // Apps lane (Product 2): the node deploy. The Worker enqueues this; the
       // daemon runs the real isolated provision via the injected AppDeployRunner.
+      //
+      // Self-mark completed on success (mirrors the AGENT_* arms). The runner is
+      // NOT idempotent across separate successful runs — it ensures the tenant
+      // DB, creates a `containers` row, and enqueues a CONTAINER_PROVISION. A
+      // slow-but-successful deploy that crosses PER_JOB_TIMEOUT_MS would, without
+      // a terminal row, get re-swept by recoverStaleJobs() and double-provision
+      // (a second container row + a second CONTAINER_PROVISION). A completed row
+      // is the only thing that prevents the re-sweep.
       case JOB_TYPES.APP_DEPLOY:
         await dispatchAppDeployJob(job);
+        await jobsRepository.updateStatus(job.id, "completed", {
+          completed_at: new Date(),
+        });
         break;
       // Apps lane (Product 2): tear down a deleted app's isolated tenant DB.
       // The Worker enqueues this; the daemon runs the real DROP + slot release


### PR DESCRIPTION
Four provisioning-robustness fixes surfaced by an audit. Each is independently scoped; all live in the cloud provisioning path.

## 1. Permanent-failure sandbox write-back is now atomic
**Before:** On a permanently-failed job, flipping the dependent status row (sandbox → `error`/`deletion_failed`, app → `failed`) ran in a best-effort `try/catch` that only logged, **after** the job-status `failed` write. A partial commit (or a swallowed sandbox-write error) could leave the sandbox stuck in `provisioning` for up to 10 minutes — until the `markStuckProvisioningWithoutActiveJobAsError` cron caught it.

**After:** `JobsRepository.incrementAttempt` now accepts an optional `onFailedInTx(tx, job)` callback that runs the dependent flip **inside the same transaction** as the `failed` job-status write, so both commit (or roll back) atomically. The 10-min cron stays as the backstop, never the primary signal. The apps read-cache invalidation runs **post-commit** (cache work must not live inside a DB transaction).

- `packages/cloud-shared/src/db/repositories/jobs.ts` — `incrementAttempt` wraps its write in `dbWrite.transaction` + runs `onFailedInTx` on the `failed` flip.
- `packages/cloud-shared/src/lib/services/provisioning-jobs.ts` — new `buildPermanentFailureWriteback()` builds the in-tx dependent write for `AGENT_PROVISION` / `APP_DEPLOY` / `AGENT_DELETE`; the failure handler passes it to `incrementAttempt`.

## 2. Apps-lane executors self-mark terminal on SUCCESS
**Before:** `APP_DEPLOY` and the generic `CONTAINER_*` dispatch relied on "never re-swept." A slow-but-successful deploy that crossed `PER_JOB_TIMEOUT_MS` could be re-claimed by `recoverStaleJobs()` and **double-provision** (a second `containers` row + a second `CONTAINER_PROVISION`, or a second container) — these executors are not idempotent across separate successful runs.

**After:** both cases call `jobsRepository.updateStatus(job.id, "completed", …)` after a successful dispatch, mirroring the `AGENT_*` arms / `CONTAINER_STOP` / `APP_DB_DEPROVISION`. `recoverStaleJobs()` only sweeps `in_progress` rows, so a `completed` row is immune.

- `packages/cloud-shared/src/lib/services/provisioning-jobs.ts`

## 3. Warm-pool claim failures are now observable
**Before:** the warm-pool claim `try/catch` in the agent-create route swallowed errors to `logger.warn` with no aggregable signal, so a persistently broken warm pool silently degraded every create to the slow async path.

**After:** added a stable `event: "warm_pool.claim_failed"` field to the warn log (matching the `event:`-keyed structured-log convention used elsewhere in cloud-shared). Fallback behavior is unchanged.

- `packages/cloud-api/v1/eliza/agents/route.ts`

## 4. Pin the control-plane daemon to the agent lane
**Before:** `PROVISIONING_JOB_LANES` was inert — no in-repo deploy config set it, so the single control-plane daemon claimed **all** job types, including apps-lane jobs (`APP_DEPLOY` / `CONTAINER_*`) it has no backend wired for. It would claim-and-fail those through retries.

**After:** the `deploy-eliza-provisioning-worker.yml` env reconciliation now writes `PROVISIONING_JOB_LANES=agent` into `/opt/eliza/cloud/.env.local` (same self-healing mechanism as the `HEADSCALE_*` keys; constant value, reconciled every deploy). The dedicated apps daemon (`apps-provisioning-worker.ts`, hardcoded to `APPS_JOB_TYPES`, on a separate node with its own `deploy-apps-worker.yml` / `eliza-apps-worker.service`) owns the apps lane — so nothing strands. This is exactly the cutover the daemon's own in-code docs call for ("Pin the main worker to `PROVISIONING_JOB_LANES=agent` once this is live").

- `.github/workflows/deploy-eliza-provisioning-worker.yml`

## Verification
- `bun install --no-save --ignore-scripts` at the worktree root.
- `bun run --cwd packages/cloud-shared typecheck` and `bun run --cwd packages/cloud-api typecheck` — **no new errors in any changed file** (filtered by filename). Remaining errors are pre-existing, unrelated codegen/build-artifact misses (`@elizaos/logger`, `@elizaos/security/kms`, `./generated/validation-keyword-data`) that only appear because the worktree ran `--ignore-scripts` (no build/codegen).
- Biome `check` passes clean on all three changed TS files (after fixing import ordering).
- `provisioning-job-types.test.ts`: 22/22 pass, 100% coverage. (`provisioning-jobs-lanes.test.ts` fails only on `Cannot find module '@elizaos/core'` from the unbuilt worktree — environment, not logic.)
- Workflow YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)