### PR TITLE
fix(shared): unwrap primitive + `response`-keyed reply wrappers

### DIFF
--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -90,6 +90,19 @@ describe("assistant text helpers", () => {
     expect(extractAssistantReplyText('{"reply":7,"action":"NONE"}')).toBe("7");
   });
 
+  it("unwraps the `response` wrapper key too (the key drifts reply/response)", () => {
+    expect(extractAssistantReplyText('{"response":"54"}')).toBe("54");
+    expect(extractAssistantReplyText('{"response":42}')).toBe("42");
+    expect(extractAssistantReplyText('{"response":"hi","action":"NONE"}')).toBe(
+      "hi",
+    );
+    // still rejects a non-primitive value or an unknown-key payload
+    expect(extractAssistantReplyText('{"response":{"x":1}}')).toBeNull();
+    expect(
+      extractAssistantReplyText('{"response":"hi","userData":{"id":1}}'),
+    ).toBeNull();
+  });
+
   it("does not rewrite ordinary chat text that merely contains the word reply", () => {
     expect(
       extractAssistantReplyText("Sure — my reply is that the sky is blue."),

--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -75,11 +75,19 @@ describe("assistant text helpers", () => {
     );
   });
 
-  it("does NOT unwrap a reply object carrying unrelated data (preserve content)", () => {
+  it("does NOT unwrap a reply object carrying unrelated data or a non-primitive reply", () => {
     expect(
       extractAssistantReplyText('{"reply":"hi","userData":{"id":1}}'),
     ).toBeNull();
-    expect(extractAssistantReplyText('{"reply":42}')).toBeNull();
+    // an object/array reply is not user-facing text → leave it alone
+    expect(extractAssistantReplyText('{"reply":{"x":1}}')).toBeNull();
+    expect(extractAssistantReplyText('{"reply":[1,2]}')).toBeNull();
+  });
+
+  it("unwraps a primitive (number/boolean) reply the model emitted as text", () => {
+    expect(extractAssistantReplyText('{"reply":42}')).toBe("42");
+    expect(extractAssistantReplyText('{"reply":true}')).toBe("true");
+    expect(extractAssistantReplyText('{"reply":7,"action":"NONE"}')).toBe("7");
   });
 
   it("does not rewrite ordinary chat text that merely contains the word reply", () => {

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -207,6 +207,7 @@ function isResponseHandlerPayload(
 // JSON with a `reply` field plus unrelated data.
 const REPLY_PAYLOAD_KEYS = new Set([
   "reply",
+  "response",
   "text",
   "message",
   "thought",
@@ -219,23 +220,32 @@ const REPLY_PAYLOAD_KEYS = new Set([
   "attachments",
 ]);
 
-function isSimpleReplyPayload(
-  value: Record<string, unknown>,
-): value is Record<string, unknown> & { reply: string | number | boolean } {
-  const reply = value.reply;
-  // Allow a primitive reply: models emit `{"reply":42}` / `{"reply":true}` too,
-  // not just `{"reply":"…"}`. Objects/arrays aren't user-facing text — reject.
-  if (
-    typeof reply !== "string" &&
-    typeof reply !== "number" &&
-    typeof reply !== "boolean"
-  ) {
-    return false;
+// The model wraps its answer under `reply` or `response` (the key drifts by
+// model/image — both observed on cloud agents). Return the primitive value from
+// whichever is present, but only when EVERY key is a known response-shape key,
+// so ordinary chat text that merely contains JSON is never rewritten. Allows a
+// primitive value (`{"reply":42}` / `{"response":true}`), not just strings;
+// objects/arrays aren't user-facing text and are rejected.
+const PRIMARY_REPLY_KEYS = ["reply", "response"] as const;
+
+function getSimpleReplyValue(value: Record<string, unknown>): string | null {
+  let found: string | number | boolean | undefined;
+  for (const key of PRIMARY_REPLY_KEYS) {
+    const candidate = value[key];
+    if (
+      typeof candidate === "string" ||
+      typeof candidate === "number" ||
+      typeof candidate === "boolean"
+    ) {
+      found = candidate;
+      break;
+    }
   }
+  if (found === undefined) return null;
   for (const key of Object.keys(value)) {
-    if (!REPLY_PAYLOAD_KEYS.has(key)) return false;
+    if (!REPLY_PAYLOAD_KEYS.has(key)) return null;
   }
-  return true;
+  return String(found);
 }
 
 /**
@@ -273,20 +283,22 @@ export function extractAssistantReplyText(input: string): string | null {
   }
 
   // Shape 2: the model emitted its whole reply object as text, e.g.
-  // `{"reply":"107"}` or `{"reply":"…","action":"NONE"}` (observed from
-  // gpt-oss/glm on cloud agents). Only unwrap a well-formed object whose keys
-  // are all known response-shape keys, so ordinary chat text that merely
-  // contains JSON is never rewritten.
+  // `{"reply":"107"}`, `{"response":"54"}`, or `{"reply":"…","action":"NONE"}`
+  // (observed from gpt-oss/glm on cloud agents; the wrapper key drifts between
+  // `reply` and `response`). Only unwrap a well-formed object whose keys are all
+  // known response-shape keys, so ordinary chat text that merely contains JSON
+  // is never rewritten.
   if (
     trimmed.startsWith("{") &&
     trimmed.endsWith("}") &&
-    trimmed.includes('"reply"')
+    (trimmed.includes('"reply"') || trimmed.includes('"response"'))
   ) {
     const parsed = tryParseObject(trimmed);
-    if (parsed && isSimpleReplyPayload(parsed)) {
-      const reply = String(parsed.reply).trim();
-      if (!reply) return null;
-      return stripAssistantStageDirections(reply).trim() || null;
+    const reply = parsed ? getSimpleReplyValue(parsed) : null;
+    if (reply !== null) {
+      const trimmedReply = reply.trim();
+      if (!trimmedReply) return null;
+      return stripAssistantStageDirections(trimmedReply).trim() || null;
     }
   }
 

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -221,8 +221,17 @@ const REPLY_PAYLOAD_KEYS = new Set([
 
 function isSimpleReplyPayload(
   value: Record<string, unknown>,
-): value is Record<string, unknown> & { reply: string } {
-  if (typeof value.reply !== "string") return false;
+): value is Record<string, unknown> & { reply: string | number | boolean } {
+  const reply = value.reply;
+  // Allow a primitive reply: models emit `{"reply":42}` / `{"reply":true}` too,
+  // not just `{"reply":"…"}`. Objects/arrays aren't user-facing text — reject.
+  if (
+    typeof reply !== "string" &&
+    typeof reply !== "number" &&
+    typeof reply !== "boolean"
+  ) {
+    return false;
+  }
   for (const key of Object.keys(value)) {
     if (!REPLY_PAYLOAD_KEYS.has(key)) return false;
   }
@@ -275,7 +284,7 @@ export function extractAssistantReplyText(input: string): string | null {
   ) {
     const parsed = tryParseObject(trimmed);
     if (parsed && isSimpleReplyPayload(parsed)) {
-      const reply = parsed.reply.trim();
+      const reply = String(parsed.reply).trim();
       if (!reply) return null;
       return stripAssistantStageDirections(reply).trim() || null;
     }


### PR DESCRIPTION
Follow-up to #8635. Cloud agents (gpt-oss `:nitro`) emit not just `{"reply":"…"}` but also **primitive** replies like `{"reply":42}` or `{"reply":true}` — **observed rendering raw in the chat on-device** on a dedicated agent. The previous `typeof reply === "string"` check left those un-unwrapped.

Accept `string | number | boolean` and `String()`-coerce. Objects/arrays are still rejected (not user-facing text). Tests: `{"reply":42}` → `"42"`, `{"reply":true}` → `"true"`, `{"reply":{…}}`/`[…]` → `null`. 12/12 green, lint + typecheck clean.

Refs #8434, #8635.