### PR TITLE
feat(plugin-waifu-imagegen-app): image-gen AppView for the agent ElizaOS web UI

### DIFF
--- a/plugins/plugin-waifu-imagegen-app/README.md
+++ b/plugins/plugin-waifu-imagegen-app/README.md
@@ -1,0 +1,60 @@
+# @elizaos/plugin-waifu-imagegen-app
+
+Native **image-generation AppView** for waifu agents. Renders inside an agent's
+ElizaOS web UI canvas (the apps overlay / desktop tab) and invokes the
+waifu.fun image-gen mini-app endpoint directly, settled in Eliza Cloud credits.
+
+Phase 1 of giving each waifu agent its own ElizaOS web UI: this replaces the
+broken waifu patron panel with a first-class app-plugin view.
+
+## What it ships
+
+- **`ImageGenAppView.tsx`** — prompt input, aspect + model selectors, a
+  credits/markup/model price strip, a generate button with loading state, typed
+  error notices (401 sign-in / 402 insufficient-credits / 404 unavailable), and
+  the resulting image with the settled charge. Built on `@elizaos/app-core`
+  primitives (`PagePanel`, `Button`, `Spinner`) and `@elizaos/ui/agent-surface`
+  (`useAgentElement`), matching the visual + agent-addressability language of
+  `plugin-hyperliquid-app`.
+- **`imagegen-client.ts`** — auth-aware `POST` to
+  `/v2/agents/:token/apps/image-gen/invoke` on the waifu API. Sends the
+  agent-app invoke key (`x-waifu-app-invoke-key`) when present, else a Steward
+  JWT bearer. Maps HTTP status onto typed `ImageGenError`s.
+- **`imagegen-config.ts`** — resolves the waifu API base, agent token, and auth
+  credential from a host-injected `window.__WAIFU_IMAGEGEN__` global,
+  `import.meta.env` (`VITE_WAIFU_*`), or a production default.
+- **`imagegen-contracts.ts`** — standalone typed contract (aspects, models,
+  prompt bounds, result + charge shapes, error classifier). No waifu-monorepo
+  imports.
+- **`plugin.ts`** — the `views` declaration (`waifu-imagegen`) that
+  `plugin-app-manager` reads to discover + launch the view. Points at the
+  third-partyized bundle (`dist/views/bundle.js`) and the `ImageGenAppView` export.
+
+## Lazy + third-partyized
+
+The overlay registration (`imagegen-app.ts`) loads the view via a dynamic
+`import()`, and the view bundle third-partyizes `react`, `lucide-react`,
+`@elizaos/ui`, and `@elizaos/app-core` (see `vite.config.views.ts`). The view's
+component tree never lands in the main or mobile entry chunk.
+
+## Configuration
+
+Inject per-agent config when the shell mounts the view:
+
+```ts
+window.__WAIFU_IMAGEGEN__ = {
+  apiBase: "https://waifu.fun",
+  agentTokenAddress: "0x...",
+  stewardJwt: "<jwt>",        // or appInvokeKey for trusted same-process hosts
+  metadata: { inferenceMarkupPercentage: 100, model: "gpt-image-2" },
+};
+```
+
+Or pass `agentTokenAddress` / `metadata` as props to `<ImageGenAppView>`.
+
+## Build
+
+```sh
+bun run build        # js + view bundle + types
+bun run build:views  # just the third-partyized view bundle
+```

--- a/plugins/plugin-waifu-imagegen-app/package.json
+++ b/plugins/plugin-waifu-imagegen-app/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@elizaos/plugin-waifu-imagegen-app",
+  "version": "2.0.3-beta.14",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./*.css": "./dist/*.css",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "dependencies": {
+    "@elizaos/app-core": "workspace:*",
+    "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*",
+    "@elizaos/ui": "workspace:*",
+    "lucide-react": "^1.0.0",
+    "react": "^19.0.0"
+  },
+  "elizaos": {
+    "app": {
+      "displayName": "Image Generation",
+      "category": "creative"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bun run build:js && bun run build:views && bun run build:types",
+    "clean": "rm -rf dist",
+    "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
+    "build:views": "bunx --bun vite build --config vite.config.views.ts",
+    "build:types": "tsc --noCheck -p tsconfig.build.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
@@ -1,0 +1,283 @@
+import type { OverlayAppContext } from "@elizaos/app-core";
+import { Button, PagePanel, Spinner } from "@elizaos/app-core";
+import { useAgentElement } from "@elizaos/ui/agent-surface";
+import { ArrowLeft, ImageIcon, Sparkles } from "lucide-react";
+import { useId } from "react";
+import {
+  IMAGE_GEN_ASPECTS,
+  IMAGE_GEN_MODELS,
+  IMAGE_GEN_PROMPT_MAX,
+  imageGenMarkupPct,
+  imageGenModelLabel,
+} from "./imagegen-contracts";
+import { useImageGenState } from "./useImageGenState";
+
+function SettlementPill() {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-ok/35 bg-ok/12 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ok"
+      role="status"
+      aria-label="Settled in credits"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-ok" />
+      credits
+    </span>
+  );
+}
+
+function PriceStrip({ metadata }: { metadata: unknown }) {
+  const markupPct = imageGenMarkupPct(metadata);
+  const meteredModel = imageGenModelLabel(metadata);
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted">
+      <span className="inline-flex items-center gap-1.5">
+        settlement <SettlementPill />
+      </span>
+      <span>
+        markup{" "}
+        <span className="font-medium text-txt">
+          {markupPct === null ? "n/a" : `+${markupPct}%`}
+        </span>
+      </span>
+      {meteredModel ? (
+        <span>
+          model <span className="font-medium text-txt">{meteredModel}</span>
+        </span>
+      ) : null}
+      <span>
+        price <span className="font-medium text-txt">billed on generate</span>
+      </span>
+    </div>
+  );
+}
+
+function formatUsd(value: number | undefined): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return `$${value.toFixed(value < 0.01 ? 6 : 4)}`;
+}
+
+export interface ImageGenAppViewProps extends OverlayAppContext {
+  /** Optional host override for which agent's image-gen app to invoke. */
+  agentTokenAddress?: string;
+  /** Optional host-supplied app metadata bag (markup pct, metered model). */
+  metadata?: unknown;
+  /** Raised when the backend reports the app is no longer available (404). */
+  onUnavailable?: () => void;
+}
+
+export function ImageGenAppView({
+  exitToApps,
+  agentTokenAddress,
+  metadata,
+  onUnavailable,
+}: ImageGenAppViewProps) {
+  const promptId = useId();
+  const {
+    config,
+    prompt,
+    setPrompt,
+    aspect,
+    setAspect,
+    model,
+    setModel,
+    busy,
+    error,
+    result,
+    promptValid,
+    canGenerate,
+    generate,
+  } = useImageGenState({ agentTokenAddress, metadata, onUnavailable });
+
+  const trimmedLength = prompt.trim().length;
+  const settledTotal = formatUsd(result?.charge?.totalCost);
+
+  const backButton = useAgentElement<HTMLButtonElement>({
+    id: "action-back",
+    role: "button",
+    label: "Back to apps",
+    group: "imagegen-header",
+    description:
+      "Exit the image generation view and return to the apps overlay",
+  });
+  const generateButton = useAgentElement<HTMLButtonElement>({
+    id: "action-generate",
+    role: "button",
+    label: "Generate image",
+    group: "imagegen-form",
+    description: "Generate an image from the current prompt, aspect, and model",
+    status: busy ? "active" : "inactive",
+  });
+  const promptField = useAgentElement<HTMLTextAreaElement>({
+    id: "field-prompt",
+    role: "textarea",
+    label: "Prompt",
+    group: "imagegen-form",
+    description: "Describe the image to generate",
+  });
+
+  return (
+    <div
+      data-testid="imagegen-shell"
+      className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
+    >
+      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+        <Button
+          ref={backButton.ref}
+          {...backButton.agentProps}
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 text-muted hover:text-txt"
+          onClick={exitToApps}
+          aria-label="Back"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+
+        <div className="min-w-0">
+          <h1 className="text-base font-semibold text-txt">Image Generation</h1>
+        </div>
+      </div>
+
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+        <div className="mx-auto max-w-3xl space-y-4">
+          {!config.agentTokenAddress && (
+            <PagePanel.Notice tone="warning">
+              No agent is configured for image generation.
+            </PagePanel.Notice>
+          )}
+
+          <PriceStrip metadata={config.metadata} />
+
+          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+            <label
+              htmlFor={promptId}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-[0.12em] text-muted"
+            >
+              prompt
+            </label>
+            <textarea
+              ref={promptField.ref}
+              {...promptField.agentProps}
+              id={promptId}
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              maxLength={IMAGE_GEN_PROMPT_MAX}
+              rows={3}
+              placeholder="describe the image you want"
+              disabled={busy}
+              className="w-full resize-none rounded-md border border-border bg-bg-accent px-3 py-2 text-sm text-txt outline-none transition-colors placeholder:text-muted focus:border-accent/50 disabled:opacity-60"
+            />
+            <div className="mt-1 flex items-center justify-between text-[11px] uppercase tracking-[0.12em] text-muted">
+              <span>aspect</span>
+              <span>
+                {trimmedLength}/{IMAGE_GEN_PROMPT_MAX}
+              </span>
+            </div>
+
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {IMAGE_GEN_ASPECTS.map((option) => (
+                <Button
+                  key={option}
+                  type="button"
+                  variant={option === aspect ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7 px-2 font-mono text-xs tabular-nums"
+                  disabled={busy}
+                  onClick={() => setAspect(option)}
+                  aria-pressed={option === aspect}
+                >
+                  {option}
+                </Button>
+              ))}
+            </div>
+
+            <div className="mt-3 text-[11px] uppercase tracking-[0.12em] text-muted">
+              model
+            </div>
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {IMAGE_GEN_MODELS.map((option) => (
+                <Button
+                  key={option.id}
+                  type="button"
+                  variant={option.id === model ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  disabled={busy}
+                  onClick={() => setModel(option.id)}
+                  aria-pressed={option.id === model}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+
+            <Button
+              ref={generateButton.ref}
+              {...generateButton.agentProps}
+              type="button"
+              variant="default"
+              className="mt-4 w-full gap-2"
+              disabled={!canGenerate}
+              onClick={() => void generate()}
+            >
+              {busy ? (
+                <>
+                  <Spinner className="h-4 w-4" />
+                  generating
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4" />
+                  generate
+                </>
+              )}
+            </Button>
+
+            {!promptValid && trimmedLength > 0 && (
+              <p className="mt-2 text-xs text-muted">
+                prompt must be between 3 and {IMAGE_GEN_PROMPT_MAX} characters
+              </p>
+            )}
+          </section>
+
+          {error && (
+            <PagePanel.Notice
+              tone={error.kind === "auth" ? "accent" : "danger"}
+            >
+              {error.message}
+            </PagePanel.Notice>
+          )}
+
+          {busy && !result && (
+            <div className="flex items-center justify-center py-12 text-sm text-muted">
+              <Spinner className="mr-3 h-5 w-5" />
+              generating image
+            </div>
+          )}
+
+          {result?.imageUrl && (
+            <figure className="rounded-lg border border-border/24 bg-card/50 p-3">
+              <img
+                src={result.imageUrl}
+                alt={result.prompt}
+                className="w-full rounded-md border border-border object-contain"
+              />
+              <figcaption className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs uppercase tracking-[0.12em] text-muted">
+                <span className="inline-flex items-center gap-1.5">
+                  <ImageIcon className="h-3.5 w-3.5" />
+                  {result.aspect}
+                </span>
+                {settledTotal ? (
+                  <span>
+                    charged{" "}
+                    <span className="font-medium text-txt">{settledTotal}</span>
+                  </span>
+                ) : null}
+              </figcaption>
+            </figure>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-waifu-imagegen-app/src/imagegen-app-view-bundle.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/imagegen-app-view-bundle.ts
@@ -1,0 +1,6 @@
+// Vite view-bundle entry. Re-exports the view component so the built bundle
+// (dist/views/bundle.js) exposes the named export the shell view loader reads
+// (`ImageGenAppView`). Kept separate from ImageGenAppView.tsx so that file
+// exports only React components and stays Fast-Refresh-compatible in dev.
+
+export { ImageGenAppView } from "./ImageGenAppView.tsx";

--- a/plugins/plugin-waifu-imagegen-app/src/imagegen-app.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/imagegen-app.ts
@@ -1,0 +1,24 @@
+import type { OverlayApp } from "@elizaos/app-core";
+import { registerOverlayApp } from "@elizaos/app-core";
+
+export const IMAGEGEN_APP_NAME = "@elizaos/plugin-waifu-imagegen-app";
+
+/**
+ * Overlay-app registration for the waifu image-gen view. The loader is lazy so
+ * the view's component tree (and its waifu invoke client) is only fetched when
+ * the window mounts — keeping it out of the main + mobile entry chunks.
+ */
+export const imageGenApp: OverlayApp = {
+  name: IMAGEGEN_APP_NAME,
+  displayName: "Image Generation",
+  description:
+    "Generate images with the agent's image-gen mini-app, settled in credits",
+  category: "creative",
+  icon: null,
+  loader: () =>
+    import("./ImageGenAppView").then((m) => ({
+      default: m.ImageGenAppView,
+    })),
+};
+
+registerOverlayApp(imageGenApp);

--- a/plugins/plugin-waifu-imagegen-app/src/imagegen-client.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/imagegen-client.ts
@@ -1,0 +1,119 @@
+/**
+ * Image-gen invoke client. Ports the auth + error-mapping behaviour of the
+ * waifu frontend (`invokeImageGen`) into a self-contained, fetch-based call so
+ * the AppView can reach the waifu API from inside the ElizaOS web UI canvas.
+ *
+ * Auth precedence (matches the backend's accepted credentials):
+ *   1. agent-app invoke key  -> header `x-waifu-app-invoke-key`
+ *   2. Steward JWT bearer    -> header `Authorization: Bearer <jwt>`
+ *
+ * 402 (insufficient credits) and 404 (app not live) are surfaced as typed
+ * {@link ImageGenError}s so the view can branch and render them gracefully.
+ */
+
+import type { WaifuImageGenRuntimeConfig } from "./imagegen-config";
+import {
+  classifyImageGenStatus,
+  type ImageGenError,
+  type ImageGenInvokeInput,
+  type ImageGenInvokeResponse,
+  type ImageGenResult,
+} from "./imagegen-contracts";
+
+function buildAuthHeaders(config: WaifuImageGenRuntimeConfig): HeadersInit {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (config.appInvokeKey) {
+    headers["x-waifu-app-invoke-key"] = config.appInvokeKey;
+  } else if (config.stewardJwt) {
+    headers.Authorization = `Bearer ${config.stewardJwt}`;
+  }
+  return headers;
+}
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error.trim()) return error;
+    const message = (payload as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return fallback;
+}
+
+/**
+ * Invoke the image-gen mini-app for the configured agent. Resolves with the
+ * settled {@link ImageGenResult}, or rejects with a typed {@link ImageGenError}
+ * (branch on `.kind`).
+ */
+export async function invokeImageGen(
+  config: WaifuImageGenRuntimeConfig,
+  input: ImageGenInvokeInput,
+): Promise<ImageGenResult> {
+  if (!config.agentTokenAddress) {
+    throw {
+      kind: "misconfigured",
+      status: 503,
+      message: "no agent configured for image generation",
+    } satisfies ImageGenError;
+  }
+  if (!config.appInvokeKey && !config.stewardJwt) {
+    throw {
+      kind: "auth",
+      status: 401,
+      message: "sign in to generate images",
+    } satisfies ImageGenError;
+  }
+
+  const body: Record<string, unknown> = {
+    prompt: input.prompt,
+    aspect: input.aspect ?? "1:1",
+  };
+  if (input.model) body.model = input.model;
+  if (input.style?.trim()) body.style = input.style.trim();
+  if (input.idempotencyKey) body.idempotencyKey = input.idempotencyKey;
+
+  const url = `${config.apiBase}/v2/agents/${encodeURIComponent(
+    config.agentTokenAddress,
+  )}/apps/image-gen/invoke`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: buildAuthHeaders(config),
+      body: JSON.stringify(body),
+    });
+  } catch (caught) {
+    throw {
+      kind: "unknown",
+      status: 0,
+      message:
+        caught instanceof Error
+          ? caught.message
+          : "could not reach image generation",
+    } satisfies ImageGenError;
+  }
+
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ImageGenInvokeResponse;
+
+  if (!response.ok) {
+    throw classifyImageGenStatus(
+      response.status,
+      readErrorMessage(payload, "image generation failed"),
+    );
+  }
+
+  if (!payload?.ok || !payload.data?.imageUrl) {
+    throw {
+      kind: "unknown",
+      status: 500,
+      message: "image generation returned no image",
+    } satisfies ImageGenError;
+  }
+
+  return payload.data;
+}

--- a/plugins/plugin-waifu-imagegen-app/src/imagegen-config.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/imagegen-config.ts
@@ -1,0 +1,122 @@
+/**
+ * Runtime configuration resolver for the waifu image-gen AppView.
+ *
+ * The image-gen invoke endpoint lives on the waifu.fun API (a different origin
+ * from the ElizaOS agent server this view renders inside), keyed by the agent's
+ * token address. This module resolves three things at view-mount time, in
+ * priority order:
+ *
+ *   1. waifu API base   — where to POST the invoke
+ *   2. agent token addr — which agent's image-gen app to invoke
+ *   3. auth credential  — a Steward JWT bearer OR an agent-app invoke key
+ *
+ * Resolution sources (first non-empty wins):
+ *   - a host-injected global `window.__WAIFU_IMAGEGEN__` (the ElizaOS shell can
+ *     populate this per-agent when it mounts the view)
+ *   - Vite-style `import.meta.env` (VITE_WAIFU_*) baked at bundle build
+ *   - a sane production default for the API base
+ *
+ * Nothing here imports from the waifu monorepo; the contract is the injected
+ * global / env shape only.
+ */
+
+export interface WaifuImageGenRuntimeConfig {
+  /** Base URL of the waifu API, e.g. "https://waifu.fun". No trailing slash. */
+  apiBase: string;
+  /** The agent's token address whose image-gen app is invoked. */
+  agentTokenAddress: string | null;
+  /** Steward JWT bearer, when the viewer is signed in. */
+  stewardJwt: string | null;
+  /**
+   * Agent-app invoke key (x-waifu-app-invoke-key). Server/runtime contexts only.
+   * Present when the host injects it for a trusted same-process surface.
+   */
+  appInvokeKey: string | null;
+  /** App metadata bag (markup pct, metered model) if the host supplies it. */
+  metadata: unknown;
+}
+
+interface InjectedConfig {
+  apiBase?: string;
+  agentTokenAddress?: string;
+  stewardJwt?: string;
+  appInvokeKey?: string;
+  metadata?: unknown;
+}
+
+const DEFAULT_WAIFU_API_BASE = "https://waifu.fun";
+
+function readInjectedGlobal(): InjectedConfig | null {
+  if (typeof window === "undefined") return null;
+  const raw = (window as unknown as Record<string, unknown>).__WAIFU_IMAGEGEN__;
+  if (!raw || typeof raw !== "object") return null;
+  return raw as InjectedConfig;
+}
+
+function readEnv(key: string): string | null {
+  // import.meta.env is baked at bundle build; guard for non-Vite hosts.
+  const env = (import.meta as unknown as { env?: Record<string, unknown> }).env;
+  const value = env?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function firstNonEmpty(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/**
+ * Resolve the live image-gen runtime config. The optional `override` lets the
+ * AppView's host props (token address, metadata) win over ambient sources when
+ * the shell passes them explicitly.
+ */
+export function resolveWaifuImageGenConfig(
+  override?: Partial<WaifuImageGenRuntimeConfig>,
+): WaifuImageGenRuntimeConfig {
+  const injected = readInjectedGlobal();
+
+  const apiBase = stripTrailingSlash(
+    firstNonEmpty(
+      override?.apiBase,
+      injected?.apiBase,
+      readEnv("VITE_WAIFU_API_BASE"),
+      DEFAULT_WAIFU_API_BASE,
+    ) ?? DEFAULT_WAIFU_API_BASE,
+  );
+
+  const agentTokenAddress = firstNonEmpty(
+    override?.agentTokenAddress,
+    injected?.agentTokenAddress,
+    readEnv("VITE_WAIFU_AGENT_TOKEN"),
+  );
+
+  const stewardJwt = firstNonEmpty(
+    override?.stewardJwt,
+    injected?.stewardJwt,
+    readEnv("VITE_WAIFU_STEWARD_JWT"),
+  );
+
+  const appInvokeKey = firstNonEmpty(
+    override?.appInvokeKey,
+    injected?.appInvokeKey,
+  );
+
+  const metadata =
+    override?.metadata !== undefined ? override.metadata : injected?.metadata;
+
+  return {
+    apiBase,
+    agentTokenAddress,
+    stewardJwt,
+    appInvokeKey,
+    metadata: metadata ?? null,
+  };
+}

--- a/plugins/plugin-waifu-imagegen-app/src/imagegen-contracts.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/imagegen-contracts.ts
@@ -1,0 +1,193 @@
+/**
+ * Typed contract for the waifu.fun image-gen mini-app invoke endpoint.
+ *
+ * Mirrors the backend in `apps/api/src/routes/v2/apps.ts`
+ * (`POST /v2/agents/:token/apps/image-gen/invoke`) and the existing waifu
+ * frontend client (`apps/frontend/src/lib/wave-t/image-gen.ts`). Kept as a
+ * standalone module so this app-plugin owns its own surface area and never
+ * imports from the waifu monorepo.
+ *
+ * Backend contract:
+ *
+ *   POST /v2/agents/:token/apps/image-gen/invoke
+ *     auth:  Steward bearer (Authorization: Bearer <jwt>)  OR
+ *            x-waifu-app-invoke-key (agent runtime, server-side only)
+ *     body:  { prompt: string (3..1800), style?: string, aspect?: AspectRatio,
+ *              model?: string, idempotencyKey?: string }
+ *     200:   { ok: true, data: ImageGenResult }
+ *     400:   bad prompt / aspect
+ *     401:   missing / invalid steward bearer
+ *     402:   insufficient credits (Eliza Cloud charge failed)
+ *     404:   image-gen app not registered / not live for this agent
+ *     409:   duplicate idempotencyKey
+ *     503:   misconfigured / db down
+ */
+
+export const IMAGE_GEN_APP_ID = "image-gen";
+
+export const IMAGE_GEN_ASPECTS = [
+  "1:1",
+  "2:3",
+  "3:2",
+  "3:4",
+  "4:3",
+  "4:5",
+  "5:4",
+  "9:16",
+  "16:9",
+  "21:9",
+] as const;
+
+export type ImageGenAspect = (typeof IMAGE_GEN_ASPECTS)[number];
+
+export interface ImageGenModelOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+export const IMAGE_GEN_MODELS: readonly ImageGenModelOption[] = [
+  { id: "openai/gpt-image-2/text-to-image", label: "GPT Image 2" },
+  { id: "bytedance/seedream-v5.0-lite", label: "Seedream 5" },
+  { id: "google/nano-banana-2/text-to-image", label: "Nano Banana 2" },
+  { id: "qwen/qwen-image-2.0/text-to-image", label: "Qwen Image" },
+] as const;
+
+export type ImageGenModelId = (typeof IMAGE_GEN_MODELS)[number]["id"];
+
+export const DEFAULT_IMAGE_GEN_MODEL_ID: ImageGenModelId =
+  "openai/gpt-image-2/text-to-image";
+
+export const DEFAULT_IMAGE_GEN_ASPECT: ImageGenAspect = "1:1";
+
+export const IMAGE_GEN_PROMPT_MIN = 3;
+export const IMAGE_GEN_PROMPT_MAX = 1800;
+
+export interface ImageGenCharge {
+  status?: string;
+  currency?: string;
+  baseCost?: number;
+  creatorMarkup?: number;
+  totalCost?: number;
+  creatorEarnings?: number;
+  balance?: number;
+  detail?: string;
+}
+
+export interface ImageGenEarnings {
+  revenueLifetimeUsd: string;
+  revenue24hUsd: string;
+  revenue7dUsd: string;
+}
+
+export interface ImageGenResult {
+  appId: string;
+  elizaCloudAppId: string;
+  agentTokenAddress: string;
+  imageUrl: string;
+  prompt: string;
+  aspect: string;
+  charge: ImageGenCharge;
+  earnings: ImageGenEarnings | null;
+  billingReality: string;
+}
+
+export interface ImageGenInvokeResponse {
+  ok: boolean;
+  data?: ImageGenResult;
+  error?: string;
+}
+
+export interface ImageGenInvokeInput {
+  prompt: string;
+  aspect?: ImageGenAspect;
+  model?: ImageGenModelId;
+  style?: string;
+  idempotencyKey?: string;
+}
+
+/** Recognised failure kinds surfaced to the AppView so it can branch on status. */
+export type ImageGenErrorKind =
+  | "auth"
+  | "insufficient-credits"
+  | "not-available"
+  | "duplicate"
+  | "bad-request"
+  | "misconfigured"
+  | "unknown";
+
+export interface ImageGenError {
+  kind: ImageGenErrorKind;
+  status: number;
+  message: string;
+}
+
+export function isImageGenError(value: unknown): value is ImageGenError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { kind?: unknown }).kind === "string" &&
+    typeof (value as { status?: unknown }).status === "number"
+  );
+}
+
+/** Map an HTTP status + message onto a typed {@link ImageGenError}. */
+export function classifyImageGenStatus(
+  status: number,
+  message: string,
+): ImageGenError {
+  switch (status) {
+    case 401:
+      return { kind: "auth", status, message: "sign in to generate images" };
+    case 402:
+      return {
+        kind: "insufficient-credits",
+        status,
+        message: "not enough credits to generate",
+      };
+    case 404:
+      return {
+        kind: "not-available",
+        status,
+        message: "image generation is not available for this agent",
+      };
+    case 409:
+      return {
+        kind: "duplicate",
+        status,
+        message: "that request was already submitted",
+      };
+    case 400:
+      return {
+        kind: "bad-request",
+        status,
+        message: message || "invalid request",
+      };
+    case 503:
+      return {
+        kind: "misconfigured",
+        status,
+        message: "image generation is temporarily unavailable",
+      };
+    default:
+      return {
+        kind: "unknown",
+        status,
+        message: message || "image generation failed",
+      };
+  }
+}
+
+/** Pull the configured creator markup pct off an app metadata bag. */
+export function imageGenMarkupPct(metadata: unknown): number | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const raw = (metadata as Record<string, unknown>).inferenceMarkupPercentage;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/** Read the metered model label off an app metadata bag. */
+export function imageGenModelLabel(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const raw = (metadata as Record<string, unknown>).model;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}

--- a/plugins/plugin-waifu-imagegen-app/src/index.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./ImageGenAppView";
+export { IMAGEGEN_APP_NAME, imageGenApp } from "./imagegen-app";
+export * from "./imagegen-client";
+export * from "./imagegen-config";
+export * from "./imagegen-contracts";
+export { waifuImageGenPlugin } from "./plugin";
+export * from "./useImageGenState";

--- a/plugins/plugin-waifu-imagegen-app/src/plugin.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/plugin.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from "@elizaos/core";
+
+/**
+ * Waifu image-gen app-plugin.
+ *
+ * Pure frontend AppView: it ships a single GUI view that renders inside an
+ * agent's ElizaOS web UI canvas and invokes the waifu.fun image-gen mini-app
+ * endpoint directly (credits-settled). No agent routes/actions/services — the
+ * backend already lives on the waifu API.
+ *
+ * The `views` array is the discovery + launch contract read by
+ * plugin-app-manager: it points at the third-partyized view bundle
+ * (`dist/views/bundle.js`) and the `ImageGenAppView` component export, and
+ * marks the view visible in the app manager and as a desktop tab.
+ */
+export const waifuImageGenPlugin: Plugin = {
+  name: "@elizaos/plugin-waifu-imagegen-app",
+  description:
+    "Native image-generation AppView for waifu agents — prompt, style/aspect/model selection, credits-settled invoke of the agent's image-gen mini-app",
+  views: [
+    {
+      id: "waifu-imagegen",
+      label: "Image Generation",
+      description:
+        "Generate images with the agent's image-gen mini-app, settled in credits",
+      icon: "ImageIcon",
+      path: "/waifu-imagegen",
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "ImageGenAppView",
+      tags: ["creative", "image", "waifu", "generation"],
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+    {
+      id: "waifu-imagegen",
+      label: "Image Generation XR",
+      description:
+        "Generate images with the agent's image-gen mini-app, settled in credits",
+      icon: "ImageIcon",
+      path: "/waifu-imagegen",
+      viewType: "xr",
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "ImageGenAppView",
+      tags: ["creative", "image", "waifu", "generation"],
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+  ],
+};

--- a/plugins/plugin-waifu-imagegen-app/src/ui.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/ui.ts
@@ -1,0 +1,6 @@
+// Browser/UI-only barrel: the view component plus its overlay-app registration.
+// Importing this (not the root index) keeps Node-only `Plugin` wiring out of
+// frontend bundles. Mirrors the hyperliquid-app `ui.ts` pattern.
+export { ImageGenAppView } from "./ImageGenAppView.tsx";
+export { IMAGEGEN_APP_NAME, imageGenApp } from "./imagegen-app.ts";
+export { useImageGenState } from "./useImageGenState.ts";

--- a/plugins/plugin-waifu-imagegen-app/src/useImageGenState.ts
+++ b/plugins/plugin-waifu-imagegen-app/src/useImageGenState.ts
@@ -1,0 +1,140 @@
+/**
+ * State hook for the image-gen AppView. Owns the prompt/aspect/model form
+ * state, the invoke lifecycle (busy / error / result), and resolves the waifu
+ * runtime config once on mount. Kept separate from the view so the .tsx file
+ * exports only React components (Fast-Refresh friendly).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { invokeImageGen } from "./imagegen-client";
+import {
+  resolveWaifuImageGenConfig,
+  type WaifuImageGenRuntimeConfig,
+} from "./imagegen-config";
+import {
+  DEFAULT_IMAGE_GEN_ASPECT,
+  DEFAULT_IMAGE_GEN_MODEL_ID,
+  IMAGE_GEN_PROMPT_MAX,
+  IMAGE_GEN_PROMPT_MIN,
+  type ImageGenAspect,
+  type ImageGenError,
+  type ImageGenModelId,
+  type ImageGenResult,
+  isImageGenError,
+} from "./imagegen-contracts";
+
+export interface ImageGenStateOptions {
+  /** Host-supplied agent token address (wins over ambient config). */
+  agentTokenAddress?: string;
+  /** Host-supplied app metadata bag (markup pct, metered model). */
+  metadata?: unknown;
+  /** Called when the backend reports the app is no longer available (404). */
+  onUnavailable?: () => void;
+}
+
+export interface ImageGenState {
+  config: WaifuImageGenRuntimeConfig;
+  prompt: string;
+  setPrompt: (next: string) => void;
+  aspect: ImageGenAspect;
+  setAspect: (next: ImageGenAspect) => void;
+  model: ImageGenModelId;
+  setModel: (next: ImageGenModelId) => void;
+  busy: boolean;
+  error: ImageGenError | null;
+  result: ImageGenResult | null;
+  promptValid: boolean;
+  canGenerate: boolean;
+  generate: () => Promise<void>;
+}
+
+function freshIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function useImageGenState(
+  options: ImageGenStateOptions = {},
+): ImageGenState {
+  const config = useMemo(
+    () =>
+      resolveWaifuImageGenConfig({
+        agentTokenAddress: options.agentTokenAddress,
+        metadata: options.metadata,
+      }),
+    [options.agentTokenAddress, options.metadata],
+  );
+
+  const [prompt, setPrompt] = useState("");
+  const [aspect, setAspect] = useState<ImageGenAspect>(
+    DEFAULT_IMAGE_GEN_ASPECT,
+  );
+  const [model, setModel] = useState<ImageGenModelId>(
+    DEFAULT_IMAGE_GEN_MODEL_ID,
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<ImageGenError | null>(null);
+  const [result, setResult] = useState<ImageGenResult | null>(null);
+
+  const trimmed = prompt.trim();
+  const promptValid =
+    trimmed.length >= IMAGE_GEN_PROMPT_MIN &&
+    trimmed.length <= IMAGE_GEN_PROMPT_MAX;
+  const canGenerate = promptValid && !busy;
+
+  const onUnavailable = options.onUnavailable;
+
+  const generate = useCallback(async () => {
+    if (busy || !promptValid) return;
+    setBusy(true);
+    setError(null);
+    // Drop any prior image so a failed retry never leaves stale output (and a
+    // stale settled charge) rendered under a fresh error.
+    setResult(null);
+    try {
+      const next = await invokeImageGen(config, {
+        prompt: trimmed,
+        aspect,
+        model,
+        idempotencyKey: freshIdempotencyKey(),
+      });
+      setResult(next);
+    } catch (caught) {
+      if (isImageGenError(caught)) {
+        // A 404 means the registry row went stale (paused/unpublished). Tell the
+        // host so it can flip the surface to an unavailable state.
+        if (caught.kind === "not-available") onUnavailable?.();
+        setError(caught);
+      } else {
+        setError({
+          kind: "unknown",
+          status: 500,
+          message:
+            caught instanceof Error
+              ? caught.message
+              : "image generation failed",
+        });
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, promptValid, config, trimmed, aspect, model, onUnavailable]);
+
+  return {
+    config,
+    prompt,
+    setPrompt,
+    aspect,
+    setAspect,
+    model,
+    setModel,
+    busy,
+    error,
+    result,
+    promptValid,
+    canGenerate,
+    generate,
+  };
+}

--- a/plugins/plugin-waifu-imagegen-app/tsconfig.build.json
+++ b/plugins/plugin-waifu-imagegen-app/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.build.shared.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
+}

--- a/plugins/plugin-waifu-imagegen-app/vite.config.views.ts
+++ b/plugins/plugin-waifu-imagegen-app/vite.config.views.ts
@@ -1,0 +1,10 @@
+import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
+
+export default createViewBundleConfig({
+  packageName: "@elizaos/plugin-waifu-imagegen-app",
+  viewId: "waifu-imagegen",
+  entry: "./src/imagegen-app-view-bundle.ts",
+  outDir: "dist/views",
+  componentExport: "ImageGenAppView",
+  additionalExternals: ["@elizaos/app-core"],
+});


### PR DESCRIPTION
Part of the waifu web-UI direction (#8434): each waifu agent's capabilities surface as ElizaOS app-plugin AppViews in its canvas, replacing the bespoke patron UI.

## What
New `plugin-waifu-imagegen-app` — the image-gen mini-app as an AppView that renders inside an agent's Eliza web UI:
- `ImageGenAppView.tsx` — prompt input, aspect/model selectors, credits/markup/price strip, generate + spinner, typed error notices, settled result image + charge
- `useImageGenState.ts` — form + invoke lifecycle (split for Fast-Refresh, mirrors the hyperliquid `.interact` split)
- `imagegen-client/config/contracts.ts` — auth-aware POST to `/v2/agents/:token/apps/image-gen/invoke`, standalone typed contract (no waifu-monorepo imports)
- `plugin.ts` — `views[]` so plugin-app-manager can discover + launch it

## Contract match
Same primitives as `HyperliquidAppView` (`@elizaos/app-core` PagePanel/Button/Spinner + `@elizaos/ui/agent-surface` useAgentElement). **Lazy/third-partyized** (dynamic-import loader + vite third-partyizes app-core) — does NOT enter the mobile entry chunk, respecting the @elizaos/ui boundary. 402→insufficient-credits, 404→unavailable, 401→sign-in handled.

## Verification
tsc strict exit 0 (no `any`), biome clean.

## Note
The invoke endpoint is cross-origin (waifu API), so the view does an auth-aware fetch (not ElizaClient.fetch). The shell injects `window.__WAIFU_IMAGEGEN__` {apiBase, agentTokenAddress, jwt/appInvokeKey} per agent — that per-agent shell wiring is the follow-up.

Co-authored-by: wakesync <shadow@shad0w.xyz>