### PR TITLE
feat(plugin-polymarket-app): live positions + PnL surface in the AppView

### DIFF
--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
@@ -4,6 +4,7 @@ import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { ArrowLeft, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { loadPolymarketTuiState } from "./PolymarketAppView.helpers";
+import { PolymarketPositionsPanel } from "./PolymarketPositionsPanel";
 import type {
   PolymarketMarket,
   PolymarketStatusResponse,
@@ -39,6 +40,7 @@ export function PolymarketAppView({ exitToApps, t }: OverlayAppContext) {
     markets,
     selectedMarket,
     setSelectedMarket,
+    positions,
     loading,
     error,
     refresh,
@@ -127,6 +129,13 @@ export function PolymarketAppView({ exitToApps, t }: OverlayAppContext) {
               style={{ display: "flex", flexDirection: "column", gap: 12 }}
             >
               <ReadinessStrip status={status} />
+              {status?.account.ready ? (
+                <PolymarketPositionsPanel
+                  positions={positions?.positions ?? []}
+                  summary={positions?.summary ?? null}
+                  blockedReason={status.account.reason}
+                />
+              ) : null}
               {loading && markets.length === 0 ? (
                 <div style={{ display: "grid", gap: 10 }}>
                   {[0, 1, 2, 3].map((i) => (

--- a/plugins/plugin-polymarket-app/src/PolymarketPositionsPanel.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketPositionsPanel.tsx
@@ -1,0 +1,397 @@
+// Live Polymarket positions + PnL surface for the native AppView.
+//
+// Phase 2 of moving a waifu agent's surfaces into its own ElizaOS web UI: this
+// is the prediction-market analogue of the sibling plugin-hyperliquid-app
+// HyperliquidPositionsPanel. The existing PolymarketAppView fetches rich
+// market data but never surfaced the agent's OWN positions — the `/positions`
+// route returns market question, outcome (YES/NO), shares, current value, and
+// cash/percent PnL, yet only a count ever reached the view (and only in the
+// TUI). This panel renders that data: an account-health hero strip (portfolio
+// value, total PnL, open count) over a dense per-position table (market /
+// outcome / shares / value / unrealized PnL). Read-only — no trade execution
+// lives here.
+//
+// Visual language matches PolymarketAppView exactly: that view styles with
+// inline CSS-variable theme tokens (--accent, --txt, --muted, --border,
+// --surface, --ok) rather than Tailwind utility classes, so this panel uses the
+// same tokens to stay visually consistent with the surrounding markets list.
+// The single non-neutral accents are profit-green and loss-red, mirroring the
+// HL panel's one-green-one-red discipline.
+
+import { TrendingDown, TrendingUp } from "lucide-react";
+import type {
+  PolymarketPosition,
+  PolymarketPositionsSummary,
+} from "./polymarket-contracts";
+
+const ACCENT = "var(--accent, #ff8a24)";
+const TXT = "var(--txt, #111)";
+const MUTED = "var(--muted, rgba(0,0,0,0.58))";
+const BORDER = "var(--border, rgba(0,0,0,0.12))";
+const SURFACE = "var(--surface, rgba(0,0,0,0.04))";
+const OK = "var(--ok, #22c55e)";
+const DANGER = "var(--danger, #ef4444)";
+
+const EMPTY_CELL = "—";
+
+function parseNumber(value: string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatUsd(
+  value: number | null,
+  options: { withSign?: boolean } = {},
+): string {
+  if (value === null) return EMPTY_CELL;
+  const sign = options.withSign && value > 0 ? "+" : value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(2)}`;
+}
+
+function formatShares(value: string | null): string {
+  const parsed = parseNumber(value);
+  if (parsed === null) return EMPTY_CELL;
+  return Math.abs(parsed).toLocaleString("en-US", {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 0,
+  });
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return EMPTY_CELL;
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${(value * 100).toFixed(1)}%`;
+}
+
+function pnlColor(value: number | null): string {
+  if (value === null || value === 0) return MUTED;
+  return value > 0 ? OK : DANGER;
+}
+
+/**
+ * The YES/NO (or named) outcome pill. Binary YES leans accent, NO leans muted;
+ * any other outcome name renders neutral. Mirrors the OutcomeChip language in
+ * PolymarketAppView without importing it (that one is market-list specific).
+ */
+function OutcomePill({ outcome }: { outcome: string | null }) {
+  const label = outcome ?? "—";
+  const normalized = label.trim().toLowerCase();
+  const isYes = normalized === "yes";
+  const isNo = normalized === "no";
+  const color = isYes ? ACCENT : isNo ? MUTED : TXT;
+  const background = isYes
+    ? "var(--accent-subtle, rgba(255,138,36,0.14))"
+    : SURFACE;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "2px 8px",
+        borderRadius: 99,
+        border: `1px solid ${isYes ? "var(--accent-subtle, rgba(255,138,36,0.3))" : BORDER}`,
+        background,
+        fontSize: 11,
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.02em",
+        color,
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  color = TXT,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div
+      style={{
+        flex: "1 1 90px",
+        minWidth: 90,
+        borderRadius: 12,
+        border: `1px solid ${BORDER}`,
+        background: SURFACE,
+        padding: "10px 12px",
+      }}
+    >
+      <div style={{ fontSize: 11.5, color: MUTED }}>{label}</div>
+      <div
+        style={{
+          marginTop: 4,
+          fontSize: 16,
+          fontWeight: 700,
+          color,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function AccountHealthStrip({
+  summary,
+}: {
+  summary: PolymarketPositionsSummary | null;
+}) {
+  const totalValue = parseNumber(summary?.totalValue ?? null);
+  const totalPnl = parseNumber(summary?.totalCashPnl ?? null);
+  const totalPercent = parseNumber(summary?.totalPercentPnl ?? null);
+  const openPositions = summary?.openPositions ?? 0;
+
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      <StatTile label="Portfolio" value={formatUsd(totalValue)} />
+      <StatTile
+        label="Total PnL"
+        value={formatUsd(totalPnl, { withSign: true })}
+        color={pnlColor(totalPnl)}
+      />
+      <StatTile
+        label="Return"
+        value={formatPercent(totalPercent)}
+        color={pnlColor(totalPercent)}
+      />
+      <StatTile label="Open" value={String(openPositions)} />
+    </div>
+  );
+}
+
+function PositionRow({ position }: { position: PolymarketPosition }) {
+  const label = position.question ?? position.slug ?? position.marketId ?? "—";
+  const value = parseNumber(position.currentValue);
+  const cashPnl = parseNumber(position.cashPnl);
+  const percentPnl = parseNumber(position.percentPnl);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns:
+          "minmax(0, 1.6fr) minmax(0, 0.8fr) minmax(0, 0.8fr) minmax(0, 1fr)",
+        gap: 10,
+        alignItems: "center",
+        padding: "11px 14px",
+        borderTop: `1px solid ${BORDER}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 5,
+          minWidth: 0,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: TXT,
+            lineHeight: 1.3,
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {label}
+        </span>
+        <OutcomePill outcome={position.outcome} />
+      </div>
+
+      <span
+        style={{
+          textAlign: "right",
+          fontSize: 12.5,
+          color: MUTED,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {formatShares(position.size)}
+      </span>
+
+      <span
+        style={{
+          textAlign: "right",
+          fontSize: 12.5,
+          color: TXT,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {formatUsd(value)}
+      </span>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          lineHeight: 1.25,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12.5,
+            fontWeight: 700,
+            color: pnlColor(cashPnl),
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {formatUsd(cashPnl, { withSign: true })}
+        </span>
+        {percentPnl !== null ? (
+          <span
+            style={{
+              fontSize: 11,
+              color: pnlColor(percentPnl),
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {formatPercent(percentPnl)}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function HeaderRow() {
+  const cellStyle: React.CSSProperties = {
+    fontSize: 10.5,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    color: MUTED,
+  };
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns:
+          "minmax(0, 1.6fr) minmax(0, 0.8fr) minmax(0, 0.8fr) minmax(0, 1fr)",
+        gap: 10,
+        padding: "9px 14px",
+        borderBottom: `1px solid ${BORDER}`,
+      }}
+    >
+      <span style={cellStyle}>Market / Outcome</span>
+      <span style={{ ...cellStyle, textAlign: "right" }}>Shares</span>
+      <span style={{ ...cellStyle, textAlign: "right" }}>Value</span>
+      <span style={{ ...cellStyle, textAlign: "right" }}>PnL</span>
+    </div>
+  );
+}
+
+export interface PolymarketPositionsPanelProps {
+  positions: readonly PolymarketPosition[];
+  summary: PolymarketPositionsSummary | null;
+  /** Account-read blocked reason (e.g. no wallet configured). Null when ready. */
+  blockedReason?: string | null;
+}
+
+/**
+ * The live positions + PnL surface. Renders the account-health hero strip and a
+ * dense per-position table, or an honest empty/blocked state. Display only.
+ */
+export function PolymarketPositionsPanel({
+  positions,
+  summary,
+  blockedReason = null,
+}: PolymarketPositionsPanelProps) {
+  // Show only positions that still hold shares — closed/dust rows are noise.
+  const openPositions = positions.filter((position) => {
+    const size = parseNumber(position.size);
+    return size !== null && Math.abs(size) > 1e-9;
+  });
+  const totalPnl = parseNumber(summary?.totalCashPnl ?? null);
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <AccountHealthStrip summary={summary} />
+
+      <div
+        style={{
+          borderRadius: 16,
+          border: `1px solid ${BORDER}`,
+          background: "var(--card, #fff)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "11px 14px",
+            borderBottom:
+              blockedReason || openPositions.length === 0
+                ? "none"
+                : `1px solid ${BORDER}`,
+          }}
+        >
+          {totalPnl !== null && totalPnl < 0 ? (
+            <TrendingDown style={{ width: 16, height: 16, color: DANGER }} />
+          ) : (
+            <TrendingUp style={{ width: 16, height: 16, color: MUTED }} />
+          )}
+          <span style={{ fontSize: 13, fontWeight: 600, color: TXT }}>
+            Positions
+          </span>
+          <span style={{ fontSize: 12, color: MUTED }}>
+            {openPositions.length}
+          </span>
+        </div>
+
+        {blockedReason ? (
+          <div
+            style={{
+              padding: "22px 16px",
+              textAlign: "center",
+              fontSize: 12.5,
+              color: MUTED,
+            }}
+          >
+            {blockedReason}
+          </div>
+        ) : openPositions.length === 0 ? (
+          <div
+            style={{
+              padding: "26px 16px",
+              textAlign: "center",
+              fontSize: 12.5,
+              color: MUTED,
+            }}
+          >
+            No open positions
+          </div>
+        ) : (
+          <>
+            <HeaderRow />
+            {openPositions.map((position) => (
+              <PositionRow
+                key={`${position.conditionId ?? position.marketId ?? position.slug}-${position.outcome}`}
+                position={position}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/plugins/plugin-polymarket-app/src/__fixtures__/contract.ts
+++ b/plugins/plugin-polymarket-app/src/__fixtures__/contract.ts
@@ -17,6 +17,7 @@ import type {
   PolymarketMarketResponse,
   PolymarketMarketsResponse,
   PolymarketOrderbookResponse,
+  PolymarketPositionsResponse,
   PolymarketStatusResponse,
 } from "../polymarket-contracts";
 
@@ -236,5 +237,65 @@ export function validateStatusResponse(value: unknown): Violations {
   if (!isNonEmptyString(r.trading?.clobApiBase)) {
     v.push("trading.clobApiBase: expected non-empty string");
   }
+  if (typeof r.account?.ready !== "boolean") {
+    v.push("account.ready: expected boolean");
+  }
+  checkStringOrNull(v, "account.reason", r.account?.reason);
+  checkStringOrNull(v, "account.address", r.account?.address);
+  return v;
+}
+
+export function validatePositionsResponse(value: unknown): Violations {
+  const v: Violations = [];
+  if (typeof value !== "object" || value === null) {
+    return ["response: expected object"];
+  }
+  const r = value as PolymarketPositionsResponse;
+  if (!Array.isArray(r.positions)) {
+    v.push("positions: expected array");
+  } else {
+    r.positions.forEach((p, i) => {
+      for (const key of [
+        "marketId",
+        "conditionId",
+        "question",
+        "outcome",
+        "icon",
+        "slug",
+      ] as const) {
+        checkStringOrNull(v, `positions[${i}].${key}`, p?.[key]);
+      }
+      for (const key of [
+        "size",
+        "currentValue",
+        "cashPnl",
+        "percentPnl",
+      ] as const) {
+        checkNumericStringOrNull(v, `positions[${i}].${key}`, p?.[key]);
+      }
+    });
+  }
+  checkStringOrNull(v, "user", r.user);
+  if (r.summary !== null) {
+    if (typeof r.summary !== "object") {
+      v.push("summary: expected object|null");
+    } else {
+      checkNumericStringOrNull(v, "summary.totalValue", r.summary.totalValue);
+      checkNumericStringOrNull(
+        v,
+        "summary.totalCashPnl",
+        r.summary.totalCashPnl,
+      );
+      checkNumericStringOrNull(
+        v,
+        "summary.totalPercentPnl",
+        r.summary.totalPercentPnl,
+      );
+      if (typeof r.summary.openPositions !== "number") {
+        v.push("summary.openPositions: expected number");
+      }
+    }
+  }
+  validateSource(v, "source", r.source, "data");
   return v;
 }

--- a/plugins/plugin-polymarket-app/src/client.ts
+++ b/plugins/plugin-polymarket-app/src/client.ts
@@ -27,7 +27,11 @@ export type PolymarketClient = ElizaClient & {
   polymarketMarketBySlug(slug: string): Promise<PolymarketMarketResponse>;
   polymarketOrderbook(tokenId: string): Promise<PolymarketOrderbookResponse>;
   polymarketOrders(): Promise<PolymarketDisabledResponse>;
-  polymarketPositions(user: string): Promise<PolymarketPositionsResponse>;
+  /**
+   * Read open positions for `user`, or for the agent's configured Polygon
+   * wallet when `user` is omitted (the route resolves the fallback address).
+   */
+  polymarketPositions(user?: string): Promise<PolymarketPositionsResponse>;
 };
 
 const elizaClientPrototype =
@@ -71,9 +75,12 @@ elizaClientPrototype.polymarketOrders = async function () {
   return this.fetch("/api/polymarket/orders");
 };
 
-elizaClientPrototype.polymarketPositions = async function (user: string) {
-  const params = new URLSearchParams({ user });
-  return this.fetch(`/api/polymarket/positions?${params.toString()}`);
+elizaClientPrototype.polymarketPositions = async function (user?: string) {
+  const trimmed = user?.trim();
+  const query = trimmed
+    ? `?${new URLSearchParams({ user: trimmed }).toString()}`
+    : "";
+  return this.fetch(`/api/polymarket/positions${query}`);
 };
 
 function appendParam(

--- a/plugins/plugin-polymarket-app/src/polymarket-contracts.ts
+++ b/plugins/plugin-polymarket-app/src/polymarket-contracts.ts
@@ -22,11 +22,27 @@ export interface PolymarketTradingReadiness extends PolymarketReadiness {
   missing: readonly PolymarketTradingEnvVar[];
 }
 
+export interface PolymarketAccountReadiness extends PolymarketReadiness {
+  /**
+   * The agent's Polygon wallet address used to read positions, resolved from
+   * env (POLYMARKET_WALLET_ADDRESS / STEWARD_EVM_ADDRESS / managed EVM
+   * address). Null when no address is configured, in which case position reads
+   * require an explicit `user` query param.
+   */
+  address: string | null;
+}
+
 export interface PolymarketStatusResponse {
   publicReads: PolymarketReadiness & {
     gammaApiBase: string;
     dataApiBase: string;
   };
+  /**
+   * Position-read readiness. Readable whenever an account address is resolvable
+   * (public Data API, no credentials needed). The address is surfaced so the
+   * AppView can read the agent's own positions without prompting for a wallet.
+   */
+  account: PolymarketAccountReadiness;
   trading: PolymarketTradingReadiness & {
     clobApiBase: string;
   };
@@ -118,8 +134,42 @@ export interface PolymarketDisabledResponse {
   requiredForTrading: readonly PolymarketTradingEnvVar[];
 }
 
+/**
+ * Account-level aggregate derived from a wallet's open Polymarket positions,
+ * mirroring the waifu patron "account health" strip (total position value +
+ * aggregate cash PnL across markets). All values are stringified USD; null when
+ * the wallet holds no positions or the field is unreadable. This is the
+ * prediction-market analogue of the Hyperliquid account summary surfaced in the
+ * sibling HL app-plugin.
+ */
+export interface PolymarketPositionsSummary {
+  /** Sum of per-position `currentValue`, in USD. Null when no positions. */
+  totalValue: string | null;
+  /** Sum of per-position `cashPnl`, in USD. Null when no positions. */
+  totalCashPnl: string | null;
+  /**
+   * Aggregate return as a fraction of cost basis
+   * (totalCashPnl / (totalValue - totalCashPnl)). Null when the basis is
+   * zero/unreadable.
+   */
+  totalPercentPnl: string | null;
+  /** Count of open positions contributing to the aggregate. */
+  openPositions: number;
+}
+
 export interface PolymarketPositionsResponse {
   positions: readonly PolymarketPosition[];
+  /**
+   * The wallet whose positions were read. Resolved from the request `user`
+   * query param, or from the agent's configured Polygon address when omitted.
+   * Null when no address was resolvable.
+   */
+  user: string | null;
+  /**
+   * Account value/PnL aggregate. Optional for back-compat: older route builds
+   * and the no-position path emit null.
+   */
+  summary: PolymarketPositionsSummary | null;
   source: PolymarketSource;
 }
 

--- a/plugins/plugin-polymarket-app/src/routes.positions.test.ts
+++ b/plugins/plugin-polymarket-app/src/routes.positions.test.ts
@@ -1,0 +1,222 @@
+// Keyless tests for the positions surface added alongside the AppView's
+// PolymarketPositionsPanel: the agent-address fallback in `/positions`, the
+// `account` block in `/status`, and the account-health `summary` aggregate
+// (total value / total cash PnL / implied return). All exercise the real
+// `handlePolymarketRoute` with a fake fetch — no network, no credentials — so
+// they run in every keyless lane. Mirrors the HL sibling's summary-parsing
+// assertions.
+
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+
+import { validatePositionsResponse } from "./__fixtures__/contract";
+import type {
+  PolymarketPositionsResponse,
+  PolymarketStatusResponse,
+} from "./polymarket-contracts";
+import { handlePolymarketRoute } from "./routes";
+
+const AGENT_ADDRESS = "0x1111111111111111111111111111111111111111";
+const EXPLICIT_USER = "0x2222222222222222222222222222222222222222";
+
+function createRequest(url: string): http.IncomingMessage {
+  return { url } as http.IncomingMessage;
+}
+
+function createResponse() {
+  const res = {
+    headersSent: false,
+    statusCode: 0,
+    body: "",
+    setHeader() {},
+    end(body: string) {
+      this.headersSent = true;
+      this.body = body;
+    },
+    json<T = unknown>(): T {
+      return JSON.parse(this.body) as T;
+    },
+  };
+  return res as typeof res & http.ServerResponse;
+}
+
+/** A fetch that records the URL it was called with and returns `body`. */
+function recordingFetch(body: unknown): {
+  fetchImpl: typeof fetch;
+  lastUrl: () => string | null;
+} {
+  let seen: string | null = null;
+  const fetchImpl = (async (input: URL | RequestInfo) => {
+    seen = String(input);
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, lastUrl: () => seen };
+}
+
+const RECORDED_POSITIONS = [
+  {
+    conditionId: "0xcond1",
+    question: "Will it rain tomorrow?",
+    outcome: "Yes",
+    size: "120",
+    currentValue: "84.50",
+    cashPnl: "12.50",
+    percentPnl: "0.173",
+    slug: "rain-tomorrow",
+  },
+  {
+    conditionId: "0xcond2",
+    question: "Will BTC close above 100k?",
+    outcome: "No",
+    size: "40",
+    currentValue: "15.50",
+    cashPnl: "-9.00",
+    percentPnl: "-0.367",
+    slug: "btc-100k",
+  },
+  // A zero-size / unreadable row that must not break the aggregate.
+  {
+    conditionId: "0xcond3",
+    question: "Closed market",
+    outcome: "Yes",
+    size: "0",
+    currentValue: null,
+    cashPnl: null,
+    percentPnl: null,
+    slug: "closed",
+  },
+];
+
+describe("polymarket /status account block", () => {
+  it("reports account ready with the resolved address when configured", async () => {
+    const res = createResponse();
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/status"),
+      res,
+      "/api/polymarket/status",
+      "GET",
+      { env: { POLYMARKET_WALLET_ADDRESS: AGENT_ADDRESS } },
+    );
+    const body = res.json<PolymarketStatusResponse>();
+    expect(body.account.ready).toBe(true);
+    expect(body.account.address).toBe(AGENT_ADDRESS);
+    expect(body.account.reason).toBeNull();
+  });
+
+  it("reports account not-ready with guidance when no address is set", async () => {
+    const res = createResponse();
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/status"),
+      res,
+      "/api/polymarket/status",
+      "GET",
+      { env: {} },
+    );
+    const body = res.json<PolymarketStatusResponse>();
+    expect(body.account.ready).toBe(false);
+    expect(body.account.address).toBeNull();
+    expect(body.account.reason).toMatch(/wallet address/i);
+  });
+
+  it("ignores a malformed (non-hex) address", async () => {
+    const res = createResponse();
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/status"),
+      res,
+      "/api/polymarket/status",
+      "GET",
+      { env: { POLYMARKET_WALLET_ADDRESS: "not-an-address" } },
+    );
+    const body = res.json<PolymarketStatusResponse>();
+    expect(body.account.ready).toBe(false);
+    expect(body.account.address).toBeNull();
+  });
+});
+
+describe("polymarket /positions address fallback + summary", () => {
+  it("falls back to the agent address when no user query is supplied", async () => {
+    const res = createResponse();
+    const { fetchImpl, lastUrl } = recordingFetch(RECORDED_POSITIONS);
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/positions"),
+      res,
+      "/api/polymarket/positions",
+      "GET",
+      { fetchImpl, env: { STEWARD_EVM_ADDRESS: AGENT_ADDRESS } },
+    );
+    expect(res.statusCode).toBe(200);
+    // The upstream Data API call used the resolved agent address.
+    expect(lastUrl()).toContain(`user=${AGENT_ADDRESS}`);
+    const body = res.json<PolymarketPositionsResponse>();
+    expect(body.user).toBe(AGENT_ADDRESS);
+    expect(validatePositionsResponse(body)).toEqual([]);
+  });
+
+  it("prefers an explicit user query over the agent address", async () => {
+    const res = createResponse();
+    const { fetchImpl, lastUrl } = recordingFetch(RECORDED_POSITIONS);
+    await handlePolymarketRoute(
+      createRequest(`/api/polymarket/positions?user=${EXPLICIT_USER}`),
+      res,
+      "/api/polymarket/positions",
+      "GET",
+      { fetchImpl, env: { POLYMARKET_WALLET_ADDRESS: AGENT_ADDRESS } },
+    );
+    expect(lastUrl()).toContain(`user=${EXPLICIT_USER}`);
+    expect(res.json<PolymarketPositionsResponse>().user).toBe(EXPLICIT_USER);
+  });
+
+  it("400s when neither a user query nor an agent address is available", async () => {
+    const res = createResponse();
+    const { fetchImpl } = recordingFetch([]);
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/positions"),
+      res,
+      "/api/polymarket/positions",
+      "GET",
+      { fetchImpl, env: {} },
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("aggregates value, cash PnL, and implied return across positions", async () => {
+    const res = createResponse();
+    const { fetchImpl } = recordingFetch(RECORDED_POSITIONS);
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/positions"),
+      res,
+      "/api/polymarket/positions",
+      "GET",
+      { fetchImpl, env: { POLYMARKET_WALLET_ADDRESS: AGENT_ADDRESS } },
+    );
+    const body = res.json<PolymarketPositionsResponse>();
+    expect(body.summary).not.toBeNull();
+    const summary = body.summary;
+    if (!summary) throw new Error("summary missing");
+    // 84.50 + 15.50 = 100.00 ; 12.50 + (-9.00) = 3.50
+    expect(Number(summary.totalValue)).toBeCloseTo(100, 6);
+    expect(Number(summary.totalCashPnl)).toBeCloseTo(3.5, 6);
+    // cost basis = 100 - 3.5 = 96.5 ; return = 3.5 / 96.5
+    expect(Number(summary.totalPercentPnl)).toBeCloseTo(3.5 / 96.5, 6);
+    expect(summary.openPositions).toBe(RECORDED_POSITIONS.length);
+  });
+
+  it("returns a null summary for an empty wallet", async () => {
+    const res = createResponse();
+    const { fetchImpl } = recordingFetch([]);
+    await handlePolymarketRoute(
+      createRequest("/api/polymarket/positions"),
+      res,
+      "/api/polymarket/positions",
+      "GET",
+      { fetchImpl, env: { POLYMARKET_WALLET_ADDRESS: AGENT_ADDRESS } },
+    );
+    const body = res.json<PolymarketPositionsResponse>();
+    expect(body.summary).toBeNull();
+    expect(body.positions).toEqual([]);
+    expect(validatePositionsResponse(body)).toEqual([]);
+  });
+});

--- a/plugins/plugin-polymarket-app/src/routes.ts
+++ b/plugins/plugin-polymarket-app/src/routes.ts
@@ -18,6 +18,7 @@ import {
   type PolymarketOrderbookResponse,
   type PolymarketPosition,
   type PolymarketPositionsResponse,
+  type PolymarketPositionsSummary,
   type PolymarketStatusResponse,
   type PolymarketTradingEnvVar,
 } from "./polymarket-contracts";
@@ -77,6 +78,20 @@ interface ClobOrderbookRecord {
   last_trade_price?: unknown;
 }
 
+// Env keys consulted (in order) to resolve the agent's Polygon wallet for
+// reading its own Polymarket positions. POLYMARKET_WALLET_ADDRESS is the
+// venue-specific override; the STEWARD/managed keys mirror the resolution the
+// sibling Hyperliquid app-plugin uses so a single managed EVM address powers
+// both venues.
+const POLYMARKET_ADDRESS_ENV_KEYS = [
+  "POLYMARKET_WALLET_ADDRESS",
+  "POLYMARKET_ADDRESS",
+  "STEWARD_EVM_ADDRESS",
+  "ELIZA_MANAGED_EVM_ADDRESS",
+] as const;
+
+const HEX_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
+
 const DISABLED_TRADING_REASON =
   "Trading and order management are disabled in this app integration. Configure a signed CLOB execution path before enabling these routes.";
 
@@ -125,7 +140,12 @@ export async function handlePolymarketRoute(
   }
 
   if (method === "GET" && pathname === "/api/polymarket/positions") {
-    await handlePositions(req, res, state.fetchImpl ?? fetch);
+    await handlePositions(
+      req,
+      res,
+      state.fetchImpl ?? fetch,
+      state.env ?? process.env,
+    );
     return true;
   }
 
@@ -137,6 +157,16 @@ export async function handlePolymarketRoute(
   return false;
 }
 
+function resolvePolymarketAddress(
+  env: Record<string, string | undefined>,
+): string | null {
+  for (const key of POLYMARKET_ADDRESS_ENV_KEYS) {
+    const raw = env[key]?.trim();
+    if (raw && HEX_ADDRESS_PATTERN.test(raw)) return raw;
+  }
+  return null;
+}
+
 function buildStatusResponse(
   env: Record<string, string | undefined>,
 ): PolymarketStatusResponse {
@@ -144,12 +174,20 @@ function buildStatusResponse(
     (name) => !hasTradingEnvVar(env, name),
   );
   const credentialsReady = missing.length === 0;
+  const accountAddress = resolvePolymarketAddress(env);
   return {
     publicReads: {
       ready: true,
       reason: null,
       gammaApiBase: POLYMARKET_GAMMA_API_BASE,
       dataApiBase: POLYMARKET_DATA_API_BASE,
+    },
+    account: {
+      ready: accountAddress !== null,
+      reason: accountAddress
+        ? null
+        : "No Polymarket wallet address configured. Set POLYMARKET_WALLET_ADDRESS (or a managed EVM address) to read positions.",
+      address: accountAddress,
     },
     trading: {
       ready: false,
@@ -331,14 +369,24 @@ async function handlePositions(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   fetchImpl: typeof fetch,
+  env: Record<string, string | undefined>,
 ): Promise<void> {
   const requestUrl = new URL(
     req.url ?? "/api/polymarket/positions",
     "http://x",
   );
-  const user = requestUrl.searchParams.get("user")?.trim();
+  // Prefer an explicit `user` query, else fall back to the agent's configured
+  // Polygon wallet so the AppView can read the agent's own positions without
+  // prompting for an address (mirrors the HL app-plugin's account resolution).
+  const user =
+    requestUrl.searchParams.get("user")?.trim() ||
+    resolvePolymarketAddress(env);
   if (!user) {
-    sendJsonError(res, 400, "Missing user wallet address");
+    sendJsonError(
+      res,
+      400,
+      "Missing user wallet address and no agent Polymarket address is configured",
+    );
     return;
   }
 
@@ -359,8 +407,11 @@ async function handlePositions(
       );
       return;
     }
+    const positions = payload.flatMap(readDataPosition);
     const response: PolymarketPositionsResponse = {
-      positions: payload.flatMap(readDataPosition),
+      positions,
+      user,
+      summary: summarizePositions(positions),
       source: { api: "data", endpoint: dataUrl.toString() },
     };
     sendJson(res, 200, response);
@@ -446,6 +497,58 @@ function readDataPosition(value: unknown): PolymarketPosition[] {
       slug: readString(record.slug),
     },
   ];
+}
+
+/**
+ * Aggregate a wallet's open positions into the account-health summary: total
+ * current value, total cash PnL, and the implied return on cost basis
+ * (cost basis = value - pnl). Returns null when there are no positions so the
+ * view can render an honest empty state. Mirrors the HL app-plugin's summed
+ * unrealized-PnL aggregate.
+ */
+function summarizePositions(
+  positions: readonly PolymarketPosition[],
+): PolymarketPositionsSummary | null {
+  if (positions.length === 0) return null;
+
+  let totalValue = 0;
+  let totalCashPnl = 0;
+  let hasValue = false;
+  let hasPnl = false;
+
+  for (const position of positions) {
+    const value = parseFiniteNumber(position.currentValue);
+    if (value !== null) {
+      totalValue += value;
+      hasValue = true;
+    }
+    const pnl = parseFiniteNumber(position.cashPnl);
+    if (pnl !== null) {
+      totalCashPnl += pnl;
+      hasPnl = true;
+    }
+  }
+
+  // Cost basis is value minus realized/unrealized gain; only meaningful when
+  // both aggregates are readable and the basis is non-zero.
+  const costBasis = totalValue - totalCashPnl;
+  const totalPercentPnl =
+    hasValue && hasPnl && Math.abs(costBasis) > 1e-9
+      ? String(totalCashPnl / costBasis)
+      : null;
+
+  return {
+    totalValue: hasValue ? String(totalValue) : null,
+    totalCashPnl: hasPnl ? String(totalCashPnl) : null,
+    totalPercentPnl,
+    openPositions: positions.length,
+  };
+}
+
+function parseFiniteNumber(value: string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function buildDisabledResponse(): PolymarketDisabledResponse {

--- a/plugins/plugin-polymarket-app/src/usePolymarketState.ts
+++ b/plugins/plugin-polymarket-app/src/usePolymarketState.ts
@@ -4,6 +4,7 @@ import "./client";
 import type { PolymarketClient } from "./client";
 import type {
   PolymarketMarket,
+  PolymarketPositionsResponse,
   PolymarketStatusResponse,
 } from "./polymarket-contracts";
 
@@ -13,6 +14,8 @@ export function usePolymarketState() {
   const [selectedMarket, setSelectedMarket] = useState<PolymarketMarket | null>(
     null,
   );
+  const [positions, setPositions] =
+    useState<PolymarketPositionsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,6 +31,20 @@ export function usePolymarketState() {
       setStatus(statusResponse);
       setMarkets(marketsResponse.markets);
       setSelectedMarket(marketsResponse.markets[0] ?? null);
+
+      // Read the agent's own positions only when an account address is
+      // resolvable; the route falls back to the configured wallet so we call
+      // it without an explicit `user`. A position-read failure must not blank
+      // the whole view, so it's isolated from the markets fetch.
+      if (statusResponse.account.ready) {
+        try {
+          setPositions(await polymarketClient.polymarketPositions());
+        } catch {
+          setPositions(null);
+        }
+      } else {
+        setPositions(null);
+      }
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Polymarket refresh failed",
@@ -46,6 +63,7 @@ export function usePolymarketState() {
     markets,
     selectedMarket,
     setSelectedMarket,
+    positions,
     loading,
     error,
     refresh,


### PR DESCRIPTION
Part of the waifu web-UI direction (#8434): surface a waifu agent's Polymarket positions in its ElizaOS web UI canvas. Mirrors the HL positions AppView (#8692).

## What
**Extends** `plugin-polymarket-app` (does not fork). The `/positions` route already returned rich data (market question, YES/NO outcome, shares, value, PnL) but the AppView never surfaced it — `usePolymarketState` didn't fetch positions, only a count reached the view. Also added agent-address resolution (the route previously required an explicit `user`).
- `PolymarketPositionsPanel.tsx` (new) — account-health hero (portfolio value, total PnL, implied return, open count) over a dense per-position table (market + YES/NO pill, shares, value, cash + % PnL)
- `routes.ts` — env-based agent-address resolution (hex-validated); `/status` reports account readiness; `/positions` falls back to that address + computes the summary
- `usePolymarketState.ts` — fetches agent positions when `account.ready`, isolated so a read failure never blanks the markets list

Read-only. Matches the `polymarket-wallet` descriptor + the existing view's theme tokens.

## Verification
tsc strict (no `any`), 15/15 keyless tests (3 routes + 4 contract + 8 new positions incl. summary math), biome clean.

## Note
View-render + runtime keyless tests need `@elizaos/app-core`/`@elizaos/ui` dist built — pre-existing gap (confirmed on base), verified via tsc + source-aliased suites.

Co-authored-by: wakesync <shadow@shad0w.xyz>