### PR TITLE
feat(plugin-waifu-swap-app): token-swap (PancakeSwap V3) AppView for waifu agents

### DIFF
--- a/plugins/plugin-waifu-swap-app/README.md
+++ b/plugins/plugin-waifu-swap-app/README.md
@@ -1,0 +1,85 @@
+# @elizaos/plugin-waifu-swap-app
+
+Native **token-swap AppView** for waifu agents. Renders inside an agent's
+ElizaOS web UI canvas (the apps overlay / desktop tab) and drives the
+**PancakeSwap v3** swap capability on the waifu.fun API.
+
+Phase of giving each waifu agent its own ElizaOS web UI: this replaces the
+broken waifu patron swap panel (`apps/frontend/src/components/agent-home/wave-t/swap-panel.tsx`)
+with a first-class app-plugin view, modeled on `plugin-hyperliquid-app` and
+`plugin-waifu-imagegen-app`.
+
+## What it ships
+
+- **`SwapAppView.tsx`** — token-in / token-out selectors, an amount input, a
+  reverse-direction control, a live quote (expected out + minimum received),
+  slippage presets, fee-tier selection, a route/price-impact detail strip, and a
+  swap CTA. Built on `@elizaos/app-core` primitives (`PagePanel`, `Button`,
+  `Spinner`) and `@elizaos/ui/agent-surface` (`useAgentElement`), matching the
+  visual + agent-addressability language of `plugin-hyperliquid-app`.
+- **`swap-client.ts`** — auth-aware `POST` to
+  `/v2/agents/:token/capabilities/pancakeswap-v3/actions/:actionSlug` on the
+  waifu API (the generic capability-action route). Sends the agent-app invoke
+  key (`x-waifu-app-invoke-key`) when present, else a Steward JWT bearer. Maps
+  HTTP status onto typed `SwapError`s.
+- **`swap-config.ts`** — resolves the waifu API base, agent token, auth
+  credential, and the swap-eligible token universe from a host-injected
+  `window.__WAIFU_SWAP__` global, `import.meta.env` (`VITE_WAIFU_*`), or a
+  production default. Always includes native BNB.
+- **`swap-contracts.ts`** — standalone typed contract (capability/action slugs,
+  fee tiers, slippage bounds, token + quote shapes, local quote estimator, error
+  classifier). No waifu-monorepo imports. EVM `Address` defined locally.
+- **`plugin.ts`** — the `views` declaration (`waifu-swap`) that
+  `plugin-app-manager` reads to discover + launch the view. Points at the
+  third-partyized bundle (`dist/views/bundle.js`) and the `SwapAppView` export.
+
+## Display-only vs execute
+
+This view is **quote-only** today.
+
+- **Quote / display — fully built.** The displayed quote is a transparent local
+  estimate (driven by per-token `priceBnb`), opportunistically upgraded with the
+  backend `quote` (read mode) action. Because the backend's `pancakeswap-v3:quote`
+  handler is **not yet registered** in the generic capability route's `HANDLERS`
+  map (it returns `501 NOT_IMPLEMENTED`), the local estimate stays the display
+  source until that lands; the client swallows the 501 and keeps the estimate.
+
+- **Execute — intentionally stubbed (`SWAP_EXECUTE_TODO`).** The `swap` action is
+  `agent_signed` + `requiresConsent`, and likewise has no backend handler yet
+  (`501`). To avoid fabricating a money path, `executeSwap()` is gated behind
+  `SWAP_EXECUTE_ENABLED = false`: a confirmed press surfaces a clear
+  "execution not enabled yet" notice instead of POSTing to a route that can't
+  fulfil it. The typed `prepareSwap()` client + unsigned-tx contract are wired
+  and ready; flip `SWAP_EXECUTE_ENABLED` once the backend handler returns either
+  an unsigned tx (client-signed, the user signs in their own wallet) or an
+  agent-signer job, and the tx shape is confirmed.
+
+**Follow-up to enable execution:** register `pancakeswap-v3:quote` and
+`pancakeswap-v3:swap` handlers in
+`apps/api/src/routes/v2/agents/capability-actions.ts` (`HANDLERS`), confirm the
+unsigned-tx response shape, then flip `SWAP_EXECUTE_ENABLED` here.
+
+## Lazy + third-partyized
+
+The overlay registration (`swap-app.ts`) loads the view via a dynamic
+`import()`, and the view bundle third-partyizes `react`, `lucide-react`,
+`@elizaos/ui`, and `@elizaos/app-core` (see `vite.config.views.ts`). The view's
+component tree never lands in the main or mobile entry chunk.
+
+## Configuration
+
+The host shell injects per-agent config when it mounts the view:
+
+```ts
+window.__WAIFU_SWAP__ = {
+  apiBase: "https://waifu.fun",
+  agentTokenAddress: "0x…",
+  stewardJwt: "…",          // OR appInvokeKey for trusted server surfaces
+  tokens: [                  // swap-eligible universe (BNB is always added)
+    { address: "0x…", symbol: "SUKI", decimals: 18, priceBnb: 0.0001 },
+  ],
+};
+```
+
+Or via `import.meta.env`: `VITE_WAIFU_API_BASE`, `VITE_WAIFU_AGENT_TOKEN`,
+`VITE_WAIFU_STEWARD_JWT`.

--- a/plugins/plugin-waifu-swap-app/package.json
+++ b/plugins/plugin-waifu-swap-app/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@elizaos/plugin-waifu-swap-app",
+  "version": "2.0.3-beta.14",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./*.css": "./dist/*.css",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "dependencies": {
+    "@elizaos/app-core": "workspace:*",
+    "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*",
+    "@elizaos/ui": "workspace:*",
+    "lucide-react": "^1.0.0",
+    "react": "^19.0.0"
+  },
+  "elizaos": {
+    "app": {
+      "displayName": "Swap",
+      "category": "trading"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bun run build:js && bun run build:views && bun run build:types",
+    "clean": "rm -rf dist",
+    "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
+    "build:views": "bunx --bun vite build --config vite.config.views.ts",
+    "build:types": "tsc --noCheck -p tsconfig.build.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
+++ b/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
@@ -1,0 +1,431 @@
+import type { OverlayAppContext } from "@elizaos/app-core";
+import { Button, PagePanel, Spinner } from "@elizaos/app-core";
+import { useAgentElement } from "@elizaos/ui/agent-surface";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowLeftRight,
+  CheckCircle2,
+  Info,
+  Settings2,
+} from "lucide-react";
+import { type ReactNode, useId } from "react";
+import {
+  PANCAKE_V3_FEE_TIERS,
+  type PancakeV3Fee,
+  SLIPPAGE_PRESETS,
+  type SwapToken,
+} from "./swap-contracts";
+import { useSwapState } from "./useSwapState";
+
+function formatAmount(value: number, maxFraction = 6): string {
+  if (!Number.isFinite(value)) return "0";
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: value > 1 ? 4 : maxFraction,
+  });
+}
+
+function formatImpact(pct: number): string {
+  if (!Number.isFinite(pct)) return "0.00%";
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function TokenChip({ token }: { token: SwapToken }) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-md border border-border bg-bg-accent px-2.5 py-1.5">
+      <span className="grid h-5 w-5 place-items-center rounded-full border border-border/40 bg-card text-[10px] font-semibold text-muted">
+        {token.symbol.slice(0, 2).toUpperCase()}
+      </span>
+      <span className="font-mono text-xs text-txt">{token.symbol}</span>
+    </span>
+  );
+}
+
+function TokenSelect({
+  label,
+  selected,
+  tokens,
+  exclude,
+  disabled,
+  onSelect,
+}: {
+  label: string;
+  selected: SwapToken | null;
+  tokens: readonly SwapToken[];
+  exclude: SwapToken | null;
+  disabled: boolean;
+  onSelect: (token: SwapToken) => void;
+}) {
+  const selectId = useId();
+  const options = tokens.filter(
+    (token) => !exclude || token.address !== exclude.address,
+  );
+  return (
+    <div className="flex items-center gap-2">
+      {selected ? <TokenChip token={selected} /> : null}
+      <label className="sr-only" htmlFor={selectId}>
+        {label}
+      </label>
+      <select
+        id={selectId}
+        value={selected?.address ?? ""}
+        disabled={disabled || options.length === 0}
+        onChange={(event) => {
+          const next = tokens.find(
+            (token) => token.address === event.target.value,
+          );
+          if (next) onSelect(next);
+        }}
+        className="rounded-md border border-border bg-bg-accent px-2 py-1.5 text-xs text-txt outline-none transition-colors focus:border-accent/50 disabled:opacity-60"
+      >
+        {selected && !options.some((t) => t.address === selected.address) ? (
+          <option value={selected.address}>{selected.symbol}</option>
+        ) : null}
+        {options.map((token) => (
+          <option key={token.address} value={token.address}>
+            {token.symbol}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  children,
+  tone,
+}: {
+  label: string;
+  children: ReactNode;
+  tone?: "default" | "danger";
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-muted">{label}</dt>
+      <dd
+        className={`tabular-nums ${tone === "danger" ? "text-danger" : "text-txt"}`}
+      >
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+export interface SwapAppViewProps extends OverlayAppContext {
+  /** Optional host override for which agent's swap capability to invoke. */
+  agentTokenAddress?: string;
+  /** Optional host-supplied swap-eligible token list. */
+  tokens?: readonly SwapToken[];
+  /** Raised when the backend reports the capability is unavailable (404). */
+  onUnavailable?: () => void;
+}
+
+export function SwapAppView({
+  exitToApps,
+  agentTokenAddress,
+  tokens: tokensProp,
+  onUnavailable,
+}: SwapAppViewProps) {
+  const amountId = useId();
+  const {
+    config,
+    tokens,
+    tokenIn,
+    tokenOut,
+    setTokenIn,
+    setTokenOut,
+    reverse,
+    amountIn,
+    setAmountIn,
+    slippagePct,
+    setSlippagePct,
+    fee,
+    setFee,
+    quote,
+    amountValid,
+    canSwap,
+    executeEnabled,
+    quoting,
+    executing,
+    error,
+    outcome,
+    executeSwap,
+  } = useSwapState({ agentTokenAddress, tokens: tokensProp, onUnavailable });
+
+  const backButton = useAgentElement<HTMLButtonElement>({
+    id: "action-back",
+    role: "button",
+    label: "Back to apps",
+    group: "swap-header",
+    description: "Exit the swap view and return to the apps overlay",
+  });
+  const reverseButton = useAgentElement<HTMLButtonElement>({
+    id: "action-reverse",
+    role: "button",
+    label: "Reverse direction",
+    group: "swap-form",
+    description: "Swap the token-in and token-out sides",
+  });
+  const swapButton = useAgentElement<HTMLButtonElement>({
+    id: "action-swap",
+    role: "button",
+    label: "Swap",
+    group: "swap-form",
+    description: "Execute the swap with the current quote",
+    status: executing ? "active" : "inactive",
+  });
+  const amountField = useAgentElement<HTMLInputElement>({
+    id: "field-amount",
+    role: "number-input",
+    label: "Amount in",
+    group: "swap-form",
+    description: "Amount of the input token to swap",
+  });
+
+  const impactDanger = (quote?.priceImpactPct ?? 0) < -1;
+
+  return (
+    <div
+      data-testid="swap-shell"
+      className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
+    >
+      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+        <Button
+          ref={backButton.ref}
+          {...backButton.agentProps}
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 text-muted hover:text-txt"
+          onClick={exitToApps}
+          aria-label="Back"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+
+        <div className="min-w-0">
+          <h1 className="text-base font-semibold text-txt">Swap</h1>
+        </div>
+
+        <div className="flex-1" />
+
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-border/35 bg-bg-accent px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted">
+          PancakeSwap v3
+        </span>
+      </div>
+
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+        <div className="mx-auto max-w-xl space-y-4">
+          {!config.agentTokenAddress && (
+            <PagePanel.Notice tone="warning">
+              No agent is configured for swapping.
+            </PagePanel.Notice>
+          )}
+
+          {/* From */}
+          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+            <div className="mb-2 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
+              <span>from</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <TokenSelect
+                label="From token"
+                selected={tokenIn}
+                tokens={tokens}
+                exclude={tokenOut}
+                disabled={executing}
+                onSelect={setTokenIn}
+              />
+              <input
+                ref={amountField.ref}
+                {...amountField.agentProps}
+                id={amountId}
+                value={amountIn}
+                inputMode="decimal"
+                placeholder="0.0"
+                disabled={executing}
+                onChange={(event) => setAmountIn(event.target.value)}
+                className="ml-auto w-full bg-transparent text-right font-mono text-2xl text-txt tabular-nums outline-none placeholder:text-muted disabled:opacity-60"
+                aria-label="Amount in"
+              />
+            </div>
+          </section>
+
+          {/* Direction */}
+          <div className="-my-2 flex justify-center">
+            <Button
+              ref={reverseButton.ref}
+              {...reverseButton.agentProps}
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 rounded-full border border-border/40 bg-bg text-muted hover:text-accent"
+              onClick={reverse}
+              disabled={executing}
+              aria-label="Reverse direction"
+            >
+              <ArrowDown className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* To */}
+          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+            <div className="mb-2 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
+              <span>to (estimate)</span>
+              {quoting ? (
+                <span className="inline-flex items-center gap-1.5 normal-case text-[10px] tracking-normal">
+                  <Spinner className="h-3 w-3" />
+                  quoting
+                </span>
+              ) : quote ? (
+                <span className="normal-case text-[10px] tracking-normal">
+                  {quote.source === "backend" ? "live quote" : "estimated"}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-3">
+              <TokenSelect
+                label="To token"
+                selected={tokenOut}
+                tokens={tokens}
+                exclude={tokenIn}
+                disabled={executing}
+                onSelect={setTokenOut}
+              />
+              <div className="ml-auto font-mono text-2xl text-txt/85 tabular-nums">
+                {quote ? formatAmount(quote.amountOut) : "0.0"}
+              </div>
+            </div>
+          </section>
+
+          {/* Slippage + fee controls */}
+          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
+              <Settings2 className="h-3.5 w-3.5" />
+              slippage tolerance
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {SLIPPAGE_PRESETS.map((preset) => (
+                <Button
+                  key={preset}
+                  type="button"
+                  variant={preset === slippagePct ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7 px-2 font-mono text-xs tabular-nums"
+                  disabled={executing}
+                  onClick={() => setSlippagePct(preset)}
+                  aria-pressed={preset === slippagePct}
+                >
+                  {preset}%
+                </Button>
+              ))}
+            </div>
+
+            <div className="mt-3 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
+              fee tier
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {PANCAKE_V3_FEE_TIERS.map((tier: PancakeV3Fee) => (
+                <Button
+                  key={tier}
+                  type="button"
+                  variant={tier === fee ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7 px-2 font-mono text-xs tabular-nums"
+                  disabled={executing}
+                  onClick={() => setFee(tier)}
+                  aria-pressed={tier === fee}
+                >
+                  {(tier / 10000).toFixed(2)}%
+                </Button>
+              ))}
+            </div>
+          </section>
+
+          {/* Route detail */}
+          {quote && amountValid ? (
+            <dl className="space-y-2 rounded-lg border border-border/24 bg-bg-accent px-4 py-3 text-xs">
+              <DetailRow label="route">
+                <span className="inline-flex items-center gap-1.5">
+                  <ArrowLeftRight className="h-3.5 w-3.5 text-muted" />
+                  via PancakeSwap v3
+                </span>
+              </DetailRow>
+              <DetailRow
+                label="price impact"
+                tone={impactDanger ? "danger" : "default"}
+              >
+                {formatImpact(quote.priceImpactPct)}
+              </DetailRow>
+              <DetailRow label="slippage">{quote.slippagePct}%</DetailRow>
+              <DetailRow label="minimum received">
+                {formatAmount(quote.minAmountOut)} {tokenOut?.symbol ?? ""}
+              </DetailRow>
+            </dl>
+          ) : null}
+
+          {/* Errors */}
+          {error && (
+            <PagePanel.Notice
+              tone={error.kind === "auth" ? "accent" : "danger"}
+            >
+              {error.message}
+            </PagePanel.Notice>
+          )}
+
+          {/* Outcome */}
+          {outcome?.kind === "stubbed" && (
+            <div className="flex items-start gap-2 rounded-lg border border-border/24 bg-bg-accent px-4 py-3 text-sm text-muted">
+              <Info className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{outcome.message}</span>
+            </div>
+          )}
+          {outcome?.kind === "prepared" && (
+            <div className="flex items-start gap-2 rounded-lg border border-ok/35 bg-ok/12 px-4 py-3 text-sm text-ok">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                transaction prepared for {shortAddress(outcome.to)} — sign in
+                your wallet to complete
+              </span>
+            </div>
+          )}
+
+          {/* Swap CTA */}
+          <Button
+            ref={swapButton.ref}
+            {...swapButton.agentProps}
+            type="button"
+            variant="default"
+            className="w-full gap-2"
+            disabled={!canSwap}
+            onClick={() => void executeSwap()}
+          >
+            {executing ? (
+              <>
+                <Spinner className="h-4 w-4" />
+                preparing swap
+              </>
+            ) : (
+              <>
+                <ArrowLeftRight className="h-4 w-4" />
+                {executeEnabled ? "swap" : "preview swap"}
+              </>
+            )}
+          </Button>
+
+          {!executeEnabled && (
+            <p className="text-center text-xs text-muted">
+              quote-only preview — on-chain execution lands when the agent
+              signer is enabled
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-waifu-swap-app/src/index.ts
+++ b/plugins/plugin-waifu-swap-app/src/index.ts
@@ -1,0 +1,7 @@
+export { waifuSwapPlugin } from "./plugin";
+export * from "./SwapAppView";
+export { SWAP_APP_NAME, swapApp } from "./swap-app";
+export * from "./swap-client";
+export * from "./swap-config";
+export * from "./swap-contracts";
+export * from "./useSwapState";

--- a/plugins/plugin-waifu-swap-app/src/plugin.ts
+++ b/plugins/plugin-waifu-swap-app/src/plugin.ts
@@ -1,0 +1,55 @@
+import type { Plugin } from "@elizaos/core";
+
+/**
+ * Waifu swap app-plugin.
+ *
+ * Pure frontend AppView: it ships a single GUI view that renders inside an
+ * agent's ElizaOS web UI canvas and drives the PancakeSwap v3 swap capability on
+ * the waifu.fun API (the generic capability-action route). It replaces the
+ * broken waifu patron swap panel with a first-class app-plugin view. No agent
+ * routes/actions/services — the backend already lives on the waifu API.
+ *
+ * Today the view is quote-only: the displayed quote comes from a transparent
+ * local estimate (opportunistically upgraded with the backend `quote` action),
+ * and on-chain execution is intentionally stubbed until the backend
+ * `pancakeswap-v3:swap` handler + agent signer land (SWAP_EXECUTE_TODO).
+ *
+ * The `views` array is the discovery + launch contract read by
+ * plugin-app-manager: it points at the third-partyized view bundle
+ * (`dist/views/bundle.js`) and the `SwapAppView` component export, and marks
+ * the view visible in the app manager and as a desktop tab.
+ */
+export const waifuSwapPlugin: Plugin = {
+  name: "@elizaos/plugin-waifu-swap-app",
+  description:
+    "Native token-swap AppView for waifu agents — PancakeSwap v3 quote, slippage control, route detail, and a guarded swap action",
+  views: [
+    {
+      id: "waifu-swap",
+      label: "Swap",
+      description:
+        "Swap tokens through PancakeSwap v3 with live quotes and route detail",
+      icon: "ArrowLeftRight",
+      path: "/waifu-swap",
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "SwapAppView",
+      tags: ["trading", "swap", "waifu", "pancakeswap"],
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+    {
+      id: "waifu-swap",
+      label: "Swap XR",
+      description:
+        "Swap tokens through PancakeSwap v3 with live quotes and route detail",
+      icon: "ArrowLeftRight",
+      path: "/waifu-swap",
+      viewType: "xr",
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "SwapAppView",
+      tags: ["trading", "swap", "waifu", "pancakeswap"],
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+  ],
+};

--- a/plugins/plugin-waifu-swap-app/src/swap-app-view-bundle.ts
+++ b/plugins/plugin-waifu-swap-app/src/swap-app-view-bundle.ts
@@ -1,0 +1,6 @@
+// Vite view-bundle entry. Re-exports the view component so the built bundle
+// (dist/views/bundle.js) exposes the named export the shell view loader reads
+// (`SwapAppView`). Kept separate from SwapAppView.tsx so that file exports only
+// React components and stays Fast-Refresh-compatible in dev.
+
+export { SwapAppView } from "./SwapAppView.tsx";

--- a/plugins/plugin-waifu-swap-app/src/swap-app.ts
+++ b/plugins/plugin-waifu-swap-app/src/swap-app.ts
@@ -1,0 +1,24 @@
+import type { OverlayApp } from "@elizaos/app-core";
+import { registerOverlayApp } from "@elizaos/app-core";
+
+export const SWAP_APP_NAME = "@elizaos/plugin-waifu-swap-app";
+
+/**
+ * Overlay-app registration for the waifu swap view. The loader is lazy so the
+ * view's component tree (and its swap capability client) is only fetched when
+ * the window mounts — keeping it out of the main + mobile entry chunks.
+ */
+export const swapApp: OverlayApp = {
+  name: SWAP_APP_NAME,
+  displayName: "Swap",
+  description:
+    "Swap tokens through PancakeSwap v3 — quote, slippage control, and route detail",
+  category: "trading",
+  icon: null,
+  loader: () =>
+    import("./SwapAppView").then((m) => ({
+      default: m.SwapAppView,
+    })),
+};
+
+registerOverlayApp(swapApp);

--- a/plugins/plugin-waifu-swap-app/src/swap-client.ts
+++ b/plugins/plugin-waifu-swap-app/src/swap-client.ts
@@ -1,0 +1,184 @@
+/**
+ * Swap capability client. Reaches the waifu.fun generic capability-action route
+ * from inside the ElizaOS web UI canvas:
+ *
+ *   POST /v2/agents/:token/capabilities/pancakeswap-v3/actions/:actionSlug
+ *
+ * Auth precedence (matches the backend's accepted credentials, same as the
+ * image-gen client):
+ *   1. agent-app invoke key  -> header `x-waifu-app-invoke-key`
+ *   2. Steward JWT bearer    -> header `Authorization: Bearer <jwt>`
+ *
+ * Two operations:
+ *
+ *   fetchBackendQuote()  — calls the `quote` action (read mode). The handler is
+ *     not wired on the backend yet (returns 501); callers treat a thrown
+ *     `not-implemented` SwapError as "use the local estimate" rather than an
+ *     error surface.
+ *
+ *   prepareSwap()        — calls the `swap` action. STUBBED at the contract
+ *     level (see SWAP_EXECUTE_ENABLED): execution is gated off until the
+ *     backend handler + agent signer land, so this only ever runs when the
+ *     stub is flipped on, and otherwise the view never calls it.
+ */
+
+import type { WaifuSwapRuntimeConfig } from "./swap-config";
+import {
+  classifySwapStatus,
+  PANCAKE_V3_CAPABILITY_SLUG,
+  PANCAKE_V3_QUOTE_ACTION_SLUG,
+  PANCAKE_V3_SWAP_ACTION_SLUG,
+  type SwapActionInput,
+  type SwapError,
+  type SwapPrepareResponse,
+  type SwapQuoteResponse,
+  type UnsignedSwapTx,
+} from "./swap-contracts";
+
+function buildAuthHeaders(config: WaifuSwapRuntimeConfig): HeadersInit {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (config.appInvokeKey) {
+    headers["x-waifu-app-invoke-key"] = config.appInvokeKey;
+  } else if (config.stewardJwt) {
+    headers.Authorization = `Bearer ${config.stewardJwt}`;
+  }
+  return headers;
+}
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error.trim()) return error;
+    const message = (payload as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return fallback;
+}
+
+function actionUrl(config: WaifuSwapRuntimeConfig, actionSlug: string): string {
+  const token = encodeURIComponent(config.agentTokenAddress ?? "");
+  return `${config.apiBase}/v2/agents/${token}/capabilities/${PANCAKE_V3_CAPABILITY_SLUG}/actions/${actionSlug}`;
+}
+
+function assertReady(config: WaifuSwapRuntimeConfig): SwapError | null {
+  if (!config.agentTokenAddress) {
+    return {
+      kind: "misconfigured",
+      status: 503,
+      message: "no agent configured for swapping",
+    };
+  }
+  if (!config.appInvokeKey && !config.stewardJwt) {
+    return { kind: "auth", status: 401, message: "sign in to swap" };
+  }
+  return null;
+}
+
+async function postAction(
+  config: WaifuSwapRuntimeConfig,
+  actionSlug: string,
+  input: SwapActionInput,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(actionUrl(config, actionSlug), {
+      method: "POST",
+      headers: buildAuthHeaders(config),
+      body: JSON.stringify(input),
+    });
+  } catch (caught) {
+    throw {
+      kind: "unknown",
+      status: 0,
+      message:
+        caught instanceof Error ? caught.message : "could not reach swap api",
+    } satisfies SwapError;
+  }
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw classifySwapStatus(
+      response.status,
+      readErrorMessage(payload, "swap request failed"),
+    );
+  }
+  return payload;
+}
+
+export interface BackendQuoteFields {
+  amountOut: number;
+  minAmountOut: number | null;
+  priceImpactPct: number | null;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Call the backend `quote` (read mode) action. Resolves with the parsed quote
+ * fields, or rejects with a typed {@link SwapError}. A 501 surfaces as
+ * `kind: "not-implemented"` so the caller can fall back to a local estimate.
+ */
+export async function fetchBackendQuote(
+  config: WaifuSwapRuntimeConfig,
+  input: SwapActionInput,
+): Promise<BackendQuoteFields> {
+  const notReady = assertReady(config);
+  if (notReady) throw notReady;
+
+  const payload = (await postAction(
+    config,
+    PANCAKE_V3_QUOTE_ACTION_SLUG,
+    input,
+  )) as SwapQuoteResponse;
+
+  const amountOut = toFiniteNumber(payload?.data?.amountOut);
+  if (amountOut === null) {
+    throw {
+      kind: "unknown",
+      status: 500,
+      message: "quote returned no output amount",
+    } satisfies SwapError;
+  }
+  return {
+    amountOut,
+    minAmountOut: toFiniteNumber(payload?.data?.minAmountOut),
+    priceImpactPct: toFiniteNumber(payload?.data?.priceImpactPct),
+  };
+}
+
+/**
+ * Call the backend `swap` action to obtain an UNSIGNED tx for the patron to
+ * sign in their own wallet. NOTE: only reachable when the execution stub is
+ * flipped on (see SWAP_EXECUTE_ENABLED / executeSwap guard). Until then the
+ * view never calls this; the function exists so the wiring is ready when the
+ * backend handler lands. Rejects with a typed {@link SwapError} (incl. the
+ * current 501 `not-implemented`).
+ */
+export async function prepareSwap(
+  config: WaifuSwapRuntimeConfig,
+  input: SwapActionInput,
+): Promise<UnsignedSwapTx> {
+  const notReady = assertReady(config);
+  if (notReady) throw notReady;
+
+  const payload = (await postAction(config, PANCAKE_V3_SWAP_ACTION_SLUG, {
+    ...input,
+    consent: true,
+  })) as SwapPrepareResponse;
+
+  const tx = payload?.data?.tx;
+  if (!tx || typeof tx.to !== "string" || typeof tx.data !== "string") {
+    throw {
+      kind: "unknown",
+      status: 500,
+      message: "swap returned no transaction to sign",
+    } satisfies SwapError;
+  }
+  return tx;
+}

--- a/plugins/plugin-waifu-swap-app/src/swap-config.ts
+++ b/plugins/plugin-waifu-swap-app/src/swap-config.ts
@@ -1,0 +1,208 @@
+/**
+ * Runtime configuration resolver for the waifu swap AppView.
+ *
+ * The PancakeSwap v3 swap/quote capability lives on the waifu.fun API (a
+ * different origin from the ElizaOS agent server this view renders inside),
+ * keyed by the agent's id/token. This module resolves, at view-mount time, in
+ * priority order:
+ *
+ *   1. waifu API base   — where to POST the capability action
+ *   2. agent token addr — which agent's capability to invoke
+ *   3. auth credential  — a Steward JWT bearer OR an agent-app invoke key
+ *   4. token universe   — the swap-eligible tokens to populate the selectors
+ *
+ * Resolution sources (first non-empty wins):
+ *   - a host-injected global `window.__WAIFU_SWAP__` (the ElizaOS shell can
+ *     populate this per-agent when it mounts the view)
+ *   - Vite-style `import.meta.env` (VITE_WAIFU_*) baked at bundle build
+ *   - a sane production default for the API base
+ *
+ * Nothing here imports from the waifu monorepo; the contract is the injected
+ * global / env shape only. Mirrors `plugin-waifu-imagegen-app`'s config module.
+ */
+
+import type { Address, SwapToken } from "./swap-contracts";
+import { PANCAKE_V3_WBNB } from "./swap-contracts";
+
+export interface WaifuSwapRuntimeConfig {
+  /** Base URL of the waifu API, e.g. "https://waifu.fun". No trailing slash. */
+  apiBase: string;
+  /** The agent's id/token address whose swap capability is invoked. */
+  agentTokenAddress: Address | null;
+  /** Steward JWT bearer, when the viewer is signed in. */
+  stewardJwt: string | null;
+  /**
+   * Agent-app invoke key (x-waifu-app-invoke-key). Server/runtime contexts only.
+   * Present when the host injects it for a trusted same-process surface.
+   */
+  appInvokeKey: string | null;
+  /** Swap-eligible tokens for the selectors. Always includes native BNB. */
+  tokens: readonly SwapToken[];
+}
+
+interface InjectedToken {
+  address?: string;
+  symbol?: string;
+  decimals?: number;
+  priceBnb?: number;
+  logoUrl?: string;
+  isNative?: boolean;
+}
+
+interface InjectedConfig {
+  apiBase?: string;
+  agentTokenAddress?: string;
+  stewardJwt?: string;
+  appInvokeKey?: string;
+  tokens?: InjectedToken[];
+}
+
+const DEFAULT_WAIFU_API_BASE = "https://waifu.fun";
+
+/** Native BNB, always present so the user has at least one selectable side. */
+export const NATIVE_BNB_TOKEN: SwapToken = {
+  address: PANCAKE_V3_WBNB,
+  symbol: "BNB",
+  decimals: 18,
+  priceBnb: 1,
+  isNative: true,
+};
+
+function readInjectedGlobal(): InjectedConfig | null {
+  if (typeof window === "undefined") return null;
+  const raw = (window as unknown as Record<string, unknown>).__WAIFU_SWAP__;
+  if (!raw || typeof raw !== "object") return null;
+  return raw as InjectedConfig;
+}
+
+function readEnv(key: string): string | null {
+  // import.meta.env is baked at bundle build; guard for non-Vite hosts.
+  const env = (import.meta as unknown as { env?: Record<string, unknown> }).env;
+  const value = env?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function firstNonEmpty(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function isAddress(value: string | null): value is Address {
+  return value !== null && /^0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+/** Coerce a loosely-typed injected token into a validated {@link SwapToken}. */
+function normaliseToken(raw: InjectedToken): SwapToken | null {
+  if (!isAddress(raw.address ?? null)) return null;
+  const symbol =
+    typeof raw.symbol === "string" && raw.symbol.trim()
+      ? raw.symbol.trim()
+      : null;
+  if (!symbol) return null;
+  const decimals =
+    typeof raw.decimals === "number" && Number.isInteger(raw.decimals)
+      ? raw.decimals
+      : 18;
+  const priceBnb =
+    typeof raw.priceBnb === "number" && Number.isFinite(raw.priceBnb)
+      ? raw.priceBnb
+      : 0;
+  return {
+    address: raw.address as Address,
+    symbol,
+    decimals,
+    priceBnb,
+    ...(typeof raw.logoUrl === "string" && raw.logoUrl.trim()
+      ? { logoUrl: raw.logoUrl.trim() }
+      : {}),
+    ...(raw.isNative === true ? { isNative: true } : {}),
+  };
+}
+
+/** Build the token universe, guaranteeing native BNB is present exactly once. */
+function resolveTokens(
+  override: readonly SwapToken[] | undefined,
+  injected: InjectedToken[] | undefined,
+): readonly SwapToken[] {
+  const fromOverride = override ?? [];
+  const fromInjected = (injected ?? [])
+    .map(normaliseToken)
+    .filter((t): t is SwapToken => t !== null);
+
+  const merged: SwapToken[] = [];
+  const seen = new Set<string>();
+  for (const token of [NATIVE_BNB_TOKEN, ...fromOverride, ...fromInjected]) {
+    const key = token.address.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(token);
+  }
+  return merged;
+}
+
+/**
+ * Override inputs the AppView host can pass. `agentTokenAddress` is accepted as
+ * a loose string (re-validated to an {@link Address} during resolution), so the
+ * shell never has to assert the 0x-literal type at the call site.
+ */
+export interface WaifuSwapConfigOverride {
+  apiBase?: string;
+  agentTokenAddress?: string;
+  stewardJwt?: string;
+  appInvokeKey?: string;
+  tokens?: readonly SwapToken[];
+}
+
+/**
+ * Resolve the live swap runtime config. The optional `override` lets the
+ * AppView's host props (token address, token list) win over ambient sources
+ * when the shell passes them explicitly.
+ */
+export function resolveWaifuSwapConfig(
+  override?: WaifuSwapConfigOverride,
+): WaifuSwapRuntimeConfig {
+  const injected = readInjectedGlobal();
+
+  const apiBase = stripTrailingSlash(
+    firstNonEmpty(
+      override?.apiBase,
+      injected?.apiBase,
+      readEnv("VITE_WAIFU_API_BASE"),
+      DEFAULT_WAIFU_API_BASE,
+    ) ?? DEFAULT_WAIFU_API_BASE,
+  );
+
+  const agentTokenRaw = firstNonEmpty(
+    override?.agentTokenAddress,
+    injected?.agentTokenAddress,
+    readEnv("VITE_WAIFU_AGENT_TOKEN"),
+  );
+  const agentTokenAddress = isAddress(agentTokenRaw) ? agentTokenRaw : null;
+
+  const stewardJwt = firstNonEmpty(
+    override?.stewardJwt,
+    injected?.stewardJwt,
+    readEnv("VITE_WAIFU_STEWARD_JWT"),
+  );
+
+  const appInvokeKey = firstNonEmpty(
+    override?.appInvokeKey,
+    injected?.appInvokeKey,
+  );
+
+  return {
+    apiBase,
+    agentTokenAddress,
+    stewardJwt,
+    appInvokeKey,
+    tokens: resolveTokens(override?.tokens, injected?.tokens),
+  };
+}

--- a/plugins/plugin-waifu-swap-app/src/swap-contracts.ts
+++ b/plugins/plugin-waifu-swap-app/src/swap-contracts.ts
@@ -1,0 +1,271 @@
+/**
+ * Typed contract for the waifu.fun PancakeSwap v3 swap capability.
+ *
+ * Mirrors the on-chain adapter spec in
+ * `packages/agent-actions/src/adapters/pancakeswap-v3/spec.ts`
+ * (`pancakeV3Spec`) and the generic capability dispatch route in
+ * `apps/api/src/routes/v2/agents/capability-actions.ts`
+ * (`POST /v2/agents/:id/capabilities/:capabilitySlug/actions/:actionSlug`).
+ * Kept as a standalone module so this app-plugin owns its own surface area and
+ * never imports from the waifu monorepo.
+ *
+ * Capability shape (from `capabilityFromAdapterSpec(pancakeV3Spec)`):
+ *
+ *   capabilitySlug: "pancakeswap-v3"
+ *   actions:
+ *     - "quote"  mode=read          (estimate exact-input output, no consent)
+ *     - "swap"   mode=agent_signed  (requiresConsent; on-chain write)
+ *
+ * Backend reality (as of this build): the generic action route exists, but the
+ * `pancakeswap-v3:*` handlers are NOT yet registered in that route's HANDLERS
+ * map (only `hyperliquid-perps:*` is). So both `quote` and `swap` currently
+ * resolve to HTTP 501 "not yet available". This view therefore:
+ *   - drives its displayed quote from a LOCAL estimate (price-driven), and
+ *   - probes the real `quote` endpoint opportunistically, falling back to the
+ *     local estimate when the backend returns 501, and
+ *   - hard-STUBS `swap` execution behind a consent guard until the backend
+ *     handler + agent signer land (see SWAP_EXECUTE_TODO).
+ */
+
+/**
+ * EVM address literal. Defined locally (rather than importing viem) so this
+ * app-plugin's contract module stays dependency-free and self-contained.
+ */
+export type Address = `0x${string}`;
+
+export const PANCAKE_V3_CAPABILITY_SLUG = "pancakeswap-v3";
+export const PANCAKE_V3_QUOTE_ACTION_SLUG = "quote";
+export const PANCAKE_V3_SWAP_ACTION_SLUG = "swap";
+
+/** Wrapped BNB — the native-asset proxy used in PancakeSwap v3 routes. */
+export const PANCAKE_V3_WBNB: Address =
+  "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
+
+/** PancakeSwap v3 fee tiers (in hundredths of a bip), from the adapter spec. */
+export const PANCAKE_V3_FEE_TIERS = [100, 500, 2500, 10000] as const;
+export type PancakeV3Fee = (typeof PANCAKE_V3_FEE_TIERS)[number];
+export const DEFAULT_PANCAKE_V3_FEE: PancakeV3Fee = 2500;
+
+/** Slippage presets surfaced as quick-select chips, plus the default. */
+export const SLIPPAGE_PRESETS = [0.1, 0.5, 1, 3] as const;
+export const DEFAULT_SLIPPAGE_PCT = 0.5;
+export const MIN_SLIPPAGE_PCT = 0.01;
+export const MAX_SLIPPAGE_PCT = 50;
+
+/**
+ * A swap-eligible token. `priceBnb` is the price of ONE whole token expressed
+ * in BNB (matches the waifu frontend `TokenMetrics.priceBnb` convention) and is
+ * what drives the local quote estimate when the backend quote is unavailable.
+ */
+export interface SwapToken {
+  readonly address: Address;
+  readonly symbol: string;
+  readonly decimals: number;
+  /** Price of 1 whole token in BNB. 1 for the native BNB/WBNB side. */
+  readonly priceBnb: number;
+  /** Optional remote logo for the token icon. */
+  readonly logoUrl?: string;
+  /** True for the native BNB / WBNB side of a pair. */
+  readonly isNative?: boolean;
+}
+
+/** Direction-resolved quote, whether locally estimated or backend-sourced. */
+export interface SwapQuote {
+  readonly tokenIn: SwapToken;
+  readonly tokenOut: SwapToken;
+  /** Human amount of tokenIn the user is spending. */
+  readonly amountIn: number;
+  /** Expected human amount of tokenOut, before slippage. */
+  readonly amountOut: number;
+  /** Worst-case tokenOut after applying slippage. */
+  readonly minAmountOut: number;
+  /** Signed price-impact percentage (negative = unfavourable). */
+  readonly priceImpactPct: number;
+  /** Slippage tolerance the quote was computed against. */
+  readonly slippagePct: number;
+  /** Fee tier the route uses. */
+  readonly fee: PancakeV3Fee;
+  /** Where the numbers came from: a local estimate or the live backend quote. */
+  readonly source: "local-estimate" | "backend";
+}
+
+/** Request body for the generic capability `quote`/`swap` action. */
+export interface SwapActionInput {
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: string;
+  fee?: PancakeV3Fee;
+  /** Worst-case output (wei or human, backend-defined) — sent for `swap`. */
+  minAmountOut?: string;
+  /** Explicit consent flag the consent-gated `swap` action requires. */
+  consent?: boolean;
+}
+
+/**
+ * Backend `quote` (read mode) response. The generic route returns the handler's
+ * raw body; for the pancakeswap-v3 quote the expected success shape carries the
+ * exact-output amount. Optional fields tolerate the handler not being wired yet.
+ */
+export interface SwapQuoteResponse {
+  ok?: boolean;
+  error?: string;
+  message?: string;
+  data?: {
+    amountOut?: string | number;
+    minAmountOut?: string | number;
+    priceImpactPct?: string | number;
+    fee?: number;
+  };
+}
+
+/**
+ * Backend `swap` (prepare_tx / client_signed) response: an UNSIGNED tx object
+ * the patron signs in their own wallet. The server never holds the user key.
+ * `agent_signed` swaps return 501 until the agent signer + policy land.
+ */
+export interface UnsignedSwapTx {
+  to: Address;
+  data: `0x${string}`;
+  value: string;
+  chainId?: number;
+}
+
+export interface SwapPrepareResponse {
+  ok?: boolean;
+  error?: string;
+  message?: string;
+  data?: {
+    tx?: UnsignedSwapTx;
+  };
+}
+
+/** Recognised failure kinds surfaced to the AppView so it can branch on status. */
+export type SwapErrorKind =
+  | "auth"
+  | "consent-required"
+  | "not-implemented"
+  | "not-available"
+  | "bad-request"
+  | "misconfigured"
+  | "unknown";
+
+export interface SwapError {
+  readonly kind: SwapErrorKind;
+  readonly status: number;
+  readonly message: string;
+}
+
+export function isSwapError(value: unknown): value is SwapError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { kind?: unknown }).kind === "string" &&
+    typeof (value as { status?: unknown }).status === "number"
+  );
+}
+
+/** Map an HTTP status + message onto a typed {@link SwapError}. */
+export function classifySwapStatus(status: number, message: string): SwapError {
+  switch (status) {
+    case 401:
+      return { kind: "auth", status, message: "sign in to swap" };
+    case 403:
+      return {
+        kind: "consent-required",
+        status,
+        message: "this swap requires explicit confirmation",
+      };
+    case 404:
+      return {
+        kind: "not-available",
+        status,
+        message: "swapping is not available for this agent",
+      };
+    case 400:
+      return {
+        kind: "bad-request",
+        status,
+        message: message || "invalid swap request",
+      };
+    case 501:
+      return {
+        kind: "not-implemented",
+        status,
+        message: "on-chain swap execution is not enabled yet",
+      };
+    case 503:
+      return {
+        kind: "misconfigured",
+        status,
+        message: "swapping is temporarily unavailable",
+      };
+    default:
+      return {
+        kind: "unknown",
+        status,
+        message: message || "swap failed",
+      };
+  }
+}
+
+/**
+ * SWAP_EXECUTE_TODO — execution is intentionally stubbed.
+ *
+ * The PancakeSwap v3 `swap` action is `agent_signed` + `requiresConsent` in the
+ * descriptor, and the generic capability route has NO `pancakeswap-v3:swap`
+ * handler registered yet (it returns 501 NOT_IMPLEMENTED). Until the backend
+ * handler returns either an unsigned tx (client_signed) or an agent-signer job,
+ * this view must NOT fabricate a money path. `executeSwap()` is guarded so a
+ * confirmed press surfaces a clear "not enabled yet" notice instead of POSTing
+ * to a route that can't fulfil it. Flip {@link SWAP_EXECUTE_ENABLED} once the
+ * backend handler lands and this contract's tx shape is confirmed.
+ */
+export const SWAP_EXECUTE_ENABLED = false as const;
+
+/**
+ * Compute a local exact-input quote from token prices. Used as the display
+ * source whenever the backend `quote` handler is unavailable (501).
+ *
+ * `priceBnb` is the price of 1 whole token in BNB, so the BNB value of the
+ * input equals `amountIn * tokenIn.priceBnb`, and the output token amount is
+ * that BNB value divided by `tokenOut.priceBnb`. Price impact is modelled as a
+ * mild, monotonic function of trade size (bounded) — a transparent placeholder
+ * until the on-chain quoter is wired, matching the existing waifu swap panel's
+ * local estimate behaviour.
+ */
+export function estimateLocalQuote(
+  tokenIn: SwapToken,
+  tokenOut: SwapToken,
+  amountIn: number,
+  slippagePct: number,
+  fee: PancakeV3Fee,
+): SwapQuote {
+  const safeIn = Number.isFinite(amountIn) && amountIn > 0 ? amountIn : 0;
+  const bnbValue = safeIn * tokenIn.priceBnb;
+  const grossOut = tokenOut.priceBnb > 0 ? bnbValue / tokenOut.priceBnb : 0;
+
+  // Bounded, size-sensitive impact placeholder (never worse than -5%).
+  const priceImpactPct = safeIn > 0 ? -Math.min(5, bnbValue * 0.04) : 0;
+
+  const impactAdjustedOut = grossOut * (1 + priceImpactPct / 100);
+  const minAmountOut =
+    impactAdjustedOut * (1 - clampSlippage(slippagePct) / 100);
+
+  return {
+    tokenIn,
+    tokenOut,
+    amountIn: safeIn,
+    amountOut: impactAdjustedOut,
+    minAmountOut: Math.max(0, minAmountOut),
+    priceImpactPct,
+    slippagePct: clampSlippage(slippagePct),
+    fee,
+    source: "local-estimate",
+  };
+}
+
+/** Clamp a slippage percentage into the supported range. */
+export function clampSlippage(pct: number): number {
+  if (!Number.isFinite(pct)) return DEFAULT_SLIPPAGE_PCT;
+  return Math.min(MAX_SLIPPAGE_PCT, Math.max(MIN_SLIPPAGE_PCT, pct));
+}

--- a/plugins/plugin-waifu-swap-app/src/ui.ts
+++ b/plugins/plugin-waifu-swap-app/src/ui.ts
@@ -1,0 +1,6 @@
+// Browser/UI-only barrel: the view component plus its overlay-app registration.
+// Importing this (not the root index) keeps Node-only `Plugin` wiring out of
+// frontend bundles. Mirrors the imagegen-app / hyperliquid-app `ui.ts` pattern.
+export { SwapAppView } from "./SwapAppView.tsx";
+export { SWAP_APP_NAME, swapApp } from "./swap-app.ts";
+export { useSwapState } from "./useSwapState.ts";

--- a/plugins/plugin-waifu-swap-app/src/useSwapState.ts
+++ b/plugins/plugin-waifu-swap-app/src/useSwapState.ts
@@ -1,0 +1,284 @@
+/**
+ * State hook for the swap AppView. Owns the token-in/token-out selection, the
+ * amount + slippage form state, the live quote (local estimate, opportunistically
+ * upgraded with a backend quote), and the guarded execute lifecycle. Kept
+ * separate from the view so the .tsx file exports only React components
+ * (Fast-Refresh friendly). Mirrors `useImageGenState`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type BackendQuoteFields,
+  fetchBackendQuote,
+  prepareSwap,
+} from "./swap-client";
+import {
+  resolveWaifuSwapConfig,
+  type WaifuSwapRuntimeConfig,
+} from "./swap-config";
+import {
+  clampSlippage,
+  DEFAULT_PANCAKE_V3_FEE,
+  DEFAULT_SLIPPAGE_PCT,
+  estimateLocalQuote,
+  isSwapError,
+  type PancakeV3Fee,
+  SWAP_EXECUTE_ENABLED,
+  type SwapError,
+  type SwapQuote,
+  type SwapToken,
+} from "./swap-contracts";
+
+export interface SwapStateOptions {
+  /** Host-supplied agent token address (wins over ambient config). */
+  agentTokenAddress?: string;
+  /** Host-supplied swap-eligible token list (wins over ambient config). */
+  tokens?: readonly SwapToken[];
+  /** Called when the backend reports the capability is unavailable (404). */
+  onUnavailable?: () => void;
+}
+
+/** Terminal outcome of a confirmed swap press. */
+export type SwapExecuteOutcome =
+  | { kind: "stubbed"; message: string }
+  | { kind: "prepared"; to: string }
+  | { kind: "error"; error: SwapError };
+
+export interface SwapState {
+  config: WaifuSwapRuntimeConfig;
+  tokens: readonly SwapToken[];
+  tokenIn: SwapToken | null;
+  tokenOut: SwapToken | null;
+  setTokenIn: (token: SwapToken) => void;
+  setTokenOut: (token: SwapToken) => void;
+  reverse: () => void;
+  amountIn: string;
+  setAmountIn: (next: string) => void;
+  slippagePct: number;
+  setSlippagePct: (next: number) => void;
+  fee: PancakeV3Fee;
+  setFee: (next: PancakeV3Fee) => void;
+  quote: SwapQuote | null;
+  amountValid: boolean;
+  canSwap: boolean;
+  executeEnabled: boolean;
+  quoting: boolean;
+  executing: boolean;
+  error: SwapError | null;
+  outcome: SwapExecuteOutcome | null;
+  executeSwap: () => Promise<void>;
+}
+
+const QUOTE_DEBOUNCE_MS = 350;
+
+export function useSwapState(options: SwapStateOptions = {}): SwapState {
+  const config = useMemo(
+    () =>
+      resolveWaifuSwapConfig({
+        agentTokenAddress: options.agentTokenAddress,
+        tokens: options.tokens,
+      }),
+    [options.agentTokenAddress, options.tokens],
+  );
+
+  const tokens = config.tokens;
+  const onUnavailable = options.onUnavailable;
+
+  const [tokenIn, setTokenIn] = useState<SwapToken | null>(
+    () => tokens[0] ?? null,
+  );
+  const [tokenOut, setTokenOut] = useState<SwapToken | null>(
+    () => tokens[1] ?? null,
+  );
+  const [amountIn, setAmountIn] = useState("");
+  const [slippagePct, setSlippageRaw] = useState(DEFAULT_SLIPPAGE_PCT);
+  const [fee, setFee] = useState<PancakeV3Fee>(DEFAULT_PANCAKE_V3_FEE);
+
+  const [backendQuote, setBackendQuote] = useState<BackendQuoteFields | null>(
+    null,
+  );
+  const [quoting, setQuoting] = useState(false);
+  const [executing, setExecuting] = useState(false);
+  const [error, setError] = useState<SwapError | null>(null);
+  const [outcome, setOutcome] = useState<SwapExecuteOutcome | null>(null);
+
+  const setSlippagePct = useCallback((next: number) => {
+    setSlippageRaw(clampSlippage(next));
+  }, []);
+
+  const parsedAmount = Number.parseFloat(amountIn);
+  const amountValid = Number.isFinite(parsedAmount) && parsedAmount > 0;
+
+  // Base quote is always the transparent local estimate; it never blocks the UI.
+  const localQuote = useMemo<SwapQuote | null>(() => {
+    if (!tokenIn || !tokenOut || !amountValid) return null;
+    return estimateLocalQuote(
+      tokenIn,
+      tokenOut,
+      parsedAmount,
+      slippagePct,
+      fee,
+    );
+  }, [tokenIn, tokenOut, amountValid, parsedAmount, slippagePct, fee]);
+
+  // If a backend quote arrives for the current inputs, prefer its numbers.
+  const quote = useMemo<SwapQuote | null>(() => {
+    if (!localQuote) return null;
+    if (!backendQuote) return localQuote;
+    const minAmountOut =
+      backendQuote.minAmountOut ??
+      backendQuote.amountOut * (1 - localQuote.slippagePct / 100);
+    return {
+      ...localQuote,
+      amountOut: backendQuote.amountOut,
+      minAmountOut: Math.max(0, minAmountOut),
+      priceImpactPct: backendQuote.priceImpactPct ?? localQuote.priceImpactPct,
+      source: "backend",
+    };
+  }, [localQuote, backendQuote]);
+
+  // Opportunistically upgrade the local estimate with the backend `quote`
+  // action. A 501 (handler not wired yet) is swallowed — the local estimate
+  // stays. Other typed errors don't disturb the display either; they only
+  // suppress the upgrade. Debounced + abortable to avoid hammering on keystroke.
+  // The prior backend quote is dropped at the top of each run so it never
+  // briefly applies to inputs it was not computed for.
+  useEffect(() => {
+    setBackendQuote(null);
+    if (!tokenIn || !tokenOut || !amountValid) return;
+    if (!config.agentTokenAddress) return;
+    if (!config.appInvokeKey && !config.stewardJwt) return;
+
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      setQuoting(true);
+      void fetchBackendQuote(config, {
+        tokenIn: tokenIn.address,
+        tokenOut: tokenOut.address,
+        amountIn,
+        fee,
+      })
+        .then((fields) => {
+          if (!cancelled) setBackendQuote(fields);
+        })
+        .catch((caught: unknown) => {
+          if (cancelled) return;
+          if (isSwapError(caught) && caught.kind === "not-available") {
+            onUnavailable?.();
+          }
+          // Local estimate remains the display source.
+        })
+        .finally(() => {
+          if (!cancelled) setQuoting(false);
+        });
+    }, QUOTE_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [config, tokenIn, tokenOut, amountIn, amountValid, fee, onUnavailable]);
+
+  const reverse = useCallback(() => {
+    setTokenIn((prevIn) => {
+      setTokenOut(prevIn);
+      return tokenOut;
+    });
+  }, [tokenOut]);
+
+  const handleSetTokenIn = useCallback(
+    (token: SwapToken) => {
+      // Disallow selecting the same token on both sides; swap if collided.
+      setTokenIn(token);
+      if (tokenOut && token.address === tokenOut.address) {
+        setTokenOut((prev) => (prev ? tokenIn : prev));
+      }
+    },
+    [tokenOut, tokenIn],
+  );
+
+  const handleSetTokenOut = useCallback(
+    (token: SwapToken) => {
+      setTokenOut(token);
+      if (tokenIn && token.address === tokenIn.address) {
+        setTokenIn((prev) => (prev ? tokenOut : prev));
+      }
+    },
+    [tokenIn, tokenOut],
+  );
+
+  const canSwap =
+    amountValid &&
+    Boolean(tokenIn) &&
+    Boolean(tokenOut) &&
+    Boolean(quote) &&
+    !executing;
+
+  const executeSwap = useCallback(async () => {
+    if (!canSwap || !tokenIn || !tokenOut || !quote) return;
+    setError(null);
+    setOutcome(null);
+
+    // SWAP_EXECUTE_TODO: execution is intentionally stubbed until the backend
+    // `pancakeswap-v3:swap` handler + agent signer land. Never fabricate a money
+    // path — surface a clear, honest "not enabled yet" outcome instead.
+    if (!SWAP_EXECUTE_ENABLED) {
+      setOutcome({
+        kind: "stubbed",
+        message:
+          "on-chain swap execution is not enabled yet — this is a quote-only preview",
+      });
+      return;
+    }
+
+    setExecuting(true);
+    try {
+      const tx = await prepareSwap(config, {
+        tokenIn: tokenIn.address,
+        tokenOut: tokenOut.address,
+        amountIn,
+        fee,
+        minAmountOut: String(quote.minAmountOut),
+      });
+      setOutcome({ kind: "prepared", to: tx.to });
+    } catch (caught) {
+      const err: SwapError = isSwapError(caught)
+        ? caught
+        : {
+            kind: "unknown",
+            status: 500,
+            message: caught instanceof Error ? caught.message : "swap failed",
+          };
+      if (err.kind === "not-available") onUnavailable?.();
+      setError(err);
+      setOutcome({ kind: "error", error: err });
+    } finally {
+      setExecuting(false);
+    }
+  }, [canSwap, tokenIn, tokenOut, quote, config, amountIn, fee, onUnavailable]);
+
+  return {
+    config,
+    tokens,
+    tokenIn,
+    tokenOut,
+    setTokenIn: handleSetTokenIn,
+    setTokenOut: handleSetTokenOut,
+    reverse,
+    amountIn,
+    setAmountIn,
+    slippagePct,
+    setSlippagePct,
+    fee,
+    setFee,
+    quote,
+    amountValid,
+    canSwap,
+    executeEnabled: SWAP_EXECUTE_ENABLED,
+    quoting,
+    executing,
+    error,
+    outcome,
+    executeSwap,
+  };
+}

--- a/plugins/plugin-waifu-swap-app/tsconfig.build.json
+++ b/plugins/plugin-waifu-swap-app/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.build.shared.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
+}

--- a/plugins/plugin-waifu-swap-app/vite.config.views.ts
+++ b/plugins/plugin-waifu-swap-app/vite.config.views.ts
@@ -1,0 +1,10 @@
+import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
+
+export default createViewBundleConfig({
+  packageName: "@elizaos/plugin-waifu-swap-app",
+  viewId: "waifu-swap",
+  entry: "./src/swap-app-view-bundle.ts",
+  outDir: "dist/views",
+  componentExport: "SwapAppView",
+  additionalExternals: ["@elizaos/app-core"],
+});


### PR DESCRIPTION
Part of the waifu web-UI direction (#8434): a token-swap AppView so a waifu agent can quote/swap inside its ElizaOS web UI canvas. New plugin, modeled on plugin-waifu-imagegen-app.

## What
New `plugin-waifu-swap-app`:
- `SwapAppView.tsx` — token-in/out selectors, amount input, reverse button, live quote (expected out + min received), slippage presets, fee-tier chips, route/price-impact strip, guarded swap CTA
- `useSwapState.ts` — form + quote + guarded-execute lifecycle
- `swap-client/config/contracts.ts` — auth-aware cross-origin POST, `window.__WAIFU_SWAP__` shell injection, standalone typed contracts + local quote estimator

## Quote vs Execute
- **Quote/display: fully built** — transparent local estimate (matching the existing waifu swap-panel), opportunistically upgraded via the backend quote action.
- **Execute: STUBBED behind `SWAP_EXECUTE_ENABLED=false`** — because the backend has **no `pancakeswap-v3:quote`/`:swap` handler registered** (the `HANDLERS` registry in `capability-actions.ts` only has `hyperliquid-perps:*`), so both return 501. A confirmed press shows a clear 'not enabled' notice instead of POSTing a dead money path. The typed `prepareSwap()` client + unsigned-tx contract are wired and ready.

**Backend follow-up:** register `pancakeswap-v3:quote` + `pancakeswap-v3:swap` handlers in `apps/api/.../capability-actions.ts`, confirm the unsigned-tx shape, flip the flag. (swap is `agent_signed` + `requiresConsent`.)

## Contract match
Lazy overlay registration, `views[]` discovery, third-partyized bundle, dual-auth cross-origin fetch. Same primitives as HyperliquidAppView.

## Verification
Pure logic modules pass strict + noImplicitAny (exit 0), zero `any`, biome clean. (One residual tsc artifact = stale `@elizaos/core` dist; `ViewDeclaration.viewType` exists in fresh source.)

Co-authored-by: wakesync <shadow@shad0w.xyz>