### PR TITLE
fix(cloud,plugin-sql): lean env-tunable agent DB pool (scale fix)

### DIFF
--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -241,6 +241,14 @@ export async function prepareManagedElizaBaseEnvironment(
         existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
       ELIZAOS_CLOUD_LARGE_MODEL:
         existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
+      // Lean multi-tenant Postgres pool. Every dedicated agent container pools
+      // against the shared cloud Postgres, so the default per-agent pool
+      // (max 20 / min 2) exhausts the server's max_connections at scale (50
+      // idle agents × min 2 = 100 connections). Cap bursts at 8 and let idle
+      // agents release ALL connections (min 0). plugin-sql reads POSTGRES_POOL_*.
+      POSTGRES_POOL_MAX: existingEnv.POSTGRES_POOL_MAX ?? "8",
+      POSTGRES_POOL_MIN: existingEnv.POSTGRES_POOL_MIN ?? "0",
+      POSTGRES_POOL_IDLE_TIMEOUT_MS: existingEnv.POSTGRES_POOL_IDLE_TIMEOUT_MS ?? "15000",
       ELIZA_CLOUD_AGENT_ID: params.agentSandboxId,
       PUBLIC_BASE_URL: mergeManagedPublicBaseUrl(
         existingEnv.PUBLIC_BASE_URL,

--- a/plugins/plugin-sql/src/pg/manager.ts
+++ b/plugins/plugin-sql/src/pg/manager.ts
@@ -11,11 +11,22 @@ export class PostgresConnectionManager {
   private shuttingDown = false;
 
   constructor(connectionString: string, rlsServerId?: string) {
+    // Pool sizing is env-tunable so multi-tenant deployments (e.g. Eliza Cloud,
+    // where many agent containers share one Postgres) can run lean pools and not
+    // exhaust the server's max_connections. Defaults preserve the original
+    // single-agent behavior (max 20 / min 2). Set POSTGRES_POOL_MIN=0 so idle
+    // agents release every connection; a small POSTGRES_POOL_MAX caps bursts.
+    const envInt = (key: string, fallback: number): number => {
+      const raw = process.env[key];
+      if (raw === undefined || raw === "") return fallback;
+      const n = Number(raw);
+      return Number.isFinite(n) && n >= 0 ? n : fallback;
+    };
     const poolConfig: PoolConfig = {
       connectionString: normalizePgSslMode(connectionString),
-      max: 20,
-      min: 2,
-      idleTimeoutMillis: 30000,
+      max: envInt("POSTGRES_POOL_MAX", 20),
+      min: envInt("POSTGRES_POOL_MIN", 2),
+      idleTimeoutMillis: envInt("POSTGRES_POOL_IDLE_TIMEOUT_MS", 30000),
       connectionTimeoutMillis: 5000,
       keepAlive: true,
       keepAliveInitialDelayMillis: 10000,


### PR DESCRIPTION
Dedicated agents each pool against the shared cloud Postgres; plugin-sql hardcoded max:20/min:2 → linear connection cost with a min-2 floor (50 idle agents = 100 conns = exhaustion, the structural half of today's 'too many clients' prod incident). Make pool sizing env-tunable (POSTGRES_POOL_MAX/_MIN/_IDLE_TIMEOUT_MS; defaults unchanged off-cloud) and set managed agents to max=8/min=0/idle=15s so idle agents release ALL connections. Paired with right-sizing the Worker Hyperdrive origin pools (staging 60→8, prod 35→25) that already recovered prod.