### PR TITLE
fix(cloud): route :nitro Cerebras ids to cerebras-direct (not OpenRouter)

### DIFF
--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -46,6 +46,7 @@ import {
   isAnthropicWebSearchEnabled,
 } from "@/lib/providers/anthropic-web-search";
 import {
+  canonicalizeCerebrasModelId,
   getAiProviderConfigurationError,
   getLanguageModel,
   hasLanguageModelProviderConfigured,
@@ -767,7 +768,10 @@ export async function handleChatCompletionsPOST(
       );
     }
 
-    const model = request.model;
+    // Collapse decorated Cerebras ids (e.g. "openai/gpt-oss-120b:nitro" emitted
+    // by dedicated agents) to the bare Cerebras id so pricing, routing, and
+    // billing all agree and route to cerebras-direct instead of OpenRouter.
+    const model = canonicalizeCerebrasModelId(request.model);
 
     if (!hasLanguageModelProviderConfigured(model)) {
       return addCorsHeaders(

--- a/packages/cloud-shared/src/lib/providers/language-model-nitro-failover.test.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model-nitro-failover.test.ts
@@ -4,6 +4,7 @@ const ORIGINAL_FETCH = globalThis.fetch;
 
 process.env.BITROUTER_API_KEY = "test-key";
 delete process.env.BITROUTER_BASE_URL;
+process.env.CEREBRAS_API_KEY = "test-cerebras-key";
 
 mock.module("@/lib/utils/logger", () => ({
   logger: {
@@ -42,6 +43,12 @@ afterEach(() => {
 describe("getLanguageModel BitRouter :nitro failover (AI SDK path)", () => {
   let models: string[];
 
+  // A NON-Cerebras :nitro id so it routes through BitRouter. Cerebras-native
+  // :nitro ids (gpt-oss-120b / zai-glm-4.7) now route to cerebras-direct instead
+  // — see the cerebras-direct test below — so they must not be used here.
+  const NITRO = "openai/gpt-4o-mini:nitro";
+  const BASE = "openai/gpt-4o-mini";
+
   beforeEach(() => {
     models = [];
   });
@@ -57,13 +64,13 @@ describe("getLanguageModel BitRouter :nitro failover (AI SDK path)", () => {
     }) as typeof fetch;
 
     const result = await generateText({
-      model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+      model: getLanguageModel(NITRO),
       prompt: "hi",
       maxRetries: 0,
     });
 
     expect(result.text).toBe("ok");
-    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+    expect(models).toEqual([NITRO, BASE]);
   });
 
   test("does not retry when the base model also fails (surfaces the error)", async () => {
@@ -74,11 +81,36 @@ describe("getLanguageModel BitRouter :nitro failover (AI SDK path)", () => {
 
     await expect(
       generateText({
-        model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+        model: getLanguageModel(NITRO),
         prompt: "hi",
         maxRetries: 0,
       }),
     ).rejects.toBeDefined();
-    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+    expect(models).toEqual([NITRO, BASE]);
+  });
+
+  test("Cerebras-native :nitro ids route to cerebras-direct, not OpenRouter", async () => {
+    // Dedicated agents emit decorated ids like "openai/gpt-oss-120b:nitro" for
+    // what are really bare Cerebras models. Those must hit cerebras-direct (the
+    // request body carries the bare id, never the :nitro/openai/ decoration),
+    // otherwise they leak to the public BitRouter → OpenRouter and 429/500.
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const model = bodyModel(init);
+      models.push(model);
+      return completion(model);
+    }) as typeof fetch;
+
+    await generateText({
+      model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    await generateText({
+      model: getLanguageModel("openai/zai-glm-4.7:nitro"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(models).toEqual(["gpt-oss-120b", "zai-glm-4.7"]);
   });
 });

--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -181,9 +181,22 @@ function isAnthropicNativeModel(model: string): boolean {
 }
 
 function normalizeCerebrasModelId(model: string): string {
-  if (model.startsWith("cerebras/")) return model.slice("cerebras/".length);
-  if (model.startsWith("cerebras:")) return model.slice("cerebras:".length);
-  return model;
+  // Strip provider/gateway namespace prefixes AND the OpenRouter routing-variant
+  // suffix (:nitro / :floor / :free / …). A dedicated agent's bundled plugin
+  // emits ids like "openai/gpt-oss-120b:nitro" / "openai/zai-glm-4.7:nitro" for
+  // what are really the bare Cerebras models gpt-oss-120b / zai-glm-4.7. Without
+  // this, isCerebrasNativeModel() misses them, so they skip cerebras-direct and
+  // fall through to BitRouter → the PUBLIC api.bitrouter.ai → OpenRouter, which
+  // 429s the :nitro variant (3 retries → 26-55s chats) or 500s "pricing
+  // unavailable" for the large model. Recognizing the underlying Cerebras id here
+  // routes them to cerebras-direct (the configured Cerebras key).
+  let id = model;
+  if (id.startsWith("cerebras/")) id = id.slice("cerebras/".length);
+  else if (id.startsWith("cerebras:")) id = id.slice("cerebras:".length);
+  else if (id.startsWith("openai/")) id = id.slice("openai/".length);
+  const variantAt = id.indexOf(":");
+  if (variantAt > 0) id = id.slice(0, variantAt);
+  return id;
 }
 
 function isCerebrasNativeModel(model: string): boolean {

--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -206,6 +206,20 @@ function isCerebrasNativeModel(model: string): boolean {
   );
 }
 
+/**
+ * Canonicalize a requested model id for pricing AND routing. Dedicated agents
+ * emit decorated ids like "openai/gpt-oss-120b:nitro" / "openai/zai-glm-4.7:nitro"
+ * for what are really the bare Cerebras models. Collapse those to the bare
+ * Cerebras id at the route entry so the pricing lookup (which only carries the
+ * Cerebras row — "openai/zai-glm-4.7" is not an OpenRouter model → 500 "pricing
+ * unavailable") and the provider routing (cerebras-direct) agree. Non-Cerebras
+ * ids are returned unchanged so their normal BitRouter/gateway routing + pricing
+ * is untouched.
+ */
+export function canonicalizeCerebrasModelId(model: string): string {
+  return isCerebrasNativeModel(model) ? normalizeCerebrasModelId(model) : model;
+}
+
 function normalizeBitRouterLanguageModelId(model: string): string {
   if (isCerebrasNativeModel(model)) {
     return `cerebras:${normalizeCerebrasModelId(model)}`;


### PR DESCRIPTION
Dedicated agents emit `openai/gpt-oss-120b:nitro` / `openai/zai-glm-4.7:nitro` for what are really bare Cerebras models. These weren't recognized as Cerebras-native, so they fell through to BitRouter → the public router → OpenRouter, which 429'd `:nitro` (3 retries → 26-55s chats) and 500'd "pricing unavailable" for the large model (no OpenRouter pricing row). Fix: (1) normalizeCerebrasModelId strips the openai/ prefix + :nitro/:floor suffix; (2) canonicalize at the chat-route entry so pricing + routing + billing all agree → cerebras-direct. Verified live: all `:nitro` ids now 200 + served=bare cerebras id (was 500/slow). Already hotfixed to prod via wrangler; this is the permanent home. Non-Cerebras :nitro keeps its BitRouter failover (test added).