### PR TITLE
fix(cloud): bare Cerebras default text model + preserve :free tier

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -194,8 +194,11 @@ function normalizeCerebrasModelId(model: string): string {
   if (id.startsWith("cerebras/")) id = id.slice("cerebras/".length);
   else if (id.startsWith("cerebras:")) id = id.slice("cerebras:".length);
   else if (id.startsWith("openai/")) id = id.slice("openai/".length);
+  // Collapse paid throughput variants (:nitro / :floor / …) to the bare Cerebras
+  // id for cerebras-direct, but PRESERVE :free so the free tier keeps its free
+  // upstream (BitRouter/OpenRouter) instead of billing the paid Cerebras key.
   const variantAt = id.indexOf(":");
-  if (variantAt > 0) id = id.slice(0, variantAt);
+  if (variantAt > 0 && id.slice(variantAt + 1) !== "free") id = id.slice(0, variantAt);
   return id;
 }
 

--- a/packages/shared/src/contracts/service-routing.ts
+++ b/packages/shared/src/contracts/service-routing.ts
@@ -45,7 +45,12 @@ import type {
 } from "@elizaos/contracts";
 import { asRecord } from "../type-guards.js";
 
-export const DEFAULT_ELIZA_CLOUD_TEXT_MODEL = "openai/gpt-oss-120b:nitro";
+// Bare Cerebras id (not the OpenRouter "openai/…:nitro" variant) so the default
+// text model routes to cerebras-direct with the configured Cerebras key instead
+// of leaking to OpenRouter (429 → 26-55s) when an agent falls back to this
+// default. Consistent with DEFAULT_ELIZA_CLOUD_LARGE_MODEL ("zai-glm-4.7"), which
+// is already bare. The :free default below intentionally keeps its free upstream.
+export const DEFAULT_ELIZA_CLOUD_TEXT_MODEL = "gpt-oss-120b";
 export const DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL = "openai/gpt-oss-120b:free";
 
 const ELIZA_CLOUD_ROUTE_BASE = {


### PR DESCRIPTION
Source-level follow-up to #8697. (1) DEFAULT_ELIZA_CLOUD_TEXT_MODEL was the OpenRouter variant `openai/gpt-oss-120b:nitro` — so an agent falling back to the default emits :nitro → OpenRouter 429. Change to bare `gpt-oss-120b` (cerebras-direct), matching the already-bare LARGE default. Ships with the next agent-image build (the cloud canonicalizer from #8697 already covers in-flight :nitro requests). (2) The route canonicalizer collapsed ANY :variant including :free → would bill free-tier to the PAID Cerebras key; preserve :free (only :nitro/:floor collapse). NOTE: this exposes a pre-existing issue — `openai/gpt-oss-120b:free` 500s because the self-hosted BitRouter is cerebras-only and has no free route. Free-tier model routing needs a product decision (separate).