### PR TITLE
style(cloud): biome-format the previously-gitignored data/ hooks

### DIFF
--- a/packages/ui/src/cloud/admin/data/use-admin-gate.ts
+++ b/packages/ui/src/cloud/admin/data/use-admin-gate.ts
@@ -91,7 +91,9 @@ export function useAdminGate(): UseAdminGateResult {
   const query = useQuery<AdminGateStatus>({
     queryKey: ["admin", "gate", "status", gate.userId],
     queryFn: async () => {
-      const res = await apiFetch("/api/v1/admin/moderation", { method: "HEAD" });
+      const res = await apiFetch("/api/v1/admin/moderation", {
+        method: "HEAD",
+      });
       return {
         isAdmin: res.headers.get("X-Is-Admin") === "true",
         role: adminRoleFromHeader(res.headers.get("X-Admin-Role")),

--- a/packages/ui/src/cloud/billing/data/billing-data.ts
+++ b/packages/ui/src/cloud/billing/data/billing-data.ts
@@ -8,7 +8,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api, ApiError } from "../../lib/api-client";
+import { ApiError, api } from "../../lib/api-client";
 import type {
   BillingUser,
   CreditBalanceResponse,
@@ -32,7 +32,10 @@ function useAuthGate(enabled = true): AuthGate {
   };
 }
 
-function authKey(parts: readonly unknown[], gate: AuthGate): readonly unknown[] {
+function authKey(
+  parts: readonly unknown[],
+  gate: AuthGate,
+): readonly unknown[] {
   return [...parts, "auth", gate.userId];
 }
 

--- a/packages/ui/src/cloud/instances/lib/data/credits.ts
+++ b/packages/ui/src/cloud/instances/lib/data/credits.ts
@@ -5,8 +5,8 @@
  * domain). Repointed at the cloud shell's typed {@link api} client + auth gate.
  */
 
-import { useQuery } from "@tanstack/react-query";
 import type { CreditBalanceResponse } from "@elizaos/cloud-shared/lib/types/cloud-api";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../lib/api-client";
 import {
   authenticatedQueryKey,

--- a/packages/ui/src/cloud/instances/lib/data/eliza-agents.ts
+++ b/packages/ui/src/cloud/instances/lib/data/eliza-agents.ts
@@ -4,12 +4,12 @@
  * at the cloud shell's typed {@link api} client and the Instances auth gate.
  */
 
-import { useQuery } from "@tanstack/react-query";
 import type {
   AgentListItemDto,
   AgentResponse,
   AgentsResponse,
 } from "@elizaos/cloud-shared/lib/types/cloud-api";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../lib/api-client";
 import {
   authenticatedQueryKey,

--- a/packages/ui/src/cloud/organization/data/use-organization.ts
+++ b/packages/ui/src/cloud/organization/data/use-organization.ts
@@ -17,12 +17,8 @@
  * - `DELETE /api/organizations/members/:userId`    remove member (owner/admin)
  */
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { api, ApiError } from "../../lib/api-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError, api } from "../../lib/api-client";
 import type {
   InviteRole,
   OrgInviteDto,


### PR DESCRIPTION
Formats the ported react-query data/ hooks (biome had skipped them while gitignored) so main's lint/Quality CI is green. Formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)