### PR TITLE
fix(cloud): accept OpenAI /v1 + bare /embeddings prefix (dedicated-agent 404)

### DIFF
--- a/packages/cloud-api/src/index.ts
+++ b/packages/cloud-api/src/index.ts
@@ -173,6 +173,21 @@ export default {
       return healthResponse(env);
     }
 
+    // OpenAI-compat prefix rewrite. Dedicated agents whose cloud base/embedding
+    // URL got stamped as the bare host (`https://api.elizacloud.ai`) hit
+    // `/v1/embeddings` / `/embeddings` (and would for `/chat/completions`),
+    // which 404 because the canonical routes live under `/api/v1/*`. Accept the
+    // OpenAI-style prefixes by rewriting to `/api/v1/*` so embeddings + inference
+    // work regardless of the agent's baked base URL. Cloud routes are all under
+    // `/api/`, so `/v1/*` and bare `/embeddings`/`/chat/completions` are
+    // otherwise-unused (404) and safe to remap.
+    const p = url.pathname;
+    if (p.startsWith("/v1/") || p === "/embeddings" || p === "/chat/completions") {
+      const rewrittenUrl = new URL(url);
+      rewrittenUrl.pathname = p.startsWith("/v1/") ? `/api${p}` : `/api/v1${p}`;
+      return (await getApp()).fetch(new Request(rewrittenUrl, request), env, ctx);
+    }
+
     return (await getApp()).fetch(request, env, ctx);
   },
 


### PR DESCRIPTION
Dedicated agents with a bare-host embedding URL hit /v1/embeddings or /embeddings → 404 → retries → +20s latency. Rewrite OpenAI-style prefixes to /api/v1/* at the Worker entry. Live via wrangler (771be24a); this is the permanent home. Verified: /v1/embeddings→200, /embeddings→200.