### PR TITLE
fix(core): don't block the chat reply on the background facts stage

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6342,22 +6342,51 @@ export async function runV5MessageRuntimeStage1(args: {
 		endStatus = "errored";
 		throw err;
 	} finally {
-		const factsOutcome = await factsTask;
-		if (recorder && trajectoryId && factsOutcome) {
-			await recordFactsAndRelationshipsStage({
-				recorder,
-				trajectoryId,
-				outcome: factsOutcome,
-				logger: args.runtime.logger,
-			});
-		}
-		if (recorder && trajectoryId) {
-			await recorder.endTrajectory(trajectoryId, endStatus).catch((err) => {
+		// Finalize the trajectory: record the FACTS_AND_RELATIONSHIPS side-effect
+		// stage, then end the trajectory.
+		//
+		// CRITICAL (latency): factsTask is the FACTS_AND_RELATIONSHIPS stage — a
+		// heavy background TEXT_LARGE call that is launched in parallel precisely
+		// so it does NOT block the user reply (see the launch comment above). The
+		// facts/relationships are persisted *inside* runFactsAndRelationshipsStage
+		// independently of this await, so the only thing awaiting it here buys is
+		// the trajectory record's facts-stage entry. Awaiting it in `finally`
+		// gated EVERY reply on the slow facts model — dedicated cloud agents took
+		// 30s+ per turn for a reply that was already ready in ~3s. So run the
+		// finalize in the background by default and let the turn return as soon as
+		// the reply is decided. Await it only when deterministic trajectory
+		// ordering is required (e.g. the scenario-runner) via ELIZA_AWAIT_FACTS_STAGE.
+		const finalizeTrajectory = async () => {
+			try {
+				const factsOutcome = await factsTask;
+				if (recorder && trajectoryId && factsOutcome) {
+					await recordFactsAndRelationshipsStage({
+						recorder,
+						trajectoryId,
+						outcome: factsOutcome,
+						logger: args.runtime.logger,
+					});
+				}
+			} catch (factsErr) {
 				args.runtime.logger?.warn?.(
-					{ err: (err as Error).message, trajectoryId },
-					"[TrajectoryRecorder] endTrajectory failed",
+					{ err: (factsErr as Error).message, trajectoryId },
+					"[facts] background facts-stage recording failed",
 				);
-			});
+			} finally {
+				if (recorder && trajectoryId) {
+					await recorder.endTrajectory(trajectoryId, endStatus).catch((err) => {
+						args.runtime.logger?.warn?.(
+							{ err: (err as Error).message, trajectoryId },
+							"[TrajectoryRecorder] endTrajectory failed",
+						);
+					});
+				}
+			}
+		};
+		if (process.env.ELIZA_AWAIT_FACTS_STAGE === "true") {
+			await finalizeTrajectory();
+		} else {
+			void finalizeTrajectory();
 		}
 	}
 }


### PR DESCRIPTION
## Problem
Dedicated cloud agents take **30-43s per chat turn** for a reply that's ready in ~3s.

Root-caused (with the cloud-agent on #8434, after the model-routing + embeddings fixes landed cloud-side): the `FACTS_AND_RELATIONSHIPS` stage (`factsTask`) is launched in parallel and is **documented as non-blocking** ("without blocking the user reply", `message.ts` ~L5901) — but the `finally` block of `runV5MessageRuntimeStage1` then `await`s it before returning:

```ts
} finally {
    const factsOutcome = await factsTask;   // gates EVERY reply on the slow facts model
    ...
}
```

That stage runs a heavy `TEXT_LARGE` call (`facts-and-relationships.ts:183` → `zai-glm-4.7` on cloud), so every reply waits ~15-24s for a side-effect.

## Fix
Finalize the trajectory (record the facts-stage + `endTrajectory`) **in the background by default**, so the turn returns as soon as the reply is decided. Await only when deterministic trajectory ordering is required (e.g. the scenario-runner) via `ELIZA_AWAIT_FACTS_STAGE=true`.

Facts/relationships are persisted **inside** `runFactsAndRelationshipsStage` independently of this await — the await only buys the trajectory record's facts-stage entry — so nothing functional is lost. This matches the stage's documented non-blocking intent.

## Impact
Dedicated-agent turn: **~33-43s → ~3-6s** (the reply path). No change to reply content or fact persistence; the facts-stage trajectory entry becomes eventually-consistent (recorded just after the reply).

## Verification
Lint + typecheck clean; **100 core tests pass** (message-handler, facts-and-relationships, message-service). Found via a source-trace workflow + adversarial verification (root cause CONFIRMED at `message.ts:6345` / `facts-and-relationships.ts:183`).

Refs #8434.