### PR TITLE
fix(cloud-frontend): global shadow passes through ALL native getters

### DIFF
--- a/packages/cloud-frontend/index.html
+++ b/packages/cloud-frontend/index.html
@@ -166,24 +166,35 @@
           // the entry graph; use a shadow instead of `window` so libraries
           // can assign Node-ish fields without mutating read-only DOM globals.
           const safeGlobal = Object.create(globalThis);
-          for (const key of [
-            "close",
-            "open",
-            "name",
-            "status",
-            "self",
-            "top",
-            "parent",
-            "frames",
-            "window",
-            "document",
-          ]) {
-            Object.defineProperty(safeGlobal, key, {
-              configurable: true,
-              enumerable: false,
-              get: () => globalThis[key],
-              set: () => {},
-            });
+          // Native DOM globals (navigator, location, history, crypto,
+          // localStorage, name, self, ...) are *accessor* properties on
+          // Window.prototype. Reading one through this derived shadow invokes
+          // the getter with the wrong receiver and throws "Illegal invocation"
+          // (e.g. MetaMask's connect-multichain reads `global.navigator.product`
+          // at module init). Re-install every inherited accessor as a
+          // pass-through to globalThis so reads resolve correctly; writes are
+          // swallowed so Node shims that assign `global.x` never mutate the
+          // read-only DOM globals.
+          for (
+            let obj = globalThis;
+            obj && obj !== Object.prototype;
+            obj = Object.getPrototypeOf(obj)
+          ) {
+            for (const key of Object.getOwnPropertyNames(obj)) {
+              if (Object.hasOwn(safeGlobal, key)) {
+                continue;
+              }
+              const desc = Object.getOwnPropertyDescriptor(obj, key);
+              if (!desc || typeof desc.get !== "function") {
+                continue;
+              }
+              Object.defineProperty(safeGlobal, key, {
+                configurable: true,
+                enumerable: false,
+                get: () => globalThis[key],
+                set: () => {},
+              });
+            }
           }
           if (!safeGlobal.process) {
             safeGlobal.process = {

--- a/packages/cloud-frontend/src/shims/global.ts
+++ b/packages/cloud-frontend/src/shims/global.ts
@@ -27,33 +27,38 @@ const getSafeGlobal = (): SafeGlobal => {
   } catch (_) {}
 
   // Fallback minimal shadow (same logic as the early script, in case this
-  // module is evaluated extremely early).
-  const g = Object.create(
-    typeof globalThis !== "undefined" ? globalThis : {},
-  ) as SafeGlobal;
-  const readonlys = [
-    "close",
-    "open",
-    "name",
-    "status",
-    "self",
-    "top",
-    "parent",
-    "frames",
-    "window",
-    "document",
-  ];
-  for (const k of readonlys) {
-    try {
-      Object.defineProperty(g, k, {
-        configurable: true,
-        enumerable: false,
-        get: () => (globalThis as Record<string, unknown>)?.[k],
-        set: () => {
-          /* ignore */
-        },
-      });
-    } catch (_) {}
+  // module is evaluated extremely early). Native DOM globals (navigator,
+  // location, crypto, name, self, ...) are accessor properties on
+  // Window.prototype: reading one through this derived shadow invokes the
+  // getter with the wrong receiver and throws "Illegal invocation". Re-install
+  // every inherited accessor as a pass-through to globalThis so reads resolve;
+  // writes are swallowed so they never touch the read-only DOM globals.
+  const base = typeof globalThis !== "undefined" ? globalThis : {};
+  const g = Object.create(base) as SafeGlobal;
+  for (
+    let obj: object | null = base;
+    obj && obj !== Object.prototype;
+    obj = Object.getPrototypeOf(obj)
+  ) {
+    for (const key of Object.getOwnPropertyNames(obj)) {
+      if (Object.hasOwn(g, key)) {
+        continue;
+      }
+      const desc = Object.getOwnPropertyDescriptor(obj, key);
+      if (!desc || typeof desc.get !== "function") {
+        continue;
+      }
+      try {
+        Object.defineProperty(g, key, {
+          configurable: true,
+          enumerable: false,
+          get: () => (globalThis as Record<string, unknown>)?.[key],
+          set: () => {
+            /* ignore */
+          },
+        });
+      } catch (_) {}
+    }
   }
   if (!g.process) {
     g.process = {


### PR DESCRIPTION
Forward-port of #8708 (on main; deployed live). Fixes Illegal invocation from the global polyfill hardcoding native accessors → wallet/multichain init crashed. Loop over globalThis prototype chain for pass-through getters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)