### PR TITLE
fix(cloud-deploy): resolve db:cloud:migrate from src via eliza-source condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "build:riscv64-artifacts": "node packages/scripts/run-bash-linux-only.mjs scripts/build-riscv64-artifacts.sh",
     "check:riscv64-artifacts": "node packages/scripts/run-bash-linux-only.mjs scripts/check-riscv64-artifacts.sh",
     "db:cloud:generate": "bun run --cwd packages/cloud-shared db:generate",
-    "db:cloud:migrate": "bun run packages/scripts/cloud/admin/migrate-with-diagnostics.ts",
+    "db:cloud:migrate": "bun --conditions=eliza-source packages/scripts/cloud/admin/migrate-with-diagnostics.ts",
     "db:cloud:studio": "bun run --cwd packages/cloud-shared db:studio",
     "db:cloud:pglite": "bun run packages/scripts/cloud/admin/dev/pglite-server.ts",
     "publish:dry-run": "bun packages/scripts/publish-from-dist.mjs",


### PR DESCRIPTION
## Problem

The **Cloud Deploy Backend** workflow's **Run Database Migrations** job fails on every staging/prod backend deploy:

```
error: Cannot find module '@elizaos/core' from '/home/runner/work/eliza/eliza/plugins/plugin-sql/src/index.ts'
error: script "db:cloud:migrate" exited with code 1
```

(verified consistent — the last several completed migration runs on develop all `failure`; surfaced on the [staging deployments](https://github.com/elizaOS/eliza/deployments/staging) page.)

### Root cause

The migration job installs with `bun install --no-save --ignore-scripts` (no build step), then runs `db:cloud:migrate`. That script pulls `@elizaos/cloud-shared/db/client` → `plugin-sql` → `@elizaos/core`. With no build, `@elizaos/core`'s dist is absent, and the migration resolves it via the **default (dist)** condition → module not found. (Locally it works only because the dist happens to be built.)

## Fix

Run the migration with `--conditions=eliza-source` — the repo's established source-mode flag (the `dev`/`dev:ui`/`dev:desktop` scripts all use it). This resolves the entire `cloud-shared → plugin-sql → @elizaos/core` graph from **TypeScript src**, so it needs no build. Since the migrate script spawns its own `bun` process, the flag must live in the script itself (an outer `--conditions` wouldn't propagate).

## Verification

- `bun --conditions=eliza-source .../migrate-with-diagnostics.ts` against an unreachable DB now gets **past all imports** to the DB-connection step (`connect ECONNREFUSED`) — no "Cannot find module" — proving the full graph resolves from src with no build.
- One-line change; resolution-only, no migration-logic change.

Note: the same workflow runs on `main` backend deploys, so this should also land on main (via the normal develop→main promote) to fix production migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)