### PR TITLE
fix(ui): don't attempt the WebSocket for dedicated cloud agents (no /ws → no reconnect churn)

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -98,30 +98,19 @@ describe("ElizaClient websocket connection policy", () => {
     expect(createdUrls[0]).toContain("token=agent-token");
   });
 
-  it("degrades a dedicated cloud agent to connected-over-REST after WS exhaustion (no disconnect overlay)", () => {
-    vi.useFakeTimers();
-    try {
-      const instances = stubWebSocketWithInstances();
-      const client = new ElizaClient(
-        "https://abc123def456.elizacloud.ai",
-        "cloud-token",
-      );
-      client.connectWs();
-      // It DID attempt a websocket (dedicated agents have a usable /ws).
-      expect(instances).toHaveLength(1);
-      // Simulate the socket never staying open through every reconnect attempt.
-      for (let i = 0; i < 15; i++) {
-        instances[instances.length - 1].onclose?.();
-      }
-      const state = client.getConnectionState();
-      expect(state.reconnectAttempt).toBeGreaterThanOrEqual(15);
-      // Instead of "failed" (which drives the full-screen "Lost backend
-      // connection" overlay) it degrades to a non-fatal connected state so REST
-      // chat keeps working and the WS keeps probing in the background.
-      expect(state.state).toBe("connected");
-    } finally {
-      vi.useRealTimers();
-    }
+  it("treats a dedicated cloud agent base as connected without opening a websocket (its /ws is not proxied)", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient(
+      "https://abc123def456.elizacloud.ai",
+      "cloud-token",
+    );
+    client.connectWs();
+    // The dedicated agent's /ws upgrade is NOT proxied by the agent-router (it
+    // 404s), so we don't attempt a websocket at all — no "Reconnecting… (N/15)"
+    // header churn — and report connected-over-REST immediately. (Revisit once
+    // /ws is proxied + advertised via /api/config.)
+    expect(instances).toHaveLength(0);
+    expect(client.getConnectionState().state).toBe("connected");
   });
 
   it("still goes failed for a non-cloud agent base after WS exhaustion (overlay preserved)", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -235,17 +235,20 @@ function shouldTreatAsConnectedWithoutWebSocket(
   return (
     isIosInProcessLocalAgentBase(value) ||
     isLocalAgentIpcBase(value) ||
-    isSharedRuntimeRestAdapterBase(value)
+    isSharedRuntimeRestAdapterBase(value) ||
+    isDedicatedCloudAgentBase(value)
   );
 }
 
 // A dedicated cloud agent lives on its own subdomain (<id>.elizacloud.ai) and
-// serves chat over REST as well as the realtime WS. Unlike the shared-runtime
-// adapter it DOES have a usable `/ws`, so we still attempt the WebSocket — but
-// if it can't connect (cold start, resume window, a slow backend) the agent is
-// still usable over REST. So on WS-reconnect exhaustion we degrade to a
-// non-fatal connected-over-REST state instead of raising the catastrophic
-// full-screen "Lost backend connection" overlay (see connectWs.onclose).
+// serves chat over REST. Its `/ws` upgrade is NOT currently proxied by the
+// agent-router (the upgrade returns 404), so attempting the WebSocket only
+// produced a "Reconnecting… (N/15)" header for ~95s before degrading. Treat
+// these bases like the shared-runtime adapter — connected-over-REST with no WS
+// attempt — so there is no reconnect churn. (The WS-reconnect-exhaustion degrade
+// in connectWs.onclose is kept as a safety net; revisit once the agent-router
+// proxies the `/ws` upgrade and the agent advertises it via /api/config so we
+// can re-enable realtime.)
 function isDedicatedCloudAgentBase(value: string | null | undefined): boolean {
   const normalized = normalizeBaseUrl(value);
   if (!normalized) return false;


### PR DESCRIPTION
## Problem
On a dedicated cloud agent (`<id>.elizacloud.ai`), the chat header shows **"Reconnecting… (N/15)"** for ~95s. The agent serves chat over REST, but its **`/ws` upgrade is not proxied by the agent-router (returns 404)**, so the client opens a socket that can never connect and churns through reconnect attempts. (#8647 already removed the catastrophic "Lost backend connection" overlay on exhaustion, but the reconnect header itself still showed.)

## Fix
Add `isDedicatedCloudAgentBase` to `shouldTreatAsConnectedWithoutWebSocket`, so `connectWs()` returns **connected-over-REST immediately and never opens the socket** for dedicated cloud bases — no reconnect churn, no header. The WS-reconnect-exhaustion degrade in `connectWs.onclose` stays as a safety net for other bases.

Forward-compat: revisit once the agent-router proxies the `/ws` upgrade and the agent advertises it via `/api/config`, so we can re-enable realtime for dedicated agents.

## Verification
Lint + typecheck clean; `client-base-websocket` + `client-cloud-agent-base` tests (19) pass (updated the dedicated test: now asserts no socket is opened + connected immediately, mirroring the shared-runtime adapter).

Refs #8434.