### PR TITLE
fix(app-control): gate desktop-only VIEWS modes off viewless text connectors (#8613)

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -586,6 +586,115 @@ describe("view switching — VIEWS action resolver", () => {
 			expect(ok).toBe(true);
 			expect(owner).not.toHaveBeenCalled();
 		});
+
+		// #8613: on a text connector with no view surface for the asker, a
+		// desktop-only nav/layout op (show/open/close/split/…) is a silent
+		// non-answer if chosen as the terminal action. validate() must drop it so
+		// the turn falls back to a REPLY the connector actually delivers.
+		function sourcedMessage(text: string, source: string) {
+			return {
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: { text, source },
+			};
+		}
+
+		it.each([
+			["discord", { action: "show", view: "wallet" }, "show me my wallet"],
+			["telegram", { action: "open", view: "calendar" }, "open my calendar"],
+			["matrix", { action: "close" }, "close this view"],
+			["slack", { action: "split", view: "wallet" }, "split the wallet view"],
+			["whatsapp", { action: "tile" }, "tile my views"],
+			["x", { action: "manager" }, "show the view manager"],
+		])("gates desktop-only mode off the %s connector (no view surface)", async (source, options, text) => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				{ agentId: "agent-1" } as never,
+				sourcedMessage(text, source) as never,
+				undefined as never,
+				options as never,
+			);
+			expect(ok).toBe(false);
+		});
+
+		it("keeps text-producing read modes available on a text connector", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			for (const options of [
+				{ action: "list" },
+				{ action: "current" },
+				{ action: "search", query: "wallet" },
+			]) {
+				const ok = await action.validate(
+					{ agentId: "agent-1" } as never,
+					sourcedMessage("list my views", "discord") as never,
+					undefined as never,
+					options as never,
+				);
+				expect(ok).toBe(true);
+			}
+		});
+
+		it("keeps capability/content ops (interact) available on a text connector", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				{ agentId: "agent-1" } as never,
+				sourcedMessage("add a calendar event", "discord") as never,
+				undefined as never,
+				{
+					action: "interact",
+					view: "calendar",
+					capability: "create-calendar-event",
+				} as never,
+			);
+			expect(ok).toBe(true);
+		});
+
+		it("still navigates on a local view-capable surface (no source / dashboard)", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			for (const source of [undefined, "chat", "user_chat", "app"]) {
+				const ok = await action.validate(
+					{ agentId: "agent-1" } as never,
+					{
+						entityId: "user-1",
+						roomId: "room-1",
+						agentId: "agent-1",
+						content: { text: "show my wallet", ...(source ? { source } : {}) },
+					} as never,
+					undefined as never,
+					{ action: "show", view: "wallet" } as never,
+				);
+				expect(ok).toBe(true);
+			}
+		});
+
+		it("owner gate still applies to authoring ops on a text connector", async () => {
+			const owner = vi.fn(async () => false);
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: owner,
+			});
+			const ok = await action.validate(
+				{ agentId: "agent-1" } as never,
+				sourcedMessage("delete the wallet plugin", "discord") as never,
+				undefined as never,
+				{ action: "delete", view: "wallet" } as never,
+			);
+			expect(ok).toBe(false);
+			expect(owner).toHaveBeenCalled();
+		});
 	});
 
 	describe("BUG PROBE: developerMode-gated views reachable by ACTIVE command", () => {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -63,6 +63,68 @@ export type ViewsMode =
 	| "split"
 	| "tile";
 
+// Connectors that deliver the agent's turn over an EXTERNAL chat surface which
+// does NOT render Eliza desktop views to the person who sent the message. On
+// these, a VIEWS navigation/layout op (show/open/close/split/…) is invisible to
+// the asker: it only drives the local desktop shell. If VIEWS is then chosen as
+// the turn's terminal action, the chat user gets no reply at all (#8613). We
+// exclude the desktop-only modes from the planner surface for these sources so
+// the turn falls back to a real text REPLY the connector reliably delivers.
+// Text-producing modes (list/current/search), capability/content ops (interact)
+// and owner authoring ops (create/edit/icon/delete) stay available everywhere.
+// Local view-capable surfaces (dashboard / desktop / mobile app chat, identified
+// by sources like "chat"/"user_chat"/"app" or no source) are intentionally NOT
+// listed, so their view-switching UX is unchanged. This is a fail-open denylist:
+// an unknown source keeps today's behavior.
+const VIEWLESS_TEXT_CONNECTOR_SOURCES = new Set([
+	"discord",
+	"telegram",
+	"matrix",
+	"slack",
+	"signal",
+	"whatsapp",
+	"twitter",
+	"x",
+	"instagram",
+	"imessage",
+	"bluebubbles",
+	"line",
+	"wechat",
+	"nostr",
+	"feishu",
+	"google-chat",
+	"farcaster",
+]);
+
+// VIEWS modes whose ONLY effect is a desktop UI navigation/layout change with no
+// inherent text answer. Invisible (and so a silent non-answer) on a connector
+// that can't surface views to the asker — see VIEWLESS_TEXT_CONNECTOR_SOURCES.
+const DESKTOP_ONLY_VIEW_MODES = new Set<ViewsMode>([
+	"show",
+	"open",
+	"close",
+	"manager",
+	"broadcast",
+	"pin",
+	"window",
+	"split",
+	"tile",
+]);
+
+/**
+ * True when the incoming message arrived over an external text connector that
+ * has no Eliza view surface for the user who sent it. Used to keep desktop-only
+ * VIEWS modes off the planner surface so a text-connector turn never resolves to
+ * a silent view navigation with no chat reply (#8613).
+ */
+export function messageHasNoViewSurface(message: Memory): boolean {
+	const source =
+		typeof message.content?.source === "string"
+			? message.content.source.toLowerCase()
+			: "";
+	return VIEWLESS_TEXT_CONNECTOR_SOURCES.has(source);
+}
+
 const MODES: readonly ViewsMode[] = [
 	"list",
 	"current",
@@ -2085,6 +2147,19 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				mode === "remove"
 			) {
 				return ownerCheck(runtime, message);
+			}
+
+			// Desktop-only navigation/layout ops are invisible on a text connector
+			// that can't render views for the asker. Offering them there lets the
+			// planner pick VIEWS as a silent terminal action (no chat reply) — drop
+			// them so the turn falls back to a real REPLY. Text/content modes stay
+			// available everywhere. (#8613)
+			if (
+				mode &&
+				DESKTOP_ONLY_VIEW_MODES.has(mode) &&
+				messageHasNoViewSurface(message)
+			) {
+				return false;
 			}
 
 			// Read modes are visible to all users.


### PR DESCRIPTION
## Summary

Fixes #8613 — on a text connector (Discord / Matrix / Telegram / …), the planner could route a user turn to a desktop-only `VIEWS` navigation/layout op (`show`/`open`/`close`/`split`/`tile`/`pin`/`window`/`manager`/`broadcast`). Those ops only drive the local desktop shell, and `VIEWS` owns the turn (`suppressPostActionContinuation`), so the chat user received **no reply at all** — a silent non-answer the runtime still recorded as `verifiedUserFacing`.

Root cause (as filed): `VIEWS.validate()` returned `true` unconditionally for every read/nav mode, with no check for whether the connector can surface views to the asker.

## Fix (issue's Approach 3 — connector-capability tiering)

`plugins/plugin-app-control/src/actions/views.ts`:
- Add `VIEWLESS_TEXT_CONNECTOR_SOURCES` — a **fail-open denylist** of external chat connectors that have no view surface for the sender (`discord`, `telegram`, `matrix`, `slack`, `signal`, `whatsapp`, `twitter`/`x`, `instagram`, `imessage`, `bluebubbles`, `line`, `wechat`, `nostr`, `feishu`, `google-chat`, `farcaster`).
- Add `DESKTOP_ONLY_VIEW_MODES` — the modes whose only effect is a desktop UI nav/layout change with no inherent text answer.
- In `validate()`: when the inferred mode is desktop-only **and** the message arrived over a viewless connector, return `false` so the turn falls back to a real `REPLY` the connector reliably delivers.

**Preserved behavior:**
- Text-producing modes (`list`/`current`/`search`), capability/content ops (`interact`), and owner authoring ops (`create`/`edit`/`icon`/`delete`) stay available **everywhere**.
- Local view-capable surfaces (dashboard / desktop / mobile app chat — sources like `chat`/`user_chat`/`app`, or no source) are **not** listed, so their view-switching UX is unchanged. The denylist is fail-open: an unknown source keeps today's behavior.

This is the most behavior-preserving of the three options the issue offered that can land without re-architecting the planner's turn-ownership: it keeps view-switching wherever a surface plausibly exists and guarantees the chat user always gets an answer on a pure text connector.

## Tests

`views-switching.test.ts` — new `validate() gating` cases:
- desktop-only modes (`show`/`open`/`close`/`split`/`tile`/`manager`) gated off discord/telegram/matrix/slack/whatsapp/x → `false`
- `list`/`current`/`search` still allowed on a text connector → `true`
- `interact` (capability/content op) still allowed on a text connector → `true`
- `show` still allowed on local view-capable surfaces (no source / `chat` / `user_chat` / `app`) → `true`
- owner gate still applies to authoring ops on a text connector

## Verification

- `bun run --cwd plugins/plugin-app-control test` → **321 passed**
- `bun run --cwd plugins/plugin-app-control typecheck` → clean
- `biome check` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
