### PR TITLE
fix(cloud-billing): atomic credit-balance decrement in container daily billing (#8342)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/container-billing.ts
+++ b/packages/cloud-shared/src/db/repositories/container-billing.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lte, or } from "drizzle-orm";
+import { and, eq, inArray, isNull, lte, or, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { containerBillingRecords, containers } from "../schemas/containers";
 import { creditTransactions } from "../schemas/credit-transactions";
@@ -192,13 +192,25 @@ export class ContainerBillingRepository {
         };
       }
 
-      await tx
+      // Atomic relative decrement — NOT an absolute write of a JS-computed
+      // newBalance derived from a stale read. The net credit-balance movement
+      // is -fromCredits (= dailyCost - fromEarnings; the earnings portion is
+      // debited from the redeemable-earnings ledger separately and never
+      // touches credit_balance), identical to the old
+      // `currentBalance + fromEarnings - dailyCost`. Decrementing the LIVE
+      // column instead of overwriting it with a stale-derived absolute means a
+      // concurrent inference debit / top-up that lands between the caller's
+      // balance read and this commit is no longer lost. The `credit_balance >= 0`
+      // check constraint backstops a concurrent-overdraft race; the per-container
+      // billing loop isolates the resulting error and retries next run.
+      const [updatedOrg] = await tx
         .update(organizations)
         .set({
-          credit_balance: String(input.newBalance),
+          credit_balance: sql`${organizations.credit_balance} - ${String(input.fromCredits)}`,
           updated_at: input.now,
         })
-        .where(eq(organizations.id, input.organizationId));
+        .where(eq(organizations.id, input.organizationId))
+        .returning({ credit_balance: organizations.credit_balance });
 
       // Record only the credit-balance movement (fromCredits). The earnings
       // portion is debited from the redeemable-earnings ledger via
@@ -249,7 +261,11 @@ export class ContainerBillingRepository {
         created_at: input.now,
       });
 
-      return { newBalance: input.newBalance, transactionId: creditTx.id, alreadyBilled: false };
+      return {
+        newBalance: updatedOrg ? Number(updatedOrg.credit_balance) : input.newBalance,
+        transactionId: creditTx.id,
+        alreadyBilled: false,
+      };
     });
   }
 }

--- a/packages/cloud-shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -302,4 +302,60 @@ describe("container billing gate + row-lock guard", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "atomic decrement preserves a concurrent debit that lands after the caller's read (no lost update)",
+    async () => {
+      if (!pgliteReady) return;
+      await dbWrite.execute(`DELETE FROM container_billing_records;`);
+      await dbWrite.execute(`DELETE FROM credit_transactions;`);
+      await dbWrite.execute(`DELETE FROM containers;`);
+      await dbWrite.execute(`DELETE FROM organizations;`);
+      await dbWrite.execute(
+        `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '50');`,
+      );
+      await dbWrite.execute(
+        `INSERT INTO containers (id, name, project_name, organization_id, user_id, status, billing_status, total_billed)
+         VALUES ('${CONTAINER_ID}', 'web', 'proj', '${ORG_ID}', '${USER_ID}', 'running', 'active', '0');`,
+      );
+
+      const now = new Date("2026-06-07T14:30:00.000Z");
+      const { periodStart, periodEnd } = computeContainerBillingPeriod(now);
+
+      // The cron read credit_balance=$50 and computed newBalance=$49.33 for a
+      // $0.67 charge. THEN a concurrent inference debit of $10 lands before the
+      // billing write commits — dropping the LIVE balance to $40.
+      await dbWrite.execute(
+        `UPDATE organizations SET credit_balance = credit_balance - 10 WHERE id = '${ORG_ID}';`,
+      );
+
+      const result = await containerBillingRepository.recordSuccessfulDailyBilling({
+        containerId: CONTAINER_ID,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        containerName: "web",
+        currentTotalBilled: "0",
+        dailyCost: 0.67,
+        newBalance: 49.33, // STALE: derived from the pre-debit read of $50.
+        fromEarnings: 0,
+        fromCredits: 0.67,
+        now,
+        billingPeriodStart: periodStart,
+        billingPeriodEnd: periodEnd,
+      });
+
+      // An absolute write of the stale newBalance would clobber to $49.33,
+      // silently erasing the $10 concurrent debit. The atomic relative
+      // decrement instead lands at 40 - 0.67 = $39.33 and returns the live value.
+      const org = await dbWrite.execute(
+        `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect(Number((org.rows[0] as { credit_balance: string }).credit_balance)).toBeCloseTo(
+        39.33,
+        6,
+      );
+      expect(result.newBalance).toBeCloseTo(39.33, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
 });


### PR DESCRIPTION
## Summary

Addresses the **[2AM] non-atomic daily debit** correctness item in #8342.

`recordSuccessfulDailyBilling` wrote an **absolute** `credit_balance` value computed in JS from a balance the caller read earlier (`newBalance = currentBalance + fromEarnings - dailyCost`). A concurrent inference debit or top-up landing between that read and this commit was **silently lost** — the absolute write clobbered it.

## Fix

Replace the absolute write with an **atomic relative decrement** against the live column and return the actual post-decrement balance:

```ts
const [updatedOrg] = await tx
  .update(organizations)
  .set({ credit_balance: sql`${organizations.credit_balance} - ${String(input.fromCredits)}`, updated_at: input.now })
  .where(eq(organizations.id, input.organizationId))
  .returning({ credit_balance: organizations.credit_balance });
```

- **No billing-semantics change.** The net movement is identical: `-fromCredits = dailyCost - fromEarnings`. The earnings portion is debited from the redeemable-earnings ledger separately (`convertToCredits`) and never touches `credit_balance` (verified), so `-fromCredits` is exactly what the old absolute write applied — just done against the live value instead of a stale read.
- **Overdraft race** is backstopped by the existing `credit_balance >= 0` check constraint; the per-container billing loop already isolates and retries such errors (`route.ts` lines 466–512).
- Mirrors the proven idiom already used in `agent-billing.ts`.

## Test

Adds a DB-backed (in-process PGlite, real SQL) regression to `container-billing-idempotency.test.ts`: seed `$50`, simulate a concurrent `$10` inference debit landing **after** the caller's read, then bill `$0.67` with the stale `newBalance=49.33`. An absolute write would clobber to `49.33` (erasing the `$10` debit); the atomic decrement correctly lands at `40 - 0.67 = 39.33`.

## Verification

- `bun test container-billing-idempotency.test.ts` → **7 pass / 0 fail**
- `cloud-shared typecheck` → clean (no errors in changed files)
- `biome check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
