### PR TITLE
test(cloud-shared): run tests with --isolate to stop cross-file mock leaks

### DIFF
--- a/packages/cloud-shared/package.json
+++ b/packages/cloud-shared/package.json
@@ -20,7 +20,7 @@
     "lint": "bunx @biomejs/biome check .",
     "lint:fix": "bunx @biomejs/biome check --write .",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",
     "db:check-migrations": "drizzle-kit check",


### PR DESCRIPTION
The test-cloud-shared lane (Windows CI + the cloud-shared portion of ci) fails ~25 env/mock-driven tests order-dependently — every one passes in isolation. Root cause: bun's mock.module + process.env mutations are process-global and leak across the ~120 single-process test files. --isolate runs each file in its own registry (the flag test-cloud-run.mjs already uses): 25 fail → 0 fail (1117 pass / 120 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)