### PR TITLE
test(cloud-shared): run tests with --isolate to stop cross-file mock leaks

### DIFF
--- a/packages/cloud-shared/package.json
+++ b/packages/cloud-shared/package.json
@@ -20,7 +20,7 @@
     "lint": "bunx @biomejs/biome check .",
     "lint:fix": "bunx @biomejs/biome check --write .",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",
     "db:check-migrations": "drizzle-kit check",


### PR DESCRIPTION
Forward-port of the develop isolate fix. 25 order-dependent mock-leak failures → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)