### PR TITLE
feat(agent): LEAN_CHAT_PLUGINS preset for dedicated chat agents (#8434)

### DIFF
--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -127,6 +127,43 @@ export const CORE_PLUGINS: readonly string[] = [
 ];
 
 /**
+ * Minimal plugin set for a dedicated, chat-only cloud agent (#8434). A dedicated
+ * agent boots a full local AgentRuntime inside its container; the default
+ * CORE_PLUGINS set carries heavy coding/automation surfaces (shell, coding-tools,
+ * browser, the orchestrator, gitpathologist) that a purely conversational agent
+ * never uses and that dominate its cold-boot time. Opt in per agent by setting
+ * `ELIZA_PLUGIN_SET=lean-chat` in the container environment.
+ *
+ * Browser is intentionally excluded — it stays OFF for lean chat until the
+ * browser surface is production-ready. This set is for dedicated agents only;
+ * cloud-PROXIED (shared-runtime) agents boot zero plugins by construction.
+ */
+export const LEAN_CHAT_PLUGINS: readonly string[] = [
+  "@elizaos/plugin-sql", // database adapter — required
+  "@elizaos/plugin-local-inference", // text + embeddings + voice — required for memory + generation
+  "@elizaos/plugin-companion", // VRM companion emotes for the app chat surface
+  "@elizaos/plugin-app-control", // VIEWS navigation in the app chat surface
+  "@elizaos/plugin-device-filesystem", // mobile-safe FILE target
+  "@elizaos/plugin-agent-skills", // skill execution + enabled-skills provider
+  "@elizaos/plugin-commands", // slash commands
+];
+
+/**
+ * Heavy surfaces force-excluded under `ELIZA_PLUGIN_SET=lean-chat` even when some
+ * other gate would otherwise add them (ELIZA_AGENT_ORCHESTRATOR, gitpathologist
+ * .git auto-detect, config allow-lists). Guarantees a lean chat agent stays lean.
+ * Browser is listed per the "browser disabled until ready" decision.
+ */
+export const LEAN_CHAT_EXCLUDED_PLUGINS: readonly string[] = [
+  "@elizaos/plugin-shell",
+  "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-browser",
+  "agent-orchestrator",
+  "@elizaos/plugin-agent-orchestrator",
+  "@elizaos/plugin-gitpathologist",
+];
+
+/**
  * Core plugins that must be imported and registered before the runtime can be
  * considered ready. Keep this list intentionally small: everything else in
  * CORE_PLUGINS should load in the deferred phase so slow feature/provider

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -250,6 +250,7 @@ import {
   BLOCKING_CORE_PLUGINS,
   CORE_PLUGINS,
   DEFERRED_CORE_PLUGINS,
+  LEAN_CHAT_PLUGINS,
   OPTIONAL_CORE_PLUGINS,
 } from "./core-plugins.ts";
 import { seedBundledDocuments } from "./default-documents.ts";
@@ -1555,6 +1556,7 @@ export {
   BLOCKING_CORE_PLUGINS,
   CORE_PLUGINS,
   DEFERRED_CORE_PLUGINS,
+  LEAN_CHAT_PLUGINS,
   OPTIONAL_CORE_PLUGINS,
 };
 

--- a/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-lean-chat.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { collectPluginNames } from "./plugin-collector.ts";
+
+// Lean chat (ELIZA_PLUGIN_SET=lean-chat) is for dedicated, off-mobile cloud
+// chat agents: it seeds the minimal LEAN_CHAT_PLUGINS set and force-drops the
+// heavy coding/automation surfaces (#8434). Browser stays off until ready.
+const ENV_KEYS = [
+  "ELIZA_PLATFORM",
+  "ELIZA_PLUGIN_SET",
+  "ELIZA_AGENT_ORCHESTRATOR",
+  "ELIZA_LOCAL_LLAMA",
+  "ELIZA_BUILD_VARIANT",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+const emptyConfig: ElizaConfig = {} as ElizaConfig;
+
+const HEAVY = [
+  "@elizaos/plugin-shell",
+  "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-browser",
+  "agent-orchestrator",
+  "@elizaos/plugin-agent-orchestrator",
+  "@elizaos/plugin-gitpathologist",
+];
+
+describe("collectPluginNames lean-chat plugin set (#8434)", () => {
+  it("seeds the lean chat set and excludes heavy/coding/browser surfaces", () => {
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    const names = collectPluginNames(emptyConfig);
+
+    // Lean chat keeps the conversational essentials.
+    expect(names.has("@elizaos/plugin-sql")).toBe(true);
+    expect(names.has("@elizaos/plugin-app-control")).toBe(true);
+    expect(names.has("@elizaos/plugin-commands")).toBe(true);
+    expect(names.has("@elizaos/plugin-agent-skills")).toBe(true);
+
+    // ...and drops every heavy surface, including browser (off until ready).
+    for (const heavy of HEAVY) {
+      expect(names.has(heavy)).toBe(false);
+    }
+  });
+
+  it("force-excludes the orchestrator even when ELIZA_AGENT_ORCHESTRATOR=1", () => {
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    process.env.ELIZA_AGENT_ORCHESTRATOR = "1";
+    const names = collectPluginNames(emptyConfig);
+    expect(names.has("agent-orchestrator")).toBe(false);
+    expect(names.has("@elizaos/plugin-agent-orchestrator")).toBe(false);
+  });
+
+  it("force-excludes heavy plugins even when a config allow-list requests them", () => {
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    const config: ElizaConfig = {
+      plugins: {
+        allow: ["shell", "coding-tools", "browser"],
+        entries: {
+          shell: { enabled: true },
+          "coding-tools": { enabled: true },
+          browser: { enabled: true },
+        },
+      },
+      features: { shell: true, codingTools: true, browser: true },
+    } as ElizaConfig;
+    const names = collectPluginNames(config);
+    expect(names.has("@elizaos/plugin-shell")).toBe(false);
+    expect(names.has("@elizaos/plugin-coding-tools")).toBe(false);
+    expect(names.has("@elizaos/plugin-browser")).toBe(false);
+  });
+
+  it("leaves the default (non-lean) desktop set carrying the full surfaces", () => {
+    // No ELIZA_PLUGIN_SET → default CORE_PLUGINS seed on desktop.
+    const names = collectPluginNames(emptyConfig);
+    expect(names.has("@elizaos/plugin-shell")).toBe(true);
+    expect(names.has("@elizaos/plugin-coding-tools")).toBe(true);
+    expect(names.has("@elizaos/plugin-browser")).toBe(true);
+  });
+});

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -29,6 +29,8 @@ import {
   CORE_PLUGINS,
   ELIZAOS_ANDROID_CORE_PLUGINS,
   ELIZAOS_ANDROID_TERMINAL_PLUGINS,
+  LEAN_CHAT_EXCLUDED_PLUGINS,
+  LEAN_CHAT_PLUGINS,
   MOBILE_CORE_PLUGINS,
   MOBILE_VIEW_PLUGINS,
   OPTIONAL_CORE_PLUGINS,
@@ -419,13 +421,30 @@ export function collectPluginNames(
   // unavailable in the app sandbox. Substitute the curated mobile-safe set.
   const onMobile = isMobilePlatform();
   const onElizaOsAndroid = isElizaOsAndroidRuntime();
-  const seedCorePlugins = onMobile ? MOBILE_CORE_PLUGINS : CORE_PLUGINS;
+  // Dedicated chat-only cloud agents opt into a lean plugin set (no shell/
+  // coding-tools/browser/orchestrator) to cut cold-boot time (#8434). Mobile keeps
+  // its own curated set; lean-chat only applies off-mobile.
+  const leanChat =
+    !onMobile &&
+    process.env.ELIZA_PLUGIN_SET?.trim().toLowerCase() === "lean-chat";
+  const seedCorePlugins = onMobile
+    ? MOBILE_CORE_PLUGINS
+    : leanChat
+      ? LEAN_CHAT_PLUGINS
+      : CORE_PLUGINS;
   const pluginsToLoad = new Set<string>(seedCorePlugins);
   const track = (name: string, reason: string) => {
     if (reasons && !reasons.has(name)) reasons.set(name, reason);
   };
   for (const core of seedCorePlugins) {
-    track(core, onMobile ? "MOBILE_CORE_PLUGINS" : "CORE_PLUGINS");
+    track(
+      core,
+      leanChat
+        ? "LEAN_CHAT_PLUGINS"
+        : onMobile
+          ? "MOBILE_CORE_PLUGINS"
+          : "CORE_PLUGINS",
+    );
   }
   // View-providing plugins register their /api/views entries on every platform
   // so their home tiles resolve (the orchestrator/inbox tiles dead-ended on
@@ -704,6 +723,15 @@ export function collectPluginNames(
       if (!mobileAllowed.has(pluginName)) {
         pluginsToLoad.delete(pluginName);
       }
+    }
+  }
+
+  // Lean chat: force-drop heavy surfaces even if a later gate (orchestrator env,
+  // gitpathologist .git auto-detect, config allow-list) added them, so a
+  // lean-chat agent is guaranteed minimal. (#8434)
+  if (leanChat) {
+    for (const name of LEAN_CHAT_EXCLUDED_PLUGINS) {
+      pluginsToLoad.delete(name);
     }
   }
 


### PR DESCRIPTION
## Summary
Part of #8434 — dedicated cloud agents boot a full local AgentRuntime loading ~15 CORE_PLUGINS (shell, coding-tools, browser, orchestrator, gitpathologist), which dominates cold-boot time for a purely conversational agent.

Adds **LEAN_CHAT_PLUGINS** (sql, local-inference, companion, app-control, device-filesystem, agent-skills, commands) selected via `ELIZA_PLUGIN_SET=lean-chat` (off-mobile only), plus a final exclusion pass that force-drops shell/coding-tools/**browser**/orchestrator/gitpathologist even if a later gate would add them. **Browser stays off until ready** per product decision.

The provisioning trigger (set `ELIZA_PLUGIN_SET=lean-chat` for managed chat agents) lands in the companion cloud-shared change. Cloud-proxied (shared-runtime) agents boot zero plugins by construction and are unaffected.

## Tests
`plugin-collector-lean-chat.test.ts` — 4 cases: lean seed + heavy/browser exclusion; orchestrator force-excluded even with `ELIZA_AGENT_ORCHESTRATOR=1`; config allow-list can't re-add heavy plugins; default (non-lean) desktop still carries the full set. **4 pass.** Typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)