### PR TITLE
fix(cloud-frontend): gate deploys on crypto-chunk safety (stop recurring blank-page crash)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -258,6 +258,14 @@ jobs:
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
+      # Gate: refuse to deploy a bundle where Rolldown folded the bn.js/crypto
+      # graph into an eager chunk — that ships the "Class constructor cannot be
+      # invoked without 'new'" Buffer.allocUnsafe crash that blanks every route.
+      # This regression has reached prod multiple times; fail the deploy instead.
+      - name: Verify bundle chunk safety
+        working-directory: packages/cloud-frontend
+        run: node scripts/verify-chunk-safety.mjs
+
       - name: Resolve Pages branch
         id: pages
         env:

--- a/packages/cloud-frontend/package.json
+++ b/packages/cloud-frontend/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "bun --bun vite",
-    "build": "bun --bun vite build && bun run build:ssr && bun run prerender",
-    "build:client": "bun --bun vite build",
+    "build": "bun --bun vite build && node scripts/verify-chunk-safety.mjs && bun run build:ssr && bun run prerender",
+    "build:client": "bun --bun vite build && node scripts/verify-chunk-safety.mjs",
+    "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "build:ssr": "bun --bun vite build --ssr src/entry-server.tsx --outDir dist-ssr",
     "prerender": "node scripts/prerender.mjs",
     "preview": "bun --bun vite preview --port 3000 --strictPort",

--- a/packages/cloud-frontend/scripts/verify-chunk-safety.mjs
+++ b/packages/cloud-frontend/scripts/verify-chunk-safety.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Build-time gate against the recurring Rolldown crypto-chunk crash
+// ("Class constructor u cannot be invoked without 'new'" at Buffer.allocUnsafe).
+//
+// Root cause (see the vendor-crypto codeSplitting group in vite.config.ts):
+// Rolldown can non-deterministically fold the bn.js / crypto graph into an
+// EAGERLY-initialized chunk (the i18n locale chunk or the entry). bn.js runs
+// `Buffer.allocUnsafe` at module-init, which throws before the bundled Buffer
+// wrapper is ready and kills the whole React tree on every route. The fix keeps
+// that graph in a dedicated LAZY `vendor-crypto` chunk — but the fix has been
+// silently dropped twice (history squashes) and a bad build shipped to prod.
+//
+// This gate fails the build whenever the bn.js marker (`toArrayLike`) lands in
+// any chunk that is NOT one of the intended lazy `vendor-*` vendor chunks, so a
+// regressed bundle can never deploy. Run after `vite build`, before deploy.
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const distAssets = path.join(process.cwd(), "dist", "assets");
+
+// bn.js's `toArrayLike` is the method that calls `Buffer.allocUnsafe` at
+// module-init; its presence marks the crypto/big-number graph.
+const CRYPTO_MARKER = "toArrayLike";
+
+// The crypto graph is allowed to live ONLY in these lazily-loaded vendor
+// chunks (loaded on demand by wallet/crypto routes), never in the eager entry
+// or locale chunks.
+const ALLOWED = /^vendor-(crypto|solana|wallet)-/;
+
+let files;
+try {
+  files = readdirSync(distAssets).filter((f) => f.endsWith(".js"));
+} catch (err) {
+  console.error(
+    `[verify-chunk-safety] cannot read ${distAssets}: ${err.message}`,
+  );
+  process.exit(2);
+}
+
+const offenders = [];
+let cryptoChunkSeen = false;
+for (const file of files) {
+  const hasMarker = readFileSync(path.join(distAssets, file), "utf8").includes(
+    CRYPTO_MARKER,
+  );
+  if (!hasMarker) continue;
+  if (ALLOWED.test(file)) {
+    cryptoChunkSeen = true;
+  } else {
+    offenders.push(file);
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    "[verify-chunk-safety] FAIL: the bn.js/crypto graph leaked into eager chunk(s):",
+  );
+  for (const f of offenders) console.error(`  - ${f}`);
+  console.error(
+    "\nThis is the Rolldown crypto-chunk crash (Buffer.allocUnsafe at module-init).\n" +
+      "The `vendor-crypto` codeSplitting group in vite.config.ts must keep the\n" +
+      "bn.js graph in a lazy vendor chunk. Do NOT deploy this bundle — it crashes\n" +
+      "the whole React tree on every route. Re-check the codeSplitting groups.",
+  );
+  process.exit(1);
+}
+
+if (!cryptoChunkSeen) {
+  console.warn(
+    "[verify-chunk-safety] note: no crypto graph found in any chunk (unexpected " +
+      "but not a crash risk) — passing.",
+  );
+}
+
+console.log(
+  `[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (${files.length} chunks scanned).`,
+);


### PR DESCRIPTION
## Problem

`elizacloud.ai` keeps going fully blank — **"Something went wrong / Class constructor u cannot be invoked without 'new'"** on every route. Root cause (documented in prior PRs #8682/#8687): Rolldown folds the **bn.js / crypto graph** into an **eagerly-initialized** chunk, where `Buffer.allocUnsafe` runs at module-init and crashes the whole React tree. The `vendor-crypto` codeSplitting group prevents it — **but the fix has been silently dropped by history squashes twice, and a regressed bundle shipped to prod each time** with nothing catching it.

## Fix — a deploy gate

`scripts/verify-chunk-safety.mjs` scans the built `dist/assets` and **fails the build** if the bn.js marker (`toArrayLike`) appears in any chunk that is *not* a lazy `vendor-*` chunk (i.e. it leaked into the eager entry/locale chunk).

- Wired into `build` and `build:client` (so every build is gated), plus a `verify:chunks` script.
- Added an explicit **"Verify bundle chunk safety"** step in `cloud-cf-deploy.yml`, right before the `wrangler pages deploy`, so a bad bundle **fails the deploy instead of blanking prod**.

## Verification

- Gate **passes** the current good build (`bn.js/crypto graph is confined to lazy vendor chunks, 107 chunks scanned`).
- Gate **fails (exit 1)** a simulated bad dist (crypto marker injected into an `index-*` chunk).
- Wired into `build:client` and confirmed it runs + passes on a real build; `cloud-cf-deploy.yml` YAML validated; biome-formatted.

Not a UI change — no `audit:cloud` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)