### PR TITLE
fix(facewear): update completion gate for register.ts app-shell refactor

### DIFF
--- a/scripts/check-smartglasses-completion-gate.mjs
+++ b/scripts/check-smartglasses-completion-gate.mjs
@@ -356,7 +356,7 @@ function softwareGateFailures() {
     ...sourceTokenFailures("plugins/plugin-facewear/src/register.ts", [
       'id: "smartglasses"',
       'path: "/apps/smartglasses"',
-      "Component: SmartglassesView",
+      "loadSmartglassesView",
       "@elizaos/plugin-facewear",
     ]),
   );


### PR DESCRIPTION
`check-smartglasses-completion-gate.mjs --self-test` regressed on develop after `register.ts` was refactored to the `registerAppShellPage({...})` API. The `SmartglassesView` is still fully registered (`export const SmartglassesView = deferredComponent(loadSmartglassesView)` + `registerAppShellPage({ id: "smartglasses", loader: loadSmartglassesView })`), but the old literal `"Component: SmartglassesView"` token is gone.

Updates the assertion to `"loadSmartglassesView"` (the loader wired into the smartglasses page). Self-test → `{ "ok": true, "software": true }`. Only the gate script changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)