### PR TITLE
feat(cloud): round-robin across multiple Cerebras keys to spread rate limits

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -14,7 +14,7 @@ import {
 import { logger } from "../utils/logger";
 import { RETRYABLE_UPSTREAM_STATUSES } from "./failover";
 import { stripOpenRouterRoutingSuffix, toBitRouterModelId } from "./model-id-translation";
-import { getProviderKey } from "./provider-env";
+import { getProviderKey, getProviderKeys } from "./provider-env";
 import { hasAnyVastProviderConfigured, resolveVastEndpointConfig } from "./vast-endpoints";
 
 let groqClient: ReturnType<typeof createOpenAI> | null = null;
@@ -24,7 +24,10 @@ let openAIClient: {
   baseURL?: string;
   client: ReturnType<typeof createOpenAI>;
 } | null = null;
-let cerebrasClient: ReturnType<typeof createOpenAI> | null = null;
+// Cerebras: one cached client PER key so we can round-robin across multiple
+// keys to spread rate-limit headroom (the dedicated-agent 429 latency fix).
+let cerebrasClientsByKey: Map<string, ReturnType<typeof createOpenAI>> | null = null;
+let cerebrasRoundRobin = 0;
 let bitRouterClient: ReturnType<typeof createOpenAI> | null = null;
 let openRouterClient: ReturnType<typeof createOpenAI> | null = null;
 let anthropicClient: ReturnType<typeof createAnthropic> | null = null;
@@ -86,19 +89,39 @@ function getOpenAIClient() {
 }
 
 function getCerebrasClient() {
-  if (!cerebrasClient) {
-    const apiKey = getProviderKey("CEREBRAS_API_KEY");
-    if (!apiKey) {
-      throw new Error("CEREBRAS_API_KEY environment variable is required");
-    }
+  // Gather every configured Cerebras key (CEREBRAS_API_KEY, CEREBRAS_API_KEYS
+  // list, CEREBRAS_API_KEY_2..). Each key gets its own cached client; we
+  // round-robin per call so concurrent dedicated-agent traffic spreads across
+  // keys instead of hammering one and hitting 429 -> retry -> 26-55s latency.
+  const keys = getProviderKeys("CEREBRAS_API_KEY");
+  if (keys.length === 0) {
+    throw new Error("CEREBRAS_API_KEY environment variable is required");
+  }
 
-    cerebrasClient = createOpenAI({
+  if (!cerebrasClientsByKey) {
+    cerebrasClientsByKey = new Map();
+  }
+  // Drop any cached clients whose key is no longer configured.
+  for (const cachedKey of cerebrasClientsByKey.keys()) {
+    if (!keys.includes(cachedKey)) {
+      cerebrasClientsByKey.delete(cachedKey);
+    }
+  }
+
+  // Round-robin selection (stable, wraps on key count).
+  const apiKey = keys[cerebrasRoundRobin % keys.length];
+  cerebrasRoundRobin = (cerebrasRoundRobin + 1) % keys.length;
+
+  let client = cerebrasClientsByKey.get(apiKey);
+  if (!client) {
+    client = createOpenAI({
       apiKey,
       baseURL: "https://api.cerebras.ai/v1",
     });
+    cerebrasClientsByKey.set(apiKey, client);
   }
 
-  return cerebrasClient;
+  return client;
 }
 
 function getBitRouterApiKey(): string | null {

--- a/packages/cloud-shared/src/lib/providers/provider-env.ts
+++ b/packages/cloud-shared/src/lib/providers/provider-env.ts
@@ -27,3 +27,44 @@ export function getRequiredProviderKey(envName: string): string {
 
   return apiKey;
 }
+
+/**
+ * Collect ALL configured keys for a provider so callers can rotate across them
+ * to spread rate-limit headroom (e.g. multiple Cerebras keys).
+ *
+ * Sources, merged + de-duped in this order:
+ *   1. `${base}S` as a comma/whitespace-separated list (e.g. `CEREBRAS_API_KEYS`)
+ *   2. the singular `${base}` (e.g. `CEREBRAS_API_KEY`)
+ *   3. numbered suffixes `${base}_2`, `${base}_3`, ... up to a small cap
+ *
+ * Placeholder values are filtered out (same rule as getProviderKey). Returns an
+ * empty array when nothing is configured.
+ */
+export function getProviderKeys(envName: string): string[] {
+  const env = getCloudAwareEnv();
+  const keys: string[] = [];
+  const seen = new Set<string>();
+
+  const push = (raw: string | undefined) => {
+    const value = raw?.trim();
+    if (!value || isPlaceholderProviderKey(value) || seen.has(value)) return;
+    seen.add(value);
+    keys.push(value);
+  };
+
+  // 1. plural list env (CEREBRAS_API_KEYS="k1,k2 k3")
+  const listRaw = env[`${envName}S`]?.trim();
+  if (listRaw) {
+    for (const part of listRaw.split(/[\s,]+/)) push(part);
+  }
+
+  // 2. singular
+  push(env[envName]);
+
+  // 3. numbered suffixes
+  for (let i = 2; i <= 16; i++) {
+    push(env[`${envName}_${i}`]);
+  }
+
+  return keys;
+}

--- a/packages/cloud-shared/src/lib/providers/provider-keys.test.ts
+++ b/packages/cloud-shared/src/lib/providers/provider-keys.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { getProviderKeys } from "./provider-env";
+
+// Snapshot + restore the env keys this suite mutates so it can't leak.
+const TOUCHED = [
+  "CEREBRAS_API_KEY",
+  "CEREBRAS_API_KEYS",
+  "CEREBRAS_API_KEY_2",
+  "CEREBRAS_API_KEY_3",
+];
+
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = {};
+  for (const k of TOUCHED) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of TOUCHED) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("getProviderKeys (multi-key provider rotation)", () => {
+  test("returns empty when nothing configured", () => {
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual([]);
+  });
+
+  test("returns the singular key when only it is set", () => {
+    process.env.CEREBRAS_API_KEY = "k-single";
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual(["k-single"]);
+  });
+
+  test("parses a comma/whitespace list from the plural env", () => {
+    process.env.CEREBRAS_API_KEYS = "k1, k2  k3,k4";
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual(["k1", "k2", "k3", "k4"]);
+  });
+
+  test("merges plural list + singular + numbered suffixes, de-duped, in order", () => {
+    process.env.CEREBRAS_API_KEYS = "k1,k2";
+    process.env.CEREBRAS_API_KEY = "k3";
+    process.env.CEREBRAS_API_KEY_2 = "k4";
+    process.env.CEREBRAS_API_KEY_3 = "k2"; // dup of list -> dropped
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual(["k1", "k2", "k3", "k4"]);
+  });
+
+  test("filters placeholder + empty values", () => {
+    process.env.CEREBRAS_API_KEYS = "your_cerebras_key, , real-key,  ";
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual(["real-key"]);
+  });
+
+  test("de-dupes identical keys across sources", () => {
+    process.env.CEREBRAS_API_KEY = "same";
+    process.env.CEREBRAS_API_KEY_2 = "same";
+    expect(getProviderKeys("CEREBRAS_API_KEY")).toEqual(["same"]);
+  });
+});


### PR DESCRIPTION
## Why
Dedicated agents hit Cerebras **429s → 3 retries → 26-55s reply latency** — the launch-blocking dedicated-chat slowness (#8434). Root cause: a single `CEREBRAS_API_KEY` cached as one client, so all concurrent agent traffic saturates one key's rate limit.

This is the **(b) multiple cerebras keys + load-balancing** lever from the latency thread — in-code, no infra change required beyond adding keys.

## What
- **`getProviderKeys(envName)`** — collects every configured key for a provider: a plural `CEREBRAS_API_KEYS` comma/space list + the singular `CEREBRAS_API_KEY` + numbered `CEREBRAS_API_KEY_2..` suffixes, de-duped, placeholders filtered.
- **`getCerebrasClient()`** now caches one client **per key** and **round-robins per call**, so concurrent dedicated-agent requests spread across keys instead of hammering one → fewer 429s → faster chat.
- **Back-compat:** a single `CEREBRAS_API_KEY` behaves exactly as before (one key → no-op rotation).
- 6 tests for the key-collection / dedup / placeholder logic.

## To activate (ops)
Set additional keys on the cloud-api Worker — either `CEREBRAS_API_KEYS="key1,key2,key3"` or `CEREBRAS_API_KEY_2`, `CEREBRAS_API_KEY_3`. Needs Cerebras account keys (Shaw). With one key it's a no-op; with N keys the per-request load divides by N.

## Verification
tsc strict clean, biome clean, 6/6 new tests pass. (The existing nitro-failover/openrouter-fallback tests typecheck clean; they only fail to *run* in a fresh worktree missing the `ai` dep — not affected by this change.)

Context: latency is the last gate on dedicated chat / the agent web UI (#8434). cc @NubsCarson — this is the load-balance half of your (b) lever.

Co-authored-by: wakesync <shadow@shad0w.xyz>