### PR TITLE
test(cloud-shared): cover OpenRouter-only + raw-fetch fallback selector paths

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model-openrouter-primary.test.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model-openrouter-primary.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+// OpenRouter-only deployment: NO BitRouter (and no other gateway/native key), so
+// OpenRouter is the PRIMARY router, not a fallback. Exercises the catch-all and
+// requiresBitRouterRouting->OpenRouter substitute paths in getLanguageModel.
+delete process.env.BITROUTER_API_KEY;
+delete process.env.BITROUTER_BASE_URL;
+delete process.env.AI_GATEWAY_API_KEY;
+delete process.env.AIGATEWAY_API_KEY;
+delete process.env.OPENAI_API_KEY;
+delete process.env.ANTHROPIC_API_KEY;
+delete process.env.CEREBRAS_API_KEY;
+delete process.env.GROQ_API_KEY;
+process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+delete process.env.OPENROUTER_BASE_URL;
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+const { generateText } = await import("ai");
+const { getLanguageModel, resolveAiProviderSource, hasLanguageModelProviderConfigured } =
+  await import("./language-model");
+
+function completion(model: string, content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("OpenRouter-only deployment (BitRouter unset)", () => {
+  test("getLanguageModel serves a catalog model directly via openrouter.ai", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = String(url);
+      return completion("anthropic/claude-sonnet-4.6", "ok");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("anthropic/claude-sonnet-4.6"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("ok");
+    expect(host).toContain("openrouter.ai");
+  });
+
+  test("getLanguageModel serves a :nitro routing-suffix model via openrouter.ai", async () => {
+    let host = "";
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      host = String(url);
+      return completion("openai/gpt-oss-120b:nitro", "ok");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("ok");
+    expect(host).toContain("openrouter.ai");
+  });
+
+  test("resolveAiProviderSource bills OpenRouter-served models to the bitrouter price catalog", () => {
+    // OpenRouter shares BitRouter's catalog; its price rows are stored under
+    // billingSource "bitrouter", so attribution must be "bitrouter" (NOT a new
+    // "openrouter" source that has no pricing rows and is not a PricingBillingSource).
+    expect(resolveAiProviderSource("anthropic/claude-sonnet-4.6")).toBe("bitrouter");
+    expect(resolveAiProviderSource("openai/gpt-oss-120b:nitro")).toBe("bitrouter");
+  });
+
+  test("hasLanguageModelProviderConfigured is true when only OpenRouter is configured", () => {
+    expect(hasLanguageModelProviderConfigured("anthropic/claude-sonnet-4.6")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("openai/gpt-oss-120b:nitro")).toBe(true);
+    expect(hasLanguageModelProviderConfigured("x-ai/grok-4")).toBe(true);
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/provider-fallback-selection.test.ts
+++ b/packages/cloud-shared/src/lib/providers/provider-fallback-selection.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Raw-fetch failover selector used by v1/apps/[id]/chat. BitRouter is primary;
+// per-family direct providers win for openai/* and anthropic/* (they call the
+// upstream with our own key), and OpenRouter (BYOK) is the universal fallback
+// for everything else.
+process.env.BITROUTER_API_KEY = "test-bitrouter-key";
+process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+process.env.OPENAI_API_KEY = "test-openai-key";
+process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+const { getProviderForModelWithFallback } = await import("./index");
+
+describe("getProviderForModelWithFallback OpenRouter wiring", () => {
+  test("openai/* falls back to OpenAI direct (NOT OpenRouter) when OPENAI_API_KEY is set", () => {
+    const { primary, fallback } = getProviderForModelWithFallback("openai/gpt-4");
+    expect(primary.name).toBe("bitrouter");
+    expect(fallback?.name).toBe("openai");
+  });
+
+  test("anthropic/* falls back to Anthropic direct (NOT OpenRouter) when ANTHROPIC_API_KEY is set", () => {
+    const { fallback } = getProviderForModelWithFallback("anthropic/claude-sonnet-4.6");
+    expect(fallback?.name).toBe("anthropic");
+  });
+
+  test("non-direct models (x-ai/*, google/*, mistralai/*) fall back to OpenRouter", () => {
+    expect(getProviderForModelWithFallback("x-ai/grok-4").fallback?.name).toBe("openrouter");
+    expect(getProviderForModelWithFallback("google/gemini-2.5-pro").fallback?.name).toBe(
+      "openrouter",
+    );
+  });
+});


### PR DESCRIPTION
## Context

The native **OpenRouter BYOK fallback** (Phase 1 of moving model routing into the Cloud Worker) and its fixes landed on `develop` (feature via the integration pipeline; billing-source + format via #8728). An adversarial multi-agent review found **two real test-coverage gaps** (pure coverage — no functional defect). This PR closes them. Tests only, no production change.

## Tests
**`language-model-openrouter-primary.test.ts`** — OpenRouter-only deployment (BitRouter unset → OpenRouter is the *primary* router):
- `getLanguageModel(...)` serves a plain catalog model and a `:nitro` model via `openrouter.ai`.
- `resolveAiProviderSource(...)` bills OpenRouter-served models to `"bitrouter"` (shared price catalog; `"openrouter"` is intentionally not a `PricingBillingSource`).
- `hasLanguageModelProviderConfigured(...)` is `true` with only `OPENROUTER_API_KEY`.

**`provider-fallback-selection.test.ts`** — raw-fetch `getProviderForModelWithFallback` (used by `v1/apps/[id]/chat`):
- `openai/*` → OpenAI direct, `anthropic/*` → Anthropic direct, `x-ai/*`/`google/*` → OpenRouter.

## Validation
- Per-file: `language-model-openrouter-primary` (4 pass), `provider-fallback-selection` (3 pass). `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)