### PR TITLE
feat(orchestrator): Codex/Claude-Code parity — MCP auto-inherit, sub-agent nesting, inline diff review

### DIFF
--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -1088,6 +1088,21 @@ export interface CodingAgentTaskSessionRecord {
   updatedAt: string;
 }
 
+/**
+ * The real git change set a coding sub-agent produced, captured from git at
+ * `task_complete` and surfaced on a session record's `metadata.lastChangeSet`
+ * (`CodingAgentTaskSessionRecord.metadata`). Structurally mirrors the
+ * orchestrator plugin's `WorkspaceChangeSet`; consumed read-only by
+ * `DiffReviewPanel`.
+ */
+export interface ChangeSetData {
+  changedFiles: string[];
+  diffStat: string;
+  diff: string;
+  truncated: boolean;
+  capturedAt: number;
+}
+
 export interface CodingAgentTaskDecisionRecord {
   id: string;
   threadId: string;

--- a/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
+++ b/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChangeSetData } from "../../../api/client-types-cloud";
+import { DiffReviewPanel } from "./DiffReviewPanel";
+
+afterEach(cleanup);
+
+function changeSet(overrides: Partial<ChangeSetData> = {}): ChangeSetData {
+  return {
+    changedFiles: ["src/app.ts", "README.md"],
+    diffStat: "2 files changed, 3 insertions(+), 1 deletion(-)",
+    diff: [
+      "diff --git a/src/app.ts b/src/app.ts",
+      "index 1111111..2222222 100644",
+      "--- a/src/app.ts",
+      "+++ b/src/app.ts",
+      "@@ -1,3 +1,3 @@",
+      " const keep = true;",
+      "-const old = 1;",
+      "+const next = 2;",
+      "diff --git a/README.md b/README.md",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -0,0 +1 @@",
+      "+Hello world",
+    ].join("\n"),
+    truncated: false,
+    capturedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("DiffReviewPanel", () => {
+  it("renders an empty state when no change set is provided", () => {
+    render(<DiffReviewPanel changeSet={undefined} />);
+    expect(
+      screen.getByText("No file changes captured for this task."),
+    ).toBeTruthy();
+  });
+
+  it("renders an empty state when the change set has no files", () => {
+    render(
+      <DiffReviewPanel
+        changeSet={changeSet({ changedFiles: [], diff: "" })}
+      />,
+    );
+    expect(
+      screen.getByText("No file changes captured for this task."),
+    ).toBeTruthy();
+  });
+
+  it("displays the diffStat", () => {
+    render(<DiffReviewPanel changeSet={changeSet()} />);
+    expect(
+      screen.getByText("2 files changed, 3 insertions(+), 1 deletion(-)"),
+    ).toBeTruthy();
+  });
+
+  it("groups one collapsible section per changed file", () => {
+    render(<DiffReviewPanel changeSet={changeSet()} />);
+    expect(screen.getByText("src/app.ts")).toBeTruthy();
+    expect(screen.getByText("README.md")).toBeTruthy();
+  });
+
+  it("classifies added and removed lines with the success/danger tokens", () => {
+    render(<DiffReviewPanel changeSet={changeSet()} />);
+    const added = screen.getByText("+const next = 2;");
+    const removed = screen.getByText("-const old = 1;");
+    const hunk = screen.getByText("@@ -1,3 +1,3 @@");
+    expect(added.className).toContain("text-success");
+    expect(removed.className).toContain("text-destructive");
+    expect(hunk.className).toContain("text-warning");
+  });
+
+  it("shows a section for a changed file even when its diff text is absent", () => {
+    render(
+      <DiffReviewPanel
+        changeSet={changeSet({
+          changedFiles: ["src/app.ts", "data/generated.bin"],
+          diff: [
+            "diff --git a/src/app.ts b/src/app.ts",
+            "+++ b/src/app.ts",
+            "@@ -1 +1 @@",
+            "+x",
+          ].join("\n"),
+        })}
+      />,
+    );
+    expect(screen.getByText("data/generated.bin")).toBeTruthy();
+    expect(
+      screen.getByText("No inline diff captured for this file."),
+    ).toBeTruthy();
+  });
+
+  it("renders a truncation warning when truncated is true", () => {
+    render(<DiffReviewPanel changeSet={changeSet({ truncated: true })} />);
+    expect(
+      screen.getByText(/This diff is truncated/),
+    ).toBeTruthy();
+  });
+
+  it("does not render a truncation warning when truncated is false", () => {
+    render(<DiffReviewPanel changeSet={changeSet({ truncated: false })} />);
+    expect(screen.queryByText(/This diff is truncated/)).toBeNull();
+  });
+
+  it("collapses a file section when its header is toggled", () => {
+    render(<DiffReviewPanel changeSet={changeSet()} />);
+    expect(screen.getByText("+const next = 2;")).toBeTruthy();
+    const header = screen.getByText("src/app.ts").closest("button");
+    if (!header) throw new Error("file header button missing");
+    fireEvent.click(header);
+    expect(screen.queryByText("+const next = 2;")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
+++ b/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
@@ -42,9 +42,7 @@ describe("DiffReviewPanel", () => {
 
   it("renders an empty state when the change set has no files", () => {
     render(
-      <DiffReviewPanel
-        changeSet={changeSet({ changedFiles: [], diff: "" })}
-      />,
+      <DiffReviewPanel changeSet={changeSet({ changedFiles: [], diff: "" })} />,
     );
     expect(
       screen.getByText("No file changes captured for this task."),
@@ -96,9 +94,7 @@ describe("DiffReviewPanel", () => {
 
   it("renders a truncation warning when truncated is true", () => {
     render(<DiffReviewPanel changeSet={changeSet({ truncated: true })} />);
-    expect(
-      screen.getByText(/This diff is truncated/),
-    ).toBeTruthy();
+    expect(screen.getByText(/This diff is truncated/)).toBeTruthy();
   });
 
   it("does not render a truncation warning when truncated is false", () => {

--- a/packages/ui/src/components/composites/code/DiffReviewPanel.tsx
+++ b/packages/ui/src/components/composites/code/DiffReviewPanel.tsx
@@ -1,0 +1,198 @@
+/**
+ * Read-only, per-file review of the real git change set a coding sub-agent
+ * produced. Pure presentation: it parses the captured unified-diff string into
+ * per-file sections and renders each line styled by prefix. No API calls, no
+ * derived state beyond per-file collapse toggles.
+ *
+ * The change set originates server-side (orchestrator `WorkspaceChangeSet`,
+ * captured from git at `task_complete`) and reaches the UI on a task session
+ * record's `metadata.lastChangeSet`. This component only displays it.
+ */
+
+import { useMemo, useState } from "react";
+import type { ChangeSetData } from "../../../api/client-types-cloud";
+import { cn } from "../../../lib/utils";
+
+export interface DiffReviewPanelProps {
+  changeSet: ChangeSetData | undefined;
+  className?: string;
+}
+
+type DiffLineKind = "add" | "remove" | "hunk" | "meta" | "context";
+
+interface DiffLine {
+  kind: DiffLineKind;
+  text: string;
+}
+
+interface FileDiff {
+  path: string;
+  lines: DiffLine[];
+}
+
+function classifyLine(text: string): DiffLineKind {
+  if (text.startsWith("@@")) return "hunk";
+  if (
+    text.startsWith("+++") ||
+    text.startsWith("---") ||
+    text.startsWith("diff --git") ||
+    text.startsWith("index ") ||
+    text.startsWith("new file") ||
+    text.startsWith("deleted file") ||
+    text.startsWith("rename ") ||
+    text.startsWith("similarity ")
+  ) {
+    return "meta";
+  }
+  if (text.startsWith("+")) return "add";
+  if (text.startsWith("-")) return "remove";
+  return "context";
+}
+
+/**
+ * Derive the post-image path from a `diff --git a/<old> b/<new>` header,
+ * falling back to the old path. Returns undefined for any other line.
+ */
+function pathFromGitHeader(line: string): string | undefined {
+  const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+  if (!match) return undefined;
+  return match[2] ?? match[1];
+}
+
+/**
+ * Split a captured unified-diff string into per-file sections. Every file the
+ * change set reports is represented even when its hunk text was omitted
+ * (the server caps how many file diffs it serializes), so a reviewer still sees
+ * the complete list of touched paths.
+ */
+function parseDiff(changeSet: ChangeSetData): FileDiff[] {
+  const byPath = new Map<string, FileDiff>();
+  const order: string[] = [];
+  const ensure = (path: string): FileDiff => {
+    let entry = byPath.get(path);
+    if (!entry) {
+      entry = { path, lines: [] };
+      byPath.set(path, entry);
+      order.push(path);
+    }
+    return entry;
+  };
+
+  let current: FileDiff | undefined;
+  for (const raw of changeSet.diff ? changeSet.diff.split("\n") : []) {
+    const headerPath = pathFromGitHeader(raw);
+    if (headerPath) {
+      current = ensure(headerPath);
+    }
+    if (current) {
+      current.lines.push({ kind: classifyLine(raw), text: raw });
+    }
+  }
+
+  // Every reported changed file gets a section even if no hunk was serialized.
+  for (const path of changeSet.changedFiles) ensure(path);
+
+  return order.map((path) => byPath.get(path) as FileDiff);
+}
+
+const LINE_TONE: Record<DiffLineKind, string> = {
+  add: "text-success",
+  remove: "text-destructive",
+  hunk: "text-warning",
+  meta: "text-muted-foreground",
+  context: "text-foreground/80",
+};
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  return (
+    <div
+      className={cn(
+        "whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed",
+        LINE_TONE[line.kind],
+      )}
+    >
+      {line.text === "" ? " " : line.text}
+    </div>
+  );
+}
+
+function FileSection({ file }: { file: FileDiff }) {
+  const [open, setOpen] = useState(true);
+  const hasHunks = file.lines.some(
+    (line) => line.kind === "add" || line.kind === "remove",
+  );
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-card/40">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] font-medium text-foreground hover:bg-muted/30"
+        aria-expanded={open}
+      >
+        <span className="text-muted-foreground">{open ? "▾" : "▸"}</span>
+        <span className="truncate font-mono">{file.path}</span>
+      </button>
+      {open ? (
+        <div className="border-t border-border bg-background/40 px-3 py-2">
+          {hasHunks ? (
+            file.lines.map((line, index) => (
+              <DiffLineRow key={`${file.path}:${index}`} line={line} />
+            ))
+          ) : (
+            <div className="text-[12px] text-muted-foreground">
+              No inline diff captured for this file.
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function DiffReviewPanel({ changeSet, className }: DiffReviewPanelProps) {
+  const files = useMemo(
+    () => (changeSet ? parseDiff(changeSet) : []),
+    [changeSet],
+  );
+
+  if (!changeSet || changeSet.changedFiles.length === 0) {
+    return (
+      <div
+        className={cn(
+          "text-[13px] text-muted-foreground",
+          className,
+        )}
+      >
+        No file changes captured for this task.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[13px] font-medium text-foreground">
+          Changes
+        </span>
+        {changeSet.diffStat ? (
+          <span className="font-mono text-[12px] text-muted-foreground">
+            {changeSet.diffStat}
+          </span>
+        ) : null}
+      </div>
+
+      {changeSet.truncated ? (
+        <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+          This diff is truncated — some changes are not shown. Review the full
+          change set in the workspace.
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        {files.map((file) => (
+          <FileSection key={file.path} file={file} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/composites/code/DiffReviewPanel.tsx
+++ b/packages/ui/src/components/composites/code/DiffReviewPanel.tsx
@@ -136,6 +136,7 @@ function FileSection({ file }: { file: FileDiff }) {
         <div className="border-t border-border bg-background/40 px-3 py-2">
           {hasHunks ? (
             file.lines.map((line, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: diff lines are an immutable, never-reordered render — line index is the only stable identity
               <DiffLineRow key={`${file.path}:${index}`} line={line} />
             ))
           ) : (
@@ -149,7 +150,10 @@ function FileSection({ file }: { file: FileDiff }) {
   );
 }
 
-export function DiffReviewPanel({ changeSet, className }: DiffReviewPanelProps) {
+export function DiffReviewPanel({
+  changeSet,
+  className,
+}: DiffReviewPanelProps) {
   const files = useMemo(
     () => (changeSet ? parseDiff(changeSet) : []),
     [changeSet],
@@ -157,12 +161,7 @@ export function DiffReviewPanel({ changeSet, className }: DiffReviewPanelProps) 
 
   if (!changeSet || changeSet.changedFiles.length === 0) {
     return (
-      <div
-        className={cn(
-          "text-[13px] text-muted-foreground",
-          className,
-        )}
-      >
+      <div className={cn("text-[13px] text-muted-foreground", className)}>
         No file changes captured for this task.
       </div>
     );
@@ -171,9 +170,7 @@ export function DiffReviewPanel({ changeSet, className }: DiffReviewPanelProps) 
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <div className="flex items-center justify-between gap-3">
-        <span className="text-[13px] font-medium text-foreground">
-          Changes
-        </span>
+        <span className="text-[13px] font-medium text-foreground">Changes</span>
         {changeSet.diffStat ? (
           <span className="font-mono text-[12px] text-muted-foreground">
             {changeSet.diffStat}

--- a/packages/ui/src/components/composites/code/index.ts
+++ b/packages/ui/src/components/composites/code/index.ts
@@ -1,0 +1,1 @@
+export * from "./DiffReviewPanel";

--- a/packages/ui/src/components/composites/index.ts
+++ b/packages/ui/src/components/composites/index.ts
@@ -20,6 +20,7 @@ export * from "../ui/status-badge.helpers";
 export * from "../ui/tooltip-extended";
 export * from "./chat";
 export * from "./chat-search-hint";
+export * from "./code";
 export * from "./form-field";
 export * from "./page-panel";
 export * from "./search";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
@@ -15,80 +15,93 @@ let dir: string;
 let prevPath: string | undefined;
 
 beforeEach(() => {
-	prevPath = process.env.ELIZA_CONFIG_PATH;
-	dir = mkdtempSync(join(tmpdir(), "acp-mcp-"));
+  prevPath = process.env.ELIZA_CONFIG_PATH;
+  dir = mkdtempSync(join(tmpdir(), "acp-mcp-"));
 });
 
 afterEach(() => {
-	if (prevPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
-	else process.env.ELIZA_CONFIG_PATH = prevPath;
-	try {
-		rmSync(dir, { recursive: true, force: true });
-	} catch {
-		// best-effort cleanup
-	}
+  if (prevPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+  else process.env.ELIZA_CONFIG_PATH = prevPath;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
 });
 
 function writeConfig(obj: unknown): void {
-	const p = join(dir, "eliza.json");
-	writeFileSync(p, JSON.stringify(obj));
-	process.env.ELIZA_CONFIG_PATH = p;
+  const p = join(dir, "eliza.json");
+  writeFileSync(p, JSON.stringify(obj));
+  process.env.ELIZA_CONFIG_PATH = p;
 }
 
 describe("readConfigMcpServers — auto-inherit parent MCP servers", () => {
-	it("returns undefined when nothing is configured (env-var fallback applies)", () => {
-		writeConfig({});
-		expect(readConfigMcpServers()).toBeUndefined();
-		writeConfig({ mcp: {} });
-		expect(readConfigMcpServers()).toBeUndefined();
-		writeConfig({ mcp: { servers: {} } });
-		expect(readConfigMcpServers()).toBeUndefined();
-	});
+  it("returns undefined when nothing is configured (env-var fallback applies)", () => {
+    writeConfig({});
+    expect(readConfigMcpServers()).toBeUndefined();
+    writeConfig({ mcp: {} });
+    expect(readConfigMcpServers()).toBeUndefined();
+    writeConfig({ mcp: { servers: {} } });
+    expect(readConfigMcpServers()).toBeUndefined();
+  });
 
-	it("converts a stdio server (env record -> name/value array)", () => {
-		writeConfig({
-			mcp: {
-				servers: {
-					fs: { command: "mcp-fs", args: ["--root", "/tmp"], env: { TOKEN: "x" } },
-				},
-			},
-		});
-		const out = readConfigMcpServers();
-		expect(out).toEqual([
-			{ name: "fs", command: "mcp-fs", args: ["--root", "/tmp"], env: [{ name: "TOKEN", value: "x" }] },
-		]);
-	});
+  it("converts a stdio server (env record -> name/value array)", () => {
+    writeConfig({
+      mcp: {
+        servers: {
+          fs: {
+            command: "mcp-fs",
+            args: ["--root", "/tmp"],
+            env: { TOKEN: "x" },
+          },
+        },
+      },
+    });
+    const out = readConfigMcpServers();
+    expect(out).toEqual([
+      {
+        name: "fs",
+        command: "mcp-fs",
+        args: ["--root", "/tmp"],
+        env: [{ name: "TOKEN", value: "x" }],
+      },
+    ]);
+  });
 
-	it("converts an http server (url + headers record)", () => {
-		writeConfig({
-			mcp: {
-				servers: {
-					search: { type: "http", url: "https://mcp.example/x", headers: { Authorization: "Bearer y" } },
-				},
-			},
-		});
-		const out = readConfigMcpServers();
-		expect(out).toEqual([
-			{
-				name: "search",
-				type: "http",
-				url: "https://mcp.example/x",
-				headers: [{ name: "Authorization", value: "Bearer y" }],
-			},
-		]);
-	});
+  it("converts an http server (url + headers record)", () => {
+    writeConfig({
+      mcp: {
+        servers: {
+          search: {
+            type: "http",
+            url: "https://mcp.example/x",
+            headers: { Authorization: "Bearer y" },
+          },
+        },
+      },
+    });
+    const out = readConfigMcpServers();
+    expect(out).toEqual([
+      {
+        name: "search",
+        type: "http",
+        url: "https://mcp.example/x",
+        headers: [{ name: "Authorization", value: "Bearer y" }],
+      },
+    ]);
+  });
 
-	it("drops malformed entries (no command and no url)", () => {
-		writeConfig({
-			mcp: { servers: { bad: { foo: "bar" }, ok: { command: "x" } } },
-		});
-		const out = readConfigMcpServers();
-		expect(out).toHaveLength(1);
-		expect(out?.[0]?.name).toBe("ok");
-	});
+  it("drops malformed entries (no command and no url)", () => {
+    writeConfig({
+      mcp: { servers: { bad: { foo: "bar" }, ok: { command: "x" } } },
+    });
+    const out = readConfigMcpServers();
+    expect(out).toHaveLength(1);
+    expect(out?.[0]?.name).toBe("ok");
+  });
 
-	it("returns undefined for a missing/unreadable config (never throws)", () => {
-		process.env.ELIZA_CONFIG_PATH = join(dir, "does-not-exist.json");
-		expect(readConfigMcpServers()).toBeUndefined();
-	});
+  it("returns undefined for a missing/unreadable config (never throws)", () => {
+    process.env.ELIZA_CONFIG_PATH = join(dir, "does-not-exist.json");
+    expect(readConfigMcpServers()).toBeUndefined();
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readConfigMcpServers } from "../services/config-env";
+
+/**
+ * Real integration test for MCP auto-inherit: write a config file, point
+ * ELIZA_CONFIG_PATH at it, and assert readConfigMcpServers converts the
+ * dashboard-persisted `mcp.servers` object into the ACP `session/new.mcpServers`
+ * array shape. No mocks — it exercises the real file read + conversion.
+ */
+
+let dir: string;
+let prevPath: string | undefined;
+
+beforeEach(() => {
+	prevPath = process.env.ELIZA_CONFIG_PATH;
+	dir = mkdtempSync(join(tmpdir(), "acp-mcp-"));
+});
+
+afterEach(() => {
+	if (prevPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+	else process.env.ELIZA_CONFIG_PATH = prevPath;
+	try {
+		rmSync(dir, { recursive: true, force: true });
+	} catch {
+		// best-effort cleanup
+	}
+});
+
+function writeConfig(obj: unknown): void {
+	const p = join(dir, "eliza.json");
+	writeFileSync(p, JSON.stringify(obj));
+	process.env.ELIZA_CONFIG_PATH = p;
+}
+
+describe("readConfigMcpServers — auto-inherit parent MCP servers", () => {
+	it("returns undefined when nothing is configured (env-var fallback applies)", () => {
+		writeConfig({});
+		expect(readConfigMcpServers()).toBeUndefined();
+		writeConfig({ mcp: {} });
+		expect(readConfigMcpServers()).toBeUndefined();
+		writeConfig({ mcp: { servers: {} } });
+		expect(readConfigMcpServers()).toBeUndefined();
+	});
+
+	it("converts a stdio server (env record -> name/value array)", () => {
+		writeConfig({
+			mcp: {
+				servers: {
+					fs: { command: "mcp-fs", args: ["--root", "/tmp"], env: { TOKEN: "x" } },
+				},
+			},
+		});
+		const out = readConfigMcpServers();
+		expect(out).toEqual([
+			{ name: "fs", command: "mcp-fs", args: ["--root", "/tmp"], env: [{ name: "TOKEN", value: "x" }] },
+		]);
+	});
+
+	it("converts an http server (url + headers record)", () => {
+		writeConfig({
+			mcp: {
+				servers: {
+					search: { type: "http", url: "https://mcp.example/x", headers: { Authorization: "Bearer y" } },
+				},
+			},
+		});
+		const out = readConfigMcpServers();
+		expect(out).toEqual([
+			{
+				name: "search",
+				type: "http",
+				url: "https://mcp.example/x",
+				headers: [{ name: "Authorization", value: "Bearer y" }],
+			},
+		]);
+	});
+
+	it("drops malformed entries (no command and no url)", () => {
+		writeConfig({
+			mcp: { servers: { bad: { foo: "bar" }, ok: { command: "x" } } },
+		});
+		const out = readConfigMcpServers();
+		expect(out).toHaveLength(1);
+		expect(out?.[0]?.name).toBe("ok");
+	});
+
+	it("returns undefined for a missing/unreadable config (never throws)", () => {
+		process.env.ELIZA_CONFIG_PATH = join(dir, "does-not-exist.json");
+		expect(readConfigMcpServers()).toBeUndefined();
+	});
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { runParentAgentBroker } from "../services/parent-agent-broker";
+
+/**
+ * Real tests for sub-agent NESTING via the parent-agent broker's new
+ * `spawn-sub-agent` mode: a running sub-agent spawns its own child on the same
+ * task through the EXISTING spawn path (no new API). Verifies depth computation,
+ * the required-field guards, and that a spawn error (e.g. the depth cap) is
+ * surfaced back to the child as text rather than thrown.
+ */
+
+type SpawnFn = (taskId: string, opts: Record<string, unknown>) => Promise<unknown>;
+
+function makeRequest(args: {
+	service: { spawnAgentForTask: SpawnFn } | null;
+	sessionMetadata: Record<string, unknown> | undefined;
+	brokerArgs: Record<string, unknown>;
+}) {
+	const runtime = {
+		getService: (name: string) =>
+			name === "ORCHESTRATOR_TASK_SERVICE" ? args.service : null,
+		logger: {
+			info() {},
+			warn() {},
+			error() {},
+			debug() {},
+			success() {},
+		},
+	};
+	return {
+		runtime: runtime as never,
+		sessionId: "sess-1",
+		session: { metadata: args.sessionMetadata } as never,
+		args: args.brokerArgs,
+	};
+}
+
+describe("parent-agent broker — spawn-sub-agent (nesting)", () => {
+	it("spawns a child for the parent task at parent depth + 1", async () => {
+		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({ task: { id: "task-1" } }));
+		const res = await runParentAgentBroker(
+			makeRequest({
+				service: { spawnAgentForTask },
+				sessionMetadata: { taskId: "task-1", nestingDepth: 0 },
+				brokerArgs: { mode: "spawn-sub-agent", task: "write tests", label: "tester" },
+			}),
+		);
+		expect(res.success).toBe(true);
+		expect(spawnAgentForTask).toHaveBeenCalledTimes(1);
+		const [taskId, opts] = spawnAgentForTask.mock.calls[0];
+		expect(taskId).toBe("task-1");
+		expect(opts).toMatchObject({
+			task: "write tests",
+			label: "tester",
+			nestingDepth: 1,
+		});
+	});
+
+	it("computes child depth from the parent session's nestingDepth", async () => {
+		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+		await runParentAgentBroker(
+			makeRequest({
+				service: { spawnAgentForTask },
+				sessionMetadata: { taskId: "t", nestingDepth: 2 },
+				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+			}),
+		);
+		expect(spawnAgentForTask.mock.calls[0][1]).toMatchObject({ nestingDepth: 3 });
+	});
+
+	it("refuses (no spawn) when the session has no taskId", async () => {
+		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+		const res = await runParentAgentBroker(
+			makeRequest({
+				service: { spawnAgentForTask },
+				sessionMetadata: {},
+				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+			}),
+		);
+		expect(res.success).toBe(false);
+		expect(spawnAgentForTask).not.toHaveBeenCalled();
+	});
+
+	it("refuses (no spawn) without a task instruction", async () => {
+		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+		const res = await runParentAgentBroker(
+			makeRequest({
+				service: { spawnAgentForTask },
+				sessionMetadata: { taskId: "t" },
+				brokerArgs: { mode: "spawn-sub-agent" },
+			}),
+		);
+		expect(res.success).toBe(false);
+		expect(spawnAgentForTask).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a spawn error (e.g. depth cap) as text, not a throw", async () => {
+		const spawnAgentForTask = vi.fn<SpawnFn>(async () => {
+			throw new Error("sub-agent nesting depth 4 exceeds the max of 3");
+		});
+		const res = await runParentAgentBroker(
+			makeRequest({
+				service: { spawnAgentForTask },
+				sessionMetadata: { taskId: "t", nestingDepth: 3 },
+				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+			}),
+		);
+		expect(res.success).toBe(false);
+		expect(res.text).toMatch(/exceeds the max/);
+	});
+
+	it("errors when the orchestrator service is unavailable", async () => {
+		const res = await runParentAgentBroker(
+			makeRequest({
+				service: null,
+				sessionMetadata: { taskId: "t" },
+				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+			}),
+		);
+		expect(res.success).toBe(false);
+	});
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
@@ -9,114 +9,125 @@ import { runParentAgentBroker } from "../services/parent-agent-broker";
  * surfaced back to the child as text rather than thrown.
  */
 
-type SpawnFn = (taskId: string, opts: Record<string, unknown>) => Promise<unknown>;
+type SpawnFn = (
+  taskId: string,
+  opts: Record<string, unknown>,
+) => Promise<unknown>;
 
 function makeRequest(args: {
-	service: { spawnAgentForTask: SpawnFn } | null;
-	sessionMetadata: Record<string, unknown> | undefined;
-	brokerArgs: Record<string, unknown>;
+  service: { spawnAgentForTask: SpawnFn } | null;
+  sessionMetadata: Record<string, unknown> | undefined;
+  brokerArgs: Record<string, unknown>;
 }) {
-	const runtime = {
-		getService: (name: string) =>
-			name === "ORCHESTRATOR_TASK_SERVICE" ? args.service : null,
-		logger: {
-			info() {},
-			warn() {},
-			error() {},
-			debug() {},
-			success() {},
-		},
-	};
-	return {
-		runtime: runtime as never,
-		sessionId: "sess-1",
-		session: { metadata: args.sessionMetadata } as never,
-		args: args.brokerArgs,
-	};
+  const runtime = {
+    getService: (name: string) =>
+      name === "ORCHESTRATOR_TASK_SERVICE" ? args.service : null,
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+      success() {},
+    },
+  };
+  return {
+    runtime: runtime as never,
+    sessionId: "sess-1",
+    session: { metadata: args.sessionMetadata } as never,
+    args: args.brokerArgs,
+  };
 }
 
 describe("parent-agent broker — spawn-sub-agent (nesting)", () => {
-	it("spawns a child for the parent task at parent depth + 1", async () => {
-		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({ task: { id: "task-1" } }));
-		const res = await runParentAgentBroker(
-			makeRequest({
-				service: { spawnAgentForTask },
-				sessionMetadata: { taskId: "task-1", nestingDepth: 0 },
-				brokerArgs: { mode: "spawn-sub-agent", task: "write tests", label: "tester" },
-			}),
-		);
-		expect(res.success).toBe(true);
-		expect(spawnAgentForTask).toHaveBeenCalledTimes(1);
-		const [taskId, opts] = spawnAgentForTask.mock.calls[0];
-		expect(taskId).toBe("task-1");
-		expect(opts).toMatchObject({
-			task: "write tests",
-			label: "tester",
-			nestingDepth: 1,
-		});
-	});
+  it("spawns a child for the parent task at parent depth + 1", async () => {
+    const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({
+      task: { id: "task-1" },
+    }));
+    const res = await runParentAgentBroker(
+      makeRequest({
+        service: { spawnAgentForTask },
+        sessionMetadata: { taskId: "task-1", nestingDepth: 0 },
+        brokerArgs: {
+          mode: "spawn-sub-agent",
+          task: "write tests",
+          label: "tester",
+        },
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(spawnAgentForTask).toHaveBeenCalledTimes(1);
+    const [taskId, opts] = spawnAgentForTask.mock.calls[0];
+    expect(taskId).toBe("task-1");
+    expect(opts).toMatchObject({
+      task: "write tests",
+      label: "tester",
+      nestingDepth: 1,
+    });
+  });
 
-	it("computes child depth from the parent session's nestingDepth", async () => {
-		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
-		await runParentAgentBroker(
-			makeRequest({
-				service: { spawnAgentForTask },
-				sessionMetadata: { taskId: "t", nestingDepth: 2 },
-				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
-			}),
-		);
-		expect(spawnAgentForTask.mock.calls[0][1]).toMatchObject({ nestingDepth: 3 });
-	});
+  it("computes child depth from the parent session's nestingDepth", async () => {
+    const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+    await runParentAgentBroker(
+      makeRequest({
+        service: { spawnAgentForTask },
+        sessionMetadata: { taskId: "t", nestingDepth: 2 },
+        brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+      }),
+    );
+    expect(spawnAgentForTask.mock.calls[0][1]).toMatchObject({
+      nestingDepth: 3,
+    });
+  });
 
-	it("refuses (no spawn) when the session has no taskId", async () => {
-		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
-		const res = await runParentAgentBroker(
-			makeRequest({
-				service: { spawnAgentForTask },
-				sessionMetadata: {},
-				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
-			}),
-		);
-		expect(res.success).toBe(false);
-		expect(spawnAgentForTask).not.toHaveBeenCalled();
-	});
+  it("refuses (no spawn) when the session has no taskId", async () => {
+    const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+    const res = await runParentAgentBroker(
+      makeRequest({
+        service: { spawnAgentForTask },
+        sessionMetadata: {},
+        brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+      }),
+    );
+    expect(res.success).toBe(false);
+    expect(spawnAgentForTask).not.toHaveBeenCalled();
+  });
 
-	it("refuses (no spawn) without a task instruction", async () => {
-		const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
-		const res = await runParentAgentBroker(
-			makeRequest({
-				service: { spawnAgentForTask },
-				sessionMetadata: { taskId: "t" },
-				brokerArgs: { mode: "spawn-sub-agent" },
-			}),
-		);
-		expect(res.success).toBe(false);
-		expect(spawnAgentForTask).not.toHaveBeenCalled();
-	});
+  it("refuses (no spawn) without a task instruction", async () => {
+    const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({}));
+    const res = await runParentAgentBroker(
+      makeRequest({
+        service: { spawnAgentForTask },
+        sessionMetadata: { taskId: "t" },
+        brokerArgs: { mode: "spawn-sub-agent" },
+      }),
+    );
+    expect(res.success).toBe(false);
+    expect(spawnAgentForTask).not.toHaveBeenCalled();
+  });
 
-	it("surfaces a spawn error (e.g. depth cap) as text, not a throw", async () => {
-		const spawnAgentForTask = vi.fn<SpawnFn>(async () => {
-			throw new Error("sub-agent nesting depth 4 exceeds the max of 3");
-		});
-		const res = await runParentAgentBroker(
-			makeRequest({
-				service: { spawnAgentForTask },
-				sessionMetadata: { taskId: "t", nestingDepth: 3 },
-				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
-			}),
-		);
-		expect(res.success).toBe(false);
-		expect(res.text).toMatch(/exceeds the max/);
-	});
+  it("surfaces a spawn error (e.g. depth cap) as text, not a throw", async () => {
+    const spawnAgentForTask = vi.fn<SpawnFn>(async () => {
+      throw new Error("sub-agent nesting depth 4 exceeds the max of 3");
+    });
+    const res = await runParentAgentBroker(
+      makeRequest({
+        service: { spawnAgentForTask },
+        sessionMetadata: { taskId: "t", nestingDepth: 3 },
+        brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+      }),
+    );
+    expect(res.success).toBe(false);
+    expect(res.text).toMatch(/exceeds the max/);
+  });
 
-	it("errors when the orchestrator service is unavailable", async () => {
-		const res = await runParentAgentBroker(
-			makeRequest({
-				service: null,
-				sessionMetadata: { taskId: "t" },
-				brokerArgs: { mode: "spawn-sub-agent", task: "x" },
-			}),
-		);
-		expect(res.success).toBe(false);
-	});
+  it("errors when the orchestrator service is unavailable", async () => {
+    const res = await runParentAgentBroker(
+      makeRequest({
+        service: null,
+        sessionMetadata: { taskId: "t" },
+        brokerArgs: { mode: "spawn-sub-agent", task: "x" },
+      }),
+    );
+    expect(res.success).toBe(false);
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { toTaskThreadDetail } from "../services/orchestrator-task-mapper.js";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
+import type { WorkspaceChangeSet } from "../services/workspace-diff.js";
+
+/**
+ * Proves the change set the sub-agent produced (captured onto the LIVE ACP
+ * session metadata at `task_complete`) is mirrored into the durable task-store
+ * session record so the existing `/api/orchestrator/tasks/:id` detail route
+ * serves it via `TaskSessionDto.metadata.lastChangeSet` — no new HTTP route.
+ */
+type EventHandler = (sessionId: string, event: string, data: unknown) => void;
+
+const CHANGE_SET: WorkspaceChangeSet = {
+  changedFiles: ["src/app.ts", "README.md"],
+  diffStat: "2 files changed, 4 insertions(+), 1 deletion(-)",
+  diff: "diff --git a/src/app.ts b/src/app.ts\n@@\n+const x = 1;\n-const y = 2;",
+  truncated: false,
+  capturedAt: Date.now(),
+};
+
+function makeFakeAcp(sessionMetadata: Record<string, unknown>) {
+  let handler: EventHandler | undefined;
+  const service = {
+    onSessionEvent(cb: EventHandler) {
+      handler = cb;
+      return () => {
+        handler = undefined;
+      };
+    },
+    getSession: vi.fn(async (sessionId: string) => ({
+      id: sessionId,
+      name: "Ada",
+      workdir: "/tmp/x",
+      metadata: sessionMetadata,
+    })),
+    // No tracked git change to capture; the change set comes from ACP metadata.
+    getChangedPaths: vi.fn(() => [] as string[]),
+    sendToSession: vi.fn(async () => ({ stopReason: "end_turn", finalText: "" })),
+    stopSession: vi.fn(async () => undefined),
+  };
+  return {
+    service,
+    emit: (sessionId: string, event: string, data: unknown) =>
+      handler?.(sessionId, event, data),
+  };
+}
+
+function makeRuntime(
+  acp: ReturnType<typeof makeFakeAcp>["service"],
+): Record<string, unknown> {
+  return {
+    character: { name: "Tester" },
+    databaseAdapter: undefined,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    useModel: vi.fn(async () => "{}"),
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : undefined,
+  };
+}
+
+async function seedTaskWithSession(
+  store: OrchestratorTaskStore,
+): Promise<{ taskId: string; sessionId: string }> {
+  // No acceptance criteria → the auto-goal verifier no-ops and the task simply
+  // moves to `validating`, isolating the change-set mirror under test.
+  const detail = await store.createTask({
+    title: "t",
+    goal: "do the thing",
+    acceptanceCriteria: [],
+  });
+  const taskId = detail.task.id;
+  const sessionId = "sess-1";
+  const now = Date.now();
+  await store.addSession({
+    id: "row-1",
+    taskId,
+    sessionId,
+    framework: "opencode",
+    label: "Ada",
+    originalTask: "do the thing",
+    workdir: "/tmp/x",
+    status: "ready",
+    decisionCount: 0,
+    autoResolvedCount: 0,
+    registeredAt: now,
+    lastActivityAt: now,
+    idleCheckCount: 0,
+    taskDelivered: false,
+    lastSeenDecisionIndex: 0,
+    spawnedAt: now,
+    retryCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+    metadata: { existingKey: "keep" },
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+  });
+  await store.updateTask(taskId, { status: "active" });
+  return { taskId, sessionId };
+}
+
+describe("change-set mirror into task store on task_complete", () => {
+  let savedFlag: string | undefined;
+  beforeEach(() => {
+    savedFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "0";
+  });
+  afterEach(() => {
+    if (savedFlag === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    else process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = savedFlag;
+  });
+
+  it("mirrors the live ACP session's lastChangeSet onto the store session and into the mapped DTO", async () => {
+    const fake = makeFakeAcp({ lastChangeSet: CHANGE_SET });
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store);
+    const runtime = makeRuntime(fake.service);
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done" });
+
+    await vi.waitFor(async () => {
+      const found = await store.findSession(sessionId);
+      expect(found?.session.metadata.lastChangeSet).toBeDefined();
+    });
+
+    const found = await store.findSession(sessionId);
+    expect(found?.session.metadata.lastChangeSet).toEqual(CHANGE_SET);
+    // Pre-existing metadata is preserved (merge, not replace).
+    expect(found?.session.metadata.existingKey).toBe("keep");
+
+    // The existing detail route serves the DTO produced by this mapper.
+    const doc = await store.getTask(taskId);
+    if (!doc) throw new Error("task missing");
+    const dto = toTaskThreadDetail(doc);
+    const sessionDto = dto.sessions.find((s) => s.sessionId === sessionId);
+    expect(sessionDto?.metadata.lastChangeSet).toEqual(CHANGE_SET);
+  });
+
+  it("stores nothing when there is no change set", async () => {
+    const fake = makeFakeAcp({});
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { sessionId } = await seedTaskWithSession(store);
+    const runtime = makeRuntime(fake.service);
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done" });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const found = await store.findSession(sessionId);
+    expect(found?.session.metadata.lastChangeSet).toBeUndefined();
+    expect(found?.session.metadata.existingKey).toBe("keep");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
@@ -38,7 +38,10 @@ function makeFakeAcp(sessionMetadata: Record<string, unknown>) {
     })),
     // No tracked git change to capture; the change set comes from ACP metadata.
     getChangedPaths: vi.fn(() => [] as string[]),
-    sendToSession: vi.fn(async () => ({ stopReason: "end_turn", finalText: "" })),
+    sendToSession: vi.fn(async () => ({
+      stopReason: "end_turn",
+      finalText: "",
+    })),
     stopSession: vi.fn(async () => undefined),
   };
   return {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { NativeAcpClient } from "./acp-native-transport.js";
+import { readConfigMcpServers } from "./config-env.js";
 import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
@@ -1174,6 +1175,10 @@ export class AcpService extends Service {
         opts.model,
         session.agentType,
       ),
+      // Auto-inherit the parent runtime's configured MCP servers (config
+      // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
+      // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
+      mcpServers: readConfigMcpServers(),
       onEvent: (event, protocolSessionId) => {
         this.handleAcpEvent(
           event,

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -6,13 +6,13 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { NativeAcpClient } from "./acp-native-transport.js";
-import { readConfigMcpServers } from "./config-env.js";
 import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
   resolveCodingAccountStrategy,
   selectCodingAccount,
 } from "./coding-account-selection.js";
+import { readConfigMcpServers } from "./config-env.js";
 import {
   buildOpencodeAcpEnv,
   resolveVendoredOpencodeAcpCommand,

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.ts
@@ -11,6 +11,7 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { getElizaNamespace, resolveStateDir } from "@elizaos/core";
+import type { AcpMcpServerConfig } from "./acp-native-transport.js";
 
 function readConfig(): Record<string, unknown> | undefined {
   try {
@@ -50,4 +51,64 @@ export function readConfigCloudKey(key: string): string | undefined {
   const config = readConfig();
   const val = (config?.cloud as Record<string, unknown> | undefined)?.[key];
   return typeof val === "string" ? val : undefined;
+}
+
+/** Convert an MCP `{ KEY: "value" }` record (env / headers) to the ACP
+ * `[{ name, value }]` shape, dropping non-string values. */
+function recordToNameValue(
+  obj: unknown,
+): Array<{ name: string; value: string }> | undefined {
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return undefined;
+  const out: Array<{ name: string; value: string }> = [];
+  for (const [name, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (name && typeof value === "string") out.push({ name, value });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Read the runtime's configured MCP servers from the config's `mcp.servers`
+ * object — the same map the dashboard `/api/config` route validates and
+ * persists — and convert it to the ACP `session/new.mcpServers` array shape, so
+ * spawned sub-agents automatically inherit the parent's MCP tools (Codex /
+ * Claude-Code parity) without the operator duplicating them in
+ * `ELIZA_ACP_MCP_SERVERS`.
+ *
+ * Returns undefined when nothing is configured (so the env-var fallback in the
+ * transport still applies) and silently drops malformed entries — it must never
+ * throw, since it runs on the sub-agent spawn path.
+ */
+export function readConfigMcpServers(): AcpMcpServerConfig[] | undefined {
+  const config = readConfig();
+  const servers = (config?.mcp as { servers?: unknown } | undefined)?.servers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    return undefined;
+  }
+  const out: AcpMcpServerConfig[] = [];
+  for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+    if (!name || !raw || typeof raw !== "object") continue;
+    const entry = raw as Record<string, unknown>;
+    const type = typeof entry.type === "string" ? entry.type : undefined;
+    const url = typeof entry.url === "string" ? entry.url : undefined;
+    // Remote MCP: an explicit http(-ish) transport type or a URL.
+    if (url && (type === undefined || type.includes("http"))) {
+      const headers = recordToNameValue(entry.headers);
+      out.push({ name, type: "http", url, ...(headers ? { headers } : {}) });
+      continue;
+    }
+    // Local stdio MCP: requires a command.
+    const command = typeof entry.command === "string" ? entry.command : undefined;
+    if (!command) continue;
+    const args = Array.isArray(entry.args)
+      ? entry.args.filter((a): a is string => typeof a === "string")
+      : undefined;
+    const env = recordToNameValue(entry.env);
+    out.push({
+      name,
+      command,
+      ...(args && args.length > 0 ? { args } : {}),
+      ...(env ? { env } : {}),
+    });
+  }
+  return out.length > 0 ? out : undefined;
 }

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.ts
@@ -85,7 +85,9 @@ export function readConfigMcpServers(): AcpMcpServerConfig[] | undefined {
     return undefined;
   }
   const out: AcpMcpServerConfig[] = [];
-  for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+  for (const [name, raw] of Object.entries(
+    servers as Record<string, unknown>,
+  )) {
     if (!name || !raw || typeof raw !== "object") continue;
     const entry = raw as Record<string, unknown>;
     const type = typeof entry.type === "string" ? entry.type : undefined;
@@ -97,7 +99,8 @@ export function readConfigMcpServers(): AcpMcpServerConfig[] | undefined {
       continue;
     }
     // Local stdio MCP: requires a command.
-    const command = typeof entry.command === "string" ? entry.command : undefined;
+    const command =
+      typeof entry.command === "string" ? entry.command : undefined;
     if (!command) continue;
     const args = Array.isArray(entry.args)
       ? entry.args.filter((a): a is string => typeof a === "string")

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -86,10 +86,7 @@ import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
 } from "./workdir-validation.js";
-import {
-  captureChangeSet,
-  type WorkspaceChangeSet,
-} from "./workspace-diff.js";
+import { captureChangeSet, type WorkspaceChangeSet } from "./workspace-diff.js";
 
 /**
  * Recoverable operator-recovery conflict.
@@ -748,7 +745,10 @@ export class OrchestratorTaskService extends Service {
       const found = await this.store.findSession(sessionId);
       if (!found) return;
       await this.store.updateSession(sessionId, {
-        metadata: { ...(found.session.metadata ?? {}), lastChangeSet: changeSet },
+        metadata: {
+          ...(found.session.metadata ?? {}),
+          lastChangeSet: changeSet,
+        },
       });
     } catch (err) {
       this.log("debug", "mirror change-set to store failed", {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -86,6 +86,10 @@ import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
 } from "./workdir-validation.js";
+import {
+  captureChangeSet,
+  type WorkspaceChangeSet,
+} from "./workspace-diff.js";
 
 /**
  * Recoverable operator-recovery conflict.
@@ -227,6 +231,22 @@ function num(value: unknown): number {
 
 function truncate(text: string, max = 2000): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Read a persisted {@link WorkspaceChangeSet} off arbitrary session metadata,
+ * validating its shape the same way the CODING_SESSION_CHANGES provider does so
+ * a malformed value never reaches the DTO. Returns undefined when absent or
+ * malformed.
+ */
+function readLastChangeSet(
+  metadata: Record<string, unknown> | undefined,
+): WorkspaceChangeSet | undefined {
+  const raw = metadata?.lastChangeSet;
+  if (!isRecord(raw)) return undefined;
+  if (!Array.isArray(raw.changedFiles)) return undefined;
+  if (typeof raw.capturedAt !== "number") return undefined;
+  return raw as unknown as WorkspaceChangeSet;
 }
 
 function findPlanRevision(
@@ -638,6 +658,7 @@ export class OrchestratorTaskService extends Service {
           completionSummary: summary ? truncate(summary) : undefined,
           stoppedAt: Date.now(),
         });
+        await this.mirrorChangeSetToStore(sessionId);
         await this.advanceTaskStatus(taskId, "validating");
         // Issue #8124: the orchestrator should always behave like `/goal` —
         // confirm the sub-agent met every acceptance criterion before marking
@@ -683,6 +704,57 @@ export class OrchestratorTaskService extends Service {
       }
       default:
         break;
+    }
+  }
+
+  /**
+   * Mirror the real git change set a sub-agent produced into the durable task
+   * store session record's metadata, so the existing `/api/orchestrator/tasks/:id`
+   * detail route serves it (`TaskSessionDto.metadata.lastChangeSet`) and the
+   * task view can render a read-only diff without a new endpoint.
+   *
+   * Source of truth is the change set the router captured onto the LIVE ACP
+   * session metadata at `task_complete`. Because the router's capture and this
+   * event-bridge handler run on the same ACP event with no guaranteed ordering,
+   * fall back to capturing it here from the same session-scoped signals (spawn
+   * baseline + agent-written tool paths) when the ACP write hasn't landed yet.
+   *
+   * Additive and null-safe: when there is no change set (unchanged completion,
+   * non-git workdir), nothing is written and the DTO simply omits it.
+   */
+  private async mirrorChangeSetToStore(sessionId: string): Promise<void> {
+    try {
+      const acp = this.acp();
+      if (!acp) return;
+      const session = await acp.getSession(sessionId);
+      if (!session) return;
+
+      let changeSet = readLastChangeSet(session.metadata);
+      if (!changeSet) {
+        const meta = session.metadata as Record<string, unknown> | undefined;
+        const baseline = str(meta?.codingBaselineSha);
+        const baselineDirty = Array.isArray(meta?.codingBaselineDirty)
+          ? (meta.codingBaselineDirty as unknown[]).map(String)
+          : [];
+        changeSet = await captureChangeSet(
+          session.workdir,
+          baseline,
+          acp.getChangedPaths(sessionId),
+          baselineDirty,
+        );
+      }
+      if (!changeSet) return;
+
+      const found = await this.store.findSession(sessionId);
+      if (!found) return;
+      await this.store.updateSession(sessionId, {
+        metadata: { ...(found.session.metadata ?? {}), lastChangeSet: changeSet },
+      });
+    } catch (err) {
+      this.log("debug", "mirror change-set to store failed", {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -125,6 +125,12 @@ export interface SpawnAgentForTaskOptions {
   /** Concrete first instruction; defaults to the task goal. */
   task?: string;
   approvalPreset?: ApprovalPreset;
+  /**
+   * Recursion depth for nested spawns. 0 (default) = spawned by the main agent;
+   * a sub-agent spawning its own child passes parentDepth + 1. Enforced against
+   * the max-nesting-depth cap so self-spawning can't run away.
+   */
+  nestingDepth?: number;
 }
 
 export interface AddMessageInput {
@@ -1565,6 +1571,18 @@ export class OrchestratorTaskService extends Service {
   ): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
+    // Nested-spawn guard: a sub-agent can spawn its own children, but only up to
+    // a bounded depth so a misbehaving agent can't self-spawn without limit.
+    const nestingDepth = opts.nestingDepth ?? 0;
+    const maxNestingDepth = ((): number => {
+      const raw = Number(process.env.ELIZA_ACP_MAX_NESTING_DEPTH);
+      return Number.isFinite(raw) && raw >= 0 ? Math.floor(raw) : 3;
+    })();
+    if (nestingDepth > maxNestingDepth) {
+      throw new Error(
+        `sub-agent nesting depth ${nestingDepth} exceeds the max of ${maxNestingDepth} (raise ELIZA_ACP_MAX_NESTING_DEPTH to allow deeper nesting)`,
+      );
+    }
     const acp = this.acp();
     if (!acp) throw new Error("ACP service unavailable");
     const workdir = opts.workdir
@@ -1634,6 +1652,9 @@ export class OrchestratorTaskService extends Service {
         // Orchestrator sessions outlive their first prompt so follow-ups and
         // validation re-dispatch can reuse them.
         keepAliveAfterComplete: true,
+        // Carried so a child this sub-agent spawns can compute its own depth
+        // (parent depth + 1) and the nesting guard above can enforce the cap.
+        nestingDepth,
       },
     });
 

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -30,14 +30,15 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
   description:
     "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
   guidance:
-    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling.',
+    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
 } as const;
 
 type ParentAgentMode =
   | "ask"
   | "list-actions"
   | "list-cloud-commands"
-  | "cloud-command";
+  | "cloud-command"
+  | "spawn-sub-agent";
 
 type CloudCommandRisk =
   | "read"
@@ -62,6 +63,11 @@ interface ParentAgentBrokerArgs {
   limit: number;
   command?: string;
   params?: Record<string, unknown>;
+  // spawn-sub-agent mode: the child sub-agent's instruction + optional routing.
+  task?: string;
+  label?: string;
+  framework?: string;
+  workdir?: string;
 }
 
 interface RuntimeWithActions {
@@ -677,6 +683,14 @@ function normalizeMode(value: unknown): ParentAgentMode {
   if (normalized === "cloud-command" || normalized === "cloud") {
     return "cloud-command";
   }
+  if (
+    normalized === "spawn-sub-agent" ||
+    normalized === "spawn" ||
+    normalized === "spawn-agent" ||
+    normalized === "sub-agent"
+  ) {
+    return "spawn-sub-agent";
+  }
   return "ask";
 }
 
@@ -708,6 +722,17 @@ function normalizeArgs(raw: unknown): ParentAgentBrokerArgs {
       normalizeString(record.action) ??
       normalizeString(record.cloudCommand),
     params,
+    task:
+      normalizeString(record.task) ??
+      normalizeString(record.prompt) ??
+      normalizeString(record.instruction),
+    label:
+      normalizeString(record.label) ??
+      normalizeString(record.agentName) ??
+      normalizeString(record.name),
+    framework:
+      normalizeString(record.framework) ?? normalizeString(record.agentType),
+    workdir: normalizeString(record.workdir),
   };
 }
 
@@ -1300,6 +1325,124 @@ async function askParentAgent(request: {
   return "Parent agent completed the request without visible output.";
 }
 
+const ORCHESTRATOR_TASK_SERVICE_NAME = "ORCHESTRATOR_TASK_SERVICE";
+
+/**
+ * Structural view of the orchestrator task service. Used instead of importing
+ * `OrchestratorTaskService` because that module imports THIS broker
+ * (PARENT_AGENT_BROKER_MANIFEST_ENTRY), so a value/type import here would create
+ * a cycle.
+ */
+interface SpawnCapableTaskService {
+  spawnAgentForTask(
+    taskId: string,
+    opts: {
+      task?: string;
+      label?: string;
+      framework?: string;
+      workdir?: string;
+      nestingDepth?: number;
+    },
+  ): Promise<unknown>;
+}
+
+/**
+ * `spawn-sub-agent` mode: let a running sub-agent spawn its OWN child sub-agent
+ * on the same task, reusing the existing orchestrator spawn path (no new API).
+ * The child's nesting depth is parent depth + 1; the orchestrator enforces the
+ * max-depth cap (and throws past it, surfaced here as text to the child).
+ */
+async function runSpawnSubAgent(request: {
+  runtime: IAgentRuntime;
+  sessionId: string;
+  session?: SessionInfo;
+  task?: string;
+  label?: string;
+  framework?: string;
+  workdir?: string;
+}): Promise<{ success: boolean; text: string; data?: Record<string, unknown> }> {
+  const log = getLogger(request.runtime);
+  const data = {
+    actionName: PARENT_AGENT_BROKER_SLUG,
+    mode: "spawn-sub-agent" as const,
+  };
+  const metadata = request.session?.metadata as
+    | Record<string, unknown>
+    | undefined;
+  const parentTaskId = normalizeString(metadata?.taskId);
+  if (!parentTaskId) {
+    return {
+      success: false,
+      text: "spawn-sub-agent can only be used from inside a coding task (no taskId on this session).",
+      data,
+    };
+  }
+  const prompt = normalizeString(request.task);
+  if (!prompt) {
+    return {
+      success: false,
+      text: 'spawn-sub-agent requires a `task` — the instruction for the child sub-agent, e.g. USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"add unit tests for src/foo.ts"}.',
+      data,
+    };
+  }
+  const parentDepth =
+    typeof metadata?.nestingDepth === "number" ? metadata.nestingDepth : 0;
+  const childDepth = parentDepth + 1;
+  const service = request.runtime.getService?.(
+    ORCHESTRATOR_TASK_SERVICE_NAME,
+  ) as SpawnCapableTaskService | null | undefined;
+  if (!service || typeof service.spawnAgentForTask !== "function") {
+    return {
+      success: false,
+      text: "Orchestrator task service is unavailable; cannot spawn a sub-agent.",
+      data,
+    };
+  }
+  try {
+    const result = await service.spawnAgentForTask(parentTaskId, {
+      task: prompt,
+      label: request.label,
+      framework: request.framework,
+      workdir: request.workdir,
+      nestingDepth: childDepth,
+    });
+    if (!result) {
+      return {
+        success: false,
+        text: `Failed to spawn sub-agent: parent task ${parentTaskId} not found.`,
+        data,
+      };
+    }
+    log?.info?.(
+      {
+        src: LOG_PREFIX,
+        event: "spawn_sub_agent",
+        sessionId: request.sessionId,
+        parentTaskId,
+        nestingDepth: childDepth,
+      },
+      `${LOG_PREFIX} spawned nested sub-agent at depth ${childDepth}`,
+    );
+    return {
+      success: true,
+      text: `Spawned a sub-agent (depth ${childDepth}) on task ${parentTaskId}${request.label ? ` named "${request.label}"` : ""}. It runs in parallel on: ${truncate(prompt, 200)}. Its progress appears in this task's thread — check back rather than blocking on it.`,
+      data: { ...data, parentTaskId, nestingDepth: childDepth },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log?.error?.(
+      {
+        src: LOG_PREFIX,
+        event: "spawn_sub_agent_error",
+        sessionId: request.sessionId,
+        error: message,
+      },
+      `${LOG_PREFIX} spawn sub-agent failed`,
+    );
+    return { success: false, text: `Failed to spawn sub-agent: ${message}`, data };
+  }
+}
+
 export async function runParentAgentBroker(
   request: ParentAgentBrokerRequest,
 ): Promise<{ success: boolean; text: string; data?: Record<string, unknown> }> {
@@ -1375,6 +1518,18 @@ export async function runParentAgentBroker(
         },
       };
     }
+  }
+
+  if (args.mode === "spawn-sub-agent") {
+    return await runSpawnSubAgent({
+      runtime: request.runtime,
+      sessionId: request.sessionId,
+      session: request.session,
+      task: args.task,
+      label: args.label,
+      framework: args.framework,
+      workdir: args.workdir,
+    });
   }
 
   if (!args.request) {

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1360,7 +1360,11 @@ async function runSpawnSubAgent(request: {
   label?: string;
   framework?: string;
   workdir?: string;
-}): Promise<{ success: boolean; text: string; data?: Record<string, unknown> }> {
+}): Promise<{
+  success: boolean;
+  text: string;
+  data?: Record<string, unknown>;
+}> {
   const log = getLogger(request.runtime);
   const data = {
     actionName: PARENT_AGENT_BROKER_SLUG,
@@ -1439,7 +1443,11 @@ async function runSpawnSubAgent(request: {
       },
       `${LOG_PREFIX} spawn sub-agent failed`,
     );
-    return { success: false, text: `Failed to spawn sub-agent: ${message}`, data };
+    return {
+      success: false,
+      text: `Failed to spawn sub-agent: ${message}`,
+      data,
+    };
   }
 }
 

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
   Button,
+  type ChangeSetData,
   type CodingAgentAddAgentInput,
   type CodingAgentOrchestratorStatus,
   type CodingAgentRerunFromEventInput,
@@ -23,6 +24,7 @@ import {
   type CodingAgentTaskTimelineItem,
   type CodingAgentTaskUsageSummary,
   client,
+  DiffReviewPanel,
   useApp,
 } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
@@ -1694,6 +1696,13 @@ export function TaskInspector({
   const sessions = [...detail.sessions].sort(
     (a, b) => b.lastActivityAt - a.lastActivityAt,
   );
+  // The real git change set the latest sub-agent produced, mirrored onto its
+  // session record's metadata at task_complete and served by the existing
+  // task-detail route. Read-only review surface; absent for in-flight or
+  // no-op completions.
+  const latestChangeSet = sessions
+    .map((session) => readSessionChangeSet(session.metadata))
+    .find((value): value is ChangeSetData => value !== undefined);
   const artifacts = [...detail.artifacts].reverse().slice(0, 12);
   const latestPlanRevisionId =
     detail.planRevisions.length > 0
@@ -1998,6 +2007,14 @@ export function TaskInspector({
         )}
       </InspectorSection>
 
+      {latestChangeSet ? (
+        <InspectorSection
+          title={t("orchestrator.changes", { defaultValue: "Changes" })}
+        >
+          <DiffReviewPanel changeSet={latestChangeSet} />
+        </InspectorSection>
+      ) : null}
+
       {plan ? <PlanSection plan={plan} t={t} /> : null}
       {detail.currentPlan && !terminal ? (
         <EditedPlanRestartSection
@@ -2038,6 +2055,25 @@ function compactText(value: string, max = 6000): string {
 
 function hasRecordEntries(value: Record<string, unknown> | null | undefined) {
   return Boolean(value && Object.keys(value).length > 0);
+}
+
+/**
+ * Validate a captured change set off a session record's metadata. The orchestrator
+ * mirrors its `WorkspaceChangeSet` onto `metadata.lastChangeSet`; guard the shape
+ * here so a malformed value never reaches the read-only diff panel.
+ */
+function readSessionChangeSet(
+  metadata: Record<string, unknown>,
+): ChangeSetData | undefined {
+  const raw = metadata.lastChangeSet;
+  if (!raw || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<ChangeSetData>;
+  if (!Array.isArray(candidate.changedFiles)) return undefined;
+  if (typeof candidate.diff !== "string") return undefined;
+  if (typeof candidate.diffStat !== "string") return undefined;
+  if (typeof candidate.truncated !== "boolean") return undefined;
+  if (typeof candidate.capturedAt !== "number") return undefined;
+  return candidate as ChangeSetData;
 }
 
 function JsonBlock({


### PR DESCRIPTION
Three sub-agent orchestration parity features, each **additive** and **without any new HTTP API** (all reuse existing orchestrator surfaces). Built off verified seams; each independently tested.

## What's in here

**1. MCP auto-inherit** (`bf74f33`)
Spawned sub-agents now inherit the parent runtime's configured MCP servers automatically. `config-env.readConfigMcpServers()` reads the dashboard-persisted `mcp.servers` object (the same one `/api/config` validates) and converts it to the ACP `session/new.mcpServers` shape; `acp-service` passes it to `NativeAcpClient`. The opt-in `ELIZA_ACP_MCP_SERVERS` env var remains a fallback. Undefined when nothing is configured → no behavior change; malformed entries are dropped (never throws on the spawn path). *5 tests.*

**2. Sub-agent nesting, no new API** (`d6a7ea8`)
A running sub-agent can spawn its own child via `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"…"}` — routed through the **existing** parent-agent broker and the **existing** `spawnAgentForTask`. `runSpawnSubAgent` reaches the task service structurally (avoiding the broker↔service import cycle), derives the parent task id + depth from session metadata, and passes `nestingDepth = parentDepth + 1`. A depth cap (`ELIZA_ACP_MAX_NESTING_DEPTH`, default 3) stops runaway self-spawning; main-agent spawns are unchanged (depth 0). *6 tests.*

**3. Inline diff-review UI** (`cd7aa06`)
The sub-agent's captured git change set now surfaces in the task view. `orchestrator-task-service.mirrorChangeSetToStore()` (on the `task_complete` event bridge) copies the live ACP session's `metadata.lastChangeSet` into the task-store session record, so the **existing** `/api/orchestrator/tasks/:id` route serves it — no new route. `@elizaos/ui`'s new `DiffReviewPanel` renders a per-file collapsible unified diff (+/- styling via existing tokens, truncation warning, empty state), shown in a "Changes" section of the `OrchestratorWorkbench` task inspector. *2 + 9 tests.*

## Verification
- plugin-agent-orchestrator suite: **156 pass / 6 skip**; typecheck exit 0.
- plugin-task-coordinator suite: **177 pass**; `build:views` clean.
- @elizaos/ui build clean; new exports present.
- Diff-review was built + adversarially reviewed via a workflow (data path traced end-to-end; integration confirmed to be the live `TaskInspector`, not a dead component); verdict: ship.

## Known residuals (non-blocking)
- Diff capture runs `git diff` twice per task completion (router for narration + mirror for the store; the two event subscribers don't await each other). Output is idempotent; left as-is to avoid refactoring the critical completion path for a rare micro-cost.
- The diff panel's live render in the desktop dashboard isn't visually eyeballed (DOM behavior is covered by jsdom tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)