### PR TITLE
feat(first-run): auto-skip the runtime picker on cloud-only hosts

### DIFF
--- a/packages/ui/src/first-run/CompactOnboarding.tsx
+++ b/packages/ui/src/first-run/CompactOnboarding.tsx
@@ -53,6 +53,25 @@ export function CompactOnboarding(): React.ReactElement {
     void finishAndMaybeClose();
   }, [c, finishAndMaybeClose]);
 
+  // Cloud-only hosts — the hosted app.elizacloud.ai web bundle and the
+  // desktop/native "cloud" runtime builds — can ONLY run on Eliza Cloud: there
+  // is no local / on-device choice to make, and therefore no inference
+  // sub-choice either. Skip the "How should Eliza run?" picker entirely and hand
+  // off straight to the cloud sign-in on first paint. The cloud-login flow's own
+  // fallback surfaces a tappable "Open sign-in page" CTA if it cannot auto-open.
+  const cloudOnlyAutoStarted = React.useRef(false);
+  React.useEffect(() => {
+    if (
+      cloudOnly &&
+      !cloudOnlyAutoStarted.current &&
+      step === "runtime" &&
+      !submitting
+    ) {
+      cloudOnlyAutoStarted.current = true;
+      chooseCloud();
+    }
+  }, [cloudOnly, step, submitting, chooseCloud]);
+
   // Local runtime needs an inference sub-choice (cloud vs on-device) before it
   // can finish — advance to that step instead of provisioning immediately.
   const chooseLocal = React.useCallback(() => {


### PR DESCRIPTION
## What

On **cloud-only hosts** — the hosted `app.elizacloud.ai` web bundle and the desktop/native cloud runtime builds (`branding.cloudOnly === true`) — there is no local / on-device runtime to choose, so the "How should Eliza run? (Eliza Cloud / This device)" picker is pointless. It still rendered, with the local option merely *disabled*, forcing the user through an extra dead-end choice.

Confirmed on the live `app.elizacloud.ai`: `branding.cloudOnly` is already `true` there, yet the picker still shows.

## Change

In `CompactOnboarding`, when `cloudOnly` is set, auto-invoke the cloud choice on first paint (`step === "runtime"`, ref-guarded so it fires once) — handing off straight to the Eliza Cloud sign-in. The cloud-login flow's existing fallback already surfaces a tappable "Open sign-in page" CTA if it can't auto-open, so this is popup-safe. Non-cloud-only hosts (desktop with a local backend, native local builds) are unaffected — the guard is `cloudOnly &&`.

## Verification

- `branding.cloudOnly` confirmed `true` on live `app.elizacloud.ai` (so the path activates there).
- Effect is ref-guarded (fires once) and gated on `cloudOnly` + `step === "runtime"` + `!submitting`.
- Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)