### PR TITLE
fix(core): resolve real model name for env-configured backends

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
@@ -5,115 +5,143 @@ import type { IAgentRuntime } from "../../../types/runtime.ts";
 import { runtimeModelContextProvider } from "./runtimeModelContext.ts";
 
 function makeRuntime(
-	settings: Record<string, string | undefined>,
-	overrides: Partial<IAgentRuntime> = {},
+  settings: Record<string, string | undefined>,
+  overrides: Partial<IAgentRuntime> = {},
 ): IAgentRuntime {
-	return {
-		getSetting: (key: string) => settings[key] ?? null,
-		models: new Map([
-			[ModelType.RESPONSE_HANDLER, [{ provider: "openai" }]],
-			[ModelType.ACTION_PLANNER, [{ provider: "openai" }]],
-		]),
-		...overrides,
-	} as unknown as IAgentRuntime;
+  return {
+    getSetting: (key: string) => settings[key] ?? null,
+    models: new Map([
+      [ModelType.RESPONSE_HANDLER, [{ provider: "openai" }]],
+      [ModelType.ACTION_PLANNER, [{ provider: "openai" }]],
+    ]),
+    ...overrides,
+  } as unknown as IAgentRuntime;
 }
 
 function makeMessage(
-	text: string,
-	content: Partial<Memory["content"]> = {},
+  text: string,
+  content: Partial<Memory["content"]> = {},
 ): Memory {
-	return {
-		content: { text, ...content },
-	} as Memory;
+  return {
+    content: { text, ...content },
+  } as Memory;
 }
 
 describe("runtimeModelContextProvider", () => {
-	it("exposes configured runtime model slots for self-model questions", async () => {
-		const runtime = makeRuntime({
-			OPENAI_SMALL_MODEL: "gpt-oss-120b",
-			OPENAI_MEDIUM_MODEL: "gpt-oss-120b",
-			OPENAI_LARGE_MODEL: "gpt-oss-120b",
-			OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
-			ELIZA_DEFAULT_AGENT_TYPE: "opencode",
-			ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
-			ELIZA_OPENCODE_BASE_URL: "https://api.cerebras.ai/v1",
-		});
+  it("exposes configured runtime model slots for self-model questions", async () => {
+    const runtime = makeRuntime({
+      OPENAI_SMALL_MODEL: "gpt-oss-120b",
+      OPENAI_MEDIUM_MODEL: "gpt-oss-120b",
+      OPENAI_LARGE_MODEL: "gpt-oss-120b",
+      OPENAI_BASE_URL: "https://api.cerebras.ai/v1",
+      ELIZA_DEFAULT_AGENT_TYPE: "opencode",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
+      ELIZA_OPENCODE_BASE_URL: "https://api.cerebras.ai/v1",
+    });
 
-		const result = await runtimeModelContextProvider.get(
-			runtime,
-			makeMessage("what model are you using?"),
-			{} as never,
-		);
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      makeMessage("what model are you using?"),
+      {} as never,
+    );
 
-		expect(result.text).toContain("Response handler model: gpt-oss-120b");
-		expect(result.text).toContain("Action planner model: gpt-oss-120b");
-		expect(result.text).toContain("Response handler provider adapter: openai");
-		expect(result.text).toContain(
-			"Response handler endpoint host: api.cerebras.ai",
-		);
-		expect(result.text).toContain("Default coding sub-agent: opencode");
-		expect(result.text).toContain("OpenCode model: gpt-oss-120b");
-		expect(result.text).toContain("OpenCode endpoint host: api.cerebras.ai");
-		expect(result.text).not.toContain("Claude 3.5");
-		expect(result.data?.responseHandlerModel).toBe("gpt-oss-120b");
-		expect(result.data?.responseHandlerEndpointHost).toBe("api.cerebras.ai");
-	});
+    expect(result.text).toContain("Response handler model: gpt-oss-120b");
+    expect(result.text).toContain("Action planner model: gpt-oss-120b");
+    expect(result.text).toContain("Response handler provider adapter: openai");
+    expect(result.text).toContain(
+      "Response handler endpoint host: api.cerebras.ai",
+    );
+    expect(result.text).toContain("Default coding sub-agent: opencode");
+    expect(result.text).toContain("OpenCode model: gpt-oss-120b");
+    expect(result.text).toContain("OpenCode endpoint host: api.cerebras.ai");
+    expect(result.text).not.toContain("Claude 3.5");
+    expect(result.data?.responseHandlerModel).toBe("gpt-oss-120b");
+    expect(result.data?.responseHandlerEndpointHost).toBe("api.cerebras.ai");
+  });
 
-	it("uses the runtime resolver when available", async () => {
-		const runtime = makeRuntime({}, {
-			resolveProviderModelString: (modelType: string) =>
-				modelType === ModelType.RESPONSE_HANDLER
-					? "resolved-response-model"
-					: `resolved-${modelType}`,
-		} as Partial<IAgentRuntime>);
+  it("uses the runtime resolver when available", async () => {
+    const runtime = makeRuntime({}, {
+      resolveProviderModelString: (modelType: string) =>
+        modelType === ModelType.RESPONSE_HANDLER
+          ? "resolved-response-model"
+          : `resolved-${modelType}`,
+    } as Partial<IAgentRuntime>);
 
-		const result = await runtimeModelContextProvider.get(
-			runtime,
-			makeMessage("which provider powers the agent right now?"),
-			{} as never,
-		);
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      makeMessage("which provider powers the agent right now?"),
+      {} as never,
+    );
 
-		expect(result.data?.responseHandlerModel).toBe("resolved-response-model");
-		expect(result.text).toContain(
-			"Action planner model: resolved-ACTION_PLANNER",
-		);
-	});
+    expect(result.data?.responseHandlerModel).toBe("resolved-response-model");
+    expect(result.text).toContain(
+      "Action planner model: resolved-ACTION_PLANNER",
+    );
+  });
 
-	it("stays silent for unrelated live-data questions", async () => {
-		const runtime = makeRuntime({
-			OPENAI_LARGE_MODEL: "gpt-oss-120b",
-			ELIZA_DEFAULT_AGENT_TYPE: "opencode",
-		});
+  it("resolves codex-cli slots to CODEX_MODEL from env (getSetting hides env vars)", async () => {
+    // codex-cli registers every slot against one CODEX_MODEL rather than the
+    // per-slot *_MODEL keys, and CODEX_MODEL is an ENV var getSetting doesn't
+    // expose — so without the env fallback the slot rendered its raw name.
+    const runtime = makeRuntime({}, {
+      models: new Map([
+        [ModelType.RESPONSE_HANDLER, [{ provider: "codex-cli" }]],
+        [ModelType.ACTION_PLANNER, [{ provider: "codex-cli" }]],
+      ]),
+    } as Partial<IAgentRuntime>);
 
-		const result = await runtimeModelContextProvider.get(
-			runtime,
-			makeMessage("what is the current BTC price in USD?"),
-			{} as never,
-		);
+    const prev = process.env.CODEX_MODEL;
+    process.env.CODEX_MODEL = "gpt-5.5";
+    try {
+      const result = await runtimeModelContextProvider.get(
+        runtime,
+        makeMessage("what model are you using?"),
+        {} as never,
+      );
+      expect(result.text).toContain("Response handler model: gpt-5.5");
+      expect(result.data?.responseHandlerModel).toBe("gpt-5.5");
+      expect(result.text).not.toContain("RESPONSE_HANDLER");
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_MODEL;
+      else process.env.CODEX_MODEL = prev;
+    }
+  });
 
-		expect(result.text).toBe("");
-		expect(result.data).toEqual({});
-	});
+  it("stays silent for unrelated live-data questions", async () => {
+    const runtime = makeRuntime({
+      OPENAI_LARGE_MODEL: "gpt-oss-120b",
+      ELIZA_DEFAULT_AGENT_TYPE: "opencode",
+    });
 
-	it("stays silent for sub-agent completion transcripts", async () => {
-		const runtime = makeRuntime({
-			OPENAI_LARGE_MODEL: "gpt-oss-120b",
-			ELIZA_DEFAULT_AGENT_TYPE: "opencode",
-		});
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      makeMessage("what is the current BTC price in USD?"),
+      {} as never,
+    );
 
-		const result = await runtimeModelContextProvider.get(
-			runtime,
-			makeMessage(
-				"[sub-agent: Build a static web app (opencode) — task_complete]\nCreated files and verified https://example.test/apps/demo/",
-				{
-					source: "sub_agent",
-					metadata: { subAgent: true, subAgentEvent: "task_complete" },
-				},
-			),
-			{} as never,
-		);
+    expect(result.text).toBe("");
+    expect(result.data).toEqual({});
+  });
 
-		expect(result.text).toBe("");
-		expect(result.data).toEqual({});
-	});
+  it("stays silent for sub-agent completion transcripts", async () => {
+    const runtime = makeRuntime({
+      OPENAI_LARGE_MODEL: "gpt-oss-120b",
+      ELIZA_DEFAULT_AGENT_TYPE: "opencode",
+    });
+
+    const result = await runtimeModelContextProvider.get(
+      runtime,
+      makeMessage(
+        "[sub-agent: Build a static web app (opencode) — task_complete]\nCreated files and verified https://example.test/apps/demo/",
+        {
+          source: "sub_agent",
+          metadata: { subAgent: true, subAgentEvent: "task_complete" },
+        },
+      ),
+      {} as never,
+    );
+
+    expect(result.text).toBe("");
+    expect(result.data).toEqual({});
+  });
 });

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
@@ -1,304 +1,327 @@
 import type {
-	IAgentRuntime,
-	Memory,
-	ModelTypeName,
-	Provider,
+  IAgentRuntime,
+  Memory,
+  ModelTypeName,
+  Provider,
 } from "../../../types/index.ts";
 import { getModelFallbackChain, ModelType } from "../../../types/model.ts";
+import { readEnv } from "../../../utils/read-env.ts";
 
 type RuntimeWithModelHelpers = IAgentRuntime & {
-	resolveProviderModelString?: (
-		resolvedModelType: string,
-		optionsModel?: string,
-		effectiveModelId?: string,
-	) => string;
-	models?: Map<string, Array<{ provider?: string }>>;
+  resolveProviderModelString?: (
+    resolvedModelType: string,
+    optionsModel?: string,
+    effectiveModelId?: string,
+  ) => string;
+  models?: Map<string, Array<{ provider?: string }>>;
 };
 
 const MODEL_SETTING_SUFFIX: Record<string, string> = {
-	[ModelType.TEXT_NANO]: "NANO_MODEL",
-	[ModelType.TEXT_SMALL]: "SMALL_MODEL",
-	[ModelType.TEXT_MEDIUM]: "MEDIUM_MODEL",
-	[ModelType.TEXT_LARGE]: "LARGE_MODEL",
-	[ModelType.TEXT_MEGA]: "MEGA_MODEL",
-	[ModelType.RESPONSE_HANDLER]: "RESPONSE_HANDLER_MODEL",
-	[ModelType.ACTION_PLANNER]: "ACTION_PLANNER_MODEL",
-	[ModelType.TEXT_REASONING_SMALL]: "REASONING_SMALL_MODEL",
-	[ModelType.TEXT_REASONING_LARGE]: "REASONING_LARGE_MODEL",
-	[ModelType.TEXT_COMPLETION]: "COMPLETION_MODEL",
+  [ModelType.TEXT_NANO]: "NANO_MODEL",
+  [ModelType.TEXT_SMALL]: "SMALL_MODEL",
+  [ModelType.TEXT_MEDIUM]: "MEDIUM_MODEL",
+  [ModelType.TEXT_LARGE]: "LARGE_MODEL",
+  [ModelType.TEXT_MEGA]: "MEGA_MODEL",
+  [ModelType.RESPONSE_HANDLER]: "RESPONSE_HANDLER_MODEL",
+  [ModelType.ACTION_PLANNER]: "ACTION_PLANNER_MODEL",
+  [ModelType.TEXT_REASONING_SMALL]: "REASONING_SMALL_MODEL",
+  [ModelType.TEXT_REASONING_LARGE]: "REASONING_LARGE_MODEL",
+  [ModelType.TEXT_COMPLETION]: "COMPLETION_MODEL",
 };
 
 const MODEL_PROVIDER_PREFIXES = ["OLLAMA_", "OPENAI_", "ANTHROPIC_", ""];
 const MODEL_CONTEXT_TERMS = new Set([
-	"model",
-	"models",
-	"llm",
-	"provider",
-	"providers",
-	"gpt",
-	"claude",
-	"sonnet",
+  "model",
+  "models",
+  "llm",
+  "provider",
+  "providers",
+  "gpt",
+  "claude",
+  "sonnet",
 ]);
 const REQUEST_CONTEXT_TERMS = new Set([
-	"what",
-	"which",
-	"who",
-	"how",
-	"tell",
-	"show",
-	"list",
-	"name",
-	"identify",
+  "what",
+  "which",
+  "who",
+  "how",
+  "tell",
+  "show",
+  "list",
+  "name",
+  "identify",
 ]);
 const SELF_MODEL_CONTEXT_TERMS = new Set([
-	"you",
-	"your",
-	"yours",
-	"agent",
-	"assistant",
-	"bot",
-	"runtime",
-	"system",
-	"current",
-	"using",
-	"running",
-	"powered",
-	"configured",
-	"default",
+  "you",
+  "your",
+  "yours",
+  "agent",
+  "assistant",
+  "bot",
+  "runtime",
+  "system",
+  "current",
+  "using",
+  "running",
+  "powered",
+  "configured",
+  "default",
 ]);
 const CODING_AGENT_CONTEXT_TERMS = new Set([
-	"opencode",
-	"codex",
-	"claude",
-	"gemini",
-	"aider",
+  "opencode",
+  "codex",
+  "claude",
+  "gemini",
+  "aider",
 ]);
 
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
-	const value = runtime.getSetting(key);
-	if (typeof value !== "string") return undefined;
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
+  const value = runtime.getSetting(key);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  // Many runtime model knobs (CODEX_MODEL, ELIZA_DEFAULT_AGENT_TYPE, opencode
+  // model/base-url) are provided as ENV vars, which `getSetting` does not
+  // expose — without this fallback every model slot rendered its raw slot name
+  // ("TEXT_LARGE") and "what model are you using" leaked internals instead of
+  // the real model (gpt-5.5 via codex).
+  const fromEnv = readEnv(key)?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
 }
 
 function fallbackModelString(
-	runtime: IAgentRuntime,
-	modelType: ModelTypeName,
+  runtime: IAgentRuntime,
+  modelType: ModelTypeName,
 ): string {
-	for (const candidate of getModelFallbackChain(modelType)) {
-		const suffix = MODEL_SETTING_SUFFIX[candidate];
-		if (!suffix) continue;
-		for (const prefix of MODEL_PROVIDER_PREFIXES) {
-			const configured = readSetting(runtime, `${prefix}${suffix}`);
-			if (configured) return configured;
-		}
-	}
-	return String(modelType);
+  for (const candidate of getModelFallbackChain(modelType)) {
+    const suffix = MODEL_SETTING_SUFFIX[candidate];
+    if (!suffix) continue;
+    for (const prefix of MODEL_PROVIDER_PREFIXES) {
+      const configured = readSetting(runtime, `${prefix}${suffix}`);
+      if (configured) return configured;
+    }
+  }
+  return String(modelType);
 }
 
 function configuredModelString(
-	runtime: RuntimeWithModelHelpers,
-	modelType: ModelTypeName,
+  runtime: RuntimeWithModelHelpers,
+  modelType: ModelTypeName,
 ): string {
-	if (typeof runtime.resolveProviderModelString === "function") {
-		return runtime.resolveProviderModelString(modelType);
-	}
-	return fallbackModelString(runtime, modelType);
+  const resolved =
+    typeof runtime.resolveProviderModelString === "function"
+      ? runtime.resolveProviderModelString(modelType)
+      : fallbackModelString(runtime, modelType);
+  // Subscription backends (codex) register every model slot against one
+  // underlying model configured via their own setting (CODEX_MODEL) rather
+  // than the per-slot *_MODEL keys the resolver checks — so the resolver
+  // returns the raw slot name ("TEXT_LARGE"). Only fall back to the codex
+  // model when that slot is actually served by the codex-cli adapter, so a
+  // stale CODEX_MODEL env on a non-codex backend can't mislabel the slot.
+  if (!resolved || resolved === String(modelType)) {
+    const provider = registeredProviderFor(runtime, modelType);
+    if (provider === "codex-cli") {
+      const codexModel = readSetting(runtime, "CODEX_MODEL");
+      if (codexModel) return codexModel;
+    }
+  }
+  return resolved;
 }
 
 function registeredProviderFor(
-	runtime: RuntimeWithModelHelpers,
-	modelType: ModelTypeName,
+  runtime: RuntimeWithModelHelpers,
+  modelType: ModelTypeName,
 ): string | undefined {
-	for (const candidate of getModelFallbackChain(modelType)) {
-		const provider = runtime.models?.get(candidate)?.[0]?.provider?.trim();
-		if (provider) return provider;
-	}
-	return undefined;
+  for (const candidate of getModelFallbackChain(modelType)) {
+    const provider = runtime.models?.get(candidate)?.[0]?.provider?.trim();
+    if (provider) return provider;
+  }
+  return undefined;
 }
 
 function optionalLine(label: string, value: string | undefined): string | null {
-	return value ? `- ${label}: ${value}` : null;
+  return value ? `- ${label}: ${value}` : null;
 }
 
 function endpointHost(value: string | undefined): string | undefined {
-	if (!value) return undefined;
-	try {
-		return new URL(value).host;
-	} catch {
-		return undefined;
-	}
+  if (!value) return undefined;
+  try {
+    return new URL(value).host;
+  } catch {
+    return undefined;
+  }
 }
 
 function providerEndpointHost(
-	runtime: IAgentRuntime,
-	provider: string | undefined,
+  runtime: IAgentRuntime,
+  provider: string | undefined,
 ): string | undefined {
-	if (!provider) return undefined;
-	const prefix = provider
-		.trim()
-		.toUpperCase()
-		.replace(/[^A-Z0-9]+/g, "_")
-		.replace(/^_+|_+$/g, "");
-	if (!prefix) return undefined;
-	return endpointHost(readSetting(runtime, `${prefix}_BASE_URL`));
+  if (!provider) return undefined;
+  const prefix = provider
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!prefix) return undefined;
+  return endpointHost(readSetting(runtime, `${prefix}_BASE_URL`));
 }
 
 function tokenize(text: string): Set<string> {
-	return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+  return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
 }
 
 function shouldRenderRuntimeModelContext(message: Memory): boolean {
-	if (
-		message.content.source === "sub_agent" ||
-		(message.content.metadata &&
-			typeof message.content.metadata === "object" &&
-			(message.content.metadata as Record<string, unknown>).subAgent === true)
-	) {
-		return false;
-	}
+  if (
+    message.content.source === "sub_agent" ||
+    (message.content.metadata &&
+      typeof message.content.metadata === "object" &&
+      (message.content.metadata as Record<string, unknown>).subAgent === true)
+  ) {
+    return false;
+  }
 
-	const text =
-		typeof message.content.text === "string" ? message.content.text : "";
-	const tokens = tokenize(text);
-	if (tokens.size === 0) return false;
+  const text =
+    typeof message.content.text === "string" ? message.content.text : "";
+  const tokens = tokenize(text);
+  if (tokens.size === 0) return false;
 
-	const hasRequestCue =
-		text.includes("?") ||
-		[...REQUEST_CONTEXT_TERMS].some((term) => tokens.has(term));
-	if (!hasRequestCue) return false;
+  const hasRequestCue =
+    text.includes("?") ||
+    [...REQUEST_CONTEXT_TERMS].some((term) => tokens.has(term));
+  if (!hasRequestCue) return false;
 
-	const hasModelTerm = [...MODEL_CONTEXT_TERMS].some((term) =>
-		tokens.has(term),
-	);
-	const hasSelfTerm = [...SELF_MODEL_CONTEXT_TERMS].some((term) =>
-		tokens.has(term),
-	);
-	if (hasModelTerm && hasSelfTerm) return true;
+  const hasModelTerm = [...MODEL_CONTEXT_TERMS].some((term) =>
+    tokens.has(term),
+  );
+  const hasSelfTerm = [...SELF_MODEL_CONTEXT_TERMS].some((term) =>
+    tokens.has(term),
+  );
+  if (hasModelTerm && hasSelfTerm) return true;
 
-	const hasCodingAgentTerm =
-		(tokens.has("coding") && tokens.has("agent")) ||
-		(tokens.has("sub") && tokens.has("agent")) ||
-		[...CODING_AGENT_CONTEXT_TERMS].some((term) => tokens.has(term));
-	return hasCodingAgentTerm && hasSelfTerm;
+  const hasCodingAgentTerm =
+    (tokens.has("coding") && tokens.has("agent")) ||
+    (tokens.has("sub") && tokens.has("agent")) ||
+    [...CODING_AGENT_CONTEXT_TERMS].some((term) => tokens.has(term));
+  return hasCodingAgentTerm && hasSelfTerm;
 }
 
 export const runtimeModelContextProvider: Provider = {
-	name: "RUNTIME_MODEL_CONTEXT",
-	description:
-		"Current runtime model configuration for answering questions about which model/provider powers the agent.",
-	descriptionCompressed:
-		"Current runtime model slots and coding sub-agent model configuration.",
-	dynamic: true,
-	position: -8,
-	contexts: ["general"],
-	contextGate: { anyOf: ["general"] },
-	cacheStable: false,
-	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
-	relevanceKeywords: [
-		"model",
-		"provider",
-		"llm",
-		"gpt",
-		"claude",
-		"sonnet",
-		"opencode",
-	],
+  name: "RUNTIME_MODEL_CONTEXT",
+  description:
+    "Current runtime model configuration for answering questions about which model/provider powers the agent.",
+  descriptionCompressed:
+    "Current runtime model slots and coding sub-agent model configuration.",
+  dynamic: true,
+  position: -8,
+  contexts: ["general"],
+  contextGate: { anyOf: ["general"] },
+  cacheStable: false,
+  cacheScope: "turn",
+  roleGate: { minRole: "USER" },
+  relevanceKeywords: [
+    "model",
+    "provider",
+    "llm",
+    "gpt",
+    "claude",
+    "sonnet",
+    "opencode",
+  ],
 
-	get: async (runtime: IAgentRuntime, message: Memory) => {
-		if (!shouldRenderRuntimeModelContext(message)) {
-			return { text: "", values: {}, data: {} };
-		}
+  get: async (runtime: IAgentRuntime, message: Memory) => {
+    if (!shouldRenderRuntimeModelContext(message)) {
+      return { text: "", values: {}, data: {} };
+    }
 
-		const runtimeWithModels = runtime as RuntimeWithModelHelpers;
-		const responseHandlerModel = configuredModelString(
-			runtimeWithModels,
-			ModelType.RESPONSE_HANDLER,
-		);
-		const actionPlannerModel = configuredModelString(
-			runtimeWithModels,
-			ModelType.ACTION_PLANNER,
-		);
-		const textLargeModel = configuredModelString(
-			runtimeWithModels,
-			ModelType.TEXT_LARGE,
-		);
-		const textSmallModel = configuredModelString(
-			runtimeWithModels,
-			ModelType.TEXT_SMALL,
-		);
-		const defaultAgentType = readSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE");
-		const opencodeModel =
-			readSetting(runtime, "ELIZA_OPENCODE_MODEL_POWERFUL") ??
-			readSetting(runtime, "ELIZA_OPENCODE_MODEL_FAST");
-		const opencodeEndpointHost = endpointHost(
-			readSetting(runtime, "ELIZA_OPENCODE_BASE_URL"),
-		);
+    const runtimeWithModels = runtime as RuntimeWithModelHelpers;
+    const responseHandlerModel = configuredModelString(
+      runtimeWithModels,
+      ModelType.RESPONSE_HANDLER,
+    );
+    const actionPlannerModel = configuredModelString(
+      runtimeWithModels,
+      ModelType.ACTION_PLANNER,
+    );
+    const textLargeModel = configuredModelString(
+      runtimeWithModels,
+      ModelType.TEXT_LARGE,
+    );
+    const textSmallModel = configuredModelString(
+      runtimeWithModels,
+      ModelType.TEXT_SMALL,
+    );
+    const defaultAgentType = readSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE");
+    const opencodeModel =
+      readSetting(runtime, "ELIZA_OPENCODE_MODEL_POWERFUL") ??
+      readSetting(runtime, "ELIZA_OPENCODE_MODEL_FAST");
+    const opencodeEndpointHost = endpointHost(
+      readSetting(runtime, "ELIZA_OPENCODE_BASE_URL"),
+    );
 
-		const responseHandlerProvider = registeredProviderFor(
-			runtimeWithModels,
-			ModelType.RESPONSE_HANDLER,
-		);
-		const actionPlannerProvider = registeredProviderFor(
-			runtimeWithModels,
-			ModelType.ACTION_PLANNER,
-		);
-		const responseHandlerEndpointHost = providerEndpointHost(
-			runtime,
-			responseHandlerProvider,
-		);
-		const actionPlannerEndpointHost = providerEndpointHost(
-			runtime,
-			actionPlannerProvider,
-		);
+    const responseHandlerProvider = registeredProviderFor(
+      runtimeWithModels,
+      ModelType.RESPONSE_HANDLER,
+    );
+    const actionPlannerProvider = registeredProviderFor(
+      runtimeWithModels,
+      ModelType.ACTION_PLANNER,
+    );
+    const responseHandlerEndpointHost = providerEndpointHost(
+      runtime,
+      responseHandlerProvider,
+    );
+    const actionPlannerEndpointHost = providerEndpointHost(
+      runtime,
+      actionPlannerProvider,
+    );
 
-		const lines = [
-			"# Runtime Model Context",
-			"Use these runtime facts when asked what model, provider, or coding agent is currently in use. Provider adapter names may identify compatibility layers; endpoint hosts identify the configured backend when present. Do not infer a different model or provider from training data or old chat history.",
-			`- Response handler model: ${responseHandlerModel}`,
-			`- Action planner model: ${actionPlannerModel}`,
-			`- Large text model: ${textLargeModel}`,
-			`- Small text model: ${textSmallModel}`,
-			optionalLine(
-				"Response handler provider adapter",
-				responseHandlerProvider,
-			),
-			optionalLine(
-				"Response handler endpoint host",
-				responseHandlerEndpointHost,
-			),
-			optionalLine("Action planner provider adapter", actionPlannerProvider),
-			optionalLine("Action planner endpoint host", actionPlannerEndpointHost),
-			optionalLine("Default coding sub-agent", defaultAgentType),
-			optionalLine("OpenCode model", opencodeModel),
-			optionalLine("OpenCode endpoint host", opencodeEndpointHost),
-		].filter((line): line is string => line !== null);
+    const lines = [
+      "# Runtime Model Context",
+      "Use these runtime facts when asked what model, provider, or coding agent is currently in use. Provider adapter names may identify compatibility layers; endpoint hosts identify the configured backend when present. Do not infer a different model or provider from training data or old chat history.",
+      `- Response handler model: ${responseHandlerModel}`,
+      `- Action planner model: ${actionPlannerModel}`,
+      `- Large text model: ${textLargeModel}`,
+      `- Small text model: ${textSmallModel}`,
+      optionalLine(
+        "Response handler provider adapter",
+        responseHandlerProvider,
+      ),
+      optionalLine(
+        "Response handler endpoint host",
+        responseHandlerEndpointHost,
+      ),
+      optionalLine("Action planner provider adapter", actionPlannerProvider),
+      optionalLine("Action planner endpoint host", actionPlannerEndpointHost),
+      optionalLine("Default coding sub-agent", defaultAgentType),
+      optionalLine("OpenCode model", opencodeModel),
+      optionalLine("OpenCode endpoint host", opencodeEndpointHost),
+    ].filter((line): line is string => line !== null);
 
-		return {
-			text: lines.join("\n"),
-			values: {
-				responseHandlerModel,
-				actionPlannerModel,
-				textLargeModel,
-				textSmallModel,
-				defaultAgentType,
-				opencodeModel,
-				opencodeEndpointHost,
-			},
-			data: {
-				responseHandlerModel,
-				actionPlannerModel,
-				textLargeModel,
-				textSmallModel,
-				responseHandlerProvider,
-				responseHandlerEndpointHost,
-				actionPlannerProvider,
-				actionPlannerEndpointHost,
-				defaultAgentType,
-				opencodeModel,
-				opencodeEndpointHost,
-			},
-		};
-	},
+    return {
+      text: lines.join("\n"),
+      values: {
+        responseHandlerModel,
+        actionPlannerModel,
+        textLargeModel,
+        textSmallModel,
+        defaultAgentType,
+        opencodeModel,
+        opencodeEndpointHost,
+      },
+      data: {
+        responseHandlerModel,
+        actionPlannerModel,
+        textLargeModel,
+        textSmallModel,
+        responseHandlerProvider,
+        responseHandlerEndpointHost,
+        actionPlannerProvider,
+        actionPlannerEndpointHost,
+        defaultAgentType,
+        opencodeModel,
+        opencodeEndpointHost,
+      },
+    };
+  },
 };


### PR DESCRIPTION
## Problem

The runtime-model-context provider answers *"what model are you using?"* from the runtime's model slots. Two gaps made it leak internal slot names instead of the real model:

1. `readSetting` only consulted `getSetting`, which does **not** expose env vars. Many model knobs (`CODEX_MODEL`, opencode model/base-url, `ELIZA_DEFAULT_AGENT_TYPE`) are provided as env, so the lookups came back empty.
2. Subscription backends (codex-cli) register **every** model slot against one underlying model (`CODEX_MODEL`) rather than the per-slot `*_MODEL` keys the resolver checks — so the resolver returned the raw slot name (`RESPONSE_HANDLER` / `TEXT_LARGE`).

Net effect: "what model are you using" rendered raw slot names instead of e.g. `gpt-5.5`.

## Fix

- `readSetting` falls back to `readEnv(key)` (the canonical env reader) when `getSetting` is empty.
- When a slot resolves to its own name **and** that slot is actually served by the `codex-cli` adapter (checked via the existing `registeredProviderFor`), fall back to `CODEX_MODEL`. The provider gate means a stale `CODEX_MODEL` on a non-codex backend cannot mislabel the slot.

## Test

Adds `resolves codex-cli slots to CODEX_MODEL from env` to `runtimeModelContext.test.ts`. Suite: **5/5 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
