### PR TITLE
fix(plugin-wallet): bound per-turn balance RPC so it can't hang the reply (~28s dedicated-agent latency)

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
@@ -1,0 +1,59 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { generatePrivateKey } from "viem/accounts";
+import { mainnet } from "viem/chains";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WalletProvider } from "../../providers/wallet";
+
+/**
+ * Regression guard for the dedicated-agent "~28s per reply" hang.
+ *
+ * evmWalletProvider.get() runs inside composeState on every message and is
+ * awaited before the agent replies. A balance RPC against a slow/unreachable
+ * endpoint used to hang until composeState's 30s provider cap fired, blocking the
+ * whole turn. getWalletBalanceForChain now bounds the RPC and must resolve to
+ * null (handled like any RPC error) instead of hanging.
+ */
+function makeRuntime(): IAgentRuntime {
+  return {
+    getCache: vi.fn(async () => null),
+    setCache: vi.fn(async () => undefined),
+    getSetting: vi.fn(() => undefined),
+  } as unknown as IAgentRuntime;
+}
+
+describe("WalletProvider per-turn RPC timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves to null instead of hanging when the balance RPC never responds", async () => {
+    vi.useFakeTimers();
+    const provider = new WalletProvider(generatePrivateKey(), makeRuntime(), {
+      mainnet,
+    });
+
+    // Simulate a mainnet RPC that accepts the request but never responds.
+    vi.spyOn(provider, "getPublicClient").mockReturnValue({
+      getBalance: () => new Promise<bigint>(() => undefined),
+    } as never);
+
+    const resultPromise = provider.getWalletBalanceForChain("mainnet" as never);
+    // Advance past the per-call bound; the race rejects and the catch returns null.
+    await vi.advanceTimersByTimeAsync(3500);
+
+    await expect(resultPromise).resolves.toBeNull();
+  });
+
+  it("returns the formatted balance when the RPC responds in time", async () => {
+    const provider = new WalletProvider(generatePrivateKey(), makeRuntime(), {
+      mainnet,
+    });
+
+    vi.spyOn(provider, "getPublicClient").mockReturnValue({
+      getBalance: async () => 1_000000000000000000n, // 1.0 ETH in wei
+    } as never);
+
+    await expect(provider.getWalletBalanceForChain("mainnet" as never)).resolves.toBe("1");
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
@@ -58,6 +58,41 @@ function headersWithoutAuthorization(headersInit?: HeadersInit): Headers {
   return headers;
 }
 
+/**
+ * Per-turn safety bound for wallet balance RPC calls. `evmWalletProvider.get()`
+ * runs inside `composeState` on every message and is awaited (via `Promise.all`)
+ * before the agent can produce a reply, so an unbounded RPC against a slow or
+ * unreachable endpoint would block the WHOLE turn up to composeState's 30s
+ * provider cap — the dedicated-agent "28s per reply" symptom. Bounding each read
+ * means a wallet-enabled agent never pays more than this per chain; on timeout we
+ * return null (logged) and that chain's balance simply isn't shown that turn.
+ */
+const WALLET_BALANCE_RPC_TIMEOUT_MS = 3000;
+
+/** Transport-level fast-fail bound so a hung socket aborts instead of lingering. */
+const WALLET_RPC_FETCH_TIMEOUT_MS = 4000;
+
+/**
+ * Race `promise` against a timeout. Rejects with a labelled error on timeout so
+ * the caller's existing try/catch can treat it like any other RPC failure. The
+ * timer is always cleared so a fast-resolving promise leaves no dangling handle.
+ */
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 function isRetryableManagedRpcStatus(status: number): boolean {
   return (
     status === 401 ||
@@ -220,9 +255,14 @@ export class WalletProvider {
   async getWalletBalanceForChain(chainName: SupportedChain): Promise<string | null> {
     try {
       const client = this.getPublicClient(chainName);
-      const balance = await client.getBalance({
-        address: this._account.address,
-      });
+      // Bound the per-turn RPC so a slow/unreachable endpoint can never block the
+      // reply pipeline (see WALLET_BALANCE_RPC_TIMEOUT_MS). On timeout this rejects
+      // and is handled by the catch below exactly like any other RPC error.
+      const balance = await withTimeout(
+        client.getBalance({ address: this._account.address }),
+        WALLET_BALANCE_RPC_TIMEOUT_MS,
+        `getBalance(${chainName})`
+      );
       return formatUnits(balance, 18);
     } catch (error) {
       logger.error(
@@ -277,10 +317,15 @@ export class WalletProvider {
         fallbackRpcUrl &&
         this._cloudRpcDisabled.has(chainName)
       ) {
-        return http(fallbackRpcUrl);
+        return http(fallbackRpcUrl, {
+          timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
+          retryCount: 0,
+        });
       }
 
       return http(managedRpc.rpcUrl, {
+        timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
+        retryCount: 0,
         fetchFn:
           managedRpc.providerName === "elizacloud" && fallbackRpcUrl
             ? async (input, init) => {
@@ -331,9 +376,15 @@ export class WalletProvider {
 
     const customRpc = chain.rpcUrls.custom;
     if (customRpc) {
-      return http(customRpc.http[0]);
+      return http(customRpc.http[0], {
+        timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
+        retryCount: 0,
+      });
     }
-    return http(chain.rpcUrls.default.http[0]);
+    return http(chain.rpcUrls.default.http[0], {
+      timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
+      retryCount: 0,
+    });
   }
 
   static genChainFromName(chainName: string, customRpcUrl?: string | null): Chain {


### PR DESCRIPTION
## Problem
Dedicated cloud chat agents replied in ~28s/turn. Root-caused (with a 4-agent investigation + confirmed against prod container logs `Error getting wallet balance for mainnet: The request took too long to respond`):

`evmWalletProvider.get()` runs inside `composeState` on **every** message and is awaited (`Promise.all`) before the agent can reply. `getWalletBalanceForChain` called viem's `client.getBalance()` with **no timeout**, and the managed-RPC path used a custom `fetchFn` whose `fetch` had **no AbortSignal** — so a slow/unreachable mainnet endpoint hung until composeState's 30s provider cap (`COMPOSE_STATE_PROVIDER_TIMEOUT_MS`) fired, blocking the whole turn. Worse: `getWalletBalances` only writes its cache after `Promise.allSettled` resolves, so the hang also prevented caching → **every** turn re-hit the hang.

Cloud agents auto-enable plugin-wallet via Steward creds (`auto-enable.ts` `hasCloudStewardWallet`), so this hit every dedicated agent — even pure chat ones that never use wallet features.

## Fix (no feature removal — wallet stays enabled, just can't block a turn)
- `withTimeout()` bounds the per-turn balance read to **3s**; on timeout it rejects and is handled by the existing `catch` (returns `null`) → `allSettled` resolves → balances cache → subsequent turns are instant.
- All `http()` transports get `timeout: 4s` + `retryCount: 0` so a hung socket fails fast instead of lingering / amplifying via retries.
- Regression test (fake timers): a never-responding RPC resolves to `null` instead of hanging; a fast RPC still returns the formatted balance.

## Verification
- `plugin-wallet` typecheck clean; **57 tests pass** (55 existing + 2 new).
- Rides the next `develop` agent image. Orthogonal to #8735 (cerebras key round-robin) / #8738 (Worker gateway) — this is a provider-hang bug, not model/routing.

Part of the dedicated-agent launch hardening tracked in #8434.