### PR TITLE
fix(core): bound the redundant successful-tool-call planner loop

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -6,8 +6,8 @@ import { parsePlannerOutput, runPlannerLoop } from "../planner-loop";
 import type { RecordedStage, TrajectoryRecorder } from "../trajectory-recorder";
 
 describe("v5 planner loop skeleton", () => {
-	it("parses planner tool calls", () => {
-		const output = parsePlannerOutput(`{
+  it("parses planner tool calls", () => {
+    const output = parsePlannerOutput(`{
   "thought": "Fetch state.",
   "toolCalls": [
     {
@@ -17,16 +17,16 @@ describe("v5 planner loop skeleton", () => {
   ]
 }`);
 
-		expect(output.toolCalls).toEqual([
-			{
-				name: "LOOKUP",
-				params: { query: "status" },
-			},
-		]);
-	});
+    expect(output.toolCalls).toEqual([
+      {
+        name: "LOOKUP",
+        params: { query: "status" },
+      },
+    ]);
+  });
 
-	it("parses OpenAI-compatible function tool call records from text", () => {
-		const output = parsePlannerOutput(`{
+  it("parses OpenAI-compatible function tool call records from text", () => {
+    const output = parsePlannerOutput(`{
   "toolCalls": [
     {
       "function": "AUTOFILL",
@@ -35,1670 +35,1719 @@ describe("v5 planner loop skeleton", () => {
   ]
 }`);
 
-		expect(output.toolCalls).toEqual([
-			{
-				name: "AUTOFILL",
-				params: { domain: "github.com", field: "password" },
-			},
-		]);
-	});
+    expect(output.toolCalls).toEqual([
+      {
+        name: "AUTOFILL",
+        params: { domain: "github.com", field: "password" },
+      },
+    ]);
+  });
 
-	it("parses local strict planner JSON as a tool call", () => {
-		const output = parsePlannerOutput(
-			`{"action":"SEND_MESSAGE","parameters":{"channelId":"c1","text":"hi"},"thought":"replying"}`,
-		);
+  it("parses local strict planner JSON as a tool call", () => {
+    const output = parsePlannerOutput(
+      `{"action":"SEND_MESSAGE","parameters":{"channelId":"c1","text":"hi"},"thought":"replying"}`,
+    );
 
-		expect(output.thought).toBe("replying");
-		expect(output.toolCalls).toEqual([
-			{
-				name: "SEND_MESSAGE",
-				params: { channelId: "c1", text: "hi" },
-			},
-		]);
-	});
+    expect(output.thought).toBe("replying");
+    expect(output.toolCalls).toEqual([
+      {
+        name: "SEND_MESSAGE",
+        params: { channelId: "c1", text: "hi" },
+      },
+    ]);
+  });
 
-	it("preserves primitive planner parameters for enum short-form expansion", () => {
-		const output = parsePlannerOutput(
-			`{"action":"SET_MODE","parameters":"fast","thought":"switching"}`,
-		);
+  it("preserves primitive planner parameters for enum short-form expansion", () => {
+    const output = parsePlannerOutput(
+      `{"action":"SET_MODE","parameters":"fast","thought":"switching"}`,
+    );
 
-		expect(output.toolCalls).toEqual([
-			{
-				name: "SET_MODE",
-				params: { parameters: "fast" },
-			},
-		]);
-	});
+    expect(output.toolCalls).toEqual([
+      {
+        name: "SET_MODE",
+        params: { parameters: "fast" },
+      },
+    ]);
+  });
 
-	it("treats non-JSON planner text as a terminal message", () => {
-		const output = parsePlannerOutput("Done from the model.");
+  it("treats non-JSON planner text as a terminal message", () => {
+    const output = parsePlannerOutput("Done from the model.");
 
-		expect(output.toolCalls).toEqual([]);
-		expect(output.messageToUser).toBe("Done from the model.");
-	});
+    expect(output.toolCalls).toEqual([]);
+    expect(output.messageToUser).toBe("Done from the model.");
+  });
 
-	it("recovers a non-terminal call the native extraction dropped after REPLY", () => {
-		// gpt-oss narrated two `{type, args}` objects in the text channel, but
-		// the provider's native extraction only surfaced the first — the
-		// terminal REPLY ack — so the real action would otherwise be lost.
-		const output = parsePlannerOutput({
-			text:
-				'{"type":"REPLY","args":{"text":"On it."}}\n' +
-				'{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent","agentType":"opencode"}}',
-			toolCalls: [{ id: "tc1", name: "REPLY", arguments: { text: "On it." } }],
-		});
+  it("recovers a non-terminal call the native extraction dropped after REPLY", () => {
+    // gpt-oss narrated two `{type, args}` objects in the text channel, but
+    // the provider's native extraction only surfaced the first — the
+    // terminal REPLY ack — so the real action would otherwise be lost.
+    const output = parsePlannerOutput({
+      text:
+        '{"type":"REPLY","args":{"text":"On it."}}\n' +
+        '{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent","agentType":"opencode"}}',
+      toolCalls: [{ id: "tc1", name: "REPLY", arguments: { text: "On it." } }],
+    });
 
-		expect(output.toolCalls.map((call) => call.name)).toEqual([
-			"REPLY",
-			"TASKS_SPAWN_AGENT",
-		]);
-		expect(output.toolCalls[1].params).toEqual({
-			action: "spawn_agent",
-			agentType: "opencode",
-		});
-		// The text was tool-call JSON, not prose — the reply comes from the
-		// REPLY call, never the raw JSON blob.
-		expect(output.messageToUser).toBe("On it.");
-	});
+    expect(output.toolCalls.map((call) => call.name)).toEqual([
+      "REPLY",
+      "TASKS_SPAWN_AGENT",
+    ]);
+    expect(output.toolCalls[1].params).toEqual({
+      action: "spawn_agent",
+      agentType: "opencode",
+    });
+    // The text was tool-call JSON, not prose — the reply comes from the
+    // REPLY call, never the raw JSON blob.
+    expect(output.messageToUser).toBe("On it.");
+  });
 
-	it("does not duplicate a call present in both the native and text channels", () => {
-		const output = parsePlannerOutput({
-			text: '{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent"}}',
-			toolCalls: [
-				{
-					id: "tc1",
-					name: "TASKS_SPAWN_AGENT",
-					arguments: { action: "spawn_agent" },
-				},
-			],
-		});
+  it("does not duplicate a call present in both the native and text channels", () => {
+    const output = parsePlannerOutput({
+      text: '{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent"}}',
+      toolCalls: [
+        {
+          id: "tc1",
+          name: "TASKS_SPAWN_AGENT",
+          arguments: { action: "spawn_agent" },
+        },
+      ],
+    });
 
-		expect(output.toolCalls.map((call) => call.name)).toEqual([
-			"TASKS_SPAWN_AGENT",
-		]);
-	});
+    expect(output.toolCalls.map((call) => call.name)).toEqual([
+      "TASKS_SPAWN_AGENT",
+    ]);
+  });
 
-	it("preserves same-name recovered calls when their parameters differ", () => {
-		const output = parsePlannerOutput({
-			text:
-				'{"type":"WRITE_FILE","args":{"path":"a.txt","contents":"a"}}' +
-				'{"type":"WRITE_FILE","args":{"path":"b.txt","contents":"b"}}',
-			toolCalls: [
-				{
-					id: "tc1",
-					name: "WRITE_FILE",
-					arguments: { path: "a.txt", contents: "a" },
-				},
-			],
-		});
+  it("preserves same-name recovered calls when their parameters differ", () => {
+    const output = parsePlannerOutput({
+      text:
+        '{"type":"WRITE_FILE","args":{"path":"a.txt","contents":"a"}}' +
+        '{"type":"WRITE_FILE","args":{"path":"b.txt","contents":"b"}}',
+      toolCalls: [
+        {
+          id: "tc1",
+          name: "WRITE_FILE",
+          arguments: { path: "a.txt", contents: "a" },
+        },
+      ],
+    });
 
-		expect(
-			output.toolCalls.map((call) => ({
-				name: call.name,
-				params: call.params,
-			})),
-		).toEqual([
-			{
-				name: "WRITE_FILE",
-				params: { path: "a.txt", contents: "a" },
-			},
-			{
-				name: "WRITE_FILE",
-				params: { path: "b.txt", contents: "b" },
-			},
-		]);
-	});
+    expect(
+      output.toolCalls.map((call) => ({
+        name: call.name,
+        params: call.params,
+      })),
+    ).toEqual([
+      {
+        name: "WRITE_FILE",
+        params: { path: "a.txt", contents: "a" },
+      },
+      {
+        name: "WRITE_FILE",
+        params: { path: "b.txt", contents: "b" },
+      },
+    ]);
+  });
 
-	it("recovers concatenated bare-object calls from a JSON string", () => {
-		const output = parsePlannerOutput(
-			'{"type":"REPLY","args":{"text":"On it."}}' +
-				'{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent"}}',
-		);
+  it("recovers concatenated bare-object calls from a JSON string", () => {
+    const output = parsePlannerOutput(
+      '{"type":"REPLY","args":{"text":"On it."}}' +
+        '{"type":"TASKS_SPAWN_AGENT","args":{"action":"spawn_agent"}}',
+    );
 
-		expect(output.toolCalls.map((call) => call.name)).toEqual([
-			"REPLY",
-			"TASKS_SPAWN_AGENT",
-		]);
-	});
+    expect(output.toolCalls.map((call) => call.name)).toEqual([
+      "REPLY",
+      "TASKS_SPAWN_AGENT",
+    ]);
+  });
 
-	it("instructs planners to use exposed tools for unresolved current work", () => {
-		expect(plannerTemplate).toContain(
-			"incomplete while user needs live/current/external data, filesystem/runtime state, command output, repo work, build, PR, deploy, verify, side effect, and exposed tool can try",
-		);
-		expect(plannerTemplate).toContain(
-			"attachments/memory/snippets do not replace explicit current run/check/fetch/inspect/build/deploy/verify/look up now",
-		);
-	});
+  it("instructs planners to use exposed tools for unresolved current work", () => {
+    expect(plannerTemplate).toContain(
+      "incomplete while user needs live/current/external data, filesystem/runtime state, command output, repo work, build, PR, deploy, verify, side effect, and exposed tool can try",
+    );
+    expect(plannerTemplate).toContain(
+      "attachments/memory/snippets do not replace explicit current run/check/fetch/inspect/build/deploy/verify/look up now",
+    );
+  });
 
-	it("forbids using SHELL as a fallback for chat-message search/recall", () => {
-		// Regression for elizaOS/eliza#7935: Stage 1 hinted
-		// candidateActions=["SEARCH_MESSAGES"], but no matching action was
-		// registered. The planner fell back to echo placeholders and grep
-		// commands, burning iterations without a real chat-history capability.
-		expect(plannerTemplate).toContain(
-			"SHELL is for filesystem/process work, not a fallback for chat-message search/recall",
-		);
-		expect(plannerTemplate).toContain(
-			"do not run shell greps, echo placeholders, or simulate the search",
-		);
-		expect(plannerTemplate).toContain(
-			"memory queries, or agent-history lookups",
-		);
-	});
+  it("forbids using SHELL as a fallback for chat-message search/recall", () => {
+    // Regression for elizaOS/eliza#7935: Stage 1 hinted
+    // candidateActions=["SEARCH_MESSAGES"], but no matching action was
+    // registered. The planner fell back to echo placeholders and grep
+    // commands, burning iterations without a real chat-history capability.
+    expect(plannerTemplate).toContain(
+      "SHELL is for filesystem/process work, not a fallback for chat-message search/recall",
+    );
+    expect(plannerTemplate).toContain(
+      "do not run shell greps, echo placeholders, or simulate the search",
+    );
+    expect(plannerTemplate).toContain(
+      "memory queries, or agent-history lookups",
+    );
+  });
 
-	it("forbids spawning coding sub-agents for chat-message recall tasks", () => {
-		expect(plannerTemplate).toContain(
-			"TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
-		);
-		expect(plannerTemplate).toContain(
-			"not a fallback for chat-message recall, memory queries, or agent-history lookups",
-		);
-		expect(plannerTemplate).toContain(
-			"routinely ends in sub-agent error/timeout",
-		);
-	});
+  it("forbids spawning coding sub-agents for chat-message recall tasks", () => {
+    expect(plannerTemplate).toContain(
+      "TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
+    );
+    expect(plannerTemplate).toContain(
+      "not a fallback for chat-message recall, memory queries, or agent-history lookups",
+    );
+    expect(plannerTemplate).toContain(
+      "routinely ends in sub-agent error/timeout",
+    );
+  });
 
-	it("forbids inventing tool workarounds for dead candidateActions hints", () => {
-		expect(plannerTemplate).toContain(
-			"candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
-		);
-		expect(plannerTemplate).toContain(
-			"do not invent SHELL/BROWSER/TASKS workarounds to fulfill it",
-		);
-		expect(plannerTemplate).toContain(
-			"placeholder echoes burn cost and produce no progress",
-		);
-	});
+  it("forbids inventing tool workarounds for dead candidateActions hints", () => {
+    expect(plannerTemplate).toContain(
+      "candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
+    );
+    expect(plannerTemplate).toContain(
+      "do not invent SHELL/BROWSER/TASKS workarounds to fulfill it",
+    );
+    expect(plannerTemplate).toContain(
+      "placeholder echoes burn cost and produce no progress",
+    );
+  });
 
-	it("forbids phantom in-flight investigative claims in messageToUser/REPLY (planner side)", () => {
-		// Live regression on 2026-05-26 in the milady deployment: user asked
-		// "look it up bitch" after the bot honestly declined a current-news
-		// question. Stage 1 routed simple=false + requiresTool=true with
-		// candidateActions=[WEB_SEARCH, SHELL]. The planner ran 4 SHELL curl
-		// iterations against duckduckgo/google-news/etc — all blocked by
-		// anti-scraping. Iter 5 REPLY then emitted:
-		//   "I'm fetching the latest info on 'big Yahu'. Please hold..."
-		// — a phantom present-continuous claim. iters=5 tools=4 but no
-		// further fetch was queued. The planner does not run in the
-		// background after returning; the user was promised data that
-		// would never arrive.
-		//
-		// The phantom-action-claim ban already lives in
-		// messageHandlerTemplate (Stage 1). This regression covers the
-		// SAME ban in plannerTemplate — the planner's messageToUser /
-		// REPLY text path that runs after every tool iteration.
-		expect(plannerTemplate).toContain(
-			"messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
-		);
-		expect(plannerTemplate).toContain('"I\'m fetching X, please hold"');
-		expect(plannerTemplate).toContain(
-			"The planner does not run in the background after returning",
-		);
-		expect(plannerTemplate).toContain("set messageToUser saying so plainly");
-		expect(plannerTemplate).toContain(
-			'"please hold" / "give me a sec" / "be right back" style stalling phrases',
-		);
-	});
+  it("forbids phantom in-flight investigative claims in messageToUser/REPLY (planner side)", () => {
+    // Live regression on 2026-05-26 in the milady deployment: user asked
+    // "look it up bitch" after the bot honestly declined a current-news
+    // question. Stage 1 routed simple=false + requiresTool=true with
+    // candidateActions=[WEB_SEARCH, SHELL]. The planner ran 4 SHELL curl
+    // iterations against duckduckgo/google-news/etc — all blocked by
+    // anti-scraping. Iter 5 REPLY then emitted:
+    //   "I'm fetching the latest info on 'big Yahu'. Please hold..."
+    // — a phantom present-continuous claim. iters=5 tools=4 but no
+    // further fetch was queued. The planner does not run in the
+    // background after returning; the user was promised data that
+    // would never arrive.
+    //
+    // The phantom-action-claim ban already lives in
+    // messageHandlerTemplate (Stage 1). This regression covers the
+    // SAME ban in plannerTemplate — the planner's messageToUser /
+    // REPLY text path that runs after every tool iteration.
+    expect(plannerTemplate).toContain(
+      "messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
+    );
+    expect(plannerTemplate).toContain('"I\'m fetching X, please hold"');
+    expect(plannerTemplate).toContain(
+      "The planner does not run in the background after returning",
+    );
+    expect(plannerTemplate).toContain("set messageToUser saying so plainly");
+    expect(plannerTemplate).toContain(
+      '"please hold" / "give me a sec" / "be right back" style stalling phrases',
+    );
+  });
 
-	it("appends mandatory chat-recall fallback policy to optimized planner prompts", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({ text: "No chat search is available." })),
-			getService: vi.fn(() => ({
-				getPrompt: vi.fn(() => ({
-					prompt:
-						"task: Optimized planner without bundled safety policy.\n\ncontext_object:\n{{contextObject}}\n\ntrajectory:\n{{trajectory}}",
-				})),
-			})),
-		};
+  it("appends mandatory chat-recall fallback policy to optimized planner prompts", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({ text: "No chat search is available." })),
+      getService: vi.fn(() => ({
+        getPrompt: vi.fn(() => ({
+          prompt:
+            "task: Optimized planner without bundled safety policy.\n\ncontext_object:\n{{contextObject}}\n\ntrajectory:\n{{trajectory}}",
+        })),
+      })),
+    };
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx", events: [] },
-			executeToolCall: vi.fn(),
-			evaluate: vi.fn(),
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx", events: [] },
+      executeToolCall: vi.fn(),
+      evaluate: vi.fn(),
+    });
 
-		const plannerParams = runtime.useModel.mock.calls[0]?.[1] as {
-			messages?: Array<{ role?: string; content?: string }>;
-		};
-		const systemContent =
-			plannerParams.messages?.find((message) => message.role === "system")
-				?.content ?? "";
-		expect(systemContent).toContain(
-			"Optimized planner without bundled safety policy",
-		);
-		expect(systemContent).toContain("mandatory planner policy:");
-		expect(systemContent).toContain(
-			"SHELL is for filesystem/process work, not a fallback for chat-message search/recall",
-		);
-		expect(systemContent).toContain(
-			"candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
-		);
-		expect(systemContent).toContain(
-			"TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
-		);
-		expect(systemContent).toContain(
-			"messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
-		);
-		expect(systemContent).toContain(
-			'"please hold" / "give me a sec" / "be right back" style stalling phrases',
-		);
-	});
+    const plannerParams = runtime.useModel.mock.calls[0]?.[1] as {
+      messages?: Array<{ role?: string; content?: string }>;
+    };
+    const systemContent =
+      plannerParams.messages?.find((message) => message.role === "system")
+        ?.content ?? "";
+    expect(systemContent).toContain(
+      "Optimized planner without bundled safety policy",
+    );
+    expect(systemContent).toContain("mandatory planner policy:");
+    expect(systemContent).toContain(
+      "SHELL is for filesystem/process work, not a fallback for chat-message search/recall",
+    );
+    expect(systemContent).toContain(
+      "candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
+    );
+    expect(systemContent).toContain(
+      "TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
+    );
+    expect(systemContent).toContain(
+      "messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
+    );
+    expect(systemContent).toContain(
+      '"please hold" / "give me a sec" / "be right back" style stalling phrases',
+    );
+  });
 
-	it("calls ACTION_PLANNER, executes the first queued tool, then evaluates", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "",
-				toolCalls: [
-					{
-						id: "call-1",
-						name: "LOOKUP",
-						arguments: { query: "status" },
-					},
-					{
-						id: "call-2",
-						name: "FOLLOW_UP",
-						arguments: { id: "next" },
-					},
-				],
-			})),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "all good",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Done.",
-		}));
+  it("calls ACTION_PLANNER, executes the first queued tool, then evaluates", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "LOOKUP",
+            arguments: { query: "status" },
+          },
+          {
+            id: "call-2",
+            name: "FOLLOW_UP",
+            arguments: { id: "next" },
+          },
+        ],
+      })),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "all good",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Done.",
+      messageToUser: "Done.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: {
-				id: "ctx",
-				staticPrefix: {
-					characterPrompt: {
-						content: "agent_name: Eliza",
-						stable: true,
-					},
-				},
-				events: [
-					{
-						id: "provider:RECENT_MESSAGES",
-						type: "provider",
-						name: "RECENT_MESSAGES",
-						text: "Recent: user asked for status.",
-					},
-					{
-						id: "msg",
-						type: "message",
-						message: {
-							role: "user",
-							content: { text: "Check status." },
-						},
-					},
-				],
-			},
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: {
+        id: "ctx",
+        staticPrefix: {
+          characterPrompt: {
+            content: "agent_name: Eliza",
+            stable: true,
+          },
+        },
+        events: [
+          {
+            id: "provider:RECENT_MESSAGES",
+            type: "provider",
+            name: "RECENT_MESSAGES",
+            text: "Recent: user asked for status.",
+          },
+          {
+            id: "msg",
+            type: "message",
+            message: {
+              role: "user",
+              content: { text: "Check status." },
+            },
+          },
+        ],
+      },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(runtime.useModel).toHaveBeenCalledWith(
-			ModelType.ACTION_PLANNER,
-			expect.objectContaining({
-				messages: expect.any(Array),
-				promptSegments: expect.any(Array),
-			}),
-			undefined,
-		);
-		const plannerParams = runtime.useModel.mock.calls[0][1];
-		// Wire-shape contract: planner emits ONLY `messages`. No legacy
-		// `prompt: string` is sent on v5 calls — adapters consume `messages`.
-		expect(plannerParams.prompt).toBeUndefined();
-		expect(plannerParams.messages.map((message) => message.role)).toEqual([
-			"system",
-			"user",
-		]);
-		expect(plannerParams.messages[0].content).toContain("planner_stage:");
-		expect(plannerParams.messages[0].content).toContain("agent_name: Eliza");
-		// Provider events render as `provider:NAME:\n<text>` (label + content).
-		// The previous shape baked an extra `provider: <name>` line into the
-		// content body, doubling up with the label. The new render drops that.
-		expect(plannerParams.messages[1].content).toContain(
-			"provider:RECENT_MESSAGES:",
-		);
-		expect(plannerParams.messages[1].content).toContain("Check status.");
-		expect(plannerParams.messages[1].content).not.toMatch(
-			/provider:RECENT_MESSAGES:\nprovider: RECENT_MESSAGES/,
-		);
-		// After the stacking fix, trajectory steps are conveyed as assistant/tool
-		// message pairs, NOT as a JSON dump in the user message. The user message
-		// (messages[1]) should no longer contain "trajectory:\n[".
-		expect(plannerParams.messages[1].content).not.toMatch(/^trajectory:\n\[/);
-		expect(plannerParams.providerOptions.eliza.modelInputBudget).toMatchObject({
-			reserveTokens: 10_000,
-			shouldCompact: false,
-		});
-		expect(plannerParams.maxTokens).toBe(1024);
-		expect(plannerParams.providerOptions.eliza.thinking).toBe("off");
-		expect(executeToolCall).toHaveBeenCalledWith(
-			{ id: "call-1", name: "LOOKUP", params: { query: "status" } },
-			expect.objectContaining({ iteration: 1 }),
-		);
-		expect(executeToolCall).toHaveBeenCalledTimes(1);
-		expect(evaluate).toHaveBeenCalledTimes(1);
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe("Done.");
-	});
+    expect(runtime.useModel).toHaveBeenCalledWith(
+      ModelType.ACTION_PLANNER,
+      expect.objectContaining({
+        messages: expect.any(Array),
+        promptSegments: expect.any(Array),
+      }),
+      undefined,
+    );
+    const plannerParams = runtime.useModel.mock.calls[0][1];
+    // Wire-shape contract: planner emits ONLY `messages`. No legacy
+    // `prompt: string` is sent on v5 calls — adapters consume `messages`.
+    expect(plannerParams.prompt).toBeUndefined();
+    expect(plannerParams.messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+    ]);
+    expect(plannerParams.messages[0].content).toContain("planner_stage:");
+    expect(plannerParams.messages[0].content).toContain("agent_name: Eliza");
+    // Provider events render as `provider:NAME:\n<text>` (label + content).
+    // The previous shape baked an extra `provider: <name>` line into the
+    // content body, doubling up with the label. The new render drops that.
+    expect(plannerParams.messages[1].content).toContain(
+      "provider:RECENT_MESSAGES:",
+    );
+    expect(plannerParams.messages[1].content).toContain("Check status.");
+    expect(plannerParams.messages[1].content).not.toMatch(
+      /provider:RECENT_MESSAGES:\nprovider: RECENT_MESSAGES/,
+    );
+    // After the stacking fix, trajectory steps are conveyed as assistant/tool
+    // message pairs, NOT as a JSON dump in the user message. The user message
+    // (messages[1]) should no longer contain "trajectory:\n[".
+    expect(plannerParams.messages[1].content).not.toMatch(/^trajectory:\n\[/);
+    expect(plannerParams.providerOptions.eliza.modelInputBudget).toMatchObject({
+      reserveTokens: 10_000,
+      shouldCompact: false,
+    });
+    expect(plannerParams.maxTokens).toBe(1024);
+    expect(plannerParams.providerOptions.eliza.thinking).toBe("off");
+    expect(executeToolCall).toHaveBeenCalledWith(
+      { id: "call-1", name: "LOOKUP", params: { query: "status" } },
+      expect.objectContaining({ iteration: 1 }),
+    );
+    expect(executeToolCall).toHaveBeenCalledTimes(1);
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBe("Done.");
+  });
 
-	it("evaluates terminal-only planner output without executing tools", async () => {
-		const runtime = {
-			useModel: vi.fn(
-				async () => `{
+  it("evaluates terminal-only planner output without executing tools", async () => {
+    const runtime = {
+      useModel: vi.fn(
+        async () => `{
   "thought": "Done.",
   "messageToUser": "Final answer.",
   "toolCalls": []
 }`,
-			),
-		};
-		const executeToolCall = vi.fn();
-		const evaluate = vi.fn();
+      ),
+    };
+    const executeToolCall = vi.fn();
+    const evaluate = vi.fn();
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(executeToolCall).not.toHaveBeenCalled();
-		expect(evaluate).not.toHaveBeenCalled();
-		expect(result.finalMessage).toBe("Final answer.");
-	});
+    expect(executeToolCall).not.toHaveBeenCalled();
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(result.finalMessage).toBe("Final answer.");
+  });
 
-	it("applies the derived per-model reserve when no reserve override is configured", async () => {
-		const runtime = {
-			useModel: vi.fn(
-				async () => `{
+  it("applies the derived per-model reserve when no reserve override is configured", async () => {
+    const runtime = {
+      useModel: vi.fn(
+        async () => `{
   "thought": "Done.",
   "messageToUser": "Final answer.",
   "toolCalls": []
 }`,
-			),
-		};
+      ),
+    };
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			config: {
-				contextWindowModelName: "gpt-oss-120b",
-			},
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      config: {
+        contextWindowModelName: "gpt-oss-120b",
+      },
+    });
 
-		const plannerParams = runtime.useModel.mock.calls[0]?.[1];
-		expect(plannerParams?.providerOptions.eliza.modelInputBudget).toMatchObject(
-			{
-				contextWindowTokens: 131_000,
-				reserveTokens: 26_200,
-				compactionThresholdTokens: 104_800,
-				resolvedModelKey: "gpt-oss-120b",
-			},
-		);
-	});
+    const plannerParams = runtime.useModel.mock.calls[0]?.[1];
+    expect(plannerParams?.providerOptions.eliza.modelInputBudget).toMatchObject(
+      {
+        contextWindowTokens: 131_000,
+        reserveTokens: 26_200,
+        compactionThresholdTokens: 104_800,
+        resolvedModelKey: "gpt-oss-120b",
+      },
+    );
+  });
 
-	it("keeps explicit compactionReserveTokens overrides with a model lookup", async () => {
-		const runtime = {
-			useModel: vi.fn(
-				async () => `{
+  it("keeps explicit compactionReserveTokens overrides with a model lookup", async () => {
+    const runtime = {
+      useModel: vi.fn(
+        async () => `{
   "thought": "Done.",
   "messageToUser": "Final answer.",
   "toolCalls": []
 }`,
-			),
-		};
+      ),
+    };
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			config: {
-				contextWindowModelName: "gpt-oss-120b",
-				compactionReserveTokens: 5_000,
-			},
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      config: {
+        contextWindowModelName: "gpt-oss-120b",
+        compactionReserveTokens: 5_000,
+      },
+    });
 
-		const plannerParams = runtime.useModel.mock.calls[0]?.[1];
-		expect(plannerParams?.providerOptions.eliza.modelInputBudget).toMatchObject(
-			{
-				contextWindowTokens: 131_000,
-				reserveTokens: 5_000,
-				compactionThresholdTokens: 126_000,
-				resolvedModelKey: "gpt-oss-120b",
-			},
-		);
-	});
+    const plannerParams = runtime.useModel.mock.calls[0]?.[1];
+    expect(plannerParams?.providerOptions.eliza.modelInputBudget).toMatchObject(
+      {
+        contextWindowTokens: 131_000,
+        reserveTokens: 5_000,
+        compactionThresholdTokens: 126_000,
+        resolvedModelKey: "gpt-oss-120b",
+      },
+    );
+  });
 
-	it("retries premature terminal output when a non-terminal tool call is required", async () => {
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce(`{
+  it("retries premature terminal output when a non-terminal tool call is required", async () => {
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce(`{
   "thought": "I can answer directly.",
   "messageToUser": "Looks fine.",
   "toolCalls": []
 }`)
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-1",
-							name: "LOOKUP",
-							arguments: { query: "status" },
-						},
-					],
-				}),
-			logger: { warn: vi.fn() },
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "checked",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Checked.",
-		}));
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "LOOKUP",
+              arguments: { query: "status" },
+            },
+          ],
+        }),
+      logger: { warn: vi.fn() },
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "checked",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Done.",
+      messageToUser: "Checked.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			tools: [
-				{
-					name: "LOOKUP",
-					description: "Lookup current status.",
-				},
-			],
-			requireNonTerminalToolCall: true,
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [
+        {
+          name: "LOOKUP",
+          description: "Lookup current status.",
+        },
+      ],
+      requireNonTerminalToolCall: true,
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		expect(retryParams.messages?.[1]?.content).toContain(
-			"previous planner response was not valid",
-		);
-		expect(executeToolCall).toHaveBeenCalledWith(
-			{ id: "call-1", name: "LOOKUP", params: { query: "status" } },
-			expect.objectContaining({ iteration: 2 }),
-		);
-		expect(result.finalMessage).toBe("Checked.");
-	});
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+    const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
+      messages?: Array<{ role?: string; content?: string | null }>;
+    };
+    expect(retryParams.messages?.[1]?.content).toContain(
+      "previous planner response was not valid",
+    );
+    expect(executeToolCall).toHaveBeenCalledWith(
+      { id: "call-1", name: "LOOKUP", params: { query: "status" } },
+      expect.objectContaining({ iteration: 2 }),
+    );
+    expect(result.finalMessage).toBe("Checked.");
+  });
 
-	it("surfaces captured REPLY refusal text when required-tool cap is hit, instead of throwing", async () => {
-		// Live regression: trajectory tj-3bb6dc66be0c16.json on 2026-05-25
-		// showed that when Stage 1 set requiresTool=true but no exposed tool
-		// could fulfill the task (chat-history search with no SEARCH_MESSAGES
-		// action), the planner emitted REPLY with valid honest refusals each
-		// iteration. The loop discarded every REPLY, hit maxRequiredToolMisses,
-		// threw TrajectoryLimitExceeded, and the caller emitted a generic
-		// apology ("Sorry, something went wrong—please try again"). The fix
-		// captures the most recent terminal-only refusal across iterations and
-		// returns it as the final user-facing message when the cap is reached.
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "reply-1",
-							name: "REPLY",
-							arguments: {
-								text: "I'm not able to search the chat history directly from here.",
-							},
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "reply-2",
-							name: "REPLY",
-							arguments: {
-								text: "I don't have a way to search the Discord message history.",
-							},
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "reply-3",
-							name: "REPLY",
-							arguments: {
-								text: "I still can't search the Discord message history from here.",
-							},
-						},
-					],
-				}),
-			logger: { warn: vi.fn() },
-		};
+  it("surfaces captured REPLY refusal text when required-tool cap is hit, instead of throwing", async () => {
+    // Live regression: trajectory tj-3bb6dc66be0c16.json on 2026-05-25
+    // showed that when Stage 1 set requiresTool=true but no exposed tool
+    // could fulfill the task (chat-history search with no SEARCH_MESSAGES
+    // action), the planner emitted REPLY with valid honest refusals each
+    // iteration. The loop discarded every REPLY, hit maxRequiredToolMisses,
+    // threw TrajectoryLimitExceeded, and the caller emitted a generic
+    // apology ("Sorry, something went wrong—please try again"). The fix
+    // captures the most recent terminal-only refusal across iterations and
+    // returns it as the final user-facing message when the cap is reached.
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "reply-1",
+              name: "REPLY",
+              arguments: {
+                text: "I'm not able to search the chat history directly from here.",
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "reply-2",
+              name: "REPLY",
+              arguments: {
+                text: "I don't have a way to search the Discord message history.",
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "reply-3",
+              name: "REPLY",
+              arguments: {
+                text: "I still can't search the Discord message history from here.",
+              },
+            },
+          ],
+        }),
+      logger: { warn: vi.fn() },
+    };
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			tools: [
-				{
-					name: "LOOKUP",
-					description: "Lookup current status.",
-				},
-			],
-			requireNonTerminalToolCall: true,
-			config: { maxRequiredToolMisses: 2 },
-			executeToolCall: vi.fn(),
-			evaluate: vi.fn(),
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [
+        {
+          name: "LOOKUP",
+          description: "Lookup current status.",
+        },
+      ],
+      requireNonTerminalToolCall: true,
+      config: { maxRequiredToolMisses: 2 },
+      executeToolCall: vi.fn(),
+      evaluate: vi.fn(),
+    });
 
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe(
-			"I still can't search the Discord message history from here.",
-		);
-		// maxRequiredToolMisses=2 allows two misses; the third exhausts the cap
-		// and returns the most recent captured refusal.
-		expect(runtime.useModel).toHaveBeenCalledTimes(3);
-	});
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBe(
+      "I still can't search the Discord message history from here.",
+    );
+    // maxRequiredToolMisses=2 allows two misses; the third exhausts the cap
+    // and returns the most recent captured refusal.
+    expect(runtime.useModel).toHaveBeenCalledTimes(3);
+  });
 
-	it("does not surface a captured refusal before the required-tool retry budget is exhausted", async () => {
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "reply-1",
-							name: "REPLY",
-							arguments: {
-								text: "I can't answer without checking first.",
-							},
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "lookup-1",
-							name: "LOOKUP",
-							arguments: { query: "status" },
-						},
-					],
-				}),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "status ok",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Status is ok.",
-		}));
+  it("does not surface a captured refusal before the required-tool retry budget is exhausted", async () => {
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "reply-1",
+              name: "REPLY",
+              arguments: {
+                text: "I can't answer without checking first.",
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "lookup-1",
+              name: "LOOKUP",
+              arguments: { query: "status" },
+            },
+          ],
+        }),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "status ok",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Done.",
+      messageToUser: "Status is ok.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			tools: [
-				{
-					name: "LOOKUP",
-					description: "Lookup current status.",
-				},
-			],
-			requireNonTerminalToolCall: true,
-			config: { maxRequiredToolMisses: 1 },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [
+        {
+          name: "LOOKUP",
+          description: "Lookup current status.",
+        },
+      ],
+      requireNonTerminalToolCall: true,
+      config: { maxRequiredToolMisses: 1 },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(result.finalMessage).toBe("Status is ok.");
-		expect(executeToolCall).toHaveBeenCalledWith(
-			{ id: "lookup-1", name: "LOOKUP", params: { query: "status" } },
-			expect.objectContaining({ iteration: 2 }),
-		);
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-	});
+    expect(result.finalMessage).toBe("Status is ok.");
+    expect(executeToolCall).toHaveBeenCalledWith(
+      { id: "lookup-1", name: "LOOKUP", params: { query: "status" } },
+      expect.objectContaining({ iteration: 2 }),
+    );
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+  });
 
-	it("does not capture native text fallback as a required-tool refusal", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "I should answer after thinking through the tool choice.",
-				toolCalls: [],
-			})),
-		};
+  it("stops re-executing an identical successful call and forces a terminal synthesis", async () => {
+    // Live regression: gpt-5.5 re-issued the SAME WEB_FETCH (same url) every
+    // iteration; each succeeded, the evaluator said CONTINUE, and the loop ran
+    // until maxTrajectoryPromptTokens aborted the turn with a generic apology.
+    // The redundant-call breaker executes the call once, skips the identical
+    // repeats, and after maxRepeatedToolCalls forces one tool-less synthesis.
+    const sameCall = {
+      id: "fetch-1",
+      name: "WEB_FETCH",
+      arguments: { url: "https://api.example.test/price" },
+    };
+    const runtime = {
+      useModel: vi
+        .fn()
+        // iter 1 (fresh) → executes; iters 2-3 repeat it → redundant
+        .mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+        .mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+        .mockResolvedValueOnce({ text: "", toolCalls: [sameCall] })
+        // forced synthesis (no tools) → terminal answer
+        .mockResolvedValueOnce(
+          '{"thought":"I already have the price.","messageToUser":"The price is 42.","toolCalls":[]}',
+        ),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "price=42",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "CONTINUE" as const,
+      thought: "Keep going.",
+    }));
 
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				tools: [
-					{
-						name: "LOOKUP",
-						description: "Lookup current status.",
-					},
-				],
-				requireNonTerminalToolCall: true,
-				config: { maxRequiredToolMisses: 1 },
-				executeToolCall: vi.fn(),
-				evaluate: vi.fn(),
-			}),
-		).rejects.toMatchObject({
-			name: "TrajectoryLimitExceeded",
-			kind: "required_tool_misses",
-		});
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-	});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [{ name: "WEB_FETCH", description: "Fetch a URL." }],
+      config: { maxRepeatedToolCalls: 1 },
+      executeToolCall,
+      evaluate,
+    });
 
-	it("retries planner calls to tools that are not exposed this turn", async () => {
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "bad-call",
-							name: "GET_PRICE",
-							arguments: { symbol: "BTC" },
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-1",
-							name: "SHELL",
-							arguments: { command: "curl -s https://example.com/btc" },
-						},
-					],
-				}),
-			logger: { warn: vi.fn() },
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "btc price",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Checked.",
-		}));
+    // The identical call ran exactly once; the repeats were skipped, not re-run.
+    expect(executeToolCall).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toContain("42");
+  });
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			tools: [
-				{
-					name: "SHELL",
-					description: "Run a shell command.",
-				},
-			],
-			executeToolCall,
-			evaluate,
-		});
+  it("does not capture native text fallback as a required-tool refusal", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "I should answer after thinking through the tool choice.",
+        toolCalls: [],
+      })),
+    };
 
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		expect(retryParams.messages?.[1]?.content).toContain(
-			"unavailable_tool_calls",
-		);
-		expect(retryParams.messages?.[1]?.content).toContain("GET_PRICE");
-		expect(retryParams.messages?.[1]?.content).toContain("SHELL");
-		expect(executeToolCall).toHaveBeenCalledTimes(1);
-		expect(executeToolCall).toHaveBeenCalledWith(
-			{
-				id: "call-1",
-				name: "SHELL",
-				params: { command: "curl -s https://example.com/btc" },
-			},
-			expect.objectContaining({ iteration: 2 }),
-		);
-		expect(runtime.logger.warn).toHaveBeenCalledWith(
-			expect.objectContaining({
-				invalidToolCalls: ["GET_PRICE"],
-				iteration: 1,
-			}),
-			"Planner called unavailable tools; retrying without executing them",
-		);
-		expect(result.finalMessage).toBe("Checked.");
-	});
+    await expect(
+      runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        tools: [
+          {
+            name: "LOOKUP",
+            description: "Lookup current status.",
+          },
+        ],
+        requireNonTerminalToolCall: true,
+        config: { maxRequiredToolMisses: 1 },
+        executeToolCall: vi.fn(),
+        evaluate: vi.fn(),
+      }),
+    ).rejects.toMatchObject({
+      name: "TrajectoryLimitExceeded",
+      kind: "required_tool_misses",
+    });
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+  });
 
-	it("bounds repeated unavailable planner tool retries even without usage metadata", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "",
-				toolCalls: [
-					{
-						id: "bad-call",
-						name: "GET_PRICE",
-						arguments: { symbol: "BTC" },
-					},
-				],
-			})),
-			logger: { warn: vi.fn() },
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "should not execute",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Done.",
-			messageToUser: "Done.",
-		}));
+  it("retries planner calls to tools that are not exposed this turn", async () => {
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "bad-call",
+              name: "GET_PRICE",
+              arguments: { symbol: "BTC" },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "SHELL",
+              arguments: { command: "curl -s https://example.com/btc" },
+            },
+          ],
+        }),
+      logger: { warn: vi.fn() },
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "btc price",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Done.",
+      messageToUser: "Checked.",
+    }));
 
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				tools: [
-					{
-						name: "SHELL",
-						description: "Run a shell command.",
-					},
-				],
-				executeToolCall,
-				evaluate,
-				config: { maxUnavailableToolCallRetries: 1 },
-			}),
-		).rejects.toMatchObject({
-			kind: "unavailable_tool_calls",
-			max: 1,
-			observed: 2,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [
+        {
+          name: "SHELL",
+          description: "Run a shell command.",
+        },
+      ],
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-		expect(executeToolCall).not.toHaveBeenCalled();
-		expect(evaluate).not.toHaveBeenCalled();
-	});
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+    const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
+      messages?: Array<{ role?: string; content?: string | null }>;
+    };
+    expect(retryParams.messages?.[1]?.content).toContain(
+      "unavailable_tool_calls",
+    );
+    expect(retryParams.messages?.[1]?.content).toContain("GET_PRICE");
+    expect(retryParams.messages?.[1]?.content).toContain("SHELL");
+    expect(executeToolCall).toHaveBeenCalledTimes(1);
+    expect(executeToolCall).toHaveBeenCalledWith(
+      {
+        id: "call-1",
+        name: "SHELL",
+        params: { command: "curl -s https://example.com/btc" },
+      },
+      expect.objectContaining({ iteration: 2 }),
+    );
+    expect(runtime.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidToolCalls: ["GET_PRICE"],
+        iteration: 1,
+      }),
+      "Planner called unavailable tools; retrying without executing them",
+    );
+    expect(result.finalMessage).toBe("Checked.");
+  });
 
-	it("replans once when a failed tool is finished without a user-visible message", async () => {
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-1",
-							name: "SHELL",
-							arguments: { command: "curl https://stale.example.invalid" },
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-2",
-							name: "SHELL",
-							arguments: { command: "curl https://backup.example.com" },
-						},
-					],
-				}),
-		};
-		const executeToolCall = vi
-			.fn()
-			.mockResolvedValueOnce({
-				success: false,
-				text: "command_failed: DNS lookup failed",
-			})
-			.mockResolvedValueOnce({
-				success: true,
-				text: "backup source returned a result",
-			});
-		const evaluate = vi
-			.fn()
-			.mockResolvedValueOnce({
-				success: false,
-				decision: "FINISH" as const,
-				thought: "The first lookup failed, but I forgot to include a reply.",
-			})
-			.mockResolvedValueOnce({
-				success: true,
-				decision: "FINISH" as const,
-				thought: "Done.",
-				messageToUser: "The backup source returned a result.",
-			});
+  it("bounds repeated unavailable planner tool retries even without usage metadata", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "",
+        toolCalls: [
+          {
+            id: "bad-call",
+            name: "GET_PRICE",
+            arguments: { symbol: "BTC" },
+          },
+        ],
+      })),
+      logger: { warn: vi.fn() },
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "should not execute",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Done.",
+      messageToUser: "Done.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			tools: [{ name: "SHELL", description: "Run a shell command." }],
-			executeToolCall,
-			evaluate,
-		});
+    await expect(
+      runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        tools: [
+          {
+            name: "SHELL",
+            description: "Run a shell command.",
+          },
+        ],
+        executeToolCall,
+        evaluate,
+        config: { maxUnavailableToolCallRetries: 1 },
+      }),
+    ).rejects.toMatchObject({
+      kind: "unavailable_tool_calls",
+      max: 1,
+      observed: 2,
+    });
 
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		expect(retryParams.messages?.[1]?.content).toContain(
-			"silent_failed_finish",
-		);
-		expect(executeToolCall).toHaveBeenCalledTimes(2);
-		expect(executeToolCall).toHaveBeenLastCalledWith(
-			{
-				id: "call-2",
-				name: "SHELL",
-				params: { command: "curl https://backup.example.com" },
-			},
-			expect.objectContaining({ iteration: 2 }),
-		);
-		expect(result.finalMessage).toBe("The backup source returned a result.");
-	});
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+    expect(executeToolCall).not.toHaveBeenCalled();
+    expect(evaluate).not.toHaveBeenCalled();
+  });
 
-	it("does not finish with terminal planner text after tool work when the evaluator asks to continue", async () => {
-		let plannerCallCount = 0;
-		const runtime = {
-			useModel: vi.fn(async () => {
-				plannerCallCount++;
-				if (plannerCallCount === 1) {
-					return {
-						text: "",
-						toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
-					};
-				}
-				if (plannerCallCount === 2) {
-					return {
-						text: "We need to call FOLLOW_UP now: to=functions.FOLLOW_UP",
-						toolCalls: [],
-					};
-				}
-				return {
-					text: "",
-					toolCalls: [{ id: "call-2", name: "FOLLOW_UP", arguments: {} }],
-				};
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "tool ok",
-		}));
-		let evaluationCount = 0;
-		const evaluate = vi.fn(async () => {
-			evaluationCount++;
-			if (evaluationCount < 3) {
-				return {
-					success: false,
-					decision: "CONTINUE" as const,
-					thought: "More tool work remains.",
-				};
-			}
-			return {
-				success: true,
-				decision: "FINISH" as const,
-				thought: "Done.",
-				messageToUser: "Done.",
-			};
-		});
+  it("replans once when a failed tool is finished without a user-visible message", async () => {
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "SHELL",
+              arguments: { command: "curl https://stale.example.invalid" },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-2",
+              name: "SHELL",
+              arguments: { command: "curl https://backup.example.com" },
+            },
+          ],
+        }),
+    };
+    const executeToolCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: false,
+        text: "command_failed: DNS lookup failed",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        text: "backup source returned a result",
+      });
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: false,
+        decision: "FINISH" as const,
+        thought: "The first lookup failed, but I forgot to include a reply.",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        decision: "FINISH" as const,
+        thought: "Done.",
+        messageToUser: "The backup source returned a result.",
+      });
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      tools: [{ name: "SHELL", description: "Run a shell command." }],
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(executeToolCall).toHaveBeenCalledTimes(2);
-		expect(executeToolCall).toHaveBeenLastCalledWith(
-			{ id: "call-2", name: "FOLLOW_UP", params: {} },
-			expect.objectContaining({ iteration: 3 }),
-		);
-		expect(result.finalMessage).toBe("Done.");
-		expect(result.finalMessage).not.toContain("to=functions");
-	});
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+    const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
+      messages?: Array<{ role?: string; content?: string | null }>;
+    };
+    expect(retryParams.messages?.[1]?.content).toContain(
+      "silent_failed_finish",
+    );
+    expect(executeToolCall).toHaveBeenCalledTimes(2);
+    expect(executeToolCall).toHaveBeenLastCalledWith(
+      {
+        id: "call-2",
+        name: "SHELL",
+        params: { command: "curl https://backup.example.com" },
+      },
+      expect.objectContaining({ iteration: 2 }),
+    );
+    expect(result.finalMessage).toBe("The backup source returned a result.");
+  });
 
-	it("throws TrajectoryLimitExceeded(trajectory_token_budget) when cumulative prompt tokens exceed config.maxTrajectoryPromptTokens", async () => {
-		// Each planner call reports 60_000 prompt tokens. With a 100_000
-		// budget the loop should survive call 1 (60k) and abort on call 2
-		// (cumulative 120k > 100k) before tool execution recurses.
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "",
-				toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
-				usage: {
-					promptTokens: 60_000,
-					completionTokens: 100,
-					totalTokens: 60_100,
-				},
-			})),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: true,
-			text: "ok",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "CONTINUE" as const,
-			thought: "Keep going.",
-		}));
+  it("does not finish with terminal planner text after tool work when the evaluator asks to continue", async () => {
+    let plannerCallCount = 0;
+    const runtime = {
+      useModel: vi.fn(async () => {
+        plannerCallCount++;
+        if (plannerCallCount === 1) {
+          return {
+            text: "",
+            toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
+          };
+        }
+        if (plannerCallCount === 2) {
+          return {
+            text: "We need to call FOLLOW_UP now: to=functions.FOLLOW_UP",
+            toolCalls: [],
+          };
+        }
+        return {
+          text: "",
+          toolCalls: [{ id: "call-2", name: "FOLLOW_UP", arguments: {} }],
+        };
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "tool ok",
+    }));
+    let evaluationCount = 0;
+    const evaluate = vi.fn(async () => {
+      evaluationCount++;
+      if (evaluationCount < 3) {
+        return {
+          success: false,
+          decision: "CONTINUE" as const,
+          thought: "More tool work remains.",
+        };
+      }
+      return {
+        success: true,
+        decision: "FINISH" as const,
+        thought: "Done.",
+        messageToUser: "Done.",
+      };
+    });
 
-		let thrown: unknown;
-		try {
-			await runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				config: { maxTrajectoryPromptTokens: 100_000 },
-				executeToolCall,
-				evaluate,
-			});
-		} catch (err) {
-			thrown = err;
-		}
-		expect(thrown).toBeInstanceOf(TrajectoryLimitExceeded);
-		expect((thrown as TrajectoryLimitExceeded).kind).toBe(
-			"trajectory_token_budget",
-		);
-		// Bounded at the call that crossed the line — 2 model calls, not 3+.
-		expect(runtime.useModel).toHaveBeenCalledTimes(2);
-	});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-	it("does not fire trajectory_token_budget when usage stays under the limit", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "done.",
-				toolCalls: [],
-				messageToUser: "done.",
-				usage: {
-					promptTokens: 1_000,
-					completionTokens: 50,
-					totalTokens: 1_050,
-				},
-			})),
-		};
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				config: { maxTrajectoryPromptTokens: 100_000 },
-				executeToolCall: vi.fn(),
-				evaluate: vi.fn(),
-			}),
-		).resolves.toBeDefined();
-	});
+    expect(executeToolCall).toHaveBeenCalledTimes(2);
+    expect(executeToolCall).toHaveBeenLastCalledWith(
+      { id: "call-2", name: "FOLLOW_UP", params: {} },
+      expect.objectContaining({ iteration: 3 }),
+    );
+    expect(result.finalMessage).toBe("Done.");
+    expect(result.finalMessage).not.toContain("to=functions");
+  });
 
-	it("tolerates missing usage on the model response (back-compat with older adapters)", async () => {
-		// Some adapter shims emit no `usage` field. The token guard should
-		// silently no-op rather than crash the loop.
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "done.",
-				toolCalls: [],
-				messageToUser: "done.",
-				// no usage field
-			})),
-		};
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			config: { maxTrajectoryPromptTokens: 100 },
-			executeToolCall: vi.fn(),
-			evaluate: vi.fn(),
-		});
-		expect(result).toBeDefined();
-	});
+  it("throws TrajectoryLimitExceeded(trajectory_token_budget) when cumulative prompt tokens exceed config.maxTrajectoryPromptTokens", async () => {
+    // Each planner call reports 60_000 prompt tokens. With a 100_000
+    // budget the loop should survive call 1 (60k) and abort on call 2
+    // (cumulative 120k > 100k) before tool execution recurses.
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "",
+        toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
+        usage: {
+          promptTokens: 60_000,
+          completionTokens: 100,
+          totalTokens: 60_100,
+        },
+      })),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: true,
+      text: "ok",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "CONTINUE" as const,
+      thought: "Keep going.",
+    }));
 
-	it("throws when the same tool failure repeats beyond the configured limit", async () => {
-		const runtime = {
-			useModel: vi.fn(async () => ({
-				text: "",
-				toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
-			})),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: false,
-			error: "boom",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: false,
-			decision: "CONTINUE" as const,
-			thought: "Retry.",
-		}));
+    let thrown: unknown;
+    try {
+      await runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        config: { maxTrajectoryPromptTokens: 100_000 },
+        executeToolCall,
+        evaluate,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(TrajectoryLimitExceeded);
+    expect((thrown as TrajectoryLimitExceeded).kind).toBe(
+      "trajectory_token_budget",
+    );
+    // Bounded at the call that crossed the line — 2 model calls, not 3+.
+    expect(runtime.useModel).toHaveBeenCalledTimes(2);
+  });
 
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				config: { maxRepeatedFailures: 1 },
-				executeToolCall,
-				evaluate,
-			}),
-		).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
-	});
+  it("does not fire trajectory_token_budget when usage stays under the limit", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "done.",
+        toolCalls: [],
+        messageToUser: "done.",
+        usage: {
+          promptTokens: 1_000,
+          completionTokens: 50,
+          totalTokens: 1_050,
+        },
+      })),
+    };
+    await expect(
+      runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        config: { maxTrajectoryPromptTokens: 100_000 },
+        executeToolCall: vi.fn(),
+        evaluate: vi.fn(),
+      }),
+    ).resolves.toBeDefined();
+  });
 
-	it("does not count different failed tool parameters as the same repeated failure", async () => {
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-1",
-							name: "SHELL",
-							arguments: { command: "curl https://stale.example.invalid" },
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-2",
-							name: "SHELL",
-							arguments: { command: "curl https://backup.example.invalid" },
-						},
-					],
-				}),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: false,
-			error: "command_failed: command exited with code 1",
-		}));
-		const evaluate = vi
-			.fn()
-			.mockResolvedValueOnce({
-				success: false,
-				decision: "CONTINUE" as const,
-				thought: "Try a different source.",
-			})
-			.mockResolvedValueOnce({
-				success: false,
-				decision: "FINISH" as const,
-				thought: "No source worked.",
-				messageToUser: "I could not retrieve that from the available sources.",
-			});
+  it("tolerates missing usage on the model response (back-compat with older adapters)", async () => {
+    // Some adapter shims emit no `usage` field. The token guard should
+    // silently no-op rather than crash the loop.
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "done.",
+        toolCalls: [],
+        messageToUser: "done.",
+        // no usage field
+      })),
+    };
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      config: { maxTrajectoryPromptTokens: 100 },
+      executeToolCall: vi.fn(),
+      evaluate: vi.fn(),
+    });
+    expect(result).toBeDefined();
+  });
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			config: { maxRepeatedFailures: 1 },
-			executeToolCall,
-			evaluate,
-		});
+  it("throws when the same tool failure repeats beyond the configured limit", async () => {
+    const runtime = {
+      useModel: vi.fn(async () => ({
+        text: "",
+        toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
+      })),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: false,
+      error: "boom",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: false,
+      decision: "CONTINUE" as const,
+      thought: "Retry.",
+    }));
 
-		expect(executeToolCall).toHaveBeenCalledTimes(2);
-		expect(result.finalMessage).toBe(
-			"I could not retrieve that from the available sources.",
-		);
-	});
+    await expect(
+      runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        config: { maxRepeatedFailures: 1 },
+        executeToolCall,
+        evaluate,
+      }),
+    ).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
+  });
 
-	it("collapses repeated parameter-validation failures on the same tool even when args vary", async () => {
-		// Regression for runaway loops where the model retries a single
-		// tool repeatedly with shifting argument shapes that every time
-		// fail `validateToolArgs`. Without canonical signing of these
-		// validation failures, the repeatKey + error message both diverge
-		// per call and `maxRepeatedFailures` never trips. Observed live as
-		// a 27-iteration runaway against TASKS where the model alternated
-		// between `action=spawn_agent` / `action=create` / `action=update`
-		// with the same set of unrecognized arguments.
-		const runtime = {
-			useModel: vi
-				.fn()
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-1",
-							name: "TASKS",
-							arguments: { action: "spawn_agent", task: "build a site" },
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-2",
-							name: "TASKS",
-							arguments: { action: "create", task: "build a site" },
-						},
-					],
-				})
-				.mockResolvedValueOnce({
-					text: "",
-					toolCalls: [
-						{
-							id: "call-3",
-							name: "TASKS",
-							arguments: { action: "update", task: "build a site" },
-						},
-					],
-				}),
-		};
-		let callCount = 0;
-		const executeToolCall = vi.fn(async () => {
-			callCount++;
-			return {
-				success: false,
-				error: `Unexpected argument 'task'; action value '${callCount}' rejected`,
-				data: {
-					parameterErrors: ["Unexpected argument 'task'", "action not in enum"],
-				},
-			};
-		});
-		const evaluate = vi.fn(async () => ({
-			success: false,
-			decision: "CONTINUE" as const,
-			thought: "Retry with a different action.",
-		}));
+  it("does not count different failed tool parameters as the same repeated failure", async () => {
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "SHELL",
+              arguments: { command: "curl https://stale.example.invalid" },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-2",
+              name: "SHELL",
+              arguments: { command: "curl https://backup.example.invalid" },
+            },
+          ],
+        }),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: false,
+      error: "command_failed: command exited with code 1",
+    }));
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: false,
+        decision: "CONTINUE" as const,
+        thought: "Try a different source.",
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        decision: "FINISH" as const,
+        thought: "No source worked.",
+        messageToUser: "I could not retrieve that from the available sources.",
+      });
 
-		await expect(
-			runPlannerLoop({
-				runtime,
-				context: { id: "ctx" },
-				config: { maxRepeatedFailures: 1 },
-				executeToolCall,
-				evaluate,
-			}),
-		).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
-		// Loop must bail on the second validation rejection, not run forever.
-		expect(executeToolCall.mock.calls.length).toBeLessThanOrEqual(2);
-	});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      config: { maxRepeatedFailures: 1 },
+      executeToolCall,
+      evaluate,
+    });
 
-	it("compacts old assistant/tool suffixes when the planner input crosses the budget threshold", async () => {
-		const capturedMessages: ChatMessage[][] = [];
-		const longPayload = `generated file content: ${"x".repeat(20_000)}`;
-		let plannerCallCount = 0;
-		const runtime = {
-			useModel: vi.fn(async (_modelType: unknown, params: unknown) => {
-				const messages =
-					(params as { messages?: ChatMessage[] }).messages ?? [];
-				capturedMessages.push(JSON.parse(JSON.stringify(messages)));
-				plannerCallCount++;
-				if (plannerCallCount === 1) {
-					return {
-						text: "",
-						toolCalls: [{ id: "call-1", name: "GENERATE", arguments: {} }],
-					};
-				}
-				return {
-					text: "",
-					toolCalls: [
-						{
-							id: "call-final",
-							name: "REPLY",
-							arguments: { text: "done" },
-						},
-					],
-				};
-			}),
-			logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
-		};
-		const recordStage = vi.fn(async () => undefined);
-		const recorder: TrajectoryRecorder = {
-			startTrajectory: vi.fn(() => "trajectory-1"),
-			recordStage,
-			endTrajectory: vi.fn(async () => undefined),
-			load: vi.fn(async () => null),
-			list: vi.fn(async () => []),
-		};
+    expect(executeToolCall).toHaveBeenCalledTimes(2);
+    expect(result.finalMessage).toBe(
+      "I could not retrieve that from the available sources.",
+    );
+  });
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			config: {
-				contextWindowTokens: 2_000,
-				compactionReserveTokens: 500,
-				compactionKeepSteps: 0,
-			},
-			recorder,
-			trajectoryId: "trajectory-1",
-			executeToolCall: vi.fn(async () => ({
-				success: true,
-				text: longPayload,
-			})),
-			evaluate: vi.fn(async () => ({
-				success: true,
-				decision: "CONTINUE" as const,
-				thought: "Continue after generated content.",
-			})),
-		});
+  it("collapses repeated parameter-validation failures on the same tool even when args vary", async () => {
+    // Regression for runaway loops where the model retries a single
+    // tool repeatedly with shifting argument shapes that every time
+    // fail `validateToolArgs`. Without canonical signing of these
+    // validation failures, the repeatKey + error message both diverge
+    // per call and `maxRepeatedFailures` never trips. Observed live as
+    // a 27-iteration runaway against TASKS where the model alternated
+    // between `action=spawn_agent` / `action=create` / `action=update`
+    // with the same set of unrecognized arguments.
+    const runtime = {
+      useModel: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "TASKS",
+              arguments: { action: "spawn_agent", task: "build a site" },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-2",
+              name: "TASKS",
+              arguments: { action: "create", task: "build a site" },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          text: "",
+          toolCalls: [
+            {
+              id: "call-3",
+              name: "TASKS",
+              arguments: { action: "update", task: "build a site" },
+            },
+          ],
+        }),
+    };
+    let callCount = 0;
+    const executeToolCall = vi.fn(async () => {
+      callCount++;
+      return {
+        success: false,
+        error: `Unexpected argument 'task'; action value '${callCount}' rejected`,
+        data: {
+          parameterErrors: ["Unexpected argument 'task'", "action not in enum"],
+        },
+      };
+    });
+    const evaluate = vi.fn(async () => ({
+      success: false,
+      decision: "CONTINUE" as const,
+      thought: "Retry with a different action.",
+    }));
 
-		expect(plannerCallCount).toBe(2);
-		const secondCall = capturedMessages[1];
-		if (!secondCall) throw new Error("Expected a second planner call");
-		const secondPayload = JSON.stringify(secondCall);
-		expect(secondPayload).toContain("compaction");
-		expect(secondPayload).toContain("GENERATE success");
-		expect(secondPayload).not.toContain("x".repeat(1_000));
+    await expect(
+      runPlannerLoop({
+        runtime,
+        context: { id: "ctx" },
+        config: { maxRepeatedFailures: 1 },
+        executeToolCall,
+        evaluate,
+      }),
+    ).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
+    // Loop must bail on the second validation rejection, not run forever.
+    expect(executeToolCall.mock.calls.length).toBeLessThanOrEqual(2);
+  });
 
-		const recordedKinds = recordStage.mock.calls.map((call) => call[1]?.kind);
-		expect(recordedKinds).toContain("compaction");
-		expect(recordedKinds).toContain("planner");
-	});
+  it("compacts old assistant/tool suffixes when the planner input crosses the budget threshold", async () => {
+    const capturedMessages: ChatMessage[][] = [];
+    const longPayload = `generated file content: ${"x".repeat(20_000)}`;
+    let plannerCallCount = 0;
+    const runtime = {
+      useModel: vi.fn(async (_modelType: unknown, params: unknown) => {
+        const messages =
+          (params as { messages?: ChatMessage[] }).messages ?? [];
+        capturedMessages.push(JSON.parse(JSON.stringify(messages)));
+        plannerCallCount++;
+        if (plannerCallCount === 1) {
+          return {
+            text: "",
+            toolCalls: [{ id: "call-1", name: "GENERATE", arguments: {} }],
+          };
+        }
+        return {
+          text: "",
+          toolCalls: [
+            {
+              id: "call-final",
+              name: "REPLY",
+              arguments: { text: "done" },
+            },
+          ],
+        };
+      }),
+      logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+    const recordStage = vi.fn(async () => undefined);
+    const recorder: TrajectoryRecorder = {
+      startTrajectory: vi.fn(() => "trajectory-1"),
+      recordStage,
+      endTrajectory: vi.fn(async () => undefined),
+      load: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+    };
+
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      config: {
+        contextWindowTokens: 2_000,
+        compactionReserveTokens: 500,
+        compactionKeepSteps: 0,
+      },
+      recorder,
+      trajectoryId: "trajectory-1",
+      executeToolCall: vi.fn(async () => ({
+        success: true,
+        text: longPayload,
+      })),
+      evaluate: vi.fn(async () => ({
+        success: true,
+        decision: "CONTINUE" as const,
+        thought: "Continue after generated content.",
+      })),
+    });
+
+    expect(plannerCallCount).toBe(2);
+    const secondCall = capturedMessages[1];
+    if (!secondCall) throw new Error("Expected a second planner call");
+    const secondPayload = JSON.stringify(secondCall);
+    expect(secondPayload).toContain("compaction");
+    expect(secondPayload).toContain("GENERATE success");
+    expect(secondPayload).not.toContain("x".repeat(1_000));
+
+    const recordedKinds = recordStage.mock.calls.map((call) => call[1]?.kind);
+    expect(recordedKinds).toContain("compaction");
+    expect(recordedKinds).toContain("planner");
+  });
 });
 
 describe("v5 planner loop — evaluator gate", () => {
-	// Conservative gate: when a successful tool drained the queue and the most
-	// recent planner output supplied an EXPLICIT `messageToUser` field, the
-	// planner loop synthesizes a FINISH evaluator output and skips the
-	// evaluator's full LLM call. The six tests below pin the fire/withhold
-	// contract — including the discriminator that native-mode tool-call returns
-	// (which fall back to `text`) do NOT trigger the gate, because `text` can
-	// be a pre-tool thought rather than a final answer.
+  // Conservative gate: when a successful tool drained the queue and the most
+  // recent planner output supplied an EXPLICIT `messageToUser` field, the
+  // planner loop synthesizes a FINISH evaluator output and skips the
+  // evaluator's full LLM call. The six tests below pin the fire/withhold
+  // contract — including the discriminator that native-mode tool-call returns
+  // (which fall back to `text`) do NOT trigger the gate, because `text` can
+  // be a pre-tool thought rather than a final answer.
 
-	function plannerJsonWith(opts: {
-		messageToUser?: string;
-		toolCalls: Array<{ name: string; args?: Record<string, unknown> }>;
-	}) {
-		// JSON-mode return: parsePlannerOutput goes through parseJsonPlannerOutput
-		// which carries `messageToUser` into `raw.messageToUser` — the explicit
-		// field the gate requires.
-		return vi.fn(async () =>
-			JSON.stringify({
-				thought: "ready",
-				toolCalls: opts.toolCalls,
-				...(opts.messageToUser ? { messageToUser: opts.messageToUser } : {}),
-			}),
-		);
-	}
+  function plannerJsonWith(opts: {
+    messageToUser?: string;
+    toolCalls: Array<{ name: string; args?: Record<string, unknown> }>;
+  }) {
+    // JSON-mode return: parsePlannerOutput goes through parseJsonPlannerOutput
+    // which carries `messageToUser` into `raw.messageToUser` — the explicit
+    // field the gate requires.
+    return vi.fn(async () =>
+      JSON.stringify({
+        thought: "ready",
+        toolCalls: opts.toolCalls,
+        ...(opts.messageToUser ? { messageToUser: opts.messageToUser } : {}),
+      }),
+    );
+  }
 
-	function plannerNativeWith(opts: {
-		text?: string;
-		toolCalls: Array<{
-			id: string;
-			name: string;
-			arguments?: Record<string, unknown>;
-		}>;
-	}) {
-		// Native-mode return: parsePlannerOutput's native branch infers
-		// messageToUser from `text` but does NOT carry it as an explicit field.
-		// The gate must withhold even if `text` is a clean string, because in
-		// native mode `text` is ambiguous (thought vs final answer).
-		return vi.fn(async () => ({
-			text: opts.text ?? "",
-			toolCalls: opts.toolCalls,
-		}));
-	}
+  function plannerNativeWith(opts: {
+    text?: string;
+    toolCalls: Array<{
+      id: string;
+      name: string;
+      arguments?: Record<string, unknown>;
+    }>;
+  }) {
+    // Native-mode return: parsePlannerOutput's native branch infers
+    // messageToUser from `text` but does NOT carry it as an explicit field.
+    // The gate must withhold even if `text` is a clean string, because in
+    // native mode `text` is ambiguous (thought vs final answer).
+    return vi.fn(async () => ({
+      text: opts.text ?? "",
+      toolCalls: opts.toolCalls,
+    }));
+  }
 
-	it("FIRES: explicit messageToUser + drained queue + success — evaluator LLM call is skipped", async () => {
-		const runtime = {
-			useModel: plannerJsonWith({
-				messageToUser: "Status check passed.",
-				toolCalls: [{ name: "LOOKUP", args: { query: "status" } }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "should not be called",
-		}));
+  it("FIRES: explicit messageToUser + drained queue + success — evaluator LLM call is skipped", async () => {
+    const runtime = {
+      useModel: plannerJsonWith({
+        messageToUser: "Status check passed.",
+        toolCalls: [{ name: "LOOKUP", args: { query: "status" } }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "should not be called",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).not.toHaveBeenCalled();
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe("Status check passed.");
-		expect(result.evaluator?.decision).toBe("FINISH");
-		expect(result.evaluator?.success).toBe(true);
-		expect(result.evaluator?.thought).toContain("Gated FINISH");
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBe("Status check passed.");
+    expect(result.evaluator?.decision).toBe("FINISH");
+    expect(result.evaluator?.success).toBe(true);
+    expect(result.evaluator?.thought).toContain("Gated FINISH");
 
-		// Consumer-shape contract: `subPlannerResultToPlannerToolResult` in
-		// services/message.ts reads `evaluator.success` and `evaluator.messageToUser`
-		// off the loop's return value. The gate's synthesized output must carry both
-		// in the shape that consumer expects, so downstream behavior is identical to
-		// a model-produced FINISH/success=true result.
-		expect(result.evaluator?.success).toBe(true);
-		expect(result.evaluator?.messageToUser).toBe("Status check passed.");
-		// Trajectory observability: the loop still records the gated decision in
-		// `evaluatorOutputs` and as a context event so trajectory dumps and replay
-		// tools see the iteration's outcome (just no recorder evaluation stage).
-		expect(result.trajectory.evaluatorOutputs).toHaveLength(1);
-		expect(result.trajectory.evaluatorOutputs[0]?.thought).toContain(
-			"Gated FINISH",
-		);
-		const evalEvents = (result.trajectory.context.events ?? []).filter(
-			(event) => event.type === "evaluation",
-		);
-		expect(evalEvents).toHaveLength(1);
-	});
+    // Consumer-shape contract: `subPlannerResultToPlannerToolResult` in
+    // services/message.ts reads `evaluator.success` and `evaluator.messageToUser`
+    // off the loop's return value. The gate's synthesized output must carry both
+    // in the shape that consumer expects, so downstream behavior is identical to
+    // a model-produced FINISH/success=true result.
+    expect(result.evaluator?.success).toBe(true);
+    expect(result.evaluator?.messageToUser).toBe("Status check passed.");
+    // Trajectory observability: the loop still records the gated decision in
+    // `evaluatorOutputs` and as a context event so trajectory dumps and replay
+    // tools see the iteration's outcome (just no recorder evaluation stage).
+    expect(result.trajectory.evaluatorOutputs).toHaveLength(1);
+    expect(result.trajectory.evaluatorOutputs[0]?.thought).toContain(
+      "Gated FINISH",
+    );
+    const evalEvents = (result.trajectory.context.events ?? []).filter(
+      (event) => event.type === "evaluation",
+    );
+    expect(evalEvents).toHaveLength(1);
+  });
 
-	it("FIRES: emits a recorder evaluation stage marked gated for trajectory-replay parity", async () => {
-		// Gated iterations must still surface on the recorder timeline so replay
-		// tools see a stage at the same slot a model-produced evaluation would
-		// occupy. The synthesized stage is `kind: "evaluation"` and carries
-		// `gated: true` / `llmCallSkipped: true` / `reason: "explicit_terminal_reply"`
-		// so reviewers can distinguish gated decisions from real evaluator calls.
-		const runtime = {
-			useModel: plannerJsonWith({
-				messageToUser: "Status check passed.",
-				toolCalls: [{ name: "LOOKUP", args: { query: "status" } }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "should not be called",
-		}));
-		const recordedStages: RecordedStage[] = [];
-		const recorder: TrajectoryRecorder = {
-			startTrajectory: vi.fn(() => "trj-gated"),
-			recordStage: vi.fn(
-				async (_trajectoryId: string, stage: RecordedStage) => {
-					recordedStages.push(stage);
-				},
-			),
-			endTrajectory: vi.fn(async () => undefined),
-			load: vi.fn(async () => null),
-			list: vi.fn(async () => []),
-		};
+  it("FIRES: emits a recorder evaluation stage marked gated for trajectory-replay parity", async () => {
+    // Gated iterations must still surface on the recorder timeline so replay
+    // tools see a stage at the same slot a model-produced evaluation would
+    // occupy. The synthesized stage is `kind: "evaluation"` and carries
+    // `gated: true` / `llmCallSkipped: true` / `reason: "explicit_terminal_reply"`
+    // so reviewers can distinguish gated decisions from real evaluator calls.
+    const runtime = {
+      useModel: plannerJsonWith({
+        messageToUser: "Status check passed.",
+        toolCalls: [{ name: "LOOKUP", args: { query: "status" } }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "should not be called",
+    }));
+    const recordedStages: RecordedStage[] = [];
+    const recorder: TrajectoryRecorder = {
+      startTrajectory: vi.fn(() => "trj-gated"),
+      recordStage: vi.fn(
+        async (_trajectoryId: string, stage: RecordedStage) => {
+          recordedStages.push(stage);
+        },
+      ),
+      endTrajectory: vi.fn(async () => undefined),
+      load: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+    };
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-			recorder,
-			trajectoryId: "trj-gated",
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+      recorder,
+      trajectoryId: "trj-gated",
+    });
 
-		// The model evaluator was NOT called.
-		expect(evaluate).not.toHaveBeenCalled();
+    // The model evaluator was NOT called.
+    expect(evaluate).not.toHaveBeenCalled();
 
-		// The recorder DID receive an evaluation stage for the gated iteration.
-		const evalStages = recordedStages.filter((s) => s.kind === "evaluation");
-		expect(evalStages).toHaveLength(1);
-		const evalStage = evalStages[0];
-		if (!evalStage?.evaluation) {
-			throw new Error("Expected an evaluation stage payload");
-		}
-		expect(evalStage.evaluation.gated).toBe(true);
-		expect(evalStage.evaluation.llmCallSkipped).toBe(true);
-		expect(evalStage.evaluation.reason).toBe("explicit_terminal_reply");
-		// The decision and message reach the recorder so timeline UIs render them.
-		expect(evalStage.evaluation.decision).toBe("FINISH");
-		expect(evalStage.evaluation.messageToUser).toBe("Status check passed.");
-		// No `model` block — there was no LLM call to attribute.
-		expect(evalStage.model).toBeUndefined();
-	});
+    // The recorder DID receive an evaluation stage for the gated iteration.
+    const evalStages = recordedStages.filter((s) => s.kind === "evaluation");
+    expect(evalStages).toHaveLength(1);
+    const evalStage = evalStages[0];
+    if (!evalStage?.evaluation) {
+      throw new Error("Expected an evaluation stage payload");
+    }
+    expect(evalStage.evaluation.gated).toBe(true);
+    expect(evalStage.evaluation.llmCallSkipped).toBe(true);
+    expect(evalStage.evaluation.reason).toBe("explicit_terminal_reply");
+    // The decision and message reach the recorder so timeline UIs render them.
+    expect(evalStage.evaluation.decision).toBe("FINISH");
+    expect(evalStage.evaluation.messageToUser).toBe("Status check passed.");
+    // No `model` block — there was no LLM call to attribute.
+    expect(evalStage.model).toBeUndefined();
+  });
 
-	it("records a FINISH evaluation when a terminal REPLY ends a continued tool loop", async () => {
-		let plannerCallCount = 0;
-		const runtime = {
-			useModel: vi.fn(async () => {
-				plannerCallCount++;
-				if (plannerCallCount === 1) {
-					return {
-						text: "",
-						toolCalls: [
-							{ id: "call-1", name: "LOOKUP", arguments: { q: "disk" } },
-						],
-					};
-				}
-				return {
-					text: "",
-					toolCalls: [
-						{
-							id: "call-final",
-							name: "REPLY",
-							arguments: { text: "Disk usage checked." },
-						},
-					],
-				};
-			}),
-		};
-		const evaluate = vi.fn(async () => ({
-			success: false,
-			decision: "CONTINUE" as const,
-			thought: "Need the planner to produce the final reply.",
-		}));
-		const recordedStages: RecordedStage[] = [];
-		const recorder: TrajectoryRecorder = {
-			startTrajectory: vi.fn(() => "trajectory-terminal"),
-			recordStage: vi.fn(
-				async (_trajectoryId: string, stage: RecordedStage) => {
-					recordedStages.push(stage);
-				},
-			),
-			endTrajectory: vi.fn(async () => undefined),
-			load: vi.fn(async () => null),
-			list: vi.fn(async () => []),
-		};
+  it("records a FINISH evaluation when a terminal REPLY ends a continued tool loop", async () => {
+    let plannerCallCount = 0;
+    const runtime = {
+      useModel: vi.fn(async () => {
+        plannerCallCount++;
+        if (plannerCallCount === 1) {
+          return {
+            text: "",
+            toolCalls: [
+              { id: "call-1", name: "LOOKUP", arguments: { q: "disk" } },
+            ],
+          };
+        }
+        return {
+          text: "",
+          toolCalls: [
+            {
+              id: "call-final",
+              name: "REPLY",
+              arguments: { text: "Disk usage checked." },
+            },
+          ],
+        };
+      }),
+    };
+    const evaluate = vi.fn(async () => ({
+      success: false,
+      decision: "CONTINUE" as const,
+      thought: "Need the planner to produce the final reply.",
+    }));
+    const recordedStages: RecordedStage[] = [];
+    const recorder: TrajectoryRecorder = {
+      startTrajectory: vi.fn(() => "trajectory-terminal"),
+      recordStage: vi.fn(
+        async (_trajectoryId: string, stage: RecordedStage) => {
+          recordedStages.push(stage);
+        },
+      ),
+      endTrajectory: vi.fn(async () => undefined),
+      load: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+    };
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx-terminal" },
-			executeToolCall: vi.fn(async () => ({
-				success: true,
-				text: "df output",
-			})),
-			evaluate,
-			recorder,
-			trajectoryId: "trajectory-terminal",
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx-terminal" },
+      executeToolCall: vi.fn(async () => ({
+        success: true,
+        text: "df output",
+      })),
+      evaluate,
+      recorder,
+      trajectoryId: "trajectory-terminal",
+    });
 
-		expect(evaluate).toHaveBeenCalledTimes(1);
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe("Disk usage checked.");
-		expect(result.evaluator?.decision).toBe("FINISH");
-		expect(
-			result.trajectory.evaluatorOutputs.map((item) => item.decision),
-		).toEqual(["CONTINUE", "FINISH"]);
-		const evalStages = recordedStages.filter(
-			(stage) => stage.kind === "evaluation",
-		);
-		expect(evalStages.at(-1)?.evaluation).toMatchObject({
-			decision: "FINISH",
-			messageToUser: "Disk usage checked.",
-			gated: true,
-			llmCallSkipped: true,
-			reason: "terminal_tool_call",
-		});
-	});
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBe("Disk usage checked.");
+    expect(result.evaluator?.decision).toBe("FINISH");
+    expect(
+      result.trajectory.evaluatorOutputs.map((item) => item.decision),
+    ).toEqual(["CONTINUE", "FINISH"]);
+    const evalStages = recordedStages.filter(
+      (stage) => stage.kind === "evaluation",
+    );
+    expect(evalStages.at(-1)?.evaluation).toMatchObject({
+      decision: "FINISH",
+      messageToUser: "Disk usage checked.",
+      gated: true,
+      llmCallSkipped: true,
+      reason: "terminal_tool_call",
+    });
+  });
 
-	it("WITHHOLDS in native-mode (text fallback, no explicit messageToUser) — evaluator IS called", async () => {
-		// Native tool-call returns infer messageToUser from `text`. That path is
-		// ambiguous (thought vs final answer), so the gate must withhold.
-		const runtime = {
-			useModel: plannerNativeWith({
-				text: "thinking",
-				toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Real evaluator decision.",
-			messageToUser: "Status: ok.",
-		}));
+  it("WITHHOLDS in native-mode (text fallback, no explicit messageToUser) — evaluator IS called", async () => {
+    // Native tool-call returns infer messageToUser from `text`. That path is
+    // ambiguous (thought vs final answer), so the gate must withhold.
+    const runtime = {
+      useModel: plannerNativeWith({
+        text: "thinking",
+        toolCalls: [{ id: "call-1", name: "LOOKUP", arguments: {} }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Real evaluator decision.",
+      messageToUser: "Status: ok.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).toHaveBeenCalledTimes(1);
-		expect(result.finalMessage).toBe("Status: ok.");
-	});
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.finalMessage).toBe("Status: ok.");
+  });
 
-	it("WITHHOLDS on tool failure — evaluator IS called", async () => {
-		const runtime = {
-			useModel: plannerJsonWith({
-				messageToUser: "Should not be used because tool failed.",
-				toolCalls: [{ name: "LOOKUP", args: {} }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({
-			success: false,
-			error: "boom",
-		}));
-		const evaluate = vi.fn(async () => ({
-			success: false,
-			decision: "FINISH" as const,
-			thought: "Halted after failure.",
-			messageToUser: "Could not check status.",
-		}));
+  it("WITHHOLDS on tool failure — evaluator IS called", async () => {
+    const runtime = {
+      useModel: plannerJsonWith({
+        messageToUser: "Should not be used because tool failed.",
+        toolCalls: [{ name: "LOOKUP", args: {} }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({
+      success: false,
+      error: "boom",
+    }));
+    const evaluate = vi.fn(async () => ({
+      success: false,
+      decision: "FINISH" as const,
+      thought: "Halted after failure.",
+      messageToUser: "Could not check status.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).toHaveBeenCalledTimes(1);
-		expect(result.evaluator?.thought).toBe("Halted after failure.");
-	});
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.evaluator?.thought).toBe("Halted after failure.");
+  });
 
-	it("WITHHOLDS when more tools remain queued — evaluator IS called", async () => {
-		const runtime = {
-			useModel: plannerJsonWith({
-				messageToUser: "Will not be used while plan is incomplete.",
-				toolCalls: [
-					{ name: "LOOKUP", args: {} },
-					{ name: "FOLLOW_UP", args: {} },
-				],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Real evaluator called.",
-		}));
+  it("WITHHOLDS when more tools remain queued — evaluator IS called", async () => {
+    const runtime = {
+      useModel: plannerJsonWith({
+        messageToUser: "Will not be used while plan is incomplete.",
+        toolCalls: [
+          { name: "LOOKUP", args: {} },
+          { name: "FOLLOW_UP", args: {} },
+        ],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Real evaluator called.",
+    }));
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).toHaveBeenCalled();
-	});
+    expect(evaluate).toHaveBeenCalled();
+  });
 
-	it("WITHHOLDS when planner produced no messageToUser — evaluator IS called", async () => {
-		const runtime = {
-			useModel: plannerJsonWith({
-				// No messageToUser field at all.
-				toolCalls: [{ name: "LOOKUP", args: {} }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Real evaluator decision.",
-			messageToUser: "Status: ok.",
-		}));
+  it("WITHHOLDS when planner produced no messageToUser — evaluator IS called", async () => {
+    const runtime = {
+      useModel: plannerJsonWith({
+        // No messageToUser field at all.
+        toolCalls: [{ name: "LOOKUP", args: {} }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Real evaluator decision.",
+      messageToUser: "Status: ok.",
+    }));
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).toHaveBeenCalledTimes(1);
-		expect(result.finalMessage).toBe("Status: ok.");
-	});
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.finalMessage).toBe("Status: ok.");
+  });
 
-	it("WITHHOLDS when explicit messageToUser contains tool-call syntax — evaluator IS called", async () => {
-		// isUnsafeUserVisibleText (reused by the gate) catches tool/function
-		// syntax leakage. The evaluator's own prompt rules force CONTINUE on
-		// leaked syntax; the gate honors the same constraint.
-		const runtime = {
-			useModel: plannerJsonWith({
-				messageToUser: "I'll need to call to=functions.LOOKUP next to verify.",
-				toolCalls: [{ name: "LOOKUP", args: {} }],
-			}),
-		};
-		const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
-		const evaluate = vi.fn(async () => ({
-			success: true,
-			decision: "FINISH" as const,
-			thought: "Real evaluator caught the leaked syntax.",
-			messageToUser: "Done.",
-		}));
+  it("WITHHOLDS when explicit messageToUser contains tool-call syntax — evaluator IS called", async () => {
+    // isUnsafeUserVisibleText (reused by the gate) catches tool/function
+    // syntax leakage. The evaluator's own prompt rules force CONTINUE on
+    // leaked syntax; the gate honors the same constraint.
+    const runtime = {
+      useModel: plannerJsonWith({
+        messageToUser: "I'll need to call to=functions.LOOKUP next to verify.",
+        toolCalls: [{ name: "LOOKUP", args: {} }],
+      }),
+    };
+    const executeToolCall = vi.fn(async () => ({ success: true, text: "ok" }));
+    const evaluate = vi.fn(async () => ({
+      success: true,
+      decision: "FINISH" as const,
+      thought: "Real evaluator caught the leaked syntax.",
+      messageToUser: "Done.",
+    }));
 
-		await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall,
-			evaluate,
-		});
+    await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall,
+      evaluate,
+    });
 
-		expect(evaluate).toHaveBeenCalled();
-	});
+    expect(evaluate).toHaveBeenCalled();
+  });
 
-	it("never surfaces scratch prose accompanying a STOP-only terminal", async () => {
-		// Live regression 2026-06-12 (tj-5d0d458b7ad281): after spawning a
-		// sub-agent the planner emitted STOP plus the free text "We should wait
-		// for the sub-agent result before replying." — and that scratch
-		// reasoning was sent to Discord verbatim as the reply.
-		const runtime = {
-			useModel: vi.fn().mockResolvedValueOnce({
-				text: "We should wait for the sub-agent result before replying.",
-				toolCalls: [{ id: "stop-1", name: "STOP", arguments: {} }],
-			}),
-			logger: { warn: vi.fn() },
-		};
+  it("never surfaces scratch prose accompanying a STOP-only terminal", async () => {
+    // Live regression 2026-06-12 (tj-5d0d458b7ad281): after spawning a
+    // sub-agent the planner emitted STOP plus the free text "We should wait
+    // for the sub-agent result before replying." — and that scratch
+    // reasoning was sent to Discord verbatim as the reply.
+    const runtime = {
+      useModel: vi.fn().mockResolvedValueOnce({
+        text: "We should wait for the sub-agent result before replying.",
+        toolCalls: [{ id: "stop-1", name: "STOP", arguments: {} }],
+      }),
+      logger: { warn: vi.fn() },
+    };
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall: vi.fn(),
-			evaluate: vi.fn(),
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall: vi.fn(),
+      evaluate: vi.fn(),
+    });
 
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBeUndefined();
-	});
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBeUndefined();
+  });
 
-	it("keeps the prose fallback for a textless REPLY terminal", async () => {
-		// Counterpart contract: when the model DID choose REPLY but put the
-		// answer in the text channel instead of the call args, the prose is
-		// the reply and must still reach the user.
-		const runtime = {
-			useModel: vi.fn().mockResolvedValueOnce({
-				text: "Here is your answer.",
-				toolCalls: [{ id: "reply-1", name: "REPLY", arguments: {} }],
-			}),
-			logger: { warn: vi.fn() },
-		};
+  it("keeps the prose fallback for a textless REPLY terminal", async () => {
+    // Counterpart contract: when the model DID choose REPLY but put the
+    // answer in the text channel instead of the call args, the prose is
+    // the reply and must still reach the user.
+    const runtime = {
+      useModel: vi.fn().mockResolvedValueOnce({
+        text: "Here is your answer.",
+        toolCalls: [{ id: "reply-1", name: "REPLY", arguments: {} }],
+      }),
+      logger: { warn: vi.fn() },
+    };
 
-		const result = await runPlannerLoop({
-			runtime,
-			context: { id: "ctx" },
-			executeToolCall: vi.fn(),
-			evaluate: vi.fn(),
-		});
+    const result = await runPlannerLoop({
+      runtime,
+      context: { id: "ctx" },
+      executeToolCall: vi.fn(),
+      evaluate: vi.fn(),
+    });
 
-		expect(result.status).toBe("finished");
-		expect(result.finalMessage).toBe("Here is your answer.");
-	});
+    expect(result.status).toBe("finished");
+    expect(result.finalMessage).toBe("Here is your answer.");
+  });
 });

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -1,216 +1,228 @@
 export interface ChainingLoopConfig {
-	/** Maximum tool calls executed during one planner loop. */
-	maxToolCalls: number;
-	/** Maximum repeated failures for the same tool/error signature. */
-	maxRepeatedFailures: number;
-	/** Maximum planner misses when Stage 1 requires a tool before failing fast. */
-	maxRequiredToolMisses: number;
-	/** Maximum planner retries after it calls only tools unavailable this turn. */
-	maxUnavailableToolCallRetries: number;
-	/** Maximum terminal-only planner turns that still evaluate to CONTINUE. */
-	maxTerminalOnlyContinuations: number;
-	/** Estimated model context window for compaction decisions. */
-	contextWindowTokens: number;
-	/**
-	 * Optional model id used to resolve the *actual* per-model context
-	 * window (and a 20%-of-window reserve floor) at compaction-budget time
-	 * via `lookupModelContextWindow`. When set and the lookup hits, this
-	 * wins over `contextWindowTokens` — letting tight-context models
-	 * (Cerebras llama3.1-8b at 32k, qwen at 64k, gpt-oss-120b at 131k) get
-	 * a budget sized to their real ceiling instead of the 128k default.
-	 *
-	 * Optional and additive: when unset, the existing
-	 * `contextWindowTokens` + `compactionReserveTokens` pair is used as
-	 * before.
-	 */
-	contextWindowModelName?: string;
-	/** Token reserve kept free for model output and provider overhead. */
-	compactionReserveTokens: number;
-	/**
-	 * @internal Tracks whether `compactionReserveTokens` came from the caller
-	 * rather than `DEFAULT_CHAINING_LOOP_CONFIG`. This lets the planner apply
-	 * the per-model derived reserve when only `contextWindowModelName` is set,
-	 * while still preserving explicit reserve overrides.
-	 */
-	compactionReserveTokensExplicit?: boolean;
-	/** Whether the planner may summarize old trajectory steps before replanning. */
-	compactionEnabled: boolean;
-	/** Number of newest completed tool steps kept verbatim after compaction. */
-	compactionKeepSteps: number;
-	/**
-	 * Maximum cumulative prompt tokens summed across every planner-stage
-	 * model call within a single user turn. Once exceeded the loop aborts
-	 * with `TrajectoryLimitExceeded({kind:"trajectory_token_budget"})`,
-	 * bounding the worst-case cost of a runaway replan.
-	 *
-	 * The count tracks **gross prompt tokens** (cached + non-cached + cache
-	 * write) — the same number the provider would meter you on; cache reads
-	 * count too because they still consume context and walltime even if the
-	 * dollar cost is discounted.
-	 *
-	 * Set to `Number.POSITIVE_INFINITY` to disable the guard. The default
-	 * of 1.5M tokens is calibrated against observed trajectories:
-	 *   - well-formed single-turn answers: 50k–250k cumulative tokens.
-	 *   - normal multi-step tool chains: 400k–800k cumulative.
-	 *   - the runaway replan that motivated this guard: 2.2M cumulative
-	 *     (13 planner iterations growing monotonically until the model's
-	 *     per-call window overflowed).
-	 *
-	 * 1.5M sits comfortably above legitimate traffic and well below the
-	 * runaway level — a turn that exceeds it is almost certainly stuck.
-	 */
-	maxTrajectoryPromptTokens: number;
-	/**
-	 * When set, caps each tool-result string rendered into the planner
-	 * input to this many characters (head + `[N chars truncated]` marker
-	 * + tail). The trajectory itself is unchanged — only the wire-shape
-	 * messages are truncated.
-	 *
-	 * Why this exists: the compactor keeps the four newest steps
-	 * verbatim by default (`compactionKeepSteps: 4`). A single
-	 * pathologically-large tool result inside the kept window — a 30 KB
-	 * shell dump, a multi-thousand-line file read, a full grep — can
-	 * blow the model's per-call context budget single-handedly, even
-	 * after compaction has done its job. This cap protects against that
-	 * single-step pathology without touching the trajectory's
-	 * archival/replay fidelity.
-	 *
-	 * Default: undefined (no cap — exact pre-PR behavior). Recommended
-	 * for tight-context models: ~8000 (one tool result still gets
-	 * roughly two pages of head + a half page of tail context).
-	 */
-	compactionMaxKeptStepChars?: number;
+  /** Maximum tool calls executed during one planner loop. */
+  maxToolCalls: number;
+  /** Maximum repeated failures for the same tool/error signature. */
+  maxRepeatedFailures: number;
+  /** Maximum planner misses when Stage 1 requires a tool before failing fast. */
+  maxRequiredToolMisses: number;
+  /** Maximum planner retries after it calls only tools unavailable this turn. */
+  maxUnavailableToolCallRetries: number;
+  /** Maximum terminal-only planner turns that still evaluate to CONTINUE. */
+  maxTerminalOnlyContinuations: number;
+  /**
+   * Maximum planner iterations whose only non-terminal tool calls exactly
+   * repeat a call that already SUCCEEDED this turn (same tool name + args).
+   * Re-running an identical successful call cannot yield new information; a
+   * model that keeps doing so is stuck (observed live: gpt-5.5 re-issuing the
+   * same WEB_FETCH 17× until `maxTrajectoryPromptTokens` aborted the turn with
+   * a generic apology). Once exceeded, the loop stops re-executing and forces
+   * one terminal synthesis call so the user gets the answer already gathered.
+   * This is the success-side analog of `maxRepeatedFailures`.
+   */
+  maxRepeatedToolCalls: number;
+  /** Estimated model context window for compaction decisions. */
+  contextWindowTokens: number;
+  /**
+   * Optional model id used to resolve the *actual* per-model context
+   * window (and a 20%-of-window reserve floor) at compaction-budget time
+   * via `lookupModelContextWindow`. When set and the lookup hits, this
+   * wins over `contextWindowTokens` — letting tight-context models
+   * (Cerebras llama3.1-8b at 32k, qwen at 64k, gpt-oss-120b at 131k) get
+   * a budget sized to their real ceiling instead of the 128k default.
+   *
+   * Optional and additive: when unset, the existing
+   * `contextWindowTokens` + `compactionReserveTokens` pair is used as
+   * before.
+   */
+  contextWindowModelName?: string;
+  /** Token reserve kept free for model output and provider overhead. */
+  compactionReserveTokens: number;
+  /**
+   * @internal Tracks whether `compactionReserveTokens` came from the caller
+   * rather than `DEFAULT_CHAINING_LOOP_CONFIG`. This lets the planner apply
+   * the per-model derived reserve when only `contextWindowModelName` is set,
+   * while still preserving explicit reserve overrides.
+   */
+  compactionReserveTokensExplicit?: boolean;
+  /** Whether the planner may summarize old trajectory steps before replanning. */
+  compactionEnabled: boolean;
+  /** Number of newest completed tool steps kept verbatim after compaction. */
+  compactionKeepSteps: number;
+  /**
+   * Maximum cumulative prompt tokens summed across every planner-stage
+   * model call within a single user turn. Once exceeded the loop aborts
+   * with `TrajectoryLimitExceeded({kind:"trajectory_token_budget"})`,
+   * bounding the worst-case cost of a runaway replan.
+   *
+   * The count tracks **gross prompt tokens** (cached + non-cached + cache
+   * write) — the same number the provider would meter you on; cache reads
+   * count too because they still consume context and walltime even if the
+   * dollar cost is discounted.
+   *
+   * Set to `Number.POSITIVE_INFINITY` to disable the guard. The default
+   * of 1.5M tokens is calibrated against observed trajectories:
+   *   - well-formed single-turn answers: 50k–250k cumulative tokens.
+   *   - normal multi-step tool chains: 400k–800k cumulative.
+   *   - the runaway replan that motivated this guard: 2.2M cumulative
+   *     (13 planner iterations growing monotonically until the model's
+   *     per-call window overflowed).
+   *
+   * 1.5M sits comfortably above legitimate traffic and well below the
+   * runaway level — a turn that exceeds it is almost certainly stuck.
+   */
+  maxTrajectoryPromptTokens: number;
+  /**
+   * When set, caps each tool-result string rendered into the planner
+   * input to this many characters (head + `[N chars truncated]` marker
+   * + tail). The trajectory itself is unchanged — only the wire-shape
+   * messages are truncated.
+   *
+   * Why this exists: the compactor keeps the four newest steps
+   * verbatim by default (`compactionKeepSteps: 4`). A single
+   * pathologically-large tool result inside the kept window — a 30 KB
+   * shell dump, a multi-thousand-line file read, a full grep — can
+   * blow the model's per-call context budget single-handedly, even
+   * after compaction has done its job. This cap protects against that
+   * single-step pathology without touching the trajectory's
+   * archival/replay fidelity.
+   *
+   * Default: undefined (no cap — exact pre-PR behavior). Recommended
+   * for tight-context models: ~8000 (one tool result still gets
+   * roughly two pages of head + a half page of tail context).
+   */
+  compactionMaxKeptStepChars?: number;
 }
 
 export const DEFAULT_CHAINING_LOOP_CONFIG: ChainingLoopConfig = {
-	maxToolCalls: 16,
-	maxRepeatedFailures: 2,
-	maxRequiredToolMisses: 3,
-	maxUnavailableToolCallRetries: 3,
-	maxTerminalOnlyContinuations: 2,
-	contextWindowTokens: 128_000,
-	compactionReserveTokens: 10_000,
-	compactionEnabled: true,
-	compactionKeepSteps: 4,
-	maxTrajectoryPromptTokens: 1_500_000,
+  maxToolCalls: 16,
+  maxRepeatedFailures: 2,
+  maxRequiredToolMisses: 3,
+  maxUnavailableToolCallRetries: 3,
+  maxTerminalOnlyContinuations: 2,
+  maxRepeatedToolCalls: 2,
+  contextWindowTokens: 128_000,
+  compactionReserveTokens: 10_000,
+  compactionEnabled: true,
+  compactionKeepSteps: 4,
+  maxTrajectoryPromptTokens: 1_500_000,
 };
 
 export type TrajectoryLimitKind =
-	| "tool_calls"
-	| "repeated_failures"
-	| "required_tool_misses"
-	| "unavailable_tool_calls"
-	| "terminal_only_continuations"
-	| "trajectory_token_budget";
+  | "tool_calls"
+  | "repeated_failures"
+  | "required_tool_misses"
+  | "unavailable_tool_calls"
+  | "terminal_only_continuations"
+  | "trajectory_token_budget";
 
 export class TrajectoryLimitExceeded extends Error {
-	readonly kind: TrajectoryLimitKind;
-	readonly max: number;
-	readonly observed: number;
+  readonly kind: TrajectoryLimitKind;
+  readonly max: number;
+  readonly observed: number;
 
-	constructor(params: {
-		kind: TrajectoryLimitKind;
-		max: number;
-		observed: number;
-		message?: string;
-	}) {
-		super(
-			params.message ??
-				`Trajectory limit exceeded: ${params.kind} (${params.observed}/${params.max})`,
-		);
-		this.name = "TrajectoryLimitExceeded";
-		this.kind = params.kind;
-		this.max = params.max;
-		this.observed = params.observed;
-	}
+  constructor(params: {
+    kind: TrajectoryLimitKind;
+    max: number;
+    observed: number;
+    message?: string;
+  }) {
+    super(
+      params.message ??
+        `Trajectory limit exceeded: ${params.kind} (${params.observed}/${params.max})`,
+    );
+    this.name = "TrajectoryLimitExceeded";
+    this.kind = params.kind;
+    this.max = params.max;
+    this.observed = params.observed;
+  }
 }
 
 export function mergeChainingLoopConfig(
-	config?: Partial<ChainingLoopConfig>,
+  config?: Partial<ChainingLoopConfig>,
 ): ChainingLoopConfig {
-	return {
-		...DEFAULT_CHAINING_LOOP_CONFIG,
-		...config,
-		compactionReserveTokensExplicit:
-			config?.compactionReserveTokens !== undefined ||
-			config?.compactionReserveTokensExplicit === true,
-	};
+  return {
+    ...DEFAULT_CHAINING_LOOP_CONFIG,
+    ...config,
+    compactionReserveTokensExplicit:
+      config?.compactionReserveTokens !== undefined ||
+      config?.compactionReserveTokensExplicit === true,
+  };
 }
 
 export function assertTrajectoryLimit(params: {
-	kind: TrajectoryLimitKind;
-	max: number;
-	observed: number;
+  kind: TrajectoryLimitKind;
+  max: number;
+  observed: number;
 }): void {
-	if (params.observed > params.max) {
-		throw new TrajectoryLimitExceeded(params);
-	}
+  if (params.observed > params.max) {
+    throw new TrajectoryLimitExceeded(params);
+  }
 }
 
 export interface FailureLike {
-	toolName?: string;
-	error?: unknown;
-	success?: boolean;
-	repeatKey?: string;
+  toolName?: string;
+  error?: unknown;
+  success?: boolean;
+  repeatKey?: string;
 }
 
 export function getFailureSignature(failure: FailureLike): string | null {
-	if (failure.success !== false && failure.error == null) {
-		return null;
-	}
+  if (failure.success !== false && failure.error == null) {
+    return null;
+  }
 
-	const toolName = failure.toolName?.trim() || "unknown_tool";
-	const rawError =
-		failure.error instanceof Error
-			? failure.error.message
-			: typeof failure.error === "string"
-				? failure.error
-				: failure.error == null
-					? "failed"
-					: JSON.stringify(failure.error);
-	const normalizedError = rawError.trim().replace(/\s+/g, " ").slice(0, 240);
-	return `${toolName}:${normalizedError}`;
+  const toolName = failure.toolName?.trim() || "unknown_tool";
+  const rawError =
+    failure.error instanceof Error
+      ? failure.error.message
+      : typeof failure.error === "string"
+        ? failure.error
+        : failure.error == null
+          ? "failed"
+          : JSON.stringify(failure.error);
+  const normalizedError = rawError.trim().replace(/\s+/g, " ").slice(0, 240);
+  return `${toolName}:${normalizedError}`;
 }
 
 export function countRepeatedFailures(
-	failures: readonly FailureLike[],
-	latestFailure: FailureLike,
+  failures: readonly FailureLike[],
+  latestFailure: FailureLike,
 ): number {
-	const latestSignature = getFailureComparisonKey(latestFailure);
-	if (!latestSignature) {
-		return 0;
-	}
+  const latestSignature = getFailureComparisonKey(latestFailure);
+  if (!latestSignature) {
+    return 0;
+  }
 
-	let count = 0;
-	for (const failure of failures) {
-		if (getFailureComparisonKey(failure) === latestSignature) {
-			count += 1;
-		}
-	}
-	return count;
+  let count = 0;
+  for (const failure of failures) {
+    if (getFailureComparisonKey(failure) === latestSignature) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function getFailureComparisonKey(failure: FailureLike): string | null {
-	const signature = getFailureSignature(failure);
-	if (!signature) return null;
-	const repeatKey = failure.repeatKey?.trim();
-	return repeatKey ? `${signature}:${repeatKey.slice(0, 240)}` : signature;
+  const signature = getFailureSignature(failure);
+  if (!signature) return null;
+  const repeatKey = failure.repeatKey?.trim();
+  return repeatKey ? `${signature}:${repeatKey.slice(0, 240)}` : signature;
 }
 
 export function assertRepeatedFailureLimit(params: {
-	failures: readonly FailureLike[];
-	latestFailure: FailureLike;
-	maxRepeatedFailures: number;
+  failures: readonly FailureLike[];
+  latestFailure: FailureLike;
+  maxRepeatedFailures: number;
 }): void {
-	const observed = countRepeatedFailures(params.failures, params.latestFailure);
-	if (observed > params.maxRepeatedFailures) {
-		throw new TrajectoryLimitExceeded({
-			kind: "repeated_failures",
-			max: params.maxRepeatedFailures,
-			observed,
-			message: `Repeated tool failure limit exceeded for ${getFailureSignature(
-				params.latestFailure,
-			)}`,
-		});
-	}
+  const observed = countRepeatedFailures(params.failures, params.latestFailure);
+  if (observed > params.maxRepeatedFailures) {
+    throw new TrajectoryLimitExceeded({
+      kind: "repeated_failures",
+      max: params.maxRepeatedFailures,
+      observed,
+      message: `Repeated tool failure limit exceeded for ${getFailureSignature(
+        params.latestFailure,
+      )}`,
+    });
+  }
 }

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -5,730 +5,780 @@ import { logger } from "../logger";
 import { plannerSchema, plannerTemplate } from "../prompts/planner";
 import { resolveOptimizedPromptForRuntime } from "../services/optimized-prompt-resolver";
 import {
-	emitStreamingHook,
-	getStreamingContext,
-	runWithStreamingContext,
+  emitStreamingHook,
+  getStreamingContext,
+  runWithStreamingContext,
 } from "../streaming-context";
 import type { ActionResult, ProviderDataRecord } from "../types/components";
 import type { ContextEvent, ContextObjectTool } from "../types/context-object";
 import {
-	type ChatMessage,
-	type GenerateTextResult,
-	ModelType,
-	type PromptSegment,
-	type ResponseSkeleton,
-	type SpanSamplerPlan,
-	type TextGenerationModelType,
-	type ToolCall,
-	type ToolChoice,
-	type ToolDefinition,
+  type ChatMessage,
+  type GenerateTextResult,
+  ModelType,
+  type PromptSegment,
+  type ResponseSkeleton,
+  type SpanSamplerPlan,
+  type TextGenerationModelType,
+  type ToolCall,
+  type ToolChoice,
+  type ToolDefinition,
 } from "../types/model";
 import { resolveStateDir } from "../utils/state-dir";
 import { computePrefixHashes } from "./context-hash";
 import { appendContextEvent } from "./context-object";
 import {
-	buildStageChatMessages,
-	cachePrefixSegments,
-	normalizePromptSegments,
-	renderContextObject,
+  buildStageChatMessages,
+  cachePrefixSegments,
+  normalizePromptSegments,
+  renderContextObject,
 } from "./context-renderer";
 import { runEvaluator } from "./evaluator";
 import {
-	extractJsonObjects,
-	parseJsonObject,
-	stringifyForModel,
+  extractJsonObjects,
+  parseJsonObject,
+  stringifyForModel,
 } from "./json-output";
 import {
-	assertRepeatedFailureLimit,
-	assertTrajectoryLimit,
-	type ChainingLoopConfig,
-	type FailureLike,
-	mergeChainingLoopConfig,
-	TrajectoryLimitExceeded,
+  assertRepeatedFailureLimit,
+  assertTrajectoryLimit,
+  type ChainingLoopConfig,
+  type FailureLike,
+  mergeChainingLoopConfig,
+  TrajectoryLimitExceeded,
 } from "./limits";
 import {
-	buildModelInputBudget,
-	type ModelInputBudget,
-	withModelInputBudgetProviderOptions,
+  buildModelInputBudget,
+  type ModelInputBudget,
+  withModelInputBudgetProviderOptions,
 } from "./model-input-budget";
 import {
-	cacheProviderOptions,
-	toolMessageContent,
-	trajectoryStepsToMessages,
+  cacheProviderOptions,
+  toolMessageContent,
+  trajectoryStepsToMessages,
 } from "./planner-rendering";
 import type {
-	ContextObject,
-	EvaluatorOutput,
-	PlannerLoopParams,
-	PlannerLoopResult,
-	PlannerRuntime,
-	PlannerStep,
-	PlannerToolCall,
-	PlannerToolResult,
-	PlannerTrajectory,
+  ContextObject,
+  EvaluatorOutput,
+  PlannerLoopParams,
+  PlannerLoopResult,
+  PlannerRuntime,
+  PlannerStep,
+  PlannerToolCall,
+  PlannerToolResult,
+  PlannerTrajectory,
 } from "./planner-types";
 import {
-	buildPlannerActionGrammarStrict,
-	buildSpanSamplerPlan,
-	withGuidedDecodeProviderOptions,
+  buildPlannerActionGrammarStrict,
+  buildSpanSamplerPlan,
+  withGuidedDecodeProviderOptions,
 } from "./response-grammar";
 import type {
-	RecordedStage,
-	RecordedToolCall,
-	RecordedUsage,
-	TrajectoryRecorder,
+  RecordedStage,
+  RecordedToolCall,
+  RecordedUsage,
+  TrajectoryRecorder,
 } from "./trajectory-recorder";
 import { captureToolStageIO } from "./trajectory-recorder";
 
 export {
-	cacheProviderOptions,
-	trajectoryStepsToMessages,
+  cacheProviderOptions,
+  trajectoryStepsToMessages,
 } from "./planner-rendering";
 
 // Test-only re-exports for the rendering memoization unit tests.
 // Underscore-prefixed so they're impossible to mistake for production API.
 export function __renderRoutingHintsBlockForTests(
-	context: ContextObject,
+  context: ContextObject,
 ): string | null {
-	return renderRoutingHintsBlock(context);
+  return renderRoutingHintsBlock(context);
 }
 export type {
-	ContextObject,
-	EvaluatorEffects,
-	EvaluatorOutput,
-	PlannerLoopParams,
-	PlannerLoopResult,
-	PlannerRuntime,
-	PlannerStep,
-	PlannerToolCall,
-	PlannerToolResult,
-	PlannerTrajectory,
+  ContextObject,
+  EvaluatorEffects,
+  EvaluatorOutput,
+  PlannerLoopParams,
+  PlannerLoopResult,
+  PlannerRuntime,
+  PlannerStep,
+  PlannerToolCall,
+  PlannerToolResult,
+  PlannerTrajectory,
 } from "./planner-types";
 
 const DEFAULT_PLANNER_MAX_TOKENS = 1024;
 
 interface RawPlannerOutput {
-	action?: unknown;
-	parameters?: unknown;
-	thought?: unknown;
-	toolCalls?: unknown;
-	messageToUser?: unknown;
-	text?: unknown;
-	// Optional explicit completion signal. When emitted as a boolean,
-	// `tryGateEvaluator` honors `completed=false` to fall through to the
-	// full evaluator instead of synthesizing a FINISH. See gate
-	// preconditions in `tryGateEvaluator`.
-	completed?: unknown;
+  action?: unknown;
+  parameters?: unknown;
+  thought?: unknown;
+  toolCalls?: unknown;
+  messageToUser?: unknown;
+  text?: unknown;
+  // Optional explicit completion signal. When emitted as a boolean,
+  // `tryGateEvaluator` honors `completed=false` to fall through to the
+  // full evaluator instead of synthesizing a FINISH. See gate
+  // preconditions in `tryGateEvaluator`.
+  completed?: unknown;
 }
 
 export async function runPlannerLoop(
-	params: PlannerLoopParams,
+  params: PlannerLoopParams,
 ): Promise<PlannerLoopResult> {
-	const plannerContext = normalizePlannerContext(params.context);
-	const config = mergeChainingLoopConfig(params.config);
-	const trajectory: PlannerTrajectory = {
-		context: plannerContext,
-		steps: [],
-		archivedSteps: [],
-		plannedQueue: [],
-		evaluatorOutputs: [],
-	};
-	const failures: FailureLike[] = [];
-	let terminalOnlyContinuations = 0;
-	let requiredToolMisses = 0;
-	let unavailableToolCallRetries = 0;
-	let silentFailedFinishRecoveries = 0;
-	const requireNonTerminalToolCall =
-		params.requireNonTerminalToolCall === true &&
-		hasExposedNonTerminalTool(params.tools);
+  const plannerContext = normalizePlannerContext(params.context);
+  const config = mergeChainingLoopConfig(params.config);
+  const trajectory: PlannerTrajectory = {
+    context: plannerContext,
+    steps: [],
+    archivedSteps: [],
+    plannedQueue: [],
+    evaluatorOutputs: [],
+  };
+  const failures: FailureLike[] = [];
+  let terminalOnlyContinuations = 0;
+  let requiredToolMisses = 0;
+  let unavailableToolCallRetries = 0;
+  let silentFailedFinishRecoveries = 0;
+  let repeatedNonTerminalToolCalls = 0;
+  const requireNonTerminalToolCall =
+    params.requireNonTerminalToolCall === true &&
+    hasExposedNonTerminalTool(params.tools);
 
-	// Cumulative gross prompt-token counter, summed across every planner
-	// stage in this user turn. Tracked alongside the existing per-iter
-	// counters (terminalOnlyContinuations, requiredToolMisses) so the
-	// `maxTrajectoryPromptTokens` guard fires on the very call that crosses
-	// the threshold rather than at the next-iteration check-in.
-	let cumulativePromptTokens = 0;
-	const observePlannerUsage = (usage: {
-		promptTokens: number;
-		completionTokens: number;
-	}): void => {
-		cumulativePromptTokens += usage.promptTokens;
-		if (cumulativePromptTokens > config.maxTrajectoryPromptTokens) {
-			throw new TrajectoryLimitExceeded({
-				kind: "trajectory_token_budget",
-				max: config.maxTrajectoryPromptTokens,
-				observed: cumulativePromptTokens,
-				message:
-					`Trajectory prompt-token budget exceeded ` +
-					`(${cumulativePromptTokens}/${config.maxTrajectoryPromptTokens}) — ` +
-					`this turn is most likely stuck in a replan loop; aborting to bound cost.`,
-			});
-		}
-	};
-	// Tracks the most recent planner output's *explicit* `messageToUser` so the
-	// post-tool evaluator gate can use it as the final response when the
-	// trajectory ends cleanly. EXPLICIT means the planner's structured output
-	// carried a `messageToUser` field — not a fallback inferred from a stray
-	// `text` field on a native tool-call return (which can be a pre-tool thought
-	// rather than a final answer). The gate refuses ambiguous signals to avoid
-	// surfacing a thought as the user-facing reply.
-	let lastPlannerExplicitMessageToUser: string | undefined;
-	// Tracks the most recent planner output's explicit `completed` flag, when
-	// emitted as a boolean. The gate (`tryGateEvaluator`) treats
-	// `completed === false` as a hard veto on synthesizing a FINISH — the
-	// planner is explicitly signaling that this turn's tool calls do not yet
-	// achieve the goal (e.g. read-then-act, multi-step deploy). When the
-	// field is absent the gate's other preconditions are honored as before.
-	let lastPlannerExplicitCompleted: boolean | undefined;
-	// Captures the most recent terminal-only refusal text the planner produced
-	// across iterations gated by `requireNonTerminalToolCall`. When Stage 1
-	// asserts `requiresTool=true` but no exposed tool can fulfill the request,
-	// the planner repeatedly emits REPLY (or bare messageToUser) with a valid
-	// honest refusal. Without this, the loop discards every refusal, exceeds
-	// `maxRequiredToolMisses`, throws `TrajectoryLimitExceeded`, and the
-	// caller surfaces a generic apology instead of the planner's real answer.
-	let lastTerminalRefusalText: string | undefined;
+  // Cumulative gross prompt-token counter, summed across every planner
+  // stage in this user turn. Tracked alongside the existing per-iter
+  // counters (terminalOnlyContinuations, requiredToolMisses) so the
+  // `maxTrajectoryPromptTokens` guard fires on the very call that crosses
+  // the threshold rather than at the next-iteration check-in.
+  let cumulativePromptTokens = 0;
+  const observePlannerUsage = (usage: {
+    promptTokens: number;
+    completionTokens: number;
+  }): void => {
+    cumulativePromptTokens += usage.promptTokens;
+    if (cumulativePromptTokens > config.maxTrajectoryPromptTokens) {
+      throw new TrajectoryLimitExceeded({
+        kind: "trajectory_token_budget",
+        max: config.maxTrajectoryPromptTokens,
+        observed: cumulativePromptTokens,
+        message:
+          `Trajectory prompt-token budget exceeded ` +
+          `(${cumulativePromptTokens}/${config.maxTrajectoryPromptTokens}) — ` +
+          `this turn is most likely stuck in a replan loop; aborting to bound cost.`,
+      });
+    }
+  };
+  // Tracks the most recent planner output's *explicit* `messageToUser` so the
+  // post-tool evaluator gate can use it as the final response when the
+  // trajectory ends cleanly. EXPLICIT means the planner's structured output
+  // carried a `messageToUser` field — not a fallback inferred from a stray
+  // `text` field on a native tool-call return (which can be a pre-tool thought
+  // rather than a final answer). The gate refuses ambiguous signals to avoid
+  // surfacing a thought as the user-facing reply.
+  let lastPlannerExplicitMessageToUser: string | undefined;
+  // Tracks the most recent planner output's explicit `completed` flag, when
+  // emitted as a boolean. The gate (`tryGateEvaluator`) treats
+  // `completed === false` as a hard veto on synthesizing a FINISH — the
+  // planner is explicitly signaling that this turn's tool calls do not yet
+  // achieve the goal (e.g. read-then-act, multi-step deploy). When the
+  // field is absent the gate's other preconditions are honored as before.
+  let lastPlannerExplicitCompleted: boolean | undefined;
+  // Captures the most recent terminal-only refusal text the planner produced
+  // across iterations gated by `requireNonTerminalToolCall`. When Stage 1
+  // asserts `requiresTool=true` but no exposed tool can fulfill the request,
+  // the planner repeatedly emits REPLY (or bare messageToUser) with a valid
+  // honest refusal. Without this, the loop discards every refusal, exceeds
+  // `maxRequiredToolMisses`, throws `TrajectoryLimitExceeded`, and the
+  // caller surfaces a generic apology instead of the planner's real answer.
+  let lastTerminalRefusalText: string | undefined;
 
-	for (let iteration = 1; ; iteration++) {
-		if (trajectory.plannedQueue.length === 0) {
-			const plannerOutput = await callPlanner({
-				runtime: params.runtime,
-				context: trajectory.context,
-				trajectory,
-				config,
-				modelType: params.modelType,
-				provider: params.provider,
-				tools: params.tools,
-				toolChoice: requireNonTerminalToolCall ? "required" : params.toolChoice,
-				recorder: params.recorder,
-				trajectoryId: params.trajectoryId,
-				parentStageId: params.parentStageId,
-				iteration,
-				onUsage: observePlannerUsage,
-			});
-			// Treat `messageToUser` as authoritative ONLY when the planner's structured
-			// output carried it as an explicit field. The native-tool-call code path
-			// in `parsePlannerOutput` falls back to `raw.text`, but in native mode
-			// `text` can be a pre-tool thought rather than a final answer — too
-			// ambiguous to drive the gate. We therefore probe `raw.messageToUser`
-			// directly here; native-mode returns won't have that key, so the gate
-			// stays inert in that path.
-			const explicit = plannerOutput.raw.messageToUser;
-			lastPlannerExplicitMessageToUser =
-				typeof explicit === "string" && explicit.trim().length > 0
-					? explicit
-					: undefined;
-			// Capture the planner's explicit `completed` boolean when present.
-			// Any non-boolean (string "false", number, null, missing) is treated
-			// as "unspecified" and does not influence the gate — only an actual
-			// `false` boolean blocks. This keeps backward compat with planner
-			// outputs that don't carry the field.
-			const completedRaw = plannerOutput.raw.completed;
-			lastPlannerExplicitCompleted =
-				typeof completedRaw === "boolean" ? completedRaw : undefined;
+  for (let iteration = 1; ; iteration++) {
+    if (trajectory.plannedQueue.length === 0) {
+      const plannerOutput = await callPlanner({
+        runtime: params.runtime,
+        context: trajectory.context,
+        trajectory,
+        config,
+        modelType: params.modelType,
+        provider: params.provider,
+        tools: params.tools,
+        // Force a tool call ONLY while the turn's "use a real tool" requirement
+        // is still unmet. Once a non-terminal tool has executed, relax to
+        // "auto" so the planner is free to synthesize a terminal REPLY from
+        // the result instead of being pushed to re-call a tool every
+        // iteration. "auto" must be EXPLICIT: passing the caller's (undefined)
+        // choice would be a no-op because callPlanner defaults undefined back
+        // to "required".
+        toolChoice: requireNonTerminalToolCall
+          ? hasExecutedNonTerminalTool(trajectory)
+            ? "auto"
+            : "required"
+          : params.toolChoice,
+        recorder: params.recorder,
+        trajectoryId: params.trajectoryId,
+        parentStageId: params.parentStageId,
+        iteration,
+        onUsage: observePlannerUsage,
+      });
+      // Treat `messageToUser` as authoritative ONLY when the planner's structured
+      // output carried it as an explicit field. The native-tool-call code path
+      // in `parsePlannerOutput` falls back to `raw.text`, but in native mode
+      // `text` can be a pre-tool thought rather than a final answer — too
+      // ambiguous to drive the gate. We therefore probe `raw.messageToUser`
+      // directly here; native-mode returns won't have that key, so the gate
+      // stays inert in that path.
+      const explicit = plannerOutput.raw.messageToUser;
+      lastPlannerExplicitMessageToUser =
+        typeof explicit === "string" && explicit.trim().length > 0
+          ? explicit
+          : undefined;
+      // Capture the planner's explicit `completed` boolean when present.
+      // Any non-boolean (string "false", number, null, missing) is treated
+      // as "unspecified" and does not influence the gate — only an actual
+      // `false` boolean blocks. This keeps backward compat with planner
+      // outputs that don't carry the field.
+      const completedRaw = plannerOutput.raw.completed;
+      lastPlannerExplicitCompleted =
+        typeof completedRaw === "boolean" ? completedRaw : undefined;
 
-			if (plannerOutput.toolCalls.length === 0) {
-				if (
-					requireNonTerminalToolCall &&
-					!hasExecutedNonTerminalTool(trajectory)
-				) {
-					const refusalCandidate = getNonEmptyString(
-						lastPlannerExplicitMessageToUser,
-					);
-					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
-					requiredToolMisses++;
-					if (
-						requiredToolMisses > config.maxRequiredToolMisses &&
-						lastTerminalRefusalText
-					) {
-						return finishWithCapturedRefusal({
-							trajectory,
-							iteration,
-							thought: plannerOutput.thought,
-							refusal: lastTerminalRefusalText,
-						});
-					}
-					assertTrajectoryLimit({
-						kind: "required_tool_misses",
-						max: config.maxRequiredToolMisses,
-						observed: requiredToolMisses,
-					});
-					handleRequiredToolPlannerMiss({
-						trajectory,
-						iteration,
-						plannerOutput,
-						reason: "no_tool_calls",
-						logger: params.runtime.logger,
-					});
-					continue;
-				}
-				trajectory.steps.push({
-					iteration,
-					thought: plannerOutput.thought,
-					terminalMessage: plannerOutput.messageToUser,
-					terminalOnly: true,
-				});
-				trajectory.context = appendTerminalPlannerOutputEvent({
-					context: trajectory.context,
-					iteration,
-					message: plannerOutput.messageToUser,
-				});
-				if (trajectory.steps.some((step) => step.toolCall)) {
-					const evaluator = await evaluateTrajectory(
-						params,
-						trajectory,
-						iteration,
-					);
-					trajectory.evaluatorOutputs.push(evaluator);
-					trajectory.context = appendEvaluationEvent({
-						context: trajectory.context,
-						iteration,
-						evaluator,
-					});
+      if (plannerOutput.toolCalls.length === 0) {
+        if (
+          requireNonTerminalToolCall &&
+          !hasExecutedNonTerminalTool(trajectory)
+        ) {
+          const refusalCandidate = getNonEmptyString(
+            lastPlannerExplicitMessageToUser,
+          );
+          if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
+          requiredToolMisses++;
+          if (
+            requiredToolMisses > config.maxRequiredToolMisses &&
+            lastTerminalRefusalText
+          ) {
+            return finishWithCapturedRefusal({
+              trajectory,
+              iteration,
+              thought: plannerOutput.thought,
+              refusal: lastTerminalRefusalText,
+            });
+          }
+          assertTrajectoryLimit({
+            kind: "required_tool_misses",
+            max: config.maxRequiredToolMisses,
+            observed: requiredToolMisses,
+          });
+          handleRequiredToolPlannerMiss({
+            trajectory,
+            iteration,
+            plannerOutput,
+            reason: "no_tool_calls",
+            logger: params.runtime.logger,
+          });
+          continue;
+        }
+        trajectory.steps.push({
+          iteration,
+          thought: plannerOutput.thought,
+          terminalMessage: plannerOutput.messageToUser,
+          terminalOnly: true,
+        });
+        trajectory.context = appendTerminalPlannerOutputEvent({
+          context: trajectory.context,
+          iteration,
+          message: plannerOutput.messageToUser,
+        });
+        if (trajectory.steps.some((step) => step.toolCall)) {
+          const evaluator = await evaluateTrajectory(
+            params,
+            trajectory,
+            iteration,
+          );
+          trajectory.evaluatorOutputs.push(evaluator);
+          trajectory.context = appendEvaluationEvent({
+            context: trajectory.context,
+            iteration,
+            evaluator,
+          });
 
-					if (evaluator.decision === "FINISH") {
-						return {
-							status: "finished",
-							trajectory,
-							evaluator,
-							finalMessage: userSafeFinalMessage(
-								preferredFinalMessageFromToolOrModel(
-									trajectory,
-									evaluator.messageToUser ?? plannerOutput.messageToUser,
-								),
-								trajectory,
-							),
-						};
-					}
+          if (evaluator.decision === "FINISH") {
+            return {
+              status: "finished",
+              trajectory,
+              evaluator,
+              finalMessage: userSafeFinalMessage(
+                preferredFinalMessageFromToolOrModel(
+                  trajectory,
+                  evaluator.messageToUser ?? plannerOutput.messageToUser,
+                ),
+                trajectory,
+              ),
+            };
+          }
 
-					if (evaluator.decision === "NEXT_RECOMMENDED") {
-						const selected = preferRecommendedToolCall(trajectory, evaluator);
-						if (!selected) {
-							params.runtime.logger?.warn?.(
-								{
-									recommendedToolCallId: evaluator.recommendedToolCallId,
-									queuedToolCallIds: trajectory.plannedQueue.map(
-										(call) => call.id,
-									),
-								},
-								"Evaluator requested NEXT_RECOMMENDED without a valid queued tool after terminal planner output; replanning",
-							);
-							trajectory.plannedQueue.length = 0;
-						}
-						continue;
-					}
+          if (evaluator.decision === "NEXT_RECOMMENDED") {
+            const selected = preferRecommendedToolCall(trajectory, evaluator);
+            if (!selected) {
+              params.runtime.logger?.warn?.(
+                {
+                  recommendedToolCallId: evaluator.recommendedToolCallId,
+                  queuedToolCallIds: trajectory.plannedQueue.map(
+                    (call) => call.id,
+                  ),
+                },
+                "Evaluator requested NEXT_RECOMMENDED without a valid queued tool after terminal planner output; replanning",
+              );
+              trajectory.plannedQueue.length = 0;
+            }
+            continue;
+          }
 
-					terminalOnlyContinuations++;
-					assertTrajectoryLimit({
-						kind: "terminal_only_continuations",
-						max: config.maxTerminalOnlyContinuations,
-						observed: terminalOnlyContinuations,
-					});
-					trajectory.plannedQueue.length = 0;
-					trajectory.context = appendTerminalContinuationEvent({
-						context: trajectory.context,
-						iteration,
-						terminalOnlyContinuations,
-						message: plannerOutput.messageToUser,
-					});
-					continue;
-				}
-				return {
-					status: "finished",
-					trajectory,
-					finalMessage: userSafeFinalMessage(
-						plannerOutput.messageToUser,
-						trajectory,
-					),
-				};
-			}
+          terminalOnlyContinuations++;
+          assertTrajectoryLimit({
+            kind: "terminal_only_continuations",
+            max: config.maxTerminalOnlyContinuations,
+            observed: terminalOnlyContinuations,
+          });
+          trajectory.plannedQueue.length = 0;
+          trajectory.context = appendTerminalContinuationEvent({
+            context: trajectory.context,
+            iteration,
+            terminalOnlyContinuations,
+            message: plannerOutput.messageToUser,
+          });
+          continue;
+        }
+        return {
+          status: "finished",
+          trajectory,
+          finalMessage: userSafeFinalMessage(
+            plannerOutput.messageToUser,
+            trajectory,
+          ),
+        };
+      }
 
-			if (plannerOutput.toolCalls.every(isTerminalToolCall)) {
-				if (
-					requireNonTerminalToolCall &&
-					!hasExecutedNonTerminalTool(trajectory)
-				) {
-					const refusalCandidate = terminalMessageFromToolCalls(
-						plannerOutput.toolCalls,
-						plannerOutput.messageToUser,
-					);
-					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
-					requiredToolMisses++;
-					if (
-						requiredToolMisses > config.maxRequiredToolMisses &&
-						lastTerminalRefusalText
-					) {
-						return finishWithCapturedRefusal({
-							trajectory,
-							iteration,
-							thought: plannerOutput.thought,
-							refusal: lastTerminalRefusalText,
-						});
-					}
-					assertTrajectoryLimit({
-						kind: "required_tool_misses",
-						max: config.maxRequiredToolMisses,
-						observed: requiredToolMisses,
-					});
-					handleRequiredToolPlannerMiss({
-						trajectory,
-						iteration,
-						plannerOutput,
-						reason: "terminal_only_tool_calls",
-						logger: params.runtime.logger,
-					});
-					continue;
-				}
-				// The messageToUser fallback applies only when a REPLY call is
-				// present (textless REPLY → the model's text is its reply). On
-				// STOP/IGNORE-only terminals the model chose silence: free text
-				// accompanying the call is scratch reasoning, not a user reply
-				// ("We should wait for the sub-agent result before replying."
-				// reached Discord verbatim, live 2026-06-12).
-				const hasReplyCall = plannerOutput.toolCalls.some(
-					(toolCall) => toolCall.name.toUpperCase() === "REPLY",
-				);
-				const finalMessage = hasReplyCall
-					? terminalMessageFromToolCalls(
-							plannerOutput.toolCalls,
-							plannerOutput.messageToUser,
-						)
-					: undefined;
-				trajectory.steps.push({
-					iteration,
-					thought: plannerOutput.thought,
-					terminalMessage: finalMessage,
-					terminalOnly: true,
-				});
-				const terminalEvaluator = terminalToolCallFinish(finalMessage);
-				// Only record an evaluation stage when the trajectory already has
-				// prior evaluator outputs. A terminal-only iteration on the very
-				// first planner turn (e.g. REPLY) is purely terminal and should
-				// not surface an `evaluation` stage in the recorded trajectory
-				// — the happy path tests assert this.
-				const shouldRecordTerminalEvaluation =
-					trajectory.evaluatorOutputs.length > 0;
-				trajectory.evaluatorOutputs.push(terminalEvaluator);
-				trajectory.context = appendEvaluationEvent({
-					context: trajectory.context,
-					iteration,
-					evaluator: terminalEvaluator,
-				});
-				if (shouldRecordTerminalEvaluation) {
-					const terminalEvalStartedAt = Date.now();
-					await recordGatedEvaluationStage({
-						recorder: params.recorder,
-						trajectoryId: params.trajectoryId,
-						parentStageId: params.parentStageId,
-						iteration,
-						startedAt: terminalEvalStartedAt,
-						endedAt: Date.now(),
-						output: terminalEvaluator,
-						reason: "terminal_tool_call",
-						logger: params.runtime.logger,
-					});
-				}
-				return {
-					status: "finished",
-					trajectory,
-					evaluator: terminalEvaluator,
-					finalMessage: userSafeFinalMessage(finalMessage, trajectory),
-				};
-			}
+      if (plannerOutput.toolCalls.every(isTerminalToolCall)) {
+        if (
+          requireNonTerminalToolCall &&
+          !hasExecutedNonTerminalTool(trajectory)
+        ) {
+          const refusalCandidate = terminalMessageFromToolCalls(
+            plannerOutput.toolCalls,
+            plannerOutput.messageToUser,
+          );
+          if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
+          requiredToolMisses++;
+          if (
+            requiredToolMisses > config.maxRequiredToolMisses &&
+            lastTerminalRefusalText
+          ) {
+            return finishWithCapturedRefusal({
+              trajectory,
+              iteration,
+              thought: plannerOutput.thought,
+              refusal: lastTerminalRefusalText,
+            });
+          }
+          assertTrajectoryLimit({
+            kind: "required_tool_misses",
+            max: config.maxRequiredToolMisses,
+            observed: requiredToolMisses,
+          });
+          handleRequiredToolPlannerMiss({
+            trajectory,
+            iteration,
+            plannerOutput,
+            reason: "terminal_only_tool_calls",
+            logger: params.runtime.logger,
+          });
+          continue;
+        }
+        // The messageToUser fallback applies only when a REPLY call is
+        // present (textless REPLY → the model's text is its reply). On
+        // STOP/IGNORE-only terminals the model chose silence: free text
+        // accompanying the call is scratch reasoning, not a user reply
+        // ("We should wait for the sub-agent result before replying."
+        // reached Discord verbatim, live 2026-06-12).
+        const hasReplyCall = plannerOutput.toolCalls.some(
+          (toolCall) => toolCall.name.toUpperCase() === "REPLY",
+        );
+        const finalMessage = hasReplyCall
+          ? terminalMessageFromToolCalls(
+              plannerOutput.toolCalls,
+              plannerOutput.messageToUser,
+            )
+          : undefined;
+        trajectory.steps.push({
+          iteration,
+          thought: plannerOutput.thought,
+          terminalMessage: finalMessage,
+          terminalOnly: true,
+        });
+        const terminalEvaluator = terminalToolCallFinish(finalMessage);
+        // Only record an evaluation stage when the trajectory already has
+        // prior evaluator outputs. A terminal-only iteration on the very
+        // first planner turn (e.g. REPLY) is purely terminal and should
+        // not surface an `evaluation` stage in the recorded trajectory
+        // — the happy path tests assert this.
+        const shouldRecordTerminalEvaluation =
+          trajectory.evaluatorOutputs.length > 0;
+        trajectory.evaluatorOutputs.push(terminalEvaluator);
+        trajectory.context = appendEvaluationEvent({
+          context: trajectory.context,
+          iteration,
+          evaluator: terminalEvaluator,
+        });
+        if (shouldRecordTerminalEvaluation) {
+          const terminalEvalStartedAt = Date.now();
+          await recordGatedEvaluationStage({
+            recorder: params.recorder,
+            trajectoryId: params.trajectoryId,
+            parentStageId: params.parentStageId,
+            iteration,
+            startedAt: terminalEvalStartedAt,
+            endedAt: Date.now(),
+            output: terminalEvaluator,
+            reason: "terminal_tool_call",
+            logger: params.runtime.logger,
+          });
+        }
+        return {
+          status: "finished",
+          trajectory,
+          evaluator: terminalEvaluator,
+          finalMessage: userSafeFinalMessage(finalMessage, trajectory),
+        };
+      }
 
-			const nonTerminalCalls = plannerOutput.toolCalls
-				.filter((toolCall) => !isTerminalToolCall(toolCall))
-				.map((toolCall, index) => ensureToolCallId(toolCall, iteration, index));
-			const unavailable = splitUnavailableToolCalls(
-				nonTerminalCalls,
-				params.tools,
-			);
-			if (unavailable.invalid.length > 0) {
-				params.runtime.logger?.warn?.(
-					{
-						iteration,
-						invalidToolCalls: unavailable.invalid.map(
-							(toolCall) => toolCall.name,
-						),
-					},
-					"Planner called unavailable tools; retrying without executing them",
-				);
-				trajectory.context = appendUnavailableToolCallEvent({
-					context: trajectory.context,
-					iteration,
-					invalidToolCalls: unavailable.invalid,
-					tools: params.tools,
-				});
-				if (unavailable.valid.length === 0) {
-					unavailableToolCallRetries++;
-					assertTrajectoryLimit({
-						kind: "unavailable_tool_calls",
-						max: config.maxUnavailableToolCallRetries,
-						observed: unavailableToolCallRetries,
-					});
-					continue;
-				}
-			}
-			const validNonTerminalCalls = unavailable.valid;
-			trajectory.plannedQueue.push(...validNonTerminalCalls);
-			trajectory.context = {
-				...trajectory.context,
-				plannedQueue: [
-					...(trajectory.context.plannedQueue ?? []),
-					...validNonTerminalCalls.map((toolCall) => ({
-						id: toolCall.id,
-						name: toolCall.name,
-						args: stringifyForModel(toolCall.params ?? {}),
-						status: "queued" as const,
-						sourceStageId: `planner:${iteration}`,
-					})),
-				],
-			};
-			for (const toolCall of validNonTerminalCalls) {
-				trajectory.context = appendContextEvent(trajectory.context, {
-					id: `queue:${toolCall.id ?? toolCall.name}:${iteration}`,
-					type: "planned_tool_call",
-					source: "planner-loop",
-					createdAt: Date.now(),
-					metadata: {
-						iteration,
-						toolCallId: toolCall.id,
-						name: toolCall.name,
-						params: stringifyForModel(toolCall.params ?? {}),
-						status: "queued",
-					},
-				});
-			}
-		}
+      const nonTerminalCalls = plannerOutput.toolCalls
+        .filter((toolCall) => !isTerminalToolCall(toolCall))
+        .map((toolCall, index) => ensureToolCallId(toolCall, iteration, index));
+      const unavailable = splitUnavailableToolCalls(
+        nonTerminalCalls,
+        params.tools,
+      );
+      if (unavailable.invalid.length > 0) {
+        params.runtime.logger?.warn?.(
+          {
+            iteration,
+            invalidToolCalls: unavailable.invalid.map(
+              (toolCall) => toolCall.name,
+            ),
+          },
+          "Planner called unavailable tools; retrying without executing them",
+        );
+        trajectory.context = appendUnavailableToolCallEvent({
+          context: trajectory.context,
+          iteration,
+          invalidToolCalls: unavailable.invalid,
+          tools: params.tools,
+        });
+        if (unavailable.valid.length === 0) {
+          unavailableToolCallRetries++;
+          assertTrajectoryLimit({
+            kind: "unavailable_tool_calls",
+            max: config.maxUnavailableToolCallRetries,
+            observed: unavailableToolCallRetries,
+          });
+          continue;
+        }
+      }
+      // Loop-breaker: a non-terminal call that exactly repeats one already
+      // SUCCEEDED this turn (same name + args) cannot return new data. Execute
+      // only genuinely-fresh calls; when every call this iteration is such a
+      // repeat, count a dead round and — past `maxRepeatedToolCalls` — force a
+      // terminal synthesis instead of looping to the prompt-token budget.
+      const { fresh: validNonTerminalCalls, redundant: redundantCalls } =
+        partitionRedundantSucceededCalls(unavailable.valid, trajectory);
+      if (validNonTerminalCalls.length === 0 && redundantCalls.length > 0) {
+        repeatedNonTerminalToolCalls++;
+        trajectory.context = appendContextEvent(trajectory.context, {
+          id: `redundant-tool-call:${iteration}`,
+          type: "instruction",
+          source: "planner-loop",
+          createdAt: Date.now(),
+          content:
+            "You already have a successful result this turn for " +
+            `${redundantCalls.map((call) => call.name).join(", ")} with these ` +
+            "exact arguments. Re-running it cannot return new information — " +
+            "answer the user now from the results already gathered.",
+        });
+        if (repeatedNonTerminalToolCalls > config.maxRepeatedToolCalls) {
+          return finishWithForcedSynthesis({
+            loop: params,
+            config,
+            trajectory,
+            iteration,
+            onUsage: observePlannerUsage,
+          });
+        }
+        trajectory.plannedQueue.length = 0;
+        continue;
+      }
+      if (redundantCalls.length > 0) {
+        params.runtime.logger?.debug?.(
+          { iteration, skipped: redundantCalls.map((call) => call.name) },
+          "Skipping tool calls that already succeeded with identical args this turn",
+        );
+      }
+      repeatedNonTerminalToolCalls = 0;
+      trajectory.plannedQueue.push(...validNonTerminalCalls);
+      trajectory.context = {
+        ...trajectory.context,
+        plannedQueue: [
+          ...(trajectory.context.plannedQueue ?? []),
+          ...validNonTerminalCalls.map((toolCall) => ({
+            id: toolCall.id,
+            name: toolCall.name,
+            args: stringifyForModel(toolCall.params ?? {}),
+            status: "queued" as const,
+            sourceStageId: `planner:${iteration}`,
+          })),
+        ],
+      };
+      for (const toolCall of validNonTerminalCalls) {
+        trajectory.context = appendContextEvent(trajectory.context, {
+          id: `queue:${toolCall.id ?? toolCall.name}:${iteration}`,
+          type: "planned_tool_call",
+          source: "planner-loop",
+          createdAt: Date.now(),
+          metadata: {
+            iteration,
+            toolCallId: toolCall.id,
+            name: toolCall.name,
+            params: stringifyForModel(toolCall.params ?? {}),
+            status: "queued",
+          },
+        });
+      }
+    }
 
-		const toolCall = trajectory.plannedQueue.shift();
-		if (!toolCall) {
-			continue;
-		}
+    const toolCall = trajectory.plannedQueue.shift();
+    if (!toolCall) {
+      continue;
+    }
 
-		await executeQueuedToolCall({
-			params,
-			trajectory,
-			toolCall,
-			iteration,
-			config,
-			failures,
-		});
+    await executeQueuedToolCall({
+      params,
+      trajectory,
+      toolCall,
+      iteration,
+      config,
+      failures,
+    });
 
-		const latestResult = trajectory.steps[trajectory.steps.length - 1]?.result;
-		if (latestResult?.continueChain === false) {
-			// `suppressPlannerReply` from terminal actions blanks finalMessage so a
-			// same-turn hallucinated `messageToUser` cannot leak past the transient
-			// filter (which only masks it on the *next* turn).
-			const suppressReply =
-				(latestResult.data as { suppressPlannerReply?: unknown } | undefined)
-					?.suppressPlannerReply === true;
-			return {
-				status: "finished",
-				trajectory,
-				finalMessage: suppressReply
-					? ""
-					: userSafeFinalMessage(latestResult.text, trajectory),
-			};
-		}
+    const latestResult = trajectory.steps[trajectory.steps.length - 1]?.result;
+    if (latestResult?.continueChain === false) {
+      // `suppressPlannerReply` from terminal actions blanks finalMessage so a
+      // same-turn hallucinated `messageToUser` cannot leak past the transient
+      // filter (which only masks it on the *next* turn).
+      const suppressReply =
+        (latestResult.data as { suppressPlannerReply?: unknown } | undefined)
+          ?.suppressPlannerReply === true;
+      return {
+        status: "finished",
+        trajectory,
+        finalMessage: suppressReply
+          ? ""
+          : userSafeFinalMessage(latestResult.text, trajectory),
+      };
+    }
 
-		await maybeCompactBeforeNextModelCall({
-			trajectory,
-			config,
-			tools: params.tools,
-			recorder: params.recorder,
-			trajectoryId: params.trajectoryId,
-			parentStageId: params.parentStageId,
-			iteration,
-			logger: params.runtime.logger,
-		});
+    await maybeCompactBeforeNextModelCall({
+      trajectory,
+      config,
+      tools: params.tools,
+      recorder: params.recorder,
+      trajectoryId: params.trajectoryId,
+      parentStageId: params.parentStageId,
+      iteration,
+      logger: params.runtime.logger,
+    });
 
-		// Conservative gate (PR #7514): when a successful tool drained the queue
-		// and the just-completed planner call gave us a clean explicit
-		// `messageToUser`, synthesize a FINISH and skip the in-loop evaluator.
-		// Falls through on any ambiguity. See `tryGateEvaluator` doc-comment.
-		const gateStartedAt = Date.now();
-		const gated = tryGateEvaluator({
-			trajectory,
-			failures,
-			lastPlannerExplicitMessageToUser,
-			lastPlannerExplicitCompleted,
-		});
-		if (gated) {
-			trajectory.evaluatorOutputs.push(gated);
-			trajectory.context = appendEvaluationEvent({
-				context: trajectory.context,
-				iteration,
-				evaluator: gated,
-			});
-			await recordGatedEvaluationStage({
-				recorder: params.recorder,
-				trajectoryId: params.trajectoryId,
-				parentStageId: params.parentStageId,
-				iteration,
-				startedAt: gateStartedAt,
-				endedAt: Date.now(),
-				output: gated,
-				logger: params.runtime.logger,
-			});
-			return {
-				status: "finished",
-				trajectory,
-				evaluator: gated,
-				finalMessage: userSafeFinalMessage(
-					preferredFinalMessageFromToolOrModel(trajectory, gated.messageToUser),
-					trajectory,
-				),
-			};
-		}
+    // Conservative gate (PR #7514): when a successful tool drained the queue
+    // and the just-completed planner call gave us a clean explicit
+    // `messageToUser`, synthesize a FINISH and skip the in-loop evaluator.
+    // Falls through on any ambiguity. See `tryGateEvaluator` doc-comment.
+    const gateStartedAt = Date.now();
+    const gated = tryGateEvaluator({
+      trajectory,
+      failures,
+      lastPlannerExplicitMessageToUser,
+      lastPlannerExplicitCompleted,
+    });
+    if (gated) {
+      trajectory.evaluatorOutputs.push(gated);
+      trajectory.context = appendEvaluationEvent({
+        context: trajectory.context,
+        iteration,
+        evaluator: gated,
+      });
+      await recordGatedEvaluationStage({
+        recorder: params.recorder,
+        trajectoryId: params.trajectoryId,
+        parentStageId: params.parentStageId,
+        iteration,
+        startedAt: gateStartedAt,
+        endedAt: Date.now(),
+        output: gated,
+        logger: params.runtime.logger,
+      });
+      return {
+        status: "finished",
+        trajectory,
+        evaluator: gated,
+        finalMessage: userSafeFinalMessage(
+          preferredFinalMessageFromToolOrModel(trajectory, gated.messageToUser),
+          trajectory,
+        ),
+      };
+    }
 
-		const evaluator = await evaluateTrajectory(params, trajectory, iteration);
-		trajectory.evaluatorOutputs.push(evaluator);
-		appendEvaluatorContextEvent(trajectory, evaluator, iteration);
+    const evaluator = await evaluateTrajectory(params, trajectory, iteration);
+    trajectory.evaluatorOutputs.push(evaluator);
+    appendEvaluatorContextEvent(trajectory, evaluator, iteration);
 
-		if (evaluator.decision === "FINISH") {
-			if (
-				shouldRecoverSilentFailedFinish({
-					evaluator,
-					trajectory,
-					recoveryCount: silentFailedFinishRecoveries,
-				})
-			) {
-				silentFailedFinishRecoveries++;
-				trajectory.context = appendSilentFailedFinishRecoveryEvent({
-					context: trajectory.context,
-					iteration,
-					evaluator,
-					trajectory,
-				});
-				continue;
-			}
-			return {
-				status: "finished",
-				trajectory,
-				evaluator,
-				finalMessage: userSafeFinalMessage(
-					preferredFinalMessageFromToolOrModel(
-						trajectory,
-						evaluator.messageToUser,
-						evaluator.success === false
-							? failedToolFallbackMessage(trajectory)
-							: undefined,
-					),
-					trajectory,
-				),
-			};
-		}
+    if (evaluator.decision === "FINISH") {
+      if (
+        shouldRecoverSilentFailedFinish({
+          evaluator,
+          trajectory,
+          recoveryCount: silentFailedFinishRecoveries,
+        })
+      ) {
+        silentFailedFinishRecoveries++;
+        trajectory.context = appendSilentFailedFinishRecoveryEvent({
+          context: trajectory.context,
+          iteration,
+          evaluator,
+          trajectory,
+        });
+        continue;
+      }
+      return {
+        status: "finished",
+        trajectory,
+        evaluator,
+        finalMessage: userSafeFinalMessage(
+          preferredFinalMessageFromToolOrModel(
+            trajectory,
+            evaluator.messageToUser,
+            evaluator.success === false
+              ? failedToolFallbackMessage(trajectory)
+              : undefined,
+          ),
+          trajectory,
+        ),
+      };
+    }
 
-		if (evaluator.decision === "NEXT_RECOMMENDED") {
-			const selected = preferRecommendedToolCall(trajectory, evaluator);
-			if (!selected) {
-				params.runtime.logger?.warn?.(
-					{
-						recommendedToolCallId: evaluator.recommendedToolCallId,
-						queuedToolCallIds: trajectory.plannedQueue.map((call) => call.id),
-					},
-					"Evaluator requested NEXT_RECOMMENDED without a valid queued tool; replanning",
-				);
-				trajectory.plannedQueue.length = 0;
-			}
-			continue;
-		}
+    if (evaluator.decision === "NEXT_RECOMMENDED") {
+      const selected = preferRecommendedToolCall(trajectory, evaluator);
+      if (!selected) {
+        params.runtime.logger?.warn?.(
+          {
+            recommendedToolCallId: evaluator.recommendedToolCallId,
+            queuedToolCallIds: trajectory.plannedQueue.map((call) => call.id),
+          },
+          "Evaluator requested NEXT_RECOMMENDED without a valid queued tool; replanning",
+        );
+        trajectory.plannedQueue.length = 0;
+      }
+      continue;
+    }
 
-		trajectory.plannedQueue.length = 0;
-	}
+    trajectory.plannedQueue.length = 0;
+  }
 }
 
 function normalizePlannerContext(context: ContextObject): ContextObject {
-	return Array.isArray(context.events)
-		? context
-		: {
-				...context,
-				events: [],
-			};
+  return Array.isArray(context.events)
+    ? context
+    : {
+        ...context,
+        events: [],
+      };
 }
 
 function renderPlannerModelInput(params: {
-	context: ContextObject;
-	trajectory: PlannerTrajectory;
-	template?: string;
-	runtime?: PlannerRuntime;
-	/**
-	 * Optional per-tool-result character cap. Forwarded directly to
-	 * `trajectoryStepsToMessages` — caps the rendered tool-result
-	 * string for each kept-verbatim step without mutating the
-	 * trajectory itself.
-	 */
-	maxToolResultChars?: number;
+  context: ContextObject;
+  trajectory: PlannerTrajectory;
+  template?: string;
+  runtime?: PlannerRuntime;
+  /**
+   * Optional per-tool-result character cap. Forwarded directly to
+   * `trajectoryStepsToMessages` — caps the rendered tool-result
+   * string for each kept-verbatim step without mutating the
+   * trajectory itself.
+   */
+  maxToolResultChars?: number;
 }): {
-	messages: ChatMessage[];
-	promptSegments: PromptSegment[];
+  messages: ChatMessage[];
+  promptSegments: PromptSegment[];
 } {
-	const renderedContext = renderContextObject(params.context);
-	const template = params.template ?? plannerTemplate;
-	const instructions = appendMandatoryPlannerPolicy(
-		template.split("context_object:")[0] ?? template,
-	).trim();
-	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
-		maxToolResultChars: params.maxToolResultChars,
-	});
-	// Action names + parameter schemas now ride directly on the tools array
-	// (each Action is exposed as its own native tool), so there is no separate
-	// available_actions block rendered into the prompt. Routing hints stay as a
-	// dedicated section since they layer business advice on top of the bare
-	// action descriptions.
-	const routingHintsBlock = renderRoutingHintsBlock(params.context);
-	const extraSegments: PromptSegment[] = [];
-	if (routingHintsBlock) {
-		extraSegments.push({ content: routingHintsBlock, stable: false });
-	}
-	const contextSegments =
-		extraSegments.length > 0
-			? [...renderedContext.promptSegments, ...extraSegments]
-			: renderedContext.promptSegments;
-	// The planner stage instructions are template-derived (`plannerTemplate`)
-	// and structurally identical across iterations and across user turns, so they
-	// belong in the cached prefix. Marking the segment `stable: true` lets the
-	// Anthropic provider stamp `cache_control` on this block and lets the
-	// cache-key prefix extend through these instructions.
-	const promptSegments = normalizePromptSegments([
-		...contextSegments,
-		{ content: `planner_stage:\n${instructions}`, stable: true },
-	]);
-	// Native tool-call messages: assistant (with toolCalls) + tool (result) per
-	// completed step. This grows append-only across planner iterations so the
-	// base prefix remains byte-identical and Cerebras's prompt cache can hit.
-	// The trajectory JSON is NOT included in dynamicBlocks here — it is conveyed
-	// through stepMessages (proper assistant/tool pairs). Including it as a
-	// dynamic block would re-introduce the JSON-dump anti-pattern in the user
-	// message and invalidate the cache prefix on every iteration.
-	const messages = buildStageChatMessages({
-		contextSegments,
-		stageLabel: "planner_stage",
-		instructions,
-		dynamicBlocks: [],
-		stepMessages,
-	});
-	return { messages, promptSegments };
+  const renderedContext = renderContextObject(params.context);
+  const template = params.template ?? plannerTemplate;
+  const instructions = appendMandatoryPlannerPolicy(
+    template.split("context_object:")[0] ?? template,
+  ).trim();
+  const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
+    maxToolResultChars: params.maxToolResultChars,
+  });
+  // Action names + parameter schemas now ride directly on the tools array
+  // (each Action is exposed as its own native tool), so there is no separate
+  // available_actions block rendered into the prompt. Routing hints stay as a
+  // dedicated section since they layer business advice on top of the bare
+  // action descriptions.
+  const routingHintsBlock = renderRoutingHintsBlock(params.context);
+  const extraSegments: PromptSegment[] = [];
+  if (routingHintsBlock) {
+    extraSegments.push({ content: routingHintsBlock, stable: false });
+  }
+  const contextSegments =
+    extraSegments.length > 0
+      ? [...renderedContext.promptSegments, ...extraSegments]
+      : renderedContext.promptSegments;
+  // The planner stage instructions are template-derived (`plannerTemplate`)
+  // and structurally identical across iterations and across user turns, so they
+  // belong in the cached prefix. Marking the segment `stable: true` lets the
+  // Anthropic provider stamp `cache_control` on this block and lets the
+  // cache-key prefix extend through these instructions.
+  const promptSegments = normalizePromptSegments([
+    ...contextSegments,
+    { content: `planner_stage:\n${instructions}`, stable: true },
+  ]);
+  // Native tool-call messages: assistant (with toolCalls) + tool (result) per
+  // completed step. This grows append-only across planner iterations so the
+  // base prefix remains byte-identical and Cerebras's prompt cache can hit.
+  // The trajectory JSON is NOT included in dynamicBlocks here — it is conveyed
+  // through stepMessages (proper assistant/tool pairs). Including it as a
+  // dynamic block would re-introduce the JSON-dump anti-pattern in the user
+  // message and invalidate the cache prefix on every iteration.
+  const messages = buildStageChatMessages({
+    contextSegments,
+    stageLabel: "planner_stage",
+    instructions,
+    dynamicBlocks: [],
+    stepMessages,
+  });
+  return { messages, promptSegments };
 }
 
 function compactionReserveForBudget(
-	config: ChainingLoopConfig,
+  config: ChainingLoopConfig,
 ): number | undefined {
-	if (
-		config.contextWindowModelName &&
-		config.compactionReserveTokensExplicit !== true
-	) {
-		return undefined;
-	}
-	return config.compactionReserveTokens;
+  if (
+    config.contextWindowModelName &&
+    config.compactionReserveTokensExplicit !== true
+  ) {
+    return undefined;
+  }
+  return config.compactionReserveTokens;
 }
 
 function normalizePlannerToolName(name: string): string {
-	return name
-		.trim()
-		.toUpperCase()
-		.replace(/[^A-Z0-9]/g, "");
+  return name
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
 }
 
 /**
@@ -748,58 +798,58 @@ function normalizePlannerToolName(name: string): string {
  * new array each time).
  */
 const ROUTING_HINTS_MEMO = new WeakMap<
-	NonNullable<ContextObject["events"]>,
-	string | null
+  NonNullable<ContextObject["events"]>,
+  string | null
 >();
 
 const MANDATORY_PLANNER_POLICY_LINES = [
-	"SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups.",
-	"candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
-	"TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
-	"messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
+  "SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups.",
+  "candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
+  "TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
+  "messageToUser and REPLY text must NEVER claim or imply an investigative action is happening",
 ];
 
 const MANDATORY_PLANNER_POLICY = [
-	"mandatory planner policy:",
-	"- SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups. When the user wants chat-message search/recall, memory queries, or agent-history lookups and no dedicated search action (e.g. SEARCH_MESSAGES, MESSAGE_SEARCH, MEMORY_SEARCH) is exposed, do not run shell greps, echo placeholders, or simulate the search — set messageToUser explaining that the capability is not available this turn.",
-	'- candidateActions naming a tool that is not in this turn\'s exposed tools list is a dead hint — do not invent SHELL/BROWSER/TASKS workarounds to fulfill it. Either an exposed tool genuinely resolves the user\'s intent (call it), or no tool fits (set messageToUser). Never emit echo-placeholder SHELL commands such as: echo "<intent-name>" / echo "placeholder for <ACTION>" / echo "search <X>" as a way to "trigger" a missing capability — placeholder echoes burn cost and produce no progress.',
-	'- TASKS_SPAWN_AGENT is for delegating coding/build/repo work to a coding sub-agent (file edits, shell tooling, building/deploying apps, running tests, opening PRs). It is not a fallback for chat-message recall, memory queries, or agent-history lookups. Spawning a coding sub-agent to "search the Discord channel for messages mentioning X" routinely ends in sub-agent error/timeout and a generic "Sorry, something went wrong" reply to the user. When the user wants chat-message recall and no dedicated search action is exposed, set messageToUser explaining the capability is not available — do not spawn a sub-agent for it.',
-	'- messageToUser and REPLY text must NEVER claim or imply an investigative action is happening, has happened, or is about to happen — "I\'m fetching X, please hold", "Let me look that up", "Pulling up the info", "Searching for the answer", "I\'m checking now", "I\'ll get back to you", "Spawning a sub-agent" — when no tool call this turn is in flight to produce that content. The planner does not run in the background after returning; once this turn ends, no further tool work happens unless a NEW user message arrives. If your tool iterations exhausted without a usable result (search returned nothing, fetch was blocked, scrape gave no usable HTML, RSS was empty), set messageToUser saying so plainly: "I tried web search via the available tools and couldn\'t find current info on X — try checking a news site directly" or "The searches returned no usable results". Never promise ongoing fetch when this turn is the planner\'s final iteration. This rule covers every grammatical form: past-perfect ("I have fetched"), bare past-tense ("I fetched"), present-continuous with subject ("I\'m fetching now", "I\'m checking"), bare present-participle without subject ("Fetching latest info", "Looking it up", "Pulling up the logs"), and "please hold" / "give me a sec" / "be right back" style stalling phrases.',
+  "mandatory planner policy:",
+  "- SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups. When the user wants chat-message search/recall, memory queries, or agent-history lookups and no dedicated search action (e.g. SEARCH_MESSAGES, MESSAGE_SEARCH, MEMORY_SEARCH) is exposed, do not run shell greps, echo placeholders, or simulate the search — set messageToUser explaining that the capability is not available this turn.",
+  '- candidateActions naming a tool that is not in this turn\'s exposed tools list is a dead hint — do not invent SHELL/BROWSER/TASKS workarounds to fulfill it. Either an exposed tool genuinely resolves the user\'s intent (call it), or no tool fits (set messageToUser). Never emit echo-placeholder SHELL commands such as: echo "<intent-name>" / echo "placeholder for <ACTION>" / echo "search <X>" as a way to "trigger" a missing capability — placeholder echoes burn cost and produce no progress.',
+  '- TASKS_SPAWN_AGENT is for delegating coding/build/repo work to a coding sub-agent (file edits, shell tooling, building/deploying apps, running tests, opening PRs). It is not a fallback for chat-message recall, memory queries, or agent-history lookups. Spawning a coding sub-agent to "search the Discord channel for messages mentioning X" routinely ends in sub-agent error/timeout and a generic "Sorry, something went wrong" reply to the user. When the user wants chat-message recall and no dedicated search action is exposed, set messageToUser explaining the capability is not available — do not spawn a sub-agent for it.',
+  '- messageToUser and REPLY text must NEVER claim or imply an investigative action is happening, has happened, or is about to happen — "I\'m fetching X, please hold", "Let me look that up", "Pulling up the info", "Searching for the answer", "I\'m checking now", "I\'ll get back to you", "Spawning a sub-agent" — when no tool call this turn is in flight to produce that content. The planner does not run in the background after returning; once this turn ends, no further tool work happens unless a NEW user message arrives. If your tool iterations exhausted without a usable result (search returned nothing, fetch was blocked, scrape gave no usable HTML, RSS was empty), set messageToUser saying so plainly: "I tried web search via the available tools and couldn\'t find current info on X — try checking a news site directly" or "The searches returned no usable results". Never promise ongoing fetch when this turn is the planner\'s final iteration. This rule covers every grammatical form: past-perfect ("I have fetched"), bare past-tense ("I fetched"), present-continuous with subject ("I\'m fetching now", "I\'m checking"), bare present-participle without subject ("Fetching latest info", "Looking it up", "Pulling up the logs"), and "please hold" / "give me a sec" / "be right back" style stalling phrases.',
 ].join("\n");
 
 function appendMandatoryPlannerPolicy(instructions: string): string {
-	if (
-		MANDATORY_PLANNER_POLICY_LINES.every((line) => instructions.includes(line))
-	) {
-		return instructions;
-	}
-	return `${instructions}\n\n${MANDATORY_PLANNER_POLICY}`;
+  if (
+    MANDATORY_PLANNER_POLICY_LINES.every((line) => instructions.includes(line))
+  ) {
+    return instructions;
+  }
+  return `${instructions}\n\n${MANDATORY_PLANNER_POLICY}`;
 }
 
 function renderRoutingHintsBlock(context: ContextObject): string | null {
-	if (process.env.ELIZA_PROMPT_COMPRESS === "1") return null;
-	const events = context.events;
-	if (events && ROUTING_HINTS_MEMO.has(events)) {
-		return ROUTING_HINTS_MEMO.get(events) ?? null;
-	}
-	const seen = new Set<string>();
-	const lines: string[] = [];
-	for (const event of events ?? []) {
-		if (event.type !== "tool" || !("tool" in event)) continue;
-		const tool = event.tool as ContextObjectTool;
-		const hint = tool.action?.routingHint?.trim();
-		if (!hint) continue;
-		const key = normalizePlannerToolName(tool.name);
-		if (seen.has(key)) continue;
-		seen.add(key);
-		lines.push(`- ${hint}`);
-	}
-	const result =
-		lines.length === 0 ? null : ["# Routing hints", ...lines].join("\n");
-	if (events) {
-		ROUTING_HINTS_MEMO.set(events, result);
-	}
-	return result;
+  if (process.env.ELIZA_PROMPT_COMPRESS === "1") return null;
+  const events = context.events;
+  if (events && ROUTING_HINTS_MEMO.has(events)) {
+    return ROUTING_HINTS_MEMO.get(events) ?? null;
+  }
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const event of events ?? []) {
+    if (event.type !== "tool" || !("tool" in event)) continue;
+    const tool = event.tool as ContextObjectTool;
+    const hint = tool.action?.routingHint?.trim();
+    if (!hint) continue;
+    const key = normalizePlannerToolName(tool.name);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(`- ${hint}`);
+  }
+  const result =
+    lines.length === 0 ? null : ["# Routing hints", ...lines].join("\n");
+  if (events) {
+    ROUTING_HINTS_MEMO.set(events, result);
+  }
+  return result;
 }
 
 /**
@@ -808,535 +858,535 @@ function renderRoutingHintsBlock(context: ContextObject): string | null {
  * and for sub-planner scoping (parent-action narrowing).
  */
 function collectExposedTools(context: ContextObject): ContextObjectTool[] {
-	const parentAction =
-		typeof context.metadata?.subPlannerParentAction === "string"
-			? context.metadata.subPlannerParentAction
-			: "";
-	const inSubPlanner = parentAction.length > 0;
-	const tools: ContextObjectTool[] = [];
-	const seen = new Set<string>();
+  const parentAction =
+    typeof context.metadata?.subPlannerParentAction === "string"
+      ? context.metadata.subPlannerParentAction
+      : "";
+  const inSubPlanner = parentAction.length > 0;
+  const tools: ContextObjectTool[] = [];
+  const seen = new Set<string>();
 
-	for (const event of context.events ?? []) {
-		if (event.type !== "tool" || !("tool" in event)) {
-			continue;
-		}
-		const tool = event.tool as ContextObjectTool;
-		if (!tool.name) {
-			continue;
-		}
-		const parentMatches =
-			typeof tool.metadata?.parentAction === "string" &&
-			tool.metadata.parentAction === parentAction;
-		if (inSubPlanner) {
-			if (event.source !== "sub-planner" && !parentMatches) {
-				continue;
-			}
-		} else if (event.source === "sub-planner" || parentMatches) {
-			continue;
-		}
-		const key = normalizePlannerToolName(tool.name);
-		if (seen.has(key)) {
-			continue;
-		}
-		seen.add(key);
-		tools.push(tool);
-	}
-	return tools;
+  for (const event of context.events ?? []) {
+    if (event.type !== "tool" || !("tool" in event)) {
+      continue;
+    }
+    const tool = event.tool as ContextObjectTool;
+    if (!tool.name) {
+      continue;
+    }
+    const parentMatches =
+      typeof tool.metadata?.parentAction === "string" &&
+      tool.metadata.parentAction === parentAction;
+    if (inSubPlanner) {
+      if (event.source !== "sub-planner" && !parentMatches) {
+        continue;
+      }
+    } else if (event.source === "sub-planner" || parentMatches) {
+      continue;
+    }
+    const key = normalizePlannerToolName(tool.name);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    tools.push(tool);
+  }
+  return tools;
 }
 
 export function parsePlannerOutput(raw: string | GenerateTextResult): {
-	thought?: string;
-	toolCalls: PlannerToolCall[];
-	messageToUser?: string;
-	raw: Record<string, unknown>;
+  thought?: string;
+  toolCalls: PlannerToolCall[];
+  messageToUser?: string;
+  raw: Record<string, unknown>;
 } {
-	if (typeof raw === "string") {
-		return parseJsonPlannerOutput(raw);
-	}
+  if (typeof raw === "string") {
+    return parseJsonPlannerOutput(raw);
+  }
 
-	const nativeToolCalls = normalizeToolCalls(raw.toolCalls);
-	const text = getNonEmptyString(raw.text);
+  const nativeToolCalls = normalizeToolCalls(raw.toolCalls);
+  const text = getNonEmptyString(raw.text);
 
-	let textRecoveredCalls: PlannerToolCall[] = [];
-	const embeddedToolCalls = parseEmbeddedToolCalls(raw.text);
-	const embeddedObjectCount =
-		typeof raw.text === "string" ? extractJsonObjects(raw.text).length : 0;
-	if (
-		embeddedToolCalls.length > 0 &&
-		(nativeToolCalls.length === 0 || embeddedObjectCount > 1)
-	) {
-		textRecoveredCalls = mergeToolCalls(textRecoveredCalls, embeddedToolCalls);
-	}
-	const toolCalls = mergeToolCalls(nativeToolCalls, textRecoveredCalls);
+  let textRecoveredCalls: PlannerToolCall[] = [];
+  const embeddedToolCalls = parseEmbeddedToolCalls(raw.text);
+  const embeddedObjectCount =
+    typeof raw.text === "string" ? extractJsonObjects(raw.text).length : 0;
+  if (
+    embeddedToolCalls.length > 0 &&
+    (nativeToolCalls.length === 0 || embeddedObjectCount > 1)
+  ) {
+    textRecoveredCalls = mergeToolCalls(textRecoveredCalls, embeddedToolCalls);
+  }
+  const toolCalls = mergeToolCalls(nativeToolCalls, textRecoveredCalls);
 
-	return {
-		toolCalls,
-		// When `raw.text` was itself tool-call JSON it is not a user-facing
-		// message — take the reply from a REPLY call rather than leaking the
-		// raw JSON blob into the channel.
-		messageToUser:
-			textRecoveredCalls.length > 0
-				? terminalMessageFromToolCalls(toolCalls)
-				: text,
-		raw: {
-			text: raw.text,
-			toolCalls: raw.toolCalls,
-		} as Record<string, unknown>,
-	};
+  return {
+    toolCalls,
+    // When `raw.text` was itself tool-call JSON it is not a user-facing
+    // message — take the reply from a REPLY call rather than leaking the
+    // raw JSON blob into the channel.
+    messageToUser:
+      textRecoveredCalls.length > 0
+        ? terminalMessageFromToolCalls(toolCalls)
+        : text,
+    raw: {
+      text: raw.text,
+      toolCalls: raw.toolCalls,
+    } as Record<string, unknown>,
+  };
 }
 
 function parseJsonPlannerOutput(raw: string): {
-	thought?: string;
-	toolCalls: PlannerToolCall[];
-	messageToUser?: string;
-	raw: Record<string, unknown>;
+  thought?: string;
+  toolCalls: PlannerToolCall[];
+  messageToUser?: string;
+  raw: Record<string, unknown>;
 } {
-	const trimmed = raw.trim();
-	const parsed = parseJsonObject<RawPlannerOutput>(trimmed);
-	if (!parsed) {
-		return {
-			toolCalls: [],
-			messageToUser: getNonEmptyString(trimmed),
-			raw: { text: trimmed },
-		};
-	}
-	const messageToUser = getNonEmptyString(parsed.messageToUser ?? parsed.text);
-	const toolCalls = normalizeToolCalls(parsed.toolCalls);
-	const bareActionCalls =
-		toolCalls.length === 0 ? normalizeBarePlannerAction(parsed) : [];
-	let resolvedCalls = toolCalls.length > 0 ? toolCalls : bareActionCalls;
-	// `parseJsonObject` only returns the FIRST top-level object, so a weak
-	// model that concatenated bare `{type, args}` calls would lose every one
-	// after the first. Recover the full set from the raw string.
-	if (resolvedCalls.length === 0) {
-		resolvedCalls = parseEmbeddedToolCalls(trimmed);
-	}
-	return {
-		thought: typeof parsed.thought === "string" ? parsed.thought : undefined,
-		toolCalls: resolvedCalls,
-		messageToUser,
-		raw: parsed as Record<string, unknown>,
-	};
+  const trimmed = raw.trim();
+  const parsed = parseJsonObject<RawPlannerOutput>(trimmed);
+  if (!parsed) {
+    return {
+      toolCalls: [],
+      messageToUser: getNonEmptyString(trimmed),
+      raw: { text: trimmed },
+    };
+  }
+  const messageToUser = getNonEmptyString(parsed.messageToUser ?? parsed.text);
+  const toolCalls = normalizeToolCalls(parsed.toolCalls);
+  const bareActionCalls =
+    toolCalls.length === 0 ? normalizeBarePlannerAction(parsed) : [];
+  let resolvedCalls = toolCalls.length > 0 ? toolCalls : bareActionCalls;
+  // `parseJsonObject` only returns the FIRST top-level object, so a weak
+  // model that concatenated bare `{type, args}` calls would lose every one
+  // after the first. Recover the full set from the raw string.
+  if (resolvedCalls.length === 0) {
+    resolvedCalls = parseEmbeddedToolCalls(trimmed);
+  }
+  return {
+    thought: typeof parsed.thought === "string" ? parsed.thought : undefined,
+    toolCalls: resolvedCalls,
+    messageToUser,
+    raw: parsed as Record<string, unknown>,
+  };
 }
 
 async function callPlanner(params: {
-	runtime: PlannerRuntime;
-	context: ContextObject;
-	trajectory: PlannerTrajectory;
-	config: ChainingLoopConfig;
-	modelType?: TextGenerationModelType;
-	provider?: string;
-	tools?: ToolDefinition[];
-	toolChoice?: ToolChoice;
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration?: number;
-	/**
-	 * Side-channel observer called once per model call with the gross
-	 * `promptTokens` reported by the provider. Used by `runPlannerLoop`
-	 * to enforce `ChainingLoopConfig.maxTrajectoryPromptTokens` without
-	 * changing this function's return type. Errors thrown from the
-	 * callback (e.g. `TrajectoryLimitExceeded`) propagate to the loop.
-	 */
-	onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;
+  runtime: PlannerRuntime;
+  context: ContextObject;
+  trajectory: PlannerTrajectory;
+  config: ChainingLoopConfig;
+  modelType?: TextGenerationModelType;
+  provider?: string;
+  tools?: ToolDefinition[];
+  toolChoice?: ToolChoice;
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration?: number;
+  /**
+   * Side-channel observer called once per model call with the gross
+   * `promptTokens` reported by the provider. Used by `runPlannerLoop`
+   * to enforce `ChainingLoopConfig.maxTrajectoryPromptTokens` without
+   * changing this function's return type. Errors thrown from the
+   * callback (e.g. `TrajectoryLimitExceeded`) propagate to the loop.
+   */
+  onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;
 }): Promise<ReturnType<typeof parsePlannerOutput>> {
-	let renderedInput = renderPlannerModelInput({
-		context: params.context,
-		trajectory: params.trajectory,
-		template: resolveOptimizedPlannerTemplate(params.runtime),
-		runtime: params.runtime,
-		maxToolResultChars: params.config.compactionMaxKeptStepChars,
-	});
-	let modelInputBudget = buildModelInputBudget({
-		messages: renderedInput.messages,
-		promptSegments: renderedInput.promptSegments,
-		tools: params.tools,
-		// `modelName` lets the per-model context-window lookup fire.
-		// The lookup result wins over contextWindowTokens (see buildModelInputBudget
-		// resolution order). Note: contextWindowTokens defaults to 128_000 so the
-		// spread is always non-empty; the lookup will still override it when
-		// contextWindowModelName resolves.
-		modelName: params.config.contextWindowModelName,
-		...(params.config.contextWindowTokens
-			? { contextWindowTokens: params.config.contextWindowTokens }
-			: {}),
-		reserveTokens: compactionReserveForBudget(params.config),
-	});
-	if (modelInputBudget.shouldCompact && params.config.compactionEnabled) {
-		const compacted = await maybeCompactPlannerTrajectory({
-			trajectory: params.trajectory,
-			budget: modelInputBudget,
-			config: params.config,
-			recorder: params.recorder,
-			trajectoryId: params.trajectoryId,
-			parentStageId: params.parentStageId,
-			iteration: params.iteration ?? 1,
-			logger: params.runtime.logger,
-		});
-		if (compacted) {
-			renderedInput = renderPlannerModelInput({
-				context: params.trajectory.context,
-				trajectory: params.trajectory,
-				template: resolveOptimizedPlannerTemplate(params.runtime),
-				runtime: params.runtime,
-				maxToolResultChars: params.config.compactionMaxKeptStepChars,
-			});
-			modelInputBudget = buildModelInputBudget({
-				messages: renderedInput.messages,
-				promptSegments: renderedInput.promptSegments,
-				tools: params.tools,
-				modelName: params.config.contextWindowModelName,
-				...(params.config.contextWindowTokens
-					? { contextWindowTokens: params.config.contextWindowTokens }
-					: {}),
-				reserveTokens: compactionReserveForBudget(params.config),
-			});
-		}
-	}
-	const prefixHashes = computePrefixHashes(renderedInput.promptSegments);
-	const cachePrefixHashes = computePrefixHashes(
-		cachePrefixSegments(renderedInput.promptSegments),
-	);
-	const prefixHash =
-		cachePrefixHashes[cachePrefixHashes.length - 1]?.hash ??
-		"no-context-segments";
-	const hasTools = Array.isArray(params.tools) && params.tools.length > 0;
-	const modelParams: {
-		messages: ChatMessage[];
-		responseSchema?: unknown;
-		promptSegments: PromptSegment[];
-		providerOptions: Record<string, unknown>;
-		tools?: ToolDefinition[];
-		toolChoice?: ToolChoice;
-		responseSkeleton?: ResponseSkeleton;
-		grammar?: string;
-		spanSamplerPlan?: SpanSamplerPlan;
-		maxTokens?: number;
-	} = {
-		messages: renderedInput.messages,
-		promptSegments: renderedInput.promptSegments,
-		providerOptions: withModelInputBudgetProviderOptions(
-			cacheProviderOptions({
-				prefixHash,
-				segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
-				promptSegments: renderedInput.promptSegments,
-				provider: params.provider,
-				hasTools,
-				conversationId: params.trajectoryId,
-			}),
-			modelInputBudget,
-		),
-		maxTokens: DEFAULT_PLANNER_MAX_TOKENS,
-	};
-	modelParams.providerOptions = {
-		...modelParams.providerOptions,
-		eliza: {
-			...((modelParams.providerOptions as { eliza?: Record<string, unknown> })
-				.eliza ?? {}),
-			thinking: "off",
-		},
-	};
-	if (hasTools) {
-		modelParams.tools = params.tools;
-		// Force a native tool call. With actions exposed directly as tools
-		// (post-PLAN_ACTIONS-wrapper refactor), every viable planner outcome —
-		// invoking an action, calling REPLY for a final message, or terminating
-		// via IGNORE / STOP — corresponds to a tool. There is no "the model
-		// shouldn't tool-call" case left, so `"required"` is the contract.
-		// Models that can't comply fail loudly; we don't degrade to text mode.
-		modelParams.toolChoice = params.toolChoice ?? "required";
-		// Per-turn structure forcing for the PLAN_ACTIONS args: pin `action` to
-		// the exact enum of actions exposed this turn and carry each action's
-		// normalized parameter schema so the local engine (W4) can do the
-		// second constrained pass (`parameters` against the chosen action's
-		// schema). Cloud adapters may ignore local structured-output hints like
-		// `responseSkeleton`, `grammar`, and
-		// `providerOptions.eliza.plannerActionSchemas`; `tools` carries the
-		// equivalent portable contract for them.
-		const exposedTools = collectExposedTools(params.context);
-		const plannerActions = exposedTools.map((tool) => ({
-			name: tool.name,
-			parameters: tool.action?.parameters ?? [],
-			allowAdditionalParameters:
-				tool.action?.allowAdditionalParameters === true,
-		}));
-		// Always use the per-action union grammar (P2-4) for the local engine:
-		// the GBNF root is the alternation of per-action branches, each with
-		// literal action name + a sub-grammar for that action's parameter
-		// shape. Chosen `action` and parameter shape are co-determined by the
-		// grammar in one call; the `validate-tool-args.ts` re-plan round
-		// is skipped when the model lands inside the strict grammar.
-		// Cloud adapters can use `tools` carrying the same schemas if they do not
-		// honor local skeleton/grammar hints.
-		const plannerActionGrammar =
-			buildPlannerActionGrammarStrict(plannerActions);
-		if (plannerActionGrammar) {
-			modelParams.responseSkeleton = plannerActionGrammar.responseSkeleton;
-			modelParams.grammar = plannerActionGrammar.grammar;
-			// Per-span argmax sampling for the planner envelope: the `action`
-			// enum span gets temperature=0 / topK=1 so the model never randomly
-			// picks the minority action under non-zero call-level temperature.
-			// `parameters` (free-json) and `thought` (free-string) keep the
-			// call-level sampler. Engines that don't honor per-span sampling
-			// ignore the field (grammar still constrains the same tokens).
-			modelParams.spanSamplerPlan = buildSpanSamplerPlan(
-				plannerActionGrammar.responseSkeleton,
-			);
-			modelParams.providerOptions = {
-				...(modelParams.providerOptions as Record<string, unknown>),
-				eliza: {
-					...((
-						modelParams.providerOptions as { eliza?: Record<string, unknown> }
-					)?.eliza ?? {}),
-					plannerActionSchemas: plannerActionGrammar.actionSchemas,
-				},
-			};
-			// Guided structured decode on by default for the planner pass that
-			// carries a forced PLAN_ACTIONS skeleton: the local engine derives the
-			// deterministic-token prefill plan and the fork fast-forwards the forced
-			// scaffold. Opt out with `ELIZA_LOCAL_GUIDED_DECODE=0`. Cloud adapters
-			// ignore `providerOptions.eliza.guidedDecode`.
-			withGuidedDecodeProviderOptions(modelParams.providerOptions);
-		}
-	} else {
-		modelParams.responseSchema = plannerSchema;
-	}
+  let renderedInput = renderPlannerModelInput({
+    context: params.context,
+    trajectory: params.trajectory,
+    template: resolveOptimizedPlannerTemplate(params.runtime),
+    runtime: params.runtime,
+    maxToolResultChars: params.config.compactionMaxKeptStepChars,
+  });
+  let modelInputBudget = buildModelInputBudget({
+    messages: renderedInput.messages,
+    promptSegments: renderedInput.promptSegments,
+    tools: params.tools,
+    // `modelName` lets the per-model context-window lookup fire.
+    // The lookup result wins over contextWindowTokens (see buildModelInputBudget
+    // resolution order). Note: contextWindowTokens defaults to 128_000 so the
+    // spread is always non-empty; the lookup will still override it when
+    // contextWindowModelName resolves.
+    modelName: params.config.contextWindowModelName,
+    ...(params.config.contextWindowTokens
+      ? { contextWindowTokens: params.config.contextWindowTokens }
+      : {}),
+    reserveTokens: compactionReserveForBudget(params.config),
+  });
+  if (modelInputBudget.shouldCompact && params.config.compactionEnabled) {
+    const compacted = await maybeCompactPlannerTrajectory({
+      trajectory: params.trajectory,
+      budget: modelInputBudget,
+      config: params.config,
+      recorder: params.recorder,
+      trajectoryId: params.trajectoryId,
+      parentStageId: params.parentStageId,
+      iteration: params.iteration ?? 1,
+      logger: params.runtime.logger,
+    });
+    if (compacted) {
+      renderedInput = renderPlannerModelInput({
+        context: params.trajectory.context,
+        trajectory: params.trajectory,
+        template: resolveOptimizedPlannerTemplate(params.runtime),
+        runtime: params.runtime,
+        maxToolResultChars: params.config.compactionMaxKeptStepChars,
+      });
+      modelInputBudget = buildModelInputBudget({
+        messages: renderedInput.messages,
+        promptSegments: renderedInput.promptSegments,
+        tools: params.tools,
+        modelName: params.config.contextWindowModelName,
+        ...(params.config.contextWindowTokens
+          ? { contextWindowTokens: params.config.contextWindowTokens }
+          : {}),
+        reserveTokens: compactionReserveForBudget(params.config),
+      });
+    }
+  }
+  const prefixHashes = computePrefixHashes(renderedInput.promptSegments);
+  const cachePrefixHashes = computePrefixHashes(
+    cachePrefixSegments(renderedInput.promptSegments),
+  );
+  const prefixHash =
+    cachePrefixHashes[cachePrefixHashes.length - 1]?.hash ??
+    "no-context-segments";
+  const hasTools = Array.isArray(params.tools) && params.tools.length > 0;
+  const modelParams: {
+    messages: ChatMessage[];
+    responseSchema?: unknown;
+    promptSegments: PromptSegment[];
+    providerOptions: Record<string, unknown>;
+    tools?: ToolDefinition[];
+    toolChoice?: ToolChoice;
+    responseSkeleton?: ResponseSkeleton;
+    grammar?: string;
+    spanSamplerPlan?: SpanSamplerPlan;
+    maxTokens?: number;
+  } = {
+    messages: renderedInput.messages,
+    promptSegments: renderedInput.promptSegments,
+    providerOptions: withModelInputBudgetProviderOptions(
+      cacheProviderOptions({
+        prefixHash,
+        segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
+        promptSegments: renderedInput.promptSegments,
+        provider: params.provider,
+        hasTools,
+        conversationId: params.trajectoryId,
+      }),
+      modelInputBudget,
+    ),
+    maxTokens: DEFAULT_PLANNER_MAX_TOKENS,
+  };
+  modelParams.providerOptions = {
+    ...modelParams.providerOptions,
+    eliza: {
+      ...((modelParams.providerOptions as { eliza?: Record<string, unknown> })
+        .eliza ?? {}),
+      thinking: "off",
+    },
+  };
+  if (hasTools) {
+    modelParams.tools = params.tools;
+    // Force a native tool call. With actions exposed directly as tools
+    // (post-PLAN_ACTIONS-wrapper refactor), every viable planner outcome —
+    // invoking an action, calling REPLY for a final message, or terminating
+    // via IGNORE / STOP — corresponds to a tool. There is no "the model
+    // shouldn't tool-call" case left, so `"required"` is the contract.
+    // Models that can't comply fail loudly; we don't degrade to text mode.
+    modelParams.toolChoice = params.toolChoice ?? "required";
+    // Per-turn structure forcing for the PLAN_ACTIONS args: pin `action` to
+    // the exact enum of actions exposed this turn and carry each action's
+    // normalized parameter schema so the local engine (W4) can do the
+    // second constrained pass (`parameters` against the chosen action's
+    // schema). Cloud adapters may ignore local structured-output hints like
+    // `responseSkeleton`, `grammar`, and
+    // `providerOptions.eliza.plannerActionSchemas`; `tools` carries the
+    // equivalent portable contract for them.
+    const exposedTools = collectExposedTools(params.context);
+    const plannerActions = exposedTools.map((tool) => ({
+      name: tool.name,
+      parameters: tool.action?.parameters ?? [],
+      allowAdditionalParameters:
+        tool.action?.allowAdditionalParameters === true,
+    }));
+    // Always use the per-action union grammar (P2-4) for the local engine:
+    // the GBNF root is the alternation of per-action branches, each with
+    // literal action name + a sub-grammar for that action's parameter
+    // shape. Chosen `action` and parameter shape are co-determined by the
+    // grammar in one call; the `validate-tool-args.ts` re-plan round
+    // is skipped when the model lands inside the strict grammar.
+    // Cloud adapters can use `tools` carrying the same schemas if they do not
+    // honor local skeleton/grammar hints.
+    const plannerActionGrammar =
+      buildPlannerActionGrammarStrict(plannerActions);
+    if (plannerActionGrammar) {
+      modelParams.responseSkeleton = plannerActionGrammar.responseSkeleton;
+      modelParams.grammar = plannerActionGrammar.grammar;
+      // Per-span argmax sampling for the planner envelope: the `action`
+      // enum span gets temperature=0 / topK=1 so the model never randomly
+      // picks the minority action under non-zero call-level temperature.
+      // `parameters` (free-json) and `thought` (free-string) keep the
+      // call-level sampler. Engines that don't honor per-span sampling
+      // ignore the field (grammar still constrains the same tokens).
+      modelParams.spanSamplerPlan = buildSpanSamplerPlan(
+        plannerActionGrammar.responseSkeleton,
+      );
+      modelParams.providerOptions = {
+        ...(modelParams.providerOptions as Record<string, unknown>),
+        eliza: {
+          ...((
+            modelParams.providerOptions as { eliza?: Record<string, unknown> }
+          )?.eliza ?? {}),
+          plannerActionSchemas: plannerActionGrammar.actionSchemas,
+        },
+      };
+      // Guided structured decode on by default for the planner pass that
+      // carries a forced PLAN_ACTIONS skeleton: the local engine derives the
+      // deterministic-token prefill plan and the fork fast-forwards the forced
+      // scaffold. Opt out with `ELIZA_LOCAL_GUIDED_DECODE=0`. Cloud adapters
+      // ignore `providerOptions.eliza.guidedDecode`.
+      withGuidedDecodeProviderOptions(modelParams.providerOptions);
+    }
+  } else {
+    modelParams.responseSchema = plannerSchema;
+  }
 
-	const startedAt = Date.now();
-	const modelType = params.modelType ?? ModelType.ACTION_PLANNER;
-	const streamingContext = getStreamingContext();
-	const raw = await runWithStreamingContext(
-		streamingContext
-			? {
-					...streamingContext,
-					onStreamChunk: async () => undefined,
-				}
-			: undefined,
-		() => params.runtime.useModel(modelType, modelParams, params.provider),
-	);
-	const endedAt = Date.now();
+  const startedAt = Date.now();
+  const modelType = params.modelType ?? ModelType.ACTION_PLANNER;
+  const streamingContext = getStreamingContext();
+  const raw = await runWithStreamingContext(
+    streamingContext
+      ? {
+          ...streamingContext,
+          onStreamChunk: async () => undefined,
+        }
+      : undefined,
+    () => params.runtime.useModel(modelType, modelParams, params.provider),
+  );
+  const endedAt = Date.now();
 
-	const parsed = parsePlannerOutput(raw);
+  const parsed = parsePlannerOutput(raw);
 
-	// Notify the cumulative-token observer first, BEFORE recording, so the
-	// loop's `maxTrajectoryPromptTokens` guard fires immediately on the call
-	// that crossed the line — not after we've already done another iteration
-	// of bookkeeping. The recorder is observability and can tolerate the
-	// minor reordering; the budget guard is load-bearing.
-	//
-	// CONSEQUENCE for trajectory consumers: when `observePlannerUsage` throws
-	// `TrajectoryLimitExceeded(kind: "trajectory_token_budget")` the call
-	// that crossed the line is intentionally **not** recorded as a planner
-	// stage. The trajectory then ends one stage short of the actual model
-	// activity. Downstream consumers that reconstruct totals from recorded
-	// stages (the trajectory CLI cost report, cost-regression dashboards)
-	// should treat the loop-level `metrics.totalPromptTokens` (populated by
-	// the recorder on `endTrajectory`) as authoritative rather than summing
-	// stage-level usages.
-	if (params.onUsage) {
-		const usage = extractUsage(raw);
-		if (usage) {
-			params.onUsage({
-				promptTokens: usage.promptTokens,
-				completionTokens: usage.completionTokens,
-			});
-		}
-	}
+  // Notify the cumulative-token observer first, BEFORE recording, so the
+  // loop's `maxTrajectoryPromptTokens` guard fires immediately on the call
+  // that crossed the line — not after we've already done another iteration
+  // of bookkeeping. The recorder is observability and can tolerate the
+  // minor reordering; the budget guard is load-bearing.
+  //
+  // CONSEQUENCE for trajectory consumers: when `observePlannerUsage` throws
+  // `TrajectoryLimitExceeded(kind: "trajectory_token_budget")` the call
+  // that crossed the line is intentionally **not** recorded as a planner
+  // stage. The trajectory then ends one stage short of the actual model
+  // activity. Downstream consumers that reconstruct totals from recorded
+  // stages (the trajectory CLI cost report, cost-regression dashboards)
+  // should treat the loop-level `metrics.totalPromptTokens` (populated by
+  // the recorder on `endTrajectory`) as authoritative rather than summing
+  // stage-level usages.
+  if (params.onUsage) {
+    const usage = extractUsage(raw);
+    if (usage) {
+      params.onUsage({
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+      });
+    }
+  }
 
-	await recordPlannerStage({
-		recorder: params.recorder,
-		trajectoryId: params.trajectoryId,
-		parentStageId: params.parentStageId,
-		iteration: params.iteration ?? 1,
-		modelType,
-		provider: params.provider,
-		modelParams,
-		raw,
-		parsed,
-		startedAt,
-		endedAt,
-		segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
-		prefixHash,
-		logger: params.runtime.logger,
-	});
+  await recordPlannerStage({
+    recorder: params.recorder,
+    trajectoryId: params.trajectoryId,
+    parentStageId: params.parentStageId,
+    iteration: params.iteration ?? 1,
+    modelType,
+    provider: params.provider,
+    modelParams,
+    raw,
+    parsed,
+    startedAt,
+    endedAt,
+    segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
+    prefixHash,
+    logger: params.runtime.logger,
+  });
 
-	return parsed;
+  return parsed;
 }
 
 async function maybeCompactPlannerTrajectory(args: {
-	trajectory: PlannerTrajectory;
-	budget: ModelInputBudget;
-	config: ChainingLoopConfig;
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration: number;
-	logger?: PlannerRuntime["logger"];
+  trajectory: PlannerTrajectory;
+  budget: ModelInputBudget;
+  config: ChainingLoopConfig;
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration: number;
+  logger?: PlannerRuntime["logger"];
 }): Promise<boolean> {
-	const keepSteps = Math.max(0, Math.floor(args.config.compactionKeepSteps));
-	const compactableStepCount = Math.max(
-		0,
-		args.trajectory.steps.length - keepSteps,
-	);
-	if (compactableStepCount === 0) {
-		args.logger?.debug?.(
-			{
-				estimatedInputTokens: args.budget.estimatedInputTokens,
-				compactionThresholdTokens: args.budget.compactionThresholdTokens,
-				stepCount: args.trajectory.steps.length,
-				keepSteps,
-			},
-			"Planner input crossed compaction threshold but no old steps are compactable",
-		);
-		return false;
-	}
+  const keepSteps = Math.max(0, Math.floor(args.config.compactionKeepSteps));
+  const compactableStepCount = Math.max(
+    0,
+    args.trajectory.steps.length - keepSteps,
+  );
+  if (compactableStepCount === 0) {
+    args.logger?.debug?.(
+      {
+        estimatedInputTokens: args.budget.estimatedInputTokens,
+        compactionThresholdTokens: args.budget.compactionThresholdTokens,
+        stepCount: args.trajectory.steps.length,
+        keepSteps,
+      },
+      "Planner input crossed compaction threshold but no old steps are compactable",
+    );
+    return false;
+  }
 
-	const startedAt = Date.now();
-	const compactedSteps = args.trajectory.steps.slice(0, compactableStepCount);
-	const keptSteps = args.trajectory.steps.slice(compactableStepCount);
-	const summary = buildCompactionSummary({
-		compactedSteps,
-		keptSteps,
-		budget: args.budget,
-	});
-	args.trajectory.archivedSteps.push(...compactedSteps);
-	args.trajectory.steps = keptSteps;
-	args.trajectory.context = appendContextEvent(args.trajectory.context, {
-		id: `compaction:${args.iteration}:${startedAt}`,
-		type: "segment",
-		source: "planner-loop",
-		createdAt: startedAt,
-		metadata: {
-			reason: "input_budget",
-			iteration: args.iteration,
-			compactedStepCount: compactableStepCount,
-			keptStepCount: keptSteps.length,
-			estimatedInputTokens: args.budget.estimatedInputTokens,
-			contextWindowTokens: args.budget.contextWindowTokens,
-			reserveTokens: args.budget.reserveTokens,
-			compactionThresholdTokens: args.budget.compactionThresholdTokens,
-		},
-		segment: {
-			id: `compaction:${args.iteration}:${startedAt}`,
-			label: "compaction",
-			content: summary,
-			stable: false,
-			metadata: {
-				reason: "input_budget",
-				iteration: args.iteration,
-				compactedStepCount: compactableStepCount,
-				keptStepCount: keptSteps.length,
-			},
-		},
-	});
-	const endedAt = Date.now();
-	await recordCompactionStage({
-		recorder: args.recorder,
-		trajectoryId: args.trajectoryId,
-		parentStageId: args.parentStageId,
-		iteration: args.iteration,
-		startedAt,
-		endedAt,
-		summary,
-		budget: args.budget,
-		compactedStepCount: compactableStepCount,
-		keptStepCount: keptSteps.length,
-		logger: args.logger,
-	});
-	return true;
+  const startedAt = Date.now();
+  const compactedSteps = args.trajectory.steps.slice(0, compactableStepCount);
+  const keptSteps = args.trajectory.steps.slice(compactableStepCount);
+  const summary = buildCompactionSummary({
+    compactedSteps,
+    keptSteps,
+    budget: args.budget,
+  });
+  args.trajectory.archivedSteps.push(...compactedSteps);
+  args.trajectory.steps = keptSteps;
+  args.trajectory.context = appendContextEvent(args.trajectory.context, {
+    id: `compaction:${args.iteration}:${startedAt}`,
+    type: "segment",
+    source: "planner-loop",
+    createdAt: startedAt,
+    metadata: {
+      reason: "input_budget",
+      iteration: args.iteration,
+      compactedStepCount: compactableStepCount,
+      keptStepCount: keptSteps.length,
+      estimatedInputTokens: args.budget.estimatedInputTokens,
+      contextWindowTokens: args.budget.contextWindowTokens,
+      reserveTokens: args.budget.reserveTokens,
+      compactionThresholdTokens: args.budget.compactionThresholdTokens,
+    },
+    segment: {
+      id: `compaction:${args.iteration}:${startedAt}`,
+      label: "compaction",
+      content: summary,
+      stable: false,
+      metadata: {
+        reason: "input_budget",
+        iteration: args.iteration,
+        compactedStepCount: compactableStepCount,
+        keptStepCount: keptSteps.length,
+      },
+    },
+  });
+  const endedAt = Date.now();
+  await recordCompactionStage({
+    recorder: args.recorder,
+    trajectoryId: args.trajectoryId,
+    parentStageId: args.parentStageId,
+    iteration: args.iteration,
+    startedAt,
+    endedAt,
+    summary,
+    budget: args.budget,
+    compactedStepCount: compactableStepCount,
+    keptStepCount: keptSteps.length,
+    logger: args.logger,
+  });
+  return true;
 }
 
 async function maybeCompactBeforeNextModelCall(args: {
-	trajectory: PlannerTrajectory;
-	config: ChainingLoopConfig;
-	tools?: ToolDefinition[];
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration: number;
-	logger?: PlannerRuntime["logger"];
+  trajectory: PlannerTrajectory;
+  config: ChainingLoopConfig;
+  tools?: ToolDefinition[];
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration: number;
+  logger?: PlannerRuntime["logger"];
 }): Promise<boolean> {
-	if (!args.config.compactionEnabled) {
-		return false;
-	}
-	const renderedInput = renderPlannerModelInput({
-		context: args.trajectory.context,
-		trajectory: args.trajectory,
-		maxToolResultChars: args.config.compactionMaxKeptStepChars,
-	});
-	const budget = buildModelInputBudget({
-		messages: renderedInput.messages,
-		promptSegments: renderedInput.promptSegments,
-		tools: args.tools,
-		modelName: args.config.contextWindowModelName,
-		...(args.config.contextWindowTokens
-			? { contextWindowTokens: args.config.contextWindowTokens }
-			: {}),
-		reserveTokens: compactionReserveForBudget(args.config),
-	});
-	if (!budget.shouldCompact) {
-		return false;
-	}
-	return maybeCompactPlannerTrajectory({
-		trajectory: args.trajectory,
-		budget,
-		config: args.config,
-		recorder: args.recorder,
-		trajectoryId: args.trajectoryId,
-		parentStageId: args.parentStageId,
-		iteration: args.iteration,
-		logger: args.logger,
-	});
+  if (!args.config.compactionEnabled) {
+    return false;
+  }
+  const renderedInput = renderPlannerModelInput({
+    context: args.trajectory.context,
+    trajectory: args.trajectory,
+    maxToolResultChars: args.config.compactionMaxKeptStepChars,
+  });
+  const budget = buildModelInputBudget({
+    messages: renderedInput.messages,
+    promptSegments: renderedInput.promptSegments,
+    tools: args.tools,
+    modelName: args.config.contextWindowModelName,
+    ...(args.config.contextWindowTokens
+      ? { contextWindowTokens: args.config.contextWindowTokens }
+      : {}),
+    reserveTokens: compactionReserveForBudget(args.config),
+  });
+  if (!budget.shouldCompact) {
+    return false;
+  }
+  return maybeCompactPlannerTrajectory({
+    trajectory: args.trajectory,
+    budget,
+    config: args.config,
+    recorder: args.recorder,
+    trajectoryId: args.trajectoryId,
+    parentStageId: args.parentStageId,
+    iteration: args.iteration,
+    logger: args.logger,
+  });
 }
 
 function buildCompactionSummary(args: {
-	compactedSteps: readonly PlannerStep[];
-	keptSteps: readonly PlannerStep[];
-	budget: ModelInputBudget;
+  compactedSteps: readonly PlannerStep[];
+  keptSteps: readonly PlannerStep[];
+  budget: ModelInputBudget;
 }): string {
-	const lines = [
-		"Compacted prior planner trajectory steps because estimated input approached the model context window.",
-		`compacted_steps: ${args.compactedSteps.length}`,
-		`kept_recent_steps_verbatim: ${args.keptSteps.length}`,
-		`estimated_input_tokens_before_compaction: ${args.budget.estimatedInputTokens}`,
-		`compaction_threshold_tokens: ${args.budget.compactionThresholdTokens}`,
-		"",
-		"Compacted step summaries:",
-	];
-	for (const step of args.compactedSteps) {
-		lines.push(`- ${summarizePlannerStep(step)}`);
-	}
-	return lines.join("\n").trim();
+  const lines = [
+    "Compacted prior planner trajectory steps because estimated input approached the model context window.",
+    `compacted_steps: ${args.compactedSteps.length}`,
+    `kept_recent_steps_verbatim: ${args.keptSteps.length}`,
+    `estimated_input_tokens_before_compaction: ${args.budget.estimatedInputTokens}`,
+    `compaction_threshold_tokens: ${args.budget.compactionThresholdTokens}`,
+    "",
+    "Compacted step summaries:",
+  ];
+  for (const step of args.compactedSteps) {
+    lines.push(`- ${summarizePlannerStep(step)}`);
+  }
+  return lines.join("\n").trim();
 }
 
 function summarizePlannerStep(step: PlannerStep): string {
-	const name = step.toolCall?.name ?? (step.terminalOnly ? "terminal" : "step");
-	const status = step.result
-		? step.result.success
-			? "success"
-			: "failed"
-		: "no_result";
-	const args =
-		step.toolCall?.params && Object.keys(step.toolCall.params).length > 0
-			? ` args=${compactText(stringifyForModel(step.toolCall.params), 180)}`
-			: "";
-	const result = step.result
-		? ` result=${compactText(toolMessageContent(step.result), 360)}`
-		: step.terminalMessage
-			? ` message=${compactText(step.terminalMessage, 240)}`
-			: "";
-	return `iter ${step.iteration} ${name} ${status}${args}${result}`;
+  const name = step.toolCall?.name ?? (step.terminalOnly ? "terminal" : "step");
+  const status = step.result
+    ? step.result.success
+      ? "success"
+      : "failed"
+    : "no_result";
+  const args =
+    step.toolCall?.params && Object.keys(step.toolCall.params).length > 0
+      ? ` args=${compactText(stringifyForModel(step.toolCall.params), 180)}`
+      : "";
+  const result = step.result
+    ? ` result=${compactText(toolMessageContent(step.result), 360)}`
+    : step.terminalMessage
+      ? ` message=${compactText(step.terminalMessage, 240)}`
+      : "";
+  return `iter ${step.iteration} ${name} ${status}${args}${result}`;
 }
 
 function compactText(value: string, maxLength: number): string {
-	const text = value.replace(/\s+/g, " ").trim();
-	if (text.length <= maxLength) {
-		return text;
-	}
-	const headLength = Math.max(20, Math.floor(maxLength * 0.65));
-	const tailLength = Math.max(20, maxLength - headLength - 24);
-	return `${text.slice(0, headLength)} ...[${text.length - headLength - tailLength} chars compacted]... ${text.slice(-tailLength)}`;
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const headLength = Math.max(20, Math.floor(maxLength * 0.65));
+  const tailLength = Math.max(20, maxLength - headLength - 24);
+  return `${text.slice(0, headLength)} ...[${text.length - headLength - tailLength} chars compacted]... ${text.slice(-tailLength)}`;
 }
 
 /**
@@ -1349,621 +1399,621 @@ function compactText(value: string, maxLength: number): string {
  * is included — no LLM call happened.
  */
 async function recordGatedEvaluationStage(args: {
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration: number;
-	startedAt: number;
-	endedAt: number;
-	output: EvaluatorOutput;
-	reason?: string;
-	logger?: PlannerRuntime["logger"];
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration: number;
+  startedAt: number;
+  endedAt: number;
+  output: EvaluatorOutput;
+  reason?: string;
+  logger?: PlannerRuntime["logger"];
 }): Promise<void> {
-	if (!args.recorder || !args.trajectoryId) return;
-	try {
-		const stage: RecordedStage = {
-			stageId: `stage-eval-iter-${args.iteration}-${args.startedAt}-gated`,
-			kind: "evaluation",
-			iteration: args.iteration,
-			parentStageId: args.parentStageId,
-			startedAt: args.startedAt,
-			endedAt: args.endedAt,
-			latencyMs: args.endedAt - args.startedAt,
-			evaluation: {
-				success: args.output.success,
-				decision: args.output.decision,
-				thought: args.output.thought,
-				messageToUser: args.output.messageToUser,
-				gated: true,
-				llmCallSkipped: true,
-				reason: args.reason ?? "explicit_terminal_reply",
-			},
-		};
-		await args.recorder.recordStage(args.trajectoryId, stage);
-	} catch (err) {
-		args.logger?.warn?.(
-			{ err: (err as Error).message, trajectoryId: args.trajectoryId },
-			"[TrajectoryRecorder] failed to record gated evaluation stage",
-		);
-	}
+  if (!args.recorder || !args.trajectoryId) return;
+  try {
+    const stage: RecordedStage = {
+      stageId: `stage-eval-iter-${args.iteration}-${args.startedAt}-gated`,
+      kind: "evaluation",
+      iteration: args.iteration,
+      parentStageId: args.parentStageId,
+      startedAt: args.startedAt,
+      endedAt: args.endedAt,
+      latencyMs: args.endedAt - args.startedAt,
+      evaluation: {
+        success: args.output.success,
+        decision: args.output.decision,
+        thought: args.output.thought,
+        messageToUser: args.output.messageToUser,
+        gated: true,
+        llmCallSkipped: true,
+        reason: args.reason ?? "explicit_terminal_reply",
+      },
+    };
+    await args.recorder.recordStage(args.trajectoryId, stage);
+  } catch (err) {
+    args.logger?.warn?.(
+      { err: (err as Error).message, trajectoryId: args.trajectoryId },
+      "[TrajectoryRecorder] failed to record gated evaluation stage",
+    );
+  }
 }
 
 async function recordCompactionStage(args: {
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration: number;
-	startedAt: number;
-	endedAt: number;
-	summary: string;
-	budget: ModelInputBudget;
-	compactedStepCount: number;
-	keptStepCount: number;
-	logger?: PlannerRuntime["logger"];
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration: number;
+  startedAt: number;
+  endedAt: number;
+  summary: string;
+  budget: ModelInputBudget;
+  compactedStepCount: number;
+  keptStepCount: number;
+  logger?: PlannerRuntime["logger"];
 }): Promise<void> {
-	if (!args.recorder || !args.trajectoryId) return;
-	try {
-		const stage: RecordedStage = {
-			stageId: `stage-compaction-iter-${args.iteration}-${args.startedAt}`,
-			kind: "compaction",
-			iteration: args.iteration,
-			parentStageId: args.parentStageId,
-			startedAt: args.startedAt,
-			endedAt: args.endedAt,
-			latencyMs: args.endedAt - args.startedAt,
-			tool: {
-				name: "CONTEXT_COMPACTION",
-				args: {
-					reason: "input_budget",
-					estimatedInputTokens: args.budget.estimatedInputTokens,
-					contextWindowTokens: args.budget.contextWindowTokens,
-					reserveTokens: args.budget.reserveTokens,
-					compactionThresholdTokens: args.budget.compactionThresholdTokens,
-				},
-				result: {
-					summary: args.summary,
-					compactedStepCount: args.compactedStepCount,
-					keptStepCount: args.keptStepCount,
-				},
-				success: true,
-				durationMs: args.endedAt - args.startedAt,
-			},
-		};
-		await args.recorder.recordStage(args.trajectoryId, stage);
-	} catch (err) {
-		args.logger?.warn?.(
-			{ err: (err as Error).message, trajectoryId: args.trajectoryId },
-			"[TrajectoryRecorder] failed to record compaction stage",
-		);
-	}
+  if (!args.recorder || !args.trajectoryId) return;
+  try {
+    const stage: RecordedStage = {
+      stageId: `stage-compaction-iter-${args.iteration}-${args.startedAt}`,
+      kind: "compaction",
+      iteration: args.iteration,
+      parentStageId: args.parentStageId,
+      startedAt: args.startedAt,
+      endedAt: args.endedAt,
+      latencyMs: args.endedAt - args.startedAt,
+      tool: {
+        name: "CONTEXT_COMPACTION",
+        args: {
+          reason: "input_budget",
+          estimatedInputTokens: args.budget.estimatedInputTokens,
+          contextWindowTokens: args.budget.contextWindowTokens,
+          reserveTokens: args.budget.reserveTokens,
+          compactionThresholdTokens: args.budget.compactionThresholdTokens,
+        },
+        result: {
+          summary: args.summary,
+          compactedStepCount: args.compactedStepCount,
+          keptStepCount: args.keptStepCount,
+        },
+        success: true,
+        durationMs: args.endedAt - args.startedAt,
+      },
+    };
+    await args.recorder.recordStage(args.trajectoryId, stage);
+  } catch (err) {
+    args.logger?.warn?.(
+      { err: (err as Error).message, trajectoryId: args.trajectoryId },
+      "[TrajectoryRecorder] failed to record compaction stage",
+    );
+  }
 }
 
 async function recordPlannerStage(args: {
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	iteration: number;
-	modelType: TextGenerationModelType;
-	provider?: string;
-	modelParams: {
-		messages?: ChatMessage[];
-		tools?: ToolDefinition[];
-		toolChoice?: ToolChoice;
-		providerOptions?: Record<string, unknown>;
-	};
-	raw: string | GenerateTextResult;
-	parsed: ReturnType<typeof parsePlannerOutput>;
-	startedAt: number;
-	endedAt: number;
-	segmentHashes: string[];
-	prefixHash: string;
-	logger?: PlannerRuntime["logger"];
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  iteration: number;
+  modelType: TextGenerationModelType;
+  provider?: string;
+  modelParams: {
+    messages?: ChatMessage[];
+    tools?: ToolDefinition[];
+    toolChoice?: ToolChoice;
+    providerOptions?: Record<string, unknown>;
+  };
+  raw: string | GenerateTextResult;
+  parsed: ReturnType<typeof parsePlannerOutput>;
+  startedAt: number;
+  endedAt: number;
+  segmentHashes: string[];
+  prefixHash: string;
+  logger?: PlannerRuntime["logger"];
 }): Promise<void> {
-	if (!args.recorder || !args.trajectoryId) return;
+  if (!args.recorder || !args.trajectoryId) return;
 
-	try {
-		const responseText =
-			typeof args.raw === "string" ? args.raw : args.raw.text;
-		const usage = extractUsage(args.raw);
-		const finishReason = extractFinishReason(args.raw);
-		const modelName = extractModelName(args.raw);
-		const stage: RecordedStage = {
-			stageId: `stage-planner-iter-${args.iteration}-${args.startedAt}`,
-			kind: "planner",
-			iteration: args.iteration,
-			parentStageId: args.parentStageId,
-			startedAt: args.startedAt,
-			endedAt: args.endedAt,
-			latencyMs: args.endedAt - args.startedAt,
-			model: {
-				modelType: String(args.modelType),
-				modelName,
-				provider: args.provider ?? "default",
-				messages: args.modelParams.messages,
-				tools: args.modelParams.tools,
-				toolChoice: args.modelParams.toolChoice,
-				providerOptions: args.modelParams.providerOptions,
-				response: responseText,
-				toolCalls: args.parsed.toolCalls.map<RecordedToolCall>((tc) => ({
-					id: tc.id,
-					name: tc.name,
-					args: tc.params,
-				})),
-				usage,
-				finishReason,
-				costUsd: usage ? computeCallCostUsd(modelName, usage) : undefined,
-			},
-			cache: {
-				segmentHashes: args.segmentHashes,
-				prefixHash: args.prefixHash,
-			},
-		};
-		await args.recorder.recordStage(args.trajectoryId, stage);
-	} catch (err) {
-		args.logger?.warn?.(
-			{ err: (err as Error).message, trajectoryId: args.trajectoryId },
-			"[TrajectoryRecorder] failed to record planner stage",
-		);
-	}
+  try {
+    const responseText =
+      typeof args.raw === "string" ? args.raw : args.raw.text;
+    const usage = extractUsage(args.raw);
+    const finishReason = extractFinishReason(args.raw);
+    const modelName = extractModelName(args.raw);
+    const stage: RecordedStage = {
+      stageId: `stage-planner-iter-${args.iteration}-${args.startedAt}`,
+      kind: "planner",
+      iteration: args.iteration,
+      parentStageId: args.parentStageId,
+      startedAt: args.startedAt,
+      endedAt: args.endedAt,
+      latencyMs: args.endedAt - args.startedAt,
+      model: {
+        modelType: String(args.modelType),
+        modelName,
+        provider: args.provider ?? "default",
+        messages: args.modelParams.messages,
+        tools: args.modelParams.tools,
+        toolChoice: args.modelParams.toolChoice,
+        providerOptions: args.modelParams.providerOptions,
+        response: responseText,
+        toolCalls: args.parsed.toolCalls.map<RecordedToolCall>((tc) => ({
+          id: tc.id,
+          name: tc.name,
+          args: tc.params,
+        })),
+        usage,
+        finishReason,
+        costUsd: usage ? computeCallCostUsd(modelName, usage) : undefined,
+      },
+      cache: {
+        segmentHashes: args.segmentHashes,
+        prefixHash: args.prefixHash,
+      },
+    };
+    await args.recorder.recordStage(args.trajectoryId, stage);
+  } catch (err) {
+    args.logger?.warn?.(
+      { err: (err as Error).message, trajectoryId: args.trajectoryId },
+      "[TrajectoryRecorder] failed to record planner stage",
+    );
+  }
 }
 
 function extractUsage(
-	raw: string | GenerateTextResult,
+  raw: string | GenerateTextResult,
 ): RecordedUsage | undefined {
-	if (typeof raw === "string") return undefined;
-	if (!raw.usage) return undefined;
-	const usage = raw.usage;
-	const promptTokens = usage.promptTokens;
-	const completionTokens = usage.completionTokens;
-	const totalTokens = usage.totalTokens;
-	const out: RecordedUsage = {
-		promptTokens,
-		completionTokens,
-		totalTokens,
-	};
-	const cacheRead = usage.cacheReadInputTokens;
-	if (typeof cacheRead === "number") {
-		out.cacheReadInputTokens = cacheRead;
-	} else {
-		// Fall back to OpenAI plugin's `cachedPromptTokens` shape, which adapters
-		// emitted before the shared schema landed.
-		const cachedPrompt =
-			"cachedPromptTokens" in usage ? usage.cachedPromptTokens : undefined;
-		if (typeof cachedPrompt === "number") {
-			out.cacheReadInputTokens = cachedPrompt;
-		}
-	}
-	const cacheCreation = usage.cacheCreationInputTokens;
-	if (typeof cacheCreation === "number") {
-		out.cacheCreationInputTokens = cacheCreation;
-	}
-	return out;
+  if (typeof raw === "string") return undefined;
+  if (!raw.usage) return undefined;
+  const usage = raw.usage;
+  const promptTokens = usage.promptTokens;
+  const completionTokens = usage.completionTokens;
+  const totalTokens = usage.totalTokens;
+  const out: RecordedUsage = {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+  };
+  const cacheRead = usage.cacheReadInputTokens;
+  if (typeof cacheRead === "number") {
+    out.cacheReadInputTokens = cacheRead;
+  } else {
+    // Fall back to OpenAI plugin's `cachedPromptTokens` shape, which adapters
+    // emitted before the shared schema landed.
+    const cachedPrompt =
+      "cachedPromptTokens" in usage ? usage.cachedPromptTokens : undefined;
+    if (typeof cachedPrompt === "number") {
+      out.cacheReadInputTokens = cachedPrompt;
+    }
+  }
+  const cacheCreation = usage.cacheCreationInputTokens;
+  if (typeof cacheCreation === "number") {
+    out.cacheCreationInputTokens = cacheCreation;
+  }
+  return out;
 }
 
 function extractFinishReason(
-	raw: string | GenerateTextResult,
+  raw: string | GenerateTextResult,
 ): string | undefined {
-	if (typeof raw === "string") return undefined;
-	return raw.finishReason;
+  if (typeof raw === "string") return undefined;
+  return raw.finishReason;
 }
 
 function extractModelName(
-	raw: string | GenerateTextResult,
+  raw: string | GenerateTextResult,
 ): string | undefined {
-	if (typeof raw === "string") return undefined;
-	const meta = raw.providerMetadata;
-	if (meta && typeof meta === "object") {
-		const direct = (meta as Record<string, unknown>).modelName;
-		if (typeof direct === "string") return direct;
-		const model = (meta as Record<string, unknown>).model;
-		if (typeof model === "string") return model;
-	}
-	return undefined;
+  if (typeof raw === "string") return undefined;
+  const meta = raw.providerMetadata;
+  if (meta && typeof meta === "object") {
+    const direct = (meta as Record<string, unknown>).modelName;
+    if (typeof direct === "string") return direct;
+    const model = (meta as Record<string, unknown>).model;
+    if (typeof model === "string") return model;
+  }
+  return undefined;
 }
 
 async function evaluateTrajectory(
-	params: PlannerLoopParams,
-	trajectory: PlannerTrajectory,
-	iteration: number,
+  params: PlannerLoopParams,
+  trajectory: PlannerTrajectory,
+  iteration: number,
 ): Promise<EvaluatorOutput> {
-	if (params.evaluate) {
-		return params.evaluate({
-			runtime: params.runtime,
-			context: trajectory.context,
-			trajectory,
-		});
-	}
+  if (params.evaluate) {
+    return params.evaluate({
+      runtime: params.runtime,
+      context: trajectory.context,
+      trajectory,
+    });
+  }
 
-	return runEvaluator({
-		runtime: params.runtime,
-		context: trajectory.context,
-		trajectory,
-		effects: params.evaluatorEffects,
-		recorder: params.recorder,
-		trajectoryId: params.trajectoryId,
-		parentStageId: params.parentStageId,
-		iteration,
-	});
+  return runEvaluator({
+    runtime: params.runtime,
+    context: trajectory.context,
+    trajectory,
+    effects: params.evaluatorEffects,
+    recorder: params.recorder,
+    trajectoryId: params.trajectoryId,
+    parentStageId: params.parentStageId,
+    iteration,
+  });
 }
 
 function appendEvaluationEvent(args: {
-	context: ContextObject;
-	iteration: number;
-	evaluator: EvaluatorOutput;
+  context: ContextObject;
+  iteration: number;
+  evaluator: EvaluatorOutput;
 }): ContextObject {
-	const createdAt = Date.now();
-	return appendContextEvent(args.context, {
-		id: `evaluation:${args.iteration}:${createdAt}`,
-		type: "evaluation",
-		source: "planner-loop",
-		createdAt,
-		metadata: {
-			iteration: args.iteration,
-			success: args.evaluator.success,
-			decision: args.evaluator.decision,
-			thought: args.evaluator.thought,
-			messageToUser: args.evaluator.messageToUser,
-			recommendedToolCallId: args.evaluator.recommendedToolCallId,
-		},
-	});
+  const createdAt = Date.now();
+  return appendContextEvent(args.context, {
+    id: `evaluation:${args.iteration}:${createdAt}`,
+    type: "evaluation",
+    source: "planner-loop",
+    createdAt,
+    metadata: {
+      iteration: args.iteration,
+      success: args.evaluator.success,
+      decision: args.evaluator.decision,
+      thought: args.evaluator.thought,
+      messageToUser: args.evaluator.messageToUser,
+      recommendedToolCallId: args.evaluator.recommendedToolCallId,
+    },
+  });
 }
 
 function appendEvaluatorContextEvent(
-	trajectory: PlannerTrajectory,
-	evaluator: EvaluatorOutput,
-	iteration: number,
+  trajectory: PlannerTrajectory,
+  evaluator: EvaluatorOutput,
+  iteration: number,
 ): void {
-	trajectory.context = appendEvaluationEvent({
-		context: trajectory.context,
-		iteration,
-		evaluator,
-	});
+  trajectory.context = appendEvaluationEvent({
+    context: trajectory.context,
+    iteration,
+    evaluator,
+  });
 }
 
 function appendTerminalPlannerOutputEvent(args: {
-	context: ContextObject;
-	iteration: number;
-	message?: string;
+  context: ContextObject;
+  iteration: number;
+  message?: string;
 }): ContextObject {
-	const createdAt = Date.now();
-	const unsafe = isUnsafeUserVisibleText(args.message);
-	const content = [
-		"planner_terminal_output:",
-		compactText(args.message ?? "", 1_200),
-		"",
-		unsafe
-			? "note: This output looked like internal planning or attempted tool-call text. It must not be shown directly to the user."
-			: "note: Evaluate whether this user-visible output actually completes the request.",
-	].join("\n");
-	return appendContextEvent(args.context, {
-		id: `terminal-planner-output:${args.iteration}:${createdAt}`,
-		type: "segment",
-		source: "planner-loop",
-		createdAt,
-		metadata: {
-			iteration: args.iteration,
-			unsafe,
-		},
-		segment: {
-			id: `terminal-planner-output:${args.iteration}:${createdAt}`,
-			label: "terminal_planner_output",
-			content,
-			stable: false,
-			metadata: {
-				iteration: args.iteration,
-				unsafe,
-			},
-		},
-	});
+  const createdAt = Date.now();
+  const unsafe = isUnsafeUserVisibleText(args.message);
+  const content = [
+    "planner_terminal_output:",
+    compactText(args.message ?? "", 1_200),
+    "",
+    unsafe
+      ? "note: This output looked like internal planning or attempted tool-call text. It must not be shown directly to the user."
+      : "note: Evaluate whether this user-visible output actually completes the request.",
+  ].join("\n");
+  return appendContextEvent(args.context, {
+    id: `terminal-planner-output:${args.iteration}:${createdAt}`,
+    type: "segment",
+    source: "planner-loop",
+    createdAt,
+    metadata: {
+      iteration: args.iteration,
+      unsafe,
+    },
+    segment: {
+      id: `terminal-planner-output:${args.iteration}:${createdAt}`,
+      label: "terminal_planner_output",
+      content,
+      stable: false,
+      metadata: {
+        iteration: args.iteration,
+        unsafe,
+      },
+    },
+  });
 }
 
 function appendTerminalContinuationEvent(args: {
-	context: ContextObject;
-	iteration: number;
-	terminalOnlyContinuations: number;
-	message?: string;
+  context: ContextObject;
+  iteration: number;
+  terminalOnlyContinuations: number;
+  message?: string;
 }): ContextObject {
-	const createdAt = Date.now();
-	const unsafe = isUnsafeUserVisibleText(args.message);
-	const content = [
-		"planner_retry_instruction:",
-		`terminal_only_continuations: ${args.terminalOnlyContinuations}`,
-		unsafe
-			? "The previous planner output exposed internal tool planning. Emit native toolCalls for remaining work, or a concise user-safe message only if the request is complete."
-			: "The evaluator found the previous terminal planner output partial. Emit native toolCalls for remaining work.",
-	].join("\n");
-	return appendContextEvent(args.context, {
-		id: `terminal-planner-retry:${args.iteration}:${createdAt}`,
-		type: "segment",
-		source: "planner-loop",
-		createdAt,
-		metadata: {
-			iteration: args.iteration,
-			terminalOnlyContinuations: args.terminalOnlyContinuations,
-			unsafe,
-		},
-		segment: {
-			id: `terminal-planner-retry:${args.iteration}:${createdAt}`,
-			label: "planner_retry_instruction",
-			content,
-			stable: false,
-			metadata: {
-				iteration: args.iteration,
-				terminalOnlyContinuations: args.terminalOnlyContinuations,
-				unsafe,
-			},
-		},
-	});
+  const createdAt = Date.now();
+  const unsafe = isUnsafeUserVisibleText(args.message);
+  const content = [
+    "planner_retry_instruction:",
+    `terminal_only_continuations: ${args.terminalOnlyContinuations}`,
+    unsafe
+      ? "The previous planner output exposed internal tool planning. Emit native toolCalls for remaining work, or a concise user-safe message only if the request is complete."
+      : "The evaluator found the previous terminal planner output partial. Emit native toolCalls for remaining work.",
+  ].join("\n");
+  return appendContextEvent(args.context, {
+    id: `terminal-planner-retry:${args.iteration}:${createdAt}`,
+    type: "segment",
+    source: "planner-loop",
+    createdAt,
+    metadata: {
+      iteration: args.iteration,
+      terminalOnlyContinuations: args.terminalOnlyContinuations,
+      unsafe,
+    },
+    segment: {
+      id: `terminal-planner-retry:${args.iteration}:${createdAt}`,
+      label: "planner_retry_instruction",
+      content,
+      stable: false,
+      metadata: {
+        iteration: args.iteration,
+        terminalOnlyContinuations: args.terminalOnlyContinuations,
+        unsafe,
+      },
+    },
+  });
 }
 
 function appendUnavailableToolCallEvent(args: {
-	context: ContextObject;
-	iteration: number;
-	invalidToolCalls: readonly PlannerToolCall[];
-	tools?: ToolDefinition[];
+  context: ContextObject;
+  iteration: number;
+  invalidToolCalls: readonly PlannerToolCall[];
+  tools?: ToolDefinition[];
 }): ContextObject {
-	const createdAt = Date.now();
-	const exposed = Array.from(exposedToolNameSet(args.tools) ?? []).sort();
-	const invalid = args.invalidToolCalls.map((toolCall) => toolCall.name);
-	const content = [
-		"planner_retry_instruction:",
-		`unavailable_tool_calls: ${JSON.stringify(invalid)}`,
-		`available_tools: ${JSON.stringify(exposed)}`,
-		"The previous planner output called tools that were not exposed for this turn. Retry using only available_tools, or return a terminal REPLY if no exposed tool fits.",
-	].join("\n");
-	return appendContextEvent(args.context, {
-		id: `unavailable-tool-call-retry:${args.iteration}:${createdAt}`,
-		type: "instruction",
-		source: "planner-loop",
-		createdAt,
-		content,
-		metadata: {
-			iteration: args.iteration,
-			invalidToolCalls: invalid,
-			availableTools: exposed,
-		},
-	});
+  const createdAt = Date.now();
+  const exposed = Array.from(exposedToolNameSet(args.tools) ?? []).sort();
+  const invalid = args.invalidToolCalls.map((toolCall) => toolCall.name);
+  const content = [
+    "planner_retry_instruction:",
+    `unavailable_tool_calls: ${JSON.stringify(invalid)}`,
+    `available_tools: ${JSON.stringify(exposed)}`,
+    "The previous planner output called tools that were not exposed for this turn. Retry using only available_tools, or return a terminal REPLY if no exposed tool fits.",
+  ].join("\n");
+  return appendContextEvent(args.context, {
+    id: `unavailable-tool-call-retry:${args.iteration}:${createdAt}`,
+    type: "instruction",
+    source: "planner-loop",
+    createdAt,
+    content,
+    metadata: {
+      iteration: args.iteration,
+      invalidToolCalls: invalid,
+      availableTools: exposed,
+    },
+  });
 }
 
 function appendSilentFailedFinishRecoveryEvent(args: {
-	context: ContextObject;
-	iteration: number;
-	evaluator: EvaluatorOutput;
-	trajectory: PlannerTrajectory;
+  context: ContextObject;
+  iteration: number;
+  evaluator: EvaluatorOutput;
+  trajectory: PlannerTrajectory;
 }): ContextObject {
-	const createdAt = Date.now();
-	const failedStep = latestFailedToolStep(args.trajectory);
-	const failedToolName = failedStep?.toolCall?.name;
-	const content = [
-		"planner_retry_instruction:",
-		"silent_failed_finish: true",
-		failedToolName ? `failed_tool: ${failedToolName}` : null,
-		"The latest tool step failed, and the evaluator finished without a user-visible message. Retry once with a different available approach if possible; otherwise return a concise user-visible blocker instead of ending silently.",
-	]
-		.filter((line): line is string => line !== null)
-		.join("\n");
-	return appendContextEvent(args.context, {
-		id: `silent-failed-finish-retry:${args.iteration}:${createdAt}`,
-		type: "instruction",
-		source: "planner-loop",
-		createdAt,
-		content,
-		metadata: {
-			iteration: args.iteration,
-			evaluatorDecision: args.evaluator.decision,
-			evaluatorSuccess: args.evaluator.success,
-			failedToolName,
-		},
-	});
+  const createdAt = Date.now();
+  const failedStep = latestFailedToolStep(args.trajectory);
+  const failedToolName = failedStep?.toolCall?.name;
+  const content = [
+    "planner_retry_instruction:",
+    "silent_failed_finish: true",
+    failedToolName ? `failed_tool: ${failedToolName}` : null,
+    "The latest tool step failed, and the evaluator finished without a user-visible message. Retry once with a different available approach if possible; otherwise return a concise user-visible blocker instead of ending silently.",
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+  return appendContextEvent(args.context, {
+    id: `silent-failed-finish-retry:${args.iteration}:${createdAt}`,
+    type: "instruction",
+    source: "planner-loop",
+    createdAt,
+    content,
+    metadata: {
+      iteration: args.iteration,
+      evaluatorDecision: args.evaluator.decision,
+      evaluatorSuccess: args.evaluator.success,
+      failedToolName,
+    },
+  });
 }
 
 async function executeQueuedToolCall(params: {
-	params: PlannerLoopParams;
-	trajectory: PlannerTrajectory;
-	toolCall: PlannerToolCall;
-	iteration: number;
-	config: ChainingLoopConfig;
-	failures: FailureLike[];
+  params: PlannerLoopParams;
+  trajectory: PlannerTrajectory;
+  toolCall: PlannerToolCall;
+  iteration: number;
+  config: ChainingLoopConfig;
+  failures: FailureLike[];
 }): Promise<void> {
-	assertTrajectoryLimit({
-		kind: "tool_calls",
-		max: params.config.maxToolCalls,
-		observed:
-			params.trajectory.steps.filter((step) => step.toolCall).length + 1,
-	});
+  assertTrajectoryLimit({
+    kind: "tool_calls",
+    max: params.config.maxToolCalls,
+    observed:
+      params.trajectory.steps.filter((step) => step.toolCall).length + 1,
+  });
 
-	const streamingContext = getStreamingContext();
-	const contextEvent = findToolContextEvent(
-		params.trajectory.context,
-		params.toolCall,
-	);
-	await emitStreamingHook(streamingContext, "onToolCall", {
-		toolCall: plannerToolCallToStreamingToolCall(params.toolCall, "pending"),
-		contextEvent,
-		messageId: streamingContext?.messageId,
-		metadata: { iteration: params.iteration },
-	});
+  const streamingContext = getStreamingContext();
+  const contextEvent = findToolContextEvent(
+    params.trajectory.context,
+    params.toolCall,
+  );
+  await emitStreamingHook(streamingContext, "onToolCall", {
+    toolCall: plannerToolCallToStreamingToolCall(params.toolCall, "pending"),
+    contextEvent,
+    messageId: streamingContext?.messageId,
+    metadata: { iteration: params.iteration },
+  });
 
-	await params.params.onToolCallEnqueued?.(params.toolCall, {
-		iteration: params.iteration,
-	});
+  await params.params.onToolCallEnqueued?.(params.toolCall, {
+    iteration: params.iteration,
+  });
 
-	const startedAt = Date.now();
-	let result: PlannerToolResult;
-	try {
-		result = await params.params.executeToolCall(params.toolCall, {
-			trajectory: params.trajectory,
-			iteration: params.iteration,
-		});
-	} catch (error) {
-		result = {
-			success: false,
-			error,
-		};
-	}
-	const endedAt = Date.now();
+  const startedAt = Date.now();
+  let result: PlannerToolResult;
+  try {
+    result = await params.params.executeToolCall(params.toolCall, {
+      trajectory: params.trajectory,
+      iteration: params.iteration,
+    });
+  } catch (error) {
+    result = {
+      success: false,
+      error,
+    };
+  }
+  const endedAt = Date.now();
 
-	// Parameter-validation rejections from `validateToolArgs` set
-	// `result.data.parameterErrors`. A model that keeps the same tool but
-	// shuffles its argument shape across retries (e.g. trying `action=create`
-	// then `action=spawn_agent` then `action=update`) varies both the error
-	// string and the params JSON, so the per-call repeatKey + per-call error
-	// message both diverge and `assertRepeatedFailureLimit` never trips —
-	// even though the failure category is identical and the model is just
-	// hunting for a valid arg shape that does not exist on this action.
-	// Collapse parameter-validation failures of a tool to a single canonical
-	// signature so the existing repeated-failure guard catches that pattern.
-	const isParameterValidationFailure = Array.isArray(
-		(result.data as { parameterErrors?: unknown } | undefined)?.parameterErrors,
-	);
-	const failure = {
-		toolName: params.toolCall.name,
-		success: result.success,
-		error: isParameterValidationFailure
-			? "parameter_validation_failed"
-			: result.error,
-		repeatKey: isParameterValidationFailure
-			? "parameter_validation"
-			: toolFailureRepeatKey(params.toolCall),
-	};
-	if (!result.success || result.error != null) {
-		params.failures.push(failure);
-		assertRepeatedFailureLimit({
-			failures: params.failures,
-			latestFailure: failure,
-			maxRepeatedFailures: params.config.maxRepeatedFailures,
-		});
-	}
+  // Parameter-validation rejections from `validateToolArgs` set
+  // `result.data.parameterErrors`. A model that keeps the same tool but
+  // shuffles its argument shape across retries (e.g. trying `action=create`
+  // then `action=spawn_agent` then `action=update`) varies both the error
+  // string and the params JSON, so the per-call repeatKey + per-call error
+  // message both diverge and `assertRepeatedFailureLimit` never trips —
+  // even though the failure category is identical and the model is just
+  // hunting for a valid arg shape that does not exist on this action.
+  // Collapse parameter-validation failures of a tool to a single canonical
+  // signature so the existing repeated-failure guard catches that pattern.
+  const isParameterValidationFailure = Array.isArray(
+    (result.data as { parameterErrors?: unknown } | undefined)?.parameterErrors,
+  );
+  const failure = {
+    toolName: params.toolCall.name,
+    success: result.success,
+    error: isParameterValidationFailure
+      ? "parameter_validation_failed"
+      : result.error,
+    repeatKey: isParameterValidationFailure
+      ? "parameter_validation"
+      : toolFailureRepeatKey(params.toolCall),
+  };
+  if (!result.success || result.error != null) {
+    params.failures.push(failure);
+    assertRepeatedFailureLimit({
+      failures: params.failures,
+      latestFailure: failure,
+      maxRepeatedFailures: params.config.maxRepeatedFailures,
+    });
+  }
 
-	params.trajectory.steps.push({
-		iteration: params.iteration,
-		toolCall: params.toolCall,
-		result,
-	});
-	params.trajectory.context = {
-		...params.trajectory.context,
-		plannedQueue: (params.trajectory.context.plannedQueue ?? []).map((entry) =>
-			entry.id === params.toolCall.id ||
-			(!entry.id && entry.name === params.toolCall.name)
-				? {
-						...entry,
-						status: result.success ? "completed" : "failed",
-					}
-				: entry,
-		),
-	};
-	params.trajectory.context = appendContextEvent(params.trajectory.context, {
-		id: `tool-result:${params.toolCall.id ?? params.toolCall.name}:${endedAt}`,
-		type: "tool_result",
-		source: "planner-loop",
-		createdAt: endedAt,
-		metadata: {
-			iteration: params.iteration,
-			toolCallId: params.toolCall.id,
-			name: params.toolCall.name,
-			params: stringifyForModel(params.toolCall.params ?? {}),
-			result: stringifyForModel(result),
-			status: result.success ? "completed" : "failed",
-		},
-	});
+  params.trajectory.steps.push({
+    iteration: params.iteration,
+    toolCall: params.toolCall,
+    result,
+  });
+  params.trajectory.context = {
+    ...params.trajectory.context,
+    plannedQueue: (params.trajectory.context.plannedQueue ?? []).map((entry) =>
+      entry.id === params.toolCall.id ||
+      (!entry.id && entry.name === params.toolCall.name)
+        ? {
+            ...entry,
+            status: result.success ? "completed" : "failed",
+          }
+        : entry,
+    ),
+  };
+  params.trajectory.context = appendContextEvent(params.trajectory.context, {
+    id: `tool-result:${params.toolCall.id ?? params.toolCall.name}:${endedAt}`,
+    type: "tool_result",
+    source: "planner-loop",
+    createdAt: endedAt,
+    metadata: {
+      iteration: params.iteration,
+      toolCallId: params.toolCall.id,
+      name: params.toolCall.name,
+      params: stringifyForModel(params.toolCall.params ?? {}),
+      result: stringifyForModel(result),
+      status: result.success ? "completed" : "failed",
+    },
+  });
 
-	await recordToolStage({
-		recorder: params.params.recorder,
-		trajectoryId: params.params.trajectoryId,
-		parentStageId: params.params.parentStageId,
-		toolCall: params.toolCall,
-		result,
-		startedAt,
-		endedAt,
-		logger: params.params.runtime.logger,
-	});
+  await recordToolStage({
+    recorder: params.params.recorder,
+    trajectoryId: params.params.trajectoryId,
+    parentStageId: params.params.parentStageId,
+    toolCall: params.toolCall,
+    result,
+    startedAt,
+    endedAt,
+    logger: params.params.runtime.logger,
+  });
 }
 
 async function recordToolStage(args: {
-	recorder?: TrajectoryRecorder;
-	trajectoryId?: string;
-	parentStageId?: string;
-	toolCall: PlannerToolCall;
-	result: PlannerToolResult;
-	startedAt: number;
-	endedAt: number;
-	logger?: PlannerRuntime["logger"];
+  recorder?: TrajectoryRecorder;
+  trajectoryId?: string;
+  parentStageId?: string;
+  toolCall: PlannerToolCall;
+  result: PlannerToolResult;
+  startedAt: number;
+  endedAt: number;
+  logger?: PlannerRuntime["logger"];
 }): Promise<void> {
-	if (!args.recorder || !args.trajectoryId) return;
-	try {
-		const inputParams = (args.toolCall.params ?? {}) as Record<string, unknown>;
-		const io = captureToolStageIO({
-			input: inputParams,
-			output: args.result,
-			error: args.result.error,
-		});
-		const stage: RecordedStage = {
-			stageId: `stage-tool-${args.toolCall.name}-${args.startedAt}`,
-			kind: "tool",
-			parentStageId: args.parentStageId,
-			startedAt: args.startedAt,
-			endedAt: args.endedAt,
-			latencyMs: args.endedAt - args.startedAt,
-			tool: {
-				name: args.toolCall.name,
-				args: inputParams,
-				result: args.result,
-				success: args.result.success,
-				durationMs: args.endedAt - args.startedAt,
-				input: io.input,
-				output: io.output,
-				errorText: io.errorText,
-				truncated: io.truncated,
-			},
-		};
-		await args.recorder.recordStage(args.trajectoryId, stage);
-	} catch (err) {
-		args.logger?.warn?.(
-			{ err: (err as Error).message, trajectoryId: args.trajectoryId },
-			"[TrajectoryRecorder] failed to record tool stage",
-		);
-	}
+  if (!args.recorder || !args.trajectoryId) return;
+  try {
+    const inputParams = (args.toolCall.params ?? {}) as Record<string, unknown>;
+    const io = captureToolStageIO({
+      input: inputParams,
+      output: args.result,
+      error: args.result.error,
+    });
+    const stage: RecordedStage = {
+      stageId: `stage-tool-${args.toolCall.name}-${args.startedAt}`,
+      kind: "tool",
+      parentStageId: args.parentStageId,
+      startedAt: args.startedAt,
+      endedAt: args.endedAt,
+      latencyMs: args.endedAt - args.startedAt,
+      tool: {
+        name: args.toolCall.name,
+        args: inputParams,
+        result: args.result,
+        success: args.result.success,
+        durationMs: args.endedAt - args.startedAt,
+        input: io.input,
+        output: io.output,
+        errorText: io.errorText,
+        truncated: io.truncated,
+      },
+    };
+    await args.recorder.recordStage(args.trajectoryId, stage);
+  } catch (err) {
+    args.logger?.warn?.(
+      { err: (err as Error).message, trajectoryId: args.trajectoryId },
+      "[TrajectoryRecorder] failed to record tool stage",
+    );
+  }
 }
 
 function plannerToolCallToStreamingToolCall(
-	toolCall: PlannerToolCall,
-	status: "pending" | "completed" | "failed",
+  toolCall: PlannerToolCall,
+  status: "pending" | "completed" | "failed",
 ): ToolCall {
-	return {
-		id: toolCall.id ?? toolCall.name,
-		name: toolCall.name,
-		arguments: (toolCall.params ?? {}) as ToolCall["arguments"],
-		status,
-	};
+  return {
+    id: toolCall.id ?? toolCall.name,
+    name: toolCall.name,
+    arguments: (toolCall.params ?? {}) as ToolCall["arguments"],
+    status,
+  };
 }
 
 function findToolContextEvent(
-	context: ContextObject,
-	toolCall: PlannerToolCall,
+  context: ContextObject,
+  toolCall: PlannerToolCall,
 ): ContextEvent | undefined {
-	return context.events.find((event) => {
-		if (event.type !== "tool" || !("tool" in event)) {
-			return false;
-		}
-		const tool = (event as { tool?: { name?: string } }).tool;
-		return tool?.name === toolCall.name;
-	});
+  return context.events.find((event) => {
+    if (event.type !== "tool" || !("tool" in event)) {
+      return false;
+    }
+    const tool = (event as { tool?: { name?: string } }).tool;
+    return tool?.name === toolCall.name;
+  });
 }
 
 function normalizeToolCalls(value: unknown): PlannerToolCall[] {
-	if (value == null || value === "") {
-		return [];
-	}
+  if (value == null || value === "") {
+    return [];
+  }
 
-	const entries = Array.isArray(value) ? value : [value];
-	const calls: PlannerToolCall[] = [];
-	for (const entry of entries) {
-		const call = normalizeToolCall(entry);
-		if (call) {
-			calls.push(call);
-		}
-	}
-	return calls;
+  const entries = Array.isArray(value) ? value : [value];
+  const calls: PlannerToolCall[] = [];
+  for (const entry of entries) {
+    const call = normalizeToolCall(entry);
+    if (call) {
+      calls.push(call);
+    }
+  }
+  return calls;
 }
 
 /**
@@ -1976,23 +2026,23 @@ function normalizeToolCalls(value: unknown): PlannerToolCall[] {
  * `{action, parameters}`, and `{name, arguments}` shapes resolve identically.
  */
 function parseEmbeddedToolCalls(text: string | undefined): PlannerToolCall[] {
-	if (!text) {
-		return [];
-	}
-	const calls: PlannerToolCall[] = [];
-	for (const objectText of extractJsonObjects(text)) {
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(objectText);
-		} catch {
-			continue;
-		}
-		const call = normalizeToolCall(parsed);
-		if (call) {
-			calls.push(call);
-		}
-	}
-	return calls;
+  if (!text) {
+    return [];
+  }
+  const calls: PlannerToolCall[] = [];
+  for (const objectText of extractJsonObjects(text)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(objectText);
+    } catch {
+      continue;
+    }
+    const call = normalizeToolCall(parsed);
+    if (call) {
+      calls.push(call);
+    }
+  }
+  return calls;
 }
 
 /**
@@ -2002,46 +2052,46 @@ function parseEmbeddedToolCalls(text: string | undefined): PlannerToolCall[] {
  * calls the native extraction missed.
  */
 function mergeToolCalls(
-	native: PlannerToolCall[],
-	fromText: PlannerToolCall[],
+  native: PlannerToolCall[],
+  fromText: PlannerToolCall[],
 ): PlannerToolCall[] {
-	if (fromText.length === 0) {
-		return native;
-	}
-	const callKey = (call: PlannerToolCall) =>
-		`${call.name.toUpperCase()}:${JSON.stringify(call.params ?? {})}`;
-	const seen = new Set(native.map(callKey));
-	const merged = [...native];
-	for (const call of fromText) {
-		const key = callKey(call);
-		if (seen.has(key)) {
-			continue;
-		}
-		seen.add(key);
-		merged.push(call);
-	}
-	return merged;
+  if (fromText.length === 0) {
+    return native;
+  }
+  const callKey = (call: PlannerToolCall) =>
+    `${call.name.toUpperCase()}:${JSON.stringify(call.params ?? {})}`;
+  const seen = new Set(native.map(callKey));
+  const merged = [...native];
+  for (const call of fromText) {
+    const key = callKey(call);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(call);
+  }
+  return merged;
 }
 
 function normalizeBarePlannerAction(
-	parsed: RawPlannerOutput,
+  parsed: RawPlannerOutput,
 ): PlannerToolCall[] {
-	if (typeof parsed.action !== "string" || parsed.action.trim().length === 0) {
-		return [];
-	}
-	const call = normalizeToolCall(parsed);
-	if (!call) return [];
-	if (
-		call.params === undefined &&
-		"parameters" in parsed &&
-		(parsed.parameters === null ||
-			typeof parsed.parameters === "string" ||
-			typeof parsed.parameters === "number" ||
-			typeof parsed.parameters === "boolean")
-	) {
-		call.params = { parameters: parsed.parameters };
-	}
-	return [call];
+  if (typeof parsed.action !== "string" || parsed.action.trim().length === 0) {
+    return [];
+  }
+  const call = normalizeToolCall(parsed);
+  if (!call) return [];
+  if (
+    call.params === undefined &&
+    "parameters" in parsed &&
+    (parsed.parameters === null ||
+      typeof parsed.parameters === "string" ||
+      typeof parsed.parameters === "number" ||
+      typeof parsed.parameters === "boolean")
+  ) {
+    call.params = { parameters: parsed.parameters };
+  }
+  return [call];
 }
 
 /**
@@ -2055,171 +2105,171 @@ function normalizeBarePlannerAction(
  */
 
 function normalizeToolCall(entry: unknown): PlannerToolCall | null {
-	if (typeof entry === "string") {
-		const name = normalizeToolCallName(entry);
-		return name ? { name } : null;
-	}
+  if (typeof entry === "string") {
+    const name = normalizeToolCallName(entry);
+    return name ? { name } : null;
+  }
 
-	if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-		return null;
-	}
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
 
-	const record = entry as ToolCall & Record<string, unknown>;
-	const rawFunction =
-		record.function && typeof record.function === "object"
-			? (record.function as Record<string, unknown>)
-			: null;
-	const functionName =
-		typeof record.function === "string" ? record.function : rawFunction?.name;
-	const name = normalizeToolCallName(
-		record.name ??
-			record.toolName ??
-			record.tool ??
-			record.action ??
-			record.actionName ??
-			functionName ??
-			// gpt-oss narrates calls as `{type: "ACTION", args: {...}}`. `type`
-			// is the last-resort name source so the canonical OpenAI/Anthropic
-			// envelope shapes, where `type` is "function"/"tool", still resolve
-			// through `functionName`/`name` first.
-			record.type ??
-			"",
-	);
-	if (!name) {
-		return null;
-	}
+  const record = entry as ToolCall & Record<string, unknown>;
+  const rawFunction =
+    record.function && typeof record.function === "object"
+      ? (record.function as Record<string, unknown>)
+      : null;
+  const functionName =
+    typeof record.function === "string" ? record.function : rawFunction?.name;
+  const name = normalizeToolCallName(
+    record.name ??
+      record.toolName ??
+      record.tool ??
+      record.action ??
+      record.actionName ??
+      functionName ??
+      // gpt-oss narrates calls as `{type: "ACTION", args: {...}}`. `type`
+      // is the last-resort name source so the canonical OpenAI/Anthropic
+      // envelope shapes, where `type` is "function"/"tool", still resolve
+      // through `functionName`/`name` first.
+      record.type ??
+      "",
+  );
+  if (!name) {
+    return null;
+  }
 
-	const args = normalizeArgs(
-		record.input ??
-			record.args ??
-			record.arguments ??
-			record.params ??
-			record.parameters ??
-			rawFunction?.input ??
-			rawFunction?.args ??
-			rawFunction?.arguments ??
-			rawFunction?.params ??
-			rawFunction?.parameters,
-	);
+  const args = normalizeArgs(
+    record.input ??
+      record.args ??
+      record.arguments ??
+      record.params ??
+      record.parameters ??
+      rawFunction?.input ??
+      rawFunction?.args ??
+      rawFunction?.arguments ??
+      rawFunction?.params ??
+      rawFunction?.parameters,
+  );
 
-	if (name.toUpperCase() === "PLAN_ACTIONS" && args) {
-		const actionName = normalizeToolCallName(args.action);
-		if (actionName) {
-			return {
-				id: typeof record.id === "string" ? record.id : undefined,
-				name: actionName,
-				params: normalizeArgs(args.parameters) ?? {},
-			};
-		}
-	}
+  if (name.toUpperCase() === "PLAN_ACTIONS" && args) {
+    const actionName = normalizeToolCallName(args.action);
+    if (actionName) {
+      return {
+        id: typeof record.id === "string" ? record.id : undefined,
+        name: actionName,
+        params: normalizeArgs(args.parameters) ?? {},
+      };
+    }
+  }
 
-	return {
-		id: typeof record.id === "string" ? record.id : undefined,
-		name,
-		params: args,
-	};
+  return {
+    id: typeof record.id === "string" ? record.id : undefined,
+    name,
+    params: args,
+  };
 }
 
 function normalizeToolCallName(value: unknown): string {
-	const raw = String(value ?? "").trim();
-	if (!raw) return "";
-	const withoutPrefix = raw.replace(/^(?:functions?|tools?)\./i, "");
-	return withoutPrefix.trim();
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  const withoutPrefix = raw.replace(/^(?:functions?|tools?)\./i, "");
+  return withoutPrefix.trim();
 }
 
 function normalizeArgs(value: unknown): Record<string, unknown> | undefined {
-	if (typeof value === "string") {
-		return parseJsonObject<Record<string, unknown>>(value) ?? undefined;
-	}
-	if (value && typeof value === "object" && !Array.isArray(value)) {
-		return value as Record<string, unknown>;
-	}
-	return undefined;
+  if (typeof value === "string") {
+    return parseJsonObject<Record<string, unknown>>(value) ?? undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
 }
 
 function isTerminalToolCall(toolCall: PlannerToolCall): boolean {
-	// REPLY / IGNORE / STOP / NONE are the planner's terminal signals —
-	// they mean "I have nothing further to dispatch, end the turn."
-	// `NONE` was missing here, so when the planner emitted it after a
-	// successful tool call the loop tried to EXECUTE NONE as a real
-	// action. NONE's contextGate (`contexts: ["general"]`) commonly
-	// fails when the surface narrowed to a non-general tier-A context,
-	// the call returned "Action NONE is not allowed in the current
-	// context", and the planner retried until hitting the
-	// repeated-tool-failure limit — at which point the runtime
-	// shipped a generic "something flaked" reply even though the
-	// previous action's work had succeeded. Treating NONE as terminal
-	// makes the loop stop cleanly instead.
-	return ["REPLY", "IGNORE", "STOP", "NONE"].includes(
-		toolCall.name.toUpperCase(),
-	);
+  // REPLY / IGNORE / STOP / NONE are the planner's terminal signals —
+  // they mean "I have nothing further to dispatch, end the turn."
+  // `NONE` was missing here, so when the planner emitted it after a
+  // successful tool call the loop tried to EXECUTE NONE as a real
+  // action. NONE's contextGate (`contexts: ["general"]`) commonly
+  // fails when the surface narrowed to a non-general tier-A context,
+  // the call returned "Action NONE is not allowed in the current
+  // context", and the planner retried until hitting the
+  // repeated-tool-failure limit — at which point the runtime
+  // shipped a generic "something flaked" reply even though the
+  // previous action's work had succeeded. Treating NONE as terminal
+  // makes the loop stop cleanly instead.
+  return ["REPLY", "IGNORE", "STOP", "NONE"].includes(
+    toolCall.name.toUpperCase(),
+  );
 }
 
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {
-	const maybeTool = tool as ToolDefinition & {
-		function?: { name?: unknown };
-		name?: unknown;
-	};
-	const name = maybeTool.name;
-	return typeof name === "string" && name.trim().length > 0
-		? name.trim()
-		: undefined;
+  const maybeTool = tool as ToolDefinition & {
+    function?: { name?: unknown };
+    name?: unknown;
+  };
+  const name = maybeTool.name;
+  return typeof name === "string" && name.trim().length > 0
+    ? name.trim()
+    : undefined;
 }
 
 function hasExposedNonTerminalTool(
-	tools: ToolDefinition[] | undefined,
+  tools: ToolDefinition[] | undefined,
 ): boolean {
-	return (
-		Array.isArray(tools) &&
-		tools.some((tool) => {
-			const name = getToolDefinitionName(tool);
-			return Boolean(name && !isTerminalToolCall({ name }));
-		})
-	);
+  return (
+    Array.isArray(tools) &&
+    tools.some((tool) => {
+      const name = getToolDefinitionName(tool);
+      return Boolean(name && !isTerminalToolCall({ name }));
+    })
+  );
 }
 
 function hasExecutedNonTerminalTool(trajectory: PlannerTrajectory): boolean {
-	return trajectory.steps.some(
-		(step) => step.toolCall && !isTerminalToolCall(step.toolCall),
-	);
+  return trajectory.steps.some(
+    (step) => step.toolCall && !isTerminalToolCall(step.toolCall),
+  );
 }
 
 function handleRequiredToolPlannerMiss(params: {
-	trajectory: PlannerTrajectory;
-	iteration: number;
-	plannerOutput: ReturnType<typeof parsePlannerOutput>;
-	reason: "no_tool_calls" | "terminal_only_tool_calls";
-	logger?: PlannerRuntime["logger"];
+  trajectory: PlannerTrajectory;
+  iteration: number;
+  plannerOutput: ReturnType<typeof parsePlannerOutput>;
+  reason: "no_tool_calls" | "terminal_only_tool_calls";
+  logger?: PlannerRuntime["logger"];
 }): void {
-	const createdAt = Date.now();
-	params.logger?.warn?.(
-		{
-			iteration: params.iteration,
-			reason: params.reason,
-			messageToUser: params.plannerOutput.messageToUser,
-			toolCalls: params.plannerOutput.toolCalls.map((toolCall) => ({
-				name: toolCall.name,
-				id: toolCall.id,
-			})),
-		},
-		"Planner returned terminal output before satisfying a required tool call; retrying",
-	);
-	params.trajectory.context = appendContextEvent(params.trajectory.context, {
-		id: `required-tool-retry:${params.iteration}:${params.reason}`,
-		type: "instruction",
-		source: "planner-loop",
-		createdAt,
-		content:
-			"The previous planner response was not valid because this turn is tool-required and no non-terminal tool has run yet. " +
-			"Retry by calling one exposed non-terminal tool that can attempt the current request. " +
-			"After that tool returns, use its result to decide whether to continue or answer the user.",
-		metadata: {
-			iteration: params.iteration,
-			reason: params.reason,
-			messageToUser: params.plannerOutput.messageToUser,
-			toolCalls: stringifyForModel(params.plannerOutput.toolCalls),
-		},
-	});
+  const createdAt = Date.now();
+  params.logger?.warn?.(
+    {
+      iteration: params.iteration,
+      reason: params.reason,
+      messageToUser: params.plannerOutput.messageToUser,
+      toolCalls: params.plannerOutput.toolCalls.map((toolCall) => ({
+        name: toolCall.name,
+        id: toolCall.id,
+      })),
+    },
+    "Planner returned terminal output before satisfying a required tool call; retrying",
+  );
+  params.trajectory.context = appendContextEvent(params.trajectory.context, {
+    id: `required-tool-retry:${params.iteration}:${params.reason}`,
+    type: "instruction",
+    source: "planner-loop",
+    createdAt,
+    content:
+      "The previous planner response was not valid because this turn is tool-required and no non-terminal tool has run yet. " +
+      "Retry by calling one exposed non-terminal tool that can attempt the current request. " +
+      "After that tool returns, use its result to decide whether to continue or answer the user.",
+    metadata: {
+      iteration: params.iteration,
+      reason: params.reason,
+      messageToUser: params.plannerOutput.messageToUser,
+      toolCalls: stringifyForModel(params.plannerOutput.toolCalls),
+    },
+  });
 }
 
 // Terminates the planner loop with a captured terminal-only refusal text in
@@ -2228,41 +2278,145 @@ function handleRequiredToolPlannerMiss(params: {
 // fulfill the request: the planner produces honest REPLY refusals across
 // iterations, and surfacing the last one is materially better than the
 // generic apology the caller would otherwise emit.
+function canonicalParamsString(value: unknown): string {
+  // Sorted-key serialization so two logically-identical tool calls that differ
+  // only in key insertion order (common across LLM re-emissions) map to the
+  // same identity — otherwise the redundant-call loop-breaker never trips.
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.fromEntries(
+          Object.entries(val as Record<string, unknown>).sort(([a], [b]) =>
+            a < b ? -1 : a > b ? 1 : 0,
+          ),
+        )
+      : val,
+  );
+}
+
+function toolCallIdentity(toolCall: PlannerToolCall): string {
+  return `${toolCall.name} ${canonicalParamsString(toolCall.params ?? {})}`;
+}
+
+/**
+ * Split a set of planned non-terminal calls into those that are genuinely new
+ * this turn and those that exactly repeat a call which already SUCCEEDED (same
+ * tool name + arguments). A repeat of a successful call cannot return new
+ * information, so the loop should not re-execute it.
+ */
+function partitionRedundantSucceededCalls(
+  calls: PlannerToolCall[],
+  trajectory: PlannerTrajectory,
+): { fresh: PlannerToolCall[]; redundant: PlannerToolCall[] } {
+  const succeeded = new Set<string>();
+  for (const step of trajectory.steps) {
+    if (step.toolCall && step.result?.success === true) {
+      succeeded.add(toolCallIdentity(step.toolCall));
+    }
+  }
+  const fresh: PlannerToolCall[] = [];
+  const redundant: PlannerToolCall[] = [];
+  for (const call of calls) {
+    if (succeeded.has(toolCallIdentity(call))) redundant.push(call);
+    else fresh.push(call);
+  }
+  return { fresh, redundant };
+}
+
+/**
+ * Terminal escape hatch for a planner stuck re-issuing an identical successful
+ * call. Makes one `toolChoice: "none"` planner call so the model MUST answer in
+ * prose — synthesizing from the tool results already gathered — then returns
+ * that as the final message. Bounded (one extra call, no tools) so it cannot
+ * itself loop.
+ */
+async function finishWithForcedSynthesis(params: {
+  loop: PlannerLoopParams;
+  config: ChainingLoopConfig;
+  trajectory: PlannerTrajectory;
+  iteration: number;
+  onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;
+}): Promise<PlannerLoopResult> {
+  const { loop, config, trajectory, iteration } = params;
+  trajectory.context = appendContextEvent(trajectory.context, {
+    id: `force-synthesis:${iteration}`,
+    type: "instruction",
+    source: "planner-loop",
+    createdAt: Date.now(),
+    content:
+      "Tool gathering for this turn is complete and the same call was repeated " +
+      "without new results. Do not call any tool. Write the final answer to the " +
+      "user now from the tool results already in this trajectory; if they do not " +
+      "contain the answer, say plainly what you found and what was missing.",
+  });
+  const synthOutput = await callPlanner({
+    runtime: loop.runtime,
+    context: trajectory.context,
+    trajectory,
+    config,
+    modelType: loop.modelType,
+    provider: loop.provider,
+    // No tools: forces free-text prose across both cloud ("none") and local
+    // engines. Passing tools here would re-engage the per-action grammar /
+    // responseSkeleton, fighting the "answer in prose, call no tool" intent.
+    tools: undefined,
+    recorder: loop.recorder,
+    trajectoryId: loop.trajectoryId,
+    parentStageId: loop.parentStageId,
+    iteration,
+    onUsage: params.onUsage,
+  });
+  const finalMessage = preferredFinalMessageFromToolOrModel(
+    trajectory,
+    synthOutput.messageToUser,
+  );
+  trajectory.steps.push({
+    iteration,
+    thought: synthOutput.thought,
+    terminalMessage: finalMessage,
+    terminalOnly: true,
+  });
+  return {
+    status: "finished",
+    trajectory,
+    finalMessage: userSafeFinalMessage(finalMessage, trajectory),
+  };
+}
+
 function finishWithCapturedRefusal(params: {
-	trajectory: PlannerTrajectory;
-	iteration: number;
-	thought: string | undefined;
-	refusal: string;
+  trajectory: PlannerTrajectory;
+  iteration: number;
+  thought: string | undefined;
+  refusal: string;
 }): {
-	status: "finished";
-	trajectory: PlannerTrajectory;
-	finalMessage: string | undefined;
+  status: "finished";
+  trajectory: PlannerTrajectory;
+  finalMessage: string | undefined;
 } {
-	params.trajectory.steps.push({
-		iteration: params.iteration,
-		thought: params.thought,
-		terminalMessage: params.refusal,
-		terminalOnly: true,
-	});
-	return {
-		status: "finished",
-		trajectory: params.trajectory,
-		finalMessage: userSafeFinalMessage(params.refusal, params.trajectory),
-	};
+  params.trajectory.steps.push({
+    iteration: params.iteration,
+    thought: params.thought,
+    terminalMessage: params.refusal,
+    terminalOnly: true,
+  });
+  return {
+    status: "finished",
+    trajectory: params.trajectory,
+    finalMessage: userSafeFinalMessage(params.refusal, params.trajectory),
+  };
 }
 
 function terminalMessageFromToolCalls(
-	toolCalls: PlannerToolCall[],
-	fallback?: string,
+  toolCalls: PlannerToolCall[],
+  fallback?: string,
 ): string | undefined {
-	const reply = toolCalls.find(
-		(toolCall) => toolCall.name.toUpperCase() === "REPLY",
-	);
-	const params = reply?.params;
-	return (
-		getNonEmptyString(params?.text ?? params?.message ?? params?.reply) ??
-		fallback
-	);
+  const reply = toolCalls.find(
+    (toolCall) => toolCall.name.toUpperCase() === "REPLY",
+  );
+  const params = reply?.params;
+  return (
+    getNonEmptyString(params?.text ?? params?.message ?? params?.reply) ??
+    fallback
+  );
 }
 
 /**
@@ -2285,15 +2439,15 @@ function terminalMessageFromToolCalls(
  * wrapper text.
  */
 function latestToolResultText(
-	trajectory: PlannerTrajectory,
+  trajectory: PlannerTrajectory,
 ): string | undefined {
-	for (const step of [...trajectory.steps].reverse()) {
-		const text = step.result?.userFacingText?.trim();
-		if (text) {
-			return text;
-		}
-	}
-	return undefined;
+  for (const step of [...trajectory.steps].reverse()) {
+    const text = step.result?.userFacingText?.trim();
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -2317,107 +2471,107 @@ function latestToolResultText(
 // Exported for unit-test coverage of the success-filter / failed-step
 // invariant; not part of the public runtime surface.
 export function singleVerifiedUserFacingToolResultText(
-	trajectory: PlannerTrajectory,
+  trajectory: PlannerTrajectory,
 ): string | undefined {
-	const successfulToolSteps = trajectory.steps.filter(
-		(step) => step.toolCall && step.result?.success === true,
-	);
-	if (successfulToolSteps.length !== 1) return undefined;
-	const result = successfulToolSteps[0]?.result;
-	if (result?.verifiedUserFacing !== true) return undefined;
-	const text = result.userFacingText?.trim();
-	return text || undefined;
+  const successfulToolSteps = trajectory.steps.filter(
+    (step) => step.toolCall && step.result?.success === true,
+  );
+  if (successfulToolSteps.length !== 1) return undefined;
+  const result = successfulToolSteps[0]?.result;
+  if (result?.verifiedUserFacing !== true) return undefined;
+  const text = result.userFacingText?.trim();
+  return text || undefined;
 }
 
 function preferredFinalMessageFromToolOrModel(
-	trajectory: PlannerTrajectory,
-	modelMessage?: unknown,
-	fallback?: unknown,
+  trajectory: PlannerTrajectory,
+  modelMessage?: unknown,
+  fallback?: unknown,
 ): string | undefined {
-	// Precedence:
-	//   1. A single successful tool whose result was explicitly marked
-	//      `verifiedUserFacing: true` — used for structured outputs
-	//      (paths, ids, counts) where evaluator paraphrase risks
-	//      hallucinating a value.
-	//   2. The model/evaluator's explicit `messageToUser` — authoritative
-	//      by default; the evaluator has seen the full trajectory and
-	//      chose what the user should read.
-	//   3. The most recent tool's `userFacingText` — fallback when neither
-	//      the model nor any verified tool provided a clean reply.
-	//   4. An explicit caller-provided fallback (e.g. failed-tool message).
-	//
-	// Regression coverage:
-	//   - `planner-loop-user-facing-text.test.ts` → "does not regress
-	//     evaluator's explicit messageToUser path" — evaluator wins when
-	//     no tool sets `verifiedUserFacing`.
-	//   - `planner-happy-path.test.ts` → "prefers a single tool's verified
-	//     user-facing text over evaluator paraphrase" — tool wins when it
-	//     opts in via `verifiedUserFacing: true`.
-	return (
-		singleVerifiedUserFacingToolResultText(trajectory) ??
-		getNonEmptyString(modelMessage) ??
-		latestToolResultText(trajectory) ??
-		getNonEmptyString(fallback)
-	);
+  // Precedence:
+  //   1. A single successful tool whose result was explicitly marked
+  //      `verifiedUserFacing: true` — used for structured outputs
+  //      (paths, ids, counts) where evaluator paraphrase risks
+  //      hallucinating a value.
+  //   2. The model/evaluator's explicit `messageToUser` — authoritative
+  //      by default; the evaluator has seen the full trajectory and
+  //      chose what the user should read.
+  //   3. The most recent tool's `userFacingText` — fallback when neither
+  //      the model nor any verified tool provided a clean reply.
+  //   4. An explicit caller-provided fallback (e.g. failed-tool message).
+  //
+  // Regression coverage:
+  //   - `planner-loop-user-facing-text.test.ts` → "does not regress
+  //     evaluator's explicit messageToUser path" — evaluator wins when
+  //     no tool sets `verifiedUserFacing`.
+  //   - `planner-happy-path.test.ts` → "prefers a single tool's verified
+  //     user-facing text over evaluator paraphrase" — tool wins when it
+  //     opts in via `verifiedUserFacing: true`.
+  return (
+    singleVerifiedUserFacingToolResultText(trajectory) ??
+    getNonEmptyString(modelMessage) ??
+    latestToolResultText(trajectory) ??
+    getNonEmptyString(fallback)
+  );
 }
 
 function latestFailedToolStep(
-	trajectory: PlannerTrajectory,
+  trajectory: PlannerTrajectory,
 ): PlannerStep | undefined {
-	return [...trajectory.steps]
-		.reverse()
-		.find((step) => step.result && step.result.success === false);
+  return [...trajectory.steps]
+    .reverse()
+    .find((step) => step.result && step.result.success === false);
 }
 
 function shouldRecoverSilentFailedFinish(args: {
-	evaluator: EvaluatorOutput;
-	trajectory: PlannerTrajectory;
-	recoveryCount: number;
+  evaluator: EvaluatorOutput;
+  trajectory: PlannerTrajectory;
+  recoveryCount: number;
 }): boolean {
-	if (args.recoveryCount >= 1) return false;
-	if (args.evaluator.success !== false) return false;
-	if (getNonEmptyString(args.evaluator.messageToUser)) return false;
-	return latestFailedToolStep(args.trajectory) !== undefined;
+  if (args.recoveryCount >= 1) return false;
+  if (args.evaluator.success !== false) return false;
+  if (getNonEmptyString(args.evaluator.messageToUser)) return false;
+  return latestFailedToolStep(args.trajectory) !== undefined;
 }
 
 function failedToolFallbackMessage(
-	trajectory: PlannerTrajectory,
+  trajectory: PlannerTrajectory,
 ): string | undefined {
-	if (!latestFailedToolStep(trajectory)) return undefined;
-	return "I tried to complete that, but the available runtime step failed before it produced a usable result.";
+  if (!latestFailedToolStep(trajectory)) return undefined;
+  return "I tried to complete that, but the available runtime step failed before it produced a usable result.";
 }
 
 function exposedToolNameSet(
-	tools: ToolDefinition[] | undefined,
+  tools: ToolDefinition[] | undefined,
 ): Set<string> | null {
-	if (!Array.isArray(tools) || tools.length === 0) return null;
-	const names = tools
-		.map(getToolDefinitionName)
-		.filter((name): name is string => Boolean(name))
-		.map((name) => name.toUpperCase());
-	return names.length > 0 ? new Set(names) : null;
+  if (!Array.isArray(tools) || tools.length === 0) return null;
+  const names = tools
+    .map(getToolDefinitionName)
+    .filter((name): name is string => Boolean(name))
+    .map((name) => name.toUpperCase());
+  return names.length > 0 ? new Set(names) : null;
 }
 
 function splitUnavailableToolCalls(
-	toolCalls: PlannerToolCall[],
-	tools: ToolDefinition[] | undefined,
+  toolCalls: PlannerToolCall[],
+  tools: ToolDefinition[] | undefined,
 ): { valid: PlannerToolCall[]; invalid: PlannerToolCall[] } {
-	const exposed = exposedToolNameSet(tools);
-	if (!exposed) return { valid: toolCalls, invalid: [] };
-	const valid: PlannerToolCall[] = [];
-	const invalid: PlannerToolCall[] = [];
-	for (const toolCall of toolCalls) {
-		if (exposed.has(toolCall.name.toUpperCase())) {
-			valid.push(toolCall);
-		} else {
-			invalid.push(toolCall);
-		}
-	}
-	return { valid, invalid };
+  const exposed = exposedToolNameSet(tools);
+  if (!exposed) return { valid: toolCalls, invalid: [] };
+  const valid: PlannerToolCall[] = [];
+  const invalid: PlannerToolCall[] = [];
+  for (const toolCall of toolCalls) {
+    if (exposed.has(toolCall.name.toUpperCase())) {
+      valid.push(toolCall);
+    } else {
+      invalid.push(toolCall);
+    }
+  }
+  return { valid, invalid };
 }
 
 function toolFailureRepeatKey(toolCall: PlannerToolCall): string {
-	return `${toolCall.name}:${stringifyForModel(toolCall.params ?? {})}`;
+  return `${toolCall.name}:${stringifyForModel(toolCall.params ?? {})}`;
 }
 
 /**
@@ -2479,66 +2633,66 @@ function toolFailureRepeatKey(toolCall: PlannerToolCall): string {
  * trigger the gate — those calls remain on the full evaluator path.
  */
 function tryGateEvaluator(args: {
-	trajectory: PlannerTrajectory;
-	failures: readonly FailureLike[];
-	lastPlannerExplicitMessageToUser: string | undefined;
-	lastPlannerExplicitCompleted: boolean | undefined;
+  trajectory: PlannerTrajectory;
+  failures: readonly FailureLike[];
+  lastPlannerExplicitMessageToUser: string | undefined;
+  lastPlannerExplicitCompleted: boolean | undefined;
 }): EvaluatorOutput | null {
-	const latestStep = args.trajectory.steps[args.trajectory.steps.length - 1];
-	const latestResult = latestStep?.result;
-	if (latestResult?.success !== true) return null;
-	if (args.trajectory.plannedQueue.length > 0) return null;
-	if (args.failures.length > 0) return null;
-	const message = args.lastPlannerExplicitMessageToUser?.trim();
-	if (!message) return null;
-	if (isUnsafeUserVisibleText(message)) return null;
-	// Precondition 6: respect the planner's own completion disclaimer.
-	if (args.lastPlannerExplicitCompleted === false) return null;
+  const latestStep = args.trajectory.steps[args.trajectory.steps.length - 1];
+  const latestResult = latestStep?.result;
+  if (latestResult?.success !== true) return null;
+  if (args.trajectory.plannedQueue.length > 0) return null;
+  if (args.failures.length > 0) return null;
+  const message = args.lastPlannerExplicitMessageToUser?.trim();
+  if (!message) return null;
+  if (isUnsafeUserVisibleText(message)) return null;
+  // Precondition 6: respect the planner's own completion disclaimer.
+  if (args.lastPlannerExplicitCompleted === false) return null;
 
-	return {
-		success: true,
-		decision: "FINISH",
-		thought: GATED_EVALUATOR_THOUGHT,
-		messageToUser: message,
-	};
+  return {
+    success: true,
+    decision: "FINISH",
+    thought: GATED_EVALUATOR_THOUGHT,
+    messageToUser: message,
+  };
 }
 
 /** Marker the gate stamps onto synthesized EvaluatorOutputs so trajectory
  * dumps and replay tools can identify gated (i.e. evaluator-skipped) decisions
  * cheaply. */
 export const GATED_EVALUATOR_THOUGHT =
-	"Gated FINISH: queue drained successfully with a clean planner messageToUser; evaluator LLM call skipped.";
+  "Gated FINISH: queue drained successfully with a clean planner messageToUser; evaluator LLM call skipped.";
 
 const TERMINAL_TOOL_CALL_FINISH_THOUGHT =
-	"Terminal FINISH: planner ended the loop with a terminal tool call; evaluator LLM call skipped.";
+  "Terminal FINISH: planner ended the loop with a terminal tool call; evaluator LLM call skipped.";
 
 function terminalToolCallFinish(
-	finalMessage: string | undefined,
+  finalMessage: string | undefined,
 ): EvaluatorOutput {
-	const output: EvaluatorOutput = {
-		success: true,
-		decision: "FINISH",
-		thought: TERMINAL_TOOL_CALL_FINISH_THOUGHT,
-	};
-	if (finalMessage) {
-		output.messageToUser = finalMessage;
-	}
-	return output;
+  const output: EvaluatorOutput = {
+    success: true,
+    decision: "FINISH",
+    thought: TERMINAL_TOOL_CALL_FINISH_THOUGHT,
+  };
+  if (finalMessage) {
+    output.messageToUser = finalMessage;
+  }
+  return output;
 }
 
 function userSafeFinalMessage(
-	message: string | undefined,
-	trajectory: PlannerTrajectory,
+  message: string | undefined,
+  trajectory: PlannerTrajectory,
 ): string | undefined {
-	const candidate = getNonEmptyString(message);
-	if (candidate && !isUnsafeUserVisibleText(candidate)) {
-		return candidate;
-	}
-	const latest = latestToolResultText(trajectory);
-	if (latest && !isUnsafeUserVisibleText(latest)) {
-		return latest;
-	}
-	return candidate ? "I handled the available step." : undefined;
+  const candidate = getNonEmptyString(message);
+  if (candidate && !isUnsafeUserVisibleText(candidate)) {
+    return candidate;
+  }
+  const latest = latestToolResultText(trajectory);
+  if (latest && !isUnsafeUserVisibleText(latest)) {
+    return latest;
+  }
+  return candidate ? "I handled the available step." : undefined;
 }
 
 // Canonical TASKS/spawn-arg vocabulary. A planner that hallucinates its own
@@ -2550,103 +2704,103 @@ function userSafeFinalMessage(
 // genuine user-requested JSON answer carries foreign keys, so this never fires
 // on a real reply.
 const SPAWN_ARG_KEYS = new Set([
-	"task",
-	"agentType",
-	"approvalPreset",
-	"brief",
-	"workdir",
-	"model",
-	"memoryContent",
-	"agents",
-	"repo",
-	"keepAliveAfterComplete",
-	"op",
-	"action",
+  "task",
+  "agentType",
+  "approvalPreset",
+  "brief",
+  "workdir",
+  "model",
+  "memoryContent",
+  "agents",
+  "repo",
+  "keepAliveAfterComplete",
+  "op",
+  "action",
 ]);
 const SPAWN_ARG_DISCRIMINATORS = [
-	"task",
-	"agentType",
-	"approvalPreset",
-	"brief",
+  "task",
+  "agentType",
+  "approvalPreset",
+  "brief",
 ];
 
 export function looksLikeSpawnEnvelopeJson(text: string): boolean {
-	let body = text.trim();
-	const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-	if (fence?.[1]) body = fence[1].trim();
-	if (!body.startsWith("{") || !body.endsWith("}")) return false;
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(body);
-	} catch {
-		return false;
-	}
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		return false;
-	}
-	const keys = Object.keys(parsed as Record<string, unknown>);
-	if (keys.length === 0) return false;
-	if (!keys.every((k) => SPAWN_ARG_KEYS.has(k))) return false;
-	return (
-		SPAWN_ARG_DISCRIMINATORS.filter((k) => k in (parsed as object)).length >= 2
-	);
+  let body = text.trim();
+  const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  if (fence?.[1]) body = fence[1].trim();
+  if (!body.startsWith("{") || !body.endsWith("}")) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return false;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+  const keys = Object.keys(parsed as Record<string, unknown>);
+  if (keys.length === 0) return false;
+  if (!keys.every((k) => SPAWN_ARG_KEYS.has(k))) return false;
+  return (
+    SPAWN_ARG_DISCRIMINATORS.filter((k) => k in (parsed as object)).length >= 2
+  );
 }
 
 function isUnsafeUserVisibleText(value: string | undefined): boolean {
-	if (!value) return false;
-	const text = value.trim();
-	if (!text) return false;
-	if (looksLikeSpawnEnvelopeJson(text)) return true;
-	return [
-		/\bto=functions\.[A-Z0-9_]+\b/i,
-		/\bfunctions\.[A-Z0-9_]+\b/i,
-		/"action"\s*:\s*"functions\.[A-Z0-9_]+"/i,
-		/\b(?:tool|function)\s+calls?\b/i,
-		/\b(?:I|we)\s+(?:need|should|must|will)\s+to\s+(?:call|use|invoke|issue|perform)\b/i,
-		/\b(?:call|use|invoke)\s+[A-Z][A-Z0-9_]{2,}\b/,
-		/\b(?:MESSAGE\s+action|action=(?:draft_reply|respond|send_draft|triage|list_inbox))\b/i,
-		/\{\s*"parameters"\s*:/i,
-	].some((pattern) => pattern.test(text));
+  if (!value) return false;
+  const text = value.trim();
+  if (!text) return false;
+  if (looksLikeSpawnEnvelopeJson(text)) return true;
+  return [
+    /\bto=functions\.[A-Z0-9_]+\b/i,
+    /\bfunctions\.[A-Z0-9_]+\b/i,
+    /"action"\s*:\s*"functions\.[A-Z0-9_]+"/i,
+    /\b(?:tool|function)\s+calls?\b/i,
+    /\b(?:I|we)\s+(?:need|should|must|will)\s+to\s+(?:call|use|invoke|issue|perform)\b/i,
+    /\b(?:call|use|invoke)\s+[A-Z][A-Z0-9_]{2,}\b/,
+    /\b(?:MESSAGE\s+action|action=(?:draft_reply|respond|send_draft|triage|list_inbox))\b/i,
+    /\{\s*"parameters"\s*:/i,
+  ].some((pattern) => pattern.test(text));
 }
 
 function preferRecommendedToolCall(
-	trajectory: PlannerTrajectory,
-	evaluator: EvaluatorOutput,
+  trajectory: PlannerTrajectory,
+  evaluator: EvaluatorOutput,
 ): boolean {
-	if (evaluator.recommendedToolCallId) {
-		const recommendation = evaluator.recommendedToolCallId;
-		let index = trajectory.plannedQueue.findIndex(
-			(toolCall) => toolCall.id === recommendation,
-		);
-		if (index < 0) {
-			index = trajectory.plannedQueue.findIndex(
-				(toolCall) => toolCall.name === recommendation,
-			);
-		}
-		if (index > 0) {
-			const [selected] = trajectory.plannedQueue.splice(index, 1);
-			if (selected) {
-				trajectory.plannedQueue.unshift(selected);
-			}
-		}
-		return index >= 0;
-	}
+  if (evaluator.recommendedToolCallId) {
+    const recommendation = evaluator.recommendedToolCallId;
+    let index = trajectory.plannedQueue.findIndex(
+      (toolCall) => toolCall.id === recommendation,
+    );
+    if (index < 0) {
+      index = trajectory.plannedQueue.findIndex(
+        (toolCall) => toolCall.name === recommendation,
+      );
+    }
+    if (index > 0) {
+      const [selected] = trajectory.plannedQueue.splice(index, 1);
+      if (selected) {
+        trajectory.plannedQueue.unshift(selected);
+      }
+    }
+    return index >= 0;
+  }
 
-	return trajectory.plannedQueue.length > 0;
+  return trajectory.plannedQueue.length > 0;
 }
 
 function ensureToolCallId(
-	toolCall: PlannerToolCall,
-	iteration: number,
-	index: number,
+  toolCall: PlannerToolCall,
+  iteration: number,
+  index: number,
 ): PlannerToolCall {
-	if (typeof toolCall.id === "string" && toolCall.id.length > 0) {
-		return toolCall;
-	}
-	return {
-		...toolCall,
-		id: `tool-${iteration}-${index}`,
-	};
+  if (typeof toolCall.id === "string" && toolCall.id.length > 0) {
+    return toolCall;
+  }
+  return {
+    ...toolCall,
+    id: `tool-${iteration}-${index}`,
+  };
 }
 
 /**
@@ -2656,30 +2810,30 @@ function ensureToolCallId(
  * mapping in one place avoids drift between the two paths.
  */
 export function actionResultToPlannerToolResult(
-	result: ActionResult,
+  result: ActionResult,
 ): PlannerToolResult {
-	const data: Record<string, unknown> = {};
-	if (result.data) {
-		Object.assign(data, result.data as ProviderDataRecord);
-	}
-	if (result.values) {
-		data.values = result.values;
-	}
-	return {
-		success: result.success,
-		text: result.text,
-		userFacingText: result.userFacingText,
-		verifiedUserFacing: result.verifiedUserFacing,
-		data: Object.keys(data).length > 0 ? data : undefined,
-		error: result.error,
-		continueChain: result.continueChain,
-	};
+  const data: Record<string, unknown> = {};
+  if (result.data) {
+    Object.assign(data, result.data as ProviderDataRecord);
+  }
+  if (result.values) {
+    data.values = result.values;
+  }
+  return {
+    success: result.success,
+    text: result.text,
+    userFacingText: result.userFacingText,
+    verifiedUserFacing: result.verifiedUserFacing,
+    data: Object.keys(data).length > 0 ? data : undefined,
+    error: result.error,
+    continueChain: result.continueChain,
+  };
 }
 
 function getNonEmptyString(value: unknown): string | undefined {
-	return typeof value === "string" && value.trim().length > 0
-		? value
-		: undefined;
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 /**
@@ -2702,98 +2856,98 @@ let cachedDiskOptimizedPlannerPrompt: string | null = null;
 let cachedDiskOptimizedPlannerLoaded = false;
 
 function loadOptimizedPlannerFromDisk(): string | null {
-	const dir = join(resolveStateDir(), "optimized-prompts", "action_planner");
-	if (!existsSync(dir)) return null;
+  const dir = join(resolveStateDir(), "optimized-prompts", "action_planner");
+  if (!existsSync(dir)) return null;
 
-	// Preferred path: read via the `current` symlink that
-	// `OptimizedPromptService.setPrompt` / `rollback` maintain. This is the
-	// authoritative live artifact.
-	const currentPath = join(dir, "current");
-	if (existsSync(currentPath)) {
-		try {
-			const raw = readFileSync(currentPath, "utf-8");
-			const parsed = JSON.parse(raw) as {
-				task?: string;
-				prompt?: string;
-			};
-			if (
-				parsed.task === "action_planner" &&
-				typeof parsed.prompt === "string"
-			) {
-				return parsed.prompt;
-			}
-		} catch (err) {
-			logger.warn(
-				{ path: currentPath, err: (err as Error).message },
-				"[PlannerLoop] malformed action_planner 'current' artifact; falling back to mtime scan",
-			);
-		}
-	}
+  // Preferred path: read via the `current` symlink that
+  // `OptimizedPromptService.setPrompt` / `rollback` maintain. This is the
+  // authoritative live artifact.
+  const currentPath = join(dir, "current");
+  if (existsSync(currentPath)) {
+    try {
+      const raw = readFileSync(currentPath, "utf-8");
+      const parsed = JSON.parse(raw) as {
+        task?: string;
+        prompt?: string;
+      };
+      if (
+        parsed.task === "action_planner" &&
+        typeof parsed.prompt === "string"
+      ) {
+        return parsed.prompt;
+      }
+    } catch (err) {
+      logger.warn(
+        { path: currentPath, err: (err as Error).message },
+        "[PlannerLoop] malformed action_planner 'current' artifact; falling back to mtime scan",
+      );
+    }
+  }
 
-	// Fallback: legacy / pre-symlink stores. Pick the newest artifact by
-	// mtime so we still find something when `current` is missing.
-	const entries = readdirSync(dir)
-		.filter((f) => f.endsWith(".json"))
-		.map((f) => ({
-			path: join(dir, f),
-			mtime: statSync(join(dir, f)).mtimeMs,
-		}))
-		.sort((a, b) => b.mtime - a.mtime);
-	for (const entry of entries) {
-		try {
-			const raw = readFileSync(entry.path, "utf-8");
-			const parsed = JSON.parse(raw) as {
-				task?: string;
-				prompt?: string;
-			};
-			if (
-				parsed.task === "action_planner" &&
-				typeof parsed.prompt === "string"
-			) {
-				return parsed.prompt;
-			}
-		} catch (err) {
-			logger.warn(
-				{ path: entry.path, err: (err as Error).message },
-				"[PlannerLoop] malformed action_planner artifact; trying next candidate",
-			);
-		}
-	}
-	return null;
+  // Fallback: legacy / pre-symlink stores. Pick the newest artifact by
+  // mtime so we still find something when `current` is missing.
+  const entries = readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({
+      path: join(dir, f),
+      mtime: statSync(join(dir, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+  for (const entry of entries) {
+    try {
+      const raw = readFileSync(entry.path, "utf-8");
+      const parsed = JSON.parse(raw) as {
+        task?: string;
+        prompt?: string;
+      };
+      if (
+        parsed.task === "action_planner" &&
+        typeof parsed.prompt === "string"
+      ) {
+        return parsed.prompt;
+      }
+    } catch (err) {
+      logger.warn(
+        { path: entry.path, err: (err as Error).message },
+        "[PlannerLoop] malformed action_planner artifact; trying next candidate",
+      );
+    }
+  }
+  return null;
 }
 
 function resolveOptimizedPlannerTemplate(runtime: PlannerRuntime): string {
-	// Production path: consult the registered service first. When it has
-	// an artifact for `action_planner`, return that. The shared helper
-	// gracefully no-ops when `getService` is missing on the runtime.
-	const fromService = resolveOptimizedPromptForRuntime(
-		runtime as PlannerRuntime & {
-			getService?: <T>(name: string) => T | null | undefined;
-		},
-		"action_planner",
-		plannerTemplate,
-	);
-	if (fromService !== plannerTemplate) return fromService;
+  // Production path: consult the registered service first. When it has
+  // an artifact for `action_planner`, return that. The shared helper
+  // gracefully no-ops when `getService` is missing on the runtime.
+  const fromService = resolveOptimizedPromptForRuntime(
+    runtime as PlannerRuntime & {
+      getService?: <T>(name: string) => T | null | undefined;
+    },
+    "action_planner",
+    plannerTemplate,
+  );
+  if (fromService !== plannerTemplate) return fromService;
 
-	// Fallback: read the on-disk store directly. Handles the test runtime
-	// path (where the service may not have started before the first
-	// planner call), the lazy-start race in production, and any other
-	// path that hasn't gotten the service registered yet.
-	if (!cachedDiskOptimizedPlannerLoaded) {
-		try {
-			cachedDiskOptimizedPlannerPrompt = loadOptimizedPlannerFromDisk();
-		} catch (err) {
-			// readdir/stat failures on the optimized-prompts directory are
-			// non-fatal: we fall back to the bundled `plannerTemplate`. Log so
-			// repeated boot failures show up in operator output rather than
-			// being silently masked.
-			logger.warn(
-				{ err: (err as Error).message },
-				"[PlannerLoop] optimized planner disk load failed; using bundled template",
-			);
-			cachedDiskOptimizedPlannerPrompt = null;
-		}
-		cachedDiskOptimizedPlannerLoaded = true;
-	}
-	return cachedDiskOptimizedPlannerPrompt ?? plannerTemplate;
+  // Fallback: read the on-disk store directly. Handles the test runtime
+  // path (where the service may not have started before the first
+  // planner call), the lazy-start race in production, and any other
+  // path that hasn't gotten the service registered yet.
+  if (!cachedDiskOptimizedPlannerLoaded) {
+    try {
+      cachedDiskOptimizedPlannerPrompt = loadOptimizedPlannerFromDisk();
+    } catch (err) {
+      // readdir/stat failures on the optimized-prompts directory are
+      // non-fatal: we fall back to the bundled `plannerTemplate`. Log so
+      // repeated boot failures show up in operator output rather than
+      // being silently masked.
+      logger.warn(
+        { err: (err as Error).message },
+        "[PlannerLoop] optimized planner disk load failed; using bundled template",
+      );
+      cachedDiskOptimizedPlannerPrompt = null;
+    }
+    cachedDiskOptimizedPlannerLoaded = true;
+  }
+  return cachedDiskOptimizedPlannerPrompt ?? plannerTemplate;
 }


### PR DESCRIPTION
## Problem

A planner that re-issues a tool call **identical** to one that already **succeeded** this turn (same tool name + arguments) cannot get new information — but nothing stopped it.

Observed live: `gpt-5.5` re-issued the same `WEB_FETCH` (same URL) on every planner iteration; each call succeeded, the evaluator said `CONTINUE`, and the loop ran until `maxTrajectoryPromptTokens` aborted the turn — the user got a generic *"sorry, something went wrong"* apology instead of the data that had been fetched 17 times.

This is the success-side analog of the existing `maxRepeatedFailures` guard (which only catches *failing* repeats).

## Fix

In `runPlannerLoop`:

- **Identity:** identify calls by name + **sorted-key** argument serialization (`canonicalParamsString`), so re-emissions that differ only in key insertion order (common across LLM turns) map to one identity.
- **Skip redundant:** partition each iteration's non-terminal calls into genuinely-fresh vs repeats of an already-succeeded call; execute only the fresh ones.
- **Bound + synthesize:** when every planned call is a redundant repeat, count a dead round; past the new `maxRepeatedToolCalls` bound (default **2**), force **one** tool-less synthesis call so the model writes the final answer from results already in the trajectory.
- **Relax toolChoice:** once a non-terminal tool has executed, relax `toolChoice` from `required` → `auto` (made explicit, since `callPlanner` defaults `undefined` back to `required`) so the planner may synthesize a terminal `REPLY` instead of being pushed to re-call a tool every iteration.

All structural (tool-call identity + trajectory state), no text heuristics.

## Test

Adds `stops re-executing an identical successful call and forces a terminal synthesis` to `planner-loop.test.ts` — same `WEB_FETCH` returned every iteration, asserts it executes **once** and the loop terminates with the synthesized answer. Full planner-loop suite: **45/45 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
