### PR TITLE
fix(orchestrator): never narrate an ACP method-not-found as a task failure

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1022,6 +1022,60 @@ describe("SubAgentRouter", () => {
       expect(handleMessage).not.toHaveBeenCalled();
     });
 
+    it("suppresses a method-not-found on an auxiliary ACP method (terminal/fs)", async () => {
+      // The adapter lacking an auxiliary client method (terminal/*, fs/*) is
+      // internal protocol noise — the sub-agent keeps running and its real
+      // outcome still arrives via task_complete. The old cancel-only check
+      // surfaced these as task failures.
+      session = sessionWithTask("build a tiny app");
+      acp = makeAcpService(session);
+      const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "error", {
+        message: "Method not found: terminal/create",
+        code: -32601,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(handleMessage).not.toHaveBeenCalled();
+    });
+
+    it("does surface a sub-agent build error that merely says 'method not found'", async () => {
+      // A real failure whose text happens to contain the words "method not
+      // found" (e.g. an upstream "405 Method Not Allowed") names no ACP method
+      // path and carries no -32601 code — it must reach the user, not be
+      // swallowed as internal protocol noise.
+      session = sessionWithTask("build a tiny app");
+      acp = makeAcpService(session);
+      const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "error", {
+        message: "build failed: GET /api returned 405 method not found",
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(handleMessage).toHaveBeenCalled();
+    });
+
+    it("does not suppress a -32601 on session/prompt (the task cannot run)", async () => {
+      // A method-not-found on the core prompt method means the adapter cannot
+      // run the task at all — swallowing it would hang the user until timeout.
+      session = sessionWithTask("build a tiny app");
+      acp = makeAcpService(session);
+      const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "error", {
+        message: "session/prompt failed",
+        code: -32601,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(handleMessage).toHaveBeenCalled();
+    });
+
     it("stops retrying once the budget is exhausted and posts honestly", async () => {
       // Already at the default max (2) → no further retry.
       session = sessionWithTask(`build it at ${DEAD_URL}`, 2);

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -520,10 +520,10 @@ export class SubAgentRouter extends Service {
       );
       return;
     }
-    if (event === "error" && isUnsupportedCancelError(data)) {
+    if (event === "error" && isUnsupportedAcpMethodError(data)) {
       this.log(
         "debug",
-        "suppressing internal unsupported session/cancel error",
+        "suppressing internal ACP method-not-found error (not a task failure)",
         {
           sessionId,
         },
@@ -1391,14 +1391,32 @@ function shouldInject(event: SessionEventName): boolean {
   );
 }
 
-function isUnsupportedCancelError(data: unknown): boolean {
-  const serialized = JSON.stringify(data);
-  const message =
-    pickPayloadString(data, "message") ??
-    (typeof serialized === "string" ? serialized : "");
-  return (
-    /method\s+not\s+found/i.test(message) && /session\/cancel/i.test(message)
-  );
+function isUnsupportedAcpMethodError(data: unknown): boolean {
+  const serialized =
+    typeof data === "object" && data !== null
+      ? JSON.stringify(data)
+      : String(data ?? "");
+  // Gate on the JSON-RPC method-not-found CODE (-32601), NOT free text. A
+  // sub-agent's own build error that merely contains the words "method not
+  // found" (e.g. an upstream "405 Method Not Allowed") must still reach the
+  // user — only a real -32601 from the ACP layer is internal protocol noise.
+  // It means the CLIENT called an auxiliary method the adapter lacks
+  // (session/cancel, terminal/*, fs/*); the sub-agent keeps running and the
+  // real outcome still arrives via task_complete or a timeout.
+  const isMethodNotFound =
+    /"code"\s*:\s*-32601\b/.test(serialized) ||
+    /\(-32601\)/.test(serialized) ||
+    // A "method not found" that names an ACP RPC method path (session/cancel,
+    // terminal/*, fs/*). The method-path requirement distinguishes a real
+    // ACP-layer gap from a sub-agent's own build output that merely contains
+    // the words "method not found".
+    (/method\s+not\s+found/i.test(serialized) &&
+      /\b(?:session|terminal|fs|_meta)\/[a-z_]+/i.test(serialized));
+  if (!isMethodNotFound) return false;
+  // NEVER suppress a -32601 on the core prompt method: that means the adapter
+  // cannot run the task at all, so swallowing it would hang the user with no
+  // feedback until the full ACP timeout fires.
+  return !/session\/prompt/i.test(serialized);
 }
 
 function verifiedUrlCompletionFallback(text: string, verifiedUrls: string[]) {


### PR DESCRIPTION
## Problem

`SubAgentRouter` suppressed only `session/cancel` method-not-found errors. When an ACP adapter lacked **another** auxiliary client method (`terminal/*`, `fs/*`, `_meta/*`), the `-32601` surfaced to the user as a **task failure** — even though the sub-agent kept running and its real outcome still arrived via `task_complete` (or a timeout). Users saw a scary "method not found" error for a task that actually succeeded.

## Fix

Generalize the suppression from cancel-only to **any auxiliary ACP method-not-found**, gated on the JSON-RPC **`-32601` code** (or a `method-path` match like `session|terminal|fs|_meta/…`) rather than free text. Two guard rails keep it honest:

- A sub-agent's **own build error** that merely contains the words "method not found" (e.g. an upstream `405 Method Not Allowed`) names no ACP method path and carries no `-32601` — it still reaches the user.
- A `-32601` on **`session/prompt`** is **never** suppressed: that means the adapter cannot run the task at all, so swallowing it would hang the user with no feedback until the full ACP timeout.

## Test

Three cases added to `sub-agent-router.test.ts`:
- auxiliary `terminal/*` `-32601` **is** suppressed (this one **fails on the old cancel-only check** — it's the regression that proves the fix),
- a build error that merely says "method not found" **does** reach the user,
- a `session/prompt` `-32601` **does** reach the user.

Full suite: **88/88 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
