### PR TITLE
feat(orchestrator): re-attach an app-deploy contract at sub-agent spawn

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  augmentTaskWithDeployGuidance,
+  buildAppDeployGuidance,
+  isAppBuildTask,
+} from "../../src/services/app-deploy-guidance.js";
+
+describe("app-deploy-guidance", () => {
+  describe("isAppBuildTask", () => {
+    it("matches hosted web-surface builds", () => {
+      expect(isAppBuildTask("build me a website about cats")).toBe(true);
+      expect(isAppBuildTask("create a landing page for my startup")).toBe(true);
+      expect(isAppBuildTask("make a web app dashboard")).toBe(true);
+    });
+
+    it("does NOT match non-hosted builds (CLI / library / script / bot)", () => {
+      expect(isAppBuildTask("build a CLI tool to parse logs")).toBe(false);
+      expect(isAppBuildTask("create a npm library for dates")).toBe(false);
+      expect(isAppBuildTask("write a script to rename files")).toBe(false);
+      expect(isAppBuildTask("fix the bug in the parser")).toBe(false);
+    });
+
+    it("ignores empty/nullish input", () => {
+      expect(isAppBuildTask("")).toBe(false);
+      expect(isAppBuildTask(undefined)).toBe(false);
+      expect(isAppBuildTask(null)).toBe(false);
+    });
+  });
+
+  describe("augmentTaskWithDeployGuidance", () => {
+    it("appends the Eliza Cloud contract to an app-build task by default", () => {
+      const out = augmentTaskWithDeployGuidance("build a website about cats", {
+        target: "eliza-cloud",
+      });
+      expect(out).toContain("build a website about cats");
+      expect(out).toContain("App Deployment (Eliza Cloud)");
+      expect(out).toContain("verified live");
+    });
+
+    it("passes a non-app task through unchanged", () => {
+      const task = "fix the bug in the parser";
+      expect(
+        augmentTaskWithDeployGuidance(task, { target: "eliza-cloud" }),
+      ).toBe(task);
+    });
+
+    it("is idempotent — does not double-append the contract", () => {
+      const once = augmentTaskWithDeployGuidance("build a website", {
+        target: "eliza-cloud",
+      });
+      const twice = augmentTaskWithDeployGuidance(once, {
+        target: "eliza-cloud",
+      });
+      expect(twice).toBe(once);
+    });
+
+    it("uses the gated agent-home host when that target is configured", () => {
+      const out = augmentTaskWithDeployGuidance("build a website", {
+        target: "agent-home",
+        agentHomeAppsDir: "/data/apps",
+        agentHomeBaseUrl: "https://example.test",
+      });
+      expect(out).toContain("App Deployment (agent-home)");
+      expect(out).toContain("/data/apps/<slug>/");
+      expect(out).toContain("https://example.test/apps/<slug>/");
+      // The Cloud contract header must not appear (the agent-home block only
+      // references Cloud to say "do NOT use it for this one").
+      expect(out).not.toContain("App Deployment (Eliza Cloud)");
+    });
+  });
+
+  describe("buildAppDeployGuidance", () => {
+    it("defaults to Eliza Cloud for an unspecified/empty config", () => {
+      expect(buildAppDeployGuidance({ target: "eliza-cloud" })).toContain(
+        "Eliza Cloud",
+      );
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { NativeAcpClient } from "./acp-native-transport.js";
+import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
@@ -614,6 +615,15 @@ export class AcpService extends Service {
     // separate enforceSessionLimit()/store.create() left a read-then-act race).
     await this.reserveSessionSlot(session);
 
+    // App-build tasks lose the parent's deploy contract at the spawn boundary.
+    // Re-attach it ONCE here, before the transport branch, so BOTH the native
+    // and the CLI/acpx paths host the app and report a verified URL. No-op for
+    // non-app tasks; applied only to the initial task, never to follow-up sends.
+    const initialTask =
+      opts.initialTask && opts.initialTask.trim().length > 0
+        ? augmentTaskWithDeployGuidance(opts.initialTask)
+        : opts.initialTask;
+
     if (this.transportMode === "native") {
       const result = await this.spawnNativeSession(id, session, {
         ...opts,
@@ -623,7 +633,7 @@ export class AcpService extends Service {
         const keepAliveAfterComplete =
           (opts.metadata as Record<string, unknown> | undefined)
             ?.keepAliveAfterComplete === true;
-        void this.sendPrompt(id, opts.initialTask, {
+        void this.sendPrompt(id, initialTask ?? "", {
           timeoutMs: opts.timeoutMs,
           model: opts.model,
         })
@@ -631,8 +641,8 @@ export class AcpService extends Service {
             this.log("error", "initial prompt failed", {
               sessionId: id,
               agentType,
-              promptLength: opts.initialTask?.length ?? 0,
-              promptPreview: preview(opts.initialTask ?? ""),
+              promptLength: initialTask?.length ?? 0,
+              promptPreview: preview(initialTask ?? ""),
               error: errorMessage(err),
             });
           })
@@ -690,7 +700,7 @@ export class AcpService extends Service {
       const keepAliveAfterComplete =
         (opts.metadata as Record<string, unknown> | undefined)
           ?.keepAliveAfterComplete === true;
-      void this.sendPrompt(id, opts.initialTask, {
+      void this.sendPrompt(id, initialTask ?? "", {
         timeoutMs: opts.timeoutMs,
         model: opts.model,
       })
@@ -698,8 +708,8 @@ export class AcpService extends Service {
           this.log("error", "initial prompt failed", {
             sessionId: id,
             agentType,
-            promptLength: opts.initialTask?.length ?? 0,
-            promptPreview: preview(opts.initialTask ?? ""),
+            promptLength: initialTask?.length ?? 0,
+            promptPreview: preview(initialTask ?? ""),
             error: errorMessage(err),
           });
         })

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -1,0 +1,110 @@
+/**
+ * App-deployment guidance for spawned coding sub-agents.
+ *
+ * When a sub-agent is asked to build an app / website, the planner-level
+ * app-build contract (in the parent agent's system prompt) does not survive the
+ * terse spawn task. Without it the sub-agent just writes local files that are
+ * never served, so the user gets "no live URL". This module re-injects a
+ * deployment contract into the sub-agent's initial task at the spawn chokepoint
+ * so the result is actually hosted and a verified URL is reported.
+ *
+ * Default target is **Eliza Cloud** (the productized path for every user).
+ * Operators can opt into a personal **agent-home** static host via env — that
+ * is gated so other users never see it.
+ *
+ * @module services/app-deploy-guidance
+ */
+
+import { readConfigEnvKey } from "./config-env.js";
+import { APP_DEPLOY_TASK_RE } from "./skill-recommender.js";
+
+/**
+ * Whether a task builds a HOSTED web surface that should get the deploy
+ * contract. Uses the narrow APP_DEPLOY_TASK_RE — a CLI tool / library / doc
+ * page must NOT be told to deploy and report a live URL.
+ */
+export function isAppBuildTask(taskText: string | undefined | null): boolean {
+  if (typeof taskText !== "string" || taskText.trim().length === 0) {
+    return false;
+  }
+  return APP_DEPLOY_TASK_RE.test(taskText);
+}
+
+export type AppDeployTarget = "eliza-cloud" | "agent-home";
+
+export interface AppDeployConfig {
+  target: AppDeployTarget;
+  /** agent-home: absolute dir whose `<slug>/` subdirs are served as apps. */
+  agentHomeAppsDir?: string;
+  /** agent-home: public base URL; apps resolve at `<baseUrl>/apps/<slug>/`. */
+  agentHomeBaseUrl?: string;
+}
+
+/**
+ * Resolve the deploy target from env. agent-home requires BOTH an apps dir and
+ * a base URL to be configured; otherwise we fall back to Eliza Cloud so a
+ * half-configured operator override can never strand a normal user.
+ */
+export function resolveAppDeployConfig(): AppDeployConfig {
+  const requested = readConfigEnvKey("ELIZA_APP_DEPLOY_TARGET")
+    ?.trim()
+    .toLowerCase();
+  const agentHomeAppsDir = readConfigEnvKey(
+    "ELIZA_AGENT_HOME_APPS_DIR",
+  )?.trim();
+  const agentHomeBaseUrl = readConfigEnvKey("ELIZA_AGENT_HOME_BASE_URL")
+    ?.trim()
+    .replace(/\/+$/, "");
+
+  if (requested === "agent-home" && agentHomeAppsDir && agentHomeBaseUrl) {
+    return { target: "agent-home", agentHomeAppsDir, agentHomeBaseUrl };
+  }
+  return { target: "eliza-cloud" };
+}
+
+function elizaCloudGuidance(): string {
+  return [
+    "--- App Deployment (Eliza Cloud) ---",
+    "This task builds an app/site, so it must end up actually HOSTED with a verified live URL — not just local files.",
+    "- Build a real, working app and load it to confirm it works before reporting done.",
+    "- Host it on Eliza Cloud: use `@elizaos/cloud-sdk` when available, register the app to get an `appId`, and deploy via the Cloud container/app flow.",
+    "- For auth, use Eliza Cloud OAuth via a same-origin proxy to `/api/v1/apps/<appId>/chat` with the user's bearer token (add `X-Affiliate-Code` when monetizing). Use Cloud DB / hosted APIs for persistence.",
+    "- Do NOT hardcode owner API keys in frontend code, use mock replies, or hand-roll legacy `/messages` routes. Follow the `build-monetized-app` skill for the canonical registration + deploy + domain flow.",
+    "- Report ONLY the verified live Cloud URL. If you could not deploy or verify it, say that plainly — never report an unverified or guessed URL.",
+  ].join("\n");
+}
+
+function agentHomeGuidance(config: AppDeployConfig): string {
+  const dir = config.agentHomeAppsDir ?? "";
+  const base = config.agentHomeBaseUrl ?? "";
+  return [
+    "--- App Deployment (agent-home) ---",
+    "This is a quick static/fun app for the operator's personal agent-home host. Do NOT use Eliza Cloud for this one.",
+    "- Pick a fresh, short kebab-case `<slug>` from the request.",
+    `- Write the app's static files (index.html + css/js — there is NO per-app build step) into \`${dir}/<slug>/\`.`,
+    `- It is then served immediately at \`${base}/apps/<slug>/\` — load that URL to confirm it works, then report it as the live link.`,
+    "- Do NOT run `deploy.sh` (operator-only; only needed when adding a new Next.js backend route). Static apps need no build/restart.",
+  ].join("\n");
+}
+
+/** Build the deploy-guidance block for the configured target. */
+export function buildAppDeployGuidance(config?: AppDeployConfig): string {
+  const resolved = config ?? resolveAppDeployConfig();
+  return resolved.target === "agent-home"
+    ? agentHomeGuidance(resolved)
+    : elizaCloudGuidance();
+}
+
+/**
+ * Append the deploy contract to an app-build task; pass non-app tasks through
+ * unchanged. Idempotent — skips if the block is already present.
+ */
+export function augmentTaskWithDeployGuidance(
+  task: string,
+  config?: AppDeployConfig,
+): string {
+  if (!isAppBuildTask(task) || task.includes("--- App Deployment")) {
+    return task;
+  }
+  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(config)}`;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -30,8 +30,17 @@ const KEYWORD_CANDIDATE_LIMIT = 10;
 const LLM_SHORT_CIRCUIT_SCORE = 0.9;
 const BUILD_MONETIZED_APP_SLUG = "build-monetized-app";
 const ELIZA_CLOUD_SKILL_SLUG = "eliza-cloud";
-const APP_BUILD_TASK_RE =
-  /\b(build|create|make|ship|write|develop|generate)\b(?:(?!\b(?:article|blog|post)\b)[\s\S]){0,120}\b(app|site|page|tool|game|dashboard|chatbot|chat\s*bot|chat\s+app|assistant|companion)\b/i;
+export const APP_BUILD_TASK_RE =
+  /\b(build|create|make|ship|write|develop|generate|design)\b(?:(?!\b(?:article|blog|post)\b)[\s\S]){0,120}\b(app|application|web\s?site|website|web\s?page|webpage|landing\s?page|site|page|tool|game|dashboard|chat\s?bot|chatbot|chat\s+app|assistant|companion|portfolio|widget)\b/i;
+
+// Narrower than APP_BUILD_TASK_RE. The deploy CONTRACT (host it, report a
+// verified URL) must only attach to builds that produce a hosted WEB surface —
+// not CLI tools, libraries, scripts, bots, or doc "pages" (which the broad
+// regex's `tool`/`page`/`portfolio`/`widget` nouns false-positive). The skill
+// recommender tolerates over-matching (it only suggests a skill); the spawn-
+// time deploy injection rewrites the task contract, so it uses this gate.
+export const APP_DEPLOY_TASK_RE =
+  /\b(build|create|make|ship|deploy|generate|design)\b(?:(?!\b(?:article|blog|post|cli|command[-\s]?line|library|package|script|extension|bot|plugin)\b)[\s\S]){0,120}\b(web\s?app|webapp|web\s?site|website|web\s?page|webpage|landing\s?page|home\s?page|dashboard|micro\s?site|website|app)\b/i;
 // Tokens shorter than this carry no signal — they show up in nearly every
 // task description and would inflate every skill's score equally.
 const MIN_TOKEN_LENGTH = 4;


### PR DESCRIPTION
## Problem

When a sub-agent is asked to *build an app / website*, the parent agent's planner-level app-build contract (host it, report a verified URL) does **not** survive the terse spawn task handed to the coding sub-agent. So the sub-agent just writes local files that are never served, and the user gets *"no live URL"* for a build that looked successful.

## Fix

Re-inject a deploy contract into the sub-agent's **initial task** once at the `AcpService` spawn chokepoint, **before** the transport branch, so both the native and CLI/acpx paths carry it. The injection is:

- **Gated** — only app-build tasks get it, via the narrow `APP_DEPLOY_TASK_RE` (which excludes CLI tools, libraries, scripts, bots, doc pages). No-op for everything else.
- **Idempotent** — skips if the contract block is already present.

Default target is **Eliza Cloud** — the productized path: `@elizaos/cloud-sdk` register → deploy → OAuth proxy to `/api/v1/apps/<appId>/chat` → hosted DB, per the `build-monetized-app` skill, and *report only a verified live URL*. Operators can opt into a personal static host with `ELIZA_APP_DEPLOY_TARGET=agent-home` (+ apps-dir + base-url); a half-configured override falls back to Cloud so a normal user is never stranded.

## Test

New `app-deploy-guidance.test.ts` (8 cases): hosted-surface matching vs CLI/library/script exclusion, Cloud-default contract append, non-app pass-through, idempotency, and the gated agent-home path. Suite green.

## Note

This is a behavior-changing feature for app-build sub-agent spawns — happy to adjust the default contract wording or gate to match maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
