### PR TITLE
feat(cloud): new managed agents use local in-container DB + lean chat plugins (#8696, #8434)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -691,3 +691,29 @@ describe("ElizaSandboxService.executeResume", () => {
     }
   });
 });
+
+describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
+  const DB = "postgres://shared.example/railway";
+
+  test("local-state agent gets ELIZA_MANAGED_DATABASE_URL and NO DATABASE_URL", async () => {
+    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const env = computeManagedAgentDbEnv({ ELIZA_AGENT_LOCAL_STATE: "1" }, DB);
+    expect(env.DATABASE_URL).toBeUndefined();
+    expect(env.ELIZA_MANAGED_DATABASE_URL).toBe(DB);
+  });
+
+  test("existing agent (no flag) keeps the shared DATABASE_URL injection", async () => {
+    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const env = computeManagedAgentDbEnv({}, DB);
+    expect(env.DATABASE_URL).toBe(DB);
+    expect(env.ELIZA_MANAGED_DATABASE_URL).toBeUndefined();
+  });
+
+  test("caller-supplied DATABASE_URL is preserved; managed exposed separately", async () => {
+    const { computeManagedAgentDbEnv } = await import("./eliza-sandbox.ts?actual");
+    const env = computeManagedAgentDbEnv({ DATABASE_URL: "postgres://own.example/db" }, DB);
+    // dbEnv never clobbers the caller's DATABASE_URL (it is spread first in create()).
+    expect(env.DATABASE_URL).toBeUndefined();
+    expect(env.ELIZA_MANAGED_DATABASE_URL).toBe(DB);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -186,6 +186,33 @@ class BridgeRouteUnavailableError extends Error {
   }
 }
 
+/**
+ * Decide how the shared managed DB URL is exposed to an agent container (#8696).
+ *
+ * - A self-contained image that shipped its OWN `DATABASE_URL` keeps it; the
+ *   managed URL is exposed under `ELIZA_MANAGED_DATABASE_URL` so it can opt in.
+ * - A local-state agent (provisioned with `ELIZA_AGENT_LOCAL_STATE=1`) keeps
+ *   agent-state in a local in-container PGlite DB on the persistent volume and
+ *   uses the shared DB only for auth/discovery via the cloud API. The managed URL
+ *   is exposed as `ELIZA_MANAGED_DATABASE_URL` (opt-in) and `DATABASE_URL` is left
+ *   UNSET so plugin-sql falls back to local PGlite — removing the shared-Postgres
+ *   connection hot path.
+ * - Otherwise (existing agents with no flag) the managed URL is injected as
+ *   `DATABASE_URL`, byte-identical to the prior behavior — a forward cutover with
+ *   no migration.
+ */
+export function computeManagedAgentDbEnv(
+  callerEnv: Record<string, string>,
+  dbUri: string,
+): Record<string, string> {
+  const callerSuppliedDatabaseUrl =
+    typeof callerEnv.DATABASE_URL === "string" && callerEnv.DATABASE_URL.trim().length > 0;
+  const wantsLocalState = callerEnv.ELIZA_AGENT_LOCAL_STATE === "1";
+  return callerSuppliedDatabaseUrl || wantsLocalState
+    ? { ELIZA_MANAGED_DATABASE_URL: dbUri }
+    : { DATABASE_URL: dbUri };
+}
+
 export class ElizaSandboxService {
   private _provider?: SandboxProvider;
   private _providerPromise?: Promise<SandboxProvider>;
@@ -884,17 +911,14 @@ export class ElizaSandboxService {
         // name (ELIZA_MANAGED_DATABASE_URL) so the image can opt in. Only when
         // the caller did NOT supply one do we inject the managed URL as
         // DATABASE_URL — the normal managed-agent path, byte-identical to before.
-        const callerSuppliedDatabaseUrl =
-          typeof callerEnv.DATABASE_URL === "string" && callerEnv.DATABASE_URL.trim().length > 0;
+        const dbEnv = computeManagedAgentDbEnv(callerEnv, dbUri);
         handle = await (await this.getProvider()).create({
           agentId: rec.id,
           agentName: rec.agent_name ?? "CloudAgent",
           organizationId: rec.organization_id,
           environmentVars: {
             ...callerEnv,
-            ...(callerSuppliedDatabaseUrl
-              ? { ELIZA_MANAGED_DATABASE_URL: dbUri }
-              : { DATABASE_URL: dbUri }),
+            ...dbEnv,
           },
           // Path A: pass the persisted character so the container boots AS
           // this agent (see docker-sandbox-provider ELIZA_AGENT_CHARACTER_JSON

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
@@ -169,4 +169,39 @@ describe("managed Eliza environment", () => {
       "https://custom.example.com/api/v1",
     );
   });
+
+  test("defaults new agents to local in-container state + lean chat plugins (#8696/#8434)", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+    });
+
+    // Local agent-state on the persistent volume — no shared-DB hot path.
+    expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("1");
+    expect(result.environmentVars.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
+    // Lean chat plugin set for fast cold-start.
+    expect(result.environmentVars.ELIZA_PLUGIN_SET).toBe("lean-chat");
+  });
+
+  test("honors escape hatches: shared DB + custom plugin set + custom pglite dir", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+      existingEnv: {
+        ELIZA_AGENT_LOCAL_STATE: "0",
+        ELIZA_PLUGIN_SET: "full",
+        PGLITE_DATA_DIR: "/custom/pgdata",
+      },
+    });
+
+    expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("0");
+    expect(result.environmentVars.ELIZA_PLUGIN_SET).toBe("full");
+    expect(result.environmentVars.PGLITE_DATA_DIR).toBe("/custom/pgdata");
+  });
 });

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -249,11 +249,28 @@ export async function prepareManagedElizaBaseEnvironment(
         existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
       ELIZAOS_CLOUD_LARGE_MODEL:
         existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
-      // Lean multi-tenant Postgres pool. Every dedicated agent container pools
-      // against the shared cloud Postgres, so the default per-agent pool
-      // (max 20 / min 2) exhausts the server's max_connections at scale (50
-      // idle agents × min 2 = 100 connections). Cap bursts at 8 and let idle
-      // agents release ALL connections (min 0). plugin-sql reads POSTGRES_POOL_*.
+      // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
+      // the persistent /root/.eliza volume) instead of the shared cloud Postgres;
+      // auth + discovery still flow through the cloud API (ELIZAOS_CLOUD_* above).
+      // This removes the shared-Postgres connection hot path that caused the
+      // "too many clients" incident (#8696). The flag is read at container-create
+      // time (eliza-sandbox.ts): only agents PROVISIONED with it set go local, so
+      // existing agents keep their shared-DB state untouched — a forward cutover
+      // with no migration. Set ELIZA_AGENT_LOCAL_STATE=0 to provision a new agent
+      // on the shared DB instead. PGLITE_DATA_DIR is pinned under the persistent
+      // mount so local state survives container restarts.
+      ELIZA_AGENT_LOCAL_STATE: existingEnv.ELIZA_AGENT_LOCAL_STATE ?? "1",
+      PGLITE_DATA_DIR: existingEnv.PGLITE_DATA_DIR ?? "/root/.eliza/.pgdata",
+      // New dedicated agents boot the lean chat plugin set (no shell/coding-tools/
+      // browser/orchestrator) for fast cold-start (#8434). Override per agent by
+      // pinning ELIZA_PLUGIN_SET to another value at create.
+      ELIZA_PLUGIN_SET: existingEnv.ELIZA_PLUGIN_SET ?? "lean-chat",
+      // Lean Postgres pool — only applies to agents still on the SHARED DB
+      // (existing agents, or new agents provisioned with ELIZA_AGENT_LOCAL_STATE=0).
+      // The default per-agent pool (max 20 / min 2) exhausts the server's
+      // max_connections at scale (50 idle agents × min 2 = 100). Cap bursts at 8
+      // and let idle agents release ALL connections (min 0). plugin-sql reads
+      // POSTGRES_POOL_*; harmless (unused) under local PGlite.
       POSTGRES_POOL_MAX: existingEnv.POSTGRES_POOL_MAX ?? "8",
       POSTGRES_POOL_MIN: existingEnv.POSTGRES_POOL_MIN ?? "0",
       POSTGRES_POOL_IDLE_TIMEOUT_MS: existingEnv.POSTGRES_POOL_IDLE_TIMEOUT_MS ?? "15000",


### PR DESCRIPTION
## Summary
Root-cause fix for the #8696 "too many clients" incident. Instead of every dedicated agent pooling against the single shared cloud Postgres, **new managed agents keep agent-state in a local in-container PGlite DB** on the persistent `/root/.eliza` volume and use the shared DB only for auth/discovery via the cloud API — removing the shared-Postgres connection hot path (so a pooler/DB-split is no longer required for agents). Also activates the #8434 lean chat plugin set for new agents.

## Design — safe, migration-free forward cutover
- `prepareManagedElizaBaseEnvironment` stamps new agents with `ELIZA_AGENT_LOCAL_STATE=1`, `PGLITE_DATA_DIR=/root/.eliza/.pgdata` (persistent mount → survives restarts), `ELIZA_PLUGIN_SET=lean-chat`.
- `computeManagedAgentDbEnv` (in `eliza-sandbox.create()`) injects the shared `DATABASE_URL` **only** when the agent is not flagged local-state and didn't ship its own DB. **Existing agents (no flag) keep their shared-DB state untouched** — no migration, no data loss; only newly provisioned agents go local. Shared URL still exposed as `ELIZA_MANAGED_DATABASE_URL` for opt-in.
- **Escape hatches:** `ELIZA_AGENT_LOCAL_STATE=0` keeps a new agent on the shared DB; `ELIZA_PLUGIN_SET` override changes plugins. `POSTGRES_POOL_*` retained for the shared-DB path.

Auth/discovery unchanged (cloud API). Ships to **staging first** via CI for validation before any prod promote.

## Tests
- `managed-eliza-config.test.ts`: new agents default to local-state + lean-chat; escape hatches honored. (11 pass)
- `eliza-sandbox.test.ts`: `computeManagedAgentDbEnv` — local → no `DATABASE_URL`; existing → shared `DATABASE_URL`; caller-supplied preserved. (19 pass)
- typecheck + biome clean.

Depends on #8730 (LEAN_CHAT_PLUGINS mechanism, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)