### PR TITLE
fix(plugin-elizacloud): cap per-turn native cerebras concurrency (stops 429-induced 30-63s latency)

### DIFF
--- a/plugins/plugin-elizacloud/AGENTS.md
+++ b/plugins/plugin-elizacloud/AGENTS.md
@@ -204,7 +204,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |
-| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native `/chat/completions` calls (text tiers). A single turn fans providers out via composeState's `Promise.all`, each calling `useModel` -> the native chat path; firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst; set `2` for mild parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
+| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native cloud text calls. Covers BOTH native text routes sharing the one cerebras key: `/chat/completions` (native-transport callers) AND `/responses` (bare-`{ prompt }` callers, incl. the primary reply action). The per-turn burst comes from the prompt batcher (`dynamicPromptExecFromState`, always sets providerOptions -> `/chat/completions`) and the merged evaluator call — NOT from composeState providers (no provider calls `useModel` during composeState); firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst (right for the cerebras-bottlenecked dedicated-agent default); the trade-off is that ALL native cloud text calls serialize in the process — non-cerebras deployments can raise this for parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
 
 ### Optional — model tiers (each has a fallback bare env alias)
 

--- a/plugins/plugin-elizacloud/AGENTS.md
+++ b/plugins/plugin-elizacloud/AGENTS.md
@@ -204,6 +204,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |
+| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native `/chat/completions` calls (text tiers). A single turn fans providers out via composeState's `Promise.all`, each calling `useModel` -> the native chat path; firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst; set `2` for mild parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
 
 ### Optional — model tiers (each has a fallback bare env alias)
 

--- a/plugins/plugin-elizacloud/CLAUDE.md
+++ b/plugins/plugin-elizacloud/CLAUDE.md
@@ -204,7 +204,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |
-| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native `/chat/completions` calls (text tiers). A single turn fans providers out via composeState's `Promise.all`, each calling `useModel` -> the native chat path; firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst; set `2` for mild parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
+| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native cloud text calls. Covers BOTH native text routes sharing the one cerebras key: `/chat/completions` (native-transport callers) AND `/responses` (bare-`{ prompt }` callers, incl. the primary reply action). The per-turn burst comes from the prompt batcher (`dynamicPromptExecFromState`, always sets providerOptions -> `/chat/completions`) and the merged evaluator call — NOT from composeState providers (no provider calls `useModel` during composeState); firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst (right for the cerebras-bottlenecked dedicated-agent default); the trade-off is that ALL native cloud text calls serialize in the process — non-cerebras deployments can raise this for parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
 
 ### Optional — model tiers (each has a fallback bare env alias)
 

--- a/plugins/plugin-elizacloud/CLAUDE.md
+++ b/plugins/plugin-elizacloud/CLAUDE.md
@@ -204,6 +204,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |
+| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `1` — per-process cap on CONCURRENT native `/chat/completions` calls (text tiers). A single turn fans providers out via composeState's `Promise.all`, each calling `useModel` -> the native chat path; firing them at once overruns the shared cerebras key's concurrent limit -> 429 -> retries. Default `1` serializes the burst; set `2` for mild parallelism. Embeddings use a separate `/embeddings` route and are NOT gated. |
 
 ### Optional — model tiers (each has a fallback bare env alias)
 

--- a/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the per-process native-cerebras concurrency limiter that wraps
+ * the `/chat/completions` round-trip in `generateNativeChatCompletion`
+ * (src/models/text.ts).
+ *
+ * A single chat turn fans providers out via composeState's `Promise.all`, each
+ * calling `useModel` -> generateNativeChatCompletion; firing them all at once
+ * overruns the one shared cerebras key's concurrent limit -> 429. The limiter
+ * serializes that burst. These tests use a fake `requestRaw` backed by
+ * controllable deferreds — NO live API.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Controllable fake transport. Each `requestRaw` call registers an in-flight
+// entry and resolves only when the test resolves its deferred. We track the
+// observed max-in-flight to assert the cap.
+type Deferred = {
+  resolve: (value: Response) => void;
+  reject: (err: unknown) => void;
+};
+
+const transport = {
+  inFlight: 0,
+  maxInFlight: 0,
+  /** FIFO list of pending deferreds in acquire order. */
+  pending: [] as Deferred[],
+  /** Order in which calls actually entered the guarded section. */
+  enterOrder: [] as number[],
+  reset() {
+    this.inFlight = 0;
+    this.maxInFlight = 0;
+    this.pending = [];
+    this.enterOrder = [];
+  },
+};
+
+let callSeq = 0;
+
+const requestRaw = vi.fn(async (_method: string, _path: string, _opts?: unknown) => {
+  const seq = callSeq++;
+  transport.inFlight += 1;
+  transport.maxInFlight = Math.max(transport.maxInFlight, transport.inFlight);
+  transport.enterOrder.push(seq);
+  try {
+    return await new Promise<Response>((resolve, reject) => {
+      transport.pending.push({ resolve, reject });
+    });
+  } finally {
+    transport.inFlight -= 1;
+  }
+});
+
+vi.mock("../src/utils/sdk-client", () => ({
+  createCloudApiClient: () => ({ requestRaw }),
+  createElizaCloudClient: () => ({}),
+}));
+
+// Imported after the mock is registered.
+import { __resetNativeChatLimiterForTests, generateNativeChatCompletion } from "../src/models/text";
+
+function fakeRuntime(): IAgentRuntime {
+  return {
+    character: { name: "Eliza", bio: [] },
+    getSetting: () => undefined,
+    emitEvent: vi.fn(),
+    emitModelUsageEvent: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function okResponse(text = "pong"): Response {
+  const body = JSON.stringify({
+    choices: [{ message: { content: text }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  });
+  return new Response(body, { status: 200, headers: { "content-type": "application/json" } });
+}
+
+/** Yield enough microtasks for the semaphore queue to settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
+function fireNativeCall(): Promise<unknown> {
+  return generateNativeChatCompletion(
+    fakeRuntime(),
+    "TEXT_SMALL" as never,
+    { prompt: "hi" } as never,
+    { modelName: "cerebras/gpt-oss-120b", prompt: "hi" }
+  );
+}
+
+describe("native cerebras concurrency limiter", () => {
+  beforeEach(() => {
+    transport.reset();
+    callSeq = 0;
+    requestRaw.mockClear();
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    __resetNativeChatLimiterForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    __resetNativeChatLimiterForTests();
+  });
+
+  it("caps in-flight native calls at 1 by default", async () => {
+    const calls = [
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+    ];
+    await flush();
+
+    // Default limit is 1 -> only one call should have entered the transport.
+    expect(transport.inFlight).toBe(1);
+    expect(transport.maxInFlight).toBe(1);
+
+    // Drain one-by-one; each release lets the next in.
+    for (let i = 0; i < 5; i++) {
+      expect(transport.pending.length).toBe(1);
+      transport.pending.shift()?.resolve(okResponse());
+      await flush();
+    }
+
+    await Promise.all(calls);
+    expect(transport.maxInFlight).toBe(1);
+    expect(requestRaw).toHaveBeenCalledTimes(5);
+  });
+
+  it("caps in-flight native calls at 2 when ELIZAOS_CLOUD_NATIVE_CONCURRENCY=2", async () => {
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "2";
+    __resetNativeChatLimiterForTests();
+
+    const calls = [
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+      fireNativeCall(),
+    ];
+    await flush();
+
+    expect(transport.inFlight).toBe(2);
+    expect(transport.maxInFlight).toBe(2);
+
+    while (transport.pending.length > 0) {
+      transport.pending.shift()?.resolve(okResponse());
+      await flush();
+    }
+
+    await Promise.all(calls);
+    // Max in-flight never exceeded the configured cap of 2.
+    expect(transport.maxInFlight).toBe(2);
+  });
+
+  it("admits queued callers in FIFO acquire order", async () => {
+    // Default limit 1; fire 3 and resolve in order, asserting entry order is FIFO.
+    const calls = [fireNativeCall(), fireNativeCall(), fireNativeCall()];
+    await flush();
+
+    // First caller entered.
+    expect(transport.enterOrder).toEqual([0]);
+    transport.pending.shift()?.resolve(okResponse());
+    await flush();
+    expect(transport.enterOrder).toEqual([0, 1]);
+    transport.pending.shift()?.resolve(okResponse());
+    await flush();
+    expect(transport.enterOrder).toEqual([0, 1, 2]);
+    transport.pending.shift()?.resolve(okResponse());
+    await flush();
+
+    await Promise.all(calls);
+    expect(transport.enterOrder).toEqual([0, 1, 2]);
+  });
+
+  it("releases the permit when the request rejects (next call proceeds)", async () => {
+    const first = fireNativeCall();
+    await flush();
+    expect(transport.inFlight).toBe(1);
+
+    const second = fireNativeCall();
+    await flush();
+    // Second is queued behind the semaphore (limit 1).
+    expect(transport.inFlight).toBe(1);
+
+    // Reject the first call's transport -> permit must be released in finally.
+    transport.pending.shift()?.reject(new Error("boom"));
+    await flush();
+    await expect(first).rejects.toThrow("boom");
+
+    // The second call should now be in-flight (permit was freed despite the throw).
+    expect(transport.inFlight).toBe(1);
+    expect(transport.pending.length).toBe(1);
+    transport.pending.shift()?.resolve(okResponse());
+    await second;
+    expect(transport.maxInFlight).toBe(1);
+  });
+
+  describe("knob parsing", () => {
+    const cases: Array<{ raw: string | undefined; expected: number }> = [
+      { raw: "2", expected: 2 },
+      { raw: "0", expected: 1 },
+      { raw: "abc", expected: 1 },
+      { raw: undefined, expected: 1 },
+    ];
+
+    for (const { raw, expected } of cases) {
+      it(`ELIZAOS_CLOUD_NATIVE_CONCURRENCY=${JSON.stringify(raw)} -> limit ${expected}`, async () => {
+        if (raw === undefined) {
+          delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+        } else {
+          process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = raw;
+        }
+        __resetNativeChatLimiterForTests();
+
+        // Fire expected+2 calls; the observed concurrency ceiling proves the limit.
+        const n = expected + 2;
+        const calls = Array.from({ length: n }, () => fireNativeCall());
+        await flush();
+
+        expect(transport.maxInFlight).toBe(expected);
+
+        while (transport.pending.length > 0) {
+          transport.pending.shift()?.resolve(okResponse());
+          await flush();
+        }
+        await Promise.all(calls);
+        expect(transport.maxInFlight).toBe(expected);
+      });
+    }
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
@@ -57,7 +57,11 @@ vi.mock("../src/utils/sdk-client", () => ({
 }));
 
 // Imported after the mock is registered.
-import { __resetNativeChatLimiterForTests, generateNativeChatCompletion } from "../src/models/text";
+import {
+  __resetNativeChatLimiterForTests,
+  generateNativeChatCompletion,
+  withNativeChatLimit,
+} from "../src/models/text";
 
 function fakeRuntime(): IAgentRuntime {
   return {
@@ -89,6 +93,16 @@ function fireNativeCall(): Promise<unknown> {
     "TEXT_SMALL" as never,
     { prompt: "hi" } as never,
     { modelName: "cerebras/gpt-oss-120b", prompt: "hi" }
+  );
+}
+
+// Mirrors the production /responses round-trip: the bare-`{ prompt }` path also
+// funnels its requestRaw network call through `withNativeChatLimit`, sharing the
+// SAME per-process limiter as the /chat/completions route. We drive the helper
+// directly with the same fake transport so the two routes contend on one cap.
+function fireResponsesCall(): Promise<unknown> {
+  return withNativeChatLimit(() =>
+    requestRaw("POST", "/responses", { headers: {}, json: { prompt: "hi" } })
   );
 }
 
@@ -233,5 +247,61 @@ describe("native cerebras concurrency limiter", () => {
         expect(transport.maxInFlight).toBe(expected);
       });
     }
+  });
+
+  describe("shared cap across both native routes (/chat/completions + /responses)", () => {
+    it("interleaved /chat/completions and /responses calls never exceed one cap (default 1)", async () => {
+      // Both routes hit the SAME shared cerebras key, so they must contend on
+      // ONE limiter. Interleave them and assert max-in-flight across BOTH ≤ 1.
+      const calls = [
+        fireNativeCall(), // /chat/completions
+        fireResponsesCall(), // /responses
+        fireNativeCall(), // /chat/completions
+        fireResponsesCall(), // /responses
+      ];
+      await flush();
+
+      // Default cap 1 -> only ONE round-trip in flight regardless of route.
+      expect(transport.inFlight).toBe(1);
+      expect(transport.maxInFlight).toBe(1);
+
+      // Drain one-by-one; each release admits the next, whichever route it is.
+      for (let i = 0; i < 4; i++) {
+        expect(transport.pending.length).toBe(1);
+        transport.pending.shift()?.resolve(okResponse());
+        await flush();
+      }
+
+      await Promise.all(calls);
+      // The /responses path was NEVER able to bypass the cap.
+      expect(transport.maxInFlight).toBe(1);
+      expect(requestRaw).toHaveBeenCalledTimes(4);
+    });
+
+    it("interleaved routes respect a raised cap of 2", async () => {
+      process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "2";
+      __resetNativeChatLimiterForTests();
+
+      const calls = [
+        fireResponsesCall(),
+        fireNativeCall(),
+        fireResponsesCall(),
+        fireNativeCall(),
+        fireResponsesCall(),
+      ];
+      await flush();
+
+      // Cap 2 across BOTH routes combined.
+      expect(transport.inFlight).toBe(2);
+      expect(transport.maxInFlight).toBe(2);
+
+      while (transport.pending.length > 0) {
+        transport.pending.shift()?.resolve(okResponse());
+        await flush();
+      }
+
+      await Promise.all(calls);
+      expect(transport.maxInFlight).toBe(2);
+    });
   });
 });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -10,6 +10,7 @@ import {
   ModelType,
   renderChatMessagesForPrompt,
   resolveEffectiveSystemPrompt,
+  Semaphore,
 } from "@elizaos/core";
 import type { LanguageModel } from "ai";
 import { createOpenAIClient } from "../providers/openai";
@@ -35,6 +36,47 @@ const TEXT_MEGA_MODEL_TYPE = (ModelType.TEXT_MEGA ?? "TEXT_MEGA") as ModelTypeNa
 const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ??
   "RESPONSE_HANDLER") as ModelTypeName;
 const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ?? "ACTION_PLANNER") as ModelTypeName;
+
+/**
+ * Per-process cap on CONCURRENT native cerebras `/chat/completions` calls.
+ *
+ * A single chat turn fans providers out via composeState's `Promise.all`
+ * (core runtime.ts), and each provider can call `useModel` -> here. Firing them
+ * all at once overruns the ONE shared cerebras key's concurrent-request limit
+ * -> 429 -> 3 retries x backoff -> 30-63s of latency. Serializing the per-turn
+ * burst through a small semaphore keeps each call ~3s with no 429, without
+ * needing more keys or backend changes.
+ *
+ * Tunable via `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` (integer, default 1 = fully
+ * serialize; set 2 for mild parallelism). Embeddings use a SEPARATE
+ * `/embeddings` route (embeddings.ts) and are intentionally NOT gated here.
+ */
+const NATIVE_CONCURRENCY_ENV = "ELIZAOS_CLOUD_NATIVE_CONCURRENCY";
+const DEFAULT_NATIVE_CONCURRENCY = 1;
+
+let nativeChatLimiter: Semaphore | null = null;
+
+function resolveNativeConcurrency(): number {
+  const raw =
+    typeof process !== "undefined" ? process.env[NATIVE_CONCURRENCY_ENV] : undefined;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_NATIVE_CONCURRENCY;
+}
+
+function getNativeChatLimiter(): Semaphore {
+  if (!nativeChatLimiter) {
+    nativeChatLimiter = new Semaphore(resolveNativeConcurrency());
+  }
+  return nativeChatLimiter;
+}
+
+/**
+ * Test-only: discard the cached limiter so the next call re-reads the env knob.
+ * Production code never needs this — the knob is read once per process.
+ */
+export function __resetNativeChatLimiterForTests(): void {
+  nativeChatLimiter = null;
+}
 
 type ResponsesApiResponse = Record<string, unknown> & {
   error?: {
@@ -869,7 +911,9 @@ async function generateTextWithModel(
   return text;
 }
 
-async function generateNativeChatCompletion(
+// Exported for unit tests (the concurrency limiter wrapper). Not part of the
+// plugin's public model-handler surface.
+export async function generateNativeChatCompletion(
   runtime: IAgentRuntime,
   modelType: TextModelType,
   params: GenerateTextParamsWithNativeOptions,
@@ -900,10 +944,23 @@ async function generateNativeChatCompletion(
       headers["x-eliza-span-samplers"] = samplerHeader;
     }
   }
-  const response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
-    headers,
-    json: requestBody,
-  });
+  // Serialize the per-turn composeState burst through a small semaphore so N
+  // simultaneous useModel calls don't overrun the one shared cerebras key's
+  // concurrent limit (-> 429 -> retries -> 30-63s). Hold the permit only across
+  // the network round-trip; release the instant the server responds (the
+  // text()/JSON parse below runs unguarded). `finally` frees the permit even on
+  // throw so a failed call never starves the queue.
+  const limiter = getNativeChatLimiter();
+  await limiter.acquire();
+  let response: Response;
+  try {
+    response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
+      headers,
+      json: requestBody,
+    });
+  } finally {
+    limiter.release();
+  }
   const responseText = await response.text();
   let data: ChatCompletionsResponse = {};
   if (responseText) {

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -38,18 +38,30 @@ const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ??
 const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ?? "ACTION_PLANNER") as ModelTypeName;
 
 /**
- * Per-process cap on CONCURRENT native cerebras `/chat/completions` calls.
+ * Per-process cap on CONCURRENT native cloud text calls.
  *
- * A single chat turn fans providers out via composeState's `Promise.all`
- * (core runtime.ts), and each provider can call `useModel` -> here. Firing them
- * all at once overruns the ONE shared cerebras key's concurrent-request limit
- * -> 429 -> 3 retries x backoff -> 30-63s of latency. Serializing the per-turn
- * burst through a small semaphore keeps each call ~3s with no 429, without
- * needing more keys or backend changes.
+ * Covers BOTH native cloud text routes that share the one cerebras key:
+ * the `/chat/completions` round-trip (native-transport callers) AND the
+ * `/responses` round-trip (bare-`{ prompt }` callers, incl. the primary reply
+ * action). Same model name -> same shared key -> same concurrency budget, so
+ * both routes must funnel through this one semaphore or a bare-prompt call can
+ * still push the key over its limit.
  *
- * Tunable via `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` (integer, default 1 = fully
- * serialize; set 2 for mild parallelism). Embeddings use a SEPARATE
- * `/embeddings` route (embeddings.ts) and are intentionally NOT gated here.
+ * The per-turn burst that triggers the 429 comes from the prompt BATCHER
+ * (`dynamicPromptExecFromState`, which always sets providerOptions -> native
+ * `/chat/completions`) and the merged evaluator call — NOT from composeState
+ * providers (no provider calls `useModel` during composeState). Firing those
+ * at once overruns the ONE shared cerebras key's concurrent-request limit
+ * -> 429 -> 3 retries x backoff -> 30-63s of latency. Serializing them through
+ * a small semaphore keeps each call ~3s with no 429, without needing more keys
+ * or backend changes.
+ *
+ * Trade-off: this serializes ALL native cloud text calls in the process (the
+ * right default for the cerebras-bottlenecked dedicated-agent default of 1).
+ * Non-cerebras deployments can raise `ELIZAOS_CLOUD_NATIVE_CONCURRENCY`
+ * (integer, default 1 = fully serialize; set 2+ for parallelism). Embeddings
+ * use a SEPARATE `/embeddings` route (embeddings.ts) and are intentionally NOT
+ * gated here.
  */
 const NATIVE_CONCURRENCY_ENV = "ELIZAOS_CLOUD_NATIVE_CONCURRENCY";
 const DEFAULT_NATIVE_CONCURRENCY = 1;
@@ -68,6 +80,26 @@ function getNativeChatLimiter(): Semaphore {
     nativeChatLimiter = new Semaphore(resolveNativeConcurrency());
   }
   return nativeChatLimiter;
+}
+
+/**
+ * Run a single cerebras-bound network round-trip under the shared per-process
+ * concurrency cap. Hold the permit only across `fn` (the `requestRaw` call);
+ * release the instant the server responds so response-body parsing runs
+ * unguarded. `finally` frees the permit even on throw so a failed call never
+ * starves the queue. Used by BOTH native text routes (`/chat/completions` and
+ * `/responses`) so every cerebras text call shares one budget.
+ *
+ * Exported for unit tests that drive the shared cap directly.
+ */
+export async function withNativeChatLimit<T>(fn: () => Promise<T>): Promise<T> {
+  const limiter = getNativeChatLimiter();
+  await limiter.acquire();
+  try {
+    return await fn();
+  } finally {
+    limiter.release();
+  }
 }
 
 /**
@@ -848,10 +880,14 @@ async function generateTextWithModel(
       responsesHeaders["x-eliza-span-samplers"] = samplerHeader;
     }
   }
-  const response = await createCloudApiClient(runtime).requestRaw("POST", "/responses", {
-    headers: responsesHeaders,
-    json: requestBody,
-  });
+  // Same shared cerebras key as the /chat/completions route, so gate this
+  // bare-prompt round-trip through the SAME limiter (parsing stays unguarded).
+  const response = await withNativeChatLimit(() =>
+    createCloudApiClient(runtime).requestRaw("POST", "/responses", {
+      headers: responsesHeaders,
+      json: requestBody,
+    })
+  );
   const responseText = await response.text();
   let data: ResponsesApiResponse = {};
   if (responseText) {
@@ -944,23 +980,17 @@ export async function generateNativeChatCompletion(
       headers["x-eliza-span-samplers"] = samplerHeader;
     }
   }
-  // Serialize the per-turn composeState burst through a small semaphore so N
-  // simultaneous useModel calls don't overrun the one shared cerebras key's
-  // concurrent limit (-> 429 -> retries -> 30-63s). Hold the permit only across
-  // the network round-trip; release the instant the server responds (the
-  // text()/JSON parse below runs unguarded). `finally` frees the permit even on
-  // throw so a failed call never starves the queue.
-  const limiter = getNativeChatLimiter();
-  await limiter.acquire();
-  let response: Response;
-  try {
-    response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
+  // Serialize the per-turn batcher/evaluator burst through the SAME shared
+  // semaphore the /responses route uses, so N simultaneous native cloud text
+  // calls don't overrun the one shared cerebras key's concurrent limit (-> 429
+  // -> retries -> 30-63s). The permit is held only across the network
+  // round-trip; the text()/JSON parse below runs unguarded.
+  const response = await withNativeChatLimit(() =>
+    createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
       headers,
       json: requestBody,
-    });
-  } finally {
-    limiter.release();
-  }
+    })
+  );
   const responseText = await response.text();
   let data: ChatCompletionsResponse = {};
   if (responseText) {


### PR DESCRIPTION
## What
Adds a per-process concurrency limiter around the dedicated agent's native cerebras `/chat/completions` calls. Default **1** (serialize), configurable via `ELIZAOS_CLOUD_NATIVE_CONCURRENCY`.

## Why (root-caused against prod)
A single chat turn fans providers out **concurrently** via `composeState`'s `Promise.all` (`core runtime.ts`), and each provider's `.get()` can call `runtime.useModel` → `generateNativeChatCompletion` → one **shared** cerebras key. N simultaneous requests overrun that key's **concurrent-request** ceiling → `429 Too Many Requests` → 3 retries × backoff → the observed **30-63s** + "model provider is rate-limited" replies.

Proven it's **concurrency, not a per-minute rate**: a *single* chat turn after a 45s idle gap 429s, while a lone direct inference is 3s/200. Serializing the per-turn burst keeps each call ~3s with **no 429** — and fixes latency **without** needing more cerebras keys.

## How
- Reuse `@elizaos/core`'s `Semaphore`; module-level singleton reads the env knob once (default 1; non-finite/≤0 → 1).
- Wrap **only** the `requestRaw("POST", "/chat/completions", …)` round-trip in `acquire()`/`finally release()`; `response.text()`/JSON parse stay **outside** the guard (permit freed the instant the server responds).
- **Embeddings** (`/embeddings`) and the `/responses` path are untouched.

Complements #8735 (round-robin keys) and #8754 (lean plugins) — this is the code-level fix that works **even with one key**.

## Tests
8 (vitest, no live API): cap at 1 and 2, FIFO admission, permit released on rejection, knob parsing. Typecheck + biome clean.

@cloud-agent (plugin-elizacloud owner) — this is the latency fix that doesn't depend on shaw's cerebras capacity; tune `ELIZAOS_CLOUD_NATIVE_CONCURRENCY=2` if you want mild parallelism once multi-key lands. Refs #8434.