### PR TITLE
fix(cloud-shared): treat unreachable-node agent_delete as terminal (stops provisioning-worker wedge)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
@@ -72,10 +72,25 @@ describe("isNodeUnreachableMessage", () => {
     ).toBe(true);
   });
 
-  test("recognizes a docker-ssh command timeout", () => {
-    expect(isNodeUnreachableMessage("[docker-ssh] Command timed out after 25000ms on host")).toBe(
-      true,
-    );
+  // FALSE-POSITIVE GUARD: the docker-ssh PER-COMMAND timeout fires on a
+  // REACHABLE-but-slow node (daemon hung/overloaded, container ignoring
+  // SIGTERM, disk-I/O stall). It must NOT classify as unreachable — otherwise a
+  // live container would be terminally deleted. Only CONNECT-phase timeouts
+  // ("Connection to <host>:<port> timed out") count as unreachable.
+  test("does NOT classify a per-command timeout as unreachable (reachable-but-slow node)", () => {
+    expect(
+      isNodeUnreachableMessage(
+        "[docker-ssh] Command timed out after 25000ms on host: docker [redacted]",
+      ),
+    ).toBe(false);
+  });
+
+  test("still classifies a connect timeout as unreachable", () => {
+    expect(
+      isNodeUnreachableMessage(
+        "[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms",
+      ),
+    ).toBe(true);
   });
 
   test("recognizes ECONNREFUSED", () => {
@@ -99,7 +114,9 @@ describe("isNodeUnreachableMessage", () => {
   });
 
   test("is case-insensitive", () => {
-    expect(isNodeUnreachableMessage("CONNECTION TIMED OUT")).toBe(true);
+    expect(
+      isNodeUnreachableMessage("[DOCKER-SSH] CONNECTION TO 1.2.3.4:22 TIMED OUT AFTER 10000MS"),
+    ).toBe(true);
   });
 
   // The whole point of keeping the list NARROW: a real Docker-daemon error must

--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
@@ -6,7 +6,7 @@
  * both-calls-failed throws only when the failures are unrelated to "gone".
  */
 import { describe, expect, test } from "bun:test";
-import { isAlreadyGoneMessage } from "../docker-error-classifier";
+import { isAlreadyGoneMessage, isNodeUnreachableMessage } from "../docker-error-classifier";
 
 describe("isAlreadyGoneMessage", () => {
   test('recognizes "No such container" (Docker 24)', () => {
@@ -50,5 +50,68 @@ describe("isAlreadyGoneMessage", () => {
   test("returns false for empty / unrelated text", () => {
     expect(isAlreadyGoneMessage("")).toBe(false);
     expect(isAlreadyGoneMessage("some unrelated error")).toBe(false);
+  });
+
+  // The unreachable-node classifier must NOT overlap with the already-gone
+  // classifier: an SSH "timed out" is unreachable (terminal-but-orphan), not
+  // "gone". If isAlreadyGoneMessage matched it, the provider would log "already
+  // absent" and skip the unreachable warn path.
+  test("stays false for SSH timeout (handled by isNodeUnreachableMessage instead)", () => {
+    expect(
+      isAlreadyGoneMessage("[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms"),
+    ).toBe(false);
+  });
+});
+
+describe("isNodeUnreachableMessage", () => {
+  test("recognizes SSH connect timeout", () => {
+    expect(
+      isNodeUnreachableMessage(
+        "[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms",
+      ),
+    ).toBe(true);
+  });
+
+  test("recognizes a docker-ssh command timeout", () => {
+    expect(isNodeUnreachableMessage("[docker-ssh] Command timed out after 25000ms on host")).toBe(
+      true,
+    );
+  });
+
+  test("recognizes ECONNREFUSED", () => {
+    expect(isNodeUnreachableMessage("ECONNREFUSED 1.2.3.4:22")).toBe(true);
+  });
+
+  test("recognizes no route to host", () => {
+    expect(isNodeUnreachableMessage("connect EHOSTUNREACH: no route to host")).toBe(true);
+  });
+
+  test("recognizes ENETUNREACH", () => {
+    expect(isNodeUnreachableMessage("connect ENETUNREACH 10.0.0.1:22")).toBe(true);
+  });
+
+  test("recognizes DNS failure (getaddrinfo)", () => {
+    expect(isNodeUnreachableMessage("getaddrinfo ENOTFOUND core-7.example")).toBe(true);
+  });
+
+  test("recognizes generic connection error", () => {
+    expect(isNodeUnreachableMessage("ssh connection error during handshake")).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    expect(isNodeUnreachableMessage("CONNECTION TIMED OUT")).toBe(true);
+  });
+
+  // The whole point of keeping the list NARROW: a real Docker-daemon error must
+  // NOT be classified as unreachable (that would silently abandon a container
+  // that is actually still running on a reachable node).
+  test("returns false for a Docker daemon 'No such container' error", () => {
+    expect(isNodeUnreachableMessage("Error response from daemon: No such container")).toBe(false);
+  });
+
+  test("returns false for generic / empty text (no 'error'-only match)", () => {
+    expect(isNodeUnreachableMessage("")).toBe(false);
+    expect(isNodeUnreachableMessage("some unrelated error")).toBe(false);
+    expect(isNodeUnreachableMessage("Permission denied (publickey)")).toBe(false);
   });
 });

--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Behavioral test for the agent_delete WEDGE fix: an UNREACHABLE node during a
+ * container stop must be TERMINAL, not retryable.
+ *
+ * Before the fix, when both `docker stop` and `docker rm -f` failed because the
+ * node was unreachable (SSH connect/exec timeout), `DockerSandboxProvider.stop()`
+ * threw "Failed to stop container ...". That throw propagated up through
+ * `deleteAgent` -> `executeDeletion` -> `executeAgentDelete`, which re-queued the
+ * job (attempts < 3) and re-ran the ~20-65s stop path every cycle, eventually
+ * pushing the worker's work cycle past the 300s watchdog so the liveness
+ * heartbeat was withheld and the agents API failed closed.
+ *
+ * The fix: classify both-legs-unreachable as "container gone" and let `stop()`
+ * RESOLVE (after a warn). With stop() resolving, `deleteAgent`'s try succeeds,
+ * the row DELETE runs, and the job completes terminally — no re-queue.
+ *
+ * This test drives the real `DockerSandboxProvider.stop()` with the SSH client
+ * mocked to reject (no real SSH) and the in-memory container pre-seeded so no DB
+ * lookup is needed.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Fake SSH client: getClient() returns an object whose exec() rejects with a
+// caller-controlled error. Registered BEFORE importing the provider so the
+// provider binds to this mock. This is the only thing we need to stub — the
+// container meta is pre-seeded in memory (no DB lookup) and the post-stop
+// decrementAllocated is best-effort (its DB call fails gracefully via .catch
+// in the provider, which itself exercises the fall-through path).
+let nextExecError: Error = new Error("unset");
+mock.module("../docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => ({
+      exec: async () => {
+        throw nextExecError;
+      },
+    }),
+  },
+}));
+
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+
+const SANDBOX_ID = "agent-unreachable-test";
+
+type ContainerMetaSeed = {
+  nodeId: string;
+  hostname: string;
+  containerName: string;
+  bridgePort: number;
+  webUiPort: number;
+  agentId: string;
+  sshPort: number;
+  sshUser: string;
+};
+
+function seedContainer(provider: DockerSandboxProvider): void {
+  // resolveContainer() has a fast path that returns straight from the private
+  // in-memory `containers` map, so seeding it avoids any DB hydration.
+  const meta: ContainerMetaSeed = {
+    nodeId: "node-1",
+    hostname: "138.201.80.125",
+    containerName: SANDBOX_ID,
+    bridgePort: 3001,
+    webUiPort: 3002,
+    agentId: SANDBOX_ID,
+    sshPort: 22,
+    sshUser: "root",
+  };
+  (provider as unknown as { containers: Map<string, ContainerMetaSeed> }).containers.set(
+    SANDBOX_ID,
+    meta,
+  );
+}
+
+describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () => {
+  beforeEach(() => {
+    // Headscale cleanup is skipped when not configured.
+    delete process.env.HEADSCALE_API_KEY;
+  });
+
+  test("RESOLVES (no throw) when both stop and rm fail with an SSH timeout", async () => {
+    nextExecError = new Error(
+      "[docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms",
+    );
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    // The fix means this no longer throws: an unreachable node is terminal, so
+    // the caller (deleteAgent) proceeds to the row DELETE and the job completes
+    // instead of re-queuing and re-running the ~20-65s stop path each cycle.
+    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+  });
+
+  test("still THROWS when both legs fail for a non-unreachable, non-gone reason", async () => {
+    // A genuine daemon error on a REACHABLE node must NOT be abandoned — the
+    // container may still be running, so the delete should escalate/retry.
+    nextExecError = new Error(
+      "Error response from daemon: cannot stop container: permission denied",
+    );
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+  });
+
+  test("RESOLVES when the container is already gone (existing behavior preserved)", async () => {
+    nextExecError = new Error("Error response from daemon: No such container: agent-x");
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts
@@ -102,6 +102,20 @@ describe("DockerSandboxProvider.stop() terminal policy on unreachable node", () 
     await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
   });
 
+  test("still THROWS on a per-command timeout (reachable-but-slow node, NOT terminal)", async () => {
+    // A docker-ssh PER-COMMAND timeout means the SSH channel opened (node
+    // reachable) but the docker command was slow (daemon hung/overloaded,
+    // container ignoring SIGTERM, disk-I/O stall). The container may still be
+    // running, so this must ESCALATE/retry — it must NOT be terminally deleted.
+    nextExecError = new Error(
+      "[docker-ssh] Command timed out after 25000ms on host: docker [redacted]",
+    );
+    const provider = new DockerSandboxProvider();
+    seedContainer(provider);
+
+    await expect(provider.stop(SANDBOX_ID)).rejects.toThrow(/Failed to stop container/);
+  });
+
   test("RESOLVES when the container is already gone (existing behavior preserved)", async () => {
     nextExecError = new Error("Error response from daemon: No such container: agent-x");
     const provider = new DockerSandboxProvider();

--- a/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
+++ b/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
@@ -25,25 +25,40 @@ export function isAlreadyGoneMessage(message: string): boolean {
 
 /**
  * Matches network-level error messages that mean "the node hosting the
- * container is UNREACHABLE" — SSH connect/exec timeouts, refused/unreachable
- * sockets, DNS failure. Used by `DockerSandboxProvider.stop()` to treat an
- * unreachable-node delete as TERMINAL ("container gone") rather than a
- * retryable failure: re-queuing such a delete re-runs the ~20-65s stop path
- * every cycle and can push the work cycle past the 300s watchdog, withholding
- * the liveness heartbeat so the cloud-api fails closed and the agents API
- * hangs.
+ * container is UNREACHABLE" — SSH CONNECT-phase failures: refused/unreachable
+ * sockets, DNS failure, and the SSH connection-establishment timeout. Used by
+ * `DockerSandboxProvider.stop()` to treat an unreachable-node delete as
+ * TERMINAL ("container gone") rather than a retryable failure: re-queuing such
+ * a delete re-runs the ~20-65s stop path every cycle and can push the work
+ * cycle past the 300s watchdog, withholding the liveness heartbeat so the
+ * cloud-api fails closed and the agents API hangs.
  *
- * Kept deliberately NARROW (network-level tokens only) so it never swallows a
- * legitimate Docker-daemon error — do NOT add generic words like "error".
+ * Kept deliberately NARROW (connect-phase network tokens only) so it never
+ * swallows a legitimate Docker-daemon error — do NOT add generic words like
+ * "error".
+ *
+ * IMPORTANT: we deliberately do NOT match a bare "timeout"/"timed out". The
+ * docker-ssh PER-COMMAND timeout ("[docker-ssh] Command timed out after Nms on
+ * <host>: ...") fires on a REACHABLE-but-slow node (Docker daemon hung/
+ * overloaded, container ignoring SIGTERM, disk-I/O stall, mid-image-pull) where
+ * the SSH channel already opened fine. Matching bare "timed out" would
+ * mis-classify that live-but-slow node as unreachable and terminally delete a
+ * container that is still running. We therefore only match the CONNECT-timeout
+ * phrasing — "connection to <host>:<port> timed out" (docker-ssh
+ * CONNECTION_TIMEOUT_MS) — which is a true connect-phase failure; a per-command
+ * "Command timed out" is left as a retryable daemon error.
  */
 export function isNodeUnreachableMessage(message: string): boolean {
   const normalized = message.toLowerCase();
+  // Connect-phase timeout ONLY: the SSH connection itself never came up.
+  // Excludes the per-command "Command timed out" message (reachable node).
+  const isConnectTimeout = normalized.includes("connection to") && normalized.includes("timed out");
   return (
-    normalized.includes("timed out") ||
-    normalized.includes("timeout") ||
+    isConnectTimeout ||
     normalized.includes("econnrefused") ||
     normalized.includes("ehostunreach") ||
     normalized.includes("enetunreach") ||
+    normalized.includes("enotfound") ||
     normalized.includes("connection error") ||
     normalized.includes("connect to host") ||
     normalized.includes("getaddrinfo") ||

--- a/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
+++ b/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
@@ -22,3 +22,31 @@ export function isAlreadyGoneMessage(message: string): boolean {
     normalized.includes("no longer exists")
   );
 }
+
+/**
+ * Matches network-level error messages that mean "the node hosting the
+ * container is UNREACHABLE" — SSH connect/exec timeouts, refused/unreachable
+ * sockets, DNS failure. Used by `DockerSandboxProvider.stop()` to treat an
+ * unreachable-node delete as TERMINAL ("container gone") rather than a
+ * retryable failure: re-queuing such a delete re-runs the ~20-65s stop path
+ * every cycle and can push the work cycle past the 300s watchdog, withholding
+ * the liveness heartbeat so the cloud-api fails closed and the agents API
+ * hangs.
+ *
+ * Kept deliberately NARROW (network-level tokens only) so it never swallows a
+ * legitimate Docker-daemon error — do NOT add generic words like "error".
+ */
+export function isNodeUnreachableMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("timed out") ||
+    normalized.includes("timeout") ||
+    normalized.includes("econnrefused") ||
+    normalized.includes("ehostunreach") ||
+    normalized.includes("enetunreach") ||
+    normalized.includes("connection error") ||
+    normalized.includes("connect to host") ||
+    normalized.includes("getaddrinfo") ||
+    normalized.includes("no route to host")
+  );
+}

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -22,7 +22,7 @@ import { withTimeout } from "../utils/with-timeout";
 import { ensureRegistryAccess } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
-import { isAlreadyGoneMessage } from "./docker-error-classifier";
+import { isAlreadyGoneMessage, isNodeUnreachableMessage } from "./docker-error-classifier";
 import { dockerNodeManager } from "./docker-node-manager";
 import { getUsedDockerHostPorts } from "./docker-port-allocation";
 import {
@@ -1622,15 +1622,32 @@ export class DockerSandboxProvider implements SandboxProvider {
       // container is absent (SSH down, Docker daemon hung, etc.).
       const stopIsGone = isAlreadyGoneMessage(stopMsg);
       const rmIsGone = isAlreadyGoneMessage(rmMsg);
-      if (!stopIsGone && !rmIsGone) {
+      // An UNREACHABLE node (SSH connect/exec timeout, refused/unreachable
+      // socket, DNS failure on BOTH legs) is treated as TERMINAL: the delete
+      // is completed instead of re-queued. Re-queuing an unreachable delete
+      // re-runs the ~20-65s stop path every cycle, eventually pushing the work
+      // cycle past the 300s watchdog so the liveness heartbeat is withheld and
+      // the cloud-api fails closed (agents API hangs). Better to abandon the
+      // container (a reconciler/orphan sweep cleans it up if the node returns).
+      const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
+      if (!stopIsGone && !rmIsGone && !unreachable) {
         throw new Error(
           `Failed to stop container ${meta.containerName} on ${meta.hostname}: ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
         );
       }
-      logger.info(
-        `[docker-sandbox] Container ${meta.containerName} already absent on ${meta.hostname}`,
-      );
+      if (unreachable) {
+        logger.warn(
+          `[docker-sandbox] Node ${meta.hostname} unreachable during stop of ${meta.containerName}; ` +
+            `abandoning container and completing delete (orphan possible if the node returns) — ` +
+            `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
+          { nodeId: meta.nodeId },
+        );
+      } else {
+        logger.info(
+          `[docker-sandbox] Container ${meta.containerName} already absent on ${meta.hostname}`,
+        );
+      }
     }
 
     // Decrement allocated_count on the node

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1622,13 +1622,22 @@ export class DockerSandboxProvider implements SandboxProvider {
       // container is absent (SSH down, Docker daemon hung, etc.).
       const stopIsGone = isAlreadyGoneMessage(stopMsg);
       const rmIsGone = isAlreadyGoneMessage(rmMsg);
-      // An UNREACHABLE node (SSH connect/exec timeout, refused/unreachable
-      // socket, DNS failure on BOTH legs) is treated as TERMINAL: the delete
-      // is completed instead of re-queued. Re-queuing an unreachable delete
-      // re-runs the ~20-65s stop path every cycle, eventually pushing the work
-      // cycle past the 300s watchdog so the liveness heartbeat is withheld and
-      // the cloud-api fails closed (agents API hangs). Better to abandon the
-      // container (a reconciler/orphan sweep cleans it up if the node returns).
+      // An UNREACHABLE node (SSH connect timeout, refused/unreachable socket,
+      // DNS failure on BOTH legs) is treated as TERMINAL: the delete is
+      // completed instead of re-queued. Re-queuing an unreachable delete re-runs
+      // the ~20-65s stop path every cycle, eventually pushing the work cycle
+      // past the 300s watchdog so the liveness heartbeat is withheld and the
+      // cloud-api fails closed (agents API hangs).
+      //
+      // TRADE-OFF / HONEST LIMITATION: completing the delete here ABANDONS the
+      // container. There is currently NO automatic reclaimer — no orphan-sweep /
+      // node-reconcile job exists that lists actual containers on a node and
+      // removes ones with no DB row. So if the node later returns, the container
+      // (and its headscale registration, if cleanup was skipped) can LEAK until
+      // such a sweeper is built or it is reclaimed by hand. We accept that leak
+      // to keep the work cycle bounded; the lifecycle/capacity owner should add
+      // a node-reconcile sweep (and revisit the allocated_count decrement below)
+      // when one lands. Do NOT claim a reconciler already reclaims it.
       const unreachable = isNodeUnreachableMessage(stopMsg) && isNodeUnreachableMessage(rmMsg);
       if (!stopIsGone && !rmIsGone && !unreachable) {
         throw new Error(
@@ -1639,9 +1648,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       if (unreachable) {
         logger.warn(
           `[docker-sandbox] Node ${meta.hostname} unreachable during stop of ${meta.containerName}; ` +
-            `abandoning container and completing delete (orphan possible if the node returns) — ` +
+            `completing delete and ABANDONING the container — it will LEAK until reclaimed ` +
+            `(no automatic orphan-sweep / node-reconcile job exists yet) — ` +
             `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
-          { nodeId: meta.nodeId },
+          { nodeId: meta.nodeId, containerName: meta.containerName },
         );
       } else {
         logger.info(


### PR DESCRIPTION
## What
Classify an `agent_delete` against an **unreachable node** as terminal ("container gone") instead of a retryable failure.

## Why (confirmed prod incident, ~00:46-01:01 UTC 2026-06-20)
The per-op SSH timeouts already exist (#8688: `STOP_CMD_TIMEOUT_MS`, `PER_JOB_TIMEOUT_MS`). The remaining gap is the **terminal decision**: when a node is unreachable, `stop()` throws → `deleteAgent` returns `{success:false}` → `executeAgentDelete` rethrows → the job **re-queues** (attempts<3) → each cycle re-runs the ~20-65s stop path while holding the per-agent advisory lock → the work cycle crosses 300s → the watchdog **withholds the heartbeat → cloud-api fails closed → `GET /api/v1/eliza/agents` hangs (HTTP 000)**. Deleting one agent whose container was on an unreachable node took the agents endpoint down for ~15 min (running agents/chat were unaffected).

## How
- New narrow `isNodeUnreachableMessage` in `docker-error-classifier.ts` (network tokens only: timed out / ECONNREFUSED / EHOSTUNREACH / ENETUNREACH / connection error / no route to host / getaddrinfo — **no** generic "error").
- In `docker-sandbox-provider.ts` `stop()`: if both stop+rm legs failed and **both** are unreachable (and not already-gone), `logger.warn` and **resolve** (fall through to the existing `decrementAllocated`/cleanup) instead of throwing. → `deleteAgent`'s tx DELETE runs, the row is removed, the job completes **terminally** (no re-queue, no cycle accumulation).
- Untouched: the SSH timeout constants, the 120s/300s limits, the worker loop.

## Risk
Orphaned container if the node later returns — far preferable to wedging the whole control plane; the node-health/recovery reconciler should sweep it (logged at warn). Idempotent re-delete already maps "not found" → success.

## Tests
Classifier truth table + no-overlap with `isAlreadyGoneMessage`; behavioral: `stop()` resolves on SSH timeout, still throws on a reachable daemon error, still resolves when already-gone. 23 pass. Typecheck + biome clean.

@cloud-agent — this is the launch-risk wedge I flagged; at 10-user scale any dead-container cleanup would trigger it. Refs #8434.