### PR TITLE
fix(ui): sync persisted active-agent label on rename + cover the agent manager with tests

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudCompatAgent } from "../../api/client-types-cloud";
+
+const appMock = vi.hoisted(() => ({
+  value: {} as {
+    elizaCloudConnected: boolean;
+    setActionNotice: ReturnType<typeof vi.fn>;
+  },
+}));
+
+const clientMock = vi.hoisted(() => ({
+  getCloudCompatAgents: vi.fn(),
+  updateCloudCompatAgent: vi.fn(),
+  deleteCloudCompatAgent: vi.fn(),
+  suspendCloudCompatAgent: vi.fn(),
+  resumeCloudCompatAgent: vi.fn(),
+  selectOrProvisionCloudAgent: vi.fn(),
+}));
+
+const persistenceMock = vi.hoisted(() => ({
+  loadPersistedActiveServer: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+  // The rename path never calls this, but the component imports it — pass args
+  // through so any incidental call returns a record shaped like the real fn.
+  createPersistedActiveServer: vi.fn((args: Record<string, unknown>) => args),
+}));
+
+vi.mock("../../state", () => ({
+  useApp: () => appMock.value,
+}));
+
+vi.mock("../../api", () => ({
+  client: clientMock,
+}));
+
+vi.mock("../../api/client-cloud", () => ({
+  resolveCloudAgentApiBase: () => "https://agent.example.test",
+}));
+
+vi.mock("../../config/boot-config", () => ({
+  getBootConfig: () => ({ cloudApiBase: "https://www.elizacloud.ai" }),
+}));
+
+vi.mock("../../config/branding", () => ({
+  useBranding: () => ({ appName: "Eliza" }),
+}));
+
+vi.mock("../../state/persistence", () => persistenceMock);
+
+import { CloudAgentsSection } from "./CloudAgentsSection";
+
+function agent(overrides: Partial<CloudCompatAgent> = {}): CloudCompatAgent {
+  return {
+    agent_id: "agent-1",
+    agent_name: "Old Name",
+    node_id: null,
+    container_id: null,
+    headscale_ip: null,
+    bridge_url: null,
+    web_ui_url: null,
+    status: "running",
+    agent_config: {},
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    containerUrl: "",
+    webUiUrl: null,
+    database_status: "ready",
+    error_message: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+async function renderWithAgents(list: CloudCompatAgent[]) {
+  clientMock.getCloudCompatAgents.mockResolvedValue({
+    success: true,
+    data: list,
+  });
+  render(<CloudAgentsSection />);
+  // Wait for the initial refresh() to resolve and render the rows.
+  await waitFor(() =>
+    expect(
+      screen.getByTestId(`cloud-agent-rename-${list[0].agent_id}`),
+    ).toBeTruthy(),
+  );
+}
+
+describe("CloudAgentsSection rename", () => {
+  beforeEach(() => {
+    appMock.value = {
+      elizaCloudConnected: true,
+      setActionNotice: vi.fn(),
+    };
+    clientMock.getCloudCompatAgents.mockReset();
+    clientMock.updateCloudCompatAgent.mockReset();
+    persistenceMock.loadPersistedActiveServer.mockReset();
+    persistenceMock.savePersistedActiveServer.mockReset();
+    // No active cloud server by default → activeId === null.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Old Name",
+      accessToken: "tok",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renames an agent: calls updateCloudCompatAgent and shows the new name", async () => {
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "New Name" },
+    });
+    await renderWithAgents([agent()]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    const input = screen.getByTestId(
+      "cloud-agent-rename-input-agent-1",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "New Name" } });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(clientMock.updateCloudCompatAgent).toHaveBeenCalledWith(
+        "agent-1",
+        {
+          agentName: "New Name",
+        },
+      ),
+    );
+    // Row reconciles to the new name (editing closes, label updates).
+    await waitFor(() => expect(screen.getByText("New Name")).toBeTruthy());
+  });
+
+  it("is a no-op when the name is unchanged (no client call)", async () => {
+    await renderWithAgents([agent({ agent_name: "Same" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    // Leave the value as the current name and save.
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    expect(clientMock.updateCloudCompatAgent).not.toHaveBeenCalled();
+    // Editing closed back to the row view.
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agent-rename-agent-1")).toBeTruthy(),
+    );
+  });
+
+  it("is a no-op when the name is empty/whitespace (no client call)", async () => {
+    await renderWithAgents([agent({ agent_name: "Keep" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    const input = screen.getByTestId("cloud-agent-rename-input-agent-1");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    expect(clientMock.updateCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("reverts and surfaces an error when the rename fails", async () => {
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: false,
+      error: "boom",
+      data: { agentId: "agent-1", agentName: "" },
+    });
+    await renderWithAgents([agent({ agent_name: "Original" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "Attempt" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "boom",
+        "error",
+        expect.any(Number),
+      ),
+    );
+    // The active-server label must NOT be rewritten on a failed rename.
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+    // Cancel the (still-open) editor and confirm the row reverted to the
+    // original name — no optimistic name leaked into the list.
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-cancel-agent-1"));
+    await waitFor(() => expect(screen.getByText("Original")).toBeTruthy());
+    expect(screen.queryByText("Attempt")).toBeNull();
+  });
+
+  it("updates the persisted active-server label when renaming the active agent", async () => {
+    // agent-1 is the active cloud server.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Old Name",
+      accessToken: "tok",
+    });
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "Renamed Active" },
+    });
+    await renderWithAgents([agent({ agent_name: "Old Name" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "Renamed Active" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(persistenceMock.savePersistedActiveServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "cloud",
+          id: "cloud:agent-1",
+          label: "Renamed Active",
+        }),
+      ),
+    );
+  });
+
+  it("does NOT touch the persisted active server when renaming a non-active agent", async () => {
+    // The active server is a DIFFERENT agent (agent-2), so renaming agent-1
+    // must not rewrite the persisted label.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-2",
+      label: "Other",
+      accessToken: "tok",
+    });
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "New" },
+    });
+    await renderWithAgents([agent({ agent_id: "agent-1", agent_name: "A1" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "New" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(clientMock.updateCloudCompatAgent).toHaveBeenCalled(),
+    );
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -204,6 +204,15 @@ export function CloudAgentsSection() {
             a.agent_id === agent.agent_id ? { ...a, agent_name: name } : a,
           ),
         );
+        // If we just renamed the agent bound as the active cloud server, refresh
+        // the persisted label so the switcher/header reflect the new name without
+        // waiting for a re-bind (mirrors how switchTo/create set the label).
+        if (agent.agent_id === activeId) {
+          const active = loadPersistedActiveServer();
+          if (active?.kind === "cloud") {
+            savePersistedActiveServer({ ...active, label: name });
+          }
+        }
         setActionNotice(`Renamed to ${name}.`, "success", 3000);
         setEditingId(null);
       } catch (err) {
@@ -216,7 +225,7 @@ export function CloudAgentsSection() {
         setBusyId(null);
       }
     },
-    [editName, setActionNotice],
+    [editName, activeId, setActionNotice],
   );
 
   const setLocalStatus = useCallback((agentId: string, status: string) => {
@@ -331,6 +340,7 @@ export function CloudAgentsSection() {
                     }}
                     className="flex-1"
                     aria-label="Agent name"
+                    data-testid={`cloud-agent-rename-input-${agent.agent_id}`}
                     disabled={busy}
                     autoFocus
                   />
@@ -338,6 +348,7 @@ export function CloudAgentsSection() {
                     variant="default"
                     size="sm"
                     disabled={busy}
+                    data-testid={`cloud-agent-rename-save-${agent.agent_id}`}
                     onClick={() => void saveRename(agent)}
                   >
                     {busy ? "Saving…" : "Save"}
@@ -346,6 +357,7 @@ export function CloudAgentsSection() {
                     variant="ghost"
                     size="sm"
                     disabled={busy}
+                    data-testid={`cloud-agent-rename-cancel-${agent.agent_id}`}
                     onClick={() => setEditingId(null)}
                   >
                     Cancel
@@ -406,6 +418,7 @@ export function CloudAgentsSection() {
                       size="sm"
                       disabled={busy}
                       aria-label={`Rename ${agent.agent_name || agent.agent_id}`}
+                      data-testid={`cloud-agent-rename-${agent.agent_id}`}
                       onClick={() => startRename(agent)}
                     >
                       <Pencil className="h-4 w-4" aria-hidden />


### PR DESCRIPTION
## What
The in-Settings cloud agent manager (#8609) already has a rename affordance (pencil → inline input → Save/Cancel). This fixes a real gap in it and adds its first test coverage.

## Fixes
1. **Stale label after renaming the *active* agent.** `saveRename` called `updateCloudCompatAgent` but never updated the persisted active server, so renaming the currently-bound agent left the switcher/header showing the **old** name until a re-bind. Now, on a successful rename where `agent.agent_id === activeId`, it re-reads `loadPersistedActiveServer()` and `savePersistedActiveServer({ ...active, label: name })` (preserving id/apiBase/token) — mirroring how `switchTo`/create set the label.
2. **Testids** on the rename controls (`cloud-agent-rename-<id>`, `-input-`, `-save-`, `-cancel-`) for testability/automation.

## Tests
New `CloudAgentsSection.test.tsx` (none existed) — 6 tests: save calls `updateCloudCompatAgent(id, {agentName})` and the row reflects the new name; unchanged/empty name is a no-op; failure surfaces the error + reverts + never rewrites the active label; active-agent rename updates the persisted label; non-active rename leaves it untouched. **6/6 pass**, typecheck + biome clean.

(CI's red Format Check / lint-and-types are pre-existing develop-wide biome breakage in unrelated files, not this PR.)

Refs #8434.