### PR TITLE
perf(agent): exclude plugin-local-inference from lean-chat (cloud agents → fast cloud embeddings)

### DIFF
--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -161,6 +161,15 @@ export const LEAN_CHAT_EXCLUDED_PLUGINS: readonly string[] = [
   "agent-orchestrator",
   "@elizaos/plugin-agent-orchestrator",
   "@elizaos/plugin-gitpathologist",
+  // Cloud chat agents route models to Eliza Cloud (plugin-elizacloud), which
+  // serves TEXT_EMBEDDING via the fast 1536-dim cloud endpoint. plugin-local-
+  // inference otherwise wins the TEXT_EMBEDDING registration with an on-device
+  // gte-small GGUF that runs on the container's (contended) CPU — measured at
+  // 1.5–98s per batch and ~30s/turn on a dedicated agent, plus a 384↔1536
+  // dimension mismatch that drops every memory insert. A cloud agent has no
+  // local GPU and no reason to run local inference, so exclude it and let the
+  // cloud embedding handler serve TEXT_EMBEDDING.
+  "@elizaos/plugin-local-inference",
 ];
 
 /**


### PR DESCRIPTION
Cloud chat agents were running gte-small embeddings on the container CPU (1.5–98s/batch, ~30s/turn, + 384↔1536 dim mismatch dropping memory inserts) despite routing everything else to Eliza Cloud. Exclude plugin-local-inference from lean-chat so the cloud embedding handler serves TEXT_EMBEDDING. The last per-turn latency source after the cerebras paid-key + billing-deferral (#8759) fixes. Diagnosed via live container trace. cc @shawmakesmagic (#8730 lean-chat owner). Part of #8434.