### PR TITLE
fix(ui): recover from deleted/unreachable dedicated cloud agent instead of dead-ending

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -15,14 +15,27 @@ const clientMock = vi.hoisted(() => ({
   getFirstRunStatus: vi.fn(),
   getFirstRunOptions: vi.fn(),
   getConfig: vi.fn(),
+  getCloudCompatAgent: vi.fn(),
   hasToken: vi.fn(),
   getBaseUrl: vi.fn(() => ""),
   setBaseUrl: vi.fn(),
   setToken: vi.fn(),
 }));
 
+const cloudMock = vi.hoisted(() => ({
+  getCloudAuthToken: vi.fn(() => null as string | null),
+}));
+
 vi.mock("../api", () => ({
   client: clientMock,
+}));
+
+vi.mock("../api/client-cloud", () => ({
+  getCloudAuthToken: cloudMock.getCloudAuthToken,
+  // isDirectCloudSharedAgentBase is also imported by the module under test.
+  isDirectCloudSharedAgentBase: (url: string | null | undefined) =>
+    !!url &&
+    /\/api\/v1\/eliza\/agents\/[^/]+(?:\/bridge)?\/?$/.test(url.trim()),
 }));
 
 vi.mock("../platform", async (importOriginal) => ({
@@ -115,8 +128,13 @@ beforeEach(() => {
   });
   clientMock.getFirstRunOptions.mockResolvedValue(firstRunOptions());
   clientMock.getConfig.mockResolvedValue({});
+  clientMock.getCloudCompatAgent.mockResolvedValue({
+    success: true,
+    data: { agent_id: "agent-123" },
+  });
   clientMock.hasToken.mockReturnValue(false);
   clientMock.getBaseUrl.mockReturnValue("");
+  cloudMock.getCloudAuthToken.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -481,6 +499,271 @@ describe("runPollingBackend", () => {
 
     expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_AUTH_REQUIRED" });
     expect(clearPersistedActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("routes a DELETED dedicated cloud agent to agent selection instead of Backend Unreachable (outer 404)", async () => {
+    // Regression: a deleted/unreachable dedicated cloud agent
+    // (<id>.elizacloud.ai) 404'd the first auth poll and dead-ended on
+    // BACKEND_NOT_FOUND ("Backend Unreachable"). With a cloud token present and
+    // the control-plane confirming the agent is gone, clear the dead saved
+    // server and route to first-run agent selection.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    clientMock.getBaseUrl.mockReturnValue("https://agent-123.elizacloud.ai");
+    clientMock.hasToken.mockReturnValue(true);
+    cloudMock.getCloudAuthToken.mockReturnValue("cloud-token");
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Not Found"), {
+        kind: "http",
+        status: 404,
+        path: "/api/auth/status",
+      }),
+    );
+    // Control-plane confirms the agent no longer exists.
+    clientMock.getCloudCompatAgent.mockRejectedValue(
+      Object.assign(new Error("Not Found"), { kind: "http", status: 404 }),
+    );
+
+    const staleAgent = {
+      id: "cloud:agent-123",
+      kind: "cloud" as const,
+      label: "Dedicated agent",
+      apiBase: "https://agent-123.elizacloud.ai",
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: staleAgent,
+      restoredActiveServer: staleAgent,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clientMock.getCloudCompatAgent).toHaveBeenCalledWith("agent-123");
+    expect(clearPersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(clientMock.setBaseUrl).toHaveBeenCalledWith(null);
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_NOT_FOUND" });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
+  });
+
+  it("treats a STILL-EXISTING dedicated cloud agent's 404 as first-run-complete (outer 404)", async () => {
+    // Guard: when the control-plane confirms the dedicated agent still exists,
+    // the first-run-shell 404 means "no shell on a cloud agent" (first-run is
+    // done) — go to chat, do NOT clear the saved server.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    clientMock.getBaseUrl.mockReturnValue("https://agent-123.elizacloud.ai");
+    clientMock.hasToken.mockReturnValue(true);
+    cloudMock.getCloudAuthToken.mockReturnValue("cloud-token");
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Not Found"), {
+        kind: "http",
+        status: 404,
+        path: "/api/auth/status",
+      }),
+    );
+    clientMock.getCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agent_id: "agent-123" },
+    });
+
+    const agent = {
+      id: "cloud:agent-123",
+      kind: "cloud" as const,
+      label: "Dedicated agent",
+      apiBase: "https://agent-123.elizacloud.ai",
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: agent,
+      restoredActiveServer: agent,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clientMock.getCloudCompatAgent).toHaveBeenCalledWith("agent-123");
+    expect(clearPersistedActiveServer).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_NOT_FOUND" });
+    expect(deps.setFirstRunComplete).toHaveBeenCalledWith(true);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: true,
+    });
+  });
+
+  it("does NOT strand on Backend Unreachable when the agent lookup is inconclusive (no cloud token)", async () => {
+    // Without a cloud token we cannot verify the dedicated agent. Rather than
+    // wrongly clearing the saved server, fall back to the prior behaviour: the
+    // 404 is treated as first-run-complete (a dedicated cloud agent has no shell),
+    // never a hard "Backend Unreachable" dead-end.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    clientMock.getBaseUrl.mockReturnValue("https://agent-123.elizacloud.ai");
+    clientMock.hasToken.mockReturnValue(true);
+    cloudMock.getCloudAuthToken.mockReturnValue(null);
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Not Found"), {
+        kind: "http",
+        status: 404,
+        path: "/api/auth/status",
+      }),
+    );
+
+    const agent = {
+      id: "cloud:agent-123",
+      kind: "cloud" as const,
+      label: "Dedicated agent",
+      apiBase: "https://agent-123.elizacloud.ai",
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: agent,
+      restoredActiveServer: agent,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clientMock.getCloudCompatAgent).not.toHaveBeenCalled();
+    expect(clearPersistedActiveServer).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_NOT_FOUND" });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: true,
+    });
+  });
+
+  it("routes a DELETED dedicated cloud agent to agent selection from the options-fetch 404 (inner 404)", async () => {
+    // The inner first-run-options loop has its own 404 branch. A dedicated cloud
+    // agent that returns auth:ok + firstRun incomplete but 404s on options must
+    // verify + recover the same way as the outer catch.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    clientMock.getBaseUrl.mockReturnValue("https://agent-123.elizacloud.ai");
+    clientMock.hasToken.mockReturnValue(true);
+    cloudMock.getCloudAuthToken.mockReturnValue("cloud-token");
+    clientMock.getAuthStatus.mockResolvedValue({
+      required: false,
+      authenticated: true,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+    clientMock.getFirstRunStatus.mockResolvedValue({
+      complete: false,
+      cloudProvisioned: false,
+    });
+    clientMock.getFirstRunOptions.mockRejectedValue(
+      Object.assign(new Error("Not Found"), {
+        kind: "http",
+        status: 404,
+        path: "/api/first-run/options",
+      }),
+    );
+    clientMock.getCloudCompatAgent.mockRejectedValue(
+      Object.assign(new Error("Not Found"), { kind: "http", status: 404 }),
+    );
+
+    const staleAgent = {
+      id: "cloud:agent-123",
+      kind: "cloud" as const,
+      label: "Dedicated agent",
+      apiBase: "https://agent-123.elizacloud.ai",
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: staleAgent,
+      restoredActiveServer: staleAgent,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clientMock.getCloudCompatAgent).toHaveBeenCalledWith("agent-123");
+    expect(clearPersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_NOT_FOUND" });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
   });
 });
 

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -10,12 +10,18 @@ import { logger } from "@elizaos/logger";
 import { getStylePresets } from "@elizaos/shared";
 import type { FirstRunOptions } from "../api";
 import { client } from "../api";
-import { isDirectCloudSharedAgentBase } from "../api/client-cloud";
+import {
+  getCloudAuthToken,
+  isDirectCloudSharedAgentBase,
+} from "../api/client-cloud";
 import { getBackendStartupTimeoutMs, scanProviderCredentials } from "../bridge";
 import type { FirstRunRuntimeTarget } from "../first-run/runtime-target";
 import type { UiLanguage } from "../i18n";
 import { isAndroid, isIOS } from "../platform";
-import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
+import {
+  ELIZA_CLOUD_CONTROL_PLANE_HOSTS,
+  isElizaCloudControlPlaneAgentlessBase,
+} from "../utils/cloud-agent-base";
 import {
   asApiLikeError,
   clearPersistedSetupStep,
@@ -122,6 +128,94 @@ export function isRecoverableRemoteBase(args: {
     return false;
   }
   return true;
+}
+
+// Direct elizaCloud control-plane API base, used to verify an agent record when
+// a per-agent base 404s. Mirrors DEFAULT_DIRECT_CLOUD_API_BASE_URL in
+// api/client-cloud.ts and DIRECT_CLOUD_API_BASE in startup-phase-restore.ts;
+// kept inline because that constant is module-private.
+const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
+
+/**
+ * True when `value` is a DEDICATED cloud agent base — an agent that lives on its
+ * own `<agentId>.elizacloud.ai` subdomain (not the control-plane, not the shared
+ * REST adapter path). Such a base 404s on `/api/first-run*` like the shared
+ * adapter, but unlike the shared adapter it can also vanish entirely when the
+ * agent is deleted or its container is unreachable — in which case the 404 means
+ * "this agent is gone", not "first-run is complete". Mirrors the host-only check
+ * in api/client-base.ts (kept inline because that helper is module-private).
+ */
+function isDedicatedCloudAgentBase(value: string | null | undefined): boolean {
+  if (!value?.trim()) return false;
+  try {
+    const host = new URL(value.trim()).hostname.toLowerCase();
+    return (
+      host.endsWith(".elizacloud.ai") &&
+      !ELIZA_CLOUD_CONTROL_PLANE_HOSTS.has(host)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract the agent id from a dedicated cloud agent base
+ * (`https://<agentId>.elizacloud.ai`) — the left-most subdomain label. Returns
+ * null for any base that is not a dedicated cloud agent subdomain.
+ */
+function dedicatedCloudAgentIdFromBase(
+  value: string | null | undefined,
+): string | null {
+  if (!isDedicatedCloudAgentBase(value)) return null;
+  try {
+    const host = new URL((value as string).trim()).hostname.toLowerCase();
+    const label = host.slice(0, host.length - ".elizacloud.ai".length);
+    return label.includes(".")
+      ? label.slice(label.lastIndexOf(".") + 1)
+      : label;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A DEDICATED cloud agent base just 404'd on the first-run shell endpoints.
+ * That 404 is ambiguous: it is the normal "no first-run shell on a cloud agent"
+ * signal, OR the agent was deleted / its container is unreachable. Disambiguate
+ * by verifying the agent record against the control-plane with the cloud auth
+ * token (mirrors startup-phase-restore's `backfillCloudApiBase` probe).
+ *
+ * Returns true only when we positively confirm the agent is GONE (the lookup
+ * 404s or reports no agent). In that case the saved server is cleared and the
+ * caller routes to first-run agent selection instead of dead-ending on
+ * "Backend Unreachable". Returns false when the agent still exists (treat the
+ * original 404 as "first-run complete", same as the shared adapter) OR when we
+ * cannot verify (no token / lookup error other than absence) — never strand the
+ * user on an unprovable assumption.
+ */
+async function dedicatedCloudAgentIsGone(base: string): Promise<boolean> {
+  const agentId = dedicatedCloudAgentIdFromBase(base);
+  if (!agentId) return false;
+  if (!getCloudAuthToken(client)) return false;
+
+  const priorBaseUrl = client.getBaseUrl();
+  const priorToken = client.hasToken();
+  // getCloudCompatAgent resolves the control-plane via the client base, so point
+  // the client at the control-plane (the dedicated subdomain is not a direct
+  // cloud base and would route the lookup to the dead agent itself).
+  client.setBaseUrl(DIRECT_CLOUD_API_BASE);
+  try {
+    const res = await client.getCloudCompatAgent(agentId);
+    // success:false / no agent id => the agent record is absent (deleted).
+    return !res.success || !res.data?.agent_id;
+  } catch (err) {
+    // A 404 is the positive "agent is gone" signal. Any other failure
+    // (network blip, 5xx) is inconclusive — do not strand the user.
+    return asApiLikeError(err)?.status === 404;
+  } finally {
+    client.setBaseUrl(priorBaseUrl || null);
+    if (!priorToken) client.setToken(null);
+  }
 }
 
 export interface PollingBackendDeps {
@@ -291,6 +385,24 @@ export async function runPollingBackend(
     deadline = Date.now() + policy.backendTimeoutMs;
     attempts = 0;
     lastErr = null;
+  };
+
+  // Terminal recovery for a deleted/unreachable DEDICATED cloud agent: clear the
+  // dead saved server + per-agent base/token, then route to first-run agent
+  // selection (the user is still signed into Eliza Cloud — the cloud auth token
+  // lives in its own storage and is untouched) instead of dead-ending on
+  // "Backend Unreachable".
+  const recoverToAgentSelection = (why: string) => {
+    logger.warn(
+      { staleBase: client.getBaseUrl(), reason: why },
+      "[startup-phase-poll] abandoning the saved cloud agent; routing to agent selection",
+    );
+    clearPersistedActiveServer();
+    client.setBaseUrl(null);
+    client.setToken(null);
+    deps.setFirstRunComplete(false);
+    deps.setFirstRunLoading(false);
+    dispatch({ type: "BACKEND_REACHED", firstRunComplete: false });
   };
 
   while (!cancelled.current && effectRunRef.current === effectRunId) {
@@ -480,6 +592,24 @@ export async function runPollingBackend(
                 dispatch({ type: "BACKEND_REACHED", firstRunComplete: false });
                 return;
               }
+              if (isDedicatedCloudAgentBase(client.getBaseUrl())) {
+                // A dedicated cloud agent (<id>.elizacloud.ai) 404s on the
+                // first-run shell like the shared adapter — but it can also have
+                // been DELETED or be unreachable. Verify the record against the
+                // control-plane: if it is gone, clear the dead saved server and
+                // route to agent selection instead of "Backend Unreachable"; if
+                // it still exists, treat the 404 as first-run-complete.
+                if (await dedicatedCloudAgentIsGone(client.getBaseUrl())) {
+                  recoverToAgentSelection(
+                    "saved dedicated cloud agent is deleted / unreachable",
+                  );
+                  return;
+                }
+                deps.setFirstRunComplete(true);
+                deps.setFirstRunLoading(false);
+                dispatch({ type: "BACKEND_REACHED", firstRunComplete: true });
+                return;
+              }
               deps.setStartupError(describeBackendFailure(err, false));
               deps.setFirstRunLoading(false);
               dispatch({ type: "BACKEND_NOT_FOUND" });
@@ -574,6 +704,23 @@ export async function runPollingBackend(
           // first-run agent selection instead of "Backend Unreachable".
           deps.setFirstRunLoading(false);
           dispatch({ type: "BACKEND_REACHED", firstRunComplete: false });
+          return;
+        }
+        if (isDedicatedCloudAgentBase(client.getBaseUrl())) {
+          // A dedicated cloud agent (<id>.elizacloud.ai) 404s on the first-run
+          // shell — but it can also have been DELETED or be unreachable. Verify
+          // the record against the control-plane: if it is gone, clear the dead
+          // saved server and route to agent selection instead of "Backend
+          // Unreachable"; if it still exists, treat the 404 as first-run-complete.
+          if (await dedicatedCloudAgentIsGone(client.getBaseUrl())) {
+            recoverToAgentSelection(
+              "saved dedicated cloud agent is deleted / unreachable",
+            );
+            return;
+          }
+          deps.setFirstRunComplete(true);
+          deps.setFirstRunLoading(false);
+          dispatch({ type: "BACKEND_REACHED", firstRunComplete: true });
           return;
         }
         deps.setStartupError(describeBackendFailure(err, false));

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -16,14 +16,22 @@ const mocks = vi.hoisted(() => ({
   client: {
     abortConversationTurn: vi.fn(),
     createConversation: vi.fn(),
+    sendConversationMessage: vi.fn(),
     sendConversationMessageStream: vi.fn(),
     sendWsMessage: vi.fn(),
     stopCodingAgent: vi.fn(),
+    getBaseUrl: vi.fn(() => ""),
   },
 }));
 
 vi.mock("../api", () => ({
   client: mocks.client,
+}));
+
+vi.mock("../api/client-cloud", () => ({
+  isDirectCloudSharedAgentBase: (url: string | null | undefined) =>
+    !!url &&
+    /\/api\/v1\/eliza\/agents\/[^/]+(?:\/bridge)?\/?$/.test(url.trim()),
 }));
 
 function conversation(id: string, roomId: string): Conversation {
@@ -220,5 +228,121 @@ describe("useChatSend stop handling", () => {
       "room-new",
       "ui-chat-stop",
     );
+  });
+});
+
+function http404(): Error {
+  return Object.assign(new Error("Not Found"), { status: 404 });
+}
+
+function mockStream404() {
+  mocks.client.sendConversationMessageStream.mockRejectedValue(http404());
+}
+
+describe("useChatSend 404 recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+  });
+
+  it("keeps the user message + notifies when the agent is gone (cloud base createConversation 404)", async () => {
+    // Regression: on a cloud agent base a send-404 fell through to recreate the
+    // conversation, which ALSO 404s when the agent is deleted/unreachable — the
+    // old code silently dropped the user's message. Now it surfaces a notice and
+    // keeps the user bubble.
+    mockStream404();
+    mocks.client.createConversation.mockRejectedValue(http404());
+    mocks.client.getBaseUrl.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123",
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledTimes(1);
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("no longer reachable"),
+      "error",
+      expect.any(Number),
+    );
+    // The user message is preserved (only the empty assistant placeholder is
+    // dropped).
+    const remaining = deps.conversationMessagesRef.current;
+    expect(
+      remaining.some((m) => m.role === "user" && m.text === "hello there"),
+    ).toBe(true);
+    expect(
+      remaining.some((m) => m.role === "assistant" && !m.text.trim()),
+    ).toBe(false);
+  });
+
+  it("recreates the conversation and replays when only the conversation was deleted", async () => {
+    // The normal recoverable case: the conversation row was deleted but the
+    // agent is fine. createConversation succeeds, the message is replayed.
+    mockStream404();
+    mocks.client.createConversation.mockResolvedValue({
+      conversation: conversation("conv-new", "room-new"),
+    });
+    mocks.client.sendConversationMessage.mockResolvedValue({ text: "hi back" });
+    mocks.client.getBaseUrl.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123",
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+    expect(mocks.client.createConversation).toHaveBeenCalledTimes(1);
+    expect(mocks.client.sendConversationMessage).toHaveBeenCalledTimes(1);
+    const remaining = deps.conversationMessagesRef.current;
+    expect(
+      remaining.some((m) => m.role === "user" && m.text === "hello there"),
+    ).toBe(true);
+    expect(
+      remaining.some((m) => m.role === "assistant" && m.text === "hi back"),
+    ).toBe(true);
+  });
+
+  it("does NOT notify on a non-cloud base when createConversation 404s (preserves prior behaviour)", async () => {
+    mockStream404();
+    mocks.client.createConversation.mockRejectedValue(http404());
+    mocks.client.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+    // Prior behaviour: the empty assistant placeholder is dropped.
+    const remaining = deps.conversationMessagesRef.current;
+    expect(
+      remaining.some((m) => m.role === "assistant" && !m.text.trim()),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -15,6 +15,7 @@ import {
   client,
   type ImageAttachment,
 } from "../api";
+import { isDirectCloudSharedAgentBase } from "../api/client-cloud";
 import {
   expandSavedCustomCommand,
   loadSavedCustomCommands,
@@ -38,6 +39,35 @@ import {
 // ── Types ────────────────────────────────────────────────────────────
 
 const CONTEXT_ROUTING_METADATA_KEY = "__responseContext";
+
+/**
+ * True when the active client base is an Eliza Cloud agent — either the
+ * shared-runtime REST adapter (`/api/v1/eliza/agents/<id>`) or a dedicated agent
+ * on its own `<id>.elizacloud.ai` subdomain. A chat-send 404 against such a base
+ * is ambiguous: it can mean "the conversation was deleted" (recoverable by
+ * recreating the conversation) OR "the agent itself was deleted / is
+ * unreachable" — in which case recreating the conversation also 404s and the
+ * user's message must NOT be silently dropped.
+ */
+function isCloudAgentBase(value: string | null | undefined): boolean {
+  if (!value?.trim()) return false;
+  if (isDirectCloudSharedAgentBase(value)) return true;
+  try {
+    const host = new URL(value.trim()).hostname.toLowerCase();
+    // Dedicated agent subdomain (mirrors isDedicatedCloudAgentBase in
+    // api/client-base.ts; that helper is module-private). The control-plane
+    // hosts are excluded — they are not per-agent bases.
+    return (
+      host.endsWith(".elizacloud.ai") &&
+      host !== "api.elizacloud.ai" &&
+      host !== "elizacloud.ai" &&
+      host !== "www.elizacloud.ai" &&
+      host !== "dev.elizacloud.ai"
+    );
+  } catch {
+    return false;
+  }
+}
 
 interface ChatViewRouting {
   view: string;
@@ -903,6 +933,12 @@ export function useChatSend(deps: UseChatSendDeps) {
 
         const status = (err as { status?: number }).status;
         if (status === 404) {
+          // A 404 on send usually means the conversation row was deleted —
+          // recreate it and replay. But on an Eliza Cloud agent base the 404 can
+          // instead mean the AGENT itself was deleted / is unreachable, in which
+          // case createConversation() ALSO 404s. Distinguish the two so we don't
+          // silently drop the user's message on a dead agent.
+          let conversation: Conversation;
           try {
             const { conversation: rawConversation } =
               await client.createConversation();
@@ -911,7 +947,39 @@ export function useChatSend(deps: UseChatSendDeps) {
                 "Conversation creation returned an invalid payload.",
               );
             }
-            const conversation = rawConversation;
+            conversation = rawConversation;
+          } catch (createErr) {
+            const createStatus = (createErr as { status?: number }).status;
+            // Conversation recreation also failed against a cloud agent base —
+            // the agent is gone/unreachable. Surface the failure and KEEP the
+            // user's message (drop only the empty assistant placeholder) so the
+            // user can retry or re-select an agent instead of losing their text.
+            if (createStatus === 404 && isCloudAgentBase(client.getBaseUrl())) {
+              setActionNotice(
+                "This agent is no longer reachable — it may have been deleted. Your message was kept; pick another agent and try again.",
+                "error",
+                10_000,
+              );
+              setConversationMessages((prev) =>
+                prev.filter(
+                  (message) =>
+                    !(message.id === assistantMsgId && !message.text.trim()),
+                ),
+              );
+              return;
+            }
+            // Non-cloud base, or a different create failure — preserve the prior
+            // behaviour (drop the empty assistant placeholder).
+            setConversationMessages((prev) =>
+              prev.filter(
+                (message) =>
+                  !(message.id === assistantMsgId && !message.text.trim()),
+              ),
+            );
+            return;
+          }
+
+          try {
             const nextCutoffTs = Date.now();
             setConversations((prev) => [conversation, ...prev]);
             setActiveConversationId(conversation.id);
@@ -987,6 +1055,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       setCompanionMessageCutoffTs,
       setConversationMessages,
       setConversations,
+      setActionNotice,
       uiLanguage,
       elizaCloudEnabled,
       elizaCloudConnected,


### PR DESCRIPTION
From the lifecycle audit (#8434). **CRITICAL:** a deleted/unreachable *dedicated* cloud agent dead-ended on "Backend Unreachable" with no escape. Both 404 branches in `startup-phase-poll.ts` now detect a dedicated cloud base + auth token, verify via `getCloudCompatAgent`, and on absence `clearPersistedActiveServer()` + route to first-run agent-selection (mirrors the agentless-base recovery). **MAJOR:** `useChatSend.ts` chat-send 404 no longer silently drops the user's message when the agent itself is gone — it surfaces a notice + keeps the bubble. 27 tests (7 new).

_CI's red Format Check / lint-and-types are pre-existing develop-wide biome breakage in ~14 unrelated files, not this PR. This PR's own files pass biome + typecheck + tests. Refs #8434 (full lifecycle audit)._