### PR TITLE
fix(ui): cloud agent manager — direct-cloud suspend/resume, async-delete polling, error-vs-empty, status badges (supersedes #8761)

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -319,6 +319,181 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expectNoLocalPersistOrStatusProbe();
   });
 
+  it("suspends Cloud agents through the direct Cloud API host on native", async () => {
+    capacitorMocks.request.mockResolvedValue({
+      status: 202,
+      data: {
+        success: true,
+        data: {
+          agentId: "agent-1",
+          action: "suspend",
+          jobId: "job-suspend",
+          status: "queued",
+          message: "Suspend job created.",
+        },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    const result = await client.suspendCloudCompatAgent("agent-1");
+
+    expect(capacitorMocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/suspend",
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer cloud-api-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      data: {
+        jobId: "job-suspend",
+        status: "queued",
+        message: "Suspend job created.",
+      },
+    });
+    expectNoLocalPersistOrStatusProbe();
+  });
+
+  it("resumes Cloud agents through the direct Cloud API host on native", async () => {
+    capacitorMocks.request.mockResolvedValue({
+      status: 202,
+      data: {
+        success: true,
+        data: {
+          agentId: "agent-1",
+          action: "resume",
+          jobId: "job-resume",
+          status: "queued",
+          message: "Resume job created.",
+        },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    const result = await client.resumeCloudCompatAgent("agent-1");
+
+    expect(capacitorMocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/resume",
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer cloud-api-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      data: {
+        jobId: "job-resume",
+        status: "queued",
+        message: "Resume job created.",
+      },
+    });
+    expectNoLocalPersistOrStatusProbe();
+  });
+
+  it("restarts Cloud agents through the direct Cloud API host on native", async () => {
+    capacitorMocks.request.mockResolvedValue({
+      status: 202,
+      data: {
+        success: true,
+        data: { jobId: "job-restart", status: "queued" },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    const result = await client.restartCloudCompatAgent("agent-1");
+
+    expect(capacitorMocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/restart",
+        method: "POST",
+      }),
+    );
+    // The route omits a message, so the client fills in a sensible default.
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          jobId: "job-restart",
+          status: "queued",
+        }),
+      }),
+    );
+    expectNoLocalPersistOrStatusProbe();
+  });
+
+  it("surfaces the Cloud error body when a native suspend is rejected", async () => {
+    capacitorMocks.request.mockResolvedValue({
+      status: 404,
+      data: { success: false, error: "Agent not found" },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+
+    await expect(client.suspendCloudCompatAgent("agent-1")).rejects.toThrow(
+      "Cloud request failed (404): Agent not found",
+    );
+    expect(capacitorMocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1/suspend",
+        method: "POST",
+      }),
+    );
+    expectNoLocalPersistOrStatusProbe();
+  });
+
+  it("returns the auth-missing result for native lifecycle calls with no Cloud token", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("native lifecycle must not fetch"));
+
+    const client = new ElizaClient("http://localhost:31337");
+    const result = await client.resumeCloudCompatAgent("agent-1");
+
+    expect(result).toEqual({
+      success: false,
+      error: "Eliza Cloud login session is missing. Sign in again.",
+      data: {
+        jobId: "",
+        status: "auth-missing",
+        message: "Eliza Cloud login session is missing. Sign in again.",
+      },
+    });
+    expect(capacitorMocks.request).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("threads the 202 jobId through a native direct delete", async () => {
+    capacitorMocks.request.mockResolvedValue({
+      status: 202,
+      data: {
+        success: true,
+        data: {
+          jobId: "job-delete",
+          status: "deleting",
+          message: "Delete job created.",
+        },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    const result = await client.deleteCloudCompatAgent("agent-1");
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        jobId: "job-delete",
+        status: "deleting",
+        message: "Delete job created.",
+      },
+    });
+    expectNoLocalPersistOrStatusProbe();
+  });
+
   it("launches Cloud agents directly on native and returns the runtime token", async () => {
     capacitorMocks.request.mockResolvedValue({
       status: 200,

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -131,6 +131,9 @@ type DirectCloudAgentCreateData = {
   status: string;
 };
 
+/** Async-job envelope returned by the restart/suspend/resume lifecycle routes. */
+type LifecycleResult = { jobId: string; status: string; message: string };
+
 type ProvisioningAgentStatusData = {
   status?: string;
   bridgeUrl?: string | null;
@@ -995,6 +998,7 @@ declare module "./client-base" {
     getCloudCompatAgents(): Promise<{
       success: boolean;
       data: CloudCompatAgent[];
+      error?: string;
     }>;
     createCloudCompatAgent(opts: {
       agentName: string;
@@ -1117,6 +1121,7 @@ declare module "./client-base" {
     }>;
     deleteCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
+      error?: string;
       data: { jobId: string; status: string; message: string };
     }>;
     /**
@@ -2050,13 +2055,16 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
 ) {
   const normalizeDelete = (response: {
     success?: boolean;
-    data?: { message?: string; status?: string };
+    data?: { message?: string; status?: string; jobId?: string };
     error?: string;
   }) => ({
     success: response.success === true,
     ...(response.error ? { error: response.error } : {}),
     data: {
-      jobId: "",
+      // A 202 async delete carries a jobId the caller can poll
+      // (`/api/v1/jobs/<id>`) to learn whether the teardown actually
+      // completed. A synchronous delete returns no jobId.
+      jobId: response.data?.jobId ?? "",
       status:
         response.data?.status ??
         (response.success === true ? "deleted" : "error"),
@@ -2070,7 +2078,7 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
 
   const direct = await directCloudRequest<{
     success: boolean;
-    data?: { message?: string; status?: string };
+    data?: { message?: string; status?: string; jobId?: string };
     error?: string;
   }>(this, `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`, {
     method: "DELETE",
@@ -2092,7 +2100,7 @@ ElizaClient.prototype.deleteCloudCompatAgent = async function (
   if (isDirectCloudBase(this)) {
     const response = await this.fetch<{
       success: boolean;
-      data?: { message?: string; status?: string };
+      data?: { message?: string; status?: string; jobId?: string };
       error?: string;
     }>(
       `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`,
@@ -2280,34 +2288,105 @@ ElizaClient.prototype.getCloudCompatAgentLogs = async function (
   );
 };
 
+/**
+ * Normalize a cloud lifecycle (restart/suspend/resume) response into the
+ * `{ success, data: { jobId, status, message } }` shape the UI expects. The
+ * direct cloud routes return a 202 `{ success, data: { jobId, status,
+ * message } }` async-job envelope; the legacy proxy returns the same shape.
+ */
+function normalizeCloudLifecycleResponse(
+  response: {
+    success?: boolean;
+    data?: { jobId?: string; status?: string; message?: string };
+    error?: string;
+  },
+  fallbackVerb: string,
+): { success: boolean; error?: string; data: LifecycleResult } {
+  const success = response.success === true;
+  return {
+    success,
+    ...(response.error ? { error: response.error } : {}),
+    data: {
+      jobId: response.data?.jobId ?? "",
+      status: response.data?.status ?? (success ? "queued" : "error"),
+      message:
+        response.data?.message ??
+        (success
+          ? `Agent ${fallbackVerb} enqueued`
+          : (response.error ?? `Agent ${fallbackVerb} failed`)),
+    },
+  };
+}
+
+/**
+ * Drive a cloud agent lifecycle action (restart/suspend/resume) through the
+ * direct-cloud ladder — direct token request → native-auth-missing guard →
+ * direct-cloud-base same-origin fetch → legacy `/api/cloud/compat` proxy.
+ * Mirrors `deleteCloudCompatAgent` so the Power/Start buttons work on
+ * phone/web (which have no local API server proxying `/api/cloud/compat/...`).
+ */
+async function runCloudLifecycleAction(
+  client: ElizaClient,
+  agentId: string,
+  action: "restart" | "suspend" | "resume",
+): Promise<{ success: boolean; error?: string; data: LifecycleResult }> {
+  const encoded = encodeURIComponent(agentId);
+  const directPath = `/api/v1/eliza/agents/${encoded}/${action}`;
+
+  const direct = await directCloudRequest<{
+    success: boolean;
+    data?: { jobId?: string; status?: string; message?: string };
+    error?: string;
+  }>(client, directPath, { method: "POST" });
+  if (direct) return normalizeCloudLifecycleResponse(direct, action);
+
+  if (isNativeDirectCloudAuthMissing(client)) {
+    return {
+      success: false,
+      error: nativeDirectCloudAuthMissingMessage(),
+      data: {
+        jobId: "",
+        status: "auth-missing",
+        message: nativeDirectCloudAuthMissingMessage(),
+      },
+    };
+  }
+
+  if (isDirectCloudBase(client)) {
+    const response = await client.fetch<{
+      success: boolean;
+      data?: { jobId?: string; status?: string; message?: string };
+      error?: string;
+    }>(directPath, { method: "POST" }, { allowNonOk: true });
+    return normalizeCloudLifecycleResponse(response, action);
+  }
+
+  return client.fetch(
+    `/api/cloud/compat/agents/${encoded}/${action}`,
+    { method: "POST" },
+    { allowNonOk: true },
+  );
+}
+
 ElizaClient.prototype.restartCloudCompatAgent = async function (
   this: ElizaClient,
   agentId,
 ) {
-  return this.fetch(
-    `/api/cloud/compat/agents/${encodeURIComponent(agentId)}/restart`,
-    { method: "POST" },
-  );
+  return runCloudLifecycleAction(this, agentId, "restart");
 };
 
 ElizaClient.prototype.suspendCloudCompatAgent = async function (
   this: ElizaClient,
   agentId,
 ) {
-  return this.fetch(
-    `/api/cloud/compat/agents/${encodeURIComponent(agentId)}/suspend`,
-    { method: "POST" },
-  );
+  return runCloudLifecycleAction(this, agentId, "suspend");
 };
 
 ElizaClient.prototype.resumeCloudCompatAgent = async function (
   this: ElizaClient,
   agentId,
 ) {
-  return this.fetch(
-    `/api/cloud/compat/agents/${encodeURIComponent(agentId)}/resume`,
-    { method: "POST" },
-  );
+  return runCloudLifecycleAction(this, agentId, "resume");
 };
 
 ElizaClient.prototype.launchCloudCompatAgent = async function (

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudCompatAgent } from "../../api/client-types-cloud";
+
+const appMock = vi.hoisted(() => ({
+  value: {} as {
+    elizaCloudConnected: boolean;
+    setActionNotice: ReturnType<typeof vi.fn>;
+  },
+}));
+
+const clientMock = vi.hoisted(() => ({
+  getCloudCompatAgents: vi.fn(),
+  updateCloudCompatAgent: vi.fn(),
+  deleteCloudCompatAgent: vi.fn(),
+  suspendCloudCompatAgent: vi.fn(),
+  resumeCloudCompatAgent: vi.fn(),
+  selectOrProvisionCloudAgent: vi.fn(),
+}));
+
+const persistenceMock = vi.hoisted(() => ({
+  loadPersistedActiveServer: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+  // The rename path never calls this, but the component imports it — pass args
+  // through so any incidental call returns a record shaped like the real fn.
+  createPersistedActiveServer: vi.fn((args: Record<string, unknown>) => args),
+}));
+
+vi.mock("../../state", () => ({
+  useApp: () => appMock.value,
+}));
+
+vi.mock("../../api", () => ({
+  client: clientMock,
+}));
+
+vi.mock("../../api/client-cloud", () => ({
+  resolveCloudAgentApiBase: () => "https://agent.example.test",
+}));
+
+vi.mock("../../config/boot-config", () => ({
+  getBootConfig: () => ({ cloudApiBase: "https://www.elizacloud.ai" }),
+}));
+
+vi.mock("../../config/branding", () => ({
+  useBranding: () => ({ appName: "Eliza" }),
+}));
+
+vi.mock("../../state/persistence", () => persistenceMock);
+
+import { CloudAgentsSection } from "./CloudAgentsSection";
+
+function agent(overrides: Partial<CloudCompatAgent> = {}): CloudCompatAgent {
+  return {
+    agent_id: "agent-1",
+    agent_name: "Old Name",
+    node_id: null,
+    container_id: null,
+    headscale_ip: null,
+    bridge_url: null,
+    web_ui_url: null,
+    status: "running",
+    agent_config: {},
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    containerUrl: "",
+    webUiUrl: null,
+    database_status: "ready",
+    error_message: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+async function renderWithAgents(list: CloudCompatAgent[]) {
+  clientMock.getCloudCompatAgents.mockResolvedValue({
+    success: true,
+    data: list,
+  });
+  render(<CloudAgentsSection />);
+  // Wait for the initial refresh() to resolve and render the rows.
+  await waitFor(() =>
+    expect(
+      screen.getByTestId(`cloud-agent-rename-${list[0].agent_id}`),
+    ).toBeTruthy(),
+  );
+}
+
+describe("CloudAgentsSection rename", () => {
+  beforeEach(() => {
+    appMock.value = {
+      elizaCloudConnected: true,
+      setActionNotice: vi.fn(),
+    };
+    clientMock.getCloudCompatAgents.mockReset();
+    clientMock.updateCloudCompatAgent.mockReset();
+    persistenceMock.loadPersistedActiveServer.mockReset();
+    persistenceMock.savePersistedActiveServer.mockReset();
+    // No active cloud server by default → activeId === null.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Old Name",
+      accessToken: "tok",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renames an agent: calls updateCloudCompatAgent and shows the new name", async () => {
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "New Name" },
+    });
+    await renderWithAgents([agent()]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    const input = screen.getByTestId(
+      "cloud-agent-rename-input-agent-1",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "New Name" } });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(clientMock.updateCloudCompatAgent).toHaveBeenCalledWith(
+        "agent-1",
+        {
+          agentName: "New Name",
+        },
+      ),
+    );
+    // Row reconciles to the new name (editing closes, label updates).
+    await waitFor(() => expect(screen.getByText("New Name")).toBeTruthy());
+  });
+
+  it("is a no-op when the name is unchanged (no client call)", async () => {
+    await renderWithAgents([agent({ agent_name: "Same" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    // Leave the value as the current name and save.
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    expect(clientMock.updateCloudCompatAgent).not.toHaveBeenCalled();
+    // Editing closed back to the row view.
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agent-rename-agent-1")).toBeTruthy(),
+    );
+  });
+
+  it("is a no-op when the name is empty/whitespace (no client call)", async () => {
+    await renderWithAgents([agent({ agent_name: "Keep" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    const input = screen.getByTestId("cloud-agent-rename-input-agent-1");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    expect(clientMock.updateCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("reverts and surfaces an error when the rename fails", async () => {
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: false,
+      error: "boom",
+      data: { agentId: "agent-1", agentName: "" },
+    });
+    await renderWithAgents([agent({ agent_name: "Original" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "Attempt" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "boom",
+        "error",
+        expect.any(Number),
+      ),
+    );
+    // The active-server label must NOT be rewritten on a failed rename.
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+    // Cancel the (still-open) editor and confirm the row reverted to the
+    // original name — no optimistic name leaked into the list.
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-cancel-agent-1"));
+    await waitFor(() => expect(screen.getByText("Original")).toBeTruthy());
+    expect(screen.queryByText("Attempt")).toBeNull();
+  });
+
+  it("updates the persisted active-server label when renaming the active agent", async () => {
+    // agent-1 is the active cloud server.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-1",
+      label: "Old Name",
+      accessToken: "tok",
+    });
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "Renamed Active" },
+    });
+    await renderWithAgents([agent({ agent_name: "Old Name" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "Renamed Active" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(persistenceMock.savePersistedActiveServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "cloud",
+          id: "cloud:agent-1",
+          label: "Renamed Active",
+        }),
+      ),
+    );
+  });
+
+  it("does NOT touch the persisted active server when renaming a non-active agent", async () => {
+    // The active server is a DIFFERENT agent (agent-2), so renaming agent-1
+    // must not rewrite the persisted label.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:agent-2",
+      label: "Other",
+      accessToken: "tok",
+    });
+    clientMock.updateCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", agentName: "New" },
+    });
+    await renderWithAgents([agent({ agent_id: "agent-1", agent_name: "A1" })]);
+
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-agent-1"));
+    fireEvent.change(screen.getByTestId("cloud-agent-rename-input-agent-1"), {
+      target: { value: "New" },
+    });
+    fireEvent.click(screen.getByTestId("cloud-agent-rename-save-agent-1"));
+
+    await waitFor(() =>
+      expect(clientMock.updateCloudCompatAgent).toHaveBeenCalled(),
+    );
+    expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -23,6 +23,7 @@ const clientMock = vi.hoisted(() => ({
   deleteCloudCompatAgent: vi.fn(),
   suspendCloudCompatAgent: vi.fn(),
   resumeCloudCompatAgent: vi.fn(),
+  getCloudCompatJobStatus: vi.fn(),
   selectOrProvisionCloudAgent: vi.fn(),
 }));
 
@@ -254,5 +255,282 @@ describe("CloudAgentsSection rename", () => {
       expect(clientMock.updateCloudCompatAgent).toHaveBeenCalled(),
     );
     expect(persistenceMock.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
+});
+
+/** Shared mock setup for the lifecycle / load-state suites below. */
+function resetClientMocks() {
+  clientMock.getCloudCompatAgents.mockReset();
+  clientMock.deleteCloudCompatAgent.mockReset();
+  clientMock.suspendCloudCompatAgent.mockReset();
+  clientMock.resumeCloudCompatAgent.mockReset();
+  clientMock.getCloudCompatJobStatus.mockReset();
+  persistenceMock.loadPersistedActiveServer.mockReset();
+  persistenceMock.savePersistedActiveServer.mockReset();
+}
+
+describe("CloudAgentsSection lifecycle (suspend/resume)", () => {
+  beforeEach(() => {
+    appMock.value = { elizaCloudConnected: true, setActionNotice: vi.fn() };
+    resetClientMocks();
+    // The active server is a DIFFERENT agent so the row's Power/Start buttons
+    // are not gated by the active-agent guard.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:other",
+      label: "Other",
+      accessToken: "tok",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("suspends a running agent via the (direct-path) client call", async () => {
+    clientMock.suspendCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-s", status: "queued", message: "Suspend enqueued" },
+    });
+    await renderWithAgents([agent({ status: "running" })]);
+
+    fireEvent.click(
+      screen.getByLabelText("Shut down Old Name", { selector: "button" }),
+    );
+
+    await waitFor(() =>
+      expect(clientMock.suspendCloudCompatAgent).toHaveBeenCalledWith(
+        "agent-1",
+      ),
+    );
+    // Optimistic transition + success notice.
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        expect.stringContaining("Shutting down"),
+        "success",
+        expect.any(Number),
+      ),
+    );
+  });
+
+  it("surfaces an error when suspend fails (e.g. 404 with no direct path)", async () => {
+    clientMock.suspendCloudCompatAgent.mockResolvedValue({
+      success: false,
+      error: "Not found",
+      data: { jobId: "", status: "error", message: "Not found" },
+    });
+    await renderWithAgents([agent({ status: "running" })]);
+
+    fireEvent.click(
+      screen.getByLabelText("Shut down Old Name", { selector: "button" }),
+    );
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        expect.any(String),
+        "error",
+        expect.any(Number),
+      ),
+    );
+  });
+
+  it("resumes a stopped agent via the (direct-path) client call", async () => {
+    clientMock.resumeCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-r", status: "queued", message: "Resume enqueued" },
+    });
+    await renderWithAgents([agent({ status: "stopped" })]);
+
+    fireEvent.click(
+      screen.getByLabelText("Start Old Name", { selector: "button" }),
+    );
+
+    await waitFor(() =>
+      expect(clientMock.resumeCloudCompatAgent).toHaveBeenCalledWith("agent-1"),
+    );
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        expect.stringContaining("Starting"),
+        "success",
+        expect.any(Number),
+      ),
+    );
+  });
+});
+
+describe("CloudAgentsSection delete (job polling)", () => {
+  beforeEach(() => {
+    appMock.value = { elizaCloudConnected: true, setActionNotice: vi.fn() };
+    resetClientMocks();
+    // The active server is a DIFFERENT agent so delete is not disabled.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:other",
+      label: "Other",
+      accessToken: "tok",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("polls the delete job and removes the row only once completed", async () => {
+    clientMock.deleteCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-del", status: "deleting", message: "queued" },
+    });
+    // First poll still processing, second poll completed.
+    clientMock.getCloudCompatJobStatus
+      .mockResolvedValueOnce({
+        success: true,
+        data: { jobId: "job-del", status: "processing" },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { jobId: "job-del", status: "completed" },
+      });
+    await renderWithAgents([agent({ agent_name: "ToDelete" })]);
+
+    // Row is present before delete completes.
+    expect(screen.getByText("ToDelete")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Delete ToDelete"));
+
+    await waitFor(
+      () =>
+        expect(clientMock.getCloudCompatJobStatus).toHaveBeenCalledWith(
+          "job-del",
+        ),
+      { timeout: 5000 },
+    );
+    // Row removed only after the job reports completed.
+    await waitFor(() => expect(screen.queryByText("ToDelete")).toBeNull(), {
+      timeout: 5000,
+    });
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("Deleted"),
+      "success",
+      expect.any(Number),
+    );
+  });
+
+  it("keeps the row and surfaces an error when the delete job fails", async () => {
+    clientMock.deleteCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-del", status: "deleting", message: "queued" },
+    });
+    clientMock.getCloudCompatJobStatus.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-del", status: "failed", error: "teardown blew up" },
+    });
+    await renderWithAgents([agent({ agent_name: "Sticky" })]);
+
+    fireEvent.click(screen.getByLabelText("Delete Sticky"));
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "teardown blew up",
+        "error",
+        expect.any(Number),
+      ),
+    );
+    // A failed job triggers a re-sync (refresh) rather than dropping the row.
+    await waitFor(() =>
+      expect(clientMock.getCloudCompatAgents.mock.calls.length).toBeGreaterThan(
+        1,
+      ),
+    );
+  });
+
+  it("removes the row immediately for a synchronous delete (no jobId)", async () => {
+    clientMock.deleteCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "", status: "deleted", message: "done" },
+    });
+    await renderWithAgents([agent({ agent_name: "Sync" })]);
+
+    fireEvent.click(screen.getByLabelText("Delete Sync"));
+
+    await waitFor(() => expect(screen.queryByText("Sync")).toBeNull());
+    expect(clientMock.getCloudCompatJobStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("CloudAgentsSection load state (error vs empty)", () => {
+  beforeEach(() => {
+    appMock.value = { elizaCloudConnected: true, setActionNotice: vi.fn() };
+    resetClientMocks();
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: "cloud:other",
+      label: "Other",
+      accessToken: "tok",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the empty state when the fetch succeeds with no agents", async () => {
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    render(<CloudAgentsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agents-empty")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("cloud-agents-error")).toBeNull();
+  });
+
+  it("shows a distinct error state (not empty) when the fetch reports failure", async () => {
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: false,
+      data: [],
+      error: "Cloud unreachable",
+    });
+    render(<CloudAgentsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agents-error")).toBeTruthy(),
+    );
+    expect(screen.getByText("Cloud unreachable")).toBeTruthy();
+    // The empty-state copy must NOT be shown for a failed fetch.
+    expect(screen.queryByTestId("cloud-agents-empty")).toBeNull();
+  });
+
+  it("shows the error state when the fetch throws", async () => {
+    clientMock.getCloudCompatAgents.mockRejectedValue(new Error("boom net"));
+    render(<CloudAgentsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agents-error")).toBeTruthy(),
+    );
+    expect(screen.getByText("boom net")).toBeTruthy();
+  });
+
+  it("retries the fetch from the error state", async () => {
+    clientMock.getCloudCompatAgents
+      .mockResolvedValueOnce({
+        success: false,
+        data: [],
+        error: "Cloud unreachable",
+      })
+      .mockResolvedValueOnce({ success: true, data: [agent()] });
+    render(<CloudAgentsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agents-error")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByTestId("cloud-agents-error-retry"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cloud-agent-rename-agent-1")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("cloud-agents-error")).toBeNull();
   });
 });

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -22,7 +22,19 @@ import {
 } from "../../state/persistence";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { StatusBadge } from "../ui/status-badge";
+import {
+  statusLabelForState,
+  statusToneForState,
+} from "../ui/status-badge.helpers";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+
+/** Maximum length accepted for a (new or edited) cloud agent name. */
+const AGENT_NAME_MAX_LENGTH = 60;
+/** How long to poll a delete job before giving up and forcing a refresh. */
+const DELETE_POLL_TIMEOUT_MS = 60_000;
+/** Delay between delete-job poll attempts. */
+const DELETE_POLL_INTERVAL_MS = 1_500;
 
 /** The agent id currently bound as the active cloud server, if any. */
 function activeCloudAgentId(): string | null {
@@ -56,6 +68,7 @@ export function CloudAgentsSection() {
   const { appName } = useBranding();
   const [agents, setAgents] = useState<CloudCompatAgent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
@@ -68,15 +81,26 @@ export function CloudAgentsSection() {
 
   const refresh = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const res = await client.getCloudCompatAgents();
-      const list = res.success ? res.data : [];
+      // A failed fetch is NOT an empty list — surface it so the user can retry
+      // instead of seeing the indistinguishable "No cloud agents yet" copy.
+      if (!res.success) {
+        setLoadError(res.error || "Could not load your cloud agents.");
+        return;
+      }
+      const list = [...res.data];
       list.sort((a, b) =>
         String(b.created_at).localeCompare(String(a.created_at)),
       );
       setAgents(list);
-    } catch {
-      setAgents([]);
+    } catch (err) {
+      setLoadError(
+        err instanceof Error
+          ? err.message
+          : "Could not load your cloud agents.",
+      );
     } finally {
       setLoading(false);
     }
@@ -156,13 +180,46 @@ export function CloudAgentsSection() {
     }
   }, [newName, cloudApiBase, bindAndReload, setActionNotice]);
 
+  /**
+   * Poll a delete job until it reaches a terminal state. Resolves `true` on a
+   * completed teardown, `false` (with the failure surfaced) when the job
+   * fails, and throws on timeout so the caller can fall back to a refresh.
+   */
+  const waitForDeleteJob = useCallback(async (jobId: string) => {
+    const deadline = Date.now() + DELETE_POLL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const res = await client.getCloudCompatJobStatus(jobId);
+      const status = res.success ? res.data.status : "failed";
+      if (status === "completed") return { ok: true as const };
+      if (status === "failed") {
+        return {
+          ok: false as const,
+          error: res.data.error || "Agent delete failed.",
+        };
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, DELETE_POLL_INTERVAL_MS),
+      );
+    }
+    throw new Error("Timed out waiting for the agent to be deleted.");
+  }, []);
+
   const deleteAgent = useCallback(
     async (agent: CloudCompatAgent) => {
       setBusyId(agent.agent_id);
       try {
         const res = await client.deleteCloudCompatAgent(agent.agent_id);
         if (!res.success) {
-          throw new Error("Delete failed");
+          throw new Error(res.error || "Delete failed");
+        }
+        // A 202 async delete returns a jobId — the teardown may still fail
+        // later, so poll the job and only drop the row once it actually
+        // completes. A synchronous delete (no jobId) is already terminal.
+        if (res.data.jobId) {
+          const outcome = await waitForDeleteJob(res.data.jobId);
+          if (!outcome.ok) {
+            throw new Error(outcome.error);
+          }
         }
         setAgents((prev) => prev.filter((a) => a.agent_id !== agent.agent_id));
         setActionNotice(`Deleted ${agent.agent_name}.`, "success", 3000);
@@ -172,11 +229,14 @@ export function CloudAgentsSection() {
           "error",
           4000,
         );
+        // The teardown failed or timed out — re-sync so the row reflects the
+        // real server state rather than a stale optimistic removal.
+        void refresh();
       } finally {
         setBusyId(null);
       }
     },
-    [setActionNotice],
+    [setActionNotice, waitForDeleteJob, refresh],
   );
 
   const startRename = useCallback((agent: CloudCompatAgent) => {
@@ -306,9 +366,37 @@ export function CloudAgentsSection() {
         description="Switch the active agent, shut one down (or start it back up), rename, or remove one you no longer need."
       >
         {loading ? (
-          <p className="px-4 py-3 text-sm text-txt-muted">Loading agents…</p>
+          <div
+            className="flex items-center gap-2 px-4 py-3 text-sm text-txt-muted"
+            data-testid="cloud-agents-loading"
+          >
+            <RefreshCw className="h-4 w-4 animate-spin" aria-hidden />
+            Loading agents…
+          </div>
+        ) : loadError ? (
+          <div
+            className="flex flex-col gap-2 px-4 py-3"
+            data-testid="cloud-agents-error"
+          >
+            <p className="text-sm text-destructive">{loadError}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="self-start"
+              data-testid="cloud-agents-error-retry"
+              onClick={() => {
+                void refresh();
+              }}
+            >
+              <RefreshCw className="mr-1 h-4 w-4" aria-hidden />
+              Try again
+            </Button>
+          </div>
         ) : agents.length === 0 ? (
-          <p className="px-4 py-3 text-sm text-txt-muted">
+          <p
+            className="px-4 py-3 text-sm text-txt-muted"
+            data-testid="cloud-agents-empty"
+          >
             No cloud agents yet — create your first one below.
           </p>
         ) : (
@@ -341,6 +429,7 @@ export function CloudAgentsSection() {
                     className="flex-1"
                     aria-label="Agent name"
                     data-testid={`cloud-agent-rename-input-${agent.agent_id}`}
+                    maxLength={AGENT_NAME_MAX_LENGTH}
                     disabled={busy}
                     autoFocus
                   />
@@ -370,7 +459,16 @@ export function CloudAgentsSection() {
                 key={agent.agent_id}
                 icon={Bot}
                 label={agent.agent_name || agent.agent_id}
-                description={isActive ? "Active · this device" : agent.status}
+                description={
+                  <span className="inline-flex items-center gap-2">
+                    {isActive ? "Active · this device" : null}
+                    <StatusBadge
+                      tone={statusToneForState(agent.status)}
+                      label={statusLabelForState(agent.status)}
+                      data-testid={`cloud-agent-status-${agent.agent_id}`}
+                    />
+                  </span>
+                }
                 active={isActive}
                 trailing={
                   <div className="flex items-center gap-2">
@@ -457,6 +555,7 @@ export function CloudAgentsSection() {
             onChange={(e) => setNewName(e.target.value)}
             placeholder={`Agent name (e.g. ${appName})`}
             className="flex-1"
+            maxLength={AGENT_NAME_MAX_LENGTH}
             disabled={creating}
           />
           <Button

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -204,6 +204,15 @@ export function CloudAgentsSection() {
             a.agent_id === agent.agent_id ? { ...a, agent_name: name } : a,
           ),
         );
+        // If we just renamed the agent bound as the active cloud server, refresh
+        // the persisted label so the switcher/header reflect the new name without
+        // waiting for a re-bind (mirrors how switchTo/create set the label).
+        if (agent.agent_id === activeId) {
+          const active = loadPersistedActiveServer();
+          if (active?.kind === "cloud") {
+            savePersistedActiveServer({ ...active, label: name });
+          }
+        }
         setActionNotice(`Renamed to ${name}.`, "success", 3000);
         setEditingId(null);
       } catch (err) {
@@ -216,7 +225,7 @@ export function CloudAgentsSection() {
         setBusyId(null);
       }
     },
-    [editName, setActionNotice],
+    [editName, activeId, setActionNotice],
   );
 
   const setLocalStatus = useCallback((agentId: string, status: string) => {
@@ -331,6 +340,7 @@ export function CloudAgentsSection() {
                     }}
                     className="flex-1"
                     aria-label="Agent name"
+                    data-testid={`cloud-agent-rename-input-${agent.agent_id}`}
                     disabled={busy}
                     autoFocus
                   />
@@ -338,6 +348,7 @@ export function CloudAgentsSection() {
                     variant="default"
                     size="sm"
                     disabled={busy}
+                    data-testid={`cloud-agent-rename-save-${agent.agent_id}`}
                     onClick={() => void saveRename(agent)}
                   >
                     {busy ? "Saving…" : "Save"}
@@ -346,6 +357,7 @@ export function CloudAgentsSection() {
                     variant="ghost"
                     size="sm"
                     disabled={busy}
+                    data-testid={`cloud-agent-rename-cancel-${agent.agent_id}`}
                     onClick={() => setEditingId(null)}
                   >
                     Cancel
@@ -406,6 +418,7 @@ export function CloudAgentsSection() {
                       size="sm"
                       disabled={busy}
                       aria-label={`Rename ${agent.agent_name || agent.agent_id}`}
+                      data-testid={`cloud-agent-rename-${agent.agent_id}`}
                       onClick={() => startRename(agent)}
                     >
                       <Pencil className="h-4 w-4" aria-hidden />

--- a/packages/ui/src/components/ui/status-badge.helpers.ts
+++ b/packages/ui/src/components/ui/status-badge.helpers.ts
@@ -18,11 +18,22 @@ export function statusToneForState(status: string): StatusVariant {
     normalized === "signed" ||
     normalized === "broadcast" ||
     normalized === "confirmed" ||
-    normalized === "ready"
+    normalized === "ready" ||
+    // Agent lifecycle: a live container.
+    normalized === "running"
   ) {
     return "success";
   }
-  if (normalized === "warning" || normalized === "pending") {
+  if (
+    normalized === "warning" ||
+    normalized === "pending" ||
+    // Agent lifecycle: transitional states (showing the spinning badge).
+    normalized === "provisioning" ||
+    normalized === "starting" ||
+    normalized === "stopping" ||
+    normalized === "resuming" ||
+    normalized === "suspending"
+  ) {
     return "warning";
   }
   if (
@@ -33,6 +44,8 @@ export function statusToneForState(status: string): StatusVariant {
   ) {
     return "danger";
   }
+  // Agent lifecycle stopped/suspended/sleeping (and unknown) fall through to the
+  // neutral "muted" tone.
   return "muted";
 }
 


### PR DESCRIPTION
From the audit (#8434). **Supersedes #8761** (includes its rename label-sync). **MAJOR:** suspend/resume/restart get the full direct-cloud fallback ladder (mirrors delete) — the Power/Start buttons no longer 404 on phone/web. 202 async delete now threads its jobId + polls `/api/v1/jobs/{id}`, removing the row only on `completed` (no fake "Deleted"). `getCloudCompatAgents` failure renders a distinct error+Retry state instead of the empty state. **Minor:** lifecycle StatusBadge + name maxLength. 42 tests (16 new).

_CI's red Format Check / lint-and-types are pre-existing develop-wide biome breakage in ~14 unrelated files, not this PR. This PR's own files pass biome + typecheck + tests. Refs #8434 (full lifecycle audit)._