### PR TITLE
fix(cloud): cerebras-only chat (graceful 429, no OpenRouter fallback) + no embedding sentinel vectors

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model-cerebras-fallback.test.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model-cerebras-fallback.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+// Cerebras-native default ids (gpt-oss-120b, zai-glm-4.7) serve directly via
+// the Cerebras key — cerebras-only by design. There is NO OpenRouter fallback:
+// a free-tier 429 must surface so the chat path can return the graceful
+// "model provider rate-limited" reply rather than failing over to a different
+// provider. OPENROUTER_API_KEY is set on purpose to prove the cerebras branch
+// never routes to OpenRouter even when an OpenRouter key is available.
+delete process.env.BITROUTER_API_KEY;
+delete process.env.AI_GATEWAY_API_KEY;
+delete process.env.AIGATEWAY_API_KEY;
+delete process.env.ANTHROPIC_API_KEY;
+delete process.env.OPENAI_API_KEY;
+delete process.env.GROQ_API_KEY;
+process.env.CEREBRAS_API_KEY = "test-cerebras-key";
+process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+delete process.env.OPENROUTER_BASE_URL;
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+const { generateText } = await import("ai");
+const { getLanguageModel, resolveAiProviderSource } = await import("./language-model");
+
+function hostOf(url: RequestInfo | URL): "openrouter" | "cerebras" | "other" {
+  const u = String(url);
+  if (u.includes("openrouter.ai")) return "openrouter";
+  if (u.includes("cerebras.ai")) return "cerebras";
+  return "other";
+}
+
+function completion(model: string, content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function tooManyRequests(): Response {
+  return new Response(JSON.stringify({ error: { message: "Rate limit exceeded" } }), {
+    status: 429,
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback)", () => {
+  let hosts: Array<"openrouter" | "cerebras" | "other">;
+
+  beforeEach(() => {
+    hosts = [];
+  });
+
+  test("a bare Cerebras id serves directly via cerebras.ai on the happy path", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return completion("gpt-oss-120b", "from-cerebras");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("gpt-oss-120b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("from-cerebras");
+    expect(hosts).toEqual(["cerebras"]);
+  });
+
+  test("a 429 surfaces (cerebras-only) and is never routed to OpenRouter", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return tooManyRequests();
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        // The decorated id dedicated agents emit; still a Cerebras-native model.
+        model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+        prompt: "hi",
+        maxRetries: 0,
+      }),
+    ).rejects.toBeDefined();
+    // No OpenRouter fallback: the 429 surfaces so the chat path can return the
+    // graceful "model provider rate-limited" reply.
+    expect(hosts).toEqual(["cerebras"]);
+  });
+
+  test("a non-retryable error (400) also surfaces via cerebras only", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 });
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        model: getLanguageModel("gpt-oss-120b"),
+        prompt: "hi",
+        maxRetries: 0,
+      }),
+    ).rejects.toBeDefined();
+    // A 400 is a real request error: OpenRouter is never reached.
+    expect(hosts).toEqual(["cerebras"]);
+  });
+
+  test("happy-path billing attributes to cerebras", () => {
+    expect(resolveAiProviderSource("gpt-oss-120b")).toBe("cerebras");
+    expect(resolveAiProviderSource("openai/gpt-oss-120b:nitro")).toBe("cerebras");
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -382,6 +382,9 @@ export function getLanguageModel(model: string) {
   }
 
   // Cerebras-native default IDs (gpt-oss-120b, zai-glm-4.7) → Cerebras direct.
+  // Cerebras-only by design: a free-tier 429 must surface so the chat path can
+  // return the graceful "model provider rate-limited" reply rather than silently
+  // failing over to OpenRouter on a different provider.
   if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
     return getCerebrasClient().chat(normalizeCerebrasModelId(model));
   }

--- a/plugins/plugin-elizacloud/__tests__/unit/embeddings.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/embeddings.test.ts
@@ -1,0 +1,162 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the Cloud API client the embeddings handlers use. requestRaw is the
+// single network seam, so we drive every success/failure path through it.
+const requestRaw = vi.fn();
+vi.mock("../../src/utils/sdk-client", () => ({
+  createCloudApiClient: () => ({ requestRaw }),
+}));
+
+// Embeddings must never emit usage on a failed batch; spy to assert that.
+const emitModelUsageEvent = vi.fn();
+vi.mock("../../src/utils/events", () => ({ emitModelUsageEvent }));
+
+const { handleTextEmbedding, handleBatchTextEmbedding } = await import(
+  "../../src/models/embeddings"
+);
+
+const DIM = 1536;
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    getSetting: (key: string) => {
+      if (key === "ELIZAOS_CLOUD_EMBEDDING_MODEL") return "text-embedding-3-small";
+      if (key === "ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS") return "1536";
+      return undefined;
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function embeddingResponse(vectors: number[][]): Response {
+  return new Response(
+    JSON.stringify({
+      data: vectors.map((embedding, index) => ({ embedding, index })),
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function vec(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, i) => (i === 0 ? seed : 0));
+}
+
+beforeEach(() => {
+  requestRaw.mockReset();
+  emitModelUsageEvent.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleTextEmbedding init + validation", () => {
+  it("returns a correctly-sized init probe vector for null (legitimate init)", async () => {
+    const result = await handleTextEmbedding(makeRuntime(), null);
+    expect(result).toHaveLength(DIM);
+    expect(result[0]).toBe(0.1);
+    // Init must never touch the network.
+    expect(requestRaw).not.toHaveBeenCalled();
+  });
+
+  it("throws on malformed params instead of returning a marker vector", async () => {
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately malformed input
+      handleTextEmbedding(makeRuntime(), { notText: "x" } as any)
+    ).rejects.toThrow(/Invalid input format/);
+    expect(requestRaw).not.toHaveBeenCalled();
+  });
+
+  it("throws on empty text instead of returning a marker vector", async () => {
+    await expect(handleTextEmbedding(makeRuntime(), "   ")).rejects.toThrow(/empty text/);
+    expect(requestRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns the real embedding for valid text", async () => {
+    requestRaw.mockResolvedValueOnce(embeddingResponse([vec(0.7)]));
+    const result = await handleTextEmbedding(makeRuntime(), "hello world");
+    expect(result).toEqual(vec(0.7));
+  });
+});
+
+describe("handleBatchTextEmbedding no-marker-on-failure", () => {
+  it("returns [] for an empty input array (not a marker)", async () => {
+    const result = await handleBatchTextEmbedding(makeRuntime(), []);
+    expect(result).toEqual([]);
+    expect(requestRaw).not.toHaveBeenCalled();
+  });
+
+  it("throws (no marker vectors) when a text is empty", async () => {
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["ok", ""])).rejects.toThrow(
+      /empty text at index 1/
+    );
+    expect(requestRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns real vectors for a successful batch and emits usage", async () => {
+    requestRaw.mockResolvedValueOnce(embeddingResponse([vec(0.1), vec(0.2)]));
+    const result = await handleBatchTextEmbedding(makeRuntime(), ["a", "b"]);
+    expect(result).toEqual([vec(0.1), vec(0.2)]);
+    expect(emitModelUsageEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on a 401 auth failure (no marker vectors, no usage)", async () => {
+    requestRaw.mockResolvedValueOnce(new Response("nope", { status: 401 }));
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["a"])).rejects.toThrow(
+      /Authentication failed/
+    );
+    expect(emitModelUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("throws on a generic non-auth API error instead of writing markers", async () => {
+    requestRaw.mockResolvedValueOnce(
+      new Response("boom", { status: 500, statusText: "Server Error" })
+    );
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["a"])).rejects.toThrow(/API error: 500/);
+    expect(emitModelUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("throws on an invalid response structure instead of writing markers", async () => {
+    requestRaw.mockResolvedValueOnce(
+      new Response(JSON.stringify({ not: "data" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["a"])).rejects.toThrow(
+      /invalid response structure/
+    );
+  });
+
+  it("throws on a transport error instead of writing markers", async () => {
+    requestRaw.mockRejectedValueOnce(new Error("network down"));
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["a"])).rejects.toThrow(/network down/);
+    expect(emitModelUsageEvent).not.toHaveBeenCalled();
+  });
+
+  // `retry-after: 1` keeps the backoff to ~1s (0 is falsy → handler defaults to
+  // 30s), well under the bumped per-test timeout.
+  it("retries once after a 429 and returns real vectors on retry success", async () => {
+    requestRaw
+      .mockResolvedValueOnce(
+        new Response("slow down", { status: 429, headers: { "retry-after": "1" } })
+      )
+      .mockResolvedValueOnce(embeddingResponse([vec(0.9)]));
+    const result = await handleBatchTextEmbedding(makeRuntime(), ["a"]);
+    expect(result).toEqual([vec(0.9)]);
+    expect(requestRaw).toHaveBeenCalledTimes(2);
+  }, 10000);
+
+  it("throws (no markers) when the post-429 retry also fails", async () => {
+    requestRaw
+      .mockResolvedValueOnce(
+        new Response("slow down", { status: 429, headers: { "retry-after": "1" } })
+      )
+      .mockResolvedValueOnce(new Response("still bad", { status: 503, statusText: "Unavailable" }));
+    await expect(handleBatchTextEmbedding(makeRuntime(), ["a"])).rejects.toThrow(
+      /Rate-limit retry failed/
+    );
+    expect(emitModelUsageEvent).not.toHaveBeenCalled();
+  }, 10000);
+});

--- a/plugins/plugin-elizacloud/src/models/embeddings.ts
+++ b/plugins/plugin-elizacloud/src/models/embeddings.ts
@@ -48,9 +48,16 @@ function getEmbeddingConfig(runtime: IAgentRuntime) {
   return { embeddingModelName, embeddingDimension };
 }
 
-function createErrorVector(dimension: number, marker: number): number[] {
+/**
+ * The init probe vector. `runtime.ensureEmbeddingDimension()` calls the handler
+ * with `null` purely to learn the vector length; it only inspects `.length`, so
+ * a deterministic non-zero[0] marker vector is the correct, legitimate response.
+ * This is the ONLY place a synthetic vector is returned — every real failure
+ * throws so it can never be persisted as a corrupt embedding (Commandment 8).
+ */
+function createInitProbeVector(dimension: number): number[] {
   const vector = Array(dimension).fill(0);
-  vector[0] = marker;
+  vector[0] = 0.1;
   return vector;
 }
 
@@ -66,7 +73,7 @@ export async function handleTextEmbedding(
 
   if (params === null) {
     logger.debug("Creating test embedding for initialization");
-    return createErrorVector(embeddingDimension, 0.1);
+    return createInitProbeVector(embeddingDimension);
   }
 
   let text: string;
@@ -75,13 +82,14 @@ export async function handleTextEmbedding(
   } else if (typeof params === "object" && params.text) {
     text = params.text;
   } else {
-    logger.warn("Invalid input format for embedding");
-    return createErrorVector(embeddingDimension, 0.2);
+    // A malformed request is a programming error, not a recoverable runtime
+    // state. Throw instead of returning a marker vector that would silently
+    // corrupt the embedding store (Commandment 8).
+    throw new Error("Invalid input format for embedding: expected string or { text: string }");
   }
 
   if (!text.trim()) {
-    logger.warn("Empty text for embedding");
-    return createErrorVector(embeddingDimension, 0.3);
+    throw new Error("Cannot generate embedding for empty text");
   }
 
   const results = await handleBatchTextEmbedding(runtime, [text]);
@@ -103,26 +111,22 @@ export async function handleBatchTextEmbedding(
   const client = createCloudApiClient(runtime, true);
 
   if (!texts || texts.length === 0) {
-    logger.warn("[BatchEmbeddings] Empty texts array");
     return [];
   }
 
+  // Every text must be non-empty: an empty input cannot produce a meaningful
+  // vector, and a marker/zero vector would silently corrupt the store. Surface
+  // the bad input to the caller (Commandment 8) instead of papering over it.
   const validTexts: { text: string; originalIndex: number }[] = [];
-  const results: number[][] = new Array(texts.length);
-
   for (let i = 0; i < texts.length; i++) {
     const text = texts[i]?.trim();
-    if (text) {
-      validTexts.push({ text, originalIndex: i });
-    } else {
-      results[i] = createErrorVector(embeddingDimension, 0.3);
+    if (!text) {
+      throw new Error(`Cannot generate embedding for empty text at index ${i}`);
     }
+    validTexts.push({ text, originalIndex: i });
   }
 
-  if (validTexts.length === 0) {
-    logger.warn("[BatchEmbeddings] All texts were empty");
-    return results;
-  }
+  const results: number[][] = new Array(texts.length);
 
   for (let batchStart = 0; batchStart < validTexts.length; batchStart += MAX_BATCH_SIZE) {
     const batchEnd = Math.min(batchStart + MAX_BATCH_SIZE, validTexts.length);
@@ -162,58 +166,56 @@ export async function handleBatchTextEmbedding(
         });
 
         if (!retryResponse.ok) {
-          logger.error(`[BatchEmbeddings] Retry failed: ${retryResponse.status}`);
-          for (const item of batch) {
-            results[item.originalIndex] = createErrorVector(embeddingDimension, 0.4);
-          }
-          continue;
+          // The post-backoff retry still failed: this batch has no embeddings.
+          // Throw so the router can fall through to another provider rather than
+          // persisting marker vectors that corrupt the store (Commandment 8).
+          throw new Error(
+            `[BatchEmbeddings] Rate-limit retry failed (${retryResponse.status} ${retryResponse.statusText})`
+          );
         }
 
         const retryData = (await retryResponse.json()) as {
-          data: Array<{ embedding: number[]; index: number }>;
+          data?: Array<{ embedding: number[]; index: number }>;
         };
 
-        if (retryData?.data) {
-          for (const item of retryData.data) {
-            const originalIndex = batch[item.index].originalIndex;
-            results[originalIndex] = item.embedding;
-          }
-          logger.info(`[BatchEmbeddings] Retry successful for ${batch.length} embeddings`);
+        if (!retryData?.data || !Array.isArray(retryData.data)) {
+          throw new Error("[BatchEmbeddings] Rate-limit retry returned invalid structure");
         }
+
+        for (const item of retryData.data) {
+          const originalIndex = batch[item.index].originalIndex;
+          results[originalIndex] = item.embedding;
+        }
+        logger.info(`[BatchEmbeddings] Retry successful for ${batch.length} embeddings`);
         continue;
       }
 
       if (!response.ok) {
-        // Auth errors (401/403) are non-recoverable with the current key —
-        // throw so the router can fall through to the next provider (e.g.
-        // local inference) instead of silently returning zero-vectors that
-        // corrupt the embedding store. Commandment 8: don't hide broken
-        // pipelines behind fallback values.
+        // Auth errors (401/403) are non-recoverable with the current key.
+        // Every other non-OK status is just as fatal for this batch — neither
+        // can produce real vectors. Throw in both cases so the router falls
+        // through to the next provider (e.g. local inference) instead of
+        // silently persisting marker/zero vectors that corrupt the embedding
+        // store. Commandment 8: don't hide broken pipelines behind fallbacks.
         if (response.status === 401 || response.status === 403) {
           throw new Error(
             `[BatchEmbeddings] Authentication failed (${response.status}). ` +
-            `Check ELIZAOS_CLOUD_API_KEY or ELIZAOS_CLOUD_EMBEDDING_API_KEY — ` +
-            `the current key is not authorized for the embedding endpoint.`
+              `Check ELIZAOS_CLOUD_API_KEY or ELIZAOS_CLOUD_EMBEDDING_API_KEY — ` +
+              `the current key is not authorized for the embedding endpoint.`
           );
         }
-        logger.error(`[BatchEmbeddings] API error: ${response.status} - ${response.statusText}`);
-        for (const item of batch) {
-          results[item.originalIndex] = createErrorVector(embeddingDimension, 0.4);
-        }
-        continue;
+        throw new Error(
+          `[BatchEmbeddings] API error: ${response.status} ${response.statusText}`
+        );
       }
 
       const data = (await response.json()) as {
-        data: Array<{ embedding: number[]; index: number }>;
+        data?: Array<{ embedding: number[]; index: number }>;
         usage?: { prompt_tokens: number; total_tokens: number };
       };
 
       if (!data?.data || !Array.isArray(data.data)) {
-        logger.error("[BatchEmbeddings] API returned invalid structure");
-        for (const item of batch) {
-          results[item.originalIndex] = createErrorVector(embeddingDimension, 0.5);
-        }
-        continue;
+        throw new Error("[BatchEmbeddings] API returned invalid response structure");
       }
 
       for (const item of data.data) {
@@ -234,16 +236,13 @@ export async function handleBatchTextEmbedding(
         `[BatchEmbeddings] Got ${batch.length} embeddings (${embeddingDimension}d), remaining: ${rateLimitInfo.remainingRequests ?? "unknown"}`
       );
     } catch (error) {
+      // Any failure in this batch (HTTP error, transport error, malformed body)
+      // means we have no real vectors for it. Log context and re-throw so the
+      // router can fall through to another provider; never persist marker/zero
+      // vectors that would corrupt the embedding store (Commandment 8).
       const message = error instanceof Error ? error.message : String(error);
-      // Re-throw auth errors so the router can fall through to another
-      // provider instead of silently inserting zero-vectors.
-      if (message.includes("Authentication failed")) {
-        throw error;
-      }
-      logger.error(`[BatchEmbeddings] Error: ${message}`);
-      for (const item of batch) {
-        results[item.originalIndex] = createErrorVector(embeddingDimension, 0.6);
-      }
+      logger.error(`[BatchEmbeddings] Batch failed: ${message}`);
+      throw error instanceof Error ? error : new Error(message);
     }
   }
 


### PR DESCRIPTION
Per the cloud agent's directive: Cerebras chat is **cerebras-only** — a free-tier 429 must surface so the chat path can return the graceful "model provider rate-limited" reply, **not** silently fail over to OpenRouter on a different provider. Rebased onto latest `develop`.

## What changed

1. **`packages/cloud-shared/src/lib/providers/language-model.ts`** — the Cerebras-native branch (gpt-oss-120b, zai-glm-4.7) is plain `getCerebrasClient().chat(...)`, cerebras-direct only. The earlier `withOpenRouterFallback(...)` wrap on this branch is removed. `withOpenRouterFallback` stays in place for the OpenAI / Anthropic native branches (unchanged from develop).

2. **`plugins/plugin-elizacloud/src/models/embeddings.ts`** — stop writing sentinel "error vectors" that corrupt the vector store. Every real failure (malformed input, empty text, API error, invalid structure, transport error, failed 429 retry) now throws so the router can fall through to another provider — consistent with the existing 401/403 branch and Commandment 8. Only the legitimate null-init probe vector remains.

## Tests
- `language-model-cerebras-fallback.test.ts` — cerebras-only: a 429 and a 400 each surface via cerebras and are never routed to OpenRouter (even when `OPENROUTER_API_KEY` is set); happy-path billing attributes to cerebras.
- `__tests__/unit/embeddings.test.ts` — no-marker-on-failure: every failure throws; only the null-init probe vector is synthetic.

## Notes
- The previous version of this PR also rerouted `provisioning-agent-chat.ts` through the shared layer; that change existed only to inherit the now-removed fallback, so it has been **reverted to develop state** (the file is no longer part of this PR).
- `#8769` (gte-small embeddings) is **not** in `develop`, and `develop` has not otherwise changed `embeddings.ts`, so the no-sentinel fix rebases cleanly and is non-redundant.