### PR TITLE
fix(cloud): deprovision lifecycle — history cleanup, sibling-job cancel, snapshot skip-not-fail, deletion_failed recovery

### DIFF
--- a/packages/cloud-api/v1/cron/agent-backups/route.ts
+++ b/packages/cloud-api/v1/cron/agent-backups/route.ts
@@ -13,7 +13,16 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * by the regular provisioning worker, which has bridge access to pull state.
  * Retention is enforced by `pruneBackups` inside the snapshot handler.
  *
- * Tunables via query string: `?intervalMs=<n>&max=<n>`.
+ * Piggybacks the low-frequency `deletion_failed` recovery sweep on the same
+ * 6-hourly tick: `reEnqueueFailedDeletions` re-arms sandboxes whose
+ * `agent_delete` exhausted its retries only because the host node was
+ * transiently unreachable, so the delete finishes once the node returns. It
+ * is a cheap, capped DB write (no container control-plane hop), so it shares
+ * this cron rather than carrying its own schedule. Without a caller the
+ * recovery sweep never runs and `deletion_failed` rows leak forever.
+ *
+ * Tunables via query string: `?intervalMs=<n>&max=<n>` (snapshots),
+ * `?deletionMinAgeMs=<n>&deletionMax=<n>` (deletion recovery).
  */
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Agent Backups]", env);
@@ -22,6 +31,8 @@ async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const url = new URL(c.req.url);
   const intervalMs = Number(url.searchParams.get("intervalMs"));
   const max = Number(url.searchParams.get("max"));
+  const deletionMinAgeMs = Number(url.searchParams.get("deletionMinAgeMs"));
+  const deletionMax = Number(url.searchParams.get("deletionMax"));
 
   const result = await provisioningJobService.enqueueScheduledBackups({
     minIntervalMs:
@@ -29,8 +40,35 @@ async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
     maxAgents: Number.isFinite(max) && max > 0 ? max : undefined,
   });
 
-  logger.info("[Agent Backups] Scheduled backup sweep complete", result);
-  return c.json({ success: true, ...result });
+  // Recover stuck `deletion_failed` sandboxes on the same tick. Conservative,
+  // capped params keep the sweep from fighting the live retry loop or
+  // re-enqueueing a large batch at once. Best-effort: a failure here must not
+  // mask a successful backup sweep, so it is reported separately.
+  let deletionRecovery: Awaited<
+    ReturnType<typeof provisioningJobService.reEnqueueFailedDeletions>
+  > | null = null;
+  try {
+    deletionRecovery = await provisioningJobService.reEnqueueFailedDeletions({
+      minAgeMs:
+        Number.isFinite(deletionMinAgeMs) && deletionMinAgeMs > 0
+          ? deletionMinAgeMs
+          : undefined,
+      maxAgents:
+        Number.isFinite(deletionMax) && deletionMax > 0
+          ? Math.min(deletionMax, 50)
+          : undefined,
+    });
+  } catch (error) {
+    logger.error("[Agent Backups] deletion-recovery sweep failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  logger.info("[Agent Backups] Scheduled backup sweep complete", {
+    ...result,
+    deletionRecovery,
+  });
+  return c.json({ success: true, ...result, deletionRecovery });
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud-shared/src/db/repositories/shared-runtime-history.test.ts
@@ -34,8 +34,8 @@ describe("SharedRuntimeHistoryRepository.deleteByAgent", () => {
 
     // The WHERE must filter on agent_id only (delete-by-agent across all
     // channels), never an unscoped DELETE that would nuke other agents' history.
-    expect(capturedWhere).toBeDefined();
-    const sql = new PgDialect().sqlToQuery(capturedWhere as SQL);
+    if (!capturedWhere) throw new Error("WHERE clause was not captured");
+    const sql = new PgDialect().sqlToQuery(capturedWhere);
     expect(sql.sql).toContain("agent_id");
     expect(sql.params).toContain("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
   });

--- a/packages/cloud-shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud-shared/src/db/repositories/shared-runtime-history.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+// Capture the generated WHERE clause so we can assert the delete is scoped to a
+// single agent (every channel) and never a table-wide wipe.
+let capturedWhere: SQL | undefined;
+
+const returning = mock(() => [{ channelId: "c1" }, { channelId: "c2" }]);
+const deleteWhere = mock((clause: SQL) => {
+  capturedWhere = clause;
+  return { returning };
+});
+const del = mock(() => ({ where: deleteWhere }));
+
+mock.module("../client", () => ({
+  dbRead: {},
+  dbWrite: { delete: del },
+}));
+
+describe("SharedRuntimeHistoryRepository.deleteByAgent", () => {
+  test("deletes every channel row for the agent and returns the count", async () => {
+    capturedWhere = undefined;
+    const { SharedRuntimeHistoryRepository } = await import("./shared-runtime-history");
+
+    const removed = await new SharedRuntimeHistoryRepository().deleteByAgent(
+      "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+    );
+
+    // Two channel rows existed → count reflects the orphaned history actually dropped.
+    expect(removed).toBe(2);
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(returning).toHaveBeenCalledTimes(1);
+
+    // The WHERE must filter on agent_id only (delete-by-agent across all
+    // channels), never an unscoped DELETE that would nuke other agents' history.
+    expect(capturedWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedWhere as SQL);
+    expect(sql.sql).toContain("agent_id");
+    expect(sql.params).toContain("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
+  });
+});

--- a/packages/cloud-shared/src/db/repositories/shared-runtime-history.ts
+++ b/packages/cloud-shared/src/db/repositories/shared-runtime-history.ts
@@ -24,6 +24,22 @@ export class SharedRuntimeHistoryRepository {
     return Array.isArray(row?.messages) ? row.messages : [];
   }
 
+  /**
+   * Delete ALL shared-runtime history rows for an agent (every channel),
+   * called when the agent itself is deleted. Without this, a shared agent's
+   * cross-turn history is orphaned: the canonical `agent_sandboxes` row is
+   * gone but its `(agent_id, channel_id)` rows linger forever (no FK cascade —
+   * this table is deliberately decoupled from the sandbox/conversation tables).
+   * Returns the number of rows removed so the caller can log the cleanup.
+   */
+  async deleteByAgent(agentId: string): Promise<number> {
+    const deleted = await dbWrite
+      .delete(sharedRuntimeHistory)
+      .where(eq(sharedRuntimeHistory.agent_id, agentId))
+      .returning({ channelId: sharedRuntimeHistory.channel_id });
+    return deleted.length;
+  }
+
   async upsert(
     agentId: string,
     channelId: string,

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -692,6 +692,80 @@ describe("ElizaSandboxService.executeResume", () => {
   });
 });
 
+// Lifecycle bring-up (resume / wake / restart) must NOT resurrect a row that an
+// agent_delete job already owns. A row in deletion_pending/deletion_failed is
+// reported as "Agent not found" so the daemon completes the job as a terminal
+// no-op instead of rebuilding a container being torn down.
+describe("ElizaSandboxService deletion-state guards (resume/wake/restart)", () => {
+  const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+  const ORG = "22222222-2222-4222-8222-222222222222";
+
+  function row(status: AgentSandbox["status"]): AgentSandbox {
+    return { ...customSandbox(), id: AGENT, organization_id: ORG, status };
+  }
+
+  for (const status of ["deletion_pending", "deletion_failed"] as const) {
+    test(`executeResume bails on ${status} (not-found, no provision)`, async () => {
+      const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+      const svc = new ElizaSandboxService();
+      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
+        row(status),
+      );
+      const provisionSpy = spyOn(svc, "provision");
+      try {
+        const res = await svc.executeResume(AGENT, ORG);
+        expect(res.success).toBe(false);
+        expect(res.error).toBe("Agent not found");
+        expect(provisionSpy).not.toHaveBeenCalled();
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
+
+    test(`executeWake bails on ${status} (not-found, no provision)`, async () => {
+      const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+      const svc = new ElizaSandboxService();
+      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
+        row(status),
+      );
+      const provisionSpy = spyOn(svc, "provision");
+      try {
+        const res = await svc.executeWake(AGENT, ORG);
+        expect(res.success).toBe(false);
+        expect(res.error).toBe("Agent not found");
+        expect(provisionSpy).not.toHaveBeenCalled();
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
+
+    test(`executeRestart bails on ${status} before shutdown/provision`, async () => {
+      const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+      const svc = new ElizaSandboxService();
+      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
+        row(status),
+      );
+      const shutdownSpy = spyOn(svc, "shutdown");
+      const provisionSpy = spyOn(svc, "provision");
+      try {
+        const res = await svc.executeRestart(AGENT, ORG);
+        expect(res.success).toBe(false);
+        expect(res.error).toBe("Agent not found");
+        // Critically: never starts the stop+rebuild sequence on a doomed row.
+        expect(shutdownSpy).not.toHaveBeenCalled();
+        expect(provisionSpy).not.toHaveBeenCalled();
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
+  }
+});
+
+// FIX 1 (orphaned shared-runtime history on delete) is covered at the repository
+// level in shared-runtime-history.test.ts: deleteAgent runs inside a
+// dbWrite.transaction (a Proxy that can't be spied here) and the cleanup is a
+// best-effort post-commit call to sharedRuntimeHistoryRepository.deleteByAgent.
+
 describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
   const DB = "postgres://shared.example/railway";
 

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -11,6 +11,7 @@ import {
   type AgentBackupSnapshotType,
   type AgentSandbox,
   type AgentSandboxBackup,
+  type AgentSandboxStatus,
   agentSandboxesRepository,
   prepareAgentBackupInsertData,
 } from "../../db/repositories/agent-sandboxes";
@@ -746,6 +747,26 @@ export class ElizaSandboxService {
         await apiKeysService.revokeForAgent(agentId);
       } catch (err) {
         logger.warn("[agent-sandbox] Failed to revoke per-agent API key", {
+          agentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // Best-effort: drop the shared-runtime (Tier-0) conversation history for
+      // this agent. That table is deliberately decoupled from the sandbox row
+      // (no FK cascade), so the per-channel history rows would otherwise be
+      // orphaned forever after the agent is gone. A failure here leaves stale
+      // rows but never un-deletes the (already gone) sandbox.
+      try {
+        const removed = await sharedRuntimeHistoryRepository.deleteByAgent(agentId);
+        if (removed > 0) {
+          logger.info("[agent-sandbox] Cleaned up shared-runtime history after delete", {
+            agentId,
+            channelsRemoved: removed,
+          });
+        }
+      } catch (err) {
+        logger.warn("[agent-sandbox] Failed to clean up shared-runtime history", {
           agentId,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -3526,6 +3547,17 @@ export class ElizaSandboxService {
   }
 
   /**
+   * A row in `deletion_pending` / `deletion_failed` is logically gone — an
+   * agent_delete job owns it. Bringing it back up (resume / wake / restart)
+   * would resurrect a container we are tearing down, so these states are
+   * treated exactly like a missing row: the daemon handler maps "Agent not
+   * found" to a terminal no-op instead of resurrecting the agent.
+   */
+  private isAwaitingDeletion(status: AgentSandboxStatus): boolean {
+    return status === "deletion_pending" || status === "deletion_failed";
+  }
+
+  /**
    * Daemon-side handler for the `agent_resume` job. Delegates to
    * `provision()` which restores `bridge_url` / `health_url` from the
    * provider's sandbox handle and reuses the existing shared DB
@@ -3548,7 +3580,7 @@ export class ElizaSandboxService {
     error?: string;
   }> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    if (!rec)
+    if (!rec || this.isAwaitingDeletion(rec.status))
       return {
         success: false,
         containerStarted: false,
@@ -3712,7 +3744,8 @@ export class ElizaSandboxService {
     error?: string;
   }> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    if (!rec) return { success: false, reprovisioned: false, error: "Agent not found" };
+    if (!rec || this.isAwaitingDeletion(rec.status))
+      return { success: false, reprovisioned: false, error: "Agent not found" };
     if (rec.status === "running" && rec.bridge_url) {
       return { success: true, reprovisioned: false };
     }
@@ -3753,6 +3786,20 @@ export class ElizaSandboxService {
     healthUrl?: string;
     error?: string;
   }> {
+    // Bail before shutdown()+provision() if the row is being deleted — restart
+    // would otherwise flip a deletion_pending row to `stopped` and rebuild a
+    // container the agent_delete job is tearing down. Reported as not-found so
+    // the daemon handler completes the job as a terminal no-op.
+    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    if (!rec || this.isAwaitingDeletion(rec.status)) {
+      return {
+        success: false,
+        containerStopped: false,
+        containerStarted: false,
+        error: "Agent not found",
+      };
+    }
+
     const shutdownResult = await this.shutdown(agentId, orgId);
     if (!shutdownResult.success) {
       if (shutdownResult.error === "Agent not found") {

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -3579,7 +3579,11 @@ export class ElizaSandboxService {
     reprovisioned: boolean;
     error?: string;
   }> {
-    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    // Read from the PRIMARY: a replica-lagged "Agent not found" / stale status
+    // here would turn a legitimate resume into a terminal no-op (the daemon
+    // maps "Agent not found" to completed), silently dropping the request. The
+    // existence + deletion-state check must be authoritative.
+    const rec = await this.getAgentForWrite(agentId, orgId);
     if (!rec || this.isAwaitingDeletion(rec.status))
       return {
         success: false,
@@ -3630,7 +3634,8 @@ export class ElizaSandboxService {
     backupId?: string;
     error?: string;
   }> {
-    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    // Primary read: replica lag must not turn a real sleep into a no-op.
+    const rec = await this.getAgentForWrite(agentId, orgId);
     if (!rec) return { success: false, containerRemoved: false, error: "Agent not found" };
     if (rec.status === "sleeping") return { success: true, containerRemoved: true };
     if (rec.status === "provisioning") {
@@ -3743,7 +3748,8 @@ export class ElizaSandboxService {
     restoredBackupId?: string;
     error?: string;
   }> {
-    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    // Primary read: a replica-lagged "Agent not found" must not no-op a wake.
+    const rec = await this.getAgentForWrite(agentId, orgId);
     if (!rec || this.isAwaitingDeletion(rec.status))
       return { success: false, reprovisioned: false, error: "Agent not found" };
     if (rec.status === "running" && rec.bridge_url) {
@@ -3789,8 +3795,10 @@ export class ElizaSandboxService {
     // Bail before shutdown()+provision() if the row is being deleted — restart
     // would otherwise flip a deletion_pending row to `stopped` and rebuild a
     // container the agent_delete job is tearing down. Reported as not-found so
-    // the daemon handler completes the job as a terminal no-op.
-    const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    // the daemon handler completes the job as a terminal no-op. Read from the
+    // PRIMARY so a replica-lagged status doesn't bail a legitimate restart (or
+    // miss an in-flight deletion) on stale data.
+    const rec = await this.getAgentForWrite(agentId, orgId);
     if (!rec || this.isAwaitingDeletion(rec.status)) {
       return {
         success: false,

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Enqueue-side delete-lifecycle hardening for ProvisioningJobService:
+ *   - enqueueAgentDeleteOnce.beforeInsert cancels the agent's OTHER pending /
+ *     in_progress lifecycle jobs (delete wins; never self-cancels the delete).
+ *   - enqueueScheduledBackups only enqueues reachable (bridge_url IS NOT NULL)
+ *     running, non-pool agents — idle agents never get an auto snapshot job.
+ *   - reEnqueueFailedDeletions re-arms old `deletion_failed` rows by enqueuing a
+ *     fresh agent_delete (so a transient unreachable-node delete completes once
+ *     the node returns).
+ *
+ * `dbWrite` is a Proxy that spyOn can't intercept, so this file mock.modules the
+ * helpers module with chainable query builders that capture the generated SQL.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+// ---- captured query state ----
+let capturedSelectWhere: SQL | undefined;
+let capturedUpdateWhere: SQL | undefined;
+let selectRows: unknown[] = [];
+let cancelledReturning: Array<{ id: string }> = [];
+
+// select(...).from(...).where(clause).limit(n) -> selectRows
+const selectLimit = mock(() => selectRows);
+const selectWhere = mock((clause: SQL) => {
+  capturedSelectWhere = clause;
+  return { limit: selectLimit };
+});
+const selectFrom = mock(() => ({ where: selectWhere }));
+const select = mock(() => ({ from: selectFrom }));
+
+// Transaction tx: only the bits enqueueLifecycleJob + beforeInsert touch.
+const txExecute = mock(async () => ({ rows: [] }));
+// tx.select().from().where().orderBy().limit() -> [] (no existing job) for the
+// reuse lookup; tx.select().from().where().limit() -> [sandbox] for the row.
+let txSelectCall = 0;
+const txSelect = mock(() => {
+  txSelectCall += 1;
+  const isSandboxLookup = txSelectCall === 1;
+  const rows = isSandboxLookup ? [{ id: "agent", status: "running", updated_at: new Date() }] : [];
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: () => rows,
+  } as Record<string, unknown>;
+  return chain;
+});
+const txUpdateWhere = mock((clause: SQL) => {
+  capturedUpdateWhere = clause;
+  return { returning: mock(async () => cancelledReturning) };
+});
+const txUpdateSet = mock(() => ({ where: txUpdateWhere }));
+const txUpdate = mock(() => ({ set: txUpdateSet }));
+const txInsertValues = mock(() => ({
+  returning: mock(async () => [{ id: "job-1", type: "agent_delete", status: "pending", data: {} }]),
+}));
+const txInsert = mock(() => ({ values: txInsertValues }));
+const tx = {
+  execute: txExecute,
+  select: txSelect,
+  update: txUpdate,
+  insert: txInsert,
+};
+const transaction = mock(async (fn: (t: typeof tx) => Promise<unknown>) => {
+  txSelectCall = 0;
+  return fn(tx);
+});
+
+const dbWriteMock = { select, transaction };
+
+// Provide the FULL helpers surface so transitive importers (repositories) keep
+// working; only dbWrite is swapped for our capturing mock.
+mock.module("../../db/helpers", () => ({
+  db: dbWriteMock,
+  dbRead: { select, query: {} },
+  dbWrite: dbWriteMock,
+  getDbConnectionInfo: () => ({}),
+  getReadDb: () => dbWriteMock,
+  getWriteDb: () => dbWriteMock,
+  getDbRoutingInfo: () => ({}),
+  logDbRouting: () => {},
+  useReadDb: (fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  useWriteDb: (fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  readQuery: async (_label: string, fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  writeQuery: async (_label: string, fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  writeTransaction: (fn: (t: typeof tx) => Promise<unknown>) => transaction(fn),
+}));
+
+// Avoid the real outbound-URL guard and job hydration/insert-prep pulling in DB.
+mock.module("../security/outbound-url", () => ({
+  assertSafeOutboundUrl: mock(async (u: string) => u),
+}));
+
+// hydrateJob / prepareJobInsertData reach into object-storage offloading; stub
+// them to keep the enqueue transaction pure.
+mock.module("../../db/repositories/jobs", () => ({
+  hydrateJob: async (j: unknown) => j,
+  prepareJobInsertData: async (j: unknown) => j,
+  jobsRepository: {},
+}));
+
+afterEach(() => {
+  capturedSelectWhere = undefined;
+  capturedUpdateWhere = undefined;
+  selectRows = [];
+  cancelledReturning = [];
+  txSelectCall = 0;
+});
+
+describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", () => {
+  test("marks the agent's non-delete pending/in_progress jobs cancelled", async () => {
+    cancelledReturning = [{ id: "j-restart" }, { id: "j-snapshot" }];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+
+    await provisioningJobService.enqueueAgentDeleteOnce({
+      agentId: "agent",
+      organizationId: "22222222-2222-4222-8222-222222222222",
+      userId: "33333333-3333-4333-8333-333333333333",
+    });
+
+    // The deletion-pending flip + the cancellation update both ran.
+    expect(txUpdate).toHaveBeenCalled();
+    // The cancellation set status='cancelled'.
+    const cancelSet = txUpdateSet.mock.calls.find(
+      (c) => (c[0] as { status?: string })?.status === "cancelled",
+    );
+    expect(cancelSet).toBeDefined();
+
+    // The cancel WHERE excludes agent_delete (delete never self-cancels) and is
+    // scoped to pending/in_progress.
+    expect(capturedUpdateWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedUpdateWhere as SQL);
+    expect(sql.sql).toContain("pending");
+    expect(sql.sql).toContain("in_progress");
+    expect(sql.params).toContain("agent_delete");
+  });
+});
+
+describe("enqueueScheduledBackups — only reachable agents", () => {
+  test("query requires bridge_url IS NOT NULL (idle agents are never enqueued)", async () => {
+    selectRows = []; // nothing due → no enqueue, but we assert the WHERE shape.
+    const { provisioningJobService } = await import("./provisioning-jobs");
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+    expect(res).toEqual({ scanned: 0, enqueued: 0 });
+
+    expect(capturedSelectWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL);
+    expect(sql.sql).toContain("bridge_url");
+    expect(sql.sql.toLowerCase()).toContain("is not null");
+  });
+
+  test("a due, reachable agent is enqueued for an auto snapshot", async () => {
+    selectRows = [{ id: "agent", organizationId: "org", userId: "user" }];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentSnapshotOnce").mockResolvedValue({
+      created: true,
+      job: { id: "snap-1" },
+    } as never);
+    try {
+      const res = await provisioningJobService.enqueueScheduledBackups();
+      expect(res).toEqual({ scanned: 1, enqueued: 1 });
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueSpy.mock.calls[0]?.[0]).toMatchObject({
+        agentId: "agent",
+        snapshotType: "auto",
+      });
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+  });
+});
+
+describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () => {
+  test("re-enqueues agent_delete for each old deletion_failed row", async () => {
+    selectRows = [
+      { id: "a1", organizationId: "o1", userId: "u1" },
+      { id: "a2", organizationId: "o2", userId: "u2" },
+    ];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockResolvedValue({
+      created: true,
+      job: { id: "del-1" },
+    } as never);
+    try {
+      const res = await provisioningJobService.reEnqueueFailedDeletions();
+      expect(res).toEqual({ scanned: 2, reEnqueued: 2, failed: 0 });
+      expect(enqueueSpy).toHaveBeenCalledTimes(2);
+      expect(enqueueSpy.mock.calls.map((c) => c[0].agentId)).toEqual(["a1", "a2"]);
+
+      // The query selects status='deletion_failed' older than the cutoff.
+      const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL);
+      expect(sql.params).toContain("deletion_failed");
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("an enqueue throw on one row is counted, the rest still process", async () => {
+    selectRows = [
+      { id: "a1", organizationId: "o1", userId: "u1" },
+      { id: "a2", organizationId: "o2", userId: "u2" },
+    ];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockImplementation(
+      async (p) => {
+        if (p.agentId === "a1") throw new Error("node still down");
+        return { created: true, job: { id: "del-2" } } as never;
+      },
+    );
+    try {
+      const res = await provisioningJobService.reEnqueueFailedDeletions();
+      expect(res).toEqual({ scanned: 2, reEnqueued: 1, failed: 1 });
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -113,11 +113,13 @@ afterEach(() => {
 describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", () => {
   test("marks the agent's non-delete pending/in_progress jobs cancelled", async () => {
     cancelledReturning = [{ id: "j-restart" }, { id: "j-snapshot" }];
+    const orgId = "22222222-2222-4222-8222-222222222222";
+    const agentId = "agent";
     const { provisioningJobService } = await import("./provisioning-jobs");
 
     await provisioningJobService.enqueueAgentDeleteOnce({
-      agentId: "agent",
-      organizationId: "22222222-2222-4222-8222-222222222222",
+      agentId,
+      organizationId: orgId,
       userId: "33333333-3333-4333-8333-333333333333",
     });
 
@@ -129,13 +131,25 @@ describe("enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs", (
     );
     expect(cancelSet).toBeDefined();
 
-    // The cancel WHERE excludes agent_delete (delete never self-cancels) and is
-    // scoped to pending/in_progress.
-    expect(capturedUpdateWhere).toBeDefined();
-    const sql = new PgDialect().sqlToQuery(capturedUpdateWhere as SQL);
+    // The cancel WHERE is scoped to this org AND this agent, excludes
+    // agent_delete (delete never self-cancels), and only touches
+    // pending/in_progress rows (terminal jobs are never reopened). Asserting the
+    // scoping prevents a future edit from cancelling sibling agents' or other
+    // orgs' jobs.
+    if (!capturedUpdateWhere) throw new Error("cancel WHERE clause was not captured");
+    const sql = new PgDialect().sqlToQuery(capturedUpdateWhere);
+    // Status filter: only pending/in_progress, never a terminal status.
     expect(sql.sql).toContain("pending");
     expect(sql.sql).toContain("in_progress");
+    expect(sql.sql).not.toContain("completed");
+    expect(sql.sql).not.toContain("cancelled");
+    expect(sql.sql).not.toContain("failed");
+    // Type filter: excludes agent_delete (the != operator + the bound value).
+    expect(sql.sql).toMatch(/<>|!=|not/i);
     expect(sql.params).toContain("agent_delete");
+    // Org + agent scoping: both ids are bound parameters of this WHERE clause.
+    expect(sql.params).toContain(orgId);
+    expect(sql.params).toContain(agentId);
   });
 });
 
@@ -177,8 +191,8 @@ describe("enqueueScheduledBackups — only reachable agents", () => {
 describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () => {
   test("re-enqueues agent_delete for each old deletion_failed row", async () => {
     selectRows = [
-      { id: "a1", organizationId: "o1", userId: "u1" },
-      { id: "a2", organizationId: "o2", userId: "u2" },
+      { id: "a1", organizationId: "o1", userId: "u1", errorCount: 1 },
+      { id: "a2", organizationId: "o2", userId: "u2", errorCount: 2 },
     ];
     const { provisioningJobService } = await import("./provisioning-jobs");
     const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockResolvedValue({
@@ -187,7 +201,7 @@ describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () =
     } as never);
     try {
       const res = await provisioningJobService.reEnqueueFailedDeletions();
-      expect(res).toEqual({ scanned: 2, reEnqueued: 2, failed: 0 });
+      expect(res).toEqual({ scanned: 2, reEnqueued: 2, failed: 0, abandoned: 0 });
       expect(enqueueSpy).toHaveBeenCalledTimes(2);
       expect(enqueueSpy.mock.calls.map((c) => c[0].agentId)).toEqual(["a1", "a2"]);
 
@@ -201,8 +215,8 @@ describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () =
 
   test("an enqueue throw on one row is counted, the rest still process", async () => {
     selectRows = [
-      { id: "a1", organizationId: "o1", userId: "u1" },
-      { id: "a2", organizationId: "o2", userId: "u2" },
+      { id: "a1", organizationId: "o1", userId: "u1", errorCount: 0 },
+      { id: "a2", organizationId: "o2", userId: "u2", errorCount: 0 },
     ];
     const { provisioningJobService } = await import("./provisioning-jobs");
     const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockImplementation(
@@ -213,7 +227,47 @@ describe("reEnqueueFailedDeletions — recover stuck deletion_failed rows", () =
     );
     try {
       const res = await provisioningJobService.reEnqueueFailedDeletions();
-      expect(res).toEqual({ scanned: 2, reEnqueued: 1, failed: 1 });
+      expect(res).toEqual({ scanned: 2, reEnqueued: 1, failed: 1, abandoned: 0 });
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("circuit-breaker: a row past the re-enqueue budget is abandoned, not re-armed", async () => {
+    // a1 is under the default budget (5) and gets re-enqueued; a2 is at/over the
+    // budget and must be skipped + surfaced for ops instead of looping forever.
+    selectRows = [
+      { id: "a1", organizationId: "o1", userId: "u1", errorCount: 4 },
+      { id: "a2", organizationId: "o2", userId: "u2", errorCount: 5 },
+    ];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockResolvedValue({
+      created: true,
+      job: { id: "del-1" },
+    } as never);
+    try {
+      const res = await provisioningJobService.reEnqueueFailedDeletions();
+      expect(res).toEqual({ scanned: 2, reEnqueued: 1, failed: 0, abandoned: 1 });
+      // Only the under-budget row was re-enqueued; the dead one was not.
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueSpy.mock.calls[0]?.[0].agentId).toBe("a1");
+    } finally {
+      enqueueSpy.mockRestore();
+    }
+  });
+
+  test("circuit-breaker threshold is configurable via maxReEnqueues", async () => {
+    selectRows = [{ id: "a1", organizationId: "o1", userId: "u1", errorCount: 2 }];
+    const { provisioningJobService } = await import("./provisioning-jobs");
+    const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockResolvedValue({
+      created: true,
+      job: { id: "del-1" },
+    } as never);
+    try {
+      // With a budget of 2, an errorCount of 2 is already abandoned.
+      const res = await provisioningJobService.reEnqueueFailedDeletions({ maxReEnqueues: 2 });
+      expect(res).toEqual({ scanned: 1, reEnqueued: 0, failed: 0, abandoned: 1 });
+      expect(enqueueSpy).not.toHaveBeenCalled();
     } finally {
       enqueueSpy.mockRestore();
     }

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Delete-lifecycle hardening for ProvisioningJobService.
+ *
+ * Covers the daemon-side handler policy that keeps a deleted/idle agent from
+ * masking real failures:
+ *   - "Agent not found" from any lifecycle service call resolves the job as a
+ *     terminal completed no-op (no retry-to-failed). A delete that landed first
+ *     means the suspend/resume/restart/snapshot has nothing left to do.
+ *   - An `auto` snapshot of a non-running agent ("Sandbox is not running") is a
+ *     terminal SKIP (completed, not failed) — these were 40/45 hard-failures.
+ *   - A `manual` snapshot of a non-running agent still errors (the user asked).
+ *
+ * Drives the real processPendingJobs loop with claimPendingJobs + the service
+ * call spied, then asserts the job was marked completed (no-op/skip) vs the
+ * error path (incrementAttempt). Pure spy-based, no DB.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { jobsRepository } from "../../db/repositories/jobs";
+import type { Job } from "../../db/schemas/jobs";
+import { elizaSandboxService } from "./eliza-sandbox";
+import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+const USER = "33333333-3333-4333-8333-333333333333";
+
+function makeJob(type: ProvisioningJobType, extraData: Record<string, unknown> = {}): Job {
+  const now = new Date("2026-06-20T00:00:00.000Z");
+  return {
+    id: "44444444-4444-4444-8444-444444444444",
+    type,
+    status: "in_progress",
+    data: { agentId: AGENT, organizationId: ORG, userId: USER, ...extraData },
+    data_storage: "inline",
+    data_key: null,
+    agent_id: AGENT,
+    character_id: null,
+    result: null,
+    result_storage: "inline",
+    result_key: null,
+    error: null,
+    error_storage: "inline",
+    error_key: null,
+    attempts: 1,
+    max_attempts: 3,
+    organization_id: ORG,
+    user_id: USER,
+    api_key_id: null,
+    generation_id: null,
+    webhook_url: null,
+    webhook_status: null,
+    estimated_completion_at: null,
+    scheduled_for: now,
+    started_at: now,
+    completed_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/**
+ * Run processPendingJobs for exactly one job type, claiming a single crafted
+ * job. Returns the spies so the caller can assert terminal disposition.
+ */
+function withClaimedJob(type: ProvisioningJobType, extraData: Record<string, unknown> = {}) {
+  const job = makeJob(type, extraData);
+  const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockImplementation(
+    async (f: { type: string }) => (f.type === type ? [job] : []),
+  );
+  const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
+  const updateStatusSpy = spyOn(jobsRepository, "updateStatus").mockResolvedValue(undefined);
+  const updateSpy = spyOn(jobsRepository, "update").mockResolvedValue(undefined as never);
+  const incrementSpy = spyOn(jobsRepository, "incrementAttempt").mockResolvedValue(undefined);
+  return {
+    job,
+    claimSpy,
+    recoverSpy,
+    updateStatusSpy,
+    updateSpy,
+    incrementSpy,
+    restore() {
+      claimSpy.mockRestore();
+      recoverSpy.mockRestore();
+      updateStatusSpy.mockRestore();
+      updateSpy.mockRestore();
+      incrementSpy.mockRestore();
+    },
+  };
+}
+
+describe("ProvisioningJobService — Agent-not-found is a terminal no-op", () => {
+  const cases: Array<{
+    name: string;
+    type: ProvisioningJobType;
+    method: keyof typeof elizaSandboxService;
+  }> = [
+    { name: "suspend", type: JOB_TYPES.AGENT_SUSPEND, method: "executeSuspend" },
+    { name: "resume", type: JOB_TYPES.AGENT_RESUME, method: "executeResume" },
+    { name: "sleep", type: JOB_TYPES.AGENT_SLEEP, method: "executeSleep" },
+    { name: "wake", type: JOB_TYPES.AGENT_WAKE, method: "executeWake" },
+    { name: "restart", type: JOB_TYPES.AGENT_RESTART, method: "executeRestart" },
+    { name: "snapshot", type: JOB_TYPES.AGENT_SNAPSHOT, method: "executeSnapshot" },
+  ];
+
+  for (const c of cases) {
+    test(`${c.name}: completes (no-op) and never increments attempts`, async () => {
+      const ctx = withClaimedJob(
+        c.type,
+        c.type === JOB_TYPES.AGENT_SNAPSHOT ? { snapshotType: "auto" } : {},
+      );
+      const svcSpy = spyOn(elizaSandboxService, c.method).mockResolvedValue({
+        success: false,
+        error: "Agent not found",
+      } as never);
+      try {
+        const res = await provisioningJobService.processPendingJobs(1, { jobTypes: [c.type] });
+        expect(res.claimed).toBe(1);
+        expect(res.succeeded).toBe(1);
+        expect(res.failed).toBe(0);
+        // Marked completed as a no-op…
+        const completed = ctx.updateStatusSpy.mock.calls.find((call) => call[1] === "completed");
+        expect(completed).toBeDefined();
+        expect(completed?.[2]?.result).toMatchObject({ skipped: true, reason: "Agent not found" });
+        // …and NEVER counted as a failed attempt.
+        expect(ctx.incrementSpy).not.toHaveBeenCalled();
+      } finally {
+        svcSpy.mockRestore();
+        ctx.restore();
+      }
+    });
+  }
+});
+
+describe("ProvisioningJobService — auto snapshot of an idle agent is a terminal SKIP", () => {
+  test("auto + 'Sandbox is not running' → completed-as-skipped, no retry", async () => {
+    const ctx = withClaimedJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" });
+    const svcSpy = spyOn(elizaSandboxService, "executeSnapshot").mockResolvedValue({
+      success: false,
+      error: "Sandbox is not running",
+    } as never);
+    try {
+      const res = await provisioningJobService.processPendingJobs(1, {
+        jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+      });
+      expect(res.succeeded).toBe(1);
+      expect(res.failed).toBe(0);
+      const completed = ctx.updateStatusSpy.mock.calls.find((call) => call[1] === "completed");
+      expect(completed).toBeDefined();
+      expect(completed?.[2]?.result).toMatchObject({
+        skipped: true,
+        reason: "Sandbox is not running",
+      });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      svcSpy.mockRestore();
+      ctx.restore();
+    }
+  });
+
+  test("manual + 'Sandbox is not running' → still errors (the user asked for it)", async () => {
+    const ctx = withClaimedJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "manual" });
+    const svcSpy = spyOn(elizaSandboxService, "executeSnapshot").mockResolvedValue({
+      success: false,
+      error: "Sandbox is not running",
+    } as never);
+    try {
+      const res = await provisioningJobService.processPendingJobs(1, {
+        jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+      });
+      // The handler throws → counted failed → incrementAttempt runs.
+      expect(res.failed).toBe(1);
+      expect(res.succeeded).toBe(0);
+      expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+      // It is NOT silently completed.
+      const completed = ctx.updateStatusSpy.mock.calls.find((call) => call[1] === "completed");
+      expect(completed).toBeUndefined();
+    } finally {
+      svcSpy.mockRestore();
+      ctx.restore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -597,8 +597,14 @@ interface LifecycleJobOptions<TData extends object> {
    * and before the new job is inserted. Used by delete to flip the
    * sandbox row to `deletion_pending` so the UI reflects intent and
    * concurrent mutations bail. Skipped if an existing job is reused.
+   * Receives the just-read sandbox row so it can branch on the prior
+   * status (e.g. delete resets the failure counter on a fresh, non-delete
+   * enqueue but preserves it across recovery re-enqueues).
    */
-  beforeInsert?: (tx: Parameters<Parameters<typeof dbWrite.transaction>[0]>[0]) => Promise<void>;
+  beforeInsert?: (
+    tx: Parameters<Parameters<typeof dbWrite.transaction>[0]>[0],
+    sandbox: LifecycleSandboxRow,
+  ) => Promise<void>;
 }
 
 /**
@@ -693,7 +699,7 @@ export class ProvisioningJobService {
         return { job: await hydrateJob(existing), created: false };
       }
 
-      await opts.beforeInsert?.(tx);
+      await opts.beforeInsert?.(tx, sandbox);
 
       const [job] = await tx
         .insert(jobs)
@@ -805,11 +811,20 @@ export class ProvisioningJobService {
       // Flip status so the UI shows "deleting" and concurrent mutations
       // bail. Actual row removal happens in executeAgentDelete once SSH
       // stop() succeeds.
-      beforeInsert: async (tx) => {
+      beforeInsert: async (tx, sandbox) => {
+        // A genuine user-initiated delete (the row is not already in a deletion
+        // state) starts the deletion-failure counter fresh — error_count may
+        // carry a stale provisioning-error value, and a new delete should get a
+        // full set of recovery sweeps before the circuit-breaker abandons it.
+        // A recovery re-enqueue (status is already deletion_pending/_failed)
+        // PRESERVES the count so reEnqueueFailedDeletions can stop the loop.
+        const isRecoveryReEnqueue =
+          sandbox.status === "deletion_pending" || sandbox.status === "deletion_failed";
         await tx
           .update(agentSandboxes)
           .set({
             status: "deletion_pending" as const,
+            ...(isRecoveryReEnqueue ? {} : { error_count: 0 }),
             updated_at: new Date(),
           })
           .where(eq(agentSandboxes.id, params.agentId));
@@ -1520,11 +1535,19 @@ export class ProvisioningJobService {
       case JOB_TYPES.AGENT_DELETE: {
         const { agentId } = readAgentDeleteJobData(job);
         return async (tx) => {
+          // Bump error_count so reEnqueueFailedDeletions can circuit-break a
+          // permanently-dead node: each exhausted agent_delete adds one, and
+          // once the count crosses the re-enqueue threshold the sweep stops
+          // re-arming the row and alerts ops instead of looping forever. Once a
+          // row reaches deletion_failed the only writer of error_count is this
+          // path (markError only touches `error` rows), so the count tracks
+          // failed delete sweeps. A fresh user-initiated delete resets it.
           await tx
             .update(agentSandboxes)
             .set({
               status: "deletion_failed",
               error_message: `Deletion permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
+              error_count: sql`${agentSandboxes.error_count} + 1`,
               updated_at: new Date(),
             })
             .where(eq(agentSandboxes.id, agentId));
@@ -2447,6 +2470,13 @@ export class ProvisioningJobService {
    * since come back will finally drop the container + row. `minAgeMs` keeps
    * this from fighting the live retry loop right after a failure.
    *
+   * Circuit-breaker: a permanently-dead node would otherwise be re-armed every
+   * sweep forever. Each exhausted agent_delete bumps the sandbox's `error_count`
+   * (see the AGENT_DELETE failure handler), so a row that has already been
+   * re-enqueued `maxReEnqueues` times is SKIPPED — logged once as
+   * `event: "deletion.abandoned_candidate"` for ops to investigate (the
+   * container likely needs a manual node-level teardown) rather than looping.
+   *
    * NOTE (follow-up): capacity accounting still counts `deletion_failed` rows
    * until they are actually removed; excluding them from capacity is a separate
    * change in the agent-creation path.
@@ -2454,9 +2484,16 @@ export class ProvisioningJobService {
   async reEnqueueFailedDeletions(params?: {
     minAgeMs?: number;
     maxAgents?: number;
-  }): Promise<{ scanned: number; reEnqueued: number; failed: number }> {
+    maxReEnqueues?: number;
+  }): Promise<{
+    scanned: number;
+    reEnqueued: number;
+    failed: number;
+    abandoned: number;
+  }> {
     const minAgeMs = params?.minAgeMs ?? 30 * 60 * 1000; // 30m
     const maxAgents = params?.maxAgents ?? 50;
+    const maxReEnqueues = params?.maxReEnqueues ?? 5;
     const cutoff = new Date(Date.now() - minAgeMs);
 
     const stuck = await dbWrite
@@ -2464,6 +2501,7 @@ export class ProvisioningJobService {
         id: agentSandboxes.id,
         organizationId: agentSandboxes.organization_id,
         userId: agentSandboxes.user_id,
+        errorCount: agentSandboxes.error_count,
       })
       .from(agentSandboxes)
       .where(
@@ -2476,7 +2514,21 @@ export class ProvisioningJobService {
 
     let reEnqueued = 0;
     let failed = 0;
+    let abandoned = 0;
     for (const agent of stuck) {
+      // Circuit-breaker: a row that has burned through maxReEnqueues sweeps is a
+      // probably-dead node — stop re-arming it and surface it for ops once.
+      if ((agent.errorCount ?? 0) >= maxReEnqueues) {
+        abandoned += 1;
+        logger.warn("[provisioning-jobs] deletion abandoned — exceeded re-enqueue budget", {
+          event: "deletion.abandoned_candidate",
+          agentId: agent.id,
+          orgId: agent.organizationId,
+          errorCount: agent.errorCount,
+          maxReEnqueues,
+        });
+        continue;
+      }
       try {
         await this.enqueueAgentDeleteOnce({
           agentId: agent.id,
@@ -2498,9 +2550,10 @@ export class ProvisioningJobService {
         scanned: stuck.length,
         reEnqueued,
         failed,
+        abandoned,
       });
     }
-    return { scanned: stuck.length, reEnqueued, failed };
+    return { scanned: stuck.length, reEnqueued, failed, abandoned };
   }
 
   private async recoverStaleJobs(

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -13,7 +13,7 @@
  * - agent_restore: Restore from backup
  */
 
-import { and, desc, eq, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, ne, type SQL, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -218,6 +218,10 @@ export interface AgentSnapshotJobResult {
   sizeBytes?: number;
   createdAt?: string;
   error?: string;
+  /** True when an auto snapshot was a terminal no-op (agent had no live state). */
+  skipped?: boolean;
+  /** Human-readable reason for a skip (e.g. "Sandbox is not running"). */
+  reason?: string;
 }
 
 function agentProvisionJobDataToRecord(data: AgentProvisionJobData): Record<string, unknown> {
@@ -809,6 +813,34 @@ export class ProvisioningJobService {
             updated_at: new Date(),
           })
           .where(eq(agentSandboxes.id, params.agentId));
+
+        // Cancel any OTHER lifecycle jobs still queued for this agent. Delete
+        // wins: a pending restart/wake/resume/etc. that runs after the row is
+        // flipped to deletion_pending (or deleted) would either re-provision a
+        // container we are tearing down or fail noisily. Marking them
+        // `cancelled` (a terminal status claimPendingJobs/recoverStaleJobs
+        // never touch) drops them cleanly and keeps them auditable. The
+        // agent_delete row itself is inserted right after this and is excluded
+        // by type, so it is never self-cancelled.
+        const cancelled = await tx
+          .update(jobs)
+          .set({ status: "cancelled", updated_at: new Date() })
+          .where(
+            and(
+              eq(jobs.organization_id, params.organizationId),
+              eq(jobs.agent_id, params.agentId),
+              ne(jobs.type, JOB_TYPES.AGENT_DELETE),
+              sql`${jobs.status} IN ('pending', 'in_progress')`,
+            ),
+          )
+          .returning({ id: jobs.id });
+        if (cancelled.length > 0) {
+          logger.info("[provisioning-jobs] Cancelled pending jobs superseded by agent_delete", {
+            agentId: params.agentId,
+            orgId: params.organizationId,
+            cancelledCount: cancelled.length,
+          });
+        }
       },
     });
   }
@@ -1182,6 +1214,12 @@ export class ProvisioningJobService {
         and(
           eq(agentSandboxes.status, "running"),
           sql`${agentSandboxes.pool_status} IS NULL`,
+          // Only enqueue agents that are actually reachable. A `running` row with
+          // no bridge_url (shared-runtime / web-only agents, or a row whose
+          // bridge was cleared) has no live state endpoint to snapshot — the
+          // snapshot would just fail with "Sandbox is not running" and burn
+          // retries. Requiring bridge_url keeps those out of the queue entirely.
+          sql`${agentSandboxes.bridge_url} IS NOT NULL`,
           sql`(${agentSandboxes.last_backup_at} IS NULL OR ${agentSandboxes.last_backup_at} < ${cutoff})`,
         ),
       )
@@ -1625,6 +1663,34 @@ export class ProvisioningJobService {
     }
   }
 
+  /**
+   * Resolve a lifecycle job whose target agent no longer exists as a terminal
+   * no-op instead of retrying to exhaustion. Once the agent row is gone (e.g. a
+   * concurrent agent_delete completed first, or a stale in_progress job was
+   * recovered after deletion), there is nothing left to suspend/resume/restart
+   * /snapshot — throwing would just burn three attempts and land the job in
+   * `failed`, masking the real (benign) cause. Returns true when it claimed the
+   * job as completed; the caller must return early. Any other failure flows
+   * through the normal retry path.
+   */
+  private async completeIfAgentGone(
+    job: Job,
+    result: { success: boolean; error?: string },
+    agentId: string,
+  ): Promise<boolean> {
+    if (result.success || result.error !== "Agent not found") return false;
+    await jobsRepository.updateStatus(job.id, "completed", {
+      result: { cloudAgentId: agentId, skipped: true, reason: "Agent not found" },
+      completed_at: new Date(),
+    });
+    logger.info("[provisioning-jobs] Job completed as no-op — agent no longer exists", {
+      jobId: job.id,
+      jobType: job.type,
+      agentId,
+    });
+    return true;
+  }
+
   private async executeAgentSuspend(job: Job): Promise<void> {
     const data = readAgentSuspendJobData(job);
 
@@ -1640,6 +1706,8 @@ export class ProvisioningJobService {
     });
 
     const result = await elizaSandboxService.executeSuspend(data.agentId, data.organizationId);
+
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 
     if (!result.success) {
       await jobsRepository.update(job.id, {
@@ -1688,6 +1756,8 @@ export class ProvisioningJobService {
     });
 
     const result = await elizaSandboxService.executeResume(data.agentId, data.organizationId);
+
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 
     if (!result.success) {
       await jobsRepository.update(job.id, {
@@ -1740,6 +1810,8 @@ export class ProvisioningJobService {
 
     const result = await elizaSandboxService.executeSleep(data.agentId, data.organizationId);
 
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
+
     if (!result.success) {
       await jobsRepository.update(job.id, {
         result: agentSleepJobResultToRecord({
@@ -1791,6 +1863,8 @@ export class ProvisioningJobService {
 
     const result = await elizaSandboxService.executeWake(data.agentId, data.organizationId);
 
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
+
     if (!result.success) {
       await jobsRepository.update(job.id, {
         result: agentWakeJobResultToRecord({
@@ -1841,6 +1915,8 @@ export class ProvisioningJobService {
     });
 
     const result = await elizaSandboxService.executeRestart(data.agentId, data.organizationId);
+
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 
     if (!result.success) {
       await jobsRepository.update(job.id, {
@@ -1905,6 +1981,8 @@ export class ProvisioningJobService {
       data.fromDigest,
     );
 
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
+
     if (!result.success) {
       // Failures are visible by the row staying on the OLD image_digest; the
       // reconciler will try again on the next cycle. The worker's standard
@@ -1959,6 +2037,8 @@ export class ProvisioningJobService {
       data.organizationId,
       data.tail,
     );
+
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 
     if (!result.success) {
       await jobsRepository.update(job.id, {
@@ -2085,6 +2165,36 @@ export class ProvisioningJobService {
       data.snapshotType,
     );
 
+    if (await this.completeIfAgentGone(job, result, data.agentId)) return;
+
+    // Scheduled (auto) backups run across every non-pool sandbox, but an idle
+    // agent (stopped/sleeping/disconnected — no bridge_url) legitimately has no
+    // live state to snapshot. Treating that as a hard failure burned three
+    // attempts per agent per tick and flooded the failed-jobs view (the bulk of
+    // it was "Sandbox is not running"), masking real snapshot failures. For an
+    // auto snapshot this is a benign no-op, so mark it completed-as-skipped
+    // WITHOUT throwing (no retry). MANUAL snapshots still surface the error —
+    // the user explicitly asked for a backup and deserves to know it can't run.
+    if (
+      !result.success &&
+      data.snapshotType === "auto" &&
+      result.error === "Sandbox is not running"
+    ) {
+      await jobsRepository.updateStatus(job.id, "completed", {
+        result: agentSnapshotJobResultToRecord({
+          cloudAgentId: data.agentId,
+          skipped: true,
+          reason: result.error,
+        }),
+        completed_at: new Date(),
+      });
+      logger.info("[provisioning-jobs] auto snapshot skipped — agent not running", {
+        jobId: job.id,
+        agentId: data.agentId,
+      });
+      return;
+    }
+
     if (!result.success) {
       await jobsRepository.update(job.id, {
         result: agentSnapshotJobResultToRecord({
@@ -2192,6 +2302,8 @@ export class ProvisioningJobService {
     });
 
     const provResult = await elizaSandboxService.provision(data.agentId, data.organizationId);
+
+    if (await this.completeIfAgentGone(job, provResult, data.agentId)) return;
 
     if (!provResult.success) {
       await jobsRepository.update(job.id, {
@@ -2319,6 +2431,76 @@ export class ProvisioningJobService {
     await Promise.all(workers);
 
     return { total, recovered, reprovisioned, failed };
+  }
+
+  /**
+   * Re-arm stuck `deletion_failed` sandboxes so a delete that failed only
+   * because the host node was transiently unreachable eventually completes.
+   *
+   * `deletion_failed` is otherwise a dead-end: the agent_delete job exhausted
+   * its retries (e.g. the core was down for a deploy), so the row sits forever
+   * — visible to ops but never auto-recovered, and still counting against the
+   * org's agent capacity. This low-frequency sweep finds rows that have been
+   * `deletion_failed` longer than `minAgeMs` and enqueues a FRESH agent_delete
+   * for each. `enqueueAgentDeleteOnce` is idempotent (it dedups an in-flight
+   * delete and re-flips the row to `deletion_pending`), so a node that has
+   * since come back will finally drop the container + row. `minAgeMs` keeps
+   * this from fighting the live retry loop right after a failure.
+   *
+   * NOTE (follow-up): capacity accounting still counts `deletion_failed` rows
+   * until they are actually removed; excluding them from capacity is a separate
+   * change in the agent-creation path.
+   */
+  async reEnqueueFailedDeletions(params?: {
+    minAgeMs?: number;
+    maxAgents?: number;
+  }): Promise<{ scanned: number; reEnqueued: number; failed: number }> {
+    const minAgeMs = params?.minAgeMs ?? 30 * 60 * 1000; // 30m
+    const maxAgents = params?.maxAgents ?? 50;
+    const cutoff = new Date(Date.now() - minAgeMs);
+
+    const stuck = await dbWrite
+      .select({
+        id: agentSandboxes.id,
+        organizationId: agentSandboxes.organization_id,
+        userId: agentSandboxes.user_id,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.status, "deletion_failed"),
+          sql`${agentSandboxes.updated_at} < ${cutoff}`,
+        ),
+      )
+      .limit(maxAgents);
+
+    let reEnqueued = 0;
+    let failed = 0;
+    for (const agent of stuck) {
+      try {
+        await this.enqueueAgentDeleteOnce({
+          agentId: agent.id,
+          organizationId: agent.organizationId,
+          userId: agent.userId,
+        });
+        reEnqueued += 1;
+      } catch (error) {
+        failed += 1;
+        logger.warn("[provisioning-jobs] re-enqueue of failed deletion failed", {
+          agentId: agent.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (stuck.length > 0) {
+      logger.info("[provisioning-jobs] Re-enqueued stuck deletions", {
+        scanned: stuck.length,
+        reEnqueued,
+        failed,
+      });
+    }
+    return { scanned: stuck.length, reEnqueued, failed };
   }
 
   private async recoverStaleJobs(


### PR DESCRIPTION
From the audit (#8434) — the one "rough" dimension. **MAJOR×4:** (1) shared-runtime conversation history is now deleted on agent delete (was orphaned). (2) `agent_delete` cancels the agent's other pending jobs + every handler treats "Agent not found" as a completed no-op + resume/wake/restart bail on deletion_pending. (3) auto `agent_snapshot` on a not-running sandbox is now a terminal SKIP (the 40/45 noise) + scheduled backups require `bridge_url`; manual snapshots still error. (4) a sweep re-enqueues old `deletion_failed` rows so a transient-unreachable-node delete completes when the node returns. 49 tests.

_CI's red Format Check / lint-and-types are pre-existing develop-wide biome breakage in ~14 unrelated files, not this PR. This PR's own files pass biome + typecheck + tests. Refs #8434 (full lifecycle audit)._