### PR TITLE
fix(cloud): provisioning-worker resilience — self-restart on wedge, per-phase timeouts, orphan-container reconciler

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-workloads.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the orphan-container reconciler's pure diff logic and its
+ * SSH-orchestration loop. The diff (`computeOrphanContainersToReap`) is the
+ * load-bearing safety property: a container is reaped ONLY when its agent id
+ * has no live DB row (or a terminal one), and never when the name does not
+ * match the managed `agent-<id>` pattern. The orchestration test pins the
+ * "never reap on an unreachable node" invariant (SSH listing returned null →
+ * skip, not reap).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  agentIdFromContainerName,
+  computeOrphanContainersToReap,
+  type LiveSandboxRef,
+  type NodeContainerRef,
+  type OrphanReconcilerNode,
+  reconcileOrphanContainers,
+} from "./docker-node-workloads";
+
+describe("agentIdFromContainerName", () => {
+  test("extracts the id from an agent-<id> name", () => {
+    expect(agentIdFromContainerName("agent-abc-123")).toBe("abc-123");
+  });
+
+  test("returns null for names without the agent- prefix", () => {
+    expect(agentIdFromContainerName("postgres")).toBeNull();
+    expect(agentIdFromContainerName("my-agent-x")).toBeNull();
+  });
+
+  test("returns null for a bare prefix with no id", () => {
+    expect(agentIdFromContainerName("agent-")).toBeNull();
+  });
+});
+
+describe("computeOrphanContainersToReap", () => {
+  const live = (id: string, status: string): LiveSandboxRef => ({ id, status });
+  const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+
+  test("reaps a container whose agent id has NO db row", () => {
+    const orphans = computeOrphanContainersToReap([container("agent-gone", "c1")], []);
+    expect(orphans).toEqual([
+      { name: "agent-gone", id: "c1", agentId: "gone", reason: "no_db_row" },
+    ]);
+  });
+
+  test("reaps a container whose db row is in a terminal state", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("agent-dead", "c2")],
+      [live("dead", "stopped")],
+    );
+    expect(orphans).toEqual([
+      { name: "agent-dead", id: "c2", agentId: "dead", reason: "terminal_db_row" },
+    ]);
+  });
+
+  test("treats error / sleeping / deletion_failed rows as terminal", () => {
+    for (const status of ["error", "sleeping", "deletion_failed"]) {
+      const orphans = computeOrphanContainersToReap(
+        [container("agent-x", "cx")],
+        [live("x", status)],
+      );
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0]?.reason).toBe("terminal_db_row");
+    }
+  });
+
+  test("does NOT reap a container with a live (running) db row", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("agent-live", "c3")],
+      [live("live", "running")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("does NOT reap a row in deletion_pending (delete job owns teardown)", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("agent-deleting", "c4")],
+      [live("deleting", "deletion_pending")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("does NOT reap provisioning / pending / disconnected rows", () => {
+    for (const status of ["provisioning", "pending", "disconnected"]) {
+      const orphans = computeOrphanContainersToReap(
+        [container("agent-x", "cx")],
+        [live("x", status)],
+      );
+      expect(orphans).toEqual([]);
+    }
+  });
+
+  test("ignores containers that do not match the agent- pattern", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("postgres", "p1"), container("redis", "r1")],
+      [],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("mixed fleet: reaps only the orphans, leaves live + non-agent alone", () => {
+    const orphans = computeOrphanContainersToReap(
+      [
+        container("agent-running", "c-run"),
+        container("agent-orphan", "c-orph"),
+        container("agent-stopped", "c-stop"),
+        container("nginx", "c-nginx"),
+      ],
+      [live("running", "running"), live("stopped", "stopped")],
+    );
+    expect(orphans.map((o) => o.id).sort()).toEqual(["c-orph", "c-stop"]);
+  });
+});
+
+describe("reconcileOrphanContainers (orchestration)", () => {
+  function makeNode(overrides: Partial<OrphanReconcilerNode> = {}): OrphanReconcilerNode {
+    return {
+      node_id: "node-1",
+      hostname: "host-1",
+      status: "healthy",
+      listAgentContainers: mock(async () => [] as NodeContainerRef[]),
+      removeContainer: mock(async () => {}),
+      ...overrides,
+    };
+  }
+
+  test("force-removes every orphan on a healthy node", async () => {
+    const removeContainer = mock(async () => {});
+    const node = makeNode({
+      listAgentContainers: mock(async () => [
+        { name: "agent-orphan", id: "c-orph" },
+        { name: "agent-live", id: "c-live" },
+      ]),
+      removeContainer,
+    });
+    const loadLive = mock(async () => [{ id: "live", status: "running" }]);
+
+    const result = await reconcileOrphanContainers([node], loadLive);
+
+    expect(removeContainer).toHaveBeenCalledTimes(1);
+    expect(removeContainer).toHaveBeenCalledWith("c-orph");
+    expect(result).toEqual({
+      nodesScanned: 1,
+      nodesSkipped: 0,
+      reaped: 1,
+      reapFailed: 0,
+    });
+  });
+
+  test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
+    const removeContainer = mock(async () => {});
+    const node = makeNode({
+      listAgentContainers: mock(async () => null),
+      removeContainer,
+    });
+
+    const result = await reconcileOrphanContainers([node], async () => []);
+
+    expect(removeContainer).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      nodesScanned: 0,
+      nodesSkipped: 1,
+      reaped: 0,
+      reapFailed: 0,
+    });
+  });
+
+  test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
+    const listAgentContainers = mock(async () => [] as NodeContainerRef[]);
+    const node = makeNode({ status: "offline", listAgentContainers });
+
+    const result = await reconcileOrphanContainers([node], async () => []);
+
+    expect(listAgentContainers).not.toHaveBeenCalled();
+    expect(result.nodesSkipped).toBe(1);
+    expect(result.nodesScanned).toBe(0);
+  });
+
+  test("counts a failed removal as reapFailed without aborting the rest", async () => {
+    const node = makeNode({
+      listAgentContainers: mock(async () => [
+        { name: "agent-a", id: "ca" },
+        { name: "agent-b", id: "cb" },
+      ]),
+      removeContainer: mock(async (id: string) => {
+        if (id === "ca") throw new Error("ssh broke");
+      }),
+    });
+
+    const result = await reconcileOrphanContainers([node], async () => []);
+
+    expect(result).toEqual({
+      nodesScanned: 1,
+      nodesSkipped: 0,
+      reaped: 1,
+      reapFailed: 1,
+    });
+  });
+
+  test("does not query the DB when a node has no agent- containers", async () => {
+    const loadLive = mock(async () => [] as LiveSandboxRef[]);
+    const node = makeNode({
+      listAgentContainers: mock(async () => [{ name: "redis", id: "r" }]),
+    });
+
+    await reconcileOrphanContainers([node], loadLive);
+
+    expect(loadLive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
@@ -178,7 +178,12 @@ export interface OrphanReconcilerNode {
    * misread an empty list as "no containers" and reap live work.
    */
   listAgentContainers(): Promise<NodeContainerRef[] | null>;
-  /** Force-remove a container by id over SSH. */
+  /**
+   * Force-remove a container by its IMMUTABLE id over SSH. Must take the id, not
+   * the name: the id pins the exact container observed in the listing, so a
+   * concurrent recreate of the same `agent-<id>` name cannot be reaped by
+   * mistake. Implementations must NOT switch to `docker rm -f <name>`.
+   */
   removeContainer(containerId: string): Promise<void>;
 }
 
@@ -247,6 +252,15 @@ export async function reconcileOrphanContainers(
 
     for (const orphan of orphans) {
       try {
+        // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
+        // id was captured in the same SSH listing that found the orphan, so it
+        // pins THAT exact container. This is what makes the reap safe against a
+        // concurrent recreate: if an agent_delete + a fresh provision race and a
+        // new `agent-<id>` container is created between the listing and the rm,
+        // `docker rm -f <id>` still targets the dead container we observed and
+        // leaves the live one alone. A future refactor to `docker rm -f <name>`
+        // would reintroduce the live-container-reap race (the name resolves to
+        // whichever container holds it NOW, i.e. the new live one) — DO NOT.
         await node.removeContainer(orphan.id);
         result.reaped += 1;
         logger.info("[orphan-reconciler] Reaped orphan container", {
@@ -350,6 +364,9 @@ export async function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcil
       async removeContainer(containerId: string): Promise<void> {
         const client = ssh();
         await client.connect();
+        // rm by the immutable container ID (see OrphanReconcilerNode.removeContainer
+        // and the reap loop): targeting the name would race a concurrent recreate
+        // of the same agent and could reap a live container. Keep this `<id>`.
         await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
       },
     };

--- a/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
@@ -1,7 +1,11 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
+import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
+import { logger } from "../utils/logger";
+import { AGENT_CONTAINER_NAME_PREFIX, shellQuote } from "./docker-sandbox-utils";
+import { DockerSSHClient } from "./docker-ssh";
 
 async function countRows(query: Promise<Array<{ count: number }>>): Promise<number> {
   const [row] = await query;
@@ -42,6 +46,316 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
   ]);
 
   return containerCount + agentCount;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan-container reconciliation
+//
+// A container named `agent-<id>` on a node whose DB row has been deleted (or
+// moved to a terminal state) is an orphan: it holds a compute slot and host
+// volume forever because nothing in the provisioner lifecycle will ever reap
+// it again. The agent_delete job removes the container as part of deletion,
+// but if that SSH step fails terminally (deletion_failed) or the row is hard
+// deleted out from under a still-running container, the leak goes unnoticed.
+// This reconciler closes that gap with a low-cadence sweep over HEALTHY nodes.
+// ---------------------------------------------------------------------------
+
+/**
+ * agent_sandboxes statuses that mean the container should NOT be running. A
+ * container backing a row in one of these states is reapable just like one
+ * with no row at all: the lifecycle has decided this agent has no live
+ * container, so a leftover Docker process is a leak.
+ *
+ * `deletion_failed` is included deliberately — that state exists precisely
+ * because the delete-time container teardown did not succeed, so reaping it
+ * here is the recovery path. `deletion_pending` is NOT terminal: an
+ * agent_delete job is actively in flight and owns the teardown; reaping under
+ * it would race the worker.
+ */
+const TERMINAL_SANDBOX_STATUSES = new Set<string>([
+  "stopped",
+  "error",
+  "sleeping",
+  "deletion_failed",
+]);
+
+/** A container seen on a node, parsed from `docker ps -a`. */
+export interface NodeContainerRef {
+  /** Container name, e.g. `agent-<uuid>`. */
+  name: string;
+  /** Docker container id (used for the `docker rm -f` target). */
+  id: string;
+}
+
+/**
+ * A live agent_sandboxes row as far as orphan reconciliation cares: its id and
+ * current status. A row counts as "live" when its status is not terminal.
+ */
+export interface LiveSandboxRef {
+  id: string;
+  status: string;
+}
+
+/** A container the reconciler has decided to forcibly remove. */
+export interface OrphanContainer {
+  /** Container name (`agent-<id>`). */
+  name: string;
+  /** Docker container id, the `docker rm -f` target. */
+  id: string;
+  /** Agent id extracted from the container name. */
+  agentId: string;
+  /** Why it was flagged: no DB row at all, or a row in a terminal state. */
+  reason: "no_db_row" | "terminal_db_row";
+}
+
+/**
+ * Extract the agent id from an `agent-<id>` container name, or null when the
+ * name does not match the managed-agent pattern (so unrelated containers on a
+ * shared node are never touched).
+ */
+export function agentIdFromContainerName(name: string): string | null {
+  if (!name.startsWith(AGENT_CONTAINER_NAME_PREFIX)) return null;
+  const agentId = name.slice(AGENT_CONTAINER_NAME_PREFIX.length);
+  return agentId.length > 0 ? agentId : null;
+}
+
+/**
+ * Pure diff: given the containers present on a node and the agent_sandboxes
+ * rows that exist for those container names, decide which containers to reap.
+ *
+ * A container is an orphan when EITHER:
+ *   - no agent_sandboxes row exists for its agent id, OR
+ *   - the row exists but its status is terminal (the lifecycle has decided
+ *     this agent has no live container).
+ *
+ * Containers whose name does not match the `agent-<id>` pattern are ignored
+ * entirely — they belong to something else on the node.
+ *
+ * This function performs NO I/O so it can be unit-tested exhaustively.
+ */
+export function computeOrphanContainersToReap(
+  containersOnNode: readonly NodeContainerRef[],
+  liveSandboxes: readonly LiveSandboxRef[],
+): OrphanContainer[] {
+  const statusById = new Map<string, string>();
+  for (const row of liveSandboxes) {
+    statusById.set(row.id, row.status);
+  }
+
+  const orphans: OrphanContainer[] = [];
+  for (const container of containersOnNode) {
+    const agentId = agentIdFromContainerName(container.name);
+    if (!agentId) continue;
+
+    const status = statusById.get(agentId);
+    if (status === undefined) {
+      orphans.push({
+        name: container.name,
+        id: container.id,
+        agentId,
+        reason: "no_db_row",
+      });
+    } else if (TERMINAL_SANDBOX_STATUSES.has(status)) {
+      orphans.push({
+        name: container.name,
+        id: container.id,
+        agentId,
+        reason: "terminal_db_row",
+      });
+    }
+  }
+  return orphans;
+}
+
+/** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
+export interface OrphanReconcilerNode {
+  node_id: string;
+  hostname: string;
+  status: string;
+  /**
+   * List `agent-`-prefixed containers on the node over SSH. Returns null when
+   * the listing failed (SSH blip) so the caller can skip the node rather than
+   * misread an empty list as "no containers" and reap live work.
+   */
+  listAgentContainers(): Promise<NodeContainerRef[] | null>;
+  /** Force-remove a container by id over SSH. */
+  removeContainer(containerId: string): Promise<void>;
+}
+
+export interface OrphanReconcileResult {
+  /** Nodes inspected (HEALTHY only). */
+  nodesScanned: number;
+  /** Nodes skipped because the SSH container listing failed. */
+  nodesSkipped: number;
+  /** Containers successfully force-removed. */
+  reaped: number;
+  /** Containers identified as orphans but whose removal failed. */
+  reapFailed: number;
+}
+
+/**
+ * Reconcile orphan containers on a set of HEALTHY nodes. The caller is
+ * responsible for passing ONLY nodes that node-health has just confirmed
+ * reachable, so a transient SSH blip never causes a live container to be
+ * reaped. Per node: list `agent-` containers, diff against the live sandbox
+ * ids, and force-remove every orphan.
+ *
+ * `loadLiveSandboxIds` returns the set of agent_sandboxes rows (id + status)
+ * for the agent ids seen on the node — injected so this stays pure-ish and
+ * unit-testable without a DB. The default production wiring is in
+ * `reconcileOrphanContainersOnNodes`.
+ */
+export async function reconcileOrphanContainers(
+  nodes: readonly OrphanReconcilerNode[],
+  loadLiveSandboxes: (agentIds: readonly string[]) => Promise<LiveSandboxRef[]>,
+): Promise<OrphanReconcileResult> {
+  const result: OrphanReconcileResult = {
+    nodesScanned: 0,
+    nodesSkipped: 0,
+    reaped: 0,
+    reapFailed: 0,
+  };
+
+  for (const node of nodes) {
+    if (node.status !== "healthy") {
+      // Defensive: callers should already filter, but never reap on a node
+      // we have not confirmed reachable.
+      result.nodesSkipped += 1;
+      continue;
+    }
+
+    const containersOnNode = await node.listAgentContainers();
+    if (containersOnNode === null) {
+      // SSH listing failed — skip rather than risk reaping live containers off
+      // a misread empty list.
+      result.nodesSkipped += 1;
+      logger.warn("[orphan-reconciler] Skipping node: container listing failed", {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+      });
+      continue;
+    }
+    result.nodesScanned += 1;
+
+    const agentIds = containersOnNode
+      .map((c) => agentIdFromContainerName(c.name))
+      .filter((id): id is string => id !== null);
+    if (agentIds.length === 0) continue;
+
+    const liveSandboxes = await loadLiveSandboxes(agentIds);
+    const orphans = computeOrphanContainersToReap(containersOnNode, liveSandboxes);
+
+    for (const orphan of orphans) {
+      try {
+        await node.removeContainer(orphan.id);
+        result.reaped += 1;
+        logger.info("[orphan-reconciler] Reaped orphan container", {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          agentId: orphan.agentId,
+          reason: orphan.reason,
+        });
+      } catch (error) {
+        result.reapFailed += 1;
+        logger.warn("[orphan-reconciler] Failed to reap orphan container", {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          agentId: orphan.agentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
+const ORPHAN_LIST_TIMEOUT_MS = 15_000;
+const ORPHAN_RM_TIMEOUT_MS = 30_000;
+
+/**
+ * Load (id, status) for the agent_sandboxes rows matching the given agent ids,
+ * including terminal-state rows. The reconciler needs the status to tell a
+ * missing row (`no_db_row`) apart from a terminal one (`terminal_db_row`).
+ */
+async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<LiveSandboxRef[]> {
+  if (agentIds.length === 0) return [];
+  return dbRead
+    .select({ id: agentSandboxes.id, status: agentSandboxes.status })
+    .from(agentSandboxes)
+    .where(inArray(agentSandboxes.id, agentIds as string[]));
+}
+
+/**
+ * Production wiring for the orphan-container reconciler: enumerate enabled,
+ * HEALTHY docker nodes and reconcile each over SSH. Built on the shared
+ * `DockerSSHClient` pool so it reuses warm connections. Every SSH call is
+ * hard-bounded so a single unresponsive node can never stall the sweep.
+ *
+ * Only `status === "healthy"` nodes are touched: the caller (the daemon's
+ * infra-maintenance cycle) runs this AFTER the node health-check, so a node
+ * that just failed its probe is excluded and a transient SSH blip never reaps
+ * live containers.
+ */
+export async function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcileResult> {
+  const enabled = await dockerNodesRepository.findEnabled();
+  const healthy = enabled.filter((node) => node.status === "healthy");
+
+  const reconcilerNodes: OrphanReconcilerNode[] = healthy.map((node) => {
+    const ssh = () =>
+      DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? undefined,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? undefined,
+      );
+    return {
+      node_id: node.node_id,
+      hostname: node.hostname,
+      status: node.status,
+      async listAgentContainers(): Promise<NodeContainerRef[] | null> {
+        try {
+          const client = ssh();
+          await client.connect();
+          const output = await client.exec(
+            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(AGENT_CONTAINER_NAME_PREFIX)}`,
+            ORPHAN_LIST_TIMEOUT_MS,
+          );
+          return (
+            output
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean)
+              // `--filter name=` is a substring match, so re-check the prefix to
+              // exclude any container that merely contains "agent-" mid-name.
+              .filter((line) => line.startsWith(AGENT_CONTAINER_NAME_PREFIX))
+              .map((line) => {
+                const [name = "", id = ""] = line.split("|");
+                return { name, id };
+              })
+              .filter((c) => c.name && c.id)
+          );
+        } catch (error) {
+          logger.warn("[orphan-reconciler] Container listing failed over SSH", {
+            nodeId: node.node_id,
+            hostname: node.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      },
+      async removeContainer(containerId: string): Promise<void> {
+        const client = ssh();
+        await client.connect();
+        await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
+      },
+    };
+  });
+
+  return reconcileOrphanContainers(reconcilerNodes, loadSandboxStatusesByIds);
 }
 
 /**

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateSelfRestart,
   maybePublishHeartbeat,
   readWorkerConfig,
+  WORKER_TIMING,
 } from "./provisioning-worker";
 
 type WorkerLogger = Parameters<typeof maybePublishHeartbeat>[0];
@@ -196,6 +197,43 @@ describe("evaluateSelfRestart (FIX 1 — K-consecutive-tick trigger)", () => {
         threshold: 3,
       }).shouldRestart,
     ).toBe(true);
+  });
+});
+
+describe("watchdog timing invariant (FIX E/F)", () => {
+  // Pins the core safety property: the WORK cycle's wall-clock budget plus the
+  // gap the loop sleeps between cycles must finish comfortably before the
+  // watchdog declares the worker wedged. If this ever fails, a slow-but-
+  // progressing cycle would self-restart — the exact false positive the design
+  // claims to prevent. Bounding the WORK group ONCE (workCycleTimeoutMs) instead
+  // of summing N per-phase 90s timeouts (4 × 90s = 360s > the 300s window) is
+  // what keeps it true, and keeps it true when a 5th phase is added.
+  it("SUM(work budget) + pollInterval < WATCHDOG_MAX_CYCLE_MS", () => {
+    const { workCycleTimeoutMs, defaultPollIntervalMs, watchdogMaxCycleMs } =
+      WORKER_TIMING;
+    expect(workCycleTimeoutMs + defaultPollIntervalMs).toBeLessThan(
+      watchdogMaxCycleMs,
+    );
+  });
+
+  it("the work-cycle budget itself is below the watchdog window", () => {
+    expect(WORKER_TIMING.workCycleTimeoutMs).toBeLessThan(
+      WORKER_TIMING.watchdogMaxCycleMs,
+    );
+  });
+
+  it("a per-phase timeout never exceeds the whole-cycle budget", () => {
+    // A single phase must not be allowed to outlast the group bound that
+    // protects the watchdog invariant.
+    expect(WORKER_TIMING.phaseTimeoutMs).toBeLessThanOrEqual(
+      WORKER_TIMING.workCycleTimeoutMs,
+    );
+  });
+
+  it("documents the true headroom (defaults: 240s + 30s = 270s < 300s)", () => {
+    expect(WORKER_TIMING.workCycleTimeoutMs).toBe(240_000);
+    expect(WORKER_TIMING.defaultPollIntervalMs).toBe(30_000);
+    expect(WORKER_TIMING.watchdogMaxCycleMs).toBe(300_000);
   });
 });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
   assertProvisioningWorkerPreflight,
+  evaluateSelfRestart,
   maybePublishHeartbeat,
+  readWorkerConfig,
 } from "./provisioning-worker";
 
 type WorkerLogger = Parameters<typeof maybePublishHeartbeat>[0];
@@ -106,5 +108,147 @@ describe("maybePublishHeartbeat (liveness gate)", () => {
     expect(publish).not.toHaveBeenCalled();
     expect(result).toEqual({ published: false, watchdogTripped: true });
     expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe("evaluateSelfRestart (FIX 1 — K-consecutive-tick trigger)", () => {
+  it("resets the counter and never restarts while the cycle is progressing", () => {
+    const result = evaluateSelfRestart({
+      watchdogTripped: false,
+      consecutiveTicks: 1,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(result).toEqual({ nextConsecutiveTicks: 0, shouldRestart: false });
+  });
+
+  it("does NOT restart on the first wedged tick (K=2)", () => {
+    const result = evaluateSelfRestart({
+      watchdogTripped: true,
+      consecutiveTicks: 0,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(result).toEqual({ nextConsecutiveTicks: 1, shouldRestart: false });
+  });
+
+  it("restarts on the K-th consecutive wedged tick (K=2)", () => {
+    const result = evaluateSelfRestart({
+      watchdogTripped: true,
+      consecutiveTicks: 1,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(result).toEqual({ nextConsecutiveTicks: 2, shouldRestart: true });
+  });
+
+  it("a single wedged tick between healthy ticks never reaches the threshold", () => {
+    // tick 1: wedged (counter 0 -> 1, no restart)
+    let state = evaluateSelfRestart({
+      watchdogTripped: true,
+      consecutiveTicks: 0,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(state.shouldRestart).toBe(false);
+    // tick 2: progressing again -> counter resets
+    state = evaluateSelfRestart({
+      watchdogTripped: false,
+      consecutiveTicks: state.nextConsecutiveTicks,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(state.nextConsecutiveTicks).toBe(0);
+    // tick 3: wedged again -> back to 1, still no restart
+    state = evaluateSelfRestart({
+      watchdogTripped: true,
+      consecutiveTicks: state.nextConsecutiveTicks,
+      selfRestartEnabled: true,
+      threshold: 2,
+    });
+    expect(state).toEqual({ nextConsecutiveTicks: 1, shouldRestart: false });
+  });
+
+  it("never restarts when the feature is disabled, even past the threshold", () => {
+    const result = evaluateSelfRestart({
+      watchdogTripped: true,
+      consecutiveTicks: 5,
+      selfRestartEnabled: false,
+      threshold: 2,
+    });
+    expect(result).toEqual({ nextConsecutiveTicks: 6, shouldRestart: false });
+  });
+
+  it("honors a higher threshold (K=3)", () => {
+    expect(
+      evaluateSelfRestart({
+        watchdogTripped: true,
+        consecutiveTicks: 1,
+        selfRestartEnabled: true,
+        threshold: 3,
+      }).shouldRestart,
+    ).toBe(false);
+    expect(
+      evaluateSelfRestart({
+        watchdogTripped: true,
+        consecutiveTicks: 2,
+        selfRestartEnabled: true,
+        threshold: 3,
+      }).shouldRestart,
+    ).toBe(true);
+  });
+});
+
+describe("readWorkerConfig (resilience knobs)", () => {
+  it("defaults: self-restart on, K=2, orphan reconciler off", () => {
+    const c = readWorkerConfig({} as NodeJS.ProcessEnv, []);
+    expect(c.selfRestartEnabled).toBe(true);
+    expect(c.watchdogConsecutiveTicks).toBe(2);
+    expect(c.orphanReconcilerEnabled).toBe(false);
+  });
+
+  it("PROVISIONING_WORKER_SELF_RESTART=0 / false disables self-restart", () => {
+    expect(
+      readWorkerConfig(
+        { PROVISIONING_WORKER_SELF_RESTART: "0" } as NodeJS.ProcessEnv,
+        [],
+      ).selfRestartEnabled,
+    ).toBe(false);
+    expect(
+      readWorkerConfig(
+        { PROVISIONING_WORKER_SELF_RESTART: "false" } as NodeJS.ProcessEnv,
+        [],
+      ).selfRestartEnabled,
+    ).toBe(false);
+  });
+
+  it("ORPHAN_RECONCILER_ENABLED=1 arms the reconciler; other values keep it off", () => {
+    expect(
+      readWorkerConfig(
+        { ORPHAN_RECONCILER_ENABLED: "1" } as NodeJS.ProcessEnv,
+        [],
+      ).orphanReconcilerEnabled,
+    ).toBe(true);
+    expect(
+      readWorkerConfig(
+        { ORPHAN_RECONCILER_ENABLED: "true" } as NodeJS.ProcessEnv,
+        [],
+      ).orphanReconcilerEnabled,
+    ).toBe(false);
+  });
+
+  it("PROVISIONING_WORKER_WATCHDOG_TICKS overrides K; garbage falls back to 2", () => {
+    expect(
+      readWorkerConfig(
+        { PROVISIONING_WORKER_WATCHDOG_TICKS: "4" } as NodeJS.ProcessEnv,
+        [],
+      ).watchdogConsecutiveTicks,
+    ).toBe(4);
+    expect(
+      readWorkerConfig(
+        { PROVISIONING_WORKER_WATCHDOG_TICKS: "nope" } as NodeJS.ProcessEnv,
+        [],
+      ).watchdogConsecutiveTicks,
+    ).toBe(2);
   });
 });

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -14,6 +14,7 @@
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { OrphanReconcileResult } from "@elizaos/cloud-shared/lib/services/docker-node-workloads";
 import {
   type ProvisioningJobType,
   resolveJobTypesForLanes,
@@ -45,6 +46,10 @@ type WorkerAgentSandboxesRepository =
   typeof import("@elizaos/cloud-shared/db/repositories/agent-sandboxes").agentSandboxesRepository;
 type WorkerJobsRepository =
   typeof import("@elizaos/cloud-shared/db/repositories/jobs").jobsRepository;
+type WorkerReconcileOrphanContainers =
+  typeof import("@elizaos/cloud-shared/lib/services/docker-node-workloads").reconcileOrphanContainersOnNodes;
+type WorkerWithTimeout =
+  typeof import("@elizaos/cloud-shared/lib/utils/with-timeout").withTimeout;
 
 interface PreflightKmsClient {
   getOrCreateKey(keyId: string): Promise<unknown>;
@@ -65,6 +70,8 @@ interface WorkerDeps {
   resolveImageDigest: WorkerResolveImageDigest;
   agentSandboxesRepository: WorkerAgentSandboxesRepository;
   jobsRepository: WorkerJobsRepository;
+  reconcileOrphanContainersOnNodes: WorkerReconcileOrphanContainers;
+  withTimeout: WorkerWithTimeout;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -80,6 +87,27 @@ export interface ProvisioningWorkerConfig {
    * reach the private tenant DB to run.
    */
   jobTypes: readonly ProvisioningJobType[];
+  /**
+   * When true (default), a watchdog-wedged worker exits with code 1 after
+   * `watchdogConsecutiveTicks` consecutive stale heartbeat ticks so systemd
+   * `Restart=always` relaunches it. Gated by `PROVISIONING_WORKER_SELF_RESTART`
+   * (set to `0`/`false` to disable, e.g. during planned infra maintenance).
+   */
+  selfRestartEnabled: boolean;
+  /**
+   * Number of consecutive heartbeat ticks the watchdog must stay tripped before
+   * the worker self-restarts. K=2 means the work cycle has been stale for ~2x
+   * `WATCHDOG_MAX_CYCLE_MS` (the worst-case infra-maintenance window) before we
+   * give up and restart, so a slow-but-healthy cycle never restart-loops.
+   */
+  watchdogConsecutiveTicks: number;
+  /**
+   * When true, the low-cadence orphan-container reconciler sweeps HEALTHY nodes
+   * for `agent-<id>` containers with no live DB row and force-removes them.
+   * Gated OFF by default via `ORPHAN_RECONCILER_ENABLED=1` because it issues
+   * `docker rm -f` and should be armed deliberately.
+   */
+  orphanReconcilerEnabled: boolean;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -91,6 +119,14 @@ const DEFAULT_BATCH_SIZE = 3;
  */
 const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
 
+/**
+ * Default consecutive-tick threshold for the self-restart watchdog. At K=2 with
+ * the 15s heartbeat tick and the 5min watchdog window, a worker that has been
+ * wedged for the watchdog window across two ticks (~2x the window from the last
+ * good cycle) restarts itself.
+ */
+const DEFAULT_WATCHDOG_CONSECUTIVE_TICKS = 2;
+
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const parsed = Number.parseInt(value, 10);
@@ -99,6 +135,13 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 function hasFlag(argv: readonly string[], flag: string): boolean {
   return argv.includes(flag);
+}
+
+/** Parse an opt-OUT boolean env flag: anything but `0`/`false` keeps the default-on. */
+function parseBooleanDefaultTrue(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "0" && normalized !== "false";
 }
 
 export function readWorkerConfig(
@@ -117,6 +160,14 @@ export function readWorkerConfig(
       DEFAULT_NODE_HEALTH_INTERVAL_MS,
     ),
     jobTypes: resolveJobTypesForLanes(env.PROVISIONING_JOB_LANES),
+    selfRestartEnabled: parseBooleanDefaultTrue(
+      env.PROVISIONING_WORKER_SELF_RESTART,
+    ),
+    watchdogConsecutiveTicks: parsePositiveInt(
+      env.PROVISIONING_WORKER_WATCHDOG_TICKS,
+      DEFAULT_WATCHDOG_CONSECUTIVE_TICKS,
+    ),
+    orphanReconcilerEnabled: env.ORPHAN_RECONCILER_ENABLED === "1",
   };
 }
 
@@ -137,6 +188,8 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/lib/services/containers/registry-probe"),
       import("@elizaos/cloud-shared/db/repositories/agent-sandboxes"),
       import("@elizaos/cloud-shared/db/repositories/jobs"),
+      import("@elizaos/cloud-shared/lib/services/docker-node-workloads"),
+      import("@elizaos/cloud-shared/lib/utils/with-timeout"),
     ]).then(
       ([
         jobsModule,
@@ -149,6 +202,8 @@ async function loadDeps(): Promise<WorkerDeps> {
         registryProbeModule,
         agentSandboxesModule,
         jobsRepoModule,
+        nodeWorkloadsModule,
+        withTimeoutModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
@@ -161,6 +216,9 @@ async function loadDeps(): Promise<WorkerDeps> {
         resolveImageDigest: registryProbeModule.resolveImageDigest,
         agentSandboxesRepository: agentSandboxesModule.agentSandboxesRepository,
         jobsRepository: jobsRepoModule.jobsRepository,
+        reconcileOrphanContainersOnNodes:
+          nodeWorkloadsModule.reconcileOrphanContainersOnNodes,
+        withTimeout: withTimeoutModule.withTimeout,
       }),
     );
   }
@@ -235,9 +293,7 @@ async function processHeartbeatCycle(
   return provisioningJobService.processRunningHeartbeats(concurrency);
 }
 
-async function processRecoveryCycle(
-  concurrency = 5,
-): Promise<RecoveryResult> {
+async function processRecoveryCycle(concurrency = 5): Promise<RecoveryResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processDisconnectedRecovery(concurrency);
 }
@@ -493,6 +549,17 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
   return { drained: result.drained.length };
 }
 
+/**
+ * FIX 3: sweep HEALTHY nodes for `agent-<id>` containers with no live DB row
+ * (or a terminal-state row) and force-remove them. The reconciler itself only
+ * touches nodes whose status is `healthy`, which the preceding node-health
+ * check just refreshed, so a transient SSH blip can never reap live containers.
+ */
+async function processOrphanReconcilerCycle(): Promise<OrphanReconcileResult> {
+  const { reconcileOrphanContainersOnNodes } = await loadDeps();
+  return reconcileOrphanContainersOnNodes();
+}
+
 let running = true;
 let lastInfraMaintenanceAt = 0;
 
@@ -511,14 +578,27 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
  * heartbeat so cloud-api fails CLOSED — `checkProvisioningWorkerHealth` sees
  * the stale key and 503s new provisions instead of routing them to a worker
  * that can't make progress — and the loud error log flags it for a human.
- * This does NOT itself restart the process (systemd `Restart=always` only
- * fires on process exit, and nothing kills us on a stale key); true
- * auto-recovery via `process.exit(1)` is a deliberate follow-up that first
- * needs a threshold comfortably above worst-case infra-maintenance on a large
- * fleet, else a slow-but-healthy cycle would restart-loop. P1 keeps a
- * *progressing* worker healthy; the watchdog fails a *wedged* one closed.
+ *
+ * On top of failing-closed, the worker self-restarts: once the watchdog stays
+ * tripped for `watchdogConsecutiveTicks` consecutive heartbeat ticks (~2x this
+ * window from the last good cycle, comfortably above worst-case infra
+ * maintenance on a large fleet), it logs loudly and `process.exit(1)`s so
+ * systemd `Restart=always` relaunches it. The K-tick gate keeps a
+ * slow-but-healthy cycle from restart-looping. Gated by
+ * `PROVISIONING_WORKER_SELF_RESTART` (default on) so it can be disabled.
  */
 const WATCHDOG_MAX_CYCLE_MS = 5 * 60_000;
+
+/**
+ * Per-phase wall-clock budget (FIX 2). Each cycle phase (provisioning, node
+ * health, autoscale, …) is wrapped in `withTimeout` so a single hung phase —
+ * a Neon stall or an unresponsive node's SSH probe — can't run unbounded and
+ * trip the watchdog. 90s is comfortably below `WATCHDOG_MAX_CYCLE_MS` so even
+ * the longest phase frees the cycle long before the worker would be declared
+ * wedged. `withTimeout` only frees the awaiter — every leaf already has its own
+ * hard SSH/HTTP/Redis timeout, so a freed phase leaves no truly-unbounded I/O.
+ */
+const PHASE_TIMEOUT_MS = 90_000;
 
 /**
  * Liveness gate. The heartbeat interval publishes ONLY when this is true.
@@ -533,6 +613,33 @@ let lastCycleCompletedAt = Date.now();
 
 /** In-flight guard so a hung Redis write can't pile up unresolved publishes. */
 let heartbeatPublishInFlight = false;
+
+/**
+ * Consecutive heartbeat ticks the watchdog has been tripped. Reset to 0 on any
+ * tick where the work cycle is progressing. Drives the self-restart decision.
+ */
+let consecutiveWatchdogTicks = 0;
+
+/**
+ * Pure decision for FIX 1's self-restart: given how many consecutive ticks the
+ * watchdog has been tripped, whether the feature is enabled, and the K
+ * threshold, decide whether the worker should exit(1) now. Exported for unit
+ * testing the K-consecutive-tick trigger without spawning a process.
+ */
+export function evaluateSelfRestart(deps: {
+  watchdogTripped: boolean;
+  consecutiveTicks: number;
+  selfRestartEnabled: boolean;
+  threshold: number;
+}): { nextConsecutiveTicks: number; shouldRestart: boolean } {
+  if (!deps.watchdogTripped) {
+    return { nextConsecutiveTicks: 0, shouldRestart: false };
+  }
+  const nextConsecutiveTicks = deps.consecutiveTicks + 1;
+  const shouldRestart =
+    deps.selfRestartEnabled && nextConsecutiveTicks >= deps.threshold;
+  return { nextConsecutiveTicks, shouldRestart };
+}
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -595,24 +702,96 @@ export async function maybePublishHeartbeat(
 }
 
 /**
+ * Loudly log and exit so systemd `Restart=always` relaunches the worker. Split
+ * out so the side-effecting `process.exit` is in one place and the rest of the
+ * tick logic stays pure/testable. Allows injecting `exit` in tests.
+ */
+function triggerSelfRestart(
+  logger: WorkerLogger,
+  consecutiveTicks: number,
+  exit: (code: number) => never = process.exit,
+): never {
+  logger.error(
+    "[provisioning-worker] WATCHDOG self-restart: work cycle wedged for " +
+      `${consecutiveTicks} consecutive heartbeat ticks (>=${Math.round(
+        WATCHDOG_MAX_CYCLE_MS / 1000,
+      )}s stale). Exiting(1) so systemd relaunches a fresh worker.`,
+    {
+      event: "worker.self_restart",
+      consecutiveWatchdogTicks: consecutiveTicks,
+      lastCycleCompletedAt: new Date(lastCycleCompletedAt).toISOString(),
+    },
+  );
+  return exit(1);
+}
+
+/**
  * Start the independent heartbeat timer. Decoupled from `pollCycle` so a slow
  * work item can never starve the liveness key. The in-flight guard skips a
  * tick rather than queueing a second publish behind a hung Redis write.
+ *
+ * Each tick also advances the self-restart watchdog: when the heartbeat is
+ * withheld because the work cycle is wedged, the consecutive-tick counter
+ * climbs; once it crosses `config.watchdogConsecutiveTicks`, the worker
+ * self-restarts (FIX 1).
  */
-function startHeartbeatInterval(logger: WorkerLogger): NodeJS.Timeout {
+function startHeartbeatInterval(
+  logger: WorkerLogger,
+  config: ProvisioningWorkerConfig,
+): NodeJS.Timeout {
   const tick = () => {
     if (heartbeatPublishInFlight) return;
     heartbeatPublishInFlight = true;
     void maybePublishHeartbeat(logger, {
       preflightOk,
       lastCycleCompletedAt,
-    }).finally(() => {
-      heartbeatPublishInFlight = false;
-    });
+    })
+      .then(({ watchdogTripped }) => {
+        const { nextConsecutiveTicks, shouldRestart } = evaluateSelfRestart({
+          watchdogTripped,
+          consecutiveTicks: consecutiveWatchdogTicks,
+          selfRestartEnabled: config.selfRestartEnabled,
+          threshold: config.watchdogConsecutiveTicks,
+        });
+        consecutiveWatchdogTicks = nextConsecutiveTicks;
+        if (shouldRestart) {
+          triggerSelfRestart(logger, nextConsecutiveTicks);
+        }
+      })
+      .finally(() => {
+        heartbeatPublishInFlight = false;
+      });
   };
   const timer = setInterval(tick, HEARTBEAT_INTERVAL_MS);
   timer.unref();
   return timer;
+}
+
+/**
+ * Run one cycle phase under a hard wall-clock budget (FIX 2). The phase is
+ * wrapped in `withTimeout` (so a hung phase frees the cycle) and its result is
+ * handed to `onResult` for logging; any throw — including the timeout — is
+ * caught and logged so one phase failing never aborts the rest of the cycle.
+ */
+async function runBoundedPhase<T>(
+  logger: WorkerLogger,
+  label: string,
+  phase: () => Promise<T>,
+  onResult: (result: T) => void,
+): Promise<void> {
+  const { withTimeout } = await loadDeps();
+  try {
+    const result = await withTimeout(
+      phase(),
+      PHASE_TIMEOUT_MS,
+      `[provisioning-worker] ${label}`,
+    );
+    onResult(result);
+  } catch (error) {
+    logger.error(`[provisioning-worker] ${label} failed`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 async function pollCycle(
@@ -636,81 +815,91 @@ async function pollCycle(
     );
     return;
   }
-  try {
-    const result = await processProvisioningWorkerCycle(
-      config.batchSize,
-      config.jobTypes,
-    );
-    if (result.claimed > 0 || result.failed > 0) {
-      logger.info(
-        "[provisioning-worker] cycle complete",
-        resultContext(result),
-      );
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  // ── WORK phases (on the watchdog's critical path) ────────────────────────
+  // Each is bounded by PHASE_TIMEOUT_MS so a single hung phase frees the cycle
+  // long before the watchdog would declare the worker wedged.
+  await runBoundedPhase(
+    logger,
+    "cycle",
+    () => processProvisioningWorkerCycle(config.batchSize, config.jobTypes),
+    (result) => {
+      if (result.claimed > 0 || result.failed > 0) {
+        logger.info(
+          "[provisioning-worker] cycle complete",
+          resultContext(result),
+        );
+      }
+    },
+  );
 
-  try {
-    const heartbeats = await processHeartbeatCycle();
-    if (heartbeats.total > 0) {
-      logger.info("[provisioning-worker] heartbeat cycle complete", {
-        total: heartbeats.total,
-        succeeded: heartbeats.succeeded,
-        failed: heartbeats.failed,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] heartbeat cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await runBoundedPhase(
+    logger,
+    "heartbeat cycle",
+    () => processHeartbeatCycle(),
+    (heartbeats) => {
+      if (heartbeats.total > 0) {
+        logger.info("[provisioning-worker] heartbeat cycle complete", {
+          total: heartbeats.total,
+          succeeded: heartbeats.succeeded,
+          failed: heartbeats.failed,
+        });
+      }
+    },
+  );
 
-  try {
-    const recovery = await processRecoveryCycle();
-    if (recovery.total > 0) {
-      logger.info("[provisioning-worker] recovery cycle complete", {
-        total: recovery.total,
-        recovered: recovery.recovered,
-        reprovisioned: recovery.reprovisioned,
-        failed: recovery.failed,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] recovery cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await runBoundedPhase(
+    logger,
+    "recovery cycle",
+    () => processRecoveryCycle(),
+    (recovery) => {
+      if (recovery.total > 0) {
+        logger.info("[provisioning-worker] recovery cycle complete", {
+          total: recovery.total,
+          recovered: recovery.recovered,
+          reprovisioned: recovery.reprovisioned,
+          failed: recovery.failed,
+        });
+      }
+    },
+  );
 
-  try {
-    const decision = await processFleetUpgradeCycle();
-    if (decision.action !== "noop") {
-      logger.info("[provisioning-worker] fleet upgrade cycle complete", {
-        action: decision.action,
-        configuredImage: decision.configuredImage,
-        targetDigest: decision.targetDigest,
-        candidates: decision.candidates,
-        enqueued: decision.enqueued,
-        inFlight: decision.inFlight,
-        detail: decision.detail,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] fleet upgrade cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await runBoundedPhase(
+    logger,
+    "fleet upgrade cycle",
+    () => processFleetUpgradeCycle(),
+    (decision) => {
+      if (decision.action !== "noop") {
+        logger.info("[provisioning-worker] fleet upgrade cycle complete", {
+          action: decision.action,
+          configuredImage: decision.configuredImage,
+          targetDigest: decision.targetDigest,
+          candidates: decision.candidates,
+          enqueued: decision.enqueued,
+          inFlight: decision.inFlight,
+          detail: decision.detail,
+        });
+      }
+    },
+  );
 
-  // Infra maintenance cycle runs on a longer interval than the heartbeat
-  // (SSH + Docker probes per node are expensive). Bundles every job that
-  // used to be forwarded from CF crons to the now-deprecated control-plane:
+  // Mark progress for the watchdog HERE — after the WORK cycle, BEFORE infra
+  // maintenance (FIX 2). Infra maintenance (SSH + Docker probes across the
+  // whole fleet) is slow and off the critical liveness path: a node-health or
+  // orphan-reconcile sweep that drags on must not make a worker that is still
+  // claiming and completing jobs look wedged. As long as the WORK cycle keeps
+  // advancing this, the heartbeat interval keeps the worker healthy.
+  lastCycleCompletedAt = Date.now();
+
+  // ── Infra maintenance (off the watchdog path) ────────────────────────────
+  // Runs on a longer interval than the heartbeat (SSH + Docker probes per node
+  // are expensive). Bundles every job that used to be forwarded from CF crons
+  // to the now-deprecated control-plane:
   //   - node health check  (was: /api/v1/cron/agent-hot-pool — healthCheckAll)
   //   - alloc reconciliation (was: agent-hot-pool — syncAllocatedCounts)
   //   - pre-pull warm image (was: agent-hot-pool — prePullAgentImageOnAvailableNodes)
   //   - node autoscale     (was: /api/v1/cron/node-autoscale)
   //   - warm pool drain    (was: /api/v1/cron/pool-drain-idle)
+  //   - orphan reconcile   (FIX 3, gated by ORPHAN_RECONCILER_ENABLED)
   // Folding them together avoids 3 parallel writers fighting over the same
   // docker_nodes rows and means there's exactly one host that owns the
   // truth: the orchestrator (this daemon). `lastInfraMaintenanceAt`
@@ -719,80 +908,102 @@ async function pollCycle(
   const now = Date.now();
   if (now - lastInfraMaintenanceAt >= config.nodeHealthIntervalMs) {
     lastInfraMaintenanceAt = now;
-    await runInfraMaintenanceCycle(logger);
+    await runInfraMaintenanceCycle(logger, config);
   }
-
-  // Mark progress for the watchdog. As long as this advances, the heartbeat
-  // interval keeps the worker healthy even across long cycles.
-  lastCycleCompletedAt = Date.now();
 }
 
-async function runInfraMaintenanceCycle(logger: WorkerLogger): Promise<void> {
-  try {
-    const summary = await processNodeHealthCheckCycle();
-    logger.info("[provisioning-worker] node health check cycle complete", {
-      total: summary.total,
-      healthy: summary.healthy,
-      unhealthy: summary.unhealthy,
-    });
-  } catch (error) {
-    logger.error("[provisioning-worker] node health check cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  try {
-    const changes = await processSyncAllocatedCountsCycle();
-    if (changes > 0) {
-      logger.info("[provisioning-worker] alloc reconcile cycle complete", {
-        changed: changes,
+async function runInfraMaintenanceCycle(
+  logger: WorkerLogger,
+  config: ProvisioningWorkerConfig,
+): Promise<void> {
+  // Every phase is bounded by PHASE_TIMEOUT_MS via runBoundedPhase so an
+  // unresponsive node's SSH probe can never stall the whole sweep.
+  await runBoundedPhase(
+    logger,
+    "node health check cycle",
+    () => processNodeHealthCheckCycle(),
+    (summary) => {
+      logger.info("[provisioning-worker] node health check cycle complete", {
+        total: summary.total,
+        healthy: summary.healthy,
+        unhealthy: summary.unhealthy,
       });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] alloc reconcile cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+    },
+  );
 
-  try {
-    const summary = await processPrePullImagesCycle();
-    if (summary) {
-      logger.info("[provisioning-worker] pre-pull images cycle complete", {
-        attempted: summary.attempted,
-        failed: summary.failed,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] pre-pull images cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await runBoundedPhase(
+    logger,
+    "alloc reconcile cycle",
+    () => processSyncAllocatedCountsCycle(),
+    (changes) => {
+      if (changes > 0) {
+        logger.info("[provisioning-worker] alloc reconcile cycle complete", {
+          changed: changes,
+        });
+      }
+    },
+  );
 
-  try {
-    const decision = await processNodeAutoscaleCycle();
-    if (decision.action !== "noop") {
-      logger.info("[provisioning-worker] node autoscale cycle complete", {
-        action: decision.action,
-        detail: decision.detail,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] node autoscale cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await runBoundedPhase(
+    logger,
+    "pre-pull images cycle",
+    () => processPrePullImagesCycle(),
+    (summary) => {
+      if (summary) {
+        logger.info("[provisioning-worker] pre-pull images cycle complete", {
+          attempted: summary.attempted,
+          failed: summary.failed,
+        });
+      }
+    },
+  );
 
-  try {
-    const result = await processPoolDrainIdleCycle();
-    if (result.drained > 0) {
-      logger.info("[provisioning-worker] warm pool drain cycle complete", {
-        drained: result.drained,
-      });
-    }
-  } catch (error) {
-    logger.error("[provisioning-worker] warm pool drain cycle failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  await runBoundedPhase(
+    logger,
+    "node autoscale cycle",
+    () => processNodeAutoscaleCycle(),
+    (decision) => {
+      if (decision.action !== "noop") {
+        logger.info("[provisioning-worker] node autoscale cycle complete", {
+          action: decision.action,
+          detail: decision.detail,
+        });
+      }
+    },
+  );
+
+  await runBoundedPhase(
+    logger,
+    "warm pool drain cycle",
+    () => processPoolDrainIdleCycle(),
+    (result) => {
+      if (result.drained > 0) {
+        logger.info("[provisioning-worker] warm pool drain cycle complete", {
+          drained: result.drained,
+        });
+      }
+    },
+  );
+
+  // FIX 3: orphan-container reconciliation. Runs LAST so it sees the fresh
+  // node-status from the health check above — the reconciler only touches
+  // HEALTHY nodes, so a node that just failed its probe is excluded and a
+  // transient SSH blip never reaps live containers. Gated OFF by default.
+  if (config.orphanReconcilerEnabled) {
+    await runBoundedPhase(
+      logger,
+      "orphan reconciler cycle",
+      () => processOrphanReconcilerCycle(),
+      (result) => {
+        logger.info("[provisioning-worker] orphan reconciler cycle complete", {
+          event: "orphan_reconciler.reaped",
+          nodesScanned: result.nodesScanned,
+          nodesSkipped: result.nodesSkipped,
+          reaped: result.reaped,
+          reapFailed: result.reapFailed,
+        });
+      },
+    );
   }
 }
 
@@ -850,6 +1061,9 @@ async function main(): Promise<void> {
     // When a dedicated apps daemon ships, pin this one to `agent`.
     jobLanes: process.env.PROVISIONING_JOB_LANES || "(all)",
     jobTypeCount: config.jobTypes.length,
+    selfRestartEnabled: config.selfRestartEnabled,
+    watchdogConsecutiveTicks: config.watchdogConsecutiveTicks,
+    orphanReconcilerEnabled: config.orphanReconcilerEnabled,
   });
 
   await assertProvisioningWorkerPreflight();
@@ -875,7 +1089,7 @@ async function main(): Promise<void> {
   // cycle takes. Publish once immediately so there's no cold gap before the
   // first tick.
   await publishHeartbeat(logger);
-  const heartbeatTimer = startHeartbeatInterval(logger);
+  const heartbeatTimer = startHeartbeatInterval(logger, config);
 
   try {
     while (running) {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -96,9 +96,12 @@ export interface ProvisioningWorkerConfig {
   selfRestartEnabled: boolean;
   /**
    * Number of consecutive heartbeat ticks the watchdog must stay tripped before
-   * the worker self-restarts. K=2 means the work cycle has been stale for ~2x
-   * `WATCHDOG_MAX_CYCLE_MS` (the worst-case infra-maintenance window) before we
-   * give up and restart, so a slow-but-healthy cycle never restart-loops.
+   * the worker self-restarts. The watchdog trips at WATCHDOG_MAX_CYCLE_MS of no
+   * completed cycle, and restart fires on the K-th consecutive tick after, so
+   * the time from the last good cycle to exit(1) is
+   * ≈ WATCHDOG_MAX_CYCLE_MS + (K-1) * HEARTBEAT_INTERVAL_MS (≈315s at K=2). The
+   * extra ticks keep a one-off slow cycle from restart-looping; they are NOT a
+   * "~2x window" multiplier.
    */
   watchdogConsecutiveTicks: number;
   /**
@@ -121,9 +124,9 @@ const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
 
 /**
  * Default consecutive-tick threshold for the self-restart watchdog. At K=2 with
- * the 15s heartbeat tick and the 5min watchdog window, a worker that has been
- * wedged for the watchdog window across two ticks (~2x the window from the last
- * good cycle) restarts itself.
+ * the 15s heartbeat tick and the 5min watchdog window, the worker restarts
+ * ≈ WATCHDOG_MAX_CYCLE_MS + (K-1) * HEARTBEAT_INTERVAL_MS ≈ 315s after the last
+ * good cycle (the watchdog window plus one extra 15s tick), not ~2x the window.
  */
 const DEFAULT_WATCHDOG_CONSECUTIVE_TICKS = 2;
 
@@ -580,25 +583,83 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
  * that can't make progress — and the loud error log flags it for a human.
  *
  * On top of failing-closed, the worker self-restarts: once the watchdog stays
- * tripped for `watchdogConsecutiveTicks` consecutive heartbeat ticks (~2x this
- * window from the last good cycle, comfortably above worst-case infra
- * maintenance on a large fleet), it logs loudly and `process.exit(1)`s so
- * systemd `Restart=always` relaunches it. The K-tick gate keeps a
- * slow-but-healthy cycle from restart-looping. Gated by
+ * tripped for `watchdogConsecutiveTicks` consecutive heartbeat ticks, it logs
+ * loudly and `process.exit(1)`s so systemd `Restart=always` relaunches it. The
+ * K-tick gate keeps a slow-but-healthy cycle from restart-looping. Gated by
  * `PROVISIONING_WORKER_SELF_RESTART` (default on) so it can be disabled.
+ *
+ * Timing (FIX G): the watchdog trips once a cycle has not completed for
+ * WATCHDOG_MAX_CYCLE_MS. The self-restart then fires on the K-th consecutive
+ * heartbeat tick AFTER it trips, so the wall-clock from the last good cycle to
+ * exit(1) is
+ *   ≈ WATCHDOG_MAX_CYCLE_MS + (K-1) * HEARTBEAT_INTERVAL_MS
+ * For the defaults (300s + (2-1)*15s) that is ≈ 315s — NOT ~600s / "~2x the
+ * window". The first wedged tick only arms the counter (no restart); the K-th
+ * tick fires it.
  */
 const WATCHDOG_MAX_CYCLE_MS = 5 * 60_000;
 
 /**
- * Per-phase wall-clock budget (FIX 2). Each cycle phase (provisioning, node
- * health, autoscale, …) is wrapped in `withTimeout` so a single hung phase —
- * a Neon stall or an unresponsive node's SSH probe — can't run unbounded and
- * trip the watchdog. 90s is comfortably below `WATCHDOG_MAX_CYCLE_MS` so even
- * the longest phase frees the cycle long before the worker would be declared
- * wedged. `withTimeout` only frees the awaiter — every leaf already has its own
- * hard SSH/HTTP/Redis timeout, so a freed phase leaves no truly-unbounded I/O.
+ * Per-phase wall-clock budget. Each cycle phase (provisioning, node health,
+ * autoscale, …) is wrapped in `withTimeout` so a single hung phase — a Neon
+ * stall or an unresponsive node's SSH probe — frees fast instead of running
+ * unbounded. `withTimeout` only frees the awaiter — every leaf already has its
+ * own hard SSH/HTTP/Redis timeout, so a freed phase leaves no truly-unbounded
+ * I/O. This is the fast per-phase wedge signal; the cycle-wide budget below is
+ * what actually keeps the watchdog invariant from being violated.
  */
-const PHASE_TIMEOUT_MS = 90_000;
+const PHASE_TIMEOUT_MS = 60_000;
+
+/**
+ * Whole-WORK-cycle wall-clock budget (FIX E). The 4 WORK phases run on the
+ * watchdog's critical path, so SUM(their budgets) + the poll interval MUST stay
+ * below WATCHDOG_MAX_CYCLE_MS — otherwise a slow-but-progressing cycle could
+ * exceed the window and the worker would self-restart (the exact false positive
+ * the design claims to prevent: 4 × 90s = 360s > 300s under the old per-phase
+ * 90s budgets). Instead of summing N per-phase timeouts, the whole WORK group
+ * is bounded ONCE by this budget. Picked comfortably below the watchdog window:
+ *   WORK_CYCLE_TIMEOUT_MS + DEFAULT_POLL_INTERVAL_MS = 240s + 30s = 270s < 300s.
+ * Adding a 5th WORK phase therefore cannot re-break the invariant — the group
+ * budget is fixed. `assertWatchdogInvariant()` pins this at module load and the
+ * unit test pins it too (FIX F).
+ */
+const WORK_CYCLE_TIMEOUT_MS = 4 * 60_000;
+
+/**
+ * The watchdog invariant, surfaced for the unit test (FIX F) so adding a phase
+ * or bumping a timeout can't silently violate it. The work cycle is bounded as
+ * a GROUP by WORK_CYCLE_TIMEOUT_MS, so that single budget (plus the poll gap)
+ * is what must fit inside the watchdog window — not the per-phase budgets.
+ */
+export const WORKER_TIMING = {
+  watchdogMaxCycleMs: WATCHDOG_MAX_CYCLE_MS,
+  workCycleTimeoutMs: WORK_CYCLE_TIMEOUT_MS,
+  phaseTimeoutMs: PHASE_TIMEOUT_MS,
+  heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+  defaultPollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+} as const;
+
+/**
+ * Guard the watchdog invariant at module load: the WORK cycle's wall-clock
+ * budget plus the time the loop sleeps between cycles must finish well before
+ * the watchdog declares the worker wedged. A future edit that bumps
+ * WORK_CYCLE_TIMEOUT_MS or lowers WATCHDOG_MAX_CYCLE_MS into violation throws
+ * loudly at startup instead of shipping a worker that self-restarts mid-cycle.
+ */
+function assertWatchdogInvariant(): void {
+  if (
+    WORK_CYCLE_TIMEOUT_MS + DEFAULT_POLL_INTERVAL_MS >=
+    WATCHDOG_MAX_CYCLE_MS
+  ) {
+    throw new Error(
+      "[provisioning-worker] watchdog invariant violated: " +
+        `WORK_CYCLE_TIMEOUT_MS (${WORK_CYCLE_TIMEOUT_MS}) + DEFAULT_POLL_INTERVAL_MS ` +
+        `(${DEFAULT_POLL_INTERVAL_MS}) must be < WATCHDOG_MAX_CYCLE_MS (${WATCHDOG_MAX_CYCLE_MS}). ` +
+        "A slow-but-progressing work cycle would otherwise trip the watchdog and self-restart.",
+    );
+  }
+}
+assertWatchdogInvariant();
 
 /**
  * Liveness gate. The heartbeat interval publishes ONLY when this is true.
@@ -794,6 +855,103 @@ async function runBoundedPhase<T>(
   }
 }
 
+/**
+ * Run the 4 WORK phases (claim/complete jobs, agent heartbeats, recovery, fleet
+ * upgrade) as a single group bounded by WORK_CYCLE_TIMEOUT_MS (FIX E). Bounding
+ * the group once — rather than summing N per-phase 90s timeouts (4 × 90s = 360s
+ * > the 300s watchdog window) — keeps the critical-path budget below
+ * WATCHDOG_MAX_CYCLE_MS, so a slow-but-progressing cycle can't self-restart. The
+ * group timeout is caught and logged so it frees the cycle without aborting the
+ * rest of pollCycle; the per-phase timeouts inside still give a fast,
+ * per-phase wedge signal.
+ */
+async function runWorkCycle(
+  logger: WorkerLogger,
+  config: ProvisioningWorkerConfig,
+): Promise<void> {
+  const { withTimeout } = await loadDeps();
+  const work = (async () => {
+    await runBoundedPhase(
+      logger,
+      "cycle",
+      () => processProvisioningWorkerCycle(config.batchSize, config.jobTypes),
+      (result) => {
+        if (result.claimed > 0 || result.failed > 0) {
+          logger.info(
+            "[provisioning-worker] cycle complete",
+            resultContext(result),
+          );
+        }
+      },
+    );
+
+    await runBoundedPhase(
+      logger,
+      "heartbeat cycle",
+      () => processHeartbeatCycle(),
+      (heartbeats) => {
+        if (heartbeats.total > 0) {
+          logger.info("[provisioning-worker] heartbeat cycle complete", {
+            total: heartbeats.total,
+            succeeded: heartbeats.succeeded,
+            failed: heartbeats.failed,
+          });
+        }
+      },
+    );
+
+    await runBoundedPhase(
+      logger,
+      "recovery cycle",
+      () => processRecoveryCycle(),
+      (recovery) => {
+        if (recovery.total > 0) {
+          logger.info("[provisioning-worker] recovery cycle complete", {
+            total: recovery.total,
+            recovered: recovery.recovered,
+            reprovisioned: recovery.reprovisioned,
+            failed: recovery.failed,
+          });
+        }
+      },
+    );
+
+    await runBoundedPhase(
+      logger,
+      "fleet upgrade cycle",
+      () => processFleetUpgradeCycle(),
+      (decision) => {
+        if (decision.action !== "noop") {
+          logger.info("[provisioning-worker] fleet upgrade cycle complete", {
+            action: decision.action,
+            configuredImage: decision.configuredImage,
+            targetDigest: decision.targetDigest,
+            candidates: decision.candidates,
+            enqueued: decision.enqueued,
+            inFlight: decision.inFlight,
+            detail: decision.detail,
+          });
+        }
+      },
+    );
+  })();
+
+  try {
+    await withTimeout(
+      work,
+      WORK_CYCLE_TIMEOUT_MS,
+      "[provisioning-worker] work cycle",
+    );
+  } catch (error) {
+    // A group-level timeout frees the cycle (every leaf is independently
+    // bounded) so the watchdog clock advances and infra maintenance still runs.
+    logger.error("[provisioning-worker] work cycle exceeded its budget", {
+      error: error instanceof Error ? error.message : String(error),
+      workCycleTimeoutMs: WORK_CYCLE_TIMEOUT_MS,
+    });
+  }
+}
+
 async function pollCycle(
   logger: WorkerLogger,
   config: ProvisioningWorkerConfig,
@@ -816,71 +974,14 @@ async function pollCycle(
     return;
   }
   // ── WORK phases (on the watchdog's critical path) ────────────────────────
-  // Each is bounded by PHASE_TIMEOUT_MS so a single hung phase frees the cycle
-  // long before the watchdog would declare the worker wedged.
-  await runBoundedPhase(
-    logger,
-    "cycle",
-    () => processProvisioningWorkerCycle(config.batchSize, config.jobTypes),
-    (result) => {
-      if (result.claimed > 0 || result.failed > 0) {
-        logger.info(
-          "[provisioning-worker] cycle complete",
-          resultContext(result),
-        );
-      }
-    },
-  );
-
-  await runBoundedPhase(
-    logger,
-    "heartbeat cycle",
-    () => processHeartbeatCycle(),
-    (heartbeats) => {
-      if (heartbeats.total > 0) {
-        logger.info("[provisioning-worker] heartbeat cycle complete", {
-          total: heartbeats.total,
-          succeeded: heartbeats.succeeded,
-          failed: heartbeats.failed,
-        });
-      }
-    },
-  );
-
-  await runBoundedPhase(
-    logger,
-    "recovery cycle",
-    () => processRecoveryCycle(),
-    (recovery) => {
-      if (recovery.total > 0) {
-        logger.info("[provisioning-worker] recovery cycle complete", {
-          total: recovery.total,
-          recovered: recovery.recovered,
-          reprovisioned: recovery.reprovisioned,
-          failed: recovery.failed,
-        });
-      }
-    },
-  );
-
-  await runBoundedPhase(
-    logger,
-    "fleet upgrade cycle",
-    () => processFleetUpgradeCycle(),
-    (decision) => {
-      if (decision.action !== "noop") {
-        logger.info("[provisioning-worker] fleet upgrade cycle complete", {
-          action: decision.action,
-          configuredImage: decision.configuredImage,
-          targetDigest: decision.targetDigest,
-          candidates: decision.candidates,
-          enqueued: decision.enqueued,
-          inFlight: decision.inFlight,
-          detail: decision.detail,
-        });
-      }
-    },
-  );
+  // The WHOLE group is bounded ONCE by WORK_CYCLE_TIMEOUT_MS (FIX E) so the
+  // critical-path budget stays below WATCHDOG_MAX_CYCLE_MS no matter how many
+  // phases there are — 4 × per-phase 90s used to sum to 360s and could trip the
+  // 300s watchdog on a slow-but-progressing cycle. Each phase keeps its own
+  // (now-shorter) per-phase timeout as a fast individual-wedge signal; the group
+  // bound is the authoritative one. A group-level timeout frees the cycle and is
+  // logged, never aborting the rest of pollCycle (infra maintenance still runs).
+  await runWorkCycle(logger, config);
 
   // Mark progress for the watchdog HERE — after the WORK cycle, BEFORE infra
   // maintenance (FIX 2). Infra maintenance (SSH + Docker probes across the


### PR DESCRIPTION
From the audit (#8434). **CRITICAL:** the single worker fails closed on a wedge but never recovered — now self-restarts (`process.exit(1)` → systemd Restart=always, confirmed) after the watchdog stays tripped K consecutive ticks (env-gated). **MAJOR:** every poll/infra phase wrapped in `withTimeout` (90s < 5min watchdog) + `lastCycleCompletedAt` advanced after the work cycle so a slow SSH sweep can't look wedged. **MAJOR:** flag-gated orphan-container reconciler (`ORPHAN_RECONCILER_ENABLED`) sweeps healthy nodes, diffs `docker ps` vs live rows, `docker rm -f` orphans — closes the container-leak. 16+ tests (pure diff + orchestration).

_CI's red Format Check / lint-and-types are pre-existing develop-wide biome breakage in ~14 unrelated files, not this PR. This PR's own files pass biome + typecheck + tests. Refs #8434 (full lifecycle audit)._