### PR TITLE
fix(cloud): native-tool calls 500 on flat ToolDefinition shape (should-respond crash)

### DIFF
--- a/packages/cloud-shared/src/lib/providers/vercel-ai-gateway-tools.test.ts
+++ b/packages/cloud-shared/src/lib/providers/vercel-ai-gateway-tools.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeToolFunction, toGatewayTools } from "./vercel-ai-gateway";
+
+/**
+ * Regression: the gateway's toGatewayTools read `tool.function.name`
+ * unconditionally. elizaOS core's createHandleResponseTool() / action planner
+ * send a FLAT ToolDefinition (`{ name, type, parameters }`) with no nested
+ * `function`, so this threw "Cannot read properties of undefined (reading
+ * 'name')" — an opaque 500 on the should-respond (RESPONSE_HANDLER) turn of
+ * every dedicated cloud agent.
+ */
+describe("toGatewayTools — tolerates flat ToolDefinition shape", () => {
+  const flatHandleResponse = {
+    name: "HANDLE_RESPONSE",
+    description: "Decide whether and how to respond",
+    type: "function",
+    strict: true,
+    parameters: {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+  };
+
+  // Cast unknown tool shapes to the gateway's tool param type without `any` —
+  // the whole point of these tests is that the runtime shape diverges from the
+  // declared type.
+  const gatewayTools = (...tools: unknown[]) => toGatewayTools(tools as never);
+
+  test("does not throw on the exact flat shape that 500'd in prod", () => {
+    expect(() => gatewayTools(flatHandleResponse)).not.toThrow();
+  });
+
+  test("keys the gateway tool map by the flat tool name", () => {
+    const result = gatewayTools(flatHandleResponse);
+    expect(Object.keys(result)).toEqual(["HANDLE_RESPONSE"]);
+  });
+
+  test("still handles the nested OpenAI shape", () => {
+    const nested = {
+      type: "function",
+      function: { name: "GET_WEATHER", parameters: { type: "object" } },
+    };
+    const result = gatewayTools(nested);
+    expect(Object.keys(result)).toEqual(["GET_WEATHER"]);
+  });
+
+  test("drops nameless tools instead of throwing", () => {
+    const nameless = { type: "function", parameters: { type: "object" } };
+    const result = gatewayTools(nameless, flatHandleResponse);
+    expect(Object.keys(result)).toEqual(["HANDLE_RESPONSE"]);
+  });
+});
+
+describe("normalizeToolFunction", () => {
+  test("reads name/parameters from the flat shape", () => {
+    const out = normalizeToolFunction({
+      name: "A",
+      type: "function",
+      parameters: { type: "object" },
+    });
+    expect(out.name).toBe("A");
+    expect(out.parameters).toMatchObject({ type: "object" });
+  });
+
+  test("reads name/parameters from the nested shape", () => {
+    const out = normalizeToolFunction({
+      type: "function",
+      function: { name: "B", parameters: { type: "object", title: "nested" } },
+    });
+    expect(out.name).toBe("B");
+    expect(out.parameters).toMatchObject({ title: "nested" });
+  });
+
+  test("returns undefined name for a nameless / non-object input", () => {
+    expect(normalizeToolFunction({}).name).toBeUndefined();
+    expect(normalizeToolFunction(undefined).name).toBeUndefined();
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
+++ b/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
@@ -484,7 +484,7 @@ function contentToText(content: GatewayChatMessage["content"]): string {
 // `tool.function.name` unconditionally threw "Cannot read properties of
 // undefined (reading 'name')" and surfaced as an opaque 500 for any caller that
 // sent the flat form.
-function normalizeToolFunction(tool: unknown): {
+export function normalizeToolFunction(tool: unknown): {
   name?: string;
   description?: unknown;
   parameters?: unknown;
@@ -498,7 +498,7 @@ function normalizeToolFunction(tool: unknown): {
   };
 }
 
-function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
+export function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
   return Object.fromEntries(
     tools
       .map((tool) => {
@@ -509,9 +509,7 @@ function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
         return [
           name,
           {
-            ...(typeof description === "string" && description
-              ? { description }
-              : {}),
+            ...(typeof description === "string" && description ? { description } : {}),
             inputSchema: jsonSchema(
               (parameters as Parameters<typeof jsonSchema>[0] | undefined) ?? {
                 type: "object",

--- a/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
+++ b/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
@@ -478,16 +478,50 @@ function contentToText(content: GatewayChatMessage["content"]): string {
     .join("\n");
 }
 
+// Tolerate BOTH the nested OpenAI tool shape (`{ function: { name, parameters } }`)
+// and the flat `ToolDefinition` envelope (`{ name, type, parameters }`) that
+// elizaOS core emits (createHandleResponseTool / the action planner). Reading
+// `tool.function.name` unconditionally threw "Cannot read properties of
+// undefined (reading 'name')" and surfaced as an opaque 500 for any caller that
+// sent the flat form.
+function normalizeToolFunction(tool: unknown): {
+  name?: string;
+  description?: unknown;
+  parameters?: unknown;
+} {
+  const record = (tool ?? {}) as Record<string, unknown>;
+  const fn = (record.function ?? record) as Record<string, unknown>;
+  return {
+    name: typeof fn.name === "string" ? fn.name : undefined,
+    description: fn.description,
+    parameters: fn.parameters,
+  };
+}
+
 function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
   return Object.fromEntries(
-    tools.map((tool) => [
-      tool.function.name,
-      {
-        ...(tool.function.description ? { description: tool.function.description } : {}),
-        inputSchema: jsonSchema(tool.function.parameters ?? { type: "object" }),
-        outputSchema: jsonSchema({ type: "object", additionalProperties: true }),
-      },
-    ]),
+    tools
+      .map((tool) => {
+        const { name, description, parameters } = normalizeToolFunction(tool);
+        if (!name) {
+          return undefined;
+        }
+        return [
+          name,
+          {
+            ...(typeof description === "string" && description
+              ? { description }
+              : {}),
+            inputSchema: jsonSchema(
+              (parameters as Parameters<typeof jsonSchema>[0] | undefined) ?? {
+                type: "object",
+              },
+            ),
+            outputSchema: jsonSchema({ type: "object", additionalProperties: true }),
+          },
+        ] as const;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined),
   );
 }
 
@@ -497,7 +531,8 @@ function toGatewayToolChoice(
   if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "required") {
     return toolChoice;
   }
-  return { type: "tool", toolName: toolChoice.function.name };
+  const { name } = normalizeToolFunction(toolChoice);
+  return name ? { type: "tool", toolName: name } : "required";
 }
 
 function mergeGatewayProviderOptions(

--- a/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for normalizeNativeTools — the tool-shape coercion that feeds
+ * the cloud /chat/completions native-tool path.
+ *
+ * Bug it guards: elizaOS core emits a FLAT `ToolDefinition` envelope
+ * (`{ name, description, type: "function", parameters }`) from
+ * createHandleResponseTool() / the action planner. The previous
+ * implementation returned array-form tools verbatim, so the cloud gateway's
+ * `toGatewayTools` read `tool.function.name` on an undefined `function` and
+ * threw "Cannot read properties of undefined (reading 'name')" — a 500 that
+ * the agent surfaced as "something went wrong on my end" on every native-tool
+ * (should-respond / RESPONSE_HANDLER) turn.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeNativeTools } from "../../src/models/text";
+
+type NativeTool = {
+  type: "function";
+  function: { name: string; description?: string; parameters?: unknown };
+};
+
+describe("normalizeNativeTools", () => {
+  it("wraps a flat ToolDefinition array into the OpenAI {type, function} shape", () => {
+    const flat = [
+      {
+        name: "HANDLE_RESPONSE",
+        description: "Decide whether and how to respond",
+        type: "function",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: { text: { type: "string" } },
+          required: ["text"],
+        },
+      },
+    ];
+
+    const result = normalizeNativeTools(flat) as NativeTool[];
+    expect(result).toHaveLength(1);
+    const [tool] = result;
+    // The gateway reads tool.function.name — it must be defined now.
+    expect(tool.type).toBe("function");
+    expect(tool.function).toBeDefined();
+    expect(tool.function.name).toBe("HANDLE_RESPONSE");
+    expect(tool.function.description).toBe("Decide whether and how to respond");
+    expect(tool.function.parameters).toMatchObject({
+      type: "object",
+      properties: { text: { type: "string" } },
+    });
+  });
+
+  it("preserves tools already in the nested {type, function} shape", () => {
+    const nested = [
+      {
+        type: "function",
+        function: {
+          name: "GET_WEATHER",
+          description: "Look up weather",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    const result = normalizeNativeTools(nested) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("GET_WEATHER");
+    expect(result[0].function.description).toBe("Look up weather");
+  });
+
+  it("normalizes the record/map form (name keyed) into wire shape", () => {
+    const record = {
+      SEARCH: {
+        description: "search",
+        parameters: { type: "object" },
+      },
+    };
+
+    const result = normalizeNativeTools(record) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("SEARCH");
+  });
+
+  it("drops nameless entries instead of throwing downstream", () => {
+    const result = normalizeNativeTools([
+      { type: "function", parameters: { type: "object" } }, // no name anywhere
+      { name: "OK", type: "function", parameters: { type: "object" } },
+    ]) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("OK");
+  });
+
+  it("accepts inputSchema/schema aliases for parameters", () => {
+    const result = normalizeNativeTools([
+      { name: "A", inputSchema: { type: "object", title: "viaInput" } },
+      { name: "B", schema: { type: "object", title: "viaSchema" } },
+    ]) as NativeTool[];
+    expect(result[0].function.parameters).toMatchObject({ title: "viaInput" });
+    expect(result[1].function.parameters).toMatchObject({ title: "viaSchema" });
+  });
+
+  it("returns undefined for empty / falsy tool inputs", () => {
+    expect(normalizeNativeTools(undefined)).toBeUndefined();
+    expect(normalizeNativeTools(null)).toBeUndefined();
+    expect(normalizeNativeTools([])).toBeUndefined();
+    expect(normalizeNativeTools({})).toBeUndefined();
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -334,30 +334,60 @@ function unwrapJsonSchema(value: unknown): unknown {
   return record.schema ?? record.jsonSchema ?? value;
 }
 
-function normalizeNativeTools(tools: unknown): unknown[] | undefined {
+// Normalize a single tool entry into the OpenAI `{ type, function }` wire
+// shape. Accepts BOTH the already-nested form (`{ type: "function", function:
+// { name, parameters } }`) and core's FLAT `ToolDefinition` envelope
+// (`{ name, type: "function", parameters }`, e.g. createHandleResponseTool /
+// the action planner). Returning the flat form verbatim made the cloud gateway
+// read `tool.function.name` on an undefined `function` → "Cannot read
+// properties of undefined (reading 'name')". Returns undefined for entries with
+// no resolvable name so they are dropped rather than crashing downstream.
+function normalizeNativeToolEntry(
+  rawTool: unknown,
+  fallbackName?: string
+): Record<string, unknown> | undefined {
+  const tool = asRecord(rawTool);
+  const nested = asRecord(tool.function);
+  const name = firstString(nested.name, tool.name, fallbackName);
+  if (!name) {
+    return undefined;
+  }
+  const description = firstString(nested.description, tool.description);
+  const inputSchema = unwrapJsonSchema(
+    nested.parameters ??
+      tool.inputSchema ??
+      tool.parameters ??
+      tool.schema ?? { type: "object" }
+  );
+  return {
+    type: "function",
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      parameters: inputSchema,
+    },
+  };
+}
+
+export function normalizeNativeTools(tools: unknown): unknown[] | undefined {
   if (!tools) {
     return undefined;
   }
 
   if (Array.isArray(tools)) {
-    return tools;
+    const normalized = tools
+      .map((tool) => normalizeNativeToolEntry(tool))
+      .filter((tool): tool is Record<string, unknown> => tool !== undefined);
+    return normalized.length > 0 ? normalized : undefined;
   }
 
   const toolSet = asRecord(tools);
   const normalized: unknown[] = [];
   for (const [name, rawTool] of Object.entries(toolSet)) {
-    const tool = asRecord(rawTool);
-    const inputSchema = unwrapJsonSchema(
-      tool.inputSchema ?? tool.parameters ?? tool.schema ?? { type: "object" }
-    );
-    normalized.push({
-      type: "function",
-      function: {
-        name,
-        ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-        parameters: inputSchema,
-      },
-    });
+    const entry = normalizeNativeToolEntry(rawTool, name);
+    if (entry) {
+      normalized.push(entry);
+    }
   }
 
   return normalized.length > 0 ? normalized : undefined;


### PR DESCRIPTION
## Problem
Dedicated cloud agents intermittently returned **"something went wrong on my end"** and ran slow. Root cause (proven by reproduction against `api.elizacloud.ai/api/v1/chat/completions`): a server-side **`Cannot read properties of undefined (reading 'name')`** on the Stage-1 `RESPONSE_HANDLER` (should-respond) call.

elizaOS core emits a **flat** `ToolDefinition` envelope from `createHandleResponseTool()` / the action planner:
```json
{ "name": "HANDLE_RESPONSE", "description": "...", "type": "function", "parameters": { ... } }
```
`name`/`parameters` are siblings of `type` — there is **no nested `function` object**. `plugin-elizacloud`'s `normalizeNativeTools` returned array-form tools **verbatim**, so the cloud gateway's `toGatewayTools` read `tool.function.name` on an undefined `function` and threw. This was newly exercised for dedicated agents once #8762 routed native-tool calls to the cloud instead of `plugin-local-inference` (which understood the flat shape).

## Fix
- **plugin-elizacloud** (`models/text.ts`): `normalizeNativeTools` now maps **every** entry into the OpenAI `{ type, function }` wire shape, accepting **both** the flat `ToolDefinition` and the already-nested form; nameless entries are dropped instead of crashing downstream.
- **cloud-shared** (`providers/vercel-ai-gateway.ts`): `toGatewayTools` / `toGatewayToolChoice` tolerate the flat shape via `normalizeToolFunction(tool.function ?? tool)` and drop nameless tools — turning the opaque 500 into a working request or clean handling for **any** client (raw API users included).
- Adds `normalize-native-tools` regression tests (flat, nested, record, nameless, schema aliases, empty).

## Constraints honored
**Cerebras-only:** no provider/OpenRouter fallback added — this only fixes the tool-shape coercion.

## Test
`bun run --cwd plugins/plugin-elizacloud test:unit` → 70 passed (6 new). Typecheck clean on both packages.

Part of the cloud 10-user launch (#8434). Pairs with #8762 and the embedding fix (sibling PR).