### PR TITLE
fix(agent): cloud containers use cloud embeddings, not local gte-small (dim mismatch + boot waste)

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1880,9 +1880,15 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     topology.services.tts || isCloudContainer,
   );
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_MEDIA", topology.services.media);
+  // Cloud containers always use cloud embeddings: the cloud TEXT_EMBEDDING
+  // handler (1536-dim) must win over plugin-local-inference's gte-small
+  // (384-dim CPU GGUF). Without this, a dedicated cloud agent warms up and
+  // serves local 384-dim embeddings while the SQL column is provisioned for the
+  // cloud dimension → every memory insert is dropped on a dimension mismatch,
+  // and the CPU embedding warmup wastes boot time.
   setCloudUsageEnv(
     "ELIZAOS_CLOUD_USE_EMBEDDINGS",
-    topology.services.embeddings,
+    topology.services.embeddings || isCloudContainer,
   );
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_RPC", topology.services.rpc);
 
@@ -2014,7 +2020,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   } else {
     delete process.env.ELIZA_CLOUD_MEDIA_DISABLED;
   }
-  if (!topology.services.embeddings) {
+  if (!topology.services.embeddings && !isCloudContainer) {
     process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED = "true";
   } else {
     delete process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED;


### PR DESCRIPTION
## Problem
On dedicated cloud agents, container logs showed:
```
[eliza] Configured local embedding env: gte-small_fp16.gguf (... dims: 384 ...)
[eliza] Local embedding warmup: prefetching gte-small_fp16.gguf
[PLUGIN:SQL] Skipping embedding insert: dimension mismatch (expectedDimension=384, receivedDimension=1536, column=dim384)
```
…even though `EMBEDDING_DIMENSION=1536` and `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS=1536`. The agent warmed up a local 384-dim CPU GGUF for `TEXT_EMBEDDING` while the SQL column was `dim384`, but the cloud handler produced 1536-dim vectors → **every memory embedding insert was dropped on a dimension mismatch** (no long-term memory), and the CPU warmup wasted boot time.

## Root cause
`applyCloudConfigToEnv()` handled the cloud-container case for inference and TTS (`|| isCloudContainer`) but **not embeddings**:
- `ELIZAOS_CLOUD_USE_EMBEDDINGS` was set only from `topology.services.embeddings`
- `ELIZA_CLOUD_EMBEDDINGS_DISABLED` was set whenever that was false

A dedicated in-container agent's first-run routing has no embeddings cloud-proxy, so `topology.services.embeddings` is false → both flags forced the local gte-small path.

## Fix (2 edits, both in `applyCloudConfigToEnv`)
1. `ELIZAOS_CLOUD_USE_EMBEDDINGS = topology.services.embeddings || isCloudContainer`
2. only set `ELIZA_CLOUD_EMBEDDINGS_DISABLED` when `!topology.services.embeddings && !isCloudContainer`

With `ELIZAOS_CLOUD_USE_EMBEDDINGS=true`, `shouldWarmupLocalEmbeddingModel()` returns false → no gte-small warmup, no local `TEXT_EMBEDDING` registration → plugin-elizacloud's 1536-dim handler serves the slot and `ensureEmbeddingDimension` snaps the column to `dim1536`. This is the embedding half of #8762's intent (cloud agents → cloud inference/embeddings, no local CPU model).

> **Requires a fresh provision** — the embedding column dim is fixed at first migration, so existing agents keep their `dim384` column.

Part of the cloud 10-user launch (#8434).