### PR TITLE
perf(cloud-agent): kill the ~30s dedicated-chat latency (DB locality + lean trims)

### DIFF
--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -70,8 +70,18 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     agentEntry?.advancedMemory ??
     config.agents?.defaults?.advancedMemory ??
     true;
+  // Lean cloud chat agents (ELIZA_PLUGIN_SET=lean-chat) skip advanced
+  // capabilities. The reflection/fact/relationship/identity evaluators they
+  // register fan out a SERIAL cloud-embedding call per extracted item every
+  // turn (measured ~7 x ~1.5s = the bulk of a dedicated chat agent's wall-clock
+  // after the DB-locality fix). A purely conversational agent still keeps raw
+  // message/reply memory; it just doesn't run the structured post-turn
+  // extraction. Scoped strictly to the lean-chat flag, so desktop/mobile/
+  // non-cloud agents (no ELIZA_PLUGIN_SET) keep advanced capabilities on.
   const advancedCapabilitiesEnabled =
-    resolveAdvancedCapabilitiesEnabled(config);
+    process.env.ELIZA_PLUGIN_SET?.trim().toLowerCase() === "lean-chat"
+      ? false
+      : resolveAdvancedCapabilitiesEnabled(config);
   const settings = applyAdvancedCapabilitySettings(
     {
       MEMORY_SUMMARY_MODEL_TYPE:

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -170,6 +170,18 @@ export const LEAN_CHAT_EXCLUDED_PLUGINS: readonly string[] = [
   // local GPU and no reason to run local inference, so exclude it and let the
   // cloud embedding handler serve TEXT_EMBEDDING.
   "@elizaos/plugin-local-inference",
+  // Cloud agent containers are Steward-provisioned (ELIZA_CLOUD_PROVISIONED=1 +
+  // STEWARD_API_URL + STEWARD_AGENT_TOKEN), which trips plugin-wallet's
+  // auto-enable manifest (hasCloudStewardWallet) on EVERY agent — even a purely
+  // conversational one. Its evmWalletProvider then warms on-chain balances at
+  // boot (getBalance(mainnet)+getBalance(base)), each a 3s RPC that times out
+  // against the cloud RPC and falls back to a public node — ~6s of dead boot
+  // time and recurring RPC noise for an agent that never reads a balance.
+  // plugin-workflow auto-enables for the same structural reason with no chat
+  // value. Auto-enable runs before the lean-chat force-drop (plugin-collector),
+  // so listing them here is what actually keeps them out of a lean chat agent.
+  "@elizaos/plugin-wallet",
+  "@elizaos/plugin-workflow",
 ];
 
 /**

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4902,6 +4902,24 @@ export async function startEliza(
     await enableAutonomyLoopIfAvailable(autonomyLoopEnabled);
     startAgentSkillsWarmup();
     startEmbeddingWarmup();
+    // Re-probe the embedding dimension now that the deferred plugin waves have
+    // registered the cloud TEXT_EMBEDDING handler (plugin-elizacloud). The probe
+    // in runtime.initialize() runs ~38s earlier — before that deferred handler
+    // exists — so on a cloud agent it finds no TEXT_EMBEDDING model and the SQL
+    // adapter keeps its hardcoded dim384 default; every 1536-dim cloud vector is
+    // then dropped on a "dimension mismatch with configured column (dim384)".
+    // ensureEmbeddingDimension() is public, idempotent, and self-guarding (it
+    // no-ops when no handler is registered, e.g. cloud-proxied agents), so this
+    // safely snaps the column to dim1536 and lets memory embeddings persist.
+    try {
+      await runtime.ensureEmbeddingDimension();
+    } catch (err) {
+      logger.warn(
+        `[eliza] deferred embedding-dimension re-probe failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     // Trigger the lazy wallet singleton fire-and-forget. This is a safety net
     // — if no wallet route or signing flow triggers it earlier, wallets are
     // still generated here. The singleton keeps this harmless if already

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -197,6 +197,21 @@ export async function prepareManagedElizaBaseEnvironment(
   params: PrepareManagedElizaSharedEnvironmentParams,
 ): Promise<ManagedElizaBaseEnvironmentResult> {
   const existingEnv = { ...(params.existingEnv ?? {}) };
+  // DATABASE_URL / ELIZA_MANAGED_DATABASE_URL are managed reserved keys
+  // (RESERVED_MANAGED_ELIZA_ENV_KEYS); the sandbox layer
+  // (computeManagedAgentDbEnv in eliza-sandbox.ts) is the SOLE authority on the
+  // agent's DB env. Strip any inherited value here so the control-plane's OWN
+  // DATABASE_URL — which the cloud Worker / provisioning daemon carries in its
+  // process env and which spreads in through params.existingEnv — cannot leak
+  // into the agent and silently override ELIZA_AGENT_LOCAL_STATE=1. That leak
+  // forced every "local-state" agent onto the remote shared Railway Postgres
+  // (~166ms/query x dozens of serial reads+writes per turn = the dominant
+  // dedicated-chat latency, plus the shared-DB blast radius). With these
+  // removed, a local-state agent gets only PGlite (+ ELIZA_MANAGED_DATABASE_URL
+  // opt-in), while a shared-DB agent (ELIZA_AGENT_LOCAL_STATE=0) still has
+  // DATABASE_URL re-injected by computeManagedAgentDbEnv.
+  delete existingEnv.DATABASE_URL;
+  delete existingEnv.ELIZA_MANAGED_DATABASE_URL;
   const { plainKey: agentApiKey } = await apiKeysService.createForAgent({
     organizationId: params.organizationId,
     userId: params.userId,


### PR DESCRIPTION
## Problem
After the crash (#8768) and gte-small (#8769) fixes, dedicated cloud-agent chat was still **~28–38s/turn**. Measured the real breakdown on a live prod agent (timestamped container logs + the central `llm_trajectories` DB):

| Cost | Cause |
|------|-------|
| **~20s (dominant)** | agent hits the **remote shared Railway Postgres** (~166ms/query × dozens of serial queries/turn) |
| ~9s | serial cloud-embedding fan-out (~7/turn, 1 text each) from the reflection/fact evaluators |
| ~6s boot | `plugin-wallet` auto-enables on every Steward-provisioned agent → `getBalance` 3s RPC timeouts |
| correctness | SQL embedding column stuck at `dim384` → 1536-dim cloud vectors dropped |

The model itself is fast (~1s/call); the latency was non-LLM serial I/O.

## Fixes (all gated to `ELIZA_PLUGIN_SET=lean-chat` / cloud containers; non-cloud agents untouched)
- **DB locality (dominant)** — `managed-eliza-config.ts`: strip the managed reserved DB keys (`DATABASE_URL`/`ELIZA_MANAGED_DATABASE_URL`) from the inherited `existingEnv`. The cloud Worker/daemon carries its own `DATABASE_URL` in process env, which spread into every agent and silently overrode `ELIZA_AGENT_LOCAL_STATE=1` → all 'local-state' agents were forced onto the remote shared DB (the dominant latency **and** the shared-DB blast radius). The sandbox layer (`computeManagedAgentDbEnv`) stays the sole DB authority. **Validated live: fresh agent now logs `Database provider: pglite` and turns dropped to 6–20s.**
- **Wallet boot stall** — `core-plugins.ts`: exclude `@elizaos/plugin-wallet` + `@elizaos/plugin-workflow` from lean-chat (they auto-enable via Steward env and warm on-chain balances at boot).
- **Embedding fan-out** — `build-character-config.ts`: lean-chat agents skip advanced capabilities, so the reflection/fact/relationship evaluators (a serial cloud-embedding per extracted item every turn) don't register. Raw message memory is unaffected.
- **Embedding dimension** — `eliza.ts`: re-probe `ensureEmbeddingDimension()` after the deferred plugin waves register the cloud TEXT_EMBEDDING handler (it registers ~38s after the init-time probe), so the column snaps from the hardcoded `dim384` to `dim1536` and 1536-dim vectors persist.

> **Deployment note:** the DB-locality fix must also reach the **provisioning daemon** (`/opt/eliza`, currently on `main`), whose `eliza-sandbox.ts` additionally needs the `wantsLocalState` branch already present on `develop`. Both are hotpatched live on the daemon now; this PR is the permanent source change.

Cerebras-only; no provider fallback. Part of the cloud 10-user launch (#8434).