### PR TITLE
fix(ui): composer keyboard blocked — pull-sheet drag handle's pointer-events override

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -386,10 +386,14 @@ describe("ContinuousChatOverlay", () => {
 
     const root = screen.getByTestId("continuous-chat-overlay");
     expect(root.className).toContain("pointer-events-none");
+    expect(root.className).not.toContain("pointer-events-auto");
 
-    const interactiveRegions = root.querySelectorAll(".pointer-events-auto");
-    expect(interactiveRegions.length).toBeGreaterThan(0);
-    expect(Array.from(interactiveRegions)).not.toContain(root);
+    // The overlay still has a LIVE interactive region: the composer fieldset
+    // re-enables pointer events (inline, gated on !pilled) so taps land on the
+    // input while the rest of the surface passes through to the view behind it.
+    const composer = screen.getByTestId("chat-sheet");
+    expect(composer.style.pointerEvents).toBe("auto");
+    expect(composer).not.toBe(root);
   });
 
   it("exposes the canonical chat composer test id on the overlay input only", () => {
@@ -615,6 +619,41 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getByTestId("chat-content").hasAttribute("inert")).toBe(true);
   });
 
+  it("keeps the collapsed pill handle non-interactive while the input is formed", () => {
+    // The pill handle is always mounted over the (faded) composer so it can
+    // crossfade pill→input. Its hit zone (px-16/pt-10) sits over the textarea, so
+    // while NOT pilled it must be pointer-events-none — otherwise it intercepts
+    // the tap meant for the composer and the mobile keyboard never opens.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    expect(sheet.getAttribute("data-detent")).toBe("collapsed");
+
+    const pill = screen.getByTestId("chat-pill");
+    expect(pill.className).toContain("pointer-events-none");
+    expect(pill.className).not.toContain("pointer-events-auto");
+    // Kept out of the tab order / a11y tree while it's not the active handle.
+    expect(pill.getAttribute("tabindex")).toBe("-1");
+    expect(pill.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("makes the pill handle interactive (drag-to-open) once collapsed to the pill", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    // Collapse the input down into the pill.
+    fireEvent.pointerDown(grabber, { clientY: 200, pointerId: 1 });
+    fireEvent.pointerMove(grabber, { clientY: 380, pointerId: 1 });
+    fireEvent.pointerUp(grabber, { clientY: 380, pointerId: 1 });
+    expect(sheet.getAttribute("data-detent")).toBe("pill");
+
+    const pill = screen.getByTestId("chat-pill");
+    // Now the handle owns the gesture: it re-enables pointer events so the user
+    // can grab/drag it open (verified by the flick-up recovery test below).
+    expect(pill.className).toContain("pointer-events-auto");
+    expect(pill.className).not.toContain("pointer-events-none");
+    expect(pill.getAttribute("aria-hidden")).toBeNull();
+  });
+
   it("recovers from the pill back to the input on tap", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const sheet = screen.getByTestId("chat-sheet");
@@ -631,7 +670,9 @@ describe("ContinuousChatOverlay", () => {
     // first tap) and clear the `inert` it carried while pilled — without that,
     // the composer silently refuses keyboard input until a second tap.
     expect(document.activeElement).toBe(textarea);
-    expect(screen.getByTestId("chat-content").hasAttribute("inert")).toBe(false);
+    expect(screen.getByTestId("chat-content").hasAttribute("inert")).toBe(
+      false,
+    );
   });
 
   it("flicks UP from the pill to recover the input", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -401,10 +401,18 @@ function PillHandle({
   binding,
   onOpen,
   glow,
+  pilled,
 }: {
   binding: PullGestureBinding;
   onOpen: () => void;
   glow: boolean;
+  // Interactive ONLY while pilled. The handle's hit zone (`px-16 pt-10`) is tall
+  // and wide and sits directly over the composer textarea; if it kept
+  // `pointer-events-auto` while NOT pilled it would intercept the tap meant for
+  // the input (the parent's `pointer-events:none` can't override a child that
+  // opts back in), so the keyboard would never open. Gate on `pilled` so taps
+  // pass through to the textarea once the input has formed.
+  pilled: boolean;
 }): React.JSX.Element {
   return (
     <button
@@ -419,10 +427,16 @@ function PillHandle({
         }
       }}
       {...binding}
+      tabIndex={pilled ? undefined : -1}
+      aria-hidden={pilled ? undefined : true}
       className={cn(
         // The bar hugs the BOTTOM (small pb) where the collapsed input sat — not
         // floating mid-air; the tall pt keeps a generous upward grab/flick zone.
-        "pointer-events-auto flex cursor-grab touch-none select-none items-end justify-center px-16 pb-1.5 pt-10 active:cursor-grabbing",
+        "flex cursor-grab touch-none select-none items-end justify-center px-16 pb-1.5 pt-10 active:cursor-grabbing",
+        // Interactive only while pilled. When NOT pilled the (faded) handle must
+        // let taps fall through to the composer textarea below it — otherwise its
+        // tall hit zone steals the tap and the keyboard never opens.
+        pilled ? "pointer-events-auto" : "pointer-events-none",
         "focus-visible:rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
       )}
     >
@@ -2626,6 +2640,7 @@ export function ContinuousChatOverlay({
               binding={pullBinding}
               onOpen={openFromPill}
               glow={listening || responding}
+              pilled={pilled}
             />
           </motion.div>
         </motion.fieldset>


### PR DESCRIPTION
## Bug (found via live on-device debugging of cloud chat)
On mobile, tapping the chat composer did **nothing** — the keyboard wouldn't open. `document.elementFromPoint` at the composer center returned the continuous-chat collapsed drag handle (`PillHandle`), not the textarea.

**Cause:** `PillHandle`'s root className hard-coded `pointer-events-auto`. Its container already gates interactivity correctly (`pointerEvents: pilled ? "auto" : "none"`), but a child opting back into pointer events overrides a parent's `pointer-events:none`. So when NOT pilled (the input is formed), the handle's tall/wide hit-zone (`px-16 pt-10`) kept intercepting taps over the composer textarea → it never focused → no keyboard.

## Fix
- Thread a `pilled` prop into `PillHandle`; make its pointer-events conditional: `pilled ? "pointer-events-auto" : "pointer-events-none"` (drag-to-open still works when collapsed; taps pass through to the composer when the input is formed). Also `tabIndex={-1}` + `aria-hidden` while inert.

## Tests
ContinuousChatOverlay.test.tsx +2 (handle inert/out-of-tab-order when not-pilled; interactive once pilled) → 44 pass; slash suite 14 pass; typecheck + biome clean. Verified on-device: composer now focuses + keyboard opens; cloud cerebras chat works end-to-end.

Refs #8434.