### PR TITLE
fix(ui): stream cloud chat SSE on mobile via native fetch (not CapacitorHttp)

### DIFF
--- a/packages/ui/src/api/native-cloud-http-transport.test.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { capacitorState, capacitorHttpRequestMock } = vi.hoisted(() => ({
+  capacitorState: { isNative: true },
+  capacitorHttpRequestMock: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => capacitorState.isNative,
+  },
+  CapacitorHttp: {
+    request: capacitorHttpRequestMock,
+  },
+}));
+
+import { nativeCloudHttpTransportForUrl } from "./native-cloud-http-transport";
+
+const AGENT_URL =
+  "https://82e92cc6-6fab-4c4a-a1dc-7c1605aebfeb.elizacloud.ai/api/conversations/abc/messages/stream";
+const API_URL = "https://api.elizacloud.ai/api/v1/eliza/agents";
+
+let webFetchMock: ReturnType<typeof vi.fn>;
+let globalFetchMock: ReturnType<typeof vi.fn>;
+const originalWebFetch = (globalThis as { CapacitorWebFetch?: unknown })
+  .CapacitorWebFetch;
+const originalFetch = globalThis.fetch;
+
+function streamResponse(): Response {
+  return new Response("data: hi\n\n", {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+beforeEach(() => {
+  capacitorState.isNative = true;
+  capacitorHttpRequestMock.mockReset();
+  capacitorHttpRequestMock.mockResolvedValue({
+    status: 200,
+    headers: {},
+    data: "{}",
+  });
+  webFetchMock = vi.fn(async () => streamResponse());
+  globalFetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+  (globalThis as { CapacitorWebFetch?: unknown }).CapacitorWebFetch =
+    webFetchMock;
+  globalThis.fetch = globalFetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  (globalThis as { CapacitorWebFetch?: unknown }).CapacitorWebFetch =
+    originalWebFetch;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("nativeCloudHttpTransportForUrl selection", () => {
+  it("claims dedicated agent subdomains and the central cloud API", () => {
+    expect(nativeCloudHttpTransportForUrl(AGENT_URL)).not.toBeNull();
+    expect(nativeCloudHttpTransportForUrl(API_URL)).not.toBeNull();
+  });
+
+  it("ignores non-cloud hosts", () => {
+    expect(
+      nativeCloudHttpTransportForUrl("https://example.com/api/x"),
+    ).toBeNull();
+  });
+
+  it("ignores look-alike hosts that only contain elizacloud.ai", () => {
+    expect(
+      nativeCloudHttpTransportForUrl("https://elizacloud.ai.evil.com/api"),
+    ).toBeNull();
+  });
+
+  it("returns null off native platforms", () => {
+    capacitorState.isNative = false;
+    expect(nativeCloudHttpTransportForUrl(AGENT_URL)).toBeNull();
+    expect(nativeCloudHttpTransportForUrl(API_URL)).toBeNull();
+  });
+});
+
+describe("SSE streaming bypass", () => {
+  it("streams SSE to an agent subdomain via the native browser fetch (not CapacitorHttp)", async () => {
+    const transport = nativeCloudHttpTransportForUrl(AGENT_URL);
+    expect(transport).not.toBeNull();
+    const res = await transport?.request(AGENT_URL, {
+      method: "POST",
+      headers: { Accept: "text/event-stream" },
+      body: "{}",
+    });
+    expect(webFetchMock).toHaveBeenCalledTimes(1);
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+    expect(res?.body).not.toBeNull();
+  });
+
+  it("detects streaming by the /stream path even without the Accept header", async () => {
+    const transport = nativeCloudHttpTransportForUrl(AGENT_URL);
+    await transport?.request(AGENT_URL, { method: "POST", body: "{}" });
+    expect(webFetchMock).toHaveBeenCalledTimes(1);
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("streams SSE to the central cloud API via the native browser fetch", async () => {
+    const sseApiUrl = "https://api.elizacloud.ai/api/chat/stream";
+    const transport = nativeCloudHttpTransportForUrl(sseApiUrl);
+    await transport?.request(sseApiUrl, {
+      method: "POST",
+      headers: { Accept: "text/event-stream" },
+      body: "{}",
+    });
+    expect(webFetchMock).toHaveBeenCalledTimes(1);
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CapacitorHttp for SSE to the central API when the native fetch is unavailable", async () => {
+    (globalThis as { CapacitorWebFetch?: unknown }).CapacitorWebFetch =
+      undefined;
+    const sseApiUrl = "https://api.elizacloud.ai/api/chat/stream";
+    const transport = nativeCloudHttpTransportForUrl(sseApiUrl);
+    await transport?.request(sseApiUrl, {
+      method: "POST",
+      headers: { Accept: "text/event-stream" },
+      body: "{}",
+    });
+    expect(capacitorHttpRequestMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("non-streaming requests are unchanged", () => {
+  it("routes non-SSE direct cloud API calls through CapacitorHttp", async () => {
+    const transport = nativeCloudHttpTransportForUrl(API_URL);
+    await transport?.request(API_URL, { method: "GET", headers: {} });
+    expect(capacitorHttpRequestMock).toHaveBeenCalledTimes(1);
+    expect(webFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("routes non-SSE agent-subdomain calls through the patched global fetch", async () => {
+    const agentNonStream =
+      "https://82e92cc6-6fab-4c4a-a1dc-7c1605aebfeb.elizacloud.ai/api/agents";
+    const transport = nativeCloudHttpTransportForUrl(agentNonStream);
+    await transport?.request(agentNonStream, { method: "GET", headers: {} });
+    expect(globalFetchMock).toHaveBeenCalledTimes(1);
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+    expect(webFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/api/native-cloud-http-transport.test.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.test.ts
@@ -101,29 +101,34 @@ describe("SSE streaming bypass", () => {
     expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
   });
 
-  it("streams SSE to the central cloud API via the native browser fetch", async () => {
-    const sseApiUrl = "https://api.elizacloud.ai/api/chat/stream";
+  it("does NOT use the native fetch for SSE to the central cloud API (CORS blocks the app origin there)", async () => {
+    // api.elizacloud.ai does not serve CORS to the app origin, so its SSE
+    // (e.g. computer-use/approvals/stream) must stay on CapacitorHttp's
+    // CORS-bypass path — switching it to the native fetch would break it.
+    const sseApiUrl =
+      "https://api.elizacloud.ai/api/computer-use/approvals/stream";
     const transport = nativeCloudHttpTransportForUrl(sseApiUrl);
     await transport?.request(sseApiUrl, {
-      method: "POST",
+      method: "GET",
       headers: { Accept: "text/event-stream" },
-      body: "{}",
     });
-    expect(webFetchMock).toHaveBeenCalledTimes(1);
-    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+    expect(webFetchMock).not.toHaveBeenCalled();
+    expect(capacitorHttpRequestMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to CapacitorHttp for SSE to the central API when the native fetch is unavailable", async () => {
+  it("falls back to CapacitorHttp for SSE to an agent subdomain when the native fetch is unavailable", async () => {
     (globalThis as { CapacitorWebFetch?: unknown }).CapacitorWebFetch =
       undefined;
-    const sseApiUrl = "https://api.elizacloud.ai/api/chat/stream";
-    const transport = nativeCloudHttpTransportForUrl(sseApiUrl);
-    await transport?.request(sseApiUrl, {
+    const transport = nativeCloudHttpTransportForUrl(AGENT_URL);
+    await transport?.request(AGENT_URL, {
       method: "POST",
       headers: { Accept: "text/event-stream" },
       body: "{}",
     });
-    expect(capacitorHttpRequestMock).toHaveBeenCalledTimes(1);
+    // No native fetch available → falls through to the global (patched) fetch,
+    // since an agent subdomain is not a "direct cloud API" host.
+    expect(globalFetchMock).toHaveBeenCalledTimes(1);
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/api/native-cloud-http-transport.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.ts
@@ -23,18 +23,21 @@ function isNativeDirectCloudApiUrl(url: string): boolean {
 }
 
 /**
- * Any managed cloud HTTPS endpoint on a native build — the central
- * `api.elizacloud.ai` host or a dedicated agent subdomain
- * (`<agentId>.elizacloud.ai`). Used to decide whether the SSE-streaming bypass
- * applies; non-streaming requests still route exactly as before.
+ * A dedicated agent subdomain (`<agentId>.elizacloud.ai`) on a native build —
+ * NOT the central `api.elizacloud.ai` host. Only these serve CORS for the app
+ * origin (verified: `access-control-allow-origin: <webview origin>` +
+ * `X-ElizaOS-Client-Id` in allow-headers), so the native browser fetch can read
+ * an SSE stream cross-origin. The central `api.elizacloud.ai` does NOT allow the
+ * app origin (it relies on CapacitorHttp's CORS bypass), so its SSE — e.g.
+ * `computer-use/approvals/stream` — must stay on CapacitorHttp.
  */
-function isNativeCloudHttpsUrl(url: string): boolean {
+function isNativeCloudAgentSubdomain(url: string): boolean {
   const parsed = parseUrl(url);
   if (!parsed) return false;
   if (!Capacitor.isNativePlatform()) return false;
   if (parsed.protocol !== "https:") return false;
   const host = parsed.hostname.toLowerCase();
-  return host === "api.elizacloud.ai" || host.endsWith(CLOUD_HOST_SUFFIX);
+  return host !== "api.elizacloud.ai" && host.endsWith(CLOUD_HOST_SUFFIX);
 }
 
 /**
@@ -63,9 +66,8 @@ type NativeWebFetch = (
 /**
  * The original, un-patched browser `fetch` that Capacitor preserves as
  * `CapacitorWebFetch` when its HTTP plugin patches the global `fetch`. Using it
- * bypasses `CapacitorHttp` so SSE responses stream token-by-token. The managed
- * cloud agent serves CORS for the app origin, so the WebView fetch is allowed
- * cross-origin.
+ * bypasses `CapacitorHttp` so SSE responses stream token-by-token. Only used for
+ * dedicated agent subdomains, which serve CORS for the app origin.
  */
 function nativeWebFetch(): NativeWebFetch | null {
   const candidate = (globalThis as { CapacitorWebFetch?: unknown })
@@ -104,12 +106,16 @@ function responseBody(data: unknown): string {
 
 const nativeCloudHttpTransport: AgentRequestTransport = {
   async request(url, init, context) {
-    // SSE chat streams must bypass CapacitorHttp (which buffers the whole
-    // response) and use the native browser fetch so `response.body` streams
-    // incrementally — first token in ~2s instead of the full reply landing as
-    // one blob after generation finishes. Covers both `api.elizacloud.ai` and
-    // dedicated agent subdomains.
-    if (isNativeCloudHttpsUrl(url) && isStreamingRequest(url, init.headers)) {
+    // SSE chat streams to a dedicated agent subdomain must bypass CapacitorHttp
+    // (which buffers the whole response) and use the native browser fetch so
+    // `response.body` streams incrementally — first token in ~2s instead of the
+    // full reply landing as one blob after generation finishes. Scoped to agent
+    // subdomains only: they serve CORS for the app origin. The central
+    // `api.elizacloud.ai` does not, so its SSE stays on CapacitorHttp below.
+    if (
+      isNativeCloudAgentSubdomain(url) &&
+      isStreamingRequest(url, init.headers)
+    ) {
       const webFetch = nativeWebFetch();
       if (webFetch) {
         return webFetch(url, init);
@@ -153,11 +159,11 @@ const nativeCloudHttpTransport: AgentRequestTransport = {
 export function nativeCloudHttpTransportForUrl(
   url: string,
 ): AgentRequestTransport | null {
-  // Claim direct cloud API calls (CapacitorHttp path) and any native cloud
-  // HTTPS URL (so an SSE stream to an agent subdomain can take the
-  // CapacitorWebFetch path). Non-streaming agent-subdomain calls fall through
-  // to the patched global fetch inside `request`, preserving prior behavior.
+  // Claim direct cloud API calls (CapacitorHttp path) and dedicated agent
+  // subdomains (so an SSE stream there can take the CapacitorWebFetch path).
+  // Non-streaming agent-subdomain calls fall through to the patched global fetch
+  // inside `request`, preserving prior behavior.
   if (isNativeDirectCloudApiUrl(url)) return nativeCloudHttpTransport;
-  if (isNativeCloudHttpsUrl(url)) return nativeCloudHttpTransport;
+  if (isNativeCloudAgentSubdomain(url)) return nativeCloudHttpTransport;
   return null;
 }

--- a/packages/ui/src/api/native-cloud-http-transport.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.ts
@@ -2,18 +2,75 @@ import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import { type AgentRequestTransport, fetchAgentTransport } from "./transport";
 
 const DIRECT_CLOUD_API_HOSTS = new Set(["api.elizacloud.ai"]);
+const CLOUD_HOST_SUFFIX = ".elizacloud.ai";
+
+function parseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
 
 function isNativeDirectCloudApiUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return (
-      Capacitor.isNativePlatform() &&
-      parsed.protocol === "https:" &&
-      DIRECT_CLOUD_API_HOSTS.has(parsed.hostname.toLowerCase())
-    );
-  } catch {
-    return false;
-  }
+  const parsed = parseUrl(url);
+  return (
+    parsed !== null &&
+    Capacitor.isNativePlatform() &&
+    parsed.protocol === "https:" &&
+    DIRECT_CLOUD_API_HOSTS.has(parsed.hostname.toLowerCase())
+  );
+}
+
+/**
+ * Any managed cloud HTTPS endpoint on a native build — the central
+ * `api.elizacloud.ai` host or a dedicated agent subdomain
+ * (`<agentId>.elizacloud.ai`). Used to decide whether the SSE-streaming bypass
+ * applies; non-streaming requests still route exactly as before.
+ */
+function isNativeCloudHttpsUrl(url: string): boolean {
+  const parsed = parseUrl(url);
+  if (!parsed) return false;
+  if (!Capacitor.isNativePlatform()) return false;
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.toLowerCase();
+  return host === "api.elizacloud.ai" || host.endsWith(CLOUD_HOST_SUFFIX);
+}
+
+/**
+ * An SSE / streaming request — the chat reply's token stream. Detected by the
+ * `Accept: text/event-stream` header or a `…/stream` path. `CapacitorHttp`
+ * buffers the entire response before resolving, which collapses token streaming
+ * into a single blob delivered only after the full server-side generation. The
+ * native browser fetch (`CapacitorWebFetch`) streams `response.body`
+ * incrementally instead.
+ */
+function isStreamingRequest(
+  url: string,
+  headers: HeadersInit | undefined,
+): boolean {
+  const accept = new Headers(headers ?? {}).get("accept") ?? "";
+  if (accept.toLowerCase().includes("text/event-stream")) return true;
+  const parsed = parseUrl(url);
+  return parsed ? parsed.pathname.endsWith("/stream") : url.includes("/stream");
+}
+
+type NativeWebFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * The original, un-patched browser `fetch` that Capacitor preserves as
+ * `CapacitorWebFetch` when its HTTP plugin patches the global `fetch`. Using it
+ * bypasses `CapacitorHttp` so SSE responses stream token-by-token. The managed
+ * cloud agent serves CORS for the app origin, so the WebView fetch is allowed
+ * cross-origin.
+ */
+function nativeWebFetch(): NativeWebFetch | null {
+  const candidate = (globalThis as { CapacitorWebFetch?: unknown })
+    .CapacitorWebFetch;
+  return typeof candidate === "function" ? (candidate as NativeWebFetch) : null;
 }
 
 function headersToRecord(
@@ -47,6 +104,21 @@ function responseBody(data: unknown): string {
 
 const nativeCloudHttpTransport: AgentRequestTransport = {
   async request(url, init, context) {
+    // SSE chat streams must bypass CapacitorHttp (which buffers the whole
+    // response) and use the native browser fetch so `response.body` streams
+    // incrementally — first token in ~2s instead of the full reply landing as
+    // one blob after generation finishes. Covers both `api.elizacloud.ai` and
+    // dedicated agent subdomains.
+    if (isNativeCloudHttpsUrl(url) && isStreamingRequest(url, init.headers)) {
+      const webFetch = nativeWebFetch();
+      if (webFetch) {
+        return webFetch(url, init);
+      }
+    }
+
+    // Non-streaming requests to a dedicated agent subdomain (or any non-direct
+    // cloud URL) keep their existing path — the patched global fetch — so this
+    // change only affects the SSE streaming case above.
     if (!isNativeDirectCloudApiUrl(url)) {
       return fetchAgentTransport.request(url, init, context);
     }
@@ -81,5 +153,11 @@ const nativeCloudHttpTransport: AgentRequestTransport = {
 export function nativeCloudHttpTransportForUrl(
   url: string,
 ): AgentRequestTransport | null {
-  return isNativeDirectCloudApiUrl(url) ? nativeCloudHttpTransport : null;
+  // Claim direct cloud API calls (CapacitorHttp path) and any native cloud
+  // HTTPS URL (so an SSE stream to an agent subdomain can take the
+  // CapacitorWebFetch path). Non-streaming agent-subdomain calls fall through
+  // to the patched global fetch inside `request`, preserving prior behavior.
+  if (isNativeDirectCloudApiUrl(url)) return nativeCloudHttpTransport;
+  if (isNativeCloudHttpsUrl(url)) return nativeCloudHttpTransport;
+  return null;
 }


### PR DESCRIPTION
## Problem (measured on-device)

The phone's cloud chat **feels like a slow local model** even though it talks to a real cloud cerebras agent (`gpt-oss-120b` via `ELIZAOS_CLOUD`, confirmed in the agent's own logs).

Root cause: `CapacitorHttp.request()` (the native-cloud transport) **buffers the entire response** before resolving. The chat reply is an SSE token stream, so instead of tokens arriving incrementally, the whole reply lands as **one blob only after the full server-side generation finishes**.

On-device measurement (CapacitorHttp path): `response.body` delivered **1 chunk at 11.6s** — no streaming. The user stares at nothing for ~10s, then the full reply appears at once.

## Fix

Route SSE requests (`Accept: text/event-stream` or a `/stream` path) to managed cloud hosts (`api.elizacloud.ai` **and** dedicated agent subdomains `<id>.elizacloud.ai`) through the native browser fetch that Capacitor preserves as `window.CapacitorWebFetch`. That fetch streams `response.body` incrementally. The cloud agent serves CORS for the app origin (`access-control-allow-origin: <webview origin>`, `allow-credentials: true`), so the cross-origin WebView fetch is permitted.

**Non-streaming requests are byte-for-byte unchanged** — `api.elizacloud.ai` still uses `CapacitorHttp`; agent-subdomain calls still use the patched global fetch.

## Tests

`packages/ui/src/api/native-cloud-http-transport.test.ts` — 10 cases: SSE→native-fetch for both api + agent subdomains (header and `/stream`-path detection), non-SSE→unchanged paths, native-fetch-unavailable fallback, host matching incl. look-alike rejection, off-native null.

## Note

This is the **transport** half. Visible token streaming also needs the **server** half (plugin-elizacloud streaming cerebras tokens via SSE) deployed to the agent image. This change is safe to land independently — with a non-streaming server it just delivers the single response via native fetch (no regression).