### PR TITLE
fix(cloud): auto-reap leaked DB connections on the shared Postgres

### DIFF
--- a/packages/cloud-shared/src/db/client.ts
+++ b/packages/cloud-shared/src/db/client.ts
@@ -227,6 +227,28 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
       error: err instanceof Error ? err.message : String(err),
     });
   });
+  // Long-running Node services (agent-server, gateways) hold pooled connections
+  // on the shared Postgres. A checkout that's never released, or a transaction
+  // left open, would otherwise sit forever and eventually exhaust
+  // max_connections ("too many clients already"). The pool reaps its OWN idle
+  // connections within seconds, so these server-side timeouts only ever fire on
+  // genuinely leaked/abandoned sessions — reclaiming the slot. Skip on Workers
+  // (maxUses=1, can't leak, and we don't want an extra round-trip per request)
+  // and on local PGlite. idle_session_timeout is PG14+; the catch keeps it a
+  // no-op on older servers (idle_in_transaction_session_timeout is PG9.6+).
+  if (!inWorkerRuntime && !isLocalTcp) {
+    pool.on("connect", (client) => {
+      void client
+        .query(
+          "SET idle_session_timeout = '10min'; SET idle_in_transaction_session_timeout = '5min'",
+        )
+        .catch((err) => {
+          logger.debug("[db] could not set idle session timeouts", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+    });
+  }
   if (isLocalTcp) {
     disableLocalPreparedStatements(pool, { simpleQueryMode: inWorkerRuntime });
   }


### PR DESCRIPTION
## Why
Login regressed **again** at ~10:05 (2026-06-20), even after `max_connections` was raised 100→200: a connection **leak** from a long-running Node service (labeled `eliza-cloud-shared` in `pg_stat_activity` thanks to #8729) refilled the pool and re-hit `too many clients already`. A checkout that's never released (or a transaction left open) sits idle forever and **never returns to the pool**, so the pool's own idle reaping can't reclaim it — it just creeps toward the ceiling.

## Fix
On each connection for **long-running Node services** (agent-server, gateways), set:
- `idle_session_timeout = 10min`
- `idle_in_transaction_session_timeout = 5min`

The pool reaps its *own* idle connections within seconds, so these server-side timeouts **only ever fire on genuinely leaked/abandoned sessions** — Postgres reclaims the slot, bounding the exhaustion at its source (no impact on healthy pooling).

Scoped to **skip Workers** (`maxUses=1`, can't leak, and we don't want an extra round-trip per request) and **local PGlite**; degrades to a no-op on pre-PG14 servers via the `catch`.

## The full picture (this + already-landed)
| Layer | Change | Status |
|---|---|---|
| Leak bounded | this PR — auto-reap leaked sessions | here |
| Attributable | `application_name` labeling | #8729 (merged) |
| Headroom | `max_connections` 100→200 | applied to prod DB |
| Cache | `shared_buffers` 128MB→2GB | applied to prod DB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)