### PR TITLE
feat(core): compose_state_providers pipeline hook for dynamic provider filtering

### DIFF
--- a/packages/core/src/__tests__/compose-state-provider-hook.test.ts
+++ b/packages/core/src/__tests__/compose-state-provider-hook.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory, Provider, UUID } from "../types";
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ENTITY_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function makeProvider(
+	name: string,
+	text: string,
+	extra: Partial<Provider> = {},
+): Provider {
+	return {
+		name,
+		get: async () => ({ text, values: {}, data: {} }),
+		...extra,
+	};
+}
+
+function makeMessage(id: string): Memory {
+	return {
+		id: id as UUID,
+		entityId: ENTITY_ID,
+		roomId: ROOM_ID,
+		content: { text: "gm" },
+	};
+}
+
+function newRuntime(name: string): AgentRuntime {
+	const runtime = new AgentRuntime({ character: { name } as Character });
+	runtime.registerProvider(makeProvider("WALLET", "WALLET_BALANCE_HEAVY"));
+	runtime.registerProvider(makeProvider("GREETING", "HELLO_THERE"));
+	// Dynamic providers are excluded from default selection; a hook can opt one in.
+	runtime.registerProvider(
+		makeProvider("CRYPTO_SWAP", "SWAP_READY", { dynamic: true }),
+	);
+	return runtime;
+}
+
+describe("compose_state_providers pipeline hook", () => {
+	it("runs every registered (non-dynamic) provider when no hook is set", async () => {
+		const runtime = newRuntime("compose-hook-baseline");
+		const state = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			null,
+			false,
+			true,
+		);
+		const order = state.data.providerOrder as string[];
+		expect(order).toContain("WALLET");
+		expect(order).toContain("GREETING");
+		// CRYPTO_SWAP is dynamic — never in the default set without opt-in.
+		expect(order).not.toContain("CRYPTO_SWAP");
+		expect(state.text).toContain("WALLET_BALANCE_HEAVY");
+	});
+
+	it("lets a hook filter out and add providers by name", async () => {
+		const runtime = newRuntime("compose-hook-filter");
+		runtime.registerPipelineHook({
+			id: "intent-filter",
+			phase: "compose_state_providers",
+			handler: (_rt, ctx) => {
+				if (ctx.phase !== "compose_state_providers") return;
+				ctx.providers.current = [
+					...ctx.providers.current.filter((n) => n !== "WALLET"),
+					"CRYPTO_SWAP",
+				];
+			},
+		});
+
+		const state = await runtime.composeState(
+			makeMessage("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+			null,
+			false,
+			true,
+		);
+		const order = state.data.providerOrder as string[];
+		expect(order).not.toContain("WALLET");
+		expect(order).toContain("GREETING");
+		// A dynamic provider named explicitly by the hook is pulled in.
+		expect(order).toContain("CRYPTO_SWAP");
+		expect(state.text).toContain("SWAP_READY");
+		expect(state.text).toContain("HELLO_THERE");
+		expect(state.text).not.toContain("WALLET_BALANCE_HEAVY");
+	});
+
+	it("is a pure pass-through when the hook returns the list unmodified", async () => {
+		const runtime = newRuntime("compose-hook-passthrough");
+		runtime.registerPipelineHook({
+			id: "noop",
+			phase: "compose_state_providers",
+			handler: () => {
+				// no-op
+			},
+		});
+
+		const state = await runtime.composeState(
+			makeMessage("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+			null,
+			false,
+			true,
+		);
+		const order = state.data.providerOrder as string[];
+		expect(order).toContain("WALLET");
+		expect(order).toContain("GREETING");
+		expect(order).not.toContain("CRYPTO_SWAP");
+	});
+
+	it("keeps the pre-hook selection when a hook corrupts providers.current", async () => {
+		const runtime = newRuntime("compose-hook-nonarray");
+		runtime.registerPipelineHook({
+			id: "corrupt",
+			phase: "compose_state_providers",
+			handler: (_rt, ctx) => {
+				if (ctx.phase !== "compose_state_providers") return;
+				// Type-erased at runtime: a buggy hook hands back a non-array.
+				(ctx.providers as { current: unknown }).current = "WALLET";
+			},
+		});
+
+		const state = await runtime.composeState(
+			makeMessage("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+			null,
+			false,
+			true,
+		);
+		const order = state.data.providerOrder as string[];
+		// Falls back to the pre-hook set instead of crashing or emptying.
+		expect(order).toContain("WALLET");
+		expect(order).toContain("GREETING");
+	});
+
+	it("does not crash when a hook throws after a partial mutation", async () => {
+		const runtime = newRuntime("compose-hook-throw");
+		runtime.registerPipelineHook({
+			id: "throws",
+			phase: "compose_state_providers",
+			handler: (_rt, ctx) => {
+				if (ctx.phase !== "compose_state_providers") return;
+				ctx.providers.current = ctx.providers.current.filter(
+					(n) => n !== "WALLET",
+				);
+				throw new Error("boom");
+			},
+		});
+
+		// The thrown error is swallowed by invokePipelineHooks; composeState resolves.
+		const state = await runtime.composeState(
+			makeMessage("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+			null,
+			false,
+			true,
+		);
+		const order = state.data.providerOrder as string[];
+		expect(order).toContain("GREETING");
+	});
+
+	it("surfaces onlyInclude and the message to the hook", async () => {
+		const runtime = newRuntime("compose-hook-context");
+		let seenOnlyInclude: boolean | undefined;
+		let seenMessageId: string | undefined;
+		let seenNames: string[] | undefined;
+		runtime.registerPipelineHook({
+			id: "capture",
+			phase: "compose_state_providers",
+			handler: (_rt, ctx) => {
+				if (ctx.phase !== "compose_state_providers") return;
+				seenOnlyInclude = ctx.onlyInclude;
+				seenMessageId = ctx.message.id;
+				seenNames = [...ctx.providers.current];
+			},
+		});
+
+		await runtime.composeState(
+			makeMessage("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+			["GREETING"],
+			true,
+			true,
+		);
+		expect(seenOnlyInclude).toBe(true);
+		expect(seenMessageId).toBe("dddddddd-dddd-dddd-dddd-dddddddddddd");
+		// onlyInclude=true ⇒ the proposed set is exactly the caller's include-list.
+		expect(seenNames).toEqual(["GREETING"]);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -169,6 +169,7 @@ import type { AgentContext } from "./types/contexts";
 import type { IMessageService } from "./types/message-service";
 import {
 	afterMemoryPersistedPipelineHookContext,
+	composeStateProvidersPipelineHookContext,
 	modelStreamChunkPipelineHookContext,
 	modelStreamEndPipelineHookContext,
 	PIPELINE_HOOK_DEBUG_LOG_MS,
@@ -1405,6 +1406,30 @@ export class AgentRuntime implements IAgentRuntime {
 					this.stateCache.delete(messageId);
 					this.stateCache.delete(`${messageId}_action_results`);
 				}
+				return;
+			}
+			case "compose_state_providers": {
+				if (!hasHooks) {
+					return;
+				}
+				const c = ctx as Extract<
+					PipelineHookContext,
+					{ phase: "compose_state_providers" }
+				>;
+				const md = c.message.content.metadata;
+				const meta =
+					typeof md === "object" && md !== null
+						? (md as Record<string, unknown>)
+						: null;
+				if (meta?.skipComposeStateProviderHooks === true) {
+					return;
+				}
+				await this.invokePipelineHooks(
+					phase,
+					c,
+					"Compose-state provider pipeline hook",
+					hookTelemetry,
+				);
 				return;
 			}
 			case "pre_should_respond": {
@@ -3515,6 +3540,40 @@ export class AgentRuntime implements IAgentRuntime {
 		if (!filterList && includeList && includeList.length > 0) {
 			for (const name of includeList) {
 				providerNames.add(name);
+			}
+		}
+		// Opt-in provider-selection hook: lets a host app filter, extend, or
+		// reorder the provider set per message intent before any provider runs.
+		// Guarded so the default (no-hook) path stays allocation-free.
+		if (this.hooksForPhase("compose_state_providers").length > 0) {
+			const selection = composeStateProvidersPipelineHookContext({
+				message,
+				providers: { current: [...providerNames] },
+				activeContexts,
+				onlyInclude,
+				includeList,
+			});
+			await this.applyPipelineHooks("compose_state_providers", selection);
+			// Boundary validation: a buggy hook may replace `current` with a
+			// non-array (or throw mid-mutation). Only adopt a well-formed list;
+			// otherwise keep the pre-hook selection rather than crash the turn.
+			const selected = selection.providers.current;
+			if (Array.isArray(selected)) {
+				providerNames.clear();
+				for (const name of selected) {
+					if (typeof name === "string" && name.length > 0) {
+						providerNames.add(name);
+					}
+				}
+			} else {
+				this.logger.warn(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						phase: "compose_state_providers",
+					},
+					"compose_state_providers hook left providers.current non-array; keeping pre-hook selection",
+				);
 			}
 		}
 		const providersToGet: Provider[] = [];

--- a/packages/core/src/types/pipeline-hooks.ts
+++ b/packages/core/src/types/pipeline-hooks.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from "./contexts";
 import type { Room } from "./environment";
 import type { Memory } from "./memory";
 import {
@@ -71,6 +72,25 @@ export const PIPELINE_HOOK_ERROR_LOG_MS = 2000;
  */
 export type PipelineHookPhase =
 	| "incoming_before_compose"
+	/**
+	 * Inside `composeState`, after the runtime selects the provider NAMES for the
+	 * turn (default selection + context routing, or an explicit include-list) but
+	 * before any provider's `get()` runs. Hooks reassign `providers.current` to
+	 * filter, extend, or reorder the set — letting a host app shape context per
+	 * message intent (e.g. drop heavy wallet/ledger providers on a greeting, add
+	 * `CRYPTO_SWAP` when transaction keywords appear). Opt-in: zero cost and
+	 * identical behavior when no hook is registered. Mutator phase (serial,
+	 * `mutatesPrimary`), so multiple hooks compose in `position` order.
+	 *
+	 * Contract: reassign `providers.current` to a `string[]`; a non-array value is
+	 * ignored and the pre-hook selection is kept (a thrown hook is swallowed and
+	 * continues, like every phase). Keep selection **deterministic for a given
+	 * message** — `composeState` caches by `message.id`. The hook also fires for
+	 * curated/internal calls (`onlyInclude === true`, e.g. response composition);
+	 * those pass an exact list the runtime depends on, so gate on `onlyInclude` and
+	 * no-op unless you mean to override them.
+	 */
+	| "compose_state_providers"
 	| "pre_should_respond"
 	/**
 	 * Overlaps the should-respond phase (heuristics + optional classifier). **All** hooks for this
@@ -154,6 +174,30 @@ export type PipelineHookSchedule = "serial" | "concurrent";
 
 export type PipelineHookContext =
 	| ({ phase: "incoming_before_compose" } & PipelineMessageTurnFields)
+	| {
+			phase: "compose_state_providers";
+			/** The message state is being composed for (read-only). */
+			message: Memory;
+			/**
+			 * The provider NAMES the runtime selected for this turn. Reassign
+			 * `providers.current` to filter, extend, or reorder the set. Only names
+			 * matching a registered provider take effect; final execution order is
+			 * still governed by each provider's `position`. Adding a name pulls in
+			 * that provider even if it is `dynamic`/`private` (explicit selection),
+			 * mirroring `composeState`'s include-list. Same `current`-replacement
+			 * convention as `post_model`'s `result.current`.
+			 */
+			providers: { current: string[] };
+			/** Routing contexts the classifier selected for this turn (read-only). */
+			activeContexts: readonly AgentContext[];
+			/**
+			 * True when the caller demanded an exact include-list (curated/internal
+			 * `composeState` calls). Well-behaved hooks usually no-op when set.
+			 */
+			onlyInclude: boolean;
+			/** The raw include-list passed to `composeState`, if any (read-only). */
+			includeList: readonly string[] | null;
+	  }
 	| ({ phase: "pre_should_respond" } & PipelineMessageTurnFields & {
 				state: State;
 				isAutonomous: boolean;
@@ -258,6 +302,7 @@ export function defaultPipelineHookSchedule(
 
 const PIPELINE_PHASE_MUTATES_PRIMARY_DEFAULT = new Set<PipelineHookPhase>([
 	"incoming_before_compose",
+	"compose_state_providers",
 	"outgoing_before_deliver",
 	"pre_model",
 	"post_model",
@@ -277,6 +322,8 @@ export function pipelineHookMetricRoomId(ctx: PipelineHookContext): UUID {
 		case "parallel_with_should_respond":
 		case "outgoing_before_deliver":
 			return ctx.roomId;
+		case "compose_state_providers":
+			return ctx.message.roomId;
 		case "pre_model":
 		case "post_model":
 			return ctx.roomId ?? DEFAULT_UUID;
@@ -342,6 +389,12 @@ export function incomingPipelineHookContext(
 		message,
 		...correlation,
 	});
+}
+
+export function composeStateProvidersPipelineHookContext(
+	fields: Omit<PipelineHookContextForPhase<"compose_state_providers">, "phase">,
+): PipelineHookContextForPhase<"compose_state_providers"> {
+	return withPipelinePhase("compose_state_providers", fields);
 }
 
 export function preShouldRespondPipelineHookContext(


### PR DESCRIPTION
Closes #8755.

## Context

#8755 asks for app-level control over which providers run during `composeState` ("provider pollution"). Most of the request is **already addressed in 2.x** — but one genuine gap exists, and this PR fills it.

### What already exists (so the issue's core premise is outdated)

- `composeState` does **not** run every provider: it excludes `dynamic` and `private` providers and applies per-turn context routing (`getActiveRoutingContextsForTurn` / `shouldIncludeByContext`). See `runtime.ts` `composeState`.
- Providers already carry intent/role selection metadata: `dynamic`, `private`, `position`, `contexts`, `contextGate`, `roleGate`, `relevanceKeywords`, `alwaysInResponseState` (`types/components.ts`).
- The core **response** path composes a curated list with `onlyInclude=true` (`CORE_RESPONSE_STATE_PROVIDERS` in `services/message.ts`) plus `filterByContextGate(...)` — the opposite of "every provider runs."
- `plugin-bootstrap` (the v1.x module the issue cites) no longer exists; it's `features/basic-capabilities` + `services/message.ts`.
- A full pipeline-hook subsystem already exists (`registerPipelineHook` / `applyPipelineHooks`).

### The genuine gap this PR closes

There was no hook that lets a host app **shape the selected provider list itself**, mid-`composeState`. This adds one, reusing the existing hook machinery.

## Change

New opt-in pipeline-hook phase **`compose_state_providers`**. It fires after the runtime selects the provider names for the turn but before any provider's `get()` runs. A hook reassigns `providers.current` to filter / extend / reorder the set:

```ts
runtime.registerPipelineHook({
  id: "intent-filter",
  phase: "compose_state_providers",
  handler: (_rt, ctx) => {
    if (ctx.phase !== "compose_state_providers") return;
    if (ctx.onlyInclude) return; // don't override curated/internal calls
    // greeting → drop heavy ledger providers, add swap context on intent
    ctx.providers.current = ctx.providers.current
      .filter((n) => n !== "EVM_WALLET_BALANCE")
      .concat(isSwapIntent(ctx.message) ? ["CRYPTO_SWAP"] : []);
  },
});
```

### Properties

- **Reuses** `registerPipelineHook` / `applyPipelineHooks`, so it inherits ordering (`position`), the metrics/observability envelope (`PIPELINE_HOOK_METRIC`), and never-throw semantics — no parallel subsystem.
- **Zero cost** on the default path: skipped entirely (no allocation) when no hook is registered.
- **Boundary-hardened**: a hook that replaces `providers.current` with a non-array (or throws mid-mutation) is ignored and the pre-hook selection is kept — no crash, no silently emptied context.
- Adding a name pulls in that provider even if it's `dynamic`/`private` (explicit selection), mirroring `composeState`'s include-list.
- Fires for curated/internal calls too (`onlyInclude === true`); the flag is exposed so hooks can self-gate.

## Tests

`packages/core/src/__tests__/compose-state-provider-hook.test.ts` — default selection, filter+add, pass-through, non-array fallback, throw-mid-mutation, and `onlyInclude`/message context exposure. `typecheck` + `biome` clean; affected runtime/provider/hook suites green.