### PR TITLE
fix(cloud): RESTORE reverted dedicated-chat fixes (#8768/#8769/#8771/#8759)

### DIFF
--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -70,8 +70,18 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     agentEntry?.advancedMemory ??
     config.agents?.defaults?.advancedMemory ??
     true;
+  // Lean cloud chat agents (ELIZA_PLUGIN_SET=lean-chat) skip advanced
+  // capabilities. The reflection/fact/relationship/identity evaluators they
+  // register fan out a SERIAL cloud-embedding call per extracted item every
+  // turn (measured ~7 x ~1.5s = the bulk of a dedicated chat agent's wall-clock
+  // after the DB-locality fix). A purely conversational agent still keeps raw
+  // message/reply memory; it just doesn't run the structured post-turn
+  // extraction. Scoped strictly to the lean-chat flag, so desktop/mobile/
+  // non-cloud agents (no ELIZA_PLUGIN_SET) keep advanced capabilities on.
   const advancedCapabilitiesEnabled =
-    resolveAdvancedCapabilitiesEnabled(config);
+    process.env.ELIZA_PLUGIN_SET?.trim().toLowerCase() === "lean-chat"
+      ? false
+      : resolveAdvancedCapabilitiesEnabled(config);
   const settings = applyAdvancedCapabilitySettings(
     {
       MEMORY_SUMMARY_MODEL_TYPE:

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -170,6 +170,18 @@ export const LEAN_CHAT_EXCLUDED_PLUGINS: readonly string[] = [
   // local GPU and no reason to run local inference, so exclude it and let the
   // cloud embedding handler serve TEXT_EMBEDDING.
   "@elizaos/plugin-local-inference",
+  // Cloud agent containers are Steward-provisioned (ELIZA_CLOUD_PROVISIONED=1 +
+  // STEWARD_API_URL + STEWARD_AGENT_TOKEN), which trips plugin-wallet's
+  // auto-enable manifest (hasCloudStewardWallet) on EVERY agent — even a purely
+  // conversational one. Its evmWalletProvider then warms on-chain balances at
+  // boot (getBalance(mainnet)+getBalance(base)), each a 3s RPC that times out
+  // against the cloud RPC and falls back to a public node — ~6s of dead boot
+  // time and recurring RPC noise for an agent that never reads a balance.
+  // plugin-workflow auto-enables for the same structural reason with no chat
+  // value. Auto-enable runs before the lean-chat force-drop (plugin-collector),
+  // so listing them here is what actually keeps them out of a lean chat agent.
+  "@elizaos/plugin-wallet",
+  "@elizaos/plugin-workflow",
 ];
 
 /**

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1881,9 +1881,15 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     topology.services.tts || isCloudContainer,
   );
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_MEDIA", topology.services.media);
+  // Cloud containers always use cloud embeddings: the cloud TEXT_EMBEDDING
+  // handler (1536-dim) must win over plugin-local-inference's gte-small
+  // (384-dim CPU GGUF). Without this, a dedicated cloud agent warms up and
+  // serves local 384-dim embeddings while the SQL column is provisioned for the
+  // cloud dimension → every memory insert is dropped on a dimension mismatch,
+  // and the CPU embedding warmup wastes boot time.
   setCloudUsageEnv(
     "ELIZAOS_CLOUD_USE_EMBEDDINGS",
-    topology.services.embeddings,
+    topology.services.embeddings || isCloudContainer,
   );
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_RPC", topology.services.rpc);
 
@@ -2015,7 +2021,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   } else {
     delete process.env.ELIZA_CLOUD_MEDIA_DISABLED;
   }
-  if (!topology.services.embeddings) {
+  if (!topology.services.embeddings && !isCloudContainer) {
     process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED = "true";
   } else {
     delete process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED;

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4909,6 +4909,24 @@ export async function startEliza(
     await enableAutonomyLoopIfAvailable(autonomyLoopEnabled);
     startAgentSkillsWarmup();
     startEmbeddingWarmup();
+    // Re-probe the embedding dimension now that the deferred plugin waves have
+    // registered the cloud TEXT_EMBEDDING handler (plugin-elizacloud). The probe
+    // in runtime.initialize() runs ~38s earlier — before that deferred handler
+    // exists — so on a cloud agent it finds no TEXT_EMBEDDING model and the SQL
+    // adapter keeps its hardcoded dim384 default; every 1536-dim cloud vector is
+    // then dropped on a "dimension mismatch with configured column (dim384)".
+    // ensureEmbeddingDimension() is public, idempotent, and self-guarding (it
+    // no-ops when no handler is registered, e.g. cloud-proxied agents), so this
+    // safely snaps the column to dim1536 and lets memory embeddings persist.
+    try {
+      await runtime.ensureEmbeddingDimension();
+    } catch (err) {
+      logger.warn(
+        `[eliza] deferred embedding-dimension re-probe failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     // Trigger the lazy wallet singleton fire-and-forget. This is a safety net
     // — if no wallet route or signing flow triggers it earlier, wallets are
     // still generated here. The singleton keeps this harmless if already

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -709,6 +709,19 @@ function getRecoverableProviderErrorStatus(error: unknown): number | null {
 
 interface ChatCompletionsHandlerOptions {
   skipOrgRateLimit?: boolean;
+  /**
+   * Cloudflare ExecutionContext. When present, the post-response billing /
+   * settlement chain (billUsage → settleReservation → reconcileCredits →
+   * recordUsageAnalytics → audit) is deferred via `waitUntil` so it never
+   * blocks the model response. The OpenAI response `usage` is built directly
+   * from the model's reported tokens (the same numbers billUsage derives), so
+   * the client sees identical output and billing amounts are unchanged — only
+   * the *timing* of the reconciliation writes moves off the hot path. This
+   * removes ~0.7–1.1s of serial DB writes from every model call; a dedicated
+   * agent makes ~10 calls/turn, so it is several seconds saved per turn.
+   * Falls back to inline `await` when absent (tests / non-Worker callers).
+   */
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
 export async function handleChatCompletionsPOST(
@@ -1030,6 +1043,7 @@ export async function handleChatCompletionsPOST(
         effectiveMaxTokens,
         webSearchOptions,
         billingSource,
+        options.executionCtx,
       );
     }
   } catch (error) {
@@ -1441,11 +1455,24 @@ async function handleNonStreamingRequest(
   effectiveMaxTokens: number | undefined,
   webSearchOptions: ReturnType<typeof buildProviderNativeWebSearchTools>,
   billingSource: PricingBillingSource,
+  executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined,
 ) {
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
+
+  // Run post-response billing/settlement off the hot path when we have a Worker
+  // ExecutionContext (waitUntil keeps the request alive for the writes without
+  // blocking the response). Falls back to inline await otherwise so tests and
+  // non-Worker callers behave exactly as before.
+  const settleOffResponsePath = async (task: () => Promise<void>) => {
+    if (typeof executionCtx?.waitUntil === "function") {
+      executionCtx.waitUntil(task());
+      return;
+    }
+    await task();
+  };
 
   const safeParamsNonStream = getSafeModelParams(model, {
     temperature: request.temperature,
@@ -1477,76 +1504,124 @@ async function handleNonStreamingRequest(
       ...cotOptions,
     } as Parameters<typeof generateText>[0]);
 
-    // Bill using actual usage from SDK response
-    const billingContext = {
-      organizationId: user.organization_id,
-      userId: user.id,
-      apiKeyId: apiKey?.id,
-      model,
-      provider,
-      billingSource,
-      requestId,
-      metadata: buildProviderReconciliationMetadata(
-        provider,
-        model,
-        false,
-        appId,
-      ),
-      affiliateCode,
-      ...buildProviderBillingFields(provider, model),
+    // Token counts for the OpenAI-compat response come straight from the
+    // model's reported usage — identical to what billUsage normalizes
+    // (inputTokens ?? promptTokens, etc.) — so the entire billing/settlement
+    // chain below can run off the response path without changing the bytes the
+    // client receives.
+    const usageRec = (result.usage ?? {}) as unknown as Record<
+      string,
+      number | undefined
+    >;
+    const responseInputTokens =
+      usageRec.inputTokens ?? usageRec.promptTokens ?? 0;
+    const responseOutputTokens =
+      usageRec.outputTokens ?? usageRec.completionTokens ?? 0;
+    const responseTokens = {
+      inputTokens: responseInputTokens,
+      outputTokens: responseOutputTokens,
+      totalTokens:
+        usageRec.totalTokens ?? responseInputTokens + responseOutputTokens,
     };
-    const billing = await billUsage(billingContext, result.usage);
-    const reconciliation = await settleReservation(billing.totalCost);
+    const responseLatencyMs = Date.now() - startTime;
 
-    // Handle app credits
-    if (appCreditsInfo) {
-      await appCreditsService.reconcileCredits({
-        appId: appCreditsInfo.appId,
-        userId: user.id,
-        estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
-        actualBaseCost: billing.totalCost,
-        description: `Chat: ${model}`,
-        metadata: { model, provider, billingSource, streaming: false },
-      });
-    }
-
-    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-      type: "chat",
-      content: result.text,
-      systemPrompt,
-      prompt: request.messages
-        .map((m) => `[${m.role}] ${getMessageContent(m)}`)
-        .join("\n"),
-      latencyMs: Date.now() - startTime,
-    });
-    if (usageRecord) {
+    // Bill using actual usage from SDK response. Deferred via waitUntil so the
+    // ~0.7-1.1s of reconciliation/audit DB writes never block the response.
+    // Same code, same amounts, same reservation — only the timing moves.
+    await settleOffResponsePath(async () => {
       try {
-        await aiBillingRecordsService.record({
-          context: billingContext,
+        const billingContext = {
+          organizationId: user.organization_id,
+          userId: user.id,
+          apiKeyId: apiKey?.id,
+          model,
+          provider,
+          billingSource,
+          requestId,
+          metadata: buildProviderReconciliationMetadata(
+            provider,
+            model,
+            false,
+            appId,
+          ),
+          affiliateCode,
+          ...buildProviderBillingFields(provider, model),
+        };
+        const billing = await billUsage(billingContext, result.usage);
+        const reconciliation = await settleReservation(billing.totalCost);
+
+        // Handle app credits
+        if (appCreditsInfo) {
+          await appCreditsService.reconcileCredits({
+            appId: appCreditsInfo.appId,
+            userId: user.id,
+            estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
+            actualBaseCost: billing.totalCost,
+            description: `Chat: ${model}`,
+            metadata: { model, provider, billingSource, streaming: false },
+          });
+        }
+
+        const usageRecord = await recordUsageAnalytics(
+          billingContext,
           billing,
-          usageRecord,
-          idempotencyKey,
-          reconciliation,
+          {
+            type: "chat",
+            content: result.text,
+            systemPrompt,
+            prompt: request.messages
+              .map((m) => `[${m.role}] ${getMessageContent(m)}`)
+              .join("\n"),
+            latencyMs: responseLatencyMs,
+          },
+        );
+        if (usageRecord) {
+          try {
+            await aiBillingRecordsService.record({
+              context: billingContext,
+              billing,
+              usageRecord,
+              idempotencyKey,
+              reconciliation,
+            });
+          } catch (auditError) {
+            logger.error("[Chat Completions] audit record failed (non-fatal)", {
+              error:
+                auditError instanceof Error
+                  ? auditError.message
+                  : String(auditError),
+              cause:
+                auditError instanceof Error && auditError.cause
+                  ? String(
+                      (auditError.cause as Error).message ?? auditError.cause,
+                    )
+                  : undefined,
+            });
+          }
+        }
+
+        logger.info("[Chat Completions] Non-streaming complete", {
+          durationMs: Date.now() - startTime,
+          inputTokens: billing.inputTokens,
+          outputTokens: billing.outputTokens,
+          totalCost: billing.totalCost,
         });
-      } catch (auditError) {
-        logger.error("[Chat Completions] audit record failed (non-fatal)", {
+      } catch (billingError) {
+        // Deferred billing failed after the response was already sent: release
+        // the held reservation so credit isn't stuck, and log. idempotencyKey
+        // keeps any later retry safe.
+        try {
+          await settleReservation(0);
+        } catch {
+          // best-effort release
+        }
+        logger.error("[Chat Completions] deferred billing failed", {
           error:
-            auditError instanceof Error
-              ? auditError.message
-              : String(auditError),
-          cause:
-            auditError instanceof Error && auditError.cause
-              ? String((auditError.cause as Error).message ?? auditError.cause)
-              : undefined,
+            billingError instanceof Error
+              ? billingError.message
+              : String(billingError),
         });
       }
-    }
-
-    logger.info("[Chat Completions] Non-streaming complete", {
-      durationMs: Date.now() - startTime,
-      inputTokens: billing.inputTokens,
-      outputTokens: billing.outputTokens,
-      totalCost: billing.totalCost,
     });
 
     // Reasoning-model empty-output guard.
@@ -1608,7 +1683,7 @@ async function handleNonStreamingRequest(
             finish_reason: finishReason,
           },
         ],
-        usage: formatOpenAIUsage(billing, result.usage),
+        usage: formatOpenAIUsage(responseTokens, result.usage),
       }),
     );
   } catch (error) {
@@ -1627,7 +1702,9 @@ honoRouter.options("/", async (c) => {
 });
 honoRouter.post("/", rateLimit(RateLimitPresets.RELAXED), async (c) => {
   try {
-    return await handleChatCompletionsPOST(c.req.raw);
+    return await handleChatCompletionsPOST(c.req.raw, {
+      executionCtx: c.executionCtx,
+    });
   } catch (error) {
     return failureResponse(c, error);
   }

--- a/packages/cloud-api/v1/responses/route.ts
+++ b/packages/cloud-api/v1/responses/route.ts
@@ -240,6 +240,7 @@ app.post("/", async (c) => {
     const chatRequest = buildChatRequest(c.req.raw, body, messages);
     const chatResponse = await handleChatCompletionsPOST(chatRequest, {
       skipOrgRateLimit: true,
+      executionCtx: c.executionCtx,
     });
 
     if (!chatResponse.ok) {

--- a/packages/cloud-shared/src/lib/providers/vercel-ai-gateway-tools.test.ts
+++ b/packages/cloud-shared/src/lib/providers/vercel-ai-gateway-tools.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeToolFunction, toGatewayTools } from "./vercel-ai-gateway";
+
+/**
+ * Regression: the gateway's toGatewayTools read `tool.function.name`
+ * unconditionally. elizaOS core's createHandleResponseTool() / action planner
+ * send a FLAT ToolDefinition (`{ name, type, parameters }`) with no nested
+ * `function`, so this threw "Cannot read properties of undefined (reading
+ * 'name')" — an opaque 500 on the should-respond (RESPONSE_HANDLER) turn of
+ * every dedicated cloud agent.
+ */
+describe("toGatewayTools — tolerates flat ToolDefinition shape", () => {
+  const flatHandleResponse = {
+    name: "HANDLE_RESPONSE",
+    description: "Decide whether and how to respond",
+    type: "function",
+    strict: true,
+    parameters: {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+  };
+
+  // Cast unknown tool shapes to the gateway's tool param type without `any` —
+  // the whole point of these tests is that the runtime shape diverges from the
+  // declared type.
+  const gatewayTools = (...tools: unknown[]) => toGatewayTools(tools as never);
+
+  test("does not throw on the exact flat shape that 500'd in prod", () => {
+    expect(() => gatewayTools(flatHandleResponse)).not.toThrow();
+  });
+
+  test("keys the gateway tool map by the flat tool name", () => {
+    const result = gatewayTools(flatHandleResponse);
+    expect(Object.keys(result)).toEqual(["HANDLE_RESPONSE"]);
+  });
+
+  test("still handles the nested OpenAI shape", () => {
+    const nested = {
+      type: "function",
+      function: { name: "GET_WEATHER", parameters: { type: "object" } },
+    };
+    const result = gatewayTools(nested);
+    expect(Object.keys(result)).toEqual(["GET_WEATHER"]);
+  });
+
+  test("drops nameless tools instead of throwing", () => {
+    const nameless = { type: "function", parameters: { type: "object" } };
+    const result = gatewayTools(nameless, flatHandleResponse);
+    expect(Object.keys(result)).toEqual(["HANDLE_RESPONSE"]);
+  });
+});
+
+describe("normalizeToolFunction", () => {
+  test("reads name/parameters from the flat shape", () => {
+    const out = normalizeToolFunction({
+      name: "A",
+      type: "function",
+      parameters: { type: "object" },
+    });
+    expect(out.name).toBe("A");
+    expect(out.parameters).toMatchObject({ type: "object" });
+  });
+
+  test("reads name/parameters from the nested shape", () => {
+    const out = normalizeToolFunction({
+      type: "function",
+      function: { name: "B", parameters: { type: "object", title: "nested" } },
+    });
+    expect(out.name).toBe("B");
+    expect(out.parameters).toMatchObject({ title: "nested" });
+  });
+
+  test("returns undefined name for a nameless / non-object input", () => {
+    expect(normalizeToolFunction({}).name).toBeUndefined();
+    expect(normalizeToolFunction(undefined).name).toBeUndefined();
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
+++ b/packages/cloud-shared/src/lib/providers/vercel-ai-gateway.ts
@@ -478,16 +478,48 @@ function contentToText(content: GatewayChatMessage["content"]): string {
     .join("\n");
 }
 
-function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
+// Tolerate BOTH the nested OpenAI tool shape (`{ function: { name, parameters } }`)
+// and the flat `ToolDefinition` envelope (`{ name, type, parameters }`) that
+// elizaOS core emits (createHandleResponseTool / the action planner). Reading
+// `tool.function.name` unconditionally threw "Cannot read properties of
+// undefined (reading 'name')" and surfaced as an opaque 500 for any caller that
+// sent the flat form.
+export function normalizeToolFunction(tool: unknown): {
+  name?: string;
+  description?: unknown;
+  parameters?: unknown;
+} {
+  const record = (tool ?? {}) as Record<string, unknown>;
+  const fn = (record.function ?? record) as Record<string, unknown>;
+  return {
+    name: typeof fn.name === "string" ? fn.name : undefined,
+    description: fn.description,
+    parameters: fn.parameters,
+  };
+}
+
+export function toGatewayTools(tools: NonNullable<OpenAIChatRequest["tools"]>) {
   return Object.fromEntries(
-    tools.map((tool) => [
-      tool.function.name,
-      {
-        ...(tool.function.description ? { description: tool.function.description } : {}),
-        inputSchema: jsonSchema(tool.function.parameters ?? { type: "object" }),
-        outputSchema: jsonSchema({ type: "object", additionalProperties: true }),
-      },
-    ]),
+    tools
+      .map((tool) => {
+        const { name, description, parameters } = normalizeToolFunction(tool);
+        if (!name) {
+          return undefined;
+        }
+        return [
+          name,
+          {
+            ...(typeof description === "string" && description ? { description } : {}),
+            inputSchema: jsonSchema(
+              (parameters as Parameters<typeof jsonSchema>[0] | undefined) ?? {
+                type: "object",
+              },
+            ),
+            outputSchema: jsonSchema({ type: "object", additionalProperties: true }),
+          },
+        ] as const;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined),
   );
 }
 
@@ -497,7 +529,8 @@ function toGatewayToolChoice(
   if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "required") {
     return toolChoice;
   }
-  return { type: "tool", toolName: toolChoice.function.name };
+  const { name } = normalizeToolFunction(toolChoice);
+  return name ? { type: "tool", toolName: name } : "required";
 }
 
 function mergeGatewayProviderOptions(

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -197,6 +197,21 @@ export async function prepareManagedElizaBaseEnvironment(
   params: PrepareManagedElizaSharedEnvironmentParams,
 ): Promise<ManagedElizaBaseEnvironmentResult> {
   const existingEnv = { ...(params.existingEnv ?? {}) };
+  // DATABASE_URL / ELIZA_MANAGED_DATABASE_URL are managed reserved keys
+  // (RESERVED_MANAGED_ELIZA_ENV_KEYS); the sandbox layer
+  // (computeManagedAgentDbEnv in eliza-sandbox.ts) is the SOLE authority on the
+  // agent's DB env. Strip any inherited value here so the control-plane's OWN
+  // DATABASE_URL — which the cloud Worker / provisioning daemon carries in its
+  // process env and which spreads in through params.existingEnv — cannot leak
+  // into the agent and silently override ELIZA_AGENT_LOCAL_STATE=1. That leak
+  // forced every "local-state" agent onto the remote shared Railway Postgres
+  // (~166ms/query x dozens of serial reads+writes per turn = the dominant
+  // dedicated-chat latency, plus the shared-DB blast radius). With these
+  // removed, a local-state agent gets only PGlite (+ ELIZA_MANAGED_DATABASE_URL
+  // opt-in), while a shared-DB agent (ELIZA_AGENT_LOCAL_STATE=0) still has
+  // DATABASE_URL re-injected by computeManagedAgentDbEnv.
+  delete existingEnv.DATABASE_URL;
+  delete existingEnv.ELIZA_MANAGED_DATABASE_URL;
   const { plainKey: agentApiKey } = await apiKeysService.createForAgent({
     organizationId: params.organizationId,
     userId: params.userId,

--- a/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for normalizeNativeTools — the tool-shape coercion that feeds
+ * the cloud /chat/completions native-tool path.
+ *
+ * Bug it guards: elizaOS core emits a FLAT `ToolDefinition` envelope
+ * (`{ name, description, type: "function", parameters }`) from
+ * createHandleResponseTool() / the action planner. The previous
+ * implementation returned array-form tools verbatim, so the cloud gateway's
+ * `toGatewayTools` read `tool.function.name` on an undefined `function` and
+ * threw "Cannot read properties of undefined (reading 'name')" — a 500 that
+ * the agent surfaced as "something went wrong on my end" on every native-tool
+ * (should-respond / RESPONSE_HANDLER) turn.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeNativeTools } from "../../src/models/text";
+
+type NativeTool = {
+  type: "function";
+  function: { name: string; description?: string; parameters?: unknown };
+};
+
+describe("normalizeNativeTools", () => {
+  it("wraps a flat ToolDefinition array into the OpenAI {type, function} shape", () => {
+    const flat = [
+      {
+        name: "HANDLE_RESPONSE",
+        description: "Decide whether and how to respond",
+        type: "function",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: { text: { type: "string" } },
+          required: ["text"],
+        },
+      },
+    ];
+
+    const result = normalizeNativeTools(flat) as NativeTool[];
+    expect(result).toHaveLength(1);
+    const [tool] = result;
+    // The gateway reads tool.function.name — it must be defined now.
+    expect(tool.type).toBe("function");
+    expect(tool.function).toBeDefined();
+    expect(tool.function.name).toBe("HANDLE_RESPONSE");
+    expect(tool.function.description).toBe("Decide whether and how to respond");
+    expect(tool.function.parameters).toMatchObject({
+      type: "object",
+      properties: { text: { type: "string" } },
+    });
+  });
+
+  it("preserves tools already in the nested {type, function} shape", () => {
+    const nested = [
+      {
+        type: "function",
+        function: {
+          name: "GET_WEATHER",
+          description: "Look up weather",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    const result = normalizeNativeTools(nested) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("GET_WEATHER");
+    expect(result[0].function.description).toBe("Look up weather");
+  });
+
+  it("normalizes the record/map form (name keyed) into wire shape", () => {
+    const record = {
+      SEARCH: {
+        description: "search",
+        parameters: { type: "object" },
+      },
+    };
+
+    const result = normalizeNativeTools(record) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("SEARCH");
+  });
+
+  it("drops nameless entries instead of throwing downstream", () => {
+    const result = normalizeNativeTools([
+      { type: "function", parameters: { type: "object" } }, // no name anywhere
+      { name: "OK", type: "function", parameters: { type: "object" } },
+    ]) as NativeTool[];
+    expect(result).toHaveLength(1);
+    expect(result[0].function.name).toBe("OK");
+  });
+
+  it("accepts inputSchema/schema aliases for parameters", () => {
+    const result = normalizeNativeTools([
+      { name: "A", inputSchema: { type: "object", title: "viaInput" } },
+      { name: "B", schema: { type: "object", title: "viaSchema" } },
+    ]) as NativeTool[];
+    expect(result[0].function.parameters).toMatchObject({ title: "viaInput" });
+    expect(result[1].function.parameters).toMatchObject({ title: "viaSchema" });
+  });
+
+  it("returns undefined for empty / falsy tool inputs", () => {
+    expect(normalizeNativeTools(undefined)).toBeUndefined();
+    expect(normalizeNativeTools(null)).toBeUndefined();
+    expect(normalizeNativeTools([])).toBeUndefined();
+    expect(normalizeNativeTools({})).toBeUndefined();
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -412,30 +412,60 @@ function unwrapJsonSchema(value: unknown): unknown {
   return record.schema ?? record.jsonSchema ?? value;
 }
 
-function normalizeNativeTools(tools: unknown): unknown[] | undefined {
+// Normalize a single tool entry into the OpenAI `{ type, function }` wire
+// shape. Accepts BOTH the already-nested form (`{ type: "function", function:
+// { name, parameters } }`) and core's FLAT `ToolDefinition` envelope
+// (`{ name, type: "function", parameters }`, e.g. createHandleResponseTool /
+// the action planner). Returning the flat form verbatim made the cloud gateway
+// read `tool.function.name` on an undefined `function` → "Cannot read
+// properties of undefined (reading 'name')". Returns undefined for entries with
+// no resolvable name so they are dropped rather than crashing downstream.
+function normalizeNativeToolEntry(
+  rawTool: unknown,
+  fallbackName?: string
+): Record<string, unknown> | undefined {
+  const tool = asRecord(rawTool);
+  const nested = asRecord(tool.function);
+  const name = firstString(nested.name, tool.name, fallbackName);
+  if (!name) {
+    return undefined;
+  }
+  const description = firstString(nested.description, tool.description);
+  const inputSchema = unwrapJsonSchema(
+    nested.parameters ??
+      tool.inputSchema ??
+      tool.parameters ??
+      tool.schema ?? { type: "object" }
+  );
+  return {
+    type: "function",
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      parameters: inputSchema,
+    },
+  };
+}
+
+export function normalizeNativeTools(tools: unknown): unknown[] | undefined {
   if (!tools) {
     return undefined;
   }
 
   if (Array.isArray(tools)) {
-    return tools;
+    const normalized = tools
+      .map((tool) => normalizeNativeToolEntry(tool))
+      .filter((tool): tool is Record<string, unknown> => tool !== undefined);
+    return normalized.length > 0 ? normalized : undefined;
   }
 
   const toolSet = asRecord(tools);
   const normalized: unknown[] = [];
   for (const [name, rawTool] of Object.entries(toolSet)) {
-    const tool = asRecord(rawTool);
-    const inputSchema = unwrapJsonSchema(
-      tool.inputSchema ?? tool.parameters ?? tool.schema ?? { type: "object" }
-    );
-    normalized.push({
-      type: "function",
-      function: {
-        name,
-        ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-        parameters: inputSchema,
-      },
-    });
+    const entry = normalizeNativeToolEntry(rawTool, name);
+    if (entry) {
+      normalized.push(entry);
+    }
   }
 
   return normalized.length > 0 ? normalized : undefined;


### PR DESCRIPTION
## Why
A wip-snapshot commit (`d014e09bd8` "wip: snapshot in-progress work across runtime, cloud-api, first-run, and tutorial") + the v2.0.4 baseline reset (merged via `02503ce935`) **clobbered all four merged dedicated-chat fixes** by overwriting their files with an older snapshot. On current develop, every one grepped 0:
- **#8768** flat-ToolDefinition 500 crash (`normalizeNativeTools` back to buggy `Array.isArray → return tools`; gateway `normalizeToolFunction` gone)
- **#8769** cloud embeddings (no local gte-small)
- **#8771** DB-locality → PGlite + dim re-probe + wallet/reflection lean trims
- **#8759** chat-completions billing defer

A fresh develop agent-image / Worker would regress to the original **~35s + intermittent 500-crash**. (Prod is unaffected — it runs the pre-clobber `sha-da6b532` image + manual Worker deploy.)

## What
Clean cherry-pick of the four original squash-merges (595fc2310, ed086ecdc6, c6823e669a, a01a45426f) onto current develop. **Zero conflicts**, the #8757 concurrency cap (default 8) preserved, all changed packages typecheck clean, original tests included.

cc @lalalune — your wip-snapshot reverted these; re-applying so the next develop build doesn't regress.
