### PR TITLE
feat(plugin-elizacloud): stream cloud chat reply via SSE (pure-add, no #8768 revert)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Unit tests for the streaming plain-prompt cloud text path in
+ * `src/models/text.ts`.
+ *
+ * Asserts:
+ *   - a plain `{ prompt, stream: true }` call yields incremental SSE chunks
+ *     (a real TextStreamResult), not a buffered string;
+ *   - native-transport calls (tools / responseSchema) still use the buffered
+ *     `/chat/completions` round-trip, never the SSE stream;
+ *   - a streaming setup error (bad status) falls back to the buffered
+ *     `/responses` path without dropping the turn;
+ *   - the shared native-concurrency permit is HELD across the full stream
+ *     lifetime and RELEASED when the stream ends, so a streaming call cannot
+ *     reintroduce the 429 burst.
+ *
+ * Everything is driven by a fake `requestRaw` backed by controllable streams —
+ * NO live API.
+ */
+import type { IAgentRuntime, TextStreamResult } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Captured requests so we can assert which route/stream-flag each call used.
+type CapturedRequest = {
+  method: string;
+  path: string;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+};
+
+const captured: CapturedRequest[] = [];
+
+// Queue of responses the fake transport returns, in call order. Each entry is a
+// factory so a test can build a fresh Response (streams are single-use) per call.
+let responseQueue: Array<() => Promise<Response> | Response> = [];
+
+const requestRaw = vi.fn(
+  async (
+    method: string,
+    path: string,
+    opts?: { json?: unknown; headers?: Record<string, string> }
+  ) => {
+    captured.push({
+      method,
+      path,
+      body: (opts?.json as Record<string, unknown>) ?? {},
+      headers: opts?.headers ?? {},
+    });
+    const factory = responseQueue.shift();
+    if (!factory) {
+      throw new Error(`unexpected requestRaw call: ${method} ${path}`);
+    }
+    return factory();
+  }
+);
+
+vi.mock("../src/utils/sdk-client", () => ({
+  createCloudApiClient: () => ({ requestRaw }),
+  createElizaCloudClient: () => ({}),
+}));
+
+import {
+  __resetNativeChatLimiterForTests,
+  generateNativeChatCompletion,
+  handleTextLarge,
+  withNativeChatLimit,
+} from "../src/models/text";
+
+function fakeRuntime(): IAgentRuntime {
+  return {
+    character: { name: "Eliza", bio: [] },
+    getSetting: () => undefined,
+    emitEvent: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+/** Build an SSE chat.completion.chunk `data:` line for one content delta. */
+function deltaEvent(content: string, finishReason?: string | null): string {
+  return `data: ${JSON.stringify({
+    choices: [{ delta: { content }, finish_reason: finishReason ?? null }],
+  })}\n\n`;
+}
+
+function usageEvent(): string {
+  return `data: ${JSON.stringify({
+    choices: [{ delta: {}, finish_reason: "stop" }],
+    usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+  })}\n\n`;
+}
+
+/**
+ * A streaming Response whose body emits each SSE frame only once the previous
+ * frame has been pulled — and only after the test invokes `release(n)`. This
+ * lets us observe that the permit stays held while the stream is mid-flight.
+ */
+function controllableSseResponse(frames: string[]): {
+  response: Response;
+  emit: (n?: number) => void;
+} {
+  const encoder = new TextEncoder();
+  let idx = 0;
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const emit = (n = 1): void => {
+    for (let i = 0; i < n; i++) {
+      if (idx < frames.length) {
+        controller?.enqueue(encoder.encode(frames[idx]));
+        idx += 1;
+      } else {
+        controller?.close();
+        return;
+      }
+    }
+    if (idx >= frames.length) {
+      controller?.close();
+    }
+  };
+  const response = new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+  return { response, emit };
+}
+
+/** A plain (non-stream) JSON Response, for buffered-path assertions. */
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Responses-API shaped buffered body (the /responses fallback path). */
+function responsesBody(text: string): unknown {
+  return {
+    output: [{ type: "message", content: [{ type: "output_text", text }] }],
+    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+  };
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
+function isStreamResult(value: unknown): value is TextStreamResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "textStream" in value &&
+    "text" in value &&
+    "usage" in value &&
+    "finishReason" in value
+  );
+}
+
+describe("elizacloud streaming plain-prompt text", () => {
+  beforeEach(() => {
+    captured.length = 0;
+    responseQueue = [];
+    requestRaw.mockClear();
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    __resetNativeChatLimiterForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    __resetNativeChatLimiterForTests();
+  });
+
+  it("yields incremental chunks for a streaming plain prompt", async () => {
+    const frames = [deltaEvent("Hello"), deltaEvent(" world"), usageEvent(), "data: [DONE]\n\n"];
+    const { response, emit } = controllableSseResponse(frames);
+    responseQueue = [() => response];
+
+    const result = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    expect(isStreamResult(result)).toBe(true);
+
+    // It went out as a streaming /chat/completions request.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.path).toBe("/chat/completions");
+    expect(captured[0]?.body.stream).toBe(true);
+
+    // Consume the stream, emitting one frame per pulled chunk.
+    const chunks: string[] = [];
+    emit(1); // first delta
+    const iterator = result.textStream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    chunks.push(first.value);
+    emit(1); // second delta
+    await flush();
+    const second = await iterator.next();
+    chunks.push(second.value);
+    emit(2); // usage + [DONE] -> close
+
+    // Drain to completion.
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      chunks.push(next.value);
+    }
+
+    expect(chunks).toEqual(["Hello", " world"]);
+    expect(await result.text).toBe("Hello world");
+    expect(await result.finishReason).toBe("stop");
+    const usage = await result.usage;
+    expect(usage?.promptTokens).toBe(3);
+    expect(usage?.completionTokens).toBe(4);
+    expect(usage?.totalTokens).toBe(7);
+  });
+
+  it("uses the buffered /chat/completions path for native-transport calls even when stream is requested", async () => {
+    responseQueue = [
+      () =>
+        jsonResponse({
+          choices: [
+            {
+              message: {
+                content: "",
+                tool_calls: [{ id: "c1", function: { name: "DO_IT", arguments: "{}" } }],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+    ];
+
+    const result = await handleTextLarge(fakeRuntime(), {
+      prompt: "plan",
+      stream: true,
+      tools: { DO_IT: { description: "do it", parameters: { type: "object" } } },
+    } as never);
+
+    // Native-transport result is the buffered object, NOT a stream.
+    expect(isStreamResult(result)).toBe(false);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.path).toBe("/chat/completions");
+    // The buffered native body never sets stream:true.
+    expect(captured[0]?.body.stream).toBeUndefined();
+    expect(captured[0]?.body.tools).toBeDefined();
+  });
+
+  it("falls back to the buffered /responses path when streaming setup fails", async () => {
+    responseQueue = [
+      // Stream attempt returns an error status -> streaming throws before the result.
+      () => jsonResponse({ error: { message: "stream unavailable" } }, 503),
+      // Buffered /responses fallback returns real text.
+      () => jsonResponse(responsesBody("buffered reply")),
+    ];
+
+    const result = await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never);
+
+    expect(typeof result).toBe("string");
+    expect(result).toBe("buffered reply");
+
+    // First the failed stream attempt, then the buffered /responses fallback.
+    expect(captured.map((c) => c.path)).toEqual(["/chat/completions", "/responses"]);
+    expect(captured[0]?.body.stream).toBe(true);
+    expect(captured[1]?.body.stream).toBeUndefined();
+  });
+
+  it("holds the shared native permit for the full stream and releases it on completion", async () => {
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "1";
+    __resetNativeChatLimiterForTests();
+
+    const frames = [deltaEvent("a"), deltaEvent("b"), usageEvent(), "data: [DONE]\n\n"];
+    const { response, emit } = controllableSseResponse(frames);
+    responseQueue = [() => response];
+
+    const result = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    // While the stream is mid-flight (not drained), a second native call that
+    // shares the SAME cap must be BLOCKED on the limiter (never reaches the
+    // transport). We probe with withNativeChatLimit directly.
+    let secondEntered = false;
+    const secondCall = withNativeChatLimit(async () => {
+      secondEntered = true;
+      return "ok";
+    });
+    await flush();
+    // The streaming call still holds the only permit (cap=1), so the second is queued.
+    expect(secondEntered).toBe(false);
+
+    // Drive the stream to completion.
+    emit(frames.length);
+    const collected: string[] = [];
+    for await (const chunk of result.textStream) {
+      collected.push(chunk);
+    }
+    await result.text;
+    await flush();
+
+    // The permit was released at stream end -> the queued call now ran.
+    expect(secondEntered).toBe(true);
+    await secondCall;
+    expect(collected).toEqual(["a", "b"]);
+  });
+
+  it("releases the native permit when the stream errors (next caller proceeds)", async () => {
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "1";
+    __resetNativeChatLimiterForTests();
+
+    // A stream body that closes with no usable text -> the stream errors mid-flight.
+    const { response, emit } = controllableSseResponse(["data: [DONE]\n\n"]);
+    responseQueue = [() => response];
+
+    const result = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    let secondEntered = false;
+    const secondCall = withNativeChatLimit(async () => {
+      secondEntered = true;
+      return "ok";
+    });
+    await flush();
+    expect(secondEntered).toBe(false);
+
+    // Close the body with no content -> stream errors.
+    emit(1);
+    await expect(
+      (async () => {
+        for await (const _chunk of result.textStream) {
+          // drain
+        }
+      })()
+    ).rejects.toThrow();
+    await flush();
+
+    // Permit freed despite the error -> the queued caller ran.
+    expect(secondEntered).toBe(true);
+    await secondCall;
+  });
+
+  it("does not stream when stream is not requested (buffered /responses)", async () => {
+    responseQueue = [() => jsonResponse(responsesBody("plain buffered"))];
+
+    const result = await handleTextLarge(fakeRuntime(), { prompt: "hi" } as never);
+
+    expect(typeof result).toBe("string");
+    expect(result).toBe("plain buffered");
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.path).toBe("/responses");
+  });
+
+  it("shares one cap across a streaming call and a buffered native call", async () => {
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "1";
+    __resetNativeChatLimiterForTests();
+
+    const frames = [deltaEvent("x"), usageEvent(), "data: [DONE]\n\n"];
+    const { response, emit } = controllableSseResponse(frames);
+    responseQueue = [() => response];
+
+    const streamResult = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    // Fire a buffered native call (shares the cap). It must NOT reach the
+    // transport while the stream holds the only permit.
+    const bufferedPromise = generateNativeChatCompletion(
+      fakeRuntime(),
+      "TEXT_LARGE" as never,
+      { prompt: "hi" } as never,
+      { modelName: "cerebras/gpt-oss-120b", prompt: "hi" }
+    );
+    await flush();
+    // Only the streaming request has hit the transport so far.
+    expect(requestRaw).toHaveBeenCalledTimes(1);
+
+    // The buffered native call's response is queued for when the permit frees.
+    responseQueue.push(() =>
+      jsonResponse({
+        choices: [{ message: { content: "buffered after stream" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })
+    );
+
+    emit(frames.length);
+    for await (const _chunk of streamResult.textStream) {
+      // drain the stream -> releases the permit at end
+    }
+    await streamResult.text;
+
+    const buffered = await bufferedPromise;
+    expect(buffered.text).toBe("buffered after stream");
+    // Both calls eventually hit the transport, but never simultaneously.
+    expect(requestRaw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -3,6 +3,7 @@ import type {
   IAgentRuntime,
   ModelTypeName,
   TextStreamResult,
+  TokenUsage,
 } from "@elizaos/core";
 import {
   buildCanonicalSystemPrompt,
@@ -107,6 +108,31 @@ export async function withNativeChatLimit<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * Acquire a permit on the shared native cap and return a release handle. Used by
+ * the streaming path, where the permit must be HELD for the full SSE lifetime
+ * (the body keeps draining the cerebras key long after the response headers
+ * arrive), not just the `requestRaw` round-trip. The returned `release` is
+ * idempotent so the caller can free the permit on the first of {stream-done,
+ * stream-error, early-abort} without risk of double-release inflating the
+ * budget. Pairs with {@link withNativeChatLimit} on the SAME limiter so a
+ * streaming call and a buffered call still contend on one budget.
+ */
+async function acquireNativeChatPermit(): Promise<{ release: () => void }> {
+  const limiter = getNativeChatLimiter();
+  await limiter.acquire();
+  let released = false;
+  return {
+    release() {
+      if (released) {
+        return;
+      }
+      released = true;
+      limiter.release();
+    },
+  };
+}
+
+/**
  * Test-only: discard the cached limiter so the next call re-reads the env knob.
  * Production code never needs this — the knob is read once per process.
  */
@@ -197,6 +223,20 @@ type ChatCompletionsResponse = Record<string, unknown> & {
     };
   }>;
   usage?: Record<string, unknown>;
+};
+
+/**
+ * One streaming `chat.completion.chunk` from the cloud SSE feed. We only read
+ * the incremental `delta.content` text and the terminal `finish_reason`; the
+ * gateway also emits a trailing chunk carrying `usage` (when
+ * `stream_options.include_usage` is set), which we surface for metering.
+ */
+type ChatCompletionStreamChunk = Record<string, unknown> & {
+  choices?: Array<{
+    delta?: { content?: unknown };
+    finish_reason?: string | null;
+  }>;
+  usage?: Record<string, unknown> | null;
 };
 
 function buildUserContent(params: GenerateTextParamsWithAttachments) {
@@ -849,6 +889,292 @@ function buildGenerateParams(
   return { generateParams, modelName, modelType, prompt: promptText, systemPrompt };
 }
 
+/**
+ * Pull every `delta.content` text fragment + the terminal usage/finish_reason
+ * out of an OpenAI-style SSE `chat.completion.chunk` line. The cloud
+ * `/chat/completions?stream=true` feed is line-delimited `data: {json}` events
+ * terminated by a `data: [DONE]` sentinel. Returns nothing for keep-alive
+ * comments / blank lines / the sentinel.
+ */
+function parseStreamLine(line: string): {
+  text?: string;
+  finishReason?: string;
+  usage?: Record<string, unknown>;
+} | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("data:")) {
+    return null;
+  }
+  const payload = trimmed.slice("data:".length).trim();
+  if (!payload || payload === "[DONE]") {
+    return null;
+  }
+  let chunk: ChatCompletionStreamChunk;
+  try {
+    chunk = JSON.parse(payload) as ChatCompletionStreamChunk;
+  } catch {
+    // A partial JSON payload here means the SSE framing was split mid-line; the
+    // caller buffers across reads, so a parse failure on a complete line is a
+    // genuinely malformed event we skip rather than crash the stream.
+    return null;
+  }
+  const choice = chunk.choices?.[0];
+  const deltaContent = choice?.delta?.content;
+  const text = typeof deltaContent === "string" ? deltaContent : undefined;
+  const finishReason =
+    typeof choice?.finish_reason === "string" ? choice.finish_reason : undefined;
+  const usage = isRecord(chunk.usage) ? chunk.usage : undefined;
+  if (text === undefined && finishReason === undefined && usage === undefined) {
+    return null;
+  }
+  return {
+    ...(text !== undefined ? { text } : {}),
+    ...(finishReason !== undefined ? { finishReason } : {}),
+    ...(usage !== undefined ? { usage } : {}),
+  };
+}
+
+/**
+ * Stream a PLAIN-PROMPT cloud reply via `/chat/completions` with `stream:true`,
+ * parsing the SSE delta chunks into a {@link TextStreamResult} the runtime's
+ * streaming `useModel` path consumes. The native concurrency permit is acquired
+ * BEFORE the request and held for the FULL stream duration (the body keeps the
+ * cerebras key busy until the last chunk), then released exactly once on
+ * completion or error so a streaming call can never reintroduce the 429 burst.
+ *
+ * Throws synchronously (before returning the result) when the request can't be
+ * established or the body is missing, so the caller can fall back to the
+ * buffered path without dropping the turn. Errors that surface mid-stream are
+ * propagated through `textStream` (and the `text` promise) — the permit is still
+ * released in that case.
+ */
+async function streamNativeChatCompletion(
+  runtime: IAgentRuntime,
+  modelType: TextModelType,
+  params: GenerateTextParams,
+  context: { modelName: string; prompt: string; systemPrompt?: string }
+): Promise<TextStreamResult> {
+  const reasoning = isReasoningModel(context.modelName);
+  const messages: Array<Record<string, unknown>> = [];
+  if (context.systemPrompt) {
+    messages.push({ role: "system", content: context.systemPrompt });
+  }
+  messages.push({ role: "user", content: context.prompt });
+
+  const requestBody: Record<string, unknown> = {
+    model: context.modelName,
+    messages,
+    max_tokens: params.maxTokens ?? 8192,
+    stream: true,
+    // Ask the gateway to emit a terminal usage chunk so streaming turns are
+    // still metered exactly like the buffered path.
+    stream_options: { include_usage: true },
+  };
+  if (!reasoning && typeof params.temperature === "number") {
+    requestBody.temperature = params.temperature;
+  }
+
+  const headers: Record<string, string> = {
+    "X-Eliza-Llm-Purpose": getPurposeForModelType(modelType),
+    "X-Eliza-Model-Type": modelType,
+    Accept: "text/event-stream",
+  };
+  if (isSpanSamplerHonoringModel(context.modelName)) {
+    const samplerHeader = buildSpanSamplerHeader(params.spanSamplerPlan);
+    if (samplerHeader) {
+      headers["x-eliza-span-samplers"] = samplerHeader;
+    }
+  }
+
+  // Hold the permit across the whole stream, not just the round-trip — release
+  // on the first of {done, error}. Acquired before the request so a stream
+  // contends on the SAME budget as buffered calls.
+  const permit = await acquireNativeChatPermit();
+
+  let response: Response;
+  try {
+    response = await createCloudApiClient(runtime).requestRaw("POST", "/chat/completions", {
+      headers,
+      json: requestBody,
+    });
+  } catch (err) {
+    permit.release();
+    throw err;
+  }
+
+  if (!response.ok) {
+    permit.release();
+    const errorText = await response.text().catch(() => "");
+    let errorMessage = `elizaOS Cloud error ${response.status}`;
+    if (errorText) {
+      try {
+        const parsed = JSON.parse(errorText) as { error?: { message?: string } };
+        if (typeof parsed.error?.message === "string" && parsed.error.message.trim()) {
+          errorMessage = parsed.error.message.trim();
+        }
+      } catch {
+        // Non-JSON error body — keep the status-based message.
+      }
+    }
+    const requestError = new Error(errorMessage) as Error & { status?: number };
+    requestError.status = response.status;
+    throw requestError;
+  }
+
+  const body = response.body;
+  if (!body) {
+    permit.release();
+    throw new Error("elizaOS Cloud returned no streaming body");
+  }
+
+  const queue: string[] = [];
+  let pendingResolve: ((value: IteratorResult<string>) => void) | null = null;
+  let pendingReject: ((reason: unknown) => void) | null = null;
+  let streamError: unknown = null;
+  let streamDone = false;
+  let accumulated = "";
+  let finishReason: string | undefined;
+  let usage: TokenUsage | undefined;
+
+  const drain = (): void => {
+    if (!pendingResolve) {
+      return;
+    }
+    if (queue.length > 0) {
+      const next = queue.shift() as string;
+      const resolver = pendingResolve;
+      pendingResolve = null;
+      pendingReject = null;
+      resolver({ value: next, done: false });
+      return;
+    }
+    if (streamError && pendingReject) {
+      const rejector = pendingReject;
+      pendingResolve = null;
+      pendingReject = null;
+      rejector(streamError);
+      return;
+    }
+    if (streamDone) {
+      const resolver = pendingResolve;
+      pendingResolve = null;
+      pendingReject = null;
+      resolver({ value: undefined as unknown as string, done: true });
+    }
+  };
+
+  const ingestLine = (line: string): void => {
+    const parsed = parseStreamLine(line);
+    if (!parsed) {
+      return;
+    }
+    if (parsed.usage) {
+      usage = convertNativeUsage(parsed.usage);
+    }
+    if (parsed.finishReason) {
+      finishReason = parsed.finishReason;
+    }
+    if (parsed.text) {
+      accumulated += parsed.text;
+      queue.push(parsed.text);
+      drain();
+    }
+  };
+
+  // Drive the SSE feed off the response body. Buffer across reads so an event
+  // split over two chunks is parsed once whole. Release the permit + emit usage
+  // exactly once when the feed ends (cleanly or with an error).
+  const pump = (async () => {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          ingestLine(line);
+          newlineIndex = buffer.indexOf("\n");
+        }
+      }
+      buffer += decoder.decode();
+      if (buffer.trim()) {
+        ingestLine(buffer);
+      }
+      if (!accumulated.trim()) {
+        throw new Error("elizaOS Cloud returned no streamed text");
+      }
+      if (usage) {
+        emitModelUsageEvent(runtime, modelType, context.prompt, usage, {
+          modelName: context.modelName,
+          ...(() => {
+            const costUsd = extractCostUsd(usage, response);
+            return typeof costUsd === "number" ? { costUsd } : {};
+          })(),
+        });
+      }
+    } catch (err) {
+      streamError = err;
+      throw err;
+    } finally {
+      streamDone = true;
+      permit.release();
+      drain();
+    }
+  })();
+
+  // Single settled view of the pump: the post-stream summary promises derive
+  // from THIS (never-rejecting) promise so an unconsumed `text`/`usage`/
+  // `finishReason` can't surface as an unhandled rejection. Consumers that
+  // iterate `textStream` still see a mid-stream error there; `text` resolves to
+  // whatever partial text accumulated, matching the runtime streaming contract
+  // (the error is observed via the iterator, not the summary promise).
+  const settled = pump.then(
+    () => ({ ok: true as const }),
+    (err) => ({ ok: false as const, err })
+  );
+
+  const textStream: AsyncIterable<string> = {
+    [Symbol.asyncIterator](): AsyncIterator<string> {
+      return {
+        next(): Promise<IteratorResult<string>> {
+          if (queue.length > 0) {
+            const next = queue.shift() as string;
+            return Promise.resolve({ value: next, done: false });
+          }
+          if (streamError) {
+            return Promise.reject(streamError);
+          }
+          if (streamDone) {
+            return Promise.resolve({
+              value: undefined as unknown as string,
+              done: true,
+            });
+          }
+          return new Promise<IteratorResult<string>>((resolve, reject) => {
+            pendingResolve = resolve;
+            pendingReject = reject;
+          });
+        },
+      };
+    },
+  };
+
+  return {
+    textStream,
+    text: settled.then(() => accumulated),
+    usage: settled.then((s) => (s.ok ? usage : undefined)),
+    finishReason: settled.then((s) => (s.ok ? (finishReason ?? "stop") : undefined)),
+    providerMetadata: { modelName: context.modelName },
+  };
+}
+
 async function generateTextWithModel(
   runtime: IAgentRuntime,
   modelType: TextModelType,
@@ -858,12 +1184,6 @@ async function generateTextWithModel(
   const paramsWithNative = params as GenerateTextParamsWithNativeOptions;
 
   logger.debug(`[ELIZAOS_CLOUD] Generating text with ${modelType} model: ${modelName}`);
-
-  if (params.stream) {
-    logger.debug(
-      "[ELIZAOS_CLOUD] Streaming text disabled for responses compatibility; falling back to buffered response."
-    );
-  }
 
   logger.log(`[ELIZAOS_CLOUD] Using ${modelType} model: ${modelName}`);
   logger.log(prompt);
@@ -877,6 +1197,27 @@ async function generateTextWithModel(
     return shouldReturnNativeResult(paramsWithNative)
       ? (nativeResult as NativeGenerateTextModelResult)
       : nativeResult.text;
+  }
+
+  // Plain-prompt path: when streaming is requested, stream tokens incrementally
+  // via /chat/completions so the user sees text appear instead of a multi-second
+  // blank wait. The native-transport (tools/schema/messages/providerOptions)
+  // calls above keep the buffered round-trip. On any streaming setup error we
+  // fall back to the buffered /responses path below so the turn is never dropped.
+  if (params.stream) {
+    try {
+      return await streamNativeChatCompletion(runtime, modelType, params, {
+        modelName,
+        prompt,
+        systemPrompt,
+      });
+    } catch (err) {
+      logger.warn(
+        `[ELIZAOS_CLOUD] Streaming text failed (${
+          err instanceof Error ? err.message : String(err)
+        }); falling back to buffered response.`
+      );
+    }
   }
 
   const reasoning = isReasoningModel(modelName);


### PR DESCRIPTION
## What
Enables token-by-token SSE streaming for the cloud chat reply (the bare-`{prompt}` primary-reply path) in plugin-elizacloud, so first-token lands in ~1-2s instead of the full reply buffering for ~8-15s. Pairs with the phone transport fix #8773 (CapacitorWebFetch streams `response.body`).

## How (pure-ADD — safe)
Re-extracted ONLY the streaming pieces from the original streaming work onto current develop, as additions:
- `acquireNativeChatPermit` (holds the SHARED native-concurrency permit for the full SSE lifetime, idempotent release — composes with the existing cap), `parseStreamLine`, `streamNativeChatCompletion` (`/chat/completions` `stream:true` + `stream_options.include_usage`)
- branch in `generateTextWithModel`: bare-prompt path streams when `params.stream` is set, falls back to the existing buffered `/responses` path on any setup error

## Safety
A naive cherry-pick of the original branch silently reverted #8768's `normalizeNativeTools` (a 500-crash) in a non-conflict region — so this was done as a pure-add instead. **Verified: `normalizeNativeTools` is byte-identical to develop; `DEFAULT_NATIVE_CONCURRENCY` stays 8; no #8765/#8769 changes.** Diff is additions-only except the now-false 'streaming disabled' debug log.

## Tests
plugin-elizacloud full suite: 184 passed / 0 failed (incl. text-streaming, text-native-concurrency, normalize-native-tools = 24/0). typecheck clean.

No core change needed (the agent already passes `stream:true`+`onStreamChunk` and the reply is a bare-prompt call).