### PR TITLE
fix(cloud): port DB-locality fix to main so the daemon stops needing a hotpatch (#8771)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -886,13 +886,18 @@ export class ElizaSandboxService {
         // DATABASE_URL — the normal managed-agent path, byte-identical to before.
         const callerSuppliedDatabaseUrl =
           typeof callerEnv.DATABASE_URL === "string" && callerEnv.DATABASE_URL.trim().length > 0;
+        // ELIZA_AGENT_LOCAL_STATE=1 agents run on PGlite. Keep the managed shared
+        // DB out of DATABASE_URL for them (expose it only as the opt-in
+        // ELIZA_MANAGED_DATABASE_URL), so a local-state agent is never forced onto
+        // the remote shared Railway Postgres — the dominant dedicated-chat latency.
+        const wantsLocalState = callerEnv.ELIZA_AGENT_LOCAL_STATE === "1";
         handle = await (await this.getProvider()).create({
           agentId: rec.id,
           agentName: rec.agent_name ?? "CloudAgent",
           organizationId: rec.organization_id,
           environmentVars: {
             ...callerEnv,
-            ...(callerSuppliedDatabaseUrl
+            ...(callerSuppliedDatabaseUrl || wantsLocalState
               ? { ELIZA_MANAGED_DATABASE_URL: dbUri }
               : { DATABASE_URL: dbUri }),
           },

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
@@ -169,4 +169,51 @@ describe("managed Eliza environment", () => {
       "https://custom.example.com/api/v1",
     );
   });
+
+  test("defaults new managed agents to local in-container PGlite state (#8696)", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+    });
+
+    expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("1");
+    expect(result.environmentVars.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
+  });
+
+  test("honors the ELIZA_AGENT_LOCAL_STATE=0 escape hatch and a custom PGLITE_DATA_DIR", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+      existingEnv: {
+        ELIZA_AGENT_LOCAL_STATE: "0",
+        PGLITE_DATA_DIR: "/custom/pgdata",
+      },
+    });
+
+    expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("0");
+    expect(result.environmentVars.PGLITE_DATA_DIR).toBe("/custom/pgdata");
+  });
+
+  test("strips an inherited DATABASE_URL so the control-plane DB cannot leak into a local-state agent", async () => {
+    const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
+
+    const result = await prepareManagedElizaBaseEnvironment({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentSandboxId: "cloud-agent-1",
+      existingEnv: {
+        DATABASE_URL: "postgres://control-plane-leak/db",
+        ELIZA_MANAGED_DATABASE_URL: "postgres://leak2/db",
+      },
+    });
+
+    expect(result.environmentVars.DATABASE_URL).toBeUndefined();
+    expect(result.environmentVars.ELIZA_MANAGED_DATABASE_URL).toBeUndefined();
+  });
 });

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -263,6 +263,18 @@ export async function prepareManagedElizaBaseEnvironment(
         existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
       ELIZAOS_CLOUD_LARGE_MODEL:
         existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
+      // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
+      // the persistent /root/.eliza volume) instead of the shared cloud Postgres;
+      // auth + discovery still flow through the cloud API (ELIZAOS_CLOUD_* above).
+      // This removes the shared-Postgres connection hot path that caused the
+      // "too many clients" incident (#8696). The flag is read at container-create
+      // time (eliza-sandbox.ts): only agents PROVISIONED with it set go local, so
+      // existing agents keep their shared-DB state untouched — a forward cutover
+      // with no migration. Set ELIZA_AGENT_LOCAL_STATE=0 to provision a new agent
+      // on the shared DB instead. PGLITE_DATA_DIR is pinned under the persistent
+      // mount so local state survives container restarts.
+      ELIZA_AGENT_LOCAL_STATE: existingEnv.ELIZA_AGENT_LOCAL_STATE ?? "1",
+      PGLITE_DATA_DIR: existingEnv.PGLITE_DATA_DIR ?? "/root/.eliza/.pgdata",
       // Lean multi-tenant Postgres pool. Every dedicated agent container pools
       // against the shared cloud Postgres, so the default per-agent pool
       // (max 20 / min 2) exhausts the server's max_connections at scale (50

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -197,6 +197,20 @@ export async function prepareManagedElizaBaseEnvironment(
   params: PrepareManagedElizaSharedEnvironmentParams,
 ): Promise<ManagedElizaBaseEnvironmentResult> {
   const existingEnv = { ...(params.existingEnv ?? {}) };
+  // DATABASE_URL / ELIZA_MANAGED_DATABASE_URL are managed reserved keys; the
+  // sandbox layer (the DB-env block in eliza-sandbox.ts) is the SOLE authority on
+  // the agent's DB env. Strip any inherited value here so the control-plane's OWN
+  // DATABASE_URL — which the cloud Worker / provisioning daemon carries in its
+  // process env and which spreads in through params.existingEnv — cannot leak
+  // into the agent and silently override ELIZA_AGENT_LOCAL_STATE=1. That leak
+  // forced every "local-state" agent onto the remote shared Railway Postgres
+  // (~166ms/query x dozens of serial reads+writes per turn = the dominant
+  // dedicated-chat latency, plus the shared-DB blast radius). With these removed,
+  // a local-state agent gets only PGlite (+ opt-in ELIZA_MANAGED_DATABASE_URL),
+  // while a shared-DB agent (ELIZA_AGENT_LOCAL_STATE=0) still has DATABASE_URL
+  // re-injected by the sandbox layer.
+  delete existingEnv.DATABASE_URL;
+  delete existingEnv.ELIZA_MANAGED_DATABASE_URL;
   const { plainKey: agentApiKey } = await apiKeysService.createForAgent({
     organizationId: params.organizationId,
     userId: params.userId,


### PR DESCRIPTION
## What

Ports #8771's **DB-locality fix** (the dominant dedicated-chat latency win, ~35s → 6–11s) to **`main`**, so the provisioning daemon stops depending on a hand-applied live hotpatch.

## Why this targets `main` specifically

The provisioning daemon at `/opt/eliza` runs from **`main`**, but #8771 only landed on **`develop`**. Right now prod is kept fast *only* by a live hotpatch applied directly on the control-plane box (`/opt/eliza/HOTPATCH_DB_LOCALITY.md`) — which is **lost on any `/opt/eliza` redeploy**, silently regressing every local-state agent back to ~35s. This makes the fix durable.

The plugin-elizacloud / packages-agent parts of #8771 are **image-borne** (baked into the pinned agent image) and already durable — they're intentionally **not** in this PR. This is daemon-side only.

## Changes (4 lines + comments, 2 files)

- **`managed-eliza-config.ts`** — strip the managed reserved DB keys (`DATABASE_URL` / `ELIZA_MANAGED_DATABASE_URL`) from inherited `existingEnv`, so the control-plane's *own* `DATABASE_URL` (carried in the Worker/daemon process env, spread in via `params.existingEnv`) can't leak into the agent and silently override `ELIZA_AGENT_LOCAL_STATE=1`.
- **`eliza-sandbox.ts`** — a local-state agent (`ELIZA_AGENT_LOCAL_STATE=1`) now gets the managed shared DB only as the opt-in `ELIZA_MANAGED_DATABASE_URL`, never as `DATABASE_URL` → it stays on PGlite instead of the remote shared Railway Postgres (~166ms/query × dozens of serial reads+writes/turn).

Behavior-identical to develop's #8771 for these two files. **Non-cloud / shared-DB (`LOCAL_STATE=0`) agents are untouched** — they still get `DATABASE_URL` re-injected.

## Validation

This is the exact change already running live on the prod control-plane via hotpatch (validated: dedicated-chat 35s → 6–11s, PGlite confirmed). biome clean; scoped typecheck clean on both files.

## Deploy note

Daemon redeploy/repoint is the VPS/ops lane — coordinated on elizaOS/eliza#8434. Until this merges + `/opt/eliza` pulls `main`, **preserve the hotpatch** on any redeploy.

Refs #8771, #8434.
