### PR TITLE
fix(plugin-elizacloud): cancel SSE reader + release native permit on early consumer break (fast-follow #8782)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -125,6 +125,28 @@ function controllableSseResponse(frames: string[]): {
   return { response, emit };
 }
 
+/**
+ * A streaming Response that emits the given raw byte-chunks verbatim and in
+ * order — deliberately NOT frame-aligned — so a single SSE event can be split
+ * mid-line across two `reader.read()`s, the way real TCP segmentation splits a
+ * socket. Exercises the pump's cross-read buffering.
+ */
+function rawChunkResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const chunk of chunks) {
+        c.enqueue(encoder.encode(chunk));
+      }
+      c.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 /** A plain (non-stream) JSON Response, for buffered-path assertions. */
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -217,6 +239,35 @@ describe("elizacloud streaming plain-prompt text", () => {
     expect(usage?.promptTokens).toBe(3);
     expect(usage?.completionTokens).toBe(4);
     expect(usage?.totalTokens).toBe(7);
+  });
+
+  it("reassembles an SSE frame split mid-line across two reads (TCP segmentation)", async () => {
+    // One delta frame carrying "Hello world", sliced mid-JSON so the event
+    // straddles two reader.read()s the way real socket segmentation splits it,
+    // then the [DONE] sentinel tacked onto the tail chunk.
+    const frame = deltaEvent("Hello world");
+    const splitAt = Math.floor(frame.length / 2);
+    // Sanity: the slice point is genuinely mid-line (no newline in the head).
+    expect(frame.slice(0, splitAt)).not.toContain("\n");
+    const chunks = [frame.slice(0, splitAt), `${frame.slice(splitAt)}data: [DONE]\n\n`];
+    responseQueue = [() => rawChunkResponse(chunks)];
+
+    const result = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    expect(isStreamResult(result)).toBe(true);
+
+    const collected: string[] = [];
+    for await (const chunk of result.textStream) {
+      collected.push(chunk);
+    }
+
+    // The split frame parsed EXACTLY ONCE into the whole token — not garbled,
+    // dropped, or double-counted across the read boundary.
+    expect(collected).toEqual(["Hello world"]);
+    expect(await result.text).toBe("Hello world");
   });
 
   it("uses the buffered /chat/completions path for native-transport calls even when stream is requested", async () => {
@@ -346,6 +397,45 @@ describe("elizacloud streaming plain-prompt text", () => {
     await flush();
 
     // Permit freed despite the error -> the queued caller ran.
+    expect(secondEntered).toBe(true);
+    await secondCall;
+  });
+
+  it("releases the native permit when the consumer breaks early (abort)", async () => {
+    process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY = "1";
+    __resetNativeChatLimiterForTests();
+
+    const frames = [deltaEvent("a"), deltaEvent("b"), usageEvent(), "data: [DONE]\n\n"];
+    const { response, emit } = controllableSseResponse(frames);
+    responseQueue = [() => response];
+
+    const result = (await handleTextLarge(fakeRuntime(), {
+      prompt: "hi",
+      stream: true,
+    } as never)) as TextStreamResult;
+
+    // A second native call sharing the cap=1 limiter is queued while the stream
+    // holds the only permit.
+    let secondEntered = false;
+    const secondCall = withNativeChatLimit(async () => {
+      secondEntered = true;
+      return "ok";
+    });
+    await flush();
+    expect(secondEntered).toBe(false);
+
+    // Pull one chunk, then ABANDON the stream mid-flight — a `for await … break`
+    // / runtime abort invokes the iterator's return(). We never drain to the
+    // natural end.
+    emit(1);
+    const iterator = result.textStream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.value).toBe("a");
+    await iterator.return?.();
+    await flush();
+
+    // The early break released the permit (didn't pin it until natural end) ->
+    // the queued caller ran.
     expect(secondEntered).toBe(true);
     await secondCall;
   });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1084,8 +1084,13 @@ async function streamNativeChatCompletion(
   // Drive the SSE feed off the response body. Buffer across reads so an event
   // split over two chunks is parsed once whole. Release the permit + emit usage
   // exactly once when the feed ends (cleanly or with an error).
+  // Hoisted so the iterator's return() can cancel the in-flight read when the
+  // consumer breaks early (abort / turn-supersede / downstream error) — see the
+  // textStream return() below.
+  let readerRef: ReadableStreamDefaultReader<Uint8Array> | null = null;
   const pump = (async () => {
     const reader = body.getReader();
+    readerRef = reader;
     const decoder = new TextDecoder();
     let buffer = "";
     try {
@@ -1160,6 +1165,20 @@ async function streamNativeChatCompletion(
           return new Promise<IteratorResult<string>>((resolve, reject) => {
             pendingResolve = resolve;
             pendingReject = reject;
+          });
+        },
+        // The consumer stopped early — `for await … break` (runtime abort,
+        // turn-supersede, a downstream throw) invokes this. Cancel the SSE
+        // reader so the underlying connection tears down instead of draining the
+        // whole reply, and release the shared #8757 native permit immediately so
+        // an abort burst can't pin all N concurrency slots on abandoned streams.
+        // The pump's finally also releases, but release() is idempotent.
+        return(): Promise<IteratorResult<string>> {
+          void readerRef?.cancel().catch(() => {});
+          permit.release();
+          return Promise.resolve({
+            value: undefined as unknown as string,
+            done: true,
           });
         },
       };


### PR DESCRIPTION
## What

Fast-follow to **#8782** — the one **should-fix** from the cloud-agent adversarial review of the streaming PR. Stacked on `nubs/cloud-chat-streaming-clean`; retarget to `develop` once #8782 merges.

## The bug

`streamNativeChatCompletion`'s `textStream` iterator defined only `next()` — no `return()`. On an **early consumer break** (runtime abort / turn-supersede / a downstream throw), `for await … break` calls `iterator.return()`, but with none defined the detached pump kept calling `reader.read()` to the stream's **natural end**. So:
- the upstream cerebras generation was **never cancelled** (wasted billed tokens), and
- the shared **#8757 native permit** (1 of N) stayed **HELD** until the full reply finished.

An abort **burst** could transiently pin every concurrency slot on abandoned streams → native/streaming throughput + latency degradation. (Self-healing — the permit releases in the pump's idempotent `finally` at natural end — so it was a should-fix, not a blocker, and #8782 was safe to pin.)

## The fix (19 lines)

- Hoist the reader (`readerRef`) so the iterator can reach it, and add a **`return()`** that `reader.cancel()`s (tears down the connection) and **releases the permit immediately**. `release()` is idempotent, so the pump's `finally` release becomes a no-op. Normal completion is untouched — `return()` is only invoked on an early break.
- **Deliberately did NOT thread `params.signal` into the fetch.** That would reject the in-flight `next()` with `AbortError` and change the runtime's clean-break semantics (it expects a quiet stop, not a thrown error). `reader.cancel()` already closes the connection, so this gets the upstream teardown without that risk.

## Tests (+90 lines, full suite green 9/9)

- **Partial-frame (TCP-split) SSE reassembly** — the cross-read buffering path (`buffer.indexOf("\n") === -1` carry-over) had zero coverage; new test splits a `data:` frame mid-JSON across two reads and asserts it parses exactly once into the whole token.
- **Early-break permit release** — under cap=1, pull one chunk, `iterator.return()`, and assert a queued native call proceeds without draining the stream to natural end.

biome + scoped typecheck clean.

Refs #8782, #8434.
