### PR TITLE
perf(core,agent): cut two wasted serial model calls per chat turn (~9s first-token)

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -70,8 +70,17 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
   it("bounds and aborts LLM query recovery before the real chat turn", async () => {
     const message = makeMessage();
+    // The corpus returns a candidate that falls BELOW the relevance threshold:
+    // documents exist, so a better recovered query is worth attempting. (This is
+    // the only case the recovery call should fire.)
     const documents = {
-      searchDocuments: vi.fn().mockResolvedValue([]),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: { text: "loosely related context" },
+          similarity: 0.05,
+          metadata: {},
+        },
+      ]),
     };
     let recoverySignal: AbortSignal | undefined;
     const useModel = vi.fn((_modelType, params) => {
@@ -92,7 +101,7 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     );
 
     expect(result).toBe(message);
-    expect(documents.searchDocuments).toHaveBeenCalledTimes(2);
+    expect(documents.searchDocuments).toHaveBeenCalledTimes(1);
     expect(useModel).toHaveBeenCalledWith(
       "TEXT_LARGE",
       expect.objectContaining({
@@ -103,5 +112,29 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
       }),
     );
     expect(recoverySignal?.aborted).toBe(true);
+  });
+
+  it("skips LLM query recovery when the corpus returns no candidates at all", async () => {
+    const message = makeMessage();
+    // No raw candidates at all (no documents indexed, or embeddings never clear
+    // retrieval). A recovered query would match nothing either, so the recovery
+    // model call is pure per-turn waste — it must NOT fire.
+    const documents = {
+      searchDocuments: vi.fn().mockResolvedValue([]),
+    };
+    const useModel = vi.fn();
+    const runtime = makeRuntime(documents, useModel);
+
+    const result = await maybeAugmentChatMessageWithDocuments(
+      runtime,
+      message,
+      {
+        lookupTimeoutMs: 10,
+        recoveryTimeoutMs: 10,
+      },
+    );
+
+    expect(result).toBe(message);
+    expect(useModel).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -395,7 +395,15 @@ export async function maybeAugmentChatMessageWithDocuments(
       .sort((left, right) => (right.similarity ?? 0) - (left.similarity ?? 0))
       .slice(0, CHAT_DOCUMENTS_LIMIT);
 
-    if (relevantMatches.length === 0) {
+    // Only spend an LLM round-trip recovering search queries when the corpus
+    // actually returned candidates that merely fell below the relevance
+    // threshold — i.e. there ARE documents and a better query might surface
+    // them. When the initial search returns NOTHING at all (no documents
+    // indexed, or — on hosts forced onto zero/low-dim embeddings, e.g. cloud
+    // agents pinned to local gte-small — nothing ever clears retrieval), the
+    // recovery call is guaranteed to match nothing too: it just burns one full
+    // generate-text round-trip on every plain-chat turn. Skip it.
+    if (relevantMatches.length === 0 && initialMatches.matches.length > 0) {
       const recoveredQueries = await recoverDocumentSearchQueriesWithLlm();
       for (const query of recoveredQueries) {
         const recovered = await loadMatchesAcrossScopes(query);

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -346,4 +346,51 @@ describe("EvaluatorService", () => {
 			}),
 		);
 	});
+
+	it("skips the schema attempt on later turns once the provider rejects it", async () => {
+		const runtime = makeRuntime();
+		const processed: string[] = [];
+
+		runtime.registerEvaluator({
+			name: "ok",
+			description: "ok section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract ok.",
+			parse: (output) => output as never,
+			processors: [
+				{
+					name: "storeOk",
+					process: async () => {
+						processed.push("ok");
+						return { success: true };
+					},
+				},
+			],
+		});
+
+		const useModel = vi
+			.fn()
+			// Turn 1: schema rejected, json_object succeeds (the existing fallback).
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce({ ok: { ok: true } })
+			// Turn 2: must go straight to json_object — no doomed schema attempt.
+			.mockResolvedValueOnce({ ok: { ok: true } });
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const service = new EvaluatorService(runtime);
+		await service.run(makeMessage());
+		await service.run(makeMessage());
+
+		// Turn 1 = 2 calls (schema + json_object); turn 2 = 1 call (json_object).
+		expect(useModel).toHaveBeenCalledTimes(3);
+		expect(useModel.mock.calls[0]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[1]?.[1]).not.toHaveProperty("responseSchema");
+		// The whole point: turn 2 never re-sends the doomed schema.
+		expect(useModel.mock.calls[2]?.[1]).not.toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[2]?.[1]?.responseFormat).toEqual({
+			type: "json_object",
+		});
+		expect(processed).toEqual(["ok", "ok"]);
+	});
 });

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -175,6 +175,16 @@ function schemaRequestLooksUnsupported(error: unknown): boolean {
 	);
 }
 
+// Once a runtime's SMALL model rejects a structured `responseSchema` request,
+// every subsequent request will be rejected the same way — the provider simply
+// does not support schema-constrained output (e.g. the cerebras gpt-oss path on
+// Eliza Cloud). Re-sending the schema each turn burns a full, DOOMED model
+// round-trip before the json_object retry succeeds — measured at ~4.5s of pure
+// waste on every turn. Remember the rejection per runtime and, from then on,
+// skip straight to the json_object request. Keyed by the live runtime instance
+// (a WeakSet, so it never leaks across agents).
+const schemaUnsupportedRuntimes = new WeakSet<object>();
+
 async function generateEvaluationOutput(params: {
 	runtime: IAgentRuntime;
 	prompt: string;
@@ -186,6 +196,38 @@ async function generateEvaluationOutput(params: {
 	// structured extraction/classification pass (all active evaluators share one
 	// merged call), not generation — the large model is wasted cost here,
 	// especially for local-first tiers.
+	const requestJsonObject = (): Promise<unknown> =>
+		runtime.useModel(ModelType.TEXT_SMALL, {
+			messages,
+			responseFormat: { type: "json_object" },
+			temperature: 0,
+		});
+	const requestPlain = (): Promise<unknown> =>
+		runtime.useModel(ModelType.TEXT_SMALL, {
+			messages,
+			temperature: 0,
+		});
+	const afterJsonObjectRejected = async (
+		fallbackError: unknown,
+	): Promise<unknown> => {
+		if (!schemaRequestLooksUnsupported(fallbackError)) throw fallbackError;
+		runtime.logger.debug(
+			{ src: "service:evaluator" },
+			"Post-turn evaluator JSON-object fallback rejected; retrying plain JSON prompt",
+		);
+		return requestPlain();
+	};
+
+	// This runtime already proved its SMALL model rejects schema-constrained
+	// output — don't pay for the doomed schema round-trip again.
+	if (schemaUnsupportedRuntimes.has(runtime)) {
+		try {
+			return await requestJsonObject();
+		} catch (fallbackError) {
+			return afterJsonObjectRejected(fallbackError);
+		}
+	}
+
 	try {
 		return await runtime.useModel(ModelType.TEXT_SMALL, {
 			messages,
@@ -195,26 +237,17 @@ async function generateEvaluationOutput(params: {
 		});
 	} catch (error) {
 		if (!schemaRequestLooksUnsupported(error)) throw error;
+		// Provider does not support schema-constrained output — remember it so
+		// every subsequent turn skips the schema attempt entirely.
+		schemaUnsupportedRuntimes.add(runtime);
 		runtime.logger.debug(
 			{ src: "service:evaluator" },
 			"Post-turn evaluator schema request rejected; retrying JSON-object fallback",
 		);
 		try {
-			return await runtime.useModel(ModelType.TEXT_SMALL, {
-				messages,
-				responseFormat: { type: "json_object" },
-				temperature: 0,
-			});
+			return await requestJsonObject();
 		} catch (fallbackError) {
-			if (!schemaRequestLooksUnsupported(fallbackError)) throw fallbackError;
-			runtime.logger.debug(
-				{ src: "service:evaluator" },
-				"Post-turn evaluator JSON-object fallback rejected; retrying plain JSON prompt",
-			);
-			return await runtime.useModel(ModelType.TEXT_SMALL, {
-				messages,
-				temperature: 0,
-			});
+			return afterJsonObjectRejected(fallbackError);
 		}
 	}
 }


### PR DESCRIPTION
## What

Two model calls fire on **every** Eliza Cloud chat turn and are pure waste — together ~9s of serial latency that gates first-token on dedicated **and** shared agents. This removes both without changing behavior for providers/corpora that actually use them.

### 1. Post-turn evaluator: stop re-sending a schema the provider always rejects (`packages/core`)
`generateEvaluationOutput` asks the SMALL model for schema-constrained output (`responseSchema`). On Eliza Cloud (cerebras `gpt-oss-120b`) that request is **rejected every turn** (`schemaRequestLooksUnsupported` → true), then retried as `json_object` — which succeeds. So every turn pays for a full **doomed** schema round-trip (~4.5s) before the real one.

Fix: a learn-once memo (`WeakSet` keyed by runtime). The first time a runtime's model rejects the schema, remember it and skip straight to `json_object` on every subsequent turn. Schema-supporting providers (OpenAI, etc.) never hit the catch, so they keep the schema path unchanged.

### 2. Document-query recovery: don't recover queries against an empty corpus (`packages/agent`)
`maybeAugmentChatMessageWithDocuments` fires an LLM **query-recovery** call (`TEXT_LARGE`) whenever retrieval returns no relevant matches. On cloud that's *every plain-chat turn* — embeddings are forced onto local gte-small and never clear the threshold (#8769) — and the recovered query then matches nothing too. ~4.5s of waste per turn (`"Document query recovery model call failed"` in the logs).

Fix: gate recovery behind `initialMatches.matches.length > 0` — only spend the round-trip when the corpus actually returned candidates that merely fell below the relevance threshold (the case it was built for). When the corpus returns nothing at all, skip it.

## Why
Streaming (now on develop: `0929e26929`, `c58996b2d7`) reveals the reply token-by-token but can't cut the *serial pre-work* before the reply call. On-device measurement showed ~4 serial `gpt-oss-120b` calls/turn (TTFB ≈ 9.6s); two of them are these wasted calls. Cutting them is the #1 remaining first-token lever for the mobile cloud-chat ship. Tracking: #8434.

## Tests
- `packages/core` evaluator: new test asserts turn 2 never re-sends the schema after a turn-1 rejection (6/6 pass).
- `packages/agent` chat-augmentation: recovery still fires for a below-threshold corpus; new test asserts it's skipped when the corpus is empty (3/3 pass).
- `packages/core` typecheck clean. (Agent typecheck shows only pre-existing unbuilt-sibling-module errors in a fresh worktree — none reference the changed file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)