### PR TITLE
feat(local-inference): Mobile Resource Workbench — on-device battery/RSS/tok-s/thermal profiling (#8800)

### DIFF
--- a/.github/workflows/mobile-resource-workbench.yml
+++ b/.github/workflows/mobile-resource-workbench.yml
@@ -1,0 +1,159 @@
+name: mobile-resource-workbench
+
+# On-device resource profiling for local inference (issue #8800): battery, RSS,
+# prefill/decode tok/s, TTFT, thermal timeline — per-tier budgets + a report.
+#
+# Layered like local-inference-bench, because the device lanes are slow and
+# hardware-bound:
+#
+#   1. harness-smoke  (PR path-filtered + nightly + dispatch): runs the pure
+#      aggregation/budget unit tests and the runner's off-device skip path on a
+#      GitHub-hosted runner. Fast, no device — the only lane that can touch PRs,
+#      and only when the workbench files change.
+#   2. android-device (dispatch only): builds the WebView-debuggable APK and runs
+#      the workbench against a real arm64 device on the self-hosted pool, then
+#      uploads the report + raw results.
+#   3. ios-sim        (dispatch only): boots a simulator, runs the workbench
+#      (RSS/tok-s/TTFT; battery/thermal are physical-only), pulls MetricKit, and
+#      uploads the report.
+#
+# Device lanes are kept OFF PR-blocking lanes until per-device baselines in
+# budgets.json are stable (most budgets are still `null` = no-baseline).
+
+on:
+  schedule:
+    # 05:30 UTC — after the nightly publish window, like local-inference-bench.
+    - cron: "30 5 * * *"
+  pull_request:
+    paths:
+      - "packages/benchmarks/mobile-resource/**"
+      - ".github/workflows/mobile-resource-workbench.yml"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Eliza-1 tier to profile"
+        type: choice
+        options: [eliza-1-0_8b, eliza-1-2b, eliza-1-4b]
+        default: eliza-1-0_8b
+      run_android:
+        description: "Run the Android device lane (self-hosted arm64)."
+        type: boolean
+        default: false
+      run_ios_sim:
+        description: "Run the iOS simulator lane."
+        type: boolean
+        default: false
+      android_runner:
+        description: "runs-on label set for the Android device lane (JSON array)."
+        default: '["self-hosted","linux","arm64","android-device"]'
+
+concurrency:
+  group: mobile-resource-workbench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  harness-smoke:
+    name: harness smoke (no device)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Unit tests (aggregation + budgets)
+        run: node --test packages/benchmarks/mobile-resource/metrics.test.mjs
+      - name: Runner off-device skip path
+        run: |
+          set -e
+          # No device + unreachable agent → must record { skipped } and exit 2.
+          set +e
+          MOBILE_RESOURCE_BASE_URL=http://127.0.0.1:59999 \
+            node packages/benchmarks/mobile-resource/run-workbench.mjs --platform=android
+          code=$?
+          set -e
+          if [ "$code" != "2" ]; then
+            echo "expected exit 2 (skipped) off-device, got $code"; exit 1
+          fi
+      - name: Report generation
+        run: node packages/benchmarks/mobile-resource/report.mjs
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-resource-report-smoke
+          path: packages/benchmarks/mobile-resource/results/report/
+          if-no-files-found: ignore
+
+  android-device:
+    name: android device profile
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_android == 'true' }}
+    runs-on: ${{ fromJSON(github.event.inputs.android_runner) }}
+    timeout-minutes: 120
+    env:
+      ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
+      ELIZA_WEBVIEW_DEBUG: "1"
+      MOBILE_RESOURCE_TIER: ${{ github.event.inputs.tier }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: android-actions/setup-android@v4
+      - name: Install workspace
+        run: bun install
+      - name: Build WebView-debuggable APK
+        run: bun run --cwd packages/app build:android
+      - name: Run workbench (Android device)
+        run: |
+          node packages/benchmarks/mobile-resource/run-workbench.mjs \
+            --platform=android --tier="$MOBILE_RESOURCE_TIER" \
+            --device-class=android-phone || true
+      - name: Report
+        if: always()
+        run: node packages/benchmarks/mobile-resource/report.mjs
+      - name: Upload report + results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-resource-android-${{ github.event.inputs.tier }}
+          path: packages/benchmarks/mobile-resource/results/
+          if-no-files-found: ignore
+
+  ios-sim:
+    name: ios simulator profile
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_ios_sim == 'true' }}
+    runs-on: [self-hosted, eliza-e2e-macos]
+    timeout-minutes: 120
+    env:
+      MOBILE_RESOURCE_TIER: ${{ github.event.inputs.tier }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+      - name: Install workspace
+        run: bun install
+      - name: Boot a simulator
+        run: |
+          xcrun simctl boot "iPhone 16 Pro" || true
+          xcrun simctl list devices booted
+      - name: Run workbench (iOS simulator)
+        run: |
+          node packages/benchmarks/mobile-resource/run-workbench.mjs \
+            --platform=ios --tier="$MOBILE_RESOURCE_TIER" \
+            --device-class=ios-phone || true
+      - name: Report
+        if: always()
+        run: node packages/benchmarks/mobile-resource/report.mjs
+      - name: Upload report + results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-resource-ios-${{ github.event.inputs.tier }}
+          path: packages/benchmarks/mobile-resource/results/
+          if-no-files-found: ignore

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -85,6 +85,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(BatteryOptimizationPlugin.class);
         registerPlugin(VoiceCapturePlugin.class);
         registerPlugin(ElizaVoicePlugin.class);
+        registerPlugin(ResourceProbePlugin.class);
         super.onCreate(savedInstanceState);
 
         // Keep the screen on while the agent app is in the foreground.

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ResourceProbePlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ResourceProbePlugin.java
@@ -1,0 +1,169 @@
+package ai.elizaos.app;
+
+import android.app.ActivityManager;
+import android.content.Context;
+import android.os.BatteryManager;
+import android.os.Build;
+import android.os.Debug;
+import android.os.PowerManager;
+import android.system.Os;
+import android.system.OsConstants;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Capacitor plugin that surfaces a live device-resource snapshot to JS for the
+ * Mobile Resource Workbench (issue #8800) — the Android parity of the iOS
+ * {@code ElizaIntent.getResourceSnapshot}.
+ *
+ * <p>Reads:
+ * <ul>
+ *   <li><b>thermalState</b> — {@link PowerManager#getCurrentThermalStatus()}
+ *       (API 29+), mapped to the shared {@code nominal/fair/serious/critical}
+ *       model; {@code "unknown"} on older OSes.</li>
+ *   <li><b>battery</b> — {@link BatteryManager} level (%), charge counter (µAh),
+ *       instantaneous current (µA), and charging flag.</li>
+ *   <li><b>memory</b> — {@link Debug#getMemoryInfo} total PSS (the app's real
+ *       footprint) plus {@link ActivityManager.MemoryInfo} device available RAM.</li>
+ *   <li><b>cpuTimeMs</b> — process user+system jiffies from {@code /proc/self/stat}
+ *       converted via {@code sysconf(_SC_CLK_TCK)}.</li>
+ *   <li><b>lowPowerMode</b> — {@link PowerManager#isPowerSaveMode()}.</li>
+ * </ul>
+ *
+ * <p>Every value the OS cannot provide is returned as JSON {@code null}, never a
+ * fabricated zero (AGENTS.md §3/§7).
+ */
+@CapacitorPlugin(name = "ResourceProbe")
+public class ResourceProbePlugin extends Plugin {
+
+    @PluginMethod
+    public void getResourceSnapshot(PluginCall call) {
+        Context context = getContext();
+        JSObject result = new JSObject();
+        result.put("platform", "android");
+
+        result.put("thermalState", readThermalState(context));
+        result.put("lowPowerMode", readPowerSaveMode(context));
+
+        BatteryManager bm = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
+        result.put("batteryLevelPct", readBatteryProperty(bm, BatteryManager.BATTERY_PROPERTY_CAPACITY));
+        result.put("batteryChargeMicroAmpHours",
+            readBatteryProperty(bm, BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER));
+        result.put("batteryCurrentMicroAmps",
+            readBatteryProperty(bm, BatteryManager.BATTERY_PROPERTY_CURRENT_NOW));
+        result.put("isCharging", bm != null && bm.isCharging());
+
+        result.put("residentMemoryMb", readTotalPssMb());
+        result.put("availableRamMb", readAvailableRamMb(context));
+        result.put("cpuTimeMs", readProcessCpuTimeMs());
+
+        result.put("capturedAtMs", System.currentTimeMillis());
+        call.resolve(result);
+    }
+
+    private static String readThermalState(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return "unknown";
+        }
+        PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        if (pm == null) {
+            return "unknown";
+        }
+        switch (pm.getCurrentThermalStatus()) {
+            case PowerManager.THERMAL_STATUS_NONE:
+                return "nominal";
+            case PowerManager.THERMAL_STATUS_LIGHT:
+            case PowerManager.THERMAL_STATUS_MODERATE:
+                return "fair";
+            case PowerManager.THERMAL_STATUS_SEVERE:
+            case PowerManager.THERMAL_STATUS_CRITICAL:
+                return "serious";
+            case PowerManager.THERMAL_STATUS_EMERGENCY:
+            case PowerManager.THERMAL_STATUS_SHUTDOWN:
+                return "critical";
+            default:
+                return "unknown";
+        }
+    }
+
+    private static Object readPowerSaveMode(Context context) {
+        PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        return pm != null ? (Object) pm.isPowerSaveMode() : JSONObject.NULL;
+    }
+
+    /** A BatteryManager integer property, or JSON null when unavailable/sentinel. */
+    private static Object readBatteryProperty(BatteryManager bm, int property) {
+        if (bm == null) {
+            return JSONObject.NULL;
+        }
+        int value = bm.getIntProperty(property);
+        // BatteryManager returns Integer.MIN_VALUE for unsupported properties.
+        return value == Integer.MIN_VALUE ? JSONObject.NULL : (Object) value;
+    }
+
+    /** Total PSS of this process in MB, or JSON null when the probe fails. */
+    private static Object readTotalPssMb() {
+        try {
+            Debug.MemoryInfo info = new Debug.MemoryInfo();
+            Debug.getMemoryInfo(info);
+            // getTotalPss() is in KB.
+            return info.getTotalPss() / 1024.0;
+        } catch (RuntimeException e) {
+            return JSONObject.NULL;
+        }
+    }
+
+    private static Object readAvailableRamMb(Context context) {
+        ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) {
+            return JSONObject.NULL;
+        }
+        ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
+        am.getMemoryInfo(info);
+        return info.availMem / 1_048_576.0;
+    }
+
+    /**
+     * Process user+system CPU time in ms from {@code /proc/self/stat} fields 14
+     * (utime) and 15 (stime), in clock ticks, converted via
+     * {@code sysconf(_SC_CLK_TCK)}.
+     */
+    private static Object readProcessCpuTimeMs() {
+        try {
+            byte[] raw = Files.readAllBytes(Paths.get("/proc/self/stat"));
+            String stat = new String(raw, StandardCharsets.UTF_8);
+            // The comm field (2nd) is parenthesised and may contain spaces; split
+            // after the closing ')' so the remaining fields are space-delimited.
+            int close = stat.lastIndexOf(')');
+            if (close < 0 || close + 2 > stat.length()) {
+                return JSONObject.NULL;
+            }
+            String[] fields = stat.substring(close + 2).trim().split("\\s+");
+            // After comm, field index 0 is "state"; utime is field 14 and stime
+            // field 15 in the 1-based proc layout → indices 11 and 12 here.
+            if (fields.length < 13) {
+                return JSONObject.NULL;
+            }
+            long utime = Long.parseLong(fields[11]);
+            long stime = Long.parseLong(fields[12]);
+            long ticksPerSecond = Os.sysconf(OsConstants._SC_CLK_TCK);
+            if (ticksPerSecond <= 0) {
+                ticksPerSecond = 100; // POSIX-conventional default on Android
+            }
+            return ((utime + stime) * 1000.0) / ticksPerSecond;
+        } catch (IOException | NumberFormatException | RuntimeException e) {
+            return JSONObject.NULL;
+        }
+    }
+}

--- a/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
@@ -1,5 +1,6 @@
 import Capacitor
 import Foundation
+import MetricKit
 import UIKit
 import UserNotifications
 
@@ -39,7 +40,20 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPairingStatus", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setPairingStatus", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getDeviceCapabilities", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getResourceSnapshot", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getMetricKitPayloads", returnType: CAPPluginReturnPromise),
     ]
+
+    /// Register the MetricKit subscriber once the plugin loads so daily
+    /// `MXMetricPayload`s (CPU, energy, app-runtime) are captured to disk for the
+    /// Mobile Resource Workbench to ingest. MetricKit is iOS 13+; on older OSes
+    /// this is a no-op and `getMetricKitPayloads` returns an empty list.
+    public override func load() {
+        super.load()
+        if #available(iOS 13.0, *) {
+            MXMetricManager.shared.add(ElizaMetricKitSink.shared)
+        }
+    }
 
     private static let pairingDeviceIdKey = "com.eliza.companion.pairing.deviceId"
     private static let pairingAgentUrlKey = "com.eliza.companion.pairing.agentUrl"
@@ -282,6 +296,137 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
         ])
     }
 
+    /// Returns a *live* resource snapshot for the Mobile Resource Workbench
+    /// (issue #8800) — distinct from the one-shot `getDeviceCapabilities`. Every
+    /// numeric field is sampled fresh on each call so the harness can build a
+    /// thermal/RSS/battery timeline across a sustained run. A value the OS cannot
+    /// provide is returned as `NSNull()`, never a fabricated zero.
+    ///
+    /// Sources:
+    ///   - `residentMemoryMb` — `task_vm_info.phys_footprint` (the figure Jetsam
+    ///     uses to kill the app), not `os.totalmem`.
+    ///   - `availableRamMb` — `os_proc_available_memory()` (iOS 13+): bytes left
+    ///     before Jetsam pressure; the real inference RAM budget.
+    ///   - `thermalState` / `lowPowerMode` — `ProcessInfo`.
+    ///   - `cpuTimeMs` — summed user+system time across live threads.
+    ///   - `batteryLevelPct` — `UIDevice` (monitoring toggled on for the read).
+    @objc public func getResourceSnapshot(_ call: CAPPluginCall) {
+        let info = ProcessInfo.processInfo
+
+        let thermal: String
+        switch info.thermalState {
+        case .nominal: thermal = "nominal"
+        case .fair: thermal = "fair"
+        case .serious: thermal = "serious"
+        case .critical: thermal = "critical"
+        @unknown default: thermal = "unknown"
+        }
+
+        let residentMb: Any = ElizaIntentPlugin.physFootprintBytes()
+            .map { Double($0) / 1_048_576.0 } ?? NSNull()
+        let availableMb: Any = ElizaIntentPlugin.availableMemoryBytes()
+            .map { Double($0) / 1_048_576.0 } ?? NSNull()
+        let cpuMs: Any = ElizaIntentPlugin.cpuTimeMs() ?? NSNull()
+
+        // Battery level is -1 when monitoring is disabled; toggle it on for the
+        // read, then restore. Returns NSNull when the device can't report it
+        // (e.g. some simulators).
+        let device = UIDevice.current
+        let priorMonitoring = device.isBatteryMonitoringEnabled
+        device.isBatteryMonitoringEnabled = true
+        let rawLevel = device.batteryLevel
+        let batteryPct: Any = rawLevel >= 0 ? Double(rawLevel) * 100.0 : NSNull()
+        let charging = device.batteryState == .charging || device.batteryState == .full
+        device.isBatteryMonitoringEnabled = priorMonitoring
+
+        call.resolve([
+            "platform": "ios",
+            "thermalState": thermal,
+            "lowPowerMode": info.isLowPowerModeEnabled,
+            "residentMemoryMb": residentMb,
+            "availableRamMb": availableMb,
+            "cpuTimeMs": cpuMs,
+            "batteryLevelPct": batteryPct,
+            "isCharging": charging,
+            "capturedAtMs": Date().timeIntervalSince1970 * 1000.0,
+        ])
+    }
+
+    /// Drains the MetricKit payloads captured since the last call (CPU / energy /
+    /// app-runtime) as an array of JSON strings, then clears them. Empty on
+    /// iOS < 13 or before the first daily delivery.
+    @objc public func getMetricKitPayloads(_ call: CAPPluginCall) {
+        if #available(iOS 13.0, *) {
+            let payloads = ElizaMetricKitSink.shared.drainPayloads()
+            call.resolve(["payloads": payloads])
+        } else {
+            call.resolve(["payloads": []])
+        }
+    }
+
+    /// `task_vm_info.phys_footprint` in bytes — the resident footprint Jetsam
+    /// measures. nil when the mach call fails.
+    private static func physFootprintBytes() -> UInt64? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let kr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+        return UInt64(info.phys_footprint)
+    }
+
+    /// Bytes available before Jetsam pressure (`os_proc_available_memory`,
+    /// iOS 13+). nil on older OSes / when it returns 0.
+    private static func availableMemoryBytes() -> UInt64? {
+        if #available(iOS 13.0, *) {
+            let available = os_proc_available_memory()
+            return available > 0 ? UInt64(available) : nil
+        }
+        return nil
+    }
+
+    /// Total user+system CPU time across live (non-idle) threads, in ms.
+    private static func cpuTimeMs() -> Double? {
+        var threadList: thread_act_array_t?
+        var threadCount = mach_msg_type_number_t(0)
+        guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
+              let threads = threadList else {
+            return nil
+        }
+        defer {
+            vm_deallocate(
+                mach_task_self_,
+                vm_address_t(UInt(bitPattern: threads)),
+                vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.stride)
+            )
+        }
+        var totalMs: Double = 0
+        let basicInfoCount = mach_msg_type_number_t(
+            MemoryLayout<thread_basic_info_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        for index in 0..<Int(threadCount) {
+            var info = thread_basic_info_data_t()
+            var count = basicInfoCount
+            let kr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+                ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                    thread_info(threads[index], thread_flavor_t(THREAD_BASIC_INFO), $0, &count)
+                }
+            }
+            if kr == KERN_SUCCESS, (info.flags & TH_FLAGS_IDLE) == 0 {
+                totalMs += Double(info.user_time.seconds) * 1000.0
+                    + Double(info.user_time.microseconds) / 1000.0
+                totalMs += Double(info.system_time.seconds) * 1000.0
+                    + Double(info.system_time.microseconds) / 1000.0
+            }
+        }
+        return totalMs
+    }
+
     /// Returns the hardware machine identifier (e.g. `iPhone17,2`). On the
     /// simulator `utsname.machine` returns the host arch, so we fall back
     /// to `SIMULATOR_MODEL_IDENTIFIER` from the env.
@@ -303,5 +448,75 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         #endif
         return raw
+    }
+}
+
+/// MetricKit subscriber that captures the OS-delivered `MXMetricPayload`s
+/// (CPU, energy, app-runtime, animation) — the Apple-sanctioned on-device
+/// energy/CPU source — to disk so the Mobile Resource Workbench can ingest them.
+///
+/// MetricKit delivers payloads roughly once per day (and on the simulator via
+/// Xcode's "Simulate MetricKit Payloads"), so this is a nightly-trend source,
+/// not a per-run gate. Payloads are written as one JSON file each under
+/// Application Support/`ElizaMetricKit/`; `drainPayloads()` reads and removes
+/// them. Bounded to the most recent files so a long-lived install can't grow the
+/// directory without limit.
+@available(iOS 13.0, *)
+final class ElizaMetricKitSink: NSObject, MXMetricManagerSubscriber {
+    static let shared = ElizaMetricKitSink()
+
+    private static let maxStoredPayloads = 32
+
+    private let directory: URL? = {
+        let fm = FileManager.default
+        guard let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else { return nil }
+        let dir = base.appendingPathComponent("ElizaMetricKit", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }()
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        guard let dir = directory else { return }
+        let fm = FileManager.default
+        for payload in payloads {
+            let json = payload.jsonRepresentation()
+            guard !json.isEmpty else { continue }
+            let name = "metric-\(Int(Date().timeIntervalSince1970 * 1000))-\(UUID().uuidString).json"
+            try? json.write(to: dir.appendingPathComponent(name))
+        }
+        pruneOldest(in: dir, fileManager: fm)
+    }
+
+    /// Reads and removes every stored payload JSON, returning each as a string.
+    func drainPayloads() -> [String] {
+        guard let dir = directory else { return [] }
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+        var out: [String] = []
+        for file in files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            if let data = try? Data(contentsOf: file),
+               let text = String(data: data, encoding: .utf8) {
+                out.append(text)
+            }
+            try? fm.removeItem(at: file)
+        }
+        return out
+    }
+
+    private func pruneOldest(in dir: URL, fileManager fm: FileManager) {
+        guard let files = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        let sorted = files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        let overflow = sorted.count - ElizaMetricKitSink.maxStoredPayloads
+        guard overflow > 0 else { return }
+        for file in sorted.prefix(overflow) {
+            try? fm.removeItem(at: file)
+        }
     }
 }

--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -213,6 +213,36 @@ export async function handleDevCompatRoutes(
     return true;
   }
 
+  // ── GET /api/dev/device-resource-metrics ────────────────────────────
+  // Recent on-device generation metrics (prefill/decode tok/s, TTFT) the
+  // device bridge differenced from `generateResult`, plus the bridge status.
+  // The Mobile Resource Workbench (issue #8800) reads this to harvest
+  // throughput without driving the device WebView. Loopback only, same
+  // convention as the other dev observability routes. `?limit=N` caps the
+  // generations returned (default 50).
+  if (method === "GET" && url.pathname === "/api/dev/device-resource-metrics") {
+    if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+      sendJsonErrorResponse(res, 403, "loopback only");
+      return true;
+    }
+    if (!(await ensureRouteAuthorized(req, res, state))) {
+      return true;
+    }
+    const limitRaw = url.searchParams.get("limit");
+    const limit = limitRaw ? Number(limitRaw) : undefined;
+    const { buildDeviceResourceMetricsDevPayload } = await import(
+      "@elizaos/plugin-local-inference/services"
+    );
+    const payload = buildDeviceResourceMetricsDevPayload(
+      undefined,
+      Number.isFinite(limit) && (limit as number) > 0
+        ? (limit as number)
+        : undefined,
+    );
+    sendJsonResponse(res, 200, payload);
+    return true;
+  }
+
   // ── GET /api/dev/inference-timing ───────────────────────────────────
   // Recent per-turn text/cloud inference latency breakdowns + per-span
   // p50/p90/p99 histograms (composeState, model round-trips, cloud HTTP +

--- a/packages/benchmarks/mobile-resource/AGENTS.md
+++ b/packages/benchmarks/mobile-resource/AGENTS.md
@@ -1,0 +1,54 @@
+# Mobile Resource Workbench — Agent Guide
+
+On-device (iOS + Android) resource profiling harness: battery, RSS, prefill/decode
+tok/s, TTFT, thermal timeline. Mirrors `loadperf`'s budgets/results/CI-gate
+shape. Standalone Node ESM — run directly with `node`, not via the suite
+orchestrator. Issue #8800.
+
+## Run
+
+```bash
+node packages/benchmarks/mobile-resource/run-workbench.mjs            # auto-detect device
+node packages/benchmarks/mobile-resource/run-workbench.mjs --platform=android --tier=eliza-1-0_8b
+node packages/benchmarks/mobile-resource/report.mjs                   # consolidated report
+```
+
+Flags: `--platform=android|ios`, `--tier=eliza-1-0_8b|eliza-1-2b|eliza-1-4b`,
+`--device-class=<budgets.json key>`, `--workloads=a,b,c`, `--base-url=<agent>`,
+`--package=<android pkg>`, `--json`, `--fail-on-missing`.
+
+Exit: `0` pass, `1` budget/gate fail, `2` skipped (no device/agent).
+
+## Smoke test (no device, no keys)
+
+```bash
+node --test packages/benchmarks/mobile-resource/metrics.test.mjs   # pure aggregation + budgets
+node packages/benchmarks/mobile-resource/report.mjs                # report from whatever results exist
+```
+
+Off-device the runner records `{ skipped }` and exits `2` — it never fabricates
+numbers.
+
+## Where the numbers come from
+
+- **tok/s + TTFT** — the agent's device bridge differences `generateResult`
+  (`computeGenerationThroughput`, in `@elizaos/shared/local-inference`) and
+  buffers them; the runner reads `GET /api/dev/device-resource-metrics`.
+- **RSS / thermal / battery / low-power** — native `getResourceSnapshot`
+  (`ElizaIntent` on iOS, `ResourceProbe` on Android) + host probes
+  (`android-probe.mjs` via adb; `ios-probe.mjs` via simctl + MetricKit).
+
+## Conventions
+
+- **Never fabricate a missing measurement.** Unmeasured → `null`, surfaced as
+  `—` in reports and recorded as `not-measured` in budget checks (which pass by
+  default; use `--fail-on-missing` to fail closed).
+- **Budgets are per device-class × tier** in `budgets.json`; `null` budget =
+  no-baseline (recorded, never fails). Ratchet in from `BASELINE.md`.
+- **Results are generated, not committed** (`results/` is gitignored; only
+  `.gitignore` is tracked).
+- Pure aggregation/budget logic lives in `metrics.mjs` and is unit-tested with
+  `node --test`. Keep device-driving glue in the runner/probes.
+
+See the root [AGENTS.md](../../../AGENTS.md) for repo-wide rules and the issue
+#8800 acceptance criteria.

--- a/packages/benchmarks/mobile-resource/BASELINE.md
+++ b/packages/benchmarks/mobile-resource/BASELINE.md
@@ -1,0 +1,63 @@
+# Mobile Resource Workbench — Baselines
+
+This file records the measured on-device baselines that back `budgets.json`.
+Until a physical-device run lands, most budgets are `null` ("no baseline yet"):
+the gate records them but never fails on them. Ratchet a budget in only after a
+stable, repeated measurement on the named device class — never hand-fill a
+fabricated number (AGENTS.md §3/§7).
+
+## How a baseline becomes a budget
+
+1. Run the workbench on the target device class for the tier:
+   ```bash
+   node packages/benchmarks/mobile-resource/run-workbench.mjs \
+     --platform=android --tier=eliza-1-0_8b --device-class=android-phone
+   ```
+2. Repeat ≥3× on a quiet, thermally-cool device; take the conservative side
+   (p50 floor for throughput, p90/peak for ceilings).
+3. Write the measured number + device + commit into the table below.
+4. Set the matching key in `budgets.json` with ~10–15% headroom, then ratchet it
+   down as optimisations land (monotonic-improvement discipline, same as
+   `loadperf`).
+
+## Provisional ceilings (NOT measurements)
+
+`maxPeakRssMb` / `maxSteadyRssMb` in `budgets.json` are **provisional limits**
+derived from each tier's GGUF footprint plus runtime overhead and the device
+memory ceiling — they are caps, not measured values:
+
+| Tier            | GGUF footprint (≈) | Provisional peak-RSS cap |
+| --------------- | ------------------ | ------------------------ |
+| `eliza-1-0_8b`  | ~0.56–0.7 GB       | 1400 MB                  |
+| `eliza-1-2b`    | ~1.3–1.6 GB        | 2600 MB                  |
+| `eliza-1-4b`    | ~2.6 GB (Q4_K_M)   | 3600 MB                  |
+
+iOS jetsam kills a foreground app around ~3–4 GB `phys_footprint`; the `4b`
+ceiling sits deliberately close to flag tiers that approach it.
+
+## Measured baselines
+
+_None yet — populate as device runs land._
+
+| Device class   | Tier           | Workload        | decode tok/s (p50) | prefill tok/s (p50) | TTFT (p90) | peak RSS | battery drain | commit |
+| -------------- | -------------- | --------------- | ------------------ | ------------------- | ---------- | -------- | ------------- | ------ |
+| ios-phone      | eliza-1-0_8b   | single-turn     | —                  | —                   | —          | —        | —             | —      |
+| ios-phone      | eliza-1-0_8b   | sustained-chat  | —                  | —                   | —          | —        | —             | —      |
+| android-phone  | eliza-1-0_8b   | single-turn     | —                  | —                   | —          | —        | —             | —      |
+| android-phone  | eliza-1-0_8b   | sustained-chat  | —                  | —                   | —          | —        | —             | —      |
+
+## Notes / known gaps
+
+- **iOS host-side live sampling** needs the in-app `ElizaIntent.getResourceSnapshot`
+  bridge (WebView). The host runner pulls MetricKit (CPU/energy) post-run but
+  cannot host-side sample RSS/thermal/battery on iOS — those come from the
+  in-app bridge driven through the WebView, or are recorded as "not available".
+- **Simulators cannot report real energy or thermal.** Sim runs cover
+  RSS / tok-s / TTFT; battery + thermal are physical-device only.
+- **Voice loop** (`--workloads=voice-loop`, `MOBILE_RESOURCE_VOICE=1`) depends on
+  the on-device voice pipeline (#8785 / #8786) being reachable; otherwise it is
+  recorded as skipped.
+- **iOS streaming + per-token thermal throttle** (`ios-llama-streaming.ts`) is a
+  separate dependency; the workbench profiles the current non-streaming
+  Capacitor llama path first. The pure throttle policy is
+  `thermalThrottleDecision()` in `@elizaos/plugin-local-inference/services`.

--- a/packages/benchmarks/mobile-resource/CLAUDE.md
+++ b/packages/benchmarks/mobile-resource/CLAUDE.md
@@ -1,0 +1,54 @@
+# Mobile Resource Workbench — Agent Guide
+
+On-device (iOS + Android) resource profiling harness: battery, RSS, prefill/decode
+tok/s, TTFT, thermal timeline. Mirrors `loadperf`'s budgets/results/CI-gate
+shape. Standalone Node ESM — run directly with `node`, not via the suite
+orchestrator. Issue #8800.
+
+## Run
+
+```bash
+node packages/benchmarks/mobile-resource/run-workbench.mjs            # auto-detect device
+node packages/benchmarks/mobile-resource/run-workbench.mjs --platform=android --tier=eliza-1-0_8b
+node packages/benchmarks/mobile-resource/report.mjs                   # consolidated report
+```
+
+Flags: `--platform=android|ios`, `--tier=eliza-1-0_8b|eliza-1-2b|eliza-1-4b`,
+`--device-class=<budgets.json key>`, `--workloads=a,b,c`, `--base-url=<agent>`,
+`--package=<android pkg>`, `--json`, `--fail-on-missing`.
+
+Exit: `0` pass, `1` budget/gate fail, `2` skipped (no device/agent).
+
+## Smoke test (no device, no keys)
+
+```bash
+node --test packages/benchmarks/mobile-resource/metrics.test.mjs   # pure aggregation + budgets
+node packages/benchmarks/mobile-resource/report.mjs                # report from whatever results exist
+```
+
+Off-device the runner records `{ skipped }` and exits `2` — it never fabricates
+numbers.
+
+## Where the numbers come from
+
+- **tok/s + TTFT** — the agent's device bridge differences `generateResult`
+  (`computeGenerationThroughput`, in `@elizaos/shared/local-inference`) and
+  buffers them; the runner reads `GET /api/dev/device-resource-metrics`.
+- **RSS / thermal / battery / low-power** — native `getResourceSnapshot`
+  (`ElizaIntent` on iOS, `ResourceProbe` on Android) + host probes
+  (`android-probe.mjs` via adb; `ios-probe.mjs` via simctl + MetricKit).
+
+## Conventions
+
+- **Never fabricate a missing measurement.** Unmeasured → `null`, surfaced as
+  `—` in reports and recorded as `not-measured` in budget checks (which pass by
+  default; use `--fail-on-missing` to fail closed).
+- **Budgets are per device-class × tier** in `budgets.json`; `null` budget =
+  no-baseline (recorded, never fails). Ratchet in from `BASELINE.md`.
+- **Results are generated, not committed** (`results/` is gitignored; only
+  `.gitignore` is tracked).
+- Pure aggregation/budget logic lives in `metrics.mjs` and is unit-tested with
+  `node --test`. Keep device-driving glue in the runner/probes.
+
+See the root [AGENTS.md](../../../AGENTS.md) for repo-wide rules and the issue
+#8800 acceptance criteria.

--- a/packages/benchmarks/mobile-resource/README.md
+++ b/packages/benchmarks/mobile-resource/README.md
@@ -1,0 +1,90 @@
+# Mobile Resource Workbench
+
+End-to-end on-device resource profiling for elizaOS local inference on **iOS +
+Android**: battery drain, peak/steady RSS, prefill/decode tokens/sec, TTFT,
+thermal-state timeline, and low-power transitions — with per-tier budgets, a
+regression gate, and a report. Mirrors the `loadperf` budgets/results/CI-gate
+discipline (issue #8800).
+
+`loadperf` measures host load/boot performance; this measures the *phone*.
+
+## What it captures
+
+| Signal | Source |
+| --- | --- |
+| prefill / decode / combined tok/s | device-bridge `generateResult` differenced by `computeGenerationThroughput` (TTFT split), harvested from `/api/dev/device-resource-metrics` |
+| TTFT | on-device first-token wall-clock (capacitor adapter → device bridge) |
+| peak / steady RSS + leak flag | native `getResourceSnapshot` (iOS `phys_footprint` / Android total PSS) + host probes (`adb dumpsys meminfo`) |
+| battery drain (% + µAh) | Android `BatteryManager` / `dumpsys battery`; iOS `UIDevice` battery (physical only) |
+| thermal-state timeline + transitions | iOS `ProcessInfo.thermalState` / Android `PowerManager.getCurrentThermalStatus` sampled over the run |
+| low-power-mode transitions | iOS `isLowPowerModeEnabled` / Android `isPowerSaveMode` |
+| CPU / energy (nightly trend) | iOS MetricKit (`MXMetricPayload`); Android `dumpsys batterystats` |
+
+Anything the OS can't report is recorded as `null` — never a fabricated `0`.
+
+## Run
+
+```bash
+# Auto-detect an attached device (adb / booted simulator); default workloads.
+node packages/benchmarks/mobile-resource/run-workbench.mjs
+
+# Pin platform + tier + device class:
+node packages/benchmarks/mobile-resource/run-workbench.mjs \
+  --platform=android --tier=eliza-1-0_8b --device-class=android-phone
+
+# Pick workloads (voice loop is opt-in, needs MOBILE_RESOURCE_VOICE=1):
+node packages/benchmarks/mobile-resource/run-workbench.mjs \
+  --workloads=cold-load,single-turn,sustained-chat
+
+# Consolidated report (markdown + HTML) from the latest results:
+node packages/benchmarks/mobile-resource/report.mjs
+```
+
+Exit codes: `0` pass, `1` budget/gate failure, `2` skipped/unavailable (no
+device/agent) — usable directly as a CI gate. When no device or agent is
+reachable the runner records `{ skipped }` and exits `2` rather than failing.
+
+## Workloads
+
+| id | what it stresses |
+| --- | --- |
+| `cold-load` | cold model load → peak RSS at load |
+| `single-turn` | one short chat → TTFT + prefill/decode tok/s + single-turn RSS |
+| `sustained-chat` | N short turns → RSS-leak window + thermal creep + battery drain |
+| `voice-loop` | full voice round-trips → voice TTFT (tied to #8785 / #8786; opt-in) |
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `run-workbench.mjs` | Runner: drives workloads, samples resources, checks budgets, writes results |
+| `metrics.mjs` | Pure aggregation + budget logic (`summarizeResourceRun`, `checkBudgets`, `computeThroughput`) |
+| `metrics.test.mjs` | `node --test` unit tests for the aggregation/budget logic |
+| `workloads.mjs` | Canonical workload definitions |
+| `android-probe.mjs` | Host-side adb probes (thermal/battery/memory) |
+| `ios-probe.mjs` | simctl device detect + MetricKit payload pull |
+| `report.mjs` | Consolidated markdown/HTML report from `results/` |
+| `lib.mjs` | Shared utilities (result recording, git context, formatting, exec) |
+| `budgets.json` | Per device-class × tier budgets |
+| `BASELINE.md` | Measured baselines + how a baseline becomes a budget |
+| `results/` | Timestamped JSON + report (gitignored; only `.gitignore` committed) |
+
+## Test the harness
+
+```bash
+node --test packages/benchmarks/mobile-resource/metrics.test.mjs
+```
+
+The pure aggregation + budget logic is unit-tested here; the device-driving
+runner and probes degrade to `skipped` off-device, so they are exercised in the
+`mobile-resource-workbench` CI lane on the self-hosted arm64 runner + iOS sim.
+
+## Notes
+
+- Not registered in the suite orchestrator — run directly with `node`, same as
+  `loadperf`.
+- Budgets in `budgets.json` start mostly `null` (no baseline yet); fill them in
+  from `BASELINE.md` as on-device numbers stabilise, then ratchet down.
+- CI: `.github/workflows/mobile-resource-workbench.yml` (`workflow_dispatch` +
+  nightly), self-hosted arm64 Android lane + iOS-sim lane, uploads the report +
+  raw traces. Kept off PR-blocking lanes until baselines are stable.

--- a/packages/benchmarks/mobile-resource/android-probe.mjs
+++ b/packages/benchmarks/mobile-resource/android-probe.mjs
@@ -1,0 +1,149 @@
+/**
+ * Android host-side resource probe (adb).
+ *
+ * Reads thermal status, battery level/energy, and PSS/available-RAM over `adb`
+ * — the OS-level counterpart to the in-app `ResourceProbe.getResourceSnapshot`
+ * native bridge. Every reader returns `null` on any failure (no adb, no device,
+ * unparseable output) so the runner degrades to "not available on this
+ * platform" rather than failing or fabricating a value.
+ *
+ * Energy: `dumpsys batterystats` is the aggregated source; we expose a coarse
+ * charge-counter delta (µAh) which, paired with the level delta, is the nightly
+ * trend signal. Per-run instrumented current draw needs an external power meter
+ * (see #8800 open question) and is out of scope here.
+ */
+
+import { tryExec } from "./lib.mjs";
+
+const ADB = process.env.ADB_PATH || "adb";
+
+/** Booted device serial, or null when adb is missing or no device is attached. */
+export function detectAndroidDevice() {
+  const out = tryExec(ADB, ["devices"], { timeoutMs: 8000 });
+  if (out == null) return null;
+  const line = out
+    .split("\n")
+    .slice(1)
+    .map((l) => l.trim())
+    .find((l) => l.endsWith("\tdevice"));
+  return line ? line.split("\t")[0] : null;
+}
+
+function shell(serial, args, opts = {}) {
+  return tryExec(ADB, ["-s", serial, "shell", ...args], opts);
+}
+
+function toFiniteOrNull(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapThermalStatus(raw) {
+  // `dumpsys thermalservice` prints "Thermal Status: N" (0..6).
+  switch (raw) {
+    case 0:
+      return "nominal";
+    case 1:
+    case 2:
+      return "fair";
+    case 3:
+    case 4:
+      return "serious";
+    case 5:
+    case 6:
+      return "critical";
+    default:
+      return "unknown";
+  }
+}
+
+export function readAndroidThermalState(serial) {
+  const out = shell(serial, ["dumpsys", "thermalservice"]);
+  if (out == null) return "unknown";
+  const m = out.match(/Thermal Status:\s*(\d+)/i);
+  if (!m) return "unknown";
+  return mapThermalStatus(Number(m[1]));
+}
+
+export function readAndroidBattery(serial) {
+  const dump = shell(serial, ["dumpsys", "battery"]);
+  let levelPct = null;
+  let isCharging = null;
+  if (dump != null) {
+    const level = dump.match(/level:\s*(\d+)/i);
+    if (level) levelPct = toFiniteOrNull(level[1]);
+    const status = dump.match(/status:\s*(\d+)/i);
+    // BatteryManager.BATTERY_STATUS_CHARGING = 2, FULL = 5.
+    if (status) isCharging = status[1] === "2" || status[1] === "5";
+  }
+  const charge = shell(serial, [
+    "cat",
+    "/sys/class/power_supply/battery/charge_counter",
+  ]);
+  const current = shell(serial, [
+    "cat",
+    "/sys/class/power_supply/battery/current_now",
+  ]);
+  return {
+    batteryLevelPct: levelPct,
+    // charge_counter is in µAh on most devices.
+    batteryChargeMicroAmpHours: charge != null ? toFiniteOrNull(charge) : null,
+    batteryCurrentMicroAmps: current != null ? toFiniteOrNull(current) : null,
+    isCharging,
+  };
+}
+
+export function readAndroidMemoryMb(serial, packageName) {
+  let residentMemoryMb = null;
+  if (packageName) {
+    const meminfo = shell(serial, ["dumpsys", "meminfo", packageName]);
+    if (meminfo != null) {
+      // "TOTAL PSS:  812345  TOTAL RSS: ..." (KB) — prefer TOTAL PSS.
+      const m =
+        meminfo.match(/TOTAL\s+PSS:\s*(\d+)/i) ||
+        meminfo.match(/TOTAL:\s*(\d+)/i);
+      if (m) residentMemoryMb = Number(m[1]) / 1024;
+    }
+  }
+  let availableRamMb = null;
+  const procMem = shell(serial, ["cat", "/proc/meminfo"]);
+  if (procMem != null) {
+    const m = procMem.match(/MemAvailable:\s*(\d+)\s*kB/i);
+    if (m) availableRamMb = Number(m[1]) / 1024;
+  }
+  return { residentMemoryMb, availableRamMb };
+}
+
+export function readAndroidLowPowerMode(serial) {
+  const out = shell(serial, ["settings", "get", "global", "low_power"]);
+  if (out == null) return null;
+  const t = out.trim();
+  if (t === "1") return true;
+  if (t === "0") return false;
+  return null;
+}
+
+/**
+ * Full host-side snapshot for the runner's sampling loop.
+ * @param {string} serial
+ * @param {string|undefined} packageName
+ * @param {number} nowMs
+ */
+export function androidResourceSnapshot(serial, packageName, nowMs) {
+  const battery = readAndroidBattery(serial);
+  const mem = readAndroidMemoryMb(serial, packageName);
+  return {
+    platform: "android",
+    atMs: nowMs,
+    thermalState: readAndroidThermalState(serial),
+    lowPowerMode: readAndroidLowPowerMode(serial),
+    cpuTimeMs: null, // host-side process CPU lives in the in-app bridge
+    ...battery,
+    ...mem,
+  };
+}
+
+/** Reset batterystats so a subsequent read reflects only the workload window. */
+export function resetAndroidBatteryStats(serial) {
+  shell(serial, ["dumpsys", "batterystats", "--reset"], { timeoutMs: 20_000 });
+}

--- a/packages/benchmarks/mobile-resource/budgets.json
+++ b/packages/benchmarks/mobile-resource/budgets.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Mobile Resource Workbench budgets, keyed by device class × Eliza-1 tier. Mirrors the loadperf budgets/results/gate discipline. min* keys are throughput floors (measured value must be >= budget); max* keys are latency/memory/battery ceilings (measured <= budget). A null budget means 'no baseline measured yet' — recorded but never fails the gate; ratchet it in once a stable on-device baseline lands (see BASELINE.md). maxPeakRssMb / maxSteadyRssMb here are PROVISIONAL ceilings derived from each tier's GGUF footprint + runtime overhead and the device jetsam/foreground ceiling — they are limits, not measured values. Throughput, TTFT, and battery budgets are null until a physical-device baseline exists, because those cannot be honestly pre-filled. The rssLeak gate is always active.",
+  "leakGrowthMbThreshold": 256,
+  "deviceClasses": {
+    "ios-phone": {
+      "_note": "iPhone tier (baseline device TBD per #8800 open question). Jetsam ceiling ~3-4 GB phys_footprint.",
+      "eliza-1-0_8b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 1400,
+        "maxSteadyRssMb": 1200,
+        "maxBatteryDrainPct": null
+      },
+      "eliza-1-2b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 2600,
+        "maxSteadyRssMb": 2300,
+        "maxBatteryDrainPct": null
+      },
+      "eliza-1-4b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 3600,
+        "maxSteadyRssMb": 3300,
+        "maxBatteryDrainPct": null
+      }
+    },
+    "android-phone": {
+      "_note": "Self-hosted arm64 device runner (Pixel-class per android-device-e2e.yml). Foreground-service memory ceiling is OEM-dependent.",
+      "eliza-1-0_8b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 1400,
+        "maxSteadyRssMb": 1200,
+        "maxBatteryDrainPct": null
+      },
+      "eliza-1-2b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 2600,
+        "maxSteadyRssMb": 2300,
+        "maxBatteryDrainPct": null
+      },
+      "eliza-1-4b": {
+        "minDecodeTokensPerSecond": null,
+        "minPrefillTokensPerSecond": null,
+        "maxTtftMs": null,
+        "maxPeakRssMb": 3600,
+        "maxSteadyRssMb": 3300,
+        "maxBatteryDrainPct": null
+      }
+    }
+  }
+}

--- a/packages/benchmarks/mobile-resource/ios-probe.mjs
+++ b/packages/benchmarks/mobile-resource/ios-probe.mjs
@@ -1,0 +1,72 @@
+/**
+ * iOS host-side resource probe (xcrun simctl).
+ *
+ * iOS has no `adb`-style host probe for live RSS/thermal/battery — those come
+ * from the in-app `ElizaIntent.getResourceSnapshot` native bridge (the runner
+ * evaluates it in the WebView). What the host *can* do is pull the MetricKit
+ * payloads the app wrote to its container (`ElizaMetricKit/`), the Apple
+ * -sanctioned CPU/energy source. Simulators cannot report real energy or
+ * thermal (#8800 open question), so on a sim the runner records those as
+ * "not available on this platform" rather than fabricating them.
+ *
+ * Every reader returns null/[] on any failure so the runner degrades cleanly.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tryExec } from "./lib.mjs";
+
+const SIMCTL = ["xcrun", "simctl"];
+
+/** Booted simulator udid, or null when simctl is missing / no sim booted. */
+export function detectBootedSimulator() {
+  const out = tryExec(SIMCTL[0], [SIMCTL[1], "list", "devices", "booted"], {
+    timeoutMs: 10_000,
+  });
+  if (out == null) return null;
+  // "    iPhone 16 Pro (UDID) (Booted)"
+  const m = out.match(/\(([0-9A-Fa-f-]{36})\)\s*\(Booted\)/);
+  return m ? m[1] : null;
+}
+
+/** Whether the target is a simulator (true) — physical iOS is devicectl-driven. */
+export function isSimulatorTarget(udid) {
+  return typeof udid === "string" && udid.length === 36;
+}
+
+/**
+ * Pull MetricKit payload JSON the app stored under its container's
+ * Application Support/ElizaMetricKit directory. Returns parsed objects.
+ */
+export function pullMetricKitPayloads(udid, bundleId) {
+  const container = tryExec(
+    SIMCTL[0],
+    [SIMCTL[1], "get_app_container", udid, bundleId, "data"],
+    { timeoutMs: 10_000 },
+  );
+  if (container == null || !existsSync(container)) return [];
+  const dir = join(
+    container,
+    "Library",
+    "Application Support",
+    "ElizaMetricKit",
+  );
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      out.push(JSON.parse(readFileSync(join(dir, name), "utf8")));
+    } catch {
+      // skip an unparseable payload file
+    }
+  }
+  return out;
+}
+
+/** Total physical memory of the host machine (sim runs in-host) in MB, or null. */
+export function readHostTotalRamMb() {
+  const out = tryExec("sysctl", ["-n", "hw.memsize"], { timeoutMs: 5000 });
+  const n = out == null ? Number.NaN : Number(out);
+  return Number.isFinite(n) ? n / 1_048_576 : null;
+}

--- a/packages/benchmarks/mobile-resource/lib.mjs
+++ b/packages/benchmarks/mobile-resource/lib.mjs
@@ -1,0 +1,143 @@
+/**
+ * Shared utilities for the Mobile Resource Workbench (issue #8800).
+ *
+ * Pure Node ESM (built-ins only) so the harness runs with
+ * `node packages/benchmarks/mobile-resource/<script>.mjs` without any
+ * build/install step — same contract as the `loadperf` harness it mirrors.
+ * Device-driving helpers (adb / xcrun simctl) degrade to a clearly-marked
+ * `skipped` result when the tool or a device is absent.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const HERE = dirname(fileURLToPath(import.meta.url));
+/** eliza repo root (…/packages/benchmarks/mobile-resource -> …) */
+export const REPO_ROOT = join(HERE, "..", "..", "..");
+export const RESULTS_ROOT = join(HERE, "results");
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+export function ms(n) {
+  return n == null ? "—" : `${Math.round(n)} ms`;
+}
+export function mb(n) {
+  return n == null ? "—" : `${n.toFixed(1)} MB`;
+}
+export function tps(n) {
+  return n == null ? "—" : `${n.toFixed(1)} tok/s`;
+}
+export function pct(n) {
+  return n == null ? "—" : `${n.toFixed(1)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+export function median(values) {
+  if (!values || values.length === 0) return null;
+  const s = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+export function sleep(msv) {
+  return new Promise((r) => setTimeout(r, msv));
+}
+
+export async function fetchJson(url, { timeoutMs = 5000, ...init } = {}) {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+    ...init,
+  });
+  if (!res.ok) throw new Error(`${url} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess (device tools)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a CLI tool, returning trimmed stdout or null on any failure (missing
+ * binary, non-zero exit, no device). Never throws — callers degrade to
+ * "not available on this platform" rather than failing the run.
+ */
+export function tryExec(cmd, args, { timeoutMs = 15_000 } = {}) {
+  try {
+    return execFileSync(cmd, args, {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** True when the named CLI tool is on PATH and runs. */
+export function hasTool(cmd, versionArgs = ["--version"]) {
+  return tryExec(cmd, versionArgs, { timeoutMs: 5000 }) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Result recording + git context
+// ---------------------------------------------------------------------------
+
+export function gitInfo() {
+  const run = (args) => {
+    try {
+      return execFileSync("git", args, {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      return null;
+    }
+  };
+  return {
+    branch: run(["rev-parse", "--abbrev-ref", "HEAD"]),
+    commit: run(["rev-parse", "--short", "HEAD"]),
+    dirty: run(["status", "--porcelain"]) ? true : false,
+  };
+}
+
+/**
+ * Persist a workload result as timestamped JSON under results/<workload>/ and
+ * update results/<workload>/latest.json. `nowIso` is supplied by the caller
+ * (keeps this module clock-free).
+ */
+export function recordResult(workload, payload, nowIso) {
+  const dir = join(RESULTS_ROOT, workload);
+  mkdirSync(dir, { recursive: true });
+  const stamp = nowIso.replace(/[:.]/g, "-");
+  const record = { workload, recordedAt: nowIso, git: gitInfo(), ...payload };
+  writeFileSync(join(dir, `${stamp}.json`), JSON.stringify(record, null, 2));
+  writeFileSync(join(dir, "latest.json"), JSON.stringify(record, null, 2));
+  return { file: join(dir, "latest.json"), record };
+}
+
+export function readLatest(workload) {
+  const f = join(RESULTS_ROOT, workload, "latest.json");
+  if (!existsSync(f)) return null;
+  try {
+    return JSON.parse(readFileSync(f, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function loadBudgets() {
+  return JSON.parse(readFileSync(join(HERE, "budgets.json"), "utf8"));
+}
+
+export { existsSync, join, mkdirSync, readFileSync, writeFileSync };

--- a/packages/benchmarks/mobile-resource/metrics.mjs
+++ b/packages/benchmarks/mobile-resource/metrics.mjs
@@ -1,0 +1,329 @@
+/**
+ * Pure aggregation + budget logic for the Mobile Resource Workbench.
+ *
+ * The runner collects two streams per workload:
+ *   - `generations` — one entry per on-device generation (token counts + ttft),
+ *   - `samples`     — one entry per sampled resource snapshot over time.
+ *
+ * This module differences and aggregates them into a summary that mirrors the
+ * runtime-side `DeviceResourceMetrics.summary()` (so on-device and offline
+ * numbers line up), and checks that summary against per-tier budgets. Kept as a
+ * dependency-free ESM module so it is unit-testable with `node --test`.
+ *
+ * Every output is `null` when the inputs could not measure it — never a
+ * fabricated zero (AGENTS.md §3/§7).
+ */
+
+const MS_PER_SECOND = 1000;
+const DEFAULT_LEAK_GROWTH_MB = 256;
+const THERMAL_RANK = { nominal: 0, fair: 1, serious: 2, critical: 3 };
+
+function isPositive(v) {
+  return typeof v === "number" && Number.isFinite(v) && v > 0;
+}
+function isFiniteNum(v) {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/** Difference raw generation counters into prefill / decode / combined tok/s. */
+export function computeThroughput({
+  promptTokens,
+  outputTokens,
+  durationMs,
+  ttftMs,
+}) {
+  const ttft = isPositive(ttftMs) && ttftMs < durationMs ? ttftMs : null;
+  const combined =
+    isPositive(durationMs) && isPositive(outputTokens)
+      ? outputTokens / (durationMs / MS_PER_SECOND)
+      : null;
+  const prefill =
+    ttft !== null && isPositive(promptTokens)
+      ? promptTokens / (ttft / MS_PER_SECOND)
+      : null;
+  const decodeMs = ttft !== null ? durationMs - ttft : null;
+  const decode =
+    decodeMs !== null && isPositive(decodeMs) && isPositive(outputTokens)
+      ? outputTokens / (decodeMs / MS_PER_SECOND)
+      : null;
+  return {
+    prefillTokensPerSecond: prefill,
+    decodeTokensPerSecond: decode,
+    combinedTokensPerSecond: combined,
+    ttftMs: ttft,
+  };
+}
+
+function summarizeHistogram(values) {
+  const xs = values.filter(isFiniteNum).sort((a, b) => a - b);
+  const n = xs.length;
+  if (n === 0)
+    return {
+      count: 0,
+      p50: null,
+      p90: null,
+      p99: null,
+      min: null,
+      max: null,
+      mean: null,
+    };
+  const pct = (p) =>
+    xs[Math.min(n - 1, Math.max(0, Math.ceil((p / 100) * n) - 1))];
+  return {
+    count: n,
+    p50: pct(50),
+    p90: pct(90),
+    p99: pct(99),
+    min: xs[0],
+    max: xs[n - 1],
+    mean: xs.reduce((a, b) => a + b, 0) / n,
+  };
+}
+
+function summarizeRss(rss, threshold) {
+  const xs = rss.filter(isFiniteNum);
+  const n = xs.length;
+  if (n === 0)
+    return {
+      firstMb: null,
+      lastMb: null,
+      peakMb: null,
+      steadyMb: null,
+      samples: 0,
+      growthMb: null,
+      leakSuspected: false,
+    };
+  const firstMb = xs[0];
+  const lastMb = xs[n - 1];
+  const peakMb = Math.max(...xs);
+  const backHalf = n >= 2 ? xs.slice(Math.floor(n / 2)) : xs;
+  const sorted = [...backHalf].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const steadyMb =
+    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  const growthMb = lastMb - firstMb;
+  let monotone = n >= 4;
+  for (let i = 1; i < n; i++)
+    if (xs[i] < xs[i - 1]) {
+      monotone = false;
+      break;
+    }
+  return {
+    firstMb,
+    lastMb,
+    peakMb,
+    steadyMb,
+    samples: n,
+    growthMb,
+    leakSuspected: monotone && growthMb > threshold,
+  };
+}
+
+/**
+ * Aggregate a workload's generation + sample streams into a summary.
+ * @param {{generations?: Array, samples?: Array}} run
+ * @param {{leakGrowthMbThreshold?: number}} [opts]
+ */
+export function summarizeResourceRun(run, opts = {}) {
+  const generations = run.generations ?? [];
+  const samples = run.samples ?? [];
+  const threshold = opts.leakGrowthMbThreshold ?? DEFAULT_LEAK_GROWTH_MB;
+
+  const prefill = [];
+  const decode = [];
+  const combined = [];
+  const ttft = [];
+  for (const g of generations) {
+    const t = g.throughput ?? computeThroughput(g);
+    if (isFiniteNum(t.prefillTokensPerSecond))
+      prefill.push(t.prefillTokensPerSecond);
+    if (isFiniteNum(t.decodeTokensPerSecond))
+      decode.push(t.decodeTokensPerSecond);
+    if (isFiniteNum(t.combinedTokensPerSecond))
+      combined.push(t.combinedTokensPerSecond);
+    if (isFiniteNum(t.ttftMs)) ttft.push(t.ttftMs);
+  }
+
+  const rss = [];
+  let firstBattery = null;
+  let lastBattery = null;
+  let firstCharge = null;
+  let lastCharge = null;
+  let chargingObserved = false;
+  let thermalInitial = null;
+  let thermalLast = null;
+  let thermalMaxRank = -1;
+  let thermalMaxState = null;
+  let thermalThrottled = 0;
+  let thermalKnown = 0;
+  let thermalSamples = 0;
+  const thermalTransitions = [];
+  let lowPowerEver = false;
+  let lowPowerLast = null;
+  let lowPowerTransitions = 0;
+
+  for (const s of samples) {
+    if (isFiniteNum(s.residentMemoryMb)) rss.push(s.residentMemoryMb);
+    if (isFiniteNum(s.batteryLevelPct)) {
+      const e = { pct: s.batteryLevelPct, atMs: s.atMs };
+      if (firstBattery === null) firstBattery = e;
+      lastBattery = e;
+    }
+    if (isFiniteNum(s.batteryChargeMicroAmpHours)) {
+      if (firstCharge === null) firstCharge = s.batteryChargeMicroAmpHours;
+      lastCharge = s.batteryChargeMicroAmpHours;
+    }
+    if (s.isCharging === true) chargingObserved = true;
+    if (s.thermalState != null) {
+      thermalSamples += 1;
+      if (thermalInitial === null) thermalInitial = s.thermalState;
+      if (s.thermalState !== "unknown") {
+        thermalKnown += 1;
+        const rank = THERMAL_RANK[s.thermalState];
+        if (rank > thermalMaxRank) {
+          thermalMaxRank = rank;
+          thermalMaxState = s.thermalState;
+        }
+        if (rank >= THERMAL_RANK.serious) thermalThrottled += 1;
+      }
+      if (s.thermalState !== thermalLast)
+        thermalTransitions.push({ atMs: s.atMs, state: s.thermalState });
+      thermalLast = s.thermalState;
+    }
+    if (typeof s.lowPowerMode === "boolean") {
+      if (s.lowPowerMode) lowPowerEver = true;
+      if (lowPowerLast !== null && lowPowerLast !== s.lowPowerMode)
+        lowPowerTransitions += 1;
+      lowPowerLast = s.lowPowerMode;
+    }
+  }
+
+  return {
+    generations: generations.length,
+    resourceSamples: samples.length,
+    prefillTokensPerSecond: summarizeHistogram(prefill),
+    decodeTokensPerSecond: summarizeHistogram(decode),
+    combinedTokensPerSecond: summarizeHistogram(combined),
+    ttftMs: summarizeHistogram(ttft),
+    rss: summarizeRss(rss, threshold),
+    battery: {
+      firstPct: firstBattery?.pct ?? null,
+      lastPct: lastBattery?.pct ?? null,
+      drainPct:
+        firstBattery && lastBattery ? firstBattery.pct - lastBattery.pct : null,
+      energyMicroAmpHoursDelta:
+        firstCharge !== null && lastCharge !== null
+          ? firstCharge - lastCharge
+          : null,
+      durationMs:
+        firstBattery && lastBattery
+          ? lastBattery.atMs - firstBattery.atMs
+          : null,
+      chargingObserved,
+    },
+    thermal: {
+      samples: thermalSamples,
+      initialState: thermalInitial,
+      maxState: thermalMaxState,
+      transitions: thermalTransitions,
+      transitionCount: Math.max(0, thermalTransitions.length - 1),
+      fractionThrottled:
+        thermalKnown > 0 ? thermalThrottled / thermalKnown : null,
+    },
+    lowPowerMode: {
+      everEnabled: lowPowerEver,
+      transitionCount: lowPowerTransitions,
+    },
+  };
+}
+
+/**
+ * Check a summary against a tier budget. Each budget key declares a direction:
+ *   - `min` budgets (throughput floors): value must be >= budget,
+ *   - `max` budgets (latency / memory / battery ceilings): value must be <= budget.
+ * A `null` budget means "no baseline yet" — recorded but never fails the gate.
+ * A `null` measured value means "not measured" — recorded, and only fails when
+ * the budget requires it AND `failOnMissing` is set.
+ */
+export function checkBudgets(summary, budget, { failOnMissing = false } = {}) {
+  if (!budget) return [];
+  const checks = [];
+  const add = (name, value, target, unit, direction) => {
+    if (target == null) {
+      checks.push({
+        name,
+        value,
+        budget: null,
+        unit,
+        direction,
+        pass: true,
+        note: "no-baseline",
+      });
+      return;
+    }
+    if (value == null) {
+      checks.push({
+        name,
+        value: null,
+        budget: target,
+        unit,
+        direction,
+        pass: !failOnMissing,
+        note: "not-measured",
+      });
+      return;
+    }
+    const pass = direction === "min" ? value >= target : value <= target;
+    checks.push({ name, value, budget: target, unit, direction, pass });
+  };
+
+  add(
+    "decodeTokensPerSecondP50",
+    summary.decodeTokensPerSecond?.p50 ?? null,
+    budget.minDecodeTokensPerSecond,
+    "tok/s",
+    "min",
+  );
+  add(
+    "prefillTokensPerSecondP50",
+    summary.prefillTokensPerSecond?.p50 ?? null,
+    budget.minPrefillTokensPerSecond,
+    "tok/s",
+    "min",
+  );
+  add("ttftMsP90", summary.ttftMs?.p90 ?? null, budget.maxTtftMs, "ms", "max");
+  add(
+    "peakRssMb",
+    summary.rss?.peakMb ?? null,
+    budget.maxPeakRssMb,
+    "MB",
+    "max",
+  );
+  add(
+    "steadyRssMb",
+    summary.rss?.steadyMb ?? null,
+    budget.maxSteadyRssMb,
+    "MB",
+    "max",
+  );
+  add(
+    "batteryDrainPct",
+    summary.battery?.drainPct ?? null,
+    budget.maxBatteryDrainPct,
+    "%",
+    "max",
+  );
+
+  // RSS leak + sustained-throttle are pass/fail honesty gates, not tunables.
+  if (summary.rss?.samples >= 4) {
+    checks.push({
+      name: "rssLeak",
+      value: summary.rss.leakSuspected ? 1 : 0,
+      budget: 0,
+      unit: "bool",
+      direction: "max",
+      pass: !summary.rss.leakSuspected,
+    });
+  }
+  return checks;
+}

--- a/packages/benchmarks/mobile-resource/metrics.test.mjs
+++ b/packages/benchmarks/mobile-resource/metrics.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the workbench aggregation + budget logic.
+ * Run: node --test packages/benchmarks/mobile-resource/metrics.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  checkBudgets,
+  computeThroughput,
+  summarizeResourceRun,
+} from "./metrics.mjs";
+
+test("computeThroughput differences prefill/decode from a measured TTFT", () => {
+  const t = computeThroughput({
+    promptTokens: 64,
+    outputTokens: 128,
+    durationMs: 1000,
+    ttftMs: 200,
+  });
+  assert.ok(Math.abs(t.prefillTokensPerSecond - 320) < 1e-6);
+  assert.ok(Math.abs(t.decodeTokensPerSecond - 160) < 1e-6);
+  assert.ok(Math.abs(t.combinedTokensPerSecond - 128) < 1e-6);
+  assert.equal(t.ttftMs, 200);
+});
+
+test("computeThroughput keeps combined but nulls prefill/decode without TTFT", () => {
+  const t = computeThroughput({
+    promptTokens: 64,
+    outputTokens: 128,
+    durationMs: 1000,
+  });
+  assert.equal(t.prefillTokensPerSecond, null);
+  assert.equal(t.decodeTokensPerSecond, null);
+  assert.ok(Math.abs(t.combinedTokensPerSecond - 128) < 1e-6);
+});
+
+test("summarizeResourceRun aggregates generations + samples", () => {
+  const summary = summarizeResourceRun(
+    {
+      generations: [
+        { promptTokens: 64, outputTokens: 128, durationMs: 1000, ttftMs: 200 },
+        { promptTokens: 64, outputTokens: 120, durationMs: 1000, ttftMs: 250 },
+      ],
+      samples: [
+        {
+          atMs: 0,
+          residentMemoryMb: 900,
+          batteryLevelPct: 80,
+          thermalState: "nominal",
+          lowPowerMode: false,
+        },
+        {
+          atMs: 1000,
+          residentMemoryMb: 1000,
+          batteryLevelPct: 79,
+          thermalState: "fair",
+          lowPowerMode: false,
+        },
+        {
+          atMs: 2000,
+          residentMemoryMb: 1150,
+          batteryLevelPct: 78,
+          thermalState: "serious",
+          lowPowerMode: true,
+        },
+        {
+          atMs: 3000,
+          residentMemoryMb: 1300,
+          batteryLevelPct: 77,
+          thermalState: "serious",
+          lowPowerMode: true,
+        },
+      ],
+    },
+    { leakGrowthMbThreshold: 100 },
+  );
+  assert.equal(summary.generations, 2);
+  assert.equal(summary.decodeTokensPerSecond.count, 2);
+  assert.equal(summary.rss.peakMb, 1300);
+  assert.equal(summary.rss.leakSuspected, true);
+  assert.equal(summary.battery.drainPct, 3);
+  assert.equal(summary.thermal.maxState, "serious");
+  assert.equal(summary.thermal.samples, 4);
+  assert.ok(Math.abs(summary.thermal.fractionThrottled - 0.5) < 1e-6);
+  assert.equal(summary.lowPowerMode.everEnabled, true);
+  assert.equal(summary.lowPowerMode.transitionCount, 1);
+});
+
+test("summarizeResourceRun reports nulls for unmeasured streams", () => {
+  const summary = summarizeResourceRun({
+    generations: [{}],
+    samples: [{ atMs: 0 }],
+  });
+  assert.equal(summary.generations, 1);
+  assert.equal(summary.prefillTokensPerSecond.count, 0);
+  assert.equal(summary.prefillTokensPerSecond.p50, null);
+  assert.equal(summary.rss.peakMb, null);
+  assert.equal(summary.battery.drainPct, null);
+  assert.equal(summary.thermal.fractionThrottled, null);
+});
+
+test("checkBudgets enforces min floors and max ceilings", () => {
+  const summary = summarizeResourceRun({
+    generations: [
+      { promptTokens: 64, outputTokens: 128, durationMs: 1000, ttftMs: 200 },
+    ],
+    samples: [
+      { atMs: 0, residentMemoryMb: 900 },
+      { atMs: 1000, residentMemoryMb: 1000 },
+    ],
+  });
+  const checks = checkBudgets(summary, {
+    minDecodeTokensPerSecond: 100, // 160 measured → pass
+    maxTtftMs: 100, // 200 measured → fail
+    maxPeakRssMb: 2000, // 1000 measured → pass
+  });
+  const byName = Object.fromEntries(checks.map((c) => [c.name, c]));
+  assert.equal(byName.decodeTokensPerSecondP50.pass, true);
+  assert.equal(byName.ttftMsP90.pass, false);
+  assert.equal(byName.peakRssMb.pass, true);
+});
+
+test("checkBudgets treats null budgets as no-baseline and missing values as pass by default", () => {
+  const summary = summarizeResourceRun({ generations: [{}], samples: [] });
+  const checks = checkBudgets(summary, {
+    minDecodeTokensPerSecond: null, // no baseline
+    maxPeakRssMb: 1500, // value not measured
+  });
+  const byName = Object.fromEntries(checks.map((c) => [c.name, c]));
+  assert.equal(byName.decodeTokensPerSecondP50.note, "no-baseline");
+  assert.equal(byName.decodeTokensPerSecondP50.pass, true);
+  assert.equal(byName.peakRssMb.note, "not-measured");
+  assert.equal(byName.peakRssMb.pass, true);
+});
+
+test("checkBudgets can fail closed on missing measurements", () => {
+  const summary = summarizeResourceRun({ generations: [{}], samples: [] });
+  const checks = checkBudgets(
+    summary,
+    { maxPeakRssMb: 1500 },
+    { failOnMissing: true },
+  );
+  const peak = checks.find((c) => c.name === "peakRssMb");
+  assert.equal(peak.pass, false);
+});

--- a/packages/benchmarks/mobile-resource/report.mjs
+++ b/packages/benchmarks/mobile-resource/report.mjs
@@ -1,0 +1,140 @@
+/**
+ * Consolidated report generator for the Mobile Resource Workbench.
+ *
+ * Reads every `results/<workload>/latest.json` and writes a markdown + HTML
+ * report under `results/report/`. Run after `run-workbench.mjs` (or in CI, to
+ * publish the artifact). Pure read/format — no device needed.
+ *
+ *   node packages/benchmarks/mobile-resource/report.mjs
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import {
+  join,
+  mb,
+  mkdirSync,
+  ms,
+  RESULTS_ROOT,
+  readLatest,
+  tps,
+  writeFileSync,
+} from "./lib.mjs";
+
+const NOW = new Date().toISOString();
+
+function listWorkloadResults() {
+  if (!existsSync(RESULTS_ROOT)) return [];
+  const out = [];
+  for (const name of readdirSync(RESULTS_ROOT)) {
+    if (name === "report") continue;
+    const rec = readLatest(name);
+    if (rec) out.push({ workload: name, rec });
+  }
+  return out;
+}
+
+function fmtPct(n) {
+  return n == null ? "—" : `${n}%`;
+}
+
+function renderMarkdown(entries) {
+  const lines = [];
+  lines.push("# Mobile Resource Workbench — Report");
+  lines.push("");
+  lines.push(`Generated: ${NOW}`);
+  lines.push("");
+  if (entries.length === 0) {
+    lines.push("_No results recorded yet. Run `run-workbench.mjs` first._");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push("## Status");
+  lines.push("");
+  lines.push("| Workload | Tier | Device | Status |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const { workload, rec } of entries) {
+    if (workload === "summary") continue;
+    const status = rec.skipped ? "skipped" : rec.pass ? "PASS" : "FAIL";
+    lines.push(
+      `| ${workload} | ${rec.tier ?? "—"} | ${rec.deviceClass ?? rec.platform ?? "—"} | ${status} |`,
+    );
+  }
+  lines.push("");
+
+  for (const { workload, rec } of entries) {
+    if (workload === "summary") continue;
+    lines.push(`## ${workload}`);
+    lines.push("");
+    if (rec.skipped) {
+      lines.push(`_skipped: ${rec.reason ?? "unavailable"}_`);
+      lines.push("");
+      continue;
+    }
+    const s = rec.summary ?? {};
+    lines.push(
+      `- generations: ${s.generations ?? 0}  samples: ${s.resourceSamples ?? 0}`,
+    );
+    lines.push(
+      `- decode tok/s (p50/p90): ${tps(s.decodeTokensPerSecond?.p50)} / ${tps(s.decodeTokensPerSecond?.p90)}`,
+    );
+    lines.push(
+      `- prefill tok/s (p50): ${tps(s.prefillTokensPerSecond?.p50)}  TTFT (p90): ${ms(s.ttftMs?.p90)}`,
+    );
+    lines.push(
+      `- RSS peak/steady: ${mb(s.rss?.peakMb)} / ${mb(s.rss?.steadyMb)}  leak: ${s.rss?.leakSuspected ?? "—"}`,
+    );
+    lines.push(
+      `- battery drain: ${fmtPct(s.battery?.drainPct)}  energy Δ: ${s.battery?.energyMicroAmpHoursDelta == null ? "—" : `${s.battery.energyMicroAmpHoursDelta} µAh`}`,
+    );
+    lines.push(
+      `- thermal: initial ${s.thermal?.initialState ?? "—"} → max ${s.thermal?.maxState ?? "—"} (${s.thermal?.transitionCount ?? 0} transitions, throttled ${s.thermal?.fractionThrottled == null ? "—" : `${Math.round(s.thermal.fractionThrottled * 100)}%`})`,
+    );
+    lines.push(
+      `- low-power transitions: ${s.lowPowerMode?.transitionCount ?? 0}`,
+    );
+    lines.push("");
+    if (Array.isArray(rec.checks) && rec.checks.length) {
+      lines.push("Budget checks:");
+      lines.push("");
+      for (const c of rec.checks) {
+        const v = c.value == null ? "—" : `${c.value}`;
+        const b = c.budget == null ? "no-baseline" : `${c.budget}`;
+        lines.push(
+          `- ${c.pass ? "PASS" : "FAIL"} ${c.name}: ${v} / ${b} ${c.unit}`,
+        );
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push(
+    "Budgets live in `budgets.json` (per device class × tier). `null` budgets are unmeasured baselines — ratchet them in as on-device numbers stabilise (see `BASELINE.md`).",
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderHtml(markdownText) {
+  // Minimal self-contained HTML wrapper (no external deps).
+  const escaped = markdownText
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return `<!doctype html><meta charset="utf-8"><title>Mobile Resource Workbench</title><body style="font:14px/1.5 ui-monospace,monospace;max-width:980px;margin:2rem auto;padding:0 1rem"><pre>${escaped}</pre></body>`;
+}
+
+function main() {
+  const entries = listWorkloadResults();
+  const md = renderMarkdown(entries);
+  const dir = join(RESULTS_ROOT, "report");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "latest.md"), md);
+  writeFileSync(join(dir, "latest.html"), renderHtml(md));
+  console.log(md);
+  console.log(`\nreport -> ${join(dir, "latest.md")}`);
+}
+
+main();

--- a/packages/benchmarks/mobile-resource/results/.gitignore
+++ b/packages/benchmarks/mobile-resource/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/benchmarks/mobile-resource/run-workbench.mjs
+++ b/packages/benchmarks/mobile-resource/run-workbench.mjs
@@ -1,0 +1,337 @@
+/**
+ * Mobile Resource Workbench runner.
+ *
+ * Drives the canonical workloads against a real device/simulator, samples
+ * device resources over time, harvests per-generation throughput from the
+ * agent's `/api/dev/device-resource-metrics` endpoint, aggregates everything,
+ * checks per-tier budgets, and writes timestamped results + a report — the same
+ * budgets/results/gate contract as `loadperf`.
+ *
+ *   node packages/benchmarks/mobile-resource/run-workbench.mjs \
+ *     --platform=android --tier=eliza-1-0_8b --device-class=android-phone
+ *
+ * Flags / env:
+ *   --platform=android|ios        (env MOBILE_RESOURCE_PLATFORM) — auto-detected when omitted
+ *   --tier=eliza-1-0_8b|2b|4b     (env MOBILE_RESOURCE_TIER, default eliza-1-0_8b)
+ *   --device-class=<key>          budgets.json key (default derived from platform)
+ *   --workloads=a,b,c             default: cold-load,single-turn,sustained-chat
+ *   --base-url=http://127.0.0.1:31337   agent API (env MOBILE_RESOURCE_BASE_URL / ELIZA_API_PORT)
+ *   --package=app.eliza           Android package for meminfo (env MOBILE_RESOURCE_ANDROID_PACKAGE)
+ *   --json                        machine-readable output
+ *   --fail-on-missing             fail budget checks whose value could not be measured
+ *
+ * Exit: 0 pass, 1 budget/gate failure, 2 skipped/unavailable — directly usable
+ * as a CI gate. A device/agent that isn't reachable records `{ skipped }` and
+ * exits 2 rather than fabricating numbers.
+ */
+
+import {
+  androidResourceSnapshot,
+  detectAndroidDevice,
+  resetAndroidBatteryStats,
+} from "./android-probe.mjs";
+import { detectBootedSimulator } from "./ios-probe.mjs";
+import {
+  fetchJson,
+  loadBudgets,
+  mb,
+  ms,
+  recordResult,
+  sleep,
+  tps,
+} from "./lib.mjs";
+import { checkBudgets, summarizeResourceRun } from "./metrics.mjs";
+import { DEFAULT_WORKLOAD_IDS, workloadById } from "./workloads.mjs";
+
+const NOW = new Date().toISOString();
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const get = (name, fallback) => {
+    const hit = argv.find((a) => a.startsWith(`--${name}=`));
+    return hit ? hit.split("=").slice(1).join("=") : fallback;
+  };
+  const apiPort = Number(process.env.ELIZA_API_PORT ?? 31337);
+  return {
+    platform: get("platform", process.env.MOBILE_RESOURCE_PLATFORM) ?? null,
+    tier: get("tier", process.env.MOBILE_RESOURCE_TIER ?? "eliza-1-0_8b"),
+    deviceClass: get("device-class", null),
+    workloads: get("workloads", DEFAULT_WORKLOAD_IDS.join(","))
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    baseUrl: (
+      get("base-url", process.env.MOBILE_RESOURCE_BASE_URL) ??
+      `http://127.0.0.1:${apiPort}`
+    ).replace(/\/$/, ""),
+    androidPackage:
+      get("package", process.env.MOBILE_RESOURCE_ANDROID_PACKAGE) ??
+      "app.eliza",
+    json: argv.includes("--json"),
+    failOnMissing: argv.includes("--fail-on-missing"),
+  };
+}
+
+/** Resolve the target device. Returns null platform when nothing is attached. */
+function resolveTarget(args) {
+  if (args.platform === "android" || args.platform == null) {
+    const serial = detectAndroidDevice();
+    if (serial)
+      return { platform: "android", device: serial, isSimulator: false };
+    if (args.platform === "android")
+      return { platform: "android", device: null, isSimulator: false };
+  }
+  if (args.platform === "ios" || args.platform == null) {
+    const udid = detectBootedSimulator();
+    if (udid) return { platform: "ios", device: udid, isSimulator: true };
+    if (args.platform === "ios")
+      return { platform: "ios", device: null, isSimulator: true };
+  }
+  return { platform: null, device: null, isSimulator: false };
+}
+
+function deviceClassFor(args, target) {
+  if (args.deviceClass) return args.deviceClass;
+  return target.platform === "ios" ? "ios-phone" : "android-phone";
+}
+
+/** Sample a resource snapshot for the platform; null when unavailable. */
+function sampleResource(target, args, atMs) {
+  if (target.platform === "android" && target.device) {
+    return androidResourceSnapshot(target.device, args.androidPackage, atMs);
+  }
+  // iOS host-side live sampling needs the in-app bridge (WebView). Without it
+  // we can't honestly sample RSS/thermal/battery on iOS host-side, so return a
+  // marker sample rather than fabricating values. MetricKit is pulled at the end.
+  return null;
+}
+
+/** Read the device-bridge generation metrics from the agent dev endpoint. */
+async function fetchGenerationMetrics(baseUrl) {
+  try {
+    const payload = await fetchJson(
+      `${baseUrl}/api/dev/device-resource-metrics?limit=200`,
+      { timeoutMs: 5000 },
+    );
+    return Array.isArray(payload?.recentGenerations)
+      ? payload.recentGenerations
+      : [];
+  } catch {
+    return null; // endpoint unreachable (agent down or older build)
+  }
+}
+
+async function reachable(baseUrl) {
+  try {
+    await fetchJson(`${baseUrl}/api/health`, { timeoutMs: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run one workload: take a baseline generation-metrics snapshot, sample
+ * resources on the workload cadence for its duration window (driving chat turns
+ * if the harness was given a chat driver), then diff the generation metrics.
+ *
+ * Chat/voice driving against the live agent is intentionally pluggable: this
+ * runner samples resources + harvests whatever generations the agent recorded
+ * during the window. A device-paired agent that runs real turns populates the
+ * dev endpoint; a quiet agent yields zero generations (recorded as such, not
+ * fabricated).
+ */
+async function runWorkload(workload, ctx) {
+  const { target, args } = ctx;
+  const startMs = Date.now();
+  const samples = [];
+
+  const before = (await fetchGenerationMetrics(args.baseUrl)) ?? [];
+  const beforeCount = before.length;
+
+  if (target.platform === "android" && target.device) {
+    resetAndroidBatteryStats(target.device);
+  }
+
+  // Sample for the workload window. The window is bounded by maxDurationMs; for
+  // chat/voice workloads an external driver (or a paired device) generates load
+  // concurrently. Sampling is wall-clock paced and capped so a hung device
+  // can't run forever.
+  const windowMs = Math.min(workload.maxDurationMs, ctx.maxWindowMs);
+  const deadline = startMs + windowMs;
+  let next = startMs;
+  while (Date.now() < deadline) {
+    const atMs = Date.now() - startMs;
+    const sample = sampleResource(target, args, atMs);
+    if (sample) samples.push(sample);
+    next += workload.sampleIntervalMs;
+    const wait = next - Date.now();
+    await sleep(Math.max(50, wait));
+    // Cold-load: stop sampling once the model reports loaded (best-effort).
+    if (workload.kind === "load-only" && samples.length >= 4) {
+      const loaded = await modelLoaded(args.baseUrl);
+      if (loaded) break;
+    }
+  }
+
+  const after = (await fetchGenerationMetrics(args.baseUrl)) ?? [];
+  const newGenerations = after.slice(beforeCount).map((g) => ({
+    promptTokens: g.promptTokens,
+    outputTokens: g.outputTokens,
+    durationMs: g.durationMs,
+    ttftMs: g.ttftMs,
+    throughput: g.throughput,
+  }));
+
+  return { samples, generations: newGenerations };
+}
+
+async function modelLoaded(baseUrl) {
+  try {
+    const payload = await fetchJson(
+      `${baseUrl}/api/dev/device-resource-metrics`,
+      { timeoutMs: 3000 },
+    );
+    return payload?.status?.loadedPath != null;
+  } catch {
+    return false;
+  }
+}
+
+function recordSkipped(reason, args) {
+  const payload = { skipped: true, reason, tier: args.tier };
+  recordResult("summary", payload, NOW);
+  if (args.json) console.log(JSON.stringify({ ...payload }, null, 2));
+  else console.error(`[mobile-resource] skipped: ${reason}`);
+  process.exit(2);
+}
+
+async function main() {
+  const args = parseArgs();
+  const target = resolveTarget(args);
+
+  const agentUp = await reachable(args.baseUrl);
+
+  if (!target.platform && !agentUp) {
+    recordSkipped(
+      "no device/simulator attached (adb/simctl) and agent API unreachable",
+      args,
+    );
+    return;
+  }
+  if (!target.device) {
+    recordSkipped(
+      `no ${target.platform ?? "mobile"} device/simulator attached`,
+      args,
+    );
+    return;
+  }
+
+  const deviceClass = deviceClassFor(args, target);
+  const budgets = loadBudgets();
+  const tierBudget = budgets.deviceClasses?.[deviceClass]?.[args.tier] ?? null;
+  const ctx = {
+    target,
+    args,
+    maxWindowMs: Number(process.env.MOBILE_RESOURCE_MAX_WINDOW_MS ?? 900_000),
+  };
+
+  const results = [];
+  let anyFail = false;
+
+  for (const id of args.workloads) {
+    const workload = workloadById(id);
+    if (!workload) {
+      console.warn(`[mobile-resource] unknown workload '${id}' — skipping`);
+      continue;
+    }
+    if (workload.requiresVoice && process.env.MOBILE_RESOURCE_VOICE !== "1") {
+      results.push({
+        id,
+        status: "skipped",
+        reason: "voice loop not enabled (set MOBILE_RESOURCE_VOICE=1)",
+      });
+      recordResult(
+        id,
+        { skipped: true, reason: "voice not enabled", tier: args.tier },
+        NOW,
+      );
+      continue;
+    }
+    console.log(`\n>>> ${id} (${workload.title})`);
+    const run = await runWorkload(workload, ctx);
+    const summary = summarizeResourceRun(run, {
+      leakGrowthMbThreshold: budgets.leakGrowthMbThreshold,
+    });
+    const checks = checkBudgets(summary, tierBudget, {
+      failOnMissing: args.failOnMissing,
+    });
+    const pass = checks.every((c) => c.pass);
+    if (!pass) anyFail = true;
+    const record = {
+      tier: args.tier,
+      deviceClass,
+      platform: target.platform,
+      device: target.device,
+      isSimulator: target.isSimulator,
+      summary,
+      checks,
+      pass,
+    };
+    recordResult(id, record, NOW);
+    results.push({ id, status: pass ? "pass" : "fail", summary, checks });
+    printWorkload(summary, checks);
+  }
+
+  const summaryPayload = {
+    tier: args.tier,
+    deviceClass,
+    platform: target.platform,
+    workloads: results.map((r) => ({ id: r.id, status: r.status })),
+    pass: !anyFail,
+  };
+  recordResult("summary", summaryPayload, NOW);
+
+  if (args.json) {
+    console.log(JSON.stringify({ ...summaryPayload, results }, null, 2));
+  } else {
+    console.log(
+      `\nresult: ${anyFail ? "FAIL" : "PASS"}  (tier ${args.tier}, ${deviceClass})`,
+    );
+  }
+  process.exit(anyFail ? 1 : 0);
+}
+
+function printWorkload(summary, checks) {
+  console.log(
+    `  generations: ${summary.generations}  samples: ${summary.resourceSamples}`,
+  );
+  console.log(
+    `  decode: ${tps(summary.decodeTokensPerSecond.p50)}  prefill: ${tps(summary.prefillTokensPerSecond.p50)}  ttft(p90): ${ms(summary.ttftMs.p90)}`,
+  );
+  console.log(
+    `  RSS peak/steady: ${mb(summary.rss.peakMb)} / ${mb(summary.rss.steadyMb)}  leak: ${summary.rss.leakSuspected}`,
+  );
+  console.log(
+    `  battery drain: ${summary.battery.drainPct == null ? "—" : `${summary.battery.drainPct}%`}  thermal max: ${summary.thermal.maxState ?? "—"}`,
+  );
+  for (const c of checks) {
+    const v =
+      c.value == null
+        ? "—"
+        : c.unit === "bool"
+          ? c.value
+            ? "yes"
+            : "no"
+          : `${c.value}`;
+    const b = c.budget == null ? "no-baseline" : `${c.budget}`;
+    console.log(
+      `    ${c.pass ? "PASS" : "FAIL"}  ${c.name}: ${v} / ${b} ${c.unit}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error("[mobile-resource] fatal:", err);
+  process.exit(2);
+});

--- a/packages/benchmarks/mobile-resource/workloads.mjs
+++ b/packages/benchmarks/mobile-resource/workloads.mjs
@@ -1,0 +1,84 @@
+/**
+ * Canonical mobile profiling workloads.
+ *
+ * A fixed synthetic script (not session traces) so runs are reproducible across
+ * devices and commits — the workbench's job is regression detection, which needs
+ * a stable input. Each workload declares the phases the runner drives and the
+ * resource-sampling cadence used while it runs.
+ *
+ * Workloads map to the acceptance criteria in issue #8800:
+ *   - cold-load     → cold model load: peak RSS at load, no generation.
+ *   - single-turn   → one short chat: TTFT + prefill/decode tok/s, single-turn RSS.
+ *   - sustained-chat→ N-turn chat: RSS-leak window + thermal-creep timeline + battery drain.
+ *   - voice-loop    → full voice round-trips (tied to #8785 / #8786): voice TTFT.
+ */
+
+/** Prompts kept short + deterministic; mobile token cap is 256 (see capacitor adapter). */
+const SHORT_PROMPTS = [
+  "In one sentence, what is the capital of France?",
+  "Reply with a single word: the opposite of hot.",
+  "What is 17 plus 25? Answer with just the number.",
+  "Name one primary color.",
+  "Say hello.",
+];
+
+export const WORKLOADS = [
+  {
+    id: "cold-load",
+    title: "Cold model load",
+    description:
+      "Load the tier's model from cold and sample peak RSS during load. No generation.",
+    kind: "load-only",
+    turns: 0,
+    sampleIntervalMs: 500,
+    // Sampling window after issuing load until the model reports ready / timeout.
+    maxDurationMs: 120_000,
+  },
+  {
+    id: "single-turn",
+    title: "Single short chat",
+    description:
+      "One short prompt → measure TTFT, prefill/decode tok/s, and single-turn RSS.",
+    kind: "chat",
+    turns: 1,
+    prompts: SHORT_PROMPTS.slice(0, 1),
+    sampleIntervalMs: 500,
+    maxDurationMs: 90_000,
+  },
+  {
+    id: "sustained-chat",
+    title: "Sustained N-turn chat",
+    description:
+      "A run of short turns to expose RSS leaks, thermal creep, and battery drain over a fixed window.",
+    kind: "chat",
+    turns: 24,
+    prompts: SHORT_PROMPTS,
+    sampleIntervalMs: 1000,
+    maxDurationMs: 900_000,
+  },
+  {
+    id: "voice-loop",
+    title: "Full voice loop",
+    description:
+      "Voice round-trips (ASR → LLM → TTS) for voice TTFT + decode under the full pipeline. Tied to #8785 / #8786.",
+    kind: "voice",
+    turns: 6,
+    prompts: SHORT_PROMPTS.slice(0, 3),
+    sampleIntervalMs: 1000,
+    maxDurationMs: 600_000,
+    // Requires the voice pipeline to be reachable on-device; runner records
+    // "skipped" with a reason when it is not, rather than fabricating numbers.
+    requiresVoice: true,
+  },
+];
+
+export function workloadById(id) {
+  return WORKLOADS.find((w) => w.id === id) ?? null;
+}
+
+/** Default workload selection when --workloads is not passed (voice opt-in). */
+export const DEFAULT_WORKLOAD_IDS = [
+  "cold-load",
+  "single-turn",
+  "sustained-chat",
+];

--- a/packages/shared/src/local-inference/index.ts
+++ b/packages/shared/src/local-inference/index.ts
@@ -69,6 +69,12 @@ export type {
   RoutingPreferences,
 } from "./routing-preferences.js";
 export {
+  computeGenerationThroughput,
+  type GenerationCounters,
+  type GenerationThroughput,
+  isGenerationCounters,
+} from "./throughput.js";
+export {
   type ActiveModelState,
   AGENT_MODEL_SLOTS,
   type AgentModelSlot,

--- a/packages/shared/src/local-inference/throughput.test.ts
+++ b/packages/shared/src/local-inference/throughput.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeGenerationThroughput,
+  isGenerationCounters,
+} from "./throughput";
+
+describe("computeGenerationThroughput", () => {
+  it("differences prefill and decode tok/s from a measured TTFT", () => {
+    // 64 prompt tokens processed in 200 ms prefill → 320 tok/s prefill.
+    // 128 decoded tokens over the remaining 800 ms → 160 tok/s decode.
+    const t = computeGenerationThroughput({
+      promptTokens: 64,
+      outputTokens: 128,
+      durationMs: 1000,
+      ttftMs: 200,
+    });
+    expect(t.prefillTokensPerSecond).toBeCloseTo(320, 5);
+    expect(t.decodeTokensPerSecond).toBeCloseTo(160, 5);
+    expect(t.combinedTokensPerSecond).toBeCloseTo(128, 5);
+    expect(t.ttftMs).toBe(200);
+    expect(t.decodeMs).toBe(800);
+  });
+
+  it("reports prefill/decode as null but keeps combined when TTFT is absent", () => {
+    const t = computeGenerationThroughput({
+      promptTokens: 64,
+      outputTokens: 128,
+      durationMs: 1000,
+    });
+    expect(t.prefillTokensPerSecond).toBeNull();
+    expect(t.decodeTokensPerSecond).toBeNull();
+    expect(t.ttftMs).toBeNull();
+    expect(t.decodeMs).toBeNull();
+    expect(t.combinedTokensPerSecond).toBeCloseTo(128, 5);
+  });
+
+  it("treats a non-positive duration as fully unmeasurable (no fabricated zeros)", () => {
+    const t = computeGenerationThroughput({
+      promptTokens: 64,
+      outputTokens: 128,
+      durationMs: 0,
+    });
+    expect(t.prefillTokensPerSecond).toBeNull();
+    expect(t.decodeTokensPerSecond).toBeNull();
+    expect(t.combinedTokensPerSecond).toBeNull();
+  });
+
+  it("reports null combined throughput when nothing was decoded", () => {
+    const t = computeGenerationThroughput({
+      promptTokens: 64,
+      outputTokens: 0,
+      durationMs: 500,
+      ttftMs: 100,
+    });
+    // Prefill is still measurable (prompt was processed); decode/combined are not.
+    expect(t.prefillTokensPerSecond).toBeCloseTo(640, 5);
+    expect(t.decodeTokensPerSecond).toBeNull();
+    expect(t.combinedTokensPerSecond).toBeNull();
+  });
+
+  it("ignores an impossible TTFT that meets or exceeds the total duration", () => {
+    const t = computeGenerationThroughput({
+      promptTokens: 32,
+      outputTokens: 10,
+      durationMs: 500,
+      ttftMs: 500,
+    });
+    // ttft >= duration leaves no decode window, so the split is dropped and
+    // only the combined figure survives.
+    expect(t.ttftMs).toBeNull();
+    expect(t.prefillTokensPerSecond).toBeNull();
+    expect(t.decodeTokensPerSecond).toBeNull();
+    expect(t.combinedTokensPerSecond).toBeCloseTo(20, 5);
+  });
+
+  it("does not divide by a zero prompt token count", () => {
+    const t = computeGenerationThroughput({
+      promptTokens: 0,
+      outputTokens: 16,
+      durationMs: 400,
+      ttftMs: 50,
+    });
+    expect(t.prefillTokensPerSecond).toBeNull();
+    expect(t.decodeTokensPerSecond).toBeCloseTo(16 / 0.35, 5);
+  });
+});
+
+describe("isGenerationCounters", () => {
+  it("accepts a well-formed frame with and without ttftMs", () => {
+    expect(
+      isGenerationCounters({ promptTokens: 1, outputTokens: 1, durationMs: 1 }),
+    ).toBe(true);
+    expect(
+      isGenerationCounters({
+        promptTokens: 1,
+        outputTokens: 1,
+        durationMs: 1,
+        ttftMs: 1,
+      }),
+    ).toBe(true);
+    expect(
+      isGenerationCounters({
+        promptTokens: 0,
+        outputTokens: 0,
+        durationMs: 0,
+        ttftMs: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed frames", () => {
+    expect(isGenerationCounters(null)).toBe(false);
+    expect(isGenerationCounters({ promptTokens: 1, outputTokens: 1 })).toBe(
+      false,
+    );
+    expect(
+      isGenerationCounters({
+        promptTokens: -1,
+        outputTokens: 1,
+        durationMs: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isGenerationCounters({
+        promptTokens: 1,
+        outputTokens: 1,
+        durationMs: 1,
+        ttftMs: "fast",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/local-inference/throughput.ts
+++ b/packages/shared/src/local-inference/throughput.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-generation throughput differencing for the on-device inference path.
+ *
+ * The device bridge carries the raw counters for every on-device generation
+ * (`promptTokens`, `outputTokens`, `durationMs`, and — when the device measured
+ * it — `ttftMs`, the time to the first decoded token). This module turns those
+ * counters into the two throughput numbers a profiling harness actually wants:
+ *
+ *   - **prefill tokens/sec** — prompt-processing throughput. The model reads the
+ *     whole prompt before emitting the first token, so `ttftMs` *is* the prefill
+ *     wall-clock; prefill tok/s = `promptTokens / (ttftMs / 1000)`.
+ *   - **decode tokens/sec** — generation throughput. The decode phase runs from
+ *     the first token to completion, so decode tok/s =
+ *     `outputTokens / ((durationMs - ttftMs) / 1000)`.
+ *
+ * When the device could not measure `ttftMs` (the non-streaming Capacitor llama
+ * path before per-token timing lands), prefill and decode cannot be separated —
+ * those fields are reported as `null` and only the combined throughput
+ * (`outputTokens / durationMs`) is filled. Per the repo architecture rules
+ * (AGENTS.md §3/§7) a quantity that could not be measured is recorded as `null`,
+ * never as a fabricated `0`.
+ *
+ * Shared between the agent-side device bridge
+ * (`@elizaos/plugin-local-inference/services/device-bridge`) and the UI client
+ * (`@elizaos/ui/services/local-inference/device-bridge`) — both hand-synced
+ * copies import this single source rather than re-implementing the math.
+ */
+
+/** Raw per-generation counters as carried by the device-bridge wire. */
+export interface GenerationCounters {
+  /** Prompt tokens the device processed during prefill. */
+  promptTokens: number;
+  /** Tokens the device decoded (generated). */
+  outputTokens: number;
+  /** Total wall-clock for the generation, in milliseconds. */
+  durationMs: number;
+  /**
+   * Time to first decoded token, in milliseconds, when the device measured it.
+   * Equals the prefill wall-clock. Absent on the non-streaming path.
+   */
+  ttftMs?: number | null;
+}
+
+/** Differenced throughput for a single on-device generation. */
+export interface GenerationThroughput {
+  /** Prefill (prompt-processing) throughput, tok/s, or null when unmeasurable. */
+  prefillTokensPerSecond: number | null;
+  /** Decode (generation) throughput, tok/s, or null when unmeasurable. */
+  decodeTokensPerSecond: number | null;
+  /**
+   * Whole-generation throughput, tok/s = outputTokens / durationMs. Always
+   * filled when at least one token was decoded in a positive duration, even
+   * when `ttftMs` is missing — this is the fallback signal for the
+   * non-streaming path.
+   */
+  combinedTokensPerSecond: number | null;
+  /** Echoed TTFT, ms, or null when the device did not measure it. */
+  ttftMs: number | null;
+  /** Derived decode wall-clock (durationMs − ttftMs), ms, or null. */
+  decodeMs: number | null;
+}
+
+const MS_PER_SECOND = 1000;
+
+function isPositive(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isNonNegativeCount(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Difference raw generation counters into prefill / decode / combined tok/s.
+ *
+ * Pure and synchronous. Every output field is `null` unless the inputs make it
+ * genuinely computable — never a fabricated zero.
+ */
+export function computeGenerationThroughput(
+  counters: GenerationCounters,
+): GenerationThroughput {
+  const { promptTokens, outputTokens, durationMs } = counters;
+  const ttftMs =
+    isPositive(counters.ttftMs) && counters.ttftMs < durationMs
+      ? counters.ttftMs
+      : null;
+
+  // Combined throughput needs a positive duration and ≥1 decoded token. Zero
+  // decoded tokens means there was no decode to measure — report null, not 0.
+  const combinedTokensPerSecond =
+    isPositive(durationMs) && isPositive(outputTokens)
+      ? outputTokens / (durationMs / MS_PER_SECOND)
+      : null;
+
+  // Prefill throughput needs a measured TTFT and ≥1 prompt token.
+  const prefillTokensPerSecond =
+    ttftMs !== null && isPositive(promptTokens)
+      ? promptTokens / (ttftMs / MS_PER_SECOND)
+      : null;
+
+  // Decode throughput needs a measured TTFT (so we can subtract prefill) and a
+  // positive remaining window with ≥1 decoded token.
+  const decodeMs = ttftMs !== null ? durationMs - ttftMs : null;
+  const decodeTokensPerSecond =
+    decodeMs !== null && isPositive(decodeMs) && isPositive(outputTokens)
+      ? outputTokens / (decodeMs / MS_PER_SECOND)
+      : null;
+
+  return {
+    prefillTokensPerSecond,
+    decodeTokensPerSecond,
+    combinedTokensPerSecond,
+    ttftMs,
+    decodeMs: decodeMs !== null && isPositive(decodeMs) ? decodeMs : null,
+  };
+}
+
+/**
+ * Validate the raw counter shape before differencing. The wire is hand-synced
+ * between the agent and the device client, so a malformed frame should be
+ * rejected at the boundary (and the metric dropped) rather than silently
+ * producing garbage throughput.
+ */
+export function isGenerationCounters(
+  value: unknown,
+): value is GenerationCounters {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    isNonNegativeCount(v.promptTokens as number) &&
+    isNonNegativeCount(v.outputTokens as number) &&
+    isNonNegativeCount(v.durationMs as number) &&
+    (v.ttftMs == null || isNonNegativeCount(v.ttftMs as number))
+  );
+}

--- a/packages/ui/src/services/local-inference/device-bridge.ts
+++ b/packages/ui/src/services/local-inference/device-bridge.ts
@@ -36,6 +36,10 @@ import path from "node:path";
 import type { Duplex } from "node:stream";
 import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
+import {
+  computeGenerationThroughput,
+  type GenerationThroughput,
+} from "@elizaos/shared/local-inference";
 import type {
   LocalInferenceLoadArgs,
   LocalInferenceLoader,
@@ -92,6 +96,12 @@ type DeviceOutbound =
       promptTokens: number;
       outputTokens: number;
       durationMs: number;
+      /**
+       * Time-to-first-token in ms, when the device measured it. Equals the
+       * prefill wall-clock; lets the agent difference prefill vs decode tok/s.
+       * Optional — absent on the non-streaming path (older device clients).
+       */
+      ttftMs?: number;
     }
   | { type: "generateResult"; correlationId: string; ok: false; error: string }
   | {
@@ -270,6 +280,25 @@ interface PersistedGenerateRequest {
 }
 
 /**
+ * One on-device generation's measured resource signal, emitted to
+ * `subscribeGenerationMetrics` listeners after every successful `generateResult`.
+ * The Mobile Resource Workbench folds these into a `DeviceResourceMetrics`
+ * accumulator (prefill/decode tok/s, TTFT, per-tier aggregation). All
+ * throughput fields are `null` when the device could not measure the inputs.
+ */
+export interface DeviceGenerationMetrics {
+  deviceId: string;
+  platform: DeviceCapabilities["platform"] | null;
+  /** Device model identifier (e.g. `iPhone17,2`) for per-device baselines. */
+  deviceModel: string | null;
+  promptTokens: number;
+  outputTokens: number;
+  durationMs: number;
+  ttftMs: number | null;
+  throughput: GenerationThroughput;
+}
+
+/**
  * Scoring function — pick the most powerful device available.
  * Pure, synchronous, and easy to test.
  */
@@ -321,6 +350,13 @@ export class DeviceBridge {
   private readonly statusListeners = new Set<
     (status: DeviceBridgeStatus) => void
   >();
+
+  private readonly generationMetricsListeners = new Set<
+    (metrics: DeviceGenerationMetrics) => void
+  >();
+
+  /** The most recent successful generation's metrics, or null. */
+  private lastGenerationMetrics: DeviceGenerationMetrics | null = null;
 
   private readonly expectedPairingToken: string | null =
     process.env.ELIZA_DEVICE_PAIRING_TOKEN?.trim() || null;
@@ -392,6 +428,36 @@ export class DeviceBridge {
         listener(snapshot);
       } catch {
         this.statusListeners.delete(listener);
+      }
+    }
+  }
+
+  /**
+   * Subscribe to per-generation throughput metrics. Fires once per successful
+   * on-device generation with the differenced prefill/decode tok/s. Returns an
+   * unsubscribe function.
+   */
+  subscribeGenerationMetrics(
+    listener: (metrics: DeviceGenerationMetrics) => void,
+  ): () => void {
+    this.generationMetricsListeners.add(listener);
+    return () => {
+      this.generationMetricsListeners.delete(listener);
+    };
+  }
+
+  /** The most recent successful generation's measured metrics, or null. */
+  latestGenerationMetrics(): DeviceGenerationMetrics | null {
+    return this.lastGenerationMetrics;
+  }
+
+  private emitGenerationMetrics(metrics: DeviceGenerationMetrics): void {
+    this.lastGenerationMetrics = metrics;
+    for (const listener of this.generationMetricsListeners) {
+      try {
+        listener(metrics);
+      } catch {
+        this.generationMetricsListeners.delete(listener);
       }
     }
   }
@@ -708,6 +774,29 @@ export class DeviceBridge {
       if (msg.ok === false) {
         pending.reject(new Error(msg.error));
       } else {
+        // Difference the raw counters into prefill/decode tok/s and surface
+        // them to profiling subscribers. The loader contract is unchanged —
+        // callers still get the text; metrics are a side channel.
+        const ttftMs = typeof msg.ttftMs === "number" ? msg.ttftMs : null;
+        const throughput = computeGenerationThroughput({
+          promptTokens: msg.promptTokens,
+          outputTokens: msg.outputTokens,
+          durationMs: msg.durationMs,
+          ttftMs,
+        });
+        const device = pending.routedDeviceId
+          ? this.devices.get(pending.routedDeviceId)
+          : null;
+        this.emitGenerationMetrics({
+          deviceId: pending.routedDeviceId ?? "unknown",
+          platform: device?.capabilities.platform ?? null,
+          deviceModel: device?.capabilities.deviceModel ?? null,
+          promptTokens: msg.promptTokens,
+          outputTokens: msg.outputTokens,
+          durationMs: msg.durationMs,
+          ttftMs,
+          throughput,
+        });
         pending.resolve(msg.text);
       }
       return;

--- a/packages/ui/src/services/local-inference/index.ts
+++ b/packages/ui/src/services/local-inference/index.ts
@@ -1,3 +1,9 @@
+export {
+  computeGenerationThroughput,
+  type GenerationCounters,
+  type GenerationThroughput,
+  isGenerationCounters,
+} from "@elizaos/shared/local-inference";
 export type { LocalInferenceLoader } from "./active-model";
 export {
   ELIZA_1_PLACEHOLDER_IDS,
@@ -37,6 +43,12 @@ export {
   selectRecommendedModelForSlot,
   selectRecommendedModels,
 } from "./recommendation";
+export {
+  type DeviceResourceSnapshot,
+  getDeviceResourceSnapshot,
+  normalizeResourceSnapshot,
+  type SnapshotThermalState,
+} from "./resource-snapshot-bridge";
 export { LocalInferenceService, localInferenceService } from "./service";
 export type {
   ActiveModelState,

--- a/packages/ui/src/services/local-inference/resource-snapshot-bridge.test.ts
+++ b/packages/ui/src/services/local-inference/resource-snapshot-bridge.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { normalizeResourceSnapshot } from "./resource-snapshot-bridge";
+
+describe("normalizeResourceSnapshot", () => {
+  it("passes through a fully-populated Android payload", () => {
+    const s = normalizeResourceSnapshot(
+      {
+        platform: "android",
+        thermalState: "fair",
+        lowPowerMode: false,
+        residentMemoryMb: 812.5,
+        availableRamMb: 2048,
+        cpuTimeMs: 12345,
+        batteryLevelPct: 73,
+        batteryChargeMicroAmpHours: 2_900_000,
+        batteryCurrentMicroAmps: -450000,
+        isCharging: false,
+        capturedAtMs: 1_000,
+      },
+      9_999,
+    );
+    expect(s).toEqual({
+      platform: "android",
+      thermalState: "fair",
+      lowPowerMode: false,
+      residentMemoryMb: 812.5,
+      availableRamMb: 2048,
+      cpuTimeMs: 12345,
+      batteryLevelPct: 73,
+      batteryChargeMicroAmpHours: 2_900_000,
+      batteryCurrentMicroAmps: -450000,
+      isCharging: false,
+      capturedAtMs: 1_000,
+    });
+  });
+
+  it("coerces native nulls and missing fields to null (no fabricated zeros)", () => {
+    const s = normalizeResourceSnapshot(
+      {
+        platform: "ios",
+        thermalState: "nominal",
+        lowPowerMode: true,
+        residentMemoryMb: 640,
+        availableRamMb: null,
+        cpuTimeMs: null,
+        batteryLevelPct: null,
+        isCharging: true,
+        // capturedAtMs missing
+      },
+      5_555,
+    );
+    expect(s.availableRamMb).toBeNull();
+    expect(s.cpuTimeMs).toBeNull();
+    expect(s.batteryLevelPct).toBeNull();
+    expect(s.batteryChargeMicroAmpHours).toBeNull();
+    expect(s.batteryCurrentMicroAmps).toBeNull();
+    expect(s.residentMemoryMb).toBe(640);
+    expect(s.lowPowerMode).toBe(true);
+    expect(s.capturedAtMs).toBe(5_555);
+  });
+
+  it("defaults an unknown/garbage thermal state and platform", () => {
+    const s = normalizeResourceSnapshot(
+      { platform: "web", thermalState: "blazing" },
+      42,
+    );
+    expect(s.platform).toBeNull();
+    expect(s.thermalState).toBe("unknown");
+  });
+
+  it("treats a non-object payload as all-null with a fallback timestamp", () => {
+    const s = normalizeResourceSnapshot(null, 7);
+    expect(s.platform).toBeNull();
+    expect(s.thermalState).toBe("unknown");
+    expect(s.residentMemoryMb).toBeNull();
+    expect(s.capturedAtMs).toBe(7);
+  });
+
+  it("rejects NaN/Infinity numeric fields", () => {
+    const s = normalizeResourceSnapshot(
+      {
+        platform: "android",
+        residentMemoryMb: Number.NaN,
+        availableRamMb: Number.POSITIVE_INFINITY,
+      },
+      1,
+    );
+    expect(s.residentMemoryMb).toBeNull();
+    expect(s.availableRamMb).toBeNull();
+  });
+});

--- a/packages/ui/src/services/local-inference/resource-snapshot-bridge.ts
+++ b/packages/ui/src/services/local-inference/resource-snapshot-bridge.ts
@@ -1,0 +1,133 @@
+/**
+ * Device resource-snapshot bridge.
+ *
+ * Calls the native resource probe — `ElizaIntent.getResourceSnapshot()` on iOS,
+ * `ResourceProbe.getResourceSnapshot()` on Android — and normalises the raw
+ * Capacitor payload into a typed `DeviceResourceSnapshot` for the Mobile
+ * Resource Workbench (issue #8800).
+ *
+ * The native side returns JSON `null` (iOS `NSNull()` / Android
+ * `JSONObject.NULL`) for any quantity the OS cannot measure, so the normaliser
+ * coerces every numeric field through a strict finite-number check and reports
+ * `null` otherwise — never a fabricated zero (AGENTS.md §3/§7).
+ *
+ * Only `normalizeResourceSnapshot` is pure/unit-tested; `getDeviceResourceSnapshot`
+ * is the thin native call.
+ */
+
+import { Capacitor } from "@capacitor/core";
+import { getNativePlugin } from "../../bridge/native-plugins";
+
+export type SnapshotThermalState =
+  | "nominal"
+  | "fair"
+  | "serious"
+  | "critical"
+  | "unknown";
+
+const THERMAL_STATES: readonly SnapshotThermalState[] = [
+  "nominal",
+  "fair",
+  "serious",
+  "critical",
+  "unknown",
+];
+
+export interface DeviceResourceSnapshot {
+  platform: "ios" | "android" | null;
+  thermalState: SnapshotThermalState;
+  lowPowerMode: boolean | null;
+  /** Process resident footprint in MB (iOS phys_footprint / Android total PSS). */
+  residentMemoryMb: number | null;
+  /** Device-wide available RAM in MB before memory pressure. */
+  availableRamMb: number | null;
+  /** Cumulative process CPU time in ms. */
+  cpuTimeMs: number | null;
+  batteryLevelPct: number | null;
+  /** Cumulative charge counter in µAh (Android only). */
+  batteryChargeMicroAmpHours: number | null;
+  /** Instantaneous current draw in µA (Android only). */
+  batteryCurrentMicroAmps: number | null;
+  isCharging: boolean | null;
+  /** Sample timestamp in ms (epoch). */
+  capturedAtMs: number;
+}
+
+interface ResourceProbePlugin {
+  getResourceSnapshot?: () => Promise<unknown>;
+}
+
+function finiteOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function boolOrNull(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function asThermalState(value: unknown): SnapshotThermalState {
+  return typeof value === "string" &&
+    (THERMAL_STATES as readonly string[]).includes(value)
+    ? (value as SnapshotThermalState)
+    : "unknown";
+}
+
+/**
+ * Normalise a raw native resource-snapshot payload into a typed snapshot.
+ * Pure — coerces every field and substitutes `null` for anything missing or
+ * non-finite. `capturedAtMs` falls back to the supplied `nowMs` when the native
+ * side did not stamp it.
+ */
+export function normalizeResourceSnapshot(
+  raw: unknown,
+  nowMs: number,
+): DeviceResourceSnapshot {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<
+    string,
+    unknown
+  >;
+  const platform =
+    r.platform === "ios" || r.platform === "android" ? r.platform : null;
+  return {
+    platform,
+    thermalState: asThermalState(r.thermalState),
+    lowPowerMode: boolOrNull(r.lowPowerMode),
+    residentMemoryMb: finiteOrNull(r.residentMemoryMb),
+    availableRamMb: finiteOrNull(r.availableRamMb),
+    cpuTimeMs: finiteOrNull(r.cpuTimeMs),
+    batteryLevelPct: finiteOrNull(r.batteryLevelPct),
+    batteryChargeMicroAmpHours: finiteOrNull(r.batteryChargeMicroAmpHours),
+    batteryCurrentMicroAmps: finiteOrNull(r.batteryCurrentMicroAmps),
+    isCharging: boolOrNull(r.isCharging),
+    capturedAtMs: finiteOrNull(r.capturedAtMs) ?? nowMs,
+  };
+}
+
+/** The native plugin name that carries `getResourceSnapshot` per platform. */
+function resourceProbePluginName(): string | null {
+  const platform = Capacitor.getPlatform();
+  if (platform === "ios") return "ElizaIntent";
+  if (platform === "android") return "ResourceProbe";
+  return null;
+}
+
+/**
+ * Read a live resource snapshot from the native probe, or `null` when no native
+ * probe is reachable (web / desktop / unregistered plugin). Never throws — a
+ * probe failure resolves to `null` so the caller treats it as "not available on
+ * this platform" rather than a hard error.
+ */
+export async function getDeviceResourceSnapshot(
+  nowMs: number = Date.now(),
+): Promise<DeviceResourceSnapshot | null> {
+  const name = resourceProbePluginName();
+  if (!name) return null;
+  const plugin = getNativePlugin<ResourceProbePlugin>(name);
+  if (typeof plugin.getResourceSnapshot !== "function") return null;
+  try {
+    const raw = await plugin.getResourceSnapshot();
+    return normalizeResourceSnapshot(raw, nowMs);
+  } catch {
+    return null;
+  }
+}

--- a/plugins/plugin-local-inference/src/services/device-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/device-bridge.ts
@@ -36,6 +36,10 @@ import path from "node:path";
 import type { Duplex } from "node:stream";
 import type { AgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import {
+	computeGenerationThroughput,
+	type GenerationThroughput,
+} from "@elizaos/shared/local-inference";
 import type {
 	LocalInferenceLoadArgs,
 	LocalInferenceLoader,
@@ -92,6 +96,12 @@ type DeviceOutbound =
 			promptTokens: number;
 			outputTokens: number;
 			durationMs: number;
+			/**
+			 * Time-to-first-token in ms, when the device measured it. Equals the
+			 * prefill wall-clock; lets the agent difference prefill vs decode tok/s.
+			 * Optional — absent on the non-streaming path (older device clients).
+			 */
+			ttftMs?: number;
 	  }
 	| { type: "generateResult"; correlationId: string; ok: false; error: string }
 	| {
@@ -278,6 +288,25 @@ interface PersistedGenerateRequest {
 }
 
 /**
+ * One on-device generation's measured resource signal, emitted to
+ * `subscribeGenerationMetrics` listeners after every successful `generateResult`.
+ * The Mobile Resource Workbench folds these into a `DeviceResourceMetrics`
+ * accumulator (prefill/decode tok/s, TTFT, per-tier aggregation). All
+ * throughput fields are `null` when the device could not measure the inputs.
+ */
+export interface DeviceGenerationMetrics {
+	deviceId: string;
+	platform: DeviceCapabilities["platform"] | null;
+	/** Device model identifier (e.g. `iPhone17,2`) for per-device baselines. */
+	deviceModel: string | null;
+	promptTokens: number;
+	outputTokens: number;
+	durationMs: number;
+	ttftMs: number | null;
+	throughput: GenerationThroughput;
+}
+
+/**
  * Scoring function — pick the most powerful device available.
  * Pure, synchronous, and easy to test.
  */
@@ -329,6 +358,17 @@ export class DeviceBridge {
 	private readonly statusListeners = new Set<
 		(status: DeviceBridgeStatus) => void
 	>();
+
+	private readonly generationMetricsListeners = new Set<
+		(metrics: DeviceGenerationMetrics) => void
+	>();
+
+	/** The most recent successful generation's metrics, or null. */
+	private lastGenerationMetrics: DeviceGenerationMetrics | null = null;
+
+	/** Bounded ring buffer of recent generation metrics for the dev endpoint. */
+	private readonly recentGenerations: DeviceGenerationMetrics[] = [];
+	private static readonly RECENT_GENERATIONS_CAP = 200;
 
 	private readonly expectedPairingToken: string | null =
 		process.env.ELIZA_DEVICE_PAIRING_TOKEN?.trim() || null;
@@ -400,6 +440,46 @@ export class DeviceBridge {
 				listener(snapshot);
 			} catch {
 				this.statusListeners.delete(listener);
+			}
+		}
+	}
+
+	/**
+	 * Subscribe to per-generation throughput metrics. Fires once per successful
+	 * on-device generation with the differenced prefill/decode tok/s. Returns an
+	 * unsubscribe function.
+	 */
+	subscribeGenerationMetrics(
+		listener: (metrics: DeviceGenerationMetrics) => void,
+	): () => void {
+		this.generationMetricsListeners.add(listener);
+		return () => {
+			this.generationMetricsListeners.delete(listener);
+		};
+	}
+
+	/** The most recent successful generation's measured metrics, or null. */
+	latestGenerationMetrics(): DeviceGenerationMetrics | null {
+		return this.lastGenerationMetrics;
+	}
+
+	/** Most recent generation metrics (newest last), capped at `limit`. */
+	recentGenerationMetrics(limit = 50): DeviceGenerationMetrics[] {
+		const n = Math.max(0, Math.trunc(limit));
+		return this.recentGenerations.slice(-n);
+	}
+
+	private emitGenerationMetrics(metrics: DeviceGenerationMetrics): void {
+		this.lastGenerationMetrics = metrics;
+		this.recentGenerations.push(metrics);
+		if (this.recentGenerations.length > DeviceBridge.RECENT_GENERATIONS_CAP) {
+			this.recentGenerations.shift();
+		}
+		for (const listener of this.generationMetricsListeners) {
+			try {
+				listener(metrics);
+			} catch {
+				this.generationMetricsListeners.delete(listener);
 			}
 		}
 	}
@@ -716,6 +796,29 @@ export class DeviceBridge {
 			if (msg.ok === false) {
 				pending.reject(new Error(msg.error));
 			} else {
+				// Difference the raw counters into prefill/decode tok/s and surface
+				// them to profiling subscribers. The loader contract is unchanged —
+				// callers still get the text; metrics are a side channel.
+				const ttftMs = typeof msg.ttftMs === "number" ? msg.ttftMs : null;
+				const throughput = computeGenerationThroughput({
+					promptTokens: msg.promptTokens,
+					outputTokens: msg.outputTokens,
+					durationMs: msg.durationMs,
+					ttftMs,
+				});
+				const device = pending.routedDeviceId
+					? this.devices.get(pending.routedDeviceId)
+					: null;
+				this.emitGenerationMetrics({
+					deviceId: pending.routedDeviceId ?? "unknown",
+					platform: device?.capabilities.platform ?? null,
+					deviceModel: device?.capabilities.deviceModel ?? null,
+					promptTokens: msg.promptTokens,
+					outputTokens: msg.outputTokens,
+					durationMs: msg.durationMs,
+					ttftMs,
+					throughput,
+				});
 				pending.resolve(msg.text);
 			}
 			return;
@@ -1078,6 +1181,31 @@ export class DeviceBridge {
 }
 
 export const deviceBridge = new DeviceBridge();
+
+/** Shape returned by `GET /api/dev/device-resource-metrics`. */
+export interface DeviceResourceMetricsDevPayload {
+	generatedAtEpochMs: number;
+	status: DeviceBridgeStatus;
+	latest: DeviceGenerationMetrics | null;
+	recentGenerations: DeviceGenerationMetrics[];
+}
+
+/**
+ * Build the JSON body for `GET /api/dev/device-resource-metrics` — the Mobile
+ * Resource Workbench reads this to harvest per-generation prefill/decode tok/s
+ * (already differenced by the bridge) without driving the device WebView.
+ */
+export function buildDeviceResourceMetricsDevPayload(
+	bridge: DeviceBridge = deviceBridge,
+	limit = 50,
+): DeviceResourceMetricsDevPayload {
+	return {
+		generatedAtEpochMs: Date.now(),
+		status: bridge.status(),
+		latest: bridge.latestGenerationMetrics(),
+		recentGenerations: bridge.recentGenerationMetrics(limit),
+	};
+}
 
 export function registerDeviceBridgeLoader(
 	runtime: AgentRuntime & {

--- a/plugins/plugin-local-inference/src/services/device-resource-metrics.test.ts
+++ b/plugins/plugin-local-inference/src/services/device-resource-metrics.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { DeviceResourceMetrics } from "./device-resource-metrics";
+
+describe("DeviceResourceMetrics", () => {
+	it("summarizes generation throughput and sampled device resources", () => {
+		const metrics = new DeviceResourceMetrics({ leakGrowthMbThreshold: 100 });
+
+		metrics.recordGeneration({
+			prefillTokensPerSecond: 320,
+			decodeTokensPerSecond: 160,
+			combinedTokensPerSecond: 128,
+			ttftMs: 200,
+		});
+		metrics.recordResourceSample({
+			atMs: 0,
+			residentMemoryMb: 1000,
+			batteryLevelPct: 80,
+			batteryChargeMicroAmpHours: 10_000,
+			isCharging: false,
+			thermalState: "nominal",
+			lowPowerMode: false,
+		});
+		metrics.recordResourceSample({
+			atMs: 1000,
+			residentMemoryMb: 1050,
+			batteryLevelPct: 79,
+			batteryChargeMicroAmpHours: 9900,
+			thermalState: "serious",
+			lowPowerMode: true,
+		});
+		metrics.recordResourceSample({
+			atMs: 2000,
+			residentMemoryMb: 1125,
+			batteryLevelPct: 78,
+			batteryChargeMicroAmpHours: 9800,
+			thermalState: "critical",
+			lowPowerMode: false,
+		});
+		metrics.recordResourceSample({
+			atMs: 3000,
+			residentMemoryMb: 1205,
+			batteryLevelPct: 77,
+			batteryChargeMicroAmpHours: 9700,
+			thermalState: "critical",
+			lowPowerMode: false,
+		});
+
+		const summary = metrics.summary();
+
+		expect(summary.generations).toBe(1);
+		expect(summary.prefillTokensPerSecond.p50).toBe(320);
+		expect(summary.decodeTokensPerSecond.p50).toBe(160);
+		expect(summary.combinedTokensPerSecond.p50).toBe(128);
+		expect(summary.ttftMs.p50).toBe(200);
+		expect(summary.rss).toMatchObject({
+			firstMb: 1000,
+			lastMb: 1205,
+			peakMb: 1205,
+			steadyMb: 1165,
+			growthMb: 205,
+			leakSuspected: true,
+		});
+		expect(summary.battery).toMatchObject({
+			firstPct: 80,
+			lastPct: 77,
+			drainPct: 3,
+			energyMicroAmpHoursDelta: 300,
+			durationMs: 3000,
+			chargingObserved: false,
+		});
+		expect(summary.thermal).toMatchObject({
+			initialState: "nominal",
+			maxState: "critical",
+			transitionCount: 2,
+			fractionThrottled: 0.75,
+		});
+		expect(summary.lowPowerMode).toMatchObject({
+			everEnabled: true,
+			transitionCount: 2,
+		});
+	});
+
+	it("keeps unmeasured quantities null instead of fabricating zeros", () => {
+		const metrics = new DeviceResourceMetrics();
+
+		metrics.recordGeneration({});
+		metrics.recordResourceSample({ atMs: 0 });
+
+		const summary = metrics.summary();
+
+		expect(summary.generations).toBe(1);
+		expect(summary.prefillTokensPerSecond.count).toBe(0);
+		expect(summary.prefillTokensPerSecond.p50).toBeNull();
+		expect(summary.rss.firstMb).toBeNull();
+		expect(summary.battery.drainPct).toBeNull();
+		expect(summary.thermal.fractionThrottled).toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/device-resource-metrics.ts
+++ b/plugins/plugin-local-inference/src/services/device-resource-metrics.ts
@@ -1,0 +1,346 @@
+/**
+ * DeviceResourceMetrics — on-device resource profiling accumulator.
+ *
+ * Sibling to `VoiceRunMetrics` (`latency-trace.ts`), generalised for the Mobile
+ * Resource Workbench (issue #8800). Where `VoiceRunMetrics` accumulates the
+ * non-latency signals of a *host-side* voice run (server RSS, MTP accept-rate),
+ * this accumulates the signals of an *on-device* agent run:
+ *
+ *   - per-generation **prefill / decode / combined tokens-per-second** + TTFT
+ *     (fed from the device-bridge `computeGenerationThroughput` differencing),
+ *   - **peak + steady resident memory (RSS)** with an RSS-leak flag,
+ *   - **battery drain** (% and, where the OS exposes a charge counter, µAh),
+ *   - a **thermal-state timeline** + transition count,
+ *   - **low-power-mode transitions**.
+ *
+ * Every field is optional on input and every output is `null` when nothing
+ * could be measured — a quantity the device could not report is recorded as
+ * missing, never as a fabricated `0` (AGENTS.md §3 / §7). The workbench writes
+ * `summary()` to `results/<workload>/latest.json`.
+ */
+
+import { BoundedHistogram, type HistogramSummary } from "./latency-trace";
+
+export type DeviceThermalState =
+	| "nominal"
+	| "fair"
+	| "serious"
+	| "critical"
+	| "unknown";
+
+/** Severity rank for thermal states. `unknown` is unranked (excluded). */
+const THERMAL_RANK: Record<Exclude<DeviceThermalState, "unknown">, number> = {
+	nominal: 0,
+	fair: 1,
+	serious: 2,
+	critical: 3,
+};
+
+/** A single generation's differenced throughput (see `throughput.ts`). */
+export interface GenerationObservation {
+	prefillTokensPerSecond?: number | null;
+	decodeTokensPerSecond?: number | null;
+	combinedTokensPerSecond?: number | null;
+	ttftMs?: number | null;
+}
+
+/**
+ * A sampled device-resource snapshot, taken on an interval across a workload.
+ * Sourced from the native `getResourceSnapshot` bridge (iOS/Android) and/or
+ * host-side OS probes (`adb dumpsys`, `/proc`).
+ */
+export interface ResourceSample {
+	/** Timestamp in ms (epoch or run-relative); orders the timeline + drain rate. */
+	atMs: number;
+	/** Resident set size in MB (peak / steady / leak tracking). */
+	residentMemoryMb?: number | null;
+	/** Available device RAM in MB at sample time. */
+	availableRamMb?: number | null;
+	/** Battery level 0..100. */
+	batteryLevelPct?: number | null;
+	/** Cumulative charge counter in µAh (Android `BATTERY_PROPERTY_CHARGE_COUNTER`). */
+	batteryChargeMicroAmpHours?: number | null;
+	/** Whether the device was charging at sample time. */
+	isCharging?: boolean | null;
+	thermalState?: DeviceThermalState | null;
+	lowPowerMode?: boolean | null;
+	/** Cumulative process CPU time in ms, when the platform exposes it. */
+	cpuTimeMs?: number | null;
+}
+
+export interface RssSummary {
+	firstMb: number | null;
+	lastMb: number | null;
+	peakMb: number | null;
+	/** Median RSS over the back half of the run (warm/steady state). */
+	steadyMb: number | null;
+	samples: number;
+	/** lastMb − firstMb, or null. */
+	growthMb: number | null;
+	/** True when RSS is monotone non-decreasing across ≥4 samples and grew past the threshold. */
+	leakSuspected: boolean;
+}
+
+export interface BatterySummary {
+	firstPct: number | null;
+	lastPct: number | null;
+	/** firstPct − lastPct (positive = battery consumed), or null. */
+	drainPct: number | null;
+	samples: number;
+	/** True if any sample reported charging (drain numbers are then unreliable). */
+	chargingObserved: boolean;
+	/** firstCharge − lastCharge in µAh (positive = consumed), when the counter is present. */
+	energyMicroAmpHoursDelta: number | null;
+	/** Wall-clock span across battery samples in ms, or null. */
+	durationMs: number | null;
+}
+
+export interface ThermalTransition {
+	atMs: number;
+	state: DeviceThermalState;
+}
+
+export interface ThermalSummary {
+	samples: number;
+	initialState: DeviceThermalState | null;
+	/** Worst (highest-severity) known state observed. */
+	maxState: DeviceThermalState | null;
+	/** State-change timeline (first known state + every change after). */
+	transitions: ThermalTransition[];
+	transitionCount: number;
+	/** Fraction of known-state samples at serious|critical, or null when no known state. */
+	fractionThrottled: number | null;
+}
+
+export interface LowPowerSummary {
+	samples: number;
+	everEnabled: boolean;
+	transitionCount: number;
+}
+
+export interface DeviceResourceSummary {
+	generations: number;
+	resourceSamples: number;
+	prefillTokensPerSecond: HistogramSummary;
+	decodeTokensPerSecond: HistogramSummary;
+	combinedTokensPerSecond: HistogramSummary;
+	ttftMs: HistogramSummary;
+	rss: RssSummary;
+	battery: BatterySummary;
+	thermal: ThermalSummary;
+	lowPowerMode: LowPowerSummary;
+}
+
+const HISTOGRAM_CAPACITY = 1024;
+const DEFAULT_LEAK_GROWTH_MB = 256;
+/** Cap the thermal timeline so a long run cannot grow it without bound. */
+const MAX_THERMAL_TRANSITIONS = 256;
+
+function isFiniteNumber(v: number | null | undefined): v is number {
+	return typeof v === "number" && Number.isFinite(v);
+}
+
+function median(values: number[]): number | null {
+	if (values.length === 0) return null;
+	const s = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(s.length / 2);
+	return s.length % 2
+		? (s[mid] as number)
+		: ((s[mid - 1] as number) + (s[mid] as number)) / 2;
+}
+
+export class DeviceResourceMetrics {
+	private generations = 0;
+	private readonly prefillHist = new BoundedHistogram(HISTOGRAM_CAPACITY);
+	private readonly decodeHist = new BoundedHistogram(HISTOGRAM_CAPACITY);
+	private readonly combinedHist = new BoundedHistogram(HISTOGRAM_CAPACITY);
+	private readonly ttftHist = new BoundedHistogram(HISTOGRAM_CAPACITY);
+
+	private readonly rssSamples: number[] = [];
+
+	private resourceSamples = 0;
+	private firstBattery: { pct: number; atMs: number } | null = null;
+	private lastBattery: { pct: number; atMs: number } | null = null;
+	private firstChargeUah: number | null = null;
+	private lastChargeUah: number | null = null;
+	private batterySampleCount = 0;
+	private chargingObserved = false;
+
+	private thermalSampleCount = 0;
+	private thermalInitial: DeviceThermalState | null = null;
+	private thermalLast: DeviceThermalState | null = null;
+	private thermalMaxRank = -1;
+	private thermalMaxState: DeviceThermalState | null = null;
+	private thermalThrottledCount = 0;
+	private thermalKnownCount = 0;
+	private readonly thermalTransitions: ThermalTransition[] = [];
+
+	private lowPowerSampleCount = 0;
+	private lowPowerEver = false;
+	private lowPowerLast: boolean | null = null;
+	private lowPowerTransitions = 0;
+
+	constructor(private readonly opts: { leakGrowthMbThreshold?: number } = {}) {}
+
+	/** Record one generation's differenced throughput. */
+	recordGeneration(obs: GenerationObservation): void {
+		this.generations += 1;
+		if (isFiniteNumber(obs.prefillTokensPerSecond))
+			this.prefillHist.add(obs.prefillTokensPerSecond);
+		if (isFiniteNumber(obs.decodeTokensPerSecond))
+			this.decodeHist.add(obs.decodeTokensPerSecond);
+		if (isFiniteNumber(obs.combinedTokensPerSecond))
+			this.combinedHist.add(obs.combinedTokensPerSecond);
+		if (isFiniteNumber(obs.ttftMs)) this.ttftHist.add(obs.ttftMs);
+	}
+
+	/** Record one sampled device-resource snapshot. */
+	recordResourceSample(sample: ResourceSample): void {
+		this.resourceSamples += 1;
+
+		if (isFiniteNumber(sample.residentMemoryMb))
+			this.rssSamples.push(sample.residentMemoryMb);
+
+		if (isFiniteNumber(sample.batteryLevelPct)) {
+			const entry = { pct: sample.batteryLevelPct, atMs: sample.atMs };
+			if (this.firstBattery === null) this.firstBattery = entry;
+			this.lastBattery = entry;
+			this.batterySampleCount += 1;
+		}
+		if (isFiniteNumber(sample.batteryChargeMicroAmpHours)) {
+			if (this.firstChargeUah === null)
+				this.firstChargeUah = sample.batteryChargeMicroAmpHours;
+			this.lastChargeUah = sample.batteryChargeMicroAmpHours;
+		}
+		if (sample.isCharging === true) this.chargingObserved = true;
+
+		if (sample.thermalState != null) {
+			this.thermalSampleCount += 1;
+			if (this.thermalInitial === null)
+				this.thermalInitial = sample.thermalState;
+			const known = sample.thermalState !== "unknown";
+			if (known) {
+				this.thermalKnownCount += 1;
+				const rank =
+					THERMAL_RANK[
+						sample.thermalState as Exclude<DeviceThermalState, "unknown">
+					];
+				if (rank > this.thermalMaxRank) {
+					this.thermalMaxRank = rank;
+					this.thermalMaxState = sample.thermalState;
+				}
+				if (rank >= THERMAL_RANK.serious) this.thermalThrottledCount += 1;
+			}
+			if (
+				sample.thermalState !== this.thermalLast &&
+				this.thermalTransitions.length < MAX_THERMAL_TRANSITIONS
+			) {
+				this.thermalTransitions.push({
+					atMs: sample.atMs,
+					state: sample.thermalState,
+				});
+			}
+			this.thermalLast = sample.thermalState;
+		}
+
+		if (typeof sample.lowPowerMode === "boolean") {
+			this.lowPowerSampleCount += 1;
+			if (sample.lowPowerMode) this.lowPowerEver = true;
+			if (
+				this.lowPowerLast !== null &&
+				this.lowPowerLast !== sample.lowPowerMode
+			)
+				this.lowPowerTransitions += 1;
+			this.lowPowerLast = sample.lowPowerMode;
+		}
+	}
+
+	private rssSummary(): RssSummary {
+		const n = this.rssSamples.length;
+		const firstMb = n > 0 ? (this.rssSamples[0] as number) : null;
+		const lastMb = n > 0 ? (this.rssSamples[n - 1] as number) : null;
+		const peakMb = n > 0 ? Math.max(...this.rssSamples) : null;
+		// Steady state = median of the back half (excludes cold-load ramp).
+		const backHalf =
+			n >= 2 ? this.rssSamples.slice(Math.floor(n / 2)) : this.rssSamples;
+		const steadyMb = median(backHalf);
+		const growthMb =
+			firstMb !== null && lastMb !== null ? lastMb - firstMb : null;
+		const threshold = this.opts.leakGrowthMbThreshold ?? DEFAULT_LEAK_GROWTH_MB;
+		let monotone = n >= 4;
+		for (let i = 1; i < n; i++) {
+			if ((this.rssSamples[i] as number) < (this.rssSamples[i - 1] as number)) {
+				monotone = false;
+				break;
+			}
+		}
+		const leakSuspected = monotone && growthMb !== null && growthMb > threshold;
+		return {
+			firstMb,
+			lastMb,
+			peakMb,
+			steadyMb,
+			samples: n,
+			growthMb,
+			leakSuspected,
+		};
+	}
+
+	private batterySummary(): BatterySummary {
+		const firstPct = this.firstBattery?.pct ?? null;
+		const lastPct = this.lastBattery?.pct ?? null;
+		const drainPct =
+			firstPct !== null && lastPct !== null ? firstPct - lastPct : null;
+		const energyMicroAmpHoursDelta =
+			this.firstChargeUah !== null && this.lastChargeUah !== null
+				? this.firstChargeUah - this.lastChargeUah
+				: null;
+		const durationMs =
+			this.firstBattery !== null && this.lastBattery !== null
+				? this.lastBattery.atMs - this.firstBattery.atMs
+				: null;
+		return {
+			firstPct,
+			lastPct,
+			drainPct,
+			samples: this.batterySampleCount,
+			chargingObserved: this.chargingObserved,
+			energyMicroAmpHoursDelta,
+			durationMs,
+		};
+	}
+
+	private thermalSummary(): ThermalSummary {
+		const fractionThrottled =
+			this.thermalKnownCount > 0
+				? this.thermalThrottledCount / this.thermalKnownCount
+				: null;
+		return {
+			samples: this.thermalSampleCount,
+			initialState: this.thermalInitial,
+			maxState: this.thermalMaxState,
+			transitions: [...this.thermalTransitions],
+			transitionCount: Math.max(0, this.thermalTransitions.length - 1),
+			fractionThrottled,
+		};
+	}
+
+	summary(): DeviceResourceSummary {
+		return {
+			generations: this.generations,
+			resourceSamples: this.resourceSamples,
+			prefillTokensPerSecond: this.prefillHist.summary(),
+			decodeTokensPerSecond: this.decodeHist.summary(),
+			combinedTokensPerSecond: this.combinedHist.summary(),
+			ttftMs: this.ttftHist.summary(),
+			rss: this.rssSummary(),
+			battery: this.batterySummary(),
+			thermal: this.thermalSummary(),
+			lowPowerMode: {
+				samples: this.lowPowerSampleCount,
+				everEnabled: this.lowPowerEver,
+				transitionCount: this.lowPowerTransitions,
+			},
+		};
+	}
+}

--- a/plugins/plugin-local-inference/src/services/index.ts
+++ b/plugins/plugin-local-inference/src/services/index.ts
@@ -44,7 +44,25 @@ export {
 	type LocalGenerateOutcome,
 	makeCloudFallbackHandler,
 } from "./cloud-fallback";
-export { type DeviceBridgeStatus, deviceBridge } from "./device-bridge";
+export {
+	buildDeviceResourceMetricsDevPayload,
+	type DeviceBridgeStatus,
+	type DeviceGenerationMetrics,
+	type DeviceResourceMetricsDevPayload,
+	deviceBridge,
+} from "./device-bridge";
+export {
+	type BatterySummary,
+	DeviceResourceMetrics,
+	type DeviceResourceSummary,
+	type DeviceThermalState,
+	type GenerationObservation,
+	type LowPowerSummary,
+	type ResourceSample,
+	type RssSummary,
+	type ThermalSummary,
+	type ThermalTransition,
+} from "./device-resource-metrics";
 export {
 	classifyDeviceTier,
 	DEVICE_TIER_ORDER,
@@ -74,6 +92,16 @@ export {
 	type ImageDescriptionRuntime,
 	type ImageDescriptionRuntimeOptions,
 } from "./image-description-runtime";
+export {
+	type CapabilityProbes,
+	defaultsForNoBinding,
+	type InferenceCapabilities,
+	probeCapabilities,
+	type ResourceSnapshot,
+	type ThermalState,
+	type ThermalThrottleDecision,
+	thermalThrottleDecision,
+} from "./inference-capabilities";
 export {
 	InferenceTelemetry,
 	inferenceTelemetry,

--- a/plugins/plugin-local-inference/src/services/inference-capabilities.test.ts
+++ b/plugins/plugin-local-inference/src/services/inference-capabilities.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+	defaultsForNoBinding,
+	probeCapabilities,
+	thermalThrottleDecision,
+} from "./inference-capabilities";
+
+describe("thermalThrottleDecision", () => {
+	it("does not throttle a cool device", () => {
+		const d = thermalThrottleDecision({ thermalState: "nominal" });
+		expect(d.throttleSpeculativeDecode).toBe(false);
+		expect(d.reduceLoad).toBe(false);
+	});
+
+	it("throttles speculative decode at serious and sheds load at critical", () => {
+		const serious = thermalThrottleDecision({ thermalState: "serious" });
+		expect(serious.throttleSpeculativeDecode).toBe(true);
+		expect(serious.reduceLoad).toBe(false);
+
+		const critical = thermalThrottleDecision({ thermalState: "critical" });
+		expect(critical.throttleSpeculativeDecode).toBe(true);
+		expect(critical.reduceLoad).toBe(true);
+	});
+
+	it("throttles under low-power mode even when cool", () => {
+		const d = thermalThrottleDecision({
+			thermalState: "nominal",
+			lowPowerMode: true,
+		});
+		expect(d.throttleSpeculativeDecode).toBe(true);
+		expect(d.reduceLoad).toBe(false);
+	});
+
+	it("does not throttle on an unknown thermal state without a low-power signal", () => {
+		const d = thermalThrottleDecision({ thermalState: "unknown" });
+		expect(d.throttleSpeculativeDecode).toBe(false);
+		expect(d.reduceLoad).toBe(false);
+	});
+
+	it("still honours low-power mode when thermal state is unknown", () => {
+		const d = thermalThrottleDecision({
+			thermalState: "unknown",
+			lowPowerMode: true,
+		});
+		expect(d.throttleSpeculativeDecode).toBe(true);
+	});
+});
+
+describe("probeCapabilities thermal gating (regression)", () => {
+	const probes = {
+		llmStreamSupported: () => true,
+		ttsStreamSupported: () => false,
+		mtpResident: () => true,
+		mmprojResident: () => false,
+		platform: () => "ios" as const,
+	};
+
+	it("keeps MTP on while cool but disables it under serious heat", () => {
+		expect(
+			probeCapabilities({ ...probes, thermalState: () => "fair" }).mtpSupported,
+		).toBe(true);
+		expect(
+			probeCapabilities({ ...probes, thermalState: () => "serious" })
+				.mtpSupported,
+		).toBe(false);
+	});
+
+	it("defaultsForNoBinding reports a safe all-off struct", () => {
+		const d = defaultsForNoBinding();
+		expect(d.streamingLlm).toBe(false);
+		expect(d.mtpSupported).toBe(false);
+		expect(d.thermalState).toBe("nominal");
+		expect(d.platform).toBe("unknown");
+	});
+});

--- a/plugins/plugin-local-inference/src/services/inference-capabilities.ts
+++ b/plugins/plugin-local-inference/src/services/inference-capabilities.ts
@@ -112,3 +112,93 @@ export function defaultsForNoBinding(): InferenceCapabilities {
 		platform: "unknown",
 	};
 }
+
+// ---------------------------------------------------------------------------
+// Sampled resource snapshot + thermal-throttle decision
+// ---------------------------------------------------------------------------
+
+/**
+ * A live, *sampled* device-resource snapshot from the native probe
+ * (iOS `getResourceSnapshot`, Android `ResourceProbe.getResourceSnapshot`) — as
+ * opposed to the one-shot `InferenceCapabilities` probe. The Mobile Resource
+ * Workbench (issue #8800) samples these on an interval across a sustained
+ * workload to build a thermal/RSS/battery timeline. Every numeric field is
+ * `null` when the platform could not measure it — never a fabricated zero.
+ */
+export interface ResourceSnapshot {
+	/** Current thermal state; `"unknown"` on platforms without a thermal API. */
+	thermalState: ThermalState | "unknown";
+	/** Whether the OS low-power / battery-saver mode is engaged, or null. */
+	lowPowerMode: boolean | null;
+	/** Process resident set size in MB, or null. */
+	residentMemoryMb: number | null;
+	/** Device-wide available RAM in MB, or null. */
+	availableRamMb: number | null;
+	/** Cumulative process CPU time in ms, or null. */
+	cpuTimeMs: number | null;
+	/** Battery level 0..100, or null. */
+	batteryLevelPct: number | null;
+	/** Sample timestamp in ms (epoch). */
+	capturedAtMs: number;
+}
+
+export interface ThermalThrottleDecision {
+	/**
+	 * Whether speculative decoding (MTP) should be disabled for the next step.
+	 * MTP burns extra compute for a latency win; under heat that trade flips.
+	 */
+	throttleSpeculativeDecode: boolean;
+	/**
+	 * Whether to proactively shed load (shrink batch / context, pause warmups)
+	 * because the device is at the top of the thermal range.
+	 */
+	reduceLoad: boolean;
+	reason: string;
+}
+
+const THROTTLE_SEVERITY: Record<ThermalState, number> = {
+	nominal: 0,
+	fair: 1,
+	serious: 2,
+	critical: 3,
+};
+
+/**
+ * Decide whether to throttle on-device inference for the current thermal /
+ * power state. Pure and synchronous so the streaming path can call it per token
+ * (the `ProcessInfo.thermalState` throttle hook the iOS streaming bridge still
+ * lists as a TODO) and the workbench can assert the policy without a device.
+ *
+ *   - `serious` / `critical` thermal → stop speculative decoding (matches the
+ *     existing one-shot MTP gate in `probeCapabilities`).
+ *   - `critical` thermal → additionally shed load.
+ *   - low-power mode → stop speculative decoding (honour the user's power intent).
+ *   - `unknown` thermal with no low-power signal → do not throttle (don't
+ *     penalise a device that simply lacks a thermal API).
+ */
+export function thermalThrottleDecision(input: {
+	thermalState: ThermalState | "unknown";
+	lowPowerMode?: boolean | null;
+}): ThermalThrottleDecision {
+	const lowPower = input.lowPowerMode === true;
+	if (input.thermalState === "unknown") {
+		return {
+			throttleSpeculativeDecode: lowPower,
+			reduceLoad: false,
+			reason: lowPower
+				? "low-power mode (thermal state unknown)"
+				: "thermal state unknown — no throttle",
+		};
+	}
+	const severity = THROTTLE_SEVERITY[input.thermalState];
+	const thermalThrottles = severity >= THROTTLE_SEVERITY.serious;
+	const reduceLoad = severity >= THROTTLE_SEVERITY.critical;
+	const throttleSpeculativeDecode = thermalThrottles || lowPower;
+	let reason: string;
+	if (reduceLoad) reason = `thermal ${input.thermalState} — shed load`;
+	else if (thermalThrottles)
+		reason = `thermal ${input.thermalState} — throttle speculative decode`;
+	else if (lowPower) reason = "low-power mode — throttle speculative decode";
+	else reason = `thermal ${input.thermalState} — nominal, no throttle`;
+	return { throttleSpeculativeDecode, reduceLoad, reason };
+}

--- a/plugins/plugin-local-inference/src/services/latency-trace.ts
+++ b/plugins/plugin-local-inference/src/services/latency-trace.ts
@@ -273,8 +273,12 @@ export interface HistogramSummary {
  * Bounded-sample running histogram for one derived metric. Keeps the last
  * `capacity` samples (FIFO) and computes percentiles on demand. Bounded so
  * a long-running process does not grow without limit.
+ *
+ * Exported so sibling accumulators (e.g. the Mobile Resource Workbench's
+ * `DeviceResourceMetrics`) reuse the same percentile logic instead of
+ * re-implementing it.
  */
-class BoundedHistogram {
+export class BoundedHistogram {
 	private readonly samples: number[] = [];
 	constructor(private readonly capacity: number) {}
 

--- a/plugins/plugin-local-inference/src/services/memory-monitor.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-monitor.test.ts
@@ -184,4 +184,25 @@ describe("MemoryMonitor", () => {
 		monitor.stop();
 		expect(monitor.isRunning()).toBe(false);
 	});
+
+	it("defaults serverRssMb to the real in-process RSS on the FFI path", async () => {
+		// No `serverRssMb` source injected → the default probe reads
+		// `process.memoryUsage().rss`, the in-process FFI host's resident set.
+		const registry = new SharedResourceRegistry();
+		const monitor = new MemoryMonitor({
+			registry,
+			config: { lowWaterMb: 768, lowWaterFraction: 0.08 },
+			sources: {
+				osMemory: () => ({
+					freeBytes: 8 * 1024 * MB,
+					totalBytes: 16 * 1024 * MB,
+				}),
+			},
+		});
+		const sample = await monitor.sample();
+		expect(sample.serverRssMb).not.toBeNull();
+		expect(sample.serverRssMb as number).toBeGreaterThan(0);
+		// The in-process RSS is bounded by total RAM (sanity, not a fabricated value).
+		expect(sample.serverRssMb as number).toBeLessThan(sample.totalMb);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/memory-monitor.ts
+++ b/plugins/plugin-local-inference/src/services/memory-monitor.ts
@@ -36,7 +36,12 @@ export interface MemoryMonitorLogger {
 export interface MemorySample {
 	totalMb: number;
 	freeMb: number;
-	/** External runtime RSS in MB when a host probe exposes it, else null. */
+	/**
+	 * Resident-set size in MB of the inference host. On the in-process FFI path
+	 * this is the current process's RSS (`process.memoryUsage().rss`); the
+	 * device-bridge path injects a phone-sourced figure. `null` only when no
+	 * probe could read it.
+	 */
 	serverRssMb: number | null;
 	/** Effective free memory used for the pressure decision (min of OS-free and total-minus-RSS-style headroom). */
 	effectiveFreeMb: number;
@@ -270,9 +275,22 @@ export class MemoryMonitor {
 }
 
 /**
- * Default RSS probe. The local text path is in-process FFI now, so there is no
- * server-side metrics endpoint to scrape.
+ * Default RSS probe for the in-process FFI path.
+ *
+ * Text inference now runs in-process via FFI llama.cpp, so the inference
+ * weights live in *this* process's address space — `process.memoryUsage().rss`
+ * is therefore the real resident-set high-water of the inference host, not a
+ * separate server to scrape. Returning it (instead of the old `null` stub) gives
+ * the monitor a genuine on-device RSS signal on desktop and on a phone running
+ * the agent in-process.
+ *
+ * The device-bridge topology (agent in a container, inference on a paired phone)
+ * is the exception: there the container process RSS is *not* the phone's, so
+ * that bootstrap injects a device-sourced `serverRssMb` via
+ * `MemoryMonitorSources` rather than using this default.
  */
 async function defaultServerRssMb(): Promise<number | null> {
-	return null;
+	const usage = process.memoryUsage?.();
+	if (!usage || !Number.isFinite(usage.rss)) return null;
+	return usage.rss / (1024 * 1024);
 }

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -784,8 +784,15 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
     let outputTokens = 0;
     let durationMs = 0;
     let lastError: string | null = null;
+    // Wall-clock time-to-first-token: from the call start to the first decoded
+    // token event. This is the on-device prefill wall-clock the resource
+    // workbench differences into prefill vs decode throughput. Stays undefined
+    // when the generation yields no tokens.
+    const startedAt = Date.now();
+    let ttftMs: number | undefined;
     for await (const event of this.generateStream(options)) {
       if (event.kind === "token") {
+        if (ttftMs === undefined) ttftMs = Date.now() - startedAt;
         text += event.text;
       } else if (event.kind === "telemetry") {
         // Native bridge currently emits no telemetry events; ignored here
@@ -818,6 +825,7 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
       promptTokens,
       outputTokens,
       durationMs,
+      ...(ttftMs !== undefined ? { ttftMs } : {}),
     };
   }
 
@@ -977,7 +985,9 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
     if (level === "major") {
       this.tokenListeners.clear();
     }
-    console.debug(`[capacitor-llama] trimMemory(${level}) — bridge hook unavailable`);
+    console.debug(
+      `[capacitor-llama] trimMemory(${level}) — bridge hook unavailable`,
+    );
   }
 
   async cancelGenerate(): Promise<void> {

--- a/plugins/plugin-native-llama/src/definitions.ts
+++ b/plugins/plugin-native-llama/src/definitions.ts
@@ -61,6 +61,13 @@ export interface GenerateResult {
   promptTokens: number;
   outputTokens: number;
   durationMs: number;
+  /**
+   * Time-to-first-token in ms — wall-clock from the generate() call to the
+   * first decoded token event. Equals the on-device prefill wall-clock, so the
+   * agent can difference prefill vs decode throughput. Omitted when no token
+   * was observed (empty generation).
+   */
+  ttftMs?: number;
 }
 
 /**

--- a/plugins/plugin-native-llama/src/device-bridge-client.ts
+++ b/plugins/plugin-native-llama/src/device-bridge-client.ts
@@ -109,6 +109,8 @@ type DeviceOutbound =
       promptTokens: number;
       outputTokens: number;
       durationMs: number;
+      /** Time-to-first-token (ms) when the device measured it; prefill wall-clock. */
+      ttftMs?: number;
     }
   | { type: "generateResult"; correlationId: string; ok: false; error: string }
   | {
@@ -429,9 +431,7 @@ export class DeviceBridgeClient {
           ...(typeof lowPowerMode === "boolean" ? { lowPowerMode } : {}),
           ...(thermalState ? { thermalState } : {}),
           mtpSupported: hardware.mtpSupported,
-          ...(hardware.mtpReason
-            ? { mtpReason: hardware.mtpReason }
-            : {}),
+          ...(hardware.mtpReason ? { mtpReason: hardware.mtpReason } : {}),
         },
         loadedPath: loaded.modelPath,
       },
@@ -526,6 +526,9 @@ export class DeviceBridgeClient {
           promptTokens: result.promptTokens,
           outputTokens: result.outputTokens,
           durationMs: result.durationMs,
+          ...(typeof result.ttftMs === "number"
+            ? { ttftMs: result.ttftMs }
+            : {}),
         });
       } catch (err) {
         this.send(ws, {

--- a/plugins/plugin-native-llama/src/generate-stream.test.ts
+++ b/plugins/plugin-native-llama/src/generate-stream.test.ts
@@ -169,6 +169,10 @@ describe("CapacitorLlamaAdapter.generateStream", () => {
     expect(result.promptTokens).toBe(2);
     expect(result.outputTokens).toBe(2);
     expect(result.durationMs).toBe(30);
+    // TTFT (wall-clock to first token) is captured for prefill/decode
+    // differencing once at least one token has been observed.
+    expect(typeof result.ttftMs).toBe("number");
+    expect(result.ttftMs as number).toBeGreaterThanOrEqual(0);
   });
 
   it("accepts samplerStages without throwing while native bridge support is pending", async () => {


### PR DESCRIPTION
Closes #8800.

## Mobile Resource Workbench

End-to-end on-device resource profiling for elizaOS local inference on **iOS + Android** — battery, peak/steady RSS, prefill/decode tokens/sec, TTFT, thermal-state timeline, and low-power transitions — built on the proven `loadperf` budgets/results/CI-gate pattern. `loadperf` measures host load; this measures the *phone*.

### Acceptance criteria

- [x] iOS native probe returns a **live** resource snapshot (resident `phys_footprint`, available RAM via `os_proc_available_memory`, thermal state, low-power mode, CPU time) — not the one-shot `getDeviceCapabilities` with `availableRamGb: NSNull()`.
- [x] iOS **MetricKit** (`MXMetricManager`) payloads (CPU/energy/runtime) captured to disk and ingested by the harness.
- [x] Android exposes a `ResourceProbe.getResourceSnapshot` Capacitor method (parity with iOS): thermal status, `BatteryManager` level/charge-counter, `Debug.getMemoryInfo` PSS; `dumpsys` hooks in the host probe.
- [x] Per-generation **prefill and decode tokens/sec** computed from the on-device `generateResult` (`durationMs`/token counts + measured TTFT) and aggregated per workload, per tier.
- [x] **Peak and steady RSS** recorded on-device with an RSS-leak flag (reused leak heuristic).
- [x] **TTFT** recorded on-device (text now; voice loop wired, tied to #8785/#8786).
- [x] **Battery drain** (% and, where available, µAh) across a fixed-duration workload.
- [x] **Thermal-state timeline** + low-power transitions across a sustained run (not a single probe).
- [x] CPU/GPU/ANE/NPU utilisation captured where the OS exposes it (MetricKit / batterystats), else explicitly recorded as missing — never faked.
- [x] `budgets.json` + `BASELINE.md` per device-class × tier (`0_8b`/`2b`/`4b`); runner writes `results/<workload>/latest.json` + a report and exits non-zero on budget regression.
- [x] `workflow_dispatch` (+ nightly) CI job: PR-path-filtered harness smoke + dispatch-only Android (self-hosted arm64) / iOS-sim lanes, uploading the report; kept off PR-blocking lanes until baselines are stable.
- [x] Missing measurements recorded as null/missing, never fabricated zeros (AGENTS.md §3/§7).

### What changed

**Shared / runtime (unit-tested):**
- `@elizaos/shared/local-inference` `computeGenerationThroughput` — differences `generateResult` into prefill/decode/combined tok/s (TTFT split); `null` when unmeasurable.
- Capacitor adapter captures first-token wall-clock (TTFT) → relayed through both hand-synced `device-bridge` copies → surfaced via `subscribeGenerationMetrics` + a recent-metrics buffer + `GET /api/dev/device-resource-metrics`.
- `DeviceResourceMetrics` accumulator generalises `VoiceRunMetrics` (tok/s, RSS+leak, battery, thermal timeline, low-power).
- `memory-monitor` reports real in-process RSS (`process.memoryUsage().rss`) on the FFI path (was a `null` stub).
- `inference-capabilities` adds a sampled `ResourceSnapshot` type + pure `thermalThrottleDecision()` policy.

**Native probes:** iOS `ElizaIntent.getResourceSnapshot` + MetricKit sink; Android `ResourceProbePlugin` (registered in both app trees). JS bridge accessor + normaliser.

**Workbench (`packages/benchmarks/mobile-resource/`):** runner + workloads (cold-load / single-turn / sustained-chat / voice-loop), adb/simctl probes, per-tier budgets, report, and `node --test` unit tests for the aggregation + budget logic.

### Testing

- `node --test packages/benchmarks/mobile-resource/metrics.test.mjs` — 7/7.
- New vitest suites: shared throughput (8), DeviceResourceMetrics (2), memory-monitor (+1), inference-capabilities (7), resource-snapshot normaliser (5), adapter TTFT (generate-stream). All green, plus 131 shared local-inference + plugin consumer suites unaffected.
- Typecheck clean for all touched code (`@elizaos/shared`, `plugin-native-llama`, `app-core` exit 0; `plugin-local-inference` has only the unrelated pre-existing `csstype`/`packages/ui` local-install artifact).

### Notes
- Native Swift/Java probes are device-CI-gated (can't compile in a headless lane); the CI device lanes are `workflow_dispatch`-only on the self-hosted pool.
- Most `budgets.json` budgets start `null` (no baseline yet) — recorded but never failing; `maxPeakRssMb`/`maxSteadyRssMb` are provisional caps derived from tier footprint (documented in `BASELINE.md`). Ratchet in as physical-device baselines land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
