### PR TITLE
perf(core): harden evaluator schema-memo against transient 400s (follow-up to #8803)

### DIFF
--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -347,10 +347,7 @@ describe("EvaluatorService", () => {
 		);
 	});
 
-	it("skips the schema attempt on later turns once the provider rejects it", async () => {
-		const runtime = makeRuntime();
-		const processed: string[] = [];
-
+	const registerOkEvaluator = (runtime: AgentRuntime): void => {
 		runtime.registerEvaluator({
 			name: "ok",
 			description: "ok section",
@@ -361,20 +358,55 @@ describe("EvaluatorService", () => {
 			processors: [
 				{
 					name: "storeOk",
-					process: async () => {
-						processed.push("ok");
-						return { success: true };
-					},
+					process: async () => ({ success: true }),
 				},
 			],
 		});
+	};
+
+	it("arms the schema skip after repeated generic rejections", async () => {
+		const runtime = makeRuntime();
+		registerOkEvaluator(runtime);
 
 		const useModel = vi
 			.fn()
-			// Turn 1: schema rejected, json_object succeeds (the existing fallback).
+			// Turn 1: generic 400 (streak 1, not yet armed) → json_object succeeds.
 			.mockRejectedValueOnce(new Error("Bad Request"))
 			.mockResolvedValueOnce({ ok: { ok: true } })
-			// Turn 2: must go straight to json_object — no doomed schema attempt.
+			// Turn 2: generic 400 again (streak 2 → arm) → json_object succeeds.
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce({ ok: { ok: true } })
+			// Turn 3: armed → straight to json_object, no schema attempt.
+			.mockResolvedValueOnce({ ok: { ok: true } });
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const service = new EvaluatorService(runtime);
+		await service.run(makeMessage());
+		await service.run(makeMessage());
+		await service.run(makeMessage());
+
+		// Turns 1 & 2 each attempt the schema (2 calls); turn 3 skips it (1 call).
+		expect(useModel).toHaveBeenCalledTimes(5);
+		expect(useModel.mock.calls[0]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[2]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[4]?.[1]).not.toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[4]?.[1]?.responseFormat).toEqual({
+			type: "json_object",
+		});
+	});
+
+	it("arms the schema skip immediately on an explicit schema rejection", async () => {
+		const runtime = makeRuntime();
+		registerOkEvaluator(runtime);
+
+		const useModel = vi
+			.fn()
+			// Turn 1: provider names the schema as the problem → arm immediately.
+			.mockRejectedValueOnce(
+				new Error("json_schema response_format is unsupported"),
+			)
+			.mockResolvedValueOnce({ ok: { ok: true } })
+			// Turn 2: armed → straight to json_object.
 			.mockResolvedValueOnce({ ok: { ok: true } });
 		runtime.useModel = useModel as AgentRuntime["useModel"];
 
@@ -382,15 +414,36 @@ describe("EvaluatorService", () => {
 		await service.run(makeMessage());
 		await service.run(makeMessage());
 
-		// Turn 1 = 2 calls (schema + json_object); turn 2 = 1 call (json_object).
+		// Schema-specific rejection arms after a single turn (no streak needed).
 		expect(useModel).toHaveBeenCalledTimes(3);
 		expect(useModel.mock.calls[0]?.[1]).toHaveProperty("responseSchema");
-		expect(useModel.mock.calls[1]?.[1]).not.toHaveProperty("responseSchema");
-		// The whole point: turn 2 never re-sends the doomed schema.
 		expect(useModel.mock.calls[2]?.[1]).not.toHaveProperty("responseSchema");
-		expect(useModel.mock.calls[2]?.[1]?.responseFormat).toEqual({
-			type: "json_object",
-		});
-		expect(processed).toEqual(["ok", "ok"]);
+	});
+
+	it("does not arm on a one-off generic rejection that later succeeds", async () => {
+		const runtime = makeRuntime();
+		registerOkEvaluator(runtime);
+
+		const useModel = vi
+			.fn()
+			// Turn 1: transient generic 400 (streak 1) → json_object succeeds.
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce({ ok: { ok: true } })
+			// Turn 2: schema SUCCEEDS → streak resets.
+			.mockResolvedValueOnce({ ok: { ok: true } })
+			// Turn 3: another lone generic 400 (streak back to 1, still not armed).
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce({ ok: { ok: true } });
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const service = new EvaluatorService(runtime);
+		await service.run(makeMessage());
+		await service.run(makeMessage());
+		await service.run(makeMessage());
+
+		// The transient blip never sticks: turns 2 and 3 still attempt the schema.
+		expect(useModel).toHaveBeenCalledTimes(5);
+		expect(useModel.mock.calls[2]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[3]?.[1]).toHaveProperty("responseSchema");
 	});
 });

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -175,6 +175,25 @@ function schemaRequestLooksUnsupported(error: unknown): boolean {
 	);
 }
 
+// A HIGH-CONFIDENCE signal that the provider STRUCTURALLY rejects schema-
+// constrained output (vs a generic/transient HTTP 400 that merely says "bad
+// request" — rate-limit, malformed prompt, context length, gateway blip). Only
+// a schema-specific rejection like this should arm the lifetime memo on its
+// own; a bare "bad request" still falls back for the turn but is re-attempted
+// next turn so a one-off blip cannot permanently downgrade a schema-capable
+// provider.
+function schemaRejectionLooksPersistent(error: unknown): boolean {
+	const message = (
+		error instanceof Error ? error.message : String(error ?? "")
+	).toLowerCase();
+	return (
+		message.includes("response schema") ||
+		message.includes("responseschema") ||
+		message.includes("json_schema") ||
+		message.includes("structured output")
+	);
+}
+
 // Once a runtime's SMALL model rejects a structured `responseSchema` request,
 // every subsequent request will be rejected the same way — the provider simply
 // does not support schema-constrained output (e.g. the cerebras gpt-oss path on
@@ -183,7 +202,15 @@ function schemaRequestLooksUnsupported(error: unknown): boolean {
 // waste on every turn. Remember the rejection per runtime and, from then on,
 // skip straight to the json_object request. Keyed by the live runtime instance
 // (a WeakSet, so it never leaks across agents).
+//
+// The memo is armed conservatively (see below): a schema-specific rejection
+// arms it immediately, but a bare/generic "bad request" must recur
+// `SCHEMA_UNSUPPORTED_STREAK_THRESHOLD` times in a row — any schema SUCCESS in
+// between resets the streak — so a transient 400 self-heals instead of
+// permanently downgrading a genuinely schema-capable provider.
 const schemaUnsupportedRuntimes = new WeakSet<object>();
+const schemaRejectionStreak = new WeakMap<object, number>();
+const SCHEMA_UNSUPPORTED_STREAK_THRESHOLD = 2;
 
 async function generateEvaluationOutput(params: {
 	runtime: IAgentRuntime;
@@ -229,17 +256,36 @@ async function generateEvaluationOutput(params: {
 	}
 
 	try {
-		return await runtime.useModel(ModelType.TEXT_SMALL, {
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
 			messages,
 			responseSchema: schema,
 			responseFormat: { type: "json_object" },
 			temperature: 0,
 		});
+		// Schema worked this turn — clear any prior rejection streak so a stray
+		// earlier 400 never accumulates toward a permanent downgrade.
+		schemaRejectionStreak.delete(runtime);
+		return result;
 	} catch (error) {
 		if (!schemaRequestLooksUnsupported(error)) throw error;
-		// Provider does not support schema-constrained output — remember it so
-		// every subsequent turn skips the schema attempt entirely.
-		schemaUnsupportedRuntimes.add(runtime);
+		// Decide whether this rejection is structural enough to PERMANENTLY skip
+		// the schema attempt from now on. A schema-specific message arms the memo
+		// immediately; a generic "bad request" must recur THRESHOLD times in a row
+		// (a single transient blip self-heals on the next schema success).
+		const streak = (schemaRejectionStreak.get(runtime) ?? 0) + 1;
+		schemaRejectionStreak.set(runtime, streak);
+		if (
+			!schemaUnsupportedRuntimes.has(runtime) &&
+			(schemaRejectionLooksPersistent(error) ||
+				streak >= SCHEMA_UNSUPPORTED_STREAK_THRESHOLD)
+		) {
+			schemaUnsupportedRuntimes.add(runtime);
+			// WARN (not debug) so an erroneous permanent downgrade is observable.
+			runtime.logger.warn(
+				{ src: "service:evaluator", streak },
+				"Post-turn evaluator: provider rejected schema-constrained output; disabling schema requests for this runtime (json_object fallback)",
+			);
+		}
 		runtime.logger.debug(
 			{ src: "service:evaluator" },
 			"Post-turn evaluator schema request rejected; retrying JSON-object fallback",


### PR DESCRIPTION
Follow-up hardening to #8803 (the evaluator schema-memo, merged to develop as `028b969454`). An adversarial pre-deploy review of the merged change surfaced a real edge case that the original review treated as behavior-preserving:

**Problem:** `schemaRequestLooksUnsupported` matches the bare substring `"bad request"` — the generic text of most HTTP 400s (rate-limit, malformed prompt, context length, gateway blip). The memo (`schemaUnsupportedRuntimes`) arms on the *first* such error and is **permanent** for the runtime's life with no recovery path. So a single transient 400 on a genuinely schema-capable provider silently downgrades it to the `json_object` path until the process restarts — a regression vs the old per-turn-retry behavior (which self-healed next turn).

**Fix (message-agnostic, so it can't break the Cerebras win):**
- A schema-*specific* rejection (`json_schema` / `response schema` / `structured output`) arms the memo immediately.
- A generic `"bad request"` only arms after `SCHEMA_UNSUPPORTED_STREAK_THRESHOLD` (2) **consecutive** rejections; any schema success in between resets the streak — so a one-off blip self-heals.
- Arming now logs at **WARN** (not debug) so an erroneous permanent downgrade is observable in prod.

The per-turn `json_object`/plain fallback is unchanged (still fires on any `"bad request"`). Cerebras gpt-oss rejects every turn, so it arms on turn 2 and the latency win holds.

**Tests:** evaluator.test.ts now covers immediate-arm (schema-token), streak-arm (2 consecutive generic), and transient self-heal. Core tests 8/8, core typecheck clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)