### PR TITLE
fix(scenario-runner): seed first-run complete so the deterministic lane is order-independent (#8801)

### DIFF
--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -479,6 +479,18 @@ export async function createScenarioRuntime(
   await seedBenchmarkLifeOpsFixtures(runtime);
   await seedLifeOpsSimulatorRuntime(runtime);
 
+  // Deterministic scenarios share one runtime; seed first-run as already
+  // complete so the firstRun provider stays silent and action-routing is
+  // order-independent. Without this, scenarios run in --lane discovery order
+  // can see a "first-run pending" planner context the strict fixtures do not
+  // cover (e.g. deterministic-xr-view-actions when it runs last).
+  await runtime.setCache("eliza:lifeops:first-run:v1", {
+    status: "complete",
+    partialAnswers: {},
+    completionCount: 1,
+    completedAt: "1970-01-01T00:00:00.000Z",
+  });
+
   // Remove upstream actions that reliably steal action-selection from the
   // domain actions scenarios actually care about. UPDATE_ENTITY's description
   // ("Add or edit contact details for a person you are talking to or


### PR DESCRIPTION
The #8801 substrate (mock-LLM harness, negative pack, provider wire-mocks, full scenario lane-tagging + `--lane` PR lane, per-plugin coverage gate, drift tests, connector loop) has **already landed on `develop`**. This PR is now the **focused follow-up fix** for the one regression that landing surfaced.

## Problem
`test:deterministic:e2e` now selects by `--lane pr-deterministic`, which runs the deterministic PR scenarios in discovery (alphabetical) order rather than the old hand-curated `--scenario` order. The deterministic lane shares one runtime, and the lifeops `firstRun` provider injects a "first-run setup hasn't run yet" planner context until first-run completes. In the new order `deterministic-xr-view-actions` runs last with first-run still pending, so its `ACTION_PLANNER` call carries the first-run context and misses the strict `XR_QUERY_VISION` fixture (`deterministic LLM proxy fixture registry has no fixture for this call`) — the lone failure in an otherwise 16/17 run.

## Fix
Seed the first-run cache (`eliza:lifeops:first-run:v1`) to `complete` once in `createScenarioRuntime`, so the `firstRun` provider stays silent and scenario action-routing is order-independent regardless of selection order. These are action-routing scenarios; none rely on first-run being pending.

## Scope note
`develop`'s CI currently has unrelated, in-flight breakages (app-browser UI smoke lanes, etc.) being repaired separately — those are not #8801 and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
