### PR TITLE
fix(ui): surface the cloud-agent handoff result + lifecycle copy

### DIFF
--- a/packages/ui/src/browser.ts
+++ b/packages/ui/src/browser.ts
@@ -104,6 +104,7 @@ export { SettingsControls } from "./components/ui/settings-controls.tsx";
 export { Skeleton } from "./components/ui/skeleton.tsx";
 export { Spinner } from "./components/ui/spinner.tsx";
 export {
+  agentLifecycleLabel,
   statusLabelForState,
   statusToneForState,
 } from "./components/ui/status-badge.helpers.ts";

--- a/packages/ui/src/components/ui/status-badge.helpers.test.ts
+++ b/packages/ui/src/components/ui/status-badge.helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentLifecycleLabel,
+  statusLabelForState,
+} from "./status-badge.helpers";
+
+describe("statusLabelForState", () => {
+  it("title-cases the raw enum (dev/admin console copy)", () => {
+    expect(statusLabelForState("resuming")).toBe("Resuming");
+    expect(statusLabelForState("suspended")).toBe("Suspended");
+    expect(statusLabelForState("provisioning")).toBe("Provisioning");
+    expect(statusLabelForState("agent_delete")).toBe("Agent Delete");
+  });
+
+  it("returns the original string when empty/whitespace", () => {
+    expect(statusLabelForState("")).toBe("");
+    expect(statusLabelForState("   ")).toBe("   ");
+  });
+});
+
+describe("agentLifecycleLabel", () => {
+  it("maps lifecycle states to friendly first-run/handoff copy", () => {
+    // The raw DB enum must not leak to users during onboarding.
+    expect(agentLifecycleLabel("resuming")).toBe("Starting up");
+    expect(agentLifecycleLabel("starting")).toBe("Starting up");
+    expect(agentLifecycleLabel("provisioning")).toBe("Setting up");
+    expect(agentLifecycleLabel("suspended")).toBe("Asleep");
+    expect(agentLifecycleLabel("sleeping")).toBe("Asleep");
+    expect(agentLifecycleLabel("running")).toBe("Ready");
+    expect(agentLifecycleLabel("failed")).toBe("Failed to start");
+  });
+
+  it("is case-insensitive", () => {
+    expect(agentLifecycleLabel("RUNNING")).toBe("Ready");
+    expect(agentLifecycleLabel("  Provisioning  ")).toBe("Setting up");
+  });
+
+  it("falls back to the title-cased label for non-lifecycle states", () => {
+    // Steward transaction states (broadcast/confirmed/signed) must keep their
+    // own labels — agentLifecycleLabel must not clobber them.
+    expect(agentLifecycleLabel("broadcast")).toBe("Broadcast");
+    expect(agentLifecycleLabel("confirmed")).toBe("Confirmed");
+    expect(agentLifecycleLabel("totally-unknown")).toBe("Totally Unknown");
+  });
+});

--- a/packages/ui/src/components/ui/status-badge.helpers.ts
+++ b/packages/ui/src/components/ui/status-badge.helpers.ts
@@ -54,3 +54,34 @@ export function statusLabelForState(status: string): string {
   if (!normalized) return status;
   return normalized.replace(/\b\w/g, (match) => match.toUpperCase());
 }
+
+/**
+ * Product copy for cloud-agent *lifecycle* states on user-facing first-run /
+ * handoff surfaces. `statusLabelForState` just title-cases the raw DB enum
+ * (fine for dev/admin consoles, weak as onboarding copy — users should not see
+ * "Resuming"/"Suspended"/"Provisioning" verbatim). This maps the lifecycle
+ * enum to friendly copy and falls back to the title-cased label for anything
+ * unknown, so it is safe to use anywhere `statusLabelForState` is used for an
+ * agent status. It is intentionally separate from `statusLabelForState` so
+ * non-lifecycle consumers (e.g. steward transaction states like
+ * "broadcast"/"confirmed") keep their own labels.
+ */
+const AGENT_LIFECYCLE_LABELS: Record<string, string> = {
+  running: "Ready",
+  ready: "Ready",
+  provisioning: "Setting up",
+  starting: "Starting up",
+  resuming: "Starting up",
+  stopping: "Stopping",
+  suspending: "Pausing",
+  suspended: "Asleep",
+  sleeping: "Asleep",
+  stopped: "Stopped",
+  error: "Failed to start",
+  failed: "Failed to start",
+};
+
+export function agentLifecycleLabel(status: string): string {
+  const normalized = status.trim().toLowerCase();
+  return AGENT_LIFECYCLE_LABELS[normalized] ?? statusLabelForState(status);
+}

--- a/packages/ui/src/events/cloud-handoff-phase.test.ts
+++ b/packages/ui/src/events/cloud-handoff-phase.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLOUD_HANDOFF_PHASE_EVENT,
+  type CloudHandoffPhaseDetail,
+  dispatchCloudHandoffPhase,
+} from "./index";
+
+describe("dispatchCloudHandoffPhase", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function capture(): CloudHandoffPhaseDetail[] {
+    const seen: CloudHandoffPhaseDetail[] = [];
+    window.addEventListener(CLOUD_HANDOFF_PHASE_EVENT, (event) => {
+      seen.push((event as CustomEvent<CloudHandoffPhaseDetail>).detail);
+    });
+    return seen;
+  }
+
+  it("emits the in-flight migrating phase", () => {
+    const seen = capture();
+    dispatchCloudHandoffPhase({ agentId: "agent-1", phase: "migrating" });
+    expect(seen).toEqual([{ agentId: "agent-1", phase: "migrating" }]);
+  });
+
+  it("carries the imported count on a successful switch", () => {
+    const seen = capture();
+    dispatchCloudHandoffPhase({
+      agentId: "agent-1",
+      phase: "switched",
+      imported: 3,
+    });
+    expect(seen[0]).toEqual({
+      agentId: "agent-1",
+      phase: "switched",
+      imported: 3,
+    });
+  });
+
+  it("carries the error on a failed handoff (no longer silently discarded)", () => {
+    const seen = capture();
+    dispatchCloudHandoffPhase({
+      agentId: "agent-1",
+      phase: "failed",
+      error: "container import failed (HTTP 500)",
+    });
+    expect(seen[0]).toEqual({
+      agentId: "agent-1",
+      phase: "failed",
+      error: "container import failed (HTTP 500)",
+    });
+  });
+
+  it("surfaces every terminal handoff status as a distinct phase", () => {
+    const seen = capture();
+    for (const phase of [
+      "switched",
+      "switched-empty",
+      "timed-out",
+      "failed",
+    ] as const) {
+      dispatchCloudHandoffPhase({ agentId: "agent-1", phase });
+    }
+    expect(seen.map((d) => d.phase)).toEqual([
+      "switched",
+      "switched-empty",
+      "timed-out",
+      "failed",
+    ]);
+  });
+});

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -66,6 +66,41 @@ export const FIRST_RUN_VOICE_PREVIEW_AWAIT_TELEPORT_EVENT =
 // ── Sidebar sync ─────────────────────────────────────────────────────────
 export const SELF_STATUS_SYNC_EVENT = "eliza:self-status-refresh" as const;
 
+// ── Shared → dedicated cloud-agent handoff ───────────────────────────────
+/**
+ * First-run provisions a personal cloud agent and lands the user in chat on the
+ * shared REST adapter while the dedicated container boots; a background
+ * supervisor then copies the conversation into the container and swaps the live
+ * client over. That swap used to be silent (`.catch(() => {})`). This event is
+ * the typed seam onto which the handoff's lifecycle is surfaced so chat-state /
+ * a progress indicator can render it instead of the user seeing nothing.
+ */
+export const CLOUD_HANDOFF_PHASE_EVENT = "eliza:cloud-handoff-phase" as const;
+
+/**
+ * `migrating` — personal container is provisioning; user is on the shared
+ * adapter. `switched` — conversation copied and the live client moved to the
+ * dedicated container (`switched-empty` when there was nothing to copy yet).
+ * `timed-out` / `failed` — the container never became ready (or an I/O step
+ * threw); the user safely stays on the working shared adapter. Mirrors
+ * `ConversationHandoffStatus` plus the `migrating` in-flight phase.
+ */
+export type CloudHandoffPhase =
+  | "migrating"
+  | "switched"
+  | "switched-empty"
+  | "timed-out"
+  | "failed";
+
+export interface CloudHandoffPhaseDetail {
+  agentId: string;
+  phase: CloudHandoffPhase;
+  /** Messages copied into the dedicated container on `switched`. */
+  imported?: number;
+  /** Error message on `failed`. */
+  error?: string;
+}
+
 // ── Tutorial ─────────────────────────────────────────────────────────────
 /**
  * The interactive tour drives the floating chat into a known state at the start
@@ -137,7 +172,8 @@ export type ElizaWindowEventName =
   | typeof VRM_TELEPORT_COMPLETE_EVENT
   | typeof FIRST_RUN_VOICE_PREVIEW_AWAIT_TELEPORT_EVENT
   | typeof SELF_STATUS_SYNC_EVENT
-  | typeof TUTORIAL_CHAT_CONTROL_EVENT;
+  | typeof TUTORIAL_CHAT_CONTROL_EVENT
+  | typeof CLOUD_HANDOFF_PHASE_EVENT;
 
 export type ElizaEventName = ElizaDocumentEventName | ElizaWindowEventName;
 
@@ -169,6 +205,17 @@ export function dispatchElizaCloudStatusUpdated(
   detail: ElizaCloudStatusUpdatedDetail,
 ): void {
   dispatchWindowEvent(ELIZA_CLOUD_STATUS_UPDATED_EVENT, detail);
+}
+
+/**
+ * Surface a shared→dedicated handoff phase. Replaces the silent
+ * `startCloudAgentHandoff(...).catch(() => {})` discard so the typed
+ * {@link ConversationHandoffResult} reaches the UI.
+ */
+export function dispatchCloudHandoffPhase(
+  detail: CloudHandoffPhaseDetail,
+): void {
+  dispatchWindowEvent(CLOUD_HANDOFF_PHASE_EVENT, detail);
 }
 
 export function readPendingFocusConnector(): string | null {

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -8,6 +8,7 @@ import {
 import type { CloudCompatAgent } from "../api/client-types-cloud";
 import { getDesktopRuntimeMode, invokeDesktopBridgeRequest } from "../bridge";
 import { getBootConfig } from "../config/boot-config";
+import { dispatchCloudHandoffPhase } from "../events";
 import {
   canSelectLocalRuntime,
   isAndroid,
@@ -780,12 +781,18 @@ export function useFirstRunController(): FirstRunController {
       // no lost history. Best-effort: on failure the user stays on the shared
       // adapter, which keeps working.
       if (selectedAgent.created && !selectedAgent.bridgeUrl) {
+        const handoffAgentId = selectedAgent.agentId;
+        // Tell the UI a migration is in flight instead of swapping silently.
+        dispatchCloudHandoffPhase({
+          agentId: handoffAgentId,
+          phase: "migrating",
+        });
         void client
           .startCloudAgentHandoff({
-            agentId: selectedAgent.agentId,
+            agentId: handoffAgentId,
             sharedApiBase: cloudAgentApiBase,
             // The shared adapter keeps one canonical conversation per agent id.
-            conversationId: selectedAgent.agentId,
+            conversationId: handoffAgentId,
             cloudApiBase:
               getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
             authToken,
@@ -794,7 +801,7 @@ export function useFirstRunController(): FirstRunController {
               client.setToken(authToken);
               const switched = createPersistedActiveServer({
                 kind: "cloud",
-                id: `cloud:${selectedAgent.agentId}`,
+                id: `cloud:${handoffAgentId}`,
                 apiBase: containerBase,
                 accessToken: authToken,
               });
@@ -808,8 +815,25 @@ export function useFirstRunController(): FirstRunController {
               switchAgentProfile(profile.id);
             },
           })
-          .catch(() => {
-            // Handoff is best-effort; the shared adapter remains usable.
+          // Stop discarding the ConversationHandoffResult: surface each terminal
+          // status (switched | switched-empty | timed-out | failed) as a typed
+          // handoff phase so the UI can render real progress and an honest
+          // failure notice. Still best-effort — the shared adapter keeps working
+          // regardless of outcome.
+          .then((result) => {
+            dispatchCloudHandoffPhase({
+              agentId: handoffAgentId,
+              phase: result.status,
+              imported: result.imported,
+              ...(result.error ? { error: result.error } : {}),
+            });
+          })
+          .catch((err: unknown) => {
+            dispatchCloudHandoffPhase({
+              agentId: handoffAgentId,
+              phase: "failed",
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
       }
     },


### PR DESCRIPTION
## What

Foundation for #8810 — stops the shared→dedicated cloud-agent handoff from being **silently discarded**, and lands the typed seam + product-copy helper the rest of the issue builds on.

Today first-run fires `client.startCloudAgentHandoff(...).catch(() => {})` (`use-first-run-controller.ts`) and throws away the rich `ConversationHandoffResult` (`switched | switched-empty | timed-out | failed` + `imported` count), so the migration from the shared adapter to the user's dedicated container is invisible — including when it times out or fails.

## Changes

- **`events/index.ts`** — new typed `CLOUD_HANDOFF_PHASE_EVENT` + `CloudHandoffPhase` / `CloudHandoffPhaseDetail` + `dispatchCloudHandoffPhase()`. The typed seam the handoff lifecycle is surfaced onto.
- **`first-run/use-first-run-controller.ts`** — dispatch `migrating` before the handoff, then map each terminal status onto the event instead of `.catch(() => {})`. Still best-effort (the shared adapter stays usable on any outcome).
- **`components/ui/status-badge.helpers.ts`** — new `agentLifecycleLabel()` (`resuming` → "Starting up", `provisioning` → "Setting up", …). Deliberately **separate** from `statusLabelForState` so `plugin-steward-app` transaction labels (`broadcast`/`confirmed`) are not clobbered; falls back to it for unknown states.
- Tests for the event seam and the lifecycle label map (incl. the steward-fallback case).

## Scope / follow-ups

This is the **decision-independent** slice. Explicitly **NOT** in this PR (gated on #8810's open questions):
- the UI consumer that renders the progress (`parsers.ts` / `useLifecycleState`) + swapping the label call-sites;
- picking ONE auth model and deleting the other — `pairDedicatedCloudAgent` has **zero non-test callers**, but the delete is a maintainer call;
- delete-or-rebrand of the orphaned, off-brand `ProvisioningChatView`.

## Test

`bun run --cwd packages/ui test` — handoff-supervisor + conversation-handoff + CloudAgentsSection + the 2 new suites green (43 tests in the touched scope). Biome clean. **No credentials needed.** Auth paths and `ProvisioningChatView` untouched.

Part of #8810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
