### PR TITLE
feat(cli-inference): claude --print / codex exec chat model-provider (subscription via the sanctioned CLI)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3307,6 +3307,22 @@
         "vitest": "^4.0.18",
       },
     },
+    "plugins/plugin-cli-inference": {
+      "name": "@elizaos/plugin-cli-inference",
+      "version": "2.0.3-beta.0",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
+        "@elizaos/core": "workspace:*",
+        "@types/bun": "^1.3.8",
+        "@types/node": "^25.0.3",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
+        "zod": "^4.4.3",
+      },
+    },
     "plugins/plugin-codex-cli": {
       "name": "@elizaos/plugin-codex-cli",
       "version": "2.0.3-beta.0",
@@ -6661,6 +6677,8 @@
     "@elizaos/plugin-clawville": ["@elizaos/plugin-clawville@workspace:plugins/plugin-clawville"],
 
     "@elizaos/plugin-cli": ["@elizaos/plugin-cli@workspace:plugins/plugin-cli"],
+
+    "@elizaos/plugin-cli-inference": ["@elizaos/plugin-cli-inference@workspace:plugins/plugin-cli-inference"],
 
     "@elizaos/plugin-codex-cli": ["@elizaos/plugin-codex-cli@workspace:plugins/plugin-codex-cli"],
 

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -200,6 +200,11 @@ export const PROVIDER_PLUGIN_MAP: Readonly<Record<string, string>> = {
   NEARAI_API_KEY: "@elizaos/plugin-nearai",
   ZAI_API_KEY: "@elizaos/plugin-zai",
   Z_AI_API_KEY: "@elizaos/plugin-zai",
+  // CLI-backed inference (claude --print / codex exec on the user's subscription
+  // via the sanctioned CLI). Loads only when ELIZA_CHAT_VIA_CLI=claude|codex; the
+  // plugin self-gates its models map on the same var, and registers at priority
+  // 100 so it wins the large tier over a co-loaded API provider.
+  ELIZA_CHAT_VIA_CLI: "@elizaos/plugin-cli-inference",
   // ElizaCloud — loaded when API key is present OR cloud is explicitly enabled
   ELIZAOS_CLOUD_API_KEY: "@elizaos/plugin-elizacloud",
   ELIZAOS_CLOUD_ENABLED: "@elizaos/plugin-elizacloud",

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -1,0 +1,91 @@
+# @elizaos/plugin-cli-inference
+
+TOS-clean SAFE/CLOUD inference route for elizaOS. Serves chat/planner inference by **spawning the sanctioned local CLI** (`claude --print` or `codex exec`) as eliza model handlers. The CLI reads its own subscription credentials from disk — eliza never sees, forwards, or logs the token.
+
+## Purpose / role
+
+This is the develop-shippable peer to the two TOS-gray, never-commit bypass paths:
+
+- the in-process claude-code-stealth fetch interceptor at `packages/agent/src/auth/credentials.ts`, and
+- `plugin-codex-cli`'s in-process `postResponses` HTTP path,
+
+both of which replay the consumer-subscription token in-process. Here the handlers SHELL OUT to the official CLI, which loads `~/.claude/.credentials.json` / `~/.codex/auth.json` itself. The token is never injected into the child env (`filterEnv` allowlist + `SENSITIVE_ENV_RE` blocklist) or into logs (stderr is redacted before logging).
+
+Node-only (`"platforms": ["node"]`) — exported from `index.node.ts` only.
+
+## Enable
+
+Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`** or **`ELIZA_CHAT_VIA_CLI=codex`**.
+
+- Unset → the plugin is never added to the resolved set (`auto-enable.ts shouldEnable` is false), and even if force-loaded its models map is empty. INERT; no existing code path changes.
+- `claude` / `codex` → the large-tier handlers spawn that CLI.
+
+## Plugin surface
+
+No actions, providers, evaluators, or routes. Model handlers only, and **only the large tier** so high-frequency should-respond/triage calls fall through to the cheap configured provider (bounding per-turn spawn cost to a few ~3-4s calls):
+
+| Model type | Backend |
+|---|---|
+| `TEXT_LARGE` | `claude --print` or `codex exec` |
+| `TEXT_MEGA` | "" |
+| `RESPONSE_HANDLER` | "" |
+| `ACTION_PLANNER` | "" |
+
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered.
+
+## Layout
+
+```
+plugins/plugin-cli-inference/
+  index.ts                  Plugin entry — gates + registers large-tier handlers; init double-activation guard
+  index.node.ts             Node re-export
+  index.browser.ts          Browser stub (node-only plugin; empty models)
+  auto-enable.ts            shouldEnable = ELIZA_CHAT_VIA_CLI is claude|codex
+  src/
+    claude-cli.ts           ClaudeCli — spawns `claude --print`; __setSpawnForTests seam
+    codex-cli-exec.ts       CodexCli — spawns `codex exec --json`; JSONL last-assistant parse
+    prompt-flatten.ts       system/developer -> system slot; user/assistant/tool -> body; nothing dropped
+    sandbox.ts              SOC2 helpers copied from plugin-sub-agent-claude-code (filterEnv/resolveSafeCwd/resolveSafeBinary/SENSITIVE_ENV_RE)
+  __tests__/
+    cli-inference.test.ts   Unit tests (mock spawn): argv, token-absence, threading, parse, throw-on-error, large-tier-only
+  build.ts  vitest.config.ts  tsconfig*.json  biome.json
+```
+
+## GenerateTextParams -> CLI mapping (HARD REQ: forward BOTH system AND messages/prompt)
+
+- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-7>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
+- **codex:** `[codex, exec, -m <ELIZA_CLI_CODEX_MODEL || gpt-5.5>, -s read-only, --skip-git-repo-check, -C <cwd>, --color never, --json, <system folded on top of flattened body>]`.
+
+`prompt-flatten` re-routes system/developer roles to the system slot and flattens user/assistant/tool turns into the body; messages are NEVER dropped (would strip skills/memory/recent-convo/grammar).
+
+## Config / env vars
+
+| Var | Required | Default | Description |
+|---|---|---|---|
+| `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude` or `codex` — the single enable gate |
+| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-7` | `claude --model` |
+| `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | `codex exec -m` |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry) |
+
+## Errors
+
+Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-cli-inference test       # vitest (mocks spawn; no real CLI)
+bun run --cwd plugins/plugin-cli-inference typecheck
+bun run --cwd plugins/plugin-cli-inference lint:check
+bun run --cwd plugins/plugin-cli-inference build
+```
+
+## Conventions / gotchas
+
+- **Node-only.** `index.browser.ts` is a stub; the real handlers use `node:child_process`.
+- **Double-activation guard.** `ELIZA_CHAT_VIA_CLI=claude` + `ELIZA_ENABLE_CLAUDE_STEALTH` both set throws in `init()` (two colliding claude routes). The guard lives in THIS plugin because `credentials.ts` is skip-worktree on the live branch.
+- **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
+- **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
+- **sandbox.ts is a copy.** Keep in sync with `packages/plugin-sub-agent-claude-code/src/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
+- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -1,0 +1,91 @@
+# @elizaos/plugin-cli-inference
+
+TOS-clean SAFE/CLOUD inference route for elizaOS. Serves chat/planner inference by **spawning the sanctioned local CLI** (`claude --print` or `codex exec`) as eliza model handlers. The CLI reads its own subscription credentials from disk — eliza never sees, forwards, or logs the token.
+
+## Purpose / role
+
+This is the develop-shippable peer to the two TOS-gray, never-commit bypass paths:
+
+- the in-process claude-code-stealth fetch interceptor at `packages/agent/src/auth/credentials.ts`, and
+- `plugin-codex-cli`'s in-process `postResponses` HTTP path,
+
+both of which replay the consumer-subscription token in-process. Here the handlers SHELL OUT to the official CLI, which loads `~/.claude/.credentials.json` / `~/.codex/auth.json` itself. The token is never injected into the child env (`filterEnv` allowlist + `SENSITIVE_ENV_RE` blocklist) or into logs (stderr is redacted before logging).
+
+Node-only (`"platforms": ["node"]`) — exported from `index.node.ts` only.
+
+## Enable
+
+Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`** or **`ELIZA_CHAT_VIA_CLI=codex`**.
+
+- Unset → the plugin is never added to the resolved set (`auto-enable.ts shouldEnable` is false), and even if force-loaded its models map is empty. INERT; no existing code path changes.
+- `claude` / `codex` → the large-tier handlers spawn that CLI.
+
+## Plugin surface
+
+No actions, providers, evaluators, or routes. Model handlers only, and **only the large tier** so high-frequency should-respond/triage calls fall through to the cheap configured provider (bounding per-turn spawn cost to a few ~3-4s calls):
+
+| Model type | Backend |
+|---|---|
+| `TEXT_LARGE` | `claude --print` or `codex exec` |
+| `TEXT_MEGA` | "" |
+| `RESPONSE_HANDLER` | "" |
+| `ACTION_PLANNER` | "" |
+
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered.
+
+## Layout
+
+```
+plugins/plugin-cli-inference/
+  index.ts                  Plugin entry — gates + registers large-tier handlers; init double-activation guard
+  index.node.ts             Node re-export
+  index.browser.ts          Browser stub (node-only plugin; empty models)
+  auto-enable.ts            shouldEnable = ELIZA_CHAT_VIA_CLI is claude|codex
+  src/
+    claude-cli.ts           ClaudeCli — spawns `claude --print`; __setSpawnForTests seam
+    codex-cli-exec.ts       CodexCli — spawns `codex exec --json`; JSONL last-assistant parse
+    prompt-flatten.ts       system/developer -> system slot; user/assistant/tool -> body; nothing dropped
+    sandbox.ts              SOC2 helpers copied from plugin-sub-agent-claude-code (filterEnv/resolveSafeCwd/resolveSafeBinary/SENSITIVE_ENV_RE)
+  __tests__/
+    cli-inference.test.ts   Unit tests (mock spawn): argv, token-absence, threading, parse, throw-on-error, large-tier-only
+  build.ts  vitest.config.ts  tsconfig*.json  biome.json
+```
+
+## GenerateTextParams -> CLI mapping (HARD REQ: forward BOTH system AND messages/prompt)
+
+- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-7>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
+- **codex:** `[codex, exec, -m <ELIZA_CLI_CODEX_MODEL || gpt-5.5>, -s read-only, --skip-git-repo-check, -C <cwd>, --color never, --json, <system folded on top of flattened body>]`.
+
+`prompt-flatten` re-routes system/developer roles to the system slot and flattens user/assistant/tool turns into the body; messages are NEVER dropped (would strip skills/memory/recent-convo/grammar).
+
+## Config / env vars
+
+| Var | Required | Default | Description |
+|---|---|---|---|
+| `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude` or `codex` — the single enable gate |
+| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-7` | `claude --model` |
+| `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | `codex exec -m` |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry) |
+
+## Errors
+
+Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-cli-inference test       # vitest (mocks spawn; no real CLI)
+bun run --cwd plugins/plugin-cli-inference typecheck
+bun run --cwd plugins/plugin-cli-inference lint:check
+bun run --cwd plugins/plugin-cli-inference build
+```
+
+## Conventions / gotchas
+
+- **Node-only.** `index.browser.ts` is a stub; the real handlers use `node:child_process`.
+- **Double-activation guard.** `ELIZA_CHAT_VIA_CLI=claude` + `ELIZA_ENABLE_CLAUDE_STEALTH` both set throws in `init()` (two colliding claude routes). The guard lives in THIS plugin because `credentials.ts` is skip-worktree on the live branch.
+- **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
+- **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
+- **sandbox.ts is a copy.** Keep in sync with `packages/plugin-sub-agent-claude-code/src/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
+- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -1,0 +1,413 @@
+import { execSync } from "node:child_process";
+import type { ChatMessage } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildModels,
+  ClaudeCli,
+  cliInferencePlugin,
+  LARGE_TIER_MODEL_TYPES,
+  resolveCliBackend,
+} from "../index";
+import {
+  __setSpawnForTests as __setClaudeSpawn,
+  defaultSpawn,
+  type SpawnOptions,
+  type SpawnResult,
+} from "../src/claude-cli";
+import {
+  __setSpawnForTests as __setCodexSpawn,
+  CodexCli,
+  parseCodexJsonl,
+} from "../src/codex-cli-exec";
+import { flattenPrompt } from "../src/prompt-flatten";
+import { resolveSafeBinary } from "../src/sandbox";
+
+/** True iff `bin` resolves on this box (gates the real-binary tests). */
+function binaryOnPath(bin: string): boolean {
+  try {
+    execSync(`command -v ${bin}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Pin fake binary paths so the SOC2 `resolveSafeBinary` allowlist check never
+// touches the real filesystem (the real claude/codex symlinks resolve outside
+// the whitelist on dev boxes). The spawn itself is fully mocked.
+const FAKE_CLAUDE = "/usr/local/bin/claude";
+const FAKE_CODEX = "/usr/local/bin/codex";
+
+interface Captured {
+  argv: string[];
+  opts: SpawnOptions;
+}
+
+/** A mock spawner that records the call and returns a canned result. */
+function recordingSpawn(result: Partial<SpawnResult>) {
+  const calls: Captured[] = [];
+  const fn = async (argv: string[], opts: SpawnOptions): Promise<SpawnResult> => {
+    calls.push({ argv, opts });
+    return {
+      code: result.code ?? 0,
+      signal: result.signal ?? null,
+      stdout: result.stdout ?? "ok",
+      stderr: result.stderr ?? "",
+      timedOut: result.timedOut ?? false,
+    };
+  };
+  return { calls, fn };
+}
+
+afterEach(() => {
+  delete process.env.ELIZA_CHAT_VIA_CLI;
+});
+
+describe("flattenPrompt", () => {
+  it("routes system/developer messages to the system slot and others to the body, dropping nothing", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "be terse" },
+      { role: "user", content: "what is 2+2?" },
+      { role: "assistant", content: "4" },
+      { role: "developer", content: "use the grammar" },
+      { role: "user", content: "and 3+3?" },
+    ];
+    const { system, body } = flattenPrompt({ system: "ROOT", messages });
+    expect(system).toContain("ROOT");
+    expect(system).toContain("be terse");
+    expect(system).toContain("use the grammar");
+    expect(body).toContain("what is 2+2?");
+    expect(body).toContain("4");
+    expect(body).toContain("and 3+3?");
+    // none of the user/assistant content was dropped
+    expect(body).toMatch(/User:/);
+    expect(body).toMatch(/Assistant:/);
+  });
+
+  it("appends a legacy prompt that is not already the message tail", () => {
+    const { body } = flattenPrompt({
+      messages: [{ role: "user", content: "first" }],
+      prompt: "second",
+    });
+    expect(body).toContain("first");
+    expect(body).toContain("second");
+  });
+});
+
+describe("claude CLI variant", () => {
+  it("assembles argv: -p<body>, --system-prompt<verbatim>, --output-format text, --model; stdin /dev/null; isolated cwd", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "hello world\n" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({
+        model: "claude-opus-4-7",
+        env: { PATH: process.env.PATH },
+        binaryPath: FAKE_CLAUDE,
+      });
+      const out = await cli.generate({
+        system: "SYSTEM PROMPT VERBATIM",
+        messages: [{ role: "user", content: "hi there" }],
+      });
+      expect(out).toBe("hello world");
+      expect(calls).toHaveLength(1);
+      const { argv, opts } = calls[0];
+
+      // -p carries the flattened body (the messages)
+      const pIdx = argv.indexOf("-p");
+      expect(pIdx).toBeGreaterThanOrEqual(0);
+      expect(argv[pIdx + 1]).toContain("hi there");
+
+      // --system-prompt carries the system VERBATIM (full replace)
+      const sysIdx = argv.indexOf("--system-prompt");
+      expect(sysIdx).toBeGreaterThanOrEqual(0);
+      expect(argv[sysIdx + 1]).toBe("SYSTEM PROMPT VERBATIM");
+
+      // output format + model + dynamic-section suppression
+      const ofIdx = argv.indexOf("--output-format");
+      expect(argv[ofIdx + 1]).toBe("text");
+      expect(argv).toContain("--exclude-dynamic-system-prompt-sections");
+      const mIdx = argv.indexOf("--model");
+      expect(argv[mIdx + 1]).toBe("claude-opus-4-7");
+
+      // stdin from /dev/null, isolated tmpdir cwd
+      expect(opts.stdinPath).toBe("/dev/null");
+      expect(opts.cwd).toContain("eliza-cli-inference-");
+    } finally {
+      restore();
+    }
+  });
+
+  it("never forwards the subscription token to the child env", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "ok" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({
+        binaryPath: FAKE_CLAUDE,
+        env: {
+          PATH: process.env.PATH,
+          HOME: "/home/test",
+          ANTHROPIC_API_KEY: "sk-ant-SHOULD-NOT-LEAK",
+          CLAUDE_CODE_OAUTH_TOKEN: "oat-SHOULD-NOT-LEAK",
+        },
+      });
+      await cli.generate({ prompt: "hi" });
+      const { opts } = calls[0];
+      expect(opts.env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(opts.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(JSON.stringify(opts.env)).not.toContain("SHOULD-NOT-LEAK");
+      // allowlisted, non-sensitive keys survive
+      expect(opts.env.HOME).toBe("/home/test");
+    } finally {
+      restore();
+    }
+  });
+
+  it("threads system+user+assistant messages: system -> --system-prompt, rest -> body, none dropped", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "answer" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
+      await cli.generate({
+        messages: [
+          { role: "system", content: "SYS-A" },
+          { role: "user", content: "USER-A" },
+          { role: "assistant", content: "ASSIST-A" },
+          { role: "user", content: "USER-B" },
+        ],
+      });
+      const { argv } = calls[0];
+      const system = argv[argv.indexOf("--system-prompt") + 1];
+      const body = argv[argv.indexOf("-p") + 1];
+      expect(system).toContain("SYS-A");
+      expect(body).toContain("USER-A");
+      expect(body).toContain("ASSIST-A");
+      expect(body).toContain("USER-B");
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns trimmed stdout", async () => {
+    const { fn } = recordingSpawn({ stdout: "  ok  \n" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
+      expect(await cli.generate({ prompt: "x" })).toBe("ok");
+    } finally {
+      restore();
+    }
+  });
+
+  it("THROWS on non-zero exit, with redacted stderr", async () => {
+    const { fn } = recordingSpawn({
+      code: 1,
+      stdout: "",
+      stderr: "boom\nANTHROPIC_API_KEY=sk-ant-leak\nmore",
+    });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
+      await expect(cli.generate({ prompt: "x" })).rejects.toThrow(/exited 1/);
+      await expect(cli.generate({ prompt: "x" })).rejects.not.toThrow(/sk-ant-leak/);
+    } finally {
+      restore();
+    }
+  });
+
+  it("THROWS on timeout (SIGTERM)", async () => {
+    const { fn } = recordingSpawn({ code: null, signal: "SIGTERM", stdout: "", timedOut: true });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({
+        env: { PATH: process.env.PATH },
+        timeoutMs: 50,
+        binaryPath: FAKE_CLAUDE,
+      });
+      await expect(cli.generate({ prompt: "x" })).rejects.toThrow(/timed out/);
+    } finally {
+      restore();
+    }
+  });
+
+  it("THROWS on empty stdout", async () => {
+    const { fn } = recordingSpawn({ code: 0, stdout: "   \n  " });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
+      await expect(cli.generate({ prompt: "x" })).rejects.toThrow(/empty stdout/);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("codex CLI variant", () => {
+  it("assembles argv: exec / -m / -s read-only / --skip-git-repo-check / -C / --color never / --json", async () => {
+    const jsonl = `{"type":"item.completed","item":{"type":"agent_message","text":"codex says hi"}}\n`;
+    const { calls, fn } = recordingSpawn({ stdout: jsonl });
+    const restore = __setCodexSpawn(fn);
+    try {
+      const cli = new CodexCli({
+        model: "gpt-5.5",
+        env: { PATH: process.env.PATH },
+        binaryPath: FAKE_CODEX,
+      });
+      const out = await cli.generate({ system: "SYS", prompt: "do a thing" });
+      expect(out).toBe("codex says hi");
+      const { argv, opts } = calls[0];
+      expect(argv).toContain("exec");
+      expect(argv[argv.indexOf("-m") + 1]).toBe("gpt-5.5");
+      expect(argv[argv.indexOf("-s") + 1]).toBe("read-only");
+      expect(argv).toContain("--skip-git-repo-check");
+      expect(argv).toContain("-C");
+      expect(argv[argv.indexOf("--color") + 1]).toBe("never");
+      expect(argv).toContain("--json");
+      // system is folded into the single positional prompt
+      const prompt = argv[argv.length - 1];
+      expect(prompt).toContain("SYS");
+      expect(prompt).toContain("do a thing");
+      expect(opts.stdinPath).toBe("/dev/null");
+    } finally {
+      restore();
+    }
+  });
+
+  it("THROWS on non-zero exit", async () => {
+    const { fn } = recordingSpawn({ code: 2, stdout: "", stderr: "nope" });
+    const restore = __setCodexSpawn(fn);
+    try {
+      const cli = new CodexCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CODEX });
+      await expect(cli.generate({ prompt: "x" })).rejects.toThrow(/codex exited 2/);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("parseCodexJsonl", () => {
+  it("concatenates assistant message fragments from JSONL in order", () => {
+    const jsonl = [
+      `{"type":"thread.started"}`,
+      `{"type":"item.completed","item":{"type":"agent_message","text":"first"}}`,
+      `{"type":"item.completed","item":{"type":"agent_message","text":"final answer"}}`,
+    ].join("\n");
+    expect(parseCodexJsonl(jsonl)).toBe("first\nfinal answer");
+  });
+
+  it("ignores non-JSON banner lines", () => {
+    const jsonl = `codex 0.139.0 starting...\n{"type":"agent_message","message":"hi"}\n`;
+    expect(parseCodexJsonl(jsonl)).toBe("hi");
+  });
+
+  it("concatenates ALL assistant fragments in order (does not truncate to the last)", () => {
+    const jsonl = [
+      `{"type":"item.completed","item":{"type":"agent_message","text":"<response>part one"}}`,
+      `{"type":"item.completed","item":{"type":"agent_message","text":"part two</response>"}}`,
+    ].join("\n");
+    expect(parseCodexJsonl(jsonl)).toBe("<response>part one\npart two</response>");
+  });
+
+  it("falls back to raw trimmed stdout ONLY when no line parsed as JSON", () => {
+    expect(parseCodexJsonl("  plain text answer  ")).toBe("plain text answer");
+  });
+
+  it("THROWS (does not dump raw JSONL) when JSON parsed but no assistant event", () => {
+    const jsonl = [`{"type":"thread.started"}`, `{"type":"token_count","count":42}`].join("\n");
+    expect(() => parseCodexJsonl(jsonl)).toThrow(/no assistant message/);
+  });
+});
+
+describe("codex default spawner (fix 1: must default, not throw)", () => {
+  it("CodexCli uses the real defaultSpawn when no test seam is installed", async () => {
+    // No __setSpawnForTests call here: a production CodexCli must spawn via the
+    // module-default spawner, not throw "codex spawner not configured". We point
+    // it at `true` (exits 0, no stdout) so the spawn runs but yields empty
+    // stdout -> the "empty stdout" guard, NOT the "spawner not configured" error.
+    const cli = new CodexCli({ env: { PATH: process.env.PATH }, binaryPath: "/usr/bin/true" });
+    await expect(cli.generate({ prompt: "x" })).rejects.toThrow(/empty stdout/);
+  });
+});
+
+describe("resolveSafeBinary accepts real symlinked installs (fix 2)", () => {
+  const hasClaude = binaryOnPath("claude");
+  const hasCodex = binaryOnPath("codex");
+
+  it.skipIf(!hasClaude)("resolves a real `claude` install symlinked out of the allowlist", () => {
+    const resolved = resolveSafeBinary("claude");
+    expect(resolved.length).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!hasCodex)("resolves a real `codex` install symlinked out of the allowlist", () => {
+    const resolved = resolveSafeBinary("codex");
+    expect(resolved.length).toBeGreaterThan(0);
+  });
+
+  it("still rejects an absolute path outside every allowlisted dir", () => {
+    // /etc exists but is not on the launcher allowlist, so an absolute path
+    // there must be refused even though the file exists.
+    expect(() => resolveSafeBinary("/etc/hostname")).toThrow(/Could not resolve/);
+  });
+});
+
+describe("defaultSpawn timeout escalation (fix 6: SIGKILL if SIGTERM ignored)", () => {
+  it("escalates to SIGKILL and rejects when the child ignores SIGTERM", async () => {
+    // A node child that traps SIGTERM and keeps running. Only SIGKILL (which
+    // cannot be trapped) can stop it. With the group-kill + 2s SIGKILL
+    // escalation, defaultSpawn must resolve as timedOut well before this 30s
+    // sleep would finish.
+    const script =
+      "process.on('SIGTERM',()=>{});setTimeout(()=>process.exit(0),30000);process.stderr.write('ready');";
+    const result = await defaultSpawn([process.execPath, "-e", script], {
+      cwd: process.cwd(),
+      env: { PATH: process.env.PATH ?? "" } as Record<string, string>,
+      timeoutMs: 300,
+      stdinPath: "/dev/null",
+    });
+    expect(result.timedOut).toBe(true);
+    // The child was force-killed: it never ran to its own exit(0), so it closed
+    // on a signal rather than code 0.
+    expect(result.code).not.toBe(0);
+  }, 10_000);
+});
+
+describe("plugin routing priority (fix 4)", () => {
+  it("registers an explicit high priority so it wins the tiers it serves", () => {
+    expect(cliInferencePlugin.priority).toBe(100);
+  });
+});
+
+describe("models map gating (large-tier only)", () => {
+  it("ELIZA_CHAT_VIA_CLI unset -> empty models map", () => {
+    expect(resolveCliBackend({})).toBeUndefined();
+    expect(buildModels({})).toEqual({});
+  });
+
+  it("ELIZA_CHAT_VIA_CLI=claude -> exactly the 3 large-tier handlers, NOT ACTION_PLANNER/TEXT_SMALL/NANO/MEDIUM", () => {
+    const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude" }) as Record<string, unknown>;
+    const keys = Object.keys(models).sort();
+    expect(keys).toEqual([...LARGE_TIER_MODEL_TYPES].sort());
+    expect(keys).toContain("TEXT_LARGE");
+    expect(keys).toContain("TEXT_MEGA");
+    expect(keys).toContain("RESPONSE_HANDLER");
+    // ACTION_PLANNER stays on the grammar/tool-honoring provider — the CLI
+    // cannot honor GBNF/native-tool/responseSchema enforcement.
+    expect(keys).not.toContain("ACTION_PLANNER");
+    expect(keys).not.toContain("TEXT_SMALL");
+    expect(keys).not.toContain("TEXT_NANO");
+    expect(keys).not.toContain("TEXT_MEDIUM");
+  });
+
+  it("ELIZA_CHAT_VIA_CLI=codex -> same large-tier-only set", () => {
+    const keys = Object.keys(
+      buildModels({ ELIZA_CHAT_VIA_CLI: "codex" }) as Record<string, unknown>
+    );
+    expect(keys.sort()).toEqual([...LARGE_TIER_MODEL_TYPES].sort());
+  });
+
+  it("resolveCliBackend accepts only claude|codex (case-insensitive)", () => {
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "Claude" })).toBe("claude");
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "CODEX" })).toBe("codex");
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "gemini" })).toBeUndefined();
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "" })).toBeUndefined();
+  });
+});

--- a/plugins/plugin-cli-inference/auto-enable.ts
+++ b/plugins/plugin-cli-inference/auto-enable.ts
@@ -1,0 +1,20 @@
+// Auto-enable check for @elizaos/plugin-cli-inference.
+//
+// Plugin manifest entry-point — referenced by package.json's
+// `elizaos.plugin.autoEnableModule`. Keep this module light: config/env reads
+// only, no service init, no transitive imports of the full plugin runtime. The
+// auto-enable engine loads dozens of these per boot.
+import type { PluginAutoEnableContext } from "@elizaos/core";
+
+/**
+ * Enable ONLY when `ELIZA_CHAT_VIA_CLI` is set to `claude` or `codex`. This is
+ * the single env gate for the SAFE/CLOUD inference route — unset means the
+ * plugin is never added to the resolved set, so it cannot affect any existing
+ * running code path. Even if it were force-loaded, its models map is empty
+ * unless the same env var is set, so the cheap configured provider keeps
+ * serving every tier.
+ */
+export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
+  const raw = ctx.env.ELIZA_CHAT_VIA_CLI?.trim().toLowerCase();
+  return raw === "claude" || raw === "codex";
+}

--- a/plugins/plugin-cli-inference/biome.json
+++ b/plugins/plugin-cli-inference/biome.json
@@ -1,0 +1,46 @@
+{
+	"root": false,
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"files": {
+		"includes": [
+			"build.ts",
+			"index.ts",
+			"index.browser.ts",
+			"index.node.ts",
+			"src/**",
+			"__tests__/**",
+			"!dist",
+			"!node_modules"
+		]
+	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"correctness": {
+				"noUnusedVariables": "error"
+			},
+			"a11y": {
+				"useButtonType": "off"
+			},
+			"style": {},
+			"complexity": {
+				"noCommaOperator": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentWidth": 2,
+		"indentStyle": "space",
+		"lineWidth": 100
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"trailingCommas": "es5",
+			"semicolons": "always"
+		}
+	}
+}

--- a/plugins/plugin-cli-inference/build.ts
+++ b/plugins/plugin-cli-inference/build.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/** Build script for @elizaos/plugin-cli-inference. */
+
+import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+
+const externalDeps = await externalsFromPackageJson("./package.json");
+
+async function build(): Promise<void> {
+  const totalStart = Date.now();
+
+  const nodeStart = Date.now();
+  console.log("🔨 Building @elizaos/plugin-cli-inference for Node (ESM)...");
+  const nodeResult = await Bun.build({
+    entrypoints: ["index.node.ts"],
+    outdir: "dist/node",
+    target: "node",
+    format: "esm",
+    sourcemap: "external",
+    minify: false,
+    external: externalDeps,
+  });
+  if (!nodeResult.success) {
+    console.error("Node ESM build failed:", nodeResult.logs);
+    throw new Error("Node ESM build failed");
+  }
+  console.log(`✅ Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
+
+  const browserStart = Date.now();
+  console.log("🌐 Building @elizaos/plugin-cli-inference for Browser...");
+  const browserResult = await Bun.build({
+    entrypoints: ["index.browser.ts"],
+    outdir: "dist/browser",
+    target: "browser",
+    format: "esm",
+    sourcemap: "external",
+    minify: true,
+    external: externalDeps,
+  });
+  if (!browserResult.success) {
+    console.error("Browser build failed:", browserResult.logs);
+    throw new Error("Browser build failed");
+  }
+  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
+
+  const dtsStart = Date.now();
+  console.log("📝 Generating TypeScript declarations...");
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await Bun.$`tsc --project tsconfig.build.json`;
+  await mkdir("dist/node", { recursive: true });
+  await mkdir("dist/browser", { recursive: true });
+  const reexportDeclaration = `export * from '../index';\nexport { default } from '../index';\n`;
+  await writeFile("dist/node/index.d.ts", reexportDeclaration);
+  await writeFile("dist/browser/index.d.ts", reexportDeclaration);
+  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
+
+  const totalTime = ((Date.now() - totalStart) / 1000).toFixed(2);
+  console.log(`🎉 All builds finished in ${totalTime}s`);
+}
+
+build().catch((err) => {
+  console.error("Build failed:", err);
+  process.exit(1);
+});

--- a/plugins/plugin-cli-inference/index.browser.ts
+++ b/plugins/plugin-cli-inference/index.browser.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from "@elizaos/core";
+
+/**
+ * Browser stub. This plugin is node-only: it spawns the `claude` / `codex` CLI
+ * via `node:child_process` and reads creds from disk. The browser bundle
+ * registers no models.
+ */
+export const cliInferencePlugin: Plugin = {
+  name: "cli-inference",
+  description: "CLI inference is node-only (spawns the claude/codex CLI). Inert in browser.",
+  config: {},
+  async init(): Promise<void> {
+    // Browser bundle intentionally does not import node:child_process.
+  },
+  models: {},
+};
+
+export default cliInferencePlugin;

--- a/plugins/plugin-cli-inference/index.node.ts
+++ b/plugins/plugin-cli-inference/index.node.ts
@@ -1,0 +1,4 @@
+import pluginDefault from "./index";
+
+export * from "./index";
+export default pluginDefault;

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -1,0 +1,180 @@
+import type { GenerateTextParams, IAgentRuntime, Plugin } from "@elizaos/core";
+import { logger, ModelType } from "@elizaos/core";
+import { ClaudeCli } from "./src/claude-cli";
+import { CodexCli } from "./src/codex-cli-exec";
+
+/**
+ * @elizaos/plugin-cli-inference — the TOS-clean SAFE/CLOUD inference route.
+ *
+ * Serves chat/planner inference by SPAWNING the sanctioned local CLI:
+ *   - `claude --print`  (reads ~/.claude/.credentials.json itself), or
+ *   - `codex exec`      (reads ~/.codex/auth.json itself).
+ *
+ * eliza never sees/forwards/logs the subscription token — the child env is
+ * filtered (allowlist + secret blocklist) and the CLI loads its own creds. This
+ * is the develop-shippable peer to the two never-commit, TOS-gray bypass paths
+ * (the claude-code-stealth fetch interceptor in
+ * `packages/agent/src/auth/credentials.ts` and plugin-codex-cli `postResponses`)
+ * which replay the consumer-subscription token in-process.
+ *
+ * The whole models map is INERT unless `ELIZA_CHAT_VIA_CLI` is `claude` or
+ * `codex`. We register TEXT_LARGE / TEXT_MEGA / RESPONSE_HANDLER only:
+ *
+ *   - RESPONSE_HANDLER is the whole point — it generates the user-facing reply,
+ *     which is exactly what "chat on the sub" means. That is one CLI spawn per
+ *     turn that actually answers (~3-4s).
+ *   - TEXT_LARGE / TEXT_MEGA cover other large free-text generations (e.g. the
+ *     post-turn evaluator) — also occasional, also tolerant of plain text.
+ *   - ACTION_PLANNER is deliberately NOT registered: the planner relies on
+ *     GBNF / native-tool / responseSchema enforcement that `claude --print` and
+ *     `codex exec` cannot honor (they emit free text), so the planner stays on
+ *     the configured grammar/tool-honoring provider (cerebras / zai).
+ *
+ * High-frequency should-respond/triage (TEXT_SMALL/NANO/MEDIUM) is never
+ * registered, so per-turn CLI spawn cost is just the user-facing reply via
+ * RESPONSE_HANDLER, plus possibly the post-turn evaluator — not the planner and
+ * not the cheap triage calls.
+ */
+
+const TEXT_MEGA_MODEL_TYPE = (ModelType.TEXT_MEGA ?? "TEXT_MEGA") as string;
+const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ?? "RESPONSE_HANDLER") as string;
+
+/** Large-tier model types this plugin registers (when enabled). */
+const LARGE_TIER_MODEL_TYPES: readonly string[] = [
+  ModelType.TEXT_LARGE,
+  TEXT_MEGA_MODEL_TYPE,
+  RESPONSE_HANDLER_MODEL_TYPE,
+];
+
+type CliBackend = "claude" | "codex";
+
+type RuntimeWithSettings = IAgentRuntime & {
+  getSetting?: (key: string) => string | number | boolean | undefined | null;
+};
+
+function readEnv(name: string): string | undefined {
+  if (typeof process === "undefined") return undefined;
+  return process.env[name];
+}
+
+function getSetting(runtime: IAgentRuntime, key: string): string | undefined {
+  const value = (runtime as RuntimeWithSettings).getSetting?.(key);
+  return value === undefined || value === null ? readEnv(key) : String(value);
+}
+
+/** Resolve the configured backend, or undefined when the plugin is inert. */
+export function resolveCliBackend(source: { ELIZA_CHAT_VIA_CLI?: string }): CliBackend | undefined {
+  const raw = source.ELIZA_CHAT_VIA_CLI?.trim().toLowerCase();
+  if (raw === "claude" || raw === "codex") return raw;
+  return undefined;
+}
+
+function parseTimeout(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function buildClaude(runtime: IAgentRuntime): ClaudeCli {
+  return new ClaudeCli({
+    model: getSetting(runtime, "ELIZA_CLI_CLAUDE_MODEL"),
+    timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+  });
+}
+
+function buildCodex(runtime: IAgentRuntime): CodexCli {
+  return new CodexCli({
+    model: getSetting(runtime, "ELIZA_CLI_CODEX_MODEL"),
+    timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+  });
+}
+
+async function generateViaCli(
+  runtime: IAgentRuntime,
+  params: GenerateTextParams,
+  modelType: string
+): Promise<string> {
+  const backend = resolveCliBackend({
+    ELIZA_CHAT_VIA_CLI: getSetting(runtime, "ELIZA_CHAT_VIA_CLI"),
+  });
+  if (!backend) {
+    // Should be unreachable: the handlers are only registered when a backend is
+    // set. Throw so useModel/AccountPool treat it as a provider failure rather
+    // than silently returning empty.
+    throw new Error("[cli-inference] ELIZA_CHAT_VIA_CLI is not set to claude|codex");
+  }
+  const generateParams = {
+    system: params.system,
+    prompt: params.prompt,
+    messages: params.messages,
+  };
+  logger.debug(`[cli-inference] ${modelType} via ${backend} CLI`);
+  const cli = backend === "claude" ? buildClaude(runtime) : buildCodex(runtime);
+  return cli.generate(generateParams);
+}
+
+/**
+ * Build the models map. When no backend is configured the map is EMPTY so the
+ * plugin registers nothing and the cheap configured provider keeps serving
+ * every tier.
+ */
+export function buildModels(
+  source: { ELIZA_CHAT_VIA_CLI?: string } = { ELIZA_CHAT_VIA_CLI: readEnv("ELIZA_CHAT_VIA_CLI") }
+): Plugin["models"] {
+  if (!resolveCliBackend(source)) return {};
+  const models: Record<
+    string,
+    (runtime: IAgentRuntime, params: GenerateTextParams) => Promise<string>
+  > = {};
+  for (const modelType of LARGE_TIER_MODEL_TYPES) {
+    models[modelType] = (runtime, params) => generateViaCli(runtime, params, modelType);
+  }
+  return models as Plugin["models"];
+}
+
+export const cliInferencePlugin: Plugin = {
+  name: "cli-inference",
+  description:
+    "TOS-clean SAFE/CLOUD inference: spawns the sanctioned claude/codex CLI as large-tier model handlers; the CLI reads its own creds. Inert unless ELIZA_CHAT_VIA_CLI=claude|codex.",
+  // High priority so that, when ELIZA_CHAT_VIA_CLI is set, this plugin
+  // deterministically wins the tiers it registers (TEXT_LARGE / TEXT_MEGA /
+  // RESPONSE_HANDLER) over default-priority (0) model providers like
+  // plugin-anthropic that would otherwise tie and resolve non-deterministically.
+  priority: 100,
+  config: {
+    ELIZA_CHAT_VIA_CLI: readEnv("ELIZA_CHAT_VIA_CLI") ?? null,
+    ELIZA_CLI_CLAUDE_MODEL: readEnv("ELIZA_CLI_CLAUDE_MODEL") ?? null,
+    ELIZA_CLI_CODEX_MODEL: readEnv("ELIZA_CLI_CODEX_MODEL") ?? null,
+    ELIZA_CLI_TIMEOUT_MS: readEnv("ELIZA_CLI_TIMEOUT_MS") ?? null,
+  },
+  async init(): Promise<void> {
+    const backend = resolveCliBackend({ ELIZA_CHAT_VIA_CLI: readEnv("ELIZA_CHAT_VIA_CLI") });
+    if (!backend) {
+      logger.info("[cli-inference] ELIZA_CHAT_VIA_CLI unset — plugin inert (no models registered)");
+      return;
+    }
+    // Double-activation guard: the in-process claude-code-stealth interceptor and
+    // this CLI-spawn path are two colliding claude routes. This guard lives HERE
+    // (not in credentials.ts, which is skip-worktree on the live branch).
+    const stealth = readEnv("ELIZA_ENABLE_CLAUDE_STEALTH")?.trim().toLowerCase();
+    const stealthOn =
+      stealth === "1" || stealth === "true" || stealth === "yes" || stealth === "on";
+    if (backend === "claude" && stealthOn) {
+      throw new Error(
+        "[cli-inference] ELIZA_CHAT_VIA_CLI=claude collides with ELIZA_ENABLE_CLAUDE_STEALTH. " +
+          "Pick one claude inference route (CLI spawn vs in-process stealth interceptor)."
+      );
+    }
+    logger.info(
+      `[cli-inference] enabled via ELIZA_CHAT_VIA_CLI=${backend} — large-tier handlers spawn the ${backend} CLI`
+    );
+  },
+  models: buildModels(),
+};
+
+export { ClaudeCli } from "./src/claude-cli";
+export { CodexCli, parseCodexJsonl } from "./src/codex-cli-exec";
+export { flattenPrompt } from "./src/prompt-flatten";
+export { LARGE_TIER_MODEL_TYPES };
+
+export default cliInferencePlugin;

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -1,0 +1,111 @@
+{
+  "name": "@elizaos/plugin-cli-inference",
+  "version": "2.0.3-beta.0",
+  "type": "module",
+  "main": "dist/node/index.node.js",
+  "module": "dist/node/index.node.js",
+  "types": "dist/index.d.ts",
+  "browser": "dist/browser/index.browser.js",
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "import": "./dist/browser/index.browser.js",
+        "default": "./dist/browser/index.browser.js"
+      },
+      "node": {
+        "types": "./dist/node/index.d.ts",
+        "import": "./dist/node/index.node.js",
+        "default": "./dist/node/index.node.js"
+      },
+      "default": "./dist/node/index.node.js"
+    },
+    "./*.css": "./dist/*.css",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist",
+    "auto-enable.ts"
+  ],
+  "elizaos": {
+    "plugin": {
+      "autoEnableModule": "./auto-enable.ts",
+      "capabilities": [
+        "text-large"
+      ]
+    }
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
+    "@elizaos/core": "workspace:*",
+    "@types/bun": "^1.3.8",
+    "@types/node": "^25.0.3",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "scripts": {
+    "build:ts": "bun run build.ts",
+    "dev": "bun --hot build.ts",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "clean": "rm -rf dist .turbo",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run --config ./vitest.config.ts",
+    "test:ts": "vitest run --config ./vitest.config.ts",
+    "build": "bun run build.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "ELIZA_CHAT_VIA_CLI": {
+        "type": "string",
+        "description": "Enable the SAFE/CLOUD CLI inference route. Set to 'claude' or 'codex' to spawn that CLI for large-tier inference. Unset = plugin inert.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CLI_CLAUDE_MODEL": {
+        "type": "string",
+        "description": "Model id passed to `claude --model`. Defaults to claude-opus-4-7.",
+        "required": false,
+        "default": "claude-opus-4-7",
+        "sensitive": false
+      },
+      "ELIZA_CLI_CODEX_MODEL": {
+        "type": "string",
+        "description": "Model id passed to `codex exec -m`. Defaults to gpt-5.5.",
+        "required": false,
+        "default": "gpt-5.5",
+        "sensitive": false
+      },
+      "ELIZA_CLI_TIMEOUT_MS": {
+        "type": "number",
+        "description": "Per-call CLI spawn timeout in milliseconds (SIGTERM on expiry). Defaults to 120000.",
+        "required": false,
+        "default": 120000,
+        "sensitive": false
+      }
+    }
+  },
+  "eliza": {
+    "platforms": [
+      "node"
+    ],
+    "runtime": "node"
+  }
+}

--- a/plugins/plugin-cli-inference/src/claude-cli.ts
+++ b/plugins/plugin-cli-inference/src/claude-cli.ts
@@ -1,0 +1,242 @@
+import { spawn } from "node:child_process";
+import { openSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@elizaos/core";
+import { flattenPrompt } from "./prompt-flatten";
+import { filterEnv, redactSensitive, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
+
+/**
+ * Claude Code CLI inference variant (TOS-clean SAFE/CLOUD route).
+ *
+ * Spawns the sanctioned `claude --print` binary, which reads its OWN OAuth
+ * credentials from `~/.claude/.credentials.json`. eliza never sees, forwards,
+ * or logs the subscription token: the child env is run through `filterEnv`
+ * (allowlist + `SENSITIVE_ENV_RE` blocklist), and stderr is redacted before
+ * logging. Distinct from the in-process stealth fetch-interceptor at
+ * `packages/agent/src/auth/credentials.ts`, which replays the token in-process
+ * and stays on a never-commit branch.
+ */
+
+const DEFAULT_MODEL = "claude-opus-4-7";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const CLAUDE_BINARY = "claude";
+
+export interface SpawnResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export type SpawnFn = (argv: string[], opts: SpawnOptions) => Promise<SpawnResult>;
+
+export interface SpawnOptions {
+  cwd: string;
+  env: Record<string, string>;
+  timeoutMs: number;
+  /** Absolute path used as stdin (always `/dev/null` in production). */
+  stdinPath: string;
+}
+
+export interface ClaudeCliConfig {
+  model?: string;
+  timeoutMs?: number;
+  /** Override the env source (defaults to `process.env`). */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Pin the resolved binary path, skipping `resolveSafeBinary`. Used by unit
+   * tests (so they never touch the real filesystem) and by container deploys
+   * that pin the CLI outside the default allowlist. When unset, the binary is
+   * resolved from PATH against the SOC2 whitelist.
+   */
+  binaryPath?: string;
+}
+
+export interface ClaudeGenerateParams {
+  system?: string;
+  prompt?: string;
+  messages?: Parameters<typeof flattenPrompt>[0]["messages"];
+}
+
+/** Grace window after SIGTERM before escalating to SIGKILL on the group. */
+const SIGKILL_GRACE_MS = 2_000;
+
+/**
+ * Default spawner: runs argv with `/dev/null` stdin, captures stdout/stderr,
+ * and enforces a hard timeout. On expiry it SIGTERMs the whole process group
+ * (the child is spawned `detached` so it leads its own group), then escalates
+ * to SIGKILL after a short grace window so a child that ignores SIGTERM cannot
+ * hang generate() past `timeoutMs + SIGKILL_GRACE_MS`. Pure I/O — overridable
+ * in tests via `__setSpawnForTests`.
+ */
+export const defaultSpawn: SpawnFn = (argv, opts) =>
+  new Promise<SpawnResult>((resolve, reject) => {
+    let stdinFd: number;
+    try {
+      // `/dev/null` stdin is REQUIRED: without it the CLI waits ~3s for stdin
+      // before falling through to the `-p` arg.
+      stdinFd = openSync(opts.stdinPath, "r");
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: [stdinFd, "pipe", "pipe"],
+      // Lead a new process group so we can signal the whole tree (the CLI may
+      // fork helpers) and so SIGKILL escalation reaches a child that traps
+      // SIGTERM.
+      detached: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let killTimer: NodeJS.Timeout | undefined;
+
+    // Signal the process group (negative pid) when we have one; fall back to
+    // the child directly if the pid is unavailable.
+    const signalTree = (sig: NodeJS.Signals): void => {
+      const pid = child.pid;
+      try {
+        if (typeof pid === "number") {
+          process.kill(-pid, sig);
+        } else {
+          child.kill(sig);
+        }
+      } catch {
+        // Group already gone — nothing to signal.
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      signalTree("SIGTERM");
+      // Hard escalation: if the child ignores SIGTERM, SIGKILL the group so
+      // generate() cannot hang past timeoutMs + grace.
+      killTimer = setTimeout(() => signalTree("SIGKILL"), SIGKILL_GRACE_MS);
+      killTimer.unref?.();
+    }, opts.timeoutMs);
+
+    const clearTimers = (): void => {
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+    };
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      clearTimers();
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimers();
+      resolve({ code, signal, stdout, stderr, timedOut });
+    });
+  });
+
+let spawnImpl: SpawnFn = defaultSpawn;
+
+/** Test seam: swap the child-process spawner. Returns a restore fn. */
+export function __setSpawnForTests(fn: SpawnFn): () => void {
+  const prev = spawnImpl;
+  spawnImpl = fn;
+  return () => {
+    spawnImpl = prev;
+  };
+}
+
+/** Redact anything resembling a secret out of stderr before logging. */
+function redactStderr(stderr: string): string {
+  return redactSensitive(stderr).slice(0, 2000);
+}
+
+export class ClaudeCli {
+  private readonly model: string;
+  private readonly timeoutMs: number;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly binaryPath?: string;
+
+  constructor(config: ClaudeCliConfig = {}) {
+    this.model = config.model ?? DEFAULT_MODEL;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.env = config.env ?? process.env;
+    this.binaryPath = config.binaryPath;
+  }
+
+  async generate(params: ClaudeGenerateParams): Promise<string> {
+    const { system, body } = flattenPrompt(params);
+    const binary = this.binaryPath ?? resolveSafeBinary(CLAUDE_BINARY, this.env);
+
+    // Isolated empty tmpdir cwd: keeps the CLI out of any real project so it
+    // never picks up repo context (which would inject Claude Code's own
+    // identity / file-aware behavior), and `resolveSafeCwd` rejects symlink
+    // escapes. Created + removed per call.
+    const rawCwd = await mkdtemp(join(tmpdir(), "eliza-cli-inference-"));
+    const cwd = resolveSafeCwd(rawCwd, [tmpdir()]);
+
+    try {
+      const argv = [binary, "-p", body];
+      // Only override the system prompt when the runtime actually supplied one.
+      // Passing `--system-prompt ''` together with
+      // `--exclude-dynamic-system-prompt-sections` would strip ALL steering
+      // (both ours and Claude Code's), leaving the model ungoverned. When the
+      // flattened system is empty we leave Claude Code's default sections in
+      // place rather than blank everything out.
+      if (system.trim().length > 0) {
+        argv.push(
+          // FULL REPLACE of the system prompt: suppresses Claude Code's own
+          // identity and lets the runtime grammar (`<response><thought><text>`
+          // + do-not-invent rules) take over.
+          "--system-prompt",
+          system,
+          // Drop Claude Code's dynamic system-prompt sections (repo/tool
+          // context) so only our system prompt governs the turn.
+          "--exclude-dynamic-system-prompt-sections"
+        );
+      }
+      argv.push("--output-format", "text", "--model", this.model);
+
+      const result = await spawnImpl(argv, {
+        cwd,
+        // NEVER inject the subscription token: filterEnv allowlists PATH/HOME/…
+        // and drops every `SENSITIVE_ENV_RE` key. The CLI reads its own creds
+        // from ~/.claude/.credentials.json.
+        env: filterEnv(this.env),
+        timeoutMs: this.timeoutMs,
+        stdinPath: "/dev/null",
+      });
+
+      if (result.timedOut) {
+        throw new Error(
+          `[cli-inference] claude timed out after ${this.timeoutMs}ms (SIGTERM): ${redactStderr(result.stderr)}`
+        );
+      }
+      if (result.code !== 0) {
+        throw new Error(
+          `[cli-inference] claude exited ${result.code} signal=${result.signal}: ${redactStderr(result.stderr)}`
+        );
+      }
+      const text = result.stdout.trim();
+      if (text.length === 0) {
+        throw new Error(
+          `[cli-inference] claude returned empty stdout: ${redactStderr(result.stderr)}`
+        );
+      }
+      return text;
+    } finally {
+      await rm(rawCwd, { recursive: true, force: true }).catch((err) => {
+        logger.debug(`[cli-inference] failed to clean isolated cwd ${rawCwd}: ${String(err)}`);
+      });
+    }
+  }
+}

--- a/plugins/plugin-cli-inference/src/codex-cli-exec.ts
+++ b/plugins/plugin-cli-inference/src/codex-cli-exec.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@elizaos/core";
+import {
+  __setSpawnForTests as __setClaudeSpawn,
+  type ClaudeGenerateParams,
+  defaultSpawn,
+  type SpawnFn,
+  type SpawnResult,
+} from "./claude-cli";
+import { flattenPrompt } from "./prompt-flatten";
+import { filterEnv, redactSensitive, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
+
+/**
+ * Codex CLI inference variant (TOS-clean SAFE/CLOUD route).
+ *
+ * Spawns the sanctioned `codex exec` binary, which reads its OWN OAuth creds
+ * from `~/.codex/auth.json`. As with the claude variant, eliza never sees or
+ * forwards the subscription token; the child env is `filterEnv`'d and stderr is
+ * redacted before logging. `codex exec` runs read-only in an isolated cwd.
+ *
+ * codex `exec` stdout is noisier than `claude --output-format text`: we request
+ * `--json` (JSONL events) and pull the LAST assistant message text, falling
+ * back to the raw trimmed stdout if no JSONL assistant event was emitted.
+ */
+
+const DEFAULT_MODEL = "gpt-5.5";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const CODEX_BINARY = "codex";
+
+// Reuse the spawner seam from claude-cli so tests can mock a single spawn fn.
+// Defaults to the real `defaultSpawn` (mirrors the claude variant) so a
+// production codex call works without any test seam being installed.
+let spawnImpl: SpawnFn = defaultSpawn;
+
+/** Test seam: swap the child-process spawner used by BOTH CLI variants. */
+export function __setSpawnForTests(fn: SpawnFn): () => void {
+  const prev = spawnImpl;
+  spawnImpl = fn;
+  // Also route the claude variant through the same mock for a single seam.
+  const restoreClaude = __setClaudeSpawn(fn);
+  return () => {
+    spawnImpl = prev;
+    restoreClaude();
+  };
+}
+
+export interface CodexCliConfig {
+  model?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  /** Injected spawner; defaults to the seam set via `__setSpawnForTests`. */
+  spawnFn?: SpawnFn;
+  /**
+   * Pin the resolved binary path, skipping `resolveSafeBinary`. Used by unit
+   * tests and by container deploys that pin the CLI outside the default
+   * allowlist. When unset, the binary is resolved from PATH against the SOC2
+   * whitelist.
+   */
+  binaryPath?: string;
+}
+
+function redactStderr(stderr: string): string {
+  return redactSensitive(stderr).slice(0, 2000);
+}
+
+export class CodexParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexParseError";
+  }
+}
+
+/**
+ * Extract the assistant text from codex `--json` JSONL stdout. codex emits one
+ * JSON object per line; the assistant's answer arrives as an `agent_message` /
+ * `item.completed` (message) event, and a long answer can be split across
+ * several such events. We concatenate EVERY assistant fragment in emission
+ * order (truncating to the last one would drop split `<response>` blocks).
+ *
+ * Returns `{ ok: true, text }` when at least one assistant fragment was found,
+ * `{ ok: false, sawJson }` otherwise. `sawJson` is true when any line parsed as
+ * JSON — the caller falls back to raw stdout ONLY when zero lines were JSON
+ * (real banner-only output); if lines were JSON but none were assistant events,
+ * the caller throws rather than dumping the raw JSONL to the channel.
+ */
+function collectAssistantFragments(
+  stdout: string
+): { ok: true; text: string } | { ok: false; sawJson: boolean } {
+  const lines = stdout.split(/\r?\n/);
+  const fragments: string[] = [];
+  let sawJson = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed[0] !== "{") continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    sawJson = true;
+    const text = extractAssistantText(obj);
+    if (text && text.trim().length > 0) fragments.push(text.trim());
+  }
+  if (fragments.length > 0) return { ok: true, text: fragments.join("\n") };
+  return { ok: false, sawJson };
+}
+
+/**
+ * Parse codex `--json` JSONL stdout into the assistant answer, concatenating
+ * all assistant fragments in order. Falls back to the raw trimmed stdout ONLY
+ * when no line was JSON at all (banner-only output). If lines parsed as JSON but
+ * none were assistant events, throws `CodexParseError` rather than leaking the
+ * raw JSONL to the channel.
+ */
+export function parseCodexJsonl(stdout: string): string {
+  const result = collectAssistantFragments(stdout);
+  if (result.ok) return result.text;
+  if (result.sawJson) {
+    throw new CodexParseError(
+      "[cli-inference] codex emitted JSONL events but no assistant message was found"
+    );
+  }
+  return stdout.trim();
+}
+
+function extractAssistantText(obj: unknown): string | undefined {
+  if (typeof obj !== "object" || obj === null) return undefined;
+  const record = obj as Record<string, unknown>;
+
+  // Newer codex: { type: "item.completed", item: { type: "message"|"agent_message", text } }
+  const item = record.item;
+  if (typeof item === "object" && item !== null) {
+    const itemRecord = item as Record<string, unknown>;
+    const itemType = itemRecord.type;
+    if (
+      itemType === "message" ||
+      itemType === "agent_message" ||
+      itemType === "assistant_message"
+    ) {
+      const text = pickText(itemRecord);
+      if (text) return text;
+    }
+  }
+
+  // Flat shape: { type: "agent_message", message|text }
+  const type = record.type;
+  if (type === "agent_message" || type === "assistant_message" || type === "message") {
+    const text = pickText(record);
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function pickText(record: Record<string, unknown>): string | undefined {
+  for (const key of ["text", "message", "content"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export class CodexCli {
+  private readonly model: string;
+  private readonly timeoutMs: number;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly spawnFn?: SpawnFn;
+  private readonly binaryPath?: string;
+
+  constructor(config: CodexCliConfig = {}) {
+    this.model = config.model ?? DEFAULT_MODEL;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.env = config.env ?? process.env;
+    this.spawnFn = config.spawnFn;
+    this.binaryPath = config.binaryPath;
+  }
+
+  private getSpawn(): SpawnFn {
+    return this.spawnFn ?? spawnImpl;
+  }
+
+  async generate(params: ClaudeGenerateParams): Promise<string> {
+    const { system, body } = flattenPrompt(params);
+    // codex `exec` takes ONE positional prompt — fold the system block on top.
+    const prompt = system.trim().length > 0 ? `${system}\n\n${body}` : body;
+    const binary = this.binaryPath ?? resolveSafeBinary(CODEX_BINARY, this.env);
+
+    const rawCwd = await mkdtemp(join(tmpdir(), "eliza-cli-inference-"));
+    const cwd = resolveSafeCwd(rawCwd, [tmpdir()]);
+
+    try {
+      const argv = [
+        binary,
+        "exec",
+        "-m",
+        this.model,
+        "-s",
+        "read-only",
+        "--skip-git-repo-check",
+        "-C",
+        cwd,
+        "--color",
+        "never",
+        "--json",
+        prompt,
+      ];
+
+      const result: SpawnResult = await this.getSpawn()(argv, {
+        cwd,
+        env: filterEnv(this.env),
+        timeoutMs: this.timeoutMs,
+        stdinPath: "/dev/null",
+      });
+
+      if (result.timedOut) {
+        throw new Error(
+          `[cli-inference] codex timed out after ${this.timeoutMs}ms (SIGTERM): ${redactStderr(result.stderr)}`
+        );
+      }
+      if (result.code !== 0) {
+        throw new Error(
+          `[cli-inference] codex exited ${result.code} signal=${result.signal}: ${redactStderr(result.stderr)}`
+        );
+      }
+      // parseCodexJsonl already handles the banner-only fallback and throws
+      // (rather than dumping raw JSONL) when JSON events were present but none
+      // were assistant messages.
+      const text = parseCodexJsonl(result.stdout);
+      if (text.length === 0) {
+        throw new Error(
+          `[cli-inference] codex returned empty stdout: ${redactStderr(result.stderr)}`
+        );
+      }
+      return text;
+    } finally {
+      await rm(rawCwd, { recursive: true, force: true }).catch((err) => {
+        logger.debug(`[cli-inference] failed to clean isolated cwd ${rawCwd}: ${String(err)}`);
+      });
+    }
+  }
+}

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -1,0 +1,99 @@
+import type { ChatMessage, ChatMessageContentPart } from "@elizaos/core";
+
+/**
+ * Flatten `GenerateTextParams` (system + messages/prompt) into the two strings
+ * the sanctioned CLIs consume:
+ *
+ *   - `system`  → claude `--system-prompt` (full replace) / codex top instructions block.
+ *   - `body`    → claude `-p <body>` / codex `exec <body>` positional prompt.
+ *
+ * HARD REQ: both `params.system` AND `params.messages`/`params.prompt` must be
+ * forwarded. Dropping `messages` would strip skills/memory/recent-conversation/
+ * the `<response>` grammar that the runtime composes into the message array, so
+ * the model would answer blind. System/developer-role messages are re-routed to
+ * the system slot (joined with an explicit `params.system`); every other role is
+ * flattened, in order, into the body. Nothing is dropped.
+ */
+
+export interface FlattenedPrompt {
+  /** Goes to claude `--system-prompt` / codex instructions block. */
+  system: string;
+  /** Goes to claude `-p` / codex `exec` positional prompt. */
+  body: string;
+}
+
+function contentToText(content: ChatMessage["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part: ChatMessageContentPart) =>
+      part.type === "text" && typeof part.text === "string" ? part.text : ""
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Render one non-system message as a labeled transcript block. */
+function renderMessage(message: ChatMessage): string {
+  const text = contentToText(message.content);
+  // Surface assistant tool calls so a multi-turn transcript keeps the call/
+  // result pairing visible to the CLI model (it has no native tool-call slot
+  // here — everything is flattened text).
+  const toolCallLines =
+    message.role === "assistant" && message.toolCalls?.length
+      ? message.toolCalls.map((call) => {
+          const args =
+            typeof call.arguments === "string"
+              ? call.arguments
+              : JSON.stringify(call.arguments ?? {});
+          return `[tool_call ${call.name} ${args}]`;
+        })
+      : [];
+
+  const label =
+    message.role === "assistant" ? "Assistant" : message.role === "tool" ? "Tool result" : "User";
+
+  const lines = [text, ...toolCallLines].filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return "";
+  return `${label}: ${lines.join("\n")}`;
+}
+
+export function flattenPrompt(params: {
+  system?: string;
+  prompt?: string;
+  messages?: ChatMessage[];
+}): FlattenedPrompt {
+  const systemParts: string[] = [];
+  if (params.system && params.system.trim().length > 0) {
+    systemParts.push(params.system);
+  }
+
+  const bodyParts: string[] = [];
+  let lastBodyText = "";
+
+  for (const message of params.messages ?? []) {
+    if (message.role === "system" || message.role === "developer") {
+      const text = contentToText(message.content);
+      if (text.trim().length > 0) systemParts.push(text);
+      continue;
+    }
+    const rendered = renderMessage(message);
+    if (rendered.length > 0) {
+      bodyParts.push(rendered);
+      lastBodyText = contentToText(message.content);
+    }
+  }
+
+  // The legacy `prompt` string is appended only when it isn't already the tail
+  // of the message transcript (callers that pass `messages` usually leave it
+  // empty, but some still set both — avoid duplicating it).
+  if (params.prompt && params.prompt.trim().length > 0 && params.prompt !== lastBodyText) {
+    bodyParts.push(params.prompt);
+  }
+
+  return {
+    system: systemParts.join("\n\n"),
+    body: bodyParts.join("\n\n"),
+  };
+}

--- a/plugins/plugin-cli-inference/src/sandbox.ts
+++ b/plugins/plugin-cli-inference/src/sandbox.ts
@@ -1,0 +1,311 @@
+/**
+ * SOC2 sandbox helpers, copied from
+ * `@elizaos/plugin-sub-agent-claude-code/src/sandbox.ts` so this node-only
+ * model-provider plugin does not depend on the worker-bundled remote plugin.
+ *
+ * Keep in sync with the upstream copy if `SAFE_ENV_KEYS` / `SENSITIVE_ENV_RE`
+ * change. Additions here over the upstream copy: the `SENSITIVE_ENV_RE` export
+ * and `redactSensitive`, used by the CLI handlers to redact subprocess stderr
+ * before logging.
+ *
+ * - `filterEnv` — explicit allowlist + token blocklist for child env.
+ * - `resolveSafeCwd` — realpath validation; cwd must be under workspace or /tmp.
+ * - `resolveSafeBinary` — PATH lookup constrained to an allowlisted launcher dir.
+ * - `redactSensitive` — strips key-named + value-shaped secrets from stderr.
+ * - `buildSandboxedCommand` — wraps argv in sandbox-exec (macOS) or bwrap (Linux).
+ */
+
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { delimiter, dirname, isAbsolute, resolve, sep } from "node:path";
+
+/** Env keys that may be forwarded to a sub-agent verbatim. */
+export const SAFE_ENV_KEYS: ReadonlySet<string> = new Set([
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "LANG",
+  "LC_ALL",
+  "SHELL",
+  "TERM",
+  "USER",
+  "LOGNAME",
+]);
+
+/**
+ * Defensive blocklist applied to BOTH the inherited env subset (after
+ * allowlist) and `extraEnv`. If a key matches this regex it is dropped.
+ */
+export const SENSITIVE_ENV_RE =
+  /(TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL|DATABASE_URL|WALLET|PRIVATE|MNEMONIC|API_KEY)/i;
+
+/** Whitelisted absolute directories that may host the sub-agent binary. */
+const BINARY_DIR_ALLOWLIST: readonly string[] = [
+  "/usr/local/bin",
+  "/usr/bin",
+  "/opt/homebrew/bin",
+  `${homedir()}/.local/bin`,
+  `${homedir()}/.bun/bin`,
+  `${homedir()}/.cargo/bin`,
+];
+
+export function filterEnv(
+  source: NodeJS.ProcessEnv,
+  allow: ReadonlySet<string> = SAFE_ENV_KEYS,
+  extra: Record<string, string | undefined> = {}
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of allow) {
+    const value = source[key];
+    if (value === undefined) continue;
+    if (SENSITIVE_ENV_RE.test(key)) continue;
+    out[key] = value;
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value === undefined) continue;
+    if (SENSITIVE_ENV_RE.test(key)) {
+      throw new Error(`Refusing to forward sensitive env var to sub-agent: ${key}`);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export class SubAgentCwdError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubAgentCwdError";
+  }
+}
+
+/**
+ * Resolve `cwd` to its realpath and require it to live under one of
+ * the supplied workspace roots OR `/tmp`. Symlink escapes are rejected.
+ */
+export function resolveSafeCwd(cwd: string, workspaceRoots: readonly string[]): string {
+  if (!cwd || typeof cwd !== "string") {
+    throw new SubAgentCwdError("cwd is required");
+  }
+  if (!isAbsolute(cwd)) {
+    throw new SubAgentCwdError(`cwd must be absolute: ${cwd}`);
+  }
+  if (!existsSync(cwd) || !statSync(cwd).isDirectory()) {
+    throw new SubAgentCwdError(`cwd does not exist or is not a directory: ${cwd}`);
+  }
+  const real = realpathSync(cwd);
+  const tmpReal = realpathSync(tmpdir());
+  const candidates = [...workspaceRoots, tmpReal]
+    .filter((root): root is string => typeof root === "string" && root.length > 0)
+    .map((root) => {
+      try {
+        return realpathSync(root);
+      } catch {
+        return resolve(root);
+      }
+    });
+  for (const root of candidates) {
+    if (real === root || real.startsWith(root + sep)) return real;
+  }
+  throw new SubAgentCwdError(
+    `cwd ${real} is not under any allowed workspace root (${candidates.join(", ")})`
+  );
+}
+
+export class SubAgentBinaryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubAgentBinaryError";
+  }
+}
+
+/**
+ * Resolve `binary` (name or path) to an absolute path under the binary
+ * whitelist. PATH lookup uses `which` semantics constrained to safe dirs.
+ */
+export function resolveSafeBinary(binary: string, env: NodeJS.ProcessEnv = process.env): string {
+  if (!binary) throw new SubAgentBinaryError("binary is required");
+
+  const candidateDirs = BINARY_DIR_ALLOWLIST.slice();
+
+  // We validate the LAUNCHER path (the entry the agent will exec) against the
+  // allowlist, NOT its realpath target. Standard installs symlink the launcher
+  // from an allowlisted dir (e.g. ~/.local/bin/claude, ~/.local/bin/codex) into
+  // a versioned/node_modules location that is intentionally outside the
+  // allowlist. Trust is established by the launcher living in an allowlisted
+  // dir; following the symlink to its target and re-checking that against the
+  // allowlist would reject every real install. We still keep the symlink target
+  // (`real`) so the spawned argv is stable across version bumps.
+  let launcher: string | null = null;
+  if (isAbsolute(binary)) {
+    // An absolute path is only trusted if its own directory is allowlisted.
+    if (existsSync(binary)) {
+      const dir = dirname(binary);
+      if (candidateDirs.some((d) => dir === d || dir.startsWith(d + sep))) {
+        launcher = binary;
+      }
+    }
+  } else if (binary.includes("/")) {
+    throw new SubAgentBinaryError(`binary must be absolute or a bare name: ${binary}`);
+  } else {
+    // `which`-style lookup, restricted to whitelisted dirs only.
+    const pathDirs = (env.PATH ?? "").split(delimiter);
+    for (const dir of pathDirs) {
+      const real = (() => {
+        try {
+          return realpathSync(dir);
+        } catch {
+          return dir;
+        }
+      })();
+      if (!candidateDirs.includes(real)) continue;
+      const guess = `${real}${sep}${binary}`;
+      if (existsSync(guess)) {
+        launcher = guess;
+        break;
+      }
+    }
+    // Last-resort: scan whitelist directly.
+    if (!launcher) {
+      for (const dir of candidateDirs) {
+        const guess = `${dir}${sep}${binary}`;
+        if (existsSync(guess)) {
+          launcher = guess;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!launcher || !existsSync(launcher)) {
+    throw new SubAgentBinaryError(
+      `Could not resolve ${binary} under any whitelisted dir: ${candidateDirs.join(", ")}`
+    );
+  }
+
+  // The launcher lives in an allowlisted dir (validated above). Resolve it to
+  // its realpath for a stable argv, but do NOT re-check the target against the
+  // allowlist — symlinking out of the allowlist is exactly how the real
+  // claude/codex installs are laid out.
+  return realpathSync(launcher);
+}
+
+export interface SandboxPlan {
+  cmd: string[];
+  /** Identifier of the sandbox layer in use; `"none"` when no helper available. */
+  sandbox: "macos-sandbox-exec" | "linux-bwrap" | "none";
+}
+
+export interface SandboxOptions {
+  workspaceRoot: string;
+  sessionId: string;
+  /** Path to a macOS .sb profile. Required on darwin. */
+  macosProfile?: string;
+  /** Path to the bwrap wrapper script. Required on linux. */
+  linuxWrapper?: string;
+}
+
+/**
+ * Build the final argv for spawning the sub-agent, prepended by an OS
+ * sandbox helper when available. Returns `sandbox: "none"` and the raw
+ * argv when no helper exists (Windows, or missing profile in dev) — the
+ * caller MUST log a WARN in that case.
+ */
+export function buildSandboxedCommand(argv: string[], opts: SandboxOptions): SandboxPlan {
+  if (process.platform === "darwin") {
+    if (opts.macosProfile && existsSync(opts.macosProfile) && hasBinary("/usr/bin/sandbox-exec")) {
+      const cmd = [
+        "/usr/bin/sandbox-exec",
+        "-D",
+        `WORKSPACE=${opts.workspaceRoot}`,
+        "-D",
+        `SESSION=${opts.sessionId}`,
+        "-D",
+        `HOME=${homedir()}`,
+        "-D",
+        `TMPDIR=${tmpdir()}`,
+        "-f",
+        opts.macosProfile,
+        ...argv,
+      ];
+      return { cmd, sandbox: "macos-sandbox-exec" };
+    }
+    return { cmd: argv, sandbox: "none" };
+  }
+  if (process.platform === "linux") {
+    if (opts.linuxWrapper && existsSync(opts.linuxWrapper) && hasBinary("/usr/bin/bwrap")) {
+      const cmd = [opts.linuxWrapper, opts.workspaceRoot, opts.sessionId, "--", ...argv];
+      return { cmd, sandbox: "linux-bwrap" };
+    }
+    return { cmd: argv, sandbox: "none" };
+  }
+  return { cmd: argv, sandbox: "none" };
+}
+
+function hasBinary(absPath: string): boolean {
+  try {
+    return existsSync(absPath);
+  } catch {
+    return false;
+  }
+}
+
+/** True iff the path resolved cleanly to an executable file. */
+export function isExecutable(path: string): boolean {
+  try {
+    const real = realpathSync(path);
+    const stat = statSync(real);
+    // 0o111 = any-execute bit.
+    return stat.isFile() && (stat.mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort discovery of the bundled sandbox profile paths relative to
+ * the package root. Returns undefined when the file is missing so callers
+ * can fall through to no-sandbox + WARN.
+ */
+export function locateBundledProfiles(packageRoot: string): {
+  macosProfile?: string;
+  linuxWrapper?: string;
+} {
+  const macos = resolve(packageRoot, "sandbox", "macos.sb");
+  const linux = resolve(packageRoot, "sandbox", "linux-bwrap.sh");
+  return {
+    ...(existsSync(macos) ? { macosProfile: macos } : {}),
+    ...(existsSync(linux) ? { linuxWrapper: linux } : {}),
+  };
+}
+
+/**
+ * Value-shaped secret patterns. `SENSITIVE_ENV_RE` only catches lines that
+ * mention a sensitive KEY name (e.g. `ANTHROPIC_API_KEY=...`); these catch the
+ * raw secret VALUE even when it appears with no key (a stack trace, a curl
+ * echo, a leaked header). Applied to subprocess stderr before logging.
+ */
+const SENSITIVE_VALUE_RES: readonly RegExp[] = [
+  /sk-ant-[A-Za-z0-9_-]{8,}/g, // Anthropic API keys
+  /sk-proj-[A-Za-z0-9_-]{8,}/g, // OpenAI project keys
+  /sk-[A-Za-z0-9_-]{8,}/g, // generic OpenAI-style keys
+  /oat[_-][A-Za-z0-9_-]{8,}/gi, // OAuth access tokens (oat_...)
+  /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g, // JWTs (header.payload.sig)
+  /gh[pousr]_[A-Za-z0-9]{8,}/g, // GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_)
+];
+
+const SECRET_PLACEHOLDER = "[REDACTED]";
+
+/**
+ * Redact secrets out of arbitrary text (subprocess stderr) before logging:
+ * drop any line matching a sensitive KEY name, then mask value-shaped secrets
+ * (sk-ant-*, sk-proj-*, sk-*, oat*, JWTs, gh*_*) anywhere in the remaining
+ * lines.
+ */
+export function redactSensitive(text: string): string {
+  const lines = text.split(/\r?\n/).filter((line) => !SENSITIVE_ENV_RE.test(line));
+  let out = lines.join("\n");
+  for (const re of SENSITIVE_VALUE_RES) {
+    out = out.replace(re, SECRET_PLACEHOLDER);
+  }
+  return out;
+}

--- a/plugins/plugin-cli-inference/tsconfig.build.json
+++ b/plugins/plugin-cli-inference/tsconfig.build.json
@@ -1,0 +1,32 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "ignoreDeprecations": "6.0",
+    "noEmit": false,
+    "paths": {
+      "@elizaos/core": [
+        "../../../packages/core/dist"
+      ]
+    },
+    "types": [
+      "node",
+      "bun-types"
+    ]
+  },
+  "include": [
+    "index.ts",
+    "index.node.ts",
+    "index.browser.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "__tests__",
+    "**/*.test.ts",
+    "build.ts"
+  ]
+}

--- a/plugins/plugin-cli-inference/tsconfig.json
+++ b/plugins/plugin-cli-inference/tsconfig.json
@@ -1,0 +1,47 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "strict": false,
+    "strictNullChecks": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": false,
+    "noImplicitAny": false,
+    "allowImportingTsExtensions": true,
+    "types": [
+      "node",
+      "bun-types"
+    ],
+    "paths": {
+      "@elizaos/core": [
+        "../../../packages/core/dist/node"
+      ]
+    }
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts",
+    "build.ts"
+  ]
+}

--- a/plugins/plugin-cli-inference/vitest.config.ts
+++ b/plugins/plugin-cli-inference/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+const elizaRoot = path.resolve(import.meta.dirname, "../..");
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@elizaos\/core$/,
+        replacement: path.join(elizaRoot, "packages", "core", "dist", "node", "index.node.js"),
+      },
+    ],
+  },
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/*.live.test.ts", "**/*.real.test.ts"],
+  },
+});


### PR DESCRIPTION
## What

A model-provider plugin (`@elizaos/plugin-cli-inference`) that serves chat/planner inference by spawning the **local Claude Code / Codex CLI** (`claude --print` / `codex exec`) as eliza model handlers, instead of calling the vendor HTTP API.

## Why

This lets an agent run its chat on the operator's **Claude Max / ChatGPT subscription via the sanctioned CLI** — the licensed vehicle for those subscriptions — rather than replaying a consumer-subscription token against the API. Useful for self-hosted operators and for per-user dedicated cloud containers where each user brings their own CLI auth.

## Design

- **Inert unless `ELIZA_CHAT_VIA_CLI=claude|codex`** — self-gated; loads via `PROVIDER_PLUGIN_MAP` + its own `autoEnableModule`. Zero effect on existing paths when unset.
- Registers `TEXT_LARGE` / `TEXT_MEGA` / `RESPONSE_HANDLER` at **priority 100** so it deterministically wins those tiers when enabled. **Does not** register `ACTION_PLANNER` — the CLI can't honor GBNF / native-tool / `responseSchema` constrained decoding, so the planner stays on the configured grammar/tool-honoring provider. `RESPONSE_HANDLER` (the user-facing reply) is the intended sub-served tier.
- Threads eliza's **full composed prompt** (`system` + `messages`) to the CLI, so the model produces eliza's exact structured output.
- **Sandboxed**: runs in an isolated empty cwd, env-filtered (`filterEnv`), binary-allowlisted; never injects the subscription token into the child env or logs (the CLI reads `~/.claude` / `~/.codex` itself). stderr is value-redacted.
- Per-call timeout with SIGKILL escalation + process-group kill; throws on timeout/non-zero-exit/empty-output so the runtime falls back to the configured provider.

## Testing

Unit tests (26) mock the spawn and assert argv, context threading, the timeout/error paths, and binary resolution. Verified end-to-end against the real `claude --print` and `codex exec` binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
