### PR TITLE
feat(core): support callback functions in character templates

### DIFF
--- a/packages/core/src/__tests__/callback-templates.test.ts
+++ b/packages/core/src/__tests__/callback-templates.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import type { Character } from "../types/agent";
+import { composePromptFromState } from "../utils";
+import type { State } from "../types/state";
+
+describe("Character Callback Templates", () => {
+	it("should support string templates (existing behavior)", async () => {
+		const template = "Hello, {{agentName}}!";
+		const state: State = {
+			agentName: "Alice",
+			values: {},
+			data: {},
+			text: "",
+		};
+
+		const result = composePromptFromState({ state, template });
+		expect(result).toContain("Alice");
+	});
+
+	it("should support callback templates that return strings", async () => {
+		const template = ({ state }: { state: State | Record<string, unknown> }) => {
+			const agentName =
+				typeof state === "object" && "agentName" in state
+					? (state.agentName as string)
+					: "Unknown";
+			return `Hello, ${agentName}!`;
+		};
+
+		const state: State = {
+			agentName: "Bob",
+			values: {},
+			data: {},
+			text: "",
+		};
+
+		const result = composePromptFromState({ state, template });
+		expect(result).toContain("Bob");
+	});
+
+	it("should support callbacks with dynamic logic", async () => {
+		const template = ({ state }: { state: State | Record<string, unknown> }) => {
+			const stateObj = state as Record<string, unknown>;
+			const tone = stateObj.formalTone ? "formal" : "casual";
+			return `Respond in a {{tone}} manner. {{agentName}} here.`.replace(
+				"{{tone}}",
+				tone
+			);
+		};
+
+		const state: State = {
+			agentName: "Charlie",
+			formalTone: true,
+			values: {},
+			data: {},
+			text: "",
+		};
+
+		const result = composePromptFromState({ state, template });
+		expect(result).toContain("formal");
+		expect(result).toContain("Charlie");
+	});
+
+	it("should handle mixed string and callback templates in character", async () => {
+		const character: Character = {
+			name: "TestAgent",
+			templates: {
+				stringTemplate: "Simple string template",
+				callbackTemplate: ({ state }: { state: State | Record<string, unknown> }) => {
+					const stateObj = state as Record<string, unknown>;
+					return `Dynamic template with ${stateObj.agentName || "agent"}`;
+				},
+			},
+		};
+
+		const state: State = {
+			agentName: "TestAgent",
+			values: {},
+			data: {},
+			text: "",
+		};
+
+		// Test string template
+		const stringResult = composePromptFromState({
+			state,
+			template: character.templates!.stringTemplate as string,
+		});
+		expect(stringResult).toBe("Simple string template");
+
+		// Test callback template
+		const callbackResult = composePromptFromState({
+			state,
+			template: character.templates!.callbackTemplate,
+		});
+		expect(callbackResult).toContain("Dynamic template");
+		expect(callbackResult).toContain("TestAgent");
+	});
+
+	it("should allow callbacks to access full state context", async () => {
+		const template = ({ state }: { state: State | Record<string, unknown> }) => {
+			const stateObj = state as State;
+			return `Agent: {{agentName}}, Context: {{roomId}}`.replace(
+				/\{\{(\w+)\}\}/g,
+				(match, key) => {
+					const value = stateObj[key as keyof State];
+					return typeof value === "string" ? value : String(value);
+				}
+			);
+		};
+
+		const state: State = {
+			agentName: "David",
+			roomId: "room-123",
+			values: {},
+			data: {},
+			text: "",
+		};
+
+		const result = composePromptFromState({ state, template });
+		expect(result).toContain("David");
+		expect(result).toContain("room-123");
+	});
+});

--- a/packages/core/src/schemas/character.ts
+++ b/packages/core/src/schemas/character.ts
@@ -251,9 +251,22 @@ export const characterSchema = z
 				"System prompt that defines the character's core behavior and response style",
 			),
 		templates: z
-			.record(z.string(), z.string())
+			.record(z.string(), z.unknown())
 			.default({})
-			.describe("Custom templates for generating different types of content"),
+			.transform((templates: Record<string, unknown>) => {
+				// Validate that all templates are either strings or functions
+				for (const [key, value] of Object.entries(templates)) {
+					if (typeof value !== 'string' && typeof value !== 'function') {
+						throw new Error(
+							`Template "${key}" must be a string or function, got ${typeof value}`
+						);
+					}
+				}
+				return templates as { [key: string]: TemplateType };
+			})
+			.describe(
+				"Custom templates for generating different types of content. Can be strings or functions that take { state } and return a string."
+			),
 		bio: z
 			.union([z.string(), z.array(z.string())])
 			.optional()

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -63,7 +63,7 @@ export interface Character {
 	name?: string;
 	username?: string;
 	system?: string;
-	templates?: { [key: string]: string };
+	templates?: { [key: string]: TemplateType };
 	bio?: string[];
 	postExamples?: string[];
 	topics?: string[];


### PR DESCRIPTION
# Relates to

The Template System

---

# Risks

**Low to Medium**

### What could be affected:
- Character template validation in runtime schema parsing
- Any external systems persisting or serializing `templates`
- Downstream consumers expecting `templates` to be strictly `string`

### Mitigations:
- Runtime validation ensures only `string | function` values are accepted
- Backward compatibility preserved for existing string-based templates
- No changes to existing composition logic behavior

---

# Background

## What does this PR do?
Adds support for callback-based templates in `Character.templates`, allowing templates to be dynamically generated using runtime state.

## What kind of change is this?
Feature (non-breaking change which adds functionality)

---

# Documentation changes needed?

No documentation changes required for core functionality.
(Optional improvement: update developer docs to mention callback templates)

---

# Testing

## Where should a reviewer start?
- `packages/core/src/types/agent.ts`
- `packages/core/src/schemas/character.ts`
- `packages/core/src/__tests__/callback-templates.test.ts`

## Detailed testing steps

```bash
cd packages/core
npm test -- callback-templates.test.ts