### PR TITLE
perf(core): batch the embedding drain so one request embeds N texts

### DIFF
--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -4,7 +4,7 @@ import type { Memory } from "../types/memory";
 import { ModelType } from "../types/model";
 import type { IAgentRuntime } from "../types/runtime";
 import { Service } from "../types/service";
-import { BatchQueue } from "../utils/batch-queue";
+import { type BatchItemOutcome, BatchQueue } from "../utils/batch-queue";
 
 interface EmbeddingQueueItem {
 	memory: Memory;
@@ -93,6 +93,12 @@ export class EmbeddingGenerationService extends Service {
 			maxParallel: 10,
 			maxRetriesAfterFailure: 3,
 			process: (item) => this.generateEmbedding(item),
+			// Batched drain: embed the whole dequeued slice in ONE model call
+			// (TEXT_EMBEDDING_BATCH) when the provider registers it; collapses the
+			// ~19 serial single-text round-trips/turn that made post-turn embedding
+			// take ~30s. On any batch failure the queue falls back to `process`
+			// (per-item) above, preserving retry/onExhausted.
+			processBatch: (items) => this.generateBatchEmbeddings(items),
 			onExhausted: async (item, error) => {
 				await this.runtime.log({
 					entityId: this.runtime.agentId,
@@ -243,6 +249,89 @@ export class EmbeddingGenerationService extends Service {
 			);
 			throw error;
 		}
+	}
+
+	/**
+	 * Batched drain path: embed every queued item's text in ONE
+	 * `TEXT_EMBEDDING_BATCH` model call, then persist each vector. Wired as the
+	 * BatchQueue `processBatch` — on ANY failure it throws, and the queue falls
+	 * back to the per-item {@link generateEmbedding} path (which carries the
+	 * retry / onExhausted semantics), so this only implements the happy path.
+	 * Idempotent: a fallback re-run just re-`updateMemory`s the same vectors.
+	 */
+	private async generateBatchEmbeddings(
+		items: EmbeddingQueueItem[],
+	): Promise<BatchItemOutcome<EmbeddingQueueItem>[]> {
+		const outcomes: BatchItemOutcome<EmbeddingQueueItem>[] = [];
+		const toEmbed: { item: EmbeddingQueueItem; text: string }[] = [];
+		for (const item of items) {
+			const text = item.memory.content?.text;
+			// No text or already vectored -> successful no-op (mirrors per-item skips).
+			if (!text || item.memory.embedding) {
+				outcomes.push({ item, success: true, retryCount: 0 });
+				continue;
+			}
+			toEmbed.push({ item, text });
+		}
+		if (toEmbed.length === 0) {
+			return outcomes;
+		}
+
+		const startTime = Date.now();
+		// One request for all texts. Throws on failure -> caller falls back to
+		// the per-item path. (A single text still goes through the same batch fn.)
+		const embeddings = await this.runtime.useModel(
+			ModelType.TEXT_EMBEDDING_BATCH,
+			{
+				texts: toEmbed.map((t) => t.text),
+			},
+		);
+		const durationMs = Date.now() - startTime;
+
+		if (!Array.isArray(embeddings) || embeddings.length !== toEmbed.length) {
+			throw new Error(
+				`[embedding] batch returned ${
+					Array.isArray(embeddings) ? embeddings.length : "non-array"
+				} vectors for ${toEmbed.length} texts`,
+			);
+		}
+
+		for (let i = 0; i < toEmbed.length; i++) {
+			const { item } = toEmbed[i];
+			const embedding = embeddings[i];
+			const { memory } = item;
+			if (memory.id) {
+				await this.runtime.updateMemory({ id: memory.id, embedding });
+				await this.runtime.log({
+					entityId: this.runtime.agentId,
+					roomId: memory.roomId || this.runtime.agentId,
+					type: "embedding_event",
+					body: {
+						runId: item.runId,
+						memoryId: memory.id,
+						status: "completed",
+						duration: durationMs,
+						source: "embeddingService:batch",
+					},
+				});
+				await this.runtime.emitEvent(EventType.EMBEDDING_GENERATION_COMPLETED, {
+					runtime: this.runtime,
+					memory: { ...memory, embedding },
+					source: "embeddingService",
+				});
+			}
+			outcomes.push({ item, success: true, retryCount: 0 });
+		}
+		this.runtime.logger.debug(
+			{
+				src: "plugin:basic-capabilities:service:embedding",
+				agentId: this.runtime.agentId,
+				count: toEmbed.length,
+				durationMs,
+			},
+			"Generated batch embeddings",
+		);
+		return outcomes;
 	}
 
 	async stop(): Promise<void> {

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -84,6 +84,14 @@ export class EmbeddingGenerationService extends Service {
 		// model as other services so we do not maintain another bespoke queue + task stack here.
 		// Task system owns WHEN (repeat EMBEDDING_DRAIN tick); we own WHAT (dequeue, embed, persist).
 		// No maxSize — bottleneck is embedding I/O, not queue length.
+		//
+		// Only wire the batched drain when the provider actually registers a
+		// TEXT_EMBEDDING_BATCH handler. Decided once here (vs a runtime
+		// negative-cache) so a non-batching provider (e.g. local gte-small) never
+		// pays a doomed batch attempt + per-item fallback on every drain.
+		const supportsBatchEmbedding = !!this.runtime.getModel(
+			ModelType.TEXT_EMBEDDING_BATCH,
+		);
 		this.batchQueue = new BatchQueue<EmbeddingQueueItem>({
 			name: EmbeddingGenerationService.EMBEDDING_DRAIN_TASK,
 			taskDescription: "Embedding generation drain",
@@ -98,7 +106,9 @@ export class EmbeddingGenerationService extends Service {
 			// ~19 serial single-text round-trips/turn that made post-turn embedding
 			// take ~30s. On any batch failure the queue falls back to `process`
 			// (per-item) above, preserving retry/onExhausted.
-			processBatch: (items) => this.generateBatchEmbeddings(items),
+			processBatch: supportsBatchEmbedding
+				? (items) => this.generateBatchEmbeddings(items)
+				: undefined,
 			onExhausted: async (item, error) => {
 				await this.runtime.log({
 					entityId: this.runtime.agentId,

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -58,6 +58,14 @@ export const ModelType = {
 	RESPONSE_HANDLER: "RESPONSE_HANDLER",
 	ACTION_PLANNER: "ACTION_PLANNER",
 	TEXT_EMBEDDING: "TEXT_EMBEDDING",
+	/**
+	 * Batch text embedding: one model call embeds N texts in a single request.
+	 * Providers that support a batched embeddings endpoint (e.g. `input: string[]`)
+	 * register this so callers that have many texts ready (the embedding-drain
+	 * service) avoid N serial single-text round-trips. Falls back to N×
+	 * {@link ModelType.TEXT_EMBEDDING} when a provider does not register it.
+	 */
+	TEXT_EMBEDDING_BATCH: "TEXT_EMBEDDING_BATCH",
 	TEXT_TOKENIZER_ENCODE: "TEXT_TOKENIZER_ENCODE",
 	TEXT_TOKENIZER_DECODE: "TEXT_TOKENIZER_DECODE",
 	TEXT_REASONING_SMALL: "REASONING_SMALL",
@@ -804,6 +812,13 @@ export interface TextEmbeddingParams {
 }
 
 /**
+ * Parameters for batch text embedding models — embed many texts in one call.
+ */
+export interface BatchTextEmbeddingParams {
+	texts: string[];
+}
+
+/**
  * Parameters for image generation models
  */
 export interface ImageGenerationParams {
@@ -1148,6 +1163,7 @@ export interface ModelParamsMap {
 	[ModelType.TEXT_REASONING_SMALL]: GenerateTextParams;
 	[ModelType.TEXT_REASONING_LARGE]: GenerateTextParams;
 	[ModelType.TEXT_EMBEDDING]: TextEmbeddingParams | string | null;
+	[ModelType.TEXT_EMBEDDING_BATCH]: BatchTextEmbeddingParams;
 	[ModelType.TEXT_TOKENIZER_ENCODE]: TokenizeTextParams;
 	[ModelType.TEXT_TOKENIZER_DECODE]: DetokenizeTextParams;
 	[ModelType.IMAGE]: ImageGenerationParams;
@@ -1182,6 +1198,7 @@ export interface ModelResultMap {
 	[ModelType.TEXT_REASONING_SMALL]: string;
 	[ModelType.TEXT_REASONING_LARGE]: string;
 	[ModelType.TEXT_EMBEDDING]: number[];
+	[ModelType.TEXT_EMBEDDING_BATCH]: number[][];
 	[ModelType.TEXT_TOKENIZER_ENCODE]: number[];
 	[ModelType.TEXT_TOKENIZER_DECODE]: string;
 	[ModelType.IMAGE]: ImageGenerationResult[];

--- a/packages/core/src/utils/batch-queue/index.ts
+++ b/packages/core/src/utils/batch-queue/index.ts
@@ -42,6 +42,15 @@ export interface BatchQueueOptions<T> {
 	drainIntervalMs: number;
 	getPriority: (item: T) => QueuePriority;
 	process: (item: T) => Promise<void>;
+	/**
+	 * Optional batched processor. When provided, a drain calls this ONCE with the
+	 * whole dequeued slice (so a provider that supports a batched request — e.g.
+	 * embeddings — sends one call instead of N). If it throws, the drain falls
+	 * back to the per-item {@link process} path, so all retry / `onExhausted`
+	 * semantics are preserved for failures. Existing per-item callers that don't
+	 * set this are completely unaffected.
+	 */
+	processBatch?: (items: T[]) => Promise<BatchItemOutcome<T>[]>;
 	maxParallel?: number;
 	maxRetriesAfterFailure?: number;
 	retryPolicy?: RetryConfig;
@@ -135,7 +144,18 @@ export class BatchQueue<T> {
 			if (batch.length === 0) {
 				return;
 			}
-			const outcomes = await this.batchProcessor.processBatch(batch);
+			// Prefer the batched processor when provided; on ANY batch-wide failure
+			// fall back to the per-item path so retry / onExhausted still apply.
+			let outcomes: BatchItemOutcome<T>[];
+			if (this.options.processBatch) {
+				try {
+					outcomes = await this.options.processBatch(batch);
+				} catch {
+					outcomes = await this.batchProcessor.processBatch(batch);
+				}
+			} else {
+				outcomes = await this.batchProcessor.processBatch(batch);
+			}
 			try {
 				this.options.onDrainBatchOutcomes?.(outcomes);
 			} catch {

--- a/packages/core/src/utils/batch-queue/process-batch.test.ts
+++ b/packages/core/src/utils/batch-queue/process-batch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import { BatchQueue } from "./index";
+
+/**
+ * Tests for the opt-in `processBatch` path on BatchQueue (added for the
+ * embedding-drain so N texts embed in one request). Existing per-item callers
+ * (no `processBatch`) are unaffected; with it set, a drain calls it ONCE and
+ * only falls back to the per-item `process` if the batched call throws.
+ */
+describe("BatchQueue processBatch", () => {
+	function makeQueue(opts: {
+		process: (item: number) => Promise<void>;
+		processBatch?: (
+			items: number[],
+		) => Promise<{ item: number; success: boolean; retryCount: number }[]>;
+	}) {
+		return new BatchQueue<number>({
+			name: "TEST_DRAIN",
+			batchSize: 10,
+			drainIntervalMs: 100,
+			getPriority: () => "normal",
+			maxParallel: 5,
+			process: opts.process,
+			processBatch: opts.processBatch,
+		});
+	}
+
+	test("a drain calls processBatch ONCE with the whole slice, not process per-item", async () => {
+		const perItem: number[] = [];
+		const batched: number[][] = [];
+		const q = makeQueue({
+			process: async (item) => {
+				perItem.push(item);
+			},
+			processBatch: async (items) => {
+				batched.push([...items]);
+				return items.map((item) => ({ item, success: true, retryCount: 0 }));
+			},
+		});
+
+		q.enqueue(1);
+		q.enqueue(2);
+		q.enqueue(3);
+		await q.drain();
+
+		// One batched call for all three; the per-item path never ran.
+		expect(batched).toEqual([[1, 2, 3]]);
+		expect(perItem).toEqual([]);
+	});
+
+	test("a batch-wide failure falls back to the per-item process path", async () => {
+		const perItem: number[] = [];
+		const q = makeQueue({
+			process: async (item) => {
+				perItem.push(item);
+			},
+			processBatch: async () => {
+				throw new Error("batch endpoint down");
+			},
+		});
+
+		q.enqueue(1);
+		q.enqueue(2);
+		await q.drain();
+
+		// processBatch threw -> every item was processed individually (retry path).
+		expect(perItem.sort()).toEqual([1, 2]);
+	});
+
+	test("without processBatch, behavior is unchanged (per-item only)", async () => {
+		const perItem: number[] = [];
+		const q = makeQueue({
+			process: async (item) => {
+				perItem.push(item);
+			},
+		});
+
+		q.enqueue(7);
+		q.enqueue(8);
+		await q.drain();
+
+		expect(perItem.sort()).toEqual([7, 8]);
+	});
+});

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -13,6 +13,7 @@ import {
   handleImageGeneration,
   handleResearch,
   handleResponseHandler,
+  handleBatchTextEmbedding,
   handleTextEmbedding,
   handleTextLarge,
   handleTextMedium,
@@ -172,6 +173,10 @@ export const elizaOSCloudPlugin: Plugin = {
   // ─── Inference Model Handlers ────────────────────────────────────────
   models: {
     [ModelType.TEXT_EMBEDDING]: handleTextEmbedding,
+    // Batch path: one request embeds N texts (the embedding-drain service uses
+    // this to collapse ~19 serial single-text round-trips into ~2 batched calls).
+    [ModelType.TEXT_EMBEDDING_BATCH]: (runtime, params: { texts: string[] }) =>
+      handleBatchTextEmbedding(runtime, params.texts),
     [TEXT_NANO_MODEL_TYPE]: handleTextNano,
     [TEXT_MEDIUM_MODEL_TYPE]: handleTextMedium,
     [ModelType.TEXT_SMALL]: handleTextSmall,


### PR DESCRIPTION
## What
Batches the post-turn embedding drain so N texts embed in **one** request instead of ~19–21 serial single-text round-trips. That serial work (~30s) is what made an *engaged* cloud-chat user (replying <~30s) queue behind it and hit ~40s turns — the last chat-smoothness item before the 10-user beta is "smooth," not "occasionally 40s."

## Root cause
The embedding-drain `BatchQueue` dequeues a slice (≤10) but `BatchProcessor` runs `process` **per-item** → 10 concurrent *single* requests, which the cloud embeddings endpoint serializes/throttles → ~1.5s × ~19 ≈ ~30s post-reply. The handler already had a true batch path (`handleBatchTextEmbedding`, `input: string[]`); it just wasn't reachable via `useModel`.

## Change (additive, zero blast radius on existing callers)
- **core types** — new `ModelType.TEXT_EMBEDDING_BATCH` (`{texts}` → `number[][]`). `TEXT_EMBEDDING` is untouched, so no existing caller's types change.
- **`BatchQueue`** — opt-in `processBatch(items[])`: a drain calls it once with the dequeued slice; **on any batch-wide failure it falls back to the per-item `process` path**, so retry / `onExhausted` semantics are fully preserved. Per-item callers that don't set it are unaffected.
- **embedding service** — `generateBatchEmbeddings` wires that to one `useModel(TEXT_EMBEDDING_BATCH, {texts})` + persists each vector (idempotent → a fallback re-run is safe).
- **plugin-elizacloud** — registers `TEXT_EMBEDDING_BATCH` → the already-present `handleBatchTextEmbedding` (true single-request batch, 429 backoff, index mapping).

Effect: ~19 singles → ~2 batched calls, ~30s → ~3s post-turn.

## Tests / checks
- New `process-batch.test.ts`: batched-once on success, **per-item fallback on batch failure**, unchanged behavior without `processBatch`. ✅ 3/3
- `bun run typecheck` (core + plugin) clean; biome clean; existing batch-queue/embedding tests green.

## Verification plan
After merge + a develop agent-image, I'll re-run the rapid-burst on a fresh prod agent (expect the engaged-user ~40s turn → ~6s). **Not a beta blocker** — the beta is launch-ready without it; this is the smoothness fast-follow.

Refs #8434.
