### PR TITLE
fix(ui): stop chat from "eating" messages on transient send/load failures

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -346,3 +346,74 @@ describe("useChatSend 404 recovery", () => {
     ).toBe(false);
   });
 });
+
+function httpStatusError(status: number, message = "Error"): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("useChatSend non-404 send failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+  });
+
+  it("surfaces a notice + keeps the user message on a transient (non-404) send failure", async () => {
+    // Regression: non-404 send failures (network drop mid-stream / 5xx) fell to
+    // a silent else branch that only reloaded — the typing dots vanished with no
+    // error, reading as "my message was lost". Now it drops only the empty
+    // assistant placeholder, keeps the user bubble, and surfaces a notice.
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      httpStatusError(503, "Service Unavailable"),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("are you there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledTimes(1);
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("waking up"),
+      "error",
+      expect.any(Number),
+    );
+    const remaining = deps.conversationMessagesRef.current;
+    expect(
+      remaining.some((m) => m.role === "user" && m.text === "are you there"),
+    ).toBe(true);
+    expect(
+      remaining.some((m) => m.role === "assistant" && !m.text.trim()),
+    ).toBe(false);
+  });
+
+  it("does not reload (which could re-fail) on an auth-failure send error, and notifies", async () => {
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      httpStatusError(401, "Unauthorized"),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello", { conversationId: "conv-1" });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("sign in again"),
+      "error",
+      expect.any(Number),
+    );
+    // Auth failures skip the reconcile reload (it would just fail again).
+    expect(deps.loadConversationMessages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -730,6 +730,17 @@ export function useChatSend(deps: UseChatSendDeps) {
           convId = conversation.id;
           convRoomId = conversation.roomId;
         } catch {
+          // First-message conversation creation failed (cold open on weak
+          // signal). The composer was already cleared upstream and the
+          // optimistic bubble hasn't rendered yet, so a bare return drops the
+          // user's text with no trace. Restore it to the composer + surface the
+          // failure so the first impression isn't a vanished message.
+          setChatInput(rawText);
+          setActionNotice(
+            "Couldn't start the conversation — check your connection and try again. Your message was restored.",
+            "error",
+            8_000,
+          );
           return;
         }
       }
@@ -1020,7 +1031,36 @@ export function useChatSend(deps: UseChatSendDeps) {
             );
           }
         } else {
-          await loadConversationMessages(convId);
+          // Non-abort, non-404 send failure (network/timeout/5xx/auth/429).
+          // Drop the empty assistant placeholder but KEEP the user's message,
+          // and surface a status-specific notice so a stalled turn is never
+          // silent dead air (the typing indicator stalls at ~30s while the SSE
+          // idle timeout is 60s — without this the user just sees the dots
+          // vanish and nothing replace them, reading as "my message was lost").
+          setConversationMessages((prev) =>
+            prev.filter(
+              (message) =>
+                !(message.id === assistantMsgId && !message.text.trim()),
+            ),
+          );
+          const kind = (err as { kind?: string }).kind;
+          const isAuth = status === 401 || status === 403;
+          const notice = isAuth
+            ? "Your session expired — sign in again and resend your message."
+            : status === 429
+              ? "The agent is busy right now — wait a few seconds and resend."
+              : status === 503 || status === 502
+                ? "The agent is still waking up — give it a moment and resend."
+                : kind === "network" || kind === "timeout"
+                  ? "Couldn't reach the agent — check your connection and resend."
+                  : "That message didn't go through — please resend.";
+          setActionNotice(notice, "error", 8_000);
+          // Reconcile from the server for non-auth errors — loadConversationMessages
+          // no longer wipes the thread on transient failures (404-only clear), so
+          // this is safe; skip on auth where the reload would just fail again.
+          if (!isAuth) {
+            await loadConversationMessages(convId);
+          }
         }
       } finally {
         if (controller && abortServerTurn) {
@@ -1051,6 +1091,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       setConversationMessages,
       setConversations,
       setActionNotice,
+      setChatInput,
       uiLanguage,
       elizaCloudEnabled,
       elizaCloudConnected,

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -305,10 +305,17 @@ export function useDataLoaders(deps: DataLoadersDeps) {
             setActiveConversationId(null);
             activeConversationIdRef.current = null;
           }
+          // The conversation is definitively gone (404) — clear the thread.
+          greetingFiredRef.current = false;
+          conversationMessagesRef.current = [];
+          setConversationMessages([]);
         }
-        greetingFiredRef.current = false;
-        conversationMessagesRef.current = [];
-        setConversationMessages([]);
+        // For TRANSIENT errors (network drop mid-stream, timeout, 5xx) do NOT
+        // wipe the thread. The message store is reused as the on-screen history,
+        // and blanking it on a flaky-connection reload looked like the app ate
+        // the entire conversation (the data is still server-side; a later reload
+        // restores it). Keep the existing messages and let the caller surface a
+        // transient error instead.
         return {
           ok: false,
           status,


### PR DESCRIPTION
Pre-launch readiness audit (24-agent workflow; flaky-mobile-data is the explicit beta target) surfaced three recoverability bugs where a **transient** failure looks like **data loss** to the user. None are server-side data loss (a refresh/reconnect restores it), but they're jarring first-impressions and cheap one-file fixes — worth landing before broadening beta invites.

### 1. Mid-stream network drop blanked the ENTIRE conversation
`useDataLoaders.ts` `loadConversationMessages` ran `conversationMessagesRef.current=[]; setConversationMessages([])` in the **shared tail** of its catch — for *any* error class, not just 404. Reached from `useChatSend.ts` after a dropped send calls the loader to reconcile; that reload also fails (still offline) → the just-sent message **and all prior history vanish** from screen.
**Fix:** move the clear *inside* the `status === 404` branch; for network/timeout/5xx keep the existing messages and return `{ok:false,status}`.

### 2. Non-404 send failures were silent (30s dead-air)
The send catch only handled `AbortError` + 404; `503/429/401/403/500/network` fell to a bare `loadConversationMessages` with no user feedback — the typing indicator stalls at ~30s while the SSE idle timeout is 60s, so the user sees the dots vanish and nothing replace them.
**Fix:** drop only the empty assistant placeholder, **keep the user's message**, and `setActionNotice` a status-specific message (waking-up / busy / sign-in-again / connection). Skip the reconcile reload on auth failures (it would just re-fail).

### 3. First-message conversation-create failure dropped the user's text
On a cold open with weak signal, `createConversation` failure hit a bare `return` — the composer was already cleared and the optimistic bubble not yet rendered, so the text vanished with no trace.
**Fix:** restore the text to the composer (`setChatInput(rawText)`) + notify.

## Tests
2 new `useChatSend` cases: transient-503 → "waking up" notice + user message preserved + empty placeholder dropped; auth-401 → "sign in again" notice + **no** reconcile reload. Suite 7/7, biome clean, types clean (ui typecheck shows only pre-existing unbuilt-sibling noise, none in the changed files).

Part of the #8434 beta-readiness pass. Companion cloud/ops handoffs (REDIS_RATE_LIMITING, Cerebras concurrency) posted on #8434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)