### PR TITLE
feat(agent): friendly rate-limited chat reply for a transient 429

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -66,6 +66,7 @@ import {
 import {
   isInsufficientCreditsError,
   isInsufficientCreditsMessage,
+  isRateLimitError,
 } from "./credit-detection.ts";
 import {
   buildWalletActionNotExecutedReply,
@@ -879,6 +880,11 @@ async function resolveExactDocumentValueForChat(
 const PROVIDER_ISSUE_CHAT_REPLY = "Sorry, I'm having a provider issue";
 const INSUFFICIENT_CREDITS_CHAT_REPLY =
   "Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
+// A transient 429 (no billing context) — e.g. the shared model key briefly
+// over its requests/min under concurrent load. Tell the user it's momentary so
+// they retry, instead of the generic "provider issue" which reads as broken.
+const RATE_LIMITED_CHAT_REPLY =
+  "I'm being rate-limited right now — give it a few seconds and try again.";
 // Used by paths #1-#3: planner picked IGNORE/NONE/empty REPLY, action ran but
 // emitted no text callback, or normalized text became empty. None of these are
 // provider failures, so the message must not blame the provider.
@@ -932,6 +938,9 @@ function classifySyntheticChatFailureText(
   }
   if (normalized === INSUFFICIENT_CREDITS_CHAT_REPLY.toLowerCase()) {
     return "insufficient_credits";
+  }
+  if (normalized === RATE_LIMITED_CHAT_REPLY.toLowerCase()) {
+    return "rate_limited";
   }
   if (normalized === NO_PROVIDER_CHAT_MESSAGE.toLowerCase()) {
     return "no_provider";
@@ -1239,6 +1248,10 @@ export function getChatFailureReply(
   if (isNoProviderError(err)) {
     return NO_PROVIDER_CHAT_MESSAGE;
   }
+  // After credits (a 429 *with* billing is "top up"): a bare 429 is transient.
+  if (isRateLimitError(err)) {
+    return RATE_LIMITED_CHAT_REPLY;
+  }
   return getProviderIssueChatReply();
 }
 
@@ -1252,6 +1265,7 @@ export type ChatFailureKind =
   | "insufficient_credits"
   | "no_provider"
   | "provider_issue"
+  | "rate_limited"
   | "local_inference";
 
 export function classifyChatFailure(
@@ -1269,6 +1283,9 @@ export function classifyChatFailure(
   }
   if (isLocalInferenceError(err)) {
     return "local_inference";
+  }
+  if (isRateLimitError(err)) {
+    return "rate_limited";
   }
   return "provider_issue";
 }

--- a/packages/agent/src/api/credit-detection.test.ts
+++ b/packages/agent/src/api/credit-detection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  isInsufficientCreditsError,
+  isRateLimitError,
+} from "./credit-detection.ts";
+
+/** Provider errors are Error instances, often with a `.status` attached. */
+function providerError(
+  message: string,
+  status?: number,
+): Error & { status?: number } {
+  const e = new Error(message) as Error & { status?: number };
+  if (status !== undefined) e.status = status;
+  return e;
+}
+
+/**
+ * `isRateLimitError` distinguishes a transient 429 ("try again in a few
+ * seconds") from credit exhaustion ("top up"). Callers check
+ * `isInsufficientCreditsError` FIRST, so a 429-with-billing is credits and a
+ * bare 429 is a rate limit.
+ */
+describe("isRateLimitError", () => {
+  it("treats a bare HTTP 429 as a rate limit", () => {
+    expect(isRateLimitError({ status: 429 })).toBe(true);
+    expect(isRateLimitError(providerError("boom", 429))).toBe(true);
+  });
+
+  it("matches rate-limit messages (no status)", () => {
+    expect(isRateLimitError("Rate limit exceeded")).toBe(true);
+    expect(isRateLimitError(providerError("Too Many Requests"))).toBe(true);
+    expect(isRateLimitError("5 requests per minute")).toBe(true);
+  });
+
+  it("does NOT match unrelated errors", () => {
+    expect(isRateLimitError({ status: 500 })).toBe(false);
+    expect(isRateLimitError(providerError("connection reset"))).toBe(false);
+    expect(isRateLimitError({ status: 402 })).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+
+  it("credit exhaustion is detected first (a 429 with billing is credits, not rate-limit)", () => {
+    // The chat route checks isInsufficientCreditsError before isRateLimitError.
+    const billing429 = providerError("Quota exceeded — billing", 429);
+    expect(isInsufficientCreditsError(billing429)).toBe(true);
+
+    const bare429 = providerError("rate limit", 429);
+    expect(isInsufficientCreditsError(bare429)).toBe(false);
+    expect(isRateLimitError(bare429)).toBe(true);
+  });
+});

--- a/packages/agent/src/api/credit-detection.ts
+++ b/packages/agent/src/api/credit-detection.ts
@@ -13,6 +13,26 @@ const INSUFFICIENT_CREDITS_RE =
 const BILLING_KEYWORDS_RE =
   /\b(?:billing|quota|credits?|budget|spending|payment|subscription|plan limit)\b/i;
 
+const RATE_LIMIT_RE =
+  /\b(?:rate[_\s-]?limit(?:ed|ing)?|too many requests|requests? per (?:minute|second|hour)|slow down)\b/i;
+
+/**
+ * A transient provider rate-limit (HTTP 429, or a rate-limit message) that is
+ * NOT billing/credit exhaustion. Callers MUST check
+ * {@link isInsufficientCreditsError} first — a 429 *with* billing context is
+ * credit exhaustion ("top up"), whereas a bare 429 is "try again in a moment".
+ */
+export function isRateLimitError(err: unknown): boolean {
+  if (err == null) return false;
+  if (typeof err === "string") return RATE_LIMIT_RE.test(err);
+  if (typeof err !== "object") return false;
+  const status = (err as { status?: number }).status;
+  if (status === 429) return true;
+  const msg = getErrorMessage(err, "");
+  const safe = msg.length > 10_000 ? msg.slice(0, 10_000) : msg;
+  return RATE_LIMIT_RE.test(safe);
+}
+
 export function isInsufficientCreditsMessage(message: string): boolean {
   const safe = message.length > 10_000 ? message.slice(0, 10_000) : message;
   return INSUFFICIENT_CREDITS_RE.test(safe);

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -122,6 +122,7 @@ export type ChatFailureKind =
   | "insufficient_credits"
   | "no_provider"
   | "provider_issue"
+  | "rate_limited"
   | "local_inference";
 
 export interface ChatActionResultSummary {


### PR DESCRIPTION
## What
A bare HTTP 429 (no billing context) — e.g. the shared Cerebras key briefly over its requests/min under concurrent load — currently falls through to the generic **"Sorry, I'm having a provider issue"**, which reads as *broken*. This classifies it as a distinct rate-limit so the user sees **"give it a few seconds and try again"** and retries.

Cloud-handoff **#4** from @phone-agent's pre-launch audit (relevant to the 10-user beta, where the single key can momentarily 429 under a concurrent wave).

## Change
- **`credit-detection.ts`** — `isRateLimitError(err)`: a 429 / rate-limit message that is **not** credit exhaustion. Callers check `isInsufficientCreditsError` first, so a 429 *with* billing context stays "top up".
- **`chat-routes.ts`** — `RATE_LIMITED_CHAT_REPLY` + a `rate_limited` `ChatFailureKind`, wired into `getChatFailureReply` / `classifyChatFailure` / the synthetic-failure classifier — **after** credits, **before** the generic provider-issue fallback.
- **`packages/ui` `client-types-chat.ts`** — mirrors `rate_limited` in the client `ChatFailureKind` (per @phone-agent: one PR for both halves rather than splitting the enum across lanes; phone to review the ui half).

## Tests / checks
- `credit-detection.test.ts`: bare 429 + rate-limit messages detected; **credit exhaustion takes precedence** (429-with-billing → credits, not rate-limit); negatives (500/402/connection-reset). 4/4 ✅
- typecheck (agent + ui) + biome clean.

Refs #8434.
