### PR TITLE
test(scenario): classify plugin-local-inference START/STOP_TRANSCRIPTION in the action-surface manifest

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -85,7 +85,12 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
     "SKILL_UNINSTALL",
     "USE_SKILL",
   ],
-  "@elizaos/plugin-local-inference": ["GENERATE_MEDIA", "IDENTIFY_SPEAKER"],
+  "@elizaos/plugin-local-inference": [
+    "GENERATE_MEDIA",
+    "IDENTIFY_SPEAKER",
+    "START_TRANSCRIPTION",
+    "STOP_TRANSCRIPTION",
+  ],
   "@elizaos/plugin-gitpathologist": ["GIT_PATHOLOGY"],
   "@elizaos/plugin-todos": ["TODO"],
   "@elizaos/plugin-streaming": ["STREAM"],
@@ -175,6 +180,9 @@ const KNOWN_UNCOVERED: readonly string[] = [
   "CLOSE_VIEW",
   // New speaker-diarization action; no deterministic keyless scenario yet.
   "IDENTIFY_SPEAKER",
+  // New on-device transcription actions; no deterministic keyless scenario yet.
+  "START_TRANSCRIPTION",
+  "STOP_TRANSCRIPTION",
 ];
 
 /**


### PR DESCRIPTION
Fixes the `Zero-Key unit + UI coverage` job (the `Scenario runner unit coverage` step): `deterministic-action-coverage.test.ts` failed because `plugin-local-inference` now ships `START_TRANSCRIPTION` + `STOP_TRANSCRIPTION` (the on-device transcription / `toggle-transcription` feature) but the stable-core action-surface manifest still only listed `GENERATE_MEDIA` + `IDENTIFY_SPEAKER`, so the live-vs-manifest drift check threw.

Adds both actions to the manifest and to `KNOWN_UNCOVERED` (no deterministic keyless scenario yet — same precedent as `IDENTIFY_SPEAKER`). `deterministic-action-coverage.test.ts` now **17/17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)