### PR TITLE
fix(phone): import PermissionRecoveryCallout from the @elizaos/ui/components barrel (unblocks build-views)

### DIFF
--- a/plugins/plugin-phone/src/components/PhoneAppView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneAppView.tsx
@@ -19,7 +19,7 @@ import { Phone } from "@elizaos/capacitor-phone";
 import type { OverlayAppContext } from "@elizaos/ui";
 import { Button, useAgentElement } from "@elizaos/ui";
 import { consumePendingPhoneNumber } from "@elizaos/ui/app-navigate-view";
-import { PermissionRecoveryCallout } from "@elizaos/ui/components/permissions/PermissionRecoveryCallout";
+import { PermissionRecoveryCallout } from "@elizaos/ui/components";
 import {
   Tabs,
   TabsContent,


### PR DESCRIPTION
The `build-views` step (prerequisite for the ui-smoke Playwright lane) failed: `plugin-phone`'s `PhoneAppView` imported the deep subpath `@elizaos/ui/components/permissions/PermissionRecoveryCallout`, which `DynamicViewLoader`'s `HOST_EXTERNAL_IMPORTERS` map doesn't rewrite (it externalizes `@elizaos/ui` by prefix but only rewrites exact keys). The view bundle shipped a bare un-rewritable specifier, so `build-views` exited 1 and **blocked every ui-smoke spec before it ran**.

Fix: import from the host-provided `@elizaos/ui/components` barrel (which re-exports it) — exactly what the guard's error message recommends.

Verified: `build-views` → **0 violations**; plugin-phone typecheck clean; tests **92/92**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)