### PR TITLE
fix(ui): reconcile deep-linked app-shell tab when its page registers late

### DIFF
--- a/packages/ui/src/state/useAppProviderEffects.ts
+++ b/packages/ui/src/state/useAppProviderEffects.ts
@@ -1,5 +1,9 @@
-import { type RefObject, useEffect, useRef } from "react";
+import { type RefObject, useEffect, useRef, useSyncExternalStore } from "react";
 import { type ConversationMessage, client } from "../api";
+import {
+  getAppShellPageRegistrySnapshot,
+  subscribeAppShellPages,
+} from "../app-shell-registry";
 import {
   getWindowNavigationPath,
   isRouteRootPath,
@@ -29,7 +33,23 @@ export function useNavigationPathSync({
   tab: Tab;
   setTabRaw: (tab: Tab) => void;
 }) {
+  // App-shell pages (e.g. `@elizaos/plugin-facewear/register` →
+  // `/apps/smartglasses/tui`) register from idle-loaded side-effect modules, so
+  // a deep link / refresh can boot before the matching registration exists.
+  // `tabFromPath` then falls through to the `apps` catalog, and that
+  // misresolution is otherwise sticky because this effect only re-runs on
+  // tab/navigation change. Re-running it when the registry version bumps lets a
+  // late registration reconcile the active tab to the real page.
+  const appShellRegistryVersion = useSyncExternalStore(
+    subscribeAppShellPages,
+    getAppShellPageRegistrySnapshot,
+    getAppShellPageRegistrySnapshot,
+  );
   useEffect(() => {
+    // `appShellRegistryVersion` is a re-run trigger, not a value read here:
+    // `tabFromPath` consults the live registry, so a version bump must re-run
+    // this effect to reconcile a deep link that booted before its page landed.
+    void appShellRegistryVersion;
     const navPath = getWindowNavigationPath();
     if (isRouteRootPath(navPath)) {
       return;
@@ -40,7 +60,7 @@ export function useNavigationPathSync({
     if (routeTab && routeTab !== tab && isNavAllowed(routeTab)) {
       setTabRaw(routeTab);
     }
-  }, [tab, setTabRaw]);
+  }, [tab, setTabRaw, appShellRegistryVersion]);
 }
 
 export function useBackendConnectionSync({

--- a/packages/ui/src/state/useNavigationPathSync.test.tsx
+++ b/packages/ui/src/state/useNavigationPathSync.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+// Regression for the app-shell deep-link boot race. App-shell pages — e.g.
+// `@elizaos/plugin-facewear/register` registering `/apps/smartglasses/tui` — are
+// loaded from idle-scheduled side-effect modules (main.tsx
+// `scheduleSideEffectAppModuleLoads`). A deep link or page refresh can therefore
+// boot before the matching registration exists; `tabFromPath` then falls through
+// to the `apps` catalog. Without registry reactivity that misresolution is
+// sticky (the sync effect only re-runs on tab/navigation change), so the page
+// renders the apps grid instead of the deep-linked view forever. This was the
+// flaky `smartglasses tui` ui-smoke failure: the snapshot showed the apps
+// catalog, not the terminal view. `useNavigationPathSync` now re-resolves the
+// active tab when the app-shell registry version bumps.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerAppShellPage } from "../app-shell-registry";
+import type { Tab } from "../navigation";
+import { useNavigationPathSync } from "./useAppProviderEffects";
+
+const REGISTRY_KEY = Symbol.for("elizaos.app-core.app-shell-page-registry");
+
+interface RegistryStoreShape {
+  entries: Map<string, unknown>;
+  version: number;
+  listeners: Set<() => void>;
+}
+
+function clearTestRegistration(id: string): void {
+  const store = (globalThis as Record<PropertyKey, unknown>)[REGISTRY_KEY] as
+    | RegistryStoreShape
+    | undefined;
+  if (!store) return;
+  if (!store.entries.delete(id)) return;
+  store.version += 1;
+  for (const listener of store.listeners) listener();
+}
+
+afterEach(() => {
+  clearTestRegistration("smartglasses.tui");
+  window.history.replaceState(null, "", "/");
+});
+
+describe("useNavigationPathSync — app-shell registry reactivity", () => {
+  it("reconciles the active tab when a deep-linked app-shell page registers late", () => {
+    window.history.replaceState(null, "", "/apps/smartglasses/tui");
+
+    const setTabRaw = vi.fn();
+    // Boot landed on the apps catalog: `/apps/smartglasses/tui` has no
+    // registration yet, so `tabFromPath` resolves it to "apps".
+    renderHook(() => useNavigationPathSync({ tab: "apps" as Tab, setTabRaw }));
+    expect(setTabRaw).not.toHaveBeenCalledWith("smartglasses.tui");
+
+    // The idle-loaded side-effect module finally registers the page.
+    act(() => {
+      registerAppShellPage({
+        id: "smartglasses.tui",
+        pluginId: "@elizaos/plugin-facewear",
+        label: "Smartglasses TUI",
+        path: "/apps/smartglasses/tui",
+        loader: async () => ({ default: () => null }),
+      });
+    });
+
+    // The registry-version bump re-runs the sync effect, which now resolves the
+    // URL to the real page and reconciles the active tab.
+    expect(setTabRaw).toHaveBeenCalledWith("smartglasses.tui");
+  });
+
+  it("leaves the tab alone when the URL already matches the active tab", () => {
+    // Page already registered (no race) and the active tab already matches the
+    // URL: the sync effect must not dispatch a redundant reconciliation.
+    registerAppShellPage({
+      id: "smartglasses.tui",
+      pluginId: "@elizaos/plugin-facewear",
+      label: "Smartglasses TUI",
+      path: "/apps/smartglasses/tui",
+      loader: async () => ({ default: () => null }),
+    });
+    window.history.replaceState(null, "", "/apps/smartglasses/tui");
+
+    const setTabRaw = vi.fn();
+    renderHook(() =>
+      useNavigationPathSync({ tab: "smartglasses.tui" as Tab, setTabRaw }),
+    );
+
+    // routeTab === tab, so no redundant reconciliation is dispatched.
+    expect(setTabRaw).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

App-shell pages (e.g. `@elizaos/plugin-facewear/register` registering `/apps/smartglasses/tui`) are loaded from **idle-scheduled** side-effect modules (`packages/app/src/main.tsx` `scheduleSideEffectAppModuleLoads`). A deep link or page refresh can boot before the matching registration exists; `tabFromPath` then falls through to the `apps` catalog. Without registry reactivity that misresolution is **sticky** — `useNavigationPathSync` only re-ran on tab/navigation change — so the page renders the apps grid instead of the deep-linked view indefinitely.

This was the **flaky `smartglasses tui` ui-smoke failure** (scenario-pr → `app browser view lifecycle` → `plugin-views-visual.spec.ts`). The Playwright failure snapshot showed the apps catalog ("Featured / Companion / LifeOps / Finance …"), not the terminal view root `[data-view-state]`. It passed in some runs and failed in others purely on idle-callback timing — only the last/heaviest TUI case tended to lose the race.

## Fix

`useNavigationPathSync` now subscribes to the app-shell page registry version (`useSyncExternalStore` over `subscribeAppShellPages`). A late `registerAppShellPage` bumps the version, re-runs the sync effect, and reconciles the active tab to the real page. The URL is preserved (boot uses `setTabRaw`, not the URL-writing `setTab`), so re-resolving `tabFromPath` on the unchanged path yields the correct page. This fixes the real product bug for **every** idle-registered app-shell page (deep-link / refresh on `/apps/<x>` and `/apps/<x>/tui`), not just smartglasses.

## Tests

Adds `packages/ui/src/state/useNavigationPathSync.test.tsx` (jsdom renderHook): pins the late-registration reconcile and the no-redundant-dispatch branch. Typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)