### PR TITLE
fix(test): realign stale ui-smoke specs with shipped product redesigns

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -356,7 +356,7 @@ const SAFE_VIEW_TILES: readonly {
 
 const SETTING_SECTIONS_TO_CLICK: readonly RegExp[] = [
   /^Basics$/,
-  /^Providers$/,
+  /^Models & Providers$/,
   /^Runtime$/,
   /^Appearance$/,
   /^Voice$/,
@@ -366,7 +366,7 @@ const SETTING_SECTIONS_TO_CLICK: readonly RegExp[] = [
   /^Connectors$/,
   /^App Permissions$/,
   /^Permissions$/,
-  /^Secrets storage$/,
+  /^Vault$/,
   /^Security$/,
   /^Updates$/,
   /^Backup & Reset$/,

--- a/packages/app/test/ui-smoke/android-system-apps.spec.ts
+++ b/packages/app/test/ui-smoke/android-system-apps.spec.ts
@@ -232,7 +232,9 @@ test("Phone, Contacts, WiFi, Messages, and Device Settings handle core interacti
     context,
     getAndroidSystemRoute("contacts"),
   ));
-  await page.getByTestId("contacts-search").fill("ada");
+  // Per-view contact search was removed; searching is now driven via the chat
+  // composer (ContactsAppView renders a hint instead of a search input).
+  await expect(page.getByTestId("contacts-search-hint")).toBeVisible();
   await page.getByTestId("contacts-new").click();
   await page.getByLabel(/^(Name|contacts\.form\.name)$/).fill("Ada Lovelace");
   await page.getByPlaceholder("+1 555 123 4567").fill("+1 555 0100");

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -83,6 +83,12 @@ export const DIRECT_ROUTE_CASES: readonly DirectRouteCase[] = [
     timeoutMs: 90_000,
   },
   {
+    name: "transcripts app window",
+    path: "/apps/transcripts",
+    selector: '[data-testid="transcripts-view"]',
+    timeoutMs: 90_000,
+  },
+  {
     name: "model tester app window",
     path: "/apps/model-tester",
     readyChecks: [

--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -676,19 +676,29 @@ test("automations overview empty state encourages creating tasks and workflows",
   await expect(page.getByRole("button", { name: "Workflows 0" })).toBeVisible();
   await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
 
+  // "New" no longer opens a task/workflow chooser — it focuses the Automations
+  // chat with a creation prefill (mirrors AutomationsFeed.test.tsx). Capture the
+  // dispatched prefill event as the proof of the new contract.
+  await page.evaluate(() => {
+    (window as unknown as { __prefill?: unknown }).__prefill = null;
+    window.addEventListener(
+      "eliza:chat:prefill",
+      (event) => {
+        (window as unknown as { __prefill?: unknown }).__prefill = (
+          event as CustomEvent
+        ).detail;
+      },
+      { once: true },
+    );
+  });
   await page.getByRole("button", { name: "New" }).click();
-  await expect(page.getByText("What do you want to create?")).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: /Task \(simple prompt\)/ }),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: /Workflow \(node graph\)/ }),
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: /Task \(simple prompt\)/ }).click();
-  await expect(page.getByRole("heading", { name: "New task" })).toBeVisible();
-  await expect(page.getByTestId("task-editor-name")).toBeVisible();
-  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as { __prefill?: unknown }).__prefill,
+      ),
+    )
+    .toEqual({ text: "Create an automation that ", select: false });
   await expect(page.getByTestId("automations-shell")).toBeVisible();
 });
 
@@ -711,11 +721,13 @@ test("automations can list tasks, create a task, and inspect workflow JSON", asy
   await expect(
     page.getByRole("button", { name: "Message triage" }),
   ).toBeVisible();
+  // Each row's open control is labelled `Open <title>` (AutomationsFeed); the
+  // bare title matches both the open and the run buttons, so target the open one.
   await expect(
-    page.getByRole("button", { name: "Message pipeline" }),
+    page.getByRole("button", { name: "Open Message pipeline" }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "Message pipeline" }).click();
+  await page.getByRole("button", { name: "Open Message pipeline" }).click();
   await expect(
     page.getByRole("heading", { name: "Message pipeline" }),
   ).toBeVisible();
@@ -725,8 +737,11 @@ test("automations can list tasks, create a task, and inspect workflow JSON", asy
   await expect(page.getByText("Graph")).toBeVisible();
   await page.getByRole("button", { name: "Close" }).click();
 
-  await page.getByRole("button", { name: "New" }).click();
-  await page.getByRole("button", { name: /Task \(simple prompt\)/ }).click();
+  // The chooser was removed; open the New TaskEditor directly via the automations
+  // hash deep-link (#automations/task/__new__, parsed by useAutomationDeepLink).
+  await page.evaluate(() => {
+    window.location.hash = "#automations/task/__new__";
+  });
   await page.getByTestId("task-editor-name").fill("Escalate inbound messages");
   await page
     .getByTestId("task-editor-prompt")
@@ -741,38 +756,12 @@ test("automations can list tasks, create a task, and inspect workflow JSON", asy
   await expect(page.getByText("Escalate inbound messages")).toBeVisible();
 });
 
-test("workflow editor generates a workflow from a prompt", async ({ page }) => {
-  const api = await installAutomationsApi(page, []);
-
-  await openAppPath(page, "/automations");
-
-  await page.getByRole("button", { name: "New" }).click();
-  await page.getByRole("button", { name: /Workflow \(node graph\)/ }).click();
-  await page
-    .getByRole("button", { name: "Generate from prompt" })
-    .first()
-    .click();
-  const workflowPrompt = page.getByPlaceholder(
-    "When a new starred email arrives in Gmail, post a summary in #ops on Slack.",
-  );
-  await workflowPrompt.fill(
-    "When a generic message event arrives, summarize it and send a digest.",
-  );
-  await page.getByRole("button", { name: "Generate" }).click();
-
-  await expect
-    .poll(() => api.getGeneratedWorkflow())
-    .toMatchObject({
-      prompt:
-        "When a generic message event arrives, summarize it and send a digest.",
-    });
-  await expect(
-    page.getByRole("heading", { name: "Generated workflow" }),
-  ).toBeVisible();
-  await expect(page.getByTestId("workflow-editor-json")).toHaveValue(
-    /Generated workflow/,
-  );
-});
+// NOTE: the in-app "generate a workflow from a prompt" surface was removed from
+// the WorkflowEditor (workflow generation is backend-only now; the UI no longer
+// exposes a "Generate from prompt" affordance — see WorkflowEditor.test.tsx
+// asserting its absence). The former Playwright case for it is intentionally
+// gone; its mock seam (`getGeneratedWorkflow` / the `/generate` route) is left in
+// `installAutomationsApi` as a harmless no-op for any future re-introduction.
 
 // Event-triggered automation coverage.
 //
@@ -797,9 +786,11 @@ test("automations renders an event trigger and creates a new event automation", 
   ).toBeVisible();
   await expect(page.getByText("On message.received")).toBeVisible();
 
-  // Create a fresh event-triage automation through the real editor flow.
-  await page.getByRole("button", { name: "New" }).click();
-  await page.getByRole("button", { name: /Task \(simple prompt\)/ }).click();
+  // Create a fresh event-triage automation through the real editor flow. The
+  // chooser was removed; open the New TaskEditor directly via the hash deep-link.
+  await page.evaluate(() => {
+    window.location.hash = "#automations/task/__new__";
+  });
   await page.getByTestId("task-editor-name").fill("Triage new chat events");
   await page
     .getByTestId("task-editor-prompt")

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -162,7 +162,7 @@ export async function expectNoPageDiagnostics(
 
 const SETTINGS_SECTION_IDS_BY_LABEL = new Map<string, string>([
   ["Basics", "identity"],
-  ["Providers", "ai-model"],
+  ["Models & Providers", "ai-model"],
   ["Runtime", "runtime"],
   ["Appearance", "appearance"],
   ["Voice", "voice"],

--- a/packages/app/test/ui-smoke/ui-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/ui-smoke.spec.ts
@@ -36,9 +36,10 @@ test("chat, apps, and settings routes render through the real shell", async ({
   await openAppPath(page, "/apps");
   await expect(page).toHaveURL(/\/apps$/);
   await expect(page.getByRole("heading", { name: "Views" })).toBeVisible();
-  await expect(
-    page.getByRole("searchbox", { name: "Search views…" }),
-  ).toBeVisible();
+  // Views search is no longer a standalone searchbox — it is bound to the global
+  // chat composer (ViewCatalog registers a chat binding with placeholder
+  // "Search views…"; covered by ViewCatalog.test.tsx). The page-render proof here
+  // is the heading plus the catalog body below.
   await expect(
     page
       .getByRole("heading", { name: "Companion" })

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -366,6 +366,13 @@ test("agent navigate by viewId-only resolves to /apps/<viewId>", async ({
 test("agent close-view navigate returns to chat", async ({ page }) => {
   test.skip(LIVE_STACK, "close-frame teardown is a renderer-contract guard");
   await openAppPath(page, "/chat");
+  // `eliza:navigate:view` is a one-shot DOM event with no queue; its listener is
+  // attached in a post-paint App effect (App.tsx). The interactive chat shell
+  // (composer visible) is the proof that effect has committed — the other cases
+  // implicitly wait for it via sendChatCommand. Without this wait, dispatching
+  // the navigate ~1.5s after load races the listener attach and the event is
+  // dropped, leaving the URL on /chat.
+  await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
 
   // Open a view first.
   await deliverAgentNavigate(page, {

--- a/scripts/ai-qa/route-catalog.ts
+++ b/scripts/ai-qa/route-catalog.ts
@@ -38,7 +38,14 @@ const READY_CHECKS_BY_PATH: Record<string, readonly ReadyCheck[]> = {
     { selector: '[data-testid="conversations-sidebar"]' },
     { selector: '[data-testid="chat-composer-textarea"]' },
   ],
-  "/connectors": [{ selector: "#root" }],
+  // Settings/lazy-view routes: wait for the actual rendered view marker, not the
+  // always-present #root, so the screenshot is captured after the lazy chunk
+  // mounts and paints (a bare #root check races the chunk and yields a blank,
+  // one-solid-color capture that fails the screenshot-quality gate).
+  "/connectors": [{ selector: '[data-testid="settings-shell"]' }],
+  "/tutorial": [{ selector: '[data-testid="tutorial-launcher"]' }],
+  "/help": [{ selector: '[data-testid="help-view"]' }],
+  "/apps/transcripts": [{ selector: '[data-testid="transcripts-view"]' }],
   "/apps": [{ selector: '[data-testid="apps-shell"]' }],
   "/views": [{ text: "Views" }],
   "/apps/lifeops": [{ selector: '[data-testid="lifeops-shell"]' }],


### PR DESCRIPTION
## Why

After [#8827](https://github.com/elizaOS/eliza/pull/8827) unblocked `build-views`, the ui-smoke jobs (`app browser view lifecycle`, `all-pages`, `ratcheted`) actually ran their specs and surfaced a batch of **deterministic** failures — specs asserting against UI that has since been **intentionally redesigned**. The product code is correct; these tests lagged. **Test/tooling only — no product source changes.**

Diagnosed via a parallel multi-agent sweep over the failing clusters; each fix verified against current source (rendered labels, testids, hash deep-link format, event contracts) and cross-checked against the subsystems' own already-migrated unit tests.

## Fixes

| Job | Fix |
|-----|-----|
| unit + UI coverage | `route-coverage` gate: add `/apps/transcripts` to `DIRECT_ROUTE_CASES` (the Transcripts view + route shipped in #8789 but was never added to the all-pages route-smoke matrix). **Verified locally: `route-coverage.test.ts` 10/10.** |
| view lifecycle | `view-switching-chat-e2e:366`: wait for the interactive chat composer before dispatching `eliza:navigate:view`. That listener attaches in a post-paint App effect and the one-shot event has no queue, so firing it ~1.5s after load raced the attach and dropped the open (URL stuck on `/chat`). |
| all-pages | settings labels: the AI-model section renders **Models & Providers** and secrets renders **Vault**; the stale `/^Providers$/` / `/^Secrets storage$/` left `openSettingsSection` falling to a non-existent `#ai-model` scroll → the 15s `scrollIntoViewIfNeeded` timeout. |
| ratcheted | automations: chooser removed — **New** focuses the Automations chat (`eliza:chat:prefill`), editors open via `#automations/task/__new__`, row open buttons are `Open <title>`, in-app workflow generation removed. Specs updated to the streamlined contract. |
| ratcheted | views search moved to the chat-composer binding (`Search views…`); contacts per-view search replaced by a chat hint (`contacts-search-hint`). |
| ratcheted (screenshot) | ai-qa `/connectors`, `/tutorial`, `/help`, `/apps/transcripts` used a bare `#root` ready-check → capture raced the lazy chunk → blank one-solid-color screenshot. Now wait on the real view markers. |

Typecheck + biome clean across all touched files. The `orchestrator-gui-workbench` deterministic failures are a separate seed-shape drift, handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)