### PR TITLE
fix(test): correct selectors in realigned ui-smoke specs (local-verified)

### DIFF
--- a/packages/app/test/ui-smoke/android-system-apps.spec.ts
+++ b/packages/app/test/ui-smoke/android-system-apps.spec.ts
@@ -260,10 +260,13 @@ test("Phone, Contacts, WiFi, Messages, and Device Settings handle core interacti
     getAndroidSystemRoute("messages"),
   ));
   await page.getByTestId("messages-new").click();
+  // The Messages app is a multi-screen list/composer with no standalone refresh
+  // control; opening the composer and reaching a sendable draft is the
+  // interaction proof.
+  await expect(page.getByTestId("messages-composer-panel")).toBeVisible();
   await page.getByTestId("messages-compose-address").fill("+1 555 0101");
   await page.getByTestId("messages-compose-body").fill("QA SMS draft");
   await expect(page.getByTestId("messages-send")).toBeEnabled();
-  await page.getByTestId("messages-refresh").click();
   await expectNoIssues(page, issues.splice(0), "messages interactions");
   await page.close();
 

--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -721,13 +721,16 @@ test("automations can list tasks, create a task, and inspect workflow JSON", asy
   await expect(
     page.getByRole("button", { name: "Message triage" }),
   ).toBeVisible();
-  // Each row's open control is labelled `Open <title>` (AutomationsFeed); the
-  // bare title matches both the open and the run buttons, so target the open one.
-  await expect(
-    page.getByRole("button", { name: "Open Message pipeline" }),
-  ).toBeVisible();
+  // The row's accessible name is its full text ("Message pipeline Active …"),
+  // which collides with the sibling "Run …" button under a bare-title role query.
+  // Target the open control by its stable agent-surface label instead
+  // (useAgentElement stamps data-agent-label="Open <title>").
+  const openMessagePipeline = page.locator(
+    '[data-agent-label="Open Message pipeline"]',
+  );
+  await expect(openMessagePipeline).toBeVisible();
 
-  await page.getByRole("button", { name: "Open Message pipeline" }).click();
+  await openMessagePipeline.click();
   await expect(
     page.getByRole("heading", { name: "Message pipeline" }),
   ).toBeVisible();

--- a/packages/app/test/ui-smoke/ui-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/ui-smoke.spec.ts
@@ -37,12 +37,16 @@ test("chat, apps, and settings routes render through the real shell", async ({
   await expect(page).toHaveURL(/\/apps$/);
   await expect(page.getByRole("heading", { name: "Views" })).toBeVisible();
   // Views search is no longer a standalone searchbox — it is bound to the global
-  // chat composer (ViewCatalog registers a chat binding with placeholder
-  // "Search views…"; covered by ViewCatalog.test.tsx). The page-render proof here
-  // is the heading plus the catalog body below.
+  // chat composer, and the catalog renders an inline "Search views by typing in
+  // the chat." hint (common.chatSearchHint). That hint plus a rendered view tile
+  // are the page-render proof (view entries are buttons/tiles, not headings).
+  await expect(
+    page.getByText("Search views by typing in the chat."),
+  ).toBeVisible();
   await expect(
     page
-      .getByRole("heading", { name: "Companion" })
+      .locator('[data-testid^="view-card-"]')
+      .first()
       .or(page.getByText("No views available")),
   ).toBeVisible();
 
@@ -53,8 +57,10 @@ test("chat, apps, and settings routes render through the real shell", async ({
   const capabilitiesSection = page.locator("#capabilities");
   await capabilitiesSection.scrollIntoViewIfNeeded();
   await expect(capabilitiesSection).toBeVisible();
+  // The section wraps both an h1 section title and an h3 subsection of the same
+  // name, so scope to the first match (section-rendered proof, not uniqueness).
   await expect(
-    capabilitiesSection.getByText("Capabilities", { exact: true }),
+    capabilitiesSection.getByText("Capabilities", { exact: true }).first(),
   ).toBeVisible();
   await expect(
     capabilitiesSection.getByRole("switch", { name: "Enable Computer Use" }),
@@ -64,6 +70,7 @@ test("chat, apps, and settings routes render through the real shell", async ({
   await expect(
     page
       .locator("#app-permissions")
-      .getByText("App Permissions", { exact: true }),
+      .getByText("App Permissions", { exact: true })
+      .first(),
   ).toBeVisible();
 });


### PR DESCRIPTION
Follow-up to [#8830](https://github.com/elizaOS/eliza/pull/8830). I ran these specs against the **live stack locally** (`bun run --cwd packages/app test:e2e <spec> --project=chromium`) and found three selectors #8830 got wrong. CI never caught them because each test failed at an *earlier* (now-fixed) assertion, so the later ones were never exercised — fixing the early one cascades to the next stale one. **All three now pass locally.**

- **automations**: the row open control's accessible name is its full text (`"Message pipeline Active …"`), which collides with the sibling `"Run …"` button under a bare-title role query, and `useAgentElement` stamps a `data-agent-label` (not a role name / `data-testid`). → target `[data-agent-label="Open Message pipeline"]`.
- **ui-smoke**: the Views catalog renders entries as button tiles, not a `Companion` heading (`{name:"Companion"}` also strict-collides with `"Phone Companion"`). → assert the `"Search views by typing in the chat."` hint + a `[data-testid^="view-card-"]` tile. Cascade: settings `#capabilities`/`#app-permissions` each wrap an h1 + h3 of the same name → scope title checks with `.first()`.
- **android-system-apps**: the multi-screen `MessagesAppView` has **no** standalone refresh control (`messages-refresh` never existed there). → assert `messages-composer-panel` visible and drop the stale `messages-refresh` click.

Local results: view-switching ✅, orchestrator ✅, automations ✅, ui-smoke ✅, ai-qa-capture ✅, android-system-apps ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)