### PR TITLE
fix(test): mock /api/transcripts in ui-smoke default routes

### DIFF
--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1799,6 +1799,22 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
     });
   });
 
+  // The Transcripts view (client.listTranscripts) hits this on mount; the
+  // keyless loopback stack answers 501 for unimplemented endpoints, which surface
+  // as console errors in the stricter app-window smoke. Serve an empty list so
+  // the view renders its real empty state cleanly.
+  await page.route("**/api/transcripts**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ transcripts: [] }),
+    });
+  });
+
   await page.route("**/api/runtime/mode", async (route) => {
     if (route.request().method() !== "GET") {
       await route.fallback();


### PR DESCRIPTION
[#8830](https://github.com/elizaOS/eliza/pull/8830) added `/apps/transcripts` to `DIRECT_ROUTE_CASES` (to satisfy the route-coverage gate). `apps-utility-interactions.spec.ts` iterates that list and asserts each app window renders with **zero** console errors / overflow. The Transcripts view calls `client.listTranscripts()` (GET `/api/transcripts`) on mount, which the keyless loopback stack answers **501 (Not Implemented)** → console error → fails the strict smoke (the `app-browser-feature-interactions` job, and the `Deterministic E2E` aggregate that gates on it). `all-pages-clicksafe` already filters benign 501 resource errors, which is why it stayed green.

Serve an empty `{ transcripts: [] }` from `installDefaultAppRoutes` so the view renders its real empty state cleanly. **Verified locally: apps-utility-interactions 8 passed.**

Closes the last red job from the conclusive run (27898858270 had 9/11 green; this fixes feature-interactions + its Deterministic E2E aggregate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)