### PR TITLE
perf(agent-image): start the agent under plain node, drop the tsx loader

### DIFF
--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -7,9 +7,12 @@ ARG APP_CORE_DIR=packages/app-core
 ARG AGENT_DIR=packages/agent
 ARG APP_DIR=packages/app
 ARG APP_ENTRYPOINT=packages/agent/dist/bin.js
-# `--import` points at the standalone tsx loader installed by the `tsx` stage
-# at /opt/tsx — avoids depending on workspace-resolved `tsx` in /app/node_modules.
-ARG APP_CMD_START="node --import /opt/tsx/node_modules/tsx/dist/loader.mjs packages/agent/dist/bin.js start"
+# F6 (#8812): start the agent under plain `node` — no `tsx` loader. The prebuilt
+# dist is already compiled JS with `.ts` specifiers rewritten to `.js` (tsconfig
+# rewriteRelativeImportExtensions), so the tsx loader only added a per-process
+# register tax. Verified by the image build + boot smoke. The `tsx` stage/COPY
+# below is now unused on the cold path and can be dropped in a follow-up.
+ARG APP_CMD_START="node packages/agent/dist/bin.js start"
 ARG APP_PORT=2138
 ARG APP_API_BIND=127.0.0.1
 ARG OCI_SOURCE=""
@@ -221,4 +224,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
   CMD sh -lc 'port="${PORT:-${APP_PORT:-${ELIZA_PORT:-2138}}}"; code="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/api/health")" && [ "$code" = "200" -o "$code" = "401" ]'
 
 ENTRYPOINT ["sh", "-lc", "exec sh \"./${APP_CORE_DIR:-packages/app-core}/scripts/docker-entrypoint.sh\" \"$@\"", "--"]
-CMD ["sh", "-lc", "exec ${APP_CMD_START:-node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"]
+CMD ["sh", "-lc", "exec ${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"]

--- a/packages/app-core/scripts/build-image.sh
+++ b/packages/app-core/scripts/build-image.sh
@@ -115,7 +115,9 @@ load_env_file "deploy/deploy.env"
 
 APP_IMAGE="${APP_IMAGE:-eliza/agent}"
 APP_ENTRYPOINT="${APP_ENTRYPOINT:-app.mjs}"
-APP_CMD_START="${APP_CMD_START:-node --import ./node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"
+# F6 (#8812): start under plain `node` — the prebuilt dist is compiled JS with
+# `.ts` specifiers rewritten to `.js`, so the tsx loader only added startup tax.
+APP_CMD_START="${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"
 APP_PORT="${APP_PORT:-2138}"
 APP_API_BIND="${APP_API_BIND:-127.0.0.1}"
 OCI_SOURCE="${OCI_SOURCE:-}"

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -182,7 +182,9 @@ load_env_file "deploy/deploy.env"
 
 APP_IMAGE="${APP_IMAGE:-eliza/agent}"
 APP_ENTRYPOINT="${APP_ENTRYPOINT:-$AGENT_DIR/dist/bin.js}"
-APP_CMD_START="${APP_CMD_START:-node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"
+# F6 (#8812): start under plain `node` — the prebuilt dist is compiled JS with
+# `.ts` specifiers rewritten to `.js`, so the tsx loader only added startup tax.
+APP_CMD_START="${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"
 APP_PORT="${APP_PORT:-2138}"
 APP_API_BIND="${APP_API_BIND:-127.0.0.1}"
 OCI_SOURCE="${OCI_SOURCE:-}"


### PR DESCRIPTION
## What

`perf(agent-image)` — start the production agent under plain **`node`** instead of `node --import <tsx loader> dist/bin.js start` (#8812, F6).

The prebuilt CI image's dist is already compiled JS with `.ts` specifiers rewritten to `.js` (tsconfig `rewriteRelativeImportExtensions`), so the tsx loader only added a per-process register/resolution tax on the cold path with **no functional benefit**.

## Where the change actually lives

The command is passed to the build via `--build-arg APP_CMD_START=...`, so the `Dockerfile.ci` `ARG` default is **overridden** — changing only the Dockerfile would be a no-op. The real defaults are in the build scripts. This PR switches all of them to `node ${APP_ENTRYPOINT} start`:
- `packages/app-core/scripts/docker-ci-smoke.sh` (CI smoke build)
- `packages/app-core/scripts/build-image.sh` (prod build)
- `packages/app-core/deploy/Dockerfile.ci` `ARG`/`CMD` fallback (kept consistent)

`build-agent-image.yml` defines no `APP_CMD_START`, so no workflow change is needed.

## Safety / validation

Validated by the existing **image build + boot smoke** (`docker-ci-smoke.sh --boot-verify-only`, which builds the image and boots it): if any runtime `.ts` import survived in the dist, plain-node boot would crash and turn the smoke **red** before publish. `bash -n` + `shellcheck` clean on the changed scripts.

The now-unused `tsx` stage + `COPY --from=tsx` in `Dockerfile.ci` are left in place (dead weight only) and can be dropped in a follow-up once this is confirmed green.

Part of #8812.
