### PR TITLE
fix(core): don't force a tool on bare requiresTool with no named action (planner over-gating)

### DIFF
--- a/packages/core/src/__tests__/message-benchmark-integration.contract.test.ts
+++ b/packages/core/src/__tests__/message-benchmark-integration.contract.test.ts
@@ -41,8 +41,9 @@ describe("message service benchmark integration contracts", () => {
 		expect(source).toContain("contentMetadata.benchmark");
 		// The planner gate consults the helper alongside Stage 1's requiresTool.
 		expect(source).toContain("isBenchmarkForcingToolCall(args.message)");
-		expect(source).toContain(
-			"messageHandler.plan.requiresTool === true || benchmarkForcingToolCall",
-		);
+		// requiresTool is still consulted (now via the named-action guard), and the
+		// benchmark signal is OR'd in so a benchmark turn forces a tool regardless.
+		expect(source).toContain("messageHandler.plan.requiresTool === true");
+		expect(source).toContain("|| benchmarkForcingToolCall");
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6264,8 +6264,21 @@ export async function runV5MessageRuntimeStage1(args: {
 		};
 		const plannerTools = collectPlannerTools(plannerContextWithDecision);
 		const benchmarkForcingToolCall = isBenchmarkForcingToolCall(args.message);
+		// Only HARD-enforce a non-terminal tool when Stage 1 both flagged the turn
+		// tool-required AND named at least one candidate action. A bare
+		// `requiresTool=true` with NO named tool is the Stage-1 classifier
+		// over-flagging pure-knowledge and sub-agent-relay turns (verified in the
+		// 2026-06-21 deepscan): forcing then makes the planner either loop
+		// re-emitting REPLY (rejected up to maxRequiredToolMisses times, answer
+		// only via fallback) or run an irrelevant tool (VIEWS / TASKS_HISTORY) just
+		// to satisfy the gate. When Stage 1 names no tool, plan with "auto" and
+		// trust the planner — it still calls a tool when one genuinely fits and
+		// answers directly when none does.
+		const stageOneNamedAToolForThisTurn =
+			messageHandler.plan.requiresTool === true &&
+			(messageHandler.plan.candidateActions?.length ?? 0) > 0;
 		const requireNonTerminalToolCall =
-			(messageHandler.plan.requiresTool === true || benchmarkForcingToolCall) &&
+			(stageOneNamedAToolForThisTurn || benchmarkForcingToolCall) &&
 			plannerTools.length > 0;
 		const effectivePlannerContext = requireNonTerminalToolCall
 			? appendContextEvent(plannerContextWithDecision, {


### PR DESCRIPTION
## Problem

The Stage-1 router's `requiresTool=true` over-flags **pure-knowledge** turns ("how old am I + star sign?") and **sub-agent-relay** turns (relaying a finished sub-agent's answer). `requireNonTerminalToolCall` then hard-forced a non-terminal tool whenever `requiresTool=true` and *any* tool was exposed — regardless of whether Stage-1 actually named one.

Consequence (verified by deep-reading live trajectories):
- The planner re-emits a terminal `REPLY`, gets rejected with "this turn is tool-required and no non-terminal tool has run yet" up to `maxRequiredToolMisses` times (**12 gate-hits, plannerIterations=4, toolCallsExecuted=0**), and the correct answer only reaches the user via the fallback — not a clean dispatch. Burns ~150K prompt tokens per turn.
- On providers that pick a real tool to satisfy the gate, it runs an **irrelevant executed tool** (VIEWS → "No current view reported yet"; TASKS_HISTORY) — wasted spend + latency to echo one answer.

## Fix

Only hard-force a non-terminal tool when Stage-1 **named at least one candidate action** (`candidateActions`), not on a bare `requiresTool=true`. When no tool is named, plan with `toolChoice: "auto"` and trust the planner — it still calls a tool when one genuinely fits, and answers directly when none does.

## Verification

- 154 planner-loop + message-handler tests pass.
- Live: the age-knowledge turn went from **12 gate-hits / 4 planner iterations** to **0 gate-hits / 2 iterations**, clean reply, no fallback. Backend-agnostic root, so it removes both the REPLY-rejection loop and the spurious-tool variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
