### PR TITLE
fix(cloud-shared): fail fast on a cerebras 429 instead of ~50s of retries

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model-cerebras-fallback.test.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model-cerebras-fallback.test.ts
@@ -103,6 +103,31 @@ describe("getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallbac
     expect(hosts).toEqual(["cerebras"]);
   });
 
+  test("a 429 FAILS FAST under default retries (one cerebras call, no ~50s backoff loop)", async () => {
+    // The bug: the gateway calls generateText/streamText WITHOUT maxRetries, so
+    // the AI SDK's default (2 retries → 3 attempts) ran a 429 through ~50s of
+    // exponential backoff before the graceful rate-limit reply surfaced.
+    // withRateLimitFailFast re-throws the 429 as non-retryable → the SDK gives up
+    // after ONE attempt. This test uses the DEFAULT retry config on purpose (no
+    // maxRetries:0) — without the fix, `attempts` would be 3.
+    let attempts = 0;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      hosts.push(hostOf(url));
+      attempts++;
+      return tooManyRequests();
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+        prompt: "hi",
+      }),
+    ).rejects.toBeDefined();
+
+    expect(attempts).toBe(1);
+    expect(hosts).toEqual(["cerebras"]);
+  });
+
   test("a non-retryable error (400) also surfaces via cerebras only", async () => {
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       hosts.push(hostOf(url));

--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -306,6 +306,55 @@ function withOpenRouterFallback(
 }
 
 /**
+ * Wraps the cerebras chat model so a 429 (rate-limited) surfaces FAST instead of
+ * after the AI SDK's default 3-attempt exponential backoff (~50s). The SDK retries
+ * a 429 because the provider marks the `APICallError` `isRetryable: true`; we
+ * re-throw just the 429 as a NON-retryable `APICallError` so the retry loop gives
+ * up on the first attempt and the chat path's graceful "model provider
+ * rate-limited" reply surfaces in a few seconds rather than stalling the turn.
+ * Only 429 is short-circuited — 5xx/network keep the SDK's normal retry/backoff,
+ * and the 429 keeps its status so downstream classification still maps it to a
+ * rate-limit reply. Cerebras-only (the chat reply path); embeddings and
+ * structured output are untouched.
+ */
+function withRateLimitFailFast(primaryModel: Parameters<typeof wrapLanguageModel>[0]["model"]) {
+  const failFast = (error: unknown): never => {
+    if (APICallError.isInstance(error) && error.statusCode === 429) {
+      throw new APICallError({
+        message: error.message,
+        url: error.url,
+        requestBodyValues: error.requestBodyValues,
+        statusCode: 429,
+        responseHeaders: error.responseHeaders,
+        responseBody: error.responseBody,
+        cause: error.cause,
+        isRetryable: false,
+        data: error.data,
+      });
+    }
+    throw error;
+  };
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        return failFast(error);
+      }
+    },
+    wrapStream: async ({ doStream }) => {
+      try {
+        return await doStream();
+      } catch (error) {
+        return failFast(error);
+      }
+    },
+  };
+  return wrapLanguageModel({ model: primaryModel, middleware });
+}
+
+/**
  * True for OpenRouter-catalog ids that NO native provider can serve directly —
  * routing-suffix variants (`:nitro`/`:floor`), the free tier, and `openai/gpt-oss-120b`
  * (an OpenRouter id, not an OpenAI-API model). These must go to the OpenRouter
@@ -382,11 +431,13 @@ export function getLanguageModel(model: string) {
   }
 
   // Cerebras-native default IDs (gpt-oss-120b, zai-glm-4.7) → Cerebras direct.
-  // Cerebras-only by design: a free-tier 429 must surface so the chat path can
-  // return the graceful "model provider rate-limited" reply rather than silently
-  // failing over to OpenRouter on a different provider.
+  // Cerebras-only by design: a 429 must surface so the chat path can return the
+  // graceful "model provider rate-limited" reply rather than silently failing
+  // over to OpenRouter on a different provider. Wrapped in withRateLimitFailFast
+  // so that 429 surfaces in ~one round-trip instead of after the AI SDK's default
+  // ~50s 3-attempt backoff (which turned a throttled turn into a 50s hang).
   if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
-    return getCerebrasClient().chat(normalizeCerebrasModelId(model));
+    return withRateLimitFailFast(getCerebrasClient().chat(normalizeCerebrasModelId(model)));
   }
 
   // OpenRouter-catalog ids no native provider can serve (`:nitro`/`:floor`,


### PR DESCRIPTION
## Problem (measured on a live prod dedicated agent)

Engaged-pace chat turns spike to **47–52s** returning a 2-token stub. Root cause traced end-to-end: the reply routes `generateDirectReplyModel → useModel →` the Worker gateway, which calls `generateText`/`streamText` **without `maxRetries`**. The AI SDK default is 2 retries → **3 attempts**, and a cerebras `429` is marked `isRetryable: true`, so a single throttled turn runs ~50s of exponential backoff before the (already-correct) graceful rate-limit reply can surface. The agent itself makes a single non-retrying call — all the latency is the gateway's SDK retry.

Burst measured (5 turns, 6s apart): `9.2 / 6.9 / **52.4** / **47.2** / 5.5s` — the two slow turns each failed on `Failed after 3 attempts. Last error: Too Many Requests`.

## Fix

Wrap the cerebras chat model in `withRateLimitFailFast` (modeled on the existing `withOpenRouterFallback` in the same file): re-throw **only** a `429` as a **non-retryable** `APICallError`, so the SDK retry loop gives up after one attempt and the chat path's existing `rate_limited` graceful reply ("model provider rate-limited — try again in a few seconds") surfaces in ~one round-trip instead of ~50s.

- **Narrow:** only `429`, only the cerebras-native chat branch. `5xx`/network keep the SDK's normal retry/backoff; embeddings (`getTextEmbeddingModel`) and structured output are untouched.
- The 429 keeps its `statusCode`, so downstream classification (`getRecoverableProviderErrorStatus` → 429 → `rate_limit_error`, and the agent's `isRateLimitError` → `rate_limited`) still fires — just fast.
- Billing unaffected (settle-to-0 on failure, same as today, just sooner).

## Test

Extended `language-model-cerebras-fallback.test.ts`: a 429 under **default** retries (not the `maxRetries:0` the other tests use to dodge the slow loop) now hits cerebras **exactly once** — was 3×. `5 pass`.

## Lane / deploy

This is the **Worker gateway** (`@elizaos/cloud-shared`), so it ships in the Cloudflare Worker deploy, **not** the agent image — agent side needs no change. @s.andujar this is your lane; happy to include it in the next gateway deploy or coordinate however you prefer. Tracking on elizaOS/eliza#8434.

**Note (separate, possibly the real ceiling fix):** *why* a single agent 429s on the paid 1000/min key at all (~30 chat calls/min in this burst) is still open — likely a concurrency or tokens-per-minute ceiling on `gpt-oss-120b`, or a Worker-side per-agent limit. This PR is a strict UX win regardless, but if it's a ceiling, raising it is the deeper fix. Investigating in parallel.