### PR TITLE
fix(orchestrator): sub-agents must run code and report the real output, not just write it

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -91,6 +91,11 @@ load-bearing facts and drops noise. Make that message the answer itself:
   result, the URL you built, or one line of what changed. Put it first and
   verbatim. If the task said "report only the number", reply with only the
   number.
+- If the task asks you to COMPUTE, RUN, or report the OUTPUT of something, you
+  must actually EXECUTE it (run the script/command) and report its REAL result.
+  A script you wrote but never ran is NOT the deliverable — it returns nothing,
+  the answer the user asked for is missing, and you force a wasteful re-spawn.
+  The value must come from a real execution, not from unexecuted code.
 - Do NOT narrate your process. No "I'll load the workspace context first",
   "checking the workspace shape", "rg is not installed so I'll use…", "the file
   already exists, reading it before editing", no step-by-step play-by-play, no


### PR DESCRIPTION
## Problem

Deepscan of a codex-exec coding-spawn (`compute the factorial of 12 and report only the number`): the sub-agent **wrote** `factorial_12.py` but never **ran** it, returned no number, and the parent had to **re-spawn a second sub-agent** to run it — violating the relay's "do NOT start another sub-agent" directive and doubling the round-trip.

The `SUB_AGENT_IDENTITY` operating manual said "lead with the deliverable — the computed result" but never that you must **execute** the code to *get* that result, so an agent could treat "wrote a script" as done.

## Fix

Add an explicit directive: compute/run/output tasks must **actually EXECUTE** the code and report the **real** result; a script written but never run is not the deliverable (it returns nothing and forces a wasteful re-spawn).

One-line behavioral contract on the identity scaffold; no code-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
