### PR TITLE
refactor(ui,agent): dedupe session code — reuse canonical helpers, kill copy-paste

### DIFF
--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -20,6 +20,7 @@ import type {
   createMessageMemory,
   UUID,
 } from "@elizaos/core";
+import { parseJSONObjectFromText } from "@elizaos/core";
 import { normalizeCharacterLanguage } from "@elizaos/shared";
 import { extractCompatTextContent } from "./compat-utils.ts";
 import {
@@ -130,31 +131,6 @@ function resolveRecoveryTimeoutMs(explicit?: number): number {
     DEFAULT_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS,
     MAX_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS,
   );
-}
-
-function parseJsonObjectFromModelText(
-  text: string,
-): Record<string, unknown> | null {
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  const parseCandidate = (
-    candidate: string,
-  ): Record<string, unknown> | null => {
-    try {
-      const parsed = JSON.parse(candidate);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : null;
-    } catch {
-      return null;
-    }
-  };
-  const direct = parseCandidate(trimmed);
-  if (direct) return direct;
-  const start = trimmed.indexOf("{");
-  const end = trimmed.lastIndexOf("}");
-  if (start === -1 || end <= start) return null;
-  return parseCandidate(trimmed.slice(start, end + 1));
 }
 
 async function withOptionalTimeout<T>(
@@ -351,7 +327,7 @@ export async function maybeAugmentChatMessageWithDocuments(
 
       const result = await Promise.race([modelPromise, timeoutPromise]);
       const raw = typeof result === "string" ? result : "";
-      const parsed = parseJsonObjectFromModelText(raw);
+      const parsed = parseJSONObjectFromText(raw);
       if (!parsed) {
         return [];
       }
@@ -365,10 +341,9 @@ export async function maybeAugmentChatMessageWithDocuments(
           rawQueries
             .filter((value): value is string => typeof value === "string")
             .map((value) => value.trim())
-            .filter((value) => value.length > 0)
-            .slice(0, CHAT_DOCUMENTS_RECOVERY_QUERY_LIMIT),
+            .filter((value) => value.length > 0),
         ),
-      ];
+      ].slice(0, CHAT_DOCUMENTS_RECOVERY_QUERY_LIMIT);
     } catch (error) {
       runtime.logger.warn(
         {

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -11,7 +11,14 @@ import {
   type NativeStreamingAgentPlugin,
   supportsNativeStreaming,
 } from "./native-agent-stream";
-import { type AgentRequestTransport, fetchAgentTransport } from "./transport";
+import {
+  type AgentRequestTransport,
+  bodyToString,
+  fetchAgentTransport,
+  headersToRecord,
+  isStreamingRequest,
+  methodAllowsBody,
+} from "./transport";
 
 export interface NativeAgentRequestOptions {
   method?: string;
@@ -82,24 +89,6 @@ function toNativeAgentPlugin(
   const addListener = plugin.addListener?.bind(plugin);
   if (!start && !stop && !getStatus && !request) return null;
   return { start, stop, getStatus, request, requestStream, addListener };
-}
-
-/**
- * An SSE / streaming request — the chat reply's token stream. Detected by the
- * `Accept: text/event-stream` header or a `…/stream` path. These are the only
- * requests routed through the streaming bridge; everything else stays buffered.
- */
-function isStreamingRequest(
-  url: string,
-  headers: HeadersInit | undefined,
-): boolean {
-  const accept = new Headers(headers ?? {}).get("accept") ?? "";
-  if (accept.toLowerCase().includes("text/event-stream")) return true;
-  try {
-    return new URL(url, "http://localhost").pathname.endsWith("/stream");
-  } catch {
-    return url.includes("/stream");
-  }
 }
 
 function isNativeAndroid(): boolean {
@@ -182,32 +171,6 @@ async function resolveNativeAgentPlugin(): Promise<NativeAgentPlugin | null> {
   }
 
   return null;
-}
-
-function headersToRecord(
-  headers: HeadersInit | undefined,
-): Record<string, string> {
-  if (!headers) return {};
-  const record: Record<string, string> = {};
-  new Headers(headers).forEach((value, key) => {
-    record[key] = value;
-  });
-  return record;
-}
-
-function methodAllowsBody(method: string): boolean {
-  const normalized = method.toUpperCase();
-  return normalized !== "GET" && normalized !== "HEAD";
-}
-
-function bodyToString(
-  body: BodyInit | null | undefined,
-): string | null | undefined {
-  if (body === null) return null;
-  if (body === undefined) return undefined;
-  if (typeof body === "string") return body;
-  if (body instanceof URLSearchParams) return body.toString();
-  return undefined;
 }
 
 function shouldBridgeFetchUrl(url: URL, rawUrl: string): boolean {

--- a/packages/ui/src/api/desktop-http-transport.ts
+++ b/packages/ui/src/api/desktop-http-transport.ts
@@ -1,7 +1,13 @@
 import { isLoopbackBindHost, isWildcardBindHost } from "@elizaos/shared";
 import { getElectrobunRendererRpc } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
-import { type AgentRequestTransport, fetchAgentTransport } from "./transport";
+import {
+  type AgentRequestTransport,
+  bodyToString,
+  fetchAgentTransport,
+  headersToRecord,
+  methodAllowsBody,
+} from "./transport";
 
 interface DesktopHttpRequestResult {
   status: number;
@@ -21,32 +27,6 @@ function isExternalPlainHttpUrl(url: string): boolean {
   } catch {
     return false;
   }
-}
-
-function headersToRecord(
-  headers: HeadersInit | undefined,
-): Record<string, string> {
-  if (!headers) return {};
-  const record: Record<string, string> = {};
-  new Headers(headers).forEach((value, key) => {
-    record[key] = value;
-  });
-  return record;
-}
-
-function methodAllowsBody(method: string): boolean {
-  const normalized = method.toUpperCase();
-  return normalized !== "GET" && normalized !== "HEAD";
-}
-
-function bodyToString(
-  body: BodyInit | null | undefined,
-): string | null | undefined {
-  if (body === null) return null;
-  if (body === undefined) return undefined;
-  if (typeof body === "string") return body;
-  if (body instanceof URLSearchParams) return body.toString();
-  return undefined;
 }
 
 const desktopHttpTransport: AgentRequestTransport = {

--- a/packages/ui/src/api/native-cloud-http-transport.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.ts
@@ -1,5 +1,12 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
-import { type AgentRequestTransport, fetchAgentTransport } from "./transport";
+import {
+  type AgentRequestTransport,
+  bodyToString,
+  fetchAgentTransport,
+  headersToRecord,
+  isStreamingRequest,
+  methodAllowsBody,
+} from "./transport";
 
 const DIRECT_CLOUD_API_HOSTS = new Set(["api.elizacloud.ai"]);
 const CLOUD_HOST_SUFFIX = ".elizacloud.ai";
@@ -50,24 +57,6 @@ function isNativeCloudAgentSubdomain(url: string): boolean {
   return !NON_AGENT_CLOUD_HOSTS.has(host) && host.endsWith(CLOUD_HOST_SUFFIX);
 }
 
-/**
- * An SSE / streaming request — the chat reply's token stream. Detected by the
- * `Accept: text/event-stream` header or a `…/stream` path. `CapacitorHttp`
- * buffers the entire response before resolving, which collapses token streaming
- * into a single blob delivered only after the full server-side generation. The
- * native browser fetch (`CapacitorWebFetch`) streams `response.body`
- * incrementally instead.
- */
-function isStreamingRequest(
-  url: string,
-  headers: HeadersInit | undefined,
-): boolean {
-  const accept = new Headers(headers ?? {}).get("accept") ?? "";
-  if (accept.toLowerCase().includes("text/event-stream")) return true;
-  const parsed = parseUrl(url);
-  return parsed ? parsed.pathname.endsWith("/stream") : url.includes("/stream");
-}
-
 type NativeWebFetch = (
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -83,29 +72,6 @@ function nativeWebFetch(): NativeWebFetch | null {
   const candidate = (globalThis as { CapacitorWebFetch?: unknown })
     .CapacitorWebFetch;
   return typeof candidate === "function" ? (candidate as NativeWebFetch) : null;
-}
-
-function headersToRecord(
-  headers: HeadersInit | undefined,
-): Record<string, string> {
-  if (!headers) return {};
-  const record: Record<string, string> = {};
-  new Headers(headers).forEach((value, key) => {
-    record[key] = value;
-  });
-  return record;
-}
-
-function methodAllowsBody(method: string): boolean {
-  const normalized = method.toUpperCase();
-  return normalized !== "GET" && normalized !== "HEAD";
-}
-
-function bodyToNativeData(body: BodyInit | null | undefined): unknown {
-  if (body === null || body === undefined) return undefined;
-  if (typeof body === "string") return body;
-  if (body instanceof URLSearchParams) return body.toString();
-  return undefined;
 }
 
 function responseBody(data: unknown): string {
@@ -140,7 +106,8 @@ const nativeCloudHttpTransport: AgentRequestTransport = {
     }
 
     const method = init.method ?? "GET";
-    const data = bodyToNativeData(init.body);
+    // CapacitorHttp has no concept of a null body — treat null and undefined alike.
+    const data = bodyToString(init.body) ?? undefined;
     if (init.body != null && data === undefined) {
       return fetchAgentTransport.request(url, init, context);
     }

--- a/packages/ui/src/api/transport.ts
+++ b/packages/ui/src/api/transport.ts
@@ -11,3 +11,57 @@ export const fetchAgentTransport: AgentRequestTransport = {
     return fetch(url, init);
   },
 };
+
+// ---------------------------------------------------------------------------
+// Shared transport helpers — used by every native/desktop transport so the
+// HTTP plumbing has a single definition each (no per-file copies that drift).
+// ---------------------------------------------------------------------------
+
+export function headersToRecord(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  if (!headers) return {};
+  const record: Record<string, string> = {};
+  new Headers(headers).forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+export function methodAllowsBody(method: string): boolean {
+  const normalized = method.toUpperCase();
+  return normalized !== "GET" && normalized !== "HEAD";
+}
+
+/**
+ * Normalize a `BodyInit` into the scalar payload native bridges accept (they
+ * cannot marshal streams/blobs). `null` is preserved distinct from `undefined`
+ * so callers that care about an explicit empty body can tell them apart.
+ */
+export function bodyToString(
+  body: BodyInit | null | undefined,
+): string | null | undefined {
+  if (body === null) return null;
+  if (body === undefined) return undefined;
+  if (typeof body === "string") return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  return undefined;
+}
+
+/**
+ * An SSE / streaming request — the chat reply's token stream. Detected by the
+ * `Accept: text/event-stream` header or a `…/stream` path. Parsing with a base
+ * resolves relative URLs too; the substring check is the final fallback.
+ */
+export function isStreamingRequest(
+  url: string,
+  headers: HeadersInit | undefined,
+): boolean {
+  const accept = new Headers(headers ?? {}).get("accept") ?? "";
+  if (accept.toLowerCase().includes("text/event-stream")) return true;
+  try {
+    return new URL(url, "http://localhost").pathname.endsWith("/stream");
+  } catch {
+    return url.includes("/stream");
+  }
+}

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -671,6 +671,20 @@ export function useChatSend(deps: UseChatSendDeps) {
     [appendLocalCommandTurn],
   );
 
+  // Drop the empty assistant placeholder bubble (a temp-resp-* that never got
+  // any streamed text) while preserving the user's message. Shared by every
+  // send-failure branch so the predicate lives in one place and can't drift.
+  const dropEmptyAssistantPlaceholder = useCallback(
+    (assistantMsgId: string) => {
+      setConversationMessages((prev) =>
+        prev.filter(
+          (message) => !(message.id === assistantMsgId && !message.text.trim()),
+        ),
+      );
+    },
+    [setConversationMessages],
+  );
+
   const runQueuedChatSend = useCallback(
     async (turn: Omit<QueuedChatSend, "resolve" | "reject">) => {
       const hasAttachedImages = Boolean(turn.images?.length);
@@ -928,12 +942,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       } catch (err) {
         const abortError = err as Error;
         if (abortError.name === "AbortError" || controller?.signal.aborted) {
-          setConversationMessages((prev) =>
-            prev.filter(
-              (message) =>
-                !(message.id === assistantMsgId && !message.text.trim()),
-            ),
-          );
+          dropEmptyAssistantPlaceholder(assistantMsgId);
           return;
         }
 
@@ -966,22 +975,12 @@ export function useChatSend(deps: UseChatSendDeps) {
                 "error",
                 10_000,
               );
-              setConversationMessages((prev) =>
-                prev.filter(
-                  (message) =>
-                    !(message.id === assistantMsgId && !message.text.trim()),
-                ),
-              );
+              dropEmptyAssistantPlaceholder(assistantMsgId);
               return;
             }
             // Non-cloud base, or a different create failure — preserve the prior
             // behaviour (drop the empty assistant placeholder).
-            setConversationMessages((prev) =>
-              prev.filter(
-                (message) =>
-                  !(message.id === assistantMsgId && !message.text.trim()),
-              ),
-            );
+            dropEmptyAssistantPlaceholder(assistantMsgId);
             return;
           }
 
@@ -1023,12 +1022,7 @@ export function useChatSend(deps: UseChatSendDeps) {
               ]),
             );
           } catch {
-            setConversationMessages((prev) =>
-              prev.filter(
-                (message) =>
-                  !(message.id === assistantMsgId && !message.text.trim()),
-              ),
-            );
+            dropEmptyAssistantPlaceholder(assistantMsgId);
           }
         } else {
           // Non-abort, non-404 send failure (network/timeout/5xx/auth/429).
@@ -1037,12 +1031,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           // silent dead air (the typing indicator stalls at ~30s while the SSE
           // idle timeout is 60s — without this the user just sees the dots
           // vanish and nothing replace them, reading as "my message was lost").
-          setConversationMessages((prev) =>
-            prev.filter(
-              (message) =>
-                !(message.id === assistantMsgId && !message.text.trim()),
-            ),
-          );
+          dropEmptyAssistantPlaceholder(assistantMsgId);
           const kind = (err as { kind?: string }).kind;
           const isAuth = status === 401 || status === 403;
           const notice = isAuth
@@ -1089,6 +1078,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       setChatLastUsage,
       setCompanionMessageCutoffTs,
       setConversationMessages,
+      dropEmptyAssistantPlaceholder,
       setConversations,
       setActionNotice,
       setChatInput,
@@ -1362,12 +1352,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         } catch (err) {
           const abortError = err as Error;
           if (abortError.name === "AbortError" || controller?.signal.aborted) {
-            setConversationMessages((prev) =>
-              prev.filter(
-                (message) =>
-                  !(message.id === assistantMsgId && !message.text.trim()),
-              ),
-            );
+            dropEmptyAssistantPlaceholder(assistantMsgId);
             return;
           }
           await loadConversationMessages(convId);


### PR DESCRIPTION
## What

Cleanup of code authored across this session, driven by an adversarially-verified deepscan against the cleanliness rules (**no >1 function with the same purpose · no AI slop · general-not-narrow, no hacky string-matching**). Net **−76 lines**, pure dedup — zero behavior change except the two fixes called out below.

## Changes

**`packages/agent/src/api/chat-augmentation.ts`** (2 fixes)
- Drop the local `parseJsonObjectFromModelText` and use core's canonical **`parseJSONObjectFromText`** (already used by sibling actions `extract-params`, `contact`, `grounded-action-reply`). Core's version is strictly stronger — JSON5 (trailing commas / single quotes / unquoted keys), strips ```` ```json ```` fences, returns `null` for arrays. The local raw-`JSON.parse` reinvention **silently dropped fenced/loose model output** on exactly the cerebras-direct / local-`gte-small` hosts this document-recovery path targets.
- Dedup recovery queries **before** slicing so the documented "up to 3 **distinct** queries" holds when the model emits leading duplicates (the prompt's own examples make that likely).

**`packages/ui/src/state/useChatSend.ts`**
- Extract the 6× copy-pasted empty-assistant-placeholder filter into one `dropEmptyAssistantPlaceholder` closure — single source of truth, no lockstep drift across send-failure branches.

**`packages/ui/src/api/{transport,native-cloud-http-transport,android-native-agent-transport,desktop-http-transport}.ts`**
- Hoist `headersToRecord` / `methodAllowsBody` / `bodyToString` / `isStreamingRequest` (byte-identical / near-verbatim copies) into the shared `./transport.ts`; the three transports now import them. Tightens native-cloud's body normalizer return from `unknown` → `string | undefined`, and adopts the relative-URL-safe `isStreamingRequest` everywhere.

## Verification
- `biome check` clean on all 6 files
- `ui` + `agent` typecheck: clean (remaining errors are pre-existing unbuilt-workspace-dep `TS2307`s, unrelated)
- `useChatSend` **7/7**, transport suites (`native-cloud` + `android` + `desktop`) **24/24** pass

Part of the launch hardening tracked in #8434.