### PR TITLE
refactor(cli-inference): remove dead sandbox code, dedup redactStderr, drop fake spawnFn injection

### DIFF
--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -36,21 +36,14 @@ import { CodexCli } from "./src/codex-cli-exec";
  * not the cheap triage calls.
  */
 
-const TEXT_MEGA_MODEL_TYPE: string = ModelType.TEXT_MEGA;
-const RESPONSE_HANDLER_MODEL_TYPE: string = ModelType.RESPONSE_HANDLER;
-
 /** Large-tier model types this plugin registers (when enabled). */
 const LARGE_TIER_MODEL_TYPES: readonly string[] = [
   ModelType.TEXT_LARGE,
-  TEXT_MEGA_MODEL_TYPE,
-  RESPONSE_HANDLER_MODEL_TYPE,
+  ModelType.TEXT_MEGA,
+  ModelType.RESPONSE_HANDLER,
 ];
 
 type CliBackend = "claude" | "codex";
-
-type RuntimeWithSettings = IAgentRuntime & {
-  getSetting?: (key: string) => string | number | boolean | undefined | null;
-};
 
 function readEnv(name: string): string | undefined {
   if (typeof process === "undefined") return undefined;
@@ -58,7 +51,7 @@ function readEnv(name: string): string | undefined {
 }
 
 function getSetting(runtime: IAgentRuntime, key: string): string | undefined {
-  const value = (runtime as RuntimeWithSettings).getSetting?.(key);
+  const value = runtime.getSetting(key);
   return value === undefined || value === null ? readEnv(key) : String(value);
 }
 

--- a/plugins/plugin-cli-inference/src/claude-cli.ts
+++ b/plugins/plugin-cli-inference/src/claude-cli.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
 import { flattenPrompt } from "./prompt-flatten";
-import { filterEnv, redactSensitive, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
+import { filterEnv, redactStderr, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
 
 /**
  * Claude Code CLI inference variant (TOS-clean SAFE/CLOUD route).
@@ -153,11 +153,6 @@ export function __setSpawnForTests(fn: SpawnFn): () => void {
   return () => {
     spawnImpl = prev;
   };
-}
-
-/** Redact anything resembling a secret out of stderr before logging. */
-function redactStderr(stderr: string): string {
-  return redactSensitive(stderr).slice(0, 2000);
 }
 
 export class ClaudeCli {

--- a/plugins/plugin-cli-inference/src/codex-cli-exec.ts
+++ b/plugins/plugin-cli-inference/src/codex-cli-exec.ts
@@ -10,7 +10,7 @@ import {
   type SpawnResult,
 } from "./claude-cli";
 import { flattenPrompt } from "./prompt-flatten";
-import { filterEnv, redactSensitive, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
+import { filterEnv, redactStderr, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
 
 /**
  * Codex CLI inference variant (TOS-clean SAFE/CLOUD route).
@@ -50,8 +50,6 @@ export interface CodexCliConfig {
   model?: string;
   timeoutMs?: number;
   env?: NodeJS.ProcessEnv;
-  /** Injected spawner; defaults to the seam set via `__setSpawnForTests`. */
-  spawnFn?: SpawnFn;
   /**
    * Pin the resolved binary path, skipping `resolveSafeBinary`. Used by unit
    * tests and by container deploys that pin the CLI outside the default
@@ -59,10 +57,6 @@ export interface CodexCliConfig {
    * whitelist.
    */
   binaryPath?: string;
-}
-
-function redactStderr(stderr: string): string {
-  return redactSensitive(stderr).slice(0, 2000);
 }
 
 export class CodexParseError extends Error {
@@ -166,19 +160,13 @@ export class CodexCli {
   private readonly model: string;
   private readonly timeoutMs: number;
   private readonly env: NodeJS.ProcessEnv;
-  private readonly spawnFn?: SpawnFn;
   private readonly binaryPath?: string;
 
   constructor(config: CodexCliConfig = {}) {
     this.model = config.model ?? DEFAULT_MODEL;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.env = config.env ?? process.env;
-    this.spawnFn = config.spawnFn;
     this.binaryPath = config.binaryPath;
-  }
-
-  private getSpawn(): SpawnFn {
-    return this.spawnFn ?? spawnImpl;
   }
 
   async generate(params: ClaudeGenerateParams): Promise<string> {
@@ -207,7 +195,7 @@ export class CodexCli {
         prompt,
       ];
 
-      const result: SpawnResult = await this.getSpawn()(argv, {
+      const result: SpawnResult = await spawnImpl(argv, {
         cwd,
         env: filterEnv(this.env),
         timeoutMs: this.timeoutMs,

--- a/plugins/plugin-cli-inference/src/sandbox.ts
+++ b/plugins/plugin-cli-inference/src/sandbox.ts
@@ -5,14 +5,14 @@
  *
  * Keep in sync with the upstream copy if `SAFE_ENV_KEYS` / `SENSITIVE_ENV_RE`
  * change. Additions here over the upstream copy: the `SENSITIVE_ENV_RE` export
- * and `redactSensitive`, used by the CLI handlers to redact subprocess stderr
- * before logging.
+ * plus `redactSensitive` / `redactStderr`, used by the CLI handlers to redact
+ * subprocess stderr before logging.
  *
  * - `filterEnv` — explicit allowlist + token blocklist for child env.
  * - `resolveSafeCwd` — realpath validation; cwd must be under workspace or /tmp.
  * - `resolveSafeBinary` — PATH lookup constrained to an allowlisted launcher dir.
  * - `redactSensitive` — strips key-named + value-shaped secrets from stderr.
- * - `buildSandboxedCommand` — wraps argv in sandbox-exec (macOS) or bwrap (Linux).
+ * - `redactStderr` — `redactSensitive` + a length cap for error messages / logs.
  */
 
 import { existsSync, realpathSync, statSync } from "node:fs";
@@ -20,7 +20,7 @@ import { homedir, tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, resolve, sep } from "node:path";
 
 /** Env keys that may be forwarded to a sub-agent verbatim. */
-export const SAFE_ENV_KEYS: ReadonlySet<string> = new Set([
+const SAFE_ENV_KEYS: ReadonlySet<string> = new Set([
   "PATH",
   "HOME",
   "TMPDIR",
@@ -71,7 +71,7 @@ export function filterEnv(
   return out;
 }
 
-export class SubAgentCwdError extends Error {
+class SubAgentCwdError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "SubAgentCwdError";
@@ -111,7 +111,7 @@ export function resolveSafeCwd(cwd: string, workspaceRoots: readonly string[]): 
   );
 }
 
-export class SubAgentBinaryError extends Error {
+class SubAgentBinaryError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "SubAgentBinaryError";
@@ -189,95 +189,6 @@ export function resolveSafeBinary(binary: string, env: NodeJS.ProcessEnv = proce
   return realpathSync(launcher);
 }
 
-export interface SandboxPlan {
-  cmd: string[];
-  /** Identifier of the sandbox layer in use; `"none"` when no helper available. */
-  sandbox: "macos-sandbox-exec" | "linux-bwrap" | "none";
-}
-
-export interface SandboxOptions {
-  workspaceRoot: string;
-  sessionId: string;
-  /** Path to a macOS .sb profile. Required on darwin. */
-  macosProfile?: string;
-  /** Path to the bwrap wrapper script. Required on linux. */
-  linuxWrapper?: string;
-}
-
-/**
- * Build the final argv for spawning the sub-agent, prepended by an OS
- * sandbox helper when available. Returns `sandbox: "none"` and the raw
- * argv when no helper exists (Windows, or missing profile in dev) — the
- * caller MUST log a WARN in that case.
- */
-export function buildSandboxedCommand(argv: string[], opts: SandboxOptions): SandboxPlan {
-  if (process.platform === "darwin") {
-    if (opts.macosProfile && existsSync(opts.macosProfile) && hasBinary("/usr/bin/sandbox-exec")) {
-      const cmd = [
-        "/usr/bin/sandbox-exec",
-        "-D",
-        `WORKSPACE=${opts.workspaceRoot}`,
-        "-D",
-        `SESSION=${opts.sessionId}`,
-        "-D",
-        `HOME=${homedir()}`,
-        "-D",
-        `TMPDIR=${tmpdir()}`,
-        "-f",
-        opts.macosProfile,
-        ...argv,
-      ];
-      return { cmd, sandbox: "macos-sandbox-exec" };
-    }
-    return { cmd: argv, sandbox: "none" };
-  }
-  if (process.platform === "linux") {
-    if (opts.linuxWrapper && existsSync(opts.linuxWrapper) && hasBinary("/usr/bin/bwrap")) {
-      const cmd = [opts.linuxWrapper, opts.workspaceRoot, opts.sessionId, "--", ...argv];
-      return { cmd, sandbox: "linux-bwrap" };
-    }
-    return { cmd: argv, sandbox: "none" };
-  }
-  return { cmd: argv, sandbox: "none" };
-}
-
-function hasBinary(absPath: string): boolean {
-  try {
-    return existsSync(absPath);
-  } catch {
-    return false;
-  }
-}
-
-/** True iff the path resolved cleanly to an executable file. */
-export function isExecutable(path: string): boolean {
-  try {
-    const real = realpathSync(path);
-    const stat = statSync(real);
-    // 0o111 = any-execute bit.
-    return stat.isFile() && (stat.mode & 0o111) !== 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Best-effort discovery of the bundled sandbox profile paths relative to
- * the package root. Returns undefined when the file is missing so callers
- * can fall through to no-sandbox + WARN.
- */
-export function locateBundledProfiles(packageRoot: string): {
-  macosProfile?: string;
-  linuxWrapper?: string;
-} {
-  const macos = resolve(packageRoot, "sandbox", "macos.sb");
-  const linux = resolve(packageRoot, "sandbox", "linux-bwrap.sh");
-  return {
-    ...(existsSync(macos) ? { macosProfile: macos } : {}),
-    ...(existsSync(linux) ? { linuxWrapper: linux } : {}),
-  };
-}
-
 /**
  * Value-shaped secret patterns. `SENSITIVE_ENV_RE` only catches lines that
  * mention a sensitive KEY name (e.g. `ANTHROPIC_API_KEY=...`); these catch the
@@ -308,4 +219,12 @@ export function redactSensitive(text: string): string {
     out = out.replace(re, SECRET_PLACEHOLDER);
   }
   return out;
+}
+
+/**
+ * Redact anything resembling a secret out of subprocess stderr before logging,
+ * then cap the length so a noisy CLI cannot blow up an error message / log line.
+ */
+export function redactStderr(stderr: string): string {
+  return redactSensitive(stderr).slice(0, 2000);
 }


### PR DESCRIPTION
Code-audit cleanup of `plugin-cli-inference` (no behavior change, +20/-125):
- delete ~93 lines of never-applied sandbox-builder code (`SandboxPlan`/`SandboxOptions`/`buildSandboxedCommand`/`isExecutable`/`locateBundledProfiles`/`hasBinary`) — verified zero references outside sandbox.ts
- define `redactStderr` once in sandbox.ts (was byte-identical in both CLI files)
- remove the never-set `CodexCliConfig.spawnFn` injection point + `getSpawn()` (the module-level `spawnImpl` test seam already covers it)
- inline the dead model-type consts + drop the `RuntimeWithSettings` alias that re-declared `IAgentRuntime.getSetting` as optional when it's guaranteed

typecheck + 26 tests + lint + build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)