### PR TITLE
feat(ui): surface the shared→dedicated cloud-agent handoff with a chat banner

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -44,6 +44,7 @@ import { AssistantOverlay } from "./components/shell/AssistantOverlay";
 import { BugReportModal } from "./components/shell/BugReportModal";
 import { ChatAmbientBackground } from "./components/shell/ChatAmbientBackground";
 import { ChatSurface } from "./components/shell/ChatSurface";
+import { CloudHandoffBanner } from "./components/shell/CloudHandoffBanner";
 import { ConnectionFailedBanner } from "./components/shell/ConnectionFailedBanner";
 import { ConnectionLostOverlay } from "./components/shell/ConnectionLostOverlay";
 import { ContinuousChatOverlay } from "./components/shell/ContinuousChatOverlay";
@@ -1821,6 +1822,7 @@ export function App() {
           <ConnectionFailedBanner />
           <SystemWarningBanner />
           <ActionBanner />
+          <CloudHandoffBanner />
           {shellContent}
         </div>
         {/* Full-screen overlay app — renders whichever overlay app is active */}

--- a/packages/ui/src/components/shell/CloudHandoffBanner.tsx
+++ b/packages/ui/src/components/shell/CloudHandoffBanner.tsx
@@ -1,0 +1,55 @@
+import { Check } from "lucide-react";
+import type { CloudHandoffPhase } from "../../events";
+import { useCloudHandoffPhase } from "../../hooks/useCloudHandoffPhase";
+import { cn } from "../../lib/utils";
+import { Spinner } from "../ui/spinner";
+
+// z-[9999] mirrors Z_SYSTEM_CRITICAL in ../../lib/floating-layers.ts, matching
+// the sibling top banners. Kept literal so Tailwind v4's scanner emits it.
+
+const MESSAGE: Record<CloudHandoffPhase, string> = {
+  migrating: "Setting up your dedicated agent — you can keep chatting.",
+  switched: "You're now on your dedicated agent.",
+  "switched-empty": "You're now on your dedicated agent.",
+  "timed-out":
+    "Your dedicated agent is taking longer — you're still on the shared one.",
+  failed:
+    "Couldn't switch to your dedicated agent yet — you're still on the shared one.",
+};
+
+/**
+ * Surfaces the shared→dedicated cloud-agent handoff so the background swap is
+ * visible instead of silent. While a freshly-provisioned agent's container
+ * boots the user chats on the shared adapter; once it's ready the live client
+ * swaps over automatically. Renders in document flow like the other top banners
+ * and self-dismisses via {@link useCloudHandoffPhase}.
+ */
+export function CloudHandoffBanner() {
+  const handoff = useCloudHandoffPhase();
+  if (!handoff) return null;
+
+  const { phase } = handoff;
+  const isFailure = phase === "timed-out" || phase === "failed";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-window-titlebar-banner="true"
+      className={cn(
+        "mobile-top-banner shrink-0 z-[9999] flex items-center gap-3 px-4 py-2 text-sm font-medium text-[color:var(--accent-foreground)]",
+        isFailure ? "bg-warn" : "bg-accent",
+      )}
+    >
+      {phase === "migrating" ? (
+        <Spinner
+          size={16}
+          className="shrink-0 text-[color:var(--accent-foreground)]"
+        />
+      ) : isFailure ? null : (
+        <Check size={16} className="shrink-0" aria-hidden />
+      )}
+      <span className="truncate">{MESSAGE[phase]}</span>
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./useActivityEvents";
 export * from "./useAutomationDeepLink";
 export * from "./useBugReport.hooks";
 export * from "./useChatAvatarVoiceBridge";
+export * from "./useCloudHandoffPhase";
 export * from "./useConnectorAccounts";
 export * from "./useConnectorReconnect";
 export * from "./useConnectorSendAsAccount";

--- a/packages/ui/src/hooks/useCloudHandoffPhase.test.tsx
+++ b/packages/ui/src/hooks/useCloudHandoffPhase.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudHandoffBanner } from "../components/shell/CloudHandoffBanner";
+import {
+  CLOUD_HANDOFF_PHASE_EVENT,
+  type CloudHandoffPhaseDetail,
+} from "../events";
+import { useCloudHandoffPhase } from "./useCloudHandoffPhase";
+
+function emit(detail: CloudHandoffPhaseDetail) {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(CLOUD_HANDOFF_PHASE_EVENT, { detail }),
+    );
+  });
+}
+
+describe("useCloudHandoffPhase", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("starts empty and holds the migrating phase while the container boots", () => {
+    const { result } = renderHook(() => useCloudHandoffPhase());
+    expect(result.current).toBeNull();
+
+    emit({ agentId: "a1", phase: "migrating" });
+    expect(result.current?.phase).toBe("migrating");
+
+    // migrating has no auto-dismiss — it persists until the swap resolves.
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(result.current?.phase).toBe("migrating");
+  });
+
+  it("auto-clears a success phase after its linger window", () => {
+    const { result } = renderHook(() => useCloudHandoffPhase());
+    emit({ agentId: "a1", phase: "switched", imported: 3 });
+    expect(result.current?.phase).toBe("switched");
+
+    act(() => vi.advanceTimersByTime(4000));
+    expect(result.current).toBeNull();
+  });
+
+  it("keeps a failure visible longer, then clears", () => {
+    const { result } = renderHook(() => useCloudHandoffPhase());
+    emit({ agentId: "a1", phase: "failed", error: "boom" });
+    expect(result.current?.phase).toBe("failed");
+
+    act(() => vi.advanceTimersByTime(4000));
+    expect(result.current?.phase).toBe("failed"); // still inside the 6s window
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("CloudHandoffBanner", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("renders nothing until a handoff starts", () => {
+    const { container } = render(<CloudHandoffBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the migrating copy, then the switched confirmation", () => {
+    render(<CloudHandoffBanner />);
+    emit({ agentId: "a1", phase: "migrating" });
+    expect(screen.queryByText(/keep chatting/i)).not.toBeNull();
+
+    emit({ agentId: "a1", phase: "switched", imported: 2 });
+    expect(screen.queryByText(/now on your dedicated agent/i)).not.toBeNull();
+  });
+
+  it("shows reassuring fallback copy on a failed/timed-out handoff", () => {
+    render(<CloudHandoffBanner />);
+    emit({ agentId: "a1", phase: "timed-out" });
+    expect(screen.queryByText(/still on the shared one/i)).not.toBeNull();
+  });
+});

--- a/packages/ui/src/hooks/useCloudHandoffPhase.ts
+++ b/packages/ui/src/hooks/useCloudHandoffPhase.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import {
+  CLOUD_HANDOFF_PHASE_EVENT,
+  type CloudHandoffPhaseDetail,
+} from "../events";
+
+// How long a terminal phase lingers before the banner self-clears. `migrating`
+// has no timer — it persists until the swap resolves (the container boot can
+// take 60-90s).
+const SUCCESS_LINGER_MS = 4000;
+const FAILURE_LINGER_MS = 6000;
+
+/**
+ * Subscribe to the shared→dedicated cloud-agent handoff lifecycle
+ * ({@link CLOUD_HANDOFF_PHASE_EVENT}) so a progress indicator can render it.
+ * The backend already drives the whole handoff (instant chat on the shared
+ * adapter → silent history import → atomic client swap) and emits the phase;
+ * this hook just exposes the latest phase and auto-clears the terminal ones so
+ * the banner dismisses itself. Returns `null` when there is nothing to show.
+ */
+export function useCloudHandoffPhase(): CloudHandoffPhaseDetail | null {
+  const [detail, setDetail] = useState<CloudHandoffPhaseDetail | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPhase = (event: Event) => {
+      const next = (event as CustomEvent<CloudHandoffPhaseDetail>).detail;
+      if (next) setDetail(next);
+    };
+    window.addEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+    return () => window.removeEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+  }, []);
+
+  useEffect(() => {
+    if (!detail || detail.phase === "migrating") return;
+    const lingerMs =
+      detail.phase === "timed-out" || detail.phase === "failed"
+        ? FAILURE_LINGER_MS
+        : SUCCESS_LINGER_MS;
+    const id = window.setTimeout(() => setDetail(null), lingerMs);
+    return () => window.clearTimeout(id);
+  }, [detail]);
+
+  return detail;
+}


### PR DESCRIPTION
## What

Make the seamless shared→dedicated cloud-agent handoff **visible**. Today a brand-new user already gets the best-case flow — they chat **instantly** on the shared adapter while their dedicated container cold-boots (~60-90s), the backend silently imports their history, and the live client **atomically swaps** to the dedicated container once it's ready (failing safe to the working shared agent). That handoff already emits a typed phase event (`CLOUD_HANDOFF_PHASE_EVENT`), but **nothing in the UI consumed it**, so the whole thing happened silently — which can read as a glitch.

This adds the missing UI consumer. No backend change.

## Changes
- **`hooks/useCloudHandoffPhase.ts`** — subscribes to `CLOUD_HANDOFF_PHASE_EVENT`; holds `migrating` while the container boots (no auto-dismiss), and auto-clears the terminal phases (`switched`/`switched-empty` after ~4s, `timed-out`/`failed` after ~6s) so the banner self-dismisses. Returns `null` when there's nothing to show.
- **`components/shell/CloudHandoffBanner.tsx`** — a self-gating top banner that mirrors the existing `ConnectionFailedBanner` / `SystemWarningBanner` pattern (document-flow, `mobile-top-banner`, `bg-accent`/`bg-warn`, `aria-live`). Copy: *"Setting up your dedicated agent — you can keep chatting"* → *"You're now on your dedicated agent"*, with reassuring fallback *"you're still on the shared one"* if it's slow.
- **`App.tsx`** / **`hooks/index.ts`** — mount + export alongside the sibling banners.

## Why this design
- Consumes the **existing** event seam rather than adding a parallel mechanism — no new handoff state, no backend wiring.
- App-level fixed banner (not coupled to a specific chat surface) because the handoff is an app-level background process; visible wherever the user is.
- Reuses the established banner pattern/tokens (no new primitives, no new color tokens).

## Verification
- `biome check` clean; `ui` typecheck clean for the new files (remaining repo errors are pre-existing unbuilt-dep `TS2307`s)
- **6/6** new tests pass — hook lifecycle (migrating persists, success/failure auto-dismiss windows) + banner copy per phase

Part of the launch flow tracked in #8434. Pairs with the already-built backend handoff (`startCloudConversationHandoff` / `conversation-handoff`).