### PR TITLE
chore(e2e-coverage): flip the #8802 ship-gate to required (baseline green)

### DIFF
--- a/.github/workflows/e2e-coverage-gate.yml
+++ b/.github/workflows/e2e-coverage-gate.yml
@@ -38,10 +38,10 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
-      - name: Build the e2e coverage matrix (advisory)
+      - name: Build the e2e coverage matrix (required)
         env:
           # Flip to "1" to make this standalone gate required.
-          E2E_COVERAGE_GATE_ENFORCE: "0"
+          E2E_COVERAGE_GATE_ENFORCE: "1"
         run: bun packages/scripts/check-e2e-coverage.ts --report-dir reports/coverage
 
       - name: Upload e2e coverage matrix

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -502,7 +502,7 @@ jobs:
       # required by setting E2E_COVERAGE_GATE_ENFORCE=1.
       - name: E2E coverage ship-gate
         env:
-          E2E_COVERAGE_GATE_ENFORCE: "0"
+          E2E_COVERAGE_GATE_ENFORCE: "1"
         run: bun test packages/scripts/__tests__/e2e-coverage.test.ts
 
       - name: E2E coverage matrix report

--- a/packages/scripts/e2e-coverage/manifest.ts
+++ b/packages/scripts/e2e-coverage/manifest.ts
@@ -236,14 +236,8 @@ export const ZERO_TEST_EXEMPT: Record<string, string> = {
     "Benchmark/eval harness plugin used to drive scenario benchmarks; it has no shipped runtime behavior to unit-test and runs only under the benchmark lanes.",
   "plugin-google-meet-cute":
     "Experimental Google Meet companion surface gated behind live Google Meet credentials; no deterministic fixture exists.",
-  "plugin-local-embedding":
-    "Native on-device embedding backend; requires downloaded model weights + native runtime, validated by the local-model validation lane rather than keyless unit tests.",
-  "plugin-mlx":
-    "Apple MLX native inference backend; requires the MLX framework + model weights on Apple Silicon, validated on-device rather than in keyless CI.",
   "plugin-native-shared-types":
     "Pure shared TypeScript type/contract definitions for the native bridges; there is no runtime behavior to test.",
-  "plugin-omnivoice":
-    "Native voice (TTS/ASR) backend; requires built native dylibs + voice models, validated by the local-model validation lane rather than keyless CI.",
   "plugin-tee":
     "Trusted-execution (dstack TEE) attestation/key-release; requires real TEE hardware + a dstack socket, validated by the dedicated TEE smoke scripts.",
   "plugin-xmtp":


### PR DESCRIPTION
Completes the last rollout step of [#8802](https://github.com/elizaOS/eliza/issues/8802) **AC7**: _"advisory for one cycle, then required once the baseline is green."_ The full scenario-pr workflow now passes on develop, so this flips `E2E_COVERAGE_GATE_ENFORCE` `0 → 1` — the develop-landscape ratchets (route-wiring lock-step, zero-test documentation, blocking gaps) become hard failures, joining the already-hard structural checks (manifested-coverage resolution, larp rejection, served-command contract).

Also drops three **dangling** `ZERO_TEST_EXEMPT` entries — `plugin-local-embedding`, `plugin-mlx`, `plugin-omnivoice` no longer exist as `plugins/` directories on develop (consolidated into `plugin-local-inference`), which the stale-exemption ratchet flagged. `ZERO_TEST_EXEMPT` now matches the actual zero-test set exactly (2004scape, action-bench, google-meet-cute, hyperscape, native-shared-types, scape, tee, xmtp).

CI on this PR runs the gate in enforce mode against develop's plugin set — `scenario-runner-e2e` green here confirms the baseline is enforce-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)