### PR TITLE
perf(agent): parallelize document-recovery searches off the chat reply path

### DIFF
--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -380,9 +380,18 @@ export async function maybeAugmentChatMessageWithDocuments(
     // generate-text round-trip on every plain-chat turn. Skip it.
     if (relevantMatches.length === 0 && initialMatches.matches.length > 0) {
       const recoveredQueries = await recoverDocumentSearchQueriesWithLlm();
-      for (const query of recoveredQueries) {
-        const recovered = await loadMatchesAcrossScopes(query);
-        if (recovered.timedOut) return message;
+      // Run the recovered-query searches concurrently. Each is an independent
+      // embedding round-trip (~1.5s); awaiting them one at a time was the bulk
+      // of the pre-reply latency (this augmentation runs before the reply is
+      // generated). Keep the original "first non-empty result wins" preference
+      // by scanning the resolved results in query order.
+      const recoveredResults = await Promise.all(
+        recoveredQueries.map((query) => loadMatchesAcrossScopes(query)),
+      );
+      if (recoveredResults.some((recovered) => recovered.timedOut)) {
+        return message;
+      }
+      for (const recovered of recoveredResults) {
         const recoveredMatches = selectRelevantMatches(recovered.matches)
           .sort(
             (left, right) => (right.similarity ?? 0) - (left.similarity ?? 0),


### PR DESCRIPTION
## What
Live forensics on a cloud agent (PhoneProd) found the dominant chat latency isn't the LLM reply (~1s) — it's the **document augmentation that runs synchronously before every reply**. `chat-routes.ts` awaits `maybeAugmentChatMessageWithDocuments` before `handleMessage`; when the initial doc search returns sub-threshold candidates, it runs an LLM query-recovery that fans out to up to 3 recovered queries, **each awaited serially** — several back-to-back ~1.5s embedding round-trips. **Measured ~11s/turn**, all before the reply, and *outside* the per-turn timer (which is why earlier latency work concluded embeddings weren't on the turn).

## Fix
Run the recovered-query searches **concurrently** (`Promise.all`) instead of serially. Behaviour preserved — first non-empty result in query order still wins, and any per-search timeout still abandons augmentation. Recovery drops from N×~1.5s serial to ~1.5s concurrent.

## Verification
biome clean; agent typecheck clean for the file (remaining repo errors are pre-existing unbuilt-dep `TS2307`s).

## Deeper follow-ups (coordinated on #8434, span core/cloud lanes)
- Defer augmentation off the pre-`handleMessage` critical path (make it a parallel context provider)
- Batch the query embeds into one `TEXT_EMBEDDING_BATCH` call
- Cache query embeddings
- Extend `ELIZA_DOCUMENT_AUGMENTATION_DISABLED` to cloud agents with no useful corpus

Part of the chat-latency root-cause tracked in #8434.