### PR TITLE
revert(agent-image): restore tsx loader to unblock the red boot-verify build

### DIFF
--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -7,12 +7,9 @@ ARG APP_CORE_DIR=packages/app-core
 ARG AGENT_DIR=packages/agent
 ARG APP_DIR=packages/app
 ARG APP_ENTRYPOINT=packages/agent/dist/bin.js
-# F6 (#8812): start the agent under plain `node` — no `tsx` loader. The prebuilt
-# dist is already compiled JS with `.ts` specifiers rewritten to `.js` (tsconfig
-# rewriteRelativeImportExtensions), so the tsx loader only added a per-process
-# register tax. Verified by the image build + boot smoke. The `tsx` stage/COPY
-# below is now unused on the cold path and can be dropped in a follow-up.
-ARG APP_CMD_START="node packages/agent/dist/bin.js start"
+# `--import` points at the standalone tsx loader installed by the `tsx` stage
+# at /opt/tsx — avoids depending on workspace-resolved `tsx` in /app/node_modules.
+ARG APP_CMD_START="node --import /opt/tsx/node_modules/tsx/dist/loader.mjs packages/agent/dist/bin.js start"
 ARG APP_PORT=2138
 ARG APP_API_BIND=127.0.0.1
 ARG OCI_SOURCE=""
@@ -224,4 +221,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
   CMD sh -lc 'port="${PORT:-${APP_PORT:-${ELIZA_PORT:-2138}}}"; code="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/api/health")" && [ "$code" = "200" -o "$code" = "401" ]'
 
 ENTRYPOINT ["sh", "-lc", "exec sh \"./${APP_CORE_DIR:-packages/app-core}/scripts/docker-entrypoint.sh\" \"$@\"", "--"]
-CMD ["sh", "-lc", "exec ${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"]
+CMD ["sh", "-lc", "exec ${APP_CMD_START:-node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"]

--- a/packages/app-core/scripts/build-image.sh
+++ b/packages/app-core/scripts/build-image.sh
@@ -115,9 +115,7 @@ load_env_file "deploy/deploy.env"
 
 APP_IMAGE="${APP_IMAGE:-eliza/agent}"
 APP_ENTRYPOINT="${APP_ENTRYPOINT:-app.mjs}"
-# F6 (#8812): start under plain `node` — the prebuilt dist is compiled JS with
-# `.ts` specifiers rewritten to `.js`, so the tsx loader only added startup tax.
-APP_CMD_START="${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"
+APP_CMD_START="${APP_CMD_START:-node --import ./node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"
 APP_PORT="${APP_PORT:-2138}"
 APP_API_BIND="${APP_API_BIND:-127.0.0.1}"
 OCI_SOURCE="${OCI_SOURCE:-}"

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -224,9 +224,7 @@ load_env_file "deploy/deploy.env"
 
 APP_IMAGE="${APP_IMAGE:-eliza/agent}"
 APP_ENTRYPOINT="${APP_ENTRYPOINT:-$AGENT_DIR/dist/bin.js}"
-# F6 (#8812): start under plain `node` — the prebuilt dist is compiled JS with
-# `.ts` specifiers rewritten to `.js`, so the tsx loader only added startup tax.
-APP_CMD_START="${APP_CMD_START:-node ${APP_ENTRYPOINT} start}"
+APP_CMD_START="${APP_CMD_START:-node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"
 APP_PORT="${APP_PORT:-2138}"
 APP_API_BIND="${APP_API_BIND:-127.0.0.1}"
 OCI_SOURCE="${OCI_SOURCE:-}"


### PR DESCRIPTION
**🚨 Launch-blocker unblock.** The develop agent-image build has been red ~10h — every build since #8837 (`99203e80c0`, 'start the agent under plain node, drop the tsx loader') fails at *Verify image boots*. Dropping tsx broke node-ESM resolution of extensionless/dir relative imports, of which there are **~559** across plugin `index.ts` files — so a forward-fix is systemic whack-a-mole, not the 3 plugins it first appears to be. The #8837 follow-up #84f1adb did not fix it.

This reverts **only #8837** (restores the tsx loader; clean auto-merge, 3 boot-script files). The tsx loader resolves all those imports transparently — the known-good boot from before 17:15. **No live agent has the tsx-less image (the build's been red the whole time), so this loses nothing currently running** — only the boot-perf optimization, which can be redone properly post-launch (a bundler that emits extension-correct ESM, or a codebase-wide import sweep).

Triggering a build-agent-image on this branch to confirm it boots green before merge. @standujar (your #8837) — shout if you have a forward-fix landing; otherwise I'm merging this to unblock all agent-side deploys for launch.