### PR TITLE
fix(plugin-elizacloud): emit json_object not json_schema for cerebras models

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Offline unit coverage for the native `/chat/completions` `response_format`
+ * gate. Cerebras-served models (the gpt-oss family) 400 on
+ * `response_format: { type: "json_schema" }`, so for those models the wire body
+ * must carry `{ type: "json_object" }` instead. Every other model keeps the
+ * full `json_schema` payload so structured output stays schema-constrained.
+ *
+ * The fetch is mocked: we capture the request body and return a canned
+ * chat-completions response, asserting only the outgoing `response_format`.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateNativeChatCompletion } from "../../src/models/text";
+
+type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
+  Partial<IAgentRuntime>;
+
+function runtime(): IAgentRuntime {
+  const settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  };
+  const fixture: RuntimeFixture = {
+    character: { name: "Eliza", bio: [] },
+    getSetting: (key: string) => settings[key],
+    emitEvent: vi.fn(),
+  };
+  return fixture as IAgentRuntime;
+}
+
+const RESPONSE_SCHEMA = {
+  schema: {
+    type: "object",
+    properties: { reply: { type: "string" } },
+    required: ["reply"],
+  },
+  name: "reply_envelope",
+};
+
+function cannedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+async function captureResponseFormat(modelName: string): Promise<unknown> {
+  let captured: Record<string, unknown> | null = null;
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (typeof init?.body === "string") {
+        captured = JSON.parse(init.body) as Record<string, unknown>;
+      }
+      return cannedResponse();
+    }
+  );
+
+  await generateNativeChatCompletion(
+    runtime(),
+    "TEXT_SMALL",
+    { prompt: "hi", responseSchema: RESPONSE_SCHEMA } as never,
+    { modelName, prompt: "hi" }
+  );
+
+  return (captured as Record<string, unknown> | null)?.response_format;
+}
+
+describe("native /chat/completions response_format gate", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits json_object for cerebras-served gpt-oss models", async () => {
+    const responseFormat = await captureResponseFormat("gpt-oss-120b");
+    expect(responseFormat).toEqual({ type: "json_object" });
+  });
+
+  it("keeps json_schema for non-cerebras models", async () => {
+    const responseFormat = await captureResponseFormat("zai-glm-4.7");
+    expect(responseFormat).toMatchObject({
+      type: "json_schema",
+      json_schema: { name: "reply_envelope" },
+    });
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -348,6 +348,18 @@ function isReasoningModel(modelName: string): boolean {
   return REASONING_MODEL_PATTERNS.some((pattern) => lower.includes(pattern));
 }
 
+/**
+ * True when the Cloud gateway routes this model to Cerebras (the gpt-oss
+ * family). Cerebras's OpenAI-compatible endpoint rejects
+ * `response_format: { type: "json_schema", ... }` with a 400, so structured
+ * output for these models must fall back to `{ type: "json_object" }`.
+ * Mirrors plugin-openai's `isCerebrasMode` json_object scrub, detected by
+ * model name here because one Cloud key serves many providers.
+ */
+function isCerebrasServedModel(modelName: string): boolean {
+  return modelName.toLowerCase().includes("gpt-oss");
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -535,9 +547,15 @@ function normalizeNativeToolChoice(toolChoice: unknown): unknown {
   return toolName ? { type: "function", function: { name: toolName } } : toolChoice;
 }
 
-function buildNativeResponseFormat(responseSchema: unknown): unknown {
+function buildNativeResponseFormat(responseSchema: unknown, modelName: string): unknown {
   if (!responseSchema) {
     return undefined;
+  }
+
+  // Cerebras-served models (gpt-oss) 400 on `response_format: json_schema`, so
+  // emit `json_object` and rely on the schema embedded in the prompt body.
+  if (isCerebrasServedModel(modelName)) {
+    return { type: "json_object" };
   }
 
   const schemaRecord = asRecord(responseSchema);
@@ -653,7 +671,7 @@ function buildNativeRequestBody(
   const promptCacheKey = providerOptions ? resolvePromptCacheKey(providerOptions) : undefined;
   const tools = normalizeNativeTools(params.tools);
   const toolChoice = normalizeNativeToolChoice(params.toolChoice);
-  const responseFormat = buildNativeResponseFormat(params.responseSchema);
+  const responseFormat = buildNativeResponseFormat(params.responseSchema, modelName);
   const requestBody: Record<string, unknown> = {
     model: modelName,
     messages: buildNativeMessages(params, promptText, systemPrompt),


### PR DESCRIPTION
## Problem

Cloud agents are served by **plugin-elizacloud** (priority 50), not plugin-openai — so plugin-openai's `isCerebrasMode` schema-scrub never runs for cloud-routed inference.

The native `/chat/completions` path (`buildNativeRequestBody` → `buildNativeResponseFormat`) always emits `response_format: { type: "json_schema", ... }` when a `responseSchema` is present. Cerebras's OpenAI-compatible endpoint (which the Cloud gateway routes the **gpt-oss** family to) rejects `json_schema` with a **400**, forcing a `json_object` fallback on every post-turn evaluator call — a wasted round-trip every turn.

## Fix

Gate `buildNativeResponseFormat` on the resolved model name: for cerebras-served (gpt-oss) models it now emits `response_format: { type: "json_object" }`; every other model keeps the full `json_schema` payload so structured output stays schema-constrained.

Detection mirrors plugin-openai's `isCerebrasMode` json_object scrub, using model-name detection (`gpt-oss`) here because one Cloud key serves many providers — consistent with the existing `isReasoningModel` model-name idiom in the same file.

## Tests

- New offline unit test `text-cerebras-response-format.test.ts`: asserts `json_object` for `gpt-oss-120b` and `json_schema` for `zai-glm-4.7` (the cloud default large model).
- Full plugin-elizacloud suite: **212 passed, 3 skipped (live-gated)**.
- `typecheck` and `lint:check` clean.