### PR TITLE
feat(ui/chat): one-tap Retry on transient chat failures

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -61,6 +61,19 @@ export const NoProviderGate: Story = {
   },
 };
 
+/**
+ * `failureKind: "rate_limited"` (and `provider_issue`) render the graceful
+ * message with a one-tap Retry that resends the preceding user turn.
+ */
+export const RateLimitedRetry: Story = {
+  args: {
+    message: makeMessage({
+      text: "The agent is busy right now — wait a few seconds and try again.",
+      failureKind: "rate_limited",
+    }),
+  },
+};
+
 /** Local-inference `downloading` status shows the warn banner + progress CTA. */
 export const LocalModelDownloading: Story = {
   args: {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1367,6 +1367,33 @@ export function MessageContent({
     );
   }
 
+  // Transient server failures (the agent was rate-limited or the provider had a
+  // hiccup) render the graceful message plus a one-tap Retry that resends the
+  // preceding user turn, so a stalled turn isn't a dead end the user has to
+  // retype. `no_provider`/`insufficient_credits` are excluded — a retry can't
+  // fix those (they have their own Settings / billing affordances).
+  if (
+    message.failureKind === "rate_limited" ||
+    message.failureKind === "provider_issue"
+  ) {
+    return (
+      <div className="border border-warn/30 bg-warn/5 rounded-sm p-3 text-sm">
+        <div className="text-muted whitespace-pre-wrap mb-2">
+          {message.text}
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            if (message.id) app.handleChatRetry(message.id);
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
   // Fast path: single plain-text segment (most messages)
   if (segments.length === 1 && segments[0].kind === "text") {
     return (


### PR DESCRIPTION
## What
On a transient failure (`rate_limited` / `provider_issue`) the chat showed the graceful 'busy — wait and resend' message as a plain bubble with **no affordance** — the user had to retype. Now those render the message **+ a one-tap Retry** that drops the failed bubble and resends the preceding user turn.

## How
- Reuses the existing **`handleChatRetry`** (already on the app context — `MessageContent` already calls `useApp()`, so no prop-drilling).
- Mirrors the existing `no_provider` warn-card pattern exactly (same card + `Button`), so it inherits a visual treatment already proven on-device.
- `no_provider` (Settings CTA) and `insufficient_credits` (billing) are intentionally excluded — a retry can't fix those.
- Added a `RateLimitedRetry` Storybook story.

## Verification
biome + typecheck clean. Visual is a clone of the on-device-verified `no_provider` card; I'll confirm on-device with the next APK refresh.

Completes the chat-resilience UX (#38) alongside the graceful-failure notices already shipped. Part of #8434.