### PR TITLE
fix(cloud-shared): seed dedicated-agent persona from the default character (not a placeholder)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -850,3 +850,47 @@ describe("computeManagedAgentDbEnv (#8696 local agent state)", () => {
     expect(merged.ELIZA_MANAGED_DATABASE_URL).toBe(DB);
   });
 });
+
+describe("buildRuntimeBootstrapAgent persona seed", () => {
+  type BootstrapRec = Pick<AgentSandbox, "id" | "agent_name" | "agent_config" | "environment_vars">;
+  type BootstrapAgent = {
+    system: string;
+    bio: string[];
+    style: { all?: string[]; chat?: string[]; post?: string[] };
+  };
+
+  async function buildBootstrap(rec: BootstrapRec): Promise<BootstrapAgent> {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService() as unknown as {
+      buildRuntimeBootstrapAgent(r: BootstrapRec): BootstrapAgent;
+    };
+    return svc.buildRuntimeBootstrapAgent(rec);
+  }
+
+  const baseRec: BootstrapRec = {
+    id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+    agent_name: "bnancy",
+    agent_config: {},
+    environment_vars: {},
+  };
+
+  test("seeds the default Eliza persona when agent_config has no system/bio", async () => {
+    const { getDefaultElizaCharacterData } = await import("../utils/default-eliza-character");
+    const persona = getDefaultElizaCharacterData();
+    const agent = await buildBootstrap(baseRec);
+    expect(agent.system).toBe(persona.system);
+    expect(agent.bio).toEqual(persona.bio);
+    expect(agent.style).toEqual(persona.style);
+    // No more placeholder identity.
+    expect(agent.system).not.toBe("Concise cloud agent.");
+  });
+
+  test("preserves a real persona supplied in agent_config", async () => {
+    const agent = await buildBootstrap({
+      ...baseRec,
+      agent_config: { system: "You are shared-nancy.", bio: ["a real bio"] },
+    });
+    expect(agent.system).toBe("You are shared-nancy.");
+    expect(agent.bio).toEqual(["a real bio"]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -30,6 +30,7 @@ import { jobs } from "../../db/schemas/jobs";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { getDefaultElizaCharacterData } from "../utils/default-eliza-character";
 import { logger } from "../utils/logger";
 import {
   computeStateHash,
@@ -386,6 +387,10 @@ export class ElizaSandboxService {
       ...rawSettings,
       secrets,
     };
+    // Without a real persona the provisioned agent has no identity ("what is
+    // your name" gets a generic deflection). Seed the canonical default Eliza
+    // character so the runtime boots with a real system prompt + bio.
+    const persona = getDefaultElizaCharacterData();
 
     return {
       ...rawConfig,
@@ -400,19 +405,20 @@ export class ElizaSandboxService {
       system:
         typeof rawConfig.system === "string" && rawConfig.system.trim()
           ? rawConfig.system
-          : "Concise cloud agent.",
-      bio:
-        Array.isArray(rawConfig.bio) && rawConfig.bio.length > 0
-          ? rawConfig.bio
-          : ["Managed Eliza Cloud agent"],
+          : persona.system,
+      bio: Array.isArray(rawConfig.bio) && rawConfig.bio.length > 0 ? rawConfig.bio : persona.bio,
       topics:
         Array.isArray(rawConfig.topics) && rawConfig.topics.length > 0
           ? rawConfig.topics
-          : ["cloud assistance"],
+          : persona.topics,
       adjectives:
         Array.isArray(rawConfig.adjectives) && rawConfig.adjectives.length > 0
           ? rawConfig.adjectives
-          : ["helpful", "concise"],
+          : persona.adjectives,
+      style:
+        rawConfig.style && typeof rawConfig.style === "object" && !Array.isArray(rawConfig.style)
+          ? rawConfig.style
+          : persona.style,
       plugins,
       settings,
     };


### PR DESCRIPTION
## Problem

Dedicated cloud agents were provisioned with a **placeholder persona**, so "what is your name" got a generic deflection ("Just here, ready to help you!"). `buildRuntimeBootstrapAgent` (the config POSTed to the runtime's `POST /api/agents`) injected a system prompt, but it had no real identity:

- `system` → `"Concise cloud agent."`
- `bio` → `["Managed Eliza Cloud agent"]`
- `topics` → `["cloud assistance"]`
- `adjectives` → `["helpful", "concise"]`

It also never passed `style` at all.

## Fix

When a dedicated agent is provisioned without a real persona, seed `system` / `bio` / `topics` / `adjectives` / `style` from the canonical **default Eliza character** (`getDefaultElizaCharacterData()` in `cloud-shared/src/lib/utils/default-eliza-character.ts`) instead of hardcoded placeholder strings. A real `system`/`bio`/etc. supplied in `agent_config` is still preserved.

These fields map 1:1 onto the elizaOS `Character` shape (`system`, `bio`, `topics`, `adjectives`, `style`), so the seed flows into the provisioned agent's character at create time and the runtime boots with a real identity + system prompt.

## Tests

`bun test packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts` — 30 pass, 0 fail (2 new persona-seed tests: seeds default persona when config lacks one; preserves a real supplied persona). `bun run --cwd packages/cloud-shared typecheck` clean; Biome clean.
