### PR TITLE
fix(ios): embed on-device Bun engine in App Store builds (prod local-agent dead)

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, expect, it } from "vitest";
 
 import {
   isIosAppStoreBuild,
@@ -14,69 +13,73 @@ import {
 // builds". The fix is to flag the release build as a store build so the engine
 // is embedded; these tests lock that contract on the build script's own gate.
 
-test("default/empty env does NOT embed the engine (the prod-regression default)", () => {
-  // This is exactly the state the apple-store-release.yml build job shipped
-  // before the fix: no variant, no engine flag → a cloud-only thin client.
-  assert.equal(isIosAppStoreBuild({}), false);
-  assert.equal(shouldIncludeIosFullBunEngine({}), false);
-});
+describe("iOS full-Bun engine embed gate", () => {
+  it("default/empty env does NOT embed the engine (the prod-regression default)", () => {
+    // This is exactly the state the apple-store-release.yml build job shipped
+    // before the fix: no variant, no engine flag → a cloud-only thin client.
+    expect(isIosAppStoreBuild({})).toBe(false);
+    expect(shouldIncludeIosFullBunEngine({})).toBe(false);
+  });
 
-test("a plain direct build does not embed the engine", () => {
-  const env = { ELIZA_BUILD_VARIANT: "direct" };
-  assert.equal(isIosAppStoreBuild(env), false);
-  assert.equal(shouldIncludeIosFullBunEngine(env), false);
-});
+  it("a plain direct build does not embed the engine", () => {
+    const env = { ELIZA_BUILD_VARIANT: "direct" };
+    expect(isIosAppStoreBuild(env)).toBe(false);
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(false);
+  });
 
-test("ELIZA_BUILD_VARIANT=store embeds the engine by default", () => {
-  const env = { ELIZA_BUILD_VARIANT: "store" };
-  assert.equal(isIosAppStoreBuild(env), true);
-  assert.equal(shouldIncludeIosFullBunEngine(env), true);
-});
+  it("ELIZA_BUILD_VARIANT=store embeds the engine by default", () => {
+    const env = { ELIZA_BUILD_VARIANT: "store" };
+    expect(isIosAppStoreBuild(env)).toBe(true);
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(true);
+  });
 
-test("ELIZA_BUILD_VARIANT=store is case-insensitive", () => {
-  assert.equal(
-    shouldIncludeIosFullBunEngine({ ELIZA_BUILD_VARIANT: "STORE" }),
-    true,
-  );
-});
+  it("ELIZA_BUILD_VARIANT=store is case-insensitive", () => {
+    expect(
+      shouldIncludeIosFullBunEngine({ ELIZA_BUILD_VARIANT: "STORE" }),
+    ).toBe(true);
+  });
 
-test("ELIZA_RELEASE_AUTHORITY=apple-app-store embeds the engine by default", () => {
-  const env = { ELIZA_RELEASE_AUTHORITY: "apple-app-store" };
-  assert.equal(isIosAppStoreBuild(env), true);
-  assert.equal(shouldIncludeIosFullBunEngine(env), true);
-});
+  it("ELIZA_RELEASE_AUTHORITY=apple-app-store embeds the engine by default", () => {
+    const env = { ELIZA_RELEASE_AUTHORITY: "apple-app-store" };
+    expect(isIosAppStoreBuild(env)).toBe(true);
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(true);
+  });
 
-test("explicit ELIZA_IOS_FULL_BUN_ENGINE=1 embeds the engine even on a direct build", () => {
-  const env = { ELIZA_BUILD_VARIANT: "direct", ELIZA_IOS_FULL_BUN_ENGINE: "1" };
-  assert.equal(shouldIncludeIosFullBunEngine(env), true);
-});
+  it("explicit ELIZA_IOS_FULL_BUN_ENGINE=1 embeds the engine even on a direct build", () => {
+    const env = {
+      ELIZA_BUILD_VARIANT: "direct",
+      ELIZA_IOS_FULL_BUN_ENGINE: "1",
+    };
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(true);
+  });
 
-test("a store build can opt into a cloud-only thin client (no engine)", () => {
-  const env = {
-    ELIZA_BUILD_VARIANT: "store",
-    ELIZA_IOS_APP_STORE_LOCAL_RUNTIME: "0",
-  };
-  assert.equal(isIosAppStoreBuild(env), true);
-  assert.equal(shouldIncludeIosFullBunEngine(env), false);
-});
+  it("a store build can opt into a cloud-only thin client (no engine)", () => {
+    const env = {
+      ELIZA_BUILD_VARIANT: "store",
+      ELIZA_IOS_APP_STORE_LOCAL_RUNTIME: "0",
+    };
+    expect(isIosAppStoreBuild(env)).toBe(true);
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(false);
+  });
 
-test("cloud-only opt-out is overridden by an explicit engine request", () => {
-  // ELIZA_IOS_FULL_BUN_ENGINE is the unconditional force switch.
-  const env = {
-    ELIZA_BUILD_VARIANT: "store",
-    ELIZA_IOS_APP_STORE_LOCAL_RUNTIME: "0",
-    ELIZA_IOS_FULL_BUN_ENGINE: "1",
-  };
-  assert.equal(shouldIncludeIosFullBunEngine(env), true);
-});
+  it("cloud-only opt-out is overridden by an explicit engine request", () => {
+    // ELIZA_IOS_FULL_BUN_ENGINE is the unconditional force switch.
+    const env = {
+      ELIZA_BUILD_VARIANT: "store",
+      ELIZA_IOS_APP_STORE_LOCAL_RUNTIME: "0",
+      ELIZA_IOS_FULL_BUN_ENGINE: "1",
+    };
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(true);
+  });
 
-test("the production release env (post-fix) embeds the engine", () => {
-  // Mirrors the env block now set on apple-store-release.yml's build-ios job.
-  const env = {
-    ELIZA_BUILD_VARIANT: "store",
-    ELIZA_RELEASE_AUTHORITY: "apple-app-store",
-    ELIZA_IOS_FULL_BUN_ENGINE: "1",
-  };
-  assert.equal(isIosAppStoreBuild(env), true);
-  assert.equal(shouldIncludeIosFullBunEngine(env), true);
+  it("the production release env (post-fix) embeds the engine", () => {
+    // Mirrors the env block now set on apple-store-release.yml's build-ios job.
+    const env = {
+      ELIZA_BUILD_VARIANT: "store",
+      ELIZA_RELEASE_AUTHORITY: "apple-app-store",
+      ELIZA_IOS_FULL_BUN_ENGINE: "1",
+    };
+    expect(isIosAppStoreBuild(env)).toBe(true);
+    expect(shouldIncludeIosFullBunEngine(env)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem

On the production iOS App Store / TestFlight build, tapping **"start local agent"** hard-failed with:

> Full Bun iOS runtime required but the JSContext compatibility transport is disabled outside iOS development builds

The shipped IPA was a **cloud-only thin client with no on-device agent runtime**.

## Root cause

`.github/workflows/apple-store-release.yml`'s `build-ios` job builds via `bun run build` → `run-mobile-build.mjs ios-overlay` → `fastlane beta/release`, and **never set `ELIZA_BUILD_VARIANT=store`**. That single missing signal caused two failures at once:

1. `packages/app/vite.config.ts` bakes `__ELIZA_BUILD_VARIANT__` from `process.env.ELIZA_BUILD_VARIANT` → it got `"direct"`, so `isNativeIosStoreBuild()` was `false` at runtime (and the store CSP was never applied — localhost origins left allowed).
2. `prepareIosOverlay()` only embeds the no-JIT Bun engine for store builds (or with the explicit flag) → a non-store overlay **omits the engine**.

At runtime: `getFullBunRuntime()` → `null`, not a dev build, `canUseJsContextCompatibilityFallback()` → `false` → the error above.

This is a bug, not by-design: the `ios` (store) target is documented as a "cloud-hybrid build [that] keeps the App Store-safe no-JIT local runtime," and `build:ios:local:device:full-bun:release` proves store builds are meant to embed it.

## Fix

- **`apple-store-release.yml` `build-ios` job env**: `ELIZA_BUILD_VARIANT=store`, `ELIZA_RELEASE_AUTHORITY=apple-app-store`, `ELIZA_IOS_FULL_BUN_ENGINE=1` (+ timeout 60→90 for the heavier engine build). The web bundle now bakes the `store` variant *and* the overlay embeds the engine.
- **CI preflight guard** in `packages/app/scripts/mobile-release-preflight.mjs` (runs before fastlane): fails the build if a store iOS build isn't flagged store-variant or wouldn't embed the engine — unless `ELIZA_IOS_APP_STORE_LOCAL_RUNTIME=0` (intentional cloud-only). Makes the fix self-verifying and regression-proof.
- Exported `shouldIncludeIosFullBunEngine` from `run-mobile-build.mjs` (single source of truth).
- **Regression test** `run-mobile-build-ios-engine-gate.test.mjs` (vitest, 9 cases) locks the gate.

> Note: the workflow / preflight / `run-mobile-build.mjs` changes already landed on `develop` via the branch-integration snapshot. **This PR's diff is the one remaining piece**: the gate test was authored with the `node:test` API but matched vitest's `**/*.test.mjs` glob, so the `app-core` vitest lane failed it with "No test suite found." Rewriting it under vitest's `describe/it/expect` makes it run in the standard `bun run --cwd packages/app-core test` lane and un-breaks `develop`'s `app-core` test suite.

## Verification

- `bun run --cwd packages/app-core test` (the gate test): **9/9 green** under vitest.
- Preflight guard exercised across 3 scenarios: bug-state → blocked; post-fix env → pass; intentional cloud-only opt-out → handled.
- Biome clean; workflow YAML valid.
- **Not** verified end-to-end: the real TestFlight build needs a CI release run + Apple signing secrets + device install (can't be done headless). The new preflight guard now fails the build loudly if the env ever regresses, instead of silently shipping an engine-less client again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)