### PR TITLE
fix(ios): ship a working on-device agent in App Store builds (full-Bun wiring)

### DIFF
--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -144,17 +144,25 @@ jobs:
     # cloud-only client, so allow more headroom than the bare-IPA budget.
     timeout-minutes: 90
     env:
-      # Mark this as the App Store build it is. Without these, `bun run build`
-      # bakes __ELIZA_BUILD_VARIANT__="direct" (so isNativeIosStoreBuild() is
-      # false and the store CSP is never applied) and `run-mobile-build.mjs
-      # ios-overlay` skips the on-device Bun engine — shipping a cloud-only thin
-      # client whose "start local agent" path hard-fails with "the JSContext
-      # compatibility transport is disabled outside iOS development builds".
-      # ELIZA_IOS_FULL_BUN_ENGINE=1 forces the engine into the IPA (store builds
-      # embed it by default, but make the intent explicit and drift-proof).
+      # Make this split build (web + cap sync + ios-overlay + fastlane) behave
+      # like buildIos()'s App Store target, which bundles a working on-device
+      # agent. These env vars are normally set by configureIosAppStoreBuildDefaults
+      # / buildWeb("ios"); the workflow must set them itself because it bypasses
+      # buildIos(). Without them the IPA ships as a cloud-only thin client whose
+      # "start local agent" path hard-fails ("the JSContext compatibility
+      # transport is disabled outside iOS development builds").
+      #   - ELIZA_BUILD_VARIANT/RELEASE_AUTHORITY: bake __ELIZA_BUILD_VARIANT__
+      #     ="store" (store CSP + isNativeIosStoreBuild()) and embed the engine.
+      #   - ELIZA_IOS_FULL_BUN_ENGINE=1: force the engine pod into the IPA.
+      #   - VITE_ELIZA_IOS_FULL_BUN_AVAILABLE=1: tell the renderer the engine is
+      #     present (isFullBunRuntimeBuiltIn) so the transport actually uses it.
+      #   - VITE_ELIZA_IOS_RUNTIME_MODE=cloud-hybrid: App Store default mode; the
+      #     user switching to "local" persists to localStorage and wins.
       ELIZA_BUILD_VARIANT: store
       ELIZA_RELEASE_AUTHORITY: apple-app-store
       ELIZA_IOS_FULL_BUN_ENGINE: "1"
+      VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "1"
+      VITE_ELIZA_IOS_RUNTIME_MODE: cloud-hybrid
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
@@ -231,6 +239,13 @@ jobs:
         run: bun run cap:sync:ios
         env:
           LANG: en_US.UTF-8
+
+      # Build the on-device agent bundle the embedded Bun engine executes.
+      # buildIos() does this via buildMobileAgentBundle(); this split workflow
+      # must run it explicitly so the ios-overlay step below can stage
+      # packages/agent/dist-mobile-ios into the app's public/agent.
+      - name: Build iOS agent bundle
+        run: bun run --cwd packages/agent build:ios-bun
 
       - name: Overlay iOS native files (Fastlane, AppDelegate, entitlements)
         run: node packages/app-core/scripts/run-mobile-build.mjs ios-overlay

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -7452,6 +7452,20 @@ export async function main(argv = process.argv.slice(2)) {
   } else {
     prepareIosOverlay();
     await generateIosBrandAssets();
+    // The App Store release pipeline splits the build into `bun run build`
+    // (web) + `cap:sync:ios` + this overlay + fastlane, so it never runs
+    // buildIos()'s local-agent staging. When the build embeds the full Bun
+    // engine, stage the agent runtime payload here (after cap sync, before
+    // pod install / fastlane archive) so the shipped IPA actually contains the
+    // agent the engine runs — without it the engine boots with nothing to
+    // execute. The agent bundle must already be built (packages/agent
+    // build:ios-bun); stageIosAgentRuntime throws with that hint if missing.
+    if (shouldIncludeIosFullBunEngine()) {
+      stageIosAgentRuntime({
+        appStoreBuild: isIosAppStoreBuild(),
+        includeFullBunEngine: true,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Context

Follow-up to the App Store engine-embed fix (#8859 + the build-variant/preflight changes already on develop). While verifying the local-agent path end-to-end, I found the engine-embed alone is **necessary but not sufficient**.

## Problem

The App Store release workflow builds via `bun run build` (web) → `cap:sync:ios` → `run-mobile-build.mjs ios-overlay` → `fastlane`. This **bypasses `buildIos()`**, which is the function that actually assembles a working on-device agent. So even with the engine embedded, three pieces were missing:

1. **Renderer flags** — `VITE_ELIZA_IOS_FULL_BUN_AVAILABLE` / `VITE_ELIZA_IOS_RUNTIME_MODE` were never baked. Without `VITE_ELIZA_IOS_FULL_BUN_AVAILABLE=1`, `isFullBunRuntimeBuiltIn()` is false, so `getFullBunRuntime()` returns null and the transport refuses the embedded engine.
2. **Agent bundle** — `buildIos()` runs `buildMobileAgentBundle()` (`packages/agent build:ios-bun` → `dist-mobile-ios`); the workflow never did. The engine would boot with no agent to execute.
3. **Asset staging** — `buildIos()` runs `stageIosAgentRuntime()` to copy the agent payload into `ios/App/App/public/agent`; `ios-overlay` never did.

(The 64MB `ElizaBunEngine.xcframework` is committed under `packages/native/bun-runtime/artifacts/` and resolved by the podspec default, so engine *embedding* already works via `pod install` — these three were the remaining gaps.)

## Fix

- **`apple-store-release.yml`** (`build-ios` job): add `VITE_ELIZA_IOS_FULL_BUN_AVAILABLE=1` + `VITE_ELIZA_IOS_RUNTIME_MODE=cloud-hybrid` to the env, and a **Build iOS agent bundle** step (`bun run --cwd packages/agent build:ios-bun`) before the overlay.
- **`run-mobile-build.mjs` `ios-overlay`**: when the build embeds the full Bun engine (`shouldIncludeIosFullBunEngine()`), call `stageIosAgentRuntime({ appStoreBuild, includeFullBunEngine: true })` so fastlane archives the agent payload. Gated, so cloud-only / non-engine app workflows are unaffected.

This mirrors exactly what `buildIos()` + `configureIosAppStoreBuildDefaults()` do for the monolithic `ios` target — the proven path that produces working local builds.

## Verification

- `node --check` + Biome clean on `run-mobile-build.mjs`; workflow YAML parses; step ordering (cap sync → agent bundle → overlay) asserted.
- The `ios-overlay` change is gated on `shouldIncludeIosFullBunEngine()`, which is false for every current consumer except this newly-enabled store path → no behavior change elsewhere.
- **Not** verified end-to-end: the macOS release build, signed IPA, and on-device boot require Apple signing secrets + a CI release run + a TestFlight install — can't be done headless. Tracked in the follow-up issue. A wrong wiring fails in CI (blocks the release; doesn't ship a broken app); the final on-device check is TestFlight before App Store promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)