### PR TITLE
perf(agent): skip doc-augmentation embed search for empty corpus

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -137,4 +137,40 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     expect(result).toBe(message);
     expect(useModel).not.toHaveBeenCalled();
   });
+
+  it("skips the embedding doc search entirely when the corpus has zero fragments", async () => {
+    const message = makeMessage();
+    // Empty corpus (the common cloud-agent case): the query embed + fragment
+    // search is pure per-turn latency for guaranteed-zero matches. A cheap
+    // fragment count must short-circuit BEFORE searchDocuments embeds anything.
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(0),
+      searchDocuments: vi.fn().mockResolvedValue([]),
+    };
+    const useModel = vi.fn();
+    const runtime = makeRuntime(documents, useModel);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).toBe(message);
+    expect(documents.countMemories).toHaveBeenCalledWith(
+      expect.objectContaining({ tableName: "document_fragments" }),
+    );
+    expect(documents.searchDocuments).not.toHaveBeenCalled();
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("still runs the document search when the corpus has fragments", async () => {
+    const message = makeMessage();
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(3),
+      searchDocuments: vi.fn().mockResolvedValue([]),
+    };
+    const runtime = makeRuntime(documents);
+
+    await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(documents.countMemories).toHaveBeenCalledTimes(1);
+    expect(documents.searchDocuments).toHaveBeenCalled();
+  });
 });

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -189,6 +189,22 @@ export async function maybeAugmentChatMessageWithDocuments(
   const documents = await getDocumentsService(runtime);
   if (!documents.service) return message;
 
+  // Skip the document search entirely when the agent has no searchable corpus.
+  // `searchDocuments` embeds the user query, then searches `document_fragments`;
+  // most cloud agents run with an empty corpus, so that embed round-trip costs
+  // ~1.5s/turn (the dominant chat-latency tax) for guaranteed-zero matches — and
+  // the LLM query-recovery fallback is already gated on having documents. A cheap
+  // fragment count avoids the wasted embed. On a count error we fall through to
+  // the normal path rather than skip augmentation.
+  try {
+    const fragmentCount = await documents.service.countMemories({
+      tableName: "document_fragments",
+    });
+    if (fragmentCount === 0) return message;
+  } catch {
+    // Count failed — do not skip; let the normal search path run.
+  }
+
   const agentId = runtime.agentId as UUID;
   const roomId =
     typeof message.roomId === "string" && message.roomId.trim().length > 0


### PR DESCRIPTION
## The latency, measured on the live Seeker + prod agents (not assumed)
End-to-end on PhoneProd: **11.7s / 15.6s per turn**. A fresh agent on the latest image (a29ecf0, with phone's #8850 parallelize): **~5-6s**. Container logs show a flood of **serial single-text embeddings** (`[BatchEmbeddings] 1/1: 1 texts`, ~14 over ~30s) — the synchronous doc-augmentation. The LLM reply itself is ~1s.

## Root cause
`chat-routes` awaits `maybeAugmentChatMessageWithDocuments` before `handleMessage`. That **embeds the user query (~1.5s cloud round-trip) and searches `document_fragments` every turn — even for agents with an empty corpus** (the common cloud case). The LLM query-recovery fallback is already gated on having documents, but the *initial* embed+search runs unconditionally.

## Fix
Cheap `countMemories({ tableName: 'document_fragments' })` gate: if zero fragments, return before `searchDocuments` embeds anything. On a count error, fall through to the normal path (never skip on uncertainty). Saves ~1.5s/turn for corpus-less agents.

## Tests
`chat-augmentation.test.ts`: 5 pass (3 existing + 2 new — skips on empty corpus / still searches when fragments exist). Typecheck + biome clean. Building an agent image to measure the real drop before merge.

@phone-agent this is the empty-corpus slice of your finding A (complements #8850 + the deferral) — shout if you'd rather fold it into your work.