### PR TITLE
fix(ui/cloud): harden agent-management UX (scroll, create-failure, delete-confirm)

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -291,6 +291,10 @@ function resetClientMocks() {
   clientMock.getCloudCompatAgentStatus.mockReset();
   persistenceMock.loadPersistedActiveServer.mockReset();
   persistenceMock.savePersistedActiveServer.mockReset();
+  // deleteAgent now guards on window.confirm; default it to accept so the
+  // lifecycle tests exercise the delete path (the dismissal path is tested
+  // explicitly below).
+  window.confirm = () => true;
 }
 
 describe("CloudAgentsSection lifecycle (suspend/resume)", () => {
@@ -684,6 +688,16 @@ describe("CloudAgentsSection delete (job polling)", () => {
 
     await waitFor(() => expect(screen.queryByText("Sync")).toBeNull());
     expect(clientMock.getCloudCompatJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("does NOT delete when the confirm dialog is dismissed", async () => {
+    window.confirm = () => false;
+    await renderWithAgents([agent({ agent_name: "Sync" })]);
+
+    fireEvent.click(screen.getByLabelText("Delete Sync"));
+
+    expect(clientMock.deleteCloudCompatAgent).not.toHaveBeenCalled();
+    expect(screen.queryByText("Sync")).not.toBeNull();
   });
 });
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -301,6 +301,16 @@ export function CloudAgentsSection() {
 
   const deleteAgent = useCallback(
     async (agent: CloudCompatAgent) => {
+      // Destructive + irreversible — tears down the container and its data.
+      // Confirm first (matches the window.confirm pattern in the other settings
+      // sections: wallet keys, vault profiles, remote plugin hosts).
+      if (
+        !window.confirm(
+          `Delete "${agent.agent_name || agent.agent_id}"? This permanently removes the agent and its data and can't be undone.`,
+        )
+      ) {
+        return;
+      }
       setBusyId(agent.agent_id);
       try {
         const res = await client.deleteCloudCompatAgent(agent.agent_id);

--- a/packages/ui/src/first-run/AgentPicker.tsx
+++ b/packages/ui/src/first-run/AgentPicker.tsx
@@ -120,7 +120,10 @@ export function AgentPicker({
         </div>
       ) : (
         <>
-          <div className="flex w-full flex-col gap-2.5">
+          {/* Cap the list height and scroll it — the onboarding card wrapper is
+              overflow:hidden, so without this a user with many agents can't
+              reach the rows below the fold (or the Back/Create row). */}
+          <div className="flex w-full flex-col gap-2.5 max-h-[min(50vh,380px)] overflow-y-auto overscroll-contain pr-0.5">
             {agents.map((agent) => {
               const isActive =
                 activeAgentId !== null && agent.agent_id === activeAgentId;

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -358,6 +358,24 @@ describe("useFirstRunController cloud first-run", () => {
     });
   });
 
+  it("routes a 0-agent auto-create failure to the picker error phase (no stuck spinner)", async () => {
+    mocks.getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
+    mocks.selectOrProvisionCloudAgent.mockRejectedValue(
+      new Error("Out of credits."),
+    );
+    const { result } = renderHook(() => useFirstRunController());
+
+    await act(async () => {
+      await result.current.finishRuntime();
+    });
+
+    // The auto-create rejected — land on the picker error phase (Back + Try
+    // again), not hang forever on the "Finding your agents…" loading spinner.
+    expect(result.current.step).toBe("pick-agent");
+    expect(result.current.pickerPhase).toBe("error");
+    expect(result.current.pickerError).toBeTruthy();
+  });
+
   it("does not arm shared-runtime handoff when a new cloud agent is already on a dedicated base", async () => {
     mocks.selectOrProvisionCloudAgent.mockResolvedValue({
       agentId: "agent-1",

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -898,12 +898,28 @@ export function useFirstRunController(): FirstRunController {
         setPickerError(list.error ?? "Could not load your agents. Try again.");
         return;
       }
+      // Auto-connect without the picker (0-agent create, 1-agent reuse), routing
+      // any failure (402/5xx/network) to the picker's error phase — which has
+      // Back + Try again — instead of stranding it on a permanent "Finding your
+      // agents…" spinner. Mirrors the onPickAgent failure handling.
+      const autoConnect = async (
+        opts: Parameters<typeof finishCloudWithSelection>[2],
+      ) => {
+        try {
+          await finishCloudWithSelection(sourceDraft, authToken, opts);
+        } catch (err) {
+          setBusyText(null);
+          setPickerPhase("error");
+          setPickerError(
+            err instanceof Error
+              ? err.message
+              : "Couldn't set up your agent. Try again.",
+          );
+        }
+      };
       if (list.data.length === 0) {
-        // Brand-new user: skip the picker and auto-create (current behavior, no
-        // extra click, no dead one-item-less UI).
-        await finishCloudWithSelection(sourceDraft, authToken, {
-          forceCreate: false,
-        });
+        // Brand-new user: skip the picker and auto-create (no extra click).
+        await autoConnect({ forceCreate: false });
         return;
       }
       // >=1 agents: render the picker (newest-first, running-prioritized to


### PR DESCRIPTION
## What
A 13-agent adversarial audit of the cloud agent-management flows (0/1/N agents, switch, edit/manage, persona) found solid plumbing but **launch-blocking UX holes** in the exact paths a real launch hits. This fixes the **must-fix** ones:

- **Flow C (launch-blocker) — picker unscrollable.** The agent list had no overflow handling and the onboarding card is `overflow:hidden`, so a user with many agents couldn't reach rows below the fold or the Back/Create row. → cap height + `overflow-y-auto` + `overscroll-contain`.
- **Flow A — create-failure dead-end.** A 0-agent auto-create failure (402/5xx/network) threw past the picker and stranded it on a permanent *"Finding your agents…"* spinner (no Back/Retry). → wrap in an `autoConnect` helper that routes failures to the existing **error phase**. + test.
- **Flow E — destructive delete, no confirm.** One click on the trash icon permanently tore down a cloud agent **and its DB**, no confirm, no undo. → `window.confirm` (matches the pattern in wallet-keys / vault-profiles / remote-plugin-host). + confirm-accepted (existing) and confirm-dismissed tests.

## Verification
biome + typecheck clean; **54 tests pass** (incl. 2 new: 0-agent-create-failure → error phase, and delete-dismissed → no-op).

## Deferred (follow-up, needs picker-test rework)
Flow B single-agent auto-connect (broke the picker tests — doing it right needs reworking the 1-active-agent test setups), the 402 add-credits CTA (helper exists, unwired), and a persona editor.

Part of the launch hardening on #8434.