### PR TITLE
perf(core): eliminate Stage-1 truncation retry spike in direct chat

### DIFF
--- a/packages/core/src/services/message.stage1-retry.test.ts
+++ b/packages/core/src/services/message.stage1-retry.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { GenerateTextResult } from "../types/index";
+import { shouldRetryStage1Generation } from "./message";
+
+/**
+ * Stage-1 retry policy (latency fix): a "malformed HANDLE_RESPONSE tool call"
+ * caused by a completion-limit truncation must NOT be retried — regenerating at
+ * the same token cap truncates again, burning full Stage-1 turns for the same
+ * result (the measured +12-16s tail-latency spike on direct/DM chat). Truncation
+ * is routed to the dedicated recovery path instead. Empty/garbled output that did
+ * not hit the cap is still worth one retry.
+ */
+function rawWith(opts: {
+	finishReason?: string;
+	completionTokens?: number;
+}): GenerateTextResult {
+	return {
+		finishReason: opts.finishReason,
+		usage:
+			opts.completionTokens === undefined
+				? undefined
+				: { completionTokens: opts.completionTokens },
+	} as unknown as GenerateTextResult;
+}
+
+describe("shouldRetryStage1Generation", () => {
+	const MAX = 1024;
+
+	it("does not retry when there is no retry reason", () => {
+		expect(
+			shouldRetryStage1Generation(null, rawWith({ completionTokens: 50 }), MAX),
+		).toBe(false);
+	});
+
+	it("retries an empty completion that did not hit the token cap", () => {
+		expect(
+			shouldRetryStage1Generation(
+				"empty completion",
+				rawWith({ completionTokens: 0 }),
+				MAX,
+			),
+		).toBe(true);
+	});
+
+	it("does NOT retry a malformed tool call truncated at the token cap", () => {
+		// completionTokens >= maxTokens => truncation; a redo truncates identically.
+		expect(
+			shouldRetryStage1Generation(
+				"malformed HANDLE_RESPONSE tool call",
+				rawWith({ completionTokens: MAX }),
+				MAX,
+			),
+		).toBe(false);
+	});
+
+	it("does NOT retry a malformed tool call with a length finish reason", () => {
+		expect(
+			shouldRetryStage1Generation(
+				"malformed HANDLE_RESPONSE tool call",
+				rawWith({ finishReason: "length" }),
+				MAX,
+			),
+		).toBe(false);
+	});
+
+	it("retries a malformed tool call that did not hit the token cap", () => {
+		// Genuinely garbled (not truncated) output may recover on a fresh attempt.
+		expect(
+			shouldRetryStage1Generation(
+				"malformed HANDLE_RESPONSE tool call",
+				rawWith({ finishReason: "stop", completionTokens: 40 }),
+				MAX,
+			),
+		).toBe(true);
+	});
+
+	it("retries a string completion (which can never be a cap truncation)", () => {
+		expect(
+			shouldRetryStage1Generation(
+				"malformed HANDLE_RESPONSE tool call",
+				"some non-empty text",
+				MAX,
+			),
+		).toBe(true);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -237,7 +237,15 @@ import {
 const PLANNER_CONTROL_ACTIONS = new Set(
 	["REPLY", "RESPOND", "IGNORE", "STOP"].map(normalizeActionIdentifier),
 );
-const DIRECT_CHANNEL_STAGE1_MAX_TOKENS = 384;
+// Direct/DM/API Stage 1 packs the whole user-facing answer into `replyText`
+// (the "simple" fast path emits it without a planner turn). A 384-token cap
+// could not fit a full reply, so any non-trivial answer truncated the
+// HANDLE_RESPONSE tool-call JSON mid-`replyText` → unparseable args →
+// "malformed HANDLE_RESPONSE tool call" → up to 2 futile Stage-1 regenerations
+// (a +12-16s tail-latency spike). Measured against cerebras gpt-oss-120b: ~30%
+// of long-answer turns truncated at 384 vs 0/120 at 1024. The cap is a ceiling,
+// not a target — short replies finish exactly as fast.
+const DIRECT_CHANNEL_STAGE1_MAX_TOKENS = 1024;
 const DIRECT_REPLY_FAST_PATH_MAX_TOKENS = 96;
 const DEFAULT_STAGE1_MAX_TOKENS = 2048;
 const STAGE1_TRUNCATION_REPLY =
@@ -4990,6 +4998,22 @@ function stage1HitCompletionLimit(
 	);
 }
 
+/**
+ * Whether a Stage-1 result should be regenerated. Empty or garbled output can be
+ * fixed by retrying, but a completion-limit truncation cannot: regenerating at
+ * the same token cap just truncates again, burning a full Stage-1 turn for the
+ * same result. A truncated envelope is routed to the dedicated truncation
+ * recovery below instead. Exported for unit coverage of the retry policy.
+ */
+export function shouldRetryStage1Generation(
+	reason: ReturnType<typeof getStage1RetryReason>,
+	raw: string | GenerateTextResult,
+	maxTokens: number,
+): boolean {
+	if (!reason) return false;
+	return !stage1HitCompletionLimit(raw, maxTokens);
+}
+
 function extractJsonStringField(
 	text: string,
 	fieldName: string,
@@ -6067,7 +6091,14 @@ export async function runV5MessageRuntimeStage1(args: {
 			stage1ModelParams,
 		)) as string | GenerateTextResult;
 		let stage1RetryReason = getStage1RetryReason(rawMessageHandler);
-		while (stage1RetryReason && stage1RetryCount < stage1RetryLimit) {
+		while (
+			stage1RetryCount < stage1RetryLimit &&
+			shouldRetryStage1Generation(
+				stage1RetryReason,
+				rawMessageHandler,
+				stage1ModelParams.maxTokens,
+			)
+		) {
 			stage1RetryCount += 1;
 			args.runtime.logger?.warn?.(
 				{


### PR DESCRIPTION
## The spike, root-caused (credit @phone-agent's finding A)
@phone-agent measured a fresh no-doc agent at `6.0 / 4.8 / **20.8** / 4.9 / **23.6**s` — a +12-16s spike on ~1/3 of turns — and pulled the logs: **zero 429s**, but repeated:
```
[message] Stage 1 returned malformed HANDLE_RESPONSE tool call — retrying (1/2)
[message] Stage 1 returned malformed HANDLE_RESPONSE tool call — retrying (2/2)
```

## Confirmed the *which* (not assumed) — reproduced against cerebras directly
I replayed the **real strict HANDLE_RESPONSE tool schema** against `gpt-oss-120b` on cerebras with the production Stage-1 token cap. The malformation is **always truncation**, never wrong-keys: the tool-call JSON cuts off mid-`replyText`, e.g.
```
{"shouldRespond":"RESPOND","contexts":["general"],"intents":["weather_query"],"replyText
```
| max_tokens | malformed rate |
|---|---|
| **384** (prod direct/DM) | **28–33%** ← matches the observed ~1/3 spike |
| **1024** | **0 / 120** |

**Mechanism:** direct/DM/API Stage 1 packs the *whole* user-facing answer into `replyText` (the 'simple' fast path emits it with no planner turn), but `DIRECT_CHANNEL_STAGE1_MAX_TOKENS` was **384**. Any non-trivial answer overruns it → truncated JSON → `getStage1RetryReason` returns 'malformed' → the loop regenerates up to 2× **at the same cap, truncating identically** → the spike. The dedicated truncation-recovery path already exists (`recoverStage1TruncatedMessageHandler`) but the retry loop runs *first* and burns the redos before it.

## Fix (two parts, same root cause)
1. **Raise `DIRECT_CHANNEL_STAGE1_MAX_TOKENS` 384 → 1024** so a full reply fits. The cap is a ceiling, not a target — short replies finish exactly as fast; only over-long ones stop truncating.
2. **Don't retry a completion-limit truncation** (`shouldRetryStage1Generation`): regenerating at the same cap is futile, so route truncation straight to the existing recovery path. Empty/garbled output that did *not* hit the cap is still retried once (unchanged).

This is the empty-corpus gate's (#8862) complement: #8862 removed the ~1.5s baseline doc-augmentation tax; this removes the ~20s tail spike. Together a fresh direct-chat turn should hold ~3.5-5s.

## Tests
- `message.stage1-retry.test.ts`: 6 cases pin the retry policy (truncation → no retry; empty/garbled non-truncated → retry once; null → none).
- 89 existing message-handler / shortcut-gate tests green; core typecheck + biome clean.

@phone-agent @lalalune flagging since it's the chat-loop heart — the change is surgical (one cap constant + one guard reusing existing helpers), no behavior change for non-truncated turns.