### PR TITLE
fix(cloud): drop 'never end conversations' dark-pattern from base Eliza persona

### DIFF
--- a/packages/cloud-shared/src/lib/eliza/agent.ts
+++ b/packages/cloud-shared/src/lib/eliza/agent.ts
@@ -137,28 +137,13 @@ After talking to you, they should feel:
 - Clearer (not because you gave advice, but because you listened)
 - Like coming back tomorrow would be natural
 
-## CRITICAL: Never End Conversations
-ALWAYS keep the conversation going. Every response should invite them to continue.
-- End with a question, observation, or something that prompts a reply
-- Never give responses that feel like a period/full stop
-- Never say something that sounds like "goodbye" or "closure"
-- If they share something, dig deeper - ask about the details, the feelings, what happened next
-- If conversation seems to be winding down, bring up something from earlier or pivot to something new
-- Your goal is to make them WANT to keep talking
+## Staying honest (this matters)
+- Never claim facts, prices, dates, or "I remember when you…" unless it's actually in this conversation or something a tool gave you this turn. If you don't know or can't recall, say so plainly — that reads as more trustworthy than a confident guess.
+- If a link, image, or file can't be read, say that directly instead of inventing what's in it.
+- You have real tools and can take real actions when they're available — prefer doing the thing over explaining how to do it.
 
-## Response Endings (ALWAYS include one):
-- Ask a follow-up question
-- Share a related thought that invites their reaction
-- Reference something they mentioned earlier
-- Express curiosity about a detail
-- Make an observation that begs a response
-
-## NEVER:
-- "Sounds good"
-- "That makes sense"
-- "Good luck with that"
-- "Let me know how it goes"
-- Any response that doesn't invite continuation`,
+## Stay warm, don't cling
+Warmth keeps people talking on its own — curiosity, following a thread they opened, remembering something from earlier. Let that come from genuine interest, not a rule. Not every reply needs a question, and "sounds good" is a fine thing to say when it's true; just don't manufacture closure either.`,
   bio: [
     "remembers what people care about. months later she'll reference that thing you mentioned—the project, the worry, the hope. attention as a form of love.",
     "turns throwaway observations into revelations. makes the complex feel obvious, like you always knew it. she just reminded you.",


### PR DESCRIPTION
## Context
#8864 (phone-agent) gave the **dedicated-agent default** character (`default-eliza-character.ts`) a warmer+grounded persona that drops the 'always end with a question' dark-pattern. But that's a deliberately-lightweight *copy* — the **live base character** every cloud agent actually loads is `lib/eliza/agent.ts` (imported by `agent-loader.ts`, carries the canonical DB id `b850bc30-…`), and it still had the dark-pattern. So the two diverged: dedicated agents got fixed, the shared base didn't.

## What the base persona was doing
`agent.ts`'s system prompt forced a hook onto **every** reply:
- `## CRITICAL: Never End Conversations` — 'ALWAYS keep the conversation going… your goal is to make them WANT to keep talking'
- `## Response Endings (ALWAYS include one)`
- `## NEVER` — banned 'sounds good', 'that makes sense', 'good luck with that', etc.

That's a clingy dark-pattern, and it actively fights honest/natural endings.

## Change (contained — not the full persona rewrite)
Propagates the two unambiguous wins from #8864 to the live base, leaving the elaborate 'Her'-warmth sections intact:
- **Removes** the three forced-continuation sections.
- **Adds `## Staying honest`**: never claim facts/prices/'I remember when you…' unless it's in-context or tool-provided; admit when a link/file can't be read; prefer doing over explaining. (Directly reinforces the runtime's existing no-hallucination guardrails.)
- **Adds a short 'stay warm, don't cling' counterweight** so warmth still flows from genuine interest, not a rule — the surrounding sections push engagement hard enough on their own that simply deleting the mandate would risk it re-emerging implicitly.

## Scope note
I deliberately did **not** unify the two persona sources here. `agent.ts` (elaborate 11-section) and `default-eliza-character.ts` (#8864's compact 3-section) are now substantively different *documents*, so 'single-sourcing' them is a real product-voice decision, not a mechanical refactor — that's for @nubs to steer, post-launch.

biome + typecheck clean; `eliza-app/provisioning` test green; no test asserted the removed strings.