### PR TITLE
fix(ui): restore clockAccessory host-override slot on HomeScreen

### DIFF
--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -255,6 +255,14 @@ export interface HomeScreenProps {
   onOpenTile: (target: HomeTileTarget) => void;
   /** Render the AOSP-only phone/contacts tiles (native OS surfaces). */
   showNativeOsTiles?: boolean;
+  /**
+   * Optional host-provided header content rendered at the top of the home
+   * screen (e.g. a brand wallet widget). The framework intentionally ships no
+   * default clock to keep the home minimal; this host-override slot stays so a
+   * host app (e.g. milady's MoonCycles wallet) can opt back into a header
+   * without the framework providing one.
+   */
+  clockAccessory?: React.ReactNode;
 }
 
 /**
@@ -267,6 +275,7 @@ export interface HomeScreenProps {
 export function HomeScreen({
   onOpenTile,
   showNativeOsTiles = false,
+  clockAccessory,
 }: HomeScreenProps): React.JSX.Element {
   // Only the AOSP native-OS tiles remain, and they need an AOSP build. On every
   // other platform `tiles` is empty and the grid renders nothing.
@@ -290,6 +299,9 @@ export function HomeScreen({
     >
       <style>{HOME_ENTER_CSS}</style>
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+        {clockAccessory ? (
+          <div className="home-enter flex justify-end">{clockAccessory}</div>
+        ) : null}
         {recentActivity.length > 0 ? (
           <div className="home-enter" style={{ animationDelay: "70ms" }}>
             <HomeCard


### PR DESCRIPTION
## Problem

`ac3159cd4b` ("keep it minimal") dropped the default clock from the shell `HomeScreen` **and** removed the `clockAccessory` host-override prop. That slot was added in `dbd9727d05` ("host-overridable home screen slot + clock accessory") specifically so a host app can inject its own header — milady's MoonCycles uses it to render its wallet widget (`MiladyHomeScreen` passes `clockAccessory={<MiladyWalletWidget/>}`).

Result: milady's `apps/app` typecheck breaks with `TS2322: 'clockAccessory' does not exist on type 'HomeScreenProps'` (red on milady develop, blocking all milady PRs), and MoonCycles lost the wallet widget.

## Fix

Restore **only** the host-override slot: add `clockAccessory?: React.ReactNode` back to `HomeScreenProps` and render it at the top of the home **only when a host provides it**. The default clock stays gone — the home is still minimal — but hosts can opt back into a header.

## Verification

- `@elizaos/ui` typecheck (`tsgo --noEmit`) clean; Biome clean.
- No-op for hosts that don't pass `clockAccessory` (e.g. eliza's own app) — nothing renders.
- Unblocks milady-ai/milady#2195 (its CI clones eliza `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)