### PR TITLE
refactor(ui): finish #8843 headersToRecord dedup + fix #8863 autoConnect comment

### DIFF
--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -10,7 +10,7 @@ import {
   startIosLocalAgentKernel,
 } from "./ios-local-agent-kernel";
 import { createIttpAgentTransport } from "./ittp-agent-transport";
-import type { AgentRequestTransport } from "./transport";
+import { type AgentRequestTransport, headersToRecord } from "./transport";
 
 let transport: AgentRequestTransport | null = null;
 let globalRequestHandlerInstalled = false;
@@ -414,14 +414,6 @@ function requestPathFromUrl(url: string): string {
   if (localAgentPath) return localAgentPath;
   const parsed = new URL(url, `${IOS_LOCAL_AGENT_IPC_BASE}/`);
   return `${parsed.pathname}${parsed.search}`;
-}
-
-function headersToRecord(headers: Headers): Record<string, string> {
-  const out: Record<string, string> = {};
-  headers.forEach((value, key) => {
-    out[key] = value;
-  });
-  return out;
 }
 
 function normalizeNativeResult(

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -910,7 +910,7 @@ export function useFirstRunController(): FirstRunController {
         setPickerError(list.error ?? "Could not load your agents. Try again.");
         return;
       }
-      // Auto-connect without the picker (0-agent create, 1-agent reuse), routing
+      // Auto-connect without the picker for the brand-new, 0-agent user, routing
       // any failure (402/5xx/network) to the picker's error phase — which has
       // Back + Try again — instead of stranding it on a permanent "Finding your
       // agents…" spinner. Mirrors the onPickAgent failure handling.


### PR DESCRIPTION
Two deepscan follow-ups from a session-wide audit (each adversarially verified before fixing):

## 1. should-fix — complete the #8843 `headersToRecord` dedup (rule 2)
#8843 hoisted a canonical `headersToRecord` into `packages/ui/src/api/transport.ts` and migrated the android / desktop / native-cloud transports — but left the **iOS sibling** (`ios-local-agent-transport.ts`) with its own private copy. Same directory, same purpose = exactly the duplication rule 2 (and the PR's own charter) forbids. Import the shared one; delete the local copy.

Behavior-preserving: the only call site passes `request.headers` (a `Headers`), which is a member of the canonical `HeadersInit | undefined` signature; both impls iterate via `forEach` to the same `Record`. `headersToRecord` now has exactly one definition in `ui/api`.

## 2. nit — fix misleading `autoConnect` comment (#8863)
The comment claimed "(0-agent create, 1-agent reuse)" but `autoConnect` only runs on the 0-agent branch; the ≥1-agent branch renders the picker and never calls it. Trimmed the inaccurate clause (the deliberate no-silent-auto-reuse design is documented right above).

## Safety
Comment + dedup only, no behavior change. `bun run --cwd packages/ui typecheck` clean. The rest of the session's 8 PRs audited clean — zero blockers (full report on #8434).