### PR TITLE
fix(agent): default a browser User-Agent on guarded HTTP GETs (live-info 403s)

### DIFF
--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -567,6 +567,13 @@ export interface GuardedHttpGetResult {
  * https scheme, rejects redirects, and caps both the timeout and the number of
  * body bytes read.
  */
+// Browser-like User-Agent for guarded GETs. Many public REST/JSON APIs (crypto
+// price, weather, news endpoints) reject undici's default `node` User-Agent —
+// or a missing one — with HTTP 403, which silently broke every WEB_FETCH
+// live-info lookup. A caller-supplied User-Agent still overrides this default.
+const GUARDED_GET_DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
 export async function performGuardedHttpGet(
   url: string,
   opts: GuardedHttpGetOptions = {},
@@ -591,7 +598,7 @@ export async function performGuardedHttpGet(
 
   const fetchOpts: RequestInit = {
     method: "GET",
-    headers: opts.headers,
+    headers: { "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT, ...opts.headers },
     redirect: "manual",
   };
 


### PR DESCRIPTION
## What

`performGuardedHttpGet` (the SSRF-guarded GET behind `WEB_FETCH` and custom actions) sent **no `User-Agent`**, so requests went out with undici's default `node` UA. Public price/weather/news JSON APIs — coingecko, coincap, kraken, wttr.in — reject that with **HTTP 403**, which silently broke every `WEB_FETCH` live-info lookup (and on weak chat models, the failed fetch then leaked a raw tool-call retry to the user).

## Fix

Send a browser-like `User-Agent` by default in `performGuardedHttpGet`; a caller-supplied `User-Agent` still overrides it. One change fixes every guarded-GET caller.

## Verification

The exact coingecko URL that returned **403** now returns **200** with the value:
```
{"success":true,"text":"63327", ...}
```
and the agent replies `Bitcoin is currently at $63,327 USD.` cleanly (live-tested on the cerebras stack), instead of leaking a failed-fetch + tool-call retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
