### PR TITLE
fix(core): strip leaked model tool-call markup from user replies + dedup helper

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -14,6 +14,21 @@ describe("message handler retrieval hint output", () => {
 		expect(replyTextFieldEvaluator.parse("Hello there.")).toBe("Hello there.");
 	});
 
+	it("strips leaked model tool-call markup out of replyText", () => {
+		// Weak models emit their native tool-call serialization as plain text;
+		// it must never reach the user. Cover closed, truncated-open, and
+		// markup-only forms.
+		expect(
+			replyTextFieldEvaluator.parse(
+				"Bitcoin is at <tool_call>WEB_FETCH<arg_key>url</arg_key><arg_value>x</arg_value></tool_call>",
+			),
+		).toBe("Bitcoin is at");
+		expect(
+			replyTextFieldEvaluator.parse("answer: 4 <tool_call>TASKS_SPAWN_AGENT"),
+		).toBe("answer: 4");
+		expect(replyTextFieldEvaluator.parse("<tool_call>X</tool_call>")).toBe("");
+	});
+
 	it("parses, trims, dedupes, and caps canonical action hint arrays", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({

--- a/packages/core/src/runtime/builtin-field-evaluators.ts
+++ b/packages/core/src/runtime/builtin-field-evaluators.ts
@@ -27,6 +27,7 @@
  */
 
 import type { JSONSchema } from "../types/model";
+import { stripJsonStructuralJunkReply } from "./json-output";
 import type { ResponseHandlerFieldEvaluator } from "./response-handler-field-evaluator";
 
 /**
@@ -57,12 +58,6 @@ function isExpressiveEmotionEnumValue(
 	value: string,
 ): value is ExpressiveEmotionEnumValue {
 	return (EXPRESSIVE_EMOTION_ENUM_VALUES as readonly string[]).includes(value);
-}
-
-function stripJsonStructuralJunkReply(value: string): string {
-	const trimmed = value.trim();
-	if (!trimmed) return "";
-	return /^[\s{}[\]":,]+$/.test(trimmed) ? "" : trimmed;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -208,3 +208,24 @@ function escapeRawJsonStringChar(char: string): string {
 export function stringifyForModel(value: unknown): string {
 	return JSON.stringify(value, null, 2);
 }
+
+/**
+ * Clean a model-produced reply field before it reaches the user. Removes
+ * structural junk that weak models emit as plain text but which is never
+ * user-facing content:
+ *   1. the model's NATIVE tool-call serialization emitted as text instead of a
+ *      structured call, e.g.
+ *      `<tool_call>WEB_FETCH<arg_key>url</arg_key><arg_value>…</arg_value></tool_call>`
+ *      (observed on cerebras gpt-oss / zai; eliza routes real tool calls
+ *      structurally, and `<arg_key>` never appears in eliza's own format), and
+ *   2. a reply that is ONLY JSON punctuation (braces/brackets/quotes/commas).
+ * Structural artifact removal — the sibling of the existing `[tool output:]`
+ * markup stripping — not semantic-content matching.
+ */
+export function stripJsonStructuralJunkReply(value: string): string {
+	const cleaned = value
+		.replace(/<tool_call\b[\s\S]*?(?:<\/tool_call>|$)/gi, "")
+		.trim();
+	if (!cleaned) return "";
+	return /^[\s{}[\]":,]+$/.test(cleaned) ? "" : cleaned;
+}

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -5,7 +5,7 @@ import type {
 	MessageHandlerResult,
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
-import { parseJsonObject } from "./json-output";
+import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
 import {
 	looksLikeNonRefusalStage1HonestyViolation,
 	looksLikeStage1HonestyViolation,
@@ -111,12 +111,6 @@ export function parseMessageHandlerOutput(
 		thought: "",
 		...(extract ? { extract } : {}),
 	};
-}
-
-function stripJsonStructuralJunkReply(value: string): string {
-	const trimmed = value.trim();
-	if (!trimmed) return "";
-	return /^[\s{}[\]":,]+$/.test(trimmed) ? "" : trimmed;
 }
 
 function normalizeStringHints(raw: unknown, maxItems: number): string[] {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -76,7 +76,7 @@ import {
 	type FactsAndRelationshipsRunResult,
 	runFactsAndRelationshipsStage,
 } from "../runtime/facts-and-relationships";
-import { parseJsonObject } from "../runtime/json-output";
+import { parseJsonObject, stripJsonStructuralJunkReply } from "../runtime/json-output";
 import { getLocalizedExamplesProvider } from "../runtime/localized-examples-provider";
 import {
 	getMessageHandlerReply,
@@ -3649,8 +3649,9 @@ export function messageHandlerFromFieldResult(
 		!rawContexts.some((context) => context.toLowerCase() === "code")
 			? ["code", ...rawContexts]
 			: rawContexts;
-	const replyTextRaw =
-		typeof result.replyText === "string" ? result.replyText : "";
+	const replyTextRaw = stripJsonStructuralJunkReply(
+		typeof result.replyText === "string" ? result.replyText : "",
+	);
 	const hasRunnableCandidateAction = candidateActionsContainRunnableAction(
 		candidateActions,
 		runtimeContext,


### PR DESCRIPTION
## What

Weak chat models (e.g. cerebras `gpt-oss` / `zai`) sometimes emit their **native tool-call serialization as plain text** instead of a structured tool call, e.g.:
```
None<tool_call>WEB_FETCH<arg_key>url</arg_key><arg_value>https://…</arg_value></tool_call>
```
which leaked **verbatim to the user** as the reply.

## Fix

Extend `stripJsonStructuralJunkReply` to remove that markup. `<arg_key>` / `<tool_call>` never appear in eliza's own `<response>` format, so this is **structural artifact removal** (the sibling of the existing `[tool output:]` stripping), **not** semantic-content matching. Applied at the message-service `replyText` chokepoint so the *synthesis* path is covered, not just the planner reply field.

Also **consolidates the two identical copies** of `stripJsonStructuralJunkReply` (in `message-handler.ts` and `builtin-field-evaluators.ts`) into one exported function in `runtime/json-output.ts`.

## Tests

Adds coverage for closed / truncated-open / markup-only forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
