### PR TITLE
fix(orchestrator): reliable sub-agent coding results (deliverable capture, spawn cap, verbatim tool-output relay)

### DIFF
--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -208,6 +208,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
+| `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Session state persistence dir when no runtime DB |
 | `ELIZA_ACP_SESSION_STORE_BACKEND` | unset | Override session store backend (`db`, `file`, or `memory`) |
 | `ELIZA_ACP_MCP_SERVERS` | unset | JSON list of MCP servers to pass to spawned sub-agents |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -2082,12 +2082,12 @@ describe("extractShortToolDeliverable", () => {
     expect(extractShortToolDeliverable(data)).toBe("hello world");
   });
 
-  it("returns undefined for multiple tool-output blocks (stays on model path)", () => {
+  it("returns the LAST block for multiple tool-output blocks (final result wins)", () => {
     const data = {
       response:
         "[tool output: a]\none\n[/tool output]\n[tool output: b]\ntwo\n[/tool output]",
     };
-    expect(extractShortToolDeliverable(data)).toBeUndefined();
+    expect(extractShortToolDeliverable(data)).toBe("two");
   });
 
   it("returns undefined when the block exceeds the 2KB verbatim gate", () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/extract-short-tool-deliverable.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/extract-short-tool-deliverable.test.ts
@@ -17,11 +17,35 @@ describe("extractShortToolDeliverable", () => {
     );
   });
 
-  it("returns undefined when there are multiple blocks (stays on summarized path)", () => {
+  it("returns the LAST block when there are multiple (final result wins)", () => {
     expect(
       extractShortToolDeliverable({
         response: `${wrap("first")}\n${wrap("second")}`,
       }),
+    ).toBe("second");
+  });
+
+  it("recovers the successful retry's output past a failed first attempt", () => {
+    // `python` not found, then `python3` succeeds — the real factorial bug.
+    expect(
+      extractShortToolDeliverable({
+        response: `${wrap("/usr/bin/bash: line 1: python: command not found")}${wrap("479001600")}479`,
+      }),
+    ).toBe("479001600");
+  });
+
+  it("skips a trailing empty block and returns the last non-empty one", () => {
+    expect(
+      extractShortToolDeliverable({
+        response: `${wrap("479001600")}\n${wrap("")}`,
+      }),
+    ).toBe("479001600");
+  });
+
+  it("returns undefined when the last block exceeds the size cap", () => {
+    const big = "a".repeat(2049);
+    expect(
+      extractShortToolDeliverable({ response: `${wrap("small")}\n${wrap(big)}` }),
     ).toBeUndefined();
   });
 

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -753,6 +753,30 @@ function pickStringArrayFromInputs(
 
 // ── action: spawn_agent (SPAWN_AGENT) ───────────────────────────────────────
 
+/** Minimal view of SubAgentRouter's per-origin spawn-cap surface. Read via the
+ *  ACPX_SUB_AGENT_ROUTER service id; a structural type (rather than importing
+ *  the concrete SubAgentRouter class) keeps this action module from importing
+ *  the router — the two are already wired together only by the index.ts barrel. */
+type SpawnCapRouter = {
+  spawnCountForOrigin(originKey: string): number;
+  noteSpawnForOrigin(originKey: string): void;
+  bestResultFor(
+    originKey: string,
+  ): { text: string; deliverable?: string } | undefined;
+};
+
+/** Max sub-agent spawns per root user message before the orchestrator relays
+ *  the best already-captured result instead of re-spawning — bounds the
+ *  weak-model re-spawn loop. Default 3 (a legitimate spawn + a retry or two);
+ *  override with ELIZA_MAX_SPAWNS_PER_ORIGIN. */
+function maxSpawnsPerOrigin(runtime: IAgentRuntime): number {
+  const raw =
+    runtime.getSetting?.("ELIZA_MAX_SPAWNS_PER_ORIGIN") ??
+    process.env.ELIZA_MAX_SPAWNS_PER_ORIGIN;
+  const n = Number.parseInt(String(raw ?? ""), 10);
+  return Number.isFinite(n) && n > 0 ? n : 3;
+}
+
 async function runSpawnAgent(
   runtime: IAgentRuntime,
   message: Memory,
@@ -870,6 +894,39 @@ async function runSpawnAgent(
         ? inboundOriginSource
         : content.source;
 
+    // Per-root-origin spawn cap. A weak coding model that returns a truncated or
+    // blocked completion makes the planner re-issue TASKS_SPAWN_AGENT for the
+    // SAME user request across turns (the router re-injects each completion, so
+    // `continueChain:false` below only stops intra-turn dups — observed live:
+    // 70 spawns for one request → ack+answer Discord spam). Once we've spawned
+    // the cap of sub-agents for this connector message + agent type, stop
+    // re-spawning and relay the best already-captured result instead.
+    const spawnCapRouter = runtime.getService?.(
+      "ACPX_SUB_AGENT_ROUTER",
+    ) as SpawnCapRouter | null | undefined;
+    const spawnOriginKey = originConnectorMessageId
+      ? `${originConnectorMessageId}\0${agentType}`
+      : undefined;
+    if (spawnCapRouter && spawnOriginKey) {
+      const cap = maxSpawnsPerOrigin(runtime);
+      if (spawnCapRouter.spawnCountForOrigin(spawnOriginKey) >= cap) {
+        const best = spawnCapRouter.bestResultFor(spawnOriginKey);
+        const replyText =
+          (best?.deliverable ?? best?.text ?? "").trim() ||
+          "I'm still working on that — the coding sub-agent took longer than expected.";
+        logger(runtime).warn(
+          `[TASKS:spawn_agent] per-origin spawn cap (${cap}) reached for ${spawnOriginKey}; relaying best result instead of re-spawning`,
+        );
+        await callbackText(callback, replyText);
+        return {
+          success: true,
+          text: replyText,
+          continueChain: false,
+          data: { actionName: "TASKS", spawnCapped: true },
+        };
+      }
+    }
+
     // Concurrency gate: serialise spawns past a small ceiling so parallel
     // coding sub-agents don't stampede the model provider into rate-limited,
     // tool-call-skipping degradation. See waitForSpawnSlot.
@@ -903,6 +960,9 @@ async function runSpawnAgent(
     });
 
     setCurrentSession(state, session);
+    if (spawnCapRouter && spawnOriginKey) {
+      spawnCapRouter.noteSpawnForOrigin(spawnOriginKey);
+    }
     logger(runtime).info(
       `Spawned acpx task agent: ${JSON.stringify({
         sessionId: session.sessionId,

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -765,6 +765,18 @@ type SpawnCapRouter = {
   ): { text: string; deliverable?: string } | undefined;
 };
 
+/** getService is loosely typed and (in test doubles) can resolve a service that
+ *  isn't the SubAgentRouter; verify the cap API exists before calling it. */
+function isSpawnCapRouter(service: unknown): service is SpawnCapRouter {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as SpawnCapRouter).spawnCountForOrigin === "function" &&
+    typeof (service as SpawnCapRouter).noteSpawnForOrigin === "function" &&
+    typeof (service as SpawnCapRouter).bestResultFor === "function"
+  );
+}
+
 /** Max sub-agent spawns per root user message before the orchestrator relays
  *  the best already-captured result instead of re-spawning — bounds the
  *  weak-model re-spawn loop. Default 3 (a legitimate spawn + a retry or two);
@@ -901,9 +913,13 @@ async function runSpawnAgent(
     // 70 spawns for one request → ack+answer Discord spam). Once we've spawned
     // the cap of sub-agents for this connector message + agent type, stop
     // re-spawning and relay the best already-captured result instead.
-    const spawnCapRouter = runtime.getService?.(
-      "ACPX_SUB_AGENT_ROUTER",
-    ) as SpawnCapRouter | null | undefined;
+    // Only treat the resolved service as a spawn-cap router when it actually
+    // exposes the cap API (calling a missing method would throw and abort the
+    // spawn — test doubles return one mock for every service id).
+    const spawnCapRouterService = runtime.getService?.("ACPX_SUB_AGENT_ROUTER");
+    const spawnCapRouter = isSpawnCapRouter(spawnCapRouterService)
+      ? spawnCapRouterService
+      : undefined;
     const spawnOriginKey = originConnectorMessageId
       ? `${originConnectorMessageId}\0${agentType}`
       : undefined;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -382,6 +382,67 @@ export class SubAgentRouter extends Service {
     }
     return true;
   }
+
+  // Per-root-origin spawn cap. completionFirstPostedSession above only
+  // suppresses duplicate POSTS; it does not stop the PLANNER from re-spawning a
+  // fresh sub-agent each time a (weak-model) completion comes back truncated or
+  // blocked. Observed live: ONE user request fanned out to 70 TASKS_SPAWN_AGENT
+  // calls (each emitting a "working on it" ack + a partial answer = Discord
+  // spam). roundTripCounts is per-session (a fresh spawn resets it),
+  // stateLostRespawnCounts only counts session_state_lost and is cleared on
+  // every task_complete, and waitForSpawnSlot caps only SIMULTANEOUS sessions —
+  // so nothing bounds SERIAL re-spawns of one user message. These count spawns
+  // against the STABLE root origin (connector/parent message id + agent type,
+  // NOT the per-spawn instruction text — so re-spawns collapse to one key while
+  // distinct parallel TASKS:create subtasks are unaffected). FIFO bounded 1024.
+  private readonly spawnCountsForOrigin = new Map<string, number>();
+  private readonly bestResultForOrigin = new Map<
+    string,
+    { text: string; deliverable?: string }
+  >();
+
+  /** Spawns already issued for this root origin (for the per-origin cap). */
+  spawnCountForOrigin(originKey: string): number {
+    return this.spawnCountsForOrigin.get(originKey) ?? 0;
+  }
+
+  /** Record a spawn against a root origin (FIFO-bounded). */
+  noteSpawnForOrigin(originKey: string): void {
+    this.spawnCountsForOrigin.set(
+      originKey,
+      (this.spawnCountsForOrigin.get(originKey) ?? 0) + 1,
+    );
+    while (this.spawnCountsForOrigin.size > 1024) {
+      const oldest = this.spawnCountsForOrigin.keys().next().value;
+      if (!oldest) break;
+      this.spawnCountsForOrigin.delete(oldest);
+    }
+  }
+
+  /** Best already-completed result for an origin, relayed instead of re-spawning. */
+  bestResultFor(
+    originKey: string,
+  ): { text: string; deliverable?: string } | undefined {
+    return this.bestResultForOrigin.get(originKey);
+  }
+
+  /** Keep the LONGEST non-empty result for an origin (full 479001600 wins over truncated 479). */
+  recordOriginResult(
+    originKey: string,
+    result: { text: string; deliverable?: string },
+  ): void {
+    const candidate = (result.deliverable ?? result.text ?? "").trim();
+    if (!candidate) return;
+    const prev = this.bestResultForOrigin.get(originKey);
+    const prevLen = (prev?.deliverable ?? prev?.text ?? "").trim().length;
+    if (prev && candidate.length <= prevLen) return;
+    this.bestResultForOrigin.set(originKey, result);
+    while (this.bestResultForOrigin.size > 1024) {
+      const oldest = this.bestResultForOrigin.keys().next().value;
+      if (!oldest) break;
+      this.bestResultForOrigin.delete(oldest);
+    }
+  }
   private started = false;
   private roundTripCap = DEFAULT_ROUND_TRIP_CAP;
   private stateLostRespawnCap = DEFAULT_STATE_LOST_RESPAWN_CAP;
@@ -832,6 +893,18 @@ export class SubAgentRouter extends Service {
       text = verifiedUrlCompletionFallback(text, verifiedUrls);
     }
     if (event === "task_complete") {
+      // Remember the best (longest) result for this root origin so the spawn
+      // cap (tasks.ts) can relay it instead of re-spawning when a weak model's
+      // later completion for the SAME user request comes back truncated/blocked.
+      // Key on the connector message id only — the stable root id the router
+      // stamps onto each synthetic re-spawn inbound and that tasks.ts reads back
+      // (so record + enforce agree); a request without one simply isn't capped.
+      if (origin.parentConnectorMessageId) {
+        this.recordOriginResult(
+          `${origin.parentConnectorMessageId}\0${session.agentType}`,
+          { text, deliverable },
+        );
+      }
       const preview = (deliverable ?? text).trim().slice(0, 200);
       void getNotifier(this.runtime)
         ?.notify({

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -770,7 +770,10 @@ export class SubAgentRouter extends Service {
     // with an empty completion. Gated to a single short block so multi-KB
     // transcripts stay on the model-rendered (summarized) path.
     let deliverable: string | undefined;
-    if (event === "task_complete" && !changeSet && verifiedUrls.length === 0) {
+    // Capture the deliverable even when files changed: a "do X and report the
+    // output" task that also writes a file must still surface the output, not
+    // only the diff summary. The verifiedUrls path keeps its dedicated handling.
+    if (event === "task_complete" && verifiedUrls.length === 0) {
       deliverable = extractShortToolDeliverable(data);
     }
     // Verify-retry: the sub-agent reported done but referenced URLs that
@@ -2014,7 +2017,15 @@ function composeNarration(
     // Preserve any deployed URL the sub-agent claimed so the downstream
     // reachability verification still runs.
     const urls = collectVerifiableUrlCandidates(response ?? "");
+    // A file write must not swallow the answer the user asked for: when the
+    // sub-agent captured a concrete deliverable (e.g. a script's stdout for a
+    // "run it and report the output" task), surface it ABOVE the change
+    // summary. This is the typed `[tool output: …]` envelope, not the raw
+    // transcript, so the leak/respawn problems the diff-summary path solved
+    // stay solved.
+    const capturedDeliverable = extractShortToolDeliverable(data);
     const lines = [
+      ...(capturedDeliverable ? [capturedDeliverable] : []),
       summarizeChangeSet(changeSet),
       changeSet.diffStat,
       ...urls,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -891,6 +891,22 @@ export class SubAgentRouter extends Service {
     }
     if (event === "task_complete" && verifiedUrls.length > 0) {
       text = verifiedUrlCompletionFallback(text, verifiedUrls);
+    } else if (
+      event === "task_complete" &&
+      deliverable &&
+      !text.includes(deliverable)
+    ) {
+      // The captured tool output IS the answer for a "run it and report the
+      // output" task. The weak model's prose paraphrase of the same run is
+      // routinely truncated (relays "479" for a captured "479001600"), and that
+      // prose — not the metadata deliverable — is what every downstream reader
+      // consumes: the planner re-derives its reply from this narration, and
+      // Stage-1 regenerates any bare-numeric reply from it. So surface the
+      // verbatim deliverable as the narration body (the header's relay /
+      // do-not-respawn directive is preserved on the first line).
+      const firstNewline = text.indexOf("\n");
+      const header = firstNewline === -1 ? text : text.slice(0, firstNewline);
+      text = `${header}\n${deliverable}`;
     }
     if (event === "task_complete") {
       // Remember the best (longest) result for this root origin so the spawn
@@ -2021,16 +2037,25 @@ export function extractShortToolDeliverable(data: unknown): string | undefined {
   const blocks = response.match(
     /\[tool output:[^\]]*\]([\s\S]*?)\[\/tool output\]/g,
   );
-  if (blocks?.length !== 1) return undefined;
-  const inner = blocks[0]
-    .replace(/^\[tool output:[^\]]*\]/, "")
-    .replace(/\[\/tool output\]$/, "")
-    .trim();
-  if (!inner) return undefined;
-  if (Buffer.byteLength(inner, "utf8") > MAX_VERBATIM_DELIVERABLE_BYTES) {
-    return undefined;
+  if (!blocks?.length) return undefined;
+  // Multi-step tool use is normal — a failed attempt then a retry (`python`
+  // not found, then `python3`), or write-a-file then run-it. The LAST
+  // non-empty block is the sub-agent's final result, so surface it verbatim:
+  // a weak coding model routinely truncates that result in its own prose
+  // (relays "479" for a captured "479001600"), and the ground-truth tool
+  // output must win over the paraphrase. A block over the size cap is a
+  // transcript dump, not a deliverable — fall back to the summarized path.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const inner = blocks[i]
+      .replace(/^\[tool output:[^\]]*\]/, "")
+      .replace(/\[\/tool output\]$/, "")
+      .trim();
+    if (!inner) continue;
+    return Buffer.byteLength(inner, "utf8") > MAX_VERBATIM_DELIVERABLE_BYTES
+      ? undefined
+      : inner;
   }
-  return inner;
+  return undefined;
 }
 
 function composeNarration(


### PR DESCRIPTION
## What

Four related fixes for the ACP coding sub-agent flow, so a weak worker model (gpt-oss-120b on Cerebras via opencode) reliably returns the correct result. All live-verified on the cerebras+opencode stack.

### 1. Restore sub-agent deliverable capture (regression)

The `v2.0.4` squash baseline rebuilt `sub-agent-router.ts` without commit `b886241cec`, re-introducing a `!changeSet` gate that swallowed a coding task's real output: any *"do X and report the output"* task that **also writes a file** had its output dropped — only the diff summary survived.

### 2. Per-root-origin spawn cap (re-spawn loop)

A weak model that returns a truncated/blocked completion makes the planner re-issue `TASKS_SPAWN_AGENT` for the **same** request across turns — observed live as **one request → ~70 spawns**, each emitting an ack + partial answer (Discord spam). Adds a per-root-origin spawn cap on the `SubAgentRouter`, keyed on the connector message id the router stamps on each re-spawn (not the per-spawn instruction). Once `ELIZA_MAX_SPAWNS_PER_ORIGIN` (default 3) sub-agents have spawned, relay the best captured result instead. Enforced only on the `spawn_agent` path, so parallel `TASKS:create` fan-out is untouched.

### 3. Guard the spawn-cap router lookup

`getService("ACPX_SUB_AGENT_ROUTER")` is loosely typed; the unchecked cast to the cap-router shape let a differently-shaped service (test doubles resolve one mock for every id) reach a missing method and throw, aborting the spawn. Verify the cap API with a type guard before using it.

### 4. Relay the verbatim final tool output as the answer

Decisive root-cause via live ACP-event tracing: the weak model truncates a computed result in **its own prose** — relaying `"479"` for a captured `"479001600"` — while the bash tool output (`479001600`, exit 0) is captured perfectly. It was discarded two ways:

- `extractShortToolDeliverable` bailed when the transcript had **>1** `[tool output]` block — but multi-step tool use is normal (a failed `python` attempt then a `python3` retry, or write-a-file then run-it). Now takes the **last non-empty short block** (the final result).
- The captured deliverable lived only in metadata; the planner re-derives its reply from `content.text` and Stage-1 regenerates any bare-numeric reply from it, so the metadata value never won. Now surfaces the deliverable as the narration body, **gated to no-verified-URL completions** so build/URL tasks are untouched.

**Live-verified (cerebras+opencode), each a single correct reply:** `factorial(12)=479001600`, `20!=2432902008176640000` (19 digits — the planner can't fabricate it), sum of first 50 primes `=5117`.

## Test

`bun run --cwd plugins/plugin-agent-orchestrator test:unit` — 680/680 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)