### PR TITLE
chore: post-audit cleanup — stale tsx-boot comments + Stage-1 retry boundary tests

### DIFF
--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -128,8 +128,8 @@ RUN find node_modules -name '*.map' -delete 2>/dev/null; \
 # `tsx` to be resolvable from /app. bun's workspace install on GHA can drop tsx from the build
 # context (it lives under `node_modules/.bun/tsx@<v>/` but isn't always
 # materialized at `node_modules/tsx/`, and dockerignore prunes per-package
-# trees). Mirror Dockerfile.cloud's pattern: install tsx in a dedicated stage
-# and COPY it into the final image's `/app/node_modules/tsx`. Idempotent and
+# trees). So install tsx in a dedicated stage and COPY it into the final image
+# at `/opt/tsx` (referenced absolutely by APP_CMD_START). Idempotent and
 # version-pinned.
 FROM node:${NODE_VERSION}-slim AS tsx
 RUN npm install --prefix /opt/tsx --ignore-scripts --no-save tsx@4.21.0 \
@@ -179,7 +179,7 @@ RUN set -eux; \
   install -m 0755 "/tmp/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}/tailscaled" /usr/local/bin/tailscaled; \
   rm -rf /tmp/tailscale.tgz /tmp/tailscale.tgz.sha256 "/tmp/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}"
 
-# Install yt-dlp from upstream GitHub release. See Dockerfile.cloud for rationale.
+# Install yt-dlp from the upstream GitHub release (latest), not the lagging distro package.
 RUN ARCH="$(dpkg --print-architecture)" \
   && case "$ARCH" in \
        amd64)  YTDLP_ASSET=yt-dlp_linux ;; \
@@ -196,8 +196,7 @@ WORKDIR /app
 COPY --from=pruner /app /app
 # tsx is required by APP_CMD_START. Bring it in
 # from its own stage so it's self-contained (with esbuild + get-tsconfig
-# deps) at /opt/tsx, independent of bun's workspace install. Mirrors
-# Dockerfile.cloud's pattern.
+# deps) at /opt/tsx, independent of bun's workspace install.
 COPY --from=tsx /opt/tsx /opt/tsx
 
 ENV NODE_ENV=production

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -69,11 +69,12 @@ BOOT_CRASH_PATTERNS=(
   'ERR_MODULE_NOT_FOUND'
   'ERR_REQUIRE_ESM'
   'MODULE_NOT_FOUND'
-  # The agent now starts under plain `node` (no tsx loader, #8837). If any
-  # workspace package shipped without a built dist, link-docker-local-app-packages.mjs
-  # rewrites its exports to ./src/*.ts, and importing that at runtime throws
-  # ERR_UNKNOWN_FILE_EXTENSION on the core boot path. Fail fast on that signature
-  # instead of waiting out the full health timeout.
+  # Defense-in-depth: the agent boots under the tsx loader (see APP_CMD_START),
+  # so .ts extensions resolve at runtime today. But if a workspace package ever
+  # shipped without a built dist, link-docker-local-app-packages.mjs rewrites its
+  # exports to ./src/*.ts, and importing that under a tsx-less or mislinked boot
+  # would throw ERR_UNKNOWN_FILE_EXTENSION on the core boot path. Fail fast on that
+  # signature instead of waiting out the full health timeout.
   'ERR_UNKNOWN_FILE_EXTENSION'
   'Unknown file extension'
   'Failed to start'

--- a/packages/core/src/services/message.stage1-retry.test.ts
+++ b/packages/core/src/services/message.stage1-retry.test.ts
@@ -83,4 +83,30 @@ describe("shouldRetryStage1Generation", () => {
 			),
 		).toBe(true);
 	});
+
+	it("retries one token under the cap (the boundary the whole guard turns on)", () => {
+		// completionTokens < maxTokens is NOT a truncation: the output stopped on
+		// its own, so a fresh attempt can still fix genuinely-garbled args.
+		expect(
+			shouldRetryStage1Generation(
+				"malformed HANDLE_RESPONSE tool call",
+				rawWith({ completionTokens: MAX - 1 }),
+				MAX,
+			),
+		).toBe(true);
+	});
+
+	it("treats non-'length' max-token finish reasons as truncation", () => {
+		// Providers report the cap differently (max_tokens / token-limit / …); the
+		// finish-reason match must catch those, not just the literal "length".
+		for (const finishReason of ["max_tokens", "token-limit", "output_limit"]) {
+			expect(
+				shouldRetryStage1Generation(
+					"malformed HANDLE_RESPONSE tool call",
+					rawWith({ finishReason }),
+					MAX,
+				),
+			).toBe(false);
+		}
+	});
 });


### PR DESCRIPTION
Follow-ups from the session's prod-readiness audit. **All non-blocking, comment/test-only, zero behavior change.**

### 1. Stale tsx-boot comments (from the #8853 revert)
#8853 reverted #8837 (restored the tsx loader), but it restored comments that still describe the *old* tsx-less boot:
- `docker-ci-smoke.sh`: comment claimed the agent *'now starts under plain node (no tsx loader, #8837)'* — it boots under tsx (`APP_CMD_START`). Recast the `ERR_UNKNOWN_FILE_EXTENSION` guard as **defense-in-depth** against a future tsx-less/mislinked boot.
- `Dockerfile.ci`: (a) comment said tsx is COPY'd to `/app/node_modules/tsx` — it's actually `/opt/tsx`; (b) two `Dockerfile.cloud` references — **no such file** exists (real sibling is `Dockerfile.cloud-agent`, which uses a *different* `npm install -g tsx` + NODE_PATH approach, so 'mirrors its pattern' was misleading); (c) dropped the dead cross-reference.

### 2. Stage-1 retry boundary tests
Added the two highest-value cases the `>= cap ⇒ don't retry` guard (#8865) turns on:
- one token **under** the cap still retries (the boundary itself),
- non-`length` truncation finish reasons (`max_tokens`/`token-limit`/`output_limit`) are treated as cap hits (pins the finish-reason alternation, previously untested).

8 retry-policy tests green; biome clean. The other audit items (DRY/test-hygiene LOWs) were judged not worth the churn and left as-is.