### PR TITLE
feat(views): four-kind view taxonomy (system / release / developer / preview)

### DIFF
--- a/packages/agent/src/__tests__/views-registry-integration.test.ts
+++ b/packages/agent/src/__tests__/views-registry-integration.test.ts
@@ -255,7 +255,11 @@ describe("GET /api/views", () => {
     expect(Array.isArray(payload.views)).toBe(true);
   });
 
-  it("excludes developerOnly views by default", async () => {
+  it("returns all view kinds with metadata so the client can gate them", async () => {
+    // GET /api/views deliberately surfaces every kind (incl. developer/preview)
+    // annotated with developerOnly/viewKind. The server cannot know whether it
+    // is talking to a dev build or which Settings toggles are on, so kind-gating
+    // is a client responsibility — the route just hands over the full catalog.
     await registerPluginViews(
       {
         name: "views-integration-wallet",
@@ -280,11 +284,15 @@ describe("GET /api/views", () => {
 
     const [, payload] = json.mock.calls[0] as [
       unknown,
-      { views: { id: string }[] },
+      { views: { id: string; developerOnly?: boolean }[] },
     ];
     const ids = payload.views.map((v) => v.id);
     expect(ids).toContain("wallet.inventory");
-    expect(ids).not.toContain("dev.logs");
+    // Developer-only views are now included (the client hides them unless the
+    // Developer-views toggle is on) and still carry the developerOnly flag.
+    expect(ids).toContain("dev.logs");
+    const devView = payload.views.find((v) => v.id === "dev.logs");
+    expect(devView?.developerOnly).toBe(true);
   });
 
   it("includes developerOnly views when developerMode query param is true", async () => {

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -118,6 +118,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   {
     id: "trajectories",
     viewKind: "developer",
+    developerOnly: true,
     label: "Trajectories",
     description: "Agent trajectory logs and training data",
     icon: "GitBranch",
@@ -143,6 +144,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   {
     id: "memories",
     viewKind: "developer",
+    developerOnly: true,
     label: "Memories",
     description: "Agent memory viewer and management",
     icon: "Brain",
@@ -155,6 +157,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   {
     id: "database",
     viewKind: "developer",
+    developerOnly: true,
     label: "Database",
     description: "Raw database viewer and query interface",
     icon: "Database",
@@ -167,6 +170,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   {
     id: "logs",
     viewKind: "developer",
+    developerOnly: true,
     label: "Logs",
     description: "Runtime logs and agent debug output",
     icon: "FileText",

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -12,6 +12,7 @@ import type { ViewDeclaration } from "@elizaos/core";
 export const BUILTIN_VIEWS: ViewDeclaration[] = [
   {
     id: "tutorial",
+    viewKind: "system",
     label: "Tutorial",
     description:
       "Interactive guided tour — learn the chat, switching views, and Settings in 90 seconds",
@@ -26,6 +27,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "help",
+    viewKind: "system",
     label: "Help",
     description:
       "Searchable FAQ and knowledge base — what Eliza is and how everything works",
@@ -40,6 +42,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "camera",
+    viewKind: "release",
     label: "Camera",
     description:
       "Live camera preview with photo capture and front/back switching",
@@ -54,6 +57,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "chat",
+    viewKind: "system",
     label: "Chat",
     description:
       "Conversations with your agent, inbound messages from every connector",
@@ -68,6 +72,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "character",
+    viewKind: "system",
     label: "Character",
     description: "Agent identity, personality, style, and knowledge documents",
     icon: "UserRound",
@@ -80,6 +85,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "automations",
+    viewKind: "release",
     label: "Automations",
     description: "Scheduled tasks and recurring workflows",
     icon: "Clock3",
@@ -91,6 +97,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "plugins-page",
+    viewKind: "release",
     label: "Plugins",
     description: "Manage installed plugins, configure credentials",
     icon: "Puzzle",
@@ -110,6 +117,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "trajectories",
+    viewKind: "developer",
     label: "Trajectories",
     description: "Agent trajectory logs and training data",
     icon: "GitBranch",
@@ -117,11 +125,11 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/trajectories",
     order: 70,
     tags: ["training", "logs", "trajectories"],
-    developerOnly: true,
     visibleInManager: true,
   },
   {
     id: "transcripts",
+    viewKind: "release",
     label: "Transcripts",
     description:
       "Recorded voice transcripts — play, scrub, and read with word sync",
@@ -134,6 +142,7 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
   },
   {
     id: "memories",
+    viewKind: "developer",
     label: "Memories",
     description: "Agent memory viewer and management",
     icon: "Brain",
@@ -141,11 +150,11 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/memories",
     order: 72,
     tags: ["memory", "knowledge"],
-    developerOnly: true,
     visibleInManager: true,
   },
   {
     id: "database",
+    viewKind: "developer",
     label: "Database",
     description: "Raw database viewer and query interface",
     icon: "Database",
@@ -153,11 +162,11 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/database",
     order: 80,
     tags: ["database", "data", "debug"],
-    developerOnly: true,
     visibleInManager: true,
   },
   {
     id: "logs",
+    viewKind: "developer",
     label: "Logs",
     description: "Runtime logs and agent debug output",
     icon: "FileText",
@@ -165,11 +174,11 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     path: "/apps/logs",
     order: 81,
     tags: ["logs", "debug", "runtime"],
-    developerOnly: true,
     visibleInManager: true,
   },
   {
     id: "settings",
+    viewKind: "system",
     label: "Settings",
     description: "Configuration, plugins, credentials, and preferences",
     icon: "Settings",

--- a/packages/agent/src/api/views-registry.kinds.test.ts
+++ b/packages/agent/src/api/views-registry.kinds.test.ts
@@ -1,0 +1,93 @@
+/**
+ * View-kind taxonomy filtering in the view registry.
+ *
+ * Verifies that `listViews` honours the four-kind taxonomy: system/release are
+ * always listed, developer is gated by `developerMode`, preview is gated by
+ * `includeAllKinds`, and the dashboard endpoint's `includeAllKinds: true`
+ * surfaces everything (so the client can apply the user's Settings toggles).
+ */
+
+import type { Plugin } from "@elizaos/core";
+import { resolveViewKind } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { BUILTIN_VIEWS } from "./builtin-views.js";
+import { listViews, unregisterPluginViews } from "./views-registry.js";
+
+const PLUGIN_NAME = "@elizaos/plugin-view-kind-fixture";
+
+function fixturePlugin(): Plugin {
+  return {
+    name: PLUGIN_NAME,
+    description: "kind fixture",
+    views: [
+      { id: "vk-system", label: "Sys", viewKind: "system", bundleUrl: "x" },
+      { id: "vk-release", label: "Rel", viewKind: "release", bundleUrl: "x" },
+      { id: "vk-dev", label: "Dev", viewKind: "developer", bundleUrl: "x" },
+      { id: "vk-preview", label: "Prev", viewKind: "preview", bundleUrl: "x" },
+      // legacy gate still maps to developer
+      { id: "vk-legacy", label: "Legacy", developerOnly: true, bundleUrl: "x" },
+    ],
+  } as Plugin;
+}
+
+async function register() {
+  const { registerPluginViews } = await import("./views-registry.js");
+  await registerPluginViews(fixturePlugin(), "/tmp/does-not-matter");
+}
+
+function ids(entries: { id: string }[]): string[] {
+  return entries.map((e) => e.id).filter((id) => id.startsWith("vk-"));
+}
+
+afterEach(() => {
+  unregisterPluginViews(PLUGIN_NAME);
+});
+
+describe("BUILTIN_VIEWS categorization", () => {
+  it("sorts every built-in view into a kind, with the dev tools as developer", () => {
+    const byId = new Map(BUILTIN_VIEWS.map((v) => [v.id, resolveViewKind(v)]));
+    expect(byId.get("chat")).toBe("system");
+    expect(byId.get("settings")).toBe("system");
+    expect(byId.get("character")).toBe("system");
+    expect(byId.get("automations")).toBe("release");
+    expect(byId.get("transcripts")).toBe("release");
+    expect(byId.get("logs")).toBe("developer");
+    expect(byId.get("database")).toBe("developer");
+    expect(byId.get("memories")).toBe("developer");
+    expect(byId.get("trajectories")).toBe("developer");
+    // No built-in is left uncategorized (resolves to a concrete kind).
+    for (const v of BUILTIN_VIEWS) {
+      expect(["system", "release", "developer", "preview"]).toContain(
+        resolveViewKind(v),
+      );
+    }
+  });
+});
+
+describe("listViews kind filtering", () => {
+  it("default (no flags): only system + release", async () => {
+    await register();
+    expect(ids(listViews()).sort()).toEqual(["vk-release", "vk-system"]);
+  });
+
+  it("developerMode: adds developer (incl. legacy developerOnly), not preview", async () => {
+    await register();
+    expect(ids(listViews({ developerMode: true })).sort()).toEqual([
+      "vk-dev",
+      "vk-legacy",
+      "vk-release",
+      "vk-system",
+    ]);
+  });
+
+  it("includeAllKinds: surfaces every kind including preview", async () => {
+    await register();
+    expect(ids(listViews({ includeAllKinds: true })).sort()).toEqual([
+      "vk-dev",
+      "vk-legacy",
+      "vk-preview",
+      "vk-release",
+      "vk-system",
+    ]);
+  });
+});

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -14,6 +14,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import {
   logger,
   type Plugin,
+  resolveViewKind,
   type ViewDeclaration,
   type ViewType,
 } from "@elizaos/core";
@@ -390,18 +391,33 @@ export function registerBuiltinViews(runtime?: IAgentRuntime): void {
 /**
  * List all registered views.
  *
- * @param filter.developerMode - When `false` (default) hidden developer-only
- *   views are excluded. Pass `true` to include them.
+ * Visibility follows the four-kind taxonomy ({@link resolveViewKind}):
+ * `system`/`release` views are always listed. `developer` views are listed
+ * only when `developerMode` is true. `preview` views are listed only when
+ * `includeAllKinds` is true. The dashboard's `GET /api/views` passes
+ * `includeAllKinds: true` so the client receives every view (with its
+ * `viewKind`) and applies the user's Settings toggles itself — the server
+ * cannot know whether it is talking to a dev build or which toggles are on.
+ *
+ * @param filter.developerMode - Include `developer`-kind views. Default false.
+ * @param filter.includeAllKinds - Include every kind regardless of toggle
+ *   (developer + preview). Default false.
  */
 export function listViews(filter?: {
   developerMode?: boolean;
+  includeAllKinds?: boolean;
   viewType?: ViewType;
 }): ViewRegistryEntry[] {
   const developerMode = filter?.developerMode ?? false;
+  const includeAllKinds = filter?.includeAllKinds ?? false;
   const requestedViewType = filter?.viewType ?? DEFAULT_VIEW_TYPE;
   const byId = new Map<string, ViewRegistryEntry>();
   for (const entry of registry.values()) {
-    if (entry.developerOnly && !developerMode) continue;
+    if (!includeAllKinds) {
+      const kind = resolveViewKind(entry);
+      if (kind === "preview") continue;
+      if (kind === "developer" && !developerMode) continue;
+    }
     const existing = byId.get(entry.id);
     if (!existing) {
       if (

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -392,12 +392,14 @@ export async function handleViewsRoutes(
 
   // ── GET /api/views ────────────────────────────────────────────────────────
   if (method === "GET" && (pathname === PREFIX || pathname === `${PREFIX}/`)) {
-    const developerMode =
-      ctx.developerMode ?? url.searchParams.get("developerMode") === "true";
     const platform = detectClientPlatform(req);
     const dynamicAllowed = isDynamicLoadingAllowed(platform);
     const viewType = parseViewTypeParam(url.searchParams.get("viewType"));
-    const allViews = listViews({ developerMode, viewType });
+    // Return every view (all four kinds) with its `viewKind` so the client can
+    // apply the user's Settings toggles + build defaults itself. The server has
+    // no way to know whether it is talking to a dev build or which kinds the
+    // user enabled, so kind-gating is a client responsibility.
+    const allViews = listViews({ includeAllKinds: true, viewType });
     // On restricted platforms (iOS/Android store builds), only surface views
     // without a dynamic bundle URL (already in-process).
     const filtered = dynamicAllowed

--- a/packages/app/src/mobile-plugin-views.ts
+++ b/packages/app/src/mobile-plugin-views.ts
@@ -28,6 +28,7 @@ const platform = getFrontendPlatform();
 if (platform === "android" || platform === "ios") {
   registerAppShellPage({
     id: "vincent",
+    viewKind: "release",
     pluginId: "@elizaos/plugin-vincent",
     label: "Vincent",
     icon: "Zap",
@@ -40,6 +41,7 @@ if (platform === "android" || platform === "ios") {
 
   registerAppShellPage({
     id: "companion",
+    viewKind: "release",
     pluginId: "@elizaos/plugin-companion",
     label: "Companion",
     icon: "Bot",
@@ -52,6 +54,7 @@ if (platform === "android" || platform === "ios") {
 
   registerAppShellPage({
     id: "steward",
+    viewKind: "release",
     pluginId: "@elizaos/plugin-steward-app",
     label: "Steward",
     icon: "Shield",

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -52,3 +52,20 @@ export * from "./tee";
 export type { TestCase, TestSuite } from "./testing";
 export * from "./tools";
 export * from "./trigger";
+export type {
+	EnabledViewKinds,
+	ViewKind,
+	ViewKindBearer,
+} from "./view-kind";
+// Explicit value + type re-exports: a bare `export *` here gets tree-shaken to
+// nothing because `plugin.ts` imports this module via `import type`, which leads
+// esbuild/vite to treat the whole module as type-only and drop its runtime
+// exports from the star re-export.
+export {
+	isAlwaysOnViewKind,
+	isViewKindEnabled,
+	isViewVisible,
+	resolveViewKind,
+	VIEW_KIND_META,
+	VIEW_KINDS,
+} from "./view-kind";

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -13,6 +13,7 @@ import type { IAgentRuntime } from "./runtime";
 import type { Service } from "./service";
 import type { ShortcutDefinition } from "./shortcut";
 import type { TestSuite } from "./testing";
+import type { ViewKind } from "./view-kind";
 
 /**
  * Type for a service class constructor.
@@ -375,9 +376,15 @@ export interface PluginAppNavTab {
 	order?: number;
 	/**
 	 * If true, this tab is only visible when Developer Mode is enabled
-	 * in Settings. Defaults to false.
+	 * in Settings. Defaults to false. Equivalent to `viewKind: "developer"`.
 	 */
 	developerOnly?: boolean;
+	/**
+	 * Four-tier visibility category. When set it supersedes `developerOnly`:
+	 * `system`/`release` are always shown, `developer`/`preview` follow their
+	 * Settings toggles. Omit to fall back to `developerOnly` → `release`.
+	 */
+	viewKind?: ViewKind;
 	/**
 	 * Optional named group the tab belongs to (used by the shell to render
 	 * grouped tab strips, e.g. workbench/dev/wallet groupings).
@@ -426,9 +433,14 @@ export interface PluginWidgetDeclaration {
 	navGroup?: string;
 	/**
 	 * If true, this widget is only visible when Developer Mode is enabled
-	 * in Settings. Defaults to false.
+	 * in Settings. Defaults to false. Equivalent to `viewKind: "developer"`.
 	 */
 	developerOnly?: boolean;
+	/**
+	 * Four-tier visibility category. Supersedes `developerOnly` when set.
+	 * See {@link ViewKind}.
+	 */
+	viewKind?: ViewKind;
 	/**
 	 * Optional package export specifier the shell will dynamically import
 	 * when rendering. Format: "<package-subpath>#<named-export>".
@@ -557,8 +569,20 @@ export interface ViewDeclaration {
 	 * Dynamic plugin install is disabled on restricted store builds (ios, android).
 	 */
 	platforms?: ViewPlatform[];
-	/** Hidden unless developer mode is enabled. Default false. */
+	/**
+	 * Hidden unless developer mode is enabled. Default false. Equivalent to
+	 * `viewKind: "developer"`.
+	 */
 	developerOnly?: boolean;
+	/**
+	 * Four-tier visibility category for this view. Supersedes `developerOnly`
+	 * when set:
+	 *  - `system`    — always shown (core shell views).
+	 *  - `release`   — always shown (public, production-ready). The default.
+	 *  - `developer` — shown when Developer views are enabled (dev builds on).
+	 *  - `preview`   — shown when Preview views are enabled (off by default).
+	 */
+	viewKind?: ViewKind;
 	/**
 	 * Named export the shell mounts from the loaded bundle module.
 	 * Defaults to `"default"`.
@@ -617,9 +641,15 @@ export interface PluginApp {
 	/**
 	 * If true, the app is a developer-tooling surface (logs, trajectory
 	 * viewer, etc.) and is hidden from the main UI unless Developer Mode is
-	 * enabled in Settings. Defaults to false.
+	 * enabled in Settings. Defaults to false. Equivalent to
+	 * `viewKind: "developer"`.
 	 */
 	developerOnly?: boolean;
+	/**
+	 * Four-tier visibility category for this app. Supersedes `developerOnly`
+	 * when set. See {@link ViewKind}.
+	 */
+	viewKind?: ViewKind;
 	/**
 	 * Controls whether the app appears in the user-facing app store/catalog.
 	 * Defaults to true. Set to false for apps that auto-install or are

--- a/packages/core/src/types/view-kind.test.ts
+++ b/packages/core/src/types/view-kind.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+	type EnabledViewKinds,
+	isAlwaysOnViewKind,
+	isViewKindEnabled,
+	isViewVisible,
+	resolveViewKind,
+	VIEW_KIND_META,
+	VIEW_KINDS,
+} from "./view-kind";
+
+const NONE: EnabledViewKinds = { developer: false, preview: false };
+const DEV: EnabledViewKinds = { developer: true, preview: false };
+const PREVIEW: EnabledViewKinds = { developer: false, preview: true };
+const ALL: EnabledViewKinds = { developer: true, preview: true };
+
+describe("resolveViewKind", () => {
+	it("uses an explicit viewKind when present", () => {
+		expect(resolveViewKind({ viewKind: "system" })).toBe("system");
+		expect(resolveViewKind({ viewKind: "preview" })).toBe("preview");
+	});
+
+	it("explicit viewKind wins over legacy developerOnly", () => {
+		expect(resolveViewKind({ viewKind: "release", developerOnly: true })).toBe(
+			"release",
+		);
+	});
+
+	it("maps legacy developerOnly:true to developer", () => {
+		expect(resolveViewKind({ developerOnly: true })).toBe("developer");
+	});
+
+	it("defaults to release", () => {
+		expect(resolveViewKind({})).toBe("release");
+		expect(resolveViewKind(undefined)).toBe("release");
+		expect(resolveViewKind(null)).toBe("release");
+		expect(resolveViewKind({ developerOnly: false })).toBe("release");
+	});
+});
+
+describe("isViewKindEnabled", () => {
+	it("system and release are always enabled", () => {
+		for (const enabled of [NONE, DEV, PREVIEW, ALL]) {
+			expect(isViewKindEnabled("system", enabled)).toBe(true);
+			expect(isViewKindEnabled("release", enabled)).toBe(true);
+		}
+	});
+
+	it("developer follows the developer toggle", () => {
+		expect(isViewKindEnabled("developer", NONE)).toBe(false);
+		expect(isViewKindEnabled("developer", DEV)).toBe(true);
+		expect(isViewKindEnabled("developer", PREVIEW)).toBe(false);
+	});
+
+	it("preview follows the preview toggle", () => {
+		expect(isViewKindEnabled("preview", NONE)).toBe(false);
+		expect(isViewKindEnabled("preview", DEV)).toBe(false);
+		expect(isViewKindEnabled("preview", PREVIEW)).toBe(true);
+	});
+});
+
+describe("isViewVisible", () => {
+	it("gates declarations end-to-end via their resolved kind", () => {
+		expect(isViewVisible({ viewKind: "system" }, NONE)).toBe(true);
+		expect(isViewVisible({ developerOnly: true }, NONE)).toBe(false);
+		expect(isViewVisible({ developerOnly: true }, DEV)).toBe(true);
+		expect(isViewVisible({ viewKind: "preview" }, DEV)).toBe(false);
+		expect(isViewVisible({ viewKind: "preview" }, ALL)).toBe(true);
+		expect(isViewVisible(undefined, NONE)).toBe(true); // defaults to release
+	});
+});
+
+describe("metadata", () => {
+	it("isAlwaysOnViewKind marks only system + release", () => {
+		expect(isAlwaysOnViewKind("system")).toBe(true);
+		expect(isAlwaysOnViewKind("release")).toBe(true);
+		expect(isAlwaysOnViewKind("developer")).toBe(false);
+		expect(isAlwaysOnViewKind("preview")).toBe(false);
+	});
+
+	it("VIEW_KIND_META covers every kind with consistent alwaysOn flags", () => {
+		for (const kind of VIEW_KINDS) {
+			const meta = VIEW_KIND_META[kind];
+			expect(meta.label.length).toBeGreaterThan(0);
+			expect(meta.description.length).toBeGreaterThan(0);
+			expect(meta.alwaysOn).toBe(isAlwaysOnViewKind(kind));
+		}
+	});
+});

--- a/packages/core/src/types/view-kind.ts
+++ b/packages/core/src/types/view-kind.ts
@@ -1,0 +1,133 @@
+/**
+ * View kinds — the four-tier categorization every view-like surface is sorted
+ * into so the shell can decide what to show by build and by user preference.
+ *
+ *  - `system`    — core views that are always present (chat, settings, …). Not
+ *                  toggleable; always visible on every build.
+ *  - `release`   — public, production-ready views meant for everyone. Always
+ *                  visible on every build.
+ *  - `developer` — developer-only tooling (logs, database, trajectory viewer)
+ *                  so devs can verify the app is working. Visible by default in
+ *                  dev builds, hidden in production until enabled in Settings.
+ *  - `preview`   — unfinished / alpha / experimental views. Hidden by default
+ *                  on every build until enabled in Settings.
+ *
+ * The taxonomy lives in `@elizaos/core` so the agent server (view registry,
+ * built-in views) and every front-end (the dashboard shell, the view manager,
+ * settings) share one definition. The *enabled* set is owned by the client —
+ * which kinds are on depends on the build (dev vs production) and the user's
+ * Settings toggles, neither of which the server can know.
+ */
+
+/** The four view kinds, in escalating "exposure" order. */
+export const VIEW_KINDS = [
+	"system",
+	"release",
+	"developer",
+	"preview",
+] as const;
+
+/** A view's category. See {@link VIEW_KINDS}. */
+export type ViewKind = (typeof VIEW_KINDS)[number];
+
+/**
+ * The two user/​build-controllable toggles. `system` and `release` are always
+ * on, so they are not represented here.
+ */
+export interface EnabledViewKinds {
+	/** Show `developer`-kind views. Default: on in dev builds, off in prod. */
+	developer: boolean;
+	/** Show `preview`-kind views. Default: off on every build. */
+	preview: boolean;
+}
+
+/** A declaration that can be sorted into a {@link ViewKind}. */
+export interface ViewKindBearer {
+	/** Explicit kind. When set, it wins over the legacy `developerOnly` flag. */
+	viewKind?: ViewKind;
+	/**
+	 * Legacy gate predating {@link viewKind}. `true` is equivalent to
+	 * `viewKind: "developer"`. Kept so existing declarations keep working.
+	 */
+	developerOnly?: boolean;
+}
+
+/**
+ * Resolve the effective kind of a view-like declaration. Explicit `viewKind`
+ * wins; a legacy `developerOnly: true` maps to `"developer"`; everything else
+ * defaults to `"release"` (public). `"system"` is always explicit — a view is
+ * never silently promoted to always-on.
+ */
+export function resolveViewKind(
+	decl: ViewKindBearer | null | undefined,
+): ViewKind {
+	if (decl?.viewKind) return decl.viewKind;
+	if (decl?.developerOnly) return "developer";
+	return "release";
+}
+
+/**
+ * Whether a given kind is visible under the current enabled set. `system` and
+ * `release` are always visible; `developer` and `preview` follow their toggles.
+ */
+export function isViewKindEnabled(
+	kind: ViewKind,
+	enabled: EnabledViewKinds,
+): boolean {
+	switch (kind) {
+		case "system":
+		case "release":
+			return true;
+		case "developer":
+			return enabled.developer;
+		case "preview":
+			return enabled.preview;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Whether a view-like declaration is visible under the current enabled set.
+ * Combines {@link resolveViewKind} + {@link isViewKindEnabled} — the single
+ * predicate every visibility filter should call.
+ */
+export function isViewVisible(
+	decl: ViewKindBearer | null | undefined,
+	enabled: EnabledViewKinds,
+): boolean {
+	return isViewKindEnabled(resolveViewKind(decl), enabled);
+}
+
+/** Whether a kind is always on (not user-toggleable). */
+export function isAlwaysOnViewKind(kind: ViewKind): boolean {
+	return kind === "system" || kind === "release";
+}
+
+/** Presentation metadata for each kind — labels/descriptions for Settings. */
+export const VIEW_KIND_META: Record<
+	ViewKind,
+	{ label: string; description: string; alwaysOn: boolean }
+> = {
+	system: {
+		label: "System",
+		description: "Core views that are always available.",
+		alwaysOn: true,
+	},
+	release: {
+		label: "Release",
+		description: "Public, production-ready views for everyone.",
+		alwaysOn: true,
+	},
+	developer: {
+		label: "Developer",
+		description:
+			"Developer tooling to verify the app is working — logs, database, trajectories.",
+		alwaysOn: false,
+	},
+	preview: {
+		label: "Preview",
+		description: "Unfinished, alpha, or experimental views still in progress.",
+		alwaysOn: false,
+	},
+};

--- a/packages/shared/src/contracts/apps.ts
+++ b/packages/shared/src/contracts/apps.ts
@@ -2,7 +2,7 @@
  * Shared app manager contracts.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime, ViewKind } from "@elizaos/core";
 import z from "zod";
 
 // ---------------------------------------------------------------------------
@@ -175,9 +175,16 @@ export interface RegistryAppInfo {
   session?: AppSessionConfig;
   /**
    * If true, the app is a developer-tooling surface and is hidden from the
-   * main UI unless Developer Mode is enabled in Settings.
+   * main UI unless Developer Mode is enabled in Settings. Equivalent to
+   * `viewKind: "developer"`.
    */
   developerOnly?: boolean;
+  /**
+   * Four-tier visibility category. Supersedes `developerOnly` when set:
+   * `system`/`release` always show; `developer`/`preview` follow Settings
+   * toggles. See `ViewKind` in `@elizaos/core`.
+   */
+  viewKind?: ViewKind;
   /**
    * Controls whether the app appears in the user-facing app store/catalog.
    * Defaults to true. Set to false for apps that auto-install or are surfaced

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2,6 +2,11 @@
  * Root App component — routing shell.
  */
 
+import {
+  type EnabledViewKinds,
+  isViewVisible,
+  type ViewKind,
+} from "@elizaos/core";
 import { X } from "lucide-react";
 import "./components/chat/chat-source-registration";
 import {
@@ -146,7 +151,7 @@ import {
   type ViewRegistryEntry,
 } from "./hooks/useAvailableViews";
 import { useDesktopTabs } from "./hooks/useDesktopTabs";
-import { useIsDeveloperMode } from "./state/useDeveloperMode";
+import { useEnabledViewKinds } from "./state/useViewKinds";
 
 const ViewCatalog = lazyNamedView(
   () => import("./components/pages/ViewCatalog"),
@@ -477,6 +482,7 @@ interface ResolvedDynamicPage {
   id: string;
   pluginId: string;
   developerOnly: boolean;
+  viewKind?: ViewKind;
   registration?: AppShellPageRegistration;
   componentExport?: string;
 }
@@ -506,6 +512,7 @@ function useResolvedDynamicPage(tab: string): ResolvedDynamicPage | null {
         id: registered.id,
         pluginId: registered.pluginId,
         developerOnly: registered.developerOnly === true,
+        viewKind: registered.viewKind,
         registration: registered,
       };
     }
@@ -522,6 +529,8 @@ function useResolvedDynamicPage(tab: string): ResolvedDynamicPage | null {
           pluginId: plugin.id,
           developerOnly:
             plugin.app?.developerOnly === true || navTab.developerOnly === true,
+          // A nav tab's own kind wins; otherwise inherit the app's kind.
+          viewKind: navTab.viewKind ?? plugin.app?.viewKind,
           registration: reg,
           componentExport: navTab.componentExport,
         };
@@ -633,9 +642,9 @@ function WalletInventoryPage() {
 
 function visibleDynamicPage(
   page: ResolvedDynamicPage | null,
-  developerModeEnabled: boolean,
+  enabledKinds: EnabledViewKinds,
 ): page is ResolvedDynamicPage {
-  return Boolean(page && (developerModeEnabled || !page.developerOnly));
+  return Boolean(page && isViewVisible(page, enabledKinds));
 }
 
 /**
@@ -1017,7 +1026,7 @@ function renderViewRouterContent({
   tab,
   dynamicPage,
   dynamicAppPage,
-  developerModeEnabled,
+  enabledKinds,
   navigationPath,
   availableViews,
   appSlug,
@@ -1027,21 +1036,21 @@ function renderViewRouterContent({
   tab: string;
   dynamicPage: ResolvedDynamicPage | null;
   dynamicAppPage: ResolvedDynamicPage | null;
-  developerModeEnabled: boolean;
+  enabledKinds: EnabledViewKinds;
   navigationPath: string;
   availableViews: ViewRegistryEntry[];
   appSlug: string | null;
   androidPhoneSurfaceEnabled: boolean;
   settingsInitialSection?: string | null;
 }): ReactNode {
-  if (visibleDynamicPage(dynamicPage, developerModeEnabled)) {
+  if (visibleDynamicPage(dynamicPage, enabledKinds)) {
     return (
       <TabContentView>
         <DynamicPluginPage resolved={dynamicPage} />
       </TabContentView>
     );
   }
-  if (visibleDynamicPage(dynamicAppPage, developerModeEnabled)) {
+  if (visibleDynamicPage(dynamicAppPage, enabledKinds)) {
     return (
       <TabContentView>
         <DynamicPluginPage resolved={dynamicAppPage} />
@@ -1079,7 +1088,7 @@ function ViewRouter({
       ? getAppSlugFromPath(navigationPath)
       : null;
   const dynamicAppPage = useResolvedDynamicPage(appSlug ?? "");
-  const developerModeEnabled = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1098,7 +1107,7 @@ function ViewRouter({
     tab,
     dynamicPage,
     dynamicAppPage,
-    developerModeEnabled,
+    enabledKinds,
     navigationPath,
     availableViews,
     appSlug,

--- a/packages/ui/src/api/client-types-config.ts
+++ b/packages/ui/src/api/client-types-config.ts
@@ -3,6 +3,7 @@
 // Update*, Extension*, Workbench*, Character*, Voice*, Skill*
 // ---------------------------------------------------------------------------
 
+import type { ViewKind } from "@elizaos/core";
 import type { MessageExampleContent, PluginParamDef } from "@elizaos/shared";
 import type { ConfigUiHint } from "../types";
 import type {
@@ -168,6 +169,7 @@ export interface PluginInfo {
     defaultEnabled?: boolean;
     navGroup?: string;
     developerOnly?: boolean;
+    viewKind?: ViewKind;
     componentExport?: string;
   }>;
   /**
@@ -180,6 +182,7 @@ export interface PluginInfo {
     category?: string;
     icon?: string | null;
     developerOnly?: boolean;
+    viewKind?: ViewKind;
     visibleInAppStore?: boolean;
     navTabs?: Array<{
       id: string;
@@ -188,6 +191,7 @@ export interface PluginInfo {
       path: string;
       order?: number;
       developerOnly?: boolean;
+      viewKind?: ViewKind;
       group?: string;
       componentExport?: string;
     }>;

--- a/packages/ui/src/app-shell-registry.ts
+++ b/packages/ui/src/app-shell-registry.ts
@@ -1,3 +1,4 @@
+import type { ViewKind } from "@elizaos/core";
 import type { ComponentType } from "react";
 
 export type AppShellPageLoader = () => Promise<{
@@ -23,8 +24,16 @@ export interface AppShellPageRegistration {
   path: string;
   /** Sort priority within the nav (lower = first). Default 100. */
   order?: number;
-  /** When true, only visible when Developer Mode is enabled in Settings. */
+  /**
+   * When true, only visible when Developer Mode is enabled in Settings.
+   * Equivalent to `viewKind: "developer"`.
+   */
   developerOnly?: boolean;
+  /**
+   * Four-tier visibility category. Supersedes `developerOnly` when set.
+   * See {@link ViewKind}.
+   */
+  viewKind?: ViewKind;
   /** Optional named group the tab belongs to. */
   group?: string;
   /**

--- a/packages/ui/src/components/apps/helpers.ts
+++ b/packages/ui/src/components/apps/helpers.ts
@@ -1,3 +1,4 @@
+import { type EnabledViewKinds, isViewVisible } from "@elizaos/core";
 import {
   getElizaCuratedAppCatalogOrder,
   isElizaCuratedAppName,
@@ -134,10 +135,12 @@ interface AppsCatalogFilterOptions {
   showActiveOnly?: boolean;
   walletEnabled?: boolean;
   /**
-   * When false (or omitted), apps marked `developerOnly: true` are hidden.
-   * Pass the current value from `useIsDeveloperMode()` to opt in.
+   * Which view kinds the user/​build has enabled (system + release always on;
+   * developer + preview follow the Settings toggles). Apps whose kind is not
+   * enabled are hidden. Pass the value from `useEnabledViewKinds()`. When
+   * omitted, only system/release apps are shown.
    */
-  developerMode?: boolean;
+  enabledKinds?: EnabledViewKinds;
 }
 
 function parseBooleanEnvValue(value: unknown): boolean {
@@ -241,7 +244,7 @@ export function filterAppsForCatalog(
     showAllApps,
     showActiveOnly = false,
     walletEnabled,
-    developerMode = false,
+    enabledKinds = { developer: false, preview: false },
   }: AppsCatalogFilterOptions = {},
 ): RegistryAppInfo[] {
   const normalizedSearch = searchQuery.trim().toLowerCase();
@@ -276,8 +279,9 @@ export function filterAppsForCatalog(
     if (!shouldShowAppInAppsView(app, { isProd, showAllApps, walletEnabled })) {
       return false;
     }
-    // Developer-only apps are hidden unless Developer Mode is on.
-    if (app.developerOnly && !developerMode) {
+    // Apps are gated by their view kind: developer apps need Developer views on,
+    // preview apps need Preview views on; system/release always show.
+    if (!isViewVisible(app, enabledKinds)) {
       return false;
     }
     // Apps that opt out of the catalog are always hidden, regardless of Developer Mode.

--- a/packages/ui/src/components/pages/AppsView.tsx
+++ b/packages/ui/src/components/pages/AppsView.tsx
@@ -16,7 +16,7 @@ import {
   shouldUseHashNavigation,
 } from "../../navigation";
 
-import { useAppSelectorShallow, useIsDeveloperMode } from "../../state";
+import { useAppSelectorShallow, useEnabledViewKinds } from "../../state";
 import { openExternalUrl } from "../../utils";
 import { AppsCatalogGrid } from "../apps/AppsCatalogGrid";
 import { AppsSidebar } from "../apps/AppsSidebar";
@@ -277,7 +277,7 @@ export function AppsView() {
     setActionNotice: s.setActionNotice,
     t: s.t,
   }));
-  const developerMode = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
   const [apps, setApps] = useState<RegistryAppInfo[]>(
     () => readAppsCache() ?? [],
   );
@@ -1018,13 +1018,13 @@ export function AppsView() {
       activeAppNames,
       searchQuery,
       walletEnabled,
-      developerMode,
+      enabledKinds,
     });
-  }, [activeAppNames, apps, searchQuery, walletEnabled, developerMode]);
+  }, [activeAppNames, apps, searchQuery, walletEnabled, enabledKinds]);
 
   const browseApps = useMemo(() => {
-    return filterAppsForCatalog(apps, { walletEnabled, developerMode });
-  }, [apps, walletEnabled, developerMode]);
+    return filterAppsForCatalog(apps, { walletEnabled, enabledKinds });
+  }, [apps, walletEnabled, enabledKinds]);
 
   const handleToggleFavorite = useCallback(
     (appName: string) => {

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -1,3 +1,4 @@
+import { isViewVisible } from "@elizaos/core";
 import { ArrowLeft } from "lucide-react";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -10,7 +11,7 @@ import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ContentLayout } from "../../layouts/content-layout";
 import { cn } from "../../lib/utils";
 import { useAppSelectorShallow } from "../../state";
-import { useIsDeveloperMode } from "../../state/useDeveloperMode";
+import { useEnabledViewKinds } from "../../state/useViewKinds";
 import {
   SettingsGroup,
   SettingsRow,
@@ -382,7 +383,7 @@ export function SettingsView({
     walletEnabled: s.walletEnabled,
   }));
   const isDesktop = useMediaQuery("(min-width: 1024px)");
-  const developerMode = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
   );
@@ -390,10 +391,10 @@ export function SettingsView({
   const visibleSections = useMemo(() => {
     return getAllSettingsSections().filter((section) => {
       if (section.id === "wallet-rpc" && walletEnabled === false) return false;
-      if (section.developerOnly && !developerMode) return false;
+      if (!isViewVisible(section, enabledKinds)) return false;
       return true;
     });
-  }, [walletEnabled, developerMode]);
+  }, [walletEnabled, enabledKinds]);
   const visibleSectionIds = useMemo(
     () => new Set(visibleSections.map((section) => section.id)),
     [visibleSections],

--- a/packages/ui/src/components/pages/ViewCatalog.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.tsx
@@ -7,6 +7,7 @@
  * or the `eliza:navigate:view` event dispatched by VIEWS actions.
  */
 
+import { type EnabledViewKinds, isViewVisible } from "@elizaos/core";
 import {
   ArrowDownAZ,
   Clock3,
@@ -39,6 +40,7 @@ import {
 } from "../../platform/platform-guards";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useIsDeveloperMode } from "../../state/useDeveloperMode";
+import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import {
   readRecentViewIds,
@@ -141,13 +143,13 @@ function isShellNavigationEntry(view: Pick<ViewRegistryEntry, "id" | "path">) {
 
 function isVisibleCatalogView(
   view: ViewRegistryEntry,
-  isDeveloperMode: boolean,
+  enabledKinds: EnabledViewKinds,
   activeModality: ViewModality,
 ) {
   if (isViewManagerEntry(view)) return false;
   if (isShellNavigationEntry(view)) return false;
   if ((view.viewType ?? "gui") !== activeModality) return false;
-  if (view.developerOnly && !isDeveloperMode) return false;
+  if (!isViewVisible(view, enabledKinds)) return false;
   if (view.visibleInManager === false) return false;
   return true;
 }
@@ -597,6 +599,7 @@ export function ViewCatalog() {
   const { views, loading, error, refresh } = useAvailableViews();
   const { tabs: desktopTabs } = useDesktopTabs();
   const isDeveloperMode = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
   const canManageDynamicViews = isDeveloperMode && isElectrobunRuntime();
   // Views are scoped to the surface modality: a GUI surface lists only GUI
   // views (TUI/XR hidden entirely); an XR surface lists only XR views.
@@ -717,7 +720,7 @@ export function ViewCatalog() {
     // When the search endpoint returned results, display those ranked by score.
     if (searchResults !== null) {
       const visible = searchResults.filter((v) => {
-        return isVisibleCatalogView(v, isDeveloperMode, activeModality);
+        return isVisibleCatalogView(v, enabledKinds, activeModality);
       });
       return {
         builtinViews: visible.filter((v) => v.builtin),
@@ -727,7 +730,7 @@ export function ViewCatalog() {
     // No active search — show all views with client-side visibility rules.
     const q = query.trim().toLowerCase();
     const visible = views.filter((v) => {
-      if (!isVisibleCatalogView(v, isDeveloperMode, activeModality)) {
+      if (!isVisibleCatalogView(v, enabledKinds, activeModality)) {
         return false;
       }
       if (!q) return true;
@@ -742,7 +745,7 @@ export function ViewCatalog() {
       builtinViews: visible.filter((v) => v.builtin),
       pluginViews: visible.filter((v) => !v.builtin),
     };
-  }, [views, isDeveloperMode, query, searchResults, activeModality]);
+  }, [views, enabledKinds, query, searchResults, activeModality]);
   const visibleViews = useMemo(
     () => [...builtinViews, ...pluginViews],
     [builtinViews, pluginViews],

--- a/packages/ui/src/components/settings/AdvancedSection.tsx
+++ b/packages/ui/src/components/settings/AdvancedSection.tsx
@@ -3,8 +3,10 @@ import { useCallback, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import {
   setDeveloperMode,
+  setPreviewMode,
   useAppSelectorShallow,
   useIsDeveloperMode,
+  useIsPreviewMode,
 } from "../../state";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
@@ -50,6 +52,7 @@ export function AdvancedSection() {
     setState: s.setState,
   }));
   const developerMode = useIsDeveloperMode();
+  const previewMode = useIsPreviewMode();
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
@@ -201,13 +204,25 @@ export function AdvancedSection() {
           />
         </SettingsGroup>
 
-        <SettingsGroup>
+        <SettingsGroup
+          title="View visibility"
+          description="Views are sorted into four kinds. System and Release views are always shown. Turn on the kinds below to reveal the rest."
+        >
           <SettingsSwitchRow
             agentId="advanced-developer-mode"
             group="advanced"
-            label="Developer Mode"
+            label="Developer views"
+            description="Developer tooling to verify the app is working — logs, database, trajectories. On by default in dev builds."
             checked={developerMode}
             onCheckedChange={(checked) => setDeveloperMode(checked)}
+          />
+          <SettingsSwitchRow
+            agentId="advanced-preview-mode"
+            group="advanced"
+            label="Preview views"
+            description="Unfinished, alpha, or experimental views still in progress. Off by default."
+            checked={previewMode}
+            onCheckedChange={(checked) => setPreviewMode(checked)}
           />
         </SettingsGroup>
 

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -1,3 +1,4 @@
+import type { ViewKind } from "@elizaos/core";
 import type { LucideIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import type { SettingsSectionGroup } from "./settings-section-meta";
@@ -51,8 +52,17 @@ export interface SettingsSectionDef {
   order?: number;
   /** Padding override for the section body panel. */
   bodyClassName?: string;
-  /** Hide unless Developer Mode is on (dev builds default on; prod off). */
+  /**
+   * Hide unless Developer Mode is on (dev builds default on; prod off).
+   * Equivalent to `viewKind: "developer"`.
+   */
   developerOnly?: boolean;
+  /**
+   * Four-tier visibility category. Supersedes `developerOnly` when set:
+   * `system`/`release` always show; `developer`/`preview` follow the Settings
+   * toggles. See `ViewKind` in `@elizaos/core`.
+   */
+  viewKind?: ViewKind;
   Component: ComponentType;
 }
 

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -10,6 +10,7 @@
  * plugins are installed or uninstalled at runtime.
  */
 
+import type { ViewKind } from "@elizaos/core";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { fetchWithCsrf } from "../api/csrf-client";
 import {
@@ -56,8 +57,17 @@ export interface ViewRegistryEntry {
   pluginName: string;
   /** Freeform tags used for search and filtering. */
   tags?: string[];
-  /** When true, the view only appears when Developer Mode is enabled. */
+  /**
+   * When true, the view only appears when Developer Mode is enabled.
+   * Equivalent to `viewKind: "developer"`.
+   */
   developerOnly?: boolean;
+  /**
+   * Four-tier visibility category. Supersedes `developerOnly` when set:
+   * `system`/`release` always show; `developer`/`preview` follow Settings
+   * toggles. See `ViewKind` in `@elizaos/core`.
+   */
+  viewKind?: ViewKind;
   /** When false, the view is hidden from the manager grid (internal views). */
   visibleInManager?: boolean;
   /** Named capabilities the view exposes (informational). */
@@ -166,6 +176,7 @@ function appShellPageToViewEntry(
     available: true,
     pluginName: page.pluginId,
     developerOnly: page.developerOnly,
+    viewKind: page.viewKind,
     visibleInManager: true,
     builtin: false,
   };

--- a/packages/ui/src/hooks/useViewCatalog.ts
+++ b/packages/ui/src/hooks/useViewCatalog.ts
@@ -17,7 +17,7 @@ import { useCallback, useMemo, useState } from "react";
 import { client } from "../api";
 import { loadAppsCatalog } from "../components/apps/load-apps-catalog";
 import { getActiveViewModality } from "../platform/platform-guards";
-import { useIsDeveloperMode } from "../state/useDeveloperMode";
+import { useEnabledViewKinds } from "../state/useViewKinds";
 import { useAvailableViews } from "./useAvailableViews";
 import { useCachedResource } from "./useCachedResource";
 import { mergeViewCatalog, type ViewEntry } from "./view-catalog";
@@ -42,7 +42,7 @@ export function useViewCatalog(): UseViewCatalogResult {
     error: viewsError,
     refresh: refreshViews,
   } = useAvailableViews();
-  const isDeveloperMode = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
   const activeModality = useMemo(() => getActiveViewModality(), []);
 
   const catalogRes = useCachedResource(
@@ -72,13 +72,13 @@ export function useViewCatalog(): UseViewCatalogResult {
       catalog,
       installed,
       activeModality,
-      isDeveloperMode,
+      enabledKinds,
     });
     if (Object.keys(pending).length === 0) return merged;
     return merged.map((e) =>
       pending[e.key] ? { ...e, state: pending[e.key] } : e,
     );
-  }, [views, catalog, installed, activeModality, isDeveloperMode, pending]);
+  }, [views, catalog, installed, activeModality, enabledKinds, pending]);
 
   const refresh = useCallback(() => {
     refreshViews();

--- a/packages/ui/src/hooks/view-catalog.test.ts
+++ b/packages/ui/src/hooks/view-catalog.test.ts
@@ -34,7 +34,7 @@ function merge(
     catalog: opts.catalog ?? [],
     installed: opts.installed ?? [],
     activeModality: opts.activeModality ?? "gui",
-    isDeveloperMode: opts.isDeveloperMode ?? false,
+    enabledKinds: opts.enabledKinds ?? { developer: false, preview: false },
   });
 }
 
@@ -95,7 +95,42 @@ describe("mergeViewCatalog", () => {
       catalog: [makeApp({ name: "@elizaos/plugin-dev", developerOnly: true })],
     };
     expect(merge(base)).toHaveLength(0);
-    expect(merge({ ...base, isDeveloperMode: true })).toHaveLength(2);
+    expect(
+      merge({ ...base, enabledKinds: { developer: true, preview: false } }),
+    ).toHaveLength(2);
+  });
+
+  it("hides preview entries unless preview mode is on", () => {
+    const base = {
+      views: [makeView("alpha", { viewKind: "preview" })],
+      catalog: [
+        makeApp({ name: "@elizaos/plugin-alpha-app", viewKind: "preview" }),
+      ],
+    };
+    // Off by default, even with developer mode on.
+    expect(merge(base)).toHaveLength(0);
+    expect(
+      merge({ ...base, enabledKinds: { developer: true, preview: false } }),
+    ).toHaveLength(0);
+    expect(
+      merge({ ...base, enabledKinds: { developer: false, preview: true } }),
+    ).toHaveLength(2);
+  });
+
+  it("always shows system and release views regardless of toggles", () => {
+    const entries = merge({
+      views: [
+        makeView("chat", {
+          viewKind: "system",
+          pluginName: "@elizaos/builtin",
+        }),
+        makeView("wallet", { viewKind: "release" }),
+      ],
+      enabledKinds: { developer: false, preview: false },
+    });
+    expect(entries.map((e) => e.id).sort()).toEqual(["chat", "wallet"]);
+    expect(entries.find((e) => e.id === "chat")?.viewKind).toBe("system");
+    expect(entries.find((e) => e.id === "wallet")?.viewKind).toBe("release");
   });
 
   it("respects visibleInManager:false and visibleInAppStore:false", () => {

--- a/packages/ui/src/hooks/view-catalog.ts
+++ b/packages/ui/src/hooks/view-catalog.ts
@@ -15,6 +15,11 @@
  * This module is the pure merge/dedupe so it can be unit-tested without React.
  */
 
+import {
+  type EnabledViewKinds,
+  isViewVisible,
+  type ViewKind,
+} from "@elizaos/core";
 import type { RegistryAppInfo } from "../api";
 import type { ViewModality } from "../platform/platform-guards";
 import type { ViewRegistryEntry } from "./useAvailableViews";
@@ -51,6 +56,8 @@ export interface ViewEntry {
   launchUrl?: string | null;
   builtin?: boolean;
   developerOnly?: boolean;
+  /** Four-tier visibility category resolved from the source declaration. */
+  viewKind?: ViewKind;
   /** Source records (one is set depending on `kind`). */
   view?: ViewRegistryEntry;
   app?: RegistryAppInfo;
@@ -78,6 +85,7 @@ function viewToEntry(view: ViewRegistryEntry): ViewEntry {
     path: view.path,
     builtin: view.builtin,
     developerOnly: view.developerOnly,
+    viewKind: view.viewKind,
     view,
   };
 }
@@ -103,6 +111,7 @@ function appToEntry(app: RegistryAppInfo, isActive: boolean): ViewEntry {
     launchType: app.launchType,
     launchUrl: app.launchUrl,
     developerOnly: app.developerOnly,
+    viewKind: app.viewKind,
     app,
   };
 }
@@ -121,9 +130,10 @@ export function mergeViewCatalog(input: {
   catalog: RegistryAppInfo[];
   installed: readonly InstalledAppLike[];
   activeModality: ViewModality;
-  isDeveloperMode: boolean;
+  /** Which view kinds the user/​build has enabled (system+release always on). */
+  enabledKinds: EnabledViewKinds;
 }): ViewEntry[] {
-  const { views, catalog, installed, activeModality, isDeveloperMode } = input;
+  const { views, catalog, installed, activeModality, enabledKinds } = input;
 
   const loadedPluginNames = new Set<string>();
   for (const v of views) {
@@ -132,7 +142,7 @@ export function mergeViewCatalog(input: {
 
   const viewEntries: ViewEntry[] = [];
   for (const v of views) {
-    if (v.developerOnly && !isDeveloperMode) continue;
+    if (!isViewVisible(v, enabledKinds)) continue;
     if (v.visibleInManager === false) continue;
     if ((v.viewType ?? "gui") !== activeModality) continue;
     viewEntries.push(viewToEntry(v));
@@ -144,7 +154,7 @@ export function mergeViewCatalog(input: {
   const seen = new Set(viewEntries.map((e) => e.id));
   const catalogEntries: ViewEntry[] = [];
   for (const app of catalog) {
-    if (app.developerOnly && !isDeveloperMode) continue;
+    if (!isViewVisible(app, enabledKinds)) continue;
     if (app.visibleInAppStore === false) continue;
     // Already shown as a loaded view → don't double-list as a catalog card.
     if (loadedPluginNames.has(app.name)) continue;

--- a/packages/ui/src/state/index.ts
+++ b/packages/ui/src/state/index.ts
@@ -23,4 +23,6 @@ export * from "./ui-preferences";
 export * from "./useApp";
 export * from "./useContentPack";
 export * from "./useDeveloperMode";
+export * from "./usePreviewMode";
+export * from "./useViewKinds";
 export * from "./useWalletState";

--- a/packages/ui/src/state/usePreviewMode.test.ts
+++ b/packages/ui/src/state/usePreviewMode.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isPreviewModeEnabled, setPreviewMode } from "./usePreviewMode";
+
+describe("usePreviewMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Reset the in-memory cache to the unset default.
+    setPreviewMode(false);
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to off", () => {
+    window.localStorage.removeItem("eliza:previewMode");
+    // The cached snapshot was seeded at module load; the default is false.
+    expect(isPreviewModeEnabled()).toBe(false);
+  });
+
+  it("persists an explicit choice to localStorage and reflects it", () => {
+    setPreviewMode(true);
+    expect(isPreviewModeEnabled()).toBe(true);
+    expect(window.localStorage.getItem("eliza:previewMode")).toBe("1");
+
+    setPreviewMode(false);
+    expect(isPreviewModeEnabled()).toBe(false);
+    expect(window.localStorage.getItem("eliza:previewMode")).toBe("0");
+  });
+});

--- a/packages/ui/src/state/usePreviewMode.ts
+++ b/packages/ui/src/state/usePreviewMode.ts
@@ -1,0 +1,98 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Preview Mode state — when on, the shell renders apps, widgets, nav tabs, and
+ * settings categorized as `preview` (unfinished / alpha / experimental views).
+ * Persists to localStorage so it survives reloads.
+ *
+ * Default: OFF on every build (dev and production alike). Preview views are
+ * always opt-in — unlike Developer Mode, they are never enabled by the build.
+ * The user's explicit choice (once made) wins on every platform/build.
+ *
+ * Mirrors {@link ./useDeveloperMode} so the two toggles behave identically
+ * apart from their default.
+ */
+
+const STORAGE_KEY = "eliza:previewMode";
+const ENABLED = "1";
+const DISABLED = "0";
+
+const listeners = new Set<() => void>();
+
+/** Build-default when the user hasn't chosen: always off. */
+function defaultPreviewMode(): boolean {
+  return false;
+}
+
+function readStorage(): boolean {
+  if (typeof window === "undefined") return defaultPreviewMode();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === ENABLED) return true;
+    if (raw === DISABLED) return false;
+    return defaultPreviewMode();
+  } catch {
+    return defaultPreviewMode();
+  }
+}
+
+/**
+ * Cached snapshot of the persisted value. `getSnapshot` runs on every render of
+ * every subscriber, so it must return a stable primitive without per-render
+ * localStorage I/O. The cache is seeded once and refreshed only when the value
+ * changes (via `setPreviewMode` or a cross-tab `storage` event).
+ */
+let cachedEnabled = readStorage();
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== null && event.key !== STORAGE_KEY) return;
+    const next = readStorage();
+    if (next === cachedEnabled) return;
+    cachedEnabled = next;
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+}
+
+function writeStorage(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, enabled ? ENABLED : DISABLED);
+  } catch {
+    // localStorage unavailable (private mode, quota, etc.) — fall through.
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): boolean {
+  return cachedEnabled;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function isPreviewModeEnabled(): boolean {
+  return cachedEnabled;
+}
+
+export function setPreviewMode(enabled: boolean): void {
+  writeStorage(enabled);
+  if (enabled === cachedEnabled) return;
+  cachedEnabled = enabled;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function useIsPreviewMode(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/ui/src/state/useViewKinds.ts
+++ b/packages/ui/src/state/useViewKinds.ts
@@ -1,0 +1,51 @@
+import {
+  type EnabledViewKinds,
+  isViewKindEnabled,
+  isViewVisible,
+  resolveViewKind,
+  type ViewKind,
+  type ViewKindBearer,
+} from "@elizaos/core";
+import { useMemo } from "react";
+import { useIsDeveloperMode } from "./useDeveloperMode";
+import { useIsPreviewMode } from "./usePreviewMode";
+
+/**
+ * The client is the authority on which view kinds are enabled: `system` and
+ * `release` are always on, while `developer` and `preview` follow the two
+ * Settings toggles (whose defaults depend on the build — dev vs production).
+ * The server returns every view with its `viewKind`; this hook tells the shell
+ * which ones to actually show.
+ *
+ * Use {@link useEnabledViewKinds} to get the toggle state and pass it to the
+ * pure `isViewVisible` / `isViewKindEnabled` helpers from `@elizaos/core`.
+ */
+export function useEnabledViewKinds(): EnabledViewKinds {
+  const developer = useIsDeveloperMode();
+  const preview = useIsPreviewMode();
+  return useMemo(() => ({ developer, preview }), [developer, preview]);
+}
+
+/**
+ * Returns a stable predicate that reports whether a view-like declaration is
+ * visible under the current toggles. Recomputed only when a toggle flips.
+ */
+export function useViewKindVisible(): (
+  decl: ViewKindBearer | null | undefined,
+) => boolean {
+  const enabled = useEnabledViewKinds();
+  return useMemo(
+    () => (decl: ViewKindBearer | null | undefined) =>
+      isViewVisible(decl, enabled),
+    [enabled],
+  );
+}
+
+export {
+  type EnabledViewKinds,
+  isViewKindEnabled,
+  isViewVisible,
+  resolveViewKind,
+  type ViewKind,
+  type ViewKindBearer,
+};

--- a/packages/ui/src/widgets/WidgetHost.tsx
+++ b/packages/ui/src/widgets/WidgetHost.tsx
@@ -11,10 +11,11 @@
  */
 
 import { Component, type ErrorInfo, type ReactNode, useMemo } from "react";
+import { isViewVisible } from "@elizaos/core";
 import { UiRenderer } from "../components/config-ui/ui-renderer";
 import type { ActivityEvent } from "../hooks/useActivityEvents";
 import { useAppSelectorShallow } from "../state";
-import { useIsDeveloperMode } from "../state/useDeveloperMode";
+import { useEnabledViewKinds } from "../state/useViewKinds";
 import { resolveWidgetsForSlot } from "./registry";
 import type { PluginWidgetDeclaration, WidgetProps, WidgetSlot } from "./types";
 import { WIDGET_UI_ACTION_EVENT } from "./WidgetHost.constants";
@@ -112,15 +113,15 @@ export function WidgetHost({
   filter,
 }: WidgetHostProps) {
   const plugins = useAppSelectorShallow((s) => s.plugins);
-  const developerModeEnabled = useIsDeveloperMode();
+  const enabledKinds = useEnabledViewKinds();
 
   const resolved = useMemo(() => {
     const all = resolveWidgetsForSlot(slot, plugins ?? []);
-    const gated = developerModeEnabled
-      ? all
-      : all.filter((entry) => entry.declaration.developerOnly !== true);
+    const gated = all.filter((entry) =>
+      isViewVisible(entry.declaration, enabledKinds),
+    );
     return filter ? gated.filter((entry) => filter(entry.declaration)) : gated;
-  }, [slot, plugins, filter, developerModeEnabled]);
+  }, [slot, plugins, filter, enabledKinds]);
 
   const pluginById = useMemo(() => {
     const map = new Map<string, (typeof plugins)[number]>();


### PR DESCRIPTION
## What & why

Sorts every view-like surface in the dashboard into one of **four kinds** and gates visibility by build + user preference, so we can ship public views to everyone while keeping dev tooling and unfinished work out of the way unless explicitly enabled.

| Kind | Meaning | Default visibility |
|------|---------|--------------------|
| `system` | Core shell views always present (chat, settings, character, tutorial, help) | **Always shown** (not toggleable) |
| `release` | Public, production-ready views for everyone | **Always shown** |
| `developer` | Dev tooling to verify the app works (logs, database, memories, trajectories) | **On in dev builds, off in prod** — Settings toggle |
| `preview` | Unfinished / alpha / experimental views | **Off everywhere** — Settings toggle |

This matches the requested behavior exactly: `bun run dev` shows **system + release + developer**; a production build shows **system + release** only; **developer** (in prod) and **preview** are opt-in via Settings.

## Design

- **`@elizaos/core`** owns the taxonomy: a new `view-kind.ts` exports the `ViewKind` type plus pure helpers `resolveViewKind`, `isViewKindEnabled`, `isViewVisible`, `isAlwaysOnViewKind`, and `VIEW_KIND_META`. Shared by the agent server and every front-end.
- A new optional `viewKind?: ViewKind` field is added to `ViewDeclaration`, `PluginAppNavTab`, `PluginApp`, `PluginWidgetDeclaration` (core), `RegistryAppInfo` (shared), `AppShellPageRegistration` + the client view/settings types (ui). The legacy `developerOnly: true` is preserved and resolves to `viewKind: "developer"`, so nothing breaks.
- **The client is the authority.** Only the client knows whether it is a dev or prod build and which Settings toggles are on. So `GET /api/views` now returns **every kind** annotated with `viewKind` (`listViews({ includeAllKinds: true })`), and the client filters. `system`/`release` always render; `developer`/`preview` follow `useEnabledViewKinds()` (backed by the existing `eliza:developerMode` localStorage key + a new `eliza:previewMode` key, default off).
- All visibility filters route through one predicate: the view manager (`mergeViewCatalog`, `ViewCatalog`), nav/route gating (`App.tsx`), the apps catalog (`filterAppsForCatalog`), and settings sections (`SettingsView`).
- **Settings** gains a *View visibility* group (in Backup & Reset / AdvancedSection) with **Developer views** + **Preview views** toggles and copy explaining the four kinds.
- Built-in views are categorized; mobile in-process views (vincent/companion/steward) are marked `release`.

## Verification

All run on this branch (rebased clean on `develop`):

**Typecheck** — `core`, `shared`, `agent`, `ui` all clean (`tsgo --noEmit`).

**Build** — `core`, `shared`, `agent`, `ui` all build to `dist` successfully.

**Tests**
- `packages/core` — `view-kind.test.ts`: **10 passed** (resolve precedence, always-on system/release, developer/preview gating, metadata).
- `packages/agent` — full `views` suite **109 passed**, incl. new `views-registry.kinds.test.ts` (**4 passed**: built-in categorization, `listViews` kind filtering — default = system+release, developerMode adds developer incl. legacy `developerOnly`, `includeAllKinds` surfaces preview) and the updated route contract test (`/api/views` returns all kinds with metadata).
- `packages/ui` — `view-catalog`, `usePreviewMode`, `ViewCatalog`, `helpers`, `SettingsView`: **37 passed**, incl. new cases: preview hidden unless preview-mode on (even with developer on), system/release always shown regardless of toggles, and `usePreviewMode` defaults off + persists to localStorage.

### Honest scope note
Verification here is automated (unit/integration tests across the web codebase + typecheck + build). The web client, the agent route contract, the apps/settings/view-manager filters, and the mobile registration path are all covered by tests. I did **not** capture a video or run on physical iOS/Android/desktop hardware in this environment — the mobile/desktop paths are exercised through the shared client code + the platform-aware route filtering (`isDynamicLoadingAllowed`) that the tests cover, but real-device screenshots/video should be captured during QA before release.

## Backward compatibility
`developerOnly` keeps working everywhere (maps to `developer`). No view loses visibility it had before: previously-`developerOnly` views stay developer-gated; everything else defaults to `release` (always shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
