### PR TITLE
refactor(ui): audit cleanup — dead dup, reuse numberOrNull, fix stray JSDoc

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1362,12 +1362,7 @@ ElizaClient.prototype.getCloudCredits = async function (this: ElizaClient) {
         this,
         "/api/v1/credits/balance",
       );
-      const balance =
-        typeof data?.balance === "number"
-          ? data.balance
-          : typeof data?.balance === "string"
-            ? Number(data.balance)
-            : null;
+      const balance = numberOrNull(data?.balance);
       return {
         connected: true,
         balance: Number.isFinite(balance) ? balance : null,
@@ -1420,12 +1415,7 @@ ElizaClient.prototype.getCloudBillingSummary = async function (
       typeof direct.pricing === "object" && direct.pricing !== null
         ? (direct.pricing as Record<string, unknown>)
         : {};
-    const balance =
-      typeof organization.creditBalance === "number"
-        ? organization.creditBalance
-        : typeof organization.creditBalance === "string"
-          ? Number(organization.creditBalance)
-          : null;
+    const balance = numberOrNull(organization.creditBalance);
     return {
       ...direct,
       balance: Number.isFinite(balance) ? balance : null,

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -43,15 +43,6 @@ import {
 
 const CONTEXT_ROUTING_METADATA_KEY = "__responseContext";
 
-/**
- * True when the active client base is an Eliza Cloud agent — either the
- * shared-runtime REST adapter (`/api/v1/eliza/agents/<id>`) or a dedicated agent
- * on its own `<id>.elizacloud.ai` subdomain. A chat-send 404 against such a base
- * is ambiguous: it can mean "the conversation was deleted" (recoverable by
- * recreating the conversation) OR "the agent itself was deleted / is
- * unreachable" — in which case recreating the conversation also 404s and the
- * user's message must NOT be silently dropped.
- */
 /** Derive the rendered-attachment kind for an optimistic bubble from its MIME. */
 function optimisticAttachmentKind(
   mimeType: string,
@@ -64,6 +55,15 @@ function optimisticAttachmentKind(
   return "image";
 }
 
+/**
+ * True when the active client base is an Eliza Cloud agent — either the
+ * shared-runtime REST adapter (`/api/v1/eliza/agents/<id>`) or a dedicated agent
+ * on its own `<id>.elizacloud.ai` subdomain. A chat-send 404 against such a base
+ * is ambiguous: it can mean "the conversation was deleted" (recoverable by
+ * recreating the conversation) OR "the agent itself was deleted / is
+ * unreachable" — in which case recreating the conversation also 404s and the
+ * user's message must NOT be silently dropped.
+ */
 function isCloudAgentBase(value: string | null | undefined): boolean {
   if (!value?.trim()) return false;
   // Either the shared-runtime REST adapter or a dedicated <id>.elizacloud.ai

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -44,14 +44,6 @@ export function normalizeDirectCloudSharedAgentApiBase(value: string): string {
   return stripTrailingSlash(url.toString());
 }
 
-export function isDirectCloudSharedAgentApiBase(value: string): boolean {
-  const normalized = normalizeDirectCloudSharedAgentApiBase(value);
-  const url = normalizeHttpUrl(normalized);
-  if (!url) return false;
-  const sharedPath = directSharedAgentPath(url.pathname);
-  return Boolean(sharedPath && !sharedPath.hasBridgeSuffix);
-}
-
 /**
  * Eliza Cloud control-plane hostnames. The bare origin (and the
  * `/api/v1/eliza/agents` collection) on any of these is NOT a per-agent base —


### PR DESCRIPTION
Cleanup sweep from the phone+cloud audit (all behavior-preserving, adversarially verified):

- **Delete dead export** `isDirectCloudSharedAgentApiBase` (`cloud-agent-base.ts`) — zero importers; its helper `normalizeDirectCloudSharedAgentApiBase` keeps its real callers, so only the dead near-duplicate goes (rule 2).
- **Reuse `numberOrNull()`** (`client-cloud.ts`) — replace two inline number-coercion blocks with the existing module-local helper (rule 2).
- **Reattach JSDoc** (`useChatSend.ts`) — the `isCloudAgentBase` doc had drifted above `optimisticAttachmentKind`; move it back to the function it documents.

`bun run --cwd packages/ui typecheck` clean. Part of the broader audit (tracker #8434); the larger items (host-only settings gate, security token scrub, composer cloud-guard) are lane-split there.