### PR TITLE
feat(attachments): PR1 — additive Media metadata + SSRF-guarded, fault-isolated attachment processing (#8876)

### DIFF
--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContentType, type Media } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+
+// Network-free: the SSRF-guarded remote fetcher is mocked so the lane performs
+// ZERO real outbound requests. importActual preserves the module's other exports
+// (the runtime graph imports more than fetchRemoteMedia from here).
+const fetchRemoteMedia = vi.fn();
+vi.mock("../media/fetch", async (importActual) => ({
+	...(await importActual<typeof import("../media/fetch")>()),
+	fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+const { DefaultMessageService } = await import("./message");
+
+function mockRuntime(
+	fetchImpl?: (input: unknown) => Promise<unknown>,
+): IAgentRuntime {
+	return {
+		logger: {
+			debug: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			error: vi.fn(),
+		},
+		getSetting: vi.fn(() => undefined),
+		useModel: vi.fn(),
+		fetch: fetchImpl,
+	} as unknown as IAgentRuntime;
+}
+
+describe("DefaultMessageService.processAttachments", () => {
+	beforeEach(() => {
+		fetchRemoteMedia.mockReset();
+	});
+
+	it("returns [] for no attachments", async () => {
+		const svc = new DefaultMessageService();
+		expect(await svc.processAttachments(mockRuntime(), [])).toEqual([]);
+	});
+
+	it("isolates a failing attachment, keeping the others, and never throws", async () => {
+		// Remote image enrichment fails (e.g. SSRF-blocked / unreachable host).
+		fetchRemoteMedia.mockRejectedValue(new Error("SSRF blocked"));
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime();
+
+		const badImage: Media = {
+			id: "a",
+			url: "http://169.254.169.254/secret.png",
+			contentType: ContentType.IMAGE,
+		};
+		// A doc that already has text skips the fetch entirely → passes through.
+		const okDoc: Media = {
+			id: "b",
+			url: "http://example.com/readme.txt",
+			contentType: ContentType.DOCUMENT,
+			text: "already extracted",
+		};
+
+		const out = await svc.processAttachments(runtime, [badImage, okDoc]);
+
+		expect(out).toHaveLength(2);
+		// Failed remote attachment: un-enriched, flagged ephemeral, URL preserved.
+		expect(out[0].description).toBeUndefined();
+		expect(out[0].ephemeral).toBe(true);
+		expect(out[0].url).toBe(badImage.url);
+		// Untouched sibling still carries its text.
+		expect(out[1].text).toBe("already extracted");
+		// The vision model was never invoked for the blocked URL.
+		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+
+	it("routes a remote attachment fetch through the SSRF-guarded fetcher", async () => {
+		fetchRemoteMedia.mockRejectedValue(new Error("blocked"));
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime();
+		await svc.processAttachments(runtime, [
+			{
+				id: "a",
+				url: "http://10.0.0.5/internal.pdf",
+				contentType: ContentType.DOCUMENT,
+			},
+		]);
+		expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMedia.mock.calls[0][0]).toMatchObject({
+			url: "http://10.0.0.5/internal.pdf",
+		});
+	});
+
+	it("extracts text from a local plain-text document via the trusted local fetch", async () => {
+		const bytes = Buffer.from("hello from a local file", "utf8");
+		const localFetch = vi.fn(async () => ({
+			ok: true,
+			arrayBuffer: async () =>
+				bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.length),
+			headers: { get: () => "text/plain; charset=utf-8" },
+		}));
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "doc",
+				url: "/api/media/abc.txt",
+				contentType: ContentType.DOCUMENT,
+			},
+		]);
+
+		expect(out[0].text).toBe("hello from a local file");
+		// Local URL → trusted runtime fetch, NOT the SSRF remote fetcher.
+		expect(fetchRemoteMedia).not.toHaveBeenCalled();
+		expect(localFetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -30,6 +30,7 @@ import {
 } from "../inference-timing";
 import { logger } from "../logger";
 import { describeImageCached } from "../media";
+import { fetchRemoteMedia } from "../media/fetch";
 import { imageDescriptionTemplate, messageHandlerTemplate } from "../prompts";
 import { checkSenderRole } from "../roles";
 import {
@@ -1349,6 +1350,13 @@ type MediaWithInlineData = Media & {
 	_data?: unknown;
 	_mimeType?: unknown;
 };
+
+/**
+ * Hard cap on bytes fetched while enriching a single attachment (description /
+ * transcription / text extraction). Bounds memory and is enforced by the
+ * SSRF-guarded fetcher for remote URLs and explicitly for local ones.
+ */
+const ATTACHMENT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
 
 function sanitizeAttachmentsForStorage(
 	attachments: Media[] | undefined,
@@ -11237,221 +11245,270 @@ export class DefaultMessageService implements IMessageService {
 					? attachment.url
 					: getLocalServerUrl(attachment.url);
 
-				// Only process images that don't already have descriptions
-				if (
-					attachment.contentType === ContentType.IMAGE &&
-					!attachment.description
-				) {
-					// Skip image analysis when vision / image-description is explicitly
-					// disabled (e.g. the user toggled the Vision capability off).
-					const disableImageDesc = runtime.getSetting(
-						"DISABLE_IMAGE_DESCRIPTION",
-					);
-					if (disableImageDesc === true || disableImageDesc === "true") {
-						return processedAttachment;
-					}
-
-					runtime.logger.debug(
-						{ src: "service:message", imageUrl: attachment.url },
-						"Generating image description",
-					);
-
-					let imageUrl = url;
-					const runtimeFetch = runtime.fetch ?? globalThis.fetch;
-					const inlineData = attachment as MediaWithInlineData;
-
+				try {
+					// Only process images that don't already have descriptions
 					if (
-						typeof inlineData._data === "string" &&
-						inlineData._data.trim() &&
-						typeof inlineData._mimeType === "string" &&
-						inlineData._mimeType.trim()
+						attachment.contentType === ContentType.IMAGE &&
+						!attachment.description
 					) {
-						imageUrl = `data:${inlineData._mimeType};base64,${inlineData._data}`;
-					} else if (!isRemote) {
-						// Convert local/internal media to base64
-						const res = await runtimeFetch(url);
-						if (!res.ok)
-							throw new Error(`Failed to fetch image: ${res.statusText}`);
-
-						const arrayBuffer = await res.arrayBuffer();
-						const buffer = Buffer.from(arrayBuffer);
-						const contentType =
-							res.headers.get("content-type") || "application/octet-stream";
-						imageUrl = `data:${contentType};base64,${buffer.toString("base64")}`;
-					}
-
-					// Describe via the shared content-addressed cache: identical image
-					// bytes reuse one stored description across messages and across the
-					// other describe paths (read action, basic-capabilities helper)
-					// instead of re-invoking the vision model every turn.
-					const resolvedImagePrompt = resolveOptimizedPromptForRuntime(
-						runtime,
-						"media_description",
-						imageDescriptionTemplate,
-					);
-					const described = await describeImageCached(
-						runtime,
-						imageUrl,
-						resolvedImagePrompt,
-					);
-					if (described) {
-						processedAttachment.description = described.description;
-						processedAttachment.title = described.title || "Image";
-						processedAttachment.text = described.text;
-						runtime.logger.debug(
-							{
-								src: "service:message",
-								descriptionPreview: described.description?.substring(0, 100),
-							},
-							"Generated image description",
+						// Skip image analysis when vision / image-description is explicitly
+						// disabled (e.g. the user toggled the Vision capability off).
+						const disableImageDesc = runtime.getSetting(
+							"DISABLE_IMAGE_DESCRIPTION",
 						);
-					} else {
-						runtime.logger.warn(
-							{ src: "service:message" },
-							"Image description unavailable for attachment",
-						);
-					}
-				} else if (
-					attachment.contentType === ContentType.DOCUMENT &&
-					!attachment.text
-				) {
-					const docFetch = runtime.fetch ?? globalThis.fetch;
-					const res = await docFetch(url);
-					if (!res.ok)
-						throw new Error(`Failed to fetch document: ${res.statusText}`);
-
-					const contentType = res.headers.get("content-type") || "";
-					const isPlainText = contentType.startsWith("text/plain");
-
-					if (isPlainText) {
-						runtime.logger.debug(
-							{ src: "service:message", documentUrl: attachment.url },
-							"Processing plain text document",
-						);
-
-						const textContent = await res.text();
-						processedAttachment.text = textContent;
-						processedAttachment.title =
-							processedAttachment.title || "Text File";
-
-						runtime.logger.debug(
-							{
-								src: "service:message",
-								textPreview: processedAttachment.text?.substring(0, 100),
-							},
-							"Extracted text content",
-						);
-					} else {
-						runtime.logger.warn(
-							{ src: "service:message", contentType },
-							"Skipping non-plain-text document",
-						);
-					}
-				} else if (
-					attachment.contentType === ContentType.AUDIO &&
-					!attachment.text
-				) {
-					runtime.logger.debug(
-						{ src: "service:message", audioUrl: attachment.url },
-						"Transcribing audio attachment",
-					);
-
-					try {
-						let transcriptionInput: string | Buffer = url;
-						const audioFetch = runtime.fetch ?? globalThis.fetch;
-
-						// For local/internal URLs, fetch the audio as a buffer
-						if (!isRemote) {
-							const res = await audioFetch(url);
-							if (!res.ok)
-								throw new Error(`Failed to fetch audio: ${res.statusText}`);
-							const arrayBuffer = await res.arrayBuffer();
-							transcriptionInput = Buffer.from(arrayBuffer);
+						if (disableImageDesc === true || disableImageDesc === "true") {
+							return processedAttachment;
 						}
 
-						const transcript = await runtime.useModel(
-							ModelType.TRANSCRIPTION,
-							transcriptionInput,
+						runtime.logger.debug(
+							{ src: "service:message", imageUrl: attachment.url },
+							"Generating image description",
 						);
 
-						if (typeof transcript === "string" && transcript.trim()) {
-							processedAttachment.text = transcript.trim();
-							processedAttachment.title = processedAttachment.title || "Audio";
-							processedAttachment.description = `Transcript: ${transcript.trim()}`;
+						let imageUrl = url;
+						const inlineData = attachment as MediaWithInlineData;
+
+						if (
+							typeof inlineData._data === "string" &&
+							inlineData._data.trim() &&
+							typeof inlineData._mimeType === "string" &&
+							inlineData._mimeType.trim()
+						) {
+							imageUrl = `data:${inlineData._mimeType};base64,${inlineData._data}`;
+						} else {
+							// Inline the bytes as a data URL so the vision model never fetches
+							// an attacker-controlled URL itself. Remote bytes go through the
+							// SSRF-guarded fetcher (blocks private/loopback hosts); local
+							// media-store URLs use the trusted runtime fetch.
+							const { buffer, contentType } = await this.fetchAttachmentBytes(
+								runtime,
+								attachment.url,
+								url,
+								isRemote,
+							);
+							imageUrl = `data:${contentType};base64,${buffer.toString("base64")}`;
+						}
+
+						// Describe via the shared content-addressed cache: identical image
+						// bytes reuse one stored description across messages and across the
+						// other describe paths (read action, basic-capabilities helper)
+						// instead of re-invoking the vision model every turn.
+						const resolvedImagePrompt = resolveOptimizedPromptForRuntime(
+							runtime,
+							"media_description",
+							imageDescriptionTemplate,
+						);
+						const described = await describeImageCached(
+							runtime,
+							imageUrl,
+							resolvedImagePrompt,
+						);
+						if (described) {
+							processedAttachment.description = described.description;
+							processedAttachment.title = described.title || "Image";
+							processedAttachment.text = described.text;
+							runtime.logger.debug(
+								{
+									src: "service:message",
+									descriptionPreview: described.description?.substring(0, 100),
+								},
+								"Generated image description",
+							);
+						} else {
+							runtime.logger.warn(
+								{ src: "service:message" },
+								"Image description unavailable for attachment",
+							);
+						}
+					} else if (
+						attachment.contentType === ContentType.DOCUMENT &&
+						!attachment.text
+					) {
+						const { buffer, contentType } = await this.fetchAttachmentBytes(
+							runtime,
+							attachment.url,
+							url,
+							isRemote,
+						);
+						const isPlainText = contentType.startsWith("text/plain");
+
+						if (isPlainText) {
+							runtime.logger.debug(
+								{ src: "service:message", documentUrl: attachment.url },
+								"Processing plain text document",
+							);
+
+							const textContent = buffer.toString("utf8");
+							processedAttachment.text = textContent;
+							processedAttachment.title =
+								processedAttachment.title || "Text File";
 
 							runtime.logger.debug(
 								{
 									src: "service:message",
-									transcriptPreview: processedAttachment.text?.substring(
-										0,
-										100,
-									),
+									textPreview: processedAttachment.text?.substring(0, 100),
 								},
-								"Transcribed audio attachment",
+								"Extracted text content",
+							);
+						} else {
+							runtime.logger.warn(
+								{ src: "service:message", contentType },
+								"Skipping non-plain-text document",
 							);
 						}
-					} catch (err) {
-						runtime.logger.warn(
-							{ src: "service:message", err },
-							"Audio transcription failed, continuing without transcript",
+					} else if (
+						attachment.contentType === ContentType.AUDIO &&
+						!attachment.text
+					) {
+						runtime.logger.debug(
+							{ src: "service:message", audioUrl: attachment.url },
+							"Transcribing audio attachment",
 						);
+
+						try {
+							// Fetch the bytes (remote → SSRF-guarded, size-capped) and pass
+							// the buffer to the transcription model so it never fetches an
+							// attacker-controlled URL itself.
+							const { buffer } = await this.fetchAttachmentBytes(
+								runtime,
+								attachment.url,
+								url,
+								isRemote,
+							);
+
+							const transcript = await runtime.useModel(
+								ModelType.TRANSCRIPTION,
+								buffer,
+							);
+
+							if (typeof transcript === "string" && transcript.trim()) {
+								processedAttachment.text = transcript.trim();
+								processedAttachment.title =
+									processedAttachment.title || "Audio";
+								processedAttachment.description = `Transcript: ${transcript.trim()}`;
+
+								runtime.logger.debug(
+									{
+										src: "service:message",
+										transcriptPreview: processedAttachment.text?.substring(
+											0,
+											100,
+										),
+									},
+									"Transcribed audio attachment",
+								);
+							}
+						} catch (err) {
+							runtime.logger.warn(
+								{ src: "service:message", err },
+								"Audio transcription failed, continuing without transcript",
+							);
+						}
+					} else if (
+						attachment.contentType === ContentType.VIDEO &&
+						!attachment.text
+					) {
+						runtime.logger.debug(
+							{ src: "service:message", videoUrl: attachment.url },
+							"Transcribing video attachment",
+						);
+
+						try {
+							// Fetch the bytes (remote → SSRF-guarded, size-capped) and pass
+							// the buffer to the transcription model so it never fetches an
+							// attacker-controlled URL itself.
+							const { buffer } = await this.fetchAttachmentBytes(
+								runtime,
+								attachment.url,
+								url,
+								isRemote,
+							);
+
+							const transcript = await runtime.useModel(
+								ModelType.TRANSCRIPTION,
+								buffer,
+							);
+
+							if (typeof transcript === "string" && transcript.trim()) {
+								processedAttachment.text = transcript.trim();
+								processedAttachment.title =
+									processedAttachment.title || "Video";
+								processedAttachment.description = `Transcript: ${transcript.trim()}`;
+
+								runtime.logger.debug(
+									{
+										src: "service:message",
+										transcriptPreview: processedAttachment.text?.substring(
+											0,
+											100,
+										),
+									},
+									"Transcribed video attachment",
+								);
+							}
+						} catch (err) {
+							runtime.logger.warn(
+								{ src: "service:message", err },
+								"Video transcription failed, continuing without transcript",
+							);
+						}
 					}
-				} else if (
-					attachment.contentType === ContentType.VIDEO &&
-					!attachment.text
-				) {
-					runtime.logger.debug(
-						{ src: "service:message", videoUrl: attachment.url },
-						"Transcribing video attachment",
+
+					return processedAttachment;
+				} catch (err) {
+					// One bad attachment must never drop the others or the message text.
+					// Degrade to the un-enriched attachment (marking remote ones
+					// ephemeral so the UI can offer a retry) and keep processing.
+					runtime.logger.warn(
+						{ src: "service:message", url: attachment.url, err },
+						"Attachment processing failed; keeping un-enriched attachment",
 					);
-
-					try {
-						let transcriptionInput: string | Buffer = url;
-						const videoFetch = runtime.fetch ?? globalThis.fetch;
-
-						// For local/internal URLs, fetch the video as a buffer
-						if (!isRemote) {
-							const res = await videoFetch(url);
-							if (!res.ok)
-								throw new Error(`Failed to fetch video: ${res.statusText}`);
-							const arrayBuffer = await res.arrayBuffer();
-							transcriptionInput = Buffer.from(arrayBuffer);
-						}
-
-						const transcript = await runtime.useModel(
-							ModelType.TRANSCRIPTION,
-							transcriptionInput,
-						);
-
-						if (typeof transcript === "string" && transcript.trim()) {
-							processedAttachment.text = transcript.trim();
-							processedAttachment.title = processedAttachment.title || "Video";
-							processedAttachment.description = `Transcript: ${transcript.trim()}`;
-
-							runtime.logger.debug(
-								{
-									src: "service:message",
-									transcriptPreview: processedAttachment.text?.substring(
-										0,
-										100,
-									),
-								},
-								"Transcribed video attachment",
-							);
-						}
-					} catch (err) {
-						runtime.logger.warn(
-							{ src: "service:message", err },
-							"Video transcription failed, continuing without transcript",
-						);
-					}
+					return {
+						...attachment,
+						ephemeral: isRemote ? true : attachment.ephemeral,
+					};
 				}
-
-				return processedAttachment;
 			}),
 		);
 
 		return processedAttachments;
+	}
+
+	/**
+	 * Fetch an attachment's bytes for enrichment with a hard size cap. Remote
+	 * (attacker-influenceable) URLs go through the SSRF-guarded fetcher, which
+	 * blocks private/loopback/link-local hosts; trusted local media-store URLs
+	 * (built from a path-validated relative URL) use the runtime fetch. This is
+	 * the ONLY place a raw fetch is used during attachment enrichment.
+	 */
+	private async fetchAttachmentBytes(
+		runtime: IAgentRuntime,
+		rawUrl: string,
+		resolvedLocalUrl: string,
+		isRemote: boolean,
+	): Promise<{ buffer: Buffer; contentType: string }> {
+		if (isRemote) {
+			const { buffer, contentType } = await fetchRemoteMedia({
+				url: rawUrl,
+				maxBytes: ATTACHMENT_FETCH_MAX_BYTES,
+			});
+			return {
+				buffer,
+				contentType: contentType ?? "application/octet-stream",
+			};
+		}
+		const runtimeFetch = runtime.fetch ?? globalThis.fetch;
+		const res = await runtimeFetch(resolvedLocalUrl);
+		if (!res.ok) {
+			throw new Error(`Failed to fetch attachment: ${res.statusText}`);
+		}
+		const buffer = Buffer.from(await res.arrayBuffer());
+		if (buffer.length > ATTACHMENT_FETCH_MAX_BYTES) {
+			throw new Error(`Attachment exceeds ${ATTACHMENT_FETCH_MAX_BYTES} bytes`);
+		}
+		const contentType =
+			res.headers.get("content-type") || "application/octet-stream";
+		return { buffer, contentType };
 	}
 
 	private resolveRecentMessagesForFailureReply(

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -219,6 +219,50 @@ export interface Media {
 	 * Generated client-side on upload; absent for small/remote/generated media.
 	 */
 	thumbnailUrl?: string;
+
+	// --- Additive metadata widening (#8876) ----------------------------------
+	// All optional and backward-compatible: `Media` is serialized inside
+	// `memories.content` (jsonb) and `central_messages.content` (text), so adding
+	// optional keys is a pure type change with zero at-rest migration. Fine-grained
+	// kind (pdf/code/transcript/3d) is derived from `mimeType` at read time — the
+	// coarse `ContentType` enum stays frozen and append-only.
+
+	/** Authoritative IANA media type of the bytes (e.g. `application/pdf`). */
+	mimeType?: string;
+
+	/** Original filename as provided by the user/connector/generator. */
+	filename?: string;
+
+	/** Byte size of the original media. */
+	size?: number;
+
+	/**
+	 * Lowercase hex sha256 of the bytes — the content-address that matches the
+	 * served `/api/media/<sha256>.<ext>` URL. Enables dedup + Files-view linkage.
+	 */
+	checksum?: string;
+
+	/** Pixel width of an image/video. */
+	width?: number;
+
+	/** Pixel height of an image/video. */
+	height?: number;
+
+	/** Duration in seconds for audio/video. */
+	duration?: number;
+
+	/** Page count for paginated documents (e.g. a PDF). */
+	pageCount?: number;
+
+	/** Creation timestamp (ms since epoch). */
+	createdAt?: number;
+
+	/**
+	 * True when `url` still points at an external/ephemeral source we could not
+	 * rehost into managed storage (e.g. egress unavailable on a network-locked
+	 * device). Surfaces a retry affordance instead of a permanently broken tile.
+	 */
+	ephemeral?: boolean;
 }
 
 export const ContentType = {


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1). **PR1 — Media type widening + inbound enrichment hardening.** Additive only; no at-rest migration; `ContentType` stays frozen.

## What this does
**Additive `Media` widening** (`packages/core/src/types/primitives.ts`)
- New optional fields: `mimeType`, `filename`, `size`, `checksum` (sha256 / content-address), `width`, `height`, `duration`, `pageCount`, `createdAt`, and `ephemeral` (external/unfetched source → UI retry affordance instead of a permanently broken tile).
- `Media` is serialized inside `memories.content` (jsonb) and `central_messages.content` (text), so adding optional keys is a pure type change with **zero migration**. `sanitizeAttachmentsForStorage` already preserves them (it strips only `_data`/`_mimeType`). Fine-grained kind (pdf/code/transcript/3d) is derived from `mimeType` at read time.

**SSRF-guarded, fault-isolated `processAttachments`** (`packages/core/src/services/message.ts`)
- All byte fetches now go through one `fetchAttachmentBytes` helper: **remote** (attacker-influenceable) URLs use the existing SSRF-guarded `media/fetch` (blocks private/loopback/link-local) with a 50 MB cap; **local** media-store URLs use the trusted runtime fetch. The scattered raw `runtime.fetch ?? globalThis.fetch` path is gone.
- Remote images/audio/video are now fetched by us and handed to the model as bytes / a data URL, so the vision/transcription model never fetches an attacker-controlled URL itself (closes a provider-side SSRF vector).
- Each attachment is wrapped in its own try/catch — one bad attachment (SSRF-blocked / oversized / unreachable) degrades to its un-enriched form (marked `ephemeral`) instead of rejecting `Promise.all` and killing the whole inbound turn.

## Tests / verification
- New network-free test (`message.processAttachments.test.ts`, `fetchRemoteMedia` mocked): failure isolation, SSRF routing, `ephemeral` marking, local plain-text extraction.
- `core` typecheck + Biome green; existing attachments-provider + messages-format tests pass.

## Acceptance criteria covered (from #8876)
- ✅ Every server-side attachment byte fetch goes through the SSRF guard; a request targeting a private/loopback host is blocked; the raw `runtime.fetch/globalThis.fetch` path no longer exists in `processAttachments`.
- ✅ One malformed attachment does not drop the others or the message text.
- ✅ Additive `Media` widening only; `ContentType` frozen; no new DB table/entity.
- ✅ `ephemeral` state present for offline-degradation UX.

> Note: the `mb` line-number references in the issue were from an earlier tree; the actual call sites are `processAttachments` image/document/audio/video branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)