### PR TITLE
fix(telegram): PR2 — never drop text on attachments, degrade unknown types, ingest inbound voice/audio/video (#8876)

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -240,14 +240,20 @@ describe("MessageManager malformed payload handling", () => {
     );
   });
 
-  it("awaits attachment send failures instead of dropping rejected promises", async () => {
+  it("degrades an unknown attachment content type to a document send (and still awaits failures)", async () => {
     const { manager } = createManager();
+    const sendDocument = vi.fn(async () => {
+      throw new Error("telegram unavailable");
+    });
 
+    // Unknown/absent content types no longer throw synchronously (which, inside
+    // Promise.all, aborted the whole reply). They degrade to a document upload;
+    // the underlying send failure is still awaited and propagated.
     await expect(
       manager.sendMessageInChunks(
         {
           chat: { id: 123 },
-          telegram: {},
+          telegram: { sendDocument },
         } as never,
         {
           text: "",
@@ -260,7 +266,102 @@ describe("MessageManager malformed payload handling", () => {
           ],
         } as never,
       ),
-    ).rejects.toThrow("Unsupported Telegram attachment content type");
+    ).rejects.toThrow("telegram unavailable");
+    expect(sendDocument).toHaveBeenCalled();
+  });
+
+  it("never drops the agent's text when sending an attachment", async () => {
+    const { manager } = createManager();
+    const sendPhoto = vi.fn(async () => undefined);
+    const sendChatAction = vi.fn(async () => undefined);
+    const sendMessage = vi.fn(async (chatId: number, text: string) => ({
+      message_id: 1,
+      date: 1,
+      text,
+      chat: { id: chatId, type: "private" },
+    }));
+
+    const sent = await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: { sendPhoto, sendMessage, sendChatAction },
+      } as never,
+      {
+        text: "here is your image",
+        attachments: [
+          {
+            id: "p1",
+            url: "https://files.test/p.png",
+            contentType: "image/png",
+          },
+        ],
+      } as never,
+    );
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1); // media sent
+    expect(sendMessage).toHaveBeenCalledTimes(1); // prose NOT dropped
+    expect(sent).toHaveLength(1);
+    expect(String(sendMessage.mock.calls[0][1])).toContain(
+      "here is your image",
+    );
+  });
+
+  it("does not post an empty trailing message for an attachment-only reply", async () => {
+    const { manager } = createManager();
+    const sendPhoto = vi.fn(async () => undefined);
+    const sendMessage = vi.fn();
+    const sendChatAction = vi.fn(async () => undefined);
+
+    const sent = await manager.sendMessageInChunks(
+      {
+        chat: { id: 123 },
+        telegram: { sendPhoto, sendMessage, sendChatAction },
+      } as never,
+      {
+        text: "",
+        attachments: [
+          {
+            id: "p1",
+            url: "https://files.test/p.png",
+            contentType: "image/png",
+          },
+        ],
+      } as never,
+    );
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sent).toEqual([]);
+  });
+
+  it("ingests an inbound voice message as an AUDIO attachment", async () => {
+    const getFileLink = vi.fn(
+      async () => new URL("https://files.test/voice.ogg"),
+    );
+    const manager = new MessageManager(
+      { telegram: { getFileLink } } as never,
+      { agentId: "agent-1" } as never,
+    );
+
+    const result = await manager.processMessage({
+      message_id: 1,
+      date: 1,
+      chat: { id: 123, type: "private" },
+      voice: {
+        file_id: "v1",
+        file_unique_id: "u1",
+        duration: 3,
+        mime_type: "audio/ogg",
+      },
+    } as never);
+
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        id: "v1",
+        url: "https://files.test/voice.ogg",
+        contentType: "audio",
+      }),
+    ]);
   });
 
   it("ignores reaction updates with empty reaction arrays", async () => {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import {
   ChannelType,
   type Content,
+  type ContentType,
   createUniqueUuid,
   decodeCallback,
   EventType,
@@ -63,6 +64,18 @@ export enum MediaType {
   DOCUMENT = "document",
   AUDIO = "audio",
   ANIMATION = "animation",
+}
+
+/**
+ * Map a Telegram file's MIME type to the coarse core ContentType. Returns the
+ * literal string values (not the `ContentType` enum object) so this stays a
+ * pure, dependency-free mapping — `ContentType` is imported as a type only.
+ */
+function contentTypeForMime(mime?: string): ContentType {
+  if (mime?.startsWith("image/")) return "image";
+  if (mime?.startsWith("video/")) return "video";
+  if (mime?.startsWith("audio/")) return "audio";
+  return "document";
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
@@ -448,6 +461,7 @@ export class MessageManager {
             source: document.mime_type?.startsWith("application/pdf")
               ? "PDF"
               : "Document",
+            contentType: contentTypeForMime(document.mime_type),
             description: documentInfo.formattedDescription,
             text: fullText,
           });
@@ -504,6 +518,7 @@ export class MessageManager {
             url: fileLink.toString(),
             title: "Image Attachment",
             source: "Image",
+            contentType: "image",
             description: imageInfo.description,
             text: imageInfo.description,
           });
@@ -518,6 +533,85 @@ export class MessageManager {
           );
         }
       }
+    }
+
+    // Voice / audio / video / animation / sticker — previously silently dropped.
+    // Setting contentType lets processAttachments transcribe audio/video and
+    // lets the attachment round-trip safely back out to any connector.
+    const pushFileAttachment = async (
+      fileId: string,
+      contentType: ContentType,
+      title: string,
+      source: string,
+    ): Promise<void> => {
+      try {
+        const fileLink = await this.bot.telegram.getFileLink(fileId);
+        attachments.push({
+          id: fileId,
+          url: fileLink.toString(),
+          title,
+          source,
+          contentType,
+        });
+      } catch (error) {
+        logger.error(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          `Error attaching ${source}`,
+        );
+      }
+    };
+
+    if ("voice" in message && message.voice) {
+      await pushFileAttachment(
+        message.voice.file_id,
+        "audio",
+        "Voice Message",
+        "Voice",
+      );
+    }
+    if ("audio" in message && message.audio) {
+      await pushFileAttachment(
+        message.audio.file_id,
+        "audio",
+        message.audio.title || message.audio.file_name || "Audio",
+        "Audio",
+      );
+    }
+    if ("video" in message && message.video) {
+      await pushFileAttachment(
+        message.video.file_id,
+        "video",
+        "Video",
+        "Video",
+      );
+    }
+    if ("video_note" in message && message.video_note) {
+      await pushFileAttachment(
+        message.video_note.file_id,
+        "video",
+        "Video Note",
+        "Video",
+      );
+    }
+    if ("animation" in message && message.animation) {
+      await pushFileAttachment(
+        message.animation.file_id,
+        "video",
+        "Animation",
+        "Animation",
+      );
+    }
+    if ("sticker" in message && message.sticker) {
+      await pushFileAttachment(
+        message.sticker.file_id,
+        "image",
+        "Sticker",
+        "Sticker",
+      );
     }
 
     logger.debug(
@@ -631,9 +725,18 @@ export class MessageManager {
           }
 
           if (!mediaType) {
-            throw new Error(
-              `Unsupported Telegram attachment content type: ${attachment.contentType}`,
+            // Degrade unknown/absent content types to a document upload instead
+            // of throwing — a throw inside Promise.all aborts the whole reply
+            // and silently drops the agent's text.
+            logger.warn(
+              {
+                src: "plugin:telegram",
+                agentId: this.runtime.agentId,
+                contentType: attachment.contentType,
+              },
+              "Unknown Telegram attachment content type; sending as document",
             );
+            mediaType = MediaType.DOCUMENT;
           }
 
           await this.sendMedia(
@@ -644,8 +747,11 @@ export class MessageManager {
           );
         }),
       );
-      return [];
-    } else {
+      // Fall through to the text path below so an attachment reply never drops
+      // the agent's accompanying prose (sent as a follow-up message).
+    }
+
+    {
       // Project any interactive blocks (choices, task cards, …) the agent
       // embedded in the text onto native inline keyboards, and send the prose
       // with the markers stripped. Plain replies pass through unchanged.
@@ -661,6 +767,12 @@ export class MessageManager {
           : hasKeyboardRows
             ? INTERACTION_ONLY_FALLBACK_TEXT
             : "";
+      // Nothing textual to send (e.g. an attachments-only reply that already
+      // dispatched its media above) — don't post an empty trailing message.
+      if (textToSend.trim().length === 0 && !hasKeyboardRows) {
+        return sentMessages;
+      }
+
       const chunks = this.splitMessage(textToSend);
 
       if (!ctx.chat) {
@@ -752,19 +864,23 @@ export class MessageManager {
   ): Promise<void> {
     try {
       const isUrl = /^(http|https):\/\//.test(mediaPath);
-      const sendFunctionMap: Record<MediaType, TelegramMediaSender> = {
-        [MediaType.PHOTO]: ctx.telegram.sendPhoto.bind(ctx.telegram),
-        [MediaType.VIDEO]: ctx.telegram.sendVideo.bind(ctx.telegram),
-        [MediaType.DOCUMENT]: ctx.telegram.sendDocument.bind(ctx.telegram),
-        [MediaType.AUDIO]: ctx.telegram.sendAudio.bind(ctx.telegram),
-        [MediaType.ANIMATION]: ctx.telegram.sendAnimation.bind(ctx.telegram),
+      // Look up the raw sender lazily and bind only the one we need. Building
+      // the full map up front and `.bind`-ing every entry would crash with
+      // "Cannot read properties of undefined" if the Telegram client is missing
+      // any single sender, aborting an unrelated media send.
+      const rawSenders: Record<MediaType, TelegramMediaSender | undefined> = {
+        [MediaType.PHOTO]: ctx.telegram.sendPhoto,
+        [MediaType.VIDEO]: ctx.telegram.sendVideo,
+        [MediaType.DOCUMENT]: ctx.telegram.sendDocument,
+        [MediaType.AUDIO]: ctx.telegram.sendAudio,
+        [MediaType.ANIMATION]: ctx.telegram.sendAnimation,
       };
 
-      const sendFunction = sendFunctionMap[type];
-
-      if (!sendFunction) {
+      const rawSend = rawSenders[type];
+      if (typeof rawSend !== "function") {
         throw new Error(`Unsupported media type: ${type}`);
       }
+      const sendFunction = rawSend.bind(ctx.telegram);
 
       if (!ctx.chat) {
         throw new Error("sendMedia: ctx.chat is undefined");


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1). **PR2 — connector attachment fixes (Telegram).** Independent of the other PRs (uses only the base `Media.contentType`).

## Outbound (`sendMessageInChunks` / `sendMedia`)
- **Never drop the agent's text.** Previously, when a reply had attachments the method sent only the media and `return []`-ed — the prose was silently dropped. Now it dispatches the media and falls through to send the text as a follow-up message, with an empty-reply guard so an attachment-only reply doesn't post a blank trailing message.
- **Degrade unknown types instead of throwing.** An unknown/absent `contentType` previously `throw`-ew inside `Promise.all`, aborting the whole reply. It now degrades to a document upload.
- **Resilient `sendMedia`.** Binds only the sender it needs, so a missing Telegram sender can't crash an unrelated media send (was eagerly `.bind`-ing all five).

## Inbound (`processMessage`)
- **Ingest voice / audio / video / video_note / animation / sticker** as `Media` (previously silently dropped).
- **Set `contentType` on every inbound attachment** (document + photo too) so audio/video are transcribed by the core `processAttachments` path and attachments round-trip safely across connectors.

## Tests / verification
- New tests: degrade-to-document + failure propagation, never-drop-text, no-empty-trailing-message, inbound voice → AUDIO.
- `plugin-telegram` suite: **62 pass**. The single failing test (`command-registration > agent (gate-safe)…`) fails **identically on `develop`** (verified by stashing this change) — pre-existing and unrelated.
- `tsc --noEmit` + Biome clean.

## Acceptance criteria covered (from #8876)
- ✅ Telegram never drops the text when sending an attachment.
- ✅ Unknown attachment type is sent as a document (not an error).
- ✅ Inbound voice/audio/video are ingested.

Deferred (per the hardened plan): the shared `core/src/connectors/attachments.ts` module and wiring the other connectors' dead outbound paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)