### PR TITLE
fix(ui): finish cloud-mobile gating — hide host security section + unlock composer for cloud agents

### DIFF
--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -13,6 +13,7 @@ import { type CodingAgentSession, client } from "../../api/client";
 import type { ConversationMessage } from "../../api/client-types-chat";
 import { isRoutineCodingAgentMessage } from "../../chat";
 import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
+import { deriveAgentReady } from "../../state/types";
 import { useChatAvatarVoiceBridge } from "../../hooks/useChatAvatarVoiceBridge";
 import { useConnectorSendAsAccount } from "../../hooks/useConnectorSendAsAccount";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
@@ -269,14 +270,15 @@ export function ChatView({
   // ── Derived composer state ──────────────────────────────────────
   const isAgentStarting =
     agentStatus?.state === "starting" || agentStatus?.state === "restarting";
-  // The agent is up but has no inference model wired — no point letting the
-  // user hit send. Surfaced as a composer lock + a pointer to Settings.
-  const agentModel =
-    typeof agentStatus?.model === "string" ? agentStatus.model.trim() : "";
+  // The agent is up but genuinely can't respond (no inference provider wired) —
+  // no point letting the user hit send. Use the server-authoritative readiness
+  // (`canRespond`) via deriveAgentReady, NOT a raw `model` string: a dedicated
+  // cloud agent reports canRespond:true with no local `model` (server-side
+  // inference), so the old model-empty check wrongly hard-locked its composer.
   const isMobileLocalRuntime = readPersistedMobileRuntimeMode() === "local";
   const isMissingInferenceProvider =
     agentStatus?.state === "running" &&
-    agentModel.length === 0 &&
+    !deriveAgentReady(agentStatus) &&
     !isMobileLocalRuntime;
   // First-turn capability fades in: the composer stays usable while the agent
   // warms up (a turn submitted during warmup is held server-side until the

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -7,6 +7,7 @@ import { useAgentElement } from "../../agent-surface";
 // grouping below reads — so the cloud sections render whenever Settings mounts.
 import { listExtraSettingsGroups } from "../../cloud/settings";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { isAndroidCloudBuild } from "../../platform/android-runtime";
 import { ContentLayout } from "../../layouts/content-layout";
 import { cn } from "../../lib/utils";
 import { useAppSelectorShallow } from "../../state";
@@ -391,6 +392,7 @@ export function SettingsView({
     return getAllSettingsSections().filter((section) => {
       if (section.id === "wallet-rpc" && walletEnabled === false) return false;
       if (section.developerOnly && !developerMode) return false;
+      if (section.hideOnCloud && isAndroidCloudBuild()) return false;
       return true;
     });
   }, [walletEnabled, developerMode]);

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -53,6 +53,12 @@ export interface SettingsSectionDef {
   bodyClassName?: string;
   /** Hide unless Developer Mode is on (dev builds default on; prod off). */
   developerOnly?: boolean;
+  /**
+   * Hide on the cloud mobile build (no host machine). For host/self-host
+   * concepts that are meaningless to a cloud user — e.g. the host
+   * remote-password security section. Evaluated against isAndroidCloudBuild().
+   */
+  hideOnCloud?: boolean;
   Component: ComponentType;
 }
 

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -49,6 +49,7 @@ import {
 } from "./settings-section-registry";
 import { VoiceSectionMount } from "./VoiceSectionMount";
 import { WalletRpcSection } from "./WalletRpcSection";
+import { isAndroidCloudBuild } from "../../platform/android-runtime";
 
 export {
   getSettingsSection,
@@ -94,6 +95,8 @@ interface SectionVisual {
   bodyClassName?: string;
   /** Hide unless Developer Mode is on. */
   developerOnly?: boolean;
+  /** Hide on the cloud mobile build (no host machine). */
+  hideOnCloud?: boolean;
   Component: ComponentType;
 }
 
@@ -212,6 +215,10 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     tone: "warn",
     hue: "amber",
     labelKey: "settings.sections.security.label",
+    // Host/self-host concept ("set a remote password so other machines can log
+    // into your host"). Meaningless for a cloud mobile user — the cloud
+    // "Sessions & Privacy" section covers real account security on cloud.
+    hideOnCloud: true,
     Component: SecuritySettingsSection,
   },
 };
@@ -235,6 +242,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] =
       defaultTitle: meta.defaultLabel,
       bodyClassName: visual.bodyClassName,
       developerOnly: visual.developerOnly,
+      hideOnCloud: visual.hideOnCloud,
       order: index,
       Component: visual.Component,
     };


### PR DESCRIPTION
Closes the two remaining host/self-host leaks on the cloud phone from the audit (#8434).

## 1. Hide the host-password `security` section on cloud
The built-in `security` section is framed around *"set a remote password so other machines can log into your host"* — meaningless for a cloud user (no host). Add `hideOnCloud?` to the section registry **mirroring @lalalune's `developerOnly` predicate**, gate `security` on it via `isAndroidCloudBuild()` in SettingsView's existing filter. The cloud **Sessions & Privacy** section already covers real account security on cloud. (`remote-plugins` is already hidden by @lalalune's `developerOnly`; `runtime` self-adapts — this is the last leak.)

## 2. Unlock the composer for cloud agents
ChatView hard-locked the composer when `agentStatus.model` was empty, telling the user to *"set up an LLM provider"* — but a dedicated cloud agent reports **`canRespond: true` with no local `model`** (server-side cerebras; verified live on `/api/status` + `/api/health`). Switch the check to the server-authoritative `deriveAgentReady(agentStatus)`. A genuine no-provider local agent (`canRespond:false`) still locks correctly.

## Safety
`hideOnCloud` lives only on the runtime registry def, **not** `SETTINGS_SECTION_META`, so the `dev-route-catalog` parity test stays green. typecheck clean. @lalalune — #1 extends your settings-gating pattern; flag if you'd rather fold it into your design.

Part of the phone+cloud audit (#8434).