### PR TITLE
fix(ui): agent manager uses canonical Steward-first cloud token

### DIFF
--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -68,6 +68,9 @@ vi.mock("../../api", () => ({
 
 vi.mock("../../api/client-cloud", () => ({
   resolveCloudAgentApiBase: () => "https://agent.example.test",
+  // currentCloudToken now resolves Steward-first via getCloudAuthToken; return
+  // null so it falls through to the persisted active-server token these tests set.
+  getCloudAuthToken: () => null,
 }));
 
 vi.mock("../../config/boot-config", () => ({

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../api";
-import { resolveCloudAgentApiBase } from "../../api/client-cloud";
+import { getCloudAuthToken, resolveCloudAgentApiBase } from "../../api/client-cloud";
 import type { CloudCompatAgent } from "../../api/client-types-cloud";
 import { getBootConfig } from "../../config/boot-config";
 import { useBranding } from "../../config/branding";
@@ -63,15 +63,20 @@ function activeCloudAgentId(): string | null {
   return id && !id.includes("/") ? id : null;
 }
 
-/** The cloud access token for the current session (persisted, or runtime). */
+/** The cloud access token for the current session. */
 function currentCloudToken(): string {
+  // Canonical Steward-first resolution (matches getCloudAuthToken: Steward JWT →
+  // runtime global → client), then fall back to the persisted active-server
+  // token for sessions without a Steward session. The old order read the
+  // persisted token first and skipped the Steward JWT entirely, which could send
+  // a stale/missing token from the agent manager.
+  const canonical = getCloudAuthToken();
+  if (canonical) return canonical;
   const persisted = loadPersistedActiveServer();
   if (persisted?.kind === "cloud" && persisted.accessToken) {
     return persisted.accessToken;
   }
-  const runtime = (globalThis as Record<string, unknown>)
-    .__ELIZA_CLOUD_AUTH_TOKEN__;
-  return typeof runtime === "string" ? runtime : "";
+  return "";
 }
 
 /**


### PR DESCRIPTION
From the audit (#8434). `CloudAgentsSection.currentCloudToken()` read the persisted active-server `accessToken` first and **skipped the canonical Steward JWT** — so the in-app agent manager (list/switch/create/delete) could send a stale/missing token while the rest of the app uses the Steward token.

Resolve Steward-first via the canonical `getCloudAuthToken()` (Steward JWT → runtime global → client), then fall back to the persisted token for sessions without a Steward session (behavior-preserving for that path). Reuses the one canonical token reader (rule 2).

typecheck clean; CloudAgentsSection tests 27/27 (mock returns null to exercise the persisted fallback).