### PR TITLE
fix(ui/security): don't auto-follow redirects on bearer-carrying native cloud HTTP

### DIFF
--- a/packages/ui/src/api/native-cloud-http-transport.ts
+++ b/packages/ui/src/api/native-cloud-http-transport.ts
@@ -118,6 +118,13 @@ const nativeCloudHttpTransport: AgentRequestTransport = {
       headers: headersToRecord(init.headers),
       ...(methodAllowsBody(method) && data !== undefined ? { data } : {}),
       responseType: "text",
+      // Don't auto-follow 3xx: this path forwards the user's cloud bearer to
+      // the dedicated agent subdomain, and CapacitorHttp (unlike browser fetch)
+      // would replay the Authorization header across a redirect. A 3xx here is a
+      // misconfig/open-redirect signal — surface it instead of leaking the token
+      // off *.elizacloud.ai. (The agent-router/central API must never 30x a
+      // bearer-carrying request.)
+      disableRedirects: true,
       ...(context?.timeoutMs
         ? {
             connectTimeout: context.timeoutMs,


### PR DESCRIPTION
Security hardening from the audit (#8434). The native `CapacitorHttp` path forwards the user's cloud bearer to the dedicated agent subdomain, and unlike browser fetch it **replays the Authorization header across a 3xx redirect** — so a misconfig/open-redirect could carry the JWT off `*.elizacloud.ai`. Set `disableRedirects:true` so a 3xx surfaces instead of silently leaking the token. Not exploitable today, but closes the gap where the browser-fetch cross-origin-strip guarantee isn't spec'd on Android. typecheck clean; native transport tests 12/12.