### PR TITLE
fix(ui): hide picker Back on cloud-only builds (was a no-op loop)

### DIFF
--- a/packages/ui/src/first-run/AgentPicker.tsx
+++ b/packages/ui/src/first-run/AgentPicker.tsx
@@ -29,6 +29,12 @@ export interface AgentPickerProps {
   onCreateNew: () => void;
   onRetry: () => void;
   onBack: () => void;
+  /**
+   * Show the Back affordance. Defaults true. Pass false for cloud-only builds
+   * where the upstream step is terminal — Back would just loop the picker back
+   * to itself (a dead-end on the phone's actual flow).
+   */
+  showBack?: boolean;
 }
 
 /** Statuses that mean the agent is being torn down — not selectable. */
@@ -67,6 +73,7 @@ export function AgentPicker({
   onCreateNew,
   onRetry,
   onBack,
+  showBack = true,
 }: AgentPickerProps): React.ReactElement {
   const binding = phase === "binding";
 
@@ -98,15 +105,17 @@ export function AgentPicker({
             {errorMessage ?? "Could not load your agents. Try again."}
           </p>
           <div className="flex items-center gap-3">
-            <button
-              type="button"
-              data-testid="onboarding-agent-back"
-              onClick={onBack}
-              className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10"
-            >
-              <ChevronLeft className="h-4 w-4" />
-              Back
-            </button>
+            {showBack && (
+              <button
+                type="button"
+                data-testid="onboarding-agent-back"
+                onClick={onBack}
+                className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Back
+              </button>
+            )}
             <button
               type="button"
               data-testid="onboarding-agent-retry"
@@ -180,17 +189,21 @@ export function AgentPicker({
             })}
           </div>
 
-          <div className="mt-1 flex items-center justify-between gap-3">
-            <button
-              type="button"
-              data-testid="onboarding-agent-back"
-              disabled={binding}
-              onClick={onBack}
-              className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 disabled:opacity-50"
-            >
-              <ChevronLeft className="h-4 w-4" />
-              Back
-            </button>
+          <div
+            className={`mt-1 flex items-center gap-3 ${showBack ? "justify-between" : "justify-end"}`}
+          >
+            {showBack && (
+              <button
+                type="button"
+                data-testid="onboarding-agent-back"
+                disabled={binding}
+                onClick={onBack}
+                className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 disabled:opacity-50"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Back
+              </button>
+            )}
             <button
               type="button"
               data-testid="onboarding-agent-create"

--- a/packages/ui/src/first-run/CompactOnboarding.tsx
+++ b/packages/ui/src/first-run/CompactOnboarding.tsx
@@ -261,6 +261,7 @@ export function CompactOnboarding(): React.ReactElement {
                 onCreateNew={c.onCreateNewAgent}
                 onRetry={c.onRetryPicker}
                 onBack={c.onBackFromPicker}
+                showBack={!cloudOnly}
               />
             ) : onInference ? (
               // INFERENCE — after picking the on-device agent, choose where it


### PR DESCRIPTION
From the audit (#8434). On cloud-only builds (the phone's real flow), the agent picker's upstream step is terminal, so the picker's **Back button looped back to itself** — a dead-end. Add `showBack?:boolean` (default true) to `AgentPicker`, pass `showBack={!cloudOnly}` from `CompactOnboarding`; the lone Create button right-aligns when Back is hidden. Default-true preserves desktop/non-cloud behavior and keeps the existing Back-click test green. typecheck + first-run tests 19/19.