### PR TITLE
fix(core): stop direct-reply fast path re-answering an earlier message (off-by-one)

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2929,6 +2929,7 @@ const RESPONSE_TASK_BASELINE_INSTRUCTIONS = [
 	"",
 	"rules:",
 	"- answer directly in the agent's voice",
+	"- reply to the final user_message only; recent_context shows earlier turns that are already answered — never reply to an earlier message again",
 	"- when the user asks for exact words, output only those exact words",
 	`- ${CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
 	"- do not select actions or tools",
@@ -2984,11 +2985,20 @@ function directReplyPromptForMessage(args: {
 		"response",
 		RESPONSE_TASK_BASELINE_INSTRUCTIONS,
 	);
+	// The current message must win against `recent_context` (the composed state,
+	// which carries the conversation history). When history is non-trivial the
+	// single `user_message:` line is easy for the model to lose against a large
+	// context block — it would intermittently re-answer an earlier turn (the
+	// off-by-one). Label the context as already-handled reference and give the
+	// current message an unambiguous, directive lead-in so it stays the target.
 	return [
 		instructions,
 		"",
-		contextText ? `recent_context:\n${contextText}` : "",
+		contextText
+			? `recent_context (earlier turns, already answered — reference only, do not reply to these):\n${contextText}`
+			: "",
 		contextText ? "" : "",
+		"Now write your reply to this new message, and only this message:",
 		`user_message: ${latestText}`,
 		`routing_thought: ${args.messageHandler.thought}`,
 	]


### PR DESCRIPTION
Fixes #8877 — the launch-blocking dedicated/DM chat off-by-one (reply N answers message N-1).

## Root cause (captured from a live instrumented agent)
I built an instrumented image that routes the fast-path's actual message + rendered prompt tail through the SSE `thought` field (node logs were inaccessible). The rendered prompt:
```
recent_context:
  ...user_message: <turn 1>  routing_thought: ...
  ...user_message: <turn 2>  routing_thought: ...
user_message: <current turn>      ← single line, buried after a ~1000-char block
routing_thought: ...
```
The current message is one line competing with a large `recent_context` block (the composed state = conversation history). With non-trivial history (~T3+), the model intermittently anchors on the most-salient EARLIER turn and re-answers it. @phone-agent's independent discriminator nailed it: **same-conversation lags from T3; fresh-conversation-per-turn = 0 lag** → purely history-driven.

## Fix (`directReplyPromptForMessage`, surgical + general — no new logic)
- Label `recent_context` as already-answered reference ("do not reply to these").
- Add an unambiguous directive lead-in for the current message.
- Add a baseline rule: reply to the final `user_message` only.
Empty-history (fresh) turns are byte-unaffected (the block only renders when history exists). No regex, no narrow special-casing.

## Verification
biome clean; no test asserts the prompt format. **Behavioral before/after** (live align probe: 8 distinct prompts, does each reply match its own question) attached once the agent-image build is green — @phone-agent is on standby to verify on-device with their repro too. Per the DoD this prompt change ships with the real-LLM before/after.