### PR TITLE
test(scenario-runner): coding-orchestration finalChecks (subAgentSpawned, fileMutationOccurred, buildValidation)

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -267,6 +267,19 @@ export type ScenarioFinalCheck =
       expected?: boolean;
       minCount?: number;
     })
+  | (CheckBase<"subAgentSpawned"> & {
+      agentType?: StringMatcher;
+      minCount?: number;
+    })
+  | (CheckBase<"fileMutationOccurred"> & {
+      path?: StringMatcher;
+      minCount?: number;
+    })
+  | (CheckBase<"buildValidation"> & {
+      workdir: string;
+      command: string;
+      expectExitZero?: boolean;
+    })
   | (CheckBase<"judgeRubric"> & {
       name: string;
       rubric: string;

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -63,6 +63,9 @@ export const FINAL_CHECK_KEYS = new Map(
       "expected",
       "minCount",
     ],
+    subAgentSpawned: ["type", "name", "agentType", "minCount"],
+    fileMutationOccurred: ["type", "name", "path", "minCount"],
+    buildValidation: ["type", "name", "workdir", "command", "expectExitZero"],
   }).map(([type, keys]) => [type, new Set(keys)]),
 );
 

--- a/packages/scenario-runner/src/final-checks/coding-checks.test.ts
+++ b/packages/scenario-runner/src/final-checks/coding-checks.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Coding / sub-agent orchestration finalChecks (audit Wave 1.2).
+ *
+ * These give scenario authors first-class proof fields for the coding
+ * capability: that a sub-agent was spawned, that files were mutated, and that
+ * generated code actually builds (dynamic build validation). Without them, a
+ * coding scenario could only assert on raw action names.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+import { afterEach, describe, expect, it } from "vitest";
+import { runFinalCheck } from "./index.ts";
+
+const runtime = {} as unknown as IAgentRuntime;
+const ctxWith = (actions: Array<Partial<CapturedAction>>): ScenarioContext =>
+  ({
+    actionsCalled: actions as CapturedAction[],
+  }) as unknown as ScenarioContext;
+const run = (check: unknown, ctx: ScenarioContext) =>
+  runFinalCheck(check as never, { runtime, ctx });
+
+describe("subAgentSpawned", () => {
+  it("passes when a spawn action fired", async () => {
+    const r = await run(
+      { type: "subAgentSpawned", name: "spawned" },
+      ctxWith([{ actionName: "TASKS_SPAWN_AGENT" }]),
+    );
+    expect(r.status).toBe("passed");
+  });
+
+  it("fails when no spawn action fired", async () => {
+    const r = await run(
+      { type: "subAgentSpawned", name: "spawned" },
+      ctxWith([{ actionName: "REPLY" }, { actionName: "TASKS_LIST_AGENTS" }]),
+    );
+    expect(r.status).toBe("failed");
+  });
+
+  it("honors agentType matching against action params", async () => {
+    const ctx = ctxWith([
+      { actionName: "TASKS_CREATE", parameters: { agentType: "codex" } },
+    ]);
+    expect(
+      (
+        await run(
+          { type: "subAgentSpawned", name: "x", agentType: "codex" },
+          ctx,
+        )
+      ).status,
+    ).toBe("passed");
+    expect(
+      (
+        await run(
+          { type: "subAgentSpawned", name: "x", agentType: "claude" },
+          ctx,
+        )
+      ).status,
+    ).toBe("failed");
+  });
+
+  it("respects minCount", async () => {
+    const ctx = ctxWith([
+      { actionName: "START_CODING_TASK" },
+      { actionName: "START_CODING_TASK" },
+    ]);
+    expect(
+      (await run({ type: "subAgentSpawned", name: "x", minCount: 2 }, ctx))
+        .status,
+    ).toBe("passed");
+    expect(
+      (await run({ type: "subAgentSpawned", name: "x", minCount: 3 }, ctx))
+        .status,
+    ).toBe("failed");
+  });
+});
+
+describe("fileMutationOccurred", () => {
+  it("passes for a write/edit action", async () => {
+    expect(
+      (
+        await run(
+          { type: "fileMutationOccurred", name: "wrote" },
+          ctxWith([{ actionName: "WRITE_FILE" }]),
+        )
+      ).status,
+    ).toBe("passed");
+    expect(
+      (
+        await run(
+          { type: "fileMutationOccurred", name: "wrote" },
+          ctxWith([{ actionName: "FILE", parameters: { action: "write" } }]),
+        )
+      ).status,
+    ).toBe("passed");
+  });
+
+  it("does NOT count a FILE read as a mutation", async () => {
+    const r = await run(
+      { type: "fileMutationOccurred", name: "wrote" },
+      ctxWith([{ actionName: "FILE", parameters: { action: "read" } }]),
+    );
+    expect(r.status).toBe("failed");
+  });
+
+  it("honors path matching", async () => {
+    const ctx = ctxWith([
+      {
+        actionName: "EDIT_FILE",
+        parameters: { file_path: "/repo/src/index.ts" },
+      },
+    ]);
+    expect(
+      (
+        await run(
+          { type: "fileMutationOccurred", name: "x", path: "index.ts" },
+          ctx,
+        )
+      ).status,
+    ).toBe("passed");
+    expect(
+      (
+        await run(
+          { type: "fileMutationOccurred", name: "x", path: "nope.ts" },
+          ctx,
+        )
+      ).status,
+    ).toBe("failed");
+  });
+});
+
+describe("buildValidation", () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("passes when the command exits 0", async () => {
+    dir = mkdtempSync(join(tmpdir(), "bv-pass-"));
+    const r = await run(
+      {
+        type: "buildValidation",
+        name: "build",
+        workdir: dir,
+        command: "exit 0",
+      },
+      ctxWith([]),
+    );
+    expect(r.status).toBe("passed");
+  });
+
+  it("fails when the command exits non-zero", async () => {
+    dir = mkdtempSync(join(tmpdir(), "bv-fail-"));
+    const r = await run(
+      {
+        type: "buildValidation",
+        name: "build",
+        workdir: dir,
+        command: "exit 1",
+      },
+      ctxWith([]),
+    );
+    expect(r.status).toBe("failed");
+    expect(r.detail).toContain("exited 1");
+  });
+
+  it("passes a non-zero exit when expectExitZero is false", async () => {
+    dir = mkdtempSync(join(tmpdir(), "bv-neg-"));
+    const r = await run(
+      {
+        type: "buildValidation",
+        name: "build",
+        workdir: dir,
+        command: "exit 2",
+        expectExitZero: false,
+      },
+      ctxWith([]),
+    );
+    expect(r.status).toBe("passed");
+  });
+
+  it("skips (dependency missing) when the workdir does not exist", async () => {
+    const r = await run(
+      {
+        type: "buildValidation",
+        name: "build",
+        workdir: join(tmpdir(), "definitely-not-here-xyz"),
+        command: "exit 0",
+      },
+      ctxWith([]),
+    );
+    expect(r.status).toBe("skipped-dependency-missing");
+  });
+
+  it("actually validates real generated code (writes a TS file, typechecks via node --check on JS)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "bv-real-"));
+    // a real compile check: node --check parses the file and fails on syntax error
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(join(dir, "good.js"), "const x = 1; module.exports = x;\n");
+    writeFileSync(join(dir, "bad.js"), "const = ;\n");
+    expect(
+      (
+        await run(
+          {
+            type: "buildValidation",
+            name: "ok",
+            workdir: dir,
+            command: "node --check good.js",
+          },
+          ctxWith([]),
+        )
+      ).status,
+    ).toBe("passed");
+    expect(
+      (
+        await run(
+          {
+            type: "buildValidation",
+            name: "bad",
+            workdir: dir,
+            command: "node --check bad.js",
+          },
+          ctxWith([]),
+        )
+      ).status,
+    ).toBe("failed");
+  });
+});
+
+describe("schema strictness", () => {
+  it("rejects unknown fields on the new checks", async () => {
+    const r = await run(
+      { type: "subAgentSpawned", name: "x", bogusField: true },
+      ctxWith([{ actionName: "TASKS_SPAWN_AGENT" }]),
+    );
+    expect(r.status).toBe("failed");
+    expect(r.detail).toContain("unknown field");
+  });
+});

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -4,6 +4,8 @@
  * cannot be misspelled or silently skipped.
  */
 
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   FINAL_CHECK_KEYS,
@@ -1162,6 +1164,186 @@ registerFinalCheckHandler("workflowDispatchOccurred", (check, { ctx }) => {
   return {
     status: "passed",
     detail: `${total} workflow dispatch record(s) observed`,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Coding / sub-agent orchestration checks (audit Wave 1.2)
+// ---------------------------------------------------------------------------
+
+// Action names that represent spawning a coding sub-agent. The orchestrator
+// promotes TASKS subactions to standalone names (TASKS_SPAWN_AGENT, etc.); the
+// direct coding path uses START_CODING_TASK / CREATE_TASK.
+const SUB_AGENT_SPAWN_ACTIONS = [
+  "TASKS_SPAWN_AGENT",
+  "TASKS_CREATE",
+  "SPAWN_AGENT",
+  "SPAWN_TASK_AGENT",
+  "START_CODING_TASK",
+  "CREATE_TASK",
+];
+
+function isSpawnAction(name: string): boolean {
+  return (
+    SUB_AGENT_SPAWN_ACTIONS.includes(name) || /SPAWN|START_CODING/i.test(name)
+  );
+}
+
+registerFinalCheckHandler("subAgentSpawned", (check, { ctx }) => {
+  const { agentType, minCount } = check as {
+    agentType?: string | string[];
+    minCount?: number;
+  };
+  const want = typeof minCount === "number" ? minCount : 1;
+  const spawns = ctx.actionsCalled.filter((a) => {
+    if (isSynthesizedReply(a) || !isSpawnAction(a.actionName)) return false;
+    if (agentType !== undefined) {
+      const params = actionParameters(a);
+      const at = String(
+        params?.agentType ??
+          params?.adapter ??
+          readPath(params ?? {}, "content.agentType") ??
+          "",
+      );
+      if (!toArray(agentType).some((t) => matchesPattern(at, t))) return false;
+    }
+    return true;
+  });
+  if (spawns.length < want) {
+    return {
+      status: "failed",
+      detail: `expected ${want} sub-agent spawn(s)${
+        agentType ? ` (agentType ${toArray(agentType).join("|")})` : ""
+      }, saw ${spawns.length}. Called: ${
+        ctx.actionsCalled.map((a) => a.actionName).join(",") || "(none)"
+      }`,
+    };
+  }
+  return {
+    status: "passed",
+    detail: `${spawns.length} sub-agent spawn(s) observed`,
+  };
+});
+
+function isFileMutation(action: { actionName: string }): boolean {
+  const name = action.actionName;
+  if (name === "FILE") {
+    const params = actionParameters(action as never);
+    const sub = String(params?.action ?? params?.subaction ?? "").toLowerCase();
+    return ["write", "edit", "create", "multi_edit", "append"].includes(sub);
+  }
+  return (
+    [
+      "WRITE_FILE",
+      "EDIT_FILE",
+      "WRITE",
+      "EDIT",
+      "CREATE_FILE",
+      "APPLY_PATCH",
+      "MULTI_EDIT",
+    ].includes(name) || /(WRITE|EDIT|PATCH)/i.test(name)
+  );
+}
+
+registerFinalCheckHandler("fileMutationOccurred", (check, { ctx }) => {
+  const { path: pathMatch, minCount } = check as {
+    path?: string | string[];
+    minCount?: number;
+  };
+  const want = typeof minCount === "number" ? minCount : 1;
+  const muts = ctx.actionsCalled.filter((a) => {
+    if (isSynthesizedReply(a) || !isFileMutation(a)) return false;
+    if (pathMatch !== undefined) {
+      const params = actionParameters(a);
+      const p = String(
+        params?.path ?? params?.file_path ?? a.result?.path ?? "",
+      );
+      if (!toArray(pathMatch).some((m) => matchesPattern(p, m))) return false;
+    }
+    return true;
+  });
+  if (muts.length < want) {
+    return {
+      status: "failed",
+      detail: `expected ${want} file mutation(s)${
+        pathMatch ? ` matching ${toArray(pathMatch).join("|")}` : ""
+      }, saw ${muts.length}`,
+    };
+  }
+  return {
+    status: "passed",
+    detail: `${muts.length} file mutation(s) observed`,
+  };
+});
+
+/**
+ * Run a build/typecheck/test command in a workspace and resolve its exit code +
+ * captured output. Never rejects; SIGKILLs on timeout (exit 124).
+ */
+function runBuildCommand(
+  command: string,
+  cwd: string,
+  timeoutMs = 180_000,
+): Promise<{ code: number; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("/bin/bash", ["-lc", command], { cwd });
+    let output = "";
+    const onData = (d: Buffer): void => {
+      output += d.toString();
+      if (output.length > 200_000) output = output.slice(-200_000);
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve({ code: 124, output: `${output}\n[buildValidation timeout]` });
+    }, timeoutMs);
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      resolve({ code: 127, output: `${output}${String(e)}` });
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, output });
+    });
+  });
+}
+
+// Dynamic build validation: actually run a build/typecheck/test in a seeded or
+// generated workspace and assert the exit code — proof the produced code is
+// sound (audit: "dynamic build validation").
+registerFinalCheckHandler("buildValidation", async (check) => {
+  const { workdir, command, expectExitZero } = check as {
+    workdir?: string;
+    command?: string;
+    expectExitZero?: boolean;
+  };
+  if (typeof workdir !== "string" || typeof command !== "string") {
+    return {
+      status: "failed",
+      detail: "buildValidation requires string `workdir` and `command`",
+    };
+  }
+  if (!existsSync(workdir)) {
+    return {
+      status: "skipped-dependency-missing",
+      detail: `buildValidation workdir does not exist: ${workdir}`,
+    };
+  }
+  const wantZero = expectExitZero !== false;
+  const { code, output } = await runBuildCommand(command, workdir);
+  const ok = wantZero ? code === 0 : code !== 0;
+  if (!ok) {
+    return {
+      status: "failed",
+      detail: `buildValidation: \`${command}\` exited ${code} (expected ${
+        wantZero ? "0" : "non-zero"
+      }). Output tail: ${output.slice(-500)}`,
+    };
+  }
+  return {
+    status: "passed",
+    detail: `buildValidation: \`${command}\` exited ${code} as expected`,
   };
 });
 


### PR DESCRIPTION
## What this is

**Wave 1.2 of the coding-capability test-harness** — first-class scenario-runner finalChecks for the coding/sub-agent capability, so coding scenarios can assert the *real thing happened* instead of matching raw action names. These are the proof primitives the live coding-flow scenarios (Wave 2) build on.

## New finalChecks

| Check | Asserts |
|---|---|
| `subAgentSpawned` | a coding sub-agent was spawned (`TASKS_SPAWN_AGENT`/`TASKS_CREATE`/`START_CODING_TASK`/…), optional `agentType` + `minCount` |
| `fileMutationOccurred` | a write/edit file action ran (a `FILE` **read** is correctly NOT counted), optional `path` + `minCount` |
| `buildValidation` | **actually runs** a build/typecheck/test command in a workspace and asserts the exit code — the goal's "dynamic build validation"; skips cleanly when the workdir is absent |

Wired into both the strict `FINAL_CHECK_KEYS` validation map (`schema/index.js`) and the `ScenarioFinalCheck` TS union (`schema/index.d.ts`).

## Evidence

- `coding-checks.test.ts` — **13 passed**, including a **real compile check**: `node --check` passes valid JS and fails a deliberate syntax error (proves `buildValidation` executes and reports truthfully). Also covers spawn/file/agentType/path/minCount matching, the read-vs-mutation distinction, the missing-workdir skip, and strict unknown-field rejection.
- biome clean on all changed files; typecheck clean on the changed scenario-runner files (the full-workspace typecheck/suite is left to CI — a fresh local worktree can't resolve unbuilt sibling packages like `@elizaos/ui`/`tui`/`personal-assistant`, which CI builds).

Evidence types per `PR_EVIDENCE.md`: unit-test output is the right proof for a test-harness primitive. Live trajectories/screenshots/video are exercised by the scenarios that *consume* these checks (Wave 2), not by this PR.

Relates to the coding-capability audit (`packages/scenario-runner/docs/coding-capability-audit/`, landed in #8941).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
