### PR TITLE
feat(attachments): PR4a — large copy-pasted text becomes a text attachment (Claude-Code style) (#8876)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -50,6 +50,8 @@ import {
   chatUploadKind,
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
+  pastedTextToAttachment,
+  shouldConvertPasteToAttachment,
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
 import { MessageAttachments } from "../chat/MessageAttachments";
@@ -3033,6 +3035,21 @@ export function ContinuousChatOverlay({
                   if (files.length > 0) {
                     e.preventDefault();
                     addImageFiles(files);
+                    return;
+                  }
+                  // A large plain-text paste becomes a collapsed text
+                  // attachment chip (Claude-Code style) instead of flooding the
+                  // textarea; small pastes fall through to the textarea as
+                  // normal.
+                  const text = e.clipboardData?.getData("text") ?? "";
+                  if (shouldConvertPasteToAttachment(text)) {
+                    e.preventDefault();
+                    setPendingImages((prev) =>
+                      [...prev, pastedTextToAttachment(text)].slice(
+                        0,
+                        MAX_CHAT_IMAGES,
+                      ),
+                    );
                   }
                 }}
                 onKeyDown={(e) => {

--- a/packages/ui/src/utils/image-attachment.test.ts
+++ b/packages/ui/src/utils/image-attachment.test.ts
@@ -6,12 +6,19 @@ import {
   chatUploadKind,
   createImageThumbnail,
   isSupportedChatUpload,
+  LARGE_PASTE_CHAR_THRESHOLD,
   MAX_ATTACHMENT_BYTES,
   MAX_ATTACHMENTS_TOTAL_BYTES,
   MAX_CHAT_IMAGES,
   partitionAttachmentFiles,
+  pastedTextToAttachment,
+  shouldConvertPasteToAttachment,
   summarizeDroppedAttachments,
 } from "./image-attachment";
+
+/** Decode an attachment's UTF-8-safe base64 `data` back to the original text. */
+const decodeAttachmentText = (data: string): string =>
+  new TextDecoder().decode(Uint8Array.from(atob(data), (c) => c.charCodeAt(0)));
 
 const file = (type: string): File => ({ type }) as File;
 const sizedFile = (type: string, size: number): File =>
@@ -201,6 +208,85 @@ describe("summarizeDroppedAttachments", () => {
       droppedOverCount: 1,
       maxMb: bytesToMb(MAX_ATTACHMENT_BYTES),
     });
+  });
+});
+
+describe("shouldConvertPasteToAttachment", () => {
+  it("returns false for text below the threshold", () => {
+    expect(shouldConvertPasteToAttachment("hello")).toBe(false);
+    expect(
+      shouldConvertPasteToAttachment(
+        "x".repeat(LARGE_PASTE_CHAR_THRESHOLD - 1),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for text at or above the threshold", () => {
+    expect(
+      shouldConvertPasteToAttachment("x".repeat(LARGE_PASTE_CHAR_THRESHOLD)),
+    ).toBe(true);
+    expect(
+      shouldConvertPasteToAttachment(
+        "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 50),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the trimmed length so surrounding whitespace doesn't tip it over", () => {
+    const justUnder = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD - 1);
+    const padded = `   \n${justUnder}\n   `;
+    // Raw length is over the threshold, but the trimmed content is not.
+    expect(padded.length).toBeGreaterThanOrEqual(LARGE_PASTE_CHAR_THRESHOLD);
+    expect(shouldConvertPasteToAttachment(padded)).toBe(false);
+  });
+
+  it("counts trimmed length so leading/trailing whitespace is ignored when large", () => {
+    const big = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD);
+    expect(shouldConvertPasteToAttachment(`  ${big}  `)).toBe(true);
+  });
+
+  it("does not convert a single long URL (a link, not a document)", () => {
+    const longUrl = `https://example.com/${"a".repeat(LARGE_PASTE_CHAR_THRESHOLD)}`;
+    expect(longUrl.length).toBeGreaterThanOrEqual(LARGE_PASTE_CHAR_THRESHOLD);
+    expect(shouldConvertPasteToAttachment(longUrl)).toBe(false);
+  });
+
+  it("does convert a long block that merely contains a URL", () => {
+    const block = `See https://example.com here\n${"word ".repeat(
+      LARGE_PASTE_CHAR_THRESHOLD,
+    )}`;
+    expect(shouldConvertPasteToAttachment(block)).toBe(true);
+  });
+});
+
+describe("pastedTextToAttachment", () => {
+  it("round-trips ASCII text through base64", () => {
+    const text = "hello world\nline two".repeat(200);
+    const att = pastedTextToAttachment(text);
+    expect(decodeAttachmentText(att.data)).toBe(text);
+  });
+
+  it("round-trips non-ASCII / emoji text without corruption", () => {
+    const text = `日本語テキスト 🚀✨ — café naïve résumé\n${"漢字".repeat(2000)} 😀`;
+    const att = pastedTextToAttachment(text);
+    expect(decodeAttachmentText(att.data)).toBe(text);
+  });
+
+  it("sets mimeType to text/markdown and a default name", () => {
+    const att = pastedTextToAttachment("anything large enough");
+    expect(att.mimeType).toBe("text/markdown");
+    expect(att.name).toBe("pasted-text.md");
+    expect(att.thumbnail).toBeUndefined();
+  });
+
+  it("honors a provided name", () => {
+    const att = pastedTextToAttachment("body", { name: "snippet.md" });
+    expect(att.name).toBe("snippet.md");
+  });
+
+  it("does not include a data-URL prefix in data", () => {
+    const att = pastedTextToAttachment("plain content");
+    expect(att.data.startsWith("data:")).toBe(false);
   });
 });
 

--- a/packages/ui/src/utils/image-attachment.ts
+++ b/packages/ui/src/utils/image-attachment.ts
@@ -301,6 +301,68 @@ export function summarizeDroppedAttachments(result: {
 }
 
 /**
+ * Character count at/above which a plain-text paste is converted into a
+ * collapsed text attachment chip (Claude-Code / claude.ai style) rather than
+ * flooding the composer textarea. Pastes shorter than this go into the textarea
+ * as normal.
+ */
+export const LARGE_PASTE_CHAR_THRESHOLD = 2000;
+
+/**
+ * True when a pasted plain-text block is large enough to become a text
+ * attachment instead of landing in the textarea. Uses the *trimmed* length so
+ * surrounding whitespace can't push a small paste over the line. A single bare
+ * URL (no internal whitespace) is never converted — pasting a link should keep
+ * working normally even when the URL is very long.
+ */
+export function shouldConvertPasteToAttachment(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < LARGE_PASTE_CHAR_THRESHOLD) return false;
+  // A lone long URL is a link, not a document — keep it in the textarea.
+  if (/^https?:\/\/\S+$/i.test(trimmed)) return false;
+  return true;
+}
+
+/**
+ * Encode a string to base64 in a UTF-8-safe, chunk-safe way. Raw `btoa(text)`
+ * throws on any code point > 0xFF (so any non-ASCII / emoji paste would break),
+ * and `String.fromCharCode(...bytes)` can overflow the call stack on a large
+ * paste. This walks the UTF-8 bytes in fixed-size chunks instead, so it round-
+ * trips arbitrary Unicode of any length.
+ */
+function utf8ToBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+/** Default file name for a pasted-text attachment. */
+const PASTED_TEXT_DEFAULT_NAME = "pasted-text.md";
+
+/**
+ * Convert a large pasted plain-text block into an {@link ImageAttachment} (the
+ * shared chat-attachment shape) so it renders as a collapsed chip and ships to
+ * the server like any other attachment. `data` is the UTF-8-safe base64 of the
+ * text (no data-URL prefix, matching the other attachment producers here),
+ * `mimeType` is `text/markdown`, and there is no thumbnail. Pure + synchronous
+ * so it unit-tests without the DOM.
+ */
+export function pastedTextToAttachment(
+  text: string,
+  opts: { name?: string } = {},
+): ImageAttachment {
+  return {
+    data: utf8ToBase64(text),
+    mimeType: "text/markdown",
+    name: opts.name ?? PASTED_TEXT_DEFAULT_NAME,
+  };
+}
+
+/**
  * Build the translated "kept N, dropped M" notice for the composer from an
  * intake/partition result, choosing the right i18n key based on whether the
  * drops were oversized, over-count, or a mix. Returns `null` when nothing was


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1) — first slice of PR4. Pasting a **large block of plain text** into the chat composer now becomes a collapsed **text-attachment chip** (Claude-Code style) instead of flooding the textarea.

- `image-attachment.ts`: `LARGE_PASTE_CHAR_THRESHOLD`, `shouldConvertPasteToAttachment` (a lone long URL is excluded so links still paste normally), `pastedTextToAttachment` (UTF-8-safe chunked base64 → `text/markdown` `ImageAttachment`). Pure + unit-tested.
- `ContinuousChatOverlay` `onPaste`: no files + large clipboard text → `preventDefault()` + add a pasted-text attachment (capped at `MAX_CHAT_IMAGES`); the files branch and small-text passthrough are unchanged.

The text attachment previews via the PR3 `CodeTile` once the pipeline populates its text.

**Tests:** 31 pass (threshold cases + Unicode/emoji base64 round-trip). `ui` typecheck + Biome clean. (The one failing overlay test is a mic/transcription voice test that fails identically on `develop` — unrelated to this paste-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)