### PR TITLE
fix(core): stop direct-reply fast path re-answering an earlier message (off-by-one) (#8877)

### DIFF
--- a/packages/core/src/services/message.direct-reply-anchoring.test.ts
+++ b/packages/core/src/services/message.direct-reply-anchoring.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../types/index";
+import type { Memory, State } from "../types/index";
+import type { MessageHandlerResult } from "../types/components";
+import { directReplyPromptForMessage } from "./message";
+
+/**
+ * Regression test for #8877: the direct-reply fast path was answering message
+ * N-1 instead of N (off-by-one). Root cause: with the fast path's tiny token
+ * budget, a small model anchored on the tail of `recent_context` (the composed
+ * state, which ends on the prior user turn) instead of the explicit
+ * `user_message:` line. The fix relabels the context as already-answered
+ * reference and gives the current message an unambiguous directive lead-in.
+ *
+ * These assertions lock in that the rendered prompt makes the CURRENT message
+ * the unmistakable reply target, regardless of what history precedes it.
+ */
+function makeRuntime(): IAgentRuntime {
+	// getService returns null so resolveOptimizedPromptForRuntime falls back to
+	// the baseline instructions verbatim — no optimized-prompt artifact needed.
+	return {
+		getService: () => null,
+	} as unknown as IAgentRuntime;
+}
+
+function makeMessage(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001",
+		entityId: "00000000-0000-0000-0000-0000000000aa",
+		roomId: "00000000-0000-0000-0000-0000000000bb",
+		content: { text },
+	} as unknown as Memory;
+}
+
+const messageHandler: MessageHandlerResult = {
+	processMessage: "RESPOND",
+	thought: "Direct private chat fast path.",
+	plan: {
+		contexts: ["simple"],
+		reply: "",
+		simple: true,
+		requiresTool: false,
+	},
+};
+
+describe("directReplyPromptForMessage anchoring (#8877)", () => {
+	it("makes the current message the directive reply target after history context", () => {
+		// recent_context deliberately ends on the PREVIOUS user turn — the exact
+		// shape that triggered the off-by-one.
+		const state = {
+			text: "user: spell the word dog\nassistant: dog\nuser: what is the capital of japan",
+		} as unknown as State;
+		const message = makeMessage("what is two plus two");
+
+		const prompt = directReplyPromptForMessage({
+			runtime: makeRuntime(),
+			message,
+			state,
+			messageHandler,
+		});
+
+		// Baseline rule that forbids re-answering an earlier turn is present.
+		expect(prompt).toContain(
+			"reply to the final user_message only; recent_context shows earlier turns that are already answered",
+		);
+		// Context is labelled as already-answered reference, not a fresh prompt.
+		expect(prompt).toContain(
+			"recent_context (earlier turns, already answered — reference only, do not reply to these):",
+		);
+		// The current message is the directive target.
+		expect(prompt).toContain(
+			"Now write your reply to this new message, and only this message:",
+		);
+		expect(prompt).toContain("user_message: what is two plus two");
+
+		// Ordering: context block → directive lead-in → current user_message.
+		const contextIdx = prompt.indexOf("recent_context (earlier turns");
+		const directiveIdx = prompt.indexOf("Now write your reply to this new");
+		const userMsgIdx = prompt.indexOf("user_message: what is two plus two");
+		expect(contextIdx).toBeGreaterThanOrEqual(0);
+		expect(directiveIdx).toBeGreaterThan(contextIdx);
+		expect(userMsgIdx).toBeGreaterThan(directiveIdx);
+
+		// The directive lead-in sits immediately before the user_message line so
+		// the current turn is the most salient, last instruction.
+		expect(prompt).toContain(
+			"Now write your reply to this new message, and only this message:\nuser_message: what is two plus two",
+		);
+	});
+
+	it("still anchors the current message when there is no prior context", () => {
+		const state = { text: "" } as unknown as State;
+		const message = makeMessage("hello there");
+
+		const prompt = directReplyPromptForMessage({
+			runtime: makeRuntime(),
+			message,
+			state,
+			messageHandler,
+		});
+
+		// No recent_context block when state is empty (the rules text mentions
+		// "recent_context", but the labelled context header must be absent)...
+		expect(prompt).not.toContain("recent_context (earlier turns");
+		// ...but the current message is still the explicit directive target.
+		expect(prompt).toContain(
+			"Now write your reply to this new message, and only this message:\nuser_message: hello there",
+		);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2929,6 +2929,7 @@ const RESPONSE_TASK_BASELINE_INSTRUCTIONS = [
 	"",
 	"rules:",
 	"- answer directly in the agent's voice",
+	"- reply to the final user_message only; recent_context shows earlier turns that are already answered — never reply to an earlier message again",
 	"- when the user asks for exact words, output only those exact words",
 	`- ${CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
 	"- do not select actions or tools",
@@ -2968,7 +2969,7 @@ direct/private rules:
 Return exactly one JSON object for {{handleResponseToolName}}. No prose, markdown, or thinking.
 `;
 
-function directReplyPromptForMessage(args: {
+export function directReplyPromptForMessage(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	state: State;
@@ -2984,11 +2985,20 @@ function directReplyPromptForMessage(args: {
 		"response",
 		RESPONSE_TASK_BASELINE_INSTRUCTIONS,
 	);
+	// The current message must win against `recent_context` (the composed state,
+	// which carries conversation history and frequently ends on the previous
+	// user turn). With the fast path's tiny token budget a single `user_message:`
+	// line is easy for a small model to lose against a large context block — it
+	// would intermittently re-answer the prior turn (the off-by-one in #8877).
+	// Label the context as already-handled reference and give the current message
+	// an unambiguous directive lead-in so it stays the reply target.
 	return [
 		instructions,
 		"",
-		contextText ? `recent_context:\n${contextText}` : "",
-		contextText ? "" : "",
+		contextText
+			? `recent_context (earlier turns, already answered — reference only, do not reply to these):\n${contextText}`
+			: "",
+		"Now write your reply to this new message, and only this message:",
 		`user_message: ${latestText}`,
 		`routing_thought: ${args.messageHandler.thought}`,
 	]


### PR DESCRIPTION
## Summary
Fixes #8877. On dedicated/DM/API chat, the **direct-reply fast path** delivered the reply to message **N-1** when the user sent message **N** (the launch-quality off-by-one @NubsCarson saw on the phone agent, reproduced + root-located server-side in #8877).

## Root cause
The fast path builds its prompt in `directReplyPromptForMessage` as `recent_context:\n{state.text}` followed by a single `user_message:` line. `state.text` (composed conversation history) routinely **ends on the previous user turn**. With the fast path's tiny token budget (`DIRECT_REPLY_FAST_PATH_MAX_TOKENS`, ~96 tokens) a small model anchors on that context tail and re-answers the earlier turn instead of the explicit `user_message:` line.

## Fix (prompt anchoring only — no behavior/contract change)
In `directReplyPromptForMessage`:
1. Baseline rule added: *"reply to the final user_message only; recent_context shows earlier turns that are already answered — never reply to an earlier message again."*
2. Context block relabelled: `recent_context (earlier turns, already answered — reference only, do not reply to these):`
3. Directive lead-in immediately before the current message: *"Now write your reply to this new message, and only this message:"* so the current turn is the **last, most-salient** instruction.

## Tests / evidence
- New deterministic regression test `message.direct-reply-anchoring.test.ts` (2 cases): with a `state.text` that deliberately ends on the prior user turn, the rendered prompt orders **context → directive → current `user_message:`**, keeps the current message as the reply target, and still anchors correctly with no prior context.
- `directReplyPromptForMessage` is now exported for the test.

```
✓ src/services/message.direct-reply-anchoring.test.ts (2)
Test Files  1 passed (1)
```

## Relationship to #8944
Supersedes [#8944](https://github.com/elizaOS/eliza/pull/8944) (@NubsCarson) — same prompt fix, now with the regression test the issue asked for. Credited as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)