### PR TITLE
feat(telegram): edit_message + react_message connector capabilities (#8903)

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.edit-react.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.edit-react.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageManager } from "./messageManager";
+
+/**
+ * Unit tests for the Telegram connector `edit_message` / `react_message`
+ * capabilities (#8903). With edit available the orchestrator's compact progress
+ * mode rewrites a single message across heartbeats instead of flooding the chat.
+ */
+function makeManager() {
+  const editMessageText = vi.fn(async () => ({ message_id: 7 }));
+  const setMessageReaction = vi.fn(async () => true);
+  const bot = { telegram: { editMessageText, setMessageReaction } };
+  const runtime = { agentId: "00000000-0000-0000-0000-0000000000aa" };
+  const manager = new MessageManager(bot as never, runtime as never);
+  return { manager, editMessageText, setMessageReaction };
+}
+
+describe("MessageManager.editMessage (#8903)", () => {
+  let env: ReturnType<typeof makeManager>;
+  beforeEach(() => {
+    env = makeManager();
+  });
+
+  it("edits in place as MarkdownV2", async () => {
+    await env.manager.editMessage(123, 7, "**bold** progress");
+    expect(env.editMessageText).toHaveBeenCalledTimes(1);
+    const [chatId, messageId, inlineId, text, opts] =
+      env.editMessageText.mock.calls[0];
+    expect(chatId).toBe(123);
+    expect(messageId).toBe(7);
+    expect(inlineId).toBeUndefined();
+    expect(typeof text).toBe("string");
+    expect(opts).toEqual({ parse_mode: "MarkdownV2" });
+  });
+
+  it("falls back to plain text when MarkdownV2 is rejected (400 parse error)", async () => {
+    const err = {
+      response: {
+        error_code: 400,
+        description: "Bad Request: can't parse entities",
+      },
+    };
+    env.editMessageText
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ message_id: 7 } as never);
+
+    await env.manager.editMessage(123, 7, "**bold** progress");
+
+    expect(env.editMessageText).toHaveBeenCalledTimes(2);
+    // The retry carries no parse_mode (plain text).
+    const retryOpts = env.editMessageText.mock.calls[1][4];
+    expect(retryOpts).toBeUndefined();
+  });
+});
+
+describe("MessageManager.addReaction (#8903)", () => {
+  let env: ReturnType<typeof makeManager>;
+  beforeEach(() => {
+    env = makeManager();
+  });
+
+  it("sets a single emoji reaction", async () => {
+    await env.manager.addReaction(123, 7, "👍");
+    expect(env.setMessageReaction).toHaveBeenCalledWith(123, 7, [
+      { type: "emoji", emoji: "👍" },
+    ]);
+  });
+
+  it("clears reactions when no emoji is given", async () => {
+    await env.manager.addReaction(123, 7, undefined);
+    expect(env.setMessageReaction).toHaveBeenCalledWith(123, 7, []);
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1602,6 +1602,81 @@ export class MessageManager {
   }
 
   /**
+   * Edits the text of a previously-sent Telegram message in place. Converts
+   * markdown to MarkdownV2 and, on a MarkdownV2 rejection, retries as plain
+   * text — mirroring {@link sendMessageInChunks}'s fallback. Used by the
+   * connector `edit_message` capability so the orchestrator's compact progress
+   * mode can rewrite one line across heartbeats instead of flooding the chat.
+   */
+  public async editMessage(
+    chatId: number | string,
+    messageId: number,
+    text: string,
+    messageThreadId?: number,
+  ): Promise<void> {
+    const formatted = convertMarkdownToTelegram(text);
+    await this.sendWithRetry(
+      () =>
+        this.bot.telegram.editMessageText(
+          chatId,
+          messageId,
+          undefined,
+          formatted,
+          { parse_mode: "MarkdownV2" },
+        ),
+      // Fallback: Telegram rejected the MarkdownV2 — edit with the raw text so
+      // the user sees the content unformatted rather than a stale message.
+      () =>
+        this.bot.telegram.editMessageText(
+          chatId,
+          messageId,
+          undefined,
+          cleanText(text),
+        ),
+    );
+    logger.info(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        chatId,
+        messageId,
+        messageThreadId,
+      },
+      "Message edited",
+    );
+  }
+
+  /**
+   * Sets a single emoji reaction on a Telegram message, or clears the bot's
+   * reactions when `emoji` is undefined. Used by the connector `react_message`
+   * capability.
+   */
+  public async addReaction(
+    chatId: number | string,
+    messageId: number,
+    emoji?: string,
+  ): Promise<void> {
+    await this.bot.telegram.setMessageReaction(
+      chatId,
+      messageId,
+      // Telegram only accepts a fixed set of reaction emoji (the `TelegramEmoji`
+      // union); the connector passes an arbitrary string, so cast and let
+      // Telegram reject an unsupported emoji at the API boundary.
+      emoji ? [{ type: "emoji", emoji } as ReactionType] : [],
+    );
+    logger.info(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        chatId,
+        messageId,
+        emoji: emoji ?? "(cleared)",
+      },
+      "Message reaction set",
+    );
+  }
+
+  /**
    * Sends a message to a Telegram chat and emits appropriate events
    * @param {number | string} chatId - The Telegram chat ID to send the message to
    * @param {Content} content - The content to send

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -9,8 +9,10 @@ import {
   type Memory,
   type MessageConnectorChatContext,
   type MessageConnectorCreateThreadParams,
+  type MessageConnectorEditParams,
   type MessageConnectorPostToThreadParams,
   type MessageConnectorQueryContext,
+  type MessageConnectorReactionParams,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   Role,
@@ -53,6 +55,8 @@ const CANONICAL_OWNER_SETTING_KEYS = ["ELIZA_ADMIN_ENTITY_ID"] as const;
 const TELEGRAM_CONNECTOR_CONTEXTS = ["social", "connectors"];
 const TELEGRAM_CONNECTOR_CAPABILITIES = [
   "send_message",
+  "edit_message",
+  "react_message",
   "resolve_targets",
   "list_rooms",
   "chat_context",
@@ -2425,6 +2429,30 @@ export class TelegramService extends Service {
             serviceInstance.createConnectorThread(runtime, params),
           postToThreadHandler: (runtime, params) =>
             serviceInstance.postToConnectorThread(runtime, params),
+          editHandler: (runtime, params) =>
+            serviceInstance.editConnectorMessage(runtime, {
+              ...params,
+              target:
+                normalizedAccountId &&
+                !(params.target as AccountScopedTargetInfo).accountId
+                  ? ({
+                      ...params.target,
+                      accountId: normalizedAccountId,
+                    } as TargetInfo)
+                  : params.target,
+            }),
+          reactHandler: (runtime, params) =>
+            serviceInstance.reactConnectorMessage(runtime, {
+              ...params,
+              target:
+                normalizedAccountId &&
+                !(params.target as AccountScopedTargetInfo).accountId
+                  ? ({
+                      ...params.target,
+                      accountId: normalizedAccountId,
+                    } as TargetInfo)
+                  : params.target,
+            }),
           resolveTargets: (query, context) =>
             serviceInstance.resolveConnectorTargets(
               query,
@@ -2567,11 +2595,22 @@ export class TelegramService extends Service {
     }
   }
 
-  async handleSendMessage(
+  /**
+   * Resolves a {@link TargetInfo} to the concrete Telegram bot, message
+   * manager, chat id and (optional) forum thread id. Shared by the send, edit
+   * and react connector handlers so the channelId / roomId / entityId
+   * resolution lives in exactly one place.
+   */
+  private async resolveTelegramSendTarget(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content,
-  ): Promise<void> {
+  ): Promise<{
+    accountId: string;
+    bot: Telegraf<Context>;
+    messageManager: MessageManager;
+    chatId: number | string;
+    threadId: number | undefined;
+  }> {
     const accountId = await this.resolveAccountIdForTarget(runtime, target);
     const accountState = this.getAccountState(accountId);
     const messageManager = accountState?.messageManager ?? this.messageManager;
@@ -2671,6 +2710,17 @@ export class TelegramService extends Service {
       );
     }
 
+    return { accountId, bot, messageManager, chatId, threadId };
+  }
+
+  async handleSendMessage(
+    runtime: IAgentRuntime,
+    target: TargetInfo,
+    content: Content,
+  ): Promise<void> {
+    const { accountId, messageManager, chatId, threadId } =
+      await this.resolveTelegramSendTarget(runtime, target);
+
     try {
       // Use existing MessageManager method, pass chatId and content
       // Assuming sendMessage handles splitting, markdown, etc.
@@ -2711,5 +2761,63 @@ export class TelegramService extends Service {
       );
       throw error;
     }
+  }
+
+  /**
+   * Edits a previously-sent Telegram message in place (capability
+   * `edit_message`). Lets the orchestrator's compact progress mode rewrite a
+   * single line across heartbeats instead of flooding the chat with new
+   * messages. Markdown is converted to MarkdownV2 with the same plain-text
+   * fallback the send path uses.
+   */
+  async editConnectorMessage(
+    runtime: IAgentRuntime,
+    params: MessageConnectorEditParams,
+  ): Promise<Memory | undefined> {
+    if (!params.messageId || !/^\d+$/.test(params.messageId)) {
+      throw new Error(
+        `Telegram edit requires a numeric messageId (got "${params.messageId}").`,
+      );
+    }
+    const text = params.content?.text;
+    if (!text?.trim()) {
+      throw new Error("Telegram edit requires non-empty content.text.");
+    }
+    const { messageManager, chatId, threadId } =
+      await this.resolveTelegramSendTarget(runtime, params.target);
+    await messageManager.editMessage(
+      chatId,
+      Number.parseInt(params.messageId, 10),
+      text,
+      threadId,
+    );
+    // Telegram's editMessageText returns the edited Message; the orchestrator
+    // only needs the call to succeed for compact-edit mode, so no Memory is
+    // synthesized here (the original send already produced one).
+    return undefined;
+  }
+
+  /**
+   * Sets (or clears) an emoji reaction on a Telegram message (capability
+   * `react_message`). Passing `remove: true` clears the bot's reactions.
+   */
+  async reactConnectorMessage(
+    runtime: IAgentRuntime,
+    params: MessageConnectorReactionParams & { remove?: boolean },
+  ): Promise<void> {
+    if (!params.messageId || !/^\d+$/.test(params.messageId)) {
+      throw new Error(
+        `Telegram reaction requires a numeric messageId (got "${params.messageId}").`,
+      );
+    }
+    const { messageManager, chatId } = await this.resolveTelegramSendTarget(
+      runtime,
+      params.target,
+    );
+    await messageManager.addReaction(
+      chatId,
+      Number.parseInt(params.messageId, 10),
+      params.remove ? undefined : params.emoji,
+    );
   }
 }


### PR DESCRIPTION
## Summary
Closes #8903 (part of #8885). Telegram floods the chat with a new message for every orchestrator progress heartbeat because the connector couldn't edit. This adds the **`edit_message`** and **`react_message`** connector capabilities — with `edit_message` advertised, the orchestrator's `resolveCanEdit` returns true and compact progress mode edits one message in place across heartbeats instead of flooding.

Discord already exposes both (`react_message`/`edit_message`); this brings Telegram to parity.

## Changes
- **`MessageManager.editMessage`** — `editMessageText` as MarkdownV2 with the *same* plain-text fallback the send path uses (routed through `sendWithRetry`, so it also inherits the 429 retry).
- **`MessageManager.addReaction`** — `setMessageReaction` with a single emoji, or clears reactions when none is given.
- **`service.ts`** — extracted the shared `TargetInfo → {bot, messageManager, chatId, threadId}` resolution out of `handleSendMessage` into `resolveTelegramSendTarget` (no duplication), added `editConnectorMessage`/`reactConnectorMessage` (numeric-messageId guarded), registered `editHandler`/`reactHandler`, and added the two capabilities to `TELEGRAM_CONNECTOR_CAPABILITIES`.

## Acceptance criteria
- [x] `editConnectorMessage` + `reactConnectorMessage` with MarkdownV2→plain fallback.
- [x] Capabilities list includes `edit_message` + `react_message`.
- [x] Orchestrator compact mode can edit in place (capability now advertised → `resolveCanEdit` true).
- [x] Mock-Bot-API test attached.

## Tests
`plugins/plugin-telegram/src/messageManager.edit-react.test.ts` (mock Bot API):
```
✓ editMessage edits in place as MarkdownV2
✓ editMessage falls back to plain text on a 400 parse error
✓ addReaction sets a single emoji reaction
✓ addReaction clears reactions when no emoji is given
Test Files  1 passed (1) · Tests  4 passed (4)
```

Scenario-runner compact-edit proof (Telegram mock + `ACPX_PROGRESS_MODE=compact`) is the natural follow-up once a Telegram scenario fixture lands; the capability + unit coverage are in place here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)