### PR TITLE
feat(orchestrator): always-on evidence-demanding grilling — auto-criteria, escalating socratic loop, typed evidence bundle

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -208,6 +208,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
+| `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Session state persistence dir when no runtime DB |
 | `ELIZA_ACP_SESSION_STORE_BACKEND` | unset | Override session store backend (`db`, `file`, or `memory`) |
 | `ELIZA_ACP_MCP_SERVERS` | unset | JSON list of MCP servers to pass to spawned sub-agents |
@@ -218,6 +219,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `TASK_AGENT_WORKDIR_ROUTES` | unset | JSON routing rules mapping task labels to workdirs |
 | `ELIZA_ORCHESTRATOR_SMITHERS` | `1` (enabled) | Set to `0` to disable the smithers task execution path and fall back to direct prompt |
 | `ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY` | unset | Enable LLM-based goal verification on task completion |
+| `ELIZA_REQUIRE_GOAL_CONTRACT` | `1` (enabled) | Auto-generate 3-5 measurable default acceptance criteria for a criteria-free, non-trivial task so the verifier always fires. Set to `0` to keep criteria-free tasks criteria-free (prior behavior). |
 | `SMITHERS_DB_PROVIDER` | unset | Database provider for smithers task storage |
 | `SMITHERS_DB_URL` | unset | Database URL for smithers task storage |
 | `SMITHERS_DB_DATA_DIR` | unset | Data directory for smithers file-backed storage |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -219,6 +219,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `TASK_AGENT_WORKDIR_ROUTES` | unset | JSON routing rules mapping task labels to workdirs |
 | `ELIZA_ORCHESTRATOR_SMITHERS` | `1` (enabled) | Set to `0` to disable the smithers task execution path and fall back to direct prompt |
 | `ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY` | unset | Enable LLM-based goal verification on task completion |
+| `ELIZA_REQUIRE_GOAL_CONTRACT` | `1` (enabled) | Auto-generate 3-5 measurable default acceptance criteria for a criteria-free, non-trivial task so the verifier always fires. Set to `0` to keep criteria-free tasks criteria-free (prior behavior). |
 | `SMITHERS_DB_PROVIDER` | unset | Database provider for smithers task storage |
 | `SMITHERS_DB_URL` | unset | Database URL for smithers task storage |
 | `SMITHERS_DB_DATA_DIR` | unset | Data directory for smithers file-backed storage |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Default acceptance-criteria generation (#8896).
+ *
+ * The auto goal-verifier only grills tasks that carry acceptance criteria, so a
+ * criteria-free "fix this bug" task historically skipped verification entirely.
+ * {@link generateDefaultAcceptanceCriteria} closes that gap by minting 3-5
+ * measurable criteria from the goal. These tests pin:
+ *
+ *  - the static (model-free) path always returns ≥3 criteria,
+ *  - coding / app-build / view-create / deploy produce DISTINCT sets,
+ *  - {@link detectTaskType} classifies sample goals correctly,
+ *  - the model path is defensive: a throwing / malformed / stingy model falls
+ *    back to the static template, never throws.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CRITERIA_TEMPLATES,
+  detectTaskType,
+  generateDefaultAcceptanceCriteria,
+  isNonTrivialGoal,
+  shouldRequireGoalContract,
+  staticAcceptanceCriteria,
+} from "../../src/services/acceptance-criteria.js";
+
+/** A runtime whose `useModel` returns the given raw string (or throws). */
+function runtimeWithModel(
+  impl: (() => Promise<unknown>) | string,
+): IAgentRuntime {
+  const useModel =
+    typeof impl === "string" ? vi.fn(async () => impl) : vi.fn(impl);
+  return { useModel } as unknown as IAgentRuntime;
+}
+
+describe("detectTaskType", () => {
+  it("defaults to coding for a plain bug-fix goal", () => {
+    expect(detectTaskType("fix the off-by-one bug in the parser")).toBe(
+      "coding",
+    );
+    expect(detectTaskType("refactor the auth module")).toBe("coding");
+  });
+
+  it("classifies view-create goals", () => {
+    expect(detectTaskType("create a new dashboard view with a viewKind")).toBe(
+      "view-create",
+    );
+    expect(detectTaskType("add a widget to the workbench")).toBe("view-create");
+  });
+
+  it("classifies app-build goals", () => {
+    expect(detectTaskType("build a landing page for the product")).toBe(
+      "app-build",
+    );
+    expect(detectTaskType("create a web app that lists todos")).toBe(
+      "app-build",
+    );
+  });
+
+  it("classifies deploy goals", () => {
+    expect(detectTaskType("deploy the service to production")).toBe("deploy");
+    expect(detectTaskType("ship to prod and set up autoscaling")).toBe(
+      "deploy",
+    );
+  });
+
+  it("is empty-safe", () => {
+    expect(detectTaskType("")).toBe("coding");
+    expect(detectTaskType("   ")).toBe("coding");
+  });
+});
+
+describe("staticAcceptanceCriteria", () => {
+  it("returns ≥3 criteria for every task type", () => {
+    for (const type of [
+      "coding",
+      "app-build",
+      "view-create",
+      "deploy",
+    ] as const) {
+      expect(DEFAULT_CRITERIA_TEMPLATES[type].length).toBeGreaterThanOrEqual(3);
+    }
+    expect(staticAcceptanceCriteria("fix bug").length).toBeGreaterThanOrEqual(
+      3,
+    );
+  });
+
+  it("produces DIFFERENT sets for coding vs app-build vs view-create", () => {
+    const coding = staticAcceptanceCriteria("fix bug", "coding");
+    const appBuild = staticAcceptanceCriteria("build a site", "app-build");
+    const viewCreate = staticAcceptanceCriteria("add a view", "view-create");
+
+    expect(coding).not.toEqual(appBuild);
+    expect(coding).not.toEqual(viewCreate);
+    expect(appBuild).not.toEqual(viewCreate);
+
+    // app-build is the coding superset plus the live-URL check.
+    expect(appBuild).toEqual([...coding, "the live URL returns HTTP 200"]);
+    // view-create is its own distinct set (no overlap with coding's checks).
+    expect(viewCreate.some((c) => coding.includes(c))).toBe(false);
+  });
+
+  it("respects an explicit task-type hint over goal detection", () => {
+    // Goal text reads like a deploy, but the hint forces view-create.
+    expect(staticAcceptanceCriteria("deploy to prod", "view-create")).toEqual(
+      staticAcceptanceCriteria("any", "view-create"),
+    );
+  });
+});
+
+describe("isNonTrivialGoal / shouldRequireGoalContract", () => {
+  it("treats blank / near-blank goals as trivial", () => {
+    expect(isNonTrivialGoal("")).toBe(false);
+    expect(isNonTrivialGoal("  ")).toBe(false);
+    expect(isNonTrivialGoal("fix")).toBe(false);
+    expect(isNonTrivialGoal("fix this bug")).toBe(true);
+  });
+
+  it("defaults the goal contract ON; only '0' disables", () => {
+    const prev = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+    try {
+      delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+      expect(shouldRequireGoalContract()).toBe(true);
+      process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "1";
+      expect(shouldRequireGoalContract()).toBe(true);
+      process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+      expect(shouldRequireGoalContract()).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+      else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = prev;
+    }
+  });
+});
+
+describe("generateDefaultAcceptanceCriteria", () => {
+  it("returns the static template when no runtime is supplied", async () => {
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "fix the bug",
+      "coding",
+    );
+    expect(criteria).toEqual([...DEFAULT_CRITERIA_TEMPLATES.coding]);
+    expect(criteria.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("falls back to the static set when useModel is absent", async () => {
+    const runtime = {} as IAgentRuntime;
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "build a web app",
+      undefined,
+      runtime,
+    );
+    expect(criteria).toEqual([...DEFAULT_CRITERIA_TEMPLATES["app-build"]]);
+  });
+
+  it("uses the model's refined criteria when it returns a valid object", async () => {
+    const refined = [
+      "the new endpoint returns 200 for a valid request",
+      "the parser handles empty input without throwing",
+      "tests for the new branch pass",
+      "the diff includes the regression test",
+    ];
+    const runtime = runtimeWithModel(JSON.stringify({ criteria: refined }));
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "fix the parser crash on empty input",
+      "coding",
+      runtime,
+    );
+    expect(criteria).toEqual(refined);
+  });
+
+  it("falls back to the static set when the model throws", async () => {
+    const runtime = runtimeWithModel(async () => {
+      throw new Error("model exploded");
+    });
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "fix the bug",
+      "coding",
+      runtime,
+    );
+    expect(criteria).toEqual([...DEFAULT_CRITERIA_TEMPLATES.coding]);
+  });
+
+  it("falls back when the model returns unparseable output", async () => {
+    const runtime = runtimeWithModel("not json at all, sorry");
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "fix the bug",
+      "coding",
+      runtime,
+    );
+    expect(criteria).toEqual([...DEFAULT_CRITERIA_TEMPLATES.coding]);
+  });
+
+  it("tops up to ≥3 from the fallback when the model is stingy", async () => {
+    const runtime = runtimeWithModel(
+      JSON.stringify({ criteria: ["only one concrete criterion"] }),
+    );
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "fix the bug",
+      "coding",
+      runtime,
+    );
+    expect(criteria.length).toBeGreaterThanOrEqual(3);
+    expect(criteria[0]).toBe("only one concrete criterion");
+  });
+
+  it("caps the criteria at the upper bound", async () => {
+    const many = Array.from({ length: 12 }, (_, i) => `criterion number ${i}`);
+    const runtime = runtimeWithModel(JSON.stringify({ criteria: many }));
+    const criteria = await generateDefaultAcceptanceCriteria(
+      "do a lot of things",
+      "coding",
+      runtime,
+    );
+    expect(criteria.length).toBeLessThanOrEqual(5);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for the TYPED completion-evidence bundle (issue #8894).
+ *
+ * Drives a real {@link OrchestratorTaskService} + in-memory store through a
+ * `task_complete` event (deterministic — no live model; the verifier model is
+ * stubbed and its prompt captured) and asserts:
+ *  - the bundle the verifier sees populates ≥3 fields (summary + diff +
+ *    tool output) from mocked session events/metadata;
+ *  - test/build stdout is mined out of recorded `tool_running` events;
+ *  - a trajectory JSONL line is written and its path recorded on a task event.
+ *
+ * The pure-string assembler (`buildCompletionEvidenceString`) and tool-output
+ * classifier (`classifyToolOutput`) are pinned directly too.
+ */
+
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { classifyToolOutput } from "../../src/services/completion-evidence.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import type { WorkspaceChangeSet } from "../../src/services/workspace-diff.js";
+
+interface SpawnResult {
+  sessionId: string;
+  agentType: string;
+  workdir: string;
+  status: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** ACP fake exposing the completion surface: event subscription, spawn, the
+ *  change-set read (`getSession`) AND a per-session `workdir` so the trajectory
+ *  writer targets the test's temp dir. */
+class BundleFakeAcp {
+  private handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | null = null;
+  private counter = 0;
+  private readonly sessionMeta = new Map<string, Record<string, unknown>>();
+  private readonly sessionWorkdir = new Map<string, string>();
+
+  constructor(private readonly defaultWorkdir: string) {}
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+
+  setSessionMetadata(sessionId: string, meta: Record<string, unknown>): void {
+    this.sessionMeta.set(sessionId, meta);
+  }
+
+  spawnSession(opts: Record<string, unknown>): Promise<SpawnResult> {
+    this.counter += 1;
+    const sessionId = `session-${this.counter}`;
+    const workdir = (opts.workdir as string | undefined) ?? this.defaultWorkdir;
+    this.sessionWorkdir.set(sessionId, workdir);
+    return Promise.resolve({
+      sessionId,
+      agentType: (opts.agentType as string | undefined) ?? "opencode",
+      workdir,
+      status: "ready",
+    });
+  }
+
+  getSession(sessionId: string): Promise<
+    | {
+        metadata: Record<string, unknown>;
+        workdir: string;
+      }
+    | undefined
+  > {
+    const workdir = this.sessionWorkdir.get(sessionId);
+    if (!workdir) return Promise.resolve(undefined);
+    return Promise.resolve({
+      metadata: this.sessionMeta.get(sessionId) ?? {},
+      workdir,
+    });
+  }
+
+  getChangedPaths(): string[] {
+    return [];
+  }
+
+  updateSessionMetadata(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  sendToSession(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stopSession(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function runtime(
+  acp: BundleFakeAcp,
+  useModel: (modelType: unknown, params: unknown) => Promise<string>,
+): IAgentRuntime {
+  return {
+    getService: () => acp,
+    useModel,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as never;
+}
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+/** Poll `predicate` until it returns truthy, flushing the macrotask queue each
+ *  iteration. Deterministic wait for a fire-and-forget side effect (the
+ *  trajectory write) instead of a fixed flush count. */
+async function waitFor<T>(
+  predicate: () => Promise<T> | T,
+  { tries = 200, label = "condition" }: { tries?: number; label?: string } = {},
+): Promise<T> {
+  for (let i = 0; i < tries; i += 1) {
+    const value = await predicate();
+    if (value) return value;
+    await flush();
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+}
+
+function changeSet(): WorkspaceChangeSet {
+  return {
+    changedFiles: ["src/cache.ts"],
+    diffStat: "1 file changed, 20 insertions(+)",
+    diff: "diff --git a/src/cache.ts b/src/cache.ts\n+export const cache = new Map();",
+    truncated: false,
+    capturedAt: Date.now(),
+  };
+}
+
+describe("classifyToolOutput", () => {
+  it("buckets test and build stdout out of mocked tool events", () => {
+    const out = classifyToolOutput([
+      {
+        text: "Test Files  3 passed (3)\nTests  12 passed (12)",
+        source: "vitest run",
+      },
+      { text: "tsc --noEmit\nCompiled with 0 errors", source: "tsc --noEmit" },
+      { text: "just narration about the code", source: "message" },
+    ]);
+    expect(out).toBeDefined();
+    expect(out?.test).toContain("Tests  12 passed (12)");
+    expect(out?.build).toContain("Compiled with 0 errors");
+    // The narration line carried no build/test marker, so nothing leaks in.
+    expect(out?.raw).toBeUndefined();
+  });
+
+  it("returns undefined when no signal carries build/test output", () => {
+    expect(
+      classifyToolOutput([{ text: "hello world", source: "message" }]),
+    ).toBeUndefined();
+  });
+});
+
+describe("completion-evidence bundle assembly + trajectory persistence", () => {
+  const prevFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  let workdir: string;
+
+  beforeEach(async () => {
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "1";
+    workdir = await mkdtemp(join(tmpdir(), "evidence-bundle-"));
+  });
+  afterEach(() => {
+    if (prevFlag === undefined) {
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    } else {
+      process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = prevFlag;
+    }
+  });
+
+  it("populates ≥3 bundle fields and feeds them to the verifier", async () => {
+    const acp = new BundleFakeAcp(workdir);
+    const prompts: string[] = [];
+    const service = new OrchestratorTaskService(
+      runtime(acp, async (_modelType, params) => {
+        prompts.push((params as { prompt: string }).prompt);
+        return '{"passed": true, "summary": "ok", "missing": []}';
+      }),
+      { store: new OrchestratorTaskStore({ backend: "memory" }) },
+    );
+    await service.start();
+
+    const task = await service.createTask({
+      title: "Cache the search endpoint",
+      goal: "Add caching to /search",
+      acceptanceCriteria: ["the search endpoint is cached", "tests pass"],
+    });
+    const detail = await service.spawnAgentForTask(task.id);
+    const sessionId = detail?.sessions[0]?.sessionId;
+    if (!sessionId) throw new Error("expected a spawned session");
+
+    // (1) diff field — change set mirrored onto the live ACP session.
+    acp.setSessionMetadata(sessionId, { lastChangeSet: changeSet() });
+
+    // (2) tool-output field — a `tool_running` event carrying real test stdout.
+    acp.emit(sessionId, "tool_running", {
+      toolCall: {
+        title: "vitest run",
+        kind: "execute",
+        status: "completed",
+        rawInput: { command: "bun run test" },
+        output:
+          "Running suite...\nTest Files  2 passed (2)\nTests  8 passed (8)",
+      },
+    });
+
+    // (3) summary field — the task_complete response.
+    acp.emit(sessionId, "task_complete", {
+      response: "Added caching and verified it works.",
+    });
+    await flush();
+    await flush();
+
+    expect(prompts).toHaveLength(1);
+    const [prompt] = prompts;
+    // diff + summary + tool output = three populated fields reaching the verifier.
+    expect(prompt).toContain("## CHANGESET");
+    expect(prompt).toContain("src/cache.ts");
+    expect(prompt).toContain("## FINAL REPLY");
+    expect(prompt).toContain("Added caching and verified it works.");
+    expect(prompt).toContain("## TEST / BUILD / TYPECHECK OUTPUT");
+    expect(prompt).toContain("Tests  8 passed (8)");
+    // The trajectory artifact is cited in the evidence.
+    expect(prompt).toContain("[trajectory] completion trajectory");
+    expect(prompt).toContain("completion-evidence.jsonl");
+  });
+
+  it("writes the bundle as a JSONL line and records its path on a task event", async () => {
+    const acp = new BundleFakeAcp(workdir);
+    const service = new OrchestratorTaskService(
+      runtime(
+        acp,
+        async () => '{"passed": true, "summary": "ok", "missing": []}',
+      ),
+      { store: new OrchestratorTaskStore({ backend: "memory" }) },
+    );
+    await service.start();
+
+    const task = await service.createTask({
+      title: "Cache it",
+      goal: "Add caching",
+      acceptanceCriteria: ["tests pass"],
+    });
+    const detail = await service.spawnAgentForTask(task.id);
+    const sessionId = detail?.sessions[0]?.sessionId;
+    if (!sessionId) throw new Error("expected a spawned session");
+
+    acp.setSessionMetadata(sessionId, { lastChangeSet: changeSet() });
+    acp.emit(sessionId, "task_complete", {
+      response: "Done and tested.",
+    });
+
+    const trajectoryPath = join(
+      workdir,
+      ".eliza",
+      "trajectories",
+      "completion-evidence.jsonl",
+    );
+    // The write is fire-and-forget (real mkdir + appendFile + addEvent); wait
+    // deterministically for the JSONL file to land instead of guessing a flush
+    // count.
+    const raw = await waitFor(
+      () => readFile(trajectoryPath, "utf8").catch(() => ""),
+      { label: "trajectory JSONL written" },
+    );
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0]) as {
+      kind: string;
+      taskId: string;
+      sessionId: string;
+      bundle: {
+        summary: string;
+        diffSummary?: string;
+        trajectoryPath?: string;
+      };
+    };
+    expect(record.kind).toBe("completion_evidence_bundle");
+    expect(record.taskId).toBe(task.id);
+    expect(record.sessionId).toBe(sessionId);
+    expect(record.bundle.summary).toBe("Done and tested.");
+    expect(record.bundle.diffSummary).toContain("src/cache.ts");
+    expect(record.bundle.trajectoryPath).toBe(trajectoryPath);
+
+    // The path is recorded on a durable task event for the reviewer.
+    const persistedEvent = await waitFor(
+      async () => {
+        const reloaded = await service.getTask(task.id);
+        return reloaded?.events.find(
+          (event) => event.eventType === "completion_evidence_persisted",
+        );
+      },
+      { label: "completion_evidence_persisted event recorded" },
+    );
+    expect(persistedEvent).toBeDefined();
+    expect(
+      (persistedEvent?.data as { trajectoryPath?: string } | undefined)
+        ?.trajectoryPath,
+    ).toBe(trajectoryPath);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildCompletionEvidenceString } from "../../src/services/completion-evidence.js";
+import {
+  buildCompletionEvidenceString,
+  buildEvidenceStringFromInput,
+} from "../../src/services/completion-evidence.js";
 import type { WorkspaceChangeSet } from "../../src/services/workspace-diff.js";
 
 function changeSet(over: Partial<WorkspaceChangeSet> = {}): WorkspaceChangeSet {
@@ -19,9 +22,9 @@ function changeSet(over: Partial<WorkspaceChangeSet> = {}): WorkspaceChangeSet {
   };
 }
 
-describe("buildCompletionEvidenceString", () => {
+describe("buildEvidenceStringFromInput (legacy signal-mining assembler)", () => {
   it("falls back to the bare summary when no richer signal exists", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "shipped it",
     });
     expect(evidence).toBe("shipped it");
@@ -29,7 +32,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("renders a CHANGESET section from a real git change set", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "done",
       changeSet: changeSet(),
     });
@@ -42,7 +45,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("omits the CHANGESET section when there are no changed files", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "done",
       changeSet: changeSet({ changedFiles: [], diff: "", diffStat: "" }),
     });
@@ -50,7 +53,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("renders DELIVERABLE and FINAL REPLY sections", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "I added caching to the search endpoint",
       deliverable: "captured stdout: cache hit ratio 0.94",
     });
@@ -61,7 +64,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("flags loopback URLs and keeps public URLs unflagged", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "deployed",
       verifiedUrls: ["http://localhost:3000/app", "https://app.example.com"],
     });
@@ -78,7 +81,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("mines build/test/typecheck lines out of recorded signals", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "done",
       signals: [
         { text: "just chatting about the weather", source: "message" },
@@ -97,7 +100,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("renders an ARTIFACTS section with screenshot/trajectory refs", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "done",
       artifacts: [
         {
@@ -120,7 +123,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("assembles all sections in a stable order when everything is present", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "final reply text",
       changeSet: changeSet(),
       deliverable: "deliverable text",
@@ -142,7 +145,7 @@ describe("buildCompletionEvidenceString", () => {
   });
 
   it("caps the total assembled evidence size", () => {
-    const evidence = buildCompletionEvidenceString({
+    const evidence = buildEvidenceStringFromInput({
       fallbackSummary: "x",
       changeSet: changeSet({ diff: "+line\n".repeat(5000) }),
       deliverable: "d".repeat(50_000),
@@ -156,5 +159,63 @@ describe("buildCompletionEvidenceString", () => {
     });
     expect(evidence.length).toBeLessThanOrEqual(8_100);
     expect(evidence).toContain("[evidence truncated]");
+  });
+});
+
+describe("buildCompletionEvidenceString (typed bundle, #8894)", () => {
+  it("falls back to the bare summary when only the summary is populated", () => {
+    const evidence = buildCompletionEvidenceString({
+      summary: "shipped it",
+      verifiedUrls: [],
+      screenshots: [],
+    });
+    expect(evidence).toBe("shipped it");
+    expect(evidence).not.toContain("##");
+  });
+
+  it("emits one section per populated field and omits empty ones", () => {
+    const evidence = buildCompletionEvidenceString({
+      summary: "final reply text",
+      diffSummary:
+        "diffstat: 1 file changed\nchangedFiles (1): src/a.ts\ndiff:\n+const x = 1;",
+      toolOutput: {
+        test: "Test Files  3 passed (3)\nTests  12 passed (12)",
+        build: "tsc --noEmit completed with 0 errors",
+      },
+      verifiedUrls: ["https://app.example.com", "http://localhost:3000"],
+      screenshots: ["/tmp/shots/home.png"],
+      trajectoryPath: "/tmp/traj/run.jsonl",
+    });
+    expect(evidence).toContain("## CHANGESET");
+    expect(evidence).toContain("src/a.ts");
+    expect(evidence).toContain("## FINAL REPLY");
+    expect(evidence).toContain("final reply text");
+    expect(evidence).toContain("## TEST / BUILD / TYPECHECK OUTPUT");
+    expect(evidence).toContain("### test");
+    expect(evidence).toContain("Tests  12 passed (12)");
+    expect(evidence).toContain("### build");
+    expect(evidence).toContain("0 errors");
+    expect(evidence).toContain("## VERIFIED URLS");
+    expect(evidence).toContain("https://app.example.com");
+    expect(evidence).toMatch(/http:\/\/localhost:3000 \(LOOPBACK/);
+    expect(evidence).toContain("## ARTIFACTS");
+    expect(evidence).toContain("[screenshot] screenshot — /tmp/shots/home.png");
+    expect(evidence).toContain(
+      "[trajectory] completion trajectory — /tmp/traj/run.jsonl",
+    );
+    // A field that was not populated produces no section.
+    expect(evidence).not.toContain("### lint");
+  });
+
+  it("omits the tool-output section when every tool field is empty", () => {
+    const evidence = buildCompletionEvidenceString({
+      summary: "did the work",
+      diffSummary: "diffstat: 1 file changed",
+      toolOutput: { test: "", build: "  " },
+      verifiedUrls: [],
+      screenshots: [],
+    });
+    expect(evidence).not.toContain("## TEST / BUILD / TYPECHECK OUTPUT");
+    expect(evidence).toContain("## CHANGESET");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-default-criteria.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-default-criteria.test.ts
@@ -1,0 +1,110 @@
+/**
+ * {@link OrchestratorTaskService.createTask} default-criteria wiring (#8896).
+ *
+ * A task created from a plain request ("fix this bug") used to carry NO
+ * acceptance criteria, so the auto goal-verifier fast-pathed to pass / parked
+ * forever in `validating`. createTask now populates measurable defaults when:
+ *   - the caller supplied none, AND
+ *   - the goal is non-trivial, AND
+ *   - the `ELIZA_REQUIRE_GOAL_CONTRACT` flag is on (default).
+ *
+ * Caller-supplied criteria are always preserved unchanged.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+
+/** A minimal runtime with NO `useModel`, forcing the deterministic static
+ *  fallback path (no model spend, fully reproducible). */
+function staticRuntime(): IAgentRuntime {
+  return {
+    getService: () => null,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+function makeService(): OrchestratorTaskService {
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  return new OrchestratorTaskService(staticRuntime(), { store });
+}
+
+const FLAG = "ELIZA_REQUIRE_GOAL_CONTRACT";
+let prevFlag: string | undefined;
+
+beforeEach(() => {
+  prevFlag = process.env[FLAG];
+  delete process.env[FLAG];
+});
+
+afterEach(() => {
+  if (prevFlag === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = prevFlag;
+});
+
+describe("createTask default acceptance criteria", () => {
+  it("populates ≥3 criteria for a criteria-free, non-trivial coding task", async () => {
+    const service = makeService();
+    const task = await service.createTask({
+      title: "Fix bug",
+      goal: "fix the off-by-one error in the date parser",
+    });
+    expect(task.acceptanceCriteria.length).toBeGreaterThanOrEqual(3);
+    // Static coding template — deterministic without a model.
+    expect(task.acceptanceCriteria).toContain("typecheck passes");
+    expect(task.acceptanceCriteria).toContain("tests pass");
+  });
+
+  it("derives a view-create criteria set from the goal text", async () => {
+    const service = makeService();
+    const task = await service.createTask({
+      title: "Add view",
+      goal: "create a new dashboard view with a viewKind for usage",
+    });
+    expect(task.acceptanceCriteria.some((c) => c.includes("/api/views"))).toBe(
+      true,
+    );
+    expect(task.acceptanceCriteria).not.toContain("typecheck passes");
+  });
+
+  it("uses an explicit kind as the task-type hint over goal keywords", async () => {
+    const service = makeService();
+    const task = await service.createTask({
+      title: "Deploy",
+      // Goal reads like coding, but kind forces the deploy template.
+      goal: "make the service reachable from the internet",
+      kind: "deploy",
+    });
+    expect(
+      task.acceptanceCriteria.some((c) => c.toLowerCase().includes("rollback")),
+    ).toBe(true);
+  });
+
+  it("never overwrites caller-supplied criteria", async () => {
+    const service = makeService();
+    const supplied = ["only this one matters"];
+    const task = await service.createTask({
+      title: "Custom",
+      goal: "do the custom thing with measurable proof",
+      acceptanceCriteria: supplied,
+    });
+    expect(task.acceptanceCriteria).toEqual(supplied);
+  });
+
+  it("leaves criteria empty when the flag is off", async () => {
+    process.env[FLAG] = "0";
+    const service = makeService();
+    const task = await service.createTask({
+      title: "Fix bug",
+      goal: "fix the off-by-one error in the date parser",
+    });
+    expect(task.acceptanceCriteria).toEqual([]);
+  });
+
+  it("leaves criteria empty for a trivial goal even with the flag on", async () => {
+    const service = makeService();
+    const task = await service.createTask({ title: "x", goal: "fix" });
+    expect(task.acceptanceCriteria).toEqual([]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -12,6 +12,7 @@ import {
   buildAutoVerifyCorrection,
   buildVerificationPrompt,
   LLM_GOAL_VERIFIER_NAME,
+  MAX_AUTO_VERIFY_ATTEMPTS,
   parseJudgeResponse,
   verifyGoalCompletion,
 } from "../../src/services/goal-llm-verifier.js";
@@ -184,6 +185,102 @@ describe("buildAutoVerifyCorrection", () => {
     // Each unmet criterion is listed with its own proof demand.
     expect(text).toContain("- c1");
     expect(text).toContain("- c2");
+  });
+
+  it("defaults to the collegial attempt-1 phrasing when no attempt is passed", () => {
+    const text = buildAutoVerifyCorrection(["tests pass"]);
+    // Attempt-1 wording, identical to the explicit attempt=1 call.
+    expect(text).toBe(buildAutoVerifyCorrection(["tests pass"], 1));
+    // No escalation language at attempt 1.
+    expect(text).not.toMatch(/FINAL ATTEMPT/);
+    expect(text).not.toMatch(/ALREADY FAILED/);
+  });
+
+  describe("escalating grill across attempts", () => {
+    const missing = ["the unit test suite is green", "the docs are updated"];
+
+    it("attempt 1 is collegial — no prior-failure or final-attempt warning", () => {
+      const text = buildAutoVerifyCorrection(missing, 1);
+      expect(text).toMatch(/did not confirm the task is complete/);
+      expect(text).toMatch(/proof to produce:/);
+      expect(text).not.toMatch(/ALREADY FAILED/);
+      expect(text).not.toMatch(/FINAL ATTEMPT/);
+    });
+
+    it("attempt 2 is pointed/socratic — direct questions and a prior-failure callout", () => {
+      const text = buildAutoVerifyCorrection(missing, 2);
+      // Calls out that a prior attempt already failed.
+      expect(text).toMatch(/attempt 2/);
+      expect(text).toMatch(/ALREADY FAILED/);
+      // Direct, socratic questions per criterion.
+      expect(text).toMatch(/Exactly which command did you run/);
+      expect(text).toMatch(/what was its EXACT output\?/);
+      expect(text).toMatch(/did you assume it works\?/i);
+      // Still not the final-attempt phrasing.
+      expect(text).not.toMatch(/FINAL ATTEMPT/);
+    });
+
+    it("attempt 3 (final) warns about escalation to a human before parking", () => {
+      const text = buildAutoVerifyCorrection(missing, 3);
+      expect(text).toMatch(/FINAL ATTEMPT/);
+      expect(text).toMatch(/ESCALATED to a human/);
+      expect(text).toMatch(/PARKED/);
+      expect(text).toMatch(/failed automatic verification twice/);
+    });
+
+    it("attempts 1, 2 and 3 produce DIFFERENT, escalating bodies", () => {
+      const a1 = buildAutoVerifyCorrection(missing, 1);
+      const a2 = buildAutoVerifyCorrection(missing, 2);
+      const a3 = buildAutoVerifyCorrection(missing, 3);
+      expect(a1).not.toBe(a2);
+      expect(a2).not.toBe(a3);
+      expect(a1).not.toBe(a3);
+    });
+
+    it("clamps attempts above the cap to the final-attempt phrasing", () => {
+      const high = buildAutoVerifyCorrection(
+        missing,
+        MAX_AUTO_VERIFY_ATTEMPTS + 5,
+      );
+      const final = buildAutoVerifyCorrection(
+        missing,
+        MAX_AUTO_VERIFY_ATTEMPTS,
+      );
+      expect(high).toBe(final);
+    });
+
+    it("clamps non-positive / non-finite attempts to attempt 1", () => {
+      const a1 = buildAutoVerifyCorrection(missing, 1);
+      expect(buildAutoVerifyCorrection(missing, 0)).toBe(a1);
+      expect(buildAutoVerifyCorrection(missing, -3)).toBe(a1);
+      expect(buildAutoVerifyCorrection(missing, Number.NaN)).toBe(a1);
+    });
+  });
+
+  describe("evidence checklist (every attempt)", () => {
+    const missing = ["tests pass", "the settings page renders the new toggle"];
+
+    for (const attempt of [1, 2, 3]) {
+      it(`attempt ${attempt} appends a checkbox list with one item + proof per unmet criterion`, () => {
+        const text = buildAutoVerifyCorrection(missing, attempt);
+        expect(text).toMatch(/Evidence checklist/i);
+        // One checkbox per unmet criterion, each carrying its proof demand.
+        expect(text).toContain("- [ ] tests pass — proof: ");
+        expect(text).toContain(
+          "- [ ] the settings page renders the new toggle — proof: ",
+        );
+        // The proof demand is the same one proofDemandFor produces (UI → screenshot).
+        const checklistLine = text
+          .split("\n")
+          .find((l) =>
+            l.includes("the settings page renders the new toggle — proof:"),
+          );
+        expect(checklistLine).toMatch(/screenshot/i);
+        // Exactly one checkbox per criterion (no duplicates / extras).
+        const boxes = text.split("\n").filter((l) => l.startsWith("- [ ] "));
+        expect(boxes).toHaveLength(missing.length);
+      });
+    }
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -14,13 +14,30 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import type {
   CreateTaskInput,
   OrchestratorTaskSession,
 } from "../../src/services/orchestrator-task-types.js";
+
+// This suite pins the status state machine and the ACP→task event bridge — NOT
+// the #8896 default-criteria feature. createTask now auto-populates acceptance
+// criteria for criteria-free, non-trivial goals (which would make these tasks
+// auto-verify on `task_complete` instead of parking in `validating`). Disable
+// the goal contract here so these tests exercise the original criteria-free
+// behavior; the default-criteria feature has its own dedicated suites
+// (acceptance-criteria.test.ts, create-task-default-criteria.test.ts).
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
 
 interface SpawnResult {
   sessionId: string;

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -190,10 +190,47 @@ describe("auto goal verification on task_complete", () => {
     });
     const lastSent = fake.sent.at(-1);
     expect(lastSent?.text).toContain("tests pass");
+    // First failure → attempt 1 → collegial phrasing + evidence checklist.
+    expect(lastSent?.text).toMatch(/did not confirm the task is complete/);
+    expect(lastSent?.text).toMatch(/Evidence checklist/i);
+    expect(lastSent?.text).not.toMatch(/FINAL ATTEMPT/);
     const doc = await store.getTask(taskId);
     expect(doc?.task.status).toBe("active");
     expect(doc?.task.metadata.autoVerifyAttempts).toBe(1);
     expect(doc?.task.status).not.toBe("done");
+  });
+
+  it("escalates the corrective tone on the second failure (attempt 2)", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    // One prior failed attempt already recorded, so the next correction is
+    // attempt 2 — the call site must pass attempts + 1 to the grill builder.
+    await store.updateTask(taskId, { metadata: { autoVerifyAttempts: 1 } });
+    const runtime = makeRuntime(fake.service, () =>
+      JSON.stringify({
+        passed: false,
+        summary: "still no proof",
+        missing: ["tests pass"],
+      }),
+    );
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "trust me it works" });
+    await vi.waitFor(() => {
+      expect(fake.service.sendToSession).toHaveBeenCalled();
+    });
+    const lastSent = fake.sent.at(-1);
+    // Pointed/socratic attempt-2 wording, not the attempt-1 collegial message.
+    expect(lastSent?.text).toMatch(/attempt 2/);
+    expect(lastSent?.text).toMatch(/ALREADY FAILED/);
+    expect(lastSent?.text).toMatch(/Exactly which command did you run/);
+    expect(lastSent?.text).toMatch(/Evidence checklist/i);
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.metadata.autoVerifyAttempts).toBe(2);
   });
 
   it("escalates to waiting_on_user after the attempt cap", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -1,0 +1,254 @@
+/**
+ * Default acceptance-criteria generation for durable orchestrator tasks.
+ *
+ * The auto goal-verifier (see {@link verifyGoalCompletion}) only grills a
+ * completed sub-agent when the task carries acceptance criteria — a task with
+ * `acceptanceCriteria.length === 0` fast-paths to "pass" (or, in
+ * {@link OrchestratorTaskService.autoVerifyCompletion}, simply parks in
+ * `validating`). The common case — a task minted from a plain request like
+ * "fix this bug" — has no criteria, so the verifier never fires and the whole
+ * grill-until-truly-done loop is skipped.
+ *
+ * This module closes that gap: when a durable task is created with EMPTY
+ * criteria and a non-trivial goal, it generates 3-5 measurable criteria and
+ * stores them on the task so the verifier always has something to grill
+ * against.
+ *
+ * Two layers:
+ *
+ *   1. **Static templates per task type** ({@link detectTaskType} +
+ *      {@link DEFAULT_CRITERIA_TEMPLATES}) — deterministic, model-free, and
+ *      always the fallback.
+ *   2. **Optional model refinement** ({@link generateDefaultAcceptanceCriteria})
+ *      — a cheap `ModelType.TEXT_SMALL` call (matching the rest of this plugin)
+ *      that turns the goal + template into concrete, measurable criteria. The
+ *      model call is fully defensive: on ANY failure (no `useModel`, throw,
+ *      malformed JSON, too-few criteria) it falls back to the static set and
+ *      never throws.
+ *
+ * Gated by `ELIZA_REQUIRE_GOAL_CONTRACT` (default ON; only `"0"` disables),
+ * mirroring the {@link shouldAutoVerifyGoal} convention.
+ *
+ * Refs: elizaOS/eliza#8896
+ *
+ * @module services/acceptance-criteria
+ */
+
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import { parseJsonObjectResponse } from "./json-model-output.js";
+
+/** Coarse task classification driving which template set is applied. */
+export type OrchestratorTaskType =
+  | "coding"
+  | "view-create"
+  | "app-build"
+  | "deploy";
+
+/** Lower bound the issue calls for: a generated set always has ≥3 criteria. */
+const MIN_CRITERIA = 3;
+/** Upper bound so the verifier prompt stays cheap and focused. */
+const MAX_CRITERIA = 5;
+/** Per-criterion length cap so a runaway model line can't bloat the record. */
+const MAX_CRITERION_CHARS = 240;
+/** A goal shorter than this is treated as trivial — no criteria generated. */
+const MIN_GOAL_CHARS = 8;
+
+/**
+ * The base coding criteria. Every "build something in the repo" task type
+ * extends this set, so a coding task and an app-build task share the same
+ * green-bar checks and the app-build only ADDS its live-URL criterion.
+ */
+const CODING_CRITERIA: readonly string[] = [
+  "typecheck passes",
+  "lint passes",
+  "tests pass",
+  "the change is summarized in the diff",
+];
+
+/**
+ * Static criteria templates keyed by task type. Each set is intentionally
+ * measurable (a verifier can grill each line against concrete evidence) and
+ * each set is DISTINCT so a misclassified task still gets useful, type-shaped
+ * criteria rather than the generic coding default.
+ */
+export const DEFAULT_CRITERIA_TEMPLATES: Readonly<
+  Record<OrchestratorTaskType, readonly string[]>
+> = {
+  coding: CODING_CRITERIA,
+  "app-build": [...CODING_CRITERIA, "the live URL returns HTTP 200"],
+  "view-create": [
+    "a Plugin.views entry is declared with a viewKind",
+    "the view appears in /api/views",
+    "a screenshot of the working view is attached",
+  ],
+  deploy: [
+    "the deployment target is reachable (non-loopback URL returns 200)",
+    "rollback/undo path is documented",
+    "the deploy command/log output shows a successful, non-errored run",
+  ],
+};
+
+/**
+ * Whether the orchestrator auto-generates default acceptance criteria for a
+ * criteria-free task so the verifier always fires. Default ON; set
+ * `ELIZA_REQUIRE_GOAL_CONTRACT=0` to disable (a criteria-free task then stays
+ * criteria-free and behaves exactly as before). Mirrors the
+ * {@link shouldAutoVerifyGoal} flag convention.
+ */
+export function shouldRequireGoalContract(): boolean {
+  return process.env.ELIZA_REQUIRE_GOAL_CONTRACT !== "0";
+}
+
+/** Keyword groups feeding {@link detectTaskType}. Ordered most-specific-first
+ *  so a goal that matches several groups gets the narrower classification. */
+const VIEW_RE =
+  /\b(view|views|viewkind|widget|dashboard\s+(?:card|panel|tile)|render\s+a\s+view)\b/i;
+const DEPLOY_RE =
+  /\b(deploy|deployment|release\s+to\s+prod|ship\s+to\s+prod|production\s+rollout|provision\s+infra|autoscal\w*|hetzner|cloudflare\s+worker|publish\s+the\s+(?:site|app))\b/i;
+const APP_BUILD_RE =
+  /\b(app|application|website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|build\s+a\s+(?:site|page|app)|create\s+a\s+(?:site|page|app))\b/i;
+
+/**
+ * Classify a task from its goal text. Defaults to `coding` — the safest
+ * superset, since every other type extends or specializes the coding checks.
+ * Pure and deterministic so the static path is fully testable without a model.
+ */
+export function detectTaskType(goal: string): OrchestratorTaskType {
+  const text = (goal ?? "").trim();
+  if (text.length === 0) return "coding";
+  // View creation is the most specific signal — check it first.
+  if (VIEW_RE.test(text)) return "view-create";
+  if (DEPLOY_RE.test(text)) return "deploy";
+  if (APP_BUILD_RE.test(text)) return "app-build";
+  return "coding";
+}
+
+/** Whether a goal is substantive enough to warrant generated criteria. A blank
+ *  or near-blank goal gets none (the caller leaves criteria empty). */
+export function isNonTrivialGoal(goal: string): boolean {
+  return (goal ?? "").trim().length >= MIN_GOAL_CHARS;
+}
+
+/** Normalize, de-dupe, length-cap and bound a candidate criteria list to the
+ *  [MIN, MAX] window, topping up from the static fallback when the model
+ *  returned too few usable lines. Always returns ≥{@link MIN_CRITERIA} when the
+ *  fallback set itself has that many. */
+function normalizeCriteria(
+  candidates: readonly string[],
+  fallback: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (raw: string): void => {
+    const trimmed = raw.trim().slice(0, MAX_CRITERION_CHARS).trim();
+    if (trimmed.length === 0) return;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(trimmed);
+  };
+  for (const candidate of candidates) {
+    if (out.length >= MAX_CRITERIA) break;
+    push(candidate);
+  }
+  // Top up to the minimum from the static fallback if the model was stingy.
+  for (const item of fallback) {
+    if (out.length >= MIN_CRITERIA) break;
+    push(item);
+  }
+  return out.slice(0, MAX_CRITERIA);
+}
+
+/**
+ * The static, model-free criteria for a goal. Always returns the template set
+ * for the detected (or hinted) task type — the deterministic fallback that
+ * {@link generateDefaultAcceptanceCriteria} returns whenever the model path is
+ * unavailable or fails.
+ */
+export function staticAcceptanceCriteria(
+  goal: string,
+  taskTypeHint?: OrchestratorTaskType,
+): string[] {
+  const type = taskTypeHint ?? detectTaskType(goal);
+  return [...DEFAULT_CRITERIA_TEMPLATES[type]];
+}
+
+/** Build the refinement prompt: hand the model the goal + the static template
+ *  and ask it to return 3-5 concrete, measurable criteria as a JSON object. */
+function buildRefinePrompt(
+  goal: string,
+  type: OrchestratorTaskType,
+  template: readonly string[],
+): string {
+  return [
+    "You are setting the acceptance criteria a coding sub-agent must PROVE before its task is accepted.",
+    "Turn the goal below into 3-5 concrete, measurable, independently-verifiable criteria.",
+    "Each criterion must be checkable from concrete evidence (a passing build/test/typecheck line, a diff hunk, a reachable URL, a screenshot) — never a vague aspiration.",
+    "",
+    `Detected task type: ${type}`,
+    "Goal:",
+    goal.trim() || "(no goal text)",
+    "",
+    "Baseline criteria for this task type (keep the ones that still apply, specialize them to the goal, and add any goal-specific ones):",
+    template.map((c, i) => `${i + 1}. ${c}`).join("\n"),
+    "",
+    'Respond with a SINGLE JSON object and nothing else, no markdown fences. Schema: { "criteria": ["<criterion>", "<criterion>", ...] }',
+    `Return between ${MIN_CRITERIA} and ${MAX_CRITERIA} criteria.`,
+  ].join("\n");
+}
+
+/** Pull a string[] from the parsed model object, tolerating the common shapes
+ *  a small model produces ({criteria:[…]} or a bare array under another key). */
+function extractCriteriaArray(parsed: Record<string, unknown>): string[] {
+  const direct = parsed.criteria;
+  const source = Array.isArray(direct)
+    ? direct
+    : (Object.values(parsed).find((value): value is unknown[] =>
+        Array.isArray(value),
+      ) ?? []);
+  return source
+    .map((entry) => (typeof entry === "string" ? entry : ""))
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Generate default acceptance criteria for a goal.
+ *
+ * - When `runtime` exposes `useModel`, attempts ONE cheap
+ *   `ModelType.TEXT_SMALL` refinement of the static template into concrete,
+ *   measurable criteria. The call is fully defensive: any failure (missing
+ *   `useModel`, throw, unparseable / empty response, too-few usable lines)
+ *   falls back to the static template — it NEVER throws.
+ * - When `runtime` is omitted, returns the static template directly (the
+ *   deterministic path the unit tests pin).
+ *
+ * Always returns ≥{@link MIN_CRITERIA} criteria for a non-trivial goal.
+ */
+export async function generateDefaultAcceptanceCriteria(
+  goal: string,
+  taskTypeHint?: OrchestratorTaskType,
+  runtime?: IAgentRuntime,
+): Promise<string[]> {
+  const type = taskTypeHint ?? detectTaskType(goal);
+  const fallback = [...DEFAULT_CRITERIA_TEMPLATES[type]];
+
+  if (!runtime || typeof runtime.useModel !== "function") return fallback;
+
+  try {
+    const prompt = buildRefinePrompt(goal, type, fallback);
+    const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+      prompt,
+      stopSequences: [],
+    });
+    const raw = typeof result === "string" ? result : String(result ?? "");
+    const parsed = parseJsonObjectResponse(raw);
+    if (!parsed) return fallback;
+    const candidates = extractCriteriaArray(parsed);
+    if (candidates.length === 0) return fallback;
+    const refined = normalizeCriteria(candidates, fallback);
+    return refined.length >= MIN_CRITERIA ? refined : fallback;
+  } catch {
+    // Defensive: criteria generation must never break task creation.
+    return fallback;
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -68,6 +68,49 @@ export interface EvidenceArtifactRef {
   ref?: string;
 }
 
+/**
+ * Captured stdout from the sub-agent's tool runs, split by tool class. Each
+ * field is the raw (already-bounded) output of a `vitest`/`tsc`/`biome`-style
+ * run mined from the recorded ACP tool events, so the verifier can read the
+ * actual run result rather than the agent's narration of it. `raw` is a
+ * catch-all for tool output that matched a build/test marker but couldn't be
+ * confidently classed as test/build/lint.
+ */
+export interface ToolOutputEvidence {
+  test?: string;
+  build?: string;
+  lint?: string;
+  raw?: string;
+}
+
+/**
+ * The TYPED completion-evidence bundle (issue #8894). This is the formalized,
+ * collect-once shape the orchestrator assembles BEFORE verification: every
+ * evidence source resolves to a named field instead of being threaded through
+ * the prompt as loose strings. {@link buildCompletionEvidenceString} serializes
+ * it into the same clearly-sectioned string the verifier already grills
+ * against, emitting exactly one section per POPULATED field and omitting empty
+ * ones.
+ *
+ * `verifiedUrls` and `screenshots` are required (default to `[]`); everything
+ * else is optional and contributes a section only when present.
+ */
+export interface CompletionEvidenceBundle {
+  /** The sub-agent's reported result — the fallback/final-reply text. */
+  summary: string;
+  /** Human-readable git diff summary (diffstat + changed files + capped diff)
+   *  captured at completion, if any. */
+  diffSummary?: string;
+  /** Captured tool stdout split by class (test/build/lint) plus a raw bucket. */
+  toolOutput?: ToolOutputEvidence;
+  /** URLs the router probed/verified at completion (loopback-flagged on render). */
+  verifiedUrls: string[];
+  /** Screenshot artifact paths found on the task/session. */
+  screenshots: string[];
+  /** Path to the persisted trajectory JSONL artifact for this completion. */
+  trajectoryPath?: string;
+}
+
 /** Total cap for the assembled evidence string. Sits under the verifier's own
  *  {@link trimEvidence} budget so the section structure survives intact. */
 const MAX_EVIDENCE_CHARS = 8_000;
@@ -78,6 +121,8 @@ const MAX_SIGNAL_LINES = 40;
 const MAX_SIGNAL_CHARS = 2_000;
 const MAX_URLS = 12;
 const MAX_ARTIFACTS = 20;
+/** Per-tool-output-field cap (test/build/lint/raw each). */
+const MAX_TOOL_OUTPUT_CHARS = 2_000;
 
 /**
  * Lines that look like the output of a build / test / typecheck / lint run.
@@ -104,6 +149,68 @@ function clamp(text: string, max: number): string {
   return `${trimmed.slice(0, max)}\n… [truncated]`;
 }
 
+/** Markers that class a signal as TEST output (vitest/jest run, suite result). */
+const TEST_MARKER_RE =
+  /\b(?:vitest|jest|pytest|test\s+files?|tests?\s+(?:passed|failed|run)|✓|✗|✔|✖|specs?|suites?|coverage|PASS|FAIL)\b/;
+/** Markers that class a signal as BUILD/TYPECHECK output (tsc/tsgo/compile). */
+const BUILD_MARKER_RE =
+  /\b(?:tsc|tsgo|typecheck|type-check|type\s+error|compiled|compilation|build\s+(?:succeeded|failed|complete)|cargo\s+build|go\s+build)\b/;
+/** Markers that class a signal as LINT output (biome/eslint). */
+const LINT_MARKER_RE = /\b(?:biome|eslint|\blint\b)\b/;
+
+/** Extract just the build/test-looking lines from one signal body, deduped and
+ *  bounded, so a noisy tool transcript collapses to its run-result lines. */
+function extractToolLines(text: string, seen: Set<string>): string[] {
+  const out: string[] = [];
+  for (const rawLine of text.replace(/\r\n/g, "\n").split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.length > 400) continue;
+    if (!BUILD_TEST_LINE_RE.test(line)) continue;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    out.push(line);
+    if (out.length >= MAX_SIGNAL_LINES) break;
+  }
+  return out;
+}
+
+/**
+ * Classify the build/test/typecheck/lint output mined from recorded tool
+ * signals into a {@link ToolOutputEvidence} bucket per tool class, so the
+ * verifier can read the actual test/build stdout under named headers. A signal
+ * is routed by the markers in its body (and source label): test markers →
+ * `test`, build/typecheck → `build`, lint → `lint`; build-test-looking lines
+ * that match none fall into `raw`. Returns undefined when nothing matched.
+ */
+export function classifyToolOutput(
+  signals: readonly EvidenceSignal[],
+): ToolOutputEvidence | undefined {
+  const buckets: Record<keyof ToolOutputEvidence, string[]> = {
+    test: [],
+    build: [],
+    lint: [],
+    raw: [],
+  };
+  const seen = new Set<string>();
+  for (const signal of signals) {
+    const lines = extractToolLines(signal.text, seen);
+    if (lines.length === 0) continue;
+    const haystack = `${signal.source ?? ""}\n${signal.text}`;
+    let bucket: keyof ToolOutputEvidence;
+    if (TEST_MARKER_RE.test(haystack)) bucket = "test";
+    else if (BUILD_MARKER_RE.test(haystack)) bucket = "build";
+    else if (LINT_MARKER_RE.test(haystack)) bucket = "lint";
+    else bucket = "raw";
+    buckets[bucket].push(...lines);
+  }
+  const out: ToolOutputEvidence = {};
+  if (buckets.test.length > 0) out.test = buckets.test.join("\n");
+  if (buckets.build.length > 0) out.build = buckets.build.join("\n");
+  if (buckets.lint.length > 0) out.lint = buckets.lint.join("\n");
+  if (buckets.raw.length > 0) out.raw = buckets.raw.join("\n");
+  return hasToolOutput(out) ? out : undefined;
+}
+
 /** Pull the lines from a signal body that read like build/test/typecheck
  *  output, so the verifier sees the actual run output rather than narration. */
 function extractBuildTestLines(signals: readonly EvidenceSignal[]): string[] {
@@ -124,13 +231,18 @@ function extractBuildTestLines(signals: readonly EvidenceSignal[]): string[] {
   return out;
 }
 
-function renderChangeSetSection(changeSet: WorkspaceChangeSet): string {
+/**
+ * Render the human-readable body of a {@link WorkspaceChangeSet} (diffstat +
+ * changed files + a capped diff) WITHOUT the section header. Used as the
+ * `diffSummary` field of a {@link CompletionEvidenceBundle}, so the bundle and
+ * the legacy assembler produce byte-identical changeset text.
+ */
+export function renderChangeSetBody(changeSet: WorkspaceChangeSet): string {
   const files =
     changeSet.changedFiles.length > 0
       ? changeSet.changedFiles.join(", ")
       : "(none)";
   const lines = [
-    "## CHANGESET (real git diff captured at completion)",
     `diffstat: ${changeSet.diffStat || "(none)"}`,
     `changedFiles (${changeSet.changedFiles.length}): ${files}`,
   ];
@@ -140,6 +252,13 @@ function renderChangeSetSection(changeSet: WorkspaceChangeSet): string {
   }
   if (changeSet.truncated) lines.push("(changeset truncated)");
   return lines.join("\n");
+}
+
+function renderChangeSetSection(changeSet: WorkspaceChangeSet): string {
+  return [
+    "## CHANGESET (real git diff captured at completion)",
+    renderChangeSetBody(changeSet),
+  ].join("\n");
 }
 
 function renderUrlsSection(urls: readonly string[]): string {
@@ -168,13 +287,114 @@ function renderArtifactsSection(
   return lines.join("\n");
 }
 
+function renderToolOutputSection(toolOutput: ToolOutputEvidence): string {
+  const lines = ["## TEST / BUILD / TYPECHECK OUTPUT (captured tool stdout)"];
+  const labelled: [string, string | undefined][] = [
+    ["test", toolOutput.test],
+    ["build", toolOutput.build],
+    ["lint", toolOutput.lint],
+    ["raw", toolOutput.raw],
+  ];
+  for (const [label, value] of labelled) {
+    const text = value?.trim();
+    if (!text) continue;
+    lines.push(`### ${label}`);
+    lines.push(clamp(text, MAX_TOOL_OUTPUT_CHARS));
+  }
+  return lines.join("\n");
+}
+
+function hasToolOutput(toolOutput: ToolOutputEvidence | undefined): boolean {
+  if (!toolOutput) return false;
+  return Boolean(
+    toolOutput.test?.trim() ||
+      toolOutput.build?.trim() ||
+      toolOutput.lint?.trim() ||
+      toolOutput.raw?.trim(),
+  );
+}
+
 /**
- * Assemble the sectioned completion-evidence string from the signals the
+ * Serialize the TYPED {@link CompletionEvidenceBundle} into the clearly-
+ * sectioned evidence string the verifier grills against — one section per
+ * POPULATED field, empty fields omitted. When nothing richer than the bare
+ * summary is present, returns the bare summary (prior thin-completion
+ * behavior). This is the issue #8894 entry point; the legacy signal-mining
+ * assembler lives in {@link buildEvidenceStringFromInput} and remains exported.
+ */
+export function buildCompletionEvidenceString(
+  bundle: CompletionEvidenceBundle,
+): string {
+  const sections: string[] = [];
+  let hasRicherSection = false;
+
+  const diff = bundle.diffSummary?.trim();
+  if (diff) {
+    sections.push(
+      ["## CHANGESET (real git diff captured at completion)", diff].join("\n"),
+    );
+    hasRicherSection = true;
+  }
+
+  const reply = bundle.summary.trim();
+  if (reply) {
+    sections.push(
+      [
+        "## FINAL REPLY (sub-agent's reported result)",
+        clamp(reply, MAX_REPLY_CHARS),
+      ].join("\n"),
+    );
+  }
+
+  if (bundle.verifiedUrls.length > 0) {
+    sections.push(renderUrlsSection(bundle.verifiedUrls));
+    hasRicherSection = true;
+  }
+
+  if (bundle.toolOutput && hasToolOutput(bundle.toolOutput)) {
+    sections.push(renderToolOutputSection(bundle.toolOutput));
+    hasRicherSection = true;
+  }
+
+  const artifacts: EvidenceArtifactRef[] = bundle.screenshots
+    .map((ref) => ref.trim())
+    .filter(Boolean)
+    .map((ref) => ({ artifactType: "screenshot", title: "screenshot", ref }));
+  const trajectory = bundle.trajectoryPath?.trim();
+  if (trajectory) {
+    artifacts.push({
+      artifactType: "trajectory",
+      title: "completion trajectory",
+      ref: trajectory,
+    });
+  }
+  if (artifacts.length > 0) {
+    sections.push(renderArtifactsSection(artifacts));
+    hasRicherSection = true;
+  }
+
+  if (!hasRicherSection) {
+    return reply;
+  }
+
+  const assembled = sections.join("\n\n");
+  return assembled.length > MAX_EVIDENCE_CHARS
+    ? `${assembled.slice(0, MAX_EVIDENCE_CHARS)}\n… [evidence truncated]`
+    : assembled;
+}
+
+/**
+ * Assemble the sectioned completion-evidence string from the loose signals the
  * orchestrator already has. Always returns a non-empty string: when nothing
  * richer than the fallback summary is available it still returns the summary,
  * so the verifier behaves exactly as before for thin completions.
+ *
+ * Retained for backward compatibility and as the signal-mining helper the
+ * bundle collector reuses to extract build/test lines; new callers should
+ * assemble a {@link CompletionEvidenceBundle} and use
+ * {@link buildCompletionEvidenceString}.
  */
-export function buildCompletionEvidenceString(
+export function buildEvidenceStringFromInput(
   input: CompletionEvidenceInput,
 ): string {
   const sections: string[] = [];

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -103,28 +103,122 @@ function proofDemandFor(criterion: string): string {
 }
 
 /**
+ * Render the explicit evidence checklist appended to every correction. Each
+ * unmet criterion becomes a markdown checkbox the worker MUST return ticked
+ * WITH the artifact pasted next to it, and carries its per-item proof demand
+ * (reusing {@link proofDemandFor}). A ticked box with no pasted artifact is
+ * treated as not done — verification will fail again.
+ */
+function buildEvidenceChecklist(missing: readonly string[]): string {
+  return [
+    "Evidence checklist — return EVERY box ticked WITH the artifact pasted inline (a ticked box and no artifact = not done):",
+    ...missing.map(
+      (criterion) => `- [ ] ${criterion} — proof: ${proofDemandFor(criterion)}`,
+    ),
+  ].join("\n");
+}
+
+/**
  * Compose the corrective message body sent back to a sub-agent when automatic
  * verification did not confirm every acceptance criterion. The
  * goal/acceptance-criteria envelope is re-applied by `buildGoalFollowUp`
  * (reason `validation_failed`); this is just the human-readable gap report.
  *
- * Behaves like a demanding manager: for EACH unmet criterion it names the
- * specific proof the worker must produce and re-report WITH (a passing
- * build/test line, a screenshot for UI, a scenario trajectory for agent
- * behavior, a reachable URL for a deploy), so the next completion arrives with
- * verifiable evidence instead of another plausible-but-unproven claim.
+ * Behaves like a demanding manager whose tone ESCALATES per attempt — a
+ * manager who has been fobbed off twice does not keep asking nicely:
+ *
+ * - **Attempt 1** — collegial: "verification didn't confirm X; here's the
+ *   proof to produce" (the per-criterion proof demands).
+ * - **Attempt 2** — pointed/socratic: direct questions per unmet criterion
+ *   ("which command did you run, and what was its output? Paste it."), and a
+ *   note that a prior attempt already failed.
+ * - **Attempt 3+ (final)** — firm last-chance: this is the final automated
+ *   attempt before the task is parked for a human; every checklist item must be
+ *   proven inline or the task is escalated.
+ *
+ * For EACH unmet criterion it names the specific proof the worker must produce
+ * and re-report WITH (a passing build/test line, a screenshot for UI, a
+ * scenario trajectory for agent behavior, a reachable URL for a deploy), and
+ * appends an explicit {@link buildEvidenceChecklist} the worker must tick with
+ * the artifact, so the next completion arrives with verifiable evidence instead
+ * of another plausible-but-unproven claim.
+ *
+ * @param missing unmet acceptance criteria the verifier could not confirm.
+ * @param attempt 1-based correction attempt (defaults to 1 so callers that
+ *        don't track attempts keep the collegial behavior). Clamped to
+ *        `[1, MAX_AUTO_VERIFY_ATTEMPTS]`; attempt `MAX_AUTO_VERIFY_ATTEMPTS`
+ *        is the final-chance phrasing before escalation to a human.
  */
-export function buildAutoVerifyCorrection(missing: readonly string[]): string {
+export function buildAutoVerifyCorrection(
+  missing: readonly string[],
+  attempt = 1,
+): string {
+  const stage = Math.min(
+    Math.max(Math.trunc(attempt) || 1, 1),
+    MAX_AUTO_VERIFY_ATTEMPTS,
+  );
+  const isFinal = stage >= MAX_AUTO_VERIFY_ATTEMPTS;
+
+  const header: string[] = [];
+  const proofSection: string[] = [];
+  const closing: string[] = [];
+
+  if (stage <= 1) {
+    // Attempt 1 — collegial gap report.
+    header.push(
+      "Automatic verification did not confirm the task is complete. A plausible description is NOT proof — each criterion below is still unproven and must be backed by a concrete artifact.",
+      "",
+      "For EACH unmet acceptance criterion, do the work and then paste the exact proof named:",
+    );
+    proofSection.push(
+      ...missing.map(
+        (criterion) =>
+          `- ${criterion}\n    → proof to produce: ${proofDemandFor(criterion)}`,
+      ),
+    );
+    closing.push(
+      "Then report complete AGAIN, and this time INCLUDE that proof inline in your final message: the actual command output (build/typecheck/test summary lines), screenshot path(s) for any UI, scenario trajectory report path for any agent behavior, and reachable non-loopback URL(s) for anything deployed. Claims without pasted evidence will fail verification again.",
+    );
+  } else if (!isFinal) {
+    // Attempt 2 — pointed, socratic interrogation; call out the prior failure.
+    header.push(
+      `This is attempt ${stage}: your previous "complete" report ALREADY FAILED automatic verification — the same criteria are still unproven. I am not going to take "it works" on faith. Answer these directly, per criterion, with pasted evidence:`,
+      "",
+    );
+    proofSection.push(
+      ...missing.map(
+        (criterion) =>
+          `- ${criterion}\n    → Exactly which command did you run for this, and what was its EXACT output? Paste it. Did you actually open/observe/run it, or did you assume it works? Show: ${proofDemandFor(criterion)}`,
+      ),
+    );
+    closing.push(
+      "Do not re-report complete until you can answer every question above with a pasted artifact. A restatement of what you intended to do is not an answer — I need the actual output, path, or URL.",
+    );
+  } else {
+    // Attempt 3+ — final automated attempt before human escalation.
+    header.push(
+      `FINAL ATTEMPT (attempt ${stage} of ${MAX_AUTO_VERIFY_ATTEMPTS}). Your work has already failed automatic verification twice. This is the LAST automated correction — if the next report is not fully proven, the task is PARKED and ESCALATED to a human, and you do not get another pass.`,
+      "",
+      "Every unmet criterion below MUST be proven INLINE in your next message — no exceptions, no promises of future work:",
+    );
+    proofSection.push(
+      ...missing.map(
+        (criterion) =>
+          `- ${criterion}\n    → REQUIRED proof (paste it or the task is escalated): ${proofDemandFor(criterion)}`,
+      ),
+    );
+    closing.push(
+      'If you cannot produce the proof for a criterion, say so explicitly and explain the blocker — do NOT report complete with the gap unproven. An unproven "complete" report at this stage parks the task for a human.',
+    );
+  }
+
   const lines = [
-    "Automatic verification did not confirm the task is complete. A plausible description is NOT proof — each criterion below is still unproven and must be backed by a concrete artifact.",
+    ...header,
+    ...proofSection,
     "",
-    "For EACH unmet acceptance criterion, do the work and then paste the exact proof named:",
-    ...missing.map(
-      (criterion) =>
-        `- ${criterion}\n    → proof to produce: ${proofDemandFor(criterion)}`,
-    ),
+    ...closing,
     "",
-    "Then report complete AGAIN, and this time INCLUDE that proof inline in your final message: the actual command output (build/typecheck/test summary lines), screenshot path(s) for any UI, scenario trajectory report path for any agent behavior, and reachable non-loopback URL(s) for anything deployed. Claims without pasted evidence will fail verification again.",
+    buildEvidenceChecklist(missing),
   ];
   return lines.join("\n");
 }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1512,7 +1512,10 @@ export class OrchestratorTaskService extends Service {
         await this.sendToTaskAgent(
           taskId,
           sessionId,
-          buildAutoVerifyCorrection(verdict.missing),
+          // Escalate the grill per attempt: `attempts` is the count of prior
+          // failures, so `attempts + 1` is this correction's 1-based stage
+          // (matches the persisted autoVerifyAttempts bump above).
+          buildAutoVerifyCorrection(verdict.missing, attempts + 1),
           "validation_failed",
         );
         await this.store.updateTask(taskId, { status: "active" });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -21,6 +21,13 @@ import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
+import {
+  detectTaskType,
+  generateDefaultAcceptanceCriteria,
+  isNonTrivialGoal,
+  type OrchestratorTaskType,
+  shouldRequireGoalContract,
+} from "./acceptance-criteria.js";
 import { AcpService } from "./acp-service.js";
 import { assignAgentName } from "./agent-name-assignment.js";
 import {
@@ -1140,7 +1147,9 @@ export class OrchestratorTaskService extends Service {
   // ---- lifecycle ---------------------------------------------------------
 
   async createTask(input: CreateTaskInput): Promise<TaskThreadDetailDto> {
-    const doc = await this.store.createTask(input);
+    const doc = await this.store.createTask(
+      await this.withDefaultAcceptanceCriteria(input),
+    );
     if (input.originalRequest) {
       await this.recordMessage(doc.task.id, {
         content: input.originalRequest,
@@ -1150,6 +1159,60 @@ export class OrchestratorTaskService extends Service {
     }
     const detail = await this.store.getTask(doc.task.id);
     return toTaskThreadDetail(detail ?? doc);
+  }
+
+  /**
+   * When a task is created WITHOUT acceptance criteria and with a non-trivial
+   * goal, populate 3-5 measurable default criteria so the auto goal-verifier
+   * (#8896) always has something to grill against instead of fast-pathing to
+   * pass / parking forever in `validating`.
+   *
+   * - **No-op when criteria were supplied** — the caller's contract wins; the
+   *   input is returned unchanged.
+   * - **Gated** behind `ELIZA_REQUIRE_GOAL_CONTRACT` (default ON; `"0"`
+   *   disables), mirroring {@link shouldAutoVerifyGoal}.
+   * - **Defensive** — {@link generateDefaultAcceptanceCriteria} never throws;
+   *   on any model failure it returns the static template set, so task creation
+   *   can never be broken by criteria generation.
+   */
+  private async withDefaultAcceptanceCriteria(
+    input: CreateTaskInput,
+  ): Promise<CreateTaskInput> {
+    const supplied = input.acceptanceCriteria;
+    // Caller-supplied criteria are authoritative — never overwrite them.
+    if (supplied && supplied.length > 0) return input;
+    if (!shouldRequireGoalContract()) return input;
+    if (!isNonTrivialGoal(input.goal)) return input;
+
+    const hint = this.taskTypeHintFor(input);
+    const generated = await generateDefaultAcceptanceCriteria(
+      input.goal,
+      hint,
+      this.runtime,
+    );
+    if (generated.length === 0) return input;
+    this.log(
+      "debug",
+      `auto-generated ${generated.length} default acceptance criteria for criteria-free task (type=${hint ?? detectTaskType(input.goal)})`,
+    );
+    return { ...input, acceptanceCriteria: generated };
+  }
+
+  /** Map an explicit `kind` on the create input to a task type when it lines up
+   *  with a known template type, so the caller's stated kind beats keyword
+   *  detection; otherwise let {@link detectTaskType} read the goal text. */
+  private taskTypeHintFor(
+    input: CreateTaskInput,
+  ): OrchestratorTaskType | undefined {
+    switch (input.kind) {
+      case "coding":
+      case "view-create":
+      case "app-build":
+      case "deploy":
+        return input.kind;
+      default:
+        return undefined;
+    }
   }
 
   async listTasks(filter: TaskListFilter = {}): Promise<TaskThreadDto[]> {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -18,8 +18,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import {
   detectTaskType,
@@ -37,8 +38,11 @@ import {
 } from "./coding-account-selection.js";
 import {
   buildCompletionEvidenceString,
+  type CompletionEvidenceBundle,
+  classifyToolOutput,
   type EvidenceArtifactRef,
   type EvidenceSignal,
+  renderChangeSetBody,
 } from "./completion-evidence.js";
 import {
   buildAutoVerifyCorrection,
@@ -868,63 +872,24 @@ export class OrchestratorTaskService extends Service {
     fallbackSummary: string,
   ): Promise<string> {
     try {
-      const doc = await this.store.getTask(taskId);
-      if (!doc) return fallbackSummary;
-
-      // Scope to this session's rows, but keep cross-session task events too
-      // (validation/build steps are sometimes recorded without a sessionId).
-      const sessionEvents = doc.events.filter(
-        (event) =>
-          event.sessionId === sessionId || event.sessionId === undefined,
-      );
-      const sessionMessages = doc.messages.filter(
-        (message) => message.sessionId === sessionId,
-      );
-
-      const changeSet = await this.resolveCompletionChangeSet(sessionId, doc);
-
-      // The longest recorded `sub_agent` stdout reply is the richest final
-      // narration; the completion summary is the reported result. Surface both.
-      const subAgentReplies = sessionMessages
-        .filter(
-          (message) =>
-            message.senderKind === "sub_agent" &&
-            message.direction === "stdout",
-        )
-        .map((message) => message.content.trim())
-        .filter((content) => content.length > 0);
-      const longestReply = subAgentReplies.sort(
-        (a, b) => b.length - a.length,
-      )[0];
-
-      const signals: EvidenceSignal[] = [
-        ...sessionEvents.map((event) => ({
-          text: `${event.summary}\n${stringifyEventData(event.data)}`,
-          source: event.eventType,
-        })),
-        ...sessionMessages.map((message) => ({
-          text: message.content,
-          source: message.senderKind,
-        })),
-      ];
-
-      const verifiedUrls = collectUrls([
+      const bundle = await this.collectEvidenceBundle(
+        taskId,
+        sessionId,
         fallbackSummary,
-        longestReply ?? "",
-        ...subAgentReplies,
-      ]);
-
-      const artifacts = this.collectArtifactRefs(doc, sessionId);
-
-      return buildCompletionEvidenceString({
-        fallbackSummary,
-        changeSet,
-        deliverable: longestReply,
-        finalReply: fallbackSummary,
-        verifiedUrls,
-        signals,
-        artifacts,
-      });
+      );
+      // Stamp the deterministic trajectory path onto the bundle so the verifier
+      // evidence (and the serialized string) cite the durable artifact, then
+      // serialize immediately and fire the actual JSONL write off the critical
+      // path. The write is fire-and-forget (`void`) so trajectory IO never
+      // delays the verifier or the event-bridge write path, and any IO failure
+      // is swallowed inside the writer — the path is valid regardless of when
+      // the file lands.
+      bundle.trajectoryPath = await this.resolveTrajectoryPath(
+        taskId,
+        sessionId,
+      );
+      void this.writeEvidenceTrajectory(taskId, sessionId, bundle);
+      return buildCompletionEvidenceString(bundle);
     } catch (err) {
       this.log("debug", "build completion evidence failed", {
         taskId,
@@ -933,6 +898,213 @@ export class OrchestratorTaskService extends Service {
       });
       return fallbackSummary;
     }
+  }
+
+  /**
+   * Assemble the TYPED {@link CompletionEvidenceBundle} from data the
+   * orchestrator already has (issue #8894). Each field resolves from a named
+   * source:
+   *  - `summary` — the `task_complete` response (fallback);
+   *  - `diffSummary` — the real git change set captured at completion, via the
+   *    same {@link readLastChangeSet} mechanism the CODING_SESSION_CHANGES path
+   *    and `mirrorChangeSetToStore` use, rendered with {@link renderChangeSetBody};
+   *  - `toolOutput` — test/build/lint stdout mined from recorded `tool_running`
+   *    events (and sub-agent messages) and classified by {@link classifyToolOutput};
+   *  - `verifiedUrls` — URLs probed at completion (session/task `subAgentVerifiedUrls`
+   *    metadata plus URLs mined from the summary and sub-agent replies);
+   *  - `screenshots` — screenshot artifact paths on the task/session.
+   *
+   * Pure with respect to throwing: returns at least the summary on any error.
+   */
+  private async collectEvidenceBundle(
+    taskId: string,
+    sessionId: string,
+    fallbackSummary: string,
+  ): Promise<CompletionEvidenceBundle> {
+    const summary = fallbackSummary.trim();
+    const empty: CompletionEvidenceBundle = {
+      summary,
+      verifiedUrls: [],
+      screenshots: [],
+    };
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return empty;
+
+    // Scope to this session's rows, but keep cross-session task events too
+    // (validation/build steps are sometimes recorded without a sessionId).
+    const sessionEvents = doc.events.filter(
+      (event) => event.sessionId === sessionId || event.sessionId === undefined,
+    );
+    const sessionMessages = doc.messages.filter(
+      (message) => message.sessionId === sessionId,
+    );
+
+    const changeSet = await this.resolveCompletionChangeSet(sessionId, doc);
+    const diffSummary =
+      changeSet && changeSet.changedFiles.length > 0
+        ? renderChangeSetBody(changeSet)
+        : undefined;
+
+    const subAgentReplies = sessionMessages
+      .filter(
+        (message) =>
+          message.senderKind === "sub_agent" && message.direction === "stdout",
+      )
+      .map((message) => message.content.trim())
+      .filter((content) => content.length > 0);
+
+    // Tool-output signals: prefer the structured `toolCall.output` recorded on
+    // `tool_running`/`tool_result` events, labelled by the tool command/title so
+    // the classifier can route the stdout to its test/build/lint bucket. Fall
+    // back to the full event/message bodies so a real run still surfaces even
+    // when the adapter folded its output into the assistant text.
+    const toolSignals: EvidenceSignal[] = [
+      ...this.extractToolSignals(sessionEvents),
+      ...sessionEvents.map((event) => ({
+        text: `${event.summary}\n${stringifyEventData(event.data)}`,
+        source: event.eventType,
+      })),
+      ...sessionMessages.map((message) => ({
+        text: message.content,
+        source: message.senderKind,
+      })),
+    ];
+    const toolOutput = classifyToolOutput(toolSignals);
+
+    const verifiedUrls = [
+      ...new Set([
+        ...this.metadataVerifiedUrls(doc, sessionId),
+        ...collectUrls([summary, ...subAgentReplies]),
+      ]),
+    ];
+
+    const screenshots = this.collectArtifactRefs(doc, sessionId).flatMap(
+      (ref) => (ref.artifactType === "screenshot" && ref.ref ? [ref.ref] : []),
+    );
+
+    return {
+      summary,
+      diffSummary,
+      toolOutput,
+      verifiedUrls,
+      screenshots: [...new Set(screenshots)],
+    };
+  }
+
+  /** Build per-tool evidence signals from recorded `tool_running`/`tool_result`
+   *  events: the signal text is the tool's captured stdout, and the source label
+   *  carries the command/title so {@link classifyToolOutput} can class it. */
+  private extractToolSignals(
+    events: OrchestratorTaskDocument["events"],
+  ): EvidenceSignal[] {
+    const signals: EvidenceSignal[] = [];
+    for (const event of events) {
+      if (
+        event.eventType !== "tool_running" &&
+        event.eventType !== "tool_result"
+      )
+        continue;
+      const toolCall = isRecord(event.data.toolCall)
+        ? event.data.toolCall
+        : event.data;
+      const output = str(toolCall.output) ?? str(event.data.output);
+      if (!output) continue;
+      const rawInput = isRecord(toolCall.rawInput) ? toolCall.rawInput : {};
+      const command =
+        str(rawInput.command) ??
+        str(toolCall.title) ??
+        str(toolCall.kind) ??
+        "tool";
+      signals.push({ text: output, source: command });
+    }
+    return signals;
+  }
+
+  /** URLs the router stamped as verified onto the task or session metadata
+   *  (`subAgentVerifiedUrls`), separate from URLs mined out of free text. */
+  private metadataVerifiedUrls(
+    doc: OrchestratorTaskDocument,
+    sessionId: string,
+  ): string[] {
+    const out: string[] = [];
+    const session = doc.sessions.find((row) => row.sessionId === sessionId);
+    for (const meta of [doc.task.metadata, session?.metadata]) {
+      const raw = meta?.subAgentVerifiedUrls;
+      if (!Array.isArray(raw)) continue;
+      for (const entry of raw) {
+        const url = str(entry);
+        if (url) out.push(url);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Write the completion-evidence bundle as a single appended JSONL line and
+   * record the artifact path on a task event so a reviewer can re-read exactly
+   * what the verifier judged.
+   *
+   * Fire-and-forget: invoked with `void` from {@link buildCompletionEvidence},
+   * so every IO step is wrapped — a failure logs and continues without throwing
+   * into the `task_complete` event path. The path is already stamped on the
+   * bundle by the caller, so a write failure only means the artifact never lands;
+   * the evidence string still cites the (intended) path.
+   */
+  private async writeEvidenceTrajectory(
+    taskId: string,
+    sessionId: string,
+    bundle: CompletionEvidenceBundle,
+  ): Promise<void> {
+    const trajectoryPath = bundle.trajectoryPath;
+    if (!trajectoryPath) return;
+    try {
+      await mkdir(dirname(trajectoryPath), { recursive: true });
+      const line = `${JSON.stringify({
+        kind: "completion_evidence_bundle",
+        taskId,
+        sessionId,
+        recordedAt: nowIso(),
+        bundle,
+      })}\n`;
+      await appendFile(trajectoryPath, line, "utf8");
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        sessionId,
+        eventType: "completion_evidence_persisted",
+        summary: "Persisted completion-evidence bundle to trajectory artifact.",
+        data: { trajectoryPath },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      this.emitChange(taskId);
+    } catch (err) {
+      this.log("debug", "persist evidence trajectory failed", {
+        taskId,
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** The completion-evidence trajectory file path: a `completion-evidence.jsonl`
+   *  under the live session workdir's `.eliza/trajectories`, else a `~/.eliza`-
+   *  scoped per-task dir when no workspace is available. Deterministic so it can
+   *  be cited in the evidence before the file is actually written. */
+  private async resolveTrajectoryPath(
+    taskId: string,
+    sessionId: string,
+  ): Promise<string> {
+    let dir = join(homedir(), ".eliza", "trajectories", taskId);
+    try {
+      const acp = this.acp();
+      const live = acp ? await acp.getSession(sessionId) : undefined;
+      const workdir = str(live?.workdir);
+      if (workdir) dir = join(workdir, ".eliza", "trajectories");
+    } catch {
+      // best-effort — keep the home-scoped task dir
+    }
+    return join(dir, "completion-evidence.jsonl");
   }
 
   /** The git change set for a completed session: prefer the live ACP session


### PR DESCRIPTION
Builds on #8883 (merged). Closes #8896, #8897, #8894. Part of #8884 (grilling epic).

Three commits that complete the core of the "grill sub-agents until truly done, with real proof" loop:

### #8896 — auto-generate default acceptance criteria so verification *always* fires
`autoVerifyCompletion` previously fast-pathed to pass when a task had no `acceptanceCriteria` — the common case ("fix this bug"), so most tasks skipped grilling entirely. Now `OrchestratorTaskService.createTask` (the single choke point for the action, the route, and `forkTask`) mints 3-5 measurable criteria from a task-type template (`coding` / `app-build` / `view-create` / `deploy`), optionally refined by a small model (fully defensive — falls back to the static template, never throws). Gated by `ELIZA_REQUIRE_GOAL_CONTRACT` (default on); caller-supplied criteria are never overwritten.

### #8897 — escalating socratic grill protocol with evidence checklist
The corrective follow-up to a failing sub-agent now escalates by attempt number: **(1)** collegial proof request → **(2)** pointed socratic questions citing the prior failure → **(3)** final last-chance before human escalation. Every correction appends a checkbox evidence checklist (one item per unmet criterion, each carrying its `proofDemandFor` demand) the worker must return ticked with the artifact inline. The call site forwards the persisted `autoVerifyAttempts` counter.

### #8894 — typed CompletionEvidenceBundle with tool-output + trajectory persistence
Formalizes the evidence the verifier sees as a typed `CompletionEvidenceBundle` (summary, diff summary, `{test,build,lint,raw}` tool output, verified URLs, screenshots, trajectory path). `collectEvidenceBundle` mines the real git change set, extracts test/build/lint stdout from recorded `tool_running`/`tool_result` events, and persists the bundle as JSONL (path recorded on a `completion_evidence_persisted` event) — all off the critical path, IO failures swallowed.

## Evidence
```
$ bun run --cwd plugins/plugin-agent-orchestrator typecheck   # exit 0
$ bun run --cwd plugins/plugin-agent-orchestrator test -- acceptance-criteria create-task-default-criteria completion-evidence completion-evidence-bundle auto-verify-completion-evidence goal-llm-verifier auto-goal-verify
 Test Files  7 passed (7)
      Tests  93 passed (93)
```
Full plugin suite green on each commit (≈899 passing; the only full-run failures are pre-existing load-contention timeouts in the untouched `smithers-task-runner.test.ts`, which passes in isolation). Rebased onto current `develop`; biome clean.

## Remaining (follow-ups, not faked)
- Live scenario-runner trajectory showing real diff+test output reaching the verifier (#8894 acceptance) needs a live model + real sub-agent spawn — the code path, JSONL persistence, and deterministic unit tests are complete; the live run is a tracked follow-up.
- #8895 (CompletionEnvelope schema enforced on sub-agents), #8898 (independent verifier sub-agent), #8899 (Reflexion memory) remain open under #8884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)