### PR TITLE
feat(cloud): route NodeAutoscaler through the ComputeProvider seam (#8919)

### DIFF
--- a/packages/cloud-shared/src/lib/services/containers/compute-provider-characterization.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/compute-provider-characterization.test.ts
@@ -240,9 +240,10 @@ describe("HetznerCloudClient servers", () => {
       networks: [33],
       labels: { purpose: "test" },
     });
-    // Response mapping: root_password → rootPassword.
+    // Response mapping: root_password → rootPassword, and public_net collapsed
+    // onto the canonical seam field publicIpv4 (null when absent).
     expect(result).toEqual({
-      server: { id: 100, name: "n1" } as never,
+      server: { id: 100, name: "n1", publicIpv4: null } as never,
       rootPassword: "pw",
     });
   });

--- a/packages/cloud-shared/src/lib/services/containers/compute-provider-fake.ts
+++ b/packages/cloud-shared/src/lib/services/containers/compute-provider-fake.ts
@@ -430,11 +430,15 @@ export class InMemoryComputeProvider implements ComputeProvider {
   }
 
   private toServer(rec: ServerRecord): ComputeServer {
+    const active = this.currentTick >= rec.activeAtTick;
     return {
       id: rec.id,
       name: rec.name,
-      status: this.currentTick >= rec.activeAtTick ? SERVER_STATUS_ACTIVE : SERVER_STATUS_NEW,
+      status: active ? SERVER_STATUS_ACTIVE : SERVER_STATUS_NEW,
       created: rec.createdIso,
+      // Deterministic fake address, assigned only once the server is active —
+      // mirrors real providers, which return no IP while still provisioning.
+      publicIpv4: active ? `10.0.0.${rec.id % 256}` : null,
       labels: { ...rec.labels },
     };
   }

--- a/packages/cloud-shared/src/lib/services/containers/compute-provider.ts
+++ b/packages/cloud-shared/src/lib/services/containers/compute-provider.ts
@@ -44,6 +44,13 @@ export interface ComputeServer {
   status: string;
   /** ISO-8601 creation timestamp. */
   created?: string;
+  /**
+   * Canonical public address (IPv4, falling back to IPv6) once the provider
+   * has assigned one — `null`/absent while still provisioning. Exposed on the
+   * seam so consumers (e.g. the node autoscaler) can resolve a hostname without
+   * reaching into provider-specific shapes like Hetzner's `public_net`.
+   */
+  publicIpv4?: string | null;
   /** Free-form provider labels. */
   labels?: Record<string, string>;
 }

--- a/packages/cloud-shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -94,6 +94,8 @@ export interface HetznerServer {
     ipv4: { ip: string; blocked: boolean } | null;
     ipv6: { ip: string; blocked: boolean } | null;
   };
+  /** Canonical public address mapped from `public_net` (satisfies the seam). */
+  publicIpv4?: string | null;
   server_type: { id: number; name: string };
   datacenter: { id: number; name: string; location: HetznerLocation };
   labels: Record<string, string>;
@@ -219,7 +221,15 @@ export class HetznerCloudClient implements ComputeProvider {
       location: input.location,
     });
 
-    return { server: data.server, rootPassword: data.root_password };
+    return {
+      server: {
+        ...data.server,
+        // Map Hetzner's public_net onto the canonical seam field (ipv4 first,
+        // then ipv6) so consumers don't depend on the provider-specific shape.
+        publicIpv4: data.server.public_net?.ipv4?.ip ?? data.server.public_net?.ipv6?.ip ?? null,
+      },
+      rootPassword: data.root_password,
+    };
   }
 
   async deleteServer(serverId: number): Promise<void> {

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -89,6 +89,7 @@ afterAll(() => {
   mock.module("./node-bootstrap", () => realNodeBootstrap);
 });
 
+import { InMemoryComputeProvider } from "./compute-provider-fake";
 import { type AutoscalePolicy, NodeAutoscaler } from "./node-autoscaler";
 
 const policy: AutoscalePolicy = {
@@ -133,6 +134,9 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       server: {
         id: 4242,
         name: "node-test",
+        // The Hetzner client now collapses public_net onto the canonical seam
+        // field; the autoscaler reads publicIpv4 (not provider-specific shapes).
+        publicIpv4: "203.0.113.10",
         public_net: {
           ipv4: { ip: "203.0.113.10" },
           ipv6: null,
@@ -327,5 +331,38 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       shouldScaleUp: true,
       reason: "available 0 < hot floor 1",
     });
+  });
+
+  // #8919: the autoscaler resolves its provider via the ComputeProvider seam, so
+  // a fake can be injected directly — no monkey-patching of getHetznerCloudClient.
+  test("provisions through an injected ComputeProvider without monkey-patching (#8919)", async () => {
+    const fake = new InMemoryComputeProvider({ serverActivateAfterTicks: 0 });
+    const autoscaler = new NodeAutoscaler(policy, () => Date.parse("2026-05-15T12:00:00Z"), fake);
+
+    const result = await autoscaler.provisionNode(
+      { nodeId: "seam-node", capacity: 4, prePullImages: [] },
+      {
+        controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+        registrationUrl: "https://cloud.example.test/register",
+        registrationSecret: "secret",
+      },
+    );
+
+    // The injected fake handled createServer — the module-mocked Hetzner client
+    // was bypassed entirely.
+    expect(mocks.createServer).not.toHaveBeenCalled();
+    const servers = await fake.listServers();
+    expect(servers.some((s) => s.name === "seam-node")).toBe(true);
+
+    // The docker node is registered with the seam's canonical publicIpv4
+    // (the fake assigns 10.0.0.<id> once active), not a provider-specific shape.
+    expect(result.nodeId).toBe("seam-node");
+    expect(result.hostname).toMatch(/^10\.0\.0\./);
+    expect(mocks.createNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        node_id: "seam-node",
+        hostname: result.hostname,
+      }),
+    );
   });
 });

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
@@ -30,11 +30,8 @@ import {
   inferNodeArchitectureFromMetadata,
   isArchitectureCompatibleWithPlatform,
 } from "../docker-sandbox-utils";
-import {
-  getHetznerCloudClient,
-  HetznerCloudError,
-  isHetznerCloudConfigured,
-} from "./hetzner-cloud-api";
+import { type ComputeProvider, getComputeProvider } from "./compute-provider";
+import { HetznerCloudError, isHetznerCloudConfigured } from "./hetzner-cloud-api";
 import { buildContainerNodeUserData, type NodeBootstrapInput } from "./node-bootstrap";
 
 // ---------------------------------------------------------------------------
@@ -121,7 +118,17 @@ export class NodeAutoscaler {
   constructor(
     private readonly policy: AutoscalePolicy = DEFAULT_AUTOSCALE_POLICY,
     private readonly nowFn: () => number = () => Date.now(),
+    // Compute provider seam: defaults (lazily, per-call) to `getComputeProvider()`
+    // — which resolves to the Hetzner client in production, so behavior is
+    // unchanged. Injecting `InMemoryComputeProvider` here lets tests drive the
+    // provision/drain path without monkey-patching the module. #8919
+    private readonly provider?: ComputeProvider,
   ) {}
+
+  /** The compute provider for this run — injected fake, or the configured default. */
+  private computeProvider(): ComputeProvider {
+    return this.provider ?? getComputeProvider();
+  }
 
   /**
    * Inspect current pool state and return a decision: should we scale up,
@@ -243,7 +250,7 @@ export class NodeAutoscaler {
       capacity,
     });
 
-    const client = getHetznerCloudClient();
+    const client = this.computeProvider();
     // `environment` + `tier` let the orchestrator scope server lookups via
     // Hetzner's label_selector (e.g. `environment=staging,tier=data-plane`) so
     // staging never touches a production node, and a runaway daemon can't
@@ -269,10 +276,10 @@ export class NodeAutoscaler {
       labels,
     });
 
-    const ip =
-      provisioned.server.public_net.ipv4?.ip ??
-      provisioned.server.public_net.ipv6?.ip ??
-      provisioned.server.name;
+    // Resolve via the canonical seam field (ipv4→ipv6 already collapsed by the
+    // provider) so this works for any ComputeProvider, not just Hetzner.
+    const ip = provisioned.server.publicIpv4 ?? provisioned.server.name;
+    const hcloudServerId = Number(provisioned.server.id);
 
     // Insert the row in `unknown` status — the cloud-init bootstrap is
     // still running; the periodic health check will flip it to healthy.
@@ -288,7 +295,7 @@ export class NodeAutoscaler {
       metadata: {
         provider: "hetzner-cloud",
         autoscaled: true,
-        hcloudServerId: provisioned.server.id,
+        hcloudServerId,
         serverType,
         location,
         image,
@@ -299,7 +306,7 @@ export class NodeAutoscaler {
 
     logger.info("[autoscaler] Provisioned new container node", {
       nodeId,
-      hcloudServerId: provisioned.server.id,
+      hcloudServerId,
       ip,
       serverType,
       location,
@@ -308,7 +315,7 @@ export class NodeAutoscaler {
     return {
       nodeId,
       hostname: ip,
-      hcloudServerId: provisioned.server.id,
+      hcloudServerId,
       rootPassword: provisioned.rootPassword,
     };
   }
@@ -361,7 +368,7 @@ export class NodeAutoscaler {
       return;
     }
 
-    const client = getHetznerCloudClient();
+    const client = this.computeProvider();
     try {
       await client.deleteServer(hcloudServerId);
     } catch (err) {


### PR DESCRIPTION
## Summary
Closes #8919 (part of #8889). `NodeAutoscaler` called `getHetznerCloudClient()` directly, so the `InMemoryComputeProvider` fake could only be injected by monkey-patching the module, and switching providers required a code change. This routes provision/drain through the `getComputeProvider()` seam with **zero production behavior change** (the seam defaults to the Hetzner client).

## Changes
- `NodeAutoscaler` takes an optional `ComputeProvider`, resolved **lazily per call** via `getComputeProvider()` (Hetzner default). No eager resolution at construction, so `evaluateCapacity()`-only usage is unaffected.
- Added a canonical **`publicIpv4`** field to the seam's `ComputeServer` so the autoscaler resolves a hostname generically instead of reaching into Hetzner's `public_net`. The Hetzner client maps `public_net` (ipv4→ipv6) onto it; the fake assigns a deterministic `10.0.0.<id>` once the server is active.
- Coerced the provider-native server id (`number | string`) to `number` for the docker-node metadata.

## Acceptance criteria
- [x] Autoscaler resolves its provider via `getComputeProvider()`.
- [x] `InMemoryComputeProvider` injectable without monkey-patching (new test does exactly this).
- [x] Hetzner remains default; existing tests green.

## Tests
- New: `provisions through an injected ComputeProvider without monkey-patching (#8919)` — asserts the module-mocked Hetzner client is bypassed, the fake holds the server, and the docker node registers with the seam's canonical `publicIpv4`.
- Updated the Hetzner characterization + autoscaler mock for the canonical field.
```
node-autoscaler.test.ts        7 pass / 0 fail
compute-provider-*.test.ts    71 pass / 0 fail
typecheck                      clean
```

Unblocks #8920 (local autoscale-loop integration test against the Hetzner mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)