### PR TITLE
feat(credentials): in-chat OAuth/credential flows — EPIC #8886 (complete)

### DIFF
--- a/packages/cloud-shared/src/lib/services/oauth/provider-alignment.test.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-alignment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
+	OAUTH_PROVIDERS as CORE_OAUTH_PROVIDERS,
+} from "@elizaos/core";
+import { getAllProviderIds } from "./provider-registry";
+import { VENDOR_REGISTRY } from "./vendor-registry";
+
+/**
+ * Enforces #8909: every provider the core OAuth atomic actions accept must be
+ * serviceable by the cloud OAuth registry — otherwise `CREATE_OAUTH_INTENT`
+ * would compile/validate a provider that no cloud handler can complete.
+ *
+ * `CONNECTOR_NATIVE_OAUTH_PROVIDERS` (e.g. discord) are serviced by their own
+ * connector, not the cloud registry, so they are the only allowed exceptions.
+ */
+describe("core OAuthProvider ⊆ cloud OAuth registry", () => {
+	const cloudProviderIds = new Set<string>([
+		...getAllProviderIds(),
+		...Object.keys(VENDOR_REGISTRY),
+	]);
+	const connectorNative = new Set<string>(CONNECTOR_NATIVE_OAUTH_PROVIDERS);
+	const servicedByCloud = CORE_OAUTH_PROVIDERS.filter(
+		(p) => !connectorNative.has(p),
+	);
+
+	test("every cloud-serviced core provider exists in the cloud registry", () => {
+		const missing = servicedByCloud.filter((p) => !cloudProviderIds.has(p));
+		expect(missing).toEqual([]);
+	});
+
+	test("github (the #8909 ask) is aligned across both layers", () => {
+		expect(CORE_OAUTH_PROVIDERS).toContain("github");
+		expect(cloudProviderIds.has("github")).toBe(true);
+	});
+
+	test("the previously-missing providers (notion, slack) are aligned", () => {
+		for (const p of ["notion", "slack"] as const) {
+			expect(CORE_OAUTH_PROVIDERS).toContain(p);
+			expect(cloudProviderIds.has(p)).toBe(true);
+		}
+	});
+
+	test("connector-native exceptions are a subset of the core enum", () => {
+		for (const p of CONNECTOR_NATIVE_OAUTH_PROVIDERS) {
+			expect(CORE_OAUTH_PROVIDERS).toContain(p);
+		}
+	});
+});

--- a/packages/cloud-shared/src/lib/services/oauth/provider-alignment.test.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-alignment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
-	OAUTH_PROVIDERS as CORE_OAUTH_PROVIDERS,
+  CONNECTOR_NATIVE_OAUTH_PROVIDERS,
+  OAUTH_PROVIDERS as CORE_OAUTH_PROVIDERS,
 } from "@elizaos/core";
 import { getAllProviderIds } from "./provider-registry";
 import { VENDOR_REGISTRY } from "./vendor-registry";
@@ -15,35 +15,33 @@ import { VENDOR_REGISTRY } from "./vendor-registry";
  * connector, not the cloud registry, so they are the only allowed exceptions.
  */
 describe("core OAuthProvider ⊆ cloud OAuth registry", () => {
-	const cloudProviderIds = new Set<string>([
-		...getAllProviderIds(),
-		...Object.keys(VENDOR_REGISTRY),
-	]);
-	const connectorNative = new Set<string>(CONNECTOR_NATIVE_OAUTH_PROVIDERS);
-	const servicedByCloud = CORE_OAUTH_PROVIDERS.filter(
-		(p) => !connectorNative.has(p),
-	);
+  const cloudProviderIds = new Set<string>([
+    ...getAllProviderIds(),
+    ...Object.keys(VENDOR_REGISTRY),
+  ]);
+  const connectorNative = new Set<string>(CONNECTOR_NATIVE_OAUTH_PROVIDERS);
+  const servicedByCloud = CORE_OAUTH_PROVIDERS.filter((p) => !connectorNative.has(p));
 
-	test("every cloud-serviced core provider exists in the cloud registry", () => {
-		const missing = servicedByCloud.filter((p) => !cloudProviderIds.has(p));
-		expect(missing).toEqual([]);
-	});
+  test("every cloud-serviced core provider exists in the cloud registry", () => {
+    const missing = servicedByCloud.filter((p) => !cloudProviderIds.has(p));
+    expect(missing).toEqual([]);
+  });
 
-	test("github (the #8909 ask) is aligned across both layers", () => {
-		expect(CORE_OAUTH_PROVIDERS).toContain("github");
-		expect(cloudProviderIds.has("github")).toBe(true);
-	});
+  test("github (the #8909 ask) is aligned across both layers", () => {
+    expect(CORE_OAUTH_PROVIDERS).toContain("github");
+    expect(cloudProviderIds.has("github")).toBe(true);
+  });
 
-	test("the previously-missing providers (notion, slack) are aligned", () => {
-		for (const p of ["notion", "slack"] as const) {
-			expect(CORE_OAUTH_PROVIDERS).toContain(p);
-			expect(cloudProviderIds.has(p)).toBe(true);
-		}
-	});
+  test("the previously-missing providers (notion, slack) are aligned", () => {
+    for (const p of ["notion", "slack"] as const) {
+      expect(CORE_OAUTH_PROVIDERS).toContain(p);
+      expect(cloudProviderIds.has(p)).toBe(true);
+    }
+  });
 
-	test("connector-native exceptions are a subset of the core enum", () => {
-		for (const p of CONNECTOR_NATIVE_OAUTH_PROVIDERS) {
-			expect(CORE_OAUTH_PROVIDERS).toContain(p);
-		}
-	});
+  test("connector-native exceptions are a subset of the core enum", () => {
+    for (const p of CONNECTOR_NATIVE_OAUTH_PROVIDERS) {
+      expect(CORE_OAUTH_PROVIDERS).toContain(p);
+    }
+  });
 });

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
@@ -3,6 +3,8 @@ import {
 	OAUTH_INTENTS_CLIENT_SERVICE,
 	type OAuthIntentEnvelope,
 	type OAuthIntentsClient,
+	OAUTH_PROVIDERS,
+	type OAuthProvider,
 } from "../types";
 import { createOAuthIntentAction } from "./create-oauth-intent";
 
@@ -93,6 +95,44 @@ describe("CREATE_OAUTH_INTENT", () => {
 
 		expect(result.success).toBe(false);
 		expect(client.create).not.toHaveBeenCalled();
+	});
+
+	test("accepts github (and aligned providers) — #8909", async () => {
+		for (const provider of ["github", "notion", "slack"] as const) {
+			// Compile-time check: the literal is assignable to OAuthProvider.
+			const typed: OAuthProvider = provider;
+			expect(OAUTH_PROVIDERS).toContain(typed);
+
+			const create = vi
+				.fn()
+				.mockResolvedValue(envelope({ provider, oauthIntentId: `oauth_${provider}` }));
+			const client: OAuthIntentsClient = {
+				create,
+				get: vi.fn(),
+				cancel: vi.fn(),
+				bind: vi.fn(),
+				revoke: vi.fn(),
+			};
+
+			const result = await createOAuthIntentAction.handler(
+				createRuntime({ [OAUTH_INTENTS_CLIENT_SERVICE]: client }) as never,
+				message() as never,
+				undefined,
+				{
+					parameters: {
+						action: "create",
+						provider,
+						scopes: ["repo"],
+						stateTokenHash: "deadbeefdeadbeef0000000000000000",
+					},
+				} as never,
+				vi.fn(),
+			);
+
+			expect(result.success).toBe(true);
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(result.data?.oauthIntentId).toBe(`oauth_${provider}`);
+		}
 	});
 
 	test("rejects when scopes are not strings", async () => {

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
 import {
 	OAUTH_INTENTS_CLIENT_SERVICE,
+	OAUTH_PROVIDERS,
 	type OAuthIntentEnvelope,
 	type OAuthIntentsClient,
-	OAUTH_PROVIDERS,
 	type OAuthProvider,
 } from "../types";
 import { createOAuthIntentAction } from "./create-oauth-intent";
@@ -105,7 +105,9 @@ describe("CREATE_OAUTH_INTENT", () => {
 
 			const create = vi
 				.fn()
-				.mockResolvedValue(envelope({ provider, oauthIntentId: `oauth_${provider}` }));
+				.mockResolvedValue(
+					envelope({ provider, oauthIntentId: `oauth_${provider}` }),
+				);
 			const client: OAuthIntentsClient = {
 				create,
 				get: vi.fn(),

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.ts
@@ -116,7 +116,7 @@ export const createOAuthIntentAction: Action = {
 	suppressPostActionContinuation: true,
 	similes: ["NEW_OAUTH_INTENT", "OPEN_OAUTH_INTENT", "START_OAUTH_FLOW"],
 	description:
-		"Create a new OAuth intent for a provider (google, discord, linkedin, linear, shopify, calendly).",
+		"Create a new OAuth intent for a provider (google, discord, github, notion, slack, linkedin, linear, shopify, calendly).",
 	descriptionCompressed:
 		"Create OAuth intent: provider, scopes, stateTokenHash.",
 	parameters: [

--- a/packages/core/src/features/oauth/index.ts
+++ b/packages/core/src/features/oauth/index.ts
@@ -27,6 +27,7 @@ export type {
 	OAuthRevokeResult,
 } from "./types.ts";
 export {
+	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
 	eligibleOAuthDeliveryTargets,
 	OAUTH_CALLBACK_BUS_CLIENT_SERVICE,
 	OAUTH_INTENTS_CLIENT_SERVICE,

--- a/packages/core/src/features/oauth/index.ts
+++ b/packages/core/src/features/oauth/index.ts
@@ -14,7 +14,12 @@ export {
 	revokeOAuthCredentialAction,
 } from "./actions/index.ts";
 
-export { oauthPlugin, oauthPlugin as default } from "./plugin.ts";
+export { LocalOAuthCallbackBus } from "./local-callback-bus.ts";
+export {
+	oauthLocalCallbackRoute,
+	oauthPlugin,
+	oauthPlugin as default,
+} from "./plugin.ts";
 export type {
 	CreateOAuthIntentInput,
 	OAuthBindResult,

--- a/packages/core/src/features/oauth/local-callback-bus.test.ts
+++ b/packages/core/src/features/oauth/local-callback-bus.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test, vi } from "vitest";
+import type { IAgentRuntime } from "../../types/index.ts";
+import { LocalOAuthCallbackBus } from "./local-callback-bus.ts";
+import { oauthLocalCallbackRoute } from "./plugin.ts";
+
+function makeBus(): LocalOAuthCallbackBus {
+	return new LocalOAuthCallbackBus({ agentId: "agent-1" } as IAgentRuntime);
+}
+
+describe("LocalOAuthCallbackBus (#8905)", () => {
+	test("publish resolves a pending waiter with the delivered result", async () => {
+		const bus = makeBus();
+		const waited = bus.waitFor("oauth_1", 5_000);
+		expect(bus.isWaiting("oauth_1")).toBe(true);
+
+		const resolved = bus.publish({
+			oauthIntentId: "oauth_1",
+			provider: "github",
+			status: "bound",
+			connectorIdentityId: "ident_42",
+			scopesGranted: ["repo"],
+		});
+		expect(resolved).toBe(true);
+
+		const result = await waited;
+		expect(result.status).toBe("bound");
+		expect(result.provider).toBe("github");
+		expect(result.connectorIdentityId).toBe("ident_42");
+		expect(typeof result.receivedAt).toBe("number");
+		expect(bus.isWaiting("oauth_1")).toBe(false);
+	});
+
+	test("publish returns false when nothing is waiting", () => {
+		const bus = makeBus();
+		expect(
+			bus.publish({
+				oauthIntentId: "missing",
+				provider: "github",
+				status: "bound",
+			}),
+		).toBe(false);
+	});
+
+	test("waitFor resolves to expired on timeout", async () => {
+		vi.useFakeTimers();
+		try {
+			const bus = makeBus();
+			const waited = bus.waitFor("oauth_to", 1_000);
+			vi.advanceTimersByTime(1_001);
+			const result = await waited;
+			expect(result.status).toBe("expired");
+			expect(result.error).toContain("timed out");
+			expect(bus.isWaiting("oauth_to")).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("a second wait supersedes the first (first expires)", async () => {
+		const bus = makeBus();
+		const first = bus.waitFor("oauth_dup", 5_000);
+		bus.waitFor("oauth_dup", 5_000);
+		const firstResult = await first;
+		expect(firstResult.status).toBe("expired");
+		expect(firstResult.error).toContain("superseded");
+	});
+
+	test("stop expires all pending waiters", async () => {
+		const bus = makeBus();
+		const waited = bus.waitFor("oauth_stop", 5_000);
+		await bus.stop();
+		const result = await waited;
+		expect(result.status).toBe("expired");
+		expect(bus.isWaiting("oauth_stop")).toBe(false);
+	});
+});
+
+describe("oauthLocalCallbackRoute (#8905)", () => {
+	function makeRes() {
+		const res = {
+			statusCode: 0,
+			body: undefined as unknown,
+			status(code: number) {
+				res.statusCode = code;
+				return res;
+			},
+			json(data: unknown) {
+				res.body = data;
+				return res;
+			},
+		};
+		return res;
+	}
+
+	function runtimeWith(bus: LocalOAuthCallbackBus | null): IAgentRuntime {
+		return {
+			agentId: "agent-1",
+			getService: () => bus,
+		} as unknown as IAgentRuntime;
+	}
+
+	test("resolves the local bus by intentId and returns 200", async () => {
+		const bus = makeBus();
+		const waited = bus.waitFor("oauth_route", 5_000);
+		const res = makeRes();
+		await oauthLocalCallbackRoute.handler?.(
+			{
+				body: {
+					oauthIntentId: "oauth_route",
+					provider: "github",
+					status: "bound",
+					connectorIdentityId: "ident_1",
+				},
+			} as never,
+			res as never,
+			runtimeWith(bus),
+		);
+		expect(res.statusCode).toBe(200);
+		expect(res.body).toEqual({ resolved: true });
+		const result = await waited;
+		expect(result.status).toBe("bound");
+		expect(result.connectorIdentityId).toBe("ident_1");
+	});
+
+	test("returns 404 when no waiter is pending for the intent", async () => {
+		const bus = makeBus();
+		const res = makeRes();
+		await oauthLocalCallbackRoute.handler?.(
+			{ body: { oauthIntentId: "nobody", status: "bound" } } as never,
+			res as never,
+			runtimeWith(bus),
+		);
+		expect(res.statusCode).toBe(404);
+		expect(res.body).toEqual({ resolved: false });
+	});
+
+	test("returns 400 on missing intentId or invalid status", async () => {
+		const res = makeRes();
+		await oauthLocalCallbackRoute.handler?.(
+			{ body: { status: "bogus" } } as never,
+			res as never,
+			runtimeWith(makeBus()),
+		);
+		expect(res.statusCode).toBe(400);
+	});
+
+	test("returns 503 when no local bus is registered", async () => {
+		const res = makeRes();
+		await oauthLocalCallbackRoute.handler?.(
+			{ body: { oauthIntentId: "x", status: "bound" } } as never,
+			res as never,
+			runtimeWith(null),
+		);
+		expect(res.statusCode).toBe(503);
+	});
+});

--- a/packages/core/src/features/oauth/local-callback-bus.ts
+++ b/packages/core/src/features/oauth/local-callback-bus.ts
@@ -1,0 +1,104 @@
+/**
+ * In-process OAuth callback bus for non-cloud deployments.
+ *
+ * The cloud deployment registers a durable, cross-process
+ * `OAuthCallbackBusClient`; without it `AWAIT_OAUTH_CALLBACK` has nothing to
+ * wait on and the five-action OAuth flow dead-ends (the action's `validate`
+ * returns false). This local fallback keeps pending intents in memory and
+ * resolves them when the local `/api/oauth/callback` route delivers a result
+ * for the intent id, making the full flow work for Telegram-/CLI-based agents
+ * with no cloud.
+ */
+
+import { logger } from "../../logger.ts";
+import type { IAgentRuntime } from "../../types/index.ts";
+import { Service } from "../../types/service.ts";
+import {
+	OAUTH_CALLBACK_BUS_CLIENT_SERVICE,
+	type OAuthCallbackBusClient,
+	type OAuthCallbackResult,
+} from "./types.ts";
+
+interface Waiter {
+	resolve: (result: OAuthCallbackResult) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+export class LocalOAuthCallbackBus
+	extends Service
+	implements OAuthCallbackBusClient
+{
+	static serviceType = OAUTH_CALLBACK_BUS_CLIENT_SERVICE;
+	capabilityDescription =
+		"In-process OAuth callback bus for non-cloud deployments.";
+
+	private readonly waiters = new Map<string, Waiter>();
+
+	static async start(runtime: IAgentRuntime): Promise<LocalOAuthCallbackBus> {
+		return new LocalOAuthCallbackBus(runtime);
+	}
+
+	waitFor(
+		oauthIntentId: string,
+		timeoutMs: number,
+	): Promise<OAuthCallbackResult> {
+		return new Promise<OAuthCallbackResult>((resolve) => {
+			// A second wait on the same intent supersedes the first (expire it).
+			const prior = this.waiters.get(oauthIntentId);
+			if (prior) {
+				clearTimeout(prior.timer);
+				prior.resolve({
+					oauthIntentId,
+					status: "expired",
+					error: "superseded by a newer wait",
+				});
+			}
+			const timer = setTimeout(() => {
+				this.waiters.delete(oauthIntentId);
+				resolve({
+					oauthIntentId,
+					status: "expired",
+					error: `timed out after ${timeoutMs}ms`,
+				});
+			}, timeoutMs);
+			// A pending OAuth wait must not, by itself, keep the process alive.
+			(timer as { unref?: () => void }).unref?.();
+			this.waiters.set(oauthIntentId, { resolve, timer });
+		});
+	}
+
+	/**
+	 * Deliver a callback result, resolving the pending waiter for its intent id.
+	 * Returns true when a waiter was resolved, false when none was pending.
+	 */
+	publish(result: OAuthCallbackResult): boolean {
+		const waiter = this.waiters.get(result.oauthIntentId);
+		if (!waiter) {
+			logger.warn(
+				`[LocalOAuthCallbackBus] no waiter for oauthIntentId=${result.oauthIntentId}`,
+			);
+			return false;
+		}
+		clearTimeout(waiter.timer);
+		this.waiters.delete(result.oauthIntentId);
+		waiter.resolve({ receivedAt: Date.now(), ...result });
+		return true;
+	}
+
+	/** True when an intent is currently being awaited (used by the route). */
+	isWaiting(oauthIntentId: string): boolean {
+		return this.waiters.has(oauthIntentId);
+	}
+
+	async stop(): Promise<void> {
+		for (const [oauthIntentId, waiter] of this.waiters) {
+			clearTimeout(waiter.timer);
+			waiter.resolve({
+				oauthIntentId,
+				status: "expired",
+				error: "callback bus stopped",
+			});
+		}
+		this.waiters.clear();
+	}
+}

--- a/packages/core/src/features/oauth/plugin.ts
+++ b/packages/core/src/features/oauth/plugin.ts
@@ -16,7 +16,12 @@
  */
 
 import { logger } from "../../logger.ts";
-import type { Plugin } from "../../types/index.ts";
+import type {
+	IAgentRuntime,
+	Plugin,
+	Route,
+	Service,
+} from "../../types/index.ts";
 import {
 	awaitOAuthCallbackAction,
 	bindOAuthCredentialAction,
@@ -24,6 +29,77 @@ import {
 	deliverOAuthLinkAction,
 	revokeOAuthCredentialAction,
 } from "./actions/index.ts";
+import { LocalOAuthCallbackBus } from "./local-callback-bus.ts";
+import {
+	OAUTH_CALLBACK_BUS_CLIENT_SERVICE,
+	OAUTH_PROVIDERS,
+	type OAuthCallbackResult,
+} from "./types.ts";
+
+type LocalBus = Service & {
+	publish?: (result: OAuthCallbackResult) => boolean;
+};
+
+const VALID_CALLBACK_STATUS = new Set<OAuthCallbackResult["status"]>([
+	"bound",
+	"denied",
+	"expired",
+]);
+
+/**
+ * Local OAuth callback delivery route (non-cloud). The OAuth provider's redirect
+ * (or a local code-exchange step) POSTs the bind result here keyed by the intent
+ * id; we resolve the in-process {@link LocalOAuthCallbackBus} so a waiting
+ * AWAIT_OAUTH_CALLBACK returns. `public` because the provider redirect is
+ * unauthenticated — the unguessable `oauthIntentId` is the capability token.
+ */
+export const oauthLocalCallbackRoute: Route = {
+	type: "POST",
+	path: "/api/oauth/callback",
+	name: "oauth-local-callback",
+	public: true,
+	rawPath: true,
+	handler: async (req, res, runtime) => {
+		const body = (req.body ?? {}) as Record<string, unknown>;
+		const oauthIntentId =
+			typeof body.oauthIntentId === "string" ? body.oauthIntentId : "";
+		const status = body.status as OAuthCallbackResult["status"];
+		if (!oauthIntentId || !VALID_CALLBACK_STATUS.has(status)) {
+			res
+				.status(400)
+				.json({ resolved: false, error: "oauthIntentId and status required" });
+			return;
+		}
+		const provider =
+			typeof body.provider === "string" &&
+			(OAUTH_PROVIDERS as readonly string[]).includes(body.provider)
+				? (body.provider as OAuthCallbackResult["provider"])
+				: undefined;
+		const bus = runtime.getService<LocalBus>(OAUTH_CALLBACK_BUS_CLIENT_SERVICE);
+		if (!bus || typeof bus.publish !== "function") {
+			res.status(503).json({
+				resolved: false,
+				error: "local OAuth callback bus unavailable",
+			});
+			return;
+		}
+		const result: OAuthCallbackResult = {
+			oauthIntentId,
+			provider,
+			status,
+			connectorIdentityId:
+				typeof body.connectorIdentityId === "string"
+					? body.connectorIdentityId
+					: undefined,
+			scopesGranted: Array.isArray(body.scopesGranted)
+				? body.scopesGranted.filter((s): s is string => typeof s === "string")
+				: undefined,
+			error: typeof body.error === "string" ? body.error : undefined,
+		};
+		const resolved = bus.publish(result);
+		res.status(resolved ? 200 : 404).json({ resolved });
+	},
+};
 
 export const oauthPlugin: Plugin = {
 	name: "oauth",
@@ -36,8 +112,18 @@ export const oauthPlugin: Plugin = {
 		bindOAuthCredentialAction,
 		revokeOAuthCredentialAction,
 	],
-	init: async () => {
-		logger.info("[OAuthPlugin] Initialized");
+	routes: [oauthLocalCallbackRoute],
+	init: async (_config: Record<string, string>, runtime: IAgentRuntime) => {
+		// Register the in-process callback bus only when no durable (cloud) bus is
+		// already present — cloud deployments supply their own cross-process bus.
+		if (!runtime.getService(OAUTH_CALLBACK_BUS_CLIENT_SERVICE)) {
+			await runtime.registerService(LocalOAuthCallbackBus);
+			logger.info(
+				"[OAuthPlugin] Initialized with in-process LocalOAuthCallbackBus (no cloud bus present)",
+			);
+		} else {
+			logger.info("[OAuthPlugin] Initialized (using existing OAuthCallbackBus)");
+		}
 	},
 };
 

--- a/packages/core/src/features/oauth/plugin.ts
+++ b/packages/core/src/features/oauth/plugin.ts
@@ -122,7 +122,9 @@ export const oauthPlugin: Plugin = {
 				"[OAuthPlugin] Initialized with in-process LocalOAuthCallbackBus (no cloud bus present)",
 			);
 		} else {
-			logger.info("[OAuthPlugin] Initialized (using existing OAuthCallbackBus)");
+			logger.info(
+				"[OAuthPlugin] Initialized (using existing OAuthCallbackBus)",
+			);
 		}
 	},
 };

--- a/packages/core/src/features/oauth/types.ts
+++ b/packages/core/src/features/oauth/types.ts
@@ -13,9 +13,22 @@
 
 import type { DeliveryTarget } from "../../sensitive-requests/dispatch-registry.ts";
 
+/**
+ * Providers the OAuth atomic actions accept.
+ *
+ * Every entry except those in {@link CONNECTOR_NATIVE_OAUTH_PROVIDERS} must be
+ * present in the cloud OAuth provider registry (`@elizaos/cloud-shared`:
+ * `getAllProviderIds()` ∪ `VENDOR_REGISTRY` keys). That subset relationship is
+ * enforced — compile-time + runtime — by `provider-alignment.test.ts` in
+ * cloud-shared, the one place that can see both layers without core importing
+ * outward.
+ */
 export type OAuthProvider =
 	| "google"
 	| "discord"
+	| "github"
+	| "notion"
+	| "slack"
 	| "linkedin"
 	| "linear"
 	| "shopify"
@@ -24,10 +37,21 @@ export type OAuthProvider =
 export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
 	"google",
 	"discord",
+	"github",
+	"notion",
+	"slack",
 	"linkedin",
 	"linear",
 	"shopify",
 	"calendly",
+] as const;
+
+/**
+ * Providers whose OAuth is serviced by a connector (not the cloud provider
+ * registry); exempt from the core ⊆ cloud-registry alignment check.
+ */
+export const CONNECTOR_NATIVE_OAUTH_PROVIDERS: readonly OAuthProvider[] = [
+	"discord",
 ] as const;
 
 export type OAuthIntentStatus =

--- a/packages/core/src/features/oauth/types.ts
+++ b/packages/core/src/features/oauth/types.ts
@@ -74,7 +74,11 @@ export interface OAuthIntentEnvelope {
 
 export interface OAuthCallbackResult {
 	oauthIntentId: string;
-	provider: OAuthProvider;
+	/**
+	 * The provider, when known. Absent for `status: "expired"` results produced
+	 * before any provider callback was received (timeout / superseded / stopped).
+	 */
+	provider?: OAuthProvider;
 	status: "bound" | "denied" | "expired";
 	connectorIdentityId?: string;
 	scopesGranted?: string[];

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -27,13 +27,6 @@ export * from "./connectors/account-manager";
 export * from "./connectors/connector-config";
 export * from "./connectors/oauth-role";
 export * from "./connectors/privacy";
-// OAuth provider contract (the canonical provider identifiers the atomic OAuth
-// actions accept). Exported so cloud-shared can enforce core ⊆ cloud-registry.
-export {
-	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
-	OAUTH_PROVIDERS,
-	type OAuthProvider,
-} from "./features/oauth/types.ts";
 // Export additional constants not re-exported by character-utils
 export {
 	CANONICAL_SECRET_KEYS,
@@ -130,6 +123,13 @@ export {
 	triageMessagesAction,
 	WhatsappMessageAdapter,
 } from "./features/messaging/triage";
+// OAuth provider contract (the canonical provider identifiers the atomic OAuth
+// actions accept). Exported so cloud-shared can enforce core ⊆ cloud-registry.
+export {
+	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
+	OAUTH_PROVIDERS,
+	type OAuthProvider,
+} from "./features/oauth/types.ts";
 export { paymentsPlugin } from "./features/payments/index.ts";
 export { PluginManagerService } from "./features/plugin-manager/services/pluginManagerService.ts";
 export {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -27,6 +27,13 @@ export * from "./connectors/account-manager";
 export * from "./connectors/connector-config";
 export * from "./connectors/oauth-role";
 export * from "./connectors/privacy";
+// OAuth provider contract (the canonical provider identifiers the atomic OAuth
+// actions accept). Exported so cloud-shared can enforce core ⊆ cloud-registry.
+export {
+	CONNECTOR_NATIVE_OAUTH_PROVIDERS,
+	OAUTH_PROVIDERS,
+	type OAuthProvider,
+} from "./features/oauth/types.ts";
 // Export additional constants not re-exported by character-utils
 export {
 	CANONICAL_SECRET_KEYS,

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -372,7 +372,9 @@ describe("buildInteractionUrlResolver (#8908)", () => {
 		// resolver returns undefined → layout falls back to block.url
 		expect(resolver.resolveUrl?.(block)).toBeUndefined();
 		const layout = toNeutralLayout(block, resolver);
-		expect(layout.rows[0]?.buttons?.[0]?.url).toBe("https://oauth.test/consent");
+		expect(layout.rows[0]?.buttons?.[0]?.url).toBe(
+			"https://oauth.test/consent",
+		);
 	});
 });
 

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import type {
 	ChoiceInteraction,
 	Content,
+	FollowupsInteraction,
 	FormInteraction,
 	SecretInteraction,
+	TaskInteraction,
 } from "../../types";
 import {
 	decodeCallback,
@@ -11,7 +13,7 @@ import {
 	isInteractionCallback,
 	MAX_CALLBACK_BYTES,
 } from "./callback";
-import { toNeutralLayout } from "./layout";
+import { buildInteractionUrlResolver, toNeutralLayout } from "./layout";
 import {
 	normalizeContentInteractions,
 	stripInteractionMarkers,
@@ -253,6 +255,95 @@ describe("layout", () => {
 			fields: [{ name: "k", type: "text" }],
 		};
 		expect(toNeutralLayout(block).needsFallback).toBe(true);
+	});
+
+	// #8908 — navigate followups render as link-out buttons when a URL resolver
+	// is supplied; reply/prompt chips keep their reply-callback behavior.
+	it("renders a navigate followup as a url button via resolveNavigateUrl", () => {
+		const block: FollowupsInteraction = {
+			kind: "followups",
+			id: "f1",
+			options: [
+				{ kind: "navigate", payload: "/tasks", label: "Open tasks" },
+				{ kind: "reply", payload: "yes", label: "Yes" },
+			],
+		};
+		const layout = toNeutralLayout(block, {
+			resolveNavigateUrl: (p) => `https://app.test${p}`,
+		});
+		const buttons = layout.rows.flatMap((r) => r.buttons ?? []);
+		const nav = buttons.find((b) => b.label === "Open tasks");
+		const reply = buttons.find((b) => b.label === "Yes");
+		expect(nav?.url).toBe("https://app.test/tasks");
+		expect(nav?.callbackData).toBeUndefined();
+		expect(reply?.url).toBeUndefined();
+		expect(decodeCallback(reply?.callbackData)).toEqual({
+			kind: "reply",
+			value: "yes",
+		});
+	});
+
+	it("keeps navigate followups as reply callbacks when no resolver is given", () => {
+		const block: FollowupsInteraction = {
+			kind: "followups",
+			id: "f1",
+			options: [{ kind: "navigate", payload: "/tasks", label: "Open tasks" }],
+		};
+		const button = toNeutralLayout(block).rows[0]?.buttons?.[0];
+		expect(button?.url).toBeUndefined();
+		expect(button?.callbackData).toBeTruthy();
+	});
+});
+
+describe("buildInteractionUrlResolver (#8908)", () => {
+	const resolver = buildInteractionUrlResolver("https://app.test/");
+
+	it("returns no resolvers when no base url is configured", () => {
+		expect(buildInteractionUrlResolver(undefined)).toEqual({});
+		expect(buildInteractionUrlResolver("")).toEqual({});
+	});
+
+	it("resolves a task block to the orchestrator deep link", () => {
+		const block: TaskInteraction = {
+			kind: "task",
+			threadId: "abc-123",
+			title: "Build it",
+		};
+		expect(resolver.resolveUrl?.(block)).toBe(
+			"https://app.test/orchestrator?taskId=abc-123",
+		);
+	});
+
+	it("resolves a form block to the hosted form route", () => {
+		const block: FormInteraction = {
+			kind: "form",
+			id: "form_7",
+			fields: [{ name: "k", type: "text" }],
+		};
+		expect(resolver.resolveUrl?.(block)).toBe("https://app.test/forms/form_7");
+	});
+
+	it("resolves navigate payloads (path + viewId) against the base url", () => {
+		expect(resolver.resolveNavigateUrl?.("/tasks")).toBe(
+			"https://app.test/tasks",
+		);
+		expect(resolver.resolveNavigateUrl?.("inbox")).toBe(
+			"https://app.test/?view=inbox",
+		);
+	});
+
+	it("defers secret/oauth blocks to their own out-of-band url", () => {
+		const block: SecretInteraction = {
+			kind: "secret",
+			id: "s1",
+			secretKind: "oauth",
+			provider: "GitHub",
+			url: "https://oauth.test/consent",
+		};
+		// resolver returns undefined → layout falls back to block.url
+		expect(resolver.resolveUrl?.(block)).toBeUndefined();
+		const layout = toNeutralLayout(block, resolver);
+		expect(layout.rows[0]?.buttons?.[0]?.url).toBe("https://oauth.test/consent");
 	});
 });
 

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -65,6 +65,35 @@ describe("parse", () => {
 		expect(form.submitLabel).toBe("Submit");
 	});
 
+	it("parses an image field with mimeTypes + maxBytes (#8910)", () => {
+		const text = `[FORM]\n${JSON.stringify({
+			title: "2FA",
+			fields: [
+				{
+					name: "seed_photo",
+					type: "image",
+					label: "Photo of seed",
+					mimeTypes: ["image/png", "image/jpeg"],
+					maxBytes: 5_000_000,
+					required: true,
+				},
+				{ name: "doc", type: "file" },
+				{ name: "ignored_mimes", type: "text", mimeTypes: ["image/png"] },
+			],
+		})}\n[/FORM]`;
+		const { blocks } = parseInteractionBlocks(text);
+		const form = blocks[0] as FormInteraction;
+		const image = form.fields.find((f) => f.name === "seed_photo");
+		expect(image?.type).toBe("image");
+		expect(image?.mimeTypes).toEqual(["image/png", "image/jpeg"]);
+		expect(image?.maxBytes).toBe(5_000_000);
+		expect(form.fields.find((f) => f.name === "doc")?.type).toBe("file");
+		// mimeTypes/maxBytes only attach to image/file fields, not text.
+		expect(form.fields.find((f) => f.name === "ignored_mimes")?.mimeTypes).toBe(
+			undefined,
+		);
+	});
+
 	it("rejects malformed form JSON (left as text)", () => {
 		const text = "[FORM]\n{not json}\n[/FORM]";
 		const { blocks, cleanedText } = parseInteractionBlocks(text);

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -55,6 +55,13 @@ export interface LayoutOptions {
 	 * as needing a free-text fallback.
 	 */
 	resolveUrl?: (block: InteractionBlock) => string | undefined;
+	/**
+	 * Resolve an external URL for a `navigate` followup chip (payload is a viewId
+	 * or `/`-prefixed path). When provided, navigate chips render as link-out
+	 * buttons instead of being re-injected as a reply. Returning undefined keeps
+	 * the reply-callback behavior.
+	 */
+	resolveNavigateUrl?: (payload: string) => string | undefined;
 	/** Buttons per row before wrapping (Telegram ~8, Discord 5). Default 3. */
 	maxButtonsPerRow?: number;
 }
@@ -106,6 +113,13 @@ export function toNeutralLayout(
 		case "followups": {
 			const buttons: NeutralButton[] = [];
 			for (const o of block.options) {
+				if (o.kind === "navigate") {
+					const url = opts.resolveNavigateUrl?.(o.payload);
+					if (url) {
+						buttons.push({ label: o.label, url, style: "secondary" });
+						continue;
+					}
+				}
 				const callbackData = encodeReplyCallback(o.payload);
 				if (callbackData)
 					buttons.push({ label: o.label, callbackData, style: "secondary" });
@@ -159,4 +173,40 @@ export function toNeutralLayout(
 			return _exhaustive;
 		}
 	}
+}
+
+/**
+ * Build the canonical link-out resolvers connectors pass to {@link toNeutralLayout}
+ * so Telegram, Discord, and any other surface produce identical URLs for task,
+ * form, and navigate blocks. `appBaseUrl` is the deployment's app/dashboard
+ * origin (`ELIZA_APP_URL`, falling back to the cloud URL). Returns `undefined`
+ * resolvers when no base URL is configured, which keeps the free-text fallback.
+ */
+export function buildInteractionUrlResolver(
+	appBaseUrl: string | undefined | null,
+): Pick<LayoutOptions, "resolveUrl" | "resolveNavigateUrl"> {
+	if (!appBaseUrl) return {};
+	const base = appBaseUrl.replace(/\/+$/, "");
+	return {
+		resolveUrl: (block) => {
+			switch (block.kind) {
+				case "task":
+					return `${base}/orchestrator?taskId=${encodeURIComponent(block.threadId)}`;
+				case "form":
+					return `${base}/forms/${encodeURIComponent(block.id)}`;
+				// Secret/OAuth blocks carry their own out-of-band entry URL
+				// (the hosted secure page); defer to it via the layout fallback.
+				default:
+					return undefined;
+			}
+		},
+		resolveNavigateUrl: (payload) => {
+			if (!payload) return undefined;
+			// A `/`-prefixed path is a dashboard route; a bare token is a viewId.
+			const path = payload.startsWith("/")
+				? payload
+				: `/?view=${encodeURIComponent(payload)}`;
+			return `${base}${path}`;
+		},
+	};
 }

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -45,6 +45,8 @@ const FIELD_TYPES: ReadonlySet<InteractionFieldType> = new Set([
 	"select",
 	"checkbox",
 	"secret",
+	"image",
+	"file",
 ]);
 const FOLLOWUP_KINDS: ReadonlySet<FollowupKind> = new Set([
 	"reply",
@@ -134,6 +136,17 @@ function parseFormField(raw: unknown): InteractionField | null {
 			}
 		}
 		field.options = opts;
+	}
+	if (type === "image" || type === "file") {
+		if (Array.isArray(r.mimeTypes)) {
+			const mimes = r.mimeTypes.filter(
+				(m): m is string => typeof m === "string",
+			);
+			if (mimes.length > 0) field.mimeTypes = mimes;
+		}
+		if (typeof r.maxBytes === "number" && r.maxBytes > 0) {
+			field.maxBytes = r.maxBytes;
+		}
 	}
 	return field;
 }

--- a/packages/core/src/types/interactions.ts
+++ b/packages/core/src/types/interactions.ts
@@ -34,7 +34,9 @@ export type InteractionFieldType =
 	| "number"
 	| "select"
 	| "checkbox"
-	| "secret";
+	| "secret"
+	| "image"
+	| "file";
 
 /** A single field in a form or secret request. */
 export interface InteractionField {
@@ -46,6 +48,13 @@ export interface InteractionField {
 	required?: boolean;
 	/** For `type: "select"` only. */
 	options?: InteractionOption[];
+	/**
+	 * For `type: "image" | "file"` only — accepted MIME types (maps to the file
+	 * input's `accept`). Defaults to `image/*` for image fields when omitted.
+	 */
+	mimeTypes?: string[];
+	/** For `type: "image" | "file"` only — max upload size in bytes. */
+	maxBytes?: number;
 }
 
 /** `[FORM]` — a structured multi-field input rendered as an inline form. */

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -204,8 +204,12 @@ export interface SensitiveRequestDelivery {
 export interface SensitiveRequestFormField {
   name: string;
   label?: string;
-  input?: "secret" | "text";
+  input?: "secret" | "text" | "image" | "file";
   required?: boolean;
+  /** For `input: "image" | "file"` — accepted MIME types (the `accept` attr). */
+  mimeTypes?: string[];
+  /** For `input: "image" | "file"` — max upload size in bytes. */
+  maxBytes?: number;
 }
 
 /**

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -150,6 +150,37 @@ function pendingOAuthRequest(): ConversationMessage["secretRequest"] {
   };
 }
 
+function pendingImageSecretRequest(): ConversationMessage["secretRequest"] {
+  return {
+    key: "TOTP_SEED_PHOTO",
+    reason: "Photograph the 2FA seed",
+    status: "pending",
+    delivery: {
+      mode: "inline_owner_app",
+      instruction: "Upload a photo of the seed.",
+      privateRouteRequired: true,
+      canCollectValueInCurrentChannel: true,
+    },
+    form: {
+      type: "sensitive_request_form",
+      kind: "secret",
+      mode: "inline_owner_app",
+      fields: [
+        {
+          name: "seed_photo",
+          label: "Seed photo",
+          input: "image",
+          required: true,
+          mimeTypes: ["image/png"],
+          maxBytes: 1_000_000,
+        },
+      ],
+      submitLabel: "Upload",
+      statusOnly: true,
+    },
+  };
+}
+
 describe("MessageContent sensitive requests", () => {
   afterEach(() => {
     cleanup();
@@ -239,6 +270,50 @@ describe("MessageContent sensitive requests", () => {
     ]);
     expect(container.textContent?.includes(rawSecret)).toBe(false);
     expect(screen.queryByLabelText("OPENAI_API_KEY")).toBeNull();
+  });
+
+  it("renders an image field as a file input and delivers it via updateSecrets (#8910)", async () => {
+    updateSecretsMock.mockResolvedValueOnce({
+      ok: true,
+      updated: ["seed_photo"],
+    });
+    render(
+      <MessageContent
+        message={baseMessage({ secretRequest: pendingImageSecretRequest() })}
+      />,
+    );
+
+    const input = screen.getByTestId(
+      "sensitive-request-file-seed_photo",
+    ) as HTMLInputElement;
+    expect(input.type).toBe("file");
+    expect(input.accept).toBe("image/png");
+    expect(input.getAttribute("capture")).toBe("environment");
+
+    const file = new File([new Uint8Array([1, 2, 3])], "seed.png", {
+      type: "image/png",
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // FileReader populates the value asynchronously; wait for the submit to enable.
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("sensitive-request-submit") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("sensitive-request-submit"));
+
+    await waitFor(() => {
+      expect(updateSecretsMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = updateSecretsMock.mock.calls[0]?.[0] as Record<
+      string,
+      string
+    >;
+    expect(Object.keys(payload)).toEqual(["seed_photo"]);
+    // Delivered as a data URL through the existing submit path.
+    expect(payload.seed_photo.startsWith("data:image/png")).toBe(true);
   });
 
   it("renders an OAuth request with a Connect button and never shows the URL in chat", () => {

--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -124,6 +124,45 @@ export const SecretRequest: Story = {
   },
 };
 
+/**
+ * #8910 — a sensitive request can collect an image (e.g. photograph a 2FA seed
+ * or QR). Renders a file input with camera capture on mobile; the upload is
+ * delivered as a data URL through the existing submit path.
+ */
+export const SecretRequestImageField: Story = {
+  args: {
+    message: makeMessage({
+      text: "",
+      secretRequest: {
+        key: "TOTP_SEED_PHOTO",
+        reason: "Photograph the 2FA seed shown on the other device.",
+        status: "pending",
+        delivery: {
+          mode: "inline_owner_app",
+          instruction: "Upload a clear photo of the seed.",
+          canCollectValueInCurrentChannel: true,
+        },
+        form: {
+          type: "sensitive_request_form",
+          kind: "secret",
+          mode: "inline_owner_app",
+          submitLabel: "Upload",
+          fields: [
+            {
+              name: "seed_photo",
+              label: "Seed photo",
+              input: "image",
+              required: true,
+              mimeTypes: ["image/png", "image/jpeg"],
+              maxBytes: 5_000_000,
+            },
+          ],
+        },
+      },
+    }),
+  },
+};
+
 /** Analysis mode surfaces XML reasoning blocks + action-name footer. */
 export const AnalysisMode: Story = {
   args: {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1055,8 +1055,7 @@ function SensitiveRequestBlock({
         <form className="space-y-3" onSubmit={handleSubmit}>
           {fields.map((field) => {
             const label = field.label ?? field.name;
-            const isUpload =
-              field.input === "image" || field.input === "file";
+            const isUpload = field.input === "image" || field.input === "file";
             if (isUpload) {
               const accept =
                 field.mimeTypes && field.mimeTypes.length > 0
@@ -1075,7 +1074,9 @@ function SensitiveRequestBlock({
                     type="file"
                     accept={accept}
                     // Mobile: prefer the rear camera for image capture (2FA QR/seed).
-                    capture={field.input === "image" ? "environment" : undefined}
+                    capture={
+                      field.input === "image" ? "environment" : undefined
+                    }
                     required={field.required && !hasValue}
                     onChange={(event) => {
                       const file = event.currentTarget.files?.[0];

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1055,6 +1055,63 @@ function SensitiveRequestBlock({
         <form className="space-y-3" onSubmit={handleSubmit}>
           {fields.map((field) => {
             const label = field.label ?? field.name;
+            const isUpload =
+              field.input === "image" || field.input === "file";
+            if (isUpload) {
+              const accept =
+                field.mimeTypes && field.mimeTypes.length > 0
+                  ? field.mimeTypes.join(",")
+                  : field.input === "image"
+                    ? "image/*"
+                    : undefined;
+              const hasValue = Boolean(values[field.name]);
+              return (
+                <label key={field.name} className="block text-xs space-y-1">
+                  <span className="font-medium">{label}</span>
+                  <input
+                    aria-label={label}
+                    data-testid={`sensitive-request-file-${field.name}`}
+                    className="w-full border border-border bg-bg px-2 py-1.5 text-sm"
+                    type="file"
+                    accept={accept}
+                    // Mobile: prefer the rear camera for image capture (2FA QR/seed).
+                    capture={field.input === "image" ? "environment" : undefined}
+                    required={field.required && !hasValue}
+                    onChange={(event) => {
+                      const file = event.currentTarget.files?.[0];
+                      if (!file) {
+                        setValues((previous) => {
+                          const next = { ...previous };
+                          delete next[field.name];
+                          return next;
+                        });
+                        return;
+                      }
+                      if (field.maxBytes && file.size > field.maxBytes) {
+                        setError(
+                          `${label} is too large (max ${Math.round(
+                            field.maxBytes / 1024,
+                          )} KB).`,
+                        );
+                        event.currentTarget.value = "";
+                        return;
+                      }
+                      const reader = new FileReader();
+                      reader.onload = () => {
+                        setError(null);
+                        setValues((previous) => ({
+                          ...previous,
+                          [field.name]: String(reader.result ?? ""),
+                        }));
+                      };
+                      reader.onerror = () =>
+                        setError(`Could not read ${label}.`);
+                      reader.readAsDataURL(file);
+                    }}
+                  />
+                </label>
+              );
+            }
             return (
               <label key={field.name} className="block text-xs space-y-1">
                 <span className="font-medium">{label}</span>

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  emitCredentialPrompt,
+  emitCredentialResolved,
+} from "../../src/api/credential-prompt.js";
+
+function makeRuntime(opts: { withSend?: boolean; appUrl?: string } = {}) {
+  const send = vi.fn(async () => undefined);
+  const runtime = {
+    agentId: "agent-1",
+    getSetting: (k: string) =>
+      k === "ELIZA_APP_URL" ? opts.appUrl : undefined,
+    ...(opts.withSend === false ? {} : { sendMessageToTarget: send }),
+  };
+  return { runtime, send };
+}
+
+const ROOM = "11111111-1111-1111-1111-111111111111";
+
+describe("emitCredentialPrompt (#8907)", () => {
+  it("posts a prompt to the origin room with key names + dashboard link", async () => {
+    const { runtime, send } = makeRuntime({ appUrl: "https://app.test/" });
+    const ok = await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "telegram" },
+      credentialKeys: ["STRIPE_KEY", "OPENAI_API_KEY"],
+      label: "fix-billing",
+    });
+    expect(ok).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const [target, content] = send.mock.calls[0];
+    expect(target).toEqual({ source: "telegram", roomId: ROOM });
+    expect(content.text).toContain("STRIPE_KEY");
+    expect(content.text).toContain("OPENAI_API_KEY");
+    expect(content.text).toContain("fix-billing");
+    expect(content.text).toContain(
+      "https://app.test/settings?section=credentials",
+    );
+  });
+
+  it("falls back to a reply instruction when no app URL is configured", async () => {
+    const { runtime, send } = makeRuntime();
+    await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "telegram" },
+      credentialKeys: ["KEY"],
+    });
+    const [, content] = send.mock.calls[0];
+    expect(content.text).toContain("Reply here");
+  });
+
+  it("is a no-op when the session has no origin room", async () => {
+    const { runtime, send } = makeRuntime({ appUrl: "https://app.test" });
+    const ok = await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { source: "telegram" },
+      credentialKeys: ["KEY"],
+    });
+    expect(ok).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the runtime cannot send to a target", async () => {
+    const { runtime } = makeRuntime({ withSend: false });
+    const ok = await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "telegram" },
+      credentialKeys: ["KEY"],
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("never throws when the send fails (best-effort side-effect)", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("connector down");
+    });
+    const runtime = {
+      agentId: "agent-1",
+      getSetting: () => undefined,
+      sendMessageToTarget: send,
+    };
+    const ok = await emitCredentialPrompt({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "telegram" },
+      credentialKeys: ["KEY"],
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("emitCredentialResolved (#8907)", () => {
+  it("posts a resolution follow-up naming the key", async () => {
+    const { runtime, send } = makeRuntime();
+    const ok = await emitCredentialResolved({
+      runtime: runtime as never,
+      metadata: { roomId: ROOM, source: "discord" },
+      key: "STRIPE_KEY",
+      label: "fix-billing",
+    });
+    expect(ok).toBe(true);
+    const [target, content] = send.mock.calls[0];
+    expect(target).toEqual({ source: "discord", roomId: ROOM });
+    expect(content.text).toContain("STRIPE_KEY");
+    expect(content.text).toContain("received");
+    expect(content.text).toContain("fix-billing");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -29,6 +29,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { SessionInfo } from "../services/types.js";
 import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
+import {
+  emitCredentialPrompt,
+  emitCredentialResolved,
+} from "./credential-prompt.js";
 import type { RouteContext } from "./route-utils.js";
 import { parseBody, sendJson } from "./route-utils.js";
 
@@ -193,6 +197,14 @@ async function handlePost(
     childSessionId: sessionId,
     credentialKeys: rawKeys as readonly string[],
   });
+  // #8907: surface the pending request as a chat prompt in the origin task
+  // thread (best-effort; never blocks the credential bridge response).
+  await emitCredentialPrompt({
+    runtime: ctx.runtime,
+    metadata: session.metadata,
+    credentialKeys: rawKeys as readonly string[],
+    label: session.name,
+  });
   sendJson(res, {
     credentialScopeId: result.credentialScopeId,
     scopedToken: result.scopedToken,
@@ -255,6 +267,13 @@ async function handleGet(
       scopedToken,
     });
     if (outcome.status === "ready") {
+      // #8907: tell the origin thread the task is unblocked (best-effort).
+      await emitCredentialResolved({
+        runtime: ctx.runtime,
+        metadata: session.metadata,
+        key,
+        label: session.name,
+      });
       sendJson(res, {
         key,
         value: outcome.value,

--- a/plugins/plugin-agent-orchestrator/src/api/credential-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/credential-prompt.ts
@@ -1,0 +1,138 @@
+/**
+ * In-chat surfacing of a sub-agent credential request (#8907).
+ *
+ * The credential bridge (`bridge-routes.ts`) already fires the sensitive-request
+ * flow (REQUEST_SECRET → owner DM / owner-app), but nothing told the user *in
+ * the originating task thread* that a sub-agent is blocked waiting on a secret —
+ * on Telegram (no side panels) that is the blocking gap. This module posts a
+ * compact prompt to the origin room when a request opens, and a status
+ * follow-up when the long-poll resolves, so the user can act without leaving
+ * chat.
+ *
+ * Kept decoupled from the route layer: it only needs the runtime's optional
+ * `sendMessageToTarget` and the origin keys the orchestrator stamps on
+ * `session.metadata` at spawn time (`roomId`, `source`).
+ */
+
+import type { Content, IAgentRuntime, UUID } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+
+type RuntimeWithSendTarget = IAgentRuntime & {
+  sendMessageToTarget?: (
+    target: { source: string; roomId?: UUID; accountId?: string },
+    content: Content,
+  ) => Promise<unknown>;
+};
+
+interface CredentialPromptOrigin {
+  roomId?: UUID;
+  source: string;
+}
+
+const DEFAULT_SOURCE = "sub_agent";
+
+function readOrigin(
+  metadata: Record<string, unknown> | undefined,
+): CredentialPromptOrigin | null {
+  if (!metadata) return null;
+  const roomId =
+    typeof metadata.roomId === "string" ? (metadata.roomId as UUID) : undefined;
+  if (!roomId) return null;
+  const source =
+    typeof metadata.source === "string" && metadata.source
+      ? metadata.source
+      : DEFAULT_SOURCE;
+  return { roomId, source };
+}
+
+/** Build the dashboard credentials link when an app base URL is configured. */
+function credentialsLink(runtime: IAgentRuntime): string | undefined {
+  const raw =
+    runtime.getSetting("ELIZA_APP_URL") ||
+    runtime.getSetting("ELIZA_CLOUD_URL");
+  const base = typeof raw === "string" && raw ? raw.replace(/\/+$/, "") : "";
+  return base ? `${base}/settings?section=credentials` : undefined;
+}
+
+function formatKeys(keys: readonly string[]): string {
+  return keys.map((k) => `\`${k}\``).join(", ");
+}
+
+/**
+ * Post a chat prompt to the origin room announcing the pending credential
+ * request. Returns true when a message was dispatched. Best-effort: a runtime
+ * without `sendMessageToTarget`, or a session with no origin room, is a no-op.
+ */
+export async function emitCredentialPrompt(input: {
+  runtime: IAgentRuntime;
+  metadata: Record<string, unknown> | undefined;
+  credentialKeys: readonly string[];
+  label?: string;
+}): Promise<boolean> {
+  const { runtime, metadata, credentialKeys, label } = input;
+  const origin = readOrigin(metadata);
+  const send = (runtime as RuntimeWithSendTarget).sendMessageToTarget;
+  if (!origin || typeof send !== "function" || credentialKeys.length === 0) {
+    return false;
+  }
+  const who = label ? `Sub-agent **${label}**` : "A sub-agent";
+  const link = credentialsLink(runtime);
+  const lines = [
+    `🔐 ${who} needs ${
+      credentialKeys.length === 1 ? "a credential" : "credentials"
+    } to continue: ${formatKeys(credentialKeys)}.`,
+    link
+      ? `Provide ${credentialKeys.length === 1 ? "it" : "them"} securely here: ${link}`
+      : "Reply here to provide it securely, or open the credentials settings.",
+  ];
+  try {
+    await send(
+      { source: origin.source, roomId: origin.roomId },
+      { text: lines.join("\n"), source: origin.source },
+    );
+    return true;
+  } catch (error) {
+    // Posting the prompt is a non-critical side-effect of the credential
+    // bridge; never let a delivery failure break the request itself.
+    logger.warn(
+      `[credential-prompt] failed to post request prompt: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Post a follow-up once a requested credential has been delivered, so the user
+ * sees the task is unblocked. Best-effort, same no-op conditions as above.
+ */
+export async function emitCredentialResolved(input: {
+  runtime: IAgentRuntime;
+  metadata: Record<string, unknown> | undefined;
+  key: string;
+  label?: string;
+}): Promise<boolean> {
+  const { runtime, metadata, key, label } = input;
+  const origin = readOrigin(metadata);
+  const send = (runtime as RuntimeWithSendTarget).sendMessageToTarget;
+  if (!origin || typeof send !== "function") return false;
+  const who = label ? `**${label}**` : "the sub-agent";
+  try {
+    await send(
+      { source: origin.source, roomId: origin.roomId },
+      {
+        text: `✅ Credential \`${key}\` received — resuming ${who}.`,
+        source: origin.source,
+      },
+    );
+    return true;
+  } catch (error) {
+    logger.warn(
+      `[credential-prompt] failed to post resolution follow-up: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -58,4 +58,20 @@ describe("renderDiscordInteractions", () => {
 		} as Content);
 		expect(out.components.length).toBeLessThanOrEqual(5);
 	});
+
+	it("renders a navigate followup as a link button via resolveNavigateUrl (#8908)", () => {
+		const out = renderDiscordInteractions(
+			{
+				text: "Done.\n[FOLLOWUPS id=f1]\nnavigate:/orchestrator=Open tasks\nreply:thanks=Thanks\n[/FOLLOWUPS]",
+			} as Content,
+			{ resolveNavigateUrl: (p) => `https://app.test${p}` },
+		);
+		const buttons = out.components.flatMap((row) => row.components);
+		const nav = buttons.find((b) => b.label === "Open tasks");
+		const reply = buttons.find((b) => b.label === "Thanks");
+		expect(nav?.style).toBe(5); // Link
+		expect(nav?.url).toBe("https://app.test/orchestrator");
+		expect(reply?.url).toBeUndefined();
+		expect(reply?.custom_id).toBeTruthy();
+	});
 });

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -40,6 +40,8 @@ export interface DiscordInteractionRender {
 export interface DiscordInteractionOptions {
 	/** Resolve a link-out URL for task / form / secret blocks. */
 	resolveUrl?: (block: InteractionBlock) => string | undefined;
+	/** Resolve a link-out URL for `navigate` followup chips. */
+	resolveNavigateUrl?: (payload: string) => string | undefined;
 }
 
 function toComponent(button: NeutralButton): DiscordComponentOptions | null {
@@ -89,6 +91,7 @@ export function renderDiscordInteractions(
 	for (const block of blocks) {
 		const layout = toNeutralLayout(block, {
 			resolveUrl: opts.resolveUrl,
+			resolveNavigateUrl: opts.resolveNavigateUrl,
 			maxButtonsPerRow: MAX_BUTTONS_PER_ROW,
 		});
 		let producedButton = false;

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+	buildInteractionUrlResolver,
 	ChannelType,
 	type Content,
 	ContentType,
@@ -922,7 +923,15 @@ export class MessageManager {
 
 					// Project embedded interaction blocks (choices, task cards, …) onto
 					// native Discord components, and strip their markers from the prose.
-					const rendered = renderDiscordInteractions(content);
+					const rawAppUrl =
+						this.runtime.getSetting("ELIZA_APP_URL") ||
+						this.runtime.getSetting("ELIZA_CLOUD_URL");
+					const appBaseUrl =
+						typeof rawAppUrl === "string" ? rawAppUrl : undefined;
+					const rendered = renderDiscordInteractions(
+						content,
+						buildInteractionUrlResolver(appBaseUrl),
+					);
 					const hasComponents = rendered.components.length > 0;
 					let textContent = normalizeDiscordMessageText(rendered.text);
 					if (textContent.trim().length === 0 && hasComponents) {

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -53,4 +53,23 @@ describe("renderTelegramInteractions", () => {
     expect(out.text).toContain("Ship it");
     expect(out.keyboardRows).toHaveLength(0);
   });
+
+  it("renders a navigate followup as a URL button via resolveNavigateUrl (#8908)", () => {
+    const content: Content = {
+      text: "Done.\n[FOLLOWUPS id=f1]\nnavigate:/orchestrator=Open tasks\nreply:thanks=Thanks\n[/FOLLOWUPS]",
+    };
+    const out = renderTelegramInteractions(content, {
+      resolveNavigateUrl: (p) => `https://app.test${p}`,
+    });
+    const buttons = out.keyboardRows.flat() as Array<{
+      text: string;
+      url?: string;
+      callback_data?: string;
+    }>;
+    const nav = buttons.find((b) => b.text === "Open tasks");
+    const reply = buttons.find((b) => b.text === "Thanks");
+    expect(nav?.url).toBe("https://app.test/orchestrator");
+    expect(reply?.url).toBeUndefined();
+    expect(reply?.callback_data).toBeTruthy();
+  });
 });

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -38,6 +38,8 @@ export interface TelegramInteractionRender {
 export interface TelegramInteractionOptions {
   /** Resolve a link-out URL for task / form / secret blocks. */
   resolveUrl?: (block: InteractionBlock) => string | undefined;
+  /** Resolve a link-out URL for `navigate` followup chips. */
+  resolveNavigateUrl?: (payload: string) => string | undefined;
 }
 
 function toTelegramButton(button: NeutralButton): InlineKeyboardButton | null {
@@ -72,6 +74,7 @@ export function renderTelegramInteractions(
   for (const block of blocks) {
     const layout = toNeutralLayout(block, {
       resolveUrl: opts.resolveUrl,
+      resolveNavigateUrl: opts.resolveNavigateUrl,
       maxButtonsPerRow: MAX_BUTTONS_PER_ROW,
     });
     let producedButton = false;

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -17,7 +17,7 @@ function createManager() {
       sendMessage,
     },
   };
-  const runtime = { agentId: "agent-1" };
+  const runtime = { agentId: "agent-1", getSetting: () => undefined };
 
   return {
     manager: new MessageManager(bot as never, runtime as never),
@@ -468,7 +468,7 @@ describe("MessageManager send resilience (sendWithRetry)", () => {
     };
     const manager = new MessageManager(
       { telegram } as never,
-      { agentId: "agent-1" } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
     );
     const ctx = { chat: { id: 123 }, telegram } as never;
     return { manager, ctx };
@@ -561,7 +561,7 @@ describe("MessageManager typing-indicator resilience", () => {
     });
     const manager = new MessageManager(
       { telegram: { sendMessage, sendChatAction } } as never,
-      { agentId: "agent-1" } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
     );
     const sent = await manager.sendMessageInChunks(
       { chat: { id: 123 }, telegram: { sendMessage, sendChatAction } } as never,

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import {
+  buildInteractionUrlResolver,
   ChannelType,
   type Content,
   type ContentType,
@@ -755,7 +756,15 @@ export class MessageManager {
       // Project any interactive blocks (choices, task cards, …) the agent
       // embedded in the text onto native inline keyboards, and send the prose
       // with the markers stripped. Plain replies pass through unchanged.
-      const rendered = renderTelegramInteractions(content);
+      const rawAppUrl =
+        this.runtime.getSetting("ELIZA_APP_URL") ||
+        this.runtime.getSetting("ELIZA_CLOUD_URL");
+      const appBaseUrl =
+        typeof rawAppUrl === "string" ? rawAppUrl : undefined;
+      const rendered = renderTelegramInteractions(
+        content,
+        buildInteractionUrlResolver(appBaseUrl),
+      );
       const sentMessages: Message.TextMessage[] = [];
 
       const telegramButtons = convertToTelegramButtons(content.buttons ?? []);
@@ -1599,6 +1608,81 @@ export class MessageManager {
         "Error handling reaction",
       );
     }
+  }
+
+  /**
+   * Edits the text of a previously-sent Telegram message in place. Converts
+   * markdown to MarkdownV2 and, on a MarkdownV2 rejection, retries as plain
+   * text — mirroring {@link sendMessageInChunks}'s fallback. Used by the
+   * connector `edit_message` capability so the orchestrator's compact progress
+   * mode can rewrite one line across heartbeats instead of flooding the chat.
+   */
+  public async editMessage(
+    chatId: number | string,
+    messageId: number,
+    text: string,
+    messageThreadId?: number,
+  ): Promise<void> {
+    const formatted = convertMarkdownToTelegram(text);
+    await this.sendWithRetry(
+      () =>
+        this.bot.telegram.editMessageText(
+          chatId,
+          messageId,
+          undefined,
+          formatted,
+          { parse_mode: "MarkdownV2" },
+        ),
+      // Fallback: Telegram rejected the MarkdownV2 — edit with the raw text so
+      // the user sees the content unformatted rather than a stale message.
+      () =>
+        this.bot.telegram.editMessageText(
+          chatId,
+          messageId,
+          undefined,
+          cleanText(text),
+        ),
+    );
+    logger.info(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        chatId,
+        messageId,
+        messageThreadId,
+      },
+      "Message edited",
+    );
+  }
+
+  /**
+   * Sets a single emoji reaction on a Telegram message, or clears the bot's
+   * reactions when `emoji` is undefined. Used by the connector `react_message`
+   * capability.
+   */
+  public async addReaction(
+    chatId: number | string,
+    messageId: number,
+    emoji?: string,
+  ): Promise<void> {
+    await this.bot.telegram.setMessageReaction(
+      chatId,
+      messageId,
+      // Telegram only accepts a fixed set of reaction emoji (the `TelegramEmoji`
+      // union); the connector passes an arbitrary string, so cast and let
+      // Telegram reject an unsupported emoji at the API boundary.
+      emoji ? [{ type: "emoji", emoji } as ReactionType] : [],
+    );
+    logger.info(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        chatId,
+        messageId,
+        emoji: emoji ?? "(cleared)",
+      },
+      "Message reaction set",
+    );
   }
 
   /**

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -759,8 +759,7 @@ export class MessageManager {
       const rawAppUrl =
         this.runtime.getSetting("ELIZA_APP_URL") ||
         this.runtime.getSetting("ELIZA_CLOUD_URL");
-      const appBaseUrl =
-        typeof rawAppUrl === "string" ? rawAppUrl : undefined;
+      const appBaseUrl = typeof rawAppUrl === "string" ? rawAppUrl : undefined;
       const rendered = renderTelegramInteractions(
         content,
         buildInteractionUrlResolver(appBaseUrl),

--- a/plugins/plugin-telegram/src/sensitive-request-adapter.ts
+++ b/plugins/plugin-telegram/src/sensitive-request-adapter.ts
@@ -10,11 +10,11 @@
  * linked, otherwise the local dashboard URL). This adapter just renders whatever
  * URL it is handed; it does not decide cloud-vs-local.
  *
- * NOTE: the dispatch registry holds one adapter per target ("dm"). In a
- * Telegram-only deployment this adapter is the DM adapter; if both Discord and
- * Telegram are loaded, registration order currently decides which claims "dm".
- * Proper per-source resolution is a registry follow-up (see the interaction
- * protocol README).
+ * Both this adapter and the Discord DM adapter register under the "dm" target;
+ * the dispatch registry keeps every adapter per target and selects the right one
+ * per request via `resolve(target, channelId, runtime)` + this adapter's
+ * `supportsChannel`, so loading both connectors no longer collides on "dm"
+ * (registration order is irrelevant). See `dispatch-registry.ts`.
  */
 
 import {


### PR DESCRIPTION
Implements four of the five children of **EPIC #8886 — credentials & in-chat interaction flows**. Each is an independent, tested slice; the fifth (#8907 in-chat credential request UX) builds on #8905 and follows.

## #8909 — github/notion/slack in core OAuthProvider + cloud alignment check
`CREATE_OAUTH_INTENT({ provider: 'github' })` failed TS + runtime validation despite GitHub being fully registered in the cloud provider registry. Added `github`/`notion`/`slack` to `OAuthProvider`, a `CONNECTOR_NATIVE_OAUTH_PROVIDERS` exception (discord), and a cloud-shared `provider-alignment.test.ts` asserting every cloud-serviced core provider exists in `getAllProviderIds() ∪ VENDOR_REGISTRY`.

## #8908 — link-out URLs in Telegram/Discord renderers
Form/task blocks fell to free-text and navigate followups were dropped because neither connector passed a `resolveUrl` at the render call site. Added a shared `buildInteractionUrlResolver(appBaseUrl)` (identical task/form/navigate URLs across connectors) + `LayoutOptions.resolveNavigateUrl`, wired into both renderers from `ELIZA_APP_URL ?? ELIZA_CLOUD_URL`. The "dm" adapter collision is already solved by the registry's `resolve()` + per-adapter `supportsChannel` (both connectors implement it); no `dm:<source>` rename needed.

## #8910 — image/file field type for credential flows
`InteractionFieldType` gains `image`/`file` + per-field `mimeTypes`/`maxBytes`; `SensitiveRequestBlock` renders `<input type=file accept=… capture=environment>`, reads the file to a data URL (enforcing `maxBytes`), and delivers it through the existing `updateSecrets` submit path. Storybook story added.

## #8905 — in-process OAuthCallbackBus + local callback route (non-cloud)
`AWAIT_OAUTH_CALLBACK` had no in-process bus, so without cloud the flow dead-ended. Added `LocalOAuthCallbackBus` (waiter map + timeout→expired + `publish`), a `POST /api/oauth/callback` route resolving it by intent id, and conditional registration (local only when no cloud bus). `OAuthCallbackResult.provider` made optional (genuinely absent on expired results).

## Tests
- core: `create-oauth-intent` (github/notion/slack), `interactions` (navigate URL + `buildInteractionUrlResolver` + image-field parse), `local-callback-bus` (resolve/timeout/supersede/stop + route 200/404/400/503) — all green.
- cloud-shared: `provider-alignment` (4) green.
- telegram + discord: navigate-followup URL-button render tests green; `messageManager` mock updated for `getSetting`.
- ui: `MessageContent.sensitive-request` image-upload → `updateSecrets` data URL.

## Notes
- Pre-existing/unrelated: the `command-registration` / `catalog-commands` "gate-safe deterministic local reply" tests are failing on a working-tree-local change to `message.ts` (issue #8877 WIP), not on this branch — both test files are byte-identical to develop and this branch never touches the command gate.
- Remaining EPIC child: **#8907** (in-chat credential request UX), which depends on #8905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)