### PR TITLE
feat(orchestrator): Reflexion-style per-task failure memory injected into re-spawns (#8899)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -65,3 +65,35 @@ describe("buildGoalPrompt capability fence", () => {
     expect(prompt).not.toContain("domains.buy");
   });
 });
+
+describe("buildGoalPrompt attempt reflections (#8899)", () => {
+  const baseInput = { agentName: "Ada", goal: "ship the thing" };
+
+  it("omits the Past Attempt Failures section when there are no reflections", () => {
+    expect(buildGoalPrompt(baseInput)).not.toContain("Past Attempt Failures");
+    expect(buildGoalPrompt({ ...baseInput, attemptReflections: [] })).not.toContain(
+      "Past Attempt Failures",
+    );
+  });
+
+  it("replays prior failed attempts (summary + missing) on re-spawn", () => {
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      attemptReflections: [
+        {
+          attempt: 1,
+          summary: "tests were never run",
+          missing: ["unit tests pass", "typecheck clean"],
+        },
+        { attempt: 2, summary: "lint still failing", missing: [] },
+      ],
+    });
+    expect(prompt).toContain("--- Past Attempt Failures ---");
+    expect(prompt).toContain("Do NOT repeat these mistakes");
+    expect(prompt).toContain("Attempt 1: tests were never run");
+    expect(prompt).toContain("Missing: unit tests pass; typecheck clean.");
+    expect(prompt).toContain("Attempt 2: lint still failing");
+    // No "Missing:" suffix when the attempt listed nothing missing.
+    expect(prompt).not.toContain("Attempt 2: lint still failing. Missing:");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -13,6 +13,8 @@
  * @module services/goal-prompt
  */
 
+import type { AttemptReflection } from "./orchestrator-task-types.js";
+
 /** The coding-relevant capability fence applied when a caller does not pass an
  * explicit allow-list. Keeps a worker from reaching for unrelated connectors or
  * broad personal-data tools. */
@@ -91,6 +93,9 @@ export interface GoalPromptInput {
   /** Explicit capability fence; overrides {@link GoalPromptInput.capabilityProfile}
    * and defaults to {@link DEFAULT_GOAL_CAPABILITIES}. */
   allowedCapabilities?: readonly string[];
+  /** Reflexion-style post-mortems from prior failed verification attempts of
+   * this same task. Injected on re-spawn so the worker doesn't repeat them. */
+  attemptReflections?: readonly AttemptReflection[];
 }
 
 export type GoalFollowUpReason =
@@ -142,6 +147,21 @@ export function buildGoalPrompt(input: GoalPromptInput): string {
     sections.push(
       "--- Acceptance Criteria ---",
       bulletList(input.acceptanceCriteria),
+    );
+  }
+
+  // Reflexion: replay prior failed verification attempts so a re-spawned worker
+  // doesn't repeat the same mistakes (#8899).
+  if (input.attemptReflections && input.attemptReflections.length > 0) {
+    const reflectionLines = input.attemptReflections.map((r) => {
+      const missing =
+        r.missing.length > 0 ? ` Missing: ${r.missing.join("; ")}.` : "";
+      return `Attempt ${r.attempt}: ${r.summary.trim()}${missing}`;
+    });
+    sections.push(
+      "--- Past Attempt Failures ---",
+      "Previous attempts at this goal failed verification for the reasons below. Do NOT repeat these mistakes — address each one before reporting done.",
+      bulletList(reflectionLines),
     );
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -65,7 +65,9 @@ import {
 } from "./orchestrator-task-mapper.js";
 import { OrchestratorTaskStore } from "./orchestrator-task-store.js";
 import {
+  type AttemptReflection,
   type CreateTaskInput,
+  MAX_ATTEMPT_REFLECTIONS,
   type OrchestratorAccountAssignment,
   type OrchestratorAccountOverview,
   type OrchestratorRoomParticipant,
@@ -229,6 +231,31 @@ function str(value: unknown): string | undefined {
 
 function num(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Coerce the persisted `metadata.attemptReflections` (free-form JSON) back into
+ * typed {@link AttemptReflection}s, dropping any malformed entries. See #8899.
+ */
+function readAttemptReflections(
+  metadata: Record<string, unknown> | undefined,
+): AttemptReflection[] {
+  const raw = metadata?.attemptReflections;
+  if (!Array.isArray(raw)) return [];
+  const out: AttemptReflection[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const r = entry as Record<string, unknown>;
+    if (typeof r.attempt !== "number" || typeof r.summary !== "string") continue;
+    out.push({
+      attempt: r.attempt,
+      summary: r.summary,
+      missing: Array.isArray(r.missing)
+        ? r.missing.filter((m): m is string => typeof m === "string")
+        : [],
+    });
+  }
+  return out;
 }
 
 function truncate(text: string, max = 2000): string {
@@ -1380,8 +1407,22 @@ export class OrchestratorTaskService extends Service {
       // `keepAliveAfterComplete`, so the ACP process is still attached and can
       // take a follow-up. Persist the bumped attempt counter first so a
       // redelivered task_complete can't double-count, then reactivate and steer.
+      // Reflexion (#8899): record a verbal post-mortem of this failed attempt so
+      // the next re-spawn of this task can replay it and avoid repeating the gap.
+      const attemptReflections = [
+        ...readAttemptReflections(doc.task.metadata),
+        {
+          attempt: attempts + 1,
+          missing: verdict.missing ?? [],
+          summary: verdict.summary ?? "",
+        },
+      ].slice(-MAX_ATTEMPT_REFLECTIONS);
       await this.store.updateTask(taskId, {
-        metadata: { ...doc.task.metadata, autoVerifyAttempts: attempts + 1 },
+        metadata: {
+          ...doc.task.metadata,
+          autoVerifyAttempts: attempts + 1,
+          attemptReflections,
+        },
       });
       await this.store.addEvent({
         id: randomUUID(),
@@ -1895,6 +1936,9 @@ export class OrchestratorTaskService extends Service {
       taskRoomId: doc.task.taskRoomId ?? doc.task.roomId,
       workdir,
       repo: opts.repo,
+      // Replay prior failed-verification post-mortems so a re-spawn of this task
+      // doesn't repeat them (#8899).
+      attemptReflections: readAttemptReflections(doc.task.metadata),
       ...(capabilityProfile ? { capabilityProfile } : {}),
     });
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -82,6 +82,24 @@ export interface OrchestratorTaskRecord {
   metadata: Record<string, unknown>;
 }
 
+/**
+ * A Reflexion-style verbal post-mortem captured when an automatic verification
+ * attempt fails. Stored on the task (under `metadata.attemptReflections`) and
+ * injected into the re-spawn prompt so a retried sub-agent doesn't repeat the
+ * same mistakes. See #8899.
+ */
+export interface AttemptReflection {
+  /** 1-based attempt number this reflection is for. */
+  attempt: number;
+  /** Acceptance criteria / evidence the verifier found missing. */
+  missing: string[];
+  /** The verifier's one-line summary of why the attempt fell short. */
+  summary: string;
+}
+
+/** Cap on retained reflections — keep the most recent few to bound prompt size. */
+export const MAX_ATTEMPT_REFLECTIONS = 5;
+
 export interface TaskProviderPolicy {
   /** Preferred sub-agent framework: claude | codex | opencode | elizaos | pi-agent. */
   preferredFramework?: string;


### PR DESCRIPTION
## Summary
Closes #8899 (part of #8884). When auto-verify failed, the per-attempt failure reasons lived only in the audit log, so a **re-spawned sub-agent repeated the same mistakes**. This adds Reflexion-style verbal post-mortems carried into retries.

Builds directly on the just-merged evidence-demanding verifier (#8882 / `baa08f4a81`).

## Changes
- `AttemptReflection` type (`attempt`, `missing[]`, `summary`) + `MAX_ATTEMPT_REFLECTIONS` cap in `orchestrator-task-types.ts`.
- On each failed verification, append a reflection to `metadata.attemptReflections` (capped, most-recent-few) alongside the bumped attempt counter.
- `buildGoalPrompt` gains an `attemptReflections` input and renders a `--- Past Attempt Failures ---` section instructing the worker not to repeat them.
- The orchestrator spawn path reads `metadata.attemptReflections` (coerced + validated via `readAttemptReflections`) and threads it through, so any re-spawn of the same task replays its post-mortems.

## Acceptance criteria
- [x] `attemptReflections` persisted on the task record (in `metadata`).
- [x] Re-spawn prompt includes a Past Attempt Failures section.
- [x] Reflection carried into retry (the spawn path reads + injects it).

## Tests
`goal-prompt.test.ts` — section omitted with no reflections; replays summary + `Missing:` on re-spawn; no spurious `Missing:` when nothing was missing.
```
goal-prompt        19/19 pass
auto-goal-verify    9/9 pass
typecheck           clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)