### PR TITLE
test(coding): wave 3 coding-capability coverage (PTY UI, settings, reload, notifications, concurrency, create-app scenario)

### DIFF
--- a/packages/agent/src/api/views-routes.bundle.test.ts
+++ b/packages/agent/src/api/views-routes.bundle.test.ts
@@ -1,0 +1,379 @@
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import type http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getView,
+  registerBuiltinViews,
+  registerPluginViews,
+  unregisterPluginViews,
+} from "./views-registry.ts";
+import {
+  clearCurrentViewState,
+  handleViewsRoutes,
+  type ViewsRouteContext,
+} from "./views-routes.ts";
+
+// Domain H route-level coverage gap: GET/HEAD /api/views/:id/bundle.js
+// (views-routes.ts L496-635). The sibling views-routes.*.test.ts files exercise
+// hero/navigate/interact/search but NOT the bundle.js branch — so its cache-bust
+// + revalidation contract was previously untested at the route boundary. This
+// file pins:
+//   • mtime+size-derived ETag (NOT content hash) and 304 revalidation,
+//   • disk re-read after an on-disk rewrite (no stale-buffer cache),
+//   • fresh ETag minted on rewrite (stale validators no longer 304),
+//   • live X-Content-Hash reflecting the current bytes,
+//   • ?v=<bundleHash> immutable-vs-no-cache cache divergence (the core cache-bust),
+//   • HEAD parity (status/ETag/Content-Length, empty body, no X-Content-Hash),
+//   • not-built (missing file) 404, and the iOS/Android 403 platform gate.
+// All synthetic: real temp dir, no PGLite/runtime/LLM. Expected ETag and
+// X-Content-Hash are recomputed in-test from a fresh fs.stat/readFile so the
+// assertions are exact rather than snapshot-fragile.
+
+const TEST_PLUGIN = "@test/views-bundle";
+const VIEW_ID = "bundle-view";
+const PKG_JSON = JSON.stringify({ name: TEST_PLUGIN });
+
+const V1_BYTES = Buffer.from("export const v=1;\n", "utf8");
+// v2 is strictly LONGER than v1 so the file size alone changes the ETag even if
+// the filesystem's mtime resolution is too coarse to register the rewrite.
+const V2_BYTES = Buffer.from(
+  "export const v=2; export const extra='a-longer-bundle-payload';\n",
+  "utf8",
+);
+
+interface CapturedRes {
+  writeHead: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}
+
+function makeBundleCtx(
+  id: string,
+  opts: {
+    method?: "GET" | "HEAD";
+    headers?: Record<string, string>;
+    search?: string;
+  } = {},
+): {
+  ctx: ViewsRouteContext;
+  res: CapturedRes;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  const req = Readable.from([]) as unknown as http.IncomingMessage;
+  req.headers = opts.headers ?? {};
+  const res: CapturedRes = {
+    writeHead: vi.fn(),
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  };
+  const json = vi.fn();
+  const error = vi.fn();
+  const search = opts.search ?? "";
+  const pathname = `/api/views/${encodeURIComponent(id)}/bundle.js`;
+  const ctx: ViewsRouteContext = {
+    req,
+    res: res as unknown as http.ServerResponse,
+    method: opts.method ?? "GET",
+    pathname,
+    url: new URL(`http://local${pathname}${search}`),
+    json,
+    error,
+    broadcastWs: vi.fn(),
+  };
+  return { ctx, res, json, error };
+}
+
+function headersFrom(res: CapturedRes): Record<string, string | number> {
+  return res.writeHead.mock.calls[0]?.[1] as Record<string, string | number>;
+}
+
+function statusFrom(res: CapturedRes): number {
+  return res.writeHead.mock.calls[0]?.[0] as number;
+}
+
+function bodyBufferFrom(res: CapturedRes): Buffer {
+  const chunk = res.end.mock.calls[0]?.[0];
+  if (chunk instanceof Buffer) return chunk;
+  if (typeof chunk === "string") return Buffer.from(chunk);
+  return Buffer.alloc(0);
+}
+
+async function registerBundleView(dir: string): Promise<void> {
+  await registerPluginViews(
+    {
+      name: TEST_PLUGIN,
+      description: "Synthetic bundle test plugin.",
+      views: [
+        {
+          id: VIEW_ID,
+          label: "Bundle View",
+          path: "/bundle-view",
+          bundlePath: "bundle.js",
+        },
+      ],
+    },
+    dir,
+  );
+}
+
+/** Recompute the route's exact ETag for the current on-disk bundle bytes. */
+async function expectedEtag(bundlePath: string): Promise<string> {
+  const s = await stat(bundlePath);
+  return `"${createHash("sha256")
+    .update(`${s.mtimeMs}-${s.size}`)
+    .digest("hex")
+    .slice(0, 16)}"`;
+}
+
+describe("GET/HEAD /api/views/:id/bundle.js — cache-bust + ETag revalidation", () => {
+  let dir: string;
+  let bundlePath: string;
+
+  beforeEach(async () => {
+    registerBuiltinViews();
+    clearCurrentViewState();
+    dir = await mkdtemp(path.join(tmpdir(), "views-bundle-"));
+    bundlePath = path.join(dir, "bundle.js");
+    await writeFile(path.join(dir, "package.json"), PKG_JSON);
+    await writeFile(bundlePath, V1_BYTES);
+    await registerBundleView(dir);
+  });
+
+  afterEach(async () => {
+    clearCurrentViewState();
+    unregisterPluginViews(TEST_PLUGIN);
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("serves the v1 bundle bytes with the JS content-type and an ETag", async () => {
+    const { ctx, res } = makeBundleCtx(VIEW_ID);
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.writeHead).toHaveBeenCalledTimes(1);
+    expect(statusFrom(res)).toBe(200);
+    const headers = headersFrom(res);
+    expect(headers["Content-Type"]).toBe(
+      "application/javascript; charset=utf-8",
+    );
+    expect(bodyBufferFrom(res)).toEqual(V1_BYTES);
+
+    // ETag is derived from mtime+size, NOT the content hash.
+    const etagV1 = headers.ETag as string;
+    expect(etagV1).toBe(await expectedEtag(bundlePath));
+    expect(etagV1).toMatch(/^"[0-9a-f]{16}"$/);
+  });
+
+  it("returns 304 with an empty body when If-None-Match matches the current ETag", async () => {
+    const etagV1 = await expectedEtag(bundlePath);
+    const { ctx, res } = makeBundleCtx(VIEW_ID, {
+      headers: { "if-none-match": etagV1 },
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.writeHead).toHaveBeenCalledTimes(1);
+    expect(statusFrom(res)).toBe(304);
+    expect(headersFrom(res)).toEqual({});
+    // 304 body must be empty (res.end() called with no chunk).
+    expect(res.end).toHaveBeenCalledTimes(1);
+    expect(res.end.mock.calls[0]).toHaveLength(0);
+  });
+
+  it("re-reads disk on rewrite: serves v2 bytes (not stale v1) and mints a fresh ETag", async () => {
+    const etagV1 = await expectedEtag(bundlePath);
+
+    // Rewrite with longer bytes AND bump mtime into the future so both size and
+    // mtimeMs diverge (defends against coarse filesystem mtime granularity).
+    await writeFile(bundlePath, V2_BYTES);
+    const future = new Date(Date.now() + 60_000);
+    await utimes(bundlePath, future, future);
+
+    const { ctx, res } = makeBundleCtx(VIEW_ID);
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(statusFrom(res)).toBe(200);
+    const headers = headersFrom(res);
+    expect(bodyBufferFrom(res)).toEqual(V2_BYTES);
+    expect(bodyBufferFrom(res)).not.toEqual(V1_BYTES);
+
+    const etagV2 = headers.ETag as string;
+    expect(etagV2).toBe(await expectedEtag(bundlePath));
+    // Regression guard: a content/mtime change MUST mint a new validator.
+    expect(etagV2).not.toBe(etagV1);
+  });
+
+  it("does not 304 a stale validator after a rewrite — serves fresh v2 bytes", async () => {
+    const etagV1 = await expectedEtag(bundlePath);
+
+    await writeFile(bundlePath, V2_BYTES);
+    const future = new Date(Date.now() + 60_000);
+    await utimes(bundlePath, future, future);
+
+    const { ctx, res } = makeBundleCtx(VIEW_ID, {
+      headers: { "if-none-match": etagV1 },
+    });
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    // Old validator no longer matches → full 200 with the new bytes.
+    expect(statusFrom(res)).toBe(200);
+    expect(bodyBufferFrom(res)).toEqual(V2_BYTES);
+  });
+
+  it("emits an X-Content-Hash that tracks the live bytes (differs across v1/v2)", async () => {
+    const { ctx: ctx1, res: res1 } = makeBundleCtx(VIEW_ID);
+    await handleViewsRoutes(ctx1);
+    const xchV1 = headersFrom(res1)["X-Content-Hash"] as string;
+    expect(xchV1).toBe(
+      `sha256-${createHash("sha256").update(V1_BYTES).digest("base64")}`,
+    );
+
+    await writeFile(bundlePath, V2_BYTES);
+    const future = new Date(Date.now() + 60_000);
+    await utimes(bundlePath, future, future);
+
+    const { ctx: ctx2, res: res2 } = makeBundleCtx(VIEW_ID);
+    await handleViewsRoutes(ctx2);
+    const xchV2 = headersFrom(res2)["X-Content-Hash"] as string;
+    expect(xchV2).toBe(
+      `sha256-${createHash("sha256").update(V2_BYTES).digest("base64")}`,
+    );
+    expect(xchV2).not.toBe(xchV1);
+  });
+
+  it("uses Cache-Control: no-cache for a ?v= that does not match the bundle hash", async () => {
+    const { ctx, res } = makeBundleCtx(VIEW_ID, { search: "?v=deadbeef" });
+    await handleViewsRoutes(ctx);
+    expect(headersFrom(res)["Cache-Control"]).toBe("no-cache");
+  });
+
+  it("serves immutable cache for ?v=<current bundleHash> but no-cache for a stale hash (cache-bust)", async () => {
+    // bundleHash is the registration-time content sha (12 hex), NOT the ETag.
+    const oldHash = getView(VIEW_ID)?.bundleHash;
+    expect(oldHash).toBeTruthy();
+    expect(oldHash).toMatch(/^[0-9a-f]{12}$/);
+    // Sanity: bundleHash is the 12-char content sha of v1.
+    expect(oldHash).toBe(
+      createHash("sha256").update(V1_BYTES).digest("hex").slice(0, 12),
+    );
+
+    // Rewrite + re-register so the entry's bundleHash refreshes to the v2 content.
+    await writeFile(bundlePath, V2_BYTES);
+    const future = new Date(Date.now() + 60_000);
+    await utimes(bundlePath, future, future);
+    await registerBundleView(dir);
+
+    const newHash = getView(VIEW_ID)?.bundleHash;
+    expect(newHash).toBeTruthy();
+    expect(newHash).not.toBe(oldHash);
+
+    // Matching (current) hash → immutable long cache.
+    const { ctx: ctxNew, res: resNew } = makeBundleCtx(VIEW_ID, {
+      search: `?v=${newHash}`,
+    });
+    await handleViewsRoutes(ctxNew);
+    expect(headersFrom(resNew)["Cache-Control"]).toBe(
+      "public, max-age=31536000, immutable",
+    );
+
+    // Stale (old v1) hash → must revalidate.
+    const { ctx: ctxOld, res: resOld } = makeBundleCtx(VIEW_ID, {
+      search: `?v=${oldHash}`,
+    });
+    await handleViewsRoutes(ctxOld);
+    expect(headersFrom(resOld)["Cache-Control"]).toBe("no-cache");
+
+    // The two cache directives MUST differ for old vs new hash.
+    expect(headersFrom(resNew)["Cache-Control"]).not.toBe(
+      headersFrom(resOld)["Cache-Control"],
+    );
+  });
+
+  it("always revalidates (no-cache) when no ?v= param is present", async () => {
+    const { ctx, res } = makeBundleCtx(VIEW_ID);
+    await handleViewsRoutes(ctx);
+    expect(headersFrom(res)["Cache-Control"]).toBe("no-cache");
+  });
+
+  it("HEAD returns 200 with ETag + Content-Length but an empty body and no X-Content-Hash", async () => {
+    const { ctx, res } = makeBundleCtx(VIEW_ID, { method: "HEAD" });
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(statusFrom(res)).toBe(200);
+    const headers = headersFrom(res);
+    expect(headers.ETag).toBe(await expectedEtag(bundlePath));
+    expect(headers["Content-Length"]).toBe(0);
+    expect(headers["X-Content-Hash"]).toBeUndefined();
+    // HEAD body is undefined (no bytes).
+    expect(res.end).toHaveBeenCalledTimes(1);
+    expect(res.end.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it("404s via the error helper when the bundle file does not exist (not built)", async () => {
+    const missingDir = await mkdtemp(
+      path.join(tmpdir(), "views-bundle-missing-"),
+    );
+    await writeFile(
+      path.join(missingDir, "package.json"),
+      JSON.stringify({ name: "@test/views-bundle-missing" }),
+    );
+    // Register a view whose bundlePath points at a file we never write.
+    await registerPluginViews(
+      {
+        name: "@test/views-bundle-missing",
+        description: "Missing bundle plugin.",
+        views: [
+          {
+            id: "missing-bundle-view",
+            label: "Missing Bundle",
+            path: "/missing-bundle",
+            bundlePath: "bundle.js",
+          },
+        ],
+      },
+      missingDir,
+    );
+
+    try {
+      const { ctx, res, error } = makeBundleCtx("missing-bundle-view");
+      await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+      expect(error).toHaveBeenCalledTimes(1);
+      const [, message, status] = error.mock.calls[0];
+      expect(status).toBe(404);
+      expect(String(message)).toMatch(/Bundle not built/);
+      // No bytes streamed for the not-found case.
+      expect(res.writeHead).not.toHaveBeenCalled();
+    } finally {
+      unregisterPluginViews("@test/views-bundle-missing");
+      await rm(missingDir, { recursive: true, force: true });
+    }
+  });
+
+  it("403s the dynamic bundle on a restricted platform (x-eliza-platform: ios)", async () => {
+    const { ctx, res, error } = makeBundleCtx(VIEW_ID, {
+      headers: { "x-eliza-platform": "ios" },
+    });
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).toHaveBeenCalledTimes(1);
+    const [, message, status] = error.mock.calls[0];
+    expect(status).toBe(403);
+    expect(String(message)).toMatch(/not permitted/i);
+    // Bytes must not be served.
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/runtime/load-plugin-from-directory-reload.test.ts
+++ b/packages/agent/src/runtime/load-plugin-from-directory-reload.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Domain H — plugin hot-reload from an on-disk built directory.
+ *
+ * Closes the gap that the sibling `load-plugin-from-directory.test.ts` leaves
+ * open: it only covers the happy load/unload path and never proves the
+ * edit -> rebuild -> live-reload -> NEW-behavior loop, nor the broken-reload
+ * rollback guarantee. Concretely this file pins:
+ *
+ *  - TEST 1: after a rebuild produces a new built entry, doing unload -> reload
+ *    serves v2 behavior — the loader re-resolves + re-imports the rebuilt
+ *    module and re-registers it so runtime.actions reflects v2 (the
+ *    PLUGIN_VERSION handler now resolves { version: 2 } and a brand-new
+ *    PLUGIN_V2_ONLY action is present). It also pins the documented gotcha that
+ *    a bare second load WITHOUT unload is a no-op (core registerPlugin returns
+ *    early on a duplicate plugin name — runtime.ts:1588-1596).
+ *  - TEST 2: a reload whose new module throws at IMPORT time (module top-level
+ *    throw) rejects to the caller, and because the dynamic import runs BEFORE
+ *    runtime.registerPlugin (load-plugin-from-directory.ts:156 vs 165) the
+ *    previously-loaded v1 plugin survives untouched — actions, ownership refs,
+ *    and the loaded-plugin tracking map are all unchanged (rollback).
+ *
+ * Fully deterministic: real AgentRuntime + real filesystem temp dirs, no mocks,
+ * no fake timers.
+ *
+ * RUNTIME CAVEAT (why each version uses a DISTINCT entry file): the loader's
+ * `?t=${Date.now()}` query-string cache-bust (load-plugin-from-directory.ts:155)
+ * works under Node's ESM loader, but this package's test runner is Bun
+ * (`bunx vitest`), and Bun's module loader caches by resolved file PATH and
+ * ignores the query string — so re-importing the SAME rewritten path under Bun
+ * returns the stale cached module. To exercise the real reload code path
+ * (resolve -> import -> extractPlugin -> registerPlugin serving the NEW module)
+ * deterministically under Bun, each "rebuild" writes a distinct built entry and
+ * the loader is pointed at it via the `entry` option; the unload/reload and
+ * rollback semantics under test are identical regardless of the cache-bust
+ * mechanism. (Fake timers are deliberately NOT used — they would freeze
+ * Date.now() and, on Node, force a `?t=` cache HIT.)
+ */
+
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetLoadedDirectoryPluginsForTests,
+  getLoadedDirectoryPlugins,
+  loadPluginFromDirectory,
+  unloadPluginFromDirectory,
+} from "./load-plugin-from-directory.ts";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  _resetLoadedDirectoryPluginsForTests();
+  tmpDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "agent-reload-dir-plugin-"),
+  );
+});
+
+afterEach(async () => {
+  _resetLoadedDirectoryPluginsForTests();
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+const PLUGIN_NAME = "reload-test-plugin";
+
+/** ESM plugin source whose PLUGIN_VERSION action resolves { version: N }. */
+function pluginSourceV1(): string {
+  return `
+export default {
+  name: ${JSON.stringify(PLUGIN_NAME)},
+  description: "reload fixture v1",
+  actions: [
+    {
+      name: "PLUGIN_VERSION",
+      description: "reports its version",
+      examples: [],
+      similes: [],
+      validate: async () => true,
+      handler: async () => ({ version: 1 }),
+    },
+  ],
+};
+`;
+}
+
+/** v2: same plugin name, version -> 2, plus a NEW action PLUGIN_V2_ONLY. */
+function pluginSourceV2(): string {
+  return `
+export default {
+  name: ${JSON.stringify(PLUGIN_NAME)},
+  description: "reload fixture v2",
+  actions: [
+    {
+      name: "PLUGIN_VERSION",
+      description: "reports its version",
+      examples: [],
+      similes: [],
+      validate: async () => true,
+      handler: async () => ({ version: 2 }),
+    },
+    {
+      name: "PLUGIN_V2_ONLY",
+      description: "only exists in v2",
+      examples: [],
+      similes: [],
+      validate: async () => true,
+      handler: async () => ({ v2: true }),
+    },
+  ],
+};
+`;
+}
+
+/** Broken v2: throws at module top level (IMPORT time), before registerPlugin. */
+function pluginSourceBroken(): string {
+  return `throw new Error("boom v2 broke the build");\n`;
+}
+
+async function scaffold(
+  dir: string,
+  pkg: Record<string, unknown>,
+  files: Record<string, string>,
+): Promise<string> {
+  const root = path.join(tmpDir, dir);
+  await fsp.mkdir(root, { recursive: true });
+  await fsp.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify(pkg, null, 2),
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    await fsp.mkdir(path.dirname(full), { recursive: true });
+    await fsp.writeFile(full, content);
+  }
+  return root;
+}
+
+/** Invoke the PLUGIN_VERSION handler off runtime.actions and read .version. */
+async function readReportedVersion(
+  runtime: AgentRuntime,
+): Promise<number | undefined> {
+  const action = runtime.actions.find((a) => a.name === "PLUGIN_VERSION");
+  const result = (await action?.handler?.(
+    runtime as unknown as never,
+    {} as never,
+    {} as never,
+  )) as { version?: number } | undefined;
+  return result?.version;
+}
+
+describe("loadPluginFromDirectory — hot reload (Domain H)", () => {
+  it("edit -> rebuild -> unload -> reload serves NEW v2 behavior", async () => {
+    const dir = await scaffold(
+      "plugin-reload",
+      { name: "@local/plugin-reload", main: "dist/index.js" },
+      { "dist/index.js": pluginSourceV1() },
+    );
+
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    expect(typeof runtime.registerPlugin).toBe("function");
+
+    // --- v1 (resolved via package.json main) ---
+    const firstLoad = await loadPluginFromDirectory({
+      runtime,
+      directory: dir,
+    });
+    expect(firstLoad.pluginName).toBe(PLUGIN_NAME);
+    expect(firstLoad.loaded).toBe(true);
+    expect(await readReportedVersion(runtime)).toBe(1);
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_V2_ONLY")).toBe(
+      false,
+    );
+
+    const firstEntry = getLoadedDirectoryPlugins().find(
+      (e) => e.pluginName === PLUGIN_NAME,
+    );
+    expect(firstEntry).toBeDefined();
+    const firstLoadedAt = firstEntry?.loadedAt ?? 0;
+    const firstDiskPath = firstEntry?.diskPath;
+
+    // "Rebuild": the new build produces a fresh entry artifact.
+    await fsp.writeFile(path.join(dir, "dist/index2.js"), pluginSourceV2());
+
+    // A bare second load WITHOUT unloading is a no-op: core registerPlugin
+    // returns early on a duplicate plugin name (runtime.ts:1588-1596), so v1
+    // stays live. This pins the documented gotcha that reload REQUIRES unload.
+    await loadPluginFromDirectory({
+      runtime,
+      directory: dir,
+      entry: "dist/index2.js",
+    });
+    expect(await readReportedVersion(runtime)).toBe(1);
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_V2_ONLY")).toBe(
+      false,
+    );
+
+    // --- proper reload: unload v1, then load again -> v2 ---
+    const unloaded = await unloadPluginFromDirectory({
+      runtime,
+      pluginName: PLUGIN_NAME,
+    });
+    expect(unloaded.unloaded).toBe(true);
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_VERSION")).toBe(
+      false,
+    );
+
+    const reload = await loadPluginFromDirectory({
+      runtime,
+      directory: dir,
+      entry: "dist/index2.js",
+    });
+    expect(reload.pluginName).toBe(PLUGIN_NAME);
+
+    // v2 is now served — the regression that proves the rebuilt module was
+    // imported and re-registered, not the stale v1.
+    expect(await readReportedVersion(runtime)).toBe(2);
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_V2_ONLY")).toBe(true);
+
+    // Tracking map holds exactly ONE entry (no duplicate leak); its diskPath
+    // now points at the rebuilt artifact and loadedAt advanced.
+    const entries = getLoadedDirectoryPlugins().filter(
+      (e) => e.pluginName === PLUGIN_NAME,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].loadedAt).toBeGreaterThanOrEqual(firstLoadedAt);
+    expect(entries[0].diskPath).not.toBe(firstDiskPath);
+
+    // Cleanup — no cross-test pollution.
+    await unloadPluginFromDirectory({ runtime, pluginName: PLUGIN_NAME });
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_VERSION")).toBe(
+      false,
+    );
+    expect(getLoadedDirectoryPlugins()).toHaveLength(0);
+  });
+
+  it("broken reload (import-time throw) rejects and v1 survives untouched (rollback)", async () => {
+    const dir = await scaffold(
+      "plugin-reload-broken",
+      { name: "@local/plugin-reload", main: "dist/index.js" },
+      { "dist/index.js": pluginSourceV1() },
+    );
+
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    // --- v1 loaded and healthy ---
+    await loadPluginFromDirectory({ runtime, directory: dir });
+    expect(await readReportedVersion(runtime)).toBe(1);
+
+    const ownershipBefore = runtime.getPluginOwnership(PLUGIN_NAME);
+    expect(ownershipBefore).not.toBeNull();
+    expect(ownershipBefore?.actions.length ?? 0).toBeGreaterThan(0);
+    const v1ActionRef = ownershipBefore?.actions.find(
+      (a) => a.name === "PLUGIN_VERSION",
+    );
+    expect(v1ActionRef).toBeDefined();
+
+    const trackingBefore = getLoadedDirectoryPlugins().find(
+      (e) => e.pluginName === PLUGIN_NAME,
+    );
+    expect(trackingBefore).toBeDefined();
+    const diskPathBefore = trackingBefore?.diskPath;
+    const loadedAtBefore = trackingBefore?.loadedAt;
+
+    // The "rebuild" produced a broken artifact that throws at module top level
+    // (IMPORT time). The dynamic import in loadPluginFromDirectory runs BEFORE
+    // registerPlugin, so the failure never reaches the runtime — prior v1 state
+    // must be untouched. NOTE: deliberately do NOT unload v1 first; the broken
+    // import must fail before any teardown of v1 happens.
+    await fsp.writeFile(path.join(dir, "dist/broken.js"), pluginSourceBroken());
+
+    await expect(
+      loadPluginFromDirectory({
+        runtime,
+        directory: dir,
+        entry: "dist/broken.js",
+      }),
+    ).rejects.toThrow(/boom v2/);
+
+    // --- rollback assertions: v1 still fully live ---
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_VERSION")).toBe(true);
+    expect(await readReportedVersion(runtime)).toBe(1);
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_V2_ONLY")).toBe(
+      false,
+    );
+
+    const ownershipAfter = runtime.getPluginOwnership(PLUGIN_NAME);
+    expect(ownershipAfter).not.toBeNull();
+    // Same live action object reference survived the failed reload.
+    expect(
+      ownershipAfter?.actions.find((a) => a.name === "PLUGIN_VERSION"),
+    ).toBe(v1ActionRef);
+
+    // The tracking map was NOT mutated by the failed load.
+    const trackingAfter = getLoadedDirectoryPlugins().filter(
+      (e) => e.pluginName === PLUGIN_NAME,
+    );
+    expect(trackingAfter).toHaveLength(1);
+    expect(trackingAfter[0].diskPath).toBe(diskPathBefore);
+    expect(trackingAfter[0].loadedAt).toBe(loadedAtBefore);
+
+    // Cleanup.
+    await unloadPluginFromDirectory({ runtime, pluginName: PLUGIN_NAME });
+    expect(runtime.actions.some((a) => a.name === "PLUGIN_VERSION")).toBe(
+      false,
+    );
+    expect(getLoadedDirectoryPlugins()).toHaveLength(0);
+  });
+});

--- a/packages/scenario-runner/src/index.ts
+++ b/packages/scenario-runner/src/index.ts
@@ -3,9 +3,8 @@ export { runScenario } from "./executor.ts";
 export { attachInterceptor } from "./interceptor.ts";
 export { judgeTextWithLlm } from "./judge.ts";
 export {
-  discoverScenarios,
   countScenarioCorpus,
-  validateScenarioCorpus,
+  discoverScenarios,
   expandScenarioDefinition,
   expandScenarioMetadata,
   listScenarioMetadata,
@@ -13,20 +12,25 @@ export {
   loadScenarioFile,
   loadScenarioMetadataFile,
   SCENARIO_EDGE_VARIANTS,
+  validateScenarioCorpus,
 } from "./loader.ts";
-export type { NativeBoundaryRow } from "./native-export.ts";
+export type {
+  NativeBoundaryRow,
+  ScenarioNativeExportManifest,
+} from "./native-export.ts";
 export {
   exportScenarioNativeJsonl,
+  recordedTrajectoryToNativeRows,
   SCENARIO_NATIVE_EXPORT_SCHEMA,
   SCENARIO_NATIVE_EXPORT_VERSION,
-  recordedTrajectoryToNativeRows,
 } from "./native-export.ts";
-export type { ScenarioNativeExportManifest } from "./native-export.ts";
+export type { TimelineEvent } from "./reporter.ts";
 export {
   buildAggregate,
   printStdoutSummary,
   writeReport,
   writeScenarioRunViewer,
+  writeTimeline,
 } from "./reporter.ts";
 export type {
   AggregateReport,

--- a/packages/scenario-runner/src/reporter.ts
+++ b/packages/scenario-runner/src/reporter.ts
@@ -7,8 +7,8 @@
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -55,6 +55,117 @@ export function writeReport(report: AggregateReport, filePath: string): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(report, null, 2), "utf-8");
   logger.info(`[scenario-runner] wrote report → ${filePath}`);
+}
+
+export interface TimelineEvent {
+  seq: number;
+  scenarioId: string;
+  kind: "scenario" | "turn" | "action" | "finalCheck";
+  name: string;
+  /** ms relative to run start */
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  status: string;
+}
+
+/**
+ * Emit an ordered, scrubbable run timeline derived from the aggregate report:
+ * scenarios laid out sequentially, turns within each scenario, and the actions
+ * captured per turn placed inside that turn's span. Times are relative to run
+ * start (ms). Per-action wall-clock isn't recorded, so a turn's actions are
+ * distributed evenly across the turn span — enough to align a video / trajectory
+ * scrubber to turn + action boundaries. Returns the events (also written as
+ * `timeline.json`).
+ */
+export function writeTimeline(
+  report: AggregateReport,
+  filePath: string,
+): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+  let seq = 0;
+  let cursor = 0;
+  for (const scenario of report.scenarios) {
+    const scenarioStart = cursor;
+    const scenarioDur = Math.max(0, scenario.durationMs || 0);
+    const scenarioEnd = scenarioStart + scenarioDur;
+    events.push({
+      seq: seq++,
+      scenarioId: scenario.id,
+      kind: "scenario",
+      name: scenario.title || scenario.id,
+      startMs: scenarioStart,
+      endMs: scenarioEnd,
+      durationMs: scenarioDur,
+      status: scenario.status,
+    });
+    let turnCursor = scenarioStart;
+    for (const turn of scenario.turns) {
+      const turnStart = turnCursor;
+      const turnDur = Math.max(0, turn.durationMs || 0);
+      const turnEnd = turnStart + turnDur;
+      events.push({
+        seq: seq++,
+        scenarioId: scenario.id,
+        kind: "turn",
+        name: turn.name || turn.kind,
+        startMs: turnStart,
+        endMs: turnEnd,
+        durationMs: turnDur,
+        status: turn.failedAssertions.length > 0 ? "failed" : "passed",
+      });
+      const actions = turn.actionsCalled ?? [];
+      if (actions.length > 0) {
+        const slice = turnDur / actions.length;
+        actions.forEach((action, i) => {
+          const aStart = turnStart + slice * i;
+          events.push({
+            seq: seq++,
+            scenarioId: scenario.id,
+            kind: "action",
+            name: action.actionName,
+            startMs: Math.round(aStart),
+            endMs: Math.round(aStart + slice),
+            durationMs: Math.round(slice),
+            status: action.result?.success === false ? "failed" : "passed",
+          });
+        });
+      }
+      turnCursor = turnEnd;
+    }
+    for (const fc of scenario.finalChecks) {
+      events.push({
+        seq: seq++,
+        scenarioId: scenario.id,
+        kind: "finalCheck",
+        name: fc.label || fc.type,
+        startMs: scenarioEnd,
+        endMs: scenarioEnd,
+        durationMs: 0,
+        status: fc.status,
+      });
+    }
+    cursor = scenarioEnd;
+  }
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        runId: report.runId,
+        startedAtIso: report.startedAtIso,
+        totalMs: cursor,
+        events,
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  logger.info(
+    `[scenario-runner] wrote timeline → ${filePath} (${events.length} events)`,
+  );
+  return events;
 }
 
 function scenarioReportFileName(id: string, index: number): string {
@@ -150,10 +261,12 @@ function asNumber(value: unknown): number | null {
 
 function truncateText(value: unknown, maxLength = 420): string {
   const text =
-    typeof value === "string" ? value : value == null ? "" : JSON.stringify(value);
-  return text.length > maxLength
-    ? `${text.slice(0, maxLength - 1)}…`
-    : text;
+    typeof value === "string"
+      ? value
+      : value == null
+        ? ""
+        : JSON.stringify(value);
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
 }
 
 function summarizeTrajectoryFile(
@@ -228,7 +341,9 @@ function summarizeTrajectoryFile(
   };
 }
 
-function defaultNativeManifestPath(nativeJsonlPath?: string): string | undefined {
+function defaultNativeManifestPath(
+  nativeJsonlPath?: string,
+): string | undefined {
   if (!nativeJsonlPath) return undefined;
   return nativeJsonlPath.endsWith(".jsonl")
     ? `${nativeJsonlPath.slice(0, -".jsonl".length)}.manifest.json`

--- a/packages/scenario-runner/src/timeline.test.ts
+++ b/packages/scenario-runner/src/timeline.test.ts
@@ -1,0 +1,134 @@
+/**
+ * writeTimeline (audit Wave 1.1) — the ordered, scrubbable run timeline artifact
+ * so a reviewer can align a video / trajectory scrubber to scenario → turn →
+ * action → finalCheck boundaries. Previously the reporter emitted only the
+ * JSON report + run viewer; there was no first-class timeline.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildAggregate, writeTimeline } from "./reporter.ts";
+import type { ScenarioReport, TurnReport } from "./types.ts";
+
+function turn(
+  name: string,
+  durationMs: number,
+  actions: string[] = [],
+): TurnReport {
+  return {
+    name,
+    kind: "action",
+    responseText: "",
+    actionsCalled: actions.map((actionName) => ({ actionName })),
+    durationMs,
+    failedAssertions: [],
+  };
+}
+
+function scenario(
+  id: string,
+  durationMs: number,
+  turns: TurnReport[],
+): ScenarioReport {
+  return {
+    id,
+    title: `Title ${id}`,
+    domain: "coding",
+    tags: [],
+    status: "passed",
+    durationMs,
+    turns,
+    finalChecks: [
+      {
+        label: "spawned",
+        type: "subAgentSpawned",
+        status: "passed",
+        detail: "ok",
+      },
+    ],
+    actionsCalled: [],
+    failedAssertions: [],
+    providerName: null,
+  };
+}
+
+describe("writeTimeline", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "timeline-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits ordered, cumulative scenario→turn→action→finalCheck events + writes JSON", () => {
+    const report = buildAggregate(
+      [
+        scenario("s1", 300, [
+          turn("t1", 100, ["TASKS_CREATE", "FILE"]),
+          turn("t2", 200, []),
+        ]),
+        scenario("s2", 150, [turn("t1", 150, [])]),
+      ],
+      null,
+      "2026-06-22T00:00:00.000Z",
+      "2026-06-22T00:01:00.000Z",
+      "run-x",
+    );
+    const file = join(dir, "timeline.json");
+    const events = writeTimeline(report, file);
+
+    // monotonic seq
+    expect(events.map((e) => e.seq)).toEqual(events.map((_e, i) => i));
+
+    // scenario s1 starts at 0; s2 starts where s1 ended (300)
+    const s1 = events.find(
+      (e) => e.kind === "scenario" && e.scenarioId === "s1",
+    );
+    const s2 = events.find(
+      (e) => e.kind === "scenario" && e.scenarioId === "s2",
+    );
+    expect(s1?.startMs).toBe(0);
+    expect(s1?.endMs).toBe(300);
+    expect(s2?.startMs).toBe(300);
+    expect(s2?.endMs).toBe(450);
+
+    // turns within s1 are sequential: t1 [0,100], t2 [100,300]
+    const s1turns = events.filter(
+      (e) => e.kind === "turn" && e.scenarioId === "s1",
+    );
+    expect(s1turns[0]?.startMs).toBe(0);
+    expect(s1turns[0]?.endMs).toBe(100);
+    expect(s1turns[1]?.startMs).toBe(100);
+    expect(s1turns[1]?.endMs).toBe(300);
+
+    // two actions in t1 are distributed across [0,100]
+    const acts = events.filter(
+      (e) => e.kind === "action" && e.scenarioId === "s1",
+    );
+    expect(acts.map((a) => a.name)).toEqual(["TASKS_CREATE", "FILE"]);
+    expect(acts[0]?.startMs).toBe(0);
+    expect(acts[1]?.startMs).toBe(50);
+    expect(acts[1]?.endMs).toBe(100);
+
+    // finalCheck is a point event at the scenario end
+    const fc = events.find(
+      (e) => e.kind === "finalCheck" && e.scenarioId === "s1",
+    );
+    expect(fc?.startMs).toBe(300);
+    expect(fc?.endMs).toBe(300);
+    expect(fc?.durationMs).toBe(0);
+
+    // persisted artifact carries totalMs = end of last scenario
+    const onDisk = JSON.parse(readFileSync(file, "utf-8"));
+    expect(onDisk.runId).toBe("run-x");
+    expect(onDisk.totalMs).toBe(450);
+    expect(onDisk.events.length).toBe(events.length);
+  });
+
+  it("handles an empty report", () => {
+    const report = buildAggregate([], null, "a", "b", "run-empty");
+    const events = writeTimeline(report, join(dir, "t.json"));
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/scenario-runner/test/scenarios/deterministic-create-app-coding.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-create-app-coding.scenario.ts
@@ -1,0 +1,578 @@
+// Gap closed: there was NO deterministic, zero-cost scenario that proves the
+// end-to-end "create an app" coding loop — scaffold real files on disk via the
+// coding-tools FILE action, then run a real build/verify via the SHELL action,
+// and assert the produced workspace is sound. The existing
+// deterministic-coding-tools-actions.scenario.ts exercises FILE/SHELL through
+// strict LLM routing on a flat note file; this scenario instead drives the
+// scaffold-then-build path directly with kind:"action" turns (no LLM, no
+// fixtures) and asserts: (1) three scaffold writes land byte-for-byte on disk,
+// (2) the build/verify SHELL command exits 0 in the scaffolded app dir, and
+// (3) NO real sub-agent spawn happened (START_CODING_TASK is not registered in
+// the scenario runtime), so the deterministic file-mutation + build path is the
+// honest, self-contained substitute for the live-only sub-agent-spawn lane.
+//
+// Sub-agent spawning is a live-only concern: app-create's dispatchCodingAgent
+// returns dispatched:false when START_CODING_TASK is absent, so a deterministic
+// lane cannot (and must not silently pretend to) spawn a sub-agent. We assert
+// that negative explicitly via a custom finalCheck.
+
+import { execFile } from "node:child_process";
+import { promises as fs, realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { stringToUuid } from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+  ScenarioTurnExecution,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import codingToolsPlugin from "../../../../plugins/plugin-coding-tools/src/index.ts";
+
+const execFileAsync = promisify(execFile);
+
+const scenarioId = "deterministic-create-app-coding";
+
+// Resolve the tmp root through realpath so the macOS /var -> /private/var
+// symlink does not break sandbox path validation (spawnSession/validatePath
+// compare resolved paths).
+const tmpRoot = path.join(
+  realpathSync(os.tmpdir()),
+  "eliza-scenario-create-app",
+);
+const repoRoot = path.join(tmpRoot, "repo");
+const appDir = path.join(repoRoot, "eliza", "apps", "app-scratch-tool");
+const blockedRoot = path.join(tmpRoot, "_blocked");
+
+const appTsxPath = path.join(appDir, "src", "App.tsx");
+const packageJsonPath = path.join(appDir, "package.json");
+const indexTsPath = path.join(appDir, "src", "index.ts");
+
+const roomId = stringToUuid(`scenario-room:${scenarioId}:main`);
+const worldId = stringToUuid(`scenario-runner-world:${scenarioId}`);
+const userId = stringToUuid(
+  `scenario-account:scenario-user:${scenarioId}:main`,
+);
+
+// ---------------------------------------------------------------------------
+// Scaffolded file contents (these are written verbatim and re-read on disk).
+// ---------------------------------------------------------------------------
+
+const appTsxContent = `export function App(): string {
+  return "scratch-tool";
+}
+`;
+
+const packageJsonContent = `${JSON.stringify(
+  {
+    name: "app-scratch-tool",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    main: "src/index.ts",
+  },
+  null,
+  2,
+)}\n`;
+
+const indexTsContent = `import { App } from "./App";
+
+export function main(): string {
+  return App();
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Turn parameter shapes (threaded straight into the action handler as options).
+// ---------------------------------------------------------------------------
+
+const writeAppTsxParameters = {
+  action: "write",
+  file_path: appTsxPath,
+  content: appTsxContent,
+};
+
+const writePackageJsonParameters = {
+  action: "write",
+  file_path: packageJsonPath,
+  content: packageJsonContent,
+};
+
+const writeIndexTsParameters = {
+  action: "write",
+  file_path: indexTsPath,
+  content: indexTsContent,
+};
+
+// Generic, fully-offline build/verify: parse package.json and confirm App.tsx
+// exists, then print a marker. Kept generic so bash.ts's message-driven command
+// rewrite heuristics (crypto/disk/health/source) never fire.
+const buildCommand =
+  "node -e \"const fs=require('fs');const p=require('path');" +
+  "const pkg=JSON.parse(fs.readFileSync(p.join(process.cwd(),'package.json'),'utf8'));" +
+  "if(pkg.name!=='app-scratch-tool'){throw new Error('bad package name');}" +
+  "if(!fs.existsSync(p.join(process.cwd(),'src','App.tsx'))){throw new Error('missing App.tsx');}" +
+  "console.log('BUILD_OK');\"";
+
+const buildParameters = {
+  action: "run",
+  command: buildCommand,
+  cwd: appDir,
+  timeout: 30_000,
+};
+
+// Disk-side build validation command for the buildValidation finalCheck. Pure
+// shell, offline, exits 0 only if both scaffolded files survived to disk.
+const buildValidationCommand =
+  "test -f package.json && test -f src/App.tsx && test -f src/index.ts && echo BUILD_VALIDATED";
+
+// ---------------------------------------------------------------------------
+// Helpers (small, JSON-stable comparisons that yield descriptive failures).
+// ---------------------------------------------------------------------------
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function actionParameters(action: CapturedAction): JsonRecord {
+  return isRecord(action.parameters) ? action.parameters : {};
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function expectEqual(
+  actual: unknown,
+  expected: unknown,
+  label: string,
+): string | undefined {
+  const actualJson = stableStringify(actual);
+  const expectedJson = stableStringify(expected);
+  return actualJson === expectedJson
+    ? undefined
+    : `expected ${label}=${expectedJson}, saw ${actualJson}`;
+}
+
+function firstAction(
+  execution: ScenarioTurnExecution,
+  actionName: string,
+): CapturedAction | string {
+  const action = execution.actionsCalled.find(
+    (candidate) => candidate.actionName === actionName,
+  );
+  return (
+    action ??
+    `expected ${actionName} action, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`
+  );
+}
+
+function actionData(action: CapturedAction): JsonRecord | string {
+  const data = action.result?.data;
+  return isRecord(data)
+    ? data
+    : `expected ActionResult.data object, saw ${stableStringify(data)}`;
+}
+
+function expectSuccess(action: CapturedAction): string | undefined {
+  return action.result?.success === true
+    ? undefined
+    : `expected ActionResult.success=true, saw ${stableStringify(action.result)}`;
+}
+
+function expectActionOptions(
+  action: CapturedAction,
+  expectedParameters: JsonRecord,
+): string | undefined {
+  return expectEqual(
+    actionParameters(action),
+    expectedParameters,
+    `${action.actionName} handler options`,
+  );
+}
+
+function expectFileWriteTurn(
+  execution: ScenarioTurnExecution,
+  expectedParameters: JsonRecord,
+  expectedPath: string,
+): string | undefined {
+  const action = firstAction(execution, "FILE");
+  if (typeof action === "string") return action;
+  return (
+    expectActionOptions(action, expectedParameters) ??
+    expectSuccess(action) ??
+    (() => {
+      const data = actionData(action);
+      if (typeof data === "string") return data;
+      if (data.path !== expectedPath) {
+        return `expected FILE write path=${expectedPath}, saw ${String(data.path)}`;
+      }
+      return typeof data.bytes === "number" && data.bytes > 0
+        ? undefined
+        : `expected FILE write byte count > 0, saw ${stableStringify(data.bytes)}`;
+    })()
+  );
+}
+
+function expectBuildTurn(execution: ScenarioTurnExecution): string | undefined {
+  const action = firstAction(execution, "SHELL");
+  if (typeof action === "string") return action;
+  return (
+    expectActionOptions(action, buildParameters) ??
+    expectSuccess(action) ??
+    (() => {
+      const data = actionData(action);
+      if (typeof data === "string") return data;
+      if (data.cwd !== appDir) {
+        return `expected SHELL cwd=${appDir}, saw ${String(data.cwd)}`;
+      }
+      if (data.exit_code !== 0) {
+        return `expected SHELL exit_code=0, saw ${String(data.exit_code)}`;
+      }
+      return action.result?.text?.includes("BUILD_OK")
+        ? undefined
+        : `expected build stdout BUILD_OK, saw ${JSON.stringify(action.result?.text)}`;
+    })()
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom finalCheck predicates.
+// ---------------------------------------------------------------------------
+
+// Emulates the file-mutation proof at the strongest possible fidelity: the bytes
+// are actually on disk, byte-for-byte equal to what we asked the FILE action to
+// write. (Complements the registered fileMutationOccurred finalCheck, which only
+// proves the action was *invoked* with a matching path.)
+async function assertScaffoldedFilesOnDisk(): Promise<string | undefined> {
+  const expectations: Array<[string, string]> = [
+    [appTsxPath, appTsxContent],
+    [packageJsonPath, packageJsonContent],
+    [indexTsPath, indexTsContent],
+  ];
+  for (const [filePath, expected] of expectations) {
+    let actual: string;
+    try {
+      actual = await fs.readFile(filePath, "utf8");
+    } catch (err) {
+      return `expected scaffolded file on disk at ${filePath}, read failed: ${(err as Error).message}`;
+    }
+    if (actual !== expected) {
+      return `expected ${filePath} content ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+    }
+  }
+  return undefined;
+}
+
+// Emulates a build-validation proof from the captured action ledger: the SHELL
+// build ran in the scaffolded app dir and exited 0. (Complements the registered
+// buildValidation finalCheck, which re-runs a command on disk.)
+function assertBuildPassedInAppDir(ctx: ScenarioContext): string | undefined {
+  const shell = ctx.actionsCalled.find((call) => call.actionName === "SHELL");
+  if (!shell) {
+    return `expected a SHELL build action, saw ${ctx.actionsCalled.map((c) => c.actionName).join(",") || "(none)"}`;
+  }
+  const data = actionData(shell);
+  if (typeof data === "string") return data;
+  if (data.exit_code !== 0) {
+    return `expected build SHELL exit_code=0, saw ${String(data.exit_code)}`;
+  }
+  if (data.cwd !== appDir) {
+    return `expected build SHELL to run in app dir ${appDir}, saw ${String(data.cwd)}`;
+  }
+  return undefined;
+}
+
+// The deterministic lane MUST NOT spawn a real sub-agent — assert the negative so
+// the scaffold+build path is the honest substitute, not a silent omission.
+function assertNoSubAgentSpawned(ctx: ScenarioContext): string | undefined {
+  const spawnNames = new Set([
+    "START_CODING_TASK",
+    "CREATE_TASK",
+    "TASKS_SPAWN_AGENT",
+    "TASKS_CREATE",
+    "SPAWN_AGENT",
+    "SPAWN_TASK_AGENT",
+  ]);
+  const spawned = ctx.actionsCalled.filter(
+    (call) =>
+      spawnNames.has(call.actionName) ||
+      /SPAWN|START_CODING/i.test(call.actionName),
+  );
+  return spawned.length === 0
+    ? undefined
+    : `expected NO sub-agent spawn in the deterministic lane, saw ${spawned.map((s) => s.actionName).join(",")}`;
+}
+
+// Exact action ledger order (no synthesized REPLY — action turns never synthesize)
+// AND filesystem cleanup so re-runs in the shared runtime stay idempotent.
+async function assertLedgerAndCleanup(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const names = (ctx.actionsCalled ?? []).map((call) => call.actionName);
+  const orderFailure = expectEqual(
+    names,
+    ["FILE", "FILE", "FILE", "SHELL"],
+    "create-app action ledger order",
+  );
+  if (orderFailure) return orderFailure;
+  const failed = (ctx.actionsCalled ?? []).filter(
+    (call) => call.result?.success !== true,
+  );
+  if (failed.length > 0) {
+    return `expected every create-app action to succeed, saw ${stableStringify(failed)}`;
+  }
+  await fs.rm(tmpRoot, { force: true, recursive: true });
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Seed: build an isolated git workspace + self-register coding-tools.
+// ---------------------------------------------------------------------------
+
+async function seedGitRepo(): Promise<void> {
+  await fs.rm(tmpRoot, { force: true, recursive: true });
+  await fs.mkdir(appDir, { recursive: true });
+  await fs.mkdir(blockedRoot, { recursive: true });
+  await fs.writeFile(path.join(repoRoot, "README.md"), "scenario repo\n");
+  await execFileAsync("git", ["init"], { cwd: repoRoot });
+  await execFileAsync(
+    "git",
+    ["config", "user.email", "scenario@example.test"],
+    {
+      cwd: repoRoot,
+    },
+  );
+  await execFileAsync("git", ["config", "user.name", "Scenario Runner"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["add", "README.md"], { cwd: repoRoot });
+  await execFileAsync("git", ["commit", "-m", "initial scenario commit"], {
+    cwd: repoRoot,
+  });
+}
+
+export default scenario({
+  // NOTE: `id` MUST be a static string literal — the loader reads it via the
+  // TypeScript AST without evaluating the module (see loader.ts
+  // getStaticStringProperty). Keep it in sync with `scenarioId` above.
+  id: "deterministic-create-app-coding",
+  lane: "pr-deterministic",
+  title: "Deterministic create-app coding loop (scaffold + build)",
+  domain: "scenario-runner",
+  tags: ["pr", "deterministic", "zero-cost", "coding-tools", "create-app"],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: ["@elizaos/plugin-coding-tools"],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed isolated create-app git workspace + coding-tools",
+      apply: async (ctx) => {
+        await seedGitRepo();
+        process.env.CODING_TOOLS_WORKSPACE_ROOTS = tmpRoot;
+        process.env.CODING_TOOLS_BLOCKED_PATHS = blockedRoot;
+
+        const runtime = ctx.runtime as
+          | {
+              plugins?: Array<{ name?: string }>;
+              registerPlugin?: (
+                plugin: typeof codingToolsPlugin,
+              ) => Promise<void>;
+              getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
+              getService?: (serviceType: string) => unknown;
+              ensureConnection?: (
+                params: Record<string, unknown>,
+              ) => Promise<void>;
+            }
+          | undefined;
+        if (!runtime?.registerPlugin) {
+          return "runtime.registerPlugin unavailable";
+        }
+        if (
+          !runtime.plugins?.some(
+            (plugin) =>
+              plugin.name === "coding-tools" ||
+              plugin.name === "@elizaos/plugin-coding-tools",
+          )
+        ) {
+          await runtime.registerPlugin(codingToolsPlugin);
+        }
+        await Promise.all([
+          runtime.getServiceLoadPromise?.("CODING_TOOLS_SESSION_CWD"),
+          runtime.getServiceLoadPromise?.("CODING_TOOLS_SANDBOX"),
+        ]);
+        const session = runtime.getService?.("CODING_TOOLS_SESSION_CWD") as
+          | { setCwd?: (conversationId: string, absPath: string) => void }
+          | null
+          | undefined;
+        const sandbox = runtime.getService?.("CODING_TOOLS_SANDBOX") as
+          | { addRoot?: (conversationId: string, absPath: string) => void }
+          | null
+          | undefined;
+        if (typeof session?.setCwd !== "function") {
+          return "coding-tools session cwd service unavailable";
+        }
+        if (typeof sandbox?.addRoot !== "function") {
+          return "coding-tools sandbox service unavailable";
+        }
+        // Allow the whole tmpRoot so writes under appDir validate; ground the
+        // session cwd to appDir so SHELL's cwd resolves there.
+        sandbox.addRoot(roomId, tmpRoot);
+        session.setCwd(roomId, appDir);
+        await runtime.ensureConnection?.({
+          entityId: userId,
+          roomId,
+          worldId,
+          userName: "Deterministic Create App",
+          source: "telegram",
+          channelId: roomId,
+          type: "DM",
+          metadata: {
+            ownership: { ownerId: userId },
+            roles: { [userId]: "OWNER" },
+          },
+        });
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Deterministic Create App",
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "scaffold src/App.tsx",
+      text: "Scaffold the create-app App component file",
+      actionName: "FILE",
+      options: writeAppTsxParameters,
+      responseIncludesAny: ["Wrote", appTsxPath],
+      assertTurn: (execution) =>
+        expectFileWriteTurn(execution, writeAppTsxParameters, appTsxPath),
+    },
+    {
+      kind: "action",
+      name: "scaffold package.json",
+      text: "Scaffold the create-app package manifest",
+      actionName: "FILE",
+      options: writePackageJsonParameters,
+      responseIncludesAny: ["Wrote", packageJsonPath],
+      assertTurn: (execution) =>
+        expectFileWriteTurn(
+          execution,
+          writePackageJsonParameters,
+          packageJsonPath,
+        ),
+    },
+    {
+      kind: "action",
+      name: "scaffold src/index.ts",
+      text: "Scaffold the create-app entry module",
+      actionName: "FILE",
+      options: writeIndexTsParameters,
+      responseIncludesAny: ["Wrote", indexTsPath],
+      assertTurn: (execution) =>
+        expectFileWriteTurn(execution, writeIndexTsParameters, indexTsPath),
+    },
+    {
+      kind: "action",
+      name: "build the scaffolded app",
+      text: "Run the create-app build and verification command",
+      actionName: "SHELL",
+      options: buildParameters,
+      responseIncludesAny: ["BUILD_OK"],
+      assertTurn: expectBuildTurn,
+    },
+  ],
+  finalChecks: [
+    // Exactly the three scaffold writes succeeded.
+    {
+      type: "actionCalled",
+      actionName: "FILE",
+      status: "success",
+      minCount: 3,
+    },
+    // The build/verify command exited 0 (handler returns success only on exit 0).
+    {
+      type: "actionCalled",
+      actionName: "SHELL",
+      status: "success",
+      minCount: 1,
+    },
+    // The real scaffolded filenames flowed through the captured action args.
+    {
+      type: "selectedActionArguments",
+      actionName: ["FILE", "SHELL"],
+      includesAll: [/App\.tsx/, /package\.json/, /index\.ts/, /BUILD_OK/],
+    },
+    // Registered file-mutation proof: a FILE write touched each scaffold path.
+    {
+      type: "fileMutationOccurred",
+      name: "scaffolded App.tsx file mutation",
+      path: /App\.tsx$/,
+      minCount: 1,
+    },
+    {
+      type: "fileMutationOccurred",
+      name: "scaffolded package.json file mutation",
+      path: /package\.json$/,
+      minCount: 1,
+    },
+    {
+      type: "fileMutationOccurred",
+      name: "all three scaffold writes",
+      minCount: 3,
+    },
+    // Registered build validation: re-run a build/verify in the scaffolded app
+    // dir on disk and assert exit 0 (proves the produced workspace is sound).
+    {
+      type: "buildValidation",
+      name: "scaffolded app dir builds/verifies clean",
+      workdir: appDir,
+      command: buildValidationCommand,
+      expectExitZero: true,
+    },
+    // file-mutation emulation at byte-for-byte fidelity on disk.
+    {
+      type: "custom",
+      name: "fileMutationOccurred — scaffolded app files exist on disk byte-for-byte",
+      predicate: assertScaffoldedFilesOnDisk,
+    },
+    // build-validation emulation from the captured ledger.
+    {
+      type: "custom",
+      name: "buildValidation — verify command passed in the scaffolded app dir",
+      predicate: assertBuildPassedInAppDir,
+    },
+    // subAgentSpawned NEGATIVE: no real sub-agent spawn in the deterministic lane.
+    {
+      type: "custom",
+      name: "subAgentSpawned — N/A asserted explicitly (deterministic lane spawns no sub-agent)",
+      predicate: assertNoSubAgentSpawned,
+    },
+    // Exact ledger order + cleanup (must be last so tmpRoot is removed at the end).
+    {
+      type: "custom",
+      name: "create-app action ledger order is exact and workspace cleaned up",
+      predicate: assertLedgerAndCleanup,
+    },
+  ],
+});

--- a/packages/ui/src/bridge/native-notifications.orchestrator.test.ts
+++ b/packages/ui/src/bridge/native-notifications.orchestrator.test.ts
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+//
+// Gap closed: the existing src/state/notifications/notification-store.test.ts
+// FULLY mocks `../../bridge/native-notifications`, so it proves the store
+// *calls* the bridge but never proves an orchestrator-shaped notification's
+// title/body/deepLink actually survive the hop into the platform Capacitor API
+// (`LocalNotifications.schedule`). And `native-notifications.ts` itself has ZERO
+// direct test coverage. This file exercises the REAL bridge end-to-end: it
+// asserts the deep link rides through to `extra.deepLink`, the android channel
+// id / numeric id / body-default mapping, the iOS ElizaIntent fallback, the
+// graceful no-op path, and the FULL store -> deliver() -> bridge -> Capacitor
+// fan-out (the assertion the mocked sibling test structurally cannot make).
+//
+// A regression that dropped/relocated the deep link, changed the channel id,
+// stopped defaulting body to "", or broke the unfocused store fan-out would
+// turn one of these red.
+
+import type { AgentNotification } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Capacitor mock (hoisted shared state; mirrors first-run/probe-local-agent.test.ts) ──
+const { capacitorState } = vi.hoisted(() => ({
+  capacitorState: {
+    isNative: true,
+    platform: "android" as "android" | "ios" | "web",
+    plugins: {} as Record<string, unknown>,
+  },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    get Plugins() {
+      return capacitorState.plugins;
+    },
+    getPlatform: () => capacitorState.platform,
+    isNativePlatform: () => capacitorState.isNative,
+    registerPlugin: vi.fn(),
+  },
+}));
+
+// Desktop bridge mock so the store's desktop sink is observable and never hits a
+// real window RPC. vi.mock resolves the specifier relative to THIS test file and
+// keys the mock by the resolved absolute module id; "./electrobun-rpc" from
+// src/bridge/ resolves to the same file the store imports as
+// "../../bridge/electrobun-rpc", so the store picks up this mock.
+const invokeDesktopBridgeRequest = vi.fn();
+vi.mock("./electrobun-rpc", () => ({
+  invokeDesktopBridgeRequest: (...args: unknown[]) =>
+    invokeDesktopBridgeRequest(...args),
+}));
+
+// The store also top-level-imports the api client; the __ingest path never
+// touches it, but module-eval pulls it in. Stub it minimally so module load is
+// inert (no transport graph).
+vi.mock("../../api/client", () => ({ client: {} }));
+
+// IMPORTANT: do NOT mock "./native-notifications" — this test drives the REAL bridge.
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+  registerNotificationToastSink,
+} from "../state/notifications/notification-store";
+import {
+  hasNativeNotificationChannel,
+  showNativeNotification,
+} from "./native-notifications";
+
+// ── Fake Capacitor plugins ────────────────────────────────────────────────────
+const schedule = vi.fn();
+const createChannel = vi.fn();
+const checkPermissions = vi.fn();
+const requestPermissions = vi.fn();
+const receiveIntent = vi.fn();
+
+function freshLocalNotifications(): Record<string, unknown> {
+  return {
+    schedule,
+    createChannel,
+    checkPermissions,
+    requestPermissions,
+  };
+}
+
+type ScheduledNotification = {
+  id: number;
+  title: string;
+  body: string;
+  channelId?: string;
+  extra?: { deepLink?: string };
+};
+
+function firstScheduled(): ScheduledNotification {
+  const arg = schedule.mock.calls[0]?.[0] as {
+    notifications: ScheduledNotification[];
+  };
+  return arg.notifications[0];
+}
+
+function makeOrchestratorNotification(
+  overrides: Partial<AgentNotification> = {},
+): AgentNotification {
+  return {
+    id: (overrides.id ?? "orch-1") as AgentNotification["id"],
+    title: overrides.title ?? "Coding agent finished",
+    body: "body" in overrides ? overrides.body : "PR #42 ready for review",
+    category: overrides.category ?? "agent",
+    priority: overrides.priority ?? "normal",
+    source: overrides.source ?? "orchestrator",
+    deepLink: "deepLink" in overrides ? overrides.deepLink : "/orchestrator",
+    createdAt: overrides.createdAt ?? 1_700_000_000_000,
+    readAt: overrides.readAt ?? null,
+  };
+}
+
+beforeEach(() => {
+  __resetNotificationStoreForTests();
+  registerNotificationToastSink(null);
+
+  schedule.mockReset().mockResolvedValue(undefined);
+  createChannel.mockReset().mockResolvedValue(undefined);
+  checkPermissions.mockReset().mockResolvedValue({ display: "granted" });
+  requestPermissions.mockReset().mockResolvedValue({ display: "granted" });
+  receiveIntent.mockReset().mockResolvedValue({ accepted: true, reason: "ok" });
+  invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+
+  capacitorState.isNative = true;
+  capacitorState.platform = "android";
+  capacitorState.plugins = { LocalNotifications: freshLocalNotifications() };
+
+  // Default the window to UNFOCUSED so deliver() fans out to the OS sinks.
+  vi.spyOn(document, "hasFocus").mockReturnValue(false);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "hidden",
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("native-notifications bridge — direct (android LocalNotifications)", () => {
+  it("schedules a local notification and resolves 'local'", async () => {
+    const result = await showNativeNotification({
+      id: "orch-1",
+      title: "Coding agent finished",
+      body: "PR #42 ready for review",
+      deepLink: "/orchestrator",
+      urgent: false,
+    });
+    expect(result).toBe("local");
+    expect(schedule).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the deep link in extra.deepLink, NOT as a top-level field (core regression)", async () => {
+    await showNativeNotification({
+      id: "orch-1",
+      title: "Coding agent finished",
+      deepLink: "/orchestrator",
+    });
+    const notif = firstScheduled();
+    expect(notif.extra?.deepLink).toBe("/orchestrator");
+    // The deep link must ride inside `extra`, never as a top-level Capacitor field.
+    expect(notif).not.toHaveProperty("deepLink");
+  });
+
+  it("maps title and body onto the scheduled notification", async () => {
+    await showNativeNotification({
+      id: "orch-1",
+      title: "Coding agent finished",
+      body: "PR #42 ready for review",
+      deepLink: "/orchestrator",
+    });
+    const notif = firstScheduled();
+    expect(notif.title).toBe("Coding agent finished");
+    expect(notif.body).toBe("PR #42 ready for review");
+  });
+
+  it("uses the eliza_notifications android channel id", async () => {
+    await showNativeNotification({ id: "orch-1", title: "x" });
+    expect(firstScheduled().channelId).toBe("eliza_notifications");
+  });
+
+  it("derives a stable positive numeric id that is identical for the same string id", async () => {
+    await showNativeNotification({ id: "orch-stable", title: "first" });
+    const idA = firstScheduled().id;
+    expect(Number.isInteger(idA)).toBe(true);
+    expect(idA).toBeGreaterThan(0);
+    expect(idA).toBeLessThan(2_000_000_000);
+
+    schedule.mockClear();
+    await showNativeNotification({ id: "orch-stable", title: "second" });
+    const idB = firstScheduled().id;
+    expect(idB).toBe(idA); // determinism / dedupe identity
+  });
+
+  it("omits the extra key entirely when there is no deep link", async () => {
+    await showNativeNotification({ id: "orch-1", title: "no link" });
+    expect(firstScheduled()).not.toHaveProperty("extra");
+  });
+
+  it("defaults a missing body to an empty string (not undefined)", async () => {
+    await showNativeNotification({ id: "orch-1", title: "only title" });
+    expect(firstScheduled().body).toBe("");
+  });
+});
+
+describe("native-notifications bridge — iOS ElizaIntent fallback", () => {
+  it("routes through ElizaIntent with deepLinkOnTap when LocalNotifications is absent", async () => {
+    capacitorState.platform = "ios";
+    capacitorState.plugins = { ElizaIntent: { receiveIntent } };
+
+    const result = await showNativeNotification({
+      id: "orch-ios",
+      title: "Coding agent finished",
+      body: "PR #42 ready for review",
+      deepLink: "/orchestrator",
+    });
+
+    expect(result).toBe("intent");
+    expect(receiveIntent).toHaveBeenCalledTimes(1);
+    const arg = receiveIntent.mock.calls[0][0] as {
+      kind: string;
+      payload: Record<string, unknown>;
+    };
+    expect(arg.kind).toBe("reminder");
+    expect(arg.payload.deepLinkOnTap).toBe("/orchestrator");
+  });
+});
+
+describe("native-notifications bridge — graceful degradation", () => {
+  it("resolves 'none' and never throws when no native plugin and no web Notification", async () => {
+    capacitorState.plugins = {};
+    vi.stubGlobal("Notification", undefined);
+
+    let result: string | undefined;
+    await expect(
+      (async () => {
+        result = await showNativeNotification({ id: "orch-1", title: "x" });
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result).toBe("none");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("native-notifications bridge — hasNativeNotificationChannel", () => {
+  it("is true on android when LocalNotifications.schedule exists", () => {
+    capacitorState.platform = "android";
+    capacitorState.plugins = { LocalNotifications: freshLocalNotifications() };
+    expect(hasNativeNotificationChannel()).toBe(true);
+  });
+
+  it("is false when the platform is not native", () => {
+    capacitorState.isNative = false;
+    expect(hasNativeNotificationChannel()).toBe(false);
+  });
+});
+
+describe("notification-store fan-out -> REAL native bridge (orchestrator)", () => {
+  // deliver() is fire-and-forget (`void showNativeNotification(...).catch`), and
+  // the schedule() call lands several microtasks later
+  // (showNativeNotification -> tryLocalNotifications -> checkPermissions -> schedule).
+  async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  }
+
+  it("fires BOTH the desktop sink and the real native schedule when the window is unfocused", async () => {
+    __ingestNotificationForTests(makeOrchestratorNotification(), 1);
+    await flushMicrotasks();
+
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledTimes(1);
+    expect(schedule).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes desktop params (title/body/urgency/silent) without a deepLink", async () => {
+    __ingestNotificationForTests(makeOrchestratorNotification(), 1);
+    await flushMicrotasks();
+
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith({
+      rpcMethod: "desktopShowNotification",
+      ipcChannel: "desktop:showNotification",
+      params: expect.objectContaining({
+        title: "Coding agent finished",
+        body: "PR #42 ready for review",
+        urgency: "normal",
+        silent: false,
+      }),
+    });
+    // The store intentionally omits the deep link from the desktop sink params.
+    const params = invokeDesktopBridgeRequest.mock.calls[0][0].params as Record<
+      string,
+      unknown
+    >;
+    expect(params).not.toHaveProperty("deepLink");
+  });
+
+  it("carries the orchestrator deep link all the way into the native extra.deepLink", async () => {
+    __ingestNotificationForTests(makeOrchestratorNotification(), 1);
+    await flushMicrotasks();
+
+    // This is the assertion the fully-mocked sibling test cannot make:
+    // store -> deliver -> showNativeNotification -> Capacitor schedule.
+    expect(firstScheduled().extra?.deepLink).toBe("/orchestrator");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-concurrent-spawn-stress.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-concurrent-spawn-stress.test.ts
@@ -1,0 +1,421 @@
+// Concurrency-stress coverage for AcpService (Wave 3.3 / Domain L).
+//
+// GAP CLOSED: the existing acp-service.test.ts:1528 proves the
+// ELIZA_ACP_MAX_SESSIONS cap holds for 6 concurrent spawns with MAX=2 — count
+// + error substring only. It does NOT exercise the >=10-simultaneous-session
+// stress path, per-session workdir isolation, native-client cwd isolation,
+// acpxSessionId non-leakage, per-session event routing, or terminal-state
+// convergence after close. This file is that superset: it fires 10–12
+// concurrent native spawns and asserts that nothing leaks across sessions and
+// that the promise-chain reserve mutex (reserveSessionSlot, acp-service.ts
+// ~L2000) never overshoots the cap under contention. A real regression — a
+// shared/last-write-wins cwd in spawnNativeSession, a non-atomic check-then-
+// reserve race, a constant acpxSessionId, or a mis-keyed event — would be
+// caught here while the legacy single-assertion test would still pass.
+//
+// Deterministic: the native transport is mocked (no subprocess, no network, no
+// timers). Each spawn resolves to "ready" via real microtasks (mkdir +
+// writeWorkspaceIdentity + InMemorySessionStore WriteQueue), so NO fake timers
+// are used — fake timers would stall mkdtemp/mkdir/WriteQueue.
+
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path, { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AcpJsonRpcMessage,
+  ApprovalPreset,
+} from "../../src/services/types.js";
+import { TERMINAL_SESSION_STATUSES } from "../../src/services/types.js";
+
+// ---------------------------------------------------------------------------
+// Native transport mock — mirrors acp-service.test.ts lines 49-96 VERBATIM,
+// with ONE required deviation: createSession returns a UNIQUE sessionId per
+// call (counter + cwd-derived) so each session records a DISTINCT
+// acpxSessionId in the store. The reference mock's constant "protocol-session"
+// would make the no-leakage assertion vacuous.
+// ---------------------------------------------------------------------------
+
+type NativeEventHandler = (
+  event: AcpJsonRpcMessage,
+  sessionId?: string,
+) => void;
+type NativeOptions = {
+  command: string;
+  cwd: string;
+  approvalPreset: ApprovalPreset;
+  timeoutMs?: number;
+  terminal?: boolean;
+  onEvent?: NativeEventHandler;
+  onStderr?: (chunk: string) => void;
+};
+type MockNativeClient = {
+  opts: NativeOptions;
+  eventHandler?: NativeEventHandler;
+  start: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+  prompt: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  closeSession: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  setEventHandler: (handler: NativeEventHandler | undefined) => void;
+  setTimeoutMs: (timeoutMs: number | undefined) => void;
+  emit: (event: AcpJsonRpcMessage, sessionId?: string) => void;
+};
+type NativeMockState = {
+  NativeAcpClient?: new (opts: NativeOptions) => MockNativeClient;
+  instances: MockNativeClient[];
+  seq: number;
+};
+
+function getNativeMockState(): NativeMockState {
+  const globalWithMock = globalThis as typeof globalThis & {
+    __acpStressNativeMock?: NativeMockState;
+  };
+  globalWithMock.__acpStressNativeMock ??= { instances: [], seq: 0 };
+  return globalWithMock.__acpStressNativeMock;
+}
+
+const nativeClientMock = getNativeMockState();
+
+vi.mock("../../src/services/acp-native-transport.js", () => {
+  const state = getNativeMockState();
+  state.NativeAcpClient = class MockNativeAcpClient
+    implements MockNativeClient
+  {
+    opts: NativeOptions;
+    eventHandler?: NativeEventHandler;
+    start = vi.fn(async () => undefined);
+    // UNIQUE per instance + keyed off cwd so a workdir/session mismatch (a
+    // last-write-wins cwd leak in spawnNativeSession) becomes detectable.
+    createSession = vi.fn(async (cwd: string) => {
+      const n = ++getNativeMockState().seq;
+      return {
+        sessionId: `proto-${n}-${cwd}`,
+        agentSessionId: `agent-${n}`,
+      };
+    });
+    prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+    cancel = vi.fn(async () => undefined);
+    closeSession = vi.fn(async () => undefined);
+    close = vi.fn(async () => undefined);
+
+    constructor(opts: NativeOptions) {
+      this.opts = opts;
+      this.eventHandler = opts.onEvent;
+      getNativeMockState().instances.push(this);
+    }
+
+    setEventHandler(handler: NativeEventHandler | undefined) {
+      this.eventHandler = handler;
+      this.opts.onEvent = handler;
+    }
+
+    setTimeoutMs(timeoutMs: number | undefined) {
+      this.opts.timeoutMs = timeoutMs;
+    }
+
+    emit(event: AcpJsonRpcMessage, sessionId?: string) {
+      this.eventHandler?.(event, sessionId);
+    }
+  };
+  return { NativeAcpClient: state.NativeAcpClient };
+});
+
+// Imported AFTER the vi.mock so AcpService binds to the mocked transport.
+import { AcpService } from "../../src/services/acp-service.js";
+
+// workspace-diff promisifies execFile (baseline SHA/dirty capture). The
+// promisified form hangs unless the callback fires, which would stall every
+// spawn; make git look unavailable so capture degrades to undefined.
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb?: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function") {
+        callback(new Error("git unavailable in test"), "", "");
+      }
+    },
+  ),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
+  spawn: vi.fn(),
+}));
+
+// Runtime helper: same shape as the reference test, but transport defaults to
+// NATIVE (undefined → AcpService picks "native"). The reference helper forces
+// ELIZA_ACP_TRANSPORT:"cli"; we must NOT, since the stress path is native.
+function runtime(settings: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    ELIZA_ACP_TRANSPORT: undefined,
+    ...settings,
+  };
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: vi.fn((key: string) => values[key]),
+    services: new Map<string, unknown[]>(),
+  } as never;
+}
+
+// `setting()` falls back to process.env, so a leaked env var would override the
+// runtime helper and silently flip the transport/cap. Scrub the relevant keys.
+const SCRUBBED_ENV_KEYS = [
+  "ELIZA_ACP_TRANSPORT",
+  "ACPX_TRANSPORT",
+  "ELIZA_ACP_MAX_SESSIONS",
+  "ELIZA_ACP_WORKSPACE_ROOT",
+  "ACPX_DEFAULT_CWD",
+  "ELIZA_ACP_CLI",
+  "ELIZA_PLATFORM",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of SCRUBBED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  nativeClientMock.instances.length = 0;
+  nativeClientMock.seq = 0;
+});
+
+const createdDirs: string[] = [];
+let activeService: AcpService | undefined;
+
+afterEach(async () => {
+  vi.useRealTimers();
+  if (activeService) {
+    await activeService.stop().catch(() => undefined);
+    activeService = undefined;
+  }
+  await Promise.all(
+    createdDirs
+      .splice(0)
+      .map((dir) =>
+        rm(dir, { recursive: true, force: true }).catch(() => undefined),
+      ),
+  );
+  for (const key of SCRUBBED_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+async function makeWorkdirs(n: number): Promise<string[]> {
+  const dirs = await Promise.all(
+    Array.from({ length: n }, () => mkdtemp(join(tmpdir(), "acp-stress-"))),
+  );
+  createdDirs.push(...dirs);
+  return dirs;
+}
+
+function isTerminal(status: string): boolean {
+  return TERMINAL_SESSION_STATUSES.has(status);
+}
+
+describe("AcpService — concurrent-spawn stress (Domain L)", () => {
+  it("holds ELIZA_ACP_MAX_SESSIONS exactly under >=10 concurrent spawns", async () => {
+    // 12 concurrent spawns, cap 4: the promise-chain reserve mutex must
+    // serialize check-and-reserve so the race cannot overshoot the cap.
+    activeService = new AcpService(runtime({ ELIZA_ACP_MAX_SESSIONS: "4" }));
+    await activeService.start();
+
+    const dirs = await makeWorkdirs(12);
+    const results = await Promise.allSettled(
+      dirs.map((wd, i) =>
+        (activeService as AcpService).spawnSession({
+          name: `cap-${i}`,
+          agentType: "codex",
+          workdir: wd,
+        }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(4);
+    expect(rejected).toHaveLength(8);
+    for (const r of rejected) {
+      const reason = (r as PromiseRejectedResult).reason;
+      expect(reason).toBeInstanceOf(Error);
+      // The cap value is interpolated into the message: "...reached (4)".
+      expect((reason as Error).message).toMatch(/max session limit reached/);
+      expect((reason as Error).message).toContain("(4)");
+    }
+
+    // STORE AGREES WITH CAP: never more than maxSessions active rows.
+    const sessions = await (activeService as AcpService).listSessions();
+    const active = sessions.filter((s) => !isTerminal(s.status));
+    expect(active).toHaveLength(4);
+  });
+
+  it("spawns 10 isolated sessions concurrently with no cross-session leakage", async () => {
+    const N = 10;
+    activeService = new AcpService(runtime({ ELIZA_ACP_MAX_SESSIONS: "16" }));
+    await activeService.start();
+
+    // Register the event sink BEFORE spawning so every "ready" is observed.
+    const eventsBySession = new Map<string, string[]>();
+    activeService.onSessionEvent((sid, event) => {
+      const list = eventsBySession.get(sid) ?? [];
+      list.push(event);
+      eventsBySession.set(sid, list);
+    });
+
+    const dirs = await makeWorkdirs(N);
+    const results = await Promise.allSettled(
+      dirs.map((wd, i) =>
+        (activeService as AcpService).spawnSession({
+          name: `proj-${i}`,
+          agentType: "codex",
+          workdir: wd,
+        }),
+      ),
+    );
+
+    // HIGH-CONCURRENCY SUCCESS: all 10 fulfill as "ready".
+    const fulfilled = results.filter(
+      (
+        r,
+      ): r is PromiseFulfilledResult<
+        Awaited<ReturnType<AcpService["spawnSession"]>>
+      > => r.status === "fulfilled",
+    );
+    expect(fulfilled).toHaveLength(N);
+    for (const r of fulfilled) {
+      expect(r.value.status).toBe("ready");
+    }
+
+    const resolvedInputs = dirs.map((d) => path.resolve(d));
+    const localIds = fulfilled.map((r) => r.value.id);
+
+    // DISTINCT WORKDIRS, NO COLLISION: each spawn result keeps its own
+    // path.resolve(input) workdir; pairwise distinct.
+    const resultWorkdirs = fulfilled.map((r) => r.value.workdir);
+    expect(new Set(resultWorkdirs).size).toBe(N);
+    expect(new Set(resultWorkdirs)).toEqual(new Set(resolvedInputs));
+
+    // NATIVE CLIENT CWD ISOLATION: one client per session, each constructed
+    // with its OWN resolved cwd (no shared/last-write-wins cwd).
+    expect(nativeClientMock.instances).toHaveLength(N);
+    const clientCwds = nativeClientMock.instances.map((c) => c.opts.cwd);
+    expect(new Set(clientCwds).size).toBe(N);
+    expect(new Set(clientCwds)).toEqual(new Set(resolvedInputs));
+
+    // NO ACPX-SESSION-ID LEAKAGE: every persisted acpxSessionId is distinct,
+    // and the per-cwd-derived id proves the session whose workdir is W carries
+    // the acpxSessionId minted from W (no event/store cross-wiring).
+    const sessions = await activeService.listSessions();
+    const byId = new Map(sessions.map((s) => [s.id, s]));
+    const acpxIds = sessions.map((s) => s.acpxSessionId);
+    expect(acpxIds.every((v) => typeof v === "string" && v.length > 0)).toBe(
+      true,
+    );
+    expect(new Set(acpxIds).size).toBe(N);
+    for (const s of sessions) {
+      // createSession returned `proto-<n>-<cwd>`; the cwd suffix must match the
+      // session's own workdir — a mismatch means a concurrent spawn's id was
+      // written onto the wrong session row.
+      expect(s.acpxSessionId).toContain(s.workdir);
+    }
+
+    // PER-SESSION EVENT ROUTING: every emitted event is keyed by one of the 10
+    // known local session ids, and each of the 10 saw a "ready".
+    const knownIds = new Set(localIds);
+    for (const sid of eventsBySession.keys()) {
+      expect(knownIds.has(sid)).toBe(true);
+    }
+    for (const sid of localIds) {
+      expect(eventsBySession.get(sid)).toContain("ready");
+      // The session whose local id is sid must own a store row.
+      expect(byId.has(sid)).toBe(true);
+    }
+  });
+
+  it("converges every session to a terminal status after closeSession", async () => {
+    const N = 10;
+    activeService = new AcpService(runtime({ ELIZA_ACP_MAX_SESSIONS: "16" }));
+    await activeService.start();
+
+    const dirs = await makeWorkdirs(N);
+    const results = await Promise.allSettled(
+      dirs.map((wd, i) =>
+        (activeService as AcpService).spawnSession({
+          name: `term-${i}`,
+          agentType: "codex",
+          workdir: wd,
+        }),
+      ),
+    );
+    const ids = results
+      .filter(
+        (
+          r,
+        ): r is PromiseFulfilledResult<
+          Awaited<ReturnType<AcpService["spawnSession"]>>
+        > => r.status === "fulfilled",
+      )
+      .map((r) => r.value.sessionId);
+    expect(ids).toHaveLength(N);
+
+    // Before close, none are terminal.
+    const before = await activeService.listSessions();
+    expect(before.filter((s) => !isTerminal(s.status))).toHaveLength(N);
+
+    // Close all concurrently → native close path sets status "stopped".
+    await Promise.all(
+      ids.map((id) => (activeService as AcpService).closeSession(id)),
+    );
+
+    const after = await activeService.listSessions();
+    expect(after).toHaveLength(N);
+    for (const s of after) {
+      expect(isTerminal(s.status)).toBe(true);
+      expect(s.status).toBe("stopped");
+    }
+    // No session lingers active.
+    expect(after.filter((s) => !isTerminal(s.status))).toHaveLength(0);
+  });
+
+  it("writes an independent on-disk identity scaffold into each workdir", async () => {
+    // Real-FS isolation: writeWorkspaceIdentity scaffolds AGENTS.md + CLAUDE.md
+    // into each bare temp workdir; distinct dirs => independent files, proving
+    // the per-workdir scaffold ran once per session without cross clobber.
+    const N = 10;
+    activeService = new AcpService(runtime({ ELIZA_ACP_MAX_SESSIONS: "16" }));
+    await activeService.start();
+
+    const dirs = await makeWorkdirs(N);
+    await Promise.all(
+      dirs.map((wd, i) =>
+        (activeService as AcpService).spawnSession({
+          name: `id-${i}`,
+          agentType: "codex",
+          workdir: wd,
+        }),
+      ),
+    );
+
+    for (const dir of dirs) {
+      const agents = join(path.resolve(dir), "AGENTS.md");
+      const claude = join(path.resolve(dir), "CLAUDE.md");
+      await expect(access(agents)).resolves.toBeUndefined();
+      await expect(access(claude)).resolves.toBeUndefined();
+      const agentsBody = await readFile(agents, "utf8");
+      // The scaffold is the operating manual, not an empty placeholder.
+      expect(agentsBody).toContain("Eliza coding sub-agent");
+    }
+  });
+});

--- a/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentSettingsSection.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentSettingsSection.test.tsx
@@ -1,0 +1,712 @@
+// @vitest-environment jsdom
+//
+// Behavioral coverage for CodingAgentSettingsSection (the task-coordinator
+// Coding-Agents settings page, src/CodingAgentSettingsSection.tsx) and its
+// sub-sections (AgentTabsSection / LlmProviderSection / ModelConfigSection /
+// GlobalPrefsSection / GitHubConnectionCard). Before this file the section had
+// ZERO in-plugin coverage — the only regression net was the two co-located
+// boundary-helper tests under src/api/. This closes that gap by asserting the
+// real wiring a user touches every time they configure a coding agent:
+//
+//   * mount loads config + preflight + models and leaves the loading state;
+//   * one tab per installed framework, with the prefs-driven default tab
+//     rendered active (data-variant="default");
+//   * switching tabs persists ELIZA_DEFAULT_AGENT_TYPE through the debounced
+//     auto-save -> client.updateConfig;
+//   * model selection persists through the prefs client to ENV_PREFIX-keyed
+//     env (powerful + fast), with fetched models preferred and FALLBACK_MODELS
+//     used on fetch failure;
+//   * approval-preset + selection-strategy persist;
+//   * the auto-save "no write without interaction" guard (autoSaveArmedRef)
+//     and the "_"-prefixed synthetic-key strip both hold;
+//   * a rejected updateConfig surfaces a role="alert" banner;
+//   * the no-installed-CLIs branch renders the install list (no tabs);
+//   * needs-auth banner POSTs /api/coding-agents/auth/{agent};
+//   * GitHub card connect / disconnect / generate-link / error states.
+//
+// Plus supplementary edge cases for the auth-sanitize + preflight-normalize
+// boundary helpers that the existing co-located tests do NOT cover
+// (protocol-relative URL, uppercase scheme, non-string url, whitespace status,
+// empty status, full round-trip, array input).
+//
+// @elizaos/ui is mocked entirely (the real Select is Radix, which misbehaves in
+// jsdom) — Select -> native <select>, Button -> <button>, etc. — mirroring the
+// sibling CodingAgentTasksPanel.test.tsx pattern. global.fetch is stubbed for
+// /api/coding-agents/preflight + /api/coding-agents/auth/{agent}; the GitHub
+// card uses client.fetch (a separate spy).
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sanitizeAuthResult } from "../../src/api/coding-agents-auth-sanitize.js";
+import { normalizePreflightAuth } from "../../src/api/coding-agents-preflight-normalize.js";
+
+// --- @elizaos/ui spies -----------------------------------------------------
+
+const getConfig = vi.fn();
+const updateConfig = vi.fn();
+const fetchModels = vi.fn();
+const githubFetch = vi.fn();
+const openExternalUrl = vi.fn();
+
+// Shared app value so useApp / useAppSelector / useAppSelectorShallow all read
+// the same fields. `t` renders vars.defaultValue and interpolates {{var}} —
+// the same contract the real i18n catalog implements — so when a key has no
+// defaultValue (e.g. the Loading placeholder) the raw key is rendered, which
+// the tests assert against verbatim.
+const mockAppValue = vi.hoisted(() => ({
+  t: (key: string, vars?: Record<string, unknown>) => {
+    const template = String(vars?.defaultValue ?? key);
+    return template.replace(/\{\{(\w+)\}\}/g, (_m: string, name: string) =>
+      vars && name in vars ? String(vars[name]) : `{{${name}}}`,
+    );
+  },
+  elizaCloudConnected: true,
+}));
+
+vi.mock("@elizaos/ui", () => {
+  type AnyProps = Record<string, unknown> & { children?: ReactNode };
+  const passthrough = ({ children }: AnyProps) => <>{children}</>;
+  return {
+    client: {
+      getConfig: (...a: unknown[]) => getConfig(...a),
+      updateConfig: (...a: unknown[]) => updateConfig(...a),
+      fetchModels: (...a: unknown[]) => fetchModels(...a),
+      fetch: (...a: unknown[]) => githubFetch(...a),
+    },
+    openExternalUrl: (...a: unknown[]) => openExternalUrl(...a),
+    useApp: () => mockAppValue,
+    useAppSelector: (sel: (s: Record<string, unknown>) => unknown) =>
+      sel(mockAppValue),
+    useAppSelectorShallow: (sel: (s: Record<string, unknown>) => unknown) =>
+      sel(mockAppValue),
+    Button: ({
+      children,
+      onClick,
+      disabled,
+      "aria-label": ariaLabel,
+      "aria-pressed": ariaPressed,
+      title,
+      variant,
+    }: {
+      children?: ReactNode;
+      onClick?: () => void;
+      disabled?: boolean;
+      "aria-label"?: string;
+      "aria-pressed"?: boolean;
+      title?: string;
+      variant?: string;
+    }) => (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-pressed={ariaPressed}
+        title={title}
+        data-variant={variant}
+      >
+        {children}
+      </button>
+    ),
+    // Radix Select stand-ins: a native <select> drives onValueChange through
+    // its change event, SelectItem -> <option>. The trigger/value/content
+    // wrappers pass children through so the <option>s end up inside <select>.
+    Select: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value?: string;
+      onValueChange?: (v: string) => void;
+      children?: ReactNode;
+    }) => (
+      <select value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+        {children}
+      </select>
+    ),
+    SelectContent: passthrough,
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children?: ReactNode;
+    }) => <option value={value}>{children}</option>,
+    SelectTrigger: passthrough,
+    SelectValue: () => null,
+    SettingsControls: {
+      Input: (p: AnyProps) => <input {...(p as object)} />,
+      Textarea: (p: AnyProps) => <textarea {...(p as object)} />,
+      SelectTrigger: passthrough,
+      SegmentedGroup: ({ children }: AnyProps) => (
+        <fieldset>{children}</fieldset>
+      ),
+      MutedText: ({ children }: AnyProps) => <span>{children}</span>,
+      Field: ({ children }: AnyProps) => <div>{children}</div>,
+      FieldLabel: ({ children }: AnyProps) => <span>{children}</span>,
+      FieldDescription: ({ children }: AnyProps) => <p>{children}</p>,
+    },
+  };
+});
+
+import { CodingAgentSettingsSection } from "../../src/CodingAgentSettingsSection";
+
+// --- preflight + global.fetch helpers --------------------------------------
+
+type PreflightRow = {
+  adapter: string;
+  installed: boolean;
+  auth?: { status: string };
+  installCommand?: string;
+  docsUrl?: string;
+};
+
+const ALL_INSTALLED: PreflightRow[] = [
+  { adapter: "eliza", installed: true, auth: { status: "authenticated" } },
+  { adapter: "pi-agent", installed: true, auth: { status: "authenticated" } },
+  { adapter: "opencode", installed: true, auth: { status: "authenticated" } },
+  {
+    adapter: "claude code",
+    installed: true,
+    auth: { status: "authenticated" },
+  },
+  {
+    adapter: "openai codex",
+    installed: true,
+    auth: { status: "authenticated" },
+  },
+];
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+// Route global.fetch by URL: preflight -> the configured rows, auth POST ->
+// a launched result. Auth POST calls are recorded on `authFetchCalls`.
+let preflightRows: PreflightRow[] = ALL_INSTALLED;
+let authFetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+function installFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.startsWith("/api/coding-agents/preflight")) {
+        return jsonResponse(preflightRows);
+      }
+      if (url.startsWith("/api/coding-agents/auth/")) {
+        authFetchCalls.push({ url, init });
+        return jsonResponse({ launched: true, instructions: "Open the CLI." });
+      }
+      return jsonResponse(null, false);
+    }),
+  );
+}
+
+// --- config / models fixtures ----------------------------------------------
+
+type EnvConfig = {
+  env?: Record<string, string>;
+  cloud?: Record<string, string>;
+};
+
+function setConfig(cfg: EnvConfig) {
+  getConfig.mockResolvedValue({ env: cfg.env ?? {}, cloud: cfg.cloud ?? {} });
+}
+
+beforeEach(() => {
+  getConfig.mockReset();
+  updateConfig.mockReset().mockResolvedValue({});
+  fetchModels
+    .mockReset()
+    .mockResolvedValue({ provider: "anthropic", models: [] });
+  githubFetch.mockReset().mockResolvedValue({ connected: false });
+  openExternalUrl.mockReset();
+  preflightRows = ALL_INSTALLED;
+  authFetchCalls = [];
+  installFetch();
+  setConfig({ env: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// Find a <select> on screen by the value of one of its <option>s. Multiple
+// selects coexist (powerful/fast model, selection-strategy, account-pool,
+// approval-preset, scratch-retention) so disambiguate by option value, never
+// by index — order/visibility can shift across renders.
+function selectWithOption(optionValue: string): HTMLSelectElement {
+  const selects = Array.from(
+    document.querySelectorAll("select"),
+  ) as HTMLSelectElement[];
+  const match = selects.find((s) =>
+    Array.from(s.options).some((o) => o.value === optionValue),
+  );
+  if (!match) {
+    throw new Error(
+      `No <select> found containing option value "${optionValue}"`,
+    );
+  }
+  return match;
+}
+
+describe("CodingAgentSettingsSection", () => {
+  it("shows the loading placeholder before config resolves, then leaves it", async () => {
+    setConfig({ env: {} });
+    render(<CodingAgentSettingsSection />);
+    // No defaultValue on the loading key -> raw key text is rendered.
+    expect(
+      screen.getByText("codingagentsettingssection.LoadingCodingAgent"),
+    ).toBeTruthy();
+    await screen.findByRole("button", { name: /elizaOS/ });
+    expect(
+      screen.queryByText("codingagentsettingssection.LoadingCodingAgent"),
+    ).toBeNull();
+  });
+
+  it("renders one tab per installed framework", async () => {
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /elizaOS/ });
+    // aria-label is `${AGENT_LABELS[agent]} ${statusLabel}` — match the label.
+    for (const label of [
+      "elizaOS",
+      "Pi Agent",
+      "OpenCode",
+      "Claude",
+      "Codex",
+    ]) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`^${label}\\s`) }),
+      ).toBeTruthy();
+    }
+  });
+
+  it("marks the prefs-default agent tab active and the rest ghost", async () => {
+    setConfig({ env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" } });
+    render(<CodingAgentSettingsSection />);
+    const claudeTab = await screen.findByRole("button", { name: /^Claude\s/ });
+    expect(claudeTab.getAttribute("data-variant")).toBe("default");
+    const codexTab = screen.getByRole("button", { name: /^Codex\s/ });
+    expect(codexTab.getAttribute("data-variant")).toBe("ghost");
+  });
+
+  it("persists the active tab through debounced auto-save when switching", async () => {
+    setConfig({ env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" } });
+    render(<CodingAgentSettingsSection />);
+    const codexTab = await screen.findByRole("button", { name: /^Codex\s/ });
+    fireEvent.click(codexTab);
+    // The clicked tab becomes active immediately.
+    expect(
+      screen
+        .getByRole("button", { name: /^Codex\s/ })
+        .getAttribute("data-variant"),
+    ).toBe("default");
+    // The debounced (400ms) auto-save persists ELIZA_DEFAULT_AGENT_TYPE=codex.
+    await waitFor(
+      () => {
+        expect(updateConfig).toHaveBeenCalled();
+        const last = updateConfig.mock.calls.at(-1)?.[0] as {
+          env: Record<string, string>;
+        };
+        expect(last.env.ELIZA_DEFAULT_AGENT_TYPE).toBe("codex");
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("persists powerful + fast model selection to ENV_PREFIX-keyed env", async () => {
+    setConfig({ env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" } });
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /^Claude\s/ });
+
+    // FALLBACK_MODELS.anthropic provides claude-opus-4-7 as an option value.
+    const powerful = selectWithOption("claude-opus-4-7");
+    fireEvent.change(powerful, { target: { value: "claude-opus-4-7" } });
+    await waitFor(
+      () => {
+        const last = updateConfig.mock.calls.at(-1)?.[0] as {
+          env: Record<string, string>;
+        };
+        expect(last?.env.ELIZA_CLAUDE_MODEL_POWERFUL).toBe("claude-opus-4-7");
+      },
+      { timeout: 2000 },
+    );
+
+    // Both selects carry the same option set; the second occurrence is Fast.
+    const sonnetSelects = (
+      Array.from(document.querySelectorAll("select")) as HTMLSelectElement[]
+    ).filter((s) =>
+      Array.from(s.options).some((o) => o.value === "claude-sonnet-4-6"),
+    );
+    expect(sonnetSelects.length).toBe(2);
+    fireEvent.change(sonnetSelects[1], {
+      target: { value: "claude-sonnet-4-6" },
+    });
+    await waitFor(
+      () => {
+        const last = updateConfig.mock.calls.at(-1)?.[0] as {
+          env: Record<string, string>;
+        };
+        expect(last?.env.ELIZA_CLAUDE_MODEL_FAST).toBe("claude-sonnet-4-6");
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("prefers fetched models and falls back to FALLBACK_MODELS on fetch failure", async () => {
+    setConfig({ env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" } });
+    fetchModels.mockImplementation(async (provider: string) => {
+      if (provider === "anthropic") {
+        return {
+          provider: "anthropic",
+          models: [{ id: "claude-x", name: "Claude X", category: "chat" }],
+        };
+      }
+      return { provider, models: [] };
+    });
+    const { unmount } = render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /^Claude\s/ });
+    // Fetched model option present, fallback NOT used.
+    expect(selectWithOption("claude-x")).toBeTruthy();
+    const fetchedOption = Array.from(selectWithOption("claude-x").options).find(
+      (o) => o.value === "claude-x",
+    );
+    expect(fetchedOption?.textContent).toBe("Claude X");
+    unmount();
+
+    // Now make fetch reject -> .catch(() => null) -> FALLBACK_MODELS.anthropic.
+    fetchModels.mockImplementation(async () => {
+      throw new Error("models endpoint down");
+    });
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /^Claude\s/ });
+    const fallback = Array.from(
+      selectWithOption("claude-opus-4-7").options,
+    ).find((o) => o.value === "claude-opus-4-7");
+    expect(fallback?.textContent).toBe("Claude Opus 4.7");
+  });
+
+  it("persists the approval-preset change", async () => {
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /elizaOS/ });
+    // The approval-preset select is the one carrying 'autonomous'.
+    const presetSelect = selectWithOption("autonomous");
+    fireEvent.change(presetSelect, { target: { value: "autonomous" } });
+    await waitFor(
+      () => {
+        const last = updateConfig.mock.calls.at(-1)?.[0] as {
+          env: Record<string, string>;
+        };
+        expect(last?.env.ELIZA_DEFAULT_APPROVAL_PRESET).toBe("autonomous");
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("persists the selection-strategy change", async () => {
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /elizaOS/ });
+    // The selection-strategy select is the one carrying 'ranked'.
+    const stratSelect = selectWithOption("ranked");
+    fireEvent.change(stratSelect, { target: { value: "ranked" } });
+    await waitFor(
+      () => {
+        const last = updateConfig.mock.calls.at(-1)?.[0] as {
+          env: Record<string, string>;
+        };
+        expect(last?.env.ELIZA_AGENT_SELECTION_STRATEGY).toBe("ranked");
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("does NOT auto-save on initial load with no user interaction (autoSaveArmedRef guard)", async () => {
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /elizaOS/ });
+    // Give the 400ms debounce ample real time to fire if the guard were broken.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it("strips synthetic '_'-prefixed keys (e.g. _CLOUD_API_KEY) from the env patch", async () => {
+    setConfig({
+      env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" },
+      cloud: { apiKey: "cloud-secret-123" },
+    });
+    render(<CodingAgentSettingsSection />);
+    const codexTab = await screen.findByRole("button", { name: /^Codex\s/ });
+    fireEvent.click(codexTab);
+    await waitFor(
+      () => {
+        expect(updateConfig).toHaveBeenCalled();
+      },
+      { timeout: 2000 },
+    );
+    const env = (
+      updateConfig.mock.calls.at(-1)?.[0] as {
+        env: Record<string, string>;
+      }
+    ).env;
+    expect(Object.keys(env).some((k) => k.startsWith("_"))).toBe(false);
+    expect(env._CLOUD_API_KEY).toBeUndefined();
+    // The real env value must still be present (proves we didn't drop everything).
+    expect(env.ELIZA_DEFAULT_AGENT_TYPE).toBe("codex");
+  });
+
+  it("surfaces a failed save in a role='alert' banner", async () => {
+    setConfig({ env: { ELIZA_DEFAULT_AGENT_TYPE: "claude" } });
+    updateConfig.mockRejectedValue(new Error("disk full"));
+    render(<CodingAgentSettingsSection />);
+    const codexTab = await screen.findByRole("button", { name: /^Codex\s/ });
+    fireEvent.click(codexTab);
+    const alert = await waitFor(() => screen.getByRole("alert"), {
+      timeout: 2000,
+    });
+    expect(alert.textContent).toContain("Failed to save settings: disk full");
+  });
+
+  it("renders the no-installed-CLIs install list when preflight reports none installed", async () => {
+    preflightRows = [
+      {
+        adapter: "claude code",
+        installed: false,
+        installCommand: "npm i -g x",
+      },
+      { adapter: "openai codex", installed: false },
+    ];
+    render(<CodingAgentSettingsSection />);
+    // NoSupportedCLIs key has no defaultValue -> raw key rendered.
+    await screen.findByText("codingagentsettingssection.NoSupportedCLIs");
+    // Every framework label appears in the install list...
+    for (const label of [
+      "elizaOS",
+      "Pi Agent",
+      "OpenCode",
+      "Claude",
+      "Codex",
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+    // ...but the tab buttons (aria-label `${label} ${statusLabel}`) are NOT shown.
+    expect(screen.queryByRole("button", { name: /^Claude\s/ })).toBeNull();
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
+  it("encodes install state into the tab aria-label (installed vs missing)", async () => {
+    preflightRows = [
+      {
+        adapter: "claude code",
+        installed: true,
+        auth: { status: "authenticated" },
+      },
+      { adapter: "openai codex", installed: false },
+    ];
+    render(<CodingAgentSettingsSection />);
+    // Only installed agents are tabbed when at least one is installed.
+    const claudeTab = await screen.findByRole("button", { name: /^Claude\s/ });
+    expect(claudeTab.getAttribute("aria-label")).toContain(
+      "codingagentsettingssection.Installed",
+    );
+    // Codex is missing -> not tabbed in this branch.
+    expect(screen.queryByRole("button", { name: /^Codex\s/ })).toBeNull();
+  });
+
+  it("shows the needs-auth banner and POSTs to /api/coding-agents/auth/{agent} on Sign in", async () => {
+    setConfig({
+      env: {
+        ELIZA_LLM_PROVIDER: "subscription",
+        ELIZA_DEFAULT_AGENT_TYPE: "claude",
+      },
+    });
+    preflightRows = [
+      {
+        adapter: "claude code",
+        installed: true,
+        auth: { status: "unauthenticated" },
+      },
+    ];
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /^Claude\s/ });
+    // The KeyRound 'Authentication required' banner + Sign in button render.
+    const signIn = await screen.findByText("Sign in");
+    fireEvent.click(signIn);
+    await waitFor(() => {
+      expect(
+        authFetchCalls.some(
+          (c) =>
+            c.url === "/api/coding-agents/auth/claude" &&
+            c.init?.method === "POST",
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("GitHubConnectionCard (via the settings section)", () => {
+  // The card is only rendered when the section is past loading and has tabs.
+  async function renderSection() {
+    render(<CodingAgentSettingsSection />);
+    await screen.findByRole("button", { name: /elizaOS/ });
+  }
+
+  it("renders the disconnected state and connects a pasted token", async () => {
+    githubFetch.mockResolvedValueOnce({ connected: false }); // initial GET
+    await renderSection();
+    await screen.findByLabelText("Not connected");
+    const input = document.querySelector(
+      'input[placeholder="ghp_…"]',
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    const connect = screen.getByRole("button", { name: "Connect" });
+    expect((connect as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "ghp_realtoken" } });
+    expect(
+      (screen.getByRole("button", { name: "Connect" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+
+    githubFetch.mockResolvedValueOnce({
+      connected: true,
+      username: "octocat",
+      scopes: ["repo"],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await screen.findByLabelText("Connected as @octocat");
+    const postCall = githubFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as RequestInit).method === "POST",
+    );
+    expect(postCall?.[0]).toBe("/api/github/token");
+    expect(String((postCall?.[1] as RequestInit).body)).toContain(
+      "ghp_realtoken",
+    );
+  });
+
+  it("renders the connected state initially and disconnects", async () => {
+    githubFetch.mockResolvedValueOnce({
+      connected: true,
+      username: "octocat",
+      scopes: ["repo", "read:user"],
+    });
+    await renderSection();
+    await screen.findByLabelText("Connected as @octocat");
+    expect(screen.getByText(/repo, read:user/)).toBeTruthy();
+
+    const disconnect = screen.getByRole("button", { name: /Disconnect/ });
+    githubFetch.mockResolvedValueOnce(undefined); // DELETE resolves
+    fireEvent.click(disconnect);
+
+    await screen.findByLabelText("Not connected");
+    const deleteCall = githubFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as RequestInit).method === "DELETE",
+    );
+    expect(deleteCall?.[0]).toBe("/api/github/token");
+  });
+
+  it("opens the github token-generation page", async () => {
+    githubFetch.mockResolvedValueOnce({ connected: false });
+    await renderSection();
+    await screen.findByLabelText("Not connected");
+    const genLink = screen.getByText(/Generate a token on github.com/);
+    fireEvent.click(genLink);
+    expect(openExternalUrl).toHaveBeenCalledTimes(1);
+    expect(String(openExternalUrl.mock.calls[0][0])).toMatch(
+      /^https:\/\/github\.com\/settings\/tokens\/new/,
+    );
+  });
+
+  it("shows the server's error message when connect returns {error}", async () => {
+    githubFetch.mockResolvedValueOnce({ connected: false }); // initial GET
+    await renderSection();
+    const input = (await waitFor(() =>
+      document.querySelector('input[placeholder="ghp_…"]'),
+    )) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ghp_bad" } });
+    githubFetch.mockResolvedValueOnce({ error: "bad token" }); // POST
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    expect(await screen.findByText("bad token")).toBeTruthy();
+    // Still disconnected after a failed connect.
+    expect(screen.getByLabelText("Not connected")).toBeTruthy();
+  });
+});
+
+// --- Supplementary boundary-helper edge cases ------------------------------
+// These add ONLY cases not already covered by the co-located
+// src/api/*.test.ts files (no duplicate scenarios).
+
+describe("sanitizeAuthResult — additional edge cases", () => {
+  it("drops a protocol-relative URL (no base -> new URL throws)", () => {
+    expect(
+      sanitizeAuthResult({ url: "//evil.com/login", instructions: "fallback" }),
+    ).toEqual({ instructions: "fallback" });
+  });
+
+  it("accepts an uppercase scheme (URL normalizes protocol to lowercase)", () => {
+    expect(sanitizeAuthResult({ url: "HTTPS://example.com/x" })).toEqual({
+      url: "HTTPS://example.com/x",
+    });
+  });
+
+  it("omits a non-string url (number) while keeping the rest", () => {
+    expect(
+      sanitizeAuthResult({ url: 123, instructions: "do this", launched: true }),
+    ).toEqual({ instructions: "do this", launched: true });
+  });
+
+  it("strips unknown fields down to the whitelist even with a valid url", () => {
+    expect(
+      sanitizeAuthResult({
+        url: "https://ok.example/login",
+        instructions: "go",
+        secretToken: "leak",
+        extra: { nested: true },
+      }),
+    ).toEqual({ url: "https://ok.example/login", instructions: "go" });
+  });
+});
+
+describe("normalizePreflightAuth — additional edge cases", () => {
+  it("treats whitespace-padded status as unknown (exact match only)", () => {
+    expect(normalizePreflightAuth({ status: " authenticated " })).toEqual({
+      status: "unknown",
+    });
+  });
+
+  it("treats empty-string status as unknown", () => {
+    expect(normalizePreflightAuth({ status: "" })).toEqual({
+      status: "unknown",
+    });
+  });
+
+  it("round-trips status + all whitelisted display fields", () => {
+    expect(
+      normalizePreflightAuth({
+        status: "authenticated",
+        method: "device-code",
+        detail: "all set",
+        loginHint: "user@host",
+      }),
+    ).toEqual({
+      status: "authenticated",
+      method: "device-code",
+      detail: "all set",
+      loginHint: "user@host",
+    });
+  });
+
+  it("returns {status:'unknown'} for an array input with no status", () => {
+    // typeof [] === "object" so it passes the object guard; no status field.
+    expect(normalizePreflightAuth([])).toEqual({ status: "unknown" });
+  });
+});

--- a/plugins/plugin-task-coordinator/__tests__/unit/PtyConsoleBase.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/PtyConsoleBase.test.tsx
@@ -1,0 +1,442 @@
+// @vitest-environment jsdom
+//
+// DOM/behavioral coverage for the live-terminal coding UX (PtyConsoleBase,
+// src/PtyConsoleBase.tsx). Before this file the PTY console component had ZERO
+// in-plugin unit coverage — the regression surface (WS subscribe/unsubscribe
+// lifecycle, buffered-output hydrate, append-on-pty-output, cross-session
+// filtering, the 200k ring-buffer trim, terminal input/Enter/Send/Ctrl-C wiring,
+// stop-vs-close semantics, the resize(120|96, 32) variant gate, session-switch
+// resubscribe, and the `disposed` guard against setState-after-unmount) was
+// entirely untested. We mock @elizaos/ui exactly like the sibling
+// CodingAgentTasksPanel.test.tsx (the vitest.config alias points @elizaos/ui at
+// real source; vi.mock overrides it) so the component's own behavior is under
+// test. The WS bus is driven deterministically by capturing the handler passed
+// to client.onWsEvent and invoking it directly inside act().
+//
+// OUT OF SCOPE (documented, not tested here): PtyTerminalPane.tsx dynamically
+// imports @xterm/xterm + @xterm/addon-fit, calls term.open() (needs a real
+// canvas/layout) and uses ResizeObserver — none of which are reliably testable
+// in jsdom; covering it would test the mocks, not the code.
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted vi.fn handles for every client method PtyConsoleBase calls.
+const getPtyBufferedOutput = vi.fn();
+const subscribePtyOutput = vi.fn();
+const unsubscribePtyOutput = vi.fn();
+const sendPtyInput = vi.fn();
+const resizePty = vi.fn();
+const stopCodingAgent = vi.fn();
+const onWsEvent = vi.fn();
+
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    getPtyBufferedOutput: (...a: unknown[]) => getPtyBufferedOutput(...a),
+    subscribePtyOutput: (...a: unknown[]) => subscribePtyOutput(...a),
+    unsubscribePtyOutput: (...a: unknown[]) => unsubscribePtyOutput(...a),
+    sendPtyInput: (...a: unknown[]) => sendPtyInput(...a),
+    resizePty: (...a: unknown[]) => resizePty(...a),
+    stopCodingAgent: (...a: unknown[]) => stopCodingAgent(...a),
+    onWsEvent: (...a: unknown[]) => onWsEvent(...a),
+  },
+  // Minimal Button stub rendering a real <button> so the header/footer
+  // aria-label / onClick wiring is exercised through getByLabelText + click.
+  Button: ({
+    children,
+    onClick,
+    title,
+    "aria-label": ariaLabel,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    title?: string;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+// Import the component AFTER the mock (vi.mock is hoisted).
+import { PtyConsoleBase } from "../../src/PtyConsoleBase";
+
+// The CodingAgentSession shape is type-only (erased at runtime). Inlined here so
+// the fixture is self-contained and matches client-types-cloud.ts exactly.
+interface CodingAgentSession {
+  sessionId: string;
+  agentType: string;
+  label: string;
+  originalTask: string;
+  workdir: string;
+  status:
+    | "active"
+    | "blocked"
+    | "completed"
+    | "stopped"
+    | "error"
+    | "tool_running";
+  decisionCount: number;
+  autoResolvedCount: number;
+  toolDescription?: string;
+  lastActivity?: string;
+}
+
+function session(
+  over: Partial<CodingAgentSession> & { sessionId: string },
+): CodingAgentSession {
+  return {
+    agentType: "codex",
+    label: "Term",
+    originalTask: "",
+    workdir: "/repo",
+    status: "active",
+    decisionCount: 0,
+    autoResolvedCount: 0,
+    ...over,
+  };
+}
+
+// Grab the pty-output WS handler the component registered so the test can drive
+// events deterministically.
+function emitPty(): (e: Record<string, unknown>) => void {
+  const call = onWsEvent.mock.calls.find(([type]) => type === "pty-output");
+  if (!call) throw new Error("onWsEvent was not called with 'pty-output'");
+  return call[1] as (e: Record<string, unknown>) => void;
+}
+
+// Read the live terminal text out of the <pre> inside the testid container.
+function preText(): string {
+  const pre = screen.getByTestId("pty-console-base").querySelector("pre");
+  if (!pre) throw new Error("no <pre> in pty-console-base");
+  return pre.textContent ?? "";
+}
+
+// Module-scope unbind spy so cleanup/session-switch can be asserted.
+let unbind: ReturnType<typeof vi.fn>;
+const onClose = vi.fn();
+
+beforeEach(() => {
+  getPtyBufferedOutput.mockReset().mockResolvedValue("");
+  subscribePtyOutput.mockReset();
+  unsubscribePtyOutput.mockReset();
+  sendPtyInput.mockReset();
+  resizePty.mockReset();
+  stopCodingAgent.mockReset().mockResolvedValue(true);
+  unbind = vi.fn();
+  onWsEvent.mockReset().mockReturnValue(unbind);
+  onClose.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderBase(
+  over?: Partial<{
+    activeSessionId: string;
+    sessions: CodingAgentSession[];
+    variant: "drawer" | "side-panel" | "full";
+  }>,
+) {
+  const props = {
+    activeSessionId: "s1",
+    sessions: [
+      session({ sessionId: "s1", label: "Term A", workdir: "/repo/a" }),
+    ],
+    onClose,
+    variant: "drawer" as const,
+    ...over,
+  };
+  return render(<PtyConsoleBase {...props} />);
+}
+
+describe("PtyConsoleBase — mount wiring", () => {
+  it("subscribes, registers the pty-output handler, fetches the buffer, and resizes (drawer => 96x32)", async () => {
+    renderBase();
+
+    await waitFor(() => expect(getPtyBufferedOutput).toHaveBeenCalledTimes(1));
+
+    expect(onWsEvent).toHaveBeenCalledTimes(1);
+    expect(onWsEvent.mock.calls[0][0]).toBe("pty-output");
+    expect(typeof onWsEvent.mock.calls[0][1]).toBe("function");
+
+    expect(subscribePtyOutput).toHaveBeenCalledTimes(1);
+    expect(subscribePtyOutput).toHaveBeenCalledWith("s1");
+    expect(getPtyBufferedOutput).toHaveBeenCalledWith("s1");
+
+    expect(resizePty).toHaveBeenCalledTimes(1);
+    expect(resizePty).toHaveBeenCalledWith("s1", 96, 32);
+  });
+
+  it("resizes to 120x32 for variant=full", async () => {
+    renderBase({ variant: "full" });
+    await waitFor(() => expect(resizePty).toHaveBeenCalledTimes(1));
+    expect(resizePty).toHaveBeenCalledWith("s1", 120, 32);
+  });
+});
+
+describe("PtyConsoleBase — output rendering", () => {
+  it("shows the 'Connecting to terminal' placeholder when the buffer is empty", async () => {
+    getPtyBufferedOutput.mockResolvedValue("");
+    renderBase();
+    await waitFor(() => expect(getPtyBufferedOutput).toHaveBeenCalled());
+    expect(preText()).toContain("Connecting to terminal");
+  });
+
+  it("hydrates the <pre> from the buffered output", async () => {
+    getPtyBufferedOutput.mockResolvedValue("hello-buffered-output");
+    renderBase();
+    await screen.findByText("hello-buffered-output");
+    expect(preText()).toBe("hello-buffered-output");
+  });
+
+  it("appends pty-output events in order", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+    const emit = emitPty();
+
+    act(() => emit({ sessionId: "s1", data: "line-1\n" }));
+    await waitFor(() => expect(preText()).toContain("line-1"));
+
+    act(() => emit({ sessionId: "s1", data: "line-2\n" }));
+    await waitFor(() => expect(preText()).toContain("line-2"));
+
+    // Concatenation order preserved: line-1 precedes line-2.
+    const text = preText();
+    expect(text.indexOf("line-1")).toBeLessThan(text.indexOf("line-2"));
+    expect(text).toBe("line-1\nline-2\n");
+  });
+
+  it("ignores events for other sessions and events with no data", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+    const emit = emitPty();
+
+    act(() => emit({ sessionId: "s2", data: "should-not-appear" }));
+    act(() => emit({ sessionId: "s1" })); // no data field => ignored
+
+    // Still showing the placeholder, no foreign data leaked in.
+    expect(preText()).not.toContain("should-not-appear");
+    expect(preText()).toContain("Connecting to terminal");
+  });
+
+  it("caps the buffer at MAX_BUFFER_CHARS (200k) keeping the tail", async () => {
+    getPtyBufferedOutput.mockResolvedValue("X".repeat(199_990));
+    renderBase();
+    await waitFor(() =>
+      expect(preText().length).toBeGreaterThanOrEqual(199_990),
+    );
+    const emit = emitPty();
+
+    act(() => emit({ sessionId: "s1", data: "Y".repeat(50) }));
+
+    await waitFor(() => expect(preText().endsWith("Y".repeat(50))).toBe(true));
+    const text = preText();
+    expect(text.length).toBe(200_000); // 199_990 + 50 = 200_040 trimmed to 200_000
+    expect(text.startsWith("X")).toBe(true); // head retained up to the cap
+    expect(text.endsWith("Y".repeat(50))).toBe(true); // tail kept, head trimmed
+  });
+});
+
+describe("PtyConsoleBase — terminal input", () => {
+  it("sends the line + newline on Enter and clears the input", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    const input = screen.getByLabelText("Terminal input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ls -la" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(sendPtyInput).toHaveBeenCalledTimes(1);
+    expect(sendPtyInput).toHaveBeenCalledWith("s1", "ls -la\n");
+    expect(input.value).toBe("");
+  });
+
+  it("does not send on a non-Enter key", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    const input = screen.getByLabelText("Terminal input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ls" } });
+    fireEvent.keyDown(input, { key: "a" });
+
+    expect(sendPtyInput).not.toHaveBeenCalled();
+  });
+
+  it("sends via the Send button", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    const input = screen.getByLabelText("Terminal input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "echo hi" } });
+    fireEvent.click(screen.getByLabelText("Send terminal input"));
+
+    expect(sendPtyInput).toHaveBeenCalledWith("s1", "echo hi\n");
+    expect(input.value).toBe("");
+  });
+
+  it("sends a bare newline for an empty line (only truly-empty data is dropped)", async () => {
+    // sendInput's `if (!data) return` blocks "" but "\n" is truthy, so an
+    // empty input + Enter still pushes a newline to the PTY.
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    const input = screen.getByLabelText("Terminal input");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(sendPtyInput).toHaveBeenCalledTimes(1);
+    expect(sendPtyInput).toHaveBeenCalledWith("s1", "\n");
+  });
+
+  it("sends the Ctrl-C (ETX) byte from the Interrupt button", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("Interrupt terminal"));
+    expect(sendPtyInput).toHaveBeenCalledWith("s1", "");
+  });
+});
+
+describe("PtyConsoleBase — stop vs close", () => {
+  it("stops the coding agent from the Stop button", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("Stop terminal session"));
+    expect(stopCodingAgent).toHaveBeenCalledTimes(1);
+    expect(stopCodingAgent).toHaveBeenCalledWith("s1");
+  });
+
+  it("calls onClose (and NOT stopCodingAgent) from the Close button", async () => {
+    renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("Close terminal"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(stopCodingAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("PtyConsoleBase — lifecycle", () => {
+  it("unbinds the WS handler and unsubscribes on unmount", async () => {
+    const result = renderBase();
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    result.unmount();
+
+    expect(unbind).toHaveBeenCalledTimes(1);
+    expect(unsubscribePtyOutput).toHaveBeenCalledTimes(1);
+    expect(unsubscribePtyOutput).toHaveBeenCalledWith("s1");
+  });
+
+  it("resubscribes on session switch and resets the output", async () => {
+    getPtyBufferedOutput.mockImplementation((id: string) =>
+      Promise.resolve(id === "s1" ? "s1-buffer" : "s2-buffer"),
+    );
+    const sessions = [
+      session({ sessionId: "s1", label: "Term A", workdir: "/repo/a" }),
+      session({ sessionId: "s2", label: "Term B", workdir: "/repo/b" }),
+    ];
+    const result = renderBase({ activeSessionId: "s1", sessions });
+    await screen.findByText("s1-buffer");
+
+    result.rerender(
+      <PtyConsoleBase
+        activeSessionId="s2"
+        sessions={sessions}
+        onClose={onClose}
+        variant="drawer"
+      />,
+    );
+
+    // Old session torn down.
+    expect(unbind).toHaveBeenCalledTimes(1);
+    expect(unsubscribePtyOutput).toHaveBeenCalledWith("s1");
+
+    // New session wired: fresh handler registration + subscribe + buffer fetch.
+    await waitFor(() => expect(onWsEvent.mock.calls.length).toBe(2));
+    expect(subscribePtyOutput).toHaveBeenCalledWith("s2");
+    expect(getPtyBufferedOutput).toHaveBeenCalledWith("s2");
+
+    // Output reset then re-hydrated from s2's buffer.
+    await screen.findByText("s2-buffer");
+    expect(preText()).toBe("s2-buffer");
+  });
+
+  it("does not setState after unmount when the buffer resolves late (disposed guard)", async () => {
+    let resolveBuf!: (v: string) => void;
+    getPtyBufferedOutput.mockReturnValue(
+      new Promise<string>((r) => {
+        resolveBuf = r;
+      }),
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = renderBase();
+    await waitFor(() => expect(getPtyBufferedOutput).toHaveBeenCalled());
+
+    // Unmount BEFORE the buffered output resolves.
+    result.unmount();
+    await act(async () => {
+      resolveBuf("late-data");
+      await Promise.resolve();
+    });
+
+    // No React "state update on an unmounted component" warning was emitted.
+    const warned = errorSpy.mock.calls.some((args) =>
+      args.some(
+        (a) =>
+          typeof a === "string" &&
+          a.includes("unmounted") &&
+          a.includes("state update"),
+      ),
+    );
+    expect(warned).toBe(false);
+    // The late data never made it into a (now-removed) <pre>.
+    expect(document.body.textContent).not.toContain("late-data");
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe("PtyConsoleBase — header label / workdir", () => {
+  it("renders the active session label and workdir", async () => {
+    renderBase({
+      activeSessionId: "s1",
+      sessions: [
+        session({ sessionId: "s1", label: "Term A", workdir: "/repo/a" }),
+      ],
+    });
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    expect(screen.getByText("Term A")).toBeTruthy();
+    expect(screen.getByText("/repo/a")).toBeTruthy();
+  });
+
+  it("falls back to 'Terminal' + the activeSessionId when the session is unknown", async () => {
+    renderBase({
+      activeSessionId: "ghost",
+      sessions: [
+        session({ sessionId: "s1", label: "Term A", workdir: "/repo/a" }),
+      ],
+    });
+    await waitFor(() => expect(onWsEvent).toHaveBeenCalled());
+
+    expect(screen.getByText("Terminal")).toBeTruthy();
+    expect(screen.getByText("ghost")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What this is

**Wave 3 coverage for the coding capability** — ~76 new deterministic tests + 1 scenario across the surfaces the audit flagged as untested. Stacked on #8945 (the new finalChecks the create-app scenario uses).

| File | Closes | Tests |
|---|---|---|
| `PtyConsoleBase.test.tsx` | live terminal coding UX (was zero-coverage) | 19 |
| `CodingAgentSettingsSection.test.tsx` | per-framework settings + GitHub card + auth helpers | 26 |
| `views-routes.bundle.test.ts` | Domain H — view-bundle ETag/cache-bust on reload | 5 |
| `load-plugin-from-directory-reload.test.ts` | Domain H — edit→rebuild→reload serves v2 | 8 |
| `native-notifications.orchestrator.test.ts` | Domain K — coding-task notification fan-out (desktop + Capacitor, `/orchestrator` deep link) | 14 |
| `acp-concurrent-spawn-stress.test.ts` | Domain L — N concurrent spawns, cap + distinct workdirs + terminal states | 4 |
| `deterministic-create-app-coding.scenario.ts` | exercises `subAgentSpawned`/`fileMutationOccurred`/`buildValidation` | scenario |

## Evidence (independently re-run against a freshly-built worktree)

- `plugin-task-coordinator`: **45 passed** (PtyConsoleBase 19 + CodingAgentSettingsSection 26)
- `agent`: **13 passed** (views-routes bundle + load-plugin reload)
- `ui`: **14 passed** (orchestrator notification fan-out)
- `plugin-agent-orchestrator`: **684 passed** (full unit suite incl. the concurrency stress)
- create-app scenario: loads via `eliza-scenarios list`; structurally validated (full proxy run is gated by an unrelated CLI react-types resolution quirk — CI's scenario lane runs it)
- biome clean on all 7 files

All deterministic — no live model/network/device; fake timers, mocked services/Capacitor, temp dirs. Per `PR_EVIDENCE.md`, unit-test output is the right proof for these; live trajectories/screenshots/video are the consuming-scenario evidence (Wave 2).

Relates to the coding-capability audit (#8941) and the new finalChecks (#8945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
