### PR TITLE
feat(core): per-channel topic LRU — Stage-1 topics extract, ChannelTopicsService, CHANNEL_TOPICS provider

### DIFF
--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -81,6 +81,12 @@ export const HANDLE_RESPONSE_SCHEMA: JSONSchema = {
 			},
 			description: "Durable subject-predicate-object relationships.",
 		},
+		topics: {
+			type: "array",
+			items: { type: "string" },
+			description:
+				"Short topic labels for this message. Lowercase nouns/noun-phrases. Max 5.",
+		},
 		addressedTo: {
 			type: "array",
 			items: { type: "string" },
@@ -110,6 +116,7 @@ export const HANDLE_RESPONSE_SCHEMA: JSONSchema = {
 		"candidateActionNames",
 		"facts",
 		"relationships",
+		"topics",
 		"addressedTo",
 		"emotion",
 	],
@@ -134,7 +141,7 @@ export function assertNativeToolName(name: string): void {
 }
 
 const HANDLE_RESPONSE_DESCRIPTION =
-	"Stage 1: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, addressedTo, emotion. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";
+	"Stage 1: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, topics, addressedTo, emotion. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";
 
 const HANDLE_RESPONSE_DIRECT_DESCRIPTION =
 	"Stage 1 direct-message: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, addressedTo, emotion. Usually RESPOND unless explicit stop. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -19,6 +19,7 @@ import {
 	postCreationTemplate,
 } from "../../prompts.ts";
 import { TURN_CONTROL_ROUTES } from "../../runtime/turn-routes";
+import { ChannelTopicsService } from "../../services/channel-topics.ts";
 import { EmbeddingGenerationService } from "../../services/embedding.ts";
 import { EvaluatorService } from "../../services/evaluator.ts";
 import { OptimizedPromptService } from "../../services/optimized-prompt.ts";
@@ -117,6 +118,7 @@ import { linkExtractionEvaluator } from "./evaluators/link-extraction.ts";
 import { actionStateProvider } from "./providers/actionState.ts";
 import { actionsProvider } from "./providers/actions.ts";
 import { attachmentsProvider } from "./providers/attachments.ts";
+import { channelTopicsProvider } from "./providers/channelTopics.ts";
 import { characterProvider } from "./providers/character.ts";
 import { choiceProvider } from "./providers/choice.ts";
 import { contextBenchProvider } from "./providers/contextBench.ts";
@@ -1232,6 +1234,7 @@ export const basicProviders = [
 	actionsProvider,
 	actionStateProvider,
 	attachmentsProvider,
+	channelTopicsProvider,
 	characterProvider,
 	choiceProvider,
 	contextBenchProvider,
@@ -1288,6 +1291,9 @@ export const basicServices: ServiceClass[] = [
 	// in-memory cache; registering it on every runtime so the planner-loop
 	// can pick up artifacts produced by `bun run train -- --backend native`.
 	OptimizedPromptService,
+	// Per-channel topic LRU. Records Stage-1-extracted topics per room and
+	// surfaces them back into routing via the CHANNEL_TOPICS provider.
+	ChannelTopicsService,
 ];
 
 /**
@@ -1422,6 +1428,7 @@ export function createBasicCapabilitiesPlugin(
 			await runtime.getService(EmbeddingGenerationService.serviceType)?.stop();
 			await runtime.getService(EvaluatorService.serviceType)?.stop();
 			await runtime.getService(OptimizedPromptService.serviceType)?.stop();
+			await runtime.getService(ChannelTopicsService.serviceType)?.stop();
 			if (config.enableAutonomy) {
 				await runtime.getService(AutonomyService.serviceType)?.stop();
 			}

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelTopicsService } from "../../../services/channel-topics";
+import type {
+	IAgentRuntime,
+	Memory,
+	Room,
+	State,
+	UUID,
+} from "../../../types/index";
+import { channelTopicsProvider } from "./channelTopics";
+
+const ROOM = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+function makeRoom(): Room {
+	return { id: ROOM, source: "test", type: "GROUP" as Room["type"] };
+}
+
+async function makeRuntimeWithService(): Promise<{
+	runtime: IAgentRuntime;
+	service: ChannelTopicsService;
+}> {
+	const rooms = new Map<UUID, Room>([[ROOM, makeRoom()]]);
+	const serviceRuntime = {
+		getRoom: vi.fn(async (id: UUID) => rooms.get(id) ?? null),
+		updateRoom: vi.fn(async (room: Room) => {
+			rooms.set(room.id, room);
+		}),
+	} as unknown as IAgentRuntime;
+	const service = await ChannelTopicsService.start(serviceRuntime);
+	const runtime = {
+		getService: vi.fn((type: string) =>
+			type === ChannelTopicsService.serviceType ? service : null,
+		),
+	} as unknown as IAgentRuntime;
+	return { runtime, service };
+}
+
+function makeMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000ff" as UUID,
+		entityId: "00000000-0000-0000-0000-0000000000ee" as UUID,
+		roomId: ROOM,
+		content: { text: "hi" },
+	} as Memory;
+}
+
+const EMPTY_STATE = {} as State;
+
+describe("CHANNEL_TOPICS provider", () => {
+	let runtime: IAgentRuntime;
+	let service: ChannelTopicsService;
+
+	beforeEach(async () => {
+		({ runtime, service } = await makeRuntimeWithService());
+	});
+
+	it("declares the Stage-1 routing scope", () => {
+		expect(channelTopicsProvider.name).toBe("CHANNEL_TOPICS");
+		expect(channelTopicsProvider.alwaysInResponseState).toBe(true);
+		expect(channelTopicsProvider.contexts).toContain("general");
+	});
+
+	it("renders the current LRU, most-recent first", async () => {
+		await service.recordTopics(ROOM, ["billing", "auth", "vacation"]);
+		const result = await channelTopicsProvider.get(
+			runtime,
+			makeMessage(),
+			EMPTY_STATE,
+		);
+		expect(result.text).toBe(
+			"# Current topics in this channel: vacation, auth, billing",
+		);
+		expect(result.data?.topics).toEqual(["vacation", "auth", "billing"]);
+		expect(result.values?.channelTopics).toBe("vacation, auth, billing");
+	});
+
+	it("no-ops (empty result) when the room has no topics", async () => {
+		const result = await channelTopicsProvider.get(
+			runtime,
+			makeMessage(),
+			EMPTY_STATE,
+		);
+		expect(result.text).toBe("");
+		expect(result.values).toEqual({});
+		expect(result.data).toEqual({});
+	});
+
+	it("no-ops when the service is not registered", async () => {
+		const noService = {
+			getService: vi.fn(() => null),
+		} as unknown as IAgentRuntime;
+		const result = await channelTopicsProvider.get(
+			noService,
+			makeMessage(),
+			EMPTY_STATE,
+		);
+		expect(result.text).toBe("");
+	});
+
+	it("reflects persisted topics via service hydration (post-restart)", async () => {
+		// Fresh service over a runtime whose room already carries persisted topics.
+		const rooms = new Map<UUID, Room>([
+			[
+				ROOM,
+				{
+					id: ROOM,
+					source: "test",
+					type: "GROUP" as Room["type"],
+					metadata: { currentTopics: ["persisted"] },
+				},
+			],
+		]);
+		const svcRuntime = {
+			getRoom: vi.fn(async (id: UUID) => rooms.get(id) ?? null),
+			updateRoom: vi.fn(),
+		} as unknown as IAgentRuntime;
+		const freshService = await ChannelTopicsService.start(svcRuntime);
+		const providerRuntime = {
+			getService: vi.fn(() => freshService),
+		} as unknown as IAgentRuntime;
+
+		const result = await channelTopicsProvider.get(
+			providerRuntime,
+			makeMessage(),
+			EMPTY_STATE,
+		);
+		expect(result.text).toBe("# Current topics in this channel: persisted");
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.ts
@@ -1,0 +1,71 @@
+/**
+ * CHANNEL_TOPICS — turn-scoped provider that surfaces the current channel's
+ * topic LRU (maintained by `ChannelTopicsService`) back into Stage-1 routing.
+ *
+ * Renders `# Current topics in this channel: <comma-list>` when the room has
+ * any recorded topics, and a no-op empty result otherwise. Opting into
+ * `alwaysInResponseState` puts it into the Stage-1 response state (alongside
+ * FACTS / CURRENT_TIME) so shouldRespond / the planner can weigh topic
+ * relevance even on the simple direct-reply path.
+ *
+ * Read-only: the provider never records topics — that happens post-parse in the
+ * message handler. It just reflects what the service already holds (hydrating
+ * from room metadata on a cold cache after restart).
+ */
+
+import { ChannelTopicsService } from "../../../services/channel-topics.ts";
+import type {
+	IAgentRuntime,
+	Memory,
+	Provider,
+	State,
+} from "../../../types/index.ts";
+
+const EMPTY_RESULT = { text: "", values: {}, data: {} } as const;
+
+export const channelTopicsProvider: Provider = {
+	name: "CHANNEL_TOPICS",
+	description:
+		"Recent topic labels for this channel (LRU). Hint for routing/relevance; never gates action selection.",
+	dynamic: true,
+	position: -4,
+	contexts: ["general"],
+	contextGate: { anyOf: ["general"] },
+	cacheStable: false,
+	cacheScope: "turn",
+	// Reach Stage-1 response state regardless of selected contexts, like
+	// FACTS / CURRENT_TIME, so shouldRespond can weigh topic relevance.
+	alwaysInResponseState: true,
+	roleGate: { minRole: "USER" },
+
+	get: async (runtime: IAgentRuntime, message: Memory, _state: State) => {
+		const service = runtime.getService<ChannelTopicsService>(
+			ChannelTopicsService.serviceType,
+		);
+		if (!service) {
+			return { ...EMPTY_RESULT };
+		}
+		const roomId = message.roomId;
+		if (!roomId) {
+			return { ...EMPTY_RESULT };
+		}
+		let topics: string[] = [];
+		try {
+			topics = await service.ensureHydrated(roomId);
+		} catch {
+			// Read path is best-effort: a hydration failure just yields no topics.
+			return { ...EMPTY_RESULT };
+		}
+		if (topics.length === 0) {
+			return { ...EMPTY_RESULT };
+		}
+		// Most-recent last in the LRU; show most-recent first for readability.
+		const ordered = [...topics].reverse();
+		const text = `# Current topics in this channel: ${ordered.join(", ")}`;
+		return {
+			text,
+			values: { channelTopics: ordered.join(", ") },
+			data: { topics: ordered },
+		};
+	},
+};

--- a/packages/core/src/features/basic-capabilities/providers/index.ts
+++ b/packages/core/src/features/basic-capabilities/providers/index.ts
@@ -7,6 +7,7 @@
 export { actionStateProvider } from "./actionState.ts";
 export { actionsProvider } from "./actions.ts";
 export { attachmentsProvider } from "./attachments.ts";
+export { channelTopicsProvider } from "./channelTopics.ts";
 export { characterProvider } from "./character.ts";
 export { choiceProvider } from "./choice.ts";
 export { contextBenchProvider } from "./contextBench.ts";
@@ -33,6 +34,7 @@ export { worldProvider } from "./world.ts";
 import { actionStateProvider as _bs_1_actionStateProvider } from "./actionState.ts";
 import { actionsProvider as _bs_2_actionsProvider } from "./actions.ts";
 import { attachmentsProvider as _bs_3_attachmentsProvider } from "./attachments.ts";
+import { channelTopicsProvider as _bs_19_channelTopicsProvider } from "./channelTopics.ts";
 import { characterProvider as _bs_4_characterProvider } from "./character.ts";
 import { choiceProvider as _bs_5_choiceProvider } from "./choice.ts";
 import { contextBenchProvider as _bs_6_contextBenchProvider } from "./contextBench.ts";
@@ -72,6 +74,7 @@ const __bundle_safety_FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX__ = [
 	_bs_16_worldProvider,
 	_bs_17_userEmotionSignalProvider,
 	_bs_18_runtimeModelContextProvider,
+	_bs_19_channelTopicsProvider,
 ];
 (
 	globalThis as Record<string, unknown>

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -259,6 +259,7 @@ export * from "./sensitive-requests";
 export * from "./services";
 export * from "./services/agentEvent";
 export * from "./services/approval";
+export * from "./services/channel-topics";
 export * from "./services/evaluator";
 export * from "./services/evaluator-priorities";
 export * from "./services/hook";

--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -114,6 +114,7 @@ describe("message handler retrieval hint output", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);
@@ -125,6 +126,7 @@ describe("message handler retrieval hint output", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);
@@ -146,6 +148,7 @@ describe("message handler retrieval hint output", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);
@@ -157,6 +160,7 @@ describe("message handler retrieval hint output", () => {
 			candidateActionNames: { type: "array" },
 			facts: { type: "array" },
 			relationships: { type: "array" },
+			topics: { type: "array" },
 			addressedTo: { type: "array" },
 			emotion: { type: "string" },
 		});

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -196,6 +196,7 @@ describe("v5 message handler routing", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);
@@ -207,6 +208,7 @@ describe("v5 message handler routing", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);

--- a/packages/core/src/runtime/__tests__/response-grammar.test.ts
+++ b/packages/core/src/runtime/__tests__/response-grammar.test.ts
@@ -76,6 +76,7 @@ describe("buildResponseGrammar — Stage-1 envelope", () => {
 			"candidateActionNames",
 			"facts",
 			"relationships",
+			"topics",
 			"addressedTo",
 			"emotion",
 		]);
@@ -115,6 +116,7 @@ describe("buildResponseGrammar — Stage-1 envelope", () => {
 		expect(responseSkeleton.spans.some((s) => s.key === "relationships")).toBe(
 			false,
 		);
+		expect(responseSkeleton.spans.some((s) => s.key === "topics")).toBe(false);
 		expect(responseSkeleton.spans.some((s) => s.key === "addressedTo")).toBe(
 			false,
 		);

--- a/packages/core/src/runtime/__tests__/topics-field-evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/topics-field-evaluator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+	MAX_MESSAGE_TOPICS,
+	MAX_TOPIC_LABEL_LENGTH,
+	normalizeTopics,
+	topicsFieldEvaluator,
+} from "../builtin-field-evaluators";
+import { parseMessageHandlerOutput } from "../message-handler";
+
+describe("topicsFieldEvaluator.parse / normalizeTopics", () => {
+	it("lowercases, trims, and collapses internal whitespace", () => {
+		expect(
+			topicsFieldEvaluator.parse?.(["  Billing  ", "Auth   Bug"], undefined),
+		).toEqual(["billing", "auth bug"]);
+	});
+
+	it("dedupes case-insensitively, preserving first occurrence order", () => {
+		expect(normalizeTopics(["Billing", "billing", "BILLING", "auth"])).toEqual([
+			"billing",
+			"auth",
+		]);
+	});
+
+	it("drops empty / whitespace-only entries", () => {
+		expect(normalizeTopics(["", "   ", "vacation", "\t"])).toEqual([
+			"vacation",
+		]);
+	});
+
+	it("drops overlong labels (sentences, not topic labels)", () => {
+		const overlong = "x".repeat(MAX_TOPIC_LABEL_LENGTH + 1);
+		const atLimit = "y".repeat(MAX_TOPIC_LABEL_LENGTH);
+		expect(normalizeTopics([overlong, atLimit, "ok"])).toEqual([atLimit, "ok"]);
+	});
+
+	it(`caps the list at ${MAX_MESSAGE_TOPICS} topics`, () => {
+		const many = ["a", "b", "c", "d", "e", "f", "g"];
+		expect(normalizeTopics(many)).toEqual(["a", "b", "c", "d", "e"]);
+		expect(normalizeTopics(many).length).toBe(MAX_MESSAGE_TOPICS);
+	});
+
+	it("coerces non-string scalars then re-applies the rules", () => {
+		// Defensive: a model may emit numbers; String() + trim still yields a label.
+		expect(normalizeTopics([1, "auth", 1])).toEqual(["1", "auth"]);
+	});
+
+	it("returns an empty array for non-array / absent input", () => {
+		expect(normalizeTopics(undefined)).toEqual([]);
+		expect(normalizeTopics(null)).toEqual([]);
+		expect(normalizeTopics("billing")).toEqual([]);
+		expect(normalizeTopics({ topic: "billing" })).toEqual([]);
+		expect(topicsFieldEvaluator.parse?.(undefined, undefined)).toEqual([]);
+	});
+});
+
+describe("parseMessageHandlerOutput — topics threading", () => {
+	it("carries normalized topics through extract", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Sure.",
+				contexts: ["simple"],
+				topics: ["  Billing ", "billing", "Auth Bug"],
+			}),
+		);
+		expect(parsed?.extract?.topics).toEqual(["billing", "auth bug"]);
+	});
+
+	it("omits topics from extract when none are present (backward compatible)", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Sure.",
+				contexts: ["simple"],
+			}),
+		);
+		expect(parsed?.extract).toBeUndefined();
+	});
+
+	it("does not build an extract when topics is the only (empty) field", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Sure.",
+				contexts: ["simple"],
+				topics: ["", "   "],
+			}),
+		);
+		expect(parsed?.extract).toBeUndefined();
+	});
+
+	it("keeps topics alongside facts/relationships/addressedTo in extract", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "",
+				contexts: ["general"],
+				facts: ["user lives in Brooklyn"],
+				topics: ["moving", "Brooklyn"],
+			}),
+		);
+		expect(parsed?.extract?.facts).toEqual(["user lives in Brooklyn"]);
+		expect(parsed?.extract?.topics).toEqual(["moving", "brooklyn"]);
+	});
+});

--- a/packages/core/src/runtime/builtin-field-evaluators.ts
+++ b/packages/core/src/runtime/builtin-field-evaluators.ts
@@ -304,6 +304,61 @@ export const relationshipsFieldEvaluator: ResponseHandlerFieldEvaluator<
 };
 
 // ---------------------------------------------------------------------------
+// topics — priority 88. Per-channel topic LRU (extract pipeline).
+//
+// Emits 1-5 SHORT topic labels for THIS message. Normalized: lowercase,
+// trimmed, deduped, empties/overlong dropped, capped at 5. Recorded into
+// `ChannelTopicsService` per-room after Stage-1 parse and surfaced back into
+// routing via the `CHANNEL_TOPICS` provider so shouldRespond/the planner can
+// weigh topic relevance.
+// ---------------------------------------------------------------------------
+
+/** Max topic labels kept per turn. */
+export const MAX_MESSAGE_TOPICS = 5;
+/** Drop topic labels longer than this (a topic label, not a sentence). */
+export const MAX_TOPIC_LABEL_LENGTH = 40;
+
+/**
+ * Normalize a raw list of topic candidates into 1-5 SHORT labels: lowercase,
+ * trimmed, deduped, empties/overlong dropped, capped at {@link MAX_MESSAGE_TOPICS}.
+ * Shared by the field evaluator and the message-handler parse path so both
+ * apply identical rules.
+ */
+export function normalizeTopics(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const item of value) {
+		const normalized = String(item ?? "")
+			.trim()
+			.toLowerCase()
+			.replace(/\s+/g, " ");
+		if (!normalized || normalized.length > MAX_TOPIC_LABEL_LENGTH) continue;
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(normalized);
+		if (result.length >= MAX_MESSAGE_TOPICS) break;
+	}
+	return result;
+}
+
+export const topicsFieldEvaluator: ResponseHandlerFieldEvaluator<string[]> = {
+	name: "topics",
+	description:
+		'1-5 SHORT topic labels for this message (lowercase nouns/noun-phrases): ["billing", "auth bug", "vacation plans"]. NOT verbs/sentences. Tracks what this channel is about over time. Empty when no salient topic.',
+	priority: 88,
+	schema: {
+		type: "array",
+		items: { type: "string" },
+		description:
+			"Short topic labels. Lowercase. 1-3 words each. Nouns/noun-phrases, not verbs. Max 5.",
+	},
+	parse(value) {
+		return normalizeTopics(value);
+	},
+};
+
+// ---------------------------------------------------------------------------
 // addressedTo — priority 90. Memory pipeline.
 // ---------------------------------------------------------------------------
 
@@ -390,6 +445,7 @@ export const BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS: ReadonlyArray<ResponseHa
 		candidateActionNamesFieldEvaluator,
 		factsFieldEvaluator,
 		relationshipsFieldEvaluator,
+		topicsFieldEvaluator,
 		addressedToFieldEvaluator,
 		emotionFieldEvaluator,
 	];

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -5,6 +5,7 @@ import type {
 	MessageHandlerResult,
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
+import { normalizeTopics } from "./builtin-field-evaluators";
 import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
 import {
 	looksLikeNonRefusalStage1HonestyViolation,
@@ -174,10 +175,12 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 				.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
 				.filter((entry): entry is string => entry.length > 0)
 		: [];
+	const topics = normalizeTopics(source.topics);
 	if (
 		facts.length === 0 &&
 		relationships.length === 0 &&
-		addressedTo.length === 0
+		addressedTo.length === 0 &&
+		topics.length === 0
 	) {
 		return undefined;
 	}
@@ -185,6 +188,7 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 	if (facts.length > 0) result.facts = facts;
 	if (relationships.length > 0) result.relationships = relationships;
 	if (addressedTo.length > 0) result.addressedTo = addressedTo;
+	if (topics.length > 0) result.topics = topics;
 	return result;
 }
 

--- a/packages/core/src/runtime/response-grammar.ts
+++ b/packages/core/src/runtime/response-grammar.ts
@@ -714,6 +714,7 @@ const DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS = new Set([
 	"shouldRespond",
 	"facts",
 	"relationships",
+	"topics",
 	"addressedTo",
 	"emotion",
 ]);

--- a/packages/core/src/services/__tests__/channel-topics.test.ts
+++ b/packages/core/src/services/__tests__/channel-topics.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Room, UUID } from "../../types/index";
+import type { IAgentRuntime } from "../../types/runtime";
+import {
+	CHANNEL_TOPICS_LRU_CAPACITY,
+	CHANNEL_TOPICS_METADATA_KEY,
+	ChannelTopicsService,
+} from "../channel-topics";
+
+const ROOM_A = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const ROOM_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
+
+interface MockRuntime {
+	runtime: IAgentRuntime;
+	rooms: Map<UUID, Room>;
+	getRoom: ReturnType<typeof vi.fn>;
+	updateRoom: ReturnType<typeof vi.fn>;
+}
+
+function makeRuntime(seed?: Partial<Record<UUID, Room>>): MockRuntime {
+	const rooms = new Map<UUID, Room>();
+	for (const [id, room] of Object.entries(seed ?? {})) {
+		if (room) rooms.set(id as UUID, room);
+	}
+	const getRoom = vi.fn(async (roomId: UUID) => rooms.get(roomId) ?? null);
+	const updateRoom = vi.fn(async (room: Room) => {
+		rooms.set(room.id, room);
+	});
+	const runtime = { getRoom, updateRoom } as unknown as IAgentRuntime;
+	return { runtime, rooms, getRoom, updateRoom };
+}
+
+function makeRoom(id: UUID, currentTopics?: string[]): Room {
+	return {
+		id,
+		source: "test",
+		type: "GROUP" as Room["type"],
+		...(currentTopics
+			? { metadata: { [CHANNEL_TOPICS_METADATA_KEY]: currentTopics } }
+			: {}),
+	};
+}
+
+describe("ChannelTopicsService", () => {
+	let mock: MockRuntime;
+	let service: ChannelTopicsService;
+
+	beforeEach(async () => {
+		mock = makeRuntime({
+			[ROOM_A]: makeRoom(ROOM_A),
+			[ROOM_B]: makeRoom(ROOM_B),
+		});
+		service = await ChannelTopicsService.start(mock.runtime);
+	});
+
+	it("records topics most-recent-last and returns a defensive copy", async () => {
+		await service.recordTopics(ROOM_A, ["billing", "auth"]);
+		const got = service.getTopicsForRoom(ROOM_A);
+		expect(got).toEqual(["billing", "auth"]);
+		// Mutating the returned array must not corrupt internal state.
+		got.push("mutated");
+		expect(service.getTopicsForRoom(ROOM_A)).toEqual(["billing", "auth"]);
+	});
+
+	it("dedupes on insert and refreshes recency (move-to-most-recent)", async () => {
+		await service.recordTopics(ROOM_A, ["a", "b", "c"]);
+		await service.recordTopics(ROOM_A, ["b"]);
+		// 'b' moves to the end; no duplicate.
+		expect(service.getTopicsForRoom(ROOM_A)).toEqual(["a", "c", "b"]);
+	});
+
+	it("caps the LRU and FIFO-evicts the oldest entries", async () => {
+		const overCapacityCount = CHANNEL_TOPICS_LRU_CAPACITY + 5;
+		const topics = Array.from({ length: overCapacityCount }, (_, i) => `t${i}`);
+		await service.recordTopics(ROOM_A, topics);
+		const got = service.getTopicsForRoom(ROOM_A);
+		expect(got.length).toBe(CHANNEL_TOPICS_LRU_CAPACITY);
+		// Oldest 5 (t0..t4) evicted; the most-recent capacity slots remain.
+		expect(got[0]).toBe(`t${overCapacityCount - CHANNEL_TOPICS_LRU_CAPACITY}`);
+		expect(got.at(-1)).toBe(`t${overCapacityCount - 1}`);
+	});
+
+	it("FIFO-evicts across multiple recordTopics calls", async () => {
+		for (let i = 0; i < CHANNEL_TOPICS_LRU_CAPACITY; i++) {
+			await service.recordTopics(ROOM_A, [`t${i}`]);
+		}
+		// One more distinct topic evicts the oldest (t0).
+		await service.recordTopics(ROOM_A, ["newest"]);
+		const got = service.getTopicsForRoom(ROOM_A);
+		expect(got.length).toBe(CHANNEL_TOPICS_LRU_CAPACITY);
+		expect(got).not.toContain("t0");
+		expect(got).toContain("t1");
+		expect(got.at(-1)).toBe("newest");
+	});
+
+	it("persists the LRU to room.metadata.currentTopics via updateRoom", async () => {
+		await service.recordTopics(ROOM_A, ["billing", "auth"]);
+		expect(mock.updateRoom).toHaveBeenCalledTimes(1);
+		const persisted = mock.rooms.get(ROOM_A);
+		expect(persisted?.metadata?.[CHANNEL_TOPICS_METADATA_KEY]).toEqual([
+			"billing",
+			"auth",
+		]);
+	});
+
+	it("hydrates from room metadata on first access (survives restart)", async () => {
+		// Simulate a restart: a fresh service over a runtime whose room already
+		// has persisted topics.
+		const restarted = makeRuntime({
+			[ROOM_A]: makeRoom(ROOM_A, ["persisted-one", "persisted-two"]),
+		});
+		const fresh = await ChannelTopicsService.start(restarted.runtime);
+
+		// ensureHydrated pulls metadata into the cache.
+		const hydrated = await fresh.ensureHydrated(ROOM_A);
+		expect(hydrated).toEqual(["persisted-one", "persisted-two"]);
+
+		// A subsequent record appends onto the hydrated list (no data loss).
+		await fresh.recordTopics(ROOM_A, ["new-topic"]);
+		expect(fresh.getTopicsForRoom(ROOM_A)).toEqual([
+			"persisted-one",
+			"persisted-two",
+			"new-topic",
+		]);
+	});
+
+	it("treats each room independently", async () => {
+		await service.recordTopics(ROOM_A, ["alpha"]);
+		await service.recordTopics(ROOM_B, ["beta", "gamma"]);
+		expect(service.getTopicsForRoom(ROOM_A)).toEqual(["alpha"]);
+		expect(service.getTopicsForRoom(ROOM_B)).toEqual(["beta", "gamma"]);
+		expect(service.getTopicsForAllRooms()).toEqual({
+			[ROOM_A]: ["alpha"],
+			[ROOM_B]: ["beta", "gamma"],
+		});
+	});
+
+	it("is a no-op for empty/invalid topic input and does not persist", async () => {
+		await service.recordTopics(ROOM_A, []);
+		expect(service.getTopicsForRoom(ROOM_A)).toEqual([]);
+		expect(mock.updateRoom).not.toHaveBeenCalled();
+	});
+
+	it("never throws when the room is missing (defensive persistence)", async () => {
+		const noRoom = makeRuntime();
+		const svc = await ChannelTopicsService.start(noRoom.runtime);
+		await expect(
+			svc.recordTopics(ROOM_A, ["billing"]),
+		).resolves.toBeUndefined();
+		// Cache still updated even though persistence found no room to write.
+		expect(svc.getTopicsForRoom(ROOM_A)).toEqual(["billing"]);
+		expect(noRoom.updateRoom).not.toHaveBeenCalled();
+	});
+
+	it("never throws when getRoom rejects (defensive hydration)", async () => {
+		const failing = makeRuntime();
+		failing.getRoom.mockRejectedValue(new Error("db down"));
+		const svc = await ChannelTopicsService.start(failing.runtime);
+		await expect(
+			svc.recordTopics(ROOM_A, ["billing"]),
+		).resolves.toBeUndefined();
+		// Cache still reflects the recorded topic despite the hydration failure.
+		expect(svc.getTopicsForRoom(ROOM_A)).toEqual(["billing"]);
+	});
+
+	it("ignores non-string garbage in persisted metadata on hydrate", async () => {
+		const dirty = makeRuntime();
+		dirty.rooms.set(ROOM_A, {
+			id: ROOM_A,
+			source: "test",
+			type: "GROUP" as Room["type"],
+			metadata: {
+				[CHANNEL_TOPICS_METADATA_KEY]: ["ok", 42, "", "  ", "ok"],
+			},
+		});
+		const svc = await ChannelTopicsService.start(dirty.runtime);
+		expect(await svc.ensureHydrated(ROOM_A)).toEqual(["ok"]);
+	});
+
+	it("clears state on stop", async () => {
+		await service.recordTopics(ROOM_A, ["billing"]);
+		await service.stop();
+		expect(service.getTopicsForAllRooms()).toEqual({});
+	});
+});

--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -1,0 +1,231 @@
+/**
+ * ChannelTopicsService — per-channel topic LRU.
+ *
+ * Maintains, per `roomId`, a bounded most-recently-used list of short topic
+ * labels extracted at Stage-1 (the `topics` field-evaluator). The list is the
+ * running answer to "what is this channel about lately?" and is surfaced back
+ * into Stage-1 routing through the `CHANNEL_TOPICS` provider so shouldRespond /
+ * the planner can weigh topic relevance.
+ *
+ * Semantics:
+ *   - Bounded LRU per room. {@link CHANNEL_TOPICS_LRU_CAPACITY} slots
+ *     (≈ the last ~100 messages worth of distinct topics). FIFO eviction:
+ *     when the list is full, the oldest entry is dropped to make room.
+ *   - Dedupe on insert: re-recording an existing topic refreshes its recency
+ *     (moves it to the most-recent end) rather than adding a duplicate.
+ *   - Ordering: index 0 is the OLDEST, the last index is the MOST RECENT.
+ *
+ * Persistence:
+ *   - Each room's list is mirrored to `room.metadata.currentTopics` via
+ *     `runtime.updateRoom` so it survives a restart.
+ *   - The in-memory cache is hydrated from `room.metadata.currentTopics` the
+ *     first time a room is touched.
+ *   - All persistence is defensive: any failure is logged and swallowed — it
+ *     must never throw into the message loop.
+ *
+ * This service is PURE LOGIC (no fs / process / native deps) so it is safe for
+ * the Node, browser, and edge build targets.
+ */
+
+import { logger } from "../logger";
+import type { Room, UUID } from "../types/index";
+import type { IAgentRuntime } from "../types/runtime";
+import { Service } from "../types/service";
+
+/** Metadata key under which a room's topic LRU is persisted. */
+export const CHANNEL_TOPICS_METADATA_KEY = "currentTopics";
+
+/**
+ * Max distinct topics retained per room. ~20 slots ≈ the last ~100 messages
+ * worth of salient topics (each message contributes 0-5 topics, most repeat).
+ */
+export const CHANNEL_TOPICS_LRU_CAPACITY = 20;
+
+const LOG_PREFIX = "[ChannelTopicsService]";
+
+/**
+ * Coerce an unknown value (e.g. read back from room metadata) into a clean
+ * topic list: strings only, trimmed, non-empty, deduped, capped at capacity.
+ * Mirrors the normalization the Stage-1 evaluator applies on the way in, so a
+ * hand-edited or legacy metadata blob can never poison the cache.
+ */
+function coerceTopicList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		const normalized = item.trim();
+		if (!normalized) continue;
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(normalized);
+	}
+	// Keep the most-recent tail if a persisted list somehow exceeds capacity.
+	return result.length > CHANNEL_TOPICS_LRU_CAPACITY
+		? result.slice(result.length - CHANNEL_TOPICS_LRU_CAPACITY)
+		: result;
+}
+
+export class ChannelTopicsService extends Service {
+	static override serviceType = "channel_topics";
+	override capabilityDescription =
+		"Maintains a per-channel LRU of recent topic labels extracted at Stage-1.";
+
+	/** roomId → ordered topic list (index 0 oldest, last most recent). */
+	private readonly topicsByRoom = new Map<UUID, string[]>();
+	/** Rooms whose metadata has already been hydrated into the cache. */
+	private readonly hydrated = new Set<UUID>();
+
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<ChannelTopicsService> {
+		return new ChannelTopicsService(runtime);
+	}
+
+	override async stop(): Promise<void> {
+		this.topicsByRoom.clear();
+		this.hydrated.clear();
+	}
+
+	/**
+	 * Hydrate a room's LRU from `room.metadata.currentTopics` the first time it
+	 * is accessed. Defensive: any failure leaves the room with an empty list.
+	 */
+	private async hydrateRoom(roomId: UUID): Promise<void> {
+		if (this.hydrated.has(roomId)) return;
+		this.hydrated.add(roomId);
+		try {
+			const room = await this.runtime.getRoom(roomId);
+			const persisted = coerceTopicList(
+				room?.metadata?.[CHANNEL_TOPICS_METADATA_KEY],
+			);
+			if (persisted.length > 0) {
+				this.topicsByRoom.set(roomId, persisted);
+			}
+		} catch (error) {
+			logger.warn(
+				{ src: "service:channel_topics", roomId, err: error },
+				`${LOG_PREFIX} hydrate from room metadata failed`,
+			);
+		}
+	}
+
+	/**
+	 * Apply new topics to a room's in-memory LRU. Dedupe refreshes recency
+	 * (move-to-most-recent); FIFO eviction drops the oldest when over capacity.
+	 * Returns the updated list (a fresh array, safe to hand out).
+	 */
+	private applyTopics(roomId: UUID, incoming: string[]): string[] {
+		const current = this.topicsByRoom.get(roomId) ?? [];
+		// Work on a Map keyed by topic to dedupe while preserving insertion
+		// order — re-inserting a key after delete moves it to the end (most
+		// recent), which is exactly the recency-refresh semantics we want.
+		const ordered = new Map<string, true>();
+		for (const topic of current) {
+			ordered.set(topic, true);
+		}
+		for (const raw of incoming) {
+			const topic = raw.trim();
+			if (!topic) continue;
+			// Refresh recency: delete then re-set pushes it to the tail.
+			ordered.delete(topic);
+			ordered.set(topic, true);
+		}
+		let next = Array.from(ordered.keys());
+		if (next.length > CHANNEL_TOPICS_LRU_CAPACITY) {
+			// FIFO eviction: drop the oldest (front) entries.
+			next = next.slice(next.length - CHANNEL_TOPICS_LRU_CAPACITY);
+		}
+		this.topicsByRoom.set(roomId, next);
+		return next;
+	}
+
+	/**
+	 * Persist a room's topic list to `room.metadata.currentTopics`. Defensive:
+	 * a missing room or a failed update is logged and swallowed — it must never
+	 * throw into the message loop.
+	 */
+	private async persistRoom(roomId: UUID, topics: string[]): Promise<void> {
+		try {
+			const room = await this.runtime.getRoom(roomId);
+			if (!room) {
+				logger.debug(
+					{ src: "service:channel_topics", roomId },
+					`${LOG_PREFIX} room not found; skipping topic persistence`,
+				);
+				return;
+			}
+			const updated: Room = {
+				...room,
+				metadata: {
+					...room.metadata,
+					[CHANNEL_TOPICS_METADATA_KEY]: topics,
+				},
+			};
+			await this.runtime.updateRoom(updated);
+		} catch (error) {
+			logger.warn(
+				{ src: "service:channel_topics", roomId, err: error },
+				`${LOG_PREFIX} persist topics to room metadata failed`,
+			);
+		}
+	}
+
+	/**
+	 * Record newly-extracted topics for a room: hydrate (first touch) → apply to
+	 * the LRU (dedupe + FIFO evict) → persist to room metadata. A no-op when
+	 * `topics` is empty. Never throws — safe to fire-and-forget from the loop.
+	 */
+	async recordTopics(roomId: UUID, topics: string[]): Promise<void> {
+		if (!roomId || !Array.isArray(topics) || topics.length === 0) {
+			return;
+		}
+		try {
+			await this.hydrateRoom(roomId);
+			const next = this.applyTopics(roomId, topics);
+			await this.persistRoom(roomId, next);
+		} catch (error) {
+			// Belt-and-suspenders: the inner helpers already swallow, but the
+			// public entry point must NEVER throw into the turn.
+			logger.warn(
+				{ src: "service:channel_topics", roomId, err: error },
+				`${LOG_PREFIX} recordTopics failed`,
+			);
+		}
+	}
+
+	/**
+	 * Synchronous accessor for a room's current LRU, most-recent last. Returns a
+	 * defensive copy (mutating it does not affect the cache). Returns the
+	 * cached list only — call {@link recordTopics} to hydrate from metadata. The
+	 * `CHANNEL_TOPICS` provider drives hydration via {@link ensureHydrated}.
+	 */
+	getTopicsForRoom(roomId: UUID): string[] {
+		const topics = this.topicsByRoom.get(roomId);
+		return topics ? [...topics] : [];
+	}
+
+	/**
+	 * Hydrate a room from metadata if not already done, then return its LRU.
+	 * Async variant used by read paths (e.g. the provider) that need the
+	 * persisted state on a cold cache (after restart).
+	 */
+	async ensureHydrated(roomId: UUID): Promise<string[]> {
+		await this.hydrateRoom(roomId);
+		return this.getTopicsForRoom(roomId);
+	}
+
+	/**
+	 * Snapshot of every room's LRU currently in memory. Each list is a
+	 * defensive copy. Reflects only rooms touched since process start (plus
+	 * whatever was hydrated on access).
+	 */
+	getTopicsForAllRooms(): Record<string, string[]> {
+		const out: Record<string, string[]> = {};
+		for (const [roomId, topics] of this.topicsByRoom.entries()) {
+			out[roomId] = [...topics];
+		}
+		return out;
+	}
+}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -42,6 +42,7 @@ import { retrieveActions } from "../runtime/action-retrieval";
 import { resolveActionRolePolicyRole } from "../runtime/action-role-policy";
 import { tierActionResults } from "../runtime/action-tiering";
 import { applyAddressedTo } from "../runtime/addressed-to";
+import { normalizeTopics } from "../runtime/builtin-field-evaluators";
 import {
 	filterByContextGate,
 	satisfiesContextGate,
@@ -231,6 +232,7 @@ import {
 } from "../utils/text-splitting";
 import { isObjectRecord as isRecord } from "../utils/type-guards";
 import { maybeHandleAnalysisActivation } from "./analysis-mode-handler";
+import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
 import {
 	buildFailureReplyPrompt,
@@ -272,6 +274,7 @@ const DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS = new Set([
 	"shouldRespond",
 	"facts",
 	"relationships",
+	"topics",
 	"addressedTo",
 	"emotion",
 ]);
@@ -3476,6 +3479,9 @@ function normalizeRawParsedForFieldRegistry(
 			? extract.addressedTo
 			: [];
 	}
+	if (normalized.topics === undefined) {
+		normalized.topics = Array.isArray(extract?.topics) ? extract.topics : [];
+	}
 	return normalized;
 }
 
@@ -3634,6 +3640,7 @@ export function messageHandlerFromFieldResult(
 				.map((addressed) => String(addressed).trim())
 				.filter(Boolean)
 		: [];
+	const topics = normalizeTopics(result.topics);
 	const preempt = fieldRun?.preempt;
 	const processMessage =
 		preempt?.mode === "ignore"
@@ -3737,8 +3744,11 @@ export function messageHandlerFromFieldResult(
 		plan.candidateActions = planCandidateActions;
 	}
 	const extract =
-		facts.length > 0 || relationships.length > 0 || addressedTo.length > 0
-			? { facts, relationships, addressedTo }
+		facts.length > 0 ||
+		relationships.length > 0 ||
+		addressedTo.length > 0 ||
+		topics.length > 0
+			? { facts, relationships, addressedTo, topics }
 			: undefined;
 	return {
 		processMessage,
@@ -6221,6 +6231,32 @@ export async function runV5MessageRuntimeStage1(args: {
 					"[message] applyAddressedTo failed",
 				);
 			});
+		}
+
+		// Record Stage-1-extracted topics into the per-channel LRU. Pure
+		// fire-and-forget side-effect (like facts/addressedTo): it persists the
+		// room's running topic list for the CHANNEL_TOPICS provider and must
+		// never block or break the turn.
+		const topics = messageHandler.extract?.topics ?? [];
+		if (topics.length > 0 && args.message.roomId) {
+			const channelTopics = args.runtime.getService<ChannelTopicsService>(
+				ChannelTopicsService.serviceType,
+			);
+			if (channelTopics) {
+				void channelTopics
+					.recordTopics(args.message.roomId, topics)
+					.catch((error) => {
+						args.runtime.logger?.warn?.(
+							{
+								err: error,
+								messageId: args.message.id,
+								roomId: args.message.roomId,
+								topicCount: topics.length,
+							},
+							"[message] recordTopics failed",
+						);
+					});
+			}
 		}
 
 		const responseHandlerEvaluation = fieldRunResult?.preempt

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -150,6 +150,13 @@ export interface MessageHandlerExtract {
 	 * Drives the "addressed" relationship edge from speaker → target.
 	 */
 	addressedTo?: string[];
+	/**
+	 * Short, normalized topic labels for the current message (1-5, lowercase,
+	 * trimmed, deduped). Maintained per-channel as an LRU by
+	 * `ChannelTopicsService` and surfaced back into Stage-1 routing via the
+	 * `CHANNEL_TOPICS` provider. Empty / omitted means "no salient topic".
+	 */
+	topics?: string[];
 }
 
 export interface MessageHandlerResult {

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -38,6 +38,7 @@ export interface ServiceTypeRegistry {
 	CONNECTOR_ACCOUNT_STORAGE: "connector_account_storage";
 	AGENT_EVENT: "agent_event";
 	OPTIMIZED_PROMPT: "optimized_prompt";
+	CHANNEL_TOPICS: "channel_topics";
 	UNKNOWN: "unknown";
 }
 
@@ -132,6 +133,7 @@ export const ServiceType = {
 	MEDIA_GENERATION: "media_generation",
 	VOICE_CACHE: "voice_cache",
 	OPTIMIZED_PROMPT: "optimized_prompt",
+	CHANNEL_TOPICS: "channel_topics",
 	UNKNOWN: "unknown",
 } as const;
 


### PR DESCRIPTION
Closes #8925, #8926. Part of #8890 (chat context enrichment epic).

Foundation of the chat-context-enrichment vision: per-channel topic tags maintained as an LRU over recent messages, extracted at Stage-1 and surfaced back into shouldRespond / the planner.

## What this does
**#8925 — Stage-1 topics + ChannelTopicsService**
- `topics?: string[]` added to `MessageHandlerExtract`; a `topicsFieldEvaluator` (priority 88) emits 1-5 short, normalized labels per turn (lowercase, trimmed, deduped, max 5), threaded through `parseMessageHandlerOutput`/`parseExtract` and the field-registry assembly onto `extract.topics`.
- `ChannelTopicsService` (pure-logic `Service`, all build targets) keeps a per-`roomId` LRU (cap 20 ≈ last 100 msgs, FIFO eviction, dedupe refreshes recency), persisted to `room.metadata.currentTopics` via `updateRoom` (hydrates on first access). Extracted topics are recorded fire-and-forget after Stage-1 parse (mirrors the facts/addressedTo seam; never blocks/breaks the turn). Topics are dropped on direct channels (added to the existing omit sets) to preserve DM prompt-cache stability.

**#8926 — CHANNEL_TOPICS provider**
- Turn-scoped provider renders `# Current topics in this channel: <comma-list>` into Stage-1 response state (no-op when empty), so shouldRespond/the planner can weigh topic relevance. Registered in `basicProviders`; service in `basicServices`; `channel_topics` added to `ServiceType`.

## Evidence
```
$ bun run --cwd packages/core typecheck    # clean
$ bun run --cwd packages/core build        # 🎉 All builds complete (Node+browser+edge, 443 .d.ts)
$ bun run --cwd packages/core test -- channel-topics topics-field-evaluator channelTopics
 Test Files 3 passed / Tests ... (all green; full new+touched set: 6 files, 129 tests)
```
18 files, +857/-4. Rebased on current develop; isolated worktree (main checkout untouched).

## Pre-existing failure (NOT introduced here) — see #8957
`message-runtime-stage1.test.ts:495` asserts `maxTokens === 384` but `DIRECT_CHANNEL_STAGE1_MAX_TOKENS` is `1024` on develop — fails on clean develop too. Filed as #8957 for the owner of that constant change; not touched here to avoid masking a possible regression.

## Remaining (follow-up, not faked)
Live scenario-runner trajectory (10 messages → topics accumulate; provider influences routing) needs a live model — code + deterministic unit tests are complete; the live run is tracked under #8890. Next in the epic: #8927 (cross-channel topic search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)