### PR TITLE
feat(workflow): EVAL_CODE action for inline sandboxed JS execution (#8914)

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/eval-code.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/eval-code.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { evalCodeAction } from '../../src/actions/eval-code';
+import { evalQuickJsCode } from '../../src/services/embedded-workflow-service';
+
+/**
+ * Unit coverage for the EVAL_CODE action + its QuickJS sandbox wrapper (#8914).
+ */
+describe('evalQuickJsCode sandbox', () => {
+  test('evaluates a return expression', async () => {
+    expect(await evalQuickJsCode('return 1 + 1;')).toBe(2);
+  });
+
+  test('exposes inputJson as $json', async () => {
+    expect(await evalQuickJsCode('return $json.x * 2;', { x: 21 })).toBe(42);
+  });
+
+  test('has no host access (console is a no-op, returns the value)', async () => {
+    expect(await evalQuickJsCode('console.log("ignored"); return "ok";')).toBe('ok');
+  });
+});
+
+describe('EVAL_CODE action', () => {
+  test('is owner-gated', () => {
+    expect(evalCodeAction.roleGate).toEqual({ minRole: 'OWNER' });
+  });
+
+  test('runs the snippet and returns the result via callback', async () => {
+    let delivered: string | undefined;
+    const result = await evalCodeAction.handler(
+      {} as never,
+      {} as never,
+      undefined,
+      { parameters: { jsCode: 'return 6 * 7;' } } as never,
+      (async (content: { text?: string }) => {
+        delivered = content.text;
+      }) as never
+    );
+    expect(result?.success).toBe(true);
+    expect(result?.text).toBe('42');
+    expect(delivered).toBe('42');
+  });
+
+  test('fails clearly when no jsCode is provided', async () => {
+    const result = await evalCodeAction.handler(
+      {} as never,
+      {} as never,
+      undefined,
+      { parameters: {} } as never,
+      undefined
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain('jsCode');
+  });
+});

--- a/plugins/plugin-workflow/src/actions/eval-code.ts
+++ b/plugins/plugin-workflow/src/actions/eval-code.ts
@@ -1,0 +1,81 @@
+/**
+ * EVAL_CODE — run a snippet of JavaScript in the isolated QuickJS sandbox and
+ * return its result (#8914).
+ *
+ * Reuses the same sandbox the workflow Code node uses (`evalQuickJsCode`): a
+ * throwaway QuickJS VM with a 5s deadline, a 32 MiB memory cap, and no host /
+ * network / filesystem access. Owner-gated (`minRole: OWNER`) since it executes
+ * caller-supplied code, even though that code can't escape the sandbox.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from '@elizaos/core';
+import { evalQuickJsCode } from '../services/embedded-workflow-service';
+
+const EVAL_CODE_CONTEXTS = ['automation', 'tasks', 'agent_internal'];
+
+interface EvalCodeParameters {
+  /** The JavaScript to run. The snippet body runs inside an IIFE, so
+   * `return <value>` yields the result. */
+  jsCode?: string;
+  code?: string;
+  /** Optional JSON exposed to the snippet as `$json` / `item.json`. */
+  inputJson?: unknown;
+}
+
+function previewResult(value: unknown): string {
+  try {
+    if (value === undefined) return 'undefined';
+    const json = JSON.stringify(value);
+    return typeof json === 'string' ? json : String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export const evalCodeAction: Action = {
+  name: 'EVAL_CODE',
+  contexts: [...EVAL_CODE_CONTEXTS],
+  contextGate: { anyOf: [...EVAL_CODE_CONTEXTS] },
+  roleGate: { minRole: 'OWNER' },
+  similes: ['RUN_CODE', 'EVALUATE_CODE', 'EXEC_JS', 'RUN_JS', 'EVAL_JS'],
+  description:
+    'Run a snippet of JavaScript in an isolated QuickJS sandbox (5s deadline, ' +
+    '32MiB cap, no network/fs/host access) and return its result. Provide a ' +
+    '`jsCode` parameter; the body runs inside a function, so `return <value>` ' +
+    'produces the output. Optional `inputJson` is exposed as `$json`.',
+  validate: async () => true,
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: HandlerOptions,
+    callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const params = (options?.parameters ?? {}) as EvalCodeParameters;
+    const jsCode = (params.jsCode ?? params.code ?? '').trim();
+    if (!jsCode) {
+      const text = 'EVAL_CODE requires a `jsCode` parameter (the JavaScript to run).';
+      if (callback) await callback({ text });
+      return { success: false, text };
+    }
+    try {
+      const result = await evalQuickJsCode(jsCode, params.inputJson);
+      const text = previewResult(result);
+      if (callback) await callback({ text });
+      return { success: true, text };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const text = `EVAL_CODE failed: ${message}`;
+      if (callback) await callback({ text });
+      return { success: false, text };
+    }
+  },
+};

--- a/plugins/plugin-workflow/src/actions/index.ts
+++ b/plugins/plugin-workflow/src/actions/index.ts
@@ -1,1 +1,2 @@
+export { evalCodeAction } from './eval-code';
 export { workflowAction } from './workflow';

--- a/plugins/plugin-workflow/src/index.ts
+++ b/plugins/plugin-workflow/src/index.ts
@@ -1,5 +1,5 @@
 import { type IAgentRuntime, logger, type Plugin } from '@elizaos/core';
-import { workflowAction } from './actions/index';
+import { evalCodeAction, workflowAction } from './actions/index';
 import * as dbSchema from './db/index';
 import {
   activeWorkflowsProvider,
@@ -61,7 +61,7 @@ export const workflowPlugin: Plugin = {
 
   schema: dbSchema,
 
-  actions: [workflowAction],
+  actions: [workflowAction, evalCodeAction],
 
   providers: [workflowStatusProvider, activeWorkflowsProvider, pendingDraftProvider],
 

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -1141,6 +1141,19 @@ async function runQuickJsCode(jsCode: string, inputItems: INodeExecutionData[]):
   });
 }
 
+/**
+ * Evaluate a snippet of JavaScript in the same isolated QuickJS sandbox the
+ * Code node uses (5s deadline, 32 MiB cap, no host/network/fs access). Optional
+ * `inputJson` is exposed to the snippet as `$json` / `item.json` / `$input[0]`.
+ * The snippet body runs inside an IIFE, so `return <value>` yields the result.
+ * Public entry point for the EVAL_CODE action (#8914).
+ */
+export async function evalQuickJsCode(jsCode: string, inputJson?: unknown): Promise<unknown> {
+  const items: INodeExecutionData[] =
+    inputJson === undefined ? [] : [{ json: (inputJson ?? {}) as Record<string, unknown> }];
+  return runQuickJsCode(jsCode, items);
+}
+
 type AutonomyServiceLike = Service & {
   getAutonomousRoomId?(): UUID | undefined;
   getTargetRoomId?(): UUID | undefined;


### PR DESCRIPTION
## Summary
Closes #8914 (part of #8887). Adds a new **owner-gated `EVAL_CODE` action** that runs a JS snippet in the **same isolated QuickJS sandbox** the workflow Code node already uses — 5s deadline, 32 MiB memory cap, no network/fs/host access (`console` is a no-op stub).

## Changes
- Export `evalQuickJsCode(jsCode, inputJson?)` from `embedded-workflow-service.ts` — a thin public wrapper over the existing private `runQuickJsCode`. `inputJson` is exposed to the snippet as `$json` / `item.json`; the body runs inside an IIFE so `return <value>` yields the result.
- New `EVAL_CODE` action (`roleGate: { minRole: 'OWNER' }`, contexts `automation`/`tasks`/`agent_internal`) reading `options.parameters.jsCode` (+ optional `inputJson`), returning the result via callback with safe error handling.
- Registered in the plugin's `actions` array.

## Acceptance criteria
- [x] New `EVAL_CODE` action calling `runQuickJsCode()` from the QuickJS sandbox.
- [x] Result returned via callback.
- [x] Owner-gated (`minRole: OWNER`) + safe error handling.

## Tests
`__tests__/unit/eval-code.test.ts`:
```
✓ evaluates a return expression (1+1=2)
✓ exposes inputJson as $json (42)
✓ no host access (console no-op, returns value)
✓ action is owner-gated
✓ runs the snippet and delivers result via callback
✓ fails clearly when no jsCode is provided
6 pass / 0 fail · typecheck clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)