### PR TITLE
feat(orchestrator): auto-generate default acceptance criteria so verification always fires (#8896)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-contract.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildDefaultAcceptanceCriteria,
+  shouldRequireGoalContract,
+} from "../services/goal-contract.js";
+
+describe("buildDefaultAcceptanceCriteria (#8896)", () => {
+  it("returns the base coding criteria for a plain coding task", () => {
+    const criteria = buildDefaultAcceptanceCriteria("ship the thing", "coding");
+    expect(criteria.length).toBe(4);
+    expect(criteria.some((c) => c.includes("typechecks"))).toBe(true);
+    expect(criteria.some((c) => c.includes("tests pass"))).toBe(true);
+    expect(criteria.some((c) => c.includes("diff is coherent"))).toBe(true);
+  });
+
+  it("appends view-create extras (registered view + screenshot)", () => {
+    const criteria = buildDefaultAcceptanceCriteria(
+      "add a view",
+      "view-create",
+    );
+    expect(criteria.length).toBe(6);
+    expect(criteria.some((c) => c.includes("GET /api/views"))).toBe(true);
+    expect(criteria.some((c) => c.toLowerCase().includes("screenshot"))).toBe(
+      true,
+    );
+  });
+
+  it("appends app-build extras (HTTP 200 smoke)", () => {
+    const criteria = buildDefaultAcceptanceCriteria("build app", "app-build");
+    expect(criteria.some((c) => c.includes("HTTP 200"))).toBe(true);
+  });
+
+  it("falls back to base criteria for an unknown/undefined kind", () => {
+    expect(buildDefaultAcceptanceCriteria("x", "mystery").length).toBe(4);
+    expect(buildDefaultAcceptanceCriteria("x").length).toBe(4);
+  });
+});
+
+describe("shouldRequireGoalContract", () => {
+  const prev = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+    else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = prev;
+  });
+
+  it("defaults on", () => {
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+    expect(shouldRequireGoalContract()).toBe(true);
+  });
+
+  it("opts out only on explicit '0'", () => {
+    process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+    expect(shouldRequireGoalContract()).toBe(false);
+    process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "1";
+    expect(shouldRequireGoalContract()).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/goal-contract.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-contract.ts
@@ -1,0 +1,52 @@
+/**
+ * Default acceptance-criteria generation (#8896).
+ *
+ * When a task is created with no acceptance criteria, automatic verification
+ * never fires (`autoVerifyCompletion` returns early on an empty list), so a
+ * sub-agent's "done" is taken on faith. This module supplies sensible,
+ * task-kind-specific default criteria so verification always has something
+ * concrete to check.
+ *
+ * Deterministic + template-based on purpose: defaults must be stable, instant,
+ * and dependency-free (no model call on the task-creation hot path).
+ */
+
+/**
+ * Whether to auto-fill default acceptance criteria for criteria-less tasks.
+ * On by default; set `ELIZA_REQUIRE_GOAL_CONTRACT=0` to opt out.
+ */
+export function shouldRequireGoalContract(): boolean {
+  return process.env.ELIZA_REQUIRE_GOAL_CONTRACT !== "0";
+}
+
+/** Criteria every code-touching task should satisfy before it claims done. */
+const BASE_CODING_CRITERIA: readonly string[] = [
+  "The change typechecks (no new type errors).",
+  "Lint/format passes on the touched files.",
+  "Relevant tests pass (and new behavior has a test).",
+  "The diff is coherent and scoped to the goal — no unrelated edits.",
+];
+
+/** Extra criteria keyed by task kind, appended to the base set. */
+const KIND_EXTRA_CRITERIA: Record<string, readonly string[]> = {
+  "app-build": ["The built app serves and a smoke request returns HTTP 200."],
+  "view-create": [
+    "The new view is registered and appears in GET /api/views.",
+    "A screenshot of the rendered view is captured.",
+  ],
+  deploy: ["The deployed target is reachable and healthy after rollout."],
+};
+
+/**
+ * Build default acceptance criteria for a task that was created without any.
+ * Returns the base coding criteria plus any kind-specific extras. The `goal`
+ * is currently unused by the templates but kept in the signature so a future
+ * model-assisted variant can specialize without a call-site change.
+ */
+export function buildDefaultAcceptanceCriteria(
+  _goal: string,
+  kind?: string,
+): string[] {
+  const extra = kind ? (KIND_EXTRA_CRITERIA[kind] ?? []) : [];
+  return [...BASE_CODING_CRITERIA, ...extra];
+}

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -41,6 +41,10 @@ import {
   verifyGoalCompletion,
 } from "./goal-llm-verifier.js";
 import {
+  buildDefaultAcceptanceCriteria,
+  shouldRequireGoalContract,
+} from "./goal-contract.js";
+import {
   buildGoalFollowUp,
   buildGoalPrompt,
   coerceGoalCapabilityProfile,
@@ -1113,7 +1117,22 @@ export class OrchestratorTaskService extends Service {
   // ---- lifecycle ---------------------------------------------------------
 
   async createTask(input: CreateTaskInput): Promise<TaskThreadDetailDto> {
-    const doc = await this.store.createTask(input);
+    // #8896: auto-fill default acceptance criteria for criteria-less tasks so
+    // automatic verification always has something concrete to check (otherwise
+    // autoVerifyCompletion returns early on an empty list and "done" is faith).
+    const effectiveInput =
+      shouldAutoVerifyGoal() &&
+      shouldRequireGoalContract() &&
+      (input.acceptanceCriteria?.length ?? 0) === 0
+        ? {
+            ...input,
+            acceptanceCriteria: buildDefaultAcceptanceCriteria(
+              input.goal,
+              input.kind,
+            ),
+          }
+        : input;
+    const doc = await this.store.createTask(effectiveInput);
     if (input.originalRequest) {
       await this.recordMessage(doc.task.id, {
         content: input.originalRequest,


### PR DESCRIPTION
## Summary
Closes #8896 (part of #8884). A task created with **no acceptance criteria** never reaches verification — `autoVerifyCompletion` returns early on an empty list, so a sub-agent's "done" is taken on faith. This auto-fills sensible, task-kind-specific defaults at creation so verification always has something concrete to check.

## Changes
- New `goal-contract.ts`:
  - `shouldRequireGoalContract()` — gate (`ELIZA_REQUIRE_GOAL_CONTRACT`, default **on**).
  - `buildDefaultAcceptanceCriteria(goal, kind)` — **deterministic + template-based** (no model call on the task-creation hot path): base coding criteria (typecheck / lint / tests / coherent diff) plus kind-specific extras — `app-build` → HTTP 200 smoke; `view-create` → registered + appears in `GET /api/views` + screenshot; `deploy` → reachable + healthy.
- `createTask` fills defaults when auto-verify is on, the contract is required, and the task arrived with no criteria (uses a local, no param reassignment).

## Acceptance criteria
- [x] Empty-criteria tasks get generated criteria (kind-specific).
- [x] Gated behind `ELIZA_REQUIRE_GOAL_CONTRACT` (default on).
- [x] Verification now fires for criteria-free tasks (they no longer hit the empty-list early return).

## Tests
`goal-contract.test.ts` (6/6): base coding criteria, view-create + app-build extras, unknown-kind fallback, env gate default-on / opt-out-on-`0`. typecheck clean.

> Template-based by design (stable, instant, dependency-free). A model-assisted variant can specialize later without a call-site change — the `goal` arg is already threaded through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)