### PR TITLE
feat(app-lifecycle): ViewKind contract for sub-agent view creation + min-plugin scaffold (#8917)

### DIFF
--- a/packages/elizaos/templates/min-plugin/SCAFFOLD.md
+++ b/packages/elizaos/templates/min-plugin/SCAFFOLD.md
@@ -55,6 +55,19 @@ Do not emit legacy fields such as `name`, `testsPassed`, or `lintClean`; the orc
 
 The orchestrator will cross-check the claims against disk and the verification log. If anything you assert does not match reality, it will retry you with a structured failure report (capped by `ELIZA_APP_VERIFICATION_MAX_RETRIES`, default `3`).
 
+## 6. View kind (only if your plugin adds a view)
+
+If your plugin contributes a UI view (a `Plugin.views` entry), set its `viewKind`
+so the shell knows when to show it. The four kinds (escalating exposure):
+
+- `system` — core, always-present views (reserved for built-ins; don't use).
+- `release` — public, production-ready, always visible. **Default for a finished view.**
+- `developer` — dev tooling (logs, inspectors); shown in dev builds, hidden in prod until enabled in Settings.
+- `preview` — unfinished / experimental; hidden on every build until enabled in Settings.
+
+Choose `release` for a complete, user-facing view; `preview` for an early/experimental one.
+If you omit `viewKind`, it defaults to `release`.
+
 ## Rules
 
 - Actions, providers, and evaluators belong in their own files under `src/actions/`, `src/providers/`, `src/evaluators/`. The plugin barrel is wiring only.

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -24,9 +24,9 @@ import type {
 } from "@elizaos/core";
 import { logger, ModelType, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
-import { isRestrictedPlatform } from "./views.js";
 import type { ViewSummary } from "./views-client.js";
 import { writeViewHeroAsset } from "./views-hero.js";
+import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
 
 export const VIEWS_CREATE_INTENT_TAG = "views-create-intent";

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -24,9 +24,9 @@ import type {
 } from "@elizaos/core";
 import { logger, ModelType, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
+import { isRestrictedPlatform } from "./views.js";
 import type { ViewSummary } from "./views-client.js";
 import { writeViewHeroAsset } from "./views-hero.js";
-import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
 
 export const VIEWS_CREATE_INTENT_TAG = "views-create-intent";
@@ -439,7 +439,7 @@ async function dispatchCodingAgent({
 	return { dispatched: true, agents };
 }
 
-function buildCreatePrompt(
+export function buildCreatePrompt(
 	intent: string,
 	pluginName: string,
 	displayName: string,
@@ -454,6 +454,7 @@ function buildCreatePrompt(
 		"workspaceRule: work in sourceDir, not the task agent scratch directory",
 		"referenceDocs: read SCAFFOLD.md for layout and conventions",
 		"viewRequirement: add a Plugin.views entry with a compiled view bundle so the view appears in the Eliza view registry",
+		'viewKindRule: set the views entry viewKind to "release" for a finished user-facing view (the default), or "preview" for an early/experimental one; never "system" (reserved for built-ins)',
 		"iconAsset: a branded assets/hero.svg is already seeded and is served as the view hero — keep it (or replace it with a real image at assets/hero.<ext>); do not delete it",
 		"implementation: edit and add files needed for the intent",
 		"verificationCommands[3]:",

--- a/plugins/plugin-app-control/src/actions/views-create.viewkind.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.viewkind.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildCreatePrompt } from "./views-create";
+
+/**
+ * #8917: the view-create prompt must instruct the sub-agent to set a ViewKind on
+ * the Plugin.views entry (release by default, never system).
+ */
+describe("buildCreatePrompt viewKind contract (#8917)", () => {
+	const prompt = buildCreatePrompt(
+		"a dashboard for X",
+		"@elizaos/plugin-x",
+		"Plugin X",
+		"/tmp/work",
+	);
+
+	it("tells the agent to set viewKind", () => {
+		expect(prompt).toContain("viewKindRule:");
+		expect(prompt.toLowerCase()).toContain("viewkind");
+	});
+
+	it("names release (default) + preview and forbids system", () => {
+		expect(prompt).toContain('"release"');
+		expect(prompt).toContain('"preview"');
+		expect(prompt).toContain('"system"');
+		expect(prompt.toLowerCase()).toContain("default");
+		expect(prompt.toLowerCase()).toContain("reserved for built-ins");
+	});
+
+	it("still requires a Plugin.views entry", () => {
+		expect(prompt).toContain("viewRequirement:");
+	});
+});


### PR DESCRIPTION
## Summary
Closes #8917 (part of #8888). The four-kind ViewKind taxonomy (`system`/`release`/`developer`/`preview`) exists in `@elizaos/core` and on built-in views, but **sub-agents creating view plugins were never told to set it**, so generated views had no kind and the min-plugin template gave no guidance.

## Changes
- `views-create` `buildCreatePrompt` now emits a **`viewKindRule`**: set the `Plugin.views` entry `viewKind` to `"release"` (default, finished user-facing) or `"preview"` (early/experimental); never `"system"` (reserved for built-ins).
- min-plugin **`SCAFFOLD.md`** documents the four kinds + the `release` default in a new "View kind" section.

## Acceptance criteria
- [x] ViewKind guidance in the min-plugin scaffold.
- [x] ViewKind rule injected into the sub-agent create prompt (default `release`).

## Tests
`views-create.viewkind.test.ts` (3/3): the prompt names the rule, lists release/preview/system with the default + reserved wording, and still requires a `Plugin.views` entry. (`buildCreatePrompt` exported for the test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)