### PR TITLE
fix(core/test): update stale Stage-1 maxTokens assertion 384 → 1024 (#8957)

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -492,7 +492,11 @@ describe("runV5MessageRuntimeStage1", () => {
 		]);
 		expect(required).not.toContain("shouldRespond");
 		expect(required).not.toContain("facts");
-		expect(params.maxTokens).toBe(384);
+		// Direct-channel Stage-1 budget is DIRECT_CHANNEL_STAGE1_MAX_TOKENS (1024).
+		// The 384 cap was deliberately raised to 1024 to stop long-answer
+		// truncation (see the constant's rationale in message.ts); this assertion
+		// was left stale at 384 (#8957).
+		expect(params.maxTokens).toBe(1024);
 		expect(
 			params.responseSkeleton?.spans?.some((s) => s.key === "shouldRespond"),
 		).toBe(false);


### PR DESCRIPTION
## Summary
Fixes #8957. `message-runtime-stage1.test.ts:495` asserted `maxTokens === 384` for the direct-channel Stage-1 path, but `DIRECT_CHANNEL_STAGE1_MAX_TOKENS` is **1024** — deliberately raised from 384 to stop long-answer truncation (the constant's own comment in `message.ts` documents the 384→1024 rationale). The assertion was left stale, so **this test failed on clean `develop`** independent of any feature branch (I hit it while verifying an unrelated core PR).

1024 is the intended value, so the assertion is updated to match (not the constant reverted).

## Tests
```
message-runtime-stage1.test.ts  71/71 pass  (was 70 pass / 1 fail on develop)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)