### PR TITLE
feat(local-inference): curate Eliza-1 local inference memory validation

### DIFF
--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -69,7 +69,10 @@ describe("pollAnthropicUsage", () => {
 
     // Probe hit the right endpoint with the OAuth bearer + beta header.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, opts] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const [url, opts] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
     expect(url).toBe("https://api.anthropic.com/api/oauth/usage");
     const headers = opts.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer flat-token");
@@ -204,7 +207,10 @@ describe("pollCodexUsage", () => {
     expect(typeof snap.refreshedAt).toBe("number");
 
     // Probe hit the right endpoint with the account id + UA headers.
-    const [url, opts] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const [url, opts] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
     expect(url).toBe("https://chatgpt.com/backend-api/wham/usage");
     const headers = opts.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer codex-token");

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -223,10 +223,12 @@ const TIER_SPECS: Readonly<Record<Eliza1TierId, TierSpec>> = {
     id: "eliza-1-4b",
     params: "4B",
     sizeGb: 2.6,
-    // 4B is the shipped mobile minimum/default. The Q4_K_M weights are 2.6 GB
-    // and the mobile bundle runs a 64k context with F16 KV until the
-    // head_dim=256 QJL path exists. The floor stays above the model size to
-    // leave headroom for the OS, app, and KV cache.
+    // 4B is the shipped mid/mobile tier. The 2.6 GB Q4_K_M weights are sized
+    // for a 128k Eliza-1 bundle, with the runtime choosing the safest cache
+    // profile per FFI path: QJL/TBQ where supported, F16 KV on Android bionic
+    // while qwen35 head_dim=256 remains incompatible with the shipped QJL
+    // kernel. The floor stays above the model size to leave headroom for the
+    // OS, app, and KV cache.
     minRamGb: 6,
     q4MinRamGb: 6,
     bucket: "mid",

--- a/packages/shared/src/local-inference/runtime-class.test.ts
+++ b/packages/shared/src/local-inference/runtime-class.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { findCatalogModel, MODEL_CATALOG } from "./catalog.js";
+import { MODEL_CATALOG } from "./catalog.js";
 import {
   classifyCatalogModelRuntimeClass,
   classifyInstalledModelRuntimeClass,

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -276,6 +276,17 @@ function buildTrajectoryParams(
 
 declare module "./client-base" {
   interface ElizaClient {
+    sendChatMessage(
+      text: string,
+      channelType?: ConversationChannelType,
+    ): Promise<{
+      text: string;
+      agentName: string;
+      noResponseReason?: "ignored";
+      failureKind?: ChatFailureKind;
+      localInference?: LocalInferenceChatMetadata;
+      actionResults?: ChatActionResultSummary[];
+    }>;
     sendChatRest(
       text: string,
       channelType?: ConversationChannelType,
@@ -785,6 +796,14 @@ ElizaClient.prototype.sendChatRest = async function (
     }
     throw error;
   }
+};
+
+ElizaClient.prototype.sendChatMessage = async function (
+  this: ElizaClient,
+  text,
+  channelType = "DM",
+) {
+  return this.sendChatRest(text, channelType);
 };
 
 ElizaClient.prototype.sendChatStream = async function (

--- a/packages/ui/src/widgets/WidgetHost.tsx
+++ b/packages/ui/src/widgets/WidgetHost.tsx
@@ -10,8 +10,8 @@
  * to the declarative UiRenderer for uiSpec widgets.
  */
 
-import { Component, type ErrorInfo, type ReactNode, useMemo } from "react";
 import { isViewVisible } from "@elizaos/core";
+import { Component, type ErrorInfo, type ReactNode, useMemo } from "react";
 import { UiRenderer } from "../components/config-ui/ui-renderer";
 import type { ActivityEvent } from "../hooks/useActivityEvents";
 import { useAppSelectorShallow } from "../state";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-store-filelock.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-store-filelock.test.ts
@@ -222,7 +222,7 @@ describe("FileSessionStore cross-instance file-lock contention", () => {
 
     // Another process holds a FRESH (non-stale) lock. Its mtime is "now", so
     // removeStaleLock must refuse to delete it and the writer must wait.
-    await writeFile(lockFile, "55555\n" + `${Date.now()}\n`, "utf8");
+    await writeFile(lockFile, `55555\n${Date.now()}\n`, "utf8");
 
     const store = new FileSessionStore(file);
 

--- a/plugins/plugin-local-inference/docs/MEMORY_ARBITER.md
+++ b/plugins/plugin-local-inference/docs/MEMORY_ARBITER.md
@@ -34,11 +34,16 @@ Live in this checkout:
 - The active text target registers a catalog/file-size-derived resident
   estimate with the shared registry, so pressure telemetry no longer
   reports the dominant text role as `0 MB`.
+- `bun run --cwd plugins/plugin-local-inference memory:benchmark` emits a
+  desktop/server memory report with host RAM, the device-fit Eliza-1 pick,
+  per-tier resident estimates, installed bundle footprints, and arbiter
+  load/eviction/pressure telemetry. Add `--load` to exercise every
+  installed Eliza-owned bundle with a short decode and RSS delta sample.
 
 Still deferred:
 
-- The desktop/server memory benchmark harness and CI `budgets.json`
-  regression gate.
+- A CI `budgets.json` regression gate fed by the desktop/server memory
+  benchmark output.
 - Voice next-stage predictors that call `preload()` during ASR / LM /
   TTS transitions.
 - Dedicated embedding-sidecar residency registration for the larger

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -89,6 +89,7 @@
 		"test:asr:real": "NODE_OPTIONS='--experimental-sqlite' bun scripts/asr-real-smoke.ts",
 		"test:kokoro:real": "bun scripts/kokoro-real-smoke.ts",
 		"probe:sd-cpp": "node scripts/probe-sd-cpp.mjs --human",
+		"memory:benchmark": "bun run scripts/memory-benchmark.ts",
 		"voice:workbench": "bun run scripts/voice-workbench.ts",
 		"corpus:generate": "bun run scripts/generate-voice-corpus.ts",
 		"clean": "rm -rf dist .turbo node_modules",

--- a/plugins/plugin-local-inference/scripts/memory-benchmark.ts
+++ b/plugins/plugin-local-inference/scripts/memory-benchmark.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+import {
+	runMemoryBenchmark,
+	summarizeMemoryBenchmark,
+} from "../src/services/memory-benchmark";
+
+interface Args {
+	loadInstalled: boolean;
+	json: boolean;
+	outFile?: string;
+	prompt?: string;
+	maxTokens?: number;
+}
+
+function parseArgs(argv: string[]): Args {
+	const args: Args = { loadInstalled: false, json: false };
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		switch (arg) {
+			case "--load":
+				args.loadInstalled = true;
+				break;
+			case "--json":
+				args.json = true;
+				break;
+			case "--out":
+				args.outFile = argv[++i];
+				break;
+			case "--prompt":
+				args.prompt = argv[++i];
+				break;
+			case "--max-tokens": {
+				const value = Number(argv[++i]);
+				if (!Number.isInteger(value) || value <= 0) {
+					throw new Error("--max-tokens must be a positive integer");
+				}
+				args.maxTokens = value;
+				break;
+			}
+			case "--help":
+			case "-h":
+				console.log(
+					[
+						"Usage: bun run scripts/memory-benchmark.ts [options]",
+						"",
+						"Options:",
+						"  --load              Load each installed Eliza-1 bundle and run a short decode",
+						"  --json              Print the full JSON report",
+						"  --out PATH          Write the JSON report to PATH",
+						"  --prompt TEXT       Prompt used for --load decode sampling",
+						"  --max-tokens N      Decode token cap for --load (default 32)",
+					].join("\n"),
+				);
+				process.exit(0);
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const report = await runMemoryBenchmark(args);
+console.log(args.json ? JSON.stringify(report, null, 2) : summarizeMemoryBenchmark(report));

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
@@ -18,7 +18,10 @@ import {
 	type LocalInferenceLoadOverrides,
 	validateLocalInferenceLoadArgs,
 } from "../services/active-model";
-import { AssignmentNotServableError } from "../services/assignments";
+import {
+	AssignmentNotServableError,
+	AssignmentRejectedError,
+} from "../services/assignments";
 import { deviceBridge } from "../services/device-bridge";
 import { classifyDeviceTier } from "../services/device-tier";
 import {
@@ -564,6 +567,10 @@ export async function handleLocalInferenceCompatRoutes(
 			);
 			sendJsonResponse(res, 200, { assignments });
 		} catch (err) {
+			if (err instanceof AssignmentRejectedError) {
+				sendJsonErrorResponse(res, 422, err.message, { code: err.code });
+				return true;
+			}
 			if (err instanceof AssignmentNotServableError) {
 				// The pick cannot run on this platform — a typed, user-visible
 				// reason (422) instead of a silent deferred load failure.

--- a/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
+++ b/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-	AssignmentNotServableError,
+	AssignmentRejectedError,
 	canServeRuntimeClassOnHost,
 	readAssignments,
 	setAssignment,
@@ -88,20 +88,22 @@ describe("canServeRuntimeClassOnHost", () => {
 });
 
 describe("setAssignment boundary validation", () => {
-	it("rejects a generic GGUF on desktop with a typed reason", async () => {
+	it("rejects a generic GGUF on desktop before assignment writes", async () => {
 		const model = await registerGenericModel();
 		await expect(setAssignment("TEXT_LARGE", model.id)).rejects.toBeInstanceOf(
-			AssignmentNotServableError,
+			AssignmentRejectedError,
 		);
 		// Nothing was written.
 		expect(await readAssignments()).toEqual({});
 	});
 
-	it("accepts a generic GGUF on mobile", async () => {
+	it("rejects a generic GGUF on mobile too", async () => {
 		process.env.ELIZA_PLATFORM = "ios";
 		const model = await registerGenericModel();
-		const next = await setAssignment("TEXT_LARGE", model.id);
-		expect(next.TEXT_LARGE).toBe(model.id);
+		await expect(setAssignment("TEXT_LARGE", model.id)).rejects.toThrow(
+			/curated Eliza-1/i,
+		);
+		expect(await readAssignments()).toEqual({});
 	});
 
 	it("always accepts a fused Eliza-1 model on desktop", async () => {
@@ -118,8 +120,7 @@ describe("setAssignment boundary validation", () => {
 	});
 
 	it("clearing a slot is never gated", async () => {
-		process.env.ELIZA_PLATFORM = "ios";
-		const model = await registerGenericModel();
+		const model = await registerFusedModel();
 		await setAssignment("TEXT_LARGE", model.id);
 		delete process.env.ELIZA_PLATFORM; // back to desktop
 		const next = await setAssignment("TEXT_LARGE", null);

--- a/plugins/plugin-local-inference/src/services/assignments.ts
+++ b/plugins/plugin-local-inference/src/services/assignments.ts
@@ -52,6 +52,27 @@ export class AssignmentNotServableError extends Error {
 }
 
 /**
+ * Raised when a slot assignment is outside the curated Eliza-1 catalog.
+ * Generic GGUF installs may still be visible to lower-level tooling, but the
+ * agent assignment policy is deliberately Eliza-1-only.
+ */
+export class AssignmentRejectedError extends Error {
+	readonly code = "ASSIGNMENT_REJECTED" as const;
+	readonly slot: AgentModelSlot;
+	readonly modelId: string;
+	constructor(args: {
+		slot: AgentModelSlot;
+		modelId: string;
+		message: string;
+	}) {
+		super(args.message);
+		this.name = "AssignmentRejectedError";
+		this.slot = args.slot;
+		this.modelId = args.modelId;
+	}
+}
+
+/**
  * Whether the current platform can serve a model of the given runtime class.
  * Fused Eliza-1 bundles are servable everywhere a fused libelizainference is
  * present (the engine's own load gate enforces the build requirement).
@@ -189,6 +210,14 @@ export async function setAssignment(
 	const current = await readAssignments();
 	const next: ModelAssignments = { ...current };
 	if (modelId) {
+		if (!isCuratedEliza1AssignmentId(modelId)) {
+			throw new AssignmentRejectedError({
+				slot,
+				modelId,
+				message:
+					"Local inference assignments are limited to curated Eliza-1 tiers.",
+			});
+		}
 		await assertAssignmentServable(slot, modelId);
 		next[slot] = modelId;
 	} else {

--- a/plugins/plugin-local-inference/src/services/index.ts
+++ b/plugins/plugin-local-inference/src/services/index.ts
@@ -133,6 +133,16 @@ export {
 	tryGetMemoryArbiter,
 } from "./memory-arbiter";
 export {
+	buildMemoryBenchmarkPlan,
+	buildMemoryBenchmarkReport,
+	type MemoryBenchmarkLoadResult,
+	type MemoryBenchmarkModelPlan,
+	type MemoryBenchmarkOptions,
+	type MemoryBenchmarkReport,
+	runMemoryBenchmark,
+	summarizeMemoryBenchmark,
+} from "./memory-benchmark";
+export {
 	type CapacitorPressureSource,
 	capacitorPressureSource,
 	compositePressureSource,

--- a/plugins/plugin-local-inference/src/services/memory-benchmark.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-benchmark.test.ts
@@ -1,0 +1,89 @@
+import { MODEL_CATALOG } from "@elizaos/shared/local-inference";
+import { describe, expect, it } from "vitest";
+import {
+	buildMemoryBenchmarkPlan,
+	buildMemoryBenchmarkReport,
+	summarizeMemoryBenchmark,
+} from "./memory-benchmark";
+import type { HardwareProbe, InstalledModel } from "./types";
+
+function hardware(freeRamGb: number): HardwareProbe {
+	return {
+		totalRamGb: 16,
+		freeRamGb,
+		gpu: null,
+		cpuCores: 8,
+		platform: "darwin",
+		arch: "arm64",
+		appleSilicon: true,
+		recommendedBucket: "mid",
+		source: "os-fallback",
+	};
+}
+
+describe("memory benchmark report", () => {
+	it("marks the device-fit Eliza-1 tier and records curated resident estimates", () => {
+		const plan = buildMemoryBenchmarkPlan({
+			catalog: MODEL_CATALOG,
+			installed: [
+				{
+					id: "eliza-1-2b",
+					displayName: "Eliza-1 2B",
+					path: "/tmp/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf",
+					sizeBytes: 1_500_000_000,
+					bundleRoot: "/tmp/eliza-1-2b.bundle",
+					bundleSizeBytes: 2_000_000_000,
+					source: "eliza-download",
+					installedAt: "2026-06-22T00:00:00.000Z",
+					lastUsedAt: null,
+				} satisfies InstalledModel,
+			],
+			hardware: hardware(4.5),
+		});
+
+		const twoB = plan.find((model) => model.modelId === "eliza-1-2b");
+		expect(twoB?.installed).toBe(true);
+		expect(twoB?.selectedByDeviceFit).toBe(true);
+		expect(twoB?.plannedKvQuant).toBe("qjl1_256");
+		expect(twoB?.estimatedResidentMb).toBeGreaterThan(0);
+
+		const larger = plan.find((model) => model.modelId === "eliza-1-9b");
+		expect(larger?.fit).toBe("tight");
+		expect(larger?.selectedByDeviceFit).toBe(false);
+
+		const largest = plan.find((model) => model.modelId === "eliza-1-27b-256k");
+		expect(largest?.fit).toBe("wontfit");
+	});
+
+	it("summarizes load and telemetry counts", async () => {
+		const report = await buildMemoryBenchmarkReport(
+			{
+				catalog: MODEL_CATALOG,
+				installed: [],
+				hardware: hardware(2),
+			},
+			[
+				{
+					type: "model_load",
+					capability: "text",
+					modelKey: "m",
+					loadMs: 3,
+					atMs: 1,
+				},
+				{
+					type: "eviction",
+					capability: "text",
+					modelKey: "m",
+					reason: "fit",
+					estimatedMb: 512,
+					atMs: 2,
+				},
+			],
+		);
+
+		expect(report.deviceFit.modelId).toBeNull();
+		expect(report.telemetry.modelLoads).toBe(1);
+		expect(report.telemetry.evictions).toBe(1);
+		expect(summarizeMemoryBenchmark(report)).toContain("cloud fallback");
+	});
+});

--- a/plugins/plugin-local-inference/src/services/memory-benchmark.ts
+++ b/plugins/plugin-local-inference/src/services/memory-benchmark.ts
@@ -1,0 +1,354 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+	ELIZA_1_CONTEXT_TARGET,
+	ELIZA_1_KV_QUANT,
+	selectBestEliza1Fit,
+} from "@elizaos/shared/local-inference";
+import type { ArbiterEvent } from "./memory-arbiter";
+import type {
+	CatalogModel,
+	HardwareProbe,
+	InstalledModel,
+	ModelHubSnapshot,
+} from "./types";
+
+const BYTES_PER_MIB = 1024 * 1024;
+
+export interface MemoryBenchmarkModelPlan {
+	modelId: string;
+	displayName: string;
+	installed: boolean;
+	path: string | null;
+	bundleRoot: string | null;
+	bundleSizeMb: number | null;
+	fileSizeMb: number | null;
+	estimatedResidentMb: number;
+	catalogMinRamMb: number | null;
+	catalogContextLength: number | null;
+	fit: "fits" | "tight" | "wontfit";
+	selectedByDeviceFit: boolean;
+	plannedContextLength: number | null;
+	plannedKvQuant: typeof ELIZA_1_KV_QUANT | null;
+}
+
+export interface MemoryBenchmarkLoadResult {
+	modelId: string;
+	ok: boolean;
+	loadMs: number | null;
+	generateMs: number | null;
+	generatedTokens: number | null;
+	generatedTokensPerSec: number | null;
+	rssBeforeMb: number;
+	rssAfterLoadMb: number | null;
+	rssAfterGenerateMb: number | null;
+	rssDeltaMb: number | null;
+	loadedContextSize: number | null;
+	loadedCacheTypeK: string | null;
+	loadedCacheTypeV: string | null;
+	error: string | null;
+}
+
+export interface MemoryBenchmarkReport {
+	generatedAt: string;
+	host: {
+		platform: NodeJS.Platform;
+		arch: NodeJS.Architecture;
+		totalRamGb: number;
+		freeRamGb: number;
+		cpuCores: number;
+	};
+	deviceFit: {
+		modelId: string | null;
+		contextLength: number | null;
+		kvQuant: typeof ELIZA_1_KV_QUANT | null;
+		contextDownscaled: boolean;
+		reason: string | null;
+	};
+	models: MemoryBenchmarkModelPlan[];
+	loads: MemoryBenchmarkLoadResult[];
+	telemetry: {
+		modelLoads: number;
+		modelUnloads: number;
+		evictions: number;
+		memoryPressureEvents: number;
+		events: ArbiterEvent[];
+	};
+}
+
+export interface MemoryBenchmarkOptions {
+	loadInstalled?: boolean;
+	prompt?: string;
+	maxTokens?: number;
+	outFile?: string;
+}
+
+function mbFromBytes(bytes: number | undefined): number | null {
+	if (!Number.isFinite(bytes) || !bytes || bytes <= 0) return null;
+	return Math.ceil(bytes / BYTES_PER_MIB);
+}
+
+function catalogMinRamMb(model: CatalogModel): number | null {
+	return typeof model.minRamGb === "number"
+		? Math.ceil(model.minRamGb * 1024)
+		: null;
+}
+
+function estimateResidentMb(
+	model: CatalogModel,
+	installed: InstalledModel | undefined,
+): number {
+	const bundleMb = mbFromBytes(installed?.bundleSizeBytes);
+	if (bundleMb !== null) return bundleMb;
+	const minRamMb = catalogMinRamMb(model);
+	if (minRamMb !== null) return minRamMb;
+	const fileMb = mbFromBytes(installed?.sizeBytes);
+	if (fileMb !== null) return fileMb;
+	return Math.ceil((model.sizeGb ?? 0) * 1024);
+}
+
+function inferFit(
+	hardware: HardwareProbe,
+	model: CatalogModel,
+): "fits" | "tight" | "wontfit" {
+	if (typeof model.minRamGb !== "number") return "wontfit";
+	if (hardware.freeRamGb >= model.minRamGb) return "fits";
+	if (hardware.totalRamGb >= model.minRamGb) return "tight";
+	return "wontfit";
+}
+
+export function buildMemoryBenchmarkPlan(snapshot: {
+	catalog: CatalogModel[];
+	installed: InstalledModel[];
+	hardware: HardwareProbe;
+}): MemoryBenchmarkModelPlan[] {
+	const recommended = selectBestEliza1Fit(snapshot.hardware.freeRamGb);
+	const installedById = new Map(
+		snapshot.installed.map((model) => [model.id, model]),
+	);
+
+	return snapshot.catalog
+		.filter((model) => !model.hiddenFromCatalog)
+		.map((model) => {
+			const installed = installedById.get(model.id);
+			const selected = recommended?.tierId === model.id;
+			return {
+				modelId: model.id,
+				displayName: model.displayName,
+				installed: Boolean(installed),
+				path: installed?.path ?? null,
+				bundleRoot: installed?.bundleRoot ?? null,
+				bundleSizeMb: mbFromBytes(installed?.bundleSizeBytes),
+				fileSizeMb: mbFromBytes(installed?.sizeBytes),
+				estimatedResidentMb: estimateResidentMb(model, installed),
+				catalogMinRamMb: catalogMinRamMb(model),
+				catalogContextLength: model.contextLength ?? null,
+				fit: inferFit(snapshot.hardware, model),
+				selectedByDeviceFit: selected,
+				plannedContextLength: selected
+					? recommended.contextLength
+					: (model.contextLength ?? ELIZA_1_CONTEXT_TARGET),
+				plannedKvQuant: selected ? recommended.kvQuant : ELIZA_1_KV_QUANT,
+			};
+		});
+}
+
+function rssMb(): number {
+	return Math.round(process.memoryUsage.rss() / BYTES_PER_MIB);
+}
+
+function generatedTokenEstimate(text: string): number {
+	const trimmed = text.trim();
+	if (!trimmed) return 0;
+	return Math.max(1, Math.ceil(trimmed.length / 4));
+}
+
+function eventCounts(
+	events: ArbiterEvent[],
+): MemoryBenchmarkReport["telemetry"] {
+	return {
+		modelLoads: events.filter((event) => event.type === "model_load").length,
+		modelUnloads: events.filter((event) => event.type === "model_unload")
+			.length,
+		evictions: events.filter((event) => event.type === "eviction").length,
+		memoryPressureEvents: events.filter(
+			(event) => event.type === "memory_pressure",
+		).length,
+		events,
+	};
+}
+
+async function loadAndMeasure(
+	model: InstalledModel,
+	options: Required<Pick<MemoryBenchmarkOptions, "prompt" | "maxTokens">>,
+	deps: {
+		service: typeof import("./service").localInferenceService;
+		engine: typeof import("./engine").localInferenceEngine;
+	},
+): Promise<MemoryBenchmarkLoadResult> {
+	const before = rssMb();
+	const start = performance.now();
+	try {
+		const state = await deps.service.setActive(null, model.id);
+		const afterLoad = rssMb();
+		const loadMs = performance.now() - start;
+		let generateMs: number | null = null;
+		let generatedTokens: number | null = null;
+		let generatedTokensPerSec: number | null = null;
+		let afterGenerate: number | null = null;
+
+		if (deps.engine.hasLoadedModel()) {
+			const generateStart = performance.now();
+			const text = await deps.engine.generate({
+				prompt: options.prompt,
+				maxTokens: options.maxTokens,
+				temperature: 0,
+			});
+			generateMs = performance.now() - generateStart;
+			generatedTokens = generatedTokenEstimate(text);
+			generatedTokensPerSec =
+				generateMs > 0 ? generatedTokens / (generateMs / 1000) : null;
+			afterGenerate = rssMb();
+		}
+
+		return {
+			modelId: model.id,
+			ok: state.status === "ready",
+			loadMs: Math.round(loadMs),
+			generateMs: generateMs === null ? null : Math.round(generateMs),
+			generatedTokens,
+			generatedTokensPerSec:
+				generatedTokensPerSec === null
+					? null
+					: Number(generatedTokensPerSec.toFixed(2)),
+			rssBeforeMb: before,
+			rssAfterLoadMb: afterLoad,
+			rssAfterGenerateMb: afterGenerate,
+			rssDeltaMb: (afterGenerate ?? afterLoad) - before,
+			loadedContextSize: state.loadedContextSize ?? null,
+			loadedCacheTypeK: state.loadedCacheTypeK ?? null,
+			loadedCacheTypeV: state.loadedCacheTypeV ?? null,
+			error: state.status === "error" ? (state.error ?? "load failed") : null,
+		};
+	} catch (err) {
+		return {
+			modelId: model.id,
+			ok: false,
+			loadMs: null,
+			generateMs: null,
+			generatedTokens: null,
+			generatedTokensPerSec: null,
+			rssBeforeMb: before,
+			rssAfterLoadMb: null,
+			rssAfterGenerateMb: null,
+			rssDeltaMb: null,
+			loadedContextSize: null,
+			loadedCacheTypeK: null,
+			loadedCacheTypeV: null,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
+function hostFromHardware(
+	hardware: HardwareProbe,
+): MemoryBenchmarkReport["host"] {
+	return {
+		platform: hardware.platform,
+		arch: hardware.arch,
+		totalRamGb: hardware.totalRamGb,
+		freeRamGb: hardware.freeRamGb,
+		cpuCores: hardware.cpuCores,
+	};
+}
+
+function deviceFitFromHardware(
+	hardware: HardwareProbe,
+): MemoryBenchmarkReport["deviceFit"] {
+	const fit = selectBestEliza1Fit(hardware.freeRamGb);
+	return {
+		modelId: fit?.tierId ?? null,
+		contextLength: fit?.contextLength ?? null,
+		kvQuant: fit?.kvQuant ?? null,
+		contextDownscaled: fit?.contextDownscaled ?? false,
+		reason: fit?.reason ?? null,
+	};
+}
+
+export async function buildMemoryBenchmarkReport(
+	snapshot: Pick<ModelHubSnapshot, "catalog" | "installed" | "hardware">,
+	events: ArbiterEvent[] = [],
+	loads: MemoryBenchmarkLoadResult[] = [],
+): Promise<MemoryBenchmarkReport> {
+	return {
+		generatedAt: new Date().toISOString(),
+		host: hostFromHardware(snapshot.hardware),
+		deviceFit: deviceFitFromHardware(snapshot.hardware),
+		models: buildMemoryBenchmarkPlan(snapshot),
+		loads,
+		telemetry: eventCounts(events),
+	};
+}
+
+export async function runMemoryBenchmark(
+	options: MemoryBenchmarkOptions = {},
+): Promise<MemoryBenchmarkReport> {
+	const [{ localInferenceService }, { localInferenceEngine }] =
+		await Promise.all([import("./service"), import("./engine")]);
+	const events: ArbiterEvent[] = [];
+	const arbiter = localInferenceService.getMemoryArbiter();
+	const unsubscribe = arbiter.onEvent((event) => {
+		events.push(event);
+	});
+
+	const snapshot = await localInferenceService.snapshot();
+	const loads: MemoryBenchmarkLoadResult[] = [];
+	const prompt =
+		options.prompt ??
+		"Summarize why a curated Eliza-1 local model should choose its own memory profile.";
+	const maxTokens = options.maxTokens ?? 32;
+
+	try {
+		if (options.loadInstalled) {
+			for (const installed of snapshot.installed.filter(
+				(model) => model.source === "eliza-download",
+			)) {
+				loads.push(
+					await loadAndMeasure(
+						installed,
+						{ prompt, maxTokens },
+						{ service: localInferenceService, engine: localInferenceEngine },
+					),
+				);
+				await localInferenceService.clearActive(null);
+			}
+		}
+	} finally {
+		unsubscribe();
+	}
+
+	const report = await buildMemoryBenchmarkReport(snapshot, events, loads);
+	if (options.outFile) {
+		await mkdir(dirname(options.outFile), { recursive: true });
+		await writeFile(options.outFile, `${JSON.stringify(report, null, 2)}\n`);
+	}
+	return report;
+}
+
+export function summarizeMemoryBenchmark(
+	report: MemoryBenchmarkReport,
+): string {
+	const selected = report.deviceFit.modelId
+		? `${report.deviceFit.modelId} @ ${report.deviceFit.contextLength} ctx`
+		: "cloud fallback";
+	const installed = report.models.filter((model) => model.installed).length;
+	const loaded = report.loads.filter((load) => load.ok).length;
+	return [
+		`Eliza-1 memory benchmark (${report.generatedAt})`,
+		`Host: ${report.host.platform}/${report.host.arch}, ${report.host.freeRamGb.toFixed(1)} GB free of ${report.host.totalRamGb.toFixed(1)} GB`,
+		`Device-fit pick: ${selected}`,
+		`Catalog tiers: ${report.models.length}; installed: ${installed}; loaded: ${loaded}`,
+		`Telemetry: loads=${report.telemetry.modelLoads}, unloads=${report.telemetry.modelUnloads}, evictions=${report.telemetry.evictions}, pressure=${report.telemetry.memoryPressureEvents}`,
+	].join("\n");
+}


### PR DESCRIPTION
## Summary
- Add an Eliza-1 local-inference memory benchmark CLI/service that reports host fit, resident estimates, installed bundle footprint, optional live load/decode measurement, and arbiter telemetry.
- Enforce curated Eliza-1 assignment IDs so generic/custom model IDs cannot be persisted into local inference slots.
- Clean up monorepo gate issues found while validating the branch, including the UI client chat helper, plugin-training view import, and final-base orchestrator formatting.

Refs #8809 (partial: write-time assignment enforcement + memory-benchmark harness only; the #8809 estimatedMb/LRU-eviction work and budgets.json gate are NOT addressed here)
Refs #8848
Refs #8808
Refs #8807

Note: #8808's original arbitrary-GGUF request is intentionally resolved in the opposite product direction per current guidance: local inference remains curated Eliza-1-only through the dedicated FFI path, with generic/custom search disabled by default.

## Validation
- `NODE_OPTIONS='--experimental-sqlite' bun run --cwd plugins/plugin-local-inference test src/services/assignments.test.ts src/services/assignment-validation.test.ts src/services/downloader.test.ts src/services/manifest/manifest.test.ts src/services/memory-arbiter.test.ts src/services/catalog.test.ts src/services/live-signals.test.ts src/services/memory-monitor.test.ts src/services/memory-benchmark.test.ts src/routes/local-inference-compat-routes.test.ts`
- `bun run --cwd plugins/plugin-local-inference memory:benchmark`
- `bun run --cwd packages/shared test src/local-inference/catalog.test.ts src/local-inference/device-fit.test.ts src/local-inference/runtime-class.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- conflict marker scan