### PR TITLE
fix: green the 7 failing windows-ci lanes

### DIFF
--- a/packages/app-core/src/services/phrase-chunked-tts.test.ts
+++ b/packages/app-core/src/services/phrase-chunked-tts.test.ts
@@ -328,7 +328,11 @@ describe("PhraseChunkedTts — latency benchmark assertions", () => {
 
     expect(dispatchAt.length).toBeGreaterThanOrEqual(3);
     // First TTS call must happen on the first ! — which is after about 3
-    // tokens (≈ 27 ms inter-token + overhead). Generous upper bound.
-    expect(dispatchAt[0]).toBeLessThan(80);
+    // tokens. Generous upper bound: the whole text streams over ~17 tokens, so
+    // a late (end-buffered) dispatch would land well past this; the bound only
+    // needs to separate "dispatched on the boundary" from "dispatched at end".
+    // Windows' ~15.6 ms default timer resolution rounds each 9 ms setTimeout up,
+    // so the early dispatch + scheduler jitter can exceed a tight 80 ms cap.
+    expect(dispatchAt[0]).toBeLessThan(150);
   });
 });

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -155,6 +155,8 @@ export default defineConfig({
       // Uses Node.js built-in test runner (node:test), not vitest.
       "scripts/android-sms-gateway-template.test.mjs",
       "scripts/stage-android-agent.test.mjs",
+      // Uses bun:test, not vitest.
+      "scripts/aosp/stage-default-models.test.mjs",
       ...(process.platform === "win32"
         ? ["scripts/lib/apple-entitlement-audit.test.mjs"]
         : []),

--- a/packages/core/src/__tests__/action-handler-callsite-audit.test.ts
+++ b/packages/core/src/__tests__/action-handler-callsite-audit.test.ts
@@ -85,6 +85,10 @@ const allowedCallsites = new Map<string, string>([
 		"plugins/plugin-app-control/src/actions/views.ts",
 		"VIEWS close-alias dispatcher (CLOSE_VIEW / CLOSE_ALL_VIEWS); forwards to the underlying VIEWS handler",
 	],
+	[
+		"packages/core/src/services/message.ts",
+		"shortcut-gate (runShortcutGate, #8792): fires a slash-command action; its callback only captures content.text (emits nothing) and the captured text is returned as a Stage1 direct_reply, so the normal message-service voice rewrite still applies",
+	],
 ]);
 
 const actionHandlerCallPattern = new RegExp(

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -492,7 +492,11 @@ describe("runV5MessageRuntimeStage1", () => {
 		]);
 		expect(required).not.toContain("shouldRespond");
 		expect(required).not.toContain("facts");
-		expect(params.maxTokens).toBe(384);
+		// Direct channels use DIRECT_CHANNEL_STAGE1_MAX_TOKENS (1024) — the cap
+		// was raised from 384 in services/message.ts so long single-turn direct
+		// replies aren't truncated. The schema stays compact (asserted above);
+		// only the token ceiling grew.
+		expect(params.maxTokens).toBe(1024);
 		expect(
 			params.responseSkeleton?.spans?.some((s) => s.key === "shouldRespond"),
 		).toBe(false);

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -60,6 +60,7 @@ const packageJsonPath = resolve(
 const IMPORTED_CORE_PLUGINS: Record<string, Plugin> = {
   "@elizaos/plugin-app-control": appControlPlugin,
   "@elizaos/plugin-coding-tools": codingToolsPlugin,
+  "@elizaos/plugin-commands": commandsPlugin,
   "@elizaos/plugin-agent-skills": agentSkillsPlugin,
   "@elizaos/plugin-local-inference": localInferencePlugin,
   "@elizaos/plugin-gitpathologist": gitPathologyPlugin,
@@ -75,6 +76,15 @@ const IMPORTED_CORE_PLUGINS: Record<string, Plugin> = {
 const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
   "@elizaos/plugin-app-control": ["APP", "HOMESCREEN", "VIEWS"],
   "@elizaos/plugin-coding-tools": ["FILE", "SHELL", "WORKTREE"],
+  "@elizaos/plugin-commands": [
+    "COMMANDS_COMMAND",
+    "CONTEXT_COMMAND",
+    "HELP_COMMAND",
+    "MODELS_COMMAND",
+    "STATUS_COMMAND",
+    "USAGE_COMMAND",
+    "WHOAMI_COMMAND",
+  ],
   "@elizaos/plugin-agent-skills": [
     "SKILL",
     "SKILL_DETAILS",
@@ -127,7 +137,6 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
 /** Core plugins that intentionally expose no agent actions (service/registry only). */
 const ACTIONLESS_CORE_PLUGINS: Record<string, Plugin> = {
   "@elizaos/plugin-shell": shellPlugin,
-  "@elizaos/plugin-commands": commandsPlugin,
   "@elizaos/plugin-video": videoPlugin,
   "@elizaos/plugin-device-filesystem": deviceFilesystemPlugin,
 };
@@ -183,6 +192,16 @@ const KNOWN_UNCOVERED: readonly string[] = [
   // New on-device transcription actions; no deterministic keyless scenario yet.
   "START_TRANSCRIPTION",
   "STOP_TRANSCRIPTION",
+  // plugin-commands slash-command actions (/help, /status, /models, …) are
+  // dispatched through the command palette, not the keyless scenario pipeline,
+  // so they have no deterministic scenario yet.
+  "COMMANDS_COMMAND",
+  "CONTEXT_COMMAND",
+  "HELP_COMMAND",
+  "MODELS_COMMAND",
+  "STATUS_COMMAND",
+  "USAGE_COMMAND",
+  "WHOAMI_COMMAND",
 ];
 
 /**

--- a/packages/scenario-runner/vitest.config.ts
+++ b/packages/scenario-runner/vitest.config.ts
@@ -70,8 +70,13 @@ const workspaceSourceAliases = workspacePluginDirs.flatMap((workspaceDir) =>
             replacement: indexPath,
           },
           {
+            // No `.ts` suffix: a subpath can be a file (`foo` -> `foo.ts`) OR a
+            // directory (`local-inference` -> `local-inference/index.ts`). Let
+            // vite's resolver add the extension / index so directory subpaths
+            // like `@elizaos/shared/local-inference` and `@elizaos/ui/components`
+            // resolve instead of looking for a literal `local-inference.ts`.
             find: new RegExp(`^${packageName}/(.*)$`),
-            replacement: path.join(sourceDir, "$1.ts"),
+            replacement: path.join(sourceDir, "$1"),
           },
         ])
     : [],
@@ -138,6 +143,13 @@ export default defineConfig({
         ),
       },
       ...workspaceSourceAliases,
-    ],
+    ].map((entry) => ({
+      ...entry,
+      // vite `resolve.alias` replacements must be POSIX forward-slash paths.
+      // `path.join` yields backslashes on Windows, which break vite's alias
+      // matching (specifiers like `@elizaos/shared/local-inference` then fall
+      // through to Node and fail with "Cannot find package"). No-op on POSIX.
+      replacement: entry.replacement.split("\\").join("/"),
+    })),
   },
 });

--- a/packages/test/vitest/default.config.ts
+++ b/packages/test/vitest/default.config.ts
@@ -137,7 +137,14 @@ const workspaceReactTestRendererEntry = path.join(
   "index.js",
 );
 const workspaceAdzeEntry = path.join(workspaceAdzeDir, "dist", "index.js");
-const asViteFsPath = (targetPath: string) => `/@fs${targetPath}`;
+// Vite's `/@fs/` protocol expects a POSIX, forward-slash absolute path. On
+// POSIX `path.join(...)` already yields `/abs/...` so `/@fs` + that gives
+// `/@fs/abs/...`. On Windows it yields `C:\abs\...` (backslashes, no leading
+// slash), so a naive `/@fs${p}` produces `/@fsC:\abs\...` which vite's
+// `/@fs/`-prefix check never matches → "Cannot find package". Normalize
+// backslashes to `/` and ensure exactly one separator after `/@fs`.
+const asViteFsPath = (targetPath: string) =>
+  `/@fs/${targetPath.split("\\").join("/").replace(/^\/+/, "")}`;
 const workspacePluginPackageNames = Object.keys({
   ...(packageManifest.dependencies ?? {}),
   ...(packageManifest.devDependencies ?? {}),

--- a/packages/test/vitest/workspace-aliases.ts
+++ b/packages/test/vitest/workspace-aliases.ts
@@ -51,6 +51,17 @@ function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * vite/rollup `resolve.alias` replacements must be POSIX, forward-slash paths.
+ * `path.join` yields backslash paths on Windows (e.g. `C:\src\local-inference`),
+ * which vite fails to resolve — surfacing as "Cannot find package
+ * '@elizaos/<pkg>/<subpath>'". Normalize at the point each replacement is built.
+ * No-op on POSIX (paths have no backslashes), so Linux/macOS behavior is identical.
+ */
+function toPosix(targetPath: string): string {
+  return targetPath.split("\\").join("/");
+}
+
 function readWorkspacePackageManifest(
   packageRoot: string,
 ): WorkspacePackageManifest | null {
@@ -124,7 +135,7 @@ function getWorkspacePackageExportAliases(
             subpath.slice(2),
           )}$`,
         ),
-        replacement,
+        replacement: toPosix(replacement),
       },
     ];
   });
@@ -141,18 +152,19 @@ function getPackageSourceAliases(
     rootReplacement: string;
   },
 ): ModuleAlias[] {
+  const normalizedRoot = toPosix(rootReplacement);
   return [
     ...(includeElizaAlias
       ? [
           {
             find: `@elizaai/${packageName}`,
-            replacement: rootReplacement,
+            replacement: normalizedRoot,
           },
         ]
       : []),
     {
       find: `@elizaos/${packageName}`,
-      replacement: rootReplacement,
+      replacement: normalizedRoot,
     },
   ];
 }
@@ -184,11 +196,16 @@ export function getOptionalInstalledPackageAliases(
     );
 
     if (installedEntry) {
-      return [{ find, replacement: installedEntry }];
+      return [{ find, replacement: toPosix(installedEntry) }];
     }
 
     return options?.fallbackPath
-      ? [{ find, replacement: resolveModuleEntry(options.fallbackPath) }]
+      ? [
+          {
+            find,
+            replacement: toPosix(resolveModuleEntry(options.fallbackPath)),
+          },
+        ]
       : [];
   });
 }
@@ -267,7 +284,7 @@ export function getAgentSourceAliases(
     return [
       {
         find: /^@elizaos\/agent\/(.+)$/,
-        replacement: path.join(sourceRoot, "$1.ts"),
+        replacement: toPosix(path.join(sourceRoot, "$1.ts")),
       },
       ...getPackageSourceAliases("agent", sourceRoot, {
         includeElizaAlias: options.includeElizaAlias,
@@ -310,11 +327,13 @@ export function getAppCoreSourceAliases(
         ? [
             {
               find: /^@elizaos\/app-core\/(.+)$/,
-              replacement: path.join(sourceRoot, "$1"),
+              replacement: toPosix(path.join(sourceRoot, "$1")),
             },
             {
               find: "@elizaos/app-core",
-              replacement: resolveModuleEntry(path.join(sourceRoot, "index")),
+              replacement: toPosix(
+                resolveModuleEntry(path.join(sourceRoot, "index")),
+              ),
             },
           ]
         : []),
@@ -349,7 +368,7 @@ export function getSharedSourceAliases(
       // prefix-replaces them into "<src>/index.ts/<subpath>" -> ENOTDIR.
       // Mirrors the agent/app-core/ui subpath aliases above.
       find: /^@elizaos\/shared\/(.+)$/,
-      replacement: path.join(sourceRoot, "$1"),
+      replacement: toPosix(path.join(sourceRoot, "$1")),
     },
     ...getPackageSourceAliases("shared", sourceRoot, {
       includeElizaAlias: options.includeElizaAlias,
@@ -371,11 +390,11 @@ export function getUiSourceAliases(
     ...getWorkspacePackageExportAliases("ui", packageRoot),
     {
       find: /^@elizaos\/ui\/api$/,
-      replacement: path.join(sourceRoot, "api", "index.ts"),
+      replacement: toPosix(path.join(sourceRoot, "api", "index.ts")),
     },
     {
       find: /^@elizaos\/ui\/(.+)$/,
-      replacement: path.join(sourceRoot, "$1"),
+      replacement: toPosix(path.join(sourceRoot, "$1")),
     },
     ...getPackageSourceAliases("ui", sourceRoot, {
       includeElizaAlias: true,

--- a/plugins/plugin-discord/__tests__/catalog-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/catalog-commands.test.ts
@@ -175,26 +175,37 @@ describe("per-target execute branching", () => {
 		expect(arg.content).toContain("ai-model");
 	});
 
-	it("agent (gate-safe): resolves a deterministic local reply without touching the pipeline", async () => {
+	it("agent (non-gate-safe option): routes the reconstructed command text through the pipeline", async () => {
+		// `think` carries an option (`/think high`). Option commands own
+		// side effects in the pipeline, so they are NOT gate-safe and must route
+		// the reconstructed command text through the message service rather than
+		// resolving to a deterministic local reply.
 		const think = findCatalog("think");
 		const interaction = makeInteraction({ level: "high" });
-		const handleMessage = vi.fn(async () => undefined);
+		const handleMessage = vi.fn(
+			async (
+				_runtime: IAgentRuntime,
+				_message: Memory,
+				callback: (content: Content) => Promise<Memory[]>,
+			) => {
+				await callback({ text: "Thinking set to high.", source: "discord" });
+			},
+		);
 		const runtime = makeRuntime({
 			messageService: { handleMessage } as never,
 		});
 
 		await think.execute(interaction as never, runtime);
 
-		// Gate-safe commands answer locally — no pipeline round-trip, no defer.
-		expect(handleMessage).not.toHaveBeenCalled();
-		expect(interaction.deferReply).not.toHaveBeenCalled();
-		expect(interaction.reply).toHaveBeenCalledTimes(1);
-		const arg = interaction.reply.mock.calls[0][0] as {
+		expect(interaction.deferReply).toHaveBeenCalledTimes(1);
+		expect(handleMessage).toHaveBeenCalledTimes(1);
+		const routedMessage = handleMessage.mock.calls[0][1] as Memory;
+		expect(routedMessage.content.text).toBe("/think high");
+		expect(routedMessage.content.source).toBe("discord");
+		const editArg = interaction.editReply.mock.calls[0][0] as {
 			content: string;
-			ephemeral: boolean;
 		};
-		expect(arg.ephemeral).toBe(true);
-		expect(arg.content).toContain("high");
+		expect(editArg.content).toBe("Thinking set to high.");
 	});
 
 	it("agent (non-gate-safe): routes the command text through the message service and replies", async () => {

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -145,7 +145,10 @@ export function createDatabaseAdapter(
 
   const dataDir = resolvePgliteDir(config.dataDir);
 
-  if (dataDir && !dataDir.includes("://")) {
+  // `:memory:` is PGlite's in-memory sentinel, not a real path. On Windows the
+  // reserved `:` makes mkdirSync throw (on POSIX it silently creates a junk
+  // `:memory:` directory), so skip directory creation for it and for URLs.
+  if (dataDir && !dataDir.includes("://") && dataDir !== ":memory:") {
     mkdirSync(dataDir, { recursive: true });
   }
 

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -137,7 +137,10 @@ export function createDatabaseAdapter(
 
   const dataDir = resolvePgliteDir(config.dataDir);
 
-  if (dataDir && !dataDir.includes("://")) {
+  // `:memory:` is PGlite's in-memory sentinel, not a real path. On Windows the
+  // reserved `:` makes mkdirSync throw (on POSIX it silently creates a junk
+  // `:memory:` directory), so skip directory creation for it and for URLs.
+  if (dataDir && !dataDir.includes("://") && dataDir !== ":memory:") {
     mkdirSync(dataDir, { recursive: true });
   }
 

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -269,6 +269,14 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   private setupShutdownHandlers() {}
 
   private createClient(options: PGliteOptions): PGlite {
+    // PGlite's in-memory mode is the `memory://` URL. `:memory:` is SQLite
+    // syntax that PGlite does NOT recognize, so it treats it as a real path and
+    // its NodeFS mkdir()s `resolve(":memory:")` — which throws EINVAL on Windows
+    // (the `:` is reserved) and silently creates a junk `:memory:` dir on POSIX.
+    // Translate to the URL form so in-memory actually stays in memory.
+    if ((options as { dataDir?: unknown }).dataDir === ":memory:") {
+      options = { ...options, dataDir: "memory://" };
+    }
     if (process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS === "1") {
       return new PGlite(options);
     }


### PR DESCRIPTION
Greens all 7 windows-ci lanes that have been failing on develop (core, shared,
app-core, scenario-runner, discord, plugin-app-control, cloud-shared). All
verified locally on windows-latest-class hardware.

## Root causes + fixes

**Windows-specific (vite alias path separators)** — `path.join` yields
backslash paths that vite's `/@fs/` protocol + alias matching reject, so
`adze`, `@elizaos/shared/local-inference`, `@elizaos/ui/components` fell through
to Node and failed with "Cannot find package" (no-op on POSIX):
- `packages/test/vitest/default.config.ts` — `asViteFsPath` emits `/@fs/<posix>`.
- `packages/test/vitest/workspace-aliases.ts` — normalize every replacement.
- `packages/scenario-runner/vitest.config.ts` — normalize the alias array + drop
  the `.ts` suffix so directory subpaths resolve.

**Windows-specific (PGlite `:memory:`)** — `plugin-sql` passed `:memory:` to
PGlite, whose NodeFS `mkdir()`s `resolve(":memory:")` → `EINVAL` on Windows.
Map it to PGlite's `memory://` in-memory URL (`pglite/manager.ts`), plus mkdir
guards in `index.ts` / `index.node.ts`.

**Develop-wide (fail on Linux too, surfaced once suites load)**:
- core: stale `maxTokens` 384->1024; new `runShortcutGate` audit allowlist entry.
- app-core: exclude the `bun:test` file from vitest; raise a CI-flaky TTS
  latency bound (Windows ~15.6ms timer resolution).
- scenario-runner: plugin-commands gained 7 slash-command actions — track them
  in the action-coverage manifest + baseline.
- discord: `think` is no longer gate-safe — update the stale test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)