### PR TITLE
feat(attachments): PR6 — files associated with knowledge (original-byte linkage + GC-aware lifecycle) (#8876)

### DIFF
--- a/packages/agent/src/api/media-runtime.test.ts
+++ b/packages/agent/src/api/media-runtime.test.ts
@@ -16,9 +16,10 @@ afterAll(() => {
 });
 
 const { persistMediaBytes } = await import("./media-store.ts");
-const { mediaFileRoute, registerMediaPipelineHook } = await import(
-  "./media-runtime.ts"
-);
+const { collectReferencedMedia, mediaFileRoute, registerMediaPipelineHook } =
+  await import("./media-runtime.ts");
+
+type Memory = import("@elizaos/core").Memory;
 
 type CapturedHook = { handler: (rt: unknown, ctx: unknown) => unknown };
 
@@ -86,6 +87,57 @@ describe("registerMediaPipelineHook", () => {
     expect(wrongPhase.content.attachments[0].url).toBe(
       "data:image/png;base64,AA",
     );
+  });
+});
+
+describe("collectReferencedMedia", () => {
+  const HASH_A = "a".repeat(64);
+  const HASH_B = "b".repeat(64);
+
+  it("collects a file referenced only via memory.metadata.mediaUrl", () => {
+    const memories = [
+      {
+        // Document-linked original-bytes file: no content.attachments entry.
+        content: { text: "a knowledge doc" },
+        metadata: { type: "document", mediaUrl: `/api/media/${HASH_A}.pdf` },
+      },
+    ] as unknown as Memory[];
+
+    const referenced = collectReferencedMedia(memories);
+
+    expect(referenced.has(`${HASH_A}.pdf`)).toBe(true);
+  });
+
+  it("collects from both content.attachments and metadata.mediaUrl", () => {
+    const memories = [
+      {
+        content: {
+          text: "msg",
+          attachments: [{ url: `/api/media/${HASH_B}.png` }],
+        },
+        metadata: { type: "document", mediaUrl: `/api/media/${HASH_A}.pdf` },
+      },
+    ] as unknown as Memory[];
+
+    const referenced = collectReferencedMedia(memories);
+
+    expect(referenced.has(`${HASH_A}.pdf`)).toBe(true);
+    expect(referenced.has(`${HASH_B}.png`)).toBe(true);
+    expect(referenced.size).toBe(2);
+  });
+
+  it("ignores non-media metadata.mediaUrl values", () => {
+    const memories = [
+      {
+        content: { text: "x" },
+        metadata: { type: "document", mediaUrl: "https://example.com/x.pdf" },
+      },
+      { content: { text: "y" }, metadata: { type: "document" } },
+    ] as unknown as Memory[];
+
+    const referenced = collectReferencedMedia(memories);
+
+    expect(referenced.size).toBe(0);
   });
 });
 

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -88,16 +88,27 @@ const MEDIA_GC_TASK_NAME = "MEDIA_GC";
 const MEDIA_GC_TAGS = ["queue", "repeat", "media-gc"];
 const MEDIA_GC_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
 
-function collectReferencedMedia(memories: Memory[]): Set<string> {
+export function collectReferencedMedia(memories: Memory[]): Set<string> {
   const referenced = new Set<string>();
   for (const memory of memories) {
     const attachments = (
       memory.content as { attachments?: Array<{ url?: unknown }> } | undefined
     )?.attachments;
-    if (!Array.isArray(attachments)) continue;
-    for (const attachment of attachments) {
-      const url = typeof attachment?.url === "string" ? attachment.url : "";
-      const name = mediaFileNameFromUrl(url);
+    if (Array.isArray(attachments)) {
+      for (const attachment of attachments) {
+        const url = typeof attachment?.url === "string" ? attachment.url : "";
+        const name = mediaFileNameFromUrl(url);
+        if (name) referenced.add(name);
+      }
+    }
+
+    // Document-linked original-bytes files: a knowledge document references its
+    // stored original via `metadata.mediaUrl` (no content.attachments entry).
+    // Collect it so the file survives GC while the document still references it.
+    const mediaUrl = (memory.metadata as { mediaUrl?: unknown } | undefined)
+      ?.mediaUrl;
+    if (typeof mediaUrl === "string") {
+      const name = mediaFileNameFromUrl(mediaUrl);
       if (name) referenced.add(name);
     }
   }

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -207,6 +207,12 @@ export interface DocumentMemoryMetadata
 	textBacked?: boolean;
 	timestamp?: number;
 	editedAt?: number;
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaUrl?: string;
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaHash?: string;
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaFileName?: string;
 }
 export interface DocumentFragmentMemoryMetadata
 	extends FragmentMetadata,

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -50,6 +50,12 @@ export interface BaseMetadata {
 export interface DocumentMetadata {
 	base?: BaseMetadata;
 	type?: "document";
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaUrl?: string;
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaHash?: string;
+	/** Served original-bytes file (content-addressed) linked to this document. */
+	mediaFileName?: string;
 }
 
 export interface FragmentMetadata {

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -30,6 +30,11 @@ export interface PresentedDocument {
   addedByRole?: string;
   addedFrom?: string;
   url?: string;
+  /** Served URL of the original-bytes file linked to this document, so the
+   *  detail view can offer "download original" (PR6). */
+  mediaUrl?: string;
+  /** Stored filename of the linked original-bytes file (PR6). */
+  mediaFileName?: string;
   provenance: DocumentProvenance;
   canEditText: boolean;
   editabilityReason?: string;
@@ -399,6 +404,12 @@ export function presentDocument(
     addedByRole: asString(metadata?.addedByRole),
     addedFrom: asString(metadata?.addedFrom),
     url: asString(metadata?.url),
+    ...(asString(metadata?.mediaUrl)
+      ? { mediaUrl: asString(metadata?.mediaUrl) }
+      : {}),
+    ...(asString(metadata?.mediaFileName)
+      ? { mediaFileName: asString(metadata?.mediaFileName) }
+      : {}),
     provenance,
     canEditText: editability.canEditText,
     editabilityReason: editability.reason,

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -1,5 +1,6 @@
 import type {
   AgentRuntime,
+  IFileStorageService,
   Memory,
   RouteHelpers,
   RouteRequestContext,
@@ -9,6 +10,7 @@ import {
   __setDocumentUrlFetchImplForTests,
   fetchDocumentFromUrl,
   isYouTubeUrl,
+  ServiceType,
 } from "@elizaos/core";
 import { parseClampedFloat, parsePositiveInteger } from "@elizaos/shared";
 import {
@@ -1032,6 +1034,9 @@ export async function handleDocumentsRoutes(
     warnings?: string[];
   }> {
     let content = document.content;
+    // Capture the bytes exactly as uploaded before any content rewrite (e.g.
+    // image → description text), so the linked original-bytes file is faithful.
+    const originalContent = document.content;
     const originalContentType = document.contentType || "text/plain";
     let contentType = originalContentType;
     const warnings: string[] = [];
@@ -1095,6 +1100,42 @@ export async function handleDocumentsRoutes(
         : actor.entityId;
     const metadata = asRecord(document.metadata);
 
+    // Persist the ORIGINAL uploaded bytes (content-addressed) and link them on
+    // the document record so it stays downloadable/previewable. Best-effort: a
+    // missing service or storage failure must never fail the upload — we log a
+    // warning and proceed without the link.
+    let mediaLink:
+      | { mediaUrl: string; mediaHash: string; mediaFileName: string }
+      | undefined;
+    if (originalContent.length > 0) {
+      try {
+        const fileStorage = runtime?.getService(
+          ServiceType.REMOTE_FILES,
+        ) as IFileStorageService | null;
+        if (fileStorage) {
+          // Text uploads carry UTF-8 text; binary/non-text uploads (images,
+          // PDFs, …) arrive base64-encoded in `content`.
+          const bytes = textBacked
+            ? Buffer.from(originalContent, "utf8")
+            : Buffer.from(originalContent, "base64");
+          const stored = await fileStorage.store(bytes, originalContentType);
+          mediaLink = {
+            mediaUrl: stored.url,
+            mediaHash: stored.hash,
+            mediaFileName: stored.fileName,
+          };
+        }
+      } catch (storageErr) {
+        runtime?.logger?.warn(
+          `[documents] failed to persist original bytes for "${document.filename}": ${
+            storageErr instanceof Error
+              ? storageErr.message
+              : String(storageErr)
+          }`,
+        );
+      }
+    }
+
     const result = await service.addDocument({
       agentId,
       worldId,
@@ -1121,6 +1162,7 @@ export async function handleDocumentsRoutes(
         ...(scopedToEntityId ? { scopedToEntityId } : {}),
         addedBy: actor.entityId,
         addedByRole: routeActorAddedByRole(actor),
+        ...(mediaLink ?? {}),
       },
     });
 

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -243,6 +243,130 @@ describe("document routes", () => {
     expect(getMemoryById).not.toHaveBeenCalled();
   });
 
+  it("links original bytes (mediaUrl/mediaHash/mediaFileName) when a file-storage service is present", async () => {
+    const store = vi.fn(
+      async (bytes: Buffer | Uint8Array, mimeType: string) => {
+        void bytes;
+        void mimeType;
+        return {
+          url: "/api/media/deadbeef.txt",
+          hash: "deadbeef",
+          fileName: "deadbeef.txt",
+          mimeType: "text/plain",
+          size: 11,
+        };
+      },
+    );
+    const getService = vi.fn(() => ({ store }));
+    addDocument.mockResolvedValueOnce({
+      clientDocumentId: "doc-id",
+      fragmentCount: 1,
+    });
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/documents",
+      runtime: { getService } as Partial<
+        NonNullable<DocumentRouteContext["runtime"]>
+      >,
+      body: {
+        content: "hello world",
+        filename: "notes.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    expect(store).toHaveBeenCalledTimes(1);
+    // Text upload → bytes are UTF-8 of the original content.
+    expect((store.mock.calls[0][0] as Buffer).toString("utf8")).toBe(
+      "hello world",
+    );
+    expect(addDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          mediaUrl: "/api/media/deadbeef.txt",
+          mediaHash: "deadbeef",
+          mediaFileName: "deadbeef.txt",
+        }),
+      }),
+    );
+  });
+
+  it("succeeds without a media link when no file-storage service is available", async () => {
+    addDocument.mockResolvedValueOnce({
+      clientDocumentId: "doc-id",
+      fragmentCount: 1,
+    });
+    const getService = vi.fn(() => null);
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/documents",
+      runtime: { getService } as Partial<
+        NonNullable<DocumentRouteContext["runtime"]>
+      >,
+      body: {
+        content: "hello world",
+        filename: "notes.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      documentId: "doc-id",
+      fragmentCount: 1,
+    });
+    const passedMetadata = (
+      addDocument.mock.calls[0][0] as {
+        metadata: Record<string, unknown>;
+      }
+    ).metadata;
+    expect(passedMetadata.mediaUrl).toBeUndefined();
+    expect(passedMetadata.mediaHash).toBeUndefined();
+    expect(passedMetadata.mediaFileName).toBeUndefined();
+  });
+
+  it("does not fail the upload when the file-storage service throws", async () => {
+    const store = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+    const getService = vi.fn(() => ({ store }));
+    const warn = vi.fn();
+    addDocument.mockResolvedValueOnce({
+      clientDocumentId: "doc-id",
+      fragmentCount: 1,
+    });
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/documents",
+      runtime: { getService, logger: { warn } } as unknown as Partial<
+        NonNullable<DocumentRouteContext["runtime"]>
+      >,
+      body: {
+        content: "hello world",
+        filename: "notes.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const passedMetadata = (
+      addDocument.mock.calls[0][0] as {
+        metadata: Record<string, unknown>;
+      }
+    ).metadata;
+    expect(passedMetadata.mediaUrl).toBeUndefined();
+  });
+
   it.each([
     null,
     42,


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1). **PR6 — "files associated with knowledge."** Builds on the PR5 file-storage service (#8956).

## What this does
- **core**: additive `mediaUrl` / `mediaHash` / `mediaFileName` on `DocumentMemoryMetadata` + `DocumentMetadata` (optional; a content-addressed link to the served original bytes).
- **plugin-documents**: `addDocument` (single + bulk, shared closure) resolves the `REMOTE_FILES` storage service and persists the **original uploaded bytes** (text→utf8, binary→base64), linking `mediaUrl/mediaHash/mediaFileName` on the document metadata. Fully **graceful** — a missing service or a store failure logs a warning and the upload still succeeds with no link. The presenter surfaces `mediaUrl` so the documents view can offer "download original."
- **agent**: the daily media GC's `collectReferencedMedia` now also counts `memory.metadata.mediaUrl`, so **document-linked files are not reclaimed** while the document exists.

## The lifecycle (deliberately careful, no refcount engine)
While a document exists, its `mediaUrl` keeps the file in the GC's referenced set. **Deleting the document** drops that reference; the daily grace-window GC then reclaims the file **only if nothing else** (another document or a chat message) references it. No eager cascade, no refcount/pinning engine — exactly the deferral discipline in #8876, and it satisfies "deleting knowledge can delete the file" safely (a shared file survives; a truly-orphaned one is swept).

## Tests / verification
- `plugin-documents`: **32 pass** (+ link-present, graceful-absent-service, store-throw-graceful).
- `agent media-runtime`: **7 pass** (+ metadata.mediaUrl collected, both sources, non-media ignored).
- Typecheck green (**core + agent**); Biome clean.

## Acceptance criteria covered (from #8876)
- ✅ Knowledge can be recorded with attachments; files are associated with documents.
- ✅ Deleting knowledge can delete the file — carefully, via GC, only when unreferenced.
- ✅ No new DB table / refcount-GC engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)