### PR TITLE
feat(orchestrator): TaskSupervisorService multi-task digest loop + stalled-agent watchdog

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -59,6 +59,7 @@ All are sub-operations of the single `TASKS` parent action:
 | `OrchestratorTaskService` | `ORCHESTRATOR_TASK_SERVICE` | Durable task store, sub-agent lifecycle API, event bridge from ACP to task records |
 | `SubAgentRouter` | `ACPX_SUB_AGENT_ROUTER` | Subscribes to AcpService events, routes terminal events into the runtime as synthetic memories |
 | `CodingWorkspaceService` | `CODING_WORKSPACE_SERVICE` | Git workspace lifecycle (clone, branch, commit, push, PR) |
+| `TaskSupervisorService` | `ORCHESTRATOR_TASK_SUPERVISOR` | Interval loop: posts a change-driven, deduped per-room digest of every live task; watchdogs each session for stall / near-cap / over-spend. Per-tick logic is the timer-free `runTick()`; clock is the settable `now` field. |
 
 ### Evaluator
 
@@ -111,6 +112,7 @@ plugins/plugin-agent-orchestrator/
                                  transport selection (native vs cli)
       acp-native-transport.ts    NativeAcpClient (ACP JSON-RPC over stdio)
       sub-agent-router.ts        SubAgentRouter service — terminal event → synthetic memory
+      task-supervisor-service.ts TaskSupervisorService — per-room digest loop + stalled/near-cap/over-spend watchdog (runTick + settable now)
       orchestrator-task-service.ts OrchestratorTaskService — durable task lifecycle
       orchestrator-task-store.ts Task persistence (DB or JSON file)
       orchestrator-task-mapper.ts DTOs: TaskThreadDto, TaskThreadDetailDto
@@ -208,6 +210,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
+| `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
 | `ELIZA_ACP_STATE_DIR` | `~/.eliza/plugin-acp` | Session state persistence dir when no runtime DB |
 | `ELIZA_ACP_SESSION_STORE_BACKEND` | unset | Override session store backend (`db`, `file`, or `memory`) |
 | `ELIZA_ACP_MCP_SERVERS` | unset | JSON list of MCP servers to pass to spawned sub-agents |
@@ -231,7 +234,9 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ACPX_DEFAULT_CWD` | runtime cwd | Default working directory for ACP sessions |
 | `ACPX_FORMAT` | `json` | ACP event format for the legacy CLI transport |
 | `ACPX_SUB_AGENT_ROUTER_DISABLED` | unset | Set to `1` to keep SubAgentRouter registered but unbound |
-| `ACPX_SUB_AGENT_ROUND_TRIP_CAP` | `32` | Per-session inject cap; force-stops ping-pong loops |
+| `ACPX_SUB_AGENT_ROUND_TRIP_CAP` | `32` | Per-session inject cap; force-stops ping-pong loops. Also read by `TaskSupervisorService` for the near-cap warning. |
+| `ELIZA_ORCHESTRATOR_SUPERVISOR` | `1` (enabled) | Set to `0` to disable the `TaskSupervisorService` digest loop + watchdog entirely |
+| `ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS` | `45000` | `TaskSupervisorService` tick interval (ms) |
 | `ACPX_PROGRESS_MODE` / `ELIZA_SUB_AGENT_PROGRESS_MODE` | `compact` | Progress UX: `compact`, `threaded`, or `silent` |
 | `ACPX_PROGRESS_DELAY_MS` / `ELIZA_SUB_AGENT_PROGRESS_DELAY_MS` | `15000` | Delay before first progress post (ms) |
 | `ACPX_PROGRESS_REACTIONS` / `ELIZA_SUB_AGENT_PROGRESS_REACTIONS` | unset | Set to `1` for emoji reactions in `threaded` mode |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -59,6 +59,7 @@ All are sub-operations of the single `TASKS` parent action:
 | `OrchestratorTaskService` | `ORCHESTRATOR_TASK_SERVICE` | Durable task store, sub-agent lifecycle API, event bridge from ACP to task records |
 | `SubAgentRouter` | `ACPX_SUB_AGENT_ROUTER` | Subscribes to AcpService events, routes terminal events into the runtime as synthetic memories |
 | `CodingWorkspaceService` | `CODING_WORKSPACE_SERVICE` | Git workspace lifecycle (clone, branch, commit, push, PR) |
+| `TaskSupervisorService` | `ORCHESTRATOR_TASK_SUPERVISOR` | Interval loop: posts a change-driven, deduped per-room digest of every live task; watchdogs each session for stall / near-cap / over-spend. Per-tick logic is the timer-free `runTick()`; clock is the settable `now` field. |
 
 ### Evaluator
 
@@ -111,6 +112,7 @@ plugins/plugin-agent-orchestrator/
                                  transport selection (native vs cli)
       acp-native-transport.ts    NativeAcpClient (ACP JSON-RPC over stdio)
       sub-agent-router.ts        SubAgentRouter service — terminal event → synthetic memory
+      task-supervisor-service.ts TaskSupervisorService — per-room digest loop + stalled/near-cap/over-spend watchdog (runTick + settable now)
       orchestrator-task-service.ts OrchestratorTaskService — durable task lifecycle
       orchestrator-task-store.ts Task persistence (DB or JSON file)
       orchestrator-task-mapper.ts DTOs: TaskThreadDto, TaskThreadDetailDto
@@ -232,7 +234,9 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ACPX_DEFAULT_CWD` | runtime cwd | Default working directory for ACP sessions |
 | `ACPX_FORMAT` | `json` | ACP event format for the legacy CLI transport |
 | `ACPX_SUB_AGENT_ROUTER_DISABLED` | unset | Set to `1` to keep SubAgentRouter registered but unbound |
-| `ACPX_SUB_AGENT_ROUND_TRIP_CAP` | `32` | Per-session inject cap; force-stops ping-pong loops |
+| `ACPX_SUB_AGENT_ROUND_TRIP_CAP` | `32` | Per-session inject cap; force-stops ping-pong loops. Also read by `TaskSupervisorService` for the near-cap warning. |
+| `ELIZA_ORCHESTRATOR_SUPERVISOR` | `1` (enabled) | Set to `0` to disable the `TaskSupervisorService` digest loop + watchdog entirely |
+| `ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS` | `45000` | `TaskSupervisorService` tick interval (ms) |
 | `ACPX_PROGRESS_MODE` / `ELIZA_SUB_AGENT_PROGRESS_MODE` | `compact` | Progress UX: `compact`, `threaded`, or `silent` |
 | `ACPX_PROGRESS_DELAY_MS` / `ELIZA_SUB_AGENT_PROGRESS_DELAY_MS` | `15000` | Delay before first progress post (ms) |
 | `ACPX_PROGRESS_REACTIONS` / `ELIZA_SUB_AGENT_PROGRESS_REACTIONS` | unset | Set to `1` for emoji reactions in `threaded` mode |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-sub-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-sub-agents.test.ts
@@ -150,6 +150,52 @@ describe("activeSubAgentsProvider", () => {
     expect(result.text).toContain("status=blocked");
   });
 
+  it("surfaces the stored stalled flag as a structural field", async () => {
+    const service = serviceMock({
+      listSessions: () => [
+        sub({
+          id: "00000000-cccc-dddd-eeee-000000000001",
+          status: "ready",
+          metadata: {
+            label: "demo",
+            roomId: ROOM,
+            userId: USER,
+            stalled: true,
+          },
+        }),
+      ],
+    });
+    const runtime = runtimeWith(service);
+    const result = await activeSubAgentsProvider.get(runtime, memory(), state);
+    expect(result.text).toContain("stalled=true");
+    const sessions = (result.data as { sessions: { stalled: boolean }[] })
+      .sessions;
+    expect(sessions[0]?.stalled).toBe(true);
+  });
+
+  it("omits the stalled marker when the flag is absent/false (cache-stable)", async () => {
+    const notStalled = sub({ status: "ready" });
+    const explicitFalse = sub({
+      status: "ready",
+      metadata: { label: "demo", roomId: ROOM, userId: USER, stalled: false },
+    });
+    const runs = [notStalled, explicitFalse].map(async (s) => {
+      const service = serviceMock({ listSessions: () => [s] });
+      const runtime = runtimeWith(service);
+      const result = await activeSubAgentsProvider.get(
+        runtime,
+        memory(),
+        state,
+      );
+      return result.text;
+    });
+    const [absentText, falseText] = await Promise.all(runs);
+    expect(absentText).not.toContain("stalled=");
+    // absent and explicit-false render identically — the provider reads the
+    // stored flag only, never computes staleness, so the text is cache-stable.
+    expect(absentText).toBe(falseText);
+  });
+
   it("renders identical text when only transient status flips occur", async () => {
     const sessionA = sub({ status: "ready" });
     const sessionB = sub({ status: "tool_running" });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor-service.test.ts
@@ -1,0 +1,490 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../../src/services/acp-service.js";
+import type {
+  TaskSessionDto,
+  TaskThreadDetailDto,
+  TaskThreadDto,
+} from "../../src/services/orchestrator-task-mapper.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import type { OrchestratorTaskStatus } from "../../src/services/orchestrator-task-types.js";
+import {
+  addSessionSpendUsd,
+  resetSessionSpendUsd,
+} from "../../src/services/spend-allowance.js";
+import {
+  GRILL_PROMPT,
+  TaskSupervisorService,
+} from "../../src/services/task-supervisor-service.js";
+
+const ROOM_A = "11111111-1111-1111-1111-111111111111";
+const ROOM_B = "22222222-2222-2222-2222-222222222222";
+const FIXED_NOW = 1_000_000_000_000;
+
+interface SessionMeta {
+  metadata: Record<string, unknown>;
+}
+
+function makeSession(over: Partial<TaskSessionDto> = {}): TaskSessionDto {
+  return {
+    id: "row-1",
+    threadId: "task-1",
+    sessionId: "sess-1",
+    framework: "codex",
+    providerSource: null,
+    model: null,
+    accountProviderId: null,
+    accountId: null,
+    accountLabel: null,
+    label: "alpha",
+    originalTask: "do the thing",
+    workdir: "/tmp/x",
+    repo: null,
+    status: "ready",
+    activeTool: null,
+    decisionCount: 1,
+    autoResolvedCount: 0,
+    registeredAt: FIXED_NOW,
+    lastActivityAt: FIXED_NOW,
+    idleCheckCount: 0,
+    taskDelivered: false,
+    completionSummary: null,
+    lastSeenDecisionIndex: 0,
+    lastInputSentAt: null,
+    stoppedAt: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    cacheTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+    metadata: {},
+    createdAt: new Date(FIXED_NOW).toISOString(),
+    updatedAt: new Date(FIXED_NOW).toISOString(),
+    ...over,
+  };
+}
+
+function makeDetail(
+  over: Partial<TaskThreadDetailDto> & {
+    id: string;
+    status: OrchestratorTaskStatus;
+    roomId: string;
+  },
+): TaskThreadDetailDto {
+  const session = over.sessions?.[0] ?? makeSession();
+  return {
+    id: over.id,
+    title: over.title ?? `Task ${over.id}`,
+    kind: "coding",
+    status: over.status,
+    priority: "normal",
+    paused: false,
+    originalRequest: "req",
+    summary: undefined,
+    sessionCount: 1,
+    activeSessionCount: 1,
+    latestSessionId: session.sessionId,
+    latestSessionLabel: session.label,
+    latestWorkdir: session.workdir,
+    latestRepo: null,
+    latestActivityAt: session.lastActivityAt,
+    decisionCount: session.decisionCount,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      state: "unavailable",
+      byProvider: [],
+    },
+    createdAt: new Date(FIXED_NOW).toISOString(),
+    updatedAt: new Date(FIXED_NOW).toISOString(),
+    closedAt: null,
+    archivedAt: null,
+    goal: "the goal",
+    roomId: over.roomId,
+    taskRoomId: over.roomId,
+    worldId: null,
+    ownerUserId: null,
+    parentTaskId: null,
+    acceptanceCriteria: [],
+    currentPlan: null,
+    providerPolicy: null,
+    lastUserTurnAt: null,
+    lastCoordinatorTurnAt: null,
+    metadata: over.metadata ?? { source: "telegram" },
+    sessions: over.sessions ?? [session],
+    decisions: [],
+    events: over.events ?? [
+      {
+        id: "e1",
+        threadId: over.id,
+        sessionId: session.sessionId,
+        eventType: "tool_running",
+        timestamp: FIXED_NOW,
+        summary: "Running Edit",
+        data: {},
+        createdAt: new Date(FIXED_NOW).toISOString(),
+      },
+    ],
+    artifacts: [],
+    messages: [],
+    transcripts: [],
+    planRevisions: [],
+  };
+}
+
+function threadOf(detail: TaskThreadDetailDto): TaskThreadDto {
+  return detail; // TaskThreadDetailDto extends TaskThreadDto
+}
+
+interface Harness {
+  runtime: IAgentRuntime;
+  sendMessageToTarget: ReturnType<typeof vi.fn>;
+  sendToTaskAgent: ReturnType<typeof vi.fn>;
+  updateSessionMetadata: ReturnType<typeof vi.fn>;
+  acpSessions: Map<string, SessionMeta>;
+}
+
+function buildHarness(details: TaskThreadDetailDto[]): Harness {
+  const detailById = new Map(details.map((d) => [d.id, d]));
+  const acpSessions = new Map<string, SessionMeta>();
+  for (const d of details) {
+    for (const s of d.sessions) {
+      acpSessions.set(s.sessionId, { metadata: { ...s.metadata } });
+    }
+  }
+
+  const sendMessageToTarget = vi.fn(async () => ({ id: "posted" }));
+  const sendToTaskAgent = vi.fn(async () => true);
+  const updateSessionMetadata = vi.fn(
+    async (sessionId: string, patch: Record<string, unknown>) => {
+      const cur = acpSessions.get(sessionId);
+      if (cur) cur.metadata = { ...cur.metadata, ...patch };
+    },
+  );
+
+  const taskService = {
+    listTasks: vi.fn(async () => details.map(threadOf)),
+    getTask: vi.fn(async (id: string) => detailById.get(id) ?? null),
+    sendToTaskAgent,
+  };
+  const acp = {
+    getSession: vi.fn(async (id: string) => {
+      const s = acpSessions.get(id);
+      return s ? { id, metadata: s.metadata } : undefined;
+    }),
+    updateSessionMetadata,
+  };
+
+  const runtime = {
+    getService: vi.fn((type: string) => {
+      if (type === OrchestratorTaskService.serviceType) return taskService;
+      if (type === AcpService.serviceType) return acp;
+      return null;
+    }),
+    sendMessageToTarget,
+    getMessageConnectors: vi.fn(() => [{ source: "telegram" }]),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as unknown as IAgentRuntime;
+
+  return {
+    runtime,
+    sendMessageToTarget,
+    sendToTaskAgent,
+    updateSessionMetadata,
+    acpSessions,
+  };
+}
+
+function newSupervisor(runtime: IAgentRuntime, now = FIXED_NOW) {
+  const svc = new TaskSupervisorService(runtime);
+  svc.now = () => now;
+  return svc;
+}
+
+describe("TaskSupervisorService digest loop (#8900)", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_ORCHESTRATOR_SUPERVISOR;
+    resetSessionSpendUsd();
+  });
+
+  it("posts exactly one grouped digest per room and dedups an identical tick", async () => {
+    const a = makeDetail({
+      id: "task-a",
+      title: "alpha",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [makeSession({ sessionId: "sa", label: "alpha" })],
+    });
+    const b = makeDetail({
+      id: "task-b",
+      title: "beta",
+      status: "validating",
+      roomId: ROOM_A,
+      sessions: [makeSession({ sessionId: "sb", label: "beta" })],
+    });
+    const h = buildHarness([a, b]);
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target, content] = h.sendMessageToTarget.mock.calls[0];
+    expect(target).toEqual({ source: "telegram", roomId: ROOM_A });
+    expect(content.text).toContain("[alpha]");
+    expect(content.text).toContain("[beta]");
+    // One grouped message covering both tasks, not one per task.
+    expect(content.text.split("\n").length).toBeGreaterThanOrEqual(3);
+
+    // Identical second tick → no new post (change-driven dedup).
+    await svc.runTick();
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("posts one digest per room when tasks live in different rooms", async () => {
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [makeSession({ sessionId: "sa", label: "alpha" })],
+    });
+    const b = makeDetail({
+      id: "task-b",
+      status: "blocked",
+      roomId: ROOM_B,
+      sessions: [makeSession({ sessionId: "sb", label: "beta" })],
+    });
+    const h = buildHarness([a, b]);
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(2);
+    const rooms = h.sendMessageToTarget.mock.calls.map((c) => c[0].roomId);
+    expect(new Set(rooms)).toEqual(new Set([ROOM_A, ROOM_B]));
+  });
+
+  it("re-posts when content changes (round count moves)", async () => {
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [
+        makeSession({ sessionId: "sa", label: "alpha", decisionCount: 1 }),
+      ],
+    });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+    await svc.runTick();
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    a.sessions[0].decisionCount = 5; // content changes
+    await svc.runTick();
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it("excludes terminal/open tasks from the digest", async () => {
+    const open = makeDetail({ id: "t-open", status: "open", roomId: ROOM_A });
+    const done = makeDetail({ id: "t-done", status: "done", roomId: ROOM_A });
+    const h = buildHarness([open, done]);
+    const svc = newSupervisor(h.runtime);
+    await svc.runTick();
+    expect(h.sendMessageToTarget).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when ELIZA_ORCHESTRATOR_SUPERVISOR=0", async () => {
+    const a = makeDetail({ id: "task-a", status: "active", roomId: ROOM_A });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+    process.env.ELIZA_ORCHESTRATOR_SUPERVISOR = "0";
+    await svc.start();
+    // start() must not arm a timer; runTick is still callable directly but
+    // start should have early-returned without throwing.
+    await svc.stop();
+    expect(h.sendMessageToTarget).not.toHaveBeenCalled();
+  });
+
+  it("one failing task does not abort the rest of the tick", async () => {
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [makeSession({ sessionId: "sa", label: "alpha" })],
+    });
+    const b = makeDetail({
+      id: "task-b",
+      status: "active",
+      roomId: ROOM_B,
+      sessions: [makeSession({ sessionId: "sb", label: "beta" })],
+    });
+    const h = buildHarness([a, b]);
+    // Make getTask throw for task-a only.
+    const original = (
+      h.runtime.getService(OrchestratorTaskService.serviceType) as {
+        getTask: ReturnType<typeof vi.fn>;
+      }
+    ).getTask;
+    (
+      h.runtime.getService(OrchestratorTaskService.serviceType) as {
+        getTask: ReturnType<typeof vi.fn>;
+      }
+    ).getTask = vi.fn(async (id: string) => {
+      if (id === "task-a") throw new Error("boom");
+      return original(id);
+    });
+    const svc = newSupervisor(h.runtime);
+    await svc.runTick();
+    // task-b still posted despite task-a throwing.
+    expect(h.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(h.sendMessageToTarget.mock.calls[0][0].roomId).toBe(ROOM_B);
+  });
+});
+
+describe("TaskSupervisorService stalled-agent watchdog (#8901)", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_ORCHESTRATOR_SUPERVISOR;
+    delete process.env.ELIZA_AGENT_SPEND_CAP_USD;
+    delete process.env.ACPX_SUB_AGENT_ROUND_TRIP_CAP;
+    resetSessionSpendUsd();
+  });
+
+  it("flips a session to stalled and grills it when lastEventAt is stale", async () => {
+    const staleSession = makeSession({
+      sessionId: "stale-1",
+      label: "alpha",
+      lastActivityAt: FIXED_NOW - 200_000, // > 120s stall TTL
+    });
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [staleSession],
+    });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+
+    // Grill sent down the existing send-to-agent path.
+    expect(h.sendToTaskAgent).toHaveBeenCalledTimes(1);
+    const [taskId, sessionId, prompt, reason] = h.sendToTaskAgent.mock.calls[0];
+    expect(taskId).toBe("task-a");
+    expect(sessionId).toBe("stale-1");
+    expect(prompt).toBe(GRILL_PROMPT);
+    expect(reason).toBe("watchdog_grill");
+
+    // Structural stalled flag persisted on the ACP session metadata.
+    expect(h.updateSessionMetadata).toHaveBeenCalledWith("stale-1", {
+      stalled: true,
+    });
+    expect(h.acpSessions.get("stale-1")?.metadata.stalled).toBe(true);
+  });
+
+  it("does not grill a session with fresh activity and clears a prior flag", async () => {
+    const freshSession = makeSession({
+      sessionId: "fresh-1",
+      label: "alpha",
+      lastActivityAt: FIXED_NOW - 1_000,
+      metadata: { stalled: true }, // was previously stalled
+    });
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [freshSession],
+    });
+    const h = buildHarness([a]);
+    // The ACP-side metadata reflects the prior stalled=true.
+    h.acpSessions.set("fresh-1", { metadata: { stalled: true } });
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+
+    expect(h.sendToTaskAgent).not.toHaveBeenCalled();
+    // Flag cleared back to false now that the session is active again.
+    expect(h.updateSessionMetadata).toHaveBeenCalledWith("fresh-1", {
+      stalled: false,
+    });
+  });
+
+  it("warns the room when a session is near the round-trip cap", async () => {
+    process.env.ACPX_SUB_AGENT_ROUND_TRIP_CAP = "32";
+    const nearCap = makeSession({
+      sessionId: "rt-1",
+      label: "alpha",
+      decisionCount: 30, // 32 - 3 margin = 29 threshold
+      lastActivityAt: FIXED_NOW, // not stalled
+    });
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [nearCap],
+    });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+
+    const warnings = h.sendMessageToTarget.mock.calls
+      .map((c) => c[1].text as string)
+      .filter((t) => t.includes("round-trips"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("30/32");
+
+    // Warning posts once per session, not every tick.
+    await svc.runTick();
+    const warningsAfter = h.sendMessageToTarget.mock.calls
+      .map((c) => c[1].text as string)
+      .filter((t) => t.includes("round-trips"));
+    expect(warningsAfter).toHaveLength(1);
+  });
+
+  it("warns the room when session spend exceeds 80% of the cap", async () => {
+    process.env.ELIZA_AGENT_SPEND_CAP_USD = "10";
+    addSessionSpendUsd("spend-1", 9); // 90% of $10
+    const session = makeSession({
+      sessionId: "spend-1",
+      label: "alpha",
+      lastActivityAt: FIXED_NOW,
+    });
+    const a = makeDetail({
+      id: "task-a",
+      status: "active",
+      roomId: ROOM_A,
+      sessions: [session],
+    });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+
+    await svc.runTick();
+
+    const spendWarnings = h.sendMessageToTarget.mock.calls
+      .map((c) => c[1].text as string)
+      .filter((t) => t.includes("budget"));
+    expect(spendWarnings).toHaveLength(1);
+    expect(spendWarnings[0]).toContain("$9.00");
+    expect(spendWarnings[0]).toContain("$10.00");
+  });
+});
+
+describe("TaskSupervisorService lifecycle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start arms a timer and stop clears it", async () => {
+    delete process.env.ELIZA_ORCHESTRATOR_SUPERVISOR;
+    vi.useFakeTimers();
+    const a = makeDetail({ id: "task-a", status: "active", roomId: ROOM_A });
+    const h = buildHarness([a]);
+    const svc = newSupervisor(h.runtime);
+    await svc.start();
+    await svc.stop();
+    // No throws; nothing should have fired synchronously.
+    expect(true).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -58,6 +58,7 @@ import {
 import { OrchestratorTaskService } from "./services/orchestrator-task-service.js";
 import { SubAgentInbox } from "./services/sub-agent-inbox.js";
 import { SubAgentRouter } from "./services/sub-agent-router.js";
+import { TaskSupervisorService } from "./services/task-supervisor-service.js";
 import { detectOrchestratorTerminalSupport } from "./services/terminal-capabilities.js";
 import {
   type AcpToolCall,
@@ -101,6 +102,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
         serviceClass(OrchestratorTaskService),
         serviceClass(SubAgentRouter),
         serviceClass(CodingWorkspaceService),
+        serviceClass(TaskSupervisorService),
       ]
     : [];
 
@@ -270,6 +272,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
         OrchestratorTaskService.serviceType,
         SubAgentRouter.serviceType,
         CodingWorkspaceService.serviceType,
+        TaskSupervisorService.serviceType,
       ];
       setTimeout(() => {
         void (async () => {
@@ -435,6 +438,10 @@ export function createAgentOrchestratorPlugin(): Plugin {
         SubAgentRouter.serviceType,
       );
       await router?.stop();
+      const supervisor = runtime.getService<TaskSupervisorService>(
+        TaskSupervisorService.serviceType,
+      );
+      await supervisor?.stop();
       await CodingWorkspaceService.stopRuntime(runtime);
     },
   };

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -114,6 +114,10 @@ export const activeSubAgentsProvider: Provider = {
           agentType: s.agentType,
           status: s.status,
           workdirTail: workdirTail(s.workdir),
+          // Structural watchdog flag persisted by TaskSupervisorService. Read as
+          // stored — never compute staleness here, so this provider segment
+          // stays cache-stable.
+          stalled: isStalled(s),
           originRoomId: (s.metadata as Record<string, unknown> | undefined)
             ?.roomId,
           originUserId: (s.metadata as Record<string, unknown> | undefined)
@@ -139,11 +143,20 @@ function hasOrigin(session: SessionInfo): boolean {
   return typeof roomId === "string" && roomId.length > 0;
 }
 
+function isStalled(session: SessionInfo): boolean {
+  const meta = session.metadata as Record<string, unknown> | undefined;
+  return meta?.stalled === true;
+}
+
 function formatLine(session: SessionInfo, live?: string): string {
   const label = labelOf(session);
   const tail = workdirTail(session.workdir);
   const bucket = bucketStatus(session.status);
-  const base = `- [${label}] sessionId=${session.id} agentType=${session.agentType} status=${bucket} workdir=…${tail}`;
+  // `stalled` is a STRUCTURAL flag stamped on the session by the watchdog —
+  // including it in the text keeps the provider cache-stable (it only flips
+  // when the stored flag flips, never on a per-render clock read).
+  const stalledMark = isStalled(session) ? " stalled=true" : "";
+  const base = `- [${label}] sessionId=${session.id} agentType=${session.agentType} status=${bucket}${stalledMark} workdir=…${tail}`;
   return live ? `${base} live="${live}"` : base;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -103,7 +103,8 @@ export type GoalFollowUpReason =
   | "orchestrator"
   | "incomplete_completion"
   | "validation_failed"
-  | "resume";
+  | "resume"
+  | "watchdog_grill";
 
 export interface GoalFollowUpInput {
   goal: string;
@@ -214,6 +215,8 @@ const FOLLOW_UP_FRAMING: Record<GoalFollowUpReason, string> = {
     "Validation of your previous completion did not pass. Address the gap against the goal and acceptance criteria below, then re-verify.",
   resume:
     "Resume the goal below where you left off. Re-check current state before making changes.",
+  watchdog_grill:
+    "The orchestrator's watchdog noticed no activity from you for a while. Report your current status against the goal below and what (if anything) is blocking you. If the goal is met, report completion with proof; otherwise keep working.",
 };
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -1,0 +1,609 @@
+/**
+ * Task supervisor: proactive multi-task digest loop + stalled-agent watchdog.
+ *
+ * The orchestrator lets one chat channel juggle many coding tasks, each driven
+ * by its own sub-agent. On a side-tab UI the operator can eyeball every task at
+ * once; on Telegram (no side tabs) they cannot. The supervisor closes that gap:
+ * it ticks on an interval, composes a COMPACT per-room digest of every live
+ * task, and posts it to the originating room — but only when the digest content
+ * actually changed since the last post (change-driven, deduped, never spammy).
+ *
+ * The same tick runs a watchdog over each active sub-agent session:
+ *  - **stalled** — no tool call / event update for N seconds → auto-send a grill
+ *    prompt ("are you still working? what's blocking you?") down the existing
+ *    send-to-agent path, and stamp a structural `stalled` flag on the session so
+ *    the cache-stable ACTIVE_SUB_AGENTS provider can surface it WITHOUT
+ *    computing time at render;
+ *  - **near round-trip cap** / **spend > 80% of cap** — post a warning to the
+ *    room so the operator can intervene before the loop force-stops.
+ *
+ * Issues #8900 (digest loop) and #8901 (stalled-agent watchdog).
+ *
+ * Design notes for testability: the per-tick logic lives in {@link
+ * TaskSupervisorService.runTick}, callable directly with no real timers. The
+ * clock is injected via the `now` field (settable in tests). The interval is
+ * only started in {@link TaskSupervisorService.start} and cleared in
+ * {@link TaskSupervisorService.stop}.
+ *
+ * @module services/task-supervisor-service
+ */
+
+import { createHash } from "node:crypto";
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import { AcpService } from "./acp-service.js";
+import { readConfigEnvKey } from "./config-env.js";
+import type {
+  TaskSessionDto,
+  TaskThreadDetailDto,
+} from "./orchestrator-task-mapper.js";
+import { OrchestratorTaskService } from "./orchestrator-task-service.js";
+import type { OrchestratorTaskStatus } from "./orchestrator-task-types.js";
+import { getSessionSpendUsd, readSpendCapUsd } from "./spend-allowance.js";
+
+const DEFAULT_INTERVAL_MS = 45_000;
+const DEFAULT_ROUND_TRIP_CAP = 32;
+/** A session with no event/tool update for this long is considered stalled. */
+const DEFAULT_STALL_TTL_MS = 120_000;
+/** Warn when a session is within this many round-trips of the cap. */
+const ROUND_TRIP_WARN_MARGIN = 3;
+/** Warn when session spend reaches this fraction of the per-session cap. */
+const SPEND_WARN_FRACTION = 0.8;
+
+/** The task states the supervisor surfaces in a digest. Terminal/open tasks are
+ *  intentionally excluded — the digest is about work in flight. */
+const SUPERVISED_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
+  new Set<OrchestratorTaskStatus>([
+    "active",
+    "validating",
+    "waiting_on_user",
+    "blocked",
+  ]);
+
+/** Per-status time-to-live (ms) before a task is flagged stale in the digest.
+ *  A task `waiting_on_user` for a while is expected; an `active` task that has
+ *  not moved is a problem far sooner. */
+const STATUS_STALE_TTL_MS: Record<string, number> = {
+  active: 180_000,
+  validating: 300_000,
+  blocked: 600_000,
+  waiting_on_user: 1_800_000,
+};
+
+const STATUS_EMOJI: Record<string, string> = {
+  active: "🏃",
+  validating: "🔎",
+  waiting_on_user: "⏸️",
+  blocked: "🚧",
+};
+
+function statusEmoji(status: string): string {
+  return STATUS_EMOJI[status] ?? "•";
+}
+
+type UuidRoomId = `${string}-${string}-${string}-${string}-${string}`;
+
+function isUuidRoom(value: unknown): value is UuidRoomId {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+/** Non-terminal task-session statuses the watchdog inspects. */
+const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "stopped",
+  "completed",
+  "done",
+  "error",
+  "errored",
+  "cancelled",
+]);
+
+/** One task's contribution to a room digest, fully resolved structurally so the
+ *  fingerprint is deterministic and the line is composed without a clock read. */
+interface DigestEntry {
+  taskId: string;
+  label: string;
+  agentType: string;
+  status: OrchestratorTaskStatus;
+  roundCount: number;
+  lastEventSummary: string;
+  stale: boolean;
+}
+
+function truncate(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+function readIntervalMs(): number {
+  const raw = readConfigEnvKey("ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS");
+  if (!raw) return DEFAULT_INTERVAL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MS;
+}
+
+function readRoundTripCap(): number {
+  const raw = readConfigEnvKey("ACPX_SUB_AGENT_ROUND_TRIP_CAP");
+  if (!raw) return DEFAULT_ROUND_TRIP_CAP;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_ROUND_TRIP_CAP;
+}
+
+/** The supervisor is ON by default; only the literal "0" disables it. */
+function isSupervisorEnabled(): boolean {
+  const raw = readConfigEnvKey("ELIZA_ORCHESTRATOR_SUPERVISOR");
+  return raw !== "0";
+}
+
+type RuntimeWithSend = IAgentRuntime & {
+  sendMessageToTarget?: (
+    target: { source: string; roomId: UuidRoomId },
+    content: {
+      text: string;
+      source: string;
+      metadata?: Record<string, unknown>;
+    },
+  ) => Promise<unknown>;
+};
+
+export class TaskSupervisorService extends Service {
+  static serviceType = "ORCHESTRATOR_TASK_SUPERVISOR";
+
+  capabilityDescription =
+    "Proactively digests every live orchestrator task into the originating room (change-driven, deduped) and watchdogs stalled / near-cap / over-spend sub-agents.";
+
+  protected override readonly runtime: IAgentRuntime;
+
+  /** Injectable clock so tests can drive staleness deterministically without
+   *  real timers. Defaults to wall-clock `Date.now`. */
+  now: () => number = () => Date.now();
+
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private readonly intervalMs = readIntervalMs();
+  private readonly roundTripCap = readRoundTripCap();
+  private readonly spendCapUsd = readSpendCapUsd();
+  private started = false;
+  private ticking = false;
+
+  /** Last posted digest fingerprint per originating room — the dedup key. */
+  private readonly lastDigestFingerprint = new Map<string, string>();
+  /** Sessions we have already warned about near-cap / over-spend, so a warning
+   *  posts once per session per threshold rather than every tick. */
+  private readonly roundTripWarned = new Set<string>();
+  private readonly spendWarned = new Set<string>();
+
+  constructor(runtime: IAgentRuntime) {
+    super(runtime);
+    this.runtime = runtime;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<TaskSupervisorService> {
+    const service = new TaskSupervisorService(runtime);
+    await service.start();
+    return service;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    if (!isSupervisorEnabled()) {
+      this.log(
+        "info",
+        "supervisor disabled via ELIZA_ORCHESTRATOR_SUPERVISOR=0",
+      );
+      return;
+    }
+    this.timer = setInterval(() => {
+      void this.runTick().catch((err) =>
+        this.log("warn", "supervisor tick failed", {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }, this.intervalMs);
+    this.timer.unref?.();
+    this.log("info", "task supervisor started", {
+      intervalMs: this.intervalMs,
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.started = false;
+  }
+
+  async dispose(): Promise<void> {
+    await this.stop();
+  }
+
+  /**
+   * One supervisor tick. Public + timer-free so it can be driven directly in
+   * tests. Resilient: a single task or session failure is logged and skipped,
+   * never aborting the rest of the tick.
+   */
+  async runTick(): Promise<void> {
+    if (this.ticking) return; // never overlap a slow tick with the next timer fire
+    this.ticking = true;
+    try {
+      const taskService = this.taskService();
+      if (!taskService) return;
+
+      let threads: Awaited<ReturnType<OrchestratorTaskService["listTasks"]>>;
+      try {
+        threads = await taskService.listTasks({ includeArchived: false });
+      } catch (err) {
+        this.log("warn", "listTasks failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      // Group resolved task details by originating room. One message per room.
+      const byRoom = new Map<
+        string,
+        { source: string; roomId: UuidRoomId; entries: DigestEntry[] }
+      >();
+
+      for (const thread of threads) {
+        if (!SUPERVISED_STATUSES.has(thread.status)) continue;
+        let detail: TaskThreadDetailDto | null;
+        try {
+          detail = await taskService.getTask(thread.id);
+        } catch (err) {
+          this.log("warn", "getTask failed", {
+            taskId: thread.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+        if (!detail) continue;
+
+        const roomId = detail.taskRoomId ?? detail.roomId;
+        if (!isUuidRoom(roomId)) continue;
+        const source = this.resolveRoomSource(detail);
+        if (!source) continue;
+
+        try {
+          await this.watchdogTask(taskService, detail);
+        } catch (err) {
+          this.log("warn", "watchdog for task failed", {
+            taskId: detail.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        const entry = this.composeDigestEntry(detail);
+        const bucket = byRoom.get(roomId);
+        if (bucket) {
+          bucket.entries.push(entry);
+        } else {
+          byRoom.set(roomId, { source, roomId, entries: [entry] });
+        }
+      }
+
+      for (const { source, roomId, entries } of byRoom.values()) {
+        try {
+          await this.postRoomDigest(source, roomId, entries);
+        } catch (err) {
+          this.log("warn", "post room digest failed", {
+            roomId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+
+  // ---- digest ------------------------------------------------------------
+
+  private composeDigestEntry(detail: TaskThreadDetailDto): DigestEntry {
+    const session = latestSession(detail.sessions);
+    const agentType = session?.framework ?? "—";
+    // Turn/round count: the running decision count on the active session is the
+    // closest structural proxy for "how many round-trips this sub-agent took".
+    const roundCount = session?.decisionCount ?? detail.decisionCount ?? 0;
+    const lastEvent = latestEvent(detail);
+    const lastEventSummary = lastEvent ? truncate(lastEvent.summary, 60) : "—";
+    const stale = this.isTaskStale(detail, session);
+    return {
+      taskId: detail.id,
+      label: detail.title || detail.id,
+      agentType,
+      status: detail.status,
+      roundCount,
+      lastEventSummary,
+      stale,
+    };
+  }
+
+  /** Time-in-status vs the per-status TTL map. Uses the most recent activity we
+   *  can observe (session activity, else the task's updatedAt). */
+  private isTaskStale(
+    detail: TaskThreadDetailDto,
+    session: TaskSessionDto | undefined,
+  ): boolean {
+    const ttl = STATUS_STALE_TTL_MS[detail.status];
+    if (!ttl) return false;
+    const lastActivityAt =
+      session?.lastActivityAt ??
+      detail.latestActivityAt ??
+      Date.parse(detail.updatedAt);
+    if (!Number.isFinite(lastActivityAt)) return false;
+    return this.now() - lastActivityAt > ttl;
+  }
+
+  private formatDigestLine(entry: DigestEntry): string {
+    const emoji = statusEmoji(entry.status);
+    const staleMark = entry.stale ? " ⚠️stale" : "";
+    return `${emoji} [${entry.label}] ${entry.agentType} · ${entry.status} · ${entry.roundCount} rounds · ${entry.lastEventSummary}${staleMark}`;
+  }
+
+  /**
+   * Build the room digest message text and post it — but only when its content
+   * fingerprint changed since the last post for this room. Unchanged → no post
+   * (the anti-spam guarantee).
+   */
+  private async postRoomDigest(
+    source: string,
+    roomId: UuidRoomId,
+    entries: DigestEntry[],
+  ): Promise<void> {
+    // Deterministic order so the fingerprint is stable turn-over-turn.
+    entries.sort((a, b) => a.taskId.localeCompare(b.taskId));
+    const lines = entries.map((entry) => this.formatDigestLine(entry));
+    const body = lines.join("\n");
+    const fingerprint = createHash("sha1").update(body).digest("hex");
+
+    if (this.lastDigestFingerprint.get(roomId) === fingerprint) {
+      return; // unchanged — stay silent
+    }
+    this.lastDigestFingerprint.set(roomId, fingerprint);
+
+    const text = `📋 Task digest (${entries.length} live)\n${body}`;
+    await this.sendToRoom(source, roomId, text);
+  }
+
+  // ---- watchdog (#8901) --------------------------------------------------
+
+  private async watchdogTask(
+    taskService: OrchestratorTaskService,
+    detail: TaskThreadDetailDto,
+  ): Promise<void> {
+    const roomId = detail.taskRoomId ?? detail.roomId;
+    const source = this.resolveRoomSource(detail);
+    for (const session of detail.sessions) {
+      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      try {
+        await this.watchdogSession(
+          taskService,
+          detail,
+          session,
+          isUuidRoom(roomId) ? roomId : undefined,
+          source,
+        );
+      } catch (err) {
+        this.log("warn", "watchdog session failed", {
+          sessionId: session.sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  private async watchdogSession(
+    taskService: OrchestratorTaskService,
+    detail: TaskThreadDetailDto,
+    session: TaskSessionDto,
+    roomId: UuidRoomId | undefined,
+    source: string | undefined,
+  ): Promise<void> {
+    // ── stall detection: no event/tool update for DEFAULT_STALL_TTL_MS ──
+    const lastEventAt = session.lastActivityAt;
+    const stalled =
+      Number.isFinite(lastEventAt) &&
+      this.now() - lastEventAt > DEFAULT_STALL_TTL_MS;
+
+    // Persist the structural flag on the ACP session metadata so the cache-
+    // stable ACTIVE_SUB_AGENTS provider reads it without computing time. Only
+    // write on a change to avoid churn.
+    await this.persistStalledFlag(session.sessionId, stalled);
+
+    if (stalled) {
+      try {
+        await taskService.sendToTaskAgent(
+          detail.id,
+          session.sessionId,
+          GRILL_PROMPT,
+          "watchdog_grill",
+        );
+        this.log("info", "grilled stalled sub-agent", {
+          sessionId: session.sessionId,
+          taskId: detail.id,
+        });
+      } catch (err) {
+        this.log("warn", "grill send failed", {
+          sessionId: session.sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // ── round-trip cap proximity warning ──
+    const roundCount = session.decisionCount;
+    if (
+      roundCount >= this.roundTripCap - ROUND_TRIP_WARN_MARGIN &&
+      !this.roundTripWarned.has(session.sessionId)
+    ) {
+      this.roundTripWarned.add(session.sessionId);
+      if (roomId && source) {
+        await this.sendToRoom(
+          source,
+          roomId,
+          `⚠️ [${session.label}] is at ${roundCount}/${this.roundTripCap} round-trips and will be force-stopped near the cap. Consider intervening.`,
+        );
+      }
+    }
+
+    // ── spend > 80% of cap warning ──
+    if (this.spendCapUsd > 0) {
+      const spent = getSessionSpendUsd(session.sessionId);
+      if (
+        spent >= this.spendCapUsd * SPEND_WARN_FRACTION &&
+        !this.spendWarned.has(session.sessionId)
+      ) {
+        this.spendWarned.add(session.sessionId);
+        if (roomId && source) {
+          await this.sendToRoom(
+            source,
+            roomId,
+            `⚠️ [${session.label}] has spent $${spent.toFixed(2)} of its $${this.spendCapUsd.toFixed(2)} budget (>${Math.round(SPEND_WARN_FRACTION * 100)}%).`,
+          );
+        }
+      }
+    }
+  }
+
+  /** Set / clear the `stalled` boolean on the live ACP session metadata. The
+   *  ACTIVE_SUB_AGENTS provider reads this structural flag directly. */
+  private async persistStalledFlag(
+    sessionId: string,
+    stalled: boolean,
+  ): Promise<void> {
+    const acp = this.acp();
+    if (!acp) return;
+    try {
+      const session = await acp.getSession(sessionId);
+      if (!session) return;
+      const current = Boolean(
+        (session.metadata as Record<string, unknown> | undefined)?.stalled,
+      );
+      if (current === stalled) return; // no churn on unchanged flag
+      await acp.updateSessionMetadata(sessionId, { stalled });
+    } catch (err) {
+      this.log("debug", "persist stalled flag failed", {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  /**
+   * Resolve the connector source for a task room. The origin source is recorded
+   * on the task metadata (mirrors how the sub-agent router reads `metadata.source`
+   * off the spawning session). Falls back to the single registered connector
+   * when unambiguous, else undefined (we never guess wrong across connectors).
+   */
+  private resolveRoomSource(detail: TaskThreadDetailDto): string | undefined {
+    const fromMeta: unknown =
+      detail.metadata?.source ?? detail.metadata?.originSource;
+    if (typeof fromMeta === "string" && fromMeta.trim()) return fromMeta.trim();
+    const connectors = this.runtime.getMessageConnectors?.();
+    if (Array.isArray(connectors) && connectors.length === 1) {
+      const only = connectors[0];
+      if (only && typeof only.source === "string") return only.source;
+    }
+    return undefined;
+  }
+
+  private async sendToRoom(
+    source: string,
+    roomId: UuidRoomId,
+    text: string,
+  ): Promise<void> {
+    const send = (this.runtime as RuntimeWithSend).sendMessageToTarget;
+    if (typeof send !== "function") {
+      this.log("warn", "sendMessageToTarget unavailable; digest dropped", {
+        roomId,
+      });
+      return;
+    }
+    // Mark as a transient internal post: tag it so the orchestrator's
+    // sendMessageToTarget thread-redirect wrapper treats it as a first-class
+    // user-facing send (it is NOT in the wrapper's internal-source skip set, so
+    // it benefits from per-task thread redirection like any planner reply).
+    await send(
+      { source, roomId },
+      {
+        text,
+        source: "task_supervisor",
+        metadata: { transient: true },
+      },
+    );
+  }
+
+  private taskService(): OrchestratorTaskService | undefined {
+    return (
+      this.runtime.getService<OrchestratorTaskService>(
+        OrchestratorTaskService.serviceType,
+      ) ?? undefined
+    );
+  }
+
+  private acp(): AcpService | undefined {
+    return (
+      this.runtime.getService<AcpService>(AcpService.serviceType) ?? undefined
+    );
+  }
+
+  private log(
+    level: "debug" | "info" | "warn" | "error",
+    message: string,
+    data?: Record<string, unknown>,
+  ): void {
+    const logger = this.runtime.logger;
+    const fn = logger?.[level];
+    if (typeof fn === "function") {
+      fn.call(
+        logger,
+        { src: "acpx:task-supervisor", ...(data ?? {}) },
+        `[TaskSupervisorService] ${message}`,
+      );
+    }
+  }
+}
+
+/** The grill the watchdog auto-sends to a stalled sub-agent. */
+export const GRILL_PROMPT =
+  "Are you still working? What is your current status, and what is blocking you? If you are done, report completion with proof.";
+
+function latestSession(
+  sessions: readonly TaskSessionDto[],
+): TaskSessionDto | undefined {
+  let latest: TaskSessionDto | undefined;
+  for (const session of sessions) {
+    if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+    if (!latest || session.lastActivityAt > latest.lastActivityAt) {
+      latest = session;
+    }
+  }
+  // Fall back to the most recent of any session when no live one exists.
+  if (!latest) {
+    for (const session of sessions) {
+      if (!latest || session.lastActivityAt > latest.lastActivityAt) {
+        latest = session;
+      }
+    }
+  }
+  return latest;
+}
+
+function latestEvent(
+  detail: TaskThreadDetailDto,
+): TaskThreadDetailDto["events"][number] | undefined {
+  let latest: TaskThreadDetailDto["events"][number] | undefined;
+  for (const event of detail.events) {
+    if (!latest || event.timestamp > latest.timestamp) latest = event;
+  }
+  return latest;
+}


### PR DESCRIPTION
Closes #8900, #8901. Part of #8885 (multi-task supervision epic).

Delivers the core of "manage multiple tasks each with sub-agents in ONE chat channel" — the Telegram (no side-tabs) differentiator vs Codex/Claude Code.

## #8900 — TaskSupervisorService (proactive multi-task digest)
New `Service` (registered + eager-started in `src/index.ts`). A timer-free, testable `runTick()` (clock injectable) is armed by `start()` on a configurable interval (default 45s, `ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS`; `.unref()`'d) and cleared on `stop()/dispose()`, with an overlap guard. Each tick reads `OrchestratorTaskService.listTasks()` filtered to `active|validating|waiting_on_user|blocked`, composes a compact per-task line (status emoji · label · framework · round count · last event · `⚠️stale` mark via per-status TTLs), groups lines by originating room into ONE message per room, and posts via `runtime.sendMessageToTarget`. Per-room SHA-1 fingerprint dedup → unchanged state never re-posts. Gated by `ELIZA_ORCHESTRATOR_SUPERVISOR` (default on). Every per-task failure is caught so one task can't break the tick.

## #8901 — stalled-agent watchdog (same tick)
Per non-terminal session: **stall** (no activity > 120s) → auto-grill via the existing goal-wrapped `sendToTaskAgent` (new `watchdog_grill` reason) and stamp a `stalled` flag on the session; **near round-trip cap** (within 3 of `ACPX_SUB_AGENT_ROUND_TRIP_CAP`) and **spend > 80%** of `ELIZA_AGENT_SPEND_CAP_USD` each post a one-time room warning. The `stalled` flag is surfaced as a STRUCTURAL field on the `ACTIVE_SUB_AGENTS` provider (read stored flag — provider stays cache-stable, no time computed at render).

## Evidence
```
$ bun run --cwd plugins/plugin-agent-orchestrator typecheck      # clean
$ bun run --cwd plugins/plugin-agent-orchestrator test
 Test Files  85 passed | 3 skipped (88)
      Tests  928 passed | 6 skipped (934)
$ bun run --cwd plugins/plugin-agent-orchestrator test -- task-supervisor-service active-sub-agents
 Test Files 2 passed / Tests 22 passed
```
13 new tests cover: grouped digest per room, dedup (no re-post on unchanged), per-room separation, stall→grill, spend/round-trip warnings, and `stalled` on the cache-stable provider. Isolated worktree; main checkout untouched; biome clean.

## Remaining (follow-up, not faked)
Live scenario-runner trajectory (spawn 2 tasks, advance one, assert a digest reaches the room) needs a live model — code + deterministic unit tests are complete; live run tracked under #8885. The only full-suite non-pass is the pre-existing `smithers-task-runner.test.ts` crash-resume timeout under parallel load (fails identically on the base tree; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)