### PR TITLE
feat(attachments): PR7 — FILES agent tool (list/get/delete via IFileStorageService) (#8876)

### DIFF
--- a/packages/agent/src/actions/files.test.ts
+++ b/packages/agent/src/actions/files.test.ts
@@ -1,0 +1,134 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { filesAction } from "./files.ts";
+
+// ServiceType.REMOTE_FILES === "aws_s3"
+const REMOTE_FILES = "aws_s3";
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+const sample = [
+  {
+    fileName: `${HASH_A}.png`,
+    url: `/api/media/${HASH_A}.png`,
+    hash: HASH_A,
+    mimeType: "image/png",
+    size: 2048,
+    createdAt: 2,
+  },
+  {
+    fileName: `${HASH_B}.pdf`,
+    url: `/api/media/${HASH_B}.pdf`,
+    hash: HASH_B,
+    mimeType: "application/pdf",
+    size: 5000,
+    createdAt: 1,
+  },
+];
+
+function fakeStorage(files = sample) {
+  return {
+    list: vi.fn(async () => [...files]),
+    getUrl: (name: string) =>
+      /^[a-f0-9]{64}\.[a-z0-9]+$/.test(name) ? `/api/media/${name}` : null,
+    exists: vi.fn(async (name: string) =>
+      files.some((file) => file.fileName === name),
+    ),
+    delete: vi.fn(async (name: string) =>
+      files.some((file) => file.fileName === name),
+    ),
+  };
+}
+
+function makeRuntime(storage: unknown): IAgentRuntime {
+  return {
+    getService: (type: string) => (type === REMOTE_FILES ? storage : null),
+    logger: { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+function run(runtime: IAgentRuntime, params: Record<string, unknown>) {
+  return filesAction.handler?.(
+    runtime,
+    {} as never,
+    {} as never,
+    { parameters: params } as never,
+  );
+}
+
+type FilesData = {
+  files?: Array<{ fileName: string; mimeType: string }>;
+  total?: number;
+  deleted?: boolean;
+  error?: string;
+};
+
+describe("filesAction", () => {
+  it("requires a valid op", async () => {
+    const res = await run(makeRuntime(fakeStorage()), {});
+    expect(res?.success).toBe(false);
+    expect((res?.data as FilesData)?.error).toBe("FILES_INVALID");
+  });
+
+  it("lists stored files newest-first", async () => {
+    const res = await run(makeRuntime(fakeStorage()), { op: "list" });
+    expect(res?.success).toBe(true);
+    const data = res?.data as FilesData;
+    expect(data.total).toBe(2);
+    expect(data.files?.[0].fileName).toBe(`${HASH_A}.png`); // createdAt 2 > 1
+  });
+
+  it("filters list by query (mime or filename substring)", async () => {
+    const res = await run(makeRuntime(fakeStorage()), {
+      op: "list",
+      query: "pdf",
+    });
+    const data = res?.data as FilesData;
+    expect(data.files).toHaveLength(1);
+    expect(data.files?.[0].mimeType).toBe("application/pdf");
+  });
+
+  it("gets a file's details + url by name", async () => {
+    const res = await run(makeRuntime(fakeStorage()), {
+      op: "get",
+      fileName: `${HASH_A}.png`,
+    });
+    expect(res?.success).toBe(true);
+    expect(res?.text).toContain(`/api/media/${HASH_A}.png`);
+  });
+
+  it("reports not-found for an unknown file in get", async () => {
+    const res = await run(makeRuntime(fakeStorage()), {
+      op: "get",
+      fileName: `${"c".repeat(64)}.png`,
+    });
+    expect(res?.success).toBe(false);
+    expect((res?.data as FilesData)?.error).toBe("FILES_NOT_FOUND");
+  });
+
+  it("requires confirm:true to delete", async () => {
+    const res = await run(makeRuntime(fakeStorage()), {
+      op: "delete",
+      fileName: `${HASH_A}.png`,
+    });
+    expect(res?.success).toBe(false);
+    expect((res?.data as FilesData)?.error).toBe("FILES_CONFIRM_REQUIRED");
+  });
+
+  it("deletes with confirm:true", async () => {
+    const storage = fakeStorage();
+    const res = await run(makeRuntime(storage), {
+      op: "delete",
+      fileName: `${HASH_A}.png`,
+      confirm: true,
+    });
+    expect(res?.success).toBe(true);
+    expect(storage.delete).toHaveBeenCalledWith(`${HASH_A}.png`);
+  });
+
+  it("degrades gracefully when the storage service is absent", async () => {
+    const res = await run(makeRuntime(null), { op: "list" });
+    expect(res?.success).toBe(false);
+    expect((res?.data as FilesData)?.error).toBe("FILES_NO_SERVICE");
+  });
+});

--- a/packages/agent/src/actions/files.ts
+++ b/packages/agent/src/actions/files.ts
@@ -1,0 +1,240 @@
+import type {
+  Action,
+  ActionResult,
+  HandlerOptions,
+  IAgentRuntime,
+  IFileStorageService,
+  StoredFileListItem,
+} from "@elizaos/core";
+import { logger, ServiceType } from "@elizaos/core";
+
+const FILES_OPS = ["list", "get", "delete"] as const;
+type FilesOp = (typeof FILES_OPS)[number];
+
+interface FilesParams {
+  action?: string;
+  op?: string;
+  subaction?: string;
+  fileName?: string;
+  query?: string;
+  limit?: number;
+  confirm?: boolean;
+}
+
+function fail(text: string, error: string): ActionResult {
+  return { success: false, text, data: { error } };
+}
+
+function getStorage(runtime: IAgentRuntime): IFileStorageService | null {
+  return (
+    runtime.getService<IFileStorageService>(ServiceType.REMOTE_FILES) ?? null
+  );
+}
+
+function normalizeOp(params: FilesParams): FilesOp | undefined {
+  const candidate = (params.action ?? params.subaction ?? params.op ?? "")
+    .toString()
+    .toLowerCase();
+  return (FILES_OPS as readonly string[]).includes(candidate)
+    ? (candidate as FilesOp)
+    : undefined;
+}
+
+function clampLimit(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(100, Math.floor(value)));
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function matchesQuery(file: StoredFileListItem, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    file.fileName.toLowerCase().includes(q) ||
+    file.mimeType.toLowerCase().includes(q)
+  );
+}
+
+async function doList(
+  runtime: IAgentRuntime,
+  params: FilesParams,
+): Promise<ActionResult> {
+  const storage = getStorage(runtime);
+  if (!storage) {
+    return fail("File storage is not available.", "FILES_NO_SERVICE");
+  }
+  const all = (await storage.list()).sort((a, b) => b.createdAt - a.createdAt);
+  const filtered = params.query
+    ? all.filter((file) => matchesQuery(file, params.query ?? ""))
+    : all;
+  const limit = clampLimit(params.limit, 20);
+  const top = filtered.slice(0, limit);
+  const text = top.length
+    ? `Found ${filtered.length} file(s).${
+        filtered.length > top.length ? ` Most recent ${top.length}:` : ""
+      }\n${top
+        .map(
+          (file) =>
+            `- ${file.fileName} (${file.mimeType}, ${humanSize(file.size)}) ${file.url}`,
+        )
+        .join("\n")}`
+    : "No stored files match.";
+  return {
+    success: true,
+    text,
+    data: { files: top, total: filtered.length },
+  };
+}
+
+async function doGet(
+  runtime: IAgentRuntime,
+  params: FilesParams,
+): Promise<ActionResult> {
+  const storage = getStorage(runtime);
+  if (!storage) {
+    return fail("File storage is not available.", "FILES_NO_SERVICE");
+  }
+  const name = params.fileName?.trim();
+  if (!name) {
+    return fail("fileName is required for op:get.", "FILES_INVALID");
+  }
+  const url = storage.getUrl(name);
+  if (!url || !(await storage.exists(name))) {
+    return fail(`No stored file named ${name}.`, "FILES_NOT_FOUND");
+  }
+  const item = (await storage.list()).find((file) => file.fileName === name);
+  return {
+    success: true,
+    text: item
+      ? `${name}: ${item.mimeType}, ${humanSize(item.size)} — ${url}`
+      : `${name} — ${url}`,
+    data: { file: item ?? { fileName: name, url } },
+  };
+}
+
+async function doDelete(
+  runtime: IAgentRuntime,
+  params: FilesParams,
+): Promise<ActionResult> {
+  const storage = getStorage(runtime);
+  if (!storage) {
+    return fail("File storage is not available.", "FILES_NO_SERVICE");
+  }
+  const name = params.fileName?.trim();
+  if (!name) {
+    return fail("fileName is required for op:delete.", "FILES_INVALID");
+  }
+  if (params.confirm !== true) {
+    return fail(
+      "Deleting a file requires confirm:true.",
+      "FILES_CONFIRM_REQUIRED",
+    );
+  }
+  const deleted = await storage.delete(name);
+  return {
+    success: deleted,
+    text: deleted
+      ? `Deleted ${name}.`
+      : `Could not delete ${name} (not found).`,
+    data: { deleted, fileName: name },
+  };
+}
+
+/**
+ * FILES action: gives the agent read/CRUD access to the content-addressed file
+ * store via {@link IFileStorageService}. op:list shows recent stored files
+ * (optional query/limit); op:get returns a file's details + served URL by
+ * fileName; op:delete removes a file (requires confirm:true).
+ */
+export const filesAction: Action = {
+  name: "FILES",
+  contexts: ["documents", "agent_internal"],
+  roleGate: { minRole: "OWNER" },
+  similes: [
+    "LIST_FILES",
+    "RECENT_FILES",
+    "SHOW_FILES",
+    "BROWSE_FILES",
+    "GET_FILE",
+    "FIND_FILE",
+    "DELETE_FILE",
+    "REMOVE_FILE",
+  ],
+  description:
+    "Access stored files. op:list shows recent stored files (optional query/limit); op:get returns a file's details + served URL by fileName; op:delete removes a file (requires confirm:true).",
+  descriptionCompressed:
+    "list/get/delete stored files; delete requires confirm:true",
+  validate: async () => true,
+  handler: async (
+    runtime: IAgentRuntime,
+    _message,
+    _state,
+    options,
+  ): Promise<ActionResult> => {
+    const params = ((options as HandlerOptions | undefined)?.parameters ??
+      {}) as FilesParams;
+    const op = normalizeOp(params);
+    if (!op) {
+      return fail(
+        `op is required and must be one of ${FILES_OPS.join(", ")}.`,
+        "FILES_INVALID",
+      );
+    }
+    try {
+      switch (op) {
+        case "list":
+          return await doList(runtime, params);
+        case "get":
+          return await doGet(runtime, params);
+        case "delete":
+          return await doDelete(runtime, params);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`[files:${op}] failed: ${msg}`);
+      return {
+        success: false,
+        text: `Failed to ${op} file(s): ${msg}`,
+        data: { error: `FILES_${op.toUpperCase()}_FAILED` },
+      };
+    }
+  },
+  parameters: [
+    {
+      name: "op",
+      description: "Operation: list | get | delete",
+      required: true,
+      schema: { type: "string" as const, enum: [...FILES_OPS] },
+    },
+    {
+      name: "fileName",
+      description: "Stored filename (<sha256>.<ext>) — required for get/delete",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "query",
+      description:
+        "Optional filter for op:list (matches filename or mime type substring)",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "limit",
+      description: "Max results for op:list (default 20, max 100)",
+      required: false,
+      schema: { type: "number" as const },
+    },
+    {
+      name: "confirm",
+      description: "Must be true to delete a file",
+      required: false,
+      schema: { type: "boolean" as const },
+    },
+  ],
+};

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -17,6 +17,7 @@ import type { CommandDefinition } from "@elizaos/plugin-commands";
 import { compactConversationAction } from "../actions/compact-conversation.ts";
 import { contactAction } from "../actions/contact.ts";
 import { databaseAction } from "../actions/database.ts";
+import { filesAction } from "../actions/files.ts";
 import { logsAction } from "../actions/logs.ts";
 import { memoryAction } from "../actions/memories.ts";
 import { notifyAction } from "../actions/notify.ts";
@@ -239,6 +240,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       compactConversationAction,
       notifyAction,
       ...promoteSubactionsToActions(memoryAction),
+      filesAction,
       // SCHEDULE_FOLLOW_UP is now the `followup` op on contactAction.
       // ARCHIVE_CODING_TASK / REOPEN_CODING_TASK live as ops on the TASKS
       // parent in @elizaos/plugin-agent-orchestrator (also surfaced via the


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1). **PR7 — the agent's file tools.** Addresses the goal's "explore what tools the agent has and needs for accessing, CRUDing and interacting with files."

A `FILES` action (registered in the eliza plugin) gives the agent read/CRUD over the content-addressed file store via the PR5 `IFileStorageService`:
- **op:list** — recent stored files (newest-first) with an optional `query` filter (filename / mime substring) and `limit` (default 20, max 100).
- **op:get** — a file's details + served URL by `fileName` (not-found reported, never thrown).
- **op:delete** — remove a file; **requires `confirm:true`**.
- `minRole: OWNER`; degrades gracefully (`FILES_NO_SERVICE`) when the storage service isn't present.

**Tests:** 8 (op validation, list newest-first, query filter, get, not-found, confirm-required, delete, graceful-no-service). Agent typecheck + Biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)