### PR TITLE
feat(attachments): PR8 — rehost remote generated/outgoing media into the durable store (#8876)

### DIFF
--- a/packages/agent/src/api/media-runtime.test.ts
+++ b/packages/agent/src/api/media-runtime.test.ts
@@ -73,6 +73,64 @@ describe("registerMediaPipelineHook", () => {
     );
   });
 
+  it("rehosts a remote media URL, marking it ephemeral when the host is blocked", async () => {
+    const { runtime, getHook } = captureHookRuntime();
+    registerMediaPipelineHook(runtime);
+    const hook = getHook();
+
+    const ctx = {
+      phase: "outgoing_before_deliver" as const,
+      content: {
+        attachments: [
+          {
+            id: "gen",
+            // Link-local host → SSRF guard blocks before any network I/O.
+            url: "http://169.254.169.254/secret.png",
+            contentType: "image",
+          },
+        ],
+      },
+    };
+    await hook.handler(runtime, ctx);
+
+    // Blocked rehost → keep the original URL and flag it for a UI retry.
+    expect(ctx.content.attachments[0].url).toBe(
+      "http://169.254.169.254/secret.png",
+    );
+    expect(
+      (ctx.content.attachments[0] as { ephemeral?: boolean }).ephemeral,
+    ).toBe(true);
+  });
+
+  it("does not rehost remote link attachments or already-stored media", async () => {
+    const { runtime, getHook } = captureHookRuntime();
+    registerMediaPipelineHook(runtime);
+    const hook = getHook();
+
+    const storedUrl = `/api/media/${"a".repeat(64)}.png`;
+    const ctx = {
+      phase: "outgoing_before_deliver" as const,
+      content: {
+        attachments: [
+          {
+            id: "link",
+            url: "https://example.com/article",
+            contentType: "link",
+          },
+          { id: "stored", url: storedUrl, contentType: "image" },
+        ],
+      },
+    };
+    await hook.handler(runtime, ctx);
+
+    // Links are not media; stored URLs are already durable — both untouched.
+    expect(ctx.content.attachments[0].url).toBe("https://example.com/article");
+    expect(
+      (ctx.content.attachments[0] as { ephemeral?: boolean }).ephemeral,
+    ).toBeUndefined();
+    expect(ctx.content.attachments[1].url).toBe(storedUrl);
+  });
+
   it("ignores non-outgoing phases and empty attachments", async () => {
     const { runtime, getHook } = captureHookRuntime();
     registerMediaPipelineHook(runtime);

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -9,6 +9,7 @@
  */
 
 import type { IAgentRuntime, Memory, Route } from "@elizaos/core";
+import { fetchRemoteMedia, logger } from "@elizaos/core";
 import {
   ensureThumbnailForStoredFile,
   gcUnreferencedMedia,
@@ -16,7 +17,44 @@ import {
   isStoredMediaUrl,
   mediaFileNameFromUrl,
   persistAttachmentUrlIfInline,
+  persistMediaBytes,
 } from "./media-store.ts";
+
+/** Cap on bytes pulled while rehosting a remote attachment into the store. */
+const REHOST_MAX_BYTES = 50 * 1024 * 1024;
+
+/** Media content types worth rehosting (skip `link` and unknown). */
+const REHOSTABLE_CONTENT_TYPES = new Set([
+  "image",
+  "video",
+  "audio",
+  "document",
+]);
+
+/**
+ * Rehost a remote (http/https) media URL into the content-addressed store via
+ * the SSRF-guarded fetcher (blocks private/loopback) with a hard size cap, so an
+ * agent-generated/provider URL that may expire becomes a durable, same-origin
+ * `/api/media/<hash>` URL. Returns the served URL, or null on any failure
+ * (blocked host, too large, unreachable) so the caller can keep the original.
+ */
+async function rehostRemoteMediaUrl(url: string): Promise<string | null> {
+  try {
+    const { buffer, contentType } = await fetchRemoteMedia({
+      url,
+      maxBytes: REHOST_MAX_BYTES,
+    });
+    return persistMediaBytes(buffer, contentType ?? "application/octet-stream")
+      .url;
+  } catch (err) {
+    logger.warn(
+      `[media-persist] failed to rehost ${url}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+}
 
 const MEDIA_URL_PREFIX = "/api/media/";
 
@@ -69,6 +107,22 @@ export function registerMediaPipelineHook(runtime: IAgentRuntime): void {
         if (!attachment || typeof attachment.url !== "string") continue;
         if (attachment.url.startsWith("data:")) {
           attachment.url = persistAttachmentUrlIfInline(attachment.url);
+        } else if (
+          /^https?:\/\//i.test(attachment.url) &&
+          !isStoredMediaUrl(attachment.url) &&
+          typeof attachment.contentType === "string" &&
+          REHOSTABLE_CONTENT_TYPES.has(attachment.contentType)
+        ) {
+          // Rehost remote agent-generated/outgoing media into the durable store
+          // so a provider URL that may expire doesn't leave a broken tile in
+          // history. SSRF-guarded + size-capped; on failure keep the original
+          // URL and mark it ephemeral so the UI can offer a retry.
+          const rehosted = await rehostRemoteMediaUrl(attachment.url);
+          if (rehosted) {
+            attachment.url = rehosted;
+          } else {
+            (attachment as { ephemeral?: boolean }).ephemeral = true;
+          }
         }
         // Pre-compute a thumbnail for stored images lacking one (generated
         // media). `ensureThumbnailForStoredFile` self-gates on image mime/size.


### PR DESCRIPTION
Part of #8876 (unified attachments & files, v1). **PR8 — generated-media durability.** The outgoing media-persist hook rehosted only `data:` URLs; agent-generated media returned as a provider `http(s)` URL was left as-is and **rotted** once that URL expired (broken tiles in history).

- `rehostRemoteMediaUrl` fetches via the **SSRF-guarded** fetcher (blocks private/loopback) with a **50MB cap** and persists to the content-addressed store, returning a durable, same-origin `/api/media/<hash>` URL.
- The `outgoing_before_deliver` hook now rehosts remote `http(s)` attachments whose `contentType` is image/video/audio/document (skips `link` + unknown, skips already-stored URLs). On failure it **keeps the original URL and marks the attachment `ephemeral`** (the PR1 field) so the UI can offer a retry — never throws.

**Tests:** +2 (SSRF-blocked host → kept + ephemeral, network-free; link/stored not rehosted); media-runtime suite **9 pass**. Agent typecheck + Biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)