### PR TITLE
feat(telegram): add edit_message + react_message connector capabilities

### DIFF
--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -53,6 +53,8 @@ describe("Telegram message connector adapter", () => {
         "resolve_targets",
         "chat_context",
         "user_context",
+        "edit_message",
+        "react_message",
       ]),
       supportedTargetKinds: ["channel", "group", "thread", "user"],
       contexts: ["social", "connectors"],
@@ -453,5 +455,85 @@ describe("Telegram message connector adapter", () => {
 
     initializeBot.mockRestore();
     createAccountRuntime.mockRestore();
+  });
+
+  it("wires edit_message + react_message connector handlers", () => {
+    const runtime = createRuntime();
+    const service = createTelegramService({
+      bot: {},
+      messageManager: {},
+      handleSendMessage: vi.fn(),
+      resolveConnectorTargets: vi.fn(),
+      listRecentConnectorTargets: vi.fn(),
+      listConnectorRooms: vi.fn(),
+      getConnectorChatContext: vi.fn(),
+      getConnectorUserContext: vi.fn(),
+    });
+
+    TelegramService.registerSendHandlers(runtime, service);
+
+    const registration = runtime.registerMessageConnector.mock.calls[0][0];
+    expect(typeof registration.editHandler).toBe("function");
+    expect(typeof registration.reactHandler).toBe("function");
+  });
+
+  it("editConnectorMessage edits via the account message manager", async () => {
+    const runtime = createRuntime();
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const service = createTelegramService({
+      bot: {},
+      messageManager: { editMessage },
+      defaultAccountId: "default",
+    });
+
+    await service.editConnectorMessage(runtime, {
+      target: { source: "telegram", channelId: "-1001234567890-42" },
+      messageId: "555",
+      content: { text: "updated text" },
+    });
+
+    expect(editMessage).toHaveBeenCalledWith(
+      "-1001234567890",
+      555,
+      "updated text",
+      42,
+    );
+  });
+
+  it("editConnectorMessage rejects empty text", async () => {
+    const runtime = createRuntime();
+    const editMessage = vi.fn();
+    const service = createTelegramService({
+      bot: {},
+      messageManager: { editMessage },
+      defaultAccountId: "default",
+    });
+
+    await expect(
+      service.editConnectorMessage(runtime, {
+        target: { source: "telegram", channelId: "-100123" },
+        messageId: "555",
+        content: { text: "   " },
+      }),
+    ).rejects.toThrow("Telegram edit requires non-empty text.");
+    expect(editMessage).not.toHaveBeenCalled();
+  });
+
+  it("reactConnectorMessage reacts via the account message manager", async () => {
+    const runtime = createRuntime();
+    const addReaction = vi.fn().mockResolvedValue(undefined);
+    const service = createTelegramService({
+      bot: {},
+      messageManager: { addReaction },
+      defaultAccountId: "default",
+    });
+
+    await service.reactConnectorMessage(runtime, {
+      target: { source: "telegram", channelId: "-100123" },
+      messageId: "777",
+      emoji: "👍",
+    });
+
+    expect(addReaction).toHaveBeenCalledWith("-100123", 777, "👍");
   });
 });

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -546,6 +546,126 @@ describe("MessageManager send resilience (sendWithRetry)", () => {
   });
 });
 
+describe("MessageManager editMessage", () => {
+  function managerWith(editMessageText: ReturnType<typeof vi.fn>) {
+    const telegram = { editMessageText };
+    const manager = new MessageManager(
+      { telegram } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
+    );
+    return { manager, editMessageText };
+  }
+
+  it("replaces text via editMessageText with MarkdownV2", async () => {
+    const editMessageText = vi.fn(async () => true);
+    const { manager } = managerWith(editMessageText);
+
+    await manager.editMessage(123, 7, "hello world");
+
+    expect(editMessageText).toHaveBeenCalledTimes(1);
+    expect(editMessageText).toHaveBeenCalledWith(
+      123,
+      7,
+      undefined,
+      "hello world",
+      { parse_mode: "MarkdownV2" },
+    );
+  });
+
+  it("retries as plain text on a MarkdownV2 400 parse error", async () => {
+    const editMessageText = vi.fn(
+      async (
+        _chatId: number | string,
+        _messageId: number,
+        _inline: undefined,
+        _text: string,
+        opts?: { parse_mode?: string },
+      ) => {
+        if (opts?.parse_mode === "MarkdownV2") {
+          throw {
+            response: {
+              error_code: 400,
+              description: "Bad Request: can't parse entities",
+            },
+          };
+        }
+        return true;
+      },
+    );
+    const { manager } = managerWith(editMessageText);
+
+    await manager.editMessage(123, 7, "**bold**");
+
+    expect(editMessageText).toHaveBeenCalledTimes(2);
+    // the successful (fallback) edit must NOT carry parse_mode
+    const fallbackCall = editMessageText.mock.calls.find(
+      (call) =>
+        (call[4] as { parse_mode?: string } | undefined)?.parse_mode ===
+        undefined,
+    );
+    expect(fallbackCall).toBeDefined();
+  });
+
+  it('swallows "message is not modified" as a no-op success', async () => {
+    const editMessageText = vi.fn(async () => {
+      throw {
+        response: {
+          error_code: 400,
+          description: "Bad Request: message is not modified",
+        },
+      };
+    });
+    const { manager } = managerWith(editMessageText);
+
+    // identical-content edit must resolve, not throw
+    await expect(
+      manager.editMessage(123, 7, "same text"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("propagates non-parse, non-not-modified errors", async () => {
+    const editMessageText = vi.fn(async () => {
+      throw {
+        response: {
+          error_code: 403,
+          description: "Forbidden: bot was blocked",
+        },
+      };
+    });
+    const { manager } = managerWith(editMessageText);
+
+    await expect(manager.editMessage(123, 7, "hi")).rejects.toBeTruthy();
+  });
+});
+
+describe("MessageManager addReaction", () => {
+  it("sets a single emoji reaction via setMessageReaction", async () => {
+    const setMessageReaction = vi.fn(async () => true);
+    const manager = new MessageManager(
+      { telegram: { setMessageReaction } } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
+    );
+
+    await manager.addReaction(123, 7, "👍");
+
+    expect(setMessageReaction).toHaveBeenCalledWith(123, 7, [
+      { type: "emoji", emoji: "👍" },
+    ]);
+  });
+
+  it("clears reactions when no emoji is provided", async () => {
+    const setMessageReaction = vi.fn(async () => true);
+    const manager = new MessageManager(
+      { telegram: { setMessageReaction } } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
+    );
+
+    await manager.addReaction(123, 7);
+
+    expect(setMessageReaction).toHaveBeenCalledWith(123, 7, []);
+  });
+});
+
 describe("MessageManager typing-indicator resilience", () => {
   it("still sends the reply when the typing action fails", async () => {
     const sendMessage = vi.fn(

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -101,6 +101,23 @@ type TelegramMediaSender = (
   extra?: { caption?: string },
 ) => Promise<unknown>;
 
+/**
+ * Detects Telegram's "message is not modified" 400 — returned when an edit's
+ * new text/markup is byte-identical to the current message. It is a benign
+ * no-op (not a failure), so the connector edit path swallows it.
+ */
+function isMessageNotModifiedError(error: unknown): boolean {
+  const response = (
+    error as {
+      response?: { error_code?: number; description?: string };
+    }
+  )?.response;
+  return (
+    response?.error_code === 400 &&
+    /message is not modified/i.test(response.description ?? "")
+  );
+}
+
 const getChannelType = (chat: Chat): ChannelType => {
   const chatType = chat.type;
 
@@ -1623,25 +1640,44 @@ export class MessageManager {
     messageThreadId?: number,
   ): Promise<void> {
     const formatted = convertMarkdownToTelegram(text);
-    await this.sendWithRetry(
-      () =>
-        this.bot.telegram.editMessageText(
-          chatId,
-          messageId,
-          undefined,
-          formatted,
-          { parse_mode: "MarkdownV2" },
-        ),
-      // Fallback: Telegram rejected the MarkdownV2 — edit with the raw text so
-      // the user sees the content unformatted rather than a stale message.
-      () =>
-        this.bot.telegram.editMessageText(
-          chatId,
-          messageId,
-          undefined,
-          cleanText(text),
-        ),
-    );
+    try {
+      await this.sendWithRetry(
+        () =>
+          this.bot.telegram.editMessageText(
+            chatId,
+            messageId,
+            undefined,
+            formatted,
+            { parse_mode: "MarkdownV2" },
+          ),
+        // Fallback: Telegram rejected the MarkdownV2 — edit with the raw text so
+        // the user sees the content unformatted rather than a stale message.
+        () =>
+          this.bot.telegram.editMessageText(
+            chatId,
+            messageId,
+            undefined,
+            cleanText(text),
+          ),
+      );
+    } catch (error) {
+      // Telegram returns "message is not modified" when the new text matches
+      // the existing message verbatim — a no-op the orchestrator's heartbeat
+      // edits hit routinely. Treat it as success rather than surfacing an error.
+      if (isMessageNotModifiedError(error)) {
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            chatId,
+            messageId,
+          },
+          "Telegram edit was a no-op (message not modified)",
+        );
+        return;
+      }
+      throw error;
+    }
     logger.info(
       {
         src: "plugin:telegram",

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -9,8 +9,10 @@ import {
   type Memory,
   type MessageConnectorChatContext,
   type MessageConnectorCreateThreadParams,
+  type MessageConnectorEditParams,
   type MessageConnectorPostToThreadParams,
   type MessageConnectorQueryContext,
+  type MessageConnectorReactionParams,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   Role,
@@ -59,6 +61,8 @@ const TELEGRAM_CONNECTOR_CAPABILITIES = [
   "user_context",
   "create_thread",
   "post_to_thread",
+  "edit_message",
+  "react_message",
 ];
 const TELEGRAM_CHAT_ID_PATTERN = /^-?\d+$/;
 const TELEGRAM_THREADED_CHANNEL_PATTERN = /^(-?\d+)-(\d+)$/;
@@ -2037,6 +2041,120 @@ export class TelegramService extends Service {
     return undefined;
   }
 
+  /**
+   * Resolves a connector `TargetInfo` (channelId / roomId / entityId) to the
+   * concrete Telegram chat id, optional forum thread id, and the account's
+   * `MessageManager`. Shared by the `edit_message` and `react_message`
+   * connector capabilities, mirroring {@link handleSendMessage}'s resolution.
+   */
+  private async resolveConnectorMessageTarget(
+    runtime: IAgentRuntime,
+    target: TargetInfo,
+  ): Promise<{
+    chatId: number | string;
+    threadId?: number;
+    messageManager: MessageManager;
+    accountId: string;
+  }> {
+    const accountId = await this.resolveAccountIdForTarget(runtime, target);
+    const accountState = this.getAccountState(accountId);
+    const messageManager = accountState?.messageManager ?? this.messageManager;
+    if (!messageManager) {
+      throw new Error(
+        "Telegram bot is not initialized — cannot edit or react to a message.",
+      );
+    }
+
+    let chatId: number | string | undefined;
+    let threadId: number | undefined;
+
+    if (target.channelId) {
+      const parts = parseTelegramTargetParts(target.channelId, target.threadId);
+      chatId = parts.chatId;
+      threadId = parts.threadId;
+    } else if (target.roomId) {
+      const room = await runtime.getRoom(target.roomId);
+      const metadata = room?.metadata as Record<string, unknown> | undefined;
+      const metadataThreadId =
+        typeof metadata?.threadId === "string" ? metadata.threadId : undefined;
+      if (room?.channelId) {
+        const parts = parseTelegramTargetParts(
+          room.channelId,
+          metadataThreadId,
+        );
+        chatId = parts.chatId;
+        threadId = parts.threadId;
+      }
+    } else if (target.entityId) {
+      const entity = await runtime.getEntityById(target.entityId);
+      const telegramMeta = entity?.metadata?.telegram as
+        | Record<string, unknown>
+        | undefined;
+      const telegramId = telegramMeta?.id;
+      if (telegramId !== undefined && telegramId !== null) {
+        chatId = telegramId as number | string;
+      }
+      if (target.threadId && /^\d+$/.test(target.threadId)) {
+        threadId = Number.parseInt(target.threadId, 10);
+      }
+    }
+
+    if (chatId === undefined) {
+      throw new Error(
+        `Could not determine target Telegram chat ID for target: ${JSON.stringify(target)}`,
+      );
+    }
+
+    return { chatId, threadId, messageManager, accountId };
+  }
+
+  /**
+   * Connector `edit_message` capability: rewrites a previously-sent message in
+   * place (used by the orchestrator's compact progress mode so heartbeats edit
+   * one message instead of flooding the chat). Returns void — the connector
+   * `editHandler` contract accepts a `Promise<void>`.
+   */
+  public async editConnectorMessage(
+    runtime: IAgentRuntime,
+    params: MessageConnectorEditParams,
+  ): Promise<void> {
+    const text = params.content?.text;
+    if (!text?.trim()) {
+      throw new Error("Telegram edit requires non-empty text.");
+    }
+    const messageId = Number.parseInt(params.messageId, 10);
+    if (!Number.isFinite(messageId)) {
+      throw new Error(
+        `Telegram edit requires a numeric message id, got "${params.messageId}".`,
+      );
+    }
+    const { chatId, threadId, messageManager } =
+      await this.resolveConnectorMessageTarget(runtime, params.target);
+    await messageManager.editMessage(chatId, messageId, text, threadId);
+  }
+
+  /**
+   * Connector `react_message` capability: sets a single emoji reaction on a
+   * message (or clears the bot's reactions when `emoji` is empty).
+   */
+  public async reactConnectorMessage(
+    runtime: IAgentRuntime,
+    params: MessageConnectorReactionParams,
+  ): Promise<void> {
+    const messageId = Number.parseInt(params.messageId, 10);
+    if (!Number.isFinite(messageId)) {
+      throw new Error(
+        `Telegram reaction requires a numeric message id, got "${params.messageId}".`,
+      );
+    }
+    const emoji = params.emoji?.trim();
+    const { chatId, messageManager } = await this.resolveConnectorMessageTarget(
+      runtime,
+      params.target,
+    );
+    await messageManager.addReaction(chatId, messageId, emoji || undefined);
+  }
+
   async resolveConnectorTargets(
     query: string,
     context: MessageConnectorQueryContext,
@@ -2413,7 +2531,7 @@ export class TelegramService extends Service {
             ? `Telegram (${state.account.name})`
             : "Telegram",
           description:
-            "Telegram connector for sending messages to chats, topics, and users.",
+            "Telegram connector for sending, editing, and reacting to messages in chats, topics, and users.",
           capabilities: [...TELEGRAM_CONNECTOR_CAPABILITIES],
           supportedTargetKinds: ["channel", "group", "thread", "user"],
           contexts: [...TELEGRAM_CONNECTOR_CONTEXTS],
@@ -2425,6 +2543,10 @@ export class TelegramService extends Service {
             serviceInstance.createConnectorThread(runtime, params),
           postToThreadHandler: (runtime, params) =>
             serviceInstance.postToConnectorThread(runtime, params),
+          editHandler: (runtime, params) =>
+            serviceInstance.editConnectorMessage(runtime, params),
+          reactHandler: (runtime, params) =>
+            serviceInstance.reactConnectorMessage(runtime, params),
           resolveTargets: (query, context) =>
             serviceInstance.resolveConnectorTargets(
               query,


### PR DESCRIPTION
Closes #8903. Part of #8885 (multi-task supervision) — unblocks #8902 (pinned task board), #8904 (screenshot delivery), #8912 (per-step streaming).

## Problem
Telegram floods chat with a new message per progress heartbeat because the connector can't edit. `TELEGRAM_CONNECTOR_CAPABILITIES` omitted `edit_message`/`react_message`, so the orchestrator's `resolveCanEdit` returned false and compact progress mode couldn't edit in place (Discord already has both).

## What this does
The low-level `MessageManager.editMessage`/`addReaction` already existed; the missing piece was the **connector wiring**:
- Added `"edit_message"` + `"react_message"` to `TELEGRAM_CONNECTOR_CAPABILITIES`.
- Added typed `editConnectorMessage` / `reactConnectorMessage` (core `MessageConnectorEditParams`/`MessageConnectorReactionParams` → `Promise<void>`, no bare booleans) and wired `editHandler`/`reactHandler` into the connector registration block next to the thread handlers.
- `resolveConnectorMessageTarget` reuses `parseTelegramTargetParts` + `resolveAccountIdForTarget` (forum-topic `<chatId>-<threadId>` aware, multi-account aware), matching `handleSendMessage`.
- Hardened `editMessage` to swallow Telegram's "message is not modified" 400 as a no-op; the existing MarkdownV2→plain-text fallback is reused.

## Evidence
```
$ bun run --cwd plugins/plugin-telegram test -- messageManager messageConnector
 Test Files  2 passed (2)
      Tests  39 passed (39)
```
tsc (`tsconfig.build.json` + `tsconfig.json`) clean (plugin has no `typecheck` script). biome clean. 4 files, +380/-20. Isolated worktree; main checkout untouched.

## Caveats (pre-existing, NOT introduced — confirmed on clean develop)
- `command-registration.test.ts` `/think` gating test fails on the baseline too (unrelated).
- Live scenario (single progress message edited across heartbeats with the Telegram mock + `ACPX_PROGRESS_MODE=compact`) is a tracked follow-up — code + mock-Bot-API unit tests are complete; not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)