### PR TITLE
feat(cloud): route NodeAutoscaler through ComputeProvider seam + local autoscale integration test

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -14,6 +14,10 @@ on:
       - "packages/cloud-sdk/**"
       - "packages/cloud-services/**"
       - "packages/scripts/cloud/**"
+      # Stateful Hetzner/control-plane mocks used by cloud integration tests
+      # (e.g. node-autoscaler.integration.test.ts) — re-run the cloud suite when
+      # the mock changes so the autoscaler gate stays honest.
+      - "packages/test/cloud-mocks/**"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"
@@ -27,6 +31,7 @@ on:
       - "packages/cloud-sdk/**"
       - "packages/cloud-services/**"
       - "packages/scripts/cloud/**"
+      - "packages/test/cloud-mocks/**"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"

--- a/packages/cloud-shared/package.json
+++ b/packages/cloud-shared/package.json
@@ -88,6 +88,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.0",
     "@cloudflare/workers-types": "^4.20260429.1",
+    "@elizaos/cloud-test-mocks": "workspace:*",
     "@types/node": "^25.6.0",
     "@types/nodemailer": "^8.0.0",
     "@types/pg": "^8.20.0",

--- a/packages/cloud-shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -25,7 +25,17 @@ import type {
 // names from `hetzner-cloud-api` keep resolving after the seam extraction.
 export type { CreateServerInput, CreateVolumeInput, ProvisionedServer } from "./compute-provider";
 
-const HCLOUD_API_BASE = process.env.HCLOUD_API_BASE_URL ?? "https://api.hetzner.cloud/v1";
+/**
+ * Resolve the Hetzner API base URL lazily (per request) rather than freezing it
+ * at module load. Production reads the real endpoint; local integration tests
+ * point `HCLOUD_API_BASE_URL` at the stateful Hetzner mock AFTER this module is
+ * imported, so a module-load-time const would capture the wrong (real) endpoint
+ * and the test client would hit the live API. Reading per request keeps prod
+ * behavior identical while making the endpoint injectable.
+ */
+function hcloudApiBase(): string {
+  return process.env.HCLOUD_API_BASE_URL ?? "https://api.hetzner.cloud/v1";
+}
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export type HetznerCloudErrorCode =
@@ -374,7 +384,7 @@ export class HetznerCloudClient implements ComputeProvider {
     const timer = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
     let response: Response;
     try {
-      response = await fetch(`${HCLOUD_API_BASE}${path}`, {
+      response = await fetch(`${hcloudApiBase()}${path}`, {
         method,
         headers: {
           Authorization: `Bearer ${this.token}`,

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Local autoscale-loop integration test (#8920).
+ *
+ * Drives the FULL scale-up → healthy → scale-down cycle of `NodeAutoscaler`
+ * against two real collaborators and NO real credentials:
+ *
+ *  1. The stateful Hetzner HTTP mock (`@elizaos/cloud-test-mocks`) — a real
+ *     fetch server whose `/servers` create/delete actions progress through a
+ *     `running → success` lifecycle, mutating `server.status` to `running` once
+ *     the action clock ticks. We point a real `HetznerCloudClient` at it via the
+ *     #8919 ComputeProvider seam (`HCLOUD_API_BASE_URL` + an injected client),
+ *     so NO HCLOUD_TOKEN and NO network to Hetzner.
+ *
+ *  2. A real PGlite-backed `docker_nodes` table (plus the `containers` /
+ *     `agent_sandboxes` tables the workload counters read), using the same
+ *     in-process PGlite harness the other cloud-shared DB tests use
+ *     (`DATABASE_URL=pglite://memory`, real SQL via `dbWrite.execute`). The
+ *     autoscaler's `dockerNodesRepository` writes/reads go through real Drizzle
+ *     against real SQL.
+ *
+ * The test ticks across multiple cycles:
+ *   - evaluateCapacity() on an empty pool → shouldScaleUp
+ *   - provisionNode() → assert a docker_nodes row appears (status `unknown`)
+ *   - flip it to `healthy` (the production health check's job) → assert
+ *     evaluateCapacity() now sees healthy capacity and stops scaling up
+ *   - add a SECOND healthy node + age both past the idle threshold + drive
+ *     utilization down (zero workloads) → evaluateCapacity() flags a drain
+ *     candidate → drainNode(deprovision) deletes the Hetzner server AND the row.
+ *
+ * Self-skips if PGlite is unavailable in this environment.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  type RunningHetznerMock,
+  startHetznerMock,
+  // Relative import: `@elizaos/cloud-test-mocks` is a private workspace package
+  // not symlinked into this package's node_modules in every environment, so we
+  // resolve the source directly. cloud-shared's tsconfig excludes *.test.ts from
+  // typecheck, and bun resolves the path natively at test time.
+} from "../../../../../test/cloud-mocks/src/hetzner/index.ts";
+
+// Env MUST be set before importing any module that reads it at load time:
+//  - DATABASE_URL: PGlite in-memory (db/client reads it lazily, but pin early).
+//  - HCLOUD_API_BASE_URL: hetzner-cloud-api reads this into a module const at
+//    import, so it must be set BEFORE the dynamic import below — we therefore
+//    start the mock and set this inside beforeAll, then import the client.
+//  - MOCK_HETZNER_LATENCY=0: the mock injects 70-220ms artificial latency per
+//    route by default; disable it so the loop runs fast.
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_HETZNER_LATENCY = "0";
+process.env.ENVIRONMENT ||= "local";
+process.env.ELIZA_AGENT_IMAGE = "ghcr.io/elizaos/eliza:latest";
+// arm64 so the autoscaler's architecture-compatibility filter treats a cax21
+// (arm) node as compatible capacity.
+process.env.ELIZA_AGENT_IMAGE_PLATFORM = "linux/arm64";
+
+const PGLITE_TIMEOUT = 60_000;
+const ACTION_MS = 5; // mock action lifecycle: provision/delete settle almost instantly
+
+const policy = {
+  minFreeSlotsBuffer: 4,
+  minHotAvailableSlots: 1,
+  maxNodes: 4,
+  scaleUpCooldownMs: 5 * 60 * 1000,
+  idleNodeMinAgeMs: 30 * 60 * 1000,
+  defaultServerType: "cax21",
+  defaultLocation: "fsn1",
+  defaultImage: "ubuntu-24.04",
+  defaultCapacity: 8,
+};
+
+const bootstrap = {
+  controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+  registrationUrl: "https://cloud.example.test/register",
+  registrationSecret: "secret",
+};
+
+let mock: RunningHetznerMock;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let HetznerCloudClient: typeof import("./hetzner-cloud-api").HetznerCloudClient;
+let NodeAutoscaler: typeof import("./node-autoscaler").NodeAutoscaler;
+let pgliteReady = true;
+/** Restored in afterAll so sibling tests in the same process see the real endpoint. */
+let originalApiBaseUrl: string | undefined;
+
+/** Wall clock the autoscaler reads; advanced by the test to age nodes. */
+let clockMs = Date.parse("2026-05-15T12:00:00Z");
+const nowFn = () => clockMs;
+
+beforeAll(async () => {
+  // 1) Boot the mock and pin its URL into the env BEFORE importing the client.
+  //    hetzner-cloud-api reads HCLOUD_API_BASE_URL per request, so setting it
+  //    here (even after the module is loaded by a sibling test) takes effect.
+  originalApiBaseUrl = process.env.HCLOUD_API_BASE_URL;
+  mock = await startHetznerMock({ actionMs: ACTION_MS });
+  process.env.HCLOUD_API_BASE_URL = mock.url;
+
+  try {
+    ({ dbWrite } = await import("../../../db/client"));
+    ({ HetznerCloudClient } = await import("./hetzner-cloud-api"));
+    ({ NodeAutoscaler } = await import("./node-autoscaler"));
+
+    // Full docker_nodes table (the repository inserts via Drizzle over the whole
+    // schema). containers + agent_sandboxes carry only the columns the workload
+    // counters read.
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS docker_nodes (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        node_id text UNIQUE NOT NULL,
+        hostname text NOT NULL,
+        ssh_port integer NOT NULL DEFAULT 22,
+        capacity integer NOT NULL DEFAULT 8,
+        enabled boolean NOT NULL DEFAULT true,
+        status text NOT NULL DEFAULT 'unknown',
+        allocated_count integer NOT NULL DEFAULT 0,
+        last_health_check timestamptz,
+        ssh_user text NOT NULL DEFAULT 'root',
+        host_key_fingerprint text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS containers (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid,
+        node_id text,
+        status text NOT NULL DEFAULT 'pending',
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS agent_sandboxes (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid,
+        node_id text,
+        status text NOT NULL DEFAULT 'pending',
+        pool_status text,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )`,
+    ];
+    for (const stmt of ddl) {
+      await dbWrite.execute(stmt);
+    }
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[node-autoscaler.integration] PGlite unavailable, skipping:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await mock?.stop();
+  if (originalApiBaseUrl === undefined) {
+    delete process.env.HCLOUD_API_BASE_URL;
+  } else {
+    process.env.HCLOUD_API_BASE_URL = originalApiBaseUrl;
+  }
+});
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  clockMs = Date.parse("2026-05-15T12:00:00Z");
+  await dbWrite.execute("DELETE FROM docker_nodes;");
+  await dbWrite.execute("DELETE FROM containers;");
+  await dbWrite.execute("DELETE FROM agent_sandboxes;");
+});
+
+/** A real Hetzner client wired to the mock — the production code path, no creds. */
+function makeAutoscaler() {
+  const provider = HetznerCloudClient.withToken("integration-test-token");
+  return new NodeAutoscaler(policy, nowFn, {
+    provider,
+    isConfigured: () => true,
+  });
+}
+
+async function nodeRows(): Promise<
+  Array<{ node_id: string; status: string; enabled: boolean; hostname: string }>
+> {
+  const res = await dbWrite.execute(
+    "SELECT node_id, status, enabled, hostname FROM docker_nodes ORDER BY node_id;",
+  );
+  return res.rows as Array<{
+    node_id: string;
+    status: string;
+    enabled: boolean;
+    hostname: string;
+  }>;
+}
+
+/**
+ * ISO timestamp `ms` before the autoscaler's injected clock. Used to backdate a
+ * node's `created_at` so it ages relative to `nowFn()` (the autoscaler reads the
+ * injected clock, but PGlite stamps `created_at = now()` at the real wall clock,
+ * which would otherwise sit in the future relative to `clockMs`).
+ */
+function isoBefore(ms: number): string {
+  return new Date(clockMs - ms).toISOString();
+}
+
+/** Wait until the mock has flipped a created server to `running`. */
+async function waitForServerRunning(serverId: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (mock.store.servers.get(serverId)?.status === "running") return;
+    await new Promise((resolve) => setTimeout(resolve, ACTION_MS));
+  }
+  throw new Error(`mock server ${serverId} never reached running`);
+}
+
+describe("NodeAutoscaler local autoscale loop (Hetzner mock + PGlite)", () => {
+  test(
+    "drives the full provision → healthy → drain cycle",
+    async () => {
+      if (!pgliteReady) return;
+      const autoscaler = makeAutoscaler();
+
+      // ── Cycle 1: empty pool → must scale up ─────────────────────────────
+      const empty = await autoscaler.evaluateCapacity();
+      expect(empty.enabledNodeCount).toBe(0);
+      expect(empty.totalAvailable).toBe(0);
+      expect(empty.shouldScaleUp).toBe(true);
+
+      // ── Provision a node through the seam (real client → mock) ───────────
+      const provisioned = await autoscaler.provisionNode({ nodeId: "node-a" }, bootstrap);
+      expect(provisioned.nodeId).toBe("node-a");
+      // The mock minted a real numeric server id and a public IPv4 the
+      // autoscaler persisted as the hostname.
+      expect(provisioned.hcloudServerId).toBeGreaterThan(0);
+      expect(provisioned.hostname).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+
+      // A docker_nodes row appears in `unknown` status (bootstrap in flight).
+      let rows = await nodeRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.node_id).toBe("node-a");
+      expect(rows[0]?.status).toBe("unknown");
+      expect(rows[0]?.hostname).toBe(provisioned.hostname);
+
+      // The mock server actually exists and progresses to `running`.
+      expect(mock.store.servers.has(provisioned.hcloudServerId)).toBe(true);
+      await waitForServerRunning(provisioned.hcloudServerId);
+      expect(mock.store.servers.get(provisioned.hcloudServerId)?.status).toBe("running");
+
+      // An `unknown` node contributes NO capacity yet → still wants to scale up.
+      const stillCold = await autoscaler.evaluateCapacity();
+      expect(stillCold.healthyNodeCount).toBe(0);
+      expect(stillCold.shouldScaleUp).toBe(true);
+
+      // ── Tick the action clock to healthy (the health-check's job) ────────
+      await dbWrite.execute(
+        "UPDATE docker_nodes SET status = 'healthy', last_health_check = now() WHERE node_id = 'node-a';",
+      );
+
+      const healthy = await autoscaler.evaluateCapacity();
+      expect(healthy.healthyNodeCount).toBe(1);
+      expect(healthy.totalCapacity).toBe(policy.defaultCapacity);
+      expect(healthy.totalAvailable).toBe(policy.defaultCapacity);
+      // Available (8) >= buffer (4) → no further scale-up.
+      expect(healthy.shouldScaleUp).toBe(false);
+
+      // ── Add a SECOND healthy node so a drain is even allowed (the loop
+      //    never drains the last healthy node) and so the pool is over-provisioned.
+      const second = await autoscaler.provisionNode({ nodeId: "node-b" }, bootstrap);
+      await dbWrite.execute(
+        "UPDATE docker_nodes SET status = 'healthy', last_health_check = now() WHERE node_id = 'node-b';",
+      );
+      await waitForServerRunning(second.hcloudServerId);
+
+      // Two healthy nodes, zero workloads → 16 free slots, way over buffer.
+      // Both rows were just inserted, so relative to the autoscaler clock they
+      // are brand-new (younger than idleNodeMinAgeMs) and NOT yet drainable.
+      const recentCreated = isoBefore(0);
+      await dbWrite.execute(
+        `UPDATE docker_nodes SET created_at = '${recentCreated}' WHERE node_id IN ('node-a','node-b');`,
+      );
+      const overProvisioned = await autoscaler.evaluateCapacity();
+      expect(overProvisioned.healthyNodeCount).toBe(2);
+      expect(overProvisioned.shouldScaleUp).toBe(false);
+      expect(overProvisioned.shouldScaleDownNodeIds).toHaveLength(0);
+
+      // ── Drive utilization down: age both nodes past the idle threshold (and
+      //    past the scale-up cooldown) so an idle, zero-workload node becomes
+      //    drainable. Utilization is already zero — no containers/sandboxes. ──
+      const agedCreated = isoBefore(policy.idleNodeMinAgeMs + 60_000);
+      await dbWrite.execute(
+        `UPDATE docker_nodes SET created_at = '${agedCreated}' WHERE node_id IN ('node-a','node-b');`,
+      );
+
+      const drainable = await autoscaler.evaluateCapacity();
+      expect(drainable.shouldScaleUp).toBe(false);
+      // At least one idle, aged node is now eligible for drain.
+      expect(drainable.shouldScaleDownNodeIds.length).toBeGreaterThan(0);
+      const drainTarget = drainable.shouldScaleDownNodeIds[0];
+      if (drainTarget === undefined) throw new Error("expected a drain candidate");
+
+      const targetRow = (await nodeRows()).find((r) => r.node_id === drainTarget);
+      const targetServerId =
+        drainTarget === "node-a" ? provisioned.hcloudServerId : second.hcloudServerId;
+      expect(targetRow).toBeDefined();
+
+      // ── drainNode(deprovision) → row deleted AND mock server deletion driven.
+      await autoscaler.drainNode(drainTarget, { deprovision: true });
+
+      const afterDrain = await nodeRows();
+      expect(afterDrain.map((r) => r.node_id)).not.toContain(drainTarget);
+      expect(afterDrain).toHaveLength(1);
+
+      // The Hetzner mock processed the delete action; the server is gone (or
+      // mid-deletion) — assert it is no longer a live `running` server.
+      const deletedDeadline = Date.now() + 5_000;
+      while (Date.now() < deletedDeadline) {
+        const s = mock.store.servers.get(targetServerId);
+        if (!s || s.status === "deleting") break;
+        await new Promise((resolve) => setTimeout(resolve, ACTION_MS));
+      }
+      const finalServer = mock.store.servers.get(targetServerId);
+      expect(finalServer === undefined || finalServer.status !== "running").toBe(true);
+
+      // The surviving node still serves capacity — the pool drained safely.
+      const settled = await autoscaler.evaluateCapacity();
+      expect(settled.healthyNodeCount).toBe(1);
+      expect(settled.shouldScaleUp).toBe(false);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "never drains the last healthy node even when idle and aged",
+    async () => {
+      if (!pgliteReady) return;
+      const autoscaler = makeAutoscaler();
+
+      const only = await autoscaler.provisionNode({ nodeId: "solo" }, bootstrap);
+      // Healthy + aged well past the idle threshold; utilization is zero.
+      const agedCreated = isoBefore(policy.idleNodeMinAgeMs + 60_000);
+      await dbWrite.execute(
+        `UPDATE docker_nodes SET status = 'healthy', last_health_check = now(), created_at = '${agedCreated}' WHERE node_id = 'solo';`,
+      );
+      await waitForServerRunning(only.hcloudServerId);
+
+      const decision = await autoscaler.evaluateCapacity();
+      // Single healthy node is the floor: it must never be drained.
+      expect(decision.healthyNodeCount).toBe(1);
+      expect(decision.shouldScaleDownNodeIds).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -1,15 +1,20 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DockerNode } from "../../../db/repositories/docker-nodes";
-
 // Bun runs every cloud-shared test file in a single process, and `mock.module`
 // overrides are process-global with no built-in per-file teardown. Without an
 // explicit restore, these stubs leak into later files that import the real
-// modules (e.g. `compute-provider-characterization.test.ts` reading
-// `HetznerCloudError.status`), producing order-dependent failures. Capture the
-// real modules up front and re-install them in `afterAll`.
+// modules, producing order-dependent failures. Capture the real modules up
+// front and re-install them in `afterAll`.
+//
+// NOTE: after the #8919 ComputeProvider-seam refactor we no longer mock
+// `./hetzner-cloud-api` at all — the autoscaler resolves its provider through an
+// injected `deps.provider` (the seam), so the fake is passed directly into the
+// constructor with NO monkey-patching of the provider singletons. We still mock
+// the DB repository, the workload counters, and node-bootstrap because those are
+// process-global collaborators the autoscaler reads directly.
 import * as realDockerNodesNs from "../../../db/repositories/docker-nodes";
 import * as realDockerNodeWorkloadsNs from "../docker-node-workloads";
-import * as realHetznerCloudApiNs from "./hetzner-cloud-api";
+import type { ComputeProvider, ProvisionedServer } from "./compute-provider";
 import * as realNodeBootstrapNs from "./node-bootstrap";
 
 // Snapshot the real exports into plain objects *before* the `mock.module` calls
@@ -19,7 +24,6 @@ import * as realNodeBootstrapNs from "./node-bootstrap";
 // `mock.module` statements) and restore from these snapshots in `afterAll`.
 const realDockerNodes = { ...realDockerNodesNs };
 const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
-const realHetznerCloudApi = { ...realHetznerCloudApiNs };
 const realNodeBootstrap = { ...realNodeBootstrapNs };
 
 const AGENT_IMAGE = "ELIZA_AGENT_IMAGE";
@@ -40,11 +44,13 @@ const mocks = {
   findAllNodes: mock(),
   createServer: mock(),
   deleteServer: mock(),
-  isConfigured: mock(),
   buildUserData: mock(),
   countAllocated: mock(),
   countRetained: mock(),
 };
+
+/** Tracks whether the injected provider reports its surface as configured. */
+let providerConfigured = true;
 
 mock.module("../../../db/repositories/docker-nodes", () => ({
   dockerNodesRepository: {
@@ -61,23 +67,6 @@ mock.module("../docker-node-workloads", () => ({
   countRetainedWorkloadsOnNode: mocks.countRetained,
 }));
 
-mock.module("./hetzner-cloud-api", () => ({
-  HetznerCloudError: class HetznerCloudError extends Error {
-    constructor(
-      public readonly code: string,
-      message: string,
-    ) {
-      super(message);
-      this.name = "HetznerCloudError";
-    }
-  },
-  getHetznerCloudClient: () => ({
-    createServer: mocks.createServer,
-    deleteServer: mocks.deleteServer,
-  }),
-  isHetznerCloudConfigured: mocks.isConfigured,
-}));
-
 mock.module("./node-bootstrap", () => ({
   buildContainerNodeUserData: mocks.buildUserData,
 }));
@@ -85,11 +74,48 @@ mock.module("./node-bootstrap", () => ({
 afterAll(() => {
   mock.module("../../../db/repositories/docker-nodes", () => realDockerNodes);
   mock.module("../docker-node-workloads", () => realDockerNodeWorkloads);
-  mock.module("./hetzner-cloud-api", () => realHetznerCloudApi);
   mock.module("./node-bootstrap", () => realNodeBootstrap);
 });
 
-import { type AutoscalePolicy, NodeAutoscaler } from "./node-autoscaler";
+import { type AutoscalePolicy, NodeAutoscaler, type NodeAutoscalerDeps } from "./node-autoscaler";
+
+/**
+ * Minimal `ComputeProvider` test double wired to the spy mocks. Only the two
+ * methods the autoscaler actually drives (`createServer` / `deleteServer`) carry
+ * behavior; the rest throw if the autoscaler ever reaches for them, which would
+ * be a regression.
+ */
+function fakeProvider(): ComputeProvider {
+  const unexpected = (name: string) => () => {
+    throw new Error(`fakeProvider.${name} should not be called by the autoscaler`);
+  };
+  return {
+    createServer: (input) => mocks.createServer(input) as Promise<ProvisionedServer>,
+    deleteServer: (id) => mocks.deleteServer(id) as Promise<void>,
+    listServers: unexpected("listServers"),
+    getServer: unexpected("getServer"),
+    powerOff: unexpected("powerOff"),
+    powerOn: unexpected("powerOn"),
+    listVolumes: unexpected("listVolumes"),
+    getVolume: unexpected("getVolume"),
+    createVolume: unexpected("createVolume"),
+    attachVolume: unexpected("attachVolume"),
+    detachVolume: unexpected("detachVolume"),
+    deleteVolume: unexpected("deleteVolume"),
+    waitForAction: unexpected("waitForAction"),
+    listServerTypes: unexpected("listServerTypes"),
+    listLocations: unexpected("listLocations"),
+    listImages: unexpected("listImages"),
+  };
+}
+
+/** The seam injection passed to every autoscaler under test. */
+function deps(): NodeAutoscalerDeps {
+  return {
+    provider: fakeProvider(),
+    isConfigured: () => providerConfigured,
+  };
+}
 
 const policy: AutoscalePolicy = {
   minFreeSlotsBuffer: 4,
@@ -103,7 +129,7 @@ const policy: AutoscalePolicy = {
   defaultCapacity: 8,
 };
 
-describe("NodeAutoscaler Hetzner provisioning", () => {
+describe("NodeAutoscaler provisioning via the ComputeProvider seam", () => {
   let originalAgentImage: string | undefined;
   let originalAgentImagePlatform: string | undefined;
   let originalHcloudNetworkIds: string | undefined;
@@ -119,7 +145,6 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     mocks.findAllNodes.mockClear();
     mocks.createServer.mockClear();
     mocks.deleteServer.mockClear();
-    mocks.isConfigured.mockClear();
     mocks.buildUserData.mockClear();
     mocks.countAllocated.mockClear();
     mocks.countRetained.mockClear();
@@ -127,12 +152,13 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     mocks.findAllNodes.mockImplementation(() => Promise.resolve(mocks.nodes));
     mocks.countAllocated.mockResolvedValue(0);
     mocks.countRetained.mockResolvedValue(0);
-    mocks.isConfigured.mockReturnValue(true);
+    providerConfigured = true;
     mocks.buildUserData.mockReturnValue("#cloud-config\n");
     mocks.createServer.mockResolvedValue({
       server: {
         id: 4242,
         name: "node-test",
+        status: "initializing",
         public_net: {
           ipv4: { ip: "203.0.113.10" },
           ipv6: null,
@@ -148,8 +174,8 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     restoreEnv(HCLOUD_NETWORK_IDS, originalHcloudNetworkIds);
   });
 
-  test("creates a Hetzner server and registers the autoscaled docker node", async () => {
-    const autoscaler = new NodeAutoscaler(policy, () => Date.parse("2026-05-15T12:00:00Z"));
+  test("creates a server (via the injected provider) and registers the autoscaled docker node", async () => {
+    const autoscaler = new NodeAutoscaler(policy, () => Date.parse("2026-05-15T12:00:00Z"), deps());
 
     const result = await autoscaler.provisionNode(
       {
@@ -218,7 +244,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
 
   test("passes configured Hetzner private network ids to new nodes", async () => {
     process.env[HCLOUD_NETWORK_IDS] = "12305703";
-    const autoscaler = new NodeAutoscaler(policy);
+    const autoscaler = new NodeAutoscaler(policy, undefined, deps());
 
     await autoscaler.provisionNode(
       { nodeId: "node-networked" },
@@ -237,9 +263,9 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     );
   });
 
-  test("fails before calling hcloud when Hetzner is not configured", async () => {
-    mocks.isConfigured.mockReturnValue(false);
-    const autoscaler = new NodeAutoscaler(policy);
+  test("fails before calling the provider when it is not configured", async () => {
+    providerConfigured = false;
+    const autoscaler = new NodeAutoscaler(policy, undefined, deps());
 
     await expect(
       autoscaler.provisionNode(
@@ -258,11 +284,12 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
   });
 
   test("generates an eliza-core-<8hex> nodeId when none is supplied", async () => {
-    const autoscaler = new NodeAutoscaler(policy);
+    const autoscaler = new NodeAutoscaler(policy, undefined, deps());
     mocks.createServer.mockResolvedValue({
       server: {
         id: 7777,
         name: "generated",
+        status: "initializing",
         public_net: { ipv4: { ip: "203.0.113.20" }, ipv6: null },
       },
       rootPassword: null,
@@ -286,7 +313,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
   });
 
   test("generated nodeIds are unique across repeated provisions", async () => {
-    const autoscaler = new NodeAutoscaler(policy);
+    const autoscaler = new NodeAutoscaler(policy, undefined, deps());
     const seen = new Set<string>();
     const N = 50;
 
@@ -296,6 +323,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
         server: {
           id: 8000 + i,
           name: "generated",
+          status: "initializing",
           public_net: { ipv4: { ip: "203.0.113.30" }, ipv6: null },
         },
         rootPassword: null,
@@ -316,7 +344,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
   });
 
   test("scales up when there is no healthy compatible capacity", async () => {
-    const autoscaler = new NodeAutoscaler(policy);
+    const autoscaler = new NodeAutoscaler(policy, undefined, deps());
 
     await expect(autoscaler.evaluateCapacity()).resolves.toMatchObject({
       totalCapacity: 0,

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
@@ -31,10 +31,12 @@ import {
   isArchitectureCompatibleWithPlatform,
 } from "../docker-sandbox-utils";
 import {
-  getHetznerCloudClient,
-  HetznerCloudError,
-  isHetznerCloudConfigured,
-} from "./hetzner-cloud-api";
+  type ComputeProvider,
+  type ComputeServer,
+  getComputeProvider,
+  isComputeConfigured,
+} from "./compute-provider";
+import { HetznerCloudError } from "./hetzner-cloud-api";
 import { buildContainerNodeUserData, type NodeBootstrapInput } from "./node-bootstrap";
 
 // ---------------------------------------------------------------------------
@@ -113,15 +115,55 @@ export interface DrainOptions {
   deprovision?: boolean;
 }
 
+/**
+ * Dependency-injection seam for {@link NodeAutoscaler}.
+ *
+ * In production these default (lazily) to the `ComputeProvider` selected by
+ * `getComputeProvider()` (Hetzner unless `COMPUTE_PROVIDER=digitalocean`) and
+ * the matching `isComputeConfigured()` check — so runtime behavior is
+ * unchanged. Tests inject a deterministic fake (`InMemoryComputeProvider`) or a
+ * real client pointed at a local Hetzner mock, with NO monkey-patching of the
+ * provider singletons.
+ *
+ * Both are resolved lazily (`provider`/`isConfigured` are getters, called only
+ * when an actual provision/drain runs) so simply constructing a
+ * `NodeAutoscaler` never builds a Hetzner client or reads `HCLOUD_TOKEN`.
+ */
+export interface NodeAutoscalerDeps {
+  /** The IaaS provider used for server create/delete. */
+  provider: ComputeProvider;
+  /** Whether the provider's elastic-provisioning surface is configured. */
+  isConfigured(): boolean;
+}
+
 // ---------------------------------------------------------------------------
 // NodeAutoscaler
 // ---------------------------------------------------------------------------
 
 export class NodeAutoscaler {
+  /** Lazily-resolved compute provider (built once, on first provision/drain). */
+  private readonly resolveProvider: () => ComputeProvider;
+  /** Configured-check for the selected provider. */
+  private readonly isConfigured: () => boolean;
+
+  /**
+   * @param policy autoscale thresholds (defaults to env-derived production policy)
+   * @param nowFn injectable clock (defaults to `Date.now`)
+   * @param deps  IaaS seam injection. Omit to use `getComputeProvider()` /
+   *              `isComputeConfigured()` (production default: Hetzner). Pass a
+   *              fake/mock-backed provider in tests — no monkey-patching needed.
+   */
   constructor(
     private readonly policy: AutoscalePolicy = DEFAULT_AUTOSCALE_POLICY,
     private readonly nowFn: () => number = () => Date.now(),
-  ) {}
+    deps?: Partial<NodeAutoscalerDeps>,
+  ) {
+    // Memoize an injected provider; otherwise defer to the seam so a bare
+    // `new NodeAutoscaler()` never constructs a Hetzner client up front.
+    const injected = deps?.provider;
+    this.resolveProvider = injected ? () => injected : () => getComputeProvider();
+    this.isConfigured = deps?.isConfigured ?? isComputeConfigured;
+  }
 
   /**
    * Inspect current pool state and return a decision: should we scale up,
@@ -212,10 +254,10 @@ export class NodeAutoscaler {
       "controlPlanePublicKey" | "registrationUrl" | "registrationSecret"
     >,
   ): Promise<ProvisionResult> {
-    if (!isHetznerCloudConfigured()) {
+    if (!this.isConfigured()) {
       throw new HetznerCloudError(
         "missing_token",
-        "Cannot provision a node: HCLOUD_TOKEN is not set.",
+        "Cannot provision a node: the compute provider is not configured (HCLOUD_TOKEN unset).",
       );
     }
     if (bootstrap.controlPlanePublicKey.trim().length === 0) {
@@ -243,7 +285,7 @@ export class NodeAutoscaler {
       capacity,
     });
 
-    const client = getHetznerCloudClient();
+    const client = this.resolveProvider();
     // `environment` + `tier` let the orchestrator scope server lookups via
     // Hetzner's label_selector (e.g. `environment=staging,tier=data-plane`) so
     // staging never touches a production node, and a runaway daemon can't
@@ -269,10 +311,11 @@ export class NodeAutoscaler {
       labels,
     });
 
-    const ip =
-      provisioned.server.public_net.ipv4?.ip ??
-      provisioned.server.public_net.ipv6?.ip ??
-      provisioned.server.name;
+    const ip = extractServerAddress(provisioned.server);
+    // The seam declares ids as `number | string`; we store/consume the server id
+    // as a numeric `hcloudServerId` throughout (it feeds `deleteServer(number)`),
+    // so normalize at this boundary. Hetzner/DO both mint numeric ids.
+    const serverId = coerceServerId(provisioned.server.id);
 
     // Insert the row in `unknown` status — the cloud-init bootstrap is
     // still running; the periodic health check will flip it to healthy.
@@ -288,7 +331,7 @@ export class NodeAutoscaler {
       metadata: {
         provider: "hetzner-cloud",
         autoscaled: true,
-        hcloudServerId: provisioned.server.id,
+        hcloudServerId: serverId,
         serverType,
         location,
         image,
@@ -299,7 +342,7 @@ export class NodeAutoscaler {
 
     logger.info("[autoscaler] Provisioned new container node", {
       nodeId,
-      hcloudServerId: provisioned.server.id,
+      hcloudServerId: serverId,
       ip,
       serverType,
       location,
@@ -308,7 +351,7 @@ export class NodeAutoscaler {
     return {
       nodeId,
       hostname: ip,
-      hcloudServerId: provisioned.server.id,
+      hcloudServerId: serverId,
       rootPassword: provisioned.rootPassword,
     };
   }
@@ -352,8 +395,8 @@ export class NodeAutoscaler {
       return;
     }
 
-    if (!isHetznerCloudConfigured()) {
-      logger.warn("[autoscaler] HCLOUD_TOKEN not set; cannot delete Hetzner server", {
+    if (!this.isConfigured()) {
+      logger.warn("[autoscaler] compute provider not configured; cannot delete server", {
         nodeId,
         hcloudServerId,
       });
@@ -361,7 +404,7 @@ export class NodeAutoscaler {
       return;
     }
 
-    const client = getHetznerCloudClient();
+    const client = this.resolveProvider();
     try {
       await client.deleteServer(hcloudServerId);
     } catch (err) {
@@ -445,6 +488,72 @@ function generateNodeId(): string {
   crypto.getRandomValues(bytes);
   const random = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `eliza-core-${random}`;
+}
+
+/**
+ * Normalize a provider server id (`number | string` at the seam) to the numeric
+ * `hcloudServerId` the autoscaler persists and later passes to
+ * `deleteServer(number)`. Both supported providers return numeric ids; a numeric
+ * string is parsed, anything else throws so a malformed id never silently
+ * becomes `NaN` in the DB.
+ */
+function coerceServerId(id: number | string): number {
+  const n = typeof id === "number" ? id : Number(id);
+  if (!Number.isFinite(n)) {
+    throw new HetznerCloudError(
+      "server_error",
+      `Compute provider returned a non-numeric server id: ${String(id)}`,
+    );
+  }
+  return n;
+}
+
+/**
+ * Extract a reachable address for a freshly-provisioned server through the
+ * provider-agnostic seam.
+ *
+ * The seam's `ComputeServer` only guarantees `id`/`name`/`status`; each provider
+ * carries IPs in its own richer subtype (Hetzner: `public_net.ipv4.ip`;
+ * DigitalOcean: `publicIp`). Rather than widen the seam or unsafe-cast the
+ * concrete type back, we probe both known shapes at runtime with type guards and
+ * fall back to the server name (Hetzner created the row in `unknown` status and
+ * the health check fixes the hostname once the node registers). This keeps the
+ * autoscaler decoupled from any single provider's wire shape.
+ */
+function extractServerAddress(server: ComputeServer): string {
+  const hetznerIp = readHetznerPublicIp(server);
+  if (hetznerIp) return hetznerIp;
+
+  const publicIp = readStringField(server, "publicIp");
+  if (publicIp) return publicIp;
+
+  return server.name;
+}
+
+/** Hetzner's `public_net.ipv4.ip ?? public_net.ipv6.ip`, runtime-validated. */
+function readHetznerPublicIp(server: ComputeServer): string | undefined {
+  const publicNet = readRecordField(server, "public_net");
+  if (!publicNet) return undefined;
+  return readNestedIp(publicNet, "ipv4") ?? readNestedIp(publicNet, "ipv6");
+}
+
+function readNestedIp(publicNet: Record<string, unknown>, family: string): string | undefined {
+  const entry = publicNet[family];
+  if (entry === null || typeof entry !== "object") return undefined;
+  const ip = (entry as Record<string, unknown>).ip;
+  return typeof ip === "string" && ip.length > 0 ? ip : undefined;
+}
+
+function readRecordField(obj: object, key: string): Record<string, unknown> | undefined {
+  const value = (obj as Record<string, unknown>)[key];
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readStringField(obj: object, key: string): string | undefined {
+  const value = (obj as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function getHcloudServerId(node: DockerNode): number | undefined {


### PR DESCRIPTION
Closes #8919, #8920. Part of #8889 (cloud deploy + autoscaling: local parity, seam, CI).

Makes the full provision→healthy→drain autoscale loop testable **locally with no Hetzner credentials** — a key "test the whole cloud deploy + autoscaling locally" goal.

## #8919 — seam refactor
`NodeAutoscaler` no longer calls `getHetznerCloudClient()` directly. Constructor gained an optional `deps?: Partial<NodeAutoscalerDeps>` (`{ provider: ComputeProvider; isConfigured() }`); when omitted it lazily resolves `getComputeProvider()` / `isComputeConfigured()`, so a bare `new NodeAutoscaler()` and the `getNodeAutoscaler()` singleton keep **Hetzner as the production default with zero behavior change** (no client built until an actual provision/drain). Hetzner-specific `public_net.ipv4.ip` access replaced with a provider-agnostic `extractServerAddress()` (runtime type-guards over Hetzner + DO shapes, no unsafe casts); `coerceServerId()` normalizes the seam's `number|string` id. The unit test now injects a typed `ComputeProvider` fake via `deps` — all monkey-patching removed.

## #8920 — local autoscale integration test (no real creds)
New `node-autoscaler.integration.test.ts`: boots the stateful Hetzner HTTP mock (`packages/test/cloud-mocks`), points a real `HetznerCloudClient` at it via the seam, against a real PGlite `docker_nodes`/`containers` DB (same harness as the existing containers tests). Drives the full cycle: empty pool → `evaluateCapacity` scale-up → `provisionNode` (row appears, mock mints server id + IPv4) → flip healthy → capacity satisfied → age idle nodes → `drainNode({deprovision})` deletes the row + the mock server → last-healthy-node-never-drained invariant. Auto-discovered by the `test:cloud` lane (cloud-tests.yml `unit-tests` job, gated on `cloud-shared/**`); added `cloud-mocks/**` to the workflow triggers.

## Evidence
```
$ bun run --cwd packages/cloud-shared typecheck   # tsc --noEmit, clean
$ bun run --cwd packages/cloud-shared test -- node-autoscaler.test.ts node-autoscaler.integration.test.ts
 8 pass / 0 fail / 96 expect() / 2 files
$ bun run test:cloud   # full lane: 1455 pass / 0 fail across 168 files
```
6 files, +558/-58. Isolated worktree; main checkout untouched; biome clean.

## Caveats (honest, pre-existing — not regressions)
- PGlite-backed test processes exit 99 at teardown (pglite-socket holds a handle); identical on the existing `containers-slot-release-idempotency.test.ts`. Pass/fail counts are 0-fail; the `test:cloud` aggregator handles it.
- The mock is imported by relative path (not symlinked here; no `bun install` run) with an explanatory comment; a `workspace:*` devDependency was added so a future install symlinks `@elizaos/cloud-test-mocks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)