### PR TITLE
feat(views): pre-edit git snapshot + rollback sub-mode for view/plugin create & edit

### DIFF
--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -13,7 +13,7 @@ This plugin registers three actions, two evaluators, one provider, and four serv
 | Name | File | Description |
 |---|---|---|
 | `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
-| `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `delete`/`remove`. Create/edit/delete are owner-gated; read modes are open. |
+| `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `HOMESCREEN` | `src/actions/homescreen.ts` | Customize the live homescreen canvas. Sub-modes: `edit`, `create` (model-generated scene document), `undo`, `redo`, `reset`, `duplicate`, `delete`, `save`. Broadcasts via `POST /api/views/events/broadcast`. |
 
 ### Evaluators
@@ -75,7 +75,11 @@ src/
     views-show.ts                 show/open sub-handler
     views-search.ts               search sub-handler
     views-create.ts               create sub-handler (multi-turn)
-    views-edit.ts                 edit sub-handler
+    views-edit.ts                 edit sub-handler (takes a pre-edit git snapshot)
+    views-icon.ts                 icon sub-handler (direct hero-asset regeneration)
+    views-rollback.ts             rollback sub-handler: git reset --hard <snapshot> + re-register (#8915)
+    views-snapshot.ts             pre-edit git snapshot + rollback helpers; snapshot-record persistence
+    views-plugin-source.ts        resolve a view's on-disk plugin source dir
     views-delete.ts               delete sub-handler + confirmation flow
   components/
     ViewManagerSpatialView.tsx    Spatial/XR variant of the view manager component
@@ -168,3 +172,4 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
 - **`puppeteer-core` is an optional peer dep.** `AppVerificationService` only loads it when a browser step is requested and the dep is present. Set `ELIZA_BROWSER_VERIFY_OPTIONAL=1` if you want failures there to be non-blocking.
 - **`AppWorkerHostService` auto-starts persisted worker apps best-effort.** On service start it asks `AppRegistryService` for persisted entries and spawns apps whose resolved isolation is `"worker"`. Spawn failures are reported without preventing the registry entry from remaining inspectable.
 - **Restricted platforms.** `isRestrictedPlatform()` in `src/actions/views.ts` returns `true` on iOS/Android store builds. Use it to gate dynamic-plugin creation flows.
+- **Pre-edit snapshots are best-effort (#8915).** `VIEWS create`/`edit` and `APP create`/edit take a `git commit --no-verify --allow-empty` snapshot of the target workdir before dispatching the coding agent and record the SHA on a `views-snapshot`-tagged Task keyed by room/plugin. A failed snapshot (workdir not in a git work tree, no committer identity, …) only disables rollback for that edit — it must never abort the dispatch. `VIEWS rollback` resolves the most-recent snapshot for the room (or an explicit `sha`/`view`), runs `git reset --hard`, then re-registers via `load-from-directory`. On verification failure after max retries, `VerificationRoomBridgeService` surfaces a chat offer naming `VIEWS action=rollback` for plugins so the user is never left with a broken create/edit. Shell out via the injectable `GitRunner` in `views-snapshot.ts` (so tests stay deterministic); do not reach into `CodingWorkspaceService`, which is keyed by managed-workspace IDs, not local repo workdirs.

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -13,7 +13,7 @@ This plugin registers three actions, two evaluators, one provider, and four serv
 | Name | File | Description |
 |---|---|---|
 | `APP` | `src/actions/app.ts` | Unified app control. Sub-modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`. `create` runs a multi-turn scaffold+coding-agent flow. Owner-gated. |
-| `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `delete`/`remove`. Create/edit/delete are owner-gated; read modes are open. |
+| `VIEWS` | `src/actions/views.ts` | Manage UI views contributed by plugins. Sub-modes: `list`, `current`, `show`/`open`, `search`, `manager`, `broadcast`, `interact`, `pin`, `window`, `create`, `edit`, `icon`, `rollback`, `delete`/`remove`. Create/edit/icon/rollback/delete are owner-gated; read modes are open. `rollback` resets a created/edited view-or-plugin workdir to the pre-edit git snapshot taken before the coding agent ran (#8915) and re-registers it via `load-from-directory`. |
 | `HOMESCREEN` | `src/actions/homescreen.ts` | Customize the live homescreen canvas. Sub-modes: `edit`, `create` (model-generated scene document), `undo`, `redo`, `reset`, `duplicate`, `delete`, `save`. Broadcasts via `POST /api/views/events/broadcast`. |
 
 ### Evaluators
@@ -75,7 +75,11 @@ src/
     views-show.ts                 show/open sub-handler
     views-search.ts               search sub-handler
     views-create.ts               create sub-handler (multi-turn)
-    views-edit.ts                 edit sub-handler
+    views-edit.ts                 edit sub-handler (takes a pre-edit git snapshot)
+    views-icon.ts                 icon sub-handler (direct hero-asset regeneration)
+    views-rollback.ts             rollback sub-handler: git reset --hard <snapshot> + re-register (#8915)
+    views-snapshot.ts             pre-edit git snapshot + rollback helpers; snapshot-record persistence
+    views-plugin-source.ts        resolve a view's on-disk plugin source dir
     views-delete.ts               delete sub-handler + confirmation flow
   components/
     ViewManagerSpatialView.tsx    Spatial/XR variant of the view manager component
@@ -168,3 +172,4 @@ Follow the same pattern in `src/actions/views.ts` and create a `src/actions/view
 - **`puppeteer-core` is an optional peer dep.** `AppVerificationService` only loads it when a browser step is requested and the dep is present. Set `ELIZA_BROWSER_VERIFY_OPTIONAL=1` if you want failures there to be non-blocking.
 - **`AppWorkerHostService` auto-starts persisted worker apps best-effort.** On service start it asks `AppRegistryService` for persisted entries and spawns apps whose resolved isolation is `"worker"`. Spawn failures are reported without preventing the registry entry from remaining inspectable.
 - **Restricted platforms.** `isRestrictedPlatform()` in `src/actions/views.ts` returns `true` on iOS/Android store builds. Use it to gate dynamic-plugin creation flows.
+- **Pre-edit snapshots are best-effort (#8915).** `VIEWS create`/`edit` and `APP create`/edit take a `git commit --no-verify --allow-empty` snapshot of the target workdir before dispatching the coding agent and record the SHA on a `views-snapshot`-tagged Task keyed by room/plugin. A failed snapshot (workdir not in a git work tree, no committer identity, …) only disables rollback for that edit — it must never abort the dispatch. `VIEWS rollback` resolves the most-recent snapshot for the room (or an explicit `sha`/`view`), runs `git reset --hard`, then re-registers via `load-from-directory`. On verification failure after max retries, `VerificationRoomBridgeService` surfaces a chat offer naming `VIEWS action=rollback` for plugins so the user is never left with a broken create/edit. Shell out via the injectable `GitRunner` in `views-snapshot.ts` (so tests stay deterministic); do not reach into `CodingWorkspaceService`, which is keyed by managed-workspace IDs, not local repo workdirs.

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -34,6 +34,10 @@ import {
 } from "../client/api.js";
 import { readStringOption } from "../params.js";
 import type { InstalledAppInfo } from "../types.js";
+import {
+	createPreEditSnapshot,
+	persistSnapshotRecord,
+} from "./views-snapshot.js";
 
 export const APP_CREATE_INTENT_TAG = "app-create-intent";
 
@@ -351,6 +355,42 @@ function readTaskAgents(result: ActionResult | undefined): TaskAgentStatus[] {
 	});
 }
 
+/**
+ * Take a pre-edit git snapshot of an app workdir and persist its SHA so the
+ * VIEWS `rollback` sub-mode can later restore it (#8915). Best-effort: snapshot
+ * failures only disable rollback and never abort the create/edit dispatch.
+ */
+async function snapshotAppWorkdir(
+	runtime: IAgentRuntime,
+	workdir: string,
+	appName: string,
+	created: boolean,
+	roomId: string,
+): Promise<void> {
+	const snapshot = await createPreEditSnapshot(workdir).catch((err) => ({
+		ok: false as const,
+		reason: err instanceof Error ? err.message : String(err),
+	}));
+	if (!snapshot.ok) {
+		logger.warn(
+			`[plugin-app-control] APP/create pre-edit snapshot skipped for ${appName}: ${snapshot.reason}`,
+		);
+		return;
+	}
+	await persistSnapshotRecord(runtime, {
+		sha: snapshot.sha,
+		workdir,
+		pluginName: appName,
+		created,
+		roomId,
+		snapshotCreatedAt: new Date().toISOString(),
+	}).catch((err) => {
+		logger.warn(
+			`[plugin-app-control] APP/create failed to persist snapshot record for ${appName}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	});
+}
+
 async function dispatchCodingAgent({
 	runtime,
 	prompt,
@@ -653,6 +693,11 @@ async function createNewApp({
 		[DISPLAY_NAME_PLACEHOLDER]: displayName,
 	});
 
+	// Pre-edit snapshot so the creation can be rolled back via VIEWS rollback
+	// (#8915). Best-effort: a failed snapshot only disables rollback, never blocks
+	// the create dispatch.
+	await snapshotAppWorkdir(runtime, workdir, name, true, originRoomId);
+
 	const prompt = buildCreatePrompt(intent, name, displayName, workdir);
 	const dispatch = await dispatchCodingAgent({
 		runtime,
@@ -725,6 +770,9 @@ async function editExistingApp({
 		await callback?.({ text });
 		return { success: false, text };
 	}
+
+	// Pre-edit snapshot so the edit can be rolled back via VIEWS rollback (#8915).
+	await snapshotAppWorkdir(runtime, workdir, app.name, false, originRoomId);
 
 	const prompt = buildEditPrompt(intent, app, workdir);
 	const dispatch = await dispatchCodingAgent({

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -28,6 +28,10 @@ import type { ViewSummary } from "./views-client.js";
 import { writeViewHeroAsset } from "./views-hero.js";
 import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
+import {
+	createPreEditSnapshot,
+	persistSnapshotRecord,
+} from "./views-snapshot.js";
 
 export const VIEWS_CREATE_INTENT_TAG = "views-create-intent";
 
@@ -611,6 +615,51 @@ export function isChoiceReply(text: string): boolean {
 	return CHOICE_RE.test(text.trim());
 }
 
+/**
+ * Take a pre-edit git snapshot of `workdir` and persist its SHA so the VIEWS
+ * `rollback` sub-mode can later restore the source if the edit goes wrong
+ * (#8915). Best-effort: a failed snapshot (e.g. workdir not in a git work tree)
+ * only disables rollback for this edit — it must never abort the create/edit
+ * dispatch itself.
+ */
+async function snapshotBeforeDispatch({
+	runtime,
+	workdir,
+	pluginName,
+	created,
+	roomId,
+}: {
+	runtime: IAgentRuntime;
+	workdir: string;
+	pluginName: string;
+	created: boolean;
+	roomId: string;
+}): Promise<string | undefined> {
+	const snapshot = await createPreEditSnapshot(workdir).catch((err) => ({
+		ok: false as const,
+		reason: err instanceof Error ? err.message : String(err),
+	}));
+	if (!snapshot.ok) {
+		logger.warn(
+			`[plugin-app-control] VIEWS/create pre-edit snapshot skipped for ${pluginName}: ${snapshot.reason}`,
+		);
+		return undefined;
+	}
+	await persistSnapshotRecord(runtime, {
+		sha: snapshot.sha,
+		workdir,
+		pluginName,
+		created,
+		roomId,
+		snapshotCreatedAt: new Date().toISOString(),
+	}).catch((err) => {
+		logger.warn(
+			`[plugin-app-control] VIEWS/create failed to persist snapshot record for ${pluginName}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	});
+	return snapshot.sha;
+}
+
 // ---------------------------------------------------------------------------
 // Create / edit helpers
 // ---------------------------------------------------------------------------
@@ -665,6 +714,16 @@ async function createNewViewPlugin({
 		);
 	}
 
+	// Take a pre-edit snapshot of the freshly-scaffolded workdir before the coding
+	// agent runs so the user can roll the whole creation back (#8915).
+	const snapshotSha = await snapshotBeforeDispatch({
+		runtime,
+		workdir,
+		pluginName: name,
+		created: true,
+		roomId: originRoomId,
+	});
+
 	const prompt = buildCreatePrompt(intent, name, displayName, workdir);
 	const dispatch = await dispatchCodingAgent({
 		runtime,
@@ -705,6 +764,7 @@ async function createNewViewPlugin({
 			workdir,
 			taskStatus: task.status,
 			taskSessionId: task.sessionId,
+			...(snapshotSha ? { snapshotSha } : {}),
 		},
 		data: {
 			name,
@@ -712,6 +772,7 @@ async function createNewViewPlugin({
 			workdir,
 			task,
 			agents: dispatch.agents,
+			...(snapshotSha ? { snapshotSha } : {}),
 			suppressActionResultClipboard: true,
 		},
 	};
@@ -738,6 +799,16 @@ async function editExistingViewPlugin({
 		await callback?.({ text });
 		return { success: false, text };
 	}
+
+	// Take a pre-edit snapshot of the existing plugin source before the coding
+	// agent mutates it so the user can undo the edit (#8915).
+	const snapshotSha = await snapshotBeforeDispatch({
+		runtime,
+		workdir,
+		pluginName: view.pluginName,
+		created: false,
+		roomId: originRoomId,
+	});
 
 	const prompt = buildEditPrompt(intent, view, workdir);
 	const dispatch = await dispatchCodingAgent({
@@ -777,12 +848,14 @@ async function editExistingViewPlugin({
 			workdir,
 			taskStatus: task.status,
 			taskSessionId: task.sessionId,
+			...(snapshotSha ? { snapshotSha } : {}),
 		},
 		data: {
 			view,
 			workdir,
 			task,
 			agents: dispatch.agents,
+			...(snapshotSha ? { snapshotSha } : {}),
 			suppressActionResultClipboard: true,
 		},
 	};

--- a/plugins/plugin-app-control/src/actions/views-edit.ts
+++ b/plugins/plugin-app-control/src/actions/views-edit.ts
@@ -25,6 +25,10 @@ import type { ViewSummary } from "./views-client.js";
 import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
 import { scoreView } from "./views-search.js";
+import {
+	createPreEditSnapshot,
+	persistSnapshotRecord,
+} from "./views-snapshot.js";
 
 export interface ViewsEditInput {
 	runtime: IAgentRuntime;
@@ -348,6 +352,32 @@ export async function runViewsEdit({
 
 	const roomId =
 		typeof message.roomId === "string" ? message.roomId : runtime.agentId;
+
+	// Pre-edit snapshot so the edit can be rolled back (#8915). Best-effort: a
+	// failed snapshot only disables rollback for this edit, never blocks it.
+	const snapshot = await createPreEditSnapshot(workdir).catch((err) => ({
+		ok: false as const,
+		reason: err instanceof Error ? err.message : String(err),
+	}));
+	if (snapshot.ok) {
+		await persistSnapshotRecord(runtime, {
+			sha: snapshot.sha,
+			workdir,
+			pluginName: view.pluginName,
+			created: false,
+			roomId,
+			snapshotCreatedAt: new Date().toISOString(),
+		}).catch((err) => {
+			logger.warn(
+				`[plugin-app-control] VIEWS/edit failed to persist snapshot for ${view.pluginName}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		});
+	} else {
+		logger.warn(
+			`[plugin-app-control] VIEWS/edit pre-edit snapshot skipped for ${view.pluginName}: ${snapshot.reason}`,
+		);
+	}
+
 	return dispatchEditAgent({
 		runtime,
 		view,

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -1380,6 +1380,64 @@ describe("view management actions", () => {
 		expect(ownerCheck).toHaveBeenCalledTimes(3);
 	});
 
+	it("owner-gates the rollback sub-mode like other mutating modes (#8915)", async () => {
+		const { runtime } = createRuntime();
+		const ownerCheck = vi.fn(async () => false);
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [view()]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: ownerCheck,
+		});
+
+		// Explicit action=rollback is owner-gated.
+		await expect(
+			action.validate?.(
+				runtime as never,
+				message("rollback") as never,
+				undefined,
+				{ action: "rollback" },
+			),
+		).resolves.toBe(false);
+		// Natural-language rollback phrasing is owner-gated too.
+		await expect(
+			action.validate?.(
+				runtime as never,
+				message("roll back the remote ledger plugin") as never,
+			),
+		).resolves.toBe(false);
+		expect(ownerCheck).toHaveBeenCalledTimes(2);
+	});
+
+	it("routes action=rollback to the rollback handler and reports no snapshot when none recorded (#8915)", async () => {
+		// No snapshot tasks recorded -> rollback short-circuits before any git/fetch,
+		// proving the dispatcher wired the rollback sub-mode in.
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [view()]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		const result = await action.handler(
+			runtime as never,
+			message("rollback the remote ledger plugin") as never,
+			undefined,
+			{ action: "rollback" },
+			callback,
+		);
+
+		expect(result?.success).toBe(false);
+		expect(result?.text?.toLowerCase()).toContain("no pre-edit snapshot");
+		// rollback never touched git/fetch when there's nothing to roll back.
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+		expect(runtime.getTasks).toHaveBeenCalled();
+	});
+
 	it("includes explicit TUI view type and always-on-top false in window navigation payloads", async () => {
 		const { runtime } = createRuntime();
 		const callback = vi.fn();

--- a/plugins/plugin-app-control/src/actions/views-rollback.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-rollback.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Tests for the VIEWS `rollback` sub-mode + git snapshot helpers (#8915).
+ *
+ * Deterministic: the git runner and the loopback re-registration call are both
+ * injected/stubbed, so no real `git` process runs and no network is touched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreMock = vi.hoisted(() => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+	resolveServerOnlyPort: vi.fn(() => 3456),
+	hasOwnerAccess: vi.fn(async () => true),
+	formatError: (error: unknown): string =>
+		error instanceof Error ? error.message : String(error),
+}));
+
+vi.mock("@elizaos/core", () => coreMock);
+
+import { isRollbackRequest, runViewsRollback } from "./views-rollback.js";
+import {
+	createPreEditSnapshot,
+	findSnapshotRecord,
+	type GitRunner,
+	isLikelySha,
+	persistSnapshotRecord,
+	rollbackToSnapshot,
+	VIEWS_SNAPSHOT_TAG,
+} from "./views-snapshot.js";
+
+type GitCall = { args: string[]; cwd: string };
+
+/**
+ * Build a deterministic git runner whose behavior is keyed by the first arg.
+ * Records every call so assertions can prove which commands ran.
+ */
+function fakeGit(
+	responses: Record<
+		string,
+		{ stdout?: string; stderr?: string; exitCode?: number }
+	>,
+): { git: GitRunner; calls: GitCall[] } {
+	const calls: GitCall[] = [];
+	const git: GitRunner = async (args, cwd) => {
+		calls.push({ args: [...args], cwd });
+		const sub = args[0] === "rev-parse" ? `rev-parse:${args[1]}` : args[0];
+		const r = responses[sub] ?? responses[args[0]] ?? {};
+		return {
+			stdout: r.stdout ?? "",
+			stderr: r.stderr ?? "",
+			exitCode: r.exitCode ?? 0,
+		};
+	};
+	return { git, calls };
+}
+
+function message(text: string, roomId = "room-1") {
+	return {
+		entityId: "user-1",
+		roomId,
+		agentId: "agent-1",
+		content: { text },
+	} as never;
+}
+
+type RuntimeTask = { id: string; metadata?: Record<string, unknown> };
+
+function createRuntime(tasks: RuntimeTask[] = []) {
+	return {
+		agentId: "agent-1",
+		getTasks: vi.fn(async () => tasks),
+		createTask: vi.fn(async (task: { metadata?: Record<string, unknown> }) => {
+			tasks.push({ id: `task-${tasks.length + 1}`, metadata: task.metadata });
+		}),
+		deleteTask: vi.fn(async (taskId: string) => {
+			const idx = tasks.findIndex((t) => t.id === taskId);
+			if (idx >= 0) tasks.splice(idx, 1);
+		}),
+	};
+}
+
+beforeEach(() => {
+	coreMock.logger.info.mockClear();
+	coreMock.logger.warn.mockClear();
+	delete process.env.ELIZA_BUILD_VARIANT;
+	delete process.env.ELIZA_PLATFORM;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("isLikelySha", () => {
+	it("accepts short and full hex shas", () => {
+		expect(isLikelySha("a1b2c3d")).toBe(true);
+		expect(isLikelySha("0123456789abcdef0123456789abcdef01234567")).toBe(true);
+	});
+	it("rejects non-shas", () => {
+		expect(isLikelySha("not-a-sha")).toBe(false);
+		expect(isLikelySha("")).toBe(false);
+		expect(isLikelySha("zzz")).toBe(false);
+	});
+});
+
+describe("createPreEditSnapshot", () => {
+	it("commits a non-destructive snapshot and returns the HEAD sha", async () => {
+		const sha = "deadbeefcafef00d";
+		const { git, calls } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			add: {},
+			commit: {},
+			"rev-parse:HEAD": { stdout: `${sha}\n` },
+		});
+
+		const result = await createPreEditSnapshot("/work/dir", { git });
+		expect(result).toEqual({ ok: true, sha });
+
+		// The snapshot must stage everything and commit with --no-verify (skip
+		// hooks) + --allow-empty (no diff still produces a snapshot point).
+		const addCall = calls.find((c) => c.args[0] === "add");
+		expect(addCall?.args).toEqual(["add", "-A"]);
+		const commitCall = calls.find((c) => c.args[0] === "commit");
+		expect(commitCall?.args).toContain("--no-verify");
+		expect(commitCall?.args).toContain("--allow-empty");
+		// Crucially it never resets/discards the working tree.
+		expect(calls.some((c) => c.args[0] === "reset")).toBe(false);
+	});
+
+	it("fails gracefully when the workdir is not a git work tree", async () => {
+		const { git } = fakeGit({
+			"rev-parse:--is-inside-work-tree": {
+				exitCode: 128,
+				stderr: "not a git repository",
+			},
+		});
+		const result = await createPreEditSnapshot("/work/dir", { git });
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("rollbackToSnapshot", () => {
+	it("runs git reset --hard <sha> in the workdir", async () => {
+		const sha = "abc1234";
+		const { git, calls } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			reset: {},
+		});
+		const result = await rollbackToSnapshot("/work/dir", sha, { git });
+		expect(result).toEqual({ ok: true, sha });
+		const resetCall = calls.find((c) => c.args[0] === "reset");
+		expect(resetCall?.args).toEqual(["reset", "--hard", sha]);
+		expect(resetCall?.cwd).toBe("/work/dir");
+	});
+
+	it("refuses an invalid sha without touching git", async () => {
+		const { git, calls } = fakeGit({});
+		const result = await rollbackToSnapshot("/work/dir", "garbage", { git });
+		expect(result.ok).toBe(false);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("surfaces a git reset failure", async () => {
+		const { git } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			reset: { exitCode: 1, stderr: "unknown revision" },
+		});
+		const result = await rollbackToSnapshot("/work/dir", "abc1234", { git });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("git reset --hard failed");
+	});
+});
+
+describe("snapshot record persistence", () => {
+	it("persists and resolves the most-recent snapshot record for a room", async () => {
+		const tasks: RuntimeTask[] = [];
+		const runtime = createRuntime(tasks);
+
+		await persistSnapshotRecord(runtime as never, {
+			sha: "1111111",
+			workdir: "/repo/plugins/plugin-old",
+			pluginName: "@elizaos/plugin-old",
+			created: false,
+			roomId: "room-1",
+			snapshotCreatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		await persistSnapshotRecord(runtime as never, {
+			sha: "2222222",
+			workdir: "/repo/plugins/plugin-new",
+			pluginName: "@elizaos/plugin-new",
+			created: true,
+			roomId: "room-1",
+			snapshotCreatedAt: "2026-02-01T00:00:00.000Z",
+		});
+
+		expect(runtime.createTask).toHaveBeenCalledTimes(2);
+		expect(tasks[0].metadata).toMatchObject({ sha: "1111111" });
+
+		const latest = await findSnapshotRecord(runtime as never, "room-1");
+		expect(latest?.record.sha).toBe("2222222");
+
+		// Target filter narrows to a specific plugin even if it isn't the newest.
+		const targeted = await findSnapshotRecord(
+			runtime as never,
+			"room-1",
+			"plugin-old",
+		);
+		expect(targeted?.record.sha).toBe("1111111");
+	});
+
+	it("does not leak snapshots across rooms", async () => {
+		const tasks: RuntimeTask[] = [];
+		const runtime = createRuntime(tasks);
+		await persistSnapshotRecord(runtime as never, {
+			sha: "3333333",
+			workdir: "/repo/plugins/plugin-x",
+			pluginName: "@elizaos/plugin-x",
+			created: true,
+			roomId: "room-other",
+			snapshotCreatedAt: "2026-03-01T00:00:00.000Z",
+		});
+		expect(await findSnapshotRecord(runtime as never, "room-1")).toBeNull();
+	});
+
+	it("tags records with the snapshot tag", async () => {
+		const tasks: RuntimeTask[] = [];
+		const runtime = createRuntime(tasks);
+		await persistSnapshotRecord(runtime as never, {
+			sha: "4444444",
+			workdir: "/repo/plugins/plugin-y",
+			pluginName: "@elizaos/plugin-y",
+			created: true,
+			roomId: "room-1",
+			snapshotCreatedAt: "2026-04-01T00:00:00.000Z",
+		});
+		const created = runtime.createTask.mock.calls[0][0] as {
+			tags?: string[];
+		};
+		expect(created.tags).toContain(VIEWS_SNAPSHOT_TAG);
+	});
+});
+
+describe("isRollbackRequest", () => {
+	it("matches natural-language rollback phrasings", () => {
+		expect(isRollbackRequest("roll back the wallet view")).toBe(true);
+		expect(isRollbackRequest("undo the plugin creation")).toBe(true);
+		expect(isRollbackRequest("revert the last edit to the plugin")).toBe(true);
+		expect(isRollbackRequest("undo that view edit")).toBe(true);
+	});
+
+	it("matches a bare 'rollback' / 'revert' reply to a failure offer", () => {
+		expect(isRollbackRequest("rollback")).toBe(true);
+		expect(isRollbackRequest("roll back")).toBe(true);
+		expect(isRollbackRequest("revert")).toBe(true);
+	});
+
+	it("does not hijack generic navigation/undo", () => {
+		expect(isRollbackRequest("go back to the home screen")).toBe(false);
+		expect(isRollbackRequest("show me the wallet view")).toBe(false);
+		// bare 'undo' belongs to HOMESCREEN, not the plugin rollback offer.
+		expect(isRollbackRequest("undo")).toBe(false);
+	});
+});
+
+describe("runViewsRollback", () => {
+	it("resets to the recorded snapshot and re-registers the plugin", async () => {
+		const sha = "feedface";
+		const tasks: RuntimeTask[] = [
+			{
+				id: "snap-1",
+				metadata: {
+					sha,
+					workdir: "/repo/plugins/plugin-habits",
+					pluginName: "@elizaos/plugin-habits",
+					created: true,
+					roomId: "room-1",
+					snapshotCreatedAt: "2026-05-01T00:00:00.000Z",
+				},
+			},
+		];
+		const runtime = createRuntime(tasks);
+		const { git, calls } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			reset: {},
+		});
+		const reregister = vi.fn(async () => ({
+			ok: true,
+			pluginName: "@elizaos/plugin-habits",
+		}));
+		const callback = vi.fn(async () => []);
+
+		const result = await runViewsRollback({
+			runtime: runtime as never,
+			message: message("rollback"),
+			options: { action: "rollback" },
+			callback,
+			git,
+			reregister,
+		});
+
+		expect(result.success).toBe(true);
+		// reset --hard <sha> ran in the recorded workdir.
+		const resetCall = calls.find((c) => c.args[0] === "reset");
+		expect(resetCall?.args).toEqual(["reset", "--hard", sha]);
+		expect(resetCall?.cwd).toBe("/repo/plugins/plugin-habits");
+		// re-registration was triggered with the same workdir.
+		expect(reregister).toHaveBeenCalledWith("/repo/plugins/plugin-habits");
+		// the consumed snapshot record was deleted.
+		expect(runtime.deleteTask).toHaveBeenCalledWith("snap-1");
+		// success surfaced to the user.
+		const said = callback.mock.calls.map(
+			(c) => (c[0] as { text: string }).text,
+		);
+		expect(said.join("\n")).toMatch(/rolled .*back/i);
+	});
+
+	it("reports honestly when no snapshot is on record", async () => {
+		const runtime = createRuntime([]);
+		const { git } = fakeGit({});
+		const callback = vi.fn(async () => []);
+		const result = await runViewsRollback({
+			runtime: runtime as never,
+			message: message("rollback"),
+			options: { action: "rollback" },
+			callback,
+			git,
+			reregister: vi.fn(),
+		});
+		expect(result.success).toBe(false);
+		expect((result.text ?? "").toLowerCase()).toContain("no pre-edit snapshot");
+	});
+
+	it("honors an explicit sha + workdir over the recorded snapshot", async () => {
+		const runtime = createRuntime([]);
+		const { git, calls } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			reset: {},
+		});
+		const reregister = vi.fn(async () => ({ ok: true }));
+		const result = await runViewsRollback({
+			runtime: runtime as never,
+			message: message("rollback"),
+			options: { action: "rollback", sha: "cafe123", workdir: "/explicit/dir" },
+			callback: vi.fn(async () => []),
+			git,
+			reregister,
+		});
+		expect(result.success).toBe(true);
+		const resetCall = calls.find((c) => c.args[0] === "reset");
+		expect(resetCall?.args).toEqual(["reset", "--hard", "cafe123"]);
+		expect(reregister).toHaveBeenCalledWith("/explicit/dir");
+	});
+
+	it("still reports success-with-warning when re-registration fails", async () => {
+		const tasks: RuntimeTask[] = [
+			{
+				id: "snap-2",
+				metadata: {
+					sha: "abcdef0",
+					workdir: "/repo/plugins/plugin-z",
+					pluginName: "@elizaos/plugin-z",
+					created: true,
+					roomId: "room-1",
+					snapshotCreatedAt: "2026-05-02T00:00:00.000Z",
+				},
+			},
+		];
+		const runtime = createRuntime(tasks);
+		const { git } = fakeGit({
+			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
+			reset: {},
+		});
+		const reregister = vi.fn(async () => ({
+			ok: false,
+			error: "load failed",
+		}));
+		const callback = vi.fn(async () => []);
+		const result = await runViewsRollback({
+			runtime: runtime as never,
+			message: message("rollback"),
+			options: { action: "rollback" },
+			callback,
+			git,
+			reregister,
+		});
+		// Source was restored even though live-reload failed → still a success,
+		// with a message telling the user to reload the agent.
+		expect(result.success).toBe(true);
+		const said = callback.mock.calls.map(
+			(c) => (c[0] as { text: string }).text,
+		);
+		expect(said.join("\n")).toMatch(/reload the agent/i);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views-rollback.ts
+++ b/plugins/plugin-app-control/src/actions/views-rollback.ts
@@ -1,0 +1,233 @@
+/**
+ * @module plugin-app-control/actions/views-rollback
+ *
+ * rollback sub-mode of the VIEWS action (#8915).
+ *
+ * Undoes a view/plugin create or edit by resetting its workdir back to the
+ * pre-edit snapshot recorded before the coding agent ran, then re-registering
+ * the plugin through the same `load-from-directory` path create uses so the
+ * running runtime reflects the restored source.
+ *
+ * Snapshot SHA resolution order:
+ *  1. explicit `sha` option,
+ *  2. the most-recent persisted snapshot record for this room (optionally
+ *     narrowed by a `view`/`target` string matching the plugin name/workdir).
+ *
+ * Owner-gated by the VIEWS action like create/edit/delete.
+ *
+ * FOLLOW-UP (#8915): a full live scenario — dispatch a real failing edit via a
+ * live model/sub-agent spawn, accept the rollback offer, and assert the source
+ * on disk is restored end-to-end — is tracked separately; it needs a live model
+ * and is not faked here. The git snapshot/rollback helpers, the sub-mode wiring,
+ * and the failure-offer text are fully covered by deterministic unit tests
+ * (views-rollback.test.ts, views-management.test.ts, verification-room-bridge.test.ts).
+ */
+
+import type {
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+} from "@elizaos/core";
+import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import { readStringOption } from "../params.js";
+import { isRestrictedPlatform } from "./views-platform.js";
+import {
+	deleteSnapshotRecord,
+	findSnapshotRecord,
+	type GitRunner,
+	isLikelySha,
+	rollbackToSnapshot,
+} from "./views-snapshot.js";
+
+/** Re-register a plugin workdir into the running runtime over loopback HTTP. */
+export type ReregisterFn = (
+	workdir: string,
+) => Promise<{ ok: boolean; pluginName?: string; error?: string }>;
+
+export interface ViewsRollbackInput {
+	runtime: IAgentRuntime;
+	message: Memory;
+	options?: Record<string, unknown>;
+	callback?: HandlerCallback;
+	/** Injectable git runner (tests). */
+	git?: GitRunner;
+	/** Injectable re-registration path (tests). */
+	reregister?: ReregisterFn;
+}
+
+/**
+ * Re-register the rolled-back plugin source via the same loopback endpoint the
+ * verification bridge / create flow use to load a freshly-built plugin.
+ */
+async function reregisterPluginFromWorkdir(
+	workdir: string,
+): Promise<{ ok: boolean; pluginName?: string; error?: string }> {
+	const port = resolveServerOnlyPort(process.env);
+	try {
+		const resp = await fetch(
+			`http://127.0.0.1:${port}/api/plugins/load-from-directory`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ directory: workdir }),
+				signal: AbortSignal.timeout(30_000),
+			},
+		);
+		const body = (await resp.json().catch(() => ({}))) as Record<
+			string,
+			unknown
+		>;
+		if (resp.ok && body.ok === true) {
+			return {
+				ok: true,
+				pluginName:
+					typeof body.pluginName === "string" ? body.pluginName : undefined,
+			};
+		}
+		return {
+			ok: false,
+			error:
+				typeof body.error === "string"
+					? body.error
+					: `load returned HTTP ${resp.status}`,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
+// "undo that creation", "roll back the wallet view", "revert the last edit",
+// "restore the plugin" — all map to the rollback sub-mode. Kept narrow so a
+// generic "go back" (a navigation request) does not hijack a rollback.
+const ROLLBACK_RE =
+	/\b(roll ?back|revert|undo)\b.{0,40}\b(view|views|plugin|plugins|edit|edits|change|changes|creation|create|app)\b|\b(view|views|plugin|plugins|edit|edits|change|changes|creation|app)\b.{0,40}\b(roll ?back|revert|undo)\b/i;
+
+// A bare one-word reply to the verification-failure rollback offer
+// ("rollback" / "roll back" / "revert"). Matches only when the entire trimmed
+// message is that verb so it can't hijack unrelated turns.
+const BARE_ROLLBACK_RE = /^(roll ?back|revert)$/i;
+
+/**
+ * True when the request asks to roll back / undo a view-or-plugin create/edit.
+ * Explicit `action=rollback` is handled by the dispatcher's mode inference; this
+ * covers natural-language phrasings and the bare 'rollback' reply to a failed
+ * verification offer.
+ */
+export function isRollbackRequest(text: string): boolean {
+	const trimmed = text.trim();
+	return BARE_ROLLBACK_RE.test(trimmed) || ROLLBACK_RE.test(trimmed);
+}
+
+function readRollbackTarget(
+	options: Record<string, unknown> | undefined,
+): string | undefined {
+	return (
+		readStringOption(options, "view") ??
+		readStringOption(options, "viewId") ??
+		readStringOption(options, "id") ??
+		readStringOption(options, "name") ??
+		readStringOption(options, "target") ??
+		readStringOption(options, "pluginName") ??
+		undefined
+	);
+}
+
+export async function runViewsRollback({
+	runtime,
+	message,
+	options,
+	callback,
+	git,
+	reregister = reregisterPluginFromWorkdir,
+}: ViewsRollbackInput): Promise<ActionResult> {
+	if (isRestrictedPlatform()) {
+		const text =
+			"Rolling back view/plugin changes is not available on this platform.";
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const roomId =
+		typeof message.roomId === "string" ? message.roomId : runtime.agentId;
+	const target = readRollbackTarget(options);
+	const explicitSha = readStringOption(options, "sha");
+	const explicitWorkdir = readStringOption(options, "workdir");
+
+	const snapshot = await findSnapshotRecord(runtime, roomId, target);
+
+	// Resolve the SHA + workdir from the explicit options first, falling back to
+	// the persisted snapshot record.
+	const sha = explicitSha ?? snapshot?.record.sha;
+	const workdir = explicitWorkdir ?? snapshot?.record.workdir;
+	const pluginName = snapshot?.record.pluginName ?? target ?? "the plugin";
+
+	if (!sha || !workdir) {
+		const text =
+			"No pre-edit snapshot is on record to roll back to. Snapshots are taken automatically when you create or edit a view/plugin; nothing to undo here.";
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	if (!isLikelySha(sha)) {
+		const text = `"${sha}" is not a valid snapshot id; cannot roll back.`;
+		await callback?.({ text });
+		return { success: false, text };
+	}
+
+	const rollback = await rollbackToSnapshot(workdir, sha, { git });
+	if (!rollback.ok) {
+		const text = `Could not roll back ${pluginName} at ${workdir}: ${rollback.reason}.`;
+		await callback?.({ text });
+		logger.warn(
+			`[plugin-app-control] VIEWS/rollback failed: ${rollback.reason}`,
+		);
+		return {
+			success: false,
+			text,
+			values: { mode: "rollback", sha, workdir },
+			data: { suppressActionResultClipboard: true },
+		};
+	}
+
+	// Re-register the restored source via the same path create uses so the
+	// running runtime reflects the rollback (views/actions deregister/re-register
+	// through the plugin lifecycle hook).
+	const reload = await reregister(workdir);
+
+	// Consume the snapshot record so a second "rollback" doesn't reuse a stale SHA.
+	if (snapshot) {
+		await deleteSnapshotRecord(runtime, snapshot.taskId);
+	}
+
+	const restored = reload.pluginName ?? pluginName;
+	const text = reload.ok
+		? `Rolled ${restored} back to the pre-edit snapshot (${sha.slice(0, 7)}) and reloaded it live.`
+		: `Rolled ${restored} back to the pre-edit snapshot (${sha.slice(0, 7)}) at ${workdir}, but live-reload failed: ${reload.error}. Reload the agent to pick up the restored source.`;
+	await callback?.({ text });
+	logger.info(
+		`[plugin-app-control] VIEWS/rollback restored ${restored} to ${sha} reloaded=${reload.ok}`,
+	);
+
+	return {
+		success: true,
+		text,
+		values: {
+			mode: "rollback",
+			sha,
+			workdir,
+			pluginName: restored,
+			reloaded: reload.ok,
+		},
+		data: {
+			sha,
+			workdir,
+			pluginName: restored,
+			reloaded: reload.ok,
+			suppressActionResultClipboard: true,
+		},
+	};
+}

--- a/plugins/plugin-app-control/src/actions/views-snapshot.ts
+++ b/plugins/plugin-app-control/src/actions/views-snapshot.ts
@@ -1,0 +1,313 @@
+/**
+ * @module plugin-app-control/actions/views-snapshot
+ *
+ * Git snapshot + rollback helpers for the view/plugin create & edit flow.
+ *
+ * Before a coding agent edits a view/plugin workdir we take a pre-edit
+ * snapshot: a non-destructive `git commit --no-verify --allow-empty` that
+ * captures the working tree exactly as it was. The resulting SHA is recorded
+ * on a Task so the `rollback` sub-mode can later run `git reset --hard <sha>`
+ * to restore the source if the edit goes wrong (the user's "undo creation"
+ * ask, #8915).
+ *
+ * We shell out to `git` directly against the target `workdir` (mirroring
+ * `plugin-agent-orchestrator/services/workspace-git-ops.ts`) rather than going
+ * through CodingWorkspaceService: that service is keyed by managed-workspace
+ * IDs (clones), whereas the view/plugin flow operates on a `workdir` inside the
+ * local repo checkout. The git runner is injectable so unit tests stay
+ * deterministic without touching a real repository.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+
+const execFileAsync = promisify(execFile);
+
+/** Tag used to persist the pre-edit snapshot SHA for a workdir. */
+export const VIEWS_SNAPSHOT_TAG = "views-snapshot";
+
+/** The canonical pre-edit snapshot commit message. */
+export const PRE_EDIT_SNAPSHOT_MESSAGE = "pre-edit snapshot";
+
+const GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Runs a single git subcommand inside `cwd`. Injectable so tests can supply a
+ * deterministic stub instead of spawning a real `git` process.
+ */
+export type GitRunner = (
+	args: readonly string[],
+	cwd: string,
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+const defaultGitRunner: GitRunner = async (args, cwd) => {
+	try {
+		const { stdout, stderr } = await execFileAsync("git", [...args], {
+			cwd,
+			timeout: GIT_TIMEOUT_MS,
+			maxBuffer: 8 * 1024 * 1024,
+			encoding: "utf8",
+			env: { ...process.env },
+		});
+		return { stdout, stderr, exitCode: 0 };
+	} catch (err) {
+		const e = err as NodeJS.ErrnoException & {
+			stdout?: string | Buffer;
+			stderr?: string | Buffer;
+			code?: number | string;
+		};
+		const stdout =
+			typeof e.stdout === "string"
+				? e.stdout
+				: (e.stdout?.toString("utf8") ?? "");
+		const stderr =
+			typeof e.stderr === "string"
+				? e.stderr
+				: (e.stderr?.toString("utf8") ?? "");
+		const exitCode = typeof e.code === "number" ? e.code : 1;
+		return { stdout, stderr, exitCode };
+	}
+};
+
+export type SnapshotResult =
+	| { ok: true; sha: string }
+	| { ok: false; reason: string };
+
+export type RollbackResult =
+	| { ok: true; sha: string }
+	| { ok: false; reason: string };
+
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+
+/** Validate a value as a plausible git object SHA (short or full). */
+export function isLikelySha(value: string): boolean {
+	return SHA_RE.test(value.trim());
+}
+
+/**
+ * Take a pre-edit snapshot of `workdir`. Stages every change (`git add -A`) and
+ * writes a non-destructive commit (`--no-verify --allow-empty`) so the working
+ * tree is preserved verbatim and the returned SHA points at it. The commit is
+ * non-destructive: nothing in the working tree is reset or discarded.
+ *
+ * Returns the snapshot SHA on success. On any git failure (not a repo, no
+ * identity, etc.) returns `{ ok: false }` with the reason — callers treat a
+ * failed snapshot as best-effort and continue the edit without rollback.
+ */
+export async function createPreEditSnapshot(
+	workdir: string,
+	options: { git?: GitRunner; message?: string } = {},
+): Promise<SnapshotResult> {
+	const git = options.git ?? defaultGitRunner;
+	const message = options.message ?? PRE_EDIT_SNAPSHOT_MESSAGE;
+
+	const inside = await git(["rev-parse", "--is-inside-work-tree"], workdir);
+	if (inside.exitCode !== 0 || inside.stdout.trim() !== "true") {
+		return {
+			ok: false,
+			reason: `not a git work tree (${(inside.stderr || inside.stdout).trim() || "git rev-parse failed"})`,
+		};
+	}
+
+	const add = await git(["add", "-A"], workdir);
+	if (add.exitCode !== 0) {
+		return {
+			ok: false,
+			reason: `git add failed: ${(add.stderr || add.stdout).trim()}`,
+		};
+	}
+
+	const commit = await git(
+		["commit", "--no-verify", "--allow-empty", "-m", message],
+		workdir,
+	);
+	if (commit.exitCode !== 0) {
+		return {
+			ok: false,
+			reason: `git commit failed: ${(commit.stderr || commit.stdout).trim()}`,
+		};
+	}
+
+	const rev = await git(["rev-parse", "HEAD"], workdir);
+	const sha = rev.stdout.trim();
+	if (rev.exitCode !== 0 || !isLikelySha(sha)) {
+		return {
+			ok: false,
+			reason: `git rev-parse HEAD failed: ${(rev.stderr || rev.stdout).trim()}`,
+		};
+	}
+
+	logger.info(
+		`[plugin-app-control] snapshot created sha=${sha} workdir=${workdir}`,
+	);
+	return { ok: true, sha };
+}
+
+/**
+ * Restore `workdir` to the snapshot `sha` via `git reset --hard <sha>`. This
+ * discards every change made after the snapshot — exactly the "undo creation"
+ * semantics the rollback sub-mode promises.
+ */
+export async function rollbackToSnapshot(
+	workdir: string,
+	sha: string,
+	options: { git?: GitRunner } = {},
+): Promise<RollbackResult> {
+	const git = options.git ?? defaultGitRunner;
+	const trimmed = sha.trim();
+	if (!isLikelySha(trimmed)) {
+		return { ok: false, reason: `invalid snapshot sha "${sha}"` };
+	}
+
+	const inside = await git(["rev-parse", "--is-inside-work-tree"], workdir);
+	if (inside.exitCode !== 0 || inside.stdout.trim() !== "true") {
+		return {
+			ok: false,
+			reason: `not a git work tree (${(inside.stderr || inside.stdout).trim() || "git rev-parse failed"})`,
+		};
+	}
+
+	const reset = await git(["reset", "--hard", trimmed], workdir);
+	if (reset.exitCode !== 0) {
+		return {
+			ok: false,
+			reason: `git reset --hard failed: ${(reset.stderr || reset.stdout).trim()}`,
+		};
+	}
+
+	logger.info(
+		`[plugin-app-control] rolled back to sha=${trimmed} workdir=${workdir}`,
+	);
+	return { ok: true, sha: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot record persistence (Task-backed)
+// ---------------------------------------------------------------------------
+
+export interface ViewsSnapshotRecord {
+	/** Snapshot commit SHA recorded before the edit. */
+	sha: string;
+	/** Absolute workdir the snapshot was taken in. */
+	workdir: string;
+	/** Owning plugin name (used to resolve the snapshot on rollback). */
+	pluginName: string;
+	/** Whether the edit created a brand-new plugin (vs editing an existing one). */
+	created: boolean;
+	/** Room the originating request came from. */
+	roomId: string;
+	/** ISO-8601 timestamp; stored as a string so it round-trips through metadata. */
+	snapshotCreatedAt: string;
+}
+
+function readString(
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = record[key];
+	return typeof value === "string" && value.trim().length > 0
+		? value
+		: undefined;
+}
+
+/**
+ * Persist a snapshot record so the rollback sub-mode can resolve the SHA later.
+ * Keyed by `pluginName` + `workdir` in metadata; the most recent record for a
+ * room/plugin wins.
+ */
+export async function persistSnapshotRecord(
+	runtime: IAgentRuntime,
+	record: ViewsSnapshotRecord,
+): Promise<void> {
+	await runtime.createTask({
+		name: "VIEWS snapshot",
+		description: `Pre-edit snapshot ${record.sha} for ${record.pluginName}`,
+		tags: [VIEWS_SNAPSHOT_TAG],
+		metadata: {
+			sha: record.sha,
+			workdir: record.workdir,
+			pluginName: record.pluginName,
+			created: record.created,
+			roomId: record.roomId,
+			snapshotCreatedAt: record.snapshotCreatedAt,
+		},
+	});
+}
+
+/**
+ * Resolve the most-recent snapshot record for a room, optionally filtered by a
+ * target string that matches the plugin name or workdir. Returns `null` when no
+ * snapshot is on record.
+ */
+export async function findSnapshotRecord(
+	runtime: IAgentRuntime,
+	roomId: string,
+	target?: string,
+): Promise<{ taskId: string; record: ViewsSnapshotRecord } | null> {
+	const tasks = await runtime.getTasks({
+		agentIds: [runtime.agentId],
+		tags: [VIEWS_SNAPSHOT_TAG],
+	});
+
+	const normalizedTarget = target?.trim().toLowerCase();
+
+	const matching = tasks
+		.map((task) => {
+			const meta = task.metadata as Record<string, unknown> | undefined;
+			if (!meta) return null;
+			const sha = readString(meta, "sha");
+			const workdir = readString(meta, "workdir");
+			const pluginName = readString(meta, "pluginName");
+			const metaRoomId = readString(meta, "roomId");
+			if (!sha || !workdir || !pluginName || !task.id) return null;
+			if (metaRoomId && metaRoomId !== roomId) return null;
+			const record: ViewsSnapshotRecord = {
+				sha,
+				workdir,
+				pluginName,
+				created: meta.created === true,
+				roomId: metaRoomId ?? roomId,
+				snapshotCreatedAt:
+					readString(meta, "snapshotCreatedAt") ?? new Date(0).toISOString(),
+			};
+			return { taskId: task.id, record };
+		})
+		.filter(
+			(entry): entry is { taskId: string; record: ViewsSnapshotRecord } =>
+				entry !== null,
+		)
+		.filter((entry) => {
+			if (!normalizedTarget) return true;
+			const plugin = entry.record.pluginName.toLowerCase();
+			const pluginBase = plugin.replace(/^@[^/]+\//, "");
+			return (
+				plugin === normalizedTarget ||
+				pluginBase === normalizedTarget ||
+				plugin.includes(normalizedTarget) ||
+				entry.record.workdir.toLowerCase().includes(normalizedTarget)
+			);
+		})
+		.sort(
+			(a, b) =>
+				Date.parse(b.record.snapshotCreatedAt) -
+				Date.parse(a.record.snapshotCreatedAt),
+		);
+
+	return matching[0] ?? null;
+}
+
+/** Delete a consumed snapshot record (best-effort). */
+export async function deleteSnapshotRecord(
+	runtime: IAgentRuntime,
+	taskId: string,
+): Promise<void> {
+	await runtime
+		.deleteTask(taskId as `${string}-${string}-${string}-${string}-${string}`)
+		.catch((err) => {
+			logger.warn(
+				`[plugin-app-control] failed to delete snapshot record ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		});
+}

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -40,6 +40,7 @@ import {
 import { runViewsEdit } from "./views-edit.js";
 import { isViewIconRequest, runViewsIcon } from "./views-icon.js";
 import { runViewsList } from "./views-list.js";
+import { isRollbackRequest, runViewsRollback } from "./views-rollback.js";
 import { runViewsSearch, scoreView } from "./views-search.js";
 import { resolveIntentView, runViewsShow } from "./views-show.js";
 
@@ -56,6 +57,7 @@ export type ViewsMode =
 	| "create"
 	| "edit"
 	| "icon"
+	| "rollback"
 	| "delete"
 	| "remove"
 	| "pin"
@@ -138,6 +140,7 @@ const MODES: readonly ViewsMode[] = [
 	"create",
 	"edit",
 	"icon",
+	"rollback",
 	"delete",
 	"remove",
 	"pin",
@@ -429,6 +432,17 @@ function inferMode(
 		if (isTileLayoutRequest(trimmed)) return "tile";
 		if (isSplitLayoutRequest(trimmed)) return "split";
 	}
+	// Explicit rollback aliases. Handled before the generic non-mode -> interact
+	// fallthrough so `action=revert`/`action=undo` resolve to the rollback handler.
+	if (
+		normalizedExplicit === "rollback" ||
+		normalizedExplicit === "roll_back" ||
+		normalizedExplicit === "revert" ||
+		normalizedExplicit === "undo" ||
+		normalizedExplicit === "restore"
+	) {
+		return "rollback";
+	}
 	if (
 		normalizedExplicit &&
 		!(MODES as readonly string[]).includes(normalizedExplicit)
@@ -450,6 +464,10 @@ function inferMode(
 
 	if (!trimmed) return null;
 
+	// Rollback/undo of a view-plugin create/edit must be checked before the
+	// edit/delete verbs so "undo the view creation" / "roll back the plugin edit"
+	// route to the rollback handler instead of being treated as an edit/delete.
+	if (isRollbackRequest(trimmed)) return "rollback";
 	if (DELETE_VERBS_RE.test(trimmed)) return "delete";
 	if (CREATE_VERBS.test(trimmed)) return "create";
 	if (EDIT_VERBS_RE.test(trimmed)) return "edit";
@@ -654,6 +672,9 @@ const CAPABILITY_PARAM_RESERVED_KEYS = new Set([
 	"editTarget",
 	"choice",
 	"confirm",
+	"sha",
+	"pluginName",
+	"workdir",
 ]);
 
 type ResolvedViewCapability = {
@@ -1883,6 +1904,13 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			"MAKE_VIEW",
 			"EDIT_VIEW",
 			"UPDATE_VIEW",
+			"ROLLBACK_VIEW",
+			"ROLLBACK_PLUGIN",
+			"REVERT_VIEW",
+			"REVERT_PLUGIN",
+			"UNDO_VIEW_CREATE",
+			"UNDO_PLUGIN_CREATE",
+			"RESTORE_VIEW",
 			"SET_VIEW_ICON",
 			"CHANGE_VIEW_ICON",
 			"GENERATE_VIEW_ICON",
@@ -1919,7 +1947,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			{
 				name: "action",
 				description:
-					"Operation: list | current | show | open | close | search | manager | broadcast | interact | pin | window | split | tile | create | edit | icon | delete | remove, or a registered/generated view capability name to resolve through the view catalog.",
+					"Operation: list | current | show | open | close | search | manager | broadcast | interact | pin | window | split | tile | create | edit | icon | rollback | delete | remove, or a registered/generated view capability name to resolve through the view catalog. Use rollback to undo a view/plugin create or edit by resetting its source to the pre-edit snapshot.",
 				required: true,
 				schema: {
 					type: "string",
@@ -2113,6 +2141,13 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				required: false,
 				schema: { type: "string" },
 			},
+			{
+				name: "sha",
+				description:
+					"Explicit pre-edit snapshot commit id to reset to (rollback mode). Defaults to the most recent recorded snapshot for this room.",
+				required: false,
+				schema: { type: "string" },
+			},
 		],
 
 		validate: async (
@@ -2145,6 +2180,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				mode === "create" ||
 				mode === "edit" ||
 				mode === "icon" ||
+				mode === "rollback" ||
 				mode === "delete" ||
 				mode === "remove"
 			) {
@@ -2491,6 +2527,14 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							repoRoot: getRepoRoot(),
 						});
 					}
+
+					case "rollback":
+						return runViewsRollback({
+							runtime,
+							message,
+							options: actionOptions,
+							callback,
+						});
 
 					case "delete":
 					case "remove": {

--- a/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
@@ -232,6 +232,61 @@ describe("VerificationRoomBridgeService — verdict posting", () => {
 		await service.stop();
 	});
 
+	it("offers a rollback in the verifyPlugin fail verdict (#8915)", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(pluginEvent("fail"));
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		// The user is offered a one-reply rollback that names the VIEWS rollback
+		// action + the target, instead of being left with a broken plugin.
+		expect(text).toMatch(/rollback/i);
+		expect(text).toContain("action=rollback");
+		expect(text).toContain("plugin-habit-tracker");
+		// Retry/cancel remain available.
+		expect(text).toMatch(/retry/i);
+		expect(text).toMatch(/cancel/i);
+
+		await service.stop();
+	});
+
+	it("does not offer a rollback for an app fail verdict (no app snapshot mode)", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit({
+			type: "escalation",
+			sessionId: "sess-app-fail",
+			data: {
+				originRoomId: "room-7",
+				label: "create-app:notes",
+				summary: "build error",
+				verification: {
+					source: "custom-validator",
+					verdict: "fail",
+					validator: { service: "app-verification", method: "verifyApp" },
+					params: { appName: "notes", workdir: "/repo/apps/app-notes" },
+				},
+			},
+		});
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).not.toContain("action=rollback");
+		expect(text).toMatch(/retry/i);
+		expect(text).toMatch(/cancel/i);
+
+		await service.stop();
+	});
+
 	it("drops a verdict event missing the validator params (no targetName)", async () => {
 		const coordinator = makeCoordinator();
 		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -248,8 +248,16 @@ function buildFailMessage(payload: BridgeEventPayload): string {
 			? `${payload.retryCount}${typeof payload.maxRetries === "number" ? `/${payload.maxRetries}` : ""}`
 			: "the maximum";
 	const summary = payload.summary ?? "no further details available";
-	const reply = "Reply 'retry' to keep going or 'cancel' to stop.";
-	return `${payload.targetName} hit verification failure ${retries} time(s). Last failure: ${summary}. ${reply}`;
+
+	// Offer a rollback so the user is never left with a broken create/edit. A
+	// pre-edit git snapshot was taken before the coding agent ran (#8915); naming
+	// the VIEWS rollback action lets them restore the source in one reply. Apps
+	// don't yet take snapshots, so they keep the retry/cancel offer.
+	const offer =
+		payload.method === VERIFY_PLUGIN_METHOD
+			? `Reply 'retry' to keep going, 'rollback' to undo the changes and restore ${payload.targetName} to its pre-edit snapshot (VIEWS action=rollback view=${payload.targetName}), or 'cancel' to stop.`
+			: "Reply 'retry' to keep going or 'cancel' to stop.";
+	return `${payload.targetName} hit verification failure ${retries} time(s). Last failure: ${summary}. ${offer}`;
 }
 
 export class VerificationRoomBridgeService extends Service {


### PR DESCRIPTION
Closes #8915. Part of #8888 (app/plugin/view lifecycle). Implements the user's "undo creation of plugins/views" ask.

## What this does (plugin-app-control)
- **Pre-edit snapshot:** before `dispatchCodingAgent` in views-create / views-edit / app-create, `createPreEditSnapshot(workdir)` does `git add -A && git commit --no-verify --allow-empty -m "pre-edit snapshot"` and records the SHA on a `views-snapshot`-tagged Task (keyed by room/plugin/workdir). Best-effort: a snapshot failure only disables rollback for that edit, never aborts dispatch.
- **`VIEWS rollback` sub-mode:** resolves the SHA (explicit `sha=` or most-recent room snapshot, optionally narrowed by view), `git reset --hard <sha>`, then re-registers via the same `POST /api/plugins/load-from-directory` path create uses. NL phrasings ("roll back the wallet view", "undo the plugin creation") route here; bare `undo` is left to HOMESCREEN.
- **Failure offer:** on `verifyPlugin` max-retry failure, the verification room bridge now offers rollback (`VIEWS action=rollback view=<name>`) instead of leaving the broken state.
- Uses a small injectable `GitRunner` (mirrors `workspace-git-ops.ts`) rather than coupling to `CodingWorkspaceService` (which is keyed by managed-workspace clone IDs; the view/plugin flow operates on local-repo workdirs) — also keeps tests deterministic.

## Evidence
```
$ bun run --cwd plugins/plugin-app-control typecheck    # tsgo --noEmit, clean
$ bun run --cwd plugins/plugin-app-control test -- views-rollback views-management verification-room-bridge
 Test Files 3 passed / Tests 66 passed
$ (full plugin suite) Test Files 27 passed / Tests 1108 passed
```
Isolated worktree; main checkout untouched; biome clean.

## Caveats / follow-ups
- Live scenario (dispatch a real failing edit, accept the offer, assert source restored on disk) needs a live model/sub-agent spawn — code + deterministic unit tests complete; live run tracked under #8888.
- APP create/edit now snapshot too, but a first-class APP `rollback` mode wasn't added (APP has no such mode); those snapshots are still recoverable via `VIEWS rollback`. Clean follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)