### PR TITLE
feat(browser): add wait_for_url subaction with streaming status + timeout

### DIFF
--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -10,7 +10,7 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 ### Actions
 
-- **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `press`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only.
+- **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `press`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `wait_for_url`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only. `wait_for_url` (pure predicate + poll loop in `src/actions/wait-for-url*.ts`) optionally opens a `url`, then polls the current tab URL against a `pattern` (substring, or a `/regex/` literal — invalid regex falls back to substring), streaming a `HandlerCallback` status each poll and resolving with a typed match/timeout result (never throws on timeout). Tunables: `timeoutMs` (default 300000) and `pollIntervalMs` (default 2000).
 - **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome/Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
 
 ### Providers
@@ -63,6 +63,8 @@ src/
   actions/
     browser.ts                     BROWSER action
     browser-autofill-login.ts      autofill_login subaction (vault-gated)
+    wait-for-url-predicate.ts      Pure URL-match predicate (substring + /regex/)
+    wait-for-url.ts                wait_for_url poll loop (injectable clock/sleep/url source)
     manage-browser-bridge.ts       MANAGE_BROWSER_BRIDGE action
   providers/
     workspace.ts                   browser_workspace provider

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -10,7 +10,7 @@ Owns the Eliza browser workspace (electrobun-embedded `BrowserView` on desktop, 
 
 ### Actions
 
-- **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `press`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only.
+- **BROWSER** (`src/actions/browser.ts`) — Core browser control. Dispatches to the active `BrowserService` target. Subactions: `open`, `navigate`, `click`, `type`, `press`, `get`, `state`, `snapshot`, `screenshot`, `reload`, `back`, `forward`, `close`, `show`, `hide`, `wait`, `wait_for_url`, `tab`, `realistic-click`, `realistic-fill`, `realistic-type`, `realistic-press`, `cursor-move`, `cursor-hide`, `autofill_login`. Role-gated OWNER only. `wait_for_url` (pure predicate + poll loop in `src/actions/wait-for-url*.ts`) optionally opens a `url`, then polls the current tab URL against a `pattern` (substring, or a `/regex/` literal — invalid regex falls back to substring), streaming a `HandlerCallback` status each poll and resolving with a typed match/timeout result (never throws on timeout). Tunables: `timeoutMs` (default 300000) and `pollIntervalMs` (default 2000).
 - **MANAGE_BROWSER_BRIDGE** (`src/actions/manage-browser-bridge.ts`) — Companion extension lifecycle for Chrome/Safari. Subactions: `install`, `reveal_folder`, `open_manager`, `refresh`. Role-gated OWNER only.
 
 ### Providers
@@ -63,6 +63,8 @@ src/
   actions/
     browser.ts                     BROWSER action
     browser-autofill-login.ts      autofill_login subaction (vault-gated)
+    wait-for-url-predicate.ts      Pure URL-match predicate (substring + /regex/)
+    wait-for-url.ts                wait_for_url poll loop (injectable clock/sleep/url source)
     manage-browser-bridge.ts       MANAGE_BROWSER_BRIDGE action
   providers/
     workspace.ts                   browser_workspace provider

--- a/plugins/plugin-browser/src/actions/browser.test.ts
+++ b/plugins/plugin-browser/src/actions/browser.test.ts
@@ -217,6 +217,101 @@ describe("BROWSER action", () => {
     });
   });
 
+  it("wait_for_url opens the url, streams a watch status, and resolves on match", async () => {
+    // open → tab; get url → matching url on the first poll.
+    const service = {
+      execute: vi.fn(async (command: { subaction: string }) => {
+        if (command.subaction === "open") {
+          return {
+            mode: "workspace",
+            subaction: "open",
+            tab: {
+              id: "tab-9",
+              title: "OAuth",
+              url: "https://gh.example/oauth",
+            },
+          };
+        }
+        if (command.subaction === "get") {
+          return {
+            mode: "workspace",
+            subaction: "get",
+            value: "https://gh.example/callback?code=abc",
+          };
+        }
+        return { mode: "workspace", subaction: command.subaction };
+      }),
+    };
+    const runtime = runtimeWithService(service);
+    const callback = vi.fn(async () => []);
+
+    const result = await browserAction.handler?.(
+      runtime as never,
+      { content: { text: "" } } as never,
+      undefined,
+      {
+        parameters: {
+          action: "wait_for_url",
+          url: "https://gh.example/oauth",
+          pattern: "callback?code=",
+          timeoutMs: 5_000,
+          pollIntervalMs: 100,
+        },
+      } as never,
+      callback as never,
+    );
+
+    // Opened the starting url, then polled the current url.
+    expect(service.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subaction: "open",
+        url: "https://gh.example/oauth",
+      }),
+      undefined,
+    );
+    // First callback is the "I opened X, watching" message.
+    expect(callback.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("watching"),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        values: expect.objectContaining({
+          success: true,
+          subaction: "wait_for_url",
+          status: "matched",
+          matched: true,
+        }),
+      }),
+    );
+    expect(result?.text).toContain("callback?code=abc");
+  });
+
+  it("wait_for_url fails fast when no pattern is supplied", async () => {
+    const service = browserService();
+    const runtime = runtimeWithService(service);
+
+    const result = await browserAction.handler?.(
+      runtime as never,
+      { content: { text: "" } } as never,
+      undefined,
+      { parameters: { action: "wait_for_url" } } as never,
+      (async () => []) as never,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        values: expect.objectContaining({
+          error: "BROWSER_WAIT_FOR_URL_NO_PATTERN",
+        }),
+      }),
+    );
+    expect(service.execute).not.toHaveBeenCalled();
+  });
+
   it("returns a structured failure when no service or workspace backend can execute", async () => {
     const { result } = await runBrowserAction({
       service: null,

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -1,6 +1,7 @@
 import type {
   Action,
   ActionExample,
+  HandlerCallback,
   HandlerOptions,
   Memory,
 } from "@elizaos/core";
@@ -11,9 +12,15 @@ import {
 } from "../browser-service.js";
 import {
   type BrowserWorkspaceCommand,
+  type BrowserWorkspaceCommandResult,
   executeBrowserWorkspaceCommand,
   getBrowserWorkspaceMode,
 } from "../workspace/browser-workspace.js";
+import {
+  WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS,
+  WAIT_FOR_URL_DEFAULT_TIMEOUT_MS,
+  waitForUrl,
+} from "./wait-for-url.js";
 
 /**
  * Targets are the registered browser backends. The agent uses what is
@@ -58,14 +65,20 @@ type BrowserWorkspaceAction =
   | "cursor_move"
   | "cursor_hide";
 
-type BrowserActionSubaction = BrowserWorkspaceSubaction | "autofill-login";
+type BrowserActionSubaction =
+  | BrowserWorkspaceSubaction
+  | "autofill-login"
+  | "wait-for-url";
 type BrowserActionValue =
   | BrowserWorkspaceAction
   | "autofill_login"
-  | "autofill-login";
+  | "autofill-login"
+  | "wait_for_url"
+  | "wait-for-url";
 type NormalizedBrowserAction =
   | BrowserWorkspaceSubaction
   | "autofill-login"
+  | "wait-for-url"
   | "info"
   | "context"
   | "get_context"
@@ -98,6 +111,10 @@ type BrowserActionParameters = {
     | "close_tab"
     | "switch_tab";
   subaction?: BrowserActionSubaction;
+  /** For action=wait_for_url: substring or regex to match the tab URL. */
+  pattern?: string;
+  /** For action=wait_for_url: poll cadence in ms (default ~2000). */
+  pollIntervalMs?: number;
   /** Registrable hostname for `action: "autofill_login"`. */
   domain?: string;
   /** Saved login username for autofill-login (optional). */
@@ -138,13 +155,20 @@ function extractFirstUrl(value: string): string | null {
 function inferBrowserSubaction(
   params: BrowserActionParameters | undefined,
   messageText: string,
-): BrowserWorkspaceCommand["subaction"] | "autofill-login" {
+): BrowserWorkspaceCommand["subaction"] | "autofill-login" | "wait-for-url" {
   const normalizedAction = normalizeBrowserAction(params?.action);
   if (
     normalizedAction === "autofill-login" ||
     params?.subaction === "autofill-login"
   ) {
     return "autofill-login";
+  }
+
+  if (
+    normalizedAction === "wait-for-url" ||
+    params?.subaction === "wait-for-url"
+  ) {
+    return "wait-for-url";
   }
 
   const legacySubaction = normalizeLegacyBrowserAction(normalizedAction);
@@ -198,6 +222,9 @@ function normalizeBrowserAction(
       return "cursor-hide";
     case "autofill_login":
       return "autofill-login";
+    case "wait_for_url":
+    case "wait-for-url":
+      return "wait-for-url";
     default:
       return action as NormalizedBrowserAction | undefined;
   }
@@ -218,6 +245,7 @@ function normalizeLegacyBrowserAction(
     case "switch_tab":
       return "tab";
     case "autofill-login":
+    case "wait-for-url":
       return undefined;
     case undefined:
       return undefined;
@@ -321,6 +349,173 @@ function formatBrowserSessionResult(
   return `Browser ${command.subaction} completed in ${result.mode} mode.`;
 }
 
+function currentUrlFromResult(
+  result: BrowserWorkspaceCommandResult,
+): string | null {
+  if (result.tab?.url) {
+    return result.tab.url;
+  }
+  if (typeof result.value === "string" && result.value.trim()) {
+    return result.value.trim();
+  }
+  if (Array.isArray(result.tabs)) {
+    const visible = result.tabs.find((tab) => tab.visible) ?? result.tabs[0];
+    if (visible?.url) {
+      return visible.url;
+    }
+  }
+  return null;
+}
+
+/**
+ * Reads the current tab URL via the active browser target. Prefers a targeted
+ * `get url` (cheap), falling back to `state` for backends that don't implement
+ * the get-url mode. Returns null when the URL is not yet readable.
+ */
+async function readCurrentBrowserUrl(
+  browserService: BrowserService | null,
+  target: BrowserTarget | undefined,
+  tabId: string | undefined,
+): Promise<string | null> {
+  const run = async (
+    command: BrowserWorkspaceCommand,
+  ): Promise<BrowserWorkspaceCommandResult> =>
+    browserService
+      ? browserService.execute(command, target)
+      : executeBrowserWorkspaceCommand(command);
+
+  try {
+    const got = await run({
+      subaction: "get",
+      getMode: "url",
+      id: tabId,
+    });
+    const url = currentUrlFromResult(got);
+    if (url) {
+      return url;
+    }
+  } catch (error) {
+    logger.debug(
+      `[BROWSER] wait_for_url get-url poll failed, falling back to state: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  try {
+    const state = await run({ subaction: "state", id: tabId });
+    return currentUrlFromResult(state);
+  } catch (error) {
+    logger.debug(
+      `[BROWSER] wait_for_url state poll could not read URL: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Handles `action: "wait_for_url"`. Optionally opens/navigates to a starting
+ * URL, tells the user it is watching, then polls the tab URL against `pattern`,
+ * streaming a status update each poll. Resolves with a typed success/timeout
+ * result and never throws on timeout.
+ */
+async function executeBrowserWaitForUrl(
+  runtime: Parameters<NonNullable<Action["handler"]>>[0],
+  params: BrowserActionParameters | undefined,
+  messageText: string,
+  callback: HandlerCallback | undefined,
+): Promise<ReturnType<NonNullable<Action["handler"]>>> {
+  const pattern = (params?.pattern ?? "").trim();
+  if (!pattern) {
+    const text =
+      "wait_for_url needs a `pattern` (substring or regex) to watch for.";
+    logger.warn(`[BROWSER] ${text}`);
+    return {
+      text,
+      success: false,
+      values: { success: false, error: "BROWSER_WAIT_FOR_URL_NO_PATTERN" },
+      data: { actionName: "BROWSER", subaction: "wait_for_url" },
+    };
+  }
+
+  const browserService =
+    runtime.getService<BrowserService>(BROWSER_SERVICE_TYPE) ?? null;
+  const target = params?.target;
+  const startUrl =
+    params?.url?.trim() || extractFirstUrl(messageText) || undefined;
+  const timeoutMs = params?.timeoutMs ?? WAIT_FOR_URL_DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs =
+    params?.pollIntervalMs ?? WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS;
+
+  let tabId = params?.id?.trim() || undefined;
+
+  // Optionally launch the starting URL so the user can act on it.
+  if (startUrl) {
+    const openCommand: BrowserWorkspaceCommand = {
+      subaction: tabId ? "navigate" : "open",
+      url: startUrl,
+      id: tabId,
+    };
+    try {
+      const opened = browserService
+        ? await browserService.execute(openCommand, target)
+        : await executeBrowserWorkspaceCommand(openCommand);
+      tabId = opened.tab?.id ?? tabId;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn(
+        `[BROWSER] wait_for_url could not open ${startUrl}: ${reason}`,
+      );
+      return {
+        text: `Couldn't open ${startUrl} to watch for "${pattern}": ${reason}`,
+        success: false,
+        values: { success: false, error: "BROWSER_WAIT_FOR_URL_OPEN_FAILED" },
+        data: { actionName: "BROWSER", subaction: "wait_for_url" },
+      };
+    }
+  }
+
+  await callback?.({
+    text: startUrl
+      ? `I opened ${startUrl} — watching for "${pattern}" and I'll resume when it's reached.`
+      : `Watching the current tab for "${pattern}" — I'll resume when it's reached.`,
+  });
+
+  logger.info(
+    `[BROWSER] wait_for_url pattern="${pattern}" timeoutMs=${timeoutMs} pollIntervalMs=${pollIntervalMs} target=${target ?? "auto"}`,
+  );
+
+  const outcome = await waitForUrl(
+    { pattern, timeoutMs, pollIntervalMs },
+    {
+      getCurrentUrl: () => readCurrentBrowserUrl(browserService, target, tabId),
+      emitStatus: async (text) => {
+        await callback?.({ text });
+      },
+    },
+  );
+
+  return {
+    text: outcome.message,
+    success: outcome.matched,
+    userFacingText: outcome.message,
+    values: {
+      success: outcome.matched,
+      subaction: "wait_for_url",
+      status: outcome.status,
+      matched: outcome.matched,
+      polls: outcome.polls,
+    },
+    data: {
+      actionName: "BROWSER",
+      subaction: "wait_for_url",
+      outcome,
+    },
+  };
+}
+
 export const browserAction: Action = {
   name: "BROWSER",
   contexts: ["browser", "web", "automation", "secrets"],
@@ -344,11 +539,11 @@ export const browserAction: Action = {
     "SIGN_IN_TO_SITE",
   ],
   description:
-    "BROWSER action. Control registered browser target: app workspace, bridge Chrome/Safari companion, computeruse Chromium, or Stagehand fallback. BrowserService picks target if omitted. action=autofill_login + domain vault-gated autofills open workspace tab.",
+    "BROWSER action. Control registered browser target: app workspace, bridge Chrome/Safari companion, computeruse Chromium, or Stagehand fallback. BrowserService picks target if omitted. action=autofill_login + domain vault-gated autofills open workspace tab. action=wait_for_url + pattern opens an optional url then watches the tab and resumes when its URL matches (OAuth callback, deploy/CI done), streaming progress.",
   descriptionCompressed:
-    "Browser open|navigate|click|type|screenshot|state|autofill_login; bridge status elsewhere",
+    "Browser open|navigate|click|type|screenshot|state|autofill_login|wait_for_url; bridge status elsewhere",
   validate: async () => true,
-  handler: async (runtime, message, _state, options) => {
+  handler: async (runtime, message, _state, options, callback) => {
     const params = (options as HandlerOptions | undefined)?.parameters as
       | BrowserActionParameters
       | undefined;
@@ -360,6 +555,10 @@ export const browserAction: Action = {
         "./browser-autofill-login.js"
       );
       return executeBrowserAutofillLogin(runtime, message, options);
+    }
+
+    if (subaction === "wait-for-url") {
+      return executeBrowserWaitForUrl(runtime, params, messageText, callback);
     }
 
     const url =
@@ -471,8 +670,22 @@ export const browserAction: Action = {
           "cursor_move",
           "cursor_hide",
           "autofill_login",
+          "wait_for_url",
         ],
       },
+    },
+    {
+      name: "pattern",
+      description:
+        "For action=wait_for_url: substring or /regex/ to match the tab URL (e.g. callback?code=, or /\\/done$/).",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "pollIntervalMs",
+      description: "For action=wait_for_url: poll cadence in ms. Default 2000.",
+      required: false,
+      schema: { type: "number" as const },
     },
     {
       name: "tabAction",
@@ -614,6 +827,21 @@ export const browserAction: Action = {
         name: "{{agentName}}",
         content: {
           text: "click completed in desktop mode.",
+        },
+      },
+    ],
+    [
+      {
+        name: "{{name1}}",
+        content: {
+          text: "Open the GitHub OAuth page and let me know when it redirects back to our callback.",
+        },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "I opened https://github.com/login/oauth/authorize — watching for \"callback?code=\" and I'll resume when it's reached.",
+          actions: ["BROWSER"],
         },
       },
     ],

--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildWaitForUrlPredicate } from "./wait-for-url-predicate.js";
+
+describe("buildWaitForUrlPredicate", () => {
+  it("matches a plain substring case-insensitively", () => {
+    const predicate = buildWaitForUrlPredicate("callback?code=");
+    expect(predicate.kind).toBe("substring");
+    expect(predicate.test("https://app.example/callback?code=abc")).toBe(true);
+    expect(predicate.test("https://APP.example/CALLBACK?CODE=abc")).toBe(true);
+    expect(predicate.test("https://app.example/login")).toBe(false);
+  });
+
+  it("treats a /regex/ literal as a regular expression", () => {
+    const predicate = buildWaitForUrlPredicate("/\\/deploy\\/.+\\/done$/");
+    expect(predicate.kind).toBe("regex");
+    expect(predicate.test("https://ci.example/deploy/123/done")).toBe(true);
+    expect(predicate.test("https://ci.example/deploy/123/running")).toBe(false);
+  });
+
+  it("honors regex literal flags", () => {
+    const predicate = buildWaitForUrlPredicate("/DONE$/i");
+    expect(predicate.kind).toBe("regex");
+    expect(predicate.test("https://ci.example/done")).toBe(true);
+  });
+
+  it("treats a bare pattern with metacharacters as a literal substring", () => {
+    // Without /.../ wrapping, metacharacters are matched literally.
+    const predicate = buildWaitForUrlPredicate("?status=done");
+    expect(predicate.kind).toBe("substring");
+    expect(predicate.test("https://ci.example/run?status=done")).toBe(true);
+    expect(predicate.test("https://ci.example/run?status=running")).toBe(false);
+  });
+
+  it("does not treat an ordinary URL path as a regex", () => {
+    const predicate = buildWaitForUrlPredicate("github.com/login");
+    expect(predicate.kind).toBe("substring");
+    expect(predicate.test("https://github.com/login/oauth")).toBe(true);
+  });
+
+  it("falls back to a substring match when a regex literal is invalid", () => {
+    const predicate = buildWaitForUrlPredicate("/foo[/");
+    expect(predicate.kind).toBe("substring");
+    // The raw pattern text is matched as a substring.
+    expect(predicate.test("https://x.example/foo[/bar")).toBe(true);
+    expect(predicate.test("https://x.example/baz")).toBe(false);
+  });
+
+  it("never matches an empty pattern", () => {
+    const predicate = buildWaitForUrlPredicate("   ");
+    expect(predicate.kind).toBe("substring");
+    expect(predicate.test("https://anything.example")).toBe(false);
+  });
+});

--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure URL-matching predicate for the BROWSER `wait_for_url` subaction.
+ *
+ * A `pattern` is treated as a regular expression only when it is written as a
+ * `/.../` literal (with optional flags); any other pattern is a
+ * case-insensitive substring match. This keeps ordinary URL fragments like
+ * `callback?code=` (which contain regex metacharacters) predictable. An invalid
+ * regex literal always falls back to a substring match so the agent never
+ * crashes on user input.
+ *
+ * Kept free of any browser/runtime imports so it stays trivially unit-testable.
+ */
+
+/** How a given pattern was interpreted when building the predicate. */
+export type WaitForUrlPatternKind = "regex" | "substring";
+
+export interface WaitForUrlPredicate {
+  /** The original, untrimmed pattern the caller supplied. */
+  readonly pattern: string;
+  /** How the pattern was interpreted ("regex" or "substring"). */
+  readonly kind: WaitForUrlPatternKind;
+  /** Returns true when `url` satisfies the pattern. */
+  test(url: string): boolean;
+}
+
+const REGEX_LITERAL = /^\/(.+)\/([a-z]*)$/i;
+
+function compileRegex(source: string, flags: string): RegExp | null {
+  try {
+    return new RegExp(source, flags);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a {@link WaitForUrlPredicate} from a caller-supplied pattern.
+ *
+ * - `"/foo\\d+/i"` → regex `/foo\d+/i`.
+ * - `"/\\/done$/"` → regex.
+ * - `"callback?code="` → substring (case-insensitive), even though it contains
+ *   regex metacharacters.
+ * - An invalid `/.../ ` literal → falls back to a case-insensitive substring
+ *   match on the original pattern text.
+ */
+export function buildWaitForUrlPredicate(pattern: string): WaitForUrlPredicate {
+  const trimmed = pattern.trim();
+
+  const literalMatch = trimmed.match(REGEX_LITERAL);
+  if (literalMatch) {
+    const [, source, flags] = literalMatch;
+    const compiled = compileRegex(source, flags || "");
+    if (compiled) {
+      return {
+        pattern,
+        kind: "regex",
+        test: (url: string) => compiled.test(url),
+      };
+    }
+    // Invalid regex literal: fall through to substring on the raw pattern.
+  }
+
+  const needle = trimmed.toLowerCase();
+  return {
+    pattern,
+    kind: "substring",
+    test: (url: string) =>
+      needle.length === 0 ? false : url.toLowerCase().includes(needle),
+  };
+}

--- a/plugins/plugin-browser/src/actions/wait-for-url.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForUrl } from "./wait-for-url.js";
+
+/**
+ * Deterministic fake clock: `now()` advances only when `sleep(ms)` is called,
+ * so the poll loop runs synchronously with no real timers.
+ */
+function fakeClock(start = 0) {
+  let current = start;
+  return {
+    now: () => current,
+    sleep: async (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+describe("waitForUrl", () => {
+  it("resolves when the URL eventually matches and emits ≥1 status callback", async () => {
+    const clock = fakeClock();
+    const urls = [
+      "https://app.example/loading",
+      "https://app.example/oauth",
+      "https://app.example/callback?code=xyz",
+    ];
+    let i = 0;
+    const getCurrentUrl = vi.fn(() => {
+      const url = urls[Math.min(i, urls.length - 1)];
+      i += 1;
+      return url;
+    });
+    const statuses: string[] = [];
+
+    const outcome = await waitForUrl(
+      { pattern: "callback?code=", timeoutMs: 60_000, pollIntervalMs: 1_000 },
+      {
+        getCurrentUrl,
+        emitStatus: (text) => {
+          statuses.push(text);
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+      },
+    );
+
+    expect(outcome.status).toBe("matched");
+    expect(outcome.matched).toBe(true);
+    expect(outcome.lastUrl).toBe("https://app.example/callback?code=xyz");
+    expect(outcome.polls).toBe(3);
+    // Two "still waiting" updates before the success update.
+    expect(statuses.filter((s) => s.startsWith("⏳"))).toHaveLength(2);
+    expect(statuses.at(-1)).toContain("✅");
+    expect(statuses.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("matches on the very first poll without emitting a waiting status", async () => {
+    const clock = fakeClock();
+    const statuses: string[] = [];
+
+    const outcome = await waitForUrl(
+      { pattern: "/done$/", timeoutMs: 10_000, pollIntervalMs: 1_000 },
+      {
+        getCurrentUrl: () => "https://ci.example/run/1/done",
+        emitStatus: (text) => {
+          statuses.push(text);
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+      },
+    );
+
+    expect(outcome.matched).toBe(true);
+    expect(outcome.polls).toBe(1);
+    expect(statuses.every((s) => !s.startsWith("⏳"))).toBe(true);
+  });
+
+  it("times out cleanly when the URL never matches (never throws)", async () => {
+    const clock = fakeClock();
+    const statuses: string[] = [];
+
+    const outcome = await waitForUrl(
+      { pattern: "callback?code=", timeoutMs: 5_000, pollIntervalMs: 1_000 },
+      {
+        getCurrentUrl: () => "https://app.example/still-loading",
+        emitStatus: (text) => {
+          statuses.push(text);
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+      },
+    );
+
+    expect(outcome.status).toBe("timeout");
+    expect(outcome.matched).toBe(false);
+    expect(outcome.lastUrl).toBe("https://app.example/still-loading");
+    expect(outcome.message).toMatch(/Timed out/);
+    expect(statuses.at(-1)).toContain("⌛");
+    // Elapsed never exceeds the deadline.
+    expect(outcome.elapsedMs).toBeLessThanOrEqual(5_000);
+  });
+
+  it("keeps waiting when the URL source is unreadable, then succeeds", async () => {
+    const clock = fakeClock();
+    const values: Array<string | null> = [null, null, "https://x.example/ok"];
+    let i = 0;
+    const outcome = await waitForUrl(
+      { pattern: "/ok$/", timeoutMs: 60_000, pollIntervalMs: 500 },
+      {
+        getCurrentUrl: () => values[Math.min(i++, values.length - 1)],
+        now: clock.now,
+        sleep: clock.sleep,
+      },
+    );
+
+    expect(outcome.matched).toBe(true);
+    expect(outcome.polls).toBe(3);
+  });
+
+  it("does not crash when getCurrentUrl throws", async () => {
+    const clock = fakeClock();
+    let i = 0;
+    const outcome = await waitForUrl(
+      { pattern: "/done$/", timeoutMs: 3_000, pollIntervalMs: 1_000 },
+      {
+        getCurrentUrl: () => {
+          i += 1;
+          if (i < 2) {
+            throw new Error("tab not ready");
+          }
+          return "https://x.example/done";
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+      },
+    );
+
+    expect(outcome.matched).toBe(true);
+  });
+});

--- a/plugins/plugin-browser/src/actions/wait-for-url.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url.ts
@@ -1,0 +1,168 @@
+/**
+ * BROWSER `wait_for_url` subaction core.
+ *
+ * Opens (or reuses) a tab, then polls the current tab URL until it matches a
+ * caller-supplied pattern (substring or regex — see
+ * {@link buildWaitForUrlPredicate}) or a deadline passes. Each poll iteration
+ * emits a streaming status update through the action's `HandlerCallback` so a
+ * Telegram/chat user sees progress; the loop never throws on timeout — it
+ * returns a typed {@link WaitForUrlOutcome}.
+ *
+ * The poll loop takes its URL source, clock, and sleep as injected
+ * dependencies so it is fully deterministic under test (fake URL source + fake
+ * timer) with no real browser.
+ */
+
+import { buildWaitForUrlPredicate } from "./wait-for-url-predicate.js";
+
+/** Default deadline: 5 minutes. */
+export const WAIT_FOR_URL_DEFAULT_TIMEOUT_MS = 300_000;
+/** Default poll cadence: ~2 seconds. */
+export const WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS = 2_000;
+/** Lower bound for the poll interval (avoids a hot loop). */
+const WAIT_FOR_URL_MIN_POLL_INTERVAL_MS = 50;
+/** Lower bound for the timeout (always allow at least one poll). */
+const WAIT_FOR_URL_MIN_TIMEOUT_MS = 1;
+
+export type WaitForUrlStatus = "matched" | "timeout";
+
+export interface WaitForUrlOutcome {
+  status: WaitForUrlStatus;
+  /** True iff the URL matched before the deadline. */
+  matched: boolean;
+  /** The pattern the caller supplied. */
+  pattern: string;
+  /** The last URL observed from the tab (null if never readable). */
+  lastUrl: string | null;
+  /** Number of poll iterations performed. */
+  polls: number;
+  /** Wall-clock elapsed time, in ms, measured from the injected clock. */
+  elapsedMs: number;
+  /** Human-readable summary suitable for a chat reply. */
+  message: string;
+}
+
+export interface WaitForUrlOptions {
+  /** Substring or regex to match against the current tab URL. */
+  pattern: string;
+  /** Deadline in ms. Defaults to {@link WAIT_FOR_URL_DEFAULT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /**
+   * Poll cadence in ms. Defaults to
+   * {@link WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS}.
+   */
+  pollIntervalMs?: number;
+}
+
+export interface WaitForUrlDeps {
+  /**
+   * Reads the current tab URL. Returns null when the URL is not yet readable
+   * (e.g. tab still loading); the loop keeps polling until the deadline.
+   */
+  getCurrentUrl: () => Promise<string | null> | string | null;
+  /** Emits a status update to the user. Optional (may be a no-op). */
+  emitStatus?: (text: string) => Promise<void> | void;
+  /** Monotonic clock in ms. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Async sleep. Defaults to a real `setTimeout` promise. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function clampPollInterval(value: number | undefined): number {
+  const candidate = value ?? WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS;
+  if (!Number.isFinite(candidate) || candidate <= 0) {
+    return WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS;
+  }
+  return Math.max(WAIT_FOR_URL_MIN_POLL_INTERVAL_MS, Math.floor(candidate));
+}
+
+function clampTimeout(value: number | undefined): number {
+  const candidate = value ?? WAIT_FOR_URL_DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(candidate) || candidate <= 0) {
+    return WAIT_FOR_URL_DEFAULT_TIMEOUT_MS;
+  }
+  return Math.max(WAIT_FOR_URL_MIN_TIMEOUT_MS, Math.floor(candidate));
+}
+
+function describeCurrentUrl(url: string | null): string {
+  return url ? `current: ${url}` : "current: unknown";
+}
+
+/**
+ * Poll the current tab URL until it matches `pattern` or the deadline passes.
+ * Never throws on timeout — returns a typed {@link WaitForUrlOutcome}.
+ */
+export async function waitForUrl(
+  options: WaitForUrlOptions,
+  deps: WaitForUrlDeps,
+): Promise<WaitForUrlOutcome> {
+  const predicate = buildWaitForUrlPredicate(options.pattern);
+  const timeoutMs = clampTimeout(options.timeoutMs);
+  const pollIntervalMs = clampPollInterval(options.pollIntervalMs);
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? realSleep;
+
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+
+  let polls = 0;
+  let lastUrl: string | null = null;
+
+  while (true) {
+    polls += 1;
+
+    let currentUrl: string | null = null;
+    try {
+      currentUrl = (await deps.getCurrentUrl()) ?? null;
+    } catch {
+      // Treat an unreadable URL like an empty poll; keep waiting.
+      currentUrl = null;
+    }
+    if (currentUrl !== null) {
+      lastUrl = currentUrl;
+    }
+
+    if (currentUrl !== null && predicate.test(currentUrl)) {
+      const elapsedMs = now() - startedAt;
+      const message = `Done — tab reached ${currentUrl} (matched ${predicate.kind} "${predicate.pattern}" after ${polls} check${polls === 1 ? "" : "s"}).`;
+      await deps.emitStatus?.(`✅ ${message}`);
+      return {
+        status: "matched",
+        matched: true,
+        pattern: predicate.pattern,
+        lastUrl,
+        polls,
+        elapsedMs,
+        message,
+      };
+    }
+
+    const elapsedMs = now() - startedAt;
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      const message = `Timed out after ${Math.round(elapsedMs / 1000)}s waiting for "${predicate.pattern}" (${describeCurrentUrl(lastUrl)}).`;
+      await deps.emitStatus?.(`⌛ ${message}`);
+      return {
+        status: "timeout",
+        matched: false,
+        pattern: predicate.pattern,
+        lastUrl,
+        polls,
+        elapsedMs,
+        message,
+      };
+    }
+
+    await deps.emitStatus?.(
+      `⏳ still waiting for "${predicate.pattern}"… (${describeCurrentUrl(currentUrl)})`,
+    );
+
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+  }
+}

--- a/plugins/plugin-browser/src/index.ts
+++ b/plugins/plugin-browser/src/index.ts
@@ -19,13 +19,27 @@ export {
   manageBrowserBridgeAction,
 } from "./actions/manage-browser-bridge.js";
 export {
+  WAIT_FOR_URL_DEFAULT_POLL_INTERVAL_MS,
+  WAIT_FOR_URL_DEFAULT_TIMEOUT_MS,
+  type WaitForUrlDeps,
+  type WaitForUrlOptions,
+  type WaitForUrlOutcome,
+  type WaitForUrlStatus,
+  waitForUrl,
+} from "./actions/wait-for-url.js";
+export {
+  buildWaitForUrlPredicate,
+  type WaitForUrlPatternKind,
+  type WaitForUrlPredicate,
+} from "./actions/wait-for-url-predicate.js";
+export * from "./bridge-policy.js";
+export * from "./bridge-readiness.js";
+export * from "./bridge-records.js";
+export {
   BROWSER_SERVICE_TYPE,
   BrowserService,
   type BrowserTarget,
 } from "./browser-service.js";
-export * from "./bridge-policy.js";
-export * from "./bridge-readiness.js";
-export * from "./bridge-records.js";
 export * from "./companion-auth.js";
 export * from "./contracts.js";
 export { BrowserBridgeAdapter } from "./message-adapter.js";
@@ -49,6 +63,11 @@ import {
   BROWSER_BRIDGE_SUBACTIONS as _bs_5_BROWSER_BRIDGE_SUBACTIONS,
   manageBrowserBridgeAction as _bs_6_manageBrowserBridgeAction,
 } from "./actions/manage-browser-bridge.js";
+import { waitForUrl as _bs_15_waitForUrl } from "./actions/wait-for-url.js";
+import { buildWaitForUrlPredicate as _bs_14_buildWaitForUrlPredicate } from "./actions/wait-for-url-predicate.js";
+import { resolveBrowserBridgeCompanionPairingTokenExpiresAt as _bs_13_resolveBrowserBridgeCompanionPairingTokenExpiresAt } from "./bridge-policy.js";
+import { resolveBrowserBridgeReadiness as _bs_11_resolveBrowserBridgeReadiness } from "./bridge-readiness.js";
+import { createBrowserBridgeCompanionStatus as _bs_12_createBrowserBridgeCompanionStatus } from "./bridge-records.js";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -58,9 +77,6 @@ import {
   BROWSER_SERVICE_TYPE as _bs_1_BROWSER_SERVICE_TYPE,
   BrowserService as _bs_2_BrowserService,
 } from "./browser-service.js";
-import { resolveBrowserBridgeCompanionPairingTokenExpiresAt as _bs_13_resolveBrowserBridgeCompanionPairingTokenExpiresAt } from "./bridge-policy.js";
-import { resolveBrowserBridgeReadiness as _bs_11_resolveBrowserBridgeReadiness } from "./bridge-readiness.js";
-import { createBrowserBridgeCompanionStatus as _bs_12_createBrowserBridgeCompanionStatus } from "./bridge-records.js";
 import { browserPlugin as _bs_7_browserPlugin } from "./plugin.js";
 import {
   FRAME_FILE as _bs_8_FRAME_FILE,
@@ -85,6 +101,8 @@ const __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__ = [
   _bs_11_resolveBrowserBridgeReadiness,
   _bs_12_createBrowserBridgeCompanionStatus,
   _bs_13_resolveBrowserBridgeCompanionPairingTokenExpiresAt,
+  _bs_14_buildWaitForUrlPredicate,
+  _bs_15_waitForUrl,
 ];
 const bundleSafetyGlobal = globalThis as typeof globalThis & {
   __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__?: typeof __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__;


### PR DESCRIPTION
Closes #8911. Part of #8887 (in-chat browser, workflows & scripts). Implements "launch a browser window and wait for status updates" (OAuth callback, deploy log, CI run).

## What this does (plugin-browser)
- New `wait_for_url` BROWSER subaction: optionally opens a start URL, sends an "I opened X — watching for …" status, then polls the active tab URL against a `pattern` (substring, or `/regex/flags` literal with safe fallback) every `pollIntervalMs` (default 2s), emitting a `HandlerCallback` progress update each poll so Telegram/chat sees it, and resolves with a typed `WaitForUrlOutcome` (`matched`/`timeout`) — never throws on timeout (default 300000ms, configurable).
- Pure, unit-tested predicate (`wait-for-url-predicate.ts`) and an injectable-deps poll loop (`wait-for-url.ts`: `getCurrentUrl`/`emitStatus`/`now`/`sleep`) for deterministic tests.
- URL source = the existing in-process `BrowserService` `get url` (with `state` fallback), the reliable path the rest of the action uses.

## Evidence
```
$ bun run --cwd plugins/plugin-browser typecheck   # tsgo --noEmit, clean
$ bun run --cwd plugins/plugin-browser test -- wait-for-url browser.test
 Test Files 3 passed / Tests 20 passed   (full suite: 16 files / 79 passed)
```
Isolated worktree; main untouched; biome clean.

## Caveats / follow-ups
- The optional `BrowserWindowInteraction` connector-link block kind was deferred (touches core interactions + connector/dashboard rendering) — tracked follow-up under #8887.
- Live browser scenario (real open→navigate→resolve) needs a live browser/model — code + deterministic unit tests complete; tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)