### PR TITLE
test(attachments): PR13 — video-recording lane + script for attachment journeys (#8876)

### DIFF
--- a/.github/workflows/attachment-journey-videos.yml
+++ b/.github/workflows/attachment-journey-videos.yml
@@ -1,0 +1,60 @@
+name: Attachment journey videos
+
+# Manual-only (workflow_dispatch): records full video runthroughs of the
+# attachment user journeys — the Files view (load + facets + CRUD affordances)
+# and the chat attachment upload flow — and uploads the .webm recordings +
+# traces + screenshots as artifacts (E2E_RECORD=1 → e2e-recordings/). Kept off
+# PR/develop CI to keep those runs fast; trigger from the Actions tab when a
+# journey video is wanted. Runs on top of the keyless ui-smoke stub stack
+# (no secrets), and the renderer build picks up @elizaos/core via the
+# core-build pre-step in run-ui-playwright.mjs.
+on:
+  workflow_dispatch:
+
+env:
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  attachment-journey-videos:
+    name: Attachment journey videos
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Record attachment journeys (Files view + chat attachment)
+        run: bun run --cwd packages/app test:e2e:record test/ui-smoke/files-view.spec.ts test/ui-smoke/chat-attachment.spec.ts --project=chromium
+
+      - name: Upload journey videos + traces
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: attachment-journey-videos
+          path: |
+            e2e-recordings/
+            packages/app/playwright-report/
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,6 +12,7 @@
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
+    "test:e2e:record": "E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "audit:app": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app",
     "test:desktop:packaged": "bunx playwright test --config playwright.electrobun.packaged.config.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",


### PR DESCRIPTION
Part of #8876 — delivers the **"video recordings of entire runthroughs of user journeys"** capability for the attachment surfaces.

- `packages/app` **`test:e2e:record`** script: `E2E_RECORD=1` over the ui-smoke config, so any spec(s) passed are recorded to `.webm` + trace + screenshots under `e2e-recordings/` (the playwright config already maps `E2E_RECORD` → `video: "on"`).
- **`.github/workflows/attachment-journey-videos.yml`**: a **workflow_dispatch (manual)** lane that records the Files-view + chat-attachment journeys and uploads the videos/traces as artifacts. Manual-only → never slows PR/develop CI; mirrors the scenario-pr app-browser job setup, keyless stub stack, on top of #8975.

**Verified locally:** `test:e2e:record test/ui-smoke/files-view.spec.ts` produced `video.webm` for both the desktop and mobile journeys (2/2 pass). package.json valid + workflow YAML valid + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)