### PR TITLE
feat(core): PR14 — shared connector attachment helpers (toMedia / contentTypeForMime / resolveAttachmentBytes) (#8876)

### DIFF
--- a/packages/core/src/connectors/attachments.test.ts
+++ b/packages/core/src/connectors/attachments.test.ts
@@ -1,0 +1,103 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+
+// Network-free: the SSRF-guarded fetcher is mocked so no real request is made.
+const fetchRemoteMedia = vi.fn();
+vi.mock("../media/fetch", async (importActual) => ({
+	...(await importActual<typeof import("../media/fetch")>()),
+	fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+const {
+	contentTypeForMime,
+	toMedia,
+	resolveAttachmentBytes,
+	DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+} = await import("./attachments");
+
+describe("contentTypeForMime", () => {
+	it("maps mime prefixes to the coarse ContentType", () => {
+		expect(contentTypeForMime("image/png")).toBe("image");
+		expect(contentTypeForMime("video/mp4")).toBe("video");
+		expect(contentTypeForMime("audio/ogg; codecs=opus")).toBe("audio");
+		expect(contentTypeForMime("application/pdf")).toBe("document");
+	});
+
+	it("defaults unknown/absent types to document", () => {
+		expect(contentTypeForMime(undefined)).toBe("document");
+		expect(contentTypeForMime(null)).toBe("document");
+		expect(contentTypeForMime("")).toBe("document");
+		expect(contentTypeForMime("application/octet-stream")).toBe("document");
+	});
+});
+
+describe("toMedia", () => {
+	it("normalizes a raw attachment with derived contentType + metadata", () => {
+		const m = toMedia({
+			id: 7,
+			url: "https://x/y.png",
+			mimeType: "image/png; charset=binary",
+			fileName: "y.png",
+			size: 123,
+			title: "pic",
+		});
+		expect(m).toMatchObject({
+			id: "7",
+			url: "https://x/y.png",
+			contentType: "image",
+			filename: "y.png",
+			size: 123,
+			title: "pic",
+			mimeType: "image/png",
+		});
+	});
+
+	it("falls back to the url for id and omits absent fields", () => {
+		const m = toMedia({ url: "https://x/doc" });
+		expect(m.id).toBe("https://x/doc");
+		expect(m.contentType).toBe("document");
+		expect(m.size).toBeUndefined();
+		expect(m.mimeType).toBeUndefined();
+		expect(m.filename).toBeUndefined();
+	});
+
+	it("uses idFallback when no id is supplied", () => {
+		expect(toMedia({ url: "u" }, { idFallback: "fb" }).id).toBe("fb");
+	});
+});
+
+describe("resolveAttachmentBytes", () => {
+	it("fetches via the SSRF-guarded fetcher with the default cap", async () => {
+		fetchRemoteMedia.mockResolvedValue({
+			buffer: Buffer.from("hi"),
+			contentType: "image/png",
+			fileName: "a.png",
+		});
+		const out = await resolveAttachmentBytes("https://x/a.png");
+		expect(fetchRemoteMedia).toHaveBeenCalledWith({
+			url: "https://x/a.png",
+			maxBytes: DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+		});
+		expect(out.contentType).toBe("image/png");
+		expect(out.fileName).toBe("a.png");
+		expect(out.buffer.toString()).toBe("hi");
+	});
+
+	it("defaults contentType when omitted and honors a custom maxBytes", async () => {
+		fetchRemoteMedia.mockResolvedValue({ buffer: Buffer.from("x") });
+		const out = await resolveAttachmentBytes("https://x/a", { maxBytes: 10 });
+		expect(fetchRemoteMedia).toHaveBeenCalledWith({
+			url: "https://x/a",
+			maxBytes: 10,
+		});
+		expect(out.contentType).toBe("application/octet-stream");
+		expect(out.fileName).toBeUndefined();
+	});
+
+	it("propagates SSRF/fetch failures", async () => {
+		fetchRemoteMedia.mockRejectedValue(new Error("blocked"));
+		await expect(
+			resolveAttachmentBytes("http://169.254.169.254/x"),
+		).rejects.toThrow("blocked");
+	});
+});

--- a/packages/core/src/connectors/attachments.ts
+++ b/packages/core/src/connectors/attachments.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared connector attachment helpers — the canonical, connector-agnostic way to
+ * (a) classify a platform attachment's MIME type into the coarse `ContentType`,
+ * (b) build a normalized `Media` from a connector's raw attachment shape, and
+ * (c) fetch attachment bytes safely (SSRF-guarded + size-capped).
+ *
+ * Every connector (Discord, Telegram, Slack, …) previously reimplemented these,
+ * often inconsistently (some set no `contentType`, some fetched with a raw,
+ * unguarded `fetch`). Connectors should import these instead. `contentTypeForMime`
+ * returns the literal `ContentType` string values (not the enum object) so it has
+ * no runtime dependency on the `ContentType` const and is safe to import from any
+ * package/runtime.
+ */
+
+import { fetchRemoteMedia } from "../media/fetch";
+import type { ContentType, Media } from "../types/primitives";
+
+/** Default hard cap on bytes pulled when resolving a connector attachment. */
+export const DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Map a platform attachment's MIME type to the coarse core `ContentType`.
+ * Returns the literal value so callers never touch the `ContentType` enum object.
+ */
+export function contentTypeForMime(mime?: string | null): ContentType {
+	const m = (mime ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+	if (m.startsWith("image/")) return "image";
+	if (m.startsWith("video/")) return "video";
+	if (m.startsWith("audio/")) return "audio";
+	return "document";
+}
+
+/** A connector's raw attachment, before normalization to {@link Media}. */
+export interface RawConnectorAttachment {
+	/** Platform attachment id (used as Media.id when present). */
+	id?: string | number;
+	/** A servable/fetchable URL for the bytes. */
+	url: string;
+	/** Platform-reported MIME type, if any. */
+	mimeType?: string | null;
+	/** Original filename, if any. */
+	fileName?: string | null;
+	/** Byte size, if known. */
+	size?: number | null;
+	/** Optional human title / description / extracted text. */
+	title?: string;
+	description?: string;
+	text?: string;
+}
+
+/**
+ * Normalize a connector's raw attachment into a `Media`, deriving `contentType`
+ * from the MIME type so audio/video are transcribed downstream and every
+ * attachment round-trips safely across connectors. Pass a default index to mint
+ * a stable id when the platform doesn't supply one.
+ */
+export function toMedia(
+	raw: RawConnectorAttachment,
+	opts?: { idFallback?: string },
+): Media {
+	const contentType = contentTypeForMime(raw.mimeType);
+	const media: Media = {
+		id: String(raw.id ?? opts?.idFallback ?? raw.url),
+		url: raw.url,
+		contentType,
+	};
+	if (raw.title) media.title = raw.title;
+	if (raw.description) media.description = raw.description;
+	if (raw.text) media.text = raw.text;
+	if (raw.fileName) media.filename = raw.fileName;
+	if (typeof raw.size === "number" && Number.isFinite(raw.size)) {
+		media.size = raw.size;
+	}
+	if (raw.mimeType) media.mimeType = raw.mimeType.split(";")[0]?.trim();
+	return media;
+}
+
+/** Bytes + resolved metadata for a connector attachment. */
+export interface ResolvedAttachmentBytes {
+	buffer: Buffer;
+	contentType: string;
+	fileName?: string;
+}
+
+/**
+ * Fetch a remote connector attachment's bytes through the SSRF-guarded fetcher
+ * (blocks private/loopback/link-local hosts) with a hard size cap. Use this for
+ * any inbound/outbound connector media fetch instead of a raw `fetch`.
+ */
+export async function resolveAttachmentBytes(
+	url: string,
+	opts?: { maxBytes?: number },
+): Promise<ResolvedAttachmentBytes> {
+	const { buffer, contentType, fileName } = await fetchRemoteMedia({
+		url,
+		maxBytes: opts?.maxBytes ?? DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES,
+	});
+	return {
+		buffer,
+		contentType: contentType ?? "application/octet-stream",
+		...(fileName ? { fileName } : {}),
+	};
+}

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -24,6 +24,7 @@ export * from "./cloud-routing";
 export * from "./connection";
 export * from "./connectors";
 export * from "./connectors/account-manager";
+export * from "./connectors/attachments";
 export * from "./connectors/connector-config";
 export * from "./connectors/oauth-role";
 export * from "./connectors/privacy";


### PR DESCRIPTION
Part of #8876. Connectors each reimplemented inbound→Media mapping (7+ times, inconsistently — some set no `contentType`, some fetched with a raw unguarded `fetch`). Adds the **canonical connector-agnostic helper** in `core/src/connectors/attachments.ts`:

- **`contentTypeForMime(mime)`** → coarse `ContentType`, returning literal string values (no dependency on the `ContentType` enum object → safe to import from any package/runtime).
- **`toMedia(raw)`** → a normalized `Media` (id/url/contentType + optional filename/size/mimeType/title/description/text) from a connector's raw attachment shape.
- **`resolveAttachmentBytes(url)`** → SSRF-guarded, size-capped fetch (via the core media fetcher) for any inbound/outbound connector media — the replacement for raw `fetch`.

Exported from the core barrel; connectors adopt these to kill the duplication and standardize SSRF/size handling (Telegram/Discord follow-ups — kept out of this PR to avoid the stale-core-dist resolution flakiness in plugin vitest; CI builds core first, so adoption lands cleanly there).

**Tests:** 8 keyless unit tests (mime mapping; toMedia normalization + fallbacks; resolve with default/custom cap, contentType default, failure propagation). core typecheck + Biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)