### PR TITLE
test(scenario): deterministic inbound-attachment flow on the mock-LLM lane (#8876)

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-inbound-attachment-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-inbound-attachment-actions.scenario.ts
@@ -1,0 +1,84 @@
+import { ModelType } from "@elizaos/core";
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { matchesScenarioInput } from "./_helpers/strict-llm-action-fixtures";
+
+// Deterministic INBOUND attachment coverage (#8876): a user message that
+// carries a `Media` attachment must flow end-to-end through a real AgentRuntime
+// under the mock (deterministic) LLM and produce a reply — i.e. an inbound
+// attachment never breaks the message pipeline. (Media GENERATION is covered by
+// deterministic-media-emote-actions.scenario.ts; the agent-facing read tool is
+// the core `ATTACHMENT` action, unit-tested in core.) The attachment is
+// surfaced into the agent's context with its stored-content hint, and the agent
+// replies. Runs keyless + strict under the deterministic LLM proxy.
+
+const noteText = "Project kickoff is Tuesday at 10am in room 4.";
+const noteDataUrl = `data:text/plain;base64,${Buffer.from(noteText).toString("base64")}`;
+const attachmentInput = "Take a look at the attached note and reply.";
+const replyText = "Thanks — I've got your attached note.";
+
+type RuntimeWithScenarioLlmFixtures = {
+  scenarioLlmFixtures?: {
+    register: (...fixtures: Array<Record<string, unknown>>) => void;
+  };
+};
+
+export default scenario({
+  id: "deterministic-inbound-attachment-actions",
+  lane: "pr-deterministic",
+  title:
+    "Deterministic inbound attachment flows through the pipeline to a reply",
+  domain: "scenario-runner",
+  tags: ["pr", "deterministic", "zero-cost", "attachments", "files"],
+  isolation: "shared-runtime",
+  seed: [
+    {
+      type: "custom",
+      name: "register the deterministic reply for the inbound attachment turn",
+      apply: (ctx) => {
+        const runtime = ctx.runtime as RuntimeWithScenarioLlmFixtures;
+        runtime.scenarioLlmFixtures?.register({
+          name: "inbound-attachment-direct-reply",
+          match: {
+            modelType: ModelType.TEXT_SMALL,
+            input: matchesScenarioInput(attachmentInput),
+          },
+          response: replyText,
+          times: "any",
+        });
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Inbound Attachment",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "user sends a text attachment and the agent replies",
+      text: attachmentInput,
+      content: {
+        attachments: [
+          {
+            id: "note-1",
+            url: noteDataUrl,
+            contentType: "document",
+            title: "note.txt",
+            mimeType: "text/plain",
+            text: noteText,
+          },
+        ],
+      },
+      responseIncludesAny: [replyText],
+      assertTurn: (execution: ScenarioTurnExecution) =>
+        execution.responseText && execution.responseText.length > 0
+          ? undefined
+          : "expected a non-empty reply to the attachment message",
+    },
+  ],
+});


### PR DESCRIPTION
Part of #8876. Adds a **pr-deterministic** scenario proving an **inbound attachment** flows through a real `AgentRuntime` under the **mock (deterministic) LLM proxy** and produces a reply — an attachment-bearing user message never breaks the message pipeline.

This is the "we use the mock LLM provider with perfect LLM calls for everything" lane the issue explicitly asks for, applied to attachment handling.

- The turn carries a text/document `Media` attachment; the runtime surfaces it into the agent context with its stored-content hint (`ATTACHMENT action=read`), and the agent replies.
- A single deterministic reply fixture keeps it **strict-green and keyless**.
- Complements existing coverage: media **generation** → `deterministic-media-emote-actions`; the agent-facing **read tool** (core `ATTACHMENT` action) → unit-tested in core.

**Verified:** passes twice, strict + keyless (`SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source ... run --scenario deterministic-inbound-attachment-actions`, ~680ms, deterministic). Biome clean.

> Real-LLM counterpart: the same flow with provider keys (live lane) — out of scope for the keyless PR lane, which is exactly why this belongs on `pr-deterministic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)