### PR TITLE
feat(chat): inline 3D model preview for .glb/.gltf attachments (#8876)

### DIFF
--- a/packages/ui/src/components/chat/MessageAttachments.stories.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.stories.tsx
@@ -126,16 +126,19 @@ export const Document: Story = {
 };
 
 /**
- * 3D model — currently surfaces as a downloadable file card (inline
- * model-viewer rendering is deferred; the bytes remain viewable/accessible via
- * download), so a generated/uploaded .glb is never walled off.
+ * 3D model (.glb/.gltf) → inline WebGL viewer (three.js, lazily loaded,
+ * auto-framed + auto-rotating) with a download affordance in the header. When
+ * WebGL is unavailable or the model can't load, it degrades to a download card
+ * so the bytes are never walled off. This story uses a served-relative URL that
+ * resolves to a fast 404 in headless/Storybook, so it deterministically renders
+ * the download fallback (the live 3D render needs a real model + GPU).
  */
 export const Model3D: Story = {
   args: {
     attachments: [
       att({
         id: "model",
-        url: "https://example.com/scene.glb",
+        url: `/api/media/${HASH}.glb`,
         contentType: "document",
         title: "scene.glb",
       }),

--- a/packages/ui/src/components/chat/MessageAttachments.test.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.test.tsx
@@ -144,6 +144,26 @@ describe("attachmentPreviewKind", () => {
     ).toBe("code");
   });
 
+  it("maps 3D models from extension and mime (before text/code)", () => {
+    expect(attachmentPreviewKind(make({ url: "https://x/scene.glb" }))).toBe(
+      "model3d",
+    );
+    expect(
+      attachmentPreviewKind(make({ url: "https://x/scene.gltf?v=2#a" })),
+    ).toBe("model3d");
+    expect(
+      attachmentPreviewKind(
+        make({ url: "https://x/blob", mimeType: "model/gltf-binary" }),
+      ),
+    ).toBe("model3d");
+    // A .gltf is JSON text, but it must still preview as a model, not as code.
+    expect(
+      attachmentPreviewKind(
+        make({ url: "https://x/scene.gltf", text: '{"asset":{}}' }),
+      ),
+    ).toBe("model3d");
+  });
+
   it("falls back to file for unknown / binary documents", () => {
     expect(attachmentPreviewKind(make({ url: "https://x/archive.zip" }))).toBe(
       "file",
@@ -197,6 +217,29 @@ describe("MessageAttachments — PDF + text/code previews", () => {
     expect(card.getAttribute("href")).toBe(
       "data:application/pdf;base64,JVBERi0=",
     );
+  });
+
+  it("renders the 3D tile, degrading to a download fallback without WebGL (jsdom)", async () => {
+    // jsdom has no WebGL context, so the model tile must surface its
+    // download-to-view fallback rather than throwing — the bytes stay reachable.
+    render(
+      <MessageAttachments
+        attachments={[
+          {
+            id: "model",
+            url: "https://x/scene.glb",
+            contentType: "document",
+            title: "scene.glb",
+          },
+        ]}
+      />,
+    );
+    // The tile chrome (with a download affordance) is always present.
+    expect(screen.getByTestId("model3d-attachment")).not.toBeNull();
+    // The WebGL probe runs in an effect; the fallback appears once it bails.
+    const fallback = await screen.findByTestId("model3d-attachment-fallback");
+    expect(fallback.getAttribute("href")).toBe("https://x/scene.glb");
+    expect(fallback.getAttribute("download")).toMatch(/\.glb$/);
   });
 
   it("renders inline CodeBlock content when att.text is present", () => {

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Code2,
   Download,
   ExternalLink,
@@ -136,7 +137,10 @@ const CODE_EXT = new RegExp(
  *   - `"code"` → inline {@link CodeBlock} when `att.text` exists, else a card
  *   - `"file"` → generic download/open card (the previous default)
  */
-export type AttachmentPreviewKind = "pdf" | "code" | "file";
+export type AttachmentPreviewKind = "pdf" | "model3d" | "code" | "file";
+
+/** glTF binary/text 3D model extensions. */
+const MODEL3D_EXT = /\.(?:glb|gltf)(?:[?#]|$)/i;
 
 /** The lower-cased path of an attachment URL (no query/hash), or "" for data: URLs. */
 function attachmentPath(url: string): string {
@@ -170,6 +174,17 @@ export function attachmentPreviewKind(
     url.trim().toLowerCase().startsWith("data:application/pdf")
   ) {
     return "pdf";
+  }
+
+  // 3D model: a model/* MIME, a .glb/.gltf URL, or a data:model/* payload.
+  // Checked before text/code so a .gltf (JSON) with extracted text still
+  // previews as a model, not as code.
+  if (
+    mime.startsWith("model/") ||
+    MODEL3D_EXT.test(path) ||
+    url.trim().toLowerCase().startsWith("data:model/")
+  ) {
+    return "model3d";
   }
 
   // Text/code: a text-* MIME, a known code/text extension, an inline
@@ -239,7 +254,9 @@ function downloadName(att: MessageAttachment, kind: string): string {
             ? "pdf"
             : kind === "code"
               ? "txt"
-              : "bin";
+              : kind === "model3d"
+                ? "glb"
+                : "bin";
   return `${att.id || "attachment"}.${ext}`;
 }
 
@@ -482,6 +499,188 @@ function PdfTile({
         sandbox="allow-same-origin"
         className="block h-[28rem] w-full border-0 bg-white"
       />
+    </figure>
+  );
+}
+
+/** Whether a (scheme-safe) model URL can be inlined in the WebGL viewer. */
+function isInlineableModelUrl(rawUrl: string): boolean {
+  const u = rawUrl.trim().toLowerCase();
+  if (!u) return false;
+  // data: URLs are not inlined (can be huge; keep parity with the PDF tile) —
+  // they degrade to a download card.
+  if (u.startsWith("data:")) return false;
+  return true;
+}
+
+type Model3dStatus = "loading" | "ready" | "error" | "unsupported";
+
+/**
+ * Inline 3D model preview (#8876). For an inlinable, scheme-safe `.glb`/`.gltf`
+ * URL, lazily loads three.js + GLTFLoader, auto-frames the model to its bounding
+ * box, and renders it in an auto-rotating WebGL canvas. Every failure mode —
+ * no WebGL (jsdom / headless without GL), a `data:` URL, a load/parse error —
+ * degrades to the same download card, so the bytes are never walled off. three
+ * is imported on demand so it never ships in the always-loaded chat bundle.
+ */
+function Model3dTile({
+  att,
+  src,
+  t,
+}: {
+  att: MessageAttachment;
+  src: string;
+  t: (key: string, values?: Record<string, unknown>) => string;
+}): React.JSX.Element {
+  const label = attachmentLabel(att);
+  const inlineable = isInlineableModelUrl(att.url);
+  const mountRef = React.useRef<HTMLDivElement | null>(null);
+  const [status, setStatus] = React.useState<Model3dStatus>(
+    inlineable ? "loading" : "unsupported",
+  );
+
+  React.useEffect(() => {
+    if (!inlineable) return;
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    // WebGL capability probe — bail to the download fallback when unavailable
+    // (jsdom, headless without GL) rather than throwing.
+    const probe = document.createElement("canvas");
+    const gl = probe.getContext("webgl2") ?? probe.getContext("webgl") ?? null;
+    if (!gl) {
+      setStatus("unsupported");
+      return;
+    }
+
+    let disposed = false;
+    let frame = 0;
+    // biome-ignore lint/suspicious/noExplicitAny: three is loaded dynamically.
+    let renderer: any = null;
+
+    (async () => {
+      try {
+        const THREE = await import("three");
+        const { GLTFLoader } = await import(
+          "three/addons/loaders/GLTFLoader.js"
+        );
+        if (disposed || !mountRef.current) return;
+        const host = mountRef.current;
+        const width = host.clientWidth || 320;
+        const height = 288;
+
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(
+          45,
+          width / height,
+          0.1,
+          1000,
+        );
+        renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+        renderer.setSize(width, height);
+        renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 2));
+        host.appendChild(renderer.domElement);
+
+        scene.add(new THREE.AmbientLight(0xffffff, 0.9));
+        const key = new THREE.DirectionalLight(0xffffff, 1.1);
+        key.position.set(3, 5, 4);
+        scene.add(key);
+
+        const gltf = await new GLTFLoader().loadAsync(src);
+        if (disposed) {
+          renderer.dispose?.();
+          return;
+        }
+        const model = gltf.scene;
+
+        // Auto-frame: center the model and pull the camera back to fit it.
+        const box = new THREE.Box3().setFromObject(model);
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        model.position.sub(center);
+        const radius = Math.max(size.x, size.y, size.z, 0.001) / 2;
+        const dist = radius / Math.sin((camera.fov * Math.PI) / 360);
+        camera.position.set(0, radius * 0.4, dist * 1.5);
+        camera.lookAt(0, 0, 0);
+        scene.add(model);
+
+        const animate = () => {
+          if (disposed) return;
+          model.rotation.y += 0.01;
+          renderer.render(scene, camera);
+          frame = requestAnimationFrame(animate);
+        };
+        setStatus("ready");
+        animate();
+      } catch {
+        if (!disposed) setStatus("error");
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (frame) cancelAnimationFrame(frame);
+      try {
+        renderer?.domElement?.remove();
+        renderer?.dispose?.();
+      } catch {
+        // best-effort teardown
+      }
+    };
+  }, [inlineable, src]);
+
+  const downloadLabel = t("messageattachments.download");
+  const showFallbackBody = status === "unsupported" || status === "error";
+
+  return (
+    <figure
+      data-testid="model3d-attachment"
+      aria-label={label}
+      className="m-0 w-full max-w-[min(28rem,100%)] overflow-hidden rounded-xl border border-white/12 bg-white/[0.04]"
+    >
+      <figcaption className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+        <Box className="h-4 w-4 shrink-0 text-white/70" />
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/90">
+          {label}
+        </span>
+        <span className="flex shrink-0 gap-1.5">
+          <TileButton
+            label={downloadLabel}
+            href={src}
+            download={downloadName(att, "model3d")}
+          >
+            <Download className="h-3.5 w-3.5" />
+          </TileButton>
+        </span>
+      </figcaption>
+      {showFallbackBody ? (
+        <a
+          href={src}
+          target="_blank"
+          rel="noreferrer"
+          download={downloadName(att, "model3d")}
+          data-testid="model3d-attachment-fallback"
+          className="flex items-center gap-2.5 px-3 py-3 text-white/85 transition-colors hover:bg-white/[0.08]"
+        >
+          <Box className="h-5 w-5 shrink-0 text-white/60" />
+          <span className="min-w-0 flex-1 text-[12px] text-white/60">
+            {t("messageattachments.model3dDownloadToView")}
+          </span>
+          <Download className="h-4 w-4 shrink-0 text-white/55" />
+        </a>
+      ) : (
+        <div
+          ref={mountRef}
+          data-testid="model3d-canvas"
+          className="relative h-72 w-full bg-black/40"
+        >
+          {status === "loading" ? (
+            <span className="absolute inset-0 flex items-center justify-center text-[12px] text-white/60">
+              {t("messageattachments.model3dLoading")}
+            </span>
+          ) : null}
+        </div>
+      )}
     </figure>
   );
 }
@@ -805,6 +1004,9 @@ export function MessageAttachments({
               const previewKind = attachmentPreviewKind(att);
               if (previewKind === "pdf") {
                 return <PdfTile key={att.id} att={att} src={src} t={t} />;
+              }
+              if (previewKind === "model3d") {
+                return <Model3dTile key={att.id} att={att} src={src} t={t} />;
               }
               if (previewKind === "code") {
                 return <CodeTile key={att.id} att={att} src={src} t={t} />;

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7464,5 +7464,7 @@
   "messageattachments.pdfPreviewTitle": "PDF preview: {{name}}",
   "messageattachments.codePreviewTitle": "Text preview: {{name}}",
   "messageattachments.pdfLabel": "PDF",
-  "messageattachments.textLabel": "Text"
+  "messageattachments.textLabel": "Text",
+  "messageattachments.model3dLoading": "Loading 3D model",
+  "messageattachments.model3dDownloadToView": "3D preview unavailable here. Download to view."
 }


### PR DESCRIPTION
Part of #8876. Upgrades 3D-model attachments from a download-only card to an **inline preview**, so "previews of everything" finally covers 3D too — without walling off the bytes.

- **`attachmentPreviewKind`**: new `model3d` kind from a `model/*` MIME, a `.glb`/`.gltf` URL, or a `data:model/*` payload. Checked **before** text/code so a `.gltf` (which is JSON) still previews as a model, not as code.
- **`Model3dTile`**: lazily imports three.js + GLTFLoader (three never ships in the always-loaded chat bundle), auto-frames the model to its bounding box, and renders it in an auto-rotating WebGL canvas with a download affordance in the header. **Every** failure mode — no WebGL (jsdom/headless), a non-inlinable URL, a load/parse error — degrades to the same download card, so the model is always reachable.
- **i18n**: two new `en` keys; other locales fall back.

## Evidence
- **14/14** `MessageAttachments` tests pass: detection maps `.glb`/`.gltf`/`model/*`/`data:model` → `model3d` (incl. a `.gltf` with extracted text, which must not fall to the code preview); the tile renders its chrome and, with no WebGL in jsdom, surfaces the **download fallback** (href = model url, download `*.glb`) rather than throwing.
- ui **typecheck** + **Biome** clean (the dynamic `three`/`three/addons` imports resolve).
- Story renders the deterministic download fallback (served-relative URL → fast 404 in headless).

> The live WebGL render (a real model in a GPU browser) is delegated to three's mature GLTFLoader. jsdom verifies detection + graceful fallback; the live render warrants a device eyeball for final visual sign-off — called out honestly rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)