### PR TITLE
feat(slack): send agent attachments on outbound (fixes silent drop) (#8876)

### DIFF
--- a/plugins/plugin-slack/src/outbound-attachments.test.ts
+++ b/plugins/plugin-slack/src/outbound-attachments.test.ts
@@ -1,0 +1,141 @@
+import { Buffer } from "node:buffer";
+import type { Media } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { SlackService } from "./service";
+
+// Outbound media coverage for the Slack connector (#8876). Slack's API takes
+// file BYTES (not a URL), so agent `Media` attachments are fetched through the
+// SSRF-guarded fetcher and uploaded via uploadFile. We stub the (instance)
+// fetch wrapper + uploadFile so the test runs offline and exercises only the
+// new send-outbound-attachments logic.
+
+type TestService = SlackService & {
+  sendOutboundAttachments: (
+    channelId: string,
+    attachments: Media[],
+    threadTs: string | undefined,
+    accountId: string | null,
+  ) => Promise<void>;
+  fetchAttachmentBytes: ReturnType<typeof vi.fn>;
+  uploadFile: ReturnType<typeof vi.fn>;
+};
+
+function createService(): TestService {
+  const runtime = {
+    agentId: "agent-1",
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+  const service = Object.create(SlackService.prototype) as TestService;
+  Object.assign(service, { runtime });
+  service.fetchAttachmentBytes = vi.fn(async () => ({
+    buffer: Buffer.from("bytes"),
+    fileName: "fetched.png",
+    contentType: "image/png",
+  }));
+  service.uploadFile = vi.fn(async () => ({ fileId: "F1", permalink: "p" }));
+  return service;
+}
+
+function media(over: Partial<Media>): Media {
+  return { id: "m", url: "https://cdn.example.com/cat.png", ...over } as Media;
+}
+
+describe("Slack outbound attachments", () => {
+  it("fetches each attachment's bytes and uploads it to the channel", async () => {
+    const service = createService();
+    await service.sendOutboundAttachments(
+      "C123",
+      [media({ id: "img", contentType: "image", title: "cat.png" })],
+      "111.222",
+      "default",
+    );
+
+    expect(service.fetchAttachmentBytes).toHaveBeenCalledWith(
+      "https://cdn.example.com/cat.png",
+    );
+    expect(service.uploadFile).toHaveBeenCalledTimes(1);
+    expect(service.uploadFile).toHaveBeenCalledWith(
+      "C123",
+      expect.any(Buffer),
+      "cat.png",
+      { title: "cat.png", threadTs: "111.222" },
+      "default",
+    );
+  });
+
+  it("uploads multiple attachments", async () => {
+    const service = createService();
+    await service.sendOutboundAttachments(
+      "C1",
+      [
+        media({ id: "a", url: "https://x/a.png" }),
+        media({ id: "b", url: "https://x/b.pdf" }),
+      ],
+      undefined,
+      null,
+    );
+    expect(service.uploadFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("derives the filename: filename > title > fetched name", async () => {
+    const service = createService();
+    await service.sendOutboundAttachments(
+      "C1",
+      [media({ id: "x", url: "https://x/blob", filename: "explicit.glb" })],
+      undefined,
+      null,
+    );
+    expect(service.uploadFile).toHaveBeenCalledWith(
+      "C1",
+      expect.any(Buffer),
+      "explicit.glb",
+      expect.anything(),
+      null,
+    );
+
+    const service2 = createService();
+    await service2.sendOutboundAttachments(
+      "C1",
+      [media({ id: "y", url: "https://x/blob" })], // no filename/title
+      undefined,
+      null,
+    );
+    // Falls back to the name returned by the fetcher.
+    expect(service2.uploadFile).toHaveBeenCalledWith(
+      "C1",
+      expect.any(Buffer),
+      "fetched.png",
+      expect.anything(),
+      null,
+    );
+  });
+
+  it("swallows a fetch failure (warns) and still uploads the rest", async () => {
+    const service = createService();
+    service.fetchAttachmentBytes = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ssrf blocked"))
+      .mockResolvedValueOnce({ buffer: Buffer.from("ok"), fileName: "ok.png" });
+
+    await expect(
+      service.sendOutboundAttachments(
+        "C1",
+        [
+          media({ id: "bad", url: "http://169.254.169.254/x" }),
+          media({ id: "good", url: "https://x/ok.png" }),
+        ],
+        undefined,
+        null,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(service.uploadFile).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        service as unknown as {
+          runtime: { logger: { warn: ReturnType<typeof vi.fn> } };
+        }
+      ).runtime.logger.warn,
+    ).toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -14,6 +14,7 @@ import {
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   type Room,
+  resolveAttachmentBytes,
   Service,
   stringToUuid,
   type TargetInfo,
@@ -1956,8 +1957,13 @@ export class SlackService extends Service implements ISlackService {
     }
 
     const text = typeof content.text === "string" ? content.text.trim() : "";
-    if (!text) {
-      throw new Error("Slack SendHandler requires non-empty text content.");
+    const outboundAttachments = Array.isArray(content.attachments)
+      ? content.attachments.filter((media) => Boolean(media?.url))
+      : [];
+    if (!text && outboundAttachments.length === 0) {
+      throw new Error(
+        "Slack SendHandler requires non-empty text or at least one attachment.",
+      );
     }
 
     let channelId = target.channelId;
@@ -1996,20 +2002,82 @@ export class SlackService extends Service implements ISlackService {
       );
     }
 
-    await this.sendMessage(
-      channelId,
-      text,
-      {
+    if (text) {
+      await this.sendMessage(
+        channelId,
+        text,
+        {
+          threadTs,
+          replyBroadcast: undefined,
+          unfurlLinks: undefined,
+          unfurlMedia: undefined,
+          mrkdwn: undefined,
+          attachments: undefined,
+          blocks: undefined,
+        },
+        accountId,
+      );
+    }
+
+    if (outboundAttachments.length > 0) {
+      await this.sendOutboundAttachments(
+        channelId,
+        outboundAttachments,
         threadTs,
-        replyBroadcast: undefined,
-        unfurlLinks: undefined,
-        unfurlMedia: undefined,
-        mrkdwn: undefined,
-        attachments: undefined,
-        blocks: undefined,
-      },
-      accountId,
-    );
+        accountId,
+      );
+    }
+  }
+
+  /**
+   * Fetch an attachment's bytes through the SSRF-guarded media fetcher. Wrapped
+   * as an instance method so it can be stubbed in unit tests without mocking the
+   * whole runtime/network stack.
+   */
+  protected async fetchAttachmentBytes(
+    url: string,
+  ): Promise<{ buffer: Buffer; fileName?: string; contentType?: string }> {
+    return resolveAttachmentBytes(url);
+  }
+
+  /**
+   * Upload agent-generated `Media` attachments to a Slack channel (#8876).
+   * Slack's API takes file BYTES (not a URL), so each attachment is fetched
+   * through the SSRF-guarded fetcher and uploaded via {@link uploadFile}. Each
+   * upload is isolated in try/catch so a single unreachable/oversized URL logs a
+   * warning and never drops the rest of the reply (the text already went out).
+   */
+  private async sendOutboundAttachments(
+    channelId: string,
+    attachments: Media[],
+    threadTs: string | undefined,
+    accountId: string | null,
+  ): Promise<void> {
+    for (const media of attachments) {
+      if (!media.url) continue;
+      try {
+        const { buffer, fileName } = await this.fetchAttachmentBytes(media.url);
+        const filename =
+          media.filename ?? media.title ?? fileName ?? "attachment";
+        await this.uploadFile(
+          channelId,
+          buffer,
+          filename,
+          { title: media.title, threadTs },
+          accountId,
+        );
+      } catch (error) {
+        this.runtime.logger.warn(
+          {
+            src: "plugin:slack",
+            agentId: this.runtime.agentId,
+            url: media.url,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Failed to send Slack outbound attachment; skipping",
+        );
+      }
+    }
   }
 
   async resolveConnectorTargets(


### PR DESCRIPTION
Part of #8876, fixes the Slack half of #8990. **Slack was silently dropping agent-generated attachments** on outbound — `handleSendMessage` sent only text and passed `attachments: undefined`, unlike Discord (#8986) and Telegram (#8989). It also threw on empty text, so attachment-only replies failed.

## Fix
- Wire `content.attachments` through `handleSendMessage`. Slack's API takes file **bytes** (not a URL), so each attachment is fetched via the **SSRF-guarded** `resolveAttachmentBytes` (`@elizaos/core`) and uploaded with the existing `uploadFile()` (`files.uploadV2`). Filename precedence: `media.filename` → `title` → fetched name.
- Allow **attachment-only** replies (require text **or** ≥1 attachment); only post text when non-empty.
- Each upload is isolated in try/catch — an unreachable/blocked/oversized URL logs a warning and never drops the rest of the reply or the text. Strictly better than the previous silent drop (**no regression**).

The byte-fetch sits behind a spyable instance method so the new logic is unit-tested without a live Slack/network.

## Evidence
- 4 new outbound-attachment tests (fetch→upload, multiple, filename precedence, failure-swallowed-and-continues) + **full plugin suite 25/25**.
- `slack typecheck` exit 0; Biome clean.

> Live upload against a real Slack workspace is the one remaining check (the unit test verifies the wiring; the live call needs creds) — tracked in #8990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)