### PR TITLE
test(scenario): real-LLM (live lane) inbound-attachment validation (#8876)

### DIFF
--- a/packages/scenario-runner/test/scenarios/live-inbound-attachment.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-inbound-attachment.scenario.ts
@@ -1,0 +1,56 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+// Real-LLM (live lane) counterpart of deterministic-inbound-attachment-actions
+// (#8876). Same inbound-attachment flow, but routed through a REAL model with no
+// fixtures: the agent must read the attached note's content and reflect it back.
+// Runs only in the credentialed live lane (needs provider keys); the keyless PR
+// lane runs the deterministic version. The "we ALSO test/validate with a real
+// LLM" requirement — turnkey: it executes as soon as model keys are present.
+
+const noteText = "Project kickoff is Tuesday at 10am in room 4.";
+const noteDataUrl = `data:text/plain;base64,${Buffer.from(noteText).toString("base64")}`;
+
+export default scenario({
+  lane: "live-only",
+  id: "live-inbound-attachment",
+  title: "Real LLM reads and summarizes an inbound text attachment",
+  domain: "attachments",
+  tags: ["live", "real-llm", "attachments", "files"],
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Inbound Attachment (live)",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "summarize the attached note",
+      room: "main",
+      text: "Read the attached note and tell me the key details.",
+      content: {
+        attachments: [
+          {
+            id: "note-1",
+            url: noteDataUrl,
+            contentType: "document",
+            title: "note.txt",
+            mimeType: "text/plain",
+            text: noteText,
+          },
+        ],
+      },
+      // A capable model that actually consumed the attachment will surface at
+      // least one concrete detail from it.
+      responseIncludesAny: ["kickoff", "Tuesday", "10", "room 4", "room"],
+      responseJudge: {
+        minimumScore: 0.6,
+        rubric:
+          "The reply must reflect the content of the attached note (a project kickoff on Tuesday at 10am in room 4), naming at least one concrete detail from it. A generic reply that ignores the attachment's content fails.",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Part of #8876. Adds the **real-LLM** counterpart of the deterministic inbound-attachment scenario (#8987): the same flow, routed through a **real model with no fixtures** — the agent must read the attached note and reflect a concrete detail back, scored by the LLM judge. This is the "we ALSO test, validate, verify and optimize everything with **real LLM**" requirement, made **turnkey**: it runs the moment provider keys are present.

- `lane: "live-only"` → runs only in the credentialed live lane; the keyless PR lane keeps running the deterministic version, so **PR CI is unaffected**.
- Assertions are model-agnostic-but-meaningful: `responseIncludesAny` on concrete note details + a `responseJudge` rubric requiring the reply to reflect the attachment's content (a generic reply that ignores it fails).

## Evidence (keyless, here)
- `list --lane live-only` **discovers** the scenario.
- `list --lane pr-deterministic` **excludes** it (count 0) → cannot break the keyless PR lane.
- Biome clean; mirrors the verified deterministic sibling's structure.

> The judged live run needs model keys by definition of the lane — that's the one part a keyless environment can't execute. With keys (locally or in the live CI lane) it runs as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)