### PR TITLE
fix(training): import registerDetailExtension from the @elizaos/ui barrel (#8876)

### DIFF
--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -23,8 +23,7 @@ import type {
   TrainingTrajectoryList,
 } from "@elizaos/ui/api";
 import { client } from "@elizaos/ui/api";
-import { Button } from "@elizaos/ui/components";
-import { registerDetailExtension } from "@elizaos/ui/components/apps/extensions/registry";
+import { Button, registerDetailExtension } from "@elizaos/ui/components";
 import type { AppDetailExtensionProps } from "@elizaos/ui/components/apps/extensions/types";
 import { useIntervalWhenDocumentVisible } from "@elizaos/ui/hooks";
 import { ContentLayout } from "@elizaos/ui/layouts";


### PR DESCRIPTION
The view-bundle host cannot rewrite deep `@elizaos/ui/components/apps/extensions/registry` specifiers, so `build-views` **failed** (exit 1):

```
✗ plugin-training: @elizaos/ui/components/apps/extensions/registry
[build-views] Import these from a host-provided specifier (e.g. the `@elizaos/ui/components` barrel) instead of a deep subpath.
```

`registerDetailExtension` is re-exported from the `@elizaos/ui/components` barrel (`components/index.ts:166`), so this imports it from there. This **unblocks `build-views` for the whole workspace** — it was aborting the entire plugin-view build, which also gates the ui-smoke live-stack's plugin views (e.g. the orchestrator task widget used by the chat task-widget journey).

**Verified:** `node packages/scripts/build-views.mjs` now exits **0** (was 1); the plugin-training view bundle builds; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)