### PR TITLE
feat(farcaster): send agent attachments as cast embeds (fixes silent drop) (#8876)

### DIFF
--- a/plugins/plugin-farcaster/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-farcaster/__tests__/outbound-media.test.ts
@@ -1,0 +1,110 @@
+import type { Content, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { FarcasterCastService } from "../services/CastService";
+
+// Outbound media coverage for the Farcaster connector (#8876). Agent-generated
+// `Media` attachments must ride along as Farcaster cast EMBEDS (url-based), which
+// the send path previously dropped (handleSendPost ignored content.attachments
+// and createCast's `media` param was dead). Mocked Neynar client → runs offline.
+
+const agentId = "00000000-0000-0000-0000-000000000001" as const;
+
+function runtime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    agentId,
+    character: { settings: {} },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: vi.fn((key: string) => settings[key] ?? null),
+    createMemory: vi.fn(),
+    useModel: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function neynarCast(text: string) {
+  return {
+    hash: "0xabc123",
+    thread_hash: "0xabc123",
+    text,
+    timestamp: new Date(1_700_000_000_000).toISOString(),
+    author: { fid: 1, display_name: "Eliza", username: "eliza" },
+  };
+}
+
+function client() {
+  return {
+    getTimeline: vi.fn(async () => ({ timeline: [] })),
+    sendCast: vi.fn(async ({ content }: { content: Content }) => [
+      neynarCast(typeof content.text === "string" ? content.text : ""),
+    ]),
+  };
+}
+
+const ACCOUNT = "brand";
+
+describe("Farcaster outbound media (embeds)", () => {
+  it("sends agent attachments as cast embeds", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const service = new FarcasterCastService(testClient as never, rt, ACCOUNT);
+
+    await service.handleSendPost(rt, {
+      text: "here's the image",
+      accountId: ACCOUNT,
+      attachments: [
+        { id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" },
+        { id: "vid", url: "https://cdn.example.com/clip.mp4", contentType: "video" },
+      ],
+    } as Content);
+
+    expect(testClient.sendCast).toHaveBeenCalledTimes(1);
+    expect(testClient.sendCast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: ["https://cdn.example.com/cat.png", "https://cdn.example.com/clip.mp4"],
+      })
+    );
+  });
+
+  it("sends a text-only post without embeds (no regression)", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const service = new FarcasterCastService(testClient as never, rt, ACCOUNT);
+
+    await service.handleSendPost(rt, {
+      text: "just text",
+      accountId: ACCOUNT,
+    } as Content);
+
+    expect(testClient.sendCast).toHaveBeenCalledTimes(1);
+    const arg = testClient.sendCast.mock.calls[0][0] as { embeds?: string[] };
+    expect(arg.embeds).toBeUndefined();
+  });
+
+  it("allows an attachment-only post (no text) instead of rejecting", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const service = new FarcasterCastService(testClient as never, rt, ACCOUNT);
+
+    await service.handleSendPost(rt, {
+      text: "",
+      accountId: ACCOUNT,
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(testClient.sendCast).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: ["https://cdn.example.com/cat.png"] })
+    );
+    // Media-only post must NOT auto-generate prose.
+    expect(rt.useModel).not.toHaveBeenCalled();
+  });
+
+  it("still rejects a blank post with neither text nor attachments", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const service = new FarcasterCastService(testClient as never, rt, ACCOUNT);
+
+    await expect(
+      service.handleSendPost(rt, { text: "   ", accountId: ACCOUNT } as Content)
+    ).rejects.toThrow("requires non-empty text");
+    expect(testClient.sendCast).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-farcaster/client/FarcasterClient.ts
+++ b/plugins/plugin-farcaster/client/FarcasterClient.ts
@@ -69,35 +69,66 @@ export class FarcasterClient {
   async sendCast({
     content,
     inReplyTo,
+    embeds,
   }: {
     content: Content;
     inReplyTo?: CastId;
+    /** Media URLs to attach as Farcaster cast embeds (#8876). */
+    embeds?: string[];
   }): Promise<NeynarCast[]> {
     const text = (content.text ?? "").trim();
-    if (text.length === 0) {
+    const mediaEmbeds = (embeds ?? []).filter(
+      (url) => typeof url === "string" && url.trim().length > 0
+    );
+    // An embeds-only cast (media with no prose) is valid; only bail when there
+    // is neither text nor media to send.
+    if (text.length === 0 && mediaEmbeds.length === 0) {
       return [];
     }
 
-    const chunks = splitPostContent(text);
+    const chunks = text.length > 0 ? splitPostContent(text) : [""];
     const sent: NeynarCast[] = [];
 
-    for (const chunk of chunks) {
-      const result = await this.publishCast(chunk, inReplyTo);
+    for (let i = 0; i < chunks.length; i++) {
+      // Attach the embeds once, on the first cast in the thread.
+      const result = await this.publishCast(
+        chunks[i],
+        inReplyTo,
+        i === 0 ? mediaEmbeds : undefined
+      );
       sent.push(result);
     }
     return sent;
   }
 
-  private async publishCast(cast: string, parentCastId?: CastId): Promise<NeynarCast> {
+  private async publishCast(
+    cast: string,
+    parentCastId?: CastId,
+    embeds?: string[]
+  ): Promise<NeynarCast> {
     try {
       const result = await logNeynarCall(
         "publishCast",
-        { textLen: cast.length, parentHash: parentCastId?.hash ?? null },
+        {
+          textLen: cast.length,
+          parentHash: parentCastId?.hash ?? null,
+          embedCount: embeds?.length ?? 0,
+        },
         async () =>
           this.neynar.publishCast({
             signerUuid: this.signerUuid,
             text: cast,
             parent: parentCastId?.hash,
+            // Neynar's embed type is a loose union; a url-only embed is valid at
+            // runtime (the documented image/link embed) but the SDK types want
+            // the cast_id variant's fields too — cast at this SDK boundary.
+            ...(embeds && embeds.length > 0
+              ? {
+                  embeds: embeds.map((url) => ({ url })) as unknown as Parameters<
+                    NeynarAPIClient["publishCast"]
+                  >[0]["embeds"],
+                }
+              : {}),
           })
       );
       if (result.success) {

--- a/plugins/plugin-farcaster/services/CastService.ts
+++ b/plugins/plugin-farcaster/services/CastService.ts
@@ -120,8 +120,13 @@ export class FarcasterCastService implements CastServiceInterface {
   }): Promise<FarcasterCast> {
     try {
       let castText = params.text;
+      const media = (params.media ?? []).filter(
+        (url) => typeof url === "string" && url.trim().length > 0
+      );
 
-      if (!castText || castText.trim() === "") {
+      // Only auto-generate prose when there is neither text nor media — a
+      // media-only cast is a valid (embeds-only) post.
+      if ((!castText || castText.trim() === "") && media.length === 0) {
         castText = await this.generateCastContent();
       }
 
@@ -134,6 +139,7 @@ export class FarcasterCastService implements CastServiceInterface {
         inReplyTo: params.replyTo
           ? { hash: params.replyTo.hash, fid: params.replyTo.fid }
           : undefined,
+        ...(media.length > 0 ? { embeds: media } : {}),
       });
 
       if (casts.length === 0) {
@@ -150,7 +156,7 @@ export class FarcasterCastService implements CastServiceInterface {
         text: cast.text,
         timestamp: cast.timestamp.getTime(),
         inReplyTo: params.replyTo?.hash,
-        media: [],
+        media: media.map((url) => ({ url })),
         metadata: {
           accountId: this.getAccountId(),
           castHash: cast.hash,
@@ -180,8 +186,16 @@ export class FarcasterCastService implements CastServiceInterface {
     }
 
     const text = typeof content.text === "string" ? content.text.trim() : "";
-    if (!text) {
-      throw new Error("Farcaster post connector requires non-empty text content.");
+    // Agent-generated attachments ride along as Farcaster cast embeds (#8876).
+    const media = Array.isArray(content.attachments)
+      ? content.attachments
+          .map((m) => m?.url)
+          .filter((u): u is string => typeof u === "string" && u.trim().length > 0)
+      : [];
+    if (!text && media.length === 0) {
+      throw new Error(
+        "Farcaster post connector requires non-empty text content or at least one attachment."
+      );
     }
 
     const parentHash = readContentString(content, ["parentHash", "replyTo", "replyToHash"]);
@@ -190,6 +204,7 @@ export class FarcasterCastService implements CastServiceInterface {
       agentId: runtime.agentId,
       roomId: createUniqueUuid(runtime, `farcaster:feed:${fid ?? runtime.agentId}`),
       text,
+      ...(media.length > 0 ? { media } : {}),
       ...(parentHash && fid ? { replyTo: { hash: parentHash, fid } } : {}),
     });
 


### PR DESCRIPTION
Part of #8876, fixes the Farcaster half of #8990. **Farcaster silently dropped agent attachments on outbound at two layers:** `CastService.handleSendPost` ignored `content.attachments`, and `createCast`'s `media` param was **dead** (`sendCast`/`publishCast` only ever sent text — no embeds). Like Discord (#8986)/Telegram (#8989)/Slack (#8991), it should send the agent's media.

## Fix
Farcaster casts take **url-based embeds** (Neynar fetches them — no byte upload):
- `handleSendPost` extracts attachment urls → passes as `media`, and allows an **attachment-only** post (require text OR ≥1 attachment).
- `createCast` forwards `media` to `sendCast` as embeds, stops auto-generating prose for a media-only cast, and records the cast's media.
- `FarcasterClient.sendCast`/`publishCast` accept `embeds` and pass `embeds: [{ url }]` to Neynar's `publishCast` (attached once, on the first cast of a chunked thread); an embeds-only cast is now valid.

## Evidence
- 4 new outbound-media tests (embeds sent / text-only no-embeds / attachment-only allowed / blank still rejected) + **full plugin suite 33/33**.
- farcaster **typecheck exit 0**; Biome clean.

> Live publish needs Neynar creds (FID + signer) — the unit test verifies the wiring. With Discord + Telegram + Slack + Farcaster, the major connectors now all send agent attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)