### PR TITLE
feat(line): send agent attachments (image messages + linked media) (#8876)

### DIFF
--- a/plugins/plugin-line/src/outbound-media.test.ts
+++ b/plugins/plugin-line/src/outbound-media.test.ts
@@ -1,0 +1,89 @@
+import type { Content } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { LineService } from "./service.js";
+
+// Outbound media coverage for the LINE connector (#8876). LINE has a dedicated
+// url-based image message but no generic file message, so image attachments are
+// sent as image messages and non-image media is appended to the text as a link
+// (rather than dropped). Mocked send/push → runs offline.
+
+type SendableService = LineService & {
+  sendConnectorContent: (to: string, content: Content) => Promise<void>;
+  pushMessages: (to: string, messages: unknown[]) => Promise<unknown>;
+  sendMessage: (to: string, text: string, opts?: unknown) => Promise<unknown>;
+};
+
+function service(): {
+  svc: SendableService;
+  send: ReturnType<typeof vi.fn>;
+  push: ReturnType<typeof vi.fn>;
+} {
+  const svc = Object.create(LineService.prototype) as SendableService;
+  const send = vi.fn(async () => ({ success: true, chatId: "U1" }));
+  const push = vi.fn(async () => ({ success: true, chatId: "U1" }));
+  (svc as { sendMessage: unknown }).sendMessage = send;
+  (svc as { pushMessages: unknown }).pushMessages = push;
+  return { svc, send, push };
+}
+
+const TO = "U123456789012345678901234567890";
+
+describe("LINE outbound media", () => {
+  it("sends an image attachment as a LINE image message, with text", async () => {
+    const { svc, send, push } = service();
+    await svc.sendConnectorContent(TO, {
+      text: "here you go",
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(send).toHaveBeenCalledWith(TO, "here you go", expect.anything());
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push.mock.calls[0][1]).toEqual([
+      {
+        type: "image",
+        originalContentUrl: "https://cdn.example.com/cat.png",
+        previewImageUrl: "https://cdn.example.com/cat.png",
+      },
+    ]);
+  });
+
+  it("sends an image-only message (no text) without a text push", async () => {
+    const { svc, send, push } = service();
+    await svc.sendConnectorContent(TO, {
+      text: "",
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends non-image media as a link in the text (LINE has no file message)", async () => {
+    const { svc, send, push } = service();
+    await svc.sendConnectorContent(TO, {
+      text: "doc attached",
+      attachments: [
+        { id: "doc", url: "https://cdn.example.com/report.pdf", contentType: "document" },
+      ],
+    } as Content);
+
+    expect(send).toHaveBeenCalledWith(
+      TO,
+      "doc attached\nhttps://cdn.example.com/report.pdf",
+      expect.anything()
+    );
+    // No image message pushed for a non-image attachment.
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("skips a non-https media url (LINE requires https)", async () => {
+    const { svc, send, push } = service();
+    await svc.sendConnectorContent(TO, {
+      text: "hi",
+      attachments: [{ id: "x", url: "http://insecure/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(send).toHaveBeenCalledWith(TO, "hi", expect.anything());
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-line/src/service.ts
+++ b/plugins/plugin-line/src/service.ts
@@ -827,16 +827,49 @@ export class LineService extends Service implements ILineService {
       return;
     }
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
-    if (!text) {
+    // Agent-generated attachments (#8876). LINE has a dedicated image message
+    // (url-based); it has no generic file message, so non-image media (video
+    // without a thumbnail, audio, documents) is appended to the text as a link
+    // rather than dropped. LINE requires https media URLs.
+    const attachments = Array.isArray(content.attachments) ? content.attachments : [];
+    const imageMessages: Message[] = [];
+    const linkedUrls: string[] = [];
+    for (const media of attachments) {
+      const url = typeof media?.url === "string" ? media.url.trim() : "";
+      if (!/^https:\/\//i.test(url)) continue;
+      if (media.contentType === "image") {
+        imageMessages.push({
+          type: "image",
+          originalContentUrl: url,
+          previewImageUrl: url,
+        });
+      } else {
+        linkedUrls.push(url);
+      }
+    }
+
+    const baseText = typeof content.text === "string" ? content.text.trim() : "";
+    const text =
+      linkedUrls.length > 0 ? [baseText, ...linkedUrls].filter(Boolean).join("\n") : baseText;
+
+    if (!text && imageMessages.length === 0) {
       return;
     }
 
-    const result = await this.sendMessage(to, text, {
-      quickReplyItems: quickReplyItemsFromStrings(data.quickReplies),
-    });
-    if (!result.success) {
-      throw new Error(result.error || "LINE message send failed");
+    if (text) {
+      const result = await this.sendMessage(to, text, {
+        quickReplyItems: quickReplyItemsFromStrings(data.quickReplies),
+      });
+      if (!result.success) {
+        throw new Error(result.error || "LINE message send failed");
+      }
+    }
+
+    if (imageMessages.length > 0) {
+      const result = await this.pushMessages(to, imageMessages);
+      if (!result.success) {
+        throw new Error(result.error || "LINE image send failed");
+      }
     }
   }
 


### PR DESCRIPTION
Part of #8876, LINE portion of #8990. LINE's `sendConnectorContent` handled flex/location/template/text but **dropped `content.attachments`** (and returned early on empty text). LINE has a dedicated url-based image message but no generic file message, so:

- **image** attachments → LINE image messages (`originalContentUrl`/`previewImageUrl`)
- **non-image** media (video w/o thumbnail, audio, documents) → appended to the text as an https link (not dropped — LINE has no file message)
- an **image-only** reply (no text) now sends instead of returning early
- non-https media urls are skipped (LINE requires https)

**Verified:** 4 new outbound-media tests + **full plugin suite 91/91**; line typecheck exit 0; Biome clean.

> Major + common connectors now send agent attachments: Discord, Telegram, Slack, Farcaster, LINE. Remaining (specialized media models) tracked in #8990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)