### PR TITLE
feat(nostr): carry agent attachments as URLs in note/DM content (#8876)

### DIFF
--- a/plugins/plugin-nostr/src/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-nostr/src/__tests__/outbound-media.test.ts
@@ -1,0 +1,103 @@
+import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { NostrService } from "../service.js";
+
+// Outbound media coverage for the Nostr connector (#8876). Nostr has no separate
+// attachment field — kind:1 notes and DMs carry media as URLs in the content
+// (clients render them inline). So agent-generated attachments are appended to
+// the text as URLs rather than dropped. Mocked send paths → runs offline.
+
+function runtime(): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    character: { settings: {} },
+    emitEvent: vi.fn(),
+    getSetting: vi.fn(() => null),
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+function service(): NostrService {
+  const instance = Object.create(NostrService.prototype) as NostrService;
+  Object.assign(instance, {
+    runtime: runtime(),
+    accountServices: new Map(),
+    connected: true,
+    seenEventIds: new Set(),
+    settings: {
+      accountId: "default",
+      privateKey: "1".repeat(64),
+      publicKey: "2".repeat(64),
+      relays: ["wss://relay.example"],
+      dmPolicy: "open",
+      allowFrom: [],
+      enabled: true,
+    },
+    privateKey: new Uint8Array(32).fill(1),
+    pool: { publish: vi.fn(async () => undefined), querySync: vi.fn(async () => []) },
+  });
+  return instance;
+}
+
+const PUBKEY = "a".repeat(64);
+const target = { source: "nostr", channelId: PUBKEY } as TargetInfo;
+
+describe("Nostr outbound media (URLs in content)", () => {
+  it("appends an attachment URL to a DM instead of dropping it", async () => {
+    const svc = service();
+    const sendDm = vi.spyOn(svc, "sendDm").mockResolvedValue({ success: true } as never);
+
+    await svc.handleSendMessage(runtime(), target, {
+      text: "here you go",
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(sendDm).toHaveBeenCalledTimes(1);
+    const arg = sendDm.mock.calls[0][0] as { text: string };
+    expect(arg.text).toContain("here you go");
+    expect(arg.text).toContain("https://cdn.example.com/cat.png");
+  });
+
+  it("appends an attachment URL to a public note", async () => {
+    const svc = service();
+    const publishNote = vi
+      .spyOn(svc, "publishNote")
+      .mockResolvedValue({ success: true, eventId: "e".repeat(64) } as never);
+    vi.spyOn(
+      svc as unknown as { nostrEventToPostMemory: () => unknown },
+      "nostrEventToPostMemory"
+    ).mockReturnValue({} as never);
+
+    await svc.handleSendPost(runtime(), {
+      text: "check this",
+      attachments: [{ id: "vid", url: "https://cdn.example.com/clip.mp4", contentType: "video" }],
+    } as Content);
+
+    expect(publishNote).toHaveBeenCalledTimes(1);
+    expect(publishNote.mock.calls[0][0]).toContain("https://cdn.example.com/clip.mp4");
+  });
+
+  it("allows an attachment-only DM (no text) — the URL becomes the content", async () => {
+    const svc = service();
+    const sendDm = vi.spyOn(svc, "sendDm").mockResolvedValue({ success: true } as never);
+
+    await svc.handleSendMessage(runtime(), target, {
+      text: "",
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(sendDm).toHaveBeenCalledTimes(1);
+    expect((sendDm.mock.calls[0][0] as { text: string }).text).toContain(
+      "https://cdn.example.com/cat.png"
+    );
+  });
+
+  it("still rejects a DM with neither text nor attachments", async () => {
+    const svc = service();
+    const sendDm = vi.spyOn(svc, "sendDm");
+    await expect(
+      svc.handleSendMessage(runtime(), target, { text: "   " } as Content)
+    ).rejects.toThrow("requires non-empty text");
+    expect(sendDm).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-nostr/src/service.ts
+++ b/plugins/plugin-nostr/src/service.ts
@@ -110,6 +110,22 @@ function getNostrTargetMetadata(target: TargetInfo): Record<string, unknown> | u
     : undefined;
 }
 
+/**
+ * Append agent-generated attachment URLs to Nostr text (#8876). Nostr has no
+ * separate attachment field — kind:1 notes and DMs carry media as URLs in the
+ * content, which clients render inline. So a generated/sent attachment becomes a
+ * URL appended to the text rather than being dropped. http(s) URLs only.
+ */
+function appendNostrAttachmentUrls(text: string, content: Content): string {
+  const urls = Array.isArray(content.attachments)
+    ? content.attachments
+        .map((media) => (typeof media?.url === "string" ? media.url.trim() : ""))
+        .filter((url) => /^https?:\/\//i.test(url))
+    : [];
+  if (urls.length === 0) return text;
+  return [text, ...urls].filter(Boolean).join("\n");
+}
+
 function clampLimit(value: number | undefined, defaultValue: number, max: number): number {
   if (!Number.isFinite(value)) {
     return defaultValue;
@@ -624,9 +640,12 @@ export class NostrService extends Service implements INostrService {
       );
     }
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = appendNostrAttachmentUrls(
+      typeof content.text === "string" ? content.text.trim() : "",
+      content
+    );
     if (!text) {
-      throw new Error("Nostr DM connector requires non-empty text content.");
+      throw new Error("Nostr DM connector requires non-empty text content or an attachment.");
     }
 
     const metadata = getNostrTargetMetadata(target);
@@ -663,9 +682,12 @@ export class NostrService extends Service implements INostrService {
       );
     }
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = appendNostrAttachmentUrls(
+      typeof content.text === "string" ? content.text.trim() : "",
+      content
+    );
     if (!text) {
-      throw new Error("Nostr post connector requires non-empty text content.");
+      throw new Error("Nostr post connector requires non-empty text content or an attachment.");
     }
 
     const result = await this.publishNote(text);


### PR DESCRIPTION
Part of #8876, Nostr portion of #8990. Nostr's outbound paths (`handleSendMessage` DM + `handleSendPost` note) **dropped `content.attachments`** and threw on empty text. Nostr has no separate attachment field — kind:1 notes and NIP-04 DMs carry media as **URLs in the content**, which clients render inline. So:

- `appendNostrAttachmentUrls()` appends each http(s) attachment URL to the text (both DM + note paths)
- an **attachment-only** send (no prose) is now allowed — the URL becomes the content — instead of being rejected

**Verified:** 4 new outbound-media tests + **full plugin suite 18/18**; nostr typecheck exit 0; Biome clean.

> Connectors now sending agent attachments: Discord, Telegram, Slack, Farcaster, LINE, Nostr. Remaining (Instagram limited-DM-API, iMessage native bridge, WhatsApp dual-transport) tracked in #8990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)