### PR TITLE
fix(chat): render inline widgets in the chat overlay, not raw markers (#8997)

### DIFF
--- a/packages/ui/src/components/chat/InlineWidgetText.test.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// Verifies the chat-overlay inline-widget renderer (#8997): assistant text with
+// inline-widget markers renders the real widgets (choice / form / followups /
+// task) and never leaks the raw `[CHOICE]`/`[FORM]`/`[TASK]`/`[FOLLOWUPS]`
+// marker syntax as text; plain replies pass through unchanged.
+
+import { cleanup, render } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+
+vi.mock("@elizaos/ui", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../../api/client", () => ({ client: {} }));
+
+import { InlineWidgetText } from "./InlineWidgetText";
+// The task widget is plugin-owned (registered by plugin-task-coordinator at
+// boot, not a built-in); register it here so this surface renders it too.
+import { registerTaskWidget } from "./widgets/task-widget";
+
+registerTaskWidget();
+
+function withApp(node: React.ReactElement) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+  );
+}
+
+describe("InlineWidgetText", () => {
+  afterEach(() => {
+    cleanup();
+    __setAppValueForTests(null);
+  });
+
+  it("renders plain text unchanged (fast path)", () => {
+    const { container } = withApp(
+      <InlineWidgetText content="just a normal reply" />,
+    );
+    expect(container.textContent).toContain("just a normal reply");
+  });
+
+  it("renders a choice picker and does not leak the [CHOICE] marker", () => {
+    const { container } = withApp(
+      <InlineWidgetText
+        content={
+          "Approve this?\n[CHOICE:approval id=c1]\nyes=Approve\nno=Reject\n[/CHOICE]"
+        }
+      />,
+    );
+    expect(container.textContent ?? "").toContain("Approve");
+    expect(container.textContent ?? "").not.toContain("[CHOICE");
+    expect(container.textContent ?? "").not.toContain("[/CHOICE]");
+  });
+
+  it("renders an inline form and does not leak the [FORM] marker", () => {
+    const form = JSON.stringify({
+      title: "Trip details",
+      fields: [{ name: "destination", type: "text", label: "Destination" }],
+    });
+    const { container } = withApp(
+      <InlineWidgetText content={`Fill this out:\n[FORM]\n${form}\n[/FORM]`} />,
+    );
+    expect(container.textContent ?? "").toContain("Destination");
+    expect(container.textContent ?? "").not.toContain("[FORM]");
+  });
+
+  it("renders suggestion chips and does not leak the [FOLLOWUPS] marker", () => {
+    const { container } = withApp(
+      <InlineWidgetText
+        content={"Done.\n[FOLLOWUPS]\nrerun=Run again\n[/FOLLOWUPS]"}
+      />,
+    );
+    expect(container.textContent ?? "").toContain("Run again");
+    expect(container.textContent ?? "").not.toContain("[FOLLOWUPS]");
+  });
+
+  it("renders a task card and does not leak the [TASK] marker", () => {
+    const { container } = withApp(
+      <InlineWidgetText
+        content={`Created it.\n[TASK:${"a".repeat(12)}]Build the thing[/TASK]\nThe builders are running.`}
+      />,
+    );
+    // The surrounding prose still renders, and the raw marker is gone (replaced
+    // by the registered task widget).
+    expect(container.textContent ?? "").toContain("Created it.");
+    expect(container.textContent ?? "").toContain("The builders are running.");
+    expect(container.textContent ?? "").not.toContain("[TASK:");
+    expect(container.textContent ?? "").not.toContain("[/TASK]");
+  });
+});

--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -1,0 +1,116 @@
+// Renders assistant message text with its inline widgets (#8876, #8997).
+//
+// Surfaces that show raw `message.content` (e.g. the continuous-chat overlay)
+// would otherwise leak the agent's inline-widget markers — `[TASK:…]`,
+// `[CHOICE:…]`, `[FORM]…[/FORM]`, `[FOLLOWUPS]…[/FOLLOWUPS]` — as literal text.
+// This component segments the content with the SAME inline-widget registry the
+// full MessageContent surface uses, rendering the prose plus the real widgets
+// (task card / choice buttons / inline form / suggestion chips). Handlers are
+// sourced from the app + composer contexts, so callers just render
+// `<InlineWidgetText content={msg.content} />`.
+
+import { type ReactNode, useMemo } from "react";
+import { useAppSelectorShallow } from "../../state";
+import { useChatComposer } from "../../state/ChatComposerContext.hooks";
+import type { FormResultValue } from "./widgets/form-request";
+// Side effect: register the built-in inline widgets (choice/followups/form/task).
+import "./widgets/inline-builtins";
+import {
+  getInlineWidget,
+  getInlineWidgets,
+  type InlineWidgetContext,
+} from "./widgets/inline-registry";
+
+interface WidgetRegion {
+  start: number;
+  end: number;
+  widgetKind: string;
+  data: unknown;
+}
+
+/** Collect non-overlapping inline-widget regions in `content`, left to right. */
+function collectWidgetRegions(content: string): WidgetRegion[] {
+  const regions: WidgetRegion[] = [];
+  for (const widget of getInlineWidgets()) {
+    for (const match of widget.parse(content)) {
+      regions.push({
+        start: match.start,
+        end: match.end,
+        widgetKind: widget.kind,
+        data: match.data,
+      });
+    }
+  }
+  regions.sort((a, b) => a.start - b.start);
+  // Drop any region that overlaps one already accepted (first match wins).
+  const accepted: WidgetRegion[] = [];
+  let lastEnd = -1;
+  for (const region of regions) {
+    if (region.start >= lastEnd) {
+      accepted.push(region);
+      lastEnd = region.end;
+    }
+  }
+  return accepted;
+}
+
+export function InlineWidgetText({ content }: { content: string }): ReactNode {
+  const { sendActionMessage } = useAppSelectorShallow((s) => ({
+    sendActionMessage: s.sendActionMessage,
+  }));
+  // Outside a chat provider this returns an inert setter, so prefill simply
+  // no-ops rather than throwing — safe on every surface.
+  const { setChatInput } = useChatComposer();
+
+  const ctx = useMemo<InlineWidgetContext>(
+    () => ({
+      sendAction: (value: string) => {
+        void sendActionMessage(value);
+      },
+      navigate: (payload: string) => {
+        if (typeof window === "undefined") return;
+        const detail = payload.startsWith("/")
+          ? { viewPath: payload }
+          : { viewId: payload };
+        window.dispatchEvent(
+          new CustomEvent("eliza:navigate:view", { detail }),
+        );
+      },
+      prefillComposer: (payload: string) => {
+        setChatInput(payload);
+      },
+      submitForm: (formId: string, values: Record<string, FormResultValue>) => {
+        void sendActionMessage(
+          `[form:submit ${formId}] ${JSON.stringify(values)}`,
+        );
+      },
+    }),
+    [sendActionMessage, setChatInput],
+  );
+
+  const regions = useMemo(() => collectWidgetRegions(content), [content]);
+
+  // Fast path: no inline widgets — render the text exactly as before.
+  if (regions.length === 0) {
+    return content;
+  }
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  regions.forEach((region, i) => {
+    if (region.start > cursor) {
+      const text = content.slice(cursor, region.start);
+      if (text) nodes.push(<span key={`t-${cursor}`}>{text}</span>);
+    }
+    const widget = getInlineWidget(region.widgetKind);
+    if (widget) {
+      nodes.push(widget.render(region.data, ctx, `w-${i}`));
+    }
+    cursor = region.end;
+  });
+  if (cursor < content.length) {
+    const tail = content.slice(cursor);
+    if (tail) nodes.push(<span key={`t-${cursor}`}>{tail}</span>);
+  }
+  return <>{nodes}</>;
+}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -54,6 +54,7 @@ import {
   shouldConvertPasteToAttachment,
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
+import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
@@ -879,7 +880,10 @@ const ThreadLine = React.memo(function ThreadLine({
         ) : isUser ? (
           <ThreadLineText content={message.content} />
         ) : (
-          message.content
+          // Assistant text renders its inline widgets (task/choice/form/
+          // followups) instead of leaking the raw `[TASK:…]`/`[CHOICE]`/… markers
+          // as text (#8997). Plain replies fall through the fast path unchanged.
+          <InlineWidgetText content={message.content} />
         )}
         {message.attachments?.length ? (
           <MessageAttachments attachments={message.attachments} />


### PR DESCRIPTION
Fixes #8997. The continuous-chat overlay (the surface `/chat` shows) rendered assistant `message.content` **raw**, leaking inline-widget markers — `[TASK:…]`, `[CHOICE:…]`, `[FORM]…[/FORM]`, `[FOLLOWUPS]…[/FOLLOWUPS]` — to the user as literal text (the full `MessageContent` surface renders them as widgets; the overlay didn't).

## Fix
Adds **`InlineWidgetText`**: segments assistant text with the **same inline-widget registry** `MessageContent` uses and renders the real widgets (task card / choice buttons / inline form / suggestion chips), sourcing handlers (`sendAction`/`navigate`/`prefillComposer`/`submitForm`) from the app + composer contexts. Plain replies hit a fast path (unchanged). The overlay's assistant bubble now uses it.

## Evidence
- **InlineWidgetText 5/5 unit tests**: choice/form/followups/task render; the raw markers no longer leak; plain text unchanged.
- ui typecheck + Biome clean.
- Live ui-smoke confirms the **task widget now renders in the overlay DOM** (`data-testid="task-widget"`, `data-task-status="active"`) where the marker previously leaked entirely.

> The `task-widget-in-chat` E2E's *click-to-open-workbench* step still hits a pointer-interception (overlay layering) — a separate layout pass, tracked in #8997. This PR resolves the marker leak + widget rendering (the substance of the finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)