### PR TITLE
feat(whatsapp): send agent attachments as media (both transports) (#8876)

### DIFF
--- a/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
@@ -1,0 +1,167 @@
+import type { IAgentRuntime, Media, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { WhatsAppConnectorService } from "../src/runtime-service";
+
+// Outbound media coverage for the WhatsApp connector (#8876). Agent attachments
+// must ship as native WhatsApp media messages via sendMediaMessage — the send
+// handler previously dropped content.attachments and threw on empty text. Both
+// transports (Cloud API + Baileys) build their payload from the same
+// WhatsAppMessage media type, so one path covers both. Mocked → runs offline.
+
+type RuntimeSendHandler = Parameters<IAgentRuntime["registerSendHandler"]>[1];
+type ConnectorTargetInfo = Parameters<RuntimeSendHandler>[1];
+type ConnectorContent = Parameters<RuntimeSendHandler>[2];
+type MessageConnectorRegistration = Parameters<
+  IAgentRuntime["registerMessageConnector"]
+>[0];
+
+function makeRuntime(registrations: MessageConnectorRegistration[]): IAgentRuntime {
+  return {
+    agentId: "agent-1" as UUID,
+    registerMessageConnector: vi.fn((registration: MessageConnectorRegistration) => {
+      registrations.push(registration);
+    }),
+    registerSendHandler: vi.fn(),
+    getRoom: vi.fn(async () => null),
+    getMemoryById: vi.fn(async () => null),
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  } as never as IAgentRuntime;
+}
+
+const known = {
+  chatId: "+14155552671",
+  senderId: "+14155552671",
+  label: "Alice",
+  isGroup: false,
+  lastMessageAt: 123,
+};
+
+function mockService() {
+  return {
+    connected: true,
+    config: { transport: "cloudapi" },
+    sendMessage: vi.fn(async () => ({ messages: [{ id: "wamid.1" }] })),
+    sendMediaMessage: vi.fn(async () => undefined),
+    listKnownTargets: vi.fn(() => [known]),
+    getKnownTarget: vi.fn((chatId: string) =>
+      chatId === known.chatId ? known : null,
+    ),
+    findKnownChatByParticipant: vi.fn((p: string) =>
+      p === known.senderId ? known : null,
+    ),
+    fetchConnectorMessages: vi.fn(async () => []),
+    searchConnectorMessages: vi.fn(async () => []),
+    reactConnectorMessage: vi.fn(async () => undefined),
+    getConnectorUser: vi.fn(async () => null),
+  } as never as WhatsAppConnectorService;
+}
+
+const TARGET = {
+  source: "whatsapp",
+  entityId: "+1 (415) 555-2671" as UUID,
+} as ConnectorTargetInfo;
+
+describe("WhatsApp connector outbound media — send handler", () => {
+  it("sends text then each attachment via sendMediaMessage", async () => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const runtime = makeRuntime(registrations);
+    const service = mockService();
+    WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+    await registrations[0].sendHandler?.(
+      runtime,
+      TARGET,
+      {
+        text: "here you go",
+        attachments: [
+          { id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" },
+          { id: "doc", url: "https://cdn.example.com/r.pdf", contentType: "document" },
+        ],
+      } as ConnectorContent,
+    );
+
+    expect(service.sendMessage).toHaveBeenCalledTimes(1);
+    expect(service.sendMediaMessage).toHaveBeenCalledTimes(2);
+    expect(service.sendMediaMessage).toHaveBeenCalledWith(
+      "default",
+      "+14155552671",
+      expect.objectContaining({ url: "https://cdn.example.com/cat.png" }),
+    );
+  });
+
+  it("sends an attachment-only message (no text) without a text send", async () => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const runtime = makeRuntime(registrations);
+    const service = mockService();
+    WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+    await registrations[0].sendHandler?.(
+      runtime,
+      TARGET,
+      {
+        text: "",
+        attachments: [
+          { id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" },
+        ],
+      } as ConnectorContent,
+    );
+
+    expect(service.sendMessage).not.toHaveBeenCalled();
+    expect(service.sendMediaMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WhatsApp sendMediaMessage — transport-agnostic media call", () => {
+  function realServiceWithClient() {
+    const clientSend = vi.fn(async () => ({ messages: [{ id: "x" }] }));
+    const svc = Object.create(
+      WhatsAppConnectorService.prototype,
+    ) as WhatsAppConnectorService & {
+      getClientForAccount: ReturnType<typeof vi.fn>;
+      sendMediaMessage: (
+        accountId: string | null | undefined,
+        to: string,
+        media: Media,
+      ) => Promise<void>;
+    };
+    (svc as { getClientForAccount: unknown }).getClientForAccount = vi.fn(() => ({
+      sendMessage: clientSend,
+    }));
+    return { svc, clientSend };
+  }
+
+  it("maps coarse content type → WhatsApp media type and calls the client by link", async () => {
+    const { svc, clientSend } = realServiceWithClient();
+    await svc.sendMediaMessage("default", "+14155552671", {
+      id: "img",
+      url: "https://cdn.example.com/cat.png",
+      contentType: "image",
+      description: "a cat",
+    } as Media);
+
+    expect(clientSend).toHaveBeenCalledWith({
+      type: "image",
+      to: "+14155552671",
+      content: { link: "https://cdn.example.com/cat.png", caption: "a cat" },
+    });
+  });
+
+  it("derives type from mimeType and sets a document filename", async () => {
+    const { svc, clientSend } = realServiceWithClient();
+    await svc.sendMediaMessage("default", "+14155552671", {
+      id: "doc",
+      url: "https://cdn.example.com/report.pdf",
+      mimeType: "application/pdf",
+      filename: "report.pdf",
+    } as Media);
+
+    expect(clientSend).toHaveBeenCalledWith({
+      type: "document",
+      to: "+14155552671",
+      content: {
+        link: "https://cdn.example.com/report.pdf",
+        filename: "report.pdf",
+      },
+    });
+  });
+});

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -4,6 +4,7 @@ import {
   createUniqueUuid,
   type IAgentRuntime,
   lifeOpsPassiveConnectorsEnabled,
+  type Media,
   type Memory,
   type Room,
   Service,
@@ -35,6 +36,7 @@ import type {
   ConnectionStatus,
   NormalizedMessage,
   WhatsAppIncomingMessage,
+  WhatsAppMediaMessage,
   WhatsAppMessageResponse,
   WhatsAppWebhookEvent,
 } from "./types";
@@ -707,7 +709,12 @@ export class WhatsAppConnectorService extends Service {
           content: ConnectorContent
         ) => {
           const text = typeof content.text === "string" ? content.text.trim() : "";
-          if (!text) {
+          const attachments = Array.isArray(content.attachments)
+            ? content.attachments.filter(
+                (media) => typeof media?.url === "string" && media.url.trim().length > 0
+              )
+            : [];
+          if (!text && attachments.length === 0) {
             return;
           }
 
@@ -732,14 +739,36 @@ export class WhatsAppConnectorService extends Service {
             }
           }
 
-          for (const chunk of chunkWhatsAppText(text)) {
-            await service.sendMessage({
-              accountId: resolved.accountId,
-              type: "text",
-              to: resolved.chatId,
-              content: chunk,
-              replyToMessageId,
-            });
+          if (text) {
+            for (const chunk of chunkWhatsAppText(text)) {
+              await service.sendMessage({
+                accountId: resolved.accountId,
+                type: "text",
+                to: resolved.chatId,
+                content: chunk,
+                replyToMessageId,
+              });
+            }
+          }
+
+          // Agent-generated attachments ride as native WhatsApp media messages
+          // (#8876). Both transports (Cloud API by-link + Baileys) build their
+          // payload from the same WhatsAppMessage media type, so one call works
+          // for either. Each is isolated so one failure never drops the rest.
+          for (const media of attachments) {
+            try {
+              await service.sendMediaMessage(resolved.accountId, resolved.chatId, media);
+            } catch (error) {
+              runtime.logger.warn(
+                {
+                  src: "plugin:whatsapp",
+                  agentId: runtime.agentId,
+                  url: media.url,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+                "Failed to send WhatsApp outbound attachment; skipping"
+              );
+            }
           }
         },
         resolveTargets: async (query: string) => {
@@ -1330,6 +1359,42 @@ export class WhatsAppConnectorService extends Service {
       message.replyToMessageId,
       message.accountId
     );
+  }
+
+  /** Coarse content type → WhatsApp media message kind. */
+  private whatsappMediaType(media: Media): "image" | "video" | "audio" | "document" {
+    const ct = (media.contentType ?? "").toLowerCase();
+    const mime = (media.mimeType ?? "").toLowerCase();
+    if (ct === "image" || mime.startsWith("image/")) return "image";
+    if (ct === "video" || mime.startsWith("video/")) return "video";
+    if (ct === "audio" || mime.startsWith("audio/")) return "audio";
+    return "document";
+  }
+
+  /**
+   * Send an agent attachment as a native WhatsApp media message (#8876). Works
+   * across both transports: the Cloud-API client and the Baileys client each
+   * build their own payload from the shared `WhatsAppMessage` media type, both
+   * keyed on a media URL (`link`).
+   */
+  async sendMediaMessage(
+    accountId: string | null | undefined,
+    to: string,
+    media: Media
+  ): Promise<void> {
+    if (!media.url) return;
+    const client = this.getClientForAccount(accountId);
+    if (!client) {
+      throw new Error("WhatsApp client not initialized");
+    }
+    const type = this.whatsappMediaType(media);
+    const filename = media.filename ?? media.title ?? undefined;
+    const mediaContent: WhatsAppMediaMessage = {
+      link: media.url,
+      ...(media.description ? { caption: media.description } : {}),
+      ...(type === "document" && filename ? { filename } : {}),
+    };
+    await client.sendMessage({ type, to, content: mediaContent });
   }
 
   async fetchConnectorMessages(


### PR DESCRIPTION
Part of #8876, WhatsApp portion of #8990. WhatsApp's send handler **dropped `content.attachments`** and threw on empty text. WhatsApp media is url-based and **both transports build their payload from the same `WhatsAppMessage` media type** — Cloud API via `buildMessagePayload`, Baileys via `MessageAdapter.toBaileys` (both handle image/video/audio/document by `link`). So one path covers both.

- New **`sendMediaMessage(accountId, to, media)`**: maps coarse `contentType` (mime fallback) → WhatsApp media kind and calls the resolved client's `sendMessage({ type, to, content: { link, caption, filename } })` — **no transport branching**.
- Send handler sends text (if any), then each attachment via `sendMediaMessage`; allows **attachment-only** replies; isolates each upload in try/catch (a bad url logs a warning, never drops the rest).

## Evidence
- 4 new outbound-media tests (handler wires attachments → `sendMediaMessage`; attachment-only; contentType + mime → media-type mapping; document filename) + **full plugin suite 35/35**.
- whatsapp **typecheck exit 0**; Biome clean.

> Live send needs a WhatsApp number (Cloud API or Baileys session); the unit tests verify the wiring + the transport-agnostic media call. With this, **all 7 messaging connectors** (Discord/Telegram/Slack/Farcaster/LINE/Nostr/WhatsApp) send agent attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)