### PR TITLE
fix(chat): render secret/auth requests in the chat overlay (#8997)

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -966,7 +966,7 @@ function sensitiveRequestStatusLabel(
   }
 }
 
-function SensitiveRequestBlock({
+export function SensitiveRequestBlock({
   request,
 }: {
   request: NonNullable<ConversationMessage["secretRequest"]>;

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -56,6 +56,7 @@ import {
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
+import { SensitiveRequestBlock } from "../chat/MessageContent";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
@@ -887,6 +888,12 @@ const ThreadLine = React.memo(function ThreadLine({
         )}
         {message.attachments?.length ? (
           <MessageAttachments attachments={message.attachments} />
+        ) : null}
+        {isAssistant && message.secretRequest ? (
+          // Secret / OAuth requests are a structured field, not a text marker —
+          // render the same block the full chat surface uses so they're
+          // actionable in the overlay instead of invisible (#8997).
+          <SensitiveRequestBlock request={message.secretRequest} />
         ) : null}
         {isAssistant && message.reasoning?.trim() ? (
           <ThinkingBlock reasoning={message.reasoning} />

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -1,4 +1,8 @@
-import type { ChatFailureKind, MessageAttachment } from "../../api";
+import type {
+  ChatFailureKind,
+  ConversationSecretRequest,
+  MessageAttachment,
+} from "../../api";
 
 /**
  * Shell phase for the device-shell foundation (HomePill + AssistantOverlay +
@@ -28,4 +32,6 @@ export interface ShellMessage {
   reasoning?: string;
   /** Media attached to this turn — user uploads and agent-generated media. */
   attachments?: MessageAttachment[];
+  /** Pending secret / OAuth request (rendered as an actionable block). */
+  secretRequest?: ConversationSecretRequest;
 }

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -357,7 +357,8 @@ export function useShellController(): ShellController {
         cached &&
         cached.content === message.text &&
         cached.failureKind === message.failureKind &&
-        (cached.reasoning || undefined) === (message.reasoning || undefined)
+        (cached.reasoning || undefined) === (message.reasoning || undefined) &&
+        cached.secretRequest === message.secretRequest
       ) {
         next.set(message.id, cached);
         return cached;
@@ -371,6 +372,9 @@ export function useShellController(): ShellController {
         ...(message.reasoning ? { reasoning: message.reasoning } : {}),
         ...(message.attachments?.length
           ? { attachments: message.attachments }
+          : {}),
+        ...(message.secretRequest
+          ? { secretRequest: message.secretRequest }
           : {}),
       };
       next.set(message.id, mapped);


### PR DESCRIPTION
Part of #8997 (the secret-request half; #9001 fixed the inline-widget marker half). The continuous-chat overlay never rendered the structured `secretRequest` field, so a secret / OAuth request from the agent was **invisible at `/chat`** (the full `MessageContent` surface renders it via `SensitiveRequestBlock`; the overlay didn't, and `ShellMessage` didn't even carry the field).

## Fix
- Export `SensitiveRequestBlock` from `MessageContent` (self-contained — takes a `request` prop, sources handlers from hooks).
- Thread `secretRequest` through `ShellMessage` + the shell-controller mapping (and cache-equality check) so it reaches the overlay.
- Render it in the overlay's assistant bubble when present — secret/OAuth requests are now actionable in the overlay instead of missing.

## Evidence
- `MessageContent.sensitive-request` **9/9** + `InlineWidgetText` **5/5** unit tests still green; ui typecheck + Biome clean.
- The `sensitive-request-in-chat` ui-smoke (which asserts `getByTestId("sensitive-request")` at `/chat`) now has the block to find — live confirmation in progress; any deeper submit/OAuth-click step shares the overlay pointer-layering follow-up noted in #8997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)