### PR TITLE
fix(chat): make overlay inline widgets pointer-events-auto in the peek (#8997)

### DIFF
--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -104,7 +104,15 @@ export function InlineWidgetText({ content }: { content: string }): ReactNode {
     }
     const widget = getInlineWidget(region.widgetKind);
     if (widget) {
-      nodes.push(widget.render(region.data, ctx, `w-${i}`));
+      // `pointer-events-auto` so the interactive widget stays clickable even
+      // where an ancestor is `pointer-events-none` (e.g. the chat overlay's
+      // peek sheet, which is pass-through by design) — the surrounding text is
+      // left as-is so plain replies still tap through. (#8997)
+      nodes.push(
+        <div key={`w-${i}`} className="pointer-events-auto">
+          {widget.render(region.data, ctx, `w-${i}`)}
+        </div>,
+      );
     }
     cursor = region.end;
   });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -893,7 +893,11 @@ const ThreadLine = React.memo(function ThreadLine({
           // Secret / OAuth requests are a structured field, not a text marker —
           // render the same block the full chat surface uses so they're
           // actionable in the overlay instead of invisible (#8997).
-          <SensitiveRequestBlock request={message.secretRequest} />
+          // `pointer-events-auto` keeps it clickable inside the peek sheet
+          // (pointer-events-none / pass-through by design).
+          <div className="pointer-events-auto">
+            <SensitiveRequestBlock request={message.secretRequest} />
+          </div>
         ) : null}
         {isAssistant && message.reasoning?.trim() ? (
           <ThinkingBlock reasoning={message.reasoning} />


### PR DESCRIPTION
Part of #8997. Interactive widgets (task / choice / form / secret-request) **render** in the chat overlay (#9001, #9003) but weren't **clickable** in the peek sheet: that region is `pointer-events:none` by design (the view behind stays live), so the widgets inherited it and clicks fell through to the scroll container.

Sets `pointer-events:auto` on **just the interactive widget subtrees** (`InlineWidgetText` widget wrappers + the `SensitiveRequestBlock` wrapper) — they capture their own clicks while surrounding plain text still taps through (design preserved).

## Evidence
- `InlineWidgetText` **5/5** unit tests green; ui typecheck + Biome clean.
- Live ui-smoke confirms it **took effect**: the click-interception moved from the pass-through scroll container to the composer's `z-10` row — revealing a **second, separate layer** (the widget can sit physically under the bottom composer at the click point depending on sheet scroll state). That composer-overlap is a layout follow-up (scroll the widget clear of the composer / open the sheet on interactive content) tracked in **#8997**.

> This PR removes the pointer-events barrier — the necessary first layer of making in-overlay widgets interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)