### PR TITLE
fix(ci): classify ui smoke specs

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -170,7 +170,7 @@ jobs:
         run: bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-diarization.spec.ts test/ui-smoke/voice-workbench-entity-extraction.spec.ts test/ui-smoke/voice-workbench-eot.spec.ts test/ui-smoke/voice-workbench-multi-agent-room.spec.ts test/ui-smoke/voice-workbench-multi-speaker.spec.ts test/ui-smoke/voice-workbench-multi-voice.spec.ts test/ui-smoke/voice-workbench-pauses.spec.ts test/ui-smoke/voice-workbench-respond-no-respond.spec.ts test/ui-smoke/voice-workbench-transcription-mode.spec.ts test/ui-smoke/voice-workbench-voice-recognition.spec.ts --project=chromium
 
       - name: Actual app real-audio voice button browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts --project=chromium-voice-mic
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts test/ui-smoke/transcript-realaudio.spec.ts --project=chromium-voice-mic
 
       - name: Upload app browser core artifacts
         if: always()
@@ -271,7 +271,7 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Actual app all-pages render + click-safety browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/all-pages-clicksafe.spec.ts test/ui-smoke/builtin-views-visual.spec.ts --project=chromium
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/all-pages-clicksafe.spec.ts test/ui-smoke/builtin-views-visual.spec.ts test/ui-smoke/documents-view.spec.ts --project=chromium
 
       - name: Upload app browser all-pages artifacts
         if: always()
@@ -316,7 +316,7 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Actual app feature interaction browser coverage
-        run: bun run --cwd packages/app test:e2e test/ui-smoke/apps-utility-interactions.spec.ts test/ui-smoke/apps-model-training-interactions.spec.ts test/ui-smoke/apps-comms-device-interactions.spec.ts test/ui-smoke/apps-diagnostics-interactions.spec.ts test/ui-smoke/apps-builtin-pages-interactions.spec.ts test/ui-smoke/settings-sections-interactions.spec.ts test/ui-smoke/settings-mobile-load.spec.ts test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts test/ui-smoke/chat-viewmanager-companion-interactions.spec.ts test/ui-smoke/vault-modal-interactions.spec.ts test/ui-smoke/desktop-workspace-interactions.spec.ts test/ui-smoke/settings-audit-capture.spec.ts test/ui-smoke/settings-chat-control.spec.ts test/ui-smoke/routing-matrix-dispatch.spec.ts test/ui-smoke/chat-overlay-controls-interactions.spec.ts test/ui-smoke/chat-attachment.spec.ts test/ui-smoke/files-view.spec.ts test/ui-smoke/conversation-management.spec.ts test/ui-smoke/chat-cloud-routed.spec.ts test/ui-smoke/slash-commands.spec.ts test/ui-smoke/model-download-deferral.spec.ts --project=chromium
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/apps-utility-interactions.spec.ts test/ui-smoke/apps-model-training-interactions.spec.ts test/ui-smoke/apps-comms-device-interactions.spec.ts test/ui-smoke/apps-diagnostics-interactions.spec.ts test/ui-smoke/apps-builtin-pages-interactions.spec.ts test/ui-smoke/settings-sections-interactions.spec.ts test/ui-smoke/settings-mobile-load.spec.ts test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts test/ui-smoke/chat-viewmanager-companion-interactions.spec.ts test/ui-smoke/vault-modal-interactions.spec.ts test/ui-smoke/desktop-workspace-interactions.spec.ts test/ui-smoke/settings-audit-capture.spec.ts test/ui-smoke/settings-chat-control.spec.ts test/ui-smoke/routing-matrix-dispatch.spec.ts test/ui-smoke/chat-overlay-controls-interactions.spec.ts test/ui-smoke/chat-attachment.spec.ts test/ui-smoke/chat-3d-model.spec.ts test/ui-smoke/chat-large-paste.spec.ts test/ui-smoke/files-view.spec.ts test/ui-smoke/files-view-crud.spec.ts test/ui-smoke/conversation-management.spec.ts test/ui-smoke/chat-cloud-routed.spec.ts test/ui-smoke/slash-commands.spec.ts test/ui-smoke/model-download-deferral.spec.ts --project=chromium
 
       - name: Upload app browser feature interaction artifacts
         if: always()

--- a/packages/app/test/ui-smoke-coverage.test.ts
+++ b/packages/app/test/ui-smoke-coverage.test.ts
@@ -97,6 +97,12 @@ const DEDICATED_TOOL: Readonly<Record<string, string>> = {
     "it measures per-section safe-area/spacing, writes a JSON verdict report plus " +
     "notch-simulated screenshots to reports/settings-spacing, so it is a deliberate " +
     "layout-audit harness rather than a narrow keyless PR assertion.",
+  "settings-theme-audit.spec.ts":
+    "runs on demand via `ELIZA_SETTINGS_THEME=1 node scripts/run-ui-playwright.mjs " +
+    "--config playwright.ui-smoke.config.ts test/ui-smoke/settings-theme-audit.spec.ts`; " +
+    "it flips every settings section through light and dark themes, captures " +
+    "screenshots, and writes theme response findings to reports/settings-theme, " +
+    "so it is a deliberate visual audit rather than default smoke.",
 };
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -71,9 +71,9 @@ describe("buildGoalPrompt attempt reflections (#8899)", () => {
 
   it("omits the Past Attempt Failures section when there are no reflections", () => {
     expect(buildGoalPrompt(baseInput)).not.toContain("Past Attempt Failures");
-    expect(buildGoalPrompt({ ...baseInput, attemptReflections: [] })).not.toContain(
-      "Past Attempt Failures",
-    );
+    expect(
+      buildGoalPrompt({ ...baseInput, attemptReflections: [] }),
+    ).not.toContain("Past Attempt Failures");
   });
 
   it("replays prior failed attempts (summary + missing) on re-spawn", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -246,7 +246,8 @@ function readAttemptReflections(
   for (const entry of raw) {
     if (!entry || typeof entry !== "object") continue;
     const r = entry as Record<string, unknown>;
-    if (typeof r.attempt !== "number" || typeof r.summary !== "string") continue;
+    if (typeof r.attempt !== "number" || typeof r.summary !== "string")
+      continue;
     out.push({
       attempt: r.attempt,
       summary: r.summary,


### PR DESCRIPTION
## Summary
- Wire newly unclassified keyless ui-smoke specs into existing Scenario PR lanes.
- Classify the opt-in settings theme sweep as a dedicated audit tool.
- Apply Biome formatting required by the latest develop Quality check.

## Verification
- `bun run --cwd packages/app test -- test/ui-smoke-coverage.test.ts`
- `bun run --cwd plugins/plugin-agent-orchestrator format:check`
- `bunx @biomejs/biome format --diagnostic-level=warn .github/workflows/scenario-pr.yml packages/app/test/ui-smoke-coverage.test.ts plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts`
- `git diff --check`

Note: full `bun run build` was skipped because the local disk is at 99% capacity with ~9 GiB free.