### PR TITLE
fix(workflow): fire WORKFLOW search from plain chat (general context) + declare query param

### DIFF
--- a/plugins/plugin-workflow/src/actions/workflow.ts
+++ b/plugins/plugin-workflow/src/actions/workflow.ts
@@ -70,9 +70,12 @@ const WORKFLOW_OPS = [
 ] as const;
 type WorkflowOp = (typeof WORKFLOW_OPS)[number];
 
-// `chat` is included so a plain chat/Telegram message ("find my Slack workflow")
-// can route to WORKFLOW search, not just automation/agent-internal turns (#8913).
-const WORKFLOW_CONTEXTS = ['chat', 'automation', 'tasks', 'agent_internal'] as const;
+// `general` (the active context a plain chat/Telegram turn actually seeds) is
+// included so a message like "find my Slack workflow" routes to WORKFLOW search,
+// not just automation/agent-internal turns (#8913). The gate matches active
+// contexts literally; `chat` is only an alias of the `general` *definition* and is
+// NOT expanded by normalizeContextList, so listing `chat` here would be inert.
+const WORKFLOW_CONTEXTS = ['general', 'automation', 'tasks', 'agent_internal'] as const;
 
 interface WorkflowActionParameters {
   action?: unknown;
@@ -771,9 +774,15 @@ export const workflowAction: Action = {
     {
       name: 'action',
       description:
-        'Operation: list, get, create, modify, activate, deactivate, toggle_active, delete, run, executions, revisions, restore, diagnose, eval_samples.',
+        'Operation: list, get, search, create, modify, activate, deactivate, toggle_active, delete, run, executions, revisions, restore, diagnose, eval_samples.',
       required: true,
       schema: { type: 'string' as const, enum: [...WORKFLOW_OPS] },
+    },
+    {
+      name: 'query',
+      description: 'Free text to match a workflow by name / node type for action=search.',
+      required: false,
+      schema: { type: 'string' as const },
     },
     {
       name: 'workflowId',


### PR DESCRIPTION
## Problem
The merged #8913 `search` op is gated on `WORKFLOW_CONTEXTS = ['chat', ...]`. **That gate is inert.** `satisfiesContextGate` matches active contexts literally through `normalizeContextList` → `expandContextAliases`, which only expands the finance `CONTEXT_ALIASES` map (money/balance/web3/defi) — **not** the per-definition `chat` alias of the `general` context. A plain chat/Telegram turn seeds active contexts as `['general']` (`packages/core/src/runtime/message-handler.ts:100,240`), so WORKFLOW search never fired from a normal message.

## Fix
- `WORKFLOW_CONTEXTS`: `'chat'` → `'general'` (the literal a plain turn actually emits).
- Declare the `query` parameter — `handleSearchWorkflows` reads `params.query`/`params.q` but it was undeclared, so the planner had no schema-advertised way to supply it.
- Add `search` to the `action` enum description.

## Why directly on develop
The #8913 implementation already merged via a sibling PR carrying this bug; #8961 (a divergent duplicate) was closed in favor of this focused fix.

Verified against core: `normalizeContextList` (context-normalization.ts) expands only `CONTEXT_ALIASES`; `chat` is an alias of the `general` *definition* (default-contexts.ts:41), never of the active-context list.