### PR TITLE
fix(ui): declare @radix-ui/react-compose-refs — unblocks repo-wide CI (Server/Client/Plugin/Zero-Key red on every PR)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2825,6 +2825,7 @@
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-compose-refs": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-hover-card": "^1.1.15",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -312,6 +312,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-compose-refs": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",


### PR DESCRIPTION
## TL;DR — this is a CI-baseline fix, not a feature
`develop`'s `Server Tests`, `Client Tests`, `Plugin Tests`, and all `Zero-Key *` e2e lanes are currently **RED on every open PR** — including PRs from multiple different authors (verified on #8941, #8944). It's a repo-wide CI-baseline failure, and this one-line dependency fix is the root cause.

## Root cause
`@radix-ui/react-slot@1.3.0` (pulled in transitively; used by `packages/ui`, e.g. `brand-button`/`brand-card`) imports `@radix-ui/react-compose-refs`. bun did **not** materialize that transitive dep anywhere Node can resolve it (confirmed missing in `packages/ui/node_modules` and root `node_modules`, on a clean install). So every test file importing a `packages/ui` component crashes at load:

```
Error: Cannot find package '@radix-ui/react-compose-refs' imported from
  .../packages/ui/node_modules/@radix-ui/react-slot/dist/index.mjs
```

That single missing import is enough to fail the whole lane (e.g. Server Tests: "1 failed | 159 passed"), and it hits every UI-importing lane → repo-wide red.

## Fix
Declare `@radix-ui/react-compose-refs` as a **direct** dependency of `packages/ui` (it is genuinely used via `react-slot`), so bun always installs it at the package level. It's already resolved in `bun.lock@1.1.3`; the lockfile change is a single workspace edge.

## Verification
- After the fix, the exact failing import resolves: `import('@radix-ui/react-compose-refs')` → `useComposedRefs` is a `function`.
- Diff is minimal and reviewable: `packages/ui/package.json` +1 line, `bun.lock` +1 line.

Merging this should turn the Server/Client/Plugin/Zero-Key lanes green again across all open PRs. Ref: the outage write-up on #8893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)