### PR TITLE
test(attachments): regression-cover the unsafe-URL scheme-allowlist guard (#8876)

### DIFF
--- a/packages/ui/src/components/chat/MessageAttachments.test.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.test.tsx
@@ -289,3 +289,63 @@ describe("MessageAttachments — PDF + text/code previews", () => {
     expect(screen.getByTestId("code-attachment-fallback")).not.toBeNull();
   });
 });
+
+describe("MessageAttachments — unsafe-URL handling (security/error path)", () => {
+  // An untrusted agent can put a dangerous-scheme URL on an attachment. The
+  // renderer must NEVER hand such a URL to the browser as href/src — it degrades
+  // to a non-clickable "unsupported attachment" card instead. This is the
+  // scheme-allowlist guard (isSafeAttachmentUrl) at the render boundary.
+  const DANGEROUS: Array<{ name: string; url: string }> = [
+    { name: "javascript:", url: "javascript:alert(1)" },
+    { name: "vbscript:", url: "vbscript:msgbox(1)" },
+    { name: "file:", url: "file:///etc/passwd" },
+    { name: "data:text/html", url: "data:text/html,<script>alert(1)</script>" },
+    { name: "scheme-relative", url: "//evil.example.com/x.png" },
+  ];
+
+  for (const { name, url } of DANGEROUS) {
+    it(`renders the neutralized unsafe card for a ${name} URL and never emits it`, () => {
+      const { container } = render(
+        <MessageAttachments
+          attachments={[
+            { id: "bad", url, contentType: "image", title: "evil" },
+          ]}
+        />,
+      );
+      // Degrades to the non-clickable unsafe card...
+      expect(screen.getByTestId("unsafe-attachment")).not.toBeNull();
+      // ...not an image/file/link that carries the dangerous URL.
+      expect(container.querySelector("img")).toBeNull();
+      expect(container.querySelector("a")).toBeNull();
+      // The dangerous URL must appear in NO href/src anywhere in the DOM.
+      const hrefs = Array.from(container.querySelectorAll("[href]")).map((el) =>
+        el.getAttribute("href"),
+      );
+      const srcs = Array.from(container.querySelectorAll("[src]")).map((el) =>
+        el.getAttribute("src"),
+      );
+      expect([...hrefs, ...srcs]).not.toContain(url);
+    });
+  }
+
+  it("still renders safe sibling attachments alongside an unsafe one", () => {
+    render(
+      <MessageAttachments
+        attachments={[
+          { id: "bad", url: "javascript:alert(1)", contentType: "image" },
+          {
+            id: "ok",
+            url: "https://x/cat.png",
+            contentType: "image",
+            title: "cat",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("unsafe-attachment")).not.toBeNull();
+    // The safe image is unaffected — the guard is per-attachment, not all-or-nothing.
+    expect(
+      document.querySelector('img[src="https://x/cat.png"]'),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Part of #8876 (error-handling / "rock solid" + security). The chat attachment renderer neutralizes **dangerous-scheme URLs** an untrusted agent might attach — `javascript:`, `vbscript:`, `file:`, `data:text/html`, scheme-relative `//host` — by degrading to a **non-clickable "unsupported attachment" card** (`unsafe-attachment`) and **never** handing the URL to the browser as `href`/`src` (the `isSafeAttachmentUrl` guard at the render boundary).

The other degrade paths (pdf / model3d / code download fallbacks) were tested; this **security/error path had zero coverage**. Closing that.

## Tests added (6)
- For each of `javascript:` / `vbscript:` / `file:` / `data:text/html` / scheme-relative: renders the neutralized `unsafe-attachment` card, emits **no** `<img>`/`<a>`, and the dangerous URL appears in **no** `href`/`src` anywhere in the DOM.
- A safe image rendered **alongside** an unsafe attachment still renders — proving the guard is **per-attachment**, not all-or-nothing.

## Verification
- `bun run --cwd packages/ui test -- MessageAttachments.test` → **20 passed** (was 14)
- `bunx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)