### PR TITLE
fix(security): SSRF-guard the background generate-image re-host fetch

### DIFF
--- a/packages/agent/src/api/background-routes.ts
+++ b/packages/agent/src/api/background-routes.ts
@@ -11,7 +11,9 @@
 
 import { Buffer } from "node:buffer";
 import {
+  fetchRemoteMedia,
   type IMediaGenerationService,
+  logger,
   type MediaGenerationRequest,
   type Route,
   ServiceType,
@@ -31,6 +33,9 @@ function jsonResult(status: number, body: unknown) {
   };
 }
 
+/** Cap on a re-hosted background image (generated art is small). */
+const BACKGROUND_IMAGE_MAX_BYTES = 16 * 1024 * 1024;
+
 /** Normalize a generated image (base64 / data URL / remote URL) to a served URL. */
 async function persistGeneratedImage(
   imageBase64: string | undefined,
@@ -45,11 +50,19 @@ async function persistGeneratedImage(
     if (persisted) return persisted.url;
   }
   if (/^https?:\/\//.test(imageUrl)) {
-    const resp = await fetch(imageUrl);
-    if (resp.ok) {
-      const bytes = Buffer.from(await resp.arrayBuffer());
-      const contentType = resp.headers.get("content-type") ?? mimeType;
-      return persistMediaBytes(bytes, contentType).url;
+    try {
+      // SSRF-guarded server-side fetch (mandated for all remote media fetches).
+      const { buffer, contentType } = await fetchRemoteMedia({
+        url: imageUrl,
+        maxBytes: BACKGROUND_IMAGE_MAX_BYTES,
+      });
+      return persistMediaBytes(buffer, contentType ?? mimeType).url;
+    } catch (err) {
+      logger.warn(
+        `[background] could not re-host generated image ${imageUrl}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
   }
   // Already a usable URL we couldn't (or needn't) re-host.


### PR DESCRIPTION
## Problem
`packages/agent/src/api/background-routes.ts` re-hosts a provider-returned remote image URL with a **raw `fetch(imageUrl)`**, bypassing the SSRF guard that CLAUDE.md mandates for *every* server-side attachment fetch (`packages/core/src/network` + `media/fetch.ts`). Although the URL comes from the agent's own media-generation service, policy requires the guard on all remote fetches.

## Fix
Route the re-host through `fetchRemoteMedia` from `@elizaos/core` (the same guarded helper `media-runtime.ts` and connector attachments use), with a 16MB cap. A blocked/failed fetch is logged and falls through to the pre-existing "usable URL we needn't re-host" behavior; the handler's outer try/catch still maps hard failures to 502.

Surfaced by the review of #8953 (closed as redundant — the Background feature already landed on develop, but it carried this raw fetch).