### PR TITLE
feat(orchestrator): CompletionEnvelope + independent verifier + screenshot delivery (#8895, #8898, #8904)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPLETION_ENVELOPE_INSTRUCTION,
+  type CompletionEnvelope,
+  envelopeCorrection,
+  parseCompletionEnvelope,
+  summarizeEnvelope,
+} from "../../src/services/completion-envelope.js";
+
+function validEnvelope(): CompletionEnvelope {
+  return {
+    diffSummary: "added the thing",
+    filesChanged: ["src/a.ts"],
+    testResults: [{ command: "bun test", exitCode: 0, summary: "12 passed" }],
+    screenshotPaths: [],
+    acceptanceCriteriaStatus: [
+      { criterion: "tests pass", met: true, evidence: "bun test exit 0" },
+    ],
+    residualRisks: [],
+  };
+}
+
+function fenced(obj: unknown): string {
+  return `Done!\n\n\`\`\`json\n${JSON.stringify(obj, null, 2)}\n\`\`\``;
+}
+
+describe("parseCompletionEnvelope (#8895)", () => {
+  it("returns present:false when there is no envelope (heuristic fallback)", () => {
+    expect(parseCompletionEnvelope("I finished the task.")).toEqual({
+      present: false,
+    });
+  });
+
+  it("parses a valid fenced envelope", () => {
+    const res = parseCompletionEnvelope(fenced(validEnvelope()));
+    expect(res.present).toBe(true);
+    expect(res.ok).toBe(true);
+    if (res.present && res.ok) {
+      expect(res.envelope.diffSummary).toBe("added the thing");
+      expect(res.envelope.testResults[0].exitCode).toBe(0);
+      expect(res.envelope.acceptanceCriteriaStatus[0].met).toBe(true);
+    }
+  });
+
+  it("flags a present-but-incomplete envelope (missing testResults)", () => {
+    const { testResults, ...partial } = validEnvelope();
+    void testResults;
+    const res = parseCompletionEnvelope(fenced(partial));
+    expect(res).toMatchObject({ present: true, ok: false });
+    if (res.present && !res.ok) {
+      expect(res.errors.join(" ")).toContain("testResults");
+    }
+  });
+
+  it("flags malformed test rows + bad criteria shapes", () => {
+    const bad = {
+      ...validEnvelope(),
+      testResults: [{ command: "x" }],
+      acceptanceCriteriaStatus: [{ criterion: "c" }],
+    };
+    const res = parseCompletionEnvelope(fenced(bad));
+    expect(res).toMatchObject({ present: true, ok: false });
+    if (res.present && !res.ok) {
+      expect(res.errors.some((e) => e.includes("testResults[0]"))).toBe(true);
+      expect(
+        res.errors.some((e) => e.includes("acceptanceCriteriaStatus[0]")),
+      ).toBe(true);
+    }
+  });
+
+  it("treats a fenced-but-unparseable block as a broken attempt (not absent)", () => {
+    const res = parseCompletionEnvelope("```json\n{not json}\n```");
+    expect(res).toMatchObject({ present: true, ok: false });
+  });
+
+  it("reads the LAST fenced block when several are present", () => {
+    const earlier = fenced({ diffSummary: "draft" });
+    const final = fenced(validEnvelope());
+    const res = parseCompletionEnvelope(`${earlier}\n\nthen\n\n${final}`);
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts a bare JSON object with no fence", () => {
+    const res = parseCompletionEnvelope(JSON.stringify(validEnvelope()));
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("summarizeEnvelope + envelopeCorrection (#8895)", () => {
+  it("summarizes met/unmet criteria + test results", () => {
+    const env = validEnvelope();
+    env.acceptanceCriteriaStatus.push({
+      criterion: "lint clean",
+      met: false,
+      evidence: "biome found 2 issues",
+    });
+    const s = summarizeEnvelope(env);
+    expect(s).toContain("bun test → exit 0");
+    expect(s).toContain("1/2 met");
+    expect(s).toContain("unmet: lint clean");
+  });
+
+  it("builds a correction listing the parse errors", () => {
+    const c = envelopeCorrection(["testResults must be an array"]);
+    expect(c).toContain("did not include a valid CompletionEnvelope");
+    expect(c).toContain("testResults must be an array");
+  });
+
+  it("the spawn instruction names every required key", () => {
+    for (const key of [
+      "diffSummary",
+      "filesChanged",
+      "testResults",
+      "acceptanceCriteriaStatus",
+      "residualRisks",
+    ]) {
+      expect(COMPLETION_ENVELOPE_INSTRUCTION).toContain(key);
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/independent-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/independent-verifier.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildIndependentVerifierPrompt,
+  runIndependentVerification,
+  shouldRunIndependentVerify,
+  verifierVerdict,
+} from "../../src/services/independent-verifier.js";
+
+function envelope(over: Record<string, unknown> = {}): string {
+  return `\`\`\`json\n${JSON.stringify({
+    diffSummary: "x",
+    filesChanged: ["src/a.ts"],
+    testResults: [{ command: "bun test", exitCode: 0, summary: "12 passed" }],
+    screenshotPaths: [],
+    acceptanceCriteriaStatus: [
+      { criterion: "tests pass", met: true, evidence: "exit 0" },
+    ],
+    residualRisks: [],
+    ...over,
+  })}\n\`\`\``;
+}
+
+describe("buildIndependentVerifierPrompt (#8898)", () => {
+  it("demands execution-based, read-only verification + an envelope", () => {
+    const p = buildIndependentVerifierPrompt({
+      goal: "add a button",
+      acceptanceCriteria: ["tests pass", "button renders"],
+    });
+    expect(p).toContain("INDEPENDENT verifier");
+    expect(p).toContain("Do NOT trust its narration");
+    expect(p).toMatch(/Do NOT edit/i);
+    expect(p).toContain("1. tests pass");
+    expect(p).toContain("CompletionEnvelope");
+  });
+});
+
+describe("verifierVerdict (#8898)", () => {
+  it("passes only when all criteria met and all commands green", () => {
+    const v = verifierVerdict(envelope());
+    expect(v.passed).toBe(true);
+    expect(v.inconclusive).toBe(false);
+  });
+
+  it("fails on an unmet criterion", () => {
+    const v = verifierVerdict(
+      envelope({
+        acceptanceCriteriaStatus: [
+          { criterion: "tests pass", met: false, evidence: "1 failing" },
+        ],
+      }),
+    );
+    expect(v.passed).toBe(false);
+    expect(v.unmet).toEqual(["tests pass"]);
+  });
+
+  it("fails on a non-zero test exit code", () => {
+    const v = verifierVerdict(
+      envelope({
+        testResults: [
+          { command: "bun test", exitCode: 1, summary: "1 failed" },
+        ],
+      }),
+    );
+    expect(v.passed).toBe(false);
+    expect(v.failedCommands).toEqual(["bun test"]);
+  });
+
+  it("is inconclusive (not a pass) when no envelope comes back", () => {
+    const v = verifierVerdict("I checked, looks good!");
+    expect(v.passed).toBe(false);
+    expect(v.inconclusive).toBe(true);
+  });
+
+  it("is inconclusive when the envelope reports no criteria", () => {
+    const v = verifierVerdict(envelope({ acceptanceCriteriaStatus: [] }));
+    expect(v.passed).toBe(false);
+    expect(v.inconclusive).toBe(true);
+  });
+});
+
+describe("shouldRunIndependentVerify (#8898)", () => {
+  it("defaults on for code-change tasks, off otherwise", () => {
+    expect(shouldRunIndependentVerify(() => undefined, true)).toBe(true);
+    expect(shouldRunIndependentVerify(() => undefined, false)).toBe(false);
+  });
+  it("honors explicit on/off overrides", () => {
+    expect(shouldRunIndependentVerify(() => "0", true)).toBe(false);
+    expect(shouldRunIndependentVerify(() => "always", false)).toBe(true);
+  });
+});
+
+describe("runIndependentVerification (#8898)", () => {
+  it("spawns with the verifier prompt and returns the verdict", async () => {
+    const spawnAndAwait = vi.fn(async () => envelope());
+    const v = await runIndependentVerification(
+      { goal: "g", acceptanceCriteria: ["tests pass"] },
+      { spawnAndAwait },
+    );
+    expect(v.passed).toBe(true);
+    expect(spawnAndAwait).toHaveBeenCalledTimes(1);
+    expect(spawnAndAwait.mock.calls[0][0]).toContain("INDEPENDENT verifier");
+  });
+
+  it("is inconclusive (never a false pass) when the spawn fails", async () => {
+    const v = await runIndependentVerification(
+      { goal: "g", acceptanceCriteria: ["tests pass"] },
+      {
+        spawnAndAwait: async () => {
+          throw new Error("acp spawn failed");
+        },
+      },
+    );
+    expect(v.passed).toBe(false);
+    expect(v.inconclusive).toBe(true);
+    expect(v.summary).toContain("failed to run");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectScreenshotPaths,
+  deliverScreenshots,
+  MAX_SCREENSHOTS,
+  screenshotsToAttachments,
+} from "../../src/services/screenshot-delivery.js";
+
+const ROOM = "11111111-1111-1111-1111-111111111111";
+
+function envelopeText(screenshotPaths: string[]): string {
+  return `Done.\n\`\`\`json\n${JSON.stringify({
+    diffSummary: "x",
+    filesChanged: [],
+    testResults: [],
+    screenshotPaths,
+    acceptanceCriteriaStatus: [],
+    residualRisks: [],
+  })}\n\`\`\``;
+}
+
+describe("collectScreenshotPaths (#8904)", () => {
+  it("reads screenshot paths from a valid CompletionEnvelope", () => {
+    const paths = collectScreenshotPaths(
+      envelopeText(["/tmp/a.png", "/tmp/b.jpg"]),
+      undefined,
+    );
+    expect(paths).toEqual(["/tmp/a.png", "/tmp/b.jpg"]);
+  });
+
+  it("also reads metadata.artifactPaths / screenshotPaths, deduped", () => {
+    const paths = collectScreenshotPaths(envelopeText(["/tmp/a.png"]), {
+      artifactPaths: ["/tmp/a.png", "/tmp/c.webp"],
+      screenshotPaths: ["/tmp/d.gif"],
+    });
+    // envelope first, then metadata.screenshotPaths, then metadata.artifactPaths (a.png deduped)
+    expect(paths).toEqual(["/tmp/a.png", "/tmp/d.gif", "/tmp/c.webp"]);
+  });
+
+  it("filters out non-image paths", () => {
+    expect(
+      collectScreenshotPaths(undefined, {
+        artifactPaths: ["/tmp/log.txt", "/tmp/shot.png"],
+      }),
+    ).toEqual(["/tmp/shot.png"]);
+  });
+
+  it("returns [] when there is no envelope and no metadata", () => {
+    expect(collectScreenshotPaths("just prose", undefined)).toEqual([]);
+  });
+});
+
+describe("screenshotsToAttachments (#8904)", () => {
+  it("builds image Media and caps the count", () => {
+    const many = Array.from({ length: 9 }, (_, i) => `/tmp/${i}.png`);
+    const atts = screenshotsToAttachments(many);
+    expect(atts).toHaveLength(MAX_SCREENSHOTS);
+    expect(atts[0]).toMatchObject({ url: "/tmp/0.png", contentType: "image" });
+    expect(atts[0].title).toBe("0.png");
+  });
+});
+
+describe("deliverScreenshots (#8904)", () => {
+  it("posts a media message with capped attachments and returns the count", async () => {
+    const send = vi.fn(async () => undefined);
+    const n = await deliverScreenshots(
+      send,
+      { source: "telegram", roomId: ROOM },
+      ["/tmp/a.png", "/tmp/b.png"],
+      "fix-ui",
+    );
+    expect(n).toBe(2);
+    const [target, content] = send.mock.calls[0];
+    expect(target).toEqual({ source: "telegram", roomId: ROOM });
+    expect(content.attachments).toHaveLength(2);
+    expect(content.text).toContain("2 screenshots from fix-ui");
+  });
+
+  it("is a no-op with no paths", async () => {
+    const send = vi.fn(async () => undefined);
+    expect(
+      await deliverScreenshots(send, { source: "t", roomId: ROOM }, []),
+    ).toBe(0);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the send fails (best-effort)", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("upload failed");
+    });
+    expect(
+      await deliverScreenshots(send, { source: "t", roomId: ROOM }, [
+        "/tmp/a.png",
+      ]),
+    ).toBe(0);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -1920,6 +1920,11 @@ export {
   summarizeEnvelope,
 } from "./services/completion-envelope.js";
 export {
+  collectScreenshotPaths,
+  deliverScreenshots,
+  screenshotsToAttachments,
+} from "./services/screenshot-delivery.js";
+export {
   AcpSessionStore,
   FileSessionStore,
   InMemorySessionStore,

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -1913,6 +1913,13 @@ export { AcpService } from "./services/acp-service.js";
 // Terminal-output normalizer for chat surfaces; consumed by live smoke harnesses.
 export { cleanForChat } from "./services/ansi-utils.js";
 export {
+  COMPLETION_ENVELOPE_INSTRUCTION,
+  type CompletionEnvelope,
+  envelopeCorrection,
+  parseCompletionEnvelope,
+  summarizeEnvelope,
+} from "./services/completion-envelope.js";
+export {
   AcpSessionStore,
   FileSessionStore,
   InMemorySessionStore,

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -1920,6 +1920,13 @@ export {
   summarizeEnvelope,
 } from "./services/completion-envelope.js";
 export {
+  buildIndependentVerifierPrompt,
+  type IndependentVerifierVerdict,
+  runIndependentVerification,
+  shouldRunIndependentVerify,
+  verifierVerdict,
+} from "./services/independent-verifier.js";
+export {
   collectScreenshotPaths,
   deliverScreenshots,
   screenshotsToAttachments,

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -1,0 +1,236 @@
+/**
+ * CompletionEnvelope — a structured, machine-checkable contract a sub-agent
+ * returns when it claims a task is done (#8895, EPIC #8884).
+ *
+ * Today sub-agents claim completion in free-form prose, so grilling is
+ * prompt-based, not contract-based. This module defines the envelope schema,
+ * the instruction injected into the spawn prompt, and a pure parser/validator.
+ * The completion path runs structural validation BEFORE the LLM judge: a present
+ * but malformed envelope is auto-blocked with a targeted re-prompt, while an
+ * ABSENT envelope falls back to the existing heuristic path (back-compat).
+ */
+
+/** One command the sub-agent ran to verify its work. */
+export interface EnvelopeTestResult {
+  command: string;
+  exitCode: number;
+  summary: string;
+}
+
+/** Per-criterion self-assessment with the evidence backing it. */
+export interface EnvelopeCriterionStatus {
+  criterion: string;
+  met: boolean;
+  evidence: string;
+}
+
+/** The structured final report a sub-agent returns on completion. */
+export interface CompletionEnvelope {
+  diffSummary: string;
+  filesChanged: string[];
+  testResults: EnvelopeTestResult[];
+  screenshotPaths: string[];
+  trajectoryPath?: string;
+  acceptanceCriteriaStatus: EnvelopeCriterionStatus[];
+  residualRisks: string[];
+}
+
+/**
+ * The instruction appended to the spawn prompt. Asks the agent to END its final
+ * message with a fenced ```json block matching the schema, in ADDITION to its
+ * prose — so weak adapters that ignore it still produce a usable prose
+ * completion (the parser treats a missing block as "fall back to heuristic").
+ */
+export const COMPLETION_ENVELOPE_INSTRUCTION = [
+  "When (and only when) you report the task FINISHED, end your final message with a fenced JSON code block matching this schema, after any prose:",
+  "```json",
+  JSON.stringify(
+    {
+      diffSummary: "string — one-line summary of what changed",
+      filesChanged: ["string — repo-relative paths"],
+      testResults: [
+        {
+          command: "string",
+          exitCode: 0,
+          summary: "string — pass/fail detail",
+        },
+      ],
+      screenshotPaths: ["string — absolute paths to any screenshots/artifacts"],
+      trajectoryPath: "string — optional path to a trajectory JSONL",
+      acceptanceCriteriaStatus: [
+        { criterion: "string", met: true, evidence: "string — how you know" },
+      ],
+      residualRisks: ["string — anything still uncertain"],
+    },
+    null,
+    2,
+  ),
+  "```",
+  "Required keys: diffSummary, filesChanged, testResults, acceptanceCriteriaStatus, residualRisks (use empty arrays where nothing applies). Do NOT emit the block while still working or when blocked — only on genuine completion.",
+].join("\n");
+
+/** Result of attempting to read an envelope out of a completion message. */
+export type CompletionEnvelopeParse =
+  | { present: false }
+  | { present: true; ok: true; envelope: CompletionEnvelope }
+  | { present: true; ok: false; errors: string[] };
+
+const FENCED_JSON_RE = /```json\s*\n([\s\S]*?)```/gi;
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+function extractJsonCandidate(text: string): string | null {
+  // Prefer the LAST fenced ```json block (the completion envelope comes last).
+  let match: RegExpExecArray | null;
+  let last: string | null = null;
+  FENCED_JSON_RE.lastIndex = 0;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((match = FENCED_JSON_RE.exec(text)) !== null) {
+    last = match[1]?.trim() ?? null;
+  }
+  if (last) return last;
+  // No fence: only treat the whole message as JSON when it clearly looks like
+  // an object (avoids misreading prose as an absent-envelope fallback).
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed;
+  return null;
+}
+
+/**
+ * Pure: detect + validate a CompletionEnvelope in a sub-agent's final message.
+ * Absent → `{present:false}` (caller uses the heuristic path). Present but
+ * invalid → `{present:true, ok:false, errors}` (caller re-prompts/blocks).
+ */
+export function parseCompletionEnvelope(text: string): CompletionEnvelopeParse {
+  const candidate = extractJsonCandidate(text ?? "");
+  if (!candidate) return { present: false };
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(candidate);
+  } catch {
+    // A fenced json block that doesn't parse IS a (broken) attempt — block it.
+    return { present: true, ok: false, errors: ["envelope is not valid JSON"] };
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      present: true,
+      ok: false,
+      errors: ["envelope is not a JSON object"],
+    };
+  }
+  const o = raw as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (typeof o.diffSummary !== "string")
+    errors.push("diffSummary must be a string");
+  if (!isStringArray(o.filesChanged))
+    errors.push("filesChanged must be a string[]");
+  if (!isStringArray(o.residualRisks))
+    errors.push("residualRisks must be a string[]");
+  if (!Array.isArray(o.screenshotPaths)) {
+    // optional-ish but must be an array when present; default to [] if missing
+    if (o.screenshotPaths !== undefined)
+      errors.push("screenshotPaths must be a string[]");
+  }
+
+  const testResults: EnvelopeTestResult[] = [];
+  if (!Array.isArray(o.testResults)) {
+    errors.push("testResults must be an array");
+  } else {
+    for (const [i, t] of o.testResults.entries()) {
+      const tr = t as Record<string, unknown>;
+      if (
+        !tr ||
+        typeof tr.command !== "string" ||
+        typeof tr.exitCode !== "number" ||
+        typeof tr.summary !== "string"
+      ) {
+        errors.push(`testResults[${i}] must be {command, exitCode, summary}`);
+      } else {
+        testResults.push({
+          command: tr.command,
+          exitCode: tr.exitCode,
+          summary: tr.summary,
+        });
+      }
+    }
+  }
+
+  const criteria: EnvelopeCriterionStatus[] = [];
+  if (!Array.isArray(o.acceptanceCriteriaStatus)) {
+    errors.push("acceptanceCriteriaStatus must be an array");
+  } else {
+    for (const [i, c] of o.acceptanceCriteriaStatus.entries()) {
+      const cs = c as Record<string, unknown>;
+      if (
+        !cs ||
+        typeof cs.criterion !== "string" ||
+        typeof cs.met !== "boolean" ||
+        typeof cs.evidence !== "string"
+      ) {
+        errors.push(
+          `acceptanceCriteriaStatus[${i}] must be {criterion, met, evidence}`,
+        );
+      } else {
+        criteria.push({
+          criterion: cs.criterion,
+          met: cs.met,
+          evidence: cs.evidence,
+        });
+      }
+    }
+  }
+
+  if (errors.length > 0) return { present: true, ok: false, errors };
+
+  return {
+    present: true,
+    ok: true,
+    envelope: {
+      diffSummary: o.diffSummary as string,
+      filesChanged: o.filesChanged as string[],
+      testResults,
+      screenshotPaths: isStringArray(o.screenshotPaths)
+        ? o.screenshotPaths
+        : [],
+      trajectoryPath:
+        typeof o.trajectoryPath === "string" ? o.trajectoryPath : undefined,
+      acceptanceCriteriaStatus: criteria,
+      residualRisks: o.residualRisks as string[],
+    },
+  };
+}
+
+/** Compact human summary of a validated envelope, for the verifier/log. */
+export function summarizeEnvelope(env: CompletionEnvelope): string {
+  const tests = env.testResults
+    .map((t) => `${t.command} → exit ${t.exitCode}`)
+    .join("; ");
+  const unmet = env.acceptanceCriteriaStatus
+    .filter((c) => !c.met)
+    .map((c) => c.criterion);
+  return [
+    `diff: ${env.diffSummary}`,
+    `files: ${env.filesChanged.length}`,
+    tests ? `tests: ${tests}` : "tests: none",
+    `criteria: ${env.acceptanceCriteriaStatus.filter((c) => c.met).length}/${env.acceptanceCriteriaStatus.length} met`,
+    unmet.length > 0 ? `unmet: ${unmet.join("; ")}` : "",
+    env.residualRisks.length > 0
+      ? `risks: ${env.residualRisks.join("; ")}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}
+
+/** A targeted re-prompt for a present-but-malformed envelope. */
+export function envelopeCorrection(errors: string[]): string {
+  return [
+    "Your completion did not include a valid CompletionEnvelope. Fix these and re-report when truly done:",
+    ...errors.map((e) => `- ${e}`),
+    "End your final message with the fenced ```json block exactly matching the required schema.",
+  ].join("\n");
+}

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -13,6 +13,7 @@
  * @module services/goal-prompt
  */
 
+import { COMPLETION_ENVELOPE_INSTRUCTION } from "./completion-envelope.js";
 import type { AttemptReflection } from "./orchestrator-task-types.js";
 
 /** The coding-relevant capability fence applied when a caller does not pass an
@@ -196,6 +197,10 @@ export function buildGoalPrompt(input: GoalPromptInput): string {
     capabilityLine,
     "--- Working Agreement ---",
     bulletList([...COMPLETION_CONTRACT]),
+    // #8895: ask for a machine-checkable CompletionEnvelope on completion so the
+    // verifier can grill against a contract, not free-form prose.
+    "--- Completion Report ---",
+    COMPLETION_ENVELOPE_INSTRUCTION,
     "--- Task ---",
     task,
   );

--- a/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
@@ -1,0 +1,146 @@
+/**
+ * Independent read-only verifier sub-agent (#8898, EPIC #8884).
+ *
+ * The goal verifier judges only what the coding sub-agent narrated — it can't
+ * independently run `bun test`, read a file, or inspect the diff. Best practice
+ * (Agent-as-a-Judge / Validation Chain) spawns a SEPARATE read-only agent that
+ * verifies by execution. This module builds that verifier's spawn prompt, runs
+ * it (via an injected spawn-and-await so it unit-tests without ACP), and turns
+ * its CompletionEnvelope into an execution-grounded verdict for `validateTask`.
+ *
+ * "Read-only" is enforced by the prompt + the spawn's approval preset (the spawn
+ * API has no hard tool whitelist): the verifier is told to run/read/inspect only,
+ * never edit.
+ */
+
+import {
+  type CompletionEnvelope,
+  parseCompletionEnvelope,
+} from "./completion-envelope.js";
+
+/** Build the independent verifier's spawn prompt. */
+export function buildIndependentVerifierPrompt(input: {
+  goal: string;
+  acceptanceCriteria: string[];
+  diffSummary?: string;
+}): string {
+  const criteria =
+    input.acceptanceCriteria.length > 0
+      ? input.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n")
+      : "(none provided — verify the goal is genuinely, observably met)";
+  return [
+    "--- Independent Verification ---",
+    "You are an INDEPENDENT verifier. A coding agent claims the task below is done. Do NOT trust its narration — confirm by EXECUTION.",
+    "Read-only: you may run tests/build/typecheck/lint, read files, and inspect the git diff. Do NOT edit, write, or commit anything.",
+    "",
+    "--- Goal ---",
+    input.goal.trim(),
+    ...(input.diffSummary ? ["--- Claimed change ---", input.diffSummary] : []),
+    "--- Acceptance Criteria ---",
+    criteria,
+    "",
+    "Steps: run the relevant tests/build/typecheck; read the changed files; inspect `git diff`. For EACH acceptance criterion, decide met/unmet from command output you actually ran.",
+    "Then output ONLY a CompletionEnvelope JSON block: set testResults to the commands you ran (with real exitCodes), acceptanceCriteriaStatus to your per-criterion verdict with the command output as evidence, and residualRisks to anything you couldn't confirm.",
+  ].join("\n");
+}
+
+export interface IndependentVerifierVerdict {
+  /** True only when every criterion is met AND every test command exited 0. */
+  passed: boolean;
+  /** Criteria the verifier marked unmet (or all, when the envelope was unusable). */
+  unmet: string[];
+  /** Test commands that exited non-zero. */
+  failedCommands: string[];
+  /** One-line human summary. */
+  summary: string;
+  /** True when no usable envelope came back (caller should not auto-pass). */
+  inconclusive: boolean;
+}
+
+/** Turn the verifier's parsed envelope into an execution-grounded verdict. */
+export function verifierVerdict(
+  completionText: string,
+): IndependentVerifierVerdict {
+  const parse = parseCompletionEnvelope(completionText);
+  if (!parse.present || !parse.ok) {
+    return {
+      passed: false,
+      unmet: [],
+      failedCommands: [],
+      summary:
+        "Independent verifier returned no usable CompletionEnvelope — treat as unverified.",
+      inconclusive: true,
+    };
+  }
+  return verdictFromEnvelope(parse.envelope);
+}
+
+/** Verdict directly from a (already-parsed) envelope. */
+export function verdictFromEnvelope(
+  env: CompletionEnvelope,
+): IndependentVerifierVerdict {
+  const unmet = env.acceptanceCriteriaStatus
+    .filter((c) => !c.met)
+    .map((c) => c.criterion);
+  const failedCommands = env.testResults
+    .filter((t) => t.exitCode !== 0)
+    .map((t) => t.command);
+  // No criteria reported is itself inconclusive — a real verifier confirms each.
+  const inconclusive = env.acceptanceCriteriaStatus.length === 0;
+  const passed =
+    !inconclusive && unmet.length === 0 && failedCommands.length === 0;
+  const summary = passed
+    ? `Independent verification passed: ${env.acceptanceCriteriaStatus.length} criteria met, ${env.testResults.length} command(s) green.`
+    : inconclusive
+      ? "Independent verifier reported no per-criterion status — unverified."
+      : `Independent verification failed: ${unmet.length} unmet criteria, ${failedCommands.length} failing command(s).`;
+  return { passed, unmet, failedCommands, summary, inconclusive };
+}
+
+/** Default-on for code-change tasks; gated by ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY. */
+export function shouldRunIndependentVerify(
+  getSetting: (key: string) => string | undefined | null,
+  hasCodeChanges: boolean,
+): boolean {
+  const raw = getSetting("ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY");
+  if (raw === "0" || raw === "false") return false;
+  if (raw === "1" || raw === "always") return true;
+  // Default: on for code-change tasks only.
+  return hasCodeChanges;
+}
+
+export interface IndependentVerifyDeps {
+  /**
+   * Spawn the read-only verifier with `prompt` and resolve its final completion
+   * text. The caller wires this to AcpService.spawnSession + awaiting the
+   * session's task_complete; tests inject a stub.
+   */
+  spawnAndAwait: (prompt: string) => Promise<string>;
+}
+
+/**
+ * Run an independent verification pass and return the verdict. A spawn failure
+ * is inconclusive (never a false pass) so the caller keeps the task in
+ * validating rather than promoting it on a verifier crash.
+ */
+export async function runIndependentVerification(
+  input: { goal: string; acceptanceCriteria: string[]; diffSummary?: string },
+  deps: IndependentVerifyDeps,
+): Promise<IndependentVerifierVerdict> {
+  const prompt = buildIndependentVerifierPrompt(input);
+  let completion: string;
+  try {
+    completion = await deps.spawnAndAwait(prompt);
+  } catch (error) {
+    return {
+      passed: false,
+      unmet: [],
+      failedCommands: [],
+      summary: `Independent verifier failed to run: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      inconclusive: true,
+    };
+  }
+  return verifierVerdict(completion);
+}

--- a/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
@@ -1,0 +1,107 @@
+/**
+ * Deliver a sub-agent's screenshots/artifacts to the originating chat (#8904,
+ * EPIC #8885).
+ *
+ * The router already forwards text, diffs, and verified URLs at task_complete
+ * but never the visual proof. When a completion carries screenshot paths (in its
+ * CompletionEnvelope, #8895, or stamped on `session.metadata.artifactPaths`),
+ * this posts them to the origin room as media — connectors that render
+ * `Content.attachments` (Telegram via `sendMedia` PHOTO) show them inline, so a
+ * Telegram user sees what a Claude-Code user sees in-terminal.
+ */
+
+import type { Content, Media, UUID } from "@elizaos/core";
+import { ContentType, logger } from "@elizaos/core";
+import { parseCompletionEnvelope } from "./completion-envelope.js";
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp)$/i;
+/** Cap how many screenshots we forward so a chatty task can't flood the chat. */
+export const MAX_SCREENSHOTS = 5;
+
+/**
+ * Pure: collect candidate screenshot paths for a completion. Prefers the
+ * validated CompletionEnvelope's `screenshotPaths`, then any
+ * `metadata.artifactPaths`/`screenshotPaths`, deduped and filtered to
+ * image-looking paths.
+ */
+export function collectScreenshotPaths(
+  completionText: string | undefined,
+  metadata: Record<string, unknown> | undefined,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (p: unknown) => {
+    if (
+      typeof p === "string" &&
+      p.trim() &&
+      IMAGE_EXT_RE.test(p) &&
+      !seen.has(p)
+    ) {
+      seen.add(p);
+      out.push(p);
+    }
+  };
+
+  if (completionText) {
+    const parsed = parseCompletionEnvelope(completionText);
+    if (parsed.present && parsed.ok)
+      for (const p of parsed.envelope.screenshotPaths) push(p);
+  }
+  if (metadata) {
+    for (const key of ["screenshotPaths", "artifactPaths"]) {
+      const v = metadata[key];
+      if (Array.isArray(v)) for (const p of v) push(p);
+    }
+  }
+  return out;
+}
+
+/** Pure: turn screenshot paths into capped image `Media[]` for `Content.attachments`. */
+export function screenshotsToAttachments(
+  paths: string[],
+  maxCount = MAX_SCREENSHOTS,
+): Media[] {
+  return paths.slice(0, maxCount).map((p, i) => ({
+    id: `screenshot-${i}` as UUID,
+    url: p,
+    title: p.split("/").pop() || `screenshot-${i}`,
+    contentType: ContentType.IMAGE,
+    source: "sub-agent",
+  }));
+}
+
+type SendToTarget = (
+  target: { source: string; roomId: UUID },
+  content: Content,
+) => Promise<unknown>;
+
+/**
+ * Post the collected screenshots to the origin room as a single media message.
+ * Best-effort: no paths → no-op; a send failure is logged, never thrown (it must
+ * not break the completion flow). Returns the count delivered.
+ */
+export async function deliverScreenshots(
+  send: SendToTarget,
+  target: { source: string; roomId: UUID },
+  paths: string[],
+  label?: string,
+): Promise<number> {
+  const attachments = screenshotsToAttachments(paths);
+  if (attachments.length === 0) return 0;
+  const who = label ? ` from ${label}` : "";
+  try {
+    await send(target, {
+      text: `📸 ${attachments.length} screenshot${attachments.length === 1 ? "" : "s"}${who}`,
+      source: target.source,
+      attachments,
+    });
+    return attachments.length;
+  } catch (error) {
+    logger.warn(
+      `[screenshot-delivery] failed to deliver ${attachments.length} screenshot(s): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return 0;
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -15,6 +15,10 @@ import {
   extractParentAgentDirective,
   parentAgentMarkerIndex,
 } from "./parent-agent-dispatch.js";
+import {
+  collectScreenshotPaths,
+  deliverScreenshots,
+} from "./screenshot-delivery.js";
 import { SsrfBlockedError, safeFetch } from "./ssrf-guard.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
 import {
@@ -943,6 +947,26 @@ export class SubAgentRouter extends Service {
             error: err instanceof Error ? err.message : String(err),
           });
         });
+      // #8904: forward any screenshots/artifacts the completion carries to the
+      // origin chat as photos (best-effort; missing target/paths → no-op). The
+      // connector renders Content.attachments (Telegram via sendMedia PHOTO).
+      const completionText =
+        pickPayloadString(data, "response") ??
+        pickPayloadString(data, "finalText");
+      const screenshotPaths = collectScreenshotPaths(
+        completionText,
+        session.metadata as Record<string, unknown> | undefined,
+      ).filter((p) => fs.existsSync(p));
+      const sendShots = (this.runtime as RuntimeWithSendTarget)
+        .sendMessageToTarget;
+      if (screenshotPaths.length > 0 && origin.source && sendShots) {
+        await deliverScreenshots(
+          (t, c) => sendShots(t, c),
+          { source: origin.source, roomId: origin.roomId },
+          screenshotPaths,
+          origin.label,
+        );
+      }
     }
     const routingKind = routingKindForEvent(event, data, capExceeded);
     const targets = swarmTargetsForRouting(origin, routingKind);


### PR DESCRIPTION
Three coupled children of the grilling/supervision epics, anchored on a structured completion contract.

## #8895 — CompletionEnvelope schema (EPIC #8884)
A machine-checkable contract a sub-agent returns on completion, so grilling is contract-based not prose-based.
- `completion-envelope.ts`: the `CompletionEnvelope` type, a **pure** `parseCompletionEnvelope` (reads the last fenced ```json block or a bare object; tri-state: **absent → heuristic fallback** (back-compat), **present-but-malformed → block/re-prompt**, **valid → structured fields**), `summarizeEnvelope`, `envelopeCorrection`.
- `buildGoalPrompt` injects `COMPLETION_ENVELOPE_INSTRUCTION` ("--- Completion Report ---") so a genuine completion ends with the envelope.

## #8898 — independent read-only verifier (EPIC #8884)
Confirms by execution instead of trusting narration (Agent-as-a-Judge).
- `independent-verifier.ts`: `buildIndependentVerifierPrompt` (read-only: run tests/build, read files, inspect diff, output an envelope), `verifierVerdict` (passes only when every criterion met AND every command exited 0; no-envelope / no-criteria → **inconclusive, never a false pass**), `shouldRunIndependentVerify` (gate `ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY`, default on for code-change tasks), `runIndependentVerification` (injected spawn-and-await; spawn failure → inconclusive).

## #8904 — screenshot/artifact delivery to chat (EPIC #8885)
- `screenshot-delivery.ts`: `collectScreenshotPaths` (from the envelope's `screenshotPaths` + `metadata.artifactPaths`, deduped/image-filtered), `screenshotsToAttachments` (capped image `Media[]`), `deliverScreenshots` (one media message to the origin via `sendMessageToTarget`; Telegram's `sendMedia` streams local files as PHOTO).
- `sub-agent-router` forwards them at `task_complete` (filtered to existing files, count-capped, best-effort).

## Tests
28 unit cases across the three modules (envelope parse/validate/summarize/correction; verifier prompt + verdict + gate + runner; screenshot collect/cap/deliver). Existing goal-prompt + router-notification suites still green. Orchestrator typecheck clean for the changed files.

## Notes
- The completion-path **gates** (envelope-parse → grill block; independent-verify spawn on `validating` → `validateTask`) are the integration points in the grilling verifier (`goal-llm-verifier` / `orchestrator-task-service`), which the in-flight #8950 reworks — landing the wiring there avoids conflicting edits. The contracts, parsers, verdict logic, prompt injection, and the screenshot forwarder land here and are independently unit-verified.
- Live scenario-runner trajectories are the remaining real-evidence step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)