### PR TITLE
fix(app-control): scope view rollback to the workdir (no repo-wide reset --hard)

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-rollback.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-rollback.test.ts
@@ -123,7 +123,7 @@ describe("createPreEditSnapshot", () => {
 		// The snapshot must stage everything and commit with --no-verify (skip
 		// hooks) + --allow-empty (no diff still produces a snapshot point).
 		const addCall = calls.find((c) => c.args[0] === "add");
-		expect(addCall?.args).toEqual(["add", "-A"]);
+		expect(addCall?.args).toEqual(["add", "-A", "--", "."]);
 		const commitCall = calls.find((c) => c.args[0] === "commit");
 		expect(commitCall?.args).toContain("--no-verify");
 		expect(commitCall?.args).toContain("--allow-empty");
@@ -144,17 +144,23 @@ describe("createPreEditSnapshot", () => {
 });
 
 describe("rollbackToSnapshot", () => {
-	it("runs git reset --hard <sha> in the workdir", async () => {
+	it("restores ONLY the workdir (checkout + clean, never reset --hard)", async () => {
 		const sha = "abc1234";
 		const { git, calls } = fakeGit({
 			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
-			reset: {},
+			checkout: {},
+			clean: {},
 		});
 		const result = await rollbackToSnapshot("/work/dir", sha, { git });
 		expect(result).toEqual({ ok: true, sha });
-		const resetCall = calls.find((c) => c.args[0] === "reset");
-		expect(resetCall?.args).toEqual(["reset", "--hard", sha]);
-		expect(resetCall?.cwd).toBe("/work/dir");
+		// A repo-wide `git reset --hard` would discard unrelated uncommitted work.
+		expect(calls.some((c) => c.args[0] === "reset")).toBe(false);
+		const checkoutCall = calls.find((c) => c.args[0] === "checkout");
+		expect(checkoutCall?.args).toEqual(["checkout", sha, "--", "."]);
+		expect(checkoutCall?.cwd).toBe("/work/dir");
+		const cleanCall = calls.find((c) => c.args[0] === "clean");
+		expect(cleanCall?.args).toEqual(["clean", "-fd", "--", "."]);
+		expect(cleanCall?.cwd).toBe("/work/dir");
 	});
 
 	it("refuses an invalid sha without touching git", async () => {
@@ -164,14 +170,14 @@ describe("rollbackToSnapshot", () => {
 		expect(calls).toHaveLength(0);
 	});
 
-	it("surfaces a git reset failure", async () => {
+	it("surfaces a git checkout failure", async () => {
 		const { git } = fakeGit({
 			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
-			reset: { exitCode: 1, stderr: "unknown revision" },
+			checkout: { exitCode: 1, stderr: "unknown revision" },
 		});
 		const result = await rollbackToSnapshot("/work/dir", "abc1234", { git });
 		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.reason).toContain("git reset --hard failed");
+		if (!result.ok) expect(result.reason).toContain("git checkout");
 	});
 });
 
@@ -285,7 +291,8 @@ describe("runViewsRollback", () => {
 		const runtime = createRuntime(tasks);
 		const { git, calls } = fakeGit({
 			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
-			reset: {},
+			checkout: {},
+			clean: {},
 		});
 		const reregister = vi.fn(async () => ({
 			ok: true,
@@ -303,10 +310,11 @@ describe("runViewsRollback", () => {
 		});
 
 		expect(result.success).toBe(true);
-		// reset --hard <sha> ran in the recorded workdir.
-		const resetCall = calls.find((c) => c.args[0] === "reset");
-		expect(resetCall?.args).toEqual(["reset", "--hard", sha]);
-		expect(resetCall?.cwd).toBe("/repo/plugins/plugin-habits");
+		// scoped checkout restored the recorded workdir (never reset --hard).
+		expect(calls.some((c) => c.args[0] === "reset")).toBe(false);
+		const checkoutCall = calls.find((c) => c.args[0] === "checkout");
+		expect(checkoutCall?.args).toEqual(["checkout", sha, "--", "."]);
+		expect(checkoutCall?.cwd).toBe("/repo/plugins/plugin-habits");
 		// re-registration was triggered with the same workdir.
 		expect(reregister).toHaveBeenCalledWith("/repo/plugins/plugin-habits");
 		// the consumed snapshot record was deleted.
@@ -338,7 +346,8 @@ describe("runViewsRollback", () => {
 		const runtime = createRuntime([]);
 		const { git, calls } = fakeGit({
 			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
-			reset: {},
+			checkout: {},
+			clean: {},
 		});
 		const reregister = vi.fn(async () => ({ ok: true }));
 		const result = await runViewsRollback({
@@ -350,8 +359,8 @@ describe("runViewsRollback", () => {
 			reregister,
 		});
 		expect(result.success).toBe(true);
-		const resetCall = calls.find((c) => c.args[0] === "reset");
-		expect(resetCall?.args).toEqual(["reset", "--hard", "cafe123"]);
+		const checkoutCall = calls.find((c) => c.args[0] === "checkout");
+		expect(checkoutCall?.args).toEqual(["checkout", "cafe123", "--", "."]);
 		expect(reregister).toHaveBeenCalledWith("/explicit/dir");
 	});
 
@@ -372,7 +381,8 @@ describe("runViewsRollback", () => {
 		const runtime = createRuntime(tasks);
 		const { git } = fakeGit({
 			"rev-parse:--is-inside-work-tree": { stdout: "true\n" },
-			reset: {},
+			checkout: {},
+			clean: {},
 		});
 		const reregister = vi.fn(async () => ({
 			ok: false,

--- a/plugins/plugin-app-control/src/actions/views-snapshot.ts
+++ b/plugins/plugin-app-control/src/actions/views-snapshot.ts
@@ -6,8 +6,9 @@
  * Before a coding agent edits a view/plugin workdir we take a pre-edit
  * snapshot: a non-destructive `git commit --no-verify --allow-empty` that
  * captures the working tree exactly as it was. The resulting SHA is recorded
- * on a Task so the `rollback` sub-mode can later run `git reset --hard <sha>`
- * to restore the source if the edit goes wrong (the user's "undo creation"
+ * on a Task so the `rollback` sub-mode can later restore that workdir (scoped
+ * `git checkout <sha> -- .` + `git clean`, never a repo-wide `git reset --hard`)
+ * if the edit goes wrong (the user's "undo creation"
  * ask, #8915).
  *
  * We shell out to `git` directly against the target `workdir` (mirroring
@@ -87,10 +88,12 @@ export function isLikelySha(value: string): boolean {
 }
 
 /**
- * Take a pre-edit snapshot of `workdir`. Stages every change (`git add -A`) and
- * writes a non-destructive commit (`--no-verify --allow-empty`) so the working
- * tree is preserved verbatim and the returned SHA points at it. The commit is
- * non-destructive: nothing in the working tree is reset or discarded.
+ * Take a pre-edit snapshot of `workdir`. Stages changes **scoped to the workdir**
+ * (`git add -A -- .`, run with `cwd=workdir`, so the snapshot never sweeps in
+ * unrelated repo changes) and writes a non-destructive commit
+ * (`--no-verify --allow-empty`) so the workdir is preserved verbatim and the
+ * returned SHA points at it. The commit is non-destructive: nothing in the
+ * working tree is reset or discarded.
  *
  * Returns the snapshot SHA on success. On any git failure (not a repo, no
  * identity, etc.) returns `{ ok: false }` with the reason — callers treat a
@@ -111,7 +114,9 @@ export async function createPreEditSnapshot(
 		};
 	}
 
-	const add = await git(["add", "-A"], workdir);
+	// Scope staging to the workdir subtree (cwd=workdir) so a snapshot never
+	// stages unrelated changes elsewhere in the repo.
+	const add = await git(["add", "-A", "--", "."], workdir);
 	if (add.exitCode !== 0) {
 		return {
 			ok: false,
@@ -146,9 +151,11 @@ export async function createPreEditSnapshot(
 }
 
 /**
- * Restore `workdir` to the snapshot `sha` via `git reset --hard <sha>`. This
- * discards every change made after the snapshot — exactly the "undo creation"
- * semantics the rollback sub-mode promises.
+ * Restore `workdir` to the snapshot `sha`, **scoped to the workdir only**:
+ * `git checkout <sha> -- .` restores tracked files and `git clean -fd -- .`
+ * removes files created after the snapshot (respecting `.gitignore`). We
+ * deliberately do NOT `git reset --hard`, which would discard unrelated
+ * working-tree changes across the entire repo — a data-loss footgun.
  */
 export async function rollbackToSnapshot(
 	workdir: string,
@@ -169,11 +176,23 @@ export async function rollbackToSnapshot(
 		};
 	}
 
-	const reset = await git(["reset", "--hard", trimmed], workdir);
-	if (reset.exitCode !== 0) {
+	// Restore only this workdir — NEVER `git reset --hard`, which is repo-wide
+	// and would discard unrelated uncommitted work elsewhere in the checkout.
+	const restore = await git(["checkout", trimmed, "--", "."], workdir);
+	if (restore.exitCode !== 0) {
 		return {
 			ok: false,
-			reason: `git reset --hard failed: ${(reset.stderr || reset.stdout).trim()}`,
+			reason: `git checkout ${trimmed} failed: ${(restore.stderr || restore.stdout).trim()}`,
+		};
+	}
+
+	// Remove files created after the snapshot, scoped to the workdir. `-d` for
+	// new dirs; no `-x`, so .gitignore'd build output / deps are left untouched.
+	const clean = await git(["clean", "-fd", "--", "."], workdir);
+	if (clean.exitCode !== 0) {
+		return {
+			ok: false,
+			reason: `git clean failed: ${(clean.stderr || clean.stdout).trim()}`,
 		};
 	}
 


### PR DESCRIPTION
## Problem (data loss on develop)
#8977 (merged) added a pre-edit snapshot/rollback for the view/plugin create/edit flow that runs git **against the live monorepo checkout**:
- `createPreEditSnapshot` → `git add -A` stages the **entire** repo working tree.
- `rollbackToSnapshot` → `git reset --hard <sha>` **discards every uncommitted change anywhere in the repo**, not just the edited plugin — silently destroying unrelated in-flight work. This violates the repo's 'never lose work' rule.

## Fix — scope everything to the workdir
- snapshot: `git add -A -- .` (cwd=workdir → stage only the workdir subtree).
- rollback: `git checkout <sha> -- .` then `git clean -fd -- .` — restore tracked files + remove files created after the snapshot, **scoped to the workdir**. No `-x`, so `.gitignore`d build output/deps survive. **Never** `git reset --hard`.

Unit + action tests updated to assert the scoped commands and that `reset` is never issued. (Surfaced by the review of #8977, which was flagged to hold for exactly this but merged.)