### PR TITLE
test(scenario): capture voice .wav artifacts + link them in the run viewer (#8934)

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1785,6 +1785,10 @@ export async function runScenario(
         runtime,
         opts.minJudgeScore,
       );
+      const voiceRun =
+        kind === "voice"
+          ? (execution.responseBody as VoiceWorkbenchScenarioRun | undefined)
+          : undefined;
       report.turns.push({
         name: turn.name,
         kind,
@@ -1793,6 +1797,9 @@ export async function runScenario(
         actionsCalled: actionsThisTurn,
         durationMs: execution.durationMs ?? 0,
         failedAssertions,
+        ...(voiceRun?.audioArtifacts && voiceRun.audioArtifacts.length > 0
+          ? { audioArtifacts: voiceRun.audioArtifacts }
+          : {}),
       });
       if (failedAssertions.length > 0) {
         report.status = "failed";

--- a/packages/scenario-runner/src/reporter.ts
+++ b/packages/scenario-runner/src/reporter.ts
@@ -314,6 +314,8 @@ function scenarioViewerHtml(): string {
     summary { cursor:pointer; padding:9px 12px; background:#fff; }
     pre { margin:0; max-height:520px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#101510; color:#eef7ea; padding:10px 12px; }
     .turn { border-top:1px solid var(--line); padding:10px 12px; }
+    .audio-artifact { display:flex; flex-direction:column; gap:2px; margin-bottom:6px; }
+    .audio-artifact audio { width:200px; height:30px; }
     @media (max-width:900px) { main { grid-template-columns:1fr; } th { top:0; } }
   </style>
 </head>
@@ -375,10 +377,20 @@ function scenarioViewerHtml(): string {
       document.getElementById("scenario-list").innerHTML = rows.map(s => \`<button class="scenario-item \${s.id === activeId ? "active" : ""}" data-id="\${esc(s.id)}"><strong>\${esc(s.id)}</strong><br><span class="\${esc(s.status)}">\${esc(s.status)}</span> <span class="muted">\${esc(s.durationMs)}ms</span></button>\`).join("");
       renderDetail();
     }
+    function audioArtifactsCell(t) {
+      const artifacts = t.audioArtifacts || [];
+      if (!artifacts.length) return "";
+      // The viewer html lives in <runDir>/viewer/; artifact paths are run-dir
+      // relative, so prefix "../" to resolve them from the viewer document.
+      return artifacts.map(a => {
+        const label = [a.kind, "turn " + a.turnIndex, a.speakerLabel].filter(Boolean).join(" · ");
+        return \`<div class="audio-artifact"><span class="muted">\${esc(label)}</span><audio controls preload="none" src="../\${esc(a.path)}"></audio></div>\`;
+      }).join("");
+    }
     function turnsTable(s) {
       const turns = s.turns || [];
       if (!turns.length) return '<div class="turn muted">No turn reports.</div>';
-      return '<table><thead><tr><th>turn</th><th>kind</th><th>status</th><th>input</th><th>response</th><th>actions</th></tr></thead><tbody>' + turns.map(t => \`<tr><td>\${esc(t.name)}</td><td>\${esc(t.kind)}</td><td>\${esc((t.failedAssertions||[]).length ? "failed" : "ok")}</td><td>\${esc(t.text)}</td><td>\${esc(t.responseText)}</td><td>\${esc((t.actionsCalled||[]).map(a => a.name || a.actionName || "").join(", "))}</td></tr>\`).join("") + '</tbody></table>';
+      return '<table><thead><tr><th>turn</th><th>kind</th><th>status</th><th>input</th><th>response</th><th>actions</th><th>audio</th></tr></thead><tbody>' + turns.map(t => \`<tr><td>\${esc(t.name)}</td><td>\${esc(t.kind)}</td><td>\${esc((t.failedAssertions||[]).length ? "failed" : "ok")}</td><td>\${esc(t.text)}</td><td>\${esc(t.responseText)}</td><td>\${esc((t.actionsCalled||[]).map(a => a.name || a.actionName || "").join(", "))}</td><td>\${audioArtifactsCell(t)}</td></tr>\`).join("") + '</tbody></table>';
     }
     function fmtNum(v) {
       return typeof v === "number" && Number.isFinite(v) ? Math.round(v).toLocaleString() : "";

--- a/packages/scenario-runner/src/types.ts
+++ b/packages/scenario-runner/src/types.ts
@@ -4,6 +4,7 @@
  * execution & report state.
  */
 
+import type { VoiceAudioArtifact } from "@elizaos/plugin-local-inference/voice-workbench";
 import type {
   CapturedAction,
   CapturedApprovalRequest,
@@ -37,6 +38,8 @@ export interface TurnReport {
   actionsCalled: CapturedAction[];
   durationMs: number;
   failedAssertions: string[];
+  /** `.wav` artifacts a `voice` turn wrote when run under `--run-dir`. */
+  audioArtifacts?: VoiceAudioArtifact[];
 }
 
 export interface ScenarioReport {

--- a/packages/scenario-runner/src/voice-turn.ts
+++ b/packages/scenario-runner/src/voice-turn.ts
@@ -11,9 +11,11 @@
  * or set `allowVoiceSkip` only for explicitly optional/manual voice coverage.
  */
 
+import path from "node:path";
 import {
   generateVoiceCorpus,
   runVoiceScenarioHeadless,
+  type VoiceAudioCaptureSink,
   type VoiceScenario,
   type VoiceWorkbenchScenarioRun,
   type VoiceWorkbenchServices,
@@ -41,6 +43,22 @@ export function voiceRunVerdict(
   return run.cases.every((c) => c.passed) ? "pass" : "fail";
 }
 
+/**
+ * When the CLI runs with `--run-dir`, voice turns write their `.wav` artifacts
+ * under `<runDir>/audio/<scenarioId>` and record run-dir-relative paths so the
+ * run viewer (served from the run dir) can link/play them. Unset ⇒ no audio IO.
+ */
+function resolveAudioCaptureSink(scenario: VoiceScenario): VoiceAudioCaptureSink | undefined {
+  const runDir = process.env.ELIZA_LIFEOPS_RUN_DIR;
+  if (!runDir) {
+    return undefined;
+  }
+  return {
+    dir: path.join(runDir, "audio", scenario.id),
+    relativeTo: runDir,
+  };
+}
+
 /** Execute a `voice` turn: generate the corpus and run it headless. */
 export async function executeVoiceTurn(
   turn: ScenarioTurn,
@@ -52,7 +70,13 @@ export async function executeVoiceTurn(
   }
   const services = voiceTurn.voiceServices ?? null;
   const corpus = await generateVoiceCorpus(scenario);
-  const run = await runVoiceScenarioHeadless({ scenario, corpus, services });
+  const captureAudio = resolveAudioCaptureSink(scenario);
+  const run = await runVoiceScenarioHeadless({
+    scenario,
+    corpus,
+    services,
+    ...(captureAudio ? { captureAudio } : {}),
+  });
   return {
     responseText: `voice:${run.scenarioId} ${voiceRunVerdict(run)} (${run.status}, ${run.cases.length} cases)`,
     responseBody: run,

--- a/plugins/plugin-local-inference/src/services/voice/voice-workbench-report.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-workbench-report.ts
@@ -19,6 +19,24 @@ import type { VoiceScenarioClass } from "./voice-scenario";
 export type VoiceWorkbenchStatus = "ran" | "skipped";
 export type VoiceWorkbenchVerdict = "pass" | "fail" | "skipped";
 
+/**
+ * A `.wav` artifact written for one scenario run when a capture sink is active.
+ * `path` is RELATIVE to the run dir the headless runner was told to write under,
+ * so the scenario run viewer (served from that dir) can reference it directly.
+ */
+export interface VoiceAudioArtifact {
+	/** Turn index this artifact belongs to; the full corpus uses turn 0. */
+	turnIndex: number;
+	/** `generated` = the full synthesized corpus; `consumed` = a per-turn slice. */
+	kind: "generated" | "consumed";
+	/** Path to the `.wav`, relative to the run dir (forward-slash separated). */
+	path: string;
+	sampleRate: number;
+	durationMs?: number;
+	/** Diarization ground-truth speaker label for a consumed per-turn slice. */
+	speakerLabel?: string;
+}
+
 /** One scenario's outcome in a workbench run. */
 export interface VoiceWorkbenchScenarioRun {
 	scenarioId: string;
@@ -29,6 +47,8 @@ export interface VoiceWorkbenchScenarioRun {
 	cases: VoiceE2eCaseResult[];
 	/** Why the scenario was skipped (artifact/backend absence), if it was. */
 	skipReason?: string;
+	/** `.wav` artifacts written when a capture sink was active (else absent). */
+	audioArtifacts?: VoiceAudioArtifact[];
 }
 
 export interface VoiceWorkbenchScenarioReport {

--- a/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
@@ -18,6 +18,8 @@
  * here, so it is unit-testable with a fake services adapter.
  */
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import type {
 	CorpusGroundTruth,
 	CorpusTurnLabel,
@@ -36,7 +38,11 @@ import {
 	type VoiceE2eCaseResult,
 } from "./e2e-harness";
 import type { VoiceScenario } from "./voice-scenario";
-import type { VoiceWorkbenchScenarioRun } from "./voice-workbench-report";
+import type {
+	VoiceAudioArtifact,
+	VoiceWorkbenchScenarioRun,
+} from "./voice-workbench-report";
+import { encodeMonoPcm16Wav } from "./wav-codec";
 
 /** What the real (or mock) services observed for one turn of audio. */
 export interface VoiceTurnObservation {
@@ -76,12 +82,54 @@ export interface VoiceWorkbenchServices {
 	}): Promise<VoiceTurnObservation>;
 }
 
+/**
+ * Where to write per-run `.wav` artifacts. When present, the runner encodes the
+ * full corpus + each consumed per-turn slice to disk under `dir` and records the
+ * paths (relative to `relativeTo`) on the run's `audioArtifacts`. Absent ⇒ no IO.
+ */
+export interface VoiceAudioCaptureSink {
+	/** Directory the `.wav` files are written into (created recursively). */
+	dir: string;
+	/** Artifact paths are recorded relative to this dir (the scenario run dir). */
+	relativeTo: string;
+}
+
 export interface RunVoiceScenarioHeadlessArgs {
 	scenario: VoiceScenario;
 	/** The generated/loaded corpus; null when its artifacts are absent. */
 	corpus: GeneratedVoiceCorpus | null;
 	/** The voice services; null when no backend is provisioned. */
 	services: VoiceWorkbenchServices | null;
+	/** When set, write the run's audio as `.wav` artifacts and record their paths. */
+	captureAudio?: VoiceAudioCaptureSink;
+}
+
+/** Encode `pcm` to `<dir>/<fileName>` and return a relative-path artifact. */
+function writeAudioArtifact(args: {
+	sink: VoiceAudioCaptureSink;
+	fileName: string;
+	pcm: Float32Array;
+	sampleRate: number;
+	turnIndex: number;
+	kind: VoiceAudioArtifact["kind"];
+	speakerLabel?: string;
+}): VoiceAudioArtifact {
+	const absolutePath = path.join(args.sink.dir, args.fileName);
+	writeFileSync(absolutePath, encodeMonoPcm16Wav(args.pcm, args.sampleRate));
+	const relativePath = path
+		.relative(args.sink.relativeTo, absolutePath)
+		.split(path.sep)
+		.join("/");
+	return {
+		turnIndex: args.turnIndex,
+		kind: args.kind,
+		path: relativePath,
+		sampleRate: args.sampleRate,
+		durationMs: Math.round((args.pcm.length / args.sampleRate) * 1000),
+		...(args.speakerLabel !== undefined
+			? { speakerLabel: args.speakerLabel }
+			: {}),
+	};
 }
 
 function skipped(
@@ -104,12 +152,29 @@ function skipped(
 export async function runVoiceScenarioHeadless(
 	args: RunVoiceScenarioHeadlessArgs,
 ): Promise<VoiceWorkbenchScenarioRun> {
-	const { scenario, corpus, services } = args;
+	const { scenario, corpus, services, captureAudio } = args;
 	if (!corpus) return skipped(scenario, "corpus artifacts absent");
 	if (!services) return skipped(scenario, "no voice backend provisioned");
 
 	const assertions = scenario.assertions ?? {};
 	const cases: VoiceE2eCaseResult[] = [];
+
+	// When a capture sink is active, write the full corpus once + each per-turn
+	// slice as `.wav` artifacts and record their (run-dir-relative) paths.
+	const audioArtifacts: VoiceAudioArtifact[] = [];
+	if (captureAudio) {
+		mkdirSync(captureAudio.dir, { recursive: true });
+		audioArtifacts.push(
+			writeAudioArtifact({
+				sink: captureAudio,
+				fileName: "corpus.wav",
+				pcm: corpus.pcm,
+				sampleRate: corpus.sampleRate,
+				turnIndex: 0,
+				kind: "generated",
+			}),
+		);
+	}
 
 	const eotSamples: Array<{
 		decided: boolean;
@@ -140,6 +205,19 @@ export async function runVoiceScenarioHeadless(
 			label.segmentStartSample,
 			label.segmentEndSample,
 		);
+		if (captureAudio) {
+			audioArtifacts.push(
+				writeAudioArtifact({
+					sink: captureAudio,
+					fileName: `turn-${label.index}.wav`,
+					pcm: audio,
+					sampleRate: corpus.sampleRate,
+					turnIndex: label.index,
+					kind: "consumed",
+					speakerLabel: label.speaker,
+				}),
+			);
+		}
 		const obs = await services.observeTurn({
 			turnIndex: label.index,
 			audio,
@@ -269,6 +347,7 @@ export async function runVoiceScenarioHeadless(
 		classes: scenario.classes,
 		status: "ran",
 		cases,
+		...(audioArtifacts.length > 0 ? { audioArtifacts } : {}),
 	};
 }
 

--- a/plugins/plugin-local-inference/src/voice-workbench.ts
+++ b/plugins/plugin-local-inference/src/voice-workbench.ts
@@ -36,6 +36,7 @@ export {
 	formatVoiceWorkbenchMarkdown,
 	type MetricRollup,
 	regressionsAgainstBaseline,
+	type VoiceAudioArtifact,
 	type VoiceWorkbenchMetrics,
 	type VoiceWorkbenchReport,
 	type VoiceWorkbenchScenarioReport,
@@ -55,6 +56,7 @@ export {
 	type RunVoiceWorkbenchArgs,
 	runVoiceScenarioHeadless,
 	runVoiceWorkbenchHeadless,
+	type VoiceAudioCaptureSink,
 	type VoiceTurnObservation,
 	type VoiceWorkbenchServices,
 } from "./services/voice/workbench-headless-runner";


### PR DESCRIPTION
## What & why

Closes #8934.

The scenario-runner `voice` turn ran headlessly and produced only JSON — no audio. `PR_EVIDENCE.md` requires **audio + narrated walkthrough** for any voice/TTS/STT change, so that lane had nothing to attach. This makes a voice scenario emit real `.wav` artifacts, record their paths on the report type, and link them in the run viewer.

## What changed

- **`VoiceWorkbenchScenarioRun.audioArtifacts`** — new optional field + canonical `VoiceAudioArtifact` type (`turnIndex`, `kind: "generated" | "consumed"`, run-dir-relative `path`, `sampleRate`, `durationMs?`, `speakerLabel?`) in `plugin-local-inference`.
- **Headless runner capture seam** — `runVoiceScenarioHeadless` takes an optional `captureAudio: { dir, relativeTo }`. When present it writes the full synthesized corpus once (`corpus.wav`, `generated`) and each consumed per-turn slice (`turn-<n>.wav`, `consumed`) via the existing `encodeMonoPcm16Wav` codec (no new encoder), recording run-dir-relative paths.
- **scenario-runner wiring** — `executeVoiceTurn` derives the audio dir from `ELIZA_LIFEOPS_RUN_DIR` (the run dir the CLI already exports); the executor surfaces `audioArtifacts` onto `TurnReport`; the run viewer renders an `<audio controls>` per artifact.

With **no** run dir there is zero audio IO — existing scenarios/tests/matrix path are byte-for-byte unchanged (all new fields optional + conditionally populated).

## Evidence

`voice-workbench-room` scenario run with `--run-dir`:

```
audio/voice-room-demo/corpus.wav   RIFF (little-endian) WAVE, PCM 16-bit mono 16000 Hz
audio/voice-room-demo/turn-0.wav   RIFF ... (alice)
audio/voice-room-demo/turn-1.wav   RIFF ...
audio/voice-room-demo/turn-2.wav   RIFF ...
```

- `matrix.json` → `scenarios[0].turns[0].audioArtifacts` = `[{turnIndex:0,kind:"generated",path:"audio/voice-room-demo/corpus.wav",sampleRate:16000,durationMs:8008}, {turnIndex:0,kind:"consumed",path:"audio/.../turn-0.wav",...,speakerLabel:"alice"}, …]`; same on the per-scenario trajectory JSON.
- `viewer/data.js` references all four relative paths; `viewer/index.html` emits `<audio controls preload="none" src="../<path>">`.
- Tests: all **72 voice test files (747 tests)** green; `voice-turn.test.ts` 5/5. (Pre-existing `deterministic-action-coverage` failure for `live-inbound-attachment.scenario.ts` is on `origin/develop`, unrelated.)

Repro:
```bash
SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 \
  bun --conditions eliza-source --tsconfig-override ../../tsconfig.json \
  src/cli.ts run test/scenarios --scenario voice-workbench-room --run-dir /tmp/voice-artifacts
# from packages/scenario-runner — then inspect /tmp/voice-artifacts/audio + viewer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
