### PR TITLE
chore: tighten desktop build dx (salvaged from #8968, no bun.lock churn)

### DIFF
--- a/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
+++ b/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
@@ -811,8 +811,12 @@ API_AVAILABLE(macos(10.14))
 		completionHandler(UNNotificationPresentationOptionBanner |
 						  UNNotificationPresentationOptionSound);
 	} else {
+		// Alert is the correct foreground presentation option on macOS 10.x.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		completionHandler(UNNotificationPresentationOptionAlert |
 						  UNNotificationPresentationOptionSound);
+#pragma clang diagnostic pop
 	}
 }
 

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -488,6 +488,26 @@ function runPackageBinary(binary, binaryArgs, options = {}) {
   fail(`Could not find bunx or npx to run ${binary}.`);
 }
 
+function resolveLocalPackageBinary(binary, cwdCandidates = []) {
+  const executableNames =
+    process.platform === "win32"
+      ? [`${binary}.cmd`, `${binary}.exe`, binary]
+      : [binary];
+  const candidates = [];
+
+  for (const cwd of cwdCandidates) {
+    for (const executableName of executableNames) {
+      candidates.push(path.join(cwd, "node_modules", ".bin", executableName));
+    }
+  }
+
+  for (const executableName of executableNames) {
+    candidates.push(path.join(ROOT, "node_modules", ".bin", executableName));
+  }
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
 function runBunPackageBinary(binary, binaryArgs, options = {}) {
   const bunx = which("bunx");
   if (bunx) {
@@ -499,6 +519,15 @@ function runBunPackageBinary(binary, binaryArgs, options = {}) {
 }
 
 function runElectrobun(commandArgs, options = {}) {
+  const local = resolveLocalPackageBinary(
+    "electrobun",
+    [options.cwd, ELECTROBUN_DIR].filter(Boolean),
+  );
+  if (local) {
+    run(local, commandArgs, options);
+    return;
+  }
+
   const direct = which("electrobun");
   if (direct) {
     run(direct, commandArgs, options);

--- a/packages/docs/build-and-release.md
+++ b/packages/docs/build-and-release.md
@@ -86,7 +86,14 @@ The official Electrobun docs expect the CLI to come from the project dependency 
 
 - `apps/app/electrobun/package.json` declares `electrobun` as a dependency.
 - `scripts/desktop-build.mjs stage` installs the Electrobun workspace package before packaging.
-- `scripts/desktop-build.mjs package` drives `bun run build -- --env=...` inside `apps/app/electrobun`, and that script invokes `bunx electrobun build` against the package-local dependency.
+- `scripts/desktop-build.mjs package` resolves `electrobun` from
+  `apps/app/electrobun/node_modules/.bin` first, then falls back to a
+  PATH/global binary and only uses `bunx` as a last resort.
+
+Why: package-local resolution keeps desktop packaging reproducible and makes CI
+logs clearer. If `bunx` is the normal path, Bun/Electrobun can silently fetch
+or materialize CLI assets during the packaging step, which looks like a hung
+build when the network is slow.
 
 We still keep two Windows-specific guards around that documented flow:
 

--- a/packages/scripts/sync-artifacts.mjs
+++ b/packages/scripts/sync-artifacts.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 /**
  * sync-artifacts.mjs
  *
@@ -105,6 +106,13 @@ async function streamToFileWithProgress(response, dest, expectedBytes) {
   const startedAt = Date.now();
   let received = 0;
   let lastLogAt = startedAt;
+  let writerError;
+  const streamError = new Promise((resolve) => {
+    writer.once("error", (err) => {
+      writerError = err;
+      resolve();
+    });
+  });
 
   if (totalBytes > 0) {
     log(
@@ -122,10 +130,8 @@ async function streamToFileWithProgress(response, dest, expectedBytes) {
       if (done) break;
       received += value.byteLength;
       if (!writer.write(value)) {
-        await new Promise((resolve, reject) => {
-          writer.once("drain", resolve);
-          writer.once("error", reject);
-        });
+        await Promise.race([once(writer, "drain"), streamError]);
+        if (writerError) throw writerError;
       }
       const now = Date.now();
       if (now - lastLogAt >= PROGRESS_INTERVAL_MS) {
@@ -137,10 +143,13 @@ async function streamToFileWithProgress(response, dest, expectedBytes) {
     reader.releaseLock();
   }
 
-  await new Promise((resolve, reject) => {
-    writer.end((err) => (err ? reject(err) : resolve()));
-    writer.once("error", reject);
-  });
+  await Promise.race([
+    new Promise((resolve, reject) => {
+      writer.end((err) => (err ? reject(err) : resolve()));
+    }),
+    streamError,
+  ]);
+  if (writerError) throw writerError;
   log(`download complete: ${progressStatus(received, totalBytes, startedAt)}`);
 }
 


### PR DESCRIPTION
Salvages the three desktop-build DX fixes from #8968 onto **current develop**, dropping that PR's spurious `bun.lock` churn and stale base (all four files are unchanged on develop since #8968's base, so these are exactly its code changes, conflict-free).

- **`sync-artifacts.mjs`** — fixes a real per-drain **error-listener leak**: the download backpressure loop registered a fresh `writer.once("error", reject)` on every drain wait and never removed it. Now one persistent `streamError` promise + `Promise.race([once(writer,"drain"), streamError])` + explicit throw.
- **`desktop-build.mjs`** — `runElectrobun` resolves `node_modules/.bin/electrobun` (cwd → `ELECTROBUN_DIR` → ROOT) before the `which()`/`bunx` fallback, so desktop packaging is reproducible and doesn't silently materialize the CLI. Windows `.cmd/.exe` handled.
- **`window-effects.mm`** — wraps the macOS 10.x deprecated notification enum in a `-Wdeprecated-declarations` push/pop (zero behavior change).
- **docs** — `build-and-release.md` updated for the CLI resolution path.

Co-authored with @odilitime (original author of #8968). Supersedes the code portion of #8968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)