### PR TITLE
feat(chat): cross-channel topic search — action + endpoint (#8927)

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/channel-topic-search.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-topic-search.ts
@@ -1,0 +1,93 @@
+/**
+ * SEARCH_CHANNEL_TOPICS — cross-channel topic search (#8927).
+ *
+ * Surfaces the per-channel topic LRUs (#8925/#8926) as a query: "which channels
+ * have been talking about X?". Ranks rooms whose recent topics match the query
+ * tokens via `ChannelTopicsService.searchTopics`. Pairs with the
+ * `/api/channel-topics/search` route registered by the basic-capabilities plugin.
+ */
+
+import type { TopicSearchHit } from "../../../services/channel-topics.ts";
+import type {
+	Action,
+	ActionResult,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "../../../types/index.ts";
+
+interface TopicSearchService {
+	searchTopics(query: string, limit?: number): TopicSearchHit[];
+}
+
+function getTopicsService(
+	runtime: IAgentRuntime,
+): TopicSearchService | undefined {
+	const svc = runtime.getService("channel_topics") as
+		| (TopicSearchService & object)
+		| null;
+	return svc && typeof svc.searchTopics === "function" ? svc : undefined;
+}
+
+/** Pull the search query from explicit params, else the message text. */
+function resolveQuery(
+	message: Memory,
+	options?: { parameters?: Record<string, unknown> },
+): string {
+	const param = options?.parameters?.query;
+	if (typeof param === "string" && param.trim()) return param.trim();
+	return (message.content?.text ?? "").trim();
+}
+
+export const channelTopicSearchAction: Action = {
+	name: "SEARCH_CHANNEL_TOPICS",
+	similes: ["TOPIC_SEARCH", "FIND_CHANNELS_BY_TOPIC", "SEARCH_TOPICS"],
+	description:
+		"Search recent per-channel topics across all rooms and return the channels most relevant to a query.",
+	parameters: [
+		{
+			name: "query",
+			description: "Topic keywords to search for across channels.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+	],
+	validate: async (runtime: IAgentRuntime): Promise<boolean> =>
+		getTopicsService(runtime) !== undefined,
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: State,
+		options?: { parameters?: Record<string, unknown> },
+	): Promise<ActionResult> => {
+		const svc = getTopicsService(runtime);
+		if (!svc) {
+			return {
+				text: "Channel topic search is unavailable.",
+				values: { success: false },
+				data: { actionName: "SEARCH_CHANNEL_TOPICS" },
+			};
+		}
+		const query = resolveQuery(message, options);
+		if (!query) {
+			return {
+				text: "Provide a topic to search for.",
+				values: { success: false },
+				data: { actionName: "SEARCH_CHANNEL_TOPICS" },
+			};
+		}
+		const hits = svc.searchTopics(query, 10);
+		const text =
+			hits.length === 0
+				? `No channels found discussing "${query}".`
+				: `Channels discussing "${query}":\n${hits
+						.map((h) => `- ${h.roomId}: ${h.matchedTopics.join(", ")}`)
+						.join("\n")}`;
+		return {
+			text,
+			values: { success: true, matchCount: hits.length },
+			data: { actionName: "SEARCH_CHANNEL_TOPICS", query, hits },
+		};
+	},
+	examples: [],
+};

--- a/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { channelTopicSearchAction } from "./actions/channel-topic-search.ts";
+import { CHANNEL_TOPICS_SEARCH_ROUTE } from "./channel-topics-routes.ts";
+
+const HITS = [
+	{
+		roomId: "room-a",
+		matchedTopics: ["stripe payout"],
+		topics: ["stripe payout"],
+	},
+];
+
+function runtimeWith(svc: unknown) {
+	return {
+		getService: (name: string) => (name === "channel_topics" ? svc : null),
+	} as never;
+}
+
+describe("SEARCH_CHANNEL_TOPICS action (#8927)", () => {
+	it("validates only when the topics service is present", async () => {
+		expect(
+			await channelTopicSearchAction.validate?.(
+				runtimeWith({ searchTopics: () => [] }),
+				{} as never,
+			),
+		).toBe(true);
+		expect(
+			await channelTopicSearchAction.validate?.(runtimeWith(null), {} as never),
+		).toBe(false);
+	});
+
+	it("searches with the param query and returns ranked rooms", async () => {
+		const searchTopics = vi.fn(() => HITS);
+		const res = await channelTopicSearchAction.handler(
+			runtimeWith({ searchTopics }),
+			{ content: { text: "" } } as never,
+			undefined,
+			{ parameters: { query: "stripe" } },
+		);
+		expect(searchTopics).toHaveBeenCalledWith("stripe", 10);
+		expect(res.values?.success).toBe(true);
+		expect(res.values?.matchCount).toBe(1);
+		expect(res.text).toContain("room-a");
+	});
+
+	it("falls back to message text when no param query", async () => {
+		const searchTopics = vi.fn(() => []);
+		await channelTopicSearchAction.handler(
+			runtimeWith({ searchTopics }),
+			{ content: { text: "billing" } } as never,
+			undefined,
+			undefined,
+		);
+		expect(searchTopics).toHaveBeenCalledWith("billing", 10);
+	});
+});
+
+describe("GET /api/channel-topics/search (#8927)", () => {
+	function makeRes() {
+		const res = {
+			code: 0,
+			body: undefined as unknown,
+			status(c: number) {
+				res.code = c;
+				return res;
+			},
+			json(b: unknown) {
+				res.body = b;
+				return res;
+			},
+		};
+		return res;
+	}
+
+	it("returns 200 with hits for a query", async () => {
+		const res = makeRes();
+		await CHANNEL_TOPICS_SEARCH_ROUTE.handler?.(
+			{ query: { q: "stripe", limit: "5" } } as never,
+			res as never,
+			runtimeWith({ searchTopics: () => HITS }),
+		);
+		expect(res.code).toBe(200);
+		expect((res.body as { count: number }).count).toBe(1);
+	});
+
+	it("returns 400 when q is missing", async () => {
+		const res = makeRes();
+		await CHANNEL_TOPICS_SEARCH_ROUTE.handler?.(
+			{ query: {} } as never,
+			res as never,
+			runtimeWith({ searchTopics: () => [] }),
+		);
+		expect(res.code).toBe(400);
+	});
+
+	it("returns 503 when the service is unavailable", async () => {
+		const res = makeRes();
+		await CHANNEL_TOPICS_SEARCH_ROUTE.handler?.(
+			{ query: { q: "x" } } as never,
+			res as never,
+			runtimeWith(null),
+		);
+		expect(res.code).toBe(503);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/channel-topics-routes.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topics-routes.ts
@@ -1,0 +1,50 @@
+/**
+ * Cross-channel topic search HTTP endpoint (#8927).
+ *
+ * GET /api/channel-topics/search?q=<query>&limit=<n> → ranks rooms whose recent
+ * per-channel topic LRUs match the query, via `ChannelTopicsService.searchTopics`.
+ * The in-chat counterpart is the SEARCH_CHANNEL_TOPICS action.
+ */
+
+import type { TopicSearchHit } from "../../services/channel-topics.ts";
+import type { Route } from "../../types/plugin.ts";
+
+interface TopicSearchService {
+	searchTopics(query: string, limit?: number): TopicSearchHit[];
+}
+
+function firstQueryValue(value: string | string[] | undefined): string {
+	if (Array.isArray(value)) return value[0] ?? "";
+	return value ?? "";
+}
+
+export const CHANNEL_TOPICS_SEARCH_ROUTE: Route = {
+	type: "GET",
+	path: "/api/channel-topics/search",
+	public: false,
+	name: "channel-topics-search",
+	description:
+		"Search recent per-channel topics across all rooms; returns matching rooms ranked by relevance.",
+	async handler(req, res, runtime) {
+		const query = firstQueryValue(req.query?.q).trim();
+		if (!query) {
+			res.status(400).json({ error: "query parameter 'q' is required" });
+			return;
+		}
+		const rawLimit = Number.parseInt(firstQueryValue(req.query?.limit), 10);
+		const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 20;
+		const svc = runtime.getService("channel_topics") as
+			| (TopicSearchService & object)
+			| null;
+		if (!svc || typeof svc.searchTopics !== "function") {
+			res
+				.status(503)
+				.json({ error: "channel topics service unavailable", hits: [] });
+			return;
+		}
+		const hits = svc.searchTopics(query, limit);
+		res.status(200).json({ query, count: hits.length, hits });
+	},
+};
+
+export const CHANNEL_TOPICS_ROUTES: Route[] = [CHANNEL_TOPICS_SEARCH_ROUTE];

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -110,10 +110,12 @@ import { readAttachmentAction } from "../working-memory/readAttachmentAction.ts"
 // Direct leaf imports — see comment in
 // ../advanced-capabilities/index.ts for the Bun.build mis-rewrite that
 // requires bypassing barrels here too.
+import { channelTopicSearchAction } from "./actions/channel-topic-search.ts";
 import { choiceAction } from "./actions/choice.ts";
 import { ignoreAction } from "./actions/ignore.ts";
 import { noneAction } from "./actions/none.ts";
 import { replyAction } from "./actions/reply.ts";
+import { CHANNEL_TOPICS_ROUTES } from "./channel-topics-routes.ts";
 import { linkExtractionEvaluator } from "./evaluators/link-extraction.ts";
 import { actionStateProvider } from "./providers/actionState.ts";
 import { actionsProvider } from "./providers/actions.ts";
@@ -1260,6 +1262,7 @@ export const basicActions = [
 	withCanonicalActionDocs(replyAction),
 	withCanonicalActionDocs(ignoreAction),
 	withCanonicalActionDocs(noneAction),
+	withCanonicalActionDocs(channelTopicSearchAction),
 ];
 
 /**
@@ -1406,6 +1409,7 @@ export function createBasicCapabilitiesPlugin(
 		],
 		routes: [
 			...TURN_CONTROL_ROUTES,
+			...CHANNEL_TOPICS_ROUTES,
 			...(config.enableAutonomy ? autonomyCapabilities.routes : []),
 		],
 		events,

--- a/packages/core/src/services/channel-topics.search.test.ts
+++ b/packages/core/src/services/channel-topics.search.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { matchTopicRooms } from "./channel-topics.ts";
+
+const ROOMS = {
+	"room-a": ["billing refund", "stripe payout", "invoice"],
+	"room-b": ["stripe webhook", "deploy"],
+	"room-c": ["chat ux", "swipe gesture"],
+};
+
+describe("matchTopicRooms — cross-channel topic search (#8927)", () => {
+	it("ranks rooms by number of matching topics, most first", () => {
+		const hits = matchTopicRooms(ROOMS, "stripe");
+		expect(hits.map((h) => h.roomId)).toEqual(["room-a", "room-b"]);
+		expect(hits[0].matchedTopics).toEqual(["stripe payout"]);
+	});
+
+	it("matches any whitespace-delimited token, case-insensitively", () => {
+		const hits = matchTopicRooms(ROOMS, "SWIPE deploy");
+		expect(hits.map((h) => h.roomId).sort()).toEqual(["room-b", "room-c"]);
+	});
+
+	it("returns the full topic list alongside the matched subset", () => {
+		const [hit] = matchTopicRooms(ROOMS, "refund");
+		expect(hit.roomId).toBe("room-a");
+		expect(hit.matchedTopics).toEqual(["billing refund"]);
+		expect(hit.topics).toEqual(ROOMS["room-a"]);
+	});
+
+	it("returns [] for an empty query and respects the limit", () => {
+		expect(matchTopicRooms(ROOMS, "   ")).toEqual([]);
+		expect(matchTopicRooms(ROOMS, "stripe", 1)).toHaveLength(1);
+	});
+
+	it("returns [] when nothing matches", () => {
+		expect(matchTopicRooms(ROOMS, "nonexistent")).toEqual([]);
+	});
+});

--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -228,4 +228,52 @@ export class ChannelTopicsService extends Service {
 		}
 		return out;
 	}
+
+	/**
+	 * Cross-channel topic search (#8927): rank rooms whose recent topics match
+	 * the query, most-matching first. Scans the in-memory per-channel LRUs.
+	 */
+	searchTopics(query: string, limit = 20): TopicSearchHit[] {
+		return matchTopicRooms(this.getTopicsForAllRooms(), query, limit);
+	}
+}
+
+/** A cross-channel topic search hit: a room whose topics matched the query. */
+export interface TopicSearchHit {
+	roomId: string;
+	/** The room's topics that matched a query token. */
+	matchedTopics: string[];
+	/** The room's full current topic LRU (most-recent last). */
+	topics: string[];
+}
+
+/**
+ * Pure matcher for {@link ChannelTopicsService.searchTopics}: rank rooms whose
+ * topics contain any whitespace-delimited query token (case-insensitive),
+ * scored by match count, capped at `limit`. Deterministic; no I/O.
+ */
+export function matchTopicRooms(
+	topicsByRoom: Record<string, string[]>,
+	query: string,
+	limit = 20,
+): TopicSearchHit[] {
+	const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+	if (tokens.length === 0) return [];
+	const scored: Array<TopicSearchHit & { score: number }> = [];
+	for (const [roomId, topics] of Object.entries(topicsByRoom)) {
+		const matched = topics.filter((t) => {
+			const lower = t.toLowerCase();
+			return tokens.some((tok) => lower.includes(tok));
+		});
+		if (matched.length > 0) {
+			scored.push({
+				roomId,
+				matchedTopics: matched,
+				topics,
+				score: matched.length,
+			});
+		}
+	}
+	scored.sort((a, b) => b.score - a.score || a.roomId.localeCompare(b.roomId));
+	return scored.slice(0, Math.max(0, limit)).map(({ score, ...hit }) => hit);
 }


### PR DESCRIPTION
Closes **#8927** (last open child of EPIC **#8890** — chat context enrichment). Builds on #8925 (Stage-1 topics + ChannelTopicsService LRU) and #8926 (CHANNEL_TOPICS provider).

- **`ChannelTopicsService.searchTopics(query, limit)`** + pure **`matchTopicRooms`**: rank rooms whose recent per-channel topic LRUs match the query tokens (case-insensitive, scored by match count).
- **`SEARCH_CHANNEL_TOPICS`** action (basic-capabilities): "which channels discussed X?" — `query` param, falls back to message text, returns ranked rooms.
- **`GET /api/channel-topics/search?q=&limit=`** route on the basic-capabilities plugin → `{ query, count, hits }`.

**Tests:** 11 unit cases (matcher ranking/tokens/limit/empty; action validate/param/fallback; route 200/400/503). Typecheck clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)