### PR TITLE
fix(farcaster): attach agent media as cast embeds on mention replies (#8990)

### DIFF
--- a/plugins/plugin-farcaster/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-farcaster/__tests__/outbound-media.test.ts
@@ -1,6 +1,8 @@
 import type { Content, IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { FarcasterCastService } from "../services/CastService";
+import { extractCastEmbedUrls } from "../utils";
+import { standardCastHandlerCallback } from "../utils/callbacks";
 
 // Outbound media coverage for the Farcaster connector (#8876). Agent-generated
 // `Media` attachments must ride along as Farcaster cast EMBEDS (url-based), which
@@ -106,5 +108,65 @@ describe("Farcaster outbound media (embeds)", () => {
       service.handleSendPost(rt, { text: "   ", accountId: ACCOUNT } as Content)
     ).rejects.toThrow("requires non-empty text");
     expect(testClient.sendCast).not.toHaveBeenCalled();
+  });
+});
+
+describe("extractCastEmbedUrls (#8990)", () => {
+  it("collects non-empty attachment urls and skips blank/missing", () => {
+    const urls = extractCastEmbedUrls({
+      text: "hi",
+      attachments: [
+        { id: "1", url: "https://cdn.example.com/a.png" },
+        { id: "2", url: "" },
+        { id: "3" },
+        { id: "4", url: "https://cdn.example.com/b.mp4" },
+      ],
+    } as unknown as Content);
+    expect(urls).toEqual(["https://cdn.example.com/a.png", "https://cdn.example.com/b.mp4"]);
+  });
+
+  it("returns [] when there are no attachments", () => {
+    expect(extractCastEmbedUrls({ text: "hi" } as Content)).toEqual([]);
+  });
+});
+
+describe("Farcaster mention-reply attaches media (#8990)", () => {
+  const roomId = "00000000-0000-0000-0000-0000000000bb" as const;
+
+  it("passes attachment urls as embeds when replying to a mention", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const callback = standardCastHandlerCallback({
+      client: testClient as never,
+      runtime: rt,
+      config: { FARCASTER_DRY_RUN: false, accountId: ACCOUNT } as never,
+      roomId: roomId as never,
+      inReplyTo: { hash: "0xparent", fid: 2 } as never,
+    });
+
+    await callback({
+      text: "here you go",
+      attachments: [{ id: "img", url: "https://cdn.example.com/cat.png", contentType: "image" }],
+    } as Content);
+
+    expect(testClient.sendCast).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: ["https://cdn.example.com/cat.png"] })
+    );
+  });
+
+  it("replies text-only with empty embeds when there are no attachments (no regression)", async () => {
+    const testClient = client();
+    const rt = runtime({ FARCASTER_FID: "1" });
+    const callback = standardCastHandlerCallback({
+      client: testClient as never,
+      runtime: rt,
+      config: { FARCASTER_DRY_RUN: false } as never,
+      roomId: roomId as never,
+    });
+
+    await callback({ text: "just text" } as Content);
+
+    const arg = testClient.sendCast.mock.calls[0][0] as { embeds?: string[] };
+    expect(arg.embeds).toEqual([]);
   });
 });

--- a/plugins/plugin-farcaster/services/CastService.ts
+++ b/plugins/plugin-farcaster/services/CastService.ts
@@ -9,7 +9,7 @@ import {
 } from "@elizaos/core";
 import type { FarcasterClient } from "../client/FarcasterClient";
 import { type Cast, FARCASTER_SOURCE } from "../types";
-import { castUuid, neynarCastToCast } from "../utils";
+import { castUuid, extractCastEmbedUrls, neynarCastToCast } from "../utils";
 import {
   DEFAULT_FARCASTER_ACCOUNT_ID,
   getFarcasterFid,
@@ -186,12 +186,9 @@ export class FarcasterCastService implements CastServiceInterface {
     }
 
     const text = typeof content.text === "string" ? content.text.trim() : "";
-    // Agent-generated attachments ride along as Farcaster cast embeds (#8876).
-    const media = Array.isArray(content.attachments)
-      ? content.attachments
-          .map((m) => m?.url)
-          .filter((u): u is string => typeof u === "string" && u.trim().length > 0)
-      : [];
+    // Agent-generated attachments ride along as Farcaster cast embeds (#8876);
+    // shared with the mention-reply callback via extractCastEmbedUrls (#8990).
+    const media = extractCastEmbedUrls(content);
     if (!text && media.length === 0) {
       throw new Error(
         "Farcaster post connector requires non-empty text content or at least one attachment."

--- a/plugins/plugin-farcaster/utils/callbacks.ts
+++ b/plugins/plugin-farcaster/utils/callbacks.ts
@@ -3,7 +3,7 @@ import type { Cast as NeynarCast } from "@neynar/nodejs-sdk/build/api";
 import type { FarcasterClient } from "../client";
 import type { CastId, FarcasterConfig } from "../types";
 import { DEFAULT_FARCASTER_ACCOUNT_ID, normalizeFarcasterAccountId } from "./config";
-import { createCastMemory, neynarCastToCast } from "./index";
+import { createCastMemory, extractCastEmbedUrls, neynarCastToCast } from "./index";
 
 export function standardCastHandlerCallback({
   client,
@@ -33,7 +33,13 @@ export function standardCastHandlerCallback({
         return [];
       }
 
-      const casts = await client.sendCast({ content, inReplyTo });
+      // Attach agent-generated media as cast embeds so mention replies don't
+      // silently drop attachments (the POST connector already does this) — #8990.
+      const casts = await client.sendCast({
+        content,
+        inReplyTo,
+        embeds: extractCastEmbedUrls(content),
+      });
 
       if (casts.length === 0) {
         runtime.logger.warn("[Farcaster] No casts posted");

--- a/plugins/plugin-farcaster/utils/index.ts
+++ b/plugins/plugin-farcaster/utils/index.ts
@@ -1,9 +1,24 @@
-import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { Content, IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { stringToUuid } from "@elizaos/core";
 import type { Cast as NeynarCast } from "@neynar/nodejs-sdk/build/api";
 import { type Cast, FARCASTER_SOURCE } from "../types";
 
 export const MAX_CAST_LENGTH = 1024;
+
+/**
+ * Extract agent-generated attachment URLs from a message {@link Content} to ride
+ * along as Farcaster cast embeds (#8876 / #8990). Neynar embeds are URL-based,
+ * so this returns each attachment's non-empty `url`. Shared by the POST connector
+ * (`handleSendPost`) and the mention-reply callback so both outbound paths attach
+ * media identically instead of one of them silently dropping it.
+ */
+export function extractCastEmbedUrls(content: Content): string[] {
+  return Array.isArray(content.attachments)
+    ? content.attachments
+        .map((m) => m?.url)
+        .filter((u): u is string => typeof u === "string" && u.trim().length > 0)
+    : [];
+}
 
 export function castId({ hash, agentId }: { hash: string; agentId: string }): string {
   return `${hash}-${agentId}`;


### PR DESCRIPTION
## Summary
Closes the **Farcaster** gap in #8990's connector outbound-attachment audit. The POST connector (`handleSendPost`, #8876) already maps `content.attachments` → url-based cast embeds, but the **mention-reply** path (`standardCastHandlerCallback`) called `client.sendCast({ content, inReplyTo })` **without embeds** — so an agent reply to a Farcaster mention silently dropped its media.

## Changes
- Extracted the attachment→embed mapping into a shared **`extractCastEmbedUrls()`** helper (`utils/index.ts`) so both outbound paths attach media identically (DRY).
- Wired it into the mention-reply callback (the fix).
- Refactored `handleSendPost` to use the same helper (removes duplicated inline extraction).

Farcaster/Neynar embeds are **url-based** (server-fetched), unlike Slack/Discord/Telegram which upload bytes — so this rides the existing url-embed design rather than adding a byte-upload path.

## Tests
`outbound-media.test.ts` (8/8): helper (keeps non-empty urls, skips blank/missing, `[]` for none) + mention-reply now passes embeds + text-only reply has no regression. typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)