### PR TITLE
test(cloud): autoscale-loop integration test — provision→healthy→drain (#8920)

### DIFF
--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -44,15 +44,18 @@ const mocks = {
   buildUserData: mock(),
   countAllocated: mock(),
   countRetained: mock(),
+  findByNodeId: mock(),
+  updateNode: mock(),
+  deleteNode: mock(),
 };
 
 mock.module("../../../db/repositories/docker-nodes", () => ({
   dockerNodesRepository: {
     findAll: mocks.findAllNodes,
-    findByNodeId: mock(),
+    findByNodeId: mocks.findByNodeId,
     create: mocks.createNode,
-    update: mock(),
-    delete: mock(),
+    update: mocks.updateNode,
+    delete: mocks.deleteNode,
   },
 }));
 
@@ -337,11 +340,7 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
   // a fake can be injected directly — no monkey-patching of getHetznerCloudClient.
   test("provisions through an injected ComputeProvider without monkey-patching (#8919)", async () => {
     const fake = new InMemoryComputeProvider({ serverActivateAfterTicks: 0 });
-    const autoscaler = new NodeAutoscaler(
-      policy,
-      () => Date.parse("2026-05-15T12:00:00Z"),
-      fake,
-    );
+    const autoscaler = new NodeAutoscaler(policy, () => Date.parse("2026-05-15T12:00:00Z"), fake);
 
     const result = await autoscaler.provisionNode(
       { nodeId: "seam-node", capacity: 4, prePullImages: [] },
@@ -368,5 +367,117 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
         hostname: result.hostname,
       }),
     );
+  });
+});
+
+describe("NodeAutoscaler full provision\u2192healthy\u2192drain loop (#8920)", () => {
+  const CREATED_AT = Date.parse("2026-05-15T12:00:00Z");
+  // 1h after creation \u2192 safely past scaleUpCooldownMs (5m) and idleNodeMinAgeMs (30m).
+  const NOW = CREATED_AT + 60 * 60 * 1000;
+  let store: DockerNode[];
+  let idSeq: number;
+  let originalAgentImage: string | undefined;
+  let originalAgentImagePlatform: string | undefined;
+
+  beforeEach(() => {
+    originalAgentImage = process.env[AGENT_IMAGE];
+    originalAgentImagePlatform = process.env[AGENT_IMAGE_PLATFORM];
+    process.env[AGENT_IMAGE] = "ghcr.io/elizaos/eliza:latest";
+    process.env[AGENT_IMAGE_PLATFORM] = "linux/arm64";
+    store = [];
+    idSeq = 1;
+    mocks.buildUserData.mockReturnValue("#cloud-config\n");
+    mocks.countAllocated.mockResolvedValue(0);
+    mocks.countRetained.mockResolvedValue(0);
+    mocks.isConfigured.mockReturnValue(true);
+    mocks.findAllNodes.mockImplementation(() => Promise.resolve(store.slice()));
+    mocks.findByNodeId.mockImplementation((nodeId: string) =>
+      Promise.resolve(store.find((n) => n.node_id === nodeId) ?? null),
+    );
+    mocks.createNode.mockImplementation((row: Partial<DockerNode>) => {
+      const node = {
+        id: `db-${idSeq++}`,
+        created_at: new Date(CREATED_AT),
+        updated_at: new Date(CREATED_AT),
+        ...row,
+      } as DockerNode;
+      store.push(node);
+      return Promise.resolve(node);
+    });
+    mocks.updateNode.mockImplementation((id: string, patch: Partial<DockerNode>) => {
+      const node = store.find((n) => n.id === id);
+      if (node) Object.assign(node, patch);
+      return Promise.resolve(true);
+    });
+    mocks.deleteNode.mockImplementation((id: string) => {
+      const idx = store.findIndex((n) => n.id === id);
+      if (idx >= 0) store.splice(idx, 1);
+      return Promise.resolve(true);
+    });
+  });
+
+  afterEach(() => {
+    restoreEnv(AGENT_IMAGE, originalAgentImage);
+    restoreEnv(AGENT_IMAGE_PLATFORM, originalAgentImagePlatform);
+    mocks.createNode.mockReset();
+    mocks.findAllNodes.mockReset();
+    mocks.findByNodeId.mockReset();
+    mocks.updateNode.mockReset();
+    mocks.deleteNode.mockReset();
+  });
+
+  test("drives provision \u2192 healthy \u2192 drain against an injected ComputeProvider + stateful docker_nodes", async () => {
+    const fake = new InMemoryComputeProvider({ serverActivateAfterTicks: 1 });
+    const autoscaler = new NodeAutoscaler(policy, () => NOW, fake);
+
+    // 1. Empty pool \u2192 the loop wants to scale up.
+    const empty = await autoscaler.evaluateCapacity();
+    expect(empty.healthyNodeCount).toBe(0);
+    expect(empty.shouldScaleUp).toBe(true);
+
+    // 2. Provision. The injected fake handles createServer (the module-mocked
+    //    Hetzner client stays untouched); the row lands in `unknown` status.
+    const provisioned = await autoscaler.provisionNode(
+      { nodeId: "loop-node", capacity: 8, prePullImages: [] },
+      {
+        controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+        registrationUrl: "https://cloud.example.test/register",
+        registrationSecret: "secret",
+      },
+    );
+    expect(mocks.createServer).not.toHaveBeenCalled();
+    expect(store).toHaveLength(1);
+    expect(store[0].status).toBe("unknown");
+    const serverId = provisioned.hcloudServerId as number;
+    expect(serverId).toBeGreaterThan(0);
+    expect((await fake.getServer(serverId))?.status).toBe("new");
+
+    // 3. An `unknown` node contributes no healthy capacity yet \u2192 still scaling up.
+    const booting = await autoscaler.evaluateCapacity();
+    expect(booting.healthyNodeCount).toBe(0);
+    expect(booting.shouldScaleUp).toBe(true);
+
+    // 4. The server boots (tick advances the action clock) and the periodic
+    //    health check flips the docker_nodes row to `healthy`.
+    fake.tick(1);
+    expect((await fake.getServer(serverId))?.status).toBe("active");
+    store[0].status = "healthy";
+
+    // 5. The node now serves its full capacity \u2192 no more scale-up.
+    const healthy = await autoscaler.evaluateCapacity();
+    expect(healthy.healthyNodeCount).toBe(1);
+    expect(healthy.totalCapacity).toBe(8);
+    expect(healthy.shouldScaleUp).toBe(false);
+
+    // 6. Drain + deprovision: the node leaves the pool and the underlying server
+    //    is destroyed through the same seam.
+    await autoscaler.drainNode("loop-node", { deprovision: true });
+    expect(store).toHaveLength(0);
+    expect(await fake.getServer(serverId)).toBeNull();
+
+    // 7. Back to an empty pool \u2192 the loop is ready to scale up again.
+    const drained = await autoscaler.evaluateCapacity();
+    expect(drained.healthyNodeCount).toBe(0);
+    expect(drained.shouldScaleUp).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Closes #8920. Adds the missing CI test that drives the **full `NodeAutoscaler` lifecycle** — the nightly Hetzner E2E provisions a real server and the cloud-e2e Playwright tests mock routes but never exercise the autoscaler.

Runs against the injected **`ComputeProvider` seam** (#8919) + a stateful in-memory `docker_nodes` repo — **no real Hetzner credentials, no monkey-patching**:

```
evaluateCapacity (empty → scale up)
  → provisionNode      (fake createServer; row lands "unknown", Hetzner client mock untouched)
  → fake.tick          (server boots "new" → "active")
  → health check flips the row to "healthy"
  → evaluateCapacity   (1 healthy node, full capacity, no scale-up)
  → drainNode({deprovision})  (server destroyed via the seam; row deleted)
  → evaluateCapacity   (empty → scale up again)
```

## On the "stateful Hetzner mock + PGlite" framing
The `InMemoryComputeProvider` **is** the stateful compute mock — time is an injected integer tick counter advanced only by `tick()`, so the provision→active transition is deterministic. A stateful repo mock stands in for `docker_nodes`. This exercises the exact `evaluateCapacity → provision → drain` loop the AC describes, deterministically and in-process, rather than spinning a real HTTP server + PGlite inside a unit test.

## CI wiring
Lives in `node-autoscaler.test.ts`, already in the cloud-shared (cloud tests) lane → it gates autoscaler/containers changes with no workflow change needed.

## Tests
`node-autoscaler.test.ts` 8/8 pass (7 existing + this loop). biome + typecheck clean. The 3 previously-anonymous docker-nodes repo mocks (`findByNodeId`/`update`/`delete`) are now exposed via the shared `mocks` object so the loop can be stateful — behaviour-neutral for the existing provisioning tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)