### PR TITLE
feat(computeruse): per-step progress streaming to the origin chat (#8912)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
@@ -127,6 +127,60 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
     expect(report.steps.length).toBe(3);
   });
 
+  it("emits a per-step onStep callback when streamProgress is set (#8912)", async () => {
+    const brain = new Brain(null, {
+      invokeModel: async () =>
+        JSON.stringify({
+          scene_summary: "still loading",
+          target_display_id: 0,
+          roi: [],
+          proposed_action: { kind: "wait", rationale: "waiting for page" },
+        }),
+    });
+    const progress: Array<{
+      step: number;
+      actionKind: string;
+      rationale: string;
+      success: boolean;
+    }> = [];
+    const report = await runComputerUseAgentLoop(
+      null,
+      { goal: "g", maxSteps: 3, streamProgress: true },
+      fakeService(),
+      { brain, captureAll, onStep: (p) => void progress.push(p) },
+    );
+    // One callback per dispatched step, in order, carrying kind + rationale.
+    expect(progress.length).toBe(report.steps.length);
+    expect(progress.length).toBeGreaterThanOrEqual(1);
+    expect(progress[0]).toMatchObject({
+      step: 1,
+      actionKind: "wait",
+      rationale: "waiting for page",
+      success: true,
+    });
+  });
+
+  it("does not call onStep when streamProgress is unset", async () => {
+    const brain = new Brain(null, {
+      invokeModel: async () =>
+        JSON.stringify({
+          scene_summary: "done",
+          target_display_id: 0,
+          roi: [],
+          proposed_action: { kind: "finish", rationale: "ok" },
+        }),
+    });
+    let calls = 0;
+    await runComputerUseAgentLoop(null, { goal: "g" }, fakeService(), {
+      brain,
+      captureAll,
+      onStep: () => {
+        calls += 1;
+      },
+    });
+    expect(calls).toBe(0);
+  });
+
   it("surfaces cascade failures as `reason: error` instead of throwing", async () => {
     // Brain emits a click with no ref + no roi → cascade can't resolve it.
     const brain = new Brain(null, {

--- a/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
@@ -56,12 +56,29 @@ const DEFAULT_MAX_STEPS = 5;
 export interface ComputerUseAgentParams {
   goal: string;
   maxSteps?: number;
+  /**
+   * When true, emit a chat message after each dispatched step so a long-running
+   * goal does not leave the origin chat silent for minutes (#8912). The action
+   * handler wires this to the runtime HandlerCallback; the loop itself calls
+   * `deps.onStep`.
+   */
+  streamProgress?: boolean;
+}
+
+/** One per-step progress event, surfaced when `streamProgress` is set. */
+export interface ComputerUseAgentStepProgress {
+  step: number;
+  actionKind: string;
+  rationale: string;
+  success: boolean;
 }
 
 interface AgentDeps {
   brain?: Brain;
   computerInterface?: ComputerInterface;
   captureAll?: () => Promise<DisplayCapture[]>;
+  /** Called after each dispatched step when `params.streamProgress` is set. */
+  onStep?: (progress: ComputerUseAgentStepProgress) => void | Promise<void>;
 }
 
 export interface ComputerUseAgentReport {
@@ -167,6 +184,14 @@ export async function runComputerUseAgentLoop(
         error: dispatchResult.error?.message,
       },
     });
+    if (params.streamProgress && deps.onStep) {
+      await deps.onStep({
+        step,
+        actionKind: proposed.proposed.kind,
+        rationale: proposed.proposed.rationale,
+        success: dispatchResult.success,
+      });
+    }
     if (!dispatchResult.success) {
       report.reason = "error";
       report.error = dispatchResult.error?.message;
@@ -235,6 +260,13 @@ export const computerUseAgentAction: Action = {
         default: DEFAULT_MAX_STEPS,
       },
     },
+    {
+      name: "streamProgress",
+      description:
+        "Post a chat message after each step so long goals aren't silent.",
+      required: false,
+      schema: { type: "boolean", default: false },
+    },
   ],
   validate: async (runtime: IAgentRuntime): Promise<boolean> => {
     return getService(runtime) !== null;
@@ -263,7 +295,19 @@ export const computerUseAgentAction: Action = {
         error: "ComputerUseService not available",
       };
     }
-    const report = await runComputerUseAgentLoop(runtime, params, service);
+    const report = await runComputerUseAgentLoop(runtime, params, service, {
+      // Stream each step to the origin chat so long goals aren't silent (#8912).
+      onStep:
+        params.streamProgress && callback
+          ? async (p) => {
+              await callback({
+                text: `Step ${p.step}: ${p.actionKind}${
+                  p.success ? "" : " (failed)"
+                } — ${p.rationale}`,
+              });
+            }
+          : undefined,
+    });
     const text =
       report.reason === "finish"
         ? `Computer-use agent finished after ${report.steps.length} step(s): goal="${report.goal}"`


### PR DESCRIPTION
Closes **#8912** — the **last open child of EPIC #8887**. `COMPUTER_USE_AGENT` only logged step lines, so long goals left the chat silent for minutes.

- `ComputerUseAgentParams.streamProgress` (opt-in) + `AgentDeps.onStep` (injectable). The loop calls `onStep({step, actionKind, rationale, success})` after each dispatched step — including a failing step — before any early return.
- The action handler wires `onStep` to the runtime `HandlerCallback` only when `streamProgress` is set: `Step N: <kind>[ (failed)] — <rationale>`. Default off; existing callers unchanged.
- `streamProgress` added to the action parameter schema.

**Tests:** 2 new (18 total green) — one `onStep` per dispatched step, in order, with kind+rationale; and `onStep` never fires when `streamProgress` is unset.

The Telegram single-status-message edit + approval inline-button relay (other two acceptance bullets) build on the merged telegram edit capability (#8903) + approvals SSE — tracked as follow-ups on #8887. Headful live-display scenario evidence is env-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)