### PR TITLE
fix(app-core): stage the fused libelizainference correctly on Windows/MSVC

### DIFF
--- a/packages/app-core/scripts/stage-desktop-fused-lib.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib.mjs
@@ -310,6 +310,11 @@ run("cmake", [
   buildDir,
   "--target",
   "elizainference",
+  // Multi-config generators (MSVC, Xcode) ignore -DCMAKE_BUILD_TYPE and pick
+  // Debug unless the build step names the config; single-config generators
+  // (Make, Ninja) silently ignore --config, so this is safe everywhere.
+  "--config",
+  "Release",
   "-j",
   String(jobs),
 ]);
@@ -317,14 +322,23 @@ run("cmake", [
 // Collect the produced shared libs (the fused lib + its ggml/llama/mtmd
 // backends) and stage them as one consistent set. Sweep the out dir first so a
 // backend switch never leaves a stale sibling the loader could pick up.
-const binDir = path.join(buildDir, "bin");
+// Multi-config generators (MSVC, Xcode) nest the artifacts under bin/<Config>;
+// single-config generators (Make, Ninja) emit straight into bin/.
+let binDir = path.join(buildDir, "bin");
+const releaseBinDir = path.join(binDir, "Release");
+if (existsSync(releaseBinDir)) binDir = releaseBinDir;
 const libExt =
   process.platform === "darwin"
     ? ".dylib"
     : process.platform === "win32"
       ? ".dll"
       : ".so";
-const fusedName = `libelizainference${libExt}`;
+// CMake prepends the `lib` prefix to shared libs on Unix only; MSVC/Windows
+// emits the bare target name (elizainference.dll).
+const fusedName =
+  process.platform === "win32"
+    ? `elizainference${libExt}`
+    : `libelizainference${libExt}`;
 if (!existsSync(path.join(binDir, fusedName))) {
   die(`build did not produce ${fusedName} in ${binDir}`);
 }


### PR DESCRIPTION
`stage-desktop-fused-lib.mjs` failed at the staging step on Windows even though the DLL built fine: MSVC is a multi-config generator that ignores `-DCMAKE_BUILD_TYPE` at configure time, so without `--config` on the build step it builds **Debug** (`bin/Debug/`), and the script then looked for `libelizainference.dll` in `bin/` — wrong dir **and** wrong name (Windows emits the bare `elizainference.dll`, no `lib` prefix).

Three Windows-correct fixes, all no-ops on Linux/macOS:
- pass `--config Release` to `cmake --build` (multi-config honors it; single-config Make/Ninja ignore it)
- resolve `binDir` to `bin/Release` when it exists, else stay at `bin/`
- on win32 the fused lib is the bare `elizainference.dll`

Verified by building the fused lib end-to-end on Windows against the current llama.cpp fork (`44ecfb44a`): `elizainference.dll` compiles, links, and stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)