### PR TITLE
feat(cloud-shared): Stripe Connect fiat payout core (#8922)

### DIFF
--- a/packages/cloud-shared/src/db/migrations/0150_stripe_connect_accounts.sql
+++ b/packages/cloud-shared/src/db/migrations/0150_stripe_connect_accounts.sql
@@ -1,0 +1,25 @@
+-- Stripe Connect accounts (#8922) — fiat payout rail for creator earnings.
+-- One row per creator who started Stripe Connect onboarding; the connected
+-- account id is the transfers.create destination. Idempotent + guarded.
+DO $$ BEGIN
+  CREATE TYPE "stripe_connect_status" AS ENUM ('pending', 'active', 'restricted', 'disabled');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "stripe_connect_accounts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"stripe_connect_account_id" text NOT NULL,
+	"status" "stripe_connect_status" DEFAULT 'pending' NOT NULL,
+	"charges_enabled" boolean DEFAULT false NOT NULL,
+	"payouts_enabled" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "stripe_connect_accounts_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "stripe_connect_accounts_account_id_unique" UNIQUE("stripe_connect_account_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "stripe_connect_accounts" ADD CONSTRAINT "stripe_connect_accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "stripe_connect_accounts_account_idx" ON "stripe_connect_accounts" USING btree ("stripe_connect_account_id");

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -1037,6 +1037,13 @@
       "when": 1779841200000,
       "tag": "0149_drop_app_billing",
       "breakpoints": true
+    },
+    {
+      "idx": 148,
+      "version": "7",
+      "when": 1779927600000,
+      "tag": "0150_stripe_connect_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/schemas/index.ts
+++ b/packages/cloud-shared/src/db/schemas/index.ts
@@ -75,6 +75,7 @@ export * from "./secrets";
 export * from "./seo";
 export * from "./service-pricing";
 export * from "./shared-runtime-history";
+export * from "./stripe-connect-accounts";
 export * from "./telegram-chats";
 export * from "./tenant-db-clusters";
 export * from "./token-redemptions";

--- a/packages/cloud-shared/src/db/schemas/stripe-connect-accounts.ts
+++ b/packages/cloud-shared/src/db/schemas/stripe-connect-accounts.ts
@@ -1,0 +1,49 @@
+/**
+ * Stripe Connect accounts (#8922) — fiat payout rail for creator earnings.
+ *
+ * One row per creator (user) who has begun Stripe Connect onboarding. The
+ * connected `stripe_connect_account_id` is the destination for `transfers.create`
+ * when a creator withdraws earnings as fiat instead of on-chain elizaOS tokens.
+ * Payout status is advanced by `transfer.created` / `payout.paid` webhooks.
+ *
+ * This table holds only the linkage + capability flags; the money math lives in
+ * the existing redeemable-earnings ledger (the single source of truth for
+ * balances) — this never duplicates a balance.
+ */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { boolean, index, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+/** Lifecycle of a connected account, mirrored from Stripe capability flags. */
+export const stripeConnectStatusEnum = pgEnum("stripe_connect_status", [
+  "pending", // account created, onboarding not finished
+  "active", // charges + payouts enabled
+  "restricted", // Stripe needs more info
+  "disabled", // rejected / disabled
+]);
+
+export type StripeConnectStatus = "pending" | "active" | "restricted" | "disabled";
+
+export const stripeConnectAccounts = pgTable(
+  "stripe_connect_accounts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    user_id: uuid("user_id")
+      .notNull()
+      .unique()
+      .references(() => users.id, { onDelete: "cascade" }),
+    stripe_connect_account_id: text("stripe_connect_account_id").notNull().unique(),
+    status: stripeConnectStatusEnum("status").notNull().default("pending"),
+    charges_enabled: boolean("charges_enabled").notNull().default(false),
+    payouts_enabled: boolean("payouts_enabled").notNull().default(false),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    account_idx: index("stripe_connect_accounts_account_idx").on(table.stripe_connect_account_id),
+  }),
+);
+
+export type StripeConnectAccount = InferSelectModel<typeof stripeConnectAccounts>;
+export type NewStripeConnectAccount = InferInsertModel<typeof stripeConnectAccounts>;

--- a/packages/cloud-shared/src/lib/services/stripe-connect-payout.test.ts
+++ b/packages/cloud-shared/src/lib/services/stripe-connect-payout.test.ts
@@ -1,0 +1,194 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  connectStatusFromCapabilities,
+  createConnectOnboarding,
+  mapConnectWebhookEvent,
+  type StripeConnectClient,
+  transferToConnectAccount,
+  usdToStripeCents,
+} from "./stripe-connect-payout";
+
+/** Mock Stripe SDK subset — records calls, returns canned ids. */
+function mockStripe(): StripeConnectClient & {
+  calls: { accounts: unknown[]; links: unknown[]; transfers: unknown[] };
+} {
+  const calls = { accounts: [] as unknown[], links: [] as unknown[], transfers: [] as unknown[] };
+  return {
+    calls,
+    accounts: {
+      create: async (p) => {
+        calls.accounts.push(p);
+        return { id: "acct_123" };
+      },
+    },
+    accountLinks: {
+      create: async (p) => {
+        calls.links.push(p);
+        return { url: "https://connect.stripe.com/setup/acct_123" };
+      },
+    },
+    transfers: {
+      create: async (p, o) => {
+        calls.transfers.push({ p, o });
+        return { id: "tr_123" };
+      },
+    },
+  };
+}
+
+describe("createConnectOnboarding (#8922)", () => {
+  it("creates an Express account + onboarding link on first onboard", async () => {
+    const stripe = mockStripe();
+    const out = await createConnectOnboarding(stripe, {
+      userId: "u1",
+      email: "creator@example.com",
+      refreshUrl: "https://app/refresh",
+      returnUrl: "https://app/return",
+    });
+    expect(out).toMatchObject({
+      accountId: "acct_123",
+      onboardingUrl: "https://connect.stripe.com/setup/acct_123",
+      created: true,
+    });
+    expect(stripe.calls.accounts[0]).toMatchObject({
+      type: "express",
+      email: "creator@example.com",
+      metadata: { userId: "u1" },
+    });
+    expect(stripe.calls.links[0]).toMatchObject({
+      account: "acct_123",
+      type: "account_onboarding",
+    });
+  });
+
+  it("reuses an existing account (no new account created)", async () => {
+    const stripe = mockStripe();
+    const out = await createConnectOnboarding(stripe, {
+      userId: "u1",
+      refreshUrl: "r",
+      returnUrl: "ret",
+      existingAccountId: "acct_existing",
+    });
+    expect(out.created).toBe(false);
+    expect(out.accountId).toBe("acct_existing");
+    expect(stripe.calls.accounts).toHaveLength(0);
+    expect(stripe.calls.links[0]).toMatchObject({ account: "acct_existing" });
+  });
+});
+
+describe("usdToStripeCents", () => {
+  it("rounds USD to integer cents", () => {
+    expect(usdToStripeCents(14.95)).toBe(1495);
+    expect(usdToStripeCents(0.1)).toBe(10);
+    expect(usdToStripeCents(99.999)).toBe(10000);
+  });
+
+  it("rejects non-positive / non-finite amounts", () => {
+    expect(() => usdToStripeCents(0)).toThrow();
+    expect(() => usdToStripeCents(-5)).toThrow();
+    expect(() => usdToStripeCents(Number.NaN)).toThrow();
+  });
+});
+
+describe("transferToConnectAccount (#8922)", () => {
+  it("transfers cents to the connected account with an idempotency key", async () => {
+    const stripe = mockStripe();
+    const out = await transferToConnectAccount(stripe, {
+      accountId: "acct_123",
+      amountUsd: 25,
+      idempotencyKey: "withdraw-abc",
+      metadata: { withdrawalId: "w1" },
+    });
+    expect(out).toEqual({ transferId: "tr_123", amountCents: 2500 });
+    const call = stripe.calls.transfers[0] as {
+      p: { amount: number; currency: string; destination: string };
+      o: { idempotencyKey: string };
+    };
+    expect(call.p).toMatchObject({
+      amount: 2500,
+      currency: "usd",
+      destination: "acct_123",
+    });
+    expect(call.o.idempotencyKey).toBe("withdraw-abc");
+  });
+
+  it("rejects an invalid amount before calling Stripe", async () => {
+    const stripe = mockStripe();
+    await expect(
+      transferToConnectAccount(stripe, {
+        accountId: "acct_123",
+        amountUsd: 0,
+        idempotencyKey: "k",
+      }),
+    ).rejects.toThrow();
+    expect(stripe.calls.transfers).toHaveLength(0);
+  });
+});
+
+describe("connectStatusFromCapabilities", () => {
+  it("maps capability flags to a status", () => {
+    expect(connectStatusFromCapabilities({ charges_enabled: true, payouts_enabled: true })).toBe(
+      "active",
+    );
+    expect(
+      connectStatusFromCapabilities({
+        charges_enabled: false,
+        payouts_enabled: false,
+        requirementsDue: true,
+      }),
+    ).toBe("restricted");
+    expect(connectStatusFromCapabilities({ charges_enabled: false, payouts_enabled: false })).toBe(
+      "pending",
+    );
+    expect(
+      connectStatusFromCapabilities({
+        charges_enabled: true,
+        payouts_enabled: true,
+        disabled: true,
+      }),
+    ).toBe("disabled");
+  });
+});
+
+describe("mapConnectWebhookEvent (#8922)", () => {
+  it("advances payout status on transfer.created / payout.paid", () => {
+    expect(mapConnectWebhookEvent({ type: "transfer.created", account: "acct_1" })).toMatchObject({
+      accountId: "acct_1",
+      payoutStatus: "in_transit",
+      ignored: false,
+    });
+    expect(mapConnectWebhookEvent({ type: "payout.paid", account: "acct_1" })).toMatchObject({
+      payoutStatus: "paid",
+      ignored: false,
+    });
+  });
+
+  it("refreshes account status on account.updated", () => {
+    const out = mapConnectWebhookEvent({
+      type: "account.updated",
+      account: "acct_1",
+      data: { object: { charges_enabled: true, payouts_enabled: true } },
+    });
+    expect(out.status).toBe("active");
+  });
+
+  it("ignores unrelated event types", () => {
+    expect(mapConnectWebhookEvent({ type: "customer.created" }).ignored).toBe(true);
+  });
+});
+
+describe("migration 0150 (#8922)", () => {
+  const migrationsDir = join(import.meta.dirname, "../../db/migrations");
+  it("creates the table + enum and is registered in the journal", () => {
+    const sql = readFileSync(join(migrationsDir, "0150_stripe_connect_accounts.sql"), "utf8");
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS "stripe_connect_accounts"/);
+    expect(sql).toMatch(/CREATE TYPE "stripe_connect_status"/);
+    const journal = JSON.parse(
+      readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf8"),
+    ) as { entries: Array<{ tag: string }> };
+    expect(journal.entries.some((e) => e.tag === "0150_stripe_connect_accounts")).toBe(true);
+    expect(existsSync(join(migrationsDir, "0150_stripe_connect_accounts.sql"))).toBe(true);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/stripe-connect-payout.ts
+++ b/packages/cloud-shared/src/lib/services/stripe-connect-payout.ts
@@ -1,0 +1,190 @@
+/**
+ * Stripe Connect fiat payout for creators (#8922).
+ *
+ * Business logic for paying creator earnings to a connected bank account via
+ * Stripe Connect Express, as an alternative to the on-chain token-redemption
+ * path (`payout-processor.ts`). The money math + balance debit stays in the
+ * redeemable-earnings ledger (the single source of truth) — this module only
+ * orchestrates the Stripe side: onboarding, transfers, and webhook status.
+ *
+ * The Stripe SDK is injected (`StripeConnectClient`) rather than imported, so the
+ * flow is fully unit-testable without a live key and the route layer passes
+ * `requireStripe()` at the boundary.
+ */
+
+import type { StripeConnectStatus } from "../../db/schemas/stripe-connect-accounts";
+
+/** Payout currency. Kept inline (not imported from `../stripe`) so this module
+ * stays SDK-agnostic — it never loads the Stripe SDK; the route injects the
+ * client. Matches `STRIPE_CURRENCY` in `../stripe`. */
+const STRIPE_CURRENCY = "usd";
+
+/** Minimal structural subset of the Stripe SDK this module uses. */
+export interface StripeConnectClient {
+  accounts: {
+    create(params: {
+      type: "express";
+      email?: string;
+      metadata?: Record<string, string>;
+    }): Promise<{ id: string }>;
+  };
+  accountLinks: {
+    create(params: {
+      account: string;
+      refresh_url: string;
+      return_url: string;
+      type: "account_onboarding";
+    }): Promise<{ url: string }>;
+  };
+  transfers: {
+    create(
+      params: {
+        amount: number;
+        currency: string;
+        destination: string;
+        metadata?: Record<string, string>;
+      },
+      options?: { idempotencyKey?: string },
+    ): Promise<{ id: string }>;
+  };
+}
+
+export interface OnboardingInput {
+  userId: string;
+  email?: string;
+  /** Where Stripe returns the user if the link expires before completion. */
+  refreshUrl: string;
+  /** Where Stripe returns the user after onboarding. */
+  returnUrl: string;
+  /** Reuse an existing connected account instead of creating a new one. */
+  existingAccountId?: string;
+}
+
+export interface OnboardingResult {
+  accountId: string;
+  onboardingUrl: string;
+  /** True when a fresh Express account was created (caller persists it). */
+  created: boolean;
+}
+
+/**
+ * Create (or reuse) an Express connected account and return a one-time
+ * onboarding URL. The caller persists `accountId` on first creation.
+ */
+export async function createConnectOnboarding(
+  stripe: StripeConnectClient,
+  input: OnboardingInput,
+): Promise<OnboardingResult> {
+  let accountId = input.existingAccountId;
+  let created = false;
+  if (!accountId) {
+    const account = await stripe.accounts.create({
+      type: "express",
+      email: input.email,
+      metadata: { userId: input.userId },
+    });
+    accountId = account.id;
+    created = true;
+  }
+  const link = await stripe.accountLinks.create({
+    account: accountId,
+    refresh_url: input.refreshUrl,
+    return_url: input.returnUrl,
+    type: "account_onboarding",
+  });
+  return { accountId, onboardingUrl: link.url, created };
+}
+
+/** Convert a USD amount to integer Stripe cents, rejecting invalid values. */
+export function usdToStripeCents(amountUsd: number): number {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+    throw new Error(`Invalid payout amount: ${amountUsd}`);
+  }
+  return Math.round(amountUsd * 100);
+}
+
+export interface TransferInput {
+  accountId: string;
+  amountUsd: number;
+  /** Stable key so a retried withdraw never double-pays. */
+  idempotencyKey: string;
+  metadata?: Record<string, string>;
+}
+
+/**
+ * Transfer funds to a connected account. Assumes the caller has already run the
+ * existing withdraw validations (creator role, monetization on, balance ≥
+ * amount) and debited the ledger atomically — this is the Stripe side only.
+ */
+export async function transferToConnectAccount(
+  stripe: StripeConnectClient,
+  input: TransferInput,
+): Promise<{ transferId: string; amountCents: number }> {
+  const amountCents = usdToStripeCents(input.amountUsd);
+  const transfer = await stripe.transfers.create(
+    {
+      amount: amountCents,
+      currency: STRIPE_CURRENCY,
+      destination: input.accountId,
+      metadata: input.metadata,
+    },
+    { idempotencyKey: input.idempotencyKey },
+  );
+  return { transferId: transfer.id, amountCents };
+}
+
+/** Derive the account status enum from Stripe capability flags. */
+export function connectStatusFromCapabilities(caps: {
+  charges_enabled: boolean;
+  payouts_enabled: boolean;
+  disabled?: boolean;
+  requirementsDue?: boolean;
+}): StripeConnectStatus {
+  if (caps.disabled) return "disabled";
+  if (caps.charges_enabled && caps.payouts_enabled) return "active";
+  if (caps.requirementsDue) return "restricted";
+  return "pending";
+}
+
+export type ConnectPayoutStatus = "in_transit" | "paid";
+
+export interface ConnectWebhookOutcome {
+  /** Connected account the event concerns, when present. */
+  accountId?: string;
+  /** Payout lifecycle the event advances to, for `transfer.created`/`payout.paid`. */
+  payoutStatus?: ConnectPayoutStatus;
+  /** Account capability refresh, for `account.updated`. */
+  status?: StripeConnectStatus;
+  /** True when the event type isn't one we act on. */
+  ignored: boolean;
+}
+
+/**
+ * Pure mapping of a Stripe Connect webhook event to the status change it implies.
+ * The route persists the outcome; keeping this pure makes it fully testable.
+ */
+export function mapConnectWebhookEvent(event: {
+  type: string;
+  account?: string;
+  data?: { object?: Record<string, unknown> };
+}): ConnectWebhookOutcome {
+  switch (event.type) {
+    case "transfer.created":
+      return { accountId: event.account, payoutStatus: "in_transit", ignored: false };
+    case "payout.paid":
+      return { accountId: event.account, payoutStatus: "paid", ignored: false };
+    case "account.updated": {
+      const obj = event.data?.object ?? {};
+      return {
+        accountId: event.account,
+        status: connectStatusFromCapabilities({
+          charges_enabled: obj.charges_enabled === true,
+          payouts_enabled: obj.payouts_enabled === true,
+        }),
+        ignored: false,
+      };
+    }
+    default:
+      return { ignored: true };
+  }
+}


### PR DESCRIPTION
Part of **#8922** (EPIC #8889). Implements the architecturally-correct **core** of Stripe Connect fiat payout — the business logic + data model that the route layer proxies.

- **`schemas/stripe-connect-accounts`** + **migration `0150`**: one row per onboarded creator (linkage + capability flags only; balances stay in the redeemable-earnings ledger).
- **`lib/services/stripe-connect-payout`** — SDK-agnostic (injectable `StripeConnectClient`, unit-testable without a live key):
  - `createConnectOnboarding` (create/reuse Express account + onboarding link)
  - `transferToConnectAccount` (`usdToStripeCents` + `transfers.create` with an idempotency key — no double-pay on retry)
  - `connectStatusFromCapabilities` + `mapConnectWebhookEvent` (pure `transfer.created`/`payout.paid`/`account.updated` → status mapping)

**Tests:** 11 (onboarding create+reuse, USD→cents, transfer idempotency + pre-call validation, capability→status, webhook mapping, migration registration) — all green via `bun test`.

**Remaining for #8922** (tracked on the issue): the thin cloud-api route proxies (`/onboard`, `/transfer`, webhook) behind the existing withdraw validations + admin gate, and the live **Stripe-test-mode** cloud-e2e — which needs a Stripe account this environment doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)