### PR TITLE
fix(core): bridge runtime EventType bus to AgentEventService streams (#8813 AC#3)

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -19,6 +19,14 @@ import {
 	postCreationTemplate,
 } from "../../prompts.ts";
 import { TURN_CONTROL_ROUTES } from "../../runtime/turn-routes";
+import {
+	bridgeActionCompletedToStreams,
+	bridgeActionStartedToStreams,
+	bridgeEvaluatorCompletedToStreams,
+	bridgeEvaluatorStartedToStreams,
+	bridgeRunEndedToStreams,
+	bridgeRunStartedToStreams,
+} from "../../services/agent-event-bridge.ts";
 import { ChannelTopicsService } from "../../services/channel-topics.ts";
 import { EmbeddingGenerationService } from "../../services/embedding.ts";
 import { EvaluatorService } from "../../services/evaluator.ts";
@@ -35,6 +43,7 @@ import type {
 	Content,
 	ControlMessagePayload,
 	EntityPayload,
+	EvaluatorEventPayload,
 	IAgentRuntime,
 	IMessageBusService,
 	InvokePayload,
@@ -1050,6 +1059,11 @@ const events: PluginEvents = {
 
 	[EventType.ACTION_STARTED]: [
 		async (payload: ActionEventPayload) => {
+			// Bridge to the AgentEventService action/lifecycle streams so the WS
+			// `agent_event` channel carries real per-turn phase data (#8813 AC#3).
+			bridgeActionStartedToStreams(payload);
+		},
+		async (payload: ActionEventPayload) => {
 			// Only notify for client_chat messages
 			const payloadContent = payload.content;
 			if (payloadContent && payloadContent.source === "client_chat") {
@@ -1100,6 +1114,10 @@ const events: PluginEvents = {
 
 	[EventType.ACTION_COMPLETED]: [
 		async (payload: ActionEventPayload) => {
+			// Bridge to the AgentEventService action/lifecycle streams (#8813 AC#3).
+			bridgeActionCompletedToStreams(payload);
+		},
+		async (payload: ActionEventPayload) => {
 			// Only notify for client_chat messages
 			const payloadContent = payload.content;
 			if (payloadContent && payloadContent.source === "client_chat") {
@@ -1118,6 +1136,10 @@ const events: PluginEvents = {
 	],
 
 	[EventType.RUN_STARTED]: [
+		async (payload: RunEventPayload) => {
+			// Bridge to the AgentEventService lifecycle stream (#8813 AC#3).
+			bridgeRunStartedToStreams(payload);
+		},
 		async (payload: RunEventPayload) => {
 			await payload.runtime.createLogs([
 				{
@@ -1147,6 +1169,10 @@ const events: PluginEvents = {
 	],
 
 	[EventType.RUN_ENDED]: [
+		async (payload: RunEventPayload) => {
+			// Bridge to the AgentEventService lifecycle stream (#8813 AC#3).
+			bridgeRunEndedToStreams(payload);
+		},
 		async (payload: RunEventPayload) => {
 			await payload.runtime.createLogs([
 				{
@@ -1208,6 +1234,20 @@ const events: PluginEvents = {
 				},
 				"Logged RUN_TIMEOUT event",
 			);
+		},
+	],
+
+	[EventType.EVALUATOR_STARTED]: [
+		async (payload: EvaluatorEventPayload) => {
+			// Bridge to the AgentEventService evaluator stream (#8813 AC#3).
+			bridgeEvaluatorStartedToStreams(payload);
+		},
+	],
+
+	[EventType.EVALUATOR_COMPLETED]: [
+		async (payload: EvaluatorEventPayload) => {
+			// Bridge to the AgentEventService evaluator stream (#8813 AC#3).
+			bridgeEvaluatorCompletedToStreams(payload);
 		},
 	],
 

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -257,6 +257,7 @@ export * from "./security";
 export * from "./sensitive-request-policy";
 export * from "./sensitive-requests";
 export * from "./services";
+export * from "./services/agent-event-bridge";
 export * from "./services/agentEvent";
 export * from "./services/approval";
 export * from "./services/channel-topics";

--- a/packages/core/src/services/agent-event-bridge.test.ts
+++ b/packages/core/src/services/agent-event-bridge.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEventPayload } from "../types/agentEvent.ts";
+import type {
+	ActionEventPayload,
+	EvaluatorEventPayload,
+} from "../types/events.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+import { ServiceType } from "../types/service.ts";
+import {
+	bridgeActionCompletedToStreams,
+	bridgeActionStartedToStreams,
+	bridgeEvaluatorCompletedToStreams,
+	bridgeEvaluatorStartedToStreams,
+	bridgeRunEndedToStreams,
+	bridgeRunStartedToStreams,
+} from "./agent-event-bridge.ts";
+import { AgentEventService } from "./agentEvent.ts";
+
+const RUN_ID = "11111111-1111-1111-1111-111111111111";
+const ROOM_ID = "22222222-2222-2222-2222-222222222222";
+const WORLD_ID = "33333333-3333-3333-3333-333333333333";
+
+async function createCtx(opts: { withService?: boolean } = {}): Promise<{
+	runtime: IAgentRuntime;
+	events: AgentEventPayload[];
+}> {
+	const withService = opts.withService ?? true;
+	const events: AgentEventPayload[] = [];
+
+	const runtimeBase = {
+		agentId: "00000000-0000-0000-0000-0000000000aa",
+		getCurrentRunId: () => RUN_ID,
+	} as unknown as IAgentRuntime;
+
+	let service: AgentEventService | null = null;
+	if (withService) {
+		service = (await AgentEventService.start(runtimeBase)) as AgentEventService;
+		service.subscribe((event) => events.push(event));
+	}
+
+	const runtime = {
+		...runtimeBase,
+		getService: (type: string) =>
+			type === ServiceType.AGENT_EVENT ? service : null,
+	} as unknown as IAgentRuntime;
+
+	return { runtime, events };
+}
+
+function actionPayload(
+	runtime: IAgentRuntime,
+	actionName: string,
+	status: "executing" | "completed" | "failed",
+): ActionEventPayload {
+	return {
+		runtime,
+		roomId: ROOM_ID,
+		world: WORLD_ID,
+		content: {
+			text: `Executing action: ${actionName}`,
+			actions: [actionName],
+			actionStatus: status,
+			source: "client_chat",
+		},
+	} as unknown as ActionEventPayload;
+}
+
+describe("agent-event-bridge", () => {
+	it("populates the action + lifecycle streams on ACTION_STARTED", async () => {
+		const { runtime, events } = await createCtx();
+		bridgeActionStartedToStreams(
+			actionPayload(runtime, "WEB_SEARCH", "executing"),
+		);
+
+		const action = events.find((e) => e.stream === "action");
+		expect(action).toBeDefined();
+		expect(action?.runId).toBe(RUN_ID);
+		expect(action?.data).toMatchObject({
+			type: "start",
+			actionName: "WEB_SEARCH",
+		});
+
+		const lifecycle = events.find((e) => e.stream === "lifecycle");
+		expect(lifecycle?.data).toMatchObject({
+			type: "action_start",
+			actionName: "WEB_SEARCH",
+		});
+	});
+
+	it("populates the action stream with success on ACTION_COMPLETED", async () => {
+		const { runtime, events } = await createCtx();
+		bridgeActionCompletedToStreams(
+			actionPayload(runtime, "WEB_SEARCH", "completed"),
+		);
+		const action = events.find((e) => e.stream === "action");
+		expect(action?.data).toMatchObject({
+			type: "complete",
+			actionName: "WEB_SEARCH",
+			success: true,
+		});
+	});
+
+	it("reports success=false when the action failed", async () => {
+		const { runtime, events } = await createCtx();
+		bridgeActionCompletedToStreams(actionPayload(runtime, "REPLY", "failed"));
+		const action = events.find((e) => e.stream === "action");
+		expect(action?.data).toMatchObject({ type: "complete", success: false });
+	});
+
+	it("populates the lifecycle stream on RUN_STARTED / RUN_ENDED", async () => {
+		const { runtime, events } = await createCtx();
+		bridgeRunStartedToStreams({
+			runtime,
+			runId: RUN_ID,
+			messageId: ROOM_ID,
+			roomId: ROOM_ID,
+			entityId: WORLD_ID,
+			startTime: 1,
+			status: "started",
+		} as unknown as Parameters<typeof bridgeRunStartedToStreams>[0]);
+		bridgeRunEndedToStreams({
+			runtime,
+			runId: RUN_ID,
+			messageId: ROOM_ID,
+			roomId: ROOM_ID,
+			entityId: WORLD_ID,
+			startTime: 1,
+			endTime: 6,
+			duration: 5,
+			status: "completed",
+		} as unknown as Parameters<typeof bridgeRunEndedToStreams>[0]);
+
+		const lifecycleTypes = events
+			.filter((e) => e.stream === "lifecycle")
+			.map((e) => e.data.type);
+		expect(lifecycleTypes).toContain("run_start");
+		expect(lifecycleTypes).toContain("run_end");
+		const runEnd = events.find(
+			(e) => e.stream === "lifecycle" && e.data.type === "run_end",
+		);
+		expect(runEnd?.data).toMatchObject({ success: true, duration: 5 });
+	});
+
+	it("clears per-run sequence state after RUN_ENDED (no map leak)", async () => {
+		const { runtime } = await createCtx();
+		const service = runtime.getService(
+			ServiceType.AGENT_EVENT,
+		) as AgentEventService;
+		bridgeRunStartedToStreams({
+			runtime,
+			runId: RUN_ID,
+			messageId: ROOM_ID,
+			roomId: ROOM_ID,
+			entityId: WORLD_ID,
+			startTime: 1,
+			status: "started",
+		} as unknown as Parameters<typeof bridgeRunStartedToStreams>[0]);
+		expect(service.getCurrentSeq(RUN_ID)).toBeGreaterThan(0);
+		bridgeRunEndedToStreams({
+			runtime,
+			runId: RUN_ID,
+			messageId: ROOM_ID,
+			roomId: ROOM_ID,
+			entityId: WORLD_ID,
+			startTime: 1,
+			endTime: 2,
+			status: "completed",
+		} as unknown as Parameters<typeof bridgeRunEndedToStreams>[0]);
+		// seq reset to 0 → run context dropped.
+		expect(service.getCurrentSeq(RUN_ID)).toBe(0);
+	});
+
+	it("populates the evaluator stream on EVALUATOR_STARTED / COMPLETED", async () => {
+		const { runtime, events } = await createCtx();
+		const base = {
+			runtime,
+			evaluatorId: WORLD_ID,
+			evaluatorName: "post_turn",
+		} as unknown as EvaluatorEventPayload;
+		bridgeEvaluatorStartedToStreams(base);
+		bridgeEvaluatorCompletedToStreams({
+			...base,
+			completed: true,
+		} as EvaluatorEventPayload);
+
+		const evals = events.filter((e) => e.stream === "evaluator");
+		expect(evals.map((e) => e.data.type)).toEqual(["start", "complete"]);
+		expect(evals[1]?.data).toMatchObject({
+			evaluatorName: "post_turn",
+			validated: true,
+		});
+	});
+
+	it("is a no-op (never throws) when AgentEventService is absent", async () => {
+		const { runtime, events } = await createCtx({ withService: false });
+		expect(() =>
+			bridgeActionStartedToStreams(
+				actionPayload(runtime, "WEB_SEARCH", "executing"),
+			),
+		).not.toThrow();
+		expect(events).toHaveLength(0);
+	});
+
+	it("falls back to the runtime current run id when the payload omits one", async () => {
+		const { runtime, events } = await createCtx();
+		// payload content has no runId → bridge uses runtime.getCurrentRunId()
+		bridgeActionStartedToStreams(actionPayload(runtime, "REPLY", "executing"));
+		expect(events[0]?.runId).toBe(RUN_ID);
+	});
+});

--- a/packages/core/src/services/agent-event-bridge.ts
+++ b/packages/core/src/services/agent-event-bridge.ts
@@ -1,0 +1,279 @@
+/**
+ * AgentEventService bridge
+ *
+ * The runtime emits coarse lifecycle telemetry on the {@link EventType} bus
+ * (`RUN_STARTED`, `ACTION_STARTED`, `EVALUATOR_STARTED`, …). Separately,
+ * {@link AgentEventService} exposes a fully-typed per-run stream taxonomy
+ * (`lifecycle | action | evaluator | tool | provider | …`) that the agent HTTP
+ * server broadcasts to WS clients as `agent_event` messages.
+ *
+ * Historically the `AgentEventService` `action` / `evaluator` / `lifecycle`
+ * streams were dead — the `emit*` helpers existed but had no call sites, so the
+ * WS channel never carried per-turn phase data. This module is the single
+ * bridge that maps the {@link EventType} bus → `AgentEventService` streams
+ * (option (b) from issue #8813): one place to wire, every existing event lights
+ * up for free, and the streams become reusable beyond the chat indicator.
+ *
+ * The bridge is intentionally defensive: it resolves `AgentEventService`
+ * lazily, no-ops when the service is not hosted (core-only tests, headless
+ * tools), and never throws back into the hot message loop.
+ */
+
+import { logger } from "../logger.ts";
+import type {
+	ActionEventPayload,
+	EvaluatorEventPayload,
+	RunEventPayload,
+} from "../types/events.ts";
+import type { IAgentRuntime } from "../types/index.ts";
+import { ServiceType } from "../types/service.ts";
+import type { AgentEventService } from "./agentEvent.ts";
+
+/**
+ * Resolve the {@link AgentEventService} if it is registered on the runtime.
+ *
+ * Duck-typed (rather than `instanceof`) so it works across bundle targets and
+ * test doubles. Returns `null` when the service is absent so callers no-op.
+ */
+function resolveAgentEventService(
+	runtime: IAgentRuntime,
+): AgentEventService | null {
+	try {
+		const service = runtime.getService(ServiceType.AGENT_EVENT);
+		if (
+			service &&
+			typeof (service as AgentEventService).emitActionStart === "function"
+		) {
+			return service as AgentEventService;
+		}
+	} catch {
+		// getService may throw on partially-initialized runtimes; treat as absent.
+	}
+	return null;
+}
+
+/**
+ * Resolve the run id to correlate a stream event with. Action/evaluator events
+ * do not carry their own run id, so we fall back to the runtime's current run.
+ */
+function resolveRunId(
+	runtime: IAgentRuntime,
+	payloadRunId?: string,
+): string | null {
+	if (payloadRunId) {
+		return payloadRunId;
+	}
+	try {
+		return runtime.getCurrentRunId?.() ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function resolveActionName(payload: ActionEventPayload): string {
+	const actions = payload.content?.actions;
+	if (Array.isArray(actions) && typeof actions[0] === "string") {
+		return actions[0];
+	}
+	return "unknown";
+}
+
+function readContentRunId(payload: ActionEventPayload): string | undefined {
+	const runId = (payload.content as Record<string, unknown> | undefined)?.runId;
+	return typeof runId === "string" && runId.length > 0 ? runId : undefined;
+}
+
+function isSuccessfulActionStatus(payload: ActionEventPayload): boolean {
+	// `actionStatus` is set to "completed" | "failed" by the action executors.
+	const status = (payload.content as Record<string, unknown> | undefined)
+		?.actionStatus;
+	return status !== "failed";
+}
+
+/**
+ * Bridge `ACTION_STARTED` → AgentEventService `action` + `lifecycle` streams.
+ */
+export function bridgeActionStartedToStreams(
+	payload: ActionEventPayload,
+): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime, readContentRunId(payload));
+	if (!runId) {
+		return;
+	}
+	const actionName = resolveActionName(payload);
+	try {
+		service.emitActionStart(runId, { actionName });
+		service.emitLifecycle(runId, { type: "action_start", actionName });
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge ACTION_STARTED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `ACTION_COMPLETED` → AgentEventService `action` + `lifecycle` streams.
+ */
+export function bridgeActionCompletedToStreams(
+	payload: ActionEventPayload,
+): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime, readContentRunId(payload));
+	if (!runId) {
+		return;
+	}
+	const actionName = resolveActionName(payload);
+	const success = isSuccessfulActionStatus(payload);
+	try {
+		service.emitActionComplete(runId, { actionName, success });
+		service.emitLifecycle(runId, {
+			type: "action_end",
+			actionName,
+			success,
+		});
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge ACTION_COMPLETED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `RUN_STARTED` → AgentEventService `lifecycle` stream.
+ */
+export function bridgeRunStartedToStreams(payload: RunEventPayload): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime, payload.runId);
+	if (!runId) {
+		return;
+	}
+	try {
+		service.emitLifecycle(runId, { type: "run_start" });
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge RUN_STARTED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `RUN_ENDED` → AgentEventService `lifecycle` stream.
+ */
+export function bridgeRunEndedToStreams(payload: RunEventPayload): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime, payload.runId);
+	if (!runId) {
+		return;
+	}
+	const duration =
+		typeof payload.duration === "number" ? payload.duration : undefined;
+	try {
+		service.emitLifecycle(runId, {
+			type: "run_end",
+			success: payload.status === "completed",
+			...(duration !== undefined ? { duration } : {}),
+		});
+		// Run is over: drop its per-run sequence/context so the bridge does not
+		// leak one map entry per turn over the life of the agent. Emitting first
+		// keeps the final `run_end` seq monotonic.
+		service.clearRunContext(runId);
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge RUN_ENDED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `EVALUATOR_STARTED` → AgentEventService `evaluator` stream.
+ */
+export function bridgeEvaluatorStartedToStreams(
+	payload: EvaluatorEventPayload,
+): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime);
+	if (!runId) {
+		return;
+	}
+	try {
+		service.emitEvaluatorStart(runId, {
+			evaluatorName: payload.evaluatorName,
+		});
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge EVALUATOR_STARTED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `EVALUATOR_COMPLETED` → AgentEventService `evaluator` stream.
+ */
+export function bridgeEvaluatorCompletedToStreams(
+	payload: EvaluatorEventPayload,
+): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const runId = resolveRunId(runtime);
+	if (!runId) {
+		return;
+	}
+	try {
+		service.emitEvaluatorComplete(runId, {
+			evaluatorName: payload.evaluatorName,
+			validated: payload.completed === true,
+		});
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge EVALUATOR_COMPLETED to AgentEventService",
+		);
+	}
+}


### PR DESCRIPTION
## What

Closes the one remaining acceptance gap (**AC#3**) from #8813 (*Rich, Claude-like agent status indicator*). The user-visible indicator already shipped via additive chat SSE (`9f360378b0`); this wires the previously-dead `AgentEventService` streams so the agent server's WS `agent_event` channel carries real per-turn phase data — reusable beyond the chat indicator.

### The gap
`emitActionStart` / `emitActionComplete` / `emitEvaluatorStart` / `emitEvaluatorComplete` / `emitLifecycle` existed on `AgentEventService` but had **no call sites** (verified by grep), so the `action` / `evaluator` / `lifecycle` streams were never populated.

### The fix — option (b) from the issue (bridge the EventType bus)
A single central bridge, `packages/core/src/services/agent-event-bridge.ts`, wired into the existing `basic-capabilities` EventType handlers:

| EventType bus | AgentEventService stream |
|---|---|
| `ACTION_STARTED` / `ACTION_COMPLETED` | `action` + `lifecycle` (success derived from `actionStatus`) |
| `RUN_STARTED` / `RUN_ENDED` | `lifecycle` (RUN_ENDED also `clearRunContext` → no per-turn map leak) |
| `EVALUATOR_STARTED` / `EVALUATOR_COMPLETED` | `evaluator` |

The bridge resolves `AgentEventService` lazily, **no-ops when it is not hosted** (core-only tests, headless tools), correlates via payload `runId` or `runtime.getCurrentRunId()`, and **never throws back into the hot message loop** (all emits wrapped, failures logged at debug).

This is option (b) rather than (a): one wiring point, every existing EventType lights up for free, DRY.

## Why not touch the chat indicator
The user-facing goal (binary dots → phase-aware "Thinking… / Running X… / Writing…") already landed via the SSE `status` event and is unchanged. This PR only fills the orthogonal AgentEventService-stream population the issue listed as AC#3.

## Tests / evidence

`packages/core/src/services/agent-event-bridge.test.ts` — **8 cases**:
- action + lifecycle streams populated on ACTION_STARTED
- action `success:true/false` on ACTION_COMPLETED (completed vs failed)
- lifecycle `run_start` / `run_end` (with duration)
- per-run seq/context cleared after RUN_ENDED (no map leak)
- evaluator stream `start` → `complete` with `validated`
- clean no-op (never throws) when the service is absent
- falls back to `runtime.getCurrentRunId()` when payload omits a runId

```
$ bun run --cwd packages/core test -- agent-event-bridge
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ bun run --cwd packages/core test -- evaluator basic-capabilities events
 Test Files  20 passed (20)
      Tests  135 passed (135)

$ bun run --cwd packages/core typecheck   # clean
$ biome check (4 changed files)           # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)