### PR TITLE
[codex] feat(app-core): harden desktop cloud runtime

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-http-request.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-http-request.test.ts
@@ -54,8 +54,37 @@ describe("desktopHttpRequest", () => {
       "https://agent.example:2138",
     ]) {
       expect(() => normalizeDesktopHttpRequest({ url })).toThrow(
-        "external plain HTTP",
+        "configured desktop API plain HTTP",
       );
+    }
+  });
+
+  it("allows the configured external desktop API base even when it is loopback", () => {
+    const previous = process.env.ELIZA_DESKTOP_TEST_API_BASE;
+    process.env.ELIZA_DESKTOP_TEST_API_BASE = "http://127.0.0.1:2138";
+    try {
+      expect(
+        normalizeDesktopHttpRequest({
+          url: "http://127.0.0.1:2138/api/config",
+        }),
+      ).toEqual({
+        url: "http://127.0.0.1:2138/api/config",
+        method: "GET",
+        headers: {},
+        body: null,
+        timeoutMs: undefined,
+      });
+      expect(() =>
+        normalizeDesktopHttpRequest({
+          url: "http://127.0.0.1:31337/api/config",
+        }),
+      ).toThrow("configured desktop API plain HTTP");
+    } finally {
+      if (typeof previous === "undefined") {
+        delete process.env.ELIZA_DESKTOP_TEST_API_BASE;
+      } else {
+        process.env.ELIZA_DESKTOP_TEST_API_BASE = previous;
+      }
     }
   });
 

--- a/packages/app-core/platforms/electrobun/src/desktop-http-request.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-http-request.ts
@@ -1,4 +1,5 @@
 import { isLoopbackBindHost, isWildcardBindHost } from "@elizaos/shared";
+import { resolveExternalApiBase } from "./api-base";
 
 function isExternalPlainHttpUrl(parsed: URL): boolean {
   return (
@@ -6,6 +7,14 @@ function isExternalPlainHttpUrl(parsed: URL): boolean {
     !isLoopbackBindHost(parsed.hostname) &&
     !isWildcardBindHost(parsed.hostname)
   );
+}
+
+function isConfiguredExternalApiBaseUrl(parsed: URL): boolean {
+  if (parsed.protocol !== "http:") return false;
+  const configured = resolveExternalApiBase(
+    process.env as Record<string, string | undefined>,
+  ).base;
+  return Boolean(configured && parsed.origin === configured);
 }
 
 export function normalizeDesktopHttpRequest(params: unknown): {
@@ -23,9 +32,12 @@ export function normalizeDesktopHttpRequest(params: unknown): {
     throw new Error("desktopHttpRequest url must be a string.");
   }
   const parsed = new URL(record.url);
-  if (!isExternalPlainHttpUrl(parsed)) {
+  if (
+    !isExternalPlainHttpUrl(parsed) &&
+    !isConfiguredExternalApiBaseUrl(parsed)
+  ) {
     throw new Error(
-      "desktopHttpRequest supports only external plain HTTP URLs.",
+      "desktopHttpRequest supports only external or configured desktop API plain HTTP URLs.",
     );
   }
   const method = typeof record.method === "string" ? record.method : "GET";

--- a/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-test-bridge-server.ts
@@ -161,6 +161,18 @@ export async function startDesktopTestBridgeServer(): Promise<
         return;
       }
 
+      if (pathname === "/main-window/show" && method === "POST") {
+        await getDesktopManager().showWindow();
+        json(res, 200, { ok: true });
+        return;
+      }
+
+      if (pathname === "/main-window/focus" && method === "POST") {
+        await getDesktopManager().focusWindow();
+        json(res, 200, { ok: true });
+        return;
+      }
+
       if (pathname === "/main-window/bounds") {
         const snapshot = getCurrentMainWindowSnapshot();
         if (!snapshot.present) {
@@ -221,6 +233,22 @@ export async function startDesktopTestBridgeServer(): Promise<
             ? { ok: true }
             : { error: "application menu handler unavailable" },
         );
+        return;
+      }
+
+      if (pathname === "/app/quit" && method === "POST") {
+        json(res, 202, { ok: true });
+        setTimeout(() => {
+          void getDesktopManager()
+            .quit()
+            .catch((error: unknown) => {
+              console.warn(
+                `[DesktopTestBridge] Graceful quit failed: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            });
+        }, 0);
         return;
       }
 

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { resolveApiToken, resolveDesktopApiPort } from "@elizaos/shared";
+import {
+  formatError,
+  resolveApiToken,
+  resolveDesktopApiPort,
+} from "@elizaos/shared";
 import type { BrowserWindow } from "electrobun/bun";
 import Electrobun, {
   ApplicationMenu,
@@ -629,10 +633,23 @@ let surfaceWindowManager: SurfaceWindowManager | null = null;
 let rendererUrlPromise: Promise<string> | null = null;
 let backgroundWindowPromise: Promise<void> | null = null;
 let isQuitting = false;
+let quitRequestPromise: Promise<void> | null = null;
 
-function requestAppQuit(): void {
+function requestAppQuit(): Promise<void> {
+  if (quitRequestPromise) {
+    return quitRequestPromise;
+  }
+
   isQuitting = true;
-  Utils.quit();
+  quitRequestPromise = (async () => {
+    await runShutdownCleanup("explicit-quit").catch((err) => {
+      logger.warn(
+        `[Main] Shutdown cleanup failed before explicit quit: ${formatError(err)}`,
+      );
+    });
+    Utils.quit();
+  })();
+  return quitRequestPromise;
 }
 
 /**
@@ -647,6 +664,7 @@ function isPackagedDesktopBuild(): boolean {
 }
 
 const cleanupFns: Array<() => void | Promise<void>> = [];
+let shutdownCleanupPromise: Promise<void> | null = null;
 let lastFocusedWindow: ManagedWindowLike | null = null;
 const macOpenedDevtoolsWindowIds = new Set<number>();
 
@@ -1160,7 +1178,7 @@ function attachMainWindow(
       logger.info(
         "[Main] Window close on Linux with no tray — quitting (no surface to restore from)",
       );
-      requestAppQuit();
+      void requestAppQuit();
       return;
     }
 
@@ -2172,13 +2190,41 @@ function setupDockReopen(): void {
 }
 
 async function runShutdownCleanup(reason: string): Promise<void> {
-  logger.info(`[Main] App quitting (${reason}), disposing native modules...`);
-  isQuitting = true;
-  sendToActiveRenderer("desktopShutdownStarted", { reason });
-  for (const cleanupFn of cleanupFns) {
-    await Promise.resolve(cleanupFn());
+  if (shutdownCleanupPromise) {
+    return shutdownCleanupPromise;
   }
-  await disposeNativeModules();
+
+  shutdownCleanupPromise = (async () => {
+    logger.info(`[Main] App quitting (${reason}), disposing native modules...`);
+    isQuitting = true;
+    sendToActiveRenderer("desktopShutdownStarted", { reason });
+    const cleanupFnsToRun = cleanupFns.splice(0);
+    const cleanupResults = await Promise.allSettled(
+      cleanupFnsToRun.map((cleanupFn) => Promise.resolve().then(cleanupFn)),
+    );
+    for (const result of cleanupResults) {
+      if (result.status === "rejected") {
+        logger.warn(
+          `[Main] Shutdown cleanup callback failed: ${
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason)
+          }`,
+        );
+      }
+    }
+    try {
+      await disposeNativeModules();
+    } catch (error) {
+      logger.warn(
+        `[Main] Native module disposal failed during shutdown: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  })();
+
+  return shutdownCleanupPromise;
 }
 
 function setupShutdown(): void {
@@ -2632,7 +2678,7 @@ async function main(): Promise<void> {
   });
   getDesktopManager().setRestoreMainWindowCallback(() => restoreWindow());
   getDesktopManager().setRequestQuitCallback(() => {
-    requestAppQuit();
+    void requestAppQuit();
   });
   getDesktopManager().setOpenSurfaceWindowCallback(
     (surface, browse, alwaysOnTop) => {

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -31,6 +31,7 @@
 
 import {
   pushApiBaseToRenderer,
+  resolveDesktopRuntimeMode,
   resolveDesktopRuntimeModeSignal,
 } from "../api-base";
 
@@ -94,7 +95,12 @@ export function injectIntoHtml(html: string): string {
   const runtimeModeInject = runtimeModeSignal
     ? `window.__ELIZA_DESKTOP_RUNTIME_MODE__=${safeJsonForHtml(runtimeModeSignal)};`
     : "";
-  const script = `<script>window.__ELIZA_API_BASE__=${baseLiteral};${runtimeModeInject}${tokenInject}${bootConfigInject}</script>`;
+  const runtime = resolveDesktopRuntimeMode(process.env);
+  const externalApiBaseInject =
+    runtime.mode === "external" && runtime.externalApi.base
+      ? `window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__=${safeJsonForHtml(runtime.externalApi.base)};`
+      : "";
+  const script = `<script>window.__ELIZA_API_BASE__=${baseLiteral};${runtimeModeInject}${externalApiBaseInject}${tokenInject}${bootConfigInject}</script>`;
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);
   }

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -1,9 +1,110 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopManager, resetDesktopManagerForTesting } from "./desktop";
 
+const electrobunMock = vi.hoisted(() => {
+  type Handler = (event?: unknown) => void;
+  const handlers = new Map<string, Handler[]>();
+  const trayInstances: Array<{
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    setImage: ReturnType<typeof vi.fn>;
+    setMenu: ReturnType<typeof vi.fn>;
+    setTitle: ReturnType<typeof vi.fn>;
+  }> = [];
+  const events = {
+    on: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    }),
+    off: vi.fn((event: string, handler: Handler) => {
+      handlers.set(
+        event,
+        (handlers.get(event) ?? []).filter((item) => item !== handler),
+      );
+    }),
+    emit(event: string, payload?: unknown) {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(payload);
+      }
+    },
+  };
+  const Tray = vi.fn(function FakeTray(this: {
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    setImage: ReturnType<typeof vi.fn>;
+    setMenu: ReturnType<typeof vi.fn>;
+    setTitle: ReturnType<typeof vi.fn>;
+  }) {
+    this.on = vi.fn();
+    this.off = vi.fn();
+    this.remove = vi.fn();
+    this.setImage = vi.fn();
+    this.setMenu = vi.fn();
+    this.setTitle = vi.fn();
+    trayInstances.push(this);
+  });
+  const Utils = {
+    clipboard: {},
+    openExternal: vi.fn(),
+    paths: {
+      home: "/tmp",
+      appData: "/tmp",
+      userData: "/tmp",
+      userCache: "/tmp",
+      userLogs: "/tmp",
+      temp: "/tmp",
+      cache: "/tmp",
+      logs: "/tmp",
+      config: "/tmp",
+      documents: "/tmp",
+      downloads: "/tmp",
+      desktop: "/tmp",
+      pictures: "/tmp",
+      music: "/tmp",
+      videos: "/tmp",
+    },
+    quit: vi.fn(),
+    showNotification: vi.fn(),
+    showItemInFolder: vi.fn(),
+  };
+  const GlobalShortcut = {
+    isRegistered: vi.fn(() => false),
+    register: vi.fn(),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+  };
+  return {
+    events,
+    handlers,
+    trayInstances,
+    GlobalShortcut,
+    Tray,
+    Utils,
+    reset() {
+      handlers.clear();
+      trayInstances.splice(0);
+      events.on.mockClear();
+      events.off.mockClear();
+      GlobalShortcut.isRegistered.mockClear();
+      GlobalShortcut.register.mockClear();
+      GlobalShortcut.unregister.mockClear();
+      GlobalShortcut.unregisterAll.mockClear();
+      Tray.mockClear();
+      for (const value of Object.values(Utils)) {
+        if (typeof value === "function" && "mockClear" in value) {
+          value.mockClear();
+        }
+      }
+    },
+  };
+});
+
 vi.mock("electrobun/bun", () => {
   return {
-    default: {},
+    default: { events: electrobunMock.events },
     BrowserView: vi.fn(),
     BuildConfig: {
       appIdentifier: "test.eliza",
@@ -12,38 +113,16 @@ vi.mock("electrobun/bun", () => {
     ContextMenu: {
       on: vi.fn(),
     },
-    GlobalShortcut: vi.fn(),
+    GlobalShortcut: electrobunMock.GlobalShortcut,
     Screen: {
       getAllDisplays: vi.fn(() => []),
     },
     Session: {
       defaultSession: {},
     },
-    Tray: vi.fn(),
+    Tray: electrobunMock.Tray,
     Updater: {},
-    Utils: {
-      clipboard: {},
-      openExternal: vi.fn(),
-      paths: {
-        home: "/tmp",
-        appData: "/tmp",
-        userData: "/tmp",
-        userCache: "/tmp",
-        userLogs: "/tmp",
-        temp: "/tmp",
-        cache: "/tmp",
-        logs: "/tmp",
-        config: "/tmp",
-        documents: "/tmp",
-        downloads: "/tmp",
-        desktop: "/tmp",
-        pictures: "/tmp",
-        music: "/tmp",
-        videos: "/tmp",
-      },
-      showNotification: vi.fn(),
-      showItemInFolder: vi.fn(),
-    },
+    Utils: electrobunMock.Utils,
   };
 });
 
@@ -124,6 +203,7 @@ describe("DesktopManager main window controls", () => {
 
   beforeEach(() => {
     resetDesktopManagerForTesting();
+    electrobunMock.reset();
     delete process.env.ELIZAOS_CLOSE_MINIMIZES_TO_TRAY;
   });
 
@@ -296,5 +376,41 @@ describe("DesktopManager main window controls", () => {
     expect(first.off).toHaveBeenCalledWith("move", expect.any(Function));
     expect(second.on).toHaveBeenCalledWith("focus", expect.any(Function));
     expect(second.on).toHaveBeenCalledWith("blur", expect.any(Function));
+  });
+
+  it("routes tray quit through the app quit callback", async () => {
+    const manager = new DesktopManager();
+    const requestQuit = vi.fn(async () => {});
+    manager.setRequestQuitCallback(requestQuit);
+
+    await manager.createTray({
+      icon: "/tmp/appIcon.png",
+      menu: [{ id: "quit", label: "Quit" }],
+    });
+
+    electrobunMock.events.emit("tray-clicked", {
+      data: { action: "quit" },
+    });
+
+    await vi.waitFor(() => expect(requestQuit).toHaveBeenCalledTimes(1));
+    expect(electrobunMock.Utils.quit).not.toHaveBeenCalled();
+  });
+
+  it("awaits tray teardown during dispose", async () => {
+    const manager = new DesktopManager();
+    await manager.createTray({
+      icon: "/tmp/appIcon.png",
+      menu: [{ id: "quit", label: "Quit" }],
+    });
+    const tray = electrobunMock.trayInstances[0];
+
+    await manager.dispose();
+
+    expect(tray.off).toHaveBeenCalledWith("tray-clicked", expect.any(Function));
+    expect(electrobunMock.events.off).toHaveBeenCalledWith(
+      "tray-clicked",
+      expect.any(Function),
+    );
+    expect(tray.remove).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -730,7 +730,11 @@ export class DesktopManager {
       } else if (action === "restart-agent" || action === "tray-restart") {
         triggerAgentRestart();
       } else if (action === "quit") {
-        Utils.quit();
+        void this.quit().catch((err: unknown) => {
+          logger.warn(
+            `[Desktop] Failed to quit from tray menu: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
       } else if (action === "open-settings") {
         this.openSettingsCallback?.();
       }
@@ -2326,7 +2330,7 @@ X-GNOME-Autostart-enabled=true
   /**
    * Clean up all resources.
    */
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this._focusPoller) {
       clearInterval(this._focusPoller);
       this._focusPoller = null;
@@ -2336,8 +2340,8 @@ X-GNOME-Autostart-enabled=true
     this.releaseNotesView?.remove();
     this.releaseNotesView = null;
     this.releaseNotesWindow = null;
-    this.unregisterAllShortcuts();
-    void this.destroyTray();
+    await this.unregisterAllShortcuts();
+    await this.destroyTray();
     this.trayMenuItems.clear();
     this.sendToWebview = null;
   }

--- a/packages/app-core/platforms/electrobun/src/native/index.ts
+++ b/packages/app-core/platforms/electrobun/src/native/index.ts
@@ -18,6 +18,7 @@ import { getSwabbleManager } from "./swabble";
 import { getTalkModeManager } from "./talkmode";
 
 const NATIVE_DISPOSE_TIMEOUT_MS = 10_000;
+let nativeDisposePromise: Promise<void> | null = null;
 
 export function initializeNativeModules(
   mainWindow: BrowserWindow,
@@ -43,6 +44,11 @@ export function initializeNativeModules(
 }
 
 export async function disposeNativeModules(): Promise<void> {
+  nativeDisposePromise ??= disposeNativeModulesOnce();
+  return nativeDisposePromise;
+}
+
+async function disposeNativeModulesOnce(): Promise<void> {
   const managers = [
     ["agent", getAgentManager()],
     ["browser-workspace", getBrowserWorkspaceManager()],

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -165,6 +165,12 @@ const workspacePackageIndex = new Map<string, ResolvedPackage[]>();
 let workspacePackageIndexBuilt = false;
 let activeRuntimeCopyTargetNodeModules: string | null = null;
 
+function resolveBunCommand(): string {
+  return path.basename(process.execPath).startsWith("bun")
+    ? process.execPath
+    : (process.env.BUN ?? "bun");
+}
+
 function isRequiredRuntimeDocDirectory(entryPath: string): boolean {
   const normalizedPath = entryPath.split(path.sep).join("/");
   return (
@@ -2283,6 +2289,69 @@ function getRequiredRuntimeEntryPaths(pkgJsonPath: string): string[] {
   return [...entries].sort();
 }
 
+function workspacePackageNeedsRuntimeBuild(packageJsonPath: string): boolean {
+  for (const entryPath of getRequiredRuntimeEntryPaths(packageJsonPath)) {
+    if (!runtimeManifestEntryExists(path.dirname(packageJsonPath), entryPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function packageHasBuildScript(packageJsonPath: string): boolean {
+  try {
+    const manifest = readJson<{ scripts?: Record<string, unknown> }>(
+      packageJsonPath,
+    );
+    return typeof manifest.scripts?.build === "string";
+  } catch {
+    return false;
+  }
+}
+
+function ensureWorkspaceRuntimeEntriesBuilt(
+  packageNames: Iterable<string>,
+): void {
+  buildWorkspacePackageIndex();
+  const built = new Set<string>();
+
+  for (const packageName of [...new Set(packageNames)].sort()) {
+    if (!isPackageNameCompatibleWithCurrentPlatform(packageName)) continue;
+
+    for (const candidate of workspacePackageIndex.get(packageName) ?? []) {
+      if (built.has(candidate.sourceDir)) continue;
+      if (!isPackageCompatibleWithCurrentPlatform(candidate.packageJsonPath)) {
+        continue;
+      }
+      if (!workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
+        continue;
+      }
+      if (!packageHasBuildScript(candidate.packageJsonPath)) {
+        continue;
+      }
+
+      console.log(
+        `[runtime-copy] building ${packageName} workspace runtime entries`,
+      );
+      try {
+        execFileSync(resolveBunCommand(), ["run", "build"], {
+          cwd: candidate.sourceDir,
+          env: { ...process.env, FORCE_COLOR: "0" },
+          stdio: "inherit",
+        });
+      } catch (error) {
+        if (workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
+          throw error;
+        }
+        console.warn(
+          `[runtime-copy] warning: ${packageName} build exited non-zero after producing required runtime entries; continuing`,
+        );
+      }
+      built.add(candidate.sourceDir);
+    }
+  }
+}
+
 // Post-copy assertion: missingAlwaysBundled catches resolve failures, but
 // can't catch a transitive-walk filter silently skipping a CORE plugin or
 // pruneCopiedPackageDir removing a load-bearing package.json or entrypoint.
@@ -2415,6 +2484,7 @@ function main(): void {
         return shouldBundle;
       }),
     );
+    ensureWorkspaceRuntimeEntriesBuilt([...alwaysBundled, ...discovered]);
     const queue: QueueEntry[] = [...new Set([...alwaysBundled, ...discovered])]
       .sort()
       .map((name) => ({

--- a/packages/app-core/scripts/lib/ios-plist-url-scheme.mjs
+++ b/packages/app-core/scripts/lib/ios-plist-url-scheme.mjs
@@ -1,0 +1,80 @@
+function escapeXmlText(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function insertBeforeRootPlistDictClose(content, insertion) {
+  const rootClose = "\n</dict>\n</plist>";
+  const index = content.lastIndexOf(rootClose);
+  if (index >= 0) {
+    return `${content.slice(0, index)}\n${insertion}${content.slice(index + "\n</dict>".length)}`;
+  }
+  const fallbackIndex = content.lastIndexOf("</dict>");
+  if (fallbackIndex < 0) {
+    throw new Error("Info.plist: could not locate top-level </dict>");
+  }
+  return `${content.slice(0, fallbackIndex)}${insertion}${content.slice(fallbackIndex + "</dict>".length)}`;
+}
+
+function findUrlTypesArrayRange(content) {
+  const keyIndex = content.indexOf("<key>CFBundleURLTypes</key>");
+  if (keyIndex < 0) return null;
+  const openMatch = /<array\b[^>]*>/g;
+  openMatch.lastIndex = keyIndex;
+  const firstOpen = openMatch.exec(content);
+  if (!firstOpen) {
+    throw new Error("Info.plist: CFBundleURLTypes has no array value");
+  }
+
+  const tagRe = /<\/?array\b[^>]*>/g;
+  tagRe.lastIndex = firstOpen.index;
+  let depth = 0;
+  for (let match = tagRe.exec(content); match; match = tagRe.exec(content)) {
+    if (match[0].startsWith("</")) {
+      depth -= 1;
+      if (depth === 0) return { start: firstOpen.index, close: match.index };
+      if (depth < 0) break;
+    } else {
+      depth += 1;
+    }
+  }
+
+  throw new Error("Info.plist: CFBundleURLTypes array is not closed");
+}
+
+export function ensurePlistUrlScheme(content, urlScheme) {
+  const trimmedScheme = String(urlScheme).trim();
+  if (!trimmedScheme) {
+    throw new Error("Cannot patch iOS Info.plist without a URL scheme");
+  }
+
+  const escapedScheme = escapeXmlText(trimmedScheme);
+  const entry = `
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>${escapedScheme}</string>
+			</array>
+		</dict>`;
+  const urlTypesArrayRange = findUrlTypesArrayRange(content);
+  if (urlTypesArrayRange === null) {
+    return insertBeforeRootPlistDictClose(
+      content,
+      `\t<key>CFBundleURLTypes</key>\n\t<array>${entry}\n\t</array>\n</dict>`,
+    );
+  }
+  const urlTypesContent = content.slice(
+    urlTypesArrayRange.start,
+    urlTypesArrayRange.close,
+  );
+  if (urlTypesContent.includes(`<string>${escapedScheme}</string>`)) {
+    return content;
+  }
+  return `${content.slice(0, urlTypesArrayRange.close)}${entry}${content.slice(urlTypesArrayRange.close)}`;
+}

--- a/packages/app-core/scripts/lib/websocket-pending-queue.ts
+++ b/packages/app-core/scripts/lib/websocket-pending-queue.ts
@@ -1,0 +1,92 @@
+export type WebSocketSendData =
+  | string
+  | Buffer
+  | ArrayBuffer
+  | ArrayBufferView
+  | readonly Buffer[];
+
+export type PendingWebSocketMessage<TData extends WebSocketSendData> = {
+  data: TData;
+  isBinary: boolean;
+  byteLength: number;
+};
+
+export type PendingWebSocketQueueState<TData extends WebSocketSendData> = {
+  messages: Array<PendingWebSocketMessage<TData>>;
+  bytes: number;
+};
+
+export type PendingWebSocketQueueLimits = {
+  maxMessages: number;
+  maxMessageBytes: number;
+  maxBytes: number;
+};
+
+export const DEFAULT_PENDING_WEBSOCKET_QUEUE_LIMITS: PendingWebSocketQueueLimits =
+  {
+    maxMessages: 128,
+    maxMessageBytes: 256 * 1024,
+    maxBytes: 1024 * 1024,
+  };
+
+export function websocketSendDataByteLength(data: WebSocketSendData): number {
+  if (typeof data === "string") {
+    return Buffer.byteLength(data);
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data.byteLength;
+  }
+  return data.reduce((total, chunk) => total + chunk.byteLength, 0);
+}
+
+export function createPendingWebSocketQueueState<
+  TData extends WebSocketSendData,
+>(): PendingWebSocketQueueState<TData> {
+  return { messages: [], bytes: 0 };
+}
+
+export function clearPendingWebSocketQueue<TData extends WebSocketSendData>(
+  state: PendingWebSocketQueueState<TData>,
+): void {
+  state.messages.length = 0;
+  state.bytes = 0;
+}
+
+export function drainPendingWebSocketQueue<TData extends WebSocketSendData>(
+  state: PendingWebSocketQueueState<TData>,
+): Array<PendingWebSocketMessage<TData>> {
+  const drained = state.messages.splice(0);
+  state.bytes = 0;
+  return drained;
+}
+
+export function enqueuePendingWebSocketMessage<TData extends WebSocketSendData>(
+  state: PendingWebSocketQueueState<TData>,
+  message: { data: TData; isBinary: boolean },
+  limits: PendingWebSocketQueueLimits = DEFAULT_PENDING_WEBSOCKET_QUEUE_LIMITS,
+): boolean {
+  const byteLength = websocketSendDataByteLength(message.data);
+  if (byteLength > limits.maxMessageBytes || byteLength > limits.maxBytes) {
+    return false;
+  }
+
+  if (
+    state.messages.length >= limits.maxMessages ||
+    state.bytes + byteLength > limits.maxBytes
+  ) {
+    return false;
+  }
+
+  state.messages.push({
+    ...message,
+    byteLength,
+  });
+  state.bytes += byteLength;
+  return true;
+}

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -1,6 +1,14 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { access, cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync, rmSync } from "node:fs";
+import {
+  access,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import {
   createServer,
   type IncomingMessage,
@@ -12,13 +20,22 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { WebSocket, WebSocketServer } from "ws";
 import { buildFirstRunRuntimeConfig } from "../src/first-run/first-run-config.ts";
+import { createLiveRuntimeChildEnv } from "../test/helpers/live-child-env.ts";
 import {
   getFirstRunProviderForLiveProvider,
-  selectLiveProvider,
+  selectLiveProviderAsync,
 } from "../test/helpers/live-provider.ts";
 import { resolveMainAppDir } from "./lib/app-dir.mjs";
 import { shouldForceStubStack } from "./lib/ui-smoke-stub-decision.mjs";
 import { viteRendererBuildNeeded } from "./lib/vite-renderer-dist-stale.mjs";
+import {
+  clearPendingWebSocketQueue,
+  createPendingWebSocketQueueState,
+  DEFAULT_PENDING_WEBSOCKET_QUEUE_LIMITS,
+  drainPendingWebSocketQueue,
+  enqueuePendingWebSocketMessage,
+  type WebSocketSendData,
+} from "./lib/websocket-pending-queue.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
 const APP_DIR = resolveMainAppDir(REPO_ROOT, "app");
@@ -36,12 +53,55 @@ const UI_SMOKE_STUB_SCRIPT = path.join(
 const READY_TIMEOUT_MS = 180_000;
 const API_PORT = Number(process.env.ELIZA_UI_SMOKE_API_PORT ?? "31337");
 const UI_PORT = Number(process.env.ELIZA_UI_SMOKE_PORT ?? "2138");
-const LIVE_PROVIDER = selectLiveProvider();
+const UI_SMOKE_RUN_ID = process.env.ELIZA_UI_SMOKE_RUN_ID?.trim() ?? "";
+const LIVE_PROVIDER = await selectLiveProviderAsync();
 // Precedence (force-stub > live opt-in > CI default) lives in one tested helper.
 // The key behavior: ELIZA_UI_SMOKE_LIVE_STACK=1 overrides the CI-based stub force
 // so a genuinely-real lane is possible (GitHub Actions always sets CI=true, which
 // would otherwise re-force the stub even when a provider key was supplied).
 const FORCE_STUB_STACK = shouldForceStubStack(process.env);
+const LIVE_STACK_OPTIONAL_VIEW_PLUGIN_ENTRIES = [
+  "calendar",
+  "inbox",
+  "todos",
+  "wallet-ui",
+] as const;
+const LIVE_STACK_OPTIONAL_VIEW_PLUGIN_PACKAGES: ReadonlyArray<{
+  id: (typeof LIVE_STACK_OPTIONAL_VIEW_PLUGIN_ENTRIES)[number];
+  dir: string;
+  requiredBuildOutputs: readonly string[];
+}> = [
+  {
+    id: "calendar",
+    dir: "plugin-calendar",
+    requiredBuildOutputs: [
+      "dist/index.js",
+      "dist/plugin.js",
+      "dist/views/bundle.js",
+    ],
+  },
+  {
+    id: "inbox",
+    dir: "plugin-inbox",
+    requiredBuildOutputs: [
+      "dist/index.js",
+      "dist/plugin.js",
+      "dist/views/bundle.js",
+    ],
+  },
+  {
+    id: "todos",
+    dir: "plugin-todos",
+    requiredBuildOutputs: ["dist/index.js", "dist/views/bundle.js"],
+  },
+  {
+    id: "wallet-ui",
+    dir: "plugin-wallet-ui",
+    requiredBuildOutputs: ["dist/index.js", "dist/views/bundle.js"],
+  },
+];
+const pendingStateDirs = new Set<string>();
+const ownedStateDirs = new Set<string>();
 
 type StartedStack = {
   apiBase: string;
@@ -50,6 +110,45 @@ type StartedStack = {
   uiBase: string;
   uiServer: Server;
 };
+
+async function createStateDir(prefix: string): Promise<string> {
+  const stateDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  pendingStateDirs.add(stateDir);
+  if (UI_SMOKE_RUN_ID) {
+    await writeFile(
+      path.join(stateDir, ".eliza-ui-smoke-run-id"),
+      `${UI_SMOKE_RUN_ID}\n`,
+      "utf8",
+    );
+  }
+  return stateDir;
+}
+
+function markStateDirOwnedByStack(stateDir: string): void {
+  pendingStateDirs.delete(stateDir);
+  ownedStateDirs.add(stateDir);
+}
+
+async function cleanupPendingStateDirs(): Promise<void> {
+  const stateDirs = Array.from(pendingStateDirs);
+  pendingStateDirs.clear();
+  await Promise.all(
+    stateDirs.map((stateDir) => rm(stateDir, { force: true, recursive: true })),
+  );
+}
+
+function cleanupKnownStateDirsSync(): void {
+  const stateDirs = new Set([...pendingStateDirs, ...ownedStateDirs]);
+  pendingStateDirs.clear();
+  ownedStateDirs.clear();
+  for (const stateDir of stateDirs) {
+    try {
+      rmSync(stateDir, { force: true, recursive: true });
+    } catch {
+      // Best effort during process teardown.
+    }
+  }
+}
 
 function resolveBunCommand(): string {
   const bunFromEnv = process.env.BUN?.trim();
@@ -268,17 +367,15 @@ function relayWebSocket(args: {
         : undefined,
   });
 
-  const pendingClientMessages: Array<{
-    data: Parameters<WebSocket["send"]>[0];
-    isBinary: boolean;
-  }> = [];
+  const pendingClientQueue =
+    createPendingWebSocketQueueState<WebSocketSendData>();
 
-  const closeSocket = (socket: WebSocket) => {
+  const closeSocket = (socket: WebSocket, code?: number, reason?: string) => {
     if (
       socket.readyState === WebSocket.OPEN ||
       socket.readyState === WebSocket.CONNECTING
     ) {
-      socket.close();
+      socket.close(code, reason);
     }
   };
 
@@ -288,12 +385,25 @@ function relayWebSocket(args: {
       return;
     }
     if (upstreamSocket.readyState === WebSocket.CONNECTING) {
-      pendingClientMessages.push({ data, isBinary });
+      const accepted = enqueuePendingWebSocketMessage(
+        pendingClientQueue,
+        { data, isBinary },
+        DEFAULT_PENDING_WEBSOCKET_QUEUE_LIMITS,
+      );
+      if (!accepted) {
+        clearPendingWebSocketQueue(pendingClientQueue);
+        closeSocket(
+          args.clientSocket,
+          1009,
+          "Pending websocket queue overflow",
+        );
+        closeSocket(upstreamSocket);
+      }
     }
   });
 
   upstreamSocket.on("open", () => {
-    for (const message of pendingClientMessages.splice(0)) {
+    for (const message of drainPendingWebSocketQueue(pendingClientQueue)) {
       upstreamSocket.send(message.data, { binary: message.isBinary });
     }
   });
@@ -306,16 +416,20 @@ function relayWebSocket(args: {
   });
 
   args.clientSocket.on("close", () => {
+    clearPendingWebSocketQueue(pendingClientQueue);
     closeSocket(upstreamSocket);
   });
   upstreamSocket.on("close", () => {
+    clearPendingWebSocketQueue(pendingClientQueue);
     closeSocket(args.clientSocket);
   });
 
   args.clientSocket.on("error", () => {
+    clearPendingWebSocketQueue(pendingClientQueue);
     closeSocket(upstreamSocket);
   });
   upstreamSocket.on("error", () => {
+    clearPendingWebSocketQueue(pendingClientQueue);
     closeSocket(args.clientSocket);
   });
 }
@@ -407,6 +521,29 @@ async function waitForChildExit(
   });
 }
 
+async function closeUiServer(uiServer: Server | null): Promise<void> {
+  if (!uiServer) return;
+  try {
+    await new Promise<void>((resolve, reject) =>
+      uiServer.close((error) => (error ? reject(error) : resolve())),
+    );
+  } catch {
+    // Best effort during shutdown.
+  }
+}
+
+async function stopApiChild(
+  apiChild: ChildProcessWithoutNullStreams | null,
+): Promise<void> {
+  if (!apiChild || apiChild.exitCode != null) return;
+  apiChild.kill("SIGTERM");
+  const exitedAfterTerm = await waitForChildExit(apiChild, 5_000);
+  if (!exitedAfterTerm && apiChild.exitCode == null) {
+    apiChild.kill("SIGKILL");
+    await waitForChildExit(apiChild, 5_000);
+  }
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
@@ -463,6 +600,54 @@ async function waitForJsonPredicate<T>(
   throw lastError instanceof Error
     ? lastError
     : new Error(`Timed out waiting for ${url}`);
+}
+
+function createProcessLogSignal(matchText: string): {
+  observe: (chunk: Buffer | string) => void;
+  wait: (timeoutMs: number, label: string) => Promise<void>;
+} {
+  let matched = false;
+  let tail = "";
+  const waiters = new Set<() => void>();
+
+  return {
+    observe(chunk) {
+      if (matched) {
+        return;
+      }
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      tail = `${tail}${text}`.slice(-Math.max(matchText.length * 2, 4096));
+      if (!tail.includes(matchText)) {
+        return;
+      }
+      matched = true;
+      tail = "";
+      for (const resolve of waiters) {
+        resolve();
+      }
+      waiters.clear();
+    },
+    async wait(timeoutMs, label) {
+      if (matched) {
+        return;
+      }
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Timed out waiting for ${label}`));
+        }, timeoutMs);
+        const finish = () => {
+          cleanup();
+          resolve();
+        };
+        const cleanup = () => {
+          clearTimeout(timeout);
+          waiters.delete(finish);
+        };
+        waiters.add(finish);
+      });
+    },
+  };
 }
 
 async function ensureUiDistReady(): Promise<void> {
@@ -605,56 +790,138 @@ async function submitFirstRun(apiBase: string): Promise<void> {
   );
 }
 
+async function seedLiveStackConfig(stateDir: string): Promise<void> {
+  await mkdir(stateDir, { recursive: true });
+  const configPath = path.join(stateDir, "eliza.json");
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        logging: { level: "error" },
+        plugins: {
+          entries: Object.fromEntries(
+            LIVE_STACK_OPTIONAL_VIEW_PLUGIN_ENTRIES.map((pluginId) => [
+              pluginId,
+              { enabled: true },
+            ]),
+          ),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+async function ensureLiveStackOptionalViewPluginsReady(): Promise<void> {
+  for (const plugin of LIVE_STACK_OPTIONAL_VIEW_PLUGIN_PACKAGES) {
+    const pluginDir = path.join(REPO_ROOT, "plugins", plugin.dir);
+    const outputPaths = plugin.requiredBuildOutputs.map((output) =>
+      path.join(pluginDir, output),
+    );
+    const missingOutputPaths: string[] = [];
+    for (const outputPath of outputPaths) {
+      try {
+        await access(outputPath);
+      } catch {
+        missingOutputPaths.push(outputPath);
+      }
+    }
+    if (missingOutputPaths.length === 0) continue;
+
+    const logs: string[] = [];
+    const child = spawn(resolveBunCommand(), ["run", "build"], {
+      cwd: pluginDir,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.on("data", (chunk) => logs.push(String(chunk)));
+    child.stderr.on("data", (chunk) => logs.push(String(chunk)));
+
+    const BUILD_TIMEOUT_MS = 300_000;
+    const exited = await waitForChildExit(child, BUILD_TIMEOUT_MS);
+    if (!exited) {
+      child.kill("SIGKILL");
+      throw new Error(
+        `Timed out building optional live-stack plugin ${plugin.id} after ${BUILD_TIMEOUT_MS}ms.\n${logs.join("").slice(-8_000)}`,
+      );
+    }
+    if (child.exitCode !== 0) {
+      throw new Error(
+        `Failed to build optional live-stack plugin ${plugin.id}.\n${logs.join("").slice(-8_000)}`,
+      );
+    }
+    for (const outputPath of outputPaths) {
+      await access(outputPath);
+    }
+  }
+}
+
 async function startStubStack(): Promise<StartedStack> {
-  const stateDir = await mkdtemp(
-    path.join(os.tmpdir(), "eliza-ui-smoke-stub-"),
-  );
-  const uiDistDir = await snapshotUiDist(stateDir);
-  const apiBase = `http://127.0.0.1:${API_PORT}`;
-  const apiChild = spawn("node", [UI_SMOKE_STUB_SCRIPT], {
-    cwd: REPO_ROOT,
-    env: {
-      ...process.env,
-      FORCE_COLOR: "0",
-      ELIZA_UI_SMOKE_API_PORT: String(API_PORT),
-      ELIZA_UI_SMOKE_STUB_IGNORE_SIGTERM: "1",
-    },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const stateDir = await createStateDir("eliza-ui-smoke-stub-");
+  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let uiServer: Server | null = null;
+  try {
+    const uiDistDir = await snapshotUiDist(stateDir);
+    const apiBase = `http://127.0.0.1:${API_PORT}`;
+    apiChild = spawn("node", [UI_SMOKE_STUB_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        ELIZA_UI_SMOKE_API_PORT: String(API_PORT),
+        ELIZA_UI_SMOKE_STUB_IGNORE_SIGTERM: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
 
-  apiChild.stdout.on("data", (chunk) => {
-    process.stdout.write(`[ui-smoke][stub] ${chunk}`);
-  });
-  apiChild.stderr.on("data", (chunk) => {
-    process.stdout.write(`[ui-smoke][stub-err] ${chunk}`);
-  });
+    apiChild.stdout.on("data", (chunk) => {
+      process.stdout.write(`[ui-smoke][stub] ${chunk}`);
+    });
+    apiChild.stderr.on("data", (chunk) => {
+      process.stdout.write(`[ui-smoke][stub-err] ${chunk}`);
+    });
 
-  await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
-  await waitForJsonPredicate<{ state?: string }>(
-    `${apiBase}/api/status`,
-    (status) => status.state === "running",
-    READY_TIMEOUT_MS,
-  );
-  await waitForJsonPredicate<{ session?: { kind?: string } }>(
-    `${apiBase}/api/auth/me`,
-    (me) => me.session?.kind === "local",
-    READY_TIMEOUT_MS,
-  );
+    await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
+    await waitForJsonPredicate<{ state?: string }>(
+      `${apiBase}/api/status`,
+      (status) => status.state === "running",
+      READY_TIMEOUT_MS,
+    );
+    await waitForJsonPredicate<{ session?: { kind?: string } }>(
+      `${apiBase}/api/auth/me`,
+      (me) => me.session?.kind === "local",
+      READY_TIMEOUT_MS,
+    );
 
-  const uiServer = await startUiProxyServer({
-    apiBase,
-    port: UI_PORT,
-    uiDistDir,
-  });
-  process.env.ELIZA_API_PORT = String(API_PORT);
+    uiServer = await startUiProxyServer({
+      apiBase,
+      port: UI_PORT,
+      uiDistDir,
+    });
+    process.env.ELIZA_API_PORT = String(API_PORT);
+    markStateDirOwnedByStack(stateDir);
+    const startedApiChild = apiChild;
+    const startedUiServer = uiServer;
 
-  return {
-    apiBase,
-    apiChild,
-    stateDir,
-    uiBase: `http://127.0.0.1:${UI_PORT}`,
-    uiServer,
-  };
+    return {
+      apiBase,
+      apiChild: startedApiChild,
+      stateDir,
+      uiBase: `http://127.0.0.1:${UI_PORT}`,
+      uiServer: startedUiServer,
+    };
+  } catch (error) {
+    await closeUiServer(uiServer);
+    await stopApiChild(apiChild);
+    await rm(stateDir, { force: true, recursive: true });
+    pendingStateDirs.delete(stateDir);
+    throw error;
+  }
 }
 
 async function startRealStack(): Promise<StartedStack> {
@@ -664,84 +931,112 @@ async function startRealStack(): Promise<StartedStack> {
     return startStubStack();
   }
 
-  const stateDir = await mkdtemp(
-    path.join(os.tmpdir(), "eliza-ui-smoke-live-"),
-  );
-  const uiDistDir = await snapshotUiDist(stateDir);
-  const apiBase = `http://127.0.0.1:${API_PORT}`;
-  const apiChild = spawn(
-    "node",
-    [
-      path.join(REPO_ROOT, "packages/app-core/scripts/run-node-tsx.mjs"),
-      path.join(REPO_ROOT, "packages/app-core/src/runtime/eliza.ts"),
-    ],
-    {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        ALLOW_NO_DATABASE: "",
-        FORCE_COLOR: "0",
-        ELIZA_API_PORT: String(API_PORT),
-        ELIZA_HOME_PORT: String(UI_PORT),
-        ELIZA_PORT: String(API_PORT),
-        ELIZA_STATE_DIR: stateDir,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
+  await ensureLiveStackOptionalViewPluginsReady();
 
-  apiChild.stdout.on("data", (chunk) => {
-    process.stdout.write(`[ui-smoke][api] ${chunk}`);
-  });
-  apiChild.stderr.on("data", (chunk) => {
-    process.stdout.write(`[ui-smoke][api-err] ${chunk}`);
-  });
-
-  await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
-  // Cloud-live mode (ELIZA_UI_SMOKE_CLOUD_LIVE=1) leaves first-run UNcompleted so
-  // the spec can drive the real cloud onboarding (login -> provision) through the
-  // UI against real Eliza Cloud. The default lane auto-completes a local first-run
-  // so chat/view specs land on a ready agent.
-  const skipAutoFirstRun = process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1";
-  if (!skipAutoFirstRun) {
-    const onboardingStatus = await fetchJson<{ complete: boolean }>(
-      `${apiBase}/api/first-run/status`,
+  const stateDir = await createStateDir("eliza-ui-smoke-live-");
+  let apiChild: ChildProcessWithoutNullStreams | null = null;
+  let uiServer: Server | null = null;
+  try {
+    await seedLiveStackConfig(stateDir);
+    const uiDistDir = await snapshotUiDist(stateDir);
+    const apiBase = `http://127.0.0.1:${API_PORT}`;
+    const deferredBootComplete = createProcessLogSignal(
+      "[eliza-boot] deferred:complete",
     );
-    if (!onboardingStatus.complete) {
-      await submitFirstRun(apiBase);
-    }
+    apiChild = spawn(
+      "node",
+      [
+        path.join(REPO_ROOT, "packages/app-core/scripts/run-node-tsx.mjs"),
+        path.join(REPO_ROOT, "packages/app-core/src/runtime/eliza.ts"),
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: createLiveRuntimeChildEnv({
+          ...(LIVE_PROVIDER?.env ?? {}),
+          ALLOW_NO_DATABASE: "",
+          FORCE_COLOR: "0",
+          ELIZA_API_PORT: String(API_PORT),
+          ELIZA_HOME_PORT: String(UI_PORT),
+          ELIZA_PORT: String(API_PORT),
+          ELIZA_STATE_DIR: stateDir,
+        }),
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
 
-    await waitForJsonPredicate<{ complete: boolean }>(
-      `${apiBase}/api/first-run/status`,
-      (status) => status.complete === true,
+    apiChild.stdout.on("data", (chunk) => {
+      deferredBootComplete.observe(chunk);
+      process.stdout.write(`[ui-smoke][api] ${chunk}`);
+    });
+    apiChild.stderr.on("data", (chunk) => {
+      deferredBootComplete.observe(chunk);
+      process.stdout.write(`[ui-smoke][api-err] ${chunk}`);
+    });
+
+    await waitForJson<{ complete: boolean }>(`${apiBase}/api/first-run/status`);
+    // Cloud-live mode (ELIZA_UI_SMOKE_CLOUD_LIVE=1) leaves first-run UNcompleted so
+    // the spec can drive the real cloud onboarding (login -> provision) through the
+    // UI against real Eliza Cloud. The default lane auto-completes a local first-run
+    // so chat/view specs land on a ready agent.
+    const skipAutoFirstRun = process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1";
+    if (!skipAutoFirstRun) {
+      const onboardingStatus = await fetchJson<{ complete: boolean }>(
+        `${apiBase}/api/first-run/status`,
+      );
+      if (!onboardingStatus.complete) {
+        await submitFirstRun(apiBase);
+      }
+
+      await waitForJsonPredicate<{ complete: boolean }>(
+        `${apiBase}/api/first-run/status`,
+        (status) => status.complete === true,
+        READY_TIMEOUT_MS,
+      );
+    }
+    await waitForJsonPredicate<{ state?: string }>(
+      `${apiBase}/api/status`,
+      (status) => status.state === "running",
       READY_TIMEOUT_MS,
     );
+    await waitForJsonPredicate<{ session?: { kind?: string } }>(
+      `${apiBase}/api/auth/me`,
+      (me) => me.session?.kind === "local",
+      READY_TIMEOUT_MS,
+    );
+    if (!skipAutoFirstRun) {
+      // App-control and plugin views are deferred capabilities. Treat the live
+      // harness as ready only after those runtime plugins have had a chance to
+      // register; otherwise chat-driven view switching can race boot.
+      await deferredBootComplete.wait(
+        READY_TIMEOUT_MS,
+        "deferred runtime plugin registration",
+      );
+    }
+
+    uiServer = await startUiProxyServer({
+      apiBase,
+      port: UI_PORT,
+      uiDistDir,
+    });
+    process.env.ELIZA_API_PORT = String(API_PORT);
+    markStateDirOwnedByStack(stateDir);
+    const startedApiChild = apiChild;
+    const startedUiServer = uiServer;
+
+    return {
+      apiBase,
+      apiChild: startedApiChild,
+      stateDir,
+      uiBase: `http://127.0.0.1:${UI_PORT}`,
+      uiServer: startedUiServer,
+    };
+  } catch (error) {
+    await closeUiServer(uiServer);
+    await stopApiChild(apiChild);
+    await rm(stateDir, { force: true, recursive: true });
+    pendingStateDirs.delete(stateDir);
+    throw error;
   }
-  await waitForJsonPredicate<{ state?: string }>(
-    `${apiBase}/api/status`,
-    (status) => status.state === "running",
-    READY_TIMEOUT_MS,
-  );
-  await waitForJsonPredicate<{ session?: { kind?: string } }>(
-    `${apiBase}/api/auth/me`,
-    (me) => me.session?.kind === "local",
-    READY_TIMEOUT_MS,
-  );
-
-  const uiServer = await startUiProxyServer({
-    apiBase,
-    port: UI_PORT,
-    uiDistDir,
-  });
-  process.env.ELIZA_API_PORT = String(API_PORT);
-
-  return {
-    apiBase,
-    apiChild,
-    stateDir,
-    uiBase: `http://127.0.0.1:${UI_PORT}`,
-    uiServer,
-  };
 }
 
 async function stopRealStack(stack: StartedStack | null): Promise<void> {
@@ -749,28 +1044,17 @@ async function stopRealStack(stack: StartedStack | null): Promise<void> {
     return;
   }
 
-  try {
-    await new Promise<void>((resolve, reject) =>
-      stack.uiServer.close((error) => (error ? reject(error) : resolve())),
-    );
-  } catch {
-    // Best effort during shutdown.
-  }
-
-  if (stack.apiChild.exitCode == null) {
-    stack.apiChild.kill("SIGTERM");
-    const exitedAfterTerm = await waitForChildExit(stack.apiChild, 5_000);
-    if (!exitedAfterTerm && stack.apiChild.exitCode == null) {
-      stack.apiChild.kill("SIGKILL");
-      await waitForChildExit(stack.apiChild, 5_000);
-    }
-  }
+  await closeUiServer(stack.uiServer);
+  await stopApiChild(stack.apiChild);
 
   await rm(stack.stateDir, { force: true, recursive: true });
+  ownedStateDirs.delete(stack.stateDir);
 }
 
 let stack: StartedStack | null = null;
 let shuttingDown = false;
+
+process.once("exit", cleanupKnownStateDirsSync);
 
 async function shutdown(exitCode: number): Promise<void> {
   if (shuttingDown) {
@@ -778,6 +1062,7 @@ async function shutdown(exitCode: number): Promise<void> {
   }
   shuttingDown = true;
   await stopRealStack(stack);
+  await cleanupPendingStateDirs();
   process.exit(exitCode);
 }
 
@@ -808,5 +1093,6 @@ try {
     }`,
   );
   await stopRealStack(stack);
+  await cleanupPendingStateDirs();
   process.exit(1);
 }

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -2099,6 +2099,15 @@ function writeSseEvent(res, payload) {
   res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
+function sendReadySseStream(req, res) {
+  sendSseHeaders(req, res);
+  writeSseEvent(res, { type: "ready" });
+  const interval = setInterval(() => {
+    res.write(": heartbeat\n\n");
+  }, 15_000);
+  req.on("close", () => clearInterval(interval));
+}
+
 async function readJsonBody(req) {
   const chunks = [];
   for await (const chunk of req) {
@@ -2743,12 +2752,7 @@ async function handleDemoOrchestratorRoute(req, res, url) {
   const task = demoOrchestratorState.tasks.find((item) => item.id === taskId);
 
   if (action === "stream" && req.method === "GET") {
-    sendSseHeaders(req, res);
-    writeSseEvent(res, { type: "ready" });
-    const interval = setInterval(() => {
-      res.write(": heartbeat\n\n");
-    }, 15_000);
-    req.on("close", () => clearInterval(interval));
+    sendReadySseStream(req, res);
     return true;
   }
 
@@ -3190,6 +3194,26 @@ const server = http.createServer(async (req, res) => {
     url.pathname.startsWith("/api/apps/hero/")
   ) {
     sendBinary(req, res, 200, "image/png", ONE_PIXEL_PNG);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/commands") {
+    sendJson(req, res, 200, {
+      commands: [],
+      surface: url.searchParams.get("surface"),
+      agentId: null,
+      generatedAt: SMOKE_GENERATED_AT,
+    });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/custom-actions") {
+    sendJson(req, res, 200, { actions: [] });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/notifications") {
+    sendJson(req, res, 200, { notifications: [], unreadCount: 0 });
     return;
   }
 
@@ -4526,6 +4550,10 @@ const server = http.createServer(async (req, res) => {
     /^\/api\/orchestrator\/tasks\/([^/]+)(?:\/([^/]+))?$/.exec(url.pathname);
   if (orchestratorTaskMatch) {
     const [, taskId, action] = orchestratorTaskMatch;
+    if (req.method === "GET" && action === "stream") {
+      sendReadySseStream(req, res);
+      return;
+    }
     if (req.method === "GET" && action === "messages") {
       sendJson(req, res, 200, { items: [], nextCursor: null });
       return;

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -69,6 +69,7 @@ import {
   resolvePlatformTemplateRoot as resolvePlatformTemplateRootImpl,
   syncPlatformTemplateFiles as syncPlatformTemplateFilesImpl,
 } from "./lib/capacitor-platform-templates.mjs";
+import { ensurePlistUrlScheme } from "./lib/ios-plist-url-scheme.mjs";
 import { resolveRepoRootFromImportMeta } from "./lib/repo-root.mjs";
 import {
   RUNTIME_PROVENANCE_FILENAME,
@@ -528,32 +529,6 @@ function insertBeforeRootPlistDictClose(content, insertion) {
   const fallbackIndex = content.lastIndexOf("</dict>");
   if (fallbackIndex < 0) return content;
   return `${content.slice(0, fallbackIndex)}${insertion}${content.slice(fallbackIndex + "</dict>".length)}`;
-}
-
-function ensurePlistUrlScheme(content, urlScheme) {
-  const escapedScheme = escapeXmlText(urlScheme);
-  const urlTypesRe =
-    /(<key>CFBundleURLTypes<\/key>\s*<array>)([\s\S]*?)(\s*<\/array>)/;
-  const entry = `
-		<dict>
-			<key>CFBundleURLName</key>
-			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>${escapedScheme}</string>
-			</array>
-		</dict>`;
-  const match = content.match(urlTypesRe);
-  if (!match) {
-    return insertBeforeRootPlistDictClose(
-      content,
-      `\t<key>CFBundleURLTypes</key>\n\t<array>${entry}\n\t</array>\n</dict>`,
-    );
-  }
-  if (match[2].includes(`<string>${escapedScheme}</string>`)) {
-    return content;
-  }
-  return content.replace(urlTypesRe, `$1${match[2]}${entry}$3`);
 }
 
 /**

--- a/packages/app-core/src/first-run/first-run-config.test.ts
+++ b/packages/app-core/src/first-run/first-run-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildFirstRunRuntimeConfig } from "./first-run-config";
+
+function baseArgs(
+  overrides: Partial<Parameters<typeof buildFirstRunRuntimeConfig>[0]> = {},
+): Parameters<typeof buildFirstRunRuntimeConfig>[0] {
+  return {
+    firstRunRuntimeTarget: "local",
+    firstRunCloudApiKey: "",
+    firstRunProvider: "openai",
+    firstRunApiKey: "provider-key",
+    firstRunVoiceProvider: "",
+    firstRunVoiceApiKey: "",
+    firstRunPrimaryModel: "primary-model",
+    firstRunOpenRouterModel: "",
+    firstRunRemoteConnected: false,
+    firstRunRemoteApiBase: "",
+    firstRunRemoteToken: "",
+    ...overrides,
+  };
+}
+
+describe("buildFirstRunRuntimeConfig", () => {
+  it("routes Cerebras first-run setup to direct Cerebras API inference", () => {
+    const result = buildFirstRunRuntimeConfig(
+      baseArgs({
+        firstRunProvider: "cerebras",
+        firstRunApiKey: "test-cerebras-api-key",
+        firstRunPrimaryModel: "gpt-oss-120b",
+      }),
+    );
+
+    expect(result.deploymentTarget).toEqual({ runtime: "local" });
+    expect(result.linkedAccounts).toBeUndefined();
+    expect(result.serviceRouting?.llmText).toEqual({
+      backend: "cerebras",
+      transport: "direct",
+      primaryModel: "gpt-oss-120b",
+    });
+    expect(result.credentialInputs).toEqual({
+      llmApiKey: "test-cerebras-api-key",
+    });
+    expect(result.needsProviderSetup).toBe(false);
+  });
+});

--- a/packages/app-core/test/helpers/live-provider.test.ts
+++ b/packages/app-core/test/helpers/live-provider.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("selectLiveProvider", () => {
@@ -18,6 +21,11 @@ describe("selectLiveProvider", () => {
       "OPENROUTER_API_KEY",
       "ELIZA_E2E_OPENROUTER_API_KEY",
       "ELIZA_PROVIDER",
+      "ELIZA_LIVE_PROVIDER_CONFIG_PATH",
+      "ELIZA_LIVE_PROVIDER_STATE_DIR",
+      "ELIZA_STATE_DIR",
+      "ELIZA_NAMESPACE",
+      "XDG_STATE_HOME",
     ]) {
       vi.stubEnv(key, "");
     }
@@ -25,6 +33,7 @@ describe("selectLiveProvider", () => {
 
   afterEach(() => {
     vi.resetModules();
+    vi.doUnmock("@elizaos/vault");
     vi.unstubAllEnvs();
   });
 
@@ -98,9 +107,90 @@ describe("selectLiveProvider", () => {
     const provider = selectLiveProvider();
     expect(provider?.name).toBe("cerebras");
     expect(provider?.baseUrl).toBe("https://api.cerebras.ai/v1");
-    expect(provider?.largeModel).toBe("gpt-oss-120b");
+    expect(provider?.largeModel).toBe("zai-glm-4.7");
     expect(provider?.smallModel).toBe("gpt-oss-120b");
     expect(provider?.env.ELIZA_PROVIDER).toBe("cerebras");
+    expect(provider?.env.CEREBRAS_MODEL).toBe("zai-glm-4.7");
+    expect(provider?.env.OPENAI_SMALL_MODEL).toBe("gpt-oss-120b");
+    expect(provider?.env.OPENAI_LARGE_MODEL).toBe("zai-glm-4.7");
+  });
+
+  it("resolves Cerebras vault references in the async selector", async () => {
+    vi.stubEnv("CEREBRAS_API_KEY", "vault://providers.cerebras.api-key");
+    vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("ELIZA_PROVIDER", "cerebras");
+
+    const get = vi.fn(async (key: string) => {
+      expect(key).toBe("providers.cerebras.api-key");
+      return "csk_resolved_cerebras_key";
+    });
+    const close = vi.fn(async () => {});
+    vi.doMock("@elizaos/vault", () => ({
+      createVault: vi.fn(() => ({ get, close })),
+    }));
+
+    const { selectLiveProviderAsync } = await import("./live-provider.ts");
+
+    const provider = await selectLiveProviderAsync();
+    expect(provider?.name).toBe("cerebras");
+    expect(provider?.apiKey).toBe("csk_resolved_cerebras_key");
+    expect(provider?.env.CEREBRAS_API_KEY).toBe("csk_resolved_cerebras_key");
+    expect(provider?.env.OPENAI_API_KEY).toBe("csk_resolved_cerebras_key");
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads a vault-referenced Cerebras key from local eliza.json in the async selector", async () => {
+    const stateDir = await mkdtemp(path.join(tmpdir(), "eliza-live-provider-"));
+    await writeFile(
+      path.join(stateDir, "eliza.json"),
+      JSON.stringify({
+        env: {
+          vars: {
+            CEREBRAS_API_KEY: "vault://CEREBRAS_API_KEY",
+          },
+        },
+      }),
+      "utf8",
+    );
+    vi.stubEnv("ELIZA_LIVE_PROVIDER_STATE_DIR", stateDir);
+    vi.stubEnv("ELIZA_PROVIDER", "cerebras");
+    vi.stubEnv("CEREBRAS_API_KEY", "");
+    vi.stubEnv("GROQ_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    const createVault = vi.fn(() => ({
+      get: vi.fn(async (key: string) => {
+        expect(key).toBe("CEREBRAS_API_KEY");
+        return "csk_local_config_cerebras_key";
+      }),
+      close: vi.fn(async () => {}),
+    }));
+    vi.doMock("@elizaos/vault", () => ({ createVault }));
+
+    try {
+      const { selectLiveProviderAsync } = await import("./live-provider.ts");
+
+      const provider = await selectLiveProviderAsync();
+      expect(provider?.name).toBe("cerebras");
+      expect(provider?.apiKey).toBe("csk_local_config_cerebras_key");
+      expect(createVault).toHaveBeenCalledWith({ workDir: stateDir });
+    } finally {
+      await rm(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the first-class Cerebras first-run provider id", async () => {
+    const { getFirstRunProviderForLiveProvider } = await import(
+      "./live-provider.ts"
+    );
+
+    expect(getFirstRunProviderForLiveProvider({ name: "cerebras" })).toBe(
+      "cerebras",
+    );
+    expect(
+      getFirstRunProviderForLiveProvider({ name: "local-llama-cpp" }),
+    ).toBe("openai");
   });
 
   it("prefers groq over a bare cerebras eval key unless cerebras is explicitly selected", async () => {

--- a/packages/app-core/test/helpers/live-provider.ts
+++ b/packages/app-core/test/helpers/live-provider.ts
@@ -1,5 +1,7 @@
 /** Selects a live LLM provider for integration tests from env and local config. */
 
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { test } from "vitest";
 
@@ -24,6 +26,87 @@ function getTrimmedEnv(name: string): string | null {
   return value ? value : null;
 }
 
+const VAULT_REF_PREFIX = "vault://";
+
+function isVaultRef(value: string): boolean {
+  return (
+    value.startsWith(VAULT_REF_PREFIX) && value.length > VAULT_REF_PREFIX.length
+  );
+}
+
+function resolveLiveProviderStateDir(): string {
+  const explicit = process.env.ELIZA_LIVE_PROVIDER_STATE_DIR?.trim();
+  if (explicit) return path.resolve(explicit);
+
+  const stateDir = process.env.ELIZA_STATE_DIR?.trim();
+  if (stateDir) return path.resolve(stateDir);
+
+  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdgState = process.env.XDG_STATE_HOME?.trim();
+  return xdgState
+    ? path.join(xdgState, namespace)
+    : path.join(homedir(), ".local", "state", namespace);
+}
+
+function resolveLiveProviderConfigPath(): string {
+  const explicit = process.env.ELIZA_LIVE_PROVIDER_CONFIG_PATH?.trim();
+  return explicit
+    ? path.resolve(explicit)
+    : path.join(resolveLiveProviderStateDir(), "eliza.json");
+}
+
+function readLocalConfigEnvValue(envVar: string): {
+  value: string;
+  stateDir: string;
+} | null {
+  const configPath = resolveLiveProviderConfigPath();
+  if (!existsSync(configPath)) return null;
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+      env?: Record<string, unknown> & {
+        vars?: Record<string, unknown>;
+      };
+    };
+    const value = config.env?.vars?.[envVar] ?? config.env?.[envVar];
+    if (typeof value !== "string" || !value.trim()) return null;
+    return {
+      value: value.trim(),
+      stateDir: path.dirname(configPath),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveMaybeVaultRef(
+  value: string,
+  opts: { stateDir?: string } = {},
+): Promise<string | null> {
+  if (!isVaultRef(value)) return value.trim() || null;
+
+  const vaultKey = value.slice(VAULT_REF_PREFIX.length);
+
+  let vault: {
+    get(key: string): Promise<string>;
+    close?: () => Promise<void>;
+  } | null = null;
+  try {
+    const { createVault } = await import("@elizaos/vault");
+    vault = createVault(opts.stateDir ? { workDir: opts.stateDir } : {}) as {
+      get(key: string): Promise<string>;
+      close?: () => Promise<void>;
+    };
+    const resolved = await vault.get(vaultKey);
+    return resolved.trim() || null;
+  } catch {
+    return null;
+  } finally {
+    if (vault?.close) {
+      await vault.close().catch(() => {});
+    }
+  }
+}
+
 function providerKeyMatchesSelection(
   providerName: LiveProviderName,
   apiKey: string,
@@ -45,19 +128,11 @@ function providerKeyMatchesSelection(
 }
 
 function getLiveTestModelOverride(kind: "small" | "large"): string | null {
-  const key =
+  return getTrimmedEnv(
     kind === "small"
-      ? ["ELIZA_LIVE_TEST_SMALL_MODEL", "ELIZA_LIVE_TEST_SMALL_MODEL"]
-      : ["ELIZA_LIVE_TEST_LARGE_MODEL", "ELIZA_LIVE_TEST_LARGE_MODEL"];
-
-  for (const name of key) {
-    const value = getTrimmedEnv(name);
-    if (value) {
-      return value;
-    }
-  }
-
-  return null;
+      ? "ELIZA_LIVE_TEST_SMALL_MODEL"
+      : "ELIZA_LIVE_TEST_LARGE_MODEL",
+  );
 }
 
 function getLiveTestBaseUrlOverride(
@@ -98,7 +173,7 @@ export type LiveProviderConfig = {
 export function getFirstRunProviderForLiveProvider(
   provider: Pick<LiveProviderConfig, "name">,
 ): string {
-  if (provider.name === "cerebras" || provider.name === "local-llama-cpp") {
+  if (provider.name === "local-llama-cpp") {
     return "openai";
   }
   if (provider.name === "google") {
@@ -117,6 +192,8 @@ export const LIVE_PROVIDER_ENV_KEYS = new Set<string>([
   "OPENAI_MEDIUM_MODEL",
   "OPENAI_ACTION_PLANNER_MODEL",
   "OPENAI_PLANNER_MODEL",
+  "CEREBRAS_BASE_URL",
+  "CEREBRAS_MODEL",
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZA_CLOUD_API_KEY",
   "ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS",
@@ -149,7 +226,7 @@ const PROVIDERS: Array<{
     smallModelEnvVar: "OPENAI_SMALL_MODEL",
     largeModelEnvVar: "OPENAI_LARGE_MODEL",
     defaultSmallModel: "gpt-oss-120b",
-    defaultLargeModel: "gpt-oss-120b",
+    defaultLargeModel: "zai-glm-4.7",
   },
   {
     name: "groq",
@@ -252,6 +329,81 @@ function providerKeyEnvCandidates(provider: {
   return [...provider.keyEnvVars, ...(provider.keyEnvVarAliases ?? [])];
 }
 
+async function resolveProviderApiKey(def: {
+  name: LiveProviderName;
+  keyEnvVars: string[];
+  keyEnvVarAliases?: string[];
+}): Promise<string> {
+  for (const envVar of providerKeyEnvCandidates(def)) {
+    const val = getTrimmedEnv(envVar);
+    if (!val) continue;
+    const resolved = await resolveMaybeVaultRef(val);
+    if (resolved && providerKeyMatchesSelection(def.name, resolved)) {
+      return resolved;
+    }
+  }
+
+  for (const envVar of def.keyEnvVars) {
+    const persisted = readLocalConfigEnvValue(envVar);
+    if (!persisted) continue;
+    const resolved = await resolveMaybeVaultRef(persisted.value, {
+      stateDir: persisted.stateDir,
+    });
+    if (resolved && providerKeyMatchesSelection(def.name, resolved)) {
+      return resolved;
+    }
+  }
+
+  return "";
+}
+
+function buildLiveProviderConfig(
+  def: (typeof PROVIDERS)[number],
+  apiKey: string,
+): LiveProviderConfig {
+  const baseUrl = getLiveTestBaseUrlOverride(def.name) ?? def.defaultBaseUrl;
+
+  const smallModel = getLiveTestModelOverride("small") ?? def.defaultSmallModel;
+  const largeModel = getLiveTestModelOverride("large") ?? def.defaultLargeModel;
+
+  const env: Record<string, string> = {};
+  // Propagate the discovered key under every canonical name so plugin code
+  // reading e.g. `GROQ_API_KEY` finds it even when the source env only had
+  // the scoped alias `ELIZA_E2E_GROQ_API_KEY`.
+  for (const envVar of def.keyEnvVars) {
+    env[envVar] = apiKey;
+  }
+  if (def.baseUrlEnvVar) {
+    env[def.baseUrlEnvVar] = baseUrl;
+  }
+  if (def.name === "cerebras") {
+    env.ELIZA_PROVIDER = "cerebras";
+    env.CEREBRAS_BASE_URL = baseUrl;
+    env.CEREBRAS_MODEL = largeModel;
+    env.OPENAI_API_KEY = apiKey;
+    env.OPENAI_MEDIUM_MODEL = largeModel;
+    env.OPENAI_ACTION_PLANNER_MODEL = largeModel;
+    env.OPENAI_PLANNER_MODEL = largeModel;
+    env.MEDIUM_MODEL = largeModel;
+    env.ACTION_PLANNER_MODEL = largeModel;
+    env.PLANNER_MODEL = largeModel;
+  }
+  env[def.smallModelEnvVar] = smallModel;
+  env[def.largeModelEnvVar] = largeModel;
+  env.SMALL_MODEL = smallModel;
+  env.LARGE_MODEL = largeModel;
+
+  return {
+    name: def.name,
+    apiKey,
+    baseUrl,
+    smallModel,
+    largeModel,
+    pluginPackage: def.plugin,
+    env,
+  };
+}
+
 /**
  * Select the first available LLM provider based on environment variables.
  * Returns null if no provider API keys are found.
@@ -292,47 +444,39 @@ export function selectLiveProvider(
       }
     }
 
-    const baseUrl = getLiveTestBaseUrlOverride(def.name) ?? def.defaultBaseUrl;
+    return buildLiveProviderConfig(def, apiKey);
+  }
 
-    const smallModel =
-      getLiveTestModelOverride("small") ?? def.defaultSmallModel;
-    const largeModel =
-      getLiveTestModelOverride("large") ?? def.defaultLargeModel;
+  return null;
+}
 
-    const env: Record<string, string> = {};
-    // Propagate the discovered key under every canonical name so plugin code
-    // reading e.g. `GROQ_API_KEY` finds it even when the source env only had
-    // the scoped alias `ELIZA_E2E_GROQ_API_KEY`.
-    for (const envVar of def.keyEnvVars) {
-      env[envVar] = apiKey;
-    }
-    if (def.baseUrlEnvVar) {
-      env[def.baseUrlEnvVar] = baseUrl;
-    }
-    if (def.name === "cerebras") {
-      env.ELIZA_PROVIDER = "cerebras";
-      env.OPENAI_API_KEY = apiKey;
-      env.OPENAI_MEDIUM_MODEL = largeModel;
-      env.OPENAI_ACTION_PLANNER_MODEL = largeModel;
-      env.OPENAI_PLANNER_MODEL = largeModel;
-      env.MEDIUM_MODEL = largeModel;
-      env.ACTION_PLANNER_MODEL = largeModel;
-      env.PLANNER_MODEL = largeModel;
-    }
-    env[def.smallModelEnvVar] = smallModel;
-    env[def.largeModelEnvVar] = largeModel;
-    env.SMALL_MODEL = smallModel;
-    env.LARGE_MODEL = largeModel;
+/**
+ * Async selector for live harnesses that should also accept `vault://KEY`
+ * sentinels and keys persisted in the local Eliza config. The synchronous
+ * `selectLiveProvider()` intentionally remains env-only for older test code.
+ */
+export async function selectLiveProviderAsync(
+  preferredProvider?: LiveProviderName,
+): Promise<LiveProviderConfig | null> {
+  const candidates = preferredProvider
+    ? PROVIDERS.filter((p) => p.name === preferredProvider)
+    : PROVIDERS;
 
-    return {
-      name: def.name,
-      apiKey,
-      baseUrl,
-      smallModel,
-      largeModel,
-      pluginPackage: def.plugin,
-      env,
-    };
+  for (const def of candidates) {
+    const apiKey = await resolveProviderApiKey(def);
+    if (!apiKey) continue;
+
+    if (def.name === "cerebras" && !preferredProvider) {
+      const explicitProvider = process.env.ELIZA_PROVIDER?.trim().toLowerCase();
+      const explicitBaseUrl = process.env.OPENAI_BASE_URL?.trim();
+      const baseUrlIsCerebras =
+        !!explicitBaseUrl && /cerebras\.ai(?:\/|$)/i.test(explicitBaseUrl);
+      if (explicitProvider !== "cerebras" && !baseUrlIsCerebras) {
+        continue;
+      }
+    }
+
+    return buildLiveProviderConfig(def, apiKey);
   }
 
   return null;

--- a/packages/app-core/test/scripts/websocket-pending-queue.test.ts
+++ b/packages/app-core/test/scripts/websocket-pending-queue.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearPendingWebSocketQueue,
+  createPendingWebSocketQueueState,
+  drainPendingWebSocketQueue,
+  enqueuePendingWebSocketMessage,
+  websocketSendDataByteLength,
+} from "../../scripts/lib/websocket-pending-queue.ts";
+
+describe("websocket pending queue", () => {
+  it("measures websocket send payload sizes", () => {
+    expect(websocketSendDataByteLength("hello")).toBe(5);
+    expect(websocketSendDataByteLength(Buffer.from("hello"))).toBe(5);
+    expect(websocketSendDataByteLength(new Uint8Array([1, 2, 3]))).toBe(3);
+    expect(
+      websocketSendDataByteLength([Buffer.from("hello"), Buffer.from("world")]),
+    ).toBe(10);
+  });
+
+  it("rejects count overflow without changing the queue", () => {
+    const queue = createPendingWebSocketQueueState<Buffer>();
+    const limits = { maxMessages: 2, maxMessageBytes: 100, maxBytes: 100 };
+
+    enqueuePendingWebSocketMessage(
+      queue,
+      { data: Buffer.from("one"), isBinary: true },
+      limits,
+    );
+    enqueuePendingWebSocketMessage(
+      queue,
+      { data: Buffer.from("two"), isBinary: true },
+      limits,
+    );
+    expect(
+      enqueuePendingWebSocketMessage(
+        queue,
+        { data: Buffer.from("three"), isBinary: true },
+        limits,
+      ),
+    ).toBe(false);
+
+    expect(queue.messages.map((message) => message.data.toString())).toEqual([
+      "one",
+      "two",
+    ]);
+  });
+
+  it("rejects byte-budget overflow without changing the queue", () => {
+    const queue = createPendingWebSocketQueueState<Buffer>();
+    const limits = { maxMessages: 10, maxMessageBytes: 10, maxBytes: 8 };
+
+    enqueuePendingWebSocketMessage(
+      queue,
+      { data: Buffer.from("aaaa"), isBinary: true },
+      limits,
+    );
+    enqueuePendingWebSocketMessage(
+      queue,
+      { data: Buffer.from("bbbb"), isBinary: true },
+      limits,
+    );
+    expect(
+      enqueuePendingWebSocketMessage(
+        queue,
+        { data: Buffer.from("cccc"), isBinary: true },
+        limits,
+      ),
+    ).toBe(false);
+
+    expect(queue.bytes).toBe(8);
+    expect(queue.messages.map((message) => message.data.toString())).toEqual([
+      "aaaa",
+      "bbbb",
+    ]);
+  });
+
+  it("rejects oversized single messages without changing the queue", () => {
+    const queue = createPendingWebSocketQueueState<Buffer>();
+    const limits = { maxMessages: 10, maxMessageBytes: 4, maxBytes: 20 };
+
+    enqueuePendingWebSocketMessage(
+      queue,
+      { data: Buffer.from("ok"), isBinary: true },
+      limits,
+    );
+    expect(
+      enqueuePendingWebSocketMessage(
+        queue,
+        { data: Buffer.from("too-large"), isBinary: true },
+        limits,
+      ),
+    ).toBe(false);
+
+    expect(queue.bytes).toBe(2);
+    expect(queue.messages.map((message) => message.data.toString())).toEqual([
+      "ok",
+    ]);
+  });
+
+  it("drains and clears byte accounting", () => {
+    const queue = createPendingWebSocketQueueState<Buffer>();
+    enqueuePendingWebSocketMessage(queue, {
+      data: Buffer.from("hello"),
+      isBinary: true,
+    });
+
+    expect(drainPendingWebSocketQueue(queue)).toHaveLength(1);
+    expect(queue.messages).toHaveLength(0);
+    expect(queue.bytes).toBe(0);
+
+    enqueuePendingWebSocketMessage(queue, {
+      data: Buffer.from("hello"),
+      isBinary: true,
+    });
+    clearPendingWebSocketQueue(queue);
+    expect(queue.messages).toHaveLength(0);
+    expect(queue.bytes).toBe(0);
+  });
+});

--- a/packages/app-core/tsconfig.json
+++ b/packages/app-core/tsconfig.json
@@ -65,6 +65,9 @@
       "@elizaos/plugin-coding-tools/*": [
         "../../plugins/plugin-coding-tools/src/*"
       ],
+      "@elizaos/plugin-commands": [
+        "../../plugins/plugin-commands/src/index.ts"
+      ],
       "@elizaos/plugin-mcp": ["../../plugins/plugin-mcp/src/index.ts"],
       "@elizaos/plugin-mcp/*": ["../../plugins/plugin-mcp/src/*"],
       "@elizaos/plugin-discord-local": [

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -87,6 +87,20 @@ function isFlagEnabled(value: string | undefined): boolean {
 const webViewDebuggingEnabled =
   !isIosStoreBuild() && isFlagEnabled(process.env.ELIZA_WEBVIEW_DEBUG);
 
+export function resolveAndroidProjectPath(
+  useAppDir: string | undefined,
+  appId: string,
+): string {
+  return useAppDir === "1" || appId !== "ai.elizaos.app"
+    ? "android"
+    : "../app-core/platforms/android";
+}
+
+const androidProjectPath = resolveAndroidProjectPath(
+  process.env.ELIZA_ANDROID_USE_APP_DIR,
+  appConfig.appId,
+);
+
 const config: CapacitorConfig = {
   appId: appConfig.appId,
   appName: appConfig.appName,
@@ -149,15 +163,10 @@ const config: CapacitorConfig = {
     webContentsDebuggingEnabled: webViewDebuggingEnabled,
   },
   android: {
-    // Point `cap sync` at the SAME android project gradle actually builds
-    // (packages/app-core/platforms/android, resolved relative to this config).
-    // Without this, cap sync writes a full project to packages/app/android while
-    // gradle builds app-core/platforms/android off a STALE committed
-    // capacitor.settings.gradle — so native plugins (@capacitor/browser, haptics,
-    // …) silently never compile and get pruned from the manifest (#8387). With
-    // the path unified, cap sync regenerates the full plugin set in place every
-    // build and nothing drifts.
-    path: "../app-core/platforms/android",
+    // Keep `cap sync` pointed at the same Android tree run-mobile-build will
+    // package. Upstream elizaOS owns the shared app-core tree; white-label or
+    // explicitly isolated builds use the app-local ignored android/ project.
+    path: androidProjectPath,
     backgroundColor: "#FF5800",
     allowMixedContent: false,
     captureInput: true,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,7 @@
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:record": "E2E_RECORD=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "audit:app": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app",
-    "test:desktop:packaged": "bunx playwright test --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",
     "test:e2e:cloud-wallet": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/cloud-wallet-import.spec.ts",
     "test:e2e:android": "node scripts/android-e2e.mjs",

--- a/packages/app/scripts/patch-ios-plist.mjs
+++ b/packages/app/scripts/patch-ios-plist.mjs
@@ -23,8 +23,11 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { ensurePlistUrlScheme } from "../../app-core/scripts/lib/ios-plist-url-scheme.mjs";
+import { readAppIdentity } from "../../app-core/scripts/lib/read-app-identity.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = resolve(__dirname, "..");
 
 const MIC_PURPOSE = "Eliza listens when you talk to your agent.";
 const SPEECH_PURPOSE =
@@ -76,13 +79,18 @@ function escapeXml(value) {
     .replace(/'/g, "&apos;");
 }
 
-function patchPlist(xml) {
+function patchPlist(xml, urlScheme) {
   let changed = false;
   let next = xml;
   for (const entry of KEYS) {
     if (hasKey(next, entry.key)) continue;
     const insertAt = findInsertionPoint(next);
     next = next.slice(0, insertAt) + renderEntry(entry) + next.slice(insertAt);
+    changed = true;
+  }
+  const nextWithScheme = ensurePlistUrlScheme(next, urlScheme);
+  if (nextWithScheme !== next) {
+    next = nextWithScheme;
     changed = true;
   }
   return { next, changed };
@@ -100,14 +108,15 @@ function main() {
     return;
   }
   const original = readFileSync(TARGET_PATH, "utf8");
-  const { next, changed } = patchPlist(original);
+  const { urlScheme } = readAppIdentity(APP_DIR);
+  const { next, changed } = patchPlist(original, urlScheme);
   if (!changed) {
     console.log("[patch-ios-plist] all keys already present — no changes.");
     return;
   }
   writeFileSync(TARGET_PATH, next);
   console.log(
-    "[patch-ios-plist] patched UIBackgroundModes + microphone/speech usage descriptions.",
+    "[patch-ios-plist] patched UIBackgroundModes, microphone/speech usage descriptions, and URL scheme.",
   );
 }
 
@@ -119,13 +128,18 @@ if (checkOnly) {
     process.exit(0);
   }
   const xml = readFileSync(TARGET_PATH, "utf8");
+  const { urlScheme } = readAppIdentity(APP_DIR);
   const missing = KEYS.filter((k) => !hasKey(xml, k.key));
-  if (missing.length === 0) {
+  const missingUrlScheme = ensurePlistUrlScheme(xml, urlScheme) !== xml;
+  if (missing.length === 0 && !missingUrlScheme) {
     console.log("[patch-ios-plist] OK — all required keys present.");
     process.exit(0);
   }
   console.error(
-    `[patch-ios-plist] missing keys: ${missing.map((k) => k.key).join(", ")}`,
+    `[patch-ios-plist] missing keys: ${[
+      ...missing.map((k) => k.key),
+      ...(missingUrlScheme ? [`CFBundleURLTypes:${urlScheme}`] : []),
+    ].join(", ")}`,
   );
   process.exit(1);
 }

--- a/packages/app/scripts/patch-ios-plist.test.mjs
+++ b/packages/app/scripts/patch-ios-plist.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { ensurePlistUrlScheme } from "../../app-core/scripts/lib/ios-plist-url-scheme.mjs";
 import { hasKey, KEYS, patchPlist } from "./patch-ios-plist.mjs";
 
 const MINIMAL_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
@@ -14,31 +15,59 @@ const MINIMAL_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 
 describe("patch-ios-plist", () => {
   it("inserts every required key on the first patch", () => {
-    const { next, changed } = patchPlist(MINIMAL_PLIST);
+    const { next, changed } = patchPlist(MINIMAL_PLIST, "elizaos");
     expect(changed).toBe(true);
     for (const entry of KEYS) {
       expect(hasKey(next, entry.key)).toBe(true);
     }
+    expect(hasKey(next, "CFBundleURLTypes")).toBe(true);
+    expect(next).toContain("<string>elizaos</string>");
     expect(next).toContain("<string>audio</string>");
     expect(next).toContain("NSMicrophoneUsageDescription");
     expect(next).toContain("NSSpeechRecognitionUsageDescription");
   });
 
   it("is idempotent — no changes on the second patch", () => {
-    const first = patchPlist(MINIMAL_PLIST);
-    const second = patchPlist(first.next);
+    const first = patchPlist(MINIMAL_PLIST, "elizaos");
+    const second = patchPlist(first.next, "elizaos");
     expect(second.changed).toBe(false);
     expect(second.next).toBe(first.next);
   });
 
   it("does not modify keys it doesn't own", () => {
-    const { next } = patchPlist(MINIMAL_PLIST);
+    const { next } = patchPlist(MINIMAL_PLIST, "elizaos");
     expect(next).toContain("<key>CFBundleName</key>");
     expect(next).toContain("<string>Eliza</string>");
   });
 
+  it("adds the URL scheme to an existing CFBundleURLTypes array", () => {
+    const plist = patchPlist(MINIMAL_PLIST, "other").next;
+    const { next, changed } = patchPlist(plist, "elizaos");
+    expect(changed).toBe(true);
+    expect(next).toContain("<string>other</string>");
+    expect(next).toContain("<string>elizaos</string>");
+    expect(next).toMatch(
+      /<key>CFBundleURLTypes<\/key>\s*<array>[\s\S]*<dict>[\s\S]*<string>other<\/string>[\s\S]*<\/dict>[\s\S]*<dict>[\s\S]*<string>elizaos<\/string>[\s\S]*<\/dict>[\s\S]*<\/array>/,
+    );
+    const schemeArrays = Array.from(
+      next.matchAll(
+        /<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/g,
+      ),
+    );
+    expect(schemeArrays).toHaveLength(2);
+    for (const [, schemesBody] of schemeArrays) {
+      expect(schemesBody).not.toContain("<dict>");
+    }
+  });
+
   it("throws when the input has no top-level </dict></plist>", () => {
-    expect(() => patchPlist("<plist></plist>")).toThrow(
+    expect(() => patchPlist("<plist></plist>", "elizaos")).toThrow(
+      /could not locate top-level/,
+    );
+  });
+
+  it("throws instead of silently skipping URL scheme insertion on malformed plist XML", () => {
+    expect(() => ensurePlistUrlScheme("<plist></plist>", "elizaos")).toThrow(
       /could not locate top-level/,
     );
   });

--- a/packages/app/src/types/app-plugin-modules.d.ts
+++ b/packages/app/src/types/app-plugin-modules.d.ts
@@ -155,6 +155,11 @@ declare module "@elizaos/plugin-personal-assistant" {
   export const WebsiteBlockerSettingsCard: ComponentType<WebsiteBlockerSettingsCardProps>;
 }
 
+declare module "@elizaos/plugin-blocker" {
+  export function registerNativeWebsiteBlockerBackend(backend: unknown): void;
+  export function registerNativeAppBlockerBackend(backend: unknown): void;
+}
+
 declare module "@elizaos/app-phone" {
   export const PhoneCompanionApp: EmptyComponent;
 }

--- a/packages/app/test/electrobun-packaged/desktop-launch-render.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/desktop-launch-render.e2e.spec.ts
@@ -24,13 +24,93 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { assertScreenshotNotBlank } from "../ui-smoke/helpers/screenshot-quality";
-import { startLiveApiServer, type TestApiServer } from "./live-api";
+import { type MockApiServer, startMockApiServer } from "./mock-api";
 import {
   PackagedDesktopHarness,
   resolvePackagedLauncher,
 } from "./packaged-app-helpers";
 
-test("packaged desktop app launches and renders a non-blank UI headless", async ({}, testInfo) => {
+type EvalOk<T> = T & { ok: true };
+type EvalErr = { ok: false; error: string };
+type EvalResult<T> = EvalOk<T> | EvalErr;
+
+async function waitForRendererShellReady(
+  harness: PackagedDesktopHarness,
+): Promise<void> {
+  let lastResult:
+    | EvalResult<{
+        ready: boolean;
+        rootLength: number;
+        bodySnippet: string;
+        startupPhase: string | null;
+      }>
+    | undefined;
+  let lastError: Error | null = null;
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          try {
+            lastResult = await harness.eval<
+              EvalResult<{
+                ready: boolean;
+                rootLength: number;
+                bodySnippet: string;
+                startupPhase: string | null;
+              }>
+            >(`(() => {
+              try {
+                const rootHtml = document.getElementById("root")?.innerHTML ?? "";
+                const startupShell = document.querySelector('[data-testid="startup-shell-loading"]');
+                const firstRunOverlay = document.querySelector('[data-testid="first-run-shell"]');
+                const startupPhase = startupShell?.getAttribute("data-startup-phase") ?? null;
+                const bodyText = (document.body?.innerText || "").replace(/\\s+/g, " ").trim();
+                return {
+                  ok: true,
+                  ready: rootHtml.length > 200 && !startupShell && !firstRunOverlay,
+                  rootLength: rootHtml.length,
+                  bodySnippet: bodyText.slice(0, 120),
+                  startupPhase,
+                };
+              } catch (e) {
+                return { ok: false, error: e instanceof Error ? e.message : String(e) };
+              }
+            })()`);
+            lastError = null;
+            return lastResult.ok && lastResult.ready;
+          } catch (error) {
+            lastError =
+              error instanceof Error ? error : new Error(String(error));
+            return false;
+          }
+        },
+        {
+          timeout: process.env.CI ? 120_000 : 60_000,
+          message:
+            "Expected packaged desktop renderer to finish startup before screenshot capture.",
+        },
+      )
+      .toBe(true);
+  } catch (error) {
+    const suffix =
+      typeof lastResult === "undefined"
+        ? `No renderer result was captured.${
+            lastError ? ` Last eval error: ${lastError.message}` : ""
+          }`
+        : `Last renderer result: ${JSON.stringify(lastResult)}`;
+    throw new Error(
+      `Expected packaged desktop renderer to finish startup before screenshot capture.\n${suffix}\n${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+test("packaged desktop app launches and renders a non-blank UI headless", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  void _browserName;
   test.setTimeout(600_000);
 
   const tempRoot = await fs.mkdtemp(
@@ -44,10 +124,10 @@ test("packaged desktop app launches and renders a non-blank UI headless", async 
     "Packaged Electrobun launcher is required (run the desktop build first).",
   ).toBeTruthy();
 
-  let api: TestApiServer | null = null;
+  let api: MockApiServer | null = null;
   let harness: PackagedDesktopHarness | null = null;
   try {
-    api = await startLiveApiServer({ firstRunComplete: true, port: 0 });
+    api = await startMockApiServer({ firstRunComplete: true, port: 0 });
     harness = new PackagedDesktopHarness({
       tempRoot,
       launcherPath: launcherPath as string,
@@ -61,15 +141,39 @@ test("packaged desktop app launches and renders a non-blank UI headless", async 
       shellReadyTimeoutMs: process.env.CI ? 120_000 : 90_000,
     });
 
+    const bounds = await harness.setMainWindowBounds({
+      x: 0,
+      y: 0,
+      width: 1240,
+      height: 860,
+    });
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.y).toBeGreaterThanOrEqual(0);
+    expect(bounds.width).toBeGreaterThanOrEqual(1100);
+    expect(bounds.height).toBeGreaterThanOrEqual(760);
+    await harness.showMainWindow();
+    await harness.focusMainWindow();
+    await harness.waitForState(
+      (state) =>
+        (state.mainWindow.bounds?.x ?? -1) >= 0 &&
+        (state.mainWindow.bounds?.y ?? -1) >= 0 &&
+        (state.mainWindow.bounds?.width ?? 0) >= 1100 &&
+        (state.mainWindow.bounds?.height ?? 0) >= 760 &&
+        state.shell.windowVisible,
+      "Expected packaged desktop window to report screenshot-sized visible bounds.",
+      30_000,
+    );
+    await waitForRendererShellReady(harness);
+
     // Real screenshot of the rendered window; assert it painted (not blank).
     const data = await harness.screenshot();
     const base64 = data.replace(/^data:image\/png;base64,/, "");
     const buffer = Buffer.from(base64, "base64");
-    await assertScreenshotNotBlank(buffer, "packaged desktop launch render");
     await fs.writeFile(
       testInfo.outputPath("desktop-launch-render.png"),
       buffer,
     );
+    await assertScreenshotNotBlank(buffer, "packaged desktop launch render");
   } finally {
     await harness?.stop().catch(() => undefined);
     await api?.close().catch(() => undefined);

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, type TestInfo, test } from "@playwright/test";
 import { assertScreenshotNotBlank } from "../ui-smoke/helpers/screenshot-quality";
-import { startLiveApiServer, type TestApiServer } from "./live-api";
+import { type MockApiServer, startMockApiServer } from "./mock-api";
 import {
   PackagedDesktopHarness,
   resolvePackagedLauncher,
@@ -15,8 +15,8 @@ type EvalErr = { ok: false; error: string };
 type EvalResult<T> = EvalOk<T> | EvalErr;
 
 const SETTINGS_SELECTOR = '[data-testid="settings-shell"]';
-const PLUGINS_SELECTOR = '[data-testid="connectors-settings-content"]';
-const FIRST_RUN_SELECTOR = '[data-testid="first-run-shell"]';
+const PLUGINS_SELECTOR = '[data-testid="plugins-shell"]';
+const FIRST_RUN_SELECTOR = '[data-testid="startup-first-run-background"]';
 const SETTINGS_ROUTE = "/settings";
 const SETTINGS_MEDIA_ROUTE = "/settings/voice";
 const PLUGINS_ROUTE = "/apps/plugins";
@@ -86,12 +86,20 @@ async function waitForEval<T>(
   },
 ): Promise<T> {
   let lastResult: T | undefined;
+  let lastError: Error | null = null;
   try {
     await expect
       .poll(
         async () => {
-          lastResult = await harness.eval<T>(script);
-          return predicate(lastResult);
+          try {
+            lastResult = await harness.eval<T>(script);
+            lastError = null;
+            return predicate(lastResult);
+          } catch (error) {
+            lastError =
+              error instanceof Error ? error : new Error(String(error));
+            return false;
+          }
         },
         {
           timeout: options.timeout,
@@ -102,7 +110,9 @@ async function waitForEval<T>(
   } catch (error) {
     const suffix =
       typeof lastResult === "undefined"
-        ? "No renderer result was captured."
+        ? `No renderer result was captured.${
+            lastError ? ` Last eval error: ${lastError.message}` : ""
+          }`
         : `Last renderer result: ${JSON.stringify(lastResult)}`;
     throw new Error(
       `${options.message}\n${suffix}\n${error instanceof Error ? error.message : String(error)}`,
@@ -419,7 +429,7 @@ async function readPersistedSettingsState(
   return result;
 }
 
-async function readVisiblePluginSectionIds(
+async function readVisiblePluginIds(
   harness: PackagedDesktopHarness,
 ): Promise<string[]> {
   const result = await waitForEval<EvalResult<{ ids: string[] }>>(
@@ -429,14 +439,14 @@ async function readVisiblePluginSectionIds(
         ${getRouteNavigationScript(PLUGINS_ROUTE)}
         const shell = document.querySelector(${JSON.stringify(PLUGINS_SELECTOR)});
         const ids = Array.from(
-          document.querySelectorAll('[data-testid^="connector-section-"]'),
+          document.querySelectorAll('[data-plugin-id]'),
         )
-          .map((node) => node.getAttribute("data-testid"))
+          .map((node) => node.getAttribute("data-plugin-id"))
           .filter((value) => typeof value === "string");
         return {
           ok: true,
           shellReady: Boolean(shell),
-          ids: ids.map((value) => value.replace(/^connector-section-/, "")),
+          ids,
         };
       } catch (error) {
         return {
@@ -445,10 +455,13 @@ async function readVisiblePluginSectionIds(
         };
       }
     })()`,
-    (current) => current.ok && current.ids.length >= 2,
+    (current) =>
+      current.ok &&
+      current.ids.includes("openai") &&
+      current.ids.includes("ollama"),
     {
       timeout: 20_000,
-      message: `Timed out waiting for visible plugin sections at ${PLUGINS_ROUTE}.`,
+      message: `Timed out waiting for visible plugin catalog entries at ${PLUGINS_ROUTE}.`,
     },
   );
 
@@ -507,13 +520,34 @@ async function triggerSettingsReset(
     harness,
     `(() => {
       try {
-        ${getRouteNavigationScript(SETTINGS_ROUTE)}
+        const shell = document.querySelector(${JSON.stringify(SETTINGS_SELECTOR)});
+        if (!shell) {
+          ${getRouteNavigationScript(SETTINGS_ROUTE)}
+          return {
+            ok: false,
+            error: "Settings shell was not mounted; navigating to Settings.",
+          };
+        }
+        const resetByAgentId = document.querySelector(
+          '[data-agent-id="advanced-reset-open"]',
+        );
         const buttons = Array.from(
           document.querySelectorAll('[data-testid="settings-shell"] button'),
         );
-        const resetButton = buttons.find((button) =>
-          /reset everything/i.test((button.textContent || "").trim()),
-        );
+        const resetButton =
+          resetByAgentId instanceof HTMLButtonElement
+            ? resetByAgentId
+            : buttons.find((button) =>
+                /reset everything/i.test((button.textContent || "").trim()),
+              );
+        if (!resetButton) {
+          const advancedSection = document.querySelector(
+            '[data-agent-id="section-advanced"]',
+          );
+          if (advancedSection instanceof HTMLButtonElement) {
+            advancedSection.click();
+          }
+        }
         return resetButton
           ? {
               ok: true,
@@ -544,16 +578,21 @@ async function triggerSettingsReset(
   const result = await waitForEval<
     EvalResult<{
       label: string;
-      autoConfirmed: boolean;
-      messageBoxStubCalls: number;
+      confirmClicked: boolean;
+      restartStubCalls: number;
     }>
   >(
     harness,
     `(() => {
       try {
-        ${getRouteNavigationScript(SETTINGS_ROUTE)}
+        const shell = document.querySelector(${JSON.stringify(SETTINGS_SELECTOR)});
+        if (!shell) {
+          return {
+            ok: false,
+            error: "Settings shell disappeared before reset confirmation.",
+          };
+        }
         const rpc = ${getDesktopRpcExpression()};
-        const canAutoConfirm = Boolean(rpc?.request?.desktopShowMessageBox);
         window.confirm = () => true;
         if (rpc?.request) {
           const resetTest =
@@ -585,21 +624,50 @@ async function triggerSettingsReset(
           }
         }
         const resetTest = window.__ELIZA_PACKAGED_RESET_TEST__ ?? null;
-        if (resetTest?.messageBoxStubCalls > 0) {
+        if (resetTest?.confirmClicked) {
           return {
             ok: true,
             label: "Reset Everything",
-            autoConfirmed: canAutoConfirm,
-            messageBoxStubCalls: resetTest.messageBoxStubCalls,
+            confirmClicked: true,
+            restartStubCalls: resetTest.restartStubCalls ?? 0,
           };
         }
+        const confirmButton = document.querySelector(
+          '[data-agent-id="advanced-reset-confirm"]',
+        );
+        if (confirmButton instanceof HTMLButtonElement) {
+          window.__ELIZA_PACKAGED_RESET_TEST__ = {
+            ...(window.__ELIZA_PACKAGED_RESET_TEST__ ?? {}),
+            confirmClicked: true,
+          };
+          confirmButton.click();
+          return {
+            ok: true,
+            label: (confirmButton.textContent || "").trim(),
+            confirmClicked: true,
+            restartStubCalls:
+              window.__ELIZA_PACKAGED_RESET_TEST__?.restartStubCalls ?? 0,
+          };
+        }
+        const resetByAgentId = document.querySelector(
+          '[data-agent-id="advanced-reset-open"]',
+        );
         const buttons = Array.from(
           document.querySelectorAll('[data-testid="settings-shell"] button'),
         );
-        const resetButton = buttons.find((button) =>
-          /reset everything/i.test((button.textContent || "").trim()),
-        );
+        const resetButton =
+          resetByAgentId instanceof HTMLButtonElement
+            ? resetByAgentId
+            : buttons.find((button) =>
+                /reset everything/i.test((button.textContent || "").trim()),
+              );
         if (!resetButton) {
+          const advancedSection = document.querySelector(
+            '[data-agent-id="section-advanced"]',
+          );
+          if (advancedSection instanceof HTMLButtonElement) {
+            advancedSection.click();
+          }
           return {
             ok: false,
             error: "Settings reset button disappeared before click.",
@@ -610,9 +678,9 @@ async function triggerSettingsReset(
           ok: false,
           error: "Clicked Settings reset button; waiting for confirmation handler.",
           label: (resetButton.textContent || "").trim(),
-          autoConfirmed: canAutoConfirm,
-          messageBoxStubCalls:
-            window.__ELIZA_PACKAGED_RESET_TEST__?.messageBoxStubCalls ?? 0,
+          confirmClicked: false,
+          restartStubCalls:
+            window.__ELIZA_PACKAGED_RESET_TEST__?.restartStubCalls ?? 0,
         };
       } catch (error) {
         return {
@@ -621,11 +689,11 @@ async function triggerSettingsReset(
         };
       }
     })()`,
-    (current) => current.ok && current.messageBoxStubCalls > 0,
+    (current) => current.ok && current.confirmClicked,
     {
       timeout: 30_000,
       message:
-        "Timed out waiting for the Settings reset click to enter the desktop confirmation path.",
+        "Timed out waiting for the Settings reset click to enter the reset confirmation path.",
     },
   );
 
@@ -819,11 +887,11 @@ async function withPackagedHarness(
     "Packaged launcher is required for packaged desktop regressions.",
   ).toBeTruthy();
 
-  let api: TestApiServer | null = null;
+  let api: MockApiServer | null = null;
   let harness: PackagedDesktopHarness | null = null;
 
   try {
-    api = await startLiveApiServer({ firstRunComplete: true, port: 0 });
+    api = await startMockApiServer({ firstRunComplete: true, port: 0 });
     harness = new PackagedDesktopHarness({
       tempRoot,
       launcherPath: launcherPath as string,
@@ -837,6 +905,9 @@ async function withPackagedHarness(
     debugPackagedPhase("initial packaged launch ready");
     await seedReturningInstallState(harness, api.baseUrl);
     debugPackagedPhase("seeded returning-install state");
+    const rendererOriginBeforeRelaunch = await harness
+      .eval<string | null>(`window.location.origin || null`)
+      .catch(() => null);
     const requestCountBeforeRelaunch = api.requests.length;
     debugPackagedPhase("starting packaged relaunch");
     await harness.relaunch({
@@ -848,39 +919,50 @@ async function withPackagedHarness(
     // Verify that localStorage state survived the relaunch. If not, the
     // startup coordinator will fall back to a fresh-install probe path and
     // may stall or show the first-run overlay instead of the app shell.
-    const persistenceCheck = await harness
-      .eval<{
-        ok: boolean;
+    const persistenceCheck = await waitForEval<
+      EvalResult<{
         firstRunComplete: string | null;
         activeServer: string | null;
         apiBase: string | null;
-      }>(
-        `(() => {
+        origin: string | null;
+      }>
+    >(
+      harness,
+      `(() => {
         try {
           return {
             ok: true,
             firstRunComplete: localStorage.getItem("eliza:first-run-complete"),
             activeServer: localStorage.getItem("elizaos:active-server"),
             apiBase: ${getApiBaseExpression()} ?? null,
+            origin: window.location.origin || null,
           };
         } catch (e) {
-          return { ok: false, firstRunComplete: null, activeServer: null, apiBase: null };
+          return {
+            ok: false,
+            error: e instanceof Error ? e.message : String(e),
+          };
         }
       })()`,
-      )
-      .catch(() => ({
-        ok: false,
-        firstRunComplete: null,
-        activeServer: null,
-        apiBase: null,
-      }));
+      (current) => current.ok,
+      {
+        timeout: process.env.CI ? 120_000 : 90_000,
+        message:
+          "Timed out waiting for renderer localStorage probe after packaged relaunch.",
+      },
+    );
 
-    if (!persistenceCheck.firstRunComplete || !persistenceCheck.activeServer) {
+    if (
+      persistenceCheck.ok &&
+      (!persistenceCheck.firstRunComplete || !persistenceCheck.activeServer)
+    ) {
       console.warn(
         `[packaged-harness] localStorage was NOT persisted across relaunch.`,
         `firstRunComplete=${persistenceCheck.firstRunComplete}`,
         `activeServer=${persistenceCheck.activeServer}`,
         `apiBase=${persistenceCheck.apiBase}`,
+        `originBefore=${rendererOriginBeforeRelaunch}`,
+        `originAfter=${persistenceCheck.origin}`,
         `— re-seeding state for this session.`,
       );
       // Re-seed when WKWebView did not flush localStorage before process exit.
@@ -978,7 +1060,7 @@ test("packaged desktop persists media, provider, and plugin state across relaunc
   void _browserName;
   test.skip(
     !isPackagedPlatform(),
-    "Packaged desktop regressions require a macOS or Windows launcher.",
+    "Packaged desktop regressions require a macOS, Windows, or Linux launcher.",
   );
 
   await withPackagedHarness(async ({ harness }) => {
@@ -1005,7 +1087,7 @@ test("packaged desktop persists media, provider, and plugin state across relaunc
     );
 
     await openRouteAndWait(harness, PLUGINS_ROUTE, PLUGINS_SELECTOR);
-    const pluginIds = await readVisiblePluginSectionIds(harness);
+    const pluginIds = await readVisiblePluginIds(harness);
     expect(pluginIds).toEqual(expect.arrayContaining(["openai", "ollama"]));
     await writeHarnessScreenshot(
       harness,
@@ -1021,7 +1103,7 @@ test("packaged desktop reset from Settings returns the shell to first-run setup"
   void _browserName;
   test.skip(
     !isPackagedPlatform(),
-    "Packaged desktop regressions require a macOS or Windows launcher.",
+    "Packaged desktop regressions require a macOS, Windows, or Linux launcher.",
   );
 
   await withPackagedHarness(async ({ api, harness }) => {
@@ -1039,8 +1121,8 @@ test("packaged desktop reset from the application menu returns the shell to firs
 }, testInfo) => {
   void _browserName;
   test.skip(
-    !isPackagedPlatform(),
-    "Packaged desktop regressions require a macOS or Windows launcher.",
+    process.platform === "linux" || !isPackagedPlatform(),
+    "Application menu reset is only supported on packaged macOS or Windows launchers.",
   );
 
   await withPackagedHarness(async ({ api, harness }) => {

--- a/packages/app/test/electrobun-packaged/mock-api.ts
+++ b/packages/app/test/electrobun-packaged/mock-api.ts
@@ -242,6 +242,28 @@ function json(res: http.ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+function eventStream(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  messages: unknown[],
+): void {
+  applyCors(res);
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.write("retry: 60000\n\n");
+  for (const message of messages) {
+    res.write(`data: ${JSON.stringify(message)}\n\n`);
+  }
+  const keepAlive = setInterval(() => {
+    res.write(": keepalive\n\n");
+  }, 25_000);
+  req.on("close", () => {
+    clearInterval(keepAlive);
+  });
+}
+
 async function readJson(req: http.IncomingMessage): Promise<JsonObject> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
@@ -428,6 +450,39 @@ export async function startMockApiServer(
     type: "stream-tab",
   };
   let overlayLayout: unknown = null;
+  const emptyComputerUseApprovalSnapshot = {
+    mode: "off",
+    pendingCount: 0,
+    pendingApprovals: [],
+  };
+  const emptyOrchestratorUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+  };
+  const emptyOrchestratorStatus = {
+    taskCount: 0,
+    activeTaskCount: 0,
+    pausedTaskCount: 0,
+    blockedTaskCount: 0,
+    validatingTaskCount: 0,
+    sessionCount: 0,
+    activeSessionCount: 0,
+    usage: emptyOrchestratorUsage,
+    byStatus: {
+      active: 0,
+      paused: 0,
+      blocked: 0,
+      validating: 0,
+      completed: 0,
+      failed: 0,
+      archived: 0,
+    },
+  };
 
   let config: JsonObject = {
     settings: { avatarIndex: 1 },
@@ -501,6 +556,23 @@ export async function startMockApiServer(
         json(res, 401, { error: "Unauthorized" });
         return;
       }
+    }
+
+    if (method === "GET" && pathname === "/api/auth/me") {
+      json(res, 200, {
+        identity: {
+          id: "local-agent",
+          displayName: "Local Agent",
+          kind: "machine",
+        },
+        session: { id: "local", kind: "local", expiresAt: null },
+        access: {
+          mode: "local",
+          passwordConfigured: false,
+          ownerConfigured: false,
+        },
+      });
+      return;
     }
 
     if (method === "GET" && pathname === "/api/permissions") {
@@ -759,6 +831,106 @@ export async function startMockApiServer(
         totalBuffered: 0,
         replayed: true,
       });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/views") {
+      json(res, 200, { views: [] });
+      return;
+    }
+    if (method === "GET" && pathname === "/api/views/current") {
+      json(res, 200, { currentView: null, justSwitched: false });
+      return;
+    }
+    if (method === "GET" && pathname === "/api/views/platform-info") {
+      json(res, 200, {
+        platform: "desktop",
+        dynamicLoadingAllowed: true,
+      });
+      return;
+    }
+    if (method === "GET" && pathname === "/api/views/search") {
+      json(res, 200, { views: [], query: searchParams.get("q") ?? "" });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/commands") {
+      json(res, 200, {
+        commands: [],
+        surface: searchParams.get("surface"),
+        activeViewId: null,
+        agentId: "agent-1",
+        generatedAt: nowIso(),
+      });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/notifications") {
+      json(res, 200, { notifications: [], unreadCount: 0 });
+      return;
+    }
+    if (method === "POST" && pathname === "/api/notifications/read-all") {
+      json(res, 200, { changed: 0 });
+      return;
+    }
+    if (method === "DELETE" && pathname === "/api/notifications") {
+      json(res, 200, { ok: true });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/computer-use/approvals") {
+      json(res, 200, emptyComputerUseApprovalSnapshot);
+      return;
+    }
+    if (method === "GET" && pathname === "/api/computer-use/approvals/stream") {
+      eventStream(req, res, [
+        { type: "snapshot", snapshot: emptyComputerUseApprovalSnapshot },
+      ]);
+      return;
+    }
+    if (method === "POST" && pathname === "/api/computer-use/approval-mode") {
+      json(res, 200, { mode: emptyComputerUseApprovalSnapshot.mode });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/inbox/chats") {
+      json(res, 200, { chats: [], count: 0 });
+      return;
+    }
+    if (method === "GET" && pathname === "/api/inbox/sources") {
+      json(res, 200, { sources: [] });
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/coding-agents") {
+      json(res, 200, []);
+      return;
+    }
+    if (method === "GET" && pathname === "/api/coding-agents/preflight") {
+      json(res, 200, { installed: [], available: false });
+      return;
+    }
+    if (
+      method === "GET" &&
+      pathname === "/api/coding-agents/coordinator/status"
+    ) {
+      json(res, 200, {
+        supervisionLevel: "unavailable",
+        taskCount: 0,
+        tasks: [],
+        pendingConfirmations: 0,
+        taskThreadCount: 0,
+        taskThreads: [],
+        frameworks: [],
+      });
+      return;
+    }
+    if (method === "GET" && pathname === "/api/orchestrator/status") {
+      json(res, 200, emptyOrchestratorStatus);
+      return;
+    }
+    if (method === "GET" && pathname === "/api/orchestrator/tasks") {
+      json(res, 200, { tasks: [] });
       return;
     }
 
@@ -1181,8 +1353,20 @@ export async function startMockApiServer(
       ]);
       return;
     }
+    if (method === "GET" && pathname === "/api/catalog/apps") {
+      json(res, 200, []);
+      return;
+    }
     if (method === "GET" && pathname === "/api/apps/installed") {
       json(res, 200, []);
+      return;
+    }
+    if (method === "POST" && pathname === "/api/apps/overlay-presence") {
+      const body = await readJson(req);
+      json(res, 200, {
+        ok: true,
+        appName: typeof body.appName === "string" ? body.appName : null,
+      });
       return;
     }
     if (method === "POST" && pathname === "/api/apps/launch") {

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -65,6 +65,12 @@ interface PackagedStartOptions {
   shellReadyTimeoutMs?: number;
 }
 
+const PACKAGED_TEST_DISABLED_FIRST_PARTY_REMOTES = ["eliza.local-model"];
+const PACKAGED_GRACEFUL_QUIT_TIMEOUT_MS = 15_000;
+const PACKAGED_LINUX_PROCESS_COOLDOWN_MS = 2_500;
+const PACKAGED_RELAUNCH_DELAY_MS =
+  process.platform === "linux" ? PACKAGED_LINUX_PROCESS_COOLDOWN_MS : 1_000;
+
 function appendLog(target: string[], chunk: Buffer | string): void {
   const text = chunk.toString();
   if (!text) return;
@@ -80,6 +86,28 @@ function collectProcessLogs(child: ChildProcess): PackagedProcessLogs {
   child.stdout?.on("data", (chunk: Buffer) => appendLog(stdout, chunk));
   child.stderr?.on("data", (chunk: Buffer) => appendLog(stderr, chunk));
   return { stdout, stderr };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveExecutableOnPath(binaryName: string): string | null {
+  const pathValue = process.env.PATH || "";
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, binaryName);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function waitAfterPackagedProcessExit(): Promise<void> {
+  if (process.platform === "linux") {
+    await delay(PACKAGED_LINUX_PROCESS_COOLDOWN_MS);
+  }
 }
 
 async function findFiles(
@@ -307,6 +335,13 @@ function createPackagedDesktopEnv(args: {
     ELIZA_DESKTOP_TEST_BRIDGE_TOKEN: args.bridgeToken,
     ELIZA_STATE_DIR: args.stateDir,
     ELECTROBUN_CONSOLE: "1",
+    // These regressions assert the main packaged shell. The native pill is
+    // covered by its own unit/UI tests and adds a second WebKitGTK toplevel on
+    // Linux headless runs, which can trip native Bun/WebKit startup crashes
+    // before the test bridge is reachable. Allow an explicit opt-in for future
+    // pill-specific packaged coverage.
+    ELIZA_DESKTOP_PILL:
+      args.baseEnv.ELIZA_TEST_PACKAGED_ENABLE_PILL === "1" ? "1" : "0",
   };
 
   if (process.platform === "win32") {
@@ -359,11 +394,53 @@ function createPackagedDesktopEnv(args: {
   };
 }
 
+interface FetchJsonOptions extends RequestInit {
+  timeoutMs?: number;
+}
+
+const BRIDGE_REQUEST_TIMEOUT_MS = 5_000;
+
 async function fetchJson<T>(
   url: string,
-  options: RequestInit = {},
+  options: FetchJsonOptions = {},
 ): Promise<T> {
-  const response = await fetch(url, options);
+  const {
+    timeoutMs = BRIDGE_REQUEST_TIMEOUT_MS,
+    signal,
+    ...requestOptions
+  } = options;
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  const abortFromCaller = () => controller.abort(signal?.reason);
+
+  if (signal?.aborted) {
+    abortFromCaller();
+  } else {
+    signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...requestOptions,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (timedOut) {
+      throw new Error(
+        `${options.method ?? "GET"} ${url} timed out after ${timeoutMs}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener("abort", abortFromCaller);
+  }
+
   if (!response.ok) {
     const responseText = (await response.text().catch(() => "")).trim();
     throw new Error(
@@ -396,6 +473,49 @@ function normalizeEvalScript(script: string): string {
   // Electrobun evaluates this as Function(script)(), so expression scripts need
   // an explicit top-level return to preserve their resolved value.
   return `return (\n${trimmed}\n);`;
+}
+
+async function seedPackagedTestFirstPartyRemoteState(
+  stateDir: string,
+): Promise<void> {
+  if (process.env.ELIZA_TEST_ENABLE_LOCAL_MODEL_REMOTE === "1") {
+    return;
+  }
+
+  const statePath = path.join(
+    stateDir,
+    "remote-plugins",
+    "first-party-remotes.json",
+  );
+  let disabled: Record<string, boolean> = {};
+  try {
+    const parsed = JSON.parse(await fs.readFile(statePath, "utf8")) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as { disabled?: unknown }).disabled === "object" &&
+      (parsed as { disabled?: unknown }).disabled !== null &&
+      !Array.isArray((parsed as { disabled?: unknown }).disabled)
+    ) {
+      disabled = {
+        ...((parsed as { disabled: Record<string, boolean> }).disabled ?? {}),
+      };
+    }
+  } catch {
+    // Fresh packaged test state has no first-party remote state file yet.
+  }
+
+  for (const id of PACKAGED_TEST_DISABLED_FIRST_PARTY_REMOTES) {
+    disabled[id] = true;
+  }
+
+  await fs.mkdir(path.dirname(statePath), { recursive: true });
+  await fs.writeFile(
+    statePath,
+    `${JSON.stringify({ version: 1, disabled }, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 async function findBridgeListenerPids(port: number): Promise<number[]> {
@@ -485,8 +605,18 @@ export class PackagedDesktopHarness {
     await fs.mkdir(this.stateDir, { recursive: true });
     await fs.mkdir(this.appDataDir, { recursive: true });
     await fs.mkdir(this.localAppDataDir, { recursive: true });
+    await seedPackagedTestFirstPartyRemoteState(this.stateDir);
 
-    const child = spawn(this.launcherPath, [], {
+    const useDedicatedXvfb =
+      process.platform === "linux" &&
+      process.env.ELIZA_ELECTROBUN_PACKAGED_USE_CURRENT_DISPLAY !== "1";
+    const xvfbRun = useDedicatedXvfb
+      ? resolveExecutableOnPath("xvfb-run")
+      : null;
+    const launchCommand = xvfbRun ?? this.launcherPath;
+    const launchArgs = xvfbRun ? ["-a", this.launcherPath] : [];
+
+    const child = spawn(launchCommand, launchArgs, {
       cwd: path.dirname(this.launcherPath),
       env: this.appEnv,
       stdio: ["ignore", "pipe", "pipe"],
@@ -503,12 +633,25 @@ export class PackagedDesktopHarness {
   }
 
   async stop(): Promise<void> {
+    await this.requestGracefulQuit().catch(() => undefined);
     const pidsToKill = new Set<number>();
-    for (const pid of await findBridgeListenerPids(this.bridgePort)) {
-      pidsToKill.add(pid);
-      const parentPid = await getParentPid(pid);
-      if (parentPid) {
-        pidsToKill.add(parentPid);
+    if (await this.waitForBridgeExit(PACKAGED_GRACEFUL_QUIT_TIMEOUT_MS)) {
+      if (await this.waitForChildExit(5_000)) {
+        await waitAfterPackagedProcessExit();
+        return;
+      }
+      // The bridge listener can disappear before the launcher/native child has
+      // fully unwound. Do not report a clean stop in that half-exited state.
+      // Fall through to the same SIGTERM/SIGKILL cleanup path used when the
+      // bridge itself stays alive.
+    } else {
+      const bridgePids = await findBridgeListenerPids(this.bridgePort);
+      for (const pid of bridgePids) {
+        pidsToKill.add(pid);
+        const parentPid = await getParentPid(pid);
+        if (parentPid) {
+          pidsToKill.add(parentPid);
+        }
       }
     }
 
@@ -517,16 +660,16 @@ export class PackagedDesktopHarness {
       pidsToKill.add(child.pid);
     }
 
+    if (pidsToKill.size === 0) {
+      return;
+    }
+
     for (const pid of pidsToKill) {
       try {
         process.kill(pid, "SIGTERM");
       } catch {
         // Process already exited.
       }
-    }
-
-    if (pidsToKill.size === 0) {
-      return;
     }
 
     await new Promise<void>((resolve) => {
@@ -549,6 +692,49 @@ export class PackagedDesktopHarness {
         setTimeout(checkExited, 250);
       };
       void checkExited();
+    });
+    await this.waitForChildExit(1_000);
+    await waitAfterPackagedProcessExit();
+  }
+
+  private async requestGracefulQuit(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/app/quit`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+      timeoutMs: 2_000,
+    });
+  }
+
+  private async waitForBridgeExit(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if ((await findBridgeListenerPids(this.bridgePort)).length === 0) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  }
+
+  private async waitForChildExit(timeoutMs: number): Promise<boolean> {
+    const child = this.process;
+    if (!child || child.exitCode !== null || child.signalCode !== null) {
+      return true;
+    }
+
+    return await new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => {
+        child.off("exit", onExit);
+        resolve(false);
+      }, timeoutMs);
+      const onExit = () => {
+        clearTimeout(timeout);
+        resolve(true);
+      };
+      child.once("exit", onExit);
     });
   }
 
@@ -580,7 +766,7 @@ export class PackagedDesktopHarness {
 
     // Short delay to let the OS release the old process's resources (ports,
     // file handles, WebKit caches) before spawning the next instance.
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    await delay(PACKAGED_RELAUNCH_DELAY_MS);
 
     await this.start(options);
   }
@@ -650,6 +836,26 @@ export class PackagedDesktopHarness {
     });
   }
 
+  async showMainWindow(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/main-window/show`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  async focusMainWindow(): Promise<void> {
+    await fetchJson<{ ok: boolean }>(`${this.bridgeUrl}/main-window/focus`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
   async waitForState(
     predicate: (state: DesktopTestBridgeState) => boolean,
     message: string,
@@ -657,6 +863,7 @@ export class PackagedDesktopHarness {
   ): Promise<DesktopTestBridgeState> {
     const startedAt = Date.now();
     let lastState: DesktopTestBridgeState | null = null;
+    let lastError: Error | null = null;
 
     while (Date.now() - startedAt < timeoutMs) {
       if (
@@ -668,15 +875,22 @@ export class PackagedDesktopHarness {
           `${message}\nPackaged app exited early.\n${formatLogs(this.logs)}`,
         );
       }
-      lastState = await this.getState();
-      if (predicate(lastState)) {
-        return lastState;
+      try {
+        lastState = await this.getState();
+        lastError = null;
+        if (predicate(lastState)) {
+          return lastState;
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
       }
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
 
     throw new Error(
-      `${message}\nLast state:\n${JSON.stringify(lastState, null, 2)}\n${formatLogs(this.logs)}`,
+      `${message}\nLast state:\n${JSON.stringify(lastState, null, 2)}${
+        lastError ? `\nLast bridge error: ${lastError.message}` : ""
+      }\n${formatLogs(this.logs)}`,
     );
   }
 
@@ -725,6 +939,7 @@ export class PackagedDesktopHarness {
         {
           headers: { Authorization: `Bearer ${this.bridgeToken}` },
           signal: controller.signal,
+          timeoutMs,
         },
       );
       return response.data;

--- a/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
@@ -284,6 +284,7 @@ test("cloud agents: list, delete, then reprovision another from Settings", async
   ).toBeDisabled();
 
   // --- Delete the non-active agent; the row disappears, the keeper remains.
+  page.once("dialog", (dialog) => void dialog.accept());
   await page.getByRole("button", { name: "Delete Disposable" }).click();
   await expect(agentRow(page, "Disposable")).toHaveCount(0, {
     timeout: 30_000,
@@ -325,6 +326,7 @@ test("cloud agents: list, delete, then reprovision another from Settings", async
   ).toBeEnabled();
 
   // --- Delete the original; only the freshly provisioned agent survives.
+  page.once("dialog", (dialog) => void dialog.accept());
   await page.getByRole("button", { name: "Delete Keeper" }).click();
   await expect(agentRow(page, "Keeper")).toHaveCount(0, { timeout: 30_000 });
   await expect(agentRow(page, "Fresh Agent")).toBeVisible();

--- a/packages/app/test/ui-smoke/live-agent-chat.spec.ts
+++ b/packages/app/test/ui-smoke/live-agent-chat.spec.ts
@@ -6,7 +6,7 @@
 // a live runtime.
 
 import { expect, type Page, test } from "@playwright/test";
-import { selectLiveProvider } from "../../../app-core/test/helpers/live-provider";
+import { selectLiveProviderAsync } from "../../../app-core/test/helpers/live-provider";
 import {
   installDefaultAppRoutes,
   openAppPath,
@@ -14,15 +14,44 @@ import {
 } from "./helpers";
 
 const LIVE_AGENT_CHAT_ENABLED = process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
-const LIVE_PROVIDER = selectLiveProvider();
-const LIVE_AGENT_RESPONSE_MARKER = "APP_LIVE_AGENT_OK";
+const LIVE_PROVIDER = await selectLiveProviderAsync();
+const REPORT_LIVE_TIMINGS = process.env.ELIZA_UI_SMOKE_REPORT_TIMINGS === "1";
+const LIVE_AGENT_RESPONSE_MARKER = "LIVE_AGENT_RESPONSE_OK";
+const LIVE_GENERAL_PROMPTS: ReadonlyArray<{
+  marker: string;
+  prompt: string;
+}> = [
+  {
+    marker: "LIVE_TIME_CHECK_OK",
+    prompt:
+      "For a Playwright end-to-end smoke test, start your reply with exactly LIVE_TIME_CHECK_OK, then answer this user request in one sentence: what time is it?",
+  },
+  {
+    marker: "LIVE_BTC_CHECK_OK",
+    prompt:
+      "For a Playwright end-to-end smoke test, start your reply with exactly LIVE_BTC_CHECK_OK, then answer this tool-free user request in one sentence: in plain terms, what is BTC? Do not look up live prices.",
+  },
+  {
+    marker: "LIVE_BTC_PRICE_HANDLED_OK",
+    prompt:
+      "For a Playwright end-to-end smoke test, start your reply with exactly LIVE_BTC_PRICE_HANDLED_OK, then answer this tool-free user request in one sentence: what is the price of BTC? Do not call tools or look up live prices; say live market data is unavailable.",
+  },
+  {
+    marker: "LIVE_WEBSITE_CODE_OK",
+    prompt:
+      "For a Playwright end-to-end smoke test, start your reply with exactly LIVE_WEBSITE_CODE_OK, then provide a tiny complete HTML example for a simple personal website.",
+  },
+];
 const CHAT_COMPOSER_SELECTOR =
   '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
 const CHAT_SEND_SELECTOR =
   '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]';
 const OPTIONAL_LIVE_ENDPOINTS = [
   /\/api\/coding-agents(?:\?|$)/,
+  /\/api\/i18n\/locale(?:\?|$)/,
   /\/api\/lifeops\/activity-signals(?:\?|$)/,
+  /\/api\/orchestrator\/status(?:\?|$)/,
+  /\/api\/orchestrator\/tasks(?:\?|$)/,
   /\/api\/tts\/cloud(?:\?|$)/,
   /\/api\/vincent\/status(?:\?|$)/,
 ];
@@ -37,6 +66,19 @@ type DeterministicAssistantFixture = {
     type: string;
     target: string | null;
   };
+};
+
+type ApiConversationResponse = {
+  conversation?: {
+    id?: string;
+  };
+};
+
+type LivePromptTiming = {
+  marker: string;
+  promptLength: number;
+  sendToUserVisibleMs: number;
+  sendToAssistantMarkerMs: number;
 };
 
 function isOptionalLiveEndpoint(url: string): boolean {
@@ -131,9 +173,82 @@ function assistantMessage(page: Page, text: string | RegExp) {
     .first();
 }
 
+async function sendPromptAndExpectAssistantMarker(
+  page: Page,
+  prompt: string,
+  marker: string,
+): Promise<LivePromptTiming> {
+  await expect(chatComposer(page)).toBeVisible({
+    timeout: 60_000,
+  });
+  await chatComposer(page).fill(prompt);
+  await expect(chatSendButton(page)).toBeEnabled();
+  const sentAt = Date.now();
+  await chatSendButton(page).click();
+
+  await expect(userMessage(page, prompt)).toBeVisible({ timeout: 30_000 });
+  const userVisibleAt = Date.now();
+  await expect(assistantMessage(page, new RegExp(marker, "i"))).toBeVisible({
+    timeout: 120_000,
+  });
+  return {
+    marker,
+    promptLength: prompt.length,
+    sendToUserVisibleMs: userVisibleAt - sentAt,
+    sendToAssistantMarkerMs: Date.now() - sentAt,
+  };
+}
+
+function reportLiveTiming(timing: LivePromptTiming): void {
+  if (!REPORT_LIVE_TIMINGS) return;
+  console.log(
+    `[live-agent-chat][timing] marker=${timing.marker} promptLength=${timing.promptLength} userVisibleMs=${timing.sendToUserVisibleMs} assistantMarkerMs=${timing.sendToAssistantMarkerMs}`,
+  );
+}
+
+async function createAndActivateLiveConversation(
+  page: Page,
+  title: string,
+): Promise<void> {
+  await openAppPath(page, "/chat");
+  await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
+
+  const response = await page.evaluate(async (conversationTitle) => {
+    const createResponse = await fetch("/api/conversations", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: conversationTitle }),
+    });
+    return {
+      ok: createResponse.ok,
+      status: createResponse.status,
+      text: await createResponse.text(),
+    };
+  }, title);
+  expect(
+    response.ok,
+    `live runtime should create an isolated chat (status=${response.status}, body=${response.text.slice(0, 500)})`,
+  ).toBe(true);
+
+  const body = JSON.parse(response.text) as ApiConversationResponse;
+  const conversationId = body.conversation?.id?.trim();
+  expect(conversationId, "created live conversation id").toBeTruthy();
+
+  await page.evaluate((id) => {
+    localStorage.setItem("eliza:chat:activeConversationId", id);
+  }, conversationId);
+  await openAppPath(page, "/chat");
+  await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
+}
+
 test("app chat sends a message to the deterministic keyless agent and renders parseable JSON", async ({
   page,
 }) => {
+  test.skip(
+    LIVE_AGENT_CHAT_ENABLED,
+    "deterministic keyless assertions are only valid against the stub stack",
+  );
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 
@@ -169,6 +284,10 @@ test("app chat sends a message to the deterministic keyless agent and renders pa
 test("app chat rejects intentionally broken deterministic mock LLM output", async ({
   page,
 }) => {
+  test.skip(
+    LIVE_AGENT_CHAT_ENABLED,
+    "deterministic keyless assertions are only valid against the stub stack",
+  );
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 
@@ -209,23 +328,33 @@ test.describe("live agent chat", () => {
   }) => {
     const failures = installFailureCollectors(page);
     await seedAppStorage(page);
-
-    await openAppPath(page, "/chat");
-    await expect(chatComposer(page)).toBeVisible({
-      timeout: 60_000,
-    });
+    await createAndActivateLiveConversation(page, "live-agent-marker");
 
     const prompt = `For a Playwright end-to-end smoke test, reply with exactly ${LIVE_AGENT_RESPONSE_MARKER} and no other words.`;
-    await chatComposer(page).fill(prompt);
-    await expect(chatSendButton(page)).toBeEnabled();
-    await chatSendButton(page).click();
-
-    await expect(userMessage(page, prompt)).toBeVisible({ timeout: 30_000 });
-
-    await expect(
-      assistantMessage(page, new RegExp(LIVE_AGENT_RESPONSE_MARKER, "i")),
-    ).toBeVisible({ timeout: 120_000 });
+    reportLiveTiming(
+      await sendPromptAndExpectAssistantMarker(
+        page,
+        prompt,
+        LIVE_AGENT_RESPONSE_MARKER,
+      ),
+    );
 
     expect(failures, "live agent chat browser/runtime failures").toEqual([]);
   });
+
+  for (const { marker, prompt } of LIVE_GENERAL_PROMPTS) {
+    test(`app chat handles live general prompt ${marker}`, async ({ page }) => {
+      const failures = installFailureCollectors(page);
+      await seedAppStorage(page);
+      await createAndActivateLiveConversation(page, `live-agent-${marker}`);
+      reportLiveTiming(
+        await sendPromptAndExpectAssistantMarker(page, prompt, marker),
+      );
+
+      expect(
+        failures,
+        `live prompt ${marker} browser/runtime failures`,
+      ).toEqual([]);
+    });
+  }
 });

--- a/packages/app/test/ui-smoke/settings-mobile-load.spec.ts
+++ b/packages/app/test/ui-smoke/settings-mobile-load.spec.ts
@@ -36,6 +36,8 @@ const BENIGN_CONSOLE = [
   /favicon/i,
 ];
 
+const DEVELOPER_ONLY_SECTION_IDS = new Set(["remote-plugins"]);
+
 function isBenign(message: string): boolean {
   return BENIGN_CONSOLE.some((pattern) => pattern.test(message));
 }
@@ -54,6 +56,10 @@ test.describe("settings sections load at mobile width", () => {
       test.skip(
         section.id === "wallet-rpc",
         "capability-gated; covered by wallet-keys.spec.ts",
+      );
+      test.skip(
+        DEVELOPER_ONLY_SECTION_IDS.has(section.id),
+        "developer-gated; hidden in ordinary keyless settings smoke",
       );
       await mkdir(OUT_DIR, { recursive: true });
 

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -16,6 +16,7 @@
       "@elizaos/plugin-personal-assistant": [
         "../../plugins/plugin-personal-assistant/src/index.ts"
       ],
+      "@elizaos/plugin-blocker": ["./src/types/app-plugin-modules.d.ts"],
       "@elizaos/plugin-phone": ["../../plugins/plugin-phone/src/index.ts"],
       "@elizaos/plugin-phone/*": ["../../plugins/plugin-phone/src/*"],
       "@elizaos/plugin-vector-browser/register": [
@@ -54,9 +55,7 @@
       "@elizaos/plugin-local-inference/services": [
         "../../plugins/plugin-local-inference/src/services/index.ts"
       ],
-      "@elizaos/plugin-browser": [
-        "../../plugins/plugin-browser/src/index.ts"
-      ],
+      "@elizaos/plugin-browser": ["../../plugins/plugin-browser/src/index.ts"],
       "@elizaos/plugin-browser/*": ["../../plugins/plugin-browser/src/*"],
       "@elizaos/plugin-computeruse": [
         "../../plugins/plugin-computeruse/src/index.ts"
@@ -68,6 +67,9 @@
         "../../plugins/plugin-registry/dist/index.d.ts"
       ],
       "@elizaos/plugin-registry/*": ["../../plugins/plugin-registry/dist/*"],
+      "@elizaos/plugin-commands": [
+        "../../plugins/plugin-commands/src/index.ts"
+      ],
       "@elizaos/plugin-whatsapp": [
         "../../plugins/plugin-whatsapp/src/index.ts"
       ],

--- a/packages/app/tsconfig.typecheck.json
+++ b/packages/app/tsconfig.typecheck.json
@@ -21,6 +21,7 @@
       "@elizaos/plugin-personal-assistant": [
         "./src/types/app-plugin-modules.d.ts"
       ],
+      "@elizaos/plugin-blocker": ["./src/types/app-plugin-modules.d.ts"],
       "@elizaos/plugin-messages/register": [
         "../../plugins/plugin-messages/src/register.ts"
       ],
@@ -69,9 +70,7 @@
       "@elizaos/plugin-elizacloud": [
         "../../plugins/plugin-elizacloud/src/index.node.ts"
       ],
-      "@elizaos/plugin-browser": [
-        "../../plugins/plugin-browser/src/index.ts"
-      ],
+      "@elizaos/plugin-browser": ["../../plugins/plugin-browser/src/index.ts"],
       "@elizaos/plugin-browser/*": ["../../plugins/plugin-browser/src/*"],
       "@elizaos/plugin-computeruse": [
         "../../plugins/plugin-computeruse/src/index.ts"
@@ -82,8 +81,9 @@
       "@elizaos/plugin-registry": [
         "../../plugins/plugin-registry/dist/index.d.ts"
       ],
-      "@elizaos/plugin-registry/*": [
-        "../../plugins/plugin-registry/dist/*"
+      "@elizaos/plugin-registry/*": ["../../plugins/plugin-registry/dist/*"],
+      "@elizaos/plugin-commands": [
+        "../../plugins/plugin-commands/src/index.ts"
       ],
       "@elizaos/plugin-whatsapp": [
         "../../plugins/plugin-whatsapp/dist/src/index.d.ts"


### PR DESCRIPTION
## Summary

Split PR A from the closed monolithic desktop/view-routing branch (#8948), following maintainer feedback to isolate the app-core desktop hardening work.

This PR keeps the surface focused on app-core desktop/cloud runtime hardening plus the app harness files needed to validate it:

- scopes `desktopHttpRequest` loopback allowance to the configured desktop API base instead of broadly allowing local HTTP
- makes Electrobun desktop shutdown/disposal idempotent and awaited, including tray quit and native cleanup paths
- adds bounded pending WebSocket queue handling for the UI smoke proxy
- makes the live UI stack provider selector async/vault-aware and supports Cerebras via `@elizaos/plugin-openai` with `gpt-oss-120b` small and `zai-glm-4.7` large defaults
- hardens live/stub UI smoke stack cleanup so temp state dirs, child API processes, and UI proxy servers are not leaked on startup failure
- adds iOS plist URL-scheme patching as a tested shared helper
- extends packaged desktop and mobile/cloud smoke harness coverage around launch, API routing, and first-run Cerebras config

Deliberately excluded from this split:

- the old `packages/core/src/services/message.ts` Stage-1 rewrite
- UI view routing / split-tile changes
- plugin-app-control / x402 / plugin infra changes
- any local-inference changes

## Validation

Synced against `origin/develop` at `2d3ae01c5c` before commit.

- `bun run --cwd packages/app-core test src/first-run/first-run-config.test.ts test/helpers/live-provider.test.ts test/scripts/websocket-pending-queue.test.ts --coverage.enabled=false`
- `bun run --cwd packages/app-core/platforms/electrobun test src/desktop-http-request.test.ts src/native/desktop-window.test.ts`
- `bun run --cwd packages/app test scripts/patch-ios-plist.test.mjs --coverage.enabled=false`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app typecheck`
- `git diff --check origin/develop...HEAD`
- `git diff --name-only origin/develop...HEAD | rg -i 'local[-_]?inference|localinference' || true` returned no files
