### PR TITLE
fix(agent): unify plugin cold-import + drop container tsx transpile (#8812)

### DIFF
--- a/packages/agent/src/runtime/plugin-resolver-cold-import.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-cold-import.test.ts
@@ -8,10 +8,12 @@ import { importPluginModuleFromPath } from "./plugin-resolver.ts";
 // The cold-import-in-place fast-path (F4) imports a plugin directly from its
 // real package root on the FIRST import of a name in this process — skipping
 // the `fs.cp` staging copy — when:
-//   1. ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE is enabled, AND
-//   2. it is the first import of this package name in the process, AND
-//   3. a built `dist/` directory exists.
-// Otherwise it falls back to staging (byte-identical to prior behavior).
+//   1. it is the first import of this package name in the process, AND
+//   2. a built `dist/` directory exists.
+// Otherwise it falls back to staging (busts the ESM module graph on re-import).
+//
+// This is a single, unconditional behavior — local dev and the container
+// resolve plugins identically; there is no env flag.
 //
 // Staging lands under `<ELIZA_STATE_DIR>/plugins/.runtime-imports/<sanitized
 // package name>/`. We point ELIZA_STATE_DIR at a controlled temp dir so we can
@@ -30,9 +32,7 @@ beforeEach(async () => {
   stateDir = path.join(tmpDir, "state");
   await fsp.mkdir(stateDir, { recursive: true });
   rememberEnv("ELIZA_STATE_DIR");
-  rememberEnv("ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE");
   process.env.ELIZA_STATE_DIR = stateDir;
-  delete process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE;
 });
 
 afterEach(async () => {
@@ -108,8 +108,7 @@ async function createFixture(
 }
 
 describe("importPluginModuleFromPath cold-import-in-place fast-path (F4)", () => {
-  it("cold fast-path: flag on + dist + first import loads in place WITHOUT staging", async () => {
-    process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE = "1";
+  it("cold fast-path: dist + first import loads in place WITHOUT staging", async () => {
     const name = "cold-fastpath-fixture-a";
     const installPath = await createFixture(name, "cold-a", true);
 
@@ -122,8 +121,7 @@ describe("importPluginModuleFromPath cold-import-in-place fast-path (F4)", () =>
     expect(await stagingHappened(name)).toBe(false);
   });
 
-  it("re-import stages: flag on + same name imported twice → 2nd import goes through staging", async () => {
-    process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE = "1";
+  it("re-import stages: same name imported twice → 2nd import goes through staging", async () => {
     const name = "cold-reimport-fixture-b";
     const installPath = await createFixture(name, "reimport-b", true);
 
@@ -142,21 +140,7 @@ describe("importPluginModuleFromPath cold-import-in-place fast-path (F4)", () =>
     expect(await stagingHappened(name)).toBe(true);
   });
 
-  it("flag off = unchanged: first import still stages (current behavior preserved)", async () => {
-    delete process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE;
-    const name = "cold-flagoff-fixture-c";
-    const installPath = await createFixture(name, "flagoff-c", true);
-
-    const mod = (await importPluginModuleFromPath(installPath, name)) as {
-      marker: string;
-    };
-
-    expect(mod.marker).toBe("flagoff-c");
-    expect(await stagingHappened(name)).toBe(true);
-  });
-
-  it("no dist → stages: flag on but package has no dist/ → falls back to staging", async () => {
-    process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE = "1";
+  it("no dist → stages: package has no dist/ → falls back to staging", async () => {
     const name = "cold-nodist-fixture-d";
     const installPath = await createFixture(name, "nodist-d", false);
 
@@ -169,7 +153,6 @@ describe("importPluginModuleFromPath cold-import-in-place fast-path (F4)", () =>
   });
 
   it("per-name keying: a cold import of one name does NOT make a different name stage", async () => {
-    process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE = "1";
     const nameX = "cold-keying-fixture-e1";
     const nameY = "cold-keying-fixture-e2";
     const installX = await createFixture(nameX, "keying-e1", true);

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -750,14 +750,15 @@ export async function importPluginModuleFromPath(
   const packageRelativePath =
     pkgRoot === absPath ? [] : ["node_modules", ...packageName.split("/")];
 
-  // Cold-boot fast-path (opt-in): on the FIRST import of this package in this
-  // process there is no ESM module record to bust, so staging's recursive
-  // `fs.cp` copy is pure I/O waste + unbounded `.runtime-imports/` growth.
-  // Import in place from the real package root instead, but ONLY when a stable
-  // built `dist/` exists. Any re-import (name already in the set) falls back to
-  // staging so hot-reloads still force a fresh module evaluation.
+  // Cold-boot fast-path: on the FIRST import of this package in this process
+  // there is no ESM module record to bust, so staging's recursive `fs.cp` copy
+  // is pure I/O waste + unbounded `.runtime-imports/` growth. Import in place
+  // from the real package root instead, but ONLY when a stable built `dist/`
+  // exists. Any re-import (name already in the set) falls back to staging so
+  // hot-reloads still force a fresh module evaluation. This is a single
+  // behavior for every boot — local dev and the container resolve plugins
+  // identically.
   const useColdFastPath =
-    coldImportInPlaceEnabled() &&
     !importedPluginPackageNames.has(packageName) &&
     existsSync(path.join(pkgRoot, "dist"));
   const importRoot = useColdFastPath
@@ -1069,24 +1070,6 @@ function stageAllHoistedNodeModulesEnabled(): boolean {
 
 function stageFullPluginPackageEnabled(): boolean {
   const raw = process.env.ELIZA_STAGE_FULL_PLUGIN_PACKAGE;
-  if (!raw) return false;
-  const normalized = raw.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes";
-}
-
-/**
- * Cold-boot fast-path opt-in. When enabled, the *first* import of a given
- * plugin package in this process is loaded in place from its real package root
- * — skipping the `fs.cp` staging copy — provided a built `dist/` is present.
- *
- * Staging exists only to bust the ESM module graph when hot-reloading a mutated
- * plugin (a fresh staged URL forces re-evaluation since ESM has no
- * cache-eviction API). On a cold boot the plugin was never imported, so there
- * is no module record to bust and staging is pure I/O waste. Default OFF; only
- * the literal "1"/"true"/"yes" enables it.
- */
-function coldImportInPlaceEnabled(): boolean {
-  const raw = process.env.ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE;
   if (!raw) return false;
   const normalized = raw.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes";

--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -7,6 +7,22 @@ ARG APP_PORT=2138
 ARG APP_BRIDGE_PORT=18790
 ARG TAILSCALE_VERSION=1.90.8
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Builder: precompile the standalone TS entrypoint to a single JS bundle so the
+# runtime image starts with plain `node entrypoint.js` — no `tsx` transpile on
+# the container cold-start path (issue #8812 F6). cloud-agent-shared.ts is
+# inlined; the dynamic `@elizaos/*` imports stay external and resolve from
+# /app/node_modules at runtime exactly as before.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM node:24-bookworm-slim AS entrypoint-build
+WORKDIR /build
+COPY eliza/packages/app-core/deploy/cloud-agent-entrypoint.ts ./cloud-agent-entrypoint.ts
+COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.ts
+RUN npx --yes esbuild@0.28.1 cloud-agent-entrypoint.ts \
+      --bundle --platform=node --format=esm --target=node24 \
+      --external:@elizaos/* --external:node:* \
+      --outfile=entrypoint.js
+
 FROM node:24-bookworm-slim
 
 ARG APP_PORT
@@ -37,16 +53,12 @@ RUN set -eux; \
 
 WORKDIR /app
 
-# Copy the entrypoint + its sibling module (standalone TS, no build step).
-# Both files are required at runtime — cloud-agent-entrypoint.ts does
-# `import "./cloud-agent-shared.ts"`.
-COPY eliza/packages/app-core/deploy/cloud-agent-entrypoint.ts ./entrypoint.ts
-COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.ts
+# Copy the prebuilt JS entrypoint (cloud-agent-shared.ts inlined by the builder
+# stage). The container runs this with plain `node` — no `tsx` transpile on the
+# cold-start path.
+COPY --from=entrypoint-build /build/entrypoint.js ./entrypoint.js
 COPY eliza/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh /usr/local/bin/cloud-agent-docker-entrypoint
 RUN chmod +x /usr/local/bin/cloud-agent-docker-entrypoint
-
-# Install tsx globally for running TypeScript directly
-RUN npm install -g tsx@4
 
 # Install elizaOS runtime + plugins so the dynamic imports inside
 # cloud-agent-shared.ts resolve and the agent runs in REAL mode (not echo).
@@ -59,7 +71,7 @@ RUN npm install --omit=dev --no-audit --no-fund --loglevel=error \
       @elizaos/plugin-sql@alpha \
     && npm cache clean --force
 
-# Ensure tsx (global) can resolve packages from /app/node_modules
+# Ensure the entrypoint can resolve packages from /app/node_modules
 ENV NODE_PATH=/app/node_modules
 ENV NODE_ENV=production
 ENV PORT=${APP_PORT}
@@ -77,4 +89,4 @@ EXPOSE ${APP_BRIDGE_PORT}
 RUN useradd -m agent && chown -R agent:agent /app
 
 ENTRYPOINT ["cloud-agent-docker-entrypoint"]
-CMD ["tsx", "entrypoint.ts"]
+CMD ["node", "entrypoint.js"]


### PR DESCRIPTION
## Summary

Finishes the two remaining open boot-time levers from #8812 by collapsing them into **one** behavior shared by local dev and the cloud container — no env flag, no per-start transpile.

### F4 — unify plugin cold-import (remove `ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE`)

The cold-boot fast-path (import a plugin in place from a stable `dist/` on the **first** import of its name in a process, and fall back to staging on any **re-import** to bust the ESM module graph) was already implemented but gated behind an opt-in env flag, defaulting OFF. The fast-path is inherently hot-reload-safe — only the first import of a name skips staging; every re-import still stages — so gating it served no purpose other than making dev and the container behave differently.

- Deleted `coldImportInPlaceEnabled()` and the `ELIZA_PLUGIN_COLD_IMPORT_IN_PLACE` gate.
- `useColdFastPath` is now `!alreadyImported(name) && dist/ exists` — unconditional.
- Updated `plugin-resolver-cold-import.test.ts` to assert the single behavior (cold first-import skips staging; re-import stages; no-`dist/` stages; per-name keying holds).

Result: cold boot no longer mints a `.runtime-imports/<plugin>/…` staging dir on first import, eliminating recursive `fs.cp` I/O and unbounded staging-dir growth on the deferred wave.

### F6 — drop the container `tsx` transpile (`Dockerfile.cloud-agent`)

The cloud-agent image ran `tsx entrypoint.ts`, transpiling TypeScript on every container cold-start. Now a builder stage precompiles the standalone entrypoint to a single JS bundle and the runtime image starts with plain `node entrypoint.js`:

- New `entrypoint-build` stage: `esbuild@0.28.1 --bundle --platform=node --format=esm --target=node24 --external:@elizaos/* --external:node:*` → `entrypoint.js` (inlines `cloud-agent-shared.ts`; keeps the dynamic `@elizaos/*` imports external so they resolve from `/app/node_modules` at runtime exactly as before).
- Runtime stage copies the prebuilt `entrypoint.js`, drops the global `tsx` install, and runs `CMD ["node", "entrypoint.js"]`.

> Scope note: `Dockerfile.ci` (the full app image) already starts from the prebuilt `packages/agent/dist/bin.js`; its `--import tsx` loader is retained deliberately as a safety net for workspace plugins that may lack a built `dist/` (per prior boot-perf work #8836/#8837). The cold-start transpile this issue targets — running a raw `.ts` entry — only existed in `Dockerfile.cloud-agent`, which is now eliminated.

The other #8812 levers — F5 (dev-server bootstrap ordering), boot-KPI CI gate (`BOOT_KPI_ENFORCE`), and the verified `BASELINE.md` — are already on `develop`.

## Verification

- `bun run --cwd packages/agent test plugin-resolver-cold-import` → **4 passed** (cold fast-path, re-import stages, no-dist stages, per-name keying).
- `bun run --cwd packages/agent lint` → clean (542 files).
- `bun run --cwd packages/agent typecheck` → clean for this change.
- Compiled `entrypoint.js` (19.8 kb, 5 dynamic `@elizaos` imports preserved as external) runs under plain `node`: parses, boots, falls into echo mode without `@elizaos/core` installed, health endpoint listens on the configured port — confirming no `tsx` is needed at start.

Closes #8812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
