### PR TITLE
fix(orchestrator): bound weak-model re-spawn loop (#8875) + rehydrate durable spend cap (#8924)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -1,7 +1,10 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runParentAgentBroker } from "../services/parent-agent-broker.js";
-import { resetSessionSpendUsd } from "../services/spend-allowance.js";
+import {
+  configureSpendLedger,
+  resetSessionSpendUsd,
+} from "../services/spend-allowance.js";
 
 function createRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
   const cache = new Map<string, unknown>();
@@ -37,6 +40,7 @@ describe("runParentAgentBroker", () => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     resetSessionSpendUsd();
+    configureSpendLedger(null);
   });
 
   it("lists matching parent actions", async () => {
@@ -361,6 +365,42 @@ describe("runParentAgentBroker", () => {
 
       expect(result.text).toContain("Reply yes");
       expect(result.text).toContain("allowance");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("enforces the cap from the DURABLE total after a restart (#8924)", async () => {
+      stubAllowance("10");
+      // A durable ledger holding $9 already spent by a PRIOR process for this
+      // session (persisted on the session record's metadata.spendUsd).
+      const persisted = new Map<string, number>([["spend-restart", 9]]);
+      configureSpendLedger({
+        load: async (sid) => persisted.get(sid) ?? 0,
+        save: async (sid, total) => {
+          persisted.set(sid, total);
+        },
+      });
+      // Simulate a restart: the in-memory ledger is empty, only the durable
+      // record survives. Without rehydration the cap check would see $0.
+      resetSessionSpendUsd();
+
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "spend-restart",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "domains.buy",
+          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 2 },
+        },
+      });
+
+      // $9 persisted + $2 now = $11 > $10 cap → must fall back to a human
+      // confirmation, proving the broker rehydrated the persisted total before
+      // enforcing the cap (the durable record survived the "restart").
+      expect(result.text).toContain("Reply yes");
       expect(fetchMock).not.toHaveBeenCalled();
     });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-completion-finish-reason.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-completion-finish-reason.test.ts
@@ -1,0 +1,151 @@
+import type { Memory, MessageHandlerResult, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { subAgentCompletionResponseEvaluator } from "../evaluators/sub-agent-completion.js";
+
+// A clean, long prose body that does not trip any of the evaluator's other
+// relay branches (no URL, no tool-output envelope, no failure marker, no
+// positive quantitative evidence, longer than the short-clean-answer cap). It
+// stands in for a weak-model completion that was cut off mid-summary.
+const LONG_TRUNCATED_BODY =
+  "I began working through the requested analysis and pulled together the " +
+  "initial set of inputs, but the response was cut off before I could finish " +
+  "writing up the complete summary of everything for you in this reply.";
+
+const UUID_A = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function makeCompletion(text: string, finishReason?: string): Memory {
+  return {
+    id: UUID_A,
+    entityId: UUID_A,
+    agentId: UUID_A,
+    roomId: UUID_A,
+    content: {
+      text,
+      source: "sub_agent",
+      metadata: {
+        subAgent: true,
+        subAgentEvent: "task_complete",
+        ...(finishReason ? { subAgentFinishReason: finishReason } : {}),
+      },
+    },
+  } as unknown as Memory;
+}
+
+function makeHandler(
+  plan: Record<string, unknown>,
+  processMessage: "RESPOND" | "STOP" | "IGNORE" = "RESPOND",
+): MessageHandlerResult {
+  return {
+    processMessage,
+    thought: "",
+    plan: { contexts: [], ...plan },
+  } as unknown as MessageHandlerResult;
+}
+
+// The evaluator only reads `message` + `messageHandler`; the rest of the
+// ResponseHandlerEvaluatorContext is irrelevant here.
+function ctx(message: Memory, messageHandler: MessageHandlerResult) {
+  return { message, messageHandler } as unknown as Parameters<
+    typeof subAgentCompletionResponseEvaluator.shouldRun
+  >[0];
+}
+
+describe("sub-agent completion: degenerate finish-reason relay (issue #8875)", () => {
+  it("relays a length-truncated completion the planner would otherwise re-spawn", async () => {
+    // The planner re-issued a fresh, concrete follow-up (TASKS_CREATE) — without
+    // the finish-reason signal this would suppress the relay and let it re-spawn.
+    const message = makeCompletion(LONG_TRUNCATED_BODY, "length");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    expect(
+      await subAgentCompletionResponseEvaluator.shouldRun(
+        ctx(message, handler),
+      ),
+    ).toBe(true);
+  });
+
+  it("relays a content_filter (blocked) completion", async () => {
+    const message = makeCompletion(LONG_TRUNCATED_BODY, "content_filter");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    expect(
+      await subAgentCompletionResponseEvaluator.shouldRun(
+        ctx(message, handler),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT relay a clean completion with a concrete follow-up (regression)", async () => {
+    // Same plan, but no degenerate finish reason: the planner keeps its
+    // concrete follow-up and the evaluator steps aside (existing behavior).
+    const message = makeCompletion(LONG_TRUNCATED_BODY);
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    expect(
+      await subAgentCompletionResponseEvaluator.shouldRun(
+        ctx(message, handler),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a non-degenerate finish reason (end_turn) as clean", async () => {
+    const message = makeCompletion(LONG_TRUNCATED_BODY, "end_turn");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    expect(
+      await subAgentCompletionResponseEvaluator.shouldRun(
+        ctx(message, handler),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT pre-empt feeding the still-running session (TASKS_SEND_TO_AGENT)", async () => {
+    // Feeding a real blocker back to the live session is the one legitimate
+    // non-relay follow-up after a degenerate completion.
+    const message = makeCompletion(LONG_TRUNCATED_BODY, "length");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_SEND_TO_AGENT"],
+      reply: "",
+    });
+    expect(
+      await subAgentCompletionResponseEvaluator.shouldRun(
+        ctx(message, handler),
+      ),
+    ).toBe(false);
+  });
+
+  it("evaluate relays the best partial and clears candidate actions", async () => {
+    const message = makeCompletion(LONG_TRUNCATED_BODY, "length");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    const patch = await subAgentCompletionResponseEvaluator.evaluate(
+      ctx(message, handler),
+    );
+    expect(patch?.clearCandidateActions).toBe(true);
+    expect(patch?.clearParentActionHints).toBe(true);
+    expect(patch?.reply).toContain("began working through");
+  });
+
+  it("evaluate suppresses (IGNORE) when a truncation has no usable partial", async () => {
+    const message = makeCompletion("", "length");
+    const handler = makeHandler({
+      candidateActions: ["TASKS_CREATE"],
+      reply: "",
+    });
+    const patch = await subAgentCompletionResponseEvaluator.evaluate(
+      ctx(message, handler),
+    );
+    expect(patch?.processMessage).toBe("IGNORE");
+    expect(patch?.clearCandidateActions).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -327,6 +327,24 @@ function deliverableFromMetadata(message: Memory): string | undefined {
   return value.length > 0 ? value : undefined;
 }
 
+// A DEGENERATE completion is one the sub-agent's model could not finish cleanly:
+// `length` (ran out of token / turn budget mid-answer — truncated) or
+// `content_filter` (refused / blocked). The ACP `stopReason` is normalized to
+// one of these by the router (subAgentFinishReason metadata) before it reaches
+// here. Re-spawning the SAME root request on a degenerate completion just
+// truncates/blocks again — the ~70x weak-model re-spawn loop (issue
+// elizaOS/eliza#8875). We relay the best partial once instead.
+const DEGENERATE_FINISH_REASONS = new Set(["length", "content_filter"]);
+
+function finishReasonFromMetadata(message: Memory): string | undefined {
+  const value = textOf(metadataRecord(message)?.subAgentFinishReason);
+  return value.length > 0 ? value : undefined;
+}
+
+function isDegenerateFinishReason(reason: string | undefined): boolean {
+  return reason !== undefined && DEGENERATE_FINISH_REASONS.has(reason);
+}
+
 // Longest completion body we treat as a bare "answer value" worth relaying over
 // a planner re-spawn. Tight on purpose: a price / short sentence qualifies; a
 // multi-line build report or transcript does not and keeps the existing
@@ -512,6 +530,20 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     ) {
       return true;
     }
+    // A truncated (`length`) or content-filtered (`content_filter`) sub-agent
+    // completion is TERMINAL for the planner: the model ran out of room or was
+    // blocked mid-answer, so a fresh TASKS_SPAWN_AGENT on the SAME root request
+    // just truncates/blocks again — the ~70x weak-model re-spawn loop the cap
+    // only bounds (issue elizaOS/eliza#8875). The ACP completion's stopReason is
+    // threaded here as subAgentFinishReason. Relay the best partial once, UNLESS
+    // the plan is feeding the still-running session more input
+    // (TASKS_SEND_TO_AGENT), which is the one legitimate non-relay follow-up.
+    if (
+      isDegenerateFinishReason(finishReasonFromMetadata(message)) &&
+      !planContinuesExistingSession(messageHandler.plan)
+    ) {
+      return true;
+    }
     const hasConcreteFollowUp =
       hasStrings(messageHandler.plan.candidateActions) &&
       !hasOnlyStaleCompletionHints(messageHandler.plan.candidateActions);
@@ -539,6 +571,42 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
         reply: deliverable,
         debug: [
           "verified sub-agent completion carries a captured deliverable; relaying it verbatim",
+        ],
+      };
+    }
+    // Degenerate completion (truncated / content-filtered): relay the best
+    // partial ONCE and clear the planner's candidate actions so it cannot
+    // re-spawn the same request. When there is nothing usable to relay, suppress
+    // the turn rather than loop (issue elizaOS/eliza#8875).
+    const finishReason = finishReasonFromMetadata(message);
+    if (
+      isDegenerateFinishReason(finishReason) &&
+      !planContinuesExistingSession(messageHandler.plan)
+    ) {
+      const partial = cleanCompletionReply(
+        replyPatchFromCompletion(currentReply, completionText, verifiedUrls),
+      );
+      if (partial) {
+        return {
+          ...respondIfNeeded(messageHandler),
+          requiresTool: false,
+          setContexts: [SIMPLE_CONTEXT_ID],
+          clearCandidateActions: true,
+          clearParentActionHints: true,
+          reply: partial,
+          debug: [
+            `sub-agent completion finished with stopReason=${finishReason} (truncated/blocked); relaying best partial once instead of re-spawning the same request`,
+          ],
+        };
+      }
+      return {
+        processMessage: "IGNORE",
+        requiresTool: false,
+        clearReply: true,
+        clearCandidateActions: true,
+        clearParentActionHints: true,
+        debug: [
+          `sub-agent completion finished with stopReason=${finishReason} and carried no usable partial; suppressing to avoid a re-spawn loop`,
         ],
       };
     }

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -10,6 +10,7 @@ import {
   addSessionSpendUsd,
   decideSpendAuthorization,
   getSessionSpendUsd,
+  hydrateSessionSpendUsd,
   readSpendCapUsd,
   stripSpendHints,
 } from "./spend-allowance.js";
@@ -1072,6 +1073,15 @@ async function runCloudCommand(args: {
   const log = getLogger(args.runtime);
   const params = args.params ?? {};
   const capUsd = readSpendCapUsd();
+  // Read the session's DURABLE spend total back before enforcing the cap, so a
+  // configured cap survives a process restart (the in-memory ledger is empty
+  // after a restart) and reflects spend from other instances sharing the same
+  // task store (#8924). No-op (keeps the cached value) when no durable backend
+  // is installed; skipped entirely when the allowance is disabled so the
+  // default confirm-everything path stays zero-overhead.
+  if (capUsd > 0) {
+    await hydrateSessionSpendUsd(args.sessionId);
+  }
   const spendDecision = decideSpendAuthorization({
     command: definition.command,
     risk: definition.risk,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -623,6 +623,16 @@ export class SubAgentRouter extends Service {
       this.stateLostCapNotified.delete(lk);
     }
 
+    // The ACP session/prompt stopReason for a task_complete tells us whether the
+    // sub-agent's model finished cleanly or DEGENERATELY (truncated / blocked).
+    // Threaded into the completion metadata below so the response evaluator can
+    // relay the best partial once rather than letting the planner re-spawn the
+    // same request — the ~70x weak-model loop (issue elizaOS/eliza#8875).
+    const finishReason =
+      event === "task_complete"
+        ? normalizeFinishReason(pickPayloadString(data, "stopReason"))
+        : undefined;
+
     // Deterministic recovery for the cross-session state_lost cascade. A lost
     // session used to be re-injected into the planner so the planner would
     // spawn a fresh sub-agent — which leaked a "the sub-agent crashed, let me
@@ -1053,6 +1063,7 @@ export class SubAgentRouter extends Service {
               ? { subAgentVerifiedUrls: verifiedUrls }
               : {}),
             ...(deliverable ? { subAgentDeliverable: deliverable } : {}),
+            ...(finishReason ? { subAgentFinishReason: finishReason } : {}),
             ...(origin.userId ? { originUserId: origin.userId } : {}),
             ...(origin.parentMessageId
               ? { originMessageId: origin.parentMessageId }
@@ -2028,6 +2039,31 @@ function pickPayloadString(data: unknown, key: string): string | undefined {
   const v = (data as Record<string, unknown>)[key];
   if (typeof v !== "string" || !v.trim()) return undefined;
   return v;
+}
+
+// Map the ACP `session/prompt` stopReason to a normalized LLM finish reason for
+// the completion evaluator. `max_tokens` / `max_turn_requests` mean the model
+// ran out of token / turn budget mid-answer (truncated); `refusal` is a
+// content-filter block. Both are DEGENERATE: the completion is partial, and the
+// planner re-issuing the SAME root request just truncates / blocks again — the
+// ~70x weak-model re-spawn loop (issue elizaOS/eliza#8875). Every other
+// stopReason (`end_turn`, `cancelled`, `exit`, `stopped`, `error`, …) is a clean
+// stop and keeps the existing routing (returns undefined → no signal).
+function normalizeFinishReason(
+  stopReason: string | undefined,
+): "length" | "content_filter" | undefined {
+  if (!stopReason) return undefined;
+  switch (stopReason.toLowerCase()) {
+    case "max_tokens":
+    case "max_turn_requests":
+    case "length":
+      return "length";
+    case "refusal":
+    case "content_filter":
+      return "content_filter";
+    default:
+      return undefined;
+  }
 }
 
 function stripToolTranscript(text: string): string {


### PR DESCRIPTION
Two focused orchestrator-reliability fixes, each isolated to the spawn / spend paths and fully unit-tested.

## #8875 — weak-model planner re-spawns one request ~70x

A sub-agent turn that finishes with ACP `stopReason` `max_tokens`/`max_turn_requests` (truncated) or `refusal` (blocked) was re-issued by the planner as a fresh `TASKS_SPAWN_AGENT` for the **same** root request — looping ~70× (Discord spam; a no-op on dashboard/web where the per-origin cap has no connector message id to key on).

Fixed at the source, exactly per the maintainer's spec on the issue:

- **`sub-agent-router.ts`** — `normalizeFinishReason()` maps the ACP `session/prompt` stopReason to a normalized `length`/`content_filter`, threaded into the `task_complete` synthetic-memory metadata as `subAgentFinishReason`.
- **`sub-agent-completion.ts`** — before the `hasConcreteFollowUp` branch, a degenerate finish reason is treated as **terminal**: relay the best partial **once** and clear the planner's candidate actions so it cannot re-spawn — *unless* the plan is feeding the still-running session more input (`TASKS_SEND_TO_AGENT`), the one legitimate non-relay follow-up. When no usable partial exists, the turn is suppressed (`IGNORE`) rather than looped.

Deterministic and unit-tested — no live-stack guessing. The existing `ELIZA_MAX_SPAWNS_PER_ORIGIN` cap stays as defense-in-depth.

## #8924 — durable per-session spend cap didn't actually survive a restart

[PR #9032](https://github.com/elizaOS/eliza/pull/9032) added the durable spend ledger (write-through persist to the session record's `metadata.spendUsd`, plus `hydrateSessionSpendUsd` to read it back) — but **nothing in the production path ever called `hydrateSessionSpendUsd`**. After a restart the in-memory ledger was empty and the cap check saw `$0`, silently letting a session spend its full allowance again. AC2 ("cap enforced from the persisted total across restart") was met only by a unit test that calls hydrate manually.

- **`parent-agent-broker.ts`** — `runCloudCommand` now rehydrates the session's durable total before the cap check whenever a cap is configured (`capUsd > 0`). A configured `ELIZA_AGENT_SPEND_CAP_USD` now survives a restart and reflects spend from other instances sharing the same task store. The default (no cap) path stays zero-overhead; hydration failures keep the in-memory total (never throw).

## Evidence

Affected-suite run (Windows, `bunx vitest run`), all green:

```
Test Files  3 passed (3)
     Tests  46 passed (46)
  sub-agent-completion-finish-reason.test.ts  (7)  ← new, #8875
  parent-agent-broker.test.ts                (14)  ← +1 restart-survival, #8924
  spend-allowance.test.ts                    (25)
```

- The new `#8924` broker test was **proven to fail without the fix** (the broker auto-authorized because in-memory spend was `$0`), then pass with it — confirming it's a meaningful regression guard.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` → clean; `biome check` on all touched files → clean.

Live-LLM trajectory N/A for these two changes: #8875 is a deterministic routing decision keyed on a structured ACP signal (unit-tested with synthetic truncated/blocked completions); #8924 is a durable-persistence wiring fix (unit-tested with a simulated restart). Neither changes model prompting.

Closes #8875
Closes #8924

🤖 Generated with [Claude Code](https://claude.com/claude-code)