### PR TITLE
[codex] feat(ui): harden view routing and dynamic views

### DIFF
--- a/packages/agent/src/__tests__/views-registry-integration.test.ts
+++ b/packages/agent/src/__tests__/views-registry-integration.test.ts
@@ -130,6 +130,7 @@ const PLUGIN_NAMES = [
   "views-integration-dev",
   "views-integration-remote",
   "views-integration-local-bundle",
+  "todos",
 ];
 
 // ---------------------------------------------------------------------------
@@ -175,6 +176,30 @@ function rawResponse(ctx: ViewsRouteContext): {
 // ---------------------------------------------------------------------------
 
 describe("GET /api/views", () => {
+  it("resolves short first-party plugin names to their workspace package roots", async () => {
+    await registerPluginViews(
+      {
+        name: "todos",
+        description: "short-name first-party plugin",
+        actions: [],
+        views: [
+          {
+            id: "short-name.todos",
+            label: "Short Name Todos",
+            path: "/short-name-todos",
+            bundlePath: "package.json",
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const entry = getView("short-name.todos");
+    expect(entry?.pluginName).toBe("todos");
+    expect(entry?.pluginDir).toContain("plugin-todos");
+    expect(entry?.available).toBe(true);
+  });
+
   it("returns registered views with views key in response body", async () => {
     await registerPluginViews(
       {

--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -84,6 +84,18 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     desktopTabEnabled: true,
   },
   {
+    id: "documents",
+    label: "Knowledge",
+    description: "Agent knowledge documents, uploads, and retrieval sources",
+    icon: "FileText",
+    heroImagePath: "assets/view-heroes/character.png",
+    path: "/character/documents",
+    order: 51,
+    tags: ["documents", "notes", "knowledge", "files", "uploads", "retrieval"],
+    visibleInManager: true,
+    desktopTabEnabled: true,
+  },
+  {
     id: "automations",
     viewKind: "release",
     label: "Automations",

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -69,33 +69,42 @@ async function resolvePluginPackageDir(
 ): Promise<string | undefined> {
   const { createRequire } = await import("node:module");
   const req = createRequire(import.meta.url);
+  const packageNames = pluginName.startsWith("@")
+    ? [pluginName]
+    : [pluginName, `@elizaos/plugin-${pluginName}`];
 
-  // Preferred: resolve the package's own package.json directly. Requires the
-  // package to expose "./package.json" in its exports map.
-  try {
-    return path.dirname(req.resolve(`${pluginName}/package.json`));
-  } catch {
-    // Fall through to resolving the package entry instead.
+  for (const packageName of packageNames) {
+    // Preferred: resolve the package's own package.json directly. Requires the
+    // package to expose "./package.json" in its exports map.
+    try {
+      return path.dirname(req.resolve(`${packageName}/package.json`));
+    } catch {
+      // Fall through to resolving the package entry instead.
+    }
   }
 
   // Fallback: resolve the package main entry (the "." export always exists for
   // a loadable plugin) and walk up to the directory that owns its package.json.
   // This keeps view bundles resolvable for plugins that don't export
   // "./package.json".
-  try {
-    let dir = path.dirname(req.resolve(pluginName));
-    for (let depth = 0; depth < 8; depth++) {
-      if (await fileExists(path.join(dir, "package.json"))) return dir;
-      const parent = path.dirname(dir);
-      if (parent === dir) break;
-      dir = parent;
+  for (const packageName of packageNames) {
+    try {
+      let dir = path.dirname(req.resolve(packageName));
+      for (let depth = 0; depth < 8; depth++) {
+        if (await fileExists(path.join(dir, "package.json"))) return dir;
+        const parent = path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
+    } catch {
+      // Package is not reachable from this module under this name.
     }
-  } catch {
-    // Package is not reachable from this module at all.
   }
 
-  const workspaceDir = await resolveWorkspacePluginPackageDir(pluginName);
-  if (workspaceDir) return workspaceDir;
+  for (const packageName of packageNames) {
+    const workspaceDir = await resolveWorkspacePluginPackageDir(packageName);
+    if (workspaceDir) return workspaceDir;
+  }
 
   logger.warn(
     { src: "ViewRegistry", pluginName },

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -9,6 +9,12 @@ const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(appDir, "..", "..");
 const workspaceRoot = path.resolve(repoRoot, "..");
 const playwrightArgs = process.argv.slice(2);
+const uiSmokeViewLockDir = path.join(
+  repoRoot,
+  ".turbo",
+  "ui-smoke-view-bundles.lock",
+);
+const uiSmokeTempPrefixes = ["eliza-ui-smoke-stub-", "eliza-ui-smoke-live-"];
 
 function resolvePlaywrightCommand() {
   // On Windows the bin shim differs by package manager: bun emits
@@ -83,6 +89,142 @@ const bunBinDir = path.dirname(env.BUN);
 const pathDelimiter = process.platform === "win32" ? ";" : ":";
 env.PATH = env.PATH ? `${bunBinDir}${pathDelimiter}${env.PATH}` : bunBinDir;
 
+function hasPlaywrightConfig(configName) {
+  return (
+    playwrightArgs.includes("--config") &&
+    playwrightArgs.some((value) => value.includes(configName))
+  );
+}
+
+function appendNodeOption(value, option) {
+  const options =
+    typeof value === "string" && value.trim().length > 0
+      ? value.trim().split(/\s+/)
+      : [];
+  if (!options.includes(option)) {
+    options.push(option);
+  }
+  return options.join(" ");
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function readLockOwnerPid(lockDir) {
+  try {
+    const owner = fs.readFileSync(path.join(lockDir, "owner"), "utf8");
+    const pid = Number.parseInt(owner.split(/\r?\n/, 1)[0] ?? "", 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    return true;
+  }
+}
+
+function acquireUiSmokeViewLock() {
+  const staleAfterMs = 30 * 60 * 1000;
+  let announcedWait = false;
+
+  fs.mkdirSync(path.dirname(uiSmokeViewLockDir), { recursive: true });
+
+  for (;;) {
+    try {
+      fs.mkdirSync(uiSmokeViewLockDir);
+      fs.writeFileSync(
+        path.join(uiSmokeViewLockDir, "owner"),
+        `${process.pid}\n${new Date().toISOString()}\n`,
+      );
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+
+      let stat = null;
+      try {
+        stat = fs.statSync(uiSmokeViewLockDir);
+      } catch {
+        continue;
+      }
+
+      const ownerPid = readLockOwnerPid(uiSmokeViewLockDir);
+      if (
+        (ownerPid !== null && !isProcessAlive(ownerPid)) ||
+        Date.now() - stat.mtimeMs > staleAfterMs
+      ) {
+        fs.rmSync(uiSmokeViewLockDir, { recursive: true, force: true });
+        continue;
+      }
+
+      if (!announcedWait) {
+        console.log("[ui-smoke] Waiting for another UI smoke run to finish...");
+        announcedWait = true;
+      }
+      sleepSync(250);
+    }
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    fs.rmSync(uiSmokeViewLockDir, { recursive: true, force: true });
+  };
+}
+
+let releaseUiSmokeViewLock = null;
+
+function releaseLocks() {
+  if (releaseUiSmokeViewLock) {
+    releaseUiSmokeViewLock();
+    releaseUiSmokeViewLock = null;
+  }
+}
+
+process.once("exit", releaseLocks);
+
+function cleanupUiSmokeStateDirsForRun() {
+  const runId = env.ELIZA_UI_SMOKE_RUN_ID?.trim();
+  if (!runId) return;
+
+  let entries = [];
+  try {
+    entries = fs.readdirSync(os.tmpdir(), { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (
+      !entry.isDirectory() ||
+      !uiSmokeTempPrefixes.some((prefix) => entry.name.startsWith(prefix))
+    ) {
+      continue;
+    }
+    const stateDir = path.join(os.tmpdir(), entry.name);
+    try {
+      const owner = fs
+        .readFileSync(path.join(stateDir, ".eliza-ui-smoke-run-id"), "utf8")
+        .trim();
+      if (owner === runId) {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    } catch {
+      // Only remove dirs explicitly stamped with this runner's id.
+    }
+  }
+}
+
 async function getDistinctFreePort(excludedPorts = new Set()) {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const port = Number(await getFreePort());
@@ -93,12 +235,16 @@ async function getDistinctFreePort(excludedPorts = new Set()) {
   throw new Error("Could not allocate a distinct free port for UI smoke.");
 }
 
-if (
-  playwrightArgs.includes("--config") &&
-  playwrightArgs.some((value) =>
-    value.includes("playwright.ui-smoke.config.ts"),
-  )
-) {
+if (hasPlaywrightConfig("playwright.electrobun.packaged.config.ts")) {
+  env.NODE_OPTIONS = appendNodeOption(
+    env.NODE_OPTIONS,
+    "--conditions=eliza-source",
+  );
+}
+
+if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
+  env.ELIZA_UI_SMOKE_RUN_ID =
+    env.ELIZA_UI_SMOKE_RUN_ID || `${process.pid}-${Date.now().toString(36)}`;
   if (env.ELIZA_UI_SMOKE_LIVE_STACK !== "1") {
     env.ELIZA_UI_SMOKE_FORCE_STUB = env.ELIZA_UI_SMOKE_FORCE_STUB || "1";
   }
@@ -119,12 +265,10 @@ if (
 }
 
 if (
-  playwrightArgs.includes("--config") &&
-  playwrightArgs.some((value) =>
-    value.includes("playwright.ui-smoke.config.ts"),
-  ) &&
+  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
   env.ELIZA_UI_SMOKE_SKIP_VIEW_BUILD !== "1"
 ) {
+  releaseUiSmokeViewLock = acquireUiSmokeViewLock();
   const result = spawnSync(
     process.execPath,
     [path.join(repoRoot, "packages", "scripts", "build-views.mjs")],
@@ -134,8 +278,10 @@ if (
       stdio: "inherit",
     },
   );
-  if ((result.status ?? 1) !== 0) {
-    process.exit(result.status ?? 1);
+  const status = result.status ?? 1;
+  if (status !== 0) {
+    releaseLocks();
+    process.exit(status);
   }
 }
 
@@ -150,10 +296,7 @@ if (
 // on live mode), mirroring the view-build step above. Turbo-cached → a fast no-op
 // when already up to date; skip with ELIZA_UI_SMOKE_SKIP_CORE_BUILD=1.
 if (
-  playwrightArgs.includes("--config") &&
-  playwrightArgs.some((value) =>
-    value.includes("playwright.ui-smoke.config.ts"),
-  ) &&
+  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
   env.ELIZA_UI_SMOKE_SKIP_CORE_BUILD !== "1"
 ) {
   const coreBuild = spawnSync(
@@ -171,16 +314,12 @@ if (
     },
   );
   if ((coreBuild.status ?? 1) !== 0) {
+    releaseLocks();
     process.exit(coreBuild.status ?? 1);
   }
 }
 
-if (
-  playwrightArgs.includes("--config") &&
-  playwrightArgs.some((value) =>
-    value.includes("playwright.dev-smoke.config.ts"),
-  )
-) {
+if (hasPlaywrightConfig("playwright.dev-smoke.config.ts")) {
   const reservedPorts = new Set();
 
   if (!env.ELIZA_DEV_SMOKE_API_PORT) {
@@ -201,10 +340,7 @@ if (
     fs.mkdtempSync(path.join(os.tmpdir(), "eliza-dev-smoke-"));
 }
 
-if (
-  playwrightArgs.includes("--config") &&
-  playwrightArgs.some((value) => value.includes("playwright.hmr.config.ts"))
-) {
+if (hasPlaywrightConfig("playwright.hmr.config.ts")) {
   const reservedPorts = new Set();
 
   if (!env.ELIZA_HMR_API_PORT) {
@@ -238,6 +374,10 @@ const child = spawn(playwrightCommand, ["test", ...playwrightArgs], {
 });
 
 child.on("exit", (code, signal) => {
+  if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
+    cleanupUiSmokeStateDirsForRun();
+  }
+  releaseLocks();
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -227,6 +227,13 @@ function importAppTaskCoordinator() {
   );
 }
 
+function importAppTaskCoordinatorRegister() {
+  return cachedDynamicImport(
+    "@elizaos/plugin-task-coordinator/register",
+    () => import("@elizaos/plugin-task-coordinator/register"),
+  );
+}
+
 function importAppTraining() {
   return cachedDynamicImport(
     "@elizaos/plugin-training",
@@ -621,6 +628,7 @@ function initializeAppModules(): Promise<void> {
       // Imported for its self-registration side effect (Vincent overlay app).
       importAppVincent(),
       importAppTaskCoordinator(),
+      importAppTaskCoordinatorRegister(),
       importAppPhone(),
       importAppSteward(),
       importAppTraining(),

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -19,9 +19,12 @@ const EXPECTED_SIDE_EFFECT_MODULES = [
   "@elizaos/plugin-device-settings/register",
   "@elizaos/plugin-messages/register",
   "@elizaos/plugin-phone/register",
-  "@elizaos/plugin-task-coordinator/register",
   "@elizaos/plugin-wifi/register",
   "@elizaos/plugin-facewear/register",
+] as const;
+
+const FIRST_RENDER_REGISTRATION_MODULES = [
+  "@elizaos/plugin-task-coordinator/register",
 ] as const;
 
 describe("side-effect app module registrations", () => {
@@ -63,6 +66,18 @@ describe("side-effect app module registrations", () => {
       id.endsWith("/register"),
     )) {
       expect(declarations).toContain(`declare module "${moduleId}";`);
+    }
+  });
+
+  it("loads chat inline-widget registrations before first render", () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, "main.tsx"),
+      "utf8",
+    );
+
+    for (const moduleId of FIRST_RENDER_REGISTRATION_MODULES) {
+      expect(source).toContain(`cachedDynamicImport(\n    "${moduleId}"`);
+      expect(source).toContain(`import("${moduleId}")`);
     }
   });
 });

--- a/packages/app/src/plugin-registrations.ts
+++ b/packages/app/src/plugin-registrations.ts
@@ -70,10 +70,6 @@ export const SIDE_EFFECT_APP_MODULE_LOADERS: readonly SideEffectAppModuleLoader[
       load: () => import("@elizaos/plugin-phone/register"),
     },
     {
-      key: "@elizaos/plugin-task-coordinator/register",
-      load: () => import("@elizaos/plugin-task-coordinator/register"),
-    },
-    {
       key: "@elizaos/plugin-wifi/register",
       load: () => import("@elizaos/plugin-wifi/register"),
     },

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -55,6 +55,7 @@ const BUILTIN_TAB_PATHS: Record<string, string> = {
   automations: "/automations",
   inventory: "/wallet",
   documents: "/character/documents",
+  files: "/apps/files",
   plugins: "/apps/plugins",
   skills: "/apps/skills",
   "fine-tuning": "/apps/fine-tuning",
@@ -71,6 +72,7 @@ const BUILTIN_TAB_PATHS: Record<string, string> = {
   tutorial: "/tutorial",
   help: "/help",
   logs: "/apps/logs",
+  background: "/background",
 };
 
 // ── navigation TAB_PATHS coverage guard (#8796) ──────────────────────────────
@@ -397,9 +399,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
       `audit BUILTIN_TAB_PATHS path drift vs navigation: ${mismatched.join(", ")}`,
     ).toEqual([]);
 
-    const uncovered = [...navDistinctPaths].filter(
-      (p) => !inlinedPaths.has(p),
-    );
+    const uncovered = [...navDistinctPaths].filter((p) => !inlinedPaths.has(p));
     expect(
       uncovered,
       `navigation TAB_PATHS adds routes the audit does not cover: ${uncovered.join(", ")}`,

--- a/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
@@ -73,3 +73,39 @@ test("chat overlay: the attach control opens an image picker", async ({
   ]);
   expect(chooser).toBeTruthy();
 });
+
+test("chat overlay: transcript text is selectable and the old transcribe toggle is absent", async ({
+  page,
+}) => {
+  await openAppPath(page, "/chat");
+  const overlay = page.getByTestId("continuous-chat-overlay");
+  await expect(overlay).toBeVisible({ timeout: 60_000 });
+
+  await expect(page.getByTestId("chat-composer-transcribe")).toHaveCount(0);
+
+  const prompt = "show selectable transcript text";
+  const composer = page.getByTestId("chat-composer-textarea");
+  await composer.fill(prompt);
+  await page.getByTestId("chat-composer-action").click();
+
+  await expect(overlay).toHaveAttribute("data-open", "true", {
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId("thread-line").first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const selectable = page.locator('[data-chat-selectable="true"]').first();
+  await expect(selectable).toBeVisible();
+  await expect(selectable).toHaveCSS("user-select", "text");
+
+  const selectedText = await selectable.evaluate((node) => {
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    return selection?.toString() ?? "";
+  });
+  expect(selectedText.trim().length).toBeGreaterThan(0);
+});

--- a/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
+++ b/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
@@ -1,0 +1,197 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { CHAT_PREFILL_EVENT } from "../../../ui/src/events";
+import {
+  expectNoPageDiagnostics,
+  expectNoRenderTelemetryErrors,
+  installDefaultAppRoutes,
+  installPageDiagnosticsGuard,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+type RuntimeMetrics = {
+  jsHeapUsedSize: number;
+  jsHeapTotalSize: number;
+  nodes: number;
+  documents: number;
+  jsEventListeners: number;
+};
+
+const MI_B = 1024 * 1024;
+const ROUTE_SETTLE_MS = 120;
+const DEFAULT_ROUTE_CYCLES = 8;
+const MAX_ROUTE_CYCLES = 60;
+
+function parseRouteCycleCount(): number {
+  const raw = process.env.ELIZA_UI_SMOKE_MEMORY_CYCLES?.trim();
+  if (!raw) return DEFAULT_ROUTE_CYCLES;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_ROUTE_CYCLES;
+  return Math.min(parsed, MAX_ROUTE_CYCLES);
+}
+
+function metricMap(
+  metrics: Array<{ name: string; value: number }>,
+): Map<string, number> {
+  return new Map(metrics.map((metric) => [metric.name, metric.value]));
+}
+
+async function collectRuntimeMetrics(page: Page): Promise<RuntimeMetrics> {
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send("Performance.enable");
+    await session.send("HeapProfiler.enable").catch(() => {});
+    await session.send("HeapProfiler.collectGarbage").catch(() => {});
+    await page.waitForTimeout(150);
+    const { metrics } = await session.send("Performance.getMetrics");
+    const byName = metricMap(metrics);
+    return {
+      jsHeapUsedSize: byName.get("JSHeapUsedSize") ?? 0,
+      jsHeapTotalSize: byName.get("JSHeapTotalSize") ?? 0,
+      nodes: byName.get("Nodes") ?? 0,
+      documents: byName.get("Documents") ?? 0,
+      jsEventListeners: byName.get("JSEventListeners") ?? 0,
+    };
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+function growth(before: number, after: number): number {
+  return Math.max(0, after - before);
+}
+
+function expectBoundedRuntimeGrowth(
+  before: RuntimeMetrics,
+  after: RuntimeMetrics,
+): void {
+  const heapGrowth = growth(before.jsHeapUsedSize, after.jsHeapUsedSize);
+  const nodeGrowth = growth(before.nodes, after.nodes);
+  const listenerGrowth = growth(
+    before.jsEventListeners,
+    after.jsEventListeners,
+  );
+  const documentGrowth = growth(before.documents, after.documents);
+  const summary = JSON.stringify({ before, after }, null, 2);
+
+  expect(
+    heapGrowth,
+    `expected retained JS heap growth to stay bounded after repeated chat/view switching; metrics=${summary}`,
+  ).toBeLessThanOrEqual(96 * MI_B);
+  expect(
+    after.jsHeapUsedSize,
+    `expected final JS heap to stay near the warmed baseline; metrics=${summary}`,
+  ).toBeLessThanOrEqual(
+    Math.max(before.jsHeapUsedSize * 2.75, before.jsHeapUsedSize + 128 * MI_B),
+  );
+  expect(
+    nodeGrowth,
+    `expected DOM node growth to stay bounded after route cycles; metrics=${summary}`,
+  ).toBeLessThanOrEqual(8_000);
+  expect(
+    after.nodes,
+    `expected final DOM node count to stay near the warmed baseline; metrics=${summary}`,
+  ).toBeLessThanOrEqual(Math.max(before.nodes * 2.5, before.nodes + 12_000));
+  expect(
+    listenerGrowth,
+    `expected event-listener growth to stay bounded after route cycles; metrics=${summary}`,
+  ).toBeLessThanOrEqual(2_000);
+  expect(
+    documentGrowth,
+    `expected document count not to grow repeatedly across SPA route changes; metrics=${summary}`,
+  ).toBeLessThanOrEqual(8);
+}
+
+async function navigateInPlace(page: Page, targetPath: string): Promise<void> {
+  await page.evaluate((path) => {
+    window.history.pushState(null, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, targetPath);
+  await expect(page).toHaveURL(
+    new RegExp(
+      `${targetPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:[?#].*)?$`,
+    ),
+  );
+}
+
+async function waitForRoute(
+  page: Page,
+  targetPath: string,
+  marker: Locator,
+): Promise<void> {
+  await navigateInPlace(page, targetPath);
+  await expect(marker).toBeVisible({ timeout: 20_000 });
+  await page.waitForTimeout(ROUTE_SETTLE_MS);
+}
+
+async function prefillChat(page: Page, text: string): Promise<void> {
+  await page.evaluate(
+    ({ eventName, value }) => {
+      window.dispatchEvent(
+        new CustomEvent(eventName, {
+          detail: { text: value, select: true },
+        }),
+      );
+    },
+    { eventName: CHAT_PREFILL_EVENT, value: text },
+  );
+  await expect(page.getByTestId("chat-composer-textarea")).toHaveValue(text);
+}
+
+test.beforeEach(async ({ page }) => {
+  installPageDiagnosticsGuard(page);
+  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+  await installDefaultAppRoutes(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await expectNoPageDiagnostics(page, testInfo.title);
+  await expectNoRenderTelemetryErrors(page, testInfo.title);
+});
+
+test("chat and routed views keep heap, DOM, and listeners bounded", async ({
+  browserName,
+  page,
+}) => {
+  const routeCycles = parseRouteCycleCount();
+  test.setTimeout(Math.max(180_000, 45_000 + routeCycles * 8_000));
+  test.skip(
+    browserName !== "chromium",
+    "CDP runtime metrics are Chromium-only.",
+  );
+
+  const composer = page.getByTestId("chat-composer-textarea");
+  const calendar = page.getByTestId("calendar-view").first();
+  const documents = page.getByTestId("documents-view").first();
+  const taskCoordinator = page.getByTestId("task-coordinator-panel").first();
+
+  await openAppPath(page, "/chat");
+  await expect(composer).toBeVisible({ timeout: 20_000 });
+
+  // Warm each route once so the baseline includes normal lazy imports, cached
+  // plugin bundles, and first-render allocations. The measured cycles below
+  // then catch retained growth, not expected startup work.
+  await waitForRoute(page, "/calendar", calendar);
+  await waitForRoute(page, "/character/documents", documents);
+  await waitForRoute(page, "/task-coordinator", taskCoordinator);
+  await waitForRoute(page, "/chat", composer);
+  await prefillChat(page, "show my calendar");
+
+  const before = await collectRuntimeMetrics(page);
+
+  const prompts = [
+    "show my notes",
+    "what's on my calendar",
+    "I want to add a new feature to my app",
+  ];
+  for (let index = 0; index < routeCycles; index += 1) {
+    await waitForRoute(page, "/calendar", calendar);
+    await waitForRoute(page, "/character/documents", documents);
+    await waitForRoute(page, "/task-coordinator", taskCoordinator);
+    await waitForRoute(page, "/chat", composer);
+    await prefillChat(page, prompts[index % prompts.length]);
+  }
+
+  const after = await collectRuntimeMetrics(page);
+  expectBoundedRuntimeGrowth(before, after);
+});

--- a/packages/app/test/ui-smoke/helpers/screenshot-quality.ts
+++ b/packages/app/test/ui-smoke/helpers/screenshot-quality.ts
@@ -1,6 +1,11 @@
 import type { Page } from "@playwright/test";
 import sharp from "sharp";
 
+// Keep packaged Playwright workers deterministic and avoid retaining native
+// libvips caches after the screenshot quality checks finish.
+sharp.cache(false);
+sharp.concurrency(1);
+
 export interface ScreenshotQuality {
   width: number;
   height: number;

--- a/packages/app/test/ui-smoke/task-widget-in-chat.spec.ts
+++ b/packages/app/test/ui-smoke/task-widget-in-chat.spec.ts
@@ -1,6 +1,7 @@
 // End-to-end Playwright spec for the chat task widget contract:
-//   1. Boot the chat route with a mocked conversation backend.
-//   2. The seeded assistant message contains `[TASK:<uuid>]<title>[/TASK]`.
+//   1. Boot the app's real continuous-chat surface with a mocked backend.
+//   2. Send a user request through the composer and stream an assistant reply
+//      containing `[TASK:<uuid>]<title>[/TASK]`.
 //   3. `MessageContent` resolves the block to a TaskWidget that polls
 //      `client.getCodingAgentTaskThread` (mocked at `/api/coding-agents/...`).
 //   4. Clicking the widget dispatches `eliza:navigate:view` →
@@ -154,17 +155,18 @@ function statusFor(detail: JsonRecord) {
 }
 
 /**
- * Installs the minimal chat-backend mock for this spec. We pre-seed a single
- * assistant message whose text contains a `[TASK:<id>]title[/TASK]` block. The
- * default `installDefaultAppRoutes` covers all the orthogonal startup routes;
- * this helper only adds the chat-conversation surface itself.
+ * Installs the minimal chat-backend mock for this spec. The default
+ * `installDefaultAppRoutes` covers all the orthogonal startup routes; this
+ * helper only adds the chat-conversation surface and task detail endpoints.
  */
-async function installSeededChatRoutes(
+async function installTaskChatRoutes(
   page: Page,
   assistantText: string,
-): Promise<{ taskFetches: number }> {
+): Promise<{ taskFetches: number; streamRequests: string[] }> {
   const detail = taskDetail();
   let taskFetches = 0;
+  let sequence = 0;
+  const streamRequests: string[] = [];
   const conversation = {
     id: CONVERSATION_ID,
     roomId: ROOM_ID,
@@ -172,24 +174,14 @@ async function installSeededChatRoutes(
     updatedAt: NOW,
     createdAt: NOW,
   };
-  const messages = [
-    {
-      id: "seed-user-1",
-      role: "user" as const,
-      text: "Spin up the planner task.",
-      source: "eliza",
-      roomId: ROOM_ID,
-      timestamp: NOW_MS - 5_000,
-    },
-    {
-      id: "seed-assistant-1",
-      role: "assistant" as const,
-      text: assistantText,
-      source: "eliza",
-      roomId: ROOM_ID,
-      timestamp: NOW_MS - 2_000,
-    },
-  ];
+  const messages: Array<{
+    id: string;
+    role: "assistant" | "user";
+    text: string;
+    source: string;
+    roomId: string;
+    timestamp: number;
+  }> = [];
 
   await page.route("**/api/conversations**", async (route) => {
     const url = new URL(route.request().url());
@@ -234,15 +226,44 @@ async function installSeededChatRoutes(
   await page.route(
     `**/api/conversations/${CONVERSATION_ID}/messages/stream`,
     async (route) => {
-      // No-op stream — the spec only exercises the pre-seeded assistant turn.
+      const body = JSON.parse(route.request().postData() ?? "{}") as {
+        text?: string;
+      };
+      const userText = (body.text ?? "").trim();
+      streamRequests.push(userText);
+      sequence += 1;
+      messages.push(
+        {
+          id: `task-user-${sequence}`,
+          role: "user",
+          text: userText,
+          source: "eliza",
+          roomId: ROOM_ID,
+          timestamp: Date.now(),
+        },
+        {
+          id: `task-assistant-${sequence}`,
+          role: "assistant",
+          text: assistantText,
+          source: "eliza",
+          roomId: ROOM_ID,
+          timestamp: Date.now() + 1,
+        },
+      );
       await route.fulfill({
         status: 200,
         contentType: "text/event-stream",
-        body: `data: ${JSON.stringify({
-          type: "done",
-          fullText: "",
-          agentName: "Eliza",
-        })}\n\n`,
+        body:
+          `data: ${JSON.stringify({
+            type: "token",
+            text: assistantText,
+            fullText: assistantText,
+          })}\n\n` +
+          `data: ${JSON.stringify({
+            type: "done",
+            fullText: assistantText,
+            agentName: "Eliza",
+          })}\n\n`,
       });
     },
   );
@@ -314,7 +335,8 @@ async function installSeededChatRoutes(
     get taskFetches() {
       return taskFetches;
     },
-  } as { taskFetches: number };
+    streamRequests,
+  } as { taskFetches: number; streamRequests: string[] };
 }
 
 test.describe("chat task widget", () => {
@@ -324,15 +346,29 @@ test.describe("chat task widget", () => {
     await seedAppStorage(page);
     await installDefaultAppRoutes(page);
     const assistantText = `Created the task you asked for.\n\n[TASK:${TASK_ID}]${TASK_TITLE}[/TASK]\n\nThe builders are running.`;
-    const handles = await installSeededChatRoutes(page, assistantText);
+    const handles = await installTaskChatRoutes(page, assistantText);
 
     await openAppPath(page, "/chat");
 
-    // The pre-seeded assistant turn renders. Surrounding prose is preserved.
-    await expect(page.getByText("Created the task you asked for.")).toBeVisible(
-      { timeout: 30_000 },
-    );
-    await expect(page.getByText("The builders are running.")).toBeVisible();
+    const userPrompt = "Spin up the planner task.";
+    await page.getByTestId("chat-composer-textarea").fill(userPrompt);
+    await page.getByTestId("chat-composer-action").click();
+
+    await expect.poll(() => handles.streamRequests).toContain(userPrompt);
+
+    // The streamed assistant turn renders. Surrounding prose is preserved.
+    await expect(
+      page
+        .getByTestId("thread-line")
+        .filter({ hasText: "Created the task you asked for." })
+        .first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page
+        .getByTestId("thread-line")
+        .filter({ hasText: "The builders are running." })
+        .first(),
+    ).toBeVisible({ timeout: 30_000 });
 
     // The TASK block resolves into a TaskWidget. Title is the fetched title
     // (taskDetail() returns the same title as the fallback here), and the

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -42,6 +42,8 @@
 //     "views" and ViewRouter mounts the dynamic bundle whose heading is the view
 //     label ("Inbox" / "Calendar"). (navigation/index.ts:495, App.tsx
 //     findRemoteViewForRoute)
+//   * `/character/documents` maps to the built-in documents/knowledge subtab,
+//     which embeds DocumentsView inside CharacterEditor.
 //   * `/wallet` maps to the `inventory` tab (TAB_PATHS.inventory === "/wallet").
 //   * `/settings` maps to the `settings` tab (settings-shell).
 //   * `/task-coordinator` is the coding view (resolveIntentView maps app/feature
@@ -62,6 +64,7 @@ const CHAT_COMPOSER_SELECTOR =
   '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
 const CHAT_SEND_SELECTOR =
   '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]';
+const VIEW_SWITCH_URL_TIMEOUT_MS = LIVE_STACK ? 90_000 : 30_000;
 
 // The exact `eliza:navigate:view` detail the renderer's WS handler emits for a
 // plain `show`/navigate frame (startup-phase-hydrate.ts:417-442): a navigate
@@ -104,6 +107,22 @@ type ViewSwitchCase = {
    * assertion there.
    */
   onView?: (page: Page) => Locator;
+};
+
+type ApiViewSummary = {
+  id?: string;
+  path?: string;
+  viewType?: string;
+};
+
+type ApiViewsResponse = {
+  views?: ApiViewSummary[];
+};
+
+type ApiConversationResponse = {
+  conversation?: {
+    id?: string;
+  };
 };
 
 const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
@@ -175,6 +194,18 @@ const VIEW_SWITCH_CASES: readonly ViewSwitchCase[] = [
     // intent there). URL is the cross-mode-stable assertion; no separate testid
     // is asserted so the deterministic + live tiers stay identical.
     expectedPath: "/task-coordinator",
+  },
+  {
+    name: 'PASSIVE: "show my notes" opens the documents/notes view',
+    kind: "passive",
+    command: "show my notes",
+    view: {
+      id: "documents",
+      path: "/character/documents",
+      label: "Knowledge",
+    },
+    expectedPath: "/character/documents",
+    onView: (page) => page.getByTestId("documents-view").first(),
   },
   // --- Multilingual: the same navigate→render pipeline (deterministic tier) and
   // real-LLM routing (live tier) must work for non-English utterances. ---
@@ -378,11 +409,46 @@ function userMessage(page: Page, text: string): Locator {
 }
 
 /** Send a chat command through the real composer + send button. */
-async function sendChatCommand(page: Page, command: string): Promise<void> {
+async function sendChatCommand(
+  page: Page,
+  command: string,
+  expectedPath?: string,
+): Promise<void> {
   await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
   await chatComposer(page).fill(command);
   await expect(chatSendButton(page)).toBeEnabled();
   await chatSendButton(page).click();
+  // In the deterministic lane, the app cannot navigate until this spec
+  // dispatches the synthetic navigate event below, so the user turn must render
+  // in chat. In the live lane, a fast VIEWS action may switch away from chat
+  // before the chat log assertion observes the user bubble; the expected URL is
+  // equivalent proof that the command entered the chat -> agent -> view pipe.
+  if (LIVE_STACK && expectedPath) {
+    await expect
+      .poll(
+        async () => {
+          if (expectedPathRegExp(expectedPath).test(page.url())) {
+            return "view";
+          }
+          if (
+            await userMessage(page, command)
+              .isVisible()
+              .catch(() => false)
+          ) {
+            return "message";
+          }
+          return "";
+        },
+        {
+          timeout: 30_000,
+          message:
+            "Expected the sent chat command to render or navigate the live app.",
+        },
+      )
+      .not.toBe("");
+    return;
+  }
+
   // The user turn must render — proves the command actually entered the
   // chat/message pipeline (not just sat in the textarea).
   await expect(userMessage(page, command)).toBeVisible({ timeout: 30_000 });
@@ -409,17 +475,83 @@ async function assertViewSwitched(
   page: Page,
   testCase: ViewSwitchCase,
 ): Promise<void> {
-  await expect(page).toHaveURL(
-    new RegExp(`${escapeForRegExp(testCase.expectedPath)}(?:[?#]|$)`),
-    { timeout: 30_000 },
-  );
+  await expect(page).toHaveURL(expectedPathRegExp(testCase.expectedPath), {
+    timeout: VIEW_SWITCH_URL_TIMEOUT_MS,
+  });
   if (testCase.onView) {
     await expect(testCase.onView(page)).toBeVisible({ timeout: 60_000 });
   }
 }
 
+function expectedPathRegExp(expectedPath: string): RegExp {
+  return new RegExp(`${escapeForRegExp(expectedPath)}(?:[?#]|$)`);
+}
+
 function escapeForRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function liveRegisteredViewIds(page: Page): Promise<Set<string>> {
+  const response = await page.request.get("/api/views");
+  expect(response.ok(), "live runtime should expose /api/views").toBe(true);
+  const body = (await response.json()) as ApiViewsResponse;
+  return new Set(
+    (body.views ?? [])
+      .map((view) => (typeof view.id === "string" ? view.id : ""))
+      .filter(Boolean),
+  );
+}
+
+async function ensureLiveViewRegisteredForCase(
+  page: Page,
+  testCase: ViewSwitchCase,
+): Promise<void> {
+  if (!LIVE_STACK) return;
+
+  const registeredViewIds = await liveRegisteredViewIds(page);
+  test.skip(
+    !registeredViewIds.has(testCase.view.id),
+    `live runtime did not register view "${testCase.view.id}"`,
+  );
+}
+
+async function createAndActivateLiveConversationForCase(
+  page: Page,
+  testCase: ViewSwitchCase,
+): Promise<void> {
+  if (!LIVE_STACK) return;
+
+  const response = await page.evaluate(
+    async (payload) => {
+      const createResponse = await fetch("/api/conversations", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      return {
+        ok: createResponse.ok,
+        status: createResponse.status,
+        text: await createResponse.text(),
+      };
+    },
+    {
+      title: `view-switch: ${testCase.view.id}`,
+    },
+  );
+  expect(
+    response.ok,
+    `live runtime should create an isolated chat (status=${response.status}, body=${response.text.slice(0, 500)})`,
+  ).toBe(true);
+  const body = JSON.parse(response.text) as ApiConversationResponse;
+  const conversationId = body.conversation?.id?.trim();
+  expect(conversationId, "created live conversation id").toBeTruthy();
+
+  await page.evaluate((id) => {
+    localStorage.setItem("eliza:chat:activeConversationId", id);
+  }, conversationId);
+  await openAppPath(page, "/chat");
+  await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
 }
 
 test.beforeEach(async ({ page }) => {
@@ -431,10 +563,12 @@ test.beforeEach(async ({ page }) => {
 
 for (const testCase of VIEW_SWITCH_CASES) {
   test(testCase.name, async ({ page }) => {
+    await ensureLiveViewRegisteredForCase(page, testCase);
     await openAppPath(page, "/chat");
+    await createAndActivateLiveConversationForCase(page, testCase);
 
     // 1) Drive the real command surface: type + send the user's message.
-    await sendChatCommand(page, testCase.command);
+    await sendChatCommand(page, testCase.command, testCase.expectedPath);
 
     // 2) Reach the navigate. Live: the real agent broadcasts shell:navigate:view
     //    and the renderer switches on its own. Deterministic: the stub does not
@@ -518,4 +652,46 @@ test("agent close-view navigate returns to chat", async ({ page }) => {
 
   // The chat composer is the proof we returned to the chat surface.
   await expect(chatComposer(page)).toBeVisible({ timeout: 30_000 });
+});
+
+test("agent split-view navigate renders notes and calendar layout", async ({
+  page,
+}) => {
+  test.skip(
+    LIVE_STACK,
+    "split-layout resolution is covered by VIEWS action tests; this guards the renderer contract",
+  );
+  await openAppPath(page, "/chat");
+  await sendChatCommand(page, "split notes and calendar side by side");
+
+  await deliverAgentNavigate(page, {
+    action: "split-view",
+    viewId: "documents",
+    viewPath: "/character/documents",
+    viewLabel: "Knowledge",
+    viewType: "gui",
+    views: ["documents", "calendar"],
+    layout: "horizontal",
+  });
+
+  await expect(page).toHaveURL(/\/views(?:[?#]|$)/, {
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("view-layout-surface")).toBeVisible({
+    timeout: 60_000,
+  });
+  const documentsPane = page.getByTestId("view-layout-pane-documents");
+  const calendarPane = page.getByTestId("view-layout-pane-calendar");
+  await expect(documentsPane).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(calendarPane).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(documentsPane.getByTestId("documents-view")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(calendarPane.getByTestId("calendar-view")).toBeVisible({
+    timeout: 30_000,
+  });
 });

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -87,6 +87,25 @@ const calendarView = {
   viewType: "gui" as const,
 };
 
+const documentsView = {
+  id: "documents",
+  label: "Knowledge",
+  available: true,
+  pluginName: "@elizaos/plugin-documents",
+  path: "/documents",
+  bundleUrl: "/api/views/documents/bundle.js",
+  viewType: "gui" as const,
+};
+
+const mockAvailableViews = [
+  remoteLedgerView,
+  viewsManagerView,
+  viewsManagerTuiView,
+  notesView,
+  calendarView,
+  documentsView,
+];
+
 vi.mock("@capacitor/keyboard", () => ({
   Keyboard: { setScroll: vi.fn(async () => undefined) },
 }));
@@ -110,13 +129,10 @@ vi.mock("./hooks/useDesktopTabs", () => ({
 
 vi.mock("./hooks/useAvailableViews", () => ({
   useAvailableViews: () => ({
-    views: [
-      remoteLedgerView,
-      viewsManagerView,
-      viewsManagerTuiView,
-      notesView,
-      calendarView,
-    ],
+    views: mockAvailableViews,
+  }),
+  useRoutableViews: () => ({
+    views: mockAvailableViews,
   }),
 }));
 
@@ -154,13 +170,23 @@ vi.mock("./state", () => {
     actionNotice: null,
     activeGameViewerUrl: null,
     activeOverlayApp: null,
+    agentStatus: null,
     backendConnection: { state: "connected" },
+    cloudHandoffPhase: "idle",
+    copyToClipboard: vi.fn(),
+    databaseSubTab: "overview",
+    dismissActionBanner: vi.fn(),
+    dismissSystemWarning: vi.fn(),
+    elizaCloudConnected: false,
+    elizaCloudVoiceProxyAvailable: false,
     gameOverlayEnabled: false,
+    handlePluginToggle: vi.fn(),
     loadDropStatus: vi.fn(async () => undefined),
     firstRunComplete: true,
     ownerName: "Test Owner",
     plugins: [],
     retryStartup: vi.fn(),
+    setActionNotice: vi.fn(),
     setState: vi.fn(),
     setTab: appState.setTab,
     setUiLanguage: vi.fn(),
@@ -171,6 +197,7 @@ vi.mock("./state", () => {
       retry: vi.fn(),
     },
     startupError: null,
+    systemWarnings: [],
     tab: appState.tab,
     t: (_key: string, options?: { defaultValue?: string }) =>
       options?.defaultValue ?? "",
@@ -254,6 +281,17 @@ vi.mock("./components/chat/SaveCommandModal", () => ({
 vi.mock("./components/pages/ChatView", () => ({
   ChatView: () => <div data-testid="chat-view" />,
   __resetCompanionSpeechMemoryForTests: vi.fn(),
+}));
+
+vi.mock("./components/character/CharacterEditor", () => ({
+  CharacterEditor: ({ initialPage }: { initialPage?: string }) => (
+    <div
+      data-initial-page={initialPage ?? ""}
+      data-testid={
+        initialPage === "documents" ? "documents-view" : "character-editor"
+      }
+    />
+  ),
 }));
 
 vi.mock("./components/pages/ViewCatalog", () => ({
@@ -401,6 +439,36 @@ describe("App navigate-view event wiring", () => {
       loaders.map((loader) => loader.getAttribute("data-view-id")),
     ).toEqual(["notes", "calendar"]);
     expect(desktopTabsMock.openTab).toHaveBeenCalledWith(notesView, {
+      pinned: false,
+    });
+    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(calendarView, {
+      pinned: false,
+    });
+  });
+
+  it("renders registered documents bundles inside split-view when registry wins", async () => {
+    appState.tab = "views";
+    window.history.replaceState(null, "", "/views");
+
+    const { getAllByTestId, getByTestId } = render(<App />);
+
+    navigateView({
+      action: "split-view",
+      viewId: "documents",
+      views: ["documents", "calendar"],
+      layout: "horizontal",
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("view-layout-surface")).toBeTruthy();
+    });
+    expect(getByTestId("view-layout-pane-documents")).toBeTruthy();
+    expect(
+      getAllByTestId("dynamic-view-loader").map((loader) =>
+        loader.getAttribute("data-view-id"),
+      ),
+    ).toEqual(["documents", "calendar"]);
+    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(documentsView, {
       pinned: false,
     });
     expect(desktopTabsMock.openTab).toHaveBeenCalledWith(calendarView, {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -85,7 +85,10 @@ import {
   isAndroidPhoneSurfaceEnabled,
   isAospShellEnabled,
   isRouteRootPath,
+  pathForTab,
   shouldUseHashNavigation,
+  TAB_PATHS,
+  tabFromPath,
 } from "./navigation";
 import { isIOS, isNative } from "./platform/init";
 import { RetainedLazyComponent } from "./retained-lazy";
@@ -149,6 +152,7 @@ import { FineTuningView } from "./components/training/injected";
 import { DynamicViewLoader } from "./components/views/DynamicViewLoader";
 import {
   useAvailableViews,
+  useRoutableViews,
   type ViewRegistryEntry,
 } from "./hooks/useAvailableViews";
 import { useDesktopTabs } from "./hooks/useDesktopTabs";
@@ -703,6 +707,7 @@ function remoteViewMatchesTab(
 const SHELL_RESERVED_PATHS = new Set([
   "/views",
   "/apps",
+  "/character/documents",
   "/apps/plugins",
   "/apps/skills",
   "/apps/trajectories",
@@ -714,6 +719,8 @@ const SHELL_RESERVED_PATHS = new Set([
   "/apps/tasks",
 ]);
 
+const SHELL_RESERVED_TABS = new Set(Object.keys(TAB_PATHS));
+
 function findRemoteViewForRoute(
   views: ViewRegistryEntry[],
   navigationPath: string,
@@ -722,6 +729,9 @@ function findRemoteViewForRoute(
 ): ViewRegistryEntry | undefined {
   const normalizedPath = trimmedNavigationPath(navigationPath);
   if (SHELL_RESERVED_PATHS.has(normalizedPath)) return undefined;
+  if (tab !== "views" && tab !== "apps" && SHELL_RESERVED_TABS.has(tab)) {
+    return undefined;
+  }
   return (
     views.find(
       (view) => remoteViewAvailable(view) && view.path === normalizedPath,
@@ -781,6 +791,19 @@ function ViewLayoutSurface({
     .filter((view): view is ViewRegistryEntry => Boolean(view));
   const paneClassName =
     "flex min-h-[18rem] min-w-0 flex-col overflow-hidden border border-border/45 bg-bg";
+  const routeOverrideForView = (
+    view: ViewRegistryEntry,
+  ): ViewRouterRouteOverride => {
+    const navigationPath =
+      view.path ??
+      (SHELL_RESERVED_TABS.has(view.id)
+        ? pathForTab(view.id)
+        : `/apps/${view.id}`);
+    return {
+      navigationPath,
+      tab: tabFromPath(navigationPath) ?? view.id,
+    };
+  };
 
   return (
     <TabContentView>
@@ -835,9 +858,7 @@ function ViewLayoutSurface({
                       viewType={view.viewType}
                     />
                   ) : (
-                    <div className="flex h-full min-h-0 items-center justify-center px-4 text-center text-sm text-muted">
-                      {view.label} is not available as a dynamic view.
-                    </div>
+                    <ViewRouter routeOverride={routeOverrideForView(view)} />
                   )}
                 </div>
               </section>
@@ -1020,7 +1041,9 @@ function renderStaticViewRouterTab({
   ) {
     return (
       <TabContentView>
-        <CharacterEditor />
+        <CharacterEditor
+          initialPage={tab === "documents" ? "documents" : undefined}
+        />
       </TabContentView>
     );
   }
@@ -1091,17 +1114,28 @@ function renderViewRouterContent({
   });
 }
 
+type ViewRouterRouteOverride = {
+  tab: string;
+  navigationPath: string;
+};
+
 function ViewRouter({
+  routeOverride,
   settingsInitialSection,
 }: {
+  routeOverride?: ViewRouterRouteOverride;
   settingsInitialSection?: string | null;
 }) {
-  const tab = useAppSelector((s) => s.tab);
+  const activeTab = useAppSelector((s) => s.tab);
+  const tab = routeOverride?.tab ?? activeTab;
   const androidPhoneSurfaceEnabled = isAndroidPhoneSurfaceEnabled();
   const dynamicPage = useResolvedDynamicPage(tab);
-  const [navigationPath, setNavigationPath] = useState(() =>
-    typeof window === "undefined" ? "/" : getWindowNavigationPath(),
+  const [navigationPath, setNavigationPath] = useState(
+    () =>
+      routeOverride?.navigationPath ??
+      (typeof window === "undefined" ? "/" : getWindowNavigationPath()),
   );
+  const routeOverridePath = routeOverride?.navigationPath;
   const appSlug =
     tab === "apps" || tab === "views"
       ? getAppSlugFromPath(navigationPath)
@@ -1110,6 +1144,10 @@ function ViewRouter({
   const enabledKinds = useEnabledViewKinds();
 
   useEffect(() => {
+    if (routeOverridePath) {
+      setNavigationPath(routeOverridePath);
+      return;
+    }
     if (typeof window === "undefined") return;
     const navEvt = shouldUseHashNavigation() ? "hashchange" : "popstate";
     const handleNavigationChange = () => {
@@ -1117,7 +1155,7 @@ function ViewRouter({
     };
     window.addEventListener(navEvt, handleNavigationChange);
     return () => window.removeEventListener(navEvt, handleNavigationChange);
-  }, []);
+  }, [routeOverridePath]);
 
   // Available views from /api/views — used to route to DynamicViewLoader
   // when a tab ID matches a view entry that ships a remote bundle URL.
@@ -1534,7 +1572,7 @@ export function App() {
   const [activeDesktopTabId, setActiveDesktopTabId] = useState<string | null>(
     null,
   );
-  const { views: availableViewsForDesktopTabs } = useAvailableViews();
+  const { views: availableViewsForDesktopTabs } = useRoutableViews();
   const [viewLayout, setViewLayout] = useState<ActiveViewLayout | null>(null);
 
   const [editingAction, setEditingAction] = useState<

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
+
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ElizaClient } from "./client-base";
+import { NETWORK_STATUS_CHANGE_EVENT } from "../events";
+import { __resetNetworkStatusForTests, ElizaClient } from "./client-base";
 
 function stubWebSocket(): string[] {
   const createdUrls: string[] = [];
@@ -48,9 +51,14 @@ function stubWebSocketWithInstances(): FakeWs[] {
   return instances;
 }
 
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    __resetNetworkStatusForTests();
   });
 
   it("treats shared-runtime REST adapter bases as connected without opening a websocket", () => {
@@ -129,5 +137,137 @@ describe("ElizaClient websocket connection policy", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("replays an early shell navigation frame when the handler attaches after the frame arrives", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+
+    instances[0].onmessage?.({
+      data: JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+      }),
+    });
+
+    const received: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => received.push(data));
+    await flushMicrotasks();
+
+    expect(received).toEqual([
+      {
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+      },
+    ]);
+  });
+
+  it("keeps an early shell navigation frame if the first handler unsubscribes before replay", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+
+    instances[0].onmessage?.({
+      data: JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+      }),
+    });
+
+    const firstHandler = vi.fn();
+    const unsubscribeFirst = client.onWsEvent(
+      "shell:navigate:view",
+      firstHandler,
+    );
+    unsubscribeFirst();
+    await flushMicrotasks();
+
+    const received: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => received.push(data));
+    await flushMicrotasks();
+
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(received).toEqual([
+      {
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+      },
+    ]);
+  });
+
+  it("does not replay an early shell navigation frame after it has been delivered", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+
+    instances[0].onmessage?.({
+      data: JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+      }),
+    });
+
+    const firstReceived: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => firstReceived.push(data));
+    await flushMicrotasks();
+
+    const secondReceived: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) =>
+      secondReceived.push(data),
+    );
+    await flushMicrotasks();
+
+    expect(firstReceived).toHaveLength(1);
+    expect(secondReceived).toEqual([]);
+  });
+
+  it("does not replay ordinary websocket frames that arrived before a handler attached", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+
+    instances[0].onmessage?.({
+      data: JSON.stringify({
+        type: "status",
+        state: "running",
+      }),
+    });
+
+    const received: Record<string, unknown>[] = [];
+    client.onWsEvent("status", (data) => received.push(data));
+    await flushMicrotasks();
+
+    expect(received).toEqual([]);
+  });
+
+  it("removes a parked network-status reconnect wake on intentional disconnect", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+
+    client.connectWs();
+    expect(instances).toHaveLength(1);
+
+    document.dispatchEvent(
+      new CustomEvent(NETWORK_STATUS_CHANGE_EVENT, {
+        detail: { connected: false },
+      }),
+    );
+    instances[0].onclose?.();
+
+    client.disconnectWs();
+    document.dispatchEvent(
+      new CustomEvent(NETWORK_STATUS_CHANGE_EVENT, {
+        detail: { connected: true },
+      }),
+    );
+
+    expect(instances).toHaveLength(1);
+    expect(client.getConnectionState().state).toBe("disconnected");
   });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -61,6 +61,8 @@ const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   "www.elizacloud.ai",
   "dev.elizacloud.ai",
 ]);
+const REPLAYABLE_WS_EVENT_TYPES = new Set(["shell:navigate:view"]);
+const WS_EVENT_BACKLOG_LIMIT = 8;
 
 type StreamChatEvent = {
   type?: string;
@@ -446,6 +448,7 @@ export class ElizaClient {
   private requestTransport: AgentRequestTransport = fetchAgentTransport;
   private ws: WebSocket | null = null;
   private wsHandlers = new Map<string, Set<WsEventHandler>>();
+  private wsEventBacklog = new Map<string, Record<string, unknown>[]>();
   private wsSendQueue: string[] = [];
   private readonly wsSendQueueLimit = 32;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -962,6 +965,47 @@ export class ElizaClient {
 
   // --- WebSocket ---
 
+  private rememberReplayableWsEvent(
+    type: string,
+    data: Record<string, unknown>,
+  ): void {
+    if (!REPLAYABLE_WS_EVENT_TYPES.has(type)) return;
+    const backlog = this.wsEventBacklog.get(type) ?? [];
+    backlog.push(data);
+    if (backlog.length > WS_EVENT_BACKLOG_LIMIT) {
+      backlog.splice(0, backlog.length - WS_EVENT_BACKLOG_LIMIT);
+    }
+    this.wsEventBacklog.set(type, backlog);
+  }
+
+  private replayBackloggedWsEvents(
+    type: string,
+    handler: WsEventHandler,
+  ): void {
+    const backlog = this.wsEventBacklog.get(type);
+    if (!backlog?.length) return;
+    const pending = backlog.slice();
+    queueMicrotask(() => {
+      if (!this.wsHandlers.get(type)?.has(handler)) return;
+      for (const data of pending) {
+        try {
+          handler(data);
+        } catch {
+          // Match normal WS dispatch: a handler error must not poison replay.
+        }
+      }
+      const current = this.wsEventBacklog.get(type);
+      if (!current?.length) return;
+      const delivered = new Set(pending);
+      const remaining = current.filter((data) => !delivered.has(data));
+      if (remaining.length > 0) {
+        this.wsEventBacklog.set(type, remaining);
+      } else {
+        this.wsEventBacklog.delete(type);
+      }
+    });
+  }
+
   connectWs(): void {
     if (shouldTreatAsConnectedWithoutWebSocket(this.baseUrl)) {
       this.backoffMs = 500;
@@ -1086,10 +1130,12 @@ export class ElizaClient {
         >;
         const type = data.type as string;
         const handlers = this.wsHandlers.get(type);
-        if (handlers) {
+        if (handlers?.size) {
           for (const handler of handlers) {
             handler(data);
           }
+        } else {
+          this.rememberReplayableWsEvent(type, data);
         }
         // Also fire "all" handlers
         const allHandlers = this.wsHandlers.get("*");
@@ -1290,6 +1336,7 @@ export class ElizaClient {
       this.wsHandlers.set(type, new Set());
     }
     this.wsHandlers.get(type)?.add(handler);
+    this.replayBackloggedWsEvents(type, handler);
     return () => {
       this.wsHandlers.get(type)?.delete(handler);
     };
@@ -1307,6 +1354,7 @@ export class ElizaClient {
     this.ws?.close();
     this.ws = null;
     this.wsSendQueue = [];
+    this.wsEventBacklog.clear();
     // Reset connection state on intentional disconnect
     this.reconnectAttempt = 0;
     this.disconnectedAt = null;

--- a/packages/ui/src/api/desktop-http-transport.test.ts
+++ b/packages/ui/src/api/desktop-http-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMock = vi.hoisted(() => ({
   isElectrobunRuntime: vi.fn(),
@@ -14,6 +14,10 @@ vi.mock("../bridge/electrobun-rpc", () => bridgeMock);
 import { desktopHttpTransportForUrl } from "./desktop-http-transport";
 
 describe("desktopHttpTransportForUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("uses the desktop RPC bridge for external plain HTTP URLs", async () => {
     runtimeMock.isElectrobunRuntime.mockReturnValue(true);
     const desktopHttpRequest = vi.fn().mockResolvedValue({
@@ -44,7 +48,39 @@ describe("desktopHttpTransportForUrl", () => {
     await expect(response?.json()).resolves.toEqual({ ok: true });
   });
 
-  it("leaves local HTTP and HTTPS URLs on the regular fetch path", () => {
+  it("uses the desktop RPC bridge for the configured external desktop API base even when it is loopback", async () => {
+    runtimeMock.isElectrobunRuntime.mockReturnValue(true);
+    vi.stubGlobal("window", {
+      __ELIZA_DESKTOP_EXTERNAL_API_BASE__: "http://127.0.0.1:2138",
+    });
+    const desktopHttpRequest = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"ok":true}',
+    });
+    const request = { desktopHttpRequest };
+    bridgeMock.getElectrobunRendererRpc.mockReturnValue({ request });
+
+    const transport = desktopHttpTransportForUrl("http://127.0.0.1:2138");
+    expect(transport).not.toBeNull();
+
+    const response = await transport?.request(
+      "http://127.0.0.1:2138/api/config",
+      {},
+      { timeoutMs: 1234 },
+    );
+
+    expect(desktopHttpRequest).toHaveBeenCalledWith({
+      url: "http://127.0.0.1:2138/api/config",
+      method: "GET",
+      headers: {},
+      body: null,
+      timeoutMs: 1234,
+    });
+    expect(response?.status).toBe(200);
+  });
+
+  it("leaves unconfigured local HTTP and HTTPS URLs on the regular fetch path", () => {
     runtimeMock.isElectrobunRuntime.mockReturnValue(true);
 
     expect(desktopHttpTransportForUrl("http://127.0.0.1:2138")).toBeNull();

--- a/packages/ui/src/api/desktop-http-transport.ts
+++ b/packages/ui/src/api/desktop-http-transport.ts
@@ -29,6 +29,29 @@ function isExternalPlainHttpUrl(url: string): boolean {
   }
 }
 
+function getConfiguredExternalApiBaseOrigin(): string | null {
+  if (typeof window === "undefined") return null;
+  const value = (window as { __ELIZA_DESKTOP_EXTERNAL_API_BASE__?: unknown })
+    .__ELIZA_DESKTOP_EXTERNAL_API_BASE__;
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" ? parsed.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+function isConfiguredExternalApiBaseUrl(url: string): boolean {
+  const allowedOrigin = getConfiguredExternalApiBaseOrigin();
+  if (!allowedOrigin) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" && parsed.origin === allowedOrigin;
+  } catch {
+    return false;
+  }
+}
 const desktopHttpTransport: AgentRequestTransport = {
   async request(url, init, context) {
     const rpc = getElectrobunRendererRpc();
@@ -66,7 +89,8 @@ const desktopHttpTransport: AgentRequestTransport = {
 export function desktopHttpTransportForUrl(
   url: string,
 ): AgentRequestTransport | null {
-  return isElectrobunRuntime() && isExternalPlainHttpUrl(url)
+  return isElectrobunRuntime() &&
+    (isExternalPlainHttpUrl(url) || isConfiguredExternalApiBaseUrl(url))
     ? desktopHttpTransport
     : null;
 }

--- a/packages/ui/src/app-navigate-view.test.ts
+++ b/packages/ui/src/app-navigate-view.test.ts
@@ -225,7 +225,7 @@ describe("App navigate-view shell handler", () => {
       placement: "right",
     });
     expect(fixture.setTab).toHaveBeenCalledWith("views");
-    expect(fixture.navigatePath).toHaveBeenCalledWith("/notes");
+    expect(fixture.navigatePath).toHaveBeenCalledWith("/views");
   });
 
   it("opens a managed app window through the desktop bridge", async () => {

--- a/packages/ui/src/app-navigate-view.ts
+++ b/packages/ui/src/app-navigate-view.ts
@@ -189,7 +189,6 @@ export function createNavigateViewHandler({
     if (detail.action === "split-view" || detail.action === "tile-views") {
       const viewIds = layoutViewIdsForDetail(detail);
       const resolvedViewIds: string[] = [];
-      let primaryPath: string | null = detail.viewPath ?? null;
       for (const viewId of viewIds) {
         const entry = desktopEntryForDetail(
           availableViewsForDesktopTabs,
@@ -199,7 +198,6 @@ export function createNavigateViewHandler({
         resolvedViewIds.push(entry.id);
         recordRecentViewId(entry.id);
         openDesktopTab(entry, { pinned: false });
-        primaryPath ??= entry.path ?? `/apps/${entry.id}`;
       }
       const primaryViewId = viewIds[0] ?? detail.viewId ?? null;
       if (primaryViewId) setActiveDesktopTabId(primaryViewId);
@@ -210,7 +208,7 @@ export function createNavigateViewHandler({
         placement: detail.placement,
       });
       setTab("views");
-      if (primaryPath) navigatePath(primaryPath);
+      navigatePath("/views");
       return;
     }
     const path = pathForNavigateViewDetail(detail);

--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -249,10 +249,12 @@ function CharacterAgentButton({
 /* ── Component ─────────────────────────────────────────────────────── */
 
 export function CharacterEditor({
+  initialPage,
   sceneOverlay = false,
   inModal: _inModal = false,
   onHeaderActionsChange,
 }: {
+  initialPage?: CharacterEditorPage;
   sceneOverlay?: boolean;
   inModal?: boolean;
   onHeaderActionsChange?: (actions: ReactNode | null) => void;
@@ -361,7 +363,7 @@ export function CharacterEditor({
   );
 
   const [activePage, setActivePage] = useState<CharacterEditorPage>(
-    tab === "documents" ? "documents" : "personality",
+    initialPage ?? (tab === "documents" ? "documents" : "personality"),
   );
   const [rightTab, setRightTab] = useState<"style" | "examples">("style");
   const [customizing, setCustomizing] = useState(false);
@@ -378,12 +380,17 @@ export function CharacterEditor({
     else if (activePage === "examples") setRightTab("examples");
   }, [activePage]);
 
-  // Sync activePage when tab changes externally (e.g. nav to /documents)
+  // Sync activePage when tab changes externally (e.g. nav to /documents) or
+  // when an embedded router renders a specific built-in subpage in split view.
   useEffect(() => {
+    if (initialPage && activePage !== initialPage) {
+      setActivePage(initialPage);
+      return;
+    }
     if (tab === "documents" && activePage !== "documents") {
       setActivePage("documents");
     }
-  }, [tab, activePage]);
+  }, [initialPage, tab, activePage]);
 
   /* ── Style entry state ──────────────────────────────────────────── */
   const [pendingStyleEntries, setPendingStyleEntries] = useState<
@@ -1444,6 +1451,11 @@ export function CharacterEditor({
           {/* ── Standalone page: character hub */}
           {!sceneOverlay && (
             <CharacterHubView
+              initialSection={
+                initialPage === "documents" || initialPage === "personality"
+                  ? initialPage
+                  : undefined
+              }
               d={d}
               bioText={bioText}
               normalizedMessageExamples={normalizedMessageExamples}

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -160,6 +160,7 @@ function writeHubCache<T>(suffix: string, value: T): void {
 }
 
 export function CharacterHubView({
+  initialSection,
   d,
   bioText,
   normalizedMessageExamples,
@@ -176,6 +177,7 @@ export function CharacterHubView({
   hasPendingChanges,
   onSave,
 }: {
+  initialSection?: CharacterHubSection;
   d: CharacterData;
   bioText: string;
   normalizedMessageExamples: MessageExampleGroup[];
@@ -203,8 +205,8 @@ export function CharacterHubView({
     tab: s.tab,
     t: s.t,
   }));
-  const [activeSection, setActiveSection] = useState<CharacterHubSection>(() =>
-    getSectionFromLocation(tab),
+  const [activeSection, setActiveSection] = useState<CharacterHubSection>(
+    () => initialSection ?? getSectionFromLocation(tab),
   );
   const [documentRecords, setDocumentRecords] = useState<DocumentRecord[]>(() =>
     readHubCache<DocumentRecord[]>("documents", []),
@@ -300,10 +302,15 @@ export function CharacterHubView({
   }, [flushPendingAutoSave]);
 
   useEffect(() => {
+    if (initialSection) {
+      setActiveSection(initialSection);
+      return;
+    }
     setActiveSection(getSectionFromLocation(tab));
-  }, [tab]);
+  }, [initialSection, tab]);
 
   useEffect(() => {
+    if (initialSection) return;
     const syncSectionFromLocation = () => {
       setActiveSection(getSectionFromLocation(tab));
     };
@@ -313,7 +320,7 @@ export function CharacterHubView({
       window.removeEventListener("popstate", syncSectionFromLocation);
       window.removeEventListener("hashchange", syncSectionFromLocation);
     };
-  }, [tab]);
+  }, [initialSection, tab]);
 
   useEffect(() => {
     let cancelled = false;
@@ -711,6 +718,7 @@ export function CharacterHubView({
   const navigateToSection = useCallback(
     (section: CharacterHubSection) => {
       setActiveSection(section);
+      if (initialSection) return;
       if (section === "documents") {
         if (tab !== "documents") {
           setTab("documents");
@@ -721,7 +729,7 @@ export function CharacterHubView({
       }
       updateCharacterSectionPath(section);
     },
-    [setTab, tab],
+    [initialSection, setTab, tab],
   );
 
   const handleOverviewOpenSection = (

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -43,6 +43,7 @@ import type {
   AutomationListResponse,
 } from "../../api/client-types-config";
 import { isApiError } from "../../api/client-types-core";
+import { dispatchChatPrefill } from "../../events";
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { useAutomationDeepLink } from "../../hooks/useAutomationDeepLink";
 import { useFetchData } from "../../hooks/useFetchData";
@@ -105,7 +106,6 @@ const FILTER_ICONS: Record<FeedFilter, ReactNode> = {
   inactive: <CircleSlash className="h-3.5 w-3.5" aria-hidden />,
 };
 const NEW_AUTOMATION_LINK_ID = "__new__";
-const CHAT_PREFILL_EVENT = "eliza:chat:prefill";
 const NEW_AUTOMATION_PROMPT = "Create an automation that ";
 
 // On mobile the workflow runtime (and its `GET /api/automations` route) is
@@ -201,12 +201,7 @@ export function AutomationsFeed({
   const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map());
 
   const focusAutomationChat = useCallback(() => {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(
-      new CustomEvent(CHAT_PREFILL_EVENT, {
-        detail: { text: NEW_AUTOMATION_PROMPT, select: false },
-      }),
-    );
+    dispatchChatPrefill({ text: NEW_AUTOMATION_PROMPT, select: false });
   }, []);
 
   const newAgent = useAgentElement<HTMLButtonElement>({

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -39,6 +39,7 @@ import type {
   WorkflowExecution,
   WorkflowRevision,
 } from "../../api/client-types-chat";
+import { dispatchChatPrefill } from "../../events";
 import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 import {
   buildWorkflowExecutionDiagnostics,
@@ -57,8 +58,6 @@ import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
 import { StatusBadge } from "../ui/status-badge";
 import { WorkflowGraphViewer } from "./WorkflowGraphViewer";
-
-const CHAT_PREFILL_EVENT = "eliza:chat:prefill";
 
 export interface WorkflowEditorProps {
   initial?: WorkflowDefinition | null;
@@ -365,26 +364,21 @@ export function WorkflowEditor({
   }, [selectedExecution]);
 
   const handleTroubleshootInChat = useCallback(() => {
-    if (!selectedExecution || typeof window === "undefined") return;
+    if (!selectedExecution) return;
     const workflowId =
       persistedWorkflowId ?? selectedExecution.workflowId ?? "unknown";
     const diagnostics = buildWorkflowExecutionDiagnostics(selectedExecution);
-    window.dispatchEvent(
-      new CustomEvent(CHAT_PREFILL_EVENT, {
-        detail: {
-          text: [
-            `Troubleshoot workflow ${workflowId} execution ${selectedExecution.id}.`,
-            "",
-            diagnostics,
-          ].join("\n"),
-          select: false,
-        },
-      }),
-    );
+    dispatchChatPrefill({
+      text: [
+        `Troubleshoot workflow ${workflowId} execution ${selectedExecution.id}.`,
+        "",
+        diagnostics,
+      ].join("\n"),
+      select: false,
+    });
   }, [persistedWorkflowId, selectedExecution]);
 
   const handleEditInChat = useCallback(() => {
-    if (typeof window === "undefined") return;
     const workflowName = lastValidWorkflow?.name ?? "this workflow";
     const workflowId =
       persistedWorkflowId ?? lastValidWorkflow?.id ?? initial?.id ?? "draft";
@@ -392,14 +386,7 @@ export function WorkflowEditor({
       workflowId === "draft"
         ? "Create a workflow that "
         : `Modify workflow ${workflowId} (${workflowName}). `;
-    window.dispatchEvent(
-      new CustomEvent(CHAT_PREFILL_EVENT, {
-        detail: {
-          text,
-          select: false,
-        },
-      }),
-    );
+    dispatchChatPrefill({ text, select: false });
   }, [initial?.id, lastValidWorkflow, persistedWorkflowId]);
 
   const handleCopyEvaluationSamples = useCallback(async () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -28,8 +29,8 @@ vi.mock("../../utils/clipboard", () => ({
   copyTextToClipboard: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { CHAT_PREFILL_EVENT } from "../../events";
 import { copyTextToClipboard } from "../../utils/clipboard";
-
 import { ContinuousChatOverlay } from "./ContinuousChatOverlay";
 import type { ShellController } from "./useShellController";
 
@@ -56,21 +57,24 @@ function makeController(
     turnStatus: null,
     recording: false,
     transcript: "",
+    transcriptionMode: false,
     // Required ShellController surface the overlay reads unconditionally — the
     // real controller always supplies these, so the mock must too.
     modelStatus: { kind: "ready" },
     send: vi.fn(),
     stop: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
     toggleRecording: vi.fn(),
     handsFree: false,
     toggleHandsFree: vi.fn(),
+    toggleTranscriptionMode: vi.fn(),
+    // A mic tap while transcribing routes through this master voice control.
+    stopTranscriptionAndMic: vi.fn(),
     setDictationSink: vi.fn(),
     setTranscriptSessionSink: vi.fn(),
     setComposerHasDraft: vi.fn(),
     clearConversation: vi.fn(),
-    // A mic tap while transcribing routes through this (the mic is the master
-    // voice control); the real controller always supplies it, so the mock must.
-    stopTranscriptionAndMic: vi.fn(),
     ...overrides,
   } as unknown as ShellController;
 }
@@ -123,6 +127,56 @@ describe("ContinuousChatOverlay", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     expect(vi.mocked(controller.send).mock.calls[0]?.[0]).toBe("ping");
     expect(input.value).toBe("");
+  });
+
+  it("prefills and focuses the composer from the shared chat prefill event", async () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const input = screen.getByLabelText("message") as HTMLInputElement;
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(CHAT_PREFILL_EVENT, {
+          detail: { text: "Show my agent workspace status.", select: true },
+        }),
+      );
+    });
+
+    expect(input.value).toBe("Show my agent workspace status.");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it("cancels pending prefill focus work on unmount", () => {
+    const requestFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation(() => 42);
+    const cancelFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+    try {
+      const { unmount } = render(
+        <ContinuousChatOverlay controller={makeController()} />,
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(CHAT_PREFILL_EVENT, {
+            detail: {
+              text: "Show my agent workspace status.",
+              select: true,
+            },
+          }),
+        );
+      });
+
+      expect(requestFrame).toHaveBeenCalledTimes(1);
+      unmount();
+      expect(cancelFrame).toHaveBeenCalledWith(42);
+    } finally {
+      requestFrame.mockRestore();
+      cancelFrame.mockRestore();
+    }
   });
 
   it("opens the sheet when the composer input is focused (type-to-open)", () => {
@@ -213,6 +267,39 @@ describe("ContinuousChatOverlay", () => {
     expect(sheet.getAttribute("data-detent")).toBe("half");
     pull(280, 420); // down → COLLAPSED
     expect(sheet.getAttribute("data-detent")).toBe("collapsed");
+  });
+
+  it("cancels delayed header navigation when unmounted before the close animation finishes", () => {
+    vi.useFakeTimers();
+    try {
+      const navigateHome = vi.fn();
+      const { unmount } = render(
+        <ContinuousChatOverlay
+          controller={makeController({
+            currentTab: "settings",
+            navigateHome,
+          } as unknown as Partial<ShellController>)}
+        />,
+      );
+      const grabber = screen.getByTestId("chat-sheet-grabber");
+      const pull = (fromY: number, toY: number) => {
+        fireEvent.pointerDown(grabber, { clientY: fromY, pointerId: 1 });
+        fireEvent.pointerMove(grabber, { clientY: toY, pointerId: 1 });
+        fireEvent.pointerUp(grabber, { clientY: toY, pointerId: 1 });
+      };
+      pull(420, 280); // collapsed → half
+      expect(screen.getByTestId("chat-full-home")).toBeTruthy();
+      fireEvent.click(screen.getByTestId("chat-full-home"));
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(navigateHome).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("opens on a fast flick even below the distance threshold (velocity)", () => {
@@ -639,6 +726,40 @@ describe("ContinuousChatOverlay", () => {
     }
   });
 
+  it("keeps chat message text selectable for normal highlight/copy", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: [
+            {
+              id: "u",
+              role: "user",
+              content: "copy my question",
+              createdAt: 1,
+            },
+            {
+              id: "a",
+              role: "assistant",
+              content: "copy my answer",
+              createdAt: 2,
+            },
+          ],
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+
+    for (const text of ["copy my question", "copy my answer"]) {
+      const textNode = screen.getByText(text);
+      const bubble = screen
+        .getByText(text)
+        .closest('[data-testid="thread-line"]')
+        ?.querySelector("div") as HTMLElement;
+      expect(bubble.className).toContain("select-text");
+      expect(bubble.className).not.toContain("select-none");
+      expect(textNode.closest('[data-chat-selectable="true"]')).toBeTruthy();
+    }
+  });
+
   it("a quick tap (released before the hold threshold) does NOT copy", () => {
     vi.useFakeTimers();
     try {
@@ -804,63 +925,36 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getByTestId("chat-composer-textarea")).toBeTruthy();
   });
 
-  // ── Transcribe button lives in the composer beside the mic, gated on voice
-  // being on (#8789). It's part of the always-present composer trailing cluster,
-  // so it shows at any detent (no need to open the sheet header).
-  it("hides the transcribe button while voice is off", () => {
+  it("does not render a separate transcribe button in the composer", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    // The mic is present, but with no active voice session the transcribe
-    // control is not offered next to it.
     expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
     expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
-    expect(screen.queryByTestId("chat-transcribing-badge")).toBeNull();
   });
 
-  it("reveals the transcribe button beside the mic while a hands-free voice session is active", () => {
+  it("keeps the composer transcribe button hidden during voice capture", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
           handsFree: true,
-          transcriptionMode: false,
-          toggleTranscriptionMode: vi.fn(),
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    const btn = screen.getByTestId("chat-composer-transcribe");
-    expect(btn.getAttribute("aria-label")).toBe("transcription mode");
-    expect(btn.getAttribute("aria-pressed")).toBe("false");
-    // It sits next to the mic (both in the composer trailing cluster).
-    expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
-  });
-
-  it("reveals the transcribe button while the mic is open (push-to-talk recording)", () => {
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
           phase: "listening",
           recording: true,
-          toggleTranscriptionMode: vi.fn(),
         } as unknown as Partial<ShellController>)}
       />,
     );
-    expect(screen.getByTestId("chat-composer-transcribe")).toBeTruthy();
+    expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
+    expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
   });
 
-  it("shows the transcribe button as Stop (pressed) while transcribing, and wires the toggle", () => {
-    const toggleTranscriptionMode = vi.fn();
+  it("shows transcription status without adding a composer transcribe button", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
           transcriptionMode: true,
-          toggleTranscriptionMode,
         } as unknown as Partial<ShellController>)}
       />,
     );
-    const btn = screen.getByTestId("chat-composer-transcribe");
-    expect(btn.getAttribute("aria-label")).toBe("stop transcription");
-    expect(btn.getAttribute("aria-pressed")).toBe("true");
-    fireEvent.click(btn);
-    expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("chat-transcribing-badge")).toBeTruthy();
+    expect(screen.queryByTestId("chat-composer-transcribe")).toBeNull();
   });
 
   it("keeps the mic button ON while transcribing (additive, not a takeover)", () => {
@@ -895,6 +989,36 @@ describe("ContinuousChatOverlay", () => {
     // it must NOT open a hands-free conversation.
     expect(stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
     expect(toggleHandsFree).not.toHaveBeenCalled();
+  });
+
+  it("does not enter push-to-talk on a long press while transcribing", () => {
+    vi.useFakeTimers();
+    try {
+      const stopTranscriptionAndMic = vi.fn();
+      const startRecording = vi.fn();
+      render(
+        <ContinuousChatOverlay
+          controller={makeController({
+            transcriptionMode: true,
+            stopTranscriptionAndMic,
+            startRecording,
+          } as unknown as Partial<ShellController>)}
+        />,
+      );
+
+      const mic = screen.getByTestId("chat-composer-mic");
+      fireEvent.pointerDown(mic, { button: 0, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      fireEvent.pointerUp(mic, { button: 0, pointerId: 1 });
+      fireEvent.click(mic);
+
+      expect(startRecording).not.toHaveBeenCalled();
+      expect(stopTranscriptionAndMic).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("drops the finished transcript into the composer as an attachment, not an auto-sent message", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -38,6 +38,8 @@ import {
 } from "../../chat/slash-menu";
 import type { SlashCommandController } from "../../chat/useSlashCommandController";
 import {
+  CHAT_PREFILL_EVENT,
+  type ChatPrefillEventDetail,
   TUTORIAL_CHAT_CONTROL_EVENT,
   type TutorialChatControlDetail,
 } from "../../events";
@@ -154,6 +156,8 @@ type PttPhase =
   | { kind: "idle" }
   | { kind: "pending"; pointerId: number; timer: number }
   | { kind: "holding"; pointerId: number };
+
+type MotionControls = { stop: () => void };
 
 const SHEET_HALF_VH = 0.46; // fraction of viewport height at the HALF detent
 // px kept clear above the panel. Sized to clear an edge-to-edge status bar
@@ -900,9 +904,9 @@ const ThreadLine = React.memo(function ThreadLine({
           // behind. The light tone is for any embedding that supplies its own
           // surrounding scrim.
           isUser ? "rounded-br-md" : "rounded-bl-md",
-          // Assistant bubbles own the press-and-hold copy gesture, so suppress
-          // the native long-press selection/callout that would fight it.
-          canCopy && "select-none [-webkit-touch-callout:none]",
+          // Message text must remain selectable for normal highlight/copy.
+          // Assistant bubbles still keep the press-and-hold copy shortcut.
+          "select-text [-webkit-touch-callout:default]",
           floating
             ? cn(
                 "border",
@@ -916,50 +920,52 @@ const ThreadLine = React.memo(function ThreadLine({
               : "bg-white/10 text-white/90",
         )}
       >
-        {isAssistant &&
-        !message.content.trim() &&
-        !message.attachments?.length ? (
-          // The in-flight assistant turn (kept by visibleMessages only while
-          // responding): show the rich status (thinking / running an action /
-          // waking) INSIDE the bubble, anchored where the streamed text fills in
-          // — then the text replaces it. Falls back to plain dots if no status.
-          <>
-            <TurnStatusInner status={turnStatus ?? null} />
-            {message.attachments?.length ? (
-              <MessageAttachments attachments={message.attachments} />
-            ) : null}
-          </>
-        ) : isUser ? (
-          // User turns stay raw text (slash command bolded); user uploads render
-          // through the standalone attachment renderer.
-          <>
-            <ThreadLineText content={message.content} />
-            {message.attachments?.length ? (
-              <MessageAttachments attachments={message.attachments} />
-            ) : null}
-          </>
-        ) : (
-          // Settled assistant turn: render inline widgets (task/choice/form/
-          // followups) instead of leaking raw `[TASK:…]`/`[CHOICE]`/… markers as
-          // text (#8997); plain replies fall through the fast path unchanged.
-          // Attachments, the secret/OAuth request, and the reasoning block render
-          // alongside. The secret block is `pointer-events-auto` so it stays
-          // clickable inside the pass-through (pointer-events-none) peek sheet.
-          <>
-            <InlineWidgetText content={message.content} />
-            {message.attachments?.length ? (
-              <MessageAttachments attachments={message.attachments} />
-            ) : null}
-            {message.secretRequest ? (
-              <div className="pointer-events-auto">
-                <SensitiveRequestBlock request={message.secretRequest} />
-              </div>
-            ) : null}
-            {message.reasoning?.trim() ? (
-              <ThinkingBlock reasoning={message.reasoning} />
-            ) : null}
-          </>
-        )}
+        <div data-chat-selectable="true">
+          {isAssistant &&
+          !message.content.trim() &&
+          !message.attachments?.length ? (
+            // The in-flight assistant turn (kept by visibleMessages only while
+            // responding): show the rich status (thinking / running an action /
+            // waking) INSIDE the bubble, anchored where the streamed text fills in
+            // — then the text replaces it. Falls back to plain dots if no status.
+            <>
+              <TurnStatusInner status={turnStatus ?? null} />
+              {message.attachments?.length ? (
+                <MessageAttachments attachments={message.attachments} />
+              ) : null}
+            </>
+          ) : isUser ? (
+            // User turns stay raw text (slash command bolded); user uploads render
+            // through the standalone attachment renderer.
+            <>
+              <ThreadLineText content={message.content} />
+              {message.attachments?.length ? (
+                <MessageAttachments attachments={message.attachments} />
+              ) : null}
+            </>
+          ) : (
+            // Settled assistant turn: render inline widgets (task/choice/form/
+            // followups) instead of leaking raw `[TASK:…]`/`[CHOICE]`/… markers as
+            // text (#8997); plain replies fall through the fast path unchanged.
+            // Attachments, the secret/OAuth request, and the reasoning block render
+            // alongside. The secret block is `pointer-events-auto` so it stays
+            // clickable inside the pass-through (pointer-events-none) peek sheet.
+            <>
+              <InlineWidgetText content={message.content} />
+              {message.attachments?.length ? (
+                <MessageAttachments attachments={message.attachments} />
+              ) : null}
+              {message.secretRequest ? (
+                <div className="pointer-events-auto">
+                  <SensitiveRequestBlock request={message.secretRequest} />
+                </div>
+              ) : null}
+              {message.reasoning?.trim() ? (
+                <ThinkingBlock reasoning={message.reasoning} />
+              ) : null}
+            </>
+          )}
+        </div>
         <AnimatePresence>
           {copied ? (
             <motion.span
@@ -1124,6 +1130,69 @@ export function ContinuousChatOverlay({
   // re-render. Drives the glass/content crossfade + scale; `threadHeight` stays
   // 0 until the input is fully formed, then takes over for input → chat.
   const openProgress = useMotionValue(pilled ? 0 : 1);
+  // Imperative animations triggered from gesture callbacks are outside React's
+  // effect cleanup, so keep one owner per motion value and stop stale springs
+  // before starting another.
+  const threadAnimationRef = React.useRef<MotionControls | null>(null);
+  const openProgressAnimationRef = React.useRef<MotionControls | null>(null);
+  const delayedNavigationTimerRef = React.useRef<number | null>(null);
+  const prefillFocusFrameRef = React.useRef<number | null>(null);
+  const prefillFocusTimerRef = React.useRef<number | null>(null);
+  const stopThreadAnimation = React.useCallback(() => {
+    threadAnimationRef.current?.stop();
+    threadAnimationRef.current = null;
+  }, []);
+  const stopOpenProgressAnimation = React.useCallback(() => {
+    openProgressAnimationRef.current?.stop();
+    openProgressAnimationRef.current = null;
+  }, []);
+  const animateThreadHeight = React.useCallback(
+    (target: number) => {
+      stopThreadAnimation();
+      threadAnimationRef.current = animate(threadHeight, target, SHEET_SPRING);
+    },
+    [stopThreadAnimation, threadHeight],
+  );
+  const animateOpenProgress = React.useCallback(
+    (target: number) => {
+      stopOpenProgressAnimation();
+      openProgressAnimationRef.current = animate(
+        openProgress,
+        target,
+        OPEN_SPRING,
+      );
+    },
+    [openProgress, stopOpenProgressAnimation],
+  );
+  const clearPrefillFocusSchedule = React.useCallback(() => {
+    if (
+      prefillFocusFrameRef.current !== null &&
+      typeof window !== "undefined" &&
+      typeof window.cancelAnimationFrame === "function"
+    ) {
+      window.cancelAnimationFrame(prefillFocusFrameRef.current);
+    }
+    if (
+      prefillFocusTimerRef.current !== null &&
+      typeof window !== "undefined"
+    ) {
+      window.clearTimeout(prefillFocusTimerRef.current);
+    }
+    prefillFocusFrameRef.current = null;
+    prefillFocusTimerRef.current = null;
+  }, []);
+  React.useEffect(
+    () => () => {
+      stopThreadAnimation();
+      stopOpenProgressAnimation();
+      if (delayedNavigationTimerRef.current !== null) {
+        window.clearTimeout(delayedNavigationTimerRef.current);
+        delayedNavigationTimerRef.current = null;
+      }
+      clearPrefillFocusSchedule();
+    },
+    [stopThreadAnimation, stopOpenProgressAnimation, clearPrefillFocusSchedule],
+  );
   // Latest `settleDrag` (defined below) exposed to the viewport-resize effect
   // (which runs earlier). A rotation can orphan an in-flight drag — re-settling
   // the morph keeps the pill↔input crossfade from stranding both bars visible.
@@ -1488,6 +1557,7 @@ export function ContinuousChatOverlay({
         event.button !== 0 ||
         hasDraft ||
         recording ||
+        transcriptionMode ||
         // Voice input is gated while a reply is in flight; type + send to queue
         // another turn instead. Re-enabled the instant the reply finishes.
         responding
@@ -1510,7 +1580,7 @@ export function ContinuousChatOverlay({
       }, 200);
       pttRef.current = { kind: "pending", pointerId, timer };
     },
-    [hasDraft, recording, responding, startRecording],
+    [hasDraft, recording, responding, startRecording, transcriptionMode],
   );
 
   // One funnel for BOTH pointerup (cancelled=false) and pointercancel
@@ -1521,7 +1591,10 @@ export function ContinuousChatOverlay({
     (event: React.PointerEvent<HTMLButtonElement>, cancelled: boolean) => {
       const phase = pttRef.current;
       if (phase.kind === "pending") window.clearTimeout(phase.timer);
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      if (
+        typeof event.currentTarget.hasPointerCapture === "function" &&
+        event.currentTarget.hasPointerCapture(event.pointerId)
+      ) {
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
       pttRef.current = { kind: "idle" };
@@ -1871,13 +1944,25 @@ export function ContinuousChatOverlay({
     draggingRef.current = false;
     const open = pilled ? 0 : 1;
     if (reduce) {
+      stopThreadAnimation();
+      stopOpenProgressAnimation();
       threadHeight.set(baseH);
       openProgress.set(open);
     } else {
-      animate(threadHeight, baseH, SHEET_SPRING);
-      animate(openProgress, open, OPEN_SPRING);
+      animateThreadHeight(baseH);
+      animateOpenProgress(open);
     }
-  }, [threadHeight, openProgress, baseH, pilled, reduce]);
+  }, [
+    threadHeight,
+    openProgress,
+    baseH,
+    pilled,
+    reduce,
+    stopThreadAnimation,
+    stopOpenProgressAnimation,
+    animateThreadHeight,
+    animateOpenProgress,
+  ]);
   // Keep the ref the (earlier-declared) viewport-resize effect calls pointing at
   // the latest settleDrag, so a rotation re-settles with current pilled/baseH.
   settleDragRef.current = settleDrag;
@@ -1885,24 +1970,32 @@ export function ContinuousChatOverlay({
   // Drive openProgress from the pilled flag for NON-drag transitions (tap the
   // pill, programmatic open/close): a live finger drag owns openProgress itself
   // (draggingRef gates this so it never fights the gesture).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: openProgress is a stable motion value ref
   React.useEffect(() => {
     if (draggingRef.current) return;
     const open = pilled ? 0 : 1;
     if (reduce) {
+      stopOpenProgressAnimation();
       openProgress.set(open);
       return;
     }
-    const controls = animate(openProgress, open, OPEN_SPRING);
-    return () => controls.stop();
-  }, [pilled, reduce]);
+    animateOpenProgress(open);
+    return stopOpenProgressAnimation;
+  }, [
+    pilled,
+    reduce,
+    openProgress,
+    animateOpenProgress,
+    stopOpenProgressAnimation,
+  ]);
 
   const closeSheet = React.useCallback(() => {
     draggingRef.current = false;
+    stopThreadAnimation();
+    stopOpenProgressAnimation();
     setFreeH(null);
     setMaximized(false);
     setMode("input");
-  }, []);
+  }, [stopThreadAnimation, stopOpenProgressAnimation]);
 
   // Leaving the chat for Settings/Home: animate OUT of maximize and collapse the
   // sheet (closeSheet un-maximizes + springs the thread height down) BEFORE
@@ -1914,7 +2007,16 @@ export function ContinuousChatOverlay({
     (go: () => void) => {
       const wasMaximized = maximized;
       closeSheet();
-      window.setTimeout(go, reduce ? 0 : wasMaximized ? 260 : 190);
+      if (delayedNavigationTimerRef.current !== null) {
+        window.clearTimeout(delayedNavigationTimerRef.current);
+      }
+      delayedNavigationTimerRef.current = window.setTimeout(
+        () => {
+          delayedNavigationTimerRef.current = null;
+          go();
+        },
+        reduce ? 0 : wasMaximized ? 260 : 190,
+      );
     },
     [closeSheet, maximized, reduce],
   );
@@ -1926,50 +2028,57 @@ export function ContinuousChatOverlay({
   // nothing). Un-maximizing drops back to the inset FULL detent.
   const toggleMaximize = React.useCallback(() => {
     if (maximized) {
+      stopThreadAnimation();
       setMaximized(false);
       return;
     }
     // Snap the morph fully open BEFORE flipping to full-bleed so no in-flight
     // pill-open spring can leak a sub-1 scale into the maximized frame (top gap).
     draggingRef.current = false;
+    stopThreadAnimation();
+    stopOpenProgressAnimation();
     openProgress.set(1);
     setFreeH(null);
     setMode("full");
     setMaximized(true);
-  }, [maximized, openProgress]);
+  }, [maximized, openProgress, stopThreadAnimation, stopOpenProgressAnimation]);
 
   // The single detent→detent animator: whenever the settled detent (or viewport)
   // changes and we're not mid finger-drag, spring the history height to it. The
   // gesture / open paths just flip sheetOpen/expanded and this reacts — no
   // per-frame React state, so the live drag stays buttery.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: baseH already encodes sheetOpen/expanded/freeH/viewportH; threadHeight is a stable ref
   React.useEffect(() => {
     if (draggingRef.current) return;
     if (reduce) {
+      stopThreadAnimation();
       threadHeight.set(baseH);
       return;
     }
-    const controls = animate(threadHeight, baseH, SHEET_SPRING);
-    return () => controls.stop();
-  }, [baseH, reduce]);
+    animateThreadHeight(baseH);
+    return stopThreadAnimation;
+  }, [baseH, reduce, threadHeight, animateThreadHeight, stopThreadAnimation]);
 
   // Snap to one of the three iOS-style detents and settle the live drag. A
   // detent change fires a light haptic so the snap feels physical on device.
   // "collapsed" hides the history entirely (just the input); "half" is the
   // comfortable reading height; "full" the near-fullscreen reading mode.
-  const goToDetent = React.useCallback((to: "collapsed" | "half" | "full") => {
-    // Flip the settled detent; the [baseH] effect springs the height to it.
-    // A detent always clears any free-drag rest height and (since only FULL
-    // can be maximized) drops full-bleed when stepping anywhere else.
-    draggingRef.current = false;
-    setFreeH(null);
-    if (to !== "full") setMaximized(false);
-    // "collapsed" is the input peek (sheet closed); half/full open the thread.
-    setMode(to === "collapsed" ? "input" : to);
-    // Stepping all the way down closes the keyboard (the chat is dismissed).
-    if (to === "collapsed") inputRef.current?.blur();
-    detentHaptic();
-  }, []);
+  const goToDetent = React.useCallback(
+    (to: "collapsed" | "half" | "full") => {
+      // Flip the settled detent; the [baseH] effect springs the height to it.
+      // A detent always clears any free-drag rest height and (since only FULL
+      // can be maximized) drops full-bleed when stepping anywhere else.
+      draggingRef.current = false;
+      stopThreadAnimation();
+      setFreeH(null);
+      if (to !== "full") setMaximized(false);
+      // "collapsed" is the input peek (sheet closed); half/full open the thread.
+      setMode(to === "collapsed" ? "input" : to);
+      // Stepping all the way down closes the keyboard (the chat is dismissed).
+      if (to === "collapsed") inputRef.current?.blur();
+      detentHaptic();
+    },
+    [stopThreadAnimation],
+  );
 
   // Collapsing always drops input focus, so the mobile keyboard goes away the
   // moment the chat is dismissed (pull-down, Escape, or click-out) — the chat is
@@ -2086,6 +2195,35 @@ export function ContinuousChatOverlay({
     return () =>
       window.removeEventListener(TUTORIAL_CHAT_CONTROL_EVENT, onControl);
   }, [goToDetent]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onPrefill = (event: Event) => {
+      const detail = (event as CustomEvent<ChatPrefillEventDetail>).detail;
+      const text = typeof detail?.text === "string" ? detail.text : "";
+      if (!text.trim()) return;
+      setMode((m) => (m === "pill" ? "input" : m));
+      setDraft(text);
+      const focusComposer = () => {
+        prefillFocusFrameRef.current = null;
+        prefillFocusTimerRef.current = null;
+        const input = inputRef.current;
+        input?.focus();
+        if (detail?.select) {
+          input?.setSelectionRange(0, text.length);
+        }
+      };
+      clearPrefillFocusSchedule();
+      if (typeof window.requestAnimationFrame === "function") {
+        prefillFocusFrameRef.current =
+          window.requestAnimationFrame(focusComposer);
+      } else {
+        prefillFocusTimerRef.current = window.setTimeout(focusComposer, 0);
+      }
+    };
+    window.addEventListener(CHAT_PREFILL_EVENT, onPrefill);
+    return () => window.removeEventListener(CHAT_PREFILL_EVENT, onPrefill);
+  }, [clearPrefillFocusSchedule]);
 
   // Push-to-talk dictation drops its final transcript into the composer draft
   // (no send): register the sink with the controller while this overlay is
@@ -2323,8 +2461,10 @@ export function ContinuousChatOverlay({
       preFocusCollapsedRef.current = true;
       detentHaptic();
     }
-    if (reduce) openProgress.set(1);
-    else animate(openProgress, 1, OPEN_SPRING);
+    if (reduce) {
+      stopOpenProgressAnimation();
+      openProgress.set(1);
+    } else animateOpenProgress(1);
     // Raise the keyboard on the SAME tap that opens the pill. While pilled, the
     // composer content is `inert`, and React only clears that on the next
     // render — too late for iOS WebKit, which honors focus() only synchronously
@@ -2338,7 +2478,14 @@ export function ContinuousChatOverlay({
     contentRef.current?.removeAttribute("inert");
     suppressExpandOnFocusRef.current = true;
     inputRef.current?.focus();
-  }, [openProgress, reduce, hasThread, goToDetent]);
+  }, [
+    openProgress,
+    reduce,
+    hasThread,
+    goToDetent,
+    stopOpenProgressAnimation,
+    animateOpenProgress,
+  ]);
 
   // --- Pull gesture --------------------------------------------------------
   // The grabber is the draggable handle. A live drag sets the threadHeight motion
@@ -2347,6 +2494,10 @@ export function ContinuousChatOverlay({
   // usePullGesture) to snap to a detent.
   const onDragOffset = React.useCallback(
     (offset: number) => {
+      if (!draggingRef.current) {
+        stopThreadAnimation();
+        stopOpenProgressAnimation();
+      }
       draggingRef.current = true;
       // PILL drag: map the upward travel to the pill→input morph (openProgress).
       // The thread stays at 0 until the input is fully formed; only the EXCESS
@@ -2389,6 +2540,8 @@ export function ContinuousChatOverlay({
       clampHeight,
       threadHeight,
       openProgress,
+      stopThreadAnimation,
+      stopOpenProgressAnimation,
     ],
   );
 
@@ -2410,8 +2563,10 @@ export function ContinuousChatOverlay({
         } else {
           // Pill → bare input bar (no thread to open into).
           setMode("input");
-          if (reduce) threadHeight.set(0);
-          else animate(threadHeight, 0, SHEET_SPRING);
+          if (reduce) {
+            stopThreadAnimation();
+            threadHeight.set(0);
+          } else animateThreadHeight(0);
           detentHaptic();
         }
         return;
@@ -3330,24 +3485,8 @@ export function ContinuousChatOverlay({
                 {agentName} is waking up — you can type now; your message sends
                 and the reply arrives in a moment.
               </span>
-              {/* Trailing controls. The transcribe toggle sits directly LEFT of
-              the mic — it's a voice control, so it appears only while voice is on
-              (voiceActive), giving record-only long-form capture next to the
-              audio button. */}
+              {/* Trailing controls. */}
               <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
-                {voiceActive ? (
-                  <SoftButton
-                    icon={FileText}
-                    label={
-                      transcriptionMode
-                        ? "stop transcription"
-                        : "transcription mode"
-                    }
-                    active={transcriptionMode}
-                    onClick={toggleTranscriptionMode}
-                    testId="chat-composer-transcribe"
-                  />
-                ) : null}
                 {/* One trailing control, ChatGPT-style: mic when there's nothing
                 to send (or while recording, to stop), swapping to send once the
                 user starts typing or attaches an image. It morphs IN PLACE (one

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -8,7 +8,10 @@ import {
   type ModuleCacheTelemetryEvent,
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
-import { DynamicViewLoader } from "./DynamicViewLoader";
+import {
+  __resetDynamicViewLoaderCacheForTests,
+  DynamicViewLoader,
+} from "./DynamicViewLoader";
 
 const { sendWsMessage } = vi.hoisted(() => ({
   sendWsMessage: vi.fn(),
@@ -38,6 +41,7 @@ describe("DynamicViewLoader", () => {
     delete window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__;
     sendWsMessage.mockClear();
     cleanup();
+    __resetDynamicViewLoaderCacheForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.clearAllTimers();
@@ -815,6 +819,55 @@ describe("DynamicViewLoader", () => {
           key: `${bundleUrl}::default`,
         }),
       ]),
+    );
+  });
+
+  it("removes global lifecycle listeners when the dynamic-view cache is reset", async () => {
+    const bundleUrl = "https://capability.example.test/assets/listeners.js";
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const addDocumentListener = vi.spyOn(document, "addEventListener");
+    const removeDocumentListener = vi.spyOn(document, "removeEventListener");
+
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = vi.fn(async () => ({
+      default: function ListenerPanel() {
+        return <div>Listener panel</div>;
+      },
+    }));
+
+    const rendered = render(
+      <DynamicViewLoader bundleUrl={bundleUrl} viewId="listener.view" />,
+    );
+    await screen.findByText("Listener panel");
+    rendered.unmount();
+
+    const memoryPressureHandler = addWindowListener.mock.calls.find(
+      ([name]) => name === "memorypressure",
+    )?.[1];
+    const visibilityHandler = addDocumentListener.mock.calls.find(
+      ([name]) => name === "visibilitychange",
+    )?.[1];
+    const appPauseHandler = addDocumentListener.mock.calls.find(
+      ([name]) => name === APP_PAUSE_EVENT,
+    )?.[1];
+
+    expect(memoryPressureHandler).toEqual(expect.any(Function));
+    expect(visibilityHandler).toEqual(expect.any(Function));
+    expect(appPauseHandler).toEqual(expect.any(Function));
+
+    __resetDynamicViewLoaderCacheForTests();
+
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      "memorypressure",
+      memoryPressureHandler,
+    );
+    expect(removeDocumentListener).toHaveBeenCalledWith(
+      "visibilitychange",
+      visibilityHandler,
+    );
+    expect(removeDocumentListener).toHaveBeenCalledWith(
+      APP_PAUSE_EVENT,
+      appPauseHandler,
     );
   });
 });

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -112,6 +112,9 @@ const DEFAULT_BUNDLE_CACHE_MAX_ENTRIES = 6;
 const LOW_MEMORY_BUNDLE_CACHE_MAX_ENTRIES = 2;
 
 let bundleCacheLifecycleInstalled = false;
+let pruneBundleCacheOnPressure: (() => void) | null = null;
+let pruneBundleCacheOnVisibilityHidden: (() => void) | null = null;
+let pruneBundleCacheOnAppPause: (() => void) | null = null;
 
 function bundleCacheStats(): {
   activeCount: number;
@@ -252,24 +255,58 @@ function pruneBundleModuleCache(
 function installBundleCacheLifecycle(): void {
   if (bundleCacheLifecycleInstalled || typeof window === "undefined") return;
   bundleCacheLifecycleInstalled = true;
-  const pruneOnPressure = () => {
+  pruneBundleCacheOnPressure = () => {
     scheduleIdleWork(() =>
       pruneBundleModuleCache({ force: true, reason: "memorypressure" }),
     );
   };
-  window.addEventListener("memorypressure", pruneOnPressure);
-  document.addEventListener("visibilitychange", () => {
+  pruneBundleCacheOnVisibilityHidden = () => {
     if (document.visibilityState === "hidden") {
       scheduleIdleWork(() =>
         pruneBundleModuleCache({ reason: "visibility-hidden" }),
       );
     }
-  });
-  document.addEventListener(APP_PAUSE_EVENT, () => {
+  };
+  pruneBundleCacheOnAppPause = () => {
     scheduleIdleWork(() =>
       pruneBundleModuleCache({ force: true, reason: "app-pause" }),
     );
-  });
+  };
+  window.addEventListener("memorypressure", pruneBundleCacheOnPressure);
+  document.addEventListener(
+    "visibilitychange",
+    pruneBundleCacheOnVisibilityHidden,
+  );
+  document.addEventListener(APP_PAUSE_EVENT, pruneBundleCacheOnAppPause);
+}
+
+export function __resetDynamicViewLoaderCacheForTests(): void {
+  for (const entry of bundleModuleCache.values()) {
+    if (entry.retentionTimer) {
+      clearTimeout(entry.retentionTimer);
+      entry.retentionTimer = null;
+    }
+    const cleanup = entry.module?.cleanup;
+    entry.module = null;
+    runBundleCleanup(cleanup);
+  }
+  bundleModuleCache.clear();
+  if (typeof window !== "undefined" && pruneBundleCacheOnPressure) {
+    window.removeEventListener("memorypressure", pruneBundleCacheOnPressure);
+  }
+  if (typeof document !== "undefined" && pruneBundleCacheOnVisibilityHidden) {
+    document.removeEventListener(
+      "visibilitychange",
+      pruneBundleCacheOnVisibilityHidden,
+    );
+  }
+  if (typeof document !== "undefined" && pruneBundleCacheOnAppPause) {
+    document.removeEventListener(APP_PAUSE_EVENT, pruneBundleCacheOnAppPause);
+  }
+  pruneBundleCacheOnPressure = null;
+  pruneBundleCacheOnVisibilityHidden = null;
+  pruneBundleCacheOnAppPause = null;
+  bundleCacheLifecycleInstalled = false;
 }
 
 function isReactComponentExport(
@@ -315,19 +352,16 @@ const APP_CORE_VIEW_COMPAT: Record<string, unknown> = {
   toneForViewerAttachment,
 };
 
-const UI_COMPONENTS_COMPAT: Record<string, unknown> = {
-  Button,
-  Input,
-  Spinner,
-  PagePanel,
-};
-
 async function importAppCoreViewCompat(): Promise<Record<string, unknown>> {
   return APP_CORE_VIEW_COMPAT;
 }
 
 async function importUiComponentsCompat(): Promise<Record<string, unknown>> {
-  return UI_COMPONENTS_COMPAT;
+  return import("../index.ts");
+}
+
+async function importUiRootCompat(): Promise<Record<string, unknown>> {
+  return import("../../index.ts");
 }
 
 const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
@@ -345,7 +379,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/capacitor-system": () =>
     importHostExternal("@elizaos/capacitor-system"),
   "@elizaos/shared": () => importHostExternal("@elizaos/shared"),
-  "@elizaos/ui": importAppCoreViewCompat,
+  "@elizaos/ui": importUiRootCompat,
   "@elizaos/plugin-browser": () =>
     importHostExternal("@elizaos/plugin-browser"),
   "@elizaos/plugin-health/screen-time/mobile-signal-setup": () =>

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -134,6 +134,7 @@ export interface CloudHandoffRetryDetail {
  */
 export const TUTORIAL_CHAT_CONTROL_EVENT =
   "eliza:tutorial:chat-control" as const;
+export const CHAT_PREFILL_EVENT = "eliza:chat:prefill" as const;
 
 export interface TutorialChatControlDetail {
   /**
@@ -149,6 +150,12 @@ export interface TutorialChatControlDetail {
   text?: string;
 }
 
+export interface ChatPrefillEventDetail {
+  text: string;
+  /** Select the inserted draft after focusing the composer. Defaults to false. */
+  select?: boolean;
+}
+
 /** Dispatch a tutorial chat-control instruction to the overlay. */
 export function dispatchTutorialChatControl(
   detail: TutorialChatControlDetail,
@@ -159,6 +166,12 @@ export function dispatchTutorialChatControl(
   );
 }
 
+/** Dispatch a request to open the floating chat and prefill its composer. */
+export function dispatchChatPrefill(detail: ChatPrefillEventDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(CHAT_PREFILL_EVENT, { detail }));
+}
+
 // ── Event-name unions (shared base widened with the UI-only events) ───────
 
 export type ElizaDocumentEventName =
@@ -167,6 +180,9 @@ export type ElizaDocumentEventName =
 
 export type ElizaWindowEventName =
   | SharedWindowEventName
+  | typeof VOICE_CONTROL_EVENT
+  | typeof TUTORIAL_CHAT_CONTROL_EVENT
+  | typeof CHAT_PREFILL_EVENT
   | typeof CLOUD_HANDOFF_PHASE_EVENT
   | typeof CLOUD_HANDOFF_RETRY_EVENT;
 

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -3,7 +3,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetResourceCache } from "./resource-cache";
-import { useAvailableViews, type ViewRegistryEntry } from "./useAvailableViews";
+import {
+  useAvailableViews,
+  useRoutableViews,
+  type ViewRegistryEntry,
+  withBuiltinShellViews,
+} from "./useAvailableViews";
 
 const { fetchWithCsrf, getFrontendPlatform } = vi.hoisted(() => ({
   fetchWithCsrf: vi.fn(),
@@ -167,6 +172,47 @@ describe("useAvailableViews", () => {
 
     expect(result.current.views).toEqual([]);
     expect(result.current.error).toBeNull();
+  });
+
+  it("adds built-in shell entries only for routable consumers", async () => {
+    fetchWithCsrf.mockResolvedValue(response(200, { views: [] }));
+
+    const available = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(available.result.current.loading).toBe(false));
+    expect(
+      available.result.current.views.find((v) => v.id === "documents"),
+    ).toBe(undefined);
+    available.unmount();
+
+    const routable = renderHook(() => useRoutableViews());
+    await waitFor(() => expect(routable.result.current.loading).toBe(false));
+
+    expect(routable.result.current.views).toContainEqual(
+      expect.objectContaining({
+        id: "documents",
+        path: "/character/documents",
+        builtin: true,
+        visibleInManager: false,
+        desktopTabEnabled: true,
+      }),
+    );
+  });
+
+  it("does not let built-in shell fallbacks override real registry entries", () => {
+    const routable = withBuiltinShellViews([
+      view("documents", {
+        label: "Registered Documents",
+        path: "/apps/registered-documents",
+        pluginName: "@elizaos/plugin-documents",
+      }),
+    ]);
+
+    expect(routable.find((v) => v.id === "documents")).toMatchObject({
+      id: "documents",
+      label: "Registered Documents",
+      path: "/apps/registered-documents",
+      pluginName: "@elizaos/plugin-documents",
+    });
   });
 
   it("silences 404s and clears views without surfacing an error", async () => {

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -19,6 +19,7 @@ import {
   listAppShellPages,
   subscribeAppShellPages,
 } from "../app-shell-registry";
+import { type BuiltinTab, TAB_PATHS, titleForTab } from "../navigation";
 import { getFrontendPlatform } from "../platform/platform-guards";
 import { startPolling } from "./resource-cache";
 import { useCachedResource } from "./useCachedResource";
@@ -155,6 +156,21 @@ const VIEWS_CACHE_KEY = "views:available";
 
 const EMPTY_VIEWS: ViewRegistryEntry[] = [];
 
+const BUILTIN_SHELL_VIEW_ENTRIES: ViewRegistryEntry[] = Object.entries(
+  TAB_PATHS,
+).map(([id, path]) => ({
+  id,
+  label: titleForTab(id as BuiltinTab),
+  viewType: "gui",
+  path,
+  available: true,
+  pluginName: "@elizaos/builtin",
+  tags: [id],
+  builtin: true,
+  visibleInManager: false,
+  desktopTabEnabled: true,
+}));
+
 /**
  * Map an in-process app-shell page (registered by a plugin via
  * `registerAppShellPage`) to a view-registry entry. On iOS/Android the agent's
@@ -209,20 +225,37 @@ function getAppShellViewEntriesSnapshot(): ViewRegistryEntry[] {
  * — app-shell pages only fill ids the network didn't return, which on mobile is
  * every dynamically-bundled plugin view the route filtered out.
  */
+function mergeViewRegistryEntries(
+  primaryViews: ViewRegistryEntry[],
+  fallbackGroups: ViewRegistryEntry[][],
+): ViewRegistryEntry[] {
+  if (fallbackGroups.every((group) => group.length === 0)) {
+    return primaryViews;
+  }
+  const byKey = new Map<string, ViewRegistryEntry>();
+  for (const view of primaryViews) {
+    byKey.set(`${view.viewType ?? "gui"}:${view.id}`, view);
+  }
+  for (const group of fallbackGroups) {
+    for (const entry of group) {
+      const key = `${entry.viewType ?? "gui"}:${entry.id}`;
+      if (!byKey.has(key)) byKey.set(key, entry);
+    }
+  }
+  return [...byKey.values()];
+}
+
 function mergeWithAppShellViews(
   networkViews: ViewRegistryEntry[],
   appShellViews: ViewRegistryEntry[],
 ): ViewRegistryEntry[] {
-  if (appShellViews.length === 0) return networkViews;
-  const byKey = new Map<string, ViewRegistryEntry>();
-  for (const view of networkViews) {
-    byKey.set(`${view.viewType ?? "gui"}:${view.id}`, view);
-  }
-  for (const entry of appShellViews) {
-    const key = `${entry.viewType ?? "gui"}:${entry.id}`;
-    if (!byKey.has(key)) byKey.set(key, entry);
-  }
-  return [...byKey.values()];
+  return mergeViewRegistryEntries(networkViews, [appShellViews]);
+}
+
+export function withBuiltinShellViews(
+  views: ViewRegistryEntry[],
+): ViewRegistryEntry[] {
+  return mergeViewRegistryEntries(views, [BUILTIN_SHELL_VIEW_ENTRIES]);
 }
 
 export function useAvailableViews(): UseAvailableViewsResult {
@@ -266,4 +299,19 @@ export function useAvailableViews(): UseAvailableViewsResult {
     error: resource.status === "error" ? resource.error : null,
     refresh: refetch,
   };
+}
+
+export function useRoutableViews(): UseAvailableViewsResult {
+  const { views, loading, error, refresh } = useAvailableViews();
+  const routableViews = useMemo(() => withBuiltinShellViews(views), [views]);
+
+  return useMemo(
+    () => ({
+      views: routableViews,
+      loading,
+      error,
+      refresh,
+    }),
+    [routableViews, loading, error, refresh],
+  );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -511,6 +511,8 @@ export {
   getVrmPreviewUrl,
   getVrmUrl,
   mergeStreamingText,
+  useAppSelector,
+  useAppSelectorShallow,
   useCompanionSceneConfig,
   usePtySessions,
   useTranslation,

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -431,6 +431,14 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
     return "views";
   }
 
+  // /character/<sub> — resolve nested character paths
+  if (normalized.startsWith("/character/")) {
+    const sub = normalized.slice("/character/".length);
+    if (sub === "documents") return "documents";
+    if (sub === "select") return "character-select";
+    return "character";
+  }
+
   const appShellAlias = APP_SHELL_PATH_TAB_ALIASES[normalized];
   if (appShellAlias) return appShellAlias;
   const registeredAppShellPage = listAppShellPages().find(
@@ -447,14 +455,6 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
   if (normalized.startsWith("/apps/")) {
     const sub = normalized.slice("/apps/".length);
     return APPS_SUB_TABS[sub] ?? "apps";
-  }
-
-  // /character/<sub> — resolve nested character paths
-  if (normalized.startsWith("/character/")) {
-    const sub = normalized.slice("/character/".length);
-    if (sub === "documents") return "documents";
-    if (sub === "select") return "character-select";
-    return "character";
   }
 
   // /settings/<sub> — resolve nested settings paths

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -337,6 +337,16 @@ body.platform-android [contenteditable="true"] {
   -webkit-touch-callout: default;
 }
 
+/* Chat transcripts are reading surfaces. Keep them selectable even in native
+   shells where the app body disables global selection to protect gestures. */
+body.native [data-chat-selectable="true"],
+body.platform-ios [data-chat-selectable="true"],
+body.platform-android [data-chat-selectable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+}
+
 /* Hide scrollbars on native shells. Mobile users don't need a visible
    scrollbar; they get a momentum scroller. */
 body.native *::-webkit-scrollbar,

--- a/plugins/plugin-calendar/src/apple-calendar.ts
+++ b/plugins/plugin-calendar/src/apple-calendar.ts
@@ -6,16 +6,14 @@ import {
   type NativeLibraryCandidate,
   resolveNativeLibraryCandidate,
 } from "@elizaos/app-core/platform/native-library-policy";
-import {
-  APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME,
-  appleCalendarMacosBridgeCandidates,
-} from "@elizaos/capacitor-calendar";
+import * as appleCalendarBridgePolicyImport from "@elizaos/capacitor-calendar/macos-bridge-policy";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
-import type { FeatureResult, IPermissionsRegistry } from "@elizaos/shared";
 import type {
   CreateLifeOpsCalendarEventAttendee,
   CreateLifeOpsCalendarEventRequest,
+  FeatureResult,
+  IPermissionsRegistry,
   LifeOpsCalendarEvent,
   LifeOpsCalendarEventAttendee,
   LifeOpsCalendarFeed,
@@ -121,6 +119,29 @@ const MODULE_DIR =
   typeof import.meta.dir === "string"
     ? import.meta.dir
     : dirname(fileURLToPath(import.meta.url));
+
+type AppleCalendarModule = typeof import("@elizaos/capacitor-calendar");
+type AppleCalendarBridgePolicyModule =
+  typeof import("@elizaos/capacitor-calendar/macos-bridge-policy");
+
+function unwrapInteropDefault<TModule extends object>(
+  module: TModule | { default?: TModule },
+  namedExport: keyof TModule,
+): TModule {
+  if (namedExport in module) return module as TModule;
+  return (module as { default?: TModule }).default ?? (module as TModule);
+}
+
+const appleCalendarBridgePolicy =
+  unwrapInteropDefault<AppleCalendarBridgePolicyModule>(
+    appleCalendarBridgePolicyImport,
+    "APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME",
+  );
+
+const {
+  APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME,
+  appleCalendarMacosBridgeCandidates,
+} = appleCalendarBridgePolicy;
 
 function nativeDylibCandidates(): NativeLibraryCandidate[] {
   return appleCalendarMacosBridgeCandidates({
@@ -290,7 +311,10 @@ async function loadIosCalendarBridge(): Promise<NativeCalendarBridge | null> {
   ).Capacitor;
   if (capacitor?.getPlatform?.() !== "ios") return null;
   try {
-    const { AppleCalendar } = await import("@elizaos/capacitor-calendar");
+    const { AppleCalendar } = unwrapInteropDefault<AppleCalendarModule>(
+      await import("@elizaos/capacitor-calendar"),
+      "AppleCalendar",
+    );
     return {
       platform: "ios",
       async listCalendars() {

--- a/plugins/plugin-native-calendar/package.json
+++ b/plugins/plugin-native-calendar/package.json
@@ -14,9 +14,18 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
+      "eliza-source": "./src/index.ts",
       "bun": "./src/index.ts",
       "development": "./src/index.ts",
       "import": "./dist/esm/index.js",
+      "require": "./dist/plugin.cjs.js"
+    },
+    "./macos-bridge-policy": {
+      "types": "./dist/esm/macos-bridge-policy.d.ts",
+      "eliza-source": "./src/macos-bridge-policy.ts",
+      "bun": "./src/macos-bridge-policy.ts",
+      "development": "./src/macos-bridge-policy.ts",
+      "import": "./dist/esm/macos-bridge-policy.js",
       "require": "./dist/plugin.cjs.js"
     },
     "./package.json": "./package.json"

--- a/plugins/plugin-task-coordinator/src/register.ts
+++ b/plugins/plugin-task-coordinator/src/register.ts
@@ -1,5 +1,7 @@
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 
+import "./register-slots.js";
+
 registerAppShellPage({
   id: "orchestrator",
   pluginId: "@elizaos/plugin-task-coordinator",

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -23,8 +23,11 @@ import type {
   TrainingTrajectoryList,
 } from "@elizaos/ui/api";
 import { client } from "@elizaos/ui/api";
-import { Button, registerDetailExtension } from "@elizaos/ui/components";
-import type { AppDetailExtensionProps } from "@elizaos/ui/components/apps/extensions/types";
+import {
+  type AppDetailExtensionProps,
+  Button,
+  registerDetailExtension,
+} from "@elizaos/ui/components";
 import { useIntervalWhenDocumentVisible } from "@elizaos/ui/hooks";
 import { ContentLayout } from "@elizaos/ui/layouts";
 import { type AppContextValue, useAppSelector } from "@elizaos/ui/state";


### PR DESCRIPTION
## Summary

Split PR B from the closed monolithic desktop/view-routing branch (#8948), following maintainer feedback to isolate the app/UI view-routing work from app-core runtime hardening and plugin infra changes.

This PR focuses on the desktop/mobile app view surface:

- routes split-tile desktop views through `ViewRouter` when a view is a built-in shell route instead of showing a dead "not available" placeholder
- adds the Knowledge/Documents route to the view registry and keeps the all-views audit aligned with current `TAB_PATHS`
- makes routable desktop tab data include built-in shell views while keeping manager-visible view data separate
- hardens `DynamicViewLoader` host externals so plugin bundles importing `@elizaos/ui` receive the real UI root module, and adds test cache lifecycle reset support
- keeps chat message text selectable/copyable and removes the separate document-looking composer transcribe button while preserving transcription status and mic behavior
- adds chat prefill focus cleanup and animation/timer cleanup to avoid UI leaks during view switching
- adds view-switching, chat overlay, task widget, and memory-stability smoke coverage
- registers task-coordinator slots from the app entrypoint, fixes training UI imports to the public UI barrel, and hardens calendar native interop/package exports for source-mode plugin loading
- keeps the UI smoke runner serialized around view builds and cleans up stamped temp state dirs

Deliberately excluded from this split:

- app-core desktop runtime hardening, now in #9045
- plugin-app-control/x402/plugin resolver changes for PR C
- the old `packages/core/src/services/message.ts` Stage-1 rewrite
- TinyPlace/Clawville POC-specific smoke code
- any local-inference changes

## Validation

Synced against `origin/develop` at `2d3ae01c5c` before commit.

- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/ui test src/App.navigate-view-wiring.test.tsx src/components/views/DynamicViewLoader.test.tsx src/hooks/useAvailableViews.test.tsx src/components/shell/ContinuousChatOverlay.test.tsx src/api/client-base-websocket.test.ts src/api/desktop-http-transport.test.ts src/app-navigate-view.test.ts --coverage.enabled=false` — 134 tests passed
- `bun run --cwd packages/app test src/plugin-registrations.test.ts --coverage.enabled=false` — 4 tests passed
- `bun run --cwd packages/agent test src/__tests__/views-registry-integration.test.ts --coverage.enabled=false` — 32 tests passed
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/agent typecheck`
- `node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/view-switching-chat-e2e.spec.ts test/ui-smoke/chat-overlay-controls-interactions.spec.ts test/ui-smoke/task-widget-in-chat.spec.ts test/ui-smoke/chat-view-memory-stability.spec.ts` — 31 passed
- `node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app test/ui-smoke/all-views-aesthetic-audit.spec.ts -g "builtin coverage matches navigation TAB_PATHS|builtin-files|builtin-background"` — 5 passed
- `git diff --check origin/develop...HEAD`
- `git diff --name-only origin/develop...HEAD | rg -i 'local[-_]?inference|localinference|packages/core/src/services/message|message-runtime-stage1|packages/core/src/runtime|packages/logger|packages/scripts/sync-artifacts|tinyplace|clawville|x402-route-validation|packages/agent/src/api/server.ts' || true` returned no files
