### PR TITLE
fix(story-gate): resolve --static-dir against cwd, fixing the red develop story gate

### DIFF
--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -79,7 +79,12 @@ function parseArgs(argv) {
   return a;
 }
 const args = parseArgs(process.argv.slice(2));
-const staticDir = resolve(pkgRoot, args.staticDir);
+// Resolve --static-dir against the invocation cwd (repo root in CI via the
+// ui-story-gate workflow, the package dir for the audit:stories scripts), the
+// standard CLI convention. Resolving against pkgRoot doubled a repo-root-
+// relative arg (packages/ui/packages/ui/storybook-static) and the gate hard-
+// failed with "missing index.json" on every develop run.
+const staticDir = resolve(process.cwd(), args.staticDir);
 const outDir = resolve(pkgRoot, args.out);
 const baselineDir = resolve(here, "baseline");
 
@@ -680,3 +685,4 @@ main().catch((err) => {
   console.error("story-gate: fatal", err);
   process.exit(1);
 });
+


### PR DESCRIPTION
The `story-gate` job is genuinely red on develop. `run-story-gate.mjs` resolved `--static-dir` against the package root (`packages/ui`), but `ui-story-gate.yml` invokes it from repo root with `--static-dir packages/ui/storybook-static`, so it doubled to `packages/ui/packages/ui/storybook-static/index.json` → `missing …/index.json` fatal on every run, regardless of story health.

Fix on the script side (resolving CLI path args against the invocation cwd is the standard convention, and avoids a `workflow`-scope change): `resolve(process.cwd(), args.staticDir)`. Correct for both callers — the workflow (cwd=repo-root + repo-relative arg → `packages/ui/storybook-static`) and the `audit:stories` package scripts (cwd=`packages/ui` + bare `storybook-static`).

Found via an audit of develop's currently-red CI lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)