### PR TITLE
fix(app-core): mirror the new background tab in the dev route catalog

### DIFF
--- a/packages/app-core/src/api/dev-route-catalog.ts
+++ b/packages/app-core/src/api/dev-route-catalog.ts
@@ -437,6 +437,16 @@ const ROUTES: DevRouteEntry[] = [
     requiresAuth: true,
     platformGate: "desktop",
   },
+  {
+    tabId: "background",
+    path: "/background",
+    label: "Background",
+    group: "Hidden",
+    visibility: "all",
+    featureFlag: null,
+    requiresAuth: true,
+    platformGate: null,
+  },
 ];
 
 /**
@@ -521,3 +531,4 @@ export function buildRouteCatalog(
     modals: MODALS.map((m) => ({ ...m })),
   };
 }
+


### PR DESCRIPTION
`dev-route-catalog.test.ts` ("represents every TAB_PATHS key") is red on develop: the swarm added a `background` tab to `TAB_PATHS` (`packages/ui/src/navigation/index.ts`) but the hardcoded `ROUTES` mirror in `dev-route-catalog.ts` wasn't updated, so the parity gate fails with `expected ['background'] to deeply equal []` (seen on the windows `test-app-core` lane; also the Linux app-core lanes).

Adds the mirror entry — `tabId: "background"`, `path: "/background"` (matching `TAB_PATHS`), `label: "Background"` (matching `titleForTab`), `group: "Hidden"` (not in any `ALL_TAB_GROUPS`). The gate asserts `tabId` parity + `path === TAB_PATHS[tabId]`; both hold.

Found via an audit of develop's currently-red lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)