### PR TITLE
test(orchestrator): grilling & multi-task scenarios with verified logic (#8932)

### DIFF
--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -101,6 +101,8 @@
     "test:unit": "bunx vitest run --config vitest.config.ts __tests__/unit",
     "test:e2e:manual": "node tests/e2e/acp-codex-smoke.mjs",
     "test:e2e:multi-account": "bun --conditions=eliza-source scripts/compose-multi-account-e2e.ts",
+    "test:scenarios": "bun --conditions=eliza-source ../../packages/scenario-runner/src/cli.ts run test/scenarios --lane pr-deterministic",
+    "test:scenarios:live": "bun --conditions=eliza-source ../../packages/scenario-runner/src/cli.ts run test/scenarios --lane live-only",
     "test:watch": "bunx vitest --config vitest.config.ts",
     "build": "bun run build.ts",
     "build:ts": "bun run build.ts"

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-scenario-logic.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-scenario-logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  contentAwareVerifierModel,
+  runGrillingEvidenceBundleCheck,
+  runGrillingHappyPathCheck,
+} from "../../test/scenarios/_helpers/grilling-scenario.ts";
+import { runMultiTaskSupervisorCheck } from "../../test/scenarios/_helpers/supervisor-scenario.ts";
+
+/**
+ * Verifies the assertion LOGIC behind the three orchestrator scenarios in
+ * `test/scenarios/` (#8932) using deterministic models, so the grilling +
+ * multi-task loops have runnable, keyless coverage independent of the scenario
+ * CLI (which the live lane drives against a real model + ACP sub-agents). The
+ * scenario files import the exact same helpers.
+ */
+function makeBaseRuntime() {
+  return {
+    character: { name: "Tester" },
+    databaseAdapter: undefined,
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    getSetting: () => undefined,
+    // getService + useModel are overridden by makeGrillingRuntime.
+    getService: () => undefined,
+    useModel: async () => "{}",
+  } as never;
+}
+
+describe("orchestrator scenario logic (#8932)", () => {
+  it("multi-task supervisor: per-room isolation + change-driven digest", async () => {
+    expect(await runMultiTaskSupervisorCheck()).toBeUndefined();
+  });
+
+  it("grilling happy-path: no-evidence completion is grilled, pasted evidence is verified done", async () => {
+    expect(
+      await runGrillingHappyPathCheck(
+        makeBaseRuntime(),
+        contentAwareVerifierModel,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("grilling evidence-bundle: the git diff + test stdout reach the verifier prompt", async () => {
+    expect(
+      await runGrillingEvidenceBundleCheck(makeBaseRuntime()),
+    ).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/grilling-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/grilling-scenario.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared logic for the orchestrator grilling scenarios (#8932). Each check
+ * drives the REAL OrchestratorTaskService verification loop over a scripted ACP
+ * (see `orchestrator-grilling-harness.ts`); the verifier model is injected so
+ * the `.scenario.ts` can use the live model while
+ * `orchestrator-scenario-logic.test.ts` uses a deterministic content-aware stub.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  makeGrillingRuntime,
+  makeScriptedAcp,
+  OrchestratorTaskService,
+  seedActiveTask,
+  waitFor,
+} from "./orchestrator-grilling-harness.ts";
+
+type VerifierModel = (...args: unknown[]) => Promise<unknown>;
+
+/** A deterministic stand-in for the verifier model: PASS only when the prompt
+ * (which embeds the completion evidence) carries a pasted passing-test line —
+ * exactly the discrimination a real judge makes. Mirrors the live model's
+ * behavior closely enough to keep the keyless lane green. */
+export const contentAwareVerifierModel: VerifierModel = async (
+  ..._args: unknown[]
+) => {
+  const opts = _args[1] as { prompt?: string } | undefined;
+  const prompt = opts?.prompt ?? "";
+  const hasPassingTests =
+    /\d+\s+passing|tests?\s+pass(ed)?\b.*\d|0\s+fail/i.test(prompt);
+  return JSON.stringify(
+    hasPassingTests
+      ? { passed: true, summary: "all criteria proven", missing: [] }
+      : {
+          passed: false,
+          summary: "no pasted test output",
+          missing: ["tests pass"],
+        },
+  );
+};
+
+/**
+ * grilling-happy-path: a sub-agent claims done with NO test output → the grill
+ * round fires (corrective re-prompt citing the unmet criterion) → the sub-agent
+ * re-reports WITH passing test output → the task is verified done.
+ */
+export async function runGrillingHappyPathCheck(
+  baseRuntime: IAgentRuntime,
+  verifierModel: VerifierModel,
+): Promise<string | undefined> {
+  const { store, taskId, sessionId } = await seedActiveTask(["tests pass"]);
+  const acp = makeScriptedAcp();
+  const runtime = makeGrillingRuntime(baseRuntime, acp.service, verifierModel);
+  const service = new OrchestratorTaskService(runtime, { store });
+  await service.start();
+  try {
+    // Round 1: claim done with no evidence → must be grilled, not accepted.
+    acp.emit(sessionId, "task_complete", {
+      response: "I implemented the widget and I believe it works.",
+    });
+    const grilled = await waitFor(() => acp.sent.length > 0);
+    if (!grilled) return "the verifier never grilled a no-evidence completion";
+    const grill = acp.sent.at(-1)?.text ?? "";
+    if (!/tests pass/i.test(grill)) {
+      return `the grill should cite the unmet criterion 'tests pass':\n${grill}`;
+    }
+    if ((await store.getTask(taskId))?.task.status === "done") {
+      return "task was marked done despite no test evidence";
+    }
+
+    // Round 2: re-report WITH pasted passing test output → verified done.
+    acp.emit(sessionId, "task_complete", {
+      response:
+        "Done. Ran `npm test` — 12 passing, 0 failing. The widget renders correctly.",
+    });
+    const done = await waitFor(
+      async () => (await store.getTask(taskId))?.task.status === "done",
+    );
+    if (!done) {
+      const status = (await store.getTask(taskId))?.task.status;
+      return `task was not verified done after pasted evidence; status=${status}`;
+    }
+    return undefined;
+  } finally {
+    await service.stop().catch(() => undefined);
+  }
+}
+
+/**
+ * grilling-evidence-bundle: assert the git diff AND the test stdout from the
+ * sub-agent's completion actually reach the verifier's prompt (the verifier
+ * judges typed evidence, not the bare event summary).
+ */
+export async function runGrillingEvidenceBundleCheck(
+  baseRuntime: IAgentRuntime,
+): Promise<string | undefined> {
+  const { store, sessionId } = await seedActiveTask([
+    "tests pass",
+    "the implementation diff is included",
+  ]);
+  const acp = makeScriptedAcp();
+  const prompts: string[] = [];
+  const capturingModel: VerifierModel = async (..._args: unknown[]) => {
+    const opts = _args[1] as { prompt?: string } | undefined;
+    prompts.push(opts?.prompt ?? "");
+    return JSON.stringify({ passed: true, summary: "ok", missing: [] });
+  };
+  const runtime = makeGrillingRuntime(baseRuntime, acp.service, capturingModel);
+  const service = new OrchestratorTaskService(runtime, { store });
+  await service.start();
+  try {
+    const DIFF =
+      "diff --git a/src/widget.ts b/src/widget.ts\n+export const widget = () => 42;";
+    const TEST_STDOUT = "npm test → 7 passing, 0 failing";
+    acp.emit(sessionId, "task_complete", {
+      response: `Implemented the widget.\n\n${DIFF}\n\n${TEST_STDOUT}`,
+    });
+    const called = await waitFor(() => prompts.length > 0);
+    if (!called) {
+      return "the verifier model was never called with the completion evidence";
+    }
+    const prompt = prompts.join("\n");
+    if (
+      !prompt.includes("widget.ts") ||
+      !prompt.includes("export const widget")
+    ) {
+      return `the git diff did not reach the verifier prompt:\n${prompt.slice(0, 400)}`;
+    }
+    if (!prompt.includes("7 passing")) {
+      return `the test stdout did not reach the verifier prompt:\n${prompt.slice(0, 400)}`;
+    }
+    return undefined;
+  } finally {
+    await service.stop().catch(() => undefined);
+  }
+}

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-grilling-harness.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-grilling-harness.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared harness for the orchestrator grilling scenarios.
+ *
+ * The grilling/verification loop is internal: it fires when the
+ * OrchestratorTaskService receives a `task_complete` session event from the ACP
+ * subprocess, runs the LLM verifier over the task's acceptance criteria, and
+ * either marks the task `done` or sends a corrective "grill" back to the
+ * sub-agent. To exercise that loop deterministically inside the scenario runner
+ * (no real coding-agent subprocess), we:
+ *
+ *   1. construct the real OrchestratorTaskService over an in-memory store,
+ *   2. inject a SCRIPTED ACP (captures the grill re-prompts, lets us emit
+ *      `task_complete` events on demand), and
+ *   3. proxy the scenario's live runtime so the verifier's `useModel` call hits
+ *      whatever model the scenario wants (the live model for a live-lane
+ *      scenario, or a capturing stub for a deterministic one).
+ *
+ * Mirrors the unit harness in `__tests__/auto-goal-verify.test.ts`, lifted to
+ * run against a real runtime under the scenario CLI so it emits the JSON report
+ * + run viewer + native JSONL that PR_EVIDENCE.md requires.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { AcpService } from "../../../src/services/acp-service.ts";
+import { OrchestratorTaskService } from "../../../src/services/orchestrator-task-service.ts";
+import { OrchestratorTaskStore } from "../../../src/services/orchestrator-task-store.ts";
+
+export type EventHandler = (
+  sessionId: string,
+  event: string,
+  data: unknown,
+) => void;
+
+/** A scripted stand-in for AcpService: records grill re-prompts and lets the
+ * scenario emit `task_complete` events as if a sub-agent reported done. */
+export function makeScriptedAcp() {
+  let handler: EventHandler | undefined;
+  const sent: Array<{ sessionId: string; text: string }> = [];
+  const service = {
+    onSessionEvent(cb: EventHandler) {
+      handler = cb;
+      return () => {
+        handler = undefined;
+      };
+    },
+    sendToSession: async (sessionId: string, text: string) => {
+      sent.push({ sessionId, text });
+      return { stopReason: "end_turn", finalText: "ok" };
+    },
+    stopSession: async () => undefined,
+    getChangedPaths: () => [],
+    getSession: async () => undefined,
+    updateSessionMetadata: async () => undefined,
+  };
+  return {
+    service,
+    sent,
+    emit: (sessionId: string, event: string, data: unknown) =>
+      handler?.(sessionId, event, data),
+  };
+}
+
+/** Wrap the scenario's real runtime so `getService(ACP)` returns the scripted
+ * ACP and `useModel` is routed to `modelOverride` (the verifier model). Every
+ * other runtime member passes through to the live runtime untouched. */
+export function makeGrillingRuntime(
+  base: IAgentRuntime,
+  acp: ReturnType<typeof makeScriptedAcp>["service"],
+  modelOverride: (...args: unknown[]) => Promise<unknown>,
+): IAgentRuntime {
+  return new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop === "getService") {
+        return (type: string) =>
+          type === AcpService.serviceType
+            ? acp
+            : (target as IAgentRuntime).getService(type as never);
+      }
+      if (prop === "useModel") return modelOverride;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as IAgentRuntime;
+}
+
+/** Seed an in-memory task + a single ready session, advanced to `active` so the
+ * completion→validating→verify path is allowed. Returns ids + the store. */
+export async function seedActiveTask(acceptanceCriteria: string[]): Promise<{
+  store: OrchestratorTaskStore;
+  taskId: string;
+  sessionId: string;
+}> {
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const detail = await store.createTask({
+    title: "Implement the widget",
+    goal: "implement the widget and prove it works",
+    acceptanceCriteria,
+  });
+  const taskId = detail.task.id;
+  const sessionId = "scenario-sess-1";
+  const now = Date.now();
+  await store.addSession({
+    id: "row-1",
+    taskId,
+    sessionId,
+    framework: "opencode",
+    label: "Ada",
+    originalTask: "implement the widget",
+    workdir: "/tmp/widget",
+    status: "ready",
+    decisionCount: 0,
+    autoResolvedCount: 0,
+    registeredAt: now,
+    lastActivityAt: now,
+    idleCheckCount: 0,
+    taskDelivered: false,
+    lastSeenDecisionIndex: 0,
+    spawnedAt: now,
+    retryCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+    metadata: {},
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+  });
+  await store.updateTask(taskId, { status: "active" });
+  return { store, taskId, sessionId };
+}
+
+export { OrchestratorTaskService };
+
+/** Poll `predicate` until it returns true or the deadline passes. */
+export async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  { timeoutMs = 15000, intervalMs = 100 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/supervisor-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/supervisor-scenario.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared logic for the multi-task supervisor scenario. Kept here so both the
+ * `.scenario.ts` (run by the scenario CLI) and `orchestrator-scenario-logic`
+ * unit test exercise the SAME assertions against the real, pure supervisor
+ * digest functions — no model, no sub-agent subprocess, so it runs keyless.
+ */
+import {
+  composeRoomDigest,
+  runSupervisorTick,
+  type SupervisorTaskView,
+} from "../../../src/services/task-supervisor-service.ts";
+
+const ROOM_A = "11111111-1111-4111-8111-111111111111";
+const ROOM_B = "22222222-2222-4222-8222-222222222222";
+
+export function multiTaskViews(): SupervisorTaskView[] {
+  return [
+    {
+      id: "t-a1",
+      label: "Refactor auth",
+      status: "active",
+      activeSessions: 1,
+      sessionLabel: "opencode · acct-1",
+      origin: { roomId: ROOM_A, source: "telegram" },
+    },
+    {
+      id: "t-a2",
+      label: "Add billing page",
+      status: "validating",
+      activeSessions: 1,
+      sessionLabel: "claude · acct-2",
+      origin: { roomId: ROOM_A, source: "telegram" },
+    },
+    {
+      id: "t-b1",
+      label: "Fix flaky CI",
+      status: "blocked",
+      activeSessions: 0,
+      sessionLabel: null,
+      origin: { roomId: ROOM_B, source: "discord" },
+    },
+    // Terminal status → excluded from the live digest.
+    {
+      id: "t-done",
+      label: "Ship landing page",
+      status: "done",
+      activeSessions: 0,
+      sessionLabel: null,
+      origin: { roomId: ROOM_A, source: "telegram" },
+    },
+    // No chat origin → cannot be addressed, skipped entirely.
+    {
+      id: "t-null",
+      label: "Background reindex",
+      status: "active",
+      activeSessions: 1,
+      sessionLabel: null,
+      origin: null,
+    },
+  ];
+}
+
+/** Returns undefined on success, or an error string describing the first failed
+ * expectation (the scenario/finalCheck contract). */
+export async function runMultiTaskSupervisorCheck(): Promise<
+  string | undefined
+> {
+  const sent: Array<{ roomId: string; text: string }> = [];
+  const send = async (
+    target: { source: string; roomId: string },
+    content: { text?: string },
+  ) => {
+    sent.push({ roomId: target.roomId, text: content.text ?? "" });
+  };
+  const seen = new Map<string, string>();
+
+  // --- Tick 1: each live room gets its own digest (isolation). ---
+  const tick1 = await runSupervisorTick(multiTaskViews(), send, seen);
+  if (tick1.posted.length !== 2) {
+    return `expected 2 rooms to receive a digest, got ${tick1.posted.length}`;
+  }
+  const roomA = sent.find((s) => s.roomId === ROOM_A);
+  const roomB = sent.find((s) => s.roomId === ROOM_B);
+  if (!roomA || !roomB) return "expected a digest for room A AND room B";
+
+  if (
+    !roomA.text.includes("Refactor auth") ||
+    !roomA.text.includes("Add billing page")
+  ) {
+    return `room A digest is missing one of its tasks:\n${roomA.text}`;
+  }
+  if (roomA.text.includes("Fix flaky CI")) {
+    return `room A digest leaked room B's task (isolation broken):\n${roomA.text}`;
+  }
+  if (sent.some((s) => s.text.includes("Ship landing page"))) {
+    return "a terminal (done) task surfaced in a live digest";
+  }
+  if (sent.some((s) => s.text.includes("Background reindex"))) {
+    return "a chat-less (null-origin) task surfaced in a digest";
+  }
+  if (!roomA.text.startsWith("📡 Task update — 2 active")) {
+    return `room A digest header should report 2 active tasks:\n${roomA.text}`;
+  }
+
+  // --- Tick 2: unchanged state → both rooms deduped (no re-post). ---
+  const before = sent.length;
+  const tick2 = await runSupervisorTick(multiTaskViews(), send, seen);
+  if (tick2.posted.length !== 0 || tick2.skipped.length !== 2) {
+    return `unchanged tick should dedup both rooms, got posted=${tick2.posted.length} skipped=${tick2.skipped.length}`;
+  }
+  if (sent.length !== before)
+    return "dedup tick should not send any new digest";
+
+  // --- Tick 3: room A loses a task → A re-posts, B still deduped. ---
+  const fewer = multiTaskViews().filter((v) => v.id !== "t-a2");
+  const tick3 = await runSupervisorTick(fewer, send, seen);
+  if (!tick3.posted.includes(ROOM_A) || !tick3.skipped.includes(ROOM_B)) {
+    return `changed room A should re-post while room B dedups, got ${JSON.stringify(tick3)}`;
+  }
+  if (sent.at(-1)?.text.includes("Add billing page")) {
+    return "re-posted room A digest still lists the removed task";
+  }
+
+  // Sanity: the pure composer is stable and sorted by label.
+  const digest = composeRoomDigest(
+    multiTaskViews().filter(
+      (v) => v.origin?.roomId === ROOM_A && v.status !== "done",
+    ),
+  );
+  if (digest.indexOf("Add billing page") > digest.indexOf("Refactor auth")) {
+    return "digest lines should be sorted by label";
+  }
+  return undefined;
+}

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-evidence-bundle.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-evidence-bundle.scenario.ts
@@ -1,0 +1,28 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { runGrillingEvidenceBundleCheck } from "./_helpers/grilling-scenario.ts";
+
+// Grilling evidence bundle (#8932): the verifier must judge TYPED evidence, not
+// the bare event summary. The sub-agent's completion carries a git diff and the
+// test stdout; this asserts both actually reach the verifier's prompt. Uses a
+// capturing model (no live judgement needed), so it runs in the keyless
+// `pr-deterministic` lane. Shared logic is verified by
+// `orchestrator-scenario-logic.test.ts`.
+export default scenario({
+  lane: "pr-deterministic",
+  id: "orchestrator.grilling-evidence-bundle",
+  title: "Grilling: the git diff + test stdout reach the verifier",
+  domain: "agent-orchestrator",
+  tags: ["orchestrator", "grilling", "evidence", "deterministic"],
+  description:
+    "A sub-agent reports complete with a git diff and pasted test stdout. Asserts the OrchestratorTaskService assembles that evidence and passes both the diff and the test output through to the verifier prompt (the verifier judges typed evidence, not the event summary).",
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "grilling-evidence-bundle",
+      predicate: (ctx) =>
+        runGrillingEvidenceBundleCheck(ctx.runtime as IAgentRuntime),
+    },
+  ],
+});

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-happy-path.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-happy-path.scenario.ts
@@ -1,0 +1,33 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { runGrillingHappyPathCheck } from "./_helpers/grilling-scenario.ts";
+
+// Grilling happy path (#8932): a sub-agent claims done with NO test output →
+// the verifier grills (corrective re-prompt citing the unmet criterion) → the
+// sub-agent re-reports WITH pasted passing test output → the task is verified
+// done. The verifier runs against the scenario's LIVE model (the judgement is
+// what's under test), so this is the `live-only` lane. The same loop is asserted
+// deterministically in `orchestrator-scenario-logic.test.ts` for keyless CI.
+export default scenario({
+  lane: "live-only",
+  id: "orchestrator.grilling-happy-path",
+  title:
+    "Grilling: a no-evidence 'done' is grilled, then verified on pasted proof",
+  domain: "agent-orchestrator",
+  tags: ["orchestrator", "grilling", "verification", "live"],
+  description:
+    "Drives the OrchestratorTaskService verification loop: round 1 claims complete with no evidence and must be grilled (not accepted); round 2 re-reports with pasted passing test output and is verified done. The verifier judgement uses the live model.",
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "grilling-happy-path",
+      predicate: (ctx) => {
+        const runtime = ctx.runtime as IAgentRuntime;
+        return runGrillingHappyPathCheck(runtime, (...args: unknown[]) =>
+          (runtime.useModel as (...a: unknown[]) => Promise<unknown>)(...args),
+        );
+      },
+    },
+  ],
+});

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.multi-task-supervisor.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.multi-task-supervisor.scenario.ts
@@ -1,0 +1,27 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { runMultiTaskSupervisorCheck } from "./_helpers/supervisor-scenario.ts";
+
+// Two concurrent tasks in one room and a third in another exercise the
+// multi-task juggler (#8932): each room gets its own digest (isolation),
+// terminal / chat-less tasks are excluded, an unchanged tick is deduped, and a
+// changed tick re-posts only the affected room. The supervisor digest functions
+// are pure, so this runs in the keyless `pr-deterministic` lane — no model, no
+// sub-agent subprocess. The assertion logic is shared with, and verified by,
+// `orchestrator-scenario-logic.test.ts`.
+export default scenario({
+  lane: "pr-deterministic",
+  id: "orchestrator.multi-task-supervisor",
+  title: "Multi-task supervisor: per-room isolation + change-driven digest",
+  domain: "agent-orchestrator",
+  tags: ["orchestrator", "multi-task", "supervisor", "deterministic"],
+  description:
+    "Two concurrent tasks in one room and a third in another exercise the multi-task juggler: each room gets its own digest (isolation), terminal/chat-less tasks are excluded, an unchanged tick is deduped, and a changed tick re-posts only the affected room.",
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "multi-task-supervisor-isolation-and-digest",
+      predicate: () => runMultiTaskSupervisorCheck(),
+    },
+  ],
+});


### PR DESCRIPTION
Adds the three orchestrator scenarios #8932 asks for, under `plugins/plugin-agent-orchestrator/test/scenarios/`, each driving the **real** verification / supervisor code (not a mock of it):

| Scenario | Lane | What it exercises |
|---|---|---|
| `orchestrator.grilling-happy-path` | `live-only` | sub-agent claims done with **no** test output → verifier **grills** (corrective re-prompt citing the unmet criterion) → re-reports **with** pasted passing test output → **verified done**. Verifier judgement uses the live model. |
| `orchestrator.grilling-evidence-bundle` | `pr-deterministic` | asserts the git **diff** AND the **test stdout** from the completion actually reach the verifier's prompt (the verifier judges typed evidence, not the bare event summary). |
| `orchestrator.multi-task-supervisor` | `pr-deterministic` | two concurrent tasks in one room + a third in another → per-room digest **isolation**, terminal/chat-less exclusion, change-driven **dedup**. |

**Shared harness** (`test/scenarios/_helpers/`): a scripted ACP + a runtime proxy that routes the verifier's `useModel` to the chosen model — mirroring the proven unit harness in `auto-goal-verify.test.ts` — so the grilling loop runs without a real coding-agent subprocess. Wired into lanes via `test:scenarios` (keyless) / `test:scenarios:live`.

## Evidence

The scenario CLI's runtime boot is environment-heavy (and currently can't boot in this PR sandbox due to unrelated module-resolution gaps), so the SAME assertion helpers the scenarios call are exercised deterministically by a unit test, giving the grilling + multi-task logic **runnable, keyless coverage** independent of the live lane:

```
$ bunx vitest run src/__tests__/orchestrator-scenario-logic.test.ts
 ✓ multi-task supervisor: per-room isolation + change-driven digest
 ✓ grilling happy-path: no-evidence completion is grilled, pasted evidence is verified done
 ✓ grilling evidence-bundle: the git diff + test stdout reach the verifier prompt
 Test Files  1 passed (1)   Tests  3 passed (3)
```

- `bun packages/scenario-runner/src/cli.ts list plugins/plugin-agent-orchestrator/test/scenarios` discovers all three.
- `typecheck` + `biome check` clean.

The grilling assertions drive a real `OrchestratorTaskService` over the scripted ACP: a no-evidence `task_complete` is grilled (corrective `sendToSession` citing the criterion, task NOT marked done); a re-report with pasted passing output is verified `done`; and the evidence-bundle check confirms a completion's diff + test stdout flow through `buildCompletionEvidence` into the verifier prompt.

**Remaining for the credentialed CI lane:** running `test:scenarios:live` end-to-end against a live model + real ACP coding-agent subprocesses (the `live-only` happy-path), and adding a CI job that invokes these lanes. The scenario files + lane scripts are in place for that; the deterministic lane (`test:scenarios` + the unit test) is green and keyless.

Refs #8932

🤖 Generated with [Claude Code](https://claude.com/claude-code)