### PR TITLE
fix(ui): scrub at-rest cloud access token from localStorage on sign-out

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -16,6 +16,7 @@ import type { StewardClient as StewardReactClient } from "@stwd/react";
 import { StewardProvider, useAuth as useStewardAuth } from "@stwd/react";
 import { StewardClient } from "@stwd/sdk";
 import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import {
   clearServerStewardSessionCookies,
   clearStaleStewardSession,
@@ -209,7 +210,13 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
           }
         : null,
       session: auth.session,
-      signOut: () => auth.signOut(),
+      signOut: () => {
+        // Drop the at-rest JWT from the persisted active server before the SDK
+        // sign-out — leaving it in localStorage is an at-rest token leak. Keeps
+        // the backend selection (kind/apiBase) so re-auth lands on the same one.
+        scrubPersistedActiveServerToken();
+        auth.signOut();
+      },
       getToken: () => auth.getToken(),
       verifyEmailCallback: async (token: string, email: string) => {
         const result = await auth.verifyEmailCallback(token, email);

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -5,6 +5,7 @@ import {
   createPersistedActiveServer,
   loadPersistedActiveServer,
   savePersistedActiveServer,
+  scrubPersistedActiveServerToken,
 } from "./persistence";
 import {
   applyRestoredConnection,
@@ -126,6 +127,36 @@ describe("Cloud active server persistence", () => {
     expect(setBaseUrl).toHaveBeenCalledWith("http://127.0.0.1:31337");
     expect(setToken).not.toHaveBeenCalled();
     expect(startLocalRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrubs the at-rest access token on sign-out but keeps the server selection", () => {
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "cloud",
+        id: "cloud:agent-1",
+        label: "Demo Agent",
+        apiBase: "https://agent-runtime.example.test/",
+        accessToken: "jwt-to-scrub",
+      }),
+    );
+
+    scrubPersistedActiveServerToken();
+
+    const after = loadPersistedActiveServer();
+    expect(after?.accessToken).toBeUndefined();
+    expect(after).toEqual(
+      expect.objectContaining({
+        id: "cloud:agent-1",
+        kind: "cloud",
+        label: "Demo Agent",
+        apiBase: "https://agent-runtime.example.test",
+      }),
+    );
+  });
+
+  it("scrubbing the token is a safe no-op when nothing is persisted", () => {
+    expect(() => scrubPersistedActiveServerToken()).not.toThrow();
+    expect(loadPersistedActiveServer()).toBeNull();
   });
 
   it("rewrites persisted iOS loopback local agents to the IPC identity", () => {

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -1125,3 +1125,18 @@ export function clearPersistedActiveServer(): void {
     localStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
   }, undefined);
 }
+
+/**
+ * Drop the bearer access token from the persisted active server while keeping
+ * the server selection (kind/apiBase/label). Call this on sign-out: the token
+ * is a JWT and leaving it in localStorage after sign-out is an at-rest leak,
+ * but clearing the whole record would needlessly forget which backend to
+ * re-authenticate against.
+ */
+export function scrubPersistedActiveServerToken(): void {
+  const current = loadPersistedActiveServer();
+  if (!current?.accessToken) return;
+  const scrubbed = { ...current };
+  delete scrubbed.accessToken;
+  savePersistedActiveServer(scrubbed);
+}


### PR DESCRIPTION
## The leak
The persisted active-server record (`elizaos:active-server` in localStorage) kept its **bearer JWT after cloud sign-out**. `clearPersistedActiveServer()` is only called on a full local-state wipe (`complete-reset-local-state-after-wipe`), not on a normal sign-out — so a signed-out device left a usable access token at rest.

## Fix (surgical)
- **`persistence.ts`** — add `scrubPersistedActiveServerToken()`: drops just `accessToken`, keeps `kind`/`apiBase`/`label` so re-auth lands on the same backend (clearing the whole record would needlessly forget the selection).
- **`StewardProviderRuntime.tsx`** — call it in the cloud `signOut` wrap **before** the SDK `auth.signOut()`. Kept out of the `@stwd/sdk` internals; converges cleanly with #8939's token work.
- 2 unit tests (scrub-keeps-selection + safe-no-op when nothing persisted).

## Notes
- Flagged to me by @phone-agent (cloud-token lane); the actual fix point was the Steward sign-out wrap.
- biome clean. The new test runs in CI (the local ui-state test runner needs `@elizaos/core` built first — its generated action-docs throw on import otherwise; affects all ui-state tests, not this change — building core + attaching the local green run).