### PR TITLE
docs(personal-assistant): point scheduled-task runner refs at plugin-scheduling

### DIFF
--- a/plugins/plugin-personal-assistant/AGENTS.md
+++ b/plugins/plugin-personal-assistant/AGENTS.md
@@ -250,7 +250,7 @@ bun run --cwd plugins/plugin-personal-assistant clean              # Remove dist
 
 - **OWNER_SCREENTIME is macOS-only.** It is platform-gated via `isDarwin()` in `src/plugin.ts` (`platformGatedActionUmbrellas`). Do not add it unconditionally.
 - **Scheduler task init is deferred.** Task workers are registered inside `init()`, but `ensureTask` calls are scheduled via `runtime.initPromise` so they run after the runtime finishes initializing. Failures are non-fatal to plugin load; check `LIFEOPS_TASK_INIT_FAILURE_CACHE_KEY` in the runtime cache for diagnostics.
-- **The runner never inspects `promptInstructions`.** Routing is done purely on structural `ScheduledTask` fields. See `src/lifeops/scheduled-task/runner.ts`.
+- **The runner never inspects `promptInstructions`.** Routing is done purely on structural `ScheduledTask` fields. The runner lives in `plugins/plugin-scheduling/src/scheduled-task/runner.ts`; the personal-assistant side wires it in via `src/lifeops/scheduled-task/{service,scheduler,runtime-wiring}.ts`.
 - **Approval flows require an approval queue.** Outbound message sends and document signatures go through `PgApprovalQueue` before any external dispatch. Never dispatch directly from action handlers.
 - **`LifeOpsService` is composed from mixins.** Core logic lives in `src/lifeops/service-mixin-*.ts` files. `src/lifeops/service.ts` composes them. Add a new domain capability as a mixin.
 - **Default packs must pass lint.** `bun run lint:default-packs` (also `pretest`) enforces the rules embedded in `scripts/lint-default-packs.mjs`. CI blocks packs that fail.

--- a/plugins/plugin-personal-assistant/CLAUDE.md
+++ b/plugins/plugin-personal-assistant/CLAUDE.md
@@ -250,7 +250,7 @@ bun run --cwd plugins/plugin-personal-assistant clean              # Remove dist
 
 - **OWNER_SCREENTIME is macOS-only.** It is platform-gated via `isDarwin()` in `src/plugin.ts` (`platformGatedActionUmbrellas`). Do not add it unconditionally.
 - **Scheduler task init is deferred.** Task workers are registered inside `init()`, but `ensureTask` calls are scheduled via `runtime.initPromise` so they run after the runtime finishes initializing. Failures are non-fatal to plugin load; check `LIFEOPS_TASK_INIT_FAILURE_CACHE_KEY` in the runtime cache for diagnostics.
-- **The runner never inspects `promptInstructions`.** Routing is done purely on structural `ScheduledTask` fields. See `src/lifeops/scheduled-task/runner.ts`.
+- **The runner never inspects `promptInstructions`.** Routing is done purely on structural `ScheduledTask` fields. The runner lives in `plugins/plugin-scheduling/src/scheduled-task/runner.ts`; the personal-assistant side wires it in via `src/lifeops/scheduled-task/{service,scheduler,runtime-wiring}.ts`.
 - **Approval flows require an approval queue.** Outbound message sends and document signatures go through `PgApprovalQueue` before any external dispatch. Never dispatch directly from action handlers.
 - **`LifeOpsService` is composed from mixins.** Core logic lives in `src/lifeops/service-mixin-*.ts` files. `src/lifeops/service.ts` composes them. Add a new domain capability as a mixin.
 - **Default packs must pass lint.** `bun run lint:default-packs` (also `pretest`) enforces the rules embedded in `scripts/lint-default-packs.mjs`. CI blocks packs that fail.

--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -10,8 +10,9 @@ for contributors.
 Every reminder, check-in, follow-up, watcher, recap, approval surface, and
 nag-the-user-when-they-go-quiet flow is a **LifeOps scheduled item** stored
 as a `ScheduledTask` record and owned by the runner at
-`src/lifeops/scheduled-task/runner.ts`. There is no second LifeOps scheduling
-mechanism.
+`plugins/plugin-scheduling/src/scheduled-task/runner.ts` (the personal-assistant
+side wires it in via `src/lifeops/scheduled-task/{service,scheduler,runtime-wiring}.ts`).
+There is no second LifeOps scheduling mechanism.
 
 `ScheduledTask` is intentionally not the repository-wide "task" primitive.
 Core runtime tasks are persisted `Task` rows handled by `TaskService`; coding


### PR DESCRIPTION
## What

Docs-only. The LifeOps scheduled-task runner moved from `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runner.ts` (now **gone**) to `plugins/plugin-scheduling/src/scheduled-task/runner.ts` (exists). The personal-assistant docs still pointed at the old path.

Updates `README.md` + `AGENTS.md`/`CLAUDE.md` so the "single runner, structural routing" architecture note points at the real file, and adds that the personal-assistant side wires it in via `src/lifeops/scheduled-task/{service,scheduler,runtime-wiring}.ts`.

- Verified the new path exists and the old one is gone.
- `AGENTS.md` and `CLAUDE.md` kept byte-identical per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)