### PR TITLE
fix(voice): desktop voice handoff sends a computed voiceTurnSignal (#8786)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
@@ -58,6 +58,7 @@ class MockVoiceRuntimeAdapter implements VoiceRuntimeAdapter {
   played = false;
   runtimeHandedOff = false;
   runtimeHandoffCount = 0;
+  lastHandoffParams: VoiceRuntimeHandoffParams | undefined;
   playbackAvailable = true;
   asrAvailable = true;
   ttsAvailable = true;
@@ -179,6 +180,7 @@ class MockVoiceRuntimeAdapter implements VoiceRuntimeAdapter {
   ): Promise<VoiceRuntimeHandoffResult> {
     this.runtimeHandedOff = true;
     this.runtimeHandoffCount += 1;
+    this.lastHandoffParams = params;
     return {
       firstTokenText: "ok",
       responseText: `response:${params.text}`,
@@ -460,6 +462,30 @@ describe("VoiceService", () => {
     await flushVoiceEvents();
 
     expect(adapter.runtimeHandoffCount).toBe(1);
+  });
+
+  it("hands the final transcript off as VOICE_DM with a COMPUTED turn signal (#8786)", async () => {
+    const { voice, adapter } = harness({
+      ELIZA_VOICE_LIVE_RUNTIME: "1",
+    });
+
+    await voice.start({ mode: "local-runtime" });
+    adapter.emitAsrFinal({ text: "what is on my calendar today" });
+    await flushVoiceEvents();
+
+    expect(adapter.runtimeHandedOff).toBe(true);
+    // The signal must be COMPUTED by voice-service from the transcript — not
+    // injected by the caller — so the server voice gate
+    // (core.voice_turn_signal / _confirm) actually has something to read on
+    // desktop. Before #8786 this path sent a bare { text } and the gate was inert.
+    const signal = adapter.lastHandoffParams?.metadata?.voiceTurnSignal as
+      | Record<string, unknown>
+      | undefined;
+    expect(signal).toBeDefined();
+    expect(typeof signal?.endOfTurnProbability).toBe("number");
+    expect(signal?.agentShouldSpeak).toBe(true);
+    expect(["agent", "user", "unknown"]).toContain(signal?.nextSpeaker);
+    expect(String(signal?.source)).toMatch(/^client-ambient/);
   });
 
   it("starts live audio mode with a mocked adapter", async () => {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+import { buildVoiceTurnSignal } from "@elizaos/shared/voice/respond-gate";
 import type { TraceService } from "../trace/trace-service";
 import { VoiceError } from "./errors";
 import type {
@@ -11,6 +12,7 @@ import type {
   VoicePipelineId,
   VoicePipelineSnapshot,
   VoicePipelineStatus,
+  VoiceRuntimeHandoffParams,
   VoiceRuntimeStatus,
   VoiceSpeakParams,
   VoiceStartParams,
@@ -165,6 +167,9 @@ export class VoiceService {
   private traceSessionReady: Promise<void> | null = null;
   private readonly unsubscriptions: Array<() => void> = [];
   private runtimeCommitTurnId: VoiceTurnId | null = null;
+  /** Agent's most recent spoken reply + when it landed — feeds the echo guard. */
+  private lastAgentReply: string | undefined;
+  private lastAgentReplyAtMs: number | undefined;
 
   constructor(options: VoiceServiceOptions = {}) {
     this.traceService = options.traceService ?? null;
@@ -774,6 +779,36 @@ export class VoiceService {
       text,
     });
 
+    // Build the client voice-turn signal from the final transcript so the
+    // server voice gate (`core.voice_turn_signal` / `_confirm`) actually runs on
+    // desktop — matching the web `useShellController` path (#8786). Without it
+    // `getVoiceTurnSignalMetadata` returns null and both gates are inert, so
+    // desktop voice silently bypasses the turn-taking authority. The echo guard
+    // uses the agent's most recent spoken reply (recorded below).
+    // At handoff the agent is "thinking" (the user just finished), so echo
+    // suppression keys off how recently the agent last spoke, not a live
+    // agentSpeaking flag (which is always false here).
+    const signal = buildVoiceTurnSignal(text, {
+      recentAgentReply: this.lastAgentReply,
+      replyAgeMs:
+        this.lastAgentReplyAtMs !== undefined
+          ? this.now().getTime() - this.lastAgentReplyAtMs
+          : undefined,
+    });
+    const handoff: VoiceRuntimeHandoffParams = {
+      text,
+      // Spelled out as a JSON-safe literal (the signal is an interface, which is
+      // not assignable to Record<string, JsonValue> without an index signature).
+      metadata: {
+        voiceTurnSignal: {
+          endOfTurnProbability: signal.endOfTurnProbability,
+          nextSpeaker: signal.nextSpeaker,
+          agentShouldSpeak: signal.agentShouldSpeak,
+          source: signal.source,
+        },
+      },
+    };
+
     // Streaming handoff: consume the reply token-by-token so the first_token
     // mark reflects the true time-to-first-token (not full-reply latency) and
     // so a future phrase-by-phrase synth can begin before generation finishes.
@@ -789,29 +824,26 @@ export class VoiceService {
       try {
         let firstMarked = false;
         let accumulated = "";
-        const result = await streamFn.call(
-          this.runtimeAdapter,
-          { text },
-          {
-            onTextDelta: (_delta: string, fullText: string) => {
-              accumulated = fullText;
-              if (!firstMarked) {
-                firstMarked = true;
-                // Mark at first-delta wall time (mark() stamps now()).
-                void this.markModelFirstToken(fullText.slice(0, 32) || "…");
-              }
-            },
-            onDone: ({ fullText }: { fullText: string }) => {
-              if (fullText) accumulated = fullText;
-            },
+        const result = await streamFn.call(this.runtimeAdapter, handoff, {
+          onTextDelta: (_delta: string, fullText: string) => {
+            accumulated = fullText;
+            if (!firstMarked) {
+              firstMarked = true;
+              // Mark at first-delta wall time (mark() stamps now()).
+              void this.markModelFirstToken(fullText.slice(0, 32) || "…");
+            }
           },
-        );
+          onDone: ({ fullText }: { fullText: string }) => {
+            if (fullText) accumulated = fullText;
+          },
+        });
         const responseText = result.responseText ?? accumulated;
         if (!firstMarked) {
           await this.markModelFirstToken(responseText.slice(0, 32) || "…");
         }
         if (responseText) {
           this.requireActiveTurn().responseText = responseText;
+          this.recordAgentReply(responseText);
         }
         return;
       } catch {
@@ -827,11 +859,12 @@ export class VoiceService {
       (this.mode === "local-runtime" || this.mode === "live-audio") &&
       this.runtimeAdapter.sendRuntimeMessage
     ) {
-      const result = await this.runtimeAdapter.sendRuntimeMessage({ text });
+      const result = await this.runtimeAdapter.sendRuntimeMessage(handoff);
       firstTokenText = result.firstTokenText ?? result.responseText ?? "";
       responseText = result.responseText;
       raw = result.raw;
     }
+    if (responseText) this.recordAgentReply(responseText);
     const modelMark = await this.markModelFirstToken(
       firstTokenText,
       raw ?? null,
@@ -848,6 +881,13 @@ export class VoiceService {
         );
       }
     }
+  }
+
+  /** Remember the agent's last spoken reply so the next turn's echo guard can
+   * suppress the agent's own TTS bleeding back into an always-on mic (#8786). */
+  private recordAgentReply(reply: string): void {
+    this.lastAgentReply = reply;
+    this.lastAgentReplyAtMs = this.now().getTime();
   }
 
   private async handleTtsResult(


### PR DESCRIPTION
## Summary

Closes one acceptance criterion of #8786 (AC #8): the **Electrobun desktop voice path now engages the server voice gate**.

Desktop voice already reached the server as a `VOICE_DM`, but its only production caller (`voice-service.ts → handoffToRuntime`) passed a bare `{ text }`, so the message carried **no `voiceTurnSignal`**. `getVoiceTurnSignalMetadata` therefore returned `null` and both server gates — `core.voice_turn_signal` (suppress) and `core.voice_turn_signal_confirm` (promote IGNORE→RESPOND) — were **inert for desktop voice**. The web path (`useShellController`) builds and sends the signal; desktop silently bypassed the turn-taking authority.

The existing adapter test passed only because it **self-injected** a signal, masking that production never produced one.

## Change

- `voice-service.ts` builds the signal from the final transcript via `@elizaos/shared/voice/respond-gate` `buildVoiceTurnSignal`, carrying the agent's most recent reply (`recentAgentReply` / `replyAgeMs`) for the echo guard, and passes it as `VOICE_DM` metadata on **both** the streaming and buffered runtime handoffs.
- Records the agent's last spoken reply (`recordAgentReply`) so the next turn's echo guard can suppress the agent's own TTS bleeding back into an always-on mic.
- Adds a `voice-service` test that drives the **real** ASR-final handoff and asserts the signal is **computed by the service** (not injected by the caller).

## Evidence (verified locally on Windows)

- **Electrobun voice tests: 23/23 pass** — `bun run --cwd packages/app-core/platforms/electrobun test src/voice/voice-service.test.ts src/voice/voice-runtime-adapter.test.ts` (includes the new `#8786` test).
- **Typecheck: voice-service clean** — `bun run --cwd packages/app-core/platforms/electrobun typecheck` reports zero errors in `voice-service.ts`. (The one remaining electrobun typecheck error, `getCatalogCommands` in `@elizaos/agent`, is pre-existing and voice-unrelated.)
- **Biome: clean** on both changed files.

## Scope / not included

This is one slice of #8786. The remaining acceptance criteria (web/desktop joined ASR+diarization ingestion with `speakerEntityId`; the live `/api/voice/audio-frames` route still emitting `text:""`; wire-or-delete `engine.runVoiceTurn`; a true multi-agent-room e2e) are larger and several are gated on the product decisions the issue itself flags as open — left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
