### PR TITLE
fix(ui): scrub agent-profile tokens on sign-out + gate off-Electrobun favorites + doc fix (follow-up #9049/#9050/#9055)

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -16,6 +16,7 @@ import type { StewardClient as StewardReactClient } from "@stwd/react";
 import { StewardProvider, useAuth as useStewardAuth } from "@stwd/react";
 import { StewardClient } from "@stwd/sdk";
 import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import {
   clearServerStewardSessionCookies,
@@ -214,7 +215,10 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
         // Drop the at-rest JWT from the persisted active server before the SDK
         // sign-out — leaving it in localStorage is an at-rest token leak. Keeps
         // the backend selection (kind/apiBase) so re-auth lands on the same one.
+        // The same JWT is also copied into the per-agent profile records, so
+        // scrub those too — otherwise the token survives at rest there.
         scrubPersistedActiveServerToken();
+        scrubPersistedAgentProfileTokens();
         auth.signOut();
       },
       getToken: () => auth.getToken(),

--- a/packages/ui/src/components/pages/ViewCatalog.test.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.test.tsx
@@ -14,10 +14,12 @@ import {
   registerDynamicView,
   unregisterDynamicView,
 } from "../../bridge/electrobun-rpc";
+import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import { useAvailableViews } from "../../hooks/useAvailableViews";
 import { useViewCatalog } from "../../hooks/useViewCatalog";
 import { getActiveViewModality } from "../../platform/platform-guards";
+import { SPRINGBOARD_STORAGE_KEY } from "../../state/springboard-layout";
 import { useIsDeveloperMode } from "../../state/useDeveloperMode";
 import {
   useViewChatBinding,
@@ -54,6 +56,7 @@ vi.mock("../../bridge/electrobun-rpc", () => ({
   unregisterDynamicView: vi.fn(),
 }));
 
+const isElectrobunRuntimeMock = vi.mocked(isElectrobunRuntime);
 const useAvailableViewsMock = vi.mocked(useAvailableViews);
 const useViewCatalogMock = vi.mocked(useViewCatalog);
 const useIsDeveloperModeMock = vi.mocked(useIsDeveloperMode);
@@ -166,6 +169,7 @@ describe("ViewCatalog", () => {
       refresh: vi.fn(),
     });
     useIsDeveloperModeMock.mockReturnValue(false);
+    isElectrobunRuntimeMock.mockReturnValue(true);
     getActiveViewModalityMock.mockReturnValue("gui");
     useViewCatalogMock.mockReturnValue({
       entries: [],
@@ -215,6 +219,23 @@ describe("ViewCatalog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Remote Ledger" }));
 
     expect(window.location.pathname).toBe("/apps/remote-ledger");
+  });
+
+  it("falls back to Springboard local favorites when off the Electrobun desktop shell", () => {
+    // useDesktopTabs is inert off-desktop, so the controlled favorites dock
+    // would be permanently empty. Off-Electrobun the catalog must omit the
+    // controlled props and let Springboard manage favorites locally.
+    isElectrobunRuntimeMock.mockReturnValue(false);
+
+    render(<ViewCatalog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByTestId("springboard-fav-local.notes"));
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(SPRINGBOARD_STORAGE_KEY) ?? "{}",
+    );
+    expect(stored.favorites).toContain("local.notes");
   });
 
   it("hides TUI and XR views entirely on a GUI surface", () => {

--- a/packages/ui/src/components/pages/ViewCatalog.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.tsx
@@ -605,7 +605,8 @@ export function ViewCatalog() {
   } = useDesktopTabs();
   const isDeveloperMode = useIsDeveloperMode();
   const enabledKinds = useEnabledViewKinds();
-  const canManageDynamicViews = isDeveloperMode && isElectrobunRuntime();
+  const isDesktop = isElectrobunRuntime();
+  const canManageDynamicViews = isDeveloperMode && isDesktop;
   // Views are scoped to the surface modality: a GUI surface lists only GUI
   // views (TUI/XR hidden entirely); an XR surface lists only XR views.
   const activeModality = useMemo(() => getActiveViewModality(), []);
@@ -1174,8 +1175,12 @@ export function ViewCatalog() {
               <Springboard
                 entries={springboardEntries}
                 onLaunch={handleSpringboardLaunch}
-                favoriteIds={favoriteViewIds}
-                onToggleFavorite={handleToggleFavorite}
+                // Favorites are unified with desktop tabs only on the Electrobun
+                // shell (useDesktopTabs is inert off-desktop). On web/mobile,
+                // omit the controlled props so Springboard uses its own local
+                // favorites state instead of a permanently empty, no-op dock.
+                favoriteIds={isDesktop ? favoriteViewIds : undefined}
+                onToggleFavorite={isDesktop ? handleToggleFavorite : undefined}
                 canManageView={canManageDynamicViews ? () => true : undefined}
                 onEditView={
                   canManageDynamicViews ? handleSpringboardEdit : undefined

--- a/packages/ui/src/state/agent-profiles.test.ts
+++ b/packages/ui/src/state/agent-profiles.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  addAgentProfile,
+  loadAgentProfileRegistry,
+  scrubPersistedAgentProfileTokens,
+} from "./agent-profiles";
+
+describe("Agent profile token scrub", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("drops the access token from every profile on sign-out but keeps the rest", () => {
+    const a = addAgentProfile({
+      label: "Cloud Agent",
+      kind: "cloud",
+      apiBase: "https://agent-runtime.example.test",
+      accessToken: "jwt-to-scrub",
+    });
+    const b = addAgentProfile({
+      label: "Remote Agent",
+      kind: "remote",
+      apiBase: "https://remote.example.test",
+      accessToken: "another-jwt",
+    });
+
+    scrubPersistedAgentProfileTokens();
+
+    const registry = loadAgentProfileRegistry();
+    const scrubbedA = registry.profiles.find((p) => p.id === a.id);
+    const scrubbedB = registry.profiles.find((p) => p.id === b.id);
+
+    expect(scrubbedA?.accessToken).toBeUndefined();
+    expect(scrubbedB?.accessToken).toBeUndefined();
+    expect(scrubbedA).toEqual(
+      expect.objectContaining({
+        id: a.id,
+        label: "Cloud Agent",
+        kind: "cloud",
+        apiBase: "https://agent-runtime.example.test",
+      }),
+    );
+    // Active selection preserved.
+    expect(registry.activeProfileId).toBe(b.id);
+  });
+
+  it("is a safe no-op when no profiles exist", () => {
+    expect(() => scrubPersistedAgentProfileTokens()).not.toThrow();
+    expect(loadAgentProfileRegistry().profiles).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/state/agent-profiles.ts
+++ b/packages/ui/src/state/agent-profiles.ts
@@ -130,6 +130,25 @@ export function removeAgentProfile(id: string): void {
   saveAgentProfileRegistry(registry);
 }
 
+/**
+ * Drop the bearer access token from every persisted agent profile while keeping
+ * the rest of each profile (label/kind/apiBase/active selection). Call this on
+ * sign-out: the token is a JWT and leaving copies in localStorage after sign-out
+ * is an at-rest leak, but clearing the whole registry would needlessly forget
+ * which backends to re-authenticate against.
+ */
+export function scrubPersistedAgentProfileTokens(): void {
+  const registry = loadAgentProfileRegistry();
+  let changed = false;
+  registry.profiles = registry.profiles.map((profile) => {
+    if (!profile.accessToken) return profile;
+    changed = true;
+    const { accessToken, ...rest } = profile;
+    return rest;
+  });
+  if (changed) saveAgentProfileRegistry(registry);
+}
+
 export function updateAgentProfile(
   id: string,
   updates: Partial<Omit<AgentProfile, "id" | "createdAt">>,

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -129,7 +129,9 @@ export const appControlPlugin: Plugin = {
 	//     resolveIntentView → matchViewCommand. The agent may also pick it.
 	//  3. POST   — viewContextEvaluator (small model): catches CONTEXTUAL intent
 	//     the user never spelled out ("fix the login bug" -> task-coordinator).
-	//     Its gate defers whenever the rigid matcher already matched.
+	//     Its gate defers whenever resolveIntentView already matches a direct
+	//     surface (the rigid matchViewCommand matcher, or the legacy intent
+	//     rules it falls back to), so it never contends with the action.
 	// view-followup-routing handles mutation follow-ups on the active view.
 	evaluators: [viewContextEvaluator],
 	responseHandlerEvaluators: [


### PR DESCRIPTION
Small, high-confidence follow-up applying code-review findings against three just-merged PRs.

## Fix 1 — Residual at-rest token leak (follow-up #9055)
**Finding:** #9055 added `scrubPersistedActiveServerToken` to strip the Steward JWT from the `elizaos:active-server` localStorage record on sign-out, but a byte-identical copy of the same JWT also persists in the per-agent profile records (`packages/ui/src/state/agent-profiles.ts`, written via `addAgentProfile({... accessToken ...})`). On sign-out those copies were **not** scrubbed, so the JWT survived at rest.

**Change:**
- `packages/ui/src/state/agent-profiles.ts` — new `scrubPersistedAgentProfileTokens()` that strips only `accessToken` from each profile, preserving label/kind/apiBase and the active selection.
- `packages/ui/src/cloud/shell/StewardProviderRuntime.tsx:217` — call it in the same sign-out path as `scrubPersistedActiveServerToken()`.
- `packages/ui/src/state/agent-profiles.test.ts` — new test asserting the token is gone (and the rest preserved) after sign-out, plus a safe no-op case.

## Fix 2 — Dead favorite/pin control off-Electrobun (follow-up #9050)
**Finding:** `ViewCatalog.tsx` always passed `onToggleFavorite`, putting `Springboard` in controlled mode sourced from `useDesktopTabs`, which returns `[]` and no-ops when `!isElectrobunRuntime()`. So on web/mobile the favorites dock was permanently empty and the per-tile pin star did nothing.

**Change:** `ViewCatalog.tsx` now omits `favoriteIds`/`onToggleFavorite` when `!isElectrobunRuntime()`, so `Springboard` falls back to its existing internal local-favorites state (the cleaner of the two options — the affordance stays useful on every platform instead of being hidden). Added a `ViewCatalog.test.tsx` case asserting the off-Electrobun pin star persists to the springboard layout.

## Fix 3 — Stale doc comment (follow-up #9049)
**Finding:** after #9049 split the matcher, the view-switch cascade comment describing the `viewContextEvaluator` gate was inaccurate.

**Change:** comment-only. `plugins/plugin-app-control/src/index.ts:132` now accurately states the gate defers via `resolveIntentView` (rigid `matchViewCommand` **plus** the legacy intent rules it falls back to). (The literal phrasing called out in the brief lived here, not in `view-command-shortcut.ts`, whose comment was already accurate.)

## Verify
- `bun run --cwd packages/ui test ViewCatalog.test.tsx agent-profiles.test.ts` → **15 passed** (run in the main checkout; this worktree's hoisted node_modules can't resolve `lucide-react`/`@stwd/*` for jsdom component tests — a known worktree artifact, not a code issue).
- `biome check` on all five touched files → clean.
- `bun run --cwd packages/ui typecheck` → the only errors on touched files are the pre-existing worktree module-resolution failures (`lucide-react`, `@stwd/react`, `@stwd/sdk`); no type errors in the added logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)