### PR TITLE
fix(orchestrator): exclude test/ scenarios from the declaration build (fixes red CI)

### DIFF
--- a/plugins/plugin-agent-orchestrator/tsconfig.build.json
+++ b/plugins/plugin-agent-orchestrator/tsconfig.build.json
@@ -25,6 +25,7 @@
     "vendor/**",
     "scripts/**",
     "src/test-utils/**",
+    "test/**",
     "vitest.config.ts",
     "**/__tests__/**",
     "**/*.test.ts",


### PR DESCRIPTION
## What
`#9054`/`#9051` added `test/scenarios/*.scenario.ts` (+ `test/scenarios/_helpers/*.ts`), which use `.ts` import extensions. The orchestrator's `tsconfig.build.json` `exclude` only covered `__tests__/`, `*.test.ts`, `*.spec.ts`, and `src/test-utils/` — **not `test/`** — so the scenario files get pulled into the declaration build and fail it:

```
test/scenarios/_helpers/grilling-scenario.ts(15,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```

(`allowImportingTsExtensions` is intentionally off for the runtime build.) This currently red-fails `@elizaos/plugin-agent-orchestrator#build` on develop.

## Fix
Add `test/**` to the build `exclude`. Test scenarios are vitest-run, not part of the shipped `.d.ts` surface.

## Verify
`bun run --cwd plugins/plugin-agent-orchestrator build` → `🎉 All builds completed` (was exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
