### PR TITLE
fix(orchestrator): stop emitting phantom 'blocked' for auto-approved sub-agent permissions

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -562,6 +562,16 @@ export class NativeAcpClient {
     return false;
   }
 
+  /** Whether a `session/request_permission` will be auto-approved without user
+   *  interaction — mirrors `resolvePermission`'s decision. AcpService uses this
+   *  to avoid surfacing a phantom "blocked" for a request the transport
+   *  immediately approves under the session's preset. */
+  approvesPermissionRequest(
+    params: Record<string, unknown> | undefined,
+  ): boolean {
+    return this.isOperationApproved(inferToolKind(asRecord(params?.toolCall)));
+  }
+
   private async resolveReadablePath(
     requested: string | undefined,
   ): Promise<string> {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1740,21 +1740,33 @@ export class AcpService extends Service {
           asRecord(params?.toolCall)?.kind ??
           "permission required",
       );
-      this.emitSessionEvent(sessionId, "blocked", {
-        message: description,
-        request: params,
-      });
-      if (isAuthText(description))
-        this.emitSessionEvent(sessionId, "login_required", {
+      // The native transport auto-responds to permission requests per the
+      // session's preset; surfacing "blocked" for a request it immediately
+      // approves is a phantom block that derails the planner (re-spawns + a
+      // user-facing "agent is blocked"). Only surface a genuine wait-for-user:
+      // an auth challenge (always), or an op the transport won't approve (a
+      // restrictive preset, or the legacy CLI transport with no native client).
+      const autoApproved =
+        this.nativeClients.get(sessionId)?.approvesPermissionRequest(params) ??
+        false;
+      const isAuthChallenge = isAuthText(description);
+      if (isAuthChallenge || !autoApproved) {
+        this.emitSessionEvent(sessionId, "blocked", {
           message: description,
           request: params,
         });
-      void this.store.updateStatus(sessionId, "blocked").catch((err) =>
-        this.log("warn", "failed to persist blocked status", {
-          sessionId,
-          err,
-        }),
-      );
+        if (isAuthChallenge)
+          this.emitSessionEvent(sessionId, "login_required", {
+            message: description,
+            request: params,
+          });
+        void this.store.updateStatus(sessionId, "blocked").catch((err) =>
+          this.log("warn", "failed to persist blocked status", {
+            sessionId,
+            err,
+          }),
+        );
+      }
     }
 
     if (sessionId && method === "session/update") {


### PR DESCRIPTION
## What
`acp-service` surfaced a `blocked` session event on **every** `session/request_permission` — *before* approval was computed. Under the autonomous preset (the default for coding sub-agents), the native transport immediately approves the request, so the "blocked" was **phantom**: it posted a user-facing "⏸️ agent is blocked" and derailed the planner into re-spawning the same task (observed live: a factorial occasionally answered *"I handled the available step."* instead of the number, with a spurious "the sub-agent was blocked" message).

## Fix
Gate the emit on the transport's **actual** decision. Adds `NativeAcpClient.approvesPermissionRequest(params)` (mirrors `resolvePermission`'s `isOperationApproved(inferToolKind(...))`) and only surfaces `blocked` for a genuine wait-for-user:
- an **auth challenge** (always — it needs the user), or
- an op a **restrictive preset / the legacy CLI transport** won't auto-approve.

Auto-approved ops (autonomous/permissive) no longer emit a phantom block.

## Verify
Live on cerebras + opencode: factorial coding tasks now return a single correct answer with **zero `blocked` posts** and one spawn (previously: phantom "blocked" + re-spawns + occasional non-answer). Backend-agnostic — verified on opencode, claude, and codex sub-agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
