### PR TITLE
refactor(local-inference): finish M9 generic-GGUF cleanup + purge M8 legacy tier refs

### DIFF
--- a/packages/shared/src/local-inference/types.ts
+++ b/packages/shared/src/local-inference/types.ts
@@ -100,13 +100,12 @@ export interface InstalledModel {
   runtimeRole?: "chat" | "mtp-drafter";
   companionFor?: string;
   /**
-   * Which desktop text runtime serves this model. `"fused-eliza1"` for an
-   * Eliza-1 bundle (full pipeline: same-file MTP, fork KV kernels, fused
-   * voice/vision); `"generic-gguf"` for a single downloaded/scanned GGUF
-   * served from an explicit `path` with stock f16 KV and reduced
-   * optimizations. Backfilled at the registry-read boundary for legacy rows
-   * via `classifyInstalledModelRuntimeClass`; consumers read the field rather
-   * than re-deriving it from the id.
+   * Which desktop text runtime serves this model. Always `"fused-eliza1"` — an
+   * Eliza-1 bundle served by the full pipeline (same-file MTP, fork KV kernels,
+   * fused voice/vision). The local stack is Eliza-1 only (#8808). Backfilled at
+   * the registry-read boundary for legacy rows via
+   * `classifyInstalledModelRuntimeClass`; consumers read the field rather than
+   * re-deriving it from the id.
    */
   runtimeClass?: import("./runtime-class.js").RuntimeClass;
 }
@@ -436,11 +435,10 @@ export interface CatalogModel {
   /** Runtime-specific acceleration metadata. */
   runtime?: LocalRuntimeAcceleration;
   /**
-   * Which desktop text runtime serves this catalog model. `"fused-eliza1"`
-   * for the curated Eliza-1 tiers (full pipeline); `"generic-gguf"` for
-   * synthetic Hugging Face / ModelScope search results (reduced
-   * optimizations). Populated by the catalog factory and the hub-search
-   * synthesizers; consumers read the field rather than matching the id prefix.
+   * Which desktop text runtime serves this catalog model. Always
+   * `"fused-eliza1"` — the curated Eliza-1 tiers, served by the full pipeline.
+   * The local stack is Eliza-1 only (#8808). Populated by the catalog factory;
+   * consumers read the field rather than matching the id prefix.
    */
   runtimeClass?: import("./runtime-class.js").RuntimeClass;
   /**

--- a/plugins/plugin-local-inference/__tests__/vl-cross-eviction.test.ts
+++ b/plugins/plugin-local-inference/__tests__/vl-cross-eviction.test.ts
@@ -230,7 +230,7 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 	});
 
 	it("vision keyed by different modelKey on the same slot still evicts and reloads", async () => {
-		// 0_8b → 2b within the vision-describe capability is the on-device
+		// 4b → 2b within the vision-describe capability is the on-device
 		// scenario of a user switching tiers mid-session.
 		const arbiter = newArbiter();
 		arbiter.start();
@@ -249,7 +249,7 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-0_8b",
+			modelKey: "qwen3-vl-4b",
 			payload: { image: { kind: "bytes", bytes: tinyPngBytes() } },
 		});
 		await arbiter.requestVisionDescribe<

--- a/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
+++ b/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
@@ -30,7 +30,9 @@ afterEach(() => {
 	}
 });
 
-async function registerGenericModel(): Promise<InstalledModel> {
+async function registerForeignModel(): Promise<InstalledModel> {
+	// A model whose id is NOT a curated Eliza-1 tier. The setAssignment boundary
+	// must reject it — the local stack is Eliza-1 only (#8808).
 	const dir = elizaModelsDir();
 	fs.mkdirSync(dir, { recursive: true });
 	const filePath = path.join(dir, "llama-3.2-3b-q4.gguf");
@@ -43,7 +45,6 @@ async function registerGenericModel(): Promise<InstalledModel> {
 		installedAt: new Date().toISOString(),
 		lastUsedAt: null,
 		source: "eliza-download",
-		runtimeClass: "generic-gguf",
 	};
 	await upsertElizaModel(model);
 	return model;
@@ -76,8 +77,8 @@ async function registerFusedModel(): Promise<InstalledModel> {
 // "non-eliza-1 models are rejected" contract.)
 
 describe("setAssignment boundary validation", () => {
-	it("rejects a generic GGUF on desktop before assignment writes", async () => {
-		const model = await registerGenericModel();
+	it("rejects a non-Eliza-1 model on desktop before assignment writes", async () => {
+		const model = await registerForeignModel();
 		await expect(setAssignment("TEXT_LARGE", model.id)).rejects.toBeInstanceOf(
 			AssignmentRejectedError,
 		);
@@ -85,9 +86,9 @@ describe("setAssignment boundary validation", () => {
 		expect(await readAssignments()).toEqual({});
 	});
 
-	it("rejects a generic GGUF on mobile too", async () => {
+	it("rejects a non-Eliza-1 model on mobile too", async () => {
 		process.env.ELIZA_PLATFORM = "ios";
-		const model = await registerGenericModel();
+		const model = await registerForeignModel();
 		await expect(setAssignment("TEXT_LARGE", model.id)).rejects.toThrow(
 			/curated Eliza-1/i,
 		);

--- a/plugins/plugin-local-inference/src/services/fused-eliza1-no-regression.test.ts
+++ b/plugins/plugin-local-inference/src/services/fused-eliza1-no-regression.test.ts
@@ -1,12 +1,10 @@
 /**
  * #8808 acceptance criterion 4 — fused eliza-1 no-regression.
  *
- * Adding the generic single-file GGUF runtime must NOT change how a fused
- * Eliza-1 tier is served. This test pins the invariants:
+ * The local stack is Eliza-1 only (#8808 cutover), so serving is deterministic.
+ * This test pins the invariants:
  *   - `decideBackend` / `BackendDispatcher` route a `runtimeClass:"fused-eliza1"`
- *     model to the fused `llama-cpp` runtime (never to the generic backend),
- *   - a `runtimeClass:"generic-gguf"` model routes to the explicit-`modelPath`
- *     generic backend,
+ *     model to the fused `llama-cpp` runtime,
  *   - the fused path retains its full-pipeline binding: the `BackendPlan` that
  *     reaches the fused backend still carries the catalog entry (with its
  *     `runtime.mtp` speculative-decode block) and the bundle-root override that
@@ -81,12 +79,10 @@ describe("fused eliza-1 no-regression (C4)", () => {
 
 	it("dispatcher forwards the fused full-pipeline binding (catalog + mtp + bundleRoot) to the fused backend", async () => {
 		const ffi = makeBackend("llama-cpp");
-		const generic = makeBackend("generic-gguf");
 		const dispatcher = new BackendDispatcher(
 			ffi,
 			() => true,
 			() => null,
-			generic,
 		);
 
 		const bundleRoot = "/models/eliza-1-4b";
@@ -106,8 +102,7 @@ describe("fused eliza-1 no-regression (C4)", () => {
 
 		await dispatcher.load(plan);
 
-		// Routed to the fused runtime, never the generic one.
-		expect(generic.loaded).toHaveLength(0);
+		// Routed to the fused runtime.
 		expect(ffi.loaded).toHaveLength(1);
 		expect(dispatcher.activeBackendId()).toBe("llama-cpp");
 
@@ -127,17 +122,15 @@ describe("fused eliza-1 no-regression (C4)", () => {
 		expect(forwarded.overrides?.cacheTypeV).toBe("tbq3_0");
 	});
 
-	it("env-override=llama-cpp keeps a fused tier on the fused path (no generic detour)", async () => {
+	it("env-override=llama-cpp keeps a fused tier on the fused path", async () => {
 		const prev = process.env.ELIZA_INFERENCE_BACKEND;
 		process.env.ELIZA_INFERENCE_BACKEND = "llama-cpp";
 		try {
 			const ffi = makeBackend("llama-cpp");
-			const generic = makeBackend("generic-gguf");
 			const dispatcher = new BackendDispatcher(
 				ffi,
 				() => true,
 				() => null,
-				generic,
 			);
 			const decision = dispatcher.decide({
 				modelPath: "/models/eliza-1-4b/text/eliza-1-4b-128k.gguf",

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget.test.ts
@@ -366,9 +366,6 @@ describe("pickVoiceTierSlot", () => {
 		expect(
 			pickVoiceTierSlot({ textModelId: "eliza-1-2b", deviceTier: "GOOD" }),
 		).toBe("desktop-2b");
-		expect(
-			pickVoiceTierSlot({ textModelId: "eliza-1-1_7b", deviceTier: "GOOD" }),
-		).toBe("desktop-2b");
 	});
 
 	it("falls through to desktop-2b (the entry tier) for small / unknown ids", () => {


### PR DESCRIPTION
Part of the Gemma 4 cutover (#9033 / #9060). The generic-single-GGUF backend was already removed from the runtime (backend.ts/engine.ts/runtime-class.ts are llama-cpp / fused-eliza1 only); this removes the **stale references the merge left behind** so the local-inference surface is genuinely Eliza-1-only.

## M9 — generic-GGUF reference cleanup
- `fused-eliza1-no-regression.test.ts`: drop the dead `generic` backend foil (the `BackendDispatcher` 4th param no longer exists) + the docstring's generic-gguf bullet. The test now pins "every model routes to the fused `llama-cpp` runtime" without the removed foil.
- `assignment-validation.test.ts`: `registerGenericModel` → `registerForeignModel`, drop the invalid `runtimeClass:"generic-gguf"` (rejection is **id-based** via `isCuratedEliza1AssignmentId`, not runtimeClass), rename the two tests to "rejects a non-Eliza-1 model". The setAssignment boundary contract is preserved.
- `shared/local-inference/types.ts`: the two `runtimeClass` doc comments now state the field is always `"fused-eliza1"`.

## M8 — purge last legacy tier refs in tests
- `voice-budget.test.ts`: drop the `eliza-1-1_7b` assertion (purged tier; the "small/unknown ids fall through to desktop-2b" test already covers it).
- `vl-cross-eviction.test.ts`: `qwen3-vl-0_8b` → `qwen3-vl-4b` (vision eviction scenario; `qwen3-vl` stays the vision family, only the purged size changes).

## Evidence
- `bun run --cwd plugins/plugin-local-inference typecheck` — green
- `bun run --cwd packages/shared typecheck` — green
- The 4 affected test files: **42 tests pass**
- biome check — clean (no fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)