### PR TITLE
fix(plugin-sql): serialize schema-dist write to remove parallel build race

### DIFF
--- a/plugins/plugin-sql/src/build.ts
+++ b/plugins/plugin-sql/src/build.ts
@@ -174,6 +174,13 @@ await writeFile(
 // resolve to a runtime JS file. Emit a small shim that re-exports the
 // schema from the bundled root so the consumer doesn't need to know the
 // internal layout.
+//
+// `dist/schema/` is otherwise only created as a side effect of the `tsc`
+// declaration emit above. Create it explicitly so this write never depends on
+// that incidental ordering — under parallel turbo builds a partial or contended
+// tsc emit could leave the directory absent and crash this step with
+// `ENOENT ... src/dist/schema/index.js`.
+mkdirSync(join(DIST, "schema"), { recursive: true });
 await writeFile(join(DIST, "schema", "index.js"), `export * from '../node/index.node.js';\n`);
 await appendFile(
   join(DIST, "index.node.d.ts"),


### PR DESCRIPTION
## Root cause

`plugins/plugin-sql/src/build.ts` writes the runtime schema shim at:

```ts
await writeFile(join(DIST, "schema", "index.js"), `export * from '../node/index.node.js';\n`);
```

but `dist/schema/` was never created explicitly. The setup block only `mkdirSync`s `dist/{node,browser,cjs,drizzle}` — **not** `dist/schema`. That directory existed solely as an *incidental side effect* of the preceding `tsc --noCheck` declaration emit (its `include` covers `schema/**/*.ts`, so tsc happened to materialize `dist/schema/*.d.ts` first).

Under parallel turbo execution (`bun run build`), a contended or partially-completed tsc emit can leave `dist/schema/` absent at the moment of the `writeFile`, which then throws the intermittent:

```
ENOENT: no such file or directory, open '.../src/dist/schema/index.js'
```

Standalone `bun run --cwd plugins/plugin-sql build` always passed because the serial run let tsc reliably create the directory before the write.

## Fix

Create the directory explicitly, removing the implicit ordering dependency on tsc:

```ts
mkdirSync(join(DIST, "schema"), { recursive: true });
await writeFile(join(DIST, "schema", "index.js"), `export * from '../node/index.node.js';\n`);
```

`plugins/plugin-sql/src/build.ts:184` (mkdir added). No arbitrary sleeps; the actual missing dependency is fixed.

## Verification

- **Reproduced the exact failure**: with tsc's emit neutered (simulating a contended/partial parallel emit so `dist/schema/` is not created), the pre-fix code throws the reported `ENOENT ... src/dist/schema/index.js`; the patched code builds cleanly and writes `dist/schema/index.js`.
- **5× clean builds** (`rm -rf src/dist` each time): all `exit=0`, `dist/schema/index.js` present every run.
- Final dist verified: `dist/schema/index.js` content is the correct shim `export * from '../node/index.node.js';` and resolves on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)