### PR TITLE
fix(app): add /background to route-smoke coverage (unblock route-coverage gate)

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -241,6 +241,12 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     timeoutMs: 60_000,
   },
   {
+    name: "background view deep link",
+    path: "/background",
+    readyChecks: [{ selector: "#root" }, { text: "Background" }],
+    timeoutMs: 60_000,
+  },
+  {
     name: "character documents deep link",
     path: "/character/documents",
     readyChecks: [{ selector: '[data-testid="character-editor-view"]' }],


### PR DESCRIPTION
## Problem

The `route-coverage` gate (`.github/workflows/scenario-pr.yml`) is RED on `develop`.

`packages/app/test/route-coverage.test.ts` fails:

```
Missing app all-pages route smoke coverage for: /background
AssertionError: expected [ '/background' ] to deeply equal []
```

The unified-background work (#8953) added `/background` to the canonical route catalog (`packages/app-core/src/api/dev-route-catalog.ts:441`) but never added it to the all-pages click-safe smoke matrix that the boot-free coverage gate cross-checks. Every catalog/app-window path must appear in the smoke spec, so a new view shipped without smoke coverage fails CI here.

## Fix

Add a `/background` deep-link case to `packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts`, matching the existing convention used by peer routes like `/views`, `/contacts`, `/camera` (`#root` + content `readyChecks`, 60s timeout). One-line change in spirit: the gate reads `path:` strings from this spec.

## Verification

```
$ bun run --cwd packages/app test test/route-coverage.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Failure reproduced on a clean branch off `origin/develop` before the change; all 10 tests green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)