### PR TITLE
fix(agent): honor lookup { all: true } for pinned dual-stack web-fetch (Invalid IP: undefined)

### DIFF
--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -356,7 +356,21 @@ async function requestWithPinnedAddress(
       method,
       path: `${url.pathname}${url.search}`,
       headers: toRequestHeaders(headers),
-      lookup: (_hostname, _options, callback) => {
+      // Honor the `all` option: Node 20+ defaults autoSelectFamily=true and, for
+      // dual-stack hosts, calls lookup with `{ all: true }` expecting an ARRAY
+      // of `{ address, family }`. Returning the single-arg form there makes Node
+      // read the address string as an array (`addr[0].address` -> undefined) and
+      // throw "Invalid IP address: undefined", failing every pinned fetch to a
+      // dual-stack host (e.g. coingecko). Branch on the option to satisfy both.
+      lookup: (_hostname, options, callback) => {
+        const wantsAll =
+          typeof options === "object" &&
+          options !== null &&
+          options.all === true;
+        if (wantsAll) {
+          callback(null, [{ address: target.pinnedAddress, family }]);
+          return;
+        }
         callback(null, target.pinnedAddress, family);
       },
       ...(url.protocol === "https:"


### PR DESCRIPTION
## What
The pinned-address fetch path (SSRF-guarded `node:http` request for code custom actions + WEB_FETCH) installs a custom `lookup` that returns the single-arg `(err, address, family)` form:

```ts
lookup: (_hostname, _options, callback) => {
  callback(null, target.pinnedAddress, family);
},
```

But **`autoSelectFamily` defaults to `true` on Node 20+** (and the repo targets Node 24). For a **dual-stack host**, Node calls `lookup` with `{ all: true }` and expects an **array** of `{ address, family }`. With the single-arg form, Node reads the address string as an array (`addr[0].address` → `undefined`) and throws:

```
Invalid IP address: undefined
```

So every pinned fetch to a dual-stack host (e.g. `api.coingecko.com`, `api.coinbase.com`) fails — live-info / price / weather lookups all error out.

## Fix
Branch on `options.all`: return `[{ address, family }]` for the array form, keep the single-arg form otherwise. Behavior-preserving for single-stack hosts; restores pinned fetch for dual-stack ones.

## Verify
Live on Node 22 (milady VPS, cerebras + WEB_FETCH): the coingecko fetch went from `Invalid IP address: undefined` → `200`, and the bot answered **"Bitcoin is currently at $64,416 USD"** (0 IP errors in the log). Single-stack hosts unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
