### PR TITLE
fix(cloud): size stale-job recovery above the cold-boot worst case (provision flapping)

### DIFF
--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Stale-job recovery threshold sizing — the cold-boot provision-flapping fix.
+ *
+ * `recoverStaleJobs` resets a job stuck `in_progress` past a threshold back to
+ * `pending`. A cold dedicated-agent provision legitimately takes up to ~11 min
+ * (image pull 5m + health check 6m) before `/api/health` answers. At the old
+ * flat 5-min threshold a slow cold provision was reset mid-flight, re-claimed,
+ * and the second provision force-removed the still-booting container (flapping +
+ * orphans on the exact cold-start path every new user hits). This pins that the
+ * cold-boot job types now outlast that worst case while fast ops keep the tight
+ * 5-min backstop.
+ */
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { jobsRepository } from "../../db/repositories/jobs";
+import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const COLD_BOOT_TYPES = [
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_WAKE,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_UPGRADE,
+] as const;
+
+const FAST_TYPES = [JOB_TYPES.AGENT_DELETE, JOB_TYPES.AGENT_SUSPEND] as const;
+
+const COLD_BOOT_WORST_CASE_MS = 11 * 60 * 1000; // PULL 5m + HEALTH_CHECK 6m
+
+describe("recoverStaleJobs threshold by job type", () => {
+  test("cold-boot types outlast the ~11min cold provision; fast ops keep the 5min backstop", async () => {
+    const seen = new Map<string, number>();
+    const spy = spyOn(jobsRepository, "recoverStaleJobs").mockImplementation(
+      async (filters: { type: string; staleThresholdMs: number }) => {
+        seen.set(filters.type, filters.staleThresholdMs);
+        return 0;
+      },
+    );
+
+    try {
+      await (
+        provisioningJobService as unknown as {
+          recoverStaleJobs(types: readonly ProvisioningJobType[]): Promise<number>;
+        }
+      ).recoverStaleJobs([...COLD_BOOT_TYPES, ...FAST_TYPES]);
+
+      // Cold-boot job types must NOT be reclaimable until well past the worst-case
+      // cold boot — otherwise a still-booting provision is reset and double-run.
+      for (const type of COLD_BOOT_TYPES) {
+        expect(seen.get(type)).toBeGreaterThan(COLD_BOOT_WORST_CASE_MS);
+      }
+      // Fast lifecycle ops keep the tight 5-min stale backstop (no cold boot).
+      for (const type of FAST_TYPES) {
+        expect(seen.get(type)).toBe(5 * 60 * 1000);
+      }
+      // And the two tiers are genuinely different (no accidental uniform value).
+      expect(seen.get(JOB_TYPES.AGENT_PROVISION)).toBeGreaterThan(
+        seen.get(JOB_TYPES.AGENT_DELETE) as number,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -615,6 +615,34 @@ interface LifecycleJobOptions<TData extends object> {
  */
 const PER_JOB_TIMEOUT_MS = 120_000;
 
+/**
+ * Stale-job recovery thresholds, by job type. `recoverStaleJobs` resets a job
+ * stuck `in_progress` past this window back to `pending` — the backstop for a
+ * crashed worker. The threshold MUST exceed the job's real worst-case
+ * wall-clock, or it false-positives a still-running job and re-claims it.
+ *
+ * The cold-boot job types (provision / resume / wake / restart / upgrade) run
+ * the full image-pull + agent-boot path, which legitimately takes up to ~11 min
+ * (docker-sandbox-provider `PULL_TIMEOUT_MS` 5m + `HEALTH_CHECK_TIMEOUT_MS` 6m)
+ * before `/api/health` answers. At the old flat 5-min threshold a slow cold
+ * provision was reset mid-flight, re-claimed, and the second provision collided
+ * on the deterministic container name (`agent-<id>`) and force-removed the
+ * still-booting container — provision flapping + orphaned containers on the
+ * exact cold-start path every new user hits. 15 min clears the worst case with
+ * margin; fast ops keep the tight 5-min backstop. (`trySetProvisioning`
+ * deliberately admits a `provisioning` row and defers to this as the time gate,
+ * so this threshold is the single source of truth for "provision is stuck".)
+ */
+const DEFAULT_STALE_JOB_THRESHOLD_MS = 5 * 60 * 1000;
+const COLD_BOOT_STALE_JOB_THRESHOLD_MS = 15 * 60 * 1000;
+const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_WAKE,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_UPGRADE,
+]);
+
 export class ProvisioningJobService {
   /**
    * Common path for the seven `enqueueAgent*Once` methods. Acquires the
@@ -2587,7 +2615,9 @@ export class ProvisioningJobService {
     for (const jobType of jobTypes) {
       const recovered = await jobsRepository.recoverStaleJobs({
         type: jobType,
-        staleThresholdMs: 5 * 60 * 1000, // 5 minutes
+        staleThresholdMs: COLD_BOOT_JOB_TYPES.has(jobType)
+          ? COLD_BOOT_STALE_JOB_THRESHOLD_MS
+          : DEFAULT_STALE_JOB_THRESHOLD_MS,
         maxAttempts: 3,
       });
       totalRecovered += recovered;


### PR DESCRIPTION
## Size stale-job recovery above the cold-boot worst case (provision flapping)

Fixes #9071.

### Problem
`recoverStaleJobs` reset a job stuck `in_progress` past a **flat 5-min** threshold back to `pending` — for *every* job type. A **cold** dedicated-agent provision legitimately takes up to **~11 min** (`PULL_TIMEOUT_MS` 5m + `HEALTH_CHECK_TIMEOUT_MS` 6m) before `/api/health` answers. So a slow cold provision had its job reset mid-flight, re-claimed, and the second `provision()` collided on the deterministic container name `agent-<id>` — the "already in use" error matched `create()`'s port-collision branch → `docker rm -f` **force-removed the still-booting container**. Result: provision flapping, repeated teardown/rebuild, and orphaned containers on the exact cold-start path every new user hits. `trySetProvisioning` deliberately admits a `provisioning` row and defers to "the job-level stale recovery as the time gate" — that gate was simply mis-sized.

Sibling fix to #9066 (which hardened the **delete** path's wall-clock; this hardens the **provision** path's).

### Fix
Per-job-type stale threshold in `ProvisioningJobService`:
- cold-boot types (`agent_provision` / `resume` / `wake` / `restart` / `upgrade`) → **15 min** (clears the ~11-min worst case with margin);
- fast ops (delete/suspend/logs/…) → keep the tight **5-min** backstop.

The `trySetProvisioning` "admit `provisioning`" design stays valid because its deferred time gate is now correctly sized — no lock-semantics change, minimal blast radius.

### Why not also gate the lock / add per-agent single-flight?
Root-causing the threshold fully closes the realistic window (cold boot ≤11m < 15m gate), so provision #1 reaches `running` before recovery can fire; a re-claim after that finds the row `running` and `provision()` idempotently returns. Adding a recency gate to the shared `trySetProvisioning` (also used by resume/wake/restart) would be belt-and-suspenders for a pathological >15-min provision — deferred to keep this fix surgical.

### Tests
`provisioning-jobs-stale-threshold.test.ts` — pins that cold-boot types get a threshold `> 11 min` (the cold-boot worst case) and fast ops keep exactly 5 min, with the two tiers genuinely distinct. **1 pass / 0 fail / 8 expect()**; biome + typecheck clean. Branched off current develop (`3a98847626`).

### Evidence
This is a daemon-internal timing fix; the human-verifiable proof is the live fleet-verify path already used for #9066 (provision → settle to a single `running` container without a mid-boot teardown). N/A: UI screenshots, LLM trajectories (no agent/prompt/model change).

Found by an adversarial multi-agent audit of the cloud dedicated-agent chat path (launch readiness): 9 findings → 2 confirmed launch-blockers (this + a core fast-path truncation), 3 real-but-minor, 4 refuted.
