### PR TITLE
fix(core): fall through to the uncapped path when the direct-reply fast path can't serve

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -291,6 +291,114 @@ describe("runV5MessageRuntimeStage1", () => {
 		);
 	});
 
+	it("falls through to the uncapped main Stage-1 path when the direct-reply fast path truncates at the cap", async () => {
+		const runtime = makeRuntime([
+			// The 96-token fast path is the first branch for short direct messages,
+			// and here it truncates mid-answer (the model had more to say).
+			{
+				text: "Rainbows form when sunlight enters a raindrop, refracts, reflects off the back, and",
+				finishReason: "length",
+				usage: { promptTokens: 40, completionTokens: 96, totalTokens: 136 },
+			},
+			// The full Stage-1 fall-through produces a complete reply.
+			stage1Response({
+				contexts: ["simple"],
+				replyText:
+					"Rainbows form when sunlight refracts, reflects, and disperses inside raindrops. Done.",
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				channelType: ChannelType.API,
+				text: "explain how rainbows form",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			// The complete fall-through reply is delivered — NOT the truncated fast text.
+			expect(result.result.responseContent?.text).toBe(
+				"Rainbows form when sunlight refracts, reflects, and disperses inside raindrops. Done.",
+			);
+			expect(result.result.responseContent?.text ?? "").not.toContain(
+				"reflects off the back, and",
+			);
+		}
+		const calls = useModelCalls(runtime);
+		// Two model calls: the truncated 96-token fast attempt, then the full path.
+		expect(calls.length).toBeGreaterThanOrEqual(2);
+		expect((calls[0]?.[1] as { maxTokens?: number })?.maxTokens).toBe(96);
+		expect(runtime.logger.debug).toHaveBeenCalledWith(
+			expect.objectContaining({
+				src: "service:message",
+				finishReason: "length",
+				maxTokens: 96,
+			}),
+			expect.stringContaining("falling through to the full Stage-1 path"),
+		);
+	});
+
+	it("returns the direct-reply fast path verbatim when it fits within the cap (no fall-through)", async () => {
+		const runtime = makeRuntime([
+			{ text: "Good morning! How can I help today?", finishReason: "stop" },
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				channelType: ChannelType.API,
+				text: "good morning",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Good morning! How can I help today?",
+			);
+		}
+		// A complete fast reply is delivered immediately — exactly one model call.
+		expect(useModelCalls(runtime).length).toBe(1);
+	});
+
+	it("falls through to the main path when the direct-reply fast path returns an empty reply", async () => {
+		const runtime = makeRuntime([
+			// Fast path returns nothing usable (reasoning-only / blank output).
+			{ text: "", finishReason: "stop" },
+			// The full Stage-1 fall-through produces a real reply.
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Hi! What can I do for you?",
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				channelType: ChannelType.API,
+				text: "good morning",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			// A real reply is delivered — not the empty fast-path text.
+			expect(result.result.responseContent?.text).toBe(
+				"Hi! What can I do for you?",
+			);
+		}
+		// Two calls: the empty fast attempt, then the full fall-through.
+		expect(useModelCalls(runtime).length).toBeGreaterThanOrEqual(2);
+	});
+
 	it("surfaces a clear reply when Stage 1 truncates before a reply can be recovered", async () => {
 		const runtime = makeRuntime([
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6050,34 +6050,59 @@ export async function runV5MessageRuntimeStage1(args: {
 				signal: stage1TurnSignal,
 			});
 			const fastEndedAt = Date.now();
-			fastMessageHandler.plan.reply = generated.text;
-			if (recorder && trajectoryId) {
-				await recordMessageHandlerStage({
-					recorder,
-					trajectoryId,
-					messages: [{ role: "user", content: generated.prompt }],
-					providerOptions: {
-						eliza: {
-							directReplyFastPath: true,
-							maxTokens: DIRECT_REPLY_FAST_PATH_MAX_TOKENS,
+			// Ship the fast reply only if it is a complete, non-empty answer. Two
+			// failure modes fall through to the uncapped main Stage-1 path instead of
+			// delivering a bad reply: (1) a truncation at the 96-token cap — the
+			// message needed a longer answer than the fast path allows (e.g.
+			// "explain X", "write a poem"), so the cut-off text is wrong; (2) an
+			// empty/whitespace reply — the small model produced nothing usable, so a
+			// blank message bubble would ship. The main path omits the cap for direct
+			// channels and has its own empty-reply recovery. Short complete replies
+			// keep the fast path.
+			if (
+				generated.text.trim() &&
+				!stage1HitCompletionLimit(
+					generated.raw,
+					DIRECT_REPLY_FAST_PATH_MAX_TOKENS,
+				)
+			) {
+				fastMessageHandler.plan.reply = generated.text;
+				if (recorder && trajectoryId) {
+					await recordMessageHandlerStage({
+						recorder,
+						trajectoryId,
+						messages: [{ role: "user", content: generated.prompt }],
+						providerOptions: {
+							eliza: {
+								directReplyFastPath: true,
+								maxTokens: DIRECT_REPLY_FAST_PATH_MAX_TOKENS,
+							},
 						},
-					},
-					raw: generated.raw,
-					parsed: fastMessageHandler,
-					startedAt: fastStartedAt,
-					endedAt: fastEndedAt,
-					logger: args.runtime.logger,
-				});
+						raw: generated.raw,
+						parsed: fastMessageHandler,
+						startedAt: fastStartedAt,
+						endedAt: fastEndedAt,
+						logger: args.runtime.logger,
+					});
+				}
+				return {
+					kind: "direct_reply",
+					messageHandler: fastMessageHandler,
+					result: createV5ReplyStrategyResult({
+						...args,
+						text: generated.text,
+						thought: fastMessageHandler.thought,
+					}),
+				};
 			}
-			return {
-				kind: "direct_reply",
-				messageHandler: fastMessageHandler,
-				result: createV5ReplyStrategyResult({
-					...args,
-					text: generated.text,
-					thought: fastMessageHandler.thought,
-				}),
-			};
+			args.runtime.logger?.debug?.(
+				{
+					src: "service:message",
+					finishReason: getStage1FinishReason(generated.raw),
+					maxTokens: DIRECT_REPLY_FAST_PATH_MAX_TOKENS,
+				},
+				"[message] Direct-reply fast path produced no usable reply (empty or truncated at the token cap); falling through to the full Stage-1 path",
+			);
 		}
 		const responseHandlerFieldContext: ResponseHandlerFieldContext = {
 			runtime: args.runtime,


### PR DESCRIPTION
## Fall through to the uncapped path when the direct-reply fast path truncates

Fixes #9073. cc @lalalune — this touches the direct-reply fast path you added to `core/message.ts`; flagging for your review since it's your design.

### Problem
The DM/API direct-reply fast path is the **first** branch for short conversational messages and hard-caps output at `DIRECT_REPLY_FAST_PATH_MAX_TOKENS = 96` with **no truncation recovery** (that lives only in the non-fast-path Stage-1 branch). `shouldUseDirectReplyFastPath` only blocks >280-char / tool-keyword messages, so "explain X", "write a poem", "summarize Y" take the fast path and — when the answer needs >96 tokens — are delivered **cut off mid-sentence** (`finish_reason=length`). Cloud dedicated-agent chat ingress defaults to `ChannelType.DM/API`, so it's live for the launch. The main path a few lines down already omits the cap for direct channels, with a comment explaining exactly why a hard ceiling truncates long replies — the fast path contradicts it.

### Fix
Reuse the existing `stage1HitCompletionLimit` on the fast-path result: ship the fast reply only when it finished within the budget; on a completion-limit truncation, **fall through to the uncapped main Stage-1 path** for a complete answer (with a debug log). Short replies that fit keep the fast path — only genuinely-long answers pay the full-path cost. Surgical: the success block is unchanged behavior, just guarded; the empty-Stage-1 *rescue* fast path (a separate, rarer last-resort after the full path already returned empty) is intentionally left as-is.

### Tests
Two new cases in `message-runtime-stage1.test.ts`:
- a fast reply with `finishReason: "length"` → asserts a **second** (full-path) model call happens and the **complete** reply is delivered, not the truncated text, plus the fall-through debug log;
- a fast reply with `finishReason: "stop"` → asserts it's returned verbatim in **exactly one** model call (fast path preserved).

**73/73** in the stage1 file + 18/18 across related message suites; biome + core typecheck clean. Branched off current develop (`3a98847626`).

### Evidence
N/A for screenshots. The human-verifiable proof is a live cerebras dedicated-agent turn: ask "explain how rainbows form" — before, the reply cuts off ~70 words in; after, it completes (the fall-through fires, visible as the `falling through to the full Stage-1 path` debug log). Real-LLM trajectory can be captured via the scenario runner on request.

Found by an adversarial multi-agent audit of the cloud dedicated-agent chat path: 2 confirmed launch-blockers (this + the provision-flapping fix #9072), 3 real-but-minor, 4 refuted.

---
**Update:** extended the guard to also fall through when the fast path returns an **empty/whitespace** reply (reasoning-only or blank small-model output → a blank message bubble), since it is the same code path and failure class. Both failure modes (truncated **or** empty) now fall through to the uncapped main path. Tests: **74/74** in the stage1 file (3 new fast-path cases: truncation, empty, and the fits-the-budget happy path); biome + core typecheck clean.
