### PR TITLE
fix(voice): join the ASR transcript into live diarization ingestion (#8786)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
@@ -23,6 +23,7 @@ import {
 	type AudioFrameEvent,
 	decodeAudioFramePcm,
 	type RuntimeEventSink,
+	type TurnTranscriber,
 } from "./audio-frame-consumer";
 import type { VoiceAttributionOutput } from "./speaker/attribution-pipeline";
 import { VadDetector } from "./vad";
@@ -119,6 +120,7 @@ function makeFrame(opts: {
 function buildHarness(
 	probs: readonly number[],
 	entityId: string | null = "entity-x",
+	transcribe?: TurnTranscriber,
 ) {
 	const silero = new ScriptedSilero(probs);
 	const vad = new VadDetector(silero, {
@@ -131,7 +133,7 @@ function buildHarness(
 	const pipeline = new FakePipeline(entityId);
 	const runtime = new FakeRuntime();
 	const consumer = new AudioFrameConsumer(
-		{ vad, pipeline, runtime },
+		{ vad, pipeline, runtime, ...(transcribe ? { transcribe } : {}) },
 		{
 			source: { kind: "device", deviceId: "pixel" },
 			attributionOptions: {
@@ -144,6 +146,26 @@ function buildHarness(
 		},
 	);
 	return { consumer, pipeline, runtime, vad };
+}
+
+/** Feed one loud turn (speech then silence) and flush, so exactly one turn
+ *  finalizes. Shared by the transcript-join tests. */
+async function driveOneTurn(consumer: AudioFrameConsumer): Promise<void> {
+	let ts = 1000;
+	let idx = 0;
+	for (let i = 0; i < 40; i++) {
+		await consumer.onAudioFrame(
+			makeFrame({ amplitude: 0.6, timestamp: ts, frameIndex: idx++ }),
+		);
+		ts += 20;
+	}
+	for (let i = 0; i < 24; i++) {
+		await consumer.onAudioFrame(
+			makeFrame({ amplitude: 0.0, timestamp: ts, frameIndex: idx++ }),
+		);
+		ts += 20;
+	}
+	await consumer.flush();
 }
 
 describe("decodeAudioFramePcm", () => {
@@ -339,5 +361,66 @@ describe("AudioFrameConsumer", () => {
 		for (const call of pl.calls) {
 			expect(call.pcm.length).toBeLessThanOrEqual(SR * 1 + 512);
 		}
+	});
+});
+
+describe("AudioFrameConsumer — ASR transcript join (#8786)", () => {
+	const TURN_PROBS = [...Array(24).fill(0.9), ...Array(12).fill(0.0)];
+
+	it("joins the per-turn ASR transcript onto VOICE_TURN_OBSERVED", async () => {
+		const seen: Array<{ length: number; sampleRate: number }> = [];
+		const transcribe: TurnTranscriber = (pcm, sampleRate) => {
+			seen.push({ length: pcm.length, sampleRate });
+			return "  I'm Jill  ";
+		};
+		const { consumer, runtime } = buildHarness(
+			TURN_PROBS,
+			"entity-x",
+			transcribe,
+		);
+		await driveOneTurn(consumer);
+
+		// The transcriber saw the real buffered turn PCM at 16 kHz.
+		expect(seen.length).toBe(1);
+		expect(seen[0].sampleRate).toBe(16_000);
+		expect(seen[0].length).toBeGreaterThan(SR * 0.4);
+		// VOICE_TURN_OBSERVED now carries the trimmed transcript (was "" before).
+		expect(runtime.emitted.length).toBe(1);
+		expect(runtime.emitted[0].payload.text).toBe("I'm Jill");
+	});
+
+	it("stays diarization-only (empty text) when no transcriber is wired", async () => {
+		const { consumer, runtime } = buildHarness(TURN_PROBS, "entity-x");
+		await driveOneTurn(consumer);
+		expect(runtime.emitted.length).toBe(1);
+		expect(runtime.emitted[0].payload.text).toBe("");
+	});
+
+	it("degrades to a transcript-less turn when ASR throws (turn kept)", async () => {
+		const transcribe: TurnTranscriber = () => {
+			throw new Error("asr decode failed");
+		};
+		const { consumer, runtime } = buildHarness(
+			TURN_PROBS,
+			"entity-x",
+			transcribe,
+		);
+		await driveOneTurn(consumer);
+		// The diarized turn still emits; only the transcript is dropped, counted.
+		expect(runtime.emitted.length).toBe(1);
+		expect(runtime.emitted[0].payload.text).toBe("");
+		expect(consumer.transcriptionErrors).toBe(1);
+	});
+
+	it("ignores an empty/whitespace transcript (no text stamped)", async () => {
+		const transcribe: TurnTranscriber = () => "   ";
+		const { consumer, runtime } = buildHarness(
+			TURN_PROBS,
+			"entity-x",
+			transcribe,
+		);
+		await driveOneTurn(consumer);
+		expect(runtime.emitted.length).toBe(1);
+		expect(runtime.emitted[0].payload.text).toBe("");
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -178,6 +178,22 @@ export interface RuntimeEventSink {
 	emitEvent(type: unknown, payload: Record<string, unknown>): Promise<void>;
 }
 
+/**
+ * Transcribe a finalized turn's buffered PCM to text (#8786). When injected, the
+ * consumer joins the ASR transcript into the diarization attribution so
+ * `VOICE_TURN_OBSERVED` carries the real text — previously the live audio-frame
+ * path attributed *who* spoke but always emitted `text: ""`, so name/partner
+ * extraction (`VoiceObserver.ingestTurn`) could never fire from live audio.
+ *
+ * Returns the transcript, or `null`/empty for silence / no decode. Best-effort:
+ * the consumer swallows a rejection (counted in `transcriptionErrors`) and falls
+ * back to a transcript-less turn rather than dropping the diarized turn.
+ */
+export type TurnTranscriber = (
+	pcm: Float32Array,
+	sampleRate: number,
+) => Promise<string | null> | string | null;
+
 // ---------------------------------------------------------------------------
 // Consumer
 // ---------------------------------------------------------------------------
@@ -189,6 +205,12 @@ export interface AudioFrameConsumerDeps {
 	pipeline: AttributionPipelineLike;
 	/** Runtime event sink for VOICE_TURN_OBSERVED. */
 	runtime: RuntimeEventSink;
+	/**
+	 * Optional ASR for the finalized turn's PCM (#8786). When present, its text
+	 * rides on `VOICE_TURN_OBSERVED` so live name/entity extraction runs. When
+	 * absent the path stays diarization-only (transcript `""`, as before).
+	 */
+	transcribe?: TurnTranscriber;
 }
 
 export interface AudioFrameConsumerConfig {
@@ -237,6 +259,7 @@ export class AudioFrameConsumer {
 	private readonly vad: VadSegmenter;
 	private readonly pipeline: AttributionPipelineLike;
 	private readonly runtime: RuntimeEventSink;
+	private readonly transcribe: TurnTranscriber | null;
 	private readonly source: VoiceInputSource | undefined;
 	private readonly attributionOptions: HandleLiveVoiceAttributionOptions;
 	private readonly maxTurnSamples: number;
@@ -261,6 +284,10 @@ export class AudioFrameConsumer {
 	/** Count of frames that failed to decode (surfaced via getters, not thrown). */
 	droppedFrames = 0;
 
+	/** Count of turns whose ASR transcribe threw (degraded to a transcript-less
+	 *  turn rather than dropping the diarized turn). */
+	transcriptionErrors = 0;
+
 	constructor(
 		deps: AudioFrameConsumerDeps,
 		config: AudioFrameConsumerConfig = {},
@@ -268,6 +295,7 @@ export class AudioFrameConsumer {
 		this.vad = deps.vad;
 		this.pipeline = deps.pipeline;
 		this.runtime = deps.runtime;
+		this.transcribe = deps.transcribe ?? null;
 		this.source = config.source;
 		this.attributionOptions = config.attributionOptions ?? {};
 		const sr = AUDIO_FRAME_PIPELINE_SAMPLE_RATE;
@@ -426,10 +454,15 @@ export class AudioFrameConsumer {
 			endedAtMs: args.endedAtMs,
 			...(this.source ? { source: this.source } : {}),
 		});
+		// Join the ASR transcript for this turn (#8786) so VOICE_TURN_OBSERVED
+		// carries the real text and live name/entity extraction can fire. ASR is
+		// best-effort: a decode failure degrades to a transcript-less turn (the
+		// diarized speaker is still emitted), never a dropped turn.
+		const opts = await this.resolveTurnOptions(args.pcm);
 		const signal = await handleLiveVoiceAttribution(
 			this.runtime as Parameters<typeof handleLiveVoiceAttribution>[0],
 			output,
-			this.attributionOptions,
+			opts,
 		);
 		const turn: AttributedTurn = {
 			turnId: args.turnId,
@@ -440,6 +473,31 @@ export class AudioFrameConsumer {
 			samples: args.pcm.length,
 		};
 		for (const listener of this.turnListeners) listener(turn);
+	}
+
+	/**
+	 * Merge the per-turn ASR transcript into the attribution options. Returns the
+	 * base options unchanged when no transcriber is wired or the decode yields no
+	 * text; a thrown decode is swallowed (counted in `transcriptionErrors`) so a
+	 * diarized turn is never dropped over an ASR failure.
+	 */
+	private async resolveTurnOptions(
+		pcm: Float32Array,
+	): Promise<HandleLiveVoiceAttributionOptions> {
+		if (!this.transcribe) return this.attributionOptions;
+		try {
+			const transcript = await this.transcribe(
+				pcm,
+				AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+			);
+			const trimmed = transcript?.trim();
+			if (trimmed) {
+				return { ...this.attributionOptions, transcript: trimmed };
+			}
+		} catch {
+			this.transcriptionErrors += 1;
+		}
+		return this.attributionOptions;
 	}
 
 	// ---- buffering ---------------------------------------------------------

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -33,6 +33,7 @@ import {
 	type AudioFrameConsumerConfig,
 	type AudioFrameEvent,
 	type RuntimeEventSink,
+	type TurnTranscriber,
 } from "./audio-frame-consumer.js";
 import type {
 	ElizaInferenceContextHandle,
@@ -139,6 +140,8 @@ export class LiveDiarizationSession {
 	private readonly recentTurns: LiveDiarizationTurnSummary[] = [];
 	private resolvedLibPath: string | null = null;
 	private buildError: string | null = null;
+	/** True once the fused ASR region is mmap-acquired for per-turn transcribe. */
+	private asrRegionAcquired = false;
 
 	constructor(private readonly runtime: RuntimeEventSink) {}
 
@@ -212,12 +215,47 @@ export class LiveDiarizationSession {
 			preRollSeconds: 0.3,
 			maxTurnSeconds: 30,
 		};
+		// Join the fused batch ASR so the live path carries the real transcript
+		// on VOICE_TURN_OBSERVED (#8786). Null when the fused build has no ASR
+		// decoder — the path then stays diarization-only, as before.
+		const transcribe = this.buildTurnTranscriber(ffi, ctx);
 		const consumer = new AudioFrameConsumer(
-			{ vad: detector, pipeline, runtime: this.runtime },
+			{
+				vad: detector,
+				pipeline,
+				runtime: this.runtime,
+				...(transcribe ? { transcribe } : {}),
+			},
 			config,
 		);
 		consumer.onTurn((turn) => this.recordTurn(turn));
 		this.consumer = consumer;
+	}
+
+	/**
+	 * Build a per-turn ASR transcriber over the fused batch decoder
+	 * (`eliza_inference_asr_transcribe`). Returns null when the fused build
+	 * exposes no ASR decoder; acquiring the ASR mmap region is best-effort (a
+	 * missing bundled ASR model leaves the path diarization-only rather than
+	 * failing the whole session). One batch decode per finalized turn — the turn
+	 * is already fully buffered for attribution, so no streaming state is needed.
+	 */
+	private buildTurnTranscriber(
+		ffi: ElizaInferenceFfi,
+		ctx: ElizaInferenceContextHandle,
+	): TurnTranscriber | null {
+		if (typeof ffi.asrTranscribe !== "function") return null;
+		try {
+			ffi.mmapAcquire(ctx, "asr");
+		} catch {
+			return null;
+		}
+		this.asrRegionAcquired = true;
+		return (pcm) => {
+			const text = ffi.asrTranscribe({ ctx, pcm, sampleRateHz: 16_000 });
+			const trimmed = text.trim();
+			return trimmed.length > 0 ? trimmed : null;
+		};
 	}
 
 	private recordTurn(turn: AttributedTurn): void {
@@ -277,6 +315,14 @@ export class LiveDiarizationSession {
 	/** Release native handles + listeners. */
 	async close(): Promise<void> {
 		await this.consumer?.close();
+		if (this.asrRegionAcquired && this.ffi && this.ctx !== null) {
+			try {
+				this.ffi.mmapEvict(this.ctx, "asr");
+			} catch {
+				// Best-effort release; the context is destroyed below regardless.
+			}
+			this.asrRegionAcquired = false;
+		}
 		await this.encoder?.dispose();
 		await this.diarizer?.dispose();
 		this.vad?.close();


### PR DESCRIPTION
## Summary

Advances #8786 (AC #1–3): **the live diarization path now joins the ASR transcript**, so a voice turn reaches the agent as one attributed `VOICE_DM` carrying **transcript + speaker** — not a transcript-less diarization event.

Before: the live audio-frame path (`/api/voice/audio-frames` → `LiveDiarizationSession` → `AudioFrameConsumer`) ran VAD + diarization + speaker attribution but **never transcribed**, emitting `VOICE_TURN_OBSERVED` with `text: ""`. The merge engine's name/partner extraction (`VoiceObserver.ingestTurn`) was therefore fed empty text, so **"I'm Jill" / "Jill is my wife" could never create or update an entity from the live path** — only the in-process engine-bridge (which already had both ASR + diarization) carried real text. This was the `text:""` gap called out in #8786.

## Change

The consumer already buffers the full turn PCM, so the join belongs there:

- **`audio-frame-consumer.ts`** — adds an optional injected `transcribe` dep and `resolveTurnOptions`, which runs ASR on the finalized turn and threads the transcript through `handleLiveVoiceAttribution` (so it rides on `VOICE_TURN_OBSERVED` and the turn signal). ASR is **best-effort**: a thrown decode degrades to a transcript-less turn (counted in `transcriptionErrors`), never a dropped diarized turn. With no transcriber wired, the path stays diarization-only (`text: ""`) — **behavior unchanged**, fully additive.
- **`live-diarization-session.ts`** — wires the fused batch ASR (`eliza_inference_asr_transcribe`) as the transcriber, `mmapAcquire("asr")` (best-effort) and evicting on close. Returns `null` when the fused build has no ASR decoder, so the path degrades gracefully where models are absent.

The resolved `speakerEntityId` already rode onto the turn metadata; the transcript now joins it — one attributed turn, both fields.

## Evidence (verified locally on Windows)

- **`audio-frame-consumer.test.ts`: 13/13 pass** — 4 new cases prove: the transcript rides onto `VOICE_TURN_OBSERVED.text` (was `""`); the no-transcriber path stays empty; a thrown ASR is counted and the turn kept; whitespace is ignored. (`bun run --cwd plugins/plugin-local-inference vitest run src/services/voice/audio-frame-consumer.test.ts`)
- **Plugin typecheck: 0 errors** (`tsgo --noEmit`).
- **Biome: clean** on all 3 files.

The unit test exercises the join logic deterministically with an injected fake transcriber (no models). The session→fused-ASR wiring is exercised on-device where the fused build + ASR model are provisioned (gated, per the repo's voice honesty contract).

## Scope

This is the joined-ingestion slice of #8786. Companion PR #9059 fixed the desktop-gate slice (AC #8). Remaining #8786 ACs (wire-or-delete the native `runVoiceTurn`; a true multi-agent-room e2e) involve product decisions the issue itself flags as open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
