### PR TITLE
test(voice): prove the VOICE_GROUP parse->gate chain end to end (#8786)

### DIFF
--- a/packages/core/src/__tests__/voice-group-room.test.ts
+++ b/packages/core/src/__tests__/voice-group-room.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { parseMessageHandlerOutput } from "../runtime/message-handler";
 import type { ResponseHandlerEvaluatorContext } from "../runtime/response-handler-evaluators";
 import { BUILTIN_RESPONSE_HANDLER_EVALUATORS } from "../services/message";
 import type { Memory } from "../types/memory";
@@ -112,5 +113,81 @@ describe("core.voice_group_address (multi-agent voice room)", () => {
 			},
 		} as unknown as ResponseHandlerEvaluatorContext;
 		expect(await gate.shouldRun(ctx)).toBe(false);
+	});
+});
+
+/**
+ * Integration: drive the REAL Stage-1 parser (`parseMessageHandlerOutput`) so
+ * `addressedTo` is *derived* from a model HANDLE_RESPONSE envelope rather than
+ * hand-fed, then feed the parsed extract to the gate across ≥3 agents. This
+ * closes the parse→decision chain the unit tests above bypass; the only step
+ * not exercised here is the live model producing the envelope (gated, real-model
+ * lane). The runtime builds `messageHandler.{processMessage,extract}` from
+ * exactly this parser output, so the context mapping mirrors production.
+ */
+describe("core.voice_group_address — parse→gate integration (#8786)", () => {
+	/** The model's Stage-1 envelope for "Eliza, what's the time" in a 3-agent
+	 *  room: RESPOND, with the address resolved to Eliza. */
+	const ADDRESSED_ENVELOPE = JSON.stringify({
+		shouldRespond: "RESPOND",
+		replyText: "It is noon.",
+		contexts: ["simple"],
+		addressedTo: ["Eliza"],
+	});
+
+	function ctxFromEnvelope(
+		agentName: string,
+		envelope: string,
+	): ResponseHandlerEvaluatorContext {
+		const parsed = parseMessageHandlerOutput(envelope);
+		if (!parsed) throw new Error("envelope failed to parse");
+		return {
+			runtime: {
+				agentId: `agent-${agentName.toLowerCase()}` as UUID,
+				character: { name: agentName },
+			},
+			message: voiceGroupMsg(),
+			messageHandler: {
+				processMessage: parsed.processMessage,
+				extract: parsed.extract ?? {},
+			},
+		} as unknown as ResponseHandlerEvaluatorContext;
+	}
+
+	it("derives addressedTo from the real parse, then only the addressed agent replies (≥3 agents)", async () => {
+		if (!gate) throw new Error("missing");
+		// The parser actually produced the addressedTo the gate consumes.
+		const parsed = parseMessageHandlerOutput(ADDRESSED_ENVELOPE);
+		expect(parsed?.processMessage).toBe("RESPOND");
+		expect(parsed?.extract?.addressedTo).toEqual(["Eliza"]);
+
+		// Eliza (addressed) is not suppressed; Claude + Aria defer.
+		expect(
+			await gate.shouldRun(ctxFromEnvelope("Eliza", ADDRESSED_ENVELOPE)),
+		).toBe(false);
+		for (const other of ["Claude", "Aria"]) {
+			const ctx = ctxFromEnvelope(other, ADDRESSED_ENVELOPE);
+			expect(await gate.shouldRun(ctx)).toBe(true);
+			expect((await gate.evaluate(ctx)).processMessage).toBe("IGNORE");
+		}
+	});
+
+	it("an undirected envelope (no addressedTo) leaves every agent to normal shouldRespond", async () => {
+		if (!gate) throw new Error("missing");
+		const undirected = JSON.stringify({
+			shouldRespond: "RESPOND",
+			replyText: "sure",
+			contexts: ["simple"],
+		});
+		// No addressedTo in the envelope → parser omits it → gate fails open.
+		expect(parseMessageHandlerOutput(undirected)?.extract?.addressedTo).toBe(
+			undefined,
+		);
+		expect(await gate.shouldRun(ctxFromEnvelope("Eliza", undirected))).toBe(
+			false,
+		);
+		expect(await gate.shouldRun(ctxFromEnvelope("Aria", undirected))).toBe(
+			false,
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Strengthens #8786 AC #9. The multi-agent `VOICE_GROUP` turn-taking gate (`core.voice_group_address`) was unit-tested by **hand-feeding `addressedTo`** straight into the gate, so the chain AC #9 actually cares about — model envelope → parser → gate decision → only the addressed agent replies — was never exercised together.

This adds a deterministic **parse→gate integration test**: it derives `addressedTo` from a real `HANDLE_RESPONSE` envelope via the production parser (`parseMessageHandlerOutput`) and feeds the *parsed* extract to the gate across 3 agents (Eliza / Claude / Aria):

- Only the addressed agent (Eliza) is allowed to reply; Claude and Aria defer (`IGNORE`).
- An undirected envelope (no `addressedTo`) leaves every agent to normal `shouldRespond`.

The runtime builds `messageHandler.{processMessage, extract}` from exactly this parser output, so the context mapping mirrors production. The only step not exercised here is the **live model producing the envelope** — that is the gated real-model lane, by design.

## Evidence (verified locally)

- `voice-group-room.test.ts`: **9/9 pass** (7 existing + 2 new integration tests).
- Core typecheck: **0 errors**. Biome: clean.

## Scope

Test-only; no runtime change (the policy already shipped and is correct). Companion PRs on #8786: [#9059](https://github.com/elizaOS/eliza/pull/9059) (desktop gate, AC #8) and [#9079](https://github.com/elizaOS/eliza/pull/9079) (joined ASR+diarization ingestion, AC #1–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
