### PR TITLE
fix(ci): stabilize nightly benchmark setup

### DIFF
--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -158,6 +158,12 @@ jobs:
       - name: Generate shared i18n assets
         run: bun run --cwd packages/shared build:i18n
 
+      - name: Prepare dev workspace packages
+        # `bun run dev` starts Vite from a clean checkout. Build the app's
+        # workspace dependencies first so Vite can resolve package exports like
+        # @elizaos/core instead of failing before the benchmark can run.
+        run: bun run dev:prepare
+
       - name: Boot dev agent
         env:
           ELIZA_API_PORT: "31337"

--- a/.github/workflows/memperf.yml
+++ b/.github/workflows/memperf.yml
@@ -37,11 +37,21 @@ jobs:
         with:
           submodules: recursive
       - uses: oven-sh/setup-bun@v2
+        with:
+          # The repo packageManager pins the exact canary used by local dev,
+          # but historical canary tags can disappear from GitHub releases.
+          # Ask setup-bun for the moving canary channel so scheduled runs do
+          # not fail before the memperf gate gets to execute.
+          bun-version: canary
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
       - name: Install workspace
         run: bun install
+      - name: Generate shared i18n assets
+        # The real-arbiter self-check imports @elizaos/core source, which
+        # expects generated keyword data to exist in a fresh checkout.
+        run: bun run --cwd packages/shared build:i18n
       - name: Metric-schema contract (shared with #8800)
         run: bun test --conditions=eliza-source packages/benchmarks/memperf/metric-schema.test.ts
       - name: Real-arbiter co-residency eviction self-check


### PR DESCRIPTION
## Why

Two scheduled develop benchmark workflows were failing before they could exercise their intended quality gates:

- `memperf` let `setup-bun` infer the exact `packageManager` canary (`bun@1.4.0-canary.1`), which returned a 404 from GitHub releases. Other workflows pass the moving `canary` channel explicitly.
- After fixing Bun setup, `memperf` reached the real-arbiter self-check and failed because a fresh checkout had not generated the core/shared i18n keyword data that source-mode imports expect.
- `Local Inference Bench` booted `bun run dev` from a clean checkout after install/i18n generation, but without building workspace package outputs. Vite then failed to resolve `@elizaos/core` before the benchmark harness could run.

## What changed

- Pass `bun-version: canary` in the `memperf` setup-bun step so scheduled runs reach the benchmark gate.
- Generate shared i18n assets in `memperf` before source-mode real-arbiter tests.
- Add a `bun run dev:prepare` step before the local-inference real-agent boot so Vite can resolve app workspace dependencies on clean runners.
- Added inline workflow comments documenting why each setup step exists.

## Verification

- Parsed both edited workflow YAML files with Ruby Psych.
- Ran `git diff --check`.
- Confirmed the first pushed run moved past the original `setup-bun` 404 and exposed the missing i18n generation step now fixed here.

Full local reproduction was intentionally skipped because this worktree has no installed workspace dependencies and the machine is currently disk-constrained; GitHub Actions is the exact environment for these workflow fixes.
