### PR TITLE
registry: add elizaos-plugin-invinoveritas (third-party verification gate)

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -1,0 +1,9 @@
+{
+  "package": "elizaos-plugin-invinoveritas",
+  "repository": "github:babyblueviper1/invinoveritas",
+  "kind": "plugin",
+  "description": "Independent, capital/risk-aware verdict before an irreversible action (review of a trade / on-chain action / plan), plus free recomputable proof verification (schnorr vs a published key) — the verification gate an agent can't self-issue. Advisory and degrades safely; pay in sats, USDC (x402), or card.",
+  "homepage": "https://api.babyblueviper.com/install",
+  "version": "0.1.0",
+  "tags": ["verification", "guardian", "review", "onchain", "trading", "x402"]
+}

--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free proof verification (BIP-340 schnorr vs a published key), verified 100% locally with zero network calls when the caller supplies the full proof event — the independent check an agent can't self-issue.",
   "homepage": "https://api.babyblueviper.com/install",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "tags": [
     "verification",
     "autonomous",

--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -2,8 +2,15 @@
   "package": "elizaos-plugin-invinoveritas",
   "repository": "github:babyblueviper1/invinoveritas",
   "kind": "plugin",
-  "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free recomputable proof verification (schnorr vs a published key) so an agent can check another agent's output without trusting it. The independent check an agent can't self-issue.",
+  "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free proof verification (BIP-340 schnorr vs a published key), verified 100% locally with zero network calls when the caller supplies the full proof event — the independent check an agent can't self-issue.",
   "homepage": "https://api.babyblueviper.com/install",
-  "version": "0.1.1",
-  "tags": ["verification", "autonomous", "second-opinion", "review", "onchain", "x402"]
+  "version": "0.2.0",
+  "tags": [
+    "verification",
+    "autonomous",
+    "second-opinion",
+    "review",
+    "onchain",
+    "x402"
+  ]
 }

--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -2,8 +2,8 @@
   "package": "elizaos-plugin-invinoveritas",
   "repository": "github:babyblueviper1/invinoveritas",
   "kind": "plugin",
-  "description": "Independent, capital/risk-aware verdict before an irreversible action (review of a trade / on-chain action / plan), plus free recomputable proof verification (schnorr vs a published key) — the verification gate an agent can't self-issue. Advisory and degrades safely; pay in sats, USDC (x402), or card.",
+  "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free recomputable proof verification (schnorr vs a published key) so an agent can check another agent's output without trusting it. The independent check an agent can't self-issue.",
   "homepage": "https://api.babyblueviper.com/install",
-  "version": "0.1.0",
-  "tags": ["verification", "guardian", "review", "onchain", "trading", "x402"]
+  "version": "0.1.1",
+  "tags": ["verification", "autonomous", "second-opinion", "review", "onchain", "x402"]
 }

--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free proof verification (BIP-340 schnorr vs a published key), verified 100% locally with zero network calls when the caller supplies the full proof event — the independent check an agent can't self-issue.",
   "homepage": "https://api.babyblueviper.com/install",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "tags": [
     "verification",
     "autonomous",

--- a/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-invinoveritas.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free proof verification (BIP-340 schnorr vs a published key), verified 100% locally with zero network calls when the caller supplies the full proof event — the independent check an agent can't self-issue.",
   "homepage": "https://api.babyblueviper.com/install",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "tags": [
     "verification",
     "autonomous",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1234,6 +1234,52 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-invinoveritas": {
+      "git": {
+        "repo": "babyblueviper1/invinoveritas",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-invinoveritas",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "An automated, independent second opinion an agent calls before a high-stakes action: one API call returns approve/concerns/reject and the agent weighs it and decides — no human in the loop, never blocks, degrades to a no-op if unavailable. Plus free proof verification (BIP-340 schnorr vs a published key), verified 100% locally with zero network calls when the caller supplies the full proof event — the independent check an agent can't self-issue.",
+      "homepage": "https://api.babyblueviper.com/install",
+      "topics": [
+        "verification",
+        "autonomous",
+        "second-opinion",
+        "review",
+        "onchain",
+        "x402"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-neynar-search": {
       "git": {
         "repo": "xavier-arosemena/elizaos-plugin-neynar-search",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1251,7 +1251,7 @@
         "repo": "elizaos-plugin-invinoveritas",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.1"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1251,7 +1251,7 @@
         "repo": "elizaos-plugin-invinoveritas",
         "v0": null,
         "v1": null,
-        "v2": "0.2.2"
+        "v2": "0.2.3"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1251,7 +1251,7 @@
         "repo": "elizaos-plugin-invinoveritas",
         "v0": null,
         "v1": null,
-        "v2": "0.2.1"
+        "v2": "0.2.2"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #19130. Registry-only addition of a third-party plugin (`elizaos-plugin-invinoveritas`) after repeated independent review found and closed real provenance, crypto trust-boundary, and identity-binding gaps.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts — rebased again this round onto fresh `upstream/develop` (clean, no conflicts) after lalalune's round-5 review, then added a new commit (registry version bump to 0.2.3). Head is now `3bc1fc5f0fa9ec0ab67a4c3b3fe5c86d71553307`.
- [x] `bun install` and the registry package's own verification commands were run after sync (see Testing below) — all pass.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (registry validate/generate/typecheck/lint/test output, npm publish provenance, live signature-verification output).

# Contribution provenance

Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - external contributor's own agent, not elizaOS's bundled contribute-to-eliza skill`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased by the maintainer onto `origin/develop@43a0e3d82c`; all six commits replayed patch-identically with zero conflicts.
- [x] Registry verification passes post-sync (`bun run validate`, `bun run generate`, `bun run typecheck`, `bun run lint:check`, `bun run test` — see Testing below for full output). No unrelated blocker encountered.

# Risks

**Low.** Registry-only change (one JSON entry + the generated index) plus a version bump on an already-listed, opt-in, advisory-only third-party plugin. No core eliza code touched. The immutable npm packages (`invinoveritas-verify@1.1.1`, `elizaos-plugin-invinoveritas@0.2.3`) pin production dependencies exactly, ship their reviewed source/tests, and keep the remote review action advisory.

# Background

## What does this PR do?

Registers `elizaos-plugin-invinoveritas` (a third-party opt-in verification plugin) at version 0.2.3 after multiple independent reviews found and closed real gaps:

**Round 1 (lalalune):** the plugin's `VERIFY_PROOF` action claimed "verified locally, trust the math not us" but actually POSTed to our own remote server and trusted the response — a real trust-boundary misrepresentation. Fixed: genuine offline BIP-340 schnorr verification via `invinoveritas-verify`'s `verifyProofLocal()` when the caller supplies the full proof event (zero network calls); a `proofId`-only call fetches the exact bytes from a dedicated endpoint then verifies locally the same way. A new `method: "local" | "fetched_then_local"` field makes the user-facing text always tell the truth about which path ran. 9 new tests added, all exercising real cryptographic math (no mocked signatures).

**Round 2 (MarcoWorms, this push):** found the 0.2.1 fix itself had 4 real provenance gaps:
1. `invinoveritas-verify`'s own npm tarball had no repository field, no shipped tests, and caret-ranged `@noble/curves`/`@noble/hashes` dependencies. **Fixed:** republished as `invinoveritas-verify@1.1.1` — deps pinned exact (`1.9.7`/`1.8.0`), tarball now ships `test.mjs` + `sample_proof.json` (11/11 hermetic tests independently re-runnable), `repository` field points at this repo's `sdk/ts` directory with a real, fetchable public commit.
2. Test suite only proved rejection paths (forged key, tampered content, malformed input) — no positive case. **Fixed:** added two tests using the real sample proof shipped with `invinoveritas-verify` (genuinely signed under the actual published verifier key): local verification with `fetch` forced to throw (proves zero network calls on the common path), and a `fetched_then_local` case (mocked fetch returns the same real event).
3. Branch was 437 commits behind `develop`. **Fixed:** rebased this pass (see Sync section above).
4. PR body predated the current provenance/evidence template and didn't disclose AI co-authorship. **Fixed:** this rewrite.

## What kind of change is this?

Bug fix (crypto trust-boundary misrepresentation) + provenance/supply-chain hardening (pinned deps, shipped tests, repository field) on an already-registered third-party plugin.

# Documentation changes needed?

My changes do not require a change to the project documentation. `integrations/elizaos/README.md` (in the plugin's own repo, not this one) was updated to describe the real local-verification behavior and the `method` field.

# Testing

## Where should a reviewer start?

`npm view elizaos-plugin-invinoveritas@0.2.3` — shows a correctly-populated `gitHead` resolving to a real, public, fetchable commit. Round 5 (this update): fixed a real proofId/fetched-event identity-binding gap lalalune found and reproduced live against the 0.2.2 tarball — see Background below.

## Detailed testing steps

None: automated tests are acceptable, output below is from real, unmocked runs.

# Evidence Gate

Evidence must match the exact commit reviewed. Registry-only change, no UI surface touched.
<!-- evidence-head:3bc1fc5f0fa9ec0ab67a4c3b3fe5c86d71553307 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - registry-only + npm package change, no UI surface exists to screenshot
<!-- evidence-row:after-screenshots -->
- [x] N/A - registry-only + npm package change, no UI surface exists to screenshot
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow to walk through
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service in this repo touched; the affected code runs inside a third-party npm package's own test suite (output below)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend touched
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed in this repo; the VERIFY_PROOF action's real-crypto behavior is covered by the plugin's own unit tests (11/11 pass, output below), not a live scenario run
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head registry and immutable-package verification:

<details><summary>Registry, provenance, and cryptographic checks</summary>

```text
head=3bc1fc5f0fa9ec0ab67a4c3b3fe5c86d71553307; registry validate=43 entries; generate=byte-stable; tests=36/36
elizaos-plugin-invinoveritas@0.2.3 integrity=sha512-Pqy30oeWxdokRsyvdpmvpiwiYT1/H+oOtECLA1XXfG98BpJ3XVg/5YFm0W8ViCy2co8DBagQSDdRVnZ68AT/nA==; gitHead=dd57c416f220d10fa154ed2f35cd60f412844876; tests=12/12
invinoveritas-verify@1.1.1 integrity=sha512-EOKYAONolVvIoSGnM0f+UtY7V0wUsxaZqM26KapU6ITiXZCa53XE2Yje4+4DrMsbU0U5qlGq+YhdkX279fSjYw==; gitHead=666163f56234d88b9cbf94d003b8eddcc5e0d0e6; tests=11/11
live rotating full event: id_integrity=true, signature_valid=true, issued_by_invinoveritas=true, is_proof_event=true; method=local; zero proof-verification network calls
root verify=350/350 workspace tasks plus all repository audits
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Registry diff (`bun run generate`, byte-stable on the exact head)

The generated entry is new and pins `npm.v2` to immutable version `0.2.3`; regeneration produces no diff.

## Registry gates (all pass, this exact head)

```
$ bun run validate
[registry] 43 third-party entries validated

$ bun run typecheck
$ tsc --noEmit -p tsconfig.json
(clean, no output)

$ bun run lint:check
Checked 55 files in 170ms. No fixes applied.

$ bun run generate:first-party:check
[registry/generate] generated artifacts are up to date.

$ bun run test
 Test Files  6 passed (6)
      Tests  36 passed (36)
```

## Package test output (fresh install, plugin's own repo)

```
$ npm install && npm run build && npm test
> elizaos-plugin-invinoveritas@0.2.3 build
> tsc
(clean)

# tests 12
# pass 12
# fail 0
```
9 original crypto tests, 2 positive tests from round 4, plus 1 new negative test this round
(proofId/fetched-event id-mismatch, reproducing lalalune's own repro exactly).

## Round 5 fix (this update)

lalalune found and reproduced live against the published 0.2.2 tarball: `callVerifyProof`'s
`proofId`-only path cryptographically verified the fetched event but never checked its `id`
matched the requested `proofId` — a compromised/misconfigured `INVINO_INDEPENDENT_NODE`
endpoint could substitute any other genuinely-valid signed event and the plugin would report
it valid for the wrong proof. Fixed: normalized exact `id` match required before local
verification runs, fails closed otherwise. The existing positive `fetched_then_local` test
requested an unrelated `"some-proof-id"` and asserted success — it encoded the exact bug,
fixed to request the matching id; added a new test reproducing lalalune's repro (64 zeroes
requested, endpoint returns the real unrelated sample event, must now fail closed).

## npm publish provenance

```
$ npm view invinoveritas-verify@1.1.1 gitHead repository
gitHead = '666163f56234d88b9cbf94d003b8eddcc5e0d0e6'
repository = { type: 'git', url: '...github.com/babyblueviper1/invinoveritas.git', directory: 'sdk/ts' }

$ npm view elizaos-plugin-invinoveritas@0.2.3 gitHead dependencies
gitHead = 'dd57c416f220d10fa154ed2f35cd60f412844876'
dependencies = { 'invinoveritas-verify': '1.1.1' }
```
Both commits are real, public, and independently fetchable:
- `https://github.com/babyblueviper1/invinoveritas/commit/666163f56234d88b9cbf94d003b8eddcc5e0d0e6`
- `https://github.com/babyblueviper1/invinoveritas/commit/dd57c416f220d10fa154ed2f35cd60f412844876`

## Known gaps / failures

- The public `proofId` fetch path returned HTTP 404 for both the current rotating handshake sample and a public ledger event during maintainer review. Full-event verification works live and fully locally; the registry description only claims that full-event path. Treat `proofId` fetch availability as service-dependent rather than proven by this review.
- Exact-head root `bun run verify` passed all 350 workspace tasks and repository audits.

Carried forward honestly from prior rounds: `invinoveritas-verify`'s
package build has no separate `.ts` source file to ship — `index.js` is the hand-authored
source directly (the `sdk/ts` directory name is a holdover from an earlier port), so "ships
source" means the real `index.js`/`index.d.ts`, not a compiled-from-TypeScript artifact.

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - external contributor's own agent, not elizaOS's bundled contribute-to-eliza skill
Attribution status: self-reported
— [pr-9090-response-r5]