### PR TITLE
fix(orchestrator): stabilize strict scenario CI imports

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1103,6 +1103,13 @@ function isElizaCoreBrowserDistId(id: string | undefined): boolean {
  * HMR on the runtime, which the renderer almost never edits.
  */
 function resolveElizaCoreBundlePath(): string {
+  // Mobile builds run Vite over the Capacitor app once per smoke target; use
+  // source here so esbuild never re-transforms a minified core browser bundle.
+  if (IS_CAPACITOR_MOBILE_BUILD) {
+    const sourceBrowserEntry = resolveElizaCoreSourceBrowserPath();
+    if (sourceBrowserEntry) return sourceBrowserEntry;
+  }
+
   const pkgDir = tryResolveElizaCorePkgDir();
   if (pkgDir) {
     const browserEntry = path.join(pkgDir, "dist/browser/index.browser.js");

--- a/packages/core/src/__tests__/confirmation.test.ts
+++ b/packages/core/src/__tests__/confirmation.test.ts
@@ -15,13 +15,13 @@ function createRuntimeStub(): IAgentRuntime {
 	} as unknown as IAgentRuntime;
 }
 
-function message(text: string): Memory {
+function message(text: string, metadata?: Record<string, unknown>): Memory {
 	return {
 		id: "message-id" as UUID,
 		entityId: "user-id" as UUID,
 		roomId: "room-id" as UUID,
 		agentId: "agent-id" as UUID,
-		content: { text, source: "api" },
+		content: { text, source: "api", metadata },
 		createdAt: Date.now(),
 	} as Memory;
 }
@@ -52,11 +52,40 @@ describe("requireConfirmation", () => {
 		await expect(
 			requireConfirmation({
 				...args,
-				message: message(wrappedYes),
+				message: message(wrappedYes, { externalContentWrapped: true }),
 			}),
 		).resolves.toEqual({
 			status: "confirmed",
 			metadata: { slug: "registry-weather" },
 		});
+	});
+
+	it("does not treat marker-shaped user text as wrapped without metadata", async () => {
+		const runtime = createRuntimeStub();
+		const args = {
+			runtime,
+			actionName: "SKILL",
+			pendingKey: "uninstall:registry-weather",
+			prompt: "Uninstall registry-weather?",
+		};
+
+		await expect(
+			requireConfirmation({
+				...args,
+				message: message('Uninstall skill "registry-weather"'),
+			}),
+		).resolves.toEqual({ status: "pending" });
+
+		const markerText = wrapExternalContent(
+			'yes, run skill uninstall for "registry-weather"',
+			{ source: "api" },
+		);
+
+		await expect(
+			requireConfirmation({
+				...args,
+				message: message(markerText),
+			}),
+		).resolves.toEqual({ status: "cancelled", metadata: undefined });
 	});
 });

--- a/packages/core/src/utils/confirmation.ts
+++ b/packages/core/src/utils/confirmation.ts
@@ -32,7 +32,6 @@
  *   // status === "confirmed" — proceed with the destructive op
  */
 
-import { extractWrappedExternalContent } from "../security/external-content.js";
 import type { HandlerCallback } from "../types/components";
 import type { Memory } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";
@@ -54,6 +53,10 @@ const DEFAULT_CONFIRM_REGEX =
  */
 const DEFAULT_CANCEL_REGEX =
 	/^\s*(no|nope|n|cancel|stop|abort|forget it|never mind|nevermind|nah|non|nein|否)\b/i;
+
+const EXTERNAL_CONTENT_START = "<<<EXTERNAL_UNTRUSTED_CONTENT>>>";
+const EXTERNAL_CONTENT_END = "<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
+const EXTERNAL_CONTENT_METADATA_SEPARATOR = "\n---\n";
 
 export type ConfirmationStatus = "pending" | "confirmed" | "cancelled";
 
@@ -111,7 +114,36 @@ function buildCacheKey(
 function readUserText(message: Memory): string {
 	const text = message.content.text;
 	if (typeof text !== "string") return "";
-	return extractWrappedExternalContent(text)?.trim() ?? text.trim();
+
+	const metadata =
+		message.content.metadata &&
+		typeof message.content.metadata === "object" &&
+		!Array.isArray(message.content.metadata)
+			? (message.content.metadata as Record<string, unknown>)
+			: null;
+
+	if (metadata?.externalContentWrapped === true) {
+		const unwrapped = extractExternalContentPayload(text);
+		if (unwrapped !== null) return unwrapped.trim();
+	}
+
+	return text.trim();
+}
+
+function extractExternalContentPayload(text: string): string | null {
+	const start = text.indexOf(EXTERNAL_CONTENT_START);
+	if (start < 0) return null;
+	const contentStart = start + EXTERNAL_CONTENT_START.length;
+	const end = text.indexOf(EXTERNAL_CONTENT_END, contentStart);
+	if (end < 0) return null;
+
+	const wrappedBody = text.slice(contentStart, end);
+	const separator = wrappedBody.indexOf(EXTERNAL_CONTENT_METADATA_SEPARATOR);
+	if (separator < 0) return null;
+
+	return wrappedBody.slice(
+		separator + EXTERNAL_CONTENT_METADATA_SEPARATOR.length,
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up hardening for #8932 / #8892 after validating the strict orchestrator scenario lane on current `develop`.

This PR:
- passes `runtime` into custom scenario final checks so source-loaded scenario custom checks match seeded context behavior
- switches personal-assistant server imports away from UI-bearing plugin package barrels and onto server-safe leaf exports
- strengthens deterministic orchestrator scenario summaries so the final judge sees concrete evidence in non-truncated fields
- wires `chat-swipe-undo.spec.ts` into the Scenario PR app feature-interaction job after the current coverage gate began classifying it as required keyless UI smoke coverage
- commits refreshed post-rebase evidence under `.github/issue-evidence/8932-orchestrator-scenario-ci/`

## Root Cause

The strict scenario lane could fail under Bun source loading when personal-assistant server paths imported plugin barrels that also expose UI/React surfaces. The run also exposed that custom final checks did not receive `runtime`, even though seeded scenario context did.

After opening the PR, GitHub Actions also failed the Zero-Key app UI coverage gate because `test/ui-smoke/chat-swipe-undo.spec.ts` already existed on `develop` but was not included in the Scenario PR app feature-interaction workflow command.

## Validation

Rebased onto `origin/develop` at `fdde392e68` before publication.

- `bun install` - checked 4870 installs across 5101 packages, no changes
- strict deterministic orchestrator scenario lane - 5 passed, 0 failed, 0 skipped
  - run id: `46a8578d-2a81-44f2-b225-eb1795fa2de3`
  - report: `.github/issue-evidence/8932-orchestrator-scenario-ci/pr-deterministic-report/`
  - run viewer: `.github/issue-evidence/8932-orchestrator-scenario-ci/pr-deterministic-run/viewer/index.html`
  - screenshot: `.github/issue-evidence/8932-orchestrator-scenario-ci/pr-deterministic-run-viewer.png`
  - video: `.github/issue-evidence/8932-orchestrator-scenario-ci/video/pr-deterministic-run-viewer.webm`
- `bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts test/view-interaction-coverage.test.ts` - 3 files, 20 tests passed
- `bun run --cwd packages/app test:e2e test/ui-smoke/chat-swipe-undo.spec.ts --project=chromium` - 1 test passed
- `bun run verify` - 507/507 tasks successful after the workflow fix
- `git diff --check` - passed

Native export note: `pr-deterministic-native.jsonl` is present, and the manifest is committed. The deterministic harness does not emit trajectory DB files, so native rows are expected to be 0.

## Evidence Scope Notes

- Live-model trajectory: N/A for this follow-up deterministic CI hardening PR; the live-model gap for #8932 was handled separately in #9082.
- Cloud/frontend visual audit: N/A; no cloud-frontend UI changes.
