### PR TITLE
fix(local-inference): live arbiter footprint accounting + device-class context tests (#8809) + Gemma KV de-slop (#8848)

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
+++ b/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
@@ -430,16 +430,19 @@ int bionic_int_env_or_default(const char* name, int fallback) {
 // Arm the eliza-1 text-model bionic config for runtime optimizations that are
 // correct for the shipped model.
 //
-// KV-quant stays OFF by default. The current shipped qwen35 Eliza-1 tiers use
-// head_dim=256, while QJL1_256/fused QJL-TBQ kernels are head_dim=128. Enabling
-// cache_type_k=qjl1_256/cache_type_v=tbq3_0 on these tiers regresses or crashes;
-// F16 KV is the correct path until a head_dim=256 QJL type or head_dim=128 model
-// variant ships. ELIZA_BIONIC_KV_QUANT=1 is left as an explicit lab override
-// for compatible test bundles only.
+// KV-quant stays OFF by default. The shipped Eliza-1 tiers are Gemma 4, whose
+// KV is already minimal by construction (MQA + windowed-SWA + shared-KV, dual
+// head dims 512 global / 256 SWA) and runs on stock f16/q8_0 KV. The legacy
+// QJL1_256 / fused QJL-TBQ kernels are head_dim=128 and dimensionally
+// inapplicable to Gemma, so cache_type_k=qjl1_256/cache_type_v=tbq3_0 is not a
+// shipping path; F16 KV is correct. ELIZA_BIONIC_KV_QUANT=1 is left as an
+// explicit lab override for head_dim=128 test bundles only.
 //
-// MTP is enabled by default for same-file NextN tiers (2B+) when a bundle path is
-// known, and remains off for 0.8B. ELIZA_BIONIC_MTP can force on/off for native
-// experiments.
+// MTP is enabled by default for same-file NextN tiers (2B+) when a bundle path
+// is known, and remains off for 0.8B. Gemma's separate-drafter MTP needs a real
+// drafter GGUF, which the base bundles do not yet ship, so on-device speculative
+// decode engages only where a same-file NextN head is present. ELIZA_BIONIC_MTP
+// can force on/off for native experiments.
 //
 // The two static names below outlive the cfg they're attached to (cfg is a
 // stack struct consumed synchronously by eliza_inference_llm_stream_open).
@@ -453,7 +456,8 @@ void arm_bionic_text_cfg(eliza_llm_stream_config_t& cfg,
         LOGI("bionic text cfg: KV-quant ON by explicit override (k=%s v=%s)",
              kKvTypeK, kKvTypeV);
     } else {
-        LOGI("bionic text cfg: KV-quant OFF (F16 KV; shipped qwen35 head_dim=256)");
+        LOGI("bionic text cfg: KV-quant OFF (stock f16/q8_0 KV; Gemma 4 KV is "
+             "already minimal)");
     }
 
     const bool default_mtp = bionic_bundle_allows_same_file_mtp(bundle_dir);
@@ -1263,8 +1267,8 @@ Java_ai_elizaos_app_ElizaVoiceNative_nativeLlmStreamOpen(
     cfg.repeat_penalty = 1.0f;
     cfg.n_gpu_layers = nGpuLayers;
     cfg.mtp_drafter_path = drafter.empty() ? nullptr : drafter.c_str();
-    // Arm safe runtime optimizations (F16 KV for shipped qwen35; MTP when a
-    // caller/env supplies a draft window).
+    // Arm safe runtime optimizations (stock f16/q8_0 KV for the shipped Gemma 4
+    // tiers; MTP when a caller/env supplies a draft window).
     // A caller-supplied drafter path is separate-drafter MTP and needs its own
     // draft window — only arm the same-file MTP env override when no drafter
     // was passed.
@@ -1412,8 +1416,8 @@ Java_ai_elizaos_app_ElizaVoiceNative_nativeLlmSelfTest(JNIEnv* env, jclass,
     cfg.top_p = 1.0f;
     cfg.repeat_penalty = 1.0f;
     cfg.n_gpu_layers = -1;   // all-GPU when the vulkan lib is staged
-    // Arm safe runtime optimizations (F16 KV for shipped qwen35; same-file MTP
-    // on 2B+ bundles, or env override for lab runs).
+    // Arm safe runtime optimizations (stock f16/q8_0 KV for the shipped Gemma 4
+    // tiers; same-file MTP on 2B+ bundles, or env override for lab runs).
     arm_bionic_text_cfg(cfg, bundleDir.c_str());
     EliLlmStream* s = eliza_inference_llm_stream_open(ctx, &cfg, &outError);
     if (!s) {

--- a/plugins/plugin-local-inference/docs/MEMORY_ARBITER.md
+++ b/plugins/plugin-local-inference/docs/MEMORY_ARBITER.md
@@ -20,13 +20,18 @@ The arbiter exists so loading a vision model can unload the text model
 gracefully and we don't get jetsam'd on iPhone or `lmkd`-killed on
 Android.
 
-## Validation status (2026-06-21)
+## Validation status (2026-06-23)
 
 Live in this checkout:
 
 - Fit-to-budget LRU eviction uses non-zero resident estimates and evicts
   the coldest evictable non-text role before a new load would exceed the
   configured budget.
+- The arbiter counts the engine-owned resident footprint (the active
+  text/embedding bundle) via `externalFootprintMb`, wired in `service.ts` to
+  `LocalInferenceEngine.getResidentFootprintMb()`. Without this the dominant
+  resident consumer was invisible to the arbiter and `evictToFit` silently
+  no-opped; it now trips for the roles that actually dominate RAM (#8809 AC#1).
 - `MemoryArbiter.preload(capability, modelKey)` warm-loads only under
   nominal pressure and only when the budget proves the resident set fits.
   It returns `false` under `low` / `critical` pressure or when the load

--- a/plugins/plugin-local-inference/src/services/context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/context-fit.test.ts
@@ -41,4 +41,43 @@ describe("computeRuntimeContextFit", () => {
 
 		expect(fit).toBeNull();
 	});
+
+	it("scales the selected context with the device RAM class (4/8/16/24/128 GB) (#8809 AC#4)", () => {
+		// One representative tier across the five canonical device classes.
+		// `weightMb` is the resident weight; `usableMb` is the post-headroom
+		// budget the caller (active-model.ts) passes. The q8_0 KV rate comes from
+		// the tier params, so the selected window tracks free RAM.
+		const deviceClassesGb = [4, 8, 16, 24, 128];
+		const fits = deviceClassesGb.map((gb) =>
+			computeRuntimeContextFit({
+				params: "9B",
+				weightMb: 6500,
+				usableMb: gb * 1024,
+				nativeContext: 131072,
+			}),
+		);
+
+		// 4 GB can't hold the weights + a minimum KV window → no fit.
+		expect(fits[0]).toBeNull();
+
+		// Every class that fits gets a 4k-aligned window within [min, native].
+		for (const fit of fits.slice(1)) {
+			expect(fit).not.toBeNull();
+			expect((fit?.contextSize ?? 0) % 4096).toBe(0);
+			expect(fit?.contextSize).toBeGreaterThanOrEqual(8192);
+			expect(fit?.contextSize).toBeLessThanOrEqual(131072);
+		}
+
+		// Context never shrinks as RAM grows (headroom → larger KV window).
+		const sizes = fits.map((f) => f?.contextSize ?? 0);
+		for (let i = 1; i < sizes.length; i++) {
+			expect(sizes[i]).toBeGreaterThanOrEqual(sizes[i - 1]);
+		}
+
+		// Tight-but-fitting (8 GB) downscales below native; roomy (128 GB) hits it.
+		expect(fits[1]?.contextDownscaled).toBe(true);
+		expect(fits[1]?.contextSize).toBeLessThan(131072);
+		expect(fits.at(-1)?.contextSize).toBe(131072);
+		expect(fits.at(-1)?.contextDownscaled).toBe(false);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -336,6 +336,12 @@ export class LocalInferenceEngine {
 	private idleUnloadTimer: NodeJS.Timeout | null = null;
 	/** Evictable text-target role id registered on `sharedResources`, or null. */
 	private textTargetRoleId: string | null = null;
+	/**
+	 * Ids of evictable roles THIS engine registered on `sharedResources`
+	 * (text-target today). `getResidentFootprintMb()` sums only these so the
+	 * arbiter never double-counts its own vision/image-gen registry roles.
+	 */
+	private readonly ownedEvictableRoleIds = new Set<string>();
 	/** Best-effort resident footprint for the active text bundle, in MiB. */
 	private textTargetEstimatedMb = 0;
 	/** Evictable drafter role id registered on `sharedResources`, or null. */
@@ -357,6 +363,28 @@ export class LocalInferenceEngine {
 	 */
 	getSharedResources(): SharedResourceRegistry {
 		return this.sharedResources;
+	}
+
+	/**
+	 * Resident RAM footprint (MB) of the model weights this engine owns on the
+	 * shared registry — the active text/embedding bundle today, plus any future
+	 * engine-registered role (drafter, voice). This is the term `service.ts`
+	 * feeds into the `MemoryArbiter` as `externalFootprintMb` so the arbiter's
+	 * proactive `evictToFit` path accounts for the dominant resident consumer
+	 * (the text target) instead of seeing only its own vision/image-gen handles
+	 * and never tripping (#8809 AC#1). Summed by role id so it never
+	 * double-counts the arbiter's own registry roles (vision/image-gen), which
+	 * the arbiter already counts in its resident map.
+	 */
+	getResidentFootprintMb(): number {
+		if (this.ownedEvictableRoleIds.size === 0) return 0;
+		let mb = 0;
+		for (const role of this.sharedResources.evictableRoles()) {
+			if (this.ownedEvictableRoleIds.has(role.id)) {
+				mb += role.estimatedResidentMb();
+			}
+		}
+		return mb;
 	}
 
 	/** The RAM-pressure monitor. Exposed for diagnostics / tests. */
@@ -404,6 +432,7 @@ export class LocalInferenceEngine {
 			});
 			this.sharedResources.acquire(role);
 			this.textTargetRoleId = role.id;
+			this.ownedEvictableRoleIds.add(role.id);
 		}
 	}
 
@@ -413,6 +442,7 @@ export class LocalInferenceEngine {
 		);
 		this.textTargetRoleId = null;
 		for (const id of ids) {
+			this.ownedEvictableRoleIds.delete(id);
 			try {
 				await this.sharedResources.release(id);
 			} catch {

--- a/plugins/plugin-local-inference/src/services/memory-arbiter.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-arbiter.test.ts
@@ -167,6 +167,78 @@ describe("MemoryArbiter — fit-to-budget LRU eviction", () => {
 		).toBe(true);
 	});
 
+	it("counts the engine's external footprint so evictToFit fires for the dominant roles (#8809 AC#1)", async () => {
+		const registry = new SharedResourceRegistry();
+		const events: ArbiterEvent[] = [];
+		// Budget 1000 MB. The active text/embedding bundle — the dominant
+		// resident consumer — is owned by the engine, NOT the arbiter's resident
+		// map, and is reported via externalFootprintMb=500. Two 400 MB capability
+		// models then can't both fit on top of it.
+		const arbiter = new MemoryArbiter({
+			registry,
+			now,
+			budgetMb: () => 1000,
+			externalFootprintMb: () => 500,
+		});
+		arbiter.onEvent((e) => events.push(e));
+		const embedding = makeCapability("embedding", {
+			residentRole: "embedding",
+			estimatedMb: 400,
+		});
+		const vision = makeCapability("vision-describe", {
+			residentRole: "vision",
+			estimatedMb: 400,
+		});
+		arbiter.registerCapability(embedding.registration);
+		arbiter.registerCapability(vision.registration);
+
+		clock = 1;
+		const e = await arbiter.acquire("embedding", "emb"); // 500 + 400 = 900 ≤ 1000
+		await e.release();
+		clock = 2;
+		const v = await arbiter.acquire("vision-describe", "vl"); // +400 → 1300 > 1000
+		await v.release();
+
+		// Without the external term this stays a silent no-op (800 ≤ 1000) and
+		// both models pile on top of the text bundle, overcommitting RAM. With
+		// it, the fit path evicts the LRU resident (emb).
+		expect(embedding.unloads).toEqual(["emb"]);
+		expect(arbiter.residentSnapshot().map((s) => s.modelKey)).toEqual(["vl"]);
+		expect(
+			events.some((e) => e.type === "eviction" && e.reason === "fit"),
+		).toBe(true);
+	});
+
+	it("keeps both models resident when no external footprint is reported", async () => {
+		const registry = new SharedResourceRegistry();
+		// externalFootprintMb defaults to 0 (the pre-#8809 accounting): 400 + 400
+		// ≤ 1000 → both fit, no eviction. This is the control for the test above.
+		const arbiter = new MemoryArbiter({ registry, now, budgetMb: () => 1000 });
+		const embedding = makeCapability("embedding", {
+			residentRole: "embedding",
+			estimatedMb: 400,
+		});
+		const vision = makeCapability("vision-describe", {
+			residentRole: "vision",
+			estimatedMb: 400,
+		});
+		arbiter.registerCapability(embedding.registration);
+		arbiter.registerCapability(vision.registration);
+
+		const e = await arbiter.acquire("embedding", "emb");
+		await e.release();
+		const v = await arbiter.acquire("vision-describe", "vl");
+		await v.release();
+
+		expect(embedding.unloads).toEqual([]);
+		expect(
+			arbiter
+				.residentSnapshot()
+				.map((s) => s.modelKey)
+				.sort(),
+		).toEqual(["emb", "vl"]);
+	});
+
 	it("never evicts the text target to make room", async () => {
 		const registry = new SharedResourceRegistry();
 		const arbiter = new MemoryArbiter({ registry, now, budgetMb: () => 1000 });

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -500,6 +500,12 @@ export class LocalInferenceService {
 					0,
 					Math.floor(totalmem() / (1024 * 1024)) - ramHeadroomReserveMb(),
 				),
+			// The dominant resident consumer — the active text/embedding bundle —
+			// is owned by the engine, not the arbiter's resident map. Feed its
+			// footprint in so the proactive fit-to-budget `evictToFit` path
+			// actually trips before a second model overcommits RAM, instead of
+			// silently no-opping on the two roles that matter most (#8809 AC#1).
+			externalFootprintMb: () => localInferenceEngine.getResidentFootprintMb(),
 		});
 		arbiter.start();
 		setMemoryArbiter(arbiter);


### PR DESCRIPTION
## What & why

Closes the remaining **host-doable** gaps in #8809 (local-inference memory management) and the **host-doable** slop in #8848 (on-device optimization enforcement). The genuinely device/training-gated items are scoped honestly below.

### #8809 — memory arbiter resident footprint (AC#1, the real bug)

`MemoryArbiter.evictToFit` only summed the arbiter's own resident map (vision/image-gen). The **dominant** resident consumer — the active text/embedding bundle — is owned by the engine on the shared registry, *not* the arbiter's map, so `evictToFit` silently no-opped on the roles that actually dominate RAM (exactly the documented AC#1 gap: "no more silent `incomingMb <= 0` no-op for the dominant roles").

- `LocalInferenceEngine.getResidentFootprintMb()` sums the engine's own resident evictable roles, tracked by role id so it never double-counts the arbiter's vision/image-gen registry roles.
- `service.ts` wires it as the arbiter's `externalFootprintMb` → `evictToFit` now trips for the dominant text role before a second model overcommits RAM.
- Tests: external footprint **drives** eviction + the control (no eviction without it); **4/8/16/24/128 GB device-class** coverage for the memory-aware runtime context selector (AC#4) landed in #9076.
- `MEMORY_ARBITER.md` validation status updated.

### #8848 — Gemma KV de-slop

The bionic JNI comments + a runtime log still claimed the shipped tiers were `qwen35` / `head_dim=256`. Post-cutover the shipped tiers are **Gemma 4** (stock f16/q8_0 KV; legacy head_dim=128 QJL/TBQ kernels dimensionally inapplicable per the M6 decision). Comments + the KV-quant-OFF log now state the Gemma reality. **No behavior change.**

## Status of the parent issues

**#8809** — AC#2 (single eviction loop), AC#3 (memperf harness + CI), AC#4 context selector (#9076), AC#5 `preload` API + voice next-stage predictor + tests, AC#6 telemetry: **already on develop**. AC#1 (this PR) closes the live-wiring bug. Genuinely remaining = **hardware-gated**: the iOS native `onTrimMemory` pressure bridge and the live on-device voice next-stage demo (the host-side predictor test already passes; the native mic-capture front-end that calls `runDeviceVoiceTurn` is the missing on-device piece, tracked with #8800/#8787).

**#8848** — items #1/#2/#6 are **MOOT** post-Gemma (KV already minimal; generic-GGUF path removed by M9); item #3 (separate-drafter MTP) is **already wired** in the JNI (`cfg.mtp_drafter_path`, gracefully null when absent) and gated only on a real drafter GGUF (training/publish). Remaining = **Mali-hardware-gated**: the `flash_attn.comp` scalar race (#4) and the coopmat prefill path (#5), which need a Pixel.

## Evidence
- `bunx vitest run` on the touched suites: **memory-arbiter (+2 new) / memory-monitor / context-fit (+device-class) / active-model-context-fit / engine / service / ram-budget / kv-spill** → **all green** (56 + 25 tests).
- `bun run typecheck` (plugin-local-inference) → **0 errors**. Biome `check` → clean.
- Real-LLM trajectory: **N/A** — no agent/action/prompt/model change (memory accounting + comments only).
- UI / cloud-frontend: **N/A** — no UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)