### PR TITLE
feat(local-inference): opt-in f16 KV when the host has headroom (#8809 AC#4)

### DIFF
--- a/packages/shared/src/local-inference/CONTEXT_SCALING.md
+++ b/packages/shared/src/local-inference/CONTEXT_SCALING.md
@@ -23,8 +23,9 @@ positional range is huge, KV-cache memory is what
 gates you, and that is where the stock q8_0 cache and (past 64k) KV spill
 do the heavy lifting. The catalog's job is to ship the largest *native* window
 per tier and then have the runtime pick a context within it that fits the
-device. That second half — a memory-aware context selector — is the gap; see
-"Wins" below.
+device. That second half — a memory-aware context selector — now lives in
+`context-fit.ts` (`computeRuntimeContextFit`), wired through `active-model.ts`;
+see "Wins" below.
 
 ---
 
@@ -307,8 +308,11 @@ error) stays — a slow voice session is worse than a clear "this device can't d
   runtime `contextSize` toward
   `min(tier.contextLength, baseNativeContext, maxFittingContext)` using
   `estimateQuantizedKvBytesPerToken`.
-- **Deferred:** an opt-in `preferAccurateKvWhenHeadroom` branch that picks f16
-  KV on hosts with abundant VRAM relative to the chosen model+context; stock
-  q8_0 remains the default and only shipped Gemma KV path.
+- **Resolved (opt-in):** `preferAccurateKvWhenHeadroom` picks f16 KV when the
+  host has the headroom to run it at (at least) the q8_0-selected window — it
+  only ever upgrades precision, never trades away context. Gated behind
+  `ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM`; stock q8_0 remains the default and
+  only shipped Gemma KV path. Implemented in `context-fit.ts` +
+  `active-model.ts` (`resolveRuntimeContextFit`).
 - **Still gated:** only add a named long-context 27B tier after the artifact and
   spill-latency gate pass.

--- a/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
@@ -65,4 +65,36 @@ describe("resolveLocalInferenceLoadArgs — runtime context fit", () => {
 
 		expect(args.contextSize).toBe(32768);
 	});
+
+	it("upgrades KV to f16 on a roomy host when the headroom opt-in is set (#8809 AC#4)", async () => {
+		const prev = process.env.ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM;
+		process.env.ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM = "1";
+		try {
+			const args = await resolveLocalInferenceLoadArgs(
+				makeInstalledModel("eliza-1-9b", 5.4),
+				undefined,
+				{ hardware: hardware(64) },
+			);
+			expect(args.contextSize).toBe(131072);
+			expect(args.cacheTypeK).toBe("f16");
+			expect(args.cacheTypeV).toBe("f16");
+		} finally {
+			if (prev === undefined) {
+				delete process.env.ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM;
+			} else {
+				process.env.ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM = prev;
+			}
+		}
+	});
+
+	it("leaves KV at the q8_0 default when the headroom opt-in is off", async () => {
+		const args = await resolveLocalInferenceLoadArgs(
+			makeInstalledModel("eliza-1-9b", 5.4),
+			undefined,
+			{ hardware: hardware(64) },
+		);
+
+		expect(args.cacheTypeK).not.toBe("f16");
+		expect(args.cacheTypeV).not.toBe("f16");
+	});
 });

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -22,7 +22,10 @@ import {
 	FIRST_RUN_DEFAULT_MODEL_ID,
 	findCatalogModel,
 } from "./catalog";
-import { computeRuntimeContextFit } from "./context-fit";
+import {
+	computeRuntimeContextFit,
+	type RuntimeContextFit,
+} from "./context-fit";
 import { localInferenceEngine } from "./engine";
 import { probeHardware } from "./hardware";
 import type { Eliza1Manifest } from "./manifest";
@@ -389,12 +392,25 @@ function applyCatalogDefaults(
 		const nativeContext =
 			installedBundleContextSize(installed, manifestLoader) ??
 			catalog?.contextLength;
-		args.contextSize = dynamicRuntimeContextSize(
+		const fit = resolveRuntimeContextFit(
 			installed,
 			catalog,
 			nativeContext,
 			hardware,
 		);
+		args.contextSize = fit?.contextSize ?? nativeContext;
+		// Headroom KV-precision upgrade: when the selector chose f16 (opt-in via
+		// ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM) and the caller/catalog left KV at
+		// the default q8_0, raise both cache types to f16. Only ever upgrades, and
+		// only when f16 still affords the selected window (#8809 AC#4).
+		if (
+			fit?.kvQuant === "f16" &&
+			(args.cacheTypeK === undefined || args.cacheTypeK === "q8_0") &&
+			(args.cacheTypeV === undefined || args.cacheTypeV === "q8_0")
+		) {
+			args.cacheTypeK = "f16";
+			args.cacheTypeV = "f16";
+		}
 	}
 
 	// Catalog-declared GPU offload default — only apply when the caller
@@ -450,16 +466,23 @@ function installedWeightMb(
 	return 0;
 }
 
-function dynamicRuntimeContextSize(
+/** ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM=1 opts into the f16-KV-on-headroom path. */
+function preferAccurateKvWhenHeadroom(): boolean {
+	const v =
+		process.env.ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM?.trim().toLowerCase();
+	return v === "1" || v === "true" || v === "yes";
+}
+
+function resolveRuntimeContextFit(
 	installed: InstalledModel,
 	catalog: CatalogModel | undefined,
 	nativeContext: number | undefined,
 	hardware: HardwareProbe | undefined,
-): number | undefined {
-	if (!catalog || nativeContext === undefined) return nativeContext;
-	if (!hardware) return nativeContext;
+): RuntimeContextFit | null {
+	if (!catalog || nativeContext === undefined) return null;
+	if (!hardware) return null;
 
-	const fit = computeRuntimeContextFit({
+	return computeRuntimeContextFit({
 		params: catalog.params,
 		weightMb: installedWeightMb(installed, catalog),
 		usableMb: Math.max(
@@ -467,8 +490,8 @@ function dynamicRuntimeContextSize(
 			hostRamMbFromProbe(hardware) - ramHeadroomReserveMb(),
 		),
 		nativeContext,
+		preferAccurateKvWhenHeadroom: preferAccurateKvWhenHeadroom(),
 	});
-	return fit?.contextSize ?? nativeContext;
 }
 
 function mergeOverrides(

--- a/plugins/plugin-local-inference/src/services/context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/context-fit.test.ts
@@ -42,6 +42,44 @@ describe("computeRuntimeContextFit", () => {
 		expect(fit).toBeNull();
 	});
 
+	it("defaults to q8_0 KV", () => {
+		const fit = computeRuntimeContextFit({
+			params: "9B",
+			weightMb: 5529,
+			usableMb: 64 * 1024,
+			nativeContext: 131072,
+		});
+		expect(fit?.kvQuant).toBe("q8_0");
+	});
+
+	it("upgrades to f16 KV when there's headroom and it's opted in (#8809 AC#4)", () => {
+		const fit = computeRuntimeContextFit({
+			params: "9B",
+			weightMb: 5529,
+			usableMb: 64 * 1024,
+			nativeContext: 131072,
+			preferAccurateKvWhenHeadroom: true,
+		});
+		expect(fit?.kvQuant).toBe("f16");
+		// f16 still affords the full native window on a roomy host.
+		expect(fit?.contextSize).toBe(131072);
+		expect(fit?.contextDownscaled).toBe(false);
+	});
+
+	it("never trades context for f16 KV precision (stays q8_0 when f16 would shrink the window)", () => {
+		// kvBudget here lets q8_0 reach the full native window but f16 (≈1.88×)
+		// would not — so the opt-in must keep q8_0 rather than downscale context.
+		const fit = computeRuntimeContextFit({
+			params: "9B",
+			weightMb: 5529,
+			usableMb: 8053,
+			nativeContext: 131072,
+			preferAccurateKvWhenHeadroom: true,
+		});
+		expect(fit?.contextSize).toBe(131072);
+		expect(fit?.kvQuant).toBe("q8_0");
+	});
+
 	it("scales the selected context with the device RAM class (4/8/16/24/128 GB) (#8809 AC#4)", () => {
 		// One representative tier across the five canonical device classes.
 		// `weightMb` is the resident weight; `usableMb` is the post-headroom

--- a/plugins/plugin-local-inference/src/services/context-fit.ts
+++ b/plugins/plugin-local-inference/src/services/context-fit.ts
@@ -5,6 +5,10 @@ const BYTES_PER_MIB = 1024 * 1024;
 const CONTEXT_STEP = 4096;
 const DEFAULT_WORKING_SET_MB = 1024;
 
+// q8_0 stores the KV cache at 34 bytes / 32 elements; f16 at 2 bytes / element.
+// f16 KV therefore costs ~1.88× the q8_0 per-token rate the estimate is keyed to.
+const F16_OVER_Q8_0_KV_RATIO = 2 / (34 / 32);
+
 export interface RuntimeContextFitInput {
 	params: string;
 	weightMb: number;
@@ -13,6 +17,14 @@ export interface RuntimeContextFitInput {
 	minContext?: number;
 	workingSetMb?: number;
 	contextStep?: number;
+	/**
+	 * When the host has enough headroom to run the more accurate f16 KV cache at
+	 * (at least) the same window q8_0 would give, prefer f16 instead of leaving
+	 * precision on the table. Opt-in — q8_0 stays the default per the device-fit
+	 * contract; this only ever *upgrades* precision and never trades away context
+	 * (#8809 AC#4). See CONTEXT_SCALING.md §5.
+	 */
+	preferAccurateKvWhenHeadroom?: boolean;
 }
 
 export interface RuntimeContextFit {
@@ -21,6 +33,8 @@ export interface RuntimeContextFit {
 	maxFittingContext: number;
 	kvBytesPerToken: number;
 	workingSetMb: number;
+	/** The KV cache precision the chosen window was sized against. */
+	kvQuant: "q8_0" | "f16";
 }
 
 function roundDownToStep(value: number, step: number): number {
@@ -58,19 +72,42 @@ export function computeRuntimeContextFit(
 
 	const kvBudgetMb = input.usableMb - input.weightMb - workingSetMb;
 	if (kvBudgetMb <= 0) return null;
+	const kvBudgetBytes = kvBudgetMb * BYTES_PER_MIB;
 
-	const maxFittingContext = roundDownToStep(
-		(kvBudgetMb * BYTES_PER_MIB) / kvBytesPerToken,
+	const q8MaxFittingContext = roundDownToStep(
+		kvBudgetBytes / kvBytesPerToken,
 		step,
 	);
-	if (maxFittingContext < minContext) return null;
+	if (q8MaxFittingContext < minContext) return null;
+	const q8ContextSize = Math.min(input.nativeContext, q8MaxFittingContext);
 
-	const contextSize = Math.min(input.nativeContext, maxFittingContext);
+	// Default: q8_0 KV, sized to the host. Opt-in headroom upgrade: if f16 KV
+	// still affords at least the q8_0-selected window, use it — more precise, and
+	// never at the cost of context.
+	let kvQuant: "q8_0" | "f16" = "q8_0";
+	let kvBytesPerTokenChosen = kvBytesPerToken;
+	let maxFittingContext = q8MaxFittingContext;
+	let contextSize = q8ContextSize;
+	if (input.preferAccurateKvWhenHeadroom) {
+		const f16BytesPerToken = kvBytesPerToken * F16_OVER_Q8_0_KV_RATIO;
+		const f16MaxFittingContext = roundDownToStep(
+			kvBudgetBytes / f16BytesPerToken,
+			step,
+		);
+		if (f16MaxFittingContext >= q8ContextSize) {
+			kvQuant = "f16";
+			kvBytesPerTokenChosen = f16BytesPerToken;
+			maxFittingContext = f16MaxFittingContext;
+			contextSize = Math.min(input.nativeContext, f16MaxFittingContext);
+		}
+	}
+
 	return {
 		contextSize,
 		contextDownscaled: contextSize < input.nativeContext,
 		maxFittingContext,
-		kvBytesPerToken,
+		kvBytesPerToken: kvBytesPerTokenChosen,
 		workingSetMb,
+		kvQuant,
 	};
 }


### PR DESCRIPTION
## What & why

Completes the **second half of #8809 AC#4** — "larger context / more accurate KV when there's headroom." The memory-aware context selector (#9076) already sized the q8_0 KV window to free RAM; this adds the documented `preferAccurateKvWhenHeadroom` branch from `CONTEXT_SCALING.md` §5, the last host-doable AC#4 item.

- `computeRuntimeContextFit` gains `preferAccurateKvWhenHeadroom` and returns `kvQuant`. When f16 KV (~1.88× the q8_0 per-token rate) still affords **at least** the q8_0-selected window, it upgrades to f16 — it only ever raises precision, **never trades away context**.
- `active-model.ts` (`resolveRuntimeContextFit`) reads the opt-in from `ELIZA_PREFER_ACCURATE_KV_WHEN_HEADROOM` and raises `cacheTypeK`/`cacheTypeV` to f16 when the fit chose it and the caller/catalog left KV at the default q8_0.
- **Default stays q8_0** (the shipped Gemma KV path) — opt-in only, no behavior regression.

## Evidence
- New tests: pure-function `f16 upgrade on headroom` / `never shrinks context for precision` / `default q8_0`, plus an integration test that the env flag flips `cacheTypeK/V` on a roomy host. **69/69 green** across the touched suites (context-fit, active-model-context-fit, active-model-switch-rollback, memory-arbiter, service, catalog, kv-spill).
- `bun run typecheck` (plugin-local-inference) → **0 errors**; Biome clean.
- Real-LLM trajectory / UI: **N/A** — load-arg sizing + a pure function; no agent/prompt/model or UI change.

## Context
This closes the last host-doable item on #8809 AC#4. With this + #9076 + #9094, every host-doable #8809 criterion is implemented and tested; the remaining items (iOS native pressure bridge, live on-device voice next-stage demo) are genuinely device-gated (tracked with #8800/#8787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)