### PR TITLE
chore(local-inference): drop stale qwen35 TokenizerFamily member (#9033)

### DIFF
--- a/packages/app/test/ui-smoke/model-download-deferral.spec.ts
+++ b/packages/app/test/ui-smoke/model-download-deferral.spec.ts
@@ -20,7 +20,7 @@ const DOWNLOAD_MODEL = {
   category: "chat",
   bucket: "medium",
   contextLength: 131_072,
-  tokenizerFamily: "qwen35",
+  tokenizerFamily: "eliza1",
   publishStatus: "published",
   blurb: "Smoke-test downloadable local tier.",
 };

--- a/packages/shared/src/local-inference/types.ts
+++ b/packages/shared/src/local-inference/types.ts
@@ -300,7 +300,6 @@ export type TokenizerFamily =
   | "gemma4"
   | "eliza1"
   | "sentencepiece"
-  | "qwen35"
   | (string & {});
 
 export type CatalogHub = "huggingface" | "modelscope";

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -343,8 +343,8 @@ function normalizeChatRole(
  * and leave legacy `prompt` unset; without this bridge the native loader sees
  * an empty string and `eliza_inference_tokenize` returns zero tokens.
  *
- * The Eliza-1 bundle is a qwen3.5-family model (catalog tokenizerFamily
- * "qwen35"), so we render the qwen ChatML template
+ * The Eliza-1 bundle is a qwen3.5-family model, so we render the qwen ChatML
+ * template
  * (`<|im_start|>role\n…<|im_end|>`) with a trailing `<|im_start|>assistant`
  * generation marker. The generate path MUST tokenize this with
  * parse_special=true so the role markers become real control tokens instead of


### PR DESCRIPTION
## What

Remove the stale `qwen35` member from the `TokenizerFamily` union in `packages/shared/src/local-inference/types.ts`. The Gemma cutover removed every active runtime reference to it, so it was a dead union member.

- `packages/shared/src/local-inference/types.ts` — drop `| "qwen35"` from `TokenizerFamily`. The remaining members are `"gemma4" | "eliza1" | "sentencepiece" | (string & {})`.
- `packages/app/test/ui-smoke/model-download-deferral.spec.ts` — the only TS file assigning `tokenizerFamily: "qwen35"` (a mock for an `eliza-1-4b` tier). Updated to `"eliza1"`, the valid family for an Eliza-1 bundle, so the spec stays type-consistent with the union.
- `plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts` — corrected a now-stale comment that referenced the removed `catalog tokenizerFamily "qwen35"` value (the substantive "qwen3.5-family model / qwen ChatML template" description is unchanged — it still describes real runtime behavior).

## Why

`qwen35` had no active runtime references after the Gemma cutover. The open `(string & {})` member meant the literal was never a hard type error anywhere, but the dead named member is misleading. This is a focused cleanup with no behavior change.

Closes #9033.

## Verification

```
$ bun run --cwd packages/shared typecheck
$ tsgo --noEmit -p tsconfig.json
EXIT: 0          # fully clean
```

```
$ bun run --cwd packages/app typecheck
../ui/src/spatial/tui/index.ts(11,3): error TS2724: '"@elizaos/tui"' has no exported member named 'getTerminalViewFactory'...
../ui/src/spatial/tui/renderer.ts(17,8): error TS2305: Module '"@elizaos/tui"' has no exported member 'TerminalViewMountOptions'...
```

The two app-typecheck errors are **pre-existing on `develop` and unrelated to this change** — a `@elizaos/ui` ↔ `@elizaos/tui` barrel mismatch (`getTerminalViewFactory` / `TerminalViewMountOptions` are defined in `packages/tui/src/view-registry.ts` but not re-exported from the `@elizaos/tui` barrel). I reproduced them identically with this branch's edits stashed. No new error is introduced by the `tokenizerFamily` change, and nothing on the touched line errors.

Affected spec parses/lists cleanly with the new value:

```
$ bunx playwright test --config playwright.ui-smoke.config.ts model-download-deferral --list
[chromium] › model-download-deferral.spec.ts:108:1 › selecting on-device inference drops the user into chat while the model downloads in the background
Total: 1 test in 1 file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)