### PR TITLE
docs(os): release-secrets maintainer playbooks + consolidated checklist (#7770)

### DIFF
--- a/packages/os/docs/release-secrets-android.md
+++ b/packages/os/docs/release-secrets-android.md
@@ -1,0 +1,143 @@
+# Maintainer: Android release credentials
+
+Playbook for the secrets `android-release.yml` consumes to build a **signed**
+AAB + APK and upload to the Google Play Store. Same shape as the apt-repo
+playbook ([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)): generate →
+set the repo secret → sanity-run → rotate/revoke.
+
+There are two independent credential groups:
+
+1. **Upload keystore** — signs the artifacts. Without it the signing preflight
+   fails loudly and the build aborts.
+2. **Play Store service account** — uploads the AAB to a Play track. Optional:
+   when absent, the workflow still builds + attaches signed artifacts to the
+   GitHub Release and only skips the `publish-play-store` job (with a warning).
+
+## Secrets this workflow reads
+
+| Secret | Required? | Used as |
+| --- | --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Yes — sign-blocking | base64 of the upload keystore `.jks`, decoded to `/tmp/elizaos-upload.jks` |
+| `ANDROID_KEYSTORE_PASSWORD` | Yes — sign-blocking | `ELIZAOS_KEYSTORE_PASSWORD` |
+| `ANDROID_KEY_ALIAS` | Yes — sign-blocking | `ELIZAOS_KEY_ALIAS` |
+| `ANDROID_KEY_PASSWORD` | Yes — sign-blocking | `ELIZAOS_KEY_PASSWORD` |
+| `PLAY_STORE_SERVICE_ACCOUNT_JSON` | Optional (gates Play upload) | base64 of the service-account JSON, decoded for `fastlane supply` |
+
+The signing preflight (`bun run preflight:android:sideload`) checks all four
+keystore inputs and exits with `::error::Missing Android release signing
+inputs: …` if any is empty, so a half-configured repo fails inside the job
+rather than producing an unsigned build.
+
+## Step 1 — Generate the upload keystore
+
+Generate a dedicated upload key on a trusted machine (not the runner). Keep it
+out of git. Play App Signing re-signs with Google's app key, so this is the
+*upload* key — protect it but it is independently rotatable through Play
+Console if leaked.
+
+```sh
+keytool -genkeypair -v \
+  -keystore elizaos-upload.jks \
+  -alias elizaos-upload \
+  -keyalg RSA -keysize 4096 -validity 10000 \
+  -storetype JKS
+```
+
+`keytool` prompts for the **keystore password** and the **key password** (you
+may set them the same). Record:
+
+- keystore password → `ANDROID_KEYSTORE_PASSWORD`
+- key alias (`elizaos-upload` above) → `ANDROID_KEY_ALIAS`
+- key password → `ANDROID_KEY_PASSWORD`
+
+Base64-encode the keystore for storage as a secret string:
+
+```sh
+base64 -w0 elizaos-upload.jks > elizaos-upload.jks.b64   # Linux
+# macOS: base64 -i elizaos-upload.jks -o elizaos-upload.jks.b64
+```
+
+`ANDROID_KEYSTORE_BASE64` is the contents of `elizaos-upload.jks.b64`.
+
+## Step 2 — Create the Play Store service account (optional)
+
+Only needed to upload to the Play Store; skip if you only want signed artifacts
+on the GitHub Release.
+
+1. In the Google Play Console: **Setup → API access** → link or create a Google
+   Cloud project.
+2. In Google Cloud Console: **IAM & Admin → Service Accounts → Create**. Name it
+   e.g. `elizaos-play-ci`. No project roles needed here.
+3. On the service account → **Keys → Add key → JSON**. The JSON downloads once.
+4. Back in Play Console → **Users and permissions → Invite new users**, add the
+   service account email, and grant release permissions for the app (at minimum
+   "Release to testing tracks" / "Release to production" as appropriate).
+
+Base64 the JSON the same way:
+
+```sh
+base64 -w0 play-ci.json > play-ci.json.b64
+```
+
+`PLAY_STORE_SERVICE_ACCOUNT_JSON` is the contents of `play-ci.json.b64`.
+
+The workflow uploads with `fastlane supply … --package_name "app.eliza"`, so the
+service account must have permission on the `app.eliza` Play listing.
+
+## Step 3 — Set the GitHub secrets
+
+At `https://github.com/elizaOS/eliza/settings/secrets/actions`, add each of the
+five secrets from the table above. Then shred the local copies:
+
+```sh
+shred -u elizaos-upload.jks elizaos-upload.jks.b64 play-ci.json play-ci.json.b64
+```
+
+## Step 4 — Sanity-trigger the workflow
+
+```sh
+gh workflow run android-release.yml \
+  --repo elizaOS/eliza \
+  --field version_name=2.0.0-beta.0 \
+  --field track=internal
+gh run watch --repo elizaOS/eliza
+```
+
+A green run:
+
+1. Builds and **signs** the AAB + APK (signing preflight passes).
+2. Attaches `Eliza-<version>.aab/.apk` + `…SHA256SUMS.txt` + the sideload APK to
+   the `v<version>` GitHub Release (the release tag must already exist).
+3. If `PLAY_STORE_SERVICE_ACCOUNT_JSON` is set, runs `publish-play-store` and
+   uploads to the chosen track.
+
+Symptoms of misconfiguration:
+
+- `::error::Missing Android release signing inputs: …` → a keystore secret is
+  empty or the base64 didn't decode to a non-empty `.jks`.
+- `play_store_ready=false` + a warning, Play job skipped → service account JSON
+  not set (artifacts still attach; this is fine if you only wanted the APK/AAB).
+
+## Rotating the upload key
+
+If you must rotate the upload key (e.g. before expiry or after suspected
+exposure), use **Play Console → App integrity → request upload key reset**;
+Google issues a new upload certificate. Then regenerate the keystore (Step 1),
+update the four keystore secrets, and sanity-run.
+
+For the service account, add a new JSON key in Google Cloud, update
+`PLAY_STORE_SERVICE_ACCOUNT_JSON`, verify a run, then delete the old key.
+
+## Revoking a compromised credential
+
+- **Service account leaked:** delete the key in Google Cloud (Service Accounts →
+  Keys) — it stops working immediately. Issue a fresh key and update the secret.
+- **Upload key leaked:** request an upload key reset in Play Console (above).
+  Play App Signing means the *app* signing key is held by Google, so a leaked
+  upload key cannot ship a malicious update once reset.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `android-release.yml` — the workflow this configures.

--- a/packages/os/docs/release-secrets-apple.md
+++ b/packages/os/docs/release-secrets-apple.md
@@ -1,0 +1,179 @@
+# Maintainer: Apple release credentials (iOS App Store + Mac App Store)
+
+Playbook for the secrets `apple-store-release.yml` consumes. Same shape as the
+apt-repo playbook ([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)):
+generate → set the repo secret → sanity-run → rotate/revoke.
+
+The workflow has two independent jobs:
+
+- **`build-ios`** — builds + uploads the iOS IPA to TestFlight / App Store via
+  Fastlane, signing with **Fastlane Match** certs.
+- **`build-macos`** — builds the Electrobun app, re-signs for the **Mac App
+  Store**, packages a `.pkg`, and uploads via `xcrun altool` with an **App Store
+  Connect API key**.
+
+You can run them separately with the `platform` dispatch input (`ios`, `macos`,
+or `both`).
+
+## Secrets this workflow reads
+
+| Secret | Job | Used as |
+| --- | --- | --- |
+| `APPLE_ID` | both | Apple account id |
+| `APPLE_TEAM_ID` | both | Developer Team ID |
+| `ITC_TEAM_ID` | iOS | App Store Connect team id (validated, sign-blocking) |
+| `APP_STORE_APP_ID` | iOS | delivery target app id (sign-blocking) |
+| `MATCH_PASSWORD` | iOS | decrypts the Match cert repo (sign-blocking) |
+| `MATCH_GIT_URL` | iOS | Match cert repo git URL (sign-blocking) |
+| `MATCH_GIT_BASIC_AUTHORIZATION` | iOS | Match cert repo basic-auth (sign-blocking) |
+| `APPLE_APP_SPECIFIC_PASSWORD` | both | `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` |
+| `MAS_CSC_LINK` | macOS | `CSC_LINK` — Mac App Store app cert `.p12` (base64) |
+| `MAS_CSC_KEY_PASSWORD` | macOS | `CSC_KEY_PASSWORD` for the app cert |
+| `MAS_INSTALLER_CERT` | macOS | "3rd Party Mac Developer Installer" cert `.p12` (base64) |
+| `MAS_INSTALLER_KEY_PASSWORD` | macOS | password for the installer cert |
+| `APP_STORE_API_KEY_ID` | macOS | API key id (`altool --apiKey`) |
+| `APP_STORE_API_ISSUER_ID` | macOS | API issuer id (`altool --apiIssuer`) |
+| `APP_STORE_API_KEY_P8` | macOS | `.p8` private key written to `AuthKey_<id>.p8` |
+
+The iOS job's "Validate iOS secrets" step and the macOS job's "Validate signing
+secrets" step both exit with `::error::Missing required … secrets: …` listing
+the empty ones, so a half-configured job fails loudly rather than producing an
+unsigned artifact.
+
+## Where each value comes from
+
+Apple identifiers and issued certificates are **re-entered from source** (Apple
+Developer / App Store Connect). Two values you **generate fresh**: the app-
+specific password and the App Store Connect API key.
+
+### Account identifiers
+
+- `APPLE_ID` — the Apple Developer account email used for delivery.
+- `APPLE_TEAM_ID` — Apple Developer → Membership → Team ID (10-char).
+- `ITC_TEAM_ID` — App Store Connect team id (often the same; visible in the
+  App Store Connect API or Fastlane `spaceship`).
+- `APP_STORE_APP_ID` — the app's App Store Connect numeric app id (Apple ID
+  shown on the app's App Information page).
+
+### App-specific password (generate fresh)
+
+At `https://appleid.apple.com` → Sign-In and Security → App-Specific Passwords →
+generate one labelled e.g. `elizaos-ci`. The value → `APPLE_APP_SPECIFIC_PASSWORD`.
+The workflow exposes it as `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`.
+
+### iOS signing via Fastlane Match
+
+iOS certs/profiles live in a private **Match** git repo, not in these secrets —
+the secrets are how CI *reaches* that repo:
+
+- `MATCH_GIT_URL` — the Match repo URL (e.g.
+  `https://github.com/elizaOS/ios-certificates.git`).
+- `MATCH_PASSWORD` — the passphrase Match used to encrypt that repo (chosen when
+  the repo was first set up with `fastlane match`).
+- `MATCH_GIT_BASIC_AUTHORIZATION` — base64 of `username:personal_access_token`
+  granting read access to the Match repo:
+  ```sh
+  printf 'ci-bot:ghp_xxx' | base64
+  ```
+
+If the Match repo does not exist yet, create the certs first from a Mac with the
+Apple account:
+
+```sh
+cd packages/app/ios
+bundle exec fastlane match appstore   # creates + pushes encrypted certs
+```
+
+### Mac App Store certificates (re-enter from source)
+
+From the Apple Developer certificates portal, issue and export two certs as
+`.p12`, then base64 them:
+
+1. **Apple Distribution** (or "3rd Party Mac Developer Application") →
+   `MAS_CSC_LINK`, export password → `MAS_CSC_KEY_PASSWORD`.
+2. **3rd Party Mac Developer Installer** → `MAS_INSTALLER_CERT`, export password
+   → `MAS_INSTALLER_KEY_PASSWORD`.
+
+```sh
+base64 -i mas-app.p12 | tr -d '\n'        # → MAS_CSC_LINK
+base64 -i mas-installer.p12 | tr -d '\n'  # → MAS_INSTALLER_CERT
+```
+
+The workflow imports both into a throwaway keychain and finds the
+`Apple Distribution` + `3rd Party Mac Developer Installer` identities by name.
+
+### App Store Connect API key (generate fresh)
+
+At App Store Connect → Users and Access → **Integrations → App Store Connect
+API → Generate API Key** (role: at least App Manager). On generation:
+
+- the **Key ID** → `APP_STORE_API_KEY_ID`
+- the **Issuer ID** (shown above the key list) → `APP_STORE_API_ISSUER_ID`
+- the **`AuthKey_<KeyID>.p8`** file (downloads once) → paste its full contents
+  into `APP_STORE_API_KEY_P8`
+
+The macOS job writes the `.p8` to
+`~/.appstoreconnect/private_keys/AuthKey_<APP_STORE_API_KEY_ID>.p8` and calls
+`xcrun altool --upload-app --apiKey <id> --apiIssuer <issuer>`, so the three
+values must come from the same generated key.
+
+## Set the GitHub secrets
+
+Add every secret from the table at
+`https://github.com/elizaOS/eliza/settings/secrets/actions`, then shred local
+`.p12` / `.p8` / base64 files:
+
+```sh
+shred -u mas-app.p12 mas-installer.p12 AuthKey_*.p8
+```
+
+## Sanity-trigger the workflow
+
+Start with iOS only (TestFlight), then macOS:
+
+```sh
+gh workflow run apple-store-release.yml \
+  --repo elizaOS/eliza \
+  --field platform=ios \
+  --field track=testflight \
+  --field version=2.0.0-beta.0
+gh run watch --repo elizaOS/eliza
+```
+
+```sh
+gh workflow run apple-store-release.yml \
+  --repo elizaOS/eliza \
+  --field platform=macos \
+  --field version=2.0.0-beta.0
+```
+
+Misconfiguration symptoms:
+
+- `::error::Missing required iOS signing secrets: MATCH_GIT_URL …` → a Match or
+  delivery secret is empty.
+- `::error::Missing required signing secrets: MAS_CSC_LINK …` → a Mac App Store
+  cert or API-key secret is empty.
+
+## Rotating credentials
+
+- **App-specific password / API key:** generate a new one, update the
+  secret(s), verify a run, then revoke the old one at appleid.apple.com /
+  App Store Connect.
+- **Match certs:** `fastlane match nuke distribution` then re-create; update
+  `MATCH_PASSWORD` only if you change the passphrase.
+- **Mac App Store certs:** revoke in the Developer portal, issue replacements,
+  re-export `.p12`, update the four `MAS_*` secrets.
+
+## Revoking a compromised credential
+
+- API key — revoke in App Store Connect → Integrations; the `.p8` is dead
+  immediately.
+- App-specific password — revoke at appleid.apple.com.
+- Distribution/installer certs — revoke in the Developer portal (this
+  invalidates in-flight signing with that cert), then reissue.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `apple-store-release.yml` — the workflow this configures.

--- a/packages/os/docs/release-secrets-checklist.md
+++ b/packages/os/docs/release-secrets-checklist.md
@@ -1,0 +1,166 @@
+# Release secrets checklist
+
+This is the consolidated index of every credential the cross-platform release
+pipeline consumes, one row per secret, with the workflow that reads it and where
+the value originates. Use it as the pre-flight gate before cutting a release on
+a fresh repo, and as the audit list when rotating credentials.
+
+Each channel has a dedicated maintainer playbook (credential generation → repo
+secret → sanity `workflow_dispatch` → rotation/revocation). This page is the
+map; the playbooks are the procedure.
+
+| Channel | Playbook |
+| --- | --- |
+| Android (keystore + Play Store) | [release-secrets-android.md](./release-secrets-android.md) |
+| Apple (iOS App Store + Mac App Store) | [release-secrets-apple.md](./release-secrets-apple.md) |
+| Homebrew tap | [release-secrets-homebrew.md](./release-secrets-homebrew.md) |
+| Snap Store | [release-secrets-snap.md](./release-secrets-snap.md) |
+| Flathub | [release-secrets-flathub.md](./release-secrets-flathub.md) |
+| Windows Store + Authenticode signing | [release-secrets-windows.md](./release-secrets-windows.md) |
+| Debian apt repo | [admin-apt-repo-setup.md](./admin-apt-repo-setup.md) |
+
+## How secrets reach the workflows
+
+All channel workflows are reusable (`workflow_call`) and are invoked by the
+orchestrators `release-all.yml` / `release-orchestrator.yml` with
+`secrets: inherit`. Each channel workflow also has a `workflow_dispatch` trigger
+so you can run it standalone for a sanity check.
+
+GitHub validates a reusable workflow's secret contract **before any job starts**.
+To stop a missing optional secret from aborting the whole pipeline at startup
+with no logs, every channel secret is declared `required: false`, and the job
+body has an explicit "check credentials" step that warns and skips (or fails
+loudly inside the job) when the secret is absent. This is the same pattern
+established for the apt repo in PR #7976.
+
+Set all secrets at: **repo Settings → Secrets and variables → Actions → New
+repository secret** (`https://github.com/elizaOS/eliza/settings/secrets/actions`).
+Org-level secrets work too if you want to share a credential across repos.
+
+`GITHUB_TOKEN` is provided automatically by Actions and is **not** something you
+configure.
+
+## Origin legend
+
+- **generate fresh** — create a new credential dedicated to CI (preferred for
+  signing keys and service principals so it can be revoked independently).
+- **re-enter from source** — copy an existing value out of a store/dashboard
+  (an issued certificate, an App Store Connect key, a registered Store app ID).
+
+## Every secret, by channel
+
+### Android — [release-secrets-android.md](./release-secrets-android.md)
+
+Workflow: `android-release.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Decoded to `/tmp/elizaos-upload.jks`, used to sign the AAB + APK | generate fresh (upload keystore) — base64 of the `.jks` |
+| `ANDROID_KEYSTORE_PASSWORD` | `ELIZAOS_KEYSTORE_PASSWORD` for gradle signing | re-enter from source (chosen at keystore creation) |
+| `ANDROID_KEY_ALIAS` | `ELIZAOS_KEY_ALIAS` for gradle signing | re-enter from source (chosen at keystore creation) |
+| `ANDROID_KEY_PASSWORD` | `ELIZAOS_KEY_PASSWORD` for gradle signing | re-enter from source (chosen at keystore creation) |
+| `PLAY_STORE_SERVICE_ACCOUNT_JSON` | Decoded for `fastlane supply` upload to Play Store; gates the `publish-play-store` job | generate fresh (Google Cloud service-account JSON), then base64 |
+
+### Apple — [release-secrets-apple.md](./release-secrets-apple.md)
+
+Workflow: `apple-store-release.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `APPLE_ID` | Apple account for upload / notarization | re-enter from source (Apple Developer account email) |
+| `APPLE_TEAM_ID` | Apple Developer Team ID | re-enter from source (membership details) |
+| `ITC_TEAM_ID` | App Store Connect (iTunes Connect) team ID | re-enter from source |
+| `APP_STORE_APP_ID` | TestFlight / App Store delivery target | re-enter from source (App Store Connect app) |
+| `MATCH_PASSWORD` | Decrypts the Fastlane Match cert repo | re-enter from source (the Match passphrase) |
+| `MATCH_GIT_URL` | Git URL of the Match cert repo | re-enter from source |
+| `MATCH_GIT_BASIC_AUTHORIZATION` | Basic-auth for the Match cert repo | generate fresh (base64 of `user:PAT`) |
+| `APPLE_APP_SPECIFIC_PASSWORD` | `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` for upload | generate fresh (appleid.apple.com app-specific password) |
+| `MAS_CSC_LINK` | `CSC_LINK` — Mac App Store app cert (`.p12`) | re-enter from source (issued cert), base64 |
+| `MAS_CSC_KEY_PASSWORD` | `CSC_KEY_PASSWORD` for the app cert | re-enter from source (`.p12` export password) |
+| `MAS_INSTALLER_CERT` | 3rd Party Mac Developer Installer cert (`.p12`) | re-enter from source (issued cert), base64 |
+| `MAS_INSTALLER_KEY_PASSWORD` | Password for the installer cert | re-enter from source (`.p12` export password) |
+| `APP_STORE_API_KEY_ID` | App Store Connect API key id (`xcrun altool --apiKey`) | re-enter from source |
+| `APP_STORE_API_ISSUER_ID` | App Store Connect API issuer id (`--apiIssuer`) | re-enter from source |
+| `APP_STORE_API_KEY_P8` | The `.p8` private key contents written to `AuthKey_<id>.p8` | generate fresh (App Store Connect API key, downloads once) |
+
+### Homebrew — [release-secrets-homebrew.md](./release-secrets-homebrew.md)
+
+Workflow: `update-homebrew.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `HOMEBREW_TAP_TOKEN` | `repository-dispatch` token to trigger `elizaOS/homebrew-tap`; gates the dispatch | generate fresh (GitHub PAT with repo scope on `elizaOS/homebrew-tap`) |
+
+### Snap — [release-secrets-snap.md](./release-secrets-snap.md)
+
+Workflow: `snap-publish.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `SNAPCRAFT_STORE_CREDENTIALS` | `snapcraft upload`; gates the Store upload (build still runs) | generate fresh (`snapcraft export-login`) |
+
+### Flathub — [release-secrets-flathub.md](./release-secrets-flathub.md)
+
+Workflow: `flatpak-publish.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `FLATHUB_TOKEN` | `GH_TOKEN` for the fork checkout + Flathub PR (falls back to `GITHUB_TOKEN`, which may lack push perms to the fork) | generate fresh (GitHub fine-grained PAT scoped to the Flathub fork) |
+
+### Windows — [release-secrets-windows.md](./release-secrets-windows.md)
+
+Workflow: `windows-store-release.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `WINDOWS_SIGN_CERT_BASE64` | Decoded to `signing.pfx`; signs the MSIX (shared with desktop Authenticode signing) | re-enter from source (code-signing cert), base64 of the `.pfx` |
+| `WINDOWS_SIGN_CERT_PASSWORD` | Password for the signing `.pfx` | re-enter from source (`.pfx` export password) |
+| `MS_TENANT_ID` | Azure AD tenant for the Partner Center token; gates the `submit-to-store` job | re-enter from source (Azure AD → Directory (tenant) ID) |
+| `MS_CLIENT_ID` | Azure AD app (service principal) client id | re-enter from source (Azure AD app registration) |
+| `MS_CLIENT_SECRET` | Azure AD app client secret | generate fresh (Azure AD → Certificates & secrets) |
+| `MS_APP_ID` | Microsoft Store app id (Partner Center) | re-enter from source (Partner Center Store ID) |
+
+### Debian apt repo — [admin-apt-repo-setup.md](./admin-apt-repo-setup.md)
+
+Workflow: `publish-apt-repo.yml`
+
+| Secret | Consumed by | Origin |
+| --- | --- | --- |
+| `DEBIAN_GPG_PRIVATE_KEY` | Armored GPG private key reprepro signs the `Release` file with | generate fresh (dedicated GPG key) |
+| `DEBIAN_GPG_KEY_ID` | 16-char hex key id passed to reprepro | re-enter from source (the generated key's id) |
+| `DEBIAN_GPG_PASSPHRASE` | Passphrase for the GPG key (optional) | re-enter from source (chosen at key creation; omit if none) |
+
+## OTA release host (optional)
+
+Not a store channel — an optional self-hosted CDN that `release-electrobun.yml`
+uploads OTA files to alongside GitHub Releases. If unconfigured, OTA is served
+from GitHub Releases (the default, fully functional path).
+
+| Item | Kind | Origin |
+| --- | --- | --- |
+| `RELEASE_UPLOAD_KEY` | secret | generate fresh (deploy SSH private key) |
+| `RELEASE_HOST_FINGERPRINT` | secret | re-enter from source (`ssh-keyscan -H <host>`) |
+| `RELEASE_HOST` | repo **variable** | re-enter from source (release hostname) |
+
+`WINDOWS_SIGN_TIMESTAMP_URL` (RFC 3161 timestamp server, e.g.
+`http://timestamp.digicert.com`) is read by `release-electrobun.yml` for the
+desktop Authenticode path; the MSIX build defaults it when unset.
+
+## Pre-release gate
+
+A channel is ready to publish only when every secret in its row block is set.
+The half-configured failure mode is the dangerous one: a build that succeeds but
+silently skips the store upload, or an unsigned artifact. The per-channel "check
+credentials" steps surface this as a warning in the run log — read them.
+
+Run each channel's `workflow_dispatch` once (see the channel playbook) before
+trusting it inside the orchestrated release.
+
+## Related
+
+- [admin-apt-repo-setup.md](./admin-apt-repo-setup.md) — the original playbook
+  this set mirrors (apt repo GPG signing).
+- [installers-release-plan.md](./installers-release-plan.md) — release artifact
+  requirements and validation gates.
+- [ci-cd-production-plan.md](./ci-cd-production-plan.md) — broader pipeline
+  status.

--- a/packages/os/docs/release-secrets-flathub.md
+++ b/packages/os/docs/release-secrets-flathub.md
@@ -1,0 +1,99 @@
+# Maintainer: Flathub credentials
+
+Playbook for the single configurable secret `flatpak-publish.yml` consumes.
+Same shape as the apt-repo playbook
+([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)): generate → set the repo
+secret → sanity-run → rotate/revoke.
+
+`flatpak-publish.yml` opens an update PR against the app's Flathub repo
+(`flathub/ai.elizaos.App`): it forks the repo, bumps the manifest `tag` +
+`sha256` to the new release tarball, and opens a PR. It runs `gh repo fork` /
+`gh pr create` as `GH_TOKEN`.
+
+## Prerequisite — initial Flathub listing (one-time, manual)
+
+Flathub requires a human-reviewed first submission before automated updates
+work. The workflow's first step checks `gh repo view flathub/ai.elizaos.App` and
+warns + skips everything if the app isn't listed yet.
+
+To get listed:
+
+1. Fork `https://github.com/flathub/flathub`.
+2. Add `ai.elizaos.App.yml` (source it from
+   `packages/app-core/packaging/flatpak/ai.elizaos.App.store.yml`).
+3. Open a PR to `flathub/flathub` — see
+   `https://docs.flathub.org/docs/for-app-authors/submission`.
+4. After approval the app lives at `https://flathub.org/apps/ai.elizaos.App` and
+   the per-app repo `flathub/ai.elizaos.App` exists.
+
+## Secret this workflow reads
+
+| Secret | Required? | Used as |
+| --- | --- | --- |
+| `FLATHUB_TOKEN` | Optional (falls back to `GITHUB_TOKEN`) | `GH_TOKEN` for the fork checkout + Flathub PR |
+
+`GITHUB_TOKEN` is auto-provided by Actions and is **not** configured. The
+workflow uses `${{ secrets.FLATHUB_TOKEN || secrets.GITHUB_TOKEN }}`: without a
+`FLATHUB_TOKEN`, it falls back to the auto token, which generally **cannot push
+to your Flathub fork** (the fork lives outside this repo). So in practice you
+need `FLATHUB_TOKEN` for the PR step to succeed.
+
+## Step 1 — Generate the token (generate fresh)
+
+A GitHub fine-grained PAT owned by the account/org that owns the Flathub fork:
+
+- `https://github.com/settings/tokens?type=beta` → Generate new token
+- Resource owner: the account/org that forked `flathub/ai.elizaos.App`
+- Repository access: the `ai.elizaos.App` fork repo
+- Permissions: **Contents: read and write**, **Pull requests: read and write**
+- copy the value → `FLATHUB_TOKEN`
+
+Use a machine/bot account that holds the fork so the token is independent of any
+maintainer.
+
+## Step 2 — Set the GitHub secret
+
+Add `FLATHUB_TOKEN` at
+`https://github.com/elizaOS/eliza/settings/secrets/actions`.
+
+## Step 3 — Sanity-trigger the workflow
+
+Only meaningful once the app is listed on Flathub (otherwise it warns + skips):
+
+```sh
+gh workflow run flatpak-publish.yml \
+  --repo elizaOS/eliza \
+  --field version=2.0.1 \
+  --field tag=v2.0.1
+gh run watch --repo elizaOS/eliza
+```
+
+A green run forks `flathub/ai.elizaos.App` (if needed), updates the manifest
+`tag` + `sha256` for the `v2.0.1` tarball, pushes a `update-to-2.0.1` branch,
+and opens a PR against the Flathub repo's `master`. Confirm by finding the new
+PR on `flathub/ai.elizaos.App`.
+
+Misconfiguration symptoms:
+
+- `::warning::App not yet listed on Flathub …` → do the initial submission
+  first (prerequisite above).
+- A `403` on `gh repo fork`/`git push`/`gh pr create` → `FLATHUB_TOKEN` missing
+  or lacking Contents/Pull-requests write on the fork (the `GITHUB_TOKEN`
+  fallback can't reach the external fork).
+
+## Rotating the token
+
+Generate a replacement fine-grained PAT (Step 1), update the secret, sanity-run.
+Then delete the old token at `https://github.com/settings/tokens`.
+
+## Revoking a compromised token
+
+Delete it at `https://github.com/settings/tokens` immediately. The scope is
+limited to the Flathub fork repo (with a fine-grained PAT), so the blast radius
+is that one repo. Issue a fresh token and update the secret.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `flatpak-publish.yml` — the workflow this configures.

--- a/packages/os/docs/release-secrets-homebrew.md
+++ b/packages/os/docs/release-secrets-homebrew.md
@@ -1,0 +1,88 @@
+# Maintainer: Homebrew tap credentials
+
+Playbook for the single secret `update-homebrew.yml` consumes. Same shape as
+the apt-repo playbook ([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)):
+generate → set the repo secret → sanity-run → rotate/revoke.
+
+`update-homebrew.yml` does not build anything. On a published release it fires a
+`repository-dispatch` event at the `elizaOS/homebrew-tap` repo (event type
+`update-homebrew`, payload `{ "version": "<x.y.z>" }`); the tap repo's own
+automation then updates its formula + cask.
+
+## Secret this workflow reads
+
+| Secret | Required? | Used as |
+| --- | --- | --- |
+| `HOMEBREW_TAP_TOKEN` | Optional (gates the dispatch) | `token` for the `repository-dispatch` action targeting `elizaOS/homebrew-tap` |
+
+The "Check credentials" step warns (`::warning::HOMEBREW_TAP_TOKEN not
+configured. Homebrew tap update skipped.`) and skips the dispatch when the
+token is empty, so an unconfigured repo doesn't abort the release — it just
+doesn't update the tap.
+
+## Step 1 — Generate the token (generate fresh)
+
+`repository-dispatch` needs write access to `elizaOS/homebrew-tap`. Create a
+GitHub Personal Access Token from an account that has push access to that repo.
+
+Classic PAT:
+
+- `https://github.com/settings/tokens` → Generate new token (classic)
+- scope: `repo`
+- copy the value → `HOMEBREW_TAP_TOKEN`
+
+Fine-grained PAT (preferred — least privilege):
+
+- `https://github.com/settings/tokens?type=beta` → Generate new token
+- Resource owner: `elizaOS`
+- Repository access: only `elizaOS/homebrew-tap`
+- Permissions: **Contents: read and write** (the tap automation needs write to
+  update the formula). The dispatch itself triggers on the repo; Contents
+  write covers it.
+- copy the value → `HOMEBREW_TAP_TOKEN`
+
+Prefer a machine/bot account so the token is independent of any one
+maintainer's identity.
+
+## Step 2 — Set the GitHub secret
+
+Add `HOMEBREW_TAP_TOKEN` at
+`https://github.com/elizaOS/eliza/settings/secrets/actions`.
+
+## Step 3 — Sanity-trigger the workflow
+
+```sh
+gh workflow run update-homebrew.yml \
+  --repo elizaOS/eliza \
+  --field version=2.0.0-beta.0
+gh run watch --repo elizaOS/eliza
+```
+
+A green run dispatches `update-homebrew` to `elizaOS/homebrew-tap`. Confirm it
+landed by checking the tap repo's Actions tab for a freshly-triggered run, then
+that the formula/cask version updated.
+
+Misconfiguration symptoms:
+
+- `::warning::HOMEBREW_TAP_TOKEN not configured … skipped` → secret empty.
+- A `403`/`404` from the dispatch step → the token lacks write access to
+  `elizaOS/homebrew-tap` (wrong account, wrong scope, or expired).
+
+## Rotating the token
+
+PATs can be set to expire. Before expiry: generate a replacement (Step 1),
+update the secret, run the sanity dispatch, then delete the old token at
+`https://github.com/settings/tokens`.
+
+## Revoking a compromised token
+
+Delete it at `https://github.com/settings/tokens` immediately — the dispatch
+stops working at once. Issue a fresh token and update the secret. Because the
+token only grants access to the tap repo (with a fine-grained PAT), the blast
+radius is limited to that repo.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `update-homebrew.yml` — the workflow this configures.

--- a/packages/os/docs/release-secrets-snap.md
+++ b/packages/os/docs/release-secrets-snap.md
@@ -1,0 +1,103 @@
+# Maintainer: Snap Store credentials
+
+Playbook for the single secret `snap-publish.yml` consumes. Same shape as the
+apt-repo playbook ([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)):
+generate → set the repo secret → sanity-run → rotate/revoke.
+
+`snap-publish.yml` always **builds** the snap (`snapcraft --destructive-mode`)
+and uploads it as a CI artifact. The Store upload (`snapcraft upload --release
+<channel>`) only runs when the credential is present, so an unconfigured repo
+still produces a `.snap` to inspect.
+
+## Prerequisite — register the snap name (one-time)
+
+Before the first publish, claim the snap name from a machine with snapcraft:
+
+```sh
+snapcraft login
+snapcraft register elizaos-app
+```
+
+The workflow's `snapcraft.yaml` lives at
+`packages/app-core/packaging/snap/snapcraft.yaml`; the registered name must
+match it.
+
+## Secret this workflow reads
+
+| Secret | Required? | Used as |
+| --- | --- | --- |
+| `SNAPCRAFT_STORE_CREDENTIALS` | Optional (gates the Store upload) | `SNAPCRAFT_STORE_CREDENTIALS` env consumed by `snapcraft upload` |
+
+The "Check Snap Store credentials" step warns (`::warning::SNAPCRAFT_STORE_CREDENTIALS
+not configured. Snap build will run but Store upload will be skipped.`) and
+skips the upload when empty.
+
+## Step 1 — Export the store credential (generate fresh)
+
+`snapcraft export-login` mints a CI token scoped to the upload ACLs. Run it on a
+machine where you're logged in to the Snap Store:
+
+```sh
+snapcraft export-login \
+  --snaps elizaos-app \
+  --acls package_upload,package_push,package_register \
+  --expires "2030-01-01T00:00:00" \
+  snap-store-credentials.txt
+cat snap-store-credentials.txt
+```
+
+The file contents (the exported login blob) → `SNAPCRAFT_STORE_CREDENTIALS`.
+
+Scope it to the `elizaos-app` snap and only the upload ACLs so the credential
+can't do more than publish this one snap. Set an expiry so a leaked token dies
+on its own.
+
+## Step 2 — Set the GitHub secret
+
+Add `SNAPCRAFT_STORE_CREDENTIALS` at
+`https://github.com/elizaOS/eliza/settings/secrets/actions`, then delete the
+local file:
+
+```sh
+shred -u snap-store-credentials.txt
+```
+
+## Step 3 — Sanity-trigger the workflow
+
+```sh
+gh workflow run snap-publish.yml \
+  --repo elizaOS/eliza \
+  --field version=2.0.1 \
+  --field tag=v2.0.1 \
+  --field channel=edge
+gh run watch --repo elizaOS/eliza
+```
+
+Use `channel=edge` for the sanity run so you don't push to `stable`. A green
+run builds the snap, uploads the CI artifact, and (with the credential set)
+runs `snapcraft upload elizaos-app_*.snap --release edge`.
+
+Misconfiguration symptoms:
+
+- `::warning::SNAPCRAFT_STORE_CREDENTIALS not configured …` → secret empty (the
+  `.snap` artifact still attaches; only the Store push is skipped).
+- An auth error from `snapcraft upload` → the credential expired or lacks the
+  `package_upload`/`package_push` ACLs, or was minted for a different snap name.
+
+## Rotating the credential
+
+Re-run `snapcraft export-login` with a new expiry (Step 1), update the secret,
+sanity-run on `edge`. The Snap Store can have multiple valid exported logins, so
+there's no hard cutover; just stop using the old one.
+
+## Revoking a compromised credential
+
+Revoke it from the Snap Store dashboard (`https://snapcraft.io/account` →
+your developer account → credentials) or by changing the account password,
+which invalidates exported logins. Then mint and set a fresh credential.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `snap-publish.yml` — the workflow this configures.

--- a/packages/os/docs/release-secrets-windows.md
+++ b/packages/os/docs/release-secrets-windows.md
@@ -1,0 +1,142 @@
+# Maintainer: Windows Store + signing credentials
+
+Playbook for the secrets `windows-store-release.yml` consumes. Same shape as
+the apt-repo playbook ([admin-apt-repo-setup.md](./admin-apt-repo-setup.md)):
+generate → set the repo secret → sanity-run → rotate/revoke.
+
+The workflow has two credential groups:
+
+1. **Authenticode signing** — signs the MSIX. Optional: when absent the MSIX is
+   built **unsigned** (with a warning). This is the *same* cert as the desktop
+   Authenticode signing used by `release-electrobun.yml`.
+2. **Partner Center submission** — submits the MSIX to the Microsoft Store via
+   the Azure AD service-principal flow. Optional: gates the `submit-to-store`
+   job (build still runs and attaches the MSIX to the GitHub Release).
+
+## Prerequisite — register the app in Partner Center (one-time)
+
+Submission needs a registered Store app:
+
+1. `https://partner.microsoft.com` → Windows & Xbox → Overview → New product →
+   App; reserve the name "elizaOS".
+2. Complete the store listing (description, screenshots, age ratings, privacy
+   policy URL).
+3. Note the **Store ID** (format `9XXXXXXXXXXXXXXX`) → `MS_APP_ID`.
+
+## Secrets this workflow reads
+
+| Secret | Required? | Used as |
+| --- | --- | --- |
+| `WINDOWS_SIGN_CERT_BASE64` | Optional (else unsigned MSIX) | decoded to `signing.pfx`, passed as `WINDOWS_SIGN_CERT_BASE64` to `build-msix.ps1` |
+| `WINDOWS_SIGN_CERT_PASSWORD` | with the cert | `.pfx` password |
+| `MS_TENANT_ID` | Optional (gates `submit-to-store`) | Azure AD tenant for the OAuth token |
+| `MS_CLIENT_ID` | with submission | service-principal client id |
+| `MS_CLIENT_SECRET` | with submission | service-principal client secret |
+| `MS_APP_ID` | with submission | Partner Center Store app id |
+
+The "Check signing credentials" step warns + builds unsigned when
+`WINDOWS_SIGN_CERT_BASE64` is empty; the "Check Partner Center credentials"
+step keys off `MS_TENANT_ID` and sets `can_submit=false` (skips the submit job)
+when empty.
+
+## Step 1 — Authenticode signing cert (re-enter from source)
+
+The signing cert is the same Authenticode code-signing certificate the desktop
+release uses. Export the issued cert (and its private key) as a password-
+protected `.pfx`, then base64 it:
+
+```sh
+base64 -w0 elizaos-codesign.pfx > elizaos-codesign.pfx.b64   # Linux
+# macOS: base64 -i elizaos-codesign.pfx -o elizaos-codesign.pfx.b64
+```
+
+- `WINDOWS_SIGN_CERT_BASE64` = contents of `elizaos-codesign.pfx.b64`
+- `WINDOWS_SIGN_CERT_PASSWORD` = the `.pfx` export password
+
+> `build-msix.ps1` also reads `WINDOWS_SIGN_TIMESTAMP_URL` (RFC 3161 timestamp
+> server) and defaults it to `http://timestamp.digicert.com` when unset. The
+> store workflow does not set it; the desktop workflow `release-electrobun.yml`
+> does. Configure `WINDOWS_SIGN_TIMESTAMP_URL` as a repo secret only if you need
+> a non-default timestamp authority for the desktop path.
+
+## Step 2 — Azure AD service principal (Partner Center submission)
+
+The submit job authenticates to the Partner Center API with a client-credentials
+grant, then links the app via `MS_APP_ID`.
+
+1. **Create the Azure AD app (re-enter ids / generate the secret):**
+   - `https://portal.azure.com` → Azure Active Directory → App registrations →
+     New registration. Name `elizaos-store-ci`, single tenant.
+   - **Application (client) ID** → `MS_CLIENT_ID`
+   - **Directory (tenant) ID** → `MS_TENANT_ID`
+   - Certificates & secrets → New client secret → copy the value →
+     `MS_CLIENT_SECRET` (**generate fresh**; visible once)
+2. **Link the Azure AD app to Partner Center:**
+   - Partner Center → Account settings → User management → Azure AD applications
+     → Add Azure AD application → select your app → assign role **Manager**
+     (needs submission create/commit permission).
+3. `MS_APP_ID` = the Store ID from the prerequisite.
+
+## Step 3 — Set the GitHub secrets
+
+Add the six secrets at
+`https://github.com/elizaOS/eliza/settings/secrets/actions`, then shred local
+cert files:
+
+```sh
+shred -u elizaos-codesign.pfx elizaos-codesign.pfx.b64
+```
+
+## Step 4 — Sanity-trigger the workflow
+
+Build-only first (no Store submission):
+
+```sh
+gh workflow run windows-store-release.yml \
+  --repo elizaOS/eliza \
+  --field version=2.0.0-beta.0 \
+  --field tag=v2.0.0-beta.0 \
+  --field submit_to_store=false
+gh run watch --repo elizaOS/eliza
+```
+
+A green build-only run downloads the Windows installer from the `v…` release,
+builds the MSIX (signed if the cert is set), and attaches it to the GitHub
+Release. Once that's confirmed, repeat with `submit_to_store=true` to exercise
+the Partner Center path.
+
+Misconfiguration symptoms:
+
+- `Write-Warning "WINDOWS_SIGN_CERT_BASE64 not set — MSIX will be built
+  unsigned"` → signing cert secret empty.
+- `Write-Warning "MS_TENANT_ID not set — … not submitted"` → Partner Center
+  secrets empty; the `submit-to-store` job is skipped.
+- A `401`/`403` from the token or `/applications/<id>` call → wrong
+  tenant/client/secret, or the Azure AD app isn't linked to Partner Center as
+  **Manager**, or `MS_APP_ID` is wrong.
+
+## Rotating credentials
+
+- **Client secret:** add a new client secret in Azure AD, update
+  `MS_CLIENT_SECRET`, verify a run, then delete the old secret. (Tenant/client
+  ids and `MS_APP_ID` don't change.)
+- **Signing cert:** when the cert nears expiry, issue a replacement, re-export
+  the `.pfx`, update `WINDOWS_SIGN_CERT_BASE64` + `WINDOWS_SIGN_CERT_PASSWORD`.
+
+## Revoking a compromised credential
+
+- **Client secret leaked:** delete it in Azure AD → App registrations →
+  Certificates & secrets (it stops working immediately); issue a new one and
+  update the secret. If the whole app registration is suspect, delete it and
+  re-create + re-link to Partner Center.
+- **Signing cert leaked:** revoke the certificate with the issuing CA and
+  reissue; update the two signing secrets.
+
+## Related
+
+- [release-secrets-checklist.md](./release-secrets-checklist.md) — every secret,
+  every channel.
+- `windows-store-release.yml` — the workflow this configures.
+- `release-electrobun.yml` — the desktop Authenticode path that shares
+  `WINDOWS_SIGN_CERT_BASE64` / `WINDOWS_SIGN_CERT_PASSWORD` /
+  `WINDOWS_SIGN_TIMESTAMP_URL`.


### PR DESCRIPTION
## What

Adds the missing maintainer documentation for the cross-platform release pipeline tracked in #7770. The publish workflows are already implemented; this fills the documentation gap with per-channel credential playbooks plus one consolidated checklist, all under `packages/os/docs/` mirroring the existing `admin-apt-repo-setup.md`.

New docs:

- `release-secrets-checklist.md` — consolidated index: every required secret per channel, the workflow that consumes it, and whether each value is **generated fresh** vs **re-entered from source**. Cross-links every per-channel playbook (including the existing apt-repo doc).
- `release-secrets-android.md` — upload keystore + Play Store service account.
- `release-secrets-apple.md` — iOS App Store (Fastlane Match) + Mac App Store certs + App Store Connect API key.
- `release-secrets-homebrew.md` — `elizaOS/homebrew-tap` dispatch token.
- `release-secrets-snap.md` — `snapcraft export-login` store credential.
- `release-secrets-flathub.md` — Flathub fork PAT (+ initial-listing prerequisite).
- `release-secrets-windows.md` — Authenticode signing cert + Partner Center (Azure AD service principal).

Each per-channel doc follows the apt-repo playbook shape: credential/cert generation → which repo secret → sanity `workflow_dispatch` run → rotation/revocation.

## Why

#7770 notes the pipeline is built but every channel needs documented secret setup before it can publish. The doable docs work was the missing maintainer playbooks + a single consolidated checklist; this delivers exactly that.

## Accuracy

Every secret name was verified against the actual workflow YAML — each documented secret matches a `secrets.<NAME>` reference in `apple-store-release.yml`, `android-release.yml`, `update-homebrew.yml`, `snap-publish.yml`, `flatpak-publish.yml`, or `windows-store-release.yml`. The reverse check confirmed no doc references a non-existent secret (the only ALL-CAPS tokens not matching a secret are the env-var names the workflows map secrets *to*: `ELIZAOS_KEY_*`, `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`, and `GH_TOKEN`).

## Verification

Docs-only change — no code, no typecheck surface. Validation run in the worktree:

- All 7 new files created under `packages/os/docs/`.
- All relative `./*.md` cross-links resolve to existing files (link checker: no broken links).
- All 30 configurable secret names cross-checked against workflow YAML: `ALL secret names verified against workflow YAML`.
- Referenced paths exist: `build-msix.ps1`, `snap/snapcraft.yaml`, `flatpak/ai.elizaos.App.store.yml`.

Scope kept to the new docs (reverted the install-touched `bun.lock` so the diff is docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)