### PR TITLE
test(local-inference): cover HF download proxy routing + cloud-api worker route (#8807)

### DIFF
--- a/packages/cloud-api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud-api/__tests__/hf-proxy-route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for GET /api/v1/hf-proxy/[...path].
+ *
+ * The route is the authenticated server-side HuggingFace download proxy used by
+ * cloud-linked devices: it requires a valid linked account, only forwards
+ * genuine `/resolve/` download paths, refuses to run without the cloud-side
+ * `HF_TOKEN`, and otherwise streams the upstream HuggingFace response straight
+ * through with the cloud token attached.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { Hono } from "hono";
+// Spread the real module: bun's `mock.module` replaces the registry entry
+// process-wide, so dropping the other real exports of workers-hono-auth would
+// break every later test file that imports from it.
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as loggerActual from "@/lib/utils/logger";
+
+const requireUserOrApiKeyWithOrg =
+  mock<(c: unknown) => Promise<{ id: string; organization_id: string }>>();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+// The route reads `c.req.param("*")`, which is only populated when the app is
+// mounted under the named-splat path the codegen emits in `_router.generated`.
+// Mount it the same way so the test exercises the real path resolution.
+const HF_PROXY_MOUNT = "/api/v1/hf-proxy/:*{.+}";
+
+let app: Hono;
+
+const realFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  const { default: hfProxyRoute } = (await import(
+    "../v1/hf-proxy/[...path]/route"
+  )) as { default: Parameters<Hono["route"]>[1] };
+  app = new Hono().route(HF_PROXY_MOUNT, hfProxyRoute);
+});
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: "user-1",
+    organization_id: "org-1",
+  });
+});
+
+afterEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  globalThis.fetch = realFetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+const RESOLVE_PATH = "elizaos/eliza-1/resolve/main/model.gguf";
+
+function makeRequest(
+  path: string,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(`https://api.example.test/api/v1/hf-proxy/${path}`, {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/v1/hf-proxy/[...path]", () => {
+  test("requires authentication", async () => {
+    // An unauthenticated request throws from the auth gate before any proxying.
+    requireUserOrApiKeyWithOrg.mockRejectedValueOnce(
+      Object.assign(new Error("Authentication required"), {
+        name: "AuthenticationError",
+      }),
+    );
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+    });
+
+    expect(res.status).toBe(401);
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a non-/resolve/ path with 400", async () => {
+    const res = await app.fetch(makeRequest("elizaos/eliza-1/tree/main"), {
+      HF_TOKEN: "hf-secret",
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Only HuggingFace resolve paths are proxied.");
+  });
+
+  test("returns 503 when HF_TOKEN is not configured", async () => {
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {});
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe(
+      "HuggingFace proxy is not configured on this deployment.",
+    );
+  });
+
+  test("proxies a valid /resolve/ request through to HuggingFace with the cloud token", async () => {
+    let capturedUrl: string | undefined;
+    let capturedAuth: string | null | undefined;
+    let capturedRange: string | null | undefined;
+
+    globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+      capturedUrl = String(input);
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get("authorization");
+      capturedRange = headers.get("range");
+      return new Response("GGUF-BYTES", {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "10",
+          "accept-ranges": "bytes",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const res = await app.fetch(
+      makeRequest(`${RESOLVE_PATH}?download=true`, { range: "bytes=0-9" }),
+      { HF_TOKEN: "hf-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    // Reconstructs the upstream HuggingFace URL 1:1, preserving the query.
+    expect(capturedUrl).toBe(
+      `https://huggingface.co/${RESOLVE_PATH}?download=true`,
+    );
+    // Attaches the cloud-side HF token, never a client-supplied one.
+    expect(capturedAuth).toBe("Bearer hf-secret");
+    // Forwards Range so resumable downloads work.
+    expect(capturedRange).toBe("bytes=0-9");
+
+    // Streams the upstream body and preserves download-relevant headers.
+    expect(await res.text()).toBe("GGUF-BYTES");
+    expect(res.headers.get("content-length")).toBe("10");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+  });
+});

--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _resetCloudSecretsForTesting } from "../elizacloud/cloud-secrets.js";
+import { resolveHfDownloadBase } from "./hf-proxy.js";
+
+/**
+ * `resolveHfDownloadBase` decides where local-inference bundle `resolve`
+ * traffic goes. Precedence (highest first):
+ *   1. `ELIZA_HF_BASE_URL` override — always wins, no auth.
+ *   2. Eliza Cloud HF proxy — when `ELIZAOS_CLOUD_API_KEY` is present.
+ *   3. Direct public huggingface.co — no auth.
+ */
+describe("resolveHfDownloadBase", () => {
+  const savedEnv = {
+    ELIZA_HF_BASE_URL: process.env.ELIZA_HF_BASE_URL,
+    ELIZAOS_CLOUD_API_KEY: process.env.ELIZAOS_CLOUD_API_KEY,
+    ELIZAOS_CLOUD_BASE_URL: process.env.ELIZAOS_CLOUD_BASE_URL,
+  };
+
+  beforeEach(() => {
+    _resetCloudSecretsForTesting();
+    delete process.env.ELIZA_HF_BASE_URL;
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  });
+
+  afterEach(() => {
+    _resetCloudSecretsForTesting();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("routes directly to the public HuggingFace host when nothing is configured", () => {
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://huggingface.co",
+      viaCloud: false,
+    });
+  });
+
+  it("routes through the Eliza Cloud HF proxy when a cloud API key is present", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "key-123";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.elizacloud.ai";
+
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://www.elizacloud.ai/api/v1/hf-proxy",
+      authHeader: { authorization: "Bearer key-123" },
+      viaCloud: true,
+    });
+  });
+
+  it("prefers the explicit ELIZA_HF_BASE_URL override over the cloud proxy", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "key-123";
+    process.env.ELIZA_HF_BASE_URL = "https://hf-mirror.example.com/";
+
+    // Override wins, trailing slash trimmed, no auth header, not via cloud.
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://hf-mirror.example.com",
+      viaCloud: false,
+    });
+  });
+
+  it("trims a trailing slash from the override base", () => {
+    process.env.ELIZA_HF_BASE_URL = "https://hf-mirror.example.com/sub/";
+
+    expect(resolveHfDownloadBase().base).toBe(
+      "https://hf-mirror.example.com/sub",
+    );
+  });
+
+  it("ignores a whitespace-only override and falls through to the next tier", () => {
+    process.env.ELIZA_HF_BASE_URL = "   ";
+
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://huggingface.co",
+      viaCloud: false,
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit-test coverage for the HuggingFace download proxy used by the local-model install flow (issue #8807, "Local-model install reliability"). No production code changes — tests only.

### `packages/shared` — `resolveHfDownloadBase()` precedence

New `src/local-inference/hf-proxy.test.ts` asserts the real precedence in `src/local-inference/hf-proxy.ts`:

1. **`ELIZA_HF_BASE_URL` override always wins** — returned base has its trailing slash trimmed, carries no auth header, and is not flagged `viaCloud`.
2. **Eliza Cloud HF proxy** when `ELIZAOS_CLOUD_API_KEY` is present — base is `<cloudApi>/hf-proxy` (resolved through `resolveCloudApiBaseUrl`, e.g. `https://www.elizacloud.ai/api/v1/hf-proxy`) with a `Bearer <key>` auth header and `viaCloud: true`.
3. **Direct public `https://huggingface.co`** when nothing is configured — no auth header.

Also covers: trailing-slash trimming on the override base, and a whitespace-only override being ignored (falls through to the next tier). The cloud-secrets sealed store is reset between cases via `_resetCloudSecretsForTesting()`.

### `packages/cloud-api` — `GET /api/v1/hf-proxy/[...path]` Worker route

New `__tests__/hf-proxy-route.test.ts` mirrors the existing route-test style (`__tests__/security-audit-route.test.ts`): spreads the real `@/lib/auth/workers-hono-auth` module and overrides only `requireUserOrApiKeyWithOrg`, silences the logger, and mounts the route app at the codegen mount path (`/api/v1/hf-proxy/:*{.+}`) so `c.req.param("*")` resolves the same way it does in `_router.generated.ts`. Cases:

- **Auth required** — when the auth gate rejects, the route returns 401.
- **Non-`/resolve/` path rejected** — 400 with `"Only HuggingFace resolve paths are proxied."`.
- **Missing `HF_TOKEN` binding** — 503 with `"HuggingFace proxy is not configured on this deployment."`.
- **Valid `/resolve/` request proxies through** — `globalThis.fetch` is stubbed; the test asserts the upstream URL is reconstructed 1:1 (`https://huggingface.co/<path>?download=true`), the cloud-side `Bearer hf-secret` token is attached, the client `Range` header is forwarded, and the streamed body + download headers (`content-length`, `accept-ranges`) pass through.

## Why

The HF proxy is the install/download path for local models; the routing precedence (override / cloud / direct) and the Worker route's auth + `/resolve/`-only + token-required guards were previously untested. These tests lock in that real behavior.

## Verification

```
# packages/shared
$ bun run --cwd packages/shared test -- hf-proxy
 Test Files  1 passed (1)
      Tests  5 passed (5)

# packages/cloud-api
$ bun run --cwd packages/cloud-api test __tests__/hf-proxy-route.test.ts
 4 pass
 0 fail
 13 expect() calls

# typecheck (filtered to touched files — both clean)
$ bun run --cwd packages/shared typecheck      # no hf-proxy errors
$ bun run --cwd packages/cloud-api typecheck   # no hf-proxy-route errors
```

Both new files lint clean under Biome.

Closes #8807 (partial — adds the requested test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)