### PR TITLE
fix(tui): re-export getTerminalViewFactory + TerminalViewMountOptions from the barrel

### DIFF
--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -229,7 +229,10 @@ export { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";
 // Terminal view registry (host mounts plugin-registered views by id)
 export {
   getTerminalView,
+  getTerminalViewFactory,
   hasTerminalView,
   listTerminalViewIds,
   registerTerminalView,
+  type TerminalViewFactory,
+  type TerminalViewMountOptions,
 } from "./view-registry.js";


### PR DESCRIPTION
While verifying #8918 (whose cloud-view scenario is already on develop, commit f393a45485), found that `getTerminalViewFactory`, `TerminalViewFactory`, and `TerminalViewMountOptions` are defined in `packages/tui/src/view-registry.ts` but not re-exported from the `@elizaos/tui` barrel — which causes 2 pre-existing `@elizaos/app` typecheck errors (the @elizaos/ui↔@elizaos/tui terminal-view renderer can't import them). This adds the three missing barrel re-exports. Tests-free, type-only surface; `packages/agent`/`packages/tui` typecheck clean after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)