### PR TITLE
fix(tui): re-export getTerminalViewFactory + TerminalViewMountOptions (fixes ui/app-control build)

### DIFF
--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -229,7 +229,9 @@ export { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";
 // Terminal view registry (host mounts plugin-registered views by id)
 export {
   getTerminalView,
+  getTerminalViewFactory,
   hasTerminalView,
   listTerminalViewIds,
   registerTerminalView,
 } from "./view-registry.js";
+export type { TerminalViewMountOptions } from "./view-registry.js";


### PR DESCRIPTION
## What
`@elizaos/ui`'s `src/spatial/tui/index.ts` imports `getTerminalViewFactory` and the `TerminalViewMountOptions` type from `@elizaos/tui`, but the tui package barrel (`packages/tui/src/index.ts`) doesn't re-export them — so the build fails:

```
packages/ui/src/spatial/tui/index.ts(11,3): error TS2724: '"@elizaos/tui"' has no exported member named 'getTerminalViewFactory'. Did you mean 'getTerminalView'?
packages/ui/src/spatial/tui/renderer.ts(17,8): error TS2305: Module '"@elizaos/tui"' has no exported member 'TerminalViewMountOptions'.
```

Both symbols **exist** in `packages/tui/src/view-registry.ts` (`getTerminalViewFactory()` at L91, `interface TerminalViewMountOptions` at L27) — the #8932 view-parity work added them + had `@elizaos/ui` consume them, but the barrel re-export was only updated for `getTerminalView`/`hasTerminalView`/`listTerminalViewIds`/`registerTerminalView`. The omission breaks `@elizaos/ui` and cascades to `@elizaos/plugin-app-control` and everything downstream of `ui`.

## Fix
Add `getTerminalViewFactory` to the value re-export and `TerminalViewMountOptions` as a `export type` — surfacing the two existing symbols at the package root. No behavior change.

## Verify
`bun run --cwd packages/tui build && bun run --cwd packages/ui build && bun run --cwd plugins/plugin-app-control build` — all three go green (were red on develop tip `09846a975e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
