### PR TITLE
feat(ui): add proactive-suggestions setting (off/subtle/chatty) (#8792)

### DIFF
--- a/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const appMock = vi.hoisted(() => ({
+  value: {} as {
+    walletEnabled: boolean;
+    browserEnabled: boolean;
+    computerUseEnabled: boolean;
+    setState: ReturnType<typeof vi.fn>;
+    t: (key: string, options?: { defaultValue?: string }) => string;
+  },
+}));
+
+const clientMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (sel: (value: typeof appMock.value) => unknown) =>
+    sel(appMock.value),
+  useAppSelectorShallow: (sel: (value: typeof appMock.value) => unknown) =>
+    sel(appMock.value),
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("./AdvancedToggle.hooks", () => ({
+  useAdvancedSettingsEnabled: () => false,
+}));
+
+vi.mock("./AdvancedToggle", () => ({ AdvancedToggle: () => <div /> }));
+
+import { CapabilitiesSection } from "./CapabilitiesSection";
+
+describe("CapabilitiesSection proactive-suggestions control", () => {
+  beforeEach(() => {
+    appMock.value = {
+      walletEnabled: false,
+      browserEnabled: false,
+      computerUseEnabled: false,
+      setState: vi.fn(),
+      t: (_key, options) => options?.defaultValue ?? _key,
+    };
+    clientMock.getConfig.mockReset();
+    clientMock.updateConfig.mockReset();
+    clientMock.fetch.mockReset();
+    // Auto-training config + status (loaded on mount).
+    clientMock.fetch.mockImplementation(async (path: string) => {
+      if (path === "/api/training/auto/config") {
+        return {
+          config: {
+            autoTrain: false,
+            triggerThreshold: 0,
+            triggerCooldownHours: 0,
+            backends: [],
+          },
+        };
+      }
+      if (path === "/api/training/auto/status") {
+        return { serviceRegistered: false };
+      }
+      return {};
+    });
+    clientMock.updateConfig.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reflects the persisted ELIZA_PROACTIVE_INTERACTIONS value", async () => {
+    clientMock.getConfig.mockResolvedValue({
+      env: { ELIZA_PROACTIVE_INTERACTIONS: "chatty" },
+    });
+
+    render(<CapabilitiesSection />);
+
+    const group = await screen.findByTestId("capability-proactive-suggestions");
+    await waitFor(() => {
+      expect(
+        within(group)
+          .getByRole("radio", { name: "Chatty" })
+          .getAttribute("aria-checked"),
+      ).toBe("true");
+    });
+    expect(
+      within(group)
+        .getByRole("radio", { name: "Subtle" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("defaults to subtle and persists the selected level via updateConfig", async () => {
+    clientMock.getConfig.mockResolvedValue({ env: {} });
+    const user = userEvent.setup();
+
+    render(<CapabilitiesSection />);
+
+    const group = await screen.findByTestId("capability-proactive-suggestions");
+    // No persisted value → the gate's `subtle` default is active.
+    await waitFor(() => {
+      expect(
+        within(group)
+          .getByRole("radio", { name: "Subtle" })
+          .getAttribute("aria-checked"),
+      ).toBe("true");
+    });
+
+    await user.click(within(group).getByRole("radio", { name: "Off" }));
+
+    await waitFor(() => {
+      expect(clientMock.updateConfig).toHaveBeenCalledWith({
+        env: { ELIZA_PROACTIVE_INTERACTIONS: "off" },
+      });
+    });
+    expect(
+      within(group)
+        .getByRole("radio", { name: "Off" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+});

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   GraduationCap,
   Loader2,
+  MessageCircle,
   MonitorCog,
   PlugZap,
   Wallet,
@@ -18,10 +19,50 @@ import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
 import {
   SettingsActionButton,
   SettingsInputRow,
+  SettingsSegmentedRow,
   SettingsSelectRow,
   SettingsSwitchRow,
 } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+
+/**
+ * Env key the proactive-interaction decider reads (`#8792`). Persisted into
+ * `config.env` (propagated to `process.env` at boot) and resolved at decider
+ * registration via `runtime.getSetting(ELIZA_PROACTIVE_INTERACTIONS)`.
+ */
+const PROACTIVE_INTERACTIONS_ENV_KEY = "ELIZA_PROACTIVE_INTERACTIONS";
+
+/** Matches `ProactiveChattiness` in the agent's proactive-interaction gate. */
+type ProactiveChattiness = "off" | "subtle" | "chatty";
+
+const PROACTIVE_CHATTINESS_VALUES: readonly ProactiveChattiness[] = [
+  "off",
+  "subtle",
+  "chatty",
+];
+
+/** Default when no value is persisted (mirrors the gate's `subtle` default). */
+const DEFAULT_PROACTIVE_CHATTINESS: ProactiveChattiness = "subtle";
+
+function readProactiveChattinessFromEnv(
+  env: unknown,
+): ProactiveChattiness | null {
+  if (!env || typeof env !== "object" || Array.isArray(env)) return null;
+  const record = env as Record<string, unknown>;
+  const vars =
+    record.vars &&
+    typeof record.vars === "object" &&
+    !Array.isArray(record.vars)
+      ? (record.vars as Record<string, unknown>)
+      : undefined;
+  const raw =
+    record[PROACTIVE_INTERACTIONS_ENV_KEY] ??
+    vars?.[PROACTIVE_INTERACTIONS_ENV_KEY];
+  const value = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  return (PROACTIVE_CHATTINESS_VALUES as readonly string[]).includes(value)
+    ? (value as ProactiveChattiness)
+    : null;
+}
 
 interface AutoTrainingConfig {
   autoTrain: boolean;
@@ -71,6 +112,9 @@ export function CapabilitiesSection() {
       t: s.t,
     }));
   const advancedEnabled = useAdvancedSettingsEnabled();
+  const [proactiveChattiness, setProactiveChattiness] =
+    useState<ProactiveChattiness>(DEFAULT_PROACTIVE_CHATTINESS);
+  const [proactiveSaving, setProactiveSaving] = useState(false);
   const [autoTrainingConfig, setAutoTrainingConfig] =
     useState<AutoTrainingConfig | null>(null);
   const [autoTrainingAvailable, setAutoTrainingAvailable] = useState<
@@ -120,6 +164,45 @@ export function CapabilitiesSection() {
   useEffect(() => {
     void refreshAutoTraining();
   }, [refreshAutoTraining]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const config = await client.getConfig();
+        const resolved = readProactiveChattinessFromEnv(config.env);
+        if (!cancelled && resolved) setProactiveChattiness(resolved);
+      } catch {
+        // Leave the default when config is unavailable.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleProactiveChattinessChange = useCallback(
+    async (next: string) => {
+      if (!(PROACTIVE_CHATTINESS_VALUES as readonly string[]).includes(next)) {
+        return;
+      }
+      const value = next as ProactiveChattiness;
+      const previous = proactiveChattiness;
+      if (value === previous) return;
+      setProactiveChattiness(value);
+      setProactiveSaving(true);
+      try {
+        await client.updateConfig({
+          env: { [PROACTIVE_INTERACTIONS_ENV_KEY]: value },
+        });
+      } catch {
+        setProactiveChattiness(previous);
+      } finally {
+        setProactiveSaving(false);
+      }
+    },
+    [proactiveChattiness],
+  );
 
   const handleAutoTrainingChange = useCallback(
     async (checked: boolean | "indeterminate") => {
@@ -365,6 +448,45 @@ export function CapabilitiesSection() {
           disabled={autoTrainingDisabled}
           checked={autoTrainingConfig?.autoTrain ?? false}
           onCheckedChange={(checked) => handleAutoTrainingChange(checked)}
+        />
+        <SettingsSegmentedRow
+          agentId="capability-proactive-suggestions"
+          icon={MessageCircle}
+          label={t("settings.sections.capabilities.proactiveName", {
+            defaultValue: "Proactive suggestions",
+          })}
+          agentLabel={t("settings.sections.capabilities.proactiveLabel", {
+            defaultValue: "Proactive suggestions",
+          })}
+          description={t("settings.sections.capabilities.proactiveHint", {
+            defaultValue:
+              "How often the agent offers a helpful suggestion when you switch views or run a shortcut.",
+          })}
+          group="capabilities"
+          testId="capability-proactive-suggestions"
+          value={proactiveChattiness}
+          onValueChange={(value) => void handleProactiveChattinessChange(value)}
+          disabled={proactiveSaving}
+          options={[
+            {
+              value: "off",
+              label: t("settings.sections.capabilities.proactiveOff", {
+                defaultValue: "Off",
+              }),
+            },
+            {
+              value: "subtle",
+              label: t("settings.sections.capabilities.proactiveSubtle", {
+                defaultValue: "Subtle",
+              }),
+            },
+            {
+              value: "chatty",
+              label: t("settings.sections.capabilities.proactiveChatty", {
+                defaultValue: "Chatty",
+              }),
+            },
+          ]}
         />
       </SettingsGroup>
 


### PR DESCRIPTION
## What

Adds a user-facing **Proactive suggestions** control (off / subtle / chatty) to the **Capabilities** settings section that drives `ELIZA_PROACTIVE_INTERACTIONS`.

Closes the open gap on #8792: the runtime/gate already consumes `ELIZA_PROACTIVE_INTERACTIONS` (the proactive-interaction decider reads it via `runtime.getSetting(PROACTIVE_CHATTINESS_SETTING_KEY)` and resolves the gate config at registration), but there was no UI to change it.

## Why

The proactive-interaction decider (`packages/agent/src/services/proactive-interaction-decider.ts` + `proactive-interaction-gate.ts`) governs when the agent proactively comments on view switches / shortcuts. Its verbosity is the `off` / `subtle` / `chatty` `ProactiveChattiness` enum, defaulting to `subtle`. Users had no way to turn it off or relax it without setting an env var by hand.

## How

- Uses the existing `SettingsSegmentedRow` primitive (`settings-agent-rows.tsx`) — the right control for a small, fixed, agent-addressable option set — so it matches the surrounding rows (and is editable from chat/voice via the agent surface, like the other settings rows).
- Reads the current level from `client.getConfig().env` and persists the selection optimistically via `client.updateConfig({ env: { ELIZA_PROACTIVE_INTERACTIONS: value } })`. This is the same `config.env` → `process.env` path already used for user-defined env vars (it is propagated at boot in `packages/agent/src/runtime/eliza.ts`, and `env` is an allowed config-write top key), so the decider resolves the value where it already looks. The setting takes effect on the next boot/reload, consistent with how the decider resolves its config at registration.
- Values mirror the gate's `ProactiveChattiness` union exactly; `subtle` is the fallback default when nothing is persisted.

## Test

Adds `CapabilitiesSection.test.tsx` (modeled on the sibling `ConnectorsSection.test.tsx`):
- reflects the persisted `ELIZA_PROACTIVE_INTERACTIONS` value (`chatty` → Chatty active),
- defaults to `subtle` when nothing is persisted, and persists the selected level via `updateConfig({ env: { ELIZA_PROACTIVE_INTERACTIONS: "off" } })`.

## Verification

```
$ bun run --cwd packages/ui test -- CapabilitiesSection.test
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ bun run --cwd packages/ui test -- settings
 Test Files  15 passed (15)
      Tests  195 passed (195)

$ biome check CapabilitiesSection.tsx CapabilitiesSection.test.tsx
 Checked 2 files. No fixes applied.  (clean)
```

`bun run --cwd packages/ui typecheck` is clean for the changed files. The only remaining typecheck errors are pre-existing and unrelated to this change — `packages/ui/src/spatial/tui/*` references `@elizaos/tui` exports (`getTerminalViewFactory`, `TerminalViewMountOptions`) that the package does not export; this reproduces on a clean `@elizaos/tui` build and is outside this PR's scope.

Scope: UI setting + its test only. The chat-message accept affordance and the e2e are separate items per #8792 and intentionally untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)