### PR TITLE
fix(views): strip springboard scrim + remove orange chat glow bars (#8796)

### DIFF
--- a/packages/ui/src/components/pages/ViewCatalog.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.tsx
@@ -1000,12 +1000,10 @@ export function ViewCatalog() {
 
   return (
     <ShellViewAgentSurface viewId="views">
-      {/* Frosted material over the unified app background: the chosen wallpaper
-          shows through (softly blurred) so the catalog reads as the same
-          surface as the home, while the scrim keeps text legible on any
-          background. */}
-      <div className="flex min-h-0 flex-1 flex-col bg-bg/55 backdrop-blur-2xl">
-        <div className="shrink-0 border-b border-border/40 px-5 pb-3 pt-5">
+      {/* Fully transparent over the unified app background — the catalog shows
+          the same wallpaper as the home screen with no scrim or extra layer. */}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="shrink-0 px-5 pb-3 pt-5">
           <div className="flex items-center justify-between gap-3">
             <h1 className="text-2xl font-semibold leading-tight text-txt">
               {t("viewmanager.title", { defaultValue: "Views" })}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3046,25 +3046,6 @@ export function ContinuousChatOverlay({
               aria-hidden="true"
               className="pointer-events-none absolute inset-x-0 top-0 z-0 h-20 bg-gradient-to-b from-white/[0.07] to-transparent"
             />
-            {/* Soft live-state glow at the base — bright warm while listening, a
-            dimmer warm while replying. Orange is the only accent (no blue).
-            Two FIXED-color blurred layers crossfaded by opacity ONLY (the old
-            single layer tweened backgroundColor, a per-frame paint on a blurred
-            element); opacity is compositor-cheap. */}
-            <motion.div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-28 blur-xl bg-[rgba(255,180,120,0.30)]"
-              initial={false}
-              animate={{ opacity: listening ? 1 : 0 }}
-              transition={{ duration: reduce ? 0 : 1.1, ease: "easeInOut" }}
-            />
-            <motion.div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-28 blur-xl bg-[rgba(255,140,80,0.18)]"
-              initial={false}
-              animate={{ opacity: responding ? 1 : 0 }}
-              transition={{ duration: reduce ? 0 : 1.1, ease: "easeInOut" }}
-            />
 
             {/* Sheet header — shown at the HALF detent and up (not just FULL).
               Left: Maximize (toggle edge-to-edge full-screen) + Clear (reset to


### PR DESCRIPTION
Rebased revival of prior #8796 work onto current `develop` (single clean commit).

## What
- **`ViewCatalog.tsx`** — drop the frosted `bg-bg/55 backdrop-blur-2xl` scrim (and its `border-b`) so the view catalog is fully transparent over the shared `AppBackground`, matching the home screen.
- **`ContinuousChatOverlay.tsx`** — remove the two orange live-state glow layers at the base of the chat overlay (the off-color orange bar visible on load / while waking). Aligns with the brand rule: orange is an accent only.

## Why
Part of #8796 (production-quality pass + all-views aesthetic audit gate). The scrim and glow bars were off-brand and double-painted over the unified background.

## Verification
- Net: `2 files changed, 4 insertions(+), 25 deletions(-)` — pure removals + comment update.
- Confirmed `listening` / `responding` / `reduce` remain used elsewhere in `ContinuousChatOverlay.tsx` (e.g. `glow={listening || responding}`), so removing the layers orphans no variables.
- Visual: recommend `bun run --cwd eliza/packages/app audit:app` (views + chat overlay) on merge-candidate; this is a removal-only style change.

Relates to #8796 (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)