### PR TITLE
test(task-coordinator): prove universal slash-command contract with a non-core plugin (#8790)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3750,6 +3750,7 @@
         "@elizaos/ui": "workspace:*",
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.0",
@@ -5299,6 +5300,7 @@
       "version": "2.0.3-beta.2",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-commands": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@elizaos/ui": "workspace:*",
         "@xterm/addon-fit": "^0.10.0",

--- a/packages/agent/src/api/commands-routes.noncore-plugin.test.ts
+++ b/packages/agent/src/api/commands-routes.noncore-plugin.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Non-core plugin command contract (#8790).
+ *
+ * Proves the universal slash-command contract end to end with a real,
+ * non-core, view-owning plugin (`@elizaos/plugin-task-coordinator`):
+ *
+ *   1. The plugin's `init()` registers a view-scoped slash command into the
+ *      per-runtime `@elizaos/plugin-commands` registry (the standard
+ *      command-registration API).
+ *   2. That command is served by `GET /api/commands` — but only while the
+ *      command's view (`orchestrator`) is the active surface (#8798).
+ *   3. The command dispatches to the plugin's own deterministic handler action
+ *      when the matching slash message arrives.
+ *
+ * This is the same register → catalog → dispatch path the built-in commands and
+ * the connector bridges use, exercised from a non-core contributor.
+ */
+
+import type { Action, Content, IAgentRuntime, Memory } from "@elizaos/core";
+import { initForRuntime } from "@elizaos/plugin-commands";
+import taskCoordinatorPlugin, {
+  ORCHESTRATOR_STATUS_COMMAND_ACTION,
+  ORCHESTRATOR_STATUS_COMMAND_KEY,
+  orchestratorStatusCommandAction,
+} from "@elizaos/plugin-task-coordinator";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { handleCommandsRoutes } from "./commands-routes.ts";
+
+const AGENT_ID = "task-coordinator-command-agent";
+const res = {} as never;
+
+interface ServedCommand {
+  key: string;
+  target: { kind: string; action?: string };
+  views?: string[];
+}
+
+interface ServedPayload {
+  commands: ServedCommand[];
+  activeViewId: string | null;
+  agentId: string | null;
+}
+
+/** Drive the real route handler and return the served catalog payload. */
+async function fetchCatalog(query: string): Promise<ServedPayload> {
+  const json = vi.fn();
+  const error = vi.fn();
+  const handled = await handleCommandsRoutes({
+    req: {} as never,
+    res,
+    method: "GET",
+    pathname: "/api/commands",
+    url: new URL(`http://localhost/api/commands${query}`),
+    json,
+    error,
+    runtime: { agentId: AGENT_ID } as never,
+  });
+  expect(handled).toBe(true);
+  expect(error).not.toHaveBeenCalled();
+  return json.mock.calls[0][1] as ServedPayload;
+}
+
+beforeAll(async () => {
+  // `@elizaos/plugin-commands` boots before app plugins and seeds the runtime's
+  // command store; mirror that ordering here, then run the plugin's init().
+  initForRuntime(AGENT_ID);
+  await taskCoordinatorPlugin.init?.({}, {
+    agentId: AGENT_ID,
+  } as unknown as IAgentRuntime);
+});
+
+describe("@elizaos/plugin-task-coordinator command contract", () => {
+  it("registers the handler action on the plugin surface", () => {
+    const action = taskCoordinatorPlugin.actions?.find(
+      (a) => a.name === ORCHESTRATOR_STATUS_COMMAND_ACTION,
+    );
+    expect(action).toBe(orchestratorStatusCommandAction);
+  });
+
+  it("serves the registered command from GET /api/commands when its view is active", async () => {
+    const payload = await fetchCatalog("?surface=gui&view=orchestrator");
+    expect(payload.agentId).toBe(AGENT_ID);
+    expect(payload.activeViewId).toBe("orchestrator");
+
+    const command = payload.commands.find(
+      (c) => c.key === ORCHESTRATOR_STATUS_COMMAND_KEY,
+    );
+    expect(command).toBeDefined();
+    expect(command?.views).toEqual(["orchestrator"]);
+    expect(command?.target).toMatchObject({
+      kind: "agent",
+      action: ORCHESTRATOR_STATUS_COMMAND_ACTION,
+    });
+  });
+
+  it("hides the view-scoped command when its view is not active (#8798)", async () => {
+    const payload = await fetchCatalog("?surface=gui");
+    const keys = new Set(payload.commands.map((c) => c.key));
+    expect(keys.has(ORCHESTRATOR_STATUS_COMMAND_KEY)).toBe(false);
+  });
+
+  it("dispatches the matching slash message to the plugin's handler", async () => {
+    const action: Action = orchestratorStatusCommandAction;
+    const runtime = { agentId: AGENT_ID } as unknown as IAgentRuntime;
+    const message = {
+      entityId: "user-1",
+      roomId: "room-1",
+      content: { text: "/orchestrator-status", source: "gui" },
+    } as unknown as Memory;
+
+    expect(await action.validate(runtime, message, undefined)).toBe(true);
+
+    const callback = vi.fn(async (_content: Content) => [] as Memory[]);
+    const result = await action.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback,
+    );
+    expect(result).toMatchObject({ success: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]?.[0]).toMatchObject({
+      text: "Orchestrator is online.",
+      source: "command",
+    });
+  });
+
+  it("does not intercept conversational text", async () => {
+    const action: Action = orchestratorStatusCommandAction;
+    const runtime = { agentId: AGENT_ID } as unknown as IAgentRuntime;
+    const message = {
+      entityId: "user-1",
+      roomId: "room-1",
+      content: { text: "what is the orchestrator status?", source: "gui" },
+    } as unknown as Memory;
+    expect(await action.validate(runtime, message, undefined)).toBe(false);
+  });
+});

--- a/packages/test/vitest/default.config.ts
+++ b/packages/test/vitest/default.config.ts
@@ -191,6 +191,7 @@ const workspacePluginSourceAliases = getWorkspacePluginAliases(repoRoot, [
   "plugin-phone",
   "plugin-signal",
   "plugin-streaming",
+  "plugin-task-coordinator",
   "plugin-whatsapp",
   "plugin-workflow",
   "plugin-x402",

--- a/plugins/plugin-task-coordinator/AGENTS.md
+++ b/plugins/plugin-task-coordinator/AGENTS.md
@@ -4,13 +4,21 @@ Coding-agent task coordinator and session control surface for elizaOS agents.
 
 ## Purpose / role
 
-This plugin adds a UI workbench for managing coding-agent task threads and PTY sessions. It registers view panels (standard, XR, and TUI variants) into the elizaOS app shell for both the task coordinator and the multi-agent orchestrator surfaces. It has no server-side runtime component (no actions, providers, services, or evaluators); all agent/task state is owned by `@elizaos/plugin-agent-orchestrator` — this plugin is the display and control layer only.
+This plugin adds a UI workbench for managing coding-agent task threads and PTY sessions. It registers view panels (standard, XR, and TUI variants) into the elizaOS app shell for both the task coordinator and the multi-agent orchestrator surfaces. All agent/task state is owned by `@elizaos/plugin-agent-orchestrator` — this plugin is the display and control layer only. Its sole server-side runtime contribution is a single view-scoped slash command for the orchestrator view (`/orchestrator-status`), registered through `@elizaos/plugin-commands`, plus its deterministic handler action (no providers, services, or evaluators).
 
 The plugin is opt-in: it must be listed in the agent's plugin configuration. Once loaded, it registers its views into the app shell and fills the slot registry entries (`CodingAgentControlChip`, `CodingAgentSettingsSection`, `CodingAgentTasksPanel`, `PtyConsoleBase`) that `@elizaos/ui` leaves empty without this plugin.
 
 ## Plugin surface
 
-No actions, providers, services, or evaluators are registered. The plugin surface is entirely views and slot-registry fills.
+The plugin surface is primarily views and slot-registry fills, plus one slash command + handler action (no providers, services, or evaluators).
+
+### Slash command (`src/orchestrator-command.ts`)
+
+| command | view scope | target | handler action |
+|---|---|---|---|
+| `/orchestrator-status` | `orchestrator` (#8798) | `agent` | `ORCHESTRATOR_STATUS_COMMAND` |
+
+The plugin's `init()` calls `registerOrchestratorCommands(runtime.agentId)`, which registers the command into the per-runtime `@elizaos/plugin-commands` registry. Being `views`-scoped, it appears in `GET /api/commands` only while the orchestrator view is the active surface; the registered `orchestratorStatusCommandAction` is its deterministic, slash-only handler. This proves a non-core, view-owning plugin can light up the universal slash-command surface end to end (#8790).
 
 ### Views registered (`src/index.ts`)
 
@@ -49,7 +57,8 @@ Registers two pages in the `developer` group via `registerAppShellPage` from `@e
 
 ```
 src/
-  index.ts                         Plugin definition — views + capabilities declared here
+  index.ts                         Plugin definition — views + capabilities, init() command registration, handler action
+  orchestrator-command.ts          /orchestrator-status slash command def + deterministic handler action (#8790)
   register.ts                      App-shell page registration (/orchestrator, /orchestrator/tui)
   register-slots.ts                Slot registry fills for ui empty-slot defaults
   register-terminal-view.tsx       Registers OrchestratorSpatialView in the @elizaos/tui terminal registry
@@ -145,7 +154,7 @@ These prefixes are used to build preference keys sent to the agent prefs API; th
 - **Two build steps.** The plugin has both a tsup JS build (`build:js`) and a Vite view-bundle build (`build:views`). The view bundle entry is `src/task-coordinator-view-bundle.ts` and outputs `dist/views/bundle.js`. Both must be built; `build` runs them in sequence.
 - **View bundle re-exports.** `task-coordinator-view-bundle.ts` re-exports all view components (`CodingAgentTasksPanel`, `TaskCoordinatorTuiView`, `OrchestratorWorkbench`, `OrchestratorTuiView`) plus the shared `interact` capability handler so the built bundle serves all `componentExport` names the view manifest declares.
 - **Slot registry is a side-effect import.** `register-slots.ts` must be imported by the host app to activate the slot fills. Without it, the UI renders empty slot defaults in place of the coding-agent components.
-- **No server runtime.** This plugin registers zero actions, providers, services, or evaluators. All task/session state lives in `@elizaos/plugin-agent-orchestrator`. API boundary helpers in `src/api/` are utilities for route handlers in app-core, not plugin-registered routes.
+- **Minimal server runtime.** This plugin registers no providers, services, or evaluators, and its only action is the `/orchestrator-status` slash-command handler (`src/orchestrator-command.ts`). All task/session state lives in `@elizaos/plugin-agent-orchestrator`. API boundary helpers in `src/api/` are utilities for route handlers in app-core, not plugin-registered routes.
 - **PTY console buffer cap.** `PtyConsoleBase` caps displayed output at 200,000 characters (`MAX_BUFFER_CHARS`). Older output is silently trimmed from the head.
 - **Live e2e test requires real Codex CLI.** `test:e2e:manual` (`test/coding-agent-codex-artifact.live.e2e.test.ts`) is skipped unless the `codex` binary is in PATH and `~/.codex/auth.json` exists.
 - **Spatial view.** `src/components/OrchestratorSpatialView.tsx` is authored once using the spatial vocabulary and renders in both GUI/XR and terminal (TUI) contexts via `register-terminal-view.tsx`. It is purely presentational (typed snapshot + action callback in, primitives out).

--- a/plugins/plugin-task-coordinator/CLAUDE.md
+++ b/plugins/plugin-task-coordinator/CLAUDE.md
@@ -4,13 +4,21 @@ Coding-agent task coordinator and session control surface for elizaOS agents.
 
 ## Purpose / role
 
-This plugin adds a UI workbench for managing coding-agent task threads and PTY sessions. It registers view panels (standard, XR, and TUI variants) into the elizaOS app shell for both the task coordinator and the multi-agent orchestrator surfaces. It has no server-side runtime component (no actions, providers, services, or evaluators); all agent/task state is owned by `@elizaos/plugin-agent-orchestrator` — this plugin is the display and control layer only.
+This plugin adds a UI workbench for managing coding-agent task threads and PTY sessions. It registers view panels (standard, XR, and TUI variants) into the elizaOS app shell for both the task coordinator and the multi-agent orchestrator surfaces. All agent/task state is owned by `@elizaos/plugin-agent-orchestrator` — this plugin is the display and control layer only. Its sole server-side runtime contribution is a single view-scoped slash command for the orchestrator view (`/orchestrator-status`), registered through `@elizaos/plugin-commands`, plus its deterministic handler action (no providers, services, or evaluators).
 
 The plugin is opt-in: it must be listed in the agent's plugin configuration. Once loaded, it registers its views into the app shell and fills the slot registry entries (`CodingAgentControlChip`, `CodingAgentSettingsSection`, `CodingAgentTasksPanel`, `PtyConsoleBase`) that `@elizaos/ui` leaves empty without this plugin.
 
 ## Plugin surface
 
-No actions, providers, services, or evaluators are registered. The plugin surface is entirely views and slot-registry fills.
+The plugin surface is primarily views and slot-registry fills, plus one slash command + handler action (no providers, services, or evaluators).
+
+### Slash command (`src/orchestrator-command.ts`)
+
+| command | view scope | target | handler action |
+|---|---|---|---|
+| `/orchestrator-status` | `orchestrator` (#8798) | `agent` | `ORCHESTRATOR_STATUS_COMMAND` |
+
+The plugin's `init()` calls `registerOrchestratorCommands(runtime.agentId)`, which registers the command into the per-runtime `@elizaos/plugin-commands` registry. Being `views`-scoped, it appears in `GET /api/commands` only while the orchestrator view is the active surface; the registered `orchestratorStatusCommandAction` is its deterministic, slash-only handler. This proves a non-core, view-owning plugin can light up the universal slash-command surface end to end (#8790).
 
 ### Views registered (`src/index.ts`)
 
@@ -49,7 +57,8 @@ Registers two pages in the `developer` group via `registerAppShellPage` from `@e
 
 ```
 src/
-  index.ts                         Plugin definition — views + capabilities declared here
+  index.ts                         Plugin definition — views + capabilities, init() command registration, handler action
+  orchestrator-command.ts          /orchestrator-status slash command def + deterministic handler action (#8790)
   register.ts                      App-shell page registration (/orchestrator, /orchestrator/tui)
   register-slots.ts                Slot registry fills for ui empty-slot defaults
   register-terminal-view.tsx       Registers OrchestratorSpatialView in the @elizaos/tui terminal registry
@@ -145,7 +154,7 @@ These prefixes are used to build preference keys sent to the agent prefs API; th
 - **Two build steps.** The plugin has both a tsup JS build (`build:js`) and a Vite view-bundle build (`build:views`). The view bundle entry is `src/task-coordinator-view-bundle.ts` and outputs `dist/views/bundle.js`. Both must be built; `build` runs them in sequence.
 - **View bundle re-exports.** `task-coordinator-view-bundle.ts` re-exports all view components (`CodingAgentTasksPanel`, `TaskCoordinatorTuiView`, `OrchestratorWorkbench`, `OrchestratorTuiView`) plus the shared `interact` capability handler so the built bundle serves all `componentExport` names the view manifest declares.
 - **Slot registry is a side-effect import.** `register-slots.ts` must be imported by the host app to activate the slot fills. Without it, the UI renders empty slot defaults in place of the coding-agent components.
-- **No server runtime.** This plugin registers zero actions, providers, services, or evaluators. All task/session state lives in `@elizaos/plugin-agent-orchestrator`. API boundary helpers in `src/api/` are utilities for route handlers in app-core, not plugin-registered routes.
+- **Minimal server runtime.** This plugin registers no providers, services, or evaluators, and its only action is the `/orchestrator-status` slash-command handler (`src/orchestrator-command.ts`). All task/session state lives in `@elizaos/plugin-agent-orchestrator`. API boundary helpers in `src/api/` are utilities for route handlers in app-core, not plugin-registered routes.
 - **PTY console buffer cap.** `PtyConsoleBase` caps displayed output at 200,000 characters (`MAX_BUFFER_CHARS`). Older output is silently trimmed from the head.
 - **Live e2e test requires real Codex CLI.** `test:e2e:manual` (`test/coding-agent-codex-artifact.live.e2e.test.ts`) is skipped unless the `codex` binary is in PATH and `~/.codex/auth.json` exists.
 - **Spatial view.** `src/components/OrchestratorSpatialView.tsx` is authored once using the spatial vocabulary and renders in both GUI/XR and terminal (TUI) contexts via `register-terminal-view.tsx`. It is purely presentational (typed snapshot + action callback in, primitives out).

--- a/plugins/plugin-task-coordinator/package.json
+++ b/plugins/plugin-task-coordinator/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-commands": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/ui": "workspace:*",
     "@xterm/addon-fit": "^0.10.0",

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -1,4 +1,8 @@
 import type { Plugin, ViewCapability } from "@elizaos/core";
+import {
+  orchestratorStatusCommandAction,
+  registerOrchestratorCommands,
+} from "./orchestrator-command";
 
 const ORCHESTRATOR_CAPABILITIES: ViewCapability[] = [
   { id: "orchestrator-status", description: "Get orchestrator status" },
@@ -183,6 +187,14 @@ const ORCHESTRATOR_CAPABILITIES: ViewCapability[] = [
 const taskCoordinatorPlugin: Plugin = {
   name: "@elizaos/plugin-task-coordinator",
   description: "Coding agent task coordinator and session control surface.",
+  // Contribute the orchestrator view's slash command into the universal command
+  // registry once the runtime is up. `@elizaos/plugin-commands` boots before app
+  // plugins, so its per-runtime store already exists here (#8790).
+  init: async (_config, runtime) => {
+    registerOrchestratorCommands(runtime.agentId);
+  },
+  // Deterministic handler for the registered slash command.
+  actions: [orchestratorStatusCommandAction],
   views: [
     // ONE declaration → GUI + XR + TUI, all drawn from the single
     // TaskCoordinatorView spatial source. `modalities` is a plain literal here
@@ -262,3 +274,10 @@ const taskCoordinatorPlugin: Plugin = {
 };
 
 export default taskCoordinatorPlugin;
+export {
+  ORCHESTRATOR_STATUS_COMMAND_ACTION,
+  ORCHESTRATOR_STATUS_COMMAND_KEY,
+  ORCHESTRATOR_VIEW_ID,
+  orchestratorStatusCommandAction,
+  registerOrchestratorCommands,
+} from "./orchestrator-command";

--- a/plugins/plugin-task-coordinator/src/orchestrator-command.ts
+++ b/plugins/plugin-task-coordinator/src/orchestrator-command.ts
@@ -1,0 +1,85 @@
+/**
+ * Universal slash-command contribution (#8790, #8798).
+ *
+ * The task-coordinator plugin owns the `orchestrator` view, so it contributes a
+ * view-scoped slash command for that view through the standard command system:
+ *
+ *   - `registerOrchestratorCommands(agentId)` registers a `CommandDefinition`
+ *     into the per-runtime registry of `@elizaos/plugin-commands`. The command
+ *     is `views`-scoped to `orchestrator`, so it appears in `GET /api/commands`
+ *     only while the orchestrator view is the active surface (#8798), and it is
+ *     `target: { kind: "agent" }` so every surface routes it to this plugin's
+ *     deterministic handler action.
+ *   - `orchestratorStatusCommandAction` is that handler: a slash-only `Action`
+ *     whose `validate()` matches `/orchestrator-status` and whose `handler()`
+ *     returns a deterministic status reply — no LLM improvisation.
+ *
+ * This is the same contract the built-in commands and the connector bridges use;
+ * registering it here proves a non-core, view-owning plugin can light up the
+ * universal command surface end to end.
+ */
+
+import type { Action, IAgentRuntime, Memory } from "@elizaos/core";
+import {
+  detectCommand,
+  hasCommand,
+  registerCommand,
+  useRuntime,
+} from "@elizaos/plugin-commands";
+
+/** The orchestrator view id this command is scoped to. */
+export const ORCHESTRATOR_VIEW_ID = "orchestrator";
+
+/** Canonical key + handler-action name for the orchestrator status command. */
+export const ORCHESTRATOR_STATUS_COMMAND_KEY = "orchestrator-status";
+export const ORCHESTRATOR_STATUS_COMMAND_ACTION = "ORCHESTRATOR_STATUS_COMMAND";
+
+/**
+ * Register the task-coordinator's view-scoped slash commands into the active
+ * per-runtime command registry. Call after `@elizaos/plugin-commands` has run
+ * `initForRuntime(agentId)` for this runtime (it boots before app plugins).
+ */
+export function registerOrchestratorCommands(agentId: string): void {
+  useRuntime(agentId);
+  registerCommand({
+    key: ORCHESTRATOR_STATUS_COMMAND_KEY,
+    nativeName: ORCHESTRATOR_STATUS_COMMAND_KEY,
+    description: "Show orchestrator status (in the orchestrator view)",
+    textAliases: ["/orchestrator-status"],
+    scope: "both",
+    category: "docks",
+    icon: "Layers",
+    surfaces: ["gui", "tui"],
+    views: [ORCHESTRATOR_VIEW_ID],
+    target: { kind: "agent", action: ORCHESTRATOR_STATUS_COMMAND_ACTION },
+    acceptsArgs: false,
+  });
+}
+
+/**
+ * Deterministic handler for `/orchestrator-status`. Slash-only `validate()`
+ * (never intercepts conversational text) and a fixed reply so the command
+ * behaves identically on every surface.
+ */
+export const orchestratorStatusCommandAction: Action = {
+  name: ORCHESTRATOR_STATUS_COMMAND_ACTION,
+  description: "Report the orchestrator surface status as a slash command.",
+  similes: ["/orchestrator-status"],
+  suppressEarlyReply: true,
+  suppressPostActionContinuation: true,
+  validate: async (runtime: IAgentRuntime, message: Memory) => {
+    const text = message.content.text ?? "";
+    if (!hasCommand(text)) return false;
+    useRuntime(runtime.agentId);
+    const detection = detectCommand(text);
+    return (
+      detection.isCommand &&
+      detection.command?.key === ORCHESTRATOR_STATUS_COMMAND_KEY
+    );
+  },
+  handler: async (_runtime, _message, _state, _options, callback) => {
+    const reply = "Orchestrator is online.";
+    if (callback) await callback({ text: reply, source: "command" });
+    return { success: true, text: reply };
+  },
+};

--- a/plugins/plugin-task-coordinator/vitest.config.ts
+++ b/plugins/plugin-task-coordinator/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "vitest/config";
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const toVitePath = (value: string): string => value.replaceAll("\\", "/");
 const pluginBrowserSrc = resolve(rootDir, "../plugin-browser/src");
+const pluginCommandsSrc = resolve(rootDir, "../plugin-commands/src");
 const pluginTrainingSrc = resolve(rootDir, "../plugin-training/src");
 const tuiSrc = resolve(rootDir, "../../packages/tui/src");
 const sharedSrc = resolve(rootDir, "../../packages/shared/src");
@@ -53,6 +54,17 @@ export default defineConfig({
             "../plugin-health/src/screen-time/mobile-signal-setup.ts",
           ),
         ),
+      },
+      {
+        // `src/index.ts` now contributes a slash command via
+        // `@elizaos/plugin-commands`. Resolve it to source (it ships no prebuilt
+        // dist when the suite runs standalone), mirroring the redirects above.
+        find: /^@elizaos\/plugin-commands$/,
+        replacement: toVitePath(resolve(pluginCommandsSrc, "index.ts")),
+      },
+      {
+        find: /^@elizaos\/plugin-commands\/(.+)$/,
+        replacement: `${toVitePath(pluginCommandsSrc)}/$1`,
       },
       {
         find: /^@elizaos\/plugin-browser$/,


### PR DESCRIPTION
## What

Proves the universal slash-command / connector-command contract (#8790) **end to end from a real, non-core, view-owning plugin** — and adds a regression test. Previously the contract was only exercised by core commands and an inline test fixture; nothing demonstrated that a non-core plugin can register a command that surfaces in `GET /api/commands` and dispatches to its own handler.

`@elizaos/plugin-task-coordinator` (which owns the `orchestrator` view) now contributes a single **view-scoped** slash command for that view:

- **`plugins/plugin-task-coordinator/src/orchestrator-command.ts`** — registers `/orchestrator-status` into the per-runtime `@elizaos/plugin-commands` registry via the standard `registerCommand` API, scoped to the `orchestrator` view (#8798), with `target: { kind: "agent", action: "ORCHESTRATOR_STATUS_COMMAND" }`; plus a slash-only, deterministic handler `Action` (no LLM improvisation).
- **`plugins/plugin-task-coordinator/src/index.ts`** — the plugin's `init()` now calls `registerOrchestratorCommands(runtime.agentId)` and the handler action is added to the plugin's `actions`. (`@elizaos/plugin-commands` boots before app plugins, so its per-runtime store already exists.)

## Why

This is the same register → catalog → dispatch path the built-in commands and the Discord/Telegram connector bridges use, but driven by a non-core contributor — closing the gap the issue calls out.

## Test

**`packages/agent/src/api/commands-routes.noncore-plugin.test.ts`** drives the real `handleCommandsRoutes` handler and the registered action, asserting that the non-core plugin's command:
1. is served by `GET /api/commands` **only while its view (`orchestrator`) is the active surface**,
2. is **hidden when the view is not active** (#8798),
3. **dispatches the matching slash message to the plugin's handler** (returns the deterministic reply and fires the callback),
4. does **not** intercept conversational text.

## Supporting wiring (minimal)

- `@elizaos/plugin-commands` added as a `workspace:*` dependency of `plugin-task-coordinator`.
- `plugin-task-coordinator` added to the shared vitest source-alias list (`packages/test/vitest/default.config.ts`) so the agent suite resolves it to source.
- `@elizaos/plugin-commands` aliased to source in the plugin's own `vitest.config.ts` (its `index.ts` now pulls in that runtime import), matching the existing per-plugin source-alias pattern.
- Plugin `CLAUDE.md`/`AGENTS.md` updated to describe the new minimal command surface.

## Verification

```
$ bun run --cwd packages/agent test -- \
    src/api/commands-routes.noncore-plugin.test.ts \
    src/api/commands-routes.test.ts \
    src/api/commands-routes.real-server.test.ts
 Test Files  3 passed (3)
      Tests  26 passed (26)

$ bun run --cwd plugins/plugin-task-coordinator test
 Test Files  15 passed (15)
      Tests  156 passed (156)
```

`tsgo` typecheck of the touched packages reports no new errors from the added code (the only `plugin-task-coordinator` tsgo errors are the pre-existing `modalities` view-declaration ones emitted with `--noCheck`). Biome clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)