### PR TITLE
feat(vision,computeruse): unify full-screen OCR onto the coord seam + auto-register at boot (#9105 M1)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/ocr-adapter-coord-seam.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/ocr-adapter-coord-seam.test.ts
@@ -1,0 +1,150 @@
+/**
+ * scene-builder OCR adapter — coord seam preference + line-only fallback.
+ *
+ * Regression coverage for the unified OCR seam (issue #9105 / M1): the
+ * scene-builder must consume the coord-aware `CoordOcrProvider` when one is
+ * registered (e.g. the plugin-vision bridge), map its blocks to SceneOcrBoxes
+ * in display-absolute coords, and fall back to the line-only `OcrProvider`
+ * registry only when no coord provider is present.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetOcrProvidersForTests,
+  type CoordOcrProvider,
+  type OcrProvider,
+  registerCoordOcrProvider,
+  registerOcrProvider,
+} from "../mobile/ocr-provider.js";
+import {
+  makeOcrIdState,
+  runOcrOnPng,
+  runOcrOnRegions,
+} from "../scene/ocr-adapter.js";
+
+function fakeCoordProvider(name = "fake-coord"): CoordOcrProvider {
+  return {
+    name,
+    // Echoes sourceX/sourceY into the returned block bbox so callers can prove
+    // the offset is threaded through (matches the real adapter's shift).
+    async describe(input) {
+      return {
+        blocks: [
+          {
+            text: "Save",
+            bbox: {
+              x: input.sourceX + 10,
+              y: input.sourceY + 20,
+              width: 40,
+              height: 16,
+            },
+            words: [],
+            semantic_position: "upper-left",
+          },
+          {
+            text: "Cancel",
+            bbox: {
+              x: input.sourceX + 60,
+              y: input.sourceY + 20,
+              width: 50,
+              height: 16,
+            },
+            words: [],
+            semantic_position: "upper-center",
+          },
+        ],
+      };
+    },
+  };
+}
+
+function fakeLineProvider(name = "fake-line"): OcrProvider {
+  return {
+    name,
+    priority: 1,
+    available: () => true,
+    async recognize() {
+      return {
+        lines: [
+          {
+            text: "LineOnly",
+            boundingBox: { x: 1, y: 2, width: 3, height: 4 },
+            confidence: 0.5,
+          },
+        ],
+        fullText: "LineOnly",
+        elapsedMs: 0,
+        providerName: name,
+        languagesUsed: [],
+      };
+    },
+  };
+}
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+describe("ocr-adapter coord seam", () => {
+  beforeEach(() => {
+    _resetOcrProvidersForTests();
+    registerCoordOcrProvider(null);
+  });
+  afterEach(() => {
+    _resetOcrProvidersForTests();
+    registerCoordOcrProvider(null);
+  });
+
+  it("maps CoordOcrProvider blocks to SceneOcrBoxes (full frame)", async () => {
+    registerCoordOcrProvider(fakeCoordProvider());
+    const boxes = await runOcrOnPng(PNG, 0, makeOcrIdState());
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0]).toMatchObject({
+      text: "Save",
+      bbox: [10, 20, 40, 16],
+      conf: 1,
+      displayId: 0,
+    });
+    expect(boxes[0].id).toBe("t0-1");
+    expect(boxes[1]).toMatchObject({ text: "Cancel", bbox: [60, 20, 50, 16] });
+    expect(boxes[1].id).toBe("t0-2");
+  });
+
+  it("prefers the coord seam over a registered line-only provider", async () => {
+    registerOcrProvider(fakeLineProvider());
+    registerCoordOcrProvider(fakeCoordProvider());
+    const boxes = await runOcrOnPng(PNG, 1, makeOcrIdState());
+    // Coord provider wins → "Save"/"Cancel", not "LineOnly".
+    expect(boxes.map((b) => b.text)).toEqual(["Save", "Cancel"]);
+    expect(boxes.every((b) => b.displayId === 1)).toBe(true);
+  });
+
+  it("falls back to the line-only registry when no coord provider", async () => {
+    registerOcrProvider(fakeLineProvider());
+    const boxes = await runOcrOnPng(PNG, 2, makeOcrIdState());
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0]).toMatchObject({
+      text: "LineOnly",
+      bbox: [1, 2, 3, 4],
+      conf: 0.5,
+      displayId: 2,
+    });
+  });
+
+  it("returns empty when nothing is registered", async () => {
+    const boxes = await runOcrOnPng(PNG, 0, makeOcrIdState());
+    expect(boxes).toEqual([]);
+  });
+
+  it("threads the crop offset through the coord seam for dirty regions", async () => {
+    registerCoordOcrProvider(fakeCoordProvider());
+    const boxes = await runOcrOnRegions(
+      [{ png: PNG, bbox: [100, 200, 80, 40] }],
+      0,
+      makeOcrIdState(),
+    );
+    // The provider echoes sourceX/sourceY (100/200) into the block bbox; the
+    // returned coords must already be display-absolute (no double-shift).
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].bbox).toEqual([110, 220, 40, 16]);
+    expect(boxes[1].bbox).toEqual([160, 220, 50, 16]);
+  });
+});

--- a/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
+++ b/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
@@ -2,31 +2,28 @@
  * OCR adapter for the WS6 scene-builder.
  *
  * The scene-builder needs text-from-image extraction on full frames and
- * (much more often) on cropped dirty blocks. There are three real sources
- * for OCR in this monorepo today:
+ * (much more often) on cropped dirty blocks. There are two registry seams it
+ * can draw from, in priority order:
  *
- *   1. `@elizaos/plugin-vision`'s `OCRService` — canonical RapidOCR
- *      (PP-OCRv5) + Apple-Vision + Tesseract chain. **Owned by WS4.** This is
- *      the one we want to use whenever it's loaded.
- *   2. The on-device iOS Apple-Vision provider — `createIosVisionOcrProvider`
- *      in `mobile/ocr-provider.ts` (WS9). Plugged into the same OcrProvider
- *      registry.
- *   3. An empty provider that returns `[]` — used in unit tests and when no
- *      provider has been registered.
+ *   1. The coord-aware `CoordOcrProvider` (`mobile/ocr-provider.ts`,
+ *      `registerCoordOcrProvider` / `getCoordOcrProvider`). This is the
+ *      canonical seam: `@elizaos/plugin-vision` registers a bridge to its
+ *      hierarchical OCR (docTR / Apple Vision) at boot, returning blocks with
+ *      bbox + words + semantic position in display-absolute coords. Preferred
+ *      whenever a provider is registered.
+ *   2. The line-only `OcrProvider` registry (`listOcrProviders()`), used by
+ *      the on-device iOS Apple-Vision provider and unit-test fakes. Fallback
+ *      when no coord provider is registered.
  *
  * **Integration choice (justified):**
  *
- * plugin-computeruse cannot take a hard `@elizaos/plugin-vision` dependency
- * — that creates a cycle (vision -> capture -> computeruse) and forces every
- * computeruse consumer to install onnxruntime-node, Sharp, and YOLO/Florence2
- * weights even when they only want desktop control.
- *
- * Instead, we re-use the existing `OcrProvider` registry that `mobile/
- * ocr-provider.ts` already publishes. A consumer (e.g. plugin-vision itself,
- * or an integrator) can call `registerOcrProvider(buildVisionOcrAdapter(
- * visionService))` at startup to wire RapidOCR in. plugin-computeruse stays
- * dep-free and the chain just degrades to "no OCR" when nothing is
- * registered. The scene-builder logs that condition once.
+ * plugin-computeruse cannot take a hard `@elizaos/plugin-vision` dependency —
+ * that creates a cycle (vision -> capture -> computeruse) and forces every
+ * computeruse consumer to install the vision OCR stack even when they only
+ * want desktop control. Instead, computeruse *publishes* both registries and
+ * a consumer (plugin-vision, or an integrator) registers a provider at
+ * startup. The chain degrades to "no OCR" when nothing is registered; the
+ * scene-builder logs that condition once.
  *
  * This module exposes:
  *   - `runOcrOnPng(png, displayId, options)` — the scene-builder calls this.
@@ -36,8 +33,16 @@
  *     module doesn't have to take a `@elizaos/core` dep itself.
  */
 
-import type { OcrLine, OcrProvider } from "../mobile/ocr-provider.js";
-import { listOcrProviders } from "../mobile/ocr-provider.js";
+import type {
+  CoordOcrBlock,
+  CoordOcrProvider,
+  OcrLine,
+  OcrProvider,
+} from "../mobile/ocr-provider.js";
+import {
+  getCoordOcrProvider,
+  listOcrProviders,
+} from "../mobile/ocr-provider.js";
 import type { SceneOcrBox } from "./scene-types.js";
 
 let logFn: (message: string) => void = () => {};
@@ -70,24 +75,49 @@ function pickProvider(): OcrProvider | null {
 
 let warnedNoProvider = false;
 
+function warnNoProviderOnce(): void {
+  if (!warnedNoProvider) {
+    warnedNoProvider = true;
+    logFn(
+      "[scene-builder] no OCR provider registered — scene.ocr will be empty until a CoordOcrProvider is registered (registerCoordOcrProvider, e.g. by plugin-vision) or an OcrProvider via registerOcrProvider().",
+    );
+  }
+}
+
 /**
- * Run OCR on a whole PNG buffer. Returns boxes tagged with `displayId` and
- * stable `t<displayId>-<seq>` ids drawn from `idState`. Empty array if no
- * provider is registered.
+ * Run OCR on a whole PNG buffer. Prefers the coord-aware provider; falls back
+ * to the line-only registry. Returns boxes tagged with `displayId` and stable
+ * `t<displayId>-<seq>` ids drawn from `idState`. Empty array if no provider is
+ * registered.
  */
 export async function runOcrOnPng(
   png: Buffer,
   displayId: number,
   idState: OcrAdapterIdState,
 ): Promise<SceneOcrBox[]> {
+  const coord = getCoordOcrProvider();
+  if (coord) {
+    try {
+      const result = await coord.describe({
+        displayId: String(displayId),
+        sourceX: 0,
+        sourceY: 0,
+        pngBytes: new Uint8Array(png.buffer, png.byteOffset, png.byteLength),
+      });
+      return result.blocks.map((block) =>
+        coordBlockToSceneBox(block, displayId, idState),
+      );
+    } catch (err) {
+      logFn(
+        `[scene-builder] CoordOcrProvider '${coord.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
+  }
+
   const provider = pickProvider();
   if (!provider) {
-    if (!warnedNoProvider) {
-      warnedNoProvider = true;
-      logFn(
-        "[scene-builder] no OCR provider registered — scene.ocr will be empty until one is registered via registerOcrProvider().",
-      );
-    }
+    warnNoProviderOnce();
     return [];
   }
   try {
@@ -117,6 +147,37 @@ export async function runOcrOnRegions(
   displayId: number,
   idState: OcrAdapterIdState,
 ): Promise<SceneOcrBox[]> {
+  const coord = getCoordOcrProvider();
+  if (coord) {
+    const out: SceneOcrBox[] = [];
+    for (const crop of crops) {
+      try {
+        // The coord provider shifts block bboxes by sourceX/sourceY, so the
+        // returned coordinates are already in display-local source space.
+        const result = await coord.describe({
+          displayId: String(displayId),
+          sourceX: crop.bbox[0] ?? 0,
+          sourceY: crop.bbox[1] ?? 0,
+          pngBytes: new Uint8Array(
+            crop.png.buffer,
+            crop.png.byteOffset,
+            crop.png.byteLength,
+          ),
+        });
+        for (const block of result.blocks) {
+          out.push(coordBlockToSceneBox(block, displayId, idState));
+        }
+      } catch (err) {
+        logFn(
+          `[scene-builder] CoordOcr region failed at ${crop.bbox.join(",")}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    return out;
+  }
+
   const provider = pickProvider();
   if (!provider) return [];
   const out: SceneOcrBox[] = [];
@@ -156,6 +217,25 @@ export async function runOcrOnRegions(
   return out;
 }
 
+/**
+ * Map a coord-aware OCR block to a SceneOcrBox. The coord seam does not carry
+ * a per-block confidence, so we default to 1 (present). The block bbox is
+ * already in display-absolute source coordinates.
+ */
+function coordBlockToSceneBox(
+  block: CoordOcrBlock,
+  displayId: number,
+  idState: OcrAdapterIdState,
+): SceneOcrBox {
+  return {
+    id: nextOcrId(idState, displayId),
+    text: block.text,
+    bbox: [block.bbox.x, block.bbox.y, block.bbox.width, block.bbox.height],
+    conf: 1,
+    displayId,
+  };
+}
+
 function toSceneBox(
   line: OcrLine,
   displayId: number,
@@ -174,3 +254,6 @@ function toSceneBox(
     displayId,
   };
 }
+
+// Re-export so the optional coord provider type is reachable for consumers.
+export type { CoordOcrProvider };

--- a/plugins/plugin-vision/build.ts
+++ b/plugins/plugin-vision/build.ts
@@ -32,8 +32,15 @@ async function build() {
   // Clean dist directory
   await $`rm -rf dist`;
 
+  // Externalize plugin-computeruse even though it is NOT a package.json
+  // dependency: plugin-vision dynamically imports its OCR seam
+  // (`@elizaos/plugin-computeruse/mobile/ocr-provider`) at boot via a
+  // best-effort import. It MUST stay external so the registry singleton is the
+  // one runtime instance computeruse reads — bundling a copy would split the
+  // registry and the registration would be invisible to computeruse.
+  const OPTIONAL_PEERS = ["@elizaos/plugin-computeruse"] as const;
   const external = await externalsFromPackageJson("./package.json", {
-    extra: NODE_BUILTINS,
+    extra: [...NODE_BUILTINS, ...OPTIONAL_PEERS],
   });
 
   // Build main package

--- a/plugins/plugin-vision/src/computeruse-ocr-bridge.test.ts
+++ b/plugins/plugin-vision/src/computeruse-ocr-bridge.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the plugin-vision -> plugin-computeruse OCR bridge (M1).
+ *
+ * Verifies the bridge delegates to whatever vision OcrWithCoordsService is
+ * registered, degrades to empty blocks when none is, and that
+ * wireComputerUseOcrBridge registers a correctly-named bridge into a fake
+ * computeruse register function — all without a real plugin-computeruse.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildVisionCoordOcrBridge,
+  type CoordOcrProviderLike,
+  VISION_COORD_OCR_BRIDGE_NAME,
+  wireComputerUseOcrBridge,
+} from "./computeruse-ocr-bridge.js";
+import type {
+  OcrWithCoordsResult,
+  OcrWithCoordsService,
+} from "./ocr-with-coords.js";
+
+function fakeService(): OcrWithCoordsService {
+  return {
+    name: "fake-vision-ocr",
+    async describe(input): Promise<OcrWithCoordsResult> {
+      return {
+        blocks: [
+          {
+            text: "Hello",
+            bbox: {
+              x: input.sourceX + 5,
+              y: input.sourceY + 6,
+              width: 30,
+              height: 12,
+            },
+            words: [],
+            semantic_position: "upper-left",
+          },
+        ],
+      };
+    },
+  };
+}
+
+const INPUT = {
+  displayId: "0",
+  sourceX: 100,
+  sourceY: 200,
+  pngBytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+};
+
+describe("computeruse-ocr-bridge", () => {
+  it("delegates describe() to the resolved vision service", async () => {
+    const bridge = buildVisionCoordOcrBridge(() => fakeService());
+    expect(bridge.name).toBe(VISION_COORD_OCR_BRIDGE_NAME);
+    const result = await bridge.describe(INPUT);
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      text: "Hello",
+      bbox: { x: 105, y: 206, width: 30, height: 12 },
+    });
+  });
+
+  it("returns empty blocks (never throws) when no service is registered", async () => {
+    const bridge = buildVisionCoordOcrBridge(() => null);
+    await expect(bridge.describe(INPUT)).resolves.toEqual({ blocks: [] });
+  });
+
+  it("resolves the service lazily per call (late registration is picked up)", async () => {
+    let svc: OcrWithCoordsService | null = null;
+    const bridge = buildVisionCoordOcrBridge(() => svc);
+    expect((await bridge.describe(INPUT)).blocks).toEqual([]);
+    svc = fakeService();
+    expect((await bridge.describe(INPUT)).blocks).toHaveLength(1);
+  });
+
+  it("wireComputerUseOcrBridge registers a named bridge via the injected register fn", () => {
+    let registered: CoordOcrProviderLike | null = null;
+    const register = vi.fn((p: CoordOcrProviderLike | null) => {
+      registered = p;
+    });
+    const ok = wireComputerUseOcrBridge(register, () => fakeService());
+    expect(ok).toBe(true);
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(registered).not.toBeNull();
+    expect((registered as unknown as CoordOcrProviderLike).name).toBe(
+      VISION_COORD_OCR_BRIDGE_NAME,
+    );
+  });
+});

--- a/plugins/plugin-vision/src/computeruse-ocr-bridge.ts
+++ b/plugins/plugin-vision/src/computeruse-ocr-bridge.ts
@@ -1,0 +1,85 @@
+/**
+ * Bridge plugin-vision's hierarchical OCR into plugin-computeruse's
+ * `CoordOcrProvider` registry seam.
+ *
+ * plugin-vision owns the OCR implementations; plugin-computeruse's
+ * scene-builder + GET_SCREEN want coordinate-aware OCR but must NOT take a
+ * hard dependency on plugin-vision (that would create a cycle and force the
+ * vision OCR stack onto every computeruse consumer). So plugin-vision
+ * registers a bridge into computeruse's seam at boot via a best-effort dynamic
+ * import (see `index.ts`).
+ *
+ * The two interfaces are structurally identical — vision's
+ * `OcrWithCoordsService.describe(OcrWithCoordsInput) -> OcrWithCoordsResult`
+ * and computeruse's `CoordOcrProvider.describe(CoordOcrInput) -> CoordOcrResult`
+ * share field shapes (displayId/sourceX/sourceY/pngBytes in; blocks with
+ * bbox+words+semantic_position out) — so the bridge is a thin pass-through.
+ * The types live in different packages, so we describe computeruse's side
+ * structurally here rather than importing it (keeps the no-hard-dep rule).
+ *
+ * Pure + injectable so the wiring is unit-testable without a real
+ * plugin-computeruse present.
+ */
+
+import {
+  getOcrWithCoordsService,
+  type OcrWithCoordsResult,
+  type OcrWithCoordsService,
+} from "./ocr-with-coords.js";
+
+/** Structural shape of `@elizaos/plugin-computeruse`'s `CoordOcrInput`. */
+export interface CoordOcrInputLike {
+  readonly displayId: string;
+  readonly sourceX: number;
+  readonly sourceY: number;
+  readonly pngBytes: Uint8Array;
+}
+
+/** Structural shape of `@elizaos/plugin-computeruse`'s `CoordOcrProvider`. */
+export interface CoordOcrProviderLike {
+  readonly name: string;
+  describe(input: CoordOcrInputLike): Promise<OcrWithCoordsResult>;
+}
+
+export type RegisterCoordOcrProvider = (
+  provider: CoordOcrProviderLike | null,
+) => void;
+
+export const VISION_COORD_OCR_BRIDGE_NAME = "vision-coord-ocr-bridge";
+
+/**
+ * Build a `CoordOcrProvider`-shaped bridge that delegates to whatever vision
+ * `OcrWithCoordsService` is currently registered. Resolving the service lazily
+ * (per call) means a later `registerOcrWithCoordsService()` (e.g. swapping in a
+ * native Windows.Media.Ocr / Apple Vision provider) is picked up automatically.
+ */
+export function buildVisionCoordOcrBridge(
+  resolve: () => OcrWithCoordsService | null = getOcrWithCoordsService,
+): CoordOcrProviderLike {
+  return {
+    name: VISION_COORD_OCR_BRIDGE_NAME,
+    async describe(input: CoordOcrInputLike): Promise<OcrWithCoordsResult> {
+      const service = resolve();
+      if (!service) return { blocks: [] };
+      // Field shapes match across the two interfaces — pass through directly.
+      return service.describe({
+        displayId: input.displayId,
+        sourceX: input.sourceX,
+        sourceY: input.sourceY,
+        pngBytes: input.pngBytes,
+      });
+    },
+  };
+}
+
+/**
+ * Register the vision OCR bridge into computeruse's CoordOcrProvider seam.
+ * Idempotent (the seam is last-call-wins). Returns true once registered.
+ */
+export function wireComputerUseOcrBridge(
+  register: RegisterCoordOcrProvider,
+  resolve?: () => OcrWithCoordsService | null,
+): boolean {
+  register(buildVisionCoordOcrBridge(resolve));
+  return true;
+}

--- a/plugins/plugin-vision/src/index.ts
+++ b/plugins/plugin-vision/src/index.ts
@@ -1,6 +1,12 @@
 import type { Plugin } from "@elizaos/core";
-import { promoteSubactionsToActions } from "@elizaos/core";
+import { logger, promoteSubactionsToActions } from "@elizaos/core";
 import { visionAction } from "./action";
+import { wireComputerUseOcrBridge } from "./computeruse-ocr-bridge";
+import {
+  getOcrWithCoordsService,
+  RapidOcrCoordAdapter,
+  registerOcrWithCoordsService,
+} from "./ocr-with-coords";
 import { visionProvider } from "./provider";
 import { VisionService } from "./service";
 
@@ -35,7 +41,35 @@ export const visionPlugin: Plugin = {
       );
     },
   },
-  init: async (_config, _runtime) => {},
+  init: async (_config, _runtime) => {
+    // Wire full-screen OCR-with-coords so plugin-computeruse's scene-builder
+    // and GET_SCREEN can consume it. plugin-vision owns the OCR engines; it
+    // registers a coord-OCR service locally and bridges it into computeruse's
+    // CoordOcrProvider seam via a best-effort dynamic import (no hard dep — the
+    // bridge is skipped cleanly when computeruse is not installed).
+    if (!getOcrWithCoordsService()) {
+      registerOcrWithCoordsService(new RapidOcrCoordAdapter());
+    }
+    try {
+      const mod = (await import(
+        "@elizaos/plugin-computeruse/mobile/ocr-provider"
+      )) as { registerCoordOcrProvider?: (provider: unknown) => void };
+      if (typeof mod.registerCoordOcrProvider === "function") {
+        wireComputerUseOcrBridge(
+          mod.registerCoordOcrProvider as (provider: unknown) => void,
+        );
+        logger.info(
+          "[vision] registered coord-OCR bridge into plugin-computeruse scene seam",
+        );
+      }
+    } catch (err) {
+      logger.debug(
+        `[vision] plugin-computeruse OCR seam not available; running standalone (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+    }
+  },
   async dispose(runtime) {
     const svc = runtime.getService<VisionService>(VisionService.serviceType);
     await svc?.stop();


### PR DESCRIPTION
First slice (M1) of the Computer-Use × Vision integration EPIC #9105.

## Problem (two verified defects)
1. `plugin-computeruse/src/scene/ocr-adapter.ts` consumed the **line-only** `OcrProvider` registry, not the coord-aware `CoordOcrProvider` seam.
2. `plugin-vision`'s plugin `init` was a literal no-op (`async () => {}`), so **no OCR provider was ever registered** → `scene.ocr` was always empty in practice.

Net effect: "full-screen OCR" did not actually reach the scene-builder.

## Change (additive, no public API change, no hard dependency)
**plugin-computeruse** — `ocr-adapter.ts` now prefers `getCoordOcrProvider()` (coord seam), maps `CoordOcrBlock → SceneOcrBox` in display-absolute coords (conf defaults to 1; the coord seam carries no per-block confidence), threads the dirty-region crop offset via `sourceX/sourceY`, and falls back to the line-only registry (iOS Apple-Vision / test fakes) when no coord provider is present. No behavior change for existing line-only consumers.

**plugin-vision** — `init` now registers a coord-OCR service locally (`RapidOcrCoordAdapter` → docTR/Apple-Vision chain) and bridges it into computeruse's `CoordOcrProvider` seam via a best-effort dynamic import of `@elizaos/plugin-computeruse/mobile/ocr-provider` (skipped cleanly when computeruse is absent — vision still runs standalone). New `computeruse-ocr-bridge.ts` is a pure, injectable, lazily-resolving structural pass-through. `build.ts` externalizes `@elizaos/plugin-computeruse` so the registry **singleton** is the one runtime instance computeruse reads (bundling a copy would split the registry and make the registration invisible).

## Evidence (local Windows backend)
- `plugin-computeruse`: **399 passed / 5 skipped** (43 files), incl. new `ocr-adapter-coord-seam.test.ts` (coord-seam mapping, coord-over-line preference, line-only fallback, empty-when-none, dirty-region offset).
- `plugin-vision`: **88 passed** (15 files), incl. new `computeruse-ocr-bridge.test.ts` (delegation, empty-when-none, lazy resolution, named registration).
- typecheck + build clean for both; biome clean.
- **Cross-package integration check**: vision's bridge (resolved via the dist package import, exactly as at runtime) registers into the same `getCoordOcrProvider()` singleton computeruse reads, and `describe()` delegates with the correct bbox shift. dist inspection confirms the registry impl is NOT bundled into vision (singleton preserved).

## Scope / follow-ons (tracked in #9105)
GET_SCREEN action, unified single-capture `ScreenState`, dHash-gated online description, local GGUF vision models via libelizainference, predict/ground split, and cross-platform/AOSP verification are subsequent milestones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)