### PR TITLE
fix(inbox): consume the optimized inbox_triage prompt (#8795)

### DIFF
--- a/plugins/plugin-inbox/src/inbox/triage-classifier.ts
+++ b/plugins/plugin-inbox/src/inbox/triage-classifier.ts
@@ -3,6 +3,7 @@ import {
   logger,
   ModelType,
   parseJsonModelRecord,
+  resolveOptimizedPromptForRuntime,
   runWithTrajectoryContext,
 } from "@elizaos/core";
 import type {
@@ -72,12 +73,12 @@ async function classifyBatch(
     ownerContext?: string;
   },
 ): Promise<TriageResult[]> {
-  const prompt = buildTriagePrompt(messages, opts);
+  const prompt = buildTriagePrompt(messages, { ...opts, runtime });
 
   let rawResponse = "";
   try {
     const result = await runWithTrajectoryContext(
-      { purpose: "lifeops-inbox-triage" },
+      { purpose: "inbox_triage" },
       () => runtime.useModel(ModelType.TEXT_SMALL, { prompt }),
     );
     rawResponse = typeof result === "string" ? result : "";
@@ -97,31 +98,47 @@ async function classifyBatch(
   return parseTriageResults(rawResponse, messages.length);
 }
 
-function buildTriagePrompt(
+/**
+ * Static classification instructions for the inbox-triage task. Exposed as the
+ * optimizable baseline so {@link resolveOptimizedPromptForRuntime} can swap in a
+ * GEPA-optimized `inbox_triage` artifact when one is registered (#8795). The
+ * dynamic owner context / examples / messages are scaffolded around it below.
+ */
+export const INBOX_TRIAGE_INSTRUCTIONS = [
+  "Classify each message into one of these categories:",
+  "",
+  "- ignore: spam, irrelevant, automated notifications, bot messages, or general chat that needs no attention",
+  "- info: informational updates the owner might want to see but doesn't need to act on",
+  "- notify: important information the owner should see, but no response is needed",
+  "- needs_reply: someone is asking a question or expects a response from the owner",
+  "- urgent: time-sensitive, critical, or from a priority contact — needs immediate attention",
+  "",
+  "For each message, also provide:",
+  "- urgency: low / medium / high",
+  "- confidence: 0.0 to 1.0 (how sure you are about this classification)",
+  "- reasoning: brief explanation",
+  "- suggestedResponse: (optional) a brief draft response if classification is needs_reply or urgent",
+].join("\n");
+
+export function buildTriagePrompt(
   messages: InboundMessage[],
   opts: {
     config?: InboxTriageConfig;
     examples?: TriageExample[];
     ownerContext?: string;
+    runtime?: IAgentRuntime;
   },
 ): string {
   const sections: string[] = [];
 
-  sections.push(
-    "Classify each message into one of these categories:",
-    "",
-    "- ignore: spam, irrelevant, automated notifications, bot messages, or general chat that needs no attention",
-    "- info: informational updates the owner might want to see but doesn't need to act on",
-    "- notify: important information the owner should see, but no response is needed",
-    "- needs_reply: someone is asking a question or expects a response from the owner",
-    "- urgent: time-sensitive, critical, or from a priority contact — needs immediate attention",
-    "",
-    "For each message, also provide:",
-    "- urgency: low / medium / high",
-    "- confidence: 0.0 to 1.0 (how sure you are about this classification)",
-    "- reasoning: brief explanation",
-    "- suggestedResponse: (optional) a brief draft response if classification is needs_reply or urgent",
-  );
+  const instructions = opts.runtime
+    ? resolveOptimizedPromptForRuntime(
+        opts.runtime,
+        "inbox_triage",
+        INBOX_TRIAGE_INSTRUCTIONS,
+      )
+    : INBOX_TRIAGE_INSTRUCTIONS;
+  sections.push(instructions);
 
   // Owner context
   if (opts.ownerContext) {

--- a/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
+++ b/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Routing coverage for the `inbox_triage` LifeOps optimization task (#8795).
+ *
+ * The triage classification instructions must consult OptimizedPromptService and
+ * use an optimized artifact when one is registered, falling back to the inline
+ * baseline otherwise (absence of an artifact is a no-op, never a failure) — the
+ * same contract `morning_brief`/`calendar_extract` already follow.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildTriagePrompt,
+  INBOX_TRIAGE_INSTRUCTIONS,
+} from "../src/inbox/triage-classifier.js";
+import type { InboundMessage } from "../src/inbox/types.js";
+
+const MESSAGES: InboundMessage[] = [
+  {
+    id: "msg-1",
+    source: "gmail",
+    senderName: "Sam Rivera",
+    channelName: "Primary",
+    channelType: "dm",
+    text: "Can you confirm the 3pm sync still works for you?",
+  },
+];
+
+function runtimeWithOptimizedPrompt(
+  promptByTask: Record<string, string>,
+): IAgentRuntime {
+  return {
+    getService: (name: string) =>
+      name === "optimized_prompt"
+        ? {
+            getPrompt: (task: string) =>
+              promptByTask[task]
+                ? { prompt: promptByTask[task], optimizerSource: "gepa" }
+                : null,
+          }
+        : null,
+  } as unknown as IAgentRuntime;
+}
+
+describe("inbox triage — OptimizedPromptService routing", () => {
+  it("uses the inline baseline when no runtime is provided", () => {
+    const prompt = buildTriagePrompt(MESSAGES, {});
+    expect(prompt).toContain(INBOX_TRIAGE_INSTRUCTIONS);
+    expect(prompt).toContain("Sam Rivera");
+  });
+
+  it("uses the inline baseline when the runtime has no optimized prompt", () => {
+    const prompt = buildTriagePrompt(MESSAGES, {
+      runtime: runtimeWithOptimizedPrompt({}),
+    });
+    expect(prompt).toContain(
+      "Classify each message into one of these categories:",
+    );
+  });
+
+  it("swaps in the optimized inbox_triage artifact and preserves message data", () => {
+    const prompt = buildTriagePrompt(MESSAGES, {
+      runtime: runtimeWithOptimizedPrompt({
+        inbox_triage: "OPTIMIZED: prefer needs_reply when a question is asked.",
+      }),
+    });
+    expect(prompt).toContain(
+      "OPTIMIZED: prefer needs_reply when a question is asked.",
+    );
+    // The inline baseline instructions are replaced by the artifact.
+    expect(prompt).not.toContain(
+      "Classify each message into one of these categories:",
+    );
+    // The dynamic message scaffold is preserved around the instructions.
+    expect(prompt).toContain("Messages to classify:");
+    expect(prompt).toContain("Sam Rivera");
+  });
+});


### PR DESCRIPTION
## What

`inbox_triage` is in the LifeOps optimization taxonomy (`OPTIMIZED_PROMPT_TASKS`), but the inbox classifier never consulted `OptimizedPromptService` — so a GEPA-optimized `inbox_triage` artifact could never reach it. `morning_brief` and `calendar_extract` already route through `resolveOptimizedPromptForRuntime`; this closes the last unwired core LifeOps consumer that has a live LLM call.

## Changes

- Extract the static classification instructions as `INBOX_TRIAGE_INSTRUCTIONS` and resolve them via `resolveOptimizedPromptForRuntime(runtime, "inbox_triage", baseline)`. The dynamic owner-context / examples / messages scaffold is preserved around the (optionally optimized) instructions — same shape as the `calendar_extract` consumer.
- Thread `runtime` from `classifyBatch` into `buildTriagePrompt`; align the trajectory tag from the ad-hoc `lifeops-inbox-triage` to the taxonomy name `inbox_triage` so triage calls bucket into the correct per-capability dataset.
- Export `buildTriagePrompt` for a no-model unit test.

## Evidence

`plugins/plugin-inbox/test/triage-optimized-prompt.test.ts` (mirrors `brief-optimized-prompt.test.ts`):
```
✓ uses the inline baseline when no runtime is provided
✓ uses the inline baseline when the runtime has no optimized prompt
✓ swaps in the optimized inbox_triage artifact and preserves message data
Test Files  1 passed (1)   Tests  3 passed (3)
```

Change is isolated to `triage-classifier.ts`. The other inbox suite failures on this branch are **pre-existing on develop** — reverting my file to develop's version reproduces the identical `inbox-action` failures (`PERMISSION_DENIED` vs `MISSING_SUBACTION`, etc.), and none of the failing files import the changed module. The `@elizaos/tui` typecheck errors are the known #9099 build-ordering artifact (the barrel export exists in source; tui just isn't prebuilt in this workspace), not introduced here.

Part of #8795 (the per-capability optimization-loop wiring). Running GEPA to produce the actual `inbox_triage` artifact remains an owner step (live-LLM budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)