### PR TITLE
ci: repair PRR workflow ref

### DIFF
--- a/.github/workflows/run-prr.yml
+++ b/.github/workflows/run-prr.yml
@@ -30,11 +30,11 @@ jobs:
         (github.event.action == 'review_requested' && vars.PRR_REVIEWER_LOGIN && github.event.requested_reviewer && github.event.requested_reviewer.login == vars.PRR_REVIEWER_LOGIN)
       ))
     # prr_ref must match uses: ref so checkout and npm ci stay in sync. On exit 1, download prr-logs-<PR#> artifact for output.log and prompts.log.
-    uses: elizaOS/prr/.github/workflows/run-prr-server.yml@feed
+    uses: elizaOS/prr/.github/workflows/run-prr-server.yml@master
     with:
       pr_number: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
       prr_repo: 'elizaOS/prr'
-      prr_ref: 'feed'
+      prr_ref: 'master'
       submit_review: ${{ github.event_name == 'workflow_dispatch' }}
     secrets:
       PRR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the PRR reusable workflow caller from the removed `elizaOS/prr@feed` ref to `elizaOS/prr@master`
- keep the paired `prr_ref` input in sync with the `uses:` ref, per the workflow contract comment

## Why
The `feed` ref no longer exists in `elizaOS/prr`, so PRR runs fail before creating any jobs or logs. Using the existing default branch lets PRR resolve the reusable workflow again without changing when PRR runs.

## Verification
- gh api `repos/elizaOS/prr/contents/.github/workflows/run-prr-server.yml?ref=master` confirms the reusable workflow exists
- git diff --check