### PR TITLE
test(calendar): add calendar_extract LifeOps capability behavior scenario (#8795)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/calendar-extract-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/calendar-extract-capability.scenario.ts
@@ -1,0 +1,73 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+/**
+ * Behavior scenario for the `calendar_extract` LifeOps capability.
+ *
+ * The calendar planner (`extractCalendarPlanWithLlm` in `@elizaos/plugin-calendar`)
+ * turns a natural-language request into a structured plan: a `subaction`
+ * (feed / search_events / create_event / update_event / delete_event /
+ * trip_window) plus an extracted time window and search queries. Its
+ * instruction body is the GEPA-optimizable `calendar_extract` prompt routed
+ * through `OptimizedPromptService`.
+ *
+ * This scenario asserts the extraction routes each request to the calendar
+ * action with the correct subaction and entities, across the read, create,
+ * reschedule, and trip-window slices. It mirrors `calendar-llm-eval-mutations`
+ * but is scoped to the extraction capability and adds a final selected-action
+ * check so a regression in the wired prompt surfaces as a failing scenario.
+ */
+export default scenario({
+  lane: "live-only",
+  id: "calendar-extract-capability",
+  title: "Calendar extract capability routes requests to the right subaction",
+  domain: "calendar",
+  tags: ["lifeops", "calendar", "calendar_extract", "llm-eval"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "LifeOps Calendar Extract Capability",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "extract-feed-window",
+      text: "What do I have on my calendar tomorrow?",
+      plannerIncludesAll: ["calendar_action"],
+      plannerExcludes: ["gmail_action", "owner_send_message"],
+    },
+    {
+      kind: "message",
+      name: "extract-create-event",
+      text: "Put a dinner with Priya on my calendar Friday at 7pm.",
+      plannerIncludesAll: ["calendar_action", "create_event", "priya"],
+      plannerExcludes: ["search_events", "gmail_action"],
+    },
+    {
+      kind: "message",
+      name: "extract-reschedule",
+      text: "Move my standup to Wednesday at 9am.",
+      plannerIncludesAll: ["calendar_action", "update_event", "standup"],
+      plannerExcludes: ["create_event", "delete_event", "gmail_action"],
+    },
+    {
+      kind: "message",
+      name: "extract-trip-window",
+      text: "What's happening while I'm in Tokyo next week?",
+      plannerIncludesAll: ["calendar_action", "trip_window", "tokyo"],
+      plannerExcludes: ["create_event", "gmail_action"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "selectedAction",
+      name: "calendar action selected for every extract turn",
+      actionName: "CALENDAR",
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Part of #8795 (LifeOps end-to-end scenario coverage + per-capability GEPA loop), scoped to **one capability done well**: a behavior scenario for the `calendar_extract` LifeOps capability.

The `calendar_extract` capability is already wired through `OptimizedPromptService` on `develop`:
- `calendar_extract` is part of the `OptimizedPromptTask` taxonomy in `@elizaos/core` (`packages/core/src/services/optimized-prompt.ts`).
- The calendar planner `extractCalendarPlanWithLlm` (`@elizaos/plugin-calendar`) resolves its instruction body via `resolveOptimizedPromptForRuntime(runtime, "calendar_extract", CALENDAR_PLAN_INSTRUCTIONS)`, so an optimized artifact substitutes the bundled instructions while the per-turn dynamic context (request/intent/conversation/time anchors) is preserved.
- That wiring is unit-tested by `plugins/plugin-calendar/test/calendar-optimized-prompt.test.ts`.

What was missing — and what this PR adds — is an **end-to-end behavior scenario** for the capability (issue acceptance criterion: "New scenarios land for calendar …").

## Change

Adds `plugins/plugin-personal-assistant/test/scenarios/calendar-extract-capability.scenario.ts`:

- Four message turns exercising the core extraction subactions: `feed` (read), `create_event`, `update_event` (reschedule), and `trip_window`.
- Per-turn planner assertions that each request routes to `calendar_action` with the right subaction/entities and excludes unrelated actions (`gmail_action`, `owner_send_message`).
- A `selectedAction` final check asserting the `CALENDAR` action is selected, so a regression in the wired `calendar_extract` prompt surfaces as a failing scenario.

Mirrors the existing `calendar-llm-eval-mutations.scenario.ts` format and lane.

## Verification

- `bun packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios` lists `calendar-extract-capability`.
- The scenario loads + parses correctly through the real `loadScenarioFile` loader (4 turns, valid `selectedAction` final check, `lane: live-only`, `domain: calendar`).
- `biome check` clean on the new file.
- Scope note: like all 155 sibling LifeOps scenarios, this is `lane: live-only` (needs a real LLM) and runs in the scheduled live lanes, not in the keyless PR lane. The deterministic proof of the underlying wiring is develop's existing `calendar-optimized-prompt.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)