### PR TITLE
test(app-core): guard the provisioning-host redis reconcile loop (#8756)

### DIFF
--- a/packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts
+++ b/packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression guard for the cloud provisioning-host env reconcile loop in
+ * `.github/workflows/deploy-eliza-provisioning-worker.yml` (#8756).
+ *
+ * The deploy workflow is the single source of truth for the provisioning host's
+ * `.env.local`. It reconciles a fixed set of keys — including
+ * `SANDBOX_REGISTRY_REDIS_URL`, which gates connector inbound routing (#8621) —
+ * with **skip-empty-before-delete** semantics: an empty secret value must
+ * `continue` (leaving any existing value intact) and must never reach the
+ * `sed -i "/^KEY=/d"` delete. Without that ordering, a momentarily-unset GitHub
+ * secret would silently blank the live key on the next deploy.
+ *
+ * Runtime env parsing of `SANDBOX_REGISTRY_REDIS_URL` is covered by
+ * `sandbox-registry.test.ts`; this test covers the workflow YAML that injects it.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workflowPath = resolve(
+  import.meta.dirname,
+  "../../../../../.github/workflows/deploy-eliza-provisioning-worker.yml",
+);
+const workflow = readFileSync(workflowPath, "utf8");
+
+describe("deploy-eliza-provisioning-worker reconcile loop", () => {
+  it("reconciles SANDBOX_REGISTRY_REDIS_URL alongside the headscale keys", () => {
+    // Both must flow through the same reconcile loop so the box self-heals on
+    // every deploy. Losing the redis line silently breaks #8621 inbound routing.
+    expect(workflow).toContain(
+      "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL",
+    );
+    expect(workflow).toContain("HEADSCALE_API_KEY=$HEADSCALE_API_KEY");
+  });
+
+  it("skips empty values before deleting the key (never blanks a live secret)", () => {
+    // The guard `[ -n "$val" ] || continue` MUST appear before the
+    // `sed -i "/^${key}=/d"` delete, so an empty secret short-circuits the loop
+    // body instead of deleting (blanking) the existing key.
+    const guardIdx = workflow.indexOf('[ -n "$val" ] || continue');
+    const deleteIdx = workflow.indexOf('sed -i "/^${key}=/d"');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(deleteIdx);
+  });
+});


### PR DESCRIPTION
## What

`#8756` notes the provisioning-worker code is merged and only operator steps remain. One of those — setting `SANDBOX_REGISTRY_REDIS_URL` (gates #8621 connector inbound routing) — is injected into the host `.env.local` solely by the reconcile loop in `.github/workflows/deploy-eliza-provisioning-worker.yml`. Runtime env parsing is covered by `sandbox-registry.test.ts`, but **no test covered the workflow YAML** that writes the value, so a regression (dropping the redis line, or moving the empty-value guard after the delete) would silently break inbound routing or blank a live secret on the next deploy.

## Change

A YAML-asserting regression test that pins the two invariants of the loop:
- `SANDBOX_REGISTRY_REDIS_URL` is reconciled alongside the headscale keys.
- the `[ -n "$val" ] || continue` guard precedes the `sed -i "/^${key}=/d"` delete — **skip-empty-before-delete**, so a momentarily-unset secret leaves the existing value intact rather than blanking it.

## Evidence

```
✓ reconciles SANDBOX_REGISTRY_REDIS_URL alongside the headscale keys
✓ skips empty values before deleting the key (never blanks a live secret)
Test Files  1 passed (1)   Tests  2 passed (2)
```

Test-only; closes the one agent-doable coverage gap in #8756. The image-bump / secret-provisioning / staging-verify steps remain operator-only (prod host access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)