### PR TITLE
feat(vision): GET_SCREEN action + native Windows.Media.Ocr coord provider (#9105 M2+M4a)

### DIFF
--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -11,8 +11,9 @@ import {
   type Memory,
   type State,
 } from "@elizaos/core";
-import type { VisionService } from "./service";
+import { buildGetScreen, summarizeGetScreen } from "./get-screen";
 import { assertValidVisionImageBuffer } from "./image-input";
+import type { VisionService } from "./service";
 import { VisionMode } from "./types";
 
 const VISION_ACTION_TIMEOUT_MS = 10_000;
@@ -22,6 +23,7 @@ const MAX_VISION_ENTITIES = 25;
 const VISION_OPS = [
   "describe",
   "capture",
+  "get_screen",
   "set_mode",
   "enable_camera",
   "disable_camera",
@@ -41,6 +43,21 @@ const ALL_VISION_CONTEXTS = [
   "memory",
   "settings",
 ] as const;
+
+const GET_SCREEN_KEYWORDS = [
+  "get_screen",
+  "get screen",
+  "read the screen",
+  "read screen",
+  "screen text",
+  "text on screen",
+  "what's on my screen",
+  "whats on my screen",
+  "what is on my screen",
+  "screen contents",
+  "ocr",
+  "extract text",
+];
 
 const DESCRIBE_KEYWORDS = [
   "describe",
@@ -371,6 +388,9 @@ function inferOpFromMessage(text: string): VisionOp | null {
   ) {
     return "set_mode";
   }
+  if (GET_SCREEN_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) {
+    return "get_screen";
+  }
   if (CAPTURE_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) {
     return "capture";
   }
@@ -378,6 +398,114 @@ function inferOpFromMessage(text: string): VisionOp | null {
     return "describe";
   }
   return null;
+}
+
+/** Structural view of plugin-computeruse's screenshot capability (no hard dep). */
+interface ComputerUseLike {
+  executeCommand?: (
+    command: string,
+    params?: Record<string, unknown>,
+  ) => Promise<{ success?: boolean; screenshot?: string; displayId?: number }>;
+}
+
+/**
+ * Acquire a fresh screen frame for GET_SCREEN. Prefers plugin-computeruse's
+ * verified OS screenshot (which also drives the CUA loop); falls back to the
+ * vision service's own screen capture. Returns null when neither is available.
+ */
+async function acquireScreenFrame(runtime: IAgentRuntime): Promise<{
+  pngBytes: Uint8Array;
+  displayId: number;
+  capturedAt: number;
+} | null> {
+  const cu = runtime.getService("computeruse") as ComputerUseLike | null;
+  if (cu?.executeCommand) {
+    try {
+      const r = await cu.executeCommand("screenshot");
+      if (
+        r?.success !== false &&
+        typeof r?.screenshot === "string" &&
+        r.screenshot
+      ) {
+        return {
+          pngBytes: new Uint8Array(Buffer.from(r.screenshot, "base64")),
+          displayId: typeof r.displayId === "number" ? r.displayId : 0,
+          capturedAt: Date.now(),
+        };
+      }
+    } catch (err) {
+      logger.debug(
+        `[vision] computeruse screenshot unavailable for get_screen (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+    }
+  }
+  const visionService = runtime.getService<VisionService>("VISION");
+  const cap = await visionService?.getScreenCapture();
+  if (cap?.data && cap.data.byteLength > 0) {
+    return {
+      pngBytes: new Uint8Array(cap.data),
+      displayId: 0,
+      capturedAt: cap.timestamp ?? Date.now(),
+    };
+  }
+  return null;
+}
+
+async function runGetScreen(
+  runtime: IAgentRuntime,
+  message: Memory,
+  options: Record<string, unknown>,
+  callback?: HandlerCallback,
+): Promise<ActionResult> {
+  const includeImage = options.includeImage === true;
+  const includeOcr = options.includeOcr !== false;
+  const displayId =
+    typeof options.displayId === "number" ? options.displayId : undefined;
+
+  const frame = await acquireScreenFrame(runtime);
+  if (!frame) {
+    const thought = "No screen capture source is available.";
+    const text =
+      "I couldn't read the screen — neither the desktop capture (plugin-computeruse) nor screen-vision mode is available right now.";
+    await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
+    if (callback) await callback({ thought, text, actions: ["VISION"] });
+    return {
+      success: false,
+      text: "No screen capture source available for get_screen",
+      values: { success: false, visionAvailable: false },
+      data: {
+        actionName: "VISION",
+        op: "get_screen",
+        error: "no_capture_source",
+      },
+    };
+  }
+
+  const result = await buildGetScreen({
+    pngBytes: frame.pngBytes,
+    displayId: displayId ?? frame.displayId,
+    includeImage,
+    includeOcr,
+    capturedAt: frame.capturedAt,
+  });
+  const text = summarizeGetScreen(result);
+  await saveExecutionRecord(runtime, message, text, text, ["VISION"]);
+  if (callback) await callback({ thought: text, text, actions: ["VISION"] });
+  return {
+    success: true,
+    text,
+    values: {
+      success: true,
+      visionAvailable: true,
+      ocrAvailable: result.ocrAvailable,
+      elementCount: result.elementCount,
+      width: result.width,
+      height: result.height,
+    },
+    data: { actionName: "VISION", ...result },
+  };
 }
 
 async function runDescribe(
@@ -1386,11 +1514,15 @@ export const visionAction: Action = {
     "SCREENSHOT",
     "CAPTURE_FRAME",
     "TAKE_PICTURE",
+    "GET_SCREEN",
+    "READ_SCREEN",
+    "SCREEN_TEXT",
+    "OCR_SCREEN",
   ],
   description:
-    "Camera and screen vision: describe the current scene, capture an image, switch vision mode (off/camera/screen/both), name a visible entity, identify a person, or start tracking an entity. The action is inferred from the message text when not explicitly provided.",
+    "Camera and screen vision: describe the current scene, capture an image, GET_SCREEN (token-frugal structured readout — OCR text + grounded UI elements with coordinates, no image unless includeImage=true), switch vision mode (off/camera/screen/both), name a visible entity, identify a person, or start tracking an entity. The action is inferred from the message text when not explicitly provided.",
   descriptionCompressed:
-    "Vision: describe / capture / set_mode / name_entity / identify_person / track_entity.",
+    "Vision: describe / capture / get_screen (OCR+elements, no image) / set_mode / name_entity / identify_person / track_entity.",
   parameters: [
     {
       name: "action",
@@ -1415,6 +1547,13 @@ export const visionAction: Action = {
         enum: ["summary", "detailed"],
         default: "detailed",
       },
+    },
+    {
+      name: "includeImage",
+      description:
+        "For action=get_screen: when true, attach the base64 screenshot too (costs image tokens). Default false — return only OCR text + grounded elements.",
+      required: false,
+      schema: { type: "boolean", default: false },
     },
     {
       name: "mode",
@@ -1507,6 +1646,8 @@ export const visionAction: Action = {
         return runDescribe(runtime, message, params, callback);
       case "capture":
         return runCapture(runtime, message, callback);
+      case "get_screen":
+        return runGetScreen(runtime, message, params, callback);
       case "set_mode":
         return runSetMode(runtime, message, params, callback);
       case "enable_camera":

--- a/plugins/plugin-vision/src/get-screen.test.ts
+++ b/plugins/plugin-vision/src/get-screen.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for GET_SCREEN core (M2, #9105).
+ *
+ * Verifies the token-frugal contract: OCR text + grounded elements by default,
+ * NO image unless includeImage=true, graceful behavior when no OCR provider.
+ */
+
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+import {
+  buildGetScreen,
+  type GetScreenResult,
+  summarizeGetScreen,
+} from "./get-screen.js";
+import type { OcrWithCoordsService } from "./ocr-with-coords.js";
+
+function fakeOcr(): OcrWithCoordsService {
+  return {
+    name: "fake",
+    async describe(input) {
+      return {
+        blocks: [
+          {
+            text: "Save",
+            bbox: {
+              x: input.sourceX + 10,
+              y: input.sourceY + 20,
+              width: 40,
+              height: 16,
+            },
+            words: [],
+            semantic_position: "upper-left",
+          },
+          {
+            text: "Open File",
+            bbox: {
+              x: input.sourceX + 80,
+              y: input.sourceY + 20,
+              width: 70,
+              height: 16,
+            },
+            words: [],
+            semantic_position: "upper-center",
+          },
+        ],
+      };
+    },
+  };
+}
+
+async function png(width = 120, height = 48): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buf);
+}
+
+describe("buildGetScreen", () => {
+  it("returns OCR text + elements and OMITS the image by default", async () => {
+    const r = await buildGetScreen({
+      pngBytes: await png(),
+      displayId: 0,
+      capturedAt: 1234,
+      ocrService: fakeOcr(),
+    });
+    expect(r.op).toBe("get_screen");
+    expect(r.width).toBe(120);
+    expect(r.height).toBe(48);
+    expect(r.lastChangeTime).toBe(1234);
+    expect(r.ocrAvailable).toBe(true);
+    expect(r.elementCount).toBe(2);
+    expect(r.elements.map((e) => e.text)).toEqual(["Save", "Open File"]);
+    expect(r.elements[0]).toMatchObject({
+      id: "el-1",
+      bbox: [10, 20, 40, 16],
+      semantic_position: "upper-left",
+      displayId: 0,
+    });
+    expect(r.ocrText).toBe("Save\nOpen File");
+    expect(r.image).toBeUndefined();
+  });
+
+  it("attaches the base64 image only when includeImage=true", async () => {
+    const bytes = await png();
+    const r = await buildGetScreen({
+      pngBytes: bytes,
+      includeImage: true,
+      ocrService: fakeOcr(),
+    });
+    expect(typeof r.image).toBe("string");
+    expect(Buffer.from(r.image as string, "base64").byteLength).toBe(
+      bytes.byteLength,
+    );
+  });
+
+  it("skips OCR when includeOcr=false (zero work, ocrAvailable=false)", async () => {
+    const r = await buildGetScreen({
+      pngBytes: await png(),
+      includeOcr: false,
+      ocrService: fakeOcr(),
+    });
+    expect(r.ocrAvailable).toBe(false);
+    expect(r.elements).toEqual([]);
+    expect(r.ocrText).toBe("");
+  });
+
+  it("degrades when no OCR provider is registered (never throws)", async () => {
+    const r = await buildGetScreen({ pngBytes: await png(), ocrService: null });
+    expect(r.ocrAvailable).toBe(false);
+    expect(r.elementCount).toBe(0);
+    expect(r.width).toBe(120);
+  });
+});
+
+describe("summarizeGetScreen", () => {
+  it("summarizes detected elements", () => {
+    const r: GetScreenResult = {
+      op: "get_screen",
+      displayId: 0,
+      width: 800,
+      height: 600,
+      lastChangeTime: 0,
+      ocrAvailable: true,
+      ocrText: "Save\nOpen",
+      elements: [
+        {
+          id: "el-1",
+          text: "Save",
+          bbox: [0, 0, 1, 1],
+          semantic_position: "center",
+          displayId: 0,
+        },
+        {
+          id: "el-2",
+          text: "Open",
+          bbox: [0, 0, 1, 1],
+          semantic_position: "center",
+          displayId: 0,
+        },
+      ],
+      elementCount: 2,
+    };
+    expect(summarizeGetScreen(r)).toContain("2 text element");
+    expect(summarizeGetScreen(r)).toContain("Save | Open");
+  });
+
+  it("notes when no OCR provider is present", () => {
+    const r: GetScreenResult = {
+      op: "get_screen",
+      displayId: 0,
+      width: 800,
+      height: 600,
+      lastChangeTime: 0,
+      ocrAvailable: false,
+      ocrText: "",
+      elements: [],
+      elementCount: 0,
+    };
+    expect(summarizeGetScreen(r)).toMatch(/No OCR provider/i);
+  });
+});

--- a/plugins/plugin-vision/src/get-screen.ts
+++ b/plugins/plugin-vision/src/get-screen.ts
@@ -1,0 +1,125 @@
+/**
+ * GET_SCREEN core (issue #9105 / M2) — token-frugal structured screen readout.
+ *
+ * Returns OCR text + grounded elements (id/text/bbox/semantic position) from a
+ * captured frame using the registered coord-OCR service (native Windows OCR /
+ * docTR / Apple Vision — zero LLM tokens). The raw image is OMITTED by default
+ * (`includeImage:false`) so a CUA loop can read the screen each tick without
+ * spending image tokens; it is only base64-attached when explicitly requested.
+ *
+ * Pure + injectable (the OCR service can be passed in) so it is unit-testable
+ * without a real capture or a registered provider.
+ */
+
+import {
+  getOcrWithCoordsService,
+  type OcrWithCoordsService,
+  readPngDimensions,
+} from "./ocr-with-coords.js";
+
+export interface GetScreenElement {
+  /** Stable per-result id. */
+  id: string;
+  text: string;
+  /** Display-absolute [x, y, width, height]. */
+  bbox: [number, number, number, number];
+  semantic_position: string;
+  displayId: number;
+}
+
+export interface GetScreenResult {
+  op: "get_screen";
+  displayId: number;
+  width: number;
+  height: number;
+  /** When the source frame was captured (ms epoch). */
+  lastChangeTime: number;
+  /** True when a coord-OCR provider was available and ran. */
+  ocrAvailable: boolean;
+  ocrText: string;
+  elements: GetScreenElement[];
+  elementCount: number;
+  /** Base64 PNG — only present when `includeImage` was requested. */
+  image?: string;
+}
+
+export interface BuildGetScreenOptions {
+  pngBytes: Uint8Array;
+  displayId?: number;
+  includeImage?: boolean;
+  includeOcr?: boolean;
+  capturedAt?: number;
+  /** Override for tests; defaults to the registered coord-OCR service. */
+  ocrService?: OcrWithCoordsService | null;
+}
+
+export async function buildGetScreen(
+  opts: BuildGetScreenOptions,
+): Promise<GetScreenResult> {
+  const displayId = opts.displayId ?? 0;
+  const includeOcr = opts.includeOcr ?? true;
+  const includeImage = opts.includeImage ?? false;
+  const capturedAt = opts.capturedAt ?? 0;
+
+  const dims = (await readPngDimensions(opts.pngBytes)) ?? {
+    width: 0,
+    height: 0,
+  };
+
+  const service =
+    opts.ocrService !== undefined ? opts.ocrService : getOcrWithCoordsService();
+
+  let elements: GetScreenElement[] = [];
+  let ocrText = "";
+  let ocrAvailable = false;
+
+  if (includeOcr && service && opts.pngBytes.byteLength > 0) {
+    ocrAvailable = true;
+    const result = await service.describe({
+      displayId: String(displayId),
+      sourceX: 0,
+      sourceY: 0,
+      pngBytes: opts.pngBytes,
+    });
+    elements = result.blocks.map((block, i) => ({
+      id: `el-${i + 1}`,
+      text: block.text,
+      bbox: [block.bbox.x, block.bbox.y, block.bbox.width, block.bbox.height],
+      semantic_position: block.semantic_position,
+      displayId,
+    }));
+    ocrText = elements.map((e) => e.text).join("\n");
+  }
+
+  const out: GetScreenResult = {
+    op: "get_screen",
+    displayId,
+    width: dims.width,
+    height: dims.height,
+    lastChangeTime: capturedAt,
+    ocrAvailable,
+    ocrText,
+    elements,
+    elementCount: elements.length,
+  };
+  if (includeImage && opts.pngBytes.byteLength > 0) {
+    out.image = Buffer.from(opts.pngBytes).toString("base64");
+  }
+  return out;
+}
+
+/** Human-readable one-line summary for the agent reply. */
+export function summarizeGetScreen(r: GetScreenResult): string {
+  if (!r.ocrAvailable) {
+    return `Screen captured (${r.width}x${r.height}). No OCR provider is registered, so no text was extracted.`;
+  }
+  if (r.elementCount === 0) {
+    return `Screen captured (${r.width}x${r.height}); no text was detected on it.`;
+  }
+  const preview = r.elements
+    .slice(0, 8)
+    .map((e) => e.text)
+    .filter(Boolean)
+    .join(" | ");
+  return `Screen captured (${r.width}x${r.height}). ${r.elementCount} text element(s) detected: ${preview}${r.elementCount > 8 ? " …" : ""}`;
+}

--- a/plugins/plugin-vision/src/index.ts
+++ b/plugins/plugin-vision/src/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "@elizaos/core";
 import { logger, promoteSubactionsToActions } from "@elizaos/core";
 import { visionAction } from "./action";
 import { wireComputerUseOcrBridge } from "./computeruse-ocr-bridge";
+import { WindowsMediaOcrService } from "./ocr-service-windows";
 import {
   getOcrWithCoordsService,
   RapidOcrCoordAdapter,
@@ -48,7 +49,15 @@ export const visionPlugin: Plugin = {
     // CoordOcrProvider seam via a best-effort dynamic import (no hard dep — the
     // bridge is skipped cleanly when computeruse is not installed).
     if (!getOcrWithCoordsService()) {
-      registerOcrWithCoordsService(new RapidOcrCoordAdapter());
+      // Prefer the native OS OCR engine where available (zero LLM tokens,
+      // NPU-accelerated): Windows.Media.Ocr on Windows; otherwise the docTR /
+      // Apple-Vision chain. Native providers can override via
+      // registerOcrWithCoordsService later.
+      if (WindowsMediaOcrService.isAvailable()) {
+        registerOcrWithCoordsService(new WindowsMediaOcrService());
+      } else {
+        registerOcrWithCoordsService(new RapidOcrCoordAdapter());
+      }
     }
     try {
       const mod = (await import(

--- a/plugins/plugin-vision/src/ocr-service-windows.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-windows.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the native Windows.Media.Ocr coord provider (M4a, #9105).
+ *
+ * The pure mapper runs on every platform; the real end-to-end OCR test runs
+ * only on a Windows host (and Windows CI) where the WinRT engine exists.
+ */
+
+import { platform } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  mapWinOcrToResult,
+  WindowsMediaOcrService,
+} from "./ocr-service-windows.js";
+
+const IS_WIN = platform() === "win32";
+
+describe("mapWinOcrToResult (pure)", () => {
+  it("maps lines→blocks with union bbox, word boxes, and source shift", () => {
+    const raw = {
+      width: 200,
+      height: 60,
+      lines: [
+        {
+          text: "Save File",
+          words: [
+            { text: "Save", x: 10, y: 20, width: 40, height: 16 },
+            { text: "File", x: 60, y: 20, width: 36, height: 16 },
+          ],
+        },
+      ],
+    };
+    const result = mapWinOcrToResult(raw, 100, 200);
+    expect(result.blocks).toHaveLength(1);
+    const block = result.blocks[0];
+    expect(block.text).toBe("Save File");
+    // Union of word rects (10..96 x, 20..36 y), shifted by source (100,200).
+    expect(block.bbox).toEqual({ x: 110, y: 220, width: 86, height: 16 });
+    expect(block.words.map((w) => w.text)).toEqual(["Save", "File"]);
+    expect(block.words[0].bbox).toEqual({
+      x: 110,
+      y: 220,
+      width: 40,
+      height: 16,
+    });
+    expect(block.semantic_position).toBeDefined();
+  });
+
+  it("drops lines with no words and tolerates zero dimensions", () => {
+    const result = mapWinOcrToResult(
+      { width: 0, height: 0, lines: [{ text: "", words: [] }] },
+      0,
+      0,
+    );
+    expect(result.blocks).toEqual([]);
+  });
+});
+
+describe("WindowsMediaOcrService", () => {
+  it("reports availability by platform", () => {
+    expect(WindowsMediaOcrService.isAvailable()).toBe(IS_WIN);
+  });
+
+  it("returns empty blocks for empty input (no spawn)", async () => {
+    const svc = new WindowsMediaOcrService();
+    const r = await svc.describe({
+      displayId: "0",
+      sourceX: 0,
+      sourceY: 0,
+      pngBytes: new Uint8Array(0),
+    });
+    expect(r).toEqual({ blocks: [] });
+  });
+
+  it.skipIf(!IS_WIN)(
+    "OCRs a rendered PNG via the real WinRT engine (Windows host)",
+    async () => {
+      const sharp = (await import("sharp")).default;
+      const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg" width="420" height="110">' +
+        '<rect width="420" height="110" fill="white"/>' +
+        '<text x="12" y="70" font-size="40" font-family="Arial, sans-serif" fill="black">Open 4242</text>' +
+        "</svg>";
+      const png = await sharp(Buffer.from(svg)).png().toBuffer();
+      const svc = new WindowsMediaOcrService();
+      const r = await svc.describe({
+        displayId: "0",
+        sourceX: 0,
+        sourceY: 0,
+        pngBytes: new Uint8Array(png),
+      });
+      const text = r.blocks.map((b) => b.text).join(" ");
+      expect(text).toMatch(/open/i);
+      expect(text).toMatch(/4242/);
+      expect(
+        r.blocks.every(
+          (b) => b.bbox.width > 0 && b.bbox.height > 0 && b.words.length > 0,
+        ),
+      ).toBe(true);
+    },
+    30000,
+  );
+});

--- a/plugins/plugin-vision/src/ocr-service-windows.ts
+++ b/plugins/plugin-vision/src/ocr-service-windows.ts
@@ -1,0 +1,248 @@
+/**
+ * Native Windows OCR-with-coords via the built-in WinRT `Windows.Media.Ocr`
+ * engine (issue #9105 / M4a).
+ *
+ * Zero LLM tokens, no model download, NPU-accelerated where available. The
+ * WinRT projection is only reachable from Windows PowerShell 5.1 (`powershell`),
+ * not PowerShell 7 (`pwsh`), so we shell to `powershell` with an embedded
+ * script. Output is `OcrWithCoordsResult`, so this plugs straight into the
+ * `OcrWithCoordsService` registry seam and (via the M1 bridge) into
+ * plugin-computeruse's `CoordOcrProvider`.
+ *
+ * The engine returns text LINES, each with WORDS that carry bounding rects.
+ * We map each line to one `OcrWithCoordsBlock` (block bbox = union of its word
+ * rects), compute the semantic position against the source tile thirds, and
+ * shift every bbox into display-absolute coordinates via `sourceX/sourceY`.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@elizaos/core";
+import {
+  computeSemanticPosition,
+  type OcrWithCoordsBlock,
+  type OcrWithCoordsInput,
+  type OcrWithCoordsResult,
+  type OcrWithCoordsService,
+  type OcrWithCoordsWord,
+} from "./ocr-with-coords.js";
+import type { BoundingBox } from "./types.js";
+
+/** Shape emitted by the embedded PowerShell script (parsed from stdout JSON). */
+interface WinOcrRaw {
+  width: number;
+  height: number;
+  lines: Array<{
+    text: string;
+    words: Array<{
+      text: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    }>;
+  }>;
+}
+
+/**
+ * Windows PowerShell 5.1 script: render the input PNG into a SoftwareBitmap and
+ * run `Windows.Media.Ocr`, emitting compact JSON. `$ImagePath` is passed via
+ * `-ImagePath`. Kept as a string so the build doesn't have to copy an asset.
+ */
+const WIN_OCR_PS1 =
+  String.raw`param([Parameter(Mandatory=$true)][string]$ImagePath)
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Runtime.WindowsRuntime
+$asTaskGeneric = ([System.WindowsRuntimeSystemExtensions].GetMethods() | Where-Object {
+  $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and
+  $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation` +
+  "`" +
+  `1'
+})[0]
+function Await($op, $resultType) {
+  $m = $asTaskGeneric.MakeGenericMethod($resultType)
+  $t = $m.Invoke($null, @($op))
+  $t.Wait(-1) | Out-Null
+  $t.Result
+}
+[Windows.Media.Ocr.OcrEngine, Windows.Media.Ocr, ContentType = WindowsRuntime] | Out-Null
+[Windows.Graphics.Imaging.BitmapDecoder, Windows.Graphics.Imaging, ContentType = WindowsRuntime] | Out-Null
+[Windows.Storage.StorageFile, Windows.Storage, ContentType = WindowsRuntime] | Out-Null
+$file = Await ([Windows.Storage.StorageFile]::GetFileFromPathAsync($ImagePath)) ([Windows.Storage.StorageFile])
+$stream = Await ($file.OpenAsync([Windows.Storage.FileAccessMode]::Read)) ([Windows.Storage.Streams.IRandomAccessStream])
+$decoder = Await ([Windows.Graphics.Imaging.BitmapDecoder]::CreateAsync($stream)) ([Windows.Graphics.Imaging.BitmapDecoder])
+$bitmap = Await ($decoder.GetSoftwareBitmapAsync()) ([Windows.Graphics.Imaging.SoftwareBitmap])
+$engine = [Windows.Media.Ocr.OcrEngine]::TryCreateFromUserProfileLanguages()
+if ($null -eq $engine) { Write-Output '{"width":0,"height":0,"lines":[]}'; exit 0 }
+$result = Await ($engine.RecognizeAsync($bitmap)) ([Windows.Media.Ocr.OcrResult])
+$lines = @()
+foreach ($line in $result.Lines) {
+  $words = @()
+  foreach ($w in $line.Words) {
+    $r = $w.BoundingRect
+    $words += [pscustomobject]@{ text = $w.Text; x = [int]$r.X; y = [int]$r.Y; width = [int]$r.Width; height = [int]$r.Height }
+  }
+  $lines += [pscustomobject]@{ text = $line.Text; words = $words }
+}
+[pscustomobject]@{ width = [int]$bitmap.PixelWidth; height = [int]$bitmap.PixelHeight; lines = $lines } | ConvertTo-Json -Depth 6 -Compress`;
+
+let cachedScriptPath: string | null = null;
+
+function ensureScriptOnDisk(): string {
+  if (cachedScriptPath) return cachedScriptPath;
+  const dir = mkdtempSync(join(tmpdir(), "eliza-winocr-"));
+  const p = join(dir, "windows-ocr.ps1");
+  writeFileSync(p, WIN_OCR_PS1, "utf8");
+  cachedScriptPath = p;
+  return p;
+}
+
+function runPowerShell(scriptPath: string, imagePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "powershell",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        scriptPath,
+        "-ImagePath",
+        imagePath,
+      ],
+      { timeout: 15000, maxBuffer: 16 * 1024 * 1024, windowsHide: true },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(
+            new Error(
+              `windows-ocr powershell failed: ${stderr || err.message}`,
+            ),
+          );
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * Map a raw Windows OCR line to an `OcrWithCoordsBlock` in display-absolute
+ * coordinates. The block bbox is the union of its word rects.
+ */
+function lineToBlock(
+  line: WinOcrRaw["lines"][number],
+  tileWidth: number,
+  tileHeight: number,
+  sourceX: number,
+  sourceY: number,
+): OcrWithCoordsBlock {
+  const words: OcrWithCoordsWord[] = line.words.map((w) => {
+    const tileBox: BoundingBox = {
+      x: w.x,
+      y: w.y,
+      width: w.width,
+      height: w.height,
+    };
+    return {
+      text: w.text,
+      bbox: {
+        x: w.x + sourceX,
+        y: w.y + sourceY,
+        width: w.width,
+        height: w.height,
+      },
+      semantic_position: computeSemanticPosition({
+        bbox: tileBox,
+        tileWidth,
+        tileHeight,
+      }),
+    };
+  });
+
+  // Union of word rects (tile-relative) → block bbox.
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const w of line.words) {
+    minX = Math.min(minX, w.x);
+    minY = Math.min(minY, w.y);
+    maxX = Math.max(maxX, w.x + w.width);
+    maxY = Math.max(maxY, w.y + w.height);
+  }
+  if (!Number.isFinite(minX)) {
+    minX = 0;
+    minY = 0;
+    maxX = 0;
+    maxY = 0;
+  }
+  const tileBlockBox: BoundingBox = {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+  return {
+    text: line.text,
+    bbox: {
+      x: minX + sourceX,
+      y: minY + sourceY,
+      width: maxX - minX,
+      height: maxY - minY,
+    },
+    words,
+    semantic_position: computeSemanticPosition({
+      bbox: tileBlockBox,
+      tileWidth,
+      tileHeight,
+    }),
+  };
+}
+
+/** Pure mapper (exported for cross-platform unit tests). */
+export function mapWinOcrToResult(
+  raw: WinOcrRaw,
+  sourceX: number,
+  sourceY: number,
+): OcrWithCoordsResult {
+  const tileWidth = raw.width > 0 ? raw.width : 1;
+  const tileHeight = raw.height > 0 ? raw.height : 1;
+  const blocks = (raw.lines ?? [])
+    .filter((l) => (l.words?.length ?? 0) > 0)
+    .map((l) => lineToBlock(l, tileWidth, tileHeight, sourceX, sourceY));
+  return { blocks };
+}
+
+export class WindowsMediaOcrService implements OcrWithCoordsService {
+  readonly name = "windows-media-ocr";
+
+  static isAvailable(): boolean {
+    return process.platform === "win32";
+  }
+
+  async describe(input: OcrWithCoordsInput): Promise<OcrWithCoordsResult> {
+    if (input.pngBytes.byteLength === 0) return { blocks: [] };
+    if (process.platform !== "win32") return { blocks: [] };
+
+    const dir = mkdtempSync(join(tmpdir(), "eliza-winocr-img-"));
+    const imgPath = join(dir, "frame.png");
+    writeFileSync(imgPath, Buffer.from(input.pngBytes));
+    try {
+      const scriptPath = ensureScriptOnDisk();
+      const stdout = await runPowerShell(scriptPath, imgPath);
+      const raw = JSON.parse(
+        stdout.trim() || '{"width":0,"height":0,"lines":[]}',
+      ) as WinOcrRaw;
+      return mapWinOcrToResult(raw, input.sourceX, input.sourceY);
+    } catch (err) {
+      logger.warn(
+        `[WindowsMediaOcr] OCR failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { blocks: [] };
+    }
+  }
+}


### PR DESCRIPTION
Milestones **M2 (GET_SCREEN)** + **M4a (native Windows OCR)** of EPIC #9105. Builds on M1 (#9107).

## M4a — native zero-token OCR-with-coords (Windows)
`WindowsMediaOcrService` runs the built-in WinRT `Windows.Media.Ocr` engine via Windows PowerShell 5.1 (PS7 lacks WinRT projection) — **zero LLM tokens, no model download, NPU-accelerated**. Maps lines → `OcrWithCoordsBlock`s (union bbox + per-word boxes + semantic position), shifted to display-absolute coords. Registered at vision boot ahead of the docTR/Apple-Vision chain on Windows; reaches plugin-computeruse's scene-builder through the M1 `CoordOcrProvider` bridge.

## M2 — token-frugal GET_SCREEN
New `get-screen.ts` core + a `get_screen` op on the VISION action. Returns `{displayId,width,height,lastChangeTime,ocrAvailable,ocrText,elements,image?}` — OCR text + grounded elements (`id/text/bbox/semantic_position`) by default; the **raw image is omitted unless `includeImage=true`**, so a CUA loop reads the screen each tick with **zero image tokens**. `acquireScreenFrame` prefers plugin-computeruse's verified OS screenshot, falling back to vision screen capture. Degrades gracefully (never throws) when no OCR provider is registered.

## Evidence (local Windows backend)
- vision suite: **99 passed (17 files)**, incl.:
  - `ocr-service-windows.test.ts` — real WinRT OCR of a rendered PNG (read "open 4242" with word boxes) + pure mapper unit tests (cross-platform) + empty-input/no-spawn.
  - `get-screen.test.ts` — image omitted by default; attached only on `includeImage`; OCR-less graceful degrade; summary formatting.
- **End-to-end on the real screen**: `ComputerUseService` screenshot (1.28 MB, 1728×1052) → `buildGetScreen` ran the real Windows OCR with the image omitted (`ocrAvailable=true`, `hasImage=false`).
- typecheck + build clean; biome clean.

## Follow-ons (#9105)
M3 (unified ScreenState + dHash-gated description), M3.5 (input/DPI correctness), M5 (predict/ground split), M6 (AOSP/Wayland/CI + PaddleOCR for Linux/AOSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)