### PR TITLE
feat(vision): GET_SCREEN element-merge core (#9105 M2)

### DIFF
--- a/plugins/plugin-vision/src/get-screen-elements.test.ts
+++ b/plugins/plugin-vision/src/get-screen-elements.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AxNodeLike,
+  bboxIou,
+  type GetScreenElement,
+  mergeScreenElements,
+  type OcrBoxLike,
+  type VlmElementLike,
+} from "./get-screen-elements.js";
+
+const ocr = (
+  id: string,
+  text: string,
+  bbox: [number, number, number, number],
+  displayId = 0,
+): OcrBoxLike => ({ id, text, bbox, conf: 0.9, displayId });
+
+const ax = (
+  id: string,
+  role: string,
+  label: string | undefined,
+  bbox: [number, number, number, number],
+  actions: string[] = ["press"],
+  displayId = 0,
+): AxNodeLike => ({ id, role, label, bbox, actions, displayId });
+
+const vlm = (
+  id: string,
+  kind: string,
+  desc: string,
+  bbox: [number, number, number, number],
+  displayId = 0,
+): VlmElementLike => ({ id, kind, desc, bbox, displayId });
+
+describe("bboxIou", () => {
+  it("is 1 for identical boxes and 0 for disjoint", () => {
+    expect(bboxIou([0, 0, 10, 10], [0, 0, 10, 10])).toBeCloseTo(1);
+    expect(bboxIou([0, 0, 10, 10], [100, 100, 10, 10])).toBe(0);
+  });
+  it("returns 0 for an empty box", () => {
+    expect(bboxIou([0, 0, 0, 10], [0, 0, 10, 10])).toBe(0);
+  });
+  it("is ~0.33 for half-overlapping equal boxes", () => {
+    // [0,0,10,10] and [5,0,10,10]: inter=5*10=50, union=100+100-50=150 → 1/3.
+    expect(bboxIou([0, 0, 10, 10], [5, 0, 10, 10])).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe("mergeScreenElements (#9105 GET_SCREEN element merge)", () => {
+  it("maps OCR-only input to elements with groundingSources=['ocr']", () => {
+    const out = mergeScreenElements({
+      ocr: [
+        ocr("o1", "Save", [10, 10, 40, 12]),
+        ocr("o2", "Cancel", [60, 10, 40, 12]),
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(
+      out.every(
+        (e) =>
+          e.groundingSources.length === 1 && e.groundingSources[0] === "ocr",
+      ),
+    ).toBe(true);
+    expect(out.map((e) => e.text)).toEqual(["Save", "Cancel"]);
+  });
+
+  it("collapses an AX node overlapping an OCR box into ONE element, AX label/role winning", () => {
+    const out = mergeScreenElements({
+      ocr: [ocr("o1", "save", [10, 10, 40, 12])],
+      ax: [ax("a1", "button", "Save document", [11, 10, 40, 12])],
+    });
+    expect(out).toHaveLength(1);
+    const el = out[0] as GetScreenElement;
+    expect(el.groundingSources.sort()).toEqual(["ax", "ocr"]);
+    expect(el.id).toBe("a1"); // AX id wins
+    expect(el.text).toBe("Save document"); // AX label wins over OCR text
+    expect(el.kind).toBe("button"); // AX role
+    expect(el.actions).toEqual(["press"]);
+  });
+
+  it("folds a VLM element overlapping the AX+OCR cluster into the same element", () => {
+    const out = mergeScreenElements({
+      ocr: [ocr("o1", "save", [10, 10, 40, 12])],
+      ax: [ax("a1", "button", "Save", [11, 10, 40, 12])],
+      vlm: [vlm("v1", "icon", "floppy disk save icon", [10, 11, 40, 12])],
+    });
+    expect(out).toHaveLength(1);
+    expect((out[0] as GetScreenElement).groundingSources.sort()).toEqual([
+      "ax",
+      "ocr",
+      "vlm",
+    ]);
+    expect((out[0] as GetScreenElement).text).toBe("Save"); // AX still wins
+  });
+
+  it("keeps non-overlapping elements from all three sources separate", () => {
+    const out = mergeScreenElements({
+      ocr: [ocr("o1", "Title", [0, 0, 50, 12])],
+      ax: [ax("a1", "button", "OK", [0, 100, 30, 14])],
+      vlm: [vlm("v1", "image", "a photo", [0, 200, 80, 80])],
+    });
+    expect(out).toHaveLength(3);
+    expect(out.map((e) => e.groundingSources)).toEqual([
+      ["ocr"],
+      ["ax"],
+      ["vlm"],
+    ]);
+  });
+
+  it("degrades gracefully with no accessibility (OCR-only), never throwing", () => {
+    expect(() => mergeScreenElements({})).not.toThrow();
+    expect(mergeScreenElements({})).toEqual([]);
+    const out = mergeScreenElements({
+      ocr: [ocr("o1", "Hello", [0, 0, 30, 10])],
+      ax: [],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.groundingSources).toEqual(["ocr"]);
+  });
+
+  it("produces deterministic top-to-bottom, left-to-right ordering regardless of input order", () => {
+    const a = ocr("a", "A", [0, 0, 10, 10]);
+    const b = ocr("b", "B", [100, 0, 10, 10]);
+    const c = ocr("c", "C", [0, 100, 10, 10]);
+    const order1 = mergeScreenElements({ ocr: [a, b, c] }).map((e) => e.text);
+    const order2 = mergeScreenElements({ ocr: [c, b, a] }).map((e) => e.text);
+    expect(order1).toEqual(["A", "B", "C"]);
+    expect(order2).toEqual(order1);
+  });
+
+  it("respects the IoU threshold boundary (collapse only above it)", () => {
+    // [0,0,10,10] vs [5,0,10,10] → IoU = 1/3 ≈ 0.333.
+    const input = {
+      ocr: [ocr("o1", "left", [0, 0, 10, 10])],
+      ax: [ax("a1", "button", "Right", [5, 0, 10, 10])],
+    };
+    // threshold above the pair's IoU → stay separate (2 elements).
+    expect(mergeScreenElements(input, { iouThreshold: 0.5 })).toHaveLength(2);
+    // threshold below the pair's IoU → collapse (1 element).
+    expect(mergeScreenElements(input, { iouThreshold: 0.3 })).toHaveLength(1);
+  });
+
+  it("never merges elements on different displays", () => {
+    const out = mergeScreenElements({
+      ocr: [ocr("o1", "same box", [0, 0, 10, 10], 0)],
+      ax: [ax("a1", "button", "other display", [0, 0, 10, 10], ["press"], 1)],
+    });
+    expect(out).toHaveLength(2);
+  });
+});

--- a/plugins/plugin-vision/src/get-screen-elements.ts
+++ b/plugins/plugin-vision/src/get-screen-elements.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure element-merge core for the GET_SCREEN action (#9105 Slice 2 / M2).
+ *
+ * GET_SCREEN returns a cheap, token-frugal list of grounded, clickable screen
+ * elements unified from three sources: OCR text boxes, accessibility (AX)
+ * clickables, and (optionally) VLM-detected elements. This module is the
+ * deterministic heart of that envelope — it collapses the three sources into a
+ * single deduplicated, stably-ordered element list, recording each element's
+ * `groundingSources` provenance.
+ *
+ * Like the M1 OCR bridge (`computeruse-ocr-bridge.ts`), this is intentionally
+ * dependency-free and pure: the source types live in `@elizaos/plugin-computeruse`
+ * (`SceneOcrBox` / `SceneAxNode` / `SceneVlmElement`), but we describe their
+ * shapes STRUCTURALLY here rather than importing them, to keep the no-hard-dep
+ * rule. That also makes the merge engine fully unit-testable with zero
+ * environment, decoupled from the runtime/native/model wiring (Slice 3).
+ */
+
+/** Display-local bounding box `[x, y, w, h]`. */
+export type Bbox = readonly [number, number, number, number];
+
+/** Structural shape of computeruse's `SceneOcrBox`. */
+export interface OcrBoxLike {
+  readonly id: string;
+  readonly text: string;
+  readonly bbox: Bbox;
+  readonly conf?: number;
+  readonly displayId: number;
+}
+
+/** Structural shape of computeruse's `SceneAxNode`. */
+export interface AxNodeLike {
+  readonly id: string;
+  readonly role: string;
+  readonly label?: string;
+  readonly bbox: Bbox;
+  readonly actions?: readonly string[];
+  readonly displayId: number;
+}
+
+/** Structural shape of computeruse's `SceneVlmElement`. */
+export interface VlmElementLike {
+  readonly id: string;
+  readonly kind: string;
+  readonly desc: string;
+  readonly bbox: Bbox;
+  readonly displayId: number;
+}
+
+export type GroundingSource = "ocr" | "ax" | "vlm";
+
+/** A single unified, grounded screen element in the GET_SCREEN envelope. */
+export interface GetScreenElement {
+  /** Stable id, preferring the AX id, then OCR, then VLM. */
+  id: string;
+  /** Display-local bbox `[x, y, w, h]` of the representative (highest-priority) source. */
+  bbox: [number, number, number, number];
+  /** User-facing text/label: AX label, else OCR text, else VLM description. */
+  text: string;
+  /** Element kind/role when known: AX role, else VLM kind. */
+  kind?: string;
+  displayId: number;
+  /** AX actions when the element is accessibility-grounded. */
+  actions?: string[];
+  /** Provenance — every source that contributed to this element, in fixed
+   * `ocr < ax < vlm` order for stability. Always non-empty. */
+  groundingSources: GroundingSource[];
+}
+
+export interface MergeScreenInput {
+  readonly ocr?: readonly OcrBoxLike[];
+  readonly ax?: readonly AxNodeLike[];
+  readonly vlm?: readonly VlmElementLike[];
+}
+
+export interface MergeScreenOptions {
+  /** Boxes whose IoU exceeds this collapse into one element (default 0.6). */
+  readonly iouThreshold?: number;
+}
+
+const DEFAULT_IOU_THRESHOLD = 0.6;
+
+/** Intersection-over-union of two `[x, y, w, h]` boxes. 0 when either is empty
+ * or they don't overlap. */
+export function bboxIou(a: Bbox, b: Bbox): number {
+  const [ax, ay, aw, ah] = a;
+  const [bx, by, bw, bh] = b;
+  if (aw <= 0 || ah <= 0 || bw <= 0 || bh <= 0) return 0;
+  const ix = Math.max(ax, bx);
+  const iy = Math.max(ay, by);
+  const ix2 = Math.min(ax + aw, bx + bw);
+  const iy2 = Math.min(ay + ah, by + bh);
+  const iw = Math.max(0, ix2 - ix);
+  const ih = Math.max(0, iy2 - iy);
+  const inter = iw * ih;
+  if (inter <= 0) return 0;
+  const union = aw * ah + bw * bh - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+interface Cluster {
+  displayId: number;
+  bbox: Bbox;
+  ax?: AxNodeLike;
+  ocr?: OcrBoxLike;
+  vlm?: VlmElementLike;
+}
+
+/** Stable sort key: top-to-bottom, then left-to-right, then by id for ties. */
+function byPosition(
+  a: { bbox: Bbox; id: string },
+  b: { bbox: Bbox; id: string },
+): number {
+  return (
+    a.bbox[1] - b.bbox[1] || a.bbox[0] - b.bbox[0] || a.id.localeCompare(b.id)
+  );
+}
+
+/**
+ * Merge OCR boxes + AX clickables + VLM elements into one deduplicated,
+ * deterministically-ordered element list.
+ *
+ * - Elements from different sources whose bboxes overlap above `iouThreshold`
+ *   (and share a `displayId`) collapse into one element that records all
+ *   contributing sources in `groundingSources`.
+ * - Field precedence is AX > OCR > VLM (AX wins id/label/role; OCR text fills
+ *   in when AX has no label; VLM desc is the last resort).
+ * - Output order is top-to-bottom, then left-to-right, so the envelope is
+ *   stable across turns regardless of input ordering.
+ * - Degrades gracefully: any source may be absent/empty (e.g. accessibility off)
+ *   and the function never throws.
+ */
+export function mergeScreenElements(
+  input: MergeScreenInput,
+  options: MergeScreenOptions = {},
+): GetScreenElement[] {
+  const threshold = options.iouThreshold ?? DEFAULT_IOU_THRESHOLD;
+  const clusters: Cluster[] = [];
+
+  const attach = (
+    displayId: number,
+    bbox: Bbox,
+    set: (c: Cluster) => void,
+  ): void => {
+    const match = clusters.find(
+      (c) => c.displayId === displayId && bboxIou(c.bbox, bbox) >= threshold,
+    );
+    if (match) {
+      set(match);
+      return;
+    }
+    const cluster: Cluster = { displayId, bbox };
+    set(cluster);
+    clusters.push(cluster);
+  };
+
+  // Process in precedence order so a cluster's representative bbox is set by its
+  // highest-priority contributing source, and pre-sort each source by position
+  // so cluster creation order is deterministic.
+  for (const ax of [...(input.ax ?? [])].sort(byPosition)) {
+    attach(ax.displayId, ax.bbox, (c) => {
+      if (!c.ax) c.ax = ax;
+    });
+  }
+  for (const ocr of [...(input.ocr ?? [])].sort(byPosition)) {
+    attach(ocr.displayId, ocr.bbox, (c) => {
+      if (!c.ocr) c.ocr = ocr;
+    });
+  }
+  for (const vlm of [...(input.vlm ?? [])].sort(byPosition)) {
+    attach(vlm.displayId, vlm.bbox, (c) => {
+      if (!c.vlm) c.vlm = vlm;
+    });
+  }
+
+  const elements = clusters.map((c): GetScreenElement => {
+    const groundingSources: GroundingSource[] = [];
+    if (c.ocr) groundingSources.push("ocr");
+    if (c.ax) groundingSources.push("ax");
+    if (c.vlm) groundingSources.push("vlm");
+
+    const id = c.ax?.id ?? c.ocr?.id ?? c.vlm?.id ?? "el";
+    const text = c.ax?.label || c.ocr?.text || c.vlm?.desc || "";
+    const kind = c.ax?.role ?? c.vlm?.kind;
+    const [x, y, w, h] = c.bbox;
+
+    const element: GetScreenElement = {
+      id,
+      bbox: [x, y, w, h],
+      text,
+      displayId: c.displayId,
+      groundingSources,
+    };
+    if (kind !== undefined) element.kind = kind;
+    if (c.ax?.actions && c.ax.actions.length > 0) {
+      element.actions = [...c.ax.actions];
+    }
+    return element;
+  });
+
+  return elements.sort(byPosition);
+}


### PR DESCRIPTION
Advances the next un-shipped P0 of the Computer Use × Vision EPIC (#9105) — **Slice 2 / M2, the GET_SCREEN element merge** — as a pure, dependency-free module, exactly mirroring how M1 (#9107) shipped its `computeruse-ocr-bridge.ts` (structural types in-module, no hard `@elizaos/plugin-computeruse` dep, fully unit-testable with zero environment).

`mergeScreenElements()` unifies the three screen-grounding sources the GET_SCREEN envelope needs (issue §6.3: OCR boxes + AX clickables + cached VLM elements) into one deduplicated, deterministically-ordered list. Each element carries the required `groundingSources: ('ocr'|'ax'|'vlm')[]` provenance.

- **Merge:** elements sharing a `displayId` whose bboxes overlap above an IoU threshold (default 0.6, injectable) collapse into one element recording all contributing sources. Field precedence AX > OCR > VLM (AX wins id/label/role; OCR text fills in; VLM desc last).
- **Deterministic:** output is sorted top-to-bottom, then left-to-right, so the envelope is stable across turns regardless of input order.
- **Degrades gracefully:** any source may be absent/empty (accessibility off) and it never throws — the issue's mandated contract.

This lands the load-bearing, token-frugal heart of GET_SCREEN decoupled from the runtime/native/model wiring (ScreenState/capture, Slice 3) that can't be exercised yet. The eventual `get_screen` op in `VISION_OPS` will call this once that wiring is in.

## Evidence
```
bunx vitest run src/get-screen-elements.test.ts  →  11 passed (11)
```
Covers: OCR-only mapping, AX+OCR collapse (AX wins), VLM fold into the cluster, non-overlapping separation, graceful no-AX degradation, deterministic ordering under shuffled input, the IoU threshold boundary, and cross-display isolation. biome clean. Real-driver/scenario evidence is N/A for this pure-logic slice until the Slice-3 runtime wiring lands.

Refs #9105

🤖 Generated with [Claude Code](https://claude.com/claude-code)