### PR TITLE
test(lifeops): pin retry-beats-terminal on the last dispatch step (#8833)

### DIFF
--- a/plugins/plugin-personal-assistant/test/contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/contracts.test.ts
@@ -402,6 +402,44 @@ describe("decideDispatchPolicy (W1-F dispatch policy)", () => {
       message: undefined,
     });
   });
+
+  it("rate_limited on the last step still retries (does not fall through to fail)", () => {
+    // Retry-with-backoff is evaluated BEFORE the isLastStep terminal check, so a
+    // transient rate-limit on the final step reschedules the same step rather
+    // than failing the whole dispatch. Pins that ordering against a refactor.
+    const result: DispatchResult = {
+      ok: false,
+      reason: "rate_limited",
+      userActionable: false,
+    };
+    expect(
+      decideDispatchPolicy(result, {
+        currentStepIndex: 2,
+        totalSteps: 3,
+        defaultRetryAfterMinutes: 7,
+      }),
+    ).toEqual({
+      kind: "retry",
+      retryAfterMinutes: 7,
+      reason: "rate_limited",
+    });
+  });
+
+  it("explicit retryAfterMinutes on the last step still retries (beats terminal)", () => {
+    const result: DispatchResult = {
+      ok: false,
+      reason: "transport_error",
+      retryAfterMinutes: 15,
+      userActionable: false,
+    };
+    expect(
+      decideDispatchPolicy(result, { currentStepIndex: 0, totalSteps: 1 }),
+    ).toEqual({
+      kind: "retry",
+      retryAfterMinutes: 15,
+      reason: "transport_error",
+    });
+  });
 });
 
 describe("PRIORITY_TO_POSTURE", () => {


### PR DESCRIPTION
Closes the one net-new pure-logic gap in the LifeOps dispatch-policy suite (#8833): `decideDispatchPolicy` evaluates the retry / rate-limit branches **before** the `isLastStep` terminal check, so a transient failure on the LAST step intentionally retries rather than failing the whole dispatch — but no test pinned that ordering (the existing `rate_limited` and `retryAfterMinutes` cases all used non-final steps).

Adds 2 cases to the existing green `decideDispatchPolicy` block in `plugins/plugin-personal-assistant/test/contracts.test.ts`:
1. `rate_limited` on the last step (`currentStepIndex: 2 / totalSteps: 3`) → `retry` with the default backoff, not `fail`.
2. explicit `retryAfterMinutes` on the last step (`currentStepIndex: 0 / totalSteps: 1`) → `retry`, not `fail`.

Locks in that retry-with-backoff dominates last-step termination, so a future reorder of the `if` chain can't silently turn a rate-limit into a terminal failure. Pure function, no creds/runtime.

## Evidence
```
bunx vitest run …/contracts.test.ts -t "decideDispatchPolicy"  →  9 passed (7 existing + 2 new)
```
biome clean.

Refs #8833

🤖 Generated with [Claude Code](https://claude.com/claude-code)