### PR TITLE
feat(computeruse): per-notch scroll + manual-drag fallback (#9105 M3.5)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the nutjs driver input-correctness helpers (M3.5, #9105).
+ *
+ * Per-notch scroll clamping and manual-drag interpolation are pure and run in
+ * the default lane. The real-driver behavior (coordinate consistency + that
+ * scroll/drag actually fire) is exercised by the gated real-driver lane.
+ *
+ * NOTE: an empirical probe on the Windows backend showed nutjs is
+ * logical-coordinate-consistent here (setPosition(x,y) → cursor exactly (x,y)),
+ * so NO DPI scale-factor multiply is applied to input dispatch — adding one
+ * would mis-place clicks. See #9105.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  clampScrollNotches,
+  interpolateDragSteps,
+} from "../platform/nut-driver.js";
+
+describe("clampScrollNotches", () => {
+  it("clamps to the 1..20 notch range and rounds", () => {
+    expect(clampScrollNotches(3)).toBe(3);
+    expect(clampScrollNotches(0)).toBe(1);
+    expect(clampScrollNotches(-5)).toBe(1);
+    expect(clampScrollNotches(999)).toBe(20);
+    expect(clampScrollNotches(2.7)).toBe(3);
+  });
+});
+
+describe("interpolateDragSteps", () => {
+  it("produces integer waypoints ending exactly at the target", () => {
+    const pts = interpolateDragSteps(0, 0, 100, 50, 5);
+    expect(pts).toHaveLength(5);
+    // Excludes the start, includes the end.
+    expect(pts[pts.length - 1]).toEqual({ x: 100, y: 50 });
+    expect(pts[0]).toEqual({ x: 20, y: 10 });
+    expect(
+      pts.every((p) => Number.isInteger(p.x) && Number.isInteger(p.y)),
+    ).toBe(true);
+  });
+
+  it("always lands on the target even with a single step", () => {
+    expect(interpolateDragSteps(10, 10, 33, 44, 1)).toEqual([{ x: 33, y: 44 }]);
+  });
+
+  it("is monotonic toward the target", () => {
+    const pts = interpolateDragSteps(0, 0, 200, 0, 10);
+    for (let i = 1; i < pts.length; i += 1) {
+      expect(pts[i].x).toBeGreaterThanOrEqual(pts[i - 1].x);
+    }
+    expect(pts[pts.length - 1].x).toBe(200);
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/nut-driver.ts
+++ b/plugins/plugin-computeruse/src/platform/nut-driver.ts
@@ -228,6 +228,63 @@ export async function nutMouseMove(x: number, y: number): Promise<void> {
   await m.mouse.setPosition(new m.Point(validateInt(x), validateInt(y)));
 }
 
+/** Inter-notch / inter-step pacing (ms) — small, just enough to defeat event
+ * coalescing in fast consumers (e.g. Chromium's MouseWheelEventQueue) without
+ * making input feel sluggish. */
+const SCROLL_NOTCH_DELAY_MS = 8;
+const DRAG_STEP_DELAY_MS = 8;
+const DRAG_STEPS = 20;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Clamp a requested scroll amount to a safe per-notch count (1..20). Pure. */
+export function clampScrollNotches(amount: number): number {
+  return Math.max(1, Math.min(validateInt(amount), 20));
+}
+
+/**
+ * Interpolated integer waypoints from (x1,y1) to (x2,y2) over `steps` moves
+ * (excludes the start, includes the end). Pure — exported for unit tests.
+ */
+export function interpolateDragSteps(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  steps: number = DRAG_STEPS,
+): Array<{ x: number; y: number }> {
+  const n = Math.max(1, Math.floor(steps));
+  const points: Array<{ x: number; y: number }> = [];
+  for (let i = 1; i <= n; i += 1) {
+    const t = i / n;
+    points.push({
+      x: Math.round(x1 + (x2 - x1) * t),
+      y: Math.round(y1 + (y2 - y1) * t),
+    });
+  }
+  return points;
+}
+
+async function manualDragMove(
+  m: NutModule,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): Promise<void> {
+  // Interpolated move with the button held — fallback for libnut builds whose
+  // `mouse.move(straightTo)` does not carry a real button-down on Windows.
+  const points = interpolateDragSteps(x1, y1, x2, y2);
+  for (let i = 0; i < points.length; i += 1) {
+    await m.mouse.setPosition(new m.Point(points[i].x, points[i].y));
+    if (i < points.length - 1) await sleep(DRAG_STEP_DELAY_MS);
+  }
+}
+
 export async function nutDrag(
   x1: number,
   y1: number,
@@ -242,7 +299,11 @@ export async function nutDrag(
   await m.mouse.setPosition(new m.Point(sx1, sy1));
   await m.mouse.pressButton(m.Button.LEFT);
   try {
-    await m.mouse.move(m.straightTo(new m.Point(sx2, sy2)));
+    try {
+      await m.mouse.move(m.straightTo(new m.Point(sx2, sy2)));
+    } catch {
+      await manualDragMove(m, sx1, sy1, sx2, sy2);
+    }
   } finally {
     await m.mouse.releaseButton(m.Button.LEFT);
   }
@@ -257,12 +318,16 @@ export async function nutScroll(
   const m = nut();
   const sx = validateInt(x);
   const sy = validateInt(y);
-  const clicks = Math.max(1, Math.min(validateInt(amount), 20));
+  const clicks = clampScrollNotches(amount);
   await m.mouse.setPosition(new m.Point(sx, sy));
-  if (direction === "up") await m.mouse.scrollUp(clicks);
-  else if (direction === "down") await m.mouse.scrollDown(clicks);
-  else if (direction === "left") await m.mouse.scrollLeft(clicks);
-  else await m.mouse.scrollRight(clicks);
+  // Emit one wheel notch at a time so coalescing consumers register each notch.
+  for (let i = 0; i < clicks; i += 1) {
+    if (direction === "up") await m.mouse.scrollUp(1);
+    else if (direction === "down") await m.mouse.scrollDown(1);
+    else if (direction === "left") await m.mouse.scrollLeft(1);
+    else await m.mouse.scrollRight(1);
+    if (i < clicks - 1) await sleep(SCROLL_NOTCH_DELAY_MS);
+  }
 }
 
 // ── Keyboard ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Milestone **M3.5** of EPIC #9105 — nutjs input-correctness robustness (adopted from open-computer-use).

## Changes
- **Per-notch scroll**: `nutScroll` emits one wheel notch at a time (`clampScrollNotches` → 1..20, 8ms pacing) so coalescing consumers (e.g. Chromium's `MouseWheelEventQueue`) register every notch instead of dropping a batched delta.
- **Manual-drag fallback**: `nutDrag` adds an interpolated down→move→up fallback (`interpolateDragSteps`) for libnut builds whose `move(straightTo)` doesn't carry a real button-down on Windows.
- Extracted pure helpers (`clampScrollNotches`, `interpolateDragSteps`) with default-lane unit coverage.

## DPI finding (important)
The issue planned a "multiply logical coords by scaleFactor before move" fix. An **empirical probe on the Windows backend disproved the need**: nutjs `setPosition(x,y)` lands the cursor at **exactly** `(x,y)` (dx=dy=0, ratio 1.0) — it is logical-coordinate-consistent on our `@nut-tree-fork/nut-js` build. Adding the multiply would **mis-place** clicks. No scale-factor multiply is applied to input dispatch; the finding is recorded in code + tests so it isn't reintroduced.

## Evidence (local Windows backend)
- Real-driver probe: `move(640,400)` → cursor `(640,400)` consistent; per-notch scroll ×3 (197ms) and interpolated drag (581ms) both fire without error.
- `nut-driver-input.test.ts`: 4 passed (clamp + interpolation).
- Full computeruse suite: **403 passed / 5 skipped (44 files)**; typecheck + biome clean.

Part of #9105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)