### PR TITLE
feat(computeruse): structured ScreenshotErrorCode contract for capture failures (#9105 M3.5)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/screenshot-errors.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/screenshot-errors.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the structured screenshot error contract (#9105 M3.5).
+ *
+ * Verifies the code-classification mapping has a single source of truth and
+ * that `tagScreenshotError` is purely additive — a `PermissionDeniedError`
+ * keeps its identity while gaining a `screenshotErrorCode`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createPermissionDeniedError,
+  isPermissionDeniedError,
+} from "../platform/permissions.js";
+import {
+  classifyScreenshotErrorCode,
+  createScreenshotError,
+  isScreenshotError,
+  type ScreenshotErrorCode,
+  tagScreenshotError,
+} from "../platform/screenshot-errors.js";
+
+describe("classifyScreenshotErrorCode", () => {
+  it("maps a permission-denied error to permission_denied", () => {
+    const err = createPermissionDeniedError({
+      permissionType: "screen_recording",
+      operation: "screenshot_capture",
+      message: "Screen Recording permission required.",
+    });
+    expect(classifyScreenshotErrorCode(err)).toBe("permission_denied");
+  });
+
+  it("maps the Linux no-tool message to tool_missing", () => {
+    const err = new Error(
+      "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
+    );
+    expect(classifyScreenshotErrorCode(err)).toBe("tool_missing");
+  });
+
+  it("maps ENOENT (spawned tool not found) to tool_missing", () => {
+    const err = new Error("spawn scrot ENOENT");
+    expect(classifyScreenshotErrorCode(err)).toBe("tool_missing");
+  });
+
+  it("maps an empty-output message to empty_output", () => {
+    expect(
+      classifyScreenshotErrorCode(
+        new Error("screencapture returned an empty file."),
+      ),
+    ).toBe("empty_output");
+    expect(
+      classifyScreenshotErrorCode(
+        new Error("capture produced a zero-byte image"),
+      ),
+    ).toBe("empty_output");
+  });
+
+  it("maps timeout messages to timeout", () => {
+    expect(classifyScreenshotErrorCode(new Error("Command timed out"))).toBe(
+      "timeout",
+    );
+    expect(
+      classifyScreenshotErrorCode(
+        new Error("spawnSync screencapture ETIMEDOUT"),
+      ),
+    ).toBe("timeout");
+  });
+
+  it("falls back to capture_failed for unrecognized errors", () => {
+    expect(classifyScreenshotErrorCode(new Error("something odd"))).toBe(
+      "capture_failed",
+    );
+  });
+
+  it("classifies a non-Error value as capture_failed", () => {
+    expect(classifyScreenshotErrorCode("weird string failure")).toBe(
+      "capture_failed",
+    );
+  });
+});
+
+describe("tagScreenshotError", () => {
+  it("annotates an Error in place and preserves its identity", () => {
+    const original = new Error("Command timed out");
+    const tagged = tagScreenshotError(original, "screenshot_capture");
+    expect(tagged).toBe(original); // same object — additive, not a wrapper
+    expect(tagged.screenshotErrorCode).toBe("timeout");
+    expect(tagged.operation).toBe("screenshot_capture");
+    expect(isScreenshotError(tagged)).toBe(true);
+  });
+
+  it("keeps a PermissionDeniedError recognizable while adding the code", () => {
+    const perm = createPermissionDeniedError({
+      permissionType: "screen_recording",
+      operation: "screenshot_capture",
+      message: "Screen Recording permission required.",
+    });
+    const tagged = tagScreenshotError(perm, "screenshot_region");
+    // Still a permission-denied error for existing callers...
+    expect(isPermissionDeniedError(tagged)).toBe(true);
+    // ...AND now also a screenshot error with the right code.
+    expect(isScreenshotError(tagged)).toBe(true);
+    expect(tagged.screenshotErrorCode).toBe("permission_denied");
+    // The error carried its own operation, so it is not overwritten.
+    expect(tagged.operation).toBe("screenshot_capture");
+  });
+
+  it("is idempotent", () => {
+    const err = new Error("No screenshot tool available.");
+    const once = tagScreenshotError(err, "screenshot_capture");
+    const twice = tagScreenshotError(once, "screenshot_region");
+    expect(twice).toBe(once);
+    expect(twice.screenshotErrorCode).toBe("tool_missing");
+    expect(twice.operation).toBe("screenshot_capture");
+  });
+
+  it("wraps a non-Error value in a fresh ScreenshotError", () => {
+    const tagged = tagScreenshotError("kernel said no", "screenshot_capture");
+    expect(isScreenshotError(tagged)).toBe(true);
+    expect(tagged.screenshotErrorCode).toBe("capture_failed");
+    expect(tagged.operation).toBe("screenshot_capture");
+    expect(tagged.message).toBe("kernel said no");
+  });
+
+  it("defaults operation only when the error lacks one", () => {
+    const noOp = new Error("boom");
+    const tagged = tagScreenshotError(noOp, "screenshot_region");
+    expect(tagged.operation).toBe("screenshot_region");
+  });
+});
+
+describe("createScreenshotError / isScreenshotError", () => {
+  it("builds a fully-formed ScreenshotError", () => {
+    const err = createScreenshotError(
+      "empty_output",
+      "screenshot_capture",
+      "empty image",
+      "underlying detail",
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ScreenshotError");
+    expect(err.screenshotErrorCode).toBe("empty_output");
+    expect(err.operation).toBe("screenshot_capture");
+    expect(err.details).toBe("underlying detail");
+    expect(isScreenshotError(err)).toBe(true);
+  });
+
+  it("rejects plain errors and non-errors from the type guard", () => {
+    expect(isScreenshotError(new Error("plain"))).toBe(false);
+    expect(isScreenshotError({ screenshotErrorCode: "timeout" })).toBe(false);
+    expect(isScreenshotError(null)).toBe(false);
+  });
+
+  it("covers every declared error code", () => {
+    const codes: ScreenshotErrorCode[] = [
+      "permission_denied",
+      "tool_missing",
+      "empty_output",
+      "timeout",
+      "capture_failed",
+    ];
+    for (const code of codes) {
+      const err = createScreenshotError(code, "op", `msg-${code}`);
+      expect(err.screenshotErrorCode).toBe(code);
+    }
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/screenshot-errors.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-errors.ts
@@ -1,0 +1,125 @@
+/**
+ * Structured screenshot error contract (issue #9105, M3.5).
+ *
+ * Capture can fail for several distinct reasons, and a caller (the CUA Brain,
+ * the GET_SCREEN op, the approval/telemetry layer) wants to react differently
+ * to each: a missing OS permission needs a "grant access" prompt; a missing CLI
+ * tool needs an "install scrot/ImageMagick" hint; an empty buffer or a timeout
+ * is a transient retry. Before this contract, those were indistinguishable —
+ * callers had to regex the human-readable message.
+ *
+ * This module adds a machine-readable {@link ScreenshotErrorCode} **additively**:
+ * `tagScreenshotError` annotates the *existing* thrown error object with a code
+ * rather than replacing it, so a `PermissionDeniedError` keeps its identity
+ * (`isPermissionDeniedError` stays true) while also gaining a
+ * `screenshotErrorCode` of `"permission_denied"`. No existing caller breaks; new
+ * callers can switch on the code.
+ */
+
+import { isPermissionDeniedError } from "./permissions.js";
+
+export type ScreenshotErrorCode =
+  /** An OS privacy permission (Screen Recording / Accessibility) is denied. */
+  | "permission_denied"
+  /** No screenshot CLI tool is installed (e.g. Linux without scrot/import). */
+  | "tool_missing"
+  /** The capture tool ran but produced an empty/zero-byte image. */
+  | "empty_output"
+  /** The capture command exceeded its timeout. */
+  | "timeout"
+  /** Any other capture failure. */
+  | "capture_failed";
+
+/** An `Error` carrying a machine-readable {@link ScreenshotErrorCode}. */
+export interface ScreenshotError extends Error {
+  readonly screenshotErrorCode: ScreenshotErrorCode;
+  /** The capture operation that failed (e.g. `screenshot_capture`). */
+  readonly operation: string;
+  /** Underlying error message, when this wraps a lower-level failure. */
+  readonly details?: string;
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isScreenshotError(value: unknown): value is ScreenshotError {
+  return (
+    value instanceof Error &&
+    "screenshotErrorCode" in value &&
+    typeof (value as { screenshotErrorCode?: unknown }).screenshotErrorCode ===
+      "string"
+  );
+}
+
+export function createScreenshotError(
+  code: ScreenshotErrorCode,
+  operation: string,
+  message: string,
+  details?: string,
+): ScreenshotError {
+  const error = new Error(message) as Mutable<ScreenshotError>;
+  error.name = "ScreenshotError";
+  error.screenshotErrorCode = code;
+  error.operation = operation;
+  if (details !== undefined) error.details = details;
+  return error;
+}
+
+/**
+ * Map any thrown value to a {@link ScreenshotErrorCode} by inspecting its type
+ * and message. Permission denials win first (they are typed); the rest are
+ * recognized from the well-known message shapes the capture functions throw.
+ * Pure — exported so the mapping has a single, testable source of truth.
+ */
+export function classifyScreenshotErrorCode(
+  error: unknown,
+): ScreenshotErrorCode {
+  if (isPermissionDeniedError(error)) return "permission_denied";
+  if (isScreenshotError(error)) return error.screenshotErrorCode;
+
+  const message = toMessage(error).toLowerCase();
+  if (
+    /no screenshot tool|install (imagemagick|scrot|gnome-screenshot)|command not found|\benoent\b|not recognized as (?:the name of )?an? (?:internal|cmdlet)/.test(
+      message,
+    )
+  ) {
+    return "tool_missing";
+  }
+  if (
+    /empty (?:file|output|image|buffer)|zero[- ]?byte|returned an empty/.test(
+      message,
+    )
+  ) {
+    return "empty_output";
+  }
+  if (/timed out|timeout|\betimedout\b/.test(message)) {
+    return "timeout";
+  }
+  return "capture_failed";
+}
+
+/**
+ * Annotate `error` with a {@link ScreenshotErrorCode} and return it. Additive:
+ * an `Error` (including a `PermissionDeniedError`) is mutated in place so its
+ * identity and existing fields are preserved; a non-`Error` value is wrapped in
+ * a fresh {@link ScreenshotError}. Idempotent — an already-tagged error is
+ * returned unchanged.
+ */
+export function tagScreenshotError(
+  error: unknown,
+  operation: string,
+): ScreenshotError {
+  if (isScreenshotError(error)) return error;
+
+  const code = classifyScreenshotErrorCode(error);
+  if (error instanceof Error) {
+    const tagged = error as Mutable<ScreenshotError>;
+    tagged.screenshotErrorCode = code;
+    if (typeof tagged.operation !== "string") tagged.operation = operation;
+    return tagged;
+  }
+  return createScreenshotError(code, operation, toMessage(error));
+}

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -20,6 +20,7 @@ import {
   createPermissionDeniedError,
   isPermissionDeniedError,
 } from "./permissions.js";
+import { tagScreenshotError } from "./screenshot-errors.js";
 
 const SCREEN_RECORDING_OPERATION_MESSAGE =
   "macOS Screen Recording permission is required for screenshots. Grant access in System Settings > Privacy & Security > Screen Recording, then retry.";
@@ -63,19 +64,21 @@ export function captureScreenshot(region?: ScreenRegion): Buffer {
       /* ignore */
     }
 
+    const operation = region ? "screenshot_region" : "screenshot_capture";
+
     if (isPermissionDeniedError(err)) {
-      throw err;
+      throw tagScreenshotError(err, operation);
     }
 
     const permissionError = classifyPermissionDeniedError(err, {
       permissionType: "screen_recording",
-      operation: region ? "screenshot_region" : "screenshot_capture",
+      operation,
     });
     if (permissionError) {
-      throw permissionError;
+      throw tagScreenshotError(permissionError, operation);
     }
 
-    throw err;
+    throw tagScreenshotError(err, operation);
   }
 }
 


### PR DESCRIPTION
## What

Adds a structured, machine-readable error contract for screenshot capture failures in `@elizaos/plugin-computeruse` — the "structured `ScreenshotErrorCode` contract" called for in the Computer-Use × Vision EPIC (#9105, §6 / M3.5).

Capture fails for distinct reasons that callers must react to differently — a denied OS permission (prompt the user), a missing CLI tool (tell them to install scrot/ImageMagick), an empty buffer or timeout (transient retry). Before this, those were indistinguishable: callers had to regex the human-readable message.

## Changes

- **New `src/platform/screenshot-errors.ts`** — `ScreenshotErrorCode` = `permission_denied | tool_missing | empty_output | timeout | capture_failed`, plus:
  - `classifyScreenshotErrorCode(err)` — the single pure source of truth mapping an error to a code (permission denials win first; the rest matched from the well-known message shapes the capture functions throw).
  - `tagScreenshotError(err, op)` — **additive**: annotates the *existing* thrown error in place, so a `PermissionDeniedError` keeps its identity (`isPermissionDeniedError` stays `true`) while also gaining `screenshotErrorCode`. Idempotent; wraps non-`Error` values.
  - `createScreenshotError` / `isScreenshotError` helpers.
- **`src/platform/screenshot.ts`** — `captureScreenshot()` now routes every throw path (permission and non-permission alike) through `tagScreenshotError`, so failures carry a code.

**Additive only — no input or capture behavior changes.** Existing callers that branch on `isPermissionDeniedError` are unaffected.

## Verification (macOS)

- `src/__tests__/screenshot-errors.test.ts` — **15 passed**: classification of all five codes, additive `PermissionDeniedError` tagging (stays permission-denied *and* gains the code), idempotence, non-`Error` wrapping, type-guard rejection.
- Full `plugin-computeruse` suite: **413 passed / 6 skipped** (44 files).
- `tsgo` typecheck clean; biome clean.

Part of #9105. No follow-up required for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
