### PR TITLE
test(task-coordinator): cover the orchestrator-status universal slash command (#8790)

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-command.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-command.test.ts
@@ -1,0 +1,95 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import {
+  commandVisibleForSurface,
+  findCommandByKey,
+  initForRuntime,
+  serializeCommand,
+  useRuntime,
+} from "@elizaos/plugin-commands";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ORCHESTRATOR_STATUS_COMMAND_ACTION,
+  ORCHESTRATOR_STATUS_COMMAND_KEY,
+  ORCHESTRATOR_VIEW_ID,
+  orchestratorStatusCommandAction,
+  registerOrchestratorCommands,
+} from "../../src/orchestrator-command";
+
+/**
+ * Locks the only non-core-plugin slash-command contribution on develop
+ * (task-coordinator's `/orchestrator-status`, #8790 / PR #9104), which shipped
+ * untested. Proves a view-owning app plugin lights up the universal command
+ * surface end to end: registration shape, slash-only validate (the misrouting
+ * guard), a deterministic no-LLM handler, and the gui/tui surface contract.
+ */
+const AGENT = "agent-orchestrator-command-test";
+
+const runtime = { agentId: AGENT } as IAgentRuntime;
+const message = (text: string): Memory =>
+  ({ content: { text } }) as unknown as Memory;
+
+describe("orchestrator slash command (#8790)", () => {
+  beforeEach(() => {
+    initForRuntime(AGENT);
+    useRuntime(AGENT);
+    registerOrchestratorCommands(AGENT);
+  });
+
+  it("registers a view-scoped, agent-target command", () => {
+    const cmd = findCommandByKey(ORCHESTRATOR_STATUS_COMMAND_KEY);
+    expect(cmd).toBeDefined();
+    expect(cmd?.target).toEqual({
+      kind: "agent",
+      action: ORCHESTRATOR_STATUS_COMMAND_ACTION,
+    });
+    expect(cmd?.views).toEqual([ORCHESTRATOR_VIEW_ID]);
+    expect(cmd?.surfaces).toEqual(["gui", "tui"]);
+    expect(cmd?.acceptsArgs).toBe(false);
+  });
+
+  it("validate() matches the slash command only, never conversational text", async () => {
+    const validate = orchestratorStatusCommandAction.validate;
+    expect(validate).toBeDefined();
+    if (!validate) return;
+    expect(await validate(runtime, message("/orchestrator-status"))).toBe(true);
+    expect(
+      await validate(runtime, message("what is the orchestrator status?")),
+    ).toBe(false);
+    expect(await validate(runtime, message("/help"))).toBe(false);
+    expect(await validate(runtime, message(""))).toBe(false);
+  });
+
+  it("handler returns a deterministic reply via callback, with no LLM call", async () => {
+    const callback = vi.fn(async () => [] as Memory[]);
+    const result = await orchestratorStatusCommandAction.handler(
+      runtime,
+      message("/orchestrator-status"),
+      undefined,
+      undefined,
+      callback,
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({
+      text: "Orchestrator is online.",
+      source: "command",
+    });
+    expect(result).toEqual({ success: true, text: "Orchestrator is online." });
+  });
+
+  it("serializes onto the wire shape and honors the gui/tui surface contract", () => {
+    const cmd = findCommandByKey(ORCHESTRATOR_STATUS_COMMAND_KEY);
+    expect(cmd).toBeDefined();
+    if (!cmd) return;
+    const wire = serializeCommand(cmd);
+    expect(wire.target).toEqual({
+      kind: "agent",
+      action: ORCHESTRATOR_STATUS_COMMAND_ACTION,
+    });
+    expect(wire.views).toEqual([ORCHESTRATOR_VIEW_ID]);
+    // Visible on the surfaces it declares, filtered out everywhere else.
+    expect(commandVisibleForSurface(cmd.surfaces, "gui")).toBe(true);
+    expect(commandVisibleForSurface(cmd.surfaces, "tui")).toBe(true);
+    expect(commandVisibleForSurface(cmd.surfaces, "discord")).toBe(false);
+    expect(commandVisibleForSurface(cmd.surfaces, "telegram")).toBe(false);
+  });
+});


### PR DESCRIPTION
The only non-core-plugin command contribution on develop — task-coordinator's `/orchestrator-status` (`plugins/plugin-task-coordinator/src/orchestrator-command.ts`, landed by #9104 to prove the universal slash-command contract with a non-core plugin) — shipped **untested**. This adds a dedicated unit test.

`plugins/plugin-task-coordinator/__tests__/unit/orchestrator-command.test.ts` (the package's vitest config already includes `__tests__/**` and aliases `@elizaos/plugin-commands` to source, so it runs keyless on Windows). Asserts the four contract pieces:
1. **Registration** — `findCommandByKey` returns the command with `target: { kind: "agent", action }`, `views: ["orchestrator"]`, `surfaces: ["gui","tui"]`, `acceptsArgs: false`.
2. **Slash-only validate** (the misrouting guard) — true for `/orchestrator-status`; false for conversational text, a different command (`/help`), and empty text.
3. **Deterministic handler** — callback fires exactly once with `{ text: "Orchestrator is online.", source: "command" }` and returns `{ success: true, text }`, with no LLM call.
4. **Surface contract** — `serializeCommand` projects `target.kind === "agent"` + `views`, and `commandVisibleForSurface` keeps it visible on gui/tui but filters it out of discord/telegram.

## Evidence
```
bunx vitest run __tests__/unit/orchestrator-command.test.ts  →  4 passed (4)
```
biome clean.

Refs #8790

🤖 Generated with [Claude Code](https://claude.com/claude-code)