### PR TITLE
feat(computeruse): Brain frame-dHash describe cache + token counters (#9105 M3)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/brain-dhash-cache.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/brain-dhash-cache.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Brain frame-dHash describe-cache (#9105 M3).
+ *
+ * The WS2 MemoryArbiter only dedups IMAGE_DESCRIPTION for local backends; the
+ * remote path re-burns tokens on an identical screen every step. The Brain's
+ * call-site dHash cache skips the model entirely for the same frame + goal.
+ * Uses real synthesized PNGs so frameDhash() is meaningful.
+ */
+
+import { deflateSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { Brain } from "../actor/brain.js";
+import type { DisplayCapture } from "../platform/capture.js";
+import type { Scene } from "../scene/scene-types.js";
+
+// ── minimal PNG synthesizer (16x16 RGB) ──────────────────────────────────────
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) {
+    crc ^= buf[i];
+    for (let k = 0; k < 8; k += 1) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+function pngChunk(type: string, data: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const t = Buffer.from(type, "ascii");
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([t, data])));
+  return Buffer.concat([len, t, data, crc]);
+}
+function makeTinyPng(seed = 0): Buffer {
+  const w = 16;
+  const h = 16;
+  const rows: number[] = [];
+  for (let y = 0; y < h; y += 1) {
+    rows.push(0);
+    for (let x = 0; x < w; x += 1) {
+      const v = ((x + seed) * 16) % 255;
+      rows.push(v, v, v);
+    }
+  }
+  const idat = deflateSync(Buffer.from(rows));
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 2;
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  return Buffer.concat([
+    sig,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", idat),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function dummyScene(): Scene {
+  return {
+    timestamp: 1,
+    displays: [
+      {
+        id: 0,
+        bounds: [0, 0, 16, 16],
+        scaleFactor: 1,
+        primary: true,
+        name: "f",
+      },
+    ],
+    focused_window: null,
+    apps: [],
+    ocr: [],
+    ax: [],
+    vlm_scene: null,
+    vlm_elements: null,
+  };
+}
+function captures(frame: Buffer): Map<number, DisplayCapture> {
+  const m = new Map<number, DisplayCapture>();
+  m.set(0, {
+    display: {
+      id: 0,
+      bounds: [0, 0, 16, 16],
+      scaleFactor: 1,
+      primary: true,
+      name: "f",
+    },
+    frame,
+  });
+  return m;
+}
+
+const VALID = JSON.stringify({
+  scene_summary: "OK",
+  target_display_id: 0,
+  roi: [],
+  proposed_action: { kind: "click", ref: "t0-1", rationale: "Save" },
+});
+
+describe("Brain frame-dHash describe cache (M3)", () => {
+  it("serves an identical frame+goal from cache without re-invoking the model", async () => {
+    let calls = 0;
+    const brain = new Brain(null, {
+      invokeModel: async () => {
+        calls += 1;
+        return VALID;
+      },
+    });
+    const frame = makeTinyPng(7);
+    const first = await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "click save",
+      captures: captures(frame),
+    });
+    const second = await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "click save",
+      captures: captures(makeTinyPng(7)), // identical pixels → identical dHash
+    });
+    expect(calls).toBe(1);
+    expect(second).toEqual(first);
+    expect(brain.getStats()).toEqual({ invocations: 1, cacheHits: 1 });
+  });
+
+  it("re-invokes for a visually different frame", async () => {
+    let calls = 0;
+    const brain = new Brain(null, {
+      invokeModel: async () => {
+        calls += 1;
+        return VALID;
+      },
+    });
+    await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "g",
+      captures: captures(makeTinyPng(0)),
+    });
+    await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "g",
+      captures: captures(makeTinyPng(60)),
+    });
+    expect(calls).toBe(2);
+    expect(brain.getStats().cacheHits).toBe(0);
+  });
+
+  it("re-invokes when the goal changes even for the same frame", async () => {
+    let calls = 0;
+    const brain = new Brain(null, {
+      invokeModel: async () => {
+        calls += 1;
+        return VALID;
+      },
+    });
+    const frame = makeTinyPng(3);
+    await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "goal A",
+      captures: captures(frame),
+    });
+    await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "goal B",
+      captures: captures(makeTinyPng(3)),
+    });
+    expect(calls).toBe(2);
+  });
+});

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -33,12 +33,23 @@ import {
   ModelType,
 } from "@elizaos/core";
 import type { DisplayCapture } from "../platform/capture.js";
+import { frameDhash } from "../scene/dhash.js";
 import type { Scene } from "../scene/scene-types.js";
 import { serializeSceneForPrompt } from "../scene/serialize.js";
 import type { BrainOutput, BrainRoi } from "./types.js";
 
 export const BRAIN_MAX_PIXELS = 1_310_720; // 1280 * 32 * 32 ≈ 1.3 MP cap
 export const BRAIN_MAX_ROIS = 2;
+/** Bound on the per-Brain dHash→BrainOutput cache (LRU-ish, oldest evicted). */
+export const BRAIN_DHASH_CACHE_MAX = 16;
+
+/** Token-accounting snapshot for a Brain instance (#9105 M3). */
+export interface BrainStats {
+  /** IMAGE_DESCRIPTION model calls actually issued. */
+  invocations: number;
+  /** Describe calls served from the frame-dHash cache (no model call). */
+  cacheHits: number;
+}
 
 export class BrainParseError extends Error {
   constructor(
@@ -75,10 +86,43 @@ export interface BrainInput {
  * test fixtures.
  */
 export class Brain {
+  /**
+   * Frame-dHash → BrainOutput cache. The WS2 MemoryArbiter only dedups the
+   * IMAGE_DESCRIPTION call for LOCAL backends; the remote/cloud path bypasses
+   * it, so an identical screen re-burns tokens every step. This call-site cache
+   * skips the model entirely when the same frame is observed for the same goal,
+   * cutting the dominant CUA-loop token cost regardless of backend (#9105 M3).
+   */
+  private readonly dhashCache = new Map<string, BrainOutput>();
+  private invocations = 0;
+  private cacheHits = 0;
+
   constructor(
     private readonly runtime: IAgentRuntime | null,
     private readonly deps: BrainDeps = {},
   ) {}
+
+  /** Token-accounting snapshot (model calls vs cache hits). */
+  getStats(): BrainStats {
+    return { invocations: this.invocations, cacheHits: this.cacheHits };
+  }
+
+  private cacheKey(frame: Buffer, goal: string): string | null {
+    const dh = frameDhash(frame);
+    return dh === null ? null : `${dh.toString()}::${goal}`;
+  }
+
+  private rememberOutput(key: string | null, output: BrainOutput): BrainOutput {
+    if (key) {
+      // Evict oldest to bound memory.
+      if (this.dhashCache.size >= BRAIN_DHASH_CACHE_MAX) {
+        const oldest = this.dhashCache.keys().next().value;
+        if (oldest !== undefined) this.dhashCache.delete(oldest);
+      }
+      this.dhashCache.set(key, output);
+    }
+    return output;
+  }
 
   async observeAndPlan(input: BrainInput): Promise<BrainOutput> {
     if (input.captures.size === 0) {
@@ -96,8 +140,21 @@ export class Brain {
     if (!targetCapture) {
       throw new Error("[computeruse/brain] could not pick a target capture");
     }
+
+    // Frame-dHash cache: identical screen + goal → reuse the prior plan, skip
+    // the (possibly remote) IMAGE_DESCRIPTION call.
+    const key = this.cacheKey(targetCapture.frame, input.goal);
+    if (key) {
+      const cached = this.dhashCache.get(key);
+      if (cached) {
+        this.cacheHits += 1;
+        return cached;
+      }
+    }
+
     const dataUrl = await encodeForBrain(targetCapture.frame);
     const prompt = brainPromptFor(compactScene, input.goal, /*strict*/ false);
+    this.invocations += 1;
     const first = await this.invoke({
       imageUrl: dataUrl,
       prompt,
@@ -112,13 +169,14 @@ export class Brain {
     };
     const rawFirst = extractText(first);
     const parsed = tryParse(rawFirst);
-    if (parsed) return enforceCaps(parsed);
+    if (parsed) return this.rememberOutput(key, enforceCaps(parsed));
     // Strict retry — same image, stricter prompt.
     const strictPrompt = brainPromptFor(
       compactScene,
       input.goal,
       /*strict*/ true,
     );
+    this.invocations += 1;
     const second = await this.invoke({
       imageUrl: dataUrl,
       prompt: strictPrompt,
@@ -126,7 +184,7 @@ export class Brain {
     });
     const rawSecond = extractText(second);
     const parsedRetry = tryParse(rawSecond);
-    if (parsedRetry) return enforceCaps(parsedRetry);
+    if (parsedRetry) return this.rememberOutput(key, enforceCaps(parsedRetry));
     throw new BrainParseError(
       "Brain output is not valid JSON conforming to BrainOutput after retry",
       rawSecond,


### PR DESCRIPTION
Focused, low-risk core of milestone **M3** (EPIC #9105): the **dHash-gated describe skip** — the dominant CUA-loop token saving.

## Why
The Brain calls `useModel(IMAGE_DESCRIPTION)` every step. The WS2 MemoryArbiter only dedups that for **local** backends; the **remote/cloud** path re-burns tokens on an unchanged screen every step.

## What
`Brain` keeps a bounded `(frameDhash :: goal) → BrainOutput` cache and **skips the model entirely** when the same frame is observed for the same goal — backend-agnostic.
- `observeAndPlan` computes `frameDhash(targetCapture.frame)`; cache hit → return prior plan, no model call.
- `getStats()` → `{invocations, cacheHits}` for per-turn token accounting.
- Bounded (`BRAIN_DHASH_CACHE_MAX=16`, oldest-evicted). Frames that don't decode bypass the cache, so existing fake-PNG tests are unaffected (no behavior change).

## Evidence
- `brain-dhash-cache.test.ts`: identical frame+goal → 1 model call + 1 cache hit (outputs equal); different frame or different goal → re-invoke. Real synthesized PNGs so `frameDhash` is meaningful.
- Brain regression + computeruse suite green; typecheck + biome clean.

## Scope note
This ships the safe, high-value half of M3. The full single-capture `ScreenStateStore` + `DirtyTileDescriber` consolidation (one capture/turn, subscriptions, memory-pressure-paused describer loop) remains tracked in #9105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)