### PR TITLE
feat(computeruse): per-Scene grounding cache in Cascade (#9105 M5)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/cascade-grounding-cache.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cascade-grounding-cache.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Cascade per-Scene grounding cache (#9105 M5 — predict/ground split).
+ *
+ * Grounding the same target on the same Scene is deterministic, so the cheap
+ * GROUND step is memoized: a repeat ground on the same Scene reuses the coords
+ * without re-running OCR/AX resolution or the (possibly model-backed) actor. A
+ * new Scene (new timestamp) invalidates the cache.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Actor } from "../actor/actor.js";
+import { Brain } from "../actor/brain.js";
+import { Cascade } from "../actor/cascade.js";
+import type { DisplayCapture } from "../platform/capture.js";
+import type { Scene } from "../scene/scene-types.js";
+
+function scene(timestamp = 1): Scene {
+  return {
+    timestamp,
+    displays: [
+      {
+        id: 0,
+        bounds: [0, 0, 1920, 1080],
+        scaleFactor: 1,
+        primary: true,
+        name: "f",
+      },
+    ],
+    focused_window: null,
+    apps: [],
+    ocr: [
+      {
+        id: "t0-1",
+        text: "Save",
+        bbox: [100, 200, 80, 32],
+        conf: 0.97,
+        displayId: 0,
+      },
+    ],
+    ax: [],
+    vlm_scene: null,
+    vlm_elements: null,
+  };
+}
+
+function captures(): Map<number, DisplayCapture> {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const m = new Map<number, DisplayCapture>();
+  m.set(0, {
+    display: {
+      id: 0,
+      bounds: [0, 0, 1920, 1080],
+      scaleFactor: 1,
+      primary: true,
+      name: "f",
+    },
+    frame: Buffer.concat([sig, Buffer.alloc(56, 1)]),
+  });
+  return m;
+}
+
+const BRAIN_OUT = {
+  scene_summary: "s",
+  target_display_id: 0,
+  roi: [{ displayId: 0, bbox: [100, 200, 80, 32], reason: "r" }],
+  proposed_action: { kind: "click", ref: "t0-1", rationale: "Save" },
+};
+
+function fakeBrain(): Brain {
+  return new Brain(null, {
+    invokeModel: async () => JSON.stringify(BRAIN_OUT),
+  });
+}
+
+function countingActor(counter: { calls: number }): Actor {
+  return {
+    name: "counting",
+    async ground() {
+      counter.calls += 1;
+      return { displayId: 0, x: 140, y: 216, confidence: 1, reason: "refined" };
+    },
+  };
+}
+
+describe("Cascade grounding cache (M5)", () => {
+  it("reuses grounding for the same target on the same Scene", async () => {
+    const counter = { calls: 0 };
+    const cascade = new Cascade({
+      brain: fakeBrain(),
+      actor: countingActor(counter),
+    });
+    const s = scene(1);
+    const r1 = await cascade.run({
+      scene: s,
+      goal: "save",
+      captures: captures(),
+    });
+    const r2 = await cascade.run({
+      scene: s,
+      goal: "save",
+      captures: captures(),
+    });
+    expect(counter.calls).toBe(1); // 2nd ground served from cache
+    expect(r2.proposed.x).toBe(r1.proposed.x);
+    expect(r2.proposed.y).toBe(r1.proposed.y);
+    expect(cascade.getGroundStats()).toEqual({ hits: 1, misses: 1 });
+  });
+
+  it("re-grounds when the Scene changes (cache invalidated by timestamp)", async () => {
+    const counter = { calls: 0 };
+    const cascade = new Cascade({
+      brain: fakeBrain(),
+      actor: countingActor(counter),
+    });
+    await cascade.run({ scene: scene(1), goal: "save", captures: captures() });
+    await cascade.run({ scene: scene(2), goal: "save", captures: captures() });
+    expect(counter.calls).toBe(2);
+    expect(cascade.getGroundStats()).toEqual({ hits: 0, misses: 2 });
+  });
+});

--- a/plugins/plugin-computeruse/src/actor/cascade.ts
+++ b/plugins/plugin-computeruse/src/actor/cascade.ts
@@ -45,8 +45,34 @@ export interface CascadeInput {
   captures: Map<number, DisplayCapture>;
 }
 
+/** Grounding-cache accounting (#9105 M5). */
+export interface CascadeGroundStats {
+  /** Grounding resolutions served from the per-Scene cache. */
+  hits: number;
+  /** Grounding resolutions that ran the full resolve (OCR/AX + optional actor). */
+  misses: number;
+}
+
 export class Cascade {
+  /**
+   * Per-Scene grounding cache (predict/ground split, #9105 M5). Grounding the
+   * same target (ref or rationale) on the same Scene is deterministic, so the
+   * cheap GROUND step is memoized — re-grounding within a turn skips a repeat
+   * `resolveReference` (OCR/AX) scan and a repeat (possibly model-backed)
+   * `actor.ground` call. Keyed by Scene timestamp so a new screen invalidates.
+   */
+  private readonly groundCache = new Map<
+    string,
+    { displayId: number; x: number; y: number }
+  >();
+  private groundStats: CascadeGroundStats = { hits: 0, misses: 0 };
+
   constructor(private readonly deps: CascadeDeps) {}
+
+  /** Grounding cache hit/miss snapshot for token/work accounting. */
+  getGroundStats(): CascadeGroundStats {
+    return { ...this.groundStats };
+  }
 
   async run(input: CascadeInput): Promise<CascadeResult> {
     const brainOut = await this.deps.brain.observeAndPlan({
@@ -210,6 +236,46 @@ export class Cascade {
   }
 
   private async resolveCoords(
+    input: CascadeInput,
+    brainOut: BrainOutput,
+    allowMissing: boolean,
+  ): Promise<{ displayId: number; x: number; y: number } | null> {
+    // GROUND fast-path: a target already grounded on this Scene is reused.
+    const action0 = brainOut.proposed_action;
+    const cacheKey = `${input.scene.timestamp}::${brainOut.target_display_id}::${
+      action0.ref ?? action0.rationale ?? ""
+    }`;
+    const cached = this.groundCache.get(cacheKey);
+    if (cached) {
+      this.groundStats.hits += 1;
+      return cached;
+    }
+    const resolved = await this.resolveCoordsUncached(
+      input,
+      brainOut,
+      allowMissing,
+    );
+    if (resolved) {
+      this.groundStats.misses += 1;
+      this.rememberGround(input.scene.timestamp, cacheKey, resolved);
+    }
+    return resolved;
+  }
+
+  /** Drop cache entries from any Scene other than `timestamp`, then store. */
+  private rememberGround(
+    timestamp: number,
+    key: string,
+    value: { displayId: number; x: number; y: number },
+  ): void {
+    const prefix = `${timestamp}::`;
+    for (const k of this.groundCache.keys()) {
+      if (!k.startsWith(prefix)) this.groundCache.delete(k);
+    }
+    this.groundCache.set(key, value);
+  }
+
+  private async resolveCoordsUncached(
     input: CascadeInput,
     brainOut: BrainOutput,
     allowMissing: boolean,


### PR DESCRIPTION
Focused core of milestone **M5** (EPIC #9105): the **predict/ground split** as a per-Scene grounding cache.

Grounding the same target (ref/rationale) on the same Scene is deterministic, so the cheap GROUND step is memoized: a repeat resolution reuses the coords instead of re-running `resolveReference` (OCR/AX scan) + a repeat (possibly model-backed) `actor.ground`. Keyed by `Scene.timestamp` → a new screen invalidates.

- `Cascade.resolveCoords` checks a per-Scene cache before the existing 3-strategy resolver (`resolveCoordsUncached`); `rememberGround` stores the result and evicts prior-Scene entries.
- `getGroundStats()` → `{hits, misses}` for work/token accounting.

**Evidence**: `cascade-grounding-cache.test.ts` — same target+Scene → `actor.ground` called once, `{hits:1,misses:1}`; new Scene timestamp → re-ground. Cascade regression + computeruse suite green; typecheck + biome clean.

The on-demand Holo grounding model (behind IMAGE_DESCRIPTION) remains tracked in #9105; this cache makes repeated grounding cheap once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)