### PR TITLE
test(cloud-shared): extract + test the provider sandbox-registry resolution (#8756)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
@@ -5,6 +5,7 @@ import {
   requiresHeadscaleRoute,
   resolveContainerPort,
   resolveDockerSandboxImage,
+  resolveSandboxRegistryEnv,
   shouldCleanupHeadscaleVpn,
 } from "../docker-sandbox-provider";
 
@@ -200,5 +201,93 @@ describe("DockerSandboxProvider Headscale route guard", () => {
         environmentVars: {},
       }),
     ).rejects.toThrow("HEADSCALE_API_KEY is not configured");
+  });
+});
+
+describe("resolveSandboxRegistryEnv (#8756)", () => {
+  const env = (overrides: Record<string, string | undefined> = {}) =>
+    ({
+      SANDBOX_REGISTRY_REDIS_URL: undefined,
+      SANDBOX_REGISTRY_REDIS_TOKEN: undefined,
+      KV_REST_API_URL: undefined,
+      KV_REST_API_TOKEN: undefined,
+      ...overrides,
+    }) as NodeJS.ProcessEnv;
+
+  test("no backend configured → cannot self-register, no warning", () => {
+    const r = resolveSandboxRegistryEnv(env());
+    expect(r.url).toBe("");
+    expect(r.canSelfRegister).toBe(false);
+    expect(r.schemeWarning).toBeNull();
+  });
+
+  test("a redis:// URL self-registers without a token (TCP carries auth)", () => {
+    const r = resolveSandboxRegistryEnv(
+      env({ SANDBOX_REGISTRY_REDIS_URL: "redis://user:pw@proxy.example:6379" }),
+    );
+    expect(r.url).toBe("redis://user:pw@proxy.example:6379");
+    expect(r.isTcp).toBe(true);
+    expect(r.canSelfRegister).toBe(true);
+    expect(r.schemeWarning).toBeNull();
+  });
+
+  test("rediss:// (TLS) is also TCP", () => {
+    expect(
+      resolveSandboxRegistryEnv(env({ SANDBOX_REGISTRY_REDIS_URL: "rediss://h:6379" })).isTcp,
+    ).toBe(true);
+  });
+
+  test("an https Upstash URL needs a token to self-register", () => {
+    expect(
+      resolveSandboxRegistryEnv(env({ SANDBOX_REGISTRY_REDIS_URL: "https://up.example" }))
+        .canSelfRegister,
+    ).toBe(false);
+    const withToken = resolveSandboxRegistryEnv(
+      env({
+        SANDBOX_REGISTRY_REDIS_URL: "https://up.example",
+        SANDBOX_REGISTRY_REDIS_TOKEN: "tok",
+      }),
+    );
+    expect(withToken.canSelfRegister).toBe(true);
+    expect(withToken.token).toBe("tok");
+    expect(withToken.schemeWarning).toBeNull();
+  });
+
+  test("explicit SANDBOX_REGISTRY_* wins over legacy KV_REST_API_*, and does NOT borrow the legacy token", () => {
+    const r = resolveSandboxRegistryEnv(
+      env({
+        SANDBOX_REGISTRY_REDIS_URL: "redis://explicit:6379",
+        KV_REST_API_URL: "https://legacy.example",
+        KV_REST_API_TOKEN: "legacy-tok",
+      }),
+    );
+    expect(r.url).toBe("redis://explicit:6379");
+    expect(r.token).toBe("");
+  });
+
+  test("legacy KV_REST_API_URL + token self-registers", () => {
+    const r = resolveSandboxRegistryEnv(
+      env({ KV_REST_API_URL: "https://kv.example", KV_REST_API_TOKEN: "kv-tok" }),
+    );
+    expect(r.url).toBe("https://kv.example");
+    expect(r.token).toBe("kv-tok");
+    expect(r.canSelfRegister).toBe(true);
+  });
+
+  test("an unexpected scheme that still self-registers surfaces a warning", () => {
+    const r = resolveSandboxRegistryEnv(
+      env({
+        SANDBOX_REGISTRY_REDIS_URL: "ws://weird.example",
+        SANDBOX_REGISTRY_REDIS_TOKEN: "t",
+      }),
+    );
+    expect(r.canSelfRegister).toBe(true);
+    expect(r.schemeWarning).toContain("unexpected scheme (ws:)");
+  });
+
+  test("trims whitespace around the URL", () => {
+    expect(
+      resolveSandboxRegistryEnv(env({ SANDBOX_REGISTRY_REDIS_URL: "  redis://h:6379  " })).url,
+    ).toBe("redis://h:6379");
   });
 });

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -449,6 +449,47 @@ export function resolveContainerPort(config: SandboxCreateConfig): string {
   return requested;
 }
 
+/** Resolved sandbox self-registration backend (the provider-side mirror of the
+ * sandbox-side `buildSandboxRegistryFromEnv`). */
+export interface SandboxRegistryResolution {
+  /** Registry URL the sandbox should register into (empty = none). */
+  url: string;
+  /** Bearer token (REST endpoints only; redis:// URLs carry their own auth). */
+  token: string;
+  /** True when `url` is a `redis(s)://` TCP URL. */
+  isTcp: boolean;
+  /** Whether the sandbox can register: a URL plus either TCP or a token. */
+  canSelfRegister: boolean;
+  /** Non-null when `url` has an unexpected scheme (registration may fail). */
+  schemeWarning: string | null;
+}
+
+/**
+ * Resolve the sandbox registry backend from the provider environment. Pure
+ * mirror of the inline logic the provisioner used to carry, exported so the
+ * security-relevant self-registration decision (#8621 inbound routing) is
+ * unit-testable and can't silently drift (#8756). Resolution order:
+ *   1. `SANDBOX_REGISTRY_REDIS_URL` (+ optional `_TOKEN`) — explicit override.
+ *   2. `KV_REST_API_URL` + `KV_REST_API_TOKEN` — legacy Upstash REST.
+ */
+export function resolveSandboxRegistryEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): SandboxRegistryResolution {
+  const explicitRegistryUrl = env.SANDBOX_REGISTRY_REDIS_URL?.trim() ?? "";
+  const explicitRegistryToken = env.SANDBOX_REGISTRY_REDIS_TOKEN?.trim() ?? "";
+  const kvRestUrl = env.KV_REST_API_URL?.trim() ?? "";
+  const kvRestToken = env.KV_REST_API_TOKEN?.trim() ?? "";
+  const url = explicitRegistryUrl || kvRestUrl;
+  const token = explicitRegistryUrl ? explicitRegistryToken : kvRestToken;
+  const isTcp = /^rediss?:\/\//i.test(url);
+  const canSelfRegister = url !== "" && (isTcp || token !== "");
+  const schemeWarning =
+    canSelfRegister && !isTcp && !/^https?:\/\//i.test(url)
+      ? `Sandbox registry URL has an unexpected scheme (${url.split(":")[0]}:) — expected redis(s):// or http(s)://. Registration may fail`
+      : null;
+  return { url, token, isTcp, canSelfRegister, schemeWarning };
+}
+
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -1066,24 +1107,18 @@ export class DockerSandboxProvider implements SandboxProvider {
       //      no token is needed; an `https://` Upstash URL needs the token.
       //   2. KV_REST_API_URL + KV_REST_API_TOKEN: legacy Upstash REST.
       // Omit when neither is configured — the sandbox skips registration.
-      const explicitRegistryUrl = process.env.SANDBOX_REGISTRY_REDIS_URL?.trim() ?? "";
-      const explicitRegistryToken = process.env.SANDBOX_REGISTRY_REDIS_TOKEN?.trim() ?? "";
-      const kvRestUrl = process.env.KV_REST_API_URL?.trim() ?? "";
-      const kvRestToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
-      const registryRedisUrl = explicitRegistryUrl || kvRestUrl;
-      const registryRedisToken = explicitRegistryUrl ? explicitRegistryToken : kvRestToken;
-      const registryIsTcp = /^rediss?:\/\//i.test(registryRedisUrl);
-      // TCP URLs carry auth inline; REST endpoints require a bearer token.
-      const canSelfRegister =
-        registryRedisUrl !== "" && (registryIsTcp || registryRedisToken !== "");
+      const {
+        url: registryRedisUrl,
+        token: registryRedisToken,
+        canSelfRegister,
+        schemeWarning,
+      } = resolveSandboxRegistryEnv(process.env);
       if (!canSelfRegister) {
         logger.warn(
           "[docker-sandbox] No sandbox registry backend configured — set SANDBOX_REGISTRY_REDIS_URL to a sandbox-reachable redis:// proxy, or KV_REST_API_URL/KV_REST_API_TOKEN to an Upstash REST endpoint. Sandbox will not register in Redis and gateways will not route inbound platform (Discord/Telegram) messages to it",
         );
-      } else if (!registryIsTcp && !/^https?:\/\//i.test(registryRedisUrl)) {
-        logger.warn(
-          `[docker-sandbox] Sandbox registry URL has an unexpected scheme (${registryRedisUrl.split(":")[0]}:) — expected redis(s):// or http(s)://. Registration may fail`,
-        );
+      } else if (schemeWarning) {
+        logger.warn(`[docker-sandbox] ${schemeWarning}`);
       }
 
       const stewardJwt = isAgentTokenSigningConfigured()


### PR DESCRIPTION
`docker-sandbox-provider.ts` already exports a tested family of pure `env -> value` helpers (`resolveDockerSandboxImage`, `requiresHeadscaleRoute`, `buildStewardProxyEnv`, `resolveContainerPort`, …). The **provider-side sandbox-registry resolution** — the symmetric mirror of the well-tested sandbox-side `buildSandboxRegistryFromEnv`, which decides whether a sandbox is even told to self-register (and is security/routing-relevant: #8621 Discord/Telegram inbound routing depends on it) — was the one member still **inline and untested**.

- Extracts the inline logic into an exported pure `resolveSandboxRegistryEnv(env)` → `{ url, token, isTcp, canSelfRegister, schemeWarning }`. The provisioner now calls it (one source, can't drift).
- Adds 8 cases to the existing `docker-sandbox-headscale-route.test.ts` (bun:test).

Covers: no backend → can't register; `redis://` self-registers without a token; `rediss://` TLS is TCP; `https://` Upstash needs a token; explicit `SANDBOX_REGISTRY_*` wins over legacy `KV_REST_API_*` **and doesn't borrow the legacy token** (a subtle real behavior); legacy KV path; an unexpected scheme that still self-registers surfaces the warning; whitespace trimming.

## Evidence
```
bun test docker-sandbox-headscale-route.test.ts  →  25 pass (17 existing + 8 new), 0 fail
cloud-shared typecheck (filtered to the file)    →  no errors
```
biome clean.

Refs #8756

🤖 Generated with [Claude Code](https://claude.com/claude-code)