### PR TITLE
fix(ui): wire developerModeEnabled in App.tsx view router (fixes TS2304 breaking ui typecheck on develop)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -156,6 +156,7 @@ import {
   type ViewRegistryEntry,
 } from "./hooks/useAvailableViews";
 import { useDesktopTabs } from "./hooks/useDesktopTabs";
+import { useIsDeveloperMode } from "./state/useDeveloperMode";
 import { useEnabledViewKinds } from "./state/useViewKinds";
 
 const ViewCatalog = lazyNamedView(
@@ -1082,6 +1083,7 @@ function renderViewRouterContent({
   availableViews,
   appSlug,
   androidPhoneSurfaceEnabled,
+  developerModeEnabled,
   settingsInitialSection,
 }: {
   tab: string;
@@ -1092,6 +1094,7 @@ function renderViewRouterContent({
   availableViews: ViewRegistryEntry[];
   appSlug: string | null;
   androidPhoneSurfaceEnabled: boolean;
+  developerModeEnabled: boolean;
   settingsInitialSection?: string | null;
 }): ReactNode {
   if (visibleDynamicPage(dynamicPage, enabledKinds)) {
@@ -1180,6 +1183,7 @@ function ViewRouter({
   // Available views from /api/views — used to route to DynamicViewLoader
   // when a tab ID matches a view entry that ships a remote bundle URL.
   const { views: availableViews } = useAvailableViews();
+  const developerModeEnabled = useIsDeveloperMode();
   const view = renderViewRouterContent({
     tab,
     dynamicPage,
@@ -1189,6 +1193,7 @@ function ViewRouter({
     availableViews,
     appSlug,
     androidPhoneSurfaceEnabled,
+    developerModeEnabled,
     settingsInitialSection,
   });
 


### PR DESCRIPTION
## The bug (live on develop)
`renderViewRouterContent` in `packages/ui/src/App.tsx` gates developerOnly app-shell pages on `developerModeEnabled`, but that name is **never defined, imported, or passed** — a live `TS2304: Cannot find name 'developerModeEnabled'` that **fails the entire `@elizaos/ui` typecheck** and cascades to every package that imports it (plugin-facewear, plugin-inbox, …).

## The fix
Thread it from `useIsDeveloperMode()` — the canonical dev-mode hook already used by ViewCatalog / AdvancedSection / useViewKinds:
- add `developerModeEnabled` to `renderViewRouterContent`'s params + type,
- resolve `const developerModeEnabled = useIsDeveloperMode()` at the call site and pass it,
- import the hook.

## Verification
- `bun run --cwd packages/ui typecheck` — **green** (was red on develop)
- biome — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)