### PR TITLE
fix(health): route the health planner through OptimizedPromptService (#8795)

### DIFF
--- a/plugins/plugin-health/src/actions/health.ts
+++ b/plugins/plugin-health/src/actions/health.ts
@@ -9,7 +9,7 @@ import type {
   ModelTypeName,
   State,
 } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
+import { ModelType, resolveOptimizedPromptForRuntime } from "@elizaos/core";
 import type { LifeOpsHealthSummaryResponse } from "../contracts/health.js";
 import type {
   HealthBackend,
@@ -160,6 +160,32 @@ type HealthLlmPlan = {
   response?: string;
 };
 
+/** Static baseline instructions for the health planner. The dynamic
+ * request/intent/params/conversation tail is appended per call. Extracted as a
+ * module constant so it can serve as the `health_checkin` OptimizedPromptService
+ * baseline (#8795). */
+const HEALTH_PLAN_INSTRUCTIONS = [
+  "Plan the HEALTH action for this request.",
+  "The user may speak in any language.",
+  "Return JSON only as a single object with exactly these fields:",
+  "subaction: today|trend|by_metric|status|null",
+  "metric: steps|heart_rate|sleep_hours|calories|distance_meters|active_minutes|null",
+  "days: number|null",
+  "shouldAct: true|false",
+  "response: string|null",
+  "",
+  "Choose status when the user asks about health backend connection or availability.",
+  "Choose trend when the user asks for fitness/health activity over a window of days, a week, or recent history.",
+  "Choose by_metric when the user names a specific metric and wants its current or recent value.",
+  "Choose today (default) when the user asks for today's overall summary.",
+  "metric must be one of the listed enum values when subaction=by_metric, otherwise null.",
+  "days must be a positive integer the user implies (e.g. 7 for 'this week'); null when not stated.",
+  "Set shouldAct=false only when the request is too vague to choose any subaction.",
+  "When shouldAct=false, response must be a short clarifying question in the user's language.",
+  "",
+  'Example: {"subaction":"today","metric":null,"days":null,"shouldAct":true,"response":null}',
+].join("\n");
+
 async function resolveHealthPlanWithLlm(args: {
   adapters: CreateHealthActionRunnerOptions;
   runtime: IAgentRuntime;
@@ -189,26 +215,17 @@ async function resolveHealthPlanWithLlm(args: {
   const paramsText = Object.entries(args.params)
     .map(([key, value]) => `${key}: ${String(value)}`)
     .join("\n");
+  // Route the static planner instructions through OptimizedPromptService for
+  // the `health_checkin` task (#8795). Falls back to HEALTH_PLAN_INSTRUCTIONS
+  // verbatim when no optimized artifact is registered, so the composed prompt
+  // is byte-identical to the prior inline version unless an optimization loads.
+  const instructions = resolveOptimizedPromptForRuntime(
+    args.runtime,
+    "health_checkin",
+    HEALTH_PLAN_INSTRUCTIONS,
+  );
   const prompt = [
-    "Plan the HEALTH action for this request.",
-    "The user may speak in any language.",
-    "Return JSON only as a single object with exactly these fields:",
-    "subaction: today|trend|by_metric|status|null",
-    "metric: steps|heart_rate|sleep_hours|calories|distance_meters|active_minutes|null",
-    "days: number|null",
-    "shouldAct: true|false",
-    "response: string|null",
-    "",
-    "Choose status when the user asks about health backend connection or availability.",
-    "Choose trend when the user asks for fitness/health activity over a window of days, a week, or recent history.",
-    "Choose by_metric when the user names a specific metric and wants its current or recent value.",
-    "Choose today (default) when the user asks for today's overall summary.",
-    "metric must be one of the listed enum values when subaction=by_metric, otherwise null.",
-    "days must be a positive integer the user implies (e.g. 7 for 'this week'); null when not stated.",
-    "Set shouldAct=false only when the request is too vague to choose any subaction.",
-    "When shouldAct=false, response must be a short clarifying question in the user's language.",
-    "",
-    'Example: {"subaction":"today","metric":null,"days":null,"shouldAct":true,"response":null}',
+    instructions,
     "",
     "Current request:",
     currentMessage || "(empty)",


### PR DESCRIPTION
Acceptance criterion #2 of #8795 — "Route LifeOps LLM call sites through OptimizedPromptService". The `health_checkin` task is fully defined in the taxonomy, scorers, and datasets but had **zero production consumer**: no call site invoked `resolveOptimizedPromptForRuntime(..., "health_checkin", ...)`.

`resolveHealthPlanWithLlm` (`plugins/plugin-health/src/actions/health.ts`) built its planner prompt fully inline. This:
- extracts the static instruction block into a module const `HEALTH_PLAN_INSTRUCTIONS`, and
- routes it through `resolveOptimizedPromptForRuntime(args.runtime, "health_checkin", HEALTH_PLAN_INSTRUCTIONS)`, keeping the dynamic request/intent/params/conversation tail appended exactly as before.

So the `health_checkin` optimization path now has a real consumer (GEPA/trajectory-optimized prompts will be picked up when registered), while the composed prompt is **byte-identical** when no optimized artifact is loaded.

## Evidence
```
plugin-health build:types (filtered to health.ts) → no errors    # the typed task literal compiles
resolveOptimizedPromptForRuntime(noServiceRuntime, "health_checkin", baseline) === baseline  →  true
```
`resolveOptimizedPromptForRuntime` returns the baseline verbatim when `OptimizedPromptService` isn't registered (the documented contract), so the default-runtime prompt is unchanged. biome clean.

Refs #8795

🤖 Generated with [Claude Code](https://claude.com/claude-code)