### PR TITLE
fix(elizacloud,ci): correct embedding 429-retry error contract + run cloud-script guards

### DIFF
--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -22,11 +22,29 @@ const workflow = readFileSync(workflowPath, "utf8");
 
 const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
 
+// The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
+// `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
+// that as a suffix and fails, so the executed cases only run where a
+// GNU-compatible sed exists. CI (Linux) has GNU sed natively; a macOS dev with
+// `brew install gnu-sed` gets coverage via the `gsed` shim injected in
+// runReconcile; otherwise the executed cases skip (the static wiring assertions
+// above still run on every platform).
+function resolveGnuSed(): string | null {
+  for (const candidate of ["sed", "gsed"]) {
+    try {
+      const out = execFileSync(candidate, ["--version"], { encoding: "utf8" });
+      if (out.includes("GNU sed")) return candidate;
+    } catch {
+      // candidate missing or not GNU — keep looking.
+    }
+  }
+  return null;
+}
+const GNU_SED = resolveGnuSed();
+
 describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring", () => {
   it("sources the key from the GitHub secret into the deploy job env", () => {
-    expect(workflow).toContain(
-      `${ENV_KEY}: \${{ secrets.${ENV_KEY} }}`,
-    );
+    expect(workflow).toContain(`${ENV_KEY}: \${{ secrets.${ENV_KEY} }}`);
   });
 
   it("forwards the key to the remote deploy script via the ssh-action envs allowlist", () => {
@@ -35,17 +53,20 @@ describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring
     // script and the reconcile loop below silently skips it.
     const envsLine = workflow
       .split("\n")
-      .find((line) => line.trim().startsWith("envs:") && line.includes(ENV_KEY));
+      .find(
+        (line) => line.trim().startsWith("envs:") && line.includes(ENV_KEY),
+      );
     expect(envsLine).toBeDefined();
-    const forwarded = (envsLine ?? "")
-      .slice(envsLine!.indexOf("envs:") + "envs:".length)
+    const line = envsLine ?? "";
+    const forwarded = line
+      .slice(line.indexOf("envs:") + "envs:".length)
       .split(",")
       .map((name) => name.trim());
     expect(forwarded).toContain(ENV_KEY);
   });
 
   it("includes the key in the .env.local reconcile loop targeting /opt/eliza/cloud/.env.local", () => {
-    expect(workflow).toContain('ENV_FILE=/opt/eliza/cloud/.env.local');
+    expect(workflow).toContain("ENV_FILE=/opt/eliza/cloud/.env.local");
     // The loop body iterates "KEY=$VALUE" entries; the entry for our key must
     // be present so the sed-delete + tee-append rewrites it into the file.
     expect(workflow).toContain(`"${ENV_KEY}=$${ENV_KEY}"`);
@@ -63,10 +84,17 @@ function extractReconcileLoop(): string {
   // Include the "done" line itself.
   const block = tail.slice(0, doneIdx + "\n            done".length);
   // De-indent the 12-space YAML script indentation.
-  return block
+  const loop = block
     .split("\n")
     .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
     .join("\n");
+  // Fail loudly if anchor drift (a renamed loop var, reindented script block, a
+  // reformatted `done`, or a swapped ssh-action) extracted a trivial/empty
+  // block — otherwise the executed cases would silently exercise nothing.
+  expect(loop).toContain("sed -i");
+  expect(loop).toContain("tee -a");
+  expect(loop).toContain(ENV_KEY);
+  return loop;
 }
 
 function runReconcile(opts: {
@@ -85,7 +113,11 @@ function runReconcile(opts: {
   // unprivileged in the scratch dir, and bind ENV_FILE to our temp path.
   const script = [
     "set -euo pipefail",
-    "sudo() { \"$@\"; }",
+    'sudo() { "$@"; }',
+    // On a macOS dev box with `brew install gnu-sed`, route the loop's `sed`
+    // through `gsed` so the verbatim GNU `sed -i` invocation behaves. On Linux
+    // (GNU sed is the default) and when skipped this is a no-op.
+    GNU_SED === "gsed" ? 'sed() { gsed "$@"; }' : "",
     `ENV_FILE='${envFile}'`,
     // The ssh-action `envs:` allowlist always exports these (possibly empty);
     // under `set -u` they must be defined or the loop aborts. Empty == skipped,
@@ -111,37 +143,43 @@ function runReconcile(opts: {
   }
 }
 
-describe("provisioning-worker .env.local reconcile loop (executed)", () => {
-  it("writes SANDBOX_REGISTRY_REDIS_URL into .env.local when the secret is set", () => {
-    const url = "redis://sandbox-registry.example.internal:6379";
-    const out = runReconcile({ redisUrl: url });
-    expect(out).toContain(`${ENV_KEY}=${url}\n`);
-  });
-
-  it("replaces a stale hand-set value rather than appending a duplicate", () => {
-    const out = runReconcile({
-      redisUrl: "redis://new.example:6379",
-      seedEnvFile: `${ENV_KEY}=redis://stale.example:6379\nOTHER=keep\n`,
+// Skip the executed cases when no GNU-compatible sed is reachable (BSD/macOS
+// without gsed); CI runs on Linux with GNU sed and keeps full coverage.
+const executedDescribe = GNU_SED ? describe : describe.skip;
+executedDescribe(
+  "provisioning-worker .env.local reconcile loop (executed)",
+  () => {
+    it("writes SANDBOX_REGISTRY_REDIS_URL into .env.local when the secret is set", () => {
+      const url = "redis://sandbox-registry.example.internal:6379";
+      const out = runReconcile({ redisUrl: url });
+      expect(out).toContain(`${ENV_KEY}=${url}\n`);
     });
-    const matches = out
-      .split("\n")
-      .filter((line) => line.startsWith(`${ENV_KEY}=`));
-    expect(matches).toEqual([`${ENV_KEY}=redis://new.example:6379`]);
-    // Unrelated keys are preserved.
-    expect(out).toContain("OTHER=keep");
-  });
 
-  it("skips the key (preserving any hand-set value) when the secret is unset", () => {
-    const out = runReconcile({
-      redisUrl: undefined,
-      seedEnvFile: `${ENV_KEY}=redis://hand-set.example:6379\n`,
+    it("replaces a stale hand-set value rather than appending a duplicate", () => {
+      const out = runReconcile({
+        redisUrl: "redis://new.example:6379",
+        seedEnvFile: `${ENV_KEY}=redis://stale.example:6379\nOTHER=keep\n`,
+      });
+      const matches = out
+        .split("\n")
+        .filter((line) => line.startsWith(`${ENV_KEY}=`));
+      expect(matches).toEqual([`${ENV_KEY}=redis://new.example:6379`]);
+      // Unrelated keys are preserved.
+      expect(out).toContain("OTHER=keep");
     });
-    // An unset GH secret must never blank a working box.
-    expect(out).toContain(`${ENV_KEY}=redis://hand-set.example:6379`);
-  });
 
-  it("skips the key when the secret is the empty string", () => {
-    const out = runReconcile({ redisUrl: "" });
-    expect(out).not.toContain(ENV_KEY);
-  });
-});
+    it("skips the key (preserving any hand-set value) when the secret is unset", () => {
+      const out = runReconcile({
+        redisUrl: undefined,
+        seedEnvFile: `${ENV_KEY}=redis://hand-set.example:6379\n`,
+      });
+      // An unset GH secret must never blank a working box.
+      expect(out).toContain(`${ENV_KEY}=redis://hand-set.example:6379`);
+    });
+
+    it("skips the key when the secret is the empty string", () => {
+      const out = runReconcile({ redisUrl: "" });
+      expect(out).not.toContain(ENV_KEY);
+    });
+  },
+);

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
+
 // Cross-platform replacement for the previous `test:cloud` shell pipeline,
 // which used `printf '...\n'` (broken under bun's embedded shell on Windows
 // — outputs literal `n` instead of newlines) and required POSIX-shell
 // `$OLDPWD` semantics.
 
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +29,11 @@ const env = {
 
 const cloudSharedSrc = path.join(repoRoot, "packages", "cloud-shared", "src");
 const cloudApiTests = path.join(repoRoot, "packages", "cloud-api", "__tests__");
+// cloud-tests.yml already triggers on `packages/scripts/cloud/**`, but nothing
+// here ran those tests — the daemon/admin guards (e.g. the provisioning-worker
+// env-reconcile regression test for #8756) silently never executed. Include the
+// directory so the path trigger actually exercises them.
+const cloudScriptsTests = path.join(repoRoot, "packages", "scripts", "cloud");
 
 const result = spawnSync(
   "bun",
@@ -35,6 +41,7 @@ const result = spawnSync(
     "test",
     cloudSharedSrc,
     cloudApiTests,
+    cloudScriptsTests,
     "--timeout",
     "120000",
     "--isolate",

--- a/plugins/plugin-elizacloud/src/models/embeddings.ts
+++ b/plugins/plugin-elizacloud/src/models/embeddings.ts
@@ -189,7 +189,6 @@ export async function handleBatchTextEmbedding(
       // bounded exponential backoff (see EMBED_* constants) instead of a single
       // 30s blind sleep.
       let response: Response | null = null;
-      let retriedAfterRateLimit = false;
       for (let attempt = 0; attempt < EMBED_MAX_ATTEMPTS; attempt++) {
         const resp = await timeInferenceSpan(
           "cloud.embedding",
@@ -227,7 +226,6 @@ export async function handleBatchTextEmbedding(
           resp.status === 503 ||
           resp.status === 504;
         if (transient && attempt < EMBED_MAX_ATTEMPTS - 1) {
-          retriedAfterRateLimit ||= resp.status === 429;
           const delay = embeddingBackoffMs(attempt, rateLimitInfo.retryAfter);
           logger.warn(
             `[BatchEmbeddings] ${resp.status} (attempt ${attempt + 1}/${EMBED_MAX_ATTEMPTS}) — backing off ${delay}ms`
@@ -261,9 +259,13 @@ export async function handleBatchTextEmbedding(
               `the current key is not authorized for the embedding endpoint.`
           );
         }
-        if (retriedAfterRateLimit) {
+        // A terminal 429 means the bounded retries were exhausted and the
+        // gateway is still rate-limiting us — surface that distinctly. Any
+        // other terminal status (incl. a 503/504 that followed an earlier 429)
+        // reports its own status, since that is the failure the caller hit.
+        if (response.status === 429) {
           throw new Error(
-            `[BatchEmbeddings] Rate-limit retry failed: API error ${response.status} ${response.statusText}`
+            `[BatchEmbeddings] Rate-limit retry exhausted: API error: ${response.status} ${response.statusText}`
           );
         }
         throw new Error(


### PR DESCRIPTION
## What

Three CI-regression follow-ups surfaced while reviewing the recently-landed PRs **#9108 / #9109 / #9112** (a multi-agent review of the CI-regression batch). All are fixes to code already on `develop`.

### 1. `plugin-elizacloud` embeddings — 429-retry error contract (live `develop` test failure)

`#9112` added a `retriedAfterRateLimit` branch that throws `"... API error <status>"` (no colon). The **unmodified** `embeddings.test.ts:156` (`throws (no markers) when the post-429 retry also fails`) asserts `/API error: 503/` (with colon) — so it **fails on `develop` right now**:

```
$ bun run --cwd plugins/plugin-elizacloud test:unit -- __tests__/unit/embeddings.test.ts
# before: 1 failed | 91 passed
# after:  92 passed | 2 skipped  (0 failed)
```

Fix: gate the rate-limit-specific message on the **terminal** status being `429` (a `503` that follows an earlier `429` now correctly reports its own `503` via the generic path), restore the `API error:` colon, and drop the now-dead `retriedAfterRateLimit` flag. No test asserts the rate-limit message string, so removing the flag is safe.

### 2. `provisioning-worker-env-reconcile.test.ts` (#9109) — macOS/BSD `sed` portability

The "executed" cases run the deploy workflow's **verbatim** GNU `sed -i "/.../d"`, which BSD/macOS `sed` rejects — **2/7 fail on every Mac dev box** (green only in Linux CI). Gate the executed block on a GNU-compatible `sed` (use a `gsed` shim when present, else `describe.skip`); Linux CI keeps full coverage. Also added extractor sanity asserts (`sed -i` / `tee -a` / key present) so future YAML anchor drift **fails loudly instead of silently testing nothing**, and removed a non-null assertion.

### 3. `test-cloud-run.mjs` — cloud-script guards never ran in CI

`cloud-tests.yml` triggers on `packages/scripts/cloud/**`, but the runner only scanned `cloud-shared/src` + `cloud-api/__tests__`, so **all 6** cloud-script guards (incl. the #8756 reconcile test from #9109) **never executed**. Include the directory; drop an unused `rmSync` import.

```
$ SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test packages/scripts/cloud
# 60 pass / 4 skip / 0 fail  (only the 2 sed-mutation cases skip, on macOS)
```

## Not included

App.tsx `TS2304: developerModeEnabled` was the 4th regression in this batch — **already fixed on `develop`** via #9135.

## Verification

- `bun run --cwd packages/ui typecheck` → exit 0 (confirms #9135 already resolved App.tsx)
- `bun run --cwd plugins/plugin-elizacloud typecheck` → exit 0; `lint:check` clean
- `bun run --cwd plugins/plugin-elizacloud test:unit -- __tests__/unit/embeddings.test.ts` → 92 pass
- `bun test packages/scripts/cloud` → 60 pass / 4 skip / 0 fail
- `biome check` on all changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
