### PR TITLE
test(app): extract + unit-test the all-views aesthetic-audit rules (#8796)

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  bucket,
+  computeVerdict,
+  OVERLAY_NATIVE_OR_CANVAS_SLUGS,
+  parseNavigationTabPaths,
+  parseRgb,
+  type VerdictFinding,
+} from "../ui-smoke/aesthetic-audit-rules";
+
+describe("parseRgb (#8796)", () => {
+  it("parses rgb() and rgba(), defaulting alpha to 1", () => {
+    expect(parseRgb("rgb(255, 0, 0)")).toEqual([255, 0, 0, 1]);
+    expect(parseRgb("rgba(0, 0, 0, 0.5)")).toEqual([0, 0, 0, 0.5]);
+  });
+  it("returns null for non-rgb strings", () => {
+    expect(parseRgb("transparent")).toBeNull();
+    expect(parseRgb("rgb(1, 2)")).toBeNull();
+    expect(parseRgb("#fff")).toBeNull();
+  });
+});
+
+describe("bucket (#8796 no-blue / orange detection)", () => {
+  it("buckets the brand orange as orange", () => {
+    expect(bucket("rgb(230, 126, 34)")).toBe("orange");
+  });
+  it("buckets a blue as blue (the banned color)", () => {
+    expect(bucket("rgb(40, 90, 230)")).toBe("blue");
+  });
+  it("buckets near-black and pure white", () => {
+    expect(bucket("rgb(10, 10, 10)")).toBe("black");
+    expect(bucket("rgb(255, 255, 255)")).toBe("white");
+  });
+  it("buckets fully transparent and low-saturation gray", () => {
+    expect(bucket("rgba(0, 0, 255, 0)")).toBe("transparent");
+    expect(bucket("rgb(128, 128, 128)")).toBe("neutral");
+  });
+  it("unparseable colors fall back to neutral (never blue)", () => {
+    expect(bucket("not-a-color")).toBe("neutral");
+  });
+});
+
+describe("parseNavigationTabPaths (#8796)", () => {
+  it("extracts the TAB_PATHS map (quoted and unquoted keys)", () => {
+    const src = `
+      type BuiltinTab = "home" | "chat";
+      export const TAB_PATHS: Record<BuiltinTab, string> = {
+        home: "/",
+        "chat": "/chat",
+      };
+    `;
+    expect(parseNavigationTabPaths(src)).toEqual({ home: "/", chat: "/chat" });
+  });
+  it("throws when TAB_PATHS is absent", () => {
+    expect(() => parseNavigationTabPaths("export const X = 1;")).toThrow(
+      /could not locate TAB_PATHS/,
+    );
+  });
+});
+
+describe("computeVerdict (#8796 verdict precedence)", () => {
+  const finding = (o: Partial<VerdictFinding> = {}): VerdictFinding => ({
+    slug: "plugin-foo-gui",
+    viewType: "gui",
+    consoleErrors: [],
+    qualityIssues: [],
+    readableChars: 500,
+    blueColors: [],
+    hoverViolations: [],
+    overlayPresent: true,
+    borderRadiusViolations: [],
+    ...o,
+  });
+
+  it("a clean gui view is good", () => {
+    expect(computeVerdict(finding())).toBe("good");
+  });
+
+  it("any console error is broken — even on an exempt surface", () => {
+    expect(computeVerdict(finding({ consoleErrors: ["boom"] }))).toBe("broken");
+    expect(
+      computeVerdict(finding({ viewType: "tui", consoleErrors: ["boom"] })),
+    ).toBe("broken");
+  });
+
+  it("a gui view with quality issues or no readable content is broken", () => {
+    expect(computeVerdict(finding({ qualityIssues: ["blurry"] }))).toBe(
+      "broken",
+    );
+    expect(computeVerdict(finding({ readableChars: 0 }))).toBe("broken");
+  });
+
+  it("TUI and overlay surfaces are exempt from the quality/content floors", () => {
+    expect(
+      computeVerdict(
+        finding({ viewType: "tui", qualityIssues: ["x"], readableChars: 0 }),
+      ),
+    ).toBe("good");
+    expect(
+      computeVerdict(
+        finding({
+          slug: "builtin-chat",
+          qualityIssues: ["x"],
+          readableChars: 0,
+        }),
+      ),
+    ).toBe("good");
+  });
+
+  it("the no-blue rule still applies to overlay surfaces", () => {
+    expect(OVERLAY_NATIVE_OR_CANVAS_SLUGS.has("builtin-chat")).toBe(true);
+    expect(
+      computeVerdict(
+        finding({ slug: "builtin-chat", blueColors: ["rgb(0,0,255)"] }),
+      ),
+    ).toBe("needs-work");
+  });
+
+  it("blue / hover violations / missing overlay are needs-work on a gui view", () => {
+    expect(computeVerdict(finding({ blueColors: ["rgb(0,0,255)"] }))).toBe(
+      "needs-work",
+    );
+    expect(computeVerdict(finding({ hoverViolations: ["x"] }))).toBe(
+      "needs-work",
+    );
+    expect(computeVerdict(finding({ overlayPresent: false }))).toBe(
+      "needs-work",
+    );
+  });
+
+  it("off-scale border radius is a soft needs-eyeball (non-blocking)", () => {
+    expect(computeVerdict(finding({ borderRadiusViolations: ["32px"] }))).toBe(
+      "needs-eyeball",
+    );
+  });
+});

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure brand-color / verdict policy for the all-views aesthetic audit (#8796).
+ *
+ * These are the heart of the audit's acceptance criteria — no-blue detection,
+ * orange/black/blue color bucketing, the TUI/overlay-canvas exemptions, and the
+ * verdict precedence — extracted out of the Playwright spec (which imports
+ * `@playwright/test` + a live `page`, so the rules were unreachable by vitest)
+ * into this dependency-free module so they can be unit-tested. The spec imports
+ * them from here; the test lives in `test/audit/` (vitest excludes
+ * `test/ui-smoke/**`).
+ */
+
+export type Bucket =
+  | "orange"
+  | "black"
+  | "blue"
+  | "white"
+  | "neutral"
+  | "transparent";
+
+export type AestheticVerdict =
+  | "good"
+  | "needs-work"
+  | "needs-eyeball"
+  | "broken";
+
+/** The subset of a view audit finding the verdict policy reads. The spec's
+ * fuller `ViewFinding` is structurally assignable to this. */
+export interface VerdictFinding {
+  slug: string;
+  viewType: "gui" | "tui";
+  consoleErrors: string[];
+  qualityIssues: string[];
+  /** Readable text length in the view root; ~0 means the view never painted. */
+  readableChars: number;
+  blueColors: string[];
+  hoverViolations: string[];
+  overlayPresent: boolean;
+  borderRadiusViolations: string[];
+}
+
+/** Parse the `TAB_PATHS` map out of the navigation index source. */
+export function parseNavigationTabPaths(
+  source: string,
+): Record<string, string> {
+  const block = source.match(
+    /export const TAB_PATHS\s*:\s*Record<BuiltinTab,\s*string>\s*=\s*\{([\s\S]*?)\};/,
+  );
+  if (!block) {
+    throw new Error(
+      "[aesthetic-audit-rules] could not locate TAB_PATHS in the navigation index source",
+    );
+  }
+  const entries: Record<string, string> = {};
+  const entryRe = /"?([a-z][a-z-]*)"?\s*:\s*"([^"]+)"/g;
+  for (const m of block[1].matchAll(entryRe)) {
+    entries[m[1]] = m[2];
+  }
+  return entries;
+}
+
+/** Parse a CSS `rgb()` / `rgba()` string to `[r, g, b, a]`, or null. */
+export function parseRgb(
+  input: string,
+): [number, number, number, number] | null {
+  const m = input.match(
+    /^rgba?\(\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)(?:\s*,\s*(\d+\.?\d*))?\s*\)$/,
+  );
+  if (!m) return null;
+  return [
+    Number(m[1]),
+    Number(m[2]),
+    Number(m[3]),
+    m[4] === undefined ? 1 : Number(m[4]),
+  ];
+}
+
+/** Bucket a CSS color into a coarse brand category. */
+export function bucket(color: string): Bucket {
+  const rgb = parseRgb(color);
+  if (!rgb) return "neutral";
+  const [r, g, b, a] = rgb;
+  if (a === 0) return "transparent";
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lum = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  const saturation = max === 0 ? 0 : (max - min) / max;
+  if (lum < 0.08) return "black";
+  if (lum > 0.95 && saturation < 0.05) return "white";
+  if (saturation < 0.15) return "neutral";
+  if (r > 200 && g > 90 && g < 200 && b < 100) return "orange";
+  if (b > r + 20 && b > g + 10) return "blue";
+  return "neutral";
+}
+
+/** Overlay-native / canvas / game surfaces that own their own chrome and so are
+ * exempt from the readable-content + blank-screenshot + floating-overlay floors
+ * (the no-blue brand rule still applies). */
+export const OVERLAY_NATIVE_OR_CANVAS_SLUGS = new Set([
+  "builtin-chat",
+  "builtin-phone",
+  "builtin-messages",
+  "builtin-camera",
+  "plugin-phone-gui",
+  "plugin-messages-gui",
+  "plugin-scape-gui",
+  "plugin-2004scape-gui",
+  "plugin-clawville-gui",
+  "plugin-hyperscape-gui",
+]);
+
+/** Verdict precedence for a view finding. */
+export function computeVerdict(finding: VerdictFinding): AestheticVerdict {
+  const exempt =
+    finding.viewType === "tui" ||
+    OVERLAY_NATIVE_OR_CANVAS_SLUGS.has(finding.slug);
+  // A console error (a real crash signal) is broken for every view. Overlay-
+  // native/canvas/terminal surfaces legitimately render little chrome text and
+  // screenshot near-one-color, so the readable-content + blank-screenshot
+  // floors are waived for them.
+  if (
+    finding.consoleErrors.length > 0 ||
+    (!exempt &&
+      (finding.qualityIssues.length > 0 || finding.readableChars < 10))
+  ) {
+    return "broken";
+  }
+  // TUI terminals are exempt from ALL color/light-surface rules: a terminal
+  // renders an ANSI/slate palette by design. They pass once they render with no
+  // real console errors.
+  if (finding.viewType === "tui") {
+    return "good";
+  }
+  // Overlay-native/canvas surfaces waive the floating-overlay + hover heuristics
+  // (they own their surface), but the no-blue brand rule still holds.
+  if (exempt) {
+    return finding.blueColors.length > 0 ? "needs-work" : "good";
+  }
+  if (
+    finding.blueColors.length > 0 ||
+    finding.hoverViolations.length > 0 ||
+    !finding.overlayPresent
+  ) {
+    return "needs-work";
+  }
+  // Off-scale border-radius is a soft signal (#8796 AC3 only asks the harness to
+  // FLAG non-token radius): a non-blocking `needs-eyeball` records it without
+  // destabilizing the green baseline.
+  if (finding.borderRadiusViolations.length > 0) {
+    return "needs-eyeball";
+  }
+  return "good";
+}

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
 import {
+  bucket,
+  computeVerdict,
+  parseNavigationTabPaths,
+} from "./aesthetic-audit-rules";
+import {
   installDefaultAppRoutes,
   openAppPath,
   seedAppStorage,
@@ -82,23 +87,6 @@ const NAV_INDEX_PATH = fileURLToPath(
   new URL("../../../ui/src/navigation/index.ts", import.meta.url),
 );
 
-function parseNavigationTabPaths(source: string): Record<string, string> {
-  const block = source.match(
-    /export const TAB_PATHS\s*:\s*Record<BuiltinTab,\s*string>\s*=\s*\{([\s\S]*?)\};/,
-  );
-  if (!block) {
-    throw new Error(
-      `[all-views-aesthetic-audit] could not locate TAB_PATHS in ${NAV_INDEX_PATH}`,
-    );
-  }
-  const entries: Record<string, string> = {};
-  const entryRe = /"?([a-z][a-z-]*)"?\s*:\s*"([^"]+)"/g;
-  for (const m of block[1].matchAll(entryRe)) {
-    entries[m[1]] = m[2];
-  }
-  return entries;
-}
-
 interface AuditCase {
   slug: string;
   path: string;
@@ -133,38 +121,6 @@ const VIEWPORTS = [
 ] as const;
 
 // ── Brand-color analysis (ported from cloud-frontend aesthetic-audit) ────────
-type Bucket = "orange" | "black" | "blue" | "white" | "neutral" | "transparent";
-
-function parseRgb(input: string): [number, number, number, number] | null {
-  const m = input.match(
-    /^rgba?\(\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)\s*,\s*(\d+\.?\d*)(?:\s*,\s*(\d+\.?\d*))?\s*\)$/,
-  );
-  if (!m) return null;
-  return [
-    Number(m[1]),
-    Number(m[2]),
-    Number(m[3]),
-    m[4] === undefined ? 1 : Number(m[4]),
-  ];
-}
-
-function bucket(color: string): Bucket {
-  const rgb = parseRgb(color);
-  if (!rgb) return "neutral";
-  const [r, g, b, a] = rgb;
-  if (a === 0) return "transparent";
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const lum = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  const saturation = max === 0 ? 0 : (max - min) / max;
-  if (lum < 0.08) return "black";
-  if (lum > 0.95 && saturation < 0.05) return "white";
-  if (saturation < 0.15) return "neutral";
-  if (r > 200 && g > 90 && g < 200 && b < 100) return "orange";
-  if (b > r + 20 && b > g + 10) return "blue";
-  return "neutral";
-}
-
 interface ViewFinding {
   slug: string;
   viewport: string;
@@ -303,68 +259,6 @@ function renderManualReviewStub(finding: ViewFinding): string {
 // chrome is in scope, so they're exempt from the readable-content + floating-
 // overlay-clearance + light-surface checks. They still must not crash, log
 // console errors, render fully blank, or use blue.
-const OVERLAY_NATIVE_OR_CANVAS_SLUGS = new Set([
-  "builtin-chat",
-  "builtin-phone",
-  "builtin-messages",
-  "builtin-camera",
-  "plugin-phone-gui",
-  "plugin-messages-gui",
-  "plugin-scape-gui",
-  "plugin-2004scape-gui",
-  "plugin-clawville-gui",
-  "plugin-hyperscape-gui",
-]);
-
-function computeVerdict(
-  finding: Omit<ViewFinding, "verdict">,
-): ViewFinding["verdict"] {
-  const exempt =
-    finding.viewType === "tui" ||
-    OVERLAY_NATIVE_OR_CANVAS_SLUGS.has(finding.slug);
-  // A console error (a real crash signal) is broken for every view. Overlay-
-  // native/canvas/terminal surfaces legitimately render little chrome text and
-  // screenshot near-one-color (an overlay over a solid bg, an empty canvas), so
-  // the readable-content + blank-screenshot floors are waived for them.
-  if (
-    finding.consoleErrors.length > 0 ||
-    (!exempt &&
-      (finding.qualityIssues.length > 0 || finding.readableChars < 10))
-  ) {
-    return "broken";
-  }
-  // TUI terminals are exempt from ALL color/light-surface rules (#8796 open
-  // question): a terminal renders an ANSI/slate palette by design, so blue-gray
-  // there is the terminal aesthetic, not a brand violation. They pass once they
-  // render with no real console errors.
-  if (finding.viewType === "tui") {
-    return "good";
-  }
-  // Overlay-native/canvas surfaces waive the floating-overlay + hover heuristics
-  // (they own their surface), but the no-blue brand rule still holds.
-  if (exempt) {
-    return finding.blueColors.length > 0 ? "needs-work" : "good";
-  }
-  if (
-    finding.blueColors.length > 0 ||
-    finding.hoverViolations.length > 0 ||
-    !finding.overlayPresent
-  ) {
-    return "needs-work";
-  }
-  // Off-scale border-radius is a soft signal, not a crash or a brand violation:
-  // the criterion (#8796 AC3) only asks the harness to FLAG non-token radius, and
-  // we cannot run a fix-grind here. Surfacing it via the report + a non-blocking
-  // `needs-eyeball` verdict records the data without destabilizing the 152/152
-  // green baseline (a `needs-work`/`broken` verdict would block the gate). TUI +
-  // games/canvas surfaces are exempt above (same set as the blue rule), since a
-  // terminal/canvas owns its own geometry.
-  if (finding.borderRadiusViolations.length > 0) {
-    return "needs-eyeball";
-  }
-  return "good";
-}
-
 const findings: ViewFinding[] = [];
 
 test.describe("all-views aesthetic audit (#8796)", () => {


### PR DESCRIPTION
The brand-color / verdict policy that is the heart of #8796's acceptance criteria — **no-blue detection**, orange/black/blue **bucketing**, the **TUI/overlay-canvas exemptions**, and **verdict precedence** — lived inline inside the Playwright spec (`all-views-aesthetic-audit.spec.ts`), which imports `@playwright/test` + a live `page`. So those pure rules had **zero unit tests** and were unreachable by vitest.

- New `packages/app/test/ui-smoke/aesthetic-audit-rules.ts` — dependency-free `parseRgb`, `bucket`, `parseNavigationTabPaths`, `OVERLAY_NATIVE_OR_CANVAS_SLUGS`, and `computeVerdict` (over a minimal `VerdictFinding` the spec's fuller `ViewFinding` is assignable to).
- The spec now **imports** them and deletes the inline copies (so the unit test covers exactly what the spec runs — no drift).
- New `packages/app/test/audit/aesthetic-audit-rules.test.ts` — lives outside `test/ui-smoke/**` (vitest excludes that dir).

## Evidence
```
bunx vitest run test/audit/aesthetic-audit-rules.test.ts  →  16 passed (16)
```
Covers: rgb/rgba parsing + alpha default; orange/blue/black/white/transparent/neutral bucketing (incl. unparseable → never blue); TAB_PATHS extraction (quoted + unquoted keys) + the throw; and the full verdict precedence — console error → broken (even exempt), gui quality/blank → broken, TUI + overlay exempt from those floors, no-blue still applies to overlays, blue/hover/missing-overlay → needs-work, off-scale radius → needs-eyeball. biome clean; app typecheck surfaced no errors in the touched files. (The Playwright walk itself is the existing `live-only` lane — unchanged behavior, same functions, just moved.)

Refs #8796

🤖 Generated with [Claude Code](https://claude.com/claude-code)