### PR TITLE
chore: remove dangling cloud-frontend refs the #9093 cutover left behind

### DIFF
--- a/packages/app-core/scripts/check-i18n.mjs
+++ b/packages/app-core/scripts/check-i18n.mjs
@@ -17,7 +17,6 @@ const LOCALE_DIR = path.join(repoRoot, "packages/ui/src/i18n/locales");
 const SCAN_DIRS = [
   path.join(repoRoot, "packages/app-core/src"),
   path.join(repoRoot, "packages/ui/src"),
-  path.join(repoRoot, "packages/cloud-frontend/src"),
 ];
 const ALLOWLIST_PATH = path.join(__dirname, "i18n-dynamic-keys.json");
 const SOURCE_LOCALE = "en";

--- a/packages/app-core/scripts/lib/agent-source-watcher.mjs
+++ b/packages/app-core/scripts/lib/agent-source-watcher.mjs
@@ -20,7 +20,6 @@ import path from "node:path";
 export const HOT_RELOAD_FRONTEND_PACKAGES = new Set([
   "ui",
   "app",
-  "cloud-frontend",
   "os-homepage",
   "homepage",
   "docs",

--- a/scripts/cloud/mock-stack-up.mjs
+++ b/scripts/cloud/mock-stack-up.mjs
@@ -395,7 +395,15 @@ async function main() {
       }
     }
 
-    if (!flags.noFrontend) {
+    // packages/cloud-frontend was consolidated into packages/app (#9093); the
+    // standalone frontend no longer exists. Skip its boot gracefully when the
+    // dir is absent so the mock stack still comes up (api + control-plane).
+    const frontendDir = path.join(REPO_ROOT, "packages/cloud-frontend");
+    if (!flags.noFrontend && !existsSync(frontendDir)) {
+      process.stderr.write(
+        `${color("gray", "[stack]")} cloud-frontend removed (#9093); skipping frontend boot. The apex frontend now lives in packages/app.\n`,
+      );
+    } else if (!flags.noFrontend) {
       const proc = spawn(
         "bun",
         [

--- a/scripts/e2e-recordings/audit-ui-coverage.mjs
+++ b/scripts/e2e-recordings/audit-ui-coverage.mjs
@@ -18,7 +18,6 @@ import {
 
 const REQUIRED_STANDALONE_UI_DIRS = [
   "packages/app",
-  "packages/cloud-frontend",
   "packages/test/cloud-e2e",
   "packages/homepage",
   "packages/os-homepage",

--- a/scripts/e2e-recordings/suites.mjs
+++ b/scripts/e2e-recordings/suites.mjs
@@ -14,14 +14,6 @@ export const UI_E2E_SUITES = [
     recordEnv: { ELIZA_UI_SMOKE_FORCE_STUB: "1" },
   },
   {
-    name: "cloud-frontend",
-    displayName: "Cloud frontend",
-    configDir: "packages/cloud-frontend",
-    script: "test:e2e",
-    coverage:
-      "Runs cloud login/session, dashboard routes, settings, API key, billing, route coverage, visual pages, screenshots, traces, and videos.",
-  },
-  {
     name: "cloud-e2e",
     displayName: "Cloud full-stack mock e2e",
     configDir: "packages/test/cloud-e2e",


### PR DESCRIPTION
## Summary

Follow-up to the #9093 apex cutover (which deleted `packages/cloud-frontend` and is now on `develop`). That PR's base predated several `cloud-frontend` references that landed on `develop` in parallel, so the merge left **dangling functional references to the now-deleted package**:

- `packages/app-core/scripts/check-i18n.mjs` — scanned `packages/cloud-frontend/src` (a deleted dir).
- `packages/app-core/scripts/lib/agent-source-watcher.mjs` — `cloud-frontend` in `HOT_RELOAD_FRONTEND_PACKAGES`.
- `scripts/e2e-recordings/suites.mjs` — a `cloud-frontend` UI e2e suite pointing at the deleted dir.
- `scripts/e2e-recordings/audit-ui-coverage.mjs` — `packages/cloud-frontend` in `REQUIRED_STANDALONE_UI_DIRS`.
- `scripts/cloud/mock-stack-up.mjs` — `cloud:mock` unconditionally `spawn`ed `bun --cwd packages/cloud-frontend dev`, which now fails.

## Changes

- Drop the cloud-frontend entries from the i18n scan dirs, the hot-reload frontend set, the e2e suite list, and the required-UI-dirs list.
- `mock-stack-up.mjs`: skip the frontend boot gracefully (with a log) when the removed package's dir is absent — the apex frontend now lives in `packages/app`.

Comment/config-only; no runtime behavior change beyond not booting a deleted package. `bun.lock` is already clean on `develop` (the cutover regenerated it). The 5 edited `.mjs` files pass `node --check`. `grep` confirms zero functional `cloud-frontend` references remain in scripts/config after this change.

## Context

This is the residual cleanup the #9093 merge couldn't include because the references were added to `develop` after the PR branched. The `e2e-recordings` and `cloud:mock` lanes would otherwise fail on the missing package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)