### PR TITLE
fix(core): log task-scheduler tick failures instead of swallowing them (#9152)

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
+import type { IDatabaseAdapter } from "../types/database";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { Task } from "../types/task";
+import {
+	registerTaskSchedulerRuntime,
+	startTaskScheduler,
+	stopTaskScheduler,
+} from "./task-scheduler.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+function makeRuntime(): IAgentRuntime {
+	return { agentId: AGENT_ID } as unknown as IAgentRuntime;
+}
+
+/**
+ * Drive a single scheduler tick: advance the fake timer to fire the interval,
+ * then let the rejected/resolved tick promise settle on the microtask queue.
+ */
+async function runOneTick(): Promise<void> {
+	await vi.advanceTimersByTimeAsync(1000);
+}
+
+describe("task-scheduler", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		errorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		stopTaskScheduler();
+		errorSpy.mockRestore();
+		vi.useRealTimers();
+	});
+
+	it("logs the error and keeps ticking when getTasks rejects", async () => {
+		const failure = new Error("db outage");
+		let getTasksCalls = 0;
+		const adapter = {
+			getTasks: vi.fn(async () => {
+				getTasksCalls += 1;
+				throw failure;
+			}),
+		} as unknown as IDatabaseAdapter;
+
+		startTaskScheduler(adapter);
+		const taskService = { runTick: vi.fn(async () => undefined) };
+		registerTaskSchedulerRuntime(makeRuntime(), taskService);
+
+		await runOneTick();
+
+		// The rejection is surfaced through the structured logger, not swallowed.
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		const [context, message] = errorSpy.mock.calls[0];
+		expect(context).toMatchObject({ err: failure });
+		expect(message).toContain("tick failed");
+
+		// Scheduling continues: a fresh dirty agent on the next tick still queries.
+		expect(getTasksCalls).toBe(1);
+		registerTaskSchedulerRuntime(makeRuntime(), taskService);
+		await runOneTick();
+		expect(getTasksCalls).toBe(2);
+		expect(errorSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not log when getTasks succeeds", async () => {
+		const task = { id: "t1", agentId: AGENT_ID } as unknown as Task;
+		const adapter = {
+			getTasks: vi.fn(async () => [task]),
+		} as unknown as IDatabaseAdapter;
+
+		startTaskScheduler(adapter);
+		const runTick = vi.fn(async () => undefined);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick });
+
+		await runOneTick();
+
+		expect(runTick).toHaveBeenCalledTimes(1);
+		expect(runTick).toHaveBeenCalledWith([task]);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/services/task-scheduler.ts
+++ b/packages/core/src/services/task-scheduler.ts
@@ -6,6 +6,7 @@
  * Opt-in: host calls startTaskScheduler(adapter); TaskService registers when daemon is present.
  */
 
+import { logger } from "../logger";
 import type { IDatabaseAdapter } from "../types/database";
 import type { UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
@@ -72,7 +73,12 @@ export function startTaskScheduler(adapterInstance: IDatabaseAdapter): void {
 	adapter = adapterInstance;
 	if (timer) return;
 	timer = setInterval(() => {
-		tick().catch(() => {});
+		// Surface batched getTasks/grouping failures so a DB outage or adapter bug
+		// is observable instead of the timer silently firing nothing. Per-agent
+		// runTick failures are already isolated + logged inside the loop above.
+		tick().catch((err) =>
+			logger.error({ err }, "[task-scheduler] tick failed"),
+		);
 	}, TICK_INTERVAL_MS) as ReturnType<typeof setInterval>;
 }
 


### PR DESCRIPTION
Closes #9152.

## Problem

The per-daemon task scheduler's interval callback (`packages/core/src/services/task-scheduler.ts`) used:

```ts
tick().catch(() => {});
```

This swallowed **every** error raised in the outer tick path — the batched `adp.getTasks({ tags: ["queue"], agentIds })` call plus the grouping logic — with no log at any level. Because this is the single process-wide timer for per-daemon scheduling, a `getTasks` failure (DB outage, adapter/schema bug) left the timer ticking and silently firing nothing for the affected agents.

The inner per-agent `try/catch` around `runTick` is correct and already surfaces failures via `runtime.logger.error` inside `runTick`/`executeTask`; only the outer path was swallowed.

## Fix

- `import { logger } from "../logger";`
- Replace the silent swallow with a structured log that includes the error context (object-first form matching the convention used elsewhere in this package, e.g. `services/setup-rpc.ts`):

```ts
tick().catch((err) =>
  logger.error({ err }, "[task-scheduler] tick failed"),
);
```

The inner per-agent catch is left unchanged — those errors are intentionally isolated per agent and already logged downstream.

## Test

Adds `packages/core/src/services/task-scheduler.test.ts` (the module had no tests):
- **rejecting `getTasks`** → asserts the error is logged via `logger.error` (`{ err }` context + `"tick failed"` message) and the scheduler **keeps ticking** (a fresh dirty agent on the next interval still triggers a `getTasks` call, and the second failure logs again).
- **successful `getTasks`** → asserts `runTick` is dispatched with the agent's tasks and **no** error is logged.

## Verification

```
$ bun run --cwd packages/core test -- task-scheduler
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ bun run --cwd packages/core typecheck
$ tsgo --noEmit -p ./tsconfig.json   # exit 0, no errors

$ bunx biome check src/services/task-scheduler.ts src/services/task-scheduler.test.ts
 Checked 2 files. No fixes applied.
```

Scope is a single source file plus its new test. No lockfile or generated-artifact churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)