### PR TITLE
chore(cloud): remove dead cloud-frontend refs left by the apex cutover (#9093)

### DIFF
--- a/packages/app-core/scripts/check-i18n.mjs
+++ b/packages/app-core/scripts/check-i18n.mjs
@@ -17,7 +17,6 @@ const LOCALE_DIR = path.join(repoRoot, "packages/ui/src/i18n/locales");
 const SCAN_DIRS = [
   path.join(repoRoot, "packages/app-core/src"),
   path.join(repoRoot, "packages/ui/src"),
-  path.join(repoRoot, "packages/cloud-frontend/src"),
 ];
 const ALLOWLIST_PATH = path.join(__dirname, "i18n-dynamic-keys.json");
 const SOURCE_LOCALE = "en";

--- a/packages/app-core/scripts/lib/agent-source-watcher.mjs
+++ b/packages/app-core/scripts/lib/agent-source-watcher.mjs
@@ -20,7 +20,6 @@ import path from "node:path";
 export const HOT_RELOAD_FRONTEND_PACKAGES = new Set([
   "ui",
   "app",
-  "cloud-frontend",
   "os-homepage",
   "homepage",
   "docs",

--- a/packages/cloud-shared/src/lib/constants/agent-flavors.ts
+++ b/packages/cloud-shared/src/lib/constants/agent-flavors.ts
@@ -35,7 +35,7 @@ export interface AgentFlavor {
  *   2. `process.env.ENVIRONMENT` — Worker `[vars]` binding from wrangler.toml.
  *   3. `process.env.NODE_ENV === "production"` — last-resort fallback.
  *
- * Wire `VITE_ENVIRONMENT` per env in `packages/cloud-frontend/wrangler.toml`
+ * Wire `VITE_ENVIRONMENT` per env in `packages/app/wrangler.toml`
  * and the cloud-cf-deploy workflow build step so staging and prod SPAs each
  * see the correct mode.
  */

--- a/packages/shared/src/hardware-catalog/index.ts
+++ b/packages/shared/src/hardware-catalog/index.ts
@@ -4,7 +4,7 @@
  * Single source of truth for hardware SKUs, copy, pricing, and color options
  * shared across:
  *   - `@elizaos/os-homepage` (marketing site product tiles + checkout)
- *   - `@elizaos/cloud-frontend` (signed-in checkout page)
+ *   - `@elizaos/app` (signed-in checkout page)
  *   - `@elizaos/cloud-api` (Stripe checkout-session creation)
  *
  * Adding a product here automatically:
@@ -47,9 +47,9 @@ export type Product = {
   summary: string;
   /** Longer marketing detail (one sentence). */
   detail: string;
-  /** Short subtitle used by cloud-frontend's checkout panel. */
+  /** Short subtitle used by the cloud checkout panel. */
   subtitle: string;
-  /** UI hint used by cloud-frontend to pick an icon and visual layout. */
+  /** UI hint used by the cloud checkout to pick an icon and visual layout. */
   kind: ProductKind;
   /** Selectable colors. */
   colors: ProductColor[];


### PR DESCRIPTION
## What

Follow-up cleanup to **#9093** (cloud-frontend → packages/app apex cutover), which merged the package deletion but left a handful of dead references to the now-deleted `packages/cloud-frontend`.

## Why these are safe / non-urgent

None break CI — they're dead config + stale doc comments:

- `check-i18n.mjs` scanned `packages/cloud-frontend/src`, but `walk()` is `existsSync`-guarded so a missing dir is a no-op (and the script isn't wired into any CI lane).
- `agent-source-watcher.mjs` `HOT_RELOAD_FRONTEND_PACKAGES` still listed `cloud-frontend` — a skip-list entry that simply never matches now.
- Two JSDoc comments (`agent-flavors.ts`, `hardware-catalog/index.ts`) pointed at `packages/cloud-frontend` (wrangler.toml + the signed-in checkout page) — repointed to `packages/app`, which now owns the apex + checkout.

## Not touched

`scenario-pr-workflow.test.ts` already validates the post-cutover state correctly (`packages/app test:e2e`; the one `cloud-frontend` string there is a `.not.toBe()` negative guard). Left as-is.

## Verification

- `biome check` on all 4 files: clean
- `typecheck` (shared, cloud-shared): 0 errors (comment-only)
- `scenario-pr-workflow.test.ts`: 10/10 pass on develop (unchanged)
- No remaining `@elizaos/cloud-frontend` imports anywhere in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)