### PR TITLE
refactor(app): remove the top-down LifeOps aggregate surface — Stage 1 (#8833)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -23,13 +23,6 @@ export interface AppMenuEntry {
 
 const APP_MENU_ENTRIES: readonly AppMenuEntry[] = [
   {
-    slug: "lifeops",
-    name: "@elizaos/plugin-personal-assistant",
-    displayName: "LifeOps",
-    windowPath: "/apps/lifeops",
-    hasDetailsPage: true,
-  },
-  {
     slug: "plugin-viewer",
     name: "@elizaos/app-plugin-viewer",
     displayName: "Plugin Viewer",

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -18,7 +18,7 @@ export interface DeepLinkHandlerContext {
   logPrefix: string;
   trustPolicy: UrlTrustPolicy;
   dispatchShareTarget: (payload: ShareTargetPayload) => void;
-  dispatchLifeOpsCallback: (url: string) => void;
+  dispatchDeepLinkCallback: (url: string) => void;
 }
 
 export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
@@ -70,13 +70,9 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
       case "browser":
         setHashRoute("browser", parsed.searchParams);
         break;
-      case "lifeops":
-        window.location.hash = "#lifeops";
-        ctx.dispatchLifeOpsCallback(url);
-        break;
       case "settings":
         window.location.hash = "#settings";
-        ctx.dispatchLifeOpsCallback(url);
+        ctx.dispatchDeepLinkCallback(url);
         break;
       case "connect":
         handleConnect(parsed);

--- a/packages/app/src/deep-link-routing.test.ts
+++ b/packages/app/src/deep-link-routing.test.ts
@@ -124,58 +124,58 @@ describe("assistant launch deep-link routing", () => {
     );
   });
 
-  it("routes Android widget daily brief links into LifeOps overview", () => {
+  it("routes Android widget daily brief links into chat with a planner hint", () => {
     const hashRoute = buildAssistantLaunchHashRoute(
       "lifeops/daily-brief",
       new URLSearchParams("source=android-widget&action=lifeops.daily-brief"),
       { generateLaunchId: () => "launch-android-widget" },
     );
 
-    expect(hashRoute?.startsWith("#lifeops?")).toBe(true);
+    expect(hashRoute?.startsWith("#chat?")).toBe(true);
     expect(params(hashRoute ?? "").get("source")).toBe("android-widget");
     expect(params(hashRoute ?? "").get("action")).toBe("lifeops.daily-brief");
-    expect(params(hashRoute ?? "").get("lifeops.section")).toBe("overview");
+    expect(params(hashRoute ?? "").get("lifeops.section")).toBeNull();
     expect(params(hashRoute ?? "").get("assistant.launchId")).toBe(
       "launch-android-widget",
     );
   });
 
-  it("routes Android feature-open inventory to LifeOps daily brief", () => {
+  it("routes Android feature-open inventory to chat with a daily-brief hint", () => {
     const hashRoute = buildAssistantLaunchHashRoute(
       "feature/open",
       new URLSearchParams("source=android-app-actions&feature=daily%20brief"),
       { generateLaunchId: () => "launch-brief" },
     );
 
-    expect(hashRoute?.startsWith("#lifeops?")).toBe(true);
+    expect(hashRoute?.startsWith("#chat?")).toBe(true);
     expect(params(hashRoute ?? "").get("source")).toBe("android-app-actions");
     expect(params(hashRoute ?? "").get("action")).toBe("lifeops.daily-brief");
-    expect(params(hashRoute ?? "").get("lifeops.section")).toBe("overview");
+    expect(params(hashRoute ?? "").get("lifeops.section")).toBeNull();
   });
 
-  it("routes Android feature-open task inventory into LifeOps reminders", () => {
+  it("routes Android feature-open task inventory into chat with a tasks hint", () => {
     const hashRoute = buildAssistantLaunchHashRoute(
       "feature/open",
       new URLSearchParams("source=android-app-actions&feature=tasks"),
       { generateLaunchId: () => "launch-tasks" },
     );
 
-    expect(hashRoute?.startsWith("#lifeops?")).toBe(true);
+    expect(hashRoute?.startsWith("#chat?")).toBe(true);
     expect(params(hashRoute ?? "").get("source")).toBe("android-app-actions");
     expect(params(hashRoute ?? "").get("action")).toBe("lifeops.tasks");
-    expect(params(hashRoute ?? "").get("lifeops.section")).toBe("reminders");
+    expect(params(hashRoute ?? "").get("lifeops.section")).toBeNull();
   });
 
-  it("opens LifeOps reminders when create links do not carry text", () => {
+  it("routes text-free create links into chat with a create hint", () => {
     const hashRoute = buildAssistantLaunchHashRoute(
       "lifeops/create",
       new URLSearchParams(),
       { generateLaunchId: () => "launch-lifeops-empty" },
     );
 
-    expect(hashRoute?.startsWith("#lifeops?")).toBe(true);
+    expect(hashRoute?.startsWith("#chat?")).toBe(true);
     expect(params(hashRoute ?? "").get("action")).toBe("lifeops.create");
-    expect(params(hashRoute ?? "").get("lifeops.section")).toBe("reminders");
+    expect(params(hashRoute ?? "").get("lifeops.section")).toBeNull();
   });
 
   it("fuzzes arbitrary assistant entry query strings without throwing or producing unsafe routes", () => {
@@ -228,7 +228,7 @@ describe("assistant launch deep-link routing", () => {
           });
 
           expect(hashRoute).not.toBeNull();
-          expect(hashRoute).toMatch(/^#(?:chat|lifeops)(?:\?|$)/);
+          expect(hashRoute).toMatch(/^#chat(?:\?|$)/);
           expect(hashRoute).not.toContain("javascript:");
           expect(hashRoute).not.toContain("\n");
           expect(hashRoute).not.toContain("\r");

--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -163,6 +163,10 @@ export function buildAssistantLaunchHashRoute(
       params.set("voice", "1");
       return formatHashRoute("chat", params);
     }
+    // Personal-assistant deep links no longer target a top-level "lifeops"
+    // aggregate view (it was decomposed into independent plugins). They route
+    // into chat with the assistant-entry source + a planner action hint so the
+    // agent handles the briefing / task intent inline.
     case "daily-brief":
     case "lifeops/daily-brief": {
       const params = withDefaultSearchParam(
@@ -172,8 +176,7 @@ export function buildAssistantLaunchHashRoute(
       );
       params.set("action", params.get("action") ?? "lifeops.daily-brief");
       ensureAssistantLaunchId(params, generateLaunchId);
-      params.set("lifeops.section", "overview");
-      return formatHashRoute("lifeops", params);
+      return formatHashRoute("chat", params);
     }
     case "lifeops/tasks": {
       const params = withDefaultSearchParam(
@@ -183,8 +186,7 @@ export function buildAssistantLaunchHashRoute(
       );
       params.set("action", params.get("action") ?? "lifeops.tasks");
       ensureAssistantLaunchId(params, generateLaunchId);
-      params.set("lifeops.section", "reminders");
-      return formatHashRoute("lifeops", params);
+      return formatHashRoute("chat", params);
     }
     case "lifeops/create":
     case "lifeops/task":
@@ -197,11 +199,7 @@ export function buildAssistantLaunchHashRoute(
       );
       params.set("action", params.get("action") ?? "lifeops.create");
       ensureAssistantLaunchId(params, generateLaunchId);
-      if (hasAssistantLaunchText(params)) {
-        return formatHashRoute("chat", params);
-      }
-      params.set("lifeops.section", "reminders");
-      return formatHashRoute("lifeops", params);
+      return formatHashRoute("chat", params);
     }
     default:
       return null;

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -199,7 +199,7 @@ function importCompanionInferenceNotice() {
   );
 }
 
-function importAppLifeOps() {
+function importPersonalAssistant() {
   return cachedDynamicImport(
     "@elizaos/plugin-personal-assistant",
     () => import("@elizaos/plugin-personal-assistant"),
@@ -298,11 +298,11 @@ const PhoneCompanionApp = lazyNamedComponent<Record<string, never>>(
   async () => (await importAppPhone()).PhoneCompanionApp,
 );
 const AppBlockerSettingsCard = lazyNamedComponent<AppBlockerSettingsCardProps>(
-  async () => (await importAppLifeOps()).AppBlockerSettingsCard,
+  async () => (await importPersonalAssistant()).AppBlockerSettingsCard,
 );
 const WebsiteBlockerSettingsCard =
   lazyNamedComponent<WebsiteBlockerSettingsCardProps>(
-    async () => (await importAppLifeOps()).WebsiteBlockerSettingsCard,
+    async () => (await importPersonalAssistant()).WebsiteBlockerSettingsCard,
   );
 const StewardLogo = lazyNamedComponent<StewardLogoProps>(
   async () => (await importAppSteward()).StewardLogo,
@@ -624,7 +624,7 @@ function initializeAppModules(): Promise<void> {
       importCompanionSceneStatusContext(),
       importCompanionInferenceNotice(),
       // Side-effect import for the PA HTTP client + Blocker settings cards.
-      importAppLifeOps(),
+      importPersonalAssistant(),
       // Imported for its self-registration side effect (Vincent overlay app).
       importAppVincent(),
       importAppTaskCoordinator(),
@@ -1582,9 +1582,6 @@ function handleDeepLink(url: string): void {
       break;
     case "browser":
       setHashRoute("browser", parsed.searchParams);
-      break;
-    case "lifeops":
-      window.location.hash = "#lifeops";
       break;
     case "settings":
       window.location.hash = "#settings";

--- a/packages/ui/src/components/pages/AppDetailsView.stories.tsx
+++ b/packages/ui/src/components/pages/AppDetailsView.stories.tsx
@@ -8,7 +8,7 @@ import { AppDetailsView } from "./AppDetailsView";
  * in-memory internal-tool / overlay registries and the (network-backed)
  * registry catalog. In Storybook the catalog never loads, so catalog-only
  * slugs fall through to the "not found" state, while internal-tool slugs
- * such as `lifeops` resolve from the in-memory registry and render fully.
+ * such as `fine-tuning` resolve from the in-memory registry and render fully.
  */
 const meta = {
   title: "Pages/AppDetailsView",
@@ -17,7 +17,7 @@ const meta = {
   parameters: { layout: "fullscreen" },
   decorators: [mockApp()],
   args: {
-    slug: "lifeops",
+    slug: "fine-tuning",
     onLaunched: () => {},
   },
 } satisfies Meta<typeof AppDetailsView>;
@@ -25,7 +25,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Internal-tool app resolved from the in-memory registry (LifeOps). */
+/** Internal-tool app resolved from the in-memory registry (Fine Tuning). */
 export const Default: Story = {};
 
 /** Same app, but with live runs surfaced in the header + Recent Runs. */
@@ -35,14 +35,14 @@ export const WithActiveRuns: Story = {
       appRuns: [
         {
           runId: "run-7c1f",
-          appName: "@elizaos/plugin-personal-assistant",
-          displayName: "LifeOps",
+          appName: "@elizaos/plugin-training",
+          displayName: "Fine Tuning",
           status: "running",
         },
         {
           runId: "run-3a90",
-          appName: "@elizaos/plugin-personal-assistant",
-          displayName: "LifeOps",
+          appName: "@elizaos/plugin-training",
+          displayName: "Fine Tuning",
           status: "exited",
         },
         // Unrelated run — filtered out by appName.

--- a/packages/ui/src/components/pages/page-scoped-conversations.ts
+++ b/packages/ui/src/components/pages/page-scoped-conversations.ts
@@ -73,14 +73,8 @@ const PAGE_SCOPE_ROUTING_CONTEXTS: Record<
     secondaryContexts: ["page", "page-plugins", "plugins", "admin"],
   },
   "page-lifeops": {
-    primaryContext: "lifeops",
-    secondaryContexts: [
-      "page",
-      "page-lifeops",
-      "lifeops",
-      "automation",
-      "social_posting",
-    ],
+    primaryContext: "automation",
+    secondaryContexts: ["page", "page-lifeops", "automation", "social_posting"],
   },
   "page-settings": {
     primaryContext: "settings",
@@ -98,7 +92,7 @@ const PAGE_SCOPE_ROUTING_CONTEXTS: Record<
  * single prompt-regime cohort instead of mixing trajectories generated under
  * different surface contracts.
  */
-export const PAGE_SCOPE_VERSION = 13;
+export const PAGE_SCOPE_VERSION = 14;
 
 export interface PageScopeIntroCopy {
   /** Short user-facing intro card title shown when the conversation is empty. */

--- a/packages/ui/src/components/settings/permission-types.ts
+++ b/packages/ui/src/components/settings/permission-types.ts
@@ -94,7 +94,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.reminders.description",
     icon: "list-todo",
     platforms: ["darwin"],
-    requiredForFeatures: ["lifeops", "reminders"],
+    requiredForFeatures: ["reminders"],
   },
   {
     id: "calendar",
@@ -104,7 +104,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.calendar.description",
     icon: "calendar",
     platforms: ["darwin", "ios"],
-    requiredForFeatures: ["lifeops", "calendar"],
+    requiredForFeatures: ["calendar"],
   },
   {
     id: "health",
@@ -114,7 +114,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.health.description",
     icon: "heart-pulse",
     platforms: ["darwin", "ios", "android"],
-    requiredForFeatures: ["lifeops", "health", "sleep"],
+    requiredForFeatures: ["health", "sleep"],
   },
   {
     id: "screentime",
@@ -124,7 +124,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.screentime.description",
     icon: "hourglass",
     platforms: ["darwin", "ios", "android"],
-    requiredForFeatures: ["lifeops", "screentime"],
+    requiredForFeatures: ["screentime"],
   },
   {
     id: "contacts",
@@ -144,7 +144,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.notes.description",
     icon: "notebook-tabs",
     platforms: ["darwin"],
-    requiredForFeatures: ["lifeops", "notes"],
+    requiredForFeatures: ["notes"],
   },
   {
     id: "notifications",
@@ -155,7 +155,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.notifications.description",
     icon: "bell",
     platforms: ["darwin", "win32", "linux", "ios", "android", "web"],
-    requiredForFeatures: ["notifications", "lifeops"],
+    requiredForFeatures: ["notifications"],
   },
   {
     id: "full-disk",
@@ -248,7 +248,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
     descriptionKey: "permissionssection.permission.appBlocking.description",
     icon: "shield-ban",
     platforms: ["ios", "android"],
-    requiredForFeatures: ["app-blocker", "lifeops"],
+    requiredForFeatures: ["app-blocker"],
   },
   {
     id: "usage-access",
@@ -300,7 +300,7 @@ export const SYSTEM_PERMISSIONS: PermissionDef[] = [
       "permissionssection.permission.batteryOptimization.description",
     icon: "battery",
     platforms: ["android"],
-    requiredForFeatures: ["lifeops", "mobile-signals"],
+    requiredForFeatures: ["mobile-signals"],
   },
 ];
 

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -151,7 +151,7 @@ export function computePromptSuggestions(
 /**
  * Derive the active {@link PageScope} from the current location so the server
  * can tailor suggestions per view. The shell navigates by path or hash
- * (`/lifeops`, `#/lifeops?...`), so the first segment of whichever is present
+ * (`/browser`, `#/browser?...`), so the first segment of whichever is present
  * is the tab id; `page-<tab>` counts only when it's a registered scope. Pure
  * for unit tests; returns undefined off-DOM or on unscoped views.
  */

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -230,8 +230,7 @@ export const ALL_TAB_GROUPS: TabGroup[] = [
     label: "Views",
     tabs: ["views", "apps", ...APPS_TOOL_TABS],
     icon: Gamepad2,
-    description:
-      "Agent-provided views, games, LifeOps, integrations, and app tools",
+    description: "Agent-provided views, games, integrations, and app tools",
   },
   {
     label: "Character",

--- a/packages/ui/src/platform/assistant-launch-payload.test.ts
+++ b/packages/ui/src/platform/assistant-launch-payload.test.ts
@@ -110,11 +110,11 @@ describe("assistant launch payloads", () => {
     expect(window.location.hash).toContain("assistant.launchId=launch-3");
   });
 
-  it("clears stale LifeOps surface params after chat consumes a create launch", () => {
+  it("clears payload params but preserves unrelated surface params on chat", () => {
     window.history.replaceState(
       null,
       "",
-      "/#chat?text=Create%20a%20task&source=assistant-entry&action=lifeops.create&assistant.launchId=launch-4&lifeops.section=reminders",
+      "/#chat?text=Create%20a%20task&source=assistant-entry&action=lifeops.create&assistant.launchId=launch-4&surface=reminders",
     );
 
     expect(
@@ -128,7 +128,7 @@ describe("assistant launch payloads", () => {
       source: "assistant-entry",
       text: "Create a task",
     });
-    expect(window.location.hash).toBe("#chat");
+    expect(window.location.hash).toBe("#chat?surface=reminders");
   });
 
   it("leaves payload params for a different route consumer", () => {

--- a/packages/ui/src/platform/assistant-launch-payload.ts
+++ b/packages/ui/src/platform/assistant-launch-payload.ts
@@ -146,9 +146,6 @@ export function clearAssistantLaunchPayloadFromHash(): void {
   for (const key of ASSISTANT_LAUNCH_PARAM_KEYS) {
     params.delete(key);
   }
-  if (routePart.replace(/^#\/?|\/+$/g, "") === "chat") {
-    params.delete("lifeops.section");
-  }
 
   const nextHash = params.toString() ? `${routePart}?${params}` : routePart;
   if (nextHash === window.location.hash) return;

--- a/packages/ui/src/state/chat-conversation-guards.ts
+++ b/packages/ui/src/state/chat-conversation-guards.ts
@@ -13,7 +13,6 @@ const LEGACY_PAGE_CHAT_TITLES = new Set([
   "automations",
   "apps",
   "phone",
-  "lifeops",
   "settings",
   "wallet",
 ]);

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -197,13 +197,6 @@ function resolveChatViewRouting(
         secondaryContexts: ["documents"],
         capabilities: ["wallet", "portfolio", "transactions"],
       };
-    case "lifeops":
-      return {
-        view: "apps",
-        primaryContext: "automation",
-        secondaryContexts: ["social_posting", "documents"],
-        capabilities: ["lifeops", "tasks", "calendar"],
-      };
     case "plugins":
     case "runtime":
     case "database":

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -124,8 +124,8 @@ export type WidgetPluginState = Pick<PluginInfo, "id" | "enabled" | "isActive">;
  * Some bundled widgets intentionally stay visible even when the runtime plugin
  * snapshot omits their feature IDs because the UI has compat-backed data
  * sources for them. Generic task-list widgets do not qualify here — Eliza does
- * not ship a runtime task-list plugin, and leaving the fallback enabled crowds
- * out the LifeOps-first sidebar with a stale generic tasks panel.
+ * not ship a runtime task-list plugin, and leaving the fallback enabled would
+ * crowd the sidebar with a stale generic tasks panel.
  */
 const BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS = new Set([
   "agent-orchestrator",


### PR DESCRIPTION
## LifeOps eradication — Stage 1 (app-shell / UI de-hardcode)

Per the decomposition direction: **LifeOps is no longer a thing unto itself** — it was split into independent plugins (inbox, calendar, health, blocker, scheduling, finances, goals, todos, …) that self-register their own views/routes/actions. This stage removes the app-shell/UI hardcoding of the `lifeops` **aggregate app/destination** and the `lifeops` **umbrella token**; every specific plugin feature stays.

### Changed (15 files, +51/−85)
- **Deep links:** drop the `lifeops` case (`#lifeops`) from `deep-link-handler.ts` + `main.tsx`; rename the generic `dispatchLifeOpsCallback`→`dispatchDeepLinkCallback` (it also served settings) and `importAppLifeOps`→`importPersonalAssistant`. PA deep-link routes (daily-brief/tasks/reminder) now route to `#chat` with the assistant-entry source + planner action hint (no aggregate view).
- **Menu/chat:** remove the `lifeops` Electrobun menu entry + the dead `useChatSend` `lifeops` case.
- **Permissions:** strip the `lifeops` umbrella token from `requiredForFeatures` arrays, keeping the specific features.
- **Page context:** repoint page-scoped `lifeops` primaryContext → `automation` (scope ver 13→14); swap the `AppDetailsView` story fixture off the removed LifeOps app.

### Intentionally NOT touched (later stages, tracked)
The cross-layer `lifeops` ids that need coordinated changes: the `page-lifeops` scope id (shared contract + agent allowlist + drift test), PA event sources (`lifeops-reminder`/`-workflow`), the shared/health contracts, the `plugin-personal-assistant` `lifeops/` subsystem, the knowledge-graph **persisted** boundary (needs a data migration), app-core benchmarks, and i18n. These are sequenced as Stages 2–8.

### Verification
- `typecheck` packages/ui + packages/app + packages/app-core → **0 errors**.
- Unit tests: `deep-link-routing` 13/13, UI (permission-card / useChatSend / page-scoped-conversations / usePromptSuggestions / chat-conversation-guards) 70/70, electrobun deep-link-events 3/3, cross-layer drift guards green. Biome clean.
- Pure-TS UI logic; on-device APK verification batched for after the eradication completes (single rebuild).

Part of #8833. First of a staged series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)