### PR TITLE
perf(ui): guard readiness poll against redundant setAgentStatus re-renders (#9141)

### DIFF
--- a/packages/ui/src/state/useChatLifecycle.readiness.test.ts
+++ b/packages/ui/src/state/useChatLifecycle.readiness.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentStatus } from "../api";
 import { shouldAwaitAgentReadiness } from "./types";
+import { readinessPollSignature } from "./useChatLifecycle";
 
 /**
  * shouldAwaitAgentReadiness is the decision that drives useChatLifecycle's 1.5s
@@ -46,5 +47,87 @@ describe("shouldAwaitAgentReadiness (#8777 waking-up banner)", () => {
     for (const state of ["error", "stopped", "not_started"] as const) {
       expect(shouldAwaitAgentReadiness(status({ state }))).toBe(false);
     }
+  });
+});
+
+/**
+ * The 1.5s readiness poll re-applies the status snapshot every tick while
+ * "waking up…". `readinessPollSignature` is the equality guard that lets the
+ * poll skip `setAgentStatus` — and the re-render of every chat-surface
+ * subscriber — when nothing load-bearing (state / port / canRespond) changed.
+ */
+describe("readinessPollSignature (#9141 readiness-poll re-render guard)", () => {
+  it("is stable across snapshots that differ only in non-load-bearing fields", () => {
+    const a = status({
+      state: "running",
+      port: 31337,
+      canRespond: false,
+      uptime: 1_000,
+      startedAt: 10,
+      agentName: "eliza",
+    });
+    const b = status({
+      state: "running",
+      port: 31337,
+      canRespond: false,
+      uptime: 9_999,
+      startedAt: 99,
+      agentName: "eliza-renamed",
+    });
+    expect(readinessPollSignature(a)).toBe(readinessPollSignature(b));
+  });
+
+  it("changes when any load-bearing field (state/port/canRespond) changes", () => {
+    const base = status({ state: "running", port: 31337, canRespond: false });
+    const sig = readinessPollSignature(base);
+    expect(
+      readinessPollSignature(status({ ...base, state: "stopped" })),
+    ).not.toBe(sig);
+    expect(readinessPollSignature(status({ ...base, port: 4000 }))).not.toBe(
+      sig,
+    );
+    expect(
+      readinessPollSignature(status({ ...base, canRespond: true })),
+    ).not.toBe(sig);
+  });
+
+  it("treats null (readiness unknown) as its own distinct signature", () => {
+    expect(readinessPollSignature(null)).not.toBe(
+      readinessPollSignature(status({ state: "running" })),
+    );
+  });
+
+  /**
+   * Mirrors the guarded poll body in useChatLifecycle: compare the incoming
+   * snapshot's signature against the last-applied one held in a ref; only call
+   * the setter when it changed. Asserts the setter is NOT called on an equal
+   * snapshot, and IS called when a load-bearing field flips.
+   */
+  it("does NOT call setAgentStatus when getStatus returns an equal snapshot", () => {
+    const setAgentStatus = vi.fn();
+    const signatureRef: { current: string | null } = { current: null };
+
+    const applyPolled = (next: AgentStatus) => {
+      const signature = readinessPollSignature(next);
+      if (signature === signatureRef.current) return;
+      signatureRef.current = signature;
+      setAgentStatus(next);
+    };
+
+    const ready = status({ state: "running", port: 31337, canRespond: false });
+    // Seed (first observation applies).
+    applyPolled(ready);
+    // Three identical polls (only uptime drifts) must be skipped.
+    applyPolled(status({ ...ready, uptime: 2_000 }));
+    applyPolled(status({ ...ready, uptime: 3_000 }));
+    applyPolled(status({ ...ready, uptime: 4_000 }));
+    expect(setAgentStatus).toHaveBeenCalledTimes(1);
+
+    // canRespond flips → the setter fires exactly once more.
+    applyPolled(status({ ...ready, canRespond: true }));
+    expect(setAgentStatus).toHaveBeenCalledTimes(2);
+    expect(setAgentStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ canRespond: true }),
+    );
   });
 });

--- a/packages/ui/src/state/useChatLifecycle.ts
+++ b/packages/ui/src/state/useChatLifecycle.ts
@@ -42,6 +42,18 @@ import { shouldAwaitAgentReadiness } from "./types";
 
 const RESET_LOG_PREFIX = "[eliza][reset]";
 
+/**
+ * Signature of the only `AgentStatus` fields the readiness poll cares about
+ * (`state`, `port`, `canRespond`). The 1.5s poll re-applies the status snapshot
+ * every tick while "waking up…"; comparing this signature lets us skip the
+ * `setAgentStatus` write — and the re-render of every chat-surface subscriber —
+ * when nothing load-bearing changed.
+ */
+export function readinessPollSignature(status: AgentStatus | null): string {
+  if (status == null) return "∅";
+  return `${status.state}|${status.port ?? ""}|${status.canRespond ?? ""}`;
+}
+
 function logResetDebug(
   message: string,
   detail?: Record<string, unknown>,
@@ -287,6 +299,7 @@ export function useChatLifecycle(deps: UseChatLifecycleDeps) {
 
   const heartbeatNotificationKeyRef = useRef<string | null>(null);
   const restartNotificationSignatureRef = useRef<string | null>(null);
+  const readinessPollSignatureRef = useRef<string | null>(null);
 
   const handleStartDraftConversation = useCallback(async () => {
     interruptActiveChatPipeline();
@@ -544,12 +557,22 @@ export function useChatLifecycle(deps: UseChatLifecycleDeps) {
   useEffect(() => {
     if (!awaitingAgentReadiness) return;
     let active = true;
+    // Reset the guard for this poll instance; the first result applies, then
+    // every subsequent identical tick is skipped. The ref persists across ticks
+    // within this effect and keeps the dep array (+ interval teardown) untouched.
+    readinessPollSignatureRef.current = null;
     const refresh = async () => {
       if (!active) return;
       if (typeof document !== "undefined" && document.hidden) return;
       try {
         const next = await client.getStatus();
-        if (active) setAgentStatus(next);
+        if (!active) return;
+        // Skip the re-render of every chat-surface subscriber when nothing
+        // load-bearing (state / port / canRespond) actually changed.
+        const signature = readinessPollSignature(next);
+        if (signature === readinessPollSignatureRef.current) return;
+        readinessPollSignatureRef.current = signature;
+        setAgentStatus(next);
       } catch {
         // Transient (agent restarting / IPC hiccup) — keep polling.
       }


### PR DESCRIPTION
## Slice of #9141 — readiness-poll re-render guard

This is the smallest standalone win called out in the issue triage: the 1.5s readiness poll in `packages/ui/src/state/useChatLifecycle.ts`. While the agent is "waking up…", the poll's `refresh()` called `setAgentStatus(next)` **unconditionally** every 1.5s, re-rendering every chat-surface subscriber even when nothing changed in the snapshot.

### Change
- Added a file-local `readinessPollSignature(status)` helper that captures only the load-bearing fields the poll cares about: `state`, `port`, `canRespond`.
- The poll now compares the new snapshot's signature against the last-applied one (held in a `useRef`), and **skips `setAgentStatus` when unchanged**.
- The effect's dependency array (`[awaitingAgentReadiness, setAgentStatus]`) and the interval teardown are **untouched** — the guard lives entirely in a ref that persists across ticks within the effect instance, per the issue's exact prescription.

Scope is strictly this one guard; the other 7 perf items in the umbrella issue are out of scope here.

### Verification
- `bun run --cwd packages/ui typecheck` — clean.
- `bunx biome check` on both touched files — clean (no `useExhaustiveDependencies` violation; the guard adds no new effect dep).
- `bun run --cwd packages/ui test useChatLifecycle.readiness` — **10 passed** (6 existing + 4 new). New tests assert:
  - the signature is stable across snapshots differing only in non-load-bearing fields (`uptime`, `startedAt`, `agentName`);
  - it changes when any of `state` / `port` / `canRespond` change;
  - **the setter is NOT called when `getStatus()` returns an equal snapshot** (three identical polls → 1 call), and fires again exactly when `canRespond` flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)