### PR TITLE
feat(computeruse): clipboard + get_cursor_position (trycua/cua parity, #9105)

### DIFF
--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -16,8 +16,9 @@ File operations belong to the FILE action; shell/terminal access belongs to the 
 
 | Name | File | What it does |
 |------|------|--------------|
-| `COMPUTER_USE` | `src/actions/use-computer.ts` | Umbrella desktop action: `screenshot`, `click`, `click_with_modifiers`, `double_click`, `right_click`, `mouse_move`, `type`, `key`, `key_combo`, `scroll`, `drag`, `detect_elements`, `ocr`. Requires `OWNER` role. Subactions are promoted to virtual top-level actions (`COMPUTER_USE_CLICK`, etc.) via `promoteSubactionsToActions`. |
+| `COMPUTER_USE` | `src/actions/use-computer.ts` | Umbrella desktop action: `screenshot`, `click`, `click_with_modifiers`, `double_click`, `right_click`, `mouse_move`, `type`, `key`, `key_combo`, `scroll`, `drag`, `get_cursor_position`, `detect_elements`, `ocr`. Requires `OWNER` role. Subactions are promoted to virtual top-level actions (`COMPUTER_USE_CLICK`, etc.) via `promoteSubactionsToActions`. |
 | `WINDOW` | `src/actions/window.ts` | Window management: `list`, `focus`, `switch`, `arrange`, `move`, `minimize`, `maximize`, `restore`, `close`. Also promoted to `WINDOW_FOCUS`, etc. |
+| `CLIPBOARD` | `src/actions/clipboard.ts` | Host clipboard read/write (`read`, `write`) — trycua/cua parity. Promoted to `CLIPBOARD_READ` / `CLIPBOARD_WRITE`. macOS pbcopy/pbpaste, Linux wl-clipboard/xclip, Windows PowerShell `Get-Clipboard` / `Set-Clipboard`. |
 | `COMPUTER_USE_AGENT` | `src/actions/use-computer-agent.ts` | High-level "give me a goal, click my way there" loop (WS7). Runs Brain → Cascade → dispatch up to `maxSteps` iterations, emitting trajectory events as structured log lines. |
 
 ### Providers
@@ -59,7 +60,7 @@ src/
     use-computer-agent.ts    COMPUTER_USE_AGENT (WS7 autonomous loop)
     window.ts                WINDOW parent action
     window-handlers.ts       Per-verb handlers called by window.ts
-    clipboard.ts             clipboardAction (CLIPBOARD parent action) — defined but NOT registered in index.ts
+    clipboard.ts             clipboardAction (CLIPBOARD parent action) — registered in index.ts; promoted to CLIPBOARD_READ / CLIPBOARD_WRITE
     helpers.ts               resolveActionParams, buildScreenshotAttachment, …
 
   actor/                     WS7 autonomous desktop loop

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -16,8 +16,9 @@ File operations belong to the FILE action; shell/terminal access belongs to the 
 
 | Name | File | What it does |
 |------|------|--------------|
-| `COMPUTER_USE` | `src/actions/use-computer.ts` | Umbrella desktop action: `screenshot`, `click`, `click_with_modifiers`, `double_click`, `right_click`, `mouse_move`, `type`, `key`, `key_combo`, `scroll`, `drag`, `detect_elements`, `ocr`. Requires `OWNER` role. Subactions are promoted to virtual top-level actions (`COMPUTER_USE_CLICK`, etc.) via `promoteSubactionsToActions`. |
+| `COMPUTER_USE` | `src/actions/use-computer.ts` | Umbrella desktop action: `screenshot`, `click`, `click_with_modifiers`, `double_click`, `right_click`, `mouse_move`, `type`, `key`, `key_combo`, `scroll`, `drag`, `get_cursor_position`, `detect_elements`, `ocr`. Requires `OWNER` role. Subactions are promoted to virtual top-level actions (`COMPUTER_USE_CLICK`, etc.) via `promoteSubactionsToActions`. |
 | `WINDOW` | `src/actions/window.ts` | Window management: `list`, `focus`, `switch`, `arrange`, `move`, `minimize`, `maximize`, `restore`, `close`. Also promoted to `WINDOW_FOCUS`, etc. |
+| `CLIPBOARD` | `src/actions/clipboard.ts` | Host clipboard read/write (`read`, `write`) — trycua/cua parity. Promoted to `CLIPBOARD_READ` / `CLIPBOARD_WRITE`. macOS pbcopy/pbpaste, Linux wl-clipboard/xclip, Windows PowerShell `Get-Clipboard` / `Set-Clipboard`. |
 | `COMPUTER_USE_AGENT` | `src/actions/use-computer-agent.ts` | High-level "give me a goal, click my way there" loop (WS7). Runs Brain → Cascade → dispatch up to `maxSteps` iterations, emitting trajectory events as structured log lines. |
 
 ### Providers
@@ -59,7 +60,7 @@ src/
     use-computer-agent.ts    COMPUTER_USE_AGENT (WS7 autonomous loop)
     window.ts                WINDOW parent action
     window-handlers.ts       Per-verb handlers called by window.ts
-    clipboard.ts             clipboardAction (CLIPBOARD parent action) — defined but NOT registered in index.ts
+    clipboard.ts             clipboardAction (CLIPBOARD parent action) — registered in index.ts; promoted to CLIPBOARD_READ / CLIPBOARD_WRITE
     helpers.ts               resolveActionParams, buildScreenshotAttachment, …
 
   actor/                     WS7 autonomous desktop loop

--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Real-driver verification of the cua-parity input verbs (#9105).
+ * Gated: runs only on a Windows host with a desktop session (and in Windows CI).
+ *
+ * - get_cursor_position: move then read back the OS cursor (uses the native
+ *   System.Windows.Forms.Cursor query on Windows because nutjs getPosition()
+ *   returns a stale constant there).
+ * - clipboard: write then read round-trips (Set-Clipboard via
+ *   [Console]::In.ReadToEnd()).
+ */
+
+import { platform } from "node:os";
+import { describe, expect, it } from "vitest";
+import { readClipboard, writeClipboard } from "../platform/clipboard.js";
+import {
+  driverGetCursorPosition,
+  driverMouseMove,
+} from "../platform/driver.js";
+
+const RUN = platform() === "win32";
+
+describe("cua parity input (real driver, Windows)", () => {
+  it.skipIf(!RUN)(
+    "get_cursor_position reflects driverMouseMove",
+    async () => {
+      for (const [x, y] of [
+        [320, 240],
+        [640, 480],
+      ] as const) {
+        await driverMouseMove(x, y);
+        await new Promise((r) => setTimeout(r, 150));
+        const pos = await driverGetCursorPosition();
+        expect(Math.abs(pos.x - x)).toBeLessThanOrEqual(2);
+        expect(Math.abs(pos.y - y)).toBeLessThanOrEqual(2);
+      }
+    },
+    20000,
+  );
+
+  it.skipIf(!RUN)(
+    "clipboard write/read round-trips",
+    async () => {
+      const token = `eliza-clip-${Date.now()}`;
+      await writeClipboard(token);
+      const back = (await readClipboard()).trim();
+      expect(back).toBe(token);
+    },
+    20000,
+  );
+});

--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-surface.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-surface.test.ts
@@ -1,0 +1,41 @@
+/**
+ * trycua/cua parity surface (#9105) — verify the newly-exposed computer-use
+ * capabilities are actually registered and wired:
+ *   - CLIPBOARD (read/write) is registered (was defined-but-unregistered).
+ *   - COMPUTER_USE exposes a get_cursor_position verb.
+ * Plus a regression guard on the Windows clipboard-write command (the previous
+ * `$input | Set-Clipboard` hung; it must read stdin via [Console]::In.ReadToEnd()).
+ */
+
+import { platform } from "node:os";
+import { describe, expect, it } from "vitest";
+import { computerUsePlugin } from "../index.js";
+import { __testing } from "../platform/clipboard.js";
+
+const actionNames = (computerUsePlugin.actions ?? []).map((a) => a.name);
+
+describe("cua parity surface", () => {
+  it("registers the CLIPBOARD action (read/write)", () => {
+    const hasClipboard = actionNames.some((n) => /CLIPBOARD/i.test(n));
+    expect(hasClipboard, `actions: ${actionNames.join(", ")}`).toBe(true);
+    // Promoted subactions present.
+    expect(actionNames).toContain("CLIPBOARD_READ");
+    expect(actionNames).toContain("CLIPBOARD_WRITE");
+  });
+
+  it("exposes a get_cursor_position computer-use verb", () => {
+    expect(actionNames).toContain("COMPUTER_USE_GET_CURSOR_POSITION");
+  });
+});
+
+describe("clipboard write command (Windows regression)", () => {
+  it.skipIf(platform() !== "win32")(
+    "reads stdin via [Console]::In.ReadToEnd(), not $input",
+    () => {
+      const plan = __testing.pickPlan();
+      const joined = plan.write.args.join(" ");
+      expect(joined).toContain("ReadToEnd");
+      expect(joined).not.toContain("$input | Set-Clipboard");
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/actions/use-computer.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer.ts
@@ -47,6 +47,7 @@ const DESKTOP_ACTIONS = new Set<DesktopActionType>([
   "key_combo",
   "scroll",
   "drag",
+  "get_cursor_position",
   "detect_elements",
   "ocr",
 ]);
@@ -242,6 +243,7 @@ export const useComputerAction: Action = {
           "key_combo",
           "scroll",
           "drag",
+          "get_cursor_position",
           "detect_elements",
           "ocr",
           "resolve_approval",
@@ -365,7 +367,8 @@ export const useComputerAction: Action = {
     const approvalDecision = parseApprovalDecision(params, message);
     if (approvalDecision) {
       if (approvalDecision.ownerMismatch) {
-        const text = "Computer-use approval callback does not belong to this user.";
+        const text =
+          "Computer-use approval callback does not belong to this user.";
         if (callback) {
           await callback({ text }, "COMPUTER_USE");
         }

--- a/plugins/plugin-computeruse/src/approval-manager.ts
+++ b/plugins/plugin-computeruse/src/approval-manager.ts
@@ -17,6 +17,7 @@ const VALID_APPROVAL_MODES: ApprovalMode[] = [
 
 const SAFE_COMMANDS = new Set<string>([
   "screenshot",
+  "get_cursor_position",
   "browser_screenshot",
   "browser_state",
   "browser_info",

--- a/plugins/plugin-computeruse/src/index.ts
+++ b/plugins/plugin-computeruse/src/index.ts
@@ -24,6 +24,7 @@
 
 import type { Plugin, Route } from "@elizaos/core";
 import { promoteSubactionsToActions } from "@elizaos/core";
+import { clipboardAction } from "./actions/clipboard.js";
 import { useComputerAction } from "./actions/use-computer.js";
 import { computerUseAgentAction } from "./actions/use-computer-agent.js";
 import { windowAction } from "./actions/window.js";
@@ -88,6 +89,9 @@ export const computerUsePlugin: Plugin = {
   actions: [
     ...promoteSubactionsToActions(useComputerAction),
     ...promoteSubactionsToActions(windowAction),
+    // CLIPBOARD (read/write the host clipboard) — a core computer-use capability
+    // (trycua/cua parity). Promoted to CLIPBOARD_READ / CLIPBOARD_WRITE.
+    ...promoteSubactionsToActions(clipboardAction),
     computerUseAgentAction,
   ],
 

--- a/plugins/plugin-computeruse/src/platform/clipboard.test.ts
+++ b/plugins/plugin-computeruse/src/platform/clipboard.test.ts
@@ -194,14 +194,20 @@ describe("clipboard — Windows", () => {
     expect(args).toEqual(["-NoProfile", "-Command", "Get-Clipboard -Raw"]);
   });
 
-  it("write pipes to PowerShell Set-Clipboard via $input", async () => {
+  it("write pipes to PowerShell Set-Clipboard via [Console]::In.ReadToEnd()", async () => {
     setPlatform("win32");
     spawnSyncMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
     const { writeClipboard } = await importClipboard();
     await writeClipboard("hello windows");
     const [cmd, args, options] = spawnSyncMock.mock.calls[0] ?? [];
     expect(cmd).toBe("powershell");
-    expect(args).toEqual(["-NoProfile", "-Command", "$input | Set-Clipboard"]);
+    // `$input | Set-Clipboard` hangs under -Command (does not consume piped
+    // stdin); read stdin to EOF explicitly instead.
+    expect(args).toEqual([
+      "-NoProfile",
+      "-Command",
+      "Set-Clipboard -Value ([Console]::In.ReadToEnd())",
+    ]);
     expect((options as { input: string }).input).toBe("hello windows");
   });
 });

--- a/plugins/plugin-computeruse/src/platform/clipboard.ts
+++ b/plugins/plugin-computeruse/src/platform/clipboard.ts
@@ -63,8 +63,14 @@ function pickPlan(): ClipboardPlan {
         args: ["-NoProfile", "-Command", "Get-Clipboard -Raw"],
       },
       write: {
+        // `$input | Set-Clipboard` does NOT reliably consume piped stdin under
+        // -Command (it hangs → ETIMEDOUT). Read stdin to EOF explicitly.
         command: "powershell",
-        args: ["-NoProfile", "-Command", "$input | Set-Clipboard"],
+        args: [
+          "-NoProfile",
+          "-Command",
+          "Set-Clipboard -Value ([Console]::In.ReadToEnd())",
+        ],
       },
     };
   }

--- a/plugins/plugin-computeruse/src/platform/desktop.ts
+++ b/plugins/plugin-computeruse/src/platform/desktop.ts
@@ -167,6 +167,44 @@ $.CGEventPost($.kCGHIDEventTap, scrollEvent);
   );
 }
 
+// ── Cursor query ────────────────────────────────────────────────────────────
+
+/**
+ * Read the current OS cursor position (legacy shell driver). Returns global
+ * logical pixels. Windows uses `System.Windows.Forms.Cursor` (must Add-Type the
+ * assembly first or the type is unresolved); macOS uses `cliclick p:.`; Linux
+ * uses `xdotool getmouselocation`.
+ */
+export function legacyGetCursorPosition(): { x: number; y: number } {
+  const os = currentPlatform();
+  if (os === "win32") {
+    const out = runCommand(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        'Add-Type -AssemblyName System.Windows.Forms; $p=[System.Windows.Forms.Cursor]::Position; "$($p.X),$($p.Y)"',
+      ],
+      5000,
+    );
+    const [x, y] = out.trim().split(",").map(Number);
+    return { x: validateInt(x), y: validateInt(y) };
+  }
+  if (os === "darwin") {
+    const out = runCommand("cliclick", ["p:."], 5000); // prints "x,y"
+    const [x, y] = out.trim().split(",").map(Number);
+    return { x: validateInt(x), y: validateInt(y) };
+  }
+  // Linux / X11
+  const out = runCommand("xdotool", ["getmouselocation", "--shell"], 5000);
+  const mx = /X=(-?\d+)/.exec(out);
+  const my = /Y=(-?\d+)/.exec(out);
+  return {
+    x: mx ? validateInt(Number(mx[1])) : 0,
+    y: my ? validateInt(Number(my[1])) : 0,
+  };
+}
+
 // ── Mouse Click ─────────────────────────────────────────────────────────────
 
 export function desktopClick(x: number, y: number): void {

--- a/plugins/plugin-computeruse/src/platform/driver.ts
+++ b/plugins/plugin-computeruse/src/platform/driver.ts
@@ -23,6 +23,7 @@ import {
   desktopRightClick,
   desktopScroll,
   desktopType,
+  legacyGetCursorPosition,
 } from "./desktop.js";
 import {
   loadFailureReason,
@@ -32,6 +33,7 @@ import {
   nutClickWithModifiers,
   nutDoubleClick,
   nutDrag,
+  nutGetCursorPosition,
   nutKeyCombo,
   nutKeyPress,
   nutMouseMove,
@@ -103,6 +105,18 @@ export async function driverRightClick(x: number, y: number): Promise<void> {
 export async function driverMouseMove(x: number, y: number): Promise<void> {
   if (selectedDriver() === "nutjs") return nutMouseMove(x, y);
   desktopMouseMove(x, y);
+}
+
+export async function driverGetCursorPosition(): Promise<{
+  x: number;
+  y: number;
+}> {
+  // nutjs `mouse.getPosition()` returns a stale/constant value on Windows
+  // (empirically verified), so always use the reliable OS query there
+  // (System.Windows.Forms.Cursor). Elsewhere prefer nutjs when it is active.
+  if (process.platform === "win32") return legacyGetCursorPosition();
+  if (selectedDriver() === "nutjs") return nutGetCursorPosition();
+  return legacyGetCursorPosition();
 }
 
 export async function driverDrag(

--- a/plugins/plugin-computeruse/src/platform/nut-driver.ts
+++ b/plugins/plugin-computeruse/src/platform/nut-driver.ts
@@ -26,6 +26,7 @@ interface NutModule {
   mouse: {
     config: { mouseSpeed: number; autoDelayMs: number };
     setPosition: (point: { x: number; y: number }) => Promise<unknown>;
+    getPosition: () => Promise<{ x: number; y: number }>;
     move: (path: Promise<unknown> | unknown) => Promise<unknown>;
     click: (button: number) => Promise<unknown>;
     doubleClick: (button: number) => Promise<unknown>;
@@ -307,6 +308,15 @@ export async function nutDrag(
   } finally {
     await m.mouse.releaseButton(m.Button.LEFT);
   }
+}
+
+export async function nutGetCursorPosition(): Promise<{
+  x: number;
+  y: number;
+}> {
+  const m = nut();
+  const p = await m.mouse.getPosition();
+  return { x: Math.round(p.x), y: Math.round(p.y) };
 }
 
 export async function nutScroll(

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -37,6 +37,7 @@ import {
   driverClickWithModifiers,
   driverDoubleClick,
   driverDrag,
+  driverGetCursorPosition,
   driverKeyCombo,
   driverKeyPress,
   driverMouseMove,
@@ -242,6 +243,7 @@ export class ComputerUseService extends Service {
       case "key_combo":
       case "scroll":
       case "drag":
+      case "get_cursor_position":
       case "detect_elements":
       case "ocr":
         return this.executeDesktopAction({
@@ -416,6 +418,15 @@ export class ComputerUseService extends Service {
             params.scrollAmount ?? 3,
           );
           break;
+        }
+        case "get_cursor_position": {
+          // Read-only query — no coordinate, no post-action screenshot.
+          const pos = await driverGetCursorPosition();
+          return this.succeedEntry(entry, {
+            success: true,
+            cursorPosition: pos,
+            message: `Cursor is at (${pos.x}, ${pos.y}).`,
+          });
         }
         case "drag": {
           this.requireCoordinate(

--- a/plugins/plugin-computeruse/src/types.ts
+++ b/plugins/plugin-computeruse/src/types.ts
@@ -26,6 +26,7 @@ export type DesktopActionType =
   | "key_combo"
   | "scroll"
   | "drag"
+  | "get_cursor_position"
   | "detect_elements"
   | "ocr";
 
@@ -158,6 +159,8 @@ export interface ComputerActionResult extends ComputerUseResult {
   screenshot?: string;
   /** Display the screenshot belongs to (when known). */
   displayId?: number;
+  /** Current cursor position (for the `get_cursor_position` action). */
+  cursorPosition?: { x: number; y: number };
   /** Structured data payload (e.g. OCR/detect results) */
   data?: unknown;
 }


### PR DESCRIPTION
trycua/cua feature-parity (EPIC #9105). trycua's cua-driver exposes a `get_cursor_position` MCP tool and clipboard control; we had neither exposed as agent capabilities.

## Changes
- **CLIPBOARD action registered.** `clipboardAction` (read/write) existed but was never added to the plugin's `actions` array — now registered and promoted to `CLIPBOARD_READ` / `CLIPBOARD_WRITE`. (macOS pbcopy/pbpaste, Linux wl-clipboard/xclip, Windows PowerShell.)
- **`get_cursor_position` computer-use verb.** New `COMPUTER_USE_GET_CURSOR_POSITION` (read-only, auto-approved via SAFE_COMMANDS). Wired through `types.ts` → `use-computer.ts` → `computer-use-service.ts` → `driver.driverGetCursorPosition`.
- **Two real Windows bugs fixed along the way:**
  1. **Clipboard write hung on Windows.** `$input | Set-Clipboard` does not consume `spawnSync`'s piped stdin under `-Command` (→ ETIMEDOUT). Now reads stdin to EOF: `Set-Clipboard -Value ([Console]::In.ReadToEnd())`. Round-trip verified.
  2. **nutjs `mouse.getPosition()` returns a stale constant on Windows** (empirically (1166,821) regardless of `setPosition`). `driverGetCursorPosition` therefore uses the native `System.Windows.Forms.Cursor` query on Windows; nutjs elsewhere.

## Evidence (local Windows backend)
- Real-driver: `driverMouseMove(x,y)` → `driverGetCursorPosition()` consistent across points; clipboard write→read round-trips.
- `cua-parity-surface.test.ts` (CLIPBOARD_READ/WRITE + COMPUTER_USE_GET_CURSOR_POSITION registered; Windows write-command regression guard) and `cua-parity-input.real.test.ts` (Windows real driver).
- Full computeruse suite green (426 passed / 5 skipped after updating the clipboard write-command test); typecheck + biome clean. CLAUDE.md + AGENTS.md updated.

Part of the trycua/cua parity track in #9105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)