### PR TITLE
chore(agent-orchestrator): remove dead gemini/aider/hermes adapter placeholders (#9146)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -11,9 +11,6 @@ const KNOWN_ADAPTER_TYPES = new Set([
   "claude",
   "codex",
   "opencode",
-  "gemini",
-  "aider",
-  "hermes",
 ]);
 
 export function normalizeTaskAgentAdapter(

--- a/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
@@ -51,7 +51,7 @@ const CEREBRAS_URL = "https://api.cerebras.ai/v1/chat/completions";
 const STAGE_1_SYSTEM = `You are Eliza, a local-first AI assistant on elizaOS.
 
 # coding sub-agents (delegation)
-When the user explicitly asks to delegate, spawn, or fire up a coding sub-agent (or names an adapter like opencode / claude / codex / gemini / aider), the planner picks TASKS_SPAWN_AGENT. The canonical call shape (handled by the planner, not this stage) is:
+When the user explicitly asks to delegate, spawn, or fire up a coding sub-agent (or names an adapter like opencode / claude / codex), the planner picks TASKS_SPAWN_AGENT. The canonical call shape (handled by the planner, not this stage) is:
 
 PLAN_ACTIONS({
   "action": "TASKS_SPAWN_AGENT",
@@ -59,7 +59,7 @@ PLAN_ACTIONS({
   "thought": "<reasoning>"
 })
 
-Valid agentTypes: claude, codex, opencode, gemini, aider.
+Valid agentTypes: claude, codex, opencode.
 
 task: Decide shouldRespond and the plan for this message.
 


### PR DESCRIPTION
## Summary

Slice of #9146 (its Q4 "resolve placeholder adapters: wire or remove"). The `gemini` / `aider` / `hermes` adapter types were dead placeholders — they appeared **only** in `KNOWN_ADAPTER_TYPES` in `plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts` with no real wiring anywhere.

Verified there is no real adapter to wire to before removing:

- Absent from the `AgentType` union (`plugins/plugin-agent-orchestrator/src/services/types.ts` — only `elizaos | pi-agent | opencode | claude | codex`).
- Absent from the `normalizeTaskAgentAdapter` switch.
- Absent from `AGENT_PROVIDER_CANDIDATES` in the app-core bridge (`packages/app-core/src/services/coding-account-bridge.ts` — only `claude` / `codex` / `opencode`).
- Absent from every spawn / ACP command config.

Because `resolvePinnedAdapter` gates on `KNOWN_ADAPTER_TYPES.has(raw)`, pinning to one of these strings returned an "accepted" adapter that no spawn path could actually launch — an unspawnable dead path. The only repo references to these names in the orchestrator surface were the three strings themselves; the `packages/feed/.../hermes-adapter` and the app-core benchmark "OpenClaw/Hermes" comment are unrelated, separate concepts.

## Changes

- Remove the three dead strings from `KNOWN_ADAPTER_TYPES`.
- Scrub the matching illustrative adapter names (`gemini` / `aider`) from the cerebras spawn-subagent live-test prompt copy (`plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts`) so it advertises only real, spawnable `agentTypes` (`claude` / `codex` / `opencode`). The test's assertions are entirely about `opencode` and were unaffected; no test depended on the removed entries.

Out of scope (left untouched): the cross-device / subscription / topology product work tracked in the rest of #9146.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — clean (no errors).
- `bun run --cwd plugins/plugin-agent-orchestrator test` — **1038 passed | 6 skipped (1044)**, 97 test files passed.
- `bun run --cwd plugins/plugin-openai typecheck` — clean.
- `grep -rn -i -E "gemini|aider|hermes" plugins/plugin-agent-orchestrator/src/` — no residual references.

Refs #9146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)