### PR TITLE
feat(local-inference): prefer GPU lib target on CUDA hosts (bundle delivery, #9105)

### DIFF
--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -750,7 +750,8 @@ export class Downloader {
 		// §7: schema version, RAM budget, and kernel-backend availability are
 		// checked against this device BEFORE any weight byte is fetched. An
 		// incompatible bundle aborts here — there is no "download anyway" path.
-		assertBundleInstallable(manifest, await this.probeDeviceCaps());
+		const deviceCaps = await this.probeDeviceCaps();
+		assertBundleInstallable(manifest, deviceCaps);
 
 		let completedBytes = manifestDownloaded.sizeBytes;
 		const downloaded = new Map<string, DownloadedFile>();
@@ -781,7 +782,15 @@ export class Downloader {
 		// whose `target` matches the host are fetched; no `lib[]` / no host match
 		// ⇒ skipped (the runtime falls back to a host-staged lib dir, else cloud).
 		// Mobile resolves to no targets — phones ship the lib natively.
-		const selectedLib = selectBundleLibFiles(manifest, resolveHostLibTargets());
+		// Prefer the GPU lib target when this device actually has a CUDA backend
+		// (NVIDIA), so a CUDA-capable host pulls the accelerated set when the
+		// bundle hosts one; everything else takes the CPU baseline. macOS arm64
+		// already resolves to the metal set (which carries the CPU fallback).
+		const preferGpu = deviceCaps.availableBackends.includes("cuda");
+		const selectedLib = selectBundleLibFiles(
+			manifest,
+			resolveHostLibTargets({ preferGpu }),
+		);
 		if (selectedLib) {
 			for (const libEntry of selectedLib.files) {
 				const relPath = `lib/${libStagedName(libEntry)}`;


### PR DESCRIPTION
Follow-up to #9163. The downloader now derives `preferGpu` from the device's probed backends (`availableBackends.includes("cuda")`) and passes it to `resolveHostLibTargets`, so a CUDA-capable host pulls the `…-cuda` fused-lib set when the bundle hosts one, falling back to the CPU baseline otherwise (macOS arm64 already maps to the metal set, which carries the CPU fallback). Completes the "CPU + platform GPU" delivery. typecheck + biome clean; `lib-target` precedence covered by its 12 existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)