### PR TITLE
refactor(ui): drop dead DatabasePageView barrel re-exports to kill 2 cycles (#9154)

### DIFF
--- a/packages/ui/src/app-shell-components.ts
+++ b/packages/ui/src/app-shell-components.ts
@@ -28,9 +28,10 @@ export { ConversationsSidebar } from "./components/conversations/ConversationsSi
 export { CustomActionEditor } from "./components/custom-actions/CustomActionEditor";
 export { CustomActionsPanel } from "./components/custom-actions/CustomActionsPanel";
 export { AppsPageView } from "./components/pages/AppsPageView";
-// AutomationsFeed, BrowserWorkspaceView removed: App.tsx lazy-loads them and
-// re-exporting from a barrel folds the lazy boundary back into main.
-export { DatabasePageView } from "./components/pages/DatabasePageView";
+// AutomationsFeed, BrowserWorkspaceView, DatabasePageView removed: App.tsx
+// lazy-loads them and re-exporting from a barrel folds the lazy boundary back
+// into main. DatabasePageView additionally closed a barrel cycle through
+// DynamicViewLoader; App.tsx and AppWindowRenderer import it by path.
 export { DocumentsView } from "./components/pages/DocumentsView";
 // HeartbeatsView / HeartbeatsDesktopShell removed: App.tsx renders the
 // heartbeats route via the lazy-loaded AutomationsFeed, and re-exporting

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -216,7 +216,8 @@ export * from "./pages/AppsPageView";
 export * from "./pages/AppsView";
 // AutomationsFeed, BrowserWorkspaceView omitted — App.tsx lazy-loads them.
 export * from "./pages/ConfigPageView";
-export * from "./pages/DatabasePageView";
+// DatabasePageView omitted — App.tsx/AppWindowRenderer import it by path, and
+// re-exporting it here closes a barrel cycle through DynamicViewLoader.
 export * from "./pages/DatabaseView";
 export * from "./pages/DocumentsView";
 export * from "./pages/ElizaCloudDashboard";


### PR DESCRIPTION
## Summary

Fixes #9154. `@elizaos/ui` had 3 barrel-induced circular dependencies through `DatabasePageView`. Two of them were genuine, init-order-fragile cycles closed by **static** barrel re-exports of `DatabasePageView`:

- `packages/ui/src/components/index.ts:219` — `export * from "./pages/DatabasePageView";`
- `packages/ui/src/app-shell-components.ts:33` — `export { DatabasePageView } from "./components/pages/DatabasePageView";`

`DatabasePageView` statically imports `DynamicViewLoader`, which transitively pulls the barrels back in, closing the loop.

Per the issue triage, both re-exports have **zero barrel consumers**:
- `App.tsx` lazy-imports `DatabasePageView` by path (`./components/pages/DatabasePageView`)
- app-core `AppWindowRenderer.tsx` imports the direct subpath `@elizaos/ui/components/pages/DatabasePageView`
- the story file imports it relatively

Nothing reads it from the `@elizaos/ui` root or `@elizaos/ui/components` barrel. Deleting both re-exports mirrors the existing `AutomationsFeed` / `BrowserWorkspaceView` / `HeartbeatsView` precedent already documented in those files.

## Result

`madge --circular packages/ui/src/index.ts` goes **3 → 1**. The remaining cycle (`App.tsx > DatabasePageView > DynamicViewLoader > index.ts`) is closed only by `DynamicViewLoader`'s **dynamic** `import("../../index.ts")` host-external singleton shim — not a static load-order hazard, and required for plugin view-bundle resolution. The two genuine load-order-fragile cycles are eliminated.

## Verification

All run on this branch (Linux, madge 8.0.0):

**Before:**
```
✖ Found 3 circular dependencies!
1) components/pages/DatabasePageView.tsx > components/views/DynamicViewLoader.tsx > components/index.ts
2) App.tsx > components/pages/DatabasePageView.tsx > components/views/DynamicViewLoader.tsx > index.ts
3) components/pages/DatabasePageView.tsx > components/views/DynamicViewLoader.tsx > index.ts > app-shell-components.ts
```

**After:**
```
✖ Found 1 circular dependency!
1) App.tsx > components/pages/DatabasePageView.tsx > components/views/DynamicViewLoader.tsx > index.ts
```

- `bun run --cwd packages/ui typecheck` — clean (exit 0)
- `bun run --cwd packages/ui build` — clean; `[verify-package-runtime-exports] verified 38 runtime export(s) for @elizaos/ui`
- `bun run --cwd packages/agent test src/__tests__/view-agent-surface-coverage.test.ts` — 74/74 passed (the coverage test that references `pages/DatabasePageView`)

## Scope

Two comment-replacing line removals; no behavior change, no lock churn. CI `madge` gate not added (madge is `npx`-only, not a declared devDep) and is out of scope for this minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)