### PR TITLE
fix(ui): paint the chat drag-handle bar — was hardcoded opacity-0 (#9142)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -482,13 +482,12 @@ function SheetGrabber({
       <span
         aria-hidden="true"
         className={cn(
-          // 30% wider bar (w-11 → w-14), a touch taller, brighter.
-          // Visually hidden bar (opacity-0): the drag/tap-to-open gesture and the
-          // keyboard handlers live on the button wrapper, so the affordance still
-          // works — we just don't draw a faux grabber line; the iOS native home
-          // indicator is the only bottom bar. Kept in layout so the hit zone is
-          // unchanged.
-          "h-2.5 w-16 rounded-full opacity-0 transition-colors duration-300",
+          // The visible grabber line. Its show/hide is driven by the WRAPPER's
+          // `grabberOpacity` crossfade (fades in over [0.55, 0.95] of the open),
+          // strictly anti-phase with the pill bar so the two are never on screen
+          // together. The bar paints at full opacity — a prior regression pinned
+          // it to `opacity-0`, leaving the handle grabbable but invisible (#9142).
+          "h-2.5 w-16 rounded-full opacity-100 transition-colors duration-300",
           glow ? "bg-[rgba(255,180,120,0.8)]" : "bg-white/45",
         )}
       />
@@ -552,14 +551,12 @@ function PillHandle({
       <span
         aria-hidden="true"
         className={cn(
-          // Identical to the SheetGrabber bar — the handle keeps the same white
-          // shape + color whether the chat is open or fully collapsed to the pill.
-          // Visually hidden bar (opacity-0): the drag/tap-to-open gesture and the
-          // keyboard handlers live on the button wrapper, so the affordance still
-          // works — we just don't draw a faux grabber line; the iOS native home
-          // indicator is the only bottom bar. Kept in layout so the hit zone is
-          // unchanged.
-          "h-2.5 w-16 rounded-full opacity-0 transition-colors duration-300",
+          // Identical to the SheetGrabber bar — same white shape + color whether
+          // the chat is open or collapsed to the pill. Its show/hide is driven by
+          // the WRAPPER's `pillOpacity` crossfade (anti-phase with the grabber).
+          // The bar paints at full opacity — a prior regression pinned it to
+          // `opacity-0`, leaving the pill handle grabbable but invisible (#9142).
+          "h-2.5 w-16 rounded-full opacity-100 transition-colors duration-300",
           glow ? "bg-[rgba(255,180,120,0.8)]" : "bg-white/45",
         )}
       />

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -280,6 +280,21 @@ async function runDragSuite(p, pointer, tag) {
   assert((await detent(p)) === "half", `[${pointer}] flick-up snaps COLLAPSED→HALF`);
   assert(near(await sheetHeight(p), halfH, TOL), `[${pointer}] HALF height ≈ ${halfH}px (got ${Math.round(await sheetHeight(p))})`);
   await snap(p, `${tag}-half`);
+  // #9142 regression guard: the grabber BAR (inner span) must actually PAINT
+  // once the sheet is open — a prior regression pinned the bar to `opacity-0`,
+  // leaving the handle grabbable but invisible. The wrapper's `grabberOpacity`
+  // crossfade owns show/hide; the bar's OWN opacity must be 1, never 0.
+  const grabberBarOpacity = await p.evaluate(() =>
+    getComputedStyle(
+      document
+        .querySelector('[data-testid="chat-sheet-grabber"]')
+        ?.querySelector("span") ?? document.body,
+    ).opacity,
+  );
+  assert(
+    grabberBarOpacity === "1",
+    `[${pointer}] grabber bar paints (inner-span opacity "${grabberBarOpacity}" === "1", not opacity-0) (#9142)`,
+  );
   // The sheet header (maximize/clear/home/settings) shows at HALF and up now,
   // not only at FULL.
   assert(


### PR DESCRIPTION
## What

The continuous-chat sheet grabber + collapsed-pill expose a grabbable, gesture-wired, keyboard-operable handle, but the **visible bar never painted**: both the `SheetGrabber` bar and the `PillHandle` bar `<span>` were hardcoded `opacity-0` (`ContinuousChatOverlay.tsx:491,562`) — "grabbable but invisible" (the reported regression).

## Fix

The wrapper opacity is already driven by the `grabberOpacity`/`pillOpacity` crossfade MotionValues (strict anti-phase, the "two pills" guard). The bar's own `opacity-0` defeated that. Set the bar to `opacity-100` so it paints; the wrapper crossfade keeps owning show/hide timing. Misleading comments corrected.

## Test

Adds a regression guard to the chat-sheet e2e (`run-chat-sheet-e2e.mjs`): once the sheet is open, the grabber bar inner-span computed opacity must be `"1"`, never `"0"`.

Closes #9142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)