### PR TITLE
fix(ui): seed a default Springboard favorites dock on first run (#9144)

### DIFF
--- a/packages/ui/src/state/springboard-layout.test.ts
+++ b/packages/ui/src/state/springboard-layout.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_SPRINGBOARD_FAVORITES,
+  defaultLayout,
   emptyLayout,
   moveIcon,
   placedIds,
@@ -104,5 +106,49 @@ describe("springboard-layout persistence", () => {
   it("returns an empty layout on malformed storage", () => {
     window.localStorage.setItem(SPRINGBOARD_STORAGE_KEY, "{not json");
     expect(readSpringboardLayout()).toEqual(emptyLayout());
+  });
+});
+
+describe("springboard-layout default dock (#9144)", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("seeds the default favorites dock on first run (no stored layout)", () => {
+    expect(readSpringboardLayout()).toEqual(defaultLayout());
+    expect(readSpringboardLayout().favorites).toEqual([
+      ...DEFAULT_SPRINGBOARD_FAVORITES,
+    ]);
+  });
+
+  it("respects a user-cleared dock (stored favorites: []) — does NOT re-seed", () => {
+    writeSpringboardLayout({ favorites: [], pages: [["a"]] });
+    expect(readSpringboardLayout().favorites).toEqual([]);
+  });
+
+  it("does not exceed the dock limit", () => {
+    expect(defaultLayout().favorites.length).toBeLessThanOrEqual(
+      SPRINGBOARD_DOCK_LIMIT,
+    );
+  });
+
+  it("keeps available default favorites and drops unknown ones on reconcile", () => {
+    // Only `settings` + `activity` exist in this catalog; `chat`/`views` are not
+    // available here and must drop cleanly (no hole, no page placement).
+    const out = reconcileLayout(defaultLayout(), [
+      "settings",
+      "activity",
+      "files",
+    ]);
+    expect(out.favorites).toEqual(["settings", "activity"]);
+    // Dropped defaults never leak into the page grid.
+    expect(out.pages.flat()).toEqual(["files"]);
+  });
+
+  it("keeps all default favorites when every default id is available", () => {
+    const out = reconcileLayout(defaultLayout(), [
+      ...DEFAULT_SPRINGBOARD_FAVORITES,
+      "files",
+    ]);
+    expect(out.favorites).toEqual([...DEFAULT_SPRINGBOARD_FAVORITES]);
+    expect(out.pages.flat()).toEqual(["files"]);
   });
 });

--- a/packages/ui/src/state/springboard-layout.ts
+++ b/packages/ui/src/state/springboard-layout.ts
@@ -18,6 +18,24 @@ export const SPRINGBOARD_PAGE_SIZE = 20;
 /** Maximum icons pinned to the dock (favorites). */
 export const SPRINGBOARD_DOCK_LIMIT = 4;
 
+/**
+ * Default favorites dock for a fresh install (#9144). Capped at
+ * SPRINGBOARD_DOCK_LIMIT. These are stable built-in `system` view ids; any that
+ * are not actually available in the live catalog are dropped during
+ * `reconcileLayout` (favorites ∩ available), so an unknown id never leaves a
+ * hole. Order matches the dock left-to-right:
+ *   - chat     — default landing + primary surface
+ *   - views    — the springboard launcher itself (home)
+ *   - settings — universal, stable system view
+ *   - activity — pairs with the default activity surface
+ */
+export const DEFAULT_SPRINGBOARD_FAVORITES: readonly string[] = [
+  "chat",
+  "views",
+  "settings",
+  "activity",
+];
+
 export interface SpringboardLayout {
   /** Ordered view ids pinned to the dock. Capped at SPRINGBOARD_DOCK_LIMIT. */
   favorites: string[];
@@ -36,6 +54,15 @@ export function emptyLayout(): SpringboardLayout {
   return { favorites: [], pages: [] };
 }
 
+/**
+ * First-run layout — seeds the default favorites dock (#9144) so the dock is
+ * never empty on a fresh install. Unknown default ids are dropped during
+ * `reconcileLayout`. Returns a fresh array so callers can't mutate the constant.
+ */
+export function defaultLayout(): SpringboardLayout {
+  return { favorites: [...DEFAULT_SPRINGBOARD_FAVORITES], pages: [] };
+}
+
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
@@ -46,7 +73,10 @@ export function readSpringboardLayout(): SpringboardLayout {
   if (typeof window === "undefined") return emptyLayout();
   try {
     const raw = window.localStorage.getItem(SPRINGBOARD_STORAGE_KEY);
-    if (!raw) return emptyLayout();
+    // Genuine first run (no stored key) seeds the default dock; a stored
+    // `favorites: []` (user cleared the dock) is respected below and NOT
+    // re-seeded.
+    if (!raw) return defaultLayout();
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return emptyLayout();
     const record = parsed as Record<string, unknown>;


### PR DESCRIPTION
## What

The iOS-like Springboard shipped with an **empty favorites dock** — `emptyLayout()` returns no favorites and `readSpringboardLayout()` returned it on first run, so a fresh install showed no dock at all (`springboard-layout.ts:35-37`).

## Fix (layout model)

- New `DEFAULT_SPRINGBOARD_FAVORITES` = `["chat","views","settings","activity"]` (capped at `SPRINGBOARD_DOCK_LIMIT`) + a `defaultLayout()` helper.
- `readSpringboardLayout()` seeds it on **genuine first run** (no stored key). A stored `favorites: []` (user cleared the dock) is respected and **not** re-seeded.
- `reconcileLayout` already intersects favorites with the live catalog, so unknown default ids drop cleanly (no page hole). `emptyLayout()` stays empty — existing toggle/move tests unchanged.

## Tests

5 new unit tests (first-run seed, user-cleared respected, dock-limit cap, unknown-default drop, all-defaults-available). `bun run --cwd packages/ui test -- src/state/springboard-layout.test.ts` → **17 passed**.

## Remaining for full close (UI integration, not in this PR)

Make `chat`/`views` dock-eligible (currently filtered from the catalog grid), render the dock on the off-desktop favorites path, and add the Springboard component + swipe / cross-page-drag e2e coverage. Tracked on #9144.

Part of #9144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)