### PR TITLE
fix(cloud-infra): pgbouncer session pooler + raised connection ceiling for the apps tenant DB (#8321)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/README.md
@@ -10,6 +10,7 @@ app worker nodes:
 | `hcloud_server.tenant_db` (+ volume) | One self-managed Postgres holding thousands of per-tenant `DATABASE`+`ROLE` (`REVOKE CONNECT FROM PUBLIC` per tenant). Reachable **only** on the private net. |
 | `hcloud_firewall.tenant_db` | SSH from operators only — Postgres stays private-net only. |
 | `random_password.tenant_db_admin` | The tenant DB superuser password, used to build the admin DSN output. |
+| `random_password.pgbouncer_auth` | The pgbouncer `auth_user` credential (resolves per-tenant SCRAM via `auth_query`). |
 
 Per-env app worker nodes + the `*.<apps_base_domain>` Cloudflare record live in
 the sibling [`apps-data-plane`](../apps-data-plane/) module, which consumes
@@ -62,6 +63,46 @@ gh workflow run terraform-apps-shared.yml --ref develop -f action=apply
 2. Run the `apps-data-plane` apply (staging then production) so app worker
    nodes attach to the shared network published here.
 
+## Connection pooling (pgbouncer) — #8321 P0 #2
+
+The default Postgres ceiling (100 connections) exhausts at ~5 apps under load.
+The tenant-db cloud-init now (a) raises `max_connections` to 500 + sizes
+`shared_buffers` to ~25% of the node's RAM, and (b) runs **pgbouncer in SESSION
+`pool_mode` on `:6432`** in front of Postgres, so app sessions are multiplexed
+onto a bounded set of server backends.
+
+**Why session mode (not transaction):** plugin-sql's runtime migrator takes
+**session-scoped** advisory locks (`pg_advisory_lock`, not the `_xact_`
+variants) across independent pool checkouts. Transaction pooling would acquire
+the lock on one backend and release it on another, orphaning it and wedging
+migrations. Session mode is the safe drop-in; a future transaction-mode move
+would first require reworking that lock path.
+
+The pooler authenticates per-tenant roles via `auth_query` against a
+`SECURITY DEFINER` lookup (`public.pgbouncer_user_lookup`) owned by `postgres`
+and execute-granted only to the `pgbouncer` role — so the pooler resolves SCRAM
+secrets without being a superuser. The app's `REVOKE CONNECT` isolation still
+gates every connection.
+
+### Operator rollout (the pooler is INERT until you do step 2)
+
+1. **Roll the tenant-db node** so the new cloud-init runs (installs + configures
+   pgbouncer). `user_data` is under `lifecycle.ignore_changes`, so editing the
+   template alone does nothing — taint and replace:
+   ```bash
+   terraform apply -var-file=shared.tfvars -replace=hcloud_server.tenant_db
+   ```
+   The data volume (PGDATA) survives the replace; it's a disruptive restart.
+   (Currently gated on the staging Hetzner server limit — see #8318.)
+2. **Route apps through the pooler:** set the `tenant_db_clusters.host` column
+   (the **app-facing** per-tenant DSN host) to the `tenant_db_pooler_endpoint`
+   output (`10.30.1.10:6432`). New per-tenant DSNs then point at the pooler;
+   the **admin/DDL** DSN (`tenant_db_admin_dsn`) stays on `:5432` — role/database
+   DDL must not go through the pooler. The DB ambassador forwards whatever port
+   the DSN carries, so no app-side change is needed.
+3. **Validate:** `psql "<a tenant DSN with :6432>"` connects; `SHOW POOLS;` on
+   the pgbouncer admin console shows session pools; `journalctl -u pgbouncer`.
+
 ## Outputs
 
 - `apps_network_id` — for `hcloud_server_network` in apps-data-plane.
@@ -69,4 +110,5 @@ gh workflow run terraform-apps-shared.yml --ref develop -f action=apply
 - `apps_subnet_cidr` — apps-data-plane uses this to compute app node private IPs.
 - `tenant_db_private_ip` — `10.30.1.10`, stable.
 - `tenant_db_public_ip` — SSH/admin only.
-- `tenant_db_admin_dsn` — **sensitive**; seed into `tenant_db_clusters`.
+- `tenant_db_admin_dsn` — **sensitive**; seed into `tenant_db_clusters` (`:5432`, direct).
+- `tenant_db_pooler_endpoint` — `10.30.1.10:6432`; set as `tenant_db_clusters.host` to route apps through pgbouncer (after rolling the node).

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
@@ -17,9 +17,21 @@
 # Postgres. The systemd unit runs on every boot, every step is grep-/path-
 # guarded, so it's a no-op after first successful run.
 #
-# STAN: tune shared_buffers/max_connections for thousands of small DBs; wire
-# volume-snapshot backups; generate a server TLS cert for hostssl (until then
-# the pg_hba lines below stay 'host' and the admin DSN uses sslmode=disable).
+# Connection scaling (#8321 P0 #2): the default Postgres ceiling is 100
+# connections, which the apps data plane exhausts at ~5 apps under load. This
+# node now (a) raises max_connections + sizes shared_buffers to the box, and
+# (b) runs pgbouncer in SESSION pool_mode on :6432 so app sessions are
+# multiplexed onto a bounded set of server backends. SESSION mode (not
+# transaction) is required because plugin-sql's migrator takes SESSION-scoped
+# advisory locks (pg_advisory_lock, not the _xact_ variants) across independent
+# pool checkouts — transaction pooling would orphan those locks and wedge
+# migrations. The pooler is INERT until an operator points the cluster's
+# app-facing host at :6432 (see README + tenant_db_pooler_endpoint output);
+# admin/DDL keeps using :5432 directly.
+#
+# STAN: wire volume-snapshot backups; generate a server TLS cert for hostssl
+# (until then the pg_hba lines below stay 'host' and the admin DSN uses
+# sslmode=disable); tighten pgbouncer listen_addr to the private IP.
 
 hostname: ${hostname}
 manage_etc_hosts: true
@@ -44,6 +56,7 @@ package_upgrade: false
 packages:
   - postgresql
   - postgresql-contrib
+  - pgbouncer
   - jq
 
 bootcmd:
@@ -144,6 +157,16 @@ write_files:
       sed -i -E "s|^#?[[:space:]]*listen_addresses[[:space:]]*=.*|listen_addresses = '*'|" "$CONF"
       sed -i -E "s|^#?[[:space:]]*password_encryption[[:space:]]*=.*|password_encryption = scram-sha-256|" "$CONF"
 
+      # Connection ceiling + memory tuning for thousands of small tenant DBs
+      # (#8321 P0 #2). pgbouncer (step 10) multiplexes app sessions, but raise
+      # the backend ceiling well above the default 100 so admin/DDL + pooled
+      # server connections have headroom. shared_buffers ~= 25% of RAM (the
+      # Postgres rule of thumb), floored at 128MB. Same idempotent sed pattern.
+      sed -i -E "s|^#?[[:space:]]*max_connections[[:space:]]*=.*|max_connections = 500|" "$CONF"
+      SHARED_BUF="$(awk '/^MemTotal/ {mb=int($2/1024/4); if (mb<128) mb=128; printf "%dMB", mb}' /proc/meminfo)"
+      [ -n "$SHARED_BUF" ] || SHARED_BUF=128MB
+      sed -i -E "s|^#?[[:space:]]*shared_buffers[[:space:]]*=.*|shared_buffers = $SHARED_BUF|" "$CONF"
+
       # 7. pg_hba — grep-guard before append so reboots don't grow the file.
       if ! grep -qE "^hostssl[[:space:]]+all[[:space:]]+all[[:space:]]+10\.30\.0\.0/16" "$HBA"; then
         echo "hostssl all all 10.30.0.0/16 scram-sha-256" >> "$HBA"
@@ -167,6 +190,77 @@ write_files:
       # random_password.tenant_db_admin in TF state, stable across reboots, so
       # this ALTER is idempotent.
       runuser -u postgres -- psql -tAc "ALTER USER postgres WITH PASSWORD '${admin_password}';" >/dev/null
+
+      # 10. pgbouncer (#8321 P0 #2) — SESSION-mode pooler on :6432 in front of
+      # Postgres. Configured HERE (not via write_files) so the conffile is
+      # written AFTER apt installs the package — otherwise the noninteractive
+      # `--force-confnew` apt option would clobber a pre-seeded pgbouncer.ini.
+      # Everything below is idempotent: CREATE OR REPLACE / grep-guarded role /
+      # overwrite of the config + userlist. Deferred cleanly if the package
+      # isn't installed yet (same posture as the postgres deferral above).
+      if command -v pgbouncer >/dev/null 2>&1; then
+        mkdir -p /etc/pgbouncer
+        # Dedicated login role + SECURITY DEFINER lookup so the pooler can
+        # resolve each per-tenant role's SCRAM secret via auth_query WITHOUT
+        # being a superuser (pg_shadow is superuser-only; the function is owned
+        # by postgres and execute-granted to pgbouncer only).
+        PGB_PW='${pgbouncer_auth_password}'
+        runuser -u postgres -- psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='pgbouncer'" | grep -q 1 \
+          || runuser -u postgres -- psql -c "CREATE ROLE pgbouncer LOGIN"
+        runuser -u postgres -- psql -c "ALTER ROLE pgbouncer WITH PASSWORD '$PGB_PW'" >/dev/null
+        runuser -u postgres -- psql -d postgres -c "CREATE OR REPLACE FUNCTION public.pgbouncer_user_lookup(p_username text) RETURNS TABLE(usename name, passwd text) LANGUAGE sql SECURITY DEFINER AS 'SELECT usename, passwd FROM pg_catalog.pg_shadow WHERE usename = \$1'"
+        runuser -u postgres -- psql -d postgres -c "REVOKE ALL ON FUNCTION public.pgbouncer_user_lookup(text) FROM PUBLIC"
+        runuser -u postgres -- psql -d postgres -c "GRANT EXECUTE ON FUNCTION public.pgbouncer_user_lookup(text) TO pgbouncer"
+
+        # auth_file: only the auth_user itself; per-tenant roles resolve via
+        # auth_query against the lookup function. 0600, postgres-owned (the
+        # pgbouncer service runs as the postgres user on Ubuntu).
+        umask 077
+        printf '"pgbouncer" "%s"\n' "$PGB_PW" > /etc/pgbouncer/userlist.txt
+        chown postgres:postgres /etc/pgbouncer/userlist.txt
+        chmod 600 /etc/pgbouncer/userlist.txt
+
+        # Build pgbouncer.ini with printf (NOT a heredoc): inside a YAML `|`
+        # block every line is indented, but a heredoc terminator must sit at
+        # column 0 — printf string literals sidestep that entirely. Single
+        # quotes keep $1 (auth_query placeholder) literal.
+        printf '%s\n' \
+          '[databases]' \
+          '; Any requested tenant database routes to the local Postgres. The app SCRAM' \
+          '; credential (validated via auth_query) still gates CONNECT, so a tenant only' \
+          '; reaches its own REVOKE-CONNECT-isolated database.' \
+          '* = host=127.0.0.1 port=5432' \
+          '' \
+          '[pgbouncer]' \
+          'logfile = /var/log/postgresql/pgbouncer.log' \
+          'pidfile = /var/run/postgresql/pgbouncer.pid' \
+          'unix_socket_dir = /var/run/postgresql' \
+          '; Reachable only on the private apps net (the firewall opens no public 6432,' \
+          '; same posture as Postgres :5432).' \
+          'listen_addr = *' \
+          'listen_port = 6432' \
+          'auth_type = scram-sha-256' \
+          'auth_file = /etc/pgbouncer/userlist.txt' \
+          'auth_user = pgbouncer' \
+          'auth_dbname = postgres' \
+          'auth_query = SELECT usename, passwd FROM public.pgbouncer_user_lookup($1)' \
+          '; SESSION mode: required by plugin-sql session-scoped migration advisory locks.' \
+          'pool_mode = session' \
+          'max_client_conn = 5000' \
+          'default_pool_size = 25' \
+          'min_pool_size = 0' \
+          'reserve_pool_size = 5' \
+          'server_tls_sslmode = prefer' \
+          'ignore_startup_parameters = extra_float_digits,search_path' \
+          'admin_users = postgres' \
+          > /etc/pgbouncer/pgbouncer.ini
+
+        systemctl enable pgbouncer >/dev/null 2>&1 || true
+        systemctl restart pgbouncer
+        log "pgbouncer up on :6432 (session mode)."
+      else
+        log "pgbouncer not installed yet; deferring pooler setup."
+      fi
 
       log "done."
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/main.tf
@@ -38,6 +38,15 @@ resource "random_password" "tenant_db_admin" {
   special = false # keep DSN URL-safe (no escaping in admin_dsn output)
 }
 
+# pgbouncer auth_user credential (#8321 P0 #2). The pooler authenticates itself
+# with this to run auth_query against the per-tenant SCRAM lookup. Stable across
+# boots so the cloud-init ALTER ROLE + userlist write are idempotent. URL-safe
+# for the same reason as the admin password (it lands in userlist.txt verbatim).
+resource "random_password" "pgbouncer_auth" {
+  length  = 40
+  special = false
+}
+
 # Operator/daemon SSH access is provisioned by cloud-init: each node's `deploy`
 # user gets `var.ssh_public_keys` in its authorized_keys (see cloud-init/*.tftpl).
 # We do NOT register an `hcloud_ssh_key` here: the apps Hetzner project is
@@ -121,9 +130,10 @@ resource "hcloud_server" "tenant_db" {
   labels       = merge(local.common_labels, { "role" = "tenant-db" })
 
   user_data = templatefile("${path.module}/cloud-init/tenant-db.yaml.tftpl", {
-    hostname          = "eliza-app-tenant"
-    admin_password    = random_password.tenant_db_admin.result
-    operator_ssh_keys = var.ssh_public_keys
+    hostname                = "eliza-app-tenant"
+    admin_password          = random_password.tenant_db_admin.result
+    pgbouncer_auth_password = random_password.pgbouncer_auth.result
+    operator_ssh_keys       = var.ssh_public_keys
   })
 
   # Same convention as control-plane / apps-data-plane: allow in-place rename

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/outputs.tf
@@ -26,7 +26,12 @@ output "tenant_db_public_ip" {
 }
 
 output "tenant_db_admin_dsn" {
-  description = "Admin DSN for the tenant Postgres cluster (over the PRIVATE network). Encrypt this and seed it into tenant_db_clusters.admin_dsn_encrypted. SENSITIVE."
+  description = "Admin DSN for the tenant Postgres cluster (over the PRIVATE network). Encrypt this and seed it into tenant_db_clusters.admin_dsn_encrypted. Targets Postgres :5432 DIRECTLY (DDL/role creation must not go through the pooler). SENSITIVE."
   value       = "postgresql://postgres:${random_password.tenant_db_admin.result}@${cidrhost(var.subnet_cidr, 10)}:5432/postgres?sslmode=require"
   sensitive   = true
+}
+
+output "tenant_db_pooler_endpoint" {
+  description = "Host:port of the pgbouncer SESSION-mode pooler (#8321 P0 #2). To route per-tenant APP connections through the pooler, set tenant_db_clusters.host to THIS value (the app-facing per-tenant DSN host) once the tenant-db node has been (re)rolled with the pgbouncer cloud-init. The admin DSN above stays on :5432. Leaving host at :5432 keeps the pooler inert."
+  value       = "${cidrhost(var.subnet_cidr, 10)}:6432"
 }

--- a/packages/cloud-infra/tests/terraform-static.test.ts
+++ b/packages/cloud-infra/tests/terraform-static.test.ts
@@ -49,6 +49,58 @@ describe("Terraform redis-rest deployment", () => {
   });
 });
 
+describe("Apps tenant-DB connection scaling (#8321 P0 #2)", () => {
+  const HETZNER_APPS_SHARED = join(
+    import.meta.dir,
+    "..",
+    "cloud",
+    "terraform",
+    "hetzner",
+    "apps-shared",
+  );
+  const tenantDbInit = readFileSync(
+    join(HETZNER_APPS_SHARED, "cloud-init", "tenant-db.yaml.tftpl"),
+    "utf-8",
+  );
+  const mainTf = readFileSync(join(HETZNER_APPS_SHARED, "main.tf"), "utf-8");
+  const outputsTf = readFileSync(join(HETZNER_APPS_SHARED, "outputs.tf"), "utf-8");
+
+  test("raises the Postgres connection ceiling above the default 100", () => {
+    expect(tenantDbInit).toContain("max_connections = 500");
+    // shared_buffers is RAM-derived (25% of MemTotal) — assert the sed wires it.
+    expect(tenantDbInit).toContain("shared_buffers = $SHARED_BUF");
+  });
+
+  test("installs pgbouncer and runs it in SESSION pool mode on :6432", () => {
+    expect(tenantDbInit).toContain("- pgbouncer");
+    expect(tenantDbInit).toContain("listen_port = 6432");
+    // SESSION (not transaction) — plugin-sql's migrator holds session-scoped
+    // advisory locks across pool checkouts; transaction pooling would orphan them.
+    expect(tenantDbInit).toContain("pool_mode = session");
+    expect(tenantDbInit).toContain("auth_type = scram-sha-256");
+    expect(tenantDbInit).toContain(
+      "auth_query = SELECT usename, passwd FROM public.pgbouncer_user_lookup($1)",
+    );
+    // auth_user resolves per-tenant SCRAM via a SECURITY DEFINER lookup, not superuser.
+    expect(tenantDbInit).toContain("SECURITY DEFINER");
+    expect(tenantDbInit).toContain("GRANT EXECUTE ON FUNCTION public.pgbouncer_user_lookup");
+  });
+
+  test("threads a stable pgbouncer auth credential through terraform", () => {
+    expect(mainTf).toContain('resource "random_password" "pgbouncer_auth"');
+    expect(mainTf).toContain(
+      "pgbouncer_auth_password = random_password.pgbouncer_auth.result",
+    );
+  });
+
+  test("exposes the pooler endpoint operators set as the app-facing cluster host", () => {
+    expect(outputsTf).toContain('output "tenant_db_pooler_endpoint"');
+    expect(outputsTf).toContain('value       = "${cidrhost(var.subnet_cidr, 10)}:6432"');
+    // The admin/DDL DSN must stay on :5432 (never through the pooler).
+    expect(outputsTf).toContain(":5432/postgres?sslmode=require");
+  });
+});
+
 describe("Terraform namespace contracts", () => {
   test("documents that database cluster keys are Kubernetes namespaces", () => {
     const variables = readK8sTerraform("variables.tf");


### PR DESCRIPTION
## What

Closes the last open **code** gap of the #8321 apps scaling audit — **P0 #2: Postgres connection ceiling**. The tenant Postgres node shipped with the default `max_connections = 100` and **no connection pooler**, so the apps data plane exhausted at ~5 apps under load / ~50 idle (`ClusterPool` shards database *count*, not connections).

This adds, in the `apps-shared` tenant-db cloud-init:
- `max_connections = 500` + `shared_buffers` sized to ~25% of the node's RAM (idempotent `sed`, same pattern as the existing conf edits).
- **pgbouncer in SESSION `pool_mode` on `:6432`** in front of Postgres. Per-tenant SCRAM is resolved via `auth_query` against a `SECURITY DEFINER` lookup (`public.pgbouncer_user_lookup`) owned by `postgres` and execute-granted only to a non-superuser `pgbouncer` role.
- `random_password.pgbouncer_auth` (main.tf) threaded into the template.
- `tenant_db_pooler_endpoint` output (`10.30.1.10:6432`).
- A `terraform-static` test asserting the ceiling + pooler config + output landed.

## Why SESSION mode (the load-bearing decision)

plugin-sql's runtime migrator takes **session-scoped** advisory locks (`pg_advisory_lock`, *not* the `_xact_` variants) across independent pool checkouts (`runtime-migrator.ts`). Under **transaction** pooling the lock would be taken on one backend and released on another — orphaned forever, wedging every later migration. **Session mode is the safe drop-in**; a future transaction-mode move would first require reworking that lock path.

## Safety: inert on merge

Nothing dials `:6432` until an operator acts. The per-tenant **app-facing DSN port is data-driven** by `tenant_db_clusters.host` (the routing seam already in place — the DB ambassador forwards whatever port the DSN carries), so **no provisioning-code change is needed** and merging this changes no running behavior. `hcloud_server.tenant_db` has `lifecycle.ignore_changes = [user_data, …]`, so even `terraform apply` is a no-op until the node is explicitly replaced.

## Operator rollout (gated — see `apps-shared/README.md`)

1. `terraform apply -replace=hcloud_server.tenant_db` to roll the node (PGDATA volume survives). *Currently gated on the staging Hetzner server limit — #8318.*
2. Set `tenant_db_clusters.host` → `tenant_db_pooler_endpoint` (`10.30.1.10:6432`). Admin/DDL DSN stays on `:5432`.
3. Validate: connect a tenant DSN on `:6432`, `SHOW POOLS;`, `journalctl -u pgbouncer`.

## Evidence

- **Tests:** `packages/cloud-infra/tests/terraform-static.test.ts` gains a `#8321 P0 #2` block asserting `max_connections`, pgbouncer install, `listen_port = 6432`, `pool_mode = session`, the `auth_query`/`SECURITY DEFINER` lookup, the `random_password.pgbouncer_auth` wiring, and the pooler-endpoint output.
- **Real `terraform apply` / on-node validation: N/A here** — apply is operator-gated and blocked on the staging server limit (#8318). The cloud-init is exercised on the node roll per the runbook; this PR is the inert IaC + test.
- **UI / LLM-trajectory / audio evidence: N/A** — infra-only change, no UI or model path touched.

## Scope

Other #8321 items (Caddy ingress P0 #1, env-var contract P0 #3, slot release P1 #7, collision-safe ports P1 #8, billing idempotency P1 #10, …) already landed on develop. This is the remaining P0. P2 hardening (hostssl cert, listen_addr tightening) stays out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
