### PR TITLE
feat(ui): conversation copy/paste parity across chat surfaces (#9148)

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.code-block.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.code-block.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// A reply containing a fenced code block renders it via the CodeBlock primitive
+// with a per-block copy button that writes EXACTLY the block contents (#9148).
+// Inline `code` spans render in the inline code primitive and stay in the flow
+// of the sentence (no separate copy affordance).
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../../api/client-types-chat";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+
+vi.mock("@elizaos/ui", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+vi.mock("../../api/client", () => ({ client: {} }));
+
+import { MessageContent } from "./MessageContent";
+
+function message(text: string): ConversationMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    text,
+    timestamp: Date.now(),
+  } as ConversationMessage;
+}
+
+function withApp(node: React.ReactElement) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+  );
+}
+
+describe("MessageContent code blocks", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    __setAppValueForTests(null);
+  });
+
+  it("renders a fenced code block with a copy button that writes the exact block contents", async () => {
+    const code = "const x = 1;\nconsole.log(x);";
+    withApp(
+      <MessageContent message={message(`Here:\n\`\`\`ts\n${code}\n\`\`\``)} />,
+    );
+
+    const block = screen.getByTestId("code-block");
+    expect(block).toBeTruthy();
+    // The rendered code text matches the block body exactly (fence + lang gone).
+    expect(block.textContent).toContain("const x = 1;");
+    expect(block.getAttribute("data-lang")).toBe("ts");
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith(code);
+  });
+
+  it("renders inline code spans inline without a block copy affordance", () => {
+    withApp(
+      <MessageContent message={message("Run `npm install` to begin.")} />,
+    );
+    const inline = screen.getByTestId("inline-code");
+    expect(inline.textContent).toBe("npm install");
+    // No block-level code affordance for an inline-only message.
+    expect(screen.queryByTestId("code-block")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -208,6 +208,19 @@ export const ChoicePicker: Story = {
   },
 };
 
+/**
+ * Fenced code block (#9148): assistant ```code``` renders via the CodeBlock
+ * primitive with a per-block copy button instead of undifferentiated prose;
+ * inline `code` spans render inline and keep their place in the sentence.
+ */
+export const CodeBlocks: Story = {
+  args: {
+    message: makeMessage({
+      text: "Run `npm install` first, then add this to `vite.config.ts`:\n```ts\nexport default defineConfig({\n  plugins: [react()],\n});\n```\nThat wires up the dev server.",
+    }),
+  },
+};
+
 /** Inline form: a `[FORM]` block becomes a structured multi-field form. */
 export const InlineForm: Story = {
   args: {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1,5 +1,6 @@
 import {
   type FormEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -25,6 +26,7 @@ import { ConfigRenderer } from "../config-ui/config-renderer";
 import { defaultRegistry } from "../config-ui/config-renderer.helpers";
 import { UiRenderer } from "../config-ui/ui-renderer";
 import { Button } from "../ui/button";
+import { CodeBlock } from "../ui/code-block";
 import { MessageAttachments } from "./MessageAttachments";
 import {
   buildInlinePluginConfigModel,
@@ -32,6 +34,7 @@ import {
   normalizePluginId,
   parseSegments,
   sensitiveRequestStatusLabel,
+  splitInlineCode,
 } from "./message-parser-helpers";
 import { ThinkingBlock } from "./ThinkingBlock";
 import type { FormResultValue } from "./widgets/form-request";
@@ -48,10 +51,40 @@ interface MessageContentProps {
 }
 
 /**
+ * Render a text run, wrapping any inline `` `code` `` spans in the CodeBlock
+ * inline primitive so they keep their place in the sentence. Returns the raw
+ * string unchanged when there is no backticked span (the common case).
+ */
+function renderInlineText(text: string): ReactNode {
+  if (!text.includes("`")) return text;
+  const parts = splitInlineCode(text);
+  if (parts.length === 1 && parts[0].kind === "text") return text;
+  // Key by the part's character offset in the source run (not the array index)
+  // so keys stay stable across re-renders and don't trip noArrayIndexKey.
+  let offset = 0;
+  return parts.map((part) => {
+    const content = part.kind === "code" ? part.code : part.text;
+    const key = `${part.kind}:${offset}`;
+    offset += content.length;
+    return part.kind === "code" ? (
+      <CodeBlock
+        key={key}
+        variant="inline"
+        value={part.code}
+        data-testid="inline-code"
+      />
+    ) : (
+      <span key={key}>{part.text}</span>
+    );
+  });
+}
+
+/**
  * Render a plain-text message body. When the message is a user-typed slash
  * command (e.g. `/imagine a cat`), the leading `/command` token is rendered in
  * bold so it reads as a command in the transcript — matching the inline
- * autocomplete the composer shows while typing.
+ * autocomplete the composer shows while typing. Inline `` `code` `` spans render
+ * in the inline code primitive while staying in the flow of the sentence.
  */
 function MessageTextBody({
   text,
@@ -71,10 +104,10 @@ function MessageTextBody({
           >
             {slash.command}
           </span>
-          {slash.rest}
+          {renderInlineText(slash.rest)}
         </>
       ) : (
-        text
+        renderInlineText(text)
       )}
     </div>
   );
@@ -1016,16 +1049,18 @@ export function MessageContent({
           const baseKey =
             seg.kind === "text"
               ? `text:${seg.text.slice(0, 80)}`
-              : seg.kind === "config"
-                ? `config:${seg.pluginId}`
-                : seg.kind === "widget"
-                  ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
-                    `widget:${seg.widgetKind}`)
-                  : seg.kind === "permission"
-                    ? `permission:${seg.payload.feature}`
-                    : seg.kind === "analysis-xml"
-                      ? `analysis:${seg.tag}`
-                      : `ui:${seg.raw.slice(0, 80)}`;
+              : seg.kind === "code"
+                ? `code:${seg.code.slice(0, 80)}`
+                : seg.kind === "config"
+                  ? `config:${seg.pluginId}`
+                  : seg.kind === "widget"
+                    ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
+                      `widget:${seg.widgetKind}`)
+                    : seg.kind === "permission"
+                      ? `permission:${seg.payload.feature}`
+                      : seg.kind === "analysis-xml"
+                        ? `analysis:${seg.tag}`
+                        : `ui:${seg.raw.slice(0, 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {
@@ -1035,6 +1070,18 @@ export function MessageContent({
                   key={segmentKey}
                   text={seg.text}
                   boldSlashCommand={message.role === "user"}
+                />
+              );
+            case "code":
+              return (
+                <CodeBlock
+                  key={segmentKey}
+                  className="my-2"
+                  value={seg.code}
+                  wrap
+                  copyable
+                  data-testid="code-block"
+                  {...(seg.lang ? { "data-lang": seg.lang } : {})}
                 />
               );
             case "analysis-xml":

--- a/packages/ui/src/components/chat/message-parser-code.test.ts
+++ b/packages/ui/src/components/chat/message-parser-code.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  conversationTranscriptText,
+  parseSegments,
+  splitInlineCode,
+} from "./message-parser-helpers";
+
+describe("parseSegments — fenced code blocks", () => {
+  it("lifts a fenced code block into a code segment with its language", () => {
+    const segments = parseSegments(
+      "Here you go:\n```ts\nconst x = 1;\nconsole.log(x);\n```\nDone.",
+      false,
+    );
+    const code = segments.find((s) => s.kind === "code");
+    expect(code).toBeDefined();
+    if (code?.kind !== "code") throw new Error("expected code segment");
+    expect(code.inline).toBe(false);
+    expect(code.lang).toBe("ts");
+    // The fence markers + language tag are stripped; the body is exact.
+    expect(code.code).toBe("const x = 1;\nconsole.log(x);");
+    // Surrounding prose is kept as text segments around the block.
+    expect(
+      segments.some((s) => s.kind === "text" && /Here you go/.test(s.text)),
+    ).toBe(true);
+    expect(
+      segments.some((s) => s.kind === "text" && /Done\./.test(s.text)),
+    ).toBe(true);
+  });
+
+  it("handles a fenced block with no language tag", () => {
+    const segments = parseSegments("```\nplain code\n```", false);
+    expect(segments).toHaveLength(1);
+    const seg = segments[0];
+    if (seg.kind !== "code") throw new Error("expected code segment");
+    expect(seg.lang).toBeUndefined();
+    expect(seg.code).toBe("plain code");
+  });
+
+  it("does not lift a fenced UiSpec JSON into raw code (stays an interactive widget)", () => {
+    const spec = JSON.stringify({
+      root: "a",
+      elements: { a: { type: "text" } },
+    });
+    const segments = parseSegments(`\`\`\`json\n${spec}\n\`\`\``, false);
+    expect(segments.some((s) => s.kind === "ui-spec")).toBe(true);
+    expect(segments.some((s) => s.kind === "code")).toBe(false);
+  });
+
+  it("leaves a plain message with no fences as a single text segment", () => {
+    const segments = parseSegments("just a normal message", false);
+    expect(segments).toEqual([{ kind: "text", text: "just a normal message" }]);
+  });
+});
+
+describe("splitInlineCode", () => {
+  it("splits a sentence with an inline code span into ordered parts", () => {
+    const parts = splitInlineCode("Run `npm install` first.");
+    expect(parts).toEqual([
+      { kind: "text", text: "Run " },
+      { kind: "code", code: "npm install" },
+      { kind: "text", text: " first." },
+    ]);
+  });
+
+  it("returns a single text part when there is no backticked span", () => {
+    expect(splitInlineCode("no code here")).toEqual([
+      { kind: "text", text: "no code here" },
+    ]);
+  });
+
+  it("treats an empty backtick pair as plain text", () => {
+    expect(splitInlineCode("a `` b")).toEqual([
+      { kind: "text", text: "a `` b" },
+    ]);
+  });
+
+  it("handles multiple inline code spans", () => {
+    const parts = splitInlineCode("`a` and `b`");
+    expect(parts.filter((p) => p.kind === "code")).toHaveLength(2);
+  });
+});
+
+describe("conversationTranscriptText", () => {
+  it("renders each turn as a Speaker: text block using the agent name", () => {
+    const text = conversationTranscriptText(
+      [
+        { role: "user", text: "hello" },
+        { role: "assistant", text: "hi there" },
+      ],
+      { agentName: "Ada" },
+    );
+    expect(text).toBe("You: hello\n\nAda: hi there");
+  });
+
+  it("skips empty / whitespace-only turns", () => {
+    const text = conversationTranscriptText([
+      { role: "user", text: "  " },
+      { role: "assistant", text: "real reply" },
+    ]);
+    expect(text).toBe("Assistant: real reply");
+  });
+
+  it("returns an empty string for an empty conversation", () => {
+    expect(conversationTranscriptText([])).toBe("");
+  });
+});

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -47,6 +47,9 @@ export type Segment =
   | { kind: "text"; text: string }
   | { kind: "config"; pluginId: string }
   | { kind: "ui-spec"; spec: UiSpec; raw: string }
+  // A fenced (```lang ... ```) or inline (`...`) code span lifted out of the
+  // prose so it can render in the CodeBlock primitive with a copy button.
+  | { kind: "code"; code: string; lang?: string; inline: boolean }
   // Any registry-driven inline widget (choice/followups/form/task/plugin).
   | { kind: "widget"; widgetKind: string; data: unknown }
   | { kind: "permission"; payload: PermissionCardPayload }
@@ -56,6 +59,21 @@ export type Segment =
 
 export const CONFIG_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
 export const FENCED_JSON_RE = /```(?:json)?\s*\n([\s\S]*?)```/g;
+
+/**
+ * Any fenced code block ```` ```lang\n…``` ````. Captures the (optional)
+ * language tag and the body. Detected after the UiSpec/patch passes so a fenced
+ * UiSpec JSON is rendered as an interactive widget, not raw code; overlapping
+ * regions are dropped before this pass claims them.
+ */
+export const FENCED_CODE_RE = /```([^\n`]*)\n([\s\S]*?)```/g;
+
+/**
+ * Inline `code` spans inside otherwise plain prose. Backticked runs that contain
+ * a newline are excluded (those are fenced blocks, handled above), and the body
+ * must be non-empty so a stray pair of backticks isn't lifted out.
+ */
+export const INLINE_CODE_RE = /`([^`\n]+)`/g;
 
 export const HIDDEN_TAG_BLOCK_RE =
   /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*?(?:<\/\1>|$)/gi;
@@ -273,6 +291,40 @@ export function findPatchRegions(
   return results;
 }
 
+/** A run of message text split into plain prose and inline `code` spans. */
+export type InlineTextPart =
+  | { kind: "text"; text: string }
+  | { kind: "code"; code: string };
+
+/**
+ * Split a plain-text run into alternating prose and inline `code` parts so the
+ * renderer can wrap backticked spans in the code primitive while keeping them in
+ * the flow of the sentence. Empty backtick pairs (` `` `) are treated as prose.
+ * Pure + synchronous so it unit-tests without the DOM.
+ */
+export function splitInlineCode(text: string): InlineTextPart[] {
+  const parts: InlineTextPart[] = [];
+  let cursor = 0;
+  INLINE_CODE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null = INLINE_CODE_RE.exec(text);
+  while (match !== null) {
+    const code = match[1];
+    if (code.trim().length > 0) {
+      if (match.index > cursor) {
+        parts.push({ kind: "text", text: text.slice(cursor, match.index) });
+      }
+      parts.push({ kind: "code", code });
+      cursor = match.index + match[0].length;
+    }
+    match = INLINE_CODE_RE.exec(text);
+  }
+  if (cursor < text.length) {
+    parts.push({ kind: "text", text: text.slice(cursor) });
+  }
+  if (parts.length === 0) parts.push({ kind: "text", text });
+  return parts;
+}
+
 export function parseSegments(text: string, analysisMode: boolean): Segment[] {
   // If analysis mode is enabled, we parse the raw text to extract XML blocks,
   // otherwise we use the normalized text which strips them.
@@ -372,6 +424,36 @@ export function parseSegments(text: string, analysisMode: boolean): Segment[] {
     }
   }
 
+  // 4. Find fenced code blocks. Runs after the UiSpec/patch passes so a fenced
+  // UiSpec JSON renders as an interactive widget, not raw code; any fence that
+  // overlaps an already-claimed region (UiSpec, config marker, …) is dropped.
+  // Inline `code` is NOT lifted to a segment here — it stays in the text and is
+  // rendered inline by `MessageTextBody` so it keeps its place in the sentence;
+  // only block code gets the CodeBlock copy affordance.
+  const overlapsExisting = (start: number, end: number): boolean =>
+    regions.some((r) => start < r.end && end > r.start);
+  FENCED_CODE_RE.lastIndex = 0;
+  m = FENCED_CODE_RE.exec(targetText);
+  while (m !== null) {
+    const start = m.index;
+    const end = m.index + m[0].length;
+    const lang = m[1].trim();
+    const code = m[2].replace(/\n$/, "");
+    if (code.length > 0 && !overlapsExisting(start, end)) {
+      regions.push({
+        start,
+        end,
+        segment: {
+          kind: "code",
+          code,
+          inline: false,
+          ...(lang ? { lang } : {}),
+        },
+      });
+    }
+    m = FENCED_CODE_RE.exec(targetText);
+  }
+
   // No special content found — return plain text
   if (regions.length === 0) {
     return [{ kind: "text", text: targetText }];
@@ -402,6 +484,38 @@ export function parseSegments(text: string, analysisMode: boolean): Segment[] {
   }
 
   return segments;
+}
+
+// ── Conversation transcript ─────────────────────────────────────────
+
+/** One message projected to its `Speaker: text` transcript line. */
+export interface ConversationTranscriptMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+/**
+ * Render a conversation as a plain-text transcript for "copy conversation".
+ * Each turn becomes a `Speaker: text` block (blank line between turns), using
+ * the display name for the speaker (the agent name for assistant turns, "You"
+ * for the user). Empty/whitespace-only turns are skipped. Pure + DOM-free so it
+ * unit-tests without React and both chat surfaces share one definition.
+ */
+export function conversationTranscriptText(
+  messages: ReadonlyArray<ConversationTranscriptMessage>,
+  options: { agentName?: string; userName?: string } = {},
+): string {
+  const agentName = options.agentName?.trim() || "Assistant";
+  const userName = options.userName?.trim() || "You";
+  return messages
+    .map((message) => {
+      const text = message.text.trim();
+      if (!text) return "";
+      const speaker = message.role === "assistant" ? agentName : userName;
+      return `${speaker}: ${text}`;
+    })
+    .filter((line) => line.length > 0)
+    .join("\n\n");
 }
 
 // ── InlinePluginConfig helpers ──────────────────────────────────────

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -11,6 +11,7 @@ import {
 // biome-ignore lint/correctness/noUnusedImports: Required for this package's JSX transform in tests.
 import * as React from "react";
 import {
+  type ClipboardEvent,
   type KeyboardEvent,
   type PointerEvent,
   type RefObject,
@@ -111,6 +112,12 @@ export interface ChatComposerProps {
   onAttachImage: () => void;
   onChatInputChange: (value: string) => void;
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Clipboard paste handler — pastes an image/file as an attachment and a large
+   * text block as a collapsed text-attachment chip (matching the mobile
+   * overlay). Optional; when omitted the textarea pastes normally.
+   */
+  onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
   onSend: () => void;
   onStop: () => void;
   onStopSpeaking: () => void;
@@ -143,6 +150,7 @@ export function ChatComposer({
   onAttachImage,
   onChatInputChange,
   onKeyDown,
+  onPaste,
   onSend,
   onStop,
   onStopSpeaking,
@@ -377,6 +385,7 @@ export function ChatComposer({
           value={chatInput}
           onChange={(event) => onChatInputChange(event.target.value)}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           data-testid="chat-composer-textarea"
           aria-label={textareaAriaLabel}
           variant={null}
@@ -613,6 +622,7 @@ export function ChatComposer({
           value={chatInput}
           onChange={(event) => onChatInputChange(event.target.value)}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           data-testid="chat-composer-textarea"
           aria-label={textareaAriaLabel}
           variant={isInline ? null : undefined}

--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+//
+// The desktop hover action rail's Copy button fires `onCopy` (which the
+// ChatView wires to the clipboard helper) and reflects the copied state in its
+// label. This closes the coverage gap called out in #9148 — the overlay copy
+// was tested but the desktop ChatMessageActions copy was not.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatMessageActions } from "./chat-message-actions";
+
+afterEach(cleanup);
+
+describe("ChatMessageActions copy", () => {
+  it("invokes onCopy when the copy button is clicked", async () => {
+    const onCopy = vi.fn();
+    render(<ChatMessageActions onCopy={onCopy} />);
+    await userEvent.click(screen.getByRole("button", { name: "Copy message" }));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects the copied state in the button label", () => {
+    render(<ChatMessageActions copied onCopy={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Copied to clipboard" }),
+    ).toBeTruthy();
+  });
+
+  it("uses provided copy labels when supplied", () => {
+    render(
+      <ChatMessageActions
+        onCopy={vi.fn()}
+        labels={{ copy: "Copy text", copiedAria: "Done" }}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Copy text" })).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -1,6 +1,7 @@
-import { RotateCcw } from "lucide-react";
+import { Check, Copy, RotateCcw } from "lucide-react";
 import {
   type ChangeEvent,
+  type ClipboardEvent,
   type DragEvent,
   type KeyboardEvent,
   useCallback,
@@ -37,6 +38,7 @@ import {
   buildDroppedAttachmentNotice,
   CHAT_UPLOAD_ACCEPT,
   chatUploadKind,
+  classifyComposerPaste,
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
 } from "../../utils/image-attachment";
@@ -51,6 +53,7 @@ import {
   mergeConnectorSendAsMetadata,
 } from "../chat/connector-send-as";
 import { MessageContent } from "../chat/MessageContent";
+import { conversationTranscriptText } from "../chat/message-parser-helpers";
 import { ChatVoiceStatusBar } from "../composites/chat/ChatVoiceStatusBar";
 import { ContinuousChatToggle } from "../composites/chat/ContinuousChatToggle";
 import { ChatAttachmentStrip } from "../composites/chat/chat-attachment-strip";
@@ -527,6 +530,31 @@ export function ChatView({
     [addImageFiles],
   );
 
+  // Paste-to-attachment, matching the mobile overlay: a pasted image/file
+  // attaches; a large text block becomes a collapsed text-attachment chip;
+  // small text falls through to the textarea. Shared classification lives in
+  // utils/image-attachment.ts so both surfaces behave identically.
+  const handleComposerPaste = useCallback(
+    (e: ClipboardEvent<HTMLTextAreaElement>) => {
+      const intent = classifyComposerPaste({
+        files: Array.from(e.clipboardData?.files ?? []),
+        text: e.clipboardData?.getData("text") ?? "",
+      });
+      if (intent.kind === "files") {
+        e.preventDefault();
+        addImageFiles(intent.files);
+        return;
+      }
+      if (intent.kind === "text-attachment") {
+        e.preventDefault();
+        setChatPendingImages((prev) =>
+          [...prev, intent.attachment].slice(0, MAX_CHAT_IMAGES),
+        );
+      }
+    },
+    [addImageFiles, setChatPendingImages],
+  );
+
   const handleFileInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       if (e.target.files) {
@@ -593,6 +621,34 @@ export function ChatView({
     },
     [copyToClipboard],
   );
+  // Copy the whole thread as a plain-text transcript (`Speaker: text`, blank
+  // line between turns) via the shared clipboard helper — parity with the
+  // overlay's full-state header. Flashes a check on success.
+  const [conversationCopied, setConversationCopied] = useState(false);
+  const conversationCopiedTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  useEffect(
+    () => () => {
+      if (conversationCopiedTimerRef.current) {
+        clearTimeout(conversationCopiedTimerRef.current);
+      }
+    },
+    [],
+  );
+  const handleCopyConversation = useCallback(() => {
+    const transcript = conversationTranscriptText(visibleMsgs, { agentName });
+    if (!transcript) return;
+    void copyToClipboard(transcript);
+    setConversationCopied(true);
+    if (conversationCopiedTimerRef.current) {
+      clearTimeout(conversationCopiedTimerRef.current);
+    }
+    conversationCopiedTimerRef.current = setTimeout(
+      () => setConversationCopied(false),
+      2000,
+    );
+  }, [agentName, copyToClipboard, visibleMsgs]);
   const renderChatMessageContent = useCallback(
     (message: ChatMessageData) => (
       <MessageContent
@@ -754,6 +810,29 @@ export function ChatView({
       </button>
     ) : null;
 
+  // Copy-the-whole-thread control, shown alongside Reset when there are
+  // messages. Same neutral resting → neutral-hover language as Reset (no orange,
+  // no blue), flashing a check on copy.
+  const copyConversationButton =
+    visibleMsgs.length > 0 ? (
+      <button
+        type="button"
+        data-testid="chat-view-copy-conversation-button"
+        aria-label={
+          conversationCopied ? "Conversation copied" : "Copy conversation"
+        }
+        title={conversationCopied ? "Conversation copied" : "Copy conversation"}
+        onClick={handleCopyConversation}
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/40 text-muted transition-colors hover:bg-bg-hover hover:text-txt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-txt/30"
+      >
+        {conversationCopied ? (
+          <Check className="h-[18px] w-[18px] text-ok" aria-hidden />
+        ) : (
+          <Copy className="h-[18px] w-[18px]" aria-hidden />
+        )}
+      </button>
+    ) : null;
+
   const composerNode = hideComposer ? null : isGameModal ? (
     <ChatComposerShell
       variant="game-modal"
@@ -763,6 +842,7 @@ export function ChatView({
           <CodingAgentControlChip />
           {continuousChatToggleVisible || resetConversationButton ? (
             <div className="flex items-center justify-end gap-1 px-1 pb-0.5">
+              {copyConversationButton}
               {resetConversationButton}
               {continuousChatToggleVisible ? (
                 <ContinuousChatToggle
@@ -808,6 +888,7 @@ export function ChatView({
         onAttachImage={() => fileInputRef.current?.click()}
         onChatInputChange={(value) => setState("chatInput", value)}
         onKeyDown={handleKeyDown}
+        onPaste={handleComposerPaste}
         onSend={() => void handleChatSend()}
         onStop={handleChatStop}
         onStopSpeaking={stopSpeaking}
@@ -826,6 +907,7 @@ export function ChatView({
           <CodingAgentControlChip />
           {continuousChatToggleVisible || resetConversationButton ? (
             <div className="flex items-center justify-end gap-1 px-1 pb-0.5">
+              {copyConversationButton}
               {resetConversationButton}
               {continuousChatToggleVisible ? (
                 <ContinuousChatToggle
@@ -868,6 +950,7 @@ export function ChatView({
         onAttachImage={() => fileInputRef.current?.click()}
         onChatInputChange={(value) => setState("chatInput", value)}
         onKeyDown={handleKeyDown}
+        onPaste={handleComposerPaste}
         onSend={() => void handleChatSend()}
         onStop={handleChatStop}
         onStopSpeaking={stopSpeaking}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1,5 +1,7 @@
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {
+  Check,
+  Copy,
   FileText,
   Film,
   Home,
@@ -51,15 +53,15 @@ import { copyTextToClipboard } from "../../utils/clipboard";
 import {
   CHAT_UPLOAD_ACCEPT,
   chatUploadKind,
+  classifyComposerPaste,
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
-  pastedTextToAttachment,
-  shouldConvertPasteToAttachment,
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
 import { SensitiveRequestBlock } from "../chat/MessageContent";
+import { conversationTranscriptText } from "../chat/message-parser-helpers";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
@@ -1243,6 +1245,38 @@ export function ContinuousChatOverlay({
   );
   const lastId = visibleMessages.at(-1)?.id ?? null;
   const lastContent = visibleMessages.at(-1)?.content ?? "";
+
+  // Copy the whole thread as a plain-text transcript from the full-state header
+  // — parity with the desktop ChatView header. Flashes a check on success.
+  const [conversationCopied, setConversationCopied] = React.useState(false);
+  const conversationCopiedTimerRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  React.useEffect(
+    () => () => {
+      if (conversationCopiedTimerRef.current) {
+        clearTimeout(conversationCopiedTimerRef.current);
+      }
+    },
+    [],
+  );
+  const handleCopyConversation = React.useCallback(() => {
+    const transcript = conversationTranscriptText(
+      visibleMessages.map((m) => ({ role: m.role, text: m.content })),
+      { agentName },
+    );
+    if (!transcript) return;
+    void copyTextToClipboard(transcript);
+    setConversationCopied(true);
+    if (conversationCopiedTimerRef.current) {
+      clearTimeout(conversationCopiedTimerRef.current);
+    }
+    conversationCopiedTimerRef.current = setTimeout(
+      () => setConversationCopied(false),
+      2000,
+    );
+  }, [agentName, visibleMessages]);
+
   // The last line id the scroll effect pinned to — lets it tell a NEW line
   // (always pin to bottom) from streaming growth of the current line (follow
   // only when the reader is already at the bottom).
@@ -3090,6 +3124,18 @@ export function ContinuousChatOverlay({
                     onClick={toggleMaximize}
                     testId="chat-full-maximize"
                   />
+                  {hasThread ? (
+                    <HeaderButton
+                      icon={conversationCopied ? Check : Copy}
+                      label={
+                        conversationCopied
+                          ? "conversation copied"
+                          : "copy conversation"
+                      }
+                      onClick={handleCopyConversation}
+                      testId="chat-full-copy-conversation"
+                    />
+                  ) : null}
                   <HeaderButton
                     icon={RotateCcw}
                     label="clear conversation"
@@ -3401,25 +3447,23 @@ export function ContinuousChatOverlay({
                 }}
                 onBlur={() => setComposerFocused(false)}
                 onPaste={(e) => {
-                  // Paste images/files straight into the composer (cmd/ctrl+V).
-                  const files = Array.from(e.clipboardData?.files ?? []);
-                  if (files.length > 0) {
+                  // Shared with the desktop composer: a pasted image/file
+                  // attaches, a large plain-text paste becomes a collapsed
+                  // text-attachment chip, and small text falls through to the
+                  // textarea as normal.
+                  const intent = classifyComposerPaste({
+                    files: Array.from(e.clipboardData?.files ?? []),
+                    text: e.clipboardData?.getData("text") ?? "",
+                  });
+                  if (intent.kind === "files") {
                     e.preventDefault();
-                    addImageFiles(files);
+                    addImageFiles(intent.files);
                     return;
                   }
-                  // A large plain-text paste becomes a collapsed text
-                  // attachment chip (Claude-Code style) instead of flooding the
-                  // textarea; small pastes fall through to the textarea as
-                  // normal.
-                  const text = e.clipboardData?.getData("text") ?? "";
-                  if (shouldConvertPasteToAttachment(text)) {
+                  if (intent.kind === "text-attachment") {
                     e.preventDefault();
                     setPendingImages((prev) =>
-                      [...prev, pastedTextToAttachment(text)].slice(
-                        0,
-                        MAX_CHAT_IMAGES,
-                      ),
+                      [...prev, intent.attachment].slice(0, MAX_CHAT_IMAGES),
                     );
                   }
                 }}

--- a/packages/ui/src/utils/image-attachment.test.ts
+++ b/packages/ui/src/utils/image-attachment.test.ts
@@ -4,6 +4,7 @@ import {
   bytesToMb,
   CHAT_UPLOAD_ACCEPT,
   chatUploadKind,
+  classifyComposerPaste,
   createImageThumbnail,
   isSupportedChatUpload,
   LARGE_PASTE_CHAR_THRESHOLD,
@@ -287,6 +288,45 @@ describe("pastedTextToAttachment", () => {
   it("does not include a data-URL prefix in data", () => {
     const att = pastedTextToAttachment("plain content");
     expect(att.data.startsWith("data:")).toBe(false);
+  });
+});
+
+describe("classifyComposerPaste", () => {
+  it("returns the files intent when the paste carries files", () => {
+    const f = file("image/png");
+    const intent = classifyComposerPaste({ files: [f], text: "" });
+    expect(intent.kind).toBe("files");
+    if (intent.kind !== "files") throw new Error("expected files intent");
+    expect(intent.files).toEqual([f]);
+  });
+
+  it("prefers files even when text is also present", () => {
+    const f = file("image/png");
+    const intent = classifyComposerPaste({
+      files: [f],
+      text: "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 10),
+    });
+    expect(intent.kind).toBe("files");
+  });
+
+  it("converts a large text paste into a text attachment", () => {
+    const text = "a ".repeat(LARGE_PASTE_CHAR_THRESHOLD);
+    const intent = classifyComposerPaste({ files: [], text });
+    expect(intent.kind).toBe("text-attachment");
+    if (intent.kind !== "text-attachment")
+      throw new Error("expected text-attachment intent");
+    expect(intent.attachment.mimeType).toBe("text/markdown");
+  });
+
+  it("passes through a small text paste (textarea handles it)", () => {
+    const intent = classifyComposerPaste({ files: [], text: "short" });
+    expect(intent.kind).toBe("passthrough");
+  });
+
+  it("passes through a lone long URL (it's a link, not a document)", () => {
+    const url = `https://example.com/${"a".repeat(LARGE_PASTE_CHAR_THRESHOLD)}`;
+    const intent = classifyComposerPaste({ files: [], text: url });
+    expect(intent.kind).toBe("passthrough");
   });
 });
 

--- a/packages/ui/src/utils/image-attachment.ts
+++ b/packages/ui/src/utils/image-attachment.ts
@@ -363,6 +363,38 @@ export function pastedTextToAttachment(
 }
 
 /**
+ * Classify a composer paste so both chat surfaces handle clipboard pastes
+ * identically. Returns either:
+ *  - `{ kind: "files" }` — the paste carried image/file data; the caller should
+ *    `preventDefault()` and run the files through {@link intakeAttachmentFiles}.
+ *  - `{ kind: "text-attachment", attachment }` — a large plain-text paste that
+ *    should become a collapsed text-attachment chip (`preventDefault()` first).
+ *  - `{ kind: "passthrough" }` — nothing to intercept; let the textarea handle
+ *    the paste normally (small text, or a lone URL).
+ * Pure + DOM-free so it unit-tests without a real ClipboardEvent.
+ */
+export type ComposerPasteIntent =
+  | { kind: "files"; files: File[] }
+  | { kind: "text-attachment"; attachment: ImageAttachment }
+  | { kind: "passthrough" };
+
+export function classifyComposerPaste(data: {
+  files: File[];
+  text: string;
+}): ComposerPasteIntent {
+  if (data.files.length > 0) {
+    return { kind: "files", files: data.files };
+  }
+  if (shouldConvertPasteToAttachment(data.text)) {
+    return {
+      kind: "text-attachment",
+      attachment: pastedTextToAttachment(data.text),
+    };
+  }
+  return { kind: "passthrough" };
+}
+
+/**
  * Build the translated "kept N, dropped M" notice for the composer from an
  * intake/partition result, choosing the right i18n key based on whether the
  * drops were oversized, over-count, or a mix. Returns `null` when nothing was


### PR DESCRIPTION
Closes #9148.

Unifies the copy/paste contract between the desktop `ChatView` and the mobile `ContinuousChatOverlay`, reusing the existing `CodeBlock`/`CopyButton`, clipboard, and attachment primitives — no new clipboard or attachment paths (per `packages/ui/CLAUDE.md` "Files / attachments").

## What changed

**Gap 1 — code-block copy.** Added a `code` segment kind to the `Segment` union and parse fenced ` ```code``` ` out of assistant text in `parseSegments` (after the UiSpec/patch passes, so a fenced UiSpec still renders as an interactive widget, not raw code; overlapping fences are dropped). Block code renders via the existing copyable `CodeBlock` primitive; inline `` `code` `` spans render inline and keep their place in the sentence via a new pure `splitInlineCode` helper. The plain-text fast path is preserved for fence-free messages.

**Gap 3 — desktop paste.** Added an optional `onPaste` prop to the desktop composer `<Textarea>`s (`chat-composer.tsx`) and wired it in `ChatView`, reusing a new shared `classifyComposerPaste` helper: a pasted image/file attaches, a large text block becomes a collapsed text-attachment chip, and small text/lone URLs fall through to the textarea — matching the mobile overlay. The overlay's inline paste handler now uses the same helper, removing the duplication.

**Gap 2 — copy conversation.** Added a copy-the-whole-thread affordance to the desktop chat header (next to Reset) and the overlay full-state header, built on a pure `conversationTranscriptText(messages)` helper (`Speaker: text`, blank line between turns) and the shared `copyTextToClipboard`/`copyToClipboard`.

## Verification

- `bun run --cwd packages/ui typecheck` — clean.
- `bun run --cwd packages/ui lint` — clean (1969 files, 0 errors).
- Tests (all green): added `message-parser-code.test.ts` (fenced-code segment, fenced-UiSpec-not-claimed, inline-code split, conversation transcript), `MessageContent.code-block.test.tsx` (renders a `CodeBlock` whose copy button writes the exact block contents; inline-only message has no block affordance), `chat-message-actions.test.tsx` (the previously-missing desktop copy → `onCopy`), and `classifyComposerPaste` cases in `image-attachment.test.ts`. Existing overlay copy tests stay green (`ContinuousChatOverlay.test.tsx`). Ran the full `packages/ui` chat/shell/composites suites: 375 passing.
- Added a `CodeBlocks` story to `MessageContent.stories.tsx` for story-gate coverage.

Note: the repo-wide `audit:ui-determinism` flags a pre-existing occurrence in `ElizaOsAppsView.tsx`, which this PR does not touch; none of the changed files introduce render-time nondeterminism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)