### PR TITLE
feat(ui): chat copy/paste parity — code-block copy, copy-thread, desktop paste (#9148)

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -25,6 +25,7 @@ import { ConfigRenderer } from "../config-ui/config-renderer";
 import { defaultRegistry } from "../config-ui/config-renderer.helpers";
 import { UiRenderer } from "../config-ui/ui-renderer";
 import { Button } from "../ui/button";
+import { CodeBlock } from "../ui/code-block";
 import { MessageAttachments } from "./MessageAttachments";
 import {
   buildInlinePluginConfigModel,
@@ -1025,7 +1026,9 @@ export function MessageContent({
                     ? `permission:${seg.payload.feature}`
                     : seg.kind === "analysis-xml"
                       ? `analysis:${seg.tag}`
-                      : `ui:${seg.raw.slice(0, 80)}`;
+                      : seg.kind === "code"
+                        ? `code:${seg.code.slice(0, 80)}`
+                        : `ui:${seg.raw.slice(0, 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {
@@ -1057,6 +1060,19 @@ export function MessageContent({
               }
               return (
                 <InlinePluginConfig key={segmentKey} pluginId={seg.pluginId} />
+              );
+            case "code":
+              return (
+                <CodeBlock
+                  key={segmentKey}
+                  className="my-2"
+                  value={seg.code.replace(/\n$/, "")}
+                  wrap
+                  copyable
+                  aria-label={
+                    seg.lang ? `${seg.lang} code block` : "code block"
+                  }
+                />
               );
             case "ui-spec":
               return (

--- a/packages/ui/src/components/chat/message-parser-helpers.code.test.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.code.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConversationTranscript,
+  parseSegments,
+} from "./message-parser-helpers";
+
+describe("parseSegments — fenced code blocks (#9148)", () => {
+  it("extracts a fenced code block as a `code` segment with its language", () => {
+    const text = "Here you go:\n```ts\nconst x = 1;\n```\nDone.";
+    const segs = parseSegments(text, false);
+    const code = segs.find((s) => s.kind === "code");
+    expect(code).toBeDefined();
+    if (code?.kind === "code") {
+      expect(code.lang).toBe("ts");
+      expect(code.code).toBe("const x = 1;\n");
+    }
+    // Surrounding prose stays as text segments.
+    expect(segs.filter((s) => s.kind === "text").length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it("handles a fence with no language info-string", () => {
+    const segs = parseSegments("```\nplain\n```", false);
+    const code = segs.find((s) => s.kind === "code");
+    expect(code?.kind === "code" && code.lang).toBe("");
+    expect(code?.kind === "code" && code.code).toBe("plain\n");
+  });
+
+  it("keeps a fence-free message on the plain-text fast path", () => {
+    const segs = parseSegments("no code here", false);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual({ kind: "text", text: "no code here" });
+  });
+
+  it("captures an unterminated fence (mid-stream) so it renders incrementally", () => {
+    const segs = parseSegments("```js\nstreaming...", false);
+    const code = segs.find((s) => s.kind === "code");
+    expect(code?.kind === "code" && code.lang).toBe("js");
+    expect(code?.kind === "code" && code.code).toBe("streaming...");
+  });
+
+  it("yields to a UiSpec fence rather than treating it as a code block", () => {
+    const spec = JSON.stringify({
+      root: "a",
+      elements: { a: { type: "text" } },
+    });
+    const segs = parseSegments("```json\n" + spec + "\n```", false);
+    expect(segs.some((s) => s.kind === "ui-spec")).toBe(true);
+    expect(segs.some((s) => s.kind === "code")).toBe(false);
+  });
+
+  it("renders a non-UiSpec JSON fence as a copyable code block", () => {
+    const segs = parseSegments('```json\n{"a":1}\n```', false);
+    expect(segs.some((s) => s.kind === "code")).toBe(true);
+    expect(segs.some((s) => s.kind === "ui-spec")).toBe(false);
+  });
+});
+
+describe("buildConversationTranscript (#9148)", () => {
+  it("labels turns by role and separates them with blank lines", () => {
+    const transcript = buildConversationTranscript([
+      { role: "user", text: "hello" },
+      { role: "assistant", text: "hi there" },
+    ]);
+    expect(transcript).toBe("User: hello\n\nAssistant: hi there");
+  });
+
+  it("strips hidden reasoning/stage blocks from assistant turns", () => {
+    const transcript = buildConversationTranscript([
+      { role: "assistant", text: "<think>secret</think>visible answer" },
+    ]);
+    expect(transcript).toBe("Assistant: visible answer");
+    expect(transcript).not.toContain("secret");
+  });
+
+  it("skips empty turns", () => {
+    const transcript = buildConversationTranscript([
+      { role: "user", text: "   " },
+      { role: "assistant", text: "kept" },
+    ]);
+    expect(transcript).toBe("Assistant: kept");
+  });
+
+  it("honors custom role labels", () => {
+    const transcript = buildConversationTranscript(
+      [{ role: "user", text: "yo" }],
+      { userLabel: "Me" },
+    );
+    expect(transcript).toBe("Me: yo");
+  });
+});

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -50,12 +50,22 @@ export type Segment =
   // Any registry-driven inline widget (choice/followups/form/task/plugin).
   | { kind: "widget"; widgetKind: string; data: unknown }
   | { kind: "permission"; payload: PermissionCardPayload }
-  | { kind: "analysis-xml"; tag: string; content: string };
+  | { kind: "analysis-xml"; tag: string; content: string }
+  // A fenced ```code``` block in assistant prose, rendered with a copy button
+  // via the shared CodeBlock primitive (issue #9148). `lang` is the (optional)
+  // info-string after the opening fence; `code` is the block body (no fences).
+  | { kind: "code"; lang: string; code: string };
 
 // ── Detection ───────────────────────────────────────────────────────
 
 export const CONFIG_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
 export const FENCED_JSON_RE = /```(?:json)?\s*\n([\s\S]*?)```/g;
+// Generic fenced code block: optional info-string (language) after the opening
+// fence, then the body up to the closing fence. Captured only when it does not
+// overlap a UiSpec/patch region (those keep their richer rendering). A fence
+// left unclosed at end-of-stream (mid-stream token) still matches so partial
+// code renders incrementally rather than as raw backticks.
+export const FENCED_CODE_RE = /```([\w+#.-]*)[ \t]*\r?\n([\s\S]*?)(?:```|$)/g;
 
 export const HIDDEN_TAG_BLOCK_RE =
   /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*?(?:<\/\1>|$)/gi;
@@ -85,6 +95,34 @@ export function normalizeDisplayText(text: string): string {
 
   normalized = stripAssistantStageDirections(normalized);
   return normalized.trim();
+}
+
+/**
+ * Build a plain-text transcript of a conversation for copy/export (#9148),
+ * shared by the desktop ChatView and the mobile overlay so the "copy whole
+ * conversation" affordance produces identical output on both surfaces.
+ * Each turn is labelled by role and separated by a blank line; assistant text
+ * is run through {@link normalizeDisplayText} so hidden reasoning/stage blocks
+ * never leak into the copied transcript. Empty-text turns are skipped. Pure.
+ */
+export function buildConversationTranscript(
+  messages: Pick<ConversationMessage, "role" | "text">[],
+  opts: { userLabel?: string; assistantLabel?: string } = {},
+): string {
+  const userLabel = opts.userLabel ?? "User";
+  const assistantLabel = opts.assistantLabel ?? "Assistant";
+  const lines: string[] = [];
+  for (const m of messages) {
+    const body =
+      m.role === "assistant"
+        ? normalizeDisplayText(m.text ?? "")
+        : (m.text ?? "").trim();
+    if (!body) continue;
+    lines.push(
+      `${m.role === "assistant" ? assistantLabel : userLabel}: ${body}`,
+    );
+  }
+  return lines.join("\n\n");
 }
 
 export function tryParse(s: string): unknown {
@@ -370,6 +408,25 @@ export function parseSegments(text: string, analysisMode: boolean): Segment[] {
         segment: { kind: "ui-spec", spec: patch.spec, raw: patch.raw },
       });
     }
+  }
+
+  // 4. Find generic fenced code blocks. Collected last and skipped when they
+  // overlap an already-found region, so UiSpec/patch fences keep their richer
+  // rendering and only plain ```code``` becomes a copyable CodeBlock (#9148).
+  FENCED_CODE_RE.lastIndex = 0;
+  m = FENCED_CODE_RE.exec(targetText);
+  while (m !== null) {
+    const start = m.index;
+    const end = m.index + m[0].length;
+    const overlaps = regions.some((r) => start < r.end && end > r.start);
+    if (!overlaps) {
+      regions.push({
+        start,
+        end,
+        segment: { kind: "code", lang: m[1] ?? "", code: m[2] ?? "" },
+      });
+    }
+    m = FENCED_CODE_RE.exec(targetText);
   }
 
   // No special content found — return plain text

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -11,6 +11,7 @@ import {
 // biome-ignore lint/correctness/noUnusedImports: Required for this package's JSX transform in tests.
 import * as React from "react";
 import {
+  type ClipboardEvent,
   type KeyboardEvent,
   type PointerEvent,
   type RefObject,
@@ -111,6 +112,12 @@ export interface ChatComposerProps {
   onAttachImage: () => void;
   onChatInputChange: (value: string) => void;
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Paste handler for the textarea (#9148). When provided, both desktop and
+   * inline composers forward paste so screenshots/large text become attachments
+   * — paste parity with the mobile overlay.
+   */
+  onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
   onSend: () => void;
   onStop: () => void;
   onStopSpeaking: () => void;
@@ -143,6 +150,7 @@ export function ChatComposer({
   onAttachImage,
   onChatInputChange,
   onKeyDown,
+  onPaste,
   onSend,
   onStop,
   onStopSpeaking,
@@ -377,6 +385,7 @@ export function ChatComposer({
           value={chatInput}
           onChange={(event) => onChatInputChange(event.target.value)}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           data-testid="chat-composer-textarea"
           aria-label={textareaAriaLabel}
           variant={null}
@@ -613,6 +622,7 @@ export function ChatComposer({
           value={chatInput}
           onChange={(event) => onChatInputChange(event.target.value)}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           data-testid="chat-composer-textarea"
           aria-label={textareaAriaLabel}
           variant={isInline ? null : undefined}

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -1,6 +1,7 @@
-import { RotateCcw } from "lucide-react";
+import { Copy, RotateCcw } from "lucide-react";
 import {
   type ChangeEvent,
+  type ClipboardEvent,
   type DragEvent,
   type KeyboardEvent,
   useCallback,
@@ -39,6 +40,7 @@ import {
   chatUploadKind,
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
+  resolveComposerPaste,
 } from "../../utils/image-attachment";
 import type { VoiceContinuousMode } from "../../voice/voice-chat-types";
 import { AccountRequiredCard } from "../chat/AccountRequiredCard";
@@ -51,6 +53,7 @@ import {
   mergeConnectorSendAsMetadata,
 } from "../chat/connector-send-as";
 import { MessageContent } from "../chat/MessageContent";
+import { buildConversationTranscript } from "../chat/message-parser-helpers";
 import { ChatVoiceStatusBar } from "../composites/chat/ChatVoiceStatusBar";
 import { ContinuousChatToggle } from "../composites/chat/ContinuousChatToggle";
 import { ChatAttachmentStrip } from "../composites/chat/chat-attachment-strip";
@@ -537,6 +540,25 @@ export function ChatView({
     [addImageFiles],
   );
 
+  // Desktop composer paste parity with the mobile overlay (#9148): pasted
+  // screenshots/files become attachments and a large text paste collapses to a
+  // text-attachment chip; small text falls through to the textarea normally.
+  const handleComposerPaste = useCallback(
+    (e: ClipboardEvent<HTMLTextAreaElement>) => {
+      const action = resolveComposerPaste(e.clipboardData);
+      if (action.kind === "files") {
+        e.preventDefault();
+        addImageFiles(action.files);
+      } else if (action.kind === "text-attachment") {
+        e.preventDefault();
+        setChatPendingImages((prev) =>
+          [...prev, action.attachment].slice(0, MAX_CHAT_IMAGES),
+        );
+      }
+    },
+    [addImageFiles, setChatPendingImages],
+  );
+
   const removeImage = useCallback(
     (index: number) => {
       setChatPendingImages((prev) => prev.filter((_, i) => i !== index));
@@ -754,6 +776,25 @@ export function ChatView({
       </button>
     ) : null;
 
+  // Copy-whole-conversation control (#9148): builds the same plain-text
+  // transcript the overlay produces and routes through the shared clipboard
+  // helper. Same neutral styling as the reset button (no orange, no blue).
+  const copyConversationButton =
+    visibleMsgs.length > 0 ? (
+      <button
+        type="button"
+        data-testid="chat-view-copy-conversation-button"
+        aria-label="Copy conversation"
+        title="Copy conversation"
+        onClick={() => {
+          void copyToClipboard(buildConversationTranscript(visibleMsgs));
+        }}
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/40 text-muted transition-colors hover:bg-bg-hover hover:text-txt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-txt/30"
+      >
+        <Copy className="h-[18px] w-[18px]" aria-hidden />
+      </button>
+    ) : null;
+
   const composerNode = hideComposer ? null : isGameModal ? (
     <ChatComposerShell
       variant="game-modal"
@@ -763,6 +804,7 @@ export function ChatView({
           <CodingAgentControlChip />
           {continuousChatToggleVisible || resetConversationButton ? (
             <div className="flex items-center justify-end gap-1 px-1 pb-0.5">
+              {copyConversationButton}
               {resetConversationButton}
               {continuousChatToggleVisible ? (
                 <ContinuousChatToggle
@@ -808,6 +850,7 @@ export function ChatView({
         onAttachImage={() => fileInputRef.current?.click()}
         onChatInputChange={(value) => setState("chatInput", value)}
         onKeyDown={handleKeyDown}
+        onPaste={handleComposerPaste}
         onSend={() => void handleChatSend()}
         onStop={handleChatStop}
         onStopSpeaking={stopSpeaking}
@@ -826,6 +869,7 @@ export function ChatView({
           <CodingAgentControlChip />
           {continuousChatToggleVisible || resetConversationButton ? (
             <div className="flex items-center justify-end gap-1 px-1 pb-0.5">
+              {copyConversationButton}
               {resetConversationButton}
               {continuousChatToggleVisible ? (
                 <ContinuousChatToggle
@@ -868,6 +912,7 @@ export function ChatView({
         onAttachImage={() => fileInputRef.current?.click()}
         onChatInputChange={(value) => setState("chatInput", value)}
         onKeyDown={handleKeyDown}
+        onPaste={handleComposerPaste}
         onSend={() => void handleChatSend()}
         onStop={handleChatStop}
         onStopSpeaking={stopSpeaking}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -53,8 +53,7 @@ import {
   chatUploadKind,
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
-  pastedTextToAttachment,
-  shouldConvertPasteToAttachment,
+  resolveComposerPaste,
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
@@ -3401,25 +3400,17 @@ export function ContinuousChatOverlay({
                 }}
                 onBlur={() => setComposerFocused(false)}
                 onPaste={(e) => {
-                  // Paste images/files straight into the composer (cmd/ctrl+V).
-                  const files = Array.from(e.clipboardData?.files ?? []);
-                  if (files.length > 0) {
+                  // Shared paste contract with the desktop composer (#9148):
+                  // files → attachments, large text → collapsed chip, else the
+                  // textarea handles it normally.
+                  const action = resolveComposerPaste(e.clipboardData);
+                  if (action.kind === "files") {
                     e.preventDefault();
-                    addImageFiles(files);
-                    return;
-                  }
-                  // A large plain-text paste becomes a collapsed text
-                  // attachment chip (Claude-Code style) instead of flooding the
-                  // textarea; small pastes fall through to the textarea as
-                  // normal.
-                  const text = e.clipboardData?.getData("text") ?? "";
-                  if (shouldConvertPasteToAttachment(text)) {
+                    addImageFiles(action.files);
+                  } else if (action.kind === "text-attachment") {
                     e.preventDefault();
                     setPendingImages((prev) =>
-                      [...prev, pastedTextToAttachment(text)].slice(
-                        0,
-                        MAX_CHAT_IMAGES,
-                      ),
+                      [...prev, action.attachment].slice(0, MAX_CHAT_IMAGES),
                     );
                   }
                 }}

--- a/packages/ui/src/utils/image-attachment.test.ts
+++ b/packages/ui/src/utils/image-attachment.test.ts
@@ -12,6 +12,7 @@ import {
   MAX_CHAT_IMAGES,
   partitionAttachmentFiles,
   pastedTextToAttachment,
+  resolveComposerPaste,
   shouldConvertPasteToAttachment,
   summarizeDroppedAttachments,
 } from "./image-attachment";
@@ -342,5 +343,50 @@ describe("buildDroppedAttachmentNotice", () => {
     expect(notice).toContain("chat.attachmentsKeptDroppedMixed");
     expect(notice).toContain('"tooLarge":1');
     expect(notice).toContain('"overCount":1');
+  });
+});
+
+describe("resolveComposerPaste", () => {
+  /** Minimal DataTransfer stand-in: files list + getData("text"). */
+  const clip = (opts: { files?: File[]; text?: string }) =>
+    ({
+      files: (opts.files ?? []) as unknown as FileList,
+      getData: (type: string) => (type === "text" ? (opts.text ?? "") : ""),
+    }) as unknown as Pick<DataTransfer, "files" | "getData">;
+
+  it("routes pasted files to the files action (screenshots/attachments)", () => {
+    const png = { type: "image/png", name: "shot.png" } as File;
+    const action = resolveComposerPaste(clip({ files: [png] }));
+    expect(action.kind).toBe("files");
+    if (action.kind === "files") {
+      expect(action.files).toHaveLength(1);
+    }
+  });
+
+  it("files take precedence over any accompanying text", () => {
+    const png = { type: "image/png", name: "shot.png" } as File;
+    const action = resolveComposerPaste(
+      clip({ files: [png], text: "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1) }),
+    );
+    expect(action.kind).toBe("files");
+  });
+
+  it("collapses a large text paste into a text attachment", () => {
+    const text = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1);
+    const action = resolveComposerPaste(clip({ text }));
+    expect(action.kind).toBe("text-attachment");
+    if (action.kind === "text-attachment") {
+      expect(action.attachment.mimeType).toBe("text/markdown");
+      expect(decodeAttachmentText(action.attachment.data)).toBe(text);
+    }
+  });
+
+  it("ignores a small text paste (textarea handles it)", () => {
+    expect(resolveComposerPaste(clip({ text: "hi" })).kind).toBe("ignore");
+  });
+
+  it("ignores an empty/absent clipboard", () => {
+    expect(resolveComposerPaste(null).kind).toBe("ignore");
+    expect(resolveComposerPaste(clip({})).kind).toBe("ignore");
   });
 });

--- a/packages/ui/src/utils/image-attachment.ts
+++ b/packages/ui/src/utils/image-attachment.ts
@@ -363,6 +363,38 @@ export function pastedTextToAttachment(
 }
 
 /**
+ * The composer-paste decision, shared by both chat surfaces (desktop ChatView
+ * and the mobile overlay) so paste behaves identically (#9148). Pure over the
+ * clipboard payload so it's testable without a DOM event:
+ *  - pasted files (e.g. a screenshot) → `files` (intake as attachments),
+ *  - a large plain-text paste → `text-attachment` (collapsed chip, Claude-Code
+ *    style) instead of flooding the textarea,
+ *  - anything else → `ignore` (let the textarea handle it normally).
+ * The caller calls `preventDefault()` for the non-`ignore` actions.
+ */
+export type ComposerPasteAction =
+  | { kind: "files"; files: File[] }
+  | { kind: "text-attachment"; attachment: ImageAttachment }
+  | { kind: "ignore" };
+
+export function resolveComposerPaste(
+  clipboard: Pick<DataTransfer, "files" | "getData"> | null | undefined,
+): ComposerPasteAction {
+  const files = Array.from(clipboard?.files ?? []);
+  if (files.length > 0) {
+    return { kind: "files", files };
+  }
+  const text = clipboard?.getData("text") ?? "";
+  if (shouldConvertPasteToAttachment(text)) {
+    return {
+      kind: "text-attachment",
+      attachment: pastedTextToAttachment(text),
+    };
+  }
+  return { kind: "ignore" };
+}
+
+/**
  * Build the translated "kept N, dropped M" notice for the composer from an
  * intake/partition result, choosing the right i18n key based on whether the
  * drops were oversized, over-count, or a mix. Returns `null` when nothing was


### PR DESCRIPTION
Closes the three copy/paste gaps from #9148 between the desktop `ChatView` and the mobile `ContinuousChatOverlay`, reusing existing primitives (no new clipboard/attachment paths — per `packages/ui/CLAUDE.md`).

## Gaps closed

**Gap 1 — per-block code copy.** Fenced ` ``` ` code blocks in assistant prose now render via the shared `CodeBlock` primitive (with its copy button) instead of undifferentiated `whitespace-pre-wrap` text. Adds a `code` `Segment` kind + `FENCED_CODE_RE` to `parseSegments`:
- yields to UiSpec / JSONL-patch fences (overlap-skip) so Generate-Mode specs keep their rich rendering;
- a non-UiSpec JSON fence becomes a copyable code block;
- an unterminated fence (mid-stream token) still matches so the block renders incrementally;
- fence-free messages keep the single-segment plain-text fast path.

**Gap 2 — copy whole conversation.** A "Copy conversation" button sits next to the `ChatView` reset control, building a plain-text transcript via the new pure `buildConversationTranscript` helper. Assistant turns run through `normalizeDisplayText`, so hidden reasoning/stage-direction blocks never leak into the copy; routed through the shared `copyToClipboard`.

**Gap 3 — desktop paste.** The desktop composer `<Textarea>`(s) now handle `onPaste`: pasted screenshots/files become attachments and a large text paste collapses to a text-attachment chip — matching the overlay. The decision is extracted into a pure `resolveComposerPaste(clipboard)` helper, and the overlay's inline handler was refactored to call it (one paste contract, two surfaces).

## Tests / validation
- New `message-parser-helpers.code.test.ts`: code-fence parsing (incl. UiSpec precedence + mid-stream), `buildConversationTranscript` (role labels, hidden-block stripping, empty-skip, custom labels).
- `resolveComposerPaste` cases added to `image-attachment.test.ts` (files vs large-text vs ignore, files-take-precedence, empty clipboard).
- `bun run --cwd packages/ui test -- message-parser-helpers.code image-attachment` → **46/46 pass**.
- `bun run --cwd packages/ui typecheck` → clean. `biome check` → clean.

Frontend-only, all in `packages/ui`. Reuses `CodeBlock`/`CopyButton`, `intakeAttachmentFiles`, `pastedTextToAttachment`, `copyToClipboard` — no new subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)