### PR TITLE
fix(app): pin crypto graph to lazy vendor chunk + hard chunk-safety gate (#9150)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -264,19 +264,16 @@ jobs:
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
-      # Refuse to deploy a bundle where Rolldown folded the bn.js/crypto graph
-      # into an eager chunk (the "Class constructor cannot be invoked without
-      # 'new'" Buffer.allocUnsafe module-init crash that blanks every route).
-      # This regression has reached prod multiple times; fail the deploy instead.
+      # Refuse to deploy a bundle where the bn.js/crypto graph folded into an
+      # eager chunk (the "Class constructor cannot be invoked without 'new'"
+      # Buffer.allocUnsafe module-init crash that blanks every route). This
+      # regression has reached prod multiple times; fail the deploy instead.
+      # HARD GATE: the chunking fold is fixed (#9150) — the `manualChunks` pin
+      # now lives under `rollupOptions.output` (the key Vite reads) and folds
+      # the crypto/wallet/solana graph into one lazy `vendor-crypto` chunk, so a
+      # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
         working-directory: packages/app
-        # NON-BLOCKING for now: surfaces the bn.js/crypto eager-chunk fold loudly
-        # (job summary) WITHOUT failing the deploy. The underlying Rolldown fold
-        # is known-non-deterministic and the vendor-crypto manualChunk pin does
-        # not yet reliably prevent it (bn.js currently co-bundles into the
-        # date-fns en_US locale chunk). Flip to a hard gate (drop
-        # continue-on-error) once the chunking fix lands. See #9150.
-        continue-on-error: true
         run: bun run verify:chunk-safety
 
       - name: Resolve Pages branch
@@ -422,19 +419,16 @@ jobs:
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
-      # Refuse to deploy a bundle where Rolldown folded the bn.js/crypto graph
-      # into an eager chunk (the "Class constructor cannot be invoked without
-      # 'new'" Buffer.allocUnsafe module-init crash that blanks every route).
-      # This regression has reached prod multiple times; fail the deploy instead.
+      # Refuse to deploy a bundle where the bn.js/crypto graph folded into an
+      # eager chunk (the "Class constructor cannot be invoked without 'new'"
+      # Buffer.allocUnsafe module-init crash that blanks every route). This
+      # regression has reached prod multiple times; fail the deploy instead.
+      # HARD GATE: the chunking fold is fixed (#9150) — the `manualChunks` pin
+      # now lives under `rollupOptions.output` (the key Vite reads) and folds
+      # the crypto/wallet/solana graph into one lazy `vendor-crypto` chunk, so a
+      # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
         working-directory: packages/app
-        # NON-BLOCKING for now: surfaces the bn.js/crypto eager-chunk fold loudly
-        # (job summary) WITHOUT failing the deploy. The underlying Rolldown fold
-        # is known-non-deterministic and the vendor-crypto manualChunk pin does
-        # not yet reliably prevent it (bn.js currently co-bundles into the
-        # date-fns en_US locale chunk). Flip to a hard gate (drop
-        # continue-on-error) once the chunking fix lands. See #9150.
-        continue-on-error: true
         run: bun run verify:chunk-safety
 
       - name: Resolve Pages branch

--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
-// Build-time gate against the recurring Rolldown crypto-chunk crash
+// Build-time gate against the recurring crypto-chunk crash
 // ("Class constructor u cannot be invoked without 'new'" at Buffer.allocUnsafe).
 //
-// History: the apex (elizacloud.ai) moved from packages/cloud-frontend to
-// packages/app (#9093). cloud-frontend shipped this gate + a `vendor-crypto`
-// chunk group; the cutover dropped both, leaving packages/app — which ships the
-// same wallet/crypto/bn.js graph — with no protection (#9150). This restores it.
+// Root cause (see resolveManualChunk in vite.config.ts): when the bn.js/crypto
+// graph is not pinned to its own chunk, Rollup folds it into an EAGERLY-
+// initialized chunk (the date-fns `en_US` i18n locale chunk, or the entry).
+// bn.js runs `Buffer.allocUnsafe` at module-init, which throws before the
+// bundled Buffer wrapper is ready and kills the whole React tree on every
+// route. The #9150 instance of this was a placement bug: the `manualChunks`
+// pin sat under `build.rolldownOptions.output` — a key Vite never reads — so it
+// was silently ignored and NO vendor chunks emitted. The fix moves the pin to
+// `build.rollupOptions.output` (the key Vite + classic Rollup read) and folds
+// the crypto/wallet/solana graph into one lazy `vendor-crypto` chunk.
 //
 // Root cause (see resolveManualChunk's vendor-crypto group in vite.config.ts):
 // Rolldown can non-deterministically fold the bn.js / crypto graph into an
@@ -65,10 +71,11 @@ if (offenders.length > 0) {
   );
   for (const f of offenders) console.error(`  - ${f}`);
   console.error(
-    "\nThis is the Rolldown crypto-chunk crash (Buffer.allocUnsafe at module-init).\n" +
-      "The `vendor-crypto` group in vite.config.ts's resolveManualChunk must keep the\n" +
-      "bn.js graph in a lazy vendor chunk. Do NOT deploy this bundle — it crashes\n" +
-      "the whole React tree on every route. Re-check the resolveManualChunk groups.",
+    "\nThis is the crypto-chunk crash (Buffer.allocUnsafe at module-init).\n" +
+      "The `vendor-crypto` branch in vite.config.ts's resolveManualChunk must keep\n" +
+      "the bn.js graph in a lazy vendor chunk, and that manualChunks fn must stay\n" +
+      "wired under `build.rollupOptions.output` (the key Vite reads). Do NOT deploy\n" +
+      "this bundle — it crashes the whole React tree on every route.",
   );
   process.exit(1);
 }

--- a/packages/app/test/verify-chunk-safety.test.ts
+++ b/packages/app/test/verify-chunk-safety.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The gate script reads `${cwd}/dist/assets/*.js` and exits non-zero when the
+// bn.js crypto marker (`toArrayLike`) lands in a chunk that is NOT one of the
+// lazy `vendor-(crypto|solana|wallet)-` chunks. We exercise it as a subprocess
+// against synthetic `dist/assets` fixtures so the regression guard is itself
+// tested — the #9150 fold (crypto graph folded into the eager date-fns `en_US`
+// locale chunk) MUST fail the gate, and a clean lazy layout MUST pass.
+
+const GATE_SCRIPT = join(
+  import.meta.dirname,
+  "..",
+  "scripts",
+  "verify-chunk-safety.mjs",
+);
+
+const CRYPTO_MARKER = "toArrayLike";
+
+let workDir: string;
+
+function writeChunk(name: string, contents: string): void {
+  writeFileSync(join(workDir, "dist", "assets", name), contents, "utf8");
+}
+
+function runGate(): { status: number; output: string } {
+  try {
+    const stdout = execFileSync("node", [GATE_SCRIPT], {
+      cwd: workDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: e.status ?? 1,
+      output: `${e.stdout ?? ""}${e.stderr ?? ""}`,
+    };
+  }
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "chunk-safety-"));
+  mkdirSync(join(workDir, "dist", "assets"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("verify-chunk-safety gate", () => {
+  it("FAILS when the bn.js crypto graph leaks into an eager locale chunk (#9150)", () => {
+    // Reproduces the real regression: the crypto marker folded into the eager
+    // date-fns `en_US` i18n locale chunk instead of a lazy vendor chunk.
+    writeChunk(
+      "en_US-SK3WV2N3-B4WdXTLq.js",
+      `function bn(){return ${CRYPTO_MARKER}}`,
+    );
+    writeChunk("index-BEExhTUo.js", "export const ok = 1;");
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain("FAIL");
+    expect(output).toContain("en_US-SK3WV2N3-B4WdXTLq.js");
+  });
+
+  it("FAILS when the crypto graph leaks into the eager entry chunk", () => {
+    writeChunk("index-BEExhTUo.js", `function bn(){return ${CRYPTO_MARKER}}`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain("index-BEExhTUo.js");
+  });
+
+  it("PASSES when the crypto graph is confined to a lazy vendor-crypto chunk", () => {
+    writeChunk(
+      "vendor-crypto-DRnRpPYP.js",
+      `function bn(){return ${CRYPTO_MARKER}}`,
+    );
+    writeChunk("en_US-SK3WV2N3-g943u0fV.js", "export const locale = {};");
+    writeChunk("index-D9yqvBmw.js", "export const app = 1;");
+
+    const { status, output } = runGate();
+    expect(status).toBe(0);
+    expect(output).toContain("OK");
+  });
+
+  it("PASSES when the crypto marker is absent entirely", () => {
+    writeChunk("index-D9yqvBmw.js", "export const app = 1;");
+
+    const { status, output } = runGate();
+    expect(status).toBe(0);
+    expect(output).toContain("OK");
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1231,59 +1231,99 @@ function appDevWsBasePlugin(): Plugin {
   };
 }
 
-function pathIncludesAny(id: string, markers: string[]): boolean {
-  return markers.some((marker) => id.includes(marker));
-}
-
 // Crypto / big-number graph (bn.js, elliptic, secp256k1, the hash + cipher
-// libs, and the `buffer` polyfill they call into). MUST be its own lazy chunk:
-// Rolldown's recursive dep-inclusion otherwise non-deterministically folds this
-// graph into an eagerly-initialized chunk (e.g. an i18n locale chunk), where
-// bn.js runs `Buffer.allocUnsafe` at module-init before the chunk's Buffer
-// wrapper is ready — throwing "Class constructor cannot be invoked without
-// 'new'" and killing the whole React tree on every route. `verify-chunk-safety`
-// fails the build if this graph ever leaks into a non-vendor chunk. (Ported
-// from packages/cloud-frontend in the apex→packages/app cutover, #9150.)
-const VENDOR_CRYPTO_RE =
+// libs, and the `buffer` polyfill they call into). Matched FIRST so it wins
+// over the generic vendor groups below. This graph MUST stay in its own
+// lazily-loaded chunk: Rollup's recursive dep-inclusion otherwise
+// non-deterministically folds it into an eagerly-initialized app chunk (e.g.
+// the date-fns `en_US` i18n locale chunk, or the entry), where bn.js runs
+// `Buffer.allocUnsafe` at module-init before the chunk's CJS Buffer wrapper is
+// hoisted — throwing "Class constructor cannot be invoked without 'new'" and
+// blanking the whole React tree on every route. `scripts/verify-chunk-
+// safety.mjs` gates the deploy against any regression of this pin.
+const VENDOR_CRYPTO_TEST =
   /\/node_modules\/(bn\.js|elliptic|secp256k1|@noble\/[^/]+|hash-base|create-hash|create-hmac|create-ecdh|browserify-sign|browserify-aes|browserify-cipher|browserify-rsa|diffie-hellman|asn1\.js|des\.js|ripemd160|sha\.js|md5\.js|hash\.js|cipher-base|evp_bytestokey|pbkdf2|public-encrypt|randombytes|randomfill|miller-rabin|brorand|hmac-drbg|minimalistic-crypto-utils|minimalistic-assert|safe-buffer|buffer)(\/|$)/;
-const VENDOR_WALLET_RE =
-  /\/node_modules\/(wagmi|@wagmi|viem|@rainbow-me|@walletconnect|@reown|@coinbase\/wallet-sdk|mipd|eventemitter3)(\/|$)/;
-const VENDOR_SOLANA_RE = /\/node_modules\/@solana\//;
 
+// EVM wallet stack (wagmi/viem/RainbowKit/WalletConnect/Reown/Coinbase). Folded
+// into `vendor-crypto` alongside the crypto core (see resolveManualChunk): the
+// wallet stack imports the bn.js/buffer graph, so a separate chunk would cross-
+// import the crypto chunk and form an init-order cycle (the wagmi 3.x `connect`
+// / `ConnectorUnavailableReconnectingError` TDZ crash).
+const VENDOR_WALLET_TEST =
+  /\/node_modules\/(wagmi|@wagmi\/|viem\/|@rainbow-me\/|@walletconnect\/|@reown\/|@coinbase\/wallet|mipd|eventemitter3)(\/|$)/;
+
+// Solana wallet/web3 stack — also folded into `vendor-crypto` (it imports the
+// same bn.js/buffer core).
+const VENDOR_SOLANA_TEST = /\/node_modules\/@solana\//;
+
+// React runtime + scheduler + react-spring.
+const VENDOR_REACT_TEST =
+  /\/node_modules\/(react|react-dom|react-is|scheduler|@react-spring)(\/|$)/;
+
+// three.js (three.module, three.webgpu, three.tsl, three.core, three/examples,
+// three/addons) + @pixiv/three-vrm collapsed into one shared async chunk to
+// avoid cross-chunk TDZ init ordering bugs with WebGPU/TSL enums (see
+// fix/three-chunk-tdz) and to keep three out of the eager entry chunk.
+const VENDOR_VRM_TEST = /\/node_modules\/@pixiv\/three-vrm\//;
+const VENDOR_THREE_TEST = /\/node_modules\/three\//;
+const VENDOR_DRACO_TEST = /\/node_modules\/draco3d(gltf)?\//;
+
+/**
+ * Rollup `output.manualChunks`. `@elizaos/vitest-vite` builds with classic
+ * Rollup (`rollup@^4`), whose only manual-chunking API is this function form —
+ * NOT rolldown's `advancedChunks` / `codeSplitting` (Rollup ignores those keys).
+ * Crucially, this must live under `build.rollupOptions.output` — the only
+ * bundle-options key Vite reads; the prior `build.rolldownOptions.output`
+ * placement was silently ignored by Vite, so NO `vendor-*` chunks emitted and
+ * the bn.js graph folded into the eager `en_US` locale chunk (#9150). The
+ * crypto/wallet/solana graph is matched first and collapsed into one lazy
+ * `vendor-crypto` chunk so it can never co-bundle with an eager chunk.
+ */
 function resolveManualChunk(id: string): string | undefined {
   const normalizedId = id.split(path.sep).join("/");
 
-  // Highest priority: keep the wallet/crypto/solana graph in dedicated LAZY
-  // vendor chunks so the bn.js Buffer.allocUnsafe-at-init crash can never reach
-  // an eager chunk (#9150). Order matters — crypto before wallet/solana.
-  if (VENDOR_CRYPTO_RE.test(normalizedId)) return "vendor-crypto";
-  if (VENDOR_WALLET_RE.test(normalizedId)) return "vendor-wallet";
-  if (VENDOR_SOLANA_RE.test(normalizedId)) return "vendor-solana";
+  if (normalizedId.includes("/node_modules/")) {
+    // Crypto + EVM-wallet + Solana collapse into ONE lazy `vendor-crypto`
+    // chunk. They are the same logical wallet/crypto graph (the wallet and
+    // solana stacks both import the bn.js/buffer core), so splitting them into
+    // sibling chunks makes Rollup emit cross-chunk import cycles
+    // (vendor-crypto -> vendor-solana -> vendor-crypto), and a cross-chunk
+    // cycle is exactly the TDZ / module-init-order hazard this pin exists to
+    // prevent. Co-bundling keeps the whole graph (and its Buffer polyfill) in a
+    // single chunk that initializes atomically, lazily, off the eager entry.
+    if (
+      VENDOR_CRYPTO_TEST.test(normalizedId) ||
+      VENDOR_WALLET_TEST.test(normalizedId) ||
+      VENDOR_SOLANA_TEST.test(normalizedId)
+    ) {
+      return "vendor-crypto";
+    }
+  }
 
   // The lucide-per-icon-imports plugin rewrites every `import { X } from
   // "lucide-react"` to a deep `lucide-react/dist/esm/icons/<file>.mjs` import,
   // and redirects the runtime registry's dynamic `import("lucide-react")` to a
   // virtual barrel that re-exports only the used icons. Each icon module is its
-  // own ES module, so without a grouping rule Rolldown emits one tiny chunk per
+  // own ES module, so without a grouping rule Rollup emits one tiny chunk per
   // icon. Collapse the used icons + their shared `createLucideIcon` helper + the
   // virtual barrel's re-export entry into a single chunk; the full barrel is
   // never imported, so the unused icons never enter the graph.
   if (
     normalizedId.includes("/lucide-react/dist/esm/icons/") ||
     normalizedId.includes("/lucide-react/dist/esm/createLucideIcon.mjs") ||
-    normalizedId.includes(LUCIDE_USED_BARREL_ID)
+    normalizedId.includes(LUCIDE_USED_BARREL_ID) ||
+    normalizedId.includes("/lucide-react/")
   ) {
     return "vendor-lucide";
   }
 
   // Phonemizer (eSpeak NG WASM, ~1.3MB) is dynamically imported through the
   // kokoro `phonemizer.ts` adapter (packages/shared/.../kokoro/phonemizer.ts).
-  // Because that adapter is the dynamic-import boundary, Rolldown otherwise emits
+  // Because that adapter is the dynamic-import boundary, Rollup otherwise emits
   // a second async chunk auto-named "phonemizer" and inlines its own copy of the
   // npm package — shipping eSpeak NG twice (a "phonemizer" chunk *and* a
   // "vendor-phonemizer" chunk). Routing BOTH the npm package and the adapter
   // source to one chunk collapses them into a single ~650KB (brotli) chunk.
-  // Kept outside the /node_modules/ gate below so the adapter source matches too.
   if (
     normalizedId.includes("/phonemizer/") ||
     normalizedId.includes("/kokoro/phonemizer")
@@ -1292,36 +1332,10 @@ function resolveManualChunk(id: string): string | undefined {
   }
 
   if (normalizedId.includes("/node_modules/")) {
-    if (
-      pathIncludesAny(normalizedId, [
-        "/@react-spring/",
-        "/react-dom/",
-        "/react-is/",
-        "/scheduler/",
-        "/react/",
-      ])
-    ) {
-      return "vendor-react";
-    }
-
-    if (normalizedId.includes("/@pixiv/three-vrm/")) {
-      return "vendor-vrm";
-    }
-
-    // Collapse all three.js code (three.module, three.webgpu, three.tsl,
-    // three.core, three/examples, three/addons) into one shared async chunk to
-    // avoid cross-chunk TDZ init ordering bugs with WebGPU/TSL enums (see
-    // fix/three-chunk-tdz) and to keep three out of the eager entry chunk.
-    if (normalizedId.includes("/three/")) {
-      return "vendor-three";
-    }
-
-    if (pathIncludesAny(normalizedId, ["/draco3d/", "/draco3dgltf/"])) {
-      return "vendor-draco";
-    }
-    if (normalizedId.includes("/lucide-react/")) {
-      return "vendor-lucide";
-    }
+    if (VENDOR_REACT_TEST.test(normalizedId)) return "vendor-react";
+    if (VENDOR_VRM_TEST.test(normalizedId)) return "vendor-vrm";
+    if (VENDOR_THREE_TEST.test(normalizedId)) return "vendor-three";
+    if (VENDOR_DRACO_TEST.test(normalizedId)) return "vendor-draco";
   }
 
   return undefined;
@@ -2974,17 +2988,24 @@ export const INVALID_TRACER_PROVIDER = {};
       input: {
         main: path.resolve(here, "index.html"),
       },
+    },
+    // rollupOptions is the ONLY bundle-options key Vite reads. The sibling
+    // `rolldownOptions` block above is NOT a Vite option — Vite ignores it
+    // entirely (`@elizaos/vitest-vite` builds with classic Rollup, which has no
+    // `rolldownOptions`) — so the chunk-splitting + otel fallback that must
+    // reach the bundler both live here, under rollupOptions.output /
+    // rollupOptions.plugins.
+    rollupOptions: {
       output: {
+        // Manual chunk-splitting. `@elizaos/vitest-vite` builds with classic
+        // Rollup, whose only chunking API is `output.manualChunks`. This lives
+        // under `rollupOptions.output` — the only bundle-options key Vite reads;
+        // the previous `rolldownOptions.output.manualChunks` placement was
+        // silently ignored, so the bn.js/crypto graph folded into the eager
+        // date-fns `en_US` locale chunk (the #9150 Buffer.allocUnsafe module-
+        // init crash). `scripts/verify-chunk-safety.mjs` gates the regression.
         manualChunks: resolveManualChunk,
       },
-    },
-    // rollupOptions mirrors the otel fallback from rolldownOptions above.
-    // Vite reads rolldownOptions only when using experimental Rolldown; when
-    // running with the classic Rollup bundler (@rollup/wasm-node, as in CI),
-    // rolldownOptions is silently ignored and the otel-api-build-* plugin
-    // never runs. The rollupOptions block below is the standard path and is
-    // always applied by Vite + Rollup.
-    rollupOptions: {
       plugins: [
         ...(otelApiEntry
           ? [


### PR DESCRIPTION
Closes #9150.

## Problem

The apex deploy lost the `verify-chunk-safety` gate after the cloud-frontend → `packages/app` cutover. The prior restore (on develop) wired the gate **non-blocking** (`continue-on-error: true`) because a *real* `build:web` still folded the entire bn.js/crypto graph into the **eager date-fns `en_US` locale chunk** — the `Buffer.allocUnsafe` module-init crash (`Class constructor cannot be invoked without 'new'`) that blanks every route.

## Root cause

The `manualChunks` pin sat under `build.rolldownOptions.output` — **a key Vite never reads**. `@elizaos/vitest-vite` builds with classic Rollup (`rollup@^4`); `rolldownOptions` is silently ignored, so **no `vendor-*` chunks emitted at all** and the crypto graph was free to fold into an eager chunk. (The cloud-frontend gate worked because it ran on `vite@8` which *does* read `rolldownOptions`.)

## Fix

- Move the `manualChunks` function to **`build.rollupOptions.output`** (the only bundle-options key Vite reads) so it actually runs.
- **Collapse crypto + EVM-wallet + Solana into ONE lazy `vendor-crypto` chunk.** Splitting them into siblings made Rollup emit a cross-chunk init cycle (`vendor-crypto -> vendor-solana -> vendor-crypto`) — the exact TDZ hazard this pin exists to prevent. Co-bundling keeps the whole graph + its Buffer polyfill initializing atomically and lazily, off the eager entry.
- **Flip both apex deploy jobs** (`deploy-console` + `deploy-app`) to a **hard gate** (drop `continue-on-error`) now that a clean build passes.
- **Add `packages/app/test/verify-chunk-safety.test.ts`** proving the gate **catches** an eager crypto chunk (en_US locale fold + entry leak) and **passes** a clean lazy-vendor layout.

## Verification (real build, no secrets needed)

```
bun run --cwd packages/app build:web:verify
✓ built in 54.38s   (no "Circular chunk" warning)
[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (427 chunks scanned).
```

- **Before:** gate FAILed — bn.js marker `toArrayLike` in `en_US-…js` (823 KB).
- **After:** `en_US` drops to 264 KB; the marker lives only in `vendor-crypto-…js`.
- `packages/app` typecheck ✅ · biome ✅ · 4/4 new gate tests pass ✅.
- The two pre-existing `view-interaction-coverage` / `hmr-coverage` ledger-count failures reproduce on pristine `origin/develop` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)