### PR TITLE
fix(computeruse): key_down/key_up must accept bare modifier keys (shift/ctrl/alt/cmd) (#9170)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/nut-driver-input.test.ts
@@ -11,12 +11,25 @@
  * would mis-place clicks. See #9105.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   clampScrollNotches,
   densifyDragPath,
   interpolateDragSteps,
 } from "../platform/nut-driver.js";
+
+const nutDriverSrc = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "platform",
+    "nut-driver.ts",
+  ),
+  "utf8",
+);
 
 describe("clampScrollNotches", () => {
   it("clamps to the 1..20 notch range and rounds", () => {
@@ -81,5 +94,29 @@ describe("densifyDragPath (M8 multi-point drag)", () => {
 
   it("handles a degenerate single-point path", () => {
     expect(densifyDragPath([{ x: 7, y: 9 }])).toEqual([{ x: 7, y: 9 }]);
+  });
+});
+
+describe("resolveKeyCode modifier support (M8 key_down/key_up regression)", () => {
+  // key_down("shift") / key_up("shift") are the primary use of the press-hold
+  // key primitives, but `resolveKeyCode` originally only mapped function keys,
+  // named keys, and single chars — so a bare modifier threw "Unsupported key".
+  // It now must consult MODIFIER_KEYS so holding shift/ctrl/alt/cmd works.
+  // (Verified live on Windows: driverKeyDown("shift") no longer throws.) The
+  // resolver loads the native nut module, so this is a static source guard that
+  // runs on every OS in the default lane — same convention as
+  // windows-powershell-safety.test.ts.
+  it("resolveKeyCode falls back to MODIFIER_KEYS for bare modifiers", () => {
+    const start = nutDriverSrc.indexOf("function resolveKeyCode(");
+    expect(start, "resolveKeyCode not found").toBeGreaterThan(-1);
+    const body = nutDriverSrc.slice(start, start + 1200);
+    expect(body).toContain("MODIFIER_KEYS[");
+  });
+
+  it("MODIFIER_KEYS maps shift/ctrl/alt/cmd to nutjs Key names", () => {
+    expect(nutDriverSrc).toContain('shift: ["LeftShift"]');
+    expect(nutDriverSrc).toContain('ctrl: ["LeftControl"]');
+    expect(nutDriverSrc).toContain('alt: ["LeftAlt"]');
+    expect(nutDriverSrc).toContain('cmd: ["LeftSuper"]');
   });
 });

--- a/plugins/plugin-computeruse/src/platform/nut-driver.ts
+++ b/plugins/plugin-computeruse/src/platform/nut-driver.ts
@@ -152,6 +152,14 @@ function resolveKeyCode(key: string): number {
     const code = m.Key[mapped];
     if (code !== undefined) return code;
   }
+  // Modifier names (shift / ctrl / alt / cmd / meta / super / win) — needed so
+  // key_down/key_up can hold a bare modifier. These live in MODIFIER_KEYS as
+  // nutjs Key names (e.g. "LeftShift"); resolve to the left-hand variant.
+  const modifierNames = MODIFIER_KEYS[canonical] ?? MODIFIER_KEYS[key.trim().toLowerCase()];
+  if (modifierNames && modifierNames.length > 0) {
+    const code = m.Key[modifierNames[0]];
+    if (code !== undefined) return code;
+  }
   // Single character — map A-Z / 0-9 directly via Key enum
   if (key.length === 1) {
     const upper = key.toUpperCase();


### PR DESCRIPTION
## Summary

M8 (develop `ca204a2027`, "verb-parity pack") added the `key_down` / `key_up`
press-hold primitives, but **holding a bare modifier throws on every platform**:

```
Unsupported key for nutjs driver: "shift"
```

`resolveKeyCode` only mapped function keys, named keys (enter/tab/…), and single
characters. A modifier name fell through to `m.Key["shift"]` (undefined) → throw.
Holding a modifier (shift/ctrl/alt/cmd) is the *primary* use of these verbs.

### Why it slipped through

M8's own real-driver test calls `driverKeyDown("shift")` / `driverKeyUp("shift")`
— but `cua-parity-input.real.test.ts` is gated to `platform() === "win32"` and so
runs **only on a Windows host / Windows CI**. It was never executed pre-merge, so
the failing call shipped; it would turn the Windows lane red. Found by running the
M8 verbs against the **live Windows backend**.

## Fix

`resolveKeyCode` now consults the existing `MODIFIER_KEYS` map (the same source
the key-combo path already uses) and resolves a bare modifier to its left-hand
nutjs `Key`: `shift→LeftShift`, `ctrl→LeftControl`, `alt→LeftAlt`,
`cmd/meta/super/win→LeftSuper`. One self-contained branch in one function; no new
imports, no signature changes.

## Evidence (live Windows, nutjs driver)

Real input dispatched on the desktop, exercising **all** M8 verbs.

Before:
```
mouse_down/up press-hold → {"x":720,"y":560} OK
middle_click            → {"x":380,"y":360} OK
drag path               → {"x":760,"y":600} OK
key_down/up threw: Unsupported key for nutjs driver: "shift"   ← BUG
DEVELOP_M8_FAIL
```

After:
```
mouse_down/up press-hold → {"x":720,"y":560} OK
middle_click            → {"x":380,"y":360} OK
drag path               → {"x":760,"y":600} OK
key_down/up press-hold  → OK
DEVELOP_M8_OK
```

- `bun run typecheck` → **0 errors** (tsgo).
- `nut-driver-input.test.ts` → **9/9 pass**, incl. a new cross-platform static
  regression guard asserting `resolveKeyCode` consults `MODIFIER_KEYS` and the
  modifier→Key mappings exist (runs in the default lane on every OS; the live
  round-trip stays the Windows real lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)