### PR TITLE
refactor: remove cross-layer LifeOps app-shell tokens (page-lifeops scope, event sources, connector id) (#8833)

### DIFF
--- a/packages/agent/src/api/conversation-metadata.ts
+++ b/packages/agent/src/api/conversation-metadata.ts
@@ -23,7 +23,6 @@ const VALID_SCOPES = new Set<ConversationScope>([
   "page-connectors",
   "page-phone",
   "page-plugins",
-  "page-lifeops",
   "page-settings",
   "page-wallet",
   "page-browser",

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -78,8 +78,8 @@ interface TaskCompletionSummary {
 // ---------------------------------------------------------------------------
 
 const CHAT_SUPPRESSED_AUTONOMY_SOURCES = new Set([
-  "lifeops-reminder",
-  "lifeops-workflow",
+  "reminder",
+  "workflow",
   "proactive-gm",
   "proactive-gn",
   "proactive-nudge",

--- a/packages/agent/src/api/suggestions-routes.test.ts
+++ b/packages/agent/src/api/suggestions-routes.test.ts
@@ -84,10 +84,10 @@ describe("parseRequestBody", () => {
 
   it("keeps a well-formed page scope and rejects junk", () => {
     expect(
-      parseRequestBody(JSON.stringify({ scope: "page-lifeops" })).scope,
-    ).toBe("page-lifeops");
+      parseRequestBody(JSON.stringify({ scope: "page-wallet" })).scope,
+    ).toBe("page-wallet");
     expect(
-      parseRequestBody(JSON.stringify({ scope: "lifeops" })).scope,
+      parseRequestBody(JSON.stringify({ scope: "wallet" })).scope,
     ).toBeUndefined(); // missing page- prefix
     expect(
       parseRequestBody(JSON.stringify({ scope: "page-<script>" })).scope,
@@ -116,7 +116,7 @@ describe("computeHeuristicSuggestions", () => {
     const out = computeHeuristicSuggestions({
       messages: [{ role: "user", content: "hey" }],
       hour: 9,
-      scope: "page-lifeops",
+      scope: "page-wallet",
     });
     expect(out[0]).toBe("Continue where we left off");
     expect(out).toHaveLength(3);
@@ -135,17 +135,18 @@ describe("computeHeuristicSuggestions", () => {
     ]);
   });
 
-  it("dedupes a lead that collides with a scope starter", () => {
-    // Morning lead "Plan my day" === page-lifeops starter "Plan my day".
+  it("dedupes a scope starter that collides with a general starter", () => {
+    // page-character starter "What can you do?" === GENERAL_STARTERS[0]
+    // "What can you do?" — the collision must not leave a duplicate.
     const out = computeHeuristicSuggestions({
       messages: [],
       hour: 9,
-      scope: "page-lifeops",
+      scope: "page-character",
     });
     expect(out).toEqual([
       "Plan my day",
-      "What's on my plate?",
-      "Review my reminders",
+      "Tune your personality",
+      "Change your voice",
     ]);
     expect(new Set(out).size).toBe(3);
   });

--- a/packages/agent/src/api/suggestions-routes.ts
+++ b/packages/agent/src/api/suggestions-routes.ts
@@ -3,7 +3,7 @@
  * the continuous-chat overlay's resting composer strip (#8225).
  *
  * The client sends recent conversation context, the local hour, and the
- * active page scope ("page-lifeops", "page-browser", …). Two tiers:
+ * active page scope ("page-wallet", "page-browser", …). Two tiers:
  *
  * - `model`     — the small text model writes EXACTLY 3 short, first-person
  *                 prompts tailored to the character, the conversation, and
@@ -138,7 +138,6 @@ const SCOPE_STARTERS: Record<string, readonly string[]> = {
     "Suggest a plugin",
     "Configure a plugin",
   ],
-  "page-lifeops": ["Plan my day", "What's on my plate?", "Review my reminders"],
   "page-settings": [
     "Review my settings",
     "Switch my model",
@@ -213,7 +212,7 @@ function buildPrompt(
         .join("\n")
     : "No conversation yet.";
 
-  // "page-lifeops" → "lifeops" — a human-readable view name for the prompt.
+  // "page-wallet" → "wallet" — a human-readable view name for the prompt.
   const viewName = request.scope?.replace(/^page-/, "");
 
   return [

--- a/packages/agent/src/providers/page-scoped-context.ts
+++ b/packages/agent/src/providers/page-scoped-context.ts
@@ -8,9 +8,6 @@ import type {
 import { logger, stringToUuid } from "@elizaos/core";
 import type {
   AppRunSummary,
-  LifeOpsCapabilitiesStatus,
-  LifeOpsInbox,
-  LifeOpsOverview,
   RegistryAppInfo,
   WalletBalancesResponse,
   WalletConfigStatus,
@@ -49,8 +46,6 @@ const PAGE_SCOPE_BRIEF: Record<string, string> = {
     "The user is in the Android Phone view. They can place calls through Android Telecom, open the dialer, send SMS through Android SMS, review recent calls, browse contacts, import vCards, and save call transcripts or summaries. Action vocabulary may include MESSAGE with operation=send/read_channel/search, VOICE_CALL, ADD_CONTACT, UPDATE_CONTACT, GET_CONTACT, and SEARCH_CONTACTS when the relevant plugins are enabled. Confirm the target number/contact and message content before calls or SMS. Ground discussion in visible phone state when present and never invent call logs, contacts, message bodies, transcripts, or delivery results.",
   "page-plugins":
     "The user is in the Plugins view. They can inspect installed plugins, registry plugins, configuration readiness, plugin health, and runtime capability gaps. Action vocabulary: PLUGIN with modes install, eject, sync, reinject, list, search, core_status, or create. When the user asks what to do, recommend the smallest plugin setup or troubleshooting action that fits the visible state. Never invent installed plugins, credentials, or enabled capabilities.",
-  "page-lifeops":
-    "The user is in the LifeOps view. They can inspect the overview, goals, reminders, calendar, messages, mail, sleep, screen time, social context, connector setup, capability readiness, and LifeOps settings. The LifeOps app provider and actions are the authoritative execution path for creating or changing personal workflows, reminders, goals, schedules, inbox drafts, connector setup, and executive-assistant follow-through. When the user asks what to do, recommend capability readiness and overview review first, then suggest the smallest concrete LifeOps action. Reference only live LifeOps state below; never invent reminders, messages, calendar events, goals, or connector status.",
   "page-settings":
     "The user is in the Settings view. They can tune models, providers, permissions, connectors, wallet RPC, cloud account state, appearance, updates, and feature toggles. Action vocabulary: UPDATE_IDENTITY, UPDATE_AI_PROVIDER, TOGGLE_CAPABILITY, and TOGGLE_AUTO_TRAINING. When the user asks what to do, recommend the smallest concrete settings change that fits the visible section. Ask before changes that affect security, spending, or external accounts. Never invent provider status, account state, or permission grants.",
   "page-wallet":
@@ -336,107 +331,6 @@ async function renderAppsLiveState(): Promise<string | null> {
   return lines.join("\n");
 }
 
-function formatLifeOpsOverviewSection(
-  label: string,
-  overview: LifeOpsOverview["owner"],
-): string {
-  return `${label}: ${overview.summary.activeOccurrenceCount} active item${overview.summary.activeOccurrenceCount === 1 ? "" : "s"}, ${overview.summary.activeReminderCount} reminder${overview.summary.activeReminderCount === 1 ? "" : "s"}, ${overview.summary.activeGoalCount} goal${overview.summary.activeGoalCount === 1 ? "" : "s"}.`;
-}
-
-async function renderLifeOpsLiveState(): Promise<string | null> {
-  const [overview, capabilities, inbox] = await Promise.all([
-    fetchLocalJson<LifeOpsOverview>("/api/lifeops/overview"),
-    fetchLocalJson<LifeOpsCapabilitiesStatus>("/api/lifeops/capabilities"),
-    fetchLocalJson<LifeOpsInbox>("/api/lifeops/inbox?limit=8"),
-  ]);
-
-  if (!overview && !capabilities && !inbox) {
-    return "Live LifeOps state: unavailable from the LifeOps API.";
-  }
-
-  const lines: string[] = ["Live LifeOps state:"];
-
-  if (capabilities) {
-    lines.push(`- App enabled: ${capabilities.appEnabled ? "yes" : "no"}.`);
-    lines.push(
-      `- Capabilities: ${capabilities.summary.workingCount} working, ${capabilities.summary.degradedCount} degraded, ${capabilities.summary.blockedCount} blocked, ${capabilities.summary.notConfiguredCount} not configured.`,
-    );
-    const attention = capabilities.capabilities.filter(
-      (capability) =>
-        capability.state === "blocked" ||
-        capability.state === "degraded" ||
-        capability.state === "not_configured",
-    );
-    for (const capability of attention.slice(0, 5)) {
-      lines.push(
-        `  - ${capability.label}: ${capability.state} — ${capability.summary}`,
-      );
-    }
-  }
-
-  if (overview) {
-    lines.push(
-      `- Overview: ${overview.summary.activeOccurrenceCount} active item${overview.summary.activeOccurrenceCount === 1 ? "" : "s"}, ${overview.summary.overdueOccurrenceCount} overdue, ${overview.summary.activeReminderCount} active reminder${overview.summary.activeReminderCount === 1 ? "" : "s"}, ${overview.summary.activeGoalCount} active goal${overview.summary.activeGoalCount === 1 ? "" : "s"}.`,
-    );
-    lines.push(`- ${formatLifeOpsOverviewSection("Owner", overview.owner)}`);
-    lines.push(
-      `- ${formatLifeOpsOverviewSection("Agent ops", overview.agentOps)}`,
-    );
-    if (overview.schedule) {
-      const relative = overview.schedule.relativeTime;
-      const wake =
-        relative.minutesSinceWake !== null
-          ? `${Math.round(relative.minutesSinceWake)}m since wake`
-          : "wake time unknown";
-      const bedtime =
-        relative.minutesUntilBedtimeTarget !== null
-          ? `${Math.round(relative.minutesUntilBedtimeTarget)}m until bedtime target`
-          : "bedtime target unknown";
-      lines.push(
-        `- Schedule: ${overview.schedule.circadianState} (${Math.round(overview.schedule.stateConfidence * 100)}% confidence), ${overview.schedule.sleepStatus}; ${wake}; ${bedtime}.`,
-      );
-    }
-    const activeReminders = [
-      ...overview.owner.reminders,
-      ...overview.agentOps.reminders,
-    ];
-    if (activeReminders.length > 0) {
-      lines.push("Active reminders:");
-      for (const reminder of activeReminders.slice(0, 5)) {
-        lines.push(
-          `- ${reminder.title} (${reminder.channel}, ${reminder.state}) scheduled ${reminder.scheduledFor}`,
-        );
-      }
-    }
-    const activeGoals = [...overview.owner.goals, ...overview.agentOps.goals];
-    if (activeGoals.length > 0) {
-      lines.push("Active goals:");
-      for (const goal of activeGoals.slice(0, 5)) {
-        lines.push(`- ${goal.title} (${goal.status})`);
-      }
-    }
-  }
-
-  if (inbox) {
-    const unreadCount = Object.values(inbox.channelCounts).reduce(
-      (sum, count) => sum + count.unread,
-      0,
-    );
-    lines.push(
-      `- Inbox: ${inbox.messages.length} recent message${inbox.messages.length === 1 ? "" : "s"}, ${unreadCount} unread.`,
-    );
-    for (const message of inbox.messages.slice(0, 5)) {
-      const subject = message.subject ? `${message.subject}: ` : "";
-      const unread = message.unread ? " unread" : "";
-      lines.push(
-        `  - ${message.channel}${unread} from ${message.sender.displayName}: ${subject}${message.snippet.slice(0, 120)}`,
-      );
-    }
-  }
-
-  return lines.join("\n");
-}
-
 function shortAddress(address: string | null | undefined): string {
   if (!address) return "(not configured)";
   if (address.length <= 14) return address;
@@ -667,8 +561,6 @@ async function renderLiveStateForScope(
       return renderAutomationsLiveState(runtime);
     case "page-apps":
       return renderAppsLiveState();
-    case "page-lifeops":
-      return renderLifeOpsLiveState();
     case "page-connectors":
     case "page-plugins":
     case "page-settings":
@@ -691,7 +583,7 @@ function formatSourceTail(entries: SourceTailEntry[]): string {
 export const pageScopedContextProvider: Provider = {
   name: "page-scoped-context",
   description:
-    "Operational context for the current page-scoped chat (Browser, Character, Apps, Connectors, Plugins, Settings, LifeOps, Automations, Wallet).",
+    "Operational context for the current page-scoped chat (Browser, Character, Apps, Connectors, Plugins, Settings, Automations, Wallet).",
   dynamic: false,
   position: 5,
   contexts: [

--- a/packages/shared/src/contracts/__tests__/schema-vs-type-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/schema-vs-type-drift.test.ts
@@ -37,7 +37,6 @@ const VALID_CONVERSATION_SCOPES = new Set([
   "page-connectors",
   "page-phone",
   "page-plugins",
-  "page-lifeops",
   "page-settings",
   "page-wallet",
   "page-browser",

--- a/packages/shared/src/contracts/conversation-routes.ts
+++ b/packages/shared/src/contracts/conversation-routes.ts
@@ -40,7 +40,6 @@ export const ConversationScopeSchema = z.enum([
   "page-connectors",
   "page-phone",
   "page-plugins",
-  "page-lifeops",
   "page-settings",
   "page-wallet",
   "page-browser",

--- a/packages/ui/src/components/pages/page-scoped-conversations.ts
+++ b/packages/ui/src/components/pages/page-scoped-conversations.ts
@@ -12,7 +12,6 @@ export type PageScope =
   | "page-connectors"
   | "page-phone"
   | "page-plugins"
-  | "page-lifeops"
   | "page-settings"
   | "page-wallet";
 
@@ -24,7 +23,6 @@ export const PAGE_SCOPES: readonly PageScope[] = [
   "page-connectors",
   "page-phone",
   "page-plugins",
-  "page-lifeops",
   "page-settings",
   "page-wallet",
 ] as const;
@@ -72,10 +70,6 @@ const PAGE_SCOPE_ROUTING_CONTEXTS: Record<
     primaryContext: "plugins",
     secondaryContexts: ["page", "page-plugins", "plugins", "admin"],
   },
-  "page-lifeops": {
-    primaryContext: "automation",
-    secondaryContexts: ["page", "page-lifeops", "automation", "social_posting"],
-  },
   "page-settings": {
     primaryContext: "settings",
     secondaryContexts: ["page", "page-settings", "settings", "admin"],
@@ -92,7 +86,7 @@ const PAGE_SCOPE_ROUTING_CONTEXTS: Record<
  * single prompt-regime cohort instead of mixing trajectories generated under
  * different surface contracts.
  */
-export const PAGE_SCOPE_VERSION = 14;
+export const PAGE_SCOPE_VERSION = 15;
 
 export interface PageScopeIntroCopy {
   /** Short user-facing intro card title shown when the conversation is empty. */
@@ -150,12 +144,6 @@ export const PAGE_SCOPE_COPY: Record<PageScope, PageScopeIntroCopy> = {
     systemAddendum:
       "You are answering inside the Plugins view. The user can inspect installed plugins, registry plugins, configuration readiness, plugin health, and runtime capability gaps. Recommend the smallest plugin setup or troubleshooting action that fits the user's goal, reference visible plugin state when present, and never invent installed plugins, credentials, or enabled capabilities.",
   },
-  "page-lifeops": {
-    title: "LifeOps chat",
-    body: "Ask me about the visible LifeOps item or the next action you want handled.",
-    systemAddendum:
-      "You are answering inside the LifeOps view. The user can inspect the current overview, goals, reminders, calendar, messages, mail, sleep, screen time, social context, connector setup, capability readiness, and LifeOps settings. Recommend capability readiness and overview review before creating or changing durable personal workflows. When the user asks for concrete LifeOps work, route through the LifeOps app actions/providers already available in the runtime instead of generic advice. Reference live LifeOps state when present, and never invent reminders, goals, messages, calendar events, or connector state.",
-  },
   "page-settings": {
     title: "Settings chat",
     body: "Use me to tune models, providers, permissions, connectors, wallet RPC, cloud account state, appearance, updates, and feature toggles. Recommended: describe the capability you want to enable or troubleshoot, and I'll point to the right section or explain the tradeoffs.",
@@ -178,7 +166,6 @@ export const PAGE_SCOPE_DEFAULT_TITLE: Record<PageScope, string> = {
   "page-connectors": "Connectors",
   "page-phone": "Phone",
   "page-plugins": "Plugins",
-  "page-lifeops": "LifeOps",
   "page-settings": "Settings",
   "page-wallet": "Wallet",
 };

--- a/packages/ui/src/components/shell/usePromptSuggestions.test.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.test.ts
@@ -161,13 +161,13 @@ describe("usePromptSuggestions (model-backed)", () => {
   it("sends the active page scope so the server can tailor per view (#8225)", async () => {
     fetchMock.mockResolvedValue({ suggestions: ["A", "B", "C"] });
     renderHook(() =>
-      usePromptSuggestions([], { enabled: true, scope: "page-lifeops" }),
+      usePromptSuggestions([], { enabled: true, scope: "page-wallet" }),
     );
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     const body = JSON.parse(
       (fetchMock.mock.calls[0][1] as { body: string }).body,
     );
-    expect(body.scope).toBe("page-lifeops");
+    expect(body.scope).toBe("page-wallet");
   });
 
   it("does not surface or remember heuristic-tier responses (retries on a later reveal)", async () => {
@@ -272,13 +272,13 @@ describe("daypartForHour", () => {
 
 describe("pageScopeFromLocation", () => {
   it("derives the scope from a path segment", () => {
-    expect(pageScopeFromLocation("/lifeops", "")).toBe("page-lifeops");
+    expect(pageScopeFromLocation("/browser", "")).toBe("page-browser");
     expect(pageScopeFromLocation("/wallet/send", "")).toBe("page-wallet");
   });
 
   it("prefers the hash segment when present (hash navigation)", () => {
     expect(pageScopeFromLocation("/", "#/settings?x=1")).toBe("page-settings");
-    expect(pageScopeFromLocation("/lifeops", "#/apps")).toBe("page-apps");
+    expect(pageScopeFromLocation("/browser", "#/apps")).toBe("page-apps");
   });
 
   it("returns undefined for unscoped or empty views", () => {

--- a/packages/ui/src/hooks/useActivityEvents.ts
+++ b/packages/ui/src/hooks/useActivityEvents.ts
@@ -48,9 +48,9 @@ function summarizeAssistantActivityEvent(data: Record<string, unknown>): {
   }
 
   switch (source) {
-    case "lifeops-reminder":
+    case "reminder":
       return { eventType: "reminder", summary: text };
-    case "lifeops-workflow":
+    case "workflow":
       return { eventType: "workflow", summary: text };
     case "proactive-gm":
     case "proactive-gn":

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -2012,24 +2012,20 @@ function formatWeeklyGoalReview(args: {
 
 // ── Main action ───────────────────────────────────────
 
-// Owner-operation actions belong to the LifeOps surface (home chat /
-// page-lifeops / app-lifeops direct rooms). On foreign page-* scopes the action set is
-// scoped to that surface (page-automations → WORKFLOW,
-// page-browser → browser actions, etc.). When owner-operation actions stay
-// eligible on those scopes, their long descriptions contaminate the
-// ACTION_PLANNER candidate list, driving the LLM to mimic the
-// life-param-extractor structured schema and producing envelopes the planner
-// cannot read.
+// Owner-operation actions belong to the home chat (the non-page-scoped
+// assistant surface). On any page-* scope the action set is scoped to that
+// surface (page-automations → WORKFLOW, page-browser → browser actions, etc.).
+// When owner-operation actions stay eligible on those scopes, their long
+// descriptions contaminate the ACTION_PLANNER candidate list, driving the LLM
+// to mimic the life-param-extractor structured schema and producing envelopes
+// the planner cannot read.
 async function isForeignPageScope(
   runtime: IAgentRuntime,
   message: Memory,
 ): Promise<boolean> {
   const room = await runtime.getRoom(message.roomId);
   const metadata = extractConversationMetadataFromRoom(room);
-  if (!isPageScopedConversationMetadata(metadata)) {
-    return false;
-  }
-  return metadata?.scope !== "page-lifeops";
+  return isPageScopedConversationMetadata(metadata);
 }
 
 // Metadata reused by the owner-* umbrella actions in owner-surfaces.ts.

--- a/plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts
@@ -1039,7 +1039,7 @@ export function withReminders<TBase extends Constructor<LifeOpsServiceBase>>(
       scheduledFor: string;
       dueAt: string | null;
     }): void {
-      this.emitAssistantEvent(args.text, "lifeops-reminder", {
+      this.emitAssistantEvent(args.text, "reminder", {
         ownerType: args.ownerType,
         ownerId: args.ownerId,
         subjectType: args.subjectType,
@@ -1499,7 +1499,7 @@ export function withReminders<TBase extends Constructor<LifeOpsServiceBase>>(
         urgency: run.status === "success" ? "medium" : "high",
         now: new Date(),
       });
-      this.emitAssistantEvent(message, "lifeops-workflow", {
+      this.emitAssistantEvent(message, "workflow", {
         workflowId: workflow.id,
         workflowTitle: workflow.title,
         workflowRunId: run.id,

--- a/plugins/plugin-workflow/src/lib/automations-types.ts
+++ b/plugins/plugin-workflow/src/lib/automations-types.ts
@@ -25,7 +25,6 @@ export type ConversationScope =
   | 'page-connectors'
   | 'page-phone'
   | 'page-plugins'
-  | 'page-lifeops'
   | 'page-settings'
   | 'page-wallet'
   | 'page-browser'


### PR DESCRIPTION
## What

Stage 2 of the LifeOps top-down de-hardcode (#8833). Stage 1 (#9162) landed the bulk; this removes the **cross-layer** umbrella tokens it left behind that span shared contracts + agent + UI + plugins. Owner direction: completely remove `lifeops`, decompose per-plugin, no umbrella.

### 1. `page-lifeops` page-scope id (removed everywhere)
The LifeOps overview view is gone, so this routing/UI scope key is dead. It is **non-persisted** (no SQL/migration references; stale `webConversation.scope` room-metadata values are silently dropped by the scope sanitizer, so no data/contract breakage). Removed from all legs of the contract together:
- shared Zod enum `ConversationScopeSchema` (`conversation-routes.ts`)
- agent runtime allowlist `VALID_SCOPES` (`conversation-metadata.ts`)
- UI `PageScope` union + `PAGE_SCOPES` + routing-contexts + `PAGE_SCOPE_COPY` + `PAGE_SCOPE_DEFAULT_TITLE` (`page-scoped-conversations.ts`), **bumped `PAGE_SCOPE_VERSION` 14 → 15**
- agent `page-scoped-context.ts` brief + live-state `case` + the now-dead `renderLifeOpsLiveState` / `formatLifeOpsOverviewSection` helpers + the now-unused `LifeOps*` type imports + the provider description
- `suggestions-routes.ts` heuristic scope starters + comments
- `schema-vs-type-drift` contract test mirror
- `plugin-workflow/src/lib/automations-types.ts` `ConversationScope` mirror union
- repointed the PA owner-operation eligibility gate (`isForeignPageScope` in `actions/life.ts`) — the "home" surface is now the non-page-scoped chat, so owner-ops are foreign on any page scope (preserves intent without the dead literal)

Per-plugin page scopes (`page-browser`, `page-wallet`, …) are kept.

### 2. `lifeops-reminder` / `lifeops-workflow` event sources → `reminder` / `workflow`
Renamed the ephemeral `AgentEventService` `source` strings consistently across emitter + UI categorizer + agent validator together:
- emitter: PA `service-mixin-reminders.ts` (`emitInAppReminderNudge`, `emitWorkflowRunNudge`)
- UI categorizer: `useActivityEvents.ts`
- agent suppressor: `CHAT_SUPPRESSED_AUTONOMY_SOURCES` (`server-helpers-swarm.ts`)

These are transient WS broadcast tokens (not a persisted DB contract), so the rename is safe.

## Left + reported (cross-repo / out-of-scope external consumers)

### 3. `lifeOpsBrowserSetupPanel` + `"lifeopsbrowser"` connector id — **NOT renamed, by design**
- The boot-config slot key `lifeOpsBrowserSetupPanel` is **set by the Milady host app** (`apps/app/src/main.tsx`, a **separate git repo**). Renaming it in elizaOS alone would silently break the host's browser-bridge setup-panel wiring (host sets a key the panel no longer reads). Cannot be safely renamed in one elizaOS PR.
- The `.includes("lifeopsbrowser")` substring check in `ConnectorSetupPanel(.tsx/.helpers.ts)` matches the **live `lifeops_browser` provider id** (`normalizePluginId("lifeops_browser")` → `"lifeopsbrowser"`), which is a registered key also used as a Discord message `source` in PA `src/lifeops/` internals (out of scope). Removing the substring would break the panel for the real connector.

Both are flagged per the task's "if it's a persisted/registered key with external consumers you can't safely rename in one PR, leave it and report" rule. Also out of scope (later stages): PA `src/lifeops/` internals, shared/health `LifeOps*` contract type rename, knowledge-graph entity boundary, app-core benchmarks, i18n json.

## Test evidence

```
typecheck (0 errors each):
  bun run --cwd packages/shared typecheck   → 0
  bun run --cwd packages/agent  typecheck   → 0
  bun run --cwd packages/ui     typecheck   → 0
  bun run --cwd plugins/plugin-workflow typecheck → 0
  bun run --cwd plugins/plugin-personal-assistant build:types → 0 (tsc emit, no syntax break)

vitest (affected suites):
  shared schema-vs-type-drift   → 1 file, 2 tests passed
  agent  suggestions-routes     → 1 file, 16 tests passed
  ui     usePromptSuggestions   → 1 file, 20 tests passed
  (conversation-metadata.ts and useActivityEvents.ts have no dedicated unit-test files;
   their contract is covered by schema-vs-type-drift + typecheck)

biome check --write → clean on all 13 touched files
```

Net diff: **13 files, +32 / −161**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)