### PR TITLE
feat(streaming): verify + harden token-by-token streaming (#9174)

### DIFF
--- a/.github/issue-evidence/9174-streaming-verify-harden/README.md
+++ b/.github/issue-evidence/9174-streaming-verify-harden/README.md
@@ -1,0 +1,85 @@
+# Evidence — #9174 Streaming responses: verify + harden token-by-token text
+
+**Branch:** `feat/streaming-verify-harden-9174` · **Base:** `develop`
+
+The pipeline was already wired end-to-end (see issue body). This change **verifies
+and hardens** it: a configurable local-streaming granularity knob, regression
+tests locking every layer of the token-stream contract, and a confirmation that
+the dashboard always streams. No new streaming mechanism was added.
+
+## What changed
+
+| Area | Change |
+| --- | --- |
+| Local granularity knob | `FfiStreamingRunner` per-step token cap is now configurable via `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` (default `32`, clamped `1`–`512`) **and** a per-call `maxTokensPerStep` arg. Lower = smoother token-by-token local streaming, at the cost of more JS↔FFI round-trips. Default behaviour is unchanged. |
+| Core export | `resolveDynamicPromptStreamFields` exported from `runtime.ts` for regression coverage of the default `text`-field stream contract. |
+| Regression tests | New/extended tests at all four layers (local FFI, core extractor, transport, frontend). |
+| Docs | `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` documented in the plugin `CLAUDE.md`/`AGENTS.md`. |
+
+## Regression coverage — the verification (automated, reproducible)
+
+Full output: [`regression-test-output.txt`](./regression-test-output.txt) — **90 tests pass.**
+
+| Issue checkbox | Layer | Locking test(s) |
+| --- | --- | --- |
+| (a) `ensure-local-inference-handler` wires `onStreamChunk → onTextChunk` | local FFI | `plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts` — per-token delivery; **+ new:** plain `stream:true` wiring, and negative (non-streaming ⇒ no `onTextChunk`) |
+| (b) extractor emits the `text`-field delta (not raw markup) | core | `packages/core/src/utils/__tests__/streaming-field-events.test.ts` — **+ new** `text`-field clean-delta + no-control-field-leak; `packages/core/src/runtime/__tests__/resolve-stream-fields.test.ts` — **new** default = `text`, opt-in/opt-out, order; `streaming-use-model.test.ts` — emits only the clean reply, with accurate `accumulated` |
+| (c) chat-routes append-vs-snapshot via `resolveStreamingUpdate` | transport | `packages/agent/src/api/__tests__/conversation-streaming.test.ts` — **+ new** clean extension ⇒ `onChunk` delta; in-place revision ⇒ `onSnapshot`; `sse-wire-streaming.test.ts` — N token frames + 1 done frame, no buffering |
+| Local granularity knob | local FFI | `plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts` — **new** default 32, env override, per-call override, clamping |
+| Dashboard always streams | frontend | `packages/ui/src/state/useChatSend.test.tsx` — **+ new** happy path uses the streaming endpoint, never the non-streaming one (reserved for 404 recovery), first-token signal fires |
+
+## Real transport demonstration — timestamped SSE token timeline
+
+[`sse-token-timeline.txt`](./sse-token-timeline.txt) was captured by driving the
+**real** `generateChatResponse()` → `writeChatTokenSse()` server code with a
+model that emits 8 tokens 35 ms apart. Each SSE `data: {type:token}` frame
+arrived at a **distinct** wall-clock time (≈36 ms apart), carrying the delta and
+accumulated `fullText` — i.e. genuine incremental emission over the wire, not a
+single batched frame at the end.
+
+```
+frame  1 | t=+  40ms (+ 40ms) | delta="Streaming " | fullText="Streaming "
+...
+frame  8 | t=+ 291ms (+ 35ms) | delta="dashboard." | fullText="Streaming works token by token into the dashboard."
+Total token frames: 8 (one per model token)
+Distinct arrival times: 8 (frames arrived incrementally, NOT batched at the end)
+```
+
+## Live-model UI video — N/A on this dev box (key + model limitation)
+
+The issue itself flags the UI video as "the one piece not verifiable headless on
+a dev box." On this machine it is genuinely blocked:
+
+- **Cloud:** both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in `.env` return
+  **401** (`authentication_error` / `invalid_api_key`) against the live APIs, so
+  a real cloud trajectory cannot be produced here.
+- **Local:** no fused model is installed (`MODELS_DIR` unset, no `.gguf` /
+  eliza-1 bundle present), so the FFI path cannot be exercised end-to-end. The
+  local FFI emission was already verified on Windows with the real fused lib
+  (issue body).
+
+### Manual E2E protocol (for a maintainer with working keys / a local model)
+
+1. `bun run dev` (boots API + dashboard).
+2. **Cloud:** set a valid `ANTHROPIC_API_KEY`, select an Anthropic agent, send a
+   message that elicits a multi-sentence reply. Observe the reply rendering
+   token-by-token. **Local:** set `MODELS_DIR` + a fused model, select the local
+   agent, repeat. Optionally set `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP=8` to
+   compare smoothness.
+3. Capture a full-page screen recording of each (`bun run test:e2e:record`).
+4. In devtools → Network, confirm `POST /api/conversations/:id/messages/stream`
+   is the request and that `data: {"type":"token"}` frames stream in before the
+   terminal `done` frame (matches `sse-token-timeline.txt`).
+
+## Reproduce the automated evidence
+
+```bash
+# local FFI
+bun run --cwd plugins/plugin-local-inference test -- src/services/ffi-streaming-runner.test.ts src/runtime/ensure-local-inference-handler.test.ts
+# core
+bun run --cwd packages/core test -- src/utils/__tests__/streaming-field-events.test.ts src/runtime/__tests__/resolve-stream-fields.test.ts src/runtime/__tests__/streaming-use-model.test.ts
+# transport
+bun run --cwd packages/agent test -- src/api/__tests__/conversation-streaming.test.ts src/api/__tests__/sse-wire-streaming.test.ts
+# frontend
+bun run --cwd packages/ui test -- src/state/useChatSend.test.tsx
+```

--- a/.github/issue-evidence/9174-streaming-verify-harden/regression-test-output.txt
+++ b/.github/issue-evidence/9174-streaming-verify-harden/regression-test-output.txt
@@ -1,0 +1,18 @@
+# #9174 streaming regression suite — full run output
+# date: 2026-06-23T19:25:39Z
+
+## plugin-local-inference (granularity knob + onStreamChunk→onTextChunk wiring)
+ Test Files  2 passed (2)
+      Tests  29 passed (29)
+
+## core (clean text-field extraction + default stream fields + useModel structured streaming)
+ Test Files  3 passed (3)
+      Tests  24 passed (24)
+
+## agent (append-vs-snapshot + SSE wire format + status frames)
+ Test Files  3 passed (3)
+      Tests  28 passed (28)
+
+## ui (dashboard always streams)
+ Test Files  1 passed (1)
+      Tests  9 passed (9)

--- a/.github/issue-evidence/9174-streaming-verify-harden/sse-token-timeline.txt
+++ b/.github/issue-evidence/9174-streaming-verify-harden/sse-token-timeline.txt
@@ -1,0 +1,16 @@
+===== #9174 SSE TOKEN TIMELINE (real transport) =====
+Each row is one SSE `data: {type:token}` frame written by the real
+writeChatTokenSse() as generateChatResponse streamed it.
+
+frame  1 | t=+  40ms (+ 40ms) | delta="Streaming " | fullText="Streaming "
+frame  2 | t=+  76ms (+ 36ms) | delta="works " | fullText="Streaming works "
+frame  3 | t=+ 111ms (+ 35ms) | delta="token " | fullText="Streaming works token "
+frame  4 | t=+ 147ms (+ 36ms) | delta="by " | fullText="Streaming works token by "
+frame  5 | t=+ 183ms (+ 36ms) | delta="token " | fullText="Streaming works token by token "
+frame  6 | t=+ 220ms (+ 37ms) | delta="into " | fullText="Streaming works token by token into "
+frame  7 | t=+ 256ms (+ 36ms) | delta="the " | fullText="Streaming works token by token into the "
+frame  8 | t=+ 291ms (+ 35ms) | delta="dashboard." | fullText="Streaming works token by token into the dashboard."
+
+Total token frames: 8 (one per model token)
+Distinct arrival times: 8 (frames arrived incrementally, NOT batched at the end)
+=====================================================

--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -173,6 +173,58 @@ describe("generateChatResponse token streaming", () => {
     expect(result.text).toBe("alpha beta gamma");
   });
 
+  it("routes a clean extension to onChunk but an in-place revision to onSnapshot", async () => {
+    // chat-routes' appendIncomingText() runs every onStreamChunk value through
+    // resolveStreamingUpdate(responseText, incoming):
+    //   - a clean extension of the buffer => append => onChunk(delta)
+    //   - an in-place revision that does NOT extend the buffer => replace =>
+    //     onSnapshot(full text)
+    // This locks that the route does not garble a corrected snapshot into the
+    // delta stream. "helo world" -> "hello world" is the canonical revision
+    // (fixes a typo in an already-streamed word) classified as a replacement.
+    const service: MessageService = {
+      async handleMessage(_runtime, _message, _callback, options) {
+        await Promise.resolve();
+        await options?.onStreamChunk?.("helo world");
+        await Promise.resolve();
+        await options?.onStreamChunk?.("hello world");
+        return {
+          didRespond: true,
+          responseContent: { text: "hello world" },
+          responseMessages: [],
+        };
+      },
+      shouldRespond: () => ({
+        shouldRespond: true,
+        skipEvaluation: true,
+        reason: "streaming-test",
+      }),
+      deleteMessage: async () => undefined,
+      clearChannel: async () => undefined,
+    };
+
+    const runtime = createRuntime({ messageService: service });
+
+    const chunks: string[] = [];
+    const snapshots: string[] = [];
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("typo"),
+      "Streaming Agent",
+      {
+        timeoutDuration: 5_000,
+        onChunk: (chunk) => chunks.push(chunk),
+        onSnapshot: (text) => snapshots.push(text),
+      },
+    );
+
+    // First emission appended as a delta; the revision replaced via snapshot.
+    expect(chunks).toEqual(["helo world"]);
+    expect(snapshots).toEqual(["hello world"]);
+    // The corrected text is what the caller ends up with — no "helo" garble.
+    expect(result.text).toBe("hello world");
+  });
+
   it("returns sanitized action result summaries for UI handoffs", async () => {
     const message = createChatMessage("create a workflow");
     const getActionResults = vi.fn(() => [

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -398,7 +398,15 @@ const DEFAULT_RESPONSE_SKELETON_STREAM_FIELDS = new Set([
 	"messageToUser",
 ]);
 
-function resolveDynamicPromptStreamFields(
+/**
+ * Resolve which structured fields stream to the consumer for the line-oriented
+ * `dynamicPromptExecFromState` path. A field streams when it opts in with
+ * `streamField: true`, or — when it expresses no preference — when its name is
+ * in {@link DEFAULT_DYNAMIC_PROMPT_STREAM_FIELDS} (the clean reply `text`).
+ * `streamField: false` always opts out. Exported for regression coverage of
+ * the default token-stream contract (#9174).
+ */
+export function resolveDynamicPromptStreamFields(
 	schema: readonly SchemaRow[],
 ): string[] {
 	return schema

--- a/packages/core/src/runtime/__tests__/resolve-stream-fields.test.ts
+++ b/packages/core/src/runtime/__tests__/resolve-stream-fields.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { resolveDynamicPromptStreamFields } from "../../runtime";
+import type { SchemaRow } from "../../types/state";
+
+/**
+ * Locks the default token-stream contract for #9174: the line-oriented
+ * dynamic-prompt path streams the clean reply `text` by default, honours
+ * explicit `streamField` opt-in/opt-out, and never streams control fields.
+ */
+describe("resolveDynamicPromptStreamFields (#9174)", () => {
+	it("streams the `text` field by default when no preference is expressed", () => {
+		const schema: SchemaRow[] = [
+			{ field: "thought", description: "internal reasoning" },
+			{ field: "text", description: "user-facing reply" },
+			{ field: "actions", description: "actions", type: "array" },
+		];
+		expect(resolveDynamicPromptStreamFields(schema)).toEqual(["text"]);
+	});
+
+	it("does not stream control fields (thought/actions) by default", () => {
+		const schema: SchemaRow[] = [
+			{ field: "thought", description: "internal reasoning" },
+			{ field: "actions", description: "actions", type: "array" },
+		];
+		expect(resolveDynamicPromptStreamFields(schema)).toEqual([]);
+	});
+
+	it("includes any field that opts in with streamField: true", () => {
+		const schema: SchemaRow[] = [
+			{ field: "thought", description: "internal reasoning" },
+			{ field: "text", description: "reply" },
+			{
+				field: "summary",
+				description: "a streamed summary",
+				streamField: true,
+			},
+		];
+		expect(resolveDynamicPromptStreamFields(schema)).toEqual([
+			"text",
+			"summary",
+		]);
+	});
+
+	it("excludes a default field that opts out with streamField: false", () => {
+		const schema: SchemaRow[] = [
+			{ field: "text", description: "reply", streamField: false },
+		];
+		expect(resolveDynamicPromptStreamFields(schema)).toEqual([]);
+	});
+
+	it("preserves document order of streamed fields", () => {
+		const schema: SchemaRow[] = [
+			{ field: "a", description: "", streamField: true },
+			{ field: "text", description: "" },
+			{ field: "b", description: "", streamField: true },
+		];
+		expect(resolveDynamicPromptStreamFields(schema)).toEqual([
+			"a",
+			"text",
+			"b",
+		]);
+	});
+});

--- a/packages/core/src/utils/__tests__/streaming-field-events.test.ts
+++ b/packages/core/src/utils/__tests__/streaming-field-events.test.ts
@@ -133,6 +133,51 @@ describe("StructuredFieldStreamExtractor per-field events", () => {
 	});
 });
 
+describe("StructuredFieldStreamExtractor emits the clean text-field delta (#9174)", () => {
+	// The default dynamic-prompt stream field is `text` (the clean reply). This
+	// locks that a structured response streams only the decoded `text` value —
+	// never the surrounding `thought:`/`actions:` markup — and that the third
+	// onChunk arg (`accumulated`) is the clean reply text, not raw markup.
+	const replySchema: SchemaRow[] = [
+		{ field: "thought", description: "internal reasoning" },
+		{ field: "text", description: "user-facing reply", streamField: true },
+		{ field: "actions", description: "actions to run", type: "array" },
+	];
+
+	it("streams only the decoded text field, never the markup around it", () => {
+		const chunks: Array<[string | undefined, string, string | undefined]> = [];
+		const extractor = new StructuredFieldStreamExtractor({
+			level: 0,
+			schema: replySchema,
+			streamFields: ["text"],
+			onChunk: (chunk, field, accumulated) =>
+				chunks.push([field, chunk, accumulated]),
+		});
+
+		feed(
+			extractor,
+			[
+				"thought: the user greeted me, respond warmly",
+				"text: Hey! Good to see you again.",
+				'actions: ["REPLY"]',
+			].join("\n"),
+		);
+		extractor.flush();
+
+		// Every emitted chunk belongs to the `text` field — no control-field leak.
+		expect(chunks.every(([field]) => field === "text")).toBe(true);
+		const joined = chunks.map(([, chunk]) => chunk).join("");
+		expect(joined).toBe("Hey! Good to see you again.");
+		// Raw field markup never reaches the user-visible token stream.
+		expect(joined).not.toContain("thought:");
+		expect(joined).not.toContain("actions:");
+		expect(joined).not.toContain("the user greeted me");
+		// `accumulated` is the clean reply text, ending at the full reply.
+		const accumulated = chunks.map(([, , acc]) => acc);
+		expect(accumulated.at(-1)).toBe("Hey! Good to see you again.");
+	});
+});
+
 describe("ResponseSkeletonStreamExtractor", () => {
 	const skeleton = {
 		spans: [

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
     sendConversationMessageStream: vi.fn(),
     sendWsMessage: vi.fn(),
     stopCodingAgent: vi.fn(),
+    renameConversation: vi.fn(() => Promise.resolve()),
     getBaseUrl: vi.fn(() => ""),
   },
 }));
@@ -379,6 +380,51 @@ describe("useChatSend 404 recovery", () => {
     expect(
       remaining.some((m) => m.role === "assistant" && !m.text.trim()),
     ).toBe(false);
+  });
+});
+
+describe("useChatSend always streams (#9174)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.renameConversation.mockResolvedValue(undefined);
+  });
+
+  it("uses the streaming endpoint on the happy path and never the non-streaming one", async () => {
+    const tokens: Array<[string, string]> = [];
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (token: string, accumulatedText?: string) => void,
+      ) => {
+        // Cloud + local both drive the UI through this same callback.
+        onToken("Hello", "Hello");
+        onToken(" world", "Hello world");
+        tokens.push(["Hello", " world"]);
+        return { text: "Hello world", completed: true };
+      },
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    // Happy path streams.
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+    // The non-streaming endpoint is reserved for 404 recovery only.
+    expect(mocks.client.sendConversationMessage).not.toHaveBeenCalled();
+    // Streaming context is active by default — the first-token signal fired as
+    // tokens arrived through onToken.
+    expect(deps.setChatFirstTokenReceived).toHaveBeenCalledWith(true);
+    // The streaming callback actually received incremental tokens.
+    expect(tokens).toEqual([["Hello", " world"]]);
   });
 });
 

--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -154,6 +154,7 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `ELIZA_LOCAL_IDLE_UNLOAD_MS` | No | Idle timeout (ms) before an inactive model is unloaded to free memory |
 | `ELIZA_LOCAL_SESSION_POOL_SIZE` | No | Number of parallel inference sessions to maintain in the session pool |
 | `ELIZA_LOCAL_MAX_SPECULATIVE_RESPONSES` | No | Maximum speculative decode responses buffered per request |
+| `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` | No | Per-step token cap for the FFI decode loop (default `32`, clamped `1`–`512`). Lower = smoother token-by-token streaming into the dashboard at the cost of more JS↔FFI round-trips |
 | `ELIZA_LOCAL_AUTO_RESIZE_PARALLEL` | No | Enable automatic parallel resize for multi-session scenarios |
 | `ELIZA_NETWORK_POLICY` | No | Network access policy override for inference routing |
 | `ELIZA_VOICE_EOT_BACKEND` | No | End-of-turn detector backend selection for voice pipeline |

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -154,6 +154,7 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `ELIZA_LOCAL_IDLE_UNLOAD_MS` | No | Idle timeout (ms) before an inactive model is unloaded to free memory |
 | `ELIZA_LOCAL_SESSION_POOL_SIZE` | No | Number of parallel inference sessions to maintain in the session pool |
 | `ELIZA_LOCAL_MAX_SPECULATIVE_RESPONSES` | No | Maximum speculative decode responses buffered per request |
+| `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` | No | Per-step token cap for the FFI decode loop (default `32`, clamped `1`–`512`). Lower = smoother token-by-token streaming into the dashboard at the cost of more JS↔FFI round-trips |
 | `ELIZA_LOCAL_AUTO_RESIZE_PARALLEL` | No | Enable automatic parallel resize for multi-session scenarios |
 | `ELIZA_NETWORK_POLICY` | No | Network access policy override for inference routing |
 | `ELIZA_VOICE_EOT_BACKEND` | No | End-of-turn detector backend selection for voice pipeline |

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -559,6 +559,54 @@ describe("ensureLocalInferenceHandler", () => {
 		expect(received.length).toBeGreaterThan(1);
 	});
 
+	it("wires onTextChunk for a plain (non-structured) stream request", async () => {
+		// The chat path can ask for token streaming via `stream: true` without a
+		// response skeleton. The handler must still bridge onStreamChunk →
+		// onTextChunk so cloud-parity token streaming works for the local model.
+		const { registrations, runtime } = makeRuntime();
+		engineState.hasLoadedModel.mockReturnValue(true);
+
+		await ensureLocalInferenceHandler(runtime);
+		const handler = findRegisteredHandler(
+			registrations,
+			ModelType.RESPONSE_HANDLER,
+		);
+
+		await handler(runtime, {
+			messages: [{ role: "user", content: "hello" }],
+			stream: true,
+			onStreamChunk: vi.fn(),
+		});
+
+		expect(engineState.generate).toHaveBeenCalledWith(
+			expect.objectContaining({ onTextChunk: expect.any(Function) }),
+		);
+	});
+
+	it("does not wire onTextChunk for a non-streaming request", async () => {
+		// Non-streaming callers must not pay the per-chunk callback overhead:
+		// engineGenerateArgsFromParams only bridges the callback when the caller
+		// asked for streaming (`stream` or `streamStructured`).
+		const { registrations, runtime } = makeRuntime();
+		engineState.hasLoadedModel.mockReturnValue(true);
+
+		await ensureLocalInferenceHandler(runtime);
+		const handler = findRegisteredHandler(
+			registrations,
+			ModelType.RESPONSE_HANDLER,
+		);
+
+		await handler(runtime, {
+			messages: [{ role: "user", content: "hello" }],
+			onStreamChunk: vi.fn(),
+		});
+
+		const args = engineState.generate.mock.calls.at(-1)?.[0] as {
+			onTextChunk?: unknown;
+		};
+		expect(args.onTextChunk).toBeUndefined();
+	});
+
 	it("threads eliza thinking provider options into local engine args", async () => {
 		const { registrations, runtime } = makeRuntime();
 		engineState.hasLoadedModel.mockReturnValue(true);

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
@@ -1,10 +1,63 @@
-import { describe, expect, it, vi } from "vitest";
-import { FfiStreamingRunner } from "./ffi-streaming-runner";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	FfiStreamingRunner,
+	resolveMaxTokensPerStep,
+} from "./ffi-streaming-runner";
 import type {
 	LlmCtxHandle,
 	LlmStreamingBinding,
 } from "./llm-streaming-binding";
-import type { LlmStreamHandle } from "./voice/ffi-bindings";
+import type { LlmStreamHandle, LlmStreamStep } from "./voice/ffi-bindings";
+
+/**
+ * Build a binding whose `llmStreamNext` emits `steps.length` steps (the last
+ * with `done: true`), and that records the `maxTokensPerStep` passed on every
+ * call so tests can assert the resolved per-step cap.
+ */
+function makeStepBinding(steps: string[]): {
+	binding: LlmStreamingBinding;
+	stepCaps: number[];
+} {
+	const stream = 7n as LlmStreamHandle;
+	const stepCaps: number[] = [];
+	let i = 0;
+	const llmStreamNext = vi.fn(
+		(args: { maxTokensPerStep?: number }): LlmStreamStep => {
+			stepCaps.push(args.maxTokensPerStep ?? -1);
+			const text = steps[i] ?? "";
+			const done = i >= steps.length - 1;
+			i += 1;
+			return {
+				tokens: [i],
+				text,
+				done,
+				drafterDrafted: 0,
+				drafterAccepted: 0,
+			};
+		},
+	);
+	const binding: LlmStreamingBinding = {
+		llmStreamSupported: () => true,
+		llmStreamOpen: vi.fn().mockReturnValue(stream),
+		llmStreamPrefill: vi.fn(),
+		llmStreamNext,
+		llmStreamCancel: vi.fn(),
+		llmStreamClose: vi.fn(),
+	};
+	return { binding, stepCaps };
+}
+
+const BASE_ARGS = {
+	slotId: 0,
+	maxTokens: 64,
+	temperature: 0,
+	topP: 1,
+	topK: 0,
+	repeatPenalty: 1,
+	draftMin: 0,
+	draftMax: 0,
+	draftModelPath: null,
+} as const;
 
 describe("FfiStreamingRunner prewarm", () => {
 	it("treats maxTokens: 0 as prefill-only and never calls next-token generation", async () => {
@@ -62,6 +115,106 @@ describe("FfiStreamingRunner prewarm", () => {
 			firstTokenMs: null,
 			drafted: 0,
 			accepted: 0,
+		});
+	});
+});
+
+describe("FfiStreamingRunner per-step granularity (#9174)", () => {
+	const ORIGINAL = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+	afterEach(() => {
+		if (ORIGINAL === undefined) {
+			delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		} else {
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = ORIGINAL;
+		}
+	});
+
+	it("defaults to a 32-token per-step cap when no override is set", async () => {
+		delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		const { binding, stepCaps } = makeStepBinding(["Hi ", "there"]);
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+		await runner.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+		});
+		expect(stepCaps).toEqual([32, 32]);
+	});
+
+	it("forwards a per-call maxTokensPerStep to every llmStreamNext call", async () => {
+		delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		const { binding, stepCaps } = makeStepBinding(["a", "b", "c"]);
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+		await runner.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+			maxTokensPerStep: 4,
+		});
+		expect(stepCaps).toEqual([4, 4, 4]);
+	});
+
+	it("honors the ELIZA_LOCAL_STREAM_TOKENS_PER_STEP env override", async () => {
+		process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "8";
+		const { binding, stepCaps } = makeStepBinding(["x", "y"]);
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+		await runner.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+		});
+		expect(stepCaps).toEqual([8, 8]);
+	});
+
+	it("lets a per-call override win over the env var", async () => {
+		process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "8";
+		const { binding, stepCaps } = makeStepBinding(["x"]);
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+		await runner.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+			maxTokensPerStep: 1,
+		});
+		expect(stepCaps).toEqual([1]);
+	});
+
+	it("clamps out-of-range per-call overrides into the supported window", async () => {
+		delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		const low = makeStepBinding(["x"]);
+		const runnerLow = new FfiStreamingRunner(low.binding, 1n as LlmCtxHandle);
+		await runnerLow.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+			maxTokensPerStep: 0,
+		});
+		// 0 floors to the minimum of 1, never disables generation.
+		expect(low.stepCaps).toEqual([1]);
+
+		const high = makeStepBinding(["x"]);
+		const runnerHigh = new FfiStreamingRunner(high.binding, 1n as LlmCtxHandle);
+		await runnerHigh.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+			maxTokensPerStep: 100_000,
+		});
+		expect(high.stepCaps).toEqual([512]);
+	});
+
+	describe("resolveMaxTokensPerStep", () => {
+		it("returns 32 when unset", () => {
+			delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+			expect(resolveMaxTokensPerStep()).toBe(32);
+		});
+
+		it("parses and clamps a valid env value", () => {
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "16";
+			expect(resolveMaxTokensPerStep()).toBe(16);
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "9999";
+			expect(resolveMaxTokensPerStep()).toBe(512);
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "0";
+			expect(resolveMaxTokensPerStep()).toBe(1);
+		});
+
+		it("falls back to 32 on a non-numeric env value", () => {
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "smooth";
+			expect(resolveMaxTokensPerStep()).toBe(32);
 		});
 	});
 });

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
@@ -75,6 +75,16 @@ export interface FfiStreamingGenerateArgs {
 	gbnfGrammar?: string | null;
 	/** Cancellation signal — fires `llmStreamCancel` on the active session. */
 	signal?: AbortSignal;
+	/**
+	 * Per-step token cap for the native decode loop. Lower values make the
+	 * local UI stream in finer-grained jumps (smoother token-by-token render)
+	 * at the cost of more JS↔FFI round-trips per reply; higher values batch
+	 * more tokens per step. When omitted, falls back to
+	 * `resolveMaxTokensPerStep()` (env `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP`,
+	 * else `DEFAULT_MAX_TOKENS_PER_STEP`). Clamped to
+	 * `[MIN_MAX_TOKENS_PER_STEP, MAX_MAX_TOKENS_PER_STEP]`.
+	 */
+	maxTokensPerStep?: number;
 	/** Per-chunk text callback. */
 	onTextChunk?: (chunk: string) => void | Promise<void>;
 	/** Speculative accept/reject events from MTP verification. */
@@ -92,6 +102,37 @@ export interface FfiStreamingGenerateResult {
 /** Default per-step caps. Match upstream llama-server's `n_predict` chunk size. */
 const DEFAULT_MAX_TOKENS_PER_STEP = 32;
 const DEFAULT_MAX_TEXT_BYTES = 1024;
+/**
+ * Sane bounds for the per-step token cap. The floor is 1 (true
+ * token-by-token); the ceiling guards against pathological values that would
+ * defeat streaming by emitting the whole reply in one step.
+ */
+const MIN_MAX_TOKENS_PER_STEP = 1;
+const MAX_MAX_TOKENS_PER_STEP = 512;
+
+/** Clamp a caller-supplied per-step cap into the supported range. */
+function clampMaxTokensPerStep(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_MAX_TOKENS_PER_STEP;
+	return Math.min(
+		MAX_MAX_TOKENS_PER_STEP,
+		Math.max(MIN_MAX_TOKENS_PER_STEP, Math.trunc(value)),
+	);
+}
+
+/**
+ * Resolve the per-step token cap for the native decode loop. Override via the
+ * `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` env var (e.g. set to `8` for smoother
+ * local streaming, weighed against the extra JS↔FFI round-trips and the shared
+ * voice phrase-chunker). Falls back to `DEFAULT_MAX_TOKENS_PER_STEP` (32) when
+ * unset or invalid; clamped to `[MIN_MAX_TOKENS_PER_STEP, MAX_MAX_TOKENS_PER_STEP]`.
+ */
+export function resolveMaxTokensPerStep(): number {
+	const raw = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP?.trim();
+	if (!raw) return DEFAULT_MAX_TOKENS_PER_STEP;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed)) return DEFAULT_MAX_TOKENS_PER_STEP;
+	return clampMaxTokensPerStep(parsed);
+}
 
 /**
  * Backend used by the mobile and desktop FFI routes.
@@ -314,6 +355,11 @@ export class FfiStreamingRunner {
 				return;
 			}
 
+			const maxTokensPerStep =
+				args.maxTokensPerStep !== undefined
+					? clampMaxTokensPerStep(args.maxTokensPerStep)
+					: resolveMaxTokensPerStep();
+
 			let tokenIndex = 0;
 			while (true) {
 				if (args.signal?.aborted) {
@@ -322,7 +368,7 @@ export class FfiStreamingRunner {
 				}
 				const step = this.ffi.llmStreamNext({
 					stream,
-					maxTokensPerStep: DEFAULT_MAX_TOKENS_PER_STEP,
+					maxTokensPerStep,
 					maxTextBytes: DEFAULT_MAX_TEXT_BYTES,
 				});
 				onStep(step);


### PR DESCRIPTION
Closes #9174.

The local + cloud token-streaming pipeline was already wired end-to-end (see the issue body). This PR **verifies and hardens** it — it adds no new streaming mechanism.

## What changed

- **Local granularity knob** — `FfiStreamingRunner`'s per-step token cap is now configurable via `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` (default `32`, clamped `1`–`512`) **and** a per-call `maxTokensPerStep` arg. Lower = smoother token-by-token local streaming, at the cost of more JS↔FFI round-trips. Default behaviour is unchanged. Documented in the plugin `CLAUDE.md`/`AGENTS.md`.
- **Regression tests lock every layer** of the token-stream contract:
  - **(a)** local handler wires `onStreamChunk → onTextChunk` — added plain `stream:true` wiring + the negative (non-streaming ⇒ no `onTextChunk`) case.
  - **(b)** structured extractor emits the clean `text`-field delta, not raw markup; `resolveDynamicPromptStreamFields` defaults to `text` (now exported + unit-tested for opt-in/opt-out/order).
  - **(c)** chat-routes append-vs-snapshot via `resolveStreamingUpdate` — clean extension ⇒ `onChunk` delta; in-place revision ⇒ `onSnapshot`.
  - dashboard **always** uses the streaming endpoint (non-streaming is reserved for 404 recovery).
- **Granularity knob tests** — default 32, env override, per-call override, clamping.

## Evidence

`.github/issue-evidence/9174-streaming-verify-harden/`:

- **90 passing streaming tests** across all four layers (`regression-test-output.txt`).
- A **real timestamped SSE token timeline** (`sse-token-timeline.txt`) captured by driving the actual `generateChatResponse()` → `writeChatTokenSse()` code: 8 frames, each arriving at a distinct wall-clock time ~36 ms apart with delta + accumulated `fullText` — genuine incremental emission, not one batched frame.
- **Live-cloud UI video: N/A on this dev box** — both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` return 401, and no local fused model is installed. This is the piece the issue itself flagged as "not verifiable headless on a dev box." A step-by-step manual E2E protocol for a maintainer with working keys / a local model is included in the evidence README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)