### PR TITLE
fix(ci): point apex chunk-safety hard gate at the verify:chunks script (#9150)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -274,7 +274,7 @@ jobs:
       # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
         working-directory: packages/app
-        run: bun run verify:chunk-safety
+        run: bun run verify:chunks
 
       - name: Resolve Pages branch
         id: pages
@@ -429,7 +429,7 @@ jobs:
       # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
         working-directory: packages/app
-        run: bun run verify:chunk-safety
+        run: bun run verify:chunks
 
       - name: Resolve Pages branch
         id: pages


### PR DESCRIPTION
## Problem

PR #9188 (already merged) made the **Verify bundle chunk safety** step a **hard gate** in both apex deploy jobs (`deploy-console` + `deploy-app`) by dropping `continue-on-error`. But the step runs:

```yaml
run: bun run verify:chunk-safety
```

while `packages/app/package.json` only defines `verify:chunks` (develop had independently renamed the script when folding the gate into `build:web`). There is **no** `verify:chunk-safety` script:

```
$ bun run verify:chunk-safety
error: Script not found "verify:chunk-safety"
```

With the gate now hard, this step **fails with "Script not found" on every apex deploy** — the gate meant to *protect* the deploy would instead *break* it.

## Fix

Point both gate steps at the existing script name `verify:chunks` (= `node scripts/verify-chunk-safety.mjs`), so the hard gate actually runs the bn.js/crypto chunk-confinement check.

## Verification

- `bun run --cwd packages/app verify:chunks` resolves and runs the gate script (vs. `verify:chunk-safety` → "Script not found").
- Full real build (`build:web`) emits the crypto graph in a single lazy `vendor-crypto` chunk (1.32 MB), the eager `en_US` locale chunk stays small (264 KB), and the gate prints `[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (426 chunks scanned).`
- 4/4 `verify-chunk-safety` unit tests pass; `packages/app` typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)