### PR TITLE
refactor(agent): promote pending-prompts/global-pause/handoff to runtime services (LifeOps Slice 3) (#8833)

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -234,6 +234,30 @@ export {
   isStewardEvmBridgeActive,
   setStewardEvmBridgeActive,
 } from "./services/external-bridge-state.ts";
+export {
+  createGlobalPauseStore,
+  GLOBAL_PAUSE_CACHE_KEY,
+  GLOBAL_PAUSE_SERVICE,
+  GlobalPauseService,
+  type GlobalPauseStatus,
+  type GlobalPauseStore,
+  type GlobalPauseWindow,
+  resolveGlobalPauseService,
+} from "./services/global-pause/index.ts";
+export {
+  createHandoffStore,
+  describeResumeCondition,
+  evaluateResume,
+  HANDOFF_SERVICE,
+  type HandoffEnterOpts,
+  HandoffService,
+  type HandoffStatus,
+  type HandoffStore,
+  type ResumeCondition,
+  type ResumeEvaluation,
+  type ResumeEvaluationInput,
+  resolveHandoffService,
+} from "./services/handoff/index.ts";
 export * from "./services/index.ts";
 export {
   type JsRuntimeBridge,
@@ -256,6 +280,20 @@ export {
   RelationshipStore,
   resolveKnowledgeGraphService,
 } from "./services/knowledge-graph/index.ts";
+// Cache-backed runtime stores promoted from LifeOps (pending-prompts /
+// global-pause / handoff). Named re-exports — same rationale as the knowledge
+// graph above: keep them out of the broad services barrel to avoid TS2308.
+export {
+  createPendingPromptsStore,
+  type ExpectedReplyKind,
+  PENDING_PROMPTS_SERVICE,
+  type PendingPrompt,
+  type PendingPromptRecordInput,
+  PendingPromptsService,
+  type PendingPromptsStore,
+  type RecordedPendingPrompt,
+  resolvePendingPromptsService,
+} from "./services/pending-prompts/index.ts";
 export * from "./services/plugin-installer";
 export type {
   CoreManagerLike,

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -56,11 +56,14 @@ import { createUserNameProvider } from "../providers/user-name.ts";
 import { createWorkspaceProvider } from "../providers/workspace-provider.ts";
 import { ElizaCharacterPersistenceService } from "../services/character-persistence.ts";
 import { LocalFileStorageService } from "../services/file-storage.ts";
+import { GlobalPauseService } from "../services/global-pause/index.ts";
+import { HandoffService } from "../services/handoff/index.ts";
 import {
   KnowledgeGraphService,
   knowledgeGraphSchema,
 } from "../services/knowledge-graph/index.ts";
 import { AgentMediaGenerationService } from "../services/media-generation.ts";
+import { PendingPromptsService } from "../services/pending-prompts/index.ts";
 import { PermissionRegistry } from "../services/permissions-registry.ts";
 import { NotificationPushService } from "../services/push/notification-push-service.ts";
 import { resolveDefaultAgentWorkspaceDir } from "../shared/workspace-resolution.ts";
@@ -135,6 +138,9 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       LocalFileStorageService as ServiceClass,
       PermissionRegistry as ServiceClass,
       KnowledgeGraphService as ServiceClass,
+      PendingPromptsService as ServiceClass,
+      GlobalPauseService as ServiceClass,
+      HandoffService as ServiceClass,
     ],
 
     init: async (_pluginConfig, runtime: IAgentRuntime) => {

--- a/packages/agent/src/services/global-pause/index.ts
+++ b/packages/agent/src/services/global-pause/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Runtime global-pause store: the vacation / pause-mode singleton consulted by
+ * the scheduled-task runner, surfaced through the registered
+ * {@link GlobalPauseService}. Cache-backed (no SQL), single canonical key.
+ */
+
+export {
+  GLOBAL_PAUSE_SERVICE,
+  GlobalPauseService,
+  resolveGlobalPauseService,
+} from "./service.ts";
+export {
+  createGlobalPauseStore,
+  GLOBAL_PAUSE_CACHE_KEY,
+  type GlobalPauseStatus,
+  type GlobalPauseStore,
+  type GlobalPauseWindow,
+} from "./store.ts";

--- a/packages/agent/src/services/global-pause/service.test.ts
+++ b/packages/agent/src/services/global-pause/service.test.ts
@@ -1,0 +1,73 @@
+/**
+ * GlobalPauseService unit test — the runtime-owned vacation / pause singleton.
+ *
+ * Mirrors the LifeOps store integration test: set the window, current()
+ * reflects active state inside the window, and clear() returns to inactive.
+ * Exercised through the registered service's `getStore()` accessor.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  GLOBAL_PAUSE_SERVICE,
+  GlobalPauseService,
+  resolveGlobalPauseService,
+} from "./service.ts";
+
+function makeRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "test-agent",
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+describe("GlobalPauseService", () => {
+  it("exposes the canonical serviceType literal", () => {
+    expect(GlobalPauseService.serviceType).toBe("eliza_global_pause");
+    expect(GLOBAL_PAUSE_SERVICE).toBe("eliza_global_pause");
+  });
+
+  it("set + current + clear lifecycle works through the service store", async () => {
+    const runtime = makeRuntime();
+    const service = await GlobalPauseService.start(runtime);
+    const store = service.getStore();
+
+    expect((await store.current()).active).toBe(false);
+
+    const startIso = new Date(Date.now() - 60_000).toISOString();
+    const endIso = new Date(Date.now() + 86_400_000).toISOString();
+    await store.set({ startIso, endIso, reason: "vacation" });
+
+    const active = await store.current();
+    expect(active.active).toBe(true);
+    expect(active.reason).toBe("vacation");
+    expect(active.startIso).toBe(startIso);
+    expect(active.endIso).toBe(endIso);
+
+    const afterEnd = await store.current(new Date(Date.parse(endIso) + 1));
+    expect(afterEnd.active).toBe(false);
+
+    await store.clear();
+    expect((await store.current()).active).toBe(false);
+
+    await service.stop();
+  });
+
+  it("resolveGlobalPauseService returns null when unregistered", () => {
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+    expect(resolveGlobalPauseService(runtime)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/global-pause/service.ts
+++ b/packages/agent/src/services/global-pause/service.ts
@@ -1,0 +1,45 @@
+/**
+ * GlobalPauseService — the runtime-owned vacation / pause-mode singleton,
+ * exposed as a registered runtime service.
+ *
+ * Global pause is a runtime primitive: the scheduled-task runner consults the
+ * store pre-fire via `runtime.getService(...)` rather than constructing the
+ * cache-backed store itself. The service is a thin factory over the per-runtime
+ * {@link GlobalPauseStore}; the store is cache-backed (no SQL), single canonical
+ * key.
+ *
+ * Mirrors `KnowledgeGraphService` (lifecycle + getService accessor).
+ */
+
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import { createGlobalPauseStore, type GlobalPauseStore } from "./store.ts";
+
+export const GLOBAL_PAUSE_SERVICE = "eliza_global_pause";
+
+export class GlobalPauseService extends Service {
+  static override serviceType = GLOBAL_PAUSE_SERVICE;
+
+  override capabilityDescription =
+    "Runtime global-pause store: vacation / pause-mode singleton consulted by the scheduler, cache-backed";
+
+  static async start(runtime: IAgentRuntime): Promise<GlobalPauseService> {
+    return new GlobalPauseService(runtime);
+  }
+
+  async stop(): Promise<void> {}
+
+  /** The cache-backed global-pause store for this runtime. */
+  getStore(): GlobalPauseStore {
+    return createGlobalPauseStore(this.runtime);
+  }
+}
+
+/**
+ * Resolve the registered {@link GlobalPauseService}. Returns `null` when the
+ * runtime has not registered it (e.g. the "eliza" plugin is absent).
+ */
+export function resolveGlobalPauseService(
+  runtime: IAgentRuntime,
+): GlobalPauseService | null {
+  return runtime.getService<GlobalPauseService>(GLOBAL_PAUSE_SERVICE);
+}

--- a/packages/agent/src/services/global-pause/store.ts
+++ b/packages/agent/src/services/global-pause/store.ts
@@ -1,0 +1,126 @@
+/**
+ * `GlobalPauseStore` — vacation / pause mode singleton.
+ *
+ * Only ONE pause window can be active at a time. The runner consults
+ * `current()` pre-fire; tasks with `respectsGlobalPause: true` skip with
+ * reason `global_pause`; tasks with `respectsGlobalPause: false` (emergencies)
+ * fire anyway. If `endIso` is set on the active window, the runner reschedules
+ * skipped tasks for `endIso` (the user's "resume my routine" moment).
+ *
+ * Backing storage: runtime cache. Single canonical key.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+
+type RuntimeCacheLike = Pick<
+  IAgentRuntime,
+  "getCache" | "setCache" | "deleteCache"
+>;
+
+export interface GlobalPauseWindow {
+  startIso: string;
+  endIso?: string;
+  reason?: string;
+}
+
+export interface GlobalPauseStatus {
+  active: boolean;
+  startIso?: string;
+  endIso?: string;
+  reason?: string;
+}
+
+export interface GlobalPauseStore {
+  set(window: GlobalPauseWindow): Promise<void>;
+  clear(): Promise<void>;
+  current(now?: Date): Promise<GlobalPauseStatus>;
+}
+
+export const GLOBAL_PAUSE_CACHE_KEY = "eliza:lifeops:global-pause:v1";
+
+function isValidIso(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+  const ms = Date.parse(value);
+  return Number.isFinite(ms);
+}
+
+function normalizeWindow(window: GlobalPauseWindow): GlobalPauseWindow {
+  if (!isValidIso(window.startIso)) {
+    throw new Error(
+      `[global-pause] invalid startIso: ${String(window.startIso)}`,
+    );
+  }
+  if (window.endIso !== undefined && !isValidIso(window.endIso)) {
+    throw new Error(`[global-pause] invalid endIso: ${String(window.endIso)}`);
+  }
+  if (
+    window.endIso !== undefined &&
+    Date.parse(window.endIso) <= Date.parse(window.startIso)
+  ) {
+    throw new Error("[global-pause] endIso must be strictly after startIso");
+  }
+  const normalized: GlobalPauseWindow = { startIso: window.startIso };
+  if (window.endIso !== undefined) {
+    normalized.endIso = window.endIso;
+  }
+  if (typeof window.reason === "string" && window.reason.trim().length > 0) {
+    normalized.reason = window.reason.trim().slice(0, 200);
+  }
+  return normalized;
+}
+
+function isWindowActive(window: GlobalPauseWindow, now: Date): boolean {
+  const startMs = Date.parse(window.startIso);
+  if (!Number.isFinite(startMs) || now.getTime() < startMs) {
+    return false;
+  }
+  if (window.endIso === undefined) {
+    return true;
+  }
+  const endMs = Date.parse(window.endIso);
+  return Number.isFinite(endMs) && now.getTime() < endMs;
+}
+
+export function createGlobalPauseStore(
+  runtime: IAgentRuntime,
+): GlobalPauseStore {
+  const cache: RuntimeCacheLike = runtime;
+
+  return {
+    async set(window: GlobalPauseWindow): Promise<void> {
+      const normalized = normalizeWindow(window);
+      await cache.setCache<GlobalPauseWindow>(
+        GLOBAL_PAUSE_CACHE_KEY,
+        normalized,
+      );
+    },
+    async clear(): Promise<void> {
+      await cache.deleteCache(GLOBAL_PAUSE_CACHE_KEY);
+    },
+    async current(now: Date = new Date()): Promise<GlobalPauseStatus> {
+      const stored = await cache.getCache<GlobalPauseWindow | null>(
+        GLOBAL_PAUSE_CACHE_KEY,
+      );
+      if (!stored || typeof stored !== "object") {
+        return { active: false };
+      }
+      if (!isValidIso(stored.startIso)) {
+        return { active: false };
+      }
+      const active = isWindowActive(stored, now);
+      const status: GlobalPauseStatus = {
+        active,
+        startIso: stored.startIso,
+      };
+      if (stored.endIso !== undefined) {
+        status.endIso = stored.endIso;
+      }
+      if (stored.reason !== undefined) {
+        status.reason = stored.reason;
+      }
+      return status;
+    },
+  };
+}

--- a/packages/agent/src/services/handoff/index.ts
+++ b/packages/agent/src/services/handoff/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Runtime handoff store: per-room handoff state gating agent contributions,
+ * surfaced through the registered {@link HandoffService}. Cache-backed (no SQL),
+ * keyed per room.
+ */
+
+export {
+  HANDOFF_SERVICE,
+  HandoffService,
+  resolveHandoffService,
+} from "./service.ts";
+export {
+  createHandoffStore,
+  describeResumeCondition,
+  evaluateResume,
+  type HandoffEnterOpts,
+  type HandoffStatus,
+  type HandoffStore,
+  type ResumeCondition,
+  type ResumeEvaluation,
+  type ResumeEvaluationInput,
+} from "./store.ts";

--- a/packages/agent/src/services/handoff/service.test.ts
+++ b/packages/agent/src/services/handoff/service.test.ts
@@ -1,0 +1,80 @@
+/**
+ * HandoffService unit test — the runtime-owned per-room handoff store.
+ *
+ * Mirrors the LifeOps room-policy contract: enter flips the room into handoff
+ * mode, status() reflects it, exit() clears it; plus the pure resume-evaluation
+ * helpers re-exported from the store. Exercised through the registered service's
+ * `getStore()` accessor.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  HANDOFF_SERVICE,
+  HandoffService,
+  resolveHandoffService,
+} from "./service.ts";
+import { evaluateResume } from "./store.ts";
+
+function makeRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "test-agent",
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+describe("HandoffService", () => {
+  it("exposes the canonical serviceType literal", () => {
+    expect(HandoffService.serviceType).toBe("eliza_handoff");
+    expect(HANDOFF_SERVICE).toBe("eliza_handoff");
+  });
+
+  it("enter + status + exit lifecycle works through the service store", async () => {
+    const runtime = makeRuntime();
+    const service = await HandoffService.start(runtime);
+    const store = service.getStore();
+    const roomId = "room-handoff-1";
+
+    expect((await store.status(roomId)).active).toBe(false);
+
+    await store.enter(roomId, {
+      reason: "handing the thread to the human",
+      resumeOn: { kind: "mention" },
+    });
+    const status = await store.status(roomId);
+    expect(status.active).toBe(true);
+    expect(status.reason).toBe("handing the thread to the human");
+    expect(status.resumeOn?.kind).toBe("mention");
+
+    // The pure resume helper re-exported through the agent store.
+    expect(evaluateResume({ status, mentionsAgent: true }).shouldResume).toBe(
+      true,
+    );
+    expect(evaluateResume({ status, mentionsAgent: false }).shouldResume).toBe(
+      false,
+    );
+
+    await store.exit(roomId);
+    expect((await store.status(roomId)).active).toBe(false);
+
+    await service.stop();
+  });
+
+  it("resolveHandoffService returns null when unregistered", () => {
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+    expect(resolveHandoffService(runtime)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/handoff/service.ts
+++ b/packages/agent/src/services/handoff/service.ts
@@ -1,0 +1,45 @@
+/**
+ * HandoffService — the runtime-owned per-room handoff state, exposed as a
+ * registered runtime service.
+ *
+ * Handoff is a runtime primitive: the room-policy provider and the
+ * `MESSAGE.handoff` resume-detection branch consume the store via
+ * `runtime.getService(...)` rather than constructing the cache-backed store
+ * itself. The service is a thin factory over the per-runtime
+ * {@link HandoffStore}; the store is cache-backed (no SQL), keyed per room.
+ *
+ * Mirrors `KnowledgeGraphService` (lifecycle + getService accessor).
+ */
+
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import { createHandoffStore, type HandoffStore } from "./store.ts";
+
+export const HANDOFF_SERVICE = "eliza_handoff";
+
+export class HandoffService extends Service {
+  static override serviceType = HANDOFF_SERVICE;
+
+  override capabilityDescription =
+    "Runtime handoff store: per-room handoff state gating agent contributions, cache-backed";
+
+  static async start(runtime: IAgentRuntime): Promise<HandoffService> {
+    return new HandoffService(runtime);
+  }
+
+  async stop(): Promise<void> {}
+
+  /** The cache-backed per-room handoff store for this runtime. */
+  getStore(): HandoffStore {
+    return createHandoffStore(this.runtime);
+  }
+}
+
+/**
+ * Resolve the registered {@link HandoffService}. Returns `null` when the
+ * runtime has not registered it (e.g. the "eliza" plugin is absent).
+ */
+export function resolveHandoffService(
+  runtime: IAgentRuntime,
+): HandoffService | null {
+  return runtime.getService<HandoffService>(HANDOFF_SERVICE);
+}

--- a/packages/agent/src/services/handoff/store.ts
+++ b/packages/agent/src/services/handoff/store.ts
@@ -1,0 +1,229 @@
+/**
+ * `HandoffStore` — per-room handoff state.
+ *
+ * When the agent says "I'll let you take it from here" in a multi-party
+ * thread, the store flips the room into handoff mode; the room-policy provider
+ * reads `status(roomId).active` and gates further agent contributions until the
+ * resume condition fires.
+ *
+ * Backing storage: runtime cache, keyed per-room. Multiple rooms can be in
+ * handoff mode simultaneously (unlike `GlobalPauseStore`, which is global).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+
+type RuntimeCacheLike = Pick<
+  IAgentRuntime,
+  "getCache" | "setCache" | "deleteCache"
+>;
+
+export type ResumeCondition =
+  | { kind: "mention" }
+  | { kind: "explicit_resume" }
+  | { kind: "silence_minutes"; minutes: number }
+  | { kind: "user_request_help"; userId: string };
+
+export interface HandoffEnterOpts {
+  reason: string;
+  resumeOn: ResumeCondition;
+}
+
+export interface HandoffStatus {
+  active: boolean;
+  enteredAt?: string;
+  reason?: string;
+  resumeOn?: ResumeCondition;
+}
+
+export interface HandoffStore {
+  enter(roomId: string, opts: HandoffEnterOpts): Promise<void>;
+  exit(roomId: string): Promise<void>;
+  status(roomId: string, now?: Date): Promise<HandoffStatus>;
+}
+
+const HANDOFF_CACHE_KEY_PREFIX = "eliza:lifeops:handoff:v1:";
+
+interface HandoffRecord {
+  roomId: string;
+  enteredAt: string;
+  reason: string;
+  resumeOn: ResumeCondition;
+}
+
+function cacheKeyForRoom(roomId: string): string {
+  return `${HANDOFF_CACHE_KEY_PREFIX}${roomId}`;
+}
+
+function isResumeCondition(value: unknown): value is ResumeCondition {
+  if (!value || typeof value !== "object") return false;
+  const cand = value as { kind?: unknown };
+  if (cand.kind === "mention") return true;
+  if (cand.kind === "explicit_resume") return true;
+  if (cand.kind === "silence_minutes") {
+    const minutes = (value as { minutes?: unknown }).minutes;
+    return (
+      typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0
+    );
+  }
+  if (cand.kind === "user_request_help") {
+    const userId = (value as { userId?: unknown }).userId;
+    return typeof userId === "string" && userId.length > 0;
+  }
+  return false;
+}
+
+function isValidRecord(value: unknown): value is HandoffRecord {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Partial<HandoffRecord>;
+  if (typeof r.roomId !== "string" || r.roomId.length === 0) return false;
+  if (
+    typeof r.enteredAt !== "string" ||
+    !Number.isFinite(Date.parse(r.enteredAt))
+  ) {
+    return false;
+  }
+  if (typeof r.reason !== "string") return false;
+  return isResumeCondition(r.resumeOn);
+}
+
+function normalizeReason(reason: string): string {
+  return reason.trim().slice(0, 200);
+}
+
+export function createHandoffStore(runtime: IAgentRuntime): HandoffStore {
+  const cache: RuntimeCacheLike = runtime;
+
+  return {
+    async enter(roomId: string, opts: HandoffEnterOpts): Promise<void> {
+      if (typeof roomId !== "string" || roomId.length === 0) {
+        throw new Error("[handoff] roomId is required");
+      }
+      if (!isResumeCondition(opts.resumeOn)) {
+        throw new Error(
+          `[handoff] invalid resumeOn: ${JSON.stringify(opts.resumeOn)}`,
+        );
+      }
+      const reason = normalizeReason(opts.reason);
+      if (reason.length === 0) {
+        throw new Error("[handoff] reason is required");
+      }
+      const record: HandoffRecord = {
+        roomId,
+        enteredAt: new Date().toISOString(),
+        reason,
+        resumeOn: opts.resumeOn,
+      };
+      await cache.setCache<HandoffRecord>(cacheKeyForRoom(roomId), record);
+    },
+
+    async exit(roomId: string): Promise<void> {
+      if (typeof roomId !== "string" || roomId.length === 0) return;
+      await cache.deleteCache(cacheKeyForRoom(roomId));
+    },
+
+    async status(
+      roomId: string,
+      _now: Date = new Date(),
+    ): Promise<HandoffStatus> {
+      void _now;
+      if (typeof roomId !== "string" || roomId.length === 0) {
+        return { active: false };
+      }
+      const stored = await cache.getCache<HandoffRecord | null>(
+        cacheKeyForRoom(roomId),
+      );
+      if (!isValidRecord(stored)) {
+        return { active: false };
+      }
+      return {
+        active: true,
+        enteredAt: stored.enteredAt,
+        reason: stored.reason,
+        resumeOn: stored.resumeOn,
+      };
+    },
+  };
+}
+
+/**
+ * Decide whether an inbound message satisfies the active resume condition,
+ * given a `HandoffStatus`. Used by the `MESSAGE.handoff` resume-detection
+ * branch and by the room-policy provider to know whether to inject the
+ * "stay-quiet" instruction.
+ *
+ * Inputs are kept minimal — callers only need to assert the room is in
+ * handoff (`status.active`) and pass message-shape facts:
+ *   - `mentionsAgent`: true if the inbound message @-mentions the agent.
+ *   - `nowIso`: time of the inbound message (defaults to now).
+ *   - `lastMessageIso`: last inbound message in the room (for
+ *     `silence_minutes`).
+ *   - `requestingUserId`: the user-id sending the inbound (for
+ *     `user_request_help`).
+ *   - `userRequestedHelp`: true if the inbound is a help request from
+ *     `requestingUserId` (planner / classifier signal).
+ */
+export interface ResumeEvaluationInput {
+  status: HandoffStatus;
+  nowIso?: string;
+  mentionsAgent?: boolean;
+  lastMessageIso?: string;
+  requestingUserId?: string;
+  userRequestedHelp?: boolean;
+}
+
+export interface ResumeEvaluation {
+  shouldResume: boolean;
+  reason?: string;
+}
+
+export function evaluateResume(input: ResumeEvaluationInput): ResumeEvaluation {
+  if (!input.status.active || !input.status.resumeOn) {
+    return { shouldResume: false };
+  }
+  const cond = input.status.resumeOn;
+  switch (cond.kind) {
+    case "mention":
+      return input.mentionsAgent === true
+        ? { shouldResume: true, reason: "mentioned" }
+        : { shouldResume: false };
+    case "explicit_resume":
+      // Explicit-resume must be triggered out-of-band via `MESSAGE.handoff`
+      // verb=resume; the planner does not auto-resume on any inbound.
+      return { shouldResume: false };
+    case "silence_minutes": {
+      const lastIso = input.lastMessageIso;
+      if (!lastIso) return { shouldResume: false };
+      const lastMs = Date.parse(lastIso);
+      if (!Number.isFinite(lastMs)) return { shouldResume: false };
+      const nowMs = input.nowIso ? Date.parse(input.nowIso) : Date.now();
+      if (!Number.isFinite(nowMs)) return { shouldResume: false };
+      const elapsedMin = (nowMs - lastMs) / 60_000;
+      return elapsedMin >= cond.minutes
+        ? { shouldResume: true, reason: `silence ≥ ${cond.minutes}m` }
+        : { shouldResume: false };
+    }
+    case "user_request_help":
+      return input.userRequestedHelp === true &&
+        input.requestingUserId === cond.userId
+        ? { shouldResume: true, reason: "user requested help" }
+        : { shouldResume: false };
+  }
+}
+
+/**
+ * Render the `ResumeCondition` to a short human-readable phrase used by
+ * the room-policy provider when injecting "do not respond unless …" into
+ * the planner context.
+ */
+export function describeResumeCondition(cond: ResumeCondition): string {
+  switch (cond.kind) {
+    case "mention":
+      return "you are @-mentioned";
+    case "explicit_resume":
+      return "the user explicitly asks to resume a handoff";
+    case "silence_minutes":
+      return `the room has been silent for at least ${cond.minutes} minute${cond.minutes === 1 ? "" : "s"}`;
+    case "user_request_help":
+      return `the participant ${cond.userId} explicitly asks the agent for help`;
+  }
+}

--- a/packages/agent/src/services/pending-prompts/index.ts
+++ b/packages/agent/src/services/pending-prompts/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Runtime pending-prompts store: open scheduled-task prompts awaiting an
+ * owner reply, surfaced through the registered {@link PendingPromptsService}.
+ * Cache-backed (no SQL), keyed per room.
+ */
+
+export {
+  PENDING_PROMPTS_SERVICE,
+  PendingPromptsService,
+  resolvePendingPromptsService,
+} from "./service.ts";
+export {
+  createPendingPromptsStore,
+  type ExpectedReplyKind,
+  type PendingPrompt,
+  type PendingPromptRecordInput,
+  type PendingPromptsStore,
+  type RecordedPendingPrompt,
+} from "./store.ts";

--- a/packages/agent/src/services/pending-prompts/service.test.ts
+++ b/packages/agent/src/services/pending-prompts/service.test.ts
@@ -1,0 +1,89 @@
+/**
+ * PendingPromptsService unit test — the runtime-owned pending-prompts store.
+ *
+ * Mirrors the LifeOps store integration test: record on fire, surface via the
+ * store, resolve on a terminal verb, and the retain-window expiry. Exercised
+ * through the registered service's `getStore()` accessor so the promotion to a
+ * runtime service preserves the cache-backed contract the scheduler reads.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  PENDING_PROMPTS_SERVICE,
+  PendingPromptsService,
+  resolvePendingPromptsService,
+} from "./service.ts";
+
+function makeRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "test-agent",
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+describe("PendingPromptsService", () => {
+  it("exposes the canonical serviceType literal", () => {
+    expect(PendingPromptsService.serviceType).toBe("eliza_pending_prompts");
+    expect(PENDING_PROMPTS_SERVICE).toBe("eliza_pending_prompts");
+  });
+
+  it("starts and exposes a cache-backed store", async () => {
+    const runtime = makeRuntime();
+    const service = await PendingPromptsService.start(runtime);
+    expect(service).toBeInstanceOf(PendingPromptsService);
+
+    const store = service.getStore();
+    const roomId = "room-checkin-1";
+    await store.record({
+      taskId: "task-checkin-1",
+      roomId,
+      promptSnippet: "How are you feeling today?",
+      firedAt: new Date().toISOString(),
+      expectedReplyKind: "free_form",
+      expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    });
+
+    const list = await store.list(roomId);
+    expect(list.length).toBe(1);
+    expect(list[0]?.taskId).toBe("task-checkin-1");
+
+    await store.resolve(roomId, "task-checkin-1");
+    expect((await store.list(roomId)).length).toBe(0);
+
+    await service.stop();
+  });
+
+  it("retains expired prompts only within the reopen window", async () => {
+    const runtime = makeRuntime();
+    const store = (await PendingPromptsService.start(runtime)).getStore();
+    const roomId = "room-checkin-2";
+    await store.record({
+      taskId: "task-old",
+      roomId,
+      promptSnippet: "old",
+      firedAt: new Date(Date.now() - 25 * 3_600_000).toISOString(),
+      expiresAt: new Date(Date.now() - 24.5 * 3_600_000).toISOString(),
+      reopenWindowHours: 24,
+    });
+    expect((await store.list(roomId)).length).toBe(0);
+  });
+
+  it("resolvePendingPromptsService returns null when unregistered", () => {
+    const runtime = {
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+    expect(resolvePendingPromptsService(runtime)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/pending-prompts/service.ts
+++ b/packages/agent/src/services/pending-prompts/service.ts
@@ -1,0 +1,48 @@
+/**
+ * PendingPromptsService — the runtime-owned store of open scheduled-task
+ * prompts, exposed as a registered runtime service.
+ *
+ * Pending prompts are a runtime primitive: any plugin (LifeOps scheduler, the
+ * work-thread evaluator, …) consumes the store via `runtime.getService(...)`
+ * rather than constructing the cache-backed store itself. The service is a thin
+ * factory over the per-runtime {@link PendingPromptsStore}; the store is
+ * cache-backed (no SQL), keyed per room.
+ *
+ * Mirrors `KnowledgeGraphService` (lifecycle + getService accessor).
+ */
+
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import {
+  createPendingPromptsStore,
+  type PendingPromptsStore,
+} from "./store.ts";
+
+export const PENDING_PROMPTS_SERVICE = "eliza_pending_prompts";
+
+export class PendingPromptsService extends Service {
+  static override serviceType = PENDING_PROMPTS_SERVICE;
+
+  override capabilityDescription =
+    "Runtime pending-prompts store: open scheduled-task prompts per room, cache-backed";
+
+  static async start(runtime: IAgentRuntime): Promise<PendingPromptsService> {
+    return new PendingPromptsService(runtime);
+  }
+
+  async stop(): Promise<void> {}
+
+  /** The cache-backed pending-prompts store for this runtime. */
+  getStore(): PendingPromptsStore {
+    return createPendingPromptsStore(this.runtime);
+  }
+}
+
+/**
+ * Resolve the registered {@link PendingPromptsService}. Returns `null` when the
+ * runtime has not registered it (e.g. the "eliza" plugin is absent).
+ */
+export function resolvePendingPromptsService(
+  runtime: IAgentRuntime,
+): PendingPromptsService | null {
+  return runtime.getService<PendingPromptsService>(PENDING_PROMPTS_SERVICE);
+}

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -1,0 +1,284 @@
+/**
+ * `PendingPromptsStore` — backing store for open scheduled-task prompts.
+ *
+ * When a `ScheduledTask` whose `completionCheck.kind === "user_replied_within"`
+ * (or implicit `user_acknowledged`) fires, the runner records the open prompt
+ * here keyed by `roomId`. When an inbound message arrives the planner uses
+ * `list(roomId)` to decide whether to route to `complete` / `acknowledge` on
+ * the open task instead of treating it as a fresh request.
+ *
+ * Retention: open prompts are retained for `expiresAt + reopenWindowHours`
+ * (default 24h) so late inbound replies still correlate. After the reopen
+ * window the entry is purged.
+ *
+ * Backing storage: runtime cache, keyed per room. Bounded per-room slot count
+ * to defend against unbounded growth in a noisy chat.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+
+type RuntimeCacheLike = Pick<
+  IAgentRuntime,
+  "getCache" | "setCache" | "deleteCache"
+>;
+
+export type ExpectedReplyKind = "any" | "yes_no" | "approval" | "free_form";
+
+export interface PendingPrompt {
+  taskId: string;
+  promptSnippet: string;
+  firedAt: string;
+  expectedReplyKind: ExpectedReplyKind;
+  expiresAt?: string;
+}
+
+export interface RecordedPendingPrompt extends PendingPrompt {
+  roomId: string;
+  /**
+   * Soft-purge cut-off. After this instant the entry is no longer returned by
+   * `list()` and is dropped on the next read. Set to
+   * `expiresAt + reopenWindowHours * 3600s`, or `firedAt + 24h` when no
+   * `expiresAt` was provided.
+   */
+  retainUntilIso: string;
+}
+
+export interface PendingPromptRecordInput {
+  taskId: string;
+  roomId: string;
+  promptSnippet: string;
+  firedAt: string;
+  expectedReplyKind?: ExpectedReplyKind;
+  expiresAt?: string;
+  /** override the default 24h reopen window */
+  reopenWindowHours?: number;
+}
+
+export interface PendingPromptsStore {
+  /** Record that a task with an open prompt has fired into a room. */
+  record(input: PendingPromptRecordInput): Promise<RecordedPendingPrompt>;
+  /** List open prompts for a room. Excludes prompts past their retain window. */
+  list(
+    roomId: string,
+    opts?: { lookbackMinutes?: number; now?: Date },
+  ): Promise<PendingPrompt[]>;
+  /** Resolve a pending prompt (called when the runner records a terminal verb). */
+  resolve(roomId: string, taskId: string): Promise<void>;
+  /** Remove all entries for a task during lifecycle cleanup. */
+  forgetTask(taskId: string): Promise<void>;
+  /** Remove every recorded entry during lifecycle cleanup. */
+  clearAll(): Promise<void>;
+}
+
+const PROMPT_SNIPPET_MAX_LENGTH = 120;
+const DEFAULT_REOPEN_WINDOW_HOURS = 24;
+const PER_ROOM_MAX_PROMPTS = 16;
+const ROOM_INDEX_KEY = "eliza:lifeops:pending-prompts:rooms:v1";
+
+function roomCacheKey(roomId: string): string {
+  return `eliza:lifeops:pending-prompts:room:${roomId}:v1`;
+}
+
+function clampSnippet(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= PROMPT_SNIPPET_MAX_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, PROMPT_SNIPPET_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+function isValidIso(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return Number.isFinite(Date.parse(value));
+}
+
+function computeRetainUntil(
+  firedAt: string,
+  expiresAt: string | undefined,
+  reopenWindowHours: number,
+): string {
+  const baseMs = expiresAt ? Date.parse(expiresAt) : Date.parse(firedAt);
+  if (!Number.isFinite(baseMs)) {
+    throw new Error("[pending-prompts] cannot compute retain window");
+  }
+  const retainMs = baseMs + reopenWindowHours * 3_600_000;
+  return new Date(retainMs).toISOString();
+}
+
+async function loadRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<RecordedPendingPrompt[]> {
+  const stored = await cache.getCache<RecordedPendingPrompt[]>(
+    roomCacheKey(roomId),
+  );
+  return Array.isArray(stored) ? stored : [];
+}
+
+async function saveRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+  entries: RecordedPendingPrompt[],
+): Promise<void> {
+  await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), entries);
+  await registerRoom(cache, roomId);
+}
+
+async function registerRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<void> {
+  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
+  const next = new Set<string>(Array.isArray(stored) ? stored : []);
+  next.add(roomId);
+  await cache.setCache<string[]>(ROOM_INDEX_KEY, [...next]);
+}
+
+async function listRooms(cache: RuntimeCacheLike): Promise<string[]> {
+  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
+  return Array.isArray(stored) ? stored : [];
+}
+
+export function createPendingPromptsStore(
+  runtime: IAgentRuntime,
+): PendingPromptsStore {
+  const cache: RuntimeCacheLike = runtime;
+
+  return {
+    async record(
+      input: PendingPromptRecordInput,
+    ): Promise<RecordedPendingPrompt> {
+      if (!input.roomId || typeof input.roomId !== "string") {
+        throw new Error("[pending-prompts] roomId is required");
+      }
+      if (!input.taskId || typeof input.taskId !== "string") {
+        throw new Error("[pending-prompts] taskId is required");
+      }
+      if (!isValidIso(input.firedAt)) {
+        throw new Error("[pending-prompts] firedAt must be ISO-8601");
+      }
+      if (input.expiresAt !== undefined && !isValidIso(input.expiresAt)) {
+        throw new Error("[pending-prompts] expiresAt must be ISO-8601");
+      }
+      const reopenWindowHours =
+        typeof input.reopenWindowHours === "number" &&
+        input.reopenWindowHours > 0
+          ? input.reopenWindowHours
+          : DEFAULT_REOPEN_WINDOW_HOURS;
+      const recorded: RecordedPendingPrompt = {
+        roomId: input.roomId,
+        taskId: input.taskId,
+        promptSnippet: clampSnippet(input.promptSnippet),
+        firedAt: input.firedAt,
+        expectedReplyKind: input.expectedReplyKind ?? "any",
+        retainUntilIso: computeRetainUntil(
+          input.firedAt,
+          input.expiresAt,
+          reopenWindowHours,
+        ),
+      };
+      if (input.expiresAt !== undefined) {
+        recorded.expiresAt = input.expiresAt;
+      }
+      const existing = await loadRoom(cache, input.roomId);
+      const filtered = existing.filter(
+        (entry) => entry.taskId !== input.taskId,
+      );
+      filtered.push(recorded);
+      // Bound per-room growth: keep newest N entries (FIFO eviction).
+      const trimmed =
+        filtered.length > PER_ROOM_MAX_PROMPTS
+          ? filtered.slice(-PER_ROOM_MAX_PROMPTS)
+          : filtered;
+      await saveRoom(cache, input.roomId, trimmed);
+      return recorded;
+    },
+
+    async list(
+      roomId: string,
+      opts: { lookbackMinutes?: number; now?: Date } = {},
+    ): Promise<PendingPrompt[]> {
+      const now = opts.now ?? new Date();
+      const lookbackCutoffMs =
+        typeof opts.lookbackMinutes === "number" && opts.lookbackMinutes > 0
+          ? now.getTime() - opts.lookbackMinutes * 60_000
+          : null;
+
+      const stored = await loadRoom(cache, roomId);
+      let mutated = false;
+      const live: RecordedPendingPrompt[] = [];
+      for (const entry of stored) {
+        const retainMs = Date.parse(entry.retainUntilIso);
+        if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
+          mutated = true;
+          continue;
+        }
+        live.push(entry);
+      }
+      if (mutated) {
+        await saveRoom(cache, roomId, live);
+      }
+
+      const visible = live.filter((entry) => {
+        if (lookbackCutoffMs === null) return true;
+        const firedMs = Date.parse(entry.firedAt);
+        return Number.isFinite(firedMs) && firedMs >= lookbackCutoffMs;
+      });
+
+      return visible
+        .slice()
+        .sort((a, b) => Date.parse(b.firedAt) - Date.parse(a.firedAt))
+        .map<PendingPrompt>((entry) => {
+          const projected: PendingPrompt = {
+            taskId: entry.taskId,
+            promptSnippet: entry.promptSnippet,
+            firedAt: entry.firedAt,
+            expectedReplyKind: entry.expectedReplyKind,
+          };
+          if (entry.expiresAt !== undefined) {
+            projected.expiresAt = entry.expiresAt;
+          }
+          return projected;
+        });
+    },
+
+    async resolve(roomId: string, taskId: string): Promise<void> {
+      const existing = await loadRoom(cache, roomId);
+      const next = existing.filter((entry) => entry.taskId !== taskId);
+      if (next.length === existing.length) {
+        return;
+      }
+      await saveRoom(cache, roomId, next);
+    },
+
+    async forgetTask(taskId: string): Promise<void> {
+      const rooms = await listRooms(cache);
+      for (const roomId of rooms) {
+        const existing = await loadRoom(cache, roomId);
+        const next = existing.filter((entry) => entry.taskId !== taskId);
+        if (next.length !== existing.length) {
+          await saveRoom(cache, roomId, next);
+        }
+      }
+    },
+
+    async clearAll(): Promise<void> {
+      const rooms = await listRooms(cache);
+      for (const roomId of rooms) {
+        if (typeof cache.deleteCache === "function") {
+          await cache.deleteCache(roomCacheKey(roomId));
+        } else {
+          await cache.setCache<RecordedPendingPrompt[]>(
+            roomCacheKey(roomId),
+            [],
+          );
+        }
+      }
+      if (typeof cache.deleteCache === "function") {
+        await cache.deleteCache(ROOM_INDEX_KEY);
+      } else {
+        await cache.setCache<string[]>(ROOM_INDEX_KEY, []);
+      }
+    },
+  };
+}

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -36,7 +36,7 @@ import type {
   Memory,
 } from "@elizaos/core";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
-import { createPendingPromptsStore } from "../lifeops/pending-prompts/store.js";
+import { resolvePendingPromptsStore } from "../lifeops/pending-prompts/store.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import type {
   ScheduledTask,
@@ -454,7 +454,7 @@ async function handleSnooze(
     ...(minutes !== undefined ? { minutes } : {}),
     ...(untilIso ? { untilIso } : {}),
   });
-  await createPendingPromptsStore(scope.runtime).forgetTask(taskId);
+  await resolvePendingPromptsStore(scope.runtime).forgetTask(taskId);
   return {
     success: true,
     text: `Snoozed scheduled task ${taskId}.`,
@@ -478,7 +478,7 @@ async function handleAcknowledge(
   const updated = await scope.runner.evaluateCompletion(taskId, {
     acknowledged: true,
   });
-  await createPendingPromptsStore(scope.runtime).forgetTask(taskId);
+  await resolvePendingPromptsStore(scope.runtime).forgetTask(taskId);
   return {
     success: true,
     text: `Acknowledged scheduled task ${taskId}.`,
@@ -506,7 +506,7 @@ async function handleVerbWithReason(
     params.reason ? { reason: params.reason } : undefined,
   );
   if (verb === "skip" || verb === "complete" || verb === "dismiss") {
-    await createPendingPromptsStore(scope.runtime).forgetTask(taskId);
+    await resolvePendingPromptsStore(scope.runtime).forgetTask(taskId);
   }
   return {
     success: true,

--- a/plugins/plugin-personal-assistant/src/lifeops/global-pause/store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/global-pause/store.ts
@@ -1,122 +1,39 @@
 /**
  * `GlobalPauseStore` — vacation / pause mode singleton.
  *
- * Only ONE pause window can be active at a time. The runner consults
- * `current()` pre-fire; tasks with `respectsGlobalPause: true` skip with
- * reason `global_pause`; tasks with `respectsGlobalPause: false` (emergencies)
- * fire anyway. If `endIso` is set on the active window, the runner reschedules
- * skipped tasks for `endIso` (the user's "resume my routine" moment).
+ * Promoted to a first-class `@elizaos/agent` runtime service in LifeOps Slice 3
+ * (`GlobalPauseService`, serviceType `eliza_global_pause`). The store
+ * implementation and its types now live inward in `@elizaos/agent`; this module
+ * re-exports them and adds {@link resolveGlobalPauseStore}, which prefers the
+ * registered runtime service (first-wins dedup) and falls back to constructing
+ * the cache-backed store directly when the service is absent.
  *
- * Backing storage: runtime cache. Single canonical key.
+ * Backing storage: runtime cache, single canonical key (unchanged).
  */
 
+import {
+  createGlobalPauseStore,
+  type GlobalPauseStore,
+  resolveGlobalPauseService,
+} from "@elizaos/agent";
 import type { IAgentRuntime } from "@elizaos/core";
-import { asCacheRuntime } from "../runtime-cache.js";
 
-export interface GlobalPauseWindow {
-  startIso: string;
-  endIso?: string;
-  reason?: string;
-}
+export {
+  createGlobalPauseStore,
+  GLOBAL_PAUSE_CACHE_KEY,
+  type GlobalPauseStatus,
+  type GlobalPauseStore,
+  type GlobalPauseWindow,
+} from "@elizaos/agent";
 
-export interface GlobalPauseStatus {
-  active: boolean;
-  startIso?: string;
-  endIso?: string;
-  reason?: string;
-}
-
-export interface GlobalPauseStore {
-  set(window: GlobalPauseWindow): Promise<void>;
-  clear(): Promise<void>;
-  current(now?: Date): Promise<GlobalPauseStatus>;
-}
-
-export const GLOBAL_PAUSE_CACHE_KEY = "eliza:lifeops:global-pause:v1";
-
-function isValidIso(value: unknown): value is string {
-  if (typeof value !== "string" || value.length === 0) {
-    return false;
-  }
-  const ms = Date.parse(value);
-  return Number.isFinite(ms);
-}
-
-function normalizeWindow(window: GlobalPauseWindow): GlobalPauseWindow {
-  if (!isValidIso(window.startIso)) {
-    throw new Error(
-      `[global-pause] invalid startIso: ${String(window.startIso)}`,
-    );
-  }
-  if (window.endIso !== undefined && !isValidIso(window.endIso)) {
-    throw new Error(`[global-pause] invalid endIso: ${String(window.endIso)}`);
-  }
-  if (
-    window.endIso !== undefined &&
-    Date.parse(window.endIso) <= Date.parse(window.startIso)
-  ) {
-    throw new Error("[global-pause] endIso must be strictly after startIso");
-  }
-  const normalized: GlobalPauseWindow = { startIso: window.startIso };
-  if (window.endIso !== undefined) {
-    normalized.endIso = window.endIso;
-  }
-  if (typeof window.reason === "string" && window.reason.trim().length > 0) {
-    normalized.reason = window.reason.trim().slice(0, 200);
-  }
-  return normalized;
-}
-
-function isWindowActive(window: GlobalPauseWindow, now: Date): boolean {
-  const startMs = Date.parse(window.startIso);
-  if (!Number.isFinite(startMs) || now.getTime() < startMs) {
-    return false;
-  }
-  if (window.endIso === undefined) {
-    return true;
-  }
-  const endMs = Date.parse(window.endIso);
-  return Number.isFinite(endMs) && now.getTime() < endMs;
-}
-
-export function createGlobalPauseStore(
+/**
+ * Resolve the global-pause store: the registered runtime service when present,
+ * else a directly-constructed cache-backed store. Both read/write the same
+ * canonical cache key, so the fallback is behaviorally identical.
+ */
+export function resolveGlobalPauseStore(
   runtime: IAgentRuntime,
 ): GlobalPauseStore {
-  const cache = asCacheRuntime(runtime);
-
-  return {
-    async set(window: GlobalPauseWindow): Promise<void> {
-      const normalized = normalizeWindow(window);
-      await cache.setCache<GlobalPauseWindow>(
-        GLOBAL_PAUSE_CACHE_KEY,
-        normalized,
-      );
-    },
-    async clear(): Promise<void> {
-      await cache.deleteCache(GLOBAL_PAUSE_CACHE_KEY);
-    },
-    async current(now: Date = new Date()): Promise<GlobalPauseStatus> {
-      const stored = await cache.getCache<GlobalPauseWindow | null>(
-        GLOBAL_PAUSE_CACHE_KEY,
-      );
-      if (!stored || typeof stored !== "object") {
-        return { active: false };
-      }
-      if (!isValidIso(stored.startIso)) {
-        return { active: false };
-      }
-      const active = isWindowActive(stored, now);
-      const status: GlobalPauseStatus = {
-        active,
-        startIso: stored.startIso,
-      };
-      if (stored.endIso !== undefined) {
-        status.endIso = stored.endIso;
-      }
-      if (stored.reason !== undefined) {
-        status.reason = stored.reason;
-      }
-      return status;
-    },
-  };
+  const service = resolveGlobalPauseService(runtime);
+  return service ? service.getStore() : createGlobalPauseStore(runtime);
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/handoff/store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/handoff/store.ts
@@ -1,225 +1,42 @@
 /**
  * `HandoffStore` — per-room handoff state.
  *
- * When the agent says "I'll let you take it from here" in a multi-party
- * thread, the store flips the room into handoff mode; the
- * `RoomPolicyProvider` reads `status(roomId).active` and gates further
- * agent contributions until the resume condition fires.
+ * Promoted to a first-class `@elizaos/agent` runtime service in LifeOps Slice 3
+ * (`HandoffService`, serviceType `eliza_handoff`). The store implementation, its
+ * types, and the pure resume-evaluation helpers (`evaluateResume`,
+ * `describeResumeCondition`) now live inward in `@elizaos/agent`; this module
+ * re-exports them and adds {@link resolveHandoffStore}, which prefers the
+ * registered runtime service (first-wins dedup) and falls back to constructing
+ * the cache-backed store directly when the service is absent.
  *
- * Backing storage: runtime cache, keyed per-room. Multiple rooms can be in
- * handoff mode simultaneously (unlike `GlobalPauseStore`, which is global).
+ * Backing storage: runtime cache, keyed per-room (unchanged).
  */
 
+import {
+  createHandoffStore,
+  type HandoffStore,
+  resolveHandoffService,
+} from "@elizaos/agent";
 import type { IAgentRuntime } from "@elizaos/core";
-import { asCacheRuntime } from "../runtime-cache.js";
 
-export type ResumeCondition =
-  | { kind: "mention" }
-  | { kind: "explicit_resume" }
-  | { kind: "silence_minutes"; minutes: number }
-  | { kind: "user_request_help"; userId: string };
-
-export interface HandoffEnterOpts {
-  reason: string;
-  resumeOn: ResumeCondition;
-}
-
-export interface HandoffStatus {
-  active: boolean;
-  enteredAt?: string;
-  reason?: string;
-  resumeOn?: ResumeCondition;
-}
-
-export interface HandoffStore {
-  enter(roomId: string, opts: HandoffEnterOpts): Promise<void>;
-  exit(roomId: string): Promise<void>;
-  status(roomId: string, now?: Date): Promise<HandoffStatus>;
-}
-
-const HANDOFF_CACHE_KEY_PREFIX = "eliza:lifeops:handoff:v1:";
-
-interface HandoffRecord {
-  roomId: string;
-  enteredAt: string;
-  reason: string;
-  resumeOn: ResumeCondition;
-}
-
-function cacheKeyForRoom(roomId: string): string {
-  return `${HANDOFF_CACHE_KEY_PREFIX}${roomId}`;
-}
-
-function isResumeCondition(value: unknown): value is ResumeCondition {
-  if (!value || typeof value !== "object") return false;
-  const cand = value as { kind?: unknown };
-  if (cand.kind === "mention") return true;
-  if (cand.kind === "explicit_resume") return true;
-  if (cand.kind === "silence_minutes") {
-    const minutes = (value as { minutes?: unknown }).minutes;
-    return (
-      typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0
-    );
-  }
-  if (cand.kind === "user_request_help") {
-    const userId = (value as { userId?: unknown }).userId;
-    return typeof userId === "string" && userId.length > 0;
-  }
-  return false;
-}
-
-function isValidRecord(value: unknown): value is HandoffRecord {
-  if (!value || typeof value !== "object") return false;
-  const r = value as Partial<HandoffRecord>;
-  if (typeof r.roomId !== "string" || r.roomId.length === 0) return false;
-  if (
-    typeof r.enteredAt !== "string" ||
-    !Number.isFinite(Date.parse(r.enteredAt))
-  ) {
-    return false;
-  }
-  if (typeof r.reason !== "string") return false;
-  return isResumeCondition(r.resumeOn);
-}
-
-function normalizeReason(reason: string): string {
-  return reason.trim().slice(0, 200);
-}
-
-export function createHandoffStore(runtime: IAgentRuntime): HandoffStore {
-  const cache = asCacheRuntime(runtime);
-
-  return {
-    async enter(roomId: string, opts: HandoffEnterOpts): Promise<void> {
-      if (typeof roomId !== "string" || roomId.length === 0) {
-        throw new Error("[handoff] roomId is required");
-      }
-      if (!isResumeCondition(opts.resumeOn)) {
-        throw new Error(
-          `[handoff] invalid resumeOn: ${JSON.stringify(opts.resumeOn)}`,
-        );
-      }
-      const reason = normalizeReason(opts.reason);
-      if (reason.length === 0) {
-        throw new Error("[handoff] reason is required");
-      }
-      const record: HandoffRecord = {
-        roomId,
-        enteredAt: new Date().toISOString(),
-        reason,
-        resumeOn: opts.resumeOn,
-      };
-      await cache.setCache<HandoffRecord>(cacheKeyForRoom(roomId), record);
-    },
-
-    async exit(roomId: string): Promise<void> {
-      if (typeof roomId !== "string" || roomId.length === 0) return;
-      await cache.deleteCache(cacheKeyForRoom(roomId));
-    },
-
-    async status(
-      roomId: string,
-      _now: Date = new Date(),
-    ): Promise<HandoffStatus> {
-      void _now;
-      if (typeof roomId !== "string" || roomId.length === 0) {
-        return { active: false };
-      }
-      const stored = await cache.getCache<HandoffRecord | null>(
-        cacheKeyForRoom(roomId),
-      );
-      if (!isValidRecord(stored)) {
-        return { active: false };
-      }
-      return {
-        active: true,
-        enteredAt: stored.enteredAt,
-        reason: stored.reason,
-        resumeOn: stored.resumeOn,
-      };
-    },
-  };
-}
+export {
+  createHandoffStore,
+  describeResumeCondition,
+  evaluateResume,
+  type HandoffEnterOpts,
+  type HandoffStatus,
+  type HandoffStore,
+  type ResumeCondition,
+  type ResumeEvaluation,
+  type ResumeEvaluationInput,
+} from "@elizaos/agent";
 
 /**
- * Decide whether an inbound message satisfies the active resume condition,
- * given a `HandoffStatus`. Used by the `MESSAGE.handoff` resume-detection
- * branch and by the `RoomPolicyProvider` to know whether to inject the
- * "stay-quiet" instruction.
- *
- * Inputs are kept minimal — callers only need to assert the room is in
- * handoff (`status.active`) and pass message-shape facts:
- *   - `mentionsAgent`: true if the inbound message @-mentions the agent.
- *   - `nowIso`: time of the inbound message (defaults to now).
- *   - `lastMessageIso`: last inbound message in the room (for
- *     `silence_minutes`).
- *   - `requestingUserId`: the user-id sending the inbound (for
- *     `user_request_help`).
- *   - `userRequestedHelp`: true if the inbound is a help request from
- *     `requestingUserId` (planner / classifier signal).
+ * Resolve the handoff store: the registered runtime service when present, else a
+ * directly-constructed cache-backed store. Both read/write the same per-room
+ * cache keys, so the fallback is behaviorally identical.
  */
-export interface ResumeEvaluationInput {
-  status: HandoffStatus;
-  nowIso?: string;
-  mentionsAgent?: boolean;
-  lastMessageIso?: string;
-  requestingUserId?: string;
-  userRequestedHelp?: boolean;
-}
-
-export interface ResumeEvaluation {
-  shouldResume: boolean;
-  reason?: string;
-}
-
-export function evaluateResume(input: ResumeEvaluationInput): ResumeEvaluation {
-  if (!input.status.active || !input.status.resumeOn) {
-    return { shouldResume: false };
-  }
-  const cond = input.status.resumeOn;
-  switch (cond.kind) {
-    case "mention":
-      return input.mentionsAgent === true
-        ? { shouldResume: true, reason: "mentioned" }
-        : { shouldResume: false };
-    case "explicit_resume":
-      // Explicit-resume must be triggered out-of-band via `MESSAGE.handoff`
-      // verb=resume; the planner does not auto-resume on any inbound.
-      return { shouldResume: false };
-    case "silence_minutes": {
-      const lastIso = input.lastMessageIso;
-      if (!lastIso) return { shouldResume: false };
-      const lastMs = Date.parse(lastIso);
-      if (!Number.isFinite(lastMs)) return { shouldResume: false };
-      const nowMs = input.nowIso ? Date.parse(input.nowIso) : Date.now();
-      if (!Number.isFinite(nowMs)) return { shouldResume: false };
-      const elapsedMin = (nowMs - lastMs) / 60_000;
-      return elapsedMin >= cond.minutes
-        ? { shouldResume: true, reason: `silence ≥ ${cond.minutes}m` }
-        : { shouldResume: false };
-    }
-    case "user_request_help":
-      return input.userRequestedHelp === true &&
-        input.requestingUserId === cond.userId
-        ? { shouldResume: true, reason: "user requested help" }
-        : { shouldResume: false };
-  }
-}
-
-/**
- * Render the `ResumeCondition` to a short human-readable phrase used by
- * the `RoomPolicyProvider` when injecting "do not respond unless …" into
- * the planner context.
- */
-export function describeResumeCondition(cond: ResumeCondition): string {
-  switch (cond.kind) {
-    case "mention":
-      return "you are @-mentioned";
-    case "explicit_resume":
-      return "the user explicitly asks to resume a handoff";
-    case "silence_minutes":
-      return `the room has been silent for at least ${cond.minutes} minute${cond.minutes === 1 ? "" : "s"}`;
-    case "user_request_help":
-      return `the participant ${cond.userId} explicitly asks the agent for help`;
-  }
+export function resolveHandoffStore(runtime: IAgentRuntime): HandoffStore {
+  const service = resolveHandoffService(runtime);
+  return service ? service.getStore() : createHandoffStore(runtime);
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/pending-prompts/store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/pending-prompts/store.ts
@@ -1,280 +1,41 @@
 /**
  * `PendingPromptsStore` — backing store for `PendingPromptsProvider`.
  *
- * When a `ScheduledTask` whose `completionCheck.kind === "user_replied_within"`
- * (or implicit `user_acknowledged`) fires, the runner records the open prompt
- * here keyed by `roomId`. When an inbound message arrives the planner uses
- * `list(roomId)` to decide whether to route to `complete` / `acknowledge` on
- * the open task instead of treating it as a fresh request.
+ * Promoted to a first-class `@elizaos/agent` runtime service in LifeOps Slice 3
+ * (`PendingPromptsService`, serviceType `eliza_pending_prompts`). The store
+ * implementation and its types now live inward in `@elizaos/agent`; this module
+ * re-exports them and adds {@link resolvePendingPromptsStore}, which prefers the
+ * registered runtime service (first-wins dedup) and falls back to constructing
+ * the cache-backed store directly when the service is absent. PA consumers
+ * resolve through the service so the store is shared runtime state.
  *
- * Retention: open prompts are retained for `expiresAt + reopenWindowHours`
- * (default 24h) so late inbound replies still correlate. After the reopen
- * window the entry is purged.
- *
- * Backing storage: runtime cache, keyed per room. Bounded per-room slot count
- * to defend against unbounded growth in a noisy chat.
+ * Backing storage: runtime cache, keyed per room (unchanged).
  */
 
+import {
+  createPendingPromptsStore,
+  type PendingPromptsStore,
+  resolvePendingPromptsService,
+} from "@elizaos/agent";
 import type { IAgentRuntime } from "@elizaos/core";
-import { asCacheRuntime, type RuntimeCacheLike } from "../runtime-cache.js";
 
-export type ExpectedReplyKind = "any" | "yes_no" | "approval" | "free_form";
+export {
+  createPendingPromptsStore,
+  type ExpectedReplyKind,
+  type PendingPrompt,
+  type PendingPromptRecordInput,
+  type PendingPromptsStore,
+  type RecordedPendingPrompt,
+} from "@elizaos/agent";
 
-export interface PendingPrompt {
-  taskId: string;
-  promptSnippet: string;
-  firedAt: string;
-  expectedReplyKind: ExpectedReplyKind;
-  expiresAt?: string;
-}
-
-export interface RecordedPendingPrompt extends PendingPrompt {
-  roomId: string;
-  /**
-   * Soft-purge cut-off. After this instant the entry is no longer returned by
-   * `list()` and is dropped on the next read. Set to
-   * `expiresAt + reopenWindowHours * 3600s`, or `firedAt + 24h` when no
-   * `expiresAt` was provided.
-   */
-  retainUntilIso: string;
-}
-
-export interface PendingPromptRecordInput {
-  taskId: string;
-  roomId: string;
-  promptSnippet: string;
-  firedAt: string;
-  expectedReplyKind?: ExpectedReplyKind;
-  expiresAt?: string;
-  /** override the default 24h reopen window */
-  reopenWindowHours?: number;
-}
-
-export interface PendingPromptsStore {
-  /** Record that a task with an open prompt has fired into a room. */
-  record(input: PendingPromptRecordInput): Promise<RecordedPendingPrompt>;
-  /** List open prompts for a room. Excludes prompts past their retain window. */
-  list(
-    roomId: string,
-    opts?: { lookbackMinutes?: number; now?: Date },
-  ): Promise<PendingPrompt[]>;
-  /** Resolve a pending prompt (called when the runner records a terminal verb). */
-  resolve(roomId: string, taskId: string): Promise<void>;
-  /** Remove all entries for a task during lifecycle cleanup. */
-  forgetTask(taskId: string): Promise<void>;
-  /** Remove every recorded entry during lifecycle cleanup. */
-  clearAll(): Promise<void>;
-}
-
-const PROMPT_SNIPPET_MAX_LENGTH = 120;
-const DEFAULT_REOPEN_WINDOW_HOURS = 24;
-const PER_ROOM_MAX_PROMPTS = 16;
-const ROOM_INDEX_KEY = "eliza:lifeops:pending-prompts:rooms:v1";
-
-function roomCacheKey(roomId: string): string {
-  return `eliza:lifeops:pending-prompts:room:${roomId}:v1`;
-}
-
-function clampSnippet(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.length <= PROMPT_SNIPPET_MAX_LENGTH) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, PROMPT_SNIPPET_MAX_LENGTH - 1).trimEnd()}…`;
-}
-
-function isValidIso(value: unknown): value is string {
-  if (typeof value !== "string" || value.length === 0) return false;
-  return Number.isFinite(Date.parse(value));
-}
-
-function computeRetainUntil(
-  firedAt: string,
-  expiresAt: string | undefined,
-  reopenWindowHours: number,
-): string {
-  const baseMs = expiresAt ? Date.parse(expiresAt) : Date.parse(firedAt);
-  if (!Number.isFinite(baseMs)) {
-    throw new Error("[pending-prompts] cannot compute retain window");
-  }
-  const retainMs = baseMs + reopenWindowHours * 3_600_000;
-  return new Date(retainMs).toISOString();
-}
-
-async function loadRoom(
-  cache: RuntimeCacheLike,
-  roomId: string,
-): Promise<RecordedPendingPrompt[]> {
-  const stored = await cache.getCache<RecordedPendingPrompt[]>(
-    roomCacheKey(roomId),
-  );
-  return Array.isArray(stored) ? stored : [];
-}
-
-async function saveRoom(
-  cache: RuntimeCacheLike,
-  roomId: string,
-  entries: RecordedPendingPrompt[],
-): Promise<void> {
-  await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), entries);
-  await registerRoom(cache, roomId);
-}
-
-async function registerRoom(
-  cache: RuntimeCacheLike,
-  roomId: string,
-): Promise<void> {
-  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
-  const next = new Set<string>(Array.isArray(stored) ? stored : []);
-  next.add(roomId);
-  await cache.setCache<string[]>(ROOM_INDEX_KEY, [...next]);
-}
-
-async function listRooms(cache: RuntimeCacheLike): Promise<string[]> {
-  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
-  return Array.isArray(stored) ? stored : [];
-}
-
-export function createPendingPromptsStore(
+/**
+ * Resolve the pending-prompts store: the registered runtime service when
+ * present, else a directly-constructed cache-backed store. Both read/write the
+ * same per-room cache keys, so the fallback is behaviorally identical.
+ */
+export function resolvePendingPromptsStore(
   runtime: IAgentRuntime,
 ): PendingPromptsStore {
-  const cache = asCacheRuntime(runtime);
-
-  return {
-    async record(
-      input: PendingPromptRecordInput,
-    ): Promise<RecordedPendingPrompt> {
-      if (!input.roomId || typeof input.roomId !== "string") {
-        throw new Error("[pending-prompts] roomId is required");
-      }
-      if (!input.taskId || typeof input.taskId !== "string") {
-        throw new Error("[pending-prompts] taskId is required");
-      }
-      if (!isValidIso(input.firedAt)) {
-        throw new Error("[pending-prompts] firedAt must be ISO-8601");
-      }
-      if (input.expiresAt !== undefined && !isValidIso(input.expiresAt)) {
-        throw new Error("[pending-prompts] expiresAt must be ISO-8601");
-      }
-      const reopenWindowHours =
-        typeof input.reopenWindowHours === "number" &&
-        input.reopenWindowHours > 0
-          ? input.reopenWindowHours
-          : DEFAULT_REOPEN_WINDOW_HOURS;
-      const recorded: RecordedPendingPrompt = {
-        roomId: input.roomId,
-        taskId: input.taskId,
-        promptSnippet: clampSnippet(input.promptSnippet),
-        firedAt: input.firedAt,
-        expectedReplyKind: input.expectedReplyKind ?? "any",
-        retainUntilIso: computeRetainUntil(
-          input.firedAt,
-          input.expiresAt,
-          reopenWindowHours,
-        ),
-      };
-      if (input.expiresAt !== undefined) {
-        recorded.expiresAt = input.expiresAt;
-      }
-      const existing = await loadRoom(cache, input.roomId);
-      const filtered = existing.filter(
-        (entry) => entry.taskId !== input.taskId,
-      );
-      filtered.push(recorded);
-      // Bound per-room growth: keep newest N entries (FIFO eviction).
-      const trimmed =
-        filtered.length > PER_ROOM_MAX_PROMPTS
-          ? filtered.slice(-PER_ROOM_MAX_PROMPTS)
-          : filtered;
-      await saveRoom(cache, input.roomId, trimmed);
-      return recorded;
-    },
-
-    async list(
-      roomId: string,
-      opts: { lookbackMinutes?: number; now?: Date } = {},
-    ): Promise<PendingPrompt[]> {
-      const now = opts.now ?? new Date();
-      const lookbackCutoffMs =
-        typeof opts.lookbackMinutes === "number" && opts.lookbackMinutes > 0
-          ? now.getTime() - opts.lookbackMinutes * 60_000
-          : null;
-
-      const stored = await loadRoom(cache, roomId);
-      let mutated = false;
-      const live: RecordedPendingPrompt[] = [];
-      for (const entry of stored) {
-        const retainMs = Date.parse(entry.retainUntilIso);
-        if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
-          mutated = true;
-          continue;
-        }
-        live.push(entry);
-      }
-      if (mutated) {
-        await saveRoom(cache, roomId, live);
-      }
-
-      const visible = live.filter((entry) => {
-        if (lookbackCutoffMs === null) return true;
-        const firedMs = Date.parse(entry.firedAt);
-        return Number.isFinite(firedMs) && firedMs >= lookbackCutoffMs;
-      });
-
-      return visible
-        .slice()
-        .sort((a, b) => Date.parse(b.firedAt) - Date.parse(a.firedAt))
-        .map<PendingPrompt>((entry) => {
-          const projected: PendingPrompt = {
-            taskId: entry.taskId,
-            promptSnippet: entry.promptSnippet,
-            firedAt: entry.firedAt,
-            expectedReplyKind: entry.expectedReplyKind,
-          };
-          if (entry.expiresAt !== undefined) {
-            projected.expiresAt = entry.expiresAt;
-          }
-          return projected;
-        });
-    },
-
-    async resolve(roomId: string, taskId: string): Promise<void> {
-      const existing = await loadRoom(cache, roomId);
-      const next = existing.filter((entry) => entry.taskId !== taskId);
-      if (next.length === existing.length) {
-        return;
-      }
-      await saveRoom(cache, roomId, next);
-    },
-
-    async forgetTask(taskId: string): Promise<void> {
-      const rooms = await listRooms(cache);
-      for (const roomId of rooms) {
-        const existing = await loadRoom(cache, roomId);
-        const next = existing.filter((entry) => entry.taskId !== taskId);
-        if (next.length !== existing.length) {
-          await saveRoom(cache, roomId, next);
-        }
-      }
-    },
-
-    async clearAll(): Promise<void> {
-      const rooms = await listRooms(cache);
-      for (const roomId of rooms) {
-        if (typeof cache.deleteCache === "function") {
-          await cache.deleteCache(roomCacheKey(roomId));
-        } else {
-          await cache.setCache<RecordedPendingPrompt[]>(
-            roomCacheKey(roomId),
-            [],
-          );
-        }
-      }
-      if (typeof cache.deleteCache === "function") {
-        await cache.deleteCache(ROOM_INDEX_KEY);
-      } else {
-        await cache.setCache<string[]>(ROOM_INDEX_KEY, []);
-      }
-    },
-  };
+  const service = resolvePendingPromptsService(runtime);
+  return service ? service.getStore() : createPendingPromptsStore(runtime);
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -10,60 +10,47 @@
 import crypto from "node:crypto";
 import { getAgentEventService } from "@elizaos/agent";
 import { getHostExecutionCapabilities } from "@elizaos/app-core/services/task-host-capabilities";
-import { type IAgentRuntime, ServiceType, logger } from "@elizaos/core";
-import { getChannelRegistry } from "../channels/index.js";
-import type { DispatchResult } from "../connectors/contract.js";
-
-import { createGlobalPauseStore } from "../global-pause/store.js";
-import {
-  ownerFactsToView,
-  resolveOwnerFactStore,
-} from "../owner/fact-store.js";
-import {
-  createAnchorRegistry,
-  getAnchorRegistry,
-  registerAnchorRegistry,
-  registerAppLifeOpsAnchors,
-} from "@elizaos/plugin-scheduling";
-import { LifeOpsRepository } from "../repository.js";
-import { getSendPolicyRegistry } from "../send-policy/index.js";
-import { getActivitySignalBus } from "../signals/bus.js";
-import {
-  createCompletionCheckRegistry,
-  registerBuiltInCompletionChecks,
-} from "@elizaos/plugin-scheduling";
-import {
-  createConsolidationRegistry,
-  registerFallbackAnchors,
-} from "@elizaos/plugin-scheduling";
-import {
-  createEscalationLadderRegistry,
-  registerDefaultEscalationLadders,
-} from "@elizaos/plugin-scheduling";
-import {
-  createTaskGateRegistry,
-  registerBuiltInGates,
-} from "@elizaos/plugin-scheduling";
-import type {
-  ScheduledTaskDispatcher,
-  ScheduledTaskDispatchRecord,
-} from "@elizaos/plugin-scheduling";
-import {
-  createScheduledTaskRunner,
-  type ScheduledTaskRunnerHandle,
-  type ScheduledTaskStore,
-} from "@elizaos/plugin-scheduling";
-import type { ScheduledTaskLogStore } from "@elizaos/plugin-scheduling";
+import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
 import type {
   ActivitySignalBusView,
   GlobalPauseView,
   OwnerFactsView,
   ScheduledTask,
+  ScheduledTaskDispatcher,
+  ScheduledTaskDispatchRecord,
   ScheduledTaskFilter,
   ScheduledTaskLogEntry,
+  ScheduledTaskLogStore,
   SubjectStoreView,
   TaskExecutionProfile,
 } from "@elizaos/plugin-scheduling";
+import {
+  createAnchorRegistry,
+  createCompletionCheckRegistry,
+  createConsolidationRegistry,
+  createEscalationLadderRegistry,
+  createScheduledTaskRunner,
+  createTaskGateRegistry,
+  getAnchorRegistry,
+  registerAnchorRegistry,
+  registerAppLifeOpsAnchors,
+  registerBuiltInCompletionChecks,
+  registerBuiltInGates,
+  registerDefaultEscalationLadders,
+  registerFallbackAnchors,
+  type ScheduledTaskRunnerHandle,
+  type ScheduledTaskStore,
+} from "@elizaos/plugin-scheduling";
+import { getChannelRegistry } from "../channels/index.js";
+import type { DispatchResult } from "../connectors/contract.js";
+import { resolveGlobalPauseStore } from "../global-pause/store.js";
+import {
+  ownerFactsToView,
+  resolveOwnerFactStore,
+} from "../owner/fact-store.js";
+import { LifeOpsRepository } from "../repository.js";
+import { getSendPolicyRegistry } from "../send-policy/index.js";
+import { getActivitySignalBus } from "../signals/bus.js";
 
 interface RepositoryBackedStores {
   store: ScheduledTaskStore;
@@ -426,7 +413,7 @@ export function createRuntimeScheduledTaskRunner(
   // still inject overrides via the options bag. The diagnostic shims warn-once
   // on missing wiring so silent always-allow / always-false defaults are gone.
   const globalPause: GlobalPauseView =
-    opts.globalPause ?? createGlobalPauseStore(opts.runtime);
+    opts.globalPause ?? resolveGlobalPauseStore(opts.runtime);
   const activity: ActivitySignalBusView =
     opts.activity ??
     getActivitySignalBus(opts.runtime) ??

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -1,25 +1,24 @@
 import { type IAgentRuntime, logger } from "@elizaos/core";
-
-import {
-  ownerFactsToView,
-  resolveOwnerFactStore,
-} from "../owner/fact-store.js";
-import {
-  createPendingPromptsStore,
-  type RecordedPendingPrompt,
-} from "../pending-prompts/store.js";
-import { getAnchorRegistry } from "@elizaos/plugin-scheduling";
-import { LifeOpsRepository } from "../repository.js";
+import type { ScheduledTask } from "@elizaos/plugin-scheduling";
 import {
   expectedReplyKindForTask,
+  getAnchorRegistry,
   isCompletionTimeoutDue,
   isRecurringTrigger,
   isScheduledTaskDue,
   markWindowFireIfNeeded,
   pendingPromptRoomIdForTask,
 } from "@elizaos/plugin-scheduling";
+import {
+  ownerFactsToView,
+  resolveOwnerFactStore,
+} from "../owner/fact-store.js";
+import {
+  type RecordedPendingPrompt,
+  resolvePendingPromptsStore,
+} from "../pending-prompts/store.js";
+import { LifeOpsRepository } from "../repository.js";
 import { getScheduledTaskRunner } from "./service.js";
-import type { ScheduledTask } from "@elizaos/plugin-scheduling";
 
 export interface ProcessDueScheduledTasksRequest {
   runtime: IAgentRuntime;
@@ -68,7 +67,7 @@ async function recordPendingPromptIfNeeded(args: {
   if (!shouldRecordPendingPrompt(args.result)) return null;
   const roomId = pendingPromptRoomIdForTask(args.result);
   if (!roomId || !args.result.state.firedAt) return null;
-  const store = createPendingPromptsStore(args.runtime);
+  const store = resolvePendingPromptsStore(args.runtime);
   return store.record({
     roomId,
     taskId: args.result.taskId,

--- a/plugins/plugin-personal-assistant/src/lifeops/work-threads/field-evaluator-thread-ops.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/work-threads/field-evaluator-thread-ops.ts
@@ -26,7 +26,7 @@ import type {
   ResponseHandlerFieldEvaluator,
   ResponseHandlerFieldHandleContext,
 } from "@elizaos/core";
-import { createPendingPromptsStore } from "../pending-prompts/store.js";
+import { resolvePendingPromptsStore } from "../pending-prompts/store.js";
 import { createWorkThreadStore } from "./store.js";
 import type { ThreadSourceRef } from "./types.js";
 
@@ -188,7 +188,7 @@ async function threadOpsShouldRun(
       roomId,
       limit: 1,
     }),
-    createPendingPromptsStore(ctx.runtime).list(roomId, {
+    resolvePendingPromptsStore(ctx.runtime).list(roomId, {
       lookbackMinutes: 60 * 24,
     }),
   ]);

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -29,8 +29,8 @@ import {
   registerHealthConnectors,
   registerHealthDefaultPacks,
 } from "@elizaos/plugin-health";
-import { remindersPlugin } from "@elizaos/plugin-reminders";
 import { inboxPlugin } from "@elizaos/plugin-inbox/plugin";
+import { remindersPlugin } from "@elizaos/plugin-reminders";
 import { remoteDesktopPlugin } from "@elizaos/plugin-remote-desktop";
 import { XDmAdapter } from "@elizaos/plugin-x/lifeops-message-adapter";
 import { blockAction } from "./actions/block.js";
@@ -1107,9 +1107,7 @@ const rawPersonalAssistantPlugin: Plugin = {
 
 export const personalAssistantPlugin: Plugin = rawPersonalAssistantPlugin;
 
-export {
-  appBlockerProvider,
-} from "@elizaos/plugin-blocker/providers/app-blocker";
+export { appBlockerProvider } from "@elizaos/plugin-blocker/providers/app-blocker";
 export {
   getAppBlockerPermissionState,
   getAppBlockerStatus,
@@ -1172,6 +1170,7 @@ export {
   type GlobalPauseStatus,
   type GlobalPauseStore,
   type GlobalPauseWindow,
+  resolveGlobalPauseStore,
 } from "./lifeops/global-pause/store.js";
 export {
   createHandoffStore,
@@ -1183,6 +1182,7 @@ export {
   type ResumeCondition,
   type ResumeEvaluation,
   type ResumeEvaluationInput,
+  resolveHandoffStore,
 } from "./lifeops/handoff/store.js";
 export {
   createMultilingualPromptRegistry,
@@ -1217,6 +1217,7 @@ export {
   createPendingPromptsStore,
   type PendingPromptRecordInput,
   type PendingPromptsStore,
+  resolvePendingPromptsStore,
 } from "./lifeops/pending-prompts/store.js";
 // LifeOps runtime exports
 export {

--- a/plugins/plugin-personal-assistant/src/providers/pending-prompts.ts
+++ b/plugins/plugin-personal-assistant/src/providers/pending-prompts.ts
@@ -27,9 +27,9 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import {
-  createPendingPromptsStore,
   type PendingPrompt,
   type PendingPromptsStore,
+  resolvePendingPromptsStore,
 } from "../lifeops/pending-prompts/store.js";
 
 export type { PendingPrompt };
@@ -79,7 +79,7 @@ export function renderPendingPromptsText(prompts: PendingPrompt[]): string {
 export function createPendingPromptsProvider(
   runtime: IAgentRuntime,
 ): PendingPromptsProvider {
-  const store: PendingPromptsStore = createPendingPromptsStore(runtime);
+  const store: PendingPromptsStore = resolvePendingPromptsStore(runtime);
   return {
     list: (roomId: string, opts) => store.list(roomId, opts),
   };
@@ -111,7 +111,7 @@ export const pendingPromptsProvider: Provider = {
 
     let store: PendingPromptsStore;
     try {
-      store = createPendingPromptsStore(runtime);
+      store = resolvePendingPromptsStore(runtime);
     } catch (error) {
       logger.debug(
         "[pending-prompts-provider] store unavailable:",

--- a/plugins/plugin-personal-assistant/src/providers/room-policy.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.ts
@@ -21,8 +21,8 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import {
-  createHandoffStore,
   describeResumeCondition,
+  resolveHandoffStore,
 } from "../lifeops/handoff/store.js";
 
 const QUIET_RESULT: ProviderResult = {
@@ -56,9 +56,9 @@ export const roomPolicyProvider: Provider = {
       return QUIET_RESULT;
     }
 
-    let store: ReturnType<typeof createHandoffStore>;
+    let store: ReturnType<typeof resolveHandoffStore>;
     try {
-      store = createHandoffStore(runtime);
+      store = resolveHandoffStore(runtime);
     } catch (error) {
       logger.debug(
         "[room-policy-provider] handoff store unavailable:",

--- a/plugins/plugin-personal-assistant/test/stubs/agent.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/agent.ts
@@ -1,6 +1,20 @@
 import os from "node:os";
 import path from "node:path";
 
+export {
+  createGlobalPauseStore,
+  GLOBAL_PAUSE_SERVICE,
+  GlobalPauseService,
+  resolveGlobalPauseService,
+} from "../../../../packages/agent/src/services/global-pause/index.ts";
+export {
+  createHandoffStore,
+  describeResumeCondition,
+  evaluateResume,
+  HANDOFF_SERVICE,
+  HandoffService,
+  resolveHandoffService,
+} from "../../../../packages/agent/src/services/handoff/index.ts";
 // The runtime knowledge graph (entity/relationship stores + service + schema)
 // is owned by @elizaos/agent. Re-export the real implementations here: they
 // are self-contained (only @elizaos/core, @elizaos/shared, drizzle-orm) and do
@@ -14,6 +28,16 @@ export {
   RelationshipStore,
   resolveKnowledgeGraphService,
 } from "../../../../packages/agent/src/services/knowledge-graph/index.ts";
+// Cache-backed runtime stores promoted from LifeOps (Slice 3). Like the
+// knowledge graph above, they are self-contained (only @elizaos/core) and the
+// personal-assistant store shims import them from `@elizaos/agent`, so re-export
+// the genuine implementations here for the test lane.
+export {
+  createPendingPromptsStore,
+  PENDING_PROMPTS_SERVICE,
+  PendingPromptsService,
+  resolvePendingPromptsService,
+} from "../../../../packages/agent/src/services/pending-prompts/index.ts";
 
 export class DatabaseSync {}
 


### PR DESCRIPTION
## LifeOps Slice 3 — promote cache-backed stores to `@elizaos/agent` runtime services

Executes **Slice 3** of the LifeOps extraction plan
(`plugins/plugin-personal-assistant/docs/lifeops-extraction-plan.md` §"Slice 3 —
Promote pending-prompts / global-pause / handoff to @elizaos/agent runtime
services"), per the owner's "decompose, no umbrella" decision (neutral `eliza_*`
serviceTypes).

The three PA-internal, cache-backed (verified zero-SQL) stores become first-class
runtime services, mirroring `KnowledgeGraphService` exactly (lifecycle +
`getService` accessor).

### What moved

**New `@elizaos/agent` runtime services** (`packages/agent/src/services/`):

| Dir | serviceType | Class | Accessor |
|---|---|---|---|
| `pending-prompts/` | `eliza_pending_prompts` | `PendingPromptsService` | `resolvePendingPromptsService` |
| `global-pause/` | `eliza_global_pause` | `GlobalPauseService` | `resolveGlobalPauseService` |
| `handoff/` | `eliza_handoff` | `HandoffService` | `resolveHandoffService` |

Each dir holds the **copied** store ops (`store.ts`), a `class XService extends
Service` over them (`service.ts`), and a barrel (`index.ts`). Bodies were lifted
verbatim from the PA store files; cache access uses the runtime directly (the
runtime is `RuntimeCacheLike`), matching the knowledge-graph service.

**Registration** — the three classes are added to `createElizaPlugin()`
`services[]` in `packages/agent/src/runtime/eliza-plugin.ts`, alongside
`KnowledgeGraphService`, and named-re-exported from `packages/agent/src/index.ts`
(KG pattern — kept out of the broad services barrel to avoid TS2308).

**PA delegation** — the three PA store files
(`plugins/plugin-personal-assistant/src/lifeops/{pending-prompts,global-pause,handoff}/store.ts`)
now re-export the canonical impl/types from `@elizaos/agent` and add a
`resolveXStore(runtime)` helper that prefers the registered runtime service
(first-wins dedup) and falls back to constructing the cache-backed store directly
when the service is absent. Both paths hit the same cache keys, so the fallback
is behaviorally identical. PA consumers — pending-prompts/room-policy providers,
the work-thread field evaluator, the scheduler, the `SCHEDULED_TASKS` action, and
the scheduled-task runtime-wiring — resolve through the helper.

**Inward-only law preserved** — `@elizaos/agent` never imports
`@elizaos/plugin-personal-assistant`; bodies were copied inward, PA's copies now
delegate. All runtime string literals (cache keys, serviceType strings) are
preserved.

### Test evidence

- `bun run --cwd packages/agent typecheck` → **0 errors**.
- `bun run --cwd plugins/plugin-personal-assistant build:types` → **clean**;
  PA `tsgo` = **475 errors == pre-existing baseline**, **0 in any touched file**
  (the baseline lives in unrelated files: `client-lifeops.ts`,
  `lifeops-routes.ts`, `connector.ts`, …).
- New focused unit tests (mirroring the KG/store tests), one per service —
  `packages/agent/src/services/{pending-prompts,global-pause,handoff}/service.test.ts`:
  **10/10 passing** (serviceType literal, lifecycle, store round-trip,
  `resolveXService` → null when unregistered).
- PA consumer tests exercising the changed call sites —
  `pending-prompts.integration`, `global-pause.integration`, `room-policy`,
  `thread-ops-field-evaluator`: **all passing**.
- Full PA unit suite: **539 passing**. The 8 failing files are **pre-existing,
  environment-only** and unrelated to this slice — 6 fail on a known PA-vitest
  resolution defect (`@elizaos/agent/security/access` subpath shadowed by the
  bare `find: "@elizaos/agent"` alias, triggered by `plugin-inbox/src`), 1 is the
  mobile-only AppBlocker Capacitor stub, 1 is a desktop-build UI text assertion.
  All fail identically on the parent develop commit and for a trivial direct
  `import("@elizaos/agent/security/access")` probe — i.e. independent of this
  change. The `decomposition-integration.test.ts` gate is one of the 6 caught by
  that same resolution defect; its actual invariant for this slice (no collision
  on the three new `eliza_*` serviceTypes) is verified separately — `rg` confirms
  the three literals are otherwise unused repo-wide.
- `bunx biome check` on all 25 touched files → **clean**.

Plan reference:
`plugins/plugin-personal-assistant/docs/lifeops-extraction-plan.md` §"Slice 3".

Closes the Slice 3 item of #8833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
