### PR TITLE
docs(computeruse): mark M9 Set-of-Marks landed in parity audit + coverage guard (#9170)

### DIFF
--- a/plugins/plugin-computeruse/docs/TRYCUA_PARITY_AUDIT.md
+++ b/plugins/plugin-computeruse/docs/TRYCUA_PARITY_AUDIT.md
@@ -66,7 +66,7 @@ Legend: ✅ have · 🟡 partial · ❌ missing · ⛔ N/A (deliberately not cha
 | predict / ground split (cheap ground vs full predict) | 🟡 (M5) | `OcrCoordinateGroundingActor` + per-Scene grounding cache; no model-string registry yet |
 | accessibility-tree grounding tier | ✅ | scene `a11y-provider` (Win UIA / macOS AX / Linux AT-SPI) |
 | OmniParser/icon detection (GGUF, no ONNX) | 🟡 | `yolo-detector.ts` (YOLOv8n COCO GGUF via `native/yolo.cpp`) |
-| **Set-of-Marks (numbered overlay) grounding** | ❌ (M9) | no `plugin-vision/src/som.ts` yet |
+| **Set-of-Marks (numbered overlay) grounding** | ✅ (M9) | `plugin-vision/src/som.ts` + `set-of-marks-provider.ts`; registered via `registerSetOfMarksProvider` seam in `mobile/ocr-provider.ts` |
 
 ### Windows / files / process / shell
 | trycua capability | elizaOS status | Where |
@@ -147,23 +147,28 @@ from the action enum so a newly-added trycua verb that lacks a per-OS test fails
 ## 5. Remaining roadmap (prioritized)
 
 1. **M14 cross-platform real lanes** *(highest leverage for the stated goal)* —
-   Linux Xvfb + macOS headful real-driver lanes; enum-derived parity guard so every
-   verb has a per-OS test. Closes the "tests of every single thing they do, on all
-   platforms" requirement that the win32-only gate currently leaves open.
-2. **M9 Set-of-Marks** — `plugin-vision/src/som.ts` (GGUF YOLO + CoordOcr merge,
-   icon-over-text suppression, NMS dedup, 1-indexed numbered overlay) via
-   `registerCoordOcrProvider`.
-3. **M12 additive verbs** — window getters (`get_current_window_id`,
+   The enum-derived parity coverage guard (`cua-parity-coverage.test.ts`) is
+   **landed** and runs on all platforms in the default lane, and the real lane is
+   no longer win32-hardcoded. The remaining piece is the **Linux Xvfb + macOS
+   headful CI lanes** that actually invoke the real config (requires a
+   `.github/workflows/**` change / `workflow` token scope). Until those exist,
+   real-driver *actuation* is verified on Windows only.
+2. **M12 additive verbs** — window getters (`get_current_window_id`,
    `get_application_windows`, `get/set_window_size`, `get_window_position`),
    `open`/`launch`, and the filesystem/`run_command` verbs (wrap the existing
    internal `file-ops.ts`/`terminal.ts` as gated `COMPUTER_USE` verbs).
-4. **M10 agent-loop registry** + predict_step/predict_click split (extend the Actor
+3. **M10 agent-loop registry** + predict_step/predict_click split (extend the Actor
    registry; keep approval gating).
-5. **M11 callback middleware** — budget cap, image-retention (only-N-recent, aligns
+4. **M11 callback middleware** — budget cap, image-retention (only-N-recent, aligns
    with M3), operator-normalizer, trajectory.
-6. **M13 provider matrix + RPC seam** — Windows Sandbox (WSB) + QEMU behind a
+5. **M13 provider matrix + RPC seam** — Windows Sandbox (WSB) + QEMU behind a
    remote-guest `{command,params}→{success,result}` RPC over the route/WS seam.
-7. **AOSP `multitouch_gesture`** (MT-Protocol-B) + an optional MCP server seam.
+6. **AOSP `multitouch_gesture`** (MT-Protocol-B) + an optional MCP server seam.
+
+**Done since this audit was first written:** M9 Set-of-Marks (numbered-overlay
+grounding) landed — `plugin-vision/src/som.ts` + `set-of-marks-provider.ts`,
+registered via the `registerSetOfMarksProvider` seam; 23/23 unit tests green on
+Windows.
 
 > **Process note for contributors:** the `*.real.test.ts` lanes only execute on a
 > Windows host. Before trusting any newly-landed computeruse milestone, run its

--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
@@ -95,8 +95,7 @@ const CAPABILITIES: Capability[] = [
   {
     cua: "set_of_marks_overlay",
     domain: "vision",
-    status: "missing",
-    milestone: "M9",
+    status: "have", // M9: plugin-vision som.ts + set-of-marks-provider via registerSetOfMarksProvider seam
   },
   // ── window ────────────────────────────────────────────────────────────────
   { cua: "window_list", domain: "window", status: "have", verb: "list" },
@@ -214,6 +213,18 @@ describe("cua parity surface (all platforms)", () => {
   it("clipboard read/write are promoted CLIPBOARD actions", () => {
     expect(actionNames).toContain("CLIPBOARD_READ");
     expect(actionNames).toContain("CLIPBOARD_WRITE");
+  });
+
+  it("Set-of-Marks (M9) registry seam exists for plugin-vision to wire", () => {
+    // M9 is a grounding capability (no discrete verb): plugin-vision builds the
+    // numbered overlay (som.ts) and registers it through this seam. Assert the
+    // seam is present so the `have` status above can't silently regress.
+    const ocrProviderSrc = readFileSync(
+      join(testDir, "..", "mobile", "ocr-provider.ts"),
+      "utf8",
+    );
+    expect(ocrProviderSrc).toContain("registerSetOfMarksProvider");
+    expect(ocrProviderSrc).toContain("SetOfMarksProvider");
   });
 });
 


### PR DESCRIPTION
M9 (Set-of-Marks numbered-overlay grounding) landed on develop (`96c82cbeb4`) —
`plugin-vision/src/som.ts` + `set-of-marks-provider.ts`, registered via the
`registerSetOfMarksProvider` seam. The just-merged parity coverage guard (#9195)
and audit doc (#9193) still listed it as **missing**; this corrects them so the
machine-checkable registry stays accurate.

- `cua-parity-coverage.test.ts`: `set_of_marks_overlay` missing → **have**, plus a
  static assertion that the `registerSetOfMarksProvider` seam exists in
  `mobile/ocr-provider.ts` (so the `have` status can't silently regress). **26/26
  pass, typecheck 0.**
- `TRYCUA_PARITY_AUDIT.md`: SoM row ❌→✅; M9 dropped from the remaining roadmap;
  M14 item refreshed (coverage guard landed + real lane un-gated; remaining piece
  is the Linux Xvfb + macOS headful CI lanes that need `workflow` scope).

M9 verified green on Windows: `som.test.ts` + `set-of-marks-provider.test.ts` 23/23.

Docs/tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)