### PR TITLE
feat(ui): dynamic priority-ranking core for the home widget surface (#9143)

### DIFF
--- a/packages/ui/src/widgets/home-priority.test.ts
+++ b/packages/ui/src/widgets/home-priority.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  baseHomeScore,
+  HOME_SIGNAL_WEIGHTS,
+  type HomeWidgetSignal,
+  homeSignalWeight,
+  rankHomeWidgets,
+  scoreHomeWidget,
+} from "./home-priority";
+
+const NOW = 1_000_000_000_000;
+const widget = (id: string, order?: number) => ({
+  id,
+  pluginId: "p",
+  order,
+});
+
+describe("baseHomeScore", () => {
+  it("maps lower order to higher base (pinned widgets rank first)", () => {
+    expect(baseHomeScore(0)).toBe(1);
+    expect(baseHomeScore(50)).toBeCloseTo(0.5);
+    expect(baseHomeScore(100)).toBe(0);
+  });
+
+  it("defaults missing/invalid order to 100 (base 0)", () => {
+    expect(baseHomeScore(undefined)).toBe(0);
+    expect(baseHomeScore(Number.NaN)).toBe(0);
+  });
+
+  it("clamps order > 100 to a non-negative base", () => {
+    expect(baseHomeScore(250)).toBe(0);
+  });
+});
+
+describe("homeSignalWeight", () => {
+  it("weights urgent event types above ambient ones", () => {
+    expect(homeSignalWeight("blocked")).toBeGreaterThan(
+      homeSignalWeight("activity"),
+    );
+    expect(homeSignalWeight("reminder")).toBeGreaterThan(
+      homeSignalWeight("workflow"),
+    );
+  });
+
+  it("falls back to the activity weight for unknown types", () => {
+    expect(homeSignalWeight("totally-unknown")).toBe(
+      HOME_SIGNAL_WEIGHTS.activity,
+    );
+  });
+});
+
+describe("scoreHomeWidget", () => {
+  it("returns the base score when there are no signals", () => {
+    expect(scoreHomeWidget(widget("a", 0), [], { now: NOW })).toBe(1);
+  });
+
+  it("adds a fresh signal's full weight on top of base", () => {
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/a", weight: 10, timestamp: NOW },
+    ];
+    // base(order 100)=0 + 10 * decay(0)=10
+    expect(scoreHomeWidget(widget("a", 100), signals, { now: NOW })).toBe(10);
+  });
+
+  it("decays a signal by recency (half-life)", () => {
+    const halfLife = 30 * 60_000;
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/a", weight: 8, timestamp: NOW - halfLife },
+    ];
+    // one half-life old → 8 * 0.5 = 4
+    expect(
+      scoreHomeWidget(widget("a", 100), signals, {
+        now: NOW,
+        signalHalfLifeMs: halfLife,
+      }),
+    ).toBeCloseTo(4);
+  });
+
+  it("ignores signals older than the max age", () => {
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/a", weight: 100, timestamp: NOW - 7 * 60 * 60_000 },
+    ];
+    expect(
+      scoreHomeWidget(widget("a", 0), signals, {
+        now: NOW,
+        signalMaxAgeMs: 6 * 60 * 60_000,
+      }),
+    ).toBe(1); // only base survives
+  });
+
+  it("only counts signals attributed to this widget", () => {
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/other", weight: 99, timestamp: NOW },
+    ];
+    expect(scoreHomeWidget(widget("a", 100), signals, { now: NOW })).toBe(0);
+  });
+});
+
+describe("rankHomeWidgets — dynamic importance, top-N", () => {
+  it("a live attention signal floats a low-base widget to the top", () => {
+    const decls = [widget("pinned", 0), widget("noisy", 100)];
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/noisy", weight: 10, timestamp: NOW },
+    ];
+    const ranked = rankHomeWidgets(decls, signals, { now: NOW });
+    expect(ranked.map((r) => r.declaration.id)).toEqual(["noisy", "pinned"]);
+  });
+
+  it("orders quiet widgets by base priority", () => {
+    const decls = [widget("low", 100), widget("high", 10), widget("mid", 50)];
+    const ranked = rankHomeWidgets(decls, [], { now: NOW });
+    expect(ranked.map((r) => r.declaration.id)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("caps the result to maxVisible (only the most important show)", () => {
+    const decls = Array.from({ length: 10 }, (_, i) => widget(`w${i}`, i * 10));
+    const ranked = rankHomeWidgets(decls, [], { now: NOW, maxVisible: 3 });
+    expect(ranked).toHaveLength(3);
+    expect(ranked.map((r) => r.declaration.id)).toEqual(["w0", "w1", "w2"]);
+  });
+
+  it("breaks ties deterministically by widget key (no reshuffle)", () => {
+    const decls = [widget("b", 50), widget("a", 50)];
+    const ranked = rankHomeWidgets(decls, [], { now: NOW });
+    expect(ranked.map((r) => r.declaration.id)).toEqual(["a", "b"]);
+  });
+
+  it("minScore above base hides declared-but-quiet widgets, keeps active ones", () => {
+    const decls = [widget("quiet", 0), widget("active", 100)];
+    const signals: HomeWidgetSignal[] = [
+      { widgetKey: "p/active", weight: 5, timestamp: NOW },
+    ];
+    // base max is 1; minScore 1.5 requires live attention to clear the bar.
+    const ranked = rankHomeWidgets(decls, signals, { now: NOW, minScore: 1.5 });
+    expect(ranked.map((r) => r.declaration.id)).toEqual(["active"]);
+  });
+
+  it("returns nothing for maxVisible 0", () => {
+    expect(
+      rankHomeWidgets([widget("a")], [], { now: NOW, maxVisible: 0 }),
+    ).toEqual([]);
+  });
+});

--- a/packages/ui/src/widgets/home-priority.ts
+++ b/packages/ui/src/widgets/home-priority.ts
@@ -1,0 +1,159 @@
+/**
+ * Home-widget priority ranking (#9143).
+ *
+ * The frontpage/home surface must NOT render every `home`-slot widget — it
+ * should surface only the highest-importance widgets *right now*, the way a
+ * phone home screen bubbles up what needs attention. This module is the pure
+ * ranking core: it scores each home widget by a stable base priority plus any
+ * recent attention/activity signals (decayed by recency), then returns the
+ * top-N ordered by current importance.
+ *
+ * It is deliberately decoupled from React and from how signals are sourced:
+ * callers (the home WidgetHost) map their live `ActivityEvent` stream into
+ * {@link HomeWidgetSignal}s and pass `now` in, so the function is pure and
+ * deterministic (no `Date.now()` in a render path — see the UI determinism
+ * gate). The signal→widget attribution and event-stream wiring live in the
+ * consumer, not here.
+ */
+
+import type { PluginWidgetDeclaration } from "./types";
+
+/** Minimal declaration shape the ranking needs (decoupled from the full type). */
+export type RankableHomeWidget = Pick<
+  PluginWidgetDeclaration,
+  "id" | "pluginId" | "order"
+>;
+
+/** A live importance signal attributed to a single home widget. */
+export interface HomeWidgetSignal {
+  /** `${pluginId}/${id}` of the widget this signal boosts. */
+  widgetKey: string;
+  /** Raw importance weight (higher = more urgent). */
+  weight: number;
+  /** Epoch-ms when the signal occurred — used for recency decay. */
+  timestamp: number;
+}
+
+export interface RankHomeWidgetsOptions {
+  /** Current time (epoch-ms). Passed in for determinism + testability. */
+  now: number;
+  /** Maximum widgets the home surface shows. Default 6. */
+  maxVisible?: number;
+  /** Half-life of an attention signal's boost, in ms. Default 30 min. */
+  signalHalfLifeMs?: number;
+  /** Signals at or beyond this age contribute nothing. Default 6 h. */
+  signalMaxAgeMs?: number;
+  /**
+   * Minimum score a widget must reach to be shown. Default 0 (keep every
+   * declared widget, capped to `maxVisible`). Raise it above the maximum base
+   * score (1) to require live attention — i.e. hide widgets that are merely
+   * declared but have no recent activity.
+   */
+  minScore?: number;
+}
+
+export interface RankedHomeWidget<D extends RankableHomeWidget> {
+  declaration: D;
+  /** Combined base-priority + decayed-attention score (higher = shown first). */
+  score: number;
+}
+
+const DEFAULT_MAX_VISIBLE = 6;
+const DEFAULT_HALF_LIFE_MS = 30 * 60_000;
+const DEFAULT_MAX_AGE_MS = 6 * 60 * 60_000;
+
+/**
+ * Default importance weights for the common activity/attention event types a
+ * consumer maps into {@link HomeWidgetSignal}s. Exported so the home WidgetHost
+ * (and tests) share one notion of "how urgent is this kind of event" rather
+ * than re-deriving it. Unknown event types should fall back to `activity`.
+ */
+export const HOME_SIGNAL_WEIGHTS: Readonly<Record<string, number>> = {
+  blocked: 10,
+  escalation: 10,
+  approval: 9,
+  reminder: 6,
+  message: 5,
+  "check-in": 4,
+  nudge: 3,
+  workflow: 2,
+  activity: 1,
+};
+
+/** Resolve an event type to its importance weight (falls back to `activity`). */
+export function homeSignalWeight(eventType: string): number {
+  return HOME_SIGNAL_WEIGHTS[eventType] ?? HOME_SIGNAL_WEIGHTS.activity;
+}
+
+/** The stable widget key used to attribute signals to a declaration. */
+export function homeWidgetKey(decl: RankableHomeWidget): string {
+  return `${decl.pluginId}/${decl.id}`;
+}
+
+/**
+ * Stable base importance derived from the declaration `order` (lower order =
+ * higher base), normalized to roughly `[0, 1]` so a single fresh attention
+ * signal outranks base ordering but base still breaks ties between cold
+ * widgets. `order` defaults to 100 (the registry default).
+ */
+export function baseHomeScore(order: number | undefined): number {
+  const resolved =
+    typeof order === "number" && Number.isFinite(order) ? order : 100;
+  return Math.max(0, 100 - resolved) / 100;
+}
+
+function recencyMultiplier(
+  ageMs: number,
+  halfLifeMs: number,
+  maxAgeMs: number,
+): number {
+  const age = ageMs < 0 ? 0 : ageMs; // a future-stamped signal counts as "now"
+  if (age >= maxAgeMs) return 0;
+  return 0.5 ** (age / halfLifeMs);
+}
+
+/**
+ * Current importance of one home widget: stable base priority plus the sum of
+ * its recent attention signals, each decayed by how long ago it fired.
+ */
+export function scoreHomeWidget(
+  decl: RankableHomeWidget,
+  signals: readonly HomeWidgetSignal[],
+  opts: RankHomeWidgetsOptions,
+): number {
+  const halfLife = opts.signalHalfLifeMs ?? DEFAULT_HALF_LIFE_MS;
+  const maxAge = opts.signalMaxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const key = homeWidgetKey(decl);
+  let attention = 0;
+  for (const signal of signals) {
+    if (signal.widgetKey !== key) continue;
+    attention +=
+      signal.weight *
+      recencyMultiplier(opts.now - signal.timestamp, halfLife, maxAge);
+  }
+  return baseHomeScore(decl.order) + attention;
+}
+
+/**
+ * Rank home widgets by current importance and return only the top-N. Ordering
+ * is descending by score; ties break deterministically by widget key so the
+ * home surface never reshuffles equal-importance widgets between renders.
+ */
+export function rankHomeWidgets<D extends RankableHomeWidget>(
+  declarations: readonly D[],
+  signals: readonly HomeWidgetSignal[],
+  opts: RankHomeWidgetsOptions,
+): RankedHomeWidget<D>[] {
+  const maxVisible = opts.maxVisible ?? DEFAULT_MAX_VISIBLE;
+  const minScore = opts.minScore ?? 0;
+  return declarations
+    .map((declaration) => ({
+      declaration,
+      key: homeWidgetKey(declaration),
+      score: scoreHomeWidget(declaration, signals, opts),
+    }))
+    .filter((entry) => entry.score >= minScore)
+    .sort((a, b) => b.score - a.score || a.key.localeCompare(b.key))
+    .slice(0, Math.max(0, maxVisible))
+    .map(({ declaration, score }) => ({ declaration, score }));
+}

--- a/packages/ui/src/widgets/index.ts
+++ b/packages/ui/src/widgets/index.ts
@@ -1,3 +1,15 @@
+export {
+  baseHomeScore,
+  HOME_SIGNAL_WEIGHTS,
+  type HomeWidgetSignal,
+  homeSignalWeight,
+  homeWidgetKey,
+  type RankableHomeWidget,
+  type RankedHomeWidget,
+  type RankHomeWidgetsOptions,
+  rankHomeWidgets,
+  scoreHomeWidget,
+} from "./home-priority";
 export type { WidgetPluginState } from "./registry";
 
 export {


### PR DESCRIPTION
Follow-up to the merged foundational slice (`27ab45dbfb`, which added the `home` slot + mounted `<WidgetHost slot="home">`). That mount renders home widgets by **static `order`**; per the design intent, the home screen should instead surface **only the highest-importance widgets right now** — bubbling up what needs attention, phone-home-screen style.

This PR adds the pure ranking core (`packages/ui/src/widgets/home-priority.ts`), the data layer the home surface will rank with:

- **`scoreHomeWidget`** = stable base priority (from `order`, lower = higher) **plus** the sum of recent attention signals, each **decayed by recency** (configurable half-life, default 30 min; signals past a max age, default 6 h, contribute nothing).
- **`rankHomeWidgets`** returns the **top-N** by current importance, with a deterministic key tie-break so equal-importance widgets never reshuffle between renders.
- **`HOME_SIGNAL_WEIGHTS` / `homeSignalWeight`** — one shared notion of how urgent each activity event type is (`blocked`/`escalation` > `reminder`/`message` > `activity`), with an `activity` fallback for unknown types.
- **`minScore`** lets a surface require live attention (hide declared-but-quiet widgets) without changing the default "show top-N including quiet ones, ordered by base".

Pure and React-free by design: callers map their live `ActivityEvent` stream into `HomeWidgetSignal`s and pass `now` in, so it's deterministic and satisfies the UI determinism gate (no `Date.now()` in a render path). Signal→widget attribution and the event-stream wiring live in the consumer.

**Next chunk:** wire this into the ViewCatalog home mount (rank + cap the rendered widgets, derive signals from `useActivityEvents`).

## Tests
`home-priority.test.ts` — 16 cases: base ordering (pinned-first), signal weighting, recency half-life decay, max-age cutoff, per-widget attribution, top-N cap, deterministic tie-break, and `minScore` gating. `bun run --cwd packages/ui test -- home-priority` → 16/16. `typecheck` + `biome` green.

Additive: a new module + barrel export only; no edits to `WidgetHost`/`ViewCatalog`/registry, so it cannot regress the merged foundational slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)