### PR TITLE
test(core): task-scheduler tick-error-logging regression coverage (#9152)

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
+import type { IDatabaseAdapter } from "../types/database";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { Task } from "../types/task";
+import {
+	registerTaskSchedulerRuntime,
+	startTaskScheduler,
+	stopTaskScheduler,
+} from "./task-scheduler.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+function makeRuntime(): IAgentRuntime {
+	return { agentId: AGENT_ID } as unknown as IAgentRuntime;
+}
+
+/**
+ * Drive a single scheduler tick: advance the fake timer to fire the interval,
+ * then let the rejected/resolved tick promise settle on the microtask queue.
+ */
+async function runOneTick(): Promise<void> {
+	await vi.advanceTimersByTimeAsync(1000);
+}
+
+describe("task-scheduler", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		errorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		stopTaskScheduler();
+		errorSpy.mockRestore();
+		vi.useRealTimers();
+	});
+
+	it("logs the error and keeps ticking when getTasks rejects", async () => {
+		const failure = new Error("db outage");
+		let getTasksCalls = 0;
+		const adapter = {
+			getTasks: vi.fn(async () => {
+				getTasksCalls += 1;
+				throw failure;
+			}),
+		} as unknown as IDatabaseAdapter;
+
+		startTaskScheduler(adapter);
+		const taskService = { runTick: vi.fn(async () => undefined) };
+		registerTaskSchedulerRuntime(makeRuntime(), taskService);
+
+		await runOneTick();
+
+		// The rejection is surfaced through the structured logger, not swallowed.
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		const [context, message] = errorSpy.mock.calls[0];
+		expect(context).toMatchObject({ err: failure });
+		expect(message).toContain("tick failed");
+
+		// Scheduling continues: a fresh dirty agent on the next tick still queries.
+		expect(getTasksCalls).toBe(1);
+		registerTaskSchedulerRuntime(makeRuntime(), taskService);
+		await runOneTick();
+		expect(getTasksCalls).toBe(2);
+		expect(errorSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not log when getTasks succeeds", async () => {
+		const task = { id: "t1", agentId: AGENT_ID } as unknown as Task;
+		const adapter = {
+			getTasks: vi.fn(async () => [task]),
+		} as unknown as IDatabaseAdapter;
+
+		startTaskScheduler(adapter);
+		const runTick = vi.fn(async () => undefined);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick });
+
+		await runOneTick();
+
+		expect(runTick).toHaveBeenCalledTimes(1);
+		expect(runTick).toHaveBeenCalledWith([task]);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Reference: #9152.

The production fix — logging the task-scheduler `tick().catch` error via the structured logger instead of swallowing it — **already landed on develop** via `b97f361c9d` (`logger.error({ err }, "[TaskScheduler] tick failed")` in `packages/core/src/services/task-scheduler.ts`). The superseded branch `fix/9152-task-scheduler-error-logging` was a duplicate of that production change, but it carried one yieldable artifact that never made it to develop: the regression **test**. This PR lands only that missing test — no production code is touched.

## What the test covers (`packages/core/src/services/task-scheduler.test.ts`)

- **getTasks rejects → logs and keeps ticking:** when the batched `getTasks` throws (e.g. DB outage), the rejection is surfaced through `logger.error` (`{ err }`, message contains `tick failed`) rather than swallowed, and the scheduler keeps firing — a freshly-registered dirty agent on the next tick still queries.
- **getTasks succeeds → no error logged:** a normal tick dispatches `runTick(tasks)` and logs no error.

The test was adapted to assert against develop's *current* production message (`tick failed` substring) so it passes without modifying production code.

## Verification (against develop's existing scheduler, no prod change)

```
$ bun run --cwd packages/core test -- task-scheduler

 ✓ packages/core/src/services/task-scheduler.test.ts > task-scheduler > logs the error and keeps ticking when getTasks rejects 5ms
 ✓ packages/core/src/services/task-scheduler.test.ts > task-scheduler > does not log when getTasks succeeds 1ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

- `bun run --cwd packages/core typecheck` — clean
- biome check on the test file — clean (No fixes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)