### PR TITLE
refactor(agent): promote approval-queue to ApprovalService (LifeOps Slice 4) (#8833)

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -228,6 +228,30 @@ export * from "./runtime/trajectory-persistence.ts";
 export * from "./runtime/trajectory-query.ts";
 export * from "./runtime/version.ts";
 export * from "./security/index.ts";
+// Runtime owner-approval queue promoted from LifeOps (Slice 4). Named
+// re-export — same rationale as the knowledge graph / pending-prompts below:
+// keep it out of the broad services barrel to avoid TS2308.
+export {
+  APPROVAL_SERVICE,
+  type ApprovalAction,
+  type ApprovalChannel,
+  type ApprovalEnqueueInput,
+  type ApprovalListFilter,
+  ApprovalNotFoundError,
+  type ApprovalPayload,
+  type ApprovalQueue,
+  type ApprovalQueueOptions,
+  type ApprovalRequest,
+  type ApprovalRequestState,
+  type ApprovalResolution,
+  ApprovalService,
+  ApprovalStateTransitionError,
+  type ApprovalTravelCalendarSync,
+  type ApprovalTravelPassenger,
+  createApprovalQueue,
+  PgApprovalQueue,
+  resolveApprovalService,
+} from "./services/approval/index.ts";
 export * from "./services/cove-quote.ts";
 export * from "./services/dstack-tee-provider.ts";
 export {

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -54,6 +54,7 @@ import { createOngoingTasksProvider } from "../providers/tasks.ts";
 import { uiCatalogProvider } from "../providers/ui-catalog.ts";
 import { createUserNameProvider } from "../providers/user-name.ts";
 import { createWorkspaceProvider } from "../providers/workspace-provider.ts";
+import { ApprovalService } from "../services/approval/index.ts";
 import { ElizaCharacterPersistenceService } from "../services/character-persistence.ts";
 import { LocalFileStorageService } from "../services/file-storage.ts";
 import { GlobalPauseService } from "../services/global-pause/index.ts";
@@ -141,6 +142,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       PendingPromptsService as ServiceClass,
       GlobalPauseService as ServiceClass,
       HandoffService as ServiceClass,
+      ApprovalService as ServiceClass,
     ],
 
     init: async (_pluginConfig, runtime: IAgentRuntime) => {

--- a/packages/agent/src/services/approval/index.ts
+++ b/packages/agent/src/services/approval/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Runtime owner-approval queue: enqueue/list/resolve outbound-action approvals
+ * over the `approval_requests` table (owned by `@elizaos/plugin-sql`, public
+ * schema), surfaced through the registered {@link ApprovalService}.
+ */
+
+export {
+  APPROVAL_SERVICE,
+  ApprovalService,
+  resolveApprovalService,
+} from "./service.ts";
+export { createApprovalQueue, PgApprovalQueue } from "./store.ts";
+export {
+  type ApprovalAction,
+  type ApprovalChannel,
+  type ApprovalEnqueueInput,
+  type ApprovalListFilter,
+  ApprovalNotFoundError,
+  type ApprovalPayload,
+  type ApprovalQueue,
+  type ApprovalQueueOptions,
+  type ApprovalRequest,
+  type ApprovalRequestState,
+  type ApprovalResolution,
+  ApprovalStateTransitionError,
+  type ApprovalTravelCalendarSync,
+  type ApprovalTravelPassenger,
+} from "./types.ts";

--- a/packages/agent/src/services/approval/service.test.ts
+++ b/packages/agent/src/services/approval/service.test.ts
@@ -1,0 +1,362 @@
+/**
+ * ApprovalService unit test — the runtime-owned owner-approval queue.
+ *
+ * Drives the promoted `PgApprovalQueue` through the registered service's
+ * `getQueue()` accessor against an in-memory fake of the `approval_requests`
+ * table (the public-schema table owned by `@elizaos/plugin-sql`). The raw SQL
+ * is unchanged from the LifeOps source, so this exercises the exact INSERT /
+ * SELECT / UPDATE … RETURNING shapes the queue emits and asserts the
+ * state-machine contract is preserved across the promotion to a runtime
+ * service.
+ *
+ * The drizzle `sql.raw` shim hands the store our raw SQL text directly; the
+ * fake `adapter.db.execute` interprets it against an in-memory row map. We only
+ * model the query shapes the store emits — not a general SQL engine.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  APPROVAL_SERVICE,
+  type ApprovalEnqueueInput,
+  ApprovalNotFoundError,
+  ApprovalService,
+  ApprovalStateTransitionError,
+  resolveApprovalService,
+} from "./index.ts";
+
+vi.mock("drizzle-orm", () => ({
+  sql: {
+    raw: (text: string) => ({ __sql: text, queryChunks: [text] }),
+  },
+}));
+
+const SELECT_COLUMNS = [
+  "id",
+  "state",
+  "requested_by",
+  "subject_user_id",
+  "action",
+  "payload",
+  "channel",
+  "reason",
+  "expires_at",
+  "resolved_at",
+  "resolved_by",
+  "resolution_reason",
+  "created_at",
+  "updated_at",
+];
+
+/** Split a parenthesised, comma-separated value list, respecting quotes. */
+function splitValues(inner: string): string[] {
+  const values: string[] = [];
+  let buf = "";
+  let inSingle = false;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    if (inSingle) {
+      buf += ch;
+      if (ch === "'") {
+        if (inner[i + 1] === "'") {
+          buf += "'";
+          i += 1;
+        } else {
+          inSingle = false;
+        }
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      buf += ch;
+      continue;
+    }
+    if (ch === ",") {
+      values.push(buf.trim());
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf.trim().length > 0) values.push(buf.trim());
+  return values;
+}
+
+function unquote(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "NULL") return null;
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+interface WhereClause {
+  id?: string;
+  agent_id?: string;
+  subject_user_id?: string;
+  state?: string;
+  action?: string;
+  expiresAtMax?: string;
+}
+
+function parseWhere(whereSql: string): WhereClause {
+  const clause: WhereClause = {};
+  for (const cond of whereSql.split(/\bAND\b/i).map((s) => s.trim())) {
+    const eq = cond.match(/^(\w+)\s*=\s*('(?:[^']|'')*')$/);
+    if (eq) {
+      const [, col, val] = eq;
+      const value = unquote(val);
+      if (value !== null) (clause as Record<string, string>)[col] = value;
+      continue;
+    }
+    const le = cond.match(/^expires_at\s*<=\s*('(?:[^']|'')*')$/);
+    if (le) {
+      const v = unquote(le[1]);
+      if (v !== null) clause.expiresAtMax = v;
+    }
+  }
+  return clause;
+}
+
+function matches(row: Record<string, unknown>, clause: WhereClause): boolean {
+  if (clause.id !== undefined && row.id !== clause.id) return false;
+  if (clause.agent_id !== undefined && row.agent_id !== clause.agent_id) {
+    return false;
+  }
+  if (
+    clause.subject_user_id !== undefined &&
+    row.subject_user_id !== clause.subject_user_id
+  ) {
+    return false;
+  }
+  if (clause.state !== undefined && row.state !== clause.state) return false;
+  if (clause.action !== undefined && row.action !== clause.action) return false;
+  if (
+    clause.expiresAtMax !== undefined &&
+    String(row.expires_at) > clause.expiresAtMax
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** Parse `col = value` assignments out of a `SET …` fragment. */
+function parseSet(setSql: string): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  for (const assign of splitValues(setSql)) {
+    const m = assign.match(/^(\w+)\s*=\s*([\s\S]+)$/);
+    if (m) out[m[1]] = unquote(m[2]);
+  }
+  return out;
+}
+
+function createApprovalTableRuntime(agentId: string): IAgentRuntime {
+  const rows = new Map<string, Record<string, unknown>>();
+
+  const execute = (
+    sqlText: string,
+  ): { rows: Array<Record<string, unknown>> } => {
+    const trimmed = sqlText.trim();
+
+    if (/^INSERT\s+INTO\s+approval_requests/i.test(trimmed)) {
+      const colsMatch = trimmed.match(/\(([\s\S]+?)\)\s*VALUES/i);
+      const valsMatch = trimmed.match(/VALUES\s*\(([\s\S]+?)\)\s*RETURNING/i);
+      if (!colsMatch || !valsMatch) throw new Error("bad INSERT in mock");
+      const columns = colsMatch[1].split(",").map((s) => s.trim());
+      const values = splitValues(valsMatch[1]);
+      const row: Record<string, unknown> = {};
+      columns.forEach((col, idx) => {
+        row[col] = unquote(values[idx] ?? "NULL");
+      });
+      rows.set(String(row.id), row);
+      return { rows: [projectSelect(row)] };
+    }
+
+    if (/^SELECT\s+/i.test(trimmed)) {
+      const whereMatch = trimmed.match(
+        /WHERE\s+([\s\S]+?)(?:\s+ORDER\s+BY|\s+LIMIT|$)/i,
+      );
+      const clause = whereMatch ? parseWhere(whereMatch[1]) : {};
+      let result = Array.from(rows.values()).filter((r) => matches(r, clause));
+      result = result.sort((a, b) =>
+        String(b.created_at).localeCompare(String(a.created_at)),
+      );
+      const limitMatch = trimmed.match(/LIMIT\s+(\d+)/i);
+      if (limitMatch) result = result.slice(0, Number(limitMatch[1]));
+      return { rows: result.map(projectSelect) };
+    }
+
+    if (/^UPDATE\s+approval_requests/i.test(trimmed)) {
+      const setMatch = trimmed.match(/SET\s+([\s\S]+?)\s+WHERE/i);
+      const whereMatch = trimmed.match(/WHERE\s+([\s\S]+?)\s+RETURNING/i);
+      if (!setMatch || !whereMatch) throw new Error("bad UPDATE in mock");
+      const assignments = parseSet(setMatch[1]);
+      const clause = parseWhere(whereMatch[1]);
+      const returnsId = /RETURNING\s+id\s*$/i.test(trimmed);
+      const updated: Array<Record<string, unknown>> = [];
+      for (const row of rows.values()) {
+        if (!matches(row, clause)) continue;
+        for (const [col, val] of Object.entries(assignments)) row[col] = val;
+        updated.push(row);
+      }
+      if (returnsId) return { rows: updated.map((r) => ({ id: r.id })) };
+      return { rows: updated.map(projectSelect) };
+    }
+
+    throw new Error(
+      `unsupported SQL in approval mock: ${trimmed.slice(0, 40)}`,
+    );
+  };
+
+  function projectSelect(
+    row: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const col of SELECT_COLUMNS) out[col] = row[col] ?? null;
+    return out;
+  }
+
+  return {
+    agentId,
+    adapter: {
+      db: {
+        execute: async (chunks: { __sql?: string }) =>
+          execute(chunks.__sql ?? ""),
+      },
+    },
+    getService: () => null,
+  } as unknown as IAgentRuntime;
+}
+
+function messageInput(
+  overrides: Partial<ApprovalEnqueueInput> = {},
+): ApprovalEnqueueInput {
+  return {
+    requestedBy: "agent:lifeops",
+    subjectUserId: "owner-123",
+    action: "send_message",
+    payload: {
+      action: "send_message",
+      recipient: "+15555551212",
+      body: "Hello!",
+      replyToMessageId: null,
+    },
+    channel: "sms",
+    reason: "agent wants to confirm before sending",
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+describe("ApprovalService", () => {
+  it("exposes the canonical serviceType literal", () => {
+    expect(ApprovalService.serviceType).toBe("eliza_approval");
+    expect(APPROVAL_SERVICE).toBe("eliza_approval");
+  });
+
+  it("resolveApprovalService returns null when unregistered", () => {
+    const runtime = { getService: () => null } as unknown as IAgentRuntime;
+    expect(resolveApprovalService(runtime)).toBeNull();
+  });
+
+  it("enqueue → approve → markExecuting → markDone happy path", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+
+    const enqueued = await queue.enqueue(messageInput());
+    expect(enqueued.state).toBe("pending");
+    expect(enqueued.resolvedAt).toBeNull();
+    expect(enqueued.action).toBe("send_message");
+
+    const fetched = await queue.byId(enqueued.id);
+    expect(fetched?.id).toBe(enqueued.id);
+
+    const approved = await queue.approve(enqueued.id, {
+      resolvedBy: "owner-123",
+      resolutionReason: "looks good",
+    });
+    expect(approved.state).toBe("approved");
+    expect(approved.resolvedBy).toBe("owner-123");
+    expect(approved.resolvedAt).toBeInstanceOf(Date);
+
+    const executing = await queue.markExecuting(enqueued.id);
+    expect(executing.state).toBe("executing");
+
+    const done = await queue.markDone(enqueued.id);
+    expect(done.state).toBe("done");
+
+    const pendingList = await queue.list({
+      subjectUserId: "owner-123",
+      state: "pending",
+      action: null,
+      limit: 10,
+    });
+    expect(pendingList.every((r) => r.id !== enqueued.id)).toBe(true);
+  });
+
+  it("enqueue → reject records the resolver", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(
+      messageInput({ subjectUserId: "owner-reject" }),
+    );
+    const rejected = await queue.reject(enqueued.id, {
+      resolvedBy: "owner-reject",
+      resolutionReason: "not now",
+    });
+    expect(rejected.state).toBe("rejected");
+    expect(rejected.resolutionReason).toBe("not now");
+  });
+
+  it("purgeExpired moves past-due pending rows to expired", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(
+      messageInput({
+        subjectUserId: "owner-expire",
+        expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+      }),
+    );
+    const purgedIds = await queue.purgeExpired(new Date());
+    expect(purgedIds).toContain(enqueued.id);
+    const after = await queue.byId(enqueued.id);
+    expect(after?.state).toBe("expired");
+  });
+
+  it("rejects invalid state transitions hard", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(
+      messageInput({ subjectUserId: "owner-invalid" }),
+    );
+    // pending -> executing is illegal; must go through approved first.
+    await expect(queue.markExecuting(enqueued.id)).rejects.toBeInstanceOf(
+      ApprovalStateTransitionError,
+    );
+    await expect(queue.markDone(enqueued.id)).rejects.toBeInstanceOf(
+      ApprovalStateTransitionError,
+    );
+  });
+
+  it("throws ApprovalNotFoundError on unknown id", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    await expect(
+      queue.approve("00000000-0000-0000-0000-000000000000", {
+        resolvedBy: "owner-123",
+        resolutionReason: "x",
+      }),
+    ).rejects.toBeInstanceOf(ApprovalNotFoundError);
+  });
+
+  it("scopes rows by agentId (no cross-agent reads)", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const service = await ApprovalService.start(runtime);
+    const enqueued = await service.getQueue("agent-1").enqueue(messageInput());
+    // A queue for a different agentId must not see agent-1's row.
+    const otherQueue = service.getQueue("agent-2");
+    expect(await otherQueue.byId(enqueued.id)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/approval/service.ts
+++ b/packages/agent/src/services/approval/service.ts
@@ -1,0 +1,52 @@
+/**
+ * ApprovalService — the runtime-owned owner-approval queue, exposed as a
+ * registered runtime service.
+ *
+ * The approval queue is a runtime primitive: any plugin (LifeOps outbound
+ * sends, document signatures, travel booking, …) consumes it via
+ * `runtime.getService(...)` rather than constructing the DB-backed queue
+ * itself. The service is a thin factory over {@link PgApprovalQueue}, backed by
+ * the `approval_requests` table owned by `@elizaos/plugin-sql` (public schema);
+ * the `agentId` is the multi-tenant partition key and defaults to
+ * `runtime.agentId`.
+ *
+ * Mirrors `KnowledgeGraphService` (lifecycle + getService accessor).
+ */
+
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import { createApprovalQueue } from "./store.ts";
+import type { ApprovalQueue } from "./types.ts";
+
+export const APPROVAL_SERVICE = "eliza_approval";
+
+export class ApprovalService extends Service {
+  static override serviceType = APPROVAL_SERVICE;
+
+  override capabilityDescription =
+    "Runtime owner-approval queue: enqueue/list/resolve outbound-action approvals over the plugin-sql approval_requests table";
+
+  static async start(runtime: IAgentRuntime): Promise<ApprovalService> {
+    return new ApprovalService(runtime);
+  }
+
+  async stop(): Promise<void> {}
+
+  /**
+   * Per-agent approval queue. `agentId` partitions the queue; it defaults to
+   * the runtime's agent id and may be overridden for admin/multi-tenant
+   * access.
+   */
+  getQueue(agentId: string = this.runtime.agentId): ApprovalQueue {
+    return createApprovalQueue(this.runtime, { agentId });
+  }
+}
+
+/**
+ * Resolve the registered {@link ApprovalService}. Returns `null` when the
+ * runtime has not registered it (e.g. the "eliza" plugin is absent).
+ */
+export function resolveApprovalService(
+  runtime: IAgentRuntime,
+): ApprovalService | null {
+  return runtime.getService<ApprovalService>(APPROVAL_SERVICE);
+}

--- a/packages/agent/src/services/approval/sql.ts
+++ b/packages/agent/src/services/approval/sql.ts
@@ -1,0 +1,121 @@
+/**
+ * Self-contained raw-SQL helpers for the runtime approval queue.
+ *
+ * The approval store issues raw SQL against the agent's database adapter over
+ * the `approval_requests` table owned by `@elizaos/plugin-sql` (public schema).
+ * This is the minimal subset of encoders/parsers/runners the store needs; it is
+ * intentionally local to `@elizaos/agent` so the runtime approval queue carries
+ * no dependency on plugin-side SQL glue. Mirrors `knowledge-graph/sql.ts`.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+
+type RawSqlQuery = {
+  queryChunks: Array<{ value?: unknown }>;
+};
+
+type RuntimeDb = {
+  execute: (query: RawSqlQuery) => Promise<unknown>;
+};
+
+let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function toText(value: unknown, fallback = ""): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return fallback;
+  return String(value);
+}
+
+function isMissingJsonValue(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function parseJsonValue<T>(value: unknown, fallback: T): T {
+  if (isMissingJsonValue(value)) return fallback;
+  if (typeof value !== "string") {
+    if (typeof value === "object") return value as T;
+    throw new Error(
+      `[ApprovalSql] Expected JSON string or object, received ${typeof value}`,
+    );
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[ApprovalSql] Invalid JSON value: ${message}`);
+  }
+}
+
+export function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (isMissingJsonValue(value)) return {};
+  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
+  const object = asObject(parsed);
+  if (object) return object;
+  throw new Error("[ApprovalSql] Expected JSON object");
+}
+
+function extractRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result
+      .map((row) => asObject(row))
+      .filter((row): row is Record<string, unknown> => row !== null);
+  }
+  const object = asObject(result);
+  if (!object) return [];
+  const rows = object.rows;
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => asObject(row))
+    .filter((row): row is Record<string, unknown> => row !== null);
+}
+
+async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
+  if (cachedSqlRaw) return cachedSqlRaw;
+  const drizzle = (await import("drizzle-orm")) as {
+    sql: { raw: (query: string) => RawSqlQuery };
+  };
+  cachedSqlRaw = drizzle.sql.raw;
+  return cachedSqlRaw;
+}
+
+function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
+  const db = runtime.adapter.db as RuntimeDb | undefined;
+  if (!db || typeof db.execute !== "function") {
+    throw new Error("runtime database adapter unavailable");
+  }
+  return db;
+}
+
+export async function executeRawSql(
+  runtime: IAgentRuntime,
+  sqlText: string,
+): Promise<Array<Record<string, unknown>>> {
+  const raw = await getSqlRaw();
+  const db = getRuntimeDb(runtime);
+  const result = await db.execute(raw(sqlText));
+  return extractRows(result);
+}
+
+export function sqlQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function sqlText(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  return sqlQuote(value);
+}
+
+export function sqlInteger(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
+  return String(Math.trunc(value));
+}
+
+export function sqlJson(value: unknown): string {
+  return sqlQuote(JSON.stringify(value ?? null));
+}

--- a/packages/agent/src/services/approval/store.ts
+++ b/packages/agent/src/services/approval/store.ts
@@ -1,31 +1,11 @@
-import { randomUUID } from "node:crypto";
-import { resolveApprovalService } from "@elizaos/agent";
-import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
-import {
-  type ApprovalAction,
-  type ApprovalChannel,
-  type ApprovalEnqueueInput,
-  type ApprovalListFilter,
-  ApprovalNotFoundError,
-  type ApprovalPayload,
-  type ApprovalQueue,
-  type ApprovalRequest,
-  type ApprovalRequestState,
-  type ApprovalResolution,
-  ApprovalStateTransitionError,
-} from "./approval-queue.types.js";
-import {
-  executeRawSql,
-  parseJsonRecord,
-  sqlInteger,
-  sqlJson,
-  sqlText,
-  toText,
-} from "./sql.js";
-
 /**
- * Concrete `ApprovalQueue` backed by the `approval_requests` table from
- * `@elizaos/plugin-sql`.
+ * `PgApprovalQueue` — concrete approval queue backed by the `approval_requests`
+ * table from `@elizaos/plugin-sql` (public schema, no schema prefix).
+ *
+ * Promoted from `@elizaos/plugin-personal-assistant`'s `lifeops/approval-queue.ts`
+ * into a first-class `@elizaos/agent` runtime store (LifeOps Slice 4). The raw
+ * SQL is unchanged — it has no schema prefix, so it targets plugin-sql's public
+ * `approval_requests` table exactly as before. There is no data migration.
  *
  * Design notes:
  *  - The state-transition table below is the single source of truth for
@@ -36,6 +16,31 @@ import {
  *  - Each row is scoped to an agent via `agentId`. Cross-agent access is
  *    not supported.
  */
+
+import { randomUUID } from "node:crypto";
+import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
+import {
+  executeRawSql,
+  parseJsonRecord,
+  sqlInteger,
+  sqlJson,
+  sqlText,
+  toText,
+} from "./sql.ts";
+import {
+  type ApprovalAction,
+  type ApprovalChannel,
+  type ApprovalEnqueueInput,
+  type ApprovalListFilter,
+  ApprovalNotFoundError,
+  type ApprovalPayload,
+  type ApprovalQueue,
+  type ApprovalQueueOptions,
+  type ApprovalRequest,
+  type ApprovalRequestState,
+  type ApprovalResolution,
+  ApprovalStateTransitionError,
+} from "./types.ts";
 
 const ALLOWED_TRANSITIONS: Readonly<
   Record<ApprovalRequestState, ReadonlyArray<ApprovalRequestState>>
@@ -561,10 +566,6 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
   return svc && typeof svc.notify === "function" ? svc : null;
 }
 
-export interface ApprovalQueueOptions {
-  readonly agentId: string;
-}
-
 export class PgApprovalQueue implements ApprovalQueue {
   private readonly runtime: IAgentRuntime;
   private readonly agentId: string;
@@ -752,27 +753,9 @@ export class PgApprovalQueue implements ApprovalQueue {
   }
 }
 
-/**
- * Resolve the approval queue for `options.agentId`.
- *
- * Promoted to the first-class `@elizaos/agent` runtime service `ApprovalService`
- * (serviceType `eliza_approval`) in LifeOps Slice 4. This factory prefers the
- * registered runtime service (first-wins dedup) and falls back to a
- * directly-constructed `PgApprovalQueue` when the service is absent. Both read
- * and write the same public-schema `approval_requests` table via identical raw
- * SQL, so the fallback is behaviorally identical.
- *
- * The runtime service is structurally the same `PgApprovalQueue`; the single
- * narrowing below re-asserts PA's travel/Duffel-precise payload contract over
- * the runtime's structurally-identical (travel-agnostic) queue interface.
- */
 export function createApprovalQueue(
   runtime: IAgentRuntime,
   options: ApprovalQueueOptions,
 ): ApprovalQueue {
-  const service = resolveApprovalService(runtime);
-  if (service) {
-    return service.getQueue(options.agentId) as unknown as ApprovalQueue;
-  }
   return new PgApprovalQueue(runtime, options);
 }

--- a/packages/agent/src/services/approval/types.ts
+++ b/packages/agent/src/services/approval/types.ts
@@ -1,0 +1,275 @@
+/**
+ * Approval-queue transport types — the runtime contract for the
+ * `approval_requests` table (owned by `@elizaos/plugin-sql`, public schema).
+ *
+ * These are agent-private (no plugin dependency): the `book_travel` payload's
+ * travel sub-shapes are declared structurally here rather than importing the
+ * Duffel/travel types from `@elizaos/plugin-personal-assistant` — the runtime
+ * state machine + SQL + validation only need the structural shape. PA keeps its
+ * own precisely-typed `approval-queue.types.ts` for the travel/Duffel domain
+ * reads; the structural overlap means PA's precise payloads remain assignable
+ * to this contract when enqueuing through the runtime {@link ApprovalQueue}.
+ */
+
+export type ApprovalRequestState =
+  | "pending"
+  | "approved"
+  | "executing"
+  | "done"
+  | "rejected"
+  | "expired";
+
+export type ApprovalAction =
+  | "send_message"
+  | "send_email"
+  | "schedule_event"
+  | "modify_event"
+  | "cancel_event"
+  | "book_travel"
+  | "make_call"
+  | "sign_document"
+  | "execute_workflow"
+  | "spend_money";
+
+export type ApprovalChannel =
+  | "telegram"
+  | "discord"
+  | "slack"
+  | "imessage"
+  | "sms"
+  | "x_dm"
+  | "email"
+  | "google_calendar"
+  | "browser"
+  | "phone"
+  | "internal";
+
+/** Travel passenger record — structural shape; see module docstring. */
+export interface ApprovalTravelPassenger {
+  readonly offerPassengerId?: string | null;
+  readonly givenName: string;
+  readonly familyName: string;
+  readonly bornOn: string;
+  readonly email?: string | null;
+  readonly phoneNumber?: string | null;
+  readonly title?: string | null;
+  readonly gender?: string | null;
+}
+
+/** Travel calendar-sync plan — structural shape; see module docstring. */
+export interface ApprovalTravelCalendarSync {
+  readonly enabled: boolean;
+  readonly calendarId?: string | null;
+  readonly title?: string | null;
+  readonly description?: string | null;
+  readonly location?: string | null;
+  readonly timeZone?: string | null;
+}
+
+export type ApprovalPayload =
+  | {
+      action: "send_message";
+      recipient: string;
+      body: string;
+      replyToMessageId: string | null;
+    }
+  | {
+      action: "send_email";
+      to: ReadonlyArray<string>;
+      cc: ReadonlyArray<string>;
+      bcc: ReadonlyArray<string>;
+      subject: string;
+      body: string;
+      threadId: string | null;
+      replyToMessageId?: string | null;
+    }
+  | {
+      action: "schedule_event";
+      calendarId: string;
+      title: string;
+      startsAtMs: number;
+      endsAtMs: number;
+      attendees: ReadonlyArray<string>;
+      location: string | null;
+      description: string | null;
+    }
+  | {
+      action: "modify_event";
+      calendarId: string;
+      eventId: string;
+      patch: {
+        title: string | null;
+        startsAtMs: number | null;
+        endsAtMs: number | null;
+        attendees: ReadonlyArray<string> | null;
+        location: string | null;
+        description: string | null;
+      };
+    }
+  | {
+      action: "cancel_event";
+      calendarId: string;
+      eventId: string;
+      notifyAttendees: boolean;
+    }
+  | {
+      action: "book_travel";
+      kind: "flight" | "hotel" | "ground";
+      provider: string;
+      itineraryRef: string;
+      totalCents: number;
+      currency: string;
+      offerId?: string | null;
+      offerRequestId?: string | null;
+      orderType?: "hold" | "instant" | null;
+      /** Opaque flight-search context (Duffel `SearchFlightsRequest` in PA). */
+      search?: Readonly<Record<string, unknown>> | null;
+      passengers?: ReadonlyArray<ApprovalTravelPassenger>;
+      calendarSync?: ApprovalTravelCalendarSync | null;
+      summary?: string | null;
+      /** Server-side cost breakdown surfaced to the user alongside any
+       *  payment-required prompt. Mirrors `DuffelCallCost`; held as a
+       *  loose record here so the approval-queue type doesn't have to
+       *  depend on the travel-adapter package. */
+      cost?: {
+        readonly totalUsd: number;
+        readonly creatorMarkupUsd: number;
+        readonly platformFeeUsd: number;
+        readonly markupPercent: number | null;
+      } | null;
+      /** Set when an x402 PaymentRequiredError fired before the booking
+       *  could be quoted. The user sees both the booking intent and the
+       *  top-up prompt in a single approval entry. */
+      paymentRequired?: {
+        readonly amount: string;
+        readonly asset: string;
+        readonly network: string;
+        readonly payTo: string;
+        readonly scheme: string;
+        readonly expiresAt: string | null;
+        readonly description: string | null;
+      } | null;
+    }
+  | {
+      action: "make_call";
+      to: string;
+      script: string;
+      maxDurationSeconds: number;
+    }
+  | {
+      action: "sign_document";
+      documentId: string;
+      documentName: string;
+      signatureUrl: string;
+      deadline: string;
+    }
+  | {
+      action: "execute_workflow";
+      workflowId: string;
+      input: Readonly<Record<string, string | number | boolean>>;
+    }
+  | {
+      action: "spend_money";
+      vendor: string;
+      amountCents: number;
+      currency: string;
+      memo: string;
+    };
+
+/** Persisted approval request. */
+export interface ApprovalRequest {
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly state: ApprovalRequestState;
+  readonly requestedBy: string;
+  readonly subjectUserId: string;
+  readonly action: ApprovalAction;
+  readonly payload: ApprovalPayload;
+  readonly channel: ApprovalChannel;
+  readonly reason: string;
+  readonly expiresAt: Date;
+  readonly resolvedAt: Date | null;
+  readonly resolvedBy: string | null;
+  readonly resolutionReason: string | null;
+}
+
+/** Input to `enqueue` — server fills in id, timestamps, and initial state. */
+export interface ApprovalEnqueueInput {
+  readonly requestedBy: string;
+  readonly subjectUserId: string;
+  readonly action: ApprovalAction;
+  readonly payload: ApprovalPayload;
+  readonly channel: ApprovalChannel;
+  readonly reason: string;
+  readonly expiresAt: Date;
+}
+
+/** Filter for `list`. All fields combine with AND. */
+export interface ApprovalListFilter {
+  readonly subjectUserId: string | null;
+  readonly state: ApprovalRequestState | null;
+  readonly action: ApprovalAction | null;
+  readonly limit: number;
+}
+
+/** Resolution input for `approve` / `reject`. */
+export interface ApprovalResolution {
+  readonly resolvedBy: string;
+  readonly resolutionReason: string;
+}
+
+/** Thrown when a state transition is invalid. */
+export class ApprovalStateTransitionError extends Error {
+  public readonly requestId: string;
+  public readonly from: ApprovalRequestState;
+  public readonly to: ApprovalRequestState;
+
+  constructor(
+    requestId: string,
+    from: ApprovalRequestState,
+    to: ApprovalRequestState,
+  ) {
+    super(
+      `[ApprovalQueue] invalid transition for request ${requestId}: ${from} -> ${to}`,
+    );
+    this.name = "ApprovalStateTransitionError";
+    this.requestId = requestId;
+    this.from = from;
+    this.to = to;
+  }
+}
+
+/** Thrown when an operation references an unknown request id. */
+export class ApprovalNotFoundError extends Error {
+  public readonly requestId: string;
+
+  constructor(requestId: string) {
+    super(`[ApprovalQueue] request not found: ${requestId}`);
+    this.name = "ApprovalNotFoundError";
+    this.requestId = requestId;
+  }
+}
+
+/**
+ * Queue interface. Implementations must:
+ *  - Reject invalid state transitions by throwing `ApprovalStateTransitionError`.
+ *  - Reject unknown ids by throwing `ApprovalNotFoundError`.
+ *  - Use the structured logger only (no `console.*`).
+ *  - Treat `purgeExpired` as idempotent.
+ */
+export interface ApprovalQueue {
+  enqueue(input: ApprovalEnqueueInput): Promise<ApprovalRequest>;
+  list(filter: ApprovalListFilter): Promise<ReadonlyArray<ApprovalRequest>>;
+  byId(id: string): Promise<ApprovalRequest | null>;
+  approve(id: string, resolution: ApprovalResolution): Promise<ApprovalRequest>;
+  reject(id: string, resolution: ApprovalResolution): Promise<ApprovalRequest>;
+  markExecuting(id: string): Promise<ApprovalRequest>;
+  markDone(id: string): Promise<ApprovalRequest>;
+  markExpired(id: string): Promise<ApprovalRequest>;
+  purgeExpired(now: Date): Promise<ReadonlyArray<string>>;
+}
+
+export interface ApprovalQueueOptions {
+  readonly agentId: string;
+}


### PR DESCRIPTION
## LifeOps decomposition — Slice 4: promote approval-queue to `@elizaos/agent` `ApprovalService`

Implements **Slice 4** of the LifeOps extraction plan: `plugins/plugin-personal-assistant/docs/lifeops-extraction-plan.md` → "Slice 4 — Promote approval-queue to `@elizaos/agent` `ApprovalService`".

Follows the just-merged **Slice 3** precedent (`pending-prompts` / `global-pause` / `handoff` runtime services, #9197) and the `KnowledgeGraphService` template.

Part of #8833.

### Why no data risk
`approval_requests` is owned by **`@elizaos/plugin-sql`** (`plugins/plugin-sql/src/schema/approvalRequests.ts`, public schema — no schema prefix). This is a pure runtime-service promotion of PA's `lifeops/approval-queue.ts` ops. **No data migration.**

### What moved

New `packages/agent/src/services/approval/`:

| File | Contents |
|---|---|
| `store.ts` | The **copied** `PgApprovalQueue` ops from PA `lifeops/approval-queue.ts` — `ALLOWED_TRANSITIONS` + `enqueue`/`list`/`byId`/`approve`/`reject`/`markExecuting`/`markDone`/`markExpired`/`purgeExpired`. Raw SQL kept **identical** (no schema prefix → targets plugin-sql's public `approval_requests`). |
| `sql.ts` | Self-contained raw-SQL helpers (mirrors `knowledge-graph/sql.ts`) — `executeRawSql` / `parseJsonRecord` / `sqlText` / `sqlInteger` / `sqlJson` / `toText`. |
| `types.ts` | Agent-private approval transport types. The `book_travel` payload's travel sub-shapes are declared **structurally** (no Duffel/PA dependency) — the runtime state machine + SQL + validation only need the structural shape, so the runtime carries no plugin dependency (inward-only law). |
| `service.ts` | `class ApprovalService extends Service` — serviceType literal `'eliza_approval'`, `getQueue(agentId)` accessor, `resolveApprovalService(runtime)`. |
| `index.ts` | Barrel. |
| `service.test.ts` | 8 unit tests over an in-memory `approval_requests` fake (state-machine happy/reject/purge, `agentId` scoping, `ApprovalNotFoundError` / `ApprovalStateTransitionError`). |

Wiring:
- Registered `ApprovalService` in `createElizaPlugin()` `services[]` next to the Slice-3 services.
- Named re-export from `packages/agent/src/index.ts` (KG / Slice-3 pattern — keeps it out of the broad services barrel to avoid TS2308).

PA delegation (`plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts`):
- `createApprovalQueue(runtime, { agentId })` now resolves the runtime `ApprovalService` when present (first-wins dedup), **falling back to the local `PgApprovalQueue` when absent** — matches the Slice-3 delegation pattern.
- PA keeps its precise travel/Duffel-typed `approval-queue.types.ts` and its local impl (the fallback). All 6 PA approval-type consumers are unchanged. All runtime string literals (serviceType, action/event names) preserved.

### Architecture notes
- Inward-only law holds: `@elizaos/agent` does **not** import PA (the approval types are declared agent-private; the `book_travel` `search`/`passengers`/`calendarSync` shapes are inlined structurally rather than importing PA's Duffel-coupled `TravelBookingPayloadFields`).
- `'eliza_approval'` is a brand-new, unique serviceType (no collision — verified repo-wide).

### Test evidence
- `bun run --cwd packages/core build` && `--cwd packages/shared build` && `generate-keywords.mjs --target ts` — clean.
- `bun run --cwd packages/agent typecheck` → **0 errors**.
- `bun run --cwd packages/agent test src/services/approval/service.test.ts` → **8/8 passing**.
- `bun run --cwd plugins/plugin-personal-assistant build:types` → **clean**.
- PA `tsgo --noEmit -p tsconfig.build.json` (after building the `@elizaos/agent` dist) → **475 errors == pre-existing baseline**, **0 errors in touched files**. (Before building the agent dist the count was 505; the 30-error delta was the stale-agent-dist `@elizaos/agent` member-resolution class that *also* hits the already-landed Slice-3 exports — i.e. an env artifact, not new errors.)
- `bun run --cwd plugins/plugin-personal-assistant build:js` → **build success** (bundles the delegating `createApprovalQueue`).
- PA approval-consumer tests that load — `approval-queue.integration.test.ts` (the fallback path, real PGlite), `book-travel.approval.integration.test.ts`, `document-action.test.ts` — **pass**.
- `bunx biome check --write` on all touched files — **clean**.

### Known, pre-existing, unrelated
`decomposition-integration.test.ts` and several PA test files fail to **load** in a fresh worktree because they transitively import unbuilt sibling packages (`@elizaos/plugin-calendar`, `@elizaos/vault`, `@elizaos/tui`). This is the documented env defect called out in the slice spec — the affected test files are **untouched** by this PR. The serviceType-collision check the gate would run is satisfied directly: `'eliza_approval'` appears only in the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
