### PR TITLE
fix(training): align Python manifest tokenizer family to gemma4 (#8848)

### DIFF
--- a/packages/training/scripts/manifest/eliza1_manifest.py
+++ b/packages/training/scripts/manifest/eliza1_manifest.py
@@ -40,7 +40,7 @@ ELIZA_1_HF_REPO: Final[str] = "elizaos/eliza-1"
 # Tokenizer identity for the Gemma 4 Eliza-1 line. Mirrors schema.ts
 # (ELIZA_1_TOKENIZER_FAMILY / ELIZA_1_TOKENIZER_VOCAB_SIZE). Stamped into the
 # emitted manifest by build_manifest() so the bundle records its tokenizer.
-ELIZA_1_TOKENIZER_FAMILY: Final[str] = "gemma"
+ELIZA_1_TOKENIZER_FAMILY: Final[str] = "gemma4"
 ELIZA_1_TOKENIZER_VOCAB_SIZE: Final[int] = 262_144
 
 # Gemma 4 KV-cache policy (MQA + windowed-SWA + shared-KV → stock q8_0; no


### PR DESCRIPTION
## What
`packages/training/scripts/manifest/eliza1_manifest.py:43` declared the tokenizer family as `"gemma"`, but the TS contract (`schema.ts:42`) and the live HF Gemma-4 manifests (#9172) use `"gemma4"`. The two validators of the same frozen contract disagreed — the Python validator would **reject** a real gemma4 manifest the TS validator accepts. The file's comment says it 'mirrors schema.ts', so this was accidental drift from the Qwen→Gemma cutover.

## Change
One line: `ELIZA_1_TOKENIZER_FAMILY = "gemma4"`.

## Evidence
`pytest test_eliza1_manifest.py` → 66/66 pass. The staging/kokoro failures elsewhere in the suite are **pre-existing** (need staging assets; fail with `"gemma"` too — verified by reverting).

Closes the last host-doable code drift on #8848 (remaining items are device/training-gated: MTP drafter GGUF, Mali/CUDA/Metal verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)