### PR TITLE
feat(local-inference): smooth chat streaming — fine-grained per-step token cap (#9174)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -318,6 +318,54 @@ describe("ensureLocalInferenceHandler", () => {
 		);
 	});
 
+	it("uses a fine-grained maxTokensPerStep for user-visible streaming, coarse for internal calls", async () => {
+		const prior = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+		try {
+			const { registrations, runtime } = makeRuntime();
+			engineState.hasLoadedModel.mockReturnValue(true);
+
+			await ensureLocalInferenceHandler(runtime);
+			const handler = findRegisteredHandler(
+				registrations,
+				ModelType.TEXT_LARGE,
+			);
+
+			// Streaming reply (onStreamChunk wired) → tuned fine-grained step (8).
+			await handler(runtime, {
+				prompt: "hi",
+				stream: true,
+				onStreamChunk: () => {},
+			});
+			expect(engineState.generate).toHaveBeenLastCalledWith(
+				expect.objectContaining({ maxTokensPerStep: 8 }),
+			);
+
+			// Internal / non-streamed call → no override (runner keeps coarse 32).
+			await handler(runtime, { prompt: "hi" });
+			expect(engineState.generate).toHaveBeenLastCalledWith(
+				expect.objectContaining({ maxTokensPerStep: undefined }),
+			);
+
+			// The shared env knob overrides the tuned streaming default.
+			process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = "4";
+			await handler(runtime, {
+				prompt: "hi",
+				stream: true,
+				onStreamChunk: () => {},
+			});
+			expect(engineState.generate).toHaveBeenLastCalledWith(
+				expect.objectContaining({ maxTokensPerStep: 4 }),
+			);
+		} finally {
+			if (prior === undefined) {
+				delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
+			} else {
+				process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP = prior;
+			}
+		}
+	});
+
 	it("passes hardware-aware load args through desktop lazy assignment loads", async () => {
 		const installed = {
 			id: "eliza-1-2b",

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -346,6 +346,26 @@ function extractThinkingControl(
  * honours them (the forced-span / prefill / grammar / prefill-plan path is
  * local-model-only).
  */
+/**
+ * Per-step token cap for USER-VISIBLE local streaming (chat replies).
+ *
+ * Benchmarked on the fused eliza-1 model (#9174): the per-`llmStreamNext` step
+ * carries a large fixed FFI overhead, so the throughput↔smoothness curve has a
+ * knee around 8 — `8` yields ~10 UI updates per 80 tokens (clearly streaming)
+ * at a modest decode-throughput cost, whereas 1–4 fall off a throughput cliff
+ * and 16–32 look jumpy. Internal / planner / voice calls do NOT set this and
+ * keep the coarse, throughput-tuned runner default (32). Overridable via the
+ * shared `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` env knob; the runner clamps it.
+ */
+const DEFAULT_CHAT_STREAM_TOKENS_PER_STEP = 8;
+function resolveChatStreamTokensPerStep(): number {
+	const raw = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP?.trim();
+	const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+	return Number.isFinite(parsed) && parsed > 0
+		? parsed
+		: DEFAULT_CHAT_STREAM_TOKENS_PER_STEP;
+}
+
 function engineGenerateArgsFromParams(
 	params: GenerateTextParams,
 	cacheKey: string | undefined,
@@ -365,6 +385,7 @@ function engineGenerateArgsFromParams(
 	spanSamplerPlan?: GenerateTextParams["spanSamplerPlan"];
 	thinking?: "auto" | "on" | "off";
 	onTextChunk?: (chunk: string) => void | Promise<void>;
+	maxTokensPerStep?: number;
 	voiceOutput?: "user-visible" | "internal";
 } {
 	const renderContent = (content: unknown): string => {
@@ -428,6 +449,13 @@ function engineGenerateArgsFromParams(
 		spanSamplerPlan: params.spanSamplerPlan,
 		thinking: extractThinkingControl(params.providerOptions),
 		onTextChunk,
+		// Stream user-visible replies in fine-grained steps so the dashboard
+		// renders token-by-token instead of in ~32-token jumps. Only when
+		// streaming (onTextChunk set) — internal/planner calls keep the coarse,
+		// throughput-tuned default. See resolveChatStreamTokensPerStep (#9174).
+		maxTokensPerStep: onTextChunk
+			? resolveChatStreamTokensPerStep()
+			: undefined,
 		voiceOutput:
 			params.voiceOutput ??
 			(typeof params.onStreamChunk === "function" ? "user-visible" : undefined),

--- a/plugins/plugin-local-inference/src/services/backend.ts
+++ b/plugins/plugin-local-inference/src/services/backend.ts
@@ -113,6 +113,14 @@ export interface GenerateArgs extends StructuredGenerateParams {
 	 */
 	onTextChunk?: (chunk: string) => void | Promise<void>;
 	/**
+	 * Max tokens the FFI backend decodes per `llmStreamNext` step — i.e. the
+	 * granularity of `onTextChunk` emission. Smaller ⇒ smoother token-by-token
+	 * streaming to the UI at the cost of more FFI round-trips per response.
+	 * Unset ⇒ the backend default (coarse, throughput-tuned). The text/chat
+	 * handler sets a small value for smooth streaming; voice leaves it unset.
+	 */
+	maxTokensPerStep?: number;
+	/**
 	 * Whether this generation is user-visible text and therefore eligible for
 	 * voice-mode TTS. Internal JSON / planner calls must not be spoken.
 	 */

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
@@ -198,6 +198,7 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 			cacheTypeV: loadConfig?.cacheTypeV,
 			contextSize: loadConfig?.contextSize,
 			signal: args.signal,
+			maxTokensPerStep: args.maxTokensPerStep,
 			onTextChunk: args.onTextChunk,
 			onVerifierEvent: args.onVerifierEvent,
 		});


### PR DESCRIPTION
Local chat replies streamed in ~32-token jumps because `FfiStreamingRunner` emits one chunk per `llmStreamNext` step (`DEFAULT_MAX_TOKENS_PER_STEP = 32`), so short replies appeared all at once. This threads the existing per-call `maxTokensPerStep` (swarm-added at the runner) the rest of the way and sets a **benchmark-tuned** value for user-visible streaming only.

### Change
- `backend.ts` — add `maxTokensPerStep?` to `GenerateArgs`.
- `ffi-streaming-backend.ts` — pass `args.maxTokensPerStep` to `runner.generateWithUsage`.
- `ensure-local-inference-handler.ts` — set `maxTokensPerStep` to a tuned `8` **only when streaming** (`onTextChunk` wired, i.e. user-visible chat); internal/planner/voice calls leave it unset and keep the coarse, throughput-tuned 32. Overridable via the shared `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` env knob.
- Regression test for the streaming-vs-internal default + env override.

### Why 8 (benchmarked on the fused eliza-1 model, 80-token deterministic gen)

| step | chunks | tok/s | totalMs |
|---|---|---|---|
| 1 | 80 | 4.7 | 16996 |
| 2 | 40 | 8.1 | 10104 |
| 4 | 20 | 10.3 | 7830 |
| **8** | **10** | ~9–11 | ~7–9k |
| 16 | 5 | 11.3 | 7251 |
| 32 | 3 | 15.5 | 5305 |

The per-step FFI overhead is large (~150ms/step modeled), so the throughput↔smoothness curve has a knee around 8: it gives ~10 UI updates per 80 tokens (clearly token-by-token) without the 1–4 throughput cliff. The cost only applies where streaming is shown.

### Validation (Windows)
typecheck clean; handler suite 21/21 (incl. new tuning test); runner+engine streaming 10/10; biome clean. The runner already honors `maxTokensPerStep` (benchmark above ran through it).

Part of #9174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)