### PR TITLE
test(voice): add music-background robustness scenario (#9147)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/workbench-scenarios.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-scenarios.ts
@@ -154,6 +154,28 @@ export const VOICE_WORKBENCH_SCENARIOS: VoiceScenario[] = [
 		assertions: { minRespondAccuracy: 0.9, maxWer: 0.35, maxDer: 0.3 },
 	},
 	{
+		id: "music-background-commands",
+		description:
+			"The owner gives commands with music playing in the background; the agent answers and the tonal music bed does not false-trigger VAD/respond.",
+		classes: ["robustness", "respond-no-respond"],
+		knownSpeakerEntityIds: ["entity-owner"],
+		// 10 dB SNR music bed across the whole scenario. The `music` noise kind is
+		// tonal/harmonic (unlike white/pink) — this scenario exercises the music
+		// augmentation that landed in corpus-augment.ts (d56efcc80b) but until now
+		// had no scenario driving it (#9147).
+		environment: { noiseSnrDb: 10, noiseKind: "music", reverb: 0.2, seed: 404 },
+		participants: [{ label: "owner", entityId: "entity-owner", isOwner: true }],
+		turns: [
+			{ speaker: "owner", text: "Eliza pause the timer", expectRespond: true },
+			{
+				speaker: "owner",
+				text: "Eliza what is the weather today",
+				expectRespond: true,
+			},
+		],
+		assertions: { minRespondAccuracy: 0.9, maxWer: 0.35, maxDer: 0.3 },
+	},
+	{
 		id: "far-field-reverb",
 		description:
 			"A far, reverberant speaker across the room — quiet and washed out — is still understood.",


### PR DESCRIPTION
## What
The deterministic `music` noise kind landed in `corpus-augment.ts` (d56efcc80b) but **no scenario exercised it** — one of the #9147 acceptance items (new robustness scenarios incl. music).

## Change
Adds `music-background-commands` to the voice workbench scenario set: the owner gives commands over a 10 dB tonal music bed; asserts respond-accuracy ≥0.9 / WER ≤0.35 / DER ≤0.3 hold and the music doesn't false-trigger VAD/respond.

## Evidence
`voice:workbench --logic` → **PASS, 8 cases**, now 15 scenarios total. Type-valid (workbench suites 40/40 green).

Note: while here I verified the `expectedSpeakerLabel` override is **already** wired (`corpus-generator.ts:294` via `turnSpeakerLabel`), so the DER scoring already respects it — no change needed there. The live self-voice-similarity wiring remains blocked on the `pending` WeSpeaker GGUF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)