### PR TITLE
fix(app): wire the manifest-driven side-effect modules Vite plugin (#9178)

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -33,6 +33,7 @@ import {
   generateNodeBuiltinStub,
   nativeModuleStubPlugin,
 } from "./vite/native-module-stub-plugin.ts";
+import { appSideEffectModulesPlugin } from "./vite/app-side-effect-modules.ts";
 import { resolveViteDevServerRuntime } from "./vite-dev-origin.ts";
 
 const _require = createRequire(import.meta.url);
@@ -1875,6 +1876,12 @@ export default defineConfig({
     ),
   },
   plugins: [
+    // Manifest-driven renderer side-effect plugin registration (#9178): resolves
+    // the `virtual:eliza-side-effect-app-modules` import in plugin-registrations.ts
+    // by scanning plugins/ for elizaos.appRegister markers. Without this the
+    // production web/mobile build fails to resolve the virtual module (the
+    // refactor added the import but never wired the providing plugin).
+    appSideEffectModulesPlugin([nativePluginsRoot]),
     // When the cloud surface is excluded (ELIZA_DISABLE_WEB_SHELL=1), replace the
     // whole `@elizaos/ui/src/cloud` subtree with empty modules. The two lazy
     // cloud entry points are already aliased to passthrough stubs, but the main


### PR DESCRIPTION
## Critical: `build:web` is broken on develop

#9178 (manifest-driven renderer side-effect registration) added `import { SIDE_EFFECT_APP_MODULE_LOADERS } from "virtual:eliza-side-effect-app-modules"` in `plugin-registrations.ts` and created the providing Vite plugin (`vite/app-side-effect-modules.ts`), **but never wired the plugin into `vite.config.ts`**. The commit only verified typecheck (which doesn't run Vite), so it missed:

```
[vite]: Rollup failed to resolve import "virtual:eliza-side-effect-app-modules"
        from "packages/app/src/plugin-registrations.ts"
error: script "build:web" exited with code 1
```

This breaks **`build:web`** → the **Android/iOS mobile builds** (run-mobile-build.mjs) **and the cloud Deploy App** (both run `packages/app build:web`).

## Fix
Register `appSideEffectModulesPlugin([nativePluginsRoot])` in the main plugins array (scans `plugins/` for the 16 `elizaos.appRegister` markers). Followed the sibling `nativeModuleStubPlugin` wiring pattern.

## Evidence
`bun run --cwd packages/app build:web` → **exit 0** (was code 1). `✓ built in 1m13s`; the virtual module resolves. Found while doing a fresh Android device build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)