### PR TITLE
feat(computeruse): M12 window bounds getters — get_window_size / get_window_position (trycua/cua, #9170)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
@@ -105,24 +105,56 @@ const CAPABILITIES: Capability[] = [
   { cua: "restore_window", domain: "window", status: "have", verb: "restore" },
   { cua: "close_window", domain: "window", status: "have", verb: "close" },
   { cua: "set_window_position", domain: "window", status: "have", verb: "move" },
-  {
-    cua: "get_window_size/position + set_window_size + get_current_window_id + get_application_windows",
-    domain: "window",
-    status: "missing",
-    milestone: "M12",
-  },
-  { cua: "open(target) / launch(app,args)", domain: "window", status: "missing", milestone: "M12" },
+  // M12 window getters/setters — all landed.
+  { cua: "get_current_window_id", domain: "window", status: "have", verb: "get_current_window_id", milestone: "M12" },
+  { cua: "get_application_windows", domain: "window", status: "have", verb: "get_application_windows", milestone: "M12" },
+  { cua: "set_window_size (set_bounds)", domain: "window", status: "have", verb: "set_bounds", milestone: "M12" },
+  { cua: "get_window_size", domain: "window", status: "have", verb: "get_window_size", milestone: "M12" },
+  { cua: "get_window_position", domain: "window", status: "have", verb: "get_window_position", milestone: "M12" },
+  // open/launch are COMPUTER_USE verbs (implemented; launch returns a pid).
+  { cua: "open(target)", domain: "input", status: "have", verb: "open", milestone: "M12" },
+  { cua: "launch(app,args)->pid", domain: "input", status: "have", verb: "launch", milestone: "M12" },
   // ── clipboard ───────────────────────────────────────────────────────────────
   { cua: "copy_to_clipboard", domain: "clipboard", status: "have", verb: "read" },
   { cua: "set_clipboard", domain: "clipboard", status: "have", verb: "write" },
   // ── filesystem / shell (gated/internal today) ───────────────────────────────
+  // Host file/shell route through the FILE / SHELL actions; sandbox guests get
+  // run_command + basic fs over the M13 RPC. Basic ops exist; the binary/dir
+  // transfer verbs below are genuine gaps (cua exposes them for guest I/O).
   {
-    cua: "filesystem verbs (exists/list/read/write/delete/mkdir/size)",
+    cua: "filesystem basic (exists/list/read_text/write_text/delete)",
     domain: "architecture",
     status: "partial",
-    milestone: "M12",
+    milestone: "M13",
   },
-  { cua: "run_command (CommandResult)", domain: "architecture", status: "partial", milestone: "M12" },
+  { cua: "run_command (CommandResult)", domain: "architecture", status: "partial", milestone: "M13" },
+  {
+    cua: "read_bytes/write_bytes (base64 binary), create_dir, directory_exists, get_file_size",
+    domain: "architecture",
+    status: "missing",
+    milestone: "M12/M13 — sandbox guest binary I/O",
+  },
+  // ── trycua blind spots — tracked decisions, not silent gaps (workflow audit) ──
+  { cua: "set_value (a11y element value write)", domain: "architecture", status: "missing", milestone: "a11y-write" },
+  { cua: "kill_app (process terminate)", domain: "architecture", status: "missing", milestone: "process-lifecycle" },
+  {
+    cua: "zoom (region magnify for grounding)",
+    domain: "architecture",
+    status: "partial",
+    milestone: "covered by M5 ROI + M9 Set-of-Marks",
+  },
+  {
+    cua: "screen recording / replay_trajectory (MP4)",
+    domain: "architecture",
+    status: "na",
+    na: "evidence concern owned by test:e2e:record + scenario-runner viewer, not an agent verb",
+  },
+  {
+    cua: "agent-cursor overlay (set_agent_cursor_*)",
+    domain: "architecture",
+    status: "na",
+    na: "UX overlay tied to cua's recording; no agent-decision value",
+  },
   // ── architecture ────────────────────────────────────────────────────────────
   { cua: "agent_loop_registry", domain: "architecture", status: "partial", milestone: "M10" },
   { cua: "predict_step/predict_click split", domain: "architecture", status: "partial", milestone: "M10" },

--- a/plugins/plugin-computeruse/src/__tests__/m12-verbs.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/m12-verbs.test.ts
@@ -78,8 +78,24 @@ describe("action-surface promotion (M12)", () => {
       "WINDOW_GET_CURRENT_WINDOW_ID",
       "WINDOW_GET_APPLICATION_WINDOWS",
       "WINDOW_SET_BOUNDS",
+      "WINDOW_GET_WINDOW_SIZE",
+      "WINDOW_GET_WINDOW_POSITION",
     ]) {
       expect(actionNames, `actions: ${actionNames.join(", ")}`).toContain(verb);
     }
+  });
+});
+
+describe("window bounds getter (get_window_size / get_window_position)", () => {
+  it("exposes get_window_size + get_window_position as window verbs", () => {
+    // Real bounds read against a live window is exercised by the gated
+    // real-driver lane; here we assert the verbs are wired into the surface.
+    expect(actionNames).toContain("WINDOW_GET_WINDOW_SIZE");
+    expect(actionNames).toContain("WINDOW_GET_WINDOW_POSITION");
+  });
+
+  it("getWindowBounds is exported by the window platform module", async () => {
+    const mod = await import("../platform/windows-list.js");
+    expect(typeof mod.getWindowBounds).toBe("function");
   });
 });

--- a/plugins/plugin-computeruse/src/actions/window.ts
+++ b/plugins/plugin-computeruse/src/actions/window.ts
@@ -34,6 +34,8 @@ const WINDOW_ACTIONS = [
   "get_current_window_id",
   "get_application_windows",
   "set_bounds",
+  "get_window_size",
+  "get_window_position",
 ] as const satisfies readonly WindowActionType[];
 
 /**

--- a/plugins/plugin-computeruse/src/parity/parity-matrix.ts
+++ b/plugins/plugin-computeruse/src/parity/parity-matrix.ts
@@ -228,6 +228,22 @@ export const PARITY_MATRIX: readonly ParityCapability[] = [
     milestone: "M12",
     os: DESKTOP_COVERED_AOSP_NA_PLANNED(),
   },
+  {
+    id: "get_window_size",
+    elizaVerb: "WINDOW_GET_WINDOW_SIZE",
+    status: "have",
+    milestone: "M12",
+    note: "GetWindowRect (win32) / AppleScript size / xdotool geometry",
+    os: { windows: "covered", linux: "planned", macos: "planned", aosp: "na" },
+  },
+  {
+    id: "get_window_position",
+    elizaVerb: "WINDOW_GET_WINDOW_POSITION",
+    status: "have",
+    milestone: "M12",
+    note: "GetWindowRect (win32) / AppleScript position / xdotool geometry",
+    os: { windows: "covered", linux: "planned", macos: "planned", aosp: "na" },
+  },
 
   // ── M13: provider matrix (sandbox-only / RPC) ────────────────────────────
   {

--- a/plugins/plugin-computeruse/src/platform/windows-list.ts
+++ b/plugins/plugin-computeruse/src/platform/windows-list.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync } from "node:child_process";
-import type { ScreenSize, WindowInfo } from "../types.js";
+import type { ScreenRegion, ScreenSize, WindowInfo } from "../types.js";
 import {
   commandExists,
   currentPlatform,
@@ -79,7 +79,7 @@ function appleScriptWindowMatchTerms(target: WindowInfo): string[] {
     .filter((value) => value.length > 0 && value !== "unknown");
 }
 
-function runDarwinWindowScript(target: WindowInfo, body: string): void {
+function runDarwinWindowScript(target: WindowInfo, body: string): string {
   const terms = appleScriptWindowMatchTerms(target);
   const termList =
     terms.length > 0
@@ -117,7 +117,7 @@ function runDarwinWindowScript(target: WindowInfo, body: string): void {
         end repeat
       end tell`;
 
-  runCommand("osascript", ["-e", script], 5000);
+  return runCommand("osascript", ["-e", script], 5000);
 }
 
 // ── List Windows ────────────────────────────────────────────────────────────
@@ -328,6 +328,99 @@ export function resizeWindow(
     success: true,
     message: `Set window to (${validateInt(x)}, ${validateInt(y)})${size}.`,
   };
+}
+
+/**
+ * Read a window's bounds — position AND size — in OS-global logical pixels
+ * (#9170 M12 — cua `get_window_size` / `get_window_position`). When `windowId`
+ * is omitted, reads the currently-focused/foreground window. Returns
+ * `{ x, y, width, height }`.
+ *
+ * Windows: `GetWindowRect` via the window's `MainWindowHandle`. macOS: AppleScript
+ * `position`/`size` of the matched process window. Linux: `xdotool
+ * getwindowgeometry --shell`.
+ */
+export function getWindowBounds(windowId?: string): ScreenRegion {
+  const os = currentPlatform();
+  const id = windowId ?? getActiveWindow()?.id;
+  if (!id) {
+    throw new Error(
+      "No windowId provided and no active window to read bounds from",
+    );
+  }
+
+  if (os === "darwin") {
+    const target = resolveWindowTargetOrThrow(id);
+    const out = runDarwinWindowScript(
+      target,
+      `set winPos to position of window 1 of proc
+       set winSize to size of window 1 of proc
+       return ((item 1 of winPos) as text) & "," & ((item 2 of winPos) as text) & "," & ((item 1 of winSize) as text) & "," & ((item 2 of winSize) as text)`,
+    ).trim();
+    const [x, y, width, height] = out.split(",").map((v) => Number(v.trim()));
+    if ([x, y, width, height].some((n) => !Number.isFinite(n))) {
+      throw new Error(`Could not read window bounds for: ${id}`);
+    }
+    return { x, y, width, height };
+  }
+
+  if (os === "linux") {
+    if (!commandExists("xdotool")) {
+      throw new Error("getWindowBounds requires xdotool on Linux");
+    }
+    const commandId = resolveWindowCommandId(id);
+    const out = runCommand(
+      "xdotool",
+      ["getwindowgeometry", "--shell", commandId],
+      5000,
+    );
+    const mx = /X=(-?\d+)/.exec(out);
+    const my = /Y=(-?\d+)/.exec(out);
+    const mw = /WIDTH=(\d+)/.exec(out);
+    const mh = /HEIGHT=(\d+)/.exec(out);
+    if (!mx || !my || !mw || !mh) {
+      throw new Error(`Could not parse xdotool geometry for: ${id}`);
+    }
+    return {
+      x: validateInt(Number(mx[1])),
+      y: validateInt(Number(my[1])),
+      width: validateInt(Number(mw[1])),
+      height: validateInt(Number(mh[1])),
+    };
+  }
+
+  if (os === "win32") {
+    const commandId = resolveWindowCommandId(id);
+    // GetWindowRect via the process MainWindowHandle. Uses -MemberDefinition
+    // (signed-assembly P/Invoke, NOT a runtime-compiled inline class) to declare
+    // the RECT struct + the import together; see desktop.ts / setWindowBounds.
+    // NOTE: do NOT pass -UsingNamespace System.Runtime.InteropServices — Add-Type
+    // already imports it for the DllImport attribute, and a duplicate using is a
+    // warning-as-error that silently fails the type and yields a zeroed rect.
+    const ps = `
+      Add-Type -MemberDefinition '[StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left; public int Top; public int Right; public int Bottom; } [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);' -Name Win32Rect -Namespace Win32
+      $proc = Get-Process -Id ${commandId} -ErrorAction SilentlyContinue
+      if (-not $proc) { throw "Window not found: ${commandId}" }
+      $r = New-Object "Win32.Win32Rect+RECT"
+      [void][Win32.Win32Rect]::GetWindowRect($proc.MainWindowHandle, [ref]$r)
+      "$($r.Left),$($r.Top),$($r.Right),$($r.Bottom)"
+    `;
+    // 10s: the first Add-Type call JIT-compiles the P/Invoke shim (cold csc),
+    // which can exceed the 5s used elsewhere when the box is under load.
+    const out = runCommand("powershell", ["-Command", ps], 10000).trim();
+    const [left, top, right, bottom] = out.split(",").map((v) => Number(v.trim()));
+    if ([left, top, right, bottom].some((n) => !Number.isFinite(n))) {
+      throw new Error(`Could not read window bounds for: ${id}`);
+    }
+    return {
+      x: left,
+      y: top,
+      width: Math.max(0, right - left),
+      height: Math.max(0, bottom - top),
+    };
+  }
+
+  throw new Error(`getWindowBounds is not supported on ${os}`);
 }
 
 export function focusWindow(windowId: string): void {

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -84,6 +84,7 @@ import {
   getActiveWindow,
   getApplicationWindows,
   getScreenSize,
+  getWindowBounds,
   listWindows,
   maximizeWindow,
   minimizeWindow,
@@ -1086,6 +1087,19 @@ export class ComputerUseService extends Service {
           );
           return this.succeedEntry(entry, result);
         }
+        case "get_window_size":
+        case "get_window_position": {
+          // windowId is optional — defaults to the focused/foreground window.
+          const bounds = getWindowBounds(params.windowId);
+          return this.succeedEntry(entry, {
+            success: true,
+            bounds,
+            message:
+              params.action === "get_window_size"
+                ? `Window size: ${bounds.width}x${bounds.height}.`
+                : `Window position: (${bounds.x}, ${bounds.y}).`,
+          });
+        }
         default:
           return this.failEntry(entry, {
             success: false,
@@ -1513,6 +1527,8 @@ export class ComputerUseService extends Service {
         return "close_window";
       case "get_current_window_id":
       case "get_application_windows":
+      case "get_window_size":
+      case "get_window_position":
         // Read-only getters — auto-approve (mapped to the SAFE list_windows).
         return "list_windows";
       case "set_bounds":

--- a/plugins/plugin-computeruse/src/types.ts
+++ b/plugins/plugin-computeruse/src/types.ts
@@ -144,7 +144,9 @@ export type WindowActionType =
   | "close"
   | "get_current_window_id"
   | "get_application_windows"
-  | "set_bounds";
+  | "set_bounds"
+  | "get_window_size"
+  | "get_window_position";
 
 export interface WindowActionParams {
   action: WindowActionType;
@@ -216,6 +218,8 @@ export interface WindowActionResult extends ComputerUseResult {
   windowId?: string | null;
   /** Focused window descriptor for "get_current_window_id". */
   window?: WindowInfo | null;
+  /** Window bounds for "get_window_size" / "get_window_position". */
+  bounds?: ScreenRegion;
 }
 
 export type FileActionType =


### PR DESCRIPTION
## Summary

Completes the M12 window-getter surface for trycua/cua parity. cua exposes
`get_window_size` and `get_window_position`; we had `set_bounds` (set) +
`get_current_window_id` + `get_application_windows`, but **no bounds READ**. This
adds both as `WINDOW` verbs over a new `getWindowBounds(windowId?)` returning
`{x,y,width,height}` (foreground window when no id).

Found via an exhaustive parity-completeness workflow + adversarial verification
against `develop`; **zero swarm collision** (no open PR touches computeruse).

## Changes
- **`platform/windows-list.ts`** — `getWindowBounds`: win32 `GetWindowRect` via the
  process `MainWindowHandle`; macOS AppleScript `position`/`size`; Linux `xdotool
  getwindowgeometry --shell`. (`runDarwinWindowScript` now returns its output.)
- **`types.ts`** — `WindowActionType += get_window_size | get_window_position`;
  `WindowActionResult.bounds`.
- **`actions/window.ts`** — both verbs in `WINDOW_ACTIONS` → auto-promoted to
  `WINDOW_GET_WINDOW_SIZE` / `WINDOW_GET_WINDOW_POSITION`.
- **`services/computer-use-service.ts`** — `executeWindowAction` cases + read-only
  approval mapping (auto-approve).
- **`parity/parity-matrix.ts`** — register both (M12, windows: covered); the
  `validateParityMatrix` guard confirms they're live actions.
- **tests** — `m12-verbs` surface + `getWindowBounds` export; **reconciled the stale
  `cua-parity-coverage` registry**: `open`/`launch` were falsely `missing` → `have`;
  split the overstated filesystem line; and added the trycua **blind spots**
  (`set_value`, `kill_app`, `read_bytes`/`write_bytes`, `zoom`, screen-recording,
  agent-cursor) as explicit tracked decisions rather than silent gaps.

## Evidence (live Windows + all-platform default lane)
- **Real `GetWindowRect` on the live desktop**: `getWindowBounds("<pid>")` →
  `{"x":256,"y":102,"width":1216,"height":808}`.
- `bun run typecheck` → **0**.
- `m12-verbs` + `cua-parity-coverage` + `cua-parity-surface` + `windows-list` →
  **50/50**; `parity-matrix` (validateParityMatrix) → **4/4** (proves the new verbs
  are registered actions).
- **P/Invoke gotcha fixed + documented**: do NOT pass `-UsingNamespace
  System.Runtime.InteropServices` to `Add-Type` (it auto-imports it; a duplicate
  using is a warning-as-error that silently yields a zeroed rect); the first
  `Add-Type` compile needs a 10s timeout under load.

macOS/Linux paths follow the established per-OS pattern; their real actuation runs
in the (now OS-un-gated) real lane once the headful CI lanes exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)