### PR TITLE
feat(computeruse): kill_app — terminate a process by pid/name (trycua/cua parity, #9170)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
@@ -136,7 +136,7 @@ const CAPABILITIES: Capability[] = [
   },
   // ── trycua blind spots — tracked decisions, not silent gaps (workflow audit) ──
   { cua: "set_value (a11y element value write)", domain: "architecture", status: "missing", milestone: "a11y-write" },
-  { cua: "kill_app (process terminate)", domain: "architecture", status: "missing", milestone: "process-lifecycle" },
+  { cua: "kill_app (process terminate)", domain: "input", status: "have", verb: "kill_app", milestone: "M12" },
   {
     cua: "zoom (region magnify for grounding)",
     domain: "architecture",

--- a/plugins/plugin-computeruse/src/__tests__/m12-verbs.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/m12-verbs.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 import { computerUsePlugin } from "../index.js";
-import { launchApp, openTarget } from "../platform/launch.js";
+import { killApp, launchApp, openTarget } from "../platform/launch.js";
 import {
   getApplicationWindows,
   resizeWindow,
@@ -34,6 +34,23 @@ describe("open / launch guards", () => {
     expect(typeof result.pid).toBe("number");
     expect(result.pid).toBeGreaterThan(0);
     expect(result.command).toBe(process.execPath);
+  });
+
+  it("killApp rejects an empty target", async () => {
+    await expect(killApp("")).rejects.toThrow(/non-empty target/);
+    await expect(killApp("   ")).rejects.toThrow(/non-empty target/);
+  });
+
+  it("launch then kill_app round-trips by pid (real process)", async () => {
+    // Spawn a benign long-lived child, then terminate it by pid.
+    const launched = await launchApp(process.execPath, [
+      "-e",
+      "setTimeout(()=>{}, 60000)",
+    ]);
+    expect(launched.pid).toBeGreaterThan(0);
+    const killed = await killApp(String(launched.pid));
+    expect(killed.killed).toBe(true);
+    expect(killed.pid).toBe(launched.pid);
   });
 
   it("launchApp rejects a non-existent executable path", async () => {
@@ -66,11 +83,12 @@ describe("window getters", () => {
 });
 
 describe("action-surface promotion (M12)", () => {
-  it("promotes open / launch under COMPUTER_USE", () => {
+  it("promotes open / launch / kill_app under COMPUTER_USE", () => {
     expect(actionNames, `actions: ${actionNames.join(", ")}`).toContain(
       "COMPUTER_USE_OPEN",
     );
     expect(actionNames).toContain("COMPUTER_USE_LAUNCH");
+    expect(actionNames).toContain("COMPUTER_USE_KILL_APP");
   });
 
   it("promotes the new window getters under WINDOW", () => {

--- a/plugins/plugin-computeruse/src/actions/use-computer.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer.ts
@@ -57,6 +57,7 @@ const DESKTOP_ACTIONS = new Set<DesktopActionType>([
   "ocr",
   "open",
   "launch",
+  "kill_app",
 ]);
 
 type ComputerUseActionParams = Omit<DesktopActionParams, "action"> & {
@@ -260,6 +261,7 @@ export const useComputerAction: Action = {
           "ocr",
           "open",
           "launch",
+          "kill_app",
           "resolve_approval",
         ],
       },

--- a/plugins/plugin-computeruse/src/parity/parity-matrix.ts
+++ b/plugins/plugin-computeruse/src/parity/parity-matrix.ts
@@ -208,6 +208,14 @@ export const PARITY_MATRIX: readonly ParityCapability[] = [
     os: ALL_PLANNED,
   },
   {
+    id: "kill_app",
+    elizaVerb: "COMPUTER_USE_KILL_APP",
+    status: "have",
+    milestone: "M12",
+    note: "terminate by pid or process name (taskkill / kill / pkill)",
+    os: { windows: "covered", linux: "planned", macos: "planned", aosp: "na" },
+  },
+  {
     id: "get_current_window_id",
     elizaVerb: "WINDOW_GET_CURRENT_WINDOW_ID",
     status: "have",

--- a/plugins/plugin-computeruse/src/platform/launch.ts
+++ b/plugins/plugin-computeruse/src/platform/launch.ts
@@ -115,3 +115,65 @@ export function launchApp(
     });
   });
 }
+
+/** Result of a kill — the resolved target and how it was addressed. */
+export interface KillResult {
+  target: string;
+  /** Numeric pid when the target was a pid; omitted for a process-name kill. */
+  pid?: number;
+  killed: true;
+}
+
+/**
+ * Terminate a running application by pid (all-digits) or process name
+ * (#9170 — trycua/cua `kill_app`). Pairs with `launchApp`. Destructive, so it
+ * routes through the approval manager like every other non-read verb. Uses
+ * `execFile` (no shell) so the target can't inject a command.
+ *
+ *   - Windows: `taskkill /F /PID <n>` or `/F /IM <name>.exe`.
+ *   - macOS / Linux: `kill -9 <pid>` or `pkill -f <name>`.
+ *
+ * Rejects when the target does not exist (non-zero exit) so the caller gets
+ * clear feedback rather than a silent no-op.
+ */
+export function killApp(target: string): Promise<KillResult> {
+  const value = String(target ?? "").trim();
+  if (!value) {
+    return Promise.reject(
+      new Error("kill_app requires a non-empty target (pid or app name)"),
+    );
+  }
+  const isPid = /^\d+$/.test(value);
+  const os = currentPlatform();
+  let command: string;
+  let args: string[];
+  if (os === "win32") {
+    command = "taskkill";
+    args = isPid
+      ? ["/F", "/PID", value]
+      : ["/F", "/IM", value.toLowerCase().endsWith(".exe") ? value : `${value}.exe`];
+  } else if (os === "darwin" || os === "linux") {
+    if (isPid) {
+      command = "kill";
+      args = ["-9", value];
+    } else {
+      command = "pkill";
+      args = ["-f", value];
+    }
+  } else {
+    return Promise.reject(new Error(`kill_app unsupported on platform "${os}"`));
+  }
+  return new Promise<KillResult>((resolve, reject) => {
+    execFile(command, args, { timeout: OPEN_TIMEOUT_MS }, (err) => {
+      if (err) {
+        reject(
+          new Error(
+            `kill_app failed for "${value}": ${err.message} (target may not be running)`,
+          ),
+        );
+      } else {
+        resolve({ target: value, ...(isPid ? { pid: Number(value) } : {}), killed: true });
+      }
+    });
+  });
+}

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -66,7 +66,7 @@ import {
   writeFile,
 } from "../platform/file-ops.js";
 import { commandExists, currentPlatform } from "../platform/helpers.js";
-import { launchApp, openTarget } from "../platform/launch.js";
+import { killApp, launchApp, openTarget } from "../platform/launch.js";
 import { classifyPermissionDeniedError } from "../platform/permissions.js";
 import {
   clearTerminal,
@@ -284,6 +284,7 @@ export class ComputerUseService extends Service {
       case "ocr":
       case "open":
       case "launch":
+      case "kill_app":
         return this.executeDesktopAction({
           ...commandParameters<DesktopActionParams>(parameters),
           action: this.mapDesktopCommandToAction(command),
@@ -523,6 +524,21 @@ export class ComputerUseService extends Service {
             success: true,
             data: { pid: launched.pid, command: launched.command },
             message: `Launched ${params.app} (pid ${launched.pid}).`,
+          });
+        }
+        case "kill_app": {
+          // Accepts a pid or an app/process name via `target` (pairs with launch).
+          const target = params.target ?? params.app;
+          if (!target) {
+            throw new Error(
+              "target (pid or app name) is required for kill_app action",
+            );
+          }
+          const killed = await killApp(String(target));
+          return this.succeedEntry(entry, {
+            success: true,
+            data: killed,
+            message: `Terminated ${killed.target}.`,
           });
         }
         default:

--- a/plugins/plugin-computeruse/src/types.ts
+++ b/plugins/plugin-computeruse/src/types.ts
@@ -35,7 +35,8 @@ export type DesktopActionType =
   | "detect_elements"
   | "ocr"
   | "open"
-  | "launch";
+  | "launch"
+  | "kill_app";
 
 export interface DesktopActionParams {
   action: DesktopActionType;


### PR DESCRIPTION
## Summary
cua exposes `kill_app` (process terminate); we had `launch` (start) but no kill. Adds the sibling `COMPUTER_USE` verb, closing a tracked parity blind spot.

- **`platform/launch.ts`** — `killApp(target)`: win32 `taskkill /F /PID|/IM`, mac/linux `kill -9` (pid) / `pkill -f` (name). `execFile` (no shell → injection-safe); rejects when the target isn't running.
- **`types.ts` / `use-computer.ts`** — `DesktopActionType += kill_app`; in `DESKTOP_ACTIONS` + the action enum → auto-promoted `COMPUTER_USE_KILL_APP`. Destructive → not in `SAFE_COMMANDS`, so it requires approval under `smart_approve` (like `launch`).
- **`computer-use-service.ts`** — `executeCommand` + `executeDesktopAction` cases (`target`, falls back to `app`).
- **`parity-matrix.ts`** — registers `COMPUTER_USE_KILL_APP` (the `validateParityMatrix` guard confirms it's a live action).
- **tests** — `m12-verbs` launch→kill round-trip by pid + empty-target guard + promotion; `cua-parity-coverage` `kill_app` `missing`→`have`.

## Evidence (live Windows + default lane, all platforms)
- **Live Windows**: launched a node child (pid 11172), `killApp(pid)` terminated it, `tasklist` confirms gone; empty-target guard fires.
- `bun run typecheck` → **0**; `m12-verbs` + `cua-parity-coverage` + `parity-matrix` → **46/46**.

macOS/linux paths follow the established per-OS pattern; real actuation runs in the OS-un-gated real lane once the headful CI lanes exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)