### PR TITLE
style(app): organize-imports for the side-effect-modules plugin import (#9178)

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -29,11 +29,11 @@ import { syncElizaEnvAliases } from "../shared/src/utils/env.ts";
 import appConfig from "./app.config";
 import { CAPACITOR_PLUGIN_NAMES } from "./scripts/capacitor-plugin-names.mjs";
 import { normalizeEnvPrefix } from "./src/env-prefix.js";
+import { appSideEffectModulesPlugin } from "./vite/app-side-effect-modules.ts";
 import {
   generateNodeBuiltinStub,
   nativeModuleStubPlugin,
 } from "./vite/native-module-stub-plugin.ts";
-import { appSideEffectModulesPlugin } from "./vite/app-side-effect-modules.ts";
 import { resolveViteDevServerRuntime } from "./vite-dev-origin.ts";
 
 const _require = createRequire(import.meta.url);


### PR DESCRIPTION
Biome `organizeImports` follow-up to #9211 — the new `appSideEffectModulesPlugin` import wasn't in sorted order. `biome check --write` reorders it (1 line, no-op functionally). Lint now clean on the file.