### PR TITLE
fix(local-inference): run ensureLocalInferenceHandler on the bionic-delegated phone (#8848)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.test.ts
@@ -25,6 +25,31 @@ describe("shouldEnableMobileLocalInference", () => {
 		).toBe(true);
 	});
 
+	it("returns true when ELIZA_BIONIC_HOST_DELEGATED=1 (Android bionic delegation)", () => {
+		// The agent delegates inference to the in-process bionic Vulkan host over
+		// UDS; without this trigger ensureLocalInferenceHandler is skipped on the
+		// phone, so the bionic loader + TTS/TRANSCRIPTION/IMAGE_DESCRIPTION
+		// handlers never register and only the direct-reply chat path works (#8848).
+		expect(
+			shouldEnableMobileLocalInference(
+				{ ELIZA_BIONIC_HOST_DELEGATED: "1" },
+				"arm64",
+			),
+		).toBe(true);
+	});
+
+	it("ELIZA_DISABLE_FFI_LLAMA=1 does not block the bionic-host path (process-external UDS)", () => {
+		expect(
+			shouldEnableMobileLocalInference(
+				{
+					ELIZA_DISABLE_FFI_LLAMA: "1",
+					ELIZA_BIONIC_HOST_DELEGATED: "1",
+				},
+				"arm64",
+			),
+		).toBe(true);
+	});
+
 	it("auto-fires on riscv64 with no env flags", () => {
 		// node-llama-cpp has no riscv64 prebuild; the FFI loader (which dlopens
 		// the cross-built libllama.so) is the only in-process llama.cpp path

--- a/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.ts
+++ b/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.ts
@@ -31,16 +31,26 @@ export function shouldEnableMobileLocalInference(
 	env: NodeJS.ProcessEnv = process.env,
 	arch: NodeJS.Architecture = process.arch,
 ): boolean {
+	// Bionic-host delegation (Android dynamic-Vulkan): the app shell stages a
+	// dynamic-Vulkan `libelizainference.so` reachable only from the in-process
+	// bionic host and sets `ELIZA_BIONIC_HOST_DELEGATED=1` (suppressing
+	// ELIZA_LOCAL_LLAMA so the musl agent never dlopen's the lib). The agent talks
+	// to that host over the abstract UDS — a process-external backend just like
+	// the device bridge. Without counting it here, ensureLocalInferenceHandler is
+	// skipped on the phone, so `tryRegisterBionicHostLoader` + the
+	// TEXT/embedding (and TTS/TRANSCRIPTION/IMAGE_DESCRIPTION) handlers never
+	// register and only the mobile-local-direct-reply chat path works (#8848).
+	const bionicHost = env.ELIZA_BIONIC_HOST_DELEGATED?.trim() === "1";
 	if (env.ELIZA_DISABLE_FFI_LLAMA?.trim() === "1") {
-		// Operator opted out of the FFI path entirely — the device-bridge
-		// path remains valid because the bridge is process-external and
-		// doesn't depend on `libllama.so` being present in the APK.
-		return env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
+		// Operator opted out of the FFI path entirely — the device-bridge and the
+		// in-process bionic host are both process-external (WS / UDS) and don't
+		// depend on `libllama.so` being dlopen'd in this musl process.
+		return env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1" || bionicHost;
 	}
 	const deviceBridge = env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
 	const localLlama = env.ELIZA_LOCAL_LLAMA?.trim() === "1";
 	const riscv64Auto = arch === "riscv64";
-	return deviceBridge || localLlama || riscv64Auto;
+	return deviceBridge || localLlama || riscv64Auto || bionicHost;
 }
 
 /**


### PR DESCRIPTION
## Bug (found on a real Pixel 9a build off develop)
On Android with dynamic-Vulkan **bionic-host delegation** (`ELIZA_BIONIC_HOST_DELEGATED=1`, which suppresses `ELIZA_LOCAL_LLAMA`), `shouldEnableMobileLocalInference()` returned **false** — so `ensureLocalInferenceHandler` was skipped, `tryRegisterBionicHostLoader` never ran, and **no model handlers registered**. `POST /api/tts/local-inference` → `No handler found for delegate type: TEXT_TO_SPEECH`; `useModel(TEXT_SMALL/EMBEDDING/TRANSCRIPTION/IMAGE_DESCRIPTION)` likewise. LLM chat only worked because the `mobile-local-direct-reply` route bypasses the model registry.

## Fix
Count `ELIZA_BIONIC_HOST_DELEGATED=1` as a valid mobile-inference trigger (the bionic host is process-external over UDS, like the device bridge — so it also survives `ELIZA_DISABLE_FFI_LLAMA=1`). +2 gate tests → **15/15 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)