### PR TITLE
feat(local-inference): on-device ASR + vision via the bionic Vulkan host (#8848)

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
+++ b/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
@@ -1540,4 +1540,92 @@ Java_ai_elizaos_app_ElizaVoiceNative_nativeKokoroSynthesize(JNIEnv* env, jclass,
     return out;
 }
 
+// ── Batch ASR (synchronous, VAD-free) ────────────────────────────────────
+//
+// The streaming pipeline (nativePipelineProcess) is VAD-gated and needs the
+// VAD/diariz/speaker GGUFs staged; this is the DIRECT audio-in/text-out
+// transcribe the fused lib exposes (eliza_inference_asr_transcribe), which
+// only mmap-acquires the `asr/` weights on the resident context. The bionic
+// host's op="asr" calls this so the agent's TRANSCRIPTION delegate gets a
+// real on-device transcript without the full attribution pipeline.
+JNIEXPORT jstring JNICALL
+Java_ai_elizaos_app_ElizaVoiceNative_nativeAsrTranscribe(JNIEnv* env, jclass,
+                                                         jlong ctxHandle,
+                                                         jfloatArray jPcm,
+                                                         jint sampleRate) {
+    auto* ctx = reinterpret_cast<EliInferenceContext*>(ctxHandle);
+    if (!ctx) {
+        throw_runtime(env, "asrTranscribe: null context", nullptr);
+        return nullptr;
+    }
+    const jsize n = env->GetArrayLength(jPcm);
+    jfloat* pcm = env->GetFloatArrayElements(jPcm, nullptr);
+    if (!pcm) {
+        throw_runtime(env, "asrTranscribe: null PCM", nullptr);
+        return nullptr;
+    }
+    // 64 KiB transcript cap — far longer than any single utterance.
+    std::vector<char> out(65536, 0);
+    char* err = nullptr;
+    const int rc = eliza_inference_asr_transcribe(
+        ctx, reinterpret_cast<const float*>(pcm), static_cast<size_t>(n),
+        sampleRate > 0 ? sampleRate : kSampleRate, out.data(), out.size(),
+        &err);
+    env->ReleaseFloatArrayElements(jPcm, pcm, JNI_ABORT);
+    if (rc < 0) {
+        throw_runtime(env, "asr_transcribe", err);
+        return nullptr;
+    }
+    LOGI("nativeAsrTranscribe: %d samples @ %d Hz -> %d transcript bytes",
+         (int)n, (int)sampleRate, rc);
+    return to_jstring(env, std::string(out.data()));
+}
+
+// ── mmproj vision (ABI v9) ───────────────────────────────────────────────
+JNIEXPORT jint JNICALL
+Java_ai_elizaos_app_ElizaVoiceNative_nativeVisionSupported(JNIEnv*, jclass) {
+    return static_cast<jint>(eliza_inference_vision_supported());
+}
+
+// Describe a raw PNG/JPEG/WebP image with the resident TEXT model + an mmproj
+// projector (eliza_inference_describe_image). The bionic host's op="image"
+// calls this so the agent's IMAGE_DESCRIPTION delegate runs screen/vision
+// recognition fully on-device.
+JNIEXPORT jstring JNICALL
+Java_ai_elizaos_app_ElizaVoiceNative_nativeDescribeImage(JNIEnv* env, jclass,
+                                                         jlong ctxHandle,
+                                                         jbyteArray jImage,
+                                                         jstring jMmproj,
+                                                         jstring jPrompt) {
+    auto* ctx = reinterpret_cast<EliInferenceContext*>(ctxHandle);
+    if (!ctx) {
+        throw_runtime(env, "describeImage: null context", nullptr);
+        return nullptr;
+    }
+    const std::string mmproj = from_jstring(env, jMmproj);
+    const std::string prompt = from_jstring(env, jPrompt);
+    const jsize n = env->GetArrayLength(jImage);
+    jbyte* img = env->GetByteArrayElements(jImage, nullptr);
+    if (!img) {
+        throw_runtime(env, "describeImage: null image bytes", nullptr);
+        return nullptr;
+    }
+    std::vector<char> out(16384, 0);
+    char* err = nullptr;
+    const int rc = eliza_inference_describe_image(
+        ctx, reinterpret_cast<const unsigned char*>(img),
+        static_cast<size_t>(n),
+        mmproj.empty() ? nullptr : mmproj.c_str(),
+        prompt.empty() ? nullptr : prompt.c_str(), out.data(), out.size(),
+        &err);
+    env->ReleaseByteArrayElements(jImage, img, JNI_ABORT);
+    if (rc < 0) {
+        throw_runtime(env, "describe_image", err);
+        return nullptr;
+    }
+    LOGI("nativeDescribeImage: %d image bytes -> %d description bytes", (int)n,
+         rc);
+    return to_jstring(env, std::string(out.data()));
+}
+
 }  // extern "C"

--- a/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
+++ b/packages/app-core/platforms/android/app/src/main/elizavoice-jni/elizavoice-jni.cpp
@@ -1564,6 +1564,16 @@ Java_ai_elizaos_app_ElizaVoiceNative_nativeAsrTranscribe(JNIEnv* env, jclass,
         throw_runtime(env, "asrTranscribe: null PCM", nullptr);
         return nullptr;
     }
+    // The ASR weights are a voice-only mmap region that must be armed before
+    // transcribe (VoiceLifecycle normally does this on voice-on). The agent's
+    // one-shot transcribe path has no lifecycle, so arm it here (idempotent if
+    // already acquired).
+    char* acqErr = nullptr;
+    if (eliza_inference_mmap_acquire(ctx, "asr", &acqErr) != 0) {
+        env->ReleaseFloatArrayElements(jPcm, pcm, JNI_ABORT);
+        throw_runtime(env, "asr mmap_acquire", acqErr);
+        return nullptr;
+    }
     // 64 KiB transcript cap — far longer than any single utterance.
     std::vector<char> out(65536, 0);
     char* err = nullptr;

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
@@ -241,6 +241,14 @@ final class ElizaBionicInferenceServer {
                 return tts(bundleDir, req.optString("text", ""),
                     (float) req.optDouble("speed", 1.0));
             }
+            if ("asr".equals(op)) {
+                return asr(bundleDir, req.optString("pcmBase64", ""),
+                    req.optInt("sampleRate", 16000));
+            }
+            if ("image".equals(op)) {
+                return describeImage(bundleDir, req.optString("imageBase64", ""),
+                    req.optString("mmprojPath", ""), req.optString("prompt", ""));
+            }
             if (!"generate".equals(op)) {
                 return errorJson("unsupported op: " + op);
             }
@@ -579,6 +587,91 @@ final class ElizaBionicInferenceServer {
             } catch (Throwable t) {
                 // A failed synth may leave the shared ctx in an unknown state;
                 // drop it so the next generate/embed/tts rebuilds cleanly.
+                resetResident();
+                throw t;
+            }
+        }
+    }
+
+    /**
+     * On-device STT: decode the base64 little-endian fp32 PCM, run the fused
+     * Qwen3-ASR batch transcribe on the resident context (it mmap-acquires the
+     * {@code asr/} weights on first use), and return {ok, text}. The agent's
+     * TRANSCRIPTION delegate routes here over UDS (op="asr"); the musl agent
+     * can't reach the fused lib itself. Reuses the ONE resident context like
+     * embed/tts so the model is not reloaded per call.
+     */
+    private String asr(String bundleDir, String pcmBase64, int sampleRate)
+            throws org.json.JSONException {
+        if (pcmBase64.isEmpty()) {
+            return errorJson("asr: empty pcmBase64");
+        }
+        byte[] raw = Base64.decode(pcmBase64, Base64.DEFAULT);
+        final int n = raw.length / 4;
+        if (n <= 0) {
+            return errorJson("asr: pcmBase64 decoded to " + raw.length + " bytes (need fp32 PCM)");
+        }
+        float[] pcm = new float[n];
+        ByteBuffer bb = ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN);
+        for (int i = 0; i < n; i++) {
+            pcm[i] = bb.getFloat();
+        }
+        final int sr = sampleRate > 0 ? sampleRate : 16000;
+        synchronized (residentLock) {
+            final long ctx = ensureResidentCtx(bundleDir);
+            try {
+                String text = ElizaVoiceNative.nativeAsrTranscribe(ctx, pcm, sr);
+                Log.i(TAG, "ASR from agent: " + n + " samples @ " + sr + " Hz -> \""
+                    + (text.length() > 200 ? text.substring(0, 200) + "…" : text) + "\"");
+                return new JSONObject()
+                    .put("ok", true)
+                    .put("text", text)
+                    .toString();
+            } catch (Throwable t) {
+                // A failed transcribe may leave the shared ctx in an unknown state;
+                // drop it so the next generate/embed/tts/asr rebuilds cleanly.
+                resetResident();
+                throw t;
+            }
+        }
+    }
+
+    /**
+     * On-device vision / screen-recognition: decode the base64 image bytes and
+     * run the fused mmproj describe-image on the resident TEXT model. When the
+     * caller doesn't pass an explicit {@code mmprojPath}, resolve the projector
+     * GGUF from the bundle's {@code vision/} dir. Returns {ok, text}. The agent's
+     * IMAGE_DESCRIPTION delegate routes here over UDS (op="image").
+     */
+    private String describeImage(String bundleDir, String imageBase64,
+            String mmprojPath, String prompt) throws org.json.JSONException {
+        if (imageBase64.isEmpty()) {
+            return errorJson("image: empty imageBase64");
+        }
+        byte[] img = Base64.decode(imageBase64, Base64.DEFAULT);
+        if (img.length == 0) {
+            return errorJson("image: imageBase64 decoded to 0 bytes");
+        }
+        String mmproj = mmprojPath;
+        if (mmproj == null || mmproj.isEmpty()) {
+            File visionDir = new File(bundleDir, "vision");
+            mmproj = firstMatch(visionDir, ".gguf");
+            if (mmproj == null) {
+                return errorJson("image: mmproj GGUF not found under " + visionDir
+                    + " (stage a vision projector or pass mmprojPath)");
+            }
+        }
+        synchronized (residentLock) {
+            final long ctx = ensureResidentCtx(bundleDir);
+            try {
+                String desc = ElizaVoiceNative.nativeDescribeImage(ctx, img, mmproj, prompt);
+                Log.i(TAG, "IMAGE from agent: " + img.length + " bytes (mmproj " + mmproj + ") -> \""
+                    + (desc.length() > 200 ? desc.substring(0, 200) + "…" : desc) + "\"");
+                return new JSONObject()
+                    .put("ok", true)
+                    .put("text", desc)
+                    .toString();
+            } catch (Throwable t) {
                 resetResident();
                 throw t;
             }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoiceNative.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoiceNative.java
@@ -228,4 +228,28 @@ final class ElizaVoiceNative {
      */
     static native float[] nativeKokoroSynthesize(
             long ctxHandle, String ggufPath, String voiceBinPath, String text, float speed);
+
+    // ── Batch ASR + mmproj vision (the agent's STT / screen-recognition path) ──
+
+    /**
+     * Transcribe {@code pcm} (16 kHz mono fp32) → UTF-8 transcript via the fused
+     * Qwen3-ASR head ({@code eliza_inference_asr_transcribe}). VAD-free: the
+     * resident context mmap-acquires the {@code asr/} weights on first use. The
+     * bionic host's op="asr" calls this so the agent TRANSCRIPTION delegate gets
+     * a real on-device transcript without the full attribution pipeline.
+     */
+    static native String nativeAsrTranscribe(long ctxHandle, float[] pcm, int sampleRate);
+
+    /** {@code eliza_inference_vision_supported()} (ABI v9): 1 if mmproj vision is built. */
+    static native int nativeVisionSupported();
+
+    /**
+     * Describe a raw PNG/JPEG/WebP image with the resident TEXT model + the
+     * mmproj projector at {@code mmprojPath} ({@code eliza_inference_describe_image}).
+     * {@code prompt} may be empty (a default describe prompt is used). The bionic
+     * host's op="image" calls this so the agent IMAGE_DESCRIPTION delegate runs
+     * screen/vision recognition fully on-device.
+     */
+    static native String nativeDescribeImage(
+            long ctxHandle, byte[] imageBytes, String mmprojPath, String prompt);
 }

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -995,6 +995,99 @@ function makeImageDescriptionHandler(): ImageDescriptionHandler {
 	};
 }
 
+// ── Bionic-host TRANSCRIPTION / IMAGE_DESCRIPTION (Android GPU delegation) ──
+//
+// On the bionic-delegated path the musl agent can't load the fused
+// libelizainference, so the engine-driven transcriber / memory-arbiter vision
+// paths above can't run here. Instead the audio / image bytes are forwarded to
+// the in-process bionic host over the UDS (op="asr" / op="image"), which runs
+// the fused Qwen3-ASR + mmproj vision on the Mali GPU and returns text. This is
+// the same delegation `BionicHostLoader` already does for text generation.
+
+/** The bionic-host loader when registered (exposes transcribe + describeImage). */
+function getBionicHostLoader(runtime: IAgentRuntime): BionicHostLoader | null {
+	const svc = (
+		runtime as { getService?: (name: string) => unknown }
+	).getService?.("localInferenceLoader");
+	if (
+		svc &&
+		typeof (svc as BionicHostLoader).transcribe === "function" &&
+		typeof (svc as BionicHostLoader).describeImage === "function"
+	) {
+		return svc as BionicHostLoader;
+	}
+	return null;
+}
+
+/** Pack a mono fp32 PCM buffer little-endian and base64-encode it for the UDS frame. */
+function float32ToBase64LE(pcm: Float32Array): string {
+	const buf = Buffer.allocUnsafe(pcm.length * 4);
+	for (let i = 0; i < pcm.length; i++) {
+		buf.writeFloatLE(pcm[i] ?? 0, i * 4);
+	}
+	return buf.toString("base64");
+}
+
+/** Resolve a vision request to base64 image bytes for the bionic host. */
+async function imageRequestToBase64(image: {
+	kind: "dataUrl" | "url";
+	dataUrl?: string;
+	url?: string;
+}): Promise<string> {
+	if (image.kind === "dataUrl" && image.dataUrl) {
+		const comma = image.dataUrl.indexOf(",");
+		return comma >= 0 ? image.dataUrl.slice(comma + 1) : image.dataUrl;
+	}
+	if (image.kind === "url" && image.url) {
+		const resp = await fetch(image.url);
+		if (!resp.ok) {
+			throw new Error(
+				`[local-inference] IMAGE_DESCRIPTION failed to fetch ${image.url}: ${resp.status}`,
+			);
+		}
+		return Buffer.from(await resp.arrayBuffer()).toString("base64");
+	}
+	throw new Error("[local-inference] IMAGE_DESCRIPTION could not resolve image bytes");
+}
+
+function makeBionicTranscriptionHandler(): TranscriptionHandler {
+	return async (runtime, params) => {
+		const signal = extractTranscriptionSignal(params);
+		throwIfAborted(signal);
+		const loader = getBionicHostLoader(runtime);
+		if (!loader) {
+			throw new Error(
+				"[local-inference] bionic-host TRANSCRIPTION requires the bionic-host loader (localInferenceLoader service)",
+			);
+		}
+		const audio = extractTranscriptionAudio(params);
+		throwIfAborted(signal);
+		const transcript = await loader.transcribe({
+			pcmBase64: float32ToBase64LE(audio.pcm),
+			sampleRate: audio.sampleRate,
+		});
+		throwIfAborted(signal);
+		return transcript;
+	};
+}
+
+function makeBionicImageDescriptionHandler(): ImageDescriptionHandler {
+	return async (runtime, params) => {
+		const loader = getBionicHostLoader(runtime);
+		if (!loader) {
+			throw new Error(
+				"[local-inference] bionic-host IMAGE_DESCRIPTION requires the bionic-host loader (localInferenceLoader service)",
+			);
+		}
+		const request = paramsToVisionRequest(params);
+		const description = await loader.describeImage({
+			imageBase64: await imageRequestToBase64(request.image),
+			prompt: request.prompt,
+		});
+		return normalizeImageDescription(description);
+	};
+}
+
 /**
  * Register the device-bridge loader on the runtime. Accepts load/generate
  * calls whether or not a mobile device is currently connected — parked
@@ -1437,20 +1530,28 @@ export async function ensureLocalInferenceHandler(
 		// makeTranscriptionHandler / EngineVoiceBridge.createStreamingTranscriber.
 		// (The old ELIZA_LOCAL_TRANSCRIPTION env gate is removed — voice is a
 		// first-class Eliza-1 surface, not opt-in.)
+		// On the bionic-delegated path the fused lib lives in the app process, not
+		// this musl agent — so transcription + vision must forward audio/image
+		// bytes to the bionic host (op="asr" / op="image") rather than the
+		// in-process engine / memory-arbiter, which can't load the lib here.
 		runtimeWithRegistration.registerModel(
 			ModelType.TRANSCRIPTION,
-			makeTranscriptionHandler(),
+			bionicHostRegistered
+				? makeBionicTranscriptionHandler()
+				: makeTranscriptionHandler(),
 			provider,
 			LOCAL_INFERENCE_PRIORITY,
 		);
 		runtimeWithRegistration.registerModel(
 			ModelType.IMAGE_DESCRIPTION,
-			makeImageDescriptionHandler(),
+			bionicHostRegistered
+				? makeBionicImageDescriptionHandler()
+				: makeImageDescriptionHandler(),
 			provider,
 			LOCAL_INFERENCE_PRIORITY,
 		);
 		logger.info(
-			`[local-inference] Registered ${provider} voice and vision handlers for TEXT_TO_SPEECH / TRANSCRIPTION / IMAGE_DESCRIPTION at priority ${LOCAL_INFERENCE_PRIORITY}`,
+			`[local-inference] Registered ${provider} voice and vision handlers for TEXT_TO_SPEECH / TRANSCRIPTION / IMAGE_DESCRIPTION at priority ${LOCAL_INFERENCE_PRIORITY}${bionicHostRegistered ? " (bionic-host delegated)" : ""}`,
 		);
 	} catch (err) {
 		logger.warn(

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
@@ -130,4 +130,62 @@ describe("BionicHostLoader (real abstract-UDS)", () => {
 		await loader.loadModel({ modelPath: "/m/text/x.gguf" });
 		await expect(loader.generate({ prompt: "x" })).rejects.toThrow();
 	});
+
+	it("transcribe forwards op=asr with pcm + sampleRate and returns the transcript", async () => {
+		let seen: Record<string, unknown> | null = null;
+		host = startHost(SOCK, (req) => {
+			seen = req;
+			return JSON.stringify({ ok: true, text: "the quick brown fox" });
+		});
+		const loader = new BionicHostLoader(SOCK);
+		await loader.loadModel({
+			modelPath: "/data/x/eliza-1/bundle/text/model.gguf",
+		});
+		const out = await loader.transcribe({
+			pcmBase64: "AAAA",
+			sampleRate: 16000,
+		});
+		expect(out).toBe("the quick brown fox");
+		expect(seen).toMatchObject({
+			op: "asr",
+			pcmBase64: "AAAA",
+			sampleRate: 16000,
+			bundleDir: "/data/x/eliza-1/bundle",
+		});
+	});
+
+	it("describeImage forwards op=image with bytes + prompt and returns the description", async () => {
+		let seen: Record<string, unknown> | null = null;
+		host = startHost(SOCK, (req) => {
+			seen = req;
+			return JSON.stringify({ ok: true, text: "a cat on a desk" });
+		});
+		const loader = new BionicHostLoader(SOCK);
+		await loader.loadModel({
+			modelPath: "/data/x/eliza-1/bundle/text/model.gguf",
+		});
+		const out = await loader.describeImage({
+			imageBase64: "iVBORw0K",
+			prompt: "what is this?",
+		});
+		expect(out).toBe("a cat on a desk");
+		expect(seen).toMatchObject({
+			op: "image",
+			imageBase64: "iVBORw0K",
+			prompt: "what is this?",
+			mmprojPath: "",
+			bundleDir: "/data/x/eliza-1/bundle",
+		});
+	});
+
+	it("transcribe throws on host ok:false", async () => {
+		host = startHost(SOCK, () =>
+			JSON.stringify({ ok: false, error: "no asr weights staged" }),
+		);
+		const loader = new BionicHostLoader(SOCK);
+		await loader.loadModel({ modelPath: "/m/text/x.gguf" });
+		await expect(
+			loader.transcribe({ pcmBase64: "AAAA", sampleRate: 16000 }),
+		).rejects.toThrow(/no asr weights staged/);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
@@ -43,6 +43,13 @@ interface BionicGenerateResponse {
 	tokS?: number;
 }
 
+/** {ok, text} response for the asr / image ops (transcript / description). */
+interface BionicTextResponse {
+	ok: boolean;
+	text?: string;
+	error?: string;
+}
+
 /**
  * Derive the fused-bundle root from a model GGUF path. The host's
  * `eliza_inference_create(bundleDir)` expects the directory that contains
@@ -101,6 +108,56 @@ export class BionicHostLoader implements LocalInferenceLoader {
 		if (typeof res.tokS === "number") {
 			logger.debug(
 				`[BionicHostLoader] generated ${res.tokens ?? "?"} tok @ ${res.tokS.toFixed(1)} tok/s on the bionic GPU host`,
+			);
+		}
+		return res.text ?? "";
+	}
+
+	/**
+	 * On-device STT: transcribe mono fp32 PCM via the bionic host's fused
+	 * Qwen3-ASR (op="asr"). The musl agent can't load the fused lib, so the
+	 * TRANSCRIPTION delegate routes the audio here over the UDS and gets the
+	 * transcript back. `pcm` is little-endian fp32 already base64-encoded.
+	 */
+	async transcribe(args: {
+		pcmBase64: string;
+		sampleRate: number;
+	}): Promise<string> {
+		const res = await this.roundTrip<BionicTextResponse>({
+			op: "asr",
+			bundleDir: this.bundleDir,
+			pcmBase64: args.pcmBase64,
+			sampleRate: args.sampleRate,
+		});
+		if (!res.ok) {
+			throw new Error(
+				`[BionicHostLoader] host asr failed: ${res.error ?? "unknown error"}`,
+			);
+		}
+		return res.text ?? "";
+	}
+
+	/**
+	 * On-device vision / screen-recognition: describe a raw image (PNG/JPEG/WebP
+	 * bytes, base64) via the bionic host's mmproj describe-image (op="image").
+	 * `mmprojPath` may be empty — the host resolves the projector from the
+	 * bundle's `vision/` dir.
+	 */
+	async describeImage(args: {
+		imageBase64: string;
+		mmprojPath?: string;
+		prompt?: string;
+	}): Promise<string> {
+		const res = await this.roundTrip<BionicTextResponse>({
+			op: "image",
+			bundleDir: this.bundleDir,
+			imageBase64: args.imageBase64,
+			mmprojPath: args.mmprojPath ?? "",
+			prompt: args.prompt ?? "",
+		});
+		if (!res.ok) {
+			throw new Error(
+				`[BionicHostLoader] host image describe failed: ${res.error ?? "unknown error"}`,
 			);
 		}
 		return res.text ?? "";


### PR DESCRIPTION
## What

Wires **on-device STT/ASR and vision/screen-recognition** through the in-process bionic Vulkan inference host on Android, so the agent's `TRANSCRIPTION` + `IMAGE_DESCRIPTION` model delegates run on the Mali GPU instead of failing.

The bionic host (`ai.elizaos.app`) already served generate/embed/tts for the musl agent over an abstract UDS, but had no ASR or vision op — and the musl agent can't dlopen the fused `libelizainference.so` itself (Vulkan/HIDL wall), while the streaming voice pipeline is VAD-gated on GGUFs not shipped in the bundle. So transcription + vision had nowhere to run on the phone.

## Changes

- **JNI** (`elizavoice-jni` / `ElizaVoiceNative`): `nativeAsrTranscribe` (`eliza_inference_asr_transcribe`, VAD-free batch — self-arms the `asr` mmap region via `mmap_acquire`) + `nativeDescribeImage` / `nativeVisionSupported` (`eliza_inference_describe_image`, ABI-v9 mmproj vision).
- **Bionic host** (`ElizaBionicInferenceServer`): `op:"asr"` (base64 fp32 PCM → transcript) and `op:"image"` (base64 image + mmproj → description), reusing the resident context like embed/tts so the model is not reloaded per call.
- **Agent** (`BionicHostLoader.transcribe()/describeImage()`): route `TRANSCRIPTION` + `IMAGE_DESCRIPTION` to the host over UDS when bionic delegation is active, instead of the in-process engine / memory-arbiter that can't load the lib on-device.
- Loader unit tests (real abstract-UDS round-trip) for the two new ops.

## Evidence — verified on a Pixel 9a (Mali-G715, fused `libelizainference` on Vulkan)

All four local-AI modalities forward-pass on one fresh sideload build, through the same bionic-host ops the agent delegates use:

| Modality | Op | Result |
|---|---|---|
| LLM | `generate` | `"Paris"` (capital of France), resident |
| Voice/TTS | `tts` (Kokoro) | ok, 71760 samples @ 24 kHz (fused, not system TTS) |
| STT/ASR | `asr` | real speech → `"What time is it?"` |
| Vision/screen-rec | `image` | accurate description of a real device screenshot ("…app called 'Milady'… 'App info'… 'Close app'…") |

The eliza-1 vision projector is the Qwen3.5-2B mmproj (`projection_dim 2048`, `qwen3vl_merger`), matching the resident `qwen35` text model.

## Gates

- `biome lint` (touched TS): clean
- `tsgo --noEmit` (plugin-local-inference): clean
- vitest: **1942 passed / 3 skipped / 0 failed**
- Android `assembleDebug` + NDK `buildCMakeDebug[arm64-v8a]`: BUILD SUCCESSFUL; verified the rebuilt `.so` exports `nativeAsrTranscribe`/`nativeDescribeImage` and the agent bundle carries the routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)