### PR TITLE
fix(cloud): apps deploy — hard CPU/swap caps + per-org container quota

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/deploy/route.ts
@@ -14,6 +14,7 @@
 
 import { Hono } from "hono";
 import { appsDeployOrganizationDecision } from "@/api-app/lib/apps-deploy-gate";
+import { containersRepository } from "@/db/repositories/containers";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDeploymentsService } from "@/lib/services/app-deployments";
@@ -85,6 +86,22 @@ app.post("/", async (c) => {
           error: parsed.error.issues[0]?.message ?? "Invalid request body",
         },
         400,
+      );
+    }
+
+    // Per-org container quota precheck — give the user an immediate, clean 409
+    // instead of queueing a deploy that fails ~30s later (the runner also
+    // enforces this atomically via createWithQuotaCheck; this is the UX layer).
+    const quota = await containersRepository.checkQuota(user.organization_id);
+    if (!quota.allowed) {
+      return c.json(
+        {
+          success: false,
+          error:
+            quota.error ??
+            `Container quota exceeded (${quota.current}/${quota.max})`,
+        },
+        409,
       );
     }
 

--- a/packages/cloud-shared/src/lib/services/__tests__/app-docker-cmd.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-docker-cmd.test.ts
@@ -13,7 +13,7 @@ function input(over: Partial<CreateContainerInput> = {}): CreateContainerInput {
     image: "ghcr.io/nubs/nubilio:latest",
     port: 3000,
     desiredCount: 1,
-    cpu: 1,
+    cpu: 1024,
     memoryMb: 512,
     healthCheckPath: "/health",
     ...over,
@@ -55,6 +55,16 @@ describe("buildAppDockerCreateCmd", () => {
     expect(cmd).toContain("-p 49001:3000");
     expect(cmd).toContain("--memory '512m'");
     expect(cmd).toContain("'ghcr.io/nubs/nubilio:latest'");
+  });
+
+  test("caps CPU and pins swap to the memory limit (untrusted-tenant DoS guards)", () => {
+    // 1024 ECS units = 1 full vCPU.
+    expect(build()).toContain("--cpus 1");
+    // Fractional + multi-vCPU allocations convert cleanly.
+    expect(build({ cpu: 512 })).toContain("--cpus 0.5");
+    expect(build({ cpu: 2048 })).toContain("--cpus 2");
+    // Swap pinned to the memory limit (no swap escape of the --memory ceiling).
+    expect(build()).toContain("--memory-swap '512m'");
   });
 
   test("never auto-injects DATABASE_URL, but forwards a caller-supplied one", () => {

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -155,7 +155,12 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
     const createContainerRow =
       this.deps.createContainerRow ??
       (async (row: NewAppContainerRow) => {
-        const created = await containersRepository.create(toNewContainer(row));
+        // Enforce the per-org container quota atomically — the same cap
+        // (credit-balance-derived) the normal /v1/containers API uses. Without
+        // this, the apps deploy path bypassed quota entirely and one org could
+        // spin up unbounded 24/7 containers (DoS / unbounded cost). Throws
+        // QuotaExceededError when over cap; the deploy route surfaces it.
+        const created = await containersRepository.createWithQuotaCheck(toNewContainer(row));
         return { containerId: created.id };
       });
 

--- a/packages/cloud-shared/src/lib/services/app-docker-cmd.ts
+++ b/packages/cloud-shared/src/lib/services/app-docker-cmd.ts
@@ -63,7 +63,20 @@ export function buildAppDockerCreateCmd(params: BuildAppDockerCmdParams): string
     "--health-timeout 5s",
     "--health-start-period 15s",
     "--health-retries 6",
-    ...(input.memoryMb ? [`--memory ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`] : []),
+    ...(input.memoryMb
+      ? [
+          `--memory ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
+          // Pin swap to the memory limit (i.e. no swap) so an untrusted image
+          // can't escape the --memory ceiling via swap on the shared node.
+          `--memory-swap ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
+        ]
+      : []),
+    // Hard CPU cap. `cpu` is ECS-style units (1024 = 1 vCPU), the same unit
+    // docker's --cpus takes once divided. Without this an untrusted tenant image
+    // can pin every core on the shared node and starve every co-tenant app (a
+    // cross-tenant availability break) — the dedicated-vCPU node sizing alone
+    // does NOT prevent in-node CPU theft.
+    ...(input.cpu > 0 ? [`--cpus ${input.cpu / 1024}`] : []),
     `-p ${params.hostPort}:${input.port}`,
     envFlags,
     shellQuote(input.image),


### PR DESCRIPTION
## Apps deploy: hard CPU/swap caps + per-org container quota

First of the Product-2 apps-deploy production-readiness blockers (from the adversarial audit on #8434). Both are untrusted-multi-tenant-on-shared-node hardening.

### 1. CPU DoS (blockers #2/#3) — `app-docker-cmd.ts`
`buildAppDockerCreateCmd` emitted `--memory` but **never `--cpus`**, even though `container-provider-input.ts` documents `cpu` as billed + intended to cap the container. So an untrusted tenant image (or a hot loop / crypto-miner) could pin **every core** on the shared node and starve every co-tenant app — a cross-tenant availability break. Dedicated-vCPU node sizing alone doesn't prevent in-node CPU theft.
- Emit `--cpus <cpu/1024>` (ECS units → docker decimal).
- Pin `--memory-swap` to the memory limit so the `--memory` ceiling can't be escaped via swap.

### 2. No per-org quota (blocker #8) — `app-deploy-runner.ts` + deploy route
The apps deploy path inserted the container via `containersRepository.create`, **bypassing** the per-org quota the normal `/v1/containers` API enforces — one org could spin up unbounded 24/7 containers (DoS / unbounded cost).
- Route the insert through `createWithQuotaCheck` (atomic, credit-balance-derived cap).
- Add a `checkQuota` **precheck** at the deploy route → immediate clean **409** instead of a deploy that fails ~30s later (UX).

### Tests
`app-docker-cmd.test.ts` asserts `--cpus` (1 / 0.5 / 2 vCPU) + `--memory-swap`; existing app-deploy suites stay green (18 pass / 0 fail). biome + typecheck clean.

Part of the Product-2 enablement: NO-GO → fixing all 8 blockers before provisioning + canary. Tenant data-isolation core (per-tenant DB + `REVOKE CONNECT`) was audited and is sound; these are the operational/resource hardening blockers.
