### PR TITLE
feat(ui): rank home-slot widgets via rankHomeWidgets (#9143)

### DIFF
--- a/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginWidgetDeclaration } from "./types";
+import { WidgetHost } from "./WidgetHost";
+
+// #9143 — the home slot must rank its declared widgets and render only the
+// top-N (HOME_MAX_VISIBLE = 6). Other slots render everything unchanged.
+
+const mockAppState = {
+  plugins: [{ id: "home-plugin", enabled: true, isActive: true }],
+  t: (key: string) => key,
+};
+
+vi.mock("../state", () => ({
+  useApp: () => mockAppState,
+  useAppSelector: <T,>(selector: (s: typeof mockAppState) => T): T =>
+    selector(mockAppState),
+  useAppSelectorShallow: <T,>(selector: (s: typeof mockAppState) => T): T =>
+    selector(mockAppState),
+}));
+
+vi.mock("../state/useDeveloperMode", () => ({
+  useIsDeveloperMode: () => false,
+}));
+
+/** A minimal uiSpec home widget keyed by id + base `order`. */
+function homeDecl(id: string, order: number): PluginWidgetDeclaration {
+  return {
+    id,
+    pluginId: "home-plugin",
+    slot: "home",
+    label: id,
+    order,
+    uiSpec: {
+      root: "root",
+      state: {},
+      elements: {
+        root: { type: "Text", props: { text: id }, children: [] },
+      },
+    },
+  };
+}
+
+// Ten home widgets with distinct base orders. Lower order = higher base score,
+// so the deterministic ranking surfaces w0..w5 (orders 0..50) and drops the
+// four with the highest orders. Declared out of order to prove the host ranks
+// rather than relying on resolver order.
+const HOME_DECLS = [
+  homeDecl("w7", 70),
+  homeDecl("w2", 20),
+  homeDecl("w9", 90),
+  homeDecl("w0", 0),
+  homeDecl("w5", 50),
+  homeDecl("w3", 30),
+  homeDecl("w8", 80),
+  homeDecl("w1", 10),
+  homeDecl("w6", 60),
+  homeDecl("w4", 40),
+];
+
+vi.mock("./registry", () => ({
+  resolveWidgetsForSlot: (slot: string) =>
+    (slot === "home" ? HOME_DECLS : []).map((declaration) => ({
+      declaration,
+      Component: null,
+    })),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderedIds(): string[] {
+  return screen
+    .getAllByTestId(/^widget-uispec-/)
+    .map((el) => el.getAttribute("data-testid")?.replace("widget-uispec-", ""))
+    .filter((id): id is string => Boolean(id));
+}
+
+describe("WidgetHost home-slot ranking (#9143)", () => {
+  it("renders only the top-6 home widgets, ranked by score (lower order first)", () => {
+    render(<WidgetHost slot="home" />);
+
+    const ids = renderedIds();
+    expect(ids).toHaveLength(6);
+    // Lower `order` → higher base score → rendered first; top-6 are w0..w5.
+    expect(ids).toEqual(["w0", "w1", "w2", "w3", "w4", "w5"]);
+
+    // The four lowest-priority widgets are dropped.
+    for (const dropped of ["w6", "w7", "w8", "w9"]) {
+      expect(screen.queryByTestId(`widget-uispec-${dropped}`)).toBeNull();
+    }
+  });
+
+  it("is deterministic — the ranked order is stable across re-renders", () => {
+    const { rerender } = render(<WidgetHost slot="home" />);
+    const first = renderedIds();
+
+    rerender(<WidgetHost slot="home" className="changed" />);
+    const second = renderedIds();
+
+    expect(second).toEqual(first);
+    expect(first).toEqual(["w0", "w1", "w2", "w3", "w4", "w5"]);
+  });
+});

--- a/packages/ui/src/widgets/WidgetHost.tsx
+++ b/packages/ui/src/widgets/WidgetHost.tsx
@@ -16,9 +16,13 @@ import { UiRenderer } from "../components/config-ui/ui-renderer";
 import type { ActivityEvent } from "../hooks/useActivityEvents";
 import { useAppSelectorShallow } from "../state";
 import { useEnabledViewKinds } from "../state/useViewKinds";
+import { homeWidgetKey, rankHomeWidgets } from "./home-priority";
 import { resolveWidgetsForSlot } from "./registry";
 import type { PluginWidgetDeclaration, WidgetProps, WidgetSlot } from "./types";
 import { WIDGET_UI_ACTION_EVENT } from "./WidgetHost.constants";
+
+/** The home surface only ever shows the top few highest-priority widgets. */
+const HOME_MAX_VISIBLE = 6;
 
 export interface WidgetUiActionEventDetail {
   pluginId: string;
@@ -130,13 +134,37 @@ export function WidgetHost({
     return filter ? gated.filter((entry) => filter(entry.declaration)) : gated;
   }, [slot, plugins, filter, enabledKinds]);
 
+  // The home surface must not render every declared widget — rank by current
+  // importance and show only the top-N (#9143). Live attention/decay signals
+  // aren't yet attributable to a specific widget from the activity stream, so
+  // ranking runs with no signals and reduces to deterministic base ordering
+  // (no reshuffle between renders). With an empty signal set `now` never feeds
+  // the decay math, so a fixed epoch keeps this render path deterministic (the
+  // UI-determinism gate forbids `Date.now()` in render) — when signal wiring
+  // lands, `now` will be threaded in off the render path. Other slots render
+  // every resolved widget unchanged.
+  const displayed = useMemo(() => {
+    if (slot !== "home") return resolved;
+    const byKey = new Map(
+      resolved.map((entry) => [homeWidgetKey(entry.declaration), entry]),
+    );
+    return rankHomeWidgets(
+      resolved.map((entry) => entry.declaration),
+      [],
+      { now: 0, maxVisible: HOME_MAX_VISIBLE },
+    ).flatMap((ranked) => {
+      const entry = byKey.get(homeWidgetKey(ranked.declaration));
+      return entry ? [entry] : [];
+    });
+  }, [slot, resolved]);
+
   const pluginById = useMemo(() => {
     const map = new Map<string, (typeof plugins)[number]>();
     for (const p of plugins ?? []) map.set(p.id, p);
     return map;
   }, [plugins]);
 
-  if (resolved.length === 0 && hideWhenEmpty) return null;
+  if (displayed.length === 0 && hideWhenEmpty) return null;
 
   const layoutClass =
     layout === "grid"
@@ -150,7 +178,7 @@ export function WidgetHost({
       data-layout={layout}
       data-slot={slot}
     >
-      {resolved.map(({ declaration, Component }) => {
+      {displayed.map(({ declaration, Component }) => {
         const widgetKey = `${declaration.pluginId}/${declaration.id}`;
         const pluginState = pluginById.get(declaration.pluginId);
 


### PR DESCRIPTION
Wires the orphaned home-widget ranking core (`packages/ui/src/widgets/home-priority.ts` — built + unit-tested, never called) into `WidgetHost` for the `home` slot only: resolved declarations now pass through `rankHomeWidgets(decls, [], {maxVisible:6})` and render the top-6. Non-home slots are byte-for-byte unchanged. Signals=[] (the `events` prop carries no widget attribution) → deterministic base-`order` ranking; `now:0` to satisfy the package's render-determinism gate.

Tests: 20 passed (new WidgetHost.home-rank.test.tsx + existing WidgetHost + home-priority suites). Typecheck + biome clean.

Part of #9143 (the per-plugin/shared-sink breadth remains the larger epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)