### PR TITLE
fix(app): un-stub `buffer` so vendor-crypto has a callable Buffer (fixes black-screen on every build)

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -189,6 +189,28 @@ const capacitorCoreEntry = path.join(
   "dist/index.js",
 );
 const patheEntry = _require.resolve("pathe");
+// The REAL feross `buffer` (a callable Buffer function), aliased below so the
+// crypto/wallet graph gets a working Buffer instead of the native-module-stub
+// plugin's empty `class Buffer {}` (which crashed vendor-crypto at module-init —
+// "Class constructor … cannot be invoked without 'new'" → blank app). `buffer`
+// is not a direct dep of packages/app (plain resolution finds only the Node
+// builtin), so we locate the highest version in the bun store directly.
+const bufferEntry: string | undefined = (() => {
+  try {
+    const bunDir = path.join(elizaRoot, "node_modules/.bun");
+    const versions = fs
+      .readdirSync(bunDir)
+      .filter((d) => /^buffer@\d/.test(d))
+      .sort();
+    for (const dir of versions.reverse()) {
+      const entry = path.join(bunDir, dir, "node_modules/buffer/index.js");
+      if (fs.existsSync(entry)) return entry;
+    }
+  } catch {
+    // fall through — alias simply not added; build behaves as before
+  }
+  return undefined;
+})();
 // Other Capacitor packages imported by eliza/packages/app-core sources.
 // Resolved here (packages/app scope) so Rollup can find them when bundling
 // files from within the eliza submodule tree where bun may not hoist them.
@@ -2100,6 +2122,12 @@ export const INVALID_TRACER_PROVIDER = {};
       "@elizaos/app-core",
       "zod",
       "@opentelemetry/api",
+      // One physical Buffer identity across bn.js / elliptic / asn1.js /
+      // @solana so the crypto graph never mixes versions. (safe-buffer is NOT
+      // deduped: it isn't directly installed at the app root, so forcing
+      // single-copy resolution there externalizes it to a bare specifier the
+      // browser can't load — it resolves + bundles fine on its own.)
+      "buffer",
     ],
     alias: [
       { find: /^react$/, replacement: reactEntry },
@@ -2124,6 +2152,14 @@ export const INVALID_TRACER_PROVIDER = {};
       // Bare Node built-in polyfills for browser — pathe provides ESM path,
       // events is pre-bundled via optimizeDeps.
       { find: /^path$/, replacement: patheEntry },
+      // Map `buffer`/`node:buffer` to the real feross buffer (the stub plugin
+      // now bypasses them) so the crypto graph gets a callable Buffer.
+      ...(bufferEntry
+        ? [
+            { find: /^buffer$/, replacement: bufferEntry },
+            { find: /^node:buffer$/, replacement: bufferEntry },
+          ]
+        : []),
       {
         find: /^fast-redact$/,
         replacement: path.resolve(here, "src/shims/fast-redact.ts"),

--- a/packages/app/vite/native-module-stub-plugin.ts
+++ b/packages/app/vite/native-module-stub-plugin.ts
@@ -297,6 +297,23 @@ export function nativeModuleStubPlugin(
     name: "native-module-stub",
     enforce: "pre",
     resolveId(id) {
+      // `buffer` must resolve to the REAL feross buffer (a callable function),
+      // never a generated stub. generateNodeBuiltinStub emits an empty
+      // `class Buffer { constructor() {} }` for it (uppercase export whose
+      // prototype has >1 props), but the crypto/wallet graph (safe-buffer,
+      // base-x, bn.js) calls `Buffer(size)` WITHOUT `new` — which an es2022
+      // class rejects with "Class constructor … cannot be invoked without
+      // 'new'", crashing the vendor-crypto chunk at module-init and blanking
+      // the whole app. Returning null lets vite's resolve.alias map it to the
+      // real package. (#9188 fixed chunk *emission*; this fixes its *contents*.)
+      if (
+        id === "buffer" ||
+        id === "node:buffer" ||
+        id.startsWith("buffer/") ||
+        id.startsWith("node:buffer/")
+      ) {
+        return null;
+      }
       // Intercept ALL node: builtins before Vite externalizes them.
       // The @elizaos/core node entry uses many Node APIs (crypto, fs, module,
       // etc.) at the top level.  Rather than stubbing each one individually,
@@ -329,7 +346,8 @@ export function nativeModuleStubPlugin(
         "v8",
         "vm",
         "assert",
-        "buffer",
+        // "buffer" deliberately omitted — handled by the early bypass above so
+        // it resolves to the real feross buffer (callable), not an empty class.
         "constants",
         "events",
         "string_decoder",


### PR DESCRIPTION
## Problem
Every current-`develop` build of the app (mobile APK **and** apex web) black-screens on boot:

```
TypeError: Class constructor Ce cannot be invoked without 'new'
  at allocUnsafe (assets/vendor-crypto-<hash>.js)   ← bn.js / safe-buffer / base-x
```

The whole React tree fails to mount on every route. CI's core tests don't catch a web-bundle render crash, so it ships green.

## Root cause
`packages/app/vite/native-module-stub-plugin.ts` replaces the `buffer`/`node:buffer` import with a **generated empty class** — `generateNodeBuiltinStub` emits `export class Buffer { constructor() {} }` for any uppercase export whose prototype has >1 props. But the crypto/wallet graph (`safe-buffer`, `base-x`, `bn.js`) calls `Buffer(size)` **without `new`**, which an `es2022` class rejects → crash at `allocUnsafe` during the lazy `vendor-crypto` chunk's module-init.

#9188 fixed the chunk *emission* (the `vendor-crypto` chunk now exists); this fixes its *contents* — the chunk shipped a non-functional Buffer.

## Fix
- **native-module-stub-plugin.ts**: bypass `buffer`/`node:buffer`/subpaths in `resolveId` (return `null`) so Vite's `resolve.alias` maps them to the real package; drop `buffer` from the `nodeBuiltins` stub set.
- **vite.config.ts**: resolve the real feross `buffer` from the bun store (it's not a direct dep of `packages/app`, so plain resolution finds only the Node builtin) and alias `buffer`/`node:buffer` to it; `dedupe` `buffer` for one Buffer identity across `bn.js`/`elliptic`/`asn1.js`/`@solana`. feross `buffer`'s `Buffer` is a plain callable `function`, so `Buffer(size)` (no `new`) is safe.

## Evidence
- `build:web` → `[verify-chunk-safety] OK` (crypto graph still confined to lazy vendor chunks; 366 chunks scanned).
- `vendor-crypto` chunk: empty `class Buffer{constructor(){}}` → **0 occurrences**; real feross buffer present (`function Buffer`, `allocUnsafe`, `INSPECT_MAX_BYTES`, `TYPED_ARRAY_SUPPORT`).
- **On-device (Android cloud APK, physical device):** was a black screen (`#root` innerHTML = 0); after the fix the app renders (`#root` innerHTML = 22k) and text chat returns correct replies. Before/after screenshots available.

## Risk
Low — this *restores* the Buffer the wallet/crypto stack requires (a stub Buffer never worked for real crypto). `resolve.alias` is wrapped so a resolution miss falls back to undefined (alias simply not added; build behaves as before). `verify-chunk-safety` re-run green.
