### PR TITLE
fix(ui): home Notifications/Messages widgets render null when empty (no empty cards on home)

### DIFF
--- a/packages/ui/src/components/chat/widgets/messages.test.tsx
+++ b/packages/ui/src/components/chat/widgets/messages.test.tsx
@@ -8,10 +8,12 @@ afterEach(() => {
 });
 
 // #9143 — the frontpage Messages widget renders recent conversations.
+// #9226 — when there are no conversations it renders nothing (no empty
+// placeholder card) so the Springboard home isn't cluttered with dead slots.
 describe("MessagesWidget (#9143)", () => {
-  it("renders its empty state when there are no conversations", () => {
-    render(<MessagesWidget pluginId="messages" />);
-    expect(screen.getByTestId("widget-messages")).toBeTruthy();
-    expect(screen.getByText("No conversations yet")).toBeTruthy();
+  it("renders nothing when there are no conversations (#9226)", () => {
+    const { container } = render(<MessagesWidget pluginId="messages" />);
+    expect(screen.queryByTestId("widget-messages")).toBeNull();
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/packages/ui/src/components/chat/widgets/messages.tsx
+++ b/packages/ui/src/components/chat/widgets/messages.tsx
@@ -4,7 +4,7 @@ import type { Conversation } from "../../../api/client-types-chat";
 import { useAppSelector } from "../../../state";
 import { formatRelativeTime } from "../../../utils/format";
 import type { WidgetProps } from "../../../widgets/types";
-import { EmptyWidgetState, WidgetSection } from "./shared";
+import { WidgetSection } from "./shared";
 
 const MAX_HOME_CONVERSATIONS = 4;
 
@@ -27,35 +27,35 @@ export function MessagesWidget(_props: WidgetProps) {
     [conversations],
   );
 
+  // Render nothing until there are conversations. The always-visible home
+  // surface (#9143) must not show an empty placeholder card — empty-state hints
+  // belong on the dedicated view, not the home slot (matches the ViewCatalog
+  // "renders nothing until populated" contract).
+  if (recent.length === 0) {
+    return null;
+  }
+
   return (
     <WidgetSection
       title="Messages"
       icon={<MessageSquare />}
       testId="widget-messages"
     >
-      {recent.length === 0 ? (
-        <EmptyWidgetState
-          icon={<MessageSquare />}
-          title="No conversations yet"
-          description="Recent chats show up here."
-        />
-      ) : (
-        <ul className="flex flex-col gap-0.5">
-          {recent.map((c) => (
-            <li
-              key={c.id}
-              className="flex items-center justify-between gap-2 px-1 py-1"
-            >
-              <span className="truncate text-xs font-medium text-txt">
-                {c.title || "Untitled"}
-              </span>
-              <span className="shrink-0 text-3xs text-muted">
-                {formatRelativeTime(c.updatedAt)}
-              </span>
-            </li>
-          ))}
-        </ul>
-      )}
+      <ul className="flex flex-col gap-0.5">
+        {recent.map((c) => (
+          <li
+            key={c.id}
+            className="flex items-center justify-between gap-2 px-1 py-1"
+          >
+            <span className="truncate text-xs font-medium text-txt">
+              {c.title || "Untitled"}
+            </span>
+            <span className="shrink-0 text-3xs text-muted">
+              {formatRelativeTime(c.updatedAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
     </WidgetSection>
   );
 }

--- a/packages/ui/src/components/chat/widgets/notifications.test.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.test.tsx
@@ -10,11 +10,15 @@ afterEach(() => {
 });
 
 // #9143 — the frontpage Notifications widget renders from the shared store.
+// #9226 — with no notifications it renders nothing (no empty placeholder card)
+// so the Springboard home isn't cluttered with dead slots.
 describe("NotificationsWidget (#9143)", () => {
-  it("renders its empty state when there are no notifications", () => {
+  it("renders nothing when there are no notifications (#9226)", () => {
     __resetNotificationStoreForTests();
-    render(<NotificationsWidget pluginId="notifications" />);
-    expect(screen.getByTestId("widget-notifications")).toBeTruthy();
-    expect(screen.getByText("No notifications yet")).toBeTruthy();
+    const { container } = render(
+      <NotificationsWidget pluginId="notifications" />,
+    );
+    expect(screen.queryByTestId("widget-notifications")).toBeNull();
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/packages/ui/src/components/chat/widgets/notifications.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.tsx
@@ -2,7 +2,7 @@ import type { AgentNotification } from "@elizaos/core";
 import { Bell } from "lucide-react";
 import { useNotifications } from "../../../state/notifications/notification-store";
 import type { WidgetProps } from "../../../widgets/types";
-import { EmptyWidgetState, WidgetSection } from "./shared";
+import { WidgetSection } from "./shared";
 
 const MAX_HOME_NOTIFICATIONS = 4;
 
@@ -35,6 +35,14 @@ export function NotificationsWidget(_props: WidgetProps) {
   const { notifications, unreadCount } = useNotifications();
   const recent = notifications.slice(0, MAX_HOME_NOTIFICATIONS);
 
+  // Render nothing until there's real activity. The always-visible home surface
+  // (#9143) must not show an empty placeholder card — empty-state hints belong
+  // on the dedicated view, not the home slot (matches the ViewCatalog
+  // "renders nothing until populated" contract).
+  if (recent.length === 0) {
+    return null;
+  }
+
   return (
     <WidgetSection
       title="Notifications"
@@ -48,19 +56,11 @@ export function NotificationsWidget(_props: WidgetProps) {
         ) : undefined
       }
     >
-      {recent.length === 0 ? (
-        <EmptyWidgetState
-          icon={<Bell />}
-          title="No notifications yet"
-          description="Agent activity and reminders show up here."
-        />
-      ) : (
-        <ul className="flex flex-col gap-0.5">
-          {recent.map((n) => (
-            <NotificationRow key={n.id} notification={n} />
-          ))}
-        </ul>
-      )}
+      <ul className="flex flex-col gap-0.5">
+        {recent.map((n) => (
+          <NotificationRow key={n.id} notification={n} />
+        ))}
+      </ul>
     </WidgetSection>
   );
 }


### PR DESCRIPTION
## Problem
The #9143 frontpage home widgets `NotificationsWidget` and `MessagesWidget` are `ALWAYS_VISIBLE_BUILTIN`, but when they have no data they render a **persistent empty placeholder card** (`EmptyWidgetState`: "No notifications yet" / "No conversations yet"). `WidgetHost` only hides a widget on zero *declarations*, not zero *data* — which contradicts the `ViewCatalog` "renders nothing until populated" contract. The result on a fresh/quiet agent is **two empty cards on the Springboard home**, which reads as a half-built UI.

## Fix
Both widgets `return null` when there's no data (no recent notifications / no conversations), so the always-visible home slot stays clean. Empty-state hints remain appropriate on dedicated views, just not on the home surface. `EmptyWidgetState` is untouched and still used by other widgets.

## Notes
- Pure render change; no data/store changes.
- biome format + lint clean; `EmptyWidgetState` export retained (other widgets use it).
- Pairs with the agent-image freshness work — the home widgets are agent-data-driven, so they populate once the agent has activity; until then they now stay hidden instead of showing empty cards.
