### PR TITLE
fix(ui): don't yank a scrolled-up reader to the bottom on every new line

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1440,11 +1440,17 @@ export function ContinuousChatOverlay({
     // flashes at the top. Infrequent — once per turn, not per token.
     if (isNewLine || justOpened) {
       const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-      if (isNewLine && !justOpened && !reduce && atBottom) {
-        endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-      } else {
-        // justOpened OR isNewLine (always re-pin) OR atBottom — all true here.
-        el.scrollTop = el.scrollHeight;
+      // Pin to the latest line ONLY on first open, or when the reader is already
+      // resting at the bottom. If they have scrolled UP to read history, a new
+      // line must NOT yank them down — the previous code force-pinned on every
+      // new line (the `else` ran whenever !atBottom), which is exactly the
+      // "scroll up to the first message and get snapped back to the bottom" bug.
+      if (justOpened || atBottom) {
+        if (isNewLine && !justOpened && !reduce) {
+          endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+        } else {
+          el.scrollTop = el.scrollHeight;
+        }
       }
       if (justOpened && focusThreadRef.current) {
         el.focus();


### PR DESCRIPTION
## Problem
Scrolling up in the chat to read older messages (e.g. to reach the first message) snaps you back to the bottom — you can't stay in the history. On a slow agent this is constant: every new line yanks the viewport down.

## Root cause
`ContinuousChatOverlay`'s transcript-pin layout effect force-pinned `scrollTop = scrollHeight` on **every new line whenever the reader was not at the bottom**. The `isNewLine || justOpened` branch only smooth-scrolled in the `isNewLine && !justOpened && !reduce && atBottom` case; the `else` fired for `isNewLine && !atBottom` too and hard-pinned to the bottom — snapping a scrolled-up reader down. This contradicts the effect's own comment: *"never yank a reader who has scrolled up to read history."*

## Fix
Re-pin only when the reader is **at the bottom** or it's the **first open**:
```ts
if (justOpened || atBottom) {
  if (isNewLine && !justOpened && !reduce) endRef.current?.scrollIntoView({behavior:"smooth",block:"end"});
  else el.scrollTop = el.scrollHeight;
}
// reader scrolled up → leave their position alone
```
Preserved: instant first-open pin, smooth auto-scroll-to-latest when resting at the bottom, the coalesced streaming-follow (already `atBottom`-gated), and the closed-peek pin.

## Verify
biome format + lint clean. Behaviour: scroll up to history → new line arrives → position holds; rest at bottom → new line → smooth-scrolls to it; first open → jumps to latest.
