### PR TITLE
fix(cloud): apps deploy reaches READY — mark app deployed on container-provision success

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -93,6 +93,47 @@ describe("executeContainerProvision", () => {
     ]);
   });
 
+  test("flips the linked app to deployed on success (#5: deploy reaches READY)", async () => {
+    const { store } = fakeStore();
+    const { provider } = fakeProvider();
+    const deployed: Array<{ appId: string; url: string | null }> = [];
+    await executeContainerProvision(
+      job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+      {
+        provider,
+        store,
+        markAppDeployed: async (appId, url) => {
+          deployed.push({ appId, url });
+        },
+      },
+    );
+    expect(deployed).toHaveLength(1);
+    expect(deployed[0]?.appId).toBe(ROW.appId);
+  });
+
+  test("does NOT mark the app deployed when provisioning fails", async () => {
+    const { store } = fakeStore();
+    const { provider } = fakeProvider({
+      async provision() {
+        throw new Error("docker create failed");
+      },
+    } as never);
+    const deployedOnFail: string[] = [];
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        {
+          provider,
+          store,
+          markAppDeployed: async (appId) => {
+            deployedOnFail.push(appId);
+          },
+        },
+      ),
+    ).rejects.toThrow("docker create failed");
+    expect(deployedOnFail).toEqual([]);
+  });
+
   test("marks error and rethrows when provisioning fails", async () => {
     const { events, store } = fakeStore();
     const { provider } = fakeProvider({

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -22,6 +22,7 @@ import { logger } from "../utils/logger";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
 import type { BuildExec } from "./app-image-builder";
+import { appsService } from "./apps";
 import { addAppRoute, removeAppRoute } from "./apps-ingress-provisioner";
 import type { ContainerExecutorDeps } from "./container-job-executors";
 import { allocateAppContainerHostPort } from "./docker-port-allocation";
@@ -173,6 +174,16 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
       listVerifiedAppOrigins(appId).then((origins) =>
         origins.map((origin) => origin.replace(/^https?:\/\//, "").replace(/\/+$/, "")),
       ),
+    markAppDeployed: async (appId, productionUrl) => {
+      // App ids are UUIDs; a non-UUID project_name (a plain /v1/containers row,
+      // which is not an app) is skipped so this never mis-updates or UUID-casts.
+      if (!/^[0-9a-f-]{36}$/i.test(appId)) return;
+      await appsService.update(appId, {
+        deployment_status: "deployed",
+        production_url: productionUrl,
+        last_deployed_at: new Date(),
+      });
+    },
     ...ingress,
   };
 }

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -72,6 +72,15 @@ export interface ContainerExecutorDeps {
    * means the app keeps only its `<shortid>.<base>` host — never fails a deploy.
    */
   listVerifiedAppHostnames?: (appId: string) => Promise<string[]>;
+  /**
+   * Flip the linked app to `deployed` (status + production_url + last_deployed_at)
+   * once its container is running AND its ingress route is live. Without this the
+   * deploy-status route echoes `building` forever — a successful deploy never
+   * reaches READY (a stranded-looking app). No-op for non-app containers (the
+   * impl resolves by app id). Optional/injected; best-effort is NOT acceptable
+   * here — a failure must surface so the deploy is retried, not silently stuck.
+   */
+  markAppDeployed?: (appId: string, productionUrl: string | null) => Promise<void>;
 }
 
 async function requireRow(store: AppContainerStore, containerId: string): Promise<AppContainerRow> {
@@ -122,6 +131,11 @@ export async function executeContainerProvision(
         nodeHost: result.nodeHost,
         hostPort: result.hostPort,
       });
+    }
+    // Container is running and routable — flip the app to `deployed` so the
+    // deploy-status route reports READY (instead of `building` forever).
+    if (deps.markAppDeployed) {
+      await deps.markAppDeployed(row.appId, endpoint?.url ?? null);
     }
   } catch (error) {
     await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Apps deploy reaches READY — mark app `deployed` on container-provision success

Product-2 apps-deploy readiness-audit **blocker #5**: a *successful* deploy never set `apps.deployment_status` to `deployed`, so the deploy-status route (which echoes that column) reported `building` **forever** — the CLI/dashboard never saw READY, making a working deploy look stranded. A clean-UX blocker.

### Fix
`executeContainerProvision` marked the container running + registered the ingress route, but never flipped the app. Add an injected `markAppDeployed` dep (mirroring the existing `onRouteAdded` / `listVerifiedAppHostnames` seam), called on success **after** the container is running and routable. The real impl (`buildContainerExecutorDeps`) sets `deployment_status='deployed'` + `production_url` + `last_deployed_at`, UUID-guarded so a plain `/v1/containers` row (non-app `project_name`) is a clean no-op. The failure path never marks deployed (so the existing failure arm's `'failed'` stands).

### Tests
`executeContainerProvision` now asserts the app is marked deployed on success and **not** on failure — 13 pass / 0 fail. biome + typecheck clean.

2nd of the Product-2 enablement PRs (after #9220). Tenant data-isolation core remains audited-sound; this is deploy-lifecycle correctness.
