### PR TITLE
fix(cloud): isolate untrusted app builds from the runtime fleet (Product-2 BLOCKER #6)

### DIFF
--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -266,6 +266,54 @@ export const containersEnv = {
   },
 
   /**
+   * Explicit arming flag for BUILD-FROM-REPO (the "Vercel-like" path where the
+   * platform builds an UNTRUSTED user Dockerfile into an image).
+   *
+   * SECURITY: a malicious Dockerfile can attack the dockerd it builds on. Even
+   * with the throwaway-isolated-builder mitigation (see app-build-cmd.ts), the
+   * build still launches a BuildKit container via SOME dockerd — so building on a
+   * node that also hosts tenant containers keeps a residual blast radius. This
+   * flag is the canary gate: build-from-repo stays OFF unless explicitly armed
+   * AND a dedicated builder host (`buildsHost()`) is configured, OR the operator
+   * opts into building on the runtime node by setting
+   * `APPS_BUILD_ON_RUNTIME_NODE=1`. Default OFF (prebuilt-image path only).
+   */
+  buildFromRepoEnabled(): boolean {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.APPS_BUILD_FROM_REPO_ENABLED);
+    return raw === "true" || raw === "1";
+  },
+
+  /**
+   * Dedicated builder host (`hostname` or `nodeId:hostname:capacity`) that runs
+   * untrusted app builds, DISTINCT from any node hosting tenant containers. When
+   * set, build-from-repo SSHes here instead of the runtime node, so a malicious
+   * Dockerfile cannot reach co-tenant containers' daemon. Undefined = no
+   * dedicated host (build-from-repo only runs if `APPS_BUILD_ON_RUNTIME_NODE=1`
+   * explicitly opts into the runtime node).
+   */
+  buildsHost(): string | undefined {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.APPS_BUILDS_HOST);
+    if (!raw) return undefined;
+    const parts = raw.split(":");
+    const host = parts.length >= 2 ? parts[1]?.trim() : parts[0]?.trim();
+    return host || undefined;
+  },
+
+  /**
+   * Escape hatch: allow building untrusted Dockerfiles on the runtime node's
+   * daemon (the one hosting tenant containers) when no dedicated builder host is
+   * configured. OFF by default — opting in accepts the residual blast radius the
+   * throwaway-isolated-builder mitigation narrows but does not eliminate.
+   */
+  buildOnRuntimeNodeAllowed(): boolean {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.APPS_BUILD_ON_RUNTIME_NODE);
+    return raw === "true" || raw === "1";
+  },
+
+  /**
    * Caddy admin-API base URL the daemon uses to add/remove per-app ingress routes
    * (e.g. `http://127.0.0.1:2019` over an SSH tunnel, or the app node's
    * private-IP admin endpoint). Undefined = ingress not wired (routes are no-ops).

--- a/packages/cloud-shared/src/lib/services/__tests__/app-build-cmd.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-build-cmd.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildAppImageBuildCmd, buildAppImagePushCmd } from "../app-build-cmd";
+import {
+  buildAppImageBuildCmd,
+  buildAppImagePushCmd,
+  buildIsolatedAppImageScript,
+  isolatedBuilderName,
+} from "../app-build-cmd";
 
 const REF = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d";
 
@@ -47,6 +52,82 @@ describe("buildAppImageBuildCmd", () => {
     const cmd = buildAppImageBuildCmd({ context: "/c; rm -rf /", imageRef: REF });
     expect(cmd).toContain("'/c; rm -rf /'");
     expect(cmd).not.toMatch(/ rm -rf \/$/); // never bare
+  });
+
+  test("builderName pins --builder and implies buildx", () => {
+    const cmd = buildAppImageBuildCmd({
+      context: "/c",
+      imageRef: REF,
+      builderName: "b1",
+      push: true,
+    });
+    expect(cmd.startsWith("docker buildx build")).toBe(true);
+    expect(cmd).toContain("--builder 'b1'");
+  });
+
+  test("noCache adds --no-cache", () => {
+    const cmd = buildAppImageBuildCmd({ context: "/c", imageRef: REF, noCache: true });
+    expect(cmd).toContain("--no-cache");
+  });
+});
+
+describe("isolatedBuilderName", () => {
+  test("derives a DNS/Docker-safe name from appId + suffix", () => {
+    const name = isolatedBuilderName("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "deadbeef00ff");
+    expect(name).toBe("apps-build-aaaaaaaaaaaa-deadbeef00ff");
+    // only [a-z0-9-]
+    expect(name).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  test("strips unsafe characters from both parts", () => {
+    expect(isolatedBuilderName("AB/cd:ef", "X Y!Z")).toBe("apps-build-abcdef-xyz");
+  });
+});
+
+describe("buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6)", () => {
+  const SCRIPT = buildIsolatedAppImageScript({
+    context: "https://github.com/u/repo.git#main",
+    imageRef: REF,
+    dockerfile: "Dockerfile",
+    push: true,
+    builderName: "apps-build-aaaaaaaaaaaa-deadbeef",
+  });
+
+  test("creates a fresh docker-container BuildKit isolated from the host daemon", () => {
+    expect(SCRIPT).toContain(
+      "docker buildx create --driver docker-container --name 'apps-build-aaaaaaaaaaaa-deadbeef' --bootstrap",
+    );
+  });
+
+  test("guarantees teardown of the throwaway builder on EXIT", () => {
+    expect(SCRIPT).toContain("trap 'docker buildx rm --force 'apps-build-aaaaaaaaaaaa-deadbeef'");
+    expect(SCRIPT).toContain("EXIT");
+  });
+
+  test("aborts the build if the isolated builder cannot be created (set -e)", () => {
+    const lines = SCRIPT.split("\n");
+    expect(lines[0]).toBe("set -e");
+    // create must come before the build so a create failure aborts pre-build
+    const createIdx = lines.findIndex((l) => l.includes("buildx create"));
+    const buildIdx = lines.findIndex((l) => l.includes("buildx build"));
+    expect(createIdx).toBeGreaterThan(-1);
+    expect(buildIdx).toBeGreaterThan(createIdx);
+  });
+
+  test("pins the build to the throwaway builder and pushes from inside it", () => {
+    expect(SCRIPT).toContain("docker buildx build --builder 'apps-build-aaaaaaaaaaaa-deadbeef'");
+    expect(SCRIPT).toContain("--push");
+    // never loads the untrusted image into the host daemon's image store
+    expect(SCRIPT).not.toContain("--load");
+  });
+
+  test("shell-quotes an injection-laced context (defense in depth)", () => {
+    const script = buildIsolatedAppImageScript({
+      context: "https://x/r.git#$(touch /pwned)",
+      imageRef: REF,
+      builderName: "b2",
+    });
+    expect(script).toContain("'https://x/r.git#$(touch /pwned)'");
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/__tests__/app-builder-host.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-builder-host.test.ts
@@ -1,0 +1,94 @@
+/**
+ * BLOCKER #6 isolation gate (pure). `decideBuilderArming` / `selectBuilderHost`
+ * decide WHETHER an untrusted user Dockerfile may be built and on WHICH host:
+ *   - OFF unless the backend is configured AND build-from-repo is explicitly
+ *     armed (APPS_BUILD_FROM_REPO_ENABLED=1), AND
+ *   - only on an ISOLATED builder host — a dedicated APPS_BUILDS_HOST, or the
+ *     runtime node ONLY when APPS_BUILD_ON_RUNTIME_NODE=1 opts in.
+ *
+ * Pure module (no DB/SSH chain), so the security gate is unit-testable directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { decideBuilderArming, selectBuilderHost } from "../app-builder-host";
+
+const RUNTIME_NODE = "10.0.0.1";
+const DEDICATED = "10.9.9.9";
+const SAVED = { ...process.env };
+
+function reset() {
+  for (const k of [
+    "APPS_BUILD_FROM_REPO_ENABLED",
+    "APPS_BUILDS_HOST",
+    "APPS_BUILD_ON_RUNTIME_NODE",
+  ]) {
+    delete process.env[k];
+  }
+}
+
+beforeEach(reset);
+afterEach(() => {
+  reset();
+  Object.assign(process.env, SAVED);
+});
+
+describe("selectBuilderHost — dedicated-host preference", () => {
+  test("prefers the dedicated builder host over the runtime node", () => {
+    process.env.APPS_BUILDS_HOST = `b1:${DEDICATED}:4`;
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1"; // dedicated still wins
+    expect(selectBuilderHost(() => RUNTIME_NODE)).toBe(DEDICATED);
+  });
+
+  test("falls back to the runtime node only when explicitly opted in", () => {
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
+    expect(selectBuilderHost(() => RUNTIME_NODE)).toBe(RUNTIME_NODE);
+  });
+
+  test("returns null when no dedicated host and runtime build not opted in", () => {
+    expect(selectBuilderHost(() => RUNTIME_NODE)).toBeNull();
+  });
+});
+
+describe("decideBuilderArming — arming gate (BLOCKER #6)", () => {
+  test("not armed when the container backend is disabled", () => {
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
+    const d = decideBuilderArming({ backendEnabled: false, selectRuntimeNode: () => RUNTIME_NODE });
+    expect(d.armed).toBe(false);
+    expect(d.host).toBeNull();
+    expect(d.reason).toBe("backend-disabled");
+  });
+
+  test("not armed when build-from-repo is not explicitly enabled", () => {
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
+    const d = decideBuilderArming({ backendEnabled: true, selectRuntimeNode: () => RUNTIME_NODE });
+    expect(d.armed).toBe(false);
+    expect(d.reason).toBe("not-armed");
+  });
+
+  test("not armed when armed but no isolated builder host resolves", () => {
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    // no APPS_BUILDS_HOST, no runtime opt-in → refuse to build on a tenant node
+    const d = decideBuilderArming({ backendEnabled: true, selectRuntimeNode: () => RUNTIME_NODE });
+    expect(d.armed).toBe(false);
+    expect(d.reason).toBe("no-isolated-host");
+  });
+
+  test("armed + dedicated when a dedicated builder host is configured", () => {
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILDS_HOST = DEDICATED;
+    const d = decideBuilderArming({ backendEnabled: true, selectRuntimeNode: () => RUNTIME_NODE });
+    expect(d.armed).toBe(true);
+    expect(d.host).toBe(DEDICATED);
+    expect(d.dedicated).toBe(true);
+  });
+
+  test("armed + NOT dedicated when only the runtime-node opt-in is set", () => {
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
+    const d = decideBuilderArming({ backendEnabled: true, selectRuntimeNode: () => RUNTIME_NODE });
+    expect(d.armed).toBe(true);
+    expect(d.host).toBe(RUNTIME_NODE);
+    expect(d.dedicated).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-builder.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { AppImageBuilder, type BuildExec } from "../app-image-builder";
 
 const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const REF = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d";
 
 function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: number }> } {
   const calls: Array<{ cmd: string; timeoutMs?: number }> = [];
@@ -15,7 +16,7 @@ function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: numbe
 }
 
 describe("AppImageBuilder", () => {
-  test("resolves the ref and execs the composed build command", async () => {
+  test("resolves the ref and execs the build inside a THROWAWAY isolated builder by default", async () => {
     const exec = fakeExec();
     const builder = new AppImageBuilder({ exec });
     const res = await builder.build({
@@ -26,15 +27,39 @@ describe("AppImageBuilder", () => {
       dockerfile: "Dockerfile",
     });
 
-    expect(res.imageRef).toBe("ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d");
+    expect(res.imageRef).toBe(REF);
     expect(res.buildOutput).toContain("Successfully built");
     expect(exec.calls).toHaveLength(1);
-    expect(exec.calls[0].cmd).toBe(
-      "docker build --tag 'ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d' --file 'Dockerfile' '/work/repo'",
-    );
+
+    const cmd = exec.calls[0].cmd;
+    // Untrusted Dockerfile → fresh isolated docker-container BuildKit, torn down.
+    expect(cmd).toContain("docker buildx create --driver docker-container --name 'apps-build-");
+    expect(cmd).toContain("--bootstrap");
+    expect(cmd).toContain("trap 'docker buildx rm --force 'apps-build-");
+    expect(cmd).toMatch(/EXIT/);
+    // The build pins --builder to that throwaway instance, never the host default.
+    expect(cmd).toContain(`docker buildx build --builder 'apps-build-`);
+    expect(cmd).toContain(`--tag '${REF}'`);
+    expect(cmd).toContain("--file 'Dockerfile'");
+    expect(cmd).toContain("'/work/repo'");
+    expect(cmd).toContain("set -e");
   });
 
-  test("push routes through buildx --push", async () => {
+  test("uses a unique throwaway builder name per build (no shared BuildKit)", async () => {
+    const exec = fakeExec();
+    const builder = new AppImageBuilder({ exec });
+    const req = { registry: "ghcr.io/elizaos", appId: APP, context: "/c" } as const;
+    await builder.build(req);
+    await builder.build(req);
+    const name = (cmd: string) => cmd.match(/--name '(apps-build-[^']+)'/)?.[1];
+    const a = name(exec.calls[0].cmd);
+    const b = name(exec.calls[1].cmd);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+  });
+
+  test("push runs --push from inside the isolated builder (never loads into host daemon)", async () => {
     const exec = fakeExec();
     await new AppImageBuilder({ exec }).build({
       registry: "ghcr.io/elizaos",
@@ -42,8 +67,25 @@ describe("AppImageBuilder", () => {
       context: "https://github.com/u/repo.git#main",
       push: true,
     });
-    expect(exec.calls[0].cmd.startsWith("docker buildx build")).toBe(true);
-    expect(exec.calls[0].cmd).toContain("--push");
+    const cmd = exec.calls[0].cmd;
+    expect(cmd).toContain("docker buildx build --builder 'apps-build-");
+    expect(cmd).toContain("--push");
+    expect(cmd).not.toContain("--load");
+    expect(cmd).toContain("docker buildx create --driver docker-container");
+  });
+
+  test("isolatedBuilder:false runs the plain host-daemon build (trusted/verification only)", async () => {
+    const exec = fakeExec();
+    const builder = new AppImageBuilder({ exec, isolatedBuilder: false });
+    await builder.build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      sourceRef: "a1b2c3d",
+      context: "/work/repo",
+      dockerfile: "Dockerfile",
+    });
+    expect(exec.calls[0].cmd).toBe(`docker build --tag '${REF}' --file 'Dockerfile' '/work/repo'`);
+    expect(exec.calls[0].cmd).not.toContain("buildx create");
   });
 
   test("propagates a build failure", async () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/node-builder-exec.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/node-builder-exec.test.ts
@@ -1,8 +1,14 @@
 /**
- * Arming gate for build-from-repo: makeNodeBuilderExec exposes the app node's
- * SSH as a BuildExec ONLY when the container backend is configured, so the
- * deploy backend cleanly falls back to prebuilt images otherwise (no accidental
- * build-mode arming). Pins that safety property.
+ * Arming gate for build-from-repo. `makeNodeBuilderExec` exposes a builder
+ * host's SSH as a BuildExec ONLY when:
+ *   - the container backend is configured,
+ *   - build-from-repo is explicitly ARMED (APPS_BUILD_FROM_REPO_ENABLED=1), AND
+ *   - an ISOLATED builder host resolves (a dedicated APPS_BUILDS_HOST, or the
+ *     runtime node only if APPS_BUILD_ON_RUNTIME_NODE=1 opts in).
+ *
+ * This pins the BLOCKER #6 mitigation: an un-armed / mis-configured canary never
+ * builds an untrusted Dockerfile, and it never builds on a tenant-hosting node
+ * by accident — it cleanly falls back to the prebuilt-image path (null).
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -16,9 +22,18 @@ function reset() {
     "CONTAINERS_DOCKER_NODES",
     "CONTAINERS_SSH_KEY",
     "CONTAINERS_SSH_KEY_PATH",
+    "APPS_BUILD_FROM_REPO_ENABLED",
+    "APPS_BUILDS_HOST",
+    "APPS_BUILD_ON_RUNTIME_NODE",
   ]) {
     delete process.env[k];
   }
+}
+
+/** Configure the container backend (node + key) so only the build gate is under test. */
+function armBackend() {
+  process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
+  process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
 }
 
 beforeEach(reset);
@@ -30,26 +45,55 @@ afterEach(() => {
 describe("makeNodeBuilderExec — arming gate", () => {
   test("returns null when no docker node is configured (→ prebuilt fallback)", () => {
     process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
     // no CONTAINERS_DOCKER_NODES
     expect(makeNodeBuilderExec()).toBeNull();
   });
 
   test("returns null when no SSH key is configured", () => {
     process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
     // no CONTAINERS_SSH_KEY / _PATH
     expect(makeNodeBuilderExec()).toBeNull();
   });
 
   test("returns null when explicitly disabled even if node + key present", () => {
     process.env.APPS_CONTAINERS_ENABLED = "0";
-    process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
-    process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+    armBackend();
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
     expect(makeNodeBuilderExec()).toBeNull();
   });
 
-  test("returns a BuildExec (exec fn) when node + key are configured", () => {
-    process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
-    process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+  test("returns null when build-from-repo is NOT armed (backend configured)", () => {
+    armBackend();
+    // APPS_BUILD_FROM_REPO_ENABLED unset → stays on prebuilt path
+    expect(makeNodeBuilderExec()).toBeNull();
+  });
+
+  test("returns null when armed but no isolated builder host (no dedicated, no runtime opt-in)", () => {
+    armBackend();
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    // neither APPS_BUILDS_HOST nor APPS_BUILD_ON_RUNTIME_NODE — refuse to build
+    // on a tenant-hosting node by default
+    expect(makeNodeBuilderExec()).toBeNull();
+  });
+
+  test("returns a BuildExec when armed + a DEDICATED builder host is set", () => {
+    armBackend();
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILDS_HOST = "builder-1:10.9.9.9:4";
+    const exec = makeNodeBuilderExec();
+    expect(exec).not.toBeNull();
+    expect(typeof exec?.exec).toBe("function");
+  });
+
+  test("returns a BuildExec when armed + runtime-node opt-in (no dedicated host)", () => {
+    armBackend();
+    process.env.APPS_BUILD_FROM_REPO_ENABLED = "1";
+    process.env.APPS_BUILD_ON_RUNTIME_NODE = "1";
     const exec = makeNodeBuilderExec();
     expect(exec).not.toBeNull();
     expect(typeof exec?.exec).toBe("function");

--- a/packages/cloud-shared/src/lib/services/app-build-cmd.ts
+++ b/packages/cloud-shared/src/lib/services/app-build-cmd.ts
@@ -14,6 +14,17 @@
  * SECURITY: only NON-secret values belong in `buildArgs` (they're baked into the
  * image history). Secrets must be injected at RUN time via the per-tenant
  * `environmentVars` (see app-docker-cmd.ts), never here.
+ *
+ * SECURITY (build isolation): the build runs an UNTRUSTED user Dockerfile. With
+ * the default `docker` buildx driver the build executes against the host's
+ * shared dockerd — the same daemon hosting other tenants' live containers — so a
+ * malicious Dockerfile (RUN steps reaching the docker socket, cache poisoning,
+ * daemon API access) can compromise co-tenants or the node. {@link isolatedBuilder}
+ * pins the build to a FRESH, THROWAWAY `docker-container` BuildKit instance whose
+ * BuildKit runs in its own container (no host build cache, no daemon image store
+ * write on `--push`), created before the build and torn down after — so an
+ * untrusted build never shares state with the runtime daemon. See
+ * {@link buildIsolatedAppImageScript}.
  */
 
 import { shellQuote } from "./docker-sandbox-utils";
@@ -34,16 +45,30 @@ export interface AppBuildCmdParams {
    * pushing), uses plain `docker build` (the image lands in the local daemon).
    */
   buildx?: boolean;
+  /**
+   * Name of a buildx builder instance to pin the build to (`--builder <name>`).
+   * Set by {@link buildIsolatedAppImageScript} to a fresh throwaway builder;
+   * implies buildx. Omit for the plain host-daemon build.
+   */
+  builderName?: string;
+  /** Pass `--no-cache` (untrusted builds skip any shared cache). */
+  noCache?: boolean;
 }
 
 /** Assemble the docker build command for a user app image. */
 export function buildAppImageBuildCmd(params: AppBuildCmdParams): string {
-  const useBuildx = params.buildx ?? Boolean(params.push);
+  const useBuildx = params.buildx ?? Boolean(params.push ?? params.builderName);
   const parts: string[] = [useBuildx ? "docker buildx build" : "docker build"];
 
+  if (params.builderName) {
+    parts.push(`--builder ${shellQuote(params.builderName)}`);
+  }
   parts.push(`--tag ${shellQuote(params.imageRef)}`);
   if (params.dockerfile) {
     parts.push(`--file ${shellQuote(params.dockerfile)}`);
+  }
+  if (params.noCache) {
+    parts.push("--no-cache");
   }
   for (const [key, value] of Object.entries(params.buildArgs ?? {})) {
     parts.push(`--build-arg ${shellQuote(`${key}=${value}`)}`);
@@ -58,6 +83,58 @@ export function buildAppImageBuildCmd(params: AppBuildCmdParams): string {
 
   parts.push(shellQuote(params.context));
   return parts.join(" ");
+}
+
+/** A DNS/Docker-safe, unique-per-build name for a throwaway buildx builder. */
+export function isolatedBuilderName(appId: string, suffix: string): string {
+  const appSlug = appId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const safeSuffix = suffix.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return `apps-build-${appSlug.slice(0, 12)}-${safeSuffix.slice(0, 12)}`;
+}
+
+export interface IsolatedAppBuildScriptParams extends Omit<AppBuildCmdParams, "builderName"> {
+  /**
+   * Unique name for the throwaway builder (see {@link isolatedBuilderName}).
+   * Must be unique per concurrent build so two builds never share a BuildKit.
+   */
+  builderName: string;
+}
+
+/**
+ * Assemble a single shell script that runs an UNTRUSTED build in a FRESH,
+ * THROWAWAY, isolated buildx builder and guarantees teardown afterwards.
+ *
+ * The script:
+ *   1. `docker buildx create --driver docker-container --name <builder>` — a
+ *      one-shot BuildKit running in its OWN container, isolated from the host
+ *      daemon's build cache and image store; `set -e` so a create failure aborts
+ *      before any build runs.
+ *   2. `trap '... buildx rm' EXIT` — the builder is ALWAYS removed (success,
+ *      failure, or signal), so untrusted BuildKit state never lingers on the
+ *      node and builders don't accumulate.
+ *   3. the `docker buildx build --builder <builder> --push ...` itself.
+ *
+ * `--push` writes straight to the registry from inside the isolated BuildKit, so
+ * even on push the untrusted image is never loaded into the host daemon's image
+ * store. The build context (a git URL or dir) and all build args are
+ * shell-quoted by {@link buildAppImageBuildCmd}; the builder name is quoted here.
+ *
+ * NOTE: `docker-container` is rootless-friendly but still needs a dockerd to
+ * launch the BuildKit container. For full root-isolation from the runtime fleet,
+ * that dockerd should be a DEDICATED builder host (no tenant containers) —
+ * selected by the executor (see container-executor-deps `selectBuilderHost`).
+ * This script provides the in-daemon throwaway-builder seam; the dedicated host
+ * is the infra complement.
+ */
+export function buildIsolatedAppImageScript(params: IsolatedAppBuildScriptParams): string {
+  const builder = shellQuote(params.builderName);
+  const buildCmd = buildAppImageBuildCmd({ ...params, buildx: true, noCache: params.noCache });
+  return [
+    "set -e",
+    `docker buildx create --driver docker-container --name ${builder} --bootstrap >/dev/null`,
+    `trap 'docker buildx rm --force ${builder} >/dev/null 2>&1 || true' EXIT`,
+    buildCmd,
+  ].join("\n");
 }
 
 /** The `docker push <ref>` command, when build + push are separate steps. */

--- a/packages/cloud-shared/src/lib/services/app-builder-host.ts
+++ b/packages/cloud-shared/src/lib/services/app-builder-host.ts
@@ -1,0 +1,75 @@
+/**
+ * Build-from-repo isolation gate (Apps / Product 2) — pure config logic that
+ * decides WHETHER and WHERE an untrusted user Dockerfile may be built.
+ *
+ * BLOCKER #6: building an untrusted Dockerfile runs RUN steps + BuildKit on some
+ * dockerd. If that dockerd also hosts other tenants' live containers, a malicious
+ * Dockerfile (docker-socket access, cache poisoning, daemon API) can compromise
+ * co-tenants or the node. The throwaway-isolated-builder (see app-build-cmd.ts)
+ * keeps the build off the host's shared build cache/image store; this module is
+ * the second half: refuse to build unless explicitly armed AND an isolated
+ * builder host is available, preferring a DEDICATED builder distinct from any
+ * node hosting tenant containers.
+ *
+ * Pure (only reads `containersEnv` + the injected node selector), so the gate is
+ * unit-testable WITHOUT the DB/store/SSH chain the executor composition pulls in.
+ */
+
+import { containersEnv } from "../config/containers-env";
+
+/**
+ * Resolve the host that runs UNTRUSTED app builds — a DEDICATED builder host
+ * distinct from any node hosting tenant containers, if one is configured.
+ *
+ * Prefers `APPS_BUILDS_HOST` (a dedicated builder). Falls back to the runtime
+ * node (`selectRuntimeNode()`) ONLY when the operator explicitly opts in via
+ * `APPS_BUILD_ON_RUNTIME_NODE=1`, accepting the residual blast radius the
+ * throwaway-isolated-builder narrows but does not eliminate. Returns null (no
+ * builder → build-from-repo stays off) otherwise.
+ *
+ * @param selectRuntimeNode resolves the runtime container node host (or null).
+ */
+export function selectBuilderHost(selectRuntimeNode: () => string | null): string | null {
+  const dedicated = containersEnv.buildsHost();
+  if (dedicated) return dedicated;
+  if (containersEnv.buildOnRuntimeNodeAllowed()) return selectRuntimeNode();
+  return null;
+}
+
+export interface BuilderArmDecision {
+  /** True only when an untrusted build may run; `host` is then non-null. */
+  armed: boolean;
+  /** The resolved builder host when armed; null otherwise. */
+  host: string | null;
+  /** True when `host` is a dedicated builder (not the runtime node). */
+  dedicated: boolean;
+  /** Operator-facing reason the build is not armed (for logging). */
+  reason?: "backend-disabled" | "not-armed" | "no-isolated-host";
+}
+
+/**
+ * Decide whether build-from-repo is armed and on which isolated host. Pure: all
+ * IO (`appsContainersEnabled`, node selection) is injected, so the security gate
+ * is fully unit-testable without the runtime fleet.
+ *
+ * Armed requires ALL of:
+ *   1. the container backend is configured (`backendEnabled`),
+ *   2. build-from-repo is explicitly armed (`APPS_BUILD_FROM_REPO_ENABLED=1`),
+ *   3. an isolated builder host resolves (dedicated, or runtime-node opt-in).
+ */
+export function decideBuilderArming(deps: {
+  backendEnabled: boolean;
+  selectRuntimeNode: () => string | null;
+}): BuilderArmDecision {
+  if (!deps.backendEnabled) {
+    return { armed: false, host: null, dedicated: false, reason: "backend-disabled" };
+  }
+  if (!containersEnv.buildFromRepoEnabled()) {
+    return { armed: false, host: null, dedicated: false, reason: "not-armed" };
+  }
+  const host = selectBuilderHost(deps.selectRuntimeNode);
+  if (!host) {
+    return { armed: false, host: null, dedicated: false, reason: "no-isolated-host" };
+  }
+  return { armed: true, host, dedicated: host !== deps.selectRuntimeNode() };
+}

--- a/packages/cloud-shared/src/lib/services/app-image-builder.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-builder.ts
@@ -1,16 +1,30 @@
 /**
  * AppImageBuilder (Apps / Product 2) — the impure build executor for the
  * repo→image pipeline. Composes the pure ref/command builders
- * ({@link buildAppImageRef}, {@link buildAppImageBuildCmd}) and runs them over
- * an injected `exec` seam: SSH to a builder node in production, a local shell in
- * verification. The ONLY IO is `exec`, so the orchestration is unit-testable
- * with a fake and the same code path is exercised locally against real Docker.
+ * ({@link buildAppImageRef}, {@link buildIsolatedAppImageScript}) and runs them
+ * over an injected `exec` seam: SSH to a builder host in production, a local
+ * shell in verification. The ONLY IO is `exec`, so the orchestration is
+ * unit-testable with a fake and the same code path is exercised locally against
+ * real Docker.
+ *
+ * SECURITY: the Dockerfile is UNTRUSTED (user-supplied). By default the build is
+ * run inside a FRESH, THROWAWAY `docker-container` BuildKit instance that is torn
+ * down after the build (see {@link buildIsolatedAppImageScript}), so an untrusted
+ * build never shares cache/state with the host daemon hosting tenant containers.
+ * The builder name carries random entropy so concurrent builds never collide on
+ * a shared BuildKit. Set `isolatedBuilder: false` only for trusted/verification
+ * builds where the host daemon is acceptable.
  *
  * Decoupled from the deploy/run path: the builder yields a resolvable image ref;
  * `app-deploy-runner.ts` resolves that ref and the container provider runs it.
  */
 
-import { type AppBuildCmdParams, buildAppImageBuildCmd } from "./app-build-cmd";
+import { randomBytes } from "node:crypto";
+import {
+  buildAppImageBuildCmd,
+  buildIsolatedAppImageScript,
+  isolatedBuilderName,
+} from "./app-build-cmd";
 import { buildAppImageRef } from "./app-image-ref";
 
 /** Command-exec seam — structurally the same as `AppContainerSsh` (reusable). */
@@ -44,10 +58,14 @@ export interface AppImageBuildResult {
 export class AppImageBuilder {
   private readonly exec: BuildExec;
   private readonly timeoutMs: number;
+  private readonly isolatedBuilder: boolean;
 
-  constructor(deps: { exec: BuildExec; timeoutMs?: number }) {
+  constructor(deps: { exec: BuildExec; timeoutMs?: number; isolatedBuilder?: boolean }) {
     this.exec = deps.exec;
     this.timeoutMs = deps.timeoutMs ?? 10 * 60_000;
+    // Untrusted Dockerfiles run in a throwaway isolated builder by default;
+    // opt out only for trusted/verification builds against the host daemon.
+    this.isolatedBuilder = deps.isolatedBuilder ?? true;
   }
 
   /** Build (and optionally push) the app image; returns the resolvable ref. */
@@ -57,14 +75,31 @@ export class AppImageBuilder {
       appId: req.appId,
       sourceRef: req.sourceRef,
     });
-    const params: AppBuildCmdParams = {
-      context: req.context,
-      dockerfile: req.dockerfile,
-      imageRef,
-      push: req.push,
-      buildArgs: req.buildArgs,
-    };
-    const buildOutput = await this.exec.exec(buildAppImageBuildCmd(params), this.timeoutMs);
+
+    let command: string;
+    if (this.isolatedBuilder) {
+      // Random per-build suffix so two concurrent untrusted builds never share a
+      // BuildKit instance; the script tears the builder down on EXIT.
+      const builderName = isolatedBuilderName(req.appId, randomBytes(6).toString("hex"));
+      command = buildIsolatedAppImageScript({
+        context: req.context,
+        dockerfile: req.dockerfile,
+        imageRef,
+        push: req.push,
+        buildArgs: req.buildArgs,
+        builderName,
+      });
+    } else {
+      command = buildAppImageBuildCmd({
+        context: req.context,
+        dockerfile: req.dockerfile,
+        imageRef,
+        push: req.push,
+        buildArgs: req.buildArgs,
+      });
+    }
+
+    const buildOutput = await this.exec.exec(command, this.timeoutMs);
     return { imageRef, buildOutput };
   }
 }

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -19,6 +19,7 @@
 import { Buffer } from "node:buffer";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
+import { decideBuilderArming, selectBuilderHost } from "./app-builder-host";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
 import type { BuildExec } from "./app-image-builder";
@@ -66,26 +67,67 @@ function selectNodeHost(): string {
 }
 
 /**
- * Expose the app node's SSH connection as a {@link BuildExec} so the deploy
- * backend can build user images FROM THEIR REPO on the node (`docker buildx
- * build --push <git-url>`) and push to the registry — the "Vercel-like" path
- * where the platform does the build, not the user. The node already has Docker
- * + buildx (it runs the containers); `AppContainerSsh.exec(cmd, timeoutMs)` is
- * structurally identical to `BuildExec.exec`. Returns null when the node backend
- * isn't configured, so the deploy backend cleanly falls back to prebuilt images.
+ * Resolve the host that runs UNTRUSTED app builds — a DEDICATED builder host
+ * distinct from any node hosting tenant containers, if one is configured.
+ * Thin binder over the pure {@link selectBuilderHost} (the runtime-node selector
+ * is this module's seed/registered-node pick). See `app-builder-host.ts`.
+ */
+export function selectBuilderHostOrNull(): string | null {
+  return selectBuilderHost(selectNodeHostOrNull);
+}
+
+/**
+ * Expose a builder host's SSH connection as a {@link BuildExec} so the deploy
+ * backend can build user images FROM THEIR REPO (`docker buildx build --push
+ * <git-url>`) and push to the registry — the "Vercel-like" path where the
+ * platform does the build, not the user. `AppContainerSsh.exec(cmd, timeoutMs)`
+ * is structurally identical to `BuildExec.exec`.
  *
- * INFRA NOTE: the node must be `docker login`'d to the registry (push for build,
- * pull for run). That credential is provisioned out-of-band (operator/cloud-init),
- * not here — same as the container SSH key.
+ * SECURITY GATE (see {@link decideBuilderArming}): returns null (→ prebuilt-image
+ * fallback, build-from-repo stays OFF) unless ALL of:
+ *   1. the container backend is configured (`appsContainersEnabled()`),
+ *   2. build-from-repo is explicitly armed (`APPS_BUILD_FROM_REPO_ENABLED=1`),
+ *   3. an isolated builder host resolves (a dedicated `APPS_BUILDS_HOST`, or the
+ *      runtime node only if `APPS_BUILD_ON_RUNTIME_NODE` is opted in).
+ * So an unconfigured/un-armed canary never builds an untrusted Dockerfile, and
+ * it never builds on a tenant-hosting node by accident.
+ *
+ * INFRA NOTE: the builder host must be `docker login`'d to the registry (push
+ * for build) and run a dockerd that supports the `docker-container` buildx
+ * driver. Provisioning a dedicated builder node (no tenant containers) is the
+ * infra complement — see the PR's infra-follow-up.
  */
 export function makeNodeBuilderExec(): BuildExec | null {
-  if (!appsContainersEnabled()) return null;
-  return makeNodeSsh();
+  const decision = decideBuilderArming({
+    backendEnabled: appsContainersEnabled(),
+    selectRuntimeNode: selectNodeHostOrNull,
+  });
+  if (!decision.armed || !decision.host) {
+    if (decision.reason === "no-isolated-host") {
+      logger.warn(
+        "[container-executor-deps] build-from-repo armed but no isolated builder host — set APPS_BUILDS_HOST (dedicated) or APPS_BUILD_ON_RUNTIME_NODE=1 to opt into the runtime node; staying on prebuilt-image path",
+      );
+    } else if (decision.reason === "not-armed") {
+      logger.info(
+        "[container-executor-deps] build-from-repo not armed (APPS_BUILD_FROM_REPO_ENABLED unset) — using prebuilt-image path",
+      );
+    }
+    return null;
+  }
+  logger.info("[container-executor-deps] build-from-repo armed", {
+    builderHost: decision.host,
+    dedicated: decision.dedicated,
+  });
+  return makeBuilderSsh(decision.host);
 }
 
 /** A pooled SSH connection to the chosen node, exposing the `AppContainerSsh` seam. */
 function makeNodeSsh(): AppContainerSsh {
-  const host = selectNodeHost();
+  return makeBuilderSsh(selectNodeHost());
+}
+
+/** A pooled SSH connection to an explicit host, exposing the `AppContainerSsh` seam. */
+function makeBuilderSsh(host: string): AppContainerSsh {
   const keyB64 = containersEnv.sshKey();
   const privateKey = keyB64 ? Buffer.from(keyB64, "base64") : undefined;
   // DockerSSHClient.exec(command, timeoutMs?) IS the AppContainerSsh shape.


### PR DESCRIPTION
## Blocker

**Product-2 BLOCKER #6 — build-from-repo runs an untrusted Dockerfile on the same node + root Docker daemon that hosts other tenants' live containers.**

`buildContainerExecutorDeps` / `makeNodeBuilderExec` wired the build path (`AppImageBuilder` → `app-build-cmd`) to run `docker build` of a **user-supplied Dockerfile** over SSH on a runtime node — the same root `dockerd` running other tenants' containers. A malicious Dockerfile (RUN steps reaching the docker socket, build-arg/cache poisoning, daemon API access) could compromise co-tenant containers or the node. The platform has real paying users.

## Fix (code) — two complementary seams, no weakening of tenant DB/network isolation

**1. Throwaway, isolated builder** — `app-build-cmd.ts`, `app-image-builder.ts`
- New `buildIsolatedAppImageScript()` emits a single shell script that:
  - `docker buildx create --driver docker-container --name <unique> --bootstrap` — a **fresh BuildKit running in its own container**, isolated from the host daemon's build cache and image store;
  - `trap 'docker buildx rm --force <unique>' EXIT` — the throwaway builder is **always torn down** (success, failure, or signal), so untrusted BuildKit state never lingers and builders don't accumulate;
  - `set -e` so a create failure aborts before any build runs.
- `--push` writes **straight to the registry from inside the isolated BuildKit**, so even on push the untrusted image is never loaded into the host daemon's image store.
- The builder name carries random per-build entropy (`randomBytes`) so two concurrent untrusted builds never share a BuildKit.
- `AppImageBuilder` defaults `isolatedBuilder: true`; opt out (`isolatedBuilder: false`) only for trusted/verification builds. All context/build-args remain shell-quoted (injection-safe).

**2. Arming gate + dedicated builder host** — `app-builder-host.ts` (new, pure), `containers-env.ts`, `container-executor-deps.ts`
- Build-from-repo is **OFF unless explicitly armed** (`APPS_BUILD_FROM_REPO_ENABLED=1`) **AND** an isolated builder host resolves.
- Host selection **prefers a dedicated `APPS_BUILDS_HOST`** (distinct from any tenant-hosting node); it only falls back to the runtime node when the operator **explicitly opts in** via `APPS_BUILD_ON_RUNTIME_NODE=1`.
- So an un-armed / mis-configured canary never builds an untrusted Dockerfile, and never builds on a tenant-hosting node by accident — it cleanly falls back to the prebuilt-image path.
- The gate (`decideBuilderArming` / `selectBuilderHost`) is a **pure module**, so the security decision is unit-testable without the DB/SSH/runtime-fleet chain.

## Tests

- `app-build-cmd.test.ts` — isolated-build script: docker-container driver, `--bootstrap`, `trap … EXIT` teardown, `set -e` ordering (create before build), `--push` from inside the isolated builder (never `--load`), injection-safe quoting; `isolatedBuilderName` derivation.
- `app-image-builder.test.ts` — default is the throwaway isolated builder; unique builder name per build; `isolatedBuilder:false` → plain host-daemon build.
- `app-builder-host.test.ts` (new) — arming gate matrix (backend-disabled / not-armed / no-isolated-host / armed+dedicated / armed+runtime-opt-in) and dedicated-host preference.
- Out-of-band: the **exact emitted script was executed under `bash` and `sh`** with a stubbed `docker` — valid POSIX shell, and the teardown `docker buildx rm` **fires even when the build fails** (exit code preserved).

## Verification

- `bunx @biomejs/biome check --write <changed files>` → clean (formatting only).
- `bun test --isolate app-build-cmd.test.ts app-image-builder.test.ts app-builder-host.test.ts` → **29 pass / 0 fail**, 100% coverage on the three changed source files.
- Filtered typecheck `bun run --cwd packages/cloud-shared typecheck | grep <my files>` → **no errors naming any changed file** (the 6 suite errors are pre-existing transitive `TS2307` noise — `@elizaos/security/kms`, generated i18n data — unrelated to this change).
- `node-builder-exec.test.ts` (the SSH-returning integration test) can't run in this worktree because `container-executor-deps` transitively imports `@elizaos/core` (not built/linked here); the **same failure reproduces on `origin/develop` unchanged** — pre-existing, not introduced here. Its gate logic is now covered purely by `app-builder-host.test.ts`.

## Infra follow-up (not code)

- Provision a **dedicated builder node** (no tenant containers) and set `APPS_BUILDS_HOST`; that node's `dockerd` needs the `docker-container` buildx driver and a registry login (`docker login`). Until that exists, build-from-repo stays **gated OFF** (or, if an operator accepts the residual blast radius the throwaway-builder narrows, `APPS_BUILD_ON_RUNTIME_NODE=1` opts into the runtime node).
