### PR TITLE
fix(cloud): fleet upgrade re-applies managed inference env (embedding dim + model pins)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -60,6 +60,7 @@ import {
   elizaCodingContainerImageAdvisoryLockSql,
   elizaProvisionAdvisoryLockSql,
 } from "./eliza-provision-lock";
+import { applyManagedAgentInferenceEnvDefaults } from "./managed-eliza-config";
 import { prepareManagedElizaEnvironment } from "./managed-eliza-env";
 import { JOB_TYPES } from "./provisioning-job-types";
 import { resolveSandboxContainerLaunchConfig } from "./sandbox-container-launch-config";
@@ -4072,7 +4073,21 @@ export class ElizaSandboxService {
       agentId,
       agentName: agent.agent_name ?? "",
       organizationId: orgId,
-      environmentVars: agent.environment_vars ?? {},
+      // Re-apply the cloud-managed inference defaults on top of the stored env so
+      // an agent provisioned BEFORE the embedding-dimension / model pins landed
+      // heals on upgrade instead of freezing a stale config (e.g. 1536-d cloud
+      // vectors written into a dim_384 column → dropped memory + ~30s/turn). This
+      // backfills ONLY the 5 inference keys if missing and preserves everything
+      // else verbatim (DATABASE_URL, ELIZA_API_TOKEN, ELIZAOS_CLOUD_API_KEY,
+      // ELIZA_AGENT_LOCAL_STATE, PGLITE_DATA_DIR, ELIZA_PLUGIN_SET, ...) — the
+      // narrow helper deliberately avoids the full provision merge, which would
+      // mint a new API key / strip DATABASE_URL / flip local-state on upgrade (#8434).
+      environmentVars: {
+        ...((agent.environment_vars as Record<string, string>) ?? {}),
+        ...applyManagedAgentInferenceEnvDefaults(
+          (agent.environment_vars as Record<string, string>) ?? {},
+        ),
+      },
       dockerImage: digestPinnedImageRef(dockerImage, toDigest),
       excludeNodeId: oldNodeId,
     };

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
@@ -263,3 +263,88 @@ describe("managed Eliza environment", () => {
     expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("768");
   });
 });
+
+describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.ELIZA_CLOUD_URL;
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    delete process.env.ELIZA_CLOUD_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  test("returns all 5 inference keys with 1536-d embedding defaults on an empty env", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({});
+
+    expect(Object.keys(result).sort()).toEqual([
+      "ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS",
+      "ELIZAOS_CLOUD_EMBEDDING_URL",
+      "ELIZAOS_CLOUD_LARGE_MODEL",
+      "ELIZAOS_CLOUD_SMALL_MODEL",
+      "EMBEDDING_DIMENSION",
+    ]);
+    expect(result.EMBEDDING_DIMENSION).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_URL).toBeTruthy();
+    expect(result.ELIZAOS_CLOUD_SMALL_MODEL).toBeTruthy();
+    expect(result.ELIZAOS_CLOUD_LARGE_MODEL).toBeTruthy();
+  });
+
+  test("preserves explicit per-agent overrides", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({
+      EMBEDDING_DIMENSION: "768",
+      ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: "768",
+      ELIZAOS_CLOUD_EMBEDDING_URL: "https://custom.example.com/api/v1",
+      ELIZAOS_CLOUD_SMALL_MODEL: "custom-small",
+      ELIZAOS_CLOUD_LARGE_MODEL: "custom-large",
+    });
+
+    expect(result.EMBEDDING_DIMENSION).toBe("768");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("768");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_URL).toBe("https://custom.example.com/api/v1");
+    expect(result.ELIZAOS_CLOUD_SMALL_MODEL).toBe("custom-small");
+    expect(result.ELIZAOS_CLOUD_LARGE_MODEL).toBe("custom-large");
+  });
+
+  test("spreading the helper heals a stale upgrade env that lacks EMBEDDING_DIMENSION", async () => {
+    // Mirrors the blue/green fleet-upgrade path (eliza-sandbox.ts): an agent
+    // provisioned BEFORE the dimension pin landed carries a stale env with no
+    // EMBEDDING_DIMENSION. Spreading the helper on top backfills "1536" (so the
+    // 1536-d cloud vectors stop landing in a dim_384 column) while preserving the
+    // agent's other env verbatim.
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const staleUpgradeEnv: Record<string, string> = {
+      DATABASE_URL: "postgres://agent/own-db",
+      ELIZA_API_TOKEN: "agent_existingtoken",
+      ELIZAOS_CLOUD_API_KEY: "sk-existing",
+      ELIZA_AGENT_LOCAL_STATE: "1",
+      PGLITE_DATA_DIR: "/root/.eliza/.pgdata",
+      ELIZA_PLUGIN_SET: "lean-chat",
+    };
+
+    const healed = {
+      ...staleUpgradeEnv,
+      ...applyManagedAgentInferenceEnvDefaults(staleUpgradeEnv),
+    };
+
+    // The inference defaults are backfilled...
+    expect(healed.EMBEDDING_DIMENSION).toBe("1536");
+    expect(healed.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    expect(healed.ELIZAOS_CLOUD_EMBEDDING_URL).toBeTruthy();
+    expect(healed.ELIZAOS_CLOUD_SMALL_MODEL).toBeTruthy();
+    expect(healed.ELIZAOS_CLOUD_LARGE_MODEL).toBeTruthy();
+    // ...and the stored env is preserved verbatim (no key rotation, no DB strip,
+    // no state flip — the whole point of the narrow helper).
+    expect(healed.DATABASE_URL).toBe("postgres://agent/own-db");
+    expect(healed.ELIZA_API_TOKEN).toBe("agent_existingtoken");
+    expect(healed.ELIZAOS_CLOUD_API_KEY).toBe("sk-existing");
+    expect(healed.ELIZA_AGENT_LOCAL_STATE).toBe("1");
+    expect(healed.PGLITE_DATA_DIR).toBe("/root/.eliza/.pgdata");
+    expect(healed.ELIZA_PLUGIN_SET).toBe("lean-chat");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -193,6 +193,30 @@ export function mergeManagedPublicBaseUrl(
   return trimmed;
 }
 
+/**
+ * The cloud-managed inference defaults: the embedding endpoint + dimensions and
+ * the Cerebras-direct small/large model pins. Pure and single-source-of-truth —
+ * both the provision path (via prepareManagedElizaBaseEnvironment) and the
+ * blue/green fleet-upgrade path (eliza-sandbox.ts) backfill these onto an
+ * agent's stored env so an agent provisioned BEFORE these pins landed heals on
+ * upgrade instead of carrying a stale 1536→dim_384 mismatch (#8434). Returns
+ * ONLY these 5 keys; an explicit per-agent value always wins.
+ */
+export function applyManagedAgentInferenceEnvDefaults(
+  existingEnv: Record<string, string>,
+): Record<string, string> {
+  return {
+    ELIZAOS_CLOUD_EMBEDDING_URL:
+      existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
+    EMBEDDING_DIMENSION: existingEnv.EMBEDDING_DIMENSION ?? "1536",
+    ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: existingEnv.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS ?? "1536",
+    ELIZAOS_CLOUD_SMALL_MODEL:
+      existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
+    ELIZAOS_CLOUD_LARGE_MODEL:
+      existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
+  };
+}
+
 export async function prepareManagedElizaBaseEnvironment(
   params: PrepareManagedElizaSharedEnvironmentParams,
 ): Promise<ManagedElizaBaseEnvironmentResult> {
@@ -236,34 +260,17 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZAOS_CLOUD_API_KEY: agentApiKey,
       ELIZAOS_CLOUD_ENABLED: "true",
       ELIZAOS_CLOUD_BASE_URL: resolveCloudApiBaseUrl(),
-      // Pin embeddings to the elizacloud Worker (api.elizacloud.ai/api/v1), whose
-      // POST /embeddings serves OpenAI text-embedding-3-small (200, 1536-dim).
-      // Without this, the plugin's getEmbeddingBaseURL() falls back to the
-      // general/text base, which resolves to the Cerebras/BitRouter endpoint that
-      // has NO /embeddings route → 404→503 on every RAG/memory turn. No separate
-      // key is needed: getEmbeddingApiKey falls back to ELIZAOS_CLOUD_API_KEY (set
-      // above), which authenticates to the Worker route. The plugin appends
-      // "/embeddings", so this must end at /api/v1 (resolveCloudApiBaseUrl already
-      // normalizes that). An explicit per-agent override still wins.
-      ELIZAOS_CLOUD_EMBEDDING_URL:
-        existingEnv.ELIZAOS_CLOUD_EMBEDDING_URL ?? resolveCloudApiBaseUrl(),
-      // Match the agent's storage vector dimension to the cloud embedding model.
-      // The elizacloud handler returns 1536-dim vectors (text-embedding-3-small,
-      // ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS default 1536), but plugin-sql's storage
-      // defaults to dim_384 unless EMBEDDING_DIMENSION is set (core/provisioning.ts)
-      // → a 1536 vector is written to the dim_384 column → "Failed query: insert
-      // into embeddings" on every memory write. Pin both to 1536 so they agree.
-      EMBEDDING_DIMENSION: existingEnv.EMBEDDING_DIMENSION ?? "1536",
-      ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS: existingEnv.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS ?? "1536",
-      // Pin the cloud's healthy Cerebras-direct models so the container never
-      // resolves a tier to the `:nitro` default (which has no Cerebras route →
-      // BitRouter→OpenRouter → 503 / wrong model). Mirrors the shared + eliza-app
-      // model config; `ELIZAOS_CLOUD_{SMALL,LARGE}_MODEL` are the highest-priority
-      // settings the plugin reads. An explicit per-agent override still wins.
-      ELIZAOS_CLOUD_SMALL_MODEL:
-        existingEnv.ELIZAOS_CLOUD_SMALL_MODEL ?? CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
-      ELIZAOS_CLOUD_LARGE_MODEL:
-        existingEnv.ELIZAOS_CLOUD_LARGE_MODEL ?? CEREBRAS_DEFAULT_TEXT_LARGE_MODEL,
+      // Cloud-managed inference defaults: pin embeddings to the elizacloud Worker
+      // base (whose POST /embeddings serves 1536-dim text-embedding-3-small —
+      // without it the plugin falls back to the Cerebras/BitRouter text base with
+      // no /embeddings route → 503), pin BOTH embedding dimensions to 1536 so the
+      // plugin-sql storage column (dim_384 by default) matches the cloud vectors
+      // instead of dropping every memory write, and pin the healthy Cerebras-direct
+      // small/large models so the container never resolves a tier to the `:nitro`
+      // default. Shared single-source helper so the fleet-upgrade path re-applies
+      // the same defaults (#8434). Each value still honors an explicit per-agent
+      // override in existingEnv.
+      ...applyManagedAgentInferenceEnvDefaults(existingEnv),
       // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
       // the persistent /root/.eliza volume) instead of the shared cloud Postgres;
       // auth + discovery still flow through the cloud API (ELIZAOS_CLOUD_* above).


### PR DESCRIPTION
## Problem

The dedicated-agent **blue/green fleet-upgrade path** froze the agent's stored env verbatim, with **no managed-env merge**:

```ts
// eliza-sandbox.ts, upgrade config (before)
environmentVars: agent.environment_vars ?? {},
```

So an agent provisioned **before** the `EMBEDDING_DIMENSION=1536` pin landed kept its stale env through an upgrade — the upgrade never healed the embedding/model config. Result: 1536-dim cloud embeddings written into a `dim_384` column → every memory write dropped (no memory) + ~30s/turn latency. Ref #8434.

The standard **provision** path already merges the managed defaults via `prepareManagedElizaEnvironment → …SharedEnvironment → …BaseEnvironment` (`managed-eliza-config.ts`), which sets the embedding + model pins. The upgrade path was the odd one out.

## Fix (narrow, single-source-of-truth)

1. **`managed-eliza-config.ts`** — extract a new exported **pure** function `applyManagedAgentInferenceEnvDefaults(existingEnv)` that returns **only** the 5 inference keys (`ELIZAOS_CLOUD_EMBEDDING_URL`, `EMBEDDING_DIMENSION`, `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS`, `ELIZAOS_CLOUD_SMALL_MODEL`, `ELIZAOS_CLOUD_LARGE_MODEL`), each honoring an explicit per-agent override (`?? default`).
2. In `prepareManagedElizaBaseEnvironment`, replace the inline block that set exactly those 5 keys with a single `...applyManagedAgentInferenceEnvDefaults(existingEnv)` spread — **byte-equivalent behavior** (same keys, same defaults, same override priority). The existing base-env tests (which already assert `EMBEDDING_DIMENSION === "1536"` and override preservation) still pass, proving no regression from the extraction.
3. **`eliza-sandbox.ts`** — backfill the inference defaults on top of the stored env in the upgrade `config`:

```ts
environmentVars: {
  ...((agent.environment_vars as Record<string, string>) ?? {}),
  ...applyManagedAgentInferenceEnvDefaults((agent.environment_vars as Record<string, string>) ?? {}),
},
```

### Why the narrow helper and NOT the full provision merge

Using the full `prepareManagedElizaEnvironment` on the upgrade path would **mint a new agent API key**, **strip `DATABASE_URL`**, and **flip `ELIZA_AGENT_LOCAL_STATE`** on every upgrade. The narrow helper backfills only the 5 inference keys **if missing** and preserves everything else verbatim (`DATABASE_URL`, `ELIZA_API_TOKEN`, `ELIZAOS_CLOUD_API_KEY`, `ELIZA_AGENT_LOCAL_STATE`, `PGLITE_DATA_DIR`, `ELIZA_PLUGIN_SET`, …) — that's the whole point.

## Operational caveat

This prevents the **freeze going forward**. Existing local-state agents whose PGlite embeddings column was already physically created at `dim_384` still need a volume reset / recreate — env alone won't migrate an already-created column. This fix stops new upgrades from inheriting the stale config.

## Tests

`packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts` — added a `describe("applyManagedAgentInferenceEnvDefaults (#8434)")` block:
- empty env → all 5 keys, `EMBEDDING_DIMENSION` / `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS` both `"1536"`;
- explicit overrides (e.g. `EMBEDDING_DIMENSION: "768"`) preserved;
- regression intent: spreading the helper over a stale upgrade env that lacks `EMBEDDING_DIMENSION` backfills `"1536"` while preserving `DATABASE_URL` / `ELIZA_API_TOKEN` / `ELIZAOS_CLOUD_API_KEY` / state / plugin-set verbatim (mirrors the upgrade-heal).

```
$ bun test packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
 17 pass / 0 fail (14 existing + 3 new), 48 expect() calls
```

Biome clean on all 3 touched files. Typecheck: `managed-eliza-config.ts` has zero errors; `eliza-sandbox.ts` shows only the worktree's pre-existing `drizzle-orm`-not-installed cascade (identical count with the base-`develop` version of the file swapped in — not introduced by this change).

Refs #8434
