### PR TITLE
fix(cloud): stop + remove the app container on app delete (Product-2 cost leak)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/containers.ts
+++ b/packages/cloud-shared/src/db/repositories/containers.ts
@@ -239,6 +239,34 @@ export class ContainersRepository {
   }
 
   /**
+   * Finds every not-yet-torn-down container for an org's project key.
+   *
+   * Returns containers in any state EXCEPT the terminal `deleting`/`deleted`
+   * (rows already on their way out). Used by app-delete teardown to find the
+   * live container(s) for an app (the deploy orchestrator sets
+   * `project_name = appId`) so they can be stopped/removed and stop being
+   * metered. `stopped`/`failed` rows are intentionally included: a `stopped`
+   * row can still hold a node slot the daemon delete must release, and a
+   * re-deploy may have left more than one row per project key.
+   */
+  async findUndeletedByProjectName(
+    organizationId: string,
+    projectName: string,
+  ): Promise<Container[]> {
+    return await dbRead
+      .select()
+      .from(containers)
+      .where(
+        and(
+          eq(containers.organization_id, organizationId),
+          eq(containers.project_name, projectName),
+          notInArray(containers.status, ["deleting", "deleted"]),
+        ),
+      )
+      .orderBy(desc(containers.created_at));
+  }
+
+  /**
    * Finds the most recent container for a character.
    */
   async findByCharacterId(characterId: string): Promise<Container | null> {
@@ -392,6 +420,29 @@ export class ContainersRepository {
       .returning();
 
     return results.length > 0;
+  }
+
+  /**
+   * Stops billing on a container at delete time, org-scoped.
+   *
+   * Mirrors `ContainerBillingRepository.suspendContainer` (status `stopped`,
+   * billing_status `suspended`) so the daily container-billing cron — which
+   * only meters `status='running'` rows in an active billing state — stops
+   * charging the org IMMEDIATELY, closing the cost-leak window between the app
+   * delete and the daemon actually removing the live container. Org-scoped to
+   * the deleting app's organization; idempotent (a re-run is a harmless no-op
+   * write). The live container teardown + node-slot release is the daemon's
+   * job via the enqueued CONTAINER_DELETE.
+   */
+  async markStoppedForBilling(id: string, organizationId: string): Promise<void> {
+    await dbWrite
+      .update(containers)
+      .set({
+        status: "stopped",
+        billing_status: "suspended",
+        updated_at: new Date(),
+      })
+      .where(and(eq(containers.id, id), eq(containers.organization_id, organizationId)));
   }
 
   /**

--- a/packages/cloud-shared/src/lib/services/__tests__/app-cleanup-container.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-cleanup-container.test.ts
@@ -1,0 +1,125 @@
+/**
+ * App-delete container teardown (Blocker #7).
+ *
+ * On app delete the deployed container was orphaned: never stopped, never
+ * removed, and STILL metered by the daily container-billing cron — a perpetual
+ * overcharge to the org. `stopAppContainers` closes that leak by (1) marking the
+ * row stopped/suspended so the cron stops metering immediately and (2) enqueuing
+ * a CONTAINER_DELETE job for the daemon to do the real `docker stop`/remove. It
+ * must be a clean no-op when the app never deployed a container.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type AppContainerTeardownDeps,
+  stopAppContainers,
+  type TeardownApp,
+  type TeardownContainer,
+} from "../app-container-teardown";
+import type { ContainerJobInsert } from "../container-job-service";
+import { JOB_TYPES } from "../provisioning-job-types";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+const APP_ID = "22222222-2222-2222-2222-222222222222";
+
+function fakeApp(): TeardownApp {
+  return { id: APP_ID, organization_id: ORG_ID };
+}
+
+function fakeContainer(id = "container-1"): TeardownContainer {
+  return { id };
+}
+
+/** Records every interaction so assertions can prove the leak is closed. */
+function recordingDeps(containers: TeardownContainer[]): {
+  deps: AppContainerTeardownDeps;
+  marked: Array<{ containerId: string; organizationId: string }>;
+  jobs: ContainerJobInsert[];
+} {
+  const marked: Array<{ containerId: string; organizationId: string }> = [];
+  const jobs: ContainerJobInsert[] = [];
+  const deps: AppContainerTeardownDeps = {
+    async findContainers(organizationId, appId) {
+      expect(organizationId).toBe(ORG_ID);
+      expect(appId).toBe(APP_ID);
+      return containers;
+    },
+    async markStoppedForBilling(containerId, organizationId) {
+      marked.push({ containerId, organizationId });
+    },
+    jobsWriter: {
+      async insertJob(job) {
+        jobs.push(job);
+        return { id: `job-${jobs.length}` };
+      },
+    },
+  };
+  return { deps, marked, jobs };
+}
+
+describe("stopAppContainers — app-delete container teardown (Blocker #7)", () => {
+  test("stops metering AND enqueues CONTAINER_DELETE for an app with a container", async () => {
+    const { deps, marked, jobs } = recordingDeps([fakeContainer()]);
+
+    const result = await stopAppContainers(fakeApp(), deps);
+
+    expect(result.errors).toEqual([]);
+    expect(result.tornDown).toBe(1);
+
+    // (1) Billing cron stops metering immediately (status=stopped/suspended).
+    expect(marked).toEqual([{ containerId: "container-1", organizationId: ORG_ID }]);
+
+    // (2) Daemon-side stop + remove is enqueued (mirrors the suspend path).
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].type).toBe(JOB_TYPES.CONTAINER_DELETE);
+    expect(jobs[0].organizationId).toBe(ORG_ID);
+    expect(jobs[0].data).toMatchObject({ containerId: "container-1", organizationId: ORG_ID });
+  });
+
+  test("tears down every undeleted container row for the app", async () => {
+    const { deps, marked, jobs } = recordingDeps([
+      fakeContainer("container-1"),
+      fakeContainer("container-2"),
+    ]);
+
+    const result = await stopAppContainers(fakeApp(), deps);
+
+    expect(result.tornDown).toBe(2);
+    expect(marked.map((m) => m.containerId)).toEqual(["container-1", "container-2"]);
+    expect(jobs.map((j) => j.data.containerId)).toEqual(["container-1", "container-2"]);
+    expect(jobs.every((j) => j.type === JOB_TYPES.CONTAINER_DELETE)).toBe(true);
+  });
+
+  test("is a clean no-op when the app never deployed a container", async () => {
+    const { deps, marked, jobs } = recordingDeps([]);
+
+    const result = await stopAppContainers(fakeApp(), deps);
+
+    expect(result.errors).toEqual([]);
+    expect(result.tornDown).toBe(0);
+    expect(marked).toEqual([]);
+    expect(jobs).toEqual([]);
+  });
+
+  test("collects a per-container error without aborting the others", async () => {
+    const failing: AppContainerTeardownDeps = {
+      async findContainers() {
+        return [fakeContainer("bad"), fakeContainer("good")];
+      },
+      async markStoppedForBilling(containerId) {
+        if (containerId === "bad") throw new Error("db down");
+      },
+      jobsWriter: {
+        async insertJob() {
+          return { id: "job" };
+        },
+      },
+    };
+
+    const result = await stopAppContainers(fakeApp(), failing);
+
+    expect(result.tornDown).toBe(1); // "good" still torn down
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("bad");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-cleanup.ts
+++ b/packages/cloud-shared/src/lib/services/app-cleanup.ts
@@ -11,11 +11,14 @@
 import { and, eq } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import type { App } from "../../db/repositories/apps";
+import { containersRepository } from "../../db/repositories/containers";
 import { appDomains } from "../../db/schemas/app-domains";
 import { managedDomains } from "../../db/schemas/managed-domains";
 import { secretBindings } from "../../db/schemas/secrets";
 import { logger } from "../utils/logger";
+import { type AppContainerTeardownDeps, stopAppContainers } from "./app-container-teardown";
 import { appsService } from "./apps";
+import { containerJobsWriter } from "./container-jobs-writer";
 import { githubReposService } from "./github-repos";
 
 interface CleanupResult {
@@ -26,6 +29,23 @@ interface CleanupResult {
     githubRepoDeleted: boolean;
     secretBindingsRemoved: number;
     managedDomainsUnlinked: number;
+    containersTornDown: number;
+  };
+}
+
+/**
+ * Wire the real container-teardown backend: the containers repo (lookup +
+ * stop-for-billing) and the shared container-jobs writer (the same SSH-free
+ * Worker-enqueues / daemon-executes path the suspend + deploy flows use). The
+ * pure orchestration lives in `app-container-teardown.ts` (injectable for tests).
+ */
+function defaultContainerTeardownDeps(): AppContainerTeardownDeps {
+  return {
+    findContainers: (organizationId, appId) =>
+      containersRepository.findUndeletedByProjectName(organizationId, appId),
+    markStoppedForBilling: (containerId, organizationId) =>
+      containersRepository.markStoppedForBilling(containerId, organizationId),
+    jobsWriter: containerJobsWriter,
   };
 }
 
@@ -34,6 +54,8 @@ interface CleanupOptions {
   deleteGitHubRepo?: boolean;
   /** Force cleanup even if some steps fail (default: true) */
   continueOnError?: boolean;
+  /** Container-teardown backend (DB repo + jobs writer). Injected in tests. */
+  containerTeardown?: AppContainerTeardownDeps;
 }
 
 /**
@@ -199,7 +221,11 @@ export async function cleanupAppResources(
   appId: string,
   options: CleanupOptions = {},
 ): Promise<CleanupResult> {
-  const { deleteGitHubRepo: shouldDeleteGitHub = true, continueOnError = true } = options;
+  const {
+    deleteGitHubRepo: shouldDeleteGitHub = true,
+    continueOnError = true,
+    containerTeardown = defaultContainerTeardownDeps(),
+  } = options;
 
   const errors: string[] = [];
   const cleaned = {
@@ -207,6 +233,7 @@ export async function cleanupAppResources(
     githubRepoDeleted: false,
     secretBindingsRemoved: 0,
     managedDomainsUnlinked: 0,
+    containersTornDown: 0,
   };
 
   logger.info("[AppCleanup] Starting comprehensive app cleanup", {
@@ -224,7 +251,18 @@ export async function cleanupAppResources(
     };
   }
 
-  // Step 1: Remove app domain records (before CASCADE deletes them)
+  // Step 1: Stop + tear down the deployed container(s). Done first so the org
+  // stops being metered (and the live container stops running) as early as
+  // possible, even if a later cleanup step fails.
+  const containerResult = await stopAppContainers(app, containerTeardown);
+  cleaned.containersTornDown = containerResult.tornDown;
+  errors.push(...containerResult.errors);
+
+  if (containerResult.errors.length > 0 && !continueOnError) {
+    return { success: false, errors, cleaned };
+  }
+
+  // Step 2: Remove app domain records (before CASCADE deletes them)
   const domainResult = await removeAppDomains(appId);
   cleaned.domainsRemoved = domainResult.removed;
   errors.push(...domainResult.errors);
@@ -233,7 +271,7 @@ export async function cleanupAppResources(
     return { success: false, errors, cleaned };
   }
 
-  // Step 2: Delete GitHub repository
+  // Step 3: Delete GitHub repository
   if (shouldDeleteGitHub) {
     const githubResult = await deleteGitHubRepo(app);
     cleaned.githubRepoDeleted = githubResult.deleted;
@@ -245,12 +283,12 @@ export async function cleanupAppResources(
     }
   }
 
-  // Step 3: Clean up secret bindings
+  // Step 4: Clean up secret bindings
   const secretResult = await cleanupSecretBindings(appId);
   cleaned.secretBindingsRemoved = secretResult.removed;
   errors.push(...secretResult.errors);
 
-  // Step 4: Unlink managed domains
+  // Step 5: Unlink managed domains
   const managedDomainsResult = await unlinkManagedDomains(appId);
   cleaned.managedDomainsUnlinked = managedDomainsResult.unlinked;
   errors.push(...managedDomainsResult.errors);
@@ -303,4 +341,5 @@ export const appCleanupService = {
   deleteGitHubRepo,
   cleanupSecretBindings,
   unlinkManagedDomains,
+  stopAppContainers,
 };

--- a/packages/cloud-shared/src/lib/services/app-container-teardown.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-teardown.ts
@@ -1,0 +1,112 @@
+/**
+ * App-delete container teardown (Blocker #7) — the pure orchestration of
+ * stopping + removing the container(s) backing a deleted app.
+ *
+ * On app delete the per-tenant DB was deprovisioned but the live container was
+ * orphaned: it kept running on the node AND kept being metered by the daily
+ * container-billing cron (a cost leak + a perpetual overcharge to the org). The
+ * suspend path already stops a container via an enqueued CONTAINER_STOP/DELETE
+ * job; delete did not. This module mirrors that path:
+ *
+ *   1. mark the container row stopped/suspended so the billing cron — which only
+ *      meters `status='running'` rows in an active billing state — stops
+ *      charging the org IMMEDIATELY (closes the leak window before the daemon
+ *      runs), and
+ *   2. enqueue a CONTAINER_DELETE job (a plain DB insert; the Worker never SSHs)
+ *      for the provisioning daemon to do the real `docker stop`/remove and
+ *      release the node slot.
+ *
+ * Kept free of `db/client` imports (the real repo + jobs writer are injected via
+ * {@link AppContainerTeardownDeps}) so it is unit-testable with no DB/queue.
+ */
+
+import { logger } from "../utils/logger";
+import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
+
+/** The minimal app shape the teardown needs (a real `App` is assignable). */
+export interface TeardownApp {
+  id: string;
+  organization_id: string;
+}
+
+/** A container row the teardown acts on (a real `Container` is assignable). */
+export interface TeardownContainer {
+  id: string;
+}
+
+/**
+ * Seam for the container-teardown backend so the cleanup can be unit-tested
+ * without a DB or a real jobs queue. Production wiring (in `app-cleanup.ts`)
+ * supplies the real containers repo + the shared container-jobs writer.
+ */
+export interface AppContainerTeardownDeps {
+  /** All not-yet-deleted container rows for this app (org-scoped). */
+  findContainers: (organizationId: string, appId: string) => Promise<TeardownContainer[]>;
+  /** Stop metering a container immediately (status=stopped, billing_status=suspended). */
+  markStoppedForBilling: (containerId: string, organizationId: string) => Promise<void>;
+  /** Enqueue the daemon-side CONTAINER_DELETE (stops + removes the live container). */
+  jobsWriter: ContainerJobsWriter;
+}
+
+/**
+ * Stop + tear down the app's deployed container(s).
+ *
+ * The deploy orchestrator sets `containers.project_name = appId`, so the app's
+ * container(s) are resolved by (organization_id, project_name=appId). Idempotent
+ * and a clean no-op when the app never deployed a container; a per-container
+ * failure is collected and does not abort teardown of the others.
+ */
+export async function stopAppContainers(
+  app: TeardownApp,
+  deps: AppContainerTeardownDeps,
+): Promise<{ tornDown: number; errors: string[] }> {
+  const errors: string[] = [];
+  let tornDown = 0;
+
+  let containers: TeardownContainer[];
+  try {
+    containers = await deps.findContainers(app.organization_id, app.id);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    errors.push(`Failed to look up app containers: ${errorMessage}`);
+    logger.error("[AppCleanup] Failed to look up app containers", {
+      appId: app.id,
+      error: errorMessage,
+    });
+    return { tornDown, errors };
+  }
+
+  if (containers.length === 0) {
+    logger.info("[AppCleanup] No container to tear down", { appId: app.id });
+    return { tornDown, errors };
+  }
+
+  const enqueuer = new ContainerJobEnqueuer(deps.jobsWriter);
+
+  for (const container of containers) {
+    try {
+      // 1. Stop metering now (close the cost-leak window before the daemon runs).
+      await deps.markStoppedForBilling(container.id, app.organization_id);
+      // 2. Enqueue the daemon-side stop + remove (also releases the node slot).
+      await enqueuer.enqueueDelete({
+        containerId: container.id,
+        organizationId: app.organization_id,
+      });
+      tornDown += 1;
+      logger.info("[AppCleanup] Stopped + enqueued container teardown", {
+        appId: app.id,
+        containerId: container.id,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      errors.push(`Failed to tear down container ${container.id}: ${errorMessage}`);
+      logger.error("[AppCleanup] Failed to tear down container", {
+        appId: app.id,
+        containerId: container.id,
+        error: errorMessage,
+      });
+    }
+  }
+
+  return { tornDown, errors };
+}


### PR DESCRIPTION
## Blocker

**Product-2 app delete orphans the running container forever** — it is never stopped/removed AND keeps being metered.

On app delete, `cleanupAppResources` (`packages/cloud-shared/src/lib/services/app-cleanup.ts`) deprovisioned the per-tenant DB and cleaned up domains/secrets/GitHub, but the app's actual **container** was left untouched:

- it kept **running** on the Hetzner node (created with `--restart unless-stopped`; the Worker can't SSH to stop it), and
- it kept getting **metered** by the daily container-billing cron — which bills every `status='running'` row in an active billing state — so the org was **overcharged in perpetuity** for an app they deleted.

The **suspend** path already handles this correctly (`ContainerBillingRepository.suspendContainer` flips the row to `stopped`/`suspended`, and an enqueued `CONTAINER_STOP`/`CONTAINER_DELETE` job tells the daemon to do the real teardown). Delete simply never did the equivalent.

## The fix

A new **Step 1** in `cleanupAppResources` tears down the app's container(s), mirroring the suspend path:

1. **Resolve** the container(s) by `(organization_id, project_name = appId)` — the deploy orchestrator sets `project_name = appId` (`app-deploy-runner.ts` `toNewContainer`).
2. **Stop metering immediately**: mark each row `status='stopped', billing_status='suspended'` (same end-state as `suspendContainer`). The billing cron only meters `status='running'` rows, so this halts the overcharge **right away** — not only once the daemon runs — closing the leak window.
3. **Enqueue `CONTAINER_DELETE`** (a plain DB insert; the Worker never touches SSH). The provisioning daemon claims it and does the real `docker stop`/remove via the node-only Hetzner client, which also atomically releases the node slot (`tryReleaseNodeSlot`, double-release-guarded). `executeContainerDelete` already does `provider.delete()` + `store.markDeleted()`.

Done **first** in the cleanup sequence so the org stops being billed (and the live container stops) as early as possible, even if a later cleanup step fails. **Idempotent** and a **clean no-op** when the app never deployed a container; a per-container failure is collected (not thrown) so it never aborts teardown of the other rows or the rest of cleanup.

**Isolation preserved:** no change to per-tenant DB or network isolation — this only stops/removes the tenant's own container and stops billing it.

### Why `CONTAINER_DELETE` (not `CONTAINER_STOP`)
The suspend path uses `CONTAINER_STOP` because it **preserves the volume** (`purgeVolume:false`) so the org can top up and redeploy. On *delete* the app is gone for good, so full teardown (`CONTAINER_DELETE` → `provider.delete()`) is the correct, complete removal.

## Files changed
- `packages/cloud-shared/src/lib/services/app-cleanup.ts` — wire container teardown as Step 1 of `cleanupAppResources`; add `containersTornDown` to the result; inject the real backend (containers repo + shared container-jobs writer).
- `packages/cloud-shared/src/lib/services/app-container-teardown.ts` *(new)* — pure, `db/client`-free orchestration (`stopAppContainers`) with an injectable `AppContainerTeardownDeps` seam, so it's unit-testable with no DB/queue.
- `packages/cloud-shared/src/db/repositories/containers.ts` — add `findUndeletedByProjectName` (resolve an app's live container rows, org-scoped) and `markStoppedForBilling` (org-scoped stop-metering write mirroring `suspendContainer`).
- `packages/cloud-shared/src/lib/services/__tests__/app-cleanup-container.test.ts` *(new)* — focused test.

## Test
`src/lib/services/__tests__/app-cleanup-container.test.ts` asserts that delete:
- **stops metering AND enqueues `CONTAINER_DELETE`** for an app with a container (the core leak-closing assertion),
- tears down **every** undeleted container row for the app,
- is a **clean no-op** when the app never deployed a container,
- **collects a per-container error** without aborting the others.

```
bunx @biomejs/biome check  → Checked 4 files. No issues (1 import-order autofix).
bun test --isolate <file>  → 4 pass / 0 fail (24 expect() calls)
typecheck (filtered)       → no errors naming the changed files
                             (suite's only errors are unrelated ../core,../shared
                              i18n generated-file noise — documented in cloud-shared AGENTS.md)
```