### PR TITLE
fix(cloud): release per-tenant DB + cluster slot on app delete in env-DSN deploy mode (#8342)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
@@ -1,0 +1,208 @@
+/**
+ * #8342 (reopened) — env-DSN deploy mode must not leak the per-tenant DB/role/
+ * cluster slot on app delete.
+ *
+ * In env-DSN mode (`APPS_TENANT_ADMIN_DSN` set → `makeDirectAppDeployRunner`),
+ * provision happens DIRECTLY through `TenantDbProvisioning.provisionForApp` and
+ * historically never wrote the canonical `app_databases` row. App delete tears
+ * down by reading that row (`findStateByAppIdForWrite`) and returns early when
+ * it's missing — so no APP_DB_DEPROVISION job, no DROP, and `releaseSlot` never
+ * runs (the cluster's finite slots drift up until they exhaust).
+ *
+ * The fix persists the teardown-readable row at provision time, keyed by appId,
+ * carrying the per-tenant DSN as plaintext (this mode has no master key; the
+ * teardown path's `decryptIfNeeded` passes plaintext through). This test wires
+ * the REAL seams end-to-end through the public deploy `run()` → row persist →
+ * Worker delete enqueue → daemon dispatch — and asserts the DROP + `releaseSlot`
+ * actually fire so the slot returns to baseline (no leak).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { AppDatabaseState } from "../../../db/repositories/app-databases";
+
+// In-memory app_databases store shared by provision (updateState) and the
+// Worker delete read (findStateByAppIdForWrite) — the row must survive across
+// both for the teardown to resolve the DSN.
+const appDatabasesStore = new Map<string, AppDatabaseState>();
+mock.module("../../../db/repositories/app-databases", () => ({
+  appDatabasesRepository: {
+    updateState: async (
+      appId: string,
+      data: Partial<AppDatabaseState>,
+    ): Promise<AppDatabaseState> => {
+      const next: AppDatabaseState = {
+        app_id: appId,
+        user_database_uri: null,
+        user_database_region: "aws-us-east-1",
+        user_database_status: "none",
+        user_database_error: null,
+        source: "app_databases",
+        ...appDatabasesStore.get(appId),
+        ...data,
+      };
+      appDatabasesStore.set(appId, next);
+      return next;
+    },
+    findStateByAppIdForWrite: async (appId: string) => appDatabasesStore.get(appId),
+  },
+}));
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+const ORG_ID = "org-env-dsn";
+const USER_ID = "user-env-dsn";
+const CLUSTER_HOST = "tenant-cluster.internal";
+const ADMIN_DSN = `postgresql://admin:pw@${CLUSTER_HOST}/postgres`;
+
+// The deploy runner loads the app via appsService.getById (twice: once to
+// resolve the image, once in linkContainerToApp). databaseMode "isolated" is
+// what makes the orchestrator call ensureTenantDb.
+mock.module("../apps", () => ({
+  appsService: {
+    getById: async (id: string) =>
+      id === APP_ID
+        ? {
+            id: APP_ID,
+            name: "my-app",
+            organization_id: ORG_ID,
+            created_by_user_id: USER_ID,
+            github_repo: null,
+            metadata: { databaseMode: "isolated" },
+          }
+        : undefined,
+    update: async () => {},
+  },
+}));
+
+// The container row write is a real-schema seam in production; here we only need
+// it to return a stable id so the orchestrator can enqueue + link.
+mock.module("../../../db/repositories/containers", () => ({
+  containersRepository: {
+    create: async () => ({ id: "container-1" }),
+  },
+}));
+
+import {
+  dispatchAppDbDeprovisionJob,
+  enqueueAppDbDeprovision,
+  readAppDbDeprovisionJobData,
+  setAppDbDeprovisioner,
+} from "../app-db-deprovision-job-service";
+import { makeDirectAppDeployRunner } from "../app-deploy-runner";
+import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+import { JOB_TYPES } from "../provisioning-job-types";
+import type { TenantDbSqlExecutor } from "../tenant-db/tenant-db-provisioner";
+import { SqlTenantDbProvisioner } from "../tenant-db/tenant-db-provisioner";
+import { SqlTenantDbProvisioning } from "../tenant-db/tenant-db-provisioning";
+import { UserDatabaseService } from "../user-database";
+
+/** Fake executor that tracks the DDL it ran and which databases are live. */
+function makeFakeExecutor(): { executor: TenantDbSqlExecutor; live: Set<string> } {
+  const live = new Set<string>();
+  const executor: TenantDbSqlExecutor = {
+    async execAdmin(statements) {
+      for (const stmt of statements) {
+        const create = stmt.match(/CREATE DATABASE "([^"]+)"/);
+        if (create) live.add(create[1]);
+        const drop = stmt.match(/DROP DATABASE IF EXISTS "([^"]+)"/);
+        if (drop) live.delete(drop[1]);
+      }
+    },
+    async execInDatabase() {},
+    async databaseExists(dbName) {
+      return live.has(dbName);
+    },
+  };
+  return { executor, live };
+}
+
+/**
+ * Build the real provisioning seam in env-DSN mode (passthrough decrypt), with a
+ * captured cluster + a `releaseSlot` spy. `database_count` is tracked so we can
+ * assert the slot is claimed on provision and released on teardown.
+ */
+function makeProvisioning() {
+  const { executor, live } = makeFakeExecutor();
+  let databaseCount = 0;
+  const released: string[] = [];
+
+  const provisioning = new SqlTenantDbProvisioning({
+    pool: {
+      async allocate() {
+        databaseCount += 1; // the real store's tryClaimSlot increments here
+        return { id: "cluster-1", host: CLUSTER_HOST, adminDsnEncrypted: ADMIN_DSN };
+      },
+    },
+    // env-DSN mode: the admin DSN is env-sourced, so decrypt is a passthrough.
+    decrypt: async (value) => value,
+    makeProvisioner: (cluster) =>
+      new SqlTenantDbProvisioner({
+        cluster,
+        executor,
+        genPassword: () => "deterministic-password",
+      }),
+    resolveClusterByHost: async (host) =>
+      host === CLUSTER_HOST ? { id: "cluster-1", adminDsnEncrypted: ADMIN_DSN } : null,
+    releaseSlot: async (clusterId) => {
+      released.push(clusterId);
+      databaseCount = Math.max(0, databaseCount - 1);
+    },
+  });
+
+  return { provisioning, live, released, slotCount: () => databaseCount };
+}
+
+describe("env-DSN deploy mode — per-tenant DB teardown (#8342)", () => {
+  test("deploy persists app_databases row; delete DROPs the DB and releases the slot", async () => {
+    appDatabasesStore.clear();
+    const { provisioning, live, released, slotCount } = makeProvisioning();
+
+    const enqueued: ContainerJobInsert[] = [];
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob(job) {
+        enqueued.push(job);
+        return { id: `job-${enqueued.length}` };
+      },
+    };
+
+    // ── DEPLOY (daemon, env-DSN mode) ─────────────────────────────────────
+    const runner = makeDirectAppDeployRunner({
+      tenantDbProvisioning: provisioning,
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+    await runner.run(APP_ID);
+
+    // The per-tenant DB is live and a cluster slot is claimed.
+    expect(live.size).toBe(1);
+    expect(slotCount()).toBe(1);
+
+    // The canonical row is now persisted (the fix — previously absent in env-DSN
+    // mode, which is exactly what stranded the teardown).
+    const persisted = appDatabasesStore.get(APP_ID);
+    expect(persisted?.user_database_status).toBe("ready");
+    expect(persisted?.user_database_uri).toContain(CLUSTER_HOST);
+    const dsn = persisted?.user_database_uri as string;
+
+    // ── DELETE (Worker, no pg backend, enqueuer wired) ────────────────────
+    const workerSvc = new UserDatabaseService(); // no provisioning backend == Worker
+    workerSvc.setDeprovisionEnqueuer((p) => enqueueAppDbDeprovision(jobsWriter, p));
+    await workerSvc.cleanupDatabase(APP_ID, { organizationId: ORG_ID, userId: USER_ID });
+
+    // An APP_DB_DEPROVISION job was enqueued carrying the per-tenant DSN.
+    const deprovJob = enqueued.find((j) => j.type === JOB_TYPES.APP_DB_DEPROVISION);
+    expect(deprovJob).toBeDefined();
+    expect(deprovJob?.organizationId).toBe(ORG_ID);
+    const { appId, dbUri } = readAppDbDeprovisionJobData({ data: deprovJob?.data });
+    expect(appId).toBe(APP_ID);
+    expect(dbUri).toBe(dsn);
+
+    // ── DAEMON dispatch — the real DROP + releaseSlot ─────────────────────
+    setAppDbDeprovisioner(provisioning);
+    const outcome = await dispatchAppDbDeprovisionJob({ data: deprovJob?.data });
+
+    expect(outcome.deprovisioned).toBe(true);
+    expect(live.size).toBe(0); // DB dropped
+    expect(released).toEqual(["cluster-1"]); // slot released exactly once
+    expect(slotCount()).toBe(0); // database_count back to baseline — no leak
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -41,6 +41,7 @@
  * per-tenant DSN, never the shared agent URL — is asserted directly.
  */
 
+import { appDatabasesRepository } from "../../db/repositories/app-databases";
 import { containersRepository } from "../../db/repositories/containers";
 import type { NewContainer } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
@@ -234,12 +235,22 @@ export function makeNodeAppDeployRunner(args: {
 /**
  * NODE factory (ENCRYPTION-FREE) — `ensureTenantDb` provisions the isolated
  * tenant DB DIRECTLY via the injected {@link TenantDbProvisioning}, returning the
- * DSN without routing through `userDatabaseService`. So it never writes the
- * field-encrypted `app_databases.user_database_uri` and needs no
+ * DSN without routing through `userDatabaseService`. It needs no
  * `SECRETS_MASTER_KEY` — the per-tenant DSN still rides into the container's
  * `environment_vars`. Use when the daemon has no field-encryption key (the
  * cluster admin DSN is env-sourced via a passthrough decrypt). Isolation is
  * unchanged: REVOKE-CONNECT per tenant still applies.
+ *
+ * It DOES persist the canonical `app_databases` row at provision time (#8342):
+ * without it, app delete (`UserDatabaseService.cleanupDatabase` →
+ * `findStateByAppIdForWrite`) finds no row and returns early, so the per-tenant
+ * DB + ROLE are never DROPped and the cluster slot is never released — the DB
+ * leaks (we keep paying) and the cluster's finite slots drift up until they
+ * exhaust. The row carries the per-tenant DSN as PLAINTEXT (this mode has no
+ * master key to encrypt with); that is safe because the teardown path decrypts
+ * with `fieldEncryption.decryptIfNeeded`, which passes plaintext through — the
+ * exact env-DSN case `dispatchAppDbDeprovisionJob` already documents. So the
+ * standard delete → APP_DB_DEPROVISION → DROP + releaseSlot path fires unchanged.
  */
 export function makeDirectAppDeployRunner(args: {
   tenantDbProvisioning: TenantDbProvisioning;
@@ -250,6 +261,15 @@ export function makeDirectAppDeployRunner(args: {
   return new DefaultAppDeployRunner({
     ensureTenantDb: async (appId) => {
       const { dsn } = await args.tenantDbProvisioning.provisionForApp(appId);
+      // Persist the teardown-readable canonical record keyed by appId so app
+      // delete can resolve the per-tenant DSN and run the DROP + slot release.
+      // Stored as plaintext — see the factory header; decryptIfNeeded passes
+      // plaintext through on the daemon side.
+      await appDatabasesRepository.updateState(appId, {
+        user_database_uri: dsn,
+        user_database_status: "ready",
+        user_database_error: null,
+      });
       return dsn;
     },
     jobsWriter: args.jobsWriter,


### PR DESCRIPTION
## Blocker (#8342 reopened) — env-DSN deploy mode leaks the per-tenant DB/role/slot on app delete

Eliza Cloud **Product-2** has real paying users. The **prod arming mode is env-DSN** (`APPS_TENANT_ADMIN_DSN` set → `apps-deploy-backend.ts` selects `makeDirectAppDeployRunner`). In that mode:

- `ensureTenantDb` calls `tenantDbProvisioning.provisionForApp(appId)`, which provisions a **real** per-tenant Postgres DB + ROLE and **claims a cluster slot** — but it **never wrote the canonical `app_databases` row**.
- App delete tears down via `UserDatabaseService.cleanupDatabase`, which reads `appDatabasesRepository.findStateByAppIdForWrite(appId)` and **returns early when there is no row**.

Result: no row → no `APP_DB_DEPROVISION` job → no `DROP DATABASE`/`DROP ROLE` → `releaseSlot` never runs → `database_count` drifts up until the cluster's **finite slots exhaust**, and we keep paying for an orphaned live DB. There is **no orphan reconciler** despite older code comments implying one.

## The fix

In env-DSN mode (`makeDirectAppDeployRunner`), persist the teardown-readable canonical `app_databases` row at provision time, keyed by `appId`, carrying the per-tenant DSN with status `ready`:

```ts
const { dsn } = await args.tenantDbProvisioning.provisionForApp(appId);
await appDatabasesRepository.updateState(appId, {
  user_database_uri: dsn,
  user_database_status: "ready",
  user_database_error: null,
});
return dsn;
```

This makes the **existing** delete path fire unchanged: delete → `cleanupDatabase` finds the row → Worker enqueues `APP_DB_DEPROVISION` (carrying the DSN) → daemon `dispatchAppDbDeprovisionJob` → `deprovisionForApp` → `DROP` + `releaseSlot`.

**Isolation is untouched** — `REVOKE CONNECT` per-tenant boundary is unchanged; this only adds the teardown bookkeeping row.

### Tradeoff (noted, safest correct option)

env-DSN mode is **encryption-free by design** (no `SECRETS_MASTER_KEY`; the cluster admin DSN is env-sourced via a passthrough decrypt). So the per-tenant DSN is stored as **plaintext** in `app_databases.user_database_uri`. This is safe and is the path the codebase already anticipates:

- The teardown path resolves the DSN with `fieldEncryption.decryptIfNeeded`, which **passes plaintext through** — `dispatchAppDbDeprovisionJob`'s own doc names "the env-DSN mode" as the plaintext case.
- There is no master key in this mode to encrypt with; encrypting would require provisioning org key infrastructure this deploy mode intentionally omits.

If/when env-DSN mode gains a master key, the same row can be encrypted at write time with no change to the teardown path. The alternative (a parallel non-encrypted teardown store) would add a second deprovision codepath; reusing the existing `app_databases` row keeps a single canonical lifecycle.

## Test (regression guard)

`packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts` wires the **real** seams end to end through the public deploy `run()`:

1. **Deploy** (env-DSN, `databaseMode: "isolated"`) → asserts the per-tenant DB is live, the slot is claimed, and the `app_databases` row is persisted (`ready` + DSN).
2. **Delete** (Worker, no `pg` backend, enqueuer wired) → asserts an `APP_DB_DEPROVISION` job is enqueued carrying the DSN.
3. **Daemon dispatch** → asserts the DB is DROPped and the cluster slot is **released exactly once** (`database_count` back to baseline — no leak).

Verified it **fails when the persist is removed** (the row is absent → teardown stranded), proving it guards the regression.

## Verification

- `bunx @biomejs/biome check --write <changed files>` → clean (no fixes).
- `bun test --isolate <test file>` → **1 pass, 12 assertions**.
- `bun run --cwd packages/cloud-shared typecheck` → exit 0, zero errors (filtered to changed files: clean).

## Files changed

- `packages/cloud-shared/src/lib/services/app-deploy-runner.ts` — persist `app_databases` row in `makeDirectAppDeployRunner.ensureTenantDb`.
- `packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts` — new integration-style lifecycle test.