### PR TITLE
feat(cloud): periodic orphan app-container reconciler (Product-2 hardening)

### DIFF
--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the orphan APP-container reconciler's pure diff logic and its
+ * SSH-orchestration loop, mirroring `docker-node-workloads.test.ts` for the
+ * apps (`containers` table) variant.
+ *
+ * The diff (`computeOrphanAppContainersToReap`) is the load-bearing safety
+ * property: an `app-<slug>` container is reaped ONLY when its NAME has no live
+ * `containers` row (or a terminal one), and NEVER when the name does not match
+ * the managed `app-` pattern. The orchestration test pins the "never reap on an
+ * unreachable node" invariant (SSH listing returned null → skip, not reap) and
+ * the reap-by-id invariant (the rm targets the immutable container id, not the
+ * name).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  type AppOrphanReconcilerNode,
+  computeOrphanAppContainersToReap,
+  isAppContainerName,
+  type LiveAppContainerRef,
+  type NodeAppContainerRef,
+  reconcileOrphanAppContainers,
+} from "./app-container-orphan-reconciler";
+
+describe("isAppContainerName", () => {
+  test("accepts an app-<slug> name", () => {
+    expect(isAppContainerName("app-abc123def456")).toBe(true);
+  });
+
+  test("rejects names without the app- prefix", () => {
+    expect(isAppContainerName("postgres")).toBe(false);
+    expect(isAppContainerName("agent-abc")).toBe(false);
+    // substring match elsewhere in the name must NOT count
+    expect(isAppContainerName("my-app-x")).toBe(false);
+  });
+
+  test("rejects a bare prefix with no slug", () => {
+    expect(isAppContainerName("app-")).toBe(false);
+  });
+});
+
+describe("computeOrphanAppContainersToReap", () => {
+  const live = (name: string, status: string): LiveAppContainerRef => ({ name, status });
+  const container = (name: string, id: string): NodeAppContainerRef => ({ name, id });
+
+  test("reaps a container whose name has NO db row", () => {
+    const orphans = computeOrphanAppContainersToReap([container("app-gone", "c1")], []);
+    expect(orphans).toEqual([{ name: "app-gone", id: "c1", reason: "no_db_row" }]);
+  });
+
+  test("reaps a container whose db row is in a terminal state (stopped/failed/deleted)", () => {
+    for (const status of ["stopped", "failed", "deleted"]) {
+      const orphans = computeOrphanAppContainersToReap(
+        [container("app-dead", "c2")],
+        [live("app-dead", status)],
+      );
+      expect(orphans).toEqual([{ name: "app-dead", id: "c2", reason: "terminal_db_row" }]);
+    }
+  });
+
+  test("does NOT reap a container with a live (running) db row", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-live", "c3")],
+      [live("app-live", "running")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("does NOT reap deploying / building / pending rows", () => {
+    for (const status of ["deploying", "building", "pending"]) {
+      const orphans = computeOrphanAppContainersToReap(
+        [container("app-x", "cx")],
+        [live("app-x", status)],
+      );
+      expect(orphans).toEqual([]);
+    }
+  });
+
+  test("does NOT reap a row in 'deleting' (delete job owns teardown)", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-deleting", "c4")],
+      [live("app-deleting", "deleting")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("ignores containers that do not match the app- pattern", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("postgres", "p1"), container("agent-abc", "a1"), container("redis", "r1")],
+      [],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("mixed fleet: reaps only the orphans, leaves live + non-app alone", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [
+        container("app-running", "c-run"),
+        container("app-orphan", "c-orph"),
+        container("app-stopped", "c-stop"),
+        container("agent-foo", "c-agent"),
+        container("nginx", "c-nginx"),
+      ],
+      [live("app-running", "running"), live("app-stopped", "stopped")],
+    );
+    expect(orphans.map((o) => o.id).sort()).toEqual(["c-orph", "c-stop"]);
+  });
+});
+
+describe("reconcileOrphanAppContainers (orchestration)", () => {
+  function makeNode(overrides: Partial<AppOrphanReconcilerNode> = {}): AppOrphanReconcilerNode {
+    return {
+      node_id: "node-1",
+      hostname: "host-1",
+      status: "healthy",
+      listAppContainers: mock(async () => [] as NodeAppContainerRef[]),
+      removeContainer: mock(async () => {}),
+      ...overrides,
+    };
+  }
+
+  test("force-removes every orphan on a healthy node — BY ID, not name", async () => {
+    const removeContainer = mock(async () => {});
+    const node = makeNode({
+      listAppContainers: mock(async () => [
+        { name: "app-orphan", id: "c-orph" },
+        { name: "app-live", id: "c-live" },
+      ]),
+      removeContainer,
+    });
+    const loadLive = mock(async () => [{ name: "app-live", status: "running" }]);
+
+    const result = await reconcileOrphanAppContainers([node], loadLive);
+
+    expect(removeContainer).toHaveBeenCalledTimes(1);
+    // reap-by-id invariant: the rm target is the immutable container id, NOT the name.
+    expect(removeContainer).toHaveBeenCalledWith("c-orph");
+    expect(result).toEqual({
+      nodesScanned: 1,
+      nodesSkipped: 0,
+      reaped: 1,
+      reapFailed: 0,
+    });
+  });
+
+  test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
+    const removeContainer = mock(async () => {});
+    const node = makeNode({
+      listAppContainers: mock(async () => null),
+      removeContainer,
+    });
+
+    const result = await reconcileOrphanAppContainers([node], async () => []);
+
+    expect(removeContainer).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      nodesScanned: 0,
+      nodesSkipped: 1,
+      reaped: 0,
+      reapFailed: 0,
+    });
+  });
+
+  test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
+    const listAppContainers = mock(async () => [] as NodeAppContainerRef[]);
+    const node = makeNode({ status: "offline", listAppContainers });
+
+    const result = await reconcileOrphanAppContainers([node], async () => []);
+
+    expect(listAppContainers).not.toHaveBeenCalled();
+    expect(result.nodesSkipped).toBe(1);
+    expect(result.nodesScanned).toBe(0);
+  });
+
+  test("counts a failed removal as reapFailed without aborting the rest", async () => {
+    const node = makeNode({
+      listAppContainers: mock(async () => [
+        { name: "app-a", id: "ca" },
+        { name: "app-b", id: "cb" },
+      ]),
+      removeContainer: mock(async (id: string) => {
+        if (id === "ca") throw new Error("ssh broke");
+      }),
+    });
+
+    const result = await reconcileOrphanAppContainers([node], async () => []);
+
+    expect(result).toEqual({
+      nodesScanned: 1,
+      nodesSkipped: 0,
+      reaped: 1,
+      reapFailed: 1,
+    });
+  });
+
+  test("does not query the DB when a node has no app- containers", async () => {
+    const loadLive = mock(async () => [] as LiveAppContainerRef[]);
+    const node = makeNode({
+      listAppContainers: mock(async () => [{ name: "agent-foo", id: "a" }]),
+    });
+
+    await reconcileOrphanAppContainers([node], loadLive);
+
+    expect(loadLive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -1,0 +1,359 @@
+/**
+ * Orphan APP-container reconciler (Apps / Product 2).
+ *
+ * The sibling of the AGENT orphan reconciler in `docker-node-workloads.ts`, for
+ * the OTHER kind of workload on the shared Hetzner-Docker pool: user-deployed
+ * APP containers (the `containers` table, NOT `agent_sandboxes`).
+ *
+ * THE GAP THIS CLOSES
+ * App-container teardown (`appCleanupService` / the CONTAINER_DELETE executor)
+ * only runs on an EXPLICIT app delete. A mid-deploy crash or a partial failure
+ * can leave an `app-<slug>` container running on a node with no live DB row (or
+ * a DB row left in a dead terminal state) — it holds a compute slot and host
+ * volume forever because nothing in the deploy lifecycle will ever reap it
+ * again. Agents already get a periodic sweep for exactly this; apps did not.
+ * This reconciler closes that gap with a low-cadence sweep over HEALTHY nodes,
+ * mirroring the agent reconciler's proven safety model EXACTLY.
+ *
+ * SAFETY INVARIANTS (identical to the agent reconciler — a wrong reaper kills a
+ * live customer app):
+ *   1. Only `status === "healthy"` nodes are touched.
+ *   2. If the SSH container listing returns null (listing failed) → SKIP the
+ *      node, never reap (a misread empty list must not reap live containers).
+ *   3. Reap by the IMMUTABLE container ID captured in the same listing — NEVER
+ *      by name (avoids the delete+recreate race where the name resolves to the
+ *      new live container).
+ *   4. Hard per-call SSH timeouts on both the list and the rm.
+ *   5. Every reap, skip, and failure is logged.
+ *   6. When unsure whether a container is an orphan → DO NOT reap.
+ *
+ * HOW APP CONTAINERS DIFFER FROM AGENTS
+ *   - App containers are named `app-<first 12 of app id>` (see
+ *     `containerNameForApp` in `app-deploy-runner.ts`); the name is written
+ *     verbatim to `containers.name`. The diff key is therefore the container
+ *     NAME itself, not an id parsed out of the name (agents key on the agent id
+ *     embedded in `agent-<id>`).
+ *   - The backing row lives in `containers`, with the status vocab
+ *     pending | building | deploying | running | stopped | failed | deleting |
+ *     deleted. A container is LIVE (do NOT reap) when its row is in
+ *     pending/building/deploying/running/deleting (`deleting` = a delete job is
+ *     in flight and owns teardown — reaping under it would race the worker). It
+ *     is an ORPHAN (reap) when its row is MISSING (`no_db_row`) or in a dead
+ *     terminal state stopped/failed/deleted (`terminal_db_row`).
+ *
+ * Non-`app-`-prefixed containers on a shared node (agents `agent-…`, the older
+ * direct `cloud-container-…` provider path, infra containers like postgres) are
+ * never matched by the `--filter name=app-` listing and never touched here.
+ */
+
+import { inArray } from "drizzle-orm";
+import { dbRead } from "../../db/helpers";
+import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
+import { containers } from "../../db/schemas/containers";
+import { logger } from "../utils/logger";
+import { shellQuote } from "./docker-sandbox-utils";
+import { DockerSSHClient } from "./docker-ssh";
+
+/**
+ * The prefix every Apps/Product-2 container name carries. Kept in lockstep with
+ * `containerNameForApp` (`app-<slug>`) in `app-deploy-runner.ts`. Defined here
+ * (rather than imported) so this safety-critical reaper has no dependency on the
+ * deploy-runner module graph; if that prefix ever changes, the two must change
+ * together.
+ */
+export const APP_CONTAINER_NAME_PREFIX = "app-";
+
+/**
+ * `containers.status` values that mean the container should NOT be running. A
+ * container backing a row in one of these states is reapable just like one with
+ * no row at all: the deploy lifecycle has decided this app has no live
+ * container, so a leftover Docker process is a leak.
+ *
+ * `stopped` and `failed` are the recovery cases — they exist precisely because a
+ * deploy ended (cleanly or in error) without the host container being removed.
+ * `deleted` is the hard-terminal state. `deleting` is NOT included: a delete job
+ * is actively in flight and owns the teardown; reaping under it would race the
+ * worker (the exact mirror of the agent reconciler excluding `deletion_pending`).
+ */
+const TERMINAL_CONTAINER_STATUSES = new Set<string>(["stopped", "failed", "deleted"]);
+
+/** A container seen on a node, parsed from `docker ps -a`. */
+export interface NodeAppContainerRef {
+  /** Container name, e.g. `app-<slug>`. */
+  name: string;
+  /** Docker container id (used for the `docker rm -f` target). */
+  id: string;
+}
+
+/**
+ * A `containers` row as far as orphan reconciliation cares: its name and
+ * current status. A row counts as "live" when its status is not terminal.
+ */
+export interface LiveAppContainerRef {
+  name: string;
+  status: string;
+}
+
+/** A container the reconciler has decided to forcibly remove. */
+export interface OrphanAppContainer {
+  /** Container name (`app-<slug>`). */
+  name: string;
+  /** Docker container id, the `docker rm -f` target. */
+  id: string;
+  /** Why it was flagged: no DB row at all, or a row in a terminal state. */
+  reason: "no_db_row" | "terminal_db_row";
+}
+
+/**
+ * True for a name that belongs to the managed-app pattern (`app-<slug>`), so
+ * unrelated containers on a shared node are never considered. A bare `app-`
+ * with no slug is rejected (mirrors the agent reconciler rejecting `agent-`).
+ */
+export function isAppContainerName(name: string): boolean {
+  return (
+    name.startsWith(APP_CONTAINER_NAME_PREFIX) && name.length > APP_CONTAINER_NAME_PREFIX.length
+  );
+}
+
+/**
+ * Pure diff: given the containers present on a node and the `containers` rows
+ * that exist for those container names, decide which containers to reap.
+ *
+ * A container is an orphan when EITHER:
+ *   - no `containers` row exists for its name (`no_db_row`), OR
+ *   - the row exists but its status is terminal (`terminal_db_row`) — the deploy
+ *     lifecycle has decided this app has no live container.
+ *
+ * Containers whose name does not match the `app-<slug>` pattern are ignored
+ * entirely — they belong to something else on the node.
+ *
+ * This function performs NO I/O so it can be unit-tested exhaustively.
+ */
+export function computeOrphanAppContainersToReap(
+  containersOnNode: readonly NodeAppContainerRef[],
+  liveContainers: readonly LiveAppContainerRef[],
+): OrphanAppContainer[] {
+  const statusByName = new Map<string, string>();
+  for (const row of liveContainers) {
+    statusByName.set(row.name, row.status);
+  }
+
+  const orphans: OrphanAppContainer[] = [];
+  for (const container of containersOnNode) {
+    if (!isAppContainerName(container.name)) continue;
+
+    const status = statusByName.get(container.name);
+    if (status === undefined) {
+      orphans.push({ name: container.name, id: container.id, reason: "no_db_row" });
+    } else if (TERMINAL_CONTAINER_STATUSES.has(status)) {
+      orphans.push({ name: container.name, id: container.id, reason: "terminal_db_row" });
+    }
+  }
+  return orphans;
+}
+
+/** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
+export interface AppOrphanReconcilerNode {
+  node_id: string;
+  hostname: string;
+  status: string;
+  /**
+   * List `app-`-prefixed containers on the node over SSH. Returns null when the
+   * listing failed (SSH blip) so the caller can skip the node rather than
+   * misread an empty list as "no containers" and reap live work.
+   */
+  listAppContainers(): Promise<NodeAppContainerRef[] | null>;
+  /**
+   * Force-remove a container by its IMMUTABLE id over SSH. Must take the id, not
+   * the name: the id pins the exact container observed in the listing, so a
+   * concurrent recreate of the same `app-<slug>` name cannot be reaped by
+   * mistake. Implementations must NOT switch to `docker rm -f <name>`.
+   */
+  removeContainer(containerId: string): Promise<void>;
+}
+
+export interface AppOrphanReconcileResult {
+  /** Nodes inspected (HEALTHY only). */
+  nodesScanned: number;
+  /** Nodes skipped because the SSH container listing failed (or not healthy). */
+  nodesSkipped: number;
+  /** Containers successfully force-removed. */
+  reaped: number;
+  /** Containers identified as orphans but whose removal failed. */
+  reapFailed: number;
+}
+
+/**
+ * Reconcile orphan APP containers on a set of HEALTHY nodes. The caller is
+ * responsible for passing ONLY nodes that node-health has just confirmed
+ * reachable, so a transient SSH blip never causes a live container to be reaped.
+ * Per node: list `app-` containers, diff against the live `containers` rows, and
+ * force-remove every orphan.
+ *
+ * `loadLiveAppContainers` returns the `containers` rows (name + status) for the
+ * container names seen on the node — injected so this stays pure-ish and
+ * unit-testable without a DB. The default production wiring is in
+ * `reconcileOrphanAppContainersOnNodes`.
+ */
+export async function reconcileOrphanAppContainers(
+  nodes: readonly AppOrphanReconcilerNode[],
+  loadLiveAppContainers: (names: readonly string[]) => Promise<LiveAppContainerRef[]>,
+): Promise<AppOrphanReconcileResult> {
+  const result: AppOrphanReconcileResult = {
+    nodesScanned: 0,
+    nodesSkipped: 0,
+    reaped: 0,
+    reapFailed: 0,
+  };
+
+  for (const node of nodes) {
+    if (node.status !== "healthy") {
+      // Defensive: callers should already filter, but never reap on a node we
+      // have not confirmed reachable.
+      result.nodesSkipped += 1;
+      continue;
+    }
+
+    const containersOnNode = await node.listAppContainers();
+    if (containersOnNode === null) {
+      // SSH listing failed — skip rather than risk reaping live containers off a
+      // misread empty list.
+      result.nodesSkipped += 1;
+      logger.warn("[app-orphan-reconciler] Skipping node: container listing failed", {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+      });
+      continue;
+    }
+    result.nodesScanned += 1;
+
+    const names = containersOnNode.map((c) => c.name).filter((name) => isAppContainerName(name));
+    if (names.length === 0) continue;
+
+    const liveContainers = await loadLiveAppContainers(names);
+    const orphans = computeOrphanAppContainersToReap(containersOnNode, liveContainers);
+
+    for (const orphan of orphans) {
+      try {
+        // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
+        // id was captured in the same SSH listing that found the orphan, so it
+        // pins THAT exact container. This is what makes the reap safe against a
+        // concurrent recreate: if a delete + a fresh deploy race and a new
+        // `app-<slug>` container is created between the listing and the rm,
+        // `docker rm -f <id>` still targets the dead container we observed and
+        // leaves the live one alone. A future refactor to `docker rm -f <name>`
+        // would reintroduce the live-container-reap race (the name resolves to
+        // whichever container holds it NOW, i.e. the new live one) — DO NOT.
+        await node.removeContainer(orphan.id);
+        result.reaped += 1;
+        logger.info("[app-orphan-reconciler] Reaped orphan app container", {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          reason: orphan.reason,
+        });
+      } catch (error) {
+        result.reapFailed += 1;
+        logger.warn("[app-orphan-reconciler] Failed to reap orphan app container", {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
+const ORPHAN_LIST_TIMEOUT_MS = 15_000;
+const ORPHAN_RM_TIMEOUT_MS = 30_000;
+
+/**
+ * Load (name, status) for the `containers` rows matching the given container
+ * names, including terminal-state rows. The reconciler needs the status to tell
+ * a missing row (`no_db_row`) apart from a terminal one (`terminal_db_row`).
+ */
+async function loadContainerStatusesByNames(
+  names: readonly string[],
+): Promise<LiveAppContainerRef[]> {
+  if (names.length === 0) return [];
+  return dbRead
+    .select({ name: containers.name, status: containers.status })
+    .from(containers)
+    .where(inArray(containers.name, names as string[]));
+}
+
+/**
+ * Production wiring for the orphan APP-container reconciler: enumerate enabled,
+ * HEALTHY docker nodes and reconcile each over SSH. Built on the shared
+ * `DockerSSHClient` pool so it reuses warm connections. Every SSH call is
+ * hard-bounded so a single unresponsive node can never stall the sweep.
+ *
+ * Only `status === "healthy"` nodes are touched: the caller (the daemon's
+ * infra-maintenance cycle) runs this AFTER the node health-check, so a node that
+ * just failed its probe is excluded and a transient SSH blip never reaps live
+ * containers.
+ */
+export async function reconcileOrphanAppContainersOnNodes(): Promise<AppOrphanReconcileResult> {
+  const enabled = await dockerNodesRepository.findEnabled();
+  const healthy = enabled.filter((node) => node.status === "healthy");
+
+  const reconcilerNodes: AppOrphanReconcilerNode[] = healthy.map((node) => {
+    const ssh = () =>
+      DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? undefined,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? undefined,
+      );
+    return {
+      node_id: node.node_id,
+      hostname: node.hostname,
+      status: node.status,
+      async listAppContainers(): Promise<NodeAppContainerRef[] | null> {
+        try {
+          const client = ssh();
+          await client.connect();
+          const output = await client.exec(
+            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(APP_CONTAINER_NAME_PREFIX)}`,
+            ORPHAN_LIST_TIMEOUT_MS,
+          );
+          return (
+            output
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean)
+              // `--filter name=` is a substring match, so re-check the prefix to
+              // exclude any container that merely contains "app-" mid-name.
+              .filter((line) => line.startsWith(APP_CONTAINER_NAME_PREFIX))
+              .map((line) => {
+                const [name = "", id = ""] = line.split("|");
+                return { name, id };
+              })
+              .filter((c) => c.name && c.id)
+          );
+        } catch (error) {
+          logger.warn("[app-orphan-reconciler] Container listing failed over SSH", {
+            nodeId: node.node_id,
+            hostname: node.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      },
+      async removeContainer(containerId: string): Promise<void> {
+        const client = ssh();
+        await client.connect();
+        // rm by the immutable container ID (see AppOrphanReconcilerNode.removeContainer
+        // and the reap loop): targeting the name would race a concurrent recreate
+        // of the same app and could reap a live container. Keep this `<id>`.
+        await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
+      },
+    };
+  });
+
+  return reconcileOrphanAppContainers(reconcilerNodes, loadContainerStatusesByNames);
+}

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -14,6 +14,7 @@
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { AppOrphanReconcileResult } from "@elizaos/cloud-shared/lib/services/app-container-orphan-reconciler";
 import type { OrphanReconcileResult } from "@elizaos/cloud-shared/lib/services/docker-node-workloads";
 import {
   type ProvisioningJobType,
@@ -48,6 +49,8 @@ type WorkerJobsRepository =
   typeof import("@elizaos/cloud-shared/db/repositories/jobs").jobsRepository;
 type WorkerReconcileOrphanContainers =
   typeof import("@elizaos/cloud-shared/lib/services/docker-node-workloads").reconcileOrphanContainersOnNodes;
+type WorkerReconcileOrphanAppContainers =
+  typeof import("@elizaos/cloud-shared/lib/services/app-container-orphan-reconciler").reconcileOrphanAppContainersOnNodes;
 type WorkerWithTimeout =
   typeof import("@elizaos/cloud-shared/lib/utils/with-timeout").withTimeout;
 
@@ -71,6 +74,7 @@ interface WorkerDeps {
   agentSandboxesRepository: WorkerAgentSandboxesRepository;
   jobsRepository: WorkerJobsRepository;
   reconcileOrphanContainersOnNodes: WorkerReconcileOrphanContainers;
+  reconcileOrphanAppContainersOnNodes: WorkerReconcileOrphanAppContainers;
   withTimeout: WorkerWithTimeout;
 }
 
@@ -105,10 +109,12 @@ export interface ProvisioningWorkerConfig {
    */
   watchdogConsecutiveTicks: number;
   /**
-   * When true, the low-cadence orphan-container reconciler sweeps HEALTHY nodes
-   * for `agent-<id>` containers with no live DB row and force-removes them.
-   * Gated OFF by default via `ORPHAN_RECONCILER_ENABLED=1` because it issues
-   * `docker rm -f` and should be armed deliberately.
+   * When true, the low-cadence orphan-container reconcilers sweep HEALTHY nodes
+   * for leaked containers with no live DB row (or a terminal-state row) and
+   * force-remove them — both the agent sweep (`agent-<id>` vs `agent_sandboxes`)
+   * and the apps sweep (`app-<slug>` vs `containers`). Gated OFF by default via
+   * `ORPHAN_RECONCILER_ENABLED=1` because they issue `docker rm -f` and should be
+   * armed deliberately.
    */
   orphanReconcilerEnabled: boolean;
 }
@@ -192,6 +198,9 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/db/repositories/agent-sandboxes"),
       import("@elizaos/cloud-shared/db/repositories/jobs"),
       import("@elizaos/cloud-shared/lib/services/docker-node-workloads"),
+      import(
+        "@elizaos/cloud-shared/lib/services/app-container-orphan-reconciler"
+      ),
       import("@elizaos/cloud-shared/lib/utils/with-timeout"),
     ]).then(
       ([
@@ -206,6 +215,7 @@ async function loadDeps(): Promise<WorkerDeps> {
         agentSandboxesModule,
         jobsRepoModule,
         nodeWorkloadsModule,
+        appOrphanReconcilerModule,
         withTimeoutModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
@@ -221,6 +231,8 @@ async function loadDeps(): Promise<WorkerDeps> {
         jobsRepository: jobsRepoModule.jobsRepository,
         reconcileOrphanContainersOnNodes:
           nodeWorkloadsModule.reconcileOrphanContainersOnNodes,
+        reconcileOrphanAppContainersOnNodes:
+          appOrphanReconcilerModule.reconcileOrphanAppContainersOnNodes,
         withTimeout: withTimeoutModule.withTimeout,
       }),
     );
@@ -561,6 +573,20 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
 async function processOrphanReconcilerCycle(): Promise<OrphanReconcileResult> {
   const { reconcileOrphanContainersOnNodes } = await loadDeps();
   return reconcileOrphanContainersOnNodes();
+}
+
+/**
+ * Apps (Product 2) sibling of the agent orphan reconciler: sweep HEALTHY nodes
+ * for `app-<slug>` containers with no live `containers` row (or a terminal-state
+ * row) and force-remove them. App-container teardown only runs on an explicit
+ * app delete, so a mid-deploy crash or partial failure leaks an app container on
+ * a node forever; this closes that gap. Same safety model as the agent sweep:
+ * it only touches `healthy` nodes (refreshed by the preceding node-health check),
+ * skips a node whose listing failed, and reaps by the immutable container id.
+ */
+async function processAppOrphanReconcilerCycle(): Promise<AppOrphanReconcileResult> {
+  const { reconcileOrphanAppContainersOnNodes } = await loadDeps();
+  return reconcileOrphanAppContainersOnNodes();
 }
 
 let running = true;
@@ -1105,6 +1131,27 @@ async function runInfraMaintenanceCycle(
           reaped: result.reaped,
           reapFailed: result.reapFailed,
         });
+      },
+    );
+
+    // Apps (Product 2) sibling sweep — same `healthy`-only, fresh-node-status,
+    // reap-by-id model. Runs right after the agent sweep so it shares the same
+    // freshly-refreshed node health and the same `docker rm -f` gating.
+    await runBoundedPhase(
+      logger,
+      "app orphan reconciler cycle",
+      () => processAppOrphanReconcilerCycle(),
+      (result) => {
+        logger.info(
+          "[provisioning-worker] app orphan reconciler cycle complete",
+          {
+            event: "app_orphan_reconciler.reaped",
+            nodesScanned: result.nodesScanned,
+            nodesSkipped: result.nodesSkipped,
+            reaped: result.reaped,
+            reapFailed: result.reapFailed,
+          },
+        );
       },
     );
   }


### PR DESCRIPTION
## The gap

App-container cleanup (`appCleanupService.deleteAppWithCleanup` / the `CONTAINER_DELETE` executor) only runs on an **explicit app delete**. A mid-deploy crash or a partial failure leaks an `app-<slug>` container on a node with **no live DB row** (or a row left in a dead terminal state) — it holds a compute slot and host volume forever, because nothing in the deploy lifecycle will ever reap it again.

AGENT containers already have a periodic orphan sweep wired into the provisioning daemon (`reconcileOrphanContainersOnNodes` in `docker-node-workloads.ts`). APP containers did not. This closes that gap (Product-2 hardening) by adding a **parallel sibling** reconciler for app containers, mirroring the proven agent pattern exactly — without touching the safety-critical agent path.

## What changed

- **New `packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts`** — `reconcileOrphanAppContainers(nodes, loadLiveAppContainers)` (pure-ish, injectable) + `reconcileOrphanAppContainersOnNodes()` (production wiring over the `DockerSSHClient` pool), plus the pure diff `computeOrphanAppContainersToReap`.
- **New `app-container-orphan-reconciler.test.ts`** — mirrors `docker-node-workloads.test.ts` for the apps variant.
- **`provisioning-worker.ts`** — wires the app reconciler as a sibling phase in `runInfraMaintenanceCycle`, right after the agent orphan sweep, under the **same `ORPHAN_RECONCILER_ENABLED` gate** and the freshly-refreshed node health.

## App container model (confirmed, differs from agents)

- App containers live in the **`containers`** table (NOT `agentSandboxes`); a container maps to a row by **NAME** (`containers.name`), not by an id embedded in the name.
- Confirmed app-container prefix is **`app-`** — `containerNameForApp(appId)` → `app-<first 12 of id>` in `app-deploy-runner.ts`, written verbatim to `containers.name`.
- `containers.status` vocab: pending | building | deploying | running | stopped | failed | deleting | deleted.
  - **LIVE — do NOT reap:** pending, building, deploying, running, **deleting** (a delete job is in-flight and owns teardown — the exact mirror of the agent reconciler excluding `deletion_pending`).
  - **ORPHAN — reap:** row MISSING (`no_db_row`) OR a dead terminal status stopped/failed/deleted (`terminal_db_row`).
- Non-`app-` containers on a shared node (agents `agent-…`, the older direct `cloud-container-…` provider path, infra like postgres) are never matched by the `--filter name=app-` listing and never touched.

## Safety invariants preserved (a wrong reaper kills a live customer app)

1. **Healthy-only** — only `status === "healthy"` nodes are touched (caller runs this AFTER the node health-check; defensively re-checked in the loop).
2. **Skip on null listing** — if the SSH listing returns `null` (listing failed), the node is SKIPPED, never reaped (a misread empty list must not reap live containers).
3. **Reap by immutable container ID, never name** — the id is captured in the same listing that flagged the orphan, so a concurrent delete+recreate of the same `app-<slug>` name cannot be reaped by mistake.
4. **Hard per-call SSH timeouts** on both the list (15s) and the rm (30s).
5. **Every reap, skip, and failure is logged** (`[app-orphan-reconciler] …`).
6. **When unsure → do not reap.**

## Daemon wiring

Added as a sibling to the agent reconciler in `provisioning-worker.ts` with the same dep-injection style (`reconcileOrphanAppContainersOnNodes` dep type + dynamic import + deps map), a `processAppOrphanReconcilerCycle()` cycle fn, and a `runBoundedPhase("app orphan reconciler cycle", …)` call inside `runInfraMaintenanceCycle` directly after the agent orphan sweep, gated by the same `config.orphanReconcilerEnabled`.

Refs Product-2 apps hardening / #8425.
