### PR TITLE
perf(ui): extract transcript-windowing into a tested pure helper (#9141 gap 4 seam)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -65,7 +65,7 @@ import { conversationTranscriptText } from "../chat/message-parser-helpers";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
-import type { ShellMessage } from "./shell-state";
+import { type ShellMessage, selectVisibleShellMessages } from "./shell-state";
 import { TopicChipsBar } from "./TopicChipsBar";
 import { TopicGroup } from "./TopicGroup";
 import { deriveChannelTopics, groupMessagesByTopic } from "./topic-grouping";
@@ -173,10 +173,6 @@ const SHEET_TOP_MARGIN = 72;
 // of resting free — so near-detent releases are deterministic + clean, and only
 // the clear gaps between detents keep the free-drag rest height.
 const SHEET_DETENT_MAGNET = 64;
-// Cap how many turns are actually rendered. Older messages stay in state (the
-// agent's context is untouched) — this only bounds DOM nodes so a long thread
-// can't jank scrolling on a phone, without pulling in a virtualizer.
-const MAX_RENDERED_MESSAGES = 80;
 
 // Feature flag: the resting one-tap prompt-suggestion strip. Off for now so the
 // composer can be tested without it; flip to true to bring the strip back.
@@ -1226,21 +1222,11 @@ export function ContinuousChatOverlay({
   // fling a history thread open to half instead of resting on the input bar).
   const suppressExpandOnFocusRef = React.useRef(false);
   const focusThreadRef = React.useRef(false);
-  // Recomputed only when the thread changes — NOT on every drag/draft re-render.
-  // Filter empty turns, then keep only the most recent window (cap DOM nodes).
+  // Recomputed only when the thread or phase changes — NOT on every drag/draft
+  // re-render. Pure windowing (empty-turn filter + most-recent cap, with the
+  // streaming-assistant exception) lives in shell-state so it's unit-tested.
   const visibleMessages = React.useMemo(
-    () =>
-      messages
-        // Drop empty turns — EXCEPT the in-flight assistant turn while a reply is
-        // streaming, so its bubble can show the breathing dots anchored where the
-        // text fills in (then the text replaces them). It's dropped again the
-        // moment we leave `responding`, so a failed/empty turn never lingers.
-        .filter(
-          (m) =>
-            m.content.trim() ||
-            (m.role === "assistant" && phase === "responding"),
-        )
-        .slice(-MAX_RENDERED_MESSAGES),
+    () => selectVisibleShellMessages(messages, phase),
     [messages, phase],
   );
   const lastId = visibleMessages.at(-1)?.id ?? null;

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { ShellMessage, ShellPhase } from "./shell-state";
+import {
+  MAX_RENDERED_SHELL_MESSAGES,
+  selectVisibleShellMessages,
+} from "./shell-state";
+
+function msg(
+  id: string,
+  role: ShellMessage["role"],
+  content: string,
+): ShellMessage {
+  return { id, role, content, createdAt: 0 };
+}
+
+describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
+  it("drops empty turns when not responding", () => {
+    const out = selectVisibleShellMessages(
+      [
+        msg("u1", "user", "hi"),
+        msg("a1", "assistant", "   "),
+        msg("u2", "user", ""),
+        msg("a2", "assistant", "answer"),
+      ],
+      "idle",
+    );
+    expect(out.map((m) => m.id)).toEqual(["u1", "a2"]);
+  });
+
+  it("keeps an empty in-flight assistant turn while responding", () => {
+    const out = selectVisibleShellMessages(
+      [msg("u1", "user", "hi"), msg("a1", "assistant", "")],
+      "responding",
+    );
+    expect(out.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("drops the empty assistant turn once the phase leaves responding", () => {
+    const thread = [msg("u1", "user", "hi"), msg("a1", "assistant", "")];
+    expect(
+      selectVisibleShellMessages(thread, "responding").map((m) => m.id),
+    ).toEqual(["u1", "a1"]);
+    expect(selectVisibleShellMessages(thread, "idle").map((m) => m.id)).toEqual(
+      ["u1"],
+    );
+  });
+
+  it("does NOT keep an empty USER turn even while responding", () => {
+    const out = selectVisibleShellMessages(
+      [msg("u1", "user", ""), msg("a1", "assistant", "")],
+      "responding",
+    );
+    expect(out.map((m) => m.id)).toEqual(["a1"]);
+  });
+
+  it("keeps only the most recent `max` non-empty turns", () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      msg(`m${i}`, i % 2 === 0 ? "user" : "assistant", `t${i}`),
+    );
+    const out = selectVisibleShellMessages(many, "idle", 3);
+    expect(out.map((m) => m.id)).toEqual(["m7", "m8", "m9"]);
+  });
+
+  it("counts the cap AFTER dropping empties (cap applies to rendered turns)", () => {
+    const out = selectVisibleShellMessages(
+      [
+        msg("e1", "assistant", "  "),
+        msg("k1", "user", "a"),
+        msg("e2", "user", ""),
+        msg("k2", "assistant", "b"),
+        msg("k3", "user", "c"),
+      ],
+      "idle",
+      2,
+    );
+    expect(out.map((m) => m.id)).toEqual(["k2", "k3"]);
+  });
+
+  it("returns all turns when under the cap and never mutates the input", () => {
+    const input = [msg("u1", "user", "hi"), msg("a1", "assistant", "yo")];
+    const frozen = Object.freeze([...input]) as readonly ShellMessage[];
+    const out = selectVisibleShellMessages(frozen, "idle");
+    expect(out.map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect(out).not.toBe(input);
+  });
+
+  it("defaults to the exported render cap", () => {
+    expect(MAX_RENDERED_SHELL_MESSAGES).toBe(80);
+    const big = Array.from({ length: 100 }, (_, i) =>
+      msg(`m${i}`, "user", `t${i}`),
+    );
+    expect(selectVisibleShellMessages(big, "idle")).toHaveLength(80);
+  });
+
+  it("is exhaustive over ShellPhase for the empty-assistant exception", () => {
+    const phases: ShellPhase[] = [
+      "booting",
+      "idle",
+      "summoned",
+      "listening",
+      "responding",
+    ];
+    const thread = [msg("u1", "user", "hi"), msg("a1", "assistant", "")];
+    for (const phase of phases) {
+      const ids = selectVisibleShellMessages(thread, phase).map((m) => m.id);
+      expect(ids).toEqual(phase === "responding" ? ["u1", "a1"] : ["u1"]);
+    }
+  });
+});

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -40,3 +40,31 @@ export interface ShellMessage {
    */
   topics?: string[];
 }
+
+/**
+ * Max chat turns actually rendered in the shell transcript. Older turns stay in
+ * state (the agent's context is untouched) — this only bounds DOM nodes so a
+ * long thread can't jank scrolling, without pulling in a virtualizer. Gap 4 of
+ * #9141 (transcript windowing) builds on this seam.
+ */
+export const MAX_RENDERED_SHELL_MESSAGES = 80;
+
+/**
+ * Pure transcript-windowing decision (#9141 gap 4 seam). Drops empty turns —
+ * EXCEPT the in-flight assistant turn while a reply is streaming (phase ===
+ * "responding"), so its bubble can show the breathing dots anchored where the
+ * text will fill in — then keeps only the most recent `max` turns to bound DOM
+ * nodes. Pure + DOM-free so the cap + streaming-turn exception are unit-testable
+ * and any future virtualizer can reuse the same predicate.
+ */
+export function selectVisibleShellMessages(
+  messages: readonly ShellMessage[],
+  phase: ShellPhase,
+  max: number = MAX_RENDERED_SHELL_MESSAGES,
+): ShellMessage[] {
+  const kept = messages.filter(
+    (m) =>
+      m.content.trim() || (m.role === "assistant" && phase === "responding"),
+  );
+  return max > 0 && kept.length > max ? kept.slice(-max) : [...kept];
+}


### PR DESCRIPTION
## What

#9141 gap 4 (transcript windowing) needs a stable, tested predicate to build a virtualizer on. The decision was inlined in `ContinuousChatOverlay`'s `visibleMessages` `useMemo` (empty-turn filter + the in-flight-assistant-while-`responding` exception + `.slice(-80)`).

## Change

Extracts it into a pure, exported `selectVisibleShellMessages(messages, phase, max)` + `MAX_RENDERED_SHELL_MESSAGES = 80` in `shell-state.ts`; the overlay now calls it. **Byte-for-byte equivalent output** → every downstream consumer untouched, zero render-behavior risk. The 80-cap + streaming-turn exception are now a unit-tested pure predicate — the exact seam gap-4 virtualization reuses.

## Tests

9 unit tests (`shell-state.test.ts`): empty-turn drop, responding-phase empty-assistant exception + its removal when phase leaves `responding`, no-keep for empty user turns, most-recent windowing, cap-after-filter, no-mutation, default cap, exhaustive over `ShellPhase`. **9/9 pass; ui typecheck + biome clean.**

Part of #9141 (gap-4 virtualization proper + the headed frame-timing/reduced-motion specs remain — measurement-first spikes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)