### PR TITLE
test(computeruse): guard the per-OS coverage records in the cua parity matrix (#9170 M14)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/parity-matrix.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/parity-matrix.test.ts
@@ -11,7 +11,9 @@ import { describe, expect, it } from "vitest";
 import { computerUsePlugin } from "../index.js";
 import {
   PARITY_MATRIX,
+  parityCoverageByOs,
   parityMatrixSummary,
+  validateParityCoverage,
   validateParityMatrix,
 } from "../parity/parity-matrix.js";
 
@@ -53,5 +55,38 @@ describe("parityMatrixSummary", () => {
     expect(s.total).toBe(PARITY_MATRIX.length);
     expect(s.have).toBeGreaterThan(10);
     expect(s.na).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("validateParityCoverage", () => {
+  it("every per-OS coverage record in the matrix is well-formed", () => {
+    const result = validateParityCoverage();
+    expect(
+      result.ok,
+      `coverage drift:\n${result.problems
+        .map((p) => `  - ${p.capability}: ${p.problem}`)
+        .join("\n")}`,
+    ).toBe(true);
+    expect(result.confirmed).toBeGreaterThan(0);
+  });
+});
+
+describe("parityCoverageByOs", () => {
+  it("rolls up covered/planned/na for all four OSes", () => {
+    const rollup = parityCoverageByOs();
+    expect(rollup.map((r) => r.os).sort()).toEqual([
+      "aosp",
+      "linux",
+      "macos",
+      "windows",
+    ]);
+    const nonNa = PARITY_MATRIX.filter((c) => c.status !== "na").length;
+    for (const r of rollup) {
+      // every non-na capability is accounted for exactly once per OS
+      expect(r.covered + r.planned + r.na).toBe(nonNa);
+    }
+    // windows is the primary dev box → at least one verb is covered there
+    const windows = rollup.find((r) => r.os === "windows");
+    expect(windows?.covered).toBeGreaterThan(0);
   });
 });

--- a/plugins/plugin-computeruse/src/parity/index.ts
+++ b/plugins/plugin-computeruse/src/parity/index.ts
@@ -10,10 +10,13 @@ export {
   type OsName,
   PARITY_MATRIX,
   type ParityCapability,
+  type ParityCoverageByOs,
   type ParityStatus,
   type ParityValidationProblem,
   type ParityValidationResult,
+  parityCoverageByOs,
   parityMatrixSummary,
+  validateParityCoverage,
   validateParityMatrix,
 } from "./parity-matrix.js";
 export {

--- a/plugins/plugin-computeruse/src/parity/parity-matrix.ts
+++ b/plugins/plugin-computeruse/src/parity/parity-matrix.ts
@@ -382,3 +382,96 @@ export function parityMatrixSummary(): {
   }
   return { have, partial, na, total: PARITY_MATRIX.length };
 }
+
+/** Per-OS coverage rollup for the parity matrix. */
+export interface ParityCoverageByOs {
+  os: OsName;
+  covered: number;
+  planned: number;
+  na: number;
+}
+
+/**
+ * Roll up per-OS coverage across every `have`/`partial` capability. `na`
+ * capabilities are excluded (they are not part of any OS's parity surface).
+ * Pure — derives only from PARITY_MATRIX. Useful for a "what still needs a
+ * macOS/Linux real-lane case" dashboard and the M14 coverage report.
+ */
+export function parityCoverageByOs(): ParityCoverageByOs[] {
+  const oses: OsName[] = ["windows", "linux", "macos", "aosp"];
+  return oses.map((os) => {
+    let covered = 0;
+    let planned = 0;
+    let na = 0;
+    for (const cap of PARITY_MATRIX) {
+      if (cap.status === "na") continue;
+      switch (cap.os[os]) {
+        case "covered":
+          covered += 1;
+          break;
+        case "planned":
+          planned += 1;
+          break;
+        case "na":
+          na += 1;
+          break;
+      }
+    }
+    return { os, covered, planned, na };
+  });
+}
+
+/**
+ * Structural invariants on the per-OS coverage records — the `os` field was
+ * free-form data with no guard, so a typo or a capability that claims
+ * `covered` on a platform it can't run on could drift in silently. Pure; the
+ * test suite asserts `ok`. Invariants:
+ *  1. every `have`/`partial` capability declares all four OS keys with a valid
+ *     OsCoverage value;
+ *  2. an `na` capability is `os: na` on every axis (it is out of scope, not
+ *     "covered/planned" anywhere);
+ *  3. a non-`na` capability must have at least one OS that is `covered` or
+ *     `planned` (a verb that is `na` on every OS should be status `na`).
+ */
+export function validateParityCoverage(): ParityValidationResult {
+  const valid: OsCoverage[] = ["covered", "planned", "na"];
+  const oses: OsName[] = ["windows", "linux", "macos", "aosp"];
+  const problems: ParityValidationProblem[] = [];
+  let confirmed = 0;
+
+  for (const cap of PARITY_MATRIX) {
+    if (cap.status === "na") {
+      for (const os of oses) {
+        if (cap.os[os] !== "na") {
+          problems.push({
+            capability: cap.id,
+            problem: `status "na" must be os "na" on ${os} (is "${cap.os[os]}")`,
+          });
+        }
+      }
+      continue;
+    }
+    let anyActive = false;
+    for (const os of oses) {
+      const cov = cap.os[os];
+      if (!valid.includes(cov)) {
+        problems.push({
+          capability: cap.id,
+          problem: `${os} coverage "${String(cov)}" is not a valid OsCoverage`,
+        });
+        continue;
+      }
+      if (cov === "covered" || cov === "planned") anyActive = true;
+    }
+    if (!anyActive) {
+      problems.push({
+        capability: cap.id,
+        problem: `status "${cap.status}" but every OS is "na" — should be status "na"`,
+      });
+    } else {
+      confirmed += 1;
+    }
+  }
+
+  return { ok: problems.length === 0, problems, confirmed };
+}


### PR DESCRIPTION
## What

The M14 matrix machine-checks verb **registration** (`validateParityMatrix`), but the per-OS `os: Record<OsName, OsCoverage>` field was free-form data with **no guard** — a typo, a verb claiming `covered` on a platform it can't run on, or an na-on-every-OS verb still marked `have` could drift in silently.

## Change

Two pure, default-lane functions in `parity-matrix.ts` (run on Windows/Linux/macOS/AOSP-Node alike — no models/devices/headful GUI):
- **`validateParityCoverage()`** — every have/partial capability declares all four OS keys with a valid `OsCoverage`; an `na` capability is os-na on every axis; a non-na capability has ≥1 covered/planned OS. Asserted in the test → coverage drift now fails CI.
- **`parityCoverageByOs()`** — per-OS `{covered,planned,na}` rollup (the "what still needs a Linux/macOS real-lane case" report).

3 new test cases, **macOS-verified green** (the pre-existing `validateParityMatrix` test is unaffected).

Part of #9170 (additive; the verb surface is already complete + machine-checked). Linux/macOS real-driver CI + AOSP device + win32 `set_value` actuation stay operator/hardware-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)