### PR TITLE
feat(cloud-shared): model the local-vs-remote app distinction as one source of truth (#9145)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
@@ -7,7 +7,14 @@
  */
 import { describe, expect, test } from "bun:test";
 import { ApiError } from "../../api/cloud-worker-errors";
-import { assertDeployable, deploymentIdFor, publicStatusFor } from "../app-deployments-helpers";
+import {
+  appKindFor,
+  assertDeployable,
+  deploymentIdFor,
+  isLocalApp,
+  isRemoteApp,
+  publicStatusFor,
+} from "../app-deployments-helpers";
 
 describe("publicStatusFor", () => {
   test("maps draft to DRAFT", () => {
@@ -57,5 +64,58 @@ describe("assertDeployable", () => {
     // retry from a fresh deploy after a deploy-side failure during upload,
     // so we don't reject it here.
     expect(() => assertDeployable({ deployment_status: "deploying" })).not.toThrow();
+  });
+});
+
+describe("appKindFor / isLocalApp / isRemoteApp (#9145)", () => {
+  test("draft app with no production_url is local", () => {
+    expect(appKindFor({ deployment_status: "draft", production_url: null })).toBe("local");
+    expect(isLocalApp({ deployment_status: "draft", production_url: null })).toBe(true);
+    expect(isRemoteApp({ deployment_status: "draft", production_url: null })).toBe(false);
+  });
+
+  test("deployed app is remote even if production_url is somehow null", () => {
+    expect(appKindFor({ deployment_status: "deployed", production_url: null })).toBe("remote");
+    expect(isRemoteApp({ deployment_status: "deployed", production_url: null })).toBe(true);
+  });
+
+  test("deployed app with production_url is remote", () => {
+    expect(
+      appKindFor({
+        deployment_status: "deployed",
+        production_url: "https://app.example.com",
+      }),
+    ).toBe("remote");
+  });
+
+  test("building/deploying app with a production_url already assigned is remote", () => {
+    expect(
+      appKindFor({
+        deployment_status: "building",
+        production_url: "https://app.example.com",
+      }),
+    ).toBe("remote");
+    expect(
+      appKindFor({
+        deployment_status: "deploying",
+        production_url: "https://app.example.com",
+      }),
+    ).toBe("remote");
+  });
+
+  test("building/deploying app without a production_url is still local", () => {
+    expect(appKindFor({ deployment_status: "building", production_url: null })).toBe("local");
+    expect(appKindFor({ deployment_status: "deploying", production_url: null })).toBe("local");
+    expect(appKindFor({ deployment_status: "building", production_url: "" })).toBe("local");
+  });
+
+  test("failed app is local (no live container, even with a stale url)", () => {
+    expect(appKindFor({ deployment_status: "failed", production_url: null })).toBe("local");
+    expect(
+      appKindFor({
+        deployment_status: "failed",
+        production_url: "https://old.example.com",
+      }),
+    ).toBe("local");
   });
 });

--- a/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
@@ -6,7 +6,7 @@
  * @elizaos/core and the rest of the runtime).
  */
 
-import type { AppDeploymentStatus } from "../../db/schemas/apps";
+import type { App, AppDeploymentStatus } from "../../db/schemas/apps";
 import { ApiError } from "../api/cloud-worker-errors";
 
 export type { AppDeploymentStatus };
@@ -58,4 +58,48 @@ export function assertDeployable(app: { deployment_status: AppDeploymentStatus }
       "A deployment is already in progress for this app",
     );
   }
+}
+
+/**
+ * Modeled local-vs-remote distinction for an app (#9145, Problem #2 / Q3).
+ *
+ * The `apps` schema has no explicit `local`/`remote` column; the distinction
+ * is derived from deployment state. An app is REMOTE once it has reached a
+ * deploy lifecycle that yields a managed-container URL. Otherwise it is LOCAL:
+ * it runs only in the desktop/device runtime against its own `app_url`.
+ *
+ * This is the single source of truth for the distinction — UI, CLI, and parity
+ * checks should derive `local` vs `remote` through here rather than re-deriving
+ * `deployment_status !== "draft"` ad hoc.
+ */
+export type AppKind = "local" | "remote";
+
+/** Fields required to classify an app as local or remote. */
+export type AppKindInput = Pick<App, "deployment_status" | "production_url">;
+
+/**
+ * An app is REMOTE iff it has reached a deploy lifecycle that yields a managed
+ * container URL: `deployed` (live), or in-flight `building`/`deploying` once a
+ * `production_url` has been assigned. `draft` and `failed` are LOCAL — `failed`
+ * has no live container, and a build that never produced a `production_url`
+ * stays LOCAL until one is assigned.
+ */
+export function appKindFor(app: AppKindInput): AppKind {
+  if (app.deployment_status === "deployed") return "remote";
+  if (
+    (app.deployment_status === "building" || app.deployment_status === "deploying") &&
+    typeof app.production_url === "string" &&
+    app.production_url.length > 0
+  ) {
+    return "remote";
+  }
+  return "local";
+}
+
+export function isRemoteApp(app: AppKindInput): boolean {
+  return appKindFor(app) === "remote";
+}
+
+export function isLocalApp(app: AppKindInput): boolean {
+  return appKindFor(app) === "local";
 }


### PR DESCRIPTION
## What

#9145 Problem #2 / Q3 — *"'local app' is implicit, not a modeled type"* — the distinction was re-derived ad hoc as `deployment_status !== "draft"` with no single source of truth.

## Change

Pure, additive `appKindFor(app): "local" | "remote"` + `isRemoteApp` / `isLocalApp` in `app-deployments-helpers.ts`, derived from the already-persisted `deployment_status` + `production_url` — **zero schema migration**. An app is REMOTE iff `deployed`, or `building`/`deploying` once a `production_url` is assigned; `draft` and `failed` are LOCAL.

## Tests

6 new cases pinning the full `deployment_status × production_url` truth table. **14 pass** (8 existing + 6 new); typecheck + biome clean. Pure — no models/devices/cloud/secrets.

The canonical parity oracle a future mock-stack remote-vs-local e2e should consume.

Part of #9145 (the Q1/Q3/Q4/Q5 product decisions, source-build service, subscription product, cloud-ops flag-flip, and android-device render remain — gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)