### PR TITLE
fix(docker): link @elizaos/registry into the agent image

### DIFF
--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -26,6 +26,12 @@ const localPackages = [
   "eliza/packages/core",
   "eliza/packages/contracts",
   "eliza/packages/cloud-routing",
+  // @elizaos/app-core's registry/index.ts eagerly re-exports
+  // `@elizaos/registry/first-party` (#9190 moved the curated app/plugin/connector
+  // registry out of app-core into this package). It must be linked or the agent
+  // boot crashes with "Cannot find package '@elizaos/registry' imported from
+  // .../app-core/dist/registry/index.js". Foundational, so listed up here.
+  "eliza/packages/registry",
   // @elizaos/agent's remote-plugin-bridge imports the `./error` subpath of
   // plugin-worker-runtime eagerly at boot. Without linking it here its
   // node_modules entry is never established, so boot crashes with


### PR DESCRIPTION
## Summary
Second stacked agent-image breaker, unmasked once #9210 fixed the vite-8/Rolldown app build (the smoke-boot step never ran before, so this was hidden).

**#9190** moved the curated registry out of `app-core` into the new `@elizaos/registry` package; `packages/app-core/src/registry/index.ts` now eagerly re-exports `@elizaos/registry/first-party`. The image links `@elizaos/*` workspace packages via an explicit list in `link-docker-local-app-packages.mjs` (they're linked, not npm-installed), and `@elizaos/registry` was never added → the real agent entrypoint crashes boot-verify:

```
[docker-ci-smoke] Detected startup crash signature: 'Cannot find package'
[eliza-autonomous] Failed to start: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@elizaos/registry'
  imported from /app/packages/app-core/dist/registry/index.js
```
(observed in build-agent-image run for develop `sha-2833fcb99`).

## Fix
Add `eliza/packages/registry` to the linked set (foundational; its exports resolve to source `.ts` loaded via the tsx loader, like the other root-linked packages).

## Verification
`build-agent-image` dispatched on this branch (build + real-entrypoint smoke boot). Merging once it boots green. Tracked on #8434.