### PR TITLE
feat(registry): add @wasmagent/eliza-rollout-plugin community plugin

### DIFF
--- a/packages/registry/entries/third-party/wasmagent__eliza-rollout-plugin.json
+++ b/packages/registry/entries/third-party/wasmagent__eliza-rollout-plugin.json
@@ -1,0 +1,11 @@
+{
+  "package": "@wasmagent/eliza-rollout-plugin",
+  "repository": "github:WasmAgent/wasmagent-js",
+  "kind": "plugin",
+  "description": "Captures elizaOS action runs as rollout-wire/v1 training records (DPO/PPO JSONL) for fine-tuning via evomerge. No sandbox layer — elizaOS Bun Worker isolation already covers that.",
+  "homepage": "https://github.com/WasmAgent/wasmagent-js/tree/main/packages/eliza-rollout-plugin",
+  "version": "1.0.3",
+  "directory": "packages/eliza-rollout-plugin",
+  "tags": ["training-data", "rlaif", "dpo", "ppo", "rollout", "fine-tuning", "wasmagent"]
+}
+


### PR DESCRIPTION
## Summary

Adds a registry entry for [`@wasmagent/eliza-rollout-plugin`](https://www.npmjs.com/package/@wasmagent/eliza-rollout-plugin) — a community plugin that captures elizaOS action runs as `rollout-wire/v1` training records (DPO/PPO-ready JSONL) for fine-tuning via evomerge.

This follows up on #9235, where @lalalune pointed out:
> 'You can register a third party plugin ... but we are wary of third party dependencies directly in the application.'

This PR is exactly that: a **third-party community plugin**, not a core dependency.

## What the plugin does

- Hooks into `runtime.registerAction` to intercept action completions
- Captures prompt/completion pairs after each action runs
- Scores and ranks completions (single-run: heuristic; multi-branch: `RolloutRanker`)
- Emits `rollout-wire/v1` JSONL to a configurable sink (local file / HTTP / console)

## What it does NOT do

- **No sandbox layer** — elizaOS's native Bun Worker isolation already handles that
- **No mandatory configuration** — zero-config default writes to `./rollouts/` locally
- **No permission changes** — does not touch `RemotePluginPermissions`

## Composing with `withCapabilityGovernance` (landed in 6c6011746b)

The governance primitive in `@elizaos/core/security` and this plugin are complementary — governance in core, training data export here. Wrapping an action with `withCapabilityGovernance` before registering it means the plugin instruments the governed wrapper, so you get both:

```ts
import { withCapabilityGovernance } from "@elizaos/core";
import { createRolloutPlugin } from "@wasmagent/eliza-rollout-plugin";

const governed = withCapabilityGovernance(myAction, {
  allowedHosts: ["api.example.com"],
  cpuMs: 10_000,
});

export default {
  actions: [governed],
  plugins: [createRolloutPlugin()],
};
```

## Usage

```ts
import { createRolloutPlugin } from '@wasmagent/eliza-rollout-plugin';

export default {
  plugins: [createRolloutPlugin()],  // zero-config
};
```

## Package

- npm: https://www.npmjs.com/package/@wasmagent/eliza-rollout-plugin
- Source: https://github.com/WasmAgent/wasmagent-js/tree/main/packages/eliza-rollout-plugin
- Version: 1.0.4