### PR TITLE
fix(registry): first-party generator emits biome-formatted JSON

### DIFF
--- a/packages/registry/src/first-party/generate.ts
+++ b/packages/registry/src/first-party/generate.ts
@@ -12,6 +12,7 @@
 //   bun run --cwd packages/registry generate:first-party   # rewrite generated.json
 //   bun run --cwd packages/registry generate:first-party --check   # CI drift gate
 
+import { execFileSync } from "node:child_process";
 import {
   existsSync,
   readdirSync,
@@ -19,9 +20,28 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { type RegistryEntry, registryEntrySchema } from "./schema";
+
+const localRequire = createRequire(import.meta.url);
+
+// `JSON.stringify(…, null, 2)` puts every array element on its own line, but
+// biome — the repo's format gate (`bun run format:check`) — collapses arrays
+// that fit onto a single line. Without reconciling the two, the committed
+// artifacts can only satisfy one gate at a time, and a later `registry build`
+// (which re-runs this generator) silently re-breaks the biome gate. Piping each
+// artifact through biome makes the generator emit exactly what `format:check`
+// expects, so generator output, committed files, and the format gate all agree.
+function biomeFormatJson(content: string, filePath: string): string {
+  const biomeBin = localRequire.resolve("@biomejs/biome/bin/biome");
+  return execFileSync(
+    process.execPath,
+    [biomeBin, "format", `--stdin-file-path=${filePath}`],
+    { input: content, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+  );
+}
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..", "..", "..", "..");
@@ -163,9 +183,9 @@ function main(): void {
   const check = process.argv.includes("--check");
   const next = generateFirstPartyRegistry();
   const artifacts: [string, string][] = [
-    [GENERATED_PATH, next.full],
-    [CURATED_DEFS_PATH, next.curated],
-    [CHANNEL_MAP_PATH, next.channels],
+    [GENERATED_PATH, biomeFormatJson(next.full, GENERATED_PATH)],
+    [CURATED_DEFS_PATH, biomeFormatJson(next.curated, CURATED_DEFS_PATH)],
+    [CHANNEL_MAP_PATH, biomeFormatJson(next.channels, CHANNEL_MAP_PATH)],
   ];
   if (check) {
     for (const [path, expected] of artifacts) {


### PR DESCRIPTION
## Problem
PR #9208 added the first-party registry artifacts (`generated.json`, `curated-app-definitions.json`, `channel-plugin-map.json`). The generator writes them with `JSON.stringify(…, null, 2)` (one array element per line), but biome's format gate (`bun run format:check`) collapses short arrays onto one line. So the committed files could satisfy **only one** of the two gates at a time, and `registry build` — which re-runs the generator — silently re-broke the biome Format Check after #9208's files were hand-formatted to pass it.

## Fix
Pipe each generated artifact through biome (resolved from the local install, fail-loud) before writing/diffing, so generator output, the committed files, and `format:check` all agree.

## Verification (run in a clean develop checkout)
- `bun run --cwd packages/registry generate:first-party` reproduces the committed files **byte-for-byte** — zero churn.
- `bun run --cwd packages/registry generate:first-party --check` (drift gate) exits **0**.
- All three artifacts pass `biome format`.
- `generate.ts` lints + formats clean.

Follow-up to #9208 (no runtime/behavior change — formatting of generated output only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)