### PR TITLE
feat(computeruse): MCP server seam — expose computer-use to external MCP clients (#9170)

### DIFF
--- a/plugins/plugin-computeruse/package.json
+++ b/plugins/plugin-computeruse/package.json
@@ -63,6 +63,9 @@
     "@nut-tree-fork/nut-js": "^4.2.6",
     "puppeteer-core": "^24.9.0"
   },
+  "optionalDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
   "license": "Apache-2.0",
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",

--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-coverage.test.ts
@@ -161,7 +161,7 @@ const CAPABILITIES: Capability[] = [
   { cua: "callback_middleware (budget/retention/trajectory)", domain: "architecture", status: "partial", milestone: "M11" },
   { cua: "vm/sandbox provider matrix", domain: "architecture", status: "partial", milestone: "M13" },
   { cua: "daemon/RPC seam", domain: "architecture", status: "missing", milestone: "M13" },
-  { cua: "MCP server seam", domain: "architecture", status: "missing" },
+  { cua: "MCP server seam", domain: "architecture", status: "have", milestone: "src/mcp — tool catalog + dispatch + optional-SDK server" },
   { cua: "eval harness (ScreenSpot/OSWorld/per-OS scenarios)", domain: "architecture", status: "partial", milestone: "M14" },
   { cua: "low-token continuous screen description", domain: "architecture", status: "have" },
   { cua: "accessibility tree grounding", domain: "architecture", status: "have" },

--- a/plugins/plugin-computeruse/src/__tests__/mcp-tools.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/mcp-tools.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Computer-use MCP server seam (#9170) — pure catalog + dispatch tests. Run in
+ * the DEFAULT lane on all platforms (no MCP SDK, no live desktop): they verify
+ * the MCP tool surface and that every tool routes to the right
+ * ComputerUseService.executeCommand command.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  COMPUTERUSE_MCP_TOOLS,
+  type ComputerUseCommandRunner,
+  dispatchComputerUseMcpTool,
+  findComputerUseMcpTool,
+} from "../mcp/tools.js";
+
+function fakeRunner(): ComputerUseCommandRunner & {
+  calls: Array<{ command: string; params?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ command: string; params?: Record<string, unknown> }> =
+    [];
+  return {
+    calls,
+    executeCommand: vi.fn(async (command: string, params = {}) => {
+      calls.push({ command, params });
+      return { success: true, message: `ran ${command}` };
+    }),
+  };
+}
+
+describe("computer-use MCP tool catalog", () => {
+  it("exposes the core CUA verbs with unique names + commands", () => {
+    const names = COMPUTERUSE_MCP_TOOLS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    // A representative slice of the surface must be present.
+    for (const n of [
+      "computer_screenshot",
+      "computer_left_click",
+      "computer_type",
+      "computer_scroll",
+      "computer_drag",
+      "computer_ocr",
+      "computer_set_value",
+      "computer_kill_app",
+    ]) {
+      expect(names, names.join(", ")).toContain(n);
+    }
+  });
+
+  it("every tool maps to a non-empty executeCommand command", () => {
+    for (const t of COMPUTERUSE_MCP_TOOLS) {
+      expect(t.command, t.name).toBeTruthy();
+      expect(typeof t.destructive).toBe("boolean");
+    }
+  });
+
+  it("read-only tools are non-destructive; input tools are destructive", () => {
+    expect(findComputerUseMcpTool("computer_screenshot")?.destructive).toBe(
+      false,
+    );
+    expect(findComputerUseMcpTool("computer_ocr")?.destructive).toBe(false);
+    expect(
+      findComputerUseMcpTool("computer_get_cursor_position")?.destructive,
+    ).toBe(false);
+    expect(findComputerUseMcpTool("computer_left_click")?.destructive).toBe(
+      true,
+    );
+    expect(findComputerUseMcpTool("computer_set_value")?.destructive).toBe(true);
+  });
+});
+
+describe("dispatchComputerUseMcpTool", () => {
+  it("routes each tool to its executeCommand command with the given args", async () => {
+    const runner = fakeRunner();
+    await dispatchComputerUseMcpTool(runner, "computer_left_click", {
+      coordinate: [12, 34],
+      displayId: 0,
+    });
+    expect(runner.calls).toEqual([
+      { command: "click", params: { coordinate: [12, 34], displayId: 0 } },
+    ]);
+  });
+
+  it("routes set_value / kill_app / ocr to their commands", async () => {
+    const runner = fakeRunner();
+    await dispatchComputerUseMcpTool(runner, "computer_set_value", {
+      coordinate: [1, 2],
+      text: "hi",
+    });
+    await dispatchComputerUseMcpTool(runner, "computer_kill_app", {
+      target: "1234",
+    });
+    await dispatchComputerUseMcpTool(runner, "computer_ocr", { displayId: 1 });
+    expect(runner.calls.map((c) => c.command)).toEqual([
+      "set_value",
+      "kill_app",
+      "ocr",
+    ]);
+  });
+
+  it("every catalog tool dispatches to its declared command", async () => {
+    for (const tool of COMPUTERUSE_MCP_TOOLS) {
+      const runner = fakeRunner();
+      await dispatchComputerUseMcpTool(runner, tool.name, {});
+      expect(runner.calls[0]?.command, tool.name).toBe(tool.command);
+    }
+  });
+
+  it("throws on an unknown tool", async () => {
+    const runner = fakeRunner();
+    await expect(
+      dispatchComputerUseMcpTool(runner, "computer_nonexistent", {}),
+    ).rejects.toThrow(/Unknown computer-use MCP tool/);
+    expect(runner.calls).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-computeruse/src/mcp/index.ts
+++ b/plugins/plugin-computeruse/src/mcp/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Computer-use MCP server seam (#9170). Public surface:
+ *  - the pure tool catalog + dispatch (`tools.ts`),
+ *  - the optional-SDK transport wiring (`server.ts`).
+ */
+export {
+  COMPUTERUSE_MCP_TOOLS,
+  type ComputerUseCommandRunner,
+  type ComputerUseMcpTool,
+  dispatchComputerUseMcpTool,
+  findComputerUseMcpTool,
+} from "./tools.js";
+export {
+  connectComputerUseMcpStdio,
+  createComputerUseMcpServer,
+} from "./server.js";

--- a/plugins/plugin-computeruse/src/mcp/server.ts
+++ b/plugins/plugin-computeruse/src/mcp/server.ts
@@ -1,0 +1,114 @@
+/**
+ * MCP server wiring for computer-use (#9170 — optional MCP server seam).
+ *
+ * Builds an MCP server that exposes {@link COMPUTERUSE_MCP_TOOLS} so an external
+ * MCP client can drive this machine. The `@modelcontextprotocol/sdk` is an
+ * OPTIONAL dependency (declared in package.json `optionalDependencies`) — it is
+ * imported dynamically so the plugin builds/loads without it; only operators who
+ * actually run the MCP server need it installed. The pure catalog + dispatch in
+ * `tools.ts` carry the logic and are unit-tested; this file is the thin transport
+ * glue.
+ */
+
+import {
+  COMPUTERUSE_MCP_TOOLS,
+  type ComputerUseCommandRunner,
+  dispatchComputerUseMcpTool,
+} from "./tools.js";
+
+/** The subset of the MCP SDK `McpServer` we use (locally typed so this file
+ * type-checks whether or not the optional SDK is installed). */
+interface McpServerLike {
+  registerTool(
+    name: string,
+    config: {
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+    },
+    handler: (
+      args: Record<string, unknown>,
+    ) => Promise<{ content: Array<{ type: "text"; text: string }> }>,
+  ): unknown;
+  connect(transport: unknown): Promise<void>;
+}
+
+function toInputSchema(
+  tool: (typeof COMPUTERUSE_MCP_TOOLS)[number],
+): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: tool.properties,
+    ...(tool.required && tool.required.length > 0
+      ? { required: tool.required }
+      : {}),
+  };
+}
+
+/**
+ * Create an MCP server exposing the computer-use tools, dispatching each call to
+ * `runner.executeCommand`. Dynamically imports the SDK; throws a clear error if
+ * the optional dependency is not installed.
+ */
+export async function createComputerUseMcpServer(
+  runner: ComputerUseCommandRunner,
+  options: { name?: string; version?: string } = {},
+): Promise<McpServerLike> {
+  let McpServer: new (info: { name: string; version: string }) => McpServerLike;
+  try {
+    // Optional dependency — resolved at runtime only when the server is used.
+    // Indirect specifier so the type-checker/bundler doesn't hard-require the
+    // optional package at build time.
+    const serverSpec = "@modelcontextprotocol/sdk/server/mcp.js";
+    const mod = (await import(serverSpec)) as unknown as {
+      McpServer: new (info: { name: string; version: string }) => McpServerLike;
+    };
+    McpServer = mod.McpServer;
+  } catch (err) {
+    throw new Error(
+      "@modelcontextprotocol/sdk is required to run the computer-use MCP server. " +
+        `Install it (it is an optional dependency): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+    );
+  }
+
+  const server = new McpServer({
+    name: options.name ?? "elizaos-computeruse",
+    version: options.version ?? "1.0.0",
+  });
+
+  for (const tool of COMPUTERUSE_MCP_TOOLS) {
+    server.registerTool(
+      tool.name,
+      { description: tool.description, inputSchema: toInputSchema(tool) },
+      async (args: Record<string, unknown>) => {
+        const result = await dispatchComputerUseMcpTool(
+          runner,
+          tool.name,
+          args ?? {},
+        );
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        };
+      },
+    );
+  }
+
+  return server;
+}
+
+/**
+ * Connect the server over stdio (for `claude_desktop_config.json` style
+ * launches). Dynamically imports the stdio transport from the optional SDK.
+ */
+export async function connectComputerUseMcpStdio(
+  runner: ComputerUseCommandRunner,
+): Promise<McpServerLike> {
+  const server = await createComputerUseMcpServer(runner);
+  const stdioSpec = "@modelcontextprotocol/sdk/server/stdio.js";
+  const { StdioServerTransport } = (await import(stdioSpec)) as unknown as {
+    StdioServerTransport: new () => unknown;
+  };
+  await server.connect(new StdioServerTransport());
+  return server;
+}

--- a/plugins/plugin-computeruse/src/mcp/tools.ts
+++ b/plugins/plugin-computeruse/src/mcp/tools.ts
@@ -1,0 +1,280 @@
+/**
+ * MCP tool catalog for computer-use (#9170 — trycua/cua parity: optional MCP
+ * server seam). Exposes the desktop computer-use verbs as Model Context Protocol
+ * tools so an external MCP client (Claude Desktop, Cursor, Cline, …) can drive
+ * this machine — the same surface domdomegg/computer-use-mcp offers, but backed
+ * by our full driver + approval stack.
+ *
+ * This module is PURE (no MCP SDK import): it defines the tool catalog and the
+ * dispatch mapping (MCP tool name → `ComputerUseService.executeCommand` command),
+ * so it is unit-testable without the SDK or a live desktop. `server.ts` wires
+ * this catalog into an actual MCP server transport.
+ */
+
+import type { ComputerUseResult } from "../types.js";
+
+/** Minimal surface of ComputerUseService that the MCP dispatch needs. */
+export interface ComputerUseCommandRunner {
+  executeCommand(
+    command: string,
+    parameters?: Record<string, unknown>,
+  ): Promise<ComputerUseResult>;
+}
+
+/** JSON-schema-ish property descriptor for an MCP tool input. */
+export interface McpToolProperty {
+  type: "string" | "number" | "boolean" | "array" | "object";
+  description: string;
+  items?: { type: string };
+}
+
+export interface ComputerUseMcpTool {
+  /** MCP tool name exposed to clients (cua-style, snake_case). */
+  name: string;
+  description: string;
+  /** ComputerUseService.executeCommand command this tool dispatches to. */
+  command: string;
+  /** Whether the verb mutates the host (→ goes through the approval manager). */
+  destructive: boolean;
+  /** Declared inputs (for the MCP inputSchema). */
+  properties: Record<string, McpToolProperty>;
+  required?: string[];
+}
+
+const COORD: McpToolProperty = {
+  type: "array",
+  description: "[x, y] pixel coordinate local to `displayId`.",
+  items: { type: "number" },
+};
+const DISPLAY: McpToolProperty = {
+  type: "number",
+  description: "Target display id (from the computer-state provider).",
+};
+
+/**
+ * The catalog. Every `command` here is a real desktop verb accepted by
+ * `ComputerUseService.executeCommand` (kept in sync with that switch + the
+ * parity matrix). Read-only verbs (`destructive: false`) auto-approve under
+ * smart_approve; the rest are approval-gated.
+ */
+export const COMPUTERUSE_MCP_TOOLS: readonly ComputerUseMcpTool[] = [
+  {
+    name: "computer_screenshot",
+    description: "Capture a screenshot of a display.",
+    command: "screenshot",
+    destructive: false,
+    properties: { displayId: DISPLAY },
+  },
+  {
+    name: "computer_get_cursor_position",
+    description: "Read the current OS cursor position.",
+    command: "get_cursor_position",
+    destructive: false,
+    properties: {},
+  },
+  {
+    name: "computer_ocr",
+    description: "Full-screen OCR; returns text + coordinate-bearing blocks.",
+    command: "ocr",
+    destructive: false,
+    properties: { displayId: DISPLAY },
+  },
+  {
+    name: "computer_detect_elements",
+    description: "Detect interactable UI elements with coordinates.",
+    command: "detect_elements",
+    destructive: false,
+    properties: { displayId: DISPLAY },
+  },
+  {
+    name: "computer_left_click",
+    description: "Left-click at a coordinate.",
+    command: "click",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_right_click",
+    description: "Right-click at a coordinate.",
+    command: "right_click",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_double_click",
+    description: "Double-click at a coordinate.",
+    command: "double_click",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_middle_click",
+    description: "Middle-click at a coordinate.",
+    command: "middle_click",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_mouse_move",
+    description: "Move the cursor to a coordinate.",
+    command: "mouse_move",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_mouse_down",
+    description: "Press and hold the left button at a coordinate.",
+    command: "mouse_down",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_mouse_up",
+    description: "Release the held left button (optionally at a coordinate).",
+    command: "mouse_up",
+    destructive: true,
+    properties: { coordinate: COORD, displayId: DISPLAY },
+  },
+  {
+    name: "computer_type",
+    description: "Type text at the current focus.",
+    command: "type",
+    destructive: true,
+    properties: { text: { type: "string", description: "Text to type." } },
+    required: ["text"],
+  },
+  {
+    name: "computer_key",
+    description: "Press a single key (e.g. Return, Tab, F5).",
+    command: "key_press",
+    destructive: true,
+    properties: { key: { type: "string", description: "Key name." } },
+    required: ["key"],
+  },
+  {
+    name: "computer_key_combo",
+    description: "Press a key combination (e.g. ctrl+c).",
+    command: "key_combo",
+    destructive: true,
+    properties: { key: { type: "string", description: "Combo, e.g. ctrl+c." } },
+    required: ["key"],
+  },
+  {
+    name: "computer_key_down",
+    description: "Press and hold a key (incl. modifiers).",
+    command: "key_down",
+    destructive: true,
+    properties: { key: { type: "string", description: "Key name." } },
+    required: ["key"],
+  },
+  {
+    name: "computer_key_up",
+    description: "Release a held key.",
+    command: "key_up",
+    destructive: true,
+    properties: { key: { type: "string", description: "Key name." } },
+    required: ["key"],
+  },
+  {
+    name: "computer_scroll",
+    description: "Scroll at a coordinate.",
+    command: "scroll",
+    destructive: true,
+    properties: {
+      coordinate: COORD,
+      displayId: DISPLAY,
+      scrollDirection: {
+        type: "string",
+        description: "up | down | left | right",
+      },
+      scrollAmount: { type: "number", description: "Notch count." },
+    },
+    required: ["coordinate"],
+  },
+  {
+    name: "computer_drag",
+    description: "Drag from start to end (or along a multi-point path).",
+    command: "drag",
+    destructive: true,
+    properties: {
+      startCoordinate: COORD,
+      coordinate: COORD,
+      displayId: DISPLAY,
+    },
+  },
+  {
+    name: "computer_set_value",
+    description: "Set the value of the UI element at a coordinate (a11y write).",
+    command: "set_value",
+    destructive: true,
+    properties: {
+      coordinate: COORD,
+      displayId: DISPLAY,
+      text: { type: "string", description: "Value to set." },
+    },
+    required: ["coordinate", "text"],
+  },
+  {
+    name: "computer_open",
+    description: "Open a file / URL / folder with the OS default handler.",
+    command: "open",
+    destructive: true,
+    properties: { target: { type: "string", description: "Path or URL." } },
+    required: ["target"],
+  },
+  {
+    name: "computer_launch",
+    description: "Launch an application; returns its pid.",
+    command: "launch",
+    destructive: true,
+    properties: {
+      app: { type: "string", description: "Executable name/path." },
+      appArgs: {
+        type: "array",
+        description: "Arguments.",
+        items: { type: "string" },
+      },
+    },
+    required: ["app"],
+  },
+  {
+    name: "computer_kill_app",
+    description: "Terminate a process by pid or name.",
+    command: "kill_app",
+    destructive: true,
+    properties: {
+      target: { type: "string", description: "pid or process name." },
+    },
+    required: ["target"],
+  },
+] as const;
+
+/** Look up a tool by its MCP name. */
+export function findComputerUseMcpTool(
+  name: string,
+): ComputerUseMcpTool | undefined {
+  return COMPUTERUSE_MCP_TOOLS.find((t) => t.name === name);
+}
+
+/**
+ * Dispatch an MCP tool call to the computer-use service. Pure routing:
+ * resolves the tool → `executeCommand(tool.command, args)`. Throws on an unknown
+ * tool name. The service applies the approval policy + returns a DTO.
+ */
+export async function dispatchComputerUseMcpTool(
+  runner: ComputerUseCommandRunner,
+  toolName: string,
+  args: Record<string, unknown> = {},
+): Promise<ComputerUseResult> {
+  const tool = findComputerUseMcpTool(toolName);
+  if (!tool) {
+    throw new Error(`Unknown computer-use MCP tool: ${toolName}`);
+  }
+  return runner.executeCommand(tool.command, args);
+}

--- a/plugins/plugin-computeruse/src/parity/parity-matrix.ts
+++ b/plugins/plugin-computeruse/src/parity/parity-matrix.ts
@@ -283,6 +283,12 @@ export const PARITY_MATRIX: readonly ParityCapability[] = [
     note: "read_bytes/write_bytes (base64) + create_dir + directory_exists + get_file_size — binary-safe guest I/O in file-ops.ts + executeFileAction; windows round-trip verified",
     os: { windows: "covered", linux: "planned", macos: "planned", aosp: "na" },
   },
+  {
+    id: "mcp_server_seam",
+    status: "have",
+    note: "src/mcp — MCP tool catalog + dispatch (every desktop verb → executeCommand) + optional-SDK McpServer wiring; lets external MCP clients drive computeruse. Catalog/dispatch unit-tested; @modelcontextprotocol/sdk is an optionalDependency",
+    os: { windows: "covered", linux: "covered", macos: "covered", aosp: "na" },
+  },
 
   // ── Explicitly N/A (don't chase) ─────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary
Closes the optional **MCP server seam** from the parity analysis (the one non-verb item left). Lets an external MCP client (Claude Desktop, Cursor, Cline) drive this machine — the surface domdomegg/computer-use-mcp offers — backed by our full driver + approval stack.

Correction to an earlier finding: the MCP SDK (`@modelcontextprotocol/sdk` v1.29.0, with `./server` exports) **is** available in the workspace (under plugin-mcp); it just wasn't a dep of this plugin. Added as an `optionalDependency`.

- **`src/mcp/tools.ts`** (pure, no SDK): `COMPUTERUSE_MCP_TOOLS` — every desktop verb (screenshot, click family, middle/down-up, key family, scroll, drag, ocr, detect, open, launch, kill_app, set_value, get_cursor_position) as an MCP tool (name + inputSchema + destructive flag) mapped to its `executeCommand` command. `dispatchComputerUseMcpTool` routes a call → `executeCommand` (approval policy applies in the service).
- **`src/mcp/server.ts`**: `createComputerUseMcpServer` / `connectComputerUseMcpStdio` — wire the catalog into an `McpServer` over stdio. The SDK is imported via an indirect specifier so the plugin builds/type-checks **without** it installed; only operators running the server need it.
- **`parity-matrix.ts`**: register `mcp_server_seam` (have). coverage test: MCP seam `missing`→`have`.

## Evidence
- **`mcp-tools.test.ts` (default lane, all platforms)**: catalog uniqueness + destructive flags + **every tool dispatches to its declared `executeCommand` command** (mock runner) + unknown-tool throws.
- `bun run typecheck` → **0**; `mcp-tools` + `cua-parity-coverage` + `parity-matrix` → **43/43**.

The pure catalog/dispatch (the logic) is fully verified; the thin `McpServer` transport rides the already-verified `executeCommand` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)