### PR TITLE
feat(registry): mark contacts/phone/wifi as OS-only system entries (hidden from app/web)

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -1291,11 +1291,11 @@
       "tags": ["device", "contacts"],
       "config": {},
       "render": {
-        "visible": true,
-        "pinTo": [],
+        "visible": false,
+        "pinTo": ["os-shell"],
         "style": "card",
         "icon": "Contact",
-        "group": "device",
+        "group": "system",
         "actions": ["enable"]
       },
       "resources": {
@@ -5799,11 +5799,11 @@
       "tags": ["device", "phone"],
       "config": {},
       "render": {
-        "visible": true,
-        "pinTo": [],
+        "visible": false,
+        "pinTo": ["os-shell"],
         "style": "card",
         "icon": "Phone",
-        "group": "device",
+        "group": "system",
         "actions": ["enable"]
       },
       "resources": {
@@ -6302,11 +6302,11 @@
       "tags": ["device", "screenshare"],
       "config": {},
       "render": {
-        "visible": true,
+        "visible": false,
         "pinTo": [],
         "style": "card",
         "icon": "ScreenShare",
-        "group": "device",
+        "group": "system",
         "actions": ["enable"]
       },
       "resources": {
@@ -8057,11 +8057,11 @@
       "tags": ["device", "wifi"],
       "config": {},
       "render": {
-        "visible": true,
-        "pinTo": [],
+        "visible": false,
+        "pinTo": ["os-shell"],
         "style": "card",
         "icon": "Wifi",
-        "group": "device",
+        "group": "system",
         "actions": ["enable"]
       },
       "resources": {

--- a/packages/registry/src/first-party/schema.ts
+++ b/packages/registry/src/first-party/schema.ts
@@ -114,6 +114,11 @@ const secondarySurfaceSchema = z.enum([
   "chat-apps-section",
   "companion-shell",
   "settings-integrations",
+  // OS-mode launcher. OS-level system entries (contacts, phone, wifi) set
+  // `visible: false` + `pinTo: ["os-shell"]` so they are hidden from the
+  // app/web/desktop catalogs and surface only when running as the device OS,
+  // where the native contacts/phone/wifi APIs are available.
+  "os-shell",
 ]);
 
 export const renderSchema = z.object({

--- a/packages/ui/src/components/pages/plugin-list-utils.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.ts
@@ -902,8 +902,12 @@ export function buildPluginListState(options: {
     (plugin) =>
       plugin.category !== "database" &&
       !ALWAYS_ON_PLUGIN_IDS.has(plugin.id) &&
-      (!isConnectorLikeMode ||
-        (plugin.category === "connector" && plugin.visible !== false)) &&
+      // Honor the registry's `render.visible: false` for every kind (not just
+      // connectors). OS-level system entries (contacts/phone/wifi) set
+      // visible:false so they stay out of the app/web Features + Connectors
+      // views and surface only in OS mode (ElizaOsAppsView).
+      plugin.visible !== false &&
+      (!isConnectorLikeMode || plugin.category === "connector") &&
       (mode !== "streaming" || plugin.category === "streaming"),
   );
   const nonDbPlugins = [SHOWCASE_PLUGIN, ...categoryPlugins];

--- a/plugins/plugin-contacts/registry-entry.json
+++ b/plugins/plugin-contacts/registry-entry.json
@@ -5,15 +5,22 @@
   "npmName": "@elizaos/plugin-contacts",
   "version": "2.0.3-beta.2",
   "source": "bundled",
-  "tags": ["device", "contacts"],
+  "tags": [
+    "device",
+    "contacts"
+  ],
   "config": {},
   "render": {
-    "visible": true,
-    "pinTo": [],
+    "visible": false,
+    "pinTo": [
+      "os-shell"
+    ],
     "style": "card",
     "icon": "Contact",
-    "group": "device",
-    "actions": ["enable"]
+    "group": "system",
+    "actions": [
+      "enable"
+    ]
   },
   "resources": {
     "homepage": "https://elizaos.ai",

--- a/plugins/plugin-phone/registry-entry.json
+++ b/plugins/plugin-phone/registry-entry.json
@@ -5,15 +5,22 @@
   "npmName": "@elizaos/plugin-phone",
   "version": "2.0.3-beta.2",
   "source": "bundled",
-  "tags": ["device", "phone"],
+  "tags": [
+    "device",
+    "phone"
+  ],
   "config": {},
   "render": {
-    "visible": true,
-    "pinTo": [],
+    "visible": false,
+    "pinTo": [
+      "os-shell"
+    ],
     "style": "card",
     "icon": "Phone",
-    "group": "device",
-    "actions": ["enable"]
+    "group": "system",
+    "actions": [
+      "enable"
+    ]
   },
   "resources": {
     "homepage": "https://elizaos.ai",

--- a/plugins/plugin-screenshare/registry-entry.json
+++ b/plugins/plugin-screenshare/registry-entry.json
@@ -5,15 +5,20 @@
   "npmName": "@elizaos/plugin-screenshare",
   "version": "2.0.3-beta.2",
   "source": "bundled",
-  "tags": ["device", "screenshare"],
+  "tags": [
+    "device",
+    "screenshare"
+  ],
   "config": {},
   "render": {
-    "visible": true,
+    "visible": false,
     "pinTo": [],
     "style": "card",
     "icon": "ScreenShare",
-    "group": "device",
-    "actions": ["enable"]
+    "group": "system",
+    "actions": [
+      "enable"
+    ]
   },
   "resources": {
     "homepage": "https://elizaos.ai",

--- a/plugins/plugin-wifi/registry-entry.json
+++ b/plugins/plugin-wifi/registry-entry.json
@@ -5,15 +5,22 @@
   "npmName": "@elizaos/plugin-wifi",
   "version": "2.0.3-beta.2",
   "source": "bundled",
-  "tags": ["device", "wifi"],
+  "tags": [
+    "device",
+    "wifi"
+  ],
   "config": {},
   "render": {
-    "visible": true,
-    "pinTo": [],
+    "visible": false,
+    "pinTo": [
+      "os-shell"
+    ],
     "style": "card",
     "icon": "Wifi",
-    "group": "device",
-    "actions": ["enable"]
+    "group": "system",
+    "actions": [
+      "enable"
+    ]
   },
   "resources": {
     "homepage": "https://elizaos.ai",


### PR DESCRIPTION
Follow-up to the merged registry de-hardcoding (#9208). The native-capability entries it added for the curated-app derivation — `contacts`, `phone`, `wifi`, `screenshare` — are **OS-level system surfaces, not catalog apps**. They should be hidden from the app/web/desktop catalogs and surface only in **OS mode** (`ElizaOsAppsView`, which already drives phone/contacts/system via the native device APIs).

## Changes
- New `os-shell` secondary surface in the registry schema.
- `contacts`/`phone`/`wifi`: `render.visible: false` + `pinTo: ["os-shell"]` + `group: "system"` — out of the app/web catalogs, marked for the OS launcher. `screenshare`: `visible: false` + `group: "system"` (it was already hidden via the AppsView hidden-list; made consistent).
- `plugin-list-utils`: the Features/Connectors list now honors `render.visible !== false` for **every** kind, not just connectors. The schema already documents "every entry shows in its primary surface unless `visible:false`", but the Features view wasn’t enforcing it. (`inmemorydb`/`localdb` are `category=database`, already excluded, so this only newly hides the system entries.)

## Why this is safe
Curated-app NL matching is **unaffected** — `getCuratedAppDefinitions()` is still BYTE-IDENTICAL (visibility doesn’t touch the `curatedApp` derivation), so "open contacts" etc. still resolve. The OS-mode rendering + native contacts/phone APIs already exist in `ElizaOsAppsView`; this PR just stops these system entries from leaking into the regular catalogs.

Verified: drift check green (biome-formatted artifacts in sync), `plugin-list-utils` tests (5), `registry` + `ui` typecheck clean, curated defs byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)