### PR TITLE
test(lifeops): add schedule_plan + reminder_dispatch capability scenarios

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
@@ -1,0 +1,97 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+function assertApiBody(options: {
+  includesAll?: ReadonlyArray<string>;
+}): (status: number, body: unknown) => string | undefined {
+  return (_status, body) => {
+    const serialized =
+      typeof body === "string" ? body : JSON.stringify(body ?? "");
+    for (const needle of options.includesAll ?? []) {
+      if (!serialized.includes(needle)) {
+        return `expected body to include "${needle}"`;
+      }
+    }
+  };
+}
+
+/**
+ * Behavior scenario for the `reminder_dispatch` LifeOps capability.
+ *
+ * When a scheduled reminder fires, the reminders mixin
+ * (`buildReminderDispatchPrompt` in
+ * `plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts`)
+ * composes the natural-language nudge the owner actually receives. Its
+ * instruction body is the GEPA-optimizable `reminder_dispatch` prompt:
+ * `REMINDER_DISPATCH_INSTRUCTIONS` is the wired baseline that
+ * `resolveOptimizedPromptForRuntime` swaps for a registered
+ * `reminder_dispatch` artifact.
+ *
+ * Unlike a chat-turn planner capability, `reminder_dispatch` runs on the
+ * delivery path, so this scenario seeds a due reminder definition and drives
+ * `POST /api/lifeops/reminders/process` to fire it. The delivery assertion
+ * (`delivered` on the `in_app` channel) confirms the dispatch path — and the
+ * prompt that authors the reminder text — executed, so a regression in the
+ * wired prompt or the firing pipeline surfaces as a failing scenario. It
+ * mirrors `reminder.lifecycle.dismiss` but is scoped to the reminder-dispatch
+ * capability.
+ */
+export default scenario({
+  lane: "live-only",
+  id: "reminder-dispatch-capability",
+  title: "Reminder dispatch capability fires a due reminder on the delivery path",
+  domain: "reminders",
+  tags: ["lifeops", "reminders", "reminder_dispatch", "llm-eval"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "LifeOps Reminder Dispatch Capability",
+    },
+  ],
+  turns: [
+    {
+      kind: "api",
+      name: "seed due reminder",
+      method: "POST",
+      path: "/api/lifeops/definitions",
+      body: {
+        kind: "task",
+        title: "Call mom",
+        timezone: "UTC",
+        priority: 1,
+        cadence: {
+          kind: "once",
+          dueAt: "{{now+10m}}",
+          visibilityLeadMinutes: 240,
+          visibilityLagMinutes: 720,
+        },
+        reminderPlan: {
+          steps: [
+            {
+              channel: "in_app",
+              offsetMinutes: 0,
+              label: "In-app reminder",
+            },
+          ],
+        },
+      },
+      expectedStatus: 201,
+    },
+    {
+      kind: "api",
+      name: "process and dispatch reminder",
+      method: "POST",
+      path: "/api/lifeops/reminders/process",
+      body: {
+        now: "{{now+10m}}",
+        limit: 10,
+      },
+      expectedStatus: 200,
+      assertResponse: assertApiBody({ includesAll: ["delivered", "in_app"] }),
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
@@ -1,0 +1,74 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+/**
+ * Behavior scenario for the `schedule_plan` LifeOps capability.
+ *
+ * The scheduling-negotiation planner (`buildSchedulingPlanPrompt` /
+ * `resolveSchedulingPlanWithLlm` in
+ * `plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.ts`)
+ * turns a natural-language meeting-coordination request into a structured
+ * negotiation plan: a `subaction` (start / propose / respond / finalize /
+ * cancel / list_active / list_proposals / null) plus `shouldAct`. Its
+ * instruction body is the GEPA-optimizable `schedule_plan` prompt:
+ * `SCHEDULE_PLAN_INSTRUCTIONS` is the wired baseline that
+ * `resolveOptimizedPromptForRuntime` swaps for a registered `schedule_plan`
+ * artifact, and the model call is tagged with `purpose: "schedule_plan"` for
+ * trajectory capture.
+ *
+ * Negotiation intents ("set up a meeting", "cancel that negotiation",
+ * "list my open negotiations") route to the `PERSONAL_ASSISTANT` umbrella
+ * action with `action=scheduling` (see `runSchedulingNegotiationHandler` in
+ * `owner-surfaces.ts`). This scenario asserts each request reaches the
+ * `PERSONAL_ASSISTANT` action and adds a final selected-action check so a
+ * regression in the wired prompt or the routing surfaces as a failing
+ * scenario. It mirrors `calendar-extract-capability` /
+ * `inbox-triage-capability` but is scoped to the schedule-plan capability.
+ */
+export default scenario({
+  lane: "live-only",
+  id: "schedule-plan-capability",
+  title: "Schedule plan capability routes negotiation requests to PERSONAL_ASSISTANT",
+  domain: "scheduling",
+  tags: ["lifeops", "scheduling", "schedule_plan", "llm-eval"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "LifeOps Schedule Plan Capability",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "plan-start-negotiation",
+      text: "Start a scheduling negotiation with Priya to find a time for our quarterly review.",
+      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
+      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
+    },
+    {
+      kind: "message",
+      name: "plan-list-negotiations",
+      text: "List my open scheduling negotiations.",
+      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
+      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
+    },
+    {
+      kind: "message",
+      name: "plan-cancel-negotiation",
+      text: "Cancel the scheduling negotiation for the quarterly review.",
+      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
+      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "selectedAction",
+      name: "personal assistant action selected for every schedule-plan turn",
+      actionName: "PERSONAL_ASSISTANT",
+    },
+  ],
+});


### PR DESCRIPTION
## What

Adds two capability-scoped scenario-runner specs so the `schedule_plan` and `reminder_dispatch` LifeOps prompts get the same regression net as `calendar_extract` and `inbox_triage`.

Both capabilities resolve their prompt through `OptimizedPromptService` via `resolveOptimizedPromptForRuntime`:

- **`schedule_plan`** — `plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.ts` (`buildSchedulingPlanPrompt`, model call purpose-tagged `schedule_plan`). It is the scheduling-**negotiation** planner, reached through the `PERSONAL_ASSISTANT` umbrella action (`action=scheduling`).
- **`reminder_dispatch`** — `plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts` (`buildReminderDispatchPrompt`). It authors the reminder nudge text on the **delivery** path, fired by `POST /api/lifeops/reminders/process`.

Until now neither had a dedicated `.scenario.ts`, so a regression in the wired/optimized prompt would not surface as a failing scenario. Named as remaining in the #9224 maintainer comment.

### New files

- `plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts` — negotiation start / list / cancel turns asserting `plannerIncludesAll: ["PERSONAL_ASSISTANT"]` + a `selectedAction: PERSONAL_ASSISTANT` final check. Mirrors `calendar-extract-capability` / `inbox-triage-capability`.
- `plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts` — seeds a due reminder definition, then drives `reminders/process` to fire it and asserts `delivered` on the `in_app` channel, exercising the dispatch prompt. Mirrors `reminder.lifecycle.dismiss`.

Both are `lane: "live-only"` (so they list/parse in CI without a key; the live run is gated like the siblings), domain-tagged, `isolation: "per-scenario"`, `requires.plugins: ["@elizaos/plugin-agent-skills"]`.

## Verification

```
$ bun packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios | grep -E 'schedule-plan-capability|reminder-dispatch-capability'
reminder-dispatch-capability
schedule-plan-capability
```

Both scenarios are discovered by `list`, validate at runtime through the `scenario()` helper (lane + `finalChecks` validated against `FINAL_CHECK_KEYS`), and a scoped `tsc --noEmit` over the two new files plus the `calendar-extract` / `inbox-triage` controls passes with exit 0.

Part of #8795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)