### PR TITLE
Per-plugin home-widget opt-in sweep (todos/goals/inbox/calendar) + coverage gate (#9143)

### DIFF
--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -155,6 +155,57 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     order: 80,
     defaultEnabled: true,
   },
+  // -- Per-plugin opt-in sinks (#9143) ---------------------------------------
+  // Manifest plugins that have live state but ship no bundled home component
+  // opt into a shared default widget via `defaultWidget`. The runtime plugin ID
+  // is the package name with the `@elizaos/plugin-` prefix stripped (see
+  // plugin-discovery-helpers.ts `workspacePluginIdFromPackageName`), so e.g.
+  // `@elizaos/plugin-todos` -> `todos`. These resolve to the shared sink
+  // component (no own component) and only render when the plugin is enabled.
+  // todos -> activity feed.
+  {
+    id: "todos.activity",
+    pluginId: "todos",
+    slot: "home",
+    label: "Todos",
+    icon: "ListTodo",
+    order: 110,
+    defaultEnabled: true,
+    defaultWidget: "activity",
+  },
+  // goals -> activity feed.
+  {
+    id: "goals.activity",
+    pluginId: "goals",
+    slot: "home",
+    label: "Goals",
+    icon: "Target",
+    order: 120,
+    defaultEnabled: true,
+    defaultWidget: "activity",
+  },
+  // inbox -> messages sink (cross-channel triage surfaces as recent items).
+  {
+    id: "inbox.messages",
+    pluginId: "inbox",
+    slot: "home",
+    label: "Inbox",
+    icon: "Inbox",
+    order: 130,
+    defaultEnabled: true,
+    defaultWidget: "messages",
+  },
+  // calendar -> notifications sink (reminders are notification-like).
+  {
+    id: "calendar.notifications",
+    pluginId: "calendar",
+    slot: "home",
+    label: "Calendar",
+    icon: "Calendar",
+    order: 140,
+    defaultEnabled: true,
+    defaultWidget: "notifications",
+  },
   // Browser workspace status — surfaces /browser state in the right rail.
   {
     id: BROWSER_STATUS_WIDGET.id,

--- a/packages/ui/src/widgets/widget-coverage.test.ts
+++ b/packages/ui/src/widgets/widget-coverage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveWidgetsForSlot, type WidgetPluginState } from "./registry";
+
+// #9143 — per-plugin home-widget coverage gate.
+//
+// The contract: every manifest plugin opted onto the frontpage resolves at
+// least one `home`-slot widget (its own bundled component OR a shared
+// `defaultWidget` sink) via `resolveWidgetsForSlot`. This enumerates the
+// opted-in batch and asserts each resolves a rendered component, so a future
+// edit that drops a declaration (or its sink mapping) fails CI here.
+//
+// IDs are the runtime plugin IDs (package name with `@elizaos/plugin-`
+// stripped — see plugin-discovery-helpers `workspacePluginIdFromPackageName`),
+// which is exactly what `PluginInfo.id` carries in the live plugin snapshot.
+const HOME_WIDGET_PLUGIN_IDS = ["todos", "goals", "inbox", "calendar"] as const;
+
+function enabled(id: string): WidgetPluginState {
+  return { id, enabled: true, isActive: true };
+}
+
+describe("home-widget per-plugin coverage gate (#9143)", () => {
+  for (const pluginId of HOME_WIDGET_PLUGIN_IDS) {
+    it(`resolves >=1 home widget with a rendered component for "${pluginId}"`, () => {
+      const resolved = resolveWidgetsForSlot("home", [enabled(pluginId)]);
+      const own = resolved.filter((r) => r.declaration.pluginId === pluginId);
+      expect(own.length).toBeGreaterThanOrEqual(1);
+      // Every opted-in declaration must render something (own component or the
+      // shared sink it opted into) — a declaration that resolves no component
+      // is a broken pipeline, not coverage.
+      for (const entry of own) {
+        expect(entry.Component).toBeTruthy();
+      }
+    });
+  }
+
+  it("enumerates every opted-in plugin (count check, fails if the batch shrinks)", () => {
+    const covered = HOME_WIDGET_PLUGIN_IDS.filter((pluginId) => {
+      const resolved = resolveWidgetsForSlot("home", [enabled(pluginId)]);
+      return resolved.some(
+        (r) => r.declaration.pluginId === pluginId && r.Component !== null,
+      );
+    });
+    expect(covered).toEqual([...HOME_WIDGET_PLUGIN_IDS]);
+  });
+
+  // Negative control (red-then-green proof): a manifest plugin that has NOT
+  // opted into a home widget resolves none. This is the failure the gate
+  // catches — opting it in (a `home` declaration with `defaultWidget`) is what
+  // turns it green. `relationships` is deliberately left un-opted here.
+  it("does NOT resolve a home widget for a plugin with no opt-in", () => {
+    const resolved = resolveWidgetsForSlot("home", [enabled("relationships")]);
+    expect(
+      resolved.some((r) => r.declaration.pluginId === "relationships"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Converts the already-built `defaultWidget` sink mechanism into real per-plugin breadth for the frontpage (`home`) widget slot, plus a paired coverage gate so the two land together and stay enforced.

Opts four `elizaos.app` manifest plugins onto the `home` slot via `defaultWidget` (zero new components — `resolveWidgetsForSlot` already maps each kind to the shared `NotificationsWidget`/`MessagesWidget`/Activity component):

| plugin | runtime id | sink |
| --- | --- | --- |
| `@elizaos/plugin-todos` | `todos` | `activity` |
| `@elizaos/plugin-goals` | `goals` | `activity` |
| `@elizaos/plugin-inbox` | `inbox` | `messages` |
| `@elizaos/plugin-calendar` | `calendar` | `notifications` |

Coverage: **0 own-widget / 4 default-sink** added by this PR.

The runtime plugin IDs match `PluginInfo.id` (package name with the `@elizaos/plugin-` prefix stripped — see `plugin-discovery-helpers.ts` `workspacePluginIdFromPackageName` / the installed-plugin derivation), so each declaration resolves when its plugin is enabled in the live snapshot. Each declaration has no own registered component, so it falls through to the shared sink — `defaultWidget` is fallback-only and never fires off the `home` slot.

## Coverage gate

New `packages/ui/src/widgets/widget-coverage.test.ts`:
- enumerates the opted-in plugin IDs and asserts each resolves >=1 `home` widget **with a rendered component**;
- a count check that fails if the batch shrinks;
- a negative control: a manifest plugin with no opt-in (`relationships`) resolves **none** — proving the gate has teeth.

**Red-then-green proof:** removing any one opt-in (e.g. the `calendar` declaration) fails the gate (the per-plugin `calendar` case + the count check go red); restoring it passes. Verified locally.

## Scope

Deliberately a verifiable batch (4 of the ~33 manifest plugins), not all at once — each lands with the gate so CI stays green. No new widget registry, no new component, no core-type change (`defaultWidget` already exists on `PluginWidgetDeclaration`). Subsequent plugins opt in the same way (one `home` declaration + add the id to the gate).

## Verification

- `bun run --cwd packages/ui test widget` → 15 files / 78 tests pass (was 72; +6 from the new coverage test).
- `bun run --cwd packages/core typecheck` → clean.
- `bun run --cwd packages/ui typecheck` → clean.
- `biome check` on both changed files → clean.

Part of #9143.