### PR TITLE
feat(training): wire MTP drafter sources to the real Gemma-4 assistant heads

### DIFF
--- a/packages/training/scripts/training/model_registry.py
+++ b/packages/training/scripts/training/model_registry.py
@@ -278,16 +278,25 @@ def _entry(**kw) -> ModelEntry:
 #   total layers   q_heads  kv_heads  head_dim(global/swa)  vocab    (HF base id)
 #   35 (7 global)  8        1 (MQA)   512 / 256             262144   google/gemma-4-E2B → eliza-1-2b  (sliding_window=512, shared_kv_layers=20 → ~15 KV-bearing)
 #
-# MTP speculative-decode drafter, per eliza tier id. Gemma 4 ships OFFICIAL
-# SEPARATE drafter models (a distinct GGUF), not a same-file NextN head, so
-# each target drafts from its own Gemma 4 drafter. Mirrors `DEFAULT_STUDENT_BASE`
-# in `scripts/distill_mtp_drafter.py` — keep the two in sync.
+# MTP speculative-decode drafter, per eliza tier id. Google ships the OFFICIAL
+# MTP head with the `-it-assistant` checkpoint of each Gemma 4 size — a distinct
+# `gemma4-assistant`-arch model (4-block NextN drafter: `nextn.pre_projection` +
+# `nextn.post_projection`), NOT a same-file NextN head and NOT a distilled
+# student. Convert it to GGUF with upstream `convert_hf_to_gguf.py` (arch
+# `gemma4-assistant`) and load it via `-md <drafter>.gguf --spec-type draft-mtp`.
+# NO H200 / distillation is required — the trained weights already exist.
+# Validated 2026-06-23: the E2B drafter (GGUF `amaranus/Gemma-4-E2B-it-qat-
+# assistant-MTP-Q8_0`) gives a 1.29x decode speedup against the eliza-1-2b
+# target on Apple M4 Max Metal (see
+# plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md).
 MTP_DRAFTER_BASE: dict[str, str] = {
-    # Gemma 4 official separate drafters (distinct GGUF per target tier).
-    "eliza-1-2b": "google/gemma-4-E2B-mtp",
-    "eliza-1-4b": "google/gemma-4-E4B-mtp",
-    "eliza-1-9b": "google/gemma-4-12B-mtp",
-    "eliza-1-27b": "google/gemma-4-31B-mtp",
+    # Official Gemma 4 assistant MTP heads (gemma4-assistant arch), per target
+    # tier. Ready GGUF conversions: amaranus/Gemma-4-{E2B,E4B}-it-qat-assistant-
+    # MTP-Q8_0-GGUF, {cortexist,Janvitos}/gemma-4-12B-it-assistant-MTP-GGUF.
+    "eliza-1-2b": "google/gemma-4-E2B-it-assistant",
+    "eliza-1-4b": "google/gemma-4-E4B-it-assistant",
+    "eliza-1-9b": "google/gemma-4-12B-it-assistant",
+    "eliza-1-27b": "google/gemma-4-31B-it-assistant",
 }
 
 REGISTRY: dict[str, ModelEntry] = {


### PR DESCRIPTION
**#2 of the Gemma-4 MTP drafter work** (the drafter is validated; this points the publish pipeline at it).

`MTP_DRAFTER_BASE` in `model_registry.py` pointed at **placeholder repos** (`google/gemma-4-E2B-mtp` etc. — these don't exist). The real drafter is the official MTP head Google ships with the **`-it-assistant`** checkpoint of each Gemma 4 size (a `gemma4-assistant`-arch 4-block NextN drafter), loaded via `-md <drafter>.gguf --spec-type draft-mtp` after upstream `convert_hf_to_gguf.py`.

- Repoints the per-tier map → `google/gemma-4-{E2B,E4B,12B,31B}-it-assistant` (all verified HTTP 200 on HF).
- Notes the ready GGUF conversions: `amaranus/Gemma-4-{E2B,E4B}-it-qat-assistant-MTP-Q8_0-GGUF`, `{cortexist,Janvitos}/gemma-4-12B-it-assistant-MTP-GGUF`.
- **No H200 / distillation needed** — the trained weights already exist.

**Validated:** the E2B drafter gives a **1.29× decode speedup** against the eliza-1-2b target on Apple M4 Max Metal (via upstream llama.cpp; see the [port plan](https://github.com/elizaOS/eliza/blob/develop/plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md)).

This makes the publish pipeline stage the real, validated drafter — the bundle is release-shaped the moment the fork gains `gemma4-assistant` arch support (the port is in flight in #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)