### PR TITLE
fix(ui): pin explicit en-US locale on render-path toLocale* calls (determinism gate green)

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -297,7 +297,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
   }
 
   const chartData = analytics.map((item) => ({
-    date: new Date(item.period_start).toLocaleDateString(),
+    date: new Date(item.period_start).toLocaleDateString("en-US"),
     requests: item.total_requests,
     users: item.unique_users,
     newUsers: item.new_users,
@@ -384,12 +384,12 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
             <div className="grid gap-3 grid-cols-1 sm:grid-cols-3">
               <DashboardStatCard
                 label="Total Requests"
-                value={totalStats.totalRequests?.toLocaleString() || "0"}
+                value={totalStats.totalRequests?.toLocaleString("en-US") || "0"}
                 icon={<Activity className="h-5 w-5 text-purple-400" />}
               />
               <DashboardStatCard
                 label="Total Users"
-                value={totalStats.totalUsers?.toLocaleString() || "0"}
+                value={totalStats.totalUsers?.toLocaleString("en-US") || "0"}
                 icon={<Users className="h-5 w-5 text-white/70" />}
               />
               <DashboardStatCard
@@ -498,7 +498,9 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <div className="grid gap-3 grid-cols-2 sm:grid-cols-5">
                 <MiniStatCard
                   label="Page Views"
-                  value={(requestStats.byType?.pageview || 0).toLocaleString()}
+                  value={(requestStats.byType?.pageview || 0).toLocaleString(
+                    "en-US",
+                  )}
                   color="text-green-400"
                 />
                 <MiniStatCard
@@ -506,12 +508,12 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   value={(
                     requestStats.totalRequests -
                     (requestStats.byType?.pageview || 0)
-                  ).toLocaleString()}
+                  ).toLocaleString("en-US")}
                   color="text-[var(--brand-orange)]"
                 />
                 <MiniStatCard
                   label="Unique Visitors"
-                  value={requestStats.uniqueIps.toLocaleString()}
+                  value={requestStats.uniqueIps.toLocaleString("en-US")}
                   color="text-white"
                 />
                 <MiniStatCard
@@ -565,7 +567,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                               style={{ backgroundColor: item.color }}
                             />
                             <span className="text-xs text-neutral-300">
-                              {item.name}: {item.value.toLocaleString()}
+                              {item.name}: {item.value.toLocaleString("en-US")}
                             </span>
                           </div>
                         ))}
@@ -611,7 +613,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                                 />
                               </div>
                               <span className="text-xs text-neutral-500 w-12 text-right">
-                                {count.toLocaleString()}
+                                {count.toLocaleString("en-US")}
                               </span>
                             </div>
                           </div>
@@ -647,14 +649,14 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 <div className="grid gap-3 grid-cols-1 sm:grid-cols-3">
                   <DashboardStatCard
                     label="Unique IPs"
-                    value={requestStats.uniqueIps.toLocaleString()}
+                    value={requestStats.uniqueIps.toLocaleString("en-US")}
                     icon={
                       <Globe className="h-5 w-5 text-[var(--brand-orange)]" />
                     }
                   />
                   <DashboardStatCard
                     label="Unique Users"
-                    value={requestStats.uniqueUsers.toLocaleString()}
+                    value={requestStats.uniqueUsers.toLocaleString("en-US")}
                     icon={<Users className="h-5 w-5 text-white/70" />}
                   />
                   <DashboardStatCard
@@ -721,7 +723,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                               </div>
                             </td>
                             <td className="py-2 px-3 text-right text-white text-xs">
-                              {visitor.requestCount.toLocaleString()}
+                              {visitor.requestCount.toLocaleString("en-US")}
                             </td>
                             <td className="py-2 px-3 text-right text-neutral-500 text-xs">
                               {formatDistanceToNow(new Date(visitor.lastSeen), {
@@ -751,7 +753,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
             <h3 className="text-sm font-medium text-white">Request Logs</h3>
             <div className="flex items-center gap-2">
               <span className="text-xs text-neutral-500">
-                {logsTotal.toLocaleString()} total
+                {logsTotal.toLocaleString("en-US")} total
               </span>
               <Button
                 variant="ghost"

--- a/packages/ui/src/cloud/applications/components/app-domains.tsx
+++ b/packages/ui/src/cloud/applications/components/app-domains.tsx
@@ -952,7 +952,7 @@ function DnsConfigPanel({
           {lastChecked && (
             <span className="text-xs text-neutral-500 hidden sm:block">
               {t("cloud.appDomains.lastChecked", {
-                time: lastChecked.toLocaleTimeString(),
+                time: lastChecked.toLocaleTimeString("en-US"),
                 defaultValue: "Last checked: {{time}}",
               })}
             </span>

--- a/packages/ui/src/cloud/applications/components/app-overview.tsx
+++ b/packages/ui/src/cloud/applications/components/app-overview.tsx
@@ -255,7 +255,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
           label={t("cloud.apps.overview.stat.totalUsers", {
             defaultValue: "Total Users",
           })}
-          value={app.total_users?.toLocaleString() || "0"}
+          value={app.total_users?.toLocaleString("en-US") || "0"}
           icon={<Shield className="h-5 w-5" />}
           accent="violet"
         />
@@ -263,7 +263,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
           label={t("cloud.apps.overview.stat.totalRequests", {
             defaultValue: "Total Requests",
           })}
-          value={app.total_requests?.toLocaleString() || "0"}
+          value={app.total_requests?.toLocaleString("en-US") || "0"}
           icon={<TrendingUp className="h-5 w-5" />}
           accent="orange"
         />

--- a/packages/ui/src/components/connectors/XRPairingPanel.tsx
+++ b/packages/ui/src/components/connectors/XRPairingPanel.tsx
@@ -86,7 +86,7 @@ export function XRPairingPanel() {
             <li key={c.id} className="text-xs text-muted">
               <span className="font-medium text-txt">{c.deviceType}</span>
               {t("xrpairing.connectedAt", {
-                time: new Date(c.connectedAt).toLocaleTimeString(),
+                time: new Date(c.connectedAt).toLocaleTimeString("en-US"),
                 defaultValue: " — connected {{time}}",
               })}
             </li>

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -1747,7 +1747,7 @@ export function MessagesPageView() {
                     </span>
                     <span>
                       {messageTypeLabel(message.type)} ·{" "}
-                      {new Date(message.date).toLocaleString()}
+                      {new Date(message.date).toLocaleString("en-US")}
                     </span>
                   </div>
                   <p className="mt-2 whitespace-pre-wrap text-txt">


### PR DESCRIPTION
## Summary

The `audit:ui-determinism` CI gate was **FAILING** with **17 NEW** render-time nondeterminism occurrences — bare `toLocaleString()` / `toLocaleDateString()` / `toLocaleTimeString()` calls with **no explicit locale**, all in component/hook **render paths**. Locale-defaulted formatting renders differently per environment, which makes screenshots and snapshots flaky.

These were ~5-day-old pre-existing debt: the audit baseline went stale after the cloud→app collapse, so the locale-defaulted calls that came over with the ported `cloud/applications/*` components surfaced as new violations. Not from any single PR.

## Fix

Pin the literal `"en-US"` as the first arg on every flagged **render-path** call — matching the repo's existing convention (e.g. `calendar.tsx`, `DatabaseView.tsx`, `chart.tsx`). Displayed precision/format is unchanged; only the locale is made explicit. The baseline is **not** touched (these are real flaky-screenshot risks, not false positives). Non-render occurrences (module-level helpers, effect/handler usage) are correctly left alone.

### Files (17 occurrences)
| File | Count |
|---|---|
| `packages/ui/src/cloud/applications/components/app-analytics.tsx` | 12 |
| `packages/ui/src/cloud/applications/components/app-overview.tsx` | 2 |
| `packages/ui/src/cloud/applications/components/app-domains.tsx` | 1 |
| `packages/ui/src/components/connectors/XRPairingPanel.tsx` | 1 |
| `packages/ui/src/components/pages/ElizaOsAppsView.tsx` | 1 |

## Verification
- `bun run audit:ui-determinism` → **OK PASSED** (exit 0; render-time count 68 → 51).
- `bun run --cwd packages/ui typecheck` → **clean** (exit 0).
- `biome check` on all 5 touched files → **clean** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)