### PR TITLE
test(orchestrator): cover iOS/AOSP terminal-unsupported stub reason mapping (#9146)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
@@ -5,14 +5,22 @@
  * touching ACP / workspace state.
  */
 
+import type { Content } from "@elizaos/core";
 import {
   _resetBuildVariantForTests,
   getBuildVariant,
   isLocalCodeExecutionAllowed,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { tasksSandboxStubAction } from "../actions/sandbox-stub.js";
+import {
+  createTerminalUnsupportedTasksAction,
+  tasksSandboxStubAction,
+} from "../actions/sandbox-stub.js";
 import { createAgentOrchestratorPlugin } from "../index.js";
+import type {
+  OrchestratorTerminalSupport,
+  OrchestratorUnsupportedReason,
+} from "../services/terminal-capabilities.js";
 
 // Keep the slow timeout because importing @elizaos/core from this plugin can
 // still exceed Vitest's default timeout on a cold cache.
@@ -127,4 +135,76 @@ describe("agent-orchestrator sandbox gating", () => {
     const data = result?.data as { reason?: string } | undefined;
     expect(data?.reason).toBe("STORE_BUILD_BLOCKED");
   });
+});
+
+describe("createTerminalUnsupportedTasksAction reason mapping", () => {
+  // Each unsupported terminal-support reason must surface a specific,
+  // user-facing stub reason code. The default (no reason) collapses to the
+  // generic TERMINAL_UNSUPPORTED. Covers the iOS (#9146 AC: "iOS/store
+  // surfaces the stub MOBILE_TERMINAL_UNSUPPORTED cleanly") and AOSP
+  // non-local-yolo paths that the full-plugin gating test does not exercise.
+  const cases: ReadonlyArray<{
+    label: string;
+    reason: OrchestratorUnsupportedReason | undefined;
+    expectedReason: string;
+  }> = [
+    {
+      label: "iOS / vanilla mobile",
+      reason: "vanilla_mobile",
+      expectedReason: "MOBILE_TERMINAL_UNSUPPORTED",
+    },
+    {
+      label: "Android not in local-yolo mode",
+      reason: "not_local_yolo",
+      expectedReason: "AOSP_TERMINAL_REQUIRES_LOCAL_YOLO",
+    },
+    {
+      label: "Android missing shell",
+      reason: "missing_shell",
+      expectedReason: "AOSP_TERMINAL_MISSING_SHELL",
+    },
+    {
+      label: "unknown / no reason",
+      reason: undefined,
+      expectedReason: "TERMINAL_UNSUPPORTED",
+    },
+  ];
+
+  for (const { label, reason, expectedReason } of cases) {
+    it(`maps ${label} -> ${expectedReason}`, async () => {
+      const support: OrchestratorTerminalSupport = {
+        supported: false,
+        reason,
+        message: `terminal unsupported: ${expectedReason}`,
+      };
+
+      const action = createTerminalUnsupportedTasksAction(support);
+
+      expect(action.name).toBe("TASKS");
+      expect(action.suppressPostActionContinuation).toBe(true);
+      expect(await action.validate({} as never, {} as never, undefined)).toBe(
+        true,
+      );
+
+      let callbackContent: Content | undefined;
+      const result = await action.handler(
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        async (response: Content) => {
+          callbackContent = response;
+          return [];
+        },
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.text).toBe(support.message);
+      const data = result?.data as { reason?: string } | undefined;
+      expect(data?.reason).toBe(expectedReason);
+
+      expect(callbackContent?.text).toBe(support.message);
+      expect(callbackContent?.actions).toEqual(["TASKS"]);
+    });
+  }
 });


### PR DESCRIPTION
## What

Adds a small, focused unit test covering `createTerminalUnsupportedTasksAction(support)` in `plugins/plugin-agent-orchestrator/src/actions/sandbox-stub.ts`, which maps an `OrchestratorTerminalSupport.reason` to a `TASKS` stub action with a specific `data.reason` code.

## Why

The existing `src/__tests__/sandbox-gating.test.ts` only covered `STORE_BUILD_BLOCKED` and (via the full plugin path) `AOSP_TERMINAL_MISSING_SHELL`. Two reason mappings had **no** direct coverage:

- The iOS path — `vanilla_mobile -> MOBILE_TERMINAL_UNSUPPORTED` (the literal #9146 AC: "iOS/store surfaces the stub MOBILE_TERMINAL_UNSUPPORTED cleanly").
- The Android non-local-yolo path — `not_local_yolo -> AOSP_TERMINAL_REQUIRES_LOCAL_YOLO`.

This is pure, synchronous, device-free logic, so it's directly unit-testable.

## What the test asserts

A new data-driven `describe` block covers the full reason mapping:

| `support.reason` | expected `data.reason` |
| --- | --- |
| `vanilla_mobile` | `MOBILE_TERMINAL_UNSUPPORTED` |
| `not_local_yolo` | `AOSP_TERMINAL_REQUIRES_LOCAL_YOLO` |
| `missing_shell` | `AOSP_TERMINAL_MISSING_SHELL` |
| `undefined` (unknown / no reason) | `TERMINAL_UNSUPPORTED` |

For each reason it builds a fake `OrchestratorTerminalSupport` (`{ supported: false, reason, message }`), calls the factory, and asserts:

- `action.name === 'TASKS'`
- `action.suppressPostActionContinuation === true`
- `await action.validate(...) === true`
- `await action.handler(...)` → `result.success === false`, `result.data.reason === <expected code>`, `result.text === support.message`
- the `HandlerCallback` received `{ text: support.message, actions: ['TASKS'] }`

## Scope

Test-only. No source changes. Strong types, no `any`/`unknown` (handler/callback signatures matched against `@elizaos/core` types). `OrchestratorUnsupportedReason | undefined` is used to drive the default-branch case without weakening types.

## Verification

```
$ bun x vitest run plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts

 ✓ ... createTerminalUnsupportedTasksAction reason mapping > maps iOS / vanilla mobile -> MOBILE_TERMINAL_UNSUPPORTED
 ✓ ... > maps Android not in local-yolo mode -> AOSP_TERMINAL_REQUIRES_LOCAL_YOLO
 ✓ ... > maps Android missing shell -> AOSP_TERMINAL_MISSING_SHELL
 ✓ ... > maps unknown / no reason -> TERMINAL_UNSUPPORTED

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Package typecheck (`tsgo --noEmit -p tsconfig.json`): exit 0, no errors.

Part of #9146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)