### PR TITLE
test(lifeops): make schedule_plan/reminder_dispatch capability checks load-bearing (#8795)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
@@ -18,22 +18,38 @@ function assertApiBody(options: {
  * Behavior scenario for the `reminder_dispatch` LifeOps capability.
  *
  * When a scheduled reminder fires, the reminders mixin
- * (`buildReminderDispatchPrompt` in
+ * (`renderReminderBody` / `buildReminderDispatchPrompt` in
  * `plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts`)
- * composes the natural-language nudge the owner actually receives. Its
- * instruction body is the GEPA-optimizable `reminder_dispatch` prompt:
+ * composes the natural-language nudge the owner receives. Its instruction body
+ * is the GEPA-optimizable `reminder_dispatch` prompt:
  * `REMINDER_DISPATCH_INSTRUCTIONS` is the wired baseline that
- * `resolveOptimizedPromptForRuntime` swaps for a registered
- * `reminder_dispatch` artifact.
+ * `resolveOptimizedPromptForRuntime(..., "reminder_dispatch", ...)` swaps for a
+ * registered `reminder_dispatch` artifact.
  *
- * Unlike a chat-turn planner capability, `reminder_dispatch` runs on the
- * delivery path, so this scenario seeds a due reminder definition and drives
- * `POST /api/lifeops/reminders/process` to fire it. The delivery assertion
- * (`delivered` on the `in_app` channel) confirms the dispatch path — and the
- * prompt that authors the reminder text — executed, so a regression in the
- * wired prompt or the firing pipeline surfaces as a failing scenario. It
- * mirrors `reminder.lifecycle.dismiss` but is scoped to the reminder-dispatch
- * capability.
+ * Unlike a chat-turn planner capability, reminder dispatch runs on the delivery
+ * path, so this scenario seeds a due reminder definition and drives
+ * `POST /api/lifeops/reminders/process` to fire it.
+ *
+ * What this scenario proves (machine-enforced):
+ *   - The firing pipeline runs and delivers a reminder on the `in_app` channel.
+ *     The executor enforces `expectedStatus` on both api turns and runs
+ *     `assertResponse(status, body)` on the process turn
+ *     (`packages/scenario-runner/src/executor.ts`); the body must contain
+ *     `"delivered"` and `"in_app"` or the turn fails. So a regression that
+ *     stops the reminder from being scheduled, matched, or delivered surfaces
+ *     as a failing scenario.
+ *
+ * What this scenario does NOT prove:
+ *   - It does not grade the LLM-authored reminder text. `renderReminderBody`
+ *     builds a static `fallback` body via `buildReminderBody` first and only
+ *     overlays the `reminder_dispatch` model output on top; on any model
+ *     failure (or a non-string response, or no `useModel`) it returns the
+ *     static fallback. Delivery therefore succeeds whether or not the
+ *     `reminder_dispatch` prompt produced usable text — this scenario asserts
+ *     the dispatch path reached delivery, not the quality of the authored copy.
+ *
+ * It mirrors `reminder.lifecycle.dismiss` but is scoped to the
+ * reminder-dispatch capability.
  */
 export default scenario({
   lane: "live-only",

--- a/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
@@ -11,23 +11,44 @@ import { scenario } from "@elizaos/scenario-runner/schema";
  * cancel / list_active / list_proposals / null) plus `shouldAct`. Its
  * instruction body is the GEPA-optimizable `schedule_plan` prompt:
  * `SCHEDULE_PLAN_INSTRUCTIONS` is the wired baseline that
- * `resolveOptimizedPromptForRuntime` swaps for a registered `schedule_plan`
- * artifact, and the model call is tagged with `purpose: "schedule_plan"` for
- * trajectory capture.
+ * `resolveOptimizedPromptForRuntime(..., "schedule_plan", ...)` swaps for a
+ * registered `schedule_plan` artifact, and the model call is tagged with
+ * `purpose: "schedule_plan"` for trajectory capture.
  *
  * Negotiation intents ("set up a meeting", "cancel that negotiation",
  * "list my open negotiations") route to the `PERSONAL_ASSISTANT` umbrella
- * action with `action=scheduling` (see `runSchedulingNegotiationHandler` in
- * `owner-surfaces.ts`). This scenario asserts each request reaches the
- * `PERSONAL_ASSISTANT` action and adds a final selected-action check so a
- * regression in the wired prompt or the routing surfaces as a failing
- * scenario. It mirrors `calendar-extract-capability` /
- * `inbox-triage-capability` but is scoped to the schedule-plan capability.
+ * action with `action=scheduling` (`PERSONAL_ASSISTANT_ACTIONS` in
+ * `owner-surfaces.ts`). Only `action=scheduling` reaches
+ * `runSchedulingNegotiationHandler`, which is the sole caller of
+ * `buildSchedulingPlanPrompt`; the sibling subactions `action=book_travel`
+ * and `action=sign_document` never invoke the `schedule_plan` prompt.
+ *
+ * What this scenario proves (machine-enforced):
+ *   - In at least one turn the router selects `PERSONAL_ASSISTANT` *with the
+ *     `scheduling` subaction*. The `selectedActionArguments` final check is
+ *     read by the executor
+ *     (`packages/scenario-runner/src/final-checks/index.ts`): it filters the
+ *     captured actions to `PERSONAL_ASSISTANT` and requires `"scheduling"` to
+ *     appear in the captured action options (`JSON.stringify(parameters)`).
+ *     Because only `action=scheduling` reaches `buildSchedulingPlanPrompt`,
+ *     this is the *load-bearing* assertion: it fails unless the schedule_plan
+ *     prompt path actually runs, so — unlike a bare `selectedAction` check —
+ *     it cannot be satisfied by a `book_travel` / `sign_document` route to the
+ *     same umbrella action.
+ *
+ * What this scenario does NOT prove:
+ *   - It does not grade the structured plan the model returns, nor the text of
+ *     the `schedule_plan` prompt output. It proves the prompt path runs, not
+ *     that the LLM authored a high-quality negotiation plan.
+ *
+ * It mirrors `calendar-extract-capability` / `inbox-triage-capability` but is
+ * scoped to the schedule-plan capability.
  */
 export default scenario({
   lane: "live-only",
   id: "schedule-plan-capability",
-  title: "Schedule plan capability routes negotiation requests to PERSONAL_ASSISTANT",
+  title:
+    "Schedule plan capability routes a negotiation request to PERSONAL_ASSISTANT scheduling",
   domain: "scheduling",
   tags: ["lifeops", "scheduling", "schedule_plan", "llm-eval"],
   isolation: "per-scenario",
@@ -46,29 +67,33 @@ export default scenario({
       kind: "message",
       name: "plan-start-negotiation",
       text: "Start a scheduling negotiation with Priya to find a time for our quarterly review.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
     {
       kind: "message",
       name: "plan-list-negotiations",
       text: "List my open scheduling negotiations.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
     {
       kind: "message",
       name: "plan-cancel-negotiation",
       text: "Cancel the scheduling negotiation for the quarterly review.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
   ],
   finalChecks: [
+    // Load-bearing assertion. `selectedActionArguments` is consumed by the
+    // executor (packages/scenario-runner/src/final-checks/index.ts:448): it
+    // filters captured actions to PERSONAL_ASSISTANT and requires the
+    // `scheduling` routing token to appear in the captured action options
+    // (`JSON.stringify(parameters)`). Without `action=scheduling` the
+    // `schedule_plan` prompt is never reached, so this fails — unlike a bare
+    // `selectedAction` check it cannot be satisfied by a book_travel /
+    // sign_document route to the same umbrella action. It fires when any one
+    // of the turns above selects the scheduling subaction, not all three.
     {
-      type: "selectedAction",
-      name: "personal assistant action selected for every schedule-plan turn",
+      type: "selectedActionArguments",
+      name: "personal-assistant routed to the scheduling subaction (exercises schedule_plan prompt path)",
       actionName: "PERSONAL_ASSISTANT",
+      includesAll: ["scheduling"],
     },
   ],
 });


### PR DESCRIPTION
Follow-up to #9252 (already merged) addressing adversarial review: the two LifeOps capability scenarios added there did not have load-bearing assertions. This PR makes them real. No production code changes — only the two `.scenario.ts` files.

### Why #9252's assertions were not load-bearing

1. **`plannerIncludesAll` / `plannerExcludes` were dead fields.** They appear nowhere in the scenario-runner executor or `final-checks/index.ts`. The `ScenarioTurn` type only accepts them via its `[key: string]: unknown` index signature, so they type-checked but evaluated nothing.
2. **`selectedAction: PERSONAL_ASSISTANT` was too weak.** It is a single `ctx.actionsCalled.find()` (final-checks/index.ts:433) that passes if the action is selected in any one turn and does **not** inspect arguments. `PERSONAL_ASSISTANT` is an umbrella over `action=book_travel|scheduling|sign_document` (`PERSONAL_ASSISTANT_ACTIONS`, owner-surfaces.ts), so the check could pass via an unrelated subaction **without** ever exercising `buildSchedulingPlanPrompt` / the `schedule_plan` prompt.
3. **Docstrings overclaimed** (said the check fires "for every turn"; implied prompt *output* was graded when only the *path* is proven).

### What changed

**`schedule-plan-capability.scenario.ts`**
- Removed the dead `plannerIncludesAll` / `plannerExcludes` per-turn fields.
- Replaced the bare `selectedAction` final check with a **`selectedActionArguments`** check (`actionName: PERSONAL_ASSISTANT`, `includesAll: ["scheduling"]`). This handler **is** read by the executor (final-checks/index.ts:448): it filters captured actions to `PERSONAL_ASSISTANT` and matches `"scheduling"` against the captured action options (`JSON.stringify(parameters)`). The interceptor captures the handler's `options` arg as `parameters` (interceptor.ts:354), and the umbrella reads `options.action === "scheduling"` to route into `runSchedulingNegotiationHandler` — the **sole** caller of `buildSchedulingPlanPrompt` → `resolveOptimizedPromptForRuntime(..., "schedule_plan", ...)`. So the check now fails unless the `schedule_plan` prompt path actually runs; a `book_travel`/`sign_document` route can no longer satisfy it.
- Rewrote the docstring to state precisely what is machine-enforced (the scheduling prompt *path* runs, in at least one turn) and what is not (the prompt *output* is not graded).

**`reminder-dispatch-capability.scenario.ts`**
- Kept the existing api-turn assertions, which are already load-bearing: the executor enforces `expectedStatus` (201/200) and runs `assertResponse(status, body)` on the process turn, failing it unless the body contains `delivered` and `in_app` (executor.ts:1411-1432).
- Made the docstring honest: it proves the dispatch pipeline reaches `in_app` delivery, but it does **not** grade the LLM-authored reminder text, because `renderReminderBody` builds a static `buildReminderBody` fallback first and returns it on any model failure / non-string response (service-mixin-reminders.ts:1365-1418).

### Load-bearing assertion (the headline)

`schedule-plan-capability` now fails unless the router selects `PERSONAL_ASSISTANT` with `action=scheduling` (the only path into the `schedule_plan` prompt), via the executor-read `selectedActionArguments` final check.

### Verification

- `bun packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios` — both `schedule-plan-capability` and `reminder-dispatch-capability` list, exit 0.
- Standalone `tsc --strict` of both `.scenario.ts` files against `@elizaos/scenario-runner/schema` — clean (exit 0).
- Branch rebased cleanly onto `origin/develop`; diff is exactly the two scenario files.

These scenarios are `lane: "live-only"` (they need a live LLM to route), so they run in the live-only lane, not the keyless PR-deterministic lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)