### PR TITLE
feat(ui): Springboard replaces the view catalog + image tiles + interaction tests

### DIFF
--- a/packages/ui/src/components/pages/Springboard.test.tsx
+++ b/packages/ui/src/components/pages/Springboard.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -23,6 +24,10 @@ function entry(id: string, label: string): ViewEntry {
     kind: "view",
     viewKind: "release",
   } as ViewEntry;
+}
+
+function imageEntry(id: string, label: string, imageUrl: string): ViewEntry {
+  return { ...entry(id, label), imageUrl };
 }
 
 const FEW = [entry("chat", "Chat"), entry("settings", "Settings")];
@@ -99,6 +104,145 @@ describe("Springboard", () => {
       <Springboard entries={[entry("chat", "Chat")]} onLaunch={() => {}} />,
     );
     expect(screen.queryByTestId("springboard-tile-settings")).toBeNull();
+  });
+
+  it("appends a newly-available view as a tile on re-render", () => {
+    const { rerender } = render(
+      <Springboard entries={[entry("chat", "Chat")]} onLaunch={() => {}} />,
+    );
+    expect(screen.queryByTestId("springboard-tile-notes")).toBeNull();
+    rerender(
+      <Springboard
+        entries={[entry("chat", "Chat"), entry("notes", "Notes")]}
+        onLaunch={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("springboard-tile-notes")).toBeTruthy();
+  });
+});
+
+describe("Springboard image tiles", () => {
+  it("renders the view's hero image as the tile when imageUrl is set", () => {
+    render(
+      <Springboard
+        entries={[imageEntry("notes", "Notes", "/api/views/notes/hero")]}
+        onLaunch={() => {}}
+      />,
+    );
+    const img = screen.getByTestId("springboard-image-notes");
+    expect(img.getAttribute("src")).toBe("/api/views/notes/hero");
+    // The launch button is still labelled for a11y + tap.
+    expect(screen.getByRole("button", { name: "Notes" })).toBeTruthy();
+  });
+
+  it("falls back to the icon glyph when the hero image fails to load", () => {
+    const { container } = render(
+      <Springboard
+        entries={[imageEntry("notes", "Notes", "/api/views/notes/hero")]}
+        onLaunch={() => {}}
+      />,
+    );
+    const img = screen.getByTestId("springboard-image-notes");
+    act(() => {
+      fireEvent.error(img);
+    });
+    // Image is gone; the Lucide fallback glyph renders so the tile is never blank.
+    expect(screen.queryByTestId("springboard-image-notes")).toBeNull();
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders the icon glyph (no image) when imageUrl is absent", () => {
+    const { container } = render(
+      <Springboard entries={[entry("notes", "Notes")]} onLaunch={() => {}} />,
+    );
+    expect(screen.queryByTestId("springboard-image-notes")).toBeNull();
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});
+
+describe("Springboard long-press to edit", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("enters edit mode after a long press on a tile", () => {
+    vi.useFakeTimers();
+    render(<Springboard entries={FEW} onLaunch={() => {}} />);
+    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Chat" }));
+    act(() => {
+      vi.advanceTimersByTime(450);
+    });
+
+    // Edit mode is on: the toggle now reads "Done" and per-tile pin affordances
+    // appear.
+    expect(screen.getByRole("button", { name: "Done" })).toBeTruthy();
+    expect(screen.getByTestId("springboard-fav-chat")).toBeTruthy();
+  });
+
+  it("does not enter edit mode when the press is released early", () => {
+    vi.useFakeTimers();
+    render(<Springboard entries={FEW} onLaunch={() => {}} />);
+    const tile = screen.getByRole("button", { name: "Chat" });
+    fireEvent.pointerDown(tile);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    fireEvent.pointerUp(tile);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    // Still resting: toggle reads "Edit", no pin affordances.
+    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+    expect(screen.queryByTestId("springboard-fav-chat")).toBeNull();
+  });
+});
+
+describe("Springboard dock favorites (local, uncontrolled)", () => {
+  // None of these ids are in DEFAULT_SPRINGBOARD_FAVORITES, so the seeded dock
+  // reconciles to empty and each favorite is a genuine add.
+  const MANY = ["a", "b", "c", "d", "e"].map((id) =>
+    entry(id, id.toUpperCase()),
+  );
+
+  it("unpins a favorited view from the dock", () => {
+    // `notes` and `files` are not default-dock ids (#9144), so the seeded dock
+    // reconciles to empty and the dock only exists once we pin `notes`.
+    render(
+      <Springboard
+        entries={[entry("notes", "Notes"), entry("files", "Files")]}
+        onLaunch={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByTestId("springboard-fav-notes"));
+    expect(
+      within(screen.getByTestId("springboard-dock")).getByText("Notes"),
+    ).toBeTruthy();
+
+    // Toggle it off again → the dock empties and unmounts.
+    fireEvent.click(screen.getByTestId("springboard-fav-notes"));
+    expect(screen.queryByTestId("springboard-dock")).toBeNull();
+    const stored = JSON.parse(
+      window.localStorage.getItem(SPRINGBOARD_STORAGE_KEY) ?? "{}",
+    );
+    expect(stored.favorites).not.toContain("notes");
+  });
+
+  it("evicts the oldest favorite when the dock is full", () => {
+    render(<Springboard entries={MANY} onLaunch={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    for (const id of ["a", "b", "c", "d", "e"]) {
+      fireEvent.click(screen.getByTestId(`springboard-fav-${id}`));
+    }
+    // Dock caps at 4 → the first-added ("A") is evicted, B–E remain.
+    const dock = within(screen.getByTestId("springboard-dock"));
+    expect(dock.queryByText("A")).toBeNull();
+    expect(dock.getByText("B")).toBeTruthy();
+    expect(dock.getByText("E")).toBeTruthy();
+    const stored = JSON.parse(
+      window.localStorage.getItem(SPRINGBOARD_STORAGE_KEY) ?? "{}",
+    );
+    expect(stored.favorites).toEqual(["b", "c", "d", "e"]);
   });
 });
 

--- a/packages/ui/src/components/pages/Springboard.tsx
+++ b/packages/ui/src/components/pages/Springboard.tsx
@@ -69,6 +69,11 @@ function IconTile({
   onLongPress,
 }: IconTileProps) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Every view shows its hero image (the endpoint returns a real image or a
+  // branded generated SVG). Fall back to the Lucide icon only if the image fails
+  // to load, so a tile is never blank.
+  const [imgFailed, setImgFailed] = useState(false);
+  const tileImage = imgFailed ? undefined : entry.imageUrl;
 
   const clear = () => {
     if (timer.current) {
@@ -96,18 +101,31 @@ function IconTile({
           onPointerUp={clear}
           onPointerLeave={clear}
           className={cn(
-            "grid h-16 w-16 place-items-center rounded-2xl",
-            "bg-bg-accent/60 text-foreground backdrop-blur-xl transition-colors",
-            "hover:bg-bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+            "h-16 w-16 overflow-hidden rounded-2xl transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+            tileImage
+              ? "bg-bg-accent/40"
+              : "grid place-items-center bg-bg-accent/60 text-foreground backdrop-blur-xl hover:bg-bg-accent",
             editing && "animate-pulse",
           )}
         >
-          <ViewIcon
-            icon={entry.icon}
-            label={entry.label}
-            id={entry.id}
-            className="h-7 w-7"
-          />
+          {tileImage ? (
+            <img
+              src={tileImage}
+              alt=""
+              draggable={false}
+              onError={() => setImgFailed(true)}
+              className="h-full w-full object-cover"
+              data-testid={`springboard-image-${entry.id}`}
+            />
+          ) : (
+            <ViewIcon
+              icon={entry.icon}
+              label={entry.label}
+              id={entry.id}
+              className="h-7 w-7"
+            />
+          )}
         </button>
         {editing ? (
           <button

--- a/packages/ui/src/components/pages/ViewCatalog.tsx
+++ b/packages/ui/src/components/pages/ViewCatalog.tsx
@@ -12,11 +12,8 @@ import {
   ArrowDownAZ,
   Clock3,
   type LucideIcon,
-  Pencil,
-  Pin,
   Plus,
   Sparkles,
-  Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -43,11 +40,7 @@ import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useIsDeveloperMode } from "../../state/useDeveloperMode";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
-import {
-  readRecentViewIds,
-  recordRecentViewId,
-  TOP_VIEW_LIMIT,
-} from "../../view-recents";
+import { readRecentViewIds, recordRecentViewId } from "../../view-recents";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { ChatSearchHint } from "../composites/chat-search-hint";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -157,10 +150,6 @@ function isVisibleCatalogView(
   return true;
 }
 
-function viewCatalogKey(view: Pick<ViewRegistryEntry, "id" | "viewType">) {
-  return `${view.viewType ?? "gui"}:${view.id}`;
-}
-
 function compareLabels(left: { label: string }, right: { label: string }) {
   return left.label.localeCompare(right.label, undefined, {
     numeric: true,
@@ -226,209 +215,6 @@ function SortControls({
         );
       })}
     </fieldset>
-  );
-}
-
-function ViewCardPinButton({
-  view,
-  onPin,
-}: {
-  view: ViewRegistryEntry;
-  onPin: (view: ViewRegistryEntry) => void;
-}) {
-  const { t } = useTranslation();
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `view-card-pin-${view.id}`,
-    role: "button",
-    label: t("viewmanager.card.pinAria", {
-      label: view.label,
-      defaultValue: "Pin {{label}} as desktop tab",
-    }),
-    group: "view-cards",
-    description: `Pin the ${view.label} view as a desktop tab`,
-    onActivate: () => onPin(view),
-  });
-  return (
-    <button
-      ref={ref}
-      type="button"
-      title={t("viewmanager.card.pinTitle", {
-        defaultValue: "Pin as desktop tab",
-      })}
-      onClick={(e) => {
-        e.stopPropagation();
-        onPin(view);
-      }}
-      className="flex h-6 w-6 items-center justify-center rounded-md bg-card/80 text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      aria-label={t("viewmanager.card.pinAria", {
-        label: view.label,
-        defaultValue: "Pin {{label}} as desktop tab",
-      })}
-      {...agentProps}
-    >
-      <Pin className="h-3 w-3" />
-    </button>
-  );
-}
-
-function ViewCardEditButton({
-  view,
-  onEdit,
-}: {
-  view: ViewRegistryEntry;
-  onEdit: (view: ViewRegistryEntry) => void;
-}) {
-  const { t } = useTranslation();
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `view-card-edit-${view.id}`,
-    role: "button",
-    label: t("viewmanager.card.editAria", {
-      label: view.label,
-      defaultValue: "Edit {{label}}",
-    }),
-    group: "view-cards",
-    description: `Edit the ${view.label} dynamic view`,
-    onActivate: () => onEdit(view),
-  });
-  return (
-    <button
-      ref={ref}
-      type="button"
-      title={t("viewmanager.card.editTitle", {
-        defaultValue: "Edit dynamic view",
-      })}
-      onClick={(e) => {
-        e.stopPropagation();
-        onEdit(view);
-      }}
-      className="flex h-6 w-6 items-center justify-center rounded-md bg-card/80 text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      aria-label={t("viewmanager.card.editAria", {
-        label: view.label,
-        defaultValue: "Edit {{label}}",
-      })}
-      {...agentProps}
-    >
-      <Pencil className="h-3 w-3" />
-    </button>
-  );
-}
-
-function ViewCardDeleteButton({
-  view,
-  onDelete,
-}: {
-  view: ViewRegistryEntry;
-  onDelete: (view: ViewRegistryEntry) => void;
-}) {
-  const { t } = useTranslation();
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `view-card-delete-${view.id}`,
-    role: "button",
-    label: t("viewmanager.card.deleteAria", {
-      label: view.label,
-      defaultValue: "Delete {{label}}",
-    }),
-    group: "view-cards",
-    description: `Delete the ${view.label} dynamic view`,
-    onActivate: () => onDelete(view),
-  });
-  return (
-    <button
-      ref={ref}
-      type="button"
-      title={t("viewmanager.card.deleteTitle", {
-        defaultValue: "Delete dynamic view",
-      })}
-      onClick={(e) => {
-        e.stopPropagation();
-        onDelete(view);
-      }}
-      className="flex h-6 w-6 items-center justify-center rounded-md bg-card/80 text-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      aria-label={t("viewmanager.card.deleteAria", {
-        label: view.label,
-        defaultValue: "Delete {{label}}",
-      })}
-      {...agentProps}
-    >
-      <Trash2 className="h-3 w-3" />
-    </button>
-  );
-}
-
-function ViewCardOpenButton({
-  view,
-  onClick,
-  children,
-}: {
-  view: ViewRegistryEntry;
-  onClick: (view: ViewRegistryEntry) => void;
-  children: React.ReactNode;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `view-card-open-${view.id}`,
-    role: "button",
-    label: view.label,
-    group: "view-cards",
-    description: view.description ?? `Open the ${view.label} view`,
-    onActivate: () => onClick(view),
-  });
-  return (
-    <button
-      ref={ref}
-      type="button"
-      onClick={() => onClick(view)}
-      className="w-full focus:outline-none"
-      {...agentProps}
-    >
-      {children}
-    </button>
-  );
-}
-
-/** A launcher tile: icon chip + label. No border, no description, no chips. */
-function ViewCard({
-  view,
-  onClick,
-  onPin,
-  onEdit,
-  onDelete,
-}: {
-  view: ViewRegistryEntry;
-  onClick: (view: ViewRegistryEntry) => void;
-  onPin?: (view: ViewRegistryEntry) => void;
-  onEdit?: (view: ViewRegistryEntry) => void;
-  onDelete?: (view: ViewRegistryEntry) => void;
-}) {
-  const isDesktop = isElectrobunRuntime();
-  const showPinButton = isDesktop && view.desktopTabEnabled !== false && onPin;
-  const showManagementButtons = Boolean(onEdit || onDelete);
-  const showHero = Boolean(view.hasHeroImage && view.heroImageUrl);
-
-  return (
-    <div className="group relative" data-testid={`view-card-${view.id}`}>
-      {(showPinButton || showManagementButtons) && (
-        <div className="absolute right-1.5 top-1.5 z-20 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-          {showPinButton && <ViewCardPinButton view={view} onPin={onPin} />}
-          {onEdit && <ViewCardEditButton view={view} onEdit={onEdit} />}
-          {onDelete && <ViewCardDeleteButton view={view} onDelete={onDelete} />}
-        </div>
-      )}
-
-      <ViewCardOpenButton view={view} onClick={onClick}>
-        <div className="flex flex-col items-center gap-2 rounded-2xl px-2 py-4 text-center transition-colors hover:bg-bg-accent/70">
-          <ViewVisual
-            id={view.id}
-            icon={view.icon}
-            label={view.label}
-            heroUrl={view.heroImageUrl}
-            showHero={showHero}
-          />
-          <span className="line-clamp-2 max-w-full text-xs font-medium leading-4 text-txt transition-colors group-hover:text-accent">
-            {view.label}
-          </span>
-        </div>
-      </ViewCardOpenButton>
-    </div>
   );
 }
 
@@ -535,43 +321,6 @@ function CatalogSection({
       <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
         {entries.map((entry) => (
           <CatalogGetCard key={entry.key} entry={entry} onGet={onGet} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ViewSection({
-  title,
-  views,
-  onViewClick,
-  onViewPin,
-  onViewEdit,
-  onViewDelete,
-  testId,
-}: {
-  title?: string;
-  views: ViewRegistryEntry[];
-  onViewClick: (view: ViewRegistryEntry) => void;
-  onViewPin: (view: ViewRegistryEntry) => void;
-  onViewEdit?: (view: ViewRegistryEntry) => void;
-  onViewDelete?: (view: ViewRegistryEntry) => void;
-  testId?: string;
-}) {
-  if (views.length === 0) return null;
-  return (
-    <div className="mb-7" data-testid={testId}>
-      {title ? <SectionLabel>{title}</SectionLabel> : null}
-      <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
-        {views.map((view) => (
-          <ViewCard
-            key={viewCatalogKey(view)}
-            view={view}
-            onClick={onViewClick}
-            onPin={onViewPin}
-            onEdit={onViewEdit}
-            onDelete={onViewDelete}
-          />
         ))}
       </div>
     </div>
@@ -768,52 +517,8 @@ export function ViewCatalog() {
     () => sortViewsForMode(visibleViews, sortMode, recentViewIds),
     [visibleViews, recentViewIds, sortMode],
   );
-  const topViews = useMemo(() => {
-    const byId = new Map(visibleViews.map((view) => [view.id, view]));
-    const ordered: ViewRegistryEntry[] = [];
-    for (const tab of desktopTabs) {
-      if (!tab.pinned) continue;
-      const view = byId.get(tab.viewId);
-      if (
-        view &&
-        !ordered.some(
-          (existing) => viewCatalogKey(existing) === viewCatalogKey(view),
-        )
-      ) {
-        ordered.push(view);
-      }
-    }
-    for (const id of recentViewIds) {
-      const view = byId.get(id);
-      if (
-        view &&
-        !ordered.some(
-          (existing) => viewCatalogKey(existing) === viewCatalogKey(view),
-        )
-      ) {
-        ordered.push(view);
-      }
-      if (ordered.length >= TOP_VIEW_LIMIT) break;
-    }
-    return ordered.slice(0, TOP_VIEW_LIMIT);
-  }, [desktopTabs, recentViewIds, visibleViews]);
-  const sortedTopViews = useMemo(
-    () => sortViewsForMode(topViews, sortMode, recentViewIds),
-    [recentViewIds, sortMode, topViews],
-  );
-
   const totalVisible = visibleViews.length;
   const hasQuery = query.trim().length > 0;
-  const topViewKeys = useMemo(
-    () => new Set(topViews.map((view) => viewCatalogKey(view))),
-    [topViews],
-  );
-  const sectionViews = useMemo(() => {
-    if (hasQuery) return sortedAllViews;
-    return sortedAllViews.filter(
-      (view) => !topViewKeys.has(viewCatalogKey(view)),
-    );
-  }, [hasQuery, sortedAllViews, topViewKeys]);
   const isSearching = searchLoading && hasQuery;
   const availableEntries = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -892,22 +597,6 @@ export function ViewCatalog() {
     } catch {
       // sandboxed — best effort navigation
     }
-  }
-
-  function handleViewPin(view: ViewRegistryEntry) {
-    // Dispatch a navigate event with action="pin-tab" so the App shell's
-    // eliza:navigate:view handler adds this view to the desktop tab bar.
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(
-      new CustomEvent("eliza:navigate:view", {
-        detail: {
-          viewId: view.id,
-          viewPath: view.path ?? `/apps/${view.id}`,
-          viewLabel: view.label,
-          action: "pin-tab",
-        },
-      }),
-    );
   }
 
   function fillManagementForm(view: ViewRegistryEntry) {
@@ -1124,68 +813,24 @@ export function ViewCatalog() {
             <ViewsLoadingSkeleton />
           ) : totalVisible === 0 && availableEntries.length === 0 ? (
             <ViewsEmptyState hasQuery={query.trim().length > 0} />
-          ) : hasQuery ? (
-            // Searching: keep the sectioned, semantic-search result list with
-            // pin/edit/delete card affordances.
-            <>
-              <ViewSection
-                testId="views-top-section"
-                title={
-                  sortedTopViews.length > 0
-                    ? t("viewmanager.section.quickAccess", {
-                        defaultValue: "Quick access",
-                      })
-                    : undefined
-                }
-                views={sortedTopViews}
-                onViewClick={handleViewClick}
-                onViewPin={handleViewPin}
-                onViewEdit={
-                  canManageDynamicViews ? fillManagementForm : undefined
-                }
-                onViewDelete={
-                  canManageDynamicViews ? handleDeleteView : undefined
-                }
-              />
-              <ViewSection
-                title={
-                  sortedTopViews.length > 0
-                    ? t("viewmanager.section.all", { defaultValue: "All" })
-                    : undefined
-                }
-                views={sectionViews}
-                onViewClick={handleViewClick}
-                onViewPin={handleViewPin}
-                onViewEdit={
-                  canManageDynamicViews ? fillManagementForm : undefined
-                }
-                onViewDelete={
-                  canManageDynamicViews ? handleDeleteView : undefined
-                }
-              />
-              <CatalogSection
-                title={t("viewmanager.section.getMore", {
-                  defaultValue: "Get more",
-                })}
-                entries={availableEntries}
-                onGet={handleGet}
-              />
-            </>
           ) : (
-            // Default: the iOS-like springboard of loaded views (names-only,
-            // paged, favorites dock = desktop tabs), with the install catalog
-            // ("Get more") underneath.
+            // The Springboard IS the view catalog: an iOS-like grid of every view
+            // as an image tile, filtered IN PLACE by search (springboardEntries
+            // is already query-scoped, so typing narrows the tiles instead of
+            // dropping into a separate list). Pin/edit/delete live in the
+            // springboard's edit mode; the install catalog ("Get more") sits
+            // underneath. The frontpage home widgets show only on the unfiltered
+            // home (#9143).
             <>
-              {/* Frontpage widgets (#9143): plugins opt a widget onto the home
-                  by declaring the `home` slot. Renders nothing until populated
-                  (hideWhenEmpty), so the launcher grid is unaffected when empty. */}
-              <WidgetHost
-                slot="home"
-                layout="grid"
-                events={homeWidgetEvents}
-                clearEvents={clearHomeWidgetEvents}
-                className="px-1 pb-3"
-              />
+              {!hasQuery ? (
+                <WidgetHost
+                  slot="home"
+                  layout="grid"
+                  events={homeWidgetEvents}
+                  clearEvents={clearHomeWidgetEvents}
+                  className="px-1 pb-3"
+                />
+              ) : null}
               <Springboard
                 entries={springboardEntries}
                 onLaunch={handleSpringboardLaunch}

--- a/packages/ui/src/components/views/ViewIcon.test.tsx
+++ b/packages/ui/src/components/views/ViewIcon.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ViewIcon } from "./ViewIcon";
+
+afterEach(() => cleanup());
+
+describe("ViewIcon image sources", () => {
+  it("renders an <img> for a data-URI icon", () => {
+    const src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    const { container } = render(<ViewIcon icon={src} />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe(src);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders an <img> for an absolute path icon", () => {
+    const { container } = render(<ViewIcon icon="/api/views/foo/hero" />);
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("/api/views/foo/hero");
+  });
+
+  it("renders an <img> for an http(s) URL icon", () => {
+    const { container } = render(
+      <ViewIcon icon="https://cdn.example.com/icon.png" />,
+    );
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://cdn.example.com/icon.png",
+    );
+  });
+});
+
+describe("ViewIcon lucide glyphs", () => {
+  it("renders the named Lucide glyph when the icon name is known", () => {
+    const { container } = render(<ViewIcon icon="Wallet" />);
+    expect(container.querySelector("svg.lucide-wallet")).toBeTruthy();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("applies the passed className to the glyph", () => {
+    const { container } = render(
+      <ViewIcon icon="Wallet" className="h-7 w-7" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.classList.contains("h-7")).toBe(true);
+    expect(svg?.classList.contains("w-7")).toBe(true);
+  });
+});
+
+describe("ViewIcon keyword inference (no/unknown icon name)", () => {
+  it("guesses a glyph from the label when no icon is given", () => {
+    const { container } = render(<ViewIcon label="Crypto Wallet" />);
+    expect(container.querySelector("svg.lucide-wallet")).toBeTruthy();
+  });
+
+  it("guesses a glyph from the id when label has no keyword", () => {
+    const { container } = render(<ViewIcon id="inbox" />);
+    expect(container.querySelector("svg.lucide-inbox")).toBeTruthy();
+  });
+
+  it("falls through an unknown icon name to keyword inference", () => {
+    // "NotARealIcon" isn't in the registry, but the label matches /calendar/.
+    const { container } = render(
+      <ViewIcon icon="NotARealIcon" label="My Calendar" />,
+    );
+    expect(container.querySelector("svg.lucide-calendar-days")).toBeTruthy();
+  });
+
+  it("falls back to the grid glyph when nothing matches", () => {
+    const { container } = render(
+      <ViewIcon icon={null} label="Zxqv" id="zxqv" />,
+    );
+    expect(container.querySelector("svg.lucide-layout-grid")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/hooks/view-catalog.ts
+++ b/packages/ui/src/hooks/view-catalog.ts
@@ -41,6 +41,13 @@ export interface ViewEntry {
   icon?: string;
   /** Real preview image URL, or undefined when only a generated fallback exists. */
   heroUrl?: string;
+  /**
+   * Always-available preview image URL — the hero endpoint, which returns a real
+   * image when one exists on disk and a deterministic branded SVG otherwise. Use
+   * this (not {@link heroUrl}) when every entry must show an image, e.g. the
+   * Springboard tiles. Undefined only for entries with no hero source at all.
+   */
+  imageUrl?: string;
   hasHero: boolean;
   category?: string;
   /** Presentation modality (`gui` for catalog apps until loaded). */
@@ -85,6 +92,7 @@ export function viewToEntry(view: ViewRegistryEntry): ViewEntry {
     description: view.description,
     icon: view.icon,
     heroUrl: hasHero ? view.heroImageUrl : undefined,
+    imageUrl: view.heroImageUrl,
     hasHero,
     modality: view.viewType ?? "gui",
     modalities: [view.viewType ?? "gui"],
@@ -108,6 +116,7 @@ function appToEntry(app: RegistryAppInfo, isActive: boolean): ViewEntry {
     description: app.description,
     icon: app.icon ?? undefined,
     heroUrl: app.heroImage ?? undefined,
+    imageUrl: app.heroImage ?? undefined,
     hasHero,
     category: app.category,
     // Catalog cards are a GUI install surface; the loaded view carries the real

--- a/packages/ui/src/state/springboard-layout.test.ts
+++ b/packages/ui/src/state/springboard-layout.test.ts
@@ -95,7 +95,10 @@ describe("springboard-layout moveIcon", () => {
   });
 
   it("marks the layout manual so the drag order is preserved", () => {
-    const layout: SpringboardLayout = { favorites: [], pages: [["a", "b", "c"]] };
+    const layout: SpringboardLayout = {
+      favorites: [],
+      pages: [["a", "b", "c"]],
+    };
     expect(layout.manual).toBeUndefined();
     const out = moveIcon(layout, "c", 0, 0, 4);
     expect(out.manual).toBe(true);

--- a/packages/ui/src/state/springboard-layout.test.ts
+++ b/packages/ui/src/state/springboard-layout.test.ts
@@ -10,6 +10,7 @@ import {
   reconcileLayout,
   SPRINGBOARD_DOCK_LIMIT,
   SPRINGBOARD_STORAGE_KEY,
+  type SpringboardLayout,
   toggleFavorite,
   writeSpringboardLayout,
 } from "./springboard-layout.js";
@@ -91,6 +92,39 @@ describe("springboard-layout moveIcon", () => {
     const out = moveIcon(layout, "a", 0, 0, 4);
     expect(out.favorites).toEqual([]);
     expect(out.pages[0]).toEqual(["a", "b"]);
+  });
+
+  it("marks the layout manual so the drag order is preserved", () => {
+    const layout: SpringboardLayout = { favorites: [], pages: [["a", "b", "c"]] };
+    expect(layout.manual).toBeUndefined();
+    const out = moveIcon(layout, "c", 0, 0, 4);
+    expect(out.manual).toBe(true);
+    // And reconcile now keeps that manual order instead of catalog order.
+    const reconciled = reconcileLayout(out, ["a", "b", "c"], 4);
+    expect(reconciled.pages[0]).toEqual(["c", "a", "b"]);
+  });
+
+  it("moves an icon across pages, repacking the flattened order", () => {
+    // Two full pages of size 2; drag the last icon to the front of page 0.
+    const layout = {
+      favorites: [],
+      pages: [
+        ["a", "b"],
+        ["c", "d"],
+      ],
+    };
+    const out = moveIcon(layout, "d", 0, 0, 2);
+    expect(out.pages.flat()).toEqual(["d", "a", "b", "c"]);
+    expect(out.pages).toEqual([
+      ["d", "a"],
+      ["b", "c"],
+    ]);
+  });
+
+  it("clamps a target index beyond the page length to the end", () => {
+    const layout = { favorites: [], pages: [["a", "b"]] };
+    const out = moveIcon(layout, "a", 0, 99, 4);
+    expect(out.pages.flat()).toEqual(["b", "a"]);
   });
 });
 


### PR DESCRIPTION
## What

Makes the **Springboard** the view catalog, gives every tile an image, and adds the interaction test coverage the launcher relied on but lacked.

### Springboard *is* the view catalog
`ViewCatalog` now always renders the `Springboard` launcher. Search filters the tiles **in place** instead of dropping into a separate sectioned hero-card list. The dead sectioned-list code is removed: `ViewCard` + its pin/edit/delete/open buttons, `ViewSection`, the `topViews` memos, `handleViewPin`, `viewCatalogKey`, and the now-unused icon imports (the shared `ViewVisual` is kept for the "Get more" catalog cards). Net −~240 lines.

The chat header's **views** button already lands here (`HeaderButton` → `navigateToViews()` → `setTab("views")` → `ViewCatalog` → `Springboard`), so no chat wiring change was needed.

### Every tile shows an image
`ViewEntry` gains `imageUrl`, always set to the `/api/views/<id>/hero` endpoint, which returns a real image when one exists on disk and a **deterministic branded SVG** otherwise (`view-hero-art.ts`) — so it is never empty. `IconTile` renders it as the tile with an `onError` fallback to the Lucide glyph, so a tile is never blank even if the fetch fails.

## Tests (the emphasis: moving / dragging / click-hold-to-edit)

- **`ViewIcon.test.tsx`** (new, 9): image URL / data-URI / path → `<img>`; named Lucide glyph; `className` passthrough; keyword inference from label & id; unknown-name → keyword fallback; grid fallback.
- **`Springboard.test.tsx`** (+8): image-tile render, `onError` → glyph fallback, no-image glyph; **long-press-to-edit** (and no-edit on early release); **unpin** from dock; **dock eviction at the limit**; append/drop on reconcile.
- **`springboard-layout.test.ts`** (+3): `moveIcon` sets `manual` + reconcile preserves the dragged order; cross-page move repacking; target-index clamp.

## Verification

- `bun run --cwd packages/ui test` (the three touched suites): **44 passed** (ViewIcon 9, springboard-layout 20, Springboard 15).
- `biome check packages/ui/src`: clean (2001 files).
- `bun run --cwd packages/ui build`: exit 0.
- Typecheck of changed files: clean. (One pre-existing repo-wide typecheck error — `shared/apps.ts` importing `@elizaos/registry/first-party/curated-app-definitions.json` — is unrelated to this change and reproduces on the branch base.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)