### PR TITLE
feat(ui): attribute the activity stream onto home-widget signals (#9143)

### DIFF
--- a/packages/ui/src/widgets/activity-signals.test.ts
+++ b/packages/ui/src/widgets/activity-signals.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityEvent } from "../hooks/useActivityEvents";
+import {
+  ACTIVITY_SIGNAL_SINKS,
+  activityEventSink,
+  activityEventsToHomeSignals,
+} from "./activity-signals";
+import { homeSignalWeight, rankHomeWidgets } from "./home-priority";
+
+/**
+ * Activity-stream → home-widget signal attribution (#9143). Pins the mapping
+ * that bridges the live `ActivityEvent` stream into the `HomeWidgetSignal`s
+ * `rankHomeWidgets` consumes: which widget each event boosts, that the weight
+ * is delegated to `homeSignalWeight`, and that the result actually moves the
+ * home ranking.
+ */
+
+const evt = (
+  eventType: string,
+  timestamp: number,
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent => ({
+  id: `evt-${eventType}-${timestamp}`,
+  eventType,
+  timestamp,
+  summary: eventType,
+  ...overrides,
+});
+
+describe("activityEventSink", () => {
+  it("routes attention/blocking events to the notifications widget", () => {
+    for (const type of [
+      "blocked",
+      "blocked_auto_resolved",
+      "escalation",
+      "error",
+      "reminder",
+      "nudge",
+      "check-in",
+    ]) {
+      expect(activityEventSink(type)).toBe(ACTIVITY_SIGNAL_SINKS.notifications);
+    }
+  });
+
+  it("routes conversational events to the messages widget", () => {
+    expect(activityEventSink("proactive-message")).toBe(
+      ACTIVITY_SIGNAL_SINKS.messages,
+    );
+    expect(activityEventSink("message")).toBe(ACTIVITY_SIGNAL_SINKS.messages);
+  });
+
+  it("falls back to the agent-orchestrator activity widget for unmapped types", () => {
+    expect(activityEventSink("task_registered")).toBe(
+      ACTIVITY_SIGNAL_SINKS.activity,
+    );
+    expect(activityEventSink("tool_running")).toBe(
+      ACTIVITY_SIGNAL_SINKS.activity,
+    );
+    expect(activityEventSink("workflow")).toBe(ACTIVITY_SIGNAL_SINKS.activity);
+    expect(activityEventSink("something-brand-new")).toBe(
+      ACTIVITY_SIGNAL_SINKS.activity,
+    );
+  });
+});
+
+describe("activityEventsToHomeSignals", () => {
+  it("maps one signal per event with the delegated weight and the event timestamp", () => {
+    const events = [
+      evt("escalation", 1000),
+      evt("proactive-message", 2000),
+      evt("tool_running", 3000),
+    ];
+    const signals = activityEventsToHomeSignals(events);
+
+    expect(signals).toEqual([
+      {
+        widgetKey: ACTIVITY_SIGNAL_SINKS.notifications,
+        weight: homeSignalWeight("escalation"),
+        timestamp: 1000,
+      },
+      {
+        widgetKey: ACTIVITY_SIGNAL_SINKS.messages,
+        weight: homeSignalWeight("proactive-message"),
+        timestamp: 2000,
+      },
+      {
+        widgetKey: ACTIVITY_SIGNAL_SINKS.activity,
+        weight: homeSignalWeight("tool_running"),
+        timestamp: 3000,
+      },
+    ]);
+  });
+
+  it("returns an empty signal set for an empty stream (deterministic, no clock read)", () => {
+    expect(activityEventsToHomeSignals([])).toEqual([]);
+  });
+
+  it("feeds rankHomeWidgets so a fresh escalation outranks a cold higher-base widget", () => {
+    // notifications has a WORSE base order (lower priority) than activity, so
+    // with no signals 'activity' would rank first. A fresh escalation signal
+    // must flip notifications to the top.
+    const declarations = [
+      { id: "notifications.recent", pluginId: "notifications", order: 80 },
+      {
+        id: "agent-orchestrator.activity",
+        pluginId: "agent-orchestrator",
+        order: 10,
+      },
+    ];
+    const now = 10_000;
+    const signals = activityEventsToHomeSignals([evt("escalation", now)]);
+
+    const ranked = rankHomeWidgets(declarations, signals, { now });
+    expect(ranked[0]?.declaration.pluginId).toBe("notifications");
+    expect(ranked[0]?.score).toBeGreaterThan(ranked[1]?.score ?? 0);
+  });
+});

--- a/packages/ui/src/widgets/activity-signals.ts
+++ b/packages/ui/src/widgets/activity-signals.ts
@@ -1,0 +1,73 @@
+/**
+ * Activity-stream → home-widget signal attribution (#9143).
+ *
+ * {@link rankHomeWidgets} (home-priority.ts) ranks the home surface by base
+ * priority plus decayed attention {@link HomeWidgetSignal}s, but it deliberately
+ * does NOT know how those signals are sourced — its docstring (and the
+ * `WidgetHost` home-ranking comment) defer "the signal→widget attribution and
+ * event-stream wiring" to the consumer. This module is that missing seam: it
+ * maps the live {@link ActivityEvent} stream (from `useActivityEvents`) onto the
+ * specific home widget each event should boost, so an escalation lights up the
+ * notifications widget, a proactive message lights up messages, and everything
+ * else feeds the agent-orchestrator activity widget.
+ *
+ * It is pure and React-free (the `ActivityEvent` import is type-only) so it can
+ * be unit-tested and called off the render path — the importance WEIGHT is left
+ * to {@link homeSignalWeight} so there is exactly one notion of "how urgent is
+ * this kind of event" across the home surface.
+ */
+
+import type { ActivityEvent } from "../hooks/useActivityEvents";
+import { type HomeWidgetSignal, homeSignalWeight } from "./home-priority";
+
+/**
+ * The home widgets activity signals can be attributed to. Keys are the canonical
+ * `${pluginId}/${id}` widget keys (see `homeWidgetKey`). Anything without an
+ * explicit mapping falls through to the agent-orchestrator activity feed.
+ */
+export const ACTIVITY_SIGNAL_SINKS = {
+  notifications: "notifications/notifications.recent",
+  messages: "messages/messages.recent",
+  activity: "agent-orchestrator/agent-orchestrator.activity",
+} as const;
+
+/**
+ * Attention/blocking events that belong on the notifications widget — the
+ * things that need a human to look or decide. Covers the blocking/decision
+ * events emitted on the task stream (`blocked`, `escalation`, `error`,
+ * `blocked_auto_resolved`) and the proactive attention nudges surfaced from the
+ * assistant stream (`reminder`, `nudge`, `check-in`).
+ */
+export const ACTIVITY_EVENT_SINK: Readonly<Record<string, string>> = {
+  blocked: ACTIVITY_SIGNAL_SINKS.notifications,
+  blocked_auto_resolved: ACTIVITY_SIGNAL_SINKS.notifications,
+  escalation: ACTIVITY_SIGNAL_SINKS.notifications,
+  error: ACTIVITY_SIGNAL_SINKS.notifications,
+  reminder: ACTIVITY_SIGNAL_SINKS.notifications,
+  nudge: ACTIVITY_SIGNAL_SINKS.notifications,
+  "check-in": ACTIVITY_SIGNAL_SINKS.notifications,
+  "proactive-message": ACTIVITY_SIGNAL_SINKS.messages,
+  message: ACTIVITY_SIGNAL_SINKS.messages,
+};
+
+/** Resolve the home widget an activity event should boost. */
+export function activityEventSink(eventType: string): string {
+  return ACTIVITY_EVENT_SINK[eventType] ?? ACTIVITY_SIGNAL_SINKS.activity;
+}
+
+/**
+ * Map a live activity-event stream onto home-widget importance signals — one
+ * signal per event, attributed to the widget {@link activityEventSink} resolves,
+ * weighted by {@link homeSignalWeight}, stamped with the event's own timestamp
+ * (so {@link rankHomeWidgets} can decay it by recency). Pure: same input → same
+ * output, no clock read.
+ */
+export function activityEventsToHomeSignals(
+  events: readonly ActivityEvent[],
+): HomeWidgetSignal[] {
+  return events.map((event) => ({
+    widgetKey: activityEventSink(event.eventType),
+    weight: homeSignalWeight(event.eventType),
+    timestamp: event.timestamp,
+  }));
+}

--- a/packages/ui/src/widgets/index.ts
+++ b/packages/ui/src/widgets/index.ts
@@ -1,4 +1,10 @@
 export {
+  ACTIVITY_EVENT_SINK,
+  ACTIVITY_SIGNAL_SINKS,
+  activityEventSink,
+  activityEventsToHomeSignals,
+} from "./activity-signals";
+export {
   baseHomeScore,
   HOME_SIGNAL_WEIGHTS,
   type HomeWidgetSignal,


### PR DESCRIPTION
`rankHomeWidgets` (home-priority.ts) already ranks the home surface by base priority + decayed attention signals, but its docstring — and the `WidgetHost` home-ranking comment (`WidgetHost.tsx:137`) — explicitly defer **how those signals are sourced** to the consumer ("Live attention/decay signals aren't yet attributable to a specific widget from the activity stream, so ranking runs with no signals"). This adds that missing seam.

`activity-signals.ts` maps the live `ActivityEvent` stream (from `useActivityEvents`) onto the home widget each event should boost:
- attention/blocking events (`blocked`, `blocked_auto_resolved`, `escalation`, `error`, `reminder`, `nudge`, `check-in`) → the **notifications** widget
- conversational events (`proactive-message`, `message`) → the **messages** widget
- everything else → the **agent-orchestrator activity** widget

It is pure and React-free (the `ActivityEvent` import is type-only), delegates the importance WEIGHT to `homeSignalWeight` (one notion of urgency across the surface), and stamps each signal with the event's own timestamp so `rankHomeWidgets` decays it by recency. No render-path change yet — this is the off-render mapping the WidgetHost comment says will "thread `now` in" once wiring lands. Exported from the `@elizaos/ui/widgets` barrel.

```
bunx vitest run src/widgets/activity-signals.test.ts → 6 passed (6)
tsgo --noEmit (widgets) → clean for the new files
```
biome clean. Refs #9143

🤖 Generated with [Claude Code](https://claude.com/claude-code)