### PR TITLE
fix: re-apply #9263 + #9265 test/scenario work clobbered by the Springboard merge

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
@@ -5,14 +5,22 @@
  * touching ACP / workspace state.
  */
 
+import type { Content } from "@elizaos/core";
 import {
   _resetBuildVariantForTests,
   getBuildVariant,
   isLocalCodeExecutionAllowed,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { tasksSandboxStubAction } from "../actions/sandbox-stub.js";
+import {
+  createTerminalUnsupportedTasksAction,
+  tasksSandboxStubAction,
+} from "../actions/sandbox-stub.js";
 import { createAgentOrchestratorPlugin } from "../index.js";
+import type {
+  OrchestratorTerminalSupport,
+  OrchestratorUnsupportedReason,
+} from "../services/terminal-capabilities.js";
 
 // Keep the slow timeout because importing @elizaos/core from this plugin can
 // still exceed Vitest's default timeout on a cold cache.
@@ -127,4 +135,76 @@ describe("agent-orchestrator sandbox gating", () => {
     const data = result?.data as { reason?: string } | undefined;
     expect(data?.reason).toBe("STORE_BUILD_BLOCKED");
   });
+});
+
+describe("createTerminalUnsupportedTasksAction reason mapping", () => {
+  // Each unsupported terminal-support reason must surface a specific,
+  // user-facing stub reason code. The default (no reason) collapses to the
+  // generic TERMINAL_UNSUPPORTED. Covers the iOS (#9146 AC: "iOS/store
+  // surfaces the stub MOBILE_TERMINAL_UNSUPPORTED cleanly") and AOSP
+  // non-local-yolo paths that the full-plugin gating test does not exercise.
+  const cases: ReadonlyArray<{
+    label: string;
+    reason: OrchestratorUnsupportedReason | undefined;
+    expectedReason: string;
+  }> = [
+    {
+      label: "iOS / vanilla mobile",
+      reason: "vanilla_mobile",
+      expectedReason: "MOBILE_TERMINAL_UNSUPPORTED",
+    },
+    {
+      label: "Android not in local-yolo mode",
+      reason: "not_local_yolo",
+      expectedReason: "AOSP_TERMINAL_REQUIRES_LOCAL_YOLO",
+    },
+    {
+      label: "Android missing shell",
+      reason: "missing_shell",
+      expectedReason: "AOSP_TERMINAL_MISSING_SHELL",
+    },
+    {
+      label: "unknown / no reason",
+      reason: undefined,
+      expectedReason: "TERMINAL_UNSUPPORTED",
+    },
+  ];
+
+  for (const { label, reason, expectedReason } of cases) {
+    it(`maps ${label} -> ${expectedReason}`, async () => {
+      const support: OrchestratorTerminalSupport = {
+        supported: false,
+        reason,
+        message: `terminal unsupported: ${expectedReason}`,
+      };
+
+      const action = createTerminalUnsupportedTasksAction(support);
+
+      expect(action.name).toBe("TASKS");
+      expect(action.suppressPostActionContinuation).toBe(true);
+      expect(await action.validate({} as never, {} as never, undefined)).toBe(
+        true,
+      );
+
+      let callbackContent: Content | undefined;
+      const result = await action.handler(
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        async (response: Content) => {
+          callbackContent = response;
+          return [];
+        },
+      );
+
+      expect(result?.success).toBe(false);
+      expect(result?.text).toBe(support.message);
+      const data = result?.data as { reason?: string } | undefined;
+      expect(data?.reason).toBe(expectedReason);
+
+      expect(callbackContent?.text).toBe(support.message);
+      expect(callbackContent?.actions).toEqual(["TASKS"]);
+    });
+  }
 });

--- a/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/reminder-dispatch-capability.scenario.ts
@@ -18,22 +18,38 @@ function assertApiBody(options: {
  * Behavior scenario for the `reminder_dispatch` LifeOps capability.
  *
  * When a scheduled reminder fires, the reminders mixin
- * (`buildReminderDispatchPrompt` in
+ * (`renderReminderBody` / `buildReminderDispatchPrompt` in
  * `plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts`)
- * composes the natural-language nudge the owner actually receives. Its
- * instruction body is the GEPA-optimizable `reminder_dispatch` prompt:
+ * composes the natural-language nudge the owner receives. Its instruction body
+ * is the GEPA-optimizable `reminder_dispatch` prompt:
  * `REMINDER_DISPATCH_INSTRUCTIONS` is the wired baseline that
- * `resolveOptimizedPromptForRuntime` swaps for a registered
- * `reminder_dispatch` artifact.
+ * `resolveOptimizedPromptForRuntime(..., "reminder_dispatch", ...)` swaps for a
+ * registered `reminder_dispatch` artifact.
  *
- * Unlike a chat-turn planner capability, `reminder_dispatch` runs on the
- * delivery path, so this scenario seeds a due reminder definition and drives
- * `POST /api/lifeops/reminders/process` to fire it. The delivery assertion
- * (`delivered` on the `in_app` channel) confirms the dispatch path — and the
- * prompt that authors the reminder text — executed, so a regression in the
- * wired prompt or the firing pipeline surfaces as a failing scenario. It
- * mirrors `reminder.lifecycle.dismiss` but is scoped to the reminder-dispatch
- * capability.
+ * Unlike a chat-turn planner capability, reminder dispatch runs on the delivery
+ * path, so this scenario seeds a due reminder definition and drives
+ * `POST /api/lifeops/reminders/process` to fire it.
+ *
+ * What this scenario proves (machine-enforced):
+ *   - The firing pipeline runs and delivers a reminder on the `in_app` channel.
+ *     The executor enforces `expectedStatus` on both api turns and runs
+ *     `assertResponse(status, body)` on the process turn
+ *     (`packages/scenario-runner/src/executor.ts`); the body must contain
+ *     `"delivered"` and `"in_app"` or the turn fails. So a regression that
+ *     stops the reminder from being scheduled, matched, or delivered surfaces
+ *     as a failing scenario.
+ *
+ * What this scenario does NOT prove:
+ *   - It does not grade the LLM-authored reminder text. `renderReminderBody`
+ *     builds a static `fallback` body via `buildReminderBody` first and only
+ *     overlays the `reminder_dispatch` model output on top; on any model
+ *     failure (or a non-string response, or no `useModel`) it returns the
+ *     static fallback. Delivery therefore succeeds whether or not the
+ *     `reminder_dispatch` prompt produced usable text — this scenario asserts
+ *     the dispatch path reached delivery, not the quality of the authored copy.
+ *
+ * It mirrors `reminder.lifecycle.dismiss` but is scoped to the
+ * reminder-dispatch capability.
  */
 export default scenario({
   lane: "live-only",

--- a/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/schedule-plan-capability.scenario.ts
@@ -11,23 +11,44 @@ import { scenario } from "@elizaos/scenario-runner/schema";
  * cancel / list_active / list_proposals / null) plus `shouldAct`. Its
  * instruction body is the GEPA-optimizable `schedule_plan` prompt:
  * `SCHEDULE_PLAN_INSTRUCTIONS` is the wired baseline that
- * `resolveOptimizedPromptForRuntime` swaps for a registered `schedule_plan`
- * artifact, and the model call is tagged with `purpose: "schedule_plan"` for
- * trajectory capture.
+ * `resolveOptimizedPromptForRuntime(..., "schedule_plan", ...)` swaps for a
+ * registered `schedule_plan` artifact, and the model call is tagged with
+ * `purpose: "schedule_plan"` for trajectory capture.
  *
  * Negotiation intents ("set up a meeting", "cancel that negotiation",
  * "list my open negotiations") route to the `PERSONAL_ASSISTANT` umbrella
- * action with `action=scheduling` (see `runSchedulingNegotiationHandler` in
- * `owner-surfaces.ts`). This scenario asserts each request reaches the
- * `PERSONAL_ASSISTANT` action and adds a final selected-action check so a
- * regression in the wired prompt or the routing surfaces as a failing
- * scenario. It mirrors `calendar-extract-capability` /
- * `inbox-triage-capability` but is scoped to the schedule-plan capability.
+ * action with `action=scheduling` (`PERSONAL_ASSISTANT_ACTIONS` in
+ * `owner-surfaces.ts`). Only `action=scheduling` reaches
+ * `runSchedulingNegotiationHandler`, which is the sole caller of
+ * `buildSchedulingPlanPrompt`; the sibling subactions `action=book_travel`
+ * and `action=sign_document` never invoke the `schedule_plan` prompt.
+ *
+ * What this scenario proves (machine-enforced):
+ *   - In at least one turn the router selects `PERSONAL_ASSISTANT` *with the
+ *     `scheduling` subaction*. The `selectedActionArguments` final check is
+ *     read by the executor
+ *     (`packages/scenario-runner/src/final-checks/index.ts`): it filters the
+ *     captured actions to `PERSONAL_ASSISTANT` and requires `"scheduling"` to
+ *     appear in the captured action options (`JSON.stringify(parameters)`).
+ *     Because only `action=scheduling` reaches `buildSchedulingPlanPrompt`,
+ *     this is the *load-bearing* assertion: it fails unless the schedule_plan
+ *     prompt path actually runs, so — unlike a bare `selectedAction` check —
+ *     it cannot be satisfied by a `book_travel` / `sign_document` route to the
+ *     same umbrella action.
+ *
+ * What this scenario does NOT prove:
+ *   - It does not grade the structured plan the model returns, nor the text of
+ *     the `schedule_plan` prompt output. It proves the prompt path runs, not
+ *     that the LLM authored a high-quality negotiation plan.
+ *
+ * It mirrors `calendar-extract-capability` / `inbox-triage-capability` but is
+ * scoped to the schedule-plan capability.
  */
 export default scenario({
   lane: "live-only",
   id: "schedule-plan-capability",
-  title: "Schedule plan capability routes negotiation requests to PERSONAL_ASSISTANT",
+  title:
+    "Schedule plan capability routes a negotiation request to PERSONAL_ASSISTANT scheduling",
   domain: "scheduling",
   tags: ["lifeops", "scheduling", "schedule_plan", "llm-eval"],
   isolation: "per-scenario",
@@ -46,29 +67,33 @@ export default scenario({
       kind: "message",
       name: "plan-start-negotiation",
       text: "Start a scheduling negotiation with Priya to find a time for our quarterly review.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
     {
       kind: "message",
       name: "plan-list-negotiations",
       text: "List my open scheduling negotiations.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
     {
       kind: "message",
       name: "plan-cancel-negotiation",
       text: "Cancel the scheduling negotiation for the quarterly review.",
-      plannerIncludesAll: ["PERSONAL_ASSISTANT"],
-      plannerExcludes: ["create_task", "spawn_agent", "list_agents"],
     },
   ],
   finalChecks: [
+    // Load-bearing assertion. `selectedActionArguments` is consumed by the
+    // executor (packages/scenario-runner/src/final-checks/index.ts:448): it
+    // filters captured actions to PERSONAL_ASSISTANT and requires the
+    // `scheduling` routing token to appear in the captured action options
+    // (`JSON.stringify(parameters)`). Without `action=scheduling` the
+    // `schedule_plan` prompt is never reached, so this fails — unlike a bare
+    // `selectedAction` check it cannot be satisfied by a book_travel /
+    // sign_document route to the same umbrella action. It fires when any one
+    // of the turns above selects the scheduling subaction, not all three.
     {
-      type: "selectedAction",
-      name: "personal assistant action selected for every schedule-plan turn",
+      type: "selectedActionArguments",
+      name: "personal-assistant routed to the scheduling subaction (exercises schedule_plan prompt path)",
       actionName: "PERSONAL_ASSISTANT",
+      includesAll: ["scheduling"],
     },
   ],
 });


### PR DESCRIPTION
PR #9261 ("Springboard replaces the view catalog", commit `bea8b85bb9`) was based on a develop snapshot from before #9263 and #9265 and, on merge, reverted three files that had landed in between:
- `plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts` — lost the 4 iOS/AOSP terminal-unsupported reason-mapping tests from #9263 (#9146).
- `schedule-plan-capability.scenario.ts` + `reminder-dispatch-capability.scenario.ts` — reverted to the weak #9252 form, losing the load-bearing `selectedActionArguments includesAll:['scheduling']` assertion from #9265 (#8795).

This cherry-picks `c2b0a928e9` (#9263) and `04cf0aa126` (#9265) back onto current develop. No new changes — a pure restoration.

Verification:
- `sandbox-gating.test.ts`: **9 passed** (5 original + 4 restored).
- Both capability scenarios parse + list cleanly; the schedule-plan scenario's load-bearing `selectedActionArguments` assertion is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)