### PR TITLE
fix(ui): unify the perf-HUD gate on __ELIZA_PERF_HUD__ (#9141)

### DIFF
--- a/packages/ui/src/components/shell/ShellOverlays.tsx
+++ b/packages/ui/src/components/shell/ShellOverlays.tsx
@@ -91,7 +91,7 @@ export function ShellOverlays({
   return (
     <>
       {/* Dev-only FPS/long-task overlay (#9141) — self-gates on
-          window.__ELIZA_PERF__, renders null + starts no loop when off. */}
+          window.__ELIZA_PERF_HUD__, renders null + starts no loop when off. */}
       <PerfOverlay />
       <CommandPalette />
       <RestartBanner />

--- a/packages/ui/src/perf/PerfOverlay.test.tsx
+++ b/packages/ui/src/perf/PerfOverlay.test.tsx
@@ -1,17 +1,41 @@
 // @vitest-environment jsdom
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PerfOverlay } from "./PerfOverlay";
+
+// #9141: the dev FPS/long-task HUD now gates on the SAME `__ELIZA_PERF_HUD__`
+// opt-in that `useFrameBudgetMonitor` reads (previously it read a divergent
+// `__ELIZA_PERF__`, so flipping the documented flag turned the monitor on but
+// left the visible overlay dark). These pin both arms of that single gate.
+type PerfHudWindow = Window & { __ELIZA_PERF_HUD__?: boolean };
 
 afterEach(() => {
   cleanup();
-  delete (window as unknown as Record<string, unknown>).__ELIZA_PERF__;
+  delete (window as PerfHudWindow).__ELIZA_PERF_HUD__;
 });
 
 describe("PerfOverlay gate (#9141)", () => {
-  it("renders nothing (and starts no loop) when __ELIZA_PERF__ is off", () => {
+  it("renders nothing (and starts no loop) when __ELIZA_PERF_HUD__ is off", () => {
     const { container } = render(<PerfOverlay />);
     expect(container.querySelector('[data-testid="perf-overlay"]')).toBeNull();
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the readout when __ELIZA_PERF_HUD__ is set", () => {
+    vi.useFakeTimers();
+    try {
+      (window as PerfHudWindow).__ELIZA_PERF_HUD__ = true;
+      const { container } = render(<PerfOverlay />);
+      // The overlay arms the sampler on mount but only paints after its first
+      // 500ms read populates the summary — advance past one interval tick.
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      const overlay = container.querySelector('[data-testid="perf-overlay"]');
+      expect(overlay).not.toBeNull();
+      expect(overlay?.textContent).toMatch(/fps/);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/perf/PerfOverlay.tsx
+++ b/packages/ui/src/perf/PerfOverlay.tsx
@@ -4,8 +4,8 @@ import {
   type FrameBudgetSummary,
 } from "../hooks/frame-budget";
 
-const PERF_FLAG = "__ELIZA_PERF__";
-/** Dispatch on `window` after flipping `window.__ELIZA_PERF__` to toggle live. */
+const PERF_FLAG = "__ELIZA_PERF_HUD__";
+/** Dispatch on `window` after flipping `window.__ELIZA_PERF_HUD__` to toggle live. */
 export const PERF_TOGGLE_EVENT = "eliza:perf-toggle";
 
 function perfEnabled(): boolean {
@@ -17,7 +17,9 @@ function perfEnabled(): boolean {
  * Dev-only FPS / long-task overlay (#9141 gap 1).
  *
  * Renders nothing — and starts NO rAF loop or observer — unless
- * `window.__ELIZA_PERF__ === true`. Flip that flag and dispatch
+ * `window.__ELIZA_PERF_HUD__ === true` (the same dev opt-in
+ * `useFrameBudgetMonitor` gates on, so the overlay and the telemetry monitor
+ * flip together). Flip that flag and dispatch
  * `window.dispatchEvent(new Event("eliza:perf-toggle"))` to turn it on at
  * runtime. Off by default ⇒ zero production cost (the prior view-lifecycle work
  * deliberately removed always-on rAF loops; this stays gated to honor that).


### PR DESCRIPTION
The dashboard's two frame-budget surfaces gated on **different** globals: `useFrameBudgetMonitor` (the telemetry monitor) reads `__ELIZA_PERF_HUD__`, but `PerfOverlay` (the visible FPS/long-task HUD) read `__ELIZA_PERF__`. So flipping the documented `__ELIZA_PERF_HUD__` flag turned the monitor on but left the on-screen overlay dark — you had to know about a second, undocumented flag.

This unifies the overlay onto `__ELIZA_PERF_HUD__` (the name `useFrameBudgetMonitor.ts:41` already uses), so one opt-in lights up both. `__ELIZA_PERF__` had no setter anywhere in the tree (grepped `packages/ui` + `packages/app`), so the rename is internal — no external caller to migrate.

- `PerfOverlay.tsx`: `PERF_FLAG` + doc comments → `__ELIZA_PERF_HUD__`
- `PerfOverlay.test.tsx`: retarget the gate test and add a positive case — with `__ELIZA_PERF_HUD__` set, the overlay arms its sampler and paints the fps readout
- `ShellOverlays.tsx`: comment updated to the unified flag

```
bunx vitest run src/perf/PerfOverlay.test.tsx → 2 passed (2)
```
biome clean. Refs #9141

🤖 Generated with [Claude Code](https://claude.com/claude-code)