### PR TITLE
fix(biome): exclude packages/logger committed src .d.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,7 @@
       "!packages/cloud-sdk/src/**/*.d.ts",
       "!packages/plugin-remote-manifest/src/**/*.d.ts",
       "!packages/plugin-worker-runtime/src/**/*.d.ts",
+      "!packages/logger/src/**/*.d.ts",
       "!**/vendor",
       "!**/vendor/**",
       "!**/public",


### PR DESCRIPTION
`@elizaos/logger` force-commits tsc-generated `src/*.d.ts` (gitignored, like cloud-sdk) but missed the biome exclude, so biome flagged the generated declarations and broke the logger lint lane (verify) + Format Check. Mirrors the existing `!packages/cloud-sdk/src/**/*.d.ts` excludes. Verified: `bun run --cwd packages/logger lint` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)