### PR TITLE
test(local-inference): pin the bionic-host UDS wire encoding (#8848)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/bionic-wire-encoding.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/bionic-wire-encoding.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Bionic-host UDS wire encoding (#8848).
+ *
+ * On the bionic-delegated path the musl agent forwards audio + image bytes to
+ * the in-process bionic host over a Unix socket. Two pure helpers do the
+ * framing: `float32ToBase64LE` packs mono fp32 PCM little-endian, and
+ * `imageRequestToBase64` resolves a vision request to base64 image bytes. A
+ * byte-order or prefix-stripping bug here corrupts every ASR/vision frame
+ * silently (the host just gets garbage), so this pins the exact wire format.
+ *
+ * `ensure-local-inference-handler` has heavy import side-effects (the service
+ * layer), so — like its sibling `ensure-local-inference-handler.test.ts` — the
+ * service modules are stubbed before the import so the two encoders can be
+ * exercised in isolation.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/active-model", () => ({
+	resolveLocalInferenceLoadArgs: vi.fn(async (t) => t),
+}));
+vi.mock("../services/assignments", () => ({
+	autoAssignAtBoot: vi.fn(async () => null),
+	readEffectiveAssignments: vi.fn(async () => ({})),
+}));
+vi.mock("../services/cache-bridge", () => ({
+	extractConversationId: vi.fn(() => null),
+	extractPromptCacheKey: vi.fn(() => null),
+	resolveLocalCacheKey: vi.fn(() => null),
+}));
+vi.mock("../services/device-bridge", () => ({
+	deviceBridge: {
+		currentModelPath: vi.fn(() => null),
+		embed: vi.fn(),
+		generate: vi.fn(),
+		loadModel: vi.fn(),
+		unloadModel: vi.fn(),
+	},
+}));
+vi.mock("../services/engine", () => ({ localInferenceEngine: {} }));
+vi.mock("../services/handler-registry", () => ({
+	handlerRegistry: { installOn: vi.fn() },
+}));
+vi.mock("../services/hardware", () => ({
+	probeHardware: vi.fn(async () => ({ memory: { totalGb: 8 } })),
+}));
+vi.mock("../services/memory-arbiter", () => ({
+	tryGetMemoryArbiter: vi.fn(() => null),
+}));
+vi.mock("../services/registry", () => ({
+	listInstalledModels: vi.fn(async () => []),
+}));
+vi.mock("../services/router-handler", () => ({
+	installRouterHandler: vi.fn(),
+}));
+vi.mock("../services/voice", () => ({
+	decodeMonoPcm16Wav: vi.fn(() => ({
+		pcm: new Float32Array([0]),
+		sampleRate: 16_000,
+	})),
+}));
+
+import {
+	float32ToBase64LE,
+	imageRequestToBase64,
+} from "./ensure-local-inference-handler";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("float32ToBase64LE", () => {
+	it("round-trips exactly-representable fp32 samples through base64 → readFloatLE", () => {
+		// Every value is exactly representable in IEEE-754 binary32, so the decoded
+		// values must equal the originals bit-for-bit (no float32 rounding drift).
+		const pcm = new Float32Array([
+			0, 1, -1, 0.5, -0.5, 0.25, -0.75, 3.5, -128.5, 32767.5,
+		]);
+		const buf = Buffer.from(float32ToBase64LE(pcm), "base64");
+		expect(buf.length).toBe(pcm.length * 4);
+
+		const decoded = new Float32Array(pcm.length);
+		for (let i = 0; i < pcm.length; i += 1) {
+			decoded[i] = buf.readFloatLE(i * 4);
+		}
+		expect(Array.from(decoded)).toEqual(Array.from(pcm));
+	});
+
+	it("encodes little-endian (1.0 → 00 00 80 3f)", () => {
+		const buf = Buffer.from(float32ToBase64LE(new Float32Array([1])), "base64");
+		expect([...buf]).toEqual([0x00, 0x00, 0x80, 0x3f]);
+	});
+
+	it("encodes an empty buffer as the empty string", () => {
+		expect(float32ToBase64LE(new Float32Array(0))).toBe("");
+	});
+});
+
+describe("imageRequestToBase64", () => {
+	it("strips the data-URL header and returns the base64 payload", async () => {
+		const payload = Buffer.from("hello bionic").toString("base64");
+		await expect(
+			imageRequestToBase64({
+				kind: "dataUrl",
+				dataUrl: `data:image/png;base64,${payload}`,
+			}),
+		).resolves.toBe(payload);
+	});
+
+	it("returns a comma-less dataUrl verbatim", async () => {
+		await expect(
+			imageRequestToBase64({ kind: "dataUrl", dataUrl: "rawbase64nocomma" }),
+		).resolves.toBe("rawbase64nocomma");
+	});
+
+	it("fetches a url and base64-encodes the response bytes", async () => {
+		const bytes = new Uint8Array([1, 2, 3, 4]);
+		globalThis.fetch = vi.fn(
+			async () => new Response(bytes, { status: 200 }),
+		) as unknown as typeof fetch;
+
+		await expect(
+			imageRequestToBase64({ kind: "url", url: "https://example.test/i.png" }),
+		).resolves.toBe(Buffer.from(bytes).toString("base64"));
+	});
+
+	it("throws when the url fetch is not ok", async () => {
+		globalThis.fetch = vi.fn(
+			async () => new Response("nope", { status: 404 }),
+		) as unknown as typeof fetch;
+
+		await expect(
+			imageRequestToBase64({
+				kind: "url",
+				url: "https://example.test/missing",
+			}),
+		).rejects.toThrow(/404/);
+	});
+
+	it("throws when neither a dataUrl nor a url is resolvable", async () => {
+		await expect(imageRequestToBase64({ kind: "dataUrl" })).rejects.toThrow(
+			/could not resolve image bytes/,
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -1020,7 +1020,7 @@ function getBionicHostLoader(runtime: IAgentRuntime): BionicHostLoader | null {
 }
 
 /** Pack a mono fp32 PCM buffer little-endian and base64-encode it for the UDS frame. */
-function float32ToBase64LE(pcm: Float32Array): string {
+export function float32ToBase64LE(pcm: Float32Array): string {
 	const buf = Buffer.allocUnsafe(pcm.length * 4);
 	for (let i = 0; i < pcm.length; i++) {
 		buf.writeFloatLE(pcm[i] ?? 0, i * 4);
@@ -1029,7 +1029,7 @@ function float32ToBase64LE(pcm: Float32Array): string {
 }
 
 /** Resolve a vision request to base64 image bytes for the bionic host. */
-async function imageRequestToBase64(image: {
+export async function imageRequestToBase64(image: {
 	kind: "dataUrl" | "url";
 	dataUrl?: string;
 	url?: string;


### PR DESCRIPTION
On the bionic-delegated path (musl agent can't load the fused lib) audio + image bytes are forwarded to the in-process bionic host over a Unix socket. Two pure helpers do the framing — `float32ToBase64LE` (mono fp32 PCM, little-endian) and `imageRequestToBase64` (vision request → base64) — but neither was exported or covered, so a byte-order or prefix-stripping regression would corrupt every ASR/vision frame silently.

- exports the two encoders from `ensure-local-inference-handler.ts` (no behavior change)
- new `bionic-wire-encoding.test.ts` pins the exact wire format:
  - `float32ToBase64LE`: exact round-trip of binary32-representable samples through base64 → `readFloatLE`, the LE byte order (`1.0 → 00 00 80 3f`), and empty → `""`
  - `imageRequestToBase64`: data-URL header stripping, comma-less passthrough, url fetch → base64, non-ok fetch throws, and unresolvable request throws

Mirrors the sibling `ensure-local-inference-handler.test.ts` service-module stubs so the encoders run in isolation despite the module's heavy import side-effects.

```
bunx vitest run src/runtime/bionic-wire-encoding.test.ts → 8 passed (8)
```
biome clean. Refs #8848

🤖 Generated with [Claude Code](https://claude.com/claude-code)