### PR TITLE
feat: inline keyless WEB_SEARCH as the general web tool

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -99,11 +99,31 @@ function extractValue(body: string, extract: string | undefined): string {
 
 export const webFetch: Action & Record<string, unknown> = {
   name: "WEB_FETCH",
-  similes: ["LOOKUP_WEB", "WEB_LOOKUP", "FETCH_URL", "HTTP_GET", "GET_URL"],
+  similes: [
+    "LOOKUP_WEB",
+    "WEB_LOOKUP",
+    "FETCH_URL",
+    "HTTP_GET",
+    "GET_URL",
+    "LIVE_INFO",
+    "CURRENT_PRICE",
+    "CHECK_PRICE",
+    "CURRENT_WEATHER",
+  ],
+  // Declaring the `web` context attaches the catalog's live-info keyword docs
+  // (price/how-much/current/latest/news/weather) so action retrieval surfaces
+  // WEB_FETCH for natural live-info phrasings ("whats the price of btc",
+  // "weather in tokyo") — without it WEB_FETCH had NO keyword terms and scored
+  // 0, so those turns fell through to a coding sub-agent spawn.
+  contexts: ["web"],
   suppressInitialMessage: true,
   description:
-    "Fetch the contents of a public https URL or JSON data API and return the result inline. " +
-    "Use for live information — current data, status pages, public REST/JSON endpoints — when you already know (or can construct) the exact URL. " +
+    "Fetch one specific URL and return its contents — a JSON API, data file, or page whose address you already have or can construct exactly. " +
+    "Prefer a JSON API over an HTML page so the value parses cleanly, and fetch it inline THIS turn — " +
+    "e.g. https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd, " +
+    "https://wttr.in/Tokyo?format=j1, " +
+    "https://nodejs.org/dist/index.json. " +
+    "Optionally pass `extract` (a dotted JSON path) to return a single field. Returns the contents inline. " +
     "No API key required. Requests are https-only, GET-only, and SSRF-guarded (internal/private hosts are blocked).",
 
   parameters: [

--- a/packages/agent/src/runtime/actions/web-search.test.ts
+++ b/packages/agent/src/runtime/actions/web-search.test.ts
@@ -1,0 +1,163 @@
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __setDnsLookupImplForTests,
+  __setPinnedFetchImplForTests,
+} from "../custom-actions.ts";
+import { webSearch } from "./web-search.ts";
+
+// A public IP so resolveUrlSafety skips real DNS and hits the pinned-fetch
+// impl, which we mock — no real network for either MCP endpoint.
+const PUBLIC_IP = "93.184.216.34";
+
+const mcpJson = (text: string): string =>
+  JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { content: [{ type: "text", text }] },
+  });
+const mcpSse = (text: string): string =>
+  `event: message\ndata: ${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { content: [{ type: "text", text }] },
+  })}\n\n`;
+const mcpErrorEnvelope = (message: string): string =>
+  JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -32602, message } });
+const mcpToolError = (text: string): string =>
+  JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { isError: true, content: [{ type: "text", text }] },
+  });
+
+/**
+ * Route each provider's mocked body by hostname (parallel vs exa). A missing
+ * key returns HTTP 500 so the action treats that provider as failed.
+ */
+function mockProviders(byHost: { parallel?: string; exa?: string }): void {
+  __setDnsLookupImplForTests(async () => [{ address: PUBLIC_IP, family: 4 }]);
+  __setPinnedFetchImplForTests(async ({ url }) => {
+    const host = (url as URL).hostname;
+    if (host.includes("parallel")) {
+      return new Response(byHost.parallel ?? "", {
+        status: byHost.parallel === undefined ? 500 : 200,
+      });
+    }
+    if (host.includes("exa")) {
+      return new Response(byHost.exa ?? "", {
+        status: byHost.exa === undefined ? 500 : 200,
+      });
+    }
+    return new Response("", { status: 404 });
+  });
+}
+
+async function runHandler(parameters: Record<string, unknown>): Promise<{
+  result: { success: boolean; text?: string; data?: unknown };
+  captured: { text?: string };
+}> {
+  const captured: { text?: string } = {};
+  const result = await webSearch.handler(
+    {} as IAgentRuntime,
+    {} as Memory,
+    {} as State,
+    { parameters },
+    (content) => {
+      captured.text = content.text;
+      return Promise.resolve([]);
+    },
+  );
+  if (!result) throw new Error("handler returned no result");
+  return { result, captured };
+}
+
+describe("WEB_SEARCH action", () => {
+  const original = process.env.ELIZA_WEB_SEARCH;
+
+  afterEach(() => {
+    __setPinnedFetchImplForTests(null);
+    __setDnsLookupImplForTests(null);
+    if (original === undefined) delete process.env.ELIZA_WEB_SEARCH;
+    else process.env.ELIZA_WEB_SEARCH = original;
+  });
+
+  it("is available by default (no key/service required)", async () => {
+    delete process.env.ELIZA_WEB_SEARCH;
+    expect(await webSearch.validate({} as IAgentRuntime, {} as Memory)).toBe(
+      true,
+    );
+  });
+
+  it("is gated off when ELIZA_WEB_SEARCH disables the capability", async () => {
+    for (const value of ["0", "false", "off"]) {
+      process.env.ELIZA_WEB_SEARCH = value;
+      expect(await webSearch.validate({} as IAgentRuntime, {} as Memory)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("fails clearly when no query is given", async () => {
+    const { result } = await runHandler({});
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("query");
+  });
+
+  it("returns parsed results from a JSON-RPC response (parallel)", async () => {
+    mockProviders({ parallel: mcpJson("RESULT: best ramen — Tabelog") });
+    const { result, captured } = await runHandler({ query: "ramen" });
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("Tabelog");
+    expect(captured.text).toContain("Tabelog");
+    expect(result.data).toMatchObject({
+      actionName: "WEB_SEARCH",
+      provider: "parallel",
+    });
+  });
+
+  it("parses an SSE 'data:' framed response (exa)", async () => {
+    mockProviders({ parallel: mcpJson(""), exa: mcpSse("EXA: top result") });
+    const { result } = await runHandler({ query: "x" });
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("EXA: top result");
+    expect(result.data).toMatchObject({ provider: "exa" });
+  });
+
+  it("treats a JSON-RPC error envelope as failure, never a result", async () => {
+    mockProviders({
+      parallel: mcpErrorEnvelope("invalid params"),
+      exa: mcpErrorEnvelope("invalid params"),
+    });
+    const { result } = await runHandler({ query: "x" });
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("No web search results");
+    // the error text must NOT be handed to the model as if it were results
+    expect(result.text).not.toContain("invalid params");
+  });
+
+  it("treats result.isError as failure, never a result", async () => {
+    mockProviders({
+      parallel: mcpToolError("rate limited, try later"),
+      exa: mcpToolError("rate limited, try later"),
+    });
+    const { result } = await runHandler({ query: "x" });
+    expect(result.success).toBe(false);
+    expect(result.text).not.toContain("rate limited");
+  });
+
+  it("falls back to exa when parallel returns no usable content", async () => {
+    mockProviders({ parallel: mcpJson(""), exa: mcpJson("EXA-ANSWER") });
+    const { result } = await runHandler({ query: "x" });
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("EXA-ANSWER");
+    expect(result.data).toMatchObject({ provider: "exa" });
+  });
+
+  it("caps the result text handed back to the model", async () => {
+    mockProviders({ parallel: mcpJson("y".repeat(20_000)) });
+    const { result } = await runHandler({ query: "x" });
+    expect(result.success).toBe(true);
+    expect((result.text ?? "").length).toBe(4_000);
+  });
+});

--- a/packages/agent/src/runtime/actions/web-search.ts
+++ b/packages/agent/src/runtime/actions/web-search.ts
@@ -1,0 +1,260 @@
+/**
+ * WEB_SEARCH — keyless inline general web search.
+ *
+ * Queries the keyless Parallel.ai search MCP (with an Exa fallback) — the same
+ * backends the bundled opencode `websearch` tool uses — but INLINE this turn,
+ * with no coding sub-agent spawn. Gives every runtime a fast, general web
+ * search ("find me X", "latest on Y", "best Z", "who/what/where is …") that
+ * needs no API key and no backing service, returning ranked results
+ * (title / url / snippet) the model answers from.
+ *
+ * Sibling of {@link module:runtime/actions/web-fetch}: WEB_FETCH reads a value
+ * from a URL you can name; WEB_SEARCH finds the pages when you can't. Routing
+ * an open-ended lookup through a coding sub-agent is slow, re-spawns, and risks
+ * leaking the weak model's tool-call markup — this answers it in one hop.
+ *
+ * Enabled by default; `validate` honors `ELIZA_WEB_SEARCH=0|false|off`. The POST
+ * is SSRF-guarded and only ever targets the two fixed public search endpoints.
+ *
+ * @module runtime/actions/web-search
+ */
+
+import {
+  type Action,
+  type ActionResult,
+  type Content,
+  type HandlerCallback,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type State,
+} from "@elizaos/core";
+import { performGuardedHttpPost } from "../custom-actions.ts";
+
+/** Keyless MCP search endpoints (no PARALLEL_API_KEY / EXA_API_KEY required). */
+const PARALLEL_MCP_URL = "https://search.parallel.ai/mcp";
+const EXA_MCP_URL = "https://mcp.exa.ai/mcp";
+/**
+ * Body read cap. Must comfortably exceed a full MCP search payload — 6-10
+ * results with livecrawled excerpts can run tens of KB — so the JSON-RPC / SSE
+ * envelope is never truncated mid-object (a truncated body fails to parse and
+ * would look like "no results"). The model only ever sees the first
+ * WEB_SEARCH_RESULT_CHARS of the extracted text.
+ */
+const WEB_SEARCH_READ_CHARS = 262_144;
+/** Cap of result text handed back to the model. */
+const WEB_SEARCH_RESULT_CHARS = 4_000;
+const DEFAULT_NUM_RESULTS = 6;
+
+/**
+ * Capability gate: WEB_SEARCH is enabled by default and opted out with
+ * `ELIZA_WEB_SEARCH=0|false|off`, mirroring the `ELIZA_WEB_FETCH` convention.
+ */
+export function isWebSearchEnabled(): boolean {
+  const raw = process.env.ELIZA_WEB_SEARCH?.toLowerCase();
+  return !(raw === "0" || raw === "false" || raw === "off");
+}
+
+interface WebSearchParams {
+  query?: string;
+  numResults?: number;
+}
+
+function readParams(options: unknown): WebSearchParams {
+  const params = (options as { parameters?: Record<string, unknown> })
+    ?.parameters;
+  if (!params || typeof params !== "object") return {};
+  const query = params.query ?? params.q ?? params.objective;
+  const rawNum = params.numResults ?? params.num_results;
+  const n =
+    typeof rawNum === "number"
+      ? rawNum
+      : Number.parseInt(String(rawNum ?? ""), 10);
+  return {
+    query: typeof query === "string" ? query.trim() : undefined,
+    numResults: Number.isFinite(n) && n > 0 ? Math.min(n, 10) : undefined,
+  };
+}
+
+/**
+ * Extract the human-readable result text from an MCP `tools/call` response. The
+ * body is either a JSON-RPC object or an SSE stream of `data:` lines; both wrap
+ * the payload at `result.content[].text`. A JSON-RPC `error` envelope or a
+ * tool-level `result.isError` is treated as a failure (returns undefined) — NOT
+ * mistaken for a search result — so the caller falls back to the other provider
+ * instead of handing the model an error string as if it were results.
+ */
+function parseMcpResultText(body: string): string | undefined {
+  const fromPayload = (payload: string): string | undefined => {
+    const trimmed = payload.trim();
+    if (!trimmed.startsWith("{")) return undefined;
+    try {
+      const data = JSON.parse(trimmed) as {
+        error?: { message?: string };
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      if (data.error || data.result?.isError) return undefined;
+      return data.result?.content?.find((item) => item.text)?.text;
+    } catch {
+      return undefined;
+    }
+  };
+  const direct = fromPayload(body);
+  if (direct) return direct;
+  for (const line of body.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const parsed = fromPayload(line.slice(6));
+    if (parsed) return parsed;
+  }
+  return undefined;
+}
+
+async function callSearchMcp(
+  url: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string | undefined> {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: toolName, arguments: args },
+  });
+  const result = await performGuardedHttpPost(url, {
+    body,
+    headers: { Accept: "application/json, text/event-stream" },
+    maxChars: WEB_SEARCH_READ_CHARS,
+  });
+  if (!result.ok || result.blocked) return undefined;
+  return parseMcpResultText(result.text);
+}
+
+export const webSearch: Action & Record<string, unknown> = {
+  name: "WEB_SEARCH",
+  similes: [
+    "SEARCH_WEB",
+    "WEB_QUERY",
+    "FIND_ONLINE",
+    "SEARCH_INTERNET",
+    "LOOKUP_ONLINE",
+  ],
+  // No context gate. An empty anyOf always passes the context-gate
+  // (context-gates.ts), so this one general web tool is a candidate on EVERY
+  // turn and is selected purely by semantic retrieval over its name / similes /
+  // description. That makes it surface for any information-seeking query —
+  // recommendations, facts, prices, news, current events — regardless of
+  // whether Stage-1 labeled the turn "web" or "simple", with no keyword list.
+  contexts: [],
+  suppressInitialMessage: true,
+  description:
+    "Search the open web and answer from the results. " +
+    "Use this for any question that needs current, real-world, or external information — prices, exchange rates, weather, sports scores, stock/crypto values, news, current events, recommendations ('best X', 'top Y'), facts about people, places, products, or companies, 'what/who/where/when is …', 'latest on …', 'how to …'. " +
+    "Returns ranked results (title, url, snippet) inline THIS turn. The snippets contain the answer — read them and answer the user directly and completely right now, citing a source; do not promise to look further. " +
+    "Keyless and fast; no API key and no coding sub-agent required.",
+  parameters: [
+    {
+      name: "query",
+      description:
+        "The search query in natural language (e.g. 'highest rated ramen shop in Tokyo').",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "numResults",
+      description: "Optional number of results to return (default 6, max 10).",
+      required: false,
+      schema: { type: "number" },
+    },
+  ],
+
+  validate: async (): Promise<boolean> => isWebSearchEnabled(),
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: { [key: string]: unknown },
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const { query, numResults } = readParams(options);
+
+    if (!query) {
+      const text = "Missing required parameter 'query'.";
+      callback?.({ text });
+      return { text, success: false, data: { actionName: "WEB_SEARCH" } };
+    }
+
+    const n = numResults ?? DEFAULT_NUM_RESULTS;
+
+    try {
+      // Parallel.ai primary, Exa fallback — both keyless, both general.
+      let results = await callSearchMcp(PARALLEL_MCP_URL, "web_search", {
+        objective: query,
+        search_queries: [query],
+      });
+      let provider = "parallel";
+      if (!results) {
+        results = await callSearchMcp(EXA_MCP_URL, "web_search_exa", {
+          query,
+          type: "auto",
+          numResults: n,
+          livecrawl: "fallback",
+        });
+        provider = "exa";
+      }
+
+      if (!results) {
+        const text = `No web search results for "${query}".`;
+        callback?.({ text });
+        return {
+          text,
+          success: false,
+          data: { actionName: "WEB_SEARCH", query },
+        };
+      }
+
+      const value = results.slice(0, WEB_SEARCH_RESULT_CHARS);
+      const content: Content = {
+        text: value,
+        actions: ["WEB_SEARCH"],
+        data: { actionName: "WEB_SEARCH", query, provider, value },
+      };
+      callback?.(content);
+      return {
+        text: value,
+        success: true,
+        data: { actionName: "WEB_SEARCH", query, provider, value },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`[web-search] error for "${query}": ${message}`);
+      const text = `Web search failed for "${query}": ${message}`;
+      callback?.({ text });
+      return {
+        text,
+        success: false,
+        data: { actionName: "WEB_SEARCH", query },
+        error: message,
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: {
+          text: "what's the highest rated ramen shop in tokyo right now?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "",
+          action: "WEB_SEARCH",
+          actionParams: { query: "highest rated ramen shop in Tokyo" },
+        },
+      },
+    ],
+  ],
+};

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -677,6 +677,73 @@ export async function performGuardedHttpGet(
   };
 }
 
+export interface GuardedHttpPostOptions extends GuardedHttpGetOptions {
+  /** Request body. Sent as `application/json` unless `Content-Type` is set. */
+  body: string;
+}
+
+/**
+ * SSRF-guarded HTTPS POST. Identical safety model to {@link performGuardedHttpGet}
+ * (https-only, internal/private targets blocked, DNS pinned, body capped) but
+ * sends a body — used by inline actions that call a public JSON/MCP endpoint
+ * (e.g. the keyless web-search MCP) rather than fetching a plain URL.
+ */
+export async function performGuardedHttpPost(
+  url: string,
+  opts: GuardedHttpPostOptions,
+): Promise<GuardedHttpGetResult> {
+  const timeoutMs = opts.timeoutMs ?? CUSTOM_ACTION_FETCH_TIMEOUT_MS;
+  const maxChars = opts.maxChars ?? GUARDED_GET_MAX_BYTES;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+  if (parsed.protocol !== "https:") {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+
+  const safety = await resolveUrlSafety(url);
+  if (safety.blocked) {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+
+  const headers = new Headers({
+    "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT,
+    "Content-Type": "application/json",
+  });
+  if (opts.headers) {
+    for (const [key, value] of Object.entries(opts.headers)) {
+      headers.set(key, value);
+    }
+  }
+
+  const fetchOpts: RequestInit = {
+    method: "POST",
+    headers,
+    body: opts.body,
+    redirect: "manual",
+  };
+
+  const response = safety.target
+    ? await fetchWithPinnedTarget(safety.target, fetchOpts, timeoutMs)
+    : await fetch(url, fetchOpts);
+
+  if (response.status >= 300 && response.status < 400) {
+    return { ok: false, status: response.status, text: "", blocked: true };
+  }
+
+  const text = await readBodyTextCapped(response, maxChars);
+  return {
+    ok: response.ok,
+    status: response.status,
+    text,
+    blocked: false,
+  };
+}
+
 function buildHandler(
   handler: CustomActionHandler,
   paramDefs: CustomActionDef["parameters"],

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4557,6 +4557,26 @@ export async function startEliza(
     }
   };
 
+  const registerWebSearchActionIfEnabled = async (): Promise<void> => {
+    try {
+      const { webSearch, isWebSearchEnabled } = await import(
+        "./actions/web-search.ts"
+      );
+      if (!isWebSearchEnabled()) {
+        logger.info(
+          "[eliza] WEB_SEARCH action disabled via ELIZA_WEB_SEARCH=0|false|off",
+        );
+        return;
+      }
+      runtime.registerAction(webSearch);
+      logger.info("[eliza] Registered keyless WEB_SEARCH action");
+    } catch (err) {
+      logger.debug(
+        `[eliza] WEB_SEARCH action registration skipped: ${formatError(err)}`,
+      );
+    }
+  };
+
   const isAutonomyEnabled = (): boolean =>
     ["true", "1"].includes((process.env.ENABLE_AUTONOMY ?? "").toLowerCase());
 
@@ -4929,6 +4949,7 @@ export async function startEliza(
     await runStewardEvmPostBoot();
     await installServerSideWebSearchIfAvailable();
     await registerWebFetchActionIfEnabled();
+    await registerWebSearchActionIfEnabled();
     bootTimer.lap("deferred:post-init");
 
     const autonomyLoopEnabled = isAutonomyEnabled();

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7243,13 +7243,21 @@ function findRuntimeActionByNames(
 	runtime: Pick<IAgentRuntime, "actions">,
 	names: string[],
 ): Action | undefined {
-	const wanted = new Set(names.map(normalizeActionIdentifier));
-	return (runtime.actions ?? []).find((action) => {
-		const candidates = [action.name, ...(action.similes ?? [])]
-			.filter((value): value is string => typeof value === "string")
-			.map(normalizeActionIdentifier);
-		return candidates.some((candidate) => wanted.has(candidate));
-	});
+	// Resolve in `names` PRIORITY order, not action-registration order, so the
+	// leading preference wins (mirrors findAvailableActionName in
+	// direct-action-heuristics.ts).
+	const actions = runtime.actions ?? [];
+	for (const want of names) {
+		const wanted = normalizeActionIdentifier(want);
+		const match = actions.find((action) => {
+			const candidates = [action.name, ...(action.similes ?? [])]
+				.filter((value): value is string => typeof value === "string")
+				.map(normalizeActionIdentifier);
+			return candidates.includes(wanted);
+		});
+		if (match) return match;
+	}
+	return undefined;
 }
 
 function looksLikeActionExplanationRequest(text: string): boolean {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -147,14 +147,22 @@ export function findAvailableActionName(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 	names: readonly string[],
 ): string | undefined {
-	const wanted = new Set(names.map(normalizeActionIdentifier));
-	return actions.find((action) => {
-		if (wanted.has(normalizeActionIdentifier(action.name))) return true;
-		const similes = Array.isArray(action.similes) ? action.similes : [];
-		return similes.some((simile) =>
-			wanted.has(normalizeActionIdentifier(String(simile))),
-		);
-	})?.name;
+	// Resolve in `names` PRIORITY order, not action-registration order: for each
+	// wanted name in turn, return the first action whose name or simile matches.
+	// The leading preference wins — e.g. WEB_SEARCH (listed ahead of WEB_FETCH)
+	// is chosen for a web lookup even though WEB_FETCH registers first.
+	for (const want of names) {
+		const wanted = normalizeActionIdentifier(want);
+		const match = actions.find((action) => {
+			if (normalizeActionIdentifier(action.name) === wanted) return true;
+			const similes = Array.isArray(action.similes) ? action.similes : [];
+			return similes.some(
+				(simile) => normalizeActionIdentifier(String(simile)) === wanted,
+			);
+		});
+		if (match) return match.name;
+	}
+	return undefined;
 }
 
 export function inferDirectCurrentRequestCandidateActions(


### PR DESCRIPTION
## Why

Open-ended web lookups — "find me X", "best Y", "latest on Z", recommendations, current events — had no good path. Routing them to a coding sub-agent is slow, re-spawns, and (on weak models) leaks tool-call markup. But a coding sub-agent's web search is just a call to the **keyless Parallel.ai / Exa search MCPs**, which work fine from a datacenter IP. So call them directly, inline, in one hop.

## What

- **New `WEB_SEARCH` action** (`packages/agent/src/runtime/actions/web-search.ts`): a query returns ranked results (title/url/snippet) the model answers from, inline this turn. Keyless (no `PARALLEL_API_KEY`/`EXA_API_KEY`), SSRF-guarded POST via a new `performGuardedHttpPost` (sibling of `performGuardedHttpGet`), gated by `ELIZA_WEB_SEARCH`. Handles JSON-RPC vs SSE response shapes and treats a JSON-RPC error envelope / `result.isError` as a **failure → provider fallback**, never as a result. 9-case unit test.
- **Un-gated** (`contexts: []`): an empty `anyOf` always passes the context-gate, so the single general web tool is a candidate on **every** turn and is selected by **semantic retrieval** over its description. It surfaces for any info-seeking query regardless of whether Stage-1 labels the turn `web` or `simple` — **no keyword enumeration**. `WEB_FETCH` stays the `contexts:["web"]` URL specialist so it doesn't compete.
- **`findAvailableActionName` / `findRuntimeActionByNames`** resolve in names-list **priority order** (not action-registration order) so the search backend wins the deterministic web-lookup. (Audited: only the web-lookup case changes; shell/coding/view callers are single-registration.)

## The general-ness

The root problem wasn't tool choice — it was that context classification is **model-based** (an LLM reads each context's description), so "best burger" gets labeled `simple` and a web-gated tool was never even exposed → the bot declined. Un-gating fixes that structurally, with **no per-keyword carve-outs**.

## Evidence

Live on a self-hosted cerebras gpt-oss Discord agent — a 12-query battery: recommendations ("best burger in chicago"), facts ("CEO of OpenAI"), how-to ("unclog a drain"), news, current events ("who won the last F1 GP"), prices (btc/eth), weather all answer **inline**; math ("2+2") and greetings do **not** misfire the tool; **0 tool-call leaks**. Routing-regression suite 21/21, web-action tests 19/19, agent suite 1599/0, orchestrator 1038/0.

Companion PRs: #9278 (planner-loop `<tool_call>` leak), #9279 (opencode spawn `websearch` permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)