### PR TITLE
fix(agent): probe embedding dimension before seeding bundled docs (fixes #8769 no-memory)

### DIFF
--- a/packages/agent/src/runtime/eliza-embedding-boot-order.test.ts
+++ b/packages/agent/src/runtime/eliza-embedding-boot-order.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression coverage for #8769: managed cloud dedicated agents booted with NO
+ * recall memory because `runtime.ensureEmbeddingDimension()` (the boot-time
+ * embedding-dimension probe) ran AFTER `seedBundledDocumentsIfEnabled()`.
+ *
+ * The probe reads the registered cloud TEXT_EMBEDDING handler's vector length
+ * (1536 on a managed agent) and snaps the plugin-sql storage column from its
+ * hardcoded `dim384` default to `dim1536`. With the probe running too late, the
+ * 4 bundled docs embedded at 1536 while the column was still `dim384`, so the
+ * plugin-sql insert guard dropped every one of them:
+ *   [PLUGIN:SQL] Skipping embedding insert: dimension mismatch
+ *   (expectedDimension=384, receivedDimension=1536, column=dim384)
+ * → no persistent memory.
+ *
+ * provisioning.test.ts in @elizaos/core exercises `provisioning.ts`'s
+ * `ensureEmbeddingDimension`, which managed agents never run (they boot
+ * `new AgentRuntime(...)` + `runtime.initialize()`, NOT
+ * `createRuntimes({ provision: true })`). So that test is false coverage for
+ * this bug. These tests cover the actual managed boot path instead:
+ *   1. The source-order invariant inside `runDeferredBoot` in eliza.ts.
+ *   2. The guard-level semantics the ordering protects.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const elizaSource = readFileSync(path.join(here, "eliza.ts"), "utf8");
+
+/**
+ * Slice out the body of the `runDeferredBoot` arrow closure so the ordering
+ * assertions cannot be satisfied by an unrelated earlier/later occurrence of
+ * the same identifier elsewhere in the (very large) eliza.ts file.
+ */
+function extractRunDeferredBootBody(source: string): string {
+  const marker = "const runDeferredBoot = async (): Promise<void> => {";
+  const start = source.indexOf(marker);
+  expect(
+    start,
+    "runDeferredBoot closure must exist in eliza.ts",
+  ).toBeGreaterThan(-1);
+
+  // Walk braces from the opening `{` to find the matching close.
+  let depth = 0;
+  let i = source.indexOf("{", start);
+  const bodyStart = i;
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return source.slice(bodyStart, i + 1);
+    }
+  }
+  throw new Error("Could not find end of runDeferredBoot closure");
+}
+
+describe("runDeferredBoot embedding-dimension ordering (#8769)", () => {
+  const body = extractRunDeferredBootBody(elizaSource);
+
+  // Match the awaited CALL statements, not comment mentions, so a doc comment
+  // that names a later step cannot skew the ordering indices.
+  const waveIdx = body.indexOf(
+    "await preregisterCorePluginsInDependencyWaves({",
+  );
+  const probeIdx = body.indexOf("await runtime.ensureEmbeddingDimension();");
+  const seedIdx = body.indexOf("await seedBundledDocumentsIfEnabled();");
+
+  it("calls all three boot steps inside runDeferredBoot", () => {
+    expect(waveIdx, "deferred core-plugin waves must run").toBeGreaterThan(-1);
+    expect(probeIdx, "embedding-dimension probe must run").toBeGreaterThan(-1);
+    expect(seedIdx, "bundled-document seed must run").toBeGreaterThan(-1);
+  });
+
+  it("probes the embedding dimension AFTER the cloud plugin waves register the TEXT_EMBEDDING handler", () => {
+    // ensureEmbeddingDimension() no-ops unless a TEXT_EMBEDDING model handler is
+    // registered; the cloud handler (plugin-elizacloud) is registered by the
+    // deferred core-plugin waves, so the probe must run after them.
+    expect(probeIdx).toBeGreaterThan(waveIdx);
+  });
+
+  it("probes the embedding dimension BEFORE seeding bundled documents (the #8769 fix)", () => {
+    // This is the invariant the fix establishes: the storage column is snapped
+    // to dim1536 before any bundled-doc embedding is written, so the inserts are
+    // not dropped on a dimension mismatch.
+    expect(probeIdx).toBeLessThan(seedIdx);
+  });
+});
+
+/**
+ * Behavioral coverage: a faithful mini-reproduction of the plugin-sql guard +
+ * probe contract, driven through both boot orders to show WHY the ordering
+ * matters at the storage layer. Mirrors BaseDrizzleAdapter:
+ *   - embeddingDimension defaults to "dim384" (base.ts:297)
+ *   - the insert guard drops a vector whose length !== the configured column
+ *     width (base.ts:2383-2399)
+ *   - ensureEmbeddingDimension(len) snaps the column via DIMENSION_MAP
+ *     (base.ts:504-521)
+ */
+const DIMENSION_MAP: Record<number, string> = {
+  384: "dim384",
+  512: "dim512",
+  768: "dim768",
+  1024: "dim1024",
+  1536: "dim1536",
+  2048: "dim2048",
+  3072: "dim3072",
+};
+
+class FakeSqlAdapter {
+  // Matches BaseDrizzleAdapter's hardcoded default.
+  embeddingDimension = "dim384";
+  readonly persisted: number[][] = [];
+
+  ensureEmbeddingDimension(length: number): void {
+    const resolved = DIMENSION_MAP[length];
+    if (resolved) this.embeddingDimension = resolved;
+  }
+
+  // Mirrors the insert guard at base.ts:2383-2399.
+  insertMemoryEmbedding(vector: number[]): boolean {
+    const expected = Number(this.embeddingDimension.replace(/^dim/, ""));
+    if (vector.length !== expected) return false; // "Skipping embedding insert: dimension mismatch"
+    this.persisted.push(vector);
+    return true;
+  }
+}
+
+const CLOUD_EMBEDDING_LENGTH = 1536;
+const bundledDocVector = () => new Array(CLOUD_EMBEDDING_LENGTH).fill(0);
+
+describe("embedding-dimension probe vs bundled-doc seed (guard semantics)", () => {
+  it("DROPS 1536-dim bundled docs when the probe runs AFTER the seed (the #8769 bug)", () => {
+    const adapter = new FakeSqlAdapter();
+
+    // Old (buggy) order: seed first, probe second.
+    const seededOk = adapter.insertMemoryEmbedding(bundledDocVector());
+    adapter.ensureEmbeddingDimension(CLOUD_EMBEDDING_LENGTH);
+
+    expect(seededOk).toBe(false);
+    expect(adapter.persisted).toHaveLength(0); // no memory persisted
+    // The column does eventually snap, but too late for the bundled docs.
+    expect(adapter.embeddingDimension).toBe("dim1536");
+  });
+
+  it("PERSISTS 1536-dim bundled docs when the probe runs BEFORE the seed (the fix)", () => {
+    const adapter = new FakeSqlAdapter();
+
+    // New (fixed) order: probe first, seed second.
+    adapter.ensureEmbeddingDimension(CLOUD_EMBEDDING_LENGTH);
+    expect(adapter.embeddingDimension).toBe("dim1536");
+
+    const seededOk = adapter.insertMemoryEmbedding(bundledDocVector());
+
+    expect(seededOk).toBe(true);
+    expect(adapter.persisted).toHaveLength(1); // bundled-doc memory persisted
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4925,6 +4925,28 @@ export async function startEliza(
     await syncRemoteCapabilityPluginsIfAvailable();
     await applyPluginRoleGatingIfAvailable();
     await registerConversationProximityProvider();
+    // Probe the embedding dimension BEFORE seeding bundled documents (#8769).
+    // The deferred plugin waves above register the cloud TEXT_EMBEDDING handler
+    // (plugin-elizacloud, 1536-dim); the probe in runtime.initialize() ran ~38s
+    // earlier, before that handler existed, so the SQL adapter kept its
+    // hardcoded dim384 default. seedBundledDocumentsIfEnabled() embeds its docs
+    // at 1536 via the cloud handler, so if the column is still dim384 every
+    // bundled-doc vector is dropped on a "dimension mismatch with configured
+    // column (dim384)" and the agent boots with no recall memory. Snapping the
+    // column to dim1536 here — after the handler is registered, before the seed
+    // writes — lets those embeddings (and all later memory) persist.
+    // ensureEmbeddingDimension() is public, idempotent, and self-guarding (it
+    // no-ops when no TEXT_EMBEDDING handler is registered, e.g. cloud-proxied
+    // agents), so this is safe on every boot path.
+    try {
+      await runtime.ensureEmbeddingDimension();
+    } catch (err) {
+      logger.warn(
+        `[eliza] deferred embedding-dimension re-probe failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     await seedBundledDocumentsIfEnabled();
     await runStewardEvmPostBoot();
     await installServerSideWebSearchIfAvailable();
@@ -4936,24 +4958,6 @@ export async function startEliza(
     await enableAutonomyLoopIfAvailable(autonomyLoopEnabled);
     startAgentSkillsWarmup();
     startEmbeddingWarmup();
-    // Re-probe the embedding dimension now that the deferred plugin waves have
-    // registered the cloud TEXT_EMBEDDING handler (plugin-elizacloud). The probe
-    // in runtime.initialize() runs ~38s earlier — before that deferred handler
-    // exists — so on a cloud agent it finds no TEXT_EMBEDDING model and the SQL
-    // adapter keeps its hardcoded dim384 default; every 1536-dim cloud vector is
-    // then dropped on a "dimension mismatch with configured column (dim384)".
-    // ensureEmbeddingDimension() is public, idempotent, and self-guarding (it
-    // no-ops when no handler is registered, e.g. cloud-proxied agents), so this
-    // safely snaps the column to dim1536 and lets memory embeddings persist.
-    try {
-      await runtime.ensureEmbeddingDimension();
-    } catch (err) {
-      logger.warn(
-        `[eliza] deferred embedding-dimension re-probe failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
     // Trigger the lazy wallet singleton fire-and-forget. This is a safety net
     // — if no wallet route or signing flow triggers it earlier, wallets are
     // still generated here. The singleton keeps this harmless if already

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -194,13 +194,24 @@ export function mergeManagedPublicBaseUrl(
 }
 
 /**
- * The cloud-managed inference defaults: the embedding endpoint + dimensions and
- * the Cerebras-direct small/large model pins. Pure and single-source-of-truth —
- * both the provision path (via prepareManagedElizaBaseEnvironment) and the
- * blue/green fleet-upgrade path (eliza-sandbox.ts) backfill these onto an
- * agent's stored env so an agent provisioned BEFORE these pins landed heals on
- * upgrade instead of carrying a stale 1536→dim_384 mismatch (#8434). Returns
- * ONLY these 5 keys; an explicit per-agent value always wins.
+ * The cloud-managed inference defaults: the embedding endpoint + the cloud
+ * embedding handler's OUTPUT dimensions, and the Cerebras-direct small/large
+ * model pins. Pure and single-source-of-truth — both the provision path (via
+ * prepareManagedElizaBaseEnvironment) and the blue/green fleet-upgrade path
+ * (eliza-sandbox.ts) backfill these onto an agent's stored env so an agent
+ * provisioned BEFORE these pins landed heals on upgrade (#8434). Returns ONLY
+ * these 5 keys; an explicit per-agent value always wins.
+ *
+ * NOTE on dimensions: EMBEDDING_DIMENSION / ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS
+ * set the width of the vectors the plugin-elizacloud TEXT_EMBEDDING handler
+ * EMITS (1536). They do NOT size the plugin-sql storage column — plugin-sql
+ * never reads either var. The storage column width is decided at boot by
+ * runtime.ensureEmbeddingDimension(), which probes the registered cloud
+ * embedding handler's actual vector length and snaps the column to dim1536.
+ * That probe must run before bundled docs are seeded; that boot ordering was
+ * the real no-memory bug (#8769) — fixed in packages/agent/src/runtime/eliza.ts,
+ * not here. Keeping these env pins ensures the handler emits 1536-wide vectors
+ * for the probe to detect.
  */
 export function applyManagedAgentInferenceEnvDefaults(
   existingEnv: Record<string, string>,
@@ -263,13 +274,16 @@ export async function prepareManagedElizaBaseEnvironment(
       // Cloud-managed inference defaults: pin embeddings to the elizacloud Worker
       // base (whose POST /embeddings serves 1536-dim text-embedding-3-small —
       // without it the plugin falls back to the Cerebras/BitRouter text base with
-      // no /embeddings route → 503), pin BOTH embedding dimensions to 1536 so the
-      // plugin-sql storage column (dim_384 by default) matches the cloud vectors
-      // instead of dropping every memory write, and pin the healthy Cerebras-direct
-      // small/large models so the container never resolves a tier to the `:nitro`
-      // default. Shared single-source helper so the fleet-upgrade path re-applies
-      // the same defaults (#8434). Each value still honors an explicit per-agent
-      // override in existingEnv.
+      // no /embeddings route → 503), pin BOTH embedding-output dimensions to 1536
+      // so the cloud TEXT_EMBEDDING handler EMITS 1536-wide vectors (these vars
+      // size the handler's output, NOT the plugin-sql storage column — plugin-sql
+      // ignores them; the column width is set at boot by the model-length probe,
+      // ensureEmbeddingDimension, see applyManagedAgentInferenceEnvDefaults above
+      // and the #8769 boot-order fix in packages/agent/src/runtime/eliza.ts), and
+      // pin the healthy Cerebras-direct small/large models so the container never
+      // resolves a tier to the `:nitro` default. Shared single-source helper so
+      // the fleet-upgrade path re-applies the same defaults (#8434). Each value
+      // still honors an explicit per-agent override in existingEnv.
       ...applyManagedAgentInferenceEnvDefaults(existingEnv),
       // New managed agents keep agent-state in a LOCAL in-container DB (PGlite on
       // the persistent /root/.eliza volume) instead of the shared cloud Postgres;


### PR DESCRIPTION
## Summary

Managed cloud dedicated agents booted with **no recall memory**. The boot log showed, for all 4 bundled docs:

```
[PLUGIN:SQL] Skipping embedding insert: dimension mismatch (expectedDimension=384, receivedDimension=1536, column=dim384)
```

so nothing persisted to vector memory.

## Root cause — a boot-ordering bug in `runDeferredBoot()` (`packages/agent/src/runtime/eliza.ts`)

plugin-sql's target embedding column is decided by the in-memory field `BaseDrizzleAdapter.embeddingDimension`, which **defaults to `dim384`** (`plugins/plugin-sql/src/base.ts:297`). It only moves to `dim1536` when `runtime.ensureEmbeddingDimension()` probes the registered cloud `TEXT_EMBEDDING` model and reads its vector length.

The boot order was wrong:

1. The deferred core-plugin waves register `plugin-elizacloud` (the 1536-dim cloud embedding handler).
2. `await seedBundledDocumentsIfEnabled()` embeds 4 docs at 1536 via that handler — but `embeddingDimension` is **still `dim384`**, so the insert guard (`plugins/plugin-sql/src/base.ts:2383-2399`) drops all 4.
3. `await runtime.ensureEmbeddingDimension()` ran **~21 lines after** the seed and only then snapped the field to `dim1536` — too late.

### Fix: reorder so the probe runs **after** the cloud handler is registered and **before** the seed

```
... deferred core-plugin waves register plugin-elizacloud ...
await registerConversationProximityProvider();
+ try { await runtime.ensureEmbeddingDimension(); } catch (err) { logger.warn(...); }   // probe: snaps column to dim1536
await seedBundledDocumentsIfEnabled();                                                  // now writes at the correct column
```

**Before:** waves → `seedBundledDocumentsIfEnabled()` → … → `ensureEmbeddingDimension()` (probe ~21 lines too late, after the seed).
**After:** waves → `ensureEmbeddingDimension()` (probe) → `seedBundledDocumentsIfEnabled()` (seed).

The probe block keeps its original `try/catch`; `ensureEmbeddingDimension()` is public, idempotent, and self-guarding (it no-ops when no `TEXT_EMBEDDING` handler is registered, e.g. cloud-proxied agents), so the reorder is safe on every boot path. Nothing between the probe's old and new positions is a precondition the probe needs (the adapter is initialized in `runtime.initialize()`, and the cloud `TEXT_EMBEDDING` handler comes from the deferred waves that now precede the probe).

## Why `EMBEDDING_DIMENSION` env was inert (not the fix)

`plugin-sql` **never reads** `EMBEDDING_DIMENSION` (grep of `plugins/plugin-sql/src/` is empty). The only TS reader, `packages/core/src/provisioning.ts:179`, is on a **dead path managed agents never execute** — they boot `new AgentRuntime(...)` + `runtime.initialize()`, not `createRuntimes({ provision: true })`. So this had to be a boot-ordering fix, not an env fix.

`packages/core/src/__tests__/provisioning.test.ts` exercises that dead `provisioning.ts` path, so it was **false coverage** for #8769.

## Tests (real coverage for the managed boot path)

Added `packages/agent/src/runtime/eliza-embedding-boot-order.test.ts` (5 tests, all passing):

- **Source-order invariant** parsed from the actual `runDeferredBoot` body: `preregisterCorePluginsInDependencyWaves` → `ensureEmbeddingDimension` → `seedBundledDocumentsIfEnabled`. Verified to **fail** when the calls are reordered back to the buggy order (not false-green).
- **Guard-level semantics**: a faithful mini-reproduction of the plugin-sql insert guard + `ensureEmbeddingDimension` snap shows a 1536-dim bundled-doc vector is **dropped** under the old order and **persists** under the new one.

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Also

Corrected misleading comments in `packages/cloud-shared/src/lib/services/managed-eliza-config.ts` that implied `EMBEDDING_DIMENSION` / `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS` size the plugin-sql storage column. They set the **cloud embedding handler's output width** (1536); the storage column width is set by the boot-time model-length probe (fixed in `eliza.ts`). The env vars themselves are kept (harmless).

## Evidence

biome clean on the touched files (`bunx @biomejs/biome ci <files>` → no errors). The worktree has pre-existing, unrelated typecheck errors (uninstalled drizzle-orm/etc.); those are out of scope and not in any touched file.

Fixes #8769
Refs #8434
