### PR TITLE
test(local-inference): cover llama-server metrics + imagegen backend selection (#8848)

### DIFF
--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ImageGenRuntimeProfile,
+	resolveDefaultImageGenModel,
+	selectImageGenBackends,
+} from "./backend-selector";
+
+/**
+ * Image-gen backend selection (#8848 / WS3).
+ *
+ * `selectImageGenBackends` is the deterministic per-platform decision tree the
+ * arbiter walks at model-load time; `resolveDefaultImageGenModel` maps a tier
+ * id to a concrete diffusion file. The whole `imagegen/` dir was untested, so a
+ * regression in the accelerator ordering or the `requiredAccelerator` override
+ * (which exists precisely so release smoke tests can't silently fall back to
+ * CPU) would pass unnoticed. Both functions are pure.
+ */
+
+const profile = (
+	o: Partial<ImageGenRuntimeProfile>,
+): ImageGenRuntimeProfile => ({
+	platform: "linux",
+	arch: "x64",
+	...o,
+});
+
+describe("selectImageGenBackends — requiredAccelerator override", () => {
+	it("pins a single backend for each explicit accelerator", () => {
+		expect(
+			selectImageGenBackends(profile({ requiredAccelerator: "cuda" })),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cuda" }]);
+		expect(
+			selectImageGenBackends(profile({ requiredAccelerator: "vulkan" })),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "vulkan" }]);
+		expect(
+			selectImageGenBackends(profile({ requiredAccelerator: "cpu" })),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
+		expect(
+			selectImageGenBackends(profile({ requiredAccelerator: "coreml" })),
+		).toEqual([{ backendId: "coreml", accelerator: "coreml" }]);
+		expect(
+			selectImageGenBackends(profile({ requiredAccelerator: "tensorrt" })),
+		).toEqual([{ backendId: "tensorrt", accelerator: "tensorrt" }]);
+	});
+
+	it("routes a required metal accelerator to mflux only on Apple Silicon", () => {
+		expect(
+			selectImageGenBackends(
+				profile({
+					requiredAccelerator: "metal",
+					platform: "darwin",
+					arch: "arm64",
+				}),
+			),
+		).toEqual([{ backendId: "mflux", accelerator: "metal" }]);
+		// Intel Mac (or anything not darwin/arm64) → sd-cpp metal.
+		expect(
+			selectImageGenBackends(
+				profile({
+					requiredAccelerator: "metal",
+					platform: "darwin",
+					arch: "x64",
+				}),
+			),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "metal" }]);
+	});
+
+	it("lets the explicit override win over the mobile shells", () => {
+		expect(
+			selectImageGenBackends(
+				profile({ requiredAccelerator: "cuda", isIos: true }),
+			),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cuda" }]);
+	});
+});
+
+describe("selectImageGenBackends — platform policy", () => {
+	it("returns Core ML only on iOS and aosp only on Android", () => {
+		expect(selectImageGenBackends(profile({ isIos: true }))).toEqual([
+			{ backendId: "coreml", accelerator: "coreml" },
+		]);
+		expect(selectImageGenBackends(profile({ isAndroid: true }))).toEqual([
+			{ backendId: "aosp", accelerator: "auto" },
+		]);
+	});
+
+	it("orders mflux→sd-cpp on Apple Silicon, sd-cpp auto→cpu on Intel Mac", () => {
+		expect(
+			selectImageGenBackends(profile({ platform: "darwin", arch: "arm64" })),
+		).toEqual([
+			{ backendId: "mflux", accelerator: "metal" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+		expect(
+			selectImageGenBackends(profile({ platform: "darwin", arch: "x64" })),
+		).toEqual([
+			{ backendId: "sd-cpp", accelerator: "auto" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+	});
+
+	it("orders tensorrt→cuda→cpu on Windows NVIDIA and vulkan→cpu on Windows AMD", () => {
+		expect(
+			selectImageGenBackends(profile({ platform: "win32", gpu: "nvidia" })),
+		).toEqual([
+			{ backendId: "tensorrt", accelerator: "tensorrt" },
+			{ backendId: "sd-cpp", accelerator: "cuda" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+		expect(
+			selectImageGenBackends(profile({ platform: "win32", gpu: "amd" })),
+		).toEqual([
+			{ backendId: "sd-cpp", accelerator: "vulkan" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+		expect(
+			selectImageGenBackends(profile({ platform: "win32", gpu: "none" })),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
+	});
+
+	it("gates Linux NVIDIA CUDA on real sd-cpp evidence", () => {
+		// GPU vendor alone is NOT evidence the installed binary has CUDA.
+		expect(
+			selectImageGenBackends(profile({ platform: "linux", gpu: "nvidia" })),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
+		// cudaCapable evidence promotes CUDA ahead of the CPU fallback.
+		expect(
+			selectImageGenBackends(
+				profile({
+					platform: "linux",
+					gpu: "nvidia",
+					sdCpp: { cudaCapable: true },
+				}),
+			),
+		).toEqual([
+			{ backendId: "sd-cpp", accelerator: "cuda" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+		// an accelerators list that includes cuda is equivalent evidence.
+		expect(
+			selectImageGenBackends(
+				profile({
+					platform: "linux",
+					gpu: "nvidia",
+					sdCpp: { accelerators: ["cuda"] },
+				}),
+			),
+		).toEqual([
+			{ backendId: "sd-cpp", accelerator: "cuda" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
+	});
+
+	it("falls back to sd-cpp CPU for an unknown platform", () => {
+		expect(
+			selectImageGenBackends(
+				profile({ platform: "freebsd" as ImageGenRuntimeProfile["platform"] }),
+			),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
+	});
+});
+
+describe("resolveDefaultImageGenModel", () => {
+	it("resolves a small tier to the SD-1.5 file (no split-diffusion fields)", () => {
+		expect(resolveDefaultImageGenModel("eliza-1-2b")).toEqual({
+			modelId: "imagegen-sd-1_5-q5_0",
+			file: "imagegen/sd-1.5-Q5_0.gguf",
+		});
+	});
+
+	it("resolves a large tier to the split Z-Image diffusion bundle", () => {
+		expect(resolveDefaultImageGenModel("eliza-1-9b")).toMatchObject({
+			modelId: "imagegen-z-image-turbo-q4_k_m",
+			file: "imagegen/z-image-turbo-Q4_K_M.gguf",
+			splitDiffusionModel: true,
+			vae: "imagegen/vae/ae.safetensors",
+		});
+	});
+
+	it("echoes back a bare model id that matches a known tier entry", () => {
+		expect(resolveDefaultImageGenModel("imagegen-sd-1_5-q5_0")).toMatchObject({
+			modelId: "imagegen-sd-1_5-q5_0",
+			file: "imagegen/sd-1.5-Q5_0.gguf",
+		});
+	});
+
+	it("returns null for an unknown key", () => {
+		expect(resolveDefaultImageGenModel("does-not-exist")).toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/llama-server-metrics.test.ts
+++ b/plugins/plugin-local-inference/src/services/llama-server-metrics.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+	diffSnapshots,
+	type LlamaServerMetricSnapshot,
+	parsePrometheusMetrics,
+} from "./llama-server-metrics";
+
+/**
+ * llama-server `/metrics` → Anthropic-shape usage accounting (#8848).
+ *
+ * `parsePrometheusMetrics` turns the Prometheus exposition payload into a
+ * counter snapshot, and `diffSnapshots` differences two snapshots into the
+ * cache-aware usage block callers bill against. Both are pure; a regression in
+ * the label-summing, the generation-counter flag, the negative-delta clamp, or
+ * the cache-creation bound silently corrupts every local-inference usage
+ * report. These pin that math.
+ */
+
+const snap = (
+	o: Partial<LlamaServerMetricSnapshot>,
+): LlamaServerMetricSnapshot => ({
+	takenAtMs: 0,
+	promptTokensTotal: 0,
+	predictedTokensTotal: 0,
+	promptTokensProcessedTotal: 0,
+	draftedTotal: 0,
+	acceptedTotal: 0,
+	kvCacheTokens: 0,
+	kvCacheUsedCells: 0,
+	...o,
+});
+
+describe("parsePrometheusMetrics", () => {
+	it("parses an unlabelled counter and flags generation counters", () => {
+		const out = parsePrometheusMetrics(
+			"llamacpp:prompt_tokens_total 1234",
+			1000,
+		);
+		expect(out.promptTokensTotal).toBe(1234);
+		expect(out.scrapeOk).toBe(true);
+		expect(out.hasGenerationCounters).toBe(true);
+		expect(out.takenAtMs).toBe(1000);
+	});
+
+	it("sums per-slot labelled samples for the same canonical field", () => {
+		const body =
+			'llamacpp:n_drafted_accepted_total{slot_id="0"} 12\n' +
+			'llamacpp:n_drafted_accepted_total{slot_id="1"} 8';
+		expect(parsePrometheusMetrics(body, 0).acceptedTotal).toBe(20);
+	});
+
+	it("prefers an unlabelled total over the labelled sum of the same field", () => {
+		const body =
+			'llamacpp:n_drafted_accepted_total{slot_id="0"} 99\n' +
+			"llamacpp:n_drafted_accepted_total 5";
+		expect(parsePrometheusMetrics(body, 0).acceptedTotal).toBe(5);
+	});
+
+	it("skips comments, malformed lines, and unknown counters", () => {
+		const body = [
+			"# HELP llamacpp:prompt_tokens_total total",
+			"# TYPE llamacpp:prompt_tokens_total counter",
+			"garbage line here",
+			"llamacpp:unknown_counter 7",
+		].join("\n");
+		const out = parsePrometheusMetrics(body, 0);
+		expect(out.promptTokensTotal).toBe(0);
+		expect(out.hasGenerationCounters).toBe(false);
+		expect(out.scrapeOk).toBe(true);
+	});
+
+	it("does not flag generation counters for a gauge-only scrape", () => {
+		const out = parsePrometheusMetrics("llamacpp:kv_cache_tokens 512", 0);
+		expect(out.kvCacheTokens).toBe(512);
+		expect(out.hasGenerationCounters).toBe(false);
+	});
+
+	it("returns an all-zero snapshot for an empty body", () => {
+		const out = parsePrometheusMetrics("", 0);
+		expect(out).toMatchObject({
+			promptTokensTotal: 0,
+			predictedTokensTotal: 0,
+			acceptedTotal: 0,
+			hasGenerationCounters: false,
+			scrapeOk: true,
+		});
+	});
+});
+
+describe("diffSnapshots", () => {
+	it("computes input/output and the cache creation/read split", () => {
+		const block = diffSnapshots(
+			snap({
+				promptTokensTotal: 100,
+				predictedTokensTotal: 10,
+				promptTokensProcessedTotal: 40,
+			}),
+			snap({
+				promptTokensTotal: 200,
+				predictedTokensTotal: 30,
+				promptTokensProcessedTotal: 90,
+			}),
+		);
+		expect(block).toMatchObject({
+			input_tokens: 100,
+			output_tokens: 20,
+			cache_creation_input_tokens: 50, // 90-40 processed
+			cache_read_input_tokens: 50, // 100 input - 50 fresh
+			cache_hit_rate: 0.5,
+		});
+	});
+
+	it("clamps negative deltas (server restart) to zero and omits cache_hit_rate", () => {
+		const block = diffSnapshots(
+			snap({ promptTokensTotal: 200, predictedTokensTotal: 50 }),
+			snap({ promptTokensTotal: 100, predictedTokensTotal: 10 }),
+		);
+		expect(block.input_tokens).toBe(0);
+		expect(block.output_tokens).toBe(0);
+		expect(block.cache_hit_rate).toBeUndefined();
+	});
+
+	it("lets responseUsage override the metric delta", () => {
+		const block = diffSnapshots(
+			snap({}),
+			snap({ promptTokensTotal: 1000, predictedTokensTotal: 500 }),
+			{ prompt_tokens: 7, completion_tokens: 3 },
+		);
+		expect(block.input_tokens).toBe(7);
+		expect(block.output_tokens).toBe(3);
+		expect(block.cache_read_input_tokens).toBe(7); // no fresh prefill → all cached
+		expect(block.cache_hit_rate).toBe(1);
+	});
+
+	it("bounds cache creation by the per-call input count", () => {
+		const block = diffSnapshots(
+			snap({}),
+			snap({ promptTokensTotal: 100, promptTokensProcessedTotal: 300 }),
+		);
+		expect(block.cache_creation_input_tokens).toBe(100); // min(300, 100)
+		expect(block.cache_read_input_tokens).toBe(0);
+		expect(block.cache_hit_rate).toBe(0);
+	});
+
+	it("adds MTP fields only when speculative tokens were drafted", () => {
+		const withMtp = diffSnapshots(
+			snap({}),
+			snap({
+				promptTokensTotal: 50,
+				predictedTokensTotal: 50,
+				draftedTotal: 10,
+				acceptedTotal: 6,
+			}),
+		);
+		expect(withMtp).toMatchObject({
+			mtp_drafted_tokens: 10,
+			mtp_accepted_tokens: 6,
+			mtp_acceptance_rate: 0.6,
+		});
+
+		const noMtp = diffSnapshots(
+			snap({}),
+			snap({ promptTokensTotal: 10, predictedTokensTotal: 10 }),
+		);
+		expect(noMtp.mtp_drafted_tokens).toBeUndefined();
+		expect(noMtp.mtp_acceptance_rate).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Two pure, previously-untested cores in the on-device inference runtime:

**`llama-server-metrics.ts`** — `parsePrometheusMetrics` (Prometheus exposition → counter snapshot) + `diffSnapshots` (two snapshots → the Anthropic-shape usage block callers bill against). Pins per-slot label summing, unlabelled-total-wins, the generation-counter flag, gauge-only scrapes, the negative-delta restart clamp, `responseUsage` override, the cache-creation bound (`min(processed, input)`), and the MTP fields gating on drafted>0.

**`imagegen/backend-selector.ts`** — `selectImageGenBackends` (per-platform accelerator-ordered backend list) + `resolveDefaultImageGenModel` (tier → diffusion file). The whole `imagegen/` dir had no tests. Pins every `requiredAccelerator` override (incl. metal→mflux only on darwin/arm64), iOS/Android shells, the macOS/Windows/Linux orderings, the Linux-NVIDIA "CUDA needs real sd-cpp evidence, not just a GPU vendor" gate, the unknown-platform fallback, and the tier/bare-id/unknown model resolution.

```
bunx vitest run llama-server-metrics.test.ts backend-selector.test.ts → 23 passed (23)
```
biome clean. Refs #8848

🤖 Generated with [Claude Code](https://claude.com/claude-code)