### PR TITLE
test(shared): cover language / label / timezone normalization helpers

### DIFF
--- a/packages/shared/src/character-language.test.ts
+++ b/packages/shared/src/character-language.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCharacterLanguage } from "./character-language";
+
+/**
+ * `normalizeCharacterLanguage` is on the eager renderer path (the i18n keyword
+ * matcher) and coerces any locale-ish string into one of the 7 supported
+ * `CharacterLanguage` values. It had no test, so a regression in the
+ * variant/alias rules (e.g. `fil`→`tl`, `zh-Hans`→`zh-CN`) would silently
+ * mis-route a character's reply language. Pure string logic.
+ */
+describe("normalizeCharacterLanguage", () => {
+  it("passes an exact canonical language through unchanged", () => {
+    expect(normalizeCharacterLanguage("zh-CN")).toBe("zh-CN");
+    expect(normalizeCharacterLanguage("es")).toBe("es");
+    expect(normalizeCharacterLanguage("tl")).toBe("tl");
+    expect(normalizeCharacterLanguage("en")).toBe("en");
+  });
+
+  it("collapses every Chinese variant onto zh-CN", () => {
+    for (const v of ["zh", "ZH", "zh-cn", "zh-Hans", "zh-hans-foo"]) {
+      expect(normalizeCharacterLanguage(v)).toBe("zh-CN");
+    }
+  });
+
+  it("normalizes regional/script tags by language prefix", () => {
+    expect(normalizeCharacterLanguage("ko-KR")).toBe("ko");
+    expect(normalizeCharacterLanguage("pt-BR")).toBe("pt");
+    expect(normalizeCharacterLanguage("es-419")).toBe("es");
+    expect(normalizeCharacterLanguage("vi-VN")).toBe("vi");
+    // Tagalog has two prefixes — its own and the legacy `fil`.
+    expect(normalizeCharacterLanguage("fil")).toBe("tl");
+    expect(normalizeCharacterLanguage("fil-PH")).toBe("tl");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(normalizeCharacterLanguage("  ko  ")).toBe("ko");
+  });
+
+  it("falls back to en for unknown, empty, or non-string input", () => {
+    expect(normalizeCharacterLanguage("de")).toBe("en");
+    expect(normalizeCharacterLanguage("xyz")).toBe("en");
+    expect(normalizeCharacterLanguage("")).toBe("en");
+    expect(normalizeCharacterLanguage("   ")).toBe("en");
+    expect(normalizeCharacterLanguage(null)).toBe("en");
+    expect(normalizeCharacterLanguage(undefined)).toBe("en");
+    expect(normalizeCharacterLanguage(42)).toBe("en");
+    expect(normalizeCharacterLanguage({})).toBe("en");
+  });
+});

--- a/packages/shared/src/lifeops-normalize/time-zone.test.ts
+++ b/packages/shared/src/lifeops-normalize/time-zone.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidTimeZone,
+  normalizeTimeZone,
+  resolveDefaultTimeZone,
+} from "./time-zone";
+
+/**
+ * IANA time-zone normalization (LifeOps normalize primitives). A scheduled
+ * reminder fired in the wrong zone is a real user-facing bug, so the
+ * "valid → passthrough, invalid/empty/nullish → host default" contract is
+ * pinned here. Deterministic given a fixed host zone — fallback assertions
+ * compare against `resolveDefaultTimeZone()` rather than a hardcoded string so
+ * they hold on any CI machine.
+ */
+describe("isValidTimeZone", () => {
+  it("accepts real IANA zones and rejects nonsense", () => {
+    expect(isValidTimeZone("UTC")).toBe(true);
+    expect(isValidTimeZone("Asia/Tokyo")).toBe(true);
+    expect(isValidTimeZone("America/New_York")).toBe(true);
+    expect(isValidTimeZone("Mars/Phobos")).toBe(false);
+    expect(isValidTimeZone("not-a-zone")).toBe(false);
+  });
+});
+
+describe("normalizeTimeZone", () => {
+  it("passes a valid IANA zone through unchanged", () => {
+    expect(normalizeTimeZone("America/New_York")).toBe("America/New_York");
+    expect(normalizeTimeZone("UTC")).toBe("UTC");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeTimeZone("  Europe/London  ")).toBe("Europe/London");
+  });
+
+  it("falls back to the host default for invalid/empty/nullish input", () => {
+    const fallback = resolveDefaultTimeZone();
+    expect(normalizeTimeZone("Not/AZone")).toBe(fallback);
+    expect(normalizeTimeZone("")).toBe(fallback);
+    expect(normalizeTimeZone("   ")).toBe(fallback);
+    expect(normalizeTimeZone(null)).toBe(fallback);
+    expect(normalizeTimeZone(undefined)).toBe(fallback);
+  });
+});

--- a/packages/shared/src/utils/labels.test.ts
+++ b/packages/shared/src/utils/labels.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { autoLabel } from "./labels";
+
+/**
+ * `autoLabel` derives the human-readable label shown next to a plugin config
+ * field from its env-key + plugin id — strip the plugin prefix, title-case the
+ * remaining words, but preserve known acronyms (API/URL/ID/…). Untested, so a
+ * regression in prefix stripping or the acronym set would silently mangle every
+ * generated settings label. Pure.
+ */
+describe("autoLabel", () => {
+  it("strips the underscored plugin prefix and preserves acronyms", () => {
+    expect(autoLabel("PLUGIN_API_KEY", "plugin")).toBe("API Key");
+    expect(autoLabel("FOO_ID_LIST", "foo")).toBe("ID List");
+  });
+
+  it("strips the collapsed (hyphen-removed) plugin prefix", () => {
+    // "my-plugin" → prefixes "MY_PLUGIN_" and "MYPLUGIN_"; the key uses the
+    // collapsed form.
+    expect(autoLabel("MYPLUGIN_URL_BASE", "my-plugin")).toBe("URL Base");
+  });
+
+  it("title-cases ordinary words", () => {
+    expect(autoLabel("FOO_REGULAR_WORD", "foo")).toBe("Regular Word");
+  });
+
+  it("leaves a key without the plugin prefix as a single title-cased token", () => {
+    expect(autoLabel("SOMEKEY", "other")).toBe("Somekey");
+  });
+
+  it("does not strip a prefix-only key (length must strictly exceed the prefix)", () => {
+    expect(autoLabel("PLUGIN_", "plugin")).toBe("Plugin");
+  });
+});


### PR DESCRIPTION
Three pure, previously-untested normalization helpers in `@elizaos/shared`, each on a user-facing path:

- **`normalizeCharacterLanguage`** (character-language.ts) — on the eager renderer path (i18n keyword matcher); pins the variant/alias rules (`zh`/`zh-Hans`→`zh-CN`, `ko-KR`→`ko`, `fil`→`tl`, regional tags by prefix) and the en fallback for unknown/empty/non-string input.
- **`autoLabel`** (utils/labels.ts) — derives the settings-field label from an env key + plugin id; pins underscored vs collapsed prefix stripping, acronym preservation (API/URL/ID), ordinary title-casing, the no-prefix passthrough, and the strict length>prefix guard.
- **`isValidTimeZone` / `normalizeTimeZone`** (lifeops-normalize/time-zone.ts) — a reminder fired in the wrong zone is a real bug; pins valid→passthrough, trim, and invalid/empty/nullish→host default (compared against `resolveDefaultTimeZone()` so it holds on any machine).

```
bunx vitest run character-language.test.ts utils/labels.test.ts time-zone.test.ts → 14 passed (14)
```
biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)