### PR TITLE
test(computeruse): cover scene serialization caps + screenshot-quality classifier (#9105)

### DIFF
--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ScreenshotQuality,
+  screenshotQualityIssues,
+} from "./screenshot-quality";
+
+/**
+ * Screenshot blank/one-color detection (#9105). `screenshotQualityIssues` is the
+ * pure classifier that turns decoded PNG metrics into human-readable quality
+ * problems — it gates the real-driver screenshot lanes, but the classifier
+ * itself (the empty floor, the one-color rule, and the `>0.995` "effectively
+ * one color" boundary) was only ever exercised through live PNG decoding. These
+ * pin the thresholds against synthetic metrics.
+ */
+
+const quality = (o: Partial<ScreenshotQuality>): ScreenshotQuality => ({
+  width: 100,
+  height: 100,
+  sampledPixels: 10_000,
+  colorBuckets: 500,
+  dominantRatio: 0.2,
+  ...o,
+});
+
+describe("screenshotQualityIssues", () => {
+  it("flags an empty screenshot", () => {
+    const issues = screenshotQualityIssues(
+      "shot",
+      quality({ width: 0, height: 0, sampledPixels: 0, colorBuckets: 0 }),
+    );
+    expect(issues).toContain("shot: screenshot is empty");
+  });
+
+  it("flags a single-color screenshot without also flagging 'effectively one color'", () => {
+    const issues = screenshotQualityIssues(
+      "shot",
+      quality({ colorBuckets: 1, dominantRatio: 1 }),
+    );
+    expect(issues).toContain("shot: screenshot is one color");
+    expect(issues.some((i) => i.includes("effectively one color"))).toBe(false);
+  });
+
+  it("flags 'effectively one color' only above the 0.995 dominance boundary", () => {
+    const over = screenshotQualityIssues(
+      "shot",
+      quality({ colorBuckets: 2, dominantRatio: 0.996 }),
+    );
+    expect(over.some((i) => i.includes("effectively one color"))).toBe(true);
+
+    // 0.99 is below the 0.995 cutoff → not flagged.
+    const under = screenshotQualityIssues(
+      "shot",
+      quality({ colorBuckets: 2, dominantRatio: 0.99 }),
+    );
+    expect(under).toEqual([]);
+  });
+
+  it("returns no issues for a healthy multi-color screenshot", () => {
+    expect(
+      screenshotQualityIssues(
+        "shot",
+        quality({ colorBuckets: 500, dominantRatio: 0.2 }),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/plugins/plugin-computeruse/src/scene/serialize.test.ts
+++ b/plugins/plugin-computeruse/src/scene/serialize.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import type { Scene, SceneApp, SceneOcrBox } from "./scene-types.js";
+import { serializeSceneForPrompt } from "./serialize.js";
+
+/**
+ * Token-budget Scene serialization (#9105 M3 / WS6). `serializeSceneForPrompt`
+ * caps the per-display OCR list, prefers the focused-display AX subtree, and
+ * clips background apps so a 4k multi-monitor session doesn't blow the prompt
+ * to thousands of tokens. `scene-provider.test.ts` only asserts a few
+ * substrings of the output; none of the cap/sort/trim branches were pinned.
+ * This does that, parsing the fenced JSON to assert structure.
+ */
+
+const baseScene = (o: Partial<Scene> = {}): Scene => ({
+  timestamp: 1000,
+  displays: [
+    {
+      id: 0,
+      bounds: [0, 0, 1920, 1080],
+      scaleFactor: 1,
+      primary: true,
+      name: "D0",
+    },
+  ],
+  focused_window: null,
+  apps: [],
+  ocr: [],
+  ax: [],
+  vlm_scene: null,
+  vlm_elements: null,
+  ...o,
+});
+
+/** Parse the fenced-JSON output, asserting the ```json … ``` framing. */
+function parseFenced(out: string): Record<string, unknown> {
+  expect(out.startsWith("```json\n")).toBe(true);
+  expect(out.endsWith("\n```")).toBe(true);
+  const body = out.slice("```json\n".length, out.length - "\n```".length);
+  return JSON.parse(body);
+}
+
+const ocrBox = (seq: number, conf: number, displayId = 0): SceneOcrBox => ({
+  id: `t${displayId}-${seq}`,
+  text: `line ${seq}`,
+  bbox: [0, 0, 10, 10],
+  conf,
+  displayId,
+});
+
+describe("serializeSceneForPrompt", () => {
+  it("emits valid fenced JSON", () => {
+    const parsed = parseFenced(serializeSceneForPrompt(baseScene()));
+    expect(parsed.timestamp).toBe(1000);
+    expect(parsed.truncation).toMatchObject({ ocr_total: 0, apps_kept: 0 });
+  });
+
+  it("keeps only the top-N most confident OCR boxes per display", () => {
+    const ocr = Array.from({ length: 30 }, (_, i) => ocrBox(i, i / 100));
+    const parsed = parseFenced(
+      serializeSceneForPrompt(baseScene({ ocr }), { ocrTopN: 3 }),
+    );
+    const kept = parsed.ocr as Array<{ conf: number }>;
+    expect(kept).toHaveLength(3);
+    // Sorted by descending confidence → the three highest (0.29, 0.28, 0.27).
+    expect(kept.map((b) => b.conf)).toEqual([0.29, 0.28, 0.27]);
+    expect(parsed.truncation).toMatchObject({ ocr_total: 30, ocr_kept: 3 });
+  });
+
+  it("rounds OCR confidence to 3 decimals", () => {
+    const parsed = parseFenced(
+      serializeSceneForPrompt(baseScene({ ocr: [ocrBox(0, 0.123456)] })),
+    );
+    expect((parsed.ocr as Array<{ conf: number }>)[0]?.conf).toBe(0.123);
+  });
+
+  it("prefers the focused-window display's AX subtree when capping", () => {
+    const ax = [
+      {
+        id: "d0a",
+        role: "button",
+        bbox: [0, 0, 1, 1],
+        actions: [],
+        displayId: 0,
+      },
+      {
+        id: "d0b",
+        role: "button",
+        bbox: [0, 0, 1, 1],
+        actions: [],
+        displayId: 0,
+      },
+      {
+        id: "d1a",
+        role: "link",
+        bbox: [0, 0, 1, 1],
+        actions: [],
+        displayId: 1,
+      },
+      {
+        id: "d1b",
+        role: "link",
+        bbox: [0, 0, 1, 1],
+        actions: [],
+        displayId: 1,
+      },
+    ];
+    const parsed = parseFenced(
+      serializeSceneForPrompt(
+        baseScene({
+          ax,
+          focused_window: {
+            app: "X",
+            pid: 1,
+            bounds: [0, 0, 1, 1],
+            title: "t",
+            displayId: 1,
+          },
+        }),
+        { axMax: 2 },
+      ),
+    );
+    const keptAx = parsed.ax as Array<{ displayId: number }>;
+    expect(keptAx).toHaveLength(2);
+    expect(keptAx.every((n) => n.displayId === 1)).toBe(true);
+    expect(parsed.truncation).toMatchObject({ ax_total: 4, ax_kept: 2 });
+  });
+
+  it("orders apps by window count then name, caps the list, and clips per-app windows", () => {
+    const win = (id: string) => ({
+      id,
+      title: `w-${id}`,
+      bounds: [0, 0, 1, 1] as [number, number, number, number],
+      displayId: 0,
+    });
+    const app = (name: string, windows: number): SceneApp => ({
+      name,
+      pid: 1,
+      windows: Array.from({ length: windows }, (_, i) => win(`${name}-${i}`)),
+    });
+    const apps = [
+      app("app-bg", 0),
+      app("app-zebra", 2),
+      app("app-mid", 1),
+      app("app-alpha", 2),
+    ];
+    const parsed = parseFenced(
+      serializeSceneForPrompt(baseScene({ apps }), {
+        appMax: 2,
+        appTopWindows: 1,
+      }),
+    );
+    const keptApps = parsed.apps as Array<{
+      name: string;
+      window_count: number;
+      windows: unknown[];
+    }>;
+    expect(keptApps).toHaveLength(2);
+    // Both 2-window apps win the cap; alpha sorts before zebra on the tie-break.
+    expect(keptApps.map((a) => a.name)).toEqual(["app-alpha", "app-zebra"]);
+    // window_count reflects the FULL count; windows array is clipped to 1.
+    expect(keptApps[0]?.window_count).toBe(2);
+    expect(keptApps[0]?.windows).toHaveLength(1);
+    expect(parsed.truncation).toMatchObject({ apps_total: 4, apps_kept: 2 });
+  });
+});


### PR DESCRIPTION
Two pure cores in the Computer-Use × Vision scene pipeline:

**`scene/serialize.ts` — `serializeSceneForPrompt`** is the token-budget Scene→prompt renderer: it caps OCR per display (top-N by confidence), prefers the focused-window display's AX subtree when capping, and clips background apps so a 4k multi-monitor session doesn't blow the prompt to thousands of tokens. `scene-provider.test.ts` only asserts a few substrings of its output — none of the cap/sort/trim branches were pinned. This parses the fenced JSON and asserts: fenced-JSON framing, OCR top-N + descending-confidence + 3-decimal rounding, focused-display AX preference, app ordering (window-count desc, name tie-break) + cap + per-app window clip + full `window_count`, and the `truncation` totals.

**`platform/screenshot-quality.ts` — `screenshotQualityIssues`** is the blank/one-color classifier gating the real-driver screenshot lanes; the classifier itself was only ever exercised through live PNG decoding. This pins the empty floor, the one-color rule (no double-flag), the `>0.995` "effectively one color" boundary (0.996 flags, 0.99 doesn't), and the healthy multi-color pass — all against synthetic metrics.

```
bunx vitest run scene/serialize.test.ts platform/screenshot-quality.test.ts → 9 passed (9)
```
biome clean. Refs #9105

🤖 Generated with [Claude Code](https://claude.com/claude-code)