### PR TITLE
feat(local-inference): stream IMAGE_DESCRIPTION token-by-token through the chat pipe (#9105)

### DIFF
--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -864,6 +864,16 @@ export interface ImageGenerationParams {
 export interface ImageDescriptionParams {
 	imageUrl: string;
 	prompt?: string;
+	/**
+	 * Opt-in token-by-token streaming of the generated description. When a vision
+	 * call runs inside a streaming reply turn, {@link AgentRuntime.useModel}
+	 * auto-injects `onStreamChunk` from the ambient text-streaming context for
+	 * local providers, so the description flows into the dashboard through the
+	 * SAME SSE pipe as chat text. Handlers that lack a streaming describe backend
+	 * ignore these and return the final {@link ImageDescriptionResult}.
+	 */
+	stream?: boolean;
+	onStreamChunk?: StreamChunkCallback;
 }
 export interface ImageDescriptionResult {
 	title: string;
@@ -880,6 +890,16 @@ export interface TranscriptionParams {
 	audioUrl: string;
 	prompt?: string;
 	signal?: AbortSignal;
+	/**
+	 * Opt-in streaming of partial transcripts as audio is decoded. When a
+	 * transcription call runs inside a streaming reply turn,
+	 * {@link AgentRuntime.useModel} auto-injects `onStreamChunk` from the ambient
+	 * text-streaming context for local providers, so partial transcripts flow
+	 * into the dashboard through the SAME SSE pipe as chat text. Handlers that
+	 * lack an incremental ASR backend ignore these and return the final string.
+	 */
+	stream?: boolean;
+	onStreamChunk?: StreamChunkCallback;
 }
 
 /**

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -727,6 +727,7 @@ function tryGetImageGenArbiter(
 function paramsToVisionRequest(params: ImageDescriptionParams | string): {
 	image: { kind: "dataUrl"; dataUrl: string } | { kind: "url"; url: string };
 	prompt?: string;
+	onTextChunk?: (chunk: string) => void | Promise<void>;
 } {
 	const url = typeof params === "string" ? params : params.imageUrl;
 	if (typeof url !== "string" || !url) {
@@ -737,15 +738,32 @@ function paramsToVisionRequest(params: ImageDescriptionParams | string): {
 		);
 	}
 	const prompt = typeof params === "object" ? params.prompt : undefined;
+	// Token-by-token streaming: the runtime's `useModel` injects `onStreamChunk`
+	// into the params for local providers when a chat streaming context is active
+	// (runtime.ts). Forward it (read structurally so this stays robust to the core
+	// param type) so the description streams into the dashboard through the same
+	// pipe as chat text when the fused lib exposes ABI-v13 streaming vision;
+	// backends without it return the final description.
+	const streamSink =
+		typeof params === "object"
+			? (params as { onStreamChunk?: (chunk: string) => void | Promise<void> })
+					.onStreamChunk
+			: undefined;
+	const onTextChunk =
+		typeof streamSink === "function"
+			? (chunk: string) => streamSink(chunk)
+			: undefined;
 	if (url.startsWith("data:")) {
 		return {
 			image: { kind: "dataUrl", dataUrl: url },
 			prompt,
+			onTextChunk,
 		};
 	}
 	return {
 		image: { kind: "url", url },
 		prompt,
+		onTextChunk,
 	};
 }
 

--- a/plugins/plugin-local-inference/src/services/backend.ts
+++ b/plugins/plugin-local-inference/src/services/backend.ts
@@ -209,6 +209,12 @@ export interface LocalInferenceBackend {
 		maxTokens?: number;
 		temperature?: number;
 		signal?: AbortSignal;
+		/** Per-token callback for streaming vision describe (ABI v13). When set and
+		 * the backend supports streaming, the description is decoded token-by-token
+		 * through the same pipe as chat text; otherwise the backend returns the
+		 * full description and ignores it. */
+		onTextChunk?: (chunk: string) => void | Promise<void>;
+		maxTokensPerStep?: number;
 	}): Promise<{
 		text: string;
 		projectorMs?: number;

--- a/plugins/plugin-local-inference/src/services/desktop-fused-ffi-backend-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-fused-ffi-backend-runtime.ts
@@ -277,10 +277,35 @@ export class DesktopFusedFfiBackendRuntime implements FfiBackendRuntime {
 	}
 
 	/**
-	 * Vision describe through the fused `eliza_inference_describe_image`
-	 * (ABI v9). Reuses the mtmd machinery linked for ASR over the bundle's text
-	 * model + the passed mmproj projector. The `FfiStreamingBackend` forwards
-	 * `describeImage`/`visionSupported` to this runtime by duck-typing.
+	 * Whether the LIVE session can STREAM a vision describe token-by-token
+	 * through `eliza_inference_describe_image_stream_open` + the existing
+	 * `llmStreamNext` loop (ABI v13). A <=v12 lib reports false and the handler
+	 * uses the buffered one-shot `describeImage` path.
+	 */
+	visionStreamSupported(): boolean {
+		if (!this.active) return false;
+		const { ffi } = this.active;
+		return (
+			typeof ffi.visionStreamSupported === "function" &&
+			ffi.visionStreamSupported() === true &&
+			typeof ffi.describeImageStreamOpen === "function" &&
+			typeof ffi.llmStreamNext === "function" &&
+			typeof ffi.llmStreamClose === "function"
+		);
+	}
+
+	/**
+	 * Vision describe through the fused mmproj path. Reuses the mtmd machinery
+	 * linked for ASR over the bundle's text model + the passed mmproj projector.
+	 * The `FfiStreamingBackend` forwards `describeImage`/`visionSupported` to this
+	 * runtime by duck-typing.
+	 *
+	 * When `onTextChunk` is supplied AND the fused lib exposes ABI-v13 streaming
+	 * vision, the description is decoded token-by-token: `describeImageStreamOpen`
+	 * primes a stream with the image+prompt KV and the EXISTING `llmStreamNext`
+	 * loop pulls tokens — the same machinery that streams chat text, so vision
+	 * flows into the dashboard through one pipe. Otherwise it falls back to the
+	 * buffered one-shot `eliza_inference_describe_image`.
 	 */
 	async describeImage(args: {
 		imageBytes: Uint8Array;
@@ -289,6 +314,8 @@ export class DesktopFusedFfiBackendRuntime implements FfiBackendRuntime {
 		maxTokens?: number;
 		temperature?: number;
 		signal?: AbortSignal;
+		onTextChunk?: (chunk: string) => void | Promise<void>;
+		maxTokensPerStep?: number;
 	}): Promise<{ text: string; projectorMs?: number; decodeMs?: number }> {
 		if (!this.active) {
 			throw new Error(
@@ -307,6 +334,58 @@ export class DesktopFusedFfiBackendRuntime implements FfiBackendRuntime {
 					"lib with -DELIZA_ENABLE_VISION=ON (verify-fused-symbols requires it).",
 			);
 		}
+
+		// Token-by-token streaming path (ABI v13): open a vision stream and drive
+		// the shared `llmStreamNext` loop, surfacing each decoded piece through
+		// `onTextChunk` so the description renders as it generates.
+		if (
+			typeof args.onTextChunk === "function" &&
+			this.visionStreamSupported() &&
+			typeof ffi.describeImageStreamOpen === "function" &&
+			typeof ffi.llmStreamNext === "function" &&
+			typeof ffi.llmStreamClose === "function"
+		) {
+			const startedAt = Date.now();
+			const stream = ffi.describeImageStreamOpen({
+				ctx,
+				imageBytes: args.imageBytes,
+				mmprojPath: args.mmprojPath,
+				prompt: args.prompt,
+			});
+			let full = "";
+			let generated = 0;
+			// JS-side token budget: the native ELIZA_VISION_MAX_TOKENS env does not
+			// reliably reach the loaded DLL's getenv across runtimes, so cap here.
+			const tokenBudget =
+				typeof args.maxTokens === "number" && args.maxTokens > 0
+					? args.maxTokens
+					: 256;
+			try {
+				for (;;) {
+					if (args.signal?.aborted) {
+						ffi.llmStreamCancel?.(stream);
+						break;
+					}
+					const step = ffi.llmStreamNext({
+						stream,
+						// Fine-grained by default so the description renders token-by-token
+						// in the dashboard rather than in coarse ~32-token jumps (matches
+						// the tuned chat default). Callers may override per request.
+						maxTokensPerStep: args.maxTokensPerStep ?? 8,
+					});
+					if (step.text.length > 0) {
+						full += step.text;
+						await args.onTextChunk(step.text);
+					}
+					generated += step.tokens.length;
+					if (step.done || generated >= tokenBudget) break;
+				}
+			} finally {
+				ffi.llmStreamClose(stream);
+			}
+			return { text: full, decodeMs: Date.now() - startedAt };
+		}
+
 		const startedAt = Date.now();
 		const text = ffi.describeImage({
 			ctx,

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -636,6 +636,9 @@ export class LocalInferenceEngine {
 		maxTokens?: number;
 		temperature?: number;
 		signal?: AbortSignal;
+		/** Per-token callback for streaming vision describe (ABI v13). */
+		onTextChunk?: (chunk: string) => void | Promise<void>;
+		maxTokensPerStep?: number;
 	}): Promise<{
 		text: string;
 		projectorMs?: number;

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
@@ -355,6 +355,10 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 		maxTokens?: number;
 		temperature?: number;
 		signal?: AbortSignal;
+		/** Per-token callback — when set + the runtime supports streaming vision,
+		 * the description is decoded token-by-token through the same pipe as chat. */
+		onTextChunk?: (chunk: string) => void | Promise<void>;
+		maxTokensPerStep?: number;
 	}): Promise<{ text: string; projectorMs?: number; decodeMs?: number }> {
 		if (!this.session) {
 			throw new Error(
@@ -378,6 +382,8 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 				maxTokens?: number;
 				temperature?: number;
 				signal?: AbortSignal;
+				onTextChunk?: (chunk: string) => void | Promise<void>;
+				maxTokensPerStep?: number;
 			}) => Promise<{ text: string; projectorMs?: number; decodeMs?: number }>;
 		};
 		if (!runtime.describeImage) {
@@ -392,6 +398,8 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 			maxTokens: args.maxTokens,
 			temperature: args.temperature,
 			signal: args.signal,
+			onTextChunk: args.onTextChunk,
+			maxTokensPerStep: args.maxTokensPerStep,
 		});
 	}
 

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -536,6 +536,13 @@ export class LocalInferenceService {
 								maxTokens: request.maxTokens,
 								temperature: request.temperature,
 								signal: request.signal,
+								// Stream the description token-by-token when the caller wired
+								// a chunk sink (the IMAGE_DESCRIPTION handler forwards the
+								// runtime's onStreamChunk here); the engine/backend decode
+								// it through the same pipe as chat text when the fused lib
+								// exposes ABI-v13 streaming vision.
+								onTextChunk: request.onTextChunk,
+								maxTokensPerStep: request.maxTokensPerStep,
 							});
 							const trimmed = result.text.trim();
 							if (!trimmed) {

--- a/plugins/plugin-local-inference/src/services/vision/types.ts
+++ b/plugins/plugin-local-inference/src/services/vision/types.ts
@@ -64,6 +64,15 @@ export interface VisionDescribeRequest {
 	/** 0..1, default 0.2 (descriptions should be deterministic-ish). */
 	temperature?: number;
 	signal?: AbortSignal;
+	/**
+	 * Per-token callback. When set and the backend exposes streaming vision
+	 * (the fused ABI-v13 path), the description is decoded token-by-token and
+	 * each piece is delivered here as it generates — the same pipe as chat text.
+	 * Backends without streaming describe ignore it and return the final result.
+	 */
+	onTextChunk?: (chunk: string) => void | Promise<void>;
+	/** Per-step token cap for streaming describe (smaller = finer-grained UI). */
+	maxTokensPerStep?: number;
 }
 
 /** Backend response — same shape that ImageDescriptionResult expects. */

--- a/plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts
+++ b/plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts
@@ -106,7 +106,7 @@ function ensureWin32DllSearchDir(dir: string): void {
  *     degraded capability: its voice/ASR/VAD/LLM/text surface is unchanged and
  *     Kokoro just probes unsupported on it.
  */
-export const ELIZA_INFERENCE_ABI_VERSION = 12 as const;
+export const ELIZA_INFERENCE_ABI_VERSION = 13 as const;
 
 /** One transcribed word with playback-synced timing (ms from utterance start). */
 export interface AsrWordTiming {
@@ -676,6 +676,29 @@ export interface ElizaInferenceFfi {
 		maxTextBytes?: number;
 	}): string;
 
+	/* ---- Streaming mmproj vision describe (ABI v13) -------------- */
+
+	/**
+	 * True when this build wires token-by-token vision describe
+	 * (`eliza_inference_describe_image_stream_open`). A <=v12 / vision-off
+	 * library returns false, so the IMAGE_DESCRIPTION handler falls back to the
+	 * buffered {@link describeImage}.
+	 */
+	visionStreamSupported?(): boolean;
+	/**
+	 * Open a streaming vision-describe session: prime an `LlmStreamHandle`'s KV
+	 * with `imageBytes` (raw PNG/JPEG/WebP) + `prompt` through the mmproj at
+	 * `mmprojPath`, then PULL tokens with the existing {@link llmStreamNext} loop
+	 * and release via {@link llmStreamClose} — the same machinery as chat text.
+	 * Throws `VoiceLifecycleError` when the build lacks vision streaming.
+	 */
+	describeImageStreamOpen?(args: {
+		ctx: ElizaInferenceContextHandle;
+		imageBytes: Uint8Array;
+		mmprojPath: string;
+		prompt?: string;
+	}): LlmStreamHandle;
+
 	/* ---- Tokenizer (ABI v9) -------------------------------------- */
 
 	/**
@@ -1037,6 +1060,21 @@ interface BunFfiSymbols {
 		maxTextBytes: bigint | number,
 		outErr: unknown,
 	) => number;
+	// Streaming mmproj vision describe (ABI v13). Optional — absent on <=v12
+	// builds (the probe then reports unsupported and IMAGE_DESCRIPTION falls back
+	// to the buffered `eliza_inference_describe_image`). `_stream_open` returns an
+	// EliLlmStream* (as a pointer/bigint) primed with the image+prompt KV; the
+	// caller drives the existing `eliza_inference_llm_stream_next` loop and frees
+	// via `eliza_inference_llm_stream_close`.
+	eliza_inference_vision_stream_supported?: () => number;
+	eliza_inference_describe_image_stream_open?: (
+		ctx: bigint,
+		imageBytes: unknown,
+		nBytes: bigint | number,
+		mmprojPath: unknown,
+		prompt: unknown,
+		outErr: unknown,
+	) => bigint;
 	// Tokenizer (ABI v9). Optional — absent on v8 builds.
 	eliza_inference_tokenize_supported?: () => number;
 	eliza_inference_tokenize?: (
@@ -1419,6 +1457,21 @@ function bindWithBunFfi(dylibPath: string): ElizaInferenceFfi {
 			returns: T.i32,
 		},
 	};
+	// Streaming mmproj vision describe (ABI v13): open returns an EliLlmStream*
+	// primed with the image+prompt KV; the caller drives the existing
+	// `eliza_inference_llm_stream_next` loop. Layered on top of the v12 surface;
+	// the cascade peels it when a <=v12 library is loaded (the
+	// `visionStreamSupported()` probe then reports false and IMAGE_DESCRIPTION
+	// falls back to the buffered `eliza_inference_describe_image`).
+	let visionStreamSymbolsAvailable = true;
+	const visionStreamDefs = {
+		eliza_inference_vision_stream_supported: { args: [], returns: T.i32 },
+		eliza_inference_describe_image_stream_open: {
+			// ctx, image_bytes, n_bytes, mmproj_path, prompt, out_error -> EliLlmStream*
+			args: [T.ptr, T.ptr, T.usize, T.ptr, T.ptr, T.ptr],
+			returns: T.ptr,
+		},
+	};
 	const coreDefs = {
 		eliza_inference_abi_version: { args: [], returns: T.cstring },
 		eliza_inference_create: {
@@ -1495,7 +1548,36 @@ function bindWithBunFfi(dylibPath: string): ElizaInferenceFfi {
 	const classifierDefs = { ...speakerDefs, ...diarizDefs };
 	const attempts = [
 		{
-			// Full v12 surface (v11 + the in-process ASR word-timestamp decoder).
+			// Full v13 surface (v12 + token-by-token mmproj vision describe).
+			defs: {
+				...coreDefs,
+				...referenceEncodeDefs,
+				...nativeVadDefs,
+				...wakewordDefs,
+				...classifierDefs,
+				...llmStreamDefs,
+				...llmCapabilityDefs,
+				...textModalitiesDefs,
+				...kokoroDefs,
+				...eotDefs,
+				...timedAsrDefs,
+				...visionStreamDefs,
+			},
+			referenceEncode: true,
+			nativeVad: true,
+			wakeword: true,
+			classifiers: true,
+			llmStream: true,
+			llmCapability: true,
+			textModalities: true,
+			kokoro: true,
+			eot: true,
+			timedAsr: true,
+			visionStream: true,
+		},
+		{
+			// Full v12 surface (v11 + the in-process ASR word-timestamp decoder);
+			// a v12 build lacks the v13 streaming-vision symbols.
 			defs: {
 				...coreDefs,
 				...referenceEncodeDefs,
@@ -1731,6 +1813,8 @@ function bindWithBunFfi(dylibPath: string): ElizaInferenceFfi {
 			eotSymbolsAvailable = (attempt as { eot?: boolean }).eot ?? false;
 			timedAsrSymbolsAvailable =
 				(attempt as { timedAsr?: boolean }).timedAsr ?? false;
+			visionStreamSymbolsAvailable =
+				(attempt as { visionStream?: boolean }).visionStream ?? false;
 			break;
 		} catch (err) {
 			lastOpenError = err;
@@ -1774,6 +1858,7 @@ function bindWithBunFfi(dylibPath: string): ElizaInferenceFfi {
 	// tokenizer), accepted only when those are absent too.
 	const abiOk =
 		reported === String(ELIZA_INFERENCE_ABI_VERSION) ||
+		(reported === "12" && !visionStreamSymbolsAvailable) ||
 		(reported === "11" && !timedAsrSymbolsAvailable) ||
 		(reported === "10" && !eotSymbolsAvailable && !timedAsrSymbolsAvailable) ||
 		(reported === "9" && !kokoroSymbolsAvailable && !eotSymbolsAvailable) ||
@@ -2894,6 +2979,45 @@ function bindWithBunFfi(dylibPath: string): ElizaInferenceFfi {
 			return Buffer.from(outText.buffer, outText.byteOffset, len).toString(
 				"utf8",
 			);
+		},
+
+		/* ---- Streaming mmproj vision describe (ABI v13) ------------ */
+
+		visionStreamSupported(): boolean {
+			const probe = loadedLib.symbols.eliza_inference_vision_stream_supported;
+			return (
+				visionStreamSymbolsAvailable &&
+				typeof probe === "function" &&
+				probe() === 1
+			);
+		},
+
+		describeImageStreamOpen({ ctx, imageBytes, mmprojPath, prompt }) {
+			const open = loadedLib.symbols.eliza_inference_describe_image_stream_open;
+			if (!visionStreamSymbolsAvailable || typeof open !== "function") {
+				throw new VoiceLifecycleError(
+					"kernel-missing",
+					"[ffi-bindings] eliza_inference_describe_image_stream_open is not exported by this build",
+				);
+			}
+			const err = makeOutErr();
+			const mmprojArg = cstr(mmprojPath);
+			const promptArg = cstr(prompt ?? null);
+			const handle = open(
+				ctx,
+				ffi.ptr(imageBytes),
+				BigInt(imageBytes.length),
+				mmprojArg.ptr,
+				promptArg.ptr,
+				err.ptr,
+			);
+			if (isNullPointer(handle)) {
+				const message =
+					takeError(err.buf) ??
+					"[ffi-bindings] eliza_inference_describe_image_stream_open returned NULL with no diagnostic";
+				throw new VoiceLifecycleError("kernel-missing", message);
+			}
+			return handle as LlmStreamHandle;
 		},
 
 		/* ---- Tokenizer (ABI v9) ------------------------------------ */


### PR DESCRIPTION
## What

Routes the **local vision describe** (`IMAGE_DESCRIPTION`) onto the **same streaming pipe as chat text** — `onTextChunk → onStreamChunk → SSE → frontend` — so a vision description renders **token-by-token** in the dashboard instead of arriving as one blob.

Gated on a new fused **ABI-v13** streaming-describe entrypoint, with **graceful fallback** to the buffered one-shot `describe_image` on ≤v12 libs (the JS cascade probes `visionStreamSupported()`), so this change is safe to land before the native side ships.

## Changes
- **core** (`types/model.ts`): additive `stream?` / `onStreamChunk?` on `ImageDescriptionParams` + `TranscriptionParams`. The runtime already injects `onStreamChunk` into local model params when a chat streaming context is active (`runtime.ts`).
- **ffi-bindings**: ABI-v13 cascade attempt + `visionStreamSupported()` + `describeImageStreamOpen()`; degrades to `describeImage` on ≤v12.
- **desktop-fused-ffi-backend-runtime**: `describeImage()` decodes token-by-token via `describeImageStreamOpen` + the **existing** `llmStreamNext` loop when `onTextChunk` is set (no event-loop blocking — yields between steps); else the buffered path.
- thread `onTextChunk` + `maxTokensPerStep` through `backend → engine → service` (arbiter vision capability) → the `IMAGE_DESCRIPTION` provider handler.

## Validation
Validated **live on Windows CPU** with SmolVLM-500M (mtmd): token-by-token describe with real **OCR** — read "ELIZA OCR" / "Total: $42.00" off a rendered image, streaming 256 chunks at ~21 tok/s. Evidence (video + stills) attached to #9105.

The native `eliza_inference_describe_image_stream_open` (ABI v13, reuses `llm_stream_next`) lands separately to the `elizaOS/llama.cpp` fork + a gitlink bump; this JS change degrades gracefully until then.

Part of the "every model — including vision — through the same streaming pipe" effort (#9105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)