### PR TITLE
test(ui, app-core): cover genui modes, main-tab discovery, first-run target mapping

### DIFF
--- a/packages/app-core/src/first-run/runtime-target.test.ts
+++ b/packages/app-core/src/first-run/runtime-target.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeServerKindToFirstRunRuntimeTarget,
+  isElizaCloudFirstRunTarget,
+} from "./runtime-target";
+
+/**
+ * First-run runtime-target mapping. `activeServerKindToFirstRunRuntimeTarget`
+ * maps the active server kind onto the first-run target the onboarding flow
+ * persists; the non-obvious `cloud → elizacloud` rename is exactly the kind of
+ * mapping a regression silently flips. `isElizaCloudFirstRunTarget` is the
+ * predicate gating cloud-only onboarding. Both pure, zero deps, untested.
+ */
+describe("activeServerKindToFirstRunRuntimeTarget", () => {
+  it("maps each server kind to its first-run target", () => {
+    expect(activeServerKindToFirstRunRuntimeTarget("local")).toBe("local");
+    expect(activeServerKindToFirstRunRuntimeTarget("remote")).toBe("remote");
+    expect(activeServerKindToFirstRunRuntimeTarget("cloud")).toBe("elizacloud");
+  });
+});
+
+describe("isElizaCloudFirstRunTarget", () => {
+  it("is true only for the elizacloud targets", () => {
+    expect(isElizaCloudFirstRunTarget("elizacloud")).toBe(true);
+    expect(isElizaCloudFirstRunTarget("elizacloud-hybrid")).toBe(true);
+    expect(isElizaCloudFirstRunTarget("local")).toBe(false);
+    expect(isElizaCloudFirstRunTarget("remote")).toBe(false);
+    expect(isElizaCloudFirstRunTarget("")).toBe(false);
+  });
+});

--- a/packages/ui/src/genui/modes.test.ts
+++ b/packages/ui/src/genui/modes.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCatalogPromptWithMode,
+  getModePromptRules,
+  getModeSystemPrompt,
+  INLINE_MODE_PROMPT_RULES,
+  STANDALONE_MODE_PROMPT_RULES,
+} from "./modes";
+
+/**
+ * GenUI generation-mode prompt assembly. `modes.ts` builds the numbered rule
+ * block and system-prompt header that tells the model whether to emit UI-only
+ * JSONL (standalone) or converse-then-UI (inline). It isn't re-exported from
+ * the genui barrel and had no test, so a regression in the rule selection or
+ * numbering would silently change every GenUI generation. Pure string assembly.
+ */
+describe("getModePromptRules", () => {
+  it("numbers the standalone rule set from 1", () => {
+    const out = getModePromptRules("standalone");
+    expect(out.startsWith(`1. ${STANDALONE_MODE_PROMPT_RULES[0]}`)).toBe(true);
+    expect(out.split("\n")).toHaveLength(STANDALONE_MODE_PROMPT_RULES.length);
+  });
+
+  it("uses the inline rule set for inline mode", () => {
+    const out = getModePromptRules("inline");
+    expect(out.startsWith(`1. ${INLINE_MODE_PROMPT_RULES[0]}`)).toBe(true);
+  });
+
+  it("appends custom rules with continued numbering", () => {
+    const out = getModePromptRules("standalone", ["Extra rule"]);
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(STANDALONE_MODE_PROMPT_RULES.length + 1);
+    expect(lines[lines.length - 1]).toBe(
+      `${STANDALONE_MODE_PROMPT_RULES.length + 1}. Extra rule`,
+    );
+  });
+});
+
+describe("getModeSystemPrompt", () => {
+  it("defaults an empty config to standalone", () => {
+    expect(getModeSystemPrompt({})).toContain("Standalone (UI-only)");
+  });
+
+  it("labels inline mode", () => {
+    expect(getModeSystemPrompt({ mode: "inline" })).toContain(
+      "Inline (conversation + UI)",
+    );
+  });
+});
+
+describe("buildCatalogPromptWithMode", () => {
+  it("returns the catalog unchanged when no mode config is given", () => {
+    expect(buildCatalogPromptWithMode("CATALOG")).toBe("CATALOG");
+  });
+
+  it("appends the mode system prompt when a config is given", () => {
+    const out = buildCatalogPromptWithMode("CATALOG", { mode: "inline" });
+    expect(out).toContain("CATALOG");
+    expect(out).toContain("## Generation Mode:");
+    expect(out).toContain("Inline (conversation + UI)");
+  });
+});

--- a/packages/ui/src/navigation/main-tab.test.ts
+++ b/packages/ui/src/navigation/main-tab.test.ts
@@ -1,0 +1,55 @@
+import type { RegistryAppInfo } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { getMainTabApp } from "./main-tab";
+
+/**
+ * Main-tab discovery. An app claims the shell's default landing tab by setting
+ * `elizaos.app.mainTab=true`; `getMainTabApp` picks the unique declarer (or the
+ * alphabetically-first when several misconfigure it) and maps its package name
+ * to a route slug. Untested, so a regression in the declarer filter, the
+ * deterministic tie-break, or the name→slug mapping would silently change where
+ * the shell lands. Pure (the sort runs on a filtered copy, never the input).
+ */
+
+// getMainTabApp only reads `name` + `mainTab`; cast a minimal record.
+const appInfo = (name: string, mainTab?: boolean | string): RegistryAppInfo =>
+  ({ name, mainTab }) as unknown as RegistryAppInfo;
+
+describe("getMainTabApp", () => {
+  it("returns null when no app declares mainTab", () => {
+    expect(getMainTabApp([])).toBeNull();
+    expect(getMainTabApp([appInfo("@elizaos/app-feed", false)])).toBeNull();
+    // a non-boolean mainTab is ignored defensively.
+    expect(getMainTabApp([appInfo("@elizaos/app-feed", "true")])).toBeNull();
+  });
+
+  it("maps the declarer's package name to a route slug", () => {
+    expect(getMainTabApp([appInfo("@elizaos/app-feed", true)])).toEqual({
+      tabId: "feed",
+      appName: "@elizaos/app-feed",
+    });
+  });
+
+  it("breaks ties deterministically by package name", () => {
+    const apps = [
+      appInfo("@elizaos/app-zebra", true),
+      appInfo("@elizaos/app-alpha", true),
+    ];
+    expect(getMainTabApp(apps)).toEqual({
+      tabId: "alpha",
+      appName: "@elizaos/app-alpha",
+    });
+  });
+
+  it("does not mutate the input array order", () => {
+    const apps = [
+      appInfo("@elizaos/app-zebra", true),
+      appInfo("@elizaos/app-alpha", true),
+    ];
+    getMainTabApp(apps);
+    expect(apps.map((a) => a.name)).toEqual([
+      "@elizaos/app-zebra",
+      "@elizaos/app-alpha",
+    ]);
+  });
+});


### PR DESCRIPTION
Three pure, previously-untested helpers across the UI shell and app-core boot:

- **`genui/modes.ts`** (`getModePromptRules` / `getModeSystemPrompt` / `buildCatalogPromptWithMode`) — assembles the numbered rule block + system-prompt header that tells the model UI-only-JSONL (standalone) vs converse-then-UI (inline). Not re-exported from the genui barrel and untested. Pins rule-set selection, 1-based numbering, custom-rule appending with continued numbering, the standalone default, the inline label, and catalog passthrough vs append.
- **`navigation/main-tab.ts`** (`getMainTabApp`) — picks the app that claims the shell's default landing tab. Pins the no-declarer → null (incl. defensive non-boolean `mainTab`), the name→route-slug mapping, the deterministic alphabetic tie-break across multiple declarers, and that the input array is never mutated.
- **`first-run/runtime-target.ts`** (`activeServerKindToFirstRunRuntimeTarget` / `isElizaCloudFirstRunTarget`) — pins the server-kind→target mapping (incl. the non-obvious `cloud → elizacloud` rename) and the cloud-target predicate.

```
ui:       bunx vitest run genui/modes.test.ts navigation/main-tab.test.ts → 11 passed
app-core: bunx vitest run first-run/runtime-target.test.ts               → 2 passed
```
biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)