### PR TITLE
test(health): cover sleep-cycle classification + personal baseline (#8795)

### DIFF
--- a/plugins/plugin-health/src/sleep/sleep-cycle.test.ts
+++ b/plugins/plugin-health/src/sleep/sleep-cycle.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { classifyLifeOpsSleepCycleType } from "./sleep-cycle.js";
+
+/**
+ * Sleep-cycle classification (#8795 health). `classifyLifeOpsSleepCycleType`
+ * decides whether an episode is an overnight sleep, a nap, or unknown — the
+ * label that drives day-boundary anchoring and the awake/wake inference. It was
+ * untested. Pure given its inputs (duration math + local-hour lookups); these
+ * use UTC so the local-hour thresholds are deterministic.
+ */
+
+const H = 3_600_000;
+// A UTC timestamp at the given local hour (UTC) on a fixed date.
+const at = (hour: number, day = 1): number => Date.UTC(2024, 0, day, hour);
+const UTC = "UTC";
+
+describe("classifyLifeOpsSleepCycleType", () => {
+  it("classifies a ≥4h evening-start sleep as overnight", () => {
+    const start = at(23);
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: start,
+        endMs: start + 7 * H,
+        nowMs: start + 8 * H,
+        timezone: UTC,
+      }),
+    ).toBe("overnight");
+  });
+
+  it("classifies a ≥4h early-morning-start sleep as overnight", () => {
+    const start = at(2); // startHour < 6
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: start,
+        endMs: start + 5 * H,
+        nowMs: start + 6 * H,
+        timezone: UTC,
+      }),
+    ).toBe("overnight");
+  });
+
+  it("classifies a ≥4h sleep that ends by 11:00 as overnight (end-hour branch)", () => {
+    // startHour 7 is neither ≥18 nor <6, so only endHour ≤ 11 can qualify it.
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: at(7),
+        endMs: at(11), // exactly 4h, ends at 11:00
+        nowMs: at(12),
+        timezone: UTC,
+      }),
+    ).toBe("overnight");
+  });
+
+  it("classifies a short daytime sleep as a nap", () => {
+    const start = at(14);
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: start,
+        endMs: start + 1.5 * H,
+        nowMs: start + 2 * H,
+        timezone: UTC,
+      }),
+    ).toBe("nap");
+  });
+
+  it("classifies a long midday sleep that fits no rule as unknown", () => {
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: at(12), // 12:00 → not ≥18, not <6
+        endMs: at(17), // 17:00 → not ≤11; 5h duration
+        nowMs: at(18),
+        timezone: UTC,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("treats a zero-duration interval as unknown", () => {
+    const t = at(10);
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: t,
+        endMs: t,
+        nowMs: t,
+        timezone: UTC,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("uses nowMs as the end when endMs is null (in-progress sleep)", () => {
+    const start = at(22); // 22:00 → ≥18
+    expect(
+      classifyLifeOpsSleepCycleType({
+        startMs: start,
+        endMs: null,
+        nowMs: start + 4 * H, // 4h so far
+        timezone: UTC,
+      }),
+    ).toBe("overnight");
+  });
+});

--- a/plugins/plugin-health/src/sleep/sleep-regularity.baseline.test.ts
+++ b/plugins/plugin-health/src/sleep/sleep-regularity.baseline.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePersonalBaseline,
+  type SleepRegularityEpisodeLike,
+} from "./sleep-regularity.js";
+
+/**
+ * Personal sleep baseline (#8795 health). `computePersonalBaseline` reduces a
+ * set of recent sleep episodes into the median bedtime/wake/duration + circular
+ * stddev that the circadian + regularity engines compare against. It was
+ * untested. Using UTC + identical episode times makes the circular means
+ * exactly predictable (mean of identical angles = that angle, stddev 0).
+ */
+
+const NOW = Date.parse("2024-01-10T00:00:00Z");
+
+// Five identical overnight episodes: 23:00 → 07:00 UTC (8h) on consecutive days.
+const overnightEpisodes = (count: number): SleepRegularityEpisodeLike[] =>
+  Array.from({ length: count }, (_, i) => ({
+    startAt: `2024-01-0${i + 1}T23:00:00Z`,
+    endAt: `2024-01-0${i + 2}T07:00:00Z`,
+    cycleType: "overnight" as const,
+  }));
+
+describe("computePersonalBaseline", () => {
+  it("returns null below the minimum sample count", () => {
+    expect(
+      computePersonalBaseline({
+        episodes: overnightEpisodes(4),
+        timezone: "UTC",
+        nowMs: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("computes medians + zero stddev for a run of identical episodes", () => {
+    const baseline = computePersonalBaseline({
+      episodes: overnightEpisodes(5),
+      timezone: "UTC",
+      nowMs: NOW,
+    });
+    expect(baseline).not.toBeNull();
+    expect(baseline).toMatchObject({
+      medianBedtimeLocalHour: 23,
+      medianWakeLocalHour: 7,
+      medianSleepDurationMin: 480, // 8h
+      sampleCount: 5,
+      windowDays: 28, // default
+    });
+    expect(baseline?.bedtimeStddevMin).toBeCloseTo(0, 5);
+    expect(baseline?.wakeStddevMin).toBeCloseTo(0, 5);
+  });
+
+  it("echoes a windowDays override and excludes naps + future/short episodes", () => {
+    const episodes: SleepRegularityEpisodeLike[] = [
+      ...overnightEpisodes(5),
+      // a nap — excluded regardless of duration
+      {
+        startAt: "2024-01-03T14:00:00Z",
+        endAt: "2024-01-03T18:00:00Z",
+        cycleType: "nap",
+      },
+      // ends after nowMs — excluded
+      {
+        startAt: "2024-01-20T23:00:00Z",
+        endAt: "2024-01-21T07:00:00Z",
+        cycleType: "overnight",
+      },
+      // under 3h — excluded
+      {
+        startAt: "2024-01-04T01:00:00Z",
+        endAt: "2024-01-04T03:00:00Z",
+        cycleType: "overnight",
+      },
+    ];
+    const baseline = computePersonalBaseline({
+      episodes,
+      timezone: "UTC",
+      nowMs: NOW,
+      windowDays: 14,
+    });
+    // Only the 5 qualifying overnight episodes count.
+    expect(baseline?.sampleCount).toBe(5);
+    expect(baseline?.windowDays).toBe(14);
+  });
+});


### PR DESCRIPTION
Two pure sleep-inference cores that drive day-boundary anchoring, circadian state, and regularity scoring — both untested:

- **`sleep-cycle.ts` — `classifyLifeOpsSleepCycleType`** labels an episode overnight / nap / unknown. Pins all three overnight entry conditions (evening start ≥18, early-morning start <6, and the end-by-11:00 branch isolated with a 07:00 start), the short-daytime nap, a long-midday "fits no rule" unknown, the zero-duration unknown, and the in-progress case where a null `endMs` falls back to `nowMs`. UTC timezone keeps the local-hour thresholds deterministic.
- **`sleep-regularity.ts` — `computePersonalBaseline`** reduces recent episodes into the median bedtime/wake/duration + circular stddev the engines compare against. Pins the min-sample gate (→ null), the exact medians + zero stddev for a run of identical UTC episodes, the `windowDays` echo, and the eligibility filter (naps, future-ending, and sub-3h episodes excluded).

```
bunx vitest run sleep-cycle.test.ts sleep-regularity.baseline.test.ts → 10 passed (10)
```
biome clean. Refs #8795

🤖 Generated with [Claude Code](https://claude.com/claude-code)