### PR TITLE
chore: integrate useful open-branch leftovers

### DIFF
--- a/plugins/plugin-app-control/README.md
+++ b/plugins/plugin-app-control/README.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-app-control
 
-An elizaOS plugin that lets an Eliza agent launch, close, list, scaffold, and verify Eliza apps; manage UI views contributed by plugins; and customize the live homescreen canvas.
+An elizaOS plugin that lets an Eliza agent launch, close, list, scaffold, and verify Eliza apps; manage UI views contributed by plugins; and change the unified app background.
 
 ## What it does
 
@@ -15,7 +15,7 @@ Loading this plugin gives an Eliza agent three new actions:
 
 **VIEWS** — Full view management. The agent can navigate to any UI view contributed by any loaded plugin; report the currently-open view; search views by name; open the view manager; broadcast events to mounted views; interact with a view (click, get state, focus, etc.); pin a view as a desktop tab; open a view in a separate window; and create, edit, or delete view plugins through a coding-agent backed flow.
 
-**HOMESCREEN** — Live homescreen customization. The agent reads the current scene document, asks the model to rewrite it based on the user's description, and pushes the updated document to the client. Also supports history operations: undo, redo, reset, duplicate, delete, save.
+**BACKGROUND** — Unified background control. The agent can set a named color or hex color, use an uploaded image, generate a background image from a prompt, undo the previous background, or reset to default. It broadcasts a `background:apply` view event that the always-mounted app background applies to the shared `BackgroundConfig` store.
 
 ## Capabilities added to the agent
 
@@ -24,7 +24,7 @@ Loading this plugin gives an Eliza agent three new actions:
 | `APP` | `automation`, `settings`, `code` | Owner |
 | `VIEWS` (read modes) | `general`, `automation`, `settings`, `code` | User |
 | `VIEWS` (create/edit/delete) | `general`, `automation`, `settings`, `code` | Owner |
-| `HOMESCREEN` | `general`, `settings` | User |
+| `BACKGROUND` | `general`, `settings` | User |
 
 The `available_apps` provider injects installed + running app data into the agent's planning context when operating in the `settings` or `automation` context, so the agent can pick a target without an extra round-trip.
 

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -66,6 +66,14 @@ describe("inferBackgroundPlan", () => {
 		});
 	});
 
+	it("does not throw on attachment records without a URL", () => {
+		expect(() =>
+			inferBackgroundPlan("set the background from this attachment", [
+				{} as Media,
+			]),
+		).not.toThrow();
+	});
+
 	it("generates from a description when no color resolves", () => {
 		const plan = inferBackgroundPlan(
 			"generate a misty forest background",

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -162,11 +162,12 @@ function resolveColor(
 function firstImageAttachment(attachments?: Media[]): Media | null {
 	if (!attachments?.length) return null;
 	for (const att of attachments) {
+		const url = typeof att.url === "string" ? att.url : "";
 		const looksImage =
 			att.contentType === "image" ||
-			/\.(png|jpe?g|gif|webp|avif|svg)(\?|#|$)/i.test(att.url) ||
-			att.url.startsWith("data:image/");
-		if (looksImage && att.url) return att;
+			/\.(png|jpe?g|gif|webp|avif|svg)(\?|#|$)/i.test(url) ||
+			url.startsWith("data:image/");
+		if (looksImage && url) return att;
 	}
 	return null;
 }

--- a/plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md
+++ b/plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md
@@ -1,5 +1,20 @@
 # Porting `gemma4-assistant` (the Gemma-4 MTP drafter arch) into the elizaOS llama.cpp fork
 
+> **UPDATE 2026-06-23 — DONE (the additive port worked).** The targeted port was
+> completed and validated in the fork, *without* a full rebase. The `mem_other` /
+> `share` / `ctx_other` infra is additive (every existing arch passes null), so the
+> custom KV kernels are untouched. Fork PR **elizaOS/llama.cpp#32** (branch
+> `feat/gemma4-assistant-arch`, 22 files +419/-26), milady gitlink bump **eliza
+> #9268**. Validated on M4 Max Metal: loads `gemma4-assistant` cleanly, correct
+> output, ~41-49% draft acceptance, **~1.1x decode speedup** (evidence:
+> `native/verify/evidence/platform/gemma4-assistant-fork-draft-mtp.log`). Three
+> fork-side MTP correctness bugs were fixed in the process (hidden-state row
+> sizing by n_embd vs n_embd_out; the target gemma4 graph never exposed its
+> post-norm hidden — `res->t_h_pre_norm = cur` took acceptance 8%->41%; the
+> `swa_full` override oversized the shared SWA draft cache). The rest of this doc
+> is the original pre-port plan, kept for reference.
+
+
 **Status (2026-06-23):** the drafter is **validated working on upstream**; the fork
 integration is scoped here. This doc is the AGENTS.md-required "concrete porting
 plan in the repo docs" that must exist before the upstream rebase / targeted port.

--- a/plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md
+++ b/plugins/plugin-local-inference/docs/gemma4-assistant-fork-port-plan.md
@@ -1,0 +1,122 @@
+# Porting `gemma4-assistant` (the Gemma-4 MTP drafter arch) into the elizaOS llama.cpp fork
+
+**Status (2026-06-23):** the drafter is **validated working on upstream**; the fork
+integration is scoped here. This doc is the AGENTS.md-required "concrete porting
+plan in the repo docs" that must exist before the upstream rebase / targeted port.
+
+## What's proven
+
+`amaranus/Gemma-4-E2B-it-qat-assistant-MTP-Q8_0` (Google's official `gemma-4-E2B-
+it-assistant` MTP head, arch `gemma4-assistant`, gemma-4 vocab, `nextn_predict_
+layers=4`) runs end-to-end via **upstream** `ggml-org/llama.cpp` (b1-ac4105d):
+
+```
+llama-cli -m <eliza-1 gemma-4-E2B> -md <amaranus> -fa on --spec-type draft-mtp
+  baseline 105.5 t/s → draft-mtp 136.2 t/s  =  1.29× on Apple M4 Max Metal
+```
+
+So the runtime + the drafter exist; the only gap is bringing the arch into the
+fork. **No H200, no distillation** is needed for a working drafter (a bigger,
+uniform all-tier speedup is a separate optimization — see the drafter runbook).
+
+## Why this is a rebase-class change, not an additive port
+
+The arch *model* (`src/models/gemma4-assistant.cpp`, 204 lines) ports cleanly —
+the fork's `llm_graph` API (`build_attn_inp_kv_iswa`, `build_attn`, `build_ffn`,
+`build_norm`, `build_lora_mm`, `llm_graph_input_embd`) is byte-identical, and
+`src/models/gemma4.cpp` is the naming template (`swa_layers`, `hparams.n_layer`,
+`nextn_predict_layers`).
+
+**The blocker is the draft↔target linkage.** gemma4-assistant's graph reaches
+into the *target* context for the target's `tok_embd` and shares the target's
+KV cache:
+
+```cpp
+const auto * model_other = llama_get_model(cparams.ctx_other);   // line 112
+ggml_tensor * x = ggml_get_rows(ctx0, model_other->tok_embd, inp_tokens);
+```
+
+This requires the upstream **`ctx_other` + shared-KV (`mem_other`/`share`)**
+infrastructure, which the fork (v1.2.0-eliza) does **not** have:
+
+- `llama_kv_cache_iswa` ctor: fork lacks the `mem_other` + `layer_share_cb share`
+  params (upstream `src/llama-kv-cache-iswa.h`).
+- `llama_memory_params`: fork lacks `mem_other` (`src/llama-memory.h`).
+- `llama_cparams` / `llama_context_params`: fork lacks `ctx_other`.
+- The `share` callback is consumed in the **KV-cache core**
+  (`src/llama-kv-cache.cpp:191` `const int32_t il_share = share(il);`) — the
+  per-layer KV mapping. The fork's KV cache carries the **custom TurboQuant / QJL
+  / PolarQuant kernels**; merging upstream's KV-sharing into it is the same
+  conflict-prone work AGENTS.md flags for the rebase.
+
+Surface: **13 upstream files** touch `mem_other` / `ctx_other` / `layer_share_cb`
+(`llama-kv-cache.{h,cpp}`, `llama-kv-cache-iswa.{h,cpp}`, `llama-memory.h`,
+`llama-cparams.h`, `llama-context.cpp`, `include/llama.h`, `llama-ext.h`,
+`llama-model.cpp`, `common/speculative.cpp`, `models/eagle3.cpp`,
+`models/gemma4-assistant.cpp`).
+
+## Recommended path: the upstream rebase
+
+The clean integration is the AGENTS.md-deferred **rebase of the fork onto recent
+upstream**, which reconciles the KV-cache divergence holistically and brings
+`gemma4-assistant` + `eagle3` + other gemma-4 fixes wholesale. The conflict-prone
+files remain the quant-slot enums (`ggml-common.h`/`ggml.h`) and the `Q1_0`
+block layout, plus the KV-cache-sharing reconciliation above.
+
+## Alternative: targeted port (only if the rebase is deferred further)
+
+If a surgical port is taken instead, the **complete file-by-file spec** is below.
+The additive parts are safe; the KV-core parts (★) are the risk.
+
+### Additive (low risk)
+1. `src/llama-arch.h`: add `LLM_ARCH_GEMMA4_ASSISTANT`; tensor enums
+   `LLM_TENSOR_NEXTN_PROJ_PRE`, `LLM_TENSOR_NEXTN_PROJ_POST`,
+   `LLM_TENSOR_MASKED_EMBD_CENTROIDS`, `LLM_TENSOR_MASKED_EMBD_ORDERING`.
+   (All needed KV enums + `LLM_TENSOR_LAYER_OUT_SCALE`/`ROPE_FREQS` already exist.)
+2. `src/llama-arch.cpp`: arch-name `"gemma4-assistant"`; the 4 tensor-name +
+   4 `LLM_TENSOR_INFOS` entries (`nextn.pre_projection`→`{LAYER_REPEATING,
+   MUL_MAT}`, `nextn.post_projection`→`{LAYER_OUTPUT, MUL_MAT}`, the two
+   masked-embd → `{LAYER_INPUT, NONE}`).
+3. `src/llama-hparams.h`: add `uint32_t n_embd_inp_impl = 0;`. `.cpp`: make
+   `n_embd_inp()` honor it (`if (n_embd_inp_impl > 0) return n_embd_inp_impl;`).
+   (`n_embd_out_impl`, `*_swa`, `swa_layers`, `nextn_predict_layers`,
+   `f_attention_scale`, `n_swa`, `rope_freq_base_train_swa` already exist.)
+4. `src/models/models.h`: add the `llama_model_gemma4_assistant` struct decl
+   (verbatim from upstream `models.h`).
+5. `src/llama-model.h`: add `nextn_proj_pre`/`nextn_proj_post` model fields.
+   (Layer fields `out_scale`, `rope_freqs`, attn/ffn norms all exist.)
+6. `src/llama-graph.h`: add `ggml_tensor * t_h_nextn = nullptr;` +
+   `get_h_nextn()`; add `const int64_t n_layer_nextn;` member to
+   `llm_graph_context` (init from `hparams.nextn_predict_layers`) — or inline.
+7. `src/models/gemma4-assistant.cpp`: NEW; copy upstream with fork-naming subs
+   (`is_swa_impl`→`swa_layers`, `n_layer()`→`n_layer`, `n_layer_nextn`→graph
+   member or `(int)hparams.nextn_predict_layers`; drop the `== n_layer_all`
+   assert). Mark `res->t_h_nextn` as a graph output (`ggml_set_output`).
+8. `src/CMakeLists.txt`: add `models/gemma4-assistant.cpp`.
+9. `src/llama-model.cpp`: add the factory `case` (`new
+   llama_model_gemma4_assistant`) + the rope-type `case` (NEOX fall-through).
+
+### KV-core + ctx_other (★ the risky reconciliation)
+10. `src/llama-cparams.h` + `include/llama.h` + `src/llama-context.cpp`: add
+    `ctx_other` (params → cparams), `llama_get_ctx_other`, and the ctor init
+    (throw if null for `GEMMA4_ASSISTANT`), default-params init.
+11. `src/llama-memory.h`: add `mem_other` to `llama_memory_params`.
+12. `src/llama-kv-cache-iswa.{h,cpp}` + `src/llama-kv-cache.{h,cpp}`: add the
+    `mem_other` + `layer_share_cb share` params and the `il_share = share(il)`
+    per-layer mapping — **reconciled with the fork's custom KV kernels**. This
+    is the rebase-class work.
+13. `src/llama-model.cpp` `create_memory`: add the `GEMMA4_ASSISTANT` share
+    lambda + `llama_kv_cache_iswa(... mem_other, filter, reuse, share)` block
+    (verbatim from upstream, adapted to the fork ctor once #12 lands).
+14. The fork's draft-context creation (the caller of `common_speculative` for
+    `--spec-type draft-mtp`): set `cparams.ctx_other = ctx_tgt` (upstream does
+    this in `tools/server/server-context.cpp:1217,1240`).
+
+## References
+
+- Upstream model: `/tmp/upstream-llama/src/models/gemma4-assistant.cpp`
+- Upstream class decl: upstream `src/models/models.h` (`llama_model_gemma4_assistant`)
+- Upstream KV-share core: upstream `src/llama-kv-cache.cpp:191`
+- Upstream host linkage: upstream `tools/server/server-context.cpp:1217,1240`
+- Fork naming template: `src/models/gemma4.cpp`; existing drafter arch: `src/models/dflash-draft.cpp`
+- Drafter validation: `native/verify/evidence/platform/amaranus-draft-mtp-metal.log`

--- a/plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md
+++ b/plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md
@@ -191,9 +191,22 @@ llama-cli -m <eliza-1 gemma-4-E2B> -md <amaranus MTP-Q8_0> -ngl 99 -ngld 99 -fa 
 ```
 
 The drafter **loads, accepts draft tokens, and accelerates** — even though it is
-trained for `gemma-4-E2B-it-assistant` while drafting the eliza-1 *base* here (the
-matched `-it` target gives more). So "one working math" is proven: a real,
-released Gemma-4 MTP drafter works on Metal, no training.
+trained for `gemma-4-E2B-it-assistant` while drafting the eliza-1 *base* here.
+So "one working math" is proven: a real, released Gemma-4 MTP drafter works on
+Metal, no training.
+
+**Speedup is target-cost-dependent (honest caveat).** Re-running against the
+*matched* `google/gemma-4-E2B-it-qat-q4_0` target gave the opposite — baseline
+145 t/s vs draft-mtp 106 t/s (a regression): on a fast Q4 target the per-step
+drafter cost outweighs the acceptance benefit. The amaranus head is QAT-derived
+from INT4 weights, so its acceptance ceiling is modest (~the 35% the LiteRT
+extraction reports); it nets a win on a *slow* target (Q8 eliza-1: 1.29×) but not
+on the fast Q4 mobile entry tier. So: a working drafter exists today **for free**
+and helps the larger/Q8 tiers; a **bigger, uniform speedup across all tiers**
+(especially the Q4 2b) is where a from-scratch BF16-distilled drafter on an H200
+— or applying TurboQuant to a higher-acceptance head — would pay off. That is the
+only place H200 spend is still justified, and it is an optimization, not a
+blocker.
 
 **Integration into eliza = bring `gemma4-assistant` into the fork.** Two options,
 both bounded (no training):

--- a/plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md
+++ b/plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md
@@ -174,3 +174,42 @@ The `mtp: "separate-drafter"` manifest + `mtp/drafter-<tier>.gguf` contract (PR
 #9172) stays as-is; this GGUF becomes `mtp/drafter-2b.gguf` once the arch loads.
 Staged locally at `~/.local/state/eliza/models/drafts/gemma-4-E2B-mtp-amaranus.gguf`.
 
+### VALIDATED on Metal via upstream llama.cpp (2026-06-23)
+
+Upstream `ggml-org/llama.cpp` (b1-ac4105d) already implements the whole path —
+`LLM_ARCH_GEMMA4_ASSISTANT`, `src/models/gemma4-assistant.cpp` (the NextN graph:
+`x = tok_embd[next]·√d`; `xh = concat(x, target_hidden)`; `nextn_proj_pre·xh` →
+4 attention blocks → `nextn_proj_post` → logits), and `--spec-type draft-mtp`
+with the `ctx_other` target-context link. Built it with Metal and ran the real
+amaranus drafter against the eliza-1 gemma-4-E2B target on an Apple M4 Max:
+
+```
+llama-cli -m <eliza-1 gemma-4-E2B> -md <amaranus MTP-Q8_0> -ngl 99 -ngld 99 -fa on \
+          --spec-type draft-mtp --spec-draft-n-max 3
+  baseline (no drafter):     105.5 tok/s
+  amaranus draft-mtp:        136.2 tok/s   →  1.29× speedup, coherent output
+```
+
+The drafter **loads, accepts draft tokens, and accelerates** — even though it is
+trained for `gemma-4-E2B-it-assistant` while drafting the eliza-1 *base* here (the
+matched `-it` target gives more). So "one working math" is proven: a real,
+released Gemma-4 MTP drafter works on Metal, no training.
+
+**Integration into eliza = bring `gemma4-assistant` into the fork.** Two options,
+both bounded (no training):
+1. **Rebase the fork onto recent upstream** (the AGENTS.md "deferred rebase"),
+   which brings `gemma4-assistant` + the upstream `draft-mtp`/`ctx_other` engine
+   wholesale. Cleanest; also lands the other upstream gemma-4 fixes.
+2. **Targeted port**: copy `src/models/gemma4-assistant.cpp`, the
+   `LLM_ARCH_GEMMA4_ASSISTANT` enum + `LLM_TENSOR_NEXTN_PROJ_{PRE,POST}` +
+   `nextn_predict_layers`/`*_length_swa` hparams, and the `ctx_other` draft-mtp
+   link, adapting to the fork's `llm_graph` API. Note the fork's current
+   `draft-mtp` is the `dflash-draft` (cross-attention) design, distinct from the
+   upstream `ctx_other` NextN design, so the speculative-engine link is the part
+   that needs care.
+
+Once the fork loads `gemma4-assistant`, the amaranus GGUF becomes
+`mtp/drafter-2b.gguf` and the `mtp: "separate-drafter"` manifest (PR #9172) ships
+release-shaped — no H200, no in-house distillation.
+Evidence: `native/verify/evidence/platform/amaranus-draft-mtp-metal.log`.
+

--- a/plugins/plugin-local-inference/native/verify/evidence/platform/amaranus-draft-mtp-metal.log
+++ b/plugins/plugin-local-inference/native/verify/evidence/platform/amaranus-draft-mtp-metal.log
@@ -1,0 +1,12 @@
+# Gemma-4-E2B MTP drafter (amaranus/Gemma-4-E2B-it-qat-assistant-MTP-Q8_0) — draft-mtp speculative decode on Apple M4 Max Metal, 2026-06-23
+# Upstream llama.cpp b1-ac4105d (has LLM_ARCH_GEMMA4_ASSISTANT + src/models/gemma4-assistant.cpp + --spec-type draft-mtp)
+# Drafter: amaranus ...MTP-Q8_0.gguf (93MB, gemma4-assistant arch, nextn_predict_layers=4, gemma4 vocab 262144)
+# Target:  eliza-1 gemma-4-E2B (candidates/gemma-2b-base-v1/text/eliza-1-2b-128k.gguf, Q8_0)
+# Command: llama-cli -m <target> -md <amaranus> -ngl 99 -ngld 99 -fa on --spec-type draft-mtp --spec-draft-n-max 3
+
+Drafter arch loaded OK (Gemma4Assistant; ctx_other linked during gen — the init-time warning is the documented "normal during memory fitting").
+Output coherent (target verifies every token).
+
+BASELINE (no drafter):       Generation 105.5 t/s
+SPEC (amaranus draft-mtp):   Generation 136.2 t/s   => 1.29x speedup on Metal
+(matched -it-assistant target gives more; amaranus is trained for gemma-4-E2B-it-assistant, here drafting the eliza-1 base.)

--- a/plugins/plugin-local-inference/native/verify/evidence/platform/amaranus-draft-mtp-metal.log
+++ b/plugins/plugin-local-inference/native/verify/evidence/platform/amaranus-draft-mtp-metal.log
@@ -10,3 +10,10 @@ Output coherent (target verifies every token).
 BASELINE (no drafter):       Generation 105.5 t/s
 SPEC (amaranus draft-mtp):   Generation 136.2 t/s   => 1.29x speedup on Metal
 (matched -it-assistant target gives more; amaranus is trained for gemma-4-E2B-it-assistant, here drafting the eliza-1 base.)
+
+# Matched target google/gemma-4-E2B-it-qat-q4_0 (the README pairing), same drafter:
+#   BASELINE (no drafter): 145.0 t/s  |  SPEC (draft-mtp): 106.1 t/s  => 0.73x (regression)
+# Interpretation: amaranus is QAT/INT4-derived (~35% acceptance ceiling). MTP nets a win on a SLOW
+# target (Q8 eliza-1, 1.29x) but the per-step drafter cost dominates on a FAST Q4 target. A working
+# drafter exists for free today (helps Q8+ tiers); a uniform all-tier speedup needs a higher-acceptance
+# (BF16-distilled / TurboQuant'd) head — the only remaining justification for H200 spend, as an optimization.

--- a/plugins/plugin-local-inference/native/verify/evidence/platform/gemma4-assistant-fork-draft-mtp.log
+++ b/plugins/plugin-local-inference/native/verify/evidence/platform/gemma4-assistant-fork-draft-mtp.log
@@ -1,0 +1,11 @@
+# gemma4-assistant arch ported into the elizaOS llama.cpp fork — draft-mtp on Apple M4 Max Metal, 2026-06-23
+# Fork branch feat/gemma4-assistant-arch (elizaOS/llama.cpp PR #32), HEAD 2323fa863; milady gitlink bump = eliza PR #9268.
+# Drafter: amaranus/Gemma-4-E2B-it-qat-assistant-MTP-Q8_0 (gemma4-assistant arch). Target: eliza-1 gemma-4-E2B (Q8_0).
+# llama-cli -m <target> -md <amaranus> -ngl 99 -ngld 99 -fa on --spec-type draft-mtp --spec-draft-n-max 2
+
+Loads gemma4-assistant cleanly: no unknown-arch, no missing-tensor errors (49 drafter tensors map).
+Correct output (e.g. "2+2" -> "4"). Draft acceptance ~41-49% (was ~2% before the fork-MTP correctness fixes).
+
+BASELINE (no drafter), 3 runs:  96.4 / 98.1 / 90.8 t/s   (median ~96)
+SPEC (draft-mtp + amaranus):   103.1 / 104.6 / 109.4 t/s  (median ~105)  => ~1.1x speedup
+(Lower than upstream's 1.29x because this host was under load; the speedup is consistent + positive at n_max 2.)


### PR DESCRIPTION
## Summary

- Hardens the app-control `BACKGROUND` action so attachment records without a string URL do not throw during image detection.
- Updates the app-control README to document `BACKGROUND` instead of the superseded `HOMESCREEN` action.
- Carries forward useful fused-engine Metal MTP validation docs and evidence from `docs/fused-engine-metal-mtp-status`.

## Branch review

- `fix/cloud-frontend-stale-refs`: main background-control work is now already on `develop`; this PR keeps the extra attachment hardening and README cleanup.
- `docs/fused-engine-metal-mtp-status`: keeps the useful Metal drafter validation, caveat, fork-port plan, and evidence logs.
- `test/8795-stretch-decider`, `perf/scroll-drag-120fps-9141`, `agent/springboard`, `perf/frame-budget-consolidate-kpi-9141`, and `chore/8796-test-drift-fixes`: superseded by current `develop`.

## Validation

- `bun run --cwd plugins/plugin-app-control test src/actions/background.test.ts`
- `bun run --cwd plugins/plugin-app-control typecheck`
- `bun run --cwd packages/ui test src/components/pages/BackgroundView.test.tsx src/state/useDisplayPreferences.background.test.tsx src/state/persistence.background.test.ts`
- `bun run --cwd packages/scenario-runner test src/__tests__/deterministic-action-coverage.test.ts src/scenario-pr-workflow.test.ts`
- `bun run --cwd packages/ui test:background-e2e`
- `rg -n "homescreenAction|createHomescreenAction|Homescreen|HOMESCREEN|homescreen:apply|homescreen-prompt|actions/homescreen" plugins/plugin-app-control packages/scenario-runner packages/core/src packages/ui/src -S` returned no matches.

## Notes

Package-wide `packages/ui` and `packages/scenario-runner` typechecks were attempted but currently fail on unrelated workspace baseline resolution/type issues outside this diff. The app-control package typecheck for the code change passes.