### PR TITLE
fix(coding-tools): make path-utils tests platform-agnostic for Windows

### DIFF
--- a/plugins/plugin-coding-tools/src/lib/path-utils.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.test.ts
@@ -66,12 +66,16 @@ describe("isWithinAnyRoot", () => {
 
 describe("normalizeAbsolute / relativeFromRoot", () => {
   it("normalizeAbsolute returns an absolute, collapsed path", () => {
-    const out = normalizeAbsolute("/a/b/../c");
-    expect(out).toBe("/a/c");
+    // path.resolve is platform-specific (drive letter + backslashes on Windows),
+    // so normalize separators before asserting the collapsed POSIX-style tail.
+    const out = normalizeAbsolute("/a/b/../c").replace(/\\/g, "/");
+    expect(out).not.toContain("/../");
+    expect(out.endsWith("/a/c")).toBe(true);
   });
 
   it("relativeFromRoot returns the path relative to root, or '.'", () => {
-    expect(relativeFromRoot("/a/b/c", "/a")).toBe("b/c");
+    // relativeFromRoot uses path.relative (backslashes on Windows) — normalize.
+    expect(relativeFromRoot("/a/b/c", "/a").replace(/\\/g, "/")).toBe("b/c");
     expect(relativeFromRoot("/a", "/a")).toBe(".");
   });
 });


### PR DESCRIPTION
The windows-ci `test-plugin-coding-tools` lane fails: `normalizeAbsolute`/`relativeFromRoot` return platform paths (drive letter + backslashes on Windows) but the tests hardcoded POSIX (`/a/c`, `b/c`). The functions are correct for the module's real-FS sandboxing; the tests just needed separator normalization. Verified: 8/8 pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)