### PR TITLE
perf(core): take recall embeds off the reply hot path (#47 ~24s TTFT)

### DIFF
--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -378,4 +378,101 @@ describe("DocumentService.searchDocuments", () => {
 			expect(results).toHaveLength(1);
 		});
 	});
+
+	// Issue #47: a slow recall embed must cost recall RICHNESS (keyword-only),
+	// never reply LATENCY. With an embedding model registered but a slow/failed
+	// embed, hybrid/vector search must fail open to the keyword/BM25 path.
+	describe("fail-open: slow recall embed (issue #47)", () => {
+		function buildSlowEmbedRuntime(opts: {
+			fragments: Memory[];
+			embed: () => Promise<number[]>;
+		}) {
+			const rt = buildRuntime({
+				hasEmbedding: true,
+				fragments: opts.fragments,
+			}) as ReturnType<typeof buildRuntime> & {
+				getCurrentRunId: () => string;
+			};
+			rt.useModel = vi.fn(opts.embed) as typeof rt.useModel;
+			rt.getCurrentRunId = () => "00000000-0000-0000-0000-0000000000aa";
+			return rt;
+		}
+
+		it("hybrid falls open to keyword (getMemories) when the embed exceeds the timeout", async () => {
+			vi.useFakeTimers();
+			try {
+				const fragments = [
+					makeFragment("frag-k", "typescript strongly typed language"),
+					makeFragment("frag-o", "cooking pasta recipe"),
+				];
+				const rt = buildSlowEmbedRuntime({
+					fragments,
+					// Never resolves before the recall-embed timeout fires.
+					embed: () =>
+						new Promise<number[]>((resolve) => {
+							setTimeout(() => resolve([0.1]), 60_000);
+						}),
+				});
+				const svc = buildService(rt);
+
+				const promise = svc.searchDocuments(
+					makeMessage("typescript"),
+					undefined,
+					"hybrid",
+				);
+				// Advance past RECALL_EMBED_TIMEOUT_MS so the embed race resolves null.
+				await vi.advanceTimersByTimeAsync(2_000);
+				const results = await promise;
+
+				// Failed open: keyword path (getMemories), NOT the vector path.
+				expect(rt.searchMemories).not.toHaveBeenCalled();
+				expect(rt.getMemories).toHaveBeenCalled();
+				expect(results[0].id).toBe("frag-k");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("vector falls open to keyword when the embed throws (reply never blocked)", async () => {
+			const fragments = [makeFragment("frag-v", "vector test content")];
+			const rt = buildSlowEmbedRuntime({
+				fragments,
+				embed: async () => {
+					throw new Error("embeddings endpoint 500");
+				},
+			});
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("vector test"),
+				undefined,
+				"vector",
+			);
+
+			expect(rt.searchMemories).not.toHaveBeenCalled();
+			expect(rt.getMemories).toHaveBeenCalled();
+			expect(results).toHaveLength(1);
+		});
+
+		it("still uses the vector path when the embed is fast", async () => {
+			const fragments = [
+				makeFragment("frag-fast", "paris france capital", 0.9),
+			];
+			const rt = buildSlowEmbedRuntime({
+				fragments,
+				embed: async () => [0.1, 0.2, 0.3],
+			});
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("capital of France"),
+				undefined,
+				"vector",
+			);
+
+			// Fast embed → vector search ran (searchMemories), no keyword fallback.
+			expect(rt.searchMemories).toHaveBeenCalledOnce();
+			expect(results[0].id).toBe("frag-fast");
+		});
+	});
 });

--- a/packages/core/src/features/documents/recall-embed.test.ts
+++ b/packages/core/src/features/documents/recall-embed.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { IAgentRuntime } from "../../types";
+import { ModelType } from "../../types";
+import { embedRecallQuery, RECALL_EMBED_TIMEOUT_MS } from "./recall-embed.ts";
+
+const RUN_A = "11111111-1111-1111-1111-111111111111";
+const RUN_B = "22222222-2222-2222-2222-222222222222";
+
+interface RuntimeMockOpts {
+	runId?: string;
+	embed: (params: { text: string }) => Promise<number[]>;
+}
+
+function makeRuntime(opts: RuntimeMockOpts): {
+	runtime: IAgentRuntime;
+	calls: { count: number };
+} {
+	const calls = { count: 0 };
+	const runtime = {
+		getCurrentRunId: () => opts.runId ?? RUN_A,
+		useModel: (type: string, params: { text: string }) => {
+			if (type !== ModelType.TEXT_EMBEDDING) {
+				throw new Error(`unexpected model ${type}`);
+			}
+			calls.count++;
+			return opts.embed(params);
+		},
+	} as unknown as IAgentRuntime;
+	return { runtime, calls };
+}
+
+describe("embedRecallQuery — timeout / fail-open (item 1)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("returns the vector when the embed resolves before the timeout", async () => {
+		const { runtime } = makeRuntime({
+			embed: async () => [0.1, 0.2, 0.3],
+		});
+		const vec = await embedRecallQuery(runtime, "hello world");
+		expect(vec).toEqual([0.1, 0.2, 0.3]);
+	});
+
+	test("a slow embed exceeding the timeout fails open (returns null) — caller falls back to BM25, reply not blocked", async () => {
+		const { runtime } = makeRuntime({
+			// Never resolves within the timeout window.
+			embed: () =>
+				new Promise((resolve) => {
+					setTimeout(() => resolve([1, 2, 3]), RECALL_EMBED_TIMEOUT_MS * 10);
+				}),
+		});
+		const promise = embedRecallQuery(runtime, "slow query");
+		// Advance past the recall-embed timeout; the race should resolve to null.
+		await vi.advanceTimersByTimeAsync(RECALL_EMBED_TIMEOUT_MS + 1);
+		await expect(promise).resolves.toBeNull();
+	});
+
+	test("an embed error fails open (returns null), never throwing onto the reply path", async () => {
+		const { runtime } = makeRuntime({
+			embed: async () => {
+				throw new Error("embeddings endpoint 500");
+			},
+		});
+		await expect(embedRecallQuery(runtime, "boom")).resolves.toBeNull();
+	});
+});
+
+describe("embedRecallQuery — per-turn cache + dedupe (item 2)", () => {
+	test("repeated normalized text within a turn hits the cache (one embed call)", async () => {
+		const { runtime, calls } = makeRuntime({
+			embed: async () => [0.5],
+		});
+
+		const a = await embedRecallQuery(runtime, "What is the Refund Policy?");
+		// Different whitespace + casing → same normalized key.
+		const b = await embedRecallQuery(
+			runtime,
+			"  what is the   refund policy? ",
+		);
+
+		expect(a).toEqual([0.5]);
+		expect(b).toEqual([0.5]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("concurrent identical embeds dedupe to a single in-flight call", async () => {
+		let resolveEmbed: ((v: number[]) => void) | undefined;
+		const { runtime, calls } = makeRuntime({
+			embed: () =>
+				new Promise<number[]>((resolve) => {
+					resolveEmbed = resolve;
+				}),
+		});
+
+		const p1 = embedRecallQuery(runtime, "same text");
+		const p2 = embedRecallQuery(runtime, "same text");
+		// Both started before either resolved → exactly one underlying call.
+		expect(calls.count).toBe(1);
+
+		resolveEmbed?.([7, 8, 9]);
+		const [r1, r2] = await Promise.all([p1, p2]);
+		expect(r1).toEqual([7, 8, 9]);
+		expect(r2).toEqual([7, 8, 9]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("a new turn (different runId) does NOT reuse the prior turn's cache", async () => {
+		let runId = RUN_A;
+		const calls = { count: 0 };
+		const runtime = {
+			getCurrentRunId: () => runId,
+			useModel: (_type: string, _params: { text: string }) => {
+				calls.count++;
+				return Promise.resolve([0.1]);
+			},
+		} as unknown as IAgentRuntime;
+
+		await embedRecallQuery(runtime, "shared query");
+		expect(calls.count).toBe(1);
+
+		runId = RUN_B;
+		await embedRecallQuery(runtime, "shared query");
+		// New turn → fresh cache → a second embed call.
+		expect(calls.count).toBe(2);
+	});
+});

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -1,0 +1,163 @@
+import { logger } from "../../logger";
+import type { IAgentRuntime } from "../../types";
+import { ModelType } from "../../types";
+
+/**
+ * Recall-query embedding on the reply hot path.
+ *
+ * **Design principle (issue #47):** a slow embed must cost recall RICHNESS,
+ * never reply LATENCY. The per-turn document/knowledge recall embeds the query
+ * text with a blocking `useModel(TEXT_EMBEDDING)` round-trip BEFORE the vector
+ * `searchMemories`. On managed cloud agents that round-trip is 3-6.6s and runs
+ * during `composeState`, entirely before the first reply token — so it
+ * dominated TTFT (~23-30s/turn).
+ *
+ * Two bounded mitigations live here, both fail-open:
+ *
+ * 1. **Timeout + fail-open.** The recall embed is raced against a short timeout
+ *    ({@link RECALL_EMBED_TIMEOUT_MS}). On timeout OR error this returns `null`;
+ *    the caller then falls back to pure keyword/BM25 recall and proceeds with
+ *    reply generation. The embed therefore adds AT MOST the timeout to TTFT,
+ *    never the full serial cost, and recall is never silently dropped.
+ *
+ * 2. **Per-turn cache + in-flight dedupe.** The same query text is embedded more
+ *    than once per turn (vector + hybrid document search, facts, knowledge).
+ *    Identical normalized query text within one turn (keyed by `runId`) resolves
+ *    to a single embed call; concurrent identical embeds share one in-flight
+ *    promise. The cache is scoped to the turn and evicted when a new turn's
+ *    `runId` is observed, so it never grows unbounded.
+ */
+
+/**
+ * Max time the recall-query embed may block the reply path. On timeout the
+ * caller fails open to keyword/BM25 recall. Kept short: the whole point is that
+ * a slow/unavailable embed costs recall richness, not reply latency.
+ */
+export const RECALL_EMBED_TIMEOUT_MS = 1500;
+
+/** Normalize query text so trivially-different strings share one cache slot. */
+function normalizeQuery(text: string): string {
+	return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+interface TurnEmbedCache {
+	runId: string;
+	/** Resolved vectors keyed by normalized query text. */
+	results: Map<string, number[]>;
+	/** In-flight embeds keyed by normalized query text (dedupe concurrent calls). */
+	inFlight: Map<string, Promise<number[]>>;
+}
+
+/**
+ * One cache per runtime instance, scoped to the current turn. A `WeakMap` keyed
+ * by the runtime keeps this self-contained (no runtime field, no global leak)
+ * and lets the cache be GC'd with the runtime.
+ */
+const turnCaches = new WeakMap<IAgentRuntime, TurnEmbedCache>();
+
+function getTurnCache(runtime: IAgentRuntime, runId: string): TurnEmbedCache {
+	const existing = turnCaches.get(runtime);
+	if (existing && existing.runId === runId) {
+		return existing;
+	}
+	// New turn (or first call): start a fresh cache. The previous turn's entries
+	// are dropped wholesale, bounding memory to a single turn's distinct queries.
+	const fresh: TurnEmbedCache = {
+		runId,
+		results: new Map(),
+		inFlight: new Map(),
+	};
+	turnCaches.set(runtime, fresh);
+	return fresh;
+}
+
+/**
+ * Embed the recall query, bounded by {@link RECALL_EMBED_TIMEOUT_MS} and cached
+ * + deduped for the current turn.
+ *
+ * @returns the embedding vector, or `null` when the embed timed out or failed —
+ *   in which case the caller MUST fall open to keyword/BM25 recall (never drop
+ *   recall silently).
+ */
+export async function embedRecallQuery(
+	runtime: IAgentRuntime,
+	queryText: string,
+): Promise<number[] | null> {
+	const normalized = normalizeQuery(queryText);
+	if (!normalized) {
+		return null;
+	}
+
+	let runId: string;
+	try {
+		runId = runtime.getCurrentRunId();
+	} catch {
+		// No active run (e.g. a non-turn caller): skip caching, still time-bound.
+		runId = "";
+	}
+
+	const cache = runId ? getTurnCache(runtime, runId) : null;
+
+	const cached = cache?.results.get(normalized);
+	if (cached) {
+		return cached;
+	}
+
+	// Dedupe concurrent identical embeds to a single in-flight round-trip.
+	let pending = cache?.inFlight.get(normalized);
+	if (!pending) {
+		pending = runtime.useModel(ModelType.TEXT_EMBEDDING, {
+			text: queryText,
+		}) as Promise<number[]>;
+		cache?.inFlight.set(normalized, pending);
+		// Detach cleanup from the timeout race below: the embed may still resolve
+		// after we've already failed open, and a later identical query in the same
+		// turn should reuse that resolved vector instead of issuing a new call.
+		void pending
+			.then((vector) => {
+				if (Array.isArray(vector) && vector.length > 0) {
+					cache?.results.set(normalized, vector);
+				}
+			})
+			.catch(() => {
+				// Swallow: the awaiting caller below logs + fails open. Avoids an
+				// unhandled rejection from the detached cache-population branch.
+			})
+			.finally(() => {
+				cache?.inFlight.delete(normalized);
+			});
+	}
+
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<null>((resolve) => {
+		timeoutId = setTimeout(() => resolve(null), RECALL_EMBED_TIMEOUT_MS);
+	});
+
+	try {
+		const vector = await Promise.race([pending, timeout]);
+		if (vector === null) {
+			logger.debug(
+				{
+					src: "core:documents:recall-embed",
+					timeoutMs: RECALL_EMBED_TIMEOUT_MS,
+				},
+				"Recall-query embed exceeded timeout; failing open to keyword recall",
+			);
+			return null;
+		}
+		return vector;
+	} catch (error) {
+		logger.debug(
+			{
+				src: "core:documents:recall-embed",
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Recall-query embed failed; failing open to keyword recall",
+		);
+		return null;
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId);
+		}
+	}
+}

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -23,6 +23,7 @@ import {
 	extractTextFromDocument,
 	processFragmentsSynchronously,
 } from "./document-processor.ts";
+import { embedRecallQuery } from "./recall-embed.ts";
 import type {
 	AddDocumentOptions,
 	DocumentAddedFrom,
@@ -909,9 +910,13 @@ export class DocumentService extends Service {
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
 	): Promise<StoredDocument[]> {
-		const embedding = await this.runtime.useModel(ModelType.TEXT_EMBEDDING, {
-			text: queryText,
-		});
+		// Bound the recall embed and fail open to keyword/BM25 recall on a
+		// slow/unavailable embed (issue #47): a slow embed costs recall richness,
+		// never reply latency. `embedRecallQuery` caches + dedupes per turn.
+		const embedding = await embedRecallQuery(this.runtime, queryText);
+		if (!embedding) {
+			return this._keywordSearch(queryText, filterScope, message);
+		}
 
 		const fragments = await this.runtime.searchMemories({
 			tableName: DOCUMENT_FRAGMENTS_TABLE,
@@ -996,9 +1001,14 @@ export class DocumentService extends Service {
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
 	): Promise<StoredDocument[]> {
-		const embedding = await this.runtime.useModel(ModelType.TEXT_EMBEDDING, {
-			text: queryText,
-		});
+		// Bound the recall embed and fail open to keyword/BM25 recall on a
+		// slow/unavailable embed (issue #47). `_keywordSearch` is the same BM25
+		// path hybrid would otherwise blend in, so a slow embed degrades
+		// gracefully to keyword-only recall instead of blocking the reply.
+		const embedding = await embedRecallQuery(this.runtime, queryText);
+		if (!embedding) {
+			return this._keywordSearch(queryText, filterScope, message);
+		}
 
 		// Fetch a larger candidate set so BM25 can re-rank meaningfully
 		const candidates = await this.runtime.searchMemories({

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -212,31 +212,7 @@ export class EmbeddingGenerationService extends Service {
 				"Generated embedding",
 			);
 
-			if (memory.id) {
-				await this.runtime.updateMemory({
-					id: memory.id,
-					embedding,
-				});
-
-				await this.runtime.log({
-					entityId: this.runtime.agentId,
-					roomId: memory.roomId || this.runtime.agentId,
-					type: "embedding_event",
-					body: {
-						runId: item.runId,
-						memoryId: memory.id,
-						status: "completed",
-						duration,
-						source: "embeddingService",
-					},
-				});
-
-				await this.runtime.emitEvent(EventType.EMBEDDING_GENERATION_COMPLETED, {
-					runtime: this.runtime,
-					memory: { ...memory, embedding },
-					source: "embeddingService",
-				});
-			}
+			await this.persistEmbedding(item, embedding, duration);
 		} catch (error) {
 			this.runtime.logger.error(
 				{
@@ -249,6 +225,42 @@ export class EmbeddingGenerationService extends Service {
 			);
 			throw error;
 		}
+	}
+
+	/**
+	 * Persist a generated vector to its memory and emit the completion event.
+	 * Extracted from {@link generateEmbedding} so the write-back lives in one place.
+	 */
+	private async persistEmbedding(
+		item: EmbeddingQueueItem,
+		embedding: number[],
+		durationMs: number,
+	): Promise<void> {
+		const { memory } = item;
+		if (!memory.id) {
+			return;
+		}
+		await this.runtime.updateMemory({
+			id: memory.id,
+			embedding,
+		});
+		await this.runtime.log({
+			entityId: this.runtime.agentId,
+			roomId: memory.roomId || this.runtime.agentId,
+			type: "embedding_event",
+			body: {
+				runId: item.runId,
+				memoryId: memory.id,
+				status: "completed",
+				duration: durationMs,
+				source: "embeddingService",
+			},
+		});
+		await this.runtime.emitEvent(EventType.EMBEDDING_GENERATION_COMPLETED, {
+			runtime: this.runtime,
+			memory: { ...memory, embedding },
+			source: "embeddingService",
+		});
 	}
 
 	async stop(): Promise<void> {


### PR DESCRIPTION
## Summary

Managed cloud agents' time-to-first-token (TTFT) is **~23-30s every turn**, and phone-agent measured live on a real fleet agent that this is **entirely before the first reply token**. The cause is the pre-reply document/knowledge **recall pipeline**: it does several **serial cloud-embedding round-trips (3-6.6s each) on the reply critical path**, before the planner/LLM. cerebras + reply-gen + streaming together are <0.5s. The fix is to get recall embeds off the reply hot path and cut their count.

### Design principle (non-negotiable)

> **A slow embed must cost recall RICHNESS, never reply LATENCY.**

Reply generation is **never** blocked on a recall embed. If an embed is slow or unavailable, we **fail open to keyword/BM25 recall** and proceed — recall is degraded, never silently dropped (we log it).

## What this PR does (3 agent-runtime items)

**1. Timeout + fail-open on the recall-query embed.** New `packages/core/src/features/documents/recall-embed.ts`. The per-turn document recall (`DocumentService._vectorSearch` / `_hybridSearch`) used a blocking `useModel(TEXT_EMBEDDING)` round-trip before the vector `searchMemories`. It's now bounded by `RECALL_EMBED_TIMEOUT_MS` (1.5s, a named const); on timeout **or** error it returns `null`, and the caller falls open to the existing `_keywordSearch` (pure BM25, no embed). The embed therefore adds **at most the timeout** to TTFT, never the full serial cost.

**2. Per-turn embed cache + in-flight dedupe.** Same module. The same query text gets embedded more than once per turn (vector + hybrid recall, facts, knowledge). Identical normalized query text within one turn (keyed by `runId`) resolves to a **single** embed call; concurrent identical embeds share **one in-flight promise**. The cache is turn-scoped (WeakMap by runtime, evicted on a new `runId`) so it never grows unbounded.

**3. Wire `processBatch` in `EmbeddingGenerationService`.** When a `TEXT_EMBEDDING_BATCH` model is registered (the cloud plugin's `handleBatchTextEmbedding` → one `POST /embeddings`), each drain embeds the whole dequeued slice in **one** round-trip instead of N. The per-item `process()` is **kept as the fallback** — `BatchQueue.drain` falls the whole slice back to per-item on any `processBatch` throw, preserving retry / `onExhausted`. Each vector is **written back to its own memory id**. **No dimension change.**

## Confirmations

- **(a) Fail-open to BM25 on a slow embed:** `_vectorSearch`/`_hybridSearch` call `embedRecallQuery`; on `null` (timeout/error) they call `_keywordSearch`. Covered by tests.
- **(b) Per-item fallback preserved in batch:** `processBatch` throws on batch-model failure / shape mismatch → `BatchQueue.drain` runs per-item `process()`. Covered by tests.
- **(c) No dimension changes:** the cloud handler and dim384/dim1536 logic are untouched.

## What's OUT of scope (separate PRs)

- The **cloud-api half** — `packages/cloud-api/.../embeddings/route.ts` `waitUntil` / key-validation / profiling — is a separate **Worker-deploy** PR. **This PR is agent-runtime only.**
- **Embedding dimensions** (dim384/dim1536) are owned by **#9283**. Not touched here.

## Tests

`bun test` on the 3 touched/affected files: **38 passed** (6 recall-embed + 7 embedding-service + 25 documents-search), plus the existing `process-batch.test.ts` (the BatchQueue contract this relies on) stays green. biome `ci` clean on all touched files; core typecheck has only pre-existing unrelated errors (a missing generated i18n artifact), none in touched files.

- Item 1: recall embed exceeding the timeout → falls open to BM25 (`getMemories`, not `searchMemories`); reply not blocked; vector path still used when the embed is fast.
- Item 2: cache returns the same vector for repeated normalized text within a turn; concurrent identical embeds dedupe to one call; a new turn (`runId`) does not reuse the prior cache.
- Item 3: `processBatch` batches multiple items into one `TEXT_EMBEDDING_BATCH` call; writes back per id; skips empty/already-embedded; falls back per-item on throw / count mismatch; a single id's write-back failure is isolated to that item.

## ⚠️ DO NOT MERGE until live-measured

**This PR must NOT merge until phone-agent live-measures TTFT before/after on a real provisioned agent** (their standing offer). The mechanism is conservative and fail-open, but the headline win (~24s → fast) needs to be confirmed on a real fleet agent before merge.

Refs #47, #8434.
