### PR TITLE
chore(registry): add @stvor/plugin-agent-commerce

### DIFF
--- a/packages/registry/entries/third-party/stvor__plugin-agent-commerce.json
+++ b/packages/registry/entries/third-party/stvor__plugin-agent-commerce.json
@@ -1,0 +1,17 @@
+{
+  "package": "@stvor/plugin-agent-commerce",
+  "repository": "github:stvor-hq/plugin-agent-commerce",
+  "kind": "plugin",
+  "description": "ERC-8183 agentic commerce for elizaOS: job lifecycle state machine, SHA-256 payload attestation, reputation gating, and prompt-injection protection.",
+  "homepage": "https://github.com/stvor-hq/plugin-agent-commerce",
+  "version": "0.2.0",
+  "tags": [
+    "commerce",
+    "erc8183",
+    "escrow",
+    "reputation",
+    "security",
+    "rate-limiting",
+    "prompt-injection"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -138,6 +138,53 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@stvor/plugin-agent-commerce": {
+      "git": {
+        "repo": "stvor-hq/plugin-agent-commerce",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@stvor/plugin-agent-commerce",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "ERC-8183 agentic commerce for elizaOS: job lifecycle state machine, SHA-256 payload attestation, reputation gating, and prompt-injection protection.",
+      "homepage": "https://github.com/stvor-hq/plugin-agent-commerce",
+      "topics": [
+        "commerce",
+        "erc8183",
+        "escrow",
+        "reputation",
+        "security",
+        "rate-limiting",
+        "prompt-injection"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@thecolony/elizaos-plugin": {
       "git": {
         "repo": "TheColonyCC/elizaos-plugin",


### PR DESCRIPTION
# Relates to

Follow-up to #9203.
This package is now maintained externally and is being submitted as a third-party registry entry per maintainer recommendation.

# Sync with develop

* [x] Rebased onto the latest `origin/develop`
* [x] Registry generated successfully

# Risks

Low.

This PR only adds a third-party registry entry and regenerates the registry manifest. No runtime code is added to the monorepo.

# Background

## What does this PR do?

Adds `@stvor/plugin-agent-commerce` to the third-party plugin registry.

Package:

* npm: https://www.npmjs.com/package/@stvor/plugin-agent-commerce
* repository: https://github.com/stvor-hq/plugin-agent-commerce

## What kind of change is this?

Improvement.

Registry metadata update only.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

* `packages/registry/entries/third-party/stvor__plugin-agent-commerce.json`

## Detailed testing steps

* Review the registry entry
* Verify the npm package exists
* Verify the repository exists

# Evidence (prove the real thing happened — see PR_EVIDENCE.md)

## Real LLM-call trajectory

N/A — registry entry only.

## Backend + frontend logs

N/A — registry entry only.

## Screenshots (before / after) + video walkthrough

N/A — registry entry only.

## Audio / voice walkthrough

N/A — registry entry only.
