### PR TITLE
fix(ui): keep springboard no-blur gate green

### DIFF
--- a/packages/ui/src/components/pages/Springboard.tsx
+++ b/packages/ui/src/components/pages/Springboard.tsx
@@ -106,8 +106,8 @@ const IconTile = memo(function IconTile({
           onPointerCancel={clear}
           className={cn(
             // ViewTileImage handles image-vs-glyph internally, so the button is
-            // one constant surface. backdrop-blur (#9281) and focus rings (#9292)
-            // were deliberately removed on develop — do not reintroduce them.
+            // one constant surface. Translucent filter effects (#9281) and
+            // focus rings (#9292) were deliberately removed on develop.
             "h-16 w-16 overflow-hidden rounded-2xl bg-bg-accent/60 text-foreground transition-colors hover:bg-bg-accent",
             editing && "animate-pulse",
           )}


### PR DESCRIPTION
## Summary

- removes the literal banned backdrop-blur token from the Springboard source comment so the no-backdrop-blur gate stays green
- preserves the existing Springboard surface behavior and styling; this is a source-text gate fix only

## Validation

- bun run --cwd packages/ui test -- src/no-backdrop-blur-gate.test.ts src/components/pages/Springboard.gestures.test.tsx src/widgets/widget-coverage.test.ts
- bun run --cwd packages/ui test -- src/no-backdrop-blur-gate.test.ts src/components/shell/conversation-undo-store.test.ts src/components/shell/topic-views.test.tsx src/widgets/widget-coverage.test.ts src/components/pages/Springboard.test.tsx src/components/pages/Springboard.gestures.test.tsx src/components/pages/SpringboardSurface.test.tsx src/components/shell/HomeSpringboardSurface.test.tsx
- bun run verify
- bun run --cwd packages/app build:web
