### PR TITLE
fix(cloud): orphan reaper must not reap a live app container (duplicate-name rows) [CRITICAL]

### DIFF
--- a/packages/cloud-shared/src/db/repositories/containers.ts
+++ b/packages/cloud-shared/src/db/repositories/containers.ts
@@ -599,7 +599,10 @@ export class ContainersRepository {
         created_at: createdAt,
       });
 
-      // 5. Create the container (unique constraint will prevent duplicate names)
+      // 5. Create the container. NOTE: there is NO unique constraint on
+      //    `containers.name` — each deploy inserts a fresh row and the
+      //    deterministic `app-<id>` name is reused across rows. Consumers that
+      //    key on name (e.g. the orphan reconciler) must handle >1 row per name.
       const values: NewContainer = {
         ...insertData,
         status: "pending",

--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -105,6 +105,57 @@ describe("computeOrphanAppContainersToReap", () => {
     );
     expect(orphans.map((o) => o.id).sort()).toEqual(["c-orph", "c-stop"]);
   });
+
+  // REGRESSION (#9234): `containers.name` has NO unique constraint, so one
+  // `app-<slug>` name maps to MANY rows (one per deploy) — routinely a mix like
+  // `[running, stopped]`. Collapsing to a single status per name (last-write-wins
+  // over an unordered `WHERE name IN (...)`) could pick the terminal row and
+  // `docker rm -f` a LIVE customer app. The diff must be FAIL-SAFE: if ANY row
+  // for a name is non-terminal, the live container is NEVER reaped — and the
+  // outcome must not depend on row order (no ORDER BY in the query).
+  test("does NOT reap a name with a running AND a stopped row — running order", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-dup", "c-live")],
+      [live("app-dup", "running"), live("app-dup", "stopped")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("does NOT reap a name with a stopped AND a running row — reversed order", () => {
+    // Same rows, opposite iteration order: a last-write-wins map would collapse
+    // to 'running' here and to 'stopped' above, making reaping order-dependent.
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-dup", "c-live")],
+      [live("app-dup", "stopped"), live("app-dup", "running")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("does NOT reap when ANY of several rows is non-terminal (running last)", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-dup", "c-live")],
+      [
+        live("app-dup", "failed"),
+        live("app-dup", "stopped"),
+        live("app-dup", "deleted"),
+        live("app-dup", "running"),
+      ],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("reaps a name when EVERY row is terminal (multiple terminal rows)", () => {
+    const orphans = computeOrphanAppContainersToReap(
+      [container("app-dead", "c-dead")],
+      [live("app-dead", "stopped"), live("app-dead", "failed"), live("app-dead", "deleted")],
+    );
+    expect(orphans).toEqual([{ name: "app-dead", id: "c-dead", reason: "terminal_db_row" }]);
+  });
+
+  test("reaps a name with NO rows as no_db_row", () => {
+    const orphans = computeOrphanAppContainersToReap([container("app-gone", "c-gone")], []);
+    expect(orphans).toEqual([{ name: "app-gone", id: "c-gone", reason: "no_db_row" }]);
+  });
 });
 
 describe("reconcileOrphanAppContainers (orchestration)", () => {

--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -121,8 +121,19 @@ export function isAppContainerName(name: string): boolean {
  *
  * A container is an orphan when EITHER:
  *   - no `containers` row exists for its name (`no_db_row`), OR
- *   - the row exists but its status is terminal (`terminal_db_row`) — the deploy
- *     lifecycle has decided this app has no live container.
+ *   - rows exist but EVERY one of them is terminal (`terminal_db_row`) — the
+ *     deploy lifecycle has decided this app has no live container.
+ *
+ * CRITICAL: a single `app-<slug>` name can map to MULTIPLE `containers` rows.
+ * `containers.name` is the deterministic `app-<first 12 of app id>` and has NO
+ * unique constraint; every deploy inserts a fresh row via `createWithQuotaCheck`
+ * and leaves prior rows behind in running/stopped/failed. So the row set for one
+ * name is routinely a mix like `[running, stopped]`. We must be FAIL-SAFE: a
+ * name is LIVE (never reaped) if ANY of its rows is non-terminal, and is reaped
+ * ONLY when EVERY row is terminal. Collapsing to a single status per name (e.g.
+ * last-write-wins over an unordered `WHERE name IN (...)`) could pick a terminal
+ * row while a live row exists and `docker rm -f` a running customer app. Group
+ * here so the decision is fail-safe and order-independent.
  *
  * Containers whose name does not match the `app-<slug>` pattern are ignored
  * entirely — they belong to something else on the node.
@@ -133,19 +144,24 @@ export function computeOrphanAppContainersToReap(
   containersOnNode: readonly NodeAppContainerRef[],
   liveContainers: readonly LiveAppContainerRef[],
 ): OrphanAppContainer[] {
-  const statusByName = new Map<string, string>();
+  // Group all statuses per name (a name can have >1 containers row — there is no
+  // unique constraint on containers.name).
+  const statusesByName = new Map<string, string[]>();
   for (const row of liveContainers) {
-    statusByName.set(row.name, row.status);
+    const list = statusesByName.get(row.name) ?? [];
+    list.push(row.status);
+    statusesByName.set(row.name, list);
   }
 
   const orphans: OrphanAppContainer[] = [];
   for (const container of containersOnNode) {
     if (!isAppContainerName(container.name)) continue;
 
-    const status = statusByName.get(container.name);
-    if (status === undefined) {
+    const statuses = statusesByName.get(container.name);
+    if (statuses === undefined || statuses.length === 0) {
       orphans.push({ name: container.name, id: container.id, reason: "no_db_row" });
-    } else if (TERMINAL_CONTAINER_STATUSES.has(status)) {
+    } else if (statuses.every((s) => TERMINAL_CONTAINER_STATUSES.has(s))) {
+      // Reap ONLY when EVERY row is terminal — any live row protects the name.
       orphans.push({ name: container.name, id: container.id, reason: "terminal_db_row" });
     }
   }
@@ -275,6 +291,12 @@ const ORPHAN_RM_TIMEOUT_MS = 30_000;
  * Load (name, status) for the `containers` rows matching the given container
  * names, including terminal-state rows. The reconciler needs the status to tell
  * a missing row (`no_db_row`) apart from a terminal one (`terminal_db_row`).
+ *
+ * This can return MULTIPLE rows for the same name: `containers.name` is the
+ * deterministic `app-<first 12 of app id>` with no unique constraint, so an app
+ * accumulates one row per deploy. `computeOrphanAppContainersToReap` groups
+ * these per name and only reaps when every row is terminal, so returning the
+ * full (unordered) set here is correct and fail-safe.
  */
 async function loadContainerStatusesByNames(
   names: readonly string[],


### PR DESCRIPTION
## CRITICAL: orphan reaper could `docker rm -f` a LIVE paying-customer app container

### The bug
`computeOrphanAppContainersToReap` built a `Map<name, status>` and ran `statusByName.set(row.name, row.status)` for every row — **last-write-wins** on duplicate names. `loadContainerStatusesByNames` queries `WHERE name IN (...)` over the whole `containers` table with **no `ORDER BY`**, no org/node scope, and includes terminal-status rows.

A single app produces **multiple `containers` rows with the same deterministic name** `app-<first 12 of appId>`: every deploy inserts a fresh row via `createWithQuotaCheck`, leaving prior rows behind as `running`/`stopped`/`failed`. **There is no unique constraint on `containers.name`** (verified: `name: text("name").notNull()` in `db/schemas/containers.ts`, no `.unique()`/unique index).

So when the DB returns `[{name:'app-x',status:'running'},{name:'app-x',status:'stopped'}]`, the map could collapse to `app-x → 'stopped'` (terminal). The live docker container `app-x` is then classified `terminal_db_row` and `docker rm -f <id>` kills the **running customer app**. Reap-by-id does **not** save it — the live container's id is the one observed in the listing. Because there is no `ORDER BY`, row order is non-deterministic, making this **intermittent and silent**.

**Live-reap chain:** unordered `WHERE name IN` → last-write-wins collapse to a terminal status → live container classified `terminal_db_row` → `docker rm -f <observed live id>` → running app destroyed.

### The fix (fail-safe + order-independent)
Group all statuses per name and reap **only when EVERY row is terminal**; any single non-terminal row protects the name. No rows → `no_db_row`.

```ts
const statusesByName = new Map<string, string[]>();
for (const row of liveContainers) {
  const list = statusesByName.get(row.name) ?? [];
  list.push(row.status);
  statusesByName.set(row.name, list);
}
// ...
const statuses = statusesByName.get(container.name);
if (statuses === undefined || statuses.length === 0) {
  orphans.push({ ..., reason: "no_db_row" });
} else if (statuses.every((s) => TERMINAL_CONTAINER_STATUSES.has(s))) {
  orphans.push({ ..., reason: "terminal_db_row" });
}
```

Any live row now protects the container, and the outcome no longer depends on the (absent) row ordering. All existing safety invariants are preserved: healthy-only nodes, null-listing skip, reap-by-immutable-id, logging, return shape.

Also fixed the **stale/incorrect comment** in `db/repositories/containers.ts` that claimed "unique constraint will prevent duplicate names" — there is none.

### Regression test
New cases in `app-container-orphan-reconciler.test.ts`:
- Two rows for one name `[running, stopped]` in **both** iteration orders → live container **NOT** reaped (the load-bearing assertion).
- `[failed, stopped, deleted, running]` → not reaped (any live row protects).
- All-terminal rows `[stopped, failed, deleted]` → reaped as `terminal_db_row`.
- No rows → reaped as `no_db_row`.

`bun test app-container-orphan-reconciler.test.ts` → **20 pass, 0 fail**. Biome clean on touched files.

### Files changed
- `packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts` — group-by-name fail-safe diff + doc update on `loadContainerStatusesByNames`.
- `packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts` — regression tests.
- `packages/cloud-shared/src/db/repositories/containers.ts` — fix the false unique-constraint comment.

Refs #8434. Original report #9234.
