### PR TITLE
chore(test): correct embedding-dimension test labels to the real mechanism

### DIFF
--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts
@@ -231,9 +231,12 @@ describe("managed Eliza environment", () => {
   });
 
   test("pins both embedding dimensions to 1536 so the storage column and the cloud probe agree (#8769)", async () => {
-    // plugin-sql storage defaults to dim_384 unless EMBEDDING_DIMENSION is set,
-    // while the cloud embedding model returns 1536-d vectors — a drift to a
-    // single value re-introduces "Skipping embedding insert: dimension mismatch".
+    // Pinning EMBEDDING_DIMENSION + ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS=1536 makes
+    // the cloud TEXT_EMBEDDING handler EMIT 1536-wide vectors. plugin-sql does NOT
+    // read these vars; the storage column is sized at boot by the model-length
+    // probe (runtime.ensureEmbeddingDimension). Both must agree on 1536 or the boot
+    // probe snaps the column to a width the handler's output won't match —
+    // re-introducing "Skipping embedding insert: dimension mismatch" (#8769).
     const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
 
     const result = await prepareManagedElizaBaseEnvironment({

--- a/packages/core/src/__tests__/provisioning.test.ts
+++ b/packages/core/src/__tests__/provisioning.test.ts
@@ -3,12 +3,19 @@ import { ensureEmbeddingDimension } from "../provisioning";
 import type { IAgentRuntime } from "../types/runtime";
 
 /**
- * ensureEmbeddingDimension (the boot embedding-dim probe #8769 depends on) has
- * two silent early-returns — no TEXT_EMBEDDING model, and an unset/invalid
- * EMBEDDING_DIMENSION — plus the happy path that snaps the storage column to the
- * configured width. None were covered; a regression dropping the model-or-dim
- * guard would call adapter.ensureEmbeddingDimension with a wrong/default width
- * and ship silently.
+ * ensureEmbeddingDimension in core/provisioning.ts — the EMBEDDING_DIMENSION-
+ * setting probe used by the daemon-composition path (createRuntimes({ provision:
+ * true }) → provisionAgent). It has two silent early-returns — no TEXT_EMBEDDING
+ * model, and an unset/invalid EMBEDDING_DIMENSION — plus the happy path that
+ * snaps the storage column to the configured width. None were covered; a
+ * regression dropping the model-or-dim guard would call
+ * adapter.ensureEmbeddingDimension with a wrong/default width and ship silently.
+ *
+ * NOTE: managed cloud agents do NOT take this path — they boot
+ * `new AgentRuntime(...)` + `runtime.initialize()` and snap the column via
+ * `runtime.ensureEmbeddingDimension()`. #8769 (the managed-boot ordering bug) is
+ * covered by packages/agent/src/runtime/eliza-embedding-boot-order.test.ts, not
+ * here; this file is valid standalone coverage for the daemon-path function.
  */
 function makeRuntime(opts: {
 	hasModel: boolean;
@@ -26,7 +33,7 @@ function makeRuntime(opts: {
 	return { runtime, ensureDim };
 }
 
-describe("ensureEmbeddingDimension (#8769 boot probe)", () => {
+describe("ensureEmbeddingDimension (core/provisioning.ts daemon-composition probe)", () => {
 	it("skips when no TEXT_EMBEDDING model is registered", async () => {
 		const { runtime, ensureDim } = makeRuntime({
 			hasModel: false,


### PR DESCRIPTION
## What

Two **comment/label-only** test cleanups flagged by the launch review — both labels carried the disproven "plugin-sql reads `EMBEDDING_DIMENSION`" / "#8769 boot probe" assumption. No behavior, no assertions, no `it`/`test` counts changed.

### 1. `packages/core/src/__tests__/provisioning.test.ts`
This file tests `core/provisioning.ts`'s `ensureEmbeddingDimension(runtime)`, which is the **daemon-composition** path (`createRuntimes({ provision: true })` → `provisionAgent`). Managed cloud agents never run it, so the old "#8769 boot probe" attribution was false coverage.

- Docstring + `describe` block relabeled to describe the function generically (the `EMBEDDING_DIMENSION`-setting probe used by the daemon-composition path).
- Added a note that managed cloud agents instead snap the column via `runtime.ensureEmbeddingDimension()`, and that #8769 is covered by `packages/agent/src/runtime/eliza-embedding-boot-order.test.ts` (which itself explicitly calls this file "false coverage").
- Test logic unchanged — it remains valid standalone coverage for the daemon-path function.

### 2. `packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts` (~L234)
The comment asserted a disproven mechanism (plugin-sql reads `EMBEDDING_DIMENSION`). Corrected to the real one:

- Pinning `EMBEDDING_DIMENSION` + `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS=1536` makes the cloud `TEXT_EMBEDDING` handler **emit** 1536-wide vectors.
- `plugin-sql` does **not** read these vars; the storage column is sized at boot by the model-length probe (`runtime.ensureEmbeddingDimension`).
- Both must agree on 1536 or the boot probe snaps the column to a width the handler's output won't match — re-introducing `Skipping embedding insert: dimension mismatch` (#8769).

## Why

The original labels encoded a mechanism that #9283 disproved: `plugin-sql` never reads `EMBEDDING_DIMENSION`; the embedding column width is set at boot by the model-length probe, not by env vars. The labels are now consistent with the real boot path.

## Test evidence

Both touched files pass:

- `packages/core/src/__tests__/provisioning.test.ts` — **5 passed (5)** (vitest)
- `packages/cloud-shared/src/lib/services/managed-eliza-config.test.ts` — **17 passed (17)** (bun test)

Biome clean on both files (package-local configs).

Refs #8769 #8434
