### PR TITLE
fix(cloud): apps deploy/redeploy lifecycle — retire stale rows, rm-f before create, keep live container running on route error

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -75,6 +75,46 @@ describe("AppContainerProvider.provision", () => {
     expect(calls).toContain("docker start 'app-nubilio'");
   });
 
+  test("removes any stale container by name BEFORE docker create (redeploy self-heal)", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49001 });
+
+    await provider.provision({
+      appId: APP_ID,
+      containerName: "app-nubilio",
+      input: INPUT,
+    });
+
+    const rmIdx = calls.indexOf("docker rm -f 'app-nubilio'");
+    const createIdx = calls.findIndex((c) => c.startsWith("docker create"));
+    // A best-effort `docker rm -f <name>` is issued, and it precedes the create
+    // so the deterministic `app-<slug>` name is free (no 'name already in use').
+    expect(rmIdx).toBeGreaterThanOrEqual(0);
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    expect(rmIdx).toBeLessThan(createIdx);
+  });
+
+  test("a failing pre-clean rm does not abort the provision (best-effort)", async () => {
+    const calls: string[] = [];
+    const ssh: AppContainerSsh = {
+      async exec(command) {
+        calls.push(command);
+        if (command.startsWith("docker rm -f")) throw new Error("no such container");
+        if (command.startsWith("docker create")) return "cid";
+        return "";
+      },
+    };
+    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49001 });
+    const result = await provider.provision({
+      appId: APP_ID,
+      containerName: "app-nubilio",
+      input: INPUT,
+    });
+    // rm threw but the create still ran and the provision succeeded.
+    expect(result.containerId).toBe("cid");
+    expect(calls.some((c) => c.startsWith("docker create"))).toBe(true);
+  });
+
   test("picks a host port not already in use on the node (collision-safe)", async () => {
     // node already has 30000 published; allocator hands out 30000 then 31000
     const ports = [30000, 31000];

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
@@ -24,12 +24,18 @@ import type { AppDatabaseState } from "../../../db/repositories/app-databases";
 // Worker delete read (findStateByAppIdForWrite) — the row must survive across
 // both for the teardown to resolve the DSN.
 const appDatabasesStore = new Map<string, AppDatabaseState>();
+// Toggle so a single test can simulate the canonical-row persist failing AFTER
+// the tenant DB is already provisioned (Bug 4 — the compensating-teardown case).
+const persistControl = { failUpdateState: false };
 mock.module("../../../db/repositories/app-databases", () => ({
   appDatabasesRepository: {
     updateState: async (
       appId: string,
       data: Partial<AppDatabaseState>,
     ): Promise<AppDatabaseState> => {
+      if (persistControl.failUpdateState) {
+        throw new Error("app_databases updateState failed");
+      }
       const next: AppDatabaseState = {
         app_id: appId,
         user_database_uri: null,
@@ -78,6 +84,11 @@ mock.module("../apps", () => ({
 mock.module("../../../db/repositories/containers", () => ({
   containersRepository: {
     create: async () => ({ id: "container-1" }),
+    // The default createContainerRow enforces quota via createWithQuotaCheck.
+    createWithQuotaCheck: async () => ({ id: "container-1" }),
+    // No prior deploy for this app — the redeploy-retire step finds nothing.
+    findUndeletedByProjectName: async () => [],
+    updateStatus: async () => null,
   },
 }));
 
@@ -204,5 +215,40 @@ describe("env-DSN deploy mode — per-tenant DB teardown (#8342)", () => {
     expect(live.size).toBe(0); // DB dropped
     expect(released).toEqual(["cluster-1"]); // slot released exactly once
     expect(slotCount()).toBe(0); // database_count back to baseline — no leak
+  });
+
+  // Bug 4 — env-DSN mode: if the canonical app_databases row fails to persist
+  // AFTER the tenant DB is provisioned, the DB + cluster slot must NOT leak.
+  // The compensating teardown DROPs the just-provisioned DB and releases the slot
+  // before rethrowing, so a failed persist self-heals.
+  test("updateState failure after provision triggers a compensating deprovision (no leak)", async () => {
+    appDatabasesStore.clear();
+    const { provisioning, live, released, slotCount } = makeProvisioning();
+
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob() {
+        return { id: "job-x" };
+      },
+    };
+
+    const runner = makeDirectAppDeployRunner({
+      tenantDbProvisioning: provisioning,
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+
+    persistControl.failUpdateState = true;
+    try {
+      // The deploy fails (the persist throws) and the error surfaces.
+      await expect(runner.run(APP_ID)).rejects.toThrow("app_databases updateState failed");
+    } finally {
+      persistControl.failUpdateState = false;
+    }
+
+    // The just-provisioned DB was torn back down and the slot released — both
+    // back to baseline, no orphaned DB and no leaked cluster slot.
+    expect(live.size).toBe(0);
+    expect(released).toEqual(["cluster-1"]);
+    expect(slotCount()).toBe(0);
   });
 });

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Bug 1 (apps deploy/redeploy lifecycle) — a redeploy must RETIRE the app's
+ * pre-existing container row(s) so stale rows from prior deploys stop counting
+ * against the per-org container quota.
+ *
+ * Root cause: every deploy creates a NEW `containers` row under the same project
+ * key (project_name = appId) and never retired the prior row. The quota readers
+ * (`checkQuota` / `createWithQuotaCheck`) count every row EXCEPT `deleting`/
+ * `deleted`, so a prior `running`/`stopped`/`failed` row kept consuming a quota
+ * slot forever. The fix flips each prior row to `deleting` (a non-counting state)
+ * before the new row is created, and enqueues a CONTAINER_DELETE so the daemon
+ * removes the old container + releases its node slot. Net effect: at most one
+ * active (quota-counting) row per app.
+ *
+ * This test wires the real `DefaultAppDeployRunner.run()` against an in-memory
+ * `containers` store, simulates a prior `running` deploy, redeploys, and asserts
+ * the prior row was flipped to `deleting`, a CONTAINER_DELETE was enqueued for
+ * it, and the count of quota-counting rows for the app stays ≤ 1.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const APP_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const ORG_ID = "org-retire";
+const USER_ID = "user-retire";
+
+// A minimal in-memory `containers` store keyed by id. Only the columns the
+// runner's retire step + the default createContainerRow touch are modeled.
+interface Row {
+  id: string;
+  organization_id: string;
+  project_name: string;
+  status: string;
+}
+const rows = new Map<string, Row>();
+
+// The set of statuses the quota readers EXCLUDE — a row in any other status
+// counts toward the org cap. Mirrors `notInArray(status, ["deleting","deleted"])`.
+const NON_COUNTING = new Set(["deleting", "deleted"]);
+function quotaCountForApp(appId: string): number {
+  let n = 0;
+  for (const row of rows.values()) {
+    if (row.project_name === appId && !NON_COUNTING.has(row.status)) n += 1;
+  }
+  return n;
+}
+
+mock.module("../../../db/repositories/containers", () => ({
+  containersRepository: {
+    // Mirrors the real reader: every row for (org, project_name) NOT already
+    // terminal (deleting/deleted).
+    findUndeletedByProjectName: async (organizationId: string, projectName: string) =>
+      [...rows.values()].filter(
+        (r) =>
+          r.organization_id === organizationId &&
+          r.project_name === projectName &&
+          !NON_COUNTING.has(r.status),
+      ),
+    updateStatus: async (id: string, status: string) => {
+      const row = rows.get(id);
+      if (row) row.status = status;
+      return row ?? null;
+    },
+    // The default createContainerRow path; inserts a fresh `pending` row.
+    createWithQuotaCheck: async () => {
+      const id = `container-new-${rows.size + 1}`;
+      rows.set(id, {
+        id,
+        organization_id: ORG_ID,
+        project_name: APP_ID,
+        status: "pending",
+      });
+      return { id };
+    },
+  },
+}));
+
+mock.module("../apps", () => ({
+  appsService: {
+    getById: async (id: string) =>
+      id === APP_ID
+        ? {
+            id: APP_ID,
+            name: "retire-app",
+            organization_id: ORG_ID,
+            created_by_user_id: USER_ID,
+            github_repo: null,
+            // "none" => stateless app, so ensureTenantDb is never called.
+            metadata: { databaseMode: "none" },
+          }
+        : undefined,
+    update: async () => {},
+  },
+}));
+
+import { DefaultAppDeployRunner } from "../app-deploy-runner";
+import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+import { JOB_TYPES } from "../provisioning-job-types";
+
+describe("DefaultAppDeployRunner — redeploy retires the prior container row (Bug 1)", () => {
+  test("a redeploy flips the prior row to deleting, enqueues its delete, and keeps quota ≤1", async () => {
+    rows.clear();
+    // Simulate a prior deploy: one live `running` row for this app.
+    rows.set("container-prior", {
+      id: "container-prior",
+      organization_id: ORG_ID,
+      project_name: APP_ID,
+      status: "running",
+    });
+    expect(quotaCountForApp(APP_ID)).toBe(1); // baseline: prior deploy counts
+
+    const enqueued: ContainerJobInsert[] = [];
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob(job) {
+        enqueued.push(job);
+        return { id: `job-${enqueued.length}` };
+      },
+    };
+
+    const runner = new DefaultAppDeployRunner({
+      ensureTenantDb: async () => {
+        throw new Error("ensureTenantDb must NOT be called for a stateless app");
+      },
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+
+    await runner.run(APP_ID);
+
+    // The prior row was retired to `deleting` (a non-quota-counting state).
+    expect(rows.get("container-prior")?.status).toBe("deleting");
+
+    // A CONTAINER_DELETE was enqueued for the prior container so the daemon
+    // removes it + releases its node slot.
+    const deleteJob = enqueued.find(
+      (j) =>
+        j.type === JOB_TYPES.CONTAINER_DELETE &&
+        (j.data as { containerId?: string }).containerId === "container-prior",
+    );
+    expect(deleteJob).toBeDefined();
+    expect(deleteJob?.organizationId).toBe(ORG_ID);
+
+    // A fresh row exists for the new deploy, AND the quota-counting rows for the
+    // app stay ≤ 1 (the retired row no longer counts) — no leak across redeploys.
+    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
+    expect(quotaCountForApp(APP_ID)).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -163,6 +163,35 @@ describe("executeContainerProvision", () => {
       }),
     ).rejects.toThrow("not found");
   });
+
+  test("route-add failure AFTER markRunning keeps the row running, never failed", async () => {
+    const prev = process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+    process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = "apps.elizacloud.ai";
+    try {
+      const { events, store } = fakeStore();
+      const { provider } = fakeProvider();
+      await expect(
+        executeContainerProvision(
+          job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+          {
+            provider,
+            store,
+            // Caddy unreachable: the route add fails AFTER the container is running.
+            onRouteAdded: async () => {
+              throw new Error("caddy unreachable");
+            },
+          },
+        ),
+      ).rejects.toThrow("caddy unreachable");
+      // The container WAS marked running (it is live), and was NOT flipped to
+      // error — a live, working container must never look reapable/failed.
+      expect(events.some((e) => e.op === "running")).toBe(true);
+      expect(events.some((e) => e.op === "error")).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+      else process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = prev;
+    }
+  });
 });
 
 describe("executeContainerDelete / restart / logs", () => {

--- a/packages/cloud-shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-provider.ts
@@ -148,6 +148,15 @@ export class AppContainerProvider {
       pidsLimit: this.deps.pidsLimit,
     });
 
+    // Best-effort pre-clean: a redeploy reuses the deterministic `app-<slug>`
+    // name, so a still-present container from a prior deploy makes `docker
+    // create --name` fail with 'name already in use'. Remove it first (no-op when
+    // absent). Mirrors `executeContainerUpgrade`/`provider.delete`; self-heals
+    // regardless of which deploy route enqueued this provision.
+    await this.deps.ssh
+      .exec(`docker rm -f ${shellQuote(params.containerName)}`)
+      .catch(() => undefined);
+
     const stdout = await this.deps.ssh.exec(createCmd);
     const containerId = (this.deps.extractContainerId ?? defaultExtractContainerId)(stdout);
     await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);

--- a/packages/cloud-shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-store.ts
@@ -26,9 +26,11 @@
  *
  * STATUS VOCAB (containers.ContainerStatus): pending | building | deploying |
  *   running | stopped | failed | deleting | deleted. We use:
- *     markRunning -> "running", markError -> "failed", markDeleted -> "stopped".
- *   ("stopped" keeps the partial unique index active_project_volume_unique happy:
- *   its predicate excludes status IN ('failed','stopped').)
+ *     markRunning -> "running", markError -> "failed", markDeleted -> "deleted".
+ *   ("deleted" is the terminal, non-quota-counting state — the quota readers
+ *   exclude only `deleting`/`deleted`, so a retired row stops counting against
+ *   the org's container cap. App containers carry no `volume_path`, so the
+ *   active_project_volume_unique index never applies to them.)
  *
  * SERVER + NODE: this is a plain DB adapter (no `pg`), but it is wired into the
  * node daemon's container-executor deps (the daemon runs the provision against a
@@ -150,9 +152,13 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
   }
 
   async markDeleted(containerId: string): Promise<void> {
-    // "stopped" rather than the terminal "deleted" so a redeploy can reuse the
-    // row; both satisfy the active_project_volume_unique predicate exclusion.
-    await containersRepository.updateStatus(containerId, "stopped");
+    // Terminal "deleted" — the daemon has actually removed the container, so the
+    // row must reach a state that does NOT count toward the per-org container
+    // quota. `checkQuota`/`createWithQuotaCheck` exclude only `deleting`/`deleted`;
+    // a `stopped` row would keep leaking quota across redeploys (the daemon never
+    // reuses this row — each deploy creates a fresh one). App containers carry no
+    // `volume_path`, so the active_project_volume_unique index never applies here.
+    await containersRepository.updateStatus(containerId, "deleted");
   }
 
   async markError(containerId: string, error: string): Promise<void> {

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -153,6 +153,18 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
     const containerName = containerNameForApp(appId);
 
     const enqueuer = new ContainerJobEnqueuer(this.deps.jobsWriter);
+
+    // Retire the app's pre-existing container row(s) BEFORE creating the new one.
+    // Every deploy creates a fresh `containers` row under the same project key
+    // (project_name = appId); without retiring the old ones, their stale
+    // `stopped`/`failed` rows keep counting against the per-org container quota
+    // forever (the quota readers exclude only `deleting`/`deleted`). We flip each
+    // prior row to `deleting` immediately (so it stops counting before the new
+    // row's quota check runs) and enqueue a CONTAINER_DELETE so the daemon
+    // removes the old container + releases its node slot. Net effect: at most one
+    // active row per app.
+    await this.retirePriorContainers(app.organization_id, appId, enqueuer);
+
     const createContainerRow =
       this.deps.createContainerRow ??
       (async (row: NewAppContainerRow) => {
@@ -205,6 +217,43 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
       jobId: result.jobId,
       image,
     });
+  }
+
+  /**
+   * Retire every pre-existing container row for an app so stale rows from prior
+   * deploys stop counting against the per-org container quota (and the old
+   * containers get torn down on the node). Each prior row is flipped to
+   * `deleting` immediately — a non-quota-counting state — so the quota count
+   * drops BEFORE the new row's createWithQuotaCheck runs (the enqueued
+   * CONTAINER_DELETE is async and would otherwise race the new row's check). The
+   * daemon's CONTAINER_DELETE then does the real `docker rm -f` + node-slot
+   * release and flips the row to terminal `deleted`. Best-effort per row: a
+   * failure to retire one row is logged but never blocks the new deploy.
+   */
+  private async retirePriorContainers(
+    organizationId: string,
+    appId: string,
+    enqueuer: ContainerJobEnqueuer,
+  ): Promise<void> {
+    const prior = await containersRepository.findUndeletedByProjectName(organizationId, appId);
+    for (const row of prior) {
+      try {
+        // Mark `deleting` up front so it stops counting toward quota before the
+        // new row's quota check; the daemon's CONTAINER_DELETE finishes the job.
+        await containersRepository.updateStatus(row.id, "deleting");
+        await enqueuer.enqueueDelete({ containerId: row.id, organizationId });
+        logger.info("[AppDeployRunner] retired prior container row", {
+          appId,
+          containerId: row.id,
+        });
+      } catch (error) {
+        logger.warn("[AppDeployRunner] failed to retire prior container row", {
+          appId,
+          containerId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 }
 
@@ -270,11 +319,26 @@ export function makeDirectAppDeployRunner(args: {
       // delete can resolve the per-tenant DSN and run the DROP + slot release.
       // Stored as plaintext — see the factory header; decryptIfNeeded passes
       // plaintext through on the daemon side.
-      await appDatabasesRepository.updateState(appId, {
-        user_database_uri: dsn,
-        user_database_status: "ready",
-        user_database_error: null,
-      });
+      try {
+        await appDatabasesRepository.updateState(appId, {
+          user_database_uri: dsn,
+          user_database_status: "ready",
+          user_database_error: null,
+        });
+      } catch (error) {
+        // The tenant DB + cluster slot already exist, but persisting the canonical
+        // row failed — without that row, app delete can't resolve the DSN to DROP
+        // the DB or release the slot, so both would leak permanently. Compensate
+        // by tearing the just-provisioned DB down (DROP DB + release slot) before
+        // rethrowing, so a failed persist self-heals instead of leaking.
+        await args.tenantDbProvisioning.deprovisionForApp(appId, dsn).catch((teardownError) => {
+          logger.error("[AppDeployRunner] compensating tenant-DB teardown failed", {
+            appId,
+            error: teardownError instanceof Error ? teardownError.message : String(teardownError),
+          });
+        });
+        throw error;
+      }
       return dsn;
     },
     jobsWriter: args.jobsWriter,

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -11,6 +11,7 @@
  * or repo directly.
  */
 
+import { logger } from "../utils/logger";
 import type { AppContainerProvider } from "./app-container-provider";
 import { deriveAppPublicUrl } from "./app-url";
 import {
@@ -105,8 +106,12 @@ export async function executeContainerProvision(
     port: row.port,
     environmentVars: row.environmentVars,
   });
+  // PROVISION + markRunning: a failure HERE means no container is running, so the
+  // row is a true provision failure -> markError (reapable/retryable). Only this
+  // span is allowed to flip the row to `failed`.
+  let result: Awaited<ReturnType<typeof deps.provider.provision>>;
   try {
-    const result = await deps.provider.provision({
+    result = await deps.provider.provision({
       appId: row.appId,
       containerName: row.containerName,
       input,
@@ -117,10 +122,20 @@ export async function executeContainerProvision(
       network: result.network,
       nodeHost: result.nodeHost,
     });
+  } catch (error) {
+    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+
+  // POST-markRunning: the container IS running. Registering the ingress route +
+  // flipping the app to `deployed` are follow-up steps; a failure here must NOT
+  // flip the row to `failed` (that would make a live, working container look
+  // reapable). Leave the status `running` and let a reconciler or a redeploy
+  // re-add the route. We rethrow so the job retries — but the row stays `running`.
+  try {
     // Register the ingress route so `<shortid>.<base>` reaches this container,
     // plus the app's verified custom domains (best-effort — a domain-lookup
     // failure must NOT fail the deploy; the app just keeps its wildcard host).
-    // Inside the try: an add failure marks the container errored (no silent 502).
     const endpoint = deriveAppPublicUrl(containerId);
     if (endpoint && deps.onRouteAdded) {
       const extraHostnames = deps.listVerifiedAppHostnames
@@ -138,7 +153,14 @@ export async function executeContainerProvision(
       await deps.markAppDeployed(row.appId, endpoint?.url ?? null);
     }
   } catch (error) {
-    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn("[ContainerExecutor] route-add/markAppDeployed failed after markRunning", {
+      containerId,
+      appId: row.appId,
+      error: message,
+    });
+    // Rethrow to retry the job — but the container row stays `running`, never
+    // `failed` (it is a live container; only the post-provision wiring failed).
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

Hardens the Product-2 apps deploy/redeploy lifecycle, fixing 4 related bugs found by the launch review. Refs #8434.

**Shared root cause:** every deploy creates a NEW `containers` row under the same deterministic name `app-<first 12 of appId>` (`project_name = appId`) and never retires the prior row/container, and the provision never `docker rm -f`'s a stale container first.

## The 4 bugs + fixes

### Bug 1 [HIGH] — per-org quota leaks across redeploys
Stale `stopped`/`failed` rows from prior deploys permanently counted against the per-org container cap — `checkQuota` / `createWithQuotaCheck` exclude only `deleting`/`deleted`, so any other status keeps consuming a quota slot forever.

- `DefaultAppDeployRunner.run` now retires the app's pre-existing rows via `containersRepository.findUndeletedByProjectName(org, appId)` **before** creating the new one — flipping each to `deleting` immediately (so the count drops before the new row's quota check runs) and enqueueing a `CONTAINER_DELETE` so the daemon removes the old container + releases its node slot.
- `ContainerRepoAppContainerStore.markDeleted` now sets terminal `deleted` (was `stopped`, which still counted). App containers carry no `volume_path`, so the `active_project_volume_unique` index never applied to them — `deleted` is safe and correct (the daemon has actually removed the container).
- **Net effect: at most one active (quota-counting) row per app.**

### Bug 2 [MEDIUM] — redeploy name collision
A fresh provision ran `docker create --name app-<slug>` which failed with `name already in use` when the prior container still existed. `AppContainerProvider.provision` now issues a best-effort `docker rm -f <name>` immediately **before** `docker create` (mirrors `executeContainerUpgrade` / `provider.delete`). Self-heals regardless of which deploy route enqueued the provision.

### Bug 3 [MEDIUM] — route-add failure marked a LIVE container `failed`
After a successful `markRunning`, an `onRouteAdded` (Caddy) failure flipped the container to `failed` via the outer catch — making a running, working container look reapable. In `executeContainerProvision` the ingress-route + `markAppDeployed` steps moved into their **own** try AFTER `markRunning`; a failure there logs a warning and rethrows (so the job retries / a reconciler re-adds the route) but leaves the row `running`, never `failed`. `markError` now fires only for true provision failures at/before `markRunning`.

### Bug 4 [LOW] — env-DSN tenant-DB + slot leak on persist failure
In `makeDirectAppDeployRunner.ensureTenantDb`, if the `app_databases` `updateState` failed AFTER the tenant DB was provisioned, the DB + cluster slot leaked (app delete reads that row to resolve the DSN for the DROP + slot release). The `updateState` is now wrapped: on failure it calls `tenantDbProvisioning.deprovisionForApp(appId, dsn)` (DROP DB + release slot) before rethrowing, so a failed persist self-heals.

## Tests (one focused test per bug)

| Bug | Test | Assertion |
| --- | --- | --- |
| 1 | `app-deploy-runner-retire.test.ts` | a redeploy flips the prior row to `deleting`, enqueues its `CONTAINER_DELETE`, and quota-counting rows stay <= 1 |
| 2 | `app-container-provider.test.ts` | provision issues `docker rm -f <name>` **before** `docker create`; a failing pre-clean does not abort the provision |
| 3 | `container-job-executors.test.ts` | a route-add failure after `markRunning` leaves status `running` (not `failed`) and rethrows; a true provision failure still `markError`s (existing test) |
| 4 | `app-deploy-runner-env-dsn-teardown.test.ts` | `updateState` failure after provision triggers the compensating `deprovisionForApp` — DB dropped + slot released, no leak |

All touched test files green (29 tests across the 5 files). `biome check` clean on touched files; `tsc --noEmit` reports 0 errors.

## Billing/isolation safety
Bug 1's retire flips prior rows to `deleting` (stops the daily container-billing meter, which only charges `running` rows) — the correct behavior for a replaced container. No charge is dropped or double-counted: the new row meters fresh once `running`. No tenant-isolation surface is touched.