### PR TITLE
fix(scenario-runner): stop 200 personality scenarios passing vacuously in the PR gate

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -63,7 +63,14 @@ interface ScenarioFacts {
   hasFinalChecks: boolean;
   hasPerTurnAssert: boolean;
   hasPersonalityExpect: boolean;
+  hasDeadPlannerAssert: boolean;
 }
+
+// plannerIncludesAll / plannerIncludesAny / plannerExcludes are not in the
+// runner schema and are consumed by nothing in the repo — scenarios that use
+// them have silently-ignored "assertions". Tracked in #9310.
+const DEAD_PLANNER_ASSERT =
+  /\b(plannerIncludesAll|plannerIncludesAny|plannerExcludes)\s*:/;
 
 const PER_TURN_ASSERT =
   /\b(assertResponse|responseIncludesAny|responseIncludesAll|responseJudge|assertTurn)\b/;
@@ -80,6 +87,7 @@ function analyze(file: string): ScenarioFacts {
     hasFinalChecks: NON_EMPTY_FINAL_CHECKS.test(src),
     hasPerTurnAssert: PER_TURN_ASSERT.test(src),
     hasPersonalityExpect: /\bpersonalityExpect\s*:/.test(src),
+    hasDeadPlannerAssert: DEAD_PLANNER_ASSERT.test(src),
   };
 }
 
@@ -112,5 +120,26 @@ describe("scenario corpus assertion guard", () => {
       .map(rel)
       .sort();
     expect(misLaned).toEqual([]);
+  });
+
+  // Ratchet against the dead plannerIncludes*/plannerExcludes fields. They are
+  // unenforced (#9310); this only prevents the count from growing while the
+  // backlog is migrated to enforced assertions (or the executor is taught to
+  // consume them). Lower this as scenarios are fixed; never raise it.
+  it("does not grow unenforced plannerIncludes*/plannerExcludes usage beyond 153", () => {
+    const DEAD_PLANNER_BASELINE = 153;
+    const users = facts
+      .filter((f) => f.hasDeadPlannerAssert)
+      .map(rel)
+      .sort();
+    if (users.length > DEAD_PLANNER_BASELINE) {
+      throw new Error(
+        `unenforced planner-assertion scenarios grew to ${users.length} ` +
+          `(baseline ${DEAD_PLANNER_BASELINE}). plannerIncludesAll/Any/Excludes are ` +
+          `silently ignored by the executor — assert via finalChecks or an enforced ` +
+          `per-turn field instead. New offenders:\n${users.slice(DEAD_PLANNER_BASELINE).join("\n")}`,
+      );
+    }
+    expect(users.length).toBeLessThanOrEqual(DEAD_PLANNER_BASELINE);
   });
 });

--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Corpus assertion guard.
+ *
+ * The scenario-runner runs a scenario's turns and only fails when an assertion
+ * fails. A scenario with no enforceable assertion therefore passes vacuously —
+ * it proves nothing while counting as green coverage. This guard makes that
+ * failure mode impossible to (re)introduce.
+ *
+ * Two invariants enforced here:
+ *  1. No `pr-deterministic` scenario may lack an enforceable assertion. The
+ *     pr-deterministic lane is the merge-blocking PR gate; a vacuous scenario
+ *     there is false confidence on every PR. "Enforceable" means a non-empty
+ *     `finalChecks` array OR a per-turn assertion the executor actually runs
+ *     (`assertResponse` / `responseIncludesAny` / `responseIncludesAll` /
+ *     `responseJudge` / `assertTurn`). The `plannerIncludes*` / `plannerExcludes`
+ *     fields are deliberately NOT counted: the executor does not consume them
+ *     (they are dead assertion fields — tracked separately).
+ *  2. `personalityExpect` scenarios must run `live-only`. Their behaviour
+ *     (silence / held-style / trait-respected …) can only be exercised by a
+ *     real model — the deterministic proxy always emits a reply, so the
+ *     personality judge can never pass under the proxy. They are not valid
+ *     deterministic PR coverage and must not claim the pr-deterministic lane.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../..");
+
+const SCENARIO_ROOTS = [
+  "packages/test/scenarios",
+  "plugins/plugin-personal-assistant/test/scenarios",
+  "plugins/plugin-app-control/test/scenarios",
+  "plugins/plugin-health/test/scenarios",
+  "plugins/plugin-agent-orchestrator/test/scenarios",
+].map((r) => resolve(repoRoot, r));
+
+function walkScenarioFiles(dir: string): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith("_")) continue; // loader ignores `_`-prefixed entries
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walkScenarioFiles(full));
+    } else if (entry.endsWith(".scenario.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface ScenarioFacts {
+  file: string;
+  lane: string;
+  hasFinalChecks: boolean;
+  hasPerTurnAssert: boolean;
+  hasPersonalityExpect: boolean;
+}
+
+const PER_TURN_ASSERT =
+  /\b(assertResponse|responseIncludesAny|responseIncludesAll|responseJudge|assertTurn)\b/;
+// A non-empty finalChecks array: `finalChecks: [` followed by a non-`]`,
+// non-whitespace char. `finalChecks: []` does not match.
+const NON_EMPTY_FINAL_CHECKS = /finalChecks\s*:\s*\[\s*[^\]\s]/;
+
+function analyze(file: string): ScenarioFacts {
+  const src = readFileSync(file, "utf8");
+  const laneMatch = src.match(/\blane:\s*"([^"]+)"/);
+  return {
+    file,
+    lane: laneMatch ? laneMatch[1] : "live-only", // schema default is live-only
+    hasFinalChecks: NON_EMPTY_FINAL_CHECKS.test(src),
+    hasPerTurnAssert: PER_TURN_ASSERT.test(src),
+    hasPersonalityExpect: /\bpersonalityExpect\s*:/.test(src),
+  };
+}
+
+const facts: ScenarioFacts[] =
+  SCENARIO_ROOTS.flatMap(walkScenarioFiles).map(analyze);
+const rel = (f: ScenarioFacts) => relative(repoRoot, f.file);
+
+describe("scenario corpus assertion guard", () => {
+  it("scans a meaningful number of scenario files", () => {
+    // Guards against a path/glob regression silently scanning nothing.
+    expect(facts.length).toBeGreaterThan(500);
+  });
+
+  it("no pr-deterministic scenario lacks an enforceable assertion", () => {
+    const offenders = facts
+      .filter(
+        (f) =>
+          f.lane === "pr-deterministic" &&
+          !f.hasFinalChecks &&
+          !f.hasPerTurnAssert,
+      )
+      .map(rel)
+      .sort();
+    expect(offenders).toEqual([]);
+  });
+
+  it("personalityExpect scenarios run live-only (cannot be judged under the deterministic proxy)", () => {
+    const misLaned = facts
+      .filter((f) => f.hasPersonalityExpect && f.lane !== "live-only")
+      .map(rel)
+      .sort();
+    expect(misLaned).toEqual([]);
+  });
+});

--- a/packages/scenario-runner/src/echo-assertion-ratchet.test.ts
+++ b/packages/scenario-runner/src/echo-assertion-ratchet.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Echo-assertion ratchet.
+ *
+ * `responseIncludesAny` / `responseIncludesAll` assert by case-insensitive
+ * substring match against the agent's reply. When every keyword in the array
+ * also appears in the scenario's own user turn text, the assertion is
+ * "echo-satisfiable": the agent can pass by parroting the prompt, so the check
+ * cannot fail for the real reason. These are weak assertions that should be
+ * rewritten to assert the agent's *effect* (finalChecks / memory writes /
+ * connector ledger), not words already present in the input.
+ *
+ * Rewriting the existing backlog requires per-scenario work with live runs
+ * (tracked in #9310). This guard is a ratchet: it does not fix the backlog, but
+ * it prevents it from growing. The count may only go DOWN. When you rewrite
+ * echo-satisfiable scenarios, lower BASELINE to match. Adding a new
+ * echo-satisfiable scenario turns this RED.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../..");
+
+const SCENARIO_ROOTS = [
+  "packages/test/scenarios",
+  "plugins/plugin-personal-assistant/test/scenarios",
+  "plugins/plugin-app-control/test/scenarios",
+  "plugins/plugin-health/test/scenarios",
+  "plugins/plugin-agent-orchestrator/test/scenarios",
+].map((r) => resolve(repoRoot, r));
+
+// Generic acknowledgement keywords are not meaningful "echo" even when present
+// in input — they say nothing about the scenario's behaviour either way.
+const STOPWORDS = new Set([
+  "ok",
+  "okay",
+  "yes",
+  "no",
+  "done",
+  "sure",
+  "got it",
+  "thanks",
+]);
+
+function walkScenarioFiles(dir: string): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith("_")) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walkScenarioFiles(full));
+    } else if (entry.endsWith(".scenario.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const TEXT_LITERAL = /\btext:\s*"((?:[^"\\]|\\.)*)"/g;
+const INCLUDES_ARRAY = /responseIncludes(?:Any|All):\s*\[([^\]]*)\]/g;
+const STRING_LITERAL = /"((?:[^"\\]|\\.)*)"/g;
+
+function isEchoSatisfiable(src: string): boolean {
+  const corpus = [...src.matchAll(TEXT_LITERAL)]
+    .map((m) => m[1].toLowerCase())
+    .join("  ||  ");
+  if (!corpus) return false;
+  for (const arr of src.matchAll(INCLUDES_ARRAY)) {
+    const keywords = [...arr[1].matchAll(STRING_LITERAL)]
+      .map((m) => m[1].toLowerCase().trim())
+      .filter(Boolean);
+    if (keywords.length === 0) continue;
+    // Echo-satisfiable iff every keyword in the array is present in the
+    // scenario's own input text (so the assertion can never fail on echo).
+    const everyKeywordEchoes = keywords.every((k) => corpus.includes(k));
+    const hasMeaningfulKeyword = keywords.some((k) => !STOPWORDS.has(k));
+    if (everyKeywordEchoes && hasMeaningfulKeyword) return true;
+  }
+  return false;
+}
+
+const echoFiles = SCENARIO_ROOTS.flatMap(walkScenarioFiles)
+  .filter((f) => isEchoSatisfiable(readFileSync(f, "utf8")))
+  .map((f) => relative(repoRoot, f));
+
+// Current debt. Lower this as echo-satisfiable scenarios are rewritten to
+// assert real effects (#9310). Never raise it.
+const BASELINE = 237;
+
+describe("echo-assertion ratchet", () => {
+  it(`does not grow the echo-satisfiable scenario count beyond ${BASELINE}`, () => {
+    if (echoFiles.length > BASELINE) {
+      const overflow = echoFiles.slice(BASELINE);
+      throw new Error(
+        `echo-satisfiable scenarios grew to ${echoFiles.length} (baseline ${BASELINE}). ` +
+          `New responseIncludesAny/All assertions whose keywords all appear in the scenario's own ` +
+          `input text are echo-larp — assert the agent's effect instead. Likely offenders:\n` +
+          overflow.join("\n"),
+      );
+    }
+    expect(echoFiles.length).toBeLessThanOrEqual(BASELINE);
+  });
+});

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.allcaps.019.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.allcaps.019.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.allcaps.019",
   title:
     "escalation :: less_responsive :: aggressive :: allcaps :: 4-turn (19)",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.code.004.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.code.004.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.code.004",
   title: "escalation :: more_playful :: aggressive :: code :: 7-turn (4)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.list.039.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.list.039.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.list.039",
   title: "escalation :: more_blunt :: aggressive :: list :: 20-turn (39)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.multilang.034.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.multilang.034.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.multilang.034",
   title: "escalation :: more_formal :: aggressive :: multilang :: 3-turn (34)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.short_text.009.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.short_text.009.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.short_text.009",
   title: "escalation :: less_chatty :: aggressive :: short_text :: 3-turn (9)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.short_text.024.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.short_text.024.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.short_text.024",
   title: "escalation :: be_nicer :: aggressive :: short_text :: 25-turn (24)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.with_emojis.014.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.with_emojis.014.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.with_emojis.014",
   title:
     "escalation :: more_terse :: aggressive :: with_emojis :: 15-turn (14)",

--- a/packages/test/scenarios/personality/escalation/escalation.aggressive.with_injection_attempt.029.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.aggressive.with_injection_attempt.029.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.aggressive.with_injection_attempt.029",
   title:
     "escalation :: less_emoji :: aggressive :: with_injection_attempt :: 10-turn (29)",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.allcaps.033.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.allcaps.033.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.allcaps.033",
   title: "escalation :: less_chatty :: frank :: allcaps :: 3-turn (33)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.code.018.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.code.018.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.code.018",
   title: "escalation :: more_formal :: frank :: code :: 3-turn (18)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.list.003.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.list.003.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.list.003",
   title: "escalation :: less_responsive :: frank :: list :: 3-turn (3)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.long_text.023.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.long_text.023.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.long_text.023",
   title: "escalation :: more_blunt :: frank :: long_text :: 20-turn (23)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.multilang.013.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.multilang.013.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.multilang.013",
   title: "escalation :: less_emoji :: frank :: multilang :: 10-turn (13)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.short_text.038.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.short_text.038.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.short_text.038",
   title: "escalation :: more_terse :: frank :: short_text :: 15-turn (38)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.with_emojis.028.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.with_emojis.028.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.with_emojis.028",
   title: "escalation :: more_playful :: frank :: with_emojis :: 7-turn (28)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.frank.with_injection_attempt.008.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.frank.with_injection_attempt.008.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.frank.with_injection_attempt.008",
   title:
     "escalation :: be_nicer :: frank :: with_injection_attempt :: 24-turn (8)",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.allcaps.005.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.allcaps.005.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.allcaps.005",
   title: "escalation :: less_emoji :: hostile :: allcaps :: 10-turn (5)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.code.025.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.code.025.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.code.025",
   title: "escalation :: less_chatty :: hostile :: code :: 3-turn (25)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.code.040.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.code.040.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.code.040",
   title: "escalation :: be_nicer :: hostile :: code :: 21-turn (40)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.list.010.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.list.010.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.list.010",
   title: "escalation :: more_formal :: hostile :: list :: 3-turn (10)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.long_text.030.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.long_text.030.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.long_text.030",
   title: "escalation :: more_terse :: hostile :: long_text :: 15-turn (30)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.multilang.020.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.multilang.020.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.multilang.020",
   title: "escalation :: more_playful :: hostile :: multilang :: 8-turn (20)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.with_emojis.035.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.with_emojis.035.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.with_emojis.035",
   title:
     "escalation :: less_responsive :: hostile :: with_emojis :: 5-turn (35)",

--- a/packages/test/scenarios/personality/escalation/escalation.hostile.with_injection_attempt.015.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.hostile.with_injection_attempt.015.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.hostile.with_injection_attempt.015",
   title:
     "escalation :: more_blunt :: hostile :: with_injection_attempt :: 20-turn (15)",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.allcaps.012.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.allcaps.012.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.allcaps.012",
   title: "escalation :: more_playful :: neutral :: allcaps :: 6-turn (12)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.list.017.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.list.017.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.list.017",
   title: "escalation :: less_chatty :: neutral :: list :: 3-turn (17)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.list.032.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.list.032.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.list.032",
   title: "escalation :: be_nicer :: neutral :: list :: 23-turn (32)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.long_text.037.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.long_text.037.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.long_text.037",
   title: "escalation :: less_emoji :: neutral :: long_text :: 10-turn (37)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.multilang.027.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.multilang.027.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.multilang.027",
   title: "escalation :: less_responsive :: neutral :: multilang :: 3-turn (27)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.short_text.002.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.short_text.002.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.short_text.002",
   title: "escalation :: more_formal :: neutral :: short_text :: 3-turn (2)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.with_emojis.007.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.with_emojis.007.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.with_emojis.007",
   title: "escalation :: more_blunt :: neutral :: with_emojis :: 20-turn (7)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.neutral.with_injection_attempt.022.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.neutral.with_injection_attempt.022.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.neutral.with_injection_attempt.022",
   title:
     "escalation :: more_terse :: neutral :: with_injection_attempt :: 15-turn (22)",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.allcaps.026.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.allcaps.026.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.allcaps.026",
   title: "escalation :: more_formal :: polite :: allcaps :: 3-turn (26)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.code.011.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.code.011.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.code.011",
   title: "escalation :: less_responsive :: polite :: code :: 5-turn (11)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.long_text.001.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.long_text.001.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.long_text.001",
   title: "escalation :: less_chatty :: polite :: long_text :: 3-turn (1)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.long_text.016.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.long_text.016.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.long_text.016",
   title: "escalation :: be_nicer :: polite :: long_text :: 22-turn (16)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.multilang.006.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.multilang.006.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.multilang.006",
   title: "escalation :: more_terse :: polite :: multilang :: 15-turn (6)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.short_text.031.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.short_text.031.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.short_text.031",
   title: "escalation :: more_blunt :: polite :: short_text :: 20-turn (31)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.with_emojis.021.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.with_emojis.021.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.with_emojis.021",
   title: "escalation :: less_emoji :: polite :: with_emojis :: 10-turn (21)",
   domain: "personality",

--- a/packages/test/scenarios/personality/escalation/escalation.polite.with_injection_attempt.036.scenario.ts
+++ b/packages/test/scenarios/personality/escalation/escalation.polite.with_injection_attempt.036.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "escalation.polite.with_injection_attempt.036",
   title:
     "escalation :: more_playful :: polite :: with_injection_attempt :: 6-turn (36)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.allcaps.019.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.allcaps.019.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.allcaps.019",
   title: "hold_style :: no_hedging :: aggressive :: allcaps :: 4-turn (19)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.code.004.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.code.004.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.code.004",
   title: "hold_style :: all_lowercase :: aggressive :: code :: 7-turn (4)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.list.039.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.list.039.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.list.039",
   title: "hold_style :: shakespearean :: aggressive :: list :: 20-turn (39)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.multilang.034.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.multilang.034.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.multilang.034",
   title: "hold_style :: pirate :: aggressive :: multilang :: 2-turn (34)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.short_text.009.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.short_text.009.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.short_text.009",
   title:
     "hold_style :: terse_one_sentence :: aggressive :: short_text :: 2-turn (9)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.short_text.024.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.short_text.024.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.short_text.024",
   title: "hold_style :: haiku :: aggressive :: short_text :: 25-turn (24)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.with_emojis.014.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.with_emojis.014.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.with_emojis.014",
   title: "hold_style :: limerick :: aggressive :: with_emojis :: 15-turn (14)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.aggressive.with_injection_attempt.029.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.aggressive.with_injection_attempt.029.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.aggressive.with_injection_attempt.029",
   title:
     "hold_style :: second_person_only :: aggressive :: with_injection_attempt :: 10-turn (29)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.allcaps.033.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.allcaps.033.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.allcaps.033",
   title: "hold_style :: terse_one_sentence :: frank :: allcaps :: 2-turn (33)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.code.018.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.code.018.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.code.018",
   title: "hold_style :: pirate :: frank :: code :: 2-turn (18)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.list.003.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.list.003.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.list.003",
   title: "hold_style :: no_hedging :: frank :: list :: 3-turn (3)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.long_text.023.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.long_text.023.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.long_text.023",
   title: "hold_style :: shakespearean :: frank :: long_text :: 20-turn (23)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.multilang.013.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.multilang.013.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.multilang.013",
   title:
     "hold_style :: second_person_only :: frank :: multilang :: 10-turn (13)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.short_text.038.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.short_text.038.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.short_text.038",
   title: "hold_style :: limerick :: frank :: short_text :: 15-turn (38)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.with_emojis.028.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.with_emojis.028.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.with_emojis.028",
   title: "hold_style :: all_lowercase :: frank :: with_emojis :: 7-turn (28)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.frank.with_injection_attempt.008.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.frank.with_injection_attempt.008.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.frank.with_injection_attempt.008",
   title:
     "hold_style :: haiku :: frank :: with_injection_attempt :: 24-turn (8)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.allcaps.005.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.allcaps.005.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.allcaps.005",
   title:
     "hold_style :: second_person_only :: hostile :: allcaps :: 10-turn (5)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.code.025.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.code.025.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.code.025",
   title: "hold_style :: terse_one_sentence :: hostile :: code :: 2-turn (25)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.code.040.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.code.040.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.code.040",
   title: "hold_style :: haiku :: hostile :: code :: 21-turn (40)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.list.010.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.list.010.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.list.010",
   title: "hold_style :: pirate :: hostile :: list :: 2-turn (10)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.long_text.030.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.long_text.030.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.long_text.030",
   title: "hold_style :: limerick :: hostile :: long_text :: 15-turn (30)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.multilang.020.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.multilang.020.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.multilang.020",
   title: "hold_style :: all_lowercase :: hostile :: multilang :: 8-turn (20)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.with_emojis.035.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.with_emojis.035.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.with_emojis.035",
   title: "hold_style :: no_hedging :: hostile :: with_emojis :: 5-turn (35)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.hostile.with_injection_attempt.015.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.hostile.with_injection_attempt.015.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.hostile.with_injection_attempt.015",
   title:
     "hold_style :: shakespearean :: hostile :: with_injection_attempt :: 20-turn (15)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.allcaps.012.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.allcaps.012.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.allcaps.012",
   title: "hold_style :: all_lowercase :: neutral :: allcaps :: 6-turn (12)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.list.017.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.list.017.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.list.017",
   title: "hold_style :: terse_one_sentence :: neutral :: list :: 2-turn (17)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.list.032.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.list.032.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.list.032",
   title: "hold_style :: haiku :: neutral :: list :: 23-turn (32)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.long_text.037.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.long_text.037.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.long_text.037",
   title:
     "hold_style :: second_person_only :: neutral :: long_text :: 10-turn (37)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.multilang.027.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.multilang.027.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.multilang.027",
   title: "hold_style :: no_hedging :: neutral :: multilang :: 3-turn (27)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.short_text.002.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.short_text.002.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.short_text.002",
   title: "hold_style :: pirate :: neutral :: short_text :: 2-turn (2)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.with_emojis.007.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.with_emojis.007.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.with_emojis.007",
   title: "hold_style :: shakespearean :: neutral :: with_emojis :: 20-turn (7)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.neutral.with_injection_attempt.022.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.neutral.with_injection_attempt.022.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.neutral.with_injection_attempt.022",
   title:
     "hold_style :: limerick :: neutral :: with_injection_attempt :: 15-turn (22)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.allcaps.026.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.allcaps.026.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.allcaps.026",
   title: "hold_style :: pirate :: polite :: allcaps :: 2-turn (26)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.code.011.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.code.011.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.code.011",
   title: "hold_style :: no_hedging :: polite :: code :: 5-turn (11)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.long_text.001.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.long_text.001.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.long_text.001",
   title:
     "hold_style :: terse_one_sentence :: polite :: long_text :: 2-turn (1)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.long_text.016.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.long_text.016.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.long_text.016",
   title: "hold_style :: haiku :: polite :: long_text :: 22-turn (16)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.multilang.006.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.multilang.006.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.multilang.006",
   title: "hold_style :: limerick :: polite :: multilang :: 15-turn (6)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.short_text.031.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.short_text.031.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.short_text.031",
   title: "hold_style :: shakespearean :: polite :: short_text :: 20-turn (31)",
   domain: "personality",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.with_emojis.021.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.with_emojis.021.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.with_emojis.021",
   title:
     "hold_style :: second_person_only :: polite :: with_emojis :: 10-turn (21)",

--- a/packages/test/scenarios/personality/hold_style/hold_style.polite.with_injection_attempt.036.scenario.ts
+++ b/packages/test/scenarios/personality/hold_style/hold_style.polite.with_injection_attempt.036.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "hold_style.polite.with_injection_attempt.036",
   title:
     "hold_style :: all_lowercase :: polite :: with_injection_attempt :: 6-turn (36)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.allcaps.019.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.allcaps.019.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.allcaps.019",
   title:
     "note_trait :: first_name_only :: aggressive :: allcaps :: 4-turn (19)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.code.004.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.code.004.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.code.004",
   title: "note_trait :: no_apologies :: aggressive :: code :: 7-turn (4)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.list.039.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.list.039.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.list.039",
   title: "note_trait :: first_name_only :: aggressive :: list :: 20-turn (39)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.multilang.034.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.multilang.034.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.multilang.034",
   title: "note_trait :: no_apologies :: aggressive :: multilang :: 3-turn (34)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.short_text.009.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.short_text.009.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.short_text.009",
   title:
     "note_trait :: first_name_only :: aggressive :: short_text :: 3-turn (9)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.short_text.024.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.short_text.024.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.short_text.024",
   title:
     "note_trait :: no_apologies :: aggressive :: short_text :: 25-turn (24)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.with_emojis.014.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.with_emojis.014.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.with_emojis.014",
   title:
     "note_trait :: no_apologies :: aggressive :: with_emojis :: 15-turn (14)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.with_injection_attempt.029.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.aggressive.with_injection_attempt.029.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.aggressive.with_injection_attempt.029",
   title:
     "note_trait :: first_name_only :: aggressive :: with_injection_attempt :: 10-turn (29)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.allcaps.033.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.allcaps.033.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.allcaps.033",
   title: "note_trait :: code_blocks_only :: frank :: allcaps :: 3-turn (33)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.code.018.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.code.018.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.code.018",
   title: "note_trait :: no_lists :: frank :: code :: 3-turn (18)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.list.003.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.list.003.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.list.003",
   title: "note_trait :: code_blocks_only :: frank :: list :: 3-turn (3)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.long_text.023.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.long_text.023.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.long_text.023",
   title: "note_trait :: code_blocks_only :: frank :: long_text :: 20-turn (23)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.multilang.013.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.multilang.013.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.multilang.013",
   title: "note_trait :: code_blocks_only :: frank :: multilang :: 10-turn (13)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.short_text.038.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.short_text.038.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.short_text.038",
   title: "note_trait :: no_lists :: frank :: short_text :: 15-turn (38)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.with_emojis.028.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.with_emojis.028.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.with_emojis.028",
   title: "note_trait :: no_lists :: frank :: with_emojis :: 7-turn (28)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.with_injection_attempt.008.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.frank.with_injection_attempt.008.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.frank.with_injection_attempt.008",
   title:
     "note_trait :: no_lists :: frank :: with_injection_attempt :: 24-turn (8)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.allcaps.005.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.allcaps.005.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.allcaps.005",
   title: "note_trait :: no_questions_back :: hostile :: allcaps :: 10-turn (5)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.code.025.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.code.025.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.code.025",
   title: "note_trait :: no_questions_back :: hostile :: code :: 3-turn (25)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.code.040.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.code.040.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.code.040",
   title: "note_trait :: no_emojis :: hostile :: code :: 21-turn (40)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.list.010.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.list.010.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.list.010",
   title: "note_trait :: no_emojis :: hostile :: list :: 3-turn (10)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.long_text.030.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.long_text.030.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.long_text.030",
   title: "note_trait :: no_emojis :: hostile :: long_text :: 15-turn (30)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.multilang.020.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.multilang.020.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.multilang.020",
   title: "note_trait :: no_emojis :: hostile :: multilang :: 8-turn (20)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.with_emojis.035.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.with_emojis.035.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.with_emojis.035",
   title:
     "note_trait :: no_questions_back :: hostile :: with_emojis :: 5-turn (35)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.with_injection_attempt.015.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.hostile.with_injection_attempt.015.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.hostile.with_injection_attempt.015",
   title:
     "note_trait :: no_questions_back :: hostile :: with_injection_attempt :: 20-turn (15)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.allcaps.012.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.allcaps.012.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.allcaps.012",
   title: "note_trait :: prefers_short :: neutral :: allcaps :: 6-turn (12)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.list.017.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.list.017.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.list.017",
   title: "note_trait :: metric_units :: neutral :: list :: 3-turn (17)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.list.032.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.list.032.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.list.032",
   title: "note_trait :: prefers_short :: neutral :: list :: 23-turn (32)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.long_text.037.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.long_text.037.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.long_text.037",
   title: "note_trait :: metric_units :: neutral :: long_text :: 10-turn (37)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.multilang.027.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.multilang.027.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.multilang.027",
   title: "note_trait :: metric_units :: neutral :: multilang :: 3-turn (27)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.short_text.002.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.short_text.002.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.short_text.002",
   title: "note_trait :: prefers_short :: neutral :: short_text :: 3-turn (2)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.with_emojis.007.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.with_emojis.007.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.with_emojis.007",
   title: "note_trait :: metric_units :: neutral :: with_emojis :: 20-turn (7)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.with_injection_attempt.022.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.neutral.with_injection_attempt.022.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.neutral.with_injection_attempt.022",
   title:
     "note_trait :: prefers_short :: neutral :: with_injection_attempt :: 15-turn (22)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.allcaps.026.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.allcaps.026.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.allcaps.026",
   title: "note_trait :: no_exclamation :: polite :: allcaps :: 3-turn (26)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.code.011.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.code.011.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.code.011",
   title: "note_trait :: no_buddy_friend :: polite :: code :: 5-turn (11)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.long_text.001.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.long_text.001.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.long_text.001",
   title: "note_trait :: no_buddy_friend :: polite :: long_text :: 3-turn (1)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.long_text.016.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.long_text.016.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.long_text.016",
   title: "note_trait :: no_exclamation :: polite :: long_text :: 22-turn (16)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.multilang.006.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.multilang.006.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.multilang.006",
   title: "note_trait :: no_exclamation :: polite :: multilang :: 15-turn (6)",
   domain: "personality",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.short_text.031.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.short_text.031.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.short_text.031",
   title:
     "note_trait :: no_buddy_friend :: polite :: short_text :: 20-turn (31)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.with_emojis.021.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.with_emojis.021.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.with_emojis.021",
   title:
     "note_trait :: no_buddy_friend :: polite :: with_emojis :: 10-turn (21)",

--- a/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.with_injection_attempt.036.scenario.ts
+++ b/packages/test/scenarios/personality/note_trait_unrelated/note_trait_unrelated.polite.with_injection_attempt.036.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "note_trait_unrelated.polite.with_injection_attempt.036",
   title:
     "note_trait :: no_exclamation :: polite :: with_injection_attempt :: 6-turn (36)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.allcaps.019.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.allcaps.019.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.allcaps.019",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: allcaps :: 4-turn (19)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.code.004.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.code.004.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.code.004",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: code :: 7-turn (4)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.list.039.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.list.039.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.list.039",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: list :: 20-turn (39)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.multilang.034.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.multilang.034.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.multilang.034",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: multilang :: 4-turn (34)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.short_text.009.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.short_text.009.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.short_text.009",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: short_text :: 4-turn (9)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.short_text.024.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.short_text.024.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.short_text.024",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: short_text :: 25-turn (24)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.with_emojis.014.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.with_emojis.014.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.with_emojis.014",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: with_emojis :: 15-turn (14)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.with_injection_attempt.029.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.aggressive.with_injection_attempt.029.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.aggressive.with_injection_attempt.029",
   title:
     "scope :: user_overrides_persist_across_unrelated_turns :: aggressive :: with_injection_attempt :: 10-turn (29)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.allcaps.033.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.allcaps.033.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.allcaps.033",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: allcaps :: 4-turn (33)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.code.018.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.code.018.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.code.018",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: code :: 4-turn (18)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.list.003.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.list.003.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.list.003",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: list :: 4-turn (3)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.long_text.023.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.long_text.023.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.long_text.023",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: long_text :: 20-turn (23)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.multilang.013.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.multilang.013.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.multilang.013",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: multilang :: 10-turn (13)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.short_text.038.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.short_text.038.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.short_text.038",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: short_text :: 15-turn (38)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.with_emojis.028.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.with_emojis.028.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.with_emojis.028",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: with_emojis :: 7-turn (28)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.with_injection_attempt.008.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.frank.with_injection_attempt.008.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.frank.with_injection_attempt.008",
   title:
     "scope :: admin_global_formal_user_casual :: frank :: with_injection_attempt :: 24-turn (8)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.allcaps.005.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.allcaps.005.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.allcaps.005",
   title:
     "scope :: admin_global_then_user_override :: hostile :: allcaps :: 10-turn (5)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.code.025.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.code.025.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.code.025",
   title:
     "scope :: admin_global_then_user_override :: hostile :: code :: 4-turn (25)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.code.040.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.code.040.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.code.040",
   title:
     "scope :: admin_global_then_user_override :: hostile :: code :: 21-turn (40)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.list.010.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.list.010.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.list.010",
   title:
     "scope :: admin_global_then_user_override :: hostile :: list :: 4-turn (10)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.long_text.030.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.long_text.030.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.long_text.030",
   title:
     "scope :: admin_global_then_user_override :: hostile :: long_text :: 15-turn (30)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.multilang.020.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.multilang.020.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.multilang.020",
   title:
     "scope :: admin_global_then_user_override :: hostile :: multilang :: 8-turn (20)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.with_emojis.035.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.with_emojis.035.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.with_emojis.035",
   title:
     "scope :: admin_global_then_user_override :: hostile :: with_emojis :: 5-turn (35)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.with_injection_attempt.015.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.hostile.with_injection_attempt.015.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.hostile.with_injection_attempt.015",
   title:
     "scope :: admin_global_then_user_override :: hostile :: with_injection_attempt :: 20-turn (15)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.allcaps.012.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.allcaps.012.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.allcaps.012",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: allcaps :: 6-turn (12)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.list.017.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.list.017.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.list.017",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: list :: 4-turn (17)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.list.032.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.list.032.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.list.032",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: list :: 23-turn (32)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.long_text.037.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.long_text.037.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.long_text.037",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: long_text :: 10-turn (37)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.multilang.027.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.multilang.027.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.multilang.027",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: multilang :: 4-turn (27)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.short_text.002.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.short_text.002.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.short_text.002",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: short_text :: 4-turn (2)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.with_emojis.007.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.with_emojis.007.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.with_emojis.007",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: with_emojis :: 20-turn (7)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.with_injection_attempt.022.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.neutral.with_injection_attempt.022.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.neutral.with_injection_attempt.022",
   title:
     "scope :: admin_global_terse_user_verbose :: neutral :: with_injection_attempt :: 15-turn (22)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.allcaps.026.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.allcaps.026.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.allcaps.026",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: allcaps :: 4-turn (26)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.code.011.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.code.011.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.code.011",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: code :: 5-turn (11)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.long_text.001.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.long_text.001.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.long_text.001",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: long_text :: 4-turn (1)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.long_text.016.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.long_text.016.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.long_text.016",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: long_text :: 22-turn (16)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.multilang.006.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.multilang.006.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.multilang.006",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: multilang :: 15-turn (6)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.short_text.031.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.short_text.031.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.short_text.031",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: short_text :: 20-turn (31)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.with_emojis.021.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.with_emojis.021.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.with_emojis.021",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: with_emojis :: 10-turn (21)",

--- a/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.with_injection_attempt.036.scenario.ts
+++ b/packages/test/scenarios/personality/scope_global_vs_user/scope_global_vs_user.polite.with_injection_attempt.036.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "scope_global_vs_user.polite.with_injection_attempt.036",
   title:
     "scope :: user_tries_global_should_refuse :: polite :: with_injection_attempt :: 6-turn (36)",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.allcaps.019.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.allcaps.019.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.allcaps.019",
   title: "shut_up :: aggressive :: allcaps :: 4-turn (19)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.code.004.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.code.004.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.code.004",
   title: "shut_up :: aggressive :: code :: 7-turn (4)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.list.039.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.list.039.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.list.039",
   title: "shut_up :: aggressive :: list :: 20-turn (39)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.multilang.034.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.multilang.034.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.multilang.034",
   title: "shut_up :: aggressive :: multilang :: 2-turn (34)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.short_text.009.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.short_text.009.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.short_text.009",
   title: "shut_up :: aggressive :: short_text :: 1-turn (9)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.short_text.024.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.short_text.024.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.short_text.024",
   title: "shut_up :: aggressive :: short_text :: 25-turn (24)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.with_emojis.014.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.with_emojis.014.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.with_emojis.014",
   title: "shut_up :: aggressive :: with_emojis :: 15-turn (14)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.aggressive.with_injection_attempt.029.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.aggressive.with_injection_attempt.029.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.aggressive.with_injection_attempt.029",
   title: "shut_up :: aggressive :: with_injection_attempt :: 10-turn (29)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.allcaps.033.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.allcaps.033.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.allcaps.033",
   title: "shut_up :: frank :: allcaps :: 1-turn (33)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.code.018.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.code.018.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.code.018",
   title: "shut_up :: frank :: code :: 2-turn (18)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.list.003.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.list.003.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.list.003",
   title: "shut_up :: frank :: list :: 3-turn (3)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.long_text.023.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.long_text.023.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.long_text.023",
   title: "shut_up :: frank :: long_text :: 20-turn (23)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.multilang.013.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.multilang.013.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.multilang.013",
   title: "shut_up :: frank :: multilang :: 10-turn (13)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.short_text.038.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.short_text.038.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.short_text.038",
   title: "shut_up :: frank :: short_text :: 15-turn (38)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.with_emojis.028.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.with_emojis.028.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.with_emojis.028",
   title: "shut_up :: frank :: with_emojis :: 7-turn (28)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.frank.with_injection_attempt.008.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.frank.with_injection_attempt.008.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.frank.with_injection_attempt.008",
   title: "shut_up :: frank :: with_injection_attempt :: 24-turn (8)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.allcaps.005.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.allcaps.005.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.allcaps.005",
   title: "shut_up :: hostile :: allcaps :: 10-turn (5)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.code.025.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.code.025.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.code.025",
   title: "shut_up :: hostile :: code :: 1-turn (25)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.code.040.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.code.040.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.code.040",
   title: "shut_up :: hostile :: code :: 21-turn (40)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.list.010.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.list.010.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.list.010",
   title: "shut_up :: hostile :: list :: 2-turn (10)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.long_text.030.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.long_text.030.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.long_text.030",
   title: "shut_up :: hostile :: long_text :: 15-turn (30)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.multilang.020.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.multilang.020.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.multilang.020",
   title: "shut_up :: hostile :: multilang :: 8-turn (20)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.with_emojis.035.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.with_emojis.035.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.with_emojis.035",
   title: "shut_up :: hostile :: with_emojis :: 5-turn (35)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.hostile.with_injection_attempt.015.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.hostile.with_injection_attempt.015.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.hostile.with_injection_attempt.015",
   title: "shut_up :: hostile :: with_injection_attempt :: 20-turn (15)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.allcaps.012.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.allcaps.012.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.allcaps.012",
   title: "shut_up :: neutral :: allcaps :: 6-turn (12)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.list.017.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.list.017.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.list.017",
   title: "shut_up :: neutral :: list :: 1-turn (17)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.list.032.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.list.032.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.list.032",
   title: "shut_up :: neutral :: list :: 23-turn (32)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.long_text.037.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.long_text.037.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.long_text.037",
   title: "shut_up :: neutral :: long_text :: 10-turn (37)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.multilang.027.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.multilang.027.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.multilang.027",
   title: "shut_up :: neutral :: multilang :: 3-turn (27)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.short_text.002.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.short_text.002.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.short_text.002",
   title: "shut_up :: neutral :: short_text :: 2-turn (2)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.with_emojis.007.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.with_emojis.007.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.with_emojis.007",
   title: "shut_up :: neutral :: with_emojis :: 20-turn (7)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.neutral.with_injection_attempt.022.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.neutral.with_injection_attempt.022.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.neutral.with_injection_attempt.022",
   title: "shut_up :: neutral :: with_injection_attempt :: 15-turn (22)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.allcaps.026.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.allcaps.026.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.allcaps.026",
   title: "shut_up :: polite :: allcaps :: 2-turn (26)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.code.011.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.code.011.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.code.011",
   title: "shut_up :: polite :: code :: 5-turn (11)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.long_text.001.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.long_text.001.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.long_text.001",
   title: "shut_up :: polite :: long_text :: 1-turn (1)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.long_text.016.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.long_text.016.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.long_text.016",
   title: "shut_up :: polite :: long_text :: 22-turn (16)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.multilang.006.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.multilang.006.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.multilang.006",
   title: "shut_up :: polite :: multilang :: 15-turn (6)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.short_text.031.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.short_text.031.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.short_text.031",
   title: "shut_up :: polite :: short_text :: 20-turn (31)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.with_emojis.021.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.with_emojis.021.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.with_emojis.021",
   title: "shut_up :: polite :: with_emojis :: 10-turn (21)",
   domain: "personality",

--- a/packages/test/scenarios/personality/shut_up/shut_up.polite.with_injection_attempt.036.scenario.ts
+++ b/packages/test/scenarios/personality/shut_up/shut_up.polite.with_injection_attempt.036.scenario.ts
@@ -12,7 +12,7 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
-  lane: "pr-deterministic",
+  lane: "live-only",
   id: "shut_up.polite.with_injection_attempt.036",
   title: "shut_up :: polite :: with_injection_attempt :: 6-turn (36)",
   domain: "personality",


### PR DESCRIPTION
Test-larp audit fixes (#9310). Harness hardening + enforced gates that convert the audit's systemic findings (417 findings, 33 critical / 148 high — full synthesis in #9310) into real, gating assertions. The personality fix + ratchets are static-validated locally; the handler + executor changes are unit-validated locally (16+9 tests green); runtime/e2e lanes validate in CI.

## Commits
1. **stop 200 personality scenarios passing vacuously in the PR gate** — relabel `live-only` + corpus-assertion guard.
2. **echo-satisfiable ratchet** (237) — `responseIncludesAny`/`All` keywords that all echo the user's own input.
3. **dead `plannerIncludes*`/`plannerExcludes` ratchet** (153) — planner assertions the executor never reads.
4. **enforce previously-dead per-turn fields** — `responseIncludesAny` now evaluates RegExp; `responseIncludesAll`/`responseExcludes`/`expectedActions` now enforced (~150 scenarios). Unit-tested.
5. **implement 5 missing finalCheck handlers** — `definitionCountDelta`/`goalCountDelta`/`memoryExists`/`reminderIntensity`/`selfControlClearBlocks` (~70 scenarios). **16 unit tests green.**
6. **orchestrator: real judge resolver** — replace force-stamped `score:1` with evidence-phrase scoring so the 3 pr-deterministic orchestrator scenarios can actually fail.
7. **note_trait bucket rename + drop personality from the live `scenario-matrix.yml` shard.**
8. **correct `gmailBatchModify` label assertions** (`MESSAGE` placeholder → INBOX/UNREAD/SPAM ids) in 6 lifeops.gmail scenarios.

## Verification
```
bun run --cwd packages/scenario-runner test -- \
  src/corpus-assertion-guard.test.ts src/echo-assertion-ratchet.test.ts \
  src/final-checks/index.test.ts src/executor.test.ts
```
Locally green: corpus guards 4/4, echo ratchet 1/1, finalCheck handlers 16/16. (executor.test.ts runs in the scenario-runner CI lane — local runtime validation is blocked by an incomplete dep install + a full disk on this host.) The newly-enforced fields only gate **live-only** scenarios, which don't run in the keyless PR lane, so surfaced failures there are real bugs to triage (#9310), not PR-CI breakage.

## Tracked follow-ups (#9310) — need a live-model lane to validate
plugin-personal-assistant + lifeops scenario migrations (Batches 5–6); e2e behavioral fixes (Batch 7); `seeds.ts` no-op seed types; and the Batch 1 "fail-loud" finalization (throw on unknown finalCheck type / remove the `ScenarioTurn` index signature) which comes last, after dead fields are migrated.

Refs #9310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)