### PR TITLE
build(on-device): deterministic always-latest renderer, no stale-artifact fallback (#9309)

### DIFF
--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -13,6 +13,7 @@ import {
   isSupportedBunVersion,
 } from "./lib/desktop-preflight.mjs";
 import { appIdentityEnv } from "./lib/read-app-identity.mjs";
+import { assertRendererRebuiltSince } from "./lib/renderer-build-manifest.mjs";
 
 const ROOT = process.cwd();
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -1040,6 +1041,51 @@ function fusedLibAlreadyStaged() {
   );
 }
 
+// Provenance for the staged fused lib so the reuse gate never silently reuses a
+// lib built for a DIFFERENT variant/platform than this build targets (#9309).
+const FUSED_LIB_SIDECAR = path.join(FUSED_LIB_OUT_DIR, "staged-fused-lib.json");
+
+function readFusedLibSidecar() {
+  try {
+    return JSON.parse(fs.readFileSync(FUSED_LIB_SIDECAR, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeFusedLibSidecar() {
+  fs.mkdirSync(FUSED_LIB_OUT_DIR, { recursive: true });
+  fs.writeFileSync(
+    FUSED_LIB_SIDECAR,
+    `${JSON.stringify(
+      {
+        variant: FUSED_LIB_VARIANT,
+        platform: process.platform,
+        builtAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+/**
+ * True only when a staged lib exists AND its provenance sidecar confirms it was
+ * built for the variant + platform this build targets. A staged lib with no
+ * sidecar (pre-provenance) or a mismatched one is NOT reusable — we cannot
+ * confirm it is the right backend, so we must rebuild rather than risk shipping
+ * a wrong-variant native lib that crashes on the device.
+ */
+function fusedLibStagedForCurrentVariant() {
+  if (!fusedLibAlreadyStaged()) return false;
+  const sidecar = readFusedLibSidecar();
+  if (!sidecar) return false;
+  return (
+    sidecar.variant === FUSED_LIB_VARIANT &&
+    sidecar.platform === process.platform
+  );
+}
+
 const FUSED_LIB_FORK_DIR = path.join(
   PLUGIN_LOCAL_INFERENCE_PACKAGE_DIR,
   "native",
@@ -1103,16 +1149,44 @@ function stageDesktopFusedLib() {
     process.env.ELIZA_DESKTOP_FUSED_LIB_OPTIONAL !== "1";
 
   if (
-    fusedLibAlreadyStaged() &&
+    fusedLibStagedForCurrentVariant() &&
     process.env.ELIZA_DESKTOP_REBUILD_FUSED_LIB !== "1"
   ) {
     console.log(
-      `[desktop-build] Reusing already-staged fused lib in ${FUSED_LIB_OUT_DIR}`,
+      `[desktop-build] Reusing already-staged fused lib in ${FUSED_LIB_OUT_DIR} ` +
+        `(variant=${FUSED_LIB_VARIANT}, ${process.platform})`,
     );
     return;
   }
 
+  // A staged lib whose provenance does not match this build (different variant
+  // or platform, or no sidecar) must never be silently reused.
+  const mismatchedStaged = fusedLibAlreadyStaged();
+  if (mismatchedStaged) {
+    const sidecar = readFusedLibSidecar();
+    console.warn(
+      `[desktop-build] Staged fused lib does not match this build ` +
+        `(want variant=${FUSED_LIB_VARIANT}/${process.platform}, found ` +
+        `${sidecar ? `${sidecar.variant}/${sidecar.platform}` : "no provenance sidecar"}). ` +
+        `It will be rebuilt to avoid shipping a wrong-variant native lib.`,
+    );
+  }
+
   if (!shouldBuild) {
+    if (mismatchedStaged) {
+      // Can't rebuild here (no toolchain requested) and the staged lib is the
+      // wrong variant — drop it so the app cleanly falls back to cloud inference
+      // instead of dlopen()-ing a mismatched backend on the device.
+      for (const name of fusedLibFilenames()) {
+        fs.rmSync(path.join(FUSED_LIB_OUT_DIR, name), { force: true });
+      }
+      fs.rmSync(FUSED_LIB_SIDECAR, { force: true });
+      console.warn(
+        "[desktop-build] Removed the mismatched fused lib; this build ships without " +
+          "local inference. Rebuild with --build-fused-lib to stage the right variant.",
+      );
+      return;
+    }
     console.log(
       "[desktop-build] Skipping fused libelizainference build (local-inference will be " +
         "unavailable in this build). Enable with --build-fused-lib or " +
@@ -1167,7 +1241,11 @@ function stageDesktopFusedLib() {
 
   if (!fusedLibAlreadyStaged()) {
     giveUp("the build produced no lib in the output dir");
+    return;
   }
+  // Record provenance so a later build with a different variant/platform won't
+  // silently reuse this lib.
+  writeFusedLibSidecar();
 }
 
 function stageDesktopBuild() {
@@ -1210,10 +1288,20 @@ function stageDesktopBuild() {
 
   ensureUiGeneratedAssets();
 
+  // Capture the moment the renderer build starts so we can prove afterward that
+  // a FRESH bundle was produced — not a stale dist silently reused (issue #9309).
+  const rendererBuildStartedAt = Date.now() - 1000;
   runBunPackageBinary("vite", ["build"], {
     cwd: APP_DIR,
     env: desktopRendererBuildEnv(),
     label: `Building renderer bundle (VITE_APP_VARIANT=${variant}, ELIZA_BUILD_VARIANT=${buildVariant})`,
+  });
+  // Fail loudly if the renderer manifest is missing or predates this build (a
+  // cached/stale dist was reused) or was built for a different variant.
+  assertRendererRebuiltSince(path.join(APP_DIR, "dist"), {
+    notBefore: rendererBuildStartedAt,
+    expectVariant: buildVariant,
+    label: "desktop",
   });
 
   runDesktopPreflight();

--- a/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.d.mts
@@ -1,0 +1,65 @@
+/**
+ * Type declarations for `renderer-build-manifest.mjs` — the deterministic build
+ * stamp for the web/renderer bundle (issue #9309). Imported by the vite
+ * `renderer-build-manifest` plugin and the platform build orchestrators.
+ */
+
+export const RENDERER_BUILD_MANIFEST_FILENAME: "eliza-renderer-build.json";
+export const RENDERER_BUILD_MANIFEST_SCHEMA: "elizaos.renderer.build/v1";
+
+export interface RendererBuildManifest {
+  schema: string;
+  buildId: string;
+  indexHtmlSha256: string;
+  assetCount: number;
+  builtAt: string;
+  commit: string | null;
+  variant: string | null;
+  capacitorTarget: string | null;
+  runtimeMode: string | null;
+}
+
+export interface RendererBuildManifestMeta {
+  builtAt?: string;
+  commit?: string | null;
+  variant?: string | null;
+  capacitorTarget?: string | null;
+  runtimeMode?: string | null;
+}
+
+export function computeRendererFingerprint(distDir: string): {
+  buildId: string;
+  indexHtmlSha256: string;
+  assetCount: number;
+};
+
+export function buildRendererManifest(
+  distDir: string,
+  meta?: RendererBuildManifestMeta,
+): RendererBuildManifest;
+
+export function writeRendererBuildManifest(
+  distDir: string,
+  meta?: RendererBuildManifestMeta,
+): RendererBuildManifest;
+
+export function readRendererBuildManifest(
+  dir: string,
+): RendererBuildManifest | null;
+
+export function assertStagedRendererMatchesBuild(
+  freshDistDir: string,
+  stagedDir: string,
+  opts?: { label?: string },
+): RendererBuildManifest;
+
+export function overlayFreshRendererIntoPublic(
+  freshDistDir: string,
+  targetPublicDir: string,
+  opts?: { label?: string },
+): RendererBuildManifest;
+
+export function assertRendererRebuiltSince(
+  distDir: string,
+  opts: { notBefore: number; expectVariant?: string | null; label?: string },
+): RendererBuildManifest;

--- a/packages/app-core/scripts/lib/renderer-build-manifest.mjs
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.mjs
@@ -1,0 +1,257 @@
+/**
+ * Renderer build manifest — the deterministic "build stamp" for the web/renderer
+ * bundle that every on-device artifact must carry.
+ *
+ * Issue #9309: the recurring on-device failure mode is a device booting STALE UI
+ * because a build step copied a cached `dist/` instead of the freshly built one.
+ * There was no machine-checkable identity for "which renderer is this", so a
+ * stale copy shipped silently.
+ *
+ * This module gives the renderer a content-derived identity:
+ *   - The vite `renderer-build-manifest` plugin writes `eliza-renderer-build.json`
+ *     into `dist/` at the end of EVERY renderer build (mobile, desktop, web).
+ *   - The file is copied into the device artifact alongside the bundle (cap sync
+ *     copies the whole webDir; desktop's Electrobun copy carries dist/), so it
+ *     ships on-device as an asserted build stamp.
+ *   - The platform orchestrators call `assertStagedRendererMatchesBuild()` after
+ *     staging so a stale/missing/partial renderer FAILS THE BUILD LOUDLY instead
+ *     of shipping old code.
+ *
+ * `buildId` is a sha256 over `index.html` + the sorted set of emitted asset
+ * file names (vite embeds each asset's content hash in its name) and their
+ * sizes. Two different source states therefore produce two different buildIds,
+ * which is exactly the freshness signal the issue asks for ("a real freshness
+ * check that fails the build when an input changed but the artifact didn't").
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const RENDERER_BUILD_MANIFEST_FILENAME = "eliza-renderer-build.json";
+export const RENDERER_BUILD_MANIFEST_SCHEMA = "elizaos.renderer.build/v1";
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Deterministic content fingerprint of a built renderer directory.
+ * @param {string} distDir absolute path to the built renderer dir (has index.html)
+ * @returns {{ buildId: string, indexHtmlSha256: string, assetCount: number }}
+ */
+export function computeRendererFingerprint(distDir) {
+  const indexPath = path.join(distDir, "index.html");
+  if (!fs.existsSync(indexPath)) {
+    throw new Error(
+      `[renderer-build-manifest] no index.html in ${distDir} — not a built renderer.`,
+    );
+  }
+  const indexHtmlSha256 = sha256(fs.readFileSync(indexPath));
+
+  const assetEntries = [];
+  const assetsDir = path.join(distDir, "assets");
+  if (fs.existsSync(assetsDir)) {
+    const walk = (dir, rel) => {
+      for (const name of fs.readdirSync(dir).sort()) {
+        const full = path.join(dir, name);
+        const relName = rel ? `${rel}/${name}` : name;
+        const stat = fs.statSync(full);
+        if (stat.isDirectory()) {
+          walk(full, relName);
+        } else {
+          assetEntries.push(`${relName}:${stat.size}`);
+        }
+      }
+    };
+    walk(assetsDir, "");
+  }
+  assetEntries.sort();
+  const buildId = sha256(`${indexHtmlSha256}\n${assetEntries.join("\n")}`);
+  return { buildId, indexHtmlSha256, assetCount: assetEntries.length };
+}
+
+/**
+ * Build the manifest object for a renderer dir (does not write it).
+ * @param {string} distDir
+ * @param {{ builtAt?: string, commit?: string|null, variant?: string|null,
+ *           capacitorTarget?: string|null, runtimeMode?: string|null }} [meta]
+ */
+export function buildRendererManifest(distDir, meta = {}) {
+  const fingerprint = computeRendererFingerprint(distDir);
+  return {
+    schema: RENDERER_BUILD_MANIFEST_SCHEMA,
+    buildId: fingerprint.buildId,
+    indexHtmlSha256: fingerprint.indexHtmlSha256,
+    assetCount: fingerprint.assetCount,
+    builtAt: meta.builtAt ?? new Date().toISOString(),
+    commit: meta.commit ?? null,
+    variant: meta.variant ?? null,
+    capacitorTarget: meta.capacitorTarget ?? null,
+    runtimeMode: meta.runtimeMode ?? null,
+  };
+}
+
+/**
+ * Write `eliza-renderer-build.json` into a built renderer dir. Returns manifest.
+ * @param {string} distDir
+ * @param {object} [meta]
+ */
+export function writeRendererBuildManifest(distDir, meta = {}) {
+  const manifest = buildRendererManifest(distDir, meta);
+  fs.writeFileSync(
+    path.join(distDir, RENDERER_BUILD_MANIFEST_FILENAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+}
+
+/**
+ * Read a renderer build manifest from a dir (the dir that holds index.html), or
+ * null if absent/unparseable.
+ * @param {string} dir
+ */
+export function readRendererBuildManifest(dir) {
+  const manifestPath = path.join(dir, RENDERER_BUILD_MANIFEST_FILENAME);
+  if (!fs.existsSync(manifestPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Assert a STAGED renderer directory carries exactly the renderer that was just
+ * built in `freshDistDir`. Throws loudly on any mismatch so a stale/missing/
+ * partial UI fails the build instead of shipping silently.
+ *
+ * @param {string} freshDistDir the just-built renderer (source of truth)
+ * @param {string} stagedDir    where it was staged for the device artifact
+ * @param {{ label?: string }} [opts]
+ * @returns the fresh manifest on success
+ */
+export function assertStagedRendererMatchesBuild(
+  freshDistDir,
+  stagedDir,
+  { label = "renderer" } = {},
+) {
+  const fresh = readRendererBuildManifest(freshDistDir);
+  if (!fresh) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: the freshly built renderer in ${freshDistDir} ` +
+        `has no ${RENDERER_BUILD_MANIFEST_FILENAME}. The renderer-build-manifest vite plugin ` +
+        `did not run — refusing to ship an unverifiable bundle.`,
+    );
+  }
+  const staged = readRendererBuildManifest(stagedDir);
+  if (!staged) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: staged renderer at ${stagedDir} has no ` +
+        `${RENDERER_BUILD_MANIFEST_FILENAME}. Capacitor sync / staging did not copy the freshly ` +
+        `built bundle — the device would boot stale or missing UI. Failing the build.`,
+    );
+  }
+  if (staged.buildId !== fresh.buildId) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: STALE RENDERER staged. ` +
+        `staged buildId=${staged.buildId} (built ${staged.builtAt}) != ` +
+        `freshly built buildId=${fresh.buildId} (built ${fresh.builtAt}). ` +
+        `The device would boot an OLD UI — failing the build instead of shipping it.`,
+    );
+  }
+  // A copied manifest paired with a partial/old index.html would pass the buildId
+  // check above; re-hash the staged index.html to defend against a torn copy.
+  const stagedIndex = path.join(stagedDir, "index.html");
+  if (!fs.existsSync(stagedIndex)) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: staged index.html missing in ${stagedDir}.`,
+    );
+  }
+  const stagedHtmlSha = sha256(fs.readFileSync(stagedIndex));
+  if (stagedHtmlSha !== fresh.indexHtmlSha256) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: staged index.html hash ${stagedHtmlSha} != ` +
+        `freshly built ${fresh.indexHtmlSha256} — partial or stale copy. Failing the build.`,
+    );
+  }
+  return fresh;
+}
+
+/**
+ * Stale-web guard: overlay the freshly built renderer onto a Capacitor `public`
+ * dir, then assert it matches. `cap sync` has been observed to leave a stale
+ * `public` (old hashed assets shipping an ancient UI). The fresh `dist` is the
+ * source of truth, so clear the hashed `assets/` and copy `dist` over `public`.
+ * Non-renderer payloads staged outside `dist` (e.g. `public/agent`, PGlite root
+ * extension assets) live outside `dist` and survive — only `public/assets` is
+ * cleared and cpSync never deletes existing non-dist files. Throws if the fresh
+ * renderer is missing or the staged result doesn't match (issue #9309).
+ *
+ * @param {string} freshDistDir the just-built renderer (source of truth)
+ * @param {string} targetPublicDir the Capacitor `public` dir to overlay
+ * @param {{ label?: string }} [opts]
+ * @returns the fresh manifest on success
+ */
+export function overlayFreshRendererIntoPublic(
+  freshDistDir,
+  targetPublicDir,
+  { label = "renderer" } = {},
+) {
+  if (!fs.existsSync(path.join(freshDistDir, "index.html"))) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: no freshly built renderer at ${freshDistDir} ` +
+        `(missing index.html). Refusing to stage a missing/stale UI.`,
+    );
+  }
+  fs.mkdirSync(targetPublicDir, { recursive: true });
+  fs.rmSync(path.join(targetPublicDir, "assets"), {
+    recursive: true,
+    force: true,
+  });
+  fs.cpSync(freshDistDir, targetPublicDir, { recursive: true });
+  return assertStagedRendererMatchesBuild(freshDistDir, targetPublicDir, {
+    label,
+  });
+}
+
+/**
+ * Assert a renderer manifest was (re)generated during THIS build invocation —
+ * i.e. it is not a stale leftover from a previous run. Used by the desktop build
+ * right after `vite build` to prove the renderer was actually rebuilt.
+ *
+ * @param {string} distDir
+ * @param {{ notBefore: number, expectVariant?: string|null, label?: string }} opts
+ *        notBefore: epoch ms captured immediately before the renderer build started
+ * @returns the manifest on success
+ */
+export function assertRendererRebuiltSince(
+  distDir,
+  { notBefore, expectVariant = null, label = "renderer" },
+) {
+  const manifest = readRendererBuildManifest(distDir);
+  if (!manifest) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: no ${RENDERER_BUILD_MANIFEST_FILENAME} in ${distDir} ` +
+        `after the renderer build. The build did not produce a verifiable renderer.`,
+    );
+  }
+  const builtAtMs = Date.parse(manifest.builtAt);
+  if (!Number.isFinite(builtAtMs) || builtAtMs < notBefore) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: renderer manifest is STALE. builtAt=${manifest.builtAt} ` +
+        `predates this build invocation (started ${new Date(notBefore).toISOString()}). ` +
+        `A cached/stale dist was reused instead of a fresh build — failing.`,
+    );
+  }
+  if (
+    expectVariant != null &&
+    manifest.variant != null &&
+    manifest.variant !== expectVariant
+  ) {
+    throw new Error(
+      `[renderer-build-manifest] ${label}: renderer built for variant '${manifest.variant}' ` +
+        `but this build targets '${expectVariant}'. A wrong-variant dist was reused — failing.`,
+    );
+  }
+  return manifest;
+}

--- a/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
+++ b/packages/app-core/scripts/lib/renderer-build-manifest.test.mts
@@ -1,0 +1,277 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  assertRendererRebuiltSince,
+  assertStagedRendererMatchesBuild,
+  buildRendererManifest,
+  computeRendererFingerprint,
+  overlayFreshRendererIntoPublic,
+  RENDERER_BUILD_MANIFEST_FILENAME,
+  readRendererBuildManifest,
+  writeRendererBuildManifest,
+} from "./renderer-build-manifest.mjs";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "renderer-manifest-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * Build a minimal renderer dist dir: index.html + assets/<name>. Mirrors what
+ * `vite build` emits (content-hashed asset names + an index.html referencing them).
+ */
+function makeDist(
+  dir: string,
+  {
+    indexHtml = "<!doctype html><html><body><div id=root></div></body></html>",
+    assets = { "index-abc123.js": "console.log(1)" },
+  }: { indexHtml?: string; assets?: Record<string, string> } = {},
+) {
+  fs.mkdirSync(path.join(dir, "assets"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "index.html"), indexHtml);
+  for (const [name, body] of Object.entries(assets)) {
+    fs.writeFileSync(path.join(dir, "assets", name), body);
+  }
+}
+
+describe("computeRendererFingerprint", () => {
+  it("is deterministic for identical content", () => {
+    const a = path.join(tmp, "a");
+    const b = path.join(tmp, "b");
+    makeDist(a);
+    makeDist(b);
+    expect(computeRendererFingerprint(a).buildId).toBe(
+      computeRendererFingerprint(b).buildId,
+    );
+  });
+
+  it("changes when index.html changes", () => {
+    const a = path.join(tmp, "a");
+    const b = path.join(tmp, "b");
+    makeDist(a);
+    makeDist(b, {
+      indexHtml: "<!doctype html><html><body>changed</body></html>",
+    });
+    expect(computeRendererFingerprint(a).buildId).not.toBe(
+      computeRendererFingerprint(b).buildId,
+    );
+  });
+
+  it("changes when an asset is added or renamed (new content hash)", () => {
+    const a = path.join(tmp, "a");
+    const b = path.join(tmp, "b");
+    makeDist(a, { assets: { "index-abc123.js": "x" } });
+    makeDist(b, { assets: { "index-def456.js": "x" } });
+    expect(computeRendererFingerprint(a).buildId).not.toBe(
+      computeRendererFingerprint(b).buildId,
+    );
+  });
+
+  it("throws when index.html is missing", () => {
+    const a = path.join(tmp, "a");
+    fs.mkdirSync(a, { recursive: true });
+    expect(() => computeRendererFingerprint(a)).toThrow(/not a built renderer/);
+  });
+});
+
+describe("writeRendererBuildManifest / readRendererBuildManifest", () => {
+  it("round-trips and records metadata", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    const written = writeRendererBuildManifest(dist, {
+      builtAt: "2026-01-01T00:00:00.000Z",
+      commit: "deadbeef",
+      variant: "store",
+      capacitorTarget: "ios",
+    });
+    expect(
+      fs.existsSync(path.join(dist, RENDERER_BUILD_MANIFEST_FILENAME)),
+    ).toBe(true);
+    const read = readRendererBuildManifest(dist);
+    expect(read).toEqual(written);
+    expect(read?.variant).toBe("store");
+    expect(read?.capacitorTarget).toBe("ios");
+    expect(read?.buildId).toBe(computeRendererFingerprint(dist).buildId);
+  });
+
+  it("returns null when no manifest is present", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    expect(readRendererBuildManifest(dist)).toBeNull();
+  });
+});
+
+describe("assertStagedRendererMatchesBuild", () => {
+  it("passes when the staged renderer is a faithful copy of the build", () => {
+    const dist = path.join(tmp, "dist");
+    const staged = path.join(tmp, "public");
+    makeDist(dist);
+    writeRendererBuildManifest(dist);
+    fs.cpSync(dist, staged, { recursive: true });
+    expect(() => assertStagedRendererMatchesBuild(dist, staged)).not.toThrow();
+  });
+
+  it("fails when the fresh build has no manifest", () => {
+    const dist = path.join(tmp, "dist");
+    const staged = path.join(tmp, "public");
+    makeDist(dist);
+    fs.cpSync(dist, staged, { recursive: true });
+    expect(() => assertStagedRendererMatchesBuild(dist, staged)).toThrow(
+      /has no eliza-renderer-build\.json/,
+    );
+  });
+
+  it("fails when the staged renderer has no manifest (stale/missing copy)", () => {
+    const dist = path.join(tmp, "dist");
+    const staged = path.join(tmp, "public");
+    makeDist(dist);
+    writeRendererBuildManifest(dist);
+    makeDist(staged); // copied bundle but manifest never made it across
+    expect(() => assertStagedRendererMatchesBuild(dist, staged)).toThrow(
+      /staged renderer .* has no/,
+    );
+  });
+
+  it("fails loudly when the staged renderer is STALE (different buildId)", () => {
+    const dist = path.join(tmp, "dist");
+    const staged = path.join(tmp, "public");
+    // Stale staged renderer: built earlier from different content.
+    makeDist(staged, {
+      indexHtml: "<!doctype html><html><body>OLD UI</body></html>",
+      assets: { "index-old000.js": "old" },
+    });
+    writeRendererBuildManifest(staged);
+    // Fresh build with new content.
+    makeDist(dist, {
+      indexHtml: "<!doctype html><html><body>NEW UI</body></html>",
+      assets: { "index-new111.js": "new" },
+    });
+    writeRendererBuildManifest(dist);
+    expect(() => assertStagedRendererMatchesBuild(dist, staged)).toThrow(
+      /STALE RENDERER/,
+    );
+  });
+
+  it("fails when the manifest matches but index.html was torn during copy", () => {
+    const dist = path.join(tmp, "dist");
+    const staged = path.join(tmp, "public");
+    makeDist(dist);
+    writeRendererBuildManifest(dist);
+    fs.cpSync(dist, staged, { recursive: true });
+    // Corrupt the staged index.html after the manifest was copied.
+    fs.writeFileSync(path.join(staged, "index.html"), "partial");
+    expect(() => assertStagedRendererMatchesBuild(dist, staged)).toThrow(
+      /partial or stale copy/,
+    );
+  });
+});
+
+describe("overlayFreshRendererIntoPublic", () => {
+  it("overlays a stale public with the fresh build and preserves non-dist payloads", () => {
+    const dist = path.join(tmp, "dist");
+    const pub = path.join(tmp, "public");
+    // Fresh build.
+    makeDist(dist, {
+      indexHtml: "<!doctype html><html><body>NEW</body></html>",
+      assets: { "index-new111.js": "new" },
+    });
+    writeRendererBuildManifest(dist);
+    // Stale public with an OLD hashed asset + an on-device agent payload that
+    // lives outside dist and must survive the overlay.
+    fs.mkdirSync(path.join(pub, "assets"), { recursive: true });
+    fs.writeFileSync(path.join(pub, "index.html"), "OLD");
+    fs.writeFileSync(path.join(pub, "assets", "index-old000.js"), "old");
+    fs.mkdirSync(path.join(pub, "agent"), { recursive: true });
+    fs.writeFileSync(path.join(pub, "agent", "agent-bundle.js"), "AGENT");
+
+    overlayFreshRendererIntoPublic(dist, pub, { label: "ios" });
+
+    // Old hashed asset is gone; fresh one is present; index matches.
+    expect(fs.existsSync(path.join(pub, "assets", "index-old000.js"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(pub, "assets", "index-new111.js"))).toBe(
+      true,
+    );
+    expect(fs.readFileSync(path.join(pub, "index.html"), "utf8")).toContain(
+      "NEW",
+    );
+    // The agent payload outside dist survived.
+    expect(
+      fs.readFileSync(path.join(pub, "agent", "agent-bundle.js"), "utf8"),
+    ).toBe("AGENT");
+    // And it now passes the staged-matches-build assertion.
+    expect(() => assertStagedRendererMatchesBuild(dist, pub)).not.toThrow();
+  });
+
+  it("throws when the fresh renderer is missing", () => {
+    const dist = path.join(tmp, "dist");
+    const pub = path.join(tmp, "public");
+    fs.mkdirSync(dist, { recursive: true }); // no index.html
+    expect(() => overlayFreshRendererIntoPublic(dist, pub)).toThrow(
+      /Refusing to stage a missing\/stale UI/,
+    );
+  });
+});
+
+describe("assertRendererRebuiltSince", () => {
+  it("passes when the manifest was built during this invocation", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    const notBefore = Date.now() - 1000;
+    writeRendererBuildManifest(dist, { variant: "base" });
+    expect(() =>
+      assertRendererRebuiltSince(dist, { notBefore, expectVariant: "base" }),
+    ).not.toThrow();
+  });
+
+  it("fails when the manifest is older than this build (stale dist reused)", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    writeRendererBuildManifest(dist, {
+      builtAt: "2020-01-01T00:00:00.000Z",
+    });
+    expect(() =>
+      assertRendererRebuiltSince(dist, { notBefore: Date.now() }),
+    ).toThrow(/STALE/);
+  });
+
+  it("fails when the renderer was built for a different variant", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    const notBefore = Date.now() - 1000;
+    writeRendererBuildManifest(dist, { variant: "direct" });
+    expect(() =>
+      assertRendererRebuiltSince(dist, { notBefore, expectVariant: "store" }),
+    ).toThrow(/wrong-variant/);
+  });
+
+  it("fails when no manifest exists after the build", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    expect(() =>
+      assertRendererRebuiltSince(dist, { notBefore: Date.now() - 1000 }),
+    ).toThrow(/no eliza-renderer-build\.json/);
+  });
+});
+
+describe("buildRendererManifest", () => {
+  it("defaults builtAt to an ISO timestamp and nulls unset metadata", () => {
+    const dist = path.join(tmp, "dist");
+    makeDist(dist);
+    const manifest = buildRendererManifest(dist);
+    expect(manifest.schema).toBe("elizaos.renderer.build/v1");
+    expect(Number.isFinite(Date.parse(manifest.builtAt))).toBe(true);
+    expect(manifest.commit).toBeNull();
+    expect(manifest.variant).toBeNull();
+    expect(manifest.capacitorTarget).toBeNull();
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -70,11 +70,17 @@ import {
   syncPlatformTemplateFiles as syncPlatformTemplateFilesImpl,
 } from "./lib/capacitor-platform-templates.mjs";
 import { ensurePlistUrlScheme } from "./lib/ios-plist-url-scheme.mjs";
+import {
+  assertStagedRendererMatchesBuild,
+  overlayFreshRendererIntoPublic,
+  readRendererBuildManifest,
+} from "./lib/renderer-build-manifest.mjs";
 import { resolveRepoRootFromImportMeta } from "./lib/repo-root.mjs";
 import {
   RUNTIME_PROVENANCE_FILENAME,
   stageAndroidAgentRuntime,
 } from "./lib/stage-android-agent.mjs";
+import { viteRendererBuildNeeded } from "./lib/vite-renderer-dist-stale.mjs";
 
 // ── Paths ───────────────────────────────────────────────────────────────
 
@@ -930,14 +936,69 @@ export function resolveMobileBuildPolicy(platform) {
 
 async function buildWeb(platform) {
   if (process.env.ELIZA_MOBILE_SKIP_WEB_BUILD === "1") {
-    const indexPath = path.join(appDir, "dist", "index.html");
+    const distDir = path.join(appDir, "dist");
+    const indexPath = path.join(distDir, "index.html");
     if (!fs.existsSync(indexPath)) {
       throw new Error(
         `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD=1 but ${indexPath} is missing.`,
       );
     }
+    // Never SILENTLY reuse a stale renderer (issue #9309). The skip flag is an
+    // explicit "reuse the existing dist" request, but it must still fail loudly
+    // when that dist is stale relative to sources or was built for a different
+    // variant/target than this build needs. A deliberate stale reuse can be
+    // forced with ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1.
+    const allowStale =
+      process.env.ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE === "1";
+    const policy = resolveMobileBuildPolicy(platform);
+    const expectedVariant =
+      process.env.ELIZA_BUILD_VARIANT || policy.buildVariant;
+    const expectedTarget = policy.capacitorTarget;
+    const manifest = readRendererBuildManifest(distDir);
+    const problems = [];
+    if (!manifest) {
+      problems.push(
+        `no ${path.join("dist", "eliza-renderer-build.json")} (renderer not built with the build-manifest plugin)`,
+      );
+    } else {
+      if (
+        expectedVariant &&
+        manifest.variant != null &&
+        manifest.variant !== expectedVariant
+      ) {
+        problems.push(
+          `dist built for variant '${manifest.variant}' but this build targets '${expectedVariant}'`,
+        );
+      }
+      if (
+        expectedTarget &&
+        manifest.capacitorTarget != null &&
+        manifest.capacitorTarget !== expectedTarget
+      ) {
+        problems.push(
+          `dist built for capacitor target '${manifest.capacitorTarget}' but this build targets '${expectedTarget}'`,
+        );
+      }
+    }
+    if (viteRendererBuildNeeded(appDir, repoRoot)) {
+      problems.push("dist is older than renderer sources (stale)");
+    }
+    if (problems.length > 0) {
+      const detail = problems.map((p) => `  - ${p}`).join("\n");
+      if (!allowStale) {
+        throw new Error(
+          `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD=1 refused — the existing web build is stale or mismatched:\n${detail}\n` +
+            `Drop ELIZA_MOBILE_SKIP_WEB_BUILD to rebuild, or set ` +
+            `ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1 to ship this dist anyway (NOT recommended).`,
+        );
+      }
+      console.warn(
+        `[mobile-build] ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1 — shipping a renderer flagged as stale/mismatched:\n${detail}`,
+      );
+    }
     console.log(
-      `[mobile-build] Reusing existing web build: ${path.relative(repoRoot, path.dirname(indexPath))}`,
+      `[mobile-build] Reusing existing web build: ${path.relative(repoRoot, distDir)}` +
+        (manifest ? ` (buildId=${manifest.buildId.slice(0, 12)})` : ""),
     );
     return;
   }
@@ -1322,6 +1383,36 @@ function mirrorCapacitorWebPayloadIntoAndroidDir() {
     );
   }
   reconcilePluginManifestWithGradle(targetAssets);
+  // Verify the staged Android renderer is exactly the freshly built one. The
+  // overlay above makes it so; this turns "should be fresh" into a hard,
+  // build-failing guarantee (issue #9309).
+  if (fs.existsSync(path.join(freshWeb, "index.html"))) {
+    assertStagedRendererMatchesBuild(freshWeb, targetPublic, {
+      label: "android",
+    });
+  }
+}
+
+/**
+ * iOS stale-web guard — the iOS counterpart to
+ * mirrorCapacitorWebPayloadIntoAndroidDir. `cap sync ios` (and a skipped sync)
+ * have both been observed to leave a STALE `ios/App/App/public` — an old entry
+ * hash shipping an ancient UI despite a fresh `dist`. The freshly vite-built
+ * bundle is the source of truth, so overlay it unconditionally: clear the hashed
+ * assets/ then copy dist over public. The on-device agent payload
+ * (`public/agent`) and PGlite root extension assets staged by
+ * stageIosAgentRuntime live OUTSIDE dist and survive — we only clear
+ * `public/assets` and cpSync never deletes existing non-dist files. After the
+ * overlay we assert the staged renderer matches the build so a stale/missing UI
+ * FAILS THE BUILD instead of shipping (issue #9309).
+ */
+function mirrorCapacitorWebPayloadIntoIosDir() {
+  const freshWeb = path.join(appDir, "dist");
+  const targetPublic = path.join(iosDir, "App", "public");
+  overlayFreshRendererIntoPublic(freshWeb, targetPublic, { label: "ios" });
+  console.log(
+    `[mobile-build] Stale-web guard: overlaid fresh ${path.relative(repoRoot, freshWeb)} → ${path.relative(repoRoot, targetPublic)}`,
+  );
 }
 
 /**
@@ -7411,6 +7502,11 @@ async function buildIos({ local = false } = {}) {
   } else {
     await runCapacitor(["sync", "ios"]);
   }
+  // Overlay the freshly built renderer onto ios/App/App/public and assert it
+  // matches the build — never ship a stale UI whether sync ran, was skipped, or
+  // left old hashed assets behind (issue #9309). Runs before the post-sync agent
+  // re-stage so the agent payload remains the final authority on public/agent.
+  mirrorCapacitorWebPayloadIntoIosDir();
   if (includesLocalAgentPayload) {
     stageIosAgentRuntime({
       appStoreBuild: isIosAppStoreBuild() && !local,

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -34,6 +34,7 @@ import {
   generateNodeBuiltinStub,
   nativeModuleStubPlugin,
 } from "./vite/native-module-stub-plugin.ts";
+import { rendererBuildManifestPlugin } from "./vite/renderer-build-manifest-plugin.ts";
 import { VENDOR_OPTIMIZED_WALLET_TEST } from "./vite/wallet-chunk-matcher.ts";
 import { resolveViteDevServerRuntime } from "./vite-dev-origin.ts";
 
@@ -2044,6 +2045,7 @@ export default defineConfig({
       },
     },
     appShellMetadataPlugin(),
+    rendererBuildManifestPlugin(),
     appDevWsBasePlugin(),
     companionAssetsPlugin(),
     elizaCoreBrowserEntryFallbackPlugin(),

--- a/packages/app/vite/renderer-build-manifest-plugin.ts
+++ b/packages/app/vite/renderer-build-manifest-plugin.ts
@@ -1,0 +1,69 @@
+import { execSync } from "node:child_process";
+import type { Plugin } from "vite";
+import {
+  RENDERER_BUILD_MANIFEST_FILENAME,
+  writeRendererBuildManifest,
+} from "../../app-core/scripts/lib/renderer-build-manifest.mjs";
+
+/**
+ * Emits `dist/eliza-renderer-build.json` at the end of EVERY production renderer
+ * build (mobile, desktop, web). The file is a content-derived build stamp that:
+ *   - ships on-device (cap sync copies the whole webDir; the desktop Electrobun
+ *     copy carries dist/), giving an asserted in-app "which renderer is this",
+ *   - lets the platform orchestrators fail the build loudly when a stale or
+ *     missing renderer would otherwise be staged (issue #9309).
+ *
+ * It runs in `closeBundle` (after all outputs are on disk) and reads the final
+ * dist directory so the fingerprint reflects exactly what was emitted. Dev
+ * servers never write a manifest (apply: "build").
+ */
+function resolveCommit(): string | null {
+  const envCommit =
+    process.env.GIT_COMMIT?.trim() || process.env.GIT_SHA?.trim();
+  if (envCommit) return envCommit;
+  try {
+    return execSync("git rev-parse HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+export function rendererBuildManifestPlugin(): Plugin {
+  let outDir = "dist";
+  return {
+    name: "renderer-build-manifest",
+    apply: "build",
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      // Model-tester and other secondary single-file builds emit no index.html;
+      // only stamp a real app bundle.
+      try {
+        const manifest = writeRendererBuildManifest(outDir, {
+          commit: resolveCommit(),
+          variant: process.env.ELIZA_BUILD_VARIANT ?? null,
+          capacitorTarget: process.env.ELIZA_CAPACITOR_BUILD_TARGET ?? null,
+          runtimeMode:
+            process.env.VITE_ELIZA_IOS_RUNTIME_MODE ??
+            process.env.VITE_ELIZA_ANDROID_RUNTIME_MODE ??
+            process.env.ELIZA_RUNTIME_MODE ??
+            null,
+        });
+        this.info?.(
+          `[renderer-build-manifest] wrote ${RENDERER_BUILD_MANIFEST_FILENAME} buildId=${manifest.buildId.slice(0, 12)} (${manifest.assetCount} assets)`,
+        );
+      } catch (err) {
+        // A renderer build with no index.html is a non-app output (e.g. the
+        // model-tester entry); skip stamping rather than failing the build.
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("not a built renderer")) return;
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/docs/apps/mobile/build-guide.md
+++ b/packages/docs/apps/mobile/build-guide.md
@@ -336,6 +336,48 @@ xattr -cr packages/app-core/platforms/ios/
 
 Then re-open the workspace in Xcode.
 
+## Deterministic, always-latest on-device builds
+
+Every on-device build packs the **latest** renderer at build time and fails
+loudly if a stale artifact would otherwise ship. The recurring failure mode this
+prevents is a device booting an old UI because Capacitor sync (or a skipped
+sync) left a stale `public/` behind.
+
+**How it works**
+
+- Every `vite build` emits a content-derived build stamp,
+  `dist/eliza-renderer-build.json` (the `renderer-build-manifest` vite plugin).
+  Its `buildId` is a sha256 over `index.html` + the emitted asset set, so two
+  different source states produce two different ids.
+- The stamp ships on-device alongside the bundle (cap sync copies the whole
+  webDir; the desktop Electrobun copy carries `dist/`), so the running app can be
+  asserted to be the latest by reading `eliza-renderer-build.json` at the web
+  root.
+- After staging, the orchestrators run `assertStagedRendererMatchesBuild()`:
+  - **iOS** overlays the freshly built `dist` onto `ios/App/App/public`
+    (clearing the hashed `assets/`, preserving the on-device `public/agent`
+    payload) and asserts the staged renderer matches the build.
+  - **Android** does the same overlay into the gradle assets tree.
+  - **Desktop** asserts the renderer manifest was regenerated during this build
+    invocation and built for the requested variant (no stale `dist` reuse).
+- The on-device agent bundle and (desktop) fused `libelizainference` are
+  re-staged every build; the fused lib records a provenance sidecar so a build
+  with a different variant/platform never silently reuses the wrong lib.
+
+**Reusing an existing web build**
+
+`ELIZA_MOBILE_SKIP_WEB_BUILD=1` reuses the existing `dist`, but the build still
+**fails** if that `dist` is older than its sources or was built for a different
+variant/target. Set `ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1` to ship it
+anyway (not recommended).
+
+**Verifying the running build is latest**
+
+An on-device/simulator smoke can fetch `/eliza-renderer-build.json` from the
+running app and assert its `buildId` equals the freshly built
+`packages/app/dist/eliza-renderer-build.json`. The same assertion runs at build
+time, so a stale UI fails the build before it ever reaches a device.
+
 ## Related
 
 - [Mobile App](/apps/mobile) — full platform configuration, plugin overview, and troubleshooting


### PR DESCRIPTION
Closes #9309 (renderer/web slice across **iOS, desktop/macOS, web**).

## Problem
The recurring on-device failure is a device booting **stale UI** because a build step staged a cached `dist/` instead of the freshly built one — `cap sync` leaving an old `public/`, a skipped sync, or a reused stale dist. There was no machine-checkable identity for "which renderer is this", so a stale copy shipped **silently**. iOS had **no** stale-web guard at all (Android did).

## What this does
Gives the renderer a content-derived **build stamp** and turns "should be fresh" into a hard, build-failing guarantee.

- **`renderer-build-manifest` vite plugin** — emits `dist/eliza-renderer-build.json` at the end of **every** renderer build (mobile, desktop, web). `buildId = sha256(index.html + emitted asset set)`, so a changed source state ⇒ a different id. The stamp ships on-device (cap sync copies the webDir; desktop carries `dist/`) as an **asserted in-app build stamp**.
- **iOS stale-web guard** (new; counterpart to Android's) — after `cap sync ios`, overlays the freshly built `dist` onto `ios/App/App/public` (clears hashed `assets/`, **preserves** the on-device `public/agent` + PGlite payloads), then `assertStagedRendererMatchesBuild()` — **fails loudly** on a stale/missing UI. Android's existing overlay now asserts too.
- **Desktop** — asserts the renderer manifest was **regenerated this build** (no stale dist reuse) and built for the requested variant. The fused `libelizainference` reuse gate is now **variant/platform-aware** via a provenance sidecar, so a build never silently reuses a wrong-variant native lib.
- **`ELIZA_MOBILE_SKIP_WEB_BUILD=1`** no longer silently reuses — it **fails** when the existing `dist` is stale vs sources or built for a different variant/target (override: `ELIZA_MOBILE_SKIP_WEB_BUILD_ALLOW_STALE=1`).

Shared logic lives in `packages/app-core/scripts/lib/renderer-build-manifest.mjs` (+ `.d.mts`).

## Evidence

**1. Plugin emits a correct stamp in a real 757-asset `vite build`:**
```json
{
  "schema": "elizaos.renderer.build/v1",
  "buildId": "37fcd9f6226fd0686eb28b4a0d6e67910a13f426c7391cacec43bc2722e4809e",
  "indexHtmlSha256": "8017923247e09dae34a6140984aae60f9a8236c4d8d7e4ba4edfa20ed6e204bd",
  "assetCount": 757, "commit": "526ba5de04...", "variant": "direct"
}
```
Recomputed fingerprint over the dist == manifest buildId (**MATCH**).

**2. Unit tests — 18/18 pass** (`scripts/lib/renderer-build-manifest.test.mts`): fingerprint determinism, change-detection (index.html / asset rename), write/read round-trip, staged-matches-build (stale buildId / missing manifest / torn index.html), overlay (removes old hashed asset, adds fresh, **preserves `public/agent`**), `assertRendererRebuiltSince` (stale builtAt / wrong variant / missing).

**3. Dependency-free end-to-end smoke on the develop base:**
```
stale-detected-and-failed: true
old-asset-removed: true
new-asset-present: true
agent-preserved: true
post-overlay-assert: PASS
```

**4. CI** — the existing `mobile-build-smoke.yml` iOS simulator lane runs `run-mobile-build.mjs ios`, exercising the new iOS guard + assertion end-to-end on every PR.

## On-device "running build is latest" check
The shipped `/eliza-renderer-build.json` is the in-app stamp: a sim/device smoke fetches it from the running app and asserts `buildId` == the freshly built `packages/app/dist/eliza-renderer-build.json`. The same assertion runs at build time, so a stale UI fails the build before reaching a device. Documented in `packages/docs/apps/mobile/build-guide.md`.

## Scope / notes
- Android keeps working (its overlay now also asserts); changes are additive.
- iOS device/App-Store `.app` archive evidence (full Xcode build) is **N/A in this environment** (no signing); covered by the iOS simulator CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)