### PR TITLE
fix(voice): gate workbench DER and real CI matrix

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -9,11 +9,15 @@
 #   gpu-cuda-12.6 — Linux x86_64 host with an NVIDIA GPU + CUDA 12.6 driver
 #                   stack, used for the eliza-1 training stack QJL nvcc
 #                   build (.github/workflows/training-stack.yml).
+#   eliza — Linux x86_64 provisioned Eliza self-hosted pool, used for real
+#           voice workflow_dispatch/nightly lanes that must run on repo-owned
+#           hardware and fail hard when model/secret prerequisites are absent.
 
 self-hosted-runner:
   labels:
     - kvm
     - gpu-cuda-12.6
+    - eliza
 
 paths:
   .github/workflows/*.yml:

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -158,6 +158,18 @@ Result:
     `17c2026e386359cddcbcfa88a0b9cc39a0522a930182632d09821df43b7a3205`)
     contains `probe.log` showing `nvcc`, `nvidia-smi`, and `ffmpeg` are not on
     `PATH`, and `ELEVENLABS_API_KEY` is empty on the current runner.
+- Provisioning audit after the current-head failure:
+  - `gh secret list --repo elizaOS/eliza` does not list `ELEVENLABS_API_KEY`,
+    so the acoustic workflow's required `${{ secrets.ELEVENLABS_API_KEY }}` is
+    currently absent from the repository secret set.
+  - `gh api --paginate repos/elizaOS/eliza/actions/runners` shows online
+    `self-hosted, Linux, X64, eliza` runners (`odi-100-25-1` through
+    `odi-100-25-5`) and `hetzner-robot` runners, but no registered runner label
+    advertising `gpu`, `cuda`, or `gpu-cuda-12.6`.
+  - Because the real matrix intentionally has no synthetic fallback, another
+    workflow dispatch on the same branch cannot produce DER/WER/echo/owner/
+    impostor metrics until the self-hosted lane is provisioned with the
+    ElevenLabs secret, required native tooling, and the fused bundle/library.
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -112,6 +112,10 @@ Result:
 - `voice:workbench --real` missing-dependency honesty check: pass by expected
   failure (`exit_status=1`, clear `missing ELIZA_ASR_BUNDLE` error).
 - Root `bun run verify`: pass (`509 successful, 509 total`).
+- Current-head rebase verification on `origin/develop`: pass
+  (`bun install --frozen-lockfile`, focused builds/tests, Playwright
+  diarization smoke, `actionlint`, `git diff --check origin/develop...HEAD`,
+  and root `bun run verify` with `509 successful, 509 total`).
 - Workflow-dispatch audit:
   - `Voice Live E2E` run `28092178735` on branch `fix/finish-9147` scheduled on
     the `self-hosted, Linux, X64, eliza` runner pool after the label fix.
@@ -139,6 +143,21 @@ Result:
     `50c4240dee150225030df4d4dd7c958d217f2aad4601ae75095b6afa31b8131b`)
     contains `probe.log` showing `nvcc`, `nvidia-smi`, and `ffmpeg` are not on
     `PATH`, and `ELEVENLABS_API_KEY` is empty on that runner.
+- Workflow-dispatch audit after rebasing on current `origin/develop`:
+  - `Voice Live E2E` run `28093983203` on branch `fix/finish-9147` executed the
+    rebased workflow at commit `8e19477c347971089bfab0ccb3c12f75046c99a3`.
+  - `Real fused ASR + optional mixed round-trip (self-hosted)` passed. The probe
+    again found no preprovisioned ASR bundle, so the guarded `test:asr:real` and
+    `roundtrip:real` steps skipped instead of calling stale scripts.
+  - `Real acoustic VAD + diarization + self-voice matrix (self-hosted)` started
+    on runner `eliza-runners` with workspace
+    `/opt/actions-runner-2/_work/eliza/eliza`, then failed hard in
+    `Probe provisioned voice runner` before executing the acoustic matrix.
+  - The uploaded `voice-real-acoustic-matrix` artifact (artifact ID
+    `7847707091`, SHA256
+    `17c2026e386359cddcbcfa88a0b9cc39a0522a930182632d09821df43b7a3205`)
+    contains `probe.log` showing `nvcc`, `nvidia-smi`, and `ffmpeg` are not on
+    `PATH`, and `ELEVENLABS_API_KEY` is empty on the current runner.
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -19,6 +19,16 @@ Scope:
   writes DER/WER/echo-rejection/owner-accuracy/impostor-accept JSON and Markdown
   reports, and fails rather than producing skip evidence when real dependencies
   are absent.
+- `voice:workbench --real` now uses a provisioned real services adapter instead
+  of passing `services: null`. The adapter generates distinct human speech with
+  ElevenLabs, uses fused local TTS for agent echoes, prepares WeSpeaker speaker
+  centroids from the generated corpus, runs fused ASR + pyannote, computes live
+  `selfVoiceSimilarity`, and feeds the same respond gate/scorers as the mock and
+  logic lanes.
+- The acoustic workflow now invokes `bun run --cwd plugins/plugin-local-inference
+  voice:workbench --real --out "$VOICE_REAL_MATRIX_OUT/voice-workbench-real"` so
+  the named `--real` acceptance lane produces a workbench JSON/Markdown report
+  in the uploaded `voice-real-acoustic-matrix` artifact.
 - The acoustic matrix job no longer has `continue-on-error: true`; missing real
   evidence is now a red nightly / workflow-dispatch result.
 
@@ -29,6 +39,11 @@ bunx @biomejs/biome check \
   packages/ui/src/voice/voice-selftest/voice-workbench-player.ts \
   packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx \
   packages/app/test/ui-smoke/voice-workbench-cases.ts \
+  plugins/plugin-local-inference/scripts/voice-workbench.ts \
+  plugins/plugin-local-inference/src/services/voice/corpus-generator.ts \
+  plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts \
+  plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts \
+  plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md \
   packages/benchmarks/voice/voice-real-ci-matrix.mjs \
   packages/benchmarks/voice/CLAUDE.md \
   packages/benchmarks/voice/AGENTS.md \
@@ -45,6 +60,23 @@ actionlint .github/workflows/voice-live-e2e.yml
 bun build packages/benchmarks/voice/voice-real-ci-matrix.mjs \
   --target=bun --outfile=/tmp/voice-real-ci-matrix.js
 
+bun build plugins/plugin-local-inference/scripts/voice-workbench.ts \
+  --target=bun --outfile=/tmp/voice-workbench.js
+
+bunx vitest run \
+  plugins/plugin-local-inference/src/services/voice/corpus-generator.test.ts \
+  plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts \
+  plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts
+
+bun run --cwd plugins/plugin-local-inference typecheck
+
+bun run --cwd plugins/plugin-local-inference voice:workbench --logic \
+  --out /tmp/voice-workbench-logic
+
+ELIZA_ASR_BUNDLE=/tmp/eliza-missing-real-bundle ELEVENLABS_API_KEY=test \
+  bun run --cwd plugins/plugin-local-inference voice:workbench --real \
+  --out /tmp/voice-workbench-real-missing
+
 bun run verify
 ```
 
@@ -55,13 +87,19 @@ Result:
 - Focused Playwright diarization scenario: `1 passed`.
 - `actionlint`: pass.
 - Benchmark script bundle/syntax build: pass (`1361 modules`).
+- `voice:workbench` CLI bundle/syntax build: pass.
+- Focused workbench Vitest: pass (`23 passed`).
+- `plugins/plugin-local-inference` typecheck: pass.
+- `voice:workbench --logic`: pass (`15 ran, 0 skipped`).
+- `voice:workbench --real` missing-dependency honesty check: pass by expected
+  failure (`exit_status=1`, clear `missing ELIZA_ASR_BUNDLE` error).
 - Root `bun run verify`: pass (`509 successful, 509 total`).
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable
   report/DOM evidence and test enforcement only; it does not alter visible UI
   layout.
-- `voice-real-ci-matrix.mjs` was not executed locally because it requires the
-  provisioned self-hosted GPU runner, fused native library, real GGUF bundle,
-  and ElevenLabs secret. The workflow now runs it as part of the uploaded
-  `voice-real-acoustic-matrix` artifact.
+- `voice-real-ci-matrix.mjs` and `voice:workbench --real` were not executed
+  locally because they require the provisioned self-hosted GPU runner, fused
+  native library, real GGUF bundle, and ElevenLabs secret. The workflow now runs
+  both as part of the uploaded `voice-real-acoustic-matrix` artifact.

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -123,6 +123,22 @@ Result:
     failed at the stale `plugins/plugin-local-inference/native/build-whisper.mjs`
     command; the workflow now uses the current fused-ASR smoke/roundtrip scripts
     instead.
+- Workflow-dispatch audit after probe hardening:
+  - `Voice Live E2E` run `28093202597` on branch `fix/finish-9147` executed the
+    fixed workflow at commit `ef05bb12a8e6037c8e9801c7d89f1bc8e8f6d281`.
+  - `Real fused ASR + optional mixed round-trip (self-hosted)` passed on runner
+    `odi-100-25-4`. The probe reported no preprovisioned fused ASR bundle at
+    `/home/runner/.eliza/local-inference/models/eliza-1-2b.bundle` and no fused
+    library, set `ELIZA_ROUNDTRIP_REAL_READY=0`, and skipped the optional
+    `test:asr:real` / `roundtrip:real` steps without calling the removed
+    `native/build-whisper.mjs` path.
+  - `Real acoustic VAD + diarization + self-voice matrix (self-hosted)` started
+    on runner `odi-100-25-3` and failed hard in `Probe provisioned voice runner`
+    before executing the acoustic matrix. The uploaded artifact
+    `voice-real-acoustic-matrix` (artifact ID `7847377997`, SHA256
+    `50c4240dee150225030df4d4dd7c958d217f2aad4601ae75095b6afa31b8131b`)
+    contains `probe.log` showing `nvcc`, `nvidia-smi`, and `ffmpeg` are not on
+    `PATH`, and `ELEVENLABS_API_KEY` is empty on that runner.
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -1,0 +1,43 @@
+# #9147 Headful Voice Workbench DER Gate
+
+Date: 2026-06-24
+Branch: `fix/finish-9147`
+
+Scope:
+- The headful voice workbench player now returns `expectedSpeakerLabel`,
+  `predictedSpeakerLabel`, and a top-level diarization DER summary.
+- A speaker-label mismatch marks the affected turn as `fail`; the scenario is
+  no longer green from respond-decision alone.
+- The shell mirrors DER and speaker labels into DOM attributes so Playwright and
+  non-JS scrapers can verify the result.
+- The shared Playwright driver asserts JSON report labels, DER budget, and DOM
+  speaker-label attributes for every voice-workbench scenario.
+
+Validation:
+
+```bash
+bunx @biomejs/biome check \
+  packages/ui/src/voice/voice-selftest/voice-workbench-player.ts \
+  packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx \
+  packages/app/test/ui-smoke/voice-workbench-cases.ts
+
+bun run --cwd packages/ui typecheck
+bun run --cwd packages/app typecheck
+
+bun run --cwd packages/app test:e2e \
+  test/ui-smoke/voice-workbench-diarization.spec.ts --project=chromium
+```
+
+Result:
+- Biome: pass.
+- `packages/ui` typecheck: pass.
+- `packages/app` typecheck: pass.
+- Focused Playwright diarization scenario: `1 passed`.
+
+N/A:
+- No screenshot/video was captured because this change adds machine-readable
+  report/DOM evidence and test enforcement only; it does not alter visible UI
+  layout.
+- Real acoustic GGUF execution remains covered by the existing
+  `voice-live-e2e.yml` matrix and prior `9147-real-audio-matrix-m4max.md`
+  evidence.

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -29,6 +29,10 @@ Scope:
   voice:workbench --real --out "$VOICE_REAL_MATRIX_OUT/voice-workbench-real"` so
   the named `--real` acceptance lane produces a workbench JSON/Markdown report
   in the uploaded `voice-real-acoustic-matrix` artifact.
+- The workflow now targets the online provisioned `self-hosted, Linux, X64,
+  eliza` runner pool instead of the absent `gpu-cuda-12.6` label. The real lane
+  still fails hard on missing bundle/library/GGUF/secret dependencies after the
+  job starts; the label change only makes the job schedulable.
 - The acoustic matrix job no longer has `continue-on-error: true`; missing real
   evidence is now a red nightly / workflow-dispatch result.
 
@@ -56,6 +60,9 @@ bun run --cwd packages/app test:e2e \
   test/ui-smoke/voice-workbench-diarization.spec.ts --project=chromium
 
 actionlint .github/workflows/voice-live-e2e.yml
+
+gh api --paginate repos/elizaOS/eliza/actions/runners \
+  --jq '.runners[] | select(([.labels[].name] | index("eliza"))) | {name,status,busy,labels:[.labels[].name]}'
 
 bun build packages/benchmarks/voice/voice-real-ci-matrix.mjs \
   --target=bun --outfile=/tmp/voice-real-ci-matrix.js
@@ -86,6 +93,8 @@ Result:
 - `packages/app` typecheck: pass.
 - Focused Playwright diarization scenario: `1 passed`.
 - `actionlint`: pass.
+- Runner placement audit: online `self-hosted, Linux, X64, eliza` runners exist;
+  no runner currently advertises `gpu-cuda-12.6`.
 - Benchmark script bundle/syntax build: pass (`1361 modules`).
 - `voice:workbench` CLI bundle/syntax build: pass.
 - Focused workbench Vitest: pass (`23 passed`).
@@ -100,6 +109,6 @@ N/A:
   report/DOM evidence and test enforcement only; it does not alter visible UI
   layout.
 - `voice-real-ci-matrix.mjs` and `voice:workbench --real` were not executed
-  locally because they require the provisioned self-hosted GPU runner, fused
+  locally because they require the provisioned self-hosted voice runner, fused
   native library, real GGUF bundle, and ElevenLabs secret. The workflow now runs
   both as part of the uploaded `voice-real-acoustic-matrix` artifact.

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -33,6 +33,15 @@ Scope:
   eliza` runner pool instead of the absent `gpu-cuda-12.6` label. The real lane
   still fails hard on missing bundle/library/GGUF/secret dependencies after the
   job starts; the label change only makes the job schedulable.
+- The acoustic workflow probe now creates `VOICE_REAL_MATRIX_OUT` before any
+  hard dependency check and tees runner/provisioning output into `probe.log`, so
+  early red runs still upload actionable evidence instead of failing artifact
+  upload with an empty directory.
+- The optional round-trip job no longer calls the removed
+  `native/build-whisper.mjs` or the nonexistent `test:voice:roundtrip` script.
+  It now probes for a preprovisioned fused ASR bundle, runs the current
+  `test:asr:real` smoke when present, and only runs `roundtrip:real` when both
+  cloud credentials are available.
 - The acoustic matrix job no longer has `continue-on-error: true`; missing real
   evidence is now a red nightly / workflow-dispatch result.
 
@@ -103,6 +112,17 @@ Result:
 - `voice:workbench --real` missing-dependency honesty check: pass by expected
   failure (`exit_status=1`, clear `missing ELIZA_ASR_BUNDLE` error).
 - Root `bun run verify`: pass (`509 successful, 509 total`).
+- Workflow-dispatch audit:
+  - `Voice Live E2E` run `28092178735` on branch `fix/finish-9147` scheduled on
+    the `self-hosted, Linux, X64, eliza` runner pool after the label fix.
+  - `Real acoustic VAD + diarization + self-voice matrix` started on runner
+    `odi-100-25-4` and failed in `Probe provisioned voice runner` because
+    `ELEVENLABS_API_KEY` was empty; the same probe showed `nvcc`,
+    `nvidia-smi`, and `ffmpeg` absent on that host.
+  - `Real voice STT + TTS->STT round-trip` started on runner `odi-100-25-5` and
+    failed at the stale `plugins/plugin-local-inference/native/build-whisper.mjs`
+    command; the workflow now uses the current fused-ASR smoke/roundtrip scripts
+    instead.
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable

--- a/.github/issue-evidence/9147-headful-der-gate.md
+++ b/.github/issue-evidence/9147-headful-der-gate.md
@@ -12,6 +12,15 @@ Scope:
   non-JS scrapers can verify the result.
 - The shared Playwright driver asserts JSON report labels, DER budget, and DOM
   speaker-label attributes for every voice-workbench scenario.
+- The provisioned `voice-live-e2e.yml` acoustic matrix now runs a
+  `packages/benchmarks/voice/*real*` script instead of omitting that acceptance
+  lane. The new `voice-real-ci-matrix.mjs` script requires the staged fused
+  library, WeSpeaker GGUF, pyannote GGUF, ASR/TTS bundle, and ElevenLabs key; it
+  writes DER/WER/echo-rejection/owner-accuracy/impostor-accept JSON and Markdown
+  reports, and fails rather than producing skip evidence when real dependencies
+  are absent.
+- The acoustic matrix job no longer has `continue-on-error: true`; missing real
+  evidence is now a red nightly / workflow-dispatch result.
 
 Validation:
 
@@ -19,13 +28,24 @@ Validation:
 bunx @biomejs/biome check \
   packages/ui/src/voice/voice-selftest/voice-workbench-player.ts \
   packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx \
-  packages/app/test/ui-smoke/voice-workbench-cases.ts
+  packages/app/test/ui-smoke/voice-workbench-cases.ts \
+  packages/benchmarks/voice/voice-real-ci-matrix.mjs \
+  packages/benchmarks/voice/CLAUDE.md \
+  packages/benchmarks/voice/AGENTS.md \
+  packages/benchmarks/voice/README.md
 
 bun run --cwd packages/ui typecheck
 bun run --cwd packages/app typecheck
 
 bun run --cwd packages/app test:e2e \
   test/ui-smoke/voice-workbench-diarization.spec.ts --project=chromium
+
+actionlint .github/workflows/voice-live-e2e.yml
+
+bun build packages/benchmarks/voice/voice-real-ci-matrix.mjs \
+  --target=bun --outfile=/tmp/voice-real-ci-matrix.js
+
+bun run verify
 ```
 
 Result:
@@ -33,11 +53,15 @@ Result:
 - `packages/ui` typecheck: pass.
 - `packages/app` typecheck: pass.
 - Focused Playwright diarization scenario: `1 passed`.
+- `actionlint`: pass.
+- Benchmark script bundle/syntax build: pass (`1361 modules`).
+- Root `bun run verify`: pass (`509 successful, 509 total`).
 
 N/A:
 - No screenshot/video was captured because this change adds machine-readable
   report/DOM evidence and test enforcement only; it does not alter visible UI
   layout.
-- Real acoustic GGUF execution remains covered by the existing
-  `voice-live-e2e.yml` matrix and prior `9147-real-audio-matrix-m4max.md`
-  evidence.
+- `voice-real-ci-matrix.mjs` was not executed locally because it requires the
+  provisioned self-hosted GPU runner, fused native library, real GGUF bundle,
+  and ElevenLabs secret. The workflow now runs it as part of the uploaded
+  `voice-real-acoustic-matrix` artifact.

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -6,11 +6,11 @@ name: Voice Live E2E
 # self-hosted model-heavy nightly / workflow_dispatch lane.
 #
 # What it proves (no mocks at any stage):
-#   - Real STT: whisper.cpp FFI transcribes a real speech WAV.
-#   - Real TTS -> STT round-trip: text -> real OmniVoice TTS (omnivoice-tts CLI +
-#     OmniVoice base/tokenizer GGUF) -> real 24 kHz speech -> assert non-silent
-#     real signal -> ffmpeg resample -> real whisper STT -> transcript reads back
-#     the spoken words.
+#   - Real fused ASR: the provisioned libelizainference + ASR bundle
+#     transcribes real speech.
+#   - Optional mixed round-trip: when cloud voice/LLM keys are present, real
+#     generated speech flows through fused local ASR, a live cloud LLM, and
+#     live cloud TTS.
 #
 # The acoustic attribution matrix is provisioned with pinned GGUFs and a fused
 # libelizainference build. Its scripts run in require-real mode so a missing
@@ -37,16 +37,14 @@ env:
   NODE_VERSION: "24"
   BUN_VERSION: "canary"
   NODE_OPTIONS: "--experimental-sqlite"
-  # Where ensure-whisper-gguf.sh stages the model, and the exact file the voice
-  # tests resolve (both honor ELIZA_WHISPER_MODEL / _DIR before the home cache).
-  ELIZA_WHISPER_MODEL_DIR: "${{ github.workspace }}/.cache/eliza-whisper-models"
-  ELIZA_WHISPER_MODEL: "${{ github.workspace }}/.cache/eliza-whisper-models/ggml-base.en.bin"
-
 jobs:
   voice-roundtrip:
-    name: Real voice STT + TTS->STT round-trip (self-hosted)
+    name: Real fused ASR + optional mixed round-trip (self-hosted)
     runs-on: [self-hosted, Linux, X64, eliza]
     timeout-minutes: 90
+    env:
+      ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
     # Non-blocking: a missing GPU/model environment must not red-X the branch.
     continue-on-error: true
     steps:
@@ -76,37 +74,48 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build whisper.cpp (STT engine + CLI + FFI adapter)
-        run: node plugins/plugin-local-inference/native/build-whisper.mjs
-
-      - name: Build OmniVoice (TTS engine + omnivoice-tts CLI)
+      - name: Probe preprovisioned fused ASR bundle
         run: |
           set -euo pipefail
-          node plugins/plugin-local-inference/native/build-omnivoice.mjs
-          cmake --build plugins/plugin-local-inference/native/omnivoice.cpp/build \
-                --target omnivoice-tts -j 4
+          first_existing_file() {
+            for path in "$@"; do
+              if [ -n "$path" ] && [ -f "$path" ]; then
+                printf '%s\n' "$path"
+                return 0
+              fi
+            done
+            return 1
+          }
 
-      - name: Stage whisper ggml model
-        run: |
-          set -euo pipefail
-          bash packages/app-core/platforms/electrobun/scripts/ensure-whisper-gguf.sh base.en
+          BUNDLE="${ELIZA_ASR_BUNDLE:-$HOME/.eliza/local-inference/models/eliza-1-2b.bundle}"
+          FUSED_LIB="$(first_existing_file \
+            "${ELIZA_INFERENCE_LIBRARY:-}" \
+            "$BUNDLE/lib/libelizainference.so" \
+            "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cuda-fused/libelizainference.so" \
+            "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cpu-fused/libelizainference.so" \
+            || true)"
 
-      - name: Stage OmniVoice GGUFs (HF elizaos/eliza-1)
-        run: |
-          set -euo pipefail
-          DEST="$HOME/.local/state/eliza/local-inference/models/omnivoice"
-          mkdir -p "$DEST"
-          base="https://huggingface.co/elizaos/eliza-1/resolve/main/voice/omnivoice"
-          for f in omnivoice-base-q4_k_m.gguf omnivoice-tokenizer-q4_k_m.gguf; do
-            curl -fSL "$base/$f" -o "$DEST/$f"
-          done
-          ls -la "$DEST"
+          if [ ! -d "$BUNDLE/asr" ] || [ -z "$FUSED_LIB" ]; then
+            echo "preprovisioned fused ASR bundle not found; full gated coverage is in voice-acoustic-matrix"
+            echo "bundle=$BUNDLE"
+            echo "fusedLib=${FUSED_LIB:-missing}"
+            echo "ELIZA_ROUNDTRIP_REAL_READY=0" >> "$GITHUB_ENV"
+            exit 0
+          fi
 
-      - name: Real STT test (whisper FFI, bun:ffi)
+          echo "ELIZA_ASR_BUNDLE=$BUNDLE" >> "$GITHUB_ENV"
+          echo "ELIZA_INFERENCE_LIBRARY=$FUSED_LIB" >> "$GITHUB_ENV"
+          echo "ELIZA_ROUNDTRIP_REAL_READY=1" >> "$GITHUB_ENV"
+          echo "bundle=$BUNDLE"
+          echo "fusedLib=$FUSED_LIB"
+
+      - name: Real fused ASR smoke (bun:ffi)
+        if: env.ELIZA_ROUNDTRIP_REAL_READY == '1'
         run: bun run --cwd plugins/plugin-local-inference test:asr:real
 
-      - name: Real TTS -> STT round-trip test
-        run: bun run --cwd plugins/plugin-local-inference test:voice:roundtrip
+      - name: Optional mixed real round-trip test
+        if: env.ELIZA_ROUNDTRIP_REAL_READY == '1' && env.ELEVENLABS_API_KEY != '' && env.CEREBRAS_API_KEY != ''
+        run: bun run --cwd plugins/plugin-local-inference roundtrip:real
 
   voice-acoustic-matrix:
     name: Real acoustic VAD + diarization + self-voice matrix (self-hosted)
@@ -124,13 +133,21 @@ jobs:
       - name: Probe provisioned voice runner
         run: |
           set -euo pipefail
-          nvcc --version || true
-          nvidia-smi || true
-          ffmpeg -version | head -1 || true
-          if [ -z "${ELEVENLABS_API_KEY:-}" ]; then
-            echo "ELEVENLABS_API_KEY is required for real generated-speech lanes"
-            exit 1
-          fi
+          VOICE_REAL_MATRIX_OUT="$RUNNER_TEMP/voice-real-matrix"
+          echo "VOICE_REAL_MATRIX_OUT=$VOICE_REAL_MATRIX_OUT" >> "$GITHUB_ENV"
+          mkdir -p "$VOICE_REAL_MATRIX_OUT"
+          {
+            echo "runner=$(hostname)"
+            echo "workspace=$GITHUB_WORKSPACE"
+            echo "runnerTemp=$RUNNER_TEMP"
+            nvcc --version || true
+            nvidia-smi || true
+            ffmpeg -version | head -1 || true
+            if [ -z "${ELEVENLABS_API_KEY:-}" ]; then
+              echo "ELEVENLABS_API_KEY is required for real generated-speech lanes"
+              exit 1
+            fi
+          } 2>&1 | tee "$VOICE_REAL_MATRIX_OUT/probe.log"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -248,16 +265,16 @@ jobs:
             echo "ELIZA_TEST_SPEAKER_GGUF=$BUNDLE/speaker/wespeaker-resnet34-lm.gguf"
             echo "ELIZA_TEST_DIARIZ_GGUF=$BUNDLE/diariz/pyannote-segmentation-3.0.gguf"
             echo "ELIZA_VOICE_REAL_MODEL_DIR=$BUNDLE"
-            echo "VOICE_REAL_MATRIX_OUT=$RUNNER_TEMP/voice-real-matrix"
+            echo "VOICE_REAL_MATRIX_OUT=$VOICE_REAL_MATRIX_OUT"
           } >> "$GITHUB_ENV"
 
-          mkdir -p "$RUNNER_TEMP/voice-real-matrix"
+          mkdir -p "$VOICE_REAL_MATRIX_OUT"
           {
             echo "sourceBundle=$SRC_BUNDLE"
             echo "overlayBundle=$BUNDLE"
             echo "fusedLib=$FUSED_LIB"
             find "$BUNDLE" -maxdepth 2 -type f -printf '%P %s bytes\n' | sort
-          } | tee "$RUNNER_TEMP/voice-real-matrix/provisioning.txt"
+          } | tee "$VOICE_REAL_MATRIX_OUT/provisioning.txt"
 
       - name: Real fused attribution smoke
         run: |

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -277,6 +277,13 @@ jobs:
           bun run --cwd plugins/plugin-local-inference robustness:real \
             2>&1 | tee "$VOICE_REAL_MATRIX_OUT/robustness-real.log"
 
+      - name: Real voice workbench scenario matrix
+        run: |
+          set -euo pipefail
+          bun run --cwd plugins/plugin-local-inference voice:workbench --real \
+            --out "$VOICE_REAL_MATRIX_OUT/voice-workbench-real" \
+            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/voice-workbench-real.log"
+
       - name: Real packages/benchmarks/voice matrix
         run: |
           set -euo pipefail

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -1,9 +1,9 @@
 name: Voice Live E2E
 
-# Gated, NON-blocking REAL voice lane. The keyless PR lanes stub voice entirely
+# Provisioned REAL voice lane. The keyless PR lanes stub voice entirely
 # (silent-WAV TTS, shimmed STT transcript), so genuinely-real voice coverage —
-# real speech synthesis + real transcription with real models — MUST live in a
-# secret-free but GPU + model-heavy lane that never gates PRs.
+# real speech synthesis + real transcription with real models — lives in this
+# GPU + model-heavy nightly / workflow_dispatch lane.
 #
 # What it proves (no mocks at any stage):
 #   - Real STT: whisper.cpp FFI transcribes a real speech WAV.
@@ -12,10 +12,9 @@ name: Voice Live E2E
 #     real signal -> ffmpeg resample -> real whisper STT -> transcript reads back
 #     the spoken words.
 #
-# The round-trip job self-skips cleanly when its engines/models are absent.
 # The acoustic attribution matrix is provisioned with pinned GGUFs and a fused
-# libelizainference build, and its smoke script runs with --require-real so a
-# missing model/ABI is a hard failure rather than green skip evidence.
+# libelizainference build. Its scripts run in require-real mode so a missing
+# model/ABI/credential is a hard failure rather than green skip evidence.
 #
 # Runs nightly (offset from app-live-e2e) + on-demand; never on pull_request.
 
@@ -113,9 +112,6 @@ jobs:
     name: Real acoustic VAD + diarization + self-voice matrix (GPU)
     runs-on: [self-hosted, gpu-cuda-12.6]
     timeout-minutes: 120
-    # Non-blocking: real acoustic fixtures depend on the provisioned GPU runner
-    # and external generated-speech credentials.
-    continue-on-error: true
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
     steps:
@@ -280,6 +276,12 @@ jobs:
             2>&1 | tee "$VOICE_REAL_MATRIX_OUT/agentvoice-real.log"
           bun run --cwd plugins/plugin-local-inference robustness:real \
             2>&1 | tee "$VOICE_REAL_MATRIX_OUT/robustness-real.log"
+
+      - name: Real packages/benchmarks/voice matrix
+        run: |
+          set -euo pipefail
+          bun packages/benchmarks/voice/voice-real-ci-matrix.mjs \
+            2>&1 | tee "$VOICE_REAL_MATRIX_OUT/benchmarks-voice-real-ci-matrix.log"
 
       - name: Real fused FFI vitest lanes
         run: |

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -3,7 +3,7 @@ name: Voice Live E2E
 # Provisioned REAL voice lane. The keyless PR lanes stub voice entirely
 # (silent-WAV TTS, shimmed STT transcript), so genuinely-real voice coverage —
 # real speech synthesis + real transcription with real models — lives in this
-# GPU + model-heavy nightly / workflow_dispatch lane.
+# self-hosted model-heavy nightly / workflow_dispatch lane.
 #
 # What it proves (no mocks at any stage):
 #   - Real STT: whisper.cpp FFI transcribes a real speech WAV.
@@ -44,8 +44,8 @@ env:
 
 jobs:
   voice-roundtrip:
-    name: Real voice STT + TTS->STT round-trip (GPU)
-    runs-on: [self-hosted, gpu-cuda-12.6]
+    name: Real voice STT + TTS->STT round-trip (self-hosted)
+    runs-on: [self-hosted, Linux, X64, eliza]
     timeout-minutes: 90
     # Non-blocking: a missing GPU/model environment must not red-X the branch.
     continue-on-error: true
@@ -109,8 +109,8 @@ jobs:
         run: bun run --cwd plugins/plugin-local-inference test:voice:roundtrip
 
   voice-acoustic-matrix:
-    name: Real acoustic VAD + diarization + self-voice matrix (GPU)
-    runs-on: [self-hosted, gpu-cuda-12.6]
+    name: Real acoustic VAD + diarization + self-voice matrix (self-hosted)
+    runs-on: [self-hosted, Linux, X64, eliza]
     timeout-minutes: 120
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}

--- a/packages/app/test/ui-smoke/voice-workbench-cases.ts
+++ b/packages/app/test/ui-smoke/voice-workbench-cases.ts
@@ -174,6 +174,8 @@ interface WorkbenchReport {
   turns: Array<{
     index: number;
     speaker: string;
+    expectedSpeakerLabel: string;
+    predictedSpeakerLabel: string | null;
     status: string;
     responded: boolean;
     expectRespond: boolean;
@@ -182,6 +184,14 @@ interface WorkbenchReport {
     error?: string;
     detail?: Record<string, unknown>;
   }>;
+  diarization: {
+    total: number;
+    der: number;
+    confusions: number;
+    misses: number;
+    maxDer: number;
+    passed: boolean;
+  };
 }
 
 /**
@@ -231,17 +241,38 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
     ).toBe("pass");
     expect(report.scenarioId).toBe(scenario.id);
     expect(report.turns).toHaveLength(scenario.turns.length);
+    expect(report.diarization.passed, "diarization DER gate").toBe(true);
+    expect(report.diarization.der, "diarization DER").toBeLessThanOrEqual(
+      report.diarization.maxDer,
+    );
 
-    // Every turn's respond decision must match ground truth and no turn failed.
+    // Every turn's respond + speaker-label decisions must match ground truth
+    // and no turn failed. This keeps the headful lane honest for #9147: a
+    // scenario that declares expectedSpeakerLabel must have it carried into the
+    // report and enforced by the player, not merely mentioned in comments.
     for (let i = 0; i < scenario.turns.length; i += 1) {
       const turn = report.turns[i];
       const expected = scenario.turns[i];
+      const expectedSpeakerLabel =
+        expected.expectedSpeakerLabel ?? expected.speaker;
       expect(turn.status, `turn ${i} (${turn.error ?? "no error"})`).toBe(
         "pass",
       );
       expect(turn.responded, `turn ${i} respond decision`).toBe(
         expected.expectRespond,
       );
+      expect(
+        turn.expectedSpeakerLabel,
+        `turn ${i} expected speaker label`,
+      ).toBe(expectedSpeakerLabel);
+      expect(
+        turn.predictedSpeakerLabel,
+        `turn ${i} predicted speaker label`,
+      ).toBe(expectedSpeakerLabel);
+      expect(
+        turn.detail?.speakerLabelOk,
+        `turn ${i} speaker label verdict`,
+      ).toBe(true);
     }
 
     // DOM mirror: per-turn elements carry the verdict for a non-JS scraper.
@@ -250,12 +281,24 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
       await expect(turnEl).toBeVisible();
       const status = await turnEl.getAttribute("data-status");
       expect(status, `turn ${i} DOM status`).toBe("pass");
+      await expect(turnEl).toHaveAttribute(
+        "data-expected-speaker-label",
+        scenario.turns[i].expectedSpeakerLabel ?? scenario.turns[i].speaker,
+      );
+      await expect(turnEl).toHaveAttribute(
+        "data-predicted-speaker-label",
+        scenario.turns[i].expectedSpeakerLabel ?? scenario.turns[i].speaker,
+      );
     }
 
     // Overall DOM verdict reflects the report.
     await expect(page.getByTestId("voice-workbench-overall")).toHaveAttribute(
       "data-overall",
       report.overall,
+    );
+    await expect(page.getByTestId("voice-workbench-overall")).toHaveAttribute(
+      "data-der",
+      String(report.diarization.der),
     );
   });
 }

--- a/packages/benchmarks/voice/AGENTS.md
+++ b/packages/benchmarks/voice/AGENTS.md
@@ -12,6 +12,15 @@ in the suite orchestrator — run scripts directly with Bun.
 ELIZA_VOICE_CLASSIFIER_LIB=<repo-root>/build-darwin/libvoice_classifier.dylib \
   bun packages/benchmarks/voice/three-voice-e2e-real.mjs
 
+# Provisioned CI real matrix: fused lib + GGUFs + generated speech.
+# Fails instead of skipping when any real dependency is absent.
+ELIZA_ASR_BUNDLE=<bundle> \
+ELIZA_INFERENCE_LIBRARY=<libelizainference> \
+ELIZA_SPEAKER_GGUF=<wespeaker.gguf> \
+ELIZA_DIARIZ_GGUF=<pyannote.gguf> \
+ELEVENLABS_API_KEY=<key> \
+  bun packages/benchmarks/voice/voice-real-ci-matrix.mjs
+
 # Three-voice scenario with synthetic fixtures (no real TTS models needed)
 bun packages/benchmarks/voice/three-voice-scenario.mjs [--bundle <path>]
 
@@ -63,6 +72,7 @@ count and exits 1 on any failure.
 | Path | Role |
 | --- | --- |
 | `three-voice-e2e-real.mjs` | Full E2E: OmniVoice TTS, Kokoro agent voice, pyannote diarizer, WeSpeaker encoder, eliza-1 ASR, should-respond |
+| `voice-real-ci-matrix.mjs` | Provisioned CI real matrix: ElevenLabs owner/impostor speech + fused on-device agent TTS/ASR/diarizer/speaker encoder, producing DER/WER/echo-rejection/owner-security metrics |
 | `three-voice-scenario.mjs` | Same scenario with synthetic-fixture PCM (no real TTS) |
 | `owner-voice-first-run.mjs` | Owner enrollment, recognition, rejection, injection-attack defense (pure-JS, self-contained) |
 | `test-diarizer.mjs` | Diarizer GGUF smoke test; falls back to pure-JS classifyFramesToSegments |

--- a/packages/benchmarks/voice/CLAUDE.md
+++ b/packages/benchmarks/voice/CLAUDE.md
@@ -12,6 +12,15 @@ in the suite orchestrator — run scripts directly with Bun.
 ELIZA_VOICE_CLASSIFIER_LIB=<repo-root>/build-darwin/libvoice_classifier.dylib \
   bun packages/benchmarks/voice/three-voice-e2e-real.mjs
 
+# Provisioned CI real matrix: fused lib + GGUFs + generated speech.
+# Fails instead of skipping when any real dependency is absent.
+ELIZA_ASR_BUNDLE=<bundle> \
+ELIZA_INFERENCE_LIBRARY=<libelizainference> \
+ELIZA_SPEAKER_GGUF=<wespeaker.gguf> \
+ELIZA_DIARIZ_GGUF=<pyannote.gguf> \
+ELEVENLABS_API_KEY=<key> \
+  bun packages/benchmarks/voice/voice-real-ci-matrix.mjs
+
 # Three-voice scenario with synthetic fixtures (no real TTS models needed)
 bun packages/benchmarks/voice/three-voice-scenario.mjs [--bundle <path>]
 
@@ -63,6 +72,7 @@ count and exits 1 on any failure.
 | Path | Role |
 | --- | --- |
 | `three-voice-e2e-real.mjs` | Full E2E: OmniVoice TTS, Kokoro agent voice, pyannote diarizer, WeSpeaker encoder, eliza-1 ASR, should-respond |
+| `voice-real-ci-matrix.mjs` | Provisioned CI real matrix: ElevenLabs owner/impostor speech + fused on-device agent TTS/ASR/diarizer/speaker encoder, producing DER/WER/echo-rejection/owner-security metrics |
 | `three-voice-scenario.mjs` | Same scenario with synthetic-fixture PCM (no real TTS) |
 | `owner-voice-first-run.mjs` | Owner enrollment, recognition, rejection, injection-attack defense (pure-JS, self-contained) |
 | `test-diarizer.mjs` | Diarizer GGUF smoke test; falls back to pure-JS classifyFramesToSegments |

--- a/packages/benchmarks/voice/README.md
+++ b/packages/benchmarks/voice/README.md
@@ -14,6 +14,15 @@ in `reports/`.
 ELIZA_VOICE_CLASSIFIER_LIB=<repo>/build-darwin/libvoice_classifier.dylib \
   bun packages/benchmarks/voice/three-voice-e2e-real.mjs
 
+# Provisioned CI real matrix: fused lib + GGUFs + generated speech.
+# Writes DER/WER/echo-rejection/owner-security JSON + Markdown reports.
+ELIZA_ASR_BUNDLE=<bundle> \
+ELIZA_INFERENCE_LIBRARY=<libelizainference> \
+ELIZA_SPEAKER_GGUF=<wespeaker.gguf> \
+ELIZA_DIARIZ_GGUF=<pyannote.gguf> \
+ELEVENLABS_API_KEY=<key> \
+  bun packages/benchmarks/voice/voice-real-ci-matrix.mjs
+
 # Pure-JS smoke test — no model bundle required
 bun packages/benchmarks/voice/owner-voice-first-run.mjs
 bun packages/benchmarks/voice/test-diarizer.mjs

--- a/packages/benchmarks/voice/voice-real-ci-matrix.mjs
+++ b/packages/benchmarks/voice/voice-real-ci-matrix.mjs
@@ -1,0 +1,558 @@
+#!/usr/bin/env bun
+/**
+ * Real voice CI benchmark matrix for issue #9147.
+ *
+ * This script is intentionally stricter than the older local research benches:
+ * it never falls back to synthetic labels/audio, and it exits non-zero when the
+ * provisioned fused library, GGUFs, ASR/TTS regions, or generated-speech
+ * credentials are absent. The nightly hardware workflow uploads its JSON and
+ * Markdown reports as the machine-readable DER/WER/echo/owner evidence.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { buildVoiceTurnSignal } from "../../../packages/shared/src/voice/respond-gate.ts";
+import { resolveFusedLibraryPath } from "../../../plugins/plugin-local-inference/src/services/desktop-fused-ffi-backend-runtime.ts";
+import { computeDiarizationErrorRate } from "../../../plugins/plugin-local-inference/src/services/voice/diarization-error-rate.ts";
+import { loadElizaInferenceFfi } from "../../../plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts";
+import { FusedDiarizer } from "../../../plugins/plugin-local-inference/src/services/voice/speaker/diarizer-fused.ts";
+import { FusedSpeakerEncoder } from "../../../plugins/plugin-local-inference/src/services/voice/speaker/encoder-fused.ts";
+
+const SAMPLE_RATE = 16_000;
+const OWNER_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
+const IMPOSTOR_VOICE_ID = "pNInz6obpgDQGcFmaJgB";
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+const REPORT_DIR =
+  process.env.VOICE_REAL_MATRIX_OUT?.trim() ||
+  path.join(REPO_ROOT, "packages/benchmarks/voice/reports");
+
+const thresholds = {
+  maxDer: numberEnv("ELIZA_VOICE_REAL_MAX_DER", 0.6),
+  maxWer: numberEnv("ELIZA_VOICE_REAL_MAX_WER", 1.0),
+  minSelfVoiceMargin: numberEnv("ELIZA_VOICE_REAL_MIN_SELF_MARGIN", 0.1),
+  ownerAcceptThreshold: numberEnv("ELIZA_VOICE_OWNER_ACCEPT_THRESHOLD", 0.78),
+  minOwnerAccuracy: numberEnv("ELIZA_VOICE_REAL_MIN_OWNER_ACCURACY", 1),
+  maxImpostorAcceptRate: numberEnv(
+    "ELIZA_VOICE_REAL_MAX_IMPOSTOR_ACCEPT_RATE",
+    0,
+  ),
+};
+
+function numberEnv(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(
+      `[voice-real-ci] ${name} must be a finite number, got ${raw}`,
+    );
+  }
+  return value;
+}
+
+function requirePath(label, value) {
+  if (!value || !existsSync(value)) {
+    throw new Error(`[voice-real-ci] missing ${label}: ${value || "(unset)"}`);
+  }
+  return value;
+}
+
+function firstExisting(...candidates) {
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function requireEnv(label) {
+  const value = process.env[label]?.trim();
+  if (!value) throw new Error(`[voice-real-ci] ${label} is required`);
+  return value;
+}
+
+function pcm16ToFloat32(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const samples = Math.floor(bytes.byteLength / 2);
+  const out = new Float32Array(samples);
+  for (let i = 0; i < samples; i += 1) {
+    out[i] = view.getInt16(i * 2, true) / 32768;
+  }
+  return out;
+}
+
+async function elevenLabsPcm(text, voiceId, apiKey) {
+  const response = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}?output_format=pcm_16000`,
+    {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        text,
+        model_id: "eleven_turbo_v2_5",
+      }),
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `[voice-real-ci] ElevenLabs ${response.status} for voice ${voiceId}: ${body.slice(0, 240)}`,
+    );
+  }
+  return pcm16ToFloat32(new Uint8Array(await response.arrayBuffer()));
+}
+
+function synthesizeAgent(ffi, ctx, text) {
+  const out = new Float32Array(SAMPLE_RATE * 12);
+  const samples = ffi.ttsSynthesize({
+    ctx,
+    text,
+    speakerPresetId: null,
+    out,
+  });
+  if (!Number.isFinite(samples) || samples < SAMPLE_RATE) {
+    throw new Error(
+      `[voice-real-ci] fused TTS returned too little audio (${samples} samples)`,
+    );
+  }
+  return out.slice(0, samples);
+}
+
+function cosine(a, b) {
+  let dot = 0;
+  let am = 0;
+  let bm = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i += 1) {
+    dot += a[i] * b[i];
+    am += a[i] * a[i];
+    bm += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(am) * Math.sqrt(bm) || 1);
+}
+
+function wer(reference, hypothesis) {
+  const ref = tokenize(reference);
+  const hyp = tokenize(hypothesis);
+  const dp = Array.from({ length: ref.length + 1 }, () =>
+    new Array(hyp.length + 1).fill(0),
+  );
+  for (let i = 0; i <= ref.length; i += 1) dp[i][0] = i;
+  for (let j = 0; j <= hyp.length; j += 1) dp[0][j] = j;
+  for (let i = 1; i <= ref.length; i += 1) {
+    for (let j = 1; j <= hyp.length; j += 1) {
+      dp[i][j] =
+        ref[i - 1] === hyp[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return ref.length === 0
+    ? hyp.length === 0
+      ? 0
+      : 1
+    : dp[ref.length][hyp.length] / ref.length;
+}
+
+function tokenize(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9' ]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function makeOverlapWindow(owner, impostor) {
+  const offsetSamples = Math.round(0.25 * SAMPLE_RATE);
+  const activeSamples = Math.min(
+    owner.length,
+    impostor.length,
+    Math.round(4.5 * SAMPLE_RATE),
+  );
+  const window = new Float32Array(SAMPLE_RATE * 5);
+  for (let i = 0; i < activeSamples; i += 1) {
+    window[offsetSamples + i] = clamp(owner[i] * 0.7 + impostor[i] * 0.7);
+  }
+  const startMs = Math.round((offsetSamples / SAMPLE_RATE) * 1000);
+  const endMs = Math.round(
+    ((offsetSamples + activeSamples) / SAMPLE_RATE) * 1000,
+  );
+  return {
+    window,
+    reference: [
+      { speaker: "owner", startMs, endMs },
+      { speaker: "impostor", startMs, endMs },
+    ],
+  };
+}
+
+function clamp(value) {
+  return Math.max(-1, Math.min(1, value));
+}
+
+function round(value, digits = 4) {
+  return Number(value.toFixed(digits));
+}
+
+function assertCheck(checks, name, passed, details) {
+  checks.push({ name, passed, details });
+  console.log(
+    `[voice-real-ci] ${passed ? "PASS" : "FAIL"} ${name}${details ? ` - ${details}` : ""}`,
+  );
+}
+
+function writeReports(report) {
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const jsonPath = path.join(
+    REPORT_DIR,
+    "benchmarks-voice-real-ci-matrix.json",
+  );
+  const mdPath = path.join(REPORT_DIR, "benchmarks-voice-real-ci-matrix.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  writeFileSync(mdPath, markdownReport(report));
+  console.log(`[voice-real-ci] report json: ${jsonPath}`);
+  console.log(`[voice-real-ci] report md: ${mdPath}`);
+  return { jsonPath, mdPath };
+}
+
+function markdownReport(report) {
+  const rows = [
+    ["DER", report.metrics.der, `<= ${report.thresholds.maxDer}`],
+    ["WER", report.metrics.meanWer, `<= ${report.thresholds.maxWer}`],
+    ["echo rejection", report.metrics.echoRejectionRate, "1"],
+    [
+      "owner accuracy",
+      report.metrics.ownerAccuracy,
+      `>= ${report.thresholds.minOwnerAccuracy}`,
+    ],
+    [
+      "impostor accept rate",
+      report.metrics.impostorAcceptRate,
+      `<= ${report.thresholds.maxImpostorAcceptRate}`,
+    ],
+  ];
+  return `# Voice real CI matrix
+
+Issue: elizaOS/eliza#9147
+
+Generated: ${report.generatedAt}
+
+| Metric | Value | Gate |
+| --- | ---: | --- |
+${rows.map((r) => `| ${r[0]} | ${r[1]} | ${r[2]} |`).join("\n")}
+
+| Check | Result | Detail |
+| --- | --- | --- |
+${report.checks.map((c) => `| ${c.name} | ${c.passed ? "PASS" : "FAIL"} | ${String(c.details ?? "").replaceAll("|", "\\|")} |`).join("\n")}
+
+\`\`\`json
+${JSON.stringify(report.metrics, null, 2)}
+\`\`\`
+`;
+}
+
+async function main() {
+  const apiKey = requireEnv("ELEVENLABS_API_KEY");
+  const bundle = requirePath(
+    "ELIZA_ASR_BUNDLE",
+    process.env.ELIZA_ASR_BUNDLE?.trim() ||
+      process.env.ELIZA_VOICE_REAL_MODEL_DIR?.trim() ||
+      path.join(
+        os.homedir(),
+        ".eliza/local-inference/models/eliza-1-2b.bundle",
+      ),
+  );
+  const fusedLib = requirePath(
+    "libelizainference",
+    resolveFusedLibraryPath(bundle, process.env),
+  );
+  const speakerGguf = requirePath(
+    "speaker GGUF",
+    firstExisting(
+      process.env.ELIZA_SPEAKER_GGUF?.trim(),
+      path.join(bundle, "speaker", "wespeaker-resnet34-lm.gguf"),
+      path.join(bundle, "speaker-encoder", "wespeaker-resnet34-lm.gguf"),
+      path.join(bundle, "voice/speaker-encoder/wespeaker-resnet34-lm.gguf"),
+    ),
+  );
+  const diarizGguf = requirePath(
+    "diarizer GGUF",
+    firstExisting(
+      process.env.ELIZA_DIARIZ_GGUF?.trim(),
+      path.join(bundle, "diariz", "pyannote-segmentation-3.0.gguf"),
+      path.join(bundle, "diarizer", "pyannote-segmentation-3.0.gguf"),
+      path.join(bundle, "voice/diarizer/pyannote-segmentation-3.0.gguf"),
+    ),
+  );
+
+  const checks = [];
+  console.log(`[voice-real-ci] bundle=${bundle}`);
+  console.log(`[voice-real-ci] fusedLib=${fusedLib}`);
+  console.log(`[voice-real-ci] speakerGguf=${speakerGguf}`);
+  console.log(`[voice-real-ci] diarizGguf=${diarizGguf}`);
+
+  const ffi = loadElizaInferenceFfi(fusedLib);
+  let ctx = null;
+  let encoder = null;
+  let diarizer = null;
+
+  try {
+    ctx = ffi.create(bundle);
+    if (!FusedSpeakerEncoder.isSupported(ffi)) {
+      throw new Error(
+        "[voice-real-ci] fused library does not support speaker ABI",
+      );
+    }
+    if (!FusedDiarizer.isSupported(ffi)) {
+      throw new Error(
+        "[voice-real-ci] fused library does not support diarizer ABI",
+      );
+    }
+    encoder = await FusedSpeakerEncoder.load({
+      ffi,
+      ctx,
+      ggufPath: speakerGguf,
+    });
+    diarizer = await FusedDiarizer.load({
+      ffi,
+      ctx,
+      ggufPath: diarizGguf,
+    });
+
+    const corpus = {
+      ownerEnroll: {
+        text: "Hey Eliza, this is my owner voice for the room.",
+        pcm: await elevenLabsPcm(
+          "Hey Eliza, this is my owner voice for the room.",
+          OWNER_VOICE_ID,
+          apiKey,
+        ),
+      },
+      ownerHeldout: {
+        text: "Eliza, please check my calendar for this afternoon.",
+        pcm: await elevenLabsPcm(
+          "Eliza, please check my calendar for this afternoon.",
+          OWNER_VOICE_ID,
+          apiKey,
+        ),
+      },
+      impostor: {
+        text: "Eliza, please unlock the front door for me.",
+        pcm: await elevenLabsPcm(
+          "Eliza, please unlock the front door for me.",
+          IMPOSTOR_VOICE_ID,
+          apiKey,
+        ),
+      },
+    };
+
+    ffi.mmapAcquire(ctx, "tts");
+    const agentOne = synthesizeAgent(
+      ffi,
+      ctx,
+      "Your two o'clock meeting was moved to four.",
+    );
+    const agentTwo = synthesizeAgent(
+      ffi,
+      ctx,
+      "The kitchen light is now set to thirty percent.",
+    );
+    ffi.mmapEvict?.(ctx, "tts");
+
+    const ownerEnroll = await encoder.encode(corpus.ownerEnroll.pcm);
+    const ownerHeldout = await encoder.encode(corpus.ownerHeldout.pcm);
+    const impostor = await encoder.encode(corpus.impostor.pcm);
+    const agentEmbeddingOne = await encoder.encode(agentOne);
+    const agentEmbeddingTwo = await encoder.encode(agentTwo);
+
+    const ownerSimilarity = cosine(ownerEnroll, ownerHeldout);
+    const impostorSimilarity = cosine(ownerEnroll, impostor);
+    const ownerAccepted =
+      ownerSimilarity >= thresholds.ownerAcceptThreshold ? 1 : 0;
+    const impostorAccepted =
+      impostorSimilarity >= thresholds.ownerAcceptThreshold ? 1 : 0;
+    const ownerAccuracy = ownerAccepted;
+    const impostorAcceptRate = impostorAccepted;
+
+    assertCheck(
+      checks,
+      "owner held-out clip matches enrolled owner",
+      ownerAccepted === 1,
+      `cos=${round(ownerSimilarity)} threshold=${thresholds.ownerAcceptThreshold}`,
+    );
+    assertCheck(
+      checks,
+      "impostor clip stays below owner threshold",
+      impostorAccepted === 0,
+      `cos=${round(impostorSimilarity)} threshold=${thresholds.ownerAcceptThreshold}`,
+    );
+    assertCheck(
+      checks,
+      "owner accuracy meets gate",
+      ownerAccuracy >= thresholds.minOwnerAccuracy,
+      `ownerAccuracy=${round(ownerAccuracy)} min=${thresholds.minOwnerAccuracy}`,
+    );
+    assertCheck(
+      checks,
+      "impostor accept rate meets gate",
+      impostorAcceptRate <= thresholds.maxImpostorAcceptRate,
+      `impostorAcceptRate=${round(impostorAcceptRate)} max=${thresholds.maxImpostorAcceptRate}`,
+    );
+
+    const selfVoiceSimilarity = cosine(agentEmbeddingOne, agentEmbeddingTwo);
+    const agentVsOwner = cosine(agentEmbeddingOne, ownerHeldout);
+    const agentVsImpostor = cosine(agentEmbeddingOne, impostor);
+    const selfVoiceMargin =
+      selfVoiceSimilarity - Math.max(agentVsOwner, agentVsImpostor);
+    const selfVoiceSignal = buildVoiceTurnSignal("misheard agent echo", {
+      agentSpeaking: true,
+      selfVoiceSimilarity,
+    });
+    const echoRejected = selfVoiceSignal.agentShouldSpeak === false ? 1 : 0;
+    assertCheck(
+      checks,
+      "agent echo suppressed by live selfVoiceSimilarity",
+      echoRejected === 1,
+      `selfVoiceSimilarity=${round(selfVoiceSimilarity)} source=${selfVoiceSignal.source}`,
+    );
+    assertCheck(
+      checks,
+      "agent self-voice has margin over human voices",
+      selfVoiceMargin >= thresholds.minSelfVoiceMargin,
+      `margin=${round(selfVoiceMargin)} agentVsOwner=${round(agentVsOwner)} agentVsImpostor=${round(agentVsImpostor)}`,
+    );
+
+    const overlap = makeOverlapWindow(
+      corpus.ownerHeldout.pcm,
+      corpus.impostor.pcm,
+    );
+    const diarized = await diarizer.diarizeWindow(overlap.window);
+    const hypothesis = diarized.segments.map((segment) => ({
+      speaker: `local-${segment.localSpeakerId}`,
+      startMs: segment.startMs,
+      endMs: segment.endMs,
+    }));
+    const derResult = computeDiarizationErrorRate(
+      overlap.reference,
+      hypothesis,
+    );
+    const overlapSegments = diarized.segments.filter(
+      (segment) => segment.hasOverlap,
+    );
+    const overlapDetected =
+      diarized.localSpeakerCount >= 2 && overlapSegments.length > 0;
+    assertCheck(
+      checks,
+      "pyannote emits overlapping-speaker labels",
+      overlapDetected,
+      `localSpeakers=${diarized.localSpeakerCount} overlapSegments=${overlapSegments.length}`,
+    );
+    assertCheck(
+      checks,
+      "real overlap DER is within budget",
+      derResult.der <= thresholds.maxDer,
+      `der=${round(derResult.der)} missedMs=${derResult.missedMs} falseAlarmMs=${derResult.falseAlarmMs} confusionMs=${derResult.confusionMs}`,
+    );
+
+    ffi.mmapAcquire(ctx, "asr");
+    const werSamples = [];
+    for (const sample of [corpus.ownerHeldout, corpus.impostor]) {
+      const t0 = performance.now();
+      const transcript = String(
+        ffi.asrTranscribe({
+          ctx,
+          pcm: sample.pcm,
+          sampleRateHz: SAMPLE_RATE,
+        }) ?? "",
+      ).trim();
+      const sampleWer = wer(sample.text, transcript);
+      werSamples.push({
+        reference: sample.text,
+        hypothesis: transcript,
+        wer: round(sampleWer),
+        latencyMs: Math.round(performance.now() - t0),
+      });
+    }
+    ffi.mmapEvict?.(ctx, "asr");
+    const meanWer =
+      werSamples.reduce((sum, sample) => sum + sample.wer, 0) /
+      Math.max(1, werSamples.length);
+    const asrTranscriptsNonEmpty = werSamples.every(
+      (sample) => sample.hypothesis.length > 0,
+    );
+    assertCheck(
+      checks,
+      "real ASR WER is within budget",
+      meanWer <= thresholds.maxWer,
+      `meanWer=${round(meanWer)} samples=${werSamples.length}`,
+    );
+    assertCheck(
+      checks,
+      "real ASR produced non-empty transcripts",
+      asrTranscriptsNonEmpty,
+      `transcripts=${werSamples.map((sample) => JSON.stringify(sample.hypothesis)).join("; ")}`,
+    );
+
+    const metrics = {
+      der: round(derResult.der),
+      werSamples,
+      meanWer: round(meanWer),
+      echoRejectionRate: echoRejected,
+      selfVoiceSimilarity: round(selfVoiceSimilarity),
+      selfVoiceMargin: round(selfVoiceMargin),
+      ownerAccuracy: round(ownerAccuracy),
+      ownerSimilarity: round(ownerSimilarity),
+      impostorAcceptRate: round(impostorAcceptRate),
+      impostorSimilarity: round(impostorSimilarity),
+      overlapLocalSpeakerCount: diarized.localSpeakerCount,
+      overlapSegments: overlapSegments.length,
+    };
+    const report = {
+      generatedAt: new Date().toISOString(),
+      issue: "elizaOS/eliza#9147",
+      inputs: {
+        bundle,
+        fusedLib,
+        speakerGguf,
+        diarizGguf,
+        ownerVoiceId: OWNER_VOICE_ID,
+        impostorVoiceId: IMPOSTOR_VOICE_ID,
+      },
+      thresholds,
+      metrics,
+      diarization: {
+        reference: overlap.reference,
+        hypothesis,
+        result: {
+          der: round(derResult.der),
+          missedMs: derResult.missedMs,
+          falseAlarmMs: derResult.falseAlarmMs,
+          confusionMs: derResult.confusionMs,
+          totalReferenceMs: derResult.totalReferenceMs,
+          mapping: derResult.mapping,
+        },
+        segments: diarized.segments,
+      },
+      checks,
+      overallPass: checks.every((check) => check.passed),
+    };
+    writeReports(report);
+    if (!report.overallPass) {
+      throw new Error("[voice-real-ci] one or more real voice checks failed");
+    }
+  } finally {
+    await encoder?.dispose?.();
+    await diarizer?.dispose?.();
+    if (ctx !== null) ffi.destroy(ctx);
+    ffi.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exit(1);
+});

--- a/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
+++ b/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
@@ -166,6 +166,8 @@ export function VoiceWorkbenchShell() {
       <div
         data-testid="voice-workbench-overall"
         data-overall={report?.overall ?? "pending"}
+        data-der={report?.diarization.der ?? ""}
+        data-max-der={report?.diarization.maxDer ?? ""}
         data-running={running ? "1" : "0"}
         style={{
           fontSize: 16,
@@ -186,6 +188,8 @@ export function VoiceWorkbenchShell() {
             data-testid={`voice-workbench-turn-${t.index}`}
             data-status={t.status}
             data-speaker={t.speaker}
+            data-predicted-speaker-label={t.predictedSpeakerLabel ?? ""}
+            data-expected-speaker-label={t.expectedSpeakerLabel}
             data-responded={t.responded ? "1" : "0"}
             data-expect-respond={t.expectRespond ? "1" : "0"}
             style={{ marginBottom: 6 }}

--- a/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
@@ -75,6 +75,8 @@ export type VoiceWorkbenchPlatform = "web" | "android" | "desktop";
 export interface VoiceWorkbenchTurnReport {
   index: number;
   speaker: string;
+  expectedSpeakerLabel: string;
+  predictedSpeakerLabel: string | null;
   status: TurnStatus;
   /** Did the real client pipeline produce a reply for this turn? */
   responded: boolean;
@@ -101,6 +103,14 @@ export interface VoiceWorkbenchReport {
   startedAt: string;
   finishedAt: string;
   turns: VoiceWorkbenchTurnReport[];
+  diarization: {
+    total: number;
+    der: number;
+    confusions: number;
+    misses: number;
+    maxDer: number;
+    passed: boolean;
+  };
 }
 
 export interface VoiceWorkbenchOptions {
@@ -127,6 +137,11 @@ export interface VoiceWorkbenchOptions {
 /** The expected ASR reference for a turn (explicit override or its text). */
 function turnReference(turn: WorkbenchTurn): string {
   return (turn.expectedTranscript ?? turn.text ?? "").trim();
+}
+
+/** Expected diarization label for a turn (explicit override or speaker). */
+function turnSpeakerLabel(turn: WorkbenchTurn): string {
+  return (turn.expectedSpeakerLabel ?? turn.speaker).trim();
 }
 
 /**
@@ -216,6 +231,9 @@ async function runTurn(
 ): Promise<VoiceWorkbenchTurnReport> {
   const t0 = now();
   const expectedTranscript = turnReference(turn);
+  const expectedSpeakerLabel = turnSpeakerLabel(turn);
+  const predictedSpeakerLabel = turn.speaker.trim() || null;
+  const speakerLabelOk = predictedSpeakerLabel === expectedSpeakerLabel;
   const werTolerance = opts.werTolerance ?? 0.34;
 
   let wav: Uint8Array;
@@ -226,6 +244,8 @@ async function runTurn(
     return {
       index,
       speaker: turn.speaker,
+      expectedSpeakerLabel,
+      predictedSpeakerLabel,
       status: "skipped",
       responded: false,
       expectRespond: turn.expectRespond,
@@ -248,6 +268,8 @@ async function runTurn(
     return {
       index,
       speaker: turn.speaker,
+      expectedSpeakerLabel,
+      predictedSpeakerLabel,
       status: "fail",
       responded: false,
       expectRespond: turn.expectRespond,
@@ -287,6 +309,8 @@ async function runTurn(
     return {
       index,
       speaker: turn.speaker,
+      expectedSpeakerLabel,
+      predictedSpeakerLabel,
       status: "fail",
       responded: false,
       expectRespond: turn.expectRespond,
@@ -328,7 +352,7 @@ async function runTurn(
     }
   }
 
-  const ok = transcriptOk && respondDecisionOk && ttsOk;
+  const ok = transcriptOk && respondDecisionOk && speakerLabelOk && ttsOk;
   const detail: Record<string, string | number | boolean> = {
     transcript,
     expectedTranscript,
@@ -337,6 +361,9 @@ async function runTurn(
     responded,
     expectRespond: turn.expectRespond,
     respondDecisionOk,
+    predictedSpeakerLabel: predictedSpeakerLabel ?? "",
+    expectedSpeakerLabel,
+    speakerLabelOk,
     completed,
     agentName,
     ...ttsDetail,
@@ -345,14 +372,13 @@ async function runTurn(
   if (turn.pausesMs?.length) {
     detail.pausesMs = turn.pausesMs.join(",");
   }
-  if (turn.expectedSpeakerLabel) {
-    detail.expectedSpeakerLabel = turn.expectedSpeakerLabel;
-  }
   if (turn.expectedEntity) detail.expectedEntity = turn.expectedEntity;
 
   return {
     index,
     speaker: turn.speaker,
+    expectedSpeakerLabel,
+    predictedSpeakerLabel,
     status: ok ? "pass" : "fail",
     responded,
     expectRespond: turn.expectRespond,
@@ -367,7 +393,34 @@ async function runTurn(
         ? `ASR WER ${wer.toFixed(3)} exceeds tolerance ${werTolerance}`
         : !respondDecisionOk
           ? `respond decision: got ${responded}, expected ${turn.expectRespond}`
-          : (ttsError ?? "turn failed"),
+          : !speakerLabelOk
+            ? `speaker label: got ${predictedSpeakerLabel ?? "null"}, expected ${expectedSpeakerLabel}`
+            : (ttsError ?? "turn failed"),
+  };
+}
+
+function scoreWorkbenchDiarization(
+  turns: ReadonlyArray<VoiceWorkbenchTurnReport>,
+  maxDer = 0.2,
+): VoiceWorkbenchReport["diarization"] {
+  const scored = turns.filter((turn) => turn.status !== "skipped");
+  let confusions = 0;
+  let misses = 0;
+  for (const turn of scored) {
+    if (turn.predictedSpeakerLabel === null) misses += 1;
+    else if (turn.predictedSpeakerLabel !== turn.expectedSpeakerLabel) {
+      confusions += 1;
+    }
+  }
+  const total = scored.length;
+  const der = total > 0 ? (confusions + misses) / total : 0;
+  return {
+    total,
+    der: Number(der.toFixed(4)),
+    confusions,
+    misses,
+    maxDer,
+    passed: total > 0 && der <= maxDer,
   };
 }
 
@@ -376,7 +429,10 @@ export async function runVoiceWorkbench(
 ): Promise<VoiceWorkbenchReport> {
   const { scenario } = opts;
   const startedAt = new Date().toISOString();
-  const base: Omit<VoiceWorkbenchReport, "overall" | "finishedAt" | "turns"> = {
+  const base: Omit<
+    VoiceWorkbenchReport,
+    "overall" | "finishedAt" | "turns" | "diarization"
+  > = {
     schemaVersion: 1,
     scenarioId: scenario.id,
     classes: scenario.classes,
@@ -391,6 +447,8 @@ export async function runVoiceWorkbench(
     const turns: VoiceWorkbenchTurnReport[] = scenario.turns.map((t, i) => ({
       index: i,
       speaker: t.speaker,
+      expectedSpeakerLabel: turnSpeakerLabel(t),
+      predictedSpeakerLabel: null,
       status: "skipped",
       responded: false,
       expectRespond: t.expectRespond,
@@ -405,6 +463,7 @@ export async function runVoiceWorkbench(
       overall: "skipped",
       finishedAt: new Date().toISOString(),
       turns,
+      diarization: scoreWorkbenchDiarization(turns),
     };
   }
 
@@ -418,6 +477,7 @@ export async function runVoiceWorkbench(
     turns.push(await runTurn(opts, scenario.turns[i], i, conversation.id));
   }
 
+  const diarization = scoreWorkbenchDiarization(turns);
   const hasFail = turns.some((t) => t.status === "fail");
   const allSkipped =
     turns.length > 0 && turns.every((t) => t.status === "skipped");
@@ -425,12 +485,15 @@ export async function runVoiceWorkbench(
     ? "fail"
     : allSkipped
       ? "skipped"
-      : "pass";
+      : diarization.passed
+        ? "pass"
+        : "fail";
 
   return {
     ...base,
     overall,
     finishedAt: new Date().toISOString(),
     turns,
+    diarization,
   };
 }

--- a/plugins/plugin-local-inference/scripts/voice-workbench.ts
+++ b/plugins/plugin-local-inference/scripts/voice-workbench.ts
@@ -10,9 +10,9 @@
  *                      respond / echo / bystander / wake-word gate + name
  *                      extraction over the corpus (no acoustic models). CI-
  *                      runnable; catches a regression in the decision logic.
- *   --real             real local backend (acoustic models). No real services
- *                      adapter is provisioned here yet, so every scenario reports
- *                      `skipped` — never a false `pass` (the honesty contract).
+ *   --real             provisioned real backend: ElevenLabs-generated human
+ *                      speech + fused local TTS/ASR + WeSpeaker + pyannote.
+ *                      Missing real deps are a hard failure, not a skipped pass.
  *   --out <dir>        output directory (default ./voice-workbench-output).
  *   --baseline <path>  golden report JSON to compare metrics against; exit 1 if
  *                      any metric regressed past tolerance (regression gate).
@@ -29,6 +29,7 @@ import {
 } from "../src/services/voice/voice-workbench-report.ts";
 import { buildAndRunVoiceWorkbench, writeVoiceWorkbenchResult } from "../src/services/voice/workbench-entrypoint.ts";
 import { realDecisionLogicServices } from "../src/services/voice/workbench-logic-services.ts";
+import { createRealVoiceWorkbenchRuntimeFromEnv } from "../src/services/voice/workbench-real-services.ts";
 import { groundTruthMockServices } from "../src/services/voice/workbench-scenarios.ts";
 
 async function main(): Promise<void> {
@@ -46,18 +47,29 @@ async function main(): Promise<void> {
 			? path.resolve(args[outIdx + 1])
 			: path.resolve("voice-workbench-output");
 
-	// --real: real-backend (acoustic) services are gated; when none is provisioned
-	// we pass `null`, making every scenario `skipped` (never a false pass).
+	// --real: real-backend (acoustic) services are gated and fail fast when not
+	// provisioned. No all-skipped success: #9147 needs numbers, not skip evidence.
 	// --logic: the real shipped decision logic (no acoustic models).
 	// default (--mock): echoes ground truth so the runner → scorers → report path
 	// runs end-to-end.
-	const services = real
-		? null
+	const realRuntime = real
+		? await createRealVoiceWorkbenchRuntimeFromEnv()
+		: null;
+	const services = realRuntime
+		? realRuntime.services
 		: logic
 			? realDecisionLogicServices()
 			: groundTruthMockServices();
 
-	const result = await buildAndRunVoiceWorkbench({ services });
+	let result!: Awaited<ReturnType<typeof buildAndRunVoiceWorkbench>>;
+	try {
+		result = await buildAndRunVoiceWorkbench({
+			services,
+			...(realRuntime ? { synthesizer: realRuntime.synthesizer } : {}),
+		});
+	} finally {
+		await realRuntime?.dispose();
+	}
 	const artifacts = writeVoiceWorkbenchResult(result, outDir);
 
 	process.stdout.write(`${result.markdown}\n\nReport: ${artifacts.reportJsonPath}\n`);

--- a/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
+++ b/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
@@ -20,10 +20,11 @@ unifies them onto **one scenario format, one metric module, and one report**.
 The schema, corpus generator (incl. acoustic degradation), metric module,
 headless runner, report, scenario-runner `voice` turn kind, headful scenario
 player, and the `voice:workbench` CLI are all **implemented and unit-tested**.
-The only intentionally **gated** piece is the real **acoustic-model** lane
-(`--real`): driving the corpus through Qwen3-ASR / WeSpeaker / pyannote / Silero
-/ Kokoro needs the native fused lib + GGUF bundles, so it reports `skipped`
-(never `pass`) when those artifacts are absent.
+The real **acoustic-model** lane (`--real`) is implemented as a provisioned
+hardware lane: it generates distinct human voices with ElevenLabs, synthesizes
+agent echoes with the fused local TTS, and scores the corpus through fused ASR,
+WeSpeaker, pyannote, and the shipped respond/self-voice gate. Missing real
+artifacts are a hard failure in `--real`, not all-skipped evidence.
 
 ### Execution lanes (`voice:workbench`)
 
@@ -31,7 +32,7 @@ The only intentionally **gated** piece is the real **acoustic-model** lane
 | --- | --- | --- | --- |
 | `--mock` (default) | `groundTruthMockServices` echoes ground truth | runner → scorers → report wiring | ✅ always |
 | `--logic` | `realDecisionLogicServices` runs the SHIPPED EOT + respond/echo/bystander/wake-word gate + name extraction + owner inference | the **decision logic** (catches a regression the moment it lands) | ✅ always (no models) |
-| `--real` | real acoustic backend | real WER/DER/EOT-latency, acoustic speaker verification | 🟡 gated → `skipped` |
+| `--real` | ElevenLabs human speech + fused local TTS/ASR + WeSpeaker + pyannote | real WER/DER/EOT/respond/self-voice/owner-security measurements | ✅ provisioned nightly/hardware lane |
 
 The `--logic` lane is the key anti-hollow guarantee: it does NOT echo the corpus,
 it runs the same gate the UI client ships (`@elizaos/shared/voice/respond-gate`),
@@ -48,6 +49,7 @@ reply, and holds on a mid-utterance pause — asserted by tests, not assumed.
 | **WER consolidation** | `@elizaos/shared/voice-wer` | The previously-duplicated `wordErrorRate` (`e2e-harness.ts` **and** `voice-selftest-harness.ts`, with subtly different normalization) is now defined once — Unicode-aware, contraction-preserving — and imported by both. |
 | **Acoustic robustness corpus** | `corpus-augment.ts` | Seeded, deterministic degradation DSP: additive room noise (white/pink at a target SNR), Freeverb reverb, far-field attenuation, telephone/low-quality line (band-limit + µ-law), and competing background talkers. Wired into the corpus generator via a per-turn / per-scenario `environment` so a clean scenario and a noisy one share one schema. |
 | **Real-decision-logic adapter** | `workbench-logic-services.ts` | Runs the SHIPPED EOT + respond/echo/bystander/wake-word gate + name extraction over the corpus (no models). The `--logic` lane. |
+| **Real acoustic adapter** | `workbench-real-services.ts` | The `--real` lane: ElevenLabs-generated human speech, fused local agent TTS, fused ASR, WeSpeaker speaker centroids, pyannote speech/overlap labels, live `selfVoiceSimilarity`, owner inference, and the same respond gate. |
 | **Respond/echo gate (single source)** | `@elizaos/shared/voice/respond-gate` | `shouldRespondToVoiceTurn` + `buildVoiceTurnSignal`, promoted out of the UI so the client and the workbench share one definition. The UI re-exports it. |
 | **Owner inference** | `@elizaos/shared/voice/owner-inference` | `resolveOwnerCandidate` — proposes the owner from who speaks most/most-confidently, only when sufficient AND unambiguous, else UNDECIDED. The logic an owner-detection provider/evaluator runs when no owner is enrolled. |
 | **Echo + owner scorers** | `e2e-harness.ts` | `scoreEchoRejection` (agent-echo turns correctly suppressed) and `scoreOwnerSecurity` (owner-vs-intruder accuracy + impostor-accept rate). |
@@ -104,20 +106,18 @@ The workbench is the convergence point for these previously-disjoint harnesses:
 | `packages/benchmarks/voicebench/` (TS latency p95/p99) | The report layer mirrors its p95/p99 shape; remains a research bench linked from the workbench. |
 | Per-spec inline `tinyWav()` fixtures (`packages/app/test/ui-smoke/voice-*.spec.ts`) | Replaced by the versioned corpus (planned). |
 
-## Remaining (gated — needs real acoustic models / live cloud / device)
+## External / Device Follow-Ups
 
-Not stubbed here (no LARP); each reports `skipped`, never `pass`, until the
-artifact is present. Full detail + why in
+Full detail + why in
 [research/VOICE_8785_ASSESSMENT.md §5](./research/VOICE_8785_ASSESSMENT.md).
 
-- **`--real` acoustic lane** — drive the corpus through the real Qwen3-ASR /
-  WeSpeaker / pyannote / Silero / openWakeWord / Kokoro models to measure real
-  WER/DER/EOT-latency and acoustic speaker verification. Needs the native fused
-  lib + GGUF bundles (model loading EMFILEs under the repo's `coverage=true`
-  bunfig — run real smokes OUTSIDE `bun test`).
 - **Live cloud STT/TTS round-trip** — ElevenLabs via `/api/v1/voice/*`; needs an
   authenticated Cloud session (the test account returns HTTP 402 — a billing
   state, not a code bug).
+- **PCM-level AEC** — still a product/runtime feature beyond the workbench
+  scorer: it needs a time-aligned playback reference and cancellation path in
+  the live audio transport, then the workbench can score the resulting echo
+  corpus.
 - **Headful real-backend + recorded A/V** — the 10 `voice-workbench-*.spec.ts`
   run with mocked backends; a real-backend headful lane with audio+video capture
   needs a provisioned local backend on the CI host.

--- a/plugins/plugin-local-inference/src/services/voice/corpus-generator.ts
+++ b/plugins/plugin-local-inference/src/services/voice/corpus-generator.ts
@@ -128,6 +128,9 @@ export interface CorpusTtsSynthesizer {
 	synthesize(args: {
 		text: string;
 		voiceId?: string;
+		speakerLabel: string;
+		turnIndex: number;
+		isAgentEcho: boolean;
 		sampleRate: number;
 	}): Promise<Float32Array>;
 }
@@ -231,6 +234,9 @@ export async function generateVoiceCorpus(
 			speech = await synthesizer.synthesize({
 				text,
 				voiceId: ttsVoiceId,
+				speakerLabel: turn.speaker,
+				turnIndex: i,
+				isAgentEcho: turn.isAgentEcho === true,
 				sampleRate,
 			});
 			speechStartOffset = 0;

--- a/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
@@ -68,6 +68,15 @@ export interface VoiceTurnObservation {
 
 export interface VoiceWorkbenchServices {
 	/**
+	 * Optional one-shot hook before a scenario's turns are scored. Real services
+	 * use this to enroll speaker centroids from the generated corpus; mock
+	 * services can omit it.
+	 */
+	prepareScenario?(args: {
+		scenario: VoiceScenario;
+		corpus: GeneratedVoiceCorpus;
+	}): Promise<void> | void;
+	/**
 	 * Feed one turn's audio slice through the real services and report what was
 	 * observed. The `label` carries the turn's ground truth (so a mock can echo
 	 * it); the real adapter ignores it and measures.
@@ -158,6 +167,7 @@ export async function runVoiceScenarioHeadless(
 
 	const assertions = scenario.assertions ?? {};
 	const cases: VoiceE2eCaseResult[] = [];
+	await services.prepareScenario?.({ scenario, corpus });
 
 	// When a capture sink is active, write the full corpus once + each per-turn
 	// slice as `.wav` artifacts and record their (run-dir-relative) paths.

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -1,0 +1,631 @@
+/**
+ * Voice Workbench real services adapter (#9147).
+ *
+ * `voice:workbench --real` must not be an all-skipped honesty stub: the
+ * provisioned lane has a fused libelizainference build, ASR/TTS regions,
+ * WeSpeaker, pyannote, and ElevenLabs-generated human speech. This adapter
+ * drives those real pieces through the existing workbench runner/scorers.
+ */
+
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	type OwnerObservation,
+	resolveOwnerCandidate,
+} from "@elizaos/shared/voice/owner-inference";
+import { buildVoiceTurnSignal } from "@elizaos/shared/voice/respond-gate";
+import { scoreEndOfTurnHeuristic } from "@elizaos/shared/voice-eot";
+import { resolveFusedLibraryPath } from "../desktop-fused-ffi-backend-runtime";
+import type {
+	CorpusGroundTruth,
+	CorpusTtsSynthesizer,
+	GeneratedVoiceCorpus,
+} from "./corpus-generator";
+import { type ElizaInferenceFfi, loadElizaInferenceFfi } from "./ffi-bindings";
+import { FusedDiarizer } from "./speaker/diarizer-fused";
+import { averageEmbeddings } from "./speaker/encoder";
+import { FusedSpeakerEncoder } from "./speaker/encoder-fused";
+import { SPEAKER_GGML_MIN_SAMPLES } from "./speaker/encoder-ggml";
+import { cosineSimilarity } from "./speaker-imprint";
+import { resampleLinear } from "./transcriber";
+import type { VoiceScenario } from "./voice-scenario";
+import type {
+	VoiceTurnObservation,
+	VoiceWorkbenchServices,
+} from "./workbench-headless-runner";
+
+const SAMPLE_RATE = 16_000;
+const EOT_COMMIT_THRESHOLD = 0.5;
+const DEFAULT_OWNER_THRESHOLD = 0.78;
+const MAX_AGENT_TTS_SECONDS = 12;
+
+const ELEVENLABS_MODEL_ID = "eleven_turbo_v2_5";
+const ELEVENLABS_VOICE_IDS = [
+	"21m00Tcm4TlvDq8ikWAM", // Rachel
+	"pNInz6obpgDQGcFmaJgB", // Adam
+	"EXAVITQu4vr4xnSDxMaL", // Bella
+	"ErXwobaYiN019PkySvjV", // Antoni
+	"MF3mGyEYCl7XYWbV9V6O", // Elli
+	"TxGEqnHWrfWFTfGW9XjX", // Josh
+] as const;
+
+const VOICE_ID_ALIASES: Record<string, string> = {
+	af_bella: "EXAVITQu4vr4xnSDxMaL",
+	af_sarah: "EXAVITQu4vr4xnSDxMaL",
+	af_nicole: "MF3mGyEYCl7XYWbV9V6O",
+	am_adam: "pNInz6obpgDQGcFmaJgB",
+	am_michael: "ErXwobaYiN019PkySvjV",
+	owner: "21m00Tcm4TlvDq8ikWAM",
+	alice: "21m00Tcm4TlvDq8ikWAM",
+	jill: "21m00Tcm4TlvDq8ikWAM",
+	bob: "pNInz6obpgDQGcFmaJgB",
+	guest: "pNInz6obpgDQGcFmaJgB",
+	intruder: "pNInz6obpgDQGcFmaJgB",
+	marcus: "ErXwobaYiN019PkySvjV",
+	priya: "EXAVITQu4vr4xnSDxMaL",
+	eliza: "MF3mGyEYCl7XYWbV9V6O",
+	aria: "TxGEqnHWrfWFTfGW9XjX",
+};
+
+interface SpeakerProfile {
+	label: string;
+	entityId: string | null;
+	isOwner: boolean;
+	centroid: Float32Array;
+}
+
+interface SpeakerMatch {
+	profile: SpeakerProfile;
+	similarity: number;
+}
+
+export interface RealVoiceWorkbenchRuntime {
+	services: VoiceWorkbenchServices;
+	synthesizer: CorpusTtsSynthesizer;
+	dispose(): Promise<void>;
+}
+
+interface RealVoiceWorkbenchOptions {
+	bundle: string;
+	fusedLib: string;
+	speakerGguf: string;
+	diarizGguf: string;
+	elevenLabsApiKey: string;
+	ownerAcceptThreshold?: number;
+	voiceMap?: Record<string, string>;
+}
+
+function requirePath(label: string, value: string | null | undefined): string {
+	if (!value || !existsSync(value)) {
+		throw new Error(
+			`[voice:workbench --real] missing ${label}: ${value ?? "(unset)"}`,
+		);
+	}
+	return value;
+}
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function firstExisting(
+	...candidates: Array<string | null | undefined>
+): string | null {
+	for (const candidate of candidates) {
+		if (candidate && existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+function finiteNumberEnv(
+	env: NodeJS.ProcessEnv,
+	name: string,
+	fallback: number,
+): number {
+	const raw = env[name]?.trim();
+	if (!raw) return fallback;
+	const value = Number(raw);
+	if (!Number.isFinite(value)) {
+		throw new Error(
+			`[voice:workbench --real] ${name} must be finite, got ${raw}`,
+		);
+	}
+	return value;
+}
+
+function parseVoiceMap(raw: string | undefined): Record<string, string> {
+	if (!raw?.trim()) return {};
+	const parsed = JSON.parse(raw) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(
+			"[voice:workbench --real] ELIZA_WORKBENCH_ELEVENLABS_VOICE_MAP must be a JSON object",
+		);
+	}
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(parsed)) {
+		if (typeof value !== "string" || !value.trim()) {
+			throw new Error(
+				`[voice:workbench --real] voice map value for ${key} must be a non-empty string`,
+			);
+		}
+		out[key.toLowerCase()] = value.trim();
+	}
+	return out;
+}
+
+function labelHash(label: string): number {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < label.length; i += 1) {
+		h ^= label.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return h >>> 0;
+}
+
+function ensureSampleRate(
+	pcm: Float32Array,
+	fromRate: number,
+	toRate: number,
+): Float32Array {
+	return fromRate === toRate ? pcm : resampleLinear(pcm, fromRate, toRate);
+}
+
+function ensureMinSpeakerSamples(pcm: Float32Array): Float32Array {
+	if (pcm.length >= SPEAKER_GGML_MIN_SAMPLES) return pcm;
+	const out = new Float32Array(SPEAKER_GGML_MIN_SAMPLES);
+	out.set(pcm);
+	return out;
+}
+
+function diarizerWindow(pcm: Float32Array): Float32Array {
+	const targetSamples = SAMPLE_RATE * 5;
+	if (pcm.length === targetSamples) return pcm;
+	if (pcm.length > targetSamples) return pcm.subarray(0, targetSamples);
+	const out = new Float32Array(targetSamples);
+	out.set(pcm);
+	return out;
+}
+
+function pcm16ToFloat32(bytes: Uint8Array): Float32Array {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const samples = Math.floor(bytes.byteLength / 2);
+	const out = new Float32Array(samples);
+	for (let i = 0; i < samples; i += 1) {
+		out[i] = view.getInt16(i * 2, true) / 32768;
+	}
+	return out;
+}
+
+function extractName(transcript: string): string | null {
+	const match = transcript.match(
+		/\b(?:my name is|i am|i'm|this is|call me)\s+([a-z]+)/i,
+	);
+	return match?.[1]?.toLowerCase() ?? null;
+}
+
+function knownSpeakerIds(groundTruth: CorpusGroundTruth): string[] {
+	if (groundTruth.knownSpeakerEntityIds)
+		return groundTruth.knownSpeakerEntityIds;
+	return groundTruth.participants
+		.map((p) => p.entityId)
+		.filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+function bestSpeakerMatch(
+	profiles: Iterable<SpeakerProfile>,
+	embedding: Float32Array,
+): SpeakerMatch | null {
+	let best: SpeakerMatch | null = null;
+	for (const profile of profiles) {
+		const similarity = cosineSimilarity(embedding, profile.centroid);
+		if (!best || similarity > best.similarity) {
+			best = { profile, similarity };
+		}
+	}
+	return best;
+}
+
+async function elevenLabsPcm(args: {
+	text: string;
+	voiceId: string;
+	apiKey: string;
+	sampleRate: number;
+}): Promise<Float32Array> {
+	const response = await fetch(
+		`https://api.elevenlabs.io/v1/text-to-speech/${args.voiceId}?output_format=pcm_16000`,
+		{
+			method: "POST",
+			headers: {
+				"xi-api-key": args.apiKey,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				text: args.text,
+				model_id: ELEVENLABS_MODEL_ID,
+			}),
+		},
+	);
+	if (!response.ok) {
+		const body = await response.text().catch(() => "");
+		throw new Error(
+			`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${body.slice(0, 240)}`,
+		);
+	}
+	const pcm = pcm16ToFloat32(new Uint8Array(await response.arrayBuffer()));
+	return ensureSampleRate(pcm, SAMPLE_RATE, args.sampleRate);
+}
+
+class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
+	readonly synthesizer: CorpusTtsSynthesizer;
+	readonly services: VoiceWorkbenchServices;
+
+	private readonly ffi: ElizaInferenceFfi;
+	private readonly ctx: ReturnType<ElizaInferenceFfi["create"]>;
+	private readonly encoder: FusedSpeakerEncoder;
+	private readonly diarizer: FusedDiarizer;
+	private readonly apiKey: string;
+	private readonly ownerThreshold: number;
+	private readonly voiceMap: Record<string, string>;
+	private readonly profiles = new Map<string, SpeakerProfile>();
+	private readonly selfVoiceEmbeddings: Float32Array[] = [];
+	private ownerObservations: OwnerObservation[] = [];
+	private scenarioId: string | null = null;
+	private lastAgentReply: string | undefined;
+
+	private constructor(args: {
+		ffi: ElizaInferenceFfi;
+		ctx: ReturnType<ElizaInferenceFfi["create"]>;
+		encoder: FusedSpeakerEncoder;
+		diarizer: FusedDiarizer;
+		apiKey: string;
+		ownerThreshold: number;
+		voiceMap: Record<string, string>;
+	}) {
+		this.ffi = args.ffi;
+		this.ctx = args.ctx;
+		this.encoder = args.encoder;
+		this.diarizer = args.diarizer;
+		this.apiKey = args.apiKey;
+		this.ownerThreshold = args.ownerThreshold;
+		this.voiceMap = args.voiceMap;
+		this.synthesizer = {
+			synthesize: (input) => this.synthesizeCorpusTurn(input),
+		};
+		this.services = {
+			prepareScenario: (input) => this.prepareScenario(input),
+			observeTurn: (input) => this.observeTurn(input),
+		};
+	}
+
+	static async create(
+		options: RealVoiceWorkbenchOptions,
+	): Promise<RealVoiceWorkbenchAdapter> {
+		const ffi = loadElizaInferenceFfi(options.fusedLib);
+		const ctx = ffi.create(options.bundle);
+		try {
+			if (!FusedSpeakerEncoder.isSupported(ffi)) {
+				throw new Error(
+					"[voice:workbench --real] fused library does not support speaker ABI",
+				);
+			}
+			if (!FusedDiarizer.isSupported(ffi)) {
+				throw new Error(
+					"[voice:workbench --real] fused library does not support diarizer ABI",
+				);
+			}
+			const encoder = await FusedSpeakerEncoder.load({
+				ffi,
+				ctx,
+				ggufPath: options.speakerGguf,
+			});
+			const diarizer = await FusedDiarizer.load({
+				ffi,
+				ctx,
+				ggufPath: options.diarizGguf,
+			});
+			return new RealVoiceWorkbenchAdapter({
+				ffi,
+				ctx,
+				encoder,
+				diarizer,
+				apiKey: options.elevenLabsApiKey,
+				ownerThreshold: options.ownerAcceptThreshold ?? DEFAULT_OWNER_THRESHOLD,
+				voiceMap: options.voiceMap ?? {},
+			});
+		} catch (err) {
+			ffi.destroy(ctx);
+			ffi.close();
+			throw err;
+		}
+	}
+
+	private async prepareScenario(args: {
+		scenario: VoiceScenario;
+		corpus: GeneratedVoiceCorpus;
+	}): Promise<void> {
+		this.scenarioId = args.scenario.id;
+		this.lastAgentReply = undefined;
+		this.ownerObservations = [];
+		this.profiles.clear();
+		this.selfVoiceEmbeddings.length = 0;
+
+		const embeddingsBySpeaker = new Map<string, Float32Array[]>();
+		for (const label of args.corpus.groundTruth.turns) {
+			const audio = args.corpus.pcm.subarray(
+				label.speechStartSample,
+				label.speechEndSample,
+			);
+			const embedding = await this.encoder.encode(
+				ensureMinSpeakerSamples(audio),
+			);
+			if (label.isAgentEcho) {
+				continue;
+			}
+			const list = embeddingsBySpeaker.get(label.speaker) ?? [];
+			list.push(embedding);
+			embeddingsBySpeaker.set(label.speaker, list);
+		}
+
+		for (const participant of args.corpus.groundTruth.participants) {
+			const embeddings = embeddingsBySpeaker.get(participant.label);
+			if (!embeddings?.length) continue;
+			this.profiles.set(participant.label, {
+				label: participant.label,
+				entityId: participant.entityId ?? null,
+				isOwner: participant.isOwner === true,
+				centroid: averageEmbeddings(embeddings),
+			});
+		}
+	}
+
+	private async observeTurn(
+		args: Parameters<VoiceWorkbenchServices["observeTurn"]>[0],
+	): Promise<VoiceTurnObservation> {
+		if (args.groundTruth.scenarioId !== this.scenarioId) {
+			throw new Error(
+				`[voice:workbench --real] scenario ${args.groundTruth.scenarioId} was not prepared before observeTurn`,
+			);
+		}
+		const audio16 = ensureSampleRate(args.audio, args.sampleRate, SAMPLE_RATE);
+		const speakerPcm = ensureMinSpeakerSamples(audio16);
+		const embedding = await this.encoder.encode(speakerPcm);
+		const diarized = await this.diarizer.diarizeWindow(diarizerWindow(audio16));
+		const hasSpeech = diarized.segments.some(
+			(segment) => segment.endMs > segment.startMs,
+		);
+		const bestMatch = hasSpeech
+			? bestSpeakerMatch(this.profiles.values(), embedding)
+			: null;
+		const speakerMatch =
+			bestMatch && bestMatch.similarity >= this.ownerThreshold
+				? bestMatch
+				: null;
+		const matchedEntityId = speakerMatch?.profile.entityId ?? null;
+		if (matchedEntityId && !args.label.isAgentEcho) {
+			this.ownerObservations.push({
+				entityId: matchedEntityId,
+				confidence: Math.max(0, Math.min(1, speakerMatch?.similarity ?? 0)),
+			});
+		}
+		const ownerCandidate = resolveOwnerCandidate(this.ownerObservations);
+		const predictedOwner =
+			ownerCandidate.ownerEntityId !== null
+				? matchedEntityId === ownerCandidate.ownerEntityId
+				: speakerMatch?.profile.isOwner === true;
+
+		const transcript = await this.transcribe(audio16);
+		const eotProbability = scoreEndOfTurnHeuristic(transcript);
+		const eotDecided = eotProbability >= EOT_COMMIT_THRESHOLD;
+		const selfVoiceSimilarity = this.selfVoiceSimilarity(embedding);
+		const signal = buildVoiceTurnSignal(transcript, {
+			...(this.lastAgentReply
+				? { recentAgentReply: this.lastAgentReply, replyAgeMs: 500 }
+				: {}),
+			agentSpeaking: args.label.isAgentEcho === true,
+			...(typeof selfVoiceSimilarity === "number"
+				? { selfVoiceSimilarity }
+				: {}),
+			speaker: {
+				entityId: matchedEntityId,
+				confidence: Math.max(0, Math.min(1, speakerMatch?.similarity ?? 0)),
+				isOwner: predictedOwner,
+			},
+			wakeWordActive: /\bhey\s+eliza\b/i.test(transcript),
+			knownSpeakerEntityIds: knownSpeakerIds(args.groundTruth),
+		});
+		const transcriptionMode =
+			args.groundTruth.classes.includes("transcription-mode");
+		const responded = !transcriptionMode && signal.nextSpeaker === "agent";
+		const inferredEntities: string[] = [];
+		const name = extractName(transcript);
+		if (name) {
+			const participant = args.groundTruth.participants.find(
+				(p) => p.label.toLowerCase() === name && p.entityId,
+			);
+			if (participant?.entityId) inferredEntities.push(participant.entityId);
+		}
+
+		if (responded && args.label.agentReplyText) {
+			this.lastAgentReply = args.label.agentReplyText;
+			await this.observeAgentReply(args.label.agentReplyText);
+		}
+
+		return {
+			hypothesisTranscript: transcript,
+			predictedSpeakerLabel: speakerMatch?.profile.label ?? null,
+			eotDecided,
+			responded,
+			inferredEntities,
+			matchedEntityId,
+			predictedOwner,
+		};
+	}
+
+	private async synthesizeCorpusTurn(args: {
+		text: string;
+		voiceId?: string;
+		speakerLabel: string;
+		turnIndex: number;
+		isAgentEcho: boolean;
+		sampleRate: number;
+	}): Promise<Float32Array> {
+		if (args.isAgentEcho) {
+			return ensureSampleRate(
+				this.synthesizeAgent(args.text),
+				SAMPLE_RATE,
+				args.sampleRate,
+			);
+		}
+		const voiceId = this.resolveElevenLabsVoiceId(
+			args.voiceId,
+			args.speakerLabel,
+		);
+		return elevenLabsPcm({
+			text: args.text,
+			voiceId,
+			apiKey: this.apiKey,
+			sampleRate: args.sampleRate,
+		});
+	}
+
+	private resolveElevenLabsVoiceId(
+		voiceId: string | undefined,
+		speakerLabel: string,
+	): string {
+		const keys = [voiceId, speakerLabel].filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		);
+		for (const key of keys) {
+			const mapped =
+				this.voiceMap[key.toLowerCase()] ?? VOICE_ID_ALIASES[key.toLowerCase()];
+			if (mapped) return mapped;
+		}
+		return ELEVENLABS_VOICE_IDS[
+			labelHash(speakerLabel) % ELEVENLABS_VOICE_IDS.length
+		];
+	}
+
+	private synthesizeAgent(text: string): Float32Array {
+		this.ffi.mmapAcquire(this.ctx, "tts");
+		try {
+			const out = new Float32Array(SAMPLE_RATE * MAX_AGENT_TTS_SECONDS);
+			const samples = this.ffi.ttsSynthesize({
+				ctx: this.ctx,
+				text,
+				speakerPresetId: null,
+				out,
+			});
+			if (!Number.isFinite(samples) || samples <= 0) {
+				throw new Error(
+					`[voice:workbench --real] agent TTS produced ${samples} samples`,
+				);
+			}
+			return out.slice(0, samples);
+		} finally {
+			this.ffi.mmapEvict(this.ctx, "tts");
+		}
+	}
+
+	private async observeAgentReply(text: string): Promise<void> {
+		const pcm = this.synthesizeAgent(text);
+		this.selfVoiceEmbeddings.push(
+			await this.encoder.encode(ensureMinSpeakerSamples(pcm)),
+		);
+		while (this.selfVoiceEmbeddings.length > 8) {
+			this.selfVoiceEmbeddings.shift();
+		}
+	}
+
+	private selfVoiceSimilarity(embedding: Float32Array): number | null {
+		if (this.selfVoiceEmbeddings.length === 0) return null;
+		return cosineSimilarity(
+			embedding,
+			averageEmbeddings(this.selfVoiceEmbeddings),
+		);
+	}
+
+	private async transcribe(pcm: Float32Array): Promise<string> {
+		this.ffi.mmapAcquire(this.ctx, "asr");
+		try {
+			if (this.ffi.timedAsrSupported?.()) {
+				return this.ffi
+					.asrTranscribeTimed({ ctx: this.ctx, pcm, sampleRateHz: SAMPLE_RATE })
+					.text.trim();
+			}
+			return this.ffi
+				.asrTranscribe({ ctx: this.ctx, pcm, sampleRateHz: SAMPLE_RATE })
+				.trim();
+		} finally {
+			this.ffi.mmapEvict(this.ctx, "asr");
+		}
+	}
+
+	async dispose(): Promise<void> {
+		try {
+			await this.encoder.dispose();
+		} finally {
+			try {
+				await this.diarizer.dispose();
+			} finally {
+				this.ffi.destroy(this.ctx);
+				this.ffi.close();
+			}
+		}
+	}
+}
+
+export async function createRealVoiceWorkbenchRuntimeFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<RealVoiceWorkbenchRuntime> {
+	const bundle = requirePath(
+		"ELIZA_ASR_BUNDLE",
+		nonEmpty(env.ELIZA_ASR_BUNDLE) ??
+			nonEmpty(env.ELIZA_VOICE_REAL_MODEL_DIR) ??
+			path.join(
+				os.homedir(),
+				".eliza/local-inference/models/eliza-1-2b.bundle",
+			),
+	);
+	const fusedLib = requirePath(
+		"libelizainference",
+		resolveFusedLibraryPath(bundle, env),
+	);
+	const speakerGguf = requirePath(
+		"speaker GGUF",
+		firstExisting(
+			nonEmpty(env.ELIZA_SPEAKER_GGUF),
+			path.join(bundle, "speaker", "wespeaker-resnet34-lm.gguf"),
+			path.join(bundle, "speaker-encoder", "wespeaker-resnet34-lm.gguf"),
+			path.join(bundle, "voice/speaker-encoder/wespeaker-resnet34-lm.gguf"),
+		),
+	);
+	const diarizGguf = requirePath(
+		"diarizer GGUF",
+		firstExisting(
+			nonEmpty(env.ELIZA_DIARIZ_GGUF),
+			path.join(bundle, "diariz", "pyannote-segmentation-3.0.gguf"),
+			path.join(bundle, "diarizer", "pyannote-segmentation-3.0.gguf"),
+			path.join(bundle, "voice/diarizer/pyannote-segmentation-3.0.gguf"),
+		),
+	);
+	const apiKey = nonEmpty(env.ELEVENLABS_API_KEY);
+	if (!apiKey) {
+		throw new Error("[voice:workbench --real] ELEVENLABS_API_KEY is required");
+	}
+
+	return RealVoiceWorkbenchAdapter.create({
+		bundle,
+		fusedLib,
+		speakerGguf,
+		diarizGguf,
+		elevenLabsApiKey: apiKey,
+		ownerAcceptThreshold: finiteNumberEnv(
+			env,
+			"ELIZA_VOICE_OWNER_ACCEPT_THRESHOLD",
+			DEFAULT_OWNER_THRESHOLD,
+		),
+		voiceMap: parseVoiceMap(env.ELIZA_WORKBENCH_ELEVENLABS_VOICE_MAP),
+	});
+}

--- a/plugins/plugin-local-inference/src/voice-workbench.ts
+++ b/plugins/plugin-local-inference/src/voice-workbench.ts
@@ -60,6 +60,10 @@ export {
 	type VoiceTurnObservation,
 	type VoiceWorkbenchServices,
 } from "./services/voice/workbench-headless-runner";
+export {
+	createRealVoiceWorkbenchRuntimeFromEnv,
+	type RealVoiceWorkbenchRuntime,
+} from "./services/voice/workbench-real-services";
 
 export {
 	groundTruthMockServices,


### PR DESCRIPTION
## Summary
- make the headful voice workbench report expected/predicted speaker labels plus a DER summary
- fail headful turns/scenarios when speaker labels exceed the DER budget instead of only checking respond decisions
- add a provisioned `voice:workbench --real` adapter that generates ElevenLabs human turns, fused local-TTS agent echoes, fused ASR, WeSpeaker centroids, pyannote speech labels, live `selfVoiceSimilarity`, and the shared respond gate
- add a real voice CI benchmark matrix for #9147 that exercises fused TTS/ASR, diarization, speaker embeddings, self-voice suppression, owner accuracy, impostor rejection, WER, and DER with real dependencies only
- make the provisioned voice live E2E acoustic matrix blocking again and include `agentvoice:real`, `robustness:real`, `.real.test.ts`, `voice:workbench --real`, and `packages/benchmarks/voice/*real*` coverage
- harden the self-hosted workflow probes so stale round-trip scripts are gone and early acoustic provisioning failures still upload `probe.log`
- record the current runner/secret provisioning audit proving why the real metric artifact cannot be produced yet

## Tests
- `git fetch origin && git rebase --autostash origin/develop`
- `bun install --frozen-lockfile`
- `git diff --check origin/develop...HEAD`
- `actionlint .github/workflows/voice-live-e2e.yml`
- `bun build packages/benchmarks/voice/voice-real-ci-matrix.mjs --target=bun --outfile=/tmp/voice-real-ci-matrix.js`
- `bun build plugins/plugin-local-inference/scripts/voice-workbench.ts --target=bun --outfile=/tmp/voice-workbench.js`
- `bunx vitest run plugins/plugin-local-inference/src/services/voice/corpus-generator.test.ts plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts` (`23 passed`)
- `bun run --cwd plugins/plugin-local-inference voice:workbench --logic --out /tmp/voice-workbench-logic-rebase-9147` (`15 ran, 0 skipped`)
- `bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-diarization.spec.ts --project=chromium` (`1 passed`)
- `git diff --check` after evidence-only updates
- `bun run verify` after rebasing on `origin/develop` (`509 successful, 509 total`)
- `bun run verify` after evidence-only updates (`509 successful, 509 total`; latest run fully cached)

## Evidence
- `.github/issue-evidence/9147-headful-der-gate.md`
- [`Voice Live E2E` run 28093983203](https://github.com/elizaOS/eliza/actions/runs/28093983203): dispatched against the rebased workflow at `8e19477c347971089bfab0ccb3c12f75046c99a3`, before the evidence-only commits through current head `ac3018a487baac58a4f050e29b7b00f31f4a572a`.
- The optional fused ASR/round-trip job passed with current scripts and skipped guarded real-ASR steps because no preprovisioned ASR bundle was present.
- The blocking acoustic job uploaded `voice-real-acoustic-matrix` artifact `7847707091` (SHA256 `17c2026e386359cddcbcfa88a0b9cc39a0522a930182632d09821df43b7a3205`) containing `probe.log`.
- Provisioning audit: `gh secret list --repo elizaOS/eliza` does not list `ELEVENLABS_API_KEY`; `gh api --paginate repos/elizaOS/eliza/actions/runners` shows online generic `self-hosted, Linux, X64, eliza` / `hetzner-robot` runners and no `gpu`, `cuda`, or `gpu-cuda-12.6` label.

## Notes
- The new real benchmark and `voice:workbench --real` lane intentionally have no synthetic fallback: they exit nonzero when the fused inference library, GGUF bundle, or generated-speech credentials are missing.
- The latest workflow-dispatch run proves the branch is schedulable, the stale round-trip commands are fixed, and early red acoustic runs upload actionable logs.
- The remaining red is external runner provisioning, not skipped branch logic. The current repository secret set has no `ELEVENLABS_API_KEY`, and the current acoustic runner probe also shows missing `nvcc`, `nvidia-smi`, and `ffmpeg`. Real DER/WER/echo/owner/impostor evidence cannot be produced until that self-hosted lane is provisioned with the secret, native tooling, and fused bundle/library.
