### PR TITLE
fix(plugin-elizacloud): normalize flat native tool_choice

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/normalize-native-tools.test.ts
@@ -12,7 +12,7 @@
  * (should-respond / RESPONSE_HANDLER) turn.
  */
 import { describe, expect, it } from "vitest";
-import { normalizeNativeTools } from "../../src/models/text";
+import { normalizeNativeToolChoice, normalizeNativeTools } from "../../src/models/text";
 
 type NativeTool = {
   type: "function";
@@ -103,5 +103,41 @@ describe("normalizeNativeTools", () => {
     expect(normalizeNativeTools(null)).toBeUndefined();
     expect(normalizeNativeTools([])).toBeUndefined();
     expect(normalizeNativeTools({})).toBeUndefined();
+  });
+});
+
+describe("normalizeNativeToolChoice", () => {
+  it("wraps a flat function choice into the OpenAI {type, function} shape", () => {
+    const result = normalizeNativeToolChoice({
+      type: "function",
+      name: "HANDLE_RESPONSE",
+    }) as NativeTool;
+
+    expect(result).toEqual({
+      type: "function",
+      function: { name: "HANDLE_RESPONSE" },
+    });
+  });
+
+  it("preserves a nested function choice while guaranteeing function.name", () => {
+    const result = normalizeNativeToolChoice({
+      type: "function",
+      function: {
+        name: "GET_WEATHER",
+      },
+    }) as NativeTool;
+
+    expect(result).toEqual({
+      type: "function",
+      function: { name: "GET_WEATHER" },
+    });
+  });
+
+  it("normalizes tool-choice aliases and drops nameless function choices", () => {
+    expect(normalizeNativeToolChoice({ type: "tool", toolName: "SEARCH" })).toEqual({
+      type: "function",
+      function: { name: "SEARCH" },
+    });
+    expect(normalizeNativeToolChoice({ type: "function" })).toBeUndefined();
   });
 });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -521,7 +521,7 @@ export function normalizeNativeTools(tools: unknown): unknown[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function normalizeNativeToolChoice(toolChoice: unknown): unknown {
+export function normalizeNativeToolChoice(toolChoice: unknown): unknown {
   if (!toolChoice) {
     return undefined;
   }
@@ -535,7 +535,17 @@ function normalizeNativeToolChoice(toolChoice: unknown): unknown {
 
   const choice = asRecord(toolChoice);
   if (choice.type === "function") {
-    return toolChoice;
+    const functionChoice = recordAt(choice, "function");
+    const toolName = firstString(functionChoice.name, choice.name, choice.toolName);
+    return toolName
+      ? {
+          type: "function",
+          function: {
+            ...functionChoice,
+            name: toolName,
+          },
+        }
+      : undefined;
   }
   if (choice.type === "tool") {
     const toolName = firstString(choice.toolName, choice.name);


### PR DESCRIPTION
## Summary
- Normalize flat native `toolChoice` values like `{ type: "function", name: "HANDLE_RESPONSE" }` into OpenAI-compatible `{ type: "function", function: { name } }` before sending `/chat/completions` to Cloud.
- Omit nameless function choices instead of forwarding malformed wire data that can make the gateway read `tool_choice.function.name` on `undefined`.
- Extend the existing native-tool normalization regression tests to cover `toolChoice` as well as `tools[]`.

## Issue
Progress on #8434 launch blocker report: hosted agents on `sha-7a5d4f9` hit `Cannot read properties of undefined (reading 'name')` in `plugin-elizacloud` native chat completions. Current develop already guards flat `tools[]`; this closes the analogous flat `toolChoice` path.

## Verification
- `bun run --cwd plugins/plugin-elizacloud test -- __tests__/unit/normalize-native-tools.test.ts __tests__/unit/text-cerebras-response-format.test.ts __tests__/text-native-concurrency.test.ts __tests__/text-streaming.test.ts` -> 4 files / 49 tests passed
- `bun run --cwd plugins/plugin-elizacloud typecheck` -> passed
- `bun run --cwd plugins/plugin-elizacloud lint:check` -> passed
- `bun run --cwd plugins/plugin-elizacloud test:unit` -> 10 files / 95 passed / 2 skipped

## Evidence notes
No live Cloud credentials or hosted fleet access were used. This is an offline parser/wire-shape regression for the failing native `/chat/completions` path.
