### PR TITLE
test(computeruse): fix Windows-only failure in terminal.real cwd lane (#9105)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/terminal.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/terminal.real.test.ts
@@ -1,6 +1,9 @@
 /**
  * Real integration tests for terminal command execution.
  */
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   checkDangerousCommand,
@@ -11,6 +14,17 @@ import {
   connectTerminal,
   executeTerminal,
 } from "../platform/terminal.js";
+
+/**
+ * A real, guaranteed-existing temp directory whose canonical path we can match
+ * against shell output. `/tmp` is unsafe as a cwd on Windows — it resolves to
+ * `C:\tmp`, which need not exist on a CI runner, so `execFile` would ENOENT
+ * before the command ever runs. macOS resolves the temp dir through `/private`,
+ * so we canonicalize with `realpathSync` and assert on the unique leaf name.
+ */
+function makeRealCwd(): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), "cua-cwd-")));
+}
 
 describe("terminal execution (real)", () => {
   it("executes a simple command", async () => {
@@ -29,26 +43,39 @@ describe("terminal execution (real)", () => {
   });
 
   it("respects cwd", async () => {
-    const result = await executeTerminal({ command: "pwd", cwd: "/tmp" });
-    expect(result.success).toBe(true);
-    // /tmp may resolve to /private/tmp on macOS
-    expect(result.output).toMatch(/\/tmp/);
+    const dir = makeRealCwd();
+    try {
+      const result = await executeTerminal({ command: "pwd", cwd: dir });
+      expect(result.success).toBe(true);
+      // `pwd` prints the path with backslashes on Windows (PowerShell
+      // Get-Location); normalize separators and match on the unique leaf so the
+      // assertion holds on Windows/macOS/Linux alike.
+      const leaf = basename(dir);
+      expect(result.output.replace(/\\/g, "/")).toContain(leaf);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("creates and uses terminal sessions", async () => {
-    const session = await connectTerminal("/tmp");
-    expect(session.success).toBe(true);
-    expect(session.sessionId).toBeDefined();
+    const dir = makeRealCwd();
+    try {
+      const session = await connectTerminal(dir);
+      expect(session.success).toBe(true);
+      expect(session.sessionId).toBeDefined();
 
-    const exec = await executeTerminal({
-      command: "echo session-test",
-      sessionId: session.sessionId,
-    });
-    expect(exec.success).toBe(true);
-    expect(exec.output).toContain("session-test");
+      const exec = await executeTerminal({
+        command: "echo session-test",
+        sessionId: session.sessionId,
+      });
+      expect(exec.success).toBe(true);
+      expect(exec.output).toContain("session-test");
 
-    const close = await closeTerminal(session.sessionId);
-    expect(close.success).toBe(true);
+      const close = await closeTerminal(session.sessionId);
+      expect(close.success).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("handles command timeout", async () => {


### PR DESCRIPTION
## What

`plugins/plugin-computeruse/src/__tests__/terminal.real.test.ts > respects cwd` **fails on Windows** (the swarm can't see this — it only runs on a Windows real-driver host).

Two Windows-specific defects in the test (not the production code):

1. **Unix-path assertion.** It asserted `result.output` matched `/\/tmp/`. On Windows the cwd *was* respected — `execFile` resolves `/tmp` → `C:\tmp` and PowerShell's `pwd` (`Get-Location`) prints it with backslashes in a table — so the regex never matched even though `terminal.ts` is correct.
2. **`/tmp` may not exist.** Passing `/tmp` as cwd resolves to `C:\tmp`, which a fresh Windows CI runner need not have; `execFile` would `ENOENT` before the command ran (it only passed on this box because `C:\tmp` happens to exist).

## Fix

Both real-cwd tests now use a guaranteed-existing temp dir (`mkdtempSync` under `os.tmpdir()`, canonicalized with `realpathSync` to handle macOS `/private` resolution) and assert on the unique leaf name against separator-normalized output. Cross-platform and no longer dependent on `/tmp`.

Production `executeTerminal`/`connectTerminal` cwd handling is **unchanged** — this is a test-robustness fix. The unit lane is unaffected (`.real.test.ts` is excluded there).

## Evidence (real Windows desktop)

Before:
```
× get... respects cwd
  AssertionError: expected '...C:\tmp...' to match /\/tmp/
Tests  1 failed | 12 passed (13)
```

After:
```
Test Files  1 passed (1)
      Tests  13 passed (13)
```

Also: `bun run --cwd plugins/plugin-computeruse typecheck` clean; `biome check` clean.

Part of the #9105 M6 Windows real-driver lane hardening. See `plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md` for the Windows real-lane requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)