### PR TITLE
fix(cloud): provisioning-lock + cold-pull timeout (300s) + VPN-registration timeout (180s)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -64,6 +64,76 @@ describe("AgentSandboxesRepository", () => {
     expect(new PgDialect().sqlToQuery(capturedWhere).sql).toContain("'sleeping'");
   });
 
+  test("provisioning lock admits a running row ONLY when it has no container (re-provision unblock)", async () => {
+    // Bug: a direct/shared provision inserts the row as `running` BEFORE any
+    // container exists. If that provision crashes, the row is stuck at
+    // `running` with NO container, and the old `status IN (...)` clause (which
+    // excludes `running`) could never retake the lock — blocking re-provision
+    // PERMANENTLY (the tonight outage; an engineer had to reset rows to
+    // `pending` by hand). The fix admits `running` too, but ONLY for a
+    // never-containerized row.
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().trySetProvisioning("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
+
+    if (!capturedWhere) throw new Error("trySetProvisioning did not build a where clause");
+    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
+
+    // The existing acquirable states still work (regression guard)...
+    expect(sql).toContain("'pending'");
+    expect(sql).toContain("'provisioning'");
+    expect(sql).toContain("'stopped'");
+    expect(sql).toContain("'sleeping'");
+    expect(sql).toContain("'disconnected'");
+    expect(sql).toContain("'error'");
+
+    // ...AND a `running` row can now be acquired...
+    expect(sql).toContain("'running'");
+
+    // ...but the `running` branch is GATED on BOTH container fields being NULL.
+    // This is the live-agent protection: the moment a container is created the
+    // provision path stamps container_name / sandbox_id, so a genuinely-running
+    // dedicated agent can NEVER satisfy this branch and can NEVER have its lock
+    // taken. Assert both NULL guards are present on the running branch.
+    expect(sql).toContain("container_name");
+    expect(sql).toContain("sandbox_id");
+    expect(sql).toContain("is null");
+    // The running admission must be an OR alternative to the IN-list, not a
+    // standalone clause that would widen acquisition.
+    expect(sql).toContain(" or ");
+  });
+
+  test("provisioning lock guards the running branch with BOTH container columns (live-agent protection)", async () => {
+    // The live-agent protection is load-bearing: acquiring the lock from a
+    // genuinely-running dedicated agent would double-provision / disrupt a live
+    // customer agent. Pin that the `running` admission requires container_name
+    // IS NULL *and* sandbox_id IS NULL — never just one. We assert the
+    // structural shape of the generated SQL: a `'running'` literal followed by
+    // two `is null` predicates on the two container columns.
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().trySetProvisioning("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
+
+    if (!capturedWhere) throw new Error("trySetProvisioning did not build a where clause");
+    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
+
+    const runningIdx = sql.indexOf("'running'");
+    expect(runningIdx).toBeGreaterThan(-1);
+    // Everything from the `'running'` literal onward must reference BOTH
+    // container columns AND `is null` — i.e. the running admission is fenced by
+    // the two NULL guards (a running-WITH-container row can never match).
+    const afterRunning = sql.slice(runningIdx);
+    expect(afterRunning).toContain("container_name");
+    expect(afterRunning).toContain("sandbox_id");
+    // Two NULL guards on the running branch (one per container column).
+    const nullGuardCount = (afterRunning.match(/is null/g) ?? []).length;
+    expect(nullGuardCount).toBeGreaterThanOrEqual(2);
+  });
+
   test("heartbeat selection excludes shared-runtime agents (no container to dial)", async () => {
     capturedWhere = undefined;
 

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -93,45 +93,29 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("'running'");
 
     // ...but the `running` branch is GATED on BOTH container fields being NULL.
-    // This is the live-agent protection: the moment a container is created the
-    // provision path stamps container_name / sandbox_id, so a genuinely-running
-    // dedicated agent can NEVER satisfy this branch and can NEVER have its lock
-    // taken. Assert both NULL guards are present on the running branch.
+    // This is the live-agent protection (load-bearing): the moment a container
+    // is created the provision path stamps container_name / sandbox_id, so a
+    // genuinely-running dedicated agent can NEVER satisfy this branch and can
+    // NEVER have its lock taken or be double-provisioned. Assert both NULL
+    // guards are present on the running branch.
     expect(sql).toContain("container_name");
     expect(sql).toContain("sandbox_id");
-    expect(sql).toContain("is null");
     // The running admission must be an OR alternative to the IN-list, not a
     // standalone clause that would widen acquisition.
     expect(sql).toContain(" or ");
-  });
 
-  test("provisioning lock guards the running branch with BOTH container columns (live-agent protection)", async () => {
-    // The live-agent protection is load-bearing: acquiring the lock from a
-    // genuinely-running dedicated agent would double-provision / disrupt a live
-    // customer agent. Pin that the `running` admission requires container_name
-    // IS NULL *and* sandbox_id IS NULL — never just one. We assert the
-    // structural shape of the generated SQL: a `'running'` literal followed by
-    // two `is null` predicates on the two container columns.
-    capturedWhere = undefined;
-
-    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
-
-    await new AgentSandboxesRepository().trySetProvisioning("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
-
-    if (!capturedWhere) throw new Error("trySetProvisioning did not build a where clause");
-    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
-
-    const runningIdx = sql.indexOf("'running'");
-    expect(runningIdx).toBeGreaterThan(-1);
-    // Everything from the `'running'` literal onward must reference BOTH
-    // container columns AND `is null` — i.e. the running admission is fenced by
-    // the two NULL guards (a running-WITH-container row can never match).
-    const afterRunning = sql.slice(runningIdx);
-    expect(afterRunning).toContain("container_name");
-    expect(afterRunning).toContain("sandbox_id");
-    // Two NULL guards on the running branch (one per container column).
-    const nullGuardCount = (afterRunning.match(/is null/g) ?? []).length;
-    expect(nullGuardCount).toBeGreaterThanOrEqual(2);
+    // Structural fence: everything from the `'running'` literal onward must
+    // reference BOTH container columns AND carry two `is null` predicates —
+    // i.e. the running admission is gated by container_name IS NULL *and*
+    // sandbox_id IS NULL, never just one (a running-WITH-container row can
+    // never match). Pin the positional shape so a future edit can't loosen the
+    // guard to a single column.
+    const i = sql.indexOf("'running'");
+    expect(i).toBeGreaterThan(-1);
+    const after = sql.slice(i);
+    expect(after).toContain("container_name");
+    expect(after).toContain("sandbox_id");
+    expect((after.match(/is null/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
   test("heartbeat selection excludes shared-runtime agents (no container to dial)", async () => {

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -458,6 +458,18 @@ export class AgentSandboxesRepository {
    * Atomically take the provisioning lock. `provisioning` is included so a
    * row left stuck by a crashed worker can be retaken; the job-level stale
    * recovery in ProvisioningJobService is the time-based gate.
+   *
+   * `running` is admitted ONLY for a never-containerized row
+   * (`container_name IS NULL AND sandbox_id IS NULL`). A direct/shared provision
+   * inserts the row as `running` BEFORE any container exists
+   * (eliza-sandbox.ts buildAgentInsertData), so a half-provisioned row that
+   * crashed before a container was created would otherwise be stuck at `running`
+   * forever — none of the other admitted states match it, and the lock could
+   * never be retaken, permanently blocking re-provision (the tonight outage).
+   * The two NULL guards keep this STRICTLY off any genuinely-running dedicated
+   * agent: the moment a container is created the provision path stamps
+   * `container_name`/`sandbox_id`, so a live agent can NEVER satisfy this branch
+   * and can NEVER have its lock taken from under it.
    */
   async trySetProvisioning(id: string): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
@@ -471,7 +483,14 @@ export class AgentSandboxesRepository {
       .where(
         and(
           eq(agentSandboxes.id, id),
-          sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'stopped', 'sleeping', 'disconnected', 'error')`,
+          sql`(
+            ${agentSandboxes.status} IN ('pending', 'provisioning', 'stopped', 'sleeping', 'disconnected', 'error')
+            OR (
+              ${agentSandboxes.status} = 'running'
+              AND ${agentSandboxes.container_name} IS NULL
+              AND ${agentSandboxes.sandbox_id} IS NULL
+            )
+          )`,
         ),
       )
       .returning();

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -46,7 +46,7 @@ import {
   WEBUI_PORT_MIN,
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
-import { headscaleIntegration } from "./headscale-integration";
+import { DEFAULT_REGISTRATION_TIMEOUT_MS, headscaleIntegration } from "./headscale-integration";
 import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
 import {
   ensureStewardTenant,
@@ -1363,7 +1363,12 @@ export class DockerSandboxProvider implements SandboxProvider {
         // "timed out" registering despite being online.
         headscaleIp = await headscaleIntegration.waitForVPNRegistration(
           vpnEnvVars.TS_HOSTNAME ?? agentId,
-          60_000,
+          // 180s default (env-overridable via VPN_REGISTRATION_TIMEOUT_MS), not
+          // a hardcoded 60s: a cold container needs >1 min to boot + register,
+          // so 60s expired before the node appeared → "continuing without VPN"
+          // → 404 despite running. Single source of truth lives in
+          // headscale-integration so the constant and this call agree.
+          DEFAULT_REGISTRATION_TIMEOUT_MS,
         );
         if (headscaleIp) {
           logger.info(

--- a/packages/cloud-shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.ts
@@ -21,8 +21,24 @@ const POLL_INTERVAL_INITIAL_MS = 1_000;
 /** Maximum polling interval after exponential backoff (ms). */
 const POLL_INTERVAL_MAX_MS = 8_000;
 
-/** Default timeout for VPN registration (ms). */
-const DEFAULT_REGISTRATION_TIMEOUT_MS = 60_000;
+/**
+ * Default timeout for VPN/headscale registration (ms), env-overridable via
+ * `VPN_REGISTRATION_TIMEOUT_MS`.
+ *
+ * 180s, not 60s: a cold container can take well over a minute to boot and run
+ * `tailscale up`, so the old hardcoded 60s expired BEFORE the node finished
+ * registering. The caller then logged "continuing without VPN" and the agent
+ * answered 404 over the router despite the container being up. 180s clears a
+ * cold registration with margin; this is the value 0xSolace set on the live box
+ * while working the outage, and the env override lets ops retune without a
+ * redeploy. Exported so the docker-sandbox provider shares this single source
+ * of truth instead of hardcoding its own timeout at the call site.
+ */
+export const DEFAULT_REGISTRATION_TIMEOUT_MS = (() => {
+  const raw = process.env.VPN_REGISTRATION_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 180_000;
+})();
 
 function headscalePublicUrl(): string {
   return (
@@ -99,7 +115,7 @@ export class HeadscaleIntegration {
    *
    * @param nodeName  Headscale node name the container registers under
    *                  (TS_HOSTNAME = inferTailscaleHostname; NOT the bare agentId).
-   * @param timeoutMs Maximum time to wait (default 60 s).
+   * @param timeoutMs Maximum time to wait (default {@link DEFAULT_REGISTRATION_TIMEOUT_MS}, 180 s; env-overridable via `VPN_REGISTRATION_TIMEOUT_MS`).
    * @returns The first VPN IP address, or `null` if the timeout was reached.
    */
   async waitForVPNRegistration(

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-job execution-timeout sizing — the cold-pull orphaning fix.
+ *
+ * `processJobType` wraps each job in `withTimeout(executeJob(job),
+ * PER_JOB_TIMEOUT_MS)`. A freshly-pinned agent image cold-pulls in ~2.5 min on
+ * the node (the leaf SSH `docker pull` allows up to PULL_TIMEOUT_MS = 300s in
+ * docker-sandbox-provider). At the old 120s ceiling this wrapper aborted the
+ * job's awaiter mid-pull — the job flipped toward failure even though the pull
+ * was still landing the image in the node cache (retry churn + half-provisioned
+ * state behind the tonight outage). 180s clears a cold pull with margin.
+ *
+ * This pins two things:
+ *   1. PER_JOB_TIMEOUT_MS outlasts a representative cold pull (and stays within
+ *      the daemon's watchdog-safe budget), and
+ *   2. the actual `withTimeout` semantics: a create/pull that takes longer than
+ *      the OLD 120s ceiling completes without timing out under the new ceiling,
+ *      while a genuinely-hung create still times out.
+ *
+ * (2) runs at a SCALED-DOWN clock so it's instant: the durations preserve the
+ * exact ordering invariant the production constant relies on
+ * (oldCeiling < coldPull < newCeiling < hung), so the test proves the behavior
+ * change without waiting minutes of real wall-clock.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { withTimeout } from "../utils/with-timeout";
+import { PER_JOB_TIMEOUT_MS } from "./provisioning-jobs";
+
+/** A cold `docker pull` of a freshly-pinned image takes ~2.5 min on the node. */
+const COLD_PULL_MS = 150_000;
+/** The old per-job ceiling that aborted the awaiter mid-pull. */
+const OLD_PER_JOB_TIMEOUT_MS = 120_000;
+/**
+ * The daemon's whole-WORK-cycle budget (provisioning-worker WORK_CYCLE_TIMEOUT_MS).
+ * PER_JOB_TIMEOUT_MS is kept <= this so a single job never reads as if it could
+ * outlive the bounded work group, and the heartbeat watchdog window (300s) is
+ * never threatened.
+ */
+const WORK_CYCLE_TIMEOUT_MS = 240_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix)", () => {
+  test("outlasts a cold image pull but stays within the watchdog-safe work budget", () => {
+    // A ~2.5min cold pull must NOT be aborted mid-flight by the per-job wrapper.
+    expect(PER_JOB_TIMEOUT_MS).toBeGreaterThan(COLD_PULL_MS);
+    // The old 120s ceiling was SHORTER than a cold pull (the bug). The fix raises it.
+    expect(PER_JOB_TIMEOUT_MS).toBeGreaterThan(OLD_PER_JOB_TIMEOUT_MS);
+    // ...but never longer than the daemon's whole-work-cycle budget, so it can't
+    // read as if a single job could outlive the bounded group / threaten the
+    // 300s heartbeat watchdog.
+    expect(PER_JOB_TIMEOUT_MS).toBeLessThanOrEqual(WORK_CYCLE_TIMEOUT_MS);
+  });
+
+  test("a create/pull longer than the OLD ceiling completes without timing out under the new ceiling", async () => {
+    // Scale the production ordering down by 1000x so the test is instant while
+    // preserving the exact invariant: OLD(120) < coldPull(150) < NEW(180).
+    const scale = 1000;
+    const newCeiling = PER_JOB_TIMEOUT_MS / scale; // 180ms
+    const coldPullDuration = COLD_PULL_MS / scale; // 150ms — would have tripped the old 120ms ceiling
+
+    // Sanity: this duration is longer than the old ceiling (so it WOULD have
+    // timed out before the fix) but shorter than the new one.
+    expect(coldPullDuration).toBeGreaterThan(OLD_PER_JOB_TIMEOUT_MS / scale);
+    expect(coldPullDuration).toBeLessThan(newCeiling);
+
+    // A create that takes longer than the old ceiling but finishes within the
+    // new one resolves cleanly — the job is NOT aborted mid-pull.
+    const createThatColdPulls = sleep(coldPullDuration).then(() => "provisioned" as const);
+    const result = await withTimeout(createThatColdPulls, newCeiling, "job agent_provision");
+    expect(result).toBe("provisioned");
+  });
+
+  test("a genuinely-hung create still times out", async () => {
+    const scale = 1000;
+    const newCeiling = PER_JOB_TIMEOUT_MS / scale; // 180ms
+
+    // A create that hangs well past the ceiling (e.g. a wedged node) must still
+    // be freed by the wrapper — the ceiling is a real backstop, not removed.
+    const hungCreate = sleep(newCeiling * 3); // never resolves before the timeout
+    await expect(withTimeout(hungCreate, newCeiling, "job agent_provision")).rejects.toThrow(
+      /timed out/,
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
@@ -3,15 +3,17 @@
  *
  * `processJobType` wraps each job in `withTimeout(executeJob(job),
  * PER_JOB_TIMEOUT_MS)`. A freshly-pinned agent image cold-pulls in ~2.5 min on
- * the node (the leaf SSH `docker pull` allows up to PULL_TIMEOUT_MS = 300s in
- * docker-sandbox-provider). At the old 120s ceiling this wrapper aborted the
- * job's awaiter mid-pull — the job flipped toward failure even though the pull
- * was still landing the image in the node cache (retry churn + half-provisioned
- * state behind the tonight outage). 180s clears a cold pull with margin.
+ * the node, and the leaf SSH `docker pull` itself allows up to
+ * PULL_TIMEOUT_MS = 300s in docker-sandbox-provider. At the old 120s ceiling
+ * this wrapper aborted the job's awaiter mid-pull — the job flipped toward
+ * failure even though the pull was still landing the image in the node cache
+ * (retry churn + half-provisioned state behind the tonight outage). 300s
+ * matches the leaf pull ceiling so the wrapper never cuts a still-progressing
+ * cold pull short.
  *
  * This pins two things:
- *   1. PER_JOB_TIMEOUT_MS outlasts a representative cold pull (and stays within
- *      the daemon's watchdog-safe budget), and
+ *   1. PER_JOB_TIMEOUT_MS outlasts a representative cold pull and matches the
+ *      leaf PULL_TIMEOUT_MS (the real ceiling that bounds a cold provision), and
  *   2. the actual `withTimeout` semantics: a create/pull that takes longer than
  *      the OLD 120s ceiling completes without timing out under the new ceiling,
  *      while a genuinely-hung create still times out.
@@ -31,39 +33,46 @@ const COLD_PULL_MS = 150_000;
 /** The old per-job ceiling that aborted the awaiter mid-pull. */
 const OLD_PER_JOB_TIMEOUT_MS = 120_000;
 /**
- * The daemon's whole-WORK-cycle budget (provisioning-worker WORK_CYCLE_TIMEOUT_MS).
- * PER_JOB_TIMEOUT_MS is kept <= this so a single job never reads as if it could
- * outlive the bounded work group, and the heartbeat watchdog window (300s) is
- * never threatened.
+ * The leaf SSH `docker pull` ceiling (docker-sandbox-provider PULL_TIMEOUT_MS).
+ * PER_JOB_TIMEOUT_MS matches this so the outer per-job wrapper never cuts a
+ * still-progressing cold pull short. This — NOT the daemon's work-cycle budget —
+ * is the real ceiling that bounds a cold provision: on the watchdog's critical
+ * path the per-job awaiter runs INSIDE the daemon's `runBoundedPhase("cycle")`
+ * (capped at PHASE_TIMEOUT_MS = 60s), so the heartbeat advances regardless of
+ * PER_JOB_TIMEOUT_MS, and the watchdog invariant
+ * (WORK_CYCLE_TIMEOUT_MS 240s + poll 30s < WATCHDOG_MAX_CYCLE_MS 300s) does not
+ * reference it. Raising PER_JOB_TIMEOUT_MS to 300s therefore stays watchdog-safe.
  */
-const WORK_CYCLE_TIMEOUT_MS = 240_000;
+const PULL_TIMEOUT_MS = 300_000;
+/** Shared 1000x scale-down so the timing tests run instantly. */
+const SCALE = 1000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe("PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix)", () => {
-  test("outlasts a cold image pull but stays within the watchdog-safe work budget", () => {
+  test("outlasts a cold image pull and matches the leaf pull ceiling", () => {
     // A ~2.5min cold pull must NOT be aborted mid-flight by the per-job wrapper.
     expect(PER_JOB_TIMEOUT_MS).toBeGreaterThan(COLD_PULL_MS);
     // The old 120s ceiling was SHORTER than a cold pull (the bug). The fix raises it.
     expect(PER_JOB_TIMEOUT_MS).toBeGreaterThan(OLD_PER_JOB_TIMEOUT_MS);
-    // ...but never longer than the daemon's whole-work-cycle budget, so it can't
-    // read as if a single job could outlive the bounded group / threaten the
-    // 300s heartbeat watchdog.
-    expect(PER_JOB_TIMEOUT_MS).toBeLessThanOrEqual(WORK_CYCLE_TIMEOUT_MS);
+    // ...up to the leaf SSH `docker pull` ceiling. Matching PULL_TIMEOUT_MS means
+    // the outer wrapper never cuts a still-progressing cold pull short — and it
+    // stays watchdog-safe because the per-job awaiter on the watchdog critical
+    // path is bounded by the daemon's PHASE_TIMEOUT_MS (60s), not by this value.
+    expect(PER_JOB_TIMEOUT_MS).toBeLessThanOrEqual(PULL_TIMEOUT_MS);
   });
 
   test("a create/pull longer than the OLD ceiling completes without timing out under the new ceiling", async () => {
     // Scale the production ordering down by 1000x so the test is instant while
-    // preserving the exact invariant: OLD(120) < coldPull(150) < NEW(180).
-    const scale = 1000;
-    const newCeiling = PER_JOB_TIMEOUT_MS / scale; // 180ms
-    const coldPullDuration = COLD_PULL_MS / scale; // 150ms — would have tripped the old 120ms ceiling
+    // preserving the exact invariant: OLD(120) < coldPull(150) < NEW(300).
+    const newCeiling = PER_JOB_TIMEOUT_MS / SCALE; // 300ms
+    const coldPullDuration = COLD_PULL_MS / SCALE; // 150ms — would have tripped the old 120ms ceiling
 
     // Sanity: this duration is longer than the old ceiling (so it WOULD have
     // timed out before the fix) but shorter than the new one.
-    expect(coldPullDuration).toBeGreaterThan(OLD_PER_JOB_TIMEOUT_MS / scale);
+    expect(coldPullDuration).toBeGreaterThan(OLD_PER_JOB_TIMEOUT_MS / SCALE);
     expect(coldPullDuration).toBeLessThan(newCeiling);
 
     // A create that takes longer than the old ceiling but finishes within the
@@ -74,8 +83,7 @@ describe("PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix)", () => {
   });
 
   test("a genuinely-hung create still times out", async () => {
-    const scale = 1000;
-    const newCeiling = PER_JOB_TIMEOUT_MS / scale; // 180ms
+    const newCeiling = PER_JOB_TIMEOUT_MS / SCALE; // 300ms
 
     // A create that hangs well past the ceiling (e.g. a wedged node) must still
     // be freed by the wrapper — the ceiling is a real backstop, not removed.

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -612,8 +612,24 @@ interface LifecycleJobOptions<TData extends object> {
  * headscale network I/O while holding a DB advisory lock) used to run for
  * minutes and starve the whole cycle. Every leaf is independently bounded, so
  * a job hitting this ceiling means something is genuinely wedged.
+ *
+ * 180s, not 120s: a freshly-pinned agent image cold-pulls in ~2.5 min on the
+ * node (the leaf SSH `docker pull` allows up to `PULL_TIMEOUT_MS` = 300s in
+ * docker-sandbox-provider). At the old 120s this wrapper aborted the awaiter
+ * mid-pull, so the job flipped toward failure even though the pull was still
+ * landing the image in the node cache — retry churn + the half-provisioned
+ * state behind the tonight outage. 180s clears a cold pull with margin.
+ *
+ * This is WATCHDOG-SAFE and stays OFF the heartbeat critical path. The
+ * provisioning-worker daemon already frees the *cycle* awaiter at its own
+ * `PHASE_TIMEOUT_MS` (60s) and advances `lastCycleCompletedAt` immediately, so
+ * the heartbeat keeps flowing regardless of this value — `PER_JOB_TIMEOUT_MS`
+ * governs only the detached background job promise, not the watchdog clock.
+ * Kept <= the daemon's `WORK_CYCLE_TIMEOUT_MS` (240s) so it never reads as if a
+ * single job could outlive the bounded work group. The watchdog window (300s)
+ * and the `WORK_CYCLE_TIMEOUT_MS + poll < 300s` invariant are untouched.
  */
-const PER_JOB_TIMEOUT_MS = 120_000;
+export const PER_JOB_TIMEOUT_MS = 180_000;
 
 /**
  * Stale-job recovery thresholds, by job type. `recoverStaleJobs` resets a job

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -608,28 +608,49 @@ interface LifecycleJobOptions<TData extends object> {
 }
 
 /**
+ * Parse a positive-integer millisecond value from an env var, falling back to
+ * `fallback` when the var is unset, non-numeric, or non-positive.
+ */
+function parsePositiveIntEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
  * Hard ceiling on a single job's execution. A slow agent_delete (SSH +
  * headscale network I/O while holding a DB advisory lock) used to run for
  * minutes and starve the whole cycle. Every leaf is independently bounded, so
  * a job hitting this ceiling means something is genuinely wedged.
  *
- * 180s, not 120s: a freshly-pinned agent image cold-pulls in ~2.5 min on the
- * node (the leaf SSH `docker pull` allows up to `PULL_TIMEOUT_MS` = 300s in
- * docker-sandbox-provider). At the old 120s this wrapper aborted the awaiter
+ * 300s default (env-overridable via `PROVISION_JOB_TIMEOUT_MS`), not 120s: a
+ * freshly-pinned agent image cold-pulls in ~2.5 min on the node, and the leaf
+ * SSH `docker pull` itself allows up to `PULL_TIMEOUT_MS` = 300s in
+ * docker-sandbox-provider. At the old 120s this wrapper aborted the awaiter
  * mid-pull, so the job flipped toward failure even though the pull was still
  * landing the image in the node cache — retry churn + the half-provisioned
- * state behind the tonight outage. 180s clears a cold pull with margin.
+ * state behind the tonight outage. Matching the leaf `PULL_TIMEOUT_MS` (300s)
+ * means the wrapper never cuts a still-progressing cold pull short. This is the
+ * value 0xSolace set on the live box while working the outage; the env override
+ * lets ops retune without a redeploy.
  *
- * This is WATCHDOG-SAFE and stays OFF the heartbeat critical path. The
- * provisioning-worker daemon already frees the *cycle* awaiter at its own
- * `PHASE_TIMEOUT_MS` (60s) and advances `lastCycleCompletedAt` immediately, so
- * the heartbeat keeps flowing regardless of this value — `PER_JOB_TIMEOUT_MS`
- * governs only the detached background job promise, not the watchdog clock.
- * Kept <= the daemon's `WORK_CYCLE_TIMEOUT_MS` (240s) so it never reads as if a
- * single job could outlive the bounded work group. The watchdog window (300s)
- * and the `WORK_CYCLE_TIMEOUT_MS + poll < 300s` invariant are untouched.
+ * This is WATCHDOG-SAFE and stays OFF the heartbeat critical path. On the
+ * watchdog's critical path the per-job awaiter runs INSIDE the daemon's
+ * `runBoundedPhase("cycle")`, itself capped at `PHASE_TIMEOUT_MS` (60s): if a
+ * job runs longer, the phase frees the *cycle* awaiter at 60s, advances
+ * `lastCycleCompletedAt`, and the heartbeat keeps flowing — REGARDLESS of
+ * `PER_JOB_TIMEOUT_MS`. This constant governs only the detached background job
+ * promise (the leaf SSH/HTTP I/O keeps running until it resolves or hits this
+ * ceiling), NOT the watchdog clock. The watchdog invariant
+ * (`WORK_CYCLE_TIMEOUT_MS` 240s + poll 30s < `WATCHDOG_MAX_CYCLE_MS` 300s) does
+ * not reference this value at all, so raising it past `WORK_CYCLE_TIMEOUT_MS`
+ * cannot violate the invariant — the real ceiling that matters is the leaf
+ * `PULL_TIMEOUT_MS` (300s), which this matches.
  */
-export const PER_JOB_TIMEOUT_MS = 180_000;
+export const PER_JOB_TIMEOUT_MS = parsePositiveIntEnv(
+  process.env.PROVISION_JOB_TIMEOUT_MS,
+  300_000,
+);
 
 /**
  * Stale-job recovery thresholds, by job type. `recoverStaleJobs` resets a job


### PR DESCRIPTION
## Context — tonight's fleet-wide provisioning outage

Several provisioning-robustness bugs combined to take down provisioning fleet-wide tonight. They were surfaced and manually worked around on the live box by **@0xSolace** (rows reset to `pending` by hand; the image pre-pulled on all nodes; the per-job and VPN-registration timeouts retuned on the box). **This PR makes those box-level workarounds permanent in code — and env-overridable — so the outage can't recur.** Box diagnosis + live-tuning credit: **@0xSolace**.

Every change touches the provisioning **hot path** (every agent), so they are deliberately conservative: a genuinely-running customer agent is never disturbed, and the heartbeat watchdog window is left untouched.

This PR now covers four things:

## 1. Provisioning lock acquires from `running`-without-container (permanent re-provision block)

A direct/shared provision inserts the `agent_sandboxes` row as `status='running'` **before** any container exists (`eliza-sandbox.ts` `buildAgentInsertData`: `const status = executionTier === "shared" ? "running" : "pending"`). If that provision crashes, the row is stuck at `running` with **no container**, and `trySetProvisioning` only acquired the lock from `pending / provisioning / stopped / sleeping / disconnected / error` — **never `running`**. So a `running`-but-containerless row could never re-acquire the lock, blocking **all** future re-provisions **permanently**.

**Fix (unchanged from the original PR):** `trySetProvisioning` now ALSO acquires from `status='running'`, but **only** for a never-containerized row:

```sql
status IN ('pending','provisioning','stopped','sleeping','disconnected','error')
OR (status = 'running' AND container_name IS NULL AND sandbox_id IS NULL)
```

**Live-agent protection (load-bearing):** the moment a container is created the provision path stamps `container_name` / `sandbox_id`. So a genuinely-running dedicated agent has those columns set and can **never** satisfy the new branch — it can **never** have its lock taken from under it or be double-provisioned. Both NULL guards are required (column names verified against `db/schemas/agent-sandboxes.ts`).

## 2. Cold-pull per-job timeout → 300s, env `PROVISION_JOB_TIMEOUT_MS`

A freshly-pinned agent image cold-pulls in ~2.5 min on the node, and the leaf SSH `docker pull` itself allows up to `PULL_TIMEOUT_MS = 300s` (`docker-sandbox-provider`). The **outer** per-job awaiter was bounded by `PER_JOB_TIMEOUT_MS = 120s`, so a cold provision was aborted mid-pull and flipped toward failure → retry churn + orphaned containers.

**Fix:** `PER_JOB_TIMEOUT_MS` → **300s**, env-overridable via **`PROVISION_JOB_TIMEOUT_MS`**. This matches the value @0xSolace set on the live box and matches the leaf `PULL_TIMEOUT_MS`, so the outer wrapper never cuts a still-progressing cold pull short.

**Watchdog-safe — re-verified for 300s against the daemon's heartbeat watchdog:**
- On the watchdog's critical path the per-job awaiter runs **inside** the daemon's `runBoundedPhase("cycle")`, itself capped at `PHASE_TIMEOUT_MS = 60s`. If a job runs longer, the phase frees the *cycle* awaiter at 60s, `lastCycleCompletedAt` advances, and the heartbeat keeps flowing — **regardless of `PER_JOB_TIMEOUT_MS`**. The per-job timeout governs only the **detached background job promise** (leaf SSH/HTTP I/O), not the watchdog clock.
- The watchdog invariant is `WORK_CYCLE_TIMEOUT_MS (240s) + DEFAULT_POLL_INTERVAL_MS (30s) = 270s < WATCHDOG_MAX_CYCLE_MS (300s)` and **does not reference `PER_JOB_TIMEOUT_MS` at all** — so raising it past `WORK_CYCLE_TIMEOUT_MS` cannot violate the invariant. `assertWatchdogInvariant()` and the 20 `provisioning-worker` timing-invariant tests confirm this (all still green).

## 3. VPN/headscale-registration timeout → 180s, env `VPN_REGISTRATION_TIMEOUT_MS`

The registration timeout was a hardcoded **60s** (`headscale-integration.ts` constant + an explicit `60_000` arg at the `docker-sandbox-provider` call site). A cold container needs >1 min to boot and run `tailscale up`, so 60s expired **before** the node registered → the caller logged `continuing without VPN` and the agent answered **404** over the router despite being up.

**Fix:** **180s**, env-overridable via **`VPN_REGISTRATION_TIMEOUT_MS`** — the value @0xSolace set on the box. **One source of truth:** `DEFAULT_REGISTRATION_TIMEOUT_MS` in `headscale-integration.ts` is now env-driven and **exported**; `docker-sandbox-provider` imports it in place of the hardcoded literal.

## 4. Test cleanups (no coverage lost)

- `agent-sandboxes.test.ts`: dropped a duplicate provisioning-lock test; its only net-new (positional) NULL-guard assertions are folded into the surviving test, which now pins that everything after the `'running'` literal references **both** container columns and carries **≥2** `IS NULL` predicates.
- `provisioning-jobs-per-job-timeout.test.ts`: hoisted the duplicated `const scale = 1000` to one module-scope `SCALE`; updated the ordering invariant to **OLD(120) < coldPull(150) < NEW(300)** and the ceiling assertion to the leaf `PULL_TIMEOUT_MS` (the real bound now that NEW > the work-cycle budget).

## Tests

```
agent-sandboxes.test.ts                      5 pass (40 expect)   # was 6; dup folded
provisioning-jobs-per-job-timeout.test.ts    3 pass (7 expect)    # OLD(120)<coldPull(150)<NEW(300)<=PULL(300)
provisioning-worker.test.ts (watchdog)       20 pass (35 expect)  # 240+30=270 < 300 invariant holds; no ref to PER_JOB_TIMEOUT_MS
```

biome clean on all touched files; typecheck clean on touched files.

Refs #8434
