### PR TITLE
test(agent): fix Windows-only failures in shell-execution-router host-exec lane

### DIFF
--- a/packages/agent/src/services/shell-execution-router.test.ts
+++ b/packages/agent/src/services/shell-execution-router.test.ts
@@ -52,10 +52,16 @@ describe("runShell", () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
+  // These host-exec tests verify ROUTING (host vs sandbox) + mode defaulting,
+  // not POSIX-shell semantics. `runShell` spawns command/args directly (no
+  // shell), so a hardcoded `/bin/sh` fails to spawn on Windows (exitCode -1,
+  // empty stdout). Use the running runtime binary (`process.execPath`, present
+  // on every platform) with `-e` to emit deterministic, separator-stable output
+  // (`console.log` writes LF, not CRLF, on Windows too).
   it("local-yolo runs commands on the host", async () => {
     const result = await runShell({
-      command: "/bin/sh",
-      args: ["-c", "printf hello"],
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('hello')"],
       toolName: "test:host",
       timeoutMs: 5_000,
     });
@@ -67,8 +73,8 @@ describe("runShell", () => {
 
   it("local-yolo defaults to local-yolo when no mode is set", async () => {
     const result = await runShell({
-      command: "/bin/sh",
-      args: ["-c", "echo hello"],
+      command: process.execPath,
+      args: ["-e", "console.log('hello')"],
       toolName: "test:default",
       timeoutMs: 5_000,
     });
@@ -346,9 +352,12 @@ describe("runShell", () => {
 
   it("honours timeoutMs by killing the child and reporting non-zero exit", async () => {
     const start = Date.now();
+    // A real long-running child the router must kill — `process.execPath` keeps
+    // the event loop alive for 5s on every platform (a `/bin/sh sleep` would be
+    // absent on Windows and exit fast, passing this test for the wrong reason).
     const result = await runShell({
-      command: "/bin/sh",
-      args: ["-c", "sleep 5"],
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => {}, 5000)"],
       toolName: "test:timeout",
       timeoutMs: 200,
     });


### PR DESCRIPTION
## What

`packages/agent/src/services/shell-execution-router.test.ts` has **3 host-exec tests that fail (or pass vacuously) on Windows** — and `packages/agent` has **no windows-ci job**, so the swarm never sees it.

`runShell` spawns `command`/`args` **directly** (`spawn(req.command, req.args)` — no shell). The tests hardcoded `command: "/bin/sh"`, which doesn't exist on Windows, so the spawn errors (`exitCode: -1`, empty stdout):

- `local-yolo runs commands on the host` → `expected -1 to be +0`
- `local-yolo defaults to local-yolo when no mode is set` → `expected '' to be 'hello\n'`
- `honours timeoutMs by killing the child` → **passed for the wrong reason**: it "timed out" only because `/bin/sh` was missing and exited fast, never exercising the kill path.

## Fix

These tests verify **routing** (host vs sandbox) + mode defaulting, not POSIX-shell semantics. Swap `/bin/sh` for `process.execPath` (the running bun/node binary, present on every platform) with `-e`:

- `process.stdout.write('hello')` → deterministic `"hello"` (no newline)
- `console.log('hello')` → `"hello\n"` (verified LF, not CRLF, on Windows bun)
- `setTimeout(() => {}, 5000)` → a real 5s child the router must kill at 200ms

Production `shell-execution-router.ts` is **unchanged** — it's already Windows-aware (`process.platform !== "win32"` guards the detached process group). Test-only fix; macOS/Linux behavior is identical.

## Evidence (real Windows desktop)

Before: `Tests  2 failed | 10 passed (12)`
After: `Tests  12 passed (12)` — and the timeout test now genuinely exercises the kill path.

`biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)