### PR TITLE
fix(cloud): finish remote app deploy flow

### DIFF
--- a/.github/issue-evidence/9145-remote-app-deploy.md
+++ b/.github/issue-evidence/9145-remote-app-deploy.md
@@ -1,0 +1,67 @@
+# 9145 remote app deploy evidence
+
+Issue: https://github.com/elizaOS/eliza/issues/9145
+
+## What this proves
+
+- Dashboard app deploy triggers `POST /api/v1/apps/:id/deploy`.
+- The client can poll `GET /api/v1/apps/:id/deploy/status` until the deployment reaches `READY`.
+- A local app definition remains stable after deploy, while the deployed app is classified as remote.
+- The mock cloud control plane can process DB-backed `APP_DEPLOY` jobs and expose a reachable production URL.
+- App deploy jobs still work when heavy job payloads are offloaded, because `appId` is retained in inline job data.
+
+## Commands run
+
+```bash
+bun run --cwd packages/ui test src/cloud/applications/lib/apps.deploy.test.ts
+```
+
+Result: passed, 1 file, 9 tests.
+
+```bash
+bun --conditions=eliza-source test \
+  packages/cloud-shared/src/lib/services/__tests__/app-deploy-job-service.test.ts \
+  packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts \
+  packages/cloud-shared/src/lib/services/__tests__/app-credits-ledger.test.ts \
+  packages/cloud-shared/src/lib/services/app-credit-math.test.ts \
+  packages/cloud-shared/src/db/repositories/jobs.test.ts
+```
+
+Result: passed, 39 tests, 104 expects.
+
+```bash
+bun run --cwd packages/test/cloud-e2e test tests/remote-app-deploy.spec.ts
+```
+
+Result: passed, 1 Playwright test.
+
+```bash
+/Users/shawwalters/.bun/bin/bunx biome check --write \
+  packages/ui/src/cloud/applications/lib/apps.ts \
+  packages/ui/src/cloud/applications/lib/apps.deploy.test.ts \
+  packages/ui/src/cloud/applications/components/app-overview.tsx \
+  packages/test/cloud-e2e/src/fixtures/env.ts \
+  packages/scripts/cloud/admin/dev/cloud-api-dev.mjs \
+  packages/test/cloud-e2e/playwright.config.ts \
+  packages/test/cloud-e2e/src/helpers/test-fixtures.ts \
+  packages/test/cloud-mocks/src/control-plane/server.ts \
+  packages/test/cloud-e2e/tests/remote-app-deploy.spec.ts \
+  packages/cloud-shared/src/db/repositories/jobs.ts \
+  packages/cloud-shared/src/db/repositories/jobs.test.ts
+```
+
+Result: passed after formatting two files.
+
+## Full verify
+
+```bash
+PATH="/Users/shawwalters/.bun/bin:$PATH" /Users/shawwalters/.bun/bin/bun run verify
+```
+
+Result: passed after rebasing onto `origin/develop`, 509 successful tasks out of 509 total in 5m1.293s.
+
+## Evidence notes
+
+- Screenshots/video: N/A for this change. The new proof is API and mock-runtime e2e coverage rather than a visual redesign.
+- Real LLM trajectory: N/A. This change is deploy plumbing, dashboard polling, mock control-plane behavior, and job persistence.
+- Subscription decision: no new subscription lane was added. Existing app monetization remains based on app credits, and the targeted app credit tests above passed.

--- a/packages/cloud-shared/src/db/repositories/jobs.test.ts
+++ b/packages/cloud-shared/src/db/repositories/jobs.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../lib/storage/r2-runtime-binding";
+import { prepareJobInsertData } from "./jobs";
+
+const ENV_KEYS = [
+  "SQL_HEAVY_PAYLOAD_STORAGE",
+  "SQL_HEAVY_PAYLOAD_MIN_BYTES",
+  "SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES",
+] as const;
+
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+function memoryBucket(objects: Map<string, string>): RuntimeR2Bucket {
+  return {
+    async get(key) {
+      const value = objects.get(key);
+      return value === undefined
+        ? null
+        : {
+            async text() {
+              return value;
+            },
+          };
+    },
+    async put(key, value) {
+      objects.set(key, typeof value === "string" ? value : String(value ?? ""));
+      return {};
+    },
+    async delete(key) {
+      objects.delete(key);
+      return {};
+    },
+  };
+}
+
+afterEach(() => {
+  setRuntimeR2Bucket(null);
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("prepareJobInsertData", () => {
+  test("preserves appId inline when job data is offloaded", async () => {
+    const objects = new Map<string, string>();
+    setRuntimeR2Bucket(memoryBucket(objects));
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+    process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES = "1";
+    process.env.SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES = "0";
+
+    const prepared = await prepareJobInsertData({
+      id: "11111111-1111-4111-8111-111111111111",
+      type: "app_deploy",
+      organization_id: "22222222-2222-4222-8222-222222222222",
+      user_id: "33333333-3333-4333-8333-333333333333",
+      data: {
+        appId: "app-123",
+        buildContext: "x".repeat(1024),
+      },
+    });
+
+    expect(prepared.data_storage).toBe("r2");
+    expect(prepared.data_key).toContain("11111111-1111-4111-8111-111111111111/data.json");
+    expect(prepared.data).toEqual({ appId: "app-123" });
+    expect(objects.size).toBe(1);
+    expect(JSON.parse([...objects.values()][0] ?? "{}")).toMatchObject({
+      appId: "app-123",
+      buildContext: expect.any(String),
+    });
+  });
+});

--- a/packages/cloud-shared/src/db/repositories/jobs.ts
+++ b/packages/cloud-shared/src/db/repositories/jobs.ts
@@ -21,7 +21,7 @@ function hasPayloadUpdates(updates: Partial<Job> | Partial<NewJob>): boolean {
 
 function stringField(
   data: Record<string, unknown>,
-  field: "agentId" | "agentName" | "characterId" | "organizationId" | "userId",
+  field: "agentId" | "agentName" | "appId" | "characterId" | "organizationId" | "userId",
 ): string | null {
   const value = data[field];
   return typeof value === "string" && value.length > 0 ? value : null;
@@ -39,6 +39,7 @@ function inlineJobData(data: Record<string, unknown>): Record<string, unknown> {
   for (const field of [
     "agentId",
     "agentName",
+    "appId",
     "characterId",
     "organizationId",
     "userId",

--- a/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
+++ b/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
@@ -226,6 +226,14 @@ async function main() {
         `ELIZA_CF_REGISTRAR_DEV_STUB:${registrarStub}`,
       ]
     : [];
+  const appDeployDevVars = [
+    "APPS_DEPLOY_ENABLED",
+    "APPS_DEPLOY_ALLOWED_ORG_IDS",
+    "APP_DEFAULT_IMAGE",
+  ].flatMap((key) => {
+    const value = process.env[key];
+    return value ? ["--var", `${key}:${value}`] : [];
+  });
 
   const wranglerArgs =
     args.length > 0
@@ -238,6 +246,7 @@ async function main() {
           apiPort,
           "--local",
           ...testModeVars,
+          ...appDeployDevVars,
         ];
 
   const useNodeWrangler = env.CLOUD_E2E === "1" && env.NODE_ENV === "test";

--- a/packages/test/cloud-e2e/package.json
+++ b/packages/test/cloud-e2e/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun --bun playwright test",
-    "test:headed": "bun --bun playwright test --headed",
-    "test:ui": "bun --bun playwright test --ui",
+    "test": "bun --conditions=eliza-source --bun playwright test",
+    "test:headed": "bun --conditions=eliza-source --bun playwright test --headed",
+    "test:ui": "bun --conditions=eliza-source --bun playwright test --ui",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/test/cloud-e2e/playwright.config.ts
+++ b/packages/test/cloud-e2e/playwright.config.ts
@@ -33,6 +33,12 @@ for (const envFile of [
 // `seedTestUser()` throws "ELIZA_KMS_BACKEND=steward requires steward.{...}".
 process.env.NODE_ENV ??= "test";
 process.env.ELIZA_KMS_BACKEND ??= "memory";
+const bunSourceCondition = "--conditions=eliza-source";
+if (!process.env.BUN_OPTIONS?.includes(bunSourceCondition)) {
+  process.env.BUN_OPTIONS = process.env.BUN_OPTIONS?.trim()
+    ? `${process.env.BUN_OPTIONS} ${bunSourceCondition}`
+    : bunSourceCondition;
+}
 
 const frontendUrl = process.env.E2E_FRONTEND_URL ?? "http://127.0.0.1:0";
 const recording = !!process.env.E2E_RECORD;

--- a/packages/test/cloud-e2e/src/fixtures/env.ts
+++ b/packages/test/cloud-e2e/src/fixtures/env.ts
@@ -37,12 +37,21 @@ function stripBunAncestryEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return cleaned;
 }
 
+function withBunSourceCondition(value: string | undefined): string {
+  const condition = "--conditions=eliza-source";
+  if (!value?.trim()) return condition;
+  return value.includes(condition) ? value : `${value} ${condition}`;
+}
+
 export function buildSharedEnv(
   urls: StackUrls,
   extra: Record<string, string> = {},
 ): NodeJS.ProcessEnv {
   return {
     ...stripBunAncestryEnv(process.env),
+    // Source-mode workspace packages (notably plugin-sql's peer dependency on
+    // core) need this when cloud-e2e spawns fresh Bun subprocesses.
+    BUN_OPTIONS: withBunSourceCondition(process.env.BUN_OPTIONS),
     NODE_ENV: "test",
     CLOUD_E2E: "1",
     // Mocks
@@ -56,6 +65,11 @@ export function buildSharedEnv(
     CONTAINER_CONTROL_PLANE_TOKEN: "test-token",
     CRON_SECRET: "test-cron-secret",
     INTERNAL_SECRET: "test-internal-secret",
+    // Apps Product 2 deploy path: enable the route and give the mock apps
+    // worker a prebuilt image to attach to container rows.
+    APPS_DEPLOY_ENABLED: "1",
+    APP_DEFAULT_IMAGE:
+      process.env.APP_DEFAULT_IMAGE ?? "ghcr.io/elizaos/eliza:e2e-app",
     // Playwright test auth bypass — secret read by cloud-shared auth helpers
     PLAYWRIGHT_TEST_AUTH: "true",
     PLAYWRIGHT_TEST_AUTH_SECRET: PLAYWRIGHT_TEST_AUTH_SECRET,

--- a/packages/test/cloud-e2e/src/helpers/test-fixtures.ts
+++ b/packages/test/cloud-e2e/src/helpers/test-fixtures.ts
@@ -9,7 +9,11 @@ import crypto from "node:crypto";
 import { test as base, expect, type Page } from "@playwright/test";
 import { PLAYWRIGHT_TEST_AUTH_SECRET } from "../fixtures/env";
 import { type SeededUser, seedTestUser } from "../fixtures/seed";
-import { type StackHandle, startCloudStack } from "../fixtures/stack";
+import {
+  type StackHandle,
+  type StartCloudStackOptions,
+  startCloudStack,
+} from "../fixtures/stack";
 
 function buildPlaywrightSessionToken(
   userId: string,
@@ -30,6 +34,7 @@ function buildPlaywrightSessionToken(
 
 export interface CloudStackFixtures {
   stack: StackHandle;
+  stackOptions: StartCloudStackOptions;
 }
 
 export interface CloudTestFixtures {
@@ -38,9 +43,11 @@ export interface CloudTestFixtures {
 }
 
 export const test = base.extend<CloudTestFixtures, CloudStackFixtures>({
+  stackOptions: [{}, { scope: "worker", option: true }],
+
   stack: [
-    async ({}, use) => {
-      const handle = await startCloudStack();
+    async ({ stackOptions }, use) => {
+      const handle = await startCloudStack(stackOptions);
       try {
         await use(handle);
       } finally {

--- a/packages/test/cloud-e2e/tests/remote-app-deploy.spec.ts
+++ b/packages/test/cloud-e2e/tests/remote-app-deploy.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Remote app deploy e2e (#9145).
+ *
+ * Drives the real cloud-api deploy route against the mock-backed apps worker:
+ * create a local/draft app, POST /deploy, tick the DB-backed APP_DEPLOY worker,
+ * poll /deploy/status to READY, and fetch the resulting production_url.
+ */
+
+import {
+  type AppDeploymentStatus,
+  appKindFor,
+} from "@elizaos/cloud-shared/lib/services/app-deployments-helpers";
+import { authedClient } from "../src/helpers/monetization";
+import { expect, test } from "../src/helpers/test-fixtures";
+
+test.use({ stackOptions: { frontend: false } });
+
+interface AppSummary {
+  id: string;
+  app_url: string;
+  allowed_origins: string[];
+  deployment_status: AppDeploymentStatus;
+  production_url: string | null;
+}
+
+interface AppEnvelope {
+  success?: boolean;
+  app?: AppSummary;
+  apiKey?: string;
+}
+
+interface DeployEnvelope {
+  success?: boolean;
+  deploymentId?: string | null;
+  status?: "BUILDING" | "READY" | "ERROR" | "DRAFT";
+  vercelUrl?: string | null;
+  error?: string | null;
+  startedAt?: string | null;
+}
+
+interface MockAppEnvelope {
+  success?: boolean;
+  appId?: string;
+  containerId?: string;
+  status?: string;
+  runtime?: string;
+}
+
+test.describe("remote app deploy", () => {
+  test("dashboard deploy endpoint reaches READY with a reachable production_url and preserved local definition", async ({
+    stack,
+    seededUser,
+  }) => {
+    const c = authedClient(stack.urls.api, seededUser.apiKey);
+    const localAppUrl = "https://local-app.example.test";
+    const allowedOrigins = [localAppUrl, "https://mobile.example.test"];
+
+    const created = await c<AppEnvelope>("POST", "/api/v1/apps", {
+      name: `Remote Deploy ${Date.now().toString(36)}`,
+      app_url: localAppUrl,
+      allowed_origins: allowedOrigins,
+      skipGitHubRepo: true,
+    });
+
+    expect([200, 201]).toContain(created.status);
+    const app = created.json.app;
+    expect(app?.id, "apps.create must return an app id").toBeTruthy();
+    if (!app?.id) throw new Error("apps.create did not return an app id");
+
+    expect(appKindFor(app)).toBe("local");
+    expect(app.production_url).toBeNull();
+    expect(app.app_url).toBe(localAppUrl);
+    expect(app.allowed_origins).toEqual(allowedOrigins);
+
+    const started = await c<DeployEnvelope>(
+      "POST",
+      `/api/v1/apps/${app.id}/deploy`,
+    );
+    expect(started.status).toBe(202);
+    expect(started.json.status).toBe("BUILDING");
+    expect(started.json.deploymentId).toBeTruthy();
+
+    let latest: DeployEnvelope | undefined;
+    for (let i = 0; i < 20; i++) {
+      const processed = await stack.mocks.controlPlane.processDbBackedJobs(
+        stack.urls.pglite,
+      );
+      expect(processed.failed, JSON.stringify(processed.errors)).toBe(0);
+
+      const status = await c<DeployEnvelope>(
+        "GET",
+        `/api/v1/apps/${app.id}/deploy/status`,
+      );
+      expect(status.status).toBe(200);
+      latest = status.json;
+      if (latest.status === "READY") break;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
+    expect(latest?.status).toBe("READY");
+    const productionUrl = latest?.vercelUrl;
+    expect(
+      productionUrl,
+      "deploy status should expose production_url",
+    ).toBeTruthy();
+    if (!productionUrl)
+      throw new Error("deploy status did not return production_url");
+
+    const deployed = await c<AppEnvelope>("GET", `/api/v1/apps/${app.id}`);
+    expect(deployed.status).toBe(200);
+    expect(deployed.json.app?.deployment_status).toBe("deployed");
+    expect(deployed.json.app?.production_url).toBe(productionUrl);
+    expect(deployed.json.app && appKindFor(deployed.json.app)).toBe("remote");
+
+    // Local-vs-remote parity: deploying creates a remote runtime, but the local
+    // app definition the client authored remains stable.
+    expect(deployed.json.app?.app_url).toBe(localAppUrl);
+    expect(deployed.json.app?.allowed_origins).toEqual(allowedOrigins);
+
+    const live = await fetch(productionUrl);
+    expect(live.status).toBe(200);
+    const liveJson = (await live.json()) as MockAppEnvelope;
+    expect(liveJson).toMatchObject({
+      success: true,
+      appId: app.id,
+      runtime: "mock-app-container",
+    });
+  });
+});

--- a/packages/test/cloud-mocks/src/control-plane/server.ts
+++ b/packages/test/cloud-mocks/src/control-plane/server.ts
@@ -121,6 +121,8 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
 
   app.use("*", async (c, next) => {
     if (c.req.path === "/health") return next();
+    // Mock production app URLs are externally reachable, unlike control-plane APIs.
+    if (c.req.path.startsWith("/mock/apps/")) return next();
     // Admin endpoints use their own token, validated per-route.
     if (c.req.path.startsWith("/api/v1/admin/")) return next();
     // Compat endpoints are public stubs.
@@ -159,6 +161,10 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     return value;
   }
 
+  function appUrl(origin: string, containerId: string): string {
+    return `${origin}/mock/apps/${encodeURIComponent(containerId)}`;
+  }
+
   async function processDbBackedJobs(
     databaseUrl: string,
     origin: string,
@@ -171,11 +177,15 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
   }> {
     const [
       { agentSandboxesRepository },
+      { appsRepository },
+      { containersRepository },
       { jobsRepository },
       { runWithCloudBindingsAsync },
       { JOB_TYPES },
     ] = await Promise.all([
       import("@elizaos/cloud-shared/db/repositories/agent-sandboxes.ts"),
+      import("@elizaos/cloud-shared/db/repositories/apps.ts"),
+      import("@elizaos/cloud-shared/db/repositories/containers.ts"),
       import("@elizaos/cloud-shared/db/repositories/jobs.ts"),
       import("@elizaos/cloud-shared/lib/runtime/cloud-bindings.ts"),
       import("@elizaos/cloud-shared/lib/services/provisioning-job-types.ts"),
@@ -204,6 +214,7 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
         const sleepJobs = await claim(JOB_TYPES.AGENT_SLEEP);
         const wakeJobs = await claim(JOB_TYPES.AGENT_WAKE);
         const snapshotJobs = await claim(JOB_TYPES.AGENT_SNAPSHOT);
+        const appDeployJobs = await claim(JOB_TYPES.APP_DEPLOY);
 
         for (const job of [
           ...provisionJobs,
@@ -213,9 +224,58 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
           ...sleepJobs,
           ...wakeJobs,
           ...snapshotJobs,
+          ...appDeployJobs,
         ]) {
           result.claimed += 1;
           try {
+            if (job.type === JOB_TYPES.APP_DEPLOY) {
+              const appId = readJobString(job, "appId");
+              const appRow = await appsRepository.findById(appId);
+              if (!appRow) {
+                throw new Error(`App not found for APP_DEPLOY: ${appId}`);
+              }
+
+              const container = await containersRepository.create({
+                name: `app-${appId.replace(/-/g, "").slice(0, 12)}`,
+                project_name: appId,
+                organization_id: appRow.organization_id,
+                user_id: appRow.created_by_user_id,
+                image_tag:
+                  process.env.APP_DEFAULT_IMAGE ??
+                  "ghcr.io/elizaos/eliza:e2e-app",
+                port: 3000,
+                environment_vars: {},
+                metadata: { appId, mockDeployed: true },
+                status: "running",
+                last_deployed_at: now(),
+              });
+
+              const productionUrl = appUrl(origin, container.id);
+              await appsRepository.update(appId, {
+                metadata: {
+                  ...((appRow.metadata as Record<string, unknown> | null) ??
+                    {}),
+                  containerId: container.id,
+                },
+                deployment_status: "deployed",
+                production_url: productionUrl,
+                last_deployed_at: now(),
+              });
+              await containersRepository.update(
+                container.id,
+                appRow.organization_id,
+                {
+                  load_balancer_url: productionUrl,
+                },
+              );
+              await jobsRepository.updateStatus(job.id, "completed", {
+                result: { appId, containerId: container.id, productionUrl },
+                completed_at: now(),
+              });
+              result.succeeded += 1;
+              continue;
+            }
+
             if (job.type === JOB_TYPES.AGENT_DELETE) {
               const agentId = readJobString(job, "agentId");
               const organizationId = readJobString(job, "organizationId");
@@ -561,7 +621,9 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     const parsed =
       rawLimit !== undefined ? Number.parseInt(rawLimit, 10) : Number.NaN;
     const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : 1000;
-    const databaseUrl = c.req.header("x-eliza-cloud-database-url")?.trim();
+    const databaseUrl =
+      c.req.header("x-eliza-cloud-database-url")?.trim() ??
+      process.env.DATABASE_URL;
     const result = databaseUrl
       ? await processDbBackedJobs(databaseUrl, new URL(c.req.url).origin, limit)
       : await tick(limit);
@@ -819,6 +881,47 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
         timestamp: now().toISOString(),
       },
     });
+  });
+
+  app.get("/mock/apps/:containerId", async (c) => {
+    await latency();
+    const containerId = c.req.param("containerId");
+    const databaseUrl =
+      c.req.header("x-eliza-cloud-database-url")?.trim() ??
+      process.env.DATABASE_URL;
+    if (databaseUrl) {
+      const [{ containersRepository }, { runWithCloudBindingsAsync }] =
+        await Promise.all([
+          import("@elizaos/cloud-shared/db/repositories/containers.ts"),
+          import("@elizaos/cloud-shared/lib/runtime/cloud-bindings.ts"),
+        ]);
+      const rows = await runWithCloudBindingsAsync(
+        { DATABASE_URL: databaseUrl },
+        () => containersRepository.listForAdminInfrastructure(500),
+      );
+      const row = rows.find((candidate) => candidate.id === containerId);
+      if (row && row.status !== "deleted") {
+        return c.json({
+          success: true,
+          appId: row.project_name,
+          containerId,
+          status: row.status,
+          runtime: "mock-app-container",
+        });
+      }
+    }
+
+    const container = store.getContainer(containerId);
+    if (container && container.status !== "deleted") {
+      return c.json({
+        success: true,
+        appId: container.projectName,
+        containerId,
+        status: container.status,
+        runtime: "mock-app-container",
+      });
+    }
+    return c.json({ success: false, error: "App container not found" }, 404);
   });
 
   // ── JSON-RPC bridge + SSE ────────────────────────────────────────────

--- a/packages/ui/src/cloud/applications/components/app-overview.tsx
+++ b/packages/ui/src/cloud/applications/components/app-overview.tsx
@@ -44,11 +44,22 @@ import { cn } from "../../../lib/utils";
 import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { App } from "../lib/apps";
-import { deployApp, regenerateAppApiKey } from "../lib/apps";
+import {
+  deployApp,
+  getLatestAppDeployment,
+  regenerateAppApiKey,
+} from "../lib/apps";
 
 interface AppOverviewProps {
   app: App;
   showApiKey?: string;
+}
+
+const DEPLOY_STATUS_POLL_INTERVAL_MS = 3_000;
+const DEPLOY_STATUS_POLL_TIMEOUT_MS = 10 * 60 * 1_000;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function AppOverview({ app, showApiKey }: AppOverviewProps) {
@@ -60,11 +71,14 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
   const [showKey, setShowKey] = useState(!!showApiKey);
   const [isRegenerating, setIsRegenerating] = useState(false);
   const [isDeploying, setIsDeploying] = useState(false);
+  const [isPollingDeployment, setIsPollingDeployment] = useState(false);
   const [monetizationEnabled, setMonetizationEnabled] = useState<
     boolean | null
   >(null);
   const [totalEarnings, setTotalEarnings] = useState<number | null>(null);
   const hideApiKeyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deploymentPollInFlightRef = useRef(false);
+  const mountedRef = useRef(true);
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -97,9 +111,89 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
 
   useEffect(() => {
     return () => {
+      mountedRef.current = false;
       if (hideApiKeyTimerRef.current) clearTimeout(hideApiKeyTimerRef.current);
     };
   }, []);
+
+  const refreshAppRecord = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ["app", app.id] }),
+    [app.id, queryClient],
+  );
+
+  const pollLatestDeployment = useCallback(
+    async (showTerminalToast: boolean) => {
+      if (deploymentPollInFlightRef.current) return;
+
+      deploymentPollInFlightRef.current = true;
+      setIsPollingDeployment(true);
+      const deadline = Date.now() + DEPLOY_STATUS_POLL_TIMEOUT_MS;
+
+      try {
+        while (Date.now() < deadline && mountedRef.current) {
+          const record = await getLatestAppDeployment(app.id);
+          await refreshAppRecord();
+
+          if (record.status === "READY") {
+            if (showTerminalToast && mountedRef.current) {
+              toast.success(
+                t("cloud.apps.overview.deployReady", {
+                  defaultValue: "Deployment is live",
+                }),
+              );
+            }
+            return;
+          }
+
+          if (record.status === "ERROR") {
+            toast.error(
+              record.error ||
+                t("cloud.apps.overview.deployFailed", {
+                  defaultValue: "Deployment failed",
+                }),
+            );
+            return;
+          }
+
+          if (record.status === "DRAFT") return;
+
+          await wait(DEPLOY_STATUS_POLL_INTERVAL_MS);
+        }
+
+        if (showTerminalToast && mountedRef.current) {
+          toast.error(
+            t("cloud.apps.overview.deployPollTimeout", {
+              defaultValue:
+                "Deployment is still running. Refresh the app to check status.",
+            }),
+          );
+        }
+      } catch (error) {
+        if (mountedRef.current) {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : t("cloud.apps.overview.deployStatusFailed", {
+                  defaultValue: "Failed to check deployment status",
+                }),
+          );
+        }
+      } finally {
+        deploymentPollInFlightRef.current = false;
+        if (mountedRef.current) setIsPollingDeployment(false);
+      }
+    },
+    [app.id, refreshAppRecord, t],
+  );
+
+  useEffect(() => {
+    if (
+      app.deployment_status === "building" ||
+      app.deployment_status === "deploying"
+    ) {
+      void pollLatestDeployment(false);
+    }
+  }, [app.deployment_status, pollLatestDeployment]);
 
   useEffect(() => {
     let cancelled = false;
@@ -154,12 +248,13 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       await deployApp(app.id);
       // Refresh the app record so the Deployment status flips to "building"
       // without a manual reload (the key is a prefix of the auth-scoped key).
-      await queryClient.invalidateQueries({ queryKey: ["app", app.id] });
+      await refreshAppRecord();
       toast.success(
         t("cloud.apps.overview.deployStarted", {
           defaultValue: "Deployment started",
         }),
       );
+      void pollLatestDeployment(true);
     } catch (error) {
       // Includes the gated `apps_deploy_disabled` case (deploy flag off) — show
       // the server's reason rather than pretending it worked.
@@ -175,6 +270,11 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
     }
   }
 
+  const deploymentInProgress =
+    app.deployment_status === "building" ||
+    app.deployment_status === "deploying";
+  const deploymentButtonDisabled =
+    isDeploying || isPollingDeployment || deploymentInProgress;
   const allowedOrigins: string[] = Array.isArray(app.allowed_origins)
     ? app.allowed_origins.filter(
         (origin): origin is string => typeof origin === "string",
@@ -280,22 +380,28 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
           </h3>
           <button
             type="button"
-            disabled={isDeploying || app.deployment_status === "building"}
+            disabled={deploymentButtonDisabled}
             onClick={handleDeploy}
             className="text-xs text-neutral-400 hover:text-white flex items-center gap-1 transition-colors disabled:opacity-50"
           >
-            {isDeploying ? (
+            {isDeploying || isPollingDeployment || deploymentInProgress ? (
               <Loader2 className="h-3 w-3 animate-spin" />
             ) : (
               <Rocket className="h-3 w-3" />
             )}
-            {app.deployment_status === "deployed"
-              ? t("cloud.apps.overview.redeploy", { defaultValue: "Redeploy" })
-              : t("cloud.apps.overview.deploy", { defaultValue: "Deploy" })}
+            {deploymentInProgress || isPollingDeployment
+              ? t("cloud.apps.overview.deploying", {
+                  defaultValue: "Deploying",
+                })
+              : app.deployment_status === "deployed"
+                ? t("cloud.apps.overview.redeploy", {
+                    defaultValue: "Redeploy",
+                  })
+                : t("cloud.apps.overview.deploy", { defaultValue: "Deploy" })}
           </button>
         </div>
         <p className="text-xs text-neutral-500">
-          {app.deployment_status === "building"
+          {deploymentInProgress || isPollingDeployment
             ? t("cloud.apps.overview.deployBuilding", {
                 defaultValue: "A deployment is in progress…",
               })

--- a/packages/ui/src/cloud/applications/lib/apps.deploy.test.ts
+++ b/packages/ui/src/cloud/applications/lib/apps.deploy.test.ts
@@ -12,6 +12,7 @@ const {
   createApp,
   deleteApp,
   deployApp,
+  getLatestAppDeployment,
   regenerateAppApiKey,
   updateApp,
 } = await import("./apps");
@@ -22,17 +23,34 @@ afterEach(() => {
 
 describe("deployApp (#9145)", () => {
   it("POSTs to /api/v1/apps/:id/deploy and returns the deployment record", async () => {
-    apiMock.mockResolvedValue({ deploymentId: "dep_1", status: "building" });
+    apiMock.mockResolvedValue({ deploymentId: "dep_1", status: "BUILDING" });
     const result = await deployApp("app_42");
     expect(apiMock).toHaveBeenCalledWith("/api/v1/apps/app_42/deploy", {
       method: "POST",
     });
-    expect(result).toEqual({ deploymentId: "dep_1", status: "building" });
+    expect(result).toEqual({ deploymentId: "dep_1", status: "BUILDING" });
   });
 
   it("propagates the gated apps_deploy_disabled error to the caller", async () => {
     apiMock.mockRejectedValue(new Error("apps_deploy_disabled"));
     await expect(deployApp("app_42")).rejects.toThrow("apps_deploy_disabled");
+  });
+
+  it("GETs /api/v1/apps/:id/deploy/status for dashboard polling", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      deploymentId: "dep_1",
+      status: "READY",
+      vercelUrl: "https://app.example.test",
+      error: null,
+      startedAt: "2026-06-24T12:00:00.000Z",
+    });
+
+    const result = await getLatestAppDeployment("app_42");
+
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/apps/app_42/deploy/status");
+    expect(result.status).toBe("READY");
+    expect(result.vercelUrl).toBe("https://app.example.test");
   });
 });
 

--- a/packages/ui/src/cloud/applications/lib/apps.ts
+++ b/packages/ui/src/cloud/applications/lib/apps.ts
@@ -36,6 +36,17 @@ export const APPS_QUERY_KEY = ["apps"] as const;
 /** Single-app key factory — exported for targeted invalidation. */
 export const appQueryKey = (id: string) => ["app", id] as const;
 
+export type DeploymentStatus = "BUILDING" | "READY" | "ERROR" | "DRAFT";
+
+export interface AppDeploymentRecord {
+  success?: boolean;
+  deploymentId: string | null;
+  status: DeploymentStatus;
+  vercelUrl: string | null;
+  error: string | null;
+  startedAt: string | null;
+}
+
 // Apps list changes only on create/edit/delete. Relax to 2 minutes so list
 // pages don't refetch on every nav while still staying responsive after
 // mutations (which also invalidate this key directly).
@@ -92,13 +103,27 @@ export async function createApp(input: {
  * Gated server-side by APPS_DEPLOY_ENABLED: when off, the route rejects with
  * `apps_deploy_disabled`, which surfaces to the caller as a thrown error.
  */
-export async function deployApp(
+export async function deployApp(id: string): Promise<{
+  deploymentId?: string;
+  status?: DeploymentStatus;
+  startedAt?: string;
+}> {
+  return api<{
+    deploymentId?: string;
+    status?: DeploymentStatus;
+    startedAt?: string;
+  }>(`/api/v1/apps/${id}/deploy`, { method: "POST" });
+}
+
+/**
+ * GET /api/v1/apps/:id/deploy/status — latest deployment record. The dashboard
+ * polls this after a deploy trigger so users see the app move from BUILDING to
+ * READY/ERROR without refreshing the page.
+ */
+export async function getLatestAppDeployment(
   id: string,
-): Promise<{ deploymentId?: string; status?: string }> {
-  return api<{ deploymentId?: string; status?: string }>(
-    `/api/v1/apps/${id}/deploy`,
-    { method: "POST" },
-  );
+): Promise<AppDeploymentRecord> {
+  return api<AppDeploymentRecord>(`/api/v1/apps/${id}/deploy/status`);
 }
 
 /** PUT /api/v1/apps/:id — update editable app fields. */


### PR DESCRIPTION
## Summary
- wire dashboard app deploy to refresh app state and poll latest deployment status until READY or ERROR
- teach the mock control plane to process DB-backed APP_DEPLOY jobs and serve a reachable mock production URL
- keep appId inline when job payloads offload to R2, with unit and cloud e2e coverage for the local-to-remote deploy path

## Verification
- bun run --cwd packages/ui test src/cloud/applications/lib/apps.deploy.test.ts
- bun --conditions=eliza-source test packages/cloud-shared/src/lib/services/__tests__/app-deploy-job-service.test.ts packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts packages/cloud-shared/src/lib/services/__tests__/app-credits-ledger.test.ts packages/cloud-shared/src/lib/services/app-credit-math.test.ts packages/cloud-shared/src/db/repositories/jobs.test.ts
- bun run --cwd packages/test/cloud-e2e test tests/remote-app-deploy.spec.ts
- PATH="/Users/shawwalters/.bun/bin:$PATH" /Users/shawwalters/.bun/bin/bun run verify (509/509 successful)

Closes #9145