### PR TITLE
fix(agent): swarm artifact attachment on Windows + 3 Windows-only test fixes

### DIFF
--- a/packages/agent/src/__tests__/views-system-smoke.test.ts
+++ b/packages/agent/src/__tests__/views-system-smoke.test.ts
@@ -354,7 +354,12 @@ describe("stage 4: GET /api/views/:id/bundle.js serves the view bundle", () => {
     expect(entry).toBeDefined();
     if (!entry) throw new Error("Expected smoke.main to be registered");
     const diskPath = getBundleDiskPath(entry);
-    expect(diskPath).toBe("/some/plugin/dir/dist/views/bundle.js");
+    // getBundleDiskPath returns a real on-disk path (path.resolve), so it is
+    // backslash/drive-rooted on Windows — compare against the platform-resolved
+    // path rather than a hardcoded POSIX string.
+    expect(diskPath).toBe(
+      path.resolve("/some/plugin/dir", "dist/views/bundle.js"),
+    );
   });
 
   it("serves relative chunks emitted beside the root bundle", async () => {

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -600,7 +600,8 @@ function removeLocalPathReferences(
   let cleaned = replaceAttachedArtifactMarkdownLinks(text, attachments);
   const titles: string[] = [];
   for (const attachment of attachments) {
-    if (!attachment.url.startsWith("/")) continue;
+    // Absolute local path (POSIX "/…" or Windows "C:\…") — skip remote URLs.
+    if (!path.isAbsolute(attachment.url)) continue;
     const title = attachment.title || path.basename(attachment.url);
     titles.push(title);
     const escapedPath = escapeRegExp(attachment.url);
@@ -661,10 +662,19 @@ function replaceAttachedArtifactMarkdownLinks(
 
 function extractLocalArtifactPaths(text: string): string[] {
   const paths = new Set<string>();
-  for (const match of text.matchAll(/`(\/[^`\n]+)`/gu)) {
+  // Match absolute on-disk paths. On Windows also accept drive-rooted paths
+  // (C:\foo, C:/foo); POSIX keeps the original "/"-rooted behavior byte-for-byte.
+  // Without the Windows arm, artifacts produced on a Windows host (backslash,
+  // drive-letter paths) are never detected, so nothing is ever attached.
+  const win = process.platform === "win32";
+  const quoted = win ? /`((?:\/|[A-Za-z]:[\\/])[^`\n]+)`/gu : /`(\/[^`\n]+)`/gu;
+  const bare = win
+    ? /(?:^|\s)((?:\/|[A-Za-z]:[\\/])[^\s"'`<>|]+)/gmu
+    : /(?:^|\s)(\/[^\s"'`<>|]+)/gmu;
+  for (const match of text.matchAll(quoted)) {
     paths.add(match[1]);
   }
-  for (const match of text.matchAll(/(?:^|\s)(\/[^\s"'`<>|]+)/gmu)) {
+  for (const match of text.matchAll(bare)) {
     paths.add(match[1].replace(/[),.;:!?]+$/u, ""));
   }
   return [...paths];

--- a/packages/agent/src/auth/credentials.test.ts
+++ b/packages/agent/src/auth/credentials.test.ts
@@ -195,8 +195,15 @@ describe("applySubscriptionCredentials", () => {
 
     const providerDir = path.join(home, "auth", "openai-codex");
     const accountFile = path.join(providerDir, "personal.json");
-    expect(fs.statSync(providerDir).mode & 0o777).toBe(0o700);
-    expect(fs.statSync(accountFile).mode & 0o777).toBe(0o600);
+    expect(fs.existsSync(accountFile)).toBe(true);
+    // POSIX permission bits (0o700/0o600) are only enforced and reported on
+    // POSIX. Windows uses NTFS ACLs and `fs.chmod` there only toggles the
+    // read-only attribute, so `mode & 0o777` is not meaningful — assert the
+    // secret-grade modes only where the OS actually enforces them.
+    if (process.platform !== "win32") {
+      expect(fs.statSync(providerDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(accountFile).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("skips malformed and provider-mismatched credential files", () => {

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -1,3 +1,4 @@
+import nodePath from "node:path";
 import { CapabilityError, type IAgentRuntime, type UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -384,7 +385,10 @@ describe("E2BRemoteCapabilityRouterService", () => {
     expect(config.provider).toBe("e2b");
     expect(config.apiKey).toBe("key");
     expect(config.workdir).toBe("/work");
-    expect(config.hostWorkspaceRoot).toBe("/repo");
+    // hostWorkspaceRoot is a LOCAL host path (path.resolve'd in production),
+    // unlike workdir which is the remote Linux sandbox path. On Windows
+    // path.resolve("/repo") → "C:\\repo", so compare against the resolved form.
+    expect(config.hostWorkspaceRoot).toBe(nodePath.resolve("/repo"));
   });
 
   it("resolves Eliza Cloud runner settings", () => {


### PR DESCRIPTION
## What

Running the `packages/agent` unit lane on a **real Windows desktop** surfaced **1 production bug + 3 POSIX-assuming tests**. `packages/agent` has **no `windows-ci` job**, so the swarm (Linux/macOS) never sees these.

### Production bug — swarm artifact attachment fully broken on Windows

`server-helpers-swarm.ts`:
- `extractLocalArtifactPaths` only matched `/`-rooted POSIX paths (`/\`(\/[^\`\n]+)\`/` etc.)
- `removeLocalPathReferences` guarded on `attachment.url.startsWith("/")`

On a Windows host, task-agent artifacts are `C:\…\result.png` (drive letter + backslashes), so **nothing was ever detected → zero attachments**, and path references were never stripped from the synthesis text. This is a real functional regression for the coding-agent/swarm feature on the Windows desktop app.

**Fix:** the extractor also matches drive-rooted paths (`C:\…` / `C:/…`) — gated to `process.platform === "win32"` so **POSIX extraction is byte-identical**; the cleanup guard uses `path.isAbsolute()` (covers POSIX `/…` and Windows `C:\…`).

### 3 test fixes (production is correct for the platform; the tests assumed POSIX)

| File | Assumed | Reality on Windows |
|------|---------|--------------------|
| `auth/credentials.test.ts` | `mode & 0o777` == `0o700`/`0o600` | POSIX-only; Windows uses NTFS ACLs, `fs.chmod` only toggles read-only. Now asserts the file exists everywhere, gates mode bits to non-Windows. |
| `services/e2b-capability-router.test.ts` | `hostWorkspaceRoot` == `/repo` | It's a LOCAL path (`path.resolve`d) → `C:\repo`. Now asserts `path.resolve("/repo")`. |
| `__tests__/views-system-smoke.test.ts` | `getBundleDiskPath` == `/some/.../bundle.js` | Real on-disk path → backslashes. Now asserts `path.resolve(...)`. |

## Evidence (real Windows desktop)

Before: `Tests  7 failed | 53 passed (60)`
After: `Tests  60 passed (60)` across the 4 files.

`bun run --cwd packages/agent typecheck` clean; `biome check` clean. macOS/Linux extraction is byte-identical (platform-gated).

> Found via the zero-`windows-ci`-coverage hunt — many packages have Windows-fragile tests but no Windows CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)