### PR TITLE
Fix scenario actionCalled success minCount

### DIFF
--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -465,7 +465,73 @@ describe("scenario executor action turns", () => {
     expect(report.failedAssertions).toContainEqual({
       label: "actionCalled",
       detail:
-        'actionCalled: expected at least one VIEWS call with result.success=true, saw {"actionName":"VIEWS","parameters":{"action":"pin","view":"remote-ledger"},"result":{"success":false,"text":"failed to open remote ledger","data":{"reason":"view missing"}}}',
+        'actionCalled: expected 1 successful VIEWS call(s) with result.success=true, saw 0. Calls: {"actionName":"VIEWS","parameters":{"action":"pin","view":"remote-ledger"},"result":{"success":false,"text":"failed to open remote ledger","data":{"reason":"view missing"}}}',
+    });
+  });
+
+  it("requires minCount successful actionCalled results when status is success", async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: false,
+        text: "first attempt failed",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        text: "second attempt worked",
+      });
+    const runtime = createRuntime([
+      {
+        name: "VIEWS",
+        description: "test action",
+        validate: vi.fn(async () => true),
+        handler,
+      } as unknown as Action,
+    ]);
+
+    const report = await runScenario(
+      {
+        id: "action-called-success-min-count",
+        title: "Action called success min count",
+        domain: "executor",
+        rooms: [{ id: "main", source: "telegram", title: "Action User" }],
+        turns: [
+          {
+            kind: "action",
+            name: "open view first",
+            actionName: "VIEWS",
+            options: { action: "pin", view: "remote-ledger" },
+          },
+          {
+            kind: "action",
+            name: "open view second",
+            actionName: "VIEWS",
+            options: { action: "pin", view: "settings" },
+          },
+        ],
+        finalChecks: [
+          {
+            type: "actionCalled",
+            actionName: "VIEWS",
+            status: "success",
+            minCount: 2,
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(report.failedAssertions).toContainEqual({
+      label: "actionCalled",
+      detail:
+        'actionCalled: expected 2 successful VIEWS call(s) with result.success=true, saw 1. Calls: {"actionName":"VIEWS","parameters":{"action":"pin","view":"remote-ledger"},"result":{"success":false,"text":"first attempt failed"}} | {"actionName":"VIEWS","parameters":{"action":"pin","view":"settings"},"result":{"success":true,"text":"second attempt worked"}}',
     });
   });
 });

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -411,21 +411,25 @@ registerFinalCheckHandler("actionCalled", (check, { ctx }) => {
     (a) => a.actionName === actionName && !isSynthesizedReply(a),
   );
   const min = typeof minCount === "number" ? minCount : 1;
+  if (status === "success") {
+    const successfulCalls = calls.filter((c) => c.result?.success === true);
+    if (successfulCalls.length < min) {
+      const actual = calls.map(actionCallSummary).join(" | ") || "(none)";
+      return {
+        status: "failed",
+        detail: `actionCalled: expected ${min} successful ${actionName} call(s) with result.success=true, saw ${successfulCalls.length}. Calls: ${actual}`,
+      };
+    }
+    return {
+      status: "passed",
+      detail: `${actionName} succeeded ${successfulCalls.length}x (${calls.length} total call(s))`,
+    };
+  }
   if (calls.length < min) {
     return {
       status: "failed",
       detail: `expected ${min} call(s) to ${actionName}, saw ${calls.length}. Called: ${ctx.actionsCalled.map((a) => a.actionName).join(",") || "(none)"}`,
     };
-  }
-  if (status === "success") {
-    const ok = calls.some((c) => c.result?.success === true);
-    if (!ok) {
-      const actual = calls.map(actionCallSummary).join(" | ") || "(none)";
-      return {
-        status: "failed",
-        detail: `actionCalled: expected at least one ${actionName} call with result.success=true, saw ${actual}`,
-      };
-    }
   }
   return { status: "passed", detail: `${actionName} called ${calls.length}x` };
 });


### PR DESCRIPTION
## Summary

- Enforces `actionCalled` `minCount` against successful `result.success === true` calls when `status: "success"` is requested.
- Preserves existing total-call `minCount` behavior for checks without a success status filter.
- Adds a regression test for the previous false positive: two calls with only one success no longer satisfies `status: "success", minCount: 2`.

## Evidence

- `bun run --cwd packages/scenario-runner test src/executor.test.ts` — passed, 10 tests.
- `bun run --cwd packages/scenario-runner typecheck` — passed.
- `bun run --cwd packages/scenario-runner test` — passed, 17 files / 121 tests.
- `bunx @biomejs/biome check packages/scenario-runner/src/final-checks/index.ts packages/scenario-runner/src/executor.test.ts` — passed.
- `git diff --check` — passed.
- `bun install` after rebase — completed, no changes.
- `bun run verify` after rebase — passed, 509 Turbo tasks.

Fixes #9330.
