### PR TITLE
fix(elizaos): correct deploy help text

### DIFF
--- a/packages/elizaos/src/cli.ts
+++ b/packages/elizaos/src/cli.ts
@@ -92,10 +92,10 @@ program
 
 program
   .command("deploy")
-  .description("Print the Eliza Cloud deployment plan for this project")
+  .description("Deploy the linked app to Eliza Cloud and poll until READY")
   .option("--app-id <id>", "Eliza Cloud app UUID to include in the plan")
   .option("--domain <host>", "Custom domain to include in the plan")
-  .option("--dry-run", "Accepted for compatibility; deploy is always a preview")
+  .option("--dry-run", "Print the deployment plan without network calls")
   .option("--verbose", "Echo resolved deploy inputs to stderr")
   .action(deploy);
 


### PR DESCRIPTION
## Summary
- Update `elizaos deploy` help text so the default command describes the real deploy-and-poll behavior.
- Update `--dry-run` help text to describe the plan-only, no-network path.

Fixes #9329

## Evidence
- `bun packages/elizaos/src/cli.ts deploy --help` shows: "Deploy the linked app to Eliza Cloud and poll until READY" and "Print the deployment plan without network calls".
- `bun run --cwd packages/elizaos test src/commands/deploy.test.ts` passed (6 tests).
- `bun run --cwd packages/elizaos typecheck` passed.
- `bun run --cwd packages/elizaos lint:check` passed.
- `bun run --cwd packages/elizaos build` passed.
- `git diff --check` passed.
- After `git fetch origin --prune && git rebase origin/develop`: `bun install` completed with no changes, and `bun run verify` passed (509 tasks).

## UI / Media Evidence
N/A: CLI help text only; no UI, media, LLM trajectory, audio, or browser flow changed.
