### PR TITLE
fix(cli): describe deploy as real cloud action

### DIFF
--- a/packages/elizaos/README.md
+++ b/packages/elizaos/README.md
@@ -59,11 +59,16 @@ elizaos plugins submit --registry owner/repo
 
 ### `elizaos deploy`
 
-Print the Eliza Cloud deployment plan for the current project. The CLI does not perform deployment side effects; authenticated build, Vercel, and domain orchestration stay in Eliza Cloud.
+Deploy the linked Eliza Cloud app for the current project by queueing a Cloud
+deployment and polling until it reaches `READY` or `ERROR`. The CLI itself does
+not run local build or Vercel orchestration; Eliza Cloud owns those deployment
+side effects. Use `--dry-run` to print the deployment plan without network
+calls.
 
 ```bash
 elizaos deploy
 elizaos deploy --app-id <id> --domain app.example.com
+elizaos deploy --dry-run
 ```
 
 ### `elizaos capability-router connect`

--- a/packages/elizaos/src/cli.ts
+++ b/packages/elizaos/src/cli.ts
@@ -5,6 +5,8 @@ import { Command } from "commander";
 import {
   capabilityRouterConnect,
   create,
+  DEPLOY_COMMAND_DESCRIPTION,
+  DEPLOY_DRY_RUN_DESCRIPTION,
   deploy,
   info,
   registerPluginsCommand,
@@ -92,10 +94,10 @@ program
 
 program
   .command("deploy")
-  .description("Print the Eliza Cloud deployment plan for this project")
+  .description(DEPLOY_COMMAND_DESCRIPTION)
   .option("--app-id <id>", "Eliza Cloud app UUID to include in the plan")
   .option("--domain <host>", "Custom domain to include in the plan")
-  .option("--dry-run", "Accepted for compatibility; deploy is always a preview")
+  .option("--dry-run", DEPLOY_DRY_RUN_DESCRIPTION)
   .option("--verbose", "Echo resolved deploy inputs to stderr")
   .action(deploy);
 

--- a/packages/elizaos/src/commands/deploy.test.ts
+++ b/packages/elizaos/src/commands/deploy.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runDeploy } from "./deploy";
+import {
+  DEPLOY_COMMAND_DESCRIPTION,
+  DEPLOY_DRY_RUN_DESCRIPTION,
+  runDeploy,
+} from "./deploy";
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -19,6 +23,14 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe("runDeploy", () => {
+  it("describes deploy as a real queue-and-poll command", () => {
+    expect(DEPLOY_COMMAND_DESCRIPTION).toContain("Deploy");
+    expect(DEPLOY_COMMAND_DESCRIPTION).toContain("poll until READY");
+    expect(DEPLOY_COMMAND_DESCRIPTION).not.toContain("plan");
+    expect(DEPLOY_DRY_RUN_DESCRIPTION).toContain("without network calls");
+    expect(DEPLOY_DRY_RUN_DESCRIPTION).not.toContain("always a preview");
+  });
+
   it("keeps dry-run mode network-free", async () => {
     const fetchMock = vi.fn();
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -12,6 +12,11 @@ import path from "node:path";
 import pc from "picocolors";
 import type { DeployOptions } from "../types.js";
 
+export const DEPLOY_COMMAND_DESCRIPTION =
+  "Deploy the linked Eliza Cloud app and poll until READY";
+export const DEPLOY_DRY_RUN_DESCRIPTION =
+  "Print the deployment plan without network calls";
+
 const DOMAIN_REGEX = /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/;
 const DEFAULT_API_BASE_URL = "https://api.elizacloud.ai/api/v1";
 const DEFAULT_POLL_INTERVAL_MS = 5_000;

--- a/packages/elizaos/src/commands/index.ts
+++ b/packages/elizaos/src/commands/index.ts
@@ -3,7 +3,12 @@ export {
   runCapabilityRouterConnect,
 } from "./capability-router.js";
 export { create } from "./create.js";
-export { deploy, runDeploy } from "./deploy.js";
+export {
+  DEPLOY_COMMAND_DESCRIPTION,
+  DEPLOY_DRY_RUN_DESCRIPTION,
+  deploy,
+  runDeploy,
+} from "./deploy.js";
 export { info } from "./info.js";
 export { registerPluginsCommand, submitPluginToRegistry } from "./plugins.js";
 export { upgrade } from "./upgrade.js";


### PR DESCRIPTION
Refs #9329.

## Summary
- Updates `elizaos deploy` Commander help so the default command is described as a real Cloud deploy that queues and polls until `READY`.
- Updates `--dry-run` help and the package README to make the no-network preview behavior explicit.
- Adds a focused regression assertion around the exported deploy help text constants.

## Evidence
- `bun run --cwd packages/elizaos test -- src/commands/deploy.test.ts` passed, 1 file / 7 tests.
- `bun run --cwd packages/elizaos typecheck` passed.
- `bun run --cwd packages/elizaos lint:check` passed.
- `bun run --cwd packages/elizaos build` passed.
- `bun run --cwd packages/elizaos test` passed, 6 files / 42 tests.
- `git diff --check` passed.
- Built CLI help now prints:

```text
Usage: elizaos deploy [options]

Deploy the linked Eliza Cloud app and poll until READY

Options:
  --app-id <id>    Eliza Cloud app UUID to include in the plan
  --domain <host>  Custom domain to include in the plan
  --dry-run        Print the deployment plan without network calls
  --verbose        Echo resolved deploy inputs to stderr
  -h, --help       display help for command
```
