### PR TITLE
fix(vault): surface audit write failures

### DIFF
--- a/packages/vault/src/audit.ts
+++ b/packages/vault/src/audit.ts
@@ -21,11 +21,12 @@ export class AuditLog {
       await fs.mkdir(dirname(this.path), { recursive: true });
       await fs.appendFile(this.path, line, { mode: 0o600 });
     } catch (err) {
-      // Audit failure must not block the caller, but it must be visible.
+      // Vault access without an audit trail is unsafe; surface the failure.
       this.logger?.warn(
         `[vault] failed to append audit record to ${this.path}`,
         err,
       );
+      throw err;
     }
   }
 }

--- a/packages/vault/test/vault.test.ts
+++ b/packages/vault/test/vault.test.ts
@@ -247,6 +247,13 @@ describe("vault — audit log", () => {
     await test.clearAuditLog();
     expect(await test.getAuditRecords()).toEqual([]);
   });
+
+  it("surfaces audit append failures to the vault caller", async () => {
+    await fs.rm(test.auditLogPath, { force: true, recursive: true });
+    await fs.mkdir(test.auditLogPath, { recursive: true });
+
+    await expect(test.vault.set("ui.theme", "dark")).rejects.toThrow();
+  });
 });
 
 describe("vault — atomicity + concurrency", () => {


### PR DESCRIPTION
## Summary
- Make `AuditLog.record()` rethrow filesystem write failures after logging the warning.
- Add a vault-level regression test proving a vault operation rejects when the audit log append cannot be written.

Fixes #9332

## Evidence
- `bun run --cwd packages/vault test test/vault.test.ts` passed (28 tests).
- `bun run --cwd packages/vault test` passed (187 tests).
- `bun run --cwd packages/vault typecheck` passed.
- `bun run --cwd packages/vault build` passed.
- `bunx @biomejs/biome check packages/vault/src/audit.ts packages/vault/test/vault.test.ts` passed.
- `git diff --check` passed.
- After `git fetch origin --prune && git rebase origin/develop`: `bun install` completed with no changes, and `bun run verify` passed (509 tasks).

## UI / Media Evidence
N/A: vault error handling only; no UI, media, LLM trajectory, audio, or browser flow changed.
