### PR TITLE
fix(vault): surface audit write failures

### DIFF
--- a/packages/vault/src/audit.ts
+++ b/packages/vault/src/audit.ts
@@ -21,11 +21,12 @@ export class AuditLog {
       await fs.mkdir(dirname(this.path), { recursive: true });
       await fs.appendFile(this.path, line, { mode: 0o600 });
     } catch (err) {
-      // Audit failure must not block the caller, but it must be visible.
+      // A vault operation without its audit record is not complete.
       this.logger?.warn(
         `[vault] failed to append audit record to ${this.path}`,
         err,
       );
+      throw err;
     }
   }
 }

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -88,6 +88,24 @@ describe("PgliteVaultImpl", () => {
     await expect(vault.remove("k")).resolves.toBeUndefined();
   });
 
+  it("rejects vault writes when the audit record cannot be written", async () => {
+    const auditPath = join(workDir, "audit-as-directory");
+    await mkdir(auditPath);
+    const auditedVault = new PgliteVaultImpl({
+      dataDir: join(workDir, ".vault-pglite-audit-fail"),
+      masterKey: inMemoryMasterKey(generateMasterKey()),
+      auditPath,
+    });
+
+    try {
+      await expect(auditedVault.set("k", "v")).rejects.toThrow(
+        /EISDIR|directory/i,
+      );
+    } finally {
+      await auditedVault.close();
+    }
+  });
+
   it("list returns all keys when no prefix", async () => {
     await vault.set("a", "1");
     await vault.set("b", "2");


### PR DESCRIPTION
Refs #9332.

## Summary
- Makes `AuditLog.record()` rethrow filesystem append failures after logging the warning.
- Preserves the existing warning visibility, but vault operations now reject instead of succeeding without an audit record.
- Adds a PGlite regression that makes the audit log path a directory and verifies `set()` rejects when the audit append cannot be written.

## Evidence
- `bun run --cwd packages/vault test -- test/pglite-vault.test.ts` passed, 1 file / 25 tests.
- `bun run --cwd packages/vault typecheck` passed.
- `bun run --cwd packages/vault test` passed, 11 files / 187 tests.
- `bun run --cwd packages/vault build` passed.
- `bunx @biomejs/biome check packages/vault/src/audit.ts packages/vault/test/pglite-vault.test.ts` passed.
- `git diff --check` passed.
