### PR TITLE
fix(tui): drop unused editor keybinding actions

### DIFF
--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -31,8 +31,6 @@ export type EditorAction =
   // Selection/autocomplete
   | "selectUp"
   | "selectDown"
-  | "selectPageUp"
-  | "selectPageDown"
   | "selectConfirm"
   | "selectCancel"
   // Clipboard
@@ -41,15 +39,7 @@ export type EditorAction =
   | "yank"
   | "yankPop"
   // Undo
-  | "undo"
-  // Tool output
-  | "expandTools"
-  // Session
-  | "toggleSessionPath"
-  | "toggleSessionSort"
-  | "renameSession"
-  | "deleteSession"
-  | "deleteSessionNoninvasive";
+  | "undo";
 
 // Re-export KeyId from keys.ts
 export type { KeyId };
@@ -92,8 +82,6 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
   // Selection/autocomplete
   selectUp: "up",
   selectDown: "down",
-  selectPageUp: "pageUp",
-  selectPageDown: "pageDown",
   selectConfirm: "enter",
   selectCancel: ["escape", "ctrl+c"],
   // Clipboard
@@ -103,14 +91,6 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
   yankPop: "alt+y",
   // Undo
   undo: "ctrl+-",
-  // Tool output
-  expandTools: "ctrl+o",
-  // Session
-  toggleSessionPath: "ctrl+p",
-  toggleSessionSort: "ctrl+s",
-  renameSession: "ctrl+r",
-  deleteSession: "ctrl+d",
-  deleteSessionNoninvasive: "ctrl+backspace",
 };
 
 /**

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert";
+import { describe, it } from "vitest";
+import {
+  DEFAULT_EDITOR_KEYBINDINGS,
+  type EditorAction,
+  EditorKeybindingsManager,
+} from "../src/keybindings.js";
+
+describe("EditorKeybindingsManager", () => {
+  it("keeps default bindings limited to live editor actions", () => {
+    const removedActions = [
+      "selectPageUp",
+      "selectPageDown",
+      "expandTools",
+      "toggleSessionPath",
+      "toggleSessionSort",
+      "renameSession",
+      "deleteSession",
+      "deleteSessionNoninvasive",
+    ];
+    const defaults = Object.keys(DEFAULT_EDITOR_KEYBINDINGS);
+    const manager = new EditorKeybindingsManager();
+
+    for (const action of removedActions) {
+      assert.ok(!defaults.includes(action));
+      assert.deepStrictEqual(manager.getKeys(action as EditorAction), []);
+    }
+    assert.deepStrictEqual(manager.getKeys("selectUp"), ["up"]);
+    assert.deepStrictEqual(manager.getKeys("selectCancel"), [
+      "escape",
+      "ctrl+c",
+    ]);
+  });
+});


### PR DESCRIPTION
Refs #9331.

## Summary
- Removes the eight dead `EditorAction` values that no TUI component handles: `selectPageUp`, `selectPageDown`, `expandTools`, `toggleSessionPath`, `toggleSessionSort`, `renameSession`, `deleteSession`, and `deleteSessionNoninvasive`.
- Removes their default key assignments from `DEFAULT_EDITOR_KEYBINDINGS`.
- Adds a keybindings regression test that confirms the removed action names are absent from defaults and live selection bindings still resolve.

## Evidence
- `bun run --cwd packages/tui test -- test/keybindings.test.ts` passed. Because the package script already includes `test/`, this ran the full TUI suite: 25 files / 478 tests.
- `bun run --cwd packages/tui build` passed.
- `bunx @biomejs/biome check packages/tui/src/keybindings.ts packages/tui/test/keybindings.test.ts` passed.
- `git diff --check` passed.
- `rg` over `packages/tui/src packages/tui/test` shows the removed action names only in the new regression test's removed-action list.
