### PR TITLE
fix(tui): remove dead editor keybindings

### DIFF
--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -31,8 +31,6 @@ export type EditorAction =
   // Selection/autocomplete
   | "selectUp"
   | "selectDown"
-  | "selectPageUp"
-  | "selectPageDown"
   | "selectConfirm"
   | "selectCancel"
   // Clipboard
@@ -41,15 +39,7 @@ export type EditorAction =
   | "yank"
   | "yankPop"
   // Undo
-  | "undo"
-  // Tool output
-  | "expandTools"
-  // Session
-  | "toggleSessionPath"
-  | "toggleSessionSort"
-  | "renameSession"
-  | "deleteSession"
-  | "deleteSessionNoninvasive";
+  | "undo";
 
 // Re-export KeyId from keys.ts
 export type { KeyId };
@@ -92,8 +82,6 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
   // Selection/autocomplete
   selectUp: "up",
   selectDown: "down",
-  selectPageUp: "pageUp",
-  selectPageDown: "pageDown",
   selectConfirm: "enter",
   selectCancel: ["escape", "ctrl+c"],
   // Clipboard
@@ -103,14 +91,6 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
   yankPop: "alt+y",
   // Undo
   undo: "ctrl+-",
-  // Tool output
-  expandTools: "ctrl+o",
-  // Session
-  toggleSessionPath: "ctrl+p",
-  toggleSessionSort: "ctrl+s",
-  renameSession: "ctrl+r",
-  deleteSession: "ctrl+d",
-  deleteSessionNoninvasive: "ctrl+backspace",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Remove the unused `EditorAction` values for selection paging, tool expansion, and session operations.
- Remove their default key assignments from `DEFAULT_EDITOR_KEYBINDINGS` so the exported keybinding map only contains actions that current TUI components consume.

Fixes #9331

## Evidence
- `bun run --cwd packages/tui test` passed (477 tests).
- `bun run --cwd packages/tui build` passed.
- `bunx @biomejs/biome check packages/tui/src/keybindings.ts` passed.
- `git diff --check` passed.
- Repo search confirmed the removed actions had no references outside `packages/tui/src/keybindings.ts`.
- After `git fetch origin --prune && git rebase origin/develop`: `bun install` completed with no changes, and `bun run verify` passed (509 tasks).

## UI / Media Evidence
N/A: TUI keybinding type/config cleanup only; no visual UI behavior, media, LLM trajectory, audio, or browser flow changed.
