### PR TITLE
test(local-inference): fix Windows-only unit-lane failures (FFI stub, SQLite handle leak, POSIX fake binaries)

### DIFF
--- a/plugins/plugin-local-inference/__tests__/W3-8-tts-cache-validation.test.ts
+++ b/plugins/plugin-local-inference/__tests__/W3-8-tts-cache-validation.test.ts
@@ -44,11 +44,14 @@ import {
 // ---------------------------------------------------------------------------
 
 let tmpRoot: string;
+const openCaches: FirstLineCache[] = [];
 
 function makeCache(
 	opts: Partial<ConstructorParameters<typeof FirstLineCache>[0]> = {},
 ): FirstLineCache {
-	return new FirstLineCache({ rootDir: tmpRoot, ...opts });
+	const cache = new FirstLineCache({ rootDir: tmpRoot, ...opts });
+	openCaches.push(cache);
+	return cache;
 }
 
 function makeKey(over: Partial<FirstLineCacheKey> = {}): FirstLineCacheKey {
@@ -99,7 +102,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	rmSync(tmpRoot, { recursive: true, force: true });
+	// Close caches before rmSync — an open SQLite (WAL) handle blocks directory
+	// removal on Windows (EBUSY/EPERM). close() is idempotent, so closing here
+	// after a test's own explicit close() is safe.
+	for (const cache of openCaches.splice(0)) cache.close();
+	rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 });
 
 // ===========================================================================

--- a/plugins/plugin-local-inference/__tests__/first-line-cache.test.ts
+++ b/plugins/plugin-local-inference/__tests__/first-line-cache.test.ts
@@ -13,9 +13,12 @@ import {
 } from "../src/services/voice/first-line-cache";
 
 let tmpRoot: string;
+const openCaches: FirstLineCache[] = [];
 
 function makeCache(opts: Partial<ConstructorParameters<typeof FirstLineCache>[0]> = {}) {
-	return new FirstLineCache({ rootDir: tmpRoot, ...opts });
+	const cache = new FirstLineCache({ rootDir: tmpRoot, ...opts });
+	openCaches.push(cache);
+	return cache;
 }
 
 function makeKey(over: Partial<FirstLineCacheKey> = {}): FirstLineCacheKey {
@@ -42,7 +45,11 @@ beforeEach(() => {
 	tmpRoot = mkdtempSync(path.join(tmpdir(), "fl-cache-"));
 });
 afterEach(() => {
-	rmSync(tmpRoot, { recursive: true, force: true });
+	// Close every cache before removing its dir: an open SQLite (WAL) handle
+	// blocks rmSync on Windows (EBUSY/EPERM); POSIX tolerates open handles.
+	// close() is idempotent, so double-closing an already-closed cache is safe.
+	for (const cache of openCaches.splice(0)) cache.close();
+	rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 });
 
 describe("hashCacheKey", () => {

--- a/plugins/plugin-local-inference/__tests__/imagegen-sd-cpp-probe.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-sd-cpp-probe.test.ts
@@ -93,6 +93,15 @@ function runProbe(env: Record<string, string | undefined>): ProbeResult {
 	return JSON.parse(firstLine) as ProbeResult;
 }
 
+// Tests that write a fake POSIX shell-script `sd` binary and have the probe
+// SPAWN it are inherently POSIX-only: Windows does not honor a `#!/usr/bin/env
+// bash` shebang and `spawn` cannot exec an extensionless script (→ ENOENT), so
+// the probe reports `binary_missing` instead of the scripted result. The probe
+// LOGIC is covered on POSIX CI; the missing/bogus-binary path (no fake spawned)
+// still runs on every platform below. On Windows the real path uses a packaged
+// `sd.exe`, which these unit fakes cannot stand in for.
+const itPosix = it.skipIf(process.platform === "win32");
+
 describe("WS3 sd-cpp probe — first-run script", () => {
 	it("reports unavailable when SD_CPP_BIN points at a missing path", () => {
 		const probe = runProbe({
@@ -107,7 +116,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.supportedModels).toBeUndefined();
 	});
 
-	it("reports CPU-only when the binary returns version but no CUDA proof", () => {
+	itPosix("reports CPU-only when the binary returns version but no CUDA proof", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd");
 		writeFileSync(
@@ -129,7 +138,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.accelerators).toContain("cpu");
 	});
 
-	it("does not treat generic --rng cuda help text as CUDA build proof", () => {
+	itPosix("does not treat generic --rng cuda help text as CUDA build proof", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-metal");
 		writeFileSync(
@@ -149,7 +158,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.accelerators).not.toContain("cuda");
 	});
 
-	it("reports CUDA when help/version proves a CUDA-capable binary", () => {
+	itPosix("reports CUDA when help/version proves a CUDA-capable binary", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-cuda");
 		writeFileSync(
@@ -169,7 +178,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.evidence).toContain("help_or_version");
 	});
 
-	it("fails closed when ELIZA_IMAGEGEN_ACCELERATOR is not supported", () => {
+	itPosix("fails closed when ELIZA_IMAGEGEN_ACCELERATOR is not supported", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd");
 		writeFileSync(
@@ -190,7 +199,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.hint).toMatch(/vulkan support/i);
 	});
 
-	it("passes when ELIZA_IMAGEGEN_ACCELERATOR is supported", () => {
+	itPosix("passes when ELIZA_IMAGEGEN_ACCELERATOR is supported", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-vulkan");
 		writeFileSync(
@@ -218,7 +227,7 @@ describe("WS3 sd-cpp probe — first-run script", () => {
 		expect(probe.reason).toBeUndefined();
 	});
 
-	it("reports binary_version_mismatch when the binary exits non-zero on --version", () => {
+	itPosix("reports binary_version_mismatch when the binary exits non-zero on --version", () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-broken");
 		writeFileSync(fakeBin, "#!/usr/bin/env bash\nexit 7\n");
@@ -266,7 +275,7 @@ describe("WS3 sd-cpp backend — binary missing yields structured error", () => 
 		}
 	});
 
-	it("rejects CUDA load when the sd-cpp binary is CPU-only", async () => {
+	itPosix("rejects CUDA load when the sd-cpp binary is CPU-only", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-cpu");
 		writeFileSync(
@@ -292,7 +301,7 @@ describe("WS3 sd-cpp backend — binary missing yields structured error", () => 
 		}
 	});
 
-	it("rejects Vulkan load when the sd-cpp binary is CPU-only", async () => {
+	itPosix("rejects Vulkan load when the sd-cpp binary is CPU-only", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-cpu");
 		writeFileSync(
@@ -318,7 +327,7 @@ describe("WS3 sd-cpp backend — binary missing yields structured error", () => 
 		}
 	});
 
-	it("rejects Metal load when the sd-cpp binary is CPU-only", async () => {
+	itPosix("rejects Metal load when the sd-cpp binary is CPU-only", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-cpu");
 		writeFileSync(
@@ -344,7 +353,7 @@ describe("WS3 sd-cpp backend — binary missing yields structured error", () => 
 		}
 	});
 
-	it("accepts CUDA load when sidecar manifest proves CUDA support", async () => {
+	itPosix("accepts CUDA load when sidecar manifest proves CUDA support", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-cuda");
 		const fakeModel = join(dir, "model.gguf");
@@ -373,7 +382,7 @@ describe("WS3 sd-cpp backend — binary missing yields structured error", () => 
 		await backend.dispose();
 	});
 
-	it("accepts Vulkan load when sidecar manifest proves Vulkan support", async () => {
+	itPosix("accepts Vulkan load when sidecar manifest proves Vulkan support", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sd-cpp-probe-"));
 		const fakeBin = join(dir, "fake-sd-vulkan");
 		const fakeModel = join(dir, "model.gguf");

--- a/plugins/plugin-local-inference/__tests__/wrap-with-first-line-cache.test.ts
+++ b/plugins/plugin-local-inference/__tests__/wrap-with-first-line-cache.test.ts
@@ -16,9 +16,12 @@ import {
 } from "../src/services/voice/wrap-with-first-line-cache";
 
 let tmpRoot: string;
+const openCaches: FirstLineCache[] = [];
 
 function makeCache(disabled = false): FirstLineCache {
-	return new FirstLineCache({ rootDir: tmpRoot, disabled });
+	const cache = new FirstLineCache({ rootDir: tmpRoot, disabled });
+	openCaches.push(cache);
+	return cache;
 }
 
 function makeRuntime(): IAgentRuntime {
@@ -48,7 +51,10 @@ beforeEach(() => {
 	tmpRoot = mkdtempSync(path.join(tmpdir(), "fl-wrap-"));
 });
 afterEach(() => {
-	rmSync(tmpRoot, { recursive: true, force: true });
+	// Close caches before rmSync — an open SQLite (WAL) handle blocks directory
+	// removal on Windows (EBUSY/EPERM). close() is idempotent.
+	for (const cache of openCaches.splice(0)) cache.close();
+	rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 });
 
 describe("wrapWithFirstLineCache — short-circuit conditions", () => {

--- a/plugins/plugin-local-inference/src/services/voice/ffi-bindings.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/ffi-bindings.test.ts
@@ -187,9 +187,16 @@ const FFI_STUB_DIR = path.resolve(
 );
 const STUB_DYLIB = path.join(
 	FFI_STUB_DIR,
+	// Per-OS shared-library naming. Windows must load a PE `.dll` — attempting to
+	// `dlopen` the committed Linux `.so` fails with error 193 (ERROR_BAD_EXE_FORMAT)
+	// rather than skipping. No Windows stub is built/committed, so the `existsSync`
+	// guards below skip these integration tests on Windows (same as Linux before
+	// `make -C scripts/ffi-stub`), instead of hard-failing on a format mismatch.
 	process.platform === "darwin"
 		? "libelizainference_stub.dylib"
-		: "libelizainference_stub.so",
+		: process.platform === "win32"
+			? "libelizainference_stub.dll"
+			: "libelizainference_stub.so",
 );
 
 function bunOnPath(): string | null {


### PR DESCRIPTION
## What

`plugins/plugin-local-inference`'s unit lane had **38 Windows-only failures** the swarm never sees — `plugin-local-inference` has **no `windows-ci` job**. Three distinct, test-side root causes:

### 1. FFI stub dylib — `dlopen` error 193 (7 tests)
`ffi-bindings.test.ts` resolved `STUB_DYLIB` to `.so` on every non-darwin platform, so Windows tried to `dlopen` the committed **Linux ELF** `libelizainference_stub.so` → `error code 193` (`ERROR_BAD_EXE_FORMAT`). Now resolves `.dll` on win32; no Windows stub is built, so the existing `existsSync` guards **skip** these subprocess-FFI tests on Windows (exactly as Linux skips before `make -C scripts/ffi-stub`).

### 2. SQLite handle leak blocks `rmSync` (31 tests)
`first-line-cache` / `wrap-with-first-line-cache` / `W3-8-tts-cache-validation` each open a **WAL-mode SQLite** cache; the `afterEach` `rmSync(tmpRoot)` then failed on Windows (`EBUSY`/`EPERM`) — POSIX tolerates removing a directory with open handles, Windows does not. The **test bodies passed**; cleanup failed. Now each `makeCache()` instance is tracked and `close()`d before `rmSync` (close is idempotent); `rmSync` gets `maxRetries` for WAL-sidecar timing.

### 3. POSIX fake binaries can't spawn on Windows (11 tests)
`imagegen-sd-cpp-probe.test.ts` writes a `#!/usr/bin/env bash` fake `sd` and has the probe **spawn** it — Windows ignores shebangs and can't exec an extensionless script (`ENOENT` → `binary_missing`). The 11 spawn-the-fake tests are gated to POSIX (`it.skipIf(win32)`); the **missing/bogus-binary** tests still run everywhere. On Windows the real path uses a packaged `sd.exe` these fakes can't stand in for.

All POSIX behavior is **byte-identical** — every change is platform-gated or cleanup-only.

## Evidence (real Windows desktop)

| File | Before | After |
|------|--------|-------|
| ffi-bindings | many fail (error 193) | 14 passed \| 2 skipped |
| first-line-cache + wrap + W3-8 | 31 failed | 59 passed |
| imagegen-sd-cpp-probe | 11 failed | 7 passed \| 11 skipped |

`bun run --cwd plugins/plugin-local-inference typecheck` clean.

### Not fixed (environmental, **not** code defects)
- `ffi-unload-ordering` — a load-induced 20s timeout in the full lane; **passes in isolation**.
- `hardware` device-tier — trips the `freeRamGb < 8` tier demotion only because concurrent test load left this box at ~7 GB free; passes on an unloaded host (verified: `probeHardware()` reports 32 GB total / 7.1 GB free / 12 cores here).

> Found via the zero-`windows-ci`-coverage hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)