### PR TITLE
refactor: web-search cleanup — own gate, DRY guard, dedupe duplicate-purpose helpers

### DIFF
--- a/packages/agent/src/runtime/actions/web-search.test.ts
+++ b/packages/agent/src/runtime/actions/web-search.test.ts
@@ -79,25 +79,25 @@ async function runHandler(parameters: ActionParameters): Promise<{
 }
 
 describe("WEB_SEARCH action", () => {
-  const original = process.env.ELIZA_WEB_SEARCH;
+  const original = process.env.ELIZA_INLINE_WEB_SEARCH;
 
   afterEach(() => {
     __setPinnedFetchImplForTests(null);
     __setDnsLookupImplForTests(null);
-    if (original === undefined) delete process.env.ELIZA_WEB_SEARCH;
-    else process.env.ELIZA_WEB_SEARCH = original;
+    if (original === undefined) delete process.env.ELIZA_INLINE_WEB_SEARCH;
+    else process.env.ELIZA_INLINE_WEB_SEARCH = original;
   });
 
   it("is available by default (no key/service required)", async () => {
-    delete process.env.ELIZA_WEB_SEARCH;
+    delete process.env.ELIZA_INLINE_WEB_SEARCH;
     expect(await webSearch.validate({} as IAgentRuntime, {} as Memory)).toBe(
       true,
     );
   });
 
-  it("is gated off when ELIZA_WEB_SEARCH disables the capability", async () => {
+  it("is gated off when ELIZA_INLINE_WEB_SEARCH disables the capability", async () => {
     for (const value of ["0", "false", "off"]) {
-      process.env.ELIZA_WEB_SEARCH = value;
+      process.env.ELIZA_INLINE_WEB_SEARCH = value;
       expect(await webSearch.validate({} as IAgentRuntime, {} as Memory)).toBe(
         false,
       );

--- a/packages/agent/src/runtime/actions/web-search.ts
+++ b/packages/agent/src/runtime/actions/web-search.ts
@@ -81,9 +81,17 @@ function readParams(options: unknown): WebSearchParams {
 }
 
 /**
- * Extract the human-readable result text from an MCP `tools/call` response. The
- * body is either a JSON-RPC object or an SSE stream of `data:` lines; both wrap
- * the payload at `result.content[].text`. A JSON-RPC `error` envelope or a
+ * Extract the human-readable result text from an MCP `tools/call` response.
+ *
+ * (Same shape as the vendored opencode `parseResponse` in
+ * plugin-agent-orchestrator/vendor/opencode/.../tool/mcp-websearch.ts, but that
+ * copy is Effect-based and lives in a third-party vendor tree `@elizaos/agent`
+ * doesn't depend on — so it can't be reused without dragging Effect in. This is
+ * the one plain-Promise copy, and it adds the error-envelope/isError handling
+ * the vendored one lacks.)
+ *
+ * The body is either a JSON-RPC object or an SSE stream of `data:` lines; both
+ * wrap the payload at `result.content[].text`. A JSON-RPC `error` envelope or a
  * tool-level `result.isError` is treated as a failure (returns undefined) — NOT
  * mistaken for a search result — so the caller falls back to the other provider
  * instead of handing the model an error string as if it were results.

--- a/packages/agent/src/runtime/actions/web-search.ts
+++ b/packages/agent/src/runtime/actions/web-search.ts
@@ -13,8 +13,9 @@
  * an open-ended lookup through a coding sub-agent is slow, re-spawns, and risks
  * leaking the weak model's tool-call markup — this answers it in one hop.
  *
- * Enabled by default; `validate` honors `ELIZA_WEB_SEARCH=0|false|off`. The POST
- * is SSRF-guarded and only ever targets the two fixed public search endpoints.
+ * Enabled by default; `validate` honors `ELIZA_INLINE_WEB_SEARCH=0|false|off`.
+ * The POST is SSRF-guarded and only ever targets the two fixed public search
+ * endpoints.
  *
  * @module runtime/actions/web-search
  */
@@ -47,11 +48,14 @@ const WEB_SEARCH_RESULT_CHARS = 4_000;
 const DEFAULT_NUM_RESULTS = 6;
 
 /**
- * Capability gate: WEB_SEARCH is enabled by default and opted out with
- * `ELIZA_WEB_SEARCH=0|false|off`, mirroring the `ELIZA_WEB_FETCH` convention.
+ * Capability gate for the INLINE keyless web-search action. Its own env var
+ * (not `ELIZA_WEB_SEARCH`, which `web-search-tools.ts` already owns for the
+ * server-side provider-native web_search) so the two web-search surfaces are
+ * independently switchable — disabling one never silently disables the other.
+ * Enabled by default; opted out with `ELIZA_INLINE_WEB_SEARCH=0|false|off`.
  */
 export function isWebSearchEnabled(): boolean {
-  const raw = process.env.ELIZA_WEB_SEARCH?.toLowerCase();
+  const raw = process.env.ELIZA_INLINE_WEB_SEARCH?.toLowerCase();
   return !(raw === "0" || raw === "false" || raw === "off");
 }
 

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -623,74 +623,28 @@ const GUARDED_GET_DEFAULT_USER_AGENT =
     "Chrome/124.0.0.0 Safari/537.36",
   ].join(" ");
 
-export async function performGuardedHttpGet(
-  url: string,
-  opts: GuardedHttpGetOptions = {},
-): Promise<GuardedHttpGetResult> {
-  const timeoutMs = opts.timeoutMs ?? CUSTOM_ACTION_FETCH_TIMEOUT_MS;
-  const maxChars = opts.maxChars ?? GUARDED_GET_MAX_BYTES;
-
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return { ok: false, status: 0, text: "", blocked: true };
-  }
-  if (parsed.protocol !== "https:") {
-    return { ok: false, status: 0, text: "", blocked: true };
-  }
-
-  const safety = await resolveUrlSafety(url);
-  if (safety.blocked) {
-    return { ok: false, status: 0, text: "", blocked: true };
-  }
-
-  // Build headers via the Headers API so a caller-supplied User-Agent (in any
-  // casing) cleanly overrides the default rather than being comma-joined onto it.
-  const headers = new Headers({ "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT });
-  if (opts.headers) {
-    for (const [key, value] of Object.entries(opts.headers)) {
-      headers.set(key, value);
-    }
-  }
-
-  const fetchOpts: RequestInit = {
-    method: "GET",
-    headers,
-    redirect: "manual",
-  };
-
-  const response = safety.target
-    ? await fetchWithPinnedTarget(safety.target, fetchOpts, timeoutMs)
-    : await fetch(url, fetchOpts);
-
-  if (response.status >= 300 && response.status < 400) {
-    return { ok: false, status: response.status, text: "", blocked: true };
-  }
-
-  const text = await readBodyTextCapped(response, maxChars);
-  return {
-    ok: response.ok,
-    status: response.status,
-    text,
-    blocked: false,
-  };
-}
-
 export interface GuardedHttpPostOptions extends GuardedHttpGetOptions {
   /** Request body. Sent as `application/json` unless `Content-Type` is set. */
   body: string;
 }
 
+interface GuardedHttpRequestOptions extends GuardedHttpGetOptions {
+  method: "GET" | "POST";
+  /** Optional body (POST). Defaults Content-Type to `application/json`. */
+  body?: string;
+}
+
 /**
- * SSRF-guarded HTTPS POST. Identical safety model to {@link performGuardedHttpGet}
- * (https-only, internal/private targets blocked, DNS pinned, body capped) but
- * sends a body — used by inline actions that call a public JSON/MCP endpoint
- * (e.g. the keyless web-search MCP) rather than fetching a plain URL.
+ * Single SSRF-guarded, https-only HTTP request used by both the GET and POST
+ * wrappers below — keeping the guard (DNS-pinned private/link-local blocking via
+ * {@link resolveUrlSafety} + {@link fetchWithPinnedTarget}, https-only scheme,
+ * redirect rejection, timeout + body cap) in ONE place so a future safety fix
+ * never has to be made twice. Public callers use {@link performGuardedHttpGet} /
+ * {@link performGuardedHttpPost}.
  */
-export async function performGuardedHttpPost(
+async function performGuardedHttpRequest(
   url: string,
-  opts: GuardedHttpPostOptions,
+  opts: GuardedHttpRequestOptions,
 ): Promise<GuardedHttpGetResult> {
   const timeoutMs = opts.timeoutMs ?? CUSTOM_ACTION_FETCH_TIMEOUT_MS;
   const maxChars = opts.maxChars ?? GUARDED_GET_MAX_BYTES;
@@ -710,10 +664,10 @@ export async function performGuardedHttpPost(
     return { ok: false, status: 0, text: "", blocked: true };
   }
 
-  const headers = new Headers({
-    "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT,
-    "Content-Type": "application/json",
-  });
+  // Build headers via the Headers API so a caller-supplied header (in any
+  // casing) cleanly overrides the default rather than being comma-joined onto it.
+  const headers = new Headers({ "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT });
+  if (opts.body !== undefined) headers.set("Content-Type", "application/json");
   if (opts.headers) {
     for (const [key, value] of Object.entries(opts.headers)) {
       headers.set(key, value);
@@ -721,10 +675,10 @@ export async function performGuardedHttpPost(
   }
 
   const fetchOpts: RequestInit = {
-    method: "POST",
+    method: opts.method,
     headers,
-    body: opts.body,
     redirect: "manual",
+    ...(opts.body !== undefined ? { body: opts.body } : {}),
   };
 
   const response = safety.target
@@ -736,12 +690,30 @@ export async function performGuardedHttpPost(
   }
 
   const text = await readBodyTextCapped(response, maxChars);
-  return {
-    ok: response.ok,
-    status: response.status,
-    text,
-    blocked: false,
-  };
+  return { ok: response.ok, status: response.status, text, blocked: false };
+}
+
+/**
+ * SSRF-guarded, https-only, GET-only HTTP fetch shared by custom actions and the
+ * built-in WEB_FETCH action.
+ */
+export async function performGuardedHttpGet(
+  url: string,
+  opts: GuardedHttpGetOptions = {},
+): Promise<GuardedHttpGetResult> {
+  return performGuardedHttpRequest(url, { ...opts, method: "GET" });
+}
+
+/**
+ * SSRF-guarded HTTPS POST with a body (default `application/json`) — used by
+ * inline actions that call a public JSON/MCP endpoint (e.g. the keyless
+ * web-search MCP). Same guard as {@link performGuardedHttpGet}.
+ */
+export async function performGuardedHttpPost(
+  url: string,
+  opts: GuardedHttpPostOptions,
+): Promise<GuardedHttpGetResult> {
+  return performGuardedHttpRequest(url, { ...opts, method: "POST" });
 }
 
 function buildHandler(

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -600,15 +600,6 @@ export interface GuardedHttpGetResult {
   blocked: boolean;
 }
 
-/**
- * SSRF-guarded, https-only, GET-only HTTP fetch shared by custom actions and
- * the built-in WEB_FETCH action.
- *
- * Reuses {@link resolveUrlSafety} (DNS-pinned private/link-local IP blocking via
- * the security network policy) and {@link fetchWithPinnedTarget}. Enforces an
- * https scheme, rejects redirects, and caps both the timeout and the number of
- * body bytes read.
- */
 // Default User-Agent for guarded GETs. Many public REST/JSON APIs (crypto
 // price, weather, news endpoints) reject undici's default `node` User-Agent - or
 // a missing one - with HTTP 403, which silently broke every WEB_FETCH live-info
@@ -693,10 +684,7 @@ async function performGuardedHttpRequest(
   return { ok: response.ok, status: response.status, text, blocked: false };
 }
 
-/**
- * SSRF-guarded, https-only, GET-only HTTP fetch shared by custom actions and the
- * built-in WEB_FETCH action.
- */
+/** SSRF-guarded https-only GET (custom actions + the built-in WEB_FETCH action). */
 export async function performGuardedHttpGet(
   url: string,
   opts: GuardedHttpGetOptions = {},

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4564,7 +4564,7 @@ export async function startEliza(
       );
       if (!isWebSearchEnabled()) {
         logger.info(
-          "[eliza] WEB_SEARCH action disabled via ELIZA_WEB_SEARCH=0|false|off",
+          "[eliza] WEB_SEARCH action disabled via ELIZA_INLINE_WEB_SEARCH=0|false|off",
         );
         return;
       }

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4537,42 +4537,30 @@ export async function startEliza(
 
   // Keyless inline live-info fetch for every runtime (not just Anthropic).
   // Opt out with ELIZA_WEB_FETCH=0|false|off, mirroring ELIZA_WEB_SEARCH.
-  const registerWebFetchActionIfEnabled = async (): Promise<void> => {
+  // Register an optional keyless inline web action (WEB_FETCH / WEB_SEARCH) when
+  // its env gate allows. One helper for both — they differ only in which module
+  // they load and which opt-out var they name.
+  const registerOptionalWebAction = async (cfg: {
+    load: () => Promise<{
+      action: Parameters<typeof runtime.registerAction>[0];
+      isEnabled: () => boolean;
+    }>;
+    label: string;
+    disabledVar: string;
+  }): Promise<void> => {
     try {
-      const { webFetch, isWebFetchEnabled } = await import(
-        "./actions/web-fetch.ts"
-      );
-      if (!isWebFetchEnabled()) {
+      const { action, isEnabled } = await cfg.load();
+      if (!isEnabled()) {
         logger.info(
-          "[eliza] WEB_FETCH action disabled via ELIZA_WEB_FETCH=0|false|off",
+          `[eliza] ${cfg.label} action disabled via ${cfg.disabledVar}=0|false|off`,
         );
         return;
       }
-      runtime.registerAction(webFetch);
-      logger.info("[eliza] Registered keyless WEB_FETCH action");
+      runtime.registerAction(action);
+      logger.info(`[eliza] Registered keyless ${cfg.label} action`);
     } catch (err) {
       logger.debug(
-        `[eliza] WEB_FETCH action registration skipped: ${formatError(err)}`,
-      );
-    }
-  };
-
-  const registerWebSearchActionIfEnabled = async (): Promise<void> => {
-    try {
-      const { webSearch, isWebSearchEnabled } = await import(
-        "./actions/web-search.ts"
-      );
-      if (!isWebSearchEnabled()) {
-        logger.info(
-          "[eliza] WEB_SEARCH action disabled via ELIZA_INLINE_WEB_SEARCH=0|false|off",
-        );
-        return;
-      }
-      runtime.registerAction(webSearch);
-      logger.info("[eliza] Registered keyless WEB_SEARCH action");
-    } catch (err) {
-      logger.debug(
-        `[eliza] WEB_SEARCH action registration skipped: ${formatError(err)}`,
+        `[eliza] ${cfg.label} action registration skipped: ${formatError(err)}`,
       );
     }
   };
@@ -4970,8 +4958,22 @@ export async function startEliza(
     await seedBundledDocumentsIfEnabled();
     await runStewardEvmPostBoot();
     await installServerSideWebSearchIfAvailable();
-    await registerWebFetchActionIfEnabled();
-    await registerWebSearchActionIfEnabled();
+    await registerOptionalWebAction({
+      load: async () => {
+        const m = await import("./actions/web-fetch.ts");
+        return { action: m.webFetch, isEnabled: m.isWebFetchEnabled };
+      },
+      label: "WEB_FETCH",
+      disabledVar: "ELIZA_WEB_FETCH",
+    });
+    await registerOptionalWebAction({
+      load: async () => {
+        const m = await import("./actions/web-search.ts");
+        return { action: m.webSearch, isEnabled: m.isWebSearchEnabled };
+      },
+      label: "WEB_SEARCH",
+      disabledVar: "ELIZA_INLINE_WEB_SEARCH",
+    });
     bootTimer.lap("deferred:post-init");
 
     const autonomyLoopEnabled = isAutonomyEnabled();

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7175,19 +7175,18 @@ function findDirectOwnedActionSuggestion(
 	messageText: string,
 ): ActionOwnershipSuggestion | null {
 	if (looksLikeLocalShellRequest(messageText)) {
-		const shellAction = findRuntimeActionByNames(runtime, [
+		const shellName = findAvailableActionName(runtime.actions ?? [], [
 			"SHELL",
 			"RUN_IN_TERMINAL",
 			"RUN_COMMAND",
 			"EXECUTE_COMMAND",
 			"TERMINAL",
-			"SHELL",
 			"RUN_SHELL",
 			"EXEC",
 		]);
-		if (shellAction) {
+		if (shellName) {
 			return {
-				actionName: shellAction.name,
+				actionName: shellName,
 				score: 100,
 				secondBestScore: 0,
 				reasons: ["direct:local-shell-check"],
@@ -7196,19 +7195,10 @@ function findDirectOwnedActionSuggestion(
 	}
 
 	if (looksLikeWebSearchRequest(messageText)) {
-		const searchAction = findRuntimeActionByNames(runtime, [
-			"SEARCH",
-			"WEB_SEARCH",
-			"SEARCH_WEB",
-			"BRAVE_SEARCH",
-			"INTERNET_SEARCH",
-			"SEARCH_INTERNET",
-			"LOOKUP_WEB",
-			"GOOGLE",
-		]);
-		if (searchAction) {
+		const searchName = findWebLookupActionName(runtime.actions ?? []);
+		if (searchName) {
 			return {
-				actionName: searchAction.name,
+				actionName: searchName,
 				score: 100,
 				secondBestScore: 0,
 				reasons: ["direct:web-search"],
@@ -7237,27 +7227,6 @@ function findDirectOwnedActionSuggestion(
 	}
 
 	return null;
-}
-
-function findRuntimeActionByNames(
-	runtime: Pick<IAgentRuntime, "actions">,
-	names: string[],
-): Action | undefined {
-	// Resolve in `names` PRIORITY order, not action-registration order, so the
-	// leading preference wins (mirrors findAvailableActionName in
-	// direct-action-heuristics.ts).
-	const actions = runtime.actions ?? [];
-	for (const want of names) {
-		const wanted = normalizeActionIdentifier(want);
-		const match = actions.find((action) => {
-			const candidates = [action.name, ...(action.similes ?? [])]
-				.filter((value): value is string => typeof value === "string")
-				.map(normalizeActionIdentifier);
-			return candidates.includes(wanted);
-		});
-		if (match) return match;
-	}
-	return undefined;
 }
 
 function looksLikeActionExplanationRequest(text: string): boolean {


### PR DESCRIPTION
Post-merge cleanup of two rough edges in the inline `WEB_SEARCH` action (#9280), found in an honest self-audit:

1. **Gate collision** — the inline action gated on `ELIZA_WEB_SEARCH`, the **same** env var `web-search-tools.ts` already owns for the server-side provider-native web_search. So disabling one silently disabled the other, and on an Anthropic/Google/OpenAI runtime both web-search surfaces could go live at once. The inline action now has its own **`ELIZA_INLINE_WEB_SEARCH`** gate — independently switchable.

2. **Duplicated SSRF guard** — `performGuardedHttpPost` was a ~50-line near-verbatim copy of `performGuardedHttpGet` (same URL/scheme parse, `resolveUrlSafety`, pinned-fetch branch, redirect rejection, body cap). A future SSRF fix would have to be made twice — a real footgun on security code. Collapsed both onto one private `performGuardedHttpRequest` core; `performGuardedHttpGet`/`performGuardedHttpPost` stay as thin public wrappers. Behavior identical.

Net -24 lines. Tests 19/19 green (web-search + web-fetch). Verified live on the self-hosted bot (web-search still answers inline across backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)