### PR TITLE
fix(cloud-shared): remove analytics overview stubs

### DIFF
--- a/packages/cloud-shared/src/lib/services/analytics.ts
+++ b/packages/cloud-shared/src/lib/services/analytics.ts
@@ -262,8 +262,6 @@ export class AnalyticsService {
             successRate: summary.successRate,
             avgCostPerRequest:
               summary.totalRequests > 0 ? summary.totalCost / summary.totalRequests : 0,
-            avgLatency: 0,
-            activeApiKeys: 0,
           },
           trends: {
             requestsChange: trends.requestsChange,
@@ -330,8 +328,6 @@ export class AnalyticsService {
           successRate: summary.successRate,
           avgCostPerRequest:
             summary.totalRequests > 0 ? summary.totalCost / summary.totalRequests : 0,
-          avgLatency: 0,
-          activeApiKeys: 0,
         },
         trends: {
           requestsChange: trends.requestsChange,


### PR DESCRIPTION
## Summary
- removes the unused `avgLatency` and `activeApiKeys` zero-stub fields from both `AnalyticsService.getOverview()` return paths
- keeps the existing computed overview summary fields unchanged

## Issue
- Fixes #9325

## Evidence
- `bun run --cwd packages/cloud-shared typecheck`
- `bun run --cwd packages/cloud-shared test` (1590 pass, 27 skip)
- `bunx @biomejs/biome check packages/cloud-shared/src/lib/services/analytics.ts`
- `git diff --check`
- `bun install`
- `bun run verify` (509 successful, 509 total)

## Notes
- No UI change; screenshots/video N/A.
- Real-LLM trajectories N/A; this is not an agent/action/prompt/model behavior change.
