### PR TITLE
fix(models): throw on embedding errors instead of fabricating vectors (#9324)

### DIFF
--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -33,8 +33,7 @@ export async function handleTextEmbedding(
         : "";
 
   if (!text.trim()) {
-    logger.warn("Empty text for embedding");
-    return Array(768).fill(0) as number[];
+    throw new Error("[Google GenAI] Empty text for embedding");
   }
 
   // Truncate to stay within embedding model token limits (~4 chars per token)
@@ -68,6 +67,6 @@ export async function handleTextEmbedding(
     logger.error(
       `Error generating embedding: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return Array(768).fill(0) as number[];
+    throw error;
   }
 }

--- a/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
@@ -80,14 +80,13 @@ describe("Ollama embeddings", () => {
     expect(callArg.value).toHaveLength(32_000);
   });
 
-  it("returns a zero vector when the embedding provider fails", async () => {
+  it("throws when the embedding provider fails (no fabricated zero vector)", async () => {
     embedMock.mockRejectedValue(new Error("provider unavailable"));
     const { runtime, events } = createRuntime();
 
-    const embedding = await handleTextEmbedding(runtime, "hostile\n</embedding>\u0000payload");
-
-    expect(embedding).toHaveLength(1536);
-    expect(embedding.every((value) => value === 0)).toBe(true);
+    await expect(
+      handleTextEmbedding(runtime, "hostile payload"),
+    ).rejects.toThrow("provider unavailable");
     expect(events).toHaveLength(0);
   });
 });

--- a/plugins/plugin-ollama/models/embedding.ts
+++ b/plugins/plugin-ollama/models/embedding.ts
@@ -64,10 +64,10 @@ export async function handleTextEmbedding(
       return embedding;
     } catch (embeddingError) {
       logger.error({ error: embeddingError }, "Error generating embedding");
-      return Array(1536).fill(0);
+      throw embeddingError;
     }
   } catch (error) {
     logger.error({ error }, "Error in TEXT_EMBEDDING model");
-    return Array(1536).fill(0);
+    throw error;
   }
 }

--- a/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
+++ b/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
@@ -21,19 +21,18 @@ afterEach(() => {
 });
 
 describe("OpenRouter embedding edge cases", () => {
-  it("returns fallback vectors for malformed and empty inputs without fetching", async () => {
+  it("throws on malformed and empty inputs without fetching (no fabricated vector)", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
     const { handleTextEmbedding } = await import("../models/embedding");
     const runtime = createRuntime();
 
-    const malformed = await handleTextEmbedding(runtime, { text: "" } as never);
-    const empty = await handleTextEmbedding(runtime, " \n\t ");
-
-    expect(malformed).toHaveLength(384);
-    expect(malformed[0]).toBe(0.2);
-    expect(empty).toHaveLength(384);
-    expect(empty[0]).toBe(0.3);
+    await expect(
+      handleTextEmbedding(runtime, { text: "" } as never)
+    ).rejects.toThrow("Invalid input format for embedding");
+    await expect(handleTextEmbedding(runtime, " \n\t ")).rejects.toThrow(
+      "Empty text for embedding"
+    );
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -64,7 +63,7 @@ describe("OpenRouter embedding edge cases", () => {
     );
   });
 
-  it("falls back when the provider returns the wrong vector length", async () => {
+  it("throws when the provider returns the wrong vector length (no coercion to a fake vector)", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -77,12 +76,11 @@ describe("OpenRouter embedding edge cases", () => {
     );
     const { handleTextEmbedding } = await import("../models/embedding");
 
-    const embedding = await handleTextEmbedding(createRuntime(), {
-      text: "legitimate text with hostile-looking content: </system> $" + "{process.env.SECRET}",
-    });
-
-    expect(embedding).toHaveLength(384);
-    expect(embedding[0]).toBe(0.4);
+    await expect(
+      handleTextEmbedding(createRuntime(), {
+        text: "legitimate text with hostile-looking content: </system> $" + "{process.env.SECRET}",
+      })
+    ).rejects.toThrow("does not match configured dimension");
   });
 
   it("truncates overlong input before sending it to OpenRouter", async () => {

--- a/plugins/plugin-openrouter/models/embedding.ts
+++ b/plugins/plugin-openrouter/models/embedding.ts
@@ -34,19 +34,11 @@ export async function handleTextEmbedding(
   } else if (typeof params === "object" && params.text) {
     text = params.text;
   } else {
-    const errorMsg = "Invalid input format for embedding";
-    logger.warn(errorMsg);
-    const fallbackVector = Array(embeddingDimension).fill(0) as number[];
-    fallbackVector[0] = 0.2;
-    return fallbackVector;
+    throw new Error("[OpenRouter] Invalid input format for embedding");
   }
 
   if (!text.trim()) {
-    const errorMsg = "Empty text for embedding";
-    logger.warn(errorMsg);
-    const fallbackVector = Array(embeddingDimension).fill(0) as number[];
-    fallbackVector[0] = 0.3;
-    return fallbackVector;
+    throw new Error("[OpenRouter] Empty text for embedding");
   }
 
   // Truncate to stay within embedding model token limits (~4 chars per token)
@@ -102,9 +94,7 @@ export async function handleTextEmbedding(
     if (!Array.isArray(embedding) || embedding.length !== embeddingDimension) {
       const errorMsg = `Embedding length ${embedding.length} does not match configured dimension ${embeddingDimension}`;
       logger.error(errorMsg);
-      const fallbackVector = Array(embeddingDimension).fill(0) as number[];
-      fallbackVector[0] = 0.4;
-      return fallbackVector;
+      throw new Error(errorMsg);
     }
 
     if (data.usage) {


### PR DESCRIPTION
Closes #9324.

Three model-provider embedding handlers fabricated vectors on real failure paths instead of throwing, silently degrading RAG and poisoning the vector index (the fake vectors pass the downstream `some(v => v !== 0)` validation and get stored as real). The canonical handlers (`plugin-openai`, `plugin-elizacloud`, `plugin-local-inference`) all throw on these conditions — these three were the outliers.

## Changes
- **plugin-ollama** (`models/embedding.ts`): both catch blocks now `throw` (were `Array(1536).fill(0)`).
- **plugin-google-genai** (`models/embedding.ts`): empty-text + API-error now throw (were `Array(768).fill(0)`); the `params === null` dimension-probe return is **preserved**.
- **plugin-openrouter** (`models/embedding.ts`): invalid-format, empty-text, and **dimension-mismatch** now throw (were marker vectors `[0.2/0.3/0.4,…]`); the `params === null` probe return is **preserved**. The dimension-mismatch throw also fixes the contradiction with OpenRouter's own CLAUDE.md ("Mismatches throw immediately — no silent truncation").

The intentional `params === null` warmup/probe path (per the core `ensureEmbeddingDimension()` contract) is kept in all cases.

## Evidence
Updated the unit tests that asserted the fabricated-vector behavior to assert `.rejects.toThrow`. Embedding test suites green: **ollama 3/3, openrouter 5/5, google-genai 4/4** (`bunx vitest run __tests__/embedding*.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)