### PR TITLE
fix(cloud-shared): drop unavailable analytics overview fields

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/analytics-overview.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/analytics-overview.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const stats = {
+  totalRequests: 4,
+  totalInputTokens: 120,
+  totalOutputTokens: 80,
+  totalCost: 2,
+  successRate: 0.75,
+};
+
+const timeSeries = [
+  {
+    timestamp: new Date("2026-06-24T00:00:00.000Z"),
+    totalRequests: 4,
+    totalCost: 2,
+    inputTokens: 120,
+    outputTokens: 80,
+    successRate: 0.75,
+  },
+];
+
+const providerBreakdown = [
+  {
+    provider: "openai",
+    totalRequests: 4,
+    totalCost: 2,
+    totalTokens: 200,
+    successRate: 0.75,
+    percentage: 100,
+  },
+];
+
+const modelBreakdown = [
+  {
+    model: "gpt-4.1-mini",
+    provider: "openai",
+    totalRequests: 4,
+    totalCost: 2,
+    totalTokens: 200,
+    avgCostPerToken: 0.01,
+    successRate: 0.75,
+  },
+];
+
+const trends = {
+  requestsChange: 10,
+  costChange: 20,
+  tokensChange: 30,
+  successRateChange: 40,
+  period: "7d",
+};
+
+const getStatsByOrganization = mock(async () => stats);
+const getUsageTimeSeries = mock(async () => timeSeries);
+const getProviderBreakdown = mock(async () => providerBreakdown);
+const getModelBreakdown = mock(async () => modelBreakdown);
+const getTrendData = mock(async () => trends);
+const getWithSWR = mock(async (_key: string, _ttl: number, load: () => Promise<unknown>) => load());
+
+mock.module("../../../db/repositories/usage-records", () => ({
+  usageRecordsRepository: {
+    getStatsByOrganization,
+    getUsageTimeSeries,
+    getProviderBreakdown,
+    getModelBreakdown,
+    getTrendData,
+  },
+}));
+
+mock.module("../../cache/client", () => ({
+  cache: {
+    getWithSWR,
+  },
+}));
+
+import { analyticsService } from "../analytics";
+
+function resetMocks() {
+  getStatsByOrganization.mockReset();
+  getUsageTimeSeries.mockReset();
+  getProviderBreakdown.mockReset();
+  getModelBreakdown.mockReset();
+  getTrendData.mockReset();
+  getWithSWR.mockReset();
+
+  getStatsByOrganization.mockResolvedValue(stats);
+  getUsageTimeSeries.mockResolvedValue(timeSeries);
+  getProviderBreakdown.mockResolvedValue(providerBreakdown);
+  getModelBreakdown.mockResolvedValue(modelBreakdown);
+  getTrendData.mockResolvedValue(trends);
+  getWithSWR.mockImplementation(async (_key: string, _ttl: number, load: () => Promise<unknown>) =>
+    load(),
+  );
+}
+
+const expectedSummary = {
+  totalRequests: 4,
+  totalCost: 2,
+  totalTokens: 200,
+  successRate: 0.75,
+  avgCostPerRequest: 0.5,
+};
+
+describe("AnalyticsService.getOverview", () => {
+  beforeEach(resetMocks);
+
+  test("returns only derived summary metrics from the cached loader path", async () => {
+    const overview = await analyticsService.getOverview("org-1", "weekly");
+
+    expect(overview.summary).toEqual(expectedSummary);
+    expect("avgLatency" in overview.summary).toBe(false);
+    expect("activeApiKeys" in overview.summary).toBe(false);
+    expect(getWithSWR).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns the same summary contract when the cache lookup misses", async () => {
+    getWithSWR.mockResolvedValueOnce(null);
+
+    const overview = await analyticsService.getOverview("org-1", "weekly");
+
+    expect(overview.summary).toEqual(expectedSummary);
+    expect("avgLatency" in overview.summary).toBe(false);
+    expect("activeApiKeys" in overview.summary).toBe(false);
+    expect(getStatsByOrganization).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/analytics.ts
+++ b/packages/cloud-shared/src/lib/services/analytics.ts
@@ -262,8 +262,6 @@ export class AnalyticsService {
             successRate: summary.successRate,
             avgCostPerRequest:
               summary.totalRequests > 0 ? summary.totalCost / summary.totalRequests : 0,
-            avgLatency: 0,
-            activeApiKeys: 0,
           },
           trends: {
             requestsChange: trends.requestsChange,
@@ -330,8 +328,6 @@ export class AnalyticsService {
           successRate: summary.successRate,
           avgCostPerRequest:
             summary.totalRequests > 0 ? summary.totalCost / summary.totalRequests : 0,
-          avgLatency: 0,
-          activeApiKeys: 0,
         },
         trends: {
           requestsChange: trends.requestsChange,


### PR DESCRIPTION
## Summary
- Remove the hardcoded `avgLatency: 0` and `activeApiKeys: 0` fields from both `AnalyticsService.getOverview()` summary paths.
- Add a focused regression test that exercises the cached-loader path and the cache-miss fallback path, asserting the overview summary only exposes derived metrics backed by usage records.

Fixes #9325.

## Evidence
- `git fetch origin && git rebase origin/develop` — branch already up to date.
- `bun install` — completed; no dependency changes. This fresh install required the normal build bootstrap before Bun package tests could resolve built workspace exports.
- `bun run build:core` — passed, generated the workspace dist artifacts used by Bun tests.
- `bun run --cwd packages/cloud-shared typecheck` — passed.
- `bun run --cwd packages/cloud-shared lint` — passed, 1148 files checked.
- `bun run --cwd packages/cloud-shared test src/lib/services/__tests__/analytics-overview.test.ts` — passed, 2 tests / 8 assertions.
- `bun run --cwd packages/cloud-shared test` — passed, 1592 passed / 27 skipped / 0 failed.
- `git diff --check` — passed.
