### PR TITLE
fix(providers): throw on embedding failures

### DIFF
--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -1,0 +1,115 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  countTokens: vi.fn(),
+  createGoogleGenAI: vi.fn(),
+  embedContent: vi.fn(),
+  emitModelUsageEvent: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  },
+  ModelType: {
+    TEXT_EMBEDDING: "TEXT_EMBEDDING",
+  },
+}));
+
+vi.mock("../utils/config", () => ({
+  createGoogleGenAI: mocks.createGoogleGenAI,
+  getEmbeddingModel: vi.fn(() => "text-embedding-004"),
+}));
+
+vi.mock("../utils/events", () => ({
+  emitModelUsageEvent: mocks.emitModelUsageEvent,
+}));
+
+vi.mock("../utils/tokenization", () => ({
+  countTokens: mocks.countTokens,
+}));
+
+import { handleTextEmbedding } from "../models/embedding";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+describe("Google GenAI embeddings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.countTokens.mockResolvedValue(5);
+    mocks.embedContent.mockResolvedValue({
+      embeddings: [{ values: [0.1, 0.2, 0.3] }],
+    });
+    mocks.createGoogleGenAI.mockReturnValue({
+      models: {
+        embedContent: mocks.embedContent,
+      },
+    });
+  });
+
+  it("returns a marker vector for null initialization probes without creating a client", async () => {
+    const embedding = await handleTextEmbedding(createRuntime(), null);
+
+    expect(embedding).toHaveLength(768);
+    expect(embedding[0]).toBe(0.1);
+    expect(embedding.slice(1).every((value) => value === 0)).toBe(true);
+    expect(mocks.createGoogleGenAI).not.toHaveBeenCalled();
+    expect(mocks.embedContent).not.toHaveBeenCalled();
+  });
+
+  it("embeds non-empty input and emits usage", async () => {
+    const runtime = createRuntime();
+
+    const embedding = await handleTextEmbedding(runtime, "hello");
+
+    expect(embedding).toEqual([0.1, 0.2, 0.3]);
+    expect(mocks.embedContent).toHaveBeenCalledWith({
+      model: "text-embedding-004",
+      contents: "hello",
+    });
+    expect(mocks.emitModelUsageEvent).toHaveBeenCalledWith(
+      runtime,
+      "TEXT_EMBEDDING",
+      "hello",
+      {
+        promptTokens: 5,
+        completionTokens: 0,
+        totalTokens: 5,
+      },
+    );
+  });
+
+  it("throws for empty embedding input before creating a client", async () => {
+    await expect(
+      handleTextEmbedding(createRuntime(), { text: " \n\t " }),
+    ).rejects.toThrow("Cannot generate embedding for empty text");
+
+    expect(mocks.createGoogleGenAI).not.toHaveBeenCalled();
+    expect(mocks.embedContent).not.toHaveBeenCalled();
+  });
+
+  it("throws when the embedding API fails", async () => {
+    mocks.embedContent.mockRejectedValue(new Error("provider unavailable"));
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "provider unavailable",
+    );
+  });
+
+  it("throws when the embedding API returns no vector", async () => {
+    mocks.embedContent.mockResolvedValue({ embeddings: [] });
+
+    await expect(handleTextEmbedding(createRuntime(), "hello")).rejects.toThrow(
+      "Google GenAI API returned no embedding",
+    );
+  });
+});

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -9,10 +9,46 @@ const TEXT_EMBEDDING_MODEL_TYPE = ((
   ElizaCore as { ModelType?: Record<string, string> }
 ).ModelType?.TEXT_EMBEDDING ?? "TEXT_EMBEDDING") as string;
 
+function createInitProbeVector(): number[] {
+  const vector = Array(768).fill(0);
+  vector[0] = 0.1;
+  return vector;
+}
+
+function extractText(
+  params: TextEmbeddingParams | string | null,
+): string | null {
+  if (params === null) {
+    return null;
+  }
+  if (typeof params === "string") {
+    return params;
+  }
+  if (typeof params === "object" && typeof params.text === "string") {
+    return params.text;
+  }
+  throw new Error(
+    "Invalid input format for embedding: expected string or { text: string }",
+  );
+}
+
 export async function handleTextEmbedding(
   runtime: IAgentRuntime,
   params: TextEmbeddingParams | string | null,
 ): Promise<number[]> {
+  if (params === null) {
+    return createInitProbeVector();
+  }
+
+  let text = extractText(params);
+  if (text === null) {
+    return createInitProbeVector();
+  }
+
+  if (!text.trim()) {
+    throw new Error("Cannot generate embedding for empty text");
+  }
+
   const genAI = createGoogleGenAI(runtime);
   if (!genAI) {
     throw new Error("Google Generative AI client not initialized");
@@ -20,21 +56,6 @@ export async function handleTextEmbedding(
 
   const embeddingModelName = getEmbeddingModel(runtime);
   logger.debug(`[TEXT_EMBEDDING] Using model: ${embeddingModelName}`);
-
-  if (params === null) {
-    return Array(768).fill(0) as number[];
-  }
-
-  let text =
-    typeof params === "string"
-      ? params
-      : typeof params === "object" && params.text
-        ? params.text
-        : "";
-
-  if (!text.trim()) {
-    throw new Error("[Google GenAI] Empty text for embedding");
-  }
 
   // Truncate to stay within embedding model token limits (~4 chars per token)
   const maxChars = 8_192 * 4;
@@ -52,6 +73,9 @@ export async function handleTextEmbedding(
     });
 
     const embedding = response.embeddings?.[0]?.values || [];
+    if (embedding.length === 0) {
+      throw new Error("Google GenAI API returned no embedding");
+    }
 
     const promptTokens = await countTokens(text);
 
@@ -67,6 +91,6 @@ export async function handleTextEmbedding(
     logger.error(
       `Error generating embedding: ${error instanceof Error ? error.message : String(error)}`,
     );
-    throw error;
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }

--- a/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
@@ -39,19 +39,31 @@ describe("Ollama embeddings", () => {
     embedMock.mockReset();
   });
 
-  it("uses a non-empty sentinel for null input and emits usage", async () => {
+  it("returns a marker vector for null initialization probes without calling the provider", async () => {
+    const { runtime, events } = createRuntime({ OLLAMA_EMBEDDING_MODEL: " embed-model " });
+
+    const embedding = await handleTextEmbedding(runtime, null);
+
+    expect(embedding).toHaveLength(1536);
+    expect(embedding[0]).toBe(0.1);
+    expect(embedding.slice(1).every((value) => value === 0)).toBe(true);
+    expect(embedMock).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+  });
+
+  it("embeds non-empty input and emits usage", async () => {
     embedMock.mockResolvedValue({
       embedding: [0.1, 0.2, 0.3],
       usage: { inputTokens: 2 },
     });
     const { runtime, events } = createRuntime({ OLLAMA_EMBEDDING_MODEL: " embed-model " });
 
-    const embedding = await handleTextEmbedding(runtime, null);
+    const embedding = await handleTextEmbedding(runtime, "hello");
 
     expect(embedding).toEqual([0.1, 0.2, 0.3]);
     expect(embedMock).toHaveBeenCalledWith({
       model: { model: "embed-model" },
-      value: "test",
+      value: "hello",
     });
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
@@ -80,13 +92,24 @@ describe("Ollama embeddings", () => {
     expect(callArg.value).toHaveLength(32_000);
   });
 
-  it("throws when the embedding provider fails (no fabricated zero vector)", async () => {
+  it("throws when the embedding provider fails", async () => {
     embedMock.mockRejectedValue(new Error("provider unavailable"));
     const { runtime, events } = createRuntime();
 
-    await expect(handleTextEmbedding(runtime, "hostile payload")).rejects.toThrow(
-      "provider unavailable"
-    );
+    await expect(
+      handleTextEmbedding(runtime, "hostile\n</embedding>\u0000payload")
+    ).rejects.toThrow("provider unavailable");
+
     expect(events).toHaveLength(0);
+  });
+
+  it("throws for empty embedding input before calling the provider", async () => {
+    const { runtime } = createRuntime();
+
+    await expect(handleTextEmbedding(runtime, " \n\t ")).rejects.toThrow(
+      "Cannot generate embedding for empty text"
+    );
+
+    expect(embedMock).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-ollama/models/embedding.ts
+++ b/plugins/plugin-ollama/models/embedding.ts
@@ -14,10 +14,39 @@ import { getBaseURL, getEmbeddingModel } from "../utils/config";
 import { emitModelUsed, estimateEmbeddingUsage, normalizeTokenUsage } from "../utils/modelUsage";
 import { ensureModelAvailable } from "./availability";
 
+function createInitProbeVector(): number[] {
+  const vector = Array(1536).fill(0);
+  vector[0] = 0.1;
+  return vector;
+}
+
+function extractText(params: TextEmbeddingParams | string | null): string | null {
+  if (params === null) {
+    return null;
+  }
+  if (typeof params === "string") {
+    return params;
+  }
+  if (typeof params === "object" && typeof params.text === "string") {
+    return params.text;
+  }
+  throw new Error("Invalid input format for embedding: expected string or { text: string }");
+}
+
 export async function handleTextEmbedding(
   runtime: IAgentRuntime,
   params: TextEmbeddingParams | string | null
 ): Promise<number[]> {
+  const text = extractText(params);
+  if (text === null) {
+    logger.debug("[Ollama] Creating test embedding for initialization");
+    return createInitProbeVector();
+  }
+
+  if (!text.trim()) {
+    throw new Error("Cannot generate embedding for empty text");
+  }
+
   try {
     const baseURL = getBaseURL(runtime);
     const customFetch = runtime.fetch ?? undefined;
@@ -30,44 +59,31 @@ export async function handleTextEmbedding(
     logger.log(`[Ollama] Using TEXT_EMBEDDING model: ${modelName}`);
     await ensureModelAvailable(modelName, baseURL, customFetch);
 
-    let text =
-      typeof params === "string"
-        ? params
-        : params
-          ? (params as TextEmbeddingParams).text || ""
-          : "";
-
     // Truncate to stay within embedding model token limits (~4 chars per token)
     const maxChars = 8_000 * 4;
+    let embeddingText = text;
     if (text.length > maxChars) {
       logger.warn(
         `[Ollama] Embedding input too long (~${Math.ceil(text.length / 4)} tokens), truncating to ~8000 tokens`
       );
-      text = text.slice(0, maxChars);
+      embeddingText = text.slice(0, maxChars);
     }
 
-    const embeddingText = text || "test";
+    const embedParams = {
+      model: ollama.embedding(modelName) as EmbeddingModel,
+      value: embeddingText,
+    };
 
-    try {
-      const embedParams = {
-        model: ollama.embedding(modelName) as EmbeddingModel,
-        value: embeddingText,
-      };
-
-      const { embedding, usage } = await embed(embedParams);
-      emitModelUsed(
-        runtime,
-        ModelType.TEXT_EMBEDDING,
-        modelName,
-        normalizeTokenUsage(usage) ?? estimateEmbeddingUsage(embeddingText)
-      );
-      return embedding;
-    } catch (embeddingError) {
-      logger.error({ error: embeddingError }, "Error generating embedding");
-      throw embeddingError;
-    }
+    const { embedding, usage } = await embed(embedParams);
+    emitModelUsed(
+      runtime,
+      ModelType.TEXT_EMBEDDING,
+      modelName,
+      normalizeTokenUsage(usage) ?? estimateEmbeddingUsage(embeddingText)
+    );
+    return embedding;
   } catch (error) {
     logger.error({ error }, "Error in TEXT_EMBEDDING model");
-    throw error;
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }

--- a/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
+++ b/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
@@ -21,18 +21,35 @@ afterEach(() => {
 });
 
 describe("OpenRouter embedding edge cases", () => {
-  it("throws on malformed and empty inputs without fetching (no fabricated vector)", async () => {
+  it("returns a marker vector for null initialization probes without fetching", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { handleTextEmbedding } = await import("../models/embedding");
+
+    const embedding = await handleTextEmbedding(createRuntime(), null);
+
+    expect(embedding).toHaveLength(384);
+    expect(embedding[0]).toBe(0.1);
+    expect(embedding.slice(1).every((value) => value === 0)).toBe(true);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws for malformed and empty inputs without fetching", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
     const { handleTextEmbedding } = await import("../models/embedding");
     const runtime = createRuntime();
 
-    await expect(handleTextEmbedding(runtime, { text: "" } as never)).rejects.toThrow(
+    await expect(handleTextEmbedding(runtime, {} as never)).rejects.toThrow(
       "Invalid input format for embedding"
+    );
+    await expect(handleTextEmbedding(runtime, { text: "" })).rejects.toThrow(
+      "Empty text for embedding"
     );
     await expect(handleTextEmbedding(runtime, " \n\t ")).rejects.toThrow(
       "Empty text for embedding"
     );
+
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -63,7 +80,7 @@ describe("OpenRouter embedding edge cases", () => {
     );
   });
 
-  it("throws when the provider returns the wrong vector length (no coercion to a fake vector)", async () => {
+  it("throws when the provider returns the wrong vector length", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -80,7 +97,7 @@ describe("OpenRouter embedding edge cases", () => {
       handleTextEmbedding(createRuntime(), {
         text: "legitimate text with hostile-looking content: </system> $" + "{process.env.SECRET}",
       })
-    ).rejects.toThrow("does not match configured dimension");
+    ).rejects.toThrow("Embedding length 3 does not match configured dimension 384");
   });
 
   it("truncates overlong input before sending it to OpenRouter", async () => {

--- a/plugins/plugin-openrouter/models/embedding.ts
+++ b/plugins/plugin-openrouter/models/embedding.ts
@@ -31,14 +31,18 @@ export async function handleTextEmbedding(
   let text: string;
   if (typeof params === "string") {
     text = params;
-  } else if (typeof params === "object" && params.text) {
+  } else if (typeof params === "object" && typeof params.text === "string") {
     text = params.text;
   } else {
-    throw new Error("[OpenRouter] Invalid input format for embedding");
+    const errorMsg = "Invalid input format for embedding";
+    logger.error(errorMsg);
+    throw new Error(errorMsg);
   }
 
   if (!text.trim()) {
-    throw new Error("[OpenRouter] Empty text for embedding");
+    const errorMsg = "Empty text for embedding";
+    logger.error(errorMsg);
+    throw new Error(errorMsg);
   }
 
   // Truncate to stay within embedding model token limits (~4 chars per token)


### PR DESCRIPTION
## Summary
- keeps `params === null` embedding init probes as marker vectors, but removes fabricated vectors from real error paths
- makes Ollama, Google GenAI, and OpenRouter throw on invalid/empty input, provider/API failures, and OpenRouter dimension mismatches
- updates/expands embedding tests for all three providers

## Issue
Fixes #9324

## Evidence
- `bun run --cwd plugins/plugin-ollama test __tests__/embedding.shape.test.ts`
- `bun run --cwd plugins/plugin-google-genai test __tests__/embedding.shape.test.ts`
- `bun run --cwd plugins/plugin-openrouter test __tests__/embedding.edge.test.ts`
- `bun run --cwd plugins/plugin-ollama typecheck`
- `bun run --cwd plugins/plugin-google-genai typecheck`
- `bun run --cwd plugins/plugin-openrouter typecheck`
- `bunx @biomejs/biome check plugins/plugin-ollama/models/embedding.ts plugins/plugin-ollama/__tests__/embedding.shape.test.ts plugins/plugin-google-genai/models/embedding.ts plugins/plugin-google-genai/__tests__/embedding.shape.test.ts plugins/plugin-openrouter/models/embedding.ts plugins/plugin-openrouter/__tests__/embedding.edge.test.ts`
- `bun run --cwd plugins/plugin-ollama test` (28 pass, 5 skip)
- `bun run --cwd plugins/plugin-google-genai test` (13 pass, 1 skip)
- `bun run --cwd plugins/plugin-openrouter test` (27 pass)
- `bun run --cwd plugins/plugin-ollama build`
- `bun run --cwd plugins/plugin-google-genai build`
- `bun run --cwd plugins/plugin-openrouter build`
- `git diff --check`
- `bun install`
- `bun run verify` (509 successful, 509 total)

## Notes
- No UI change; screenshots/video N/A.
- Real-LLM trajectories N/A; provider error handling only, covered by deterministic unit tests.
