### PR TITLE
fix(cloud): surface asset-generation failures in app-promote (#9323)

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-promote.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// --- collaborator doubles (hoisted so vi.mock factories can close over them) ---
+const apiMock = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return { ...actual, api: (...args: unknown[]) => apiMock(...args) };
+});
+vi.mock("react-router-dom", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  // t() returns the provided defaultValue so assertions read real copy.
+  useCloudT: () => (_k: string, o?: { defaultValue?: string }) =>
+    o?.defaultValue ?? _k,
+}));
+vi.mock("../../../cloud-ui/components/promotion/promote-app-dialog", () => ({
+  PromoteAppDialog: () => null,
+}));
+
+import { ApiError } from "../../lib/api-client";
+import { AppPromote } from "./app-promote";
+
+const app = { id: "app_1", name: "Test App" } as never;
+
+afterEach(() => {
+  cleanup();
+  apiMock.mockReset();
+});
+
+describe("AppPromote — asset generation error surfacing (#9323)", () => {
+  it("surfaces the error (no silent swallow) when /promote/assets fails", async () => {
+    // Initial load (promote + advertising/accounts) resolves; the assets POST rejects.
+    apiMock.mockImplementation((path: string, opts?: { method?: string }) => {
+      if (opts?.method === "POST" && path.endsWith("/promote/assets")) {
+        return Promise.reject(
+          new ApiError(
+            402,
+            "INSUFFICIENT_CREDITS",
+            "Insufficient credits to generate assets",
+          ),
+        );
+      }
+      if (path.endsWith("/advertising/accounts")) {
+        return Promise.resolve({ accounts: [] });
+      }
+      // /api/v1/apps/:id/promote -> PromotionSuggestions
+      return Promise.resolve({
+        recommendedChannels: [],
+        estimatedBudget: { min: 0, max: 0 },
+        suggestedPlatforms: [],
+        tips: [],
+      });
+    });
+
+    render(<AppPromote app={app} />);
+
+    const button = await screen.findByRole("button", {
+      name: /Generate Assets/i,
+    });
+    await userEvent.click(button);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "Insufficient credits to generate assets",
+    );
+  });
+
+  it("does not show an error on a successful generation", async () => {
+    apiMock.mockResolvedValue({
+      recommendedChannels: [],
+      estimatedBudget: { min: 0, max: 0 },
+      suggestedPlatforms: [],
+      tips: [],
+      accounts: [],
+    });
+    render(<AppPromote app={app} />);
+    const button = await screen.findByRole("button", {
+      name: /Generate Assets/i,
+    });
+    await userEvent.click(button);
+    await waitFor(() => expect(apiMock).toHaveBeenCalled());
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -20,7 +20,7 @@ import { Link } from "react-router-dom";
 import { PromoteAppDialog } from "../../../cloud-ui/components/promotion/promote-app-dialog";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
-import { api } from "../../lib/api-client";
+import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { App } from "../lib/apps";
 
@@ -50,6 +50,7 @@ export function AppPromote({ app }: AppPromoteProps) {
   const [adAccounts, setAdAccounts] = useState<AdAccount[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isGeneratingAssets, setIsGeneratingAssets] = useState(false);
+  const [assetError, setAssetError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -75,14 +76,24 @@ export function AppPromote({ app }: AppPromoteProps) {
 
   const handleGenerateAssets = async () => {
     setIsGeneratingAssets(true);
+    setAssetError(null);
     try {
       await api(`/api/v1/apps/${app.id}/promote/assets`, {
         method: "POST",
         json: { includeCopy: true, includeAdBanners: true },
       });
       await fetchData();
-    } catch {
-      // Asset generation is best-effort; the suggestions/accounts panels stay.
+    } catch (err) {
+      // The backend treats this as critical enough to refund credits on
+      // failure (e.g. 402 Insufficient Credits / 500), so surface the error
+      // instead of silently clearing the spinner and implying success.
+      setAssetError(
+        err instanceof ApiError || err instanceof Error
+          ? err.message
+          : t("cloud.appPromote.generateError", {
+              defaultValue: "Asset generation failed. Please try again.",
+            }),
+      );
     } finally {
       setIsGeneratingAssets(false);
     }
@@ -149,6 +160,11 @@ export function AppPromote({ app }: AppPromoteProps) {
           </Button>
         </div>
       </div>
+      {assetError && (
+        <p className="text-sm text-red-400" role="alert">
+          {assetError}
+        </p>
+      )}
 
       {/* Suggestions */}
       {suggestions && (


### PR DESCRIPTION
Closes #9323.

`handleGenerateAssets` (`packages/ui/src/cloud/applications/components/app-promote.tsx`) swallowed any failure in an empty `catch {}` and cleared the spinner in `finally`, giving a false impression of success. But the backend route (`promote/assets/route.ts`) treats this as critical enough to **refund credits on failure** (402 Insufficient Credits / 500) — it is not a documented best-effort contract. The user couldn't tell whether assets generated or whether they lost credits to a server error.

## Fix
- Surface the failure via an `assetError` state rendered as a `text-red-400` `role="alert"` message (the existing `withdraw-dialog` error pattern in the same component family), cleared at the start of each attempt.
- Uses the structured `ApiError.message` when available, with an i18n fallback.

## Evidence
Added `app-promote.test.tsx` (jsdom + testing-library): the error message appears on a 402 from `/promote/assets`, and **no** error shows on success. **2/2 pass** (`bunx vitest run app-promote.test.tsx`). biome clean.

Note: this is a failure-path-only behavior change (an error message that renders only when generation fails) — it does not alter the resting/hover UI, so it's verified at the unit layer (the cheapest layer that catches the bug, per `packages/ui` testing guidance) rather than the full `audit:cloud` screenshot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)