### PR TITLE
fix(ui): surface asset generation failures

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-promote.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { toast } from "sonner";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "../../lib/api-client";
+import { CloudI18nProvider } from "../../shell/CloudI18nProvider";
+import type { App } from "../lib/apps";
+import { AppPromote } from "./app-promote";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../cloud-ui/components/promotion/promote-app-dialog", () => ({
+  PromoteAppDialog: () => null,
+}));
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return {
+    ...actual,
+    api: vi.fn(),
+  };
+});
+
+const app = {
+  id: "app-1",
+  name: "LaunchPad",
+} as App;
+
+const suggestions = {
+  recommendedChannels: ["social"],
+  estimatedBudget: { min: 10, max: 25 },
+  suggestedPlatforms: ["x"],
+  tips: ["Post launch clips"],
+};
+
+function renderPromote() {
+  render(
+    <MemoryRouter>
+      <CloudI18nProvider initialLang="en">
+        <AppPromote app={app} />
+      </CloudI18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+const apiMock = vi.mocked(api);
+const toastErrorMock = vi.mocked(toast.error);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppPromote asset generation", () => {
+  it("surfaces insufficient-credit failures", async () => {
+    apiMock.mockImplementation(async (path) => {
+      if (path === "/api/v1/apps/app-1/promote") return suggestions;
+      if (path === "/api/v1/advertising/accounts") return { accounts: [] };
+      if (path === "/api/v1/apps/app-1/promote/assets") {
+        throw new ApiError(402, "INSUFFICIENT_CREDITS", "Insufficient Credits");
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    renderPromote();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /generate assets/i }),
+    );
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Insufficient credits to generate assets.",
+      );
+    });
+  });
+
+  it("surfaces generic generation failures", async () => {
+    apiMock.mockImplementation(async (path) => {
+      if (path === "/api/v1/apps/app-1/promote") return suggestions;
+      if (path === "/api/v1/advertising/accounts") return { accounts: [] };
+      if (path === "/api/v1/apps/app-1/promote/assets") {
+        throw new ApiError(500, "SERVER_ERROR", "Server error");
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    renderPromote();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /generate assets/i }),
+    );
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to generate assets. Try again.",
+      );
+    });
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -17,10 +17,11 @@
 import { ExternalLink, Loader2, Megaphone, Plus, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { PromoteAppDialog } from "../../../cloud-ui/components/promotion/promote-app-dialog";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
-import { api } from "../../lib/api-client";
+import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { App } from "../lib/apps";
 
@@ -81,8 +82,16 @@ export function AppPromote({ app }: AppPromoteProps) {
         json: { includeCopy: true, includeAdBanners: true },
       });
       await fetchData();
-    } catch {
-      // Asset generation is best-effort; the suggestions/accounts panels stay.
+    } catch (error) {
+      toast.error(
+        error instanceof ApiError && error.status === 402
+          ? t("cloud.appPromote.assetsInsufficientCredits", {
+              defaultValue: "Insufficient credits to generate assets.",
+            })
+          : t("cloud.appPromote.assetsFailed", {
+              defaultValue: "Failed to generate assets. Try again.",
+            }),
+      );
     } finally {
       setIsGeneratingAssets(false);
     }


### PR DESCRIPTION
## Summary
- shows a toast when `Generate Assets` fails instead of silently clearing the spinner
- uses a specific insufficient-credits message for API `402` responses and a generic retry message for other failures
- adds a focused AppPromote regression test for both failure paths

## Issue
Fixes #9323

## Evidence
- `bun run --cwd packages/ui test src/cloud/applications/components/app-promote.test.tsx` (2 pass)
- `bunx @biomejs/biome check packages/ui/src/cloud/applications/components/app-promote.tsx packages/ui/src/cloud/applications/components/app-promote.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui build`
- `bun run --cwd packages/ui lint`
- `git diff --check`
- `bun install`
- `bun run verify` (509 successful, 509 total)

## Notes
- `bun run --cwd packages/ui test` currently fails on unrelated existing UI gate/chat assertions in `packages/ui/src/App.tsx`, `packages/ui/src/components/pages/BackgroundView.tsx`, and `packages/ui/src/components/composites/chat/chat-composer.test.tsx`; the new focused AppPromote test passes.
- Screenshots/video N/A: no layout or route rendering changed; this is toast error handling for an existing button.
- Real-LLM trajectory N/A: no agent/action/prompt/model behavior changed.
