### PR TITLE
fix(ui): surface promote asset generation failures

### DIFF
--- a/.github/issue-evidence/9323-promote-asset-toast.md
+++ b/.github/issue-evidence/9323-promote-asset-toast.md
@@ -1,0 +1,56 @@
+# 9323 Promote Asset Toast Evidence
+
+Date: 2026-06-24
+
+Branch: `fix/9323-promote-asset-toast`
+
+## What Changed
+
+`AppPromote` now surfaces failed `POST /api/v1/apps/:id/promote/assets`
+requests with `toast.error`. HTTP 402 gets a specific insufficient-credits
+message; other failures get a generic retry message.
+
+## Verification
+
+```text
+$ bun install
+8666 packages installed [131.14s]
+```
+
+```text
+$ bun run --cwd packages/shared build:i18n
+Total: 239 entries, 6 locales
+Done!
+```
+
+```text
+$ bun run --cwd packages/ui test app-promote.test.tsx
+Test Files  1 passed (1)
+Tests       2 passed (2)
+```
+
+```text
+$ bunx @biomejs/biome check packages/ui/src/cloud/applications/components/app-promote.tsx packages/ui/src/cloud/applications/components/app-promote.test.tsx
+Checked 2 files in 61ms. No fixes applied.
+```
+
+```text
+$ bun run --cwd packages/ui typecheck
+[generate-css-strings] processed 0 target(s), updated 0
+```
+
+```text
+$ bun run verify
+Tasks:    509 successful, 509 total
+Cached:    0 cached, 509 total
+Time:      3m9.909s
+```
+
+## UI Media
+
+Full-page screenshots, video walkthrough, and browser console/network logs were
+not captured for this patch. This checkout does not contain
+`packages/cloud-frontend`, and `rg "AppPromote|app-promote" packages` shows the
+component is only referenced by `packages/ui/src/cloud/applications/components`.
+The changed behavior is a transient failed-request toast path covered by the
+focused jsdom component test above.

--- a/packages/ui/src/cloud/applications/components/app-promote.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "../../lib/api-client";
+import type { App } from "../lib/apps";
+import { AppPromote } from "./app-promote";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () =>
+    (
+      _key: string,
+      options?: { defaultValue?: string; [key: string]: unknown },
+    ) =>
+      options?.defaultValue ?? _key,
+}));
+
+vi.mock("../../../cloud-ui/components/promotion/promote-app-dialog", () => ({
+  PromoteAppDialog: () => null,
+}));
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+
+  return {
+    ...actual,
+    api: vi.fn(),
+  };
+});
+
+const app = {
+  id: "app-1",
+  name: "Milady Promote",
+} as App;
+
+const promotionSuggestions = {
+  recommendedChannels: [],
+  estimatedBudget: { min: 10, max: 20 },
+  suggestedPlatforms: [],
+  tips: [],
+};
+
+const apiMock = vi.mocked(api);
+const toastErrorMock = vi.mocked(toast.error);
+
+function mockPromoteRequests(assetError: unknown) {
+  apiMock.mockImplementation(async (path: string) => {
+    if (path === "/api/v1/apps/app-1/promote") {
+      return promotionSuggestions;
+    }
+
+    if (path === "/api/v1/advertising/accounts") {
+      return { accounts: [] };
+    }
+
+    if (path === "/api/v1/apps/app-1/promote/assets") {
+      throw assetError;
+    }
+
+    throw new Error(`Unexpected API request: ${path}`);
+  });
+}
+
+async function renderPromoteTab() {
+  render(
+    <MemoryRouter>
+      <AppPromote app={app} />
+    </MemoryRouter>,
+  );
+
+  return screen.findByRole("button", { name: /generate assets/i });
+}
+
+describe("AppPromote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows an insufficient credits toast when asset generation returns 402", async () => {
+    mockPromoteRequests(
+      new ApiError(402, "INSUFFICIENT_CREDITS", "Insufficient credits"),
+    );
+
+    const generateButton = await renderPromoteTab();
+    fireEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Not enough credits to generate promotional assets.",
+      );
+    });
+  });
+
+  it("shows a generic failure toast when asset generation fails for another reason", async () => {
+    mockPromoteRequests(new Error("server unavailable"));
+
+    const generateButton = await renderPromoteTab();
+    fireEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to generate assets. Try again.",
+      );
+    });
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -17,10 +17,11 @@
 import { ExternalLink, Loader2, Megaphone, Plus, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { PromoteAppDialog } from "../../../cloud-ui/components/promotion/promote-app-dialog";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
-import { api } from "../../lib/api-client";
+import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 import type { App } from "../lib/apps";
 
@@ -81,8 +82,20 @@ export function AppPromote({ app }: AppPromoteProps) {
         json: { includeCopy: true, includeAdBanners: true },
       });
       await fetchData();
-    } catch {
-      // Asset generation is best-effort; the suggestions/accounts panels stay.
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 402) {
+        toast.error(
+          t("cloud.appPromote.generateAssetsInsufficientCredits", {
+            defaultValue: "Not enough credits to generate promotional assets.",
+          }),
+        );
+      } else {
+        toast.error(
+          t("cloud.appPromote.generateAssetsFailed", {
+            defaultValue: "Failed to generate assets. Try again.",
+          }),
+        );
+      }
     } finally {
       setIsGeneratingAssets(false);
     }


### PR DESCRIPTION
## Summary
- Surface failed promote asset-generation requests with `toast.error` instead of silently clearing the spinner.
- Use a specific insufficient-credits message for HTTP 402 and a generic retry message for other failures.
- Add focused jsdom coverage for both failure paths plus issue evidence.

Fixes #9323

## Evidence
- `.github/issue-evidence/9323-promote-asset-toast.md`
- `bun install` passed.
- `bun run --cwd packages/shared build:i18n` passed.
- `bun run --cwd packages/ui test app-promote.test.tsx` passed: 1 file, 2 tests.
- `bunx @biomejs/biome check packages/ui/src/cloud/applications/components/app-promote.tsx packages/ui/src/cloud/applications/components/app-promote.test.tsx` passed.
- `bun run --cwd packages/ui typecheck` passed.
- `bun run verify` passed on the final commit: 509 successful, 509 total.

## Evidence N/A
- Real LLM trajectory: N/A, no agent/action/prompt/model behavior changed.
- Backend logs: N/A, no backend/runtime/API code changed.
- Full-page screenshots/video/browser network logs: N/A for this checkout. `packages/cloud-frontend` is not present, and `rg "AppPromote|app-promote" packages` shows this component is referenced only inside `packages/ui/src/cloud/applications/components`. The changed behavior is a transient failed-request toast path covered by the focused component test.
- Audio/voice walkthrough: N/A, no audio, voice, STT, or TTS code changed.
