### PR TITLE
fix(core): recover doubled streaming tool-call args (cerebras ~20s TTFT)

### DIFF
--- a/packages/core/src/services/message.stage1-retry.test.ts
+++ b/packages/core/src/services/message.stage1-retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { HANDLE_RESPONSE_TOOL_NAME } from "../actions/to-tool";
 import type { GenerateTextResult } from "../types/index";
-import { shouldRetryStage1Generation } from "./message";
+import { getStage1RetryReason, shouldRetryStage1Generation } from "./message";
 
 /**
  * Stage-1 retry policy (latency fix): a "malformed HANDLE_RESPONSE tool call"
@@ -130,5 +131,38 @@ describe("shouldRetryStage1Generation", () => {
 				undefined,
 			),
 		).toBe(false);
+	});
+});
+
+/**
+ * Stage-1 retry CAUSE (the ~20s TTFT bug): cerebras gpt-oss double-emits the
+ * HANDLE_RESPONSE tool call on one streaming delta index, so the accumulated
+ * arguments are two concatenated objects (`{…}{…}`) that a plain JSON.parse
+ * rejects — driving 2 wasted retries + the planner fallback. parseToolArguments
+ * now recovers the FIRST balanced object, so Stage-1 parses on attempt 1.
+ */
+function toolCallResult(args: string): GenerateTextResult {
+	return {
+		toolCalls: [{ name: HANDLE_RESPONSE_TOOL_NAME, arguments: args }],
+	} as unknown as GenerateTextResult;
+}
+
+describe("getStage1RetryReason — doubled tool-call recovery", () => {
+	it("recovers a double-emitted tool call (no retry reason)", () => {
+		expect(
+			getStage1RetryReason(
+				toolCallResult('{"replyText":"hi"}{"replyText":"hi"}'),
+			),
+		).toBeNull();
+	});
+
+	it("still parses a normal single-object tool call", () => {
+		expect(
+			getStage1RetryReason(toolCallResult('{"replyText":"hi"}')),
+		).toBeNull();
+	});
+
+	it("still flags an empty completion (recovery does not mask it)", () => {
+		expect(getStage1RetryReason("")).toBe("empty completion");
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3282,17 +3282,15 @@ export async function renderMessageHandlerStablePrefix(
 
 function parseToolArguments(value: unknown): Record<string, unknown> | null {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
-		if (typeof value !== "string") {
-			return null;
-		}
-		try {
-			const parsed: unknown = JSON.parse(value);
-			return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-				? (parsed as Record<string, unknown>)
-				: null;
-		} catch {
-			return null;
-		}
+		// String args are usually one JSON object, but a weak streaming model
+		// (cerebras gpt-oss double-emits the tool call on one delta index) can
+		// produce two concatenated objects (`{…}{…}`) that fail a plain
+		// JSON.parse. parseJsonObject recovers the FIRST balanced object, so the
+		// doubled emit parses on attempt 1 instead of failing as a "malformed
+		// HANDLE_RESPONSE tool call" and forcing the Stage-1 retry+planner path.
+		return typeof value === "string"
+			? parseJsonObject<Record<string, unknown>>(value)
+			: null;
 	}
 	return value as Record<string, unknown>;
 }
@@ -4300,7 +4298,7 @@ function isEmptyStage1Result(raw: string | GenerateTextResult): boolean {
 	return true;
 }
 
-function getStage1RetryReason(
+export function getStage1RetryReason(
 	raw: string | GenerateTextResult,
 ): "empty completion" | "malformed HANDLE_RESPONSE tool call" | null {
 	if (isEmptyStage1Result(raw)) {


### PR DESCRIPTION
## The ~20s TTFT bug, root-caused + wire-reproduced

Dedicated cerebras (gpt-oss-120b) chat TTFT was ~20-30s. Measured (`ELIZA_INFERENCE_TIMING`, 3 turns): per turn = **RESPONSE_HANDLER ×3 + ACTION_PLANNER ×1**, composeState+all providers only ~150ms. So it's the model-call pipeline, not context/embeds.

**Root cause (wire-reproduced, no provision needed):** with `tool_choice:"required"`, **non-streaming returns ONE clean tool call**, but **streaming double-emits the full arguments on index 0** → the accumulator concatenates → `{"replyText":"hi"}{"replyText":"hi"}`. `parseToolArguments` did a plain `JSON.parse` on that → throws → classified `malformed HANDLE_RESPONSE tool call` **every turn** → 2 wasted Stage-1 retries (each a fresh ~5-7s call) + the `client_chat` planner fallback = the whole ~20s.

## Fix
`parseToolArguments` now reuses the existing `parseJsonObject` (extracts the FIRST balanced object) instead of a bespoke `JSON.parse`. The doubled emit parses on attempt 1 → no retries, no forced planner. Removes a duplicate parse path; fixes any provider that double-emits; no behavior change for single-object / non-object args. `getStage1RetryReason` exported for the test.

## Tests
`message.stage1-retry.test.ts`: doubled `{…}{…}` → no retry reason; single object → still parses; empty → still `empty completion`. Full core suite green (923/923).

## Evidence
Wire repro + the live `InferenceTiming` breakdown are on #8434. **Before/after TTFT from a fresh-provisioned agent on this branch's image incoming** (the merge gate) — will attach.

Co-investigated with @lalalune-side + cloud-agent + vps-agent on #8434; complementary to #9278 (planner-loop markup strip, different layer). Requesting review from cloud-agent (plugin/runtime lane) + vps-agent (#9278).