### PR TITLE
chore(cloud): use isValidUUID + drop dead quota fallback (audit cleanups)

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/deploy/route.ts
@@ -97,9 +97,7 @@ app.post("/", async (c) => {
       return c.json(
         {
           success: false,
-          error:
-            quota.error ??
-            `Container quota exceeded (${quota.current}/${quota.max})`,
+          error: quota.error,
         },
         409,
       );

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -19,6 +19,7 @@
 import { Buffer } from "node:buffer";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
+import { isValidUUID } from "../utils/validation";
 import { decideBuilderArming, selectBuilderHost } from "./app-builder-host";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
@@ -219,7 +220,7 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
     markAppDeployed: async (appId, productionUrl) => {
       // App ids are UUIDs; a non-UUID project_name (a plain /v1/containers row,
       // which is not an app) is skipped so this never mis-updates or UUID-casts.
-      if (!/^[0-9a-f-]{36}$/i.test(appId)) return;
+      if (!isValidUUID(appId)) return;
       await appsService.update(appId, {
         deployment_status: "deployed",
         production_url: productionUrl,


### PR DESCRIPTION
Two small clean-code fixes surfaced by the cloud code audit. No behavior change for valid inputs; one is also a latent-bug fix.

## Fix 1 — `markAppDeployed` uses the shared `isValidUUID` validator
`packages/cloud-shared/src/lib/services/container-executor-deps.ts`

Replaces the inline ad-hoc guard `if (!/^[0-9a-f-]{36}$/i.test(appId)) return;` with the existing validator `if (!isValidUUID(appId)) return;` (imported from `../utils/validation`, same relative path as `vertex-model-registry.ts:16`).

- **Removes a rule-2 duplicate** (single source of truth for UUID validation already lives in `utils/validation.ts`).
- **Fixes a real bug:** the ad-hoc character class `[0-9a-f-]{36}` matches *any* 36-char run of hex digits or dashes — e.g. **36 dashes pass** — so the guard never actually rejected a non-UUID `project_name` (a plain `/v1/containers` row). `isValidUUID` enforces the real `xxxxxxxx-xxxx-Vxxx-Nxxx-xxxxxxxxxxxx` shape.

## Fix 2 — drop the dead `??` quota-error fallback
`packages/cloud-api/v1/apps/[id]/deploy/route.ts`

Replaces `error: quota.error ?? \`Container quota exceeded (${quota.current}/${quota.max})\`` with `error: quota.error`.

`containersRepository.checkQuota` sets a non-undefined `error` on **both** `allowed:false` return paths (`"Organization not found"` and `\`Container quota exceeded (...)\``), so the `??` branch is unreachable — and the literal duplicated the repo-produced string. The response field is typed `error?: string`, so `quota.error` assigns cleanly.

## Tests
- `packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts` — 14 pass / 0 fail (exercises the `markAppDeployed` surface).
- biome clean on both touched files.
- No test covers the `markAppDeployed` UUID guard or the quota fallback directly, so none was added (no over-adding).

Audit cleanups for #8434.