### PR TITLE
refactor(cloud): unify app + agent orphan reconcilers into one shared function

### DIFF
--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -1,91 +1,86 @@
 /**
- * Tests for the orphan APP-container reconciler's pure diff logic and its
- * SSH-orchestration loop, mirroring `docker-node-workloads.test.ts` for the
- * apps (`containers` table) variant.
- *
- * The diff (`computeOrphanAppContainersToReap`) is the load-bearing safety
- * property: an `app-<slug>` container is reaped ONLY when its NAME has no live
- * `containers` row (or a terminal one), and NEVER when the name does not match
- * the managed `app-` pattern. The orchestration test pins the "never reap on an
- * unreachable node" invariant (SSH listing returned null → skip, not reap) and
- * the reap-by-id invariant (the rm targets the immutable container id, not the
- * name).
+ * Tests for the APP orphan-container reconciler. The diff and orchestration
+ * loop now live in the shared `orphan-container-reconciler.ts`; this suite pins
+ * the APP-specific wiring: the `appContainerKeyOf` keyOf (the diff key IS the
+ * container name), the app terminal-status vocab, and the fail-safe
+ * group-by-key diff (#9307) that protects a live app sharing an `app-<slug>`
+ * name with stale stopped/failed rows. The orchestration tests pin the "never
+ * reap on an unreachable node" and "reap by immutable id, not name" invariants.
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { appContainerKeyOf } from "./app-container-orphan-reconciler";
 import {
-  type AppOrphanReconcilerNode,
-  computeOrphanAppContainersToReap,
-  isAppContainerName,
-  type LiveAppContainerRef,
-  type NodeAppContainerRef,
-  reconcileOrphanAppContainers,
-} from "./app-container-orphan-reconciler";
+  computeOrphanContainersToReap,
+  type LiveContainerRef,
+  type NodeContainerRef,
+  type OrphanReconcilerConfig,
+  type OrphanReconcilerNode,
+  reconcileOrphanContainers,
+} from "./orphan-container-reconciler";
 
-describe("isAppContainerName", () => {
-  test("accepts an app-<slug> name", () => {
-    expect(isAppContainerName("app-abc123def456")).toBe(true);
+/** The app reconciler's pure-diff deltas (matches the production config). */
+const APP_DIFF: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
+  keyOf: appContainerKeyOf,
+  terminalStatuses: new Set(["stopped", "failed", "deleted"]),
+};
+
+describe("appContainerKeyOf", () => {
+  test("accepts an app-<slug> name and returns the name as the key", () => {
+    expect(appContainerKeyOf("app-abc123def456")).toBe("app-abc123def456");
   });
 
   test("rejects names without the app- prefix", () => {
-    expect(isAppContainerName("postgres")).toBe(false);
-    expect(isAppContainerName("agent-abc")).toBe(false);
+    expect(appContainerKeyOf("postgres")).toBeNull();
+    expect(appContainerKeyOf("agent-abc")).toBeNull();
     // substring match elsewhere in the name must NOT count
-    expect(isAppContainerName("my-app-x")).toBe(false);
+    expect(appContainerKeyOf("my-app-x")).toBeNull();
   });
 
   test("rejects a bare prefix with no slug", () => {
-    expect(isAppContainerName("app-")).toBe(false);
+    expect(appContainerKeyOf("app-")).toBeNull();
   });
 });
 
-describe("computeOrphanAppContainersToReap", () => {
-  const live = (name: string, status: string): LiveAppContainerRef => ({ name, status });
-  const container = (name: string, id: string): NodeAppContainerRef => ({ name, id });
+describe("computeOrphanContainersToReap (app diff)", () => {
+  const live = (key: string, status: string): LiveContainerRef => ({ key, status });
+  const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+  const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
+    computeOrphanContainersToReap(containers, rows, APP_DIFF);
 
   test("reaps a container whose name has NO db row", () => {
-    const orphans = computeOrphanAppContainersToReap([container("app-gone", "c1")], []);
-    expect(orphans).toEqual([{ name: "app-gone", id: "c1", reason: "no_db_row" }]);
+    const orphans = compute([container("app-gone", "c1")], []);
+    expect(orphans).toEqual([{ name: "app-gone", id: "c1", key: "app-gone", reason: "no_db_row" }]);
   });
 
   test("reaps a container whose db row is in a terminal state (stopped/failed/deleted)", () => {
     for (const status of ["stopped", "failed", "deleted"]) {
-      const orphans = computeOrphanAppContainersToReap(
-        [container("app-dead", "c2")],
-        [live("app-dead", status)],
-      );
-      expect(orphans).toEqual([{ name: "app-dead", id: "c2", reason: "terminal_db_row" }]);
+      const orphans = compute([container("app-dead", "c2")], [live("app-dead", status)]);
+      expect(orphans).toEqual([
+        { name: "app-dead", id: "c2", key: "app-dead", reason: "terminal_db_row" },
+      ]);
     }
   });
 
   test("does NOT reap a container with a live (running) db row", () => {
-    const orphans = computeOrphanAppContainersToReap(
-      [container("app-live", "c3")],
-      [live("app-live", "running")],
-    );
+    const orphans = compute([container("app-live", "c3")], [live("app-live", "running")]);
     expect(orphans).toEqual([]);
   });
 
   test("does NOT reap deploying / building / pending rows", () => {
     for (const status of ["deploying", "building", "pending"]) {
-      const orphans = computeOrphanAppContainersToReap(
-        [container("app-x", "cx")],
-        [live("app-x", status)],
-      );
+      const orphans = compute([container("app-x", "cx")], [live("app-x", status)]);
       expect(orphans).toEqual([]);
     }
   });
 
   test("does NOT reap a row in 'deleting' (delete job owns teardown)", () => {
-    const orphans = computeOrphanAppContainersToReap(
-      [container("app-deleting", "c4")],
-      [live("app-deleting", "deleting")],
-    );
+    const orphans = compute([container("app-deleting", "c4")], [live("app-deleting", "deleting")]);
     expect(orphans).toEqual([]);
   });
 
   test("ignores containers that do not match the app- pattern", () => {
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [container("postgres", "p1"), container("agent-abc", "a1"), container("redis", "r1")],
       [],
     );
@@ -93,7 +88,7 @@ describe("computeOrphanAppContainersToReap", () => {
   });
 
   test("mixed fleet: reaps only the orphans, leaves live + non-app alone", () => {
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [
         container("app-running", "c-run"),
         container("app-orphan", "c-orph"),
@@ -106,7 +101,7 @@ describe("computeOrphanAppContainersToReap", () => {
     expect(orphans.map((o) => o.id).sort()).toEqual(["c-orph", "c-stop"]);
   });
 
-  // REGRESSION (#9234): `containers.name` has NO unique constraint, so one
+  // REGRESSION (#9307): `containers.name` has NO unique constraint, so one
   // `app-<slug>` name maps to MANY rows (one per deploy) — routinely a mix like
   // `[running, stopped]`. Collapsing to a single status per name (last-write-wins
   // over an unordered `WHERE name IN (...)`) could pick the terminal row and
@@ -114,7 +109,7 @@ describe("computeOrphanAppContainersToReap", () => {
   // for a name is non-terminal, the live container is NEVER reaped — and the
   // outcome must not depend on row order (no ORDER BY in the query).
   test("does NOT reap a name with a running AND a stopped row — running order", () => {
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [container("app-dup", "c-live")],
       [live("app-dup", "running"), live("app-dup", "stopped")],
     );
@@ -124,7 +119,7 @@ describe("computeOrphanAppContainersToReap", () => {
   test("does NOT reap a name with a stopped AND a running row — reversed order", () => {
     // Same rows, opposite iteration order: a last-write-wins map would collapse
     // to 'running' here and to 'stopped' above, making reaping order-dependent.
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [container("app-dup", "c-live")],
       [live("app-dup", "stopped"), live("app-dup", "running")],
     );
@@ -132,7 +127,7 @@ describe("computeOrphanAppContainersToReap", () => {
   });
 
   test("does NOT reap when ANY of several rows is non-terminal (running last)", () => {
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [container("app-dup", "c-live")],
       [
         live("app-dup", "failed"),
@@ -145,26 +140,42 @@ describe("computeOrphanAppContainersToReap", () => {
   });
 
   test("reaps a name when EVERY row is terminal (multiple terminal rows)", () => {
-    const orphans = computeOrphanAppContainersToReap(
+    const orphans = compute(
       [container("app-dead", "c-dead")],
       [live("app-dead", "stopped"), live("app-dead", "failed"), live("app-dead", "deleted")],
     );
-    expect(orphans).toEqual([{ name: "app-dead", id: "c-dead", reason: "terminal_db_row" }]);
+    expect(orphans).toEqual([
+      { name: "app-dead", id: "c-dead", key: "app-dead", reason: "terminal_db_row" },
+    ]);
   });
 
   test("reaps a name with NO rows as no_db_row", () => {
-    const orphans = computeOrphanAppContainersToReap([container("app-gone", "c-gone")], []);
-    expect(orphans).toEqual([{ name: "app-gone", id: "c-gone", reason: "no_db_row" }]);
+    const orphans = compute([container("app-gone", "c-gone")], []);
+    expect(orphans).toEqual([
+      { name: "app-gone", id: "c-gone", key: "app-gone", reason: "no_db_row" },
+    ]);
   });
 });
 
-describe("reconcileOrphanAppContainers (orchestration)", () => {
-  function makeNode(overrides: Partial<AppOrphanReconcilerNode> = {}): AppOrphanReconcilerNode {
+describe("reconcileOrphanContainers (app orchestration)", () => {
+  function makeConfig(
+    loadStatuses: OrphanReconcilerConfig["loadStatuses"],
+  ): OrphanReconcilerConfig {
+    return {
+      prefix: "app-",
+      keyOf: APP_DIFF.keyOf,
+      terminalStatuses: APP_DIFF.terminalStatuses,
+      loadStatuses,
+      logScope: "app-orphan-reconciler",
+    };
+  }
+
+  function makeNode(overrides: Partial<OrphanReconcilerNode> = {}): OrphanReconcilerNode {
     return {
       node_id: "node-1",
       hostname: "host-1",
       status: "healthy",
-      listAppContainers: mock(async () => [] as NodeAppContainerRef[]),
+      listContainers: mock(async () => [] as NodeContainerRef[]),
       removeContainer: mock(async () => {}),
       ...overrides,
     };
@@ -173,59 +184,52 @@ describe("reconcileOrphanAppContainers (orchestration)", () => {
   test("force-removes every orphan on a healthy node — BY ID, not name", async () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({
-      listAppContainers: mock(async () => [
+      listContainers: mock(async () => [
         { name: "app-orphan", id: "c-orph" },
         { name: "app-live", id: "c-live" },
       ]),
       removeContainer,
     });
-    const loadLive = mock(async () => [{ name: "app-live", status: "running" }]);
+    const loadLive = mock(async () => [{ key: "app-live", status: "running" }]);
 
-    const result = await reconcileOrphanAppContainers([node], loadLive);
+    const result = await reconcileOrphanContainers([node], makeConfig(loadLive));
 
     expect(removeContainer).toHaveBeenCalledTimes(1);
     // reap-by-id invariant: the rm target is the immutable container id, NOT the name.
     expect(removeContainer).toHaveBeenCalledWith("c-orph");
-    expect(result).toEqual({
-      nodesScanned: 1,
-      nodesSkipped: 0,
-      reaped: 1,
-      reapFailed: 0,
-    });
+    expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 0 });
   });
 
   test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
     const removeContainer = mock(async () => {});
-    const node = makeNode({
-      listAppContainers: mock(async () => null),
-      removeContainer,
-    });
+    const node = makeNode({ listContainers: mock(async () => null), removeContainer });
 
-    const result = await reconcileOrphanAppContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
     expect(removeContainer).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      nodesScanned: 0,
-      nodesSkipped: 1,
-      reaped: 0,
-      reapFailed: 0,
-    });
+    expect(result).toEqual({ nodesScanned: 0, nodesSkipped: 1, reaped: 0, reapFailed: 0 });
   });
 
   test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
-    const listAppContainers = mock(async () => [] as NodeAppContainerRef[]);
-    const node = makeNode({ status: "offline", listAppContainers });
+    const listContainers = mock(async () => [] as NodeContainerRef[]);
+    const node = makeNode({ status: "offline", listContainers });
 
-    const result = await reconcileOrphanAppContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
-    expect(listAppContainers).not.toHaveBeenCalled();
+    expect(listContainers).not.toHaveBeenCalled();
     expect(result.nodesSkipped).toBe(1);
     expect(result.nodesScanned).toBe(0);
   });
 
   test("counts a failed removal as reapFailed without aborting the rest", async () => {
     const node = makeNode({
-      listAppContainers: mock(async () => [
+      listContainers: mock(async () => [
         { name: "app-a", id: "ca" },
         { name: "app-b", id: "cb" },
       ]),
@@ -234,23 +238,19 @@ describe("reconcileOrphanAppContainers (orchestration)", () => {
       }),
     });
 
-    const result = await reconcileOrphanAppContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
-    expect(result).toEqual({
-      nodesScanned: 1,
-      nodesSkipped: 0,
-      reaped: 1,
-      reapFailed: 1,
-    });
+    expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 1 });
   });
 
   test("does not query the DB when a node has no app- containers", async () => {
-    const loadLive = mock(async () => [] as LiveAppContainerRef[]);
-    const node = makeNode({
-      listAppContainers: mock(async () => [{ name: "agent-foo", id: "a" }]),
-    });
+    const loadLive = mock(async () => [] as LiveContainerRef[]);
+    const node = makeNode({ listContainers: mock(async () => [{ name: "agent-foo", id: "a" }]) });
 
-    await reconcileOrphanAppContainers([node], loadLive);
+    await reconcileOrphanContainers([node], makeConfig(loadLive));
 
     expect(loadLive).not.toHaveBeenCalled();
   });

--- a/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -5,6 +5,13 @@
  * the OTHER kind of workload on the shared Hetzner-Docker pool: user-deployed
  * APP containers (the `containers` table, NOT `agent_sandboxes`).
  *
+ * Both share ONE implementation — the orchestration loop, the SSH wiring, the
+ * hard timeouts, the reap-by-immutable-id rm, and the fail-safe group-by-key
+ * diff all live in `orphan-container-reconciler.ts`. This module injects only
+ * the three app-specific deltas: the `app-` prefix, the `keyOf` that uses the
+ * container NAME as the diff key, and the app terminal-status vocab (plus the
+ * `containers` status query and a log tag).
+ *
  * THE GAP THIS CLOSES
  * App-container teardown (`appCleanupService` / the CONTAINER_DELETE executor)
  * only runs on an EXPLICIT app delete. A mid-deploy crash or a partial failure
@@ -12,20 +19,6 @@
  * a DB row left in a dead terminal state) — it holds a compute slot and host
  * volume forever because nothing in the deploy lifecycle will ever reap it
  * again. Agents already get a periodic sweep for exactly this; apps did not.
- * This reconciler closes that gap with a low-cadence sweep over HEALTHY nodes,
- * mirroring the agent reconciler's proven safety model EXACTLY.
- *
- * SAFETY INVARIANTS (identical to the agent reconciler — a wrong reaper kills a
- * live customer app):
- *   1. Only `status === "healthy"` nodes are touched.
- *   2. If the SSH container listing returns null (listing failed) → SKIP the
- *      node, never reap (a misread empty list must not reap live containers).
- *   3. Reap by the IMMUTABLE container ID captured in the same listing — NEVER
- *      by name (avoids the delete+recreate race where the name resolves to the
- *      new live container).
- *   4. Hard per-call SSH timeouts on both the list and the rm.
- *   5. Every reap, skip, and failure is logged.
- *   6. When unsure whether a container is an orphan → DO NOT reap.
  *
  * HOW APP CONTAINERS DIFFER FROM AGENTS
  *   - App containers are named `app-<first 12 of app id>` (see
@@ -37,9 +30,15 @@
  *     pending | building | deploying | running | stopped | failed | deleting |
  *     deleted. A container is LIVE (do NOT reap) when its row is in
  *     pending/building/deploying/running/deleting (`deleting` = a delete job is
- *     in flight and owns teardown — reaping under it would race the worker). It
- *     is an ORPHAN (reap) when its row is MISSING (`no_db_row`) or in a dead
- *     terminal state stopped/failed/deleted (`terminal_db_row`).
+ *     in flight and owns teardown). It is an ORPHAN (reap) when its row is
+ *     MISSING (`no_db_row`) or in a dead terminal state stopped/failed/deleted
+ *     (`terminal_db_row`).
+ *   - `containers.name` has NO unique constraint, so one `app-<slug>` name maps
+ *     to MANY rows (one per deploy) — the shared diff's group-by-key
+ *     `every-terminal` fail-safe (#9307) is what protects a live app sharing a
+ *     name with stale stopped/failed rows. (For agents the key is a PRIMARY KEY
+ *     so each key has at most one row and the same fail-safe reduces to a plain
+ *     single-status check — identical decisions.)
  *
  * Non-`app-`-prefixed containers on a shared node (agents `agent-…`, the older
  * direct `cloud-container-…` provider path, infra containers like postgres) are
@@ -48,11 +47,17 @@
 
 import { inArray } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
-import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { containers } from "../../db/schemas/containers";
-import { logger } from "../utils/logger";
-import { shellQuote } from "./docker-sandbox-utils";
-import { DockerSSHClient } from "./docker-ssh";
+import {
+  type LiveContainerRef,
+  type OrphanReconcileResult,
+  type OrphanReconcilerConfig,
+  reconcileOrphanContainersOnNodes,
+} from "./orphan-container-reconciler";
+
+// Re-export the shared result type so existing importers (the daemon) keep
+// `AppOrphanReconcileResult` from this module.
+export type { OrphanReconcileResult as AppOrphanReconcileResult } from "./orphan-container-reconciler";
 
 /**
  * The prefix every Apps/Product-2 container name carries. Kept in lockstep with
@@ -77,305 +82,52 @@ export const APP_CONTAINER_NAME_PREFIX = "app-";
  */
 const TERMINAL_CONTAINER_STATUSES = new Set<string>(["stopped", "failed", "deleted"]);
 
-/** A container seen on a node, parsed from `docker ps -a`. */
-export interface NodeAppContainerRef {
-  /** Container name, e.g. `app-<slug>`. */
-  name: string;
-  /** Docker container id (used for the `docker rm -f` target). */
-  id: string;
-}
-
 /**
- * A `containers` row as far as orphan reconciliation cares: its name and
- * current status. A row counts as "live" when its status is not terminal.
+ * The app reconciler's `keyOf`: the diff key is the container NAME itself (apps
+ * write the deterministic `app-<slug>` verbatim to `containers.name`). Returns
+ * null for names outside the managed-app pattern so unrelated containers on a
+ * shared node are never considered. A bare `app-` with no slug is rejected
+ * (mirrors the agent reconciler rejecting a bare `agent-`).
  */
-export interface LiveAppContainerRef {
-  name: string;
-  status: string;
-}
-
-/** A container the reconciler has decided to forcibly remove. */
-export interface OrphanAppContainer {
-  /** Container name (`app-<slug>`). */
-  name: string;
-  /** Docker container id, the `docker rm -f` target. */
-  id: string;
-  /** Why it was flagged: no DB row at all, or a row in a terminal state. */
-  reason: "no_db_row" | "terminal_db_row";
+export function appContainerKeyOf(name: string): string | null {
+  return name.startsWith(APP_CONTAINER_NAME_PREFIX) &&
+    name.length > APP_CONTAINER_NAME_PREFIX.length
+    ? name
+    : null;
 }
 
 /**
- * True for a name that belongs to the managed-app pattern (`app-<slug>`), so
- * unrelated containers on a shared node are never considered. A bare `app-`
- * with no slug is rejected (mirrors the agent reconciler rejecting `agent-`).
- */
-export function isAppContainerName(name: string): boolean {
-  return (
-    name.startsWith(APP_CONTAINER_NAME_PREFIX) && name.length > APP_CONTAINER_NAME_PREFIX.length
-  );
-}
-
-/**
- * Pure diff: given the containers present on a node and the `containers` rows
- * that exist for those container names, decide which containers to reap.
- *
- * A container is an orphan when EITHER:
- *   - no `containers` row exists for its name (`no_db_row`), OR
- *   - rows exist but EVERY one of them is terminal (`terminal_db_row`) — the
- *     deploy lifecycle has decided this app has no live container.
- *
- * CRITICAL: a single `app-<slug>` name can map to MULTIPLE `containers` rows.
- * `containers.name` is the deterministic `app-<first 12 of app id>` and has NO
- * unique constraint; every deploy inserts a fresh row via `createWithQuotaCheck`
- * and leaves prior rows behind in running/stopped/failed. So the row set for one
- * name is routinely a mix like `[running, stopped]`. We must be FAIL-SAFE: a
- * name is LIVE (never reaped) if ANY of its rows is non-terminal, and is reaped
- * ONLY when EVERY row is terminal. Collapsing to a single status per name (e.g.
- * last-write-wins over an unordered `WHERE name IN (...)`) could pick a terminal
- * row while a live row exists and `docker rm -f` a running customer app. Group
- * here so the decision is fail-safe and order-independent.
- *
- * Containers whose name does not match the `app-<slug>` pattern are ignored
- * entirely — they belong to something else on the node.
- *
- * This function performs NO I/O so it can be unit-tested exhaustively.
- */
-export function computeOrphanAppContainersToReap(
-  containersOnNode: readonly NodeAppContainerRef[],
-  liveContainers: readonly LiveAppContainerRef[],
-): OrphanAppContainer[] {
-  // Group all statuses per name (a name can have >1 containers row — there is no
-  // unique constraint on containers.name).
-  const statusesByName = new Map<string, string[]>();
-  for (const row of liveContainers) {
-    const list = statusesByName.get(row.name) ?? [];
-    list.push(row.status);
-    statusesByName.set(row.name, list);
-  }
-
-  const orphans: OrphanAppContainer[] = [];
-  for (const container of containersOnNode) {
-    if (!isAppContainerName(container.name)) continue;
-
-    const statuses = statusesByName.get(container.name);
-    if (statuses === undefined || statuses.length === 0) {
-      orphans.push({ name: container.name, id: container.id, reason: "no_db_row" });
-    } else if (statuses.every((s) => TERMINAL_CONTAINER_STATUSES.has(s))) {
-      // Reap ONLY when EVERY row is terminal — any live row protects the name.
-      orphans.push({ name: container.name, id: container.id, reason: "terminal_db_row" });
-    }
-  }
-  return orphans;
-}
-
-/** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
-export interface AppOrphanReconcilerNode {
-  node_id: string;
-  hostname: string;
-  status: string;
-  /**
-   * List `app-`-prefixed containers on the node over SSH. Returns null when the
-   * listing failed (SSH blip) so the caller can skip the node rather than
-   * misread an empty list as "no containers" and reap live work.
-   */
-  listAppContainers(): Promise<NodeAppContainerRef[] | null>;
-  /**
-   * Force-remove a container by its IMMUTABLE id over SSH. Must take the id, not
-   * the name: the id pins the exact container observed in the listing, so a
-   * concurrent recreate of the same `app-<slug>` name cannot be reaped by
-   * mistake. Implementations must NOT switch to `docker rm -f <name>`.
-   */
-  removeContainer(containerId: string): Promise<void>;
-}
-
-export interface AppOrphanReconcileResult {
-  /** Nodes inspected (HEALTHY only). */
-  nodesScanned: number;
-  /** Nodes skipped because the SSH container listing failed (or not healthy). */
-  nodesSkipped: number;
-  /** Containers successfully force-removed. */
-  reaped: number;
-  /** Containers identified as orphans but whose removal failed. */
-  reapFailed: number;
-}
-
-/**
- * Reconcile orphan APP containers on a set of HEALTHY nodes. The caller is
- * responsible for passing ONLY nodes that node-health has just confirmed
- * reachable, so a transient SSH blip never causes a live container to be reaped.
- * Per node: list `app-` containers, diff against the live `containers` rows, and
- * force-remove every orphan.
- *
- * `loadLiveAppContainers` returns the `containers` rows (name + status) for the
- * container names seen on the node — injected so this stays pure-ish and
- * unit-testable without a DB. The default production wiring is in
- * `reconcileOrphanAppContainersOnNodes`.
- */
-export async function reconcileOrphanAppContainers(
-  nodes: readonly AppOrphanReconcilerNode[],
-  loadLiveAppContainers: (names: readonly string[]) => Promise<LiveAppContainerRef[]>,
-): Promise<AppOrphanReconcileResult> {
-  const result: AppOrphanReconcileResult = {
-    nodesScanned: 0,
-    nodesSkipped: 0,
-    reaped: 0,
-    reapFailed: 0,
-  };
-
-  for (const node of nodes) {
-    if (node.status !== "healthy") {
-      // Defensive: callers should already filter, but never reap on a node we
-      // have not confirmed reachable.
-      result.nodesSkipped += 1;
-      continue;
-    }
-
-    const containersOnNode = await node.listAppContainers();
-    if (containersOnNode === null) {
-      // SSH listing failed — skip rather than risk reaping live containers off a
-      // misread empty list.
-      result.nodesSkipped += 1;
-      logger.warn("[app-orphan-reconciler] Skipping node: container listing failed", {
-        nodeId: node.node_id,
-        hostname: node.hostname,
-      });
-      continue;
-    }
-    result.nodesScanned += 1;
-
-    const names = containersOnNode.map((c) => c.name).filter((name) => isAppContainerName(name));
-    if (names.length === 0) continue;
-
-    const liveContainers = await loadLiveAppContainers(names);
-    const orphans = computeOrphanAppContainersToReap(containersOnNode, liveContainers);
-
-    for (const orphan of orphans) {
-      try {
-        // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
-        // id was captured in the same SSH listing that found the orphan, so it
-        // pins THAT exact container. This is what makes the reap safe against a
-        // concurrent recreate: if a delete + a fresh deploy race and a new
-        // `app-<slug>` container is created between the listing and the rm,
-        // `docker rm -f <id>` still targets the dead container we observed and
-        // leaves the live one alone. A future refactor to `docker rm -f <name>`
-        // would reintroduce the live-container-reap race (the name resolves to
-        // whichever container holds it NOW, i.e. the new live one) — DO NOT.
-        await node.removeContainer(orphan.id);
-        result.reaped += 1;
-        logger.info("[app-orphan-reconciler] Reaped orphan app container", {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          containerName: orphan.name,
-          reason: orphan.reason,
-        });
-      } catch (error) {
-        result.reapFailed += 1;
-        logger.warn("[app-orphan-reconciler] Failed to reap orphan app container", {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          containerName: orphan.name,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-  }
-
-  return result;
-}
-
-/** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
-const ORPHAN_LIST_TIMEOUT_MS = 15_000;
-const ORPHAN_RM_TIMEOUT_MS = 30_000;
-
-/**
- * Load (name, status) for the `containers` rows matching the given container
+ * Load (key, status) for the `containers` rows matching the given container
  * names, including terminal-state rows. The reconciler needs the status to tell
  * a missing row (`no_db_row`) apart from a terminal one (`terminal_db_row`).
  *
  * This can return MULTIPLE rows for the same name: `containers.name` is the
  * deterministic `app-<first 12 of app id>` with no unique constraint, so an app
- * accumulates one row per deploy. `computeOrphanAppContainersToReap` groups
- * these per name and only reaps when every row is terminal, so returning the
- * full (unordered) set here is correct and fail-safe.
+ * accumulates one row per deploy. The shared diff groups these per key and only
+ * reaps when every row is terminal, so returning the full (unordered) set here
+ * is correct and fail-safe.
  */
-async function loadContainerStatusesByNames(
-  names: readonly string[],
-): Promise<LiveAppContainerRef[]> {
+async function loadContainerStatusesByNames(names: readonly string[]): Promise<LiveContainerRef[]> {
   if (names.length === 0) return [];
   return dbRead
-    .select({ name: containers.name, status: containers.status })
+    .select({ key: containers.name, status: containers.status })
     .from(containers)
     .where(inArray(containers.name, names as string[]));
 }
 
+/** The three app-specific deltas injected into the shared reconciler. */
+const APP_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
+  prefix: APP_CONTAINER_NAME_PREFIX,
+  keyOf: appContainerKeyOf,
+  terminalStatuses: TERMINAL_CONTAINER_STATUSES,
+  loadStatuses: loadContainerStatusesByNames,
+  logScope: "app-orphan-reconciler",
+};
+
 /**
- * Production wiring for the orphan APP-container reconciler: enumerate enabled,
- * HEALTHY docker nodes and reconcile each over SSH. Built on the shared
- * `DockerSSHClient` pool so it reuses warm connections. Every SSH call is
- * hard-bounded so a single unresponsive node can never stall the sweep.
- *
- * Only `status === "healthy"` nodes are touched: the caller (the daemon's
- * infra-maintenance cycle) runs this AFTER the node health-check, so a node that
- * just failed its probe is excluded and a transient SSH blip never reaps live
- * containers.
+ * Production wiring for the orphan APP-container reconciler. Delegates to the
+ * shared sweep with the app deltas. The daemon imports this name.
  */
-export async function reconcileOrphanAppContainersOnNodes(): Promise<AppOrphanReconcileResult> {
-  const enabled = await dockerNodesRepository.findEnabled();
-  const healthy = enabled.filter((node) => node.status === "healthy");
-
-  const reconcilerNodes: AppOrphanReconcilerNode[] = healthy.map((node) => {
-    const ssh = () =>
-      DockerSSHClient.getClient(
-        node.hostname,
-        node.ssh_port ?? undefined,
-        node.host_key_fingerprint ?? undefined,
-        node.ssh_user ?? undefined,
-      );
-    return {
-      node_id: node.node_id,
-      hostname: node.hostname,
-      status: node.status,
-      async listAppContainers(): Promise<NodeAppContainerRef[] | null> {
-        try {
-          const client = ssh();
-          await client.connect();
-          const output = await client.exec(
-            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(APP_CONTAINER_NAME_PREFIX)}`,
-            ORPHAN_LIST_TIMEOUT_MS,
-          );
-          return (
-            output
-              .split("\n")
-              .map((line) => line.trim())
-              .filter(Boolean)
-              // `--filter name=` is a substring match, so re-check the prefix to
-              // exclude any container that merely contains "app-" mid-name.
-              .filter((line) => line.startsWith(APP_CONTAINER_NAME_PREFIX))
-              .map((line) => {
-                const [name = "", id = ""] = line.split("|");
-                return { name, id };
-              })
-              .filter((c) => c.name && c.id)
-          );
-        } catch (error) {
-          logger.warn("[app-orphan-reconciler] Container listing failed over SSH", {
-            nodeId: node.node_id,
-            hostname: node.hostname,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return null;
-        }
-      },
-      async removeContainer(containerId: string): Promise<void> {
-        const client = ssh();
-        await client.connect();
-        // rm by the immutable container ID (see AppOrphanReconcilerNode.removeContainer
-        // and the reap loop): targeting the name would race a concurrent recreate
-        // of the same app and could reap a live container. Keep this `<id>`.
-        await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
-      },
-    };
-  });
-
-  return reconcileOrphanAppContainers(reconcilerNodes, loadContainerStatusesByNames);
+export function reconcileOrphanAppContainersOnNodes(): Promise<OrphanReconcileResult> {
+  return reconcileOrphanContainersOnNodes(APP_ORPHAN_RECONCILER_CONFIG);
 }

--- a/packages/cloud-shared/src/lib/services/docker-node-workloads.test.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-workloads.test.ts
@@ -1,22 +1,35 @@
 /**
- * Tests for the orphan-container reconciler's pure diff logic and its
- * SSH-orchestration loop. The diff (`computeOrphanContainersToReap`) is the
- * load-bearing safety property: a container is reaped ONLY when its agent id
- * has no live DB row (or a terminal one), and never when the name does not
- * match the managed `agent-<id>` pattern. The orchestration test pins the
- * "never reap on an unreachable node" invariant (SSH listing returned null →
- * skip, not reap).
+ * Tests for the AGENT orphan-container reconciler. The diff and orchestration
+ * loop now live in the shared `orphan-container-reconciler.ts`; this suite pins
+ * the AGENT-specific wiring: the `agentIdFromContainerName` keyOf (parse the id
+ * out of `agent-<id>`), the agent terminal-status vocab, and that the shared
+ * diff reaps an agent container ONLY when its id has no live DB row (or a
+ * terminal one) and NEVER when the name does not match the managed pattern. The
+ * orchestration test pins the "never reap on an unreachable node" invariant
+ * (SSH listing returned null → skip, not reap).
+ *
+ * Because `agent_sandboxes.id` is a PRIMARY KEY, each agent id maps to AT MOST
+ * one DB row, so the shared group-by-key `every-terminal` diff reduces to a
+ * plain single-status check here — identical reaping decisions to the previous
+ * per-agent `Map<id,status>` last-write-wins implementation.
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { agentIdFromContainerName } from "./docker-node-workloads";
 import {
-  agentIdFromContainerName,
   computeOrphanContainersToReap,
-  type LiveSandboxRef,
+  type LiveContainerRef,
   type NodeContainerRef,
+  type OrphanReconcilerConfig,
   type OrphanReconcilerNode,
   reconcileOrphanContainers,
-} from "./docker-node-workloads";
+} from "./orphan-container-reconciler";
+
+/** The agent reconciler's pure-diff deltas (matches the production config). */
+const AGENT_DIFF: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
+  keyOf: agentIdFromContainerName,
+  terminalStatuses: new Set(["stopped", "error", "sleeping", "deletion_failed"]),
+};
 
 describe("agentIdFromContainerName", () => {
   test("extracts the id from an agent-<id> name", () => {
@@ -33,48 +46,39 @@ describe("agentIdFromContainerName", () => {
   });
 });
 
-describe("computeOrphanContainersToReap", () => {
-  const live = (id: string, status: string): LiveSandboxRef => ({ id, status });
+describe("computeOrphanContainersToReap (agent diff)", () => {
+  const live = (key: string, status: string): LiveContainerRef => ({ key, status });
   const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+  const compute = (containers: readonly NodeContainerRef[], rows: readonly LiveContainerRef[]) =>
+    computeOrphanContainersToReap(containers, rows, AGENT_DIFF);
 
   test("reaps a container whose agent id has NO db row", () => {
-    const orphans = computeOrphanContainersToReap([container("agent-gone", "c1")], []);
-    expect(orphans).toEqual([
-      { name: "agent-gone", id: "c1", agentId: "gone", reason: "no_db_row" },
-    ]);
+    const orphans = compute([container("agent-gone", "c1")], []);
+    expect(orphans).toEqual([{ name: "agent-gone", id: "c1", key: "gone", reason: "no_db_row" }]);
   });
 
   test("reaps a container whose db row is in a terminal state", () => {
-    const orphans = computeOrphanContainersToReap(
-      [container("agent-dead", "c2")],
-      [live("dead", "stopped")],
-    );
+    const orphans = compute([container("agent-dead", "c2")], [live("dead", "stopped")]);
     expect(orphans).toEqual([
-      { name: "agent-dead", id: "c2", agentId: "dead", reason: "terminal_db_row" },
+      { name: "agent-dead", id: "c2", key: "dead", reason: "terminal_db_row" },
     ]);
   });
 
   test("treats error / sleeping / deletion_failed rows as terminal", () => {
     for (const status of ["error", "sleeping", "deletion_failed"]) {
-      const orphans = computeOrphanContainersToReap(
-        [container("agent-x", "cx")],
-        [live("x", status)],
-      );
+      const orphans = compute([container("agent-x", "cx")], [live("x", status)]);
       expect(orphans).toHaveLength(1);
       expect(orphans[0]?.reason).toBe("terminal_db_row");
     }
   });
 
   test("does NOT reap a container with a live (running) db row", () => {
-    const orphans = computeOrphanContainersToReap(
-      [container("agent-live", "c3")],
-      [live("live", "running")],
-    );
+    const orphans = compute([container("agent-live", "c3")], [live("live", "running")]);
     expect(orphans).toEqual([]);
   });
 
   test("does NOT reap a row in deletion_pending (delete job owns teardown)", () => {
-    const orphans = computeOrphanContainersToReap(
+    const orphans = compute(
       [container("agent-deleting", "c4")],
       [live("deleting", "deletion_pending")],
     );
@@ -83,24 +87,18 @@ describe("computeOrphanContainersToReap", () => {
 
   test("does NOT reap provisioning / pending / disconnected rows", () => {
     for (const status of ["provisioning", "pending", "disconnected"]) {
-      const orphans = computeOrphanContainersToReap(
-        [container("agent-x", "cx")],
-        [live("x", status)],
-      );
+      const orphans = compute([container("agent-x", "cx")], [live("x", status)]);
       expect(orphans).toEqual([]);
     }
   });
 
   test("ignores containers that do not match the agent- pattern", () => {
-    const orphans = computeOrphanContainersToReap(
-      [container("postgres", "p1"), container("redis", "r1")],
-      [],
-    );
+    const orphans = compute([container("postgres", "p1"), container("redis", "r1")], []);
     expect(orphans).toEqual([]);
   });
 
   test("mixed fleet: reaps only the orphans, leaves live + non-agent alone", () => {
-    const orphans = computeOrphanContainersToReap(
+    const orphans = compute(
       [
         container("agent-running", "c-run"),
         container("agent-orphan", "c-orph"),
@@ -113,13 +111,25 @@ describe("computeOrphanContainersToReap", () => {
   });
 });
 
-describe("reconcileOrphanContainers (orchestration)", () => {
+describe("reconcileOrphanContainers (agent orchestration)", () => {
+  function makeConfig(
+    loadStatuses: OrphanReconcilerConfig["loadStatuses"],
+  ): OrphanReconcilerConfig {
+    return {
+      prefix: "agent-",
+      keyOf: AGENT_DIFF.keyOf,
+      terminalStatuses: AGENT_DIFF.terminalStatuses,
+      loadStatuses,
+      logScope: "orphan-reconciler",
+    };
+  }
+
   function makeNode(overrides: Partial<OrphanReconcilerNode> = {}): OrphanReconcilerNode {
     return {
       node_id: "node-1",
       hostname: "host-1",
       status: "healthy",
-      listAgentContainers: mock(async () => [] as NodeContainerRef[]),
+      listContainers: mock(async () => [] as NodeContainerRef[]),
       removeContainer: mock(async () => {}),
       ...overrides,
     };
@@ -128,58 +138,51 @@ describe("reconcileOrphanContainers (orchestration)", () => {
   test("force-removes every orphan on a healthy node", async () => {
     const removeContainer = mock(async () => {});
     const node = makeNode({
-      listAgentContainers: mock(async () => [
+      listContainers: mock(async () => [
         { name: "agent-orphan", id: "c-orph" },
         { name: "agent-live", id: "c-live" },
       ]),
       removeContainer,
     });
-    const loadLive = mock(async () => [{ id: "live", status: "running" }]);
+    const loadLive = mock(async () => [{ key: "live", status: "running" }]);
 
-    const result = await reconcileOrphanContainers([node], loadLive);
+    const result = await reconcileOrphanContainers([node], makeConfig(loadLive));
 
     expect(removeContainer).toHaveBeenCalledTimes(1);
     expect(removeContainer).toHaveBeenCalledWith("c-orph");
-    expect(result).toEqual({
-      nodesScanned: 1,
-      nodesSkipped: 0,
-      reaped: 1,
-      reapFailed: 0,
-    });
+    expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 0 });
   });
 
   test("SKIPS a node whose container listing failed — never reaps on a blind node", async () => {
     const removeContainer = mock(async () => {});
-    const node = makeNode({
-      listAgentContainers: mock(async () => null),
-      removeContainer,
-    });
+    const node = makeNode({ listContainers: mock(async () => null), removeContainer });
 
-    const result = await reconcileOrphanContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
     expect(removeContainer).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      nodesScanned: 0,
-      nodesSkipped: 1,
-      reaped: 0,
-      reapFailed: 0,
-    });
+    expect(result).toEqual({ nodesScanned: 0, nodesSkipped: 1, reaped: 0, reapFailed: 0 });
   });
 
   test("SKIPS a non-healthy node (defensive: caller should pre-filter)", async () => {
-    const listAgentContainers = mock(async () => [] as NodeContainerRef[]);
-    const node = makeNode({ status: "offline", listAgentContainers });
+    const listContainers = mock(async () => [] as NodeContainerRef[]);
+    const node = makeNode({ status: "offline", listContainers });
 
-    const result = await reconcileOrphanContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
-    expect(listAgentContainers).not.toHaveBeenCalled();
+    expect(listContainers).not.toHaveBeenCalled();
     expect(result.nodesSkipped).toBe(1);
     expect(result.nodesScanned).toBe(0);
   });
 
   test("counts a failed removal as reapFailed without aborting the rest", async () => {
     const node = makeNode({
-      listAgentContainers: mock(async () => [
+      listContainers: mock(async () => [
         { name: "agent-a", id: "ca" },
         { name: "agent-b", id: "cb" },
       ]),
@@ -188,23 +191,19 @@ describe("reconcileOrphanContainers (orchestration)", () => {
       }),
     });
 
-    const result = await reconcileOrphanContainers([node], async () => []);
+    const result = await reconcileOrphanContainers(
+      [node],
+      makeConfig(async () => []),
+    );
 
-    expect(result).toEqual({
-      nodesScanned: 1,
-      nodesSkipped: 0,
-      reaped: 1,
-      reapFailed: 1,
-    });
+    expect(result).toEqual({ nodesScanned: 1, nodesSkipped: 0, reaped: 1, reapFailed: 1 });
   });
 
   test("does not query the DB when a node has no agent- containers", async () => {
-    const loadLive = mock(async () => [] as LiveSandboxRef[]);
-    const node = makeNode({
-      listAgentContainers: mock(async () => [{ name: "redis", id: "r" }]),
-    });
+    const loadLive = mock(async () => [] as LiveContainerRef[]);
+    const node = makeNode({ listContainers: mock(async () => [{ name: "redis", id: "r" }]) });
 
-    await reconcileOrphanContainers([node], loadLive);
+    await reconcileOrphanContainers([node], makeConfig(loadLive));
 
     expect(loadLive).not.toHaveBeenCalled();
   });

--- a/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-workloads.ts
@@ -1,11 +1,18 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
-import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
-import { logger } from "../utils/logger";
-import { AGENT_CONTAINER_NAME_PREFIX, shellQuote } from "./docker-sandbox-utils";
-import { DockerSSHClient } from "./docker-ssh";
+import { AGENT_CONTAINER_NAME_PREFIX } from "./docker-sandbox-utils";
+import {
+  type LiveContainerRef,
+  type OrphanReconcileResult,
+  type OrphanReconcilerConfig,
+  reconcileOrphanContainersOnNodes as reconcileOrphanContainersOnNodesShared,
+} from "./orphan-container-reconciler";
+
+// Re-export the shared result type so existing importers (the daemon) keep
+// `OrphanReconcileResult` from this module.
+export type { OrphanReconcileResult } from "./orphan-container-reconciler";
 
 async function countRows(query: Promise<Array<{ count: number }>>): Promise<number> {
   const [row] = await query;
@@ -49,15 +56,22 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
 }
 
 // ---------------------------------------------------------------------------
-// Orphan-container reconciliation
+// Orphan AGENT-container reconciliation
 //
-// A container named `agent-<id>` on a node whose DB row has been deleted (or
-// moved to a terminal state) is an orphan: it holds a compute slot and host
-// volume forever because nothing in the provisioner lifecycle will ever reap
-// it again. The agent_delete job removes the container as part of deletion,
-// but if that SSH step fails terminally (deletion_failed) or the row is hard
-// deleted out from under a still-running container, the leak goes unnoticed.
-// This reconciler closes that gap with a low-cadence sweep over HEALTHY nodes.
+// A container named `agent-<id>` on a node whose agent_sandboxes row has been
+// deleted (or moved to a terminal state) is an orphan: it holds a compute slot
+// and host volume forever because nothing in the provisioner lifecycle will
+// ever reap it again. The agent_delete job removes the container as part of
+// deletion, but if that SSH step fails terminally (deletion_failed) or the row
+// is hard deleted out from under a still-running container, the leak goes
+// unnoticed. This reconciler closes that gap with a low-cadence sweep over
+// HEALTHY nodes.
+//
+// The orchestration, SSH wiring, timeouts, and reap-by-id rm are shared with
+// the app reconciler in `orphan-container-reconciler.ts`. This module injects
+// only the three agent-specific deltas: the `agent-` prefix, the `keyOf` that
+// parses the id out of `agent-<id>`, and the agent terminal-status vocab (plus
+// the agent_sandboxes status query and a log tag).
 // ---------------------------------------------------------------------------
 
 /**
@@ -79,39 +93,12 @@ const TERMINAL_SANDBOX_STATUSES = new Set<string>([
   "deletion_failed",
 ]);
 
-/** A container seen on a node, parsed from `docker ps -a`. */
-export interface NodeContainerRef {
-  /** Container name, e.g. `agent-<uuid>`. */
-  name: string;
-  /** Docker container id (used for the `docker rm -f` target). */
-  id: string;
-}
-
-/**
- * A live agent_sandboxes row as far as orphan reconciliation cares: its id and
- * current status. A row counts as "live" when its status is not terminal.
- */
-export interface LiveSandboxRef {
-  id: string;
-  status: string;
-}
-
-/** A container the reconciler has decided to forcibly remove. */
-export interface OrphanContainer {
-  /** Container name (`agent-<id>`). */
-  name: string;
-  /** Docker container id, the `docker rm -f` target. */
-  id: string;
-  /** Agent id extracted from the container name. */
-  agentId: string;
-  /** Why it was flagged: no DB row at all, or a row in a terminal state. */
-  reason: "no_db_row" | "terminal_db_row";
-}
-
 /**
  * Extract the agent id from an `agent-<id>` container name, or null when the
  * name does not match the managed-agent pattern (so unrelated containers on a
- * shared node are never touched).
+ * shared node are never touched). This is the agent reconciler's `keyOf`:
+ * agents key the diff on the id embedded in the name (the PRIMARY KEY
+ * `agent_sandboxes.id`), whereas apps key on the name itself.
  */
 export function agentIdFromContainerName(name: string): string | null {
   if (!name.startsWith(AGENT_CONTAINER_NAME_PREFIX)) return null;
@@ -120,259 +107,34 @@ export function agentIdFromContainerName(name: string): string | null {
 }
 
 /**
- * Pure diff: given the containers present on a node and the agent_sandboxes
- * rows that exist for those container names, decide which containers to reap.
- *
- * A container is an orphan when EITHER:
- *   - no agent_sandboxes row exists for its agent id, OR
- *   - the row exists but its status is terminal (the lifecycle has decided
- *     this agent has no live container).
- *
- * Containers whose name does not match the `agent-<id>` pattern are ignored
- * entirely — they belong to something else on the node.
- *
- * This function performs NO I/O so it can be unit-tested exhaustively.
- */
-export function computeOrphanContainersToReap(
-  containersOnNode: readonly NodeContainerRef[],
-  liveSandboxes: readonly LiveSandboxRef[],
-): OrphanContainer[] {
-  const statusById = new Map<string, string>();
-  for (const row of liveSandboxes) {
-    statusById.set(row.id, row.status);
-  }
-
-  const orphans: OrphanContainer[] = [];
-  for (const container of containersOnNode) {
-    const agentId = agentIdFromContainerName(container.name);
-    if (!agentId) continue;
-
-    const status = statusById.get(agentId);
-    if (status === undefined) {
-      orphans.push({
-        name: container.name,
-        id: container.id,
-        agentId,
-        reason: "no_db_row",
-      });
-    } else if (TERMINAL_SANDBOX_STATUSES.has(status)) {
-      orphans.push({
-        name: container.name,
-        id: container.id,
-        agentId,
-        reason: "terminal_db_row",
-      });
-    }
-  }
-  return orphans;
-}
-
-/** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
-export interface OrphanReconcilerNode {
-  node_id: string;
-  hostname: string;
-  status: string;
-  /**
-   * List `agent-`-prefixed containers on the node over SSH. Returns null when
-   * the listing failed (SSH blip) so the caller can skip the node rather than
-   * misread an empty list as "no containers" and reap live work.
-   */
-  listAgentContainers(): Promise<NodeContainerRef[] | null>;
-  /**
-   * Force-remove a container by its IMMUTABLE id over SSH. Must take the id, not
-   * the name: the id pins the exact container observed in the listing, so a
-   * concurrent recreate of the same `agent-<id>` name cannot be reaped by
-   * mistake. Implementations must NOT switch to `docker rm -f <name>`.
-   */
-  removeContainer(containerId: string): Promise<void>;
-}
-
-export interface OrphanReconcileResult {
-  /** Nodes inspected (HEALTHY only). */
-  nodesScanned: number;
-  /** Nodes skipped because the SSH container listing failed. */
-  nodesSkipped: number;
-  /** Containers successfully force-removed. */
-  reaped: number;
-  /** Containers identified as orphans but whose removal failed. */
-  reapFailed: number;
-}
-
-/**
- * Reconcile orphan containers on a set of HEALTHY nodes. The caller is
- * responsible for passing ONLY nodes that node-health has just confirmed
- * reachable, so a transient SSH blip never causes a live container to be
- * reaped. Per node: list `agent-` containers, diff against the live sandbox
- * ids, and force-remove every orphan.
- *
- * `loadLiveSandboxIds` returns the set of agent_sandboxes rows (id + status)
- * for the agent ids seen on the node — injected so this stays pure-ish and
- * unit-testable without a DB. The default production wiring is in
- * `reconcileOrphanContainersOnNodes`.
- */
-export async function reconcileOrphanContainers(
-  nodes: readonly OrphanReconcilerNode[],
-  loadLiveSandboxes: (agentIds: readonly string[]) => Promise<LiveSandboxRef[]>,
-): Promise<OrphanReconcileResult> {
-  const result: OrphanReconcileResult = {
-    nodesScanned: 0,
-    nodesSkipped: 0,
-    reaped: 0,
-    reapFailed: 0,
-  };
-
-  for (const node of nodes) {
-    if (node.status !== "healthy") {
-      // Defensive: callers should already filter, but never reap on a node
-      // we have not confirmed reachable.
-      result.nodesSkipped += 1;
-      continue;
-    }
-
-    const containersOnNode = await node.listAgentContainers();
-    if (containersOnNode === null) {
-      // SSH listing failed — skip rather than risk reaping live containers off
-      // a misread empty list.
-      result.nodesSkipped += 1;
-      logger.warn("[orphan-reconciler] Skipping node: container listing failed", {
-        nodeId: node.node_id,
-        hostname: node.hostname,
-      });
-      continue;
-    }
-    result.nodesScanned += 1;
-
-    const agentIds = containersOnNode
-      .map((c) => agentIdFromContainerName(c.name))
-      .filter((id): id is string => id !== null);
-    if (agentIds.length === 0) continue;
-
-    const liveSandboxes = await loadLiveSandboxes(agentIds);
-    const orphans = computeOrphanContainersToReap(containersOnNode, liveSandboxes);
-
-    for (const orphan of orphans) {
-      try {
-        // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
-        // id was captured in the same SSH listing that found the orphan, so it
-        // pins THAT exact container. This is what makes the reap safe against a
-        // concurrent recreate: if an agent_delete + a fresh provision race and a
-        // new `agent-<id>` container is created between the listing and the rm,
-        // `docker rm -f <id>` still targets the dead container we observed and
-        // leaves the live one alone. A future refactor to `docker rm -f <name>`
-        // would reintroduce the live-container-reap race (the name resolves to
-        // whichever container holds it NOW, i.e. the new live one) — DO NOT.
-        await node.removeContainer(orphan.id);
-        result.reaped += 1;
-        logger.info("[orphan-reconciler] Reaped orphan container", {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          containerName: orphan.name,
-          agentId: orphan.agentId,
-          reason: orphan.reason,
-        });
-      } catch (error) {
-        result.reapFailed += 1;
-        logger.warn("[orphan-reconciler] Failed to reap orphan container", {
-          nodeId: node.node_id,
-          hostname: node.hostname,
-          containerName: orphan.name,
-          agentId: orphan.agentId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-  }
-
-  return result;
-}
-
-/** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
-const ORPHAN_LIST_TIMEOUT_MS = 15_000;
-const ORPHAN_RM_TIMEOUT_MS = 30_000;
-
-/**
- * Load (id, status) for the agent_sandboxes rows matching the given agent ids,
+ * Load (key, status) for the agent_sandboxes rows matching the given agent ids,
  * including terminal-state rows. The reconciler needs the status to tell a
  * missing row (`no_db_row`) apart from a terminal one (`terminal_db_row`).
+ * `agent_sandboxes.id` is a PRIMARY KEY, so each key maps to at most one row.
  */
-async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<LiveSandboxRef[]> {
+async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<LiveContainerRef[]> {
   if (agentIds.length === 0) return [];
   return dbRead
-    .select({ id: agentSandboxes.id, status: agentSandboxes.status })
+    .select({ key: agentSandboxes.id, status: agentSandboxes.status })
     .from(agentSandboxes)
     .where(inArray(agentSandboxes.id, agentIds as string[]));
 }
 
+/** The three agent-specific deltas injected into the shared reconciler. */
+const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
+  prefix: AGENT_CONTAINER_NAME_PREFIX,
+  keyOf: agentIdFromContainerName,
+  terminalStatuses: TERMINAL_SANDBOX_STATUSES,
+  loadStatuses: loadSandboxStatusesByIds,
+  logScope: "orphan-reconciler",
+};
+
 /**
- * Production wiring for the orphan-container reconciler: enumerate enabled,
- * HEALTHY docker nodes and reconcile each over SSH. Built on the shared
- * `DockerSSHClient` pool so it reuses warm connections. Every SSH call is
- * hard-bounded so a single unresponsive node can never stall the sweep.
- *
- * Only `status === "healthy"` nodes are touched: the caller (the daemon's
- * infra-maintenance cycle) runs this AFTER the node health-check, so a node
- * that just failed its probe is excluded and a transient SSH blip never reaps
- * live containers.
+ * Production wiring for the orphan AGENT-container reconciler. Delegates to the
+ * shared sweep with the agent deltas. The daemon imports this name.
  */
-export async function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcileResult> {
-  const enabled = await dockerNodesRepository.findEnabled();
-  const healthy = enabled.filter((node) => node.status === "healthy");
-
-  const reconcilerNodes: OrphanReconcilerNode[] = healthy.map((node) => {
-    const ssh = () =>
-      DockerSSHClient.getClient(
-        node.hostname,
-        node.ssh_port ?? undefined,
-        node.host_key_fingerprint ?? undefined,
-        node.ssh_user ?? undefined,
-      );
-    return {
-      node_id: node.node_id,
-      hostname: node.hostname,
-      status: node.status,
-      async listAgentContainers(): Promise<NodeContainerRef[] | null> {
-        try {
-          const client = ssh();
-          await client.connect();
-          const output = await client.exec(
-            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(AGENT_CONTAINER_NAME_PREFIX)}`,
-            ORPHAN_LIST_TIMEOUT_MS,
-          );
-          return (
-            output
-              .split("\n")
-              .map((line) => line.trim())
-              .filter(Boolean)
-              // `--filter name=` is a substring match, so re-check the prefix to
-              // exclude any container that merely contains "agent-" mid-name.
-              .filter((line) => line.startsWith(AGENT_CONTAINER_NAME_PREFIX))
-              .map((line) => {
-                const [name = "", id = ""] = line.split("|");
-                return { name, id };
-              })
-              .filter((c) => c.name && c.id)
-          );
-        } catch (error) {
-          logger.warn("[orphan-reconciler] Container listing failed over SSH", {
-            nodeId: node.node_id,
-            hostname: node.hostname,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return null;
-        }
-      },
-      async removeContainer(containerId: string): Promise<void> {
-        const client = ssh();
-        await client.connect();
-        // rm by the immutable container ID (see OrphanReconcilerNode.removeContainer
-        // and the reap loop): targeting the name would race a concurrent recreate
-        // of the same agent and could reap a live container. Keep this `<id>`.
-        await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
-      },
-    };
-  });
-
-  return reconcileOrphanContainers(reconcilerNodes, loadSandboxStatusesByIds);
+export function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcileResult> {
+  return reconcileOrphanContainersOnNodesShared(AGENT_ORPHAN_RECONCILER_CONFIG);
 }
 
 /**

--- a/packages/cloud-shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud-shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the SHARED orphan-container reconciler — the single implementation
+ * behind both the agent (`docker-node-workloads.ts`) and app
+ * (`app-container-orphan-reconciler.ts`) paths.
+ *
+ * The per-path suites cover each path's wiring; this suite proves the shared
+ * diff handles BOTH key modes correctly:
+ *
+ *   1. UNIQUE keys (agents): `agent_sandboxes.id` is a PRIMARY KEY, so each key
+ *      maps to at most ONE row. The group-by-key `every-terminal` fold then
+ *      reduces to a plain single-status check — identical to the previous
+ *      per-agent last-write-wins `Map<id,status>`. This is the behavior-
+ *      preservation proof: same inputs → same reaping decisions.
+ *
+ *   2. DUPLICATE keys (apps): `containers.name` has NO unique constraint, so one
+ *      key maps to MANY rows. The #9307 fail-safe protects a live container that
+ *      shares a key with stale terminal rows — a key is reaped ONLY when EVERY
+ *      row is terminal, order-independently.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  computeOrphanContainersToReap,
+  type LiveContainerRef,
+  type NodeContainerRef,
+  type OrphanReconcilerConfig,
+} from "./orphan-container-reconciler";
+
+const container = (name: string, id: string): NodeContainerRef => ({ name, id });
+const live = (key: string, status: string): LiveContainerRef => ({ key, status });
+
+describe("shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins)", () => {
+  // keyOf parses the id out of `k-<id>`; terminal vocab is arbitrary here.
+  const diff: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
+    keyOf: (name) => (name.startsWith("k-") && name.length > 2 ? name.slice(2) : null),
+    terminalStatuses: new Set(["stopped", "error"]),
+  };
+
+  // For a UNIQUE key there is at most one status. `every(terminal)` over a
+  // singleton list `[s]` is exactly `terminal.has(s)`, and a missing key is
+  // `no_db_row` either way. So for every single-row input the group-by-key fold
+  // produces the SAME decision the old last-write-wins map would. We assert that
+  // equivalence directly over the full decision table.
+  const singleStatusReference = (status: string | undefined) => {
+    if (status === undefined) return "no_db_row";
+    return diff.terminalStatuses.has(status) ? "terminal_db_row" : null;
+  };
+
+  for (const status of [undefined, "running", "stopped", "error", "pending"] as const) {
+    test(`status=${String(status)} → matches single-status check`, () => {
+      const rows = status === undefined ? [] : [live("id1", status)];
+      const orphans = computeOrphanContainersToReap([container("k-id1", "c1")], rows, diff);
+      const expected = singleStatusReference(status);
+      if (expected === null) {
+        expect(orphans).toEqual([]);
+      } else {
+        expect(orphans).toEqual([{ name: "k-id1", id: "c1", key: "id1", reason: expected }]);
+      }
+    });
+  }
+
+  test("distinct unique keys are decided independently", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("k-a", "ca"), container("k-b", "cb"), container("k-c", "cc")],
+      [live("a", "running"), live("b", "stopped")],
+      diff,
+    );
+    // a=running → keep; b=stopped → reap; c=missing → reap.
+    expect(orphans.map((o) => `${o.key}:${o.reason}`).sort()).toEqual([
+      "b:terminal_db_row",
+      "c:no_db_row",
+    ]);
+  });
+});
+
+describe("shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-safe)", () => {
+  // keyOf is identity (the name IS the key), matching the app path.
+  const diff: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses"> = {
+    keyOf: (name) => (name.startsWith("app-") && name.length > 4 ? name : null),
+    terminalStatuses: new Set(["stopped", "failed", "deleted"]),
+  };
+
+  test("ANY non-terminal row among duplicates protects the key (both orders)", () => {
+    expect(
+      computeOrphanContainersToReap(
+        [container("app-dup", "c")],
+        [live("app-dup", "running"), live("app-dup", "stopped")],
+        diff,
+      ),
+    ).toEqual([]);
+    expect(
+      computeOrphanContainersToReap(
+        [container("app-dup", "c")],
+        [live("app-dup", "stopped"), live("app-dup", "running")],
+        diff,
+      ),
+    ).toEqual([]);
+  });
+
+  test("reaps only when EVERY duplicate row is terminal", () => {
+    const orphans = computeOrphanContainersToReap(
+      [container("app-dead", "c")],
+      [live("app-dead", "stopped"), live("app-dead", "failed"), live("app-dead", "deleted")],
+      diff,
+    );
+    expect(orphans).toEqual([
+      { name: "app-dead", id: "c", key: "app-dead", reason: "terminal_db_row" },
+    ]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud-shared/src/lib/services/orphan-container-reconciler.ts
@@ -1,0 +1,351 @@
+/**
+ * Shared orphan-container reconciler for the shared Hetzner-Docker pool.
+ *
+ * ONE generic sweep used by BOTH workload kinds that run on the pool:
+ *   - AGENT containers (`agent-<id>`, backed by `agent_sandboxes`) — wired in
+ *     `docker-node-workloads.ts`.
+ *   - APP containers (`app-<slug>`, backed by `containers`) — wired in
+ *     `app-container-orphan-reconciler.ts`.
+ *
+ * THE GAP THIS CLOSES
+ * A managed container on a node whose DB row has been deleted (or moved to a
+ * terminal state) is an orphan: it holds a compute slot and host volume forever
+ * because nothing in the provisioner / deploy lifecycle will ever reap it again.
+ * The delete job removes the container as part of deletion, but if that SSH step
+ * fails terminally or the row is hard-deleted out from under a still-running
+ * container, the leak goes unnoticed. This reconciler closes that gap with a
+ * low-cadence sweep over HEALTHY nodes.
+ *
+ * SAFETY INVARIANTS (a wrong reaper kills a live customer workload):
+ *   1. Only `status === "healthy"` nodes are touched.
+ *   2. If the SSH container listing returns null (listing failed) → SKIP the
+ *      node, never reap (a misread empty list must not reap live containers).
+ *   3. Reap by the IMMUTABLE container ID captured in the same listing — NEVER
+ *      by name (avoids the delete+recreate race where the name resolves to the
+ *      new live container).
+ *   4. Hard per-call SSH timeouts on both the list and the rm.
+ *   5. Every reap, skip, and failure is logged.
+ *   6. When unsure whether a container is an orphan → DO NOT reap.
+ *
+ * THE ONLY THINGS THAT DIFFER between the agent and app paths are injected via
+ * `OrphanReconcilerConfig`: the container-name `prefix`, the `keyOf` that maps a
+ * name to its DB diff key (agents parse the id out of `agent-<id>`; apps use the
+ * name itself), the `terminalStatuses` vocab, the `loadStatuses` DB query, and a
+ * `logScope` tag. Everything else — the orchestration loop, the SSH wiring, the
+ * timeouts, the reap-by-id rm — is identical and lives here once.
+ */
+
+import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
+import { logger } from "../utils/logger";
+import { shellQuote } from "./docker-sandbox-utils";
+import { DockerSSHClient } from "./docker-ssh";
+
+/** A container seen on a node, parsed from `docker ps -a`. */
+export interface NodeContainerRef {
+  /** Container name, e.g. `agent-<uuid>` or `app-<slug>`. */
+  name: string;
+  /** Docker container id (used for the `docker rm -f` target). */
+  id: string;
+}
+
+/**
+ * A live DB row as far as orphan reconciliation cares: its diff key and current
+ * status. A key counts as "live" when ANY of its rows is non-terminal.
+ */
+export interface LiveContainerRef {
+  /** Diff key — the agent id (agents) or the container name (apps). */
+  key: string;
+  status: string;
+}
+
+/** A container the reconciler has decided to forcibly remove. */
+export interface OrphanContainer {
+  /** Container name (`agent-<id>` / `app-<slug>`). */
+  name: string;
+  /** Docker container id, the `docker rm -f` target. */
+  id: string;
+  /** Diff key this container mapped to (agent id, or the name itself). */
+  key: string;
+  /** Why it was flagged: no DB row at all, or every row in a terminal state. */
+  reason: "no_db_row" | "terminal_db_row";
+}
+
+/** Per-node SSH surface the reconciler needs. Lets tests inject a fake node. */
+export interface OrphanReconcilerNode {
+  node_id: string;
+  hostname: string;
+  status: string;
+  /**
+   * List prefix-matching containers on the node over SSH. Returns null when the
+   * listing failed (SSH blip) so the caller can skip the node rather than
+   * misread an empty list as "no containers" and reap live work.
+   */
+  listContainers(): Promise<NodeContainerRef[] | null>;
+  /**
+   * Force-remove a container by its IMMUTABLE id over SSH. Must take the id, not
+   * the name: the id pins the exact container observed in the listing, so a
+   * concurrent recreate of the same name cannot be reaped by mistake.
+   * Implementations must NOT switch to `docker rm -f <name>`.
+   */
+  removeContainer(containerId: string): Promise<void>;
+}
+
+export interface OrphanReconcileResult {
+  /** Nodes inspected (HEALTHY only). */
+  nodesScanned: number;
+  /** Nodes skipped because the SSH container listing failed (or not healthy). */
+  nodesSkipped: number;
+  /** Containers successfully force-removed. */
+  reaped: number;
+  /** Containers identified as orphans but whose removal failed. */
+  reapFailed: number;
+}
+
+/**
+ * The per-workload deltas — the ONLY things that differ between the agent and
+ * app reconcilers. Everything else in this module is shared verbatim.
+ */
+export interface OrphanReconcilerConfig {
+  /** Container-name prefix to list and re-filter on (`agent-` / `app-`). */
+  prefix: string;
+  /**
+   * Map a container name to its DB diff key, or null when the name does not
+   * match the managed pattern (so unrelated containers are never touched).
+   * Agents parse the id out of `agent-<id>`; apps use the name itself.
+   */
+  keyOf(name: string): string | null;
+  /** DB statuses that mean the container should NOT be running (reapable). */
+  terminalStatuses: ReadonlySet<string>;
+  /**
+   * Load (key, status) for the DB rows matching the given diff keys, including
+   * terminal-state rows. The reconciler needs the status to tell a missing row
+   * (`no_db_row`) apart from a terminal one (`terminal_db_row`). May return
+   * MULTIPLE rows per key — the diff groups them and is fail-safe.
+   */
+  loadStatuses(keys: readonly string[]): Promise<LiveContainerRef[]>;
+  /** Log tag, e.g. `orphan-reconciler` / `app-orphan-reconciler`. */
+  logScope: string;
+}
+
+/**
+ * Pure diff: given the containers present on a node and the DB rows that exist
+ * for those container keys, decide which containers to reap.
+ *
+ * A container is an orphan when EITHER:
+ *   - no DB row exists for its key (`no_db_row`), OR
+ *   - rows exist but EVERY one of them is terminal (`terminal_db_row`) — the
+ *     lifecycle has decided this workload has no live container.
+ *
+ * FAIL-SAFE grouping (#9307): a single key can map to MULTIPLE DB rows. For
+ * apps, `containers.name` has NO unique constraint — every deploy inserts a
+ * fresh row and leaves prior rows behind in running/stopped/failed, so the row
+ * set for one name is routinely a mix like `[running, stopped]`. We group all
+ * statuses per key and reap ONLY when EVERY row is terminal: a name is LIVE
+ * (never reaped) if ANY of its rows is non-terminal. This is order-independent,
+ * so it does not matter that the `WHERE key IN (...)` query has no ORDER BY.
+ *
+ * For agents the key is `agent_sandboxes.id`, a PRIMARY KEY, so each key maps to
+ * AT MOST ONE row — the per-key list is a singleton and `every(terminal)`
+ * reduces to the single-row terminal check, i.e. identical reaping decisions to
+ * the previous last-write-wins map. (Proof of behavior-preservation.)
+ *
+ * Containers whose name does not match the managed pattern are ignored
+ * entirely — they belong to something else on the node.
+ *
+ * This function performs NO I/O so it can be unit-tested exhaustively.
+ */
+export function computeOrphanContainersToReap(
+  containersOnNode: readonly NodeContainerRef[],
+  liveRows: readonly LiveContainerRef[],
+  config: Pick<OrphanReconcilerConfig, "keyOf" | "terminalStatuses">,
+): OrphanContainer[] {
+  // Group all statuses per key (a key can have >1 DB rows for apps — there is no
+  // unique constraint on containers.name; for agents the key is a PK so the
+  // list is always a singleton).
+  const statusesByKey = new Map<string, string[]>();
+  for (const row of liveRows) {
+    const list = statusesByKey.get(row.key) ?? [];
+    list.push(row.status);
+    statusesByKey.set(row.key, list);
+  }
+
+  const orphans: OrphanContainer[] = [];
+  for (const container of containersOnNode) {
+    const key = config.keyOf(container.name);
+    if (key === null) continue;
+
+    const statuses = statusesByKey.get(key);
+    if (statuses === undefined || statuses.length === 0) {
+      orphans.push({ name: container.name, id: container.id, key, reason: "no_db_row" });
+    } else if (statuses.every((s) => config.terminalStatuses.has(s))) {
+      // Reap ONLY when EVERY row is terminal — any live row protects the key.
+      orphans.push({ name: container.name, id: container.id, key, reason: "terminal_db_row" });
+    }
+  }
+  return orphans;
+}
+
+/**
+ * Reconcile orphan containers on a set of HEALTHY nodes. The caller is
+ * responsible for passing ONLY nodes that node-health has just confirmed
+ * reachable, so a transient SSH blip never causes a live container to be reaped.
+ * Per node: list prefix containers, diff against the live DB rows, and
+ * force-remove every orphan.
+ *
+ * `config.loadStatuses` returns the DB rows (key + status) for the keys seen on
+ * the node — injected so this stays pure-ish and unit-testable without a DB. The
+ * default production wiring is in `reconcileOrphanContainersOnNodes`.
+ */
+export async function reconcileOrphanContainers(
+  nodes: readonly OrphanReconcilerNode[],
+  config: OrphanReconcilerConfig,
+): Promise<OrphanReconcileResult> {
+  const result: OrphanReconcileResult = {
+    nodesScanned: 0,
+    nodesSkipped: 0,
+    reaped: 0,
+    reapFailed: 0,
+  };
+
+  for (const node of nodes) {
+    if (node.status !== "healthy") {
+      // Defensive: callers should already filter, but never reap on a node we
+      // have not confirmed reachable.
+      result.nodesSkipped += 1;
+      continue;
+    }
+
+    const containersOnNode = await node.listContainers();
+    if (containersOnNode === null) {
+      // SSH listing failed — skip rather than risk reaping live containers off a
+      // misread empty list.
+      result.nodesSkipped += 1;
+      logger.warn(`[${config.logScope}] Skipping node: container listing failed`, {
+        nodeId: node.node_id,
+        hostname: node.hostname,
+      });
+      continue;
+    }
+    result.nodesScanned += 1;
+
+    const keys = containersOnNode
+      .map((c) => config.keyOf(c.name))
+      .filter((key): key is string => key !== null);
+    if (keys.length === 0) continue;
+
+    const liveRows = await config.loadStatuses(keys);
+    const orphans = computeOrphanContainersToReap(containersOnNode, liveRows, config);
+
+    for (const orphan of orphans) {
+      try {
+        // Reap by the IMMUTABLE container ID (`orphan.id`), never the name. The
+        // id was captured in the same SSH listing that found the orphan, so it
+        // pins THAT exact container. This is what makes the reap safe against a
+        // concurrent recreate: if a delete + a fresh provision/deploy race and a
+        // new container is created between the listing and the rm,
+        // `docker rm -f <id>` still targets the dead container we observed and
+        // leaves the live one alone. A future refactor to `docker rm -f <name>`
+        // would reintroduce the live-container-reap race (the name resolves to
+        // whichever container holds it NOW, i.e. the new live one) — DO NOT.
+        await node.removeContainer(orphan.id);
+        result.reaped += 1;
+        logger.info(`[${config.logScope}] Reaped orphan container`, {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          key: orphan.key,
+          reason: orphan.reason,
+        });
+      } catch (error) {
+        result.reapFailed += 1;
+        logger.warn(`[${config.logScope}] Failed to reap orphan container`, {
+          nodeId: node.node_id,
+          hostname: node.hostname,
+          containerName: orphan.name,
+          key: orphan.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Hard per-call SSH budgets so a hung node can never wedge the reconciler. */
+const ORPHAN_LIST_TIMEOUT_MS = 15_000;
+const ORPHAN_RM_TIMEOUT_MS = 30_000;
+
+/**
+ * Production wiring for the orphan-container reconciler: enumerate enabled,
+ * HEALTHY docker nodes and reconcile each over SSH. Built on the shared
+ * `DockerSSHClient` pool so it reuses warm connections. Every SSH call is
+ * hard-bounded so a single unresponsive node can never stall the sweep.
+ *
+ * Only `status === "healthy"` nodes are touched: the caller (the daemon's
+ * infra-maintenance cycle) runs this AFTER the node health-check, so a node that
+ * just failed its probe is excluded and a transient SSH blip never reaps live
+ * containers.
+ */
+export async function reconcileOrphanContainersOnNodes(
+  config: OrphanReconcilerConfig,
+): Promise<OrphanReconcileResult> {
+  const enabled = await dockerNodesRepository.findEnabled();
+  const healthy = enabled.filter((node) => node.status === "healthy");
+
+  const reconcilerNodes: OrphanReconcilerNode[] = healthy.map((node) => {
+    const ssh = () =>
+      DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? undefined,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? undefined,
+      );
+    return {
+      node_id: node.node_id,
+      hostname: node.hostname,
+      status: node.status,
+      async listContainers(): Promise<NodeContainerRef[] | null> {
+        try {
+          const client = ssh();
+          await client.connect();
+          const output = await client.exec(
+            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(config.prefix)}`,
+            ORPHAN_LIST_TIMEOUT_MS,
+          );
+          return (
+            output
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean)
+              // `--filter name=` is a substring match, so re-check the prefix to
+              // exclude any container that merely contains the prefix mid-name.
+              .filter((line) => line.startsWith(config.prefix))
+              .map((line) => {
+                const [name = "", id = ""] = line.split("|");
+                return { name, id };
+              })
+              .filter((c) => c.name && c.id)
+          );
+        } catch (error) {
+          logger.warn(`[${config.logScope}] Container listing failed over SSH`, {
+            nodeId: node.node_id,
+            hostname: node.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      },
+      async removeContainer(containerId: string): Promise<void> {
+        const client = ssh();
+        await client.connect();
+        // rm by the immutable container ID (see OrphanReconcilerNode.removeContainer
+        // and the reap loop): targeting the name would race a concurrent recreate
+        // of the same workload and could reap a live container. Keep this `<id>`.
+        await client.exec(`docker rm -f ${shellQuote(containerId)}`, ORPHAN_RM_TIMEOUT_MS);
+      },
+    };
+  });
+
+  return reconcileOrphanContainers(reconcilerNodes, config);
+}


### PR DESCRIPTION
## What

The app orphan reconciler (`app-container-orphan-reconciler.ts`) was a **~300-line near-verbatim copy** of the agent orphan reconciler (the orphan-reconciler section of `docker-node-workloads.ts`) — byte-identical after an `agent`→`app` / `sandbox`→`container` / `id`→`name` rename: the orchestration loop, the production SSH wiring (`findEnabled()` → `healthy` filter → the `ssh()` closure → `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=<prefix>` + the substring re-filter → `docker rm -f <id>`), the timeout constants, the result type, the node/ref types, and the skip/reap/log scaffolding.

This extracts **ONE** generic implementation in a new `orphan-container-reconciler.ts`. Both paths now inject only their **three real deltas** and delegate.

## The shared design — 3 injected deltas

```ts
export interface OrphanReconcilerConfig {
  prefix: string;                                                   // "agent-" | "app-"
  keyOf(name: string): string | null;                              // agentIdFromContainerName | identity(app name)
  terminalStatuses: ReadonlySet<string>;                           // TERMINAL_SANDBOX_STATUSES | TERMINAL_CONTAINER_STATUSES
  loadStatuses(keys: readonly string[]): Promise<LiveContainerRef[]>;  // the per-table status query
  logScope: string;                                                // "orphan-reconciler" | "app-orphan-reconciler"
}
```

Exported shared entry points (single result type reused for both — no per-path alias types):

```ts
export async function reconcileOrphanContainers(
  nodes: readonly OrphanReconcilerNode[],
  config: OrphanReconcilerConfig,
): Promise<OrphanReconcileResult>;

export async function reconcileOrphanContainersOnNodes(   // production SSH wiring
  config: OrphanReconcilerConfig,
): Promise<OrphanReconcileResult>;
```

`docker-node-workloads.ts` (agent) and `app-container-orphan-reconciler.ts` (app) are now thin wiring layers: each builds its config and delegates, and re-exports the result type under the exact name the daemon imports (`OrphanReconcileResult` / `AppOrphanReconcileResult`). **`provisioning-worker.ts` is unchanged** — same exported function and type names. The `count*` workload helpers and `agentIdFromContainerName` stay in `docker-node-workloads.ts`.

## Behavior-preserving for the LIVE agent reaper (proof)

The shared diff adopts the app-side **group-by-key `every-terminal`** fail-safe (#9307) as the single compute. This is provably equivalent to the agent's prior `Map<key,string>` last-write-wins **when keys are unique**, and `agent_sandboxes.id` is a **PRIMARY KEY** (`uuid("id").primaryKey()`), so agent keys are always unique:

- Each agent key maps to **at most one** row → the per-key status list is a singleton `[s]`.
- `statuses.every(s => terminal.has(s))` over `[s]` reduces **exactly** to `terminal.has(s)`.
- A missing key is still `no_db_row` either way.

→ identical reaping decisions to the old per-agent single-status check. The #9307 live-container-reap fix now protects **both** paths (apps need it because `containers.name` has no unique constraint and accumulates one row per deploy).

All safety invariants preserved: healthy-nodes-only, null-listing-skip (never reap on a failed listing), reap-by-immutable-id (never name), hard per-call SSH timeouts (15s list / 30s rm), log every reap/skip/failure.

## Tests — both existing suites green + new shared suite

- `docker-node-workloads.test.ts` (agent): **16 pass / 0 fail**
- `app-container-orphan-reconciler.test.ts` (app): **20 pass / 0 fail**
- `orphan-container-reconciler.test.ts` (**new**, shared): **8 pass / 0 fail** — proves BOTH key modes: unique agent ids reduce to a single-status check (the behavior-preservation table), and duplicate app names trigger the `every-terminal` fail-safe (order-independent).

`44 pass / 0 fail` total. biome clean on all touched files. Typecheck: no errors in the touched files or their importers (`node-autoscaler`, `docker-node-manager`, `provisioning-worker`).

## Net

Source (production, excluding tests): `docker-node-workloads.ts` 416→178 + `app-container-orphan-reconciler.ts` 381→133 + new `orphan-container-reconciler.ts` 351 = **797 → 662 lines (−135)**, and the ~300-line near-verbatim duplication collapses to one shared implementation.

Refs #8434
