### PR TITLE
fix(app-core): delegate drop status route

### DIFF
--- a/packages/app-core/src/api/drop-status-compat-route.test.ts
+++ b/packages/app-core/src/api/drop-status-compat-route.test.ts
@@ -1,0 +1,98 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleDropStatusCompatRoute } from "./drop-status-compat-route";
+
+const mocks = vi.hoisted(() => ({
+  ensureCompatSensitiveRouteAuthorized: vi.fn(),
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureCompatSensitiveRouteAuthorized:
+    mocks.ensureCompatSensitiveRouteAuthorized,
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  };
+});
+
+function fakeReq(pathname = "/api/drop/status"): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = pathname;
+  req.headers = { host: "localhost:2138" };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+function fakeRes(): http.ServerResponse {
+  return new http.ServerResponse(fakeReq());
+}
+
+describe("handleDropStatusCompatRoute", () => {
+  beforeEach(() => {
+    mocks.ensureCompatSensitiveRouteAuthorized.mockReset();
+  });
+
+  it("ignores non-drop-status routes", () => {
+    const handled = handleDropStatusCompatRoute(
+      fakeReq("/api/agent/status"),
+      fakeRes(),
+      "GET",
+      "/api/agent/status",
+    );
+
+    expect(handled).toBe(false);
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).not.toHaveBeenCalled();
+  });
+
+  it("handles unauthorized drop status requests locally", () => {
+    mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(false);
+    const req = fakeReq();
+    const res = fakeRes();
+
+    const handled = handleDropStatusCompatRoute(
+      req,
+      res,
+      "GET",
+      "/api/drop/status",
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).toHaveBeenCalledWith(
+      req,
+      res,
+    );
+  });
+
+  it("falls through for authorized drop status requests", () => {
+    mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(true);
+    const req = fakeReq();
+    const res = fakeRes();
+
+    const handled = handleDropStatusCompatRoute(
+      req,
+      res,
+      "GET",
+      "/api/drop/status",
+    );
+
+    expect(handled).toBe(false);
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).toHaveBeenCalledWith(
+      req,
+      res,
+    );
+  });
+});

--- a/packages/app-core/src/api/drop-status-compat-route.ts
+++ b/packages/app-core/src/api/drop-status-compat-route.ts
@@ -1,0 +1,23 @@
+import type http from "node:http";
+import { logger } from "@elizaos/core";
+import { ensureCompatSensitiveRouteAuthorized } from "./auth.ts";
+
+export function handleDropStatusCompatRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  method: string,
+  pathname: string,
+): boolean {
+  if (method !== "GET" || pathname !== "/api/drop/status") {
+    return false;
+  }
+
+  if (!ensureCompatSensitiveRouteAuthorized(req, res)) {
+    logger.warn(
+      "[eliza][drop] GET /api/drop/status rejected (sensitive route not authorized)",
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -140,6 +140,7 @@ import { handleCatalogRoutes } from "./catalog-routes";
 import { handleCloudPairRoute } from "./cloud-pair-route";
 import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
 import { handleDevCompatRoutes } from "./dev-compat-routes";
+import { handleDropStatusCompatRoute } from "./drop-status-compat-route";
 import { handleFirstRunRoute } from "./first-run-routes";
 import { handleFirstRunTtsRoute } from "./first-run-tts-route";
 import { handleInternalWakeRoute } from "./internal-routes";
@@ -799,25 +800,7 @@ async function handleCompatRouteInner(
   // cloud-connection management. `/api/cloud/*` connection management is
   // served by elizaCloudRoutePlugin.routes on the runtime plugin route system.
 
-  if (method === "GET" && url.pathname === "/api/drop/status") {
-    const config = loadElizaConfig() as ElizaConfig & {
-      features?: { dropEnabled?: boolean };
-    };
-    if (config.features?.dropEnabled === true) {
-      return false;
-    }
-    sendJsonResponse(res, 200, {
-      dropEnabled: false,
-      publicMintOpen: false,
-      whitelistMintOpen: false,
-      mintedOut: false,
-      currentSupply: 0,
-      maxSupply: 0,
-      shinyPrice: "0",
-      userHasMinted: false,
-    });
-    return true;
-  }
+  if (handleDropStatusCompatRoute(req, res, method, url.pathname)) return true;
 
   if (method === "POST" && url.pathname === "/api/agent/reset") {
     if (!ensureCompatSensitiveRouteAuthorized(req, res)) {


### PR DESCRIPTION
## Summary
- Remove app-core's hardcoded `/api/drop/status` disabled payload.
- Gate `/api/drop/status` with `ensureCompatSensitiveRouteAuthorized`.
- Fall through on authorized requests so `plugin-elizamaker` remains the route owner.
- Add focused app-core coverage for ignored, unauthorized, and authorized fallthrough behavior.
- Carry the minimal stale NFA route cleanup while #9357 is pending, because current `develop` otherwise fails dependent typecheck/root verify.

Fixes #9320.
Follow-up cleanup for #9322.

## Evidence
- `bun run --cwd packages/app-core test src/api/drop-status-compat-route.test.ts` - 3 pass
- `bun run --cwd packages/app-core lint` - exits 0; existing warning in `src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts`
- `bun run --cwd packages/app-core typecheck` - pass
- `bun run --cwd packages/app-core build` - pass
- `bun run --cwd packages/agent typecheck` - pass
- `bun run --cwd plugins/plugin-registry typecheck` - pass
- `git diff --check HEAD~2..HEAD` - pass
- `git fetch origin && git rebase origin/develop` - clean
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total
