### PR TITLE
fix(scenario-runner): enforce expected actions

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -157,6 +157,7 @@ export type ScenarioTurn = {
   assertTurn?: (turn: ScenarioTurnExecution) => ScenarioCheckResult;
   responseIncludesAny?: ResponsePattern[];
   responseExcludes?: ResponsePattern[];
+  expectedActions?: string[];
   responseJudge?: ScenarioJudgeRubric;
   plannerJudge?: ScenarioJudgeRubric;
   [key: string]: unknown;

--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -427,6 +427,147 @@ describe("scenario executor action turns", () => {
     ]);
   });
 
+  it("matches expectedActions against the action selected during the turn", async () => {
+    const runtime = createRuntime(
+      [
+        {
+          name: "CALENDAR_CREATE_EVENT",
+          description: "test action",
+          validate: vi.fn(async () => true),
+          handler: vi.fn(
+            async (_runtime, _message, _state, _options, callback) => {
+              await callback?.({ text: "created calendar event" });
+              return { success: true };
+            },
+          ),
+        } as Action,
+      ],
+      {
+        useModel: vi.fn() as AgentRuntime["useModel"],
+      },
+    );
+
+    const report = await runScenario(
+      {
+        id: "expected-actions-pass",
+        title: "Expected actions pass",
+        domain: "executor",
+        turns: [
+          {
+            kind: "action",
+            name: "create event",
+            actionName: "CALENDAR_CREATE_EVENT",
+            expectedActions: ["CALENDAR_CREATE"],
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.turns[0]?.failedAssertions).toEqual([]);
+    expect(runtime.useModel).not.toHaveBeenCalled();
+  });
+
+  it("reports expected and actual action names for expectedActions failures", async () => {
+    const runtime = createRuntime(
+      [
+        {
+          name: "VIEWS",
+          description: "test action",
+          validate: vi.fn(async () => true),
+          handler: vi.fn(
+            async (_runtime, _message, _state, _options, callback) => {
+              await callback?.({ text: "opened local notes" });
+              return { success: true };
+            },
+          ),
+        } as Action,
+      ],
+      {
+        useModel: vi.fn() as AgentRuntime["useModel"],
+      },
+    );
+
+    const report = await runScenario(
+      {
+        id: "expected-actions-failure",
+        title: "Expected actions failure",
+        domain: "executor",
+        turns: [
+          {
+            kind: "action",
+            name: "schedule",
+            actionName: "VIEWS",
+            expectedActions: ["CALENDAR"],
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(runtime.useModel).not.toHaveBeenCalled();
+    expect(report.turns[0]?.failedAssertions).toEqual([
+      "expectedActions: expected action in [CALENDAR], saw actions [VIEWS]",
+    ]);
+  });
+
+  it("does not satisfy expectedActions with a synthesized REPLY", async () => {
+    const runtime = {
+      ...createRuntime([]),
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback({
+            text: "I replied in plain text without selecting an action.",
+          });
+          return {};
+        }),
+      },
+    } as unknown as AgentRuntime;
+
+    const report = await runScenario(
+      {
+        id: "expected-actions-synthesized-reply",
+        title: "Expected actions synthesized reply",
+        domain: "executor",
+        turns: [
+          {
+            kind: "message",
+            name: "plain reply",
+            text: "say hello",
+            expectedActions: ["REPLY"],
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.turns[0]?.actionsCalled[0]).toMatchObject({
+      actionName: "REPLY",
+      result: { data: { source: "synthesized-reply" } },
+    });
+    expect(report.turns[0]?.failedAssertions).toEqual([
+      "expectedActions: expected action in [REPLY], saw actions [(none)]; captured actions: [REPLY]",
+    ]);
+  });
+
   it("uses action callback output directly before scenario assertions", async () => {
     const runtime = createRuntime(
       [

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -35,6 +35,7 @@ import type {
   ScenarioTurn,
   ScenarioTurnExecution,
 } from "@elizaos/scenario-runner/schema";
+import { actionMatchesScenarioExpectation } from "./action-families.ts";
 import { runFinalCheck } from "./final-checks/index.ts";
 import { attachInterceptor } from "./interceptor.ts";
 import { judgeTextWithLlm } from "./judge.ts";
@@ -67,6 +68,23 @@ function responsePatternMatches(
     return pattern.test(responseText);
   }
   return false;
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value === "string" && value.length > 0) {
+    return [value];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function isSynthesizedReplyAction(
+  action: ScenarioTurnExecution["actionsCalled"][number],
+): boolean {
+  const data = toRecord(action.result?.data);
+  return action.actionName === "REPLY" && data?.source === "synthesized-reply";
 }
 
 type ScenarioRoomDefinition = {
@@ -1463,6 +1481,34 @@ async function runTurnAssertions(
     const result = await turn.assertTurn(execution);
     if (typeof result === "string" && result.length > 0) {
       failures.push(`assertTurn: ${result}`);
+    }
+  }
+
+  const expectedActions = stringList(
+    (turn as { expectedActions?: unknown }).expectedActions,
+  );
+  if (expectedActions.length > 0) {
+    const realActions = execution.actionsCalled.filter(
+      (action) => !isSynthesizedReplyAction(action),
+    );
+    const ok = realActions.some((action) =>
+      actionMatchesScenarioExpectation(action.actionName, expectedActions),
+    );
+    if (!ok) {
+      const realActionNames =
+        realActions.map((action) => action.actionName).join(",") || "(none)";
+      const capturedActionNames =
+        execution.actionsCalled.map((action) => action.actionName).join(",") ||
+        "(none)";
+      const capturedDetail =
+        capturedActionNames === realActionNames
+          ? ""
+          : `; captured actions: [${capturedActionNames}]`;
+      failures.push(
+        `expectedActions: expected action in [${expectedActions.join(
+          ",",
+        )}], saw actions [${realActionNames}]${capturedDetail}`,
+      );
     }
   }
 


### PR DESCRIPTION
Summary
- Enforces `turn.expectedActions` in `runTurnAssertions` against captured real actions.
- Uses the existing action-family matcher so scenario expectations can match action families, not only exact names.
- Excludes synthesized reply placeholders from satisfying action expectations and adds schema typing plus executor coverage.

Evidence
- `bun install`
- `bun run --cwd packages/scenario-runner test -- src/executor.test.ts`
- `bun run --cwd packages/scenario-runner test`
- `bun run --cwd packages/scenario-runner typecheck`
- `bun run --cwd packages/scenario-runner build`
- `bunx @biomejs/biome check packages/scenario-runner/src/executor.ts packages/scenario-runner/src/executor.test.ts packages/scenario-runner/schema/index.d.ts`
- `git diff --check origin/develop..HEAD`
- `bun run verify` after rebasing onto current `origin/develop` (509 successful, 509 total)

Refs #9310.