### PR TITLE
fix(scenario-runner): add memoryExists final check

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -231,6 +231,12 @@ export type ScenarioFinalCheck =
       table: StringMatcher;
       minCount?: number;
     })
+  | (CheckBase<"memoryExists"> & {
+      table?: StringMatcher;
+      content?: unknown;
+      minCount?: number;
+      expected?: boolean;
+    })
   | (CheckBase<"gmailActionArguments"> & {
       actionName?: StringMatcher;
       subaction?: StringMatcher;

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -31,6 +31,7 @@ export const FINAL_CHECK_KEYS = new Map(
       "minCount",
     ],
     memoryWriteOccurred: ["type", "name", "table", "minCount"],
+    memoryExists: ["type", "name", "table", "content", "minCount", "expected"],
     judgeRubric: ["type", "name", "rubric", "minimumScore"],
     gmailActionArguments: [
       "type",

--- a/packages/scenario-runner/src/final-checks/index.test.ts
+++ b/packages/scenario-runner/src/final-checks/index.test.ts
@@ -1,0 +1,115 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  ScenarioContext,
+  ScenarioFinalCheck,
+} from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+import { runFinalCheck } from "./index";
+
+const runtime = {} as IAgentRuntime;
+
+function createContext(
+  overrides: Partial<ScenarioContext> = {},
+): ScenarioContext {
+  return {
+    actionsCalled: [],
+    memoryWrites: [],
+    ...overrides,
+  };
+}
+
+describe("memoryExists finalCheck", () => {
+  it("passes when a captured memory write matches the requested content", async () => {
+    const result = await runFinalCheck(
+      {
+        type: "memoryExists",
+        content: {
+          text: { $contains: "submit report" },
+        },
+      } as ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: createContext({
+          memoryWrites: [
+            {
+              table: "messages",
+              content: {
+                text: "Added todo: Submit Report.",
+              },
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      type: "memoryExists",
+      status: "passed",
+      detail: "1 matching memory write(s)",
+    });
+  });
+
+  it("fails when no captured memory write matches the requested content", async () => {
+    const result = await runFinalCheck(
+      {
+        type: "memoryExists",
+        content: {
+          text: { $contains: "timesheet" },
+        },
+      } as ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: createContext({
+          memoryWrites: [
+            {
+              table: "messages",
+              content: {
+                text: "Added todo: Submit Report.",
+              },
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      type: "memoryExists",
+      status: "failed",
+      detail: "expected 1 matching memory write(s), saw 0 of 1 total",
+    });
+  });
+
+  it("supports table filters, minCount, and negative checks", async () => {
+    const ctx = createContext({
+      memoryWrites: [
+        { table: "messages", content: { text: "take vitamins" } },
+        { table: "messages", content: { text: "vitamins overdue" } },
+        { table: "facts", content: { text: "vitamins" } },
+      ],
+    });
+
+    await expect(
+      runFinalCheck(
+        {
+          type: "memoryExists",
+          table: "messages",
+          content: { text: { $contains: "vitamins" } },
+          minCount: 2,
+        } as ScenarioFinalCheck,
+        { runtime, ctx },
+      ),
+    ).resolves.toMatchObject({ status: "passed" });
+
+    await expect(
+      runFinalCheck(
+        {
+          type: "memoryExists",
+          table: "messages",
+          content: { text: { $contains: "deleted" } },
+          expected: false,
+        } as ScenarioFinalCheck,
+        { runtime, ctx },
+      ),
+    ).resolves.toMatchObject({ status: "passed" });
+  });
+});

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -138,6 +138,34 @@ function matchesExpectedFields(
   );
 }
 
+function matchesContentMatcher(actual: unknown, expected: unknown): boolean {
+  const expectedRecord = toRecord(expected);
+  if (expectedRecord) {
+    if (Object.hasOwn(expectedRecord, "$contains")) {
+      const needle = expectedRecord.$contains;
+      if (typeof needle !== "string" && !(needle instanceof RegExp)) {
+        return false;
+      }
+      const haystack =
+        typeof actual === "string" ? actual : JSON.stringify(actual ?? "");
+      return matchesPattern(haystack, needle);
+    }
+    const actualRecord = toRecord(actual);
+    if (!actualRecord) {
+      return false;
+    }
+    return Object.entries(expectedRecord).every(([key, value]) =>
+      matchesContentMatcher(actualRecord[key], value),
+    );
+  }
+  if (Array.isArray(expected)) {
+    return expected.some((candidate) =>
+      matchesContentMatcher(actual, candidate),
+    );
+  }
+  return valuesEqual(actual, expected);
+}
+
 type GmailMockRequest = {
   environment?: string;
   method?: string;
@@ -513,6 +541,50 @@ registerFinalCheckHandler("memoryWriteOccurred", (check, { ctx }) => {
   return {
     status: "passed",
     detail: `${matched.length} write(s) to [${tables.join(",")}]`,
+  };
+});
+
+registerFinalCheckHandler("memoryExists", (check, { ctx }) => {
+  const { table, content, minCount, expected } = check as {
+    table?: string | string[];
+    content?: unknown;
+    minCount?: number;
+    expected?: boolean;
+  };
+  const tables = table === undefined ? [] : toArray(table);
+  const writes = ctx.memoryWrites ?? [];
+  const matched = writes.filter((write) => {
+    if (tables.length > 0 && !tables.includes(write.table)) {
+      return false;
+    }
+    if (content === undefined) {
+      return true;
+    }
+    return matchesContentMatcher(write.content, content);
+  });
+  const wantPresent = expected ?? true;
+  const wantCount = typeof minCount === "number" ? minCount : 1;
+  if (wantPresent) {
+    if (matched.length < wantCount) {
+      return {
+        status: "failed",
+        detail: `expected ${wantCount} matching memory write(s), saw ${matched.length} of ${writes.length} total`,
+      };
+    }
+    return {
+      status: "passed",
+      detail: `${matched.length} matching memory write(s)`,
+    };
+  }
+  if (matched.length > 0) {
+    return {
+      status: "failed",
+      detail: `expected no matching memory write, saw ${matched.length}`,
+    };
+  }
+  return {
+    status: "passed",
+    detail: "no matching memory write observed",
   };
 });
 


### PR DESCRIPTION
## Summary

Partial fix for #9310.

Adds a real `memoryExists` finalCheck handler in the scenario-runner so authored todo scenarios no longer fail with `no handler registered` for that proof. The handler checks the captured `memoryWrites` ledger, supports optional table filters, `minCount`, negative checks via `expected:false`, and the existing scenario shape:

```ts
content: {
  text: { $contains: "submit report" }
}
```

Also registers `memoryExists` in the scenario schema/types and adds focused red/green unit coverage.

## Evidence

- `bun run --cwd packages/scenario-runner test src/final-checks/index.test.ts` - 1 file / 3 tests passed
- `bun run --cwd packages/scenario-runner test` - 18 files / 123 tests passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner build` - passed
- `bunx @biomejs/biome check packages/scenario-runner/src/final-checks/index.ts packages/scenario-runner/src/final-checks/index.test.ts packages/scenario-runner/schema/index.js packages/scenario-runner/schema/index.d.ts` - passed
- `git fetch origin && git rebase origin/develop` - no-op after final verify
- `bun install` - no dependency changes
- `bun run verify` - 509 successful / 509 total

## Notes

This intentionally does not touch the active `expectedActions` claim on #9310, and it does not implement the other missing finalCheck handlers yet.
