### PR TITLE
fix(scenario-runner): add definitionCountDelta final check

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -141,6 +141,18 @@ type CheckBase<Type extends string> = {
 
 type StringMatcher = string | string[];
 type ResponsePattern = string | RegExp;
+type DefinitionCountRequiredSlot = {
+  label?: string;
+  minuteOfDay?: number;
+};
+type DefinitionCountWebsiteAccess = {
+  groupKey?: string;
+  websites?: string[];
+  unlockMode?: string;
+  unlockDurationMinutes?: number;
+  callbackKey?: string | null;
+  reason?: string;
+};
 
 export type ScenarioTurn = {
   kind?: string;
@@ -276,6 +288,20 @@ export type ScenarioFinalCheck =
       workflowId?: string;
       expected?: boolean;
       minCount?: number;
+    })
+  | (CheckBase<"definitionCountDelta"> & {
+      title: string;
+      titleAliases?: string[];
+      delta?: number;
+      cadenceKind?: "once" | "daily" | "weekly" | "times_per_day" | "interval";
+      requiredSlots?: DefinitionCountRequiredSlot[];
+      requiredWeekdays?: number[];
+      requiredWindows?: string[];
+      requiredEveryMinutes?: number;
+      requiredMaxOccurrencesPerDay?: number;
+      expectedTimeZone?: string;
+      requireReminderPlan?: boolean;
+      websiteAccess?: DefinitionCountWebsiteAccess;
     })
   | (CheckBase<"judgeRubric"> & {
       name: string;

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -64,6 +64,22 @@ export const FINAL_CHECK_KEYS = new Map(
       "expected",
       "minCount",
     ],
+    definitionCountDelta: [
+      "type",
+      "name",
+      "title",
+      "titleAliases",
+      "delta",
+      "cadenceKind",
+      "requiredSlots",
+      "requiredWeekdays",
+      "requiredWindows",
+      "requiredEveryMinutes",
+      "requiredMaxOccurrencesPerDay",
+      "expectedTimeZone",
+      "requireReminderPlan",
+      "websiteAccess",
+    ],
   }).map(([type, keys]) => [type, new Set(keys)]),
 );
 

--- a/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
+++ b/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
@@ -1,0 +1,160 @@
+import type { ScenarioFinalCheck } from "@elizaos/scenario-runner/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  definitions: [] as unknown[],
+}));
+
+vi.mock("@elizaos/plugin-personal-assistant/lifeops/service", () => ({
+  LifeOpsService: class {
+    async listDefinitions(): Promise<unknown[]> {
+      return mockState.definitions;
+    }
+  },
+}));
+
+const { runFinalCheck } = await import("./index.ts");
+
+function definitionRecord(
+  definition: Record<string, unknown>,
+  reminderPlan: unknown = null,
+): unknown {
+  return {
+    definition: {
+      id: "definition-1",
+      title: "Brush teeth",
+      timezone: "UTC",
+      cadence: { kind: "daily", windows: ["morning"] },
+      reminderPlanId: reminderPlan ? "plan-1" : null,
+      websiteAccess: null,
+      ...definition,
+    },
+    reminderPlan,
+  };
+}
+
+async function run(check: ScenarioFinalCheck) {
+  return runFinalCheck(check, {
+    runtime: {} as never,
+    ctx: { actionsCalled: [] },
+  });
+}
+
+describe("definitionCountDelta final check", () => {
+  beforeEach(() => {
+    mockState.definitions = [];
+  });
+
+  it("passes when a matching definition has the required cadence slots, timezone, and reminder plan", async () => {
+    mockState.definitions = [
+      definitionRecord(
+        {
+          title: "Brush teeth 8 am & 9 pm",
+          timezone: "America/Denver",
+          cadence: {
+            kind: "times_per_day",
+            slots: [
+              { label: "Morning", minuteOfDay: 480, durationMinutes: 15 },
+              { label: "Night", minuteOfDay: 1260, durationMinutes: 15 },
+            ],
+          },
+        },
+        { id: "plan-1", steps: [{ channel: "in_app", offsetMinutes: 0 }] },
+      ),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: ["Brush teeth 8 am & 9 pm"],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      expectedTimeZone: "America/Denver",
+      requireReminderPlan: true,
+    });
+
+    expect(result.status).toBe("passed");
+  });
+
+  it("passes interval cadence and required windows/max occurrence fields", async () => {
+    mockState.definitions = [
+      definitionRecord(
+        {
+          title: "Drink water",
+          cadence: {
+            kind: "interval",
+            everyMinutes: 180,
+            maxOccurrencesPerDay: 4,
+            windows: ["morning", "afternoon", "evening"],
+          },
+        },
+        { id: "plan-1" },
+      ),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "interval",
+      requiredEveryMinutes: 180,
+      requiredMaxOccurrencesPerDay: 4,
+      requiredWindows: ["morning", "afternoon", "evening"],
+      requireReminderPlan: true,
+    });
+
+    expect(result.status).toBe("passed");
+  });
+
+  it("fails when a matching definition is missing a required slot", async () => {
+    mockState.definitions = [
+      definitionRecord({
+        title: "Brush teeth",
+        cadence: {
+          kind: "times_per_day",
+          slots: [{ label: "Morning", minuteOfDay: 480 }],
+        },
+      }),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("1260");
+  });
+
+  it("fails when website access fields do not match", async () => {
+    mockState.definitions = [
+      definitionRecord({
+        title: "Workout",
+        cadence: { kind: "daily", windows: ["afternoon"] },
+        websiteAccess: {
+          groupKey: "workout",
+          websites: ["youtube.com"],
+          unlockMode: "fixed_duration",
+          unlockDurationMinutes: 30,
+        },
+      }),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "Workout",
+      delta: 1,
+      websiteAccess: {
+        unlockMode: "fixed_duration",
+        unlockDurationMinutes: 60,
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("websiteAccess");
+  });
+});

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { LifeOpsService } from "@elizaos/plugin-personal-assistant/lifeops/service";
 import {
   FINAL_CHECK_KEYS,
   type ScenarioContext,
@@ -165,6 +166,232 @@ function matchesContentMatcher(actual: unknown, expected: unknown): boolean {
     );
   }
   return valuesEqual(actual, expected);
+}
+
+function normalizeComparableText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function textMatchesLoose(actual: string, expected: string): boolean {
+  const normalizedActual = normalizeComparableText(actual);
+  const normalizedExpected = normalizeComparableText(expected);
+  return (
+    normalizedActual === normalizedExpected ||
+    normalizedActual.includes(normalizedExpected) ||
+    normalizedExpected.includes(normalizedActual)
+  );
+}
+
+function recordHasEntries(value: unknown): boolean {
+  const record = toRecord(value);
+  return Boolean(record && Object.keys(record).length > 0);
+}
+
+type DefinitionCountCheck = {
+  title?: string;
+  titleAliases?: string[];
+  delta?: number;
+  cadenceKind?: string;
+  requiredSlots?: Array<{ label?: string; minuteOfDay?: number }>;
+  requiredWeekdays?: number[];
+  requiredWindows?: string[];
+  requiredEveryMinutes?: number;
+  requiredMaxOccurrencesPerDay?: number;
+  expectedTimeZone?: string;
+  requireReminderPlan?: boolean;
+  websiteAccess?: Record<string, unknown>;
+};
+
+type DefinitionRecordLike = {
+  definition: Record<string, unknown>;
+  reminderPlan: unknown;
+};
+
+type DefinitionListingService = {
+  listDefinitions(): Promise<unknown[]>;
+};
+
+function isDefinitionListingService(
+  value: unknown,
+): value is DefinitionListingService {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  if (!("listDefinitions" in value)) {
+    return false;
+  }
+  return typeof value.listDefinitions === "function";
+}
+
+function definitionRecordFromValue(
+  value: unknown,
+): DefinitionRecordLike | null {
+  const record = toRecord(value);
+  if (!record) {
+    return null;
+  }
+  const definition = toRecord(record.definition) ?? record;
+  if (typeof definition.title !== "string") {
+    return null;
+  }
+  return {
+    definition,
+    reminderPlan: record.reminderPlan ?? definition.reminderPlan ?? null,
+  };
+}
+
+function definitionTitleMatches(
+  definition: Record<string, unknown>,
+  check: DefinitionCountCheck,
+): boolean {
+  if (typeof check.title !== "string" || check.title.trim().length === 0) {
+    return false;
+  }
+  if (typeof definition.title !== "string") {
+    return false;
+  }
+  const actualTitle = definition.title;
+  const accepted = [check.title, ...(check.titleAliases ?? [])];
+  return accepted.some((title) => textMatchesLoose(actualTitle, title));
+}
+
+function requiredSlotMatches(
+  actualSlot: unknown,
+  expectedSlot: { label?: string; minuteOfDay?: number },
+): boolean {
+  const actual = toRecord(actualSlot);
+  if (!actual) {
+    return false;
+  }
+  if (
+    typeof expectedSlot.minuteOfDay === "number" &&
+    actual.minuteOfDay !== expectedSlot.minuteOfDay
+  ) {
+    return false;
+  }
+  if (typeof expectedSlot.label === "string") {
+    return (
+      typeof actual.label === "string" &&
+      textMatchesLoose(actual.label, expectedSlot.label)
+    );
+  }
+  return true;
+}
+
+function arrayContainsAllValues(actual: unknown, expected: unknown[]): boolean {
+  if (!Array.isArray(actual)) {
+    return false;
+  }
+  return expected.every((expectedValue) =>
+    actual.some((actualValue) =>
+      looselyMatchesValue(actualValue, expectedValue),
+    ),
+  );
+}
+
+function looselyMatchesValue(actual: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return arrayContainsAllValues(actual, expected);
+  }
+  const expectedRecord = toRecord(expected);
+  if (expectedRecord) {
+    const actualRecord = toRecord(actual);
+    return Boolean(
+      actualRecord &&
+        Object.entries(expectedRecord).every(([key, value]) =>
+          looselyMatchesValue(actualRecord[key], value),
+        ),
+    );
+  }
+  if (typeof expected === "string") {
+    return (
+      typeof actual === "string" &&
+      normalizeComparableText(actual) === normalizeComparableText(expected)
+    );
+  }
+  return actual === expected;
+}
+
+function definitionMismatchReasons(
+  record: DefinitionRecordLike,
+  check: DefinitionCountCheck,
+): string[] {
+  const reasons: string[] = [];
+  const cadence = toRecord(record.definition.cadence);
+  if (
+    typeof check.cadenceKind === "string" &&
+    cadence?.kind !== check.cadenceKind
+  ) {
+    reasons.push(
+      `cadence.kind expected ${check.cadenceKind}, saw ${String(cadence?.kind ?? "missing")}`,
+    );
+  }
+  if (
+    typeof check.expectedTimeZone === "string" &&
+    record.definition.timezone !== check.expectedTimeZone
+  ) {
+    reasons.push(
+      `timezone expected ${check.expectedTimeZone}, saw ${String(record.definition.timezone ?? "missing")}`,
+    );
+  }
+  if (Array.isArray(check.requiredSlots) && check.requiredSlots.length > 0) {
+    const slots = Array.isArray(cadence?.slots) ? cadence.slots : [];
+    for (const slot of check.requiredSlots) {
+      if (!slots.some((actualSlot) => requiredSlotMatches(actualSlot, slot))) {
+        reasons.push(`missing required slot ${JSON.stringify(slot)}`);
+      }
+    }
+  }
+  if (
+    Array.isArray(check.requiredWeekdays) &&
+    check.requiredWeekdays.length > 0 &&
+    !arrayContainsAllValues(cadence?.weekdays, check.requiredWeekdays)
+  ) {
+    reasons.push(`weekdays missing [${check.requiredWeekdays.join(", ")}]`);
+  }
+  if (
+    Array.isArray(check.requiredWindows) &&
+    check.requiredWindows.length > 0 &&
+    !arrayContainsAllValues(cadence?.windows, check.requiredWindows)
+  ) {
+    reasons.push(`windows missing [${check.requiredWindows.join(", ")}]`);
+  }
+  if (
+    typeof check.requiredEveryMinutes === "number" &&
+    cadence?.everyMinutes !== check.requiredEveryMinutes
+  ) {
+    reasons.push(
+      `everyMinutes expected ${check.requiredEveryMinutes}, saw ${String(cadence?.everyMinutes ?? "missing")}`,
+    );
+  }
+  if (
+    typeof check.requiredMaxOccurrencesPerDay === "number" &&
+    cadence?.maxOccurrencesPerDay !== check.requiredMaxOccurrencesPerDay
+  ) {
+    reasons.push(
+      `maxOccurrencesPerDay expected ${check.requiredMaxOccurrencesPerDay}, saw ${String(cadence?.maxOccurrencesPerDay ?? "missing")}`,
+    );
+  }
+  if (typeof check.requireReminderPlan === "boolean") {
+    const hasReminderPlan =
+      recordHasEntries(record.reminderPlan) ||
+      (typeof record.definition.reminderPlanId === "string" &&
+        record.definition.reminderPlanId.length > 0);
+    if (hasReminderPlan !== check.requireReminderPlan) {
+      reasons.push(
+        `reminderPlan expected ${check.requireReminderPlan}, saw ${hasReminderPlan}`,
+      );
+    }
+  }
+  if (check.websiteAccess) {
+    const websiteAccess = toRecord(record.definition.websiteAccess);
+    if (!websiteAccess) {
+      reasons.push("websiteAccess missing");
+    } else if (!looselyMatchesValue(websiteAccess, check.websiteAccess)) {
+      reasons.push("websiteAccess did not match expected fields");
+    }
+  }
+  return reasons;
 }
 
 type GmailMockRequest = {
@@ -592,6 +819,73 @@ registerFinalCheckHandler("memoryExists", (check, { ctx }) => {
     detail: "no matching memory write observed",
   };
 });
+
+registerFinalCheckHandler(
+  "definitionCountDelta",
+  async (check, { runtime }) => {
+    const definitionCheck = check as DefinitionCountCheck;
+    if (
+      typeof definitionCheck.title !== "string" ||
+      definitionCheck.title.trim().length === 0
+    ) {
+      return {
+        status: "failed",
+        detail: "definitionCountDelta requires a non-empty title",
+      };
+    }
+    const service = new LifeOpsService(runtime);
+    if (!isDefinitionListingService(service)) {
+      return {
+        status: "failed",
+        detail: "LifeOpsService does not expose listDefinitions()",
+      };
+    }
+    const records = (await service.listDefinitions())
+      .map(definitionRecordFromValue)
+      .filter((record): record is DefinitionRecordLike => record !== null);
+    const titleMatches = records.filter((record) =>
+      definitionTitleMatches(record.definition, definitionCheck),
+    );
+    const matched = titleMatches.filter(
+      (record) =>
+        definitionMismatchReasons(record, definitionCheck).length === 0,
+    );
+    const delta =
+      typeof definitionCheck.delta === "number" ? definitionCheck.delta : 1;
+    if (delta <= 0) {
+      if (matched.length === 0) {
+        return {
+          status: "passed",
+          detail: `no matching definition for "${definitionCheck.title}"`,
+        };
+      }
+      return {
+        status: "failed",
+        detail: `expected no matching definition for "${definitionCheck.title}", saw ${matched.length}`,
+      };
+    }
+    if (matched.length >= delta) {
+      return {
+        status: "passed",
+        detail: `${matched.length} matching definition(s) for "${definitionCheck.title}"`,
+      };
+    }
+    const mismatchDetails = titleMatches
+      .map((record) => {
+        const title = String(record.definition.title ?? "(untitled)");
+        const reasons = definitionMismatchReasons(record, definitionCheck);
+        return `${title}: ${reasons.join("; ") || "matched"}`;
+      })
+      .join(" | ");
+    return {
+      status: "failed",
+      detail:
+        titleMatches.length === 0
+          ? `expected ${delta} matching definition(s) for "${definitionCheck.title}", saw none among ${records.length} definition(s)`
+          : `expected ${delta} matching definition(s) for "${definitionCheck.title}", saw ${matched.length}. Candidate mismatches: ${mismatchDetails}`,
+    };
+  },
+);
 
 registerFinalCheckHandler("approvalRequestExists", (check, { ctx }) => {
   if (ctx.approvalRequests === undefined) {


### PR DESCRIPTION
## Summary

Partial fix for #9310.

Adds a `definitionCountDelta` finalCheck handler backed by the real LifeOps definition service. This turns the authored LifeOps/todos/reminders/habits/hygiene definition checks from `no handler registered` into structural validation against saved definition records.

The handler validates:
- `title` / `titleAliases`
- `delta`
- `cadenceKind`
- `requiredSlots`
- `requiredWeekdays`
- `requiredWindows`
- `requiredEveryMinutes`
- `requiredMaxOccurrencesPerDay`
- `expectedTimeZone`
- `requireReminderPlan`
- `websiteAccess`

It also registers the type in the schema strict-key map and adds TypeScript schema coverage.

## Evidence

- `bun run --cwd packages/scenario-runner test src/final-checks/definition-count-final-check.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 18 files / 125 tests passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner build` - passed
- `bunx @biomejs/biome check packages/scenario-runner/src/final-checks/index.ts packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts packages/scenario-runner/schema/index.js packages/scenario-runner/schema/index.d.ts` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - rebased cleanly, then final pre-PR check was up to date
- `bun install` - no dependency changes
- `bun run verify` - 509 successful / 509 total

## Notes

This stays separate from PR #9364 (`memoryExists`), PR #9365 (`goalCountDelta`), and the other open #9310 harness slices.
