### PR TITLE
fix(scenario-runner): add reminderIntensity final check

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -314,6 +314,16 @@ export type ScenarioFinalCheck =
       requireReminderPlan?: boolean;
       websiteAccess?: DefinitionCountWebsiteAccess;
     })
+  | (CheckBase<"reminderIntensity"> & {
+      title: string;
+      titleAliases?: string[];
+      expected:
+        | "minimal"
+        | "normal"
+        | "persistent"
+        | "high_priority_only"
+        | "escalated";
+    })
   | (CheckBase<"judgeRubric"> & {
       name: string;
       rubric: string;

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -93,6 +93,7 @@ export const FINAL_CHECK_KEYS = new Map(
       "requireReminderPlan",
       "websiteAccess",
     ],
+    reminderIntensity: ["type", "name", "title", "titleAliases", "expected"],
   }).map(([type, keys]) => [type, new Set(keys)]),
 );
 

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -7,6 +7,10 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { LifeOpsService } from "@elizaos/plugin-personal-assistant/lifeops/service";
 import {
+  REMINDER_ESCALATION_INDEX_METADATA_KEY,
+  REMINDER_LIFECYCLE_METADATA_KEY,
+} from "@elizaos/plugin-personal-assistant/lifeops/service-constants";
+import {
   FINAL_CHECK_KEYS,
   type ScenarioContext,
   type ScenarioFinalCheck,
@@ -1671,6 +1675,46 @@ registerFinalCheckHandler("workflowDispatchOccurred", (check, { ctx }) => {
   };
 });
 
+registerFinalCheckHandler(
+  "reminderIntensity",
+  async (check, { runtime, ctx }) => {
+    const { title, titleAliases, expected } = check as {
+      title?: string;
+      titleAliases?: string[];
+      expected?: string;
+    };
+    if (typeof title !== "string" || title.length === 0) {
+      return { status: "failed", detail: "reminderIntensity missing title" };
+    }
+    if (typeof expected !== "string" || expected.length === 0) {
+      return { status: "failed", detail: "reminderIntensity missing expected" };
+    }
+    const titleCandidates = titleCandidatesForReminderIntensity({
+      title,
+      titleAliases,
+    });
+    if (expected === "escalated") {
+      const attempts = collectReminderAttempts(
+        (ctx.turns ?? []).map((turn) => turn.responseBody),
+      );
+      const matched = attempts.filter((attempt) =>
+        isDeliveredEscalationAttempt(attempt, titleCandidates),
+      );
+      if (matched.length > 0) {
+        return {
+          status: "passed",
+          detail: `${matched.length} delivered escalation reminder attempt(s) matched [${titleCandidates.join(", ")}]`,
+        };
+      }
+      return {
+        status: "failed",
+        detail: `no delivered escalation reminder attempts matched [${titleCandidates.join(", ")}]; saw ${attempts.length} reminder attempt(s)`,
+      };
+    }
+    return checkStoredReminderIntensity(runtime, titleCandidates, expected);
+  },
+);
+
 // judgeRubric is handled inline by the executor so it can reuse the live LLM
 // without threading the runtime through the generic handler registry.
 registerFinalCheckHandler("judgeRubric", () => ({
@@ -1717,5 +1761,141 @@ export async function runFinalCheck(
     type,
     status: outcome.status,
     detail: outcome.detail,
+  };
+}
+
+type ReminderPreferenceService = {
+  listDefinitions(): Promise<unknown[]>;
+  getReminderPreference(definitionId?: string | null): Promise<unknown>;
+};
+
+function isReminderPreferenceService(
+  value: unknown,
+): value is ReminderPreferenceService {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  return (
+    "listDefinitions" in value &&
+    typeof value.listDefinitions === "function" &&
+    "getReminderPreference" in value &&
+    typeof value.getReminderPreference === "function"
+  );
+}
+
+function titleCandidatesForReminderIntensity(check: {
+  title: string;
+  titleAliases?: string[];
+}): string[] {
+  return [check.title, ...(check.titleAliases ?? [])];
+}
+
+function reminderDefinitionTitle(value: unknown): string | null {
+  const record = toRecord(value);
+  const definition = toRecord(record?.definition);
+  return typeof definition?.title === "string" ? definition.title : null;
+}
+
+function reminderDefinitionId(value: unknown): string | null {
+  const record = toRecord(value);
+  const definition = toRecord(record?.definition);
+  return typeof definition?.id === "string" ? definition.id : null;
+}
+
+function matchesReminderTitle(value: unknown, candidates: string[]): boolean {
+  return (
+    typeof value === "string" &&
+    candidates.some((candidate) => textMatchesLoose(value, candidate))
+  );
+}
+
+function collectReminderAttempts(
+  value: unknown,
+  out: Record<string, unknown>[] = [],
+): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectReminderAttempts(entry, out);
+    }
+    return out;
+  }
+  const record = toRecord(value);
+  if (!record) {
+    return out;
+  }
+  if (toRecord(record.deliveryMetadata)) {
+    out.push(record);
+  }
+  for (const entry of Object.values(record)) {
+    collectReminderAttempts(entry, out);
+  }
+  return out;
+}
+
+function isDeliveredEscalationAttempt(
+  attempt: Record<string, unknown>,
+  titleCandidates: string[],
+): boolean {
+  if (attempt.outcome !== "delivered") {
+    return false;
+  }
+  const deliveryMetadata = toRecord(attempt.deliveryMetadata);
+  if (!deliveryMetadata) {
+    return false;
+  }
+  if (!matchesReminderTitle(deliveryMetadata.title, titleCandidates)) {
+    return false;
+  }
+  return (
+    deliveryMetadata[REMINDER_LIFECYCLE_METADATA_KEY] === "escalation" ||
+    typeof deliveryMetadata[REMINDER_ESCALATION_INDEX_METADATA_KEY] === "number"
+  );
+}
+
+async function checkStoredReminderIntensity(
+  runtime: IAgentRuntime,
+  titleCandidates: string[],
+  expected: string,
+): Promise<FinalCheckOutcome> {
+  const service = new LifeOpsService(runtime);
+  if (!isReminderPreferenceService(service)) {
+    return {
+      status: "skipped-dependency-missing",
+      detail: "LifeOpsService does not expose reminder preference methods",
+    };
+  }
+  const definitions = await service.listDefinitions();
+  const match = definitions.find((entry) => {
+    const title = reminderDefinitionTitle(entry);
+    return title !== null && matchesReminderTitle(title, titleCandidates);
+  });
+  if (!match) {
+    return {
+      status: "failed",
+      detail: `no reminder definition matched [${titleCandidates.join(", ")}]`,
+    };
+  }
+  const definitionId = reminderDefinitionId(match);
+  if (!definitionId) {
+    return {
+      status: "failed",
+      detail: "matched reminder definition has no id",
+    };
+  }
+  const preference = toRecord(
+    await service.getReminderPreference(definitionId),
+  );
+  const effective = toRecord(preference?.effective);
+  const actual =
+    typeof effective?.intensity === "string" ? effective.intensity : undefined;
+  if (actual === expected) {
+    return {
+      status: "passed",
+      detail: `reminder "${reminderDefinitionTitle(match) ?? definitionId}" effective intensity=${expected}`,
+    };
+  }
+  return {
+    status: "failed",
+    detail: `expected reminder "${reminderDefinitionTitle(match) ?? definitionId}" effective intensity=${expected}, saw ${actual ?? "(missing)"}`,
   };
 }

--- a/packages/scenario-runner/src/final-checks/reminder-intensity-final-check.test.ts
+++ b/packages/scenario-runner/src/final-checks/reminder-intensity-final-check.test.ts
@@ -1,0 +1,168 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { REMINDER_LIFECYCLE_METADATA_KEY } from "@elizaos/plugin-personal-assistant/lifeops/service-constants";
+import type { ScenarioFinalCheck } from "@elizaos/scenario-runner/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLifeOpsState = vi.hoisted(() => ({
+  definitions: [] as unknown[],
+  preference: null as unknown,
+}));
+
+vi.mock("@elizaos/plugin-personal-assistant/lifeops/service", () => ({
+  LifeOpsService: class {
+    async listDefinitions(): Promise<unknown[]> {
+      return mockLifeOpsState.definitions;
+    }
+
+    async getReminderPreference(): Promise<unknown> {
+      return mockLifeOpsState.preference;
+    }
+  },
+}));
+
+const { runFinalCheck } = await import("./index.ts");
+
+const runtime = {} as IAgentRuntime;
+
+describe("reminderIntensity final check", () => {
+  beforeEach(() => {
+    mockLifeOpsState.definitions = [];
+    mockLifeOpsState.preference = null;
+  });
+
+  it("passes when a matching reminder preference stores the expected intensity", async () => {
+    mockLifeOpsState.definitions = [
+      {
+        definition: {
+          id: "definition-brush-teeth",
+          title: "Brush teeth",
+        },
+      },
+    ];
+    mockLifeOpsState.preference = {
+      effective: {
+        intensity: "minimal",
+      },
+    };
+
+    const report = await runFinalCheck(
+      {
+        type: "reminderIntensity",
+        title: "brush teeth",
+        expected: "minimal",
+      } satisfies ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: {
+          actionsCalled: [],
+        },
+      },
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.detail).toContain("effective intensity=minimal");
+  });
+
+  it("fails when the stored reminder preference has a different intensity", async () => {
+    mockLifeOpsState.definitions = [
+      {
+        definition: {
+          id: "definition-brush-teeth",
+          title: "Brush teeth",
+        },
+      },
+    ];
+    mockLifeOpsState.preference = {
+      effective: {
+        intensity: "normal",
+      },
+    };
+
+    const report = await runFinalCheck(
+      {
+        type: "reminderIntensity",
+        title: "Brush teeth",
+        expected: "minimal",
+      } satisfies ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: {
+          actionsCalled: [],
+        },
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.detail).toContain("saw normal");
+  });
+
+  it("passes escalated when captured turn bodies include a delivered escalation attempt", async () => {
+    const report = await runFinalCheck(
+      {
+        type: "reminderIntensity",
+        title: "Call dentist",
+        expected: "escalated",
+      } satisfies ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: {
+          actionsCalled: [],
+          turns: [
+            {
+              actionsCalled: [],
+              responseBody: {
+                attempts: [
+                  {
+                    outcome: "delivered",
+                    deliveryMetadata: {
+                      title: "Call dentist",
+                      [REMINDER_LIFECYCLE_METADATA_KEY]: "escalation",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.detail).toContain("delivered escalation");
+  });
+
+  it("fails escalated when no delivered escalation attempt matches the title", async () => {
+    const report = await runFinalCheck(
+      {
+        type: "reminderIntensity",
+        title: "Call dentist",
+        expected: "escalated",
+      } satisfies ScenarioFinalCheck,
+      {
+        runtime,
+        ctx: {
+          actionsCalled: [],
+          turns: [
+            {
+              actionsCalled: [],
+              responseBody: {
+                attempts: [
+                  {
+                    outcome: "delivered",
+                    deliveryMetadata: {
+                      title: "Drink water",
+                      [REMINDER_LIFECYCLE_METADATA_KEY]: "escalation",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.detail).toContain("no delivered escalation");
+  });
+});


### PR DESCRIPTION
## Summary
- registers `reminderIntensity` in the scenario schema strict final-check allow-list
- adds a scenario-runner final-check handler for stored reminder preference intensity and delivered escalation attempts
- adds focused Vitest coverage for pass/fail paths for both meanings currently authored in scenarios

Part of #9310.

## Evidence
- `bun run --cwd packages/scenario-runner test src/final-checks/reminder-intensity-final-check.test.ts` — 1 file / 4 tests passed
- `bunx @biomejs/biome check packages/scenario-runner/src/final-checks/index.ts packages/scenario-runner/src/final-checks/reminder-intensity-final-check.test.ts packages/scenario-runner/schema/index.js packages/scenario-runner/schema/index.d.ts` — passed
- `bun run --cwd packages/scenario-runner typecheck` — passed
- `bun run --cwd packages/scenario-runner test` — 18 files / 125 tests passed
- `bun run --cwd packages/scenario-runner build` — passed
- `git diff --check` — passed
- `git fetch origin` + `git rebase origin/develop` — branch up to date, no conflicts
- `bun install` — no dependency changes
- `bun run verify` — 509/509 turbo tasks successful

## PR Evidence Matrix
- Real-LLM trajectories: N/A, harness final-check behavior only; no agent prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
