### PR TITLE
docs(feed): document canonical Railway host

### DIFF
--- a/packages/feed/RAILWAY.md
+++ b/packages/feed/RAILWAY.md
@@ -35,6 +35,19 @@ not just `packages/feed`.
 - Start: `bash packages/feed/scripts/railway-start.sh` (ensures the schema, then
   `next start` binding `$PORT`).
 
+## Canonical host: feed.elizacloud.ai
+
+Use `https://feed.elizacloud.ai` as the public Feed origin in production. Set
+`NEXT_PUBLIC_APP_URL=https://feed.elizacloud.ai` on the web service so Next.js
+metadata, Open Graph cards, and Farcaster Mini App frame URLs all point at the
+same canonical host.
+
+The Cloudflare Worker route for `*.elizacloud.ai/*` makes `cloud-api` the
+default origin for every subdomain. Because Feed is served from its own Railway
+origin, the `feed.elizacloud.ai/*` host must be carved out of that wildcard
+route in Cloudflare: either add a more-specific Workers route with Worker =
+None, or make the `feed` DNS record DNS-only.
+
 ## 1. Create the project + services
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents `https://feed.elizacloud.ai` as the production Feed origin in `packages/feed/RAILWAY.md`.
- Calls out the required `NEXT_PUBLIC_APP_URL` value for canonical metadata, Open Graph cards, and Farcaster Mini App frame URLs.
- Adds the Cloudflare wildcard Worker carve-out note for `feed.elizacloud.ai/*` so the host routes to the Railway Feed origin instead of the default `cloud-api` origin.

Refs #9301.

The Feed metadata/logo/Wrangler fixes for #9301 are already present on `develop` via `ca94cdca2e fix(feed): restore canonical logo metadata`. This PR keeps the remaining Railway deployment note isolated instead of reviving the older broad/stale branch.

## Evidence
- `git diff --check`
- `bunx @biomejs/biome check --files-ignore-unknown=true packages/feed/RAILWAY.md` (Biome ignored this Markdown path and processed 0 files)
- `bun install`
- `bun run verify` (509/509 tasks successful)

## N/A
- UI screenshots/video: documentation-only change.
- Real LLM trajectories: documentation-only change.
- Backend/frontend runtime logs: documentation-only change.
