### PR TITLE
fix(scenario-runner): run selfcontrol cleanup steps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2573,6 +2573,7 @@
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-agent-skills": "workspace:*",
         "@elizaos/plugin-app-control": "workspace:*",
+        "@elizaos/plugin-blocker": "workspace:*",
         "@elizaos/plugin-coding-tools": "workspace:*",
         "@elizaos/plugin-commands": "workspace:*",
         "@elizaos/plugin-device-filesystem": "workspace:*",

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -78,6 +78,7 @@
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-agent-skills": "workspace:*",
     "@elizaos/plugin-app-control": "workspace:*",
+    "@elizaos/plugin-blocker": "workspace:*",
     "@elizaos/plugin-coding-tools": "workspace:*",
     "@elizaos/plugin-commands": "workspace:*",
     "@elizaos/plugin-device-filesystem": "workspace:*",

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -128,6 +128,19 @@ export type ScenarioSeedStep =
       [key: string]: unknown;
     };
 
+export type ScenarioCleanupStep =
+  | {
+      type: "gmailDeleteDrafts";
+      name?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: "selfControlClearBlocks";
+      name?: string;
+      profile?: string;
+      [key: string]: unknown;
+    };
+
 export type ScenarioJudgeRubric = {
   rubric: string;
   minimumScore?: number;
@@ -325,6 +338,7 @@ export type ScenarioDefinition = {
   lane?: ScenarioLane;
   turns: ScenarioTurn[];
   seed?: ScenarioSeedStep[];
+  cleanup?: ScenarioCleanupStep[];
   finalChecks?: ScenarioFinalCheck[];
   [key: string]: unknown;
 };

--- a/packages/scenario-runner/src/executor-cleanup.test.ts
+++ b/packages/scenario-runner/src/executor-cleanup.test.ts
@@ -1,0 +1,144 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentRuntime } from "@elizaos/core";
+import {
+  reconcileSelfControlBlockState,
+  resetSelfControlStatusCache,
+  startSelfControlBlock,
+} from "@elizaos/plugin-blocker/services/website-blocker/index";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runScenario } from "./executor";
+
+function createRuntime(): AgentRuntime {
+  return {
+    actions: [],
+    routes: [],
+    ensureConnection: vi.fn(async () => undefined),
+    getService: vi.fn(() => null),
+    setSetting: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as AgentRuntime;
+}
+
+function createHostsFile(): { dir: string; hostsFilePath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scenario-cleanup-"));
+  const hostsFilePath = path.join(dir, "hosts");
+  fs.writeFileSync(
+    hostsFilePath,
+    ["127.0.0.1 localhost", "::1 localhost", ""].join("\n"),
+    "utf8",
+  );
+  return { dir, hostsFilePath };
+}
+
+const previousWebsiteBlockerHostsFilePath =
+  process.env.WEBSITE_BLOCKER_HOSTS_FILE_PATH;
+const previousSelfControlHostsFilePath =
+  process.env.SELFCONTROL_HOSTS_FILE_PATH;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  resetSelfControlStatusCache();
+  if (previousWebsiteBlockerHostsFilePath !== undefined) {
+    process.env.WEBSITE_BLOCKER_HOSTS_FILE_PATH =
+      previousWebsiteBlockerHostsFilePath;
+  } else {
+    delete process.env.WEBSITE_BLOCKER_HOSTS_FILE_PATH;
+  }
+  if (previousSelfControlHostsFilePath !== undefined) {
+    process.env.SELFCONTROL_HOSTS_FILE_PATH = previousSelfControlHostsFilePath;
+  } else {
+    delete process.env.SELFCONTROL_HOSTS_FILE_PATH;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("scenario cleanup", () => {
+  it("clears self-control website blocks from the scenario hosts file", async () => {
+    const { dir, hostsFilePath } = createHostsFile();
+    tempDirs.push(dir);
+    process.env.WEBSITE_BLOCKER_HOSTS_FILE_PATH = hostsFilePath;
+    process.env.SELFCONTROL_HOSTS_FILE_PATH = hostsFilePath;
+    resetSelfControlStatusCache();
+
+    const start = await startSelfControlBlock({
+      websites: ["x.com"],
+      durationMinutes: 30,
+      metadata: { profile: "unit-cleanup" },
+    });
+
+    expect(start.success).toBe(true);
+    expect((await reconcileSelfControlBlockState()).active).toBe(true);
+
+    const report = await runScenario(
+      {
+        id: "selfcontrol-cleanup",
+        title: "Self-control cleanup",
+        domain: "executor",
+        turns: [],
+        cleanup: [
+          {
+            type: "selfControlClearBlocks",
+            profile: "unit-cleanup",
+          },
+        ],
+      },
+      createRuntime(),
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("passed");
+    expect((await reconcileSelfControlBlockState()).active).toBe(false);
+  });
+
+  it("reports cleanup failure when the self-control hosts file is unavailable", async () => {
+    const { dir, hostsFilePath } = createHostsFile();
+    tempDirs.push(dir);
+    fs.rmSync(hostsFilePath, { force: true });
+    process.env.WEBSITE_BLOCKER_HOSTS_FILE_PATH = hostsFilePath;
+    process.env.SELFCONTROL_HOSTS_FILE_PATH = hostsFilePath;
+    resetSelfControlStatusCache();
+
+    const report = await runScenario(
+      {
+        id: "selfcontrol-cleanup-missing-hosts",
+        title: "Self-control cleanup missing hosts",
+        domain: "executor",
+        turns: [],
+        cleanup: [
+          {
+            type: "selfControlClearBlocks",
+            name: "clear self-control",
+          },
+        ],
+      },
+      createRuntime(),
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.failedAssertions).toContainEqual({
+      label: "cleanup",
+      detail: expect.stringContaining("cleanup clear self-control"),
+    });
+    expect(report.failedAssertions[0]?.detail).toContain(
+      "selfControlClearBlocks failed",
+    );
+  });
+});

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -25,6 +25,7 @@ import {
   logger,
   stringToUuid,
 } from "@elizaos/core";
+import { stopSelfControlBlock } from "@elizaos/plugin-blocker/services/website-blocker/index";
 import type { VoiceWorkbenchScenarioRun } from "@elizaos/plugin-local-inference/voice-workbench";
 import type {
   CapturedAction,
@@ -1070,6 +1071,14 @@ async function deleteMockGmailDrafts(): Promise<string | undefined> {
   return undefined;
 }
 
+async function clearSelfControlBlocks(): Promise<string | undefined> {
+  const result = await stopSelfControlBlock();
+  if (result.success) {
+    return undefined;
+  }
+  return `selfControlClearBlocks failed: ${result.error}`;
+}
+
 async function runScenarioCleanups(
   scenario: ScenarioDefinition,
 ): Promise<string[]> {
@@ -1083,19 +1092,21 @@ async function runScenarioCleanups(
       continue;
     }
     const step = cleanup as { type?: unknown; name?: unknown };
-    if (step.type !== "gmailDeleteDrafts") {
-      continue;
-    }
+    let result: string | undefined;
     try {
-      const result = await deleteMockGmailDrafts();
+      if (step.type === "gmailDeleteDrafts") {
+        result = await deleteMockGmailDrafts();
+      } else if (step.type === "selfControlClearBlocks") {
+        result = await clearSelfControlBlocks();
+      } else {
+        continue;
+      }
       if (result) {
-        failures.push(
-          `cleanup ${String(step.name ?? "gmailDeleteDrafts")}: ${result}`,
-        );
+        failures.push(`cleanup ${String(step.name ?? step.type)}: ${result}`);
       }
     } catch (err) {
       failures.push(
-        `cleanup ${String(step.name ?? "gmailDeleteDrafts")} threw: ${err instanceof Error ? err.message : String(err)}`,
+        `cleanup ${String(step.name ?? step.type)} threw: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- runs `selfControlClearBlocks` cleanup steps instead of silently skipping them
- clears scenario-managed website blocker state through the existing `@elizaos/plugin-blocker` engine API
- types scenario cleanup steps for `gmailDeleteDrafts` and `selfControlClearBlocks`
- adds focused executor cleanup coverage with a temporary hosts file

Part of #9310.

## Evidence
- `bun run --cwd packages/scenario-runner test src/executor-cleanup.test.ts` — 1 file / 2 tests passed
- `bunx @biomejs/biome check packages/scenario-runner/src/executor.ts packages/scenario-runner/src/executor-cleanup.test.ts packages/scenario-runner/schema/index.d.ts packages/scenario-runner/package.json bun.lock` — passed
- `bun run --cwd packages/scenario-runner typecheck` — passed
- `bun run --cwd packages/scenario-runner test` — 18 files / 123 tests passed
- `bun run --cwd packages/scenario-runner build` — passed
- `git diff --check` — passed
- `git fetch origin` + `git rebase origin/develop` — branch up to date, no conflicts
- `bun install` — lockfile updated only for the new direct workspace dependency
- `bun run verify` — 509/509 turbo tasks successful

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario-runner cleanup behavior only; no agent prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
