### PR TITLE
fix(cloud): harden auto top-up credit persist + cover it (#9321)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/auto-top-up-idempotency.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/auto-top-up-idempotency.test.ts
@@ -1,0 +1,268 @@
+/**
+ * #9321 — auto-top-up must PERSIST the credits it just charged for, and it must
+ * dedup against the async Stripe webhook so the org is credited exactly once.
+ *
+ * The existing auto-top-up.test.ts mocks creditsService.addCredits at the seam to
+ * prove the right args are passed. This file goes one layer deeper: it runs the
+ * REAL creditsService.addCredits (the shared persistence path) over an in-memory
+ * ledger that mirrors the production idempotency contract — the app-level
+ * pre-check (findByStripePaymentIntent) and the atomic CTE that only inserts when
+ * no row exists for that payment-intent id. That lets us assert the two things the
+ * fix actually has to guarantee:
+ *   (a) a successful auto-top-up writes a ledger row + bumps the org balance, and
+ *   (b) the webhook replaying the SAME payment-intent id does not double-credit.
+ * Only the boundaries are mocked (Stripe, the DB executor, repositories, cache).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// In-memory ledger shared by the repository fake and the SQL-executor fake.
+// ---------------------------------------------------------------------------
+interface LedgerRow {
+  id: string;
+  organization_id: string;
+  amount: string;
+  type: string;
+  description: string;
+  metadata: unknown;
+  stripe_payment_intent_id: string | null;
+  created_at: Date;
+  user_id: string | null;
+}
+
+const ORG_ID = "org-1";
+const ledger: LedgerRow[] = [];
+const org = { id: ORG_ID, credit_balance: "5.00" };
+let txSeq = 0;
+
+function resetLedger() {
+  ledger.length = 0;
+  org.credit_balance = "5.00";
+  txSeq = 0;
+}
+
+// ---------------------------------------------------------------------------
+// DB boundary: sqlRows runs the real addCredits CTE. We emulate just the
+// idempotency-relevant behavior: insert a row + bump balance ONLY when no row
+// already exists for this payment-intent id; otherwise insert nothing.
+// ---------------------------------------------------------------------------
+const sqlRows = mock(async (_db: unknown, query: { queryChunks?: unknown[] }) => {
+  // drizzle's sql`` interleaves StringChunk objects (the SQL fragments) with the
+  // bound params, which sit in queryChunks as bare primitives. Keep only the
+  // primitives — those are the values the real query would bind.
+  const params = (query.queryChunks ?? []).filter(
+    (chunk) => typeof chunk === "string" || typeof chunk === "number",
+  );
+
+  const organizationId = params.find((v) => v === ORG_ID) as string | undefined;
+  const stripeId =
+    (params.find((v) => typeof v === "string" && (v as string).startsWith("pi_")) as
+      | string
+      | undefined) ?? null;
+  const amountStr = params.find(
+    (v) => typeof v === "string" && /^\d+(\.\d+)?$/.test(v as string),
+  ) as string | undefined;
+  const amount = Number(amountStr ?? "0");
+
+  if (organizationId !== ORG_ID) {
+    return [{ org_exists: false }];
+  }
+
+  const current = Number(org.credit_balance);
+  const alreadyExists =
+    stripeId !== null && ledger.some((r) => r.stripe_payment_intent_id === stripeId);
+
+  if (alreadyExists) {
+    // CTE inserts nothing; balance unchanged; no `inserted` row returned.
+    return [
+      {
+        org_exists: true,
+        current_balance: current,
+        new_balance: current,
+        id: null,
+      },
+    ];
+  }
+
+  const newBalance = current + amount;
+  org.credit_balance = newBalance.toFixed(2);
+  txSeq += 1;
+  const row: LedgerRow = {
+    id: `tx-${txSeq}`,
+    organization_id: ORG_ID,
+    amount: amount.toFixed(2),
+    type: "credit",
+    description: "Auto top-up",
+    metadata: {},
+    stripe_payment_intent_id: stripeId,
+    created_at: new Date(),
+    user_id: null,
+  };
+  ledger.push(row);
+
+  return [
+    {
+      org_exists: true,
+      current_balance: current,
+      new_balance: newBalance,
+      ...row,
+    },
+  ];
+});
+
+mock.module("../../../db/execute-helpers", () => ({
+  sqlRows,
+}));
+
+const dbReadStub = {
+  select: mock(() => ({ from: mock(() => ({ where: mock(async () => []) })) })),
+};
+mock.module("../../../db/helpers", () => ({
+  dbWrite: {},
+  dbRead: dbReadStub,
+  db: {},
+  getDbConnectionInfo: mock(() => ({})),
+}));
+
+// Repositories — the app-level idempotency pre-check + balance reads come through here.
+const findByStripePaymentIntent = mock(async (paymentIntentId: string) =>
+  ledger.find((r) => r.stripe_payment_intent_id === paymentIntentId),
+);
+const findOrgById = mock(async (id: string) => (id === ORG_ID ? { ...org } : undefined));
+const listByOrganization = mock(async () => [{ id: "user-1", email: "billing@example.com" }]);
+const updateOrganization = mock(async () => undefined);
+
+// Mock the repositories barrel directly (not the leaf modules) so the real
+// db/client → plugin-sql → @elizaos/core chain is never pulled in. Provide the
+// full set of repos the credits import graph touches.
+mock.module("../../../db/repositories", () => ({
+  creditTransactionsRepository: {
+    findByStripePaymentIntent,
+  },
+  organizationsRepository: {
+    findById: findOrgById,
+    update: updateOrganization,
+  },
+  usersRepository: {
+    listByOrganization,
+  },
+  userSessionsRepository: {},
+  creditPacksRepository: {},
+}));
+
+// dbRead is only used by the auto-top-up cron query, which we don't drive here.
+mock.module("../../../db/client", () => ({
+  dbRead: {
+    select: mock(() => ({
+      from: mock(() => ({ where: mock(async () => []) })),
+    })),
+  },
+}));
+
+// Stripe boundary.
+const createPaymentIntent = mock(async () => ({
+  id: "pi_auto_123",
+  status: "succeeded",
+}));
+const retrievePaymentMethod = mock(async () => ({
+  card: { brand: "visa", last4: "4242" },
+}));
+mock.module("../../stripe", () => ({
+  requireStripe: mock(() => ({
+    paymentIntents: { create: createPaymentIntent },
+    paymentMethods: { retrieve: retrievePaymentMethod },
+  })),
+}));
+
+// No affiliate markup for these cases (keep base == total).
+mock.module("../affiliates", () => ({
+  affiliatesService: { getReferrer: mock(async () => null) },
+}));
+
+mock.module("../email", () => ({
+  emailService: {
+    sendAutoTopUpSuccessEmail: mock(async () => true),
+    sendAutoTopUpDisabledEmail: mock(async () => true),
+  },
+}));
+
+// Cache + side-channel no-ops so the real addCredits path doesn't reach for infra.
+mock.module("../../cache/invalidation", () => ({
+  CacheInvalidation: { onCreditMutation: mock(async () => undefined) },
+}));
+mock.module("../../cache/organizations-cache", () => ({
+  invalidateOrganizationCache: mock(async () => undefined),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
+}));
+
+const { AutoTopUpService } = await import("../auto-top-up");
+const { creditsService } = await import("../credits");
+
+type AutoTopUpOrganization = Parameters<AutoTopUpService["executeAutoTopUp"]>[0];
+
+function makeOrganization(): AutoTopUpOrganization {
+  return {
+    id: ORG_ID,
+    name: "Acme Cloud",
+    credit_balance: org.credit_balance,
+    auto_top_up_threshold: "10.00",
+    auto_top_up_amount: "10.00",
+    stripe_customer_id: "cus_123",
+    stripe_default_payment_method: "pm_123",
+    billing_email: "billing@example.com",
+    auto_top_up_enabled: true,
+  } as AutoTopUpOrganization;
+}
+
+beforeEach(() => {
+  resetLedger();
+  sqlRows.mockClear();
+  findByStripePaymentIntent.mockClear();
+  findOrgById.mockClear();
+  createPaymentIntent.mockClear();
+});
+
+describe("auto-top-up persistence + webhook idempotency (#9321, real credit logic)", () => {
+  test("a successful auto-top-up writes one ledger row and bumps the org balance", async () => {
+    const result = await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+
+    // Real persistence happened: exactly one ledger row keyed on the payment intent.
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0].stripe_payment_intent_id).toBe("pi_auto_123");
+    expect(Number(ledger[0].amount)).toBe(10);
+
+    // Org balance moved 5 → 15 in the store, and the returned balance is DB-derived.
+    expect(Number(org.credit_balance)).toBe(15);
+    expect(result).toEqual({
+      organizationId: ORG_ID,
+      success: true,
+      amount: 10,
+      newBalance: 15,
+    });
+  });
+
+  test("the webhook replaying the same payment-intent id does not double-credit", async () => {
+    // Sync path (auto-top-up) credits first.
+    await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+    expect(ledger).toHaveLength(1);
+    expect(Number(org.credit_balance)).toBe(15);
+
+    // Now the async Stripe webhook fires with the SAME payment intent + same base credits.
+    const replay = await creditsService.addCredits({
+      organizationId: ORG_ID,
+      amount: 10,
+      description: "Webhook credit",
+      stripePaymentIntentId: "pi_auto_123",
+    });
+
+    // No second ledger row, balance unchanged — exactly one credit, order-independent.
+    expect(ledger).toHaveLength(1);
+    expect(Number(org.credit_balance)).toBe(15);
+    expect(replay.newBalance).toBe(15);
+    expect(replay.transaction.id).toBe("tx-1"); // the pre-existing row, not a new one
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/auto-top-up.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/auto-top-up.test.ts
@@ -65,10 +65,12 @@ mock.module("../email", () => ({
   },
 }));
 
+const loggerError = mock();
+
 mock.module("../../utils/logger", () => ({
   logger: {
     debug: mock(),
-    error: mock(),
+    error: loggerError,
     info: mock(),
     warn: mock(),
   },
@@ -103,11 +105,20 @@ beforeEach(() => {
   getReferrer.mockReset();
   sendAutoTopUpSuccessEmail.mockReset();
   sendAutoTopUpDisabledEmail.mockReset();
+  loggerError.mockReset();
 
   listByOrganization.mockResolvedValue([{ id: "user-1", email: "billing@example.com" }]);
-  createPaymentIntent.mockResolvedValue({ id: "pi_auto_123", status: "succeeded" });
-  retrievePaymentMethod.mockResolvedValue({ card: { brand: "visa", last4: "4242" } });
-  addCredits.mockResolvedValue({ transaction: { id: "tx-1" }, newBalance: 42.25 });
+  createPaymentIntent.mockResolvedValue({
+    id: "pi_auto_123",
+    status: "succeeded",
+  });
+  retrievePaymentMethod.mockResolvedValue({
+    card: { brand: "visa", last4: "4242" },
+  });
+  addCredits.mockResolvedValue({
+    transaction: { id: "tx-1" },
+    newBalance: 42.25,
+  });
   getReferrer.mockResolvedValue(null);
   sendAutoTopUpSuccessEmail.mockResolvedValue(true);
   sendAutoTopUpDisabledEmail.mockResolvedValue(true);
@@ -152,5 +163,48 @@ describe("AutoTopUpService.executeAutoTopUp", () => {
       amount: 10,
       newBalance: 42.25,
     });
+  });
+
+  test("credits the base amount, never the fee-inclusive total charged to Stripe", async () => {
+    // 10% affiliate markup on a $10 base → Stripe is charged more, but the org is only
+    // credited the base. addCredits and the webhook (paymentIntent.metadata.credits) must
+    // agree on the base, otherwise the two paths can't dedup to a single credit.
+    getReferrer.mockResolvedValue({
+      id: "code-1",
+      user_id: "owner-1",
+      markup_percent: "10",
+    });
+
+    await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+
+    // base $10 + 10% affiliate + 20% platform = $13 charged
+    expect(createPaymentIntent.mock.calls[0][0].amount).toBe(1300);
+    // but only the base $10 is credited
+    expect(addCredits.mock.calls[0][0].amount).toBe(10);
+    expect(addCredits.mock.calls[0][0].stripePaymentIntentId).toBe("pi_auto_123");
+  });
+
+  test("charged-but-persist-failed: logs CRITICAL and still returns success with the local balance", async () => {
+    // The card is already charged when addCredits throws. We must NOT flip to
+    // success:false (that risks a retry / double charge) — the Stripe webhook reconciles
+    // via the same payment-intent idempotency key. Fall back to previousBalance + amount.
+    addCredits.mockRejectedValue(new Error("db down"));
+
+    const result = await new AutoTopUpService().executeAutoTopUp(makeOrganization());
+
+    expect(addCredits).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      organizationId: "org-1",
+      success: true,
+      amount: 10,
+      newBalance: 15, // local fallback: previousBalance 5 + amount 10
+    });
+
+    const critical = loggerError.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("CRITICAL"),
+    );
+    expect(critical).toBeDefined();
+    expect(critical?.[0]).toContain("org-1");
+    expect(critical?.[0]).toContain("pi_auto_123");
   });
 });

--- a/packages/cloud-shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud-shared/src/lib/services/auto-top-up.ts
@@ -244,17 +244,36 @@ export class AutoTopUpService {
 
     if (paymentIntent.status === "succeeded") {
       const previousBalance = Number(org.credit_balance);
-      const { creditsService } = await import("./credits");
-      const { newBalance } = await creditsService.addCredits({
-        organizationId,
-        amount,
-        description: `Auto top-up - $${amount.toFixed(2)}`,
-        metadata: {
-          ...metadata,
-          payment_intent_id: paymentIntent.id,
-        },
-        stripePaymentIntentId: paymentIntent.id,
-      });
+
+      // Persist the credits synchronously so the API never reports success while the
+      // balance is still unwritten. `creditsService` lives in `./credits`, which
+      // dynamic-imports this module back — load it dynamically to avoid the cycle.
+      // `stripePaymentIntentId` is load-bearing: it's the same id the Stripe webhook
+      // uses, so the 3-layer idempotency guard collapses sync-add + webhook into
+      // exactly one credit. Drop it and the org double-credits.
+      let newBalance = previousBalance + amount;
+      try {
+        const { creditsService } = await import("./credits");
+        const persisted = await creditsService.addCredits({
+          organizationId,
+          amount,
+          description: `Auto top-up - $${amount.toFixed(2)}`,
+          metadata: {
+            ...metadata,
+            payment_intent_id: paymentIntent.id,
+          },
+          stripePaymentIntentId: paymentIntent.id,
+        });
+        newBalance = persisted.newBalance;
+      } catch (persistError) {
+        // The card is ALREADY charged. Never flip to success:false here — that risks a
+        // retry / double charge. Log loudly and let the Stripe webhook reconcile via the
+        // same payment-intent idempotency key; fall back to the locally-computed balance.
+        logger.error(
+          `[AutoTopUp] CRITICAL: auto-top-up charged but sync credit persist failed; the Stripe webhook will reconcile via idempotency, org=${organizationId}, pi=${paymentIntent.id}`,
+          persistError,
+        );
+      }
 
       logger.info(
         `[AutoTopUp] ✓ Auto top-up succeeded for org ${organizationId}. Payment: ${paymentIntent.id}`,


### PR DESCRIPTION
## What

Auto top-up charges the Stripe PaymentIntent, then persists the credits synchronously via `creditsService.addCredits` with `stripePaymentIntentId: paymentIntent.id` as the idempotency key — so the sync add and the async Stripe webhook collapse to **exactly one** credit (3-layer guard: app-level pre-check + atomic CTE `ON CONFLICT DO NOTHING` + unique index, all keyed on `stripe_payment_intent_id`).

That persist call existed but had **no error handling**, and the card is *already charged* by the time we get there. If the DB write threw, the whole `executeAutoTopUp` threw → risk of a charge retry / double charge. This PR wraps it:

- on persist failure: log **CRITICAL** (org + pi id) and **fall back** to returning `success: true` with the locally-computed balance. We never flip to `success: false` here — the webhook reconciles via the same idempotency key.
- credit the **base `amount`**, not the fee-inclusive `totalAmount` charged to Stripe (the webhook credits the same base, so both paths agree).
- dynamic `import("./credits")` kept — `credits.ts` dynamic-imports this module back, so a static import would be a cycle.

## Tests

This path had **zero** coverage. Added:

- base-amount-not-total is credited, with the payment-intent id passed.
- charged-but-persist-failed → logs CRITICAL, still returns success with the local balance (no `success: false`).
- a **real-credit-logic** idempotency test: runs the actual `creditsService.addCredits` over an in-memory ledger that mirrors the production idempotency contract, and proves the webhook replaying the same `pi` id does **not** double-credit (one ledger row, balance unchanged). Only the boundaries (Stripe, the DB executor, repos, cache) are mocked.

## Verify

```
bun test --isolate packages/cloud-shared/.../auto-top-up.test.ts auto-top-up-idempotency.test.ts
# 5 pass / 0 fail
```

cloud-shared typecheck: no errors in the changed files (the 4 pre-existing errors are missing i18n codegen artifacts in core/shared, unrelated).

Closes #9321