### PR TITLE
fix(electrobun): Windows production bugs — which CLI probe + lsof port reclaim

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -1271,21 +1271,39 @@ function shouldAutoRecoverPgliteFailure(line: string): boolean {
  * Set ELIZA_AGENT_RECLAIM_STALE_PORT=1 to restore the old "take over default
  * port" behavior.
  */
+/**
+ * PIDs listening on `port`. POSIX uses `lsof`; Windows uses
+ * `Get-NetTCPConnection` (locale-independent and returns the owning PID
+ * directly — `lsof` does not exist on Windows, so the reclaim was a silent
+ * no-op there before).
+ */
+function listListeningPids(port: number): number[] {
+  const result =
+    process.platform === "win32"
+      ? Bun.spawnSync([
+          "powershell.exe",
+          "-NoProfile",
+          "-Command",
+          `(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue).OwningProcess`,
+        ])
+      : Bun.spawnSync(["lsof", "-ti", `tcp:${port}`]);
+  return new TextDecoder()
+    .decode(result.stdout)
+    .trim()
+    .split(/\r?\n/)
+    .map((p) => parseInt(p.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+}
+
 async function maybeReclaimPortWithSigkill(port: number): Promise<void> {
   const raw = process.env.ELIZA_AGENT_RECLAIM_STALE_PORT?.trim().toLowerCase();
   if (raw !== "1" && raw !== "true" && raw !== "yes") {
     return;
   }
   try {
-    const lsofResult = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`]);
-    const pids = new TextDecoder()
-      .decode(lsofResult.stdout)
-      .trim()
-      .split("\n")
-      .filter(Boolean);
-    for (const pid of pids) {
-      const numPid = parseInt(pid, 10);
-      if (!Number.isNaN(numPid) && numPid !== process.pid) {
+    const pids = listListeningPids(port);
+    for (const numPid of pids) {
+      if (numPid !== process.pid) {
         diagnosticLog(
           `[Agent] Reclaim: killing process ${numPid} on port ${port} (ELIZA_AGENT_RECLAIM_STALE_PORT)`,
         );
@@ -1300,7 +1318,7 @@ async function maybeReclaimPortWithSigkill(port: number): Promise<void> {
       await new Promise((r) => setTimeout(r, 500));
     }
   } catch {
-    // lsof missing — ignore
+    // port-listing tool missing — ignore
   }
 }
 

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -82,7 +82,12 @@ function isTruthyFlag(value: string | undefined): boolean {
 
 async function isCliInstalled(name: string): Promise<boolean> {
   try {
-    const proc = Bun.spawn(["which", name], {
+    // `which` does not exist on Windows — use `where`. Without this, every CLI
+    // probe (claude, gh, ollama, codex, gemini, gcloud …) spawns a missing
+    // binary, returns false, and the desktop app reports installed CLIs as
+    // absent on Windows.
+    const probe = process.platform === "win32" ? "where" : "which";
+    const proc = Bun.spawn([probe, name], {
       stdout: "pipe",
       stderr: "ignore",
     });


### PR DESCRIPTION
## What

The source-level Windows audit found two POSIX-only spawns in the electrobun desktop shell's native layer (no test exercises them — electrobun has no `windows-ci`):

1. **`credentials.ts` `isCliInstalled()`** spawned `which <name>` unconditionally. `which` doesn't exist on Windows → every CLI probe (`claude`, `gh`, `ollama`, `codex`, `gemini`, `gcloud`, …) returns false → the desktop app reports installed CLIs as **absent on Windows**. → `where` on win32. (`readKeychainCredential` stays darwin-gated; these CLI probes are not gated.)
2. **`agent.ts` `maybeReclaimPortWithSigkill()`** (opt-in `ELIZA_AGENT_RECLAIM_STALE_PORT`) spawned `lsof -ti tcp:<port>` — absent on Windows, so the reclaim **silently no-op'd** there. → extract `listListeningPids()` and add a Windows path via `Get-NetTCPConnection -LocalPort <port> -State Listen` (locale-independent, returns the owning PID directly; `process.kill` already force-terminates on Windows).

## Safety / evidence

POSIX behavior unchanged (every change win32-gated). electrobun typecheck clean (`tsgo --noEmit -p packages/app-core/platforms/electrobun/tsconfig.json`); `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)