### PR TITLE
fix(scenario-runner): seed connector degradation

### DIFF
--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -1,0 +1,182 @@
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import type {
+  ScenarioContext,
+  ScenarioSeedStep,
+} from "@elizaos/scenario-runner/schema";
+import { describe, expect, it, vi } from "vitest";
+import { applyScenarioSeedStep } from "./seeds";
+
+type ConnectorContributionForTest = {
+  kind: string;
+  capabilities: string[];
+  modes: Array<"local" | "cloud">;
+  describe: { label: string };
+  start: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  verify: () => Promise<boolean>;
+  status: () => Promise<{
+    state: "ok" | "degraded" | "disconnected";
+    message?: string;
+    observedAt: string;
+  }>;
+  send?: (payload: unknown) => Promise<unknown>;
+};
+
+type ConnectorRegistryModuleForTest = {
+  createConnectorRegistry: () => {
+    register: (contribution: ConnectorContributionForTest) => void;
+    get: (kind: string) => ConnectorContributionForTest | null;
+    list: (filter?: {
+      capability?: string;
+      mode?: "local" | "cloud";
+    }) => ConnectorContributionForTest[];
+    byCapability: (capability: string) => ConnectorContributionForTest[];
+  };
+  getConnectorRegistry: (
+    runtime: AgentRuntime,
+  ) => ReturnType<
+    ConnectorRegistryModuleForTest["createConnectorRegistry"]
+  > | null;
+  registerConnectorRegistry: (
+    runtime: AgentRuntime,
+    registry: ReturnType<
+      ConnectorRegistryModuleForTest["createConnectorRegistry"]
+    >,
+  ) => void;
+};
+
+async function loadConnectorRegistryForTest(): Promise<ConnectorRegistryModuleForTest> {
+  const specifier = new URL(
+    "../../../plugins/plugin-personal-assistant/src/lifeops/connectors/registry.ts",
+    import.meta.url,
+  ).href;
+  return import(specifier) as Promise<ConnectorRegistryModuleForTest>;
+}
+
+function createSeedContext() {
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+  } as unknown as AgentRuntime;
+  return { runtime, ctx: { runtime } as ScenarioContext };
+}
+
+function baseConnector(
+  overrides: Partial<ConnectorContributionForTest> = {},
+): ConnectorContributionForTest {
+  return {
+    kind: "telegram",
+    capabilities: ["telegram.send"],
+    modes: ["local"],
+    describe: { label: "Telegram bridge" },
+    start: vi.fn(async () => undefined),
+    disconnect: vi.fn(async () => undefined),
+    verify: vi.fn(async () => true),
+    status: vi.fn(async () => ({
+      state: "ok" as const,
+      observedAt: "2026-01-01T00:00:00.000Z",
+    })),
+    send: vi.fn(async () => ({ ok: true, messageId: "sent-1" })),
+    ...overrides,
+  };
+}
+
+describe("scenario connector seeds", () => {
+  it("registers connectorStatus seeds as degraded connector contributions", async () => {
+    const { ctx, runtime } = createSeedContext();
+    const { getConnectorRegistry } = await loadConnectorRegistryForTest();
+
+    const result = await applyScenarioSeedStep(ctx, {
+      type: "connectorStatus",
+      connector: "gmail",
+      provider: "Gmail API",
+      state: "missing-scope",
+      capabilities: ["google.gmail.triage"],
+      scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+    } as ScenarioSeedStep);
+
+    expect(result).toBeUndefined();
+    const registry = getConnectorRegistry(runtime);
+    const connector = registry?.get("gmail");
+    expect(connector?.describe.label).toBe("Gmail API");
+    expect(connector?.capabilities).toEqual([
+      "google.gmail.triage",
+      "https://www.googleapis.com/auth/gmail.readonly",
+    ]);
+    await expect(connector?.status()).resolves.toMatchObject({
+      state: "degraded",
+      message: "Gmail API seeded missing scope",
+    });
+  });
+
+  it("overrides existing connector auth status and send failures", async () => {
+    const { ctx, runtime } = createSeedContext();
+    const {
+      createConnectorRegistry,
+      getConnectorRegistry,
+      registerConnectorRegistry,
+    } = await loadConnectorRegistryForTest();
+    const base = createConnectorRegistry();
+    base.register(baseConnector());
+    registerConnectorRegistry(runtime, base);
+
+    await applyScenarioSeedStep(ctx, {
+      type: "connectorAuthSession",
+      connector: "telegram",
+      provider: "Telegram bridge",
+      state: "auth-expired",
+    } as ScenarioSeedStep);
+
+    const connector = getConnectorRegistry(runtime)?.get("telegram");
+    await expect(connector?.status()).resolves.toMatchObject({
+      state: "disconnected",
+      message: "Telegram bridge seeded auth expired",
+    });
+    await expect(connector?.send?.({ text: "hello" })).resolves.toMatchObject({
+      ok: false,
+      reason: "auth_expired",
+      userActionable: true,
+    });
+  });
+
+  it("limits transportFault failures before delegating to the base sender", async () => {
+    const { ctx, runtime } = createSeedContext();
+    const {
+      createConnectorRegistry,
+      getConnectorRegistry,
+      registerConnectorRegistry,
+    } = await loadConnectorRegistryForTest();
+    const base = createConnectorRegistry();
+    base.register(
+      baseConnector({
+        kind: "whatsapp",
+        capabilities: ["whatsapp.send"],
+        describe: { label: "WhatsApp bridge" },
+      }),
+    );
+    registerConnectorRegistry(runtime, base);
+
+    await applyScenarioSeedStep(ctx, {
+      type: "transportFault",
+      connector: "whatsapp",
+      provider: "WhatsApp bridge",
+      state: "rate-limited",
+      limit: 1,
+    } as ScenarioSeedStep);
+
+    const connector = getConnectorRegistry(runtime)?.get("whatsapp");
+    await expect(connector?.status()).resolves.toMatchObject({
+      state: "degraded",
+      message: "WhatsApp bridge seeded rate limited",
+    });
+    await expect(connector?.send?.({ text: "first" })).resolves.toMatchObject({
+      ok: false,
+      reason: "rate_limited",
+      retryAfterMinutes: 5,
+      userActionable: false,
+    });
+    await expect(connector?.send?.({ text: "second" })).resolves.toMatchObject({
+      ok: true,
+      messageId: "sent-1",
+    });
+  });
+});

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -131,6 +131,16 @@ type GmailInboxSeed = {
   clearLedger?: unknown;
 };
 
+type ConnectorSeed = {
+  type: "connectorStatus" | "connectorAuthSession" | "transportFault";
+  connector?: unknown;
+  provider?: unknown;
+  state?: unknown;
+  capabilities?: unknown;
+  scopes?: unknown;
+  limit?: unknown;
+};
+
 type MemoryContactSeed = {
   kind?: unknown;
   type?: unknown;
@@ -141,6 +151,74 @@ type MemoryContactSeed = {
   lastContactedAt?: unknown;
   relationshipStatus?: unknown;
 };
+
+type ConnectorStatusLike = {
+  state: "ok" | "degraded" | "disconnected";
+  message?: string;
+  observedAt: string;
+};
+
+type DispatchResultLike =
+  | { ok: true; messageId?: string }
+  | {
+      ok: false;
+      reason:
+        | "disconnected"
+        | "rate_limited"
+        | "auth_expired"
+        | "unknown_recipient"
+        | "transport_error";
+      retryAfterMinutes?: number;
+      userActionable: boolean;
+      message?: string;
+    };
+
+type ConnectorModeLike = "local" | "cloud";
+
+type ConnectorRegistryFilterLike = {
+  capability?: string;
+  mode?: ConnectorModeLike;
+};
+
+type ConnectorContributionLike = {
+  kind: string;
+  capabilities: string[];
+  modes: ConnectorModeLike[];
+  describe: { label: string };
+  start: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  verify: () => Promise<boolean>;
+  status: () => Promise<ConnectorStatusLike>;
+  send?: (payload: unknown) => Promise<DispatchResultLike>;
+  read?: (query: unknown) => Promise<unknown>;
+  requiresApproval?: boolean;
+  oauth?: unknown;
+  apiBaseUrl?: string;
+};
+
+type ConnectorRegistryLike = {
+  register: (contribution: ConnectorContributionLike) => void;
+  list: (filter?: ConnectorRegistryFilterLike) => ConnectorContributionLike[];
+  get: (kind: string) => ConnectorContributionLike | null;
+  byCapability: (capability: string) => ConnectorContributionLike[];
+};
+
+type ConnectorRegistryModule = {
+  createConnectorRegistry: () => ConnectorRegistryLike;
+  getConnectorRegistry: (runtime: AgentRuntime) => ConnectorRegistryLike | null;
+  registerConnectorRegistry: (
+    runtime: AgentRuntime,
+    registry: ConnectorRegistryLike,
+  ) => void;
+};
+
+async function loadConnectorRegistry(): Promise<ConnectorRegistryModule> {
+  const specifier = new URL(
+    "../../../plugins/plugin-personal-assistant/src/lifeops/connectors/registry.ts",
+    import.meta.url,
+  ).href;
+  return import(specifier) as Promise<ConnectorRegistryModule>;
+}
 
 type RelationshipsServiceLike = {
   getContact: (entityId: UUID) => Promise<unknown>;
@@ -205,6 +283,12 @@ function readOptionalNumber(value: unknown): number | undefined {
 
 function readOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
 }
 
 function readScenarioNow(ctx: ScenarioContext): Date {
@@ -530,6 +614,212 @@ async function seedGmailInbox(
   return undefined;
 }
 
+function normalizeConnectorKind(value: unknown): string | null {
+  const raw = readNonEmptyString(value);
+  return raw ? raw.toLowerCase().replace(/[\s_]+/g, "-") : null;
+}
+
+function connectorStateText(seed: ConnectorSeed): string {
+  return readNonEmptyString(seed.state)?.replace(/[-_]+/g, " ") ?? "degraded";
+}
+
+function connectorLabel(seed: ConnectorSeed, connector: string): string {
+  return readNonEmptyString(seed.provider) ?? connector;
+}
+
+function connectorStatusFromSeed(
+  seed: ConnectorSeed,
+  connector: string,
+): ConnectorStatusLike {
+  const state = readNonEmptyString(seed.state);
+  const disconnected =
+    seed.type === "connectorAuthSession" ||
+    state === "auth-expired" ||
+    state === "session-revoked" ||
+    state === "disconnected" ||
+    state === "helper-disconnected";
+  return {
+    state: disconnected ? "disconnected" : "degraded",
+    message: `${connectorLabel(seed, connector)} seeded ${connectorStateText(seed)}`,
+    observedAt: new Date().toISOString(),
+  };
+}
+
+function dispatchFailureFromSeed(seed: ConnectorSeed): DispatchResultLike {
+  const state = readNonEmptyString(seed.state);
+  const message = `${connectorLabel(
+    seed,
+    readNonEmptyString(seed.connector) ?? "connector",
+  )} seeded ${connectorStateText(seed)}`;
+  if (state === "rate-limited") {
+    return {
+      ok: false,
+      reason: "rate_limited",
+      retryAfterMinutes: 5,
+      userActionable: false,
+      message,
+    };
+  }
+  if (
+    seed.type === "connectorAuthSession" ||
+    state === "auth-expired" ||
+    state === "session-revoked" ||
+    state === "missing-scope"
+  ) {
+    return {
+      ok: false,
+      reason: "auth_expired",
+      userActionable: true,
+      message,
+    };
+  }
+  if (
+    state === "disconnected" ||
+    state === "helper-disconnected" ||
+    state === "transport-offline" ||
+    state === "blocked-resume"
+  ) {
+    return {
+      ok: false,
+      reason: "disconnected",
+      userActionable: true,
+      message,
+    };
+  }
+  return {
+    ok: false,
+    reason: "transport_error",
+    userActionable: state === "hold-expired",
+    message,
+  };
+}
+
+function connectorMatchesFilter(
+  contribution: ConnectorContributionLike,
+  filter?: ConnectorRegistryFilterLike,
+): boolean {
+  if (!filter) {
+    return true;
+  }
+  if (
+    filter.capability &&
+    !contribution.capabilities.includes(filter.capability)
+  ) {
+    return false;
+  }
+  if (filter.mode && !contribution.modes.includes(filter.mode)) {
+    return false;
+  }
+  return true;
+}
+
+function seededConnectorContribution(
+  seed: ConnectorSeed,
+  connector: string,
+  base: ConnectorContributionLike | null,
+): ConnectorContributionLike {
+  const capabilities = readStringArray(seed.capabilities);
+  const scopedCapabilities = readStringArray(seed.scopes);
+  const allCapabilities =
+    capabilities.length > 0 || scopedCapabilities.length > 0
+      ? [...capabilities, ...scopedCapabilities]
+      : (base?.capabilities ?? [`${connector}.scenario-seeded`]);
+  const limit = readPositiveInteger(seed.limit);
+  let failuresRemaining =
+    seed.type === "transportFault"
+      ? (limit ?? Number.POSITIVE_INFINITY)
+      : Number.POSITIVE_INFINITY;
+  const failure = () => dispatchFailureFromSeed(seed);
+
+  return {
+    ...(base ?? {}),
+    kind: base?.kind ?? connector,
+    capabilities: allCapabilities,
+    modes: base?.modes ?? ["local"],
+    describe: base?.describe ?? { label: connectorLabel(seed, connector) },
+    start: base?.start ?? (async () => undefined),
+    disconnect: base?.disconnect ?? (async () => undefined),
+    verify: async () => false,
+    status: async () => connectorStatusFromSeed(seed, connector),
+    ...(base?.read ? { read: base.read.bind(base) } : {}),
+    ...(base?.requiresApproval !== undefined
+      ? { requiresApproval: base.requiresApproval }
+      : {}),
+    ...(base?.oauth ? { oauth: base.oauth } : {}),
+    ...(base?.apiBaseUrl ? { apiBaseUrl: base.apiBaseUrl } : {}),
+    send: async (payload: unknown) => {
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1;
+        return failure();
+      }
+      if (base?.send) {
+        return base.send(payload);
+      }
+      return failure();
+    },
+  };
+}
+
+function createSeededConnectorRegistry(
+  base: ConnectorRegistryLike,
+  seed: ConnectorSeed,
+  connector: string,
+): ConnectorRegistryLike {
+  const getSeeded = (): ConnectorContributionLike =>
+    seededConnectorContribution(seed, connector, base.get(connector));
+
+  return {
+    register(contribution) {
+      base.register(contribution);
+    },
+    get(kind) {
+      return kind === connector ? getSeeded() : base.get(kind);
+    },
+    list(filter) {
+      const listed = base.list(filter).flatMap((contribution) => {
+        if (contribution.kind !== connector) {
+          return [contribution];
+        }
+        const seeded = getSeeded();
+        return connectorMatchesFilter(seeded, filter) ? [seeded] : [];
+      });
+      if (!listed.some((contribution) => contribution.kind === connector)) {
+        const seeded = getSeeded();
+        if (connectorMatchesFilter(seeded, filter)) {
+          listed.push(seeded);
+        }
+      }
+      return listed;
+    },
+    byCapability(capability) {
+      return this.list({ capability });
+    },
+  };
+}
+
+async function seedConnector(
+  ctx: ScenarioContext,
+  seed: ConnectorSeed,
+): Promise<string | undefined> {
+  const connector = normalizeConnectorKind(seed.connector);
+  if (!connector) {
+    return `${seed.type} seed requires a connector`;
+  }
+  const runtime = requireRuntime(ctx);
+  const {
+    createConnectorRegistry,
+    getConnectorRegistry,
+    registerConnectorRegistry,
+  } = await loadConnectorRegistry();
+  const currentRegistry =
+    getConnectorRegistry(runtime) ?? createConnectorRegistry();
+  registerConnectorRegistry(
+    runtime,
+    createSeededConnectorRegistry(currentRegistry, seed, connector),
+  );
+  return undefined;
+}
+
 export async function applyScenarioSeedStep(
   ctx: ScenarioContext,
   seed: ScenarioSeedStep,
@@ -549,6 +839,13 @@ export async function applyScenarioSeedStep(
   }
   if (seed.type === "gmailInbox") {
     return seedGmailInbox(seed as GmailInboxSeed);
+  }
+  if (
+    seed.type === "connectorStatus" ||
+    seed.type === "connectorAuthSession" ||
+    seed.type === "transportFault"
+  ) {
+    return seedConnector(ctx, seed as ConnectorSeed);
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- handles `connectorStatus`, `connectorAuthSession`, and `transportFault` scenario seed steps instead of silently dropping them
- wraps the per-runtime LifeOps `ConnectorRegistry` so seeded connectors surface degraded/disconnected status in provider context
- returns typed seeded `DispatchResult` failures for auth/session and transport faults, with `transportFault.limit` support before delegating to the base sender
- adds focused connector seed tests covering synthetic connectors, existing-registry overrides, and limited transport fault delegation

Part of #9310.

## Evidence
- `bun run --cwd packages/scenario-runner test src/seeds.test.ts` - 1 file / 3 tests passed
- `bunx @biomejs/biome check packages/scenario-runner/src/seeds.ts packages/scenario-runner/src/seeds.test.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test` - 18 files / 124 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin` + `git rebase origin/develop` - rebased cleanly
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario-runner seed behavior only; no agent prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
