### PR TITLE
test(ui): cover chat inline marker parsers

### DIFF
--- a/packages/ui/src/components/chat/message-choice-parser.test.ts
+++ b/packages/ui/src/components/chat/message-choice-parser.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { findChoiceRegions, parseChoiceBody } from "./message-choice-parser";
+
+describe("parseChoiceBody", () => {
+  it("parses value=label rows and preserves equals signs in labels", () => {
+    expect(parseChoiceBody("yes=Approve\nno=Reject\nexpr=a=b=c")).toEqual([
+      { value: "yes", label: "Approve" },
+      { value: "no", label: "Reject" },
+      { value: "expr", label: "a=b=c" },
+    ]);
+  });
+
+  it("trims rows and skips malformed options", () => {
+    expect(
+      parseChoiceBody("\n no-equals \n =missing value \n v= \n ok = OK "),
+    ).toEqual([{ value: "ok", label: "OK" }]);
+  });
+});
+
+describe("findChoiceRegions", () => {
+  it("locates a CHOICE block with an explicit id and allow_custom flag", () => {
+    const text =
+      "Approve this?\n[CHOICE:approval allow_custom id=choice-1]\nyes=Approve\nno=Reject\n[/CHOICE]";
+    const regions = findChoiceRegions(text);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toMatchObject({
+      id: "choice-1",
+      scope: "approval",
+      allowCustom: true,
+      options: [
+        { value: "yes", label: "Approve" },
+        { value: "no", label: "Reject" },
+      ],
+    });
+    expect(text.slice(regions[0].start, regions[0].end)).toBe(
+      "[CHOICE:approval allow_custom id=choice-1]\nyes=Approve\nno=Reject\n[/CHOICE]",
+    );
+  });
+
+  it("generates an id when none is supplied", () => {
+    const regions = findChoiceRegions("[CHOICE:next]\na=A\n[/CHOICE]");
+    expect(regions).toHaveLength(1);
+    expect(regions[0].id.length).toBeGreaterThan(0);
+  });
+
+  it("allows hyphenated and underscored scopes", () => {
+    const regions = findChoiceRegions(
+      "[CHOICE:app_create-flow id=c1]\nrun=Run\n[/CHOICE]",
+    );
+    expect(regions[0].scope).toBe("app_create-flow");
+  });
+
+  it("ignores blocks with no valid options", () => {
+    expect(
+      findChoiceRegions("[CHOICE:approval id=c1]\nnot-a-pair\n[/CHOICE]"),
+    ).toEqual([]);
+  });
+
+  it("ignores malformed or unterminated markers", () => {
+    expect(findChoiceRegions("[CHOICE id=c1]\ny=Yes\n[/CHOICE]")).toEqual([]);
+    expect(findChoiceRegions("[CHOICE:approval id=c1]\ny=Yes")).toEqual([]);
+  });
+
+  it("finds multiple blocks in one message", () => {
+    const text =
+      "[CHOICE:first id=a]\ny=Yes\n[/CHOICE]\nthen\n[CHOICE:second id=b]\nn=No\n[/CHOICE]";
+    const regions = findChoiceRegions(text);
+    expect(regions.map((region) => region.id)).toEqual(["a", "b"]);
+    expect(regions.map((region) => region.scope)).toEqual(["first", "second"]);
+  });
+});

--- a/packages/ui/src/components/chat/message-parser-edge.test.ts
+++ b/packages/ui/src/components/chat/message-parser-edge.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { findChoiceRegions } from "./message-choice-parser";
+import { findFollowupsRegions } from "./message-followups-parser";
+import { findFormRegions } from "./message-form-parser";
+import { normalizeDisplayText } from "./message-parser-helpers";
+import { findTaskRegions, MAX_TASK_TITLE_LEN } from "./message-task-parser";
+
+const taskId = "0123abcd-1234-5678-9abc-deadbeefcafe";
+
+describe("inline marker parser edge cases", () => {
+  it("parses adjacent markers without one parser swallowing the next", () => {
+    const formBody = JSON.stringify({
+      id: "edge-form",
+      fields: [{ name: "topic", type: "text", label: "Topic" }],
+    });
+    const text =
+      "[CHOICE:approval id=dup]\ny=Yes\n[/CHOICE]" +
+      "[FOLLOWUPS id=dup]\nnavigate:/apps=Open apps\n[/FOLLOWUPS]" +
+      `[FORM]\n${formBody}\n[/FORM]` +
+      `[TASK:${taskId}]Review launch notes[/TASK]`;
+
+    const choices = findChoiceRegions(text);
+    const followups = findFollowupsRegions(text);
+    const forms = findFormRegions(text);
+    const tasks = findTaskRegions(text);
+
+    expect(choices).toHaveLength(1);
+    expect(followups).toHaveLength(1);
+    expect(forms).toHaveLength(1);
+    expect(tasks).toHaveLength(1);
+    expect(choices[0].end).toBe(followups[0].start);
+    expect(followups[0].end).toBe(forms[0].start);
+    expect(forms[0].end).toBe(tasks[0].start);
+  });
+
+  it("preserves unicode labels and task titles", () => {
+    const choice = findChoiceRegions(
+      "[CHOICE:greeting id=c1]\nhello=Bonjour \u2600\uFE0F\n[/CHOICE]",
+    );
+    const followups = findFollowupsRegions(
+      "[FOLLOWUPS id=f1]\nreply:\u4F60\u597D=Say hello\n[/FOLLOWUPS]",
+    );
+    const tasks = findTaskRegions(
+      `[TASK:${taskId}]\u4ED5\u4E8B\u3092\u78BA\u8A8D[/TASK]`,
+    );
+
+    expect(choice[0].options[0]).toEqual({
+      value: "hello",
+      label: "Bonjour \u2600\uFE0F",
+    });
+    expect(followups[0].options[0]).toEqual({
+      kind: "reply",
+      payload: "\u4F60\u597D",
+      label: "Say hello",
+    });
+    expect(tasks[0].title).toBe("\u4ED5\u4E8B\u3092\u78BA\u8A8D");
+  });
+
+  it("keeps duplicate ids as distinct regions instead of deduping", () => {
+    const choices = findChoiceRegions(
+      "[CHOICE:one id=dup]\na=A\n[/CHOICE]\n[CHOICE:two id=dup]\nb=B\n[/CHOICE]",
+    );
+    const followups = findFollowupsRegions(
+      "[FOLLOWUPS id=dup]\na=A\n[/FOLLOWUPS]\n[FOLLOWUPS id=dup]\nb=B\n[/FOLLOWUPS]",
+    );
+
+    expect(choices.map((region) => region.id)).toEqual(["dup", "dup"]);
+    expect(choices.map((region) => region.scope)).toEqual(["one", "two"]);
+    expect(followups.map((region) => region.id)).toEqual(["dup", "dup"]);
+  });
+
+  it("bounds normalized display text before later parser passes", () => {
+    const longPrefix = "x".repeat(200_010);
+    const marker = "[CHOICE:late id=c1]\ny=Yes\n[/CHOICE]";
+    const normalized = normalizeDisplayText(`${longPrefix}${marker}`);
+
+    expect(normalized).toHaveLength(200_000);
+    expect(normalized).not.toContain("[CHOICE:late");
+    expect(findChoiceRegions(normalized)).toEqual([]);
+  });
+
+  it("keeps task title bounds stable for very long titles", () => {
+    const longTitle = "x".repeat(MAX_TASK_TITLE_LEN + 100);
+    const tasks = findTaskRegions(`[TASK:${taskId}]${longTitle}[/TASK]`);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].title).toHaveLength(MAX_TASK_TITLE_LEN);
+    expect(tasks[0].title.endsWith("…")).toBe(true);
+  });
+
+  it("ignores malformed markers across parser families", () => {
+    expect(findChoiceRegions("[CHOICE id=c1]\ny=Yes\n[/CHOICE]")).toEqual([]);
+    expect(findFollowupsRegions("[FOLLOWUPS id=f1]\ny=Yes\n[/CHOICE]")).toEqual(
+      [],
+    );
+    expect(
+      findFormRegions('[FORM]\n{"fields":[{"name":"bad.name"}]}\n[/FORM]'),
+    ).toEqual([]);
+    expect(findTaskRegions("[TASK:ABCDEF12]Title[/TASK]")).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/chat/message-parser-streaming.test.ts
+++ b/packages/ui/src/components/chat/message-parser-streaming.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { findChoiceRegions } from "./message-choice-parser";
+import { findFollowupsRegions } from "./message-followups-parser";
+import { findFormRegions } from "./message-form-parser";
+import { findTaskRegions } from "./message-task-parser";
+
+const taskId = "0123abcd-1234-5678-9abc-deadbeefcafe";
+
+const formBody = JSON.stringify({
+  fields: [{ name: "destination", type: "text", label: "Destination" }],
+});
+
+const parserCases = [
+  {
+    name: "CHOICE",
+    full: "[CHOICE:approval id=c1]\nyes=Approve\n[/CHOICE]",
+    find: findChoiceRegions,
+  },
+  {
+    name: "FOLLOWUPS",
+    full: "[FOLLOWUPS id=f1]\nreply:again=Try again\n[/FOLLOWUPS]",
+    find: findFollowupsRegions,
+  },
+  {
+    name: "FORM",
+    full: `[FORM]\n${formBody}\n[/FORM]`,
+    find: findFormRegions,
+  },
+  {
+    name: "TASK",
+    full: `[TASK:${taskId}]Build the app[/TASK]`,
+    find: findTaskRegions,
+  },
+];
+
+describe("streaming inline-marker parsers", () => {
+  it.each(parserCases)("does not emit a $name widget for any proper prefix", ({
+    full,
+    find,
+  }) => {
+    for (let end = 0; end < full.length; end++) {
+      expect(find(full.slice(0, end))).toEqual([]);
+    }
+    expect(find(full)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds dedicated `message-choice-parser` unit coverage for option parsing, explicit/generated ids, malformed markers, and multiple blocks.
- Adds streaming-prefix regression coverage for CHOICE, FOLLOWUPS, FORM, and TASK markers so proper prefixes do not emit partial widgets.
- Adds shared edge coverage for adjacent markers, unicode payloads, duplicate ids, normalized 200k display bounds, long task-title bounds, and malformed marker families.

Refs #9304.

## Evidence
- `bun install`
- `bun run build:core`
- `bun run --cwd packages/ui test src/components/chat/message-choice-parser.test.ts src/components/chat/message-parser-streaming.test.ts src/components/chat/message-parser-edge.test.ts src/components/chat/message-form-parser.test.ts src/components/chat/message-followups-parser.test.ts src/components/chat/message-task-parser.test.ts` — 6 files / 44 tests passed
- `bunx @biomejs/biome check packages/ui/src/components/chat/message-choice-parser.test.ts packages/ui/src/components/chat/message-parser-streaming.test.ts packages/ui/src/components/chat/message-parser-edge.test.ts`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/ui build`
- `git diff --check`
- `git fetch origin && git rebase origin/develop` — clean
- `bun install`
- focused parser test command again after rebase — 6 files / 44 tests passed
- `bun run verify` — 509/509 tasks successful in 2m3.785s
- final `git fetch origin` confirmed `origin/develop` is an ancestor of branch head

## Notes
- `bun run --cwd packages/ui test` was also attempted; the full package suite is currently red on unrelated existing failures: `@elizaos/tui` entry resolution in spatial tests, the no-backdrop/focus-ring gates, and the existing chat composer `ring-white/15` expectation. The focused parser suite and root verify are green.
- UI screenshots/video: N/A, test-only parser coverage with no rendered UI change.
- Real LLM trajectories: N/A, parser/unit coverage only.
