### PR TITLE
test(scenario-runner): replace expectedActionParams

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -64,6 +64,7 @@ interface ScenarioFacts {
   hasPerTurnAssert: boolean;
   hasPersonalityExpect: boolean;
   hasDeadPlannerAssert: boolean;
+  hasExpectedActionParams: boolean;
 }
 
 // plannerIncludesAll / plannerIncludesAny / plannerExcludes are not in the
@@ -71,6 +72,7 @@ interface ScenarioFacts {
 // them have silently-ignored "assertions". Tracked in #9310.
 const DEAD_PLANNER_ASSERT =
   /\b(plannerIncludesAll|plannerIncludesAny|plannerExcludes)\s*:/;
+const DEAD_EXPECTED_ACTION_PARAMS = /\bexpectedActionParams\s*:/;
 
 const PER_TURN_ASSERT =
   /\b(assertResponse|responseIncludesAny|responseIncludesAll|responseJudge|assertTurn)\b/;
@@ -88,6 +90,7 @@ function analyze(file: string): ScenarioFacts {
     hasPerTurnAssert: PER_TURN_ASSERT.test(src),
     hasPersonalityExpect: /\bpersonalityExpect\s*:/.test(src),
     hasDeadPlannerAssert: DEAD_PLANNER_ASSERT.test(src),
+    hasExpectedActionParams: DEAD_EXPECTED_ACTION_PARAMS.test(src),
   };
 }
 
@@ -120,6 +123,14 @@ describe("scenario corpus assertion guard", () => {
       .map(rel)
       .sort();
     expect(misLaned).toEqual([]);
+  });
+
+  it("does not use dead expectedActionParams turn assertions", () => {
+    const offenders = facts
+      .filter((f) => f.hasExpectedActionParams)
+      .map(rel)
+      .sort();
+    expect(offenders).toEqual([]);
   });
 
   // Ratchet against the dead plannerIncludes*/plannerExcludes fields. They are

--- a/packages/test/scenarios/relationships/rolodex.add-contact.scenario.ts
+++ b/packages/test/scenarios/relationships/rolodex.add-contact.scenario.ts
@@ -36,9 +36,6 @@ export default scenario({
       room: "main",
       text: "Add Alice Chen to my contacts, she's at Acme Inc.",
       expectedActions: ["ADD_CONTACT"],
-      expectedActionParams: {
-        ADD_CONTACT: { $regex: "Alice" },
-      },
     },
   ],
 
@@ -47,6 +44,11 @@ export default scenario({
       type: "actionCalled",
       actionName: "ADD_CONTACT",
       minCount: 1,
+    },
+    {
+      type: "selectedActionArguments",
+      actionName: "ADD_CONTACT",
+      includesAny: [/Alice/i],
     },
   ],
 });


### PR DESCRIPTION
## Summary
- migrates the only authored `expectedActionParams` assertion to the already-enforced `selectedActionArguments` finalCheck
- keeps the ADD_CONTACT argument assertion checking for `Alice`
- adds a corpus guard so dead `expectedActionParams` turn assertions cannot be reintroduced

Part of #9310.

## Evidence
- `rg -n "expectedActionParams" packages/test/scenarios plugins/*/test/scenarios -g '*.ts'` - no matches
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 5 tests passed
- `bunx @biomejs/biome check packages/scenario-runner/src/corpus-assertion-guard.test.ts packages/test/scenarios/relationships/rolodex.add-contact.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test` - 17 files / 124 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - up to date
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion migration and corpus guard only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed