### PR TITLE
ci: build + push the EDAD example-app image to GHCR (prereq for #9300)

### DIFF
--- a/.github/workflows/build-example-app-images.yml
+++ b/.github/workflows/build-example-app-images.yml
@@ -1,0 +1,153 @@
+name: Build Example App Images
+
+# Builds + pushes the example-app showcase images consumed by the Apps/Product 2
+# showcase e2e loop. Right now that's just EDAD; future example apps (e.g. the
+# clone-ur-crush app) get their own job here once they have a standalone build.
+#
+# The showcase spec (packages/test/cloud-e2e/tests/example-apps-showcase.spec.ts)
+# deploys `ghcr.io/elizaos/example-edad:showcase` via the prebuilt-image path
+# (app.metadata.imageTag → app-deploy-runner.ts), but nothing in the repo built
+# that image. This workflow is that missing piece.
+#
+# Why we bundle on the runner instead of building ./Dockerfile from scratch:
+#   server.ts imports `@elizaos/cloud-sdk` (workspace:*). That only resolves
+#   inside the monorepo, and the SDK's dist/ is gitignored. A standalone docker
+#   build of ./Dockerfile would crash at boot ("Cannot find package
+#   @elizaos/cloud-sdk"). Instead we run `bun build server.ts` on the runner —
+#   where the workspace IS resolvable — which inlines the SDK into a single
+#   self-contained server.js (verified: 0 residual @elizaos/cloud-sdk imports),
+#   then ship that with Dockerfile.bundle from a tiny context. Same pre-build
+#   sequence build-agent-image.yml uses to make the cloud-sdk dist available.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "packages/examples/cloud/edad/**"
+      - "packages/cloud-sdk/**"
+      - ".github/workflows/build-example-app-images.yml"
+  workflow_dispatch:
+
+# One in-flight build per ref; a newer push cancels the stale one (avoids the
+# queue pile-up the agent-image build learned the hard way).
+concurrency:
+  group: build-example-edad-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: elizaos/example-edad
+
+# Least privilege by default; the build job opts into packages: write.
+permissions:
+  contents: read
+
+jobs:
+  build-edad:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "canary"
+
+      - name: Cache Bun install
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-canary-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-canary-
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        # Creates the @elizaos/cloud-sdk workspace symlink edad resolves through.
+        # --no-frozen-lockfile mirrors build-agent-image.yml: a downstream
+        # lockfile drift on develop shouldn't short-circuit the install.
+        env:
+          NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
+        run: bun install --no-frozen-lockfile
+
+      - name: Build @elizaos/cloud-sdk
+        # The SDK's `exports.import` points at ./dist/index.js, which is
+        # gitignored (absent on a cold checkout). Without this build, the
+        # `bun build` below fails to resolve "@elizaos/cloud-sdk" even with the
+        # workspace symlink in place. build-agent-image.yml builds this same
+        # package for the same reason.
+        env:
+          NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
+        run: |
+          cd packages/cloud-sdk
+          bun install --no-frozen-lockfile --ignore-scripts
+          bun run build
+
+      - name: Bundle the EDAD server (inline the workspace SDK)
+        # Produces a single self-contained server.js with @elizaos/cloud-sdk
+        # inlined — no workspace dep, no bun install needed in the image. Output
+        # goes to ./dist (already gitignored, same dir edad's `build` script
+        # uses); dist/ (server.js + public/) is the tiny docker build context.
+        run: |
+          set -euo pipefail
+          cd packages/examples/cloud/edad
+          rm -rf ./dist
+          bun build server.ts --outdir=./dist --target=bun --format=esm
+          cp -r public ./dist/public
+          test -f ./dist/server.js
+          # Guard: the bundle must NOT still reference the workspace dep, else
+          # the image would crash at boot.
+          if grep -q "@elizaos/cloud-sdk" ./dist/server.js; then
+            echo "::error::server.js still references @elizaos/cloud-sdk — bundle did not inline the workspace dep" >&2
+            exit 1
+          fi
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # :showcase    → the moving tag the showcase spec deploys
+          # :sha-<short> → immutable per-commit tag (mirrors build-agent-image.yml)
+          tags: |
+            type=raw,value=showcase
+            type=sha,prefix=sha-,format=short
+
+      - id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: packages/examples/cloud/edad/dist
+          file: packages/examples/cloud/edad/Dockerfile.bundle
+          push: true
+          provenance: false
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Make image public
+        # The deploy puller pulls anonymously; keep the package public.
+        # Idempotent — patching to public when already public is a no-op.
+        run: |
+          curl \
+            -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/orgs/elizaOS/packages/container/example-edad/visibility \
+            -d '{"visibility":"public"}' || \
+          echo "::warning::Could not set package visibility to public — set it once manually in the GHCR package settings"

--- a/packages/examples/cloud/edad/Dockerfile.bundle
+++ b/packages/examples/cloud/edad/Dockerfile.bundle
@@ -1,0 +1,37 @@
+# Showcase image for the EDAD example app (ghcr.io/elizaos/example-edad).
+#
+# Why this is separate from ./Dockerfile:
+#   The committed ./Dockerfile runs `bun run server.ts` directly, which imports
+#   `@elizaos/cloud-sdk` (a `workspace:*` dep). That only resolves inside the
+#   monorepo — a standalone build context has no workspace symlink and the
+#   SDK's `dist/` is gitignored, so a from-scratch image build of ./Dockerfile
+#   would crash at boot with "Cannot find package '@elizaos/cloud-sdk'".
+#
+#   The CI workflow (build-example-app-images.yml) sidesteps that: it runs
+#   `bun build server.ts` on the runner — where the workspace IS resolvable —
+#   producing a single self-contained `server.js` with the SDK inlined and zero
+#   remaining workspace dep. This Dockerfile just ships that bundle, so the
+#   build context is the tiny bundle dir (server.js + public/) instead of the
+#   29G monorepo. No `bun install` in-image, no workspace coupling.
+#
+# Build context: the ./dist bundle dir prepared by the workflow, containing:
+#   server.js   (self-contained, SDK inlined)
+#   public/     (static assets served by the bundle via import.meta.dir)
+ARG BUN_BASE=oven/bun:canary-alpine
+
+FROM ${BUN_BASE}
+
+WORKDIR /app
+
+COPY server.js ./
+COPY public ./public
+
+ENV PORT=3000
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:3000/health || exit 1
+
+CMD ["bun", "run", "server.js"]


### PR DESCRIPTION
## What

Adds the CI workflow that builds + pushes the EDAD example-app image to GHCR (`ghcr.io/elizaos/example-edad:showcase` + `:sha-<short>`).

This is the prerequisite image-build slice for #9300. The showcase e2e loop (`packages/test/cloud-e2e/tests/example-apps-showcase.spec.ts`) already deploys `ghcr.io/elizaos/example-edad:showcase` through the prebuilt-image path (`app.metadata.imageTag` → `app-deploy-runner.ts`), but nothing in the repo actually built that image — so the real-staging deploy had no image to pull. This fills that gap. It does **not** close #9300 (the real-staging deploy driver is a follow-up).

## The interesting bit — the workspace-dep build context

`edad/server.ts` imports `@elizaos/cloud-sdk`, which is a `workspace:*` dep. The committed `edad/Dockerfile` runs `bun run server.ts` directly, but:
- a standalone docker context has no workspace symlink, and
- the SDK's `dist/` is gitignored (absent on a cold checkout).

So a straight `docker build` of that Dockerfile would crash at boot with `Cannot find package '@elizaos/cloud-sdk'`. Confirmed locally: a cold `bun build` errors `Could not resolve "@elizaos/cloud-sdk"`, and it still errors right after `bun install` because the SDK's `exports.import` points at the unbuilt `dist/index.js`.

The fix mirrors what `build-agent-image.yml` already does for the same package: on the runner (where the workspace resolves), `bun install` → build `packages/cloud-sdk` → `bun build server.ts --target=bun`. That inlines the SDK into a single self-contained `server.js` with **zero** residual `@elizaos/cloud-sdk` imports (verified locally: 7 modules bundled, only `node:`/`bun` builtins left). A new `Dockerfile.bundle` then ships just that bundle + `public/` from a tiny `dist/` context — no `bun install` in-image, no 29G monorepo context. The existing `Dockerfile` is left untouched (it's the documented ECR/embedded path).

Verified locally (Docker not available here, so CI is the build proof):
- `bun build` inlines the SDK → self-contained `server.js`, 0 workspace-dep refs.
- the bundle boots stateless (no `DATABASE_URL`): `/health` → `ok`, `/` serves the HTML, `/api/config` returns config.
- the workflow has a guard step that fails the build if `server.js` still references `@elizaos/cloud-sdk`.

## Tags + triggers

- `:showcase` (the moving tag the showcase spec deploys) + `:sha-<short>` (immutable, mirrors `build-agent-image.yml`).
- push to `develop` touching `packages/examples/cloud/edad/**` or `packages/cloud-sdk/**`, plus `workflow_dispatch`.
- `concurrency: cancel-in-progress` so a newer push cancels the stale build.
- Makes the GHCR package public so the deploy puller can pull anonymously (idempotent; warns instead of failing if the API call can't set it).

## Validation

- `actionlint` 1.7.12 → clean (includes shellcheck on the `run:` blocks).
- YAML structure parsed + image ref matches the spec's `imageTag` exactly.
- grep confirms no other workflow already builds this image.

## Not in scope (follow-ups)

The real-staging EDAD deploy driver (the `test.skip` under `MONETIZED_LOOP_REAL=1`), operator prep (showcase org + secrets + allowed-org-ids + daemon), and the clone-ur-crush image (needs a standalone Dockerfile first). Tracked under #9300.
