### PR TITLE
test(scenario-runner): assert todo completion effect

### DIFF
--- a/packages/test/scenarios/todos/todo.complete.scenario.ts
+++ b/packages/test/scenarios/todos/todo.complete.scenario.ts
@@ -40,5 +40,34 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      type: "custom",
+      name: "take-out-trash-completed",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) =>
+            action.result?.data && typeof action.result.data === "object"
+              ? (action.result.data as Record<string, unknown>)
+              : null,
+          )
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const completed = lifeResults.find(
+          (data) => data.title === "Take out trash",
+        );
+        if (!completed) {
+          const seen =
+            lifeResults
+              .map((data) =>
+                typeof data.title === "string" ? data.title : "(untitled)",
+              )
+              .join(", ") || "(none)";
+          return `expected completed todo title "Take out trash"; saw ${seen}`;
+        }
+        if (completed.state !== "completed") {
+          return `expected "Take out trash" state completed; got ${String(completed.state ?? "(missing)")}`;
+        }
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.complete` beyond echoable response words plus `actionCalled(LIFE)`
- adds a scenario-local custom final check that inspects captured `LIFE` result data
- requires the completed occurrence title to be `Take out trash` and its state to be `completed`

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.complete.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 17 files / 125 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed