### PR TITLE
test(scenario-runner): assert todo priority effect

### DIFF
--- a/packages/test/scenarios/todos/todo.update.priority.scenario.ts
+++ b/packages/test/scenarios/todos/todo.update.priority.scenario.ts
@@ -41,5 +41,46 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      type: "custom",
+      name: "tax-forms-priority-raised",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) =>
+            action.result?.data && typeof action.result.data === "object"
+              ? (action.result.data as Record<string, unknown>)
+              : null,
+          )
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const updated = lifeResults.find((data) => {
+          const definition =
+            data.definition && typeof data.definition === "object"
+              ? (data.definition as Record<string, unknown>)
+              : null;
+          return definition?.title === "Finish tax forms";
+        });
+        if (!updated) {
+          const seen =
+            lifeResults
+              .map((data) => {
+                const definition =
+                  data.definition && typeof data.definition === "object"
+                    ? (data.definition as Record<string, unknown>)
+                    : null;
+                return typeof definition?.title === "string"
+                  ? definition.title
+                  : "(untitled)";
+              })
+              .join(", ") || "(none)";
+          return `expected updated todo definition "Finish tax forms"; saw ${seen}`;
+        }
+        const definition = updated.definition as Record<string, unknown>;
+        const priority = definition.priority;
+        if (typeof priority !== "number" || priority <= 3) {
+          return `expected "Finish tax forms" priority to be raised above 3; got ${String(priority ?? "(missing)")}`;
+        }
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.update.priority` beyond echoable response words plus `actionCalled(LIFE)`
- adds a scenario-local custom final check that inspects captured `LIFE` result data
- requires the updated definition title to be `Finish tax forms` and its priority to be raised above the seeded neutral value

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.update.priority.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 17 files / 128 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
