### PR TITLE
test(scenario-runner): assert todo due date effect

### DIFF
--- a/packages/test/scenarios/todos/todo.update.due.scenario.ts
+++ b/packages/test/scenarios/todos/todo.update.due.scenario.ts
@@ -45,5 +45,64 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      type: "custom",
+      name: "passport-due-date-moved",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) =>
+            action.result?.data && typeof action.result.data === "object"
+              ? (action.result.data as Record<string, unknown>)
+              : null,
+          )
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const updated = lifeResults.find((data) => {
+          const definition =
+            data.definition && typeof data.definition === "object"
+              ? (data.definition as Record<string, unknown>)
+              : null;
+          return definition?.title === "Renew passport";
+        });
+        if (!updated) {
+          const seen =
+            lifeResults
+              .map((data) => {
+                const definition =
+                  data.definition && typeof data.definition === "object"
+                    ? (data.definition as Record<string, unknown>)
+                    : null;
+                return typeof definition?.title === "string"
+                  ? definition.title
+                  : "(untitled)";
+              })
+              .join(", ") || "(none)";
+          return `expected updated todo definition "Renew passport"; saw ${seen}`;
+        }
+        const definition = updated.definition as Record<string, unknown>;
+        const cadence =
+          definition.cadence && typeof definition.cadence === "object"
+            ? (definition.cadence as Record<string, unknown>)
+            : null;
+        if (cadence?.kind !== "once") {
+          return `expected "Renew passport" to remain a one-off todo; got cadence kind ${String(cadence?.kind ?? "(missing)")}`;
+        }
+        if (typeof cadence.dueAt !== "string") {
+          return `expected "Renew passport" to have a dueAt string; got ${String(cadence.dueAt ?? "(missing)")}`;
+        }
+        const dueAtMs = Date.parse(cadence.dueAt);
+        if (!Number.isFinite(dueAtMs)) {
+          return `expected "Renew passport" dueAt to be a valid ISO date; got ${cadence.dueAt}`;
+        }
+        const scenarioNowMs = ctx.now ? Date.parse(ctx.now) : Number.NaN;
+        if (!Number.isFinite(scenarioNowMs)) {
+          return `expected scenario clock to be available; got ${String(ctx.now ?? "(missing)")}`;
+        }
+        const seededDueAtMs = scenarioNowMs + 2 * 60 * 60_000;
+        if (dueAtMs <= seededDueAtMs) {
+          return `expected "Renew passport" dueAt to move after seeded due time ${new Date(seededDueAtMs).toISOString()}; got ${cadence.dueAt}`;
+        }
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.update.due` beyond echoable response words plus `actionCalled(LIFE)`
- adds a scenario-local custom final check that inspects captured `LIFE` result data
- requires the updated definition title to be `Renew passport` and its one-off `dueAt` to move after the seeded `now+2h` due time

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.update.due.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 18 files / 131 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git rebase origin/develop` - rebased cleanly onto `8864703344`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
