### PR TITLE
test(scenario-runner): assert todo deletion effect

### DIFF
--- a/packages/test/scenarios/todos/todo.delete.scenario.ts
+++ b/packages/test/scenarios/todos/todo.delete.scenario.ts
@@ -1,4 +1,6 @@
+import type { AgentRuntime } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { LifeOpsRepository } from "../../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts";
 
 export default scenario({
   lane: "live-only",
@@ -46,6 +48,28 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "garage-todo-deleted",
+      predicate: async (ctx) => {
+        const runtime = ctx.runtime as AgentRuntime | undefined;
+        if (!runtime) return "scenario runtime unavailable";
+        await LifeOpsRepository.bootstrapSchema(runtime);
+        const repository = new LifeOpsRepository(runtime);
+        const definitions = await repository.listDefinitions(
+          String(runtime.agentId),
+        );
+        const remaining = definitions.filter(
+          (definition) => definition.title === "Reorganize garage",
+        );
+        if (remaining.length > 0) {
+          const seen = remaining
+            .map((definition) => `${definition.id}:${definition.status}`)
+            .join(", ");
+          return `expected "Reorganize garage" definition to be deleted; still saw ${seen}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.delete` beyond confirmation/deleted response words plus `actionCalled(LIFE)`
- adds a scenario-local custom final check backed by `LifeOpsRepository`
- requires the seeded definition titled `Reorganize garage` to be absent after the confirmed delete flow

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.delete.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 18 files / 131 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
