### PR TITLE
test(scenario-runner): assert todo deprioritize effect

### DIFF
--- a/packages/test/scenarios/todos/todo.deprioritize.scenario.ts
+++ b/packages/test/scenarios/todos/todo.deprioritize.scenario.ts
@@ -1,5 +1,8 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
+const SEEDED_PRIORITY = 4;
+const LOW_PRIORITY_CEILING = 2;
+
 export default scenario({
   lane: "live-only",
   id: "todo.deprioritize",
@@ -21,7 +24,7 @@ export default scenario({
     {
       type: "todo",
       name: "Reorganize closet",
-      priority: 2,
+      priority: SEEDED_PRIORITY,
       dueIso: "{{now+3d}}",
     },
   ],
@@ -45,6 +48,47 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "closet-priority-lowered",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) =>
+            action.result?.data && typeof action.result.data === "object"
+              ? (action.result.data as Record<string, unknown>)
+              : null,
+          )
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const updated = lifeResults.find((data) => {
+          const definition =
+            data.definition && typeof data.definition === "object"
+              ? (data.definition as Record<string, unknown>)
+              : null;
+          return definition?.title === "Reorganize closet";
+        });
+        if (!updated) {
+          const seen =
+            lifeResults
+              .map((data) => {
+                const definition =
+                  data.definition && typeof data.definition === "object"
+                    ? (data.definition as Record<string, unknown>)
+                    : null;
+                return typeof definition?.title === "string"
+                  ? definition.title
+                  : "(untitled)";
+              })
+              .join(", ") || "(none)";
+          return `expected updated todo definition "Reorganize closet"; saw ${seen}`;
+        }
+        const definition = updated.definition as Record<string, unknown>;
+        const priority = definition.priority;
+        if (typeof priority !== "number" || priority > LOW_PRIORITY_CEILING) {
+          return `expected "Reorganize closet" priority to be lowered from ${SEEDED_PRIORITY} to ${LOW_PRIORITY_CEILING} or below; got ${String(priority ?? "(missing)")}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.deprioritize` beyond echoable response words plus `actionCalled(LIFE)`
- seeds `Reorganize closet` at priority `4` so the request has a measurable lowering effect
- adds a scenario-local custom final check that inspects captured `LIFE` result data and requires the updated priority to be `2` or lower

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.deprioritize.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 19 files / 135 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - rebased cleanly; commit `29d2638363`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
