### PR TITLE
test(scenario-runner): assert upcoming todo list effect

### DIFF
--- a/packages/test/scenarios/todos/todo.list.upcoming.scenario.ts
+++ b/packages/test/scenarios/todos/todo.list.upcoming.scenario.ts
@@ -1,5 +1,24 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
+const EXPECTED_UPCOMING_TITLES = ["Team review", "Finalize slides"] as const;
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function occurrenceTitlesFromLifeData(data: Record<string, unknown>): string[] {
+  const owner = toRecord(data.owner);
+  const occurrences =
+    (Array.isArray(owner?.occurrences) ? owner.occurrences : null) ??
+    (Array.isArray(data.occurrences) ? data.occurrences : []);
+
+  return occurrences
+    .map((occurrence) => toRecord(occurrence)?.title)
+    .filter((title): title is string => typeof title === "string");
+}
+
 export default scenario({
   lane: "live-only",
   id: "todo.list.upcoming",
@@ -21,12 +40,12 @@ export default scenario({
     {
       type: "todo",
       name: "Team review",
-      dueIso: "{{now+2d}}",
+      dueIso: "{{now+6h}}",
     },
     {
       type: "todo",
       name: "Finalize slides",
-      dueIso: "{{now+4d}}",
+      dueIso: "{{now+10h}}",
     },
   ],
   turns: [
@@ -49,6 +68,25 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "upcoming-overview-includes-seeded-todos",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) => toRecord(action.result?.data))
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const titles = lifeResults.flatMap(occurrenceTitlesFromLifeData);
+        const titleSet = new Set(titles);
+        const missing = EXPECTED_UPCOMING_TITLES.filter(
+          (title) => !titleSet.has(title),
+        );
+
+        if (missing.length > 0) {
+          return `expected LIFE overview result to include upcoming todos ${EXPECTED_UPCOMING_TITLES.join(", ")}; missing ${missing.join(", ")}; saw ${titles.join(", ") || "(none)"}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.list.upcoming` beyond `actionCalled(LIFE)` alone
- keeps the existing `LIFE` routing and response assertions
- moves the seeded upcoming todo due times inside the `LIFE` overview horizon so the scenario can assert the real action-result payload
- adds a scenario-local custom final check that requires both seeded todos, `Team review` and `Finalize slides`, to appear in returned overview occurrences

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.list.upcoming.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 20 files / 139 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `6b5345f74d`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
