### PR TITLE
fix(core): recognize Windows absolute plugin paths in loadPluginModule

### DIFF
--- a/packages/core/src/utils/plugin-loader.ts
+++ b/packages/core/src/utils/plugin-loader.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 const moduleCache = new Map<string, unknown>();
 
@@ -32,8 +32,10 @@ export async function loadPluginModule<T = unknown>(
 	const { repoRoot, npmScope = "@elizaos" } = options;
 	const errors: string[] = [];
 
-	// Direct path import
-	if (nameOrPath.startsWith(".") || nameOrPath.startsWith("/")) {
+	// Direct path import. Use path.isAbsolute (not startsWith("/")) so a Windows
+	// absolute path (a C: drive path or UNC path) is recognized — otherwise it
+	// falls through to npm/workspace resolution and fails to load on Windows.
+	if (nameOrPath.startsWith(".") || isAbsolute(nameOrPath)) {
 		const mod = await import(/* @vite-ignore */ resolve(nameOrPath));
 		moduleCache.set(cacheKey, mod);
 		return mod as T;


### PR DESCRIPTION
## What

`loadPluginModule` (`packages/core/src/utils/plugin-loader.ts`) detected a direct-path import with `nameOrPath.startsWith("/")`, which only matches POSIX absolute paths. A **Windows absolute path** (`C:\…\myplugin`, or a UNC `\server\share`) never starts with `/`, so it fell through to npm/workspace resolution and **failed to load on Windows**.

Fix: use `path.isAbsolute()` (handles Windows drive/UNC paths, POSIX `/`, and leaves the `startsWith(".")` relative check intact).

## Safety

POSIX behavior is unchanged — `isAbsolute` is identical to `startsWith("/")` for `/…` inputs; npm package names and `./relative` paths still resolve as before. Verified on a real Windows box: `isAbsolute("C:\plugins\x")=true`, `("/x")=true`, `("./x")=false`, `("@scope/p")=false`.

Found via a Windows production-source audit (no test exercises this — `core`'s Windows lane never loads a plugin by absolute path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)