### PR TITLE
test(scenario-runner): assert overdue todo list effect

### DIFF
--- a/packages/test/scenarios/todos/todo.list.overdue.scenario.ts
+++ b/packages/test/scenarios/todos/todo.list.overdue.scenario.ts
@@ -1,5 +1,24 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
+const EXPECTED_OVERDUE_TITLES = ["File expense report"] as const;
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function occurrenceTitlesFromLifeData(data: Record<string, unknown>): string[] {
+  const owner = toRecord(data.owner);
+  const occurrences =
+    (Array.isArray(owner?.occurrences) ? owner.occurrences : null) ??
+    (Array.isArray(data.occurrences) ? data.occurrences : []);
+
+  return occurrences
+    .map((occurrence) => toRecord(occurrence)?.title)
+    .filter((title): title is string => typeof title === "string");
+}
+
 export default scenario({
   lane: "live-only",
   id: "todo.list.overdue",
@@ -44,6 +63,25 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "overdue-overview-includes-seeded-todo",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) => toRecord(action.result?.data))
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const titles = lifeResults.flatMap(occurrenceTitlesFromLifeData);
+        const titleSet = new Set(titles);
+        const missing = EXPECTED_OVERDUE_TITLES.filter(
+          (title) => !titleSet.has(title),
+        );
+
+        if (missing.length > 0) {
+          return `expected LIFE overview result to include overdue todo ${EXPECTED_OVERDUE_TITLES.join(", ")}; missing ${missing.join(", ")}; saw ${titles.join(", ") || "(none)"}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.list.overdue` beyond `actionCalled(LIFE)` alone
- keeps the existing `LIFE` routing and response assertions
- adds a scenario-local custom final check that requires the seeded overdue todo, `File expense report`, to appear in returned `LIFE` overview occurrences

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.list.overdue.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 20 files / 139 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `f21a10579a`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
