### PR TITLE
test(scenario-runner): assert todo prioritize effect

### DIFF
--- a/packages/test/scenarios/todos/todo.prioritize.scenario.ts
+++ b/packages/test/scenarios/todos/todo.prioritize.scenario.ts
@@ -1,5 +1,38 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
+const TOP_TODO_TITLE = "Submit tax forms";
+const TOP_TODO_PRIORITY = 1;
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function ownerOccurrencesFromLifeData(
+  data: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const owner = toRecord(data.owner);
+  const occurrences =
+    (Array.isArray(owner?.occurrences) ? owner.occurrences : null) ??
+    (Array.isArray(data.occurrences) ? data.occurrences : []);
+
+  return occurrences
+    .map((occurrence) => toRecord(occurrence))
+    .filter((occurrence): occurrence is Record<string, unknown> =>
+      Boolean(occurrence),
+    );
+}
+
+function summarizeOccurrence(occurrence: Record<string, unknown>): string {
+  const title =
+    typeof occurrence.title === "string" ? occurrence.title : "(untitled)";
+  const priority =
+    typeof occurrence.priority === "number" ? occurrence.priority : "unknown";
+
+  return `${title}:${priority}`;
+}
+
 export default scenario({
   lane: "live-only",
   id: "todo.prioritize",
@@ -53,6 +86,33 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "urgent-todo-ranked-first-in-overview",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) => toRecord(action.result?.data))
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const snapshots = lifeResults.map(ownerOccurrencesFromLifeData);
+        const hasExpectedTop = snapshots.some((occurrences) => {
+          const top = occurrences.at(0);
+          return (
+            top?.title === TOP_TODO_TITLE && top.priority === TOP_TODO_PRIORITY
+          );
+        });
+
+        if (!hasExpectedTop) {
+          const observed = snapshots
+            .map((occurrences) =>
+              occurrences.map(summarizeOccurrence).join(", "),
+            )
+            .filter((summary) => summary.length > 0)
+            .join("; ");
+          return `expected LIFE overview to rank ${TOP_TODO_TITLE}:${TOP_TODO_PRIORITY} first; saw ${observed || "(none)"}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.prioritize` beyond `actionCalled(LIFE)` alone
- keeps the existing `LIFE` routing and response assertions
- adds a scenario-local custom final check that requires the seeded urgent todo, `Submit tax forms`, to be the top owner overview occurrence with priority `1`

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.prioritize.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 20 files / 139 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `263cbfbbfb`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
