### PR TITLE
test(scenario-runner): assert cross-device todo create proof

### DIFF
--- a/packages/test/scenarios/todos/todo.cross-device.create-and-query.scenario.ts
+++ b/packages/test/scenarios/todos/todo.cross-device.create-and-query.scenario.ts
@@ -55,5 +55,16 @@ export default scenario({
       status: "success",
       minCount: 3,
     },
+    {
+      type: "definitionCountDelta",
+      title: "Pick up dry cleaning",
+      titleAliases: [
+        "pick up dry cleaning",
+        "Pick up dry cleaning tomorrow",
+        "Dry cleaning",
+      ],
+      delta: 1,
+      cadenceKind: "once",
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.cross-device.create-and-query` beyond `actionCalled(LIFE)` alone
- keeps the existing dashboard create/confirm flow and mobile query assertion
- adds a `definitionCountDelta` final check requiring one saved one-off definition for `Pick up dry cleaning`

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.cross-device.create-and-query.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 21 files / 143 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `c3edfb4118`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
