### PR TITLE
test(scenario-runner): assert todo prioritize result

### DIFF
--- a/packages/test/scenarios/todos/todo.prioritize.scenario.ts
+++ b/packages/test/scenarios/todos/todo.prioritize.scenario.ts
@@ -1,5 +1,24 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
+const EXPECTED_TOP_TODO_TITLE = "Submit tax forms";
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function occurrenceTitlesFromLifeData(data: Record<string, unknown>): string[] {
+  const owner = toRecord(data.owner);
+  const occurrences =
+    (Array.isArray(owner?.occurrences) ? owner.occurrences : null) ??
+    (Array.isArray(data.occurrences) ? data.occurrences : []);
+
+  return occurrences
+    .map((occurrence) => toRecord(occurrence)?.title)
+    .filter((title): title is string => typeof title === "string");
+}
+
 export default scenario({
   lane: "live-only",
   id: "todo.prioritize",
@@ -53,6 +72,22 @@ export default scenario({
       actionName: "LIFE",
       status: "success",
       minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "urgent-todo-is-top-priority-result",
+      predicate: async (ctx) => {
+        const lifeResults = ctx.actionsCalled
+          .filter((action) => action.actionName === "LIFE")
+          .map((action) => toRecord(action.result?.data))
+          .filter((data): data is Record<string, unknown> => data !== null);
+        const titles = lifeResults.flatMap(occurrenceTitlesFromLifeData);
+        const topTitle = titles[0];
+
+        if (topTitle !== EXPECTED_TOP_TODO_TITLE) {
+          return `expected LIFE overview result to rank "${EXPECTED_TOP_TODO_TITLE}" first; saw ${titles.join(", ") || "(none)"}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- Adds a scenario-local custom final check to `todo.prioritize`.
- The check inspects captured `LIFE` action result data and requires `Submit tax forms` to be the first owner overview occurrence.
- Keeps the existing `LIFE` routing and response assertions unchanged.

## Evidence
- `bun install` passed.
- `bun run --cwd packages/core prebuild` passed.
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.prioritize.scenario.ts` passed.
- `bun --conditions eliza-source src/cli.ts list ../test/scenarios --scenario todo.prioritize` passed from `packages/scenario-runner`.
- `bun run --cwd packages/scenario-runner test src/echo-assertion-ratchet.test.ts` passed: 1 file / 1 test.
- `bun run --cwd packages/scenario-runner test src/scenario-expansion.test.ts` passed: 1 file / 7 tests.
- `bun run --cwd packages/scenario-runner test` passed: 21 files / 143 tests.
- `bun run --cwd packages/scenario-runner typecheck` passed.
- `bun run --cwd packages/scenario-runner build` passed.
- `git diff --check origin/develop..HEAD` passed.
- `bun run verify` passed: 509/509 tasks.

Closes no issue; contributes to #9310.
