### PR TITLE
test(scenario-runner): assert global alarm proof

### DIFF
--- a/packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts
+++ b/packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts
@@ -38,5 +38,13 @@ export default scenario({
       status: "success",
       minCount: 2,
     },
+    {
+      type: "definitionCountDelta",
+      title: "Wake up alarm",
+      titleAliases: ["Wake-up alarm", "Morning alarm", "Wake up"],
+      delta: 1,
+      cadenceKind: "once",
+      requireReminderPlan: true,
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `todo.cross-device.global-alarm` beyond `actionCalled(LIFE)` alone
- keeps the existing alarm save flow and `LIFE` success assertion
- adds a `definitionCountDelta` final check requiring one saved one-off wake-up alarm definition with a reminder plan

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 21 files / 143 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git diff --check` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `347704f07a`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
