### PR TITLE
fix(elizaos): plugins submit npm validation fails on Windows

### DIFF
--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -94,7 +94,7 @@ export async function submitPluginToRegistry(
   }
 
   if (!options.skipValidation) {
-    validatePublishedPackage(metadata.package);
+    await validatePublishedPackage(metadata.package);
     validateGithubRepository(metadata.repository);
   }
 
@@ -316,8 +316,33 @@ function sanitizeBranchPart(packageName: string): string {
     .slice(0, 80);
 }
 
-function validatePublishedPackage(packageName: string): void {
-  ensureCommand("npm", ["view", packageName, "version"]);
+async function validatePublishedPackage(packageName: string): Promise<void> {
+  // npm is `npm.cmd` on Windows, and Node cannot spawn a .cmd without
+  // `shell: true` (ENOENT/EINVAL), so `npm view` fails there. On Windows,
+  // verify publication via the public registry directly; keep `npm view`
+  // unchanged elsewhere.
+  if (process.platform !== "win32") {
+    ensureCommand("npm", ["view", packageName, "version"]);
+    return;
+  }
+  const encoded = packageName.replace(/\//g, "%2f");
+  const res = await fetch(`https://registry.npmjs.org/${encoded}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  }).catch((err: unknown) => {
+    throw new Error(
+      `Failed to reach the npm registry to validate ${packageName}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  });
+  if (res.status === 404) {
+    throw new Error(`Package ${packageName} is not published to npm.`);
+  }
+  if (!res.ok) {
+    throw new Error(
+      `npm registry returned status ${res.status} validating ${packageName}.`,
+    );
+  }
 }
 
 function validateGithubRepository(repository: string): void {


### PR DESCRIPTION
## What

`elizaos plugins submit` calls `validatePublishedPackage` → `ensureCommand("npm", ["view", <pkg>, "version"])`. On **Windows** `npm` is `npm.cmd`, and Node's `spawnSync` cannot exec a `.cmd` without `shell: true`:
- `spawnSync("npm", …)` → **ENOENT** (no `npm.exe`)
- `spawnSync("npm.cmd", …)` → **EINVAL** (Node's CVE-2024-27980 block on `.cmd` without a shell)

So `elizaos plugins submit` **throws at the publish-validation step on Windows**. (`git`/`gh` are `.exe` and work fine; `npm` is the only `.cmd`.)

## Fix

On Windows, verify the package is published via a direct **public-registry GET** (`https://registry.npmjs.org/<pkg>`) — cross-platform, no spawn, no `shell: true` (avoids the DEP0190 arg-injection deprecation). **POSIX behavior is byte-identical** — `npm view` is kept unchanged there, so the existing path stays CI-tested on Linux/macOS. `validatePublishedPackage` becomes `async`; its caller (`submitPluginToRegistry`) is already async.

## Evidence (real Windows, under Node — the CLI runtime)

```
node spawnSync(npm)      → ERROR ENOENT
node spawnSync(npm.cmd)  → ERROR EINVAL
```
Registry check (this box): `left-pad` → 200, `@types/node` (scoped) → 200, unpublished → 404 — matching the npm-publication semantics `npm view` provided.

The existing `plugins.test.ts` uses `skipValidation: true`, so this path is unaffected by the change. Found via a Windows production-source audit of the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)