### PR TITLE
test(scenario-runner): assert todo block chain effects

### DIFF
--- a/packages/test/scenarios/cross-cutting/cross.multi-action-chain.create-todo-then-block-sites.scenario.ts
+++ b/packages/test/scenarios/cross-cutting/cross.multi-action-chain.create-todo-then-block-sites.scenario.ts
@@ -10,6 +10,26 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 const TASK_CREATE_ACTIONS = ["CREATE_TASK", "LIFE"];
+const TODO_TITLE = "do 50 push-ups";
+const BLOCKED_WEBSITES = ["x.com", "instagram.com", "reddit.com"];
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function actionResultWebsites(action: {
+  result?: { data?: unknown };
+}): string[] {
+  const data = toRecord(action.result?.data);
+  const websites = data?.websites;
+  return Array.isArray(websites)
+    ? websites
+        .filter((website): website is string => typeof website === "string")
+        .map((website) => website.toLowerCase())
+    : [];
+}
 
 export default scenario({
   lane: "live-only",
@@ -36,7 +56,7 @@ export default scenario({
       kind: "message",
       name: "create-todo",
       room: "main",
-      text: "Create a todo: 'do 50 push-ups'",
+      text: `Create a todo: '${TODO_TITLE}'`,
       assertTurn: (turn) => {
         const hit = turn.actionsCalled.find((a) =>
           TASK_CREATE_ACTIONS.includes(a.actionName),
@@ -66,6 +86,13 @@ export default scenario({
             turn.actionsCalled.map((a) => a.actionName).join(", ") || "(none)";
           return `Expected WEBSITE_BLOCK action but got: ${fired}`;
         }
+        const websites = actionResultWebsites(blocked);
+        const missing = BLOCKED_WEBSITES.filter(
+          (website) => !websites.includes(website),
+        );
+        if (missing.length > 0) {
+          return `Expected WEBSITE_BLOCK result data to include [${BLOCKED_WEBSITES.join(", ")}]; missing [${missing.join(", ")}]. Saw: ${JSON.stringify(blocked.result?.data ?? null)}`;
+        }
       },
     },
   ],
@@ -75,6 +102,12 @@ export default scenario({
       type: "actionCalled",
       actionName: "WEBSITE_BLOCK",
       minCount: 1,
+    },
+    {
+      type: "definitionCountDelta",
+      title: TODO_TITLE,
+      titleAliases: ["50 push-ups", "do 50 push ups", "Push-ups"],
+      delta: 1,
     },
   ],
 });


### PR DESCRIPTION
## Summary
- strengthens `cross.multi-action-chain.create-todo-then-block-sites` beyond action names alone
- adds a turn-level assertion that the `WEBSITE_BLOCK` result data includes the requested hosts: `x.com`, `instagram.com`, and `reddit.com`
- adds a `definitionCountDelta` final check requiring the `do 50 push-ups` todo definition to be persisted

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/cross-cutting/cross.multi-action-chain.create-todo-then-block-sites.scenario.ts` - passed
- `git diff --check` - passed
- `bun --conditions eliza-source src/cli.ts list ../test/scenarios --scenario cross.multi-action-chain.create-todo-then-block-sites` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 22 files / 146 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git fetch origin && git rebase origin/develop` - branch up to date; commit `97543e2e33`
- `bun install` - no dependency changes
- `bun run verify` - 509 successful, 509 total

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
