### PR TITLE
test(scenario-runner): assert global alarm persistence

### DIFF
--- a/packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts
+++ b/packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts
@@ -38,5 +38,13 @@ export default scenario({
       status: "success",
       minCount: 2,
     },
+    {
+      type: "definitionCountDelta",
+      title: "Wake up",
+      titleAliases: ["Wake up alarm", "Morning alarm", "7am alarm"],
+      delta: 1,
+      cadenceKind: "once",
+      requireReminderPlan: true,
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- Strengthens `todo.cross-device.global-alarm` beyond the previous `actionCalled(LIFE)` smoke check.
- Keeps the existing two-turn preview/confirm flow and LIFE success assertion.
- Adds a `definitionCountDelta` final check requiring one saved one-off wake-up/alarm definition with a reminder plan.

## Evidence
- `bun install`
- `bun run --cwd packages/core prebuild`
- `bunx @biomejs/biome check packages/test/scenarios/todos/todo.cross-device.global-alarm.scenario.ts`
- `bun --conditions eliza-source src/cli.ts list ../test/scenarios --scenario todo.cross-device.global-alarm` from `packages/scenario-runner`
- `bun run --cwd packages/scenario-runner test` (22 files / 146 tests)
- `bun run --cwd packages/scenario-runner typecheck`
- `bun run --cwd packages/scenario-runner build`
- `git diff --check origin/develop..HEAD`
- `bun run verify` (509 successful / 509 total)

## PR Evidence
- Real-LLM trajectories: N/A, scenario assertion strengthening only.
- Backend logs: N/A, no backend runtime code changed.
- UI screenshots/video: N/A, no UI changed.

Part of #9310.