### PR TITLE
fix(app-core): eliza dashboard npx spawn fails on Windows

### DIFF
--- a/packages/app-core/src/cli/program/register.dashboard.ts
+++ b/packages/app-core/src/cli/program/register.dashboard.ts
@@ -117,11 +117,15 @@ export function registerDashboardCommand(program: Command) {
         return;
       }
 
-      const { spawn } = await import("node:child_process");
+      const { spawn, spawnSync } = await import("node:child_process");
       const child = spawn("npx", ["vite"], {
         cwd: appDir,
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env },
+        // npx is `npx.cmd` on Windows; Node cannot spawn a .cmd without a
+        // shell (ENOENT), so the dev dashboard never started there. The args
+        // are constant, so enabling the shell on Windows is injection-safe.
+        shell: process.platform === "win32",
       });
 
       let opened = false;
@@ -156,6 +160,12 @@ export function registerDashboardCommand(program: Command) {
       setTimeout(tryOpen, 10_000);
 
       const cleanup = () => {
+        if (process.platform === "win32" && child.pid) {
+          // shell:true ran npx inside cmd.exe; a SIGTERM to the shell would
+          // orphan the vite grandchild, so kill the whole tree by PID.
+          spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"]);
+          return;
+        }
         child.kill("SIGTERM");
       };
       process.on("SIGINT", cleanup);


### PR DESCRIPTION
## What

`eliza dashboard` (dev dashboard, requires a dev checkout) runs `spawn("npx", ["vite"])`. On **Windows** `npx` is `npx.cmd`, and Node cannot `spawn` a `.cmd` without a shell → **ENOENT**, so the dev server never started (the child `error` handler just logged *"Failed to start app dev server"*).

## Fix

- `shell: process.platform === "win32"` on the spawn — args are constant (`["vite"]`), so it's injection-safe (no DEP0190 concern with attacker-controlled args).
- On cleanup, Windows uses `taskkill /pid <pid> /t /f` to kill the whole tree — `shell:true` wraps npx in `cmd.exe`, and a plain `SIGTERM` to the shell would orphan the `vite` grandchild on Ctrl+C.

POSIX behavior is unchanged (both additions are win32-gated). Verified on Windows: `node spawn("npx")` → ENOENT; with `shell:true` → runs. Found via the same repo-wide audit that fixed the CLI's `npm` spawn ([#9409](https://github.com/elizaOS/eliza/pull/9409)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)