### PR TITLE
fix(tailscale): CLI detection fails on Windows (which -> where)

### DIFF
--- a/plugins/plugin-tailscale/src/services/LocalTailscaleService.ts
+++ b/plugins/plugin-tailscale/src/services/LocalTailscaleService.ts
@@ -47,7 +47,10 @@ function runCommand(cmd: string, args: string[]): Promise<SpawnResult> {
 
 function checkTailscaleInstalled(): Promise<boolean> {
   return new Promise((resolve) => {
-    const proc = spawn("which", ["tailscale"]);
+    // `which` does not exist on Windows; use `where`. Otherwise the probe
+    // spawn errors (ENOENT) and tailscale is always reported as not installed.
+    const probe = process.platform === "win32" ? "where" : "which";
+    const proc = spawn(probe, ["tailscale"]);
     proc.on("exit", (code) => resolve(code === 0));
     proc.on("error", () => resolve(false));
   });


### PR DESCRIPTION
checkTailscaleInstalled() spawned `which tailscale`. `which` doesn't exist on Windows → the probe errors (ENOENT) → tailscale is always reported as not installed on Windows even when it is. Use `where` on win32 (matches the pattern in #9374). 🤖 Generated with [Claude Code](https://claude.com/claude-code)