### PR TITLE
fix(plugin-lmstudio): throw on embedding failure instead of fabricating a zero vector (#9324)

### DIFF
--- a/plugins/plugin-lmstudio/__tests__/embedding.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/embedding.test.ts
@@ -74,15 +74,14 @@ describe("LM Studio embeddings", () => {
     expect(callArg.value).toHaveLength(32_000);
   });
 
-  it("returns a zero vector when the provider rejects", async () => {
+  it("throws when the embedding provider fails (no fabricated zero vector)", async () => {
     embedMock.mockRejectedValue(new Error("LM Studio embeddings unavailable"));
 
-    const embedding = await handleTextEmbedding(
-      createRuntime({ LMSTUDIO_EMBEDDING_MODEL: "nomic-embed" }),
-      { text: "hello" }
-    );
-
-    expect(embedding).toHaveLength(1536);
-    expect(embedding.every((value) => value === 0)).toBe(true);
+    await expect(
+      handleTextEmbedding(
+        createRuntime({ LMSTUDIO_EMBEDDING_MODEL: "nomic-embed" }),
+        { text: "hello" }
+      )
+    ).rejects.toThrow("LM Studio embeddings unavailable");
   });
 });

--- a/plugins/plugin-lmstudio/models/embedding.ts
+++ b/plugins/plugin-lmstudio/models/embedding.ts
@@ -2,14 +2,15 @@
  * Embeddings via LM Studio's OpenAI-compatible `/v1/embeddings` endpoint.
  *
  * LM Studio only exposes embeddings when the user explicitly loads an embedding-capable
- * model (e.g. `nomic-embed-text-v1.5-Q4_K_M`). If `LMSTUDIO_EMBEDDING_MODEL` is not set
- * and the server has no embedding model loaded, this handler returns a zero vector with
- * a logged warning — the runtime stays alive but the agent's recall quality degrades
- * until the operator configures one.
+ * model (e.g. `nomic-embed-text-v1.5-Q4_K_M`). When `LMSTUDIO_EMBEDDING_MODEL` is unset
+ * (no embedding model configured at all), this handler returns a zero vector with a
+ * logged warning so a text-only deployment stays alive — embeddings are simply absent,
+ * not failing.
  *
- * Why a zero vector instead of throwing: parity with `plugin-ollama`. The embedding
- * path is hit during message persistence; throwing would crash every inbound message
- * when the local server is configured for text-only.
+ * A real embed failure is different: when the provider is configured but the request
+ * errors, this throws (matching `plugin-openai`/`plugin-ollama`/`plugin-elizacloud`).
+ * Fabricating a zero vector on error silently poisons the vector store and degrades RAG
+ * with no signal — see #9324. Recall callers fail open to keyword search on the throw.
  */
 
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
@@ -77,6 +78,6 @@ export async function handleTextEmbedding(
     return embedding;
   } catch (error) {
     logger.error({ error }, "[LMStudio] Error generating embedding");
-    return new Array<number>(DEFAULT_ZERO_VECTOR_DIM).fill(0);
+    throw error;
   }
 }


### PR DESCRIPTION
## Problem

[#9324](https://github.com/elizaOS/eliza/issues/9324) ("Model-provider embedding handlers return fake zero/marker vectors on error instead of throwing") fixed **plugin-ollama**, **plugin-google-genai**, and **plugin-openrouter** (via #9350, merged). It scoped itself to those three outliers and named `plugin-openai` / `plugin-elizacloud` / `plugin-local-inference` as already-correct — but it **missed `plugin-lmstudio`**, which had the identical bug.

`plugins/plugin-lmstudio/models/embedding.ts` returned `new Array(1536).fill(0)` from its `catch (error)` block on a real provider failure. Its docstring even justified this as *"parity with plugin-ollama"* — a rationale that is now invalid, since ollama throws after #9324.

A fabricated zero vector on a real embed error silently poisons the vector store and degrades RAG with no signal. The canonical handlers (`plugin-openai`, `plugin-elizacloud`, and now ollama/google-genai/openrouter) all throw; recall callers fail open to keyword/BM25 search on the throw (`core` `recall-embed.ts` / `embedRecallQuery`).

## Change

- **`models/embedding.ts`** — the `catch (error)` path now `throw error` instead of fabricating a zero vector, matching the canonical providers. Docstring updated.
- **`__tests__/embedding.test.ts`** — the existing test `"returns a zero vector when the provider rejects"` asserted the *buggy* behavior (a larp test that locked the bug in). Flipped to `"throws when the embedding provider fails (no fabricated zero vector)"`, mirroring `plugin-ollama`'s `embedding.shape.test.ts`.

## Deliberately unchanged (scope discipline)

The **unset-`LMSTUDIO_EMBEDDING_MODEL`** path (no embedding model configured at all) keeps its documented zero-vector degradation. That is an *absent capability* for a text-only LM Studio deployment, not a runtime failure — different from the error path #9324 targets. Whether unconfigured embeddings should hard-fail vs. soft-degrade is a separate product decision; flagging it here rather than changing it.

## Verification

`plugins/plugin-lmstudio` vitest — **4/4 pass** including the flipped throw test:

```
✓ returns a zero vector and skips the provider when no embedding model is configured
✓ substitutes empty embedding input with a non-empty probe string
✓ truncates hostile oversized input before embedding
✓ throws when the embedding provider fails (no fabricated zero vector)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)