### PR TITLE
fix(agent-skills): dependency install fails on Windows (sh -> cmd /c)

### DIFF
--- a/plugins/plugin-agent-skills/src/services/install.ts
+++ b/plugins/plugin-agent-skills/src/services/install.ts
@@ -218,7 +218,13 @@ async function executeInstall(
 		});
 
 		return await new Promise((resolve) => {
-			const child = spawn("sh", ["-c", command], {
+			// `sh` does not exist natively on Windows; use cmd /c so the install
+			// command resolves (npm/bun/cargo are .cmd/.exe found by cmd). The
+			// command string is unchanged. (brew/apt are POSIX-only and still fail
+			// on Windows, as those package managers do not exist there anyway.)
+			const shellBin = process.platform === "win32" ? "cmd" : "sh";
+			const shellFlag = process.platform === "win32" ? "/c" : "-c";
+			const child = spawn(shellBin, [shellFlag, command], {
 				stdio: ["pipe", "pipe", "pipe"],
 				timeout,
 			});


### PR DESCRIPTION
installSkillDependency ran the built install command via `spawn("sh", ["-c", command])`. `sh` doesn't exist natively on Windows → skill dependency install fails (ENOENT). Use `cmd /c` on Windows; the command string is unchanged so node (npm/bun) and cargo installs resolve (npm is npm.cmd, found by cmd). brew/apt are POSIX-only and absent on Windows regardless. POSIX behavior unchanged. Part of the repo-wide Windows spawn audit. 🤖 Generated with [Claude Code](https://claude.com/claude-code)