### PR TITLE
fix(plugin-ollama,plugin-lmstudio): throw on text-gen failure instead of fabricating an "Error generating text…" reply

### DIFF
--- a/plugins/plugin-lmstudio/__tests__/text.shape.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/text.shape.test.ts
@@ -158,7 +158,7 @@ describe("LM Studio text plumbing shape", () => {
     expect(args.model.modelId).toBe("auto-detected-model");
   });
 
-  it("returns a provider error string when model discovery has no usable models", async () => {
+  it("throws when model discovery has no usable models", async () => {
     detectLMStudioMock.mockResolvedValueOnce({
       available: false,
       baseURL: "http://localhost:1234/v1",
@@ -167,9 +167,7 @@ describe("LM Studio text plumbing shape", () => {
     const runtime = createRuntime();
     (runtime.getSetting as ReturnType<typeof vi.fn>).mockImplementation(() => null);
 
-    const result = await handleTextSmall(runtime, { prompt: "p" } as never);
-
-    expect(result).toMatch(/Error generating text/i);
+    await expect(handleTextSmall(runtime, { prompt: "p" } as never)).rejects.toThrow();
     expect(generateTextMock).not.toHaveBeenCalled();
   });
 
@@ -306,7 +304,7 @@ describe("LM Studio text plumbing shape", () => {
     expect(JSON.parse(out as string)).toEqual({ foo: "bar" });
   });
 
-  it("returns an error string when generateText throws (resilience)", async () => {
+  it("throws when generateText fails (no fabricated reply)", async () => {
     generateTextMock.mockRejectedValue(
       Object.assign(new Error("loaded model is unavailable"), {
         statusCode: 500,
@@ -315,8 +313,8 @@ describe("LM Studio text plumbing shape", () => {
       })
     );
 
-    const result = await handleResponseHandler(createRuntime(), { prompt: "p" } as never);
-    expect(typeof result).toBe("string");
-    expect(result).toMatch(/Error generating text/i);
+    await expect(
+      handleResponseHandler(createRuntime(), { prompt: "p" } as never)
+    ).rejects.toThrow("loaded model is unavailable");
   });
 });

--- a/plugins/plugin-lmstudio/models/text.ts
+++ b/plugins/plugin-lmstudio/models/text.ts
@@ -647,7 +647,11 @@ async function handleTextWithModelType(
     return result.text;
   } catch (error) {
     logTextFailure("generateText", modelType, modelIdForLog || "(unknown)", baseURL, error);
-    return "Error generating text. Please try again later.";
+    // Throw, never fabricate a reply. A hardcoded "Error generating text…" string
+    // would be persisted to memory and sent to the user as the agent's response —
+    // in the wrong language/voice — and would bypass core's grounded failure-reply
+    // path (buildFailureReplyPrompt). The canonical providers all throw here.
+    throw error;
   }
 }
 

--- a/plugins/plugin-ollama/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/native-plumbing.shape.test.ts
@@ -134,13 +134,13 @@ describe("Ollama native text plumbing", () => {
     });
   });
 
-  it("rejects malformed array tool definitions before calling the provider", async () => {
-    const result = await handleTextSmall(createRuntime(), {
-      prompt: "use a broken tool",
-      tools: [{ description: "missing name", parameters: { type: "object" } }],
-    } as never);
-
-    expect(result).toBe("Error generating text. Please try again later.");
+  it("throws on malformed array tool definitions before calling the provider", async () => {
+    await expect(
+      handleTextSmall(createRuntime(), {
+        prompt: "use a broken tool",
+        tools: [{ description: "missing name", parameters: { type: "object" } }],
+      } as never)
+    ).rejects.toThrow();
     expect(generateTextMock).not.toHaveBeenCalled();
     expect(streamTextMock).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-ollama/models/text.ts
+++ b/plugins/plugin-ollama/models/text.ts
@@ -674,7 +674,13 @@ async function handleTextWithModelType(
       endpoint,
       error
     );
-    return "Error generating text. Please try again later.";
+    // Throw, never fabricate a reply. A hardcoded "Error generating text…" string
+    // would be persisted to memory and sent to the user as the agent's response —
+    // in the wrong language/voice — and would bypass core's grounded failure-reply
+    // path (buildFailureReplyPrompt). The canonical providers (openai, anthropic,
+    // google-genai, elizacloud, openrouter) all throw here; the message pipeline
+    // handles it.
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Problem

Same fabricate-on-error class as [#9324](https://github.com/elizaOS/eliza/issues/9324) (which fixed it for embeddings), but for **text generation**.

`plugin-ollama` (`models/text.ts:677`) and `plugin-lmstudio` (`models/text.ts:650`) caught **any** generation failure and returned the hardcoded string `"Error generating text. Please try again later."` as the model's result. That string is then:

- persisted to memory and **sent to the user as the agent's reply** — in English, not the character's voice/language,
- **indistinguishable downstream from a real response**, and
- worst: it **bypasses core's grounded failure-reply path**. Core catches a *thrown* text-gen error and routes to `buildFailureReplyPrompt` (`packages/core/src/services/message.ts`), which is deliberately constrained to never hallucinate an answer (pinned by `failure-reply-prompt.test.ts`, a live Cerebras regression). The fake "success" string short-circuits that safety mechanism.

The **5 canonical providers** — openai, anthropic, google-genai, elizacloud, openrouter — all `throw` here, so the message pipeline already handles a thrown text-gen error. ollama + lmstudio were the only two outliers (the same pair that were embedding-fabrication outliers in #9324).

## Change

- both handlers' top-level `catch` now `throw error`
- flips the **three tests that pinned the fabricated string** (a larp pattern that locked the bug in — cf. #9310) to assert the throw:
  - `plugin-ollama` `native-plumbing.shape.test.ts` — malformed tool def
  - `plugin-lmstudio` `text.shape.test.ts` — failed model discovery; `generateText` rejects

## Verification

- `plugin-lmstudio` — **49/49 pass**
- `plugin-ollama` — **26 pass + 5 skipped** (skipped = live-server integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)