### PR TITLE
test(scenario-runner): assert wind-down clarification

### DIFF
--- a/packages/test/scenarios/selfcontrol/selfcontrol.nighttime-wind-down.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.nighttime-wind-down.scenario.ts
@@ -26,12 +26,26 @@ export default scenario({
       name: "schedule-nightly-block",
       room: "main",
       text: "Block apps after 10pm every night until I go to sleep.",
+      forbiddenActions: ["APP_BLOCK", "WEBSITE_BLOCK", "BLOCK"],
+      assertResponse: (text) => {
+        if (!/\?/.test(text)) {
+          return "expected the response to ask a clarification question";
+        }
+        if (!/\b(app|apps|application|applications)\b/i.test(text)) {
+          return "expected the response to clarify which apps to block";
+        }
+        if (
+          !/\b(which|what|specific|include|choose|pick|select)\b/i.test(text)
+        ) {
+          return "expected the response to ask for the specific apps to include";
+        }
+      },
     },
   ],
   finalChecks: [
     {
       type: "actionCalled",
-      actionName: "APP_BLOCK",
+      actionName: "REPLY",
       minCount: 1,
     },
   ],


### PR DESCRIPTION
## Summary
- aligns `selfcontrol.nighttime-wind-down` with its title/description: ambiguous nightly app-block requests must ask which apps to include
- forbids `APP_BLOCK`, `WEBSITE_BLOCK`, and `BLOCK` on the ambiguous request
- replaces the block-action final check with a `REPLY` final check and adds a turn-level clarification assertion

Part of #9310.

## Evidence
- `bunx @biomejs/biome check packages/test/scenarios/selfcontrol/selfcontrol.nighttime-wind-down.scenario.ts` - passed
- `git diff --check` - passed
- `bun --conditions eliza-source src/cli.ts list ../test/scenarios --scenario selfcontrol.nighttime-wind-down` - passed
- `bun run --cwd packages/scenario-runner typecheck` - passed
- `bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` - 1 file / 4 tests passed
- `bun run --cwd packages/scenario-runner test` - 22 files / 148 tests passed
- `bun run --cwd packages/scenario-runner build` - passed
- `git fetch origin && git rebase origin/develop` - PR patch already present after merge; current synced head `04ef547ec2`
- `bun install` - passed on current `origin/develop`; existing peer warning for `@langchain/core@1.1.36`
- `bun run verify` - 509 successful, 509 total on current `origin/develop`

## PR Evidence Matrix
- Real-LLM trajectories: N/A, scenario assertion strengthening only; no prompt/model behavior changed
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI changed
