### PR TITLE
fix(on-device): adversarial-review fixes for the #9309 determinism gates

### DIFF
--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -1093,20 +1093,28 @@ function writeFusedLibSidecar() {
 }
 
 /**
- * True only when a staged lib exists AND its provenance sidecar confirms it was
- * built for the variant + platform this build targets. A staged lib with no
- * sidecar (pre-provenance) or a mismatched one is NOT reusable — we cannot
- * confirm it is the right backend, so we must rebuild rather than risk shipping
- * a wrong-variant native lib that crashes on the device.
+ * A staged lib whose provenance sidecar names a DIFFERENT variant/platform than
+ * this build targets — a confirmed wrong-variant lib we must not ship.
  */
-function fusedLibStagedForCurrentVariant() {
+function fusedLibStagedVariantMismatch() {
   if (!fusedLibAlreadyStaged()) return false;
   const sidecar = readFusedLibSidecar();
-  if (!sidecar) return false;
+  if (!sidecar) return false; // no provenance ≠ wrong provenance
   return (
-    sidecar.variant === FUSED_LIB_VARIANT &&
-    sidecar.platform === process.platform
+    sidecar.variant !== FUSED_LIB_VARIANT ||
+    sidecar.platform !== process.platform
   );
+}
+
+/**
+ * Whether a staged lib can be reused. A lib with a matching sidecar is reused; a
+ * sidecar-less lib (e.g. a prebuilt artifact a CI step dropped into
+ * dist/local-inference/lib) is TRUSTED and reused — we can't confirm its variant
+ * but it was deliberately staged. Only a sidecar that names a different
+ * variant/platform forces a rebuild.
+ */
+function fusedLibStagedForCurrentVariant() {
+  return fusedLibAlreadyStaged() && !fusedLibStagedVariantMismatch();
 }
 
 const FUSED_LIB_FORK_DIR = path.join(
@@ -1182,21 +1190,22 @@ function stageDesktopFusedLib() {
     return;
   }
 
-  // A staged lib whose provenance does not match this build (different variant
-  // or platform, or no sidecar) must never be silently reused.
-  const mismatchedStaged = fusedLibAlreadyStaged();
-  if (mismatchedStaged) {
+  // A staged lib whose sidecar names a DIFFERENT variant/platform is a confirmed
+  // wrong-variant lib — never silently reused. (A sidecar-less drop-in is trusted
+  // and was already reused above.)
+  const variantMismatch = fusedLibStagedVariantMismatch();
+  if (variantMismatch) {
     const sidecar = readFusedLibSidecar();
     console.warn(
       `[desktop-build] Staged fused lib does not match this build ` +
         `(want variant=${FUSED_LIB_VARIANT}/${process.platform}, found ` +
-        `${sidecar ? `${sidecar.variant}/${sidecar.platform}` : "no provenance sidecar"}). ` +
+        `${sidecar.variant}/${sidecar.platform}). ` +
         `It will be rebuilt to avoid shipping a wrong-variant native lib.`,
     );
   }
 
   if (!shouldBuild) {
-    if (mismatchedStaged) {
+    if (variantMismatch) {
       // Can't rebuild here (no toolchain requested) and the staged lib is the
       // wrong variant — drop it so the app cleanly falls back to cloud inference
       // instead of dlopen()-ing a mismatched backend on the device.

--- a/packages/app-core/scripts/run-mobile-build-mtp-staleness.test.mts
+++ b/packages/app-core/scripts/run-mobile-build-mtp-staleness.test.mts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { mtpSliceReuse } from "./run-mobile-build.mjs";
+import {
+  mtpForceRebuildRequested,
+  mtpSliceReuse,
+} from "./run-mobile-build.mjs";
 
 // Far-future mtimes keep these tests independent of the checkout's own file
 // timestamps (the worktree stamps every file at checkout time, including the
@@ -88,5 +91,26 @@ describe("mtpSliceReuse", () => {
     // and the fresh mtime keeps the slice reusable rather than rebuilding blindly.
     const result = mtpSliceReuse(caps, fork, null);
     expect(result.reusable).toBe(true);
+  });
+});
+
+describe("mtpForceRebuildRequested", () => {
+  it("does NOT force a rebuild for a fresh, reusable slice", () => {
+    expect(mtpForceRebuildRequested({ reusable: true }, {})).toBe(false);
+  });
+
+  it("forces a rebuild when the slice is stale (so the child does not reuse it)", () => {
+    expect(
+      mtpForceRebuildRequested({ reusable: false, reason: "stale" }, {}),
+    ).toBe(true);
+  });
+
+  it("forces a rebuild when the operator override is set, even if reusable", () => {
+    expect(
+      mtpForceRebuildRequested(
+        { reusable: true },
+        { ELIZA_IOS_REBUILD_MTP: "1" },
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -4939,19 +4939,22 @@ function mtpTargetOutDir(target) {
 }
 
 // The llama.cpp fork the MTP slice is compiled from. Mirrors
-// build-llama-cpp-mtp.mjs' FORK_SRC_CANDIDATES so the staleness gate keys off
-// the same source tree the builder uses.
+// build-llama-cpp-mtp.mjs' FORK_SRC_CANDIDATES (same order, env override first)
+// so the staleness gate keys off the SAME source tree the builder compiles —
+// otherwise an ELIZA_MTP_LLAMA_CPP_SRC override would make the gate check a
+// different fork than the one being built.
 const MTP_FORK_SRC_CANDIDATES = [
+  process.env.ELIZA_MTP_LLAMA_CPP_SRC?.trim(),
   path.join(
-    packagesRoot,
-    "..",
+    repoRoot,
     "plugins",
     "plugin-local-inference",
     "native",
     "llama.cpp",
   ),
   path.join(
-    repoRoot,
+    packagesRoot,
+    "..",
     "plugins",
     "plugin-local-inference",
     "native",
@@ -4965,8 +4968,8 @@ const MTP_FORK_SRC_CANDIDATES = [
     "native",
     "llama.cpp",
   ),
-  path.join(packagesRoot, "native", "ios-deps", "llama.cpp", "src"),
-];
+  path.join(repoRoot, "packages", "native", "ios-deps", "llama.cpp", "src"),
+].filter(Boolean);
 
 function resolveMtpForkSrc() {
   for (const candidate of MTP_FORK_SRC_CANDIDATES) {
@@ -5033,6 +5036,15 @@ export function mtpSliceReuse(capabilitiesPath, forkSrc, currentRevision) {
   return { reusable: true, reason: "fresh" };
 }
 
+/**
+ * Whether ensureMtpIosTarget must FORCE the child builder to rebuild: when the
+ * slice is stale, or when the operator override is set. Pure + exported so the
+ * decision is unit-testable.
+ */
+export function mtpForceRebuildRequested(reuse, env = process.env) {
+  return env.ELIZA_IOS_REBUILD_MTP === "1" || !reuse.reusable;
+}
+
 async function ensureMtpIosTarget(target) {
   const outDir = mtpTargetOutDir(target);
   const capabilities = path.join(outDir, "CAPABILITIES.json");
@@ -5042,7 +5054,8 @@ async function ensureMtpIosTarget(target) {
     forkSrc,
     currentMtpForkRevision(forkSrc),
   );
-  if (reuse.reusable && process.env.ELIZA_IOS_REBUILD_MTP !== "1") {
+  const forceRebuild = mtpForceRebuildRequested(reuse, process.env);
+  if (!forceRebuild) {
     console.log(
       `[mobile-build] Reusing fresh mtp artifact for ${target} at ${outDir}`,
     );
@@ -5055,7 +5068,13 @@ async function ensureMtpIosTarget(target) {
   } else {
     console.log(`[mobile-build] Building mtp artifact for ${target}`);
   }
-  await run("node", [MTP_BUILD_SCRIPT, "--target", target]);
+  // The child builder (build-llama-cpp-mtp.mjs) has its OWN presence-only reuse
+  // gate keyed on ELIZA_MTP_FORCE_REBUILD. Without propagating it, the child
+  // would see the stale CAPABILITIES.json and reuse it — turning this staleness
+  // gate into a no-op. Force the child to actually rebuild (#9309).
+  await run("node", [MTP_BUILD_SCRIPT, "--target", target], {
+    env: { ...process.env, ELIZA_MTP_FORCE_REBUILD: "1" },
+  });
   if (!fs.existsSync(capabilities)) {
     throw new Error(
       `[mobile-build] mtp build for ${target} did not produce CAPABILITIES.json at ${capabilities}. ` +

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -325,13 +325,14 @@ function assertInstalledIosRendererIsFresh(udid) {
     "public",
     "eliza-renderer-build.json",
   );
-  const freshManifest = path.join(
-    repoRoot,
-    "packages",
-    "app",
-    "dist",
-    "eliza-renderer-build.json",
-  );
+  // Resolve the fresh renderer from the SAME dist the installed shell was built
+  // from. A white-label shell (ELIZA_SMOKE_APP_ID) builds from its own dist
+  // (e.g. apps/app/dist); comparing against packages/app/dist would be a
+  // guaranteed buildId mismatch and a false "stale UI" failure.
+  const rendererDist = process.env.ELIZA_SMOKE_RENDERER_DIST
+    ? path.resolve(process.env.ELIZA_SMOKE_RENDERER_DIST)
+    : path.join(repoRoot, "packages", "app", "dist");
+  const freshManifest = path.join(rendererDist, "eliza-renderer-build.json");
   if (!fs.existsSync(freshManifest)) {
     console.warn(
       `[local-chat-smoke] no freshly built renderer manifest at ${freshManifest}; skipping stamp check.`,

--- a/packages/app/src/renderer-build-stamp.ts
+++ b/packages/app/src/renderer-build-stamp.ts
@@ -12,14 +12,18 @@
  * silent and never blocks boot. This is observability at a real runtime
  * boundary, not error-swallowing business logic.
  */
+/** Mirrors the canonical manifest written by buildRendererManifest() in
+ * `@elizaos/app-core/scripts/lib/renderer-build-manifest.mjs`. */
 export interface RendererBuildStamp {
   schema: string;
   buildId: string;
   indexHtmlSha256: string;
+  assetCount: number;
   builtAt: string;
   commit: string | null;
   variant: string | null;
   capacitorTarget: string | null;
+  runtimeMode: string | null;
 }
 
 declare global {
@@ -31,9 +35,17 @@ declare global {
 const MANIFEST_FILENAME = "eliza-renderer-build.json";
 
 export async function loadRendererBuildStamp(): Promise<RendererBuildStamp | null> {
+  // The manifest is only emitted by production `vite build`, never the dev
+  // server. Skip the fetch in dev so we don't log a spurious 404 (which would
+  // also trip e2e smokes that assert zero console errors).
+  if (import.meta.env?.DEV) {
+    window.__ELIZA_RENDERER_BUILD__ = null;
+    return null;
+  }
   try {
     // Resolve against the document base so it works on web, Capacitor
-    // (capacitor://localhost/), and Electrobun static hosting alike.
+    // (https://localhost/ via the configured scheme), and Electrobun static
+    // hosting alike.
     const url = new URL(MANIFEST_FILENAME, document.baseURI).toString();
     const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) {


### PR DESCRIPTION
Follow-up to #9314 + #9422 (both merged). A multi-agent adversarial review of the #9309 staleness gates found that **two of the new gates were ineffective or over-aggressive**. These fixes land the corrections against current `develop`.

## Confirmed findings fixed

**🔴 HIGH — iOS MTP staleness gate was a no-op.** `ensureMtpIosTarget` computed a STALE verdict and logged "Rebuilding…", but delegated the build to `build-llama-cpp-mtp.mjs`, whose **own** presence-only reuse gate is keyed on a *different* env var (`ELIZA_MTP_FORCE_REBUILD`). The parent never set it, so the child saw the still-present `CAPABILITIES.json` and reused the **stale** slice — the entire gate produced only a log line. Now the parent propagates `ELIZA_MTP_FORCE_REBUILD=1` to the child whenever it decides to (re)build. Extracted a pure, exported `mtpForceRebuildRequested` + 3 unit tests. (This also makes the documented `ELIZA_IOS_REBUILD_MTP=1` override actually force a rebuild — it was a no-op for the same reason.)

**🟠 MED — gate keyed off the wrong fork under override.** The gate's fork-candidate list omitted `ELIZA_MTP_LLAMA_CPP_SRC` (which the builder honors *first*), so an override made the staleness check key off a different tree than the one compiled. Prepended it (+ `.filter(Boolean)`), matching the builder's order.

**🔴 HIGH — desktop fused-lib gate deleted legitimate drop-ins.** The variant-aware reuse gate treated a *sidecar-less* staged lib (e.g. a prebuilt a CI step drops into `dist/local-inference/lib`) as a mismatch and **deleted** it on plain local builds — contradicting the documented reuse path. Now distinguishes "no provenance" (trust + reuse) from "wrong provenance" (sidecar variant/platform mismatch → rebuild, or drop when it can't rebuild). New `fusedLibStagedVariantMismatch`.

**🟠 MED — smoke false-failed white-label shells.** `assertInstalledIosRendererIsFresh` hardcoded `packages/app/dist`, so a white-label shell (`ELIZA_SMOKE_APP_ID`, built from its own dist) hit a guaranteed buildId mismatch → false "stale UI". Now resolves via `ELIZA_SMOKE_RENDERER_DIST` (default `packages/app/dist`).

**🟡 LOW — stamp type drift.** Aligned `RendererBuildStamp` with the canonical 9-field manifest (`assetCount`, `runtimeMode`) so the `as` cast no longer hides fields; corrected a scheme comment.

## Evidence
- **34/34 vitest** across the affected suites (incl. the 3 new `mtpForceRebuildRequested` cases and the `ios-engine-gate` regression suite):
  ```
  Test Files  5 passed (5)
       Tests  34 passed (34)
  ```
- `node --check` clean on all edited `.mjs`; biome clean.
- The fix is confirmed present in the branch (`ELIZA_MTP_FORCE_REBUILD` propagation).

The adversarial review that surfaced these ran 14 agents over the full round-2 diff; the two HIGH findings would each have silently defeated a determinism guarantee #9309 set out to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)