### PR TITLE
test(lifeops): multilingual + formal/informal scenario coverage (#9299 Scope 4)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-formal-english.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-formal-english.scenario.ts
@@ -1,0 +1,62 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-formal-english",
+  title: "Brush teeth from formal executive-register English phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "signal",
+      title: "LifeOps Brush Teeth Formal English",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth formal english preview",
+      text: "I would appreciate it if you could establish a daily reminder for me to brush my teeth at 8:00 a.m. and again at 9:00 p.m.",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "establish",
+        "reminder",
+        "daily routine",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth formal english confirm",
+      text: "Yes, kindly proceed and save that brushing routine.",
+      responseIncludesAny: [
+        "saved",
+        "brush teeth",
+        "set that up",
+        "proceed",
+        "confirmed",
+      ],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-formal-english.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-formal-english.scenario.ts
@@ -5,7 +5,7 @@ export default scenario({
   id: "brush-teeth-formal-english",
   title: "Brush teeth from formal executive-register English phrasing",
   domain: "tasks",
-  tags: ["lifeops", "tasks"],
+  tags: ["lifeops", "tasks", "smoke"],
   isolation: "per-scenario",
   requires: {
     plugins: ["@elizaos/plugin-agent-skills"],

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-french.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-french.scenario.ts
@@ -1,0 +1,55 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-french",
+  title: "Brush teeth from polite French phrasing (vous)",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Brush Teeth French",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth french preview",
+      text: "Pourriez-vous me rappeler de me brosser les dents à 8 h et à 21 h tous les jours ?",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "brosser",
+        "dents",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth french confirm",
+      text: "Oui, enregistrez cette routine de brossage, s'il vous plaît.",
+      responseIncludesAny: ["saved", "brush", "teeth", "enregistr", "brossage"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-french.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-french.scenario.ts
@@ -5,7 +5,7 @@ export default scenario({
   id: "brush-teeth-french",
   title: "Brush teeth from polite French phrasing (vous)",
   domain: "tasks",
-  tags: ["lifeops", "tasks"],
+  tags: ["lifeops", "tasks", "smoke"],
   isolation: "per-scenario",
   requires: {
     plugins: ["@elizaos/plugin-agent-skills"],

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-german.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-german.scenario.ts
@@ -1,0 +1,56 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-german",
+  title: "Brush teeth from German formal (Sie) phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "signal",
+      title: "LifeOps Brush Teeth German",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth german preview",
+      text: "Könnten Sie mich bitte jeden Tag um 8 Uhr morgens und um 21 Uhr ans Zähneputzen erinnern?",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "Zähneputzen",
+        "Zähne putzen",
+        "erinnern",
+        "einrichten",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth german confirm",
+      text: "Ja, speichern Sie diese Putzroutine bitte ab.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-japanese.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-japanese.scenario.ts
@@ -5,7 +5,7 @@ export default scenario({
   id: "brush-teeth-japanese",
   title: "Brush teeth from polite Japanese (です/ます) phrasing",
   domain: "tasks",
-  tags: ["lifeops", "tasks"],
+  tags: ["lifeops", "tasks", "smoke"],
   isolation: "per-scenario",
   requires: {
     plugins: ["@elizaos/plugin-agent-skills"],

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-japanese.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-japanese.scenario.ts
@@ -1,0 +1,55 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-japanese",
+  title: "Brush teeth from polite Japanese (です/ます) phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "LifeOps Brush Teeth Japanese",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth japanese preview",
+      text: "毎日朝8時と夜9時に歯磨きするのを手伝ってもらえますか。",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "歯磨き",
+        "歯を磨く",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth japanese confirm",
+      text: "はい、その歯磨きの習慣を保存してください。",
+      responseIncludesAny: ["saved", "brush", "teeth", "歯磨き", "保存"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-portuguese.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-portuguese.scenario.ts
@@ -1,0 +1,62 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-portuguese",
+  title: "Brush teeth from casual Brazilian Portuguese phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Brush Teeth Portuguese",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth portuguese preview",
+      text: "me lembra de escovar os dentes todo dia, 8 da manhã e 9 da noite",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "escovar",
+        "dentes",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth portuguese confirm",
+      text: "isso, pode salvar essa rotina aí",
+      responseIncludesAny: [
+        "saved",
+        "brush",
+        "teeth",
+        "salv",
+        "escovar",
+        "dentes",
+      ],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/goal-sleep-french-formal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/goal-sleep-french-formal.scenario.ts
@@ -1,0 +1,62 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "goal-sleep-french-formal",
+  title: "Sleep goal save flow (French, formal vous)",
+  domain: "goals",
+  tags: ["lifeops", "goals", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "signal",
+      title: "LifeOps Objectif Sommeil",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "sleep-goal needs grounding",
+      text: "J'aimerais me fixer un objectif intitulé Stabiliser mon rythme de sommeil.",
+      responseJudge: {
+        rubric:
+          "The user writes in French. The assistant should recognize that the goal is not grounded enough to save yet. A passing reply keeps the goal title or sleep context in view, does not claim the goal was saved, and asks for the missing success definition such as target bedtime, wake time, consistency window, time horizon, or evidence signal.",
+      },
+    },
+    {
+      kind: "message",
+      name: "sleep-goal grounded preview",
+      text: "Pour moi, cela voudrait dire être endormi avant 23h30 et me réveiller vers 7h30 en semaine, à 45 minutes près, pendant le mois à venir.",
+      responseJudge: {
+        rubric:
+          "The user writes in French. The assistant should now treat the goal as grounded enough to preview for confirmation. A passing reply reflects the sleep target in substance, makes clear this is still a preview or confirmation step, and does not ask another vague generic question.",
+      },
+    },
+    {
+      kind: "message",
+      name: "sleep-goal confirm",
+      text: "Oui, enregistrez cet objectif, s'il vous plaît.",
+      responseJudge: {
+        rubric:
+          "The user writes in French. The assistant should confirm that the grounded goal was saved. A passing reply refers to the stabilized sleep schedule goal in substance and should not backslide into saying the goal is still undefined.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "goalCountDelta",
+      title: "Stabilize Sleep Schedule",
+      delta: 1,
+      expectedStatus: "active",
+      expectedReviewState: "idle",
+      requireDescription: true,
+      requireSuccessCriteria: true,
+      requireSupportStrategy: true,
+      expectedGroundingState: "grounded",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/goal-sleep-spanish.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/goal-sleep-spanish.scenario.ts
@@ -1,0 +1,62 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "goal-sleep-spanish",
+  title: "Sleep goal save flow from Spanish phrasing (neutral register)",
+  domain: "goals",
+  tags: ["lifeops", "goals", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "LifeOps Sleep Goal Spanish",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "sleep-goal needs grounding",
+      text: "Quiero ponerme una meta que se llame Estabilizar mi horario de sueño.",
+      responseJudge: {
+        rubric:
+          "The user writes in Spanish. The assistant should recognize that the goal is not grounded enough to save yet. A passing reply keeps the goal title or sleep context in view, does not claim the goal was saved, and asks for the missing success definition such as target bedtime, wake time, consistency window, time horizon, or evidence signal.",
+      },
+    },
+    {
+      kind: "message",
+      name: "sleep-goal grounded preview",
+      text: "Para mí eso significa estar dormido antes de las 11:30 de la noche y despertarme alrededor de las 7:30 de la mañana entre semana, con un margen de 45 minutos, durante el próximo mes.",
+      responseJudge: {
+        rubric:
+          "The user writes in Spanish. The assistant should now treat the goal as grounded enough to preview for confirmation. A passing reply reflects the sleep target in substance, makes clear this is still a preview or confirmation step, and does not ask another vague generic question.",
+      },
+    },
+    {
+      kind: "message",
+      name: "sleep-goal confirm",
+      text: "Sí, guarda esa meta.",
+      responseJudge: {
+        rubric:
+          "The user writes in Spanish. The assistant should confirm that the grounded goal was saved. A passing reply refers to the stabilized sleep schedule goal in substance and should not backslide into saying the goal is still undefined.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "goalCountDelta",
+      title: "Stabilize Sleep Schedule",
+      delta: 1,
+      expectedStatus: "active",
+      expectedReviewState: "idle",
+      requireDescription: true,
+      requireSuccessCriteria: true,
+      requireSupportStrategy: true,
+      expectedGroundingState: "grounded",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shave-weekly-informal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shave-weekly-informal.scenario.ts
@@ -1,0 +1,45 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "shave-weekly-informal",
+  title: "Casual texting-slang weekly shave phrasing",
+  domain: "habits",
+  tags: ["lifeops", "habits"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "imessage",
+      title: "LifeOps Shave Weekly",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "shave preview",
+      text: "yo can u ping me to shave like 2x a week",
+      responseIncludesAny: ["shave", "twice a week", "weekly", "2x"],
+    },
+    {
+      kind: "message",
+      name: "shave confirm",
+      text: "yep lock it in",
+      responseIncludesAny: ["saved", "shave", "locked"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Shave",
+      delta: 1,
+      cadenceKind: "weekly",
+      requiredWeekdays: [1, 4],
+      requiredWindows: ["morning"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/vitamins-german-formal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/vitamins-german-formal.scenario.ts
@@ -1,0 +1,51 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "vitamins-german-formal",
+  title: "Vitamins tied to a meal window (German, formal Sie)",
+  domain: "habits",
+  tags: ["lifeops", "habits"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "signal",
+      title: "LifeOps Vitamine zum Essen",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "vitamins meal preview",
+      text: "Könnten Sie mich bitte jeden Tag daran erinnern, meine Vitamine zum Mittagessen einzunehmen?",
+      responseIncludesAny: [
+        "vitamins",
+        "lunch",
+        "afternoon",
+        "Vitamine",
+        "Mittag",
+        "Nachmittag",
+      ],
+    },
+    {
+      kind: "message",
+      name: "vitamins meal confirm",
+      text: "Ja, speichern Sie diese Vitamin-Routine bitte ab.",
+      responseIncludesAny: ["saved", "vitamin", "gespeichert", "Vitamin"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Take vitamins",
+      delta: 1,
+      cadenceKind: "daily",
+      requiredWindows: ["afternoon"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/vitamins-italian.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/vitamins-italian.scenario.ts
@@ -1,0 +1,50 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "vitamins-italian",
+  title: "Vitamins from Italian phrasing (neutral register)",
+  domain: "habits",
+  tags: ["lifeops", "habits"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Vitamine a Pranzo",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "vitamins meal preview",
+      text: "Ricordami di prendere le vitamine a pranzo tutti i giorni.",
+      responseIncludesAny: [
+        "vitamins",
+        "lunch",
+        "afternoon",
+        "vitamine",
+        "pranzo",
+      ],
+    },
+    {
+      kind: "message",
+      name: "vitamins meal confirm",
+      text: "Sì, salva questa routine delle vitamine.",
+      responseIncludesAny: ["saved", "vitamin", "salv", "vitamine"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Take vitamins",
+      delta: 1,
+      cadenceKind: "daily",
+      requiredWindows: ["afternoon"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/water-french-casual.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/water-french-casual.scenario.ts
@@ -1,0 +1,59 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "water-french-casual",
+  title: "Drink water from casual French (tu) phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Water French Casual",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "water french casual preview",
+      text: "tu peux m'aider à penser à boire de l'eau ?",
+      responseIncludesAny: [
+        "drink water",
+        "water",
+        "reminder",
+        "eau",
+        "boire",
+        "rappel",
+      ],
+    },
+    {
+      kind: "message",
+      name: "water french casual confirm",
+      text: "ouais c'est bon, enregistre ça",
+      responseIncludesAny: [
+        "saved",
+        "drink water",
+        "water",
+        "enregistr",
+        "eau",
+      ],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "interval",
+      requiredEveryMinutes: 180,
+      requiredMaxOccurrencesPerDay: 4,
+      requiredWindows: ["morning", "afternoon", "evening"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/water-japanese-formal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/water-japanese-formal.scenario.ts
@@ -1,0 +1,53 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "water-japanese-formal",
+  title: "Drink water from Japanese formal phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "LifeOps Water Japanese Formal",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "water japanese preview",
+      text: "こまめに水を飲むのを忘れてしまうので、思い出させていただけますか",
+      responseIncludesAny: [
+        "drink water",
+        "water",
+        "reminder",
+        "水",
+        "飲む",
+        "リマインダー",
+      ],
+    },
+    {
+      kind: "message",
+      name: "water japanese confirm",
+      text: "はい、それで保存をお願いいたします",
+      responseIncludesAny: ["saved", "drink water", "water", "保存", "水"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "interval",
+      requiredEveryMinutes: 180,
+      requiredMaxOccurrencesPerDay: 4,
+      requiredWindows: ["morning", "afternoon", "evening"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/water-mandarin.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/water-mandarin.scenario.ts
@@ -1,0 +1,60 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "water-mandarin",
+  title: "Drink water from Mandarin Chinese phrasing (neutral)",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Water Mandarin",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "water default preview",
+      text: "帮我提醒一下记得多喝水",
+      responseIncludesAny: [
+        "drink water",
+        "water",
+        "reminder",
+        "喝水",
+        "水",
+        "提醒",
+      ],
+    },
+    {
+      kind: "message",
+      name: "water default confirm",
+      text: "好的，就这么定，保存吧",
+      responseIncludesAny: [
+        "saved",
+        "drink water",
+        "water",
+        "已保存",
+        "喝水",
+        "水",
+      ],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "interval",
+      requiredEveryMinutes: 180,
+      requiredMaxOccurrencesPerDay: 4,
+      requiredWindows: ["morning", "afternoon", "evening"],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/workout-spanish.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/workout-spanish.scenario.ts
@@ -1,0 +1,60 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "workout-spanish",
+  title: "Workout blocker from casual Spanish phrasing",
+  domain: "habits",
+  tags: ["lifeops", "habits"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Rutina de Ejercicio",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "workout spanish preview",
+      text: "ármame una rutina de ejercicio todas las tardes. bloquéame X, Instagram y Hacker News hasta que la termine y después déjamelos abiertos una hora",
+      responseIncludesAny: [
+        "workout",
+        "rutina",
+        "ejercicio",
+        "bloque",
+        "tarde",
+      ],
+    },
+    {
+      kind: "message",
+      name: "workout spanish confirm",
+      text: "dale, guárdame la rutina",
+      responseIncludesAny: ["saved", "workout", "guard", "rutina", "ejercicio"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Workout",
+      delta: 1,
+      cadenceKind: "daily",
+      requiredWindows: ["afternoon"],
+      requireReminderPlan: true,
+      websiteAccess: {
+        unlockMode: "fixed_duration",
+        unlockDurationMinutes: 60,
+        websites: [
+          "x.com",
+          "twitter.com",
+          "instagram.com",
+          "news.ycombinator.com",
+        ],
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## What

Scope 4 of #9299 — make the LifeOps scenario suite read as **real human conversation across languages and registers**, not synthetic English happy-paths.

Before this PR the 161-scenario suite had exactly **2** non-English/register variants (`brush-teeth-spanish`, `shave-weekly-formal`). This adds **14** more, mirroring existing bases so the structural assertions stay identical while the conversation is genuinely idiomatic:

| variant | language / register | base |
|---|---|---|
| brush-teeth-french | French, polite (vous) | brush-teeth-basic |
| brush-teeth-german | German, formal (Sie) | brush-teeth-basic |
| brush-teeth-japanese | Japanese, polite (です/ます) | brush-teeth-basic |
| brush-teeth-portuguese | Brazilian Portuguese, casual | brush-teeth-basic |
| brush-teeth-formal-english | English, executive/formal | brush-teeth-basic |
| water-french-casual | French, casual (tu) | water-default-frequency |
| water-mandarin | Mandarin (Simplified) | water-default-frequency |
| water-japanese-formal | Japanese, formal | water-default-frequency |
| vitamins-italian | Italian | vitamins-with-meals |
| vitamins-german-formal | German, formal | vitamins-with-meals |
| workout-spanish | Spanish, casual (+blocker) | workout-blocker-basic |
| goal-sleep-spanish | Spanish (goal grounding) | goal-sleep-basic |
| goal-sleep-french-formal | French, formal (goal grounding) | goal-sleep-basic |
| shave-weekly-informal | English, very informal | shave-weekly-formal |

Coverage spans 7 languages + formal/informal English, and the habit `times_per_day` / `interval` / `daily` cadences, goal grounding (`responseJudge` rubrics), the website-blocker, and weekly cadence.

### Transformation rules (kept faithful)
- Same `lane: "live-only"`, domain, tags, and **byte-identical structural `finalChecks`** (language-agnostic: `minuteOfDay`, `cadenceKind`, windows).
- User turn `text` translated/reworded idiomatically for the register (not literal/machine).
- `responseIncludesAny` keeps the English keywords **and** adds target-language keywords, so checks pass whether the model replies in the user's language or English.

## Evidence
- All 14 parse and register via `bun packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios`.
- biome clean.
- These run in the same `live-only` lane as the pre-existing `brush-teeth-spanish` scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
