### PR TITLE
fix(on-device): eliminate iOS MTP gate residuals (fork drift + 'unknown' sentinel)

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-mtp-staleness.test.mts
+++ b/packages/app-core/scripts/run-mobile-build-mtp-staleness.test.mts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  MTP_FORK_SRC_CANDIDATES,
   mtpForceRebuildRequested,
   mtpSliceReuse,
 } from "./run-mobile-build.mjs";
@@ -91,6 +92,55 @@ describe("mtpSliceReuse", () => {
     // and the fresh mtime keeps the slice reusable rather than rebuilding blindly.
     const result = mtpSliceReuse(caps, fork, null);
     expect(result.reusable).toBe(true);
+  });
+
+  it("does NOT spuriously rebuild when the recorded revision is the 'unknown' sentinel", () => {
+    const fork = makeForkSrc(OLDER_SOURCE);
+    // Slice built when git was unavailable → recorded "unknown"; now git works
+    // and returns a real SHA. The "unknown" sentinel must normalize to null so
+    // it falls through to the (fresh) mtime check instead of rebuilding.
+    const caps = writeCapabilities("unknown", FUTURE_ARTIFACT);
+    const result = mtpSliceReuse(caps, fork, "v1.2.3-real-sha");
+    expect(result.reusable).toBe(true);
+  });
+
+  it("still catches a stale slice even when the recorded revision is 'unknown'", () => {
+    const fork = makeForkSrc(NEWER_SOURCE);
+    const caps = writeCapabilities("unknown", FUTURE_ARTIFACT);
+    const result = mtpSliceReuse(caps, fork, "v1.2.3-real-sha");
+    expect(result.reusable).toBe(false);
+    expect(result.reason).toMatch(/source newer than artifact/);
+  });
+});
+
+describe("MTP_FORK_SRC_CANDIDATES (no drift vs the builder)", () => {
+  it("mirrors build-llama-cpp-mtp.mjs: the in-repo fork + the ios-deps fallback, and nothing divergent", () => {
+    const forkSuffix = path.join(
+      "plugins",
+      "plugin-local-inference",
+      "native",
+      "llama.cpp",
+    );
+    const iosDepsSuffix = path.join(
+      "packages",
+      "native",
+      "ios-deps",
+      "llama.cpp",
+      "src",
+    );
+    expect(MTP_FORK_SRC_CANDIDATES.some((c) => c.endsWith(forkSuffix))).toBe(
+      true,
+    );
+    expect(MTP_FORK_SRC_CANDIDATES.some((c) => c.endsWith(iosDepsSuffix))).toBe(
+      true,
+    );
+    // The previously-divergent `eliza/plugins` candidate (absent from the
+    // builder) must NOT reappear — that was the drift the builder never had.
+    expect(
+      MTP_FORK_SRC_CANDIDATES.some((c) =>
+        c.includes(path.join("eliza", "plugins", "plugin-local-inference")),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -4943,32 +4943,31 @@ function mtpTargetOutDir(target) {
 // so the staleness gate keys off the SAME source tree the builder compiles —
 // otherwise an ELIZA_MTP_LLAMA_CPP_SRC override would make the gate check a
 // different fork than the one being built.
-const MTP_FORK_SRC_CANDIDATES = [
+//
+// MUST mirror build-llama-cpp-mtp.mjs FORK_SRC_CANDIDATES EXACTLY (same order,
+// same paths) so the gate keys off the SAME tree the builder compiles. The
+// builder derives its repo root from its own file location
+// (packages/app-core/scripts → repo root), NOT from run-mobile-build's
+// configurable repoRoot, so we derive the identical base here — otherwise a
+// nested-monorepo layout would make the two lists diverge.
+const mtpBuilderRepoRoot = path.resolve(__dirname, "..", "..", "..");
+export const MTP_FORK_SRC_CANDIDATES = [
   process.env.ELIZA_MTP_LLAMA_CPP_SRC?.trim(),
   path.join(
-    repoRoot,
+    mtpBuilderRepoRoot,
     "plugins",
     "plugin-local-inference",
     "native",
     "llama.cpp",
   ),
   path.join(
-    packagesRoot,
-    "..",
-    "plugins",
-    "plugin-local-inference",
+    mtpBuilderRepoRoot,
+    "packages",
     "native",
+    "ios-deps",
     "llama.cpp",
+    "src",
   ),
-  path.join(
-    repoRoot,
-    "eliza",
-    "plugins",
-    "plugin-local-inference",
-    "native",
-    "llama.cpp",
-  ),
-  path.join(repoRoot, "packages", "native", "ios-deps", "llama.cpp", "src"),
 ].filter(Boolean);
 
 function resolveMtpForkSrc() {
@@ -5008,6 +5007,11 @@ export function mtpSliceReuse(capabilitiesPath, forkSrc, currentRevision) {
   } catch {
     return { reusable: false, reason: "unreadable CAPABILITIES.json" };
   }
+  // The builder records the literal "unknown" when git is unavailable at build
+  // time; the gate returns null in the same case. Normalize both to "revision
+  // unknown" so a later build with working git doesn't spuriously rebuild on an
+  // "unknown" vs real-SHA mismatch — fall through to the mtime check instead.
+  if (recordedRevision === "unknown") recordedRevision = null;
   // Only treat a revision change as decisive when BOTH are known (CI without
   // git still falls back to the mtime check below rather than rebuilding blindly).
   if (


### PR DESCRIPTION
Cleans up the two low-severity residuals the adversarial review noted on the #9309 iOS MTP staleness gate (the HIGH/MEDIUM findings already landed in #9426).

## Fixes
- **Fork-candidate drift** → `MTP_FORK_SRC_CANDIDATES` now mirrors `build-llama-cpp-mtp.mjs` exactly: same repoRoot derivation (script location, not run-mobile-build's configurable repoRoot), same 3 candidates, same order. Removed a redundant `packagesRoot/..` duplicate and the `eliza/plugins` candidate the builder never had — under a nested-monorepo layout those could make the gate check a *different* fork than the one compiled. Exported + a drift-guard test.
- **`'unknown'` revision sentinel** → the builder records the literal `"unknown"` in `CAPABILITIES.fork.revision` when git is unavailable; the gate returns `null`. `mtpSliceReuse` now normalizes recorded `"unknown"` → `null`, so a later build with working git doesn't spuriously rebuild on an `"unknown"` vs real-SHA mismatch — it falls through to the mtime check (which still catches genuinely stale kernels). +2 tests.

## Evidence
- 11 MTP-gate vitest cases green (incl. the 2 new sentinel cases + the drift-guard), plus the `ios-engine-gate` regression suite.
- `node --check` + biome clean.

Pure refactor/hardening of the gate logic; no behavior change to the builder. Completes the #9309 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)