### PR TITLE
test(feed): keep core-flow e2e cleanup scoped

### DIFF
--- a/packages/feed/RAILWAY.md
+++ b/packages/feed/RAILWAY.md
@@ -167,19 +167,6 @@ not just `packages/feed`.
 - Start: `bash packages/feed/scripts/railway-start.sh` (ensures the schema, then
   `next start` binding `$PORT`).
 
-## Canonical host: feed.elizacloud.ai
-
-Use `https://feed.elizacloud.ai` as the public Feed origin in production. Set
-`NEXT_PUBLIC_APP_URL=https://feed.elizacloud.ai` on the web service so Next.js
-metadata, Open Graph cards, and Farcaster Mini App frame URLs all point at the
-same canonical host.
-
-The Cloudflare Worker route for `*.elizacloud.ai/*` makes `cloud-api` the
-default origin for every subdomain. Because Feed is served from its own Railway
-origin, the `feed.elizacloud.ai/*` host must be carved out of that wildcard
-route in Cloudflare: either add a more-specific Workers route with Worker =
-None, or make the `feed` DNS record DNS-only.
-
 ## 1. Create the project + services
 
 ```bash

--- a/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
+++ b/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
@@ -30,13 +30,16 @@
 
 import {
   actorState,
+  balanceTransactions,
   db,
   eq,
   inArray,
   markets,
+  pointsTransactions,
   positions,
   questions,
   sql,
+  tradingFees,
   users,
 } from "@feed/db";
 import { generateSnowflakeId } from "@feed/shared";
@@ -68,6 +71,17 @@ const seeded = {
   loserUserId: "",
   loserPositionId: "",
 };
+
+type UserWalletSnapshot = {
+  virtualBalance: string;
+  totalDeposited: string;
+  lifetimePnL: string;
+  earnedPoints: number;
+  reputationPoints: number;
+  totalFeesPaid: string;
+};
+
+let originalUserWallet: UserWalletSnapshot | null = null;
 
 async function apiGet<T>(path: string): Promise<T> {
   const response = await fetch(`${BASE_URL}${path}`, {
@@ -206,6 +220,30 @@ async function seedFixtures(userId: string): Promise<void> {
   seeded.loserUserId = await generateSnowflakeId();
   seeded.loserPositionId = await generateSnowflakeId();
 
+  const [userBeforeTest] = await db
+    .select({
+      virtualBalance: users.virtualBalance,
+      totalDeposited: users.totalDeposited,
+      lifetimePnL: users.lifetimePnL,
+      earnedPoints: users.earnedPoints,
+      reputationPoints: users.reputationPoints,
+      totalFeesPaid: users.totalFeesPaid,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!userBeforeTest) {
+    throw new Error(`Dev auth user not found before seeding: ${userId}`);
+  }
+  originalUserWallet = {
+    virtualBalance: String(userBeforeTest.virtualBalance),
+    totalDeposited: String(userBeforeTest.totalDeposited),
+    lifetimePnL: String(userBeforeTest.lifetimePnL),
+    earnedPoints: userBeforeTest.earnedPoints,
+    reputationPoints: userBeforeTest.reputationPoints,
+    totalFeesPaid: String(userBeforeTest.totalFeesPaid),
+  };
+
   // Fund the trading user. WalletService reads users.virtualBalance.
   await db
     .update(users)
@@ -292,6 +330,18 @@ async function seedFixtures(userId: string): Promise<void> {
 }
 
 async function teardownFixtures(userId: string): Promise<void> {
+  if (seeded.marketId) {
+    await db
+      .delete(balanceTransactions)
+      .where(eq(balanceTransactions.relatedId, seeded.marketId));
+    await db
+      .delete(tradingFees)
+      .where(eq(tradingFees.marketId, seeded.marketId));
+    await db.delete(pointsTransactions).where(
+      sql`${pointsTransactions.metadata} LIKE ${`%"relatedId":"${seeded.marketId}"%`}`,
+    );
+  }
+
   // Positions first (FK-free but logically owned by market + users).
   if (seeded.marketId) {
     await db.delete(positions).where(eq(positions.marketId, seeded.marketId));
@@ -305,13 +355,19 @@ async function teardownFixtures(userId: string): Promise<void> {
     await db.delete(actorState).where(eq(actorState.id, seeded.loserUserId));
     await db.delete(users).where(inArray(users.id, [seeded.loserUserId]));
   }
-  // Drop the trading user's positions in this seeded market (already covered by
-  // the marketId delete above, kept explicit for clarity).
-  if (seeded.marketId) {
+  if (originalUserWallet) {
     await db
-      .delete(positions)
-      .where(eq(positions.userId, userId))
-      .catch(() => undefined);
+      .update(users)
+      .set({
+        virtualBalance: originalUserWallet.virtualBalance,
+        totalDeposited: originalUserWallet.totalDeposited,
+        lifetimePnL: originalUserWallet.lifetimePnL,
+        earnedPoints: originalUserWallet.earnedPoints,
+        reputationPoints: originalUserWallet.reputationPoints,
+        totalFeesPaid: originalUserWallet.totalFeesPaid,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #9424 for issue #9301.

- Keeps `core-flow-bet-resolve-pnl.e2e.test.ts` cleanup scoped to seeded data.
- Removes the unsafe authenticated-user position delete that could wipe unrelated local/dev positions.
- Restores the dev auth user's pre-test wallet/PnL/stat fields and removes market-related balance/trading/points history created by the spec.
- Removes a duplicate `feed.elizacloud.ai` canonical-host section from `packages/feed/RAILWAY.md`; the detailed runbook section remains at the top.

## Evidence

Passed:

- `git fetch origin develop && git rebase origin/develop`
- `bun install` (completed; existing `@langchain/core@1.1.36` peer warning only)
- `bun run --cwd packages/feed scripts/typecheck-workspace.ts packages/testing`
- `bun run --cwd packages/feed lint`
- `git diff --check HEAD~1..HEAD`

Not run / blocked:

- Feed e2e: local temp worktree has no `DATABASE_URL`, no `packages/feed/.env*`, and no `packages/feed/apps/web/.next` production build for the Playwright `next start` webServer. PR #9424 already attached the actual bet -> resolve -> PnL e2e evidence for the spec; this PR only tightens cleanup.
- Root `bun run verify`: attempted twice. First failed in `@elizaos/example-telegram` because `@elizaos/plugin-openai` dist declarations were absent in the temp worktree; after manually building plugin-openai, the second run progressed further but failed in `@elizaos/plugin-registry` because `@elizaos/plugin-vision` declarations were absent. Building plugin-vision reports `src/image/sharp-compat.ts(18,32): error TS2307: Cannot find module 'jimp' or its corresponding type declarations`, then plugin-registry still cannot resolve a declaration file for `@elizaos/plugin-vision`. This is outside the Feed files changed here.

## Notes

Root verify's `--write` lint tasks produced unrelated local formatter churn in the temp worktree; those files are not included in this branch.
