### PR TITLE
test(ui): per-widget tests for topic-chips-bar, topic-grouped-transcript, grilling-card (#9304)

### DIFF
--- a/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.test.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type GrillingCriterion,
+  OrchestratorGrillingCard,
+} from "./orchestrator-grilling-card";
+
+afterEach(cleanup);
+
+const criteria: GrillingCriterion[] = [
+  { id: "a", label: "Has a test", state: "met", note: "6 of 6 covered" },
+  { id: "b", label: "Renders cleanly", state: "failed" },
+  { id: "c", label: "Exports types", state: "pending" },
+];
+
+describe("OrchestratorGrillingCard", () => {
+  it("renders the goal, verdict, and one row per criterion", () => {
+    render(
+      <OrchestratorGrillingCard
+        status="criteria-met"
+        goal="Ship the widget"
+        criteria={criteria}
+      />,
+    );
+    const card = screen.getByTestId("orchestrator-grilling");
+    expect(card.getAttribute("data-grilling-status")).toBe("criteria-met");
+    expect(card.textContent).toContain("Ship the widget");
+    expect(
+      screen.getByTestId("orchestrator-grilling-status").textContent,
+    ).toContain("Criteria met");
+    expect(screen.getByTestId("grilling-criterion-a")).toBeTruthy();
+    expect(screen.getByTestId("grilling-criterion-b")).toBeTruthy();
+    expect(screen.getByTestId("grilling-criterion-c")).toBeTruthy();
+  });
+
+  it("stamps each criterion's state for visual/icon selection", () => {
+    render(
+      <OrchestratorGrillingCard
+        status="criteria-failed"
+        goal="g"
+        criteria={criteria}
+      />,
+    );
+    expect(
+      screen
+        .getByTestId("grilling-criterion-a")
+        .getAttribute("data-criterion-state"),
+    ).toBe("met");
+    expect(
+      screen
+        .getByTestId("grilling-criterion-b")
+        .getAttribute("data-criterion-state"),
+    ).toBe("failed");
+    expect(
+      screen
+        .getByTestId("grilling-criterion-c")
+        .getAttribute("data-criterion-state"),
+    ).toBe("pending");
+  });
+
+  it("renders a criterion note only when present", () => {
+    render(
+      <OrchestratorGrillingCard
+        status="evidence-pending"
+        goal="g"
+        criteria={criteria}
+      />,
+    );
+    expect(screen.getByTestId("grilling-criterion-a").textContent).toContain(
+      "6 of 6 covered",
+    );
+    // Criterion b has no note — its row text is just the label + state label.
+    expect(screen.getByTestId("grilling-criterion-b").textContent).toContain(
+      "Renders cleanly",
+    );
+  });
+
+  it("shows the reviewing verdict for the pending status", () => {
+    render(
+      <OrchestratorGrillingCard
+        status="evidence-pending"
+        goal="g"
+        criteria={[]}
+      />,
+    );
+    expect(
+      screen.getByTestId("orchestrator-grilling-status").textContent,
+    ).toContain("Reviewing evidence");
+  });
+});

--- a/packages/ui/src/components/chat/widgets/topic-chips-bar.test.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-chips-bar.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type TopicChip, TopicChipsBar } from "./topic-chips-bar";
+
+afterEach(cleanup);
+
+const topics: TopicChip[] = [
+  { id: "t1", label: "Travel", count: 3 },
+  { id: "t2", label: "Budget", count: 1 },
+  { id: "t3", label: "Health" },
+];
+
+describe("TopicChipsBar", () => {
+  it("renders the empty state when there are no topics", () => {
+    render(<TopicChipsBar topics={[]} />);
+    expect(screen.getByTestId("topic-chips-bar").textContent).toContain(
+      "No topics yet",
+    );
+  });
+
+  it("renders one chip per topic and reports selection", () => {
+    const onSelect = vi.fn();
+    render(<TopicChipsBar topics={topics} onSelect={onSelect} />);
+    expect(screen.getByTestId("topic-chip-t1").textContent).toContain("Travel");
+    fireEvent.click(screen.getByTestId("topic-chip-t2"));
+    expect(onSelect).toHaveBeenCalledWith("t2");
+  });
+
+  it("marks the active chip as selected", () => {
+    render(<TopicChipsBar topics={topics} activeTopicId="t3" />);
+    expect(
+      screen.getByTestId("topic-chip-t3").getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen.getByTestId("topic-chip-t1").getAttribute("aria-selected"),
+    ).toBe("false");
+  });
+
+  it("collapses topics beyond maxVisible into a +N overflow chip", () => {
+    render(<TopicChipsBar topics={topics} maxVisible={2} />);
+    expect(screen.getByTestId("topic-chip-t1")).toBeTruthy();
+    expect(screen.getByTestId("topic-chip-t2")).toBeTruthy();
+    expect(screen.queryByTestId("topic-chip-t3")).toBeNull();
+    expect(screen.getByTestId("topic-chips-overflow").textContent).toContain(
+      "+1",
+    );
+  });
+});

--- a/packages/ui/src/components/chat/widgets/topic-grouped-transcript.test.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-grouped-transcript.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type TopicGroup,
+  TopicGroupedTranscript,
+} from "./topic-grouped-transcript";
+
+afterEach(cleanup);
+
+const groups: TopicGroup[] = [
+  {
+    id: "g1",
+    topic: "Travel",
+    messageCount: 4,
+    previewLines: ["Booked the flight", "Hotel confirmed"],
+  },
+  {
+    id: "g2",
+    topic: "Budget",
+    messageCount: 2,
+    previewLines: ["Set the cap"],
+    collapsed: true,
+  },
+];
+
+describe("TopicGroupedTranscript", () => {
+  it("renders the empty state with no groups", () => {
+    render(<TopicGroupedTranscript groups={[]} />);
+    expect(
+      screen.getByTestId("topic-grouped-transcript").textContent,
+    ).toContain("No transcript yet");
+  });
+
+  it("renders each group header with its message count", () => {
+    render(<TopicGroupedTranscript groups={groups} />);
+    expect(screen.getByTestId("topic-group-g1").textContent).toContain(
+      "Travel",
+    );
+    expect(screen.getByTestId("topic-group-g1").textContent).toContain("4 msg");
+  });
+
+  it("shows preview lines for an expanded group, hides them when collapsed", () => {
+    render(<TopicGroupedTranscript groups={groups} />);
+    // g1 starts expanded -> preview visible.
+    expect(screen.getByTestId("topic-group-g1").textContent).toContain(
+      "Booked the flight",
+    );
+    // g2 seeded collapsed -> preview hidden.
+    expect(screen.getByTestId("topic-group-g2").textContent).not.toContain(
+      "Set the cap",
+    );
+  });
+
+  it("toggles a group and reports the new collapsed state", () => {
+    const onToggle = vi.fn();
+    render(<TopicGroupedTranscript groups={groups} onToggle={onToggle} />);
+    const toggle = screen.getByTestId("topic-group-toggle-g1");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalledWith("g1", true);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("topic-group-g1").textContent).not.toContain(
+      "Booked the flight",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Lands the 3 residual per-widget unit tests from the now-superseded #9412. The
structural #9304 work (shared inline-widget-context hook, WIDGET_MATRIX, coverage
gates, credential/task tests) already merged via #9418; these per-widget tests
were the only unique remaining slice (flagged by the #9412 review). Verified
against current develop.

## Tests (12/12)

- `topic-chips-bar.test.tsx` — empty state, chip-per-topic, `onSelect` payload, active `aria-selected`, `+N` overflow.
- `topic-grouped-transcript.test.tsx` — empty state, header + count, preview show/hide by collapsed state, `onToggle` payload.
- `orchestrator-grilling-card.test.tsx` — goal/verdict/criteria render, per-criterion `data-criterion-state`, note-when-present, pending verdict.

Each drives the real prop-driven widget (no stubs) — render + states + real callback payloads.

Refs #9304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)