### PR TITLE
fix(lifeops): repair Cerebras journey eval runner

### DIFF
--- a/packages/test/vitest/real.config.ts
+++ b/packages/test/vitest/real.config.ts
@@ -248,6 +248,7 @@ const realResolveAlias: ModuleAlias[] = [
     "plugin-companion",
     "plugin-documents",
     "plugin-personal-assistant",
+    "plugin-scheduling",
     "plugin-local-inference",
     "plugin-shopify-ui",
     "plugin-training",

--- a/plugins/plugin-personal-assistant/docs/audit/cerebras-journey-eval-results.json
+++ b/plugins/plugin-personal-assistant/docs/audit/cerebras-journey-eval-results.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtIso": "2026-05-15T11:56:50.870Z",
+  "generatedAtIso": "2026-06-24T16:29:49.633Z",
   "provider": "cerebras",
   "model": "gpt-oss-120b",
   "domainsGraded": 28,
@@ -13,11 +13,11 @@
       "domain": 1,
       "title": "Onboarding & first-run setup",
       "verdict": "pass",
-      "rationale": "All default-pack seeds are correctly created in scheduled state with appropriate logs",
+      "rationale": "All default-pack seeds are correctly created in scheduled state with appropriate logs, meeting the journey expectations.",
       "usage": {
         "promptTokens": 1984,
-        "completionTokens": 50,
-        "totalTokens": 2034,
+        "completionTokens": 55,
+        "totalTokens": 2039,
         "cachedTokens": 0
       },
       "tasksObserved": 4,
@@ -32,7 +32,7 @@
         "promptTokens": 2502,
         "completionTokens": 45,
         "totalTokens": 2547,
-        "cachedTokens": 0
+        "cachedTokens": 1024
       },
       "tasksObserved": 8,
       "logEntriesObserved": 8
@@ -41,12 +41,12 @@
       "domain": 3,
       "title": "Habits",
       "verdict": "pass",
-      "rationale": "The reminder fired and completed, and the onComplete output task was correctly created in scheduled state with proper parent linkage.",
+      "rationale": "The habit reminder completed and correctly spawned a scheduled output task via the onComplete pipeline.",
       "usage": {
         "promptTokens": 1881,
-        "completionTokens": 77,
-        "totalTokens": 1958,
-        "cachedTokens": 1024
+        "completionTokens": 89,
+        "totalTokens": 1970,
+        "cachedTokens": 0
       },
       "tasksObserved": 2,
       "logEntriesObserved": 5
@@ -55,11 +55,11 @@
       "domain": 4,
       "title": "Routines & multi-step daily flows",
       "verdict": "pass",
-      "rationale": "All tasks reached their expected terminal states and pipeline children were correctly scheduled without premature completion.",
+      "rationale": "All tasks reached expected terminal states and pipeline children were correctly created and scheduled/completed as described.",
       "usage": {
         "promptTokens": 2160,
-        "completionTokens": 96,
-        "totalTokens": 2256,
+        "completionTokens": 120,
+        "totalTokens": 2280,
         "cachedTokens": 1024
       },
       "tasksObserved": 3,
@@ -69,11 +69,11 @@
       "domain": 5,
       "title": "Tasks (one-off)",
       "verdict": "pass",
-      "rationale": "The task reached completed status with appropriate fields and the log reflects the expected transitions; early completion is allowed.",
+      "rationale": "The task reached completed status with correct fields and early completion is allowed per rules.",
       "usage": {
         "promptTokens": 1460,
-        "completionTokens": 112,
-        "totalTokens": 1572,
+        "completionTokens": 116,
+        "totalTokens": 1576,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -83,11 +83,11 @@
       "domain": 6,
       "title": "Goals",
       "verdict": "pass",
-      "rationale": "The watcher was correctly scheduled with the quiet_hours gate and remains in scheduled status without premature firing, matching the expected behavior.",
+      "rationale": "The watcher is correctly scheduled with the quiet_hours gate and remains in scheduled state without premature firing.",
       "usage": {
         "promptTokens": 1431,
-        "completionTokens": 70,
-        "totalTokens": 1501,
+        "completionTokens": 75,
+        "totalTokens": 1506,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -97,11 +97,11 @@
       "domain": 7,
       "title": "Reminders & escalation ladder",
       "verdict": "pass",
-      "rationale": "The high-priority reminder correctly remains a single scheduled task with no premature fire or escalation tasks, adhering to lazy ladder semantics.",
+      "rationale": "The high-priority reminder correctly remains a single scheduled task without premature escalation tasks, adhering to the lazy ladder evaluation rule.",
       "usage": {
         "promptTokens": 1386,
-        "completionTokens": 95,
-        "totalTokens": 1481,
+        "completionTokens": 90,
+        "totalTokens": 1476,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -111,12 +111,12 @@
       "domain": 8,
       "title": "Calendar journeys",
       "verdict": "pass",
-      "rationale": "The recap was correctly skipped and the follow‑up was created in scheduled state with proper parent linkage, matching the expected terminal states and log entries.",
+      "rationale": "The recap task correctly transitioned to skipped and its onSkip child was created as a scheduled followup with proper parent linkage.",
       "usage": {
         "promptTokens": 1836,
-        "completionTokens": 98,
-        "totalTokens": 1934,
-        "cachedTokens": 1024
+        "completionTokens": 74,
+        "totalTokens": 1910,
+        "cachedTokens": 0
       },
       "tasksObserved": 2,
       "logEntriesObserved": 3
@@ -125,11 +125,11 @@
       "domain": 9,
       "title": "Inbox & email triage",
       "verdict": "pass",
-      "rationale": "The output task reached completed status with correct terminal state and log entries, meeting all required semantics.",
+      "rationale": "The output task reached completed status with correct terminal state and logs, adhering to all spine rules.",
       "usage": {
         "promptTokens": 1470,
-        "completionTokens": 67,
-        "totalTokens": 1537,
+        "completionTokens": 70,
+        "totalTokens": 1540,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -139,12 +139,12 @@
       "domain": 10,
       "title": "Travel",
       "verdict": "pass",
-      "rationale": "The approval task completed and correctly spawned a scheduled output task as defined by the onComplete pipeline.",
+      "rationale": "The approval task completed and correctly created a scheduled output child as defined by the onComplete pipeline.",
       "usage": {
         "promptTokens": 1748,
-        "completionTokens": 60,
-        "totalTokens": 1808,
-        "cachedTokens": 1664
+        "completionTokens": 76,
+        "totalTokens": 1824,
+        "cachedTokens": 1024
       },
       "tasksObserved": 2,
       "logEntriesObserved": 3
@@ -153,11 +153,11 @@
       "domain": 11,
       "title": "Follow-up repair (relationships)",
       "verdict": "pass",
-      "rationale": "The watcher was scheduled, fired, and auto‑completed via the subject_updated check as expected, with correct terminal status and timestamps.",
+      "rationale": "The watcher completed as expected after the subject update, with correct terminal status and log entries.",
       "usage": {
         "promptTokens": 1699,
-        "completionTokens": 99,
-        "totalTokens": 1798,
+        "completionTokens": 90,
+        "totalTokens": 1789,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -170,8 +170,8 @@
       "rationale": "The reminder failed and correctly spawned a scheduled followup child as defined by the onFail pipeline.",
       "usage": {
         "promptTokens": 1752,
-        "completionTokens": 71,
-        "totalTokens": 1823,
+        "completionTokens": 62,
+        "totalTokens": 1814,
         "cachedTokens": 1024
       },
       "tasksObserved": 2,
@@ -181,11 +181,11 @@
       "domain": 13,
       "title": "Self-control / app & website blockers",
       "verdict": "pass",
-      "rationale": "The task correctly evaluated the travel gate, fired, and reached the expected terminal status with appropriate log entries.",
+      "rationale": "The task correctly evaluated the travel gate, fired, and reached the expected terminal status with appropriate logs.",
       "usage": {
         "promptTokens": 1572,
-        "completionTokens": 72,
-        "totalTokens": 1644,
+        "completionTokens": 73,
+        "totalTokens": 1645,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -195,11 +195,11 @@
       "domain": 14,
       "title": "Group chat handoff",
       "verdict": "pass",
-      "rationale": "The custom watcher task is correctly created with the specified properties and remains in the scheduled state as expected.",
+      "rationale": "The task is correctly scheduled with the custom watcher properties and no erroneous state transitions.",
       "usage": {
         "promptTokens": 1388,
-        "completionTokens": 74,
-        "totalTokens": 1462,
+        "completionTokens": 75,
+        "totalTokens": 1463,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -209,12 +209,12 @@
       "domain": 15,
       "title": "Multi-channel & cross-channel search",
       "verdict": "pass",
-      "rationale": "The task is correctly scheduled with the required contextRequest and no violations of the spine rules.",
+      "rationale": "The scheduled output task includes the required contextRequest with ownerFacts, recentTaskStates, and entities, and its terminal status is correctly set to scheduled.",
       "usage": {
-        "promptTokens": 1451,
-        "completionTokens": 76,
-        "totalTokens": 1527,
-        "cachedTokens": 1408
+        "promptTokens": 1452,
+        "completionTokens": 79,
+        "totalTokens": 1531,
+        "cachedTokens": 1024
       },
       "tasksObserved": 1,
       "logEntriesObserved": 1
@@ -223,12 +223,12 @@
       "domain": 16,
       "title": "Activity signals & screen context",
       "verdict": "pass",
-      "rationale": "The task reached completed status via the health_signal_observed check within the lookback window, and all required fields and logs are correct.",
+      "rationale": "The task reached completed status via the health signal completion check within the lookback window, and all required logs and fields are present.",
       "usage": {
         "promptTokens": 1717,
-        "completionTokens": 110,
-        "totalTokens": 1827,
-        "cachedTokens": 1664
+        "completionTokens": 200,
+        "totalTokens": 1917,
+        "cachedTokens": 1024
       },
       "tasksObserved": 1,
       "logEntriesObserved": 4
@@ -237,11 +237,11 @@
       "domain": 17,
       "title": "Approval queues & action gating",
       "verdict": "pass",
-      "rationale": "The approval task reached the expected dismissed terminal state with correct log transitions and no required fire event.",
+      "rationale": "The approval task was correctly dismissed with appropriate terminal status and logs, and no required fields are missing.",
       "usage": {
         "promptTokens": 1461,
-        "completionTokens": 77,
-        "totalTokens": 1538,
+        "completionTokens": 71,
+        "totalTokens": 1532,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -251,11 +251,11 @@
       "domain": 18,
       "title": "Identity merge (canonical person)",
       "verdict": "pass",
-      "rationale": "The watcher task reached completed status with correct subject and log entries, adhering to all spine rules.",
+      "rationale": "The watcher reached completed status with correct subject and logs, and no required fields are missing.",
       "usage": {
         "promptTokens": 1471,
-        "completionTokens": 78,
-        "totalTokens": 1549,
+        "completionTokens": 76,
+        "totalTokens": 1547,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -265,11 +265,11 @@
       "domain": 19,
       "title": "Memory recall",
       "verdict": "pass",
-      "rationale": "The task is correctly scheduled with the required output configuration and no violations of the spine rules are observed.",
+      "rationale": "The task is correctly scheduled with the expected output configuration and no erroneous state transitions.",
       "usage": {
         "promptTokens": 1369,
-        "completionTokens": 81,
-        "totalTokens": 1450,
+        "completionTokens": 63,
+        "totalTokens": 1432,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -279,11 +279,11 @@
       "domain": 20,
       "title": "Connectors & permissions",
       "verdict": "pass",
-      "rationale": "The task is correctly scheduled with high priority, appropriate metadata, and no premature firing or missing required fields.",
+      "rationale": "The task is correctly scheduled with high priority, appropriate metadata, and no premature firing, matching the expected end state.",
       "usage": {
         "promptTokens": 1403,
-        "completionTokens": 72,
-        "totalTokens": 1475,
+        "completionTokens": 82,
+        "totalTokens": 1485,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -293,12 +293,12 @@
       "domain": 21,
       "title": "Health, money, screen time",
       "verdict": "pass",
-      "rationale": "The watcher was correctly scheduled with the appropriate completion check and no erroneous state transitions.",
+      "rationale": "The task is correctly scheduled with the appropriate watcher kind, trigger, priority, source, and health_signal_observed completion check, and no premature fire or completion logs are present.",
       "usage": {
         "promptTokens": 1427,
-        "completionTokens": 72,
-        "totalTokens": 1499,
-        "cachedTokens": 1408
+        "completionTokens": 92,
+        "totalTokens": 1519,
+        "cachedTokens": 1024
       },
       "tasksObserved": 1,
       "logEntriesObserved": 1
@@ -307,11 +307,11 @@
       "domain": 22,
       "title": "Push notifications",
       "verdict": "pass",
-      "rationale": "The high-priority reminder is correctly scheduled without premature firing or missing required fields, and ladder registration does not require child tasks.",
+      "rationale": "The high‑priority reminder is correctly scheduled with no premature firing or missing required fields, and ladder behavior aligns with lazy evaluation rules.",
       "usage": {
         "promptTokens": 1382,
-        "completionTokens": 85,
-        "totalTokens": 1467,
+        "completionTokens": 83,
+        "totalTokens": 1465,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -321,11 +321,11 @@
       "domain": 23,
       "title": "Remote sessions",
       "verdict": "pass",
-      "rationale": "The task is correctly scheduled with appropriate metadata and no incorrect behavior observed.",
+      "rationale": "The task is correctly scheduled with high priority and metadata, and no firing was required.",
       "usage": {
         "promptTokens": 1395,
-        "completionTokens": 128,
-        "totalTokens": 1523,
+        "completionTokens": 70,
+        "totalTokens": 1465,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -352,8 +352,8 @@
       "rationale": "The task has the required source and ownerVisible fields and remains correctly in scheduled state.",
       "usage": {
         "promptTokens": 1347,
-        "completionTokens": 76,
-        "totalTokens": 1423,
+        "completionTokens": 84,
+        "totalTokens": 1431,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -363,11 +363,11 @@
       "domain": 26,
       "title": "Workflows (event-triggered)",
       "verdict": "pass",
-      "rationale": "The watcher task completed and correctly spawned the audit‑log output task in scheduled state, matching the expected terminal statuses and pipeline behavior.",
+      "rationale": "The watcher completed and correctly spawned a scheduled output child as per pipeline rules",
       "usage": {
         "promptTokens": 1724,
-        "completionTokens": 66,
-        "totalTokens": 1790,
+        "completionTokens": 62,
+        "totalTokens": 1786,
         "cachedTokens": 1024
       },
       "tasksObserved": 2,
@@ -377,11 +377,11 @@
       "domain": 27,
       "title": "Multilingual coverage",
       "verdict": "pass",
-      "rationale": "The reminder was correctly scheduled with locale metadata and no improper failures.",
+      "rationale": "The reminder was correctly scheduled with the Spanish locale metadata and no improper failures.",
       "usage": {
         "promptTokens": 1380,
-        "completionTokens": 71,
-        "totalTokens": 1451,
+        "completionTokens": 74,
+        "totalTokens": 1454,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,
@@ -391,11 +391,11 @@
       "domain": 28,
       "title": "Suspected-but-unconfirmed flows",
       "verdict": "pass",
-      "rationale": "The custom task was scheduled and correctly dismissed with appropriate status and log entries, meeting all required semantics.",
+      "rationale": "The custom task was correctly scheduled and dismissed with appropriate terminal status and log entries",
       "usage": {
         "promptTokens": 1445,
-        "completionTokens": 63,
-        "totalTokens": 1508,
+        "completionTokens": 81,
+        "totalTokens": 1526,
         "cachedTokens": 1024
       },
       "tasksObserved": 1,

--- a/plugins/plugin-personal-assistant/scripts/run-cerebras-journey-eval.mjs
+++ b/plugins/plugin-personal-assistant/scripts/run-cerebras-journey-eval.mjs
@@ -19,13 +19,12 @@ import dotenv from "dotenv";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(here, "..");
-const elizaRoot = path.resolve(packageRoot, "..", "..");
-const elizaRoot = path.resolve(elizaRoot, "..");
+const repoRoot = path.resolve(packageRoot, "..", "..");
+const workspaceRoot = path.dirname(repoRoot);
 
 const envCandidates = [
+  path.join(repoRoot, ".env"),
   path.join(packageRoot, ".env"),
-  path.join(elizaRoot, ".env"),
-  path.join(elizaRoot, ".env"),
 ];
 for (const candidate of envCandidates) {
   if (fs.existsSync(candidate)) {
@@ -53,7 +52,7 @@ const child = spawn(
   "bunx",
   ["vitest", "run", "--config", vitestConfig, testFile],
   {
-    cwd: elizaRoot,
+    cwd: workspaceRoot,
     stdio: "inherit",
     env: process.env,
   },

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -214,6 +214,10 @@ export default defineConfig({
           "index.node.ts",
         ),
       },
+      {
+        find: /^@elizaos\/tui$/,
+        replacement: path.join(elizaRoot, "packages", "tui", "src", "index.ts"),
+      },
       // These packages are imported by @elizaos/core while this suite inlines
       // core. Resolve them through Bun's real package-store path so their own
       // nested dependencies remain visible with preserveSymlinks enabled.


### PR DESCRIPTION
## Summary

Refs #9299. This fixes the existing LifeOps Cerebras journey eval helper so the live gpt-oss-120b audit path is executable from source:

- removes the duplicate `const elizaRoot` declaration and uses one repo root + parent workspace root;
- restores the repo-relative live-e2e paths expected by the shared Vitest config;
- aliases `@elizaos/plugin-scheduling` to source in the live-e2e lane so the PA journey eval does not require prebuilt dist artifacts;
- aliases `@elizaos/tui` to source in the PA unit-test config so spatial/TUI imports do not fail before assertions;
- refreshes `cerebras-journey-eval-results.json` from a live Cerebras run: 28/28 domains pass.

## Verification

- `bun run plugins/plugin-personal-assistant/scripts/verify-cerebras-wiring.ts`
- `bun run /tmp/eliza/plugins/plugin-personal-assistant/scripts/run-cerebras-journey-eval.mjs` via temp symlink matching the real checkout name: 1 file / 29 tests passed; audit JSON shows 28/28 domains pass on Cerebras gpt-oss-120b
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/test/lifeops-optimized-prompts.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test lifeops-optimized-prompts.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/vitest.config.ts packages/test/vitest/real.config.ts plugins/plugin-personal-assistant/scripts/run-cerebras-journey-eval.mjs`
- post-rebase: `bunx @biomejs/biome check ...`, focused optimized-prompt Vitest, `git diff --check origin/develop..HEAD`

## Evidence N/A

- Screenshots/video: test-runner/config repair only; no UI rendering changes.
- Real user trajectory: this PR repairs the live evaluator and includes a fresh live Cerebras audit JSON, not an agent chat/action behavior change.
