### PR TITLE
feat(cloud-api): env-gated feed.elizacloud.ai → Railway reverse-proxy (re-deliver #9301)

### DIFF
--- a/packages/cloud-api/src/index.test.ts
+++ b/packages/cloud-api/src/index.test.ts
@@ -68,4 +68,38 @@ describe("cloud-api worker entrypoint", () => {
       "https://api-staging.elizacloud.ai/api/health",
     );
   });
+
+  test("feed.elizacloud.ai is inert when FEED_ORIGIN_HOST is unset", () => {
+    // No env / empty host => falls through to the cloud-api app (no regression).
+    expect(
+      getFrontendAliasProxyTarget(new URL("https://feed.elizacloud.ai/feed")),
+    ).toBeNull();
+    expect(
+      getFrontendAliasProxyTarget(new URL("https://feed.elizacloud.ai/feed"), {
+        FEED_ORIGIN_HOST: "",
+      }),
+    ).toBeNull();
+  });
+
+  test("proxies feed.elizacloud.ai pages to the Railway origin when configured", () => {
+    const target = getFrontendAliasProxyTarget(
+      new URL("https://feed.elizacloud.ai/markets?marketKind=prediction"),
+      { FEED_ORIGIN_HOST: "feed-web-production.up.railway.app" },
+    );
+
+    expect(target?.toString()).toBe(
+      "https://feed-web-production.up.railway.app/markets?marketKind=prediction",
+    );
+  });
+
+  test("proxies feed /api/* to the SAME Railway origin (single origin, no app/api split)", () => {
+    const target = getFrontendAliasProxyTarget(
+      new URL("https://feed.elizacloud.ai/api/health"),
+      { FEED_ORIGIN_HOST: "feed-web-production.up.railway.app" },
+    );
+
+    expect(target?.toString()).toBe(
+      "https://feed-web-production.up.railway.app/api/health",
+    );
+  });
 });

--- a/packages/cloud-api/src/index.ts
+++ b/packages/cloud-api/src/index.ts
@@ -94,9 +94,30 @@ export function redirectFrontendHost(
   return Response.redirect(targetUrl.toString(), 308);
 }
 
-export function getFrontendAliasProxyTarget(url: URL): URL | null {
+// The Feed app's public host. Feed runs on Railway and serves both its pages and
+// its own `/api/*` from one origin, so the wildcard `*.elizacloud.ai/*` Worker
+// route would otherwise swallow it (see packages/feed/RAILWAY.md). When the
+// operator sets `FEED_ORIGIN_HOST` (the Railway host) this Worker reverse-proxies
+// the host to Railway; unset = inert (request falls through to cloud-api as before).
+const FEED_ALIAS_HOST = "feed.elizacloud.ai";
+
+export function getFrontendAliasProxyTarget(
+  url: URL,
+  env?: { FEED_ORIGIN_HOST?: string },
+): URL | null {
   const hostname = normalizeHostname(url.hostname);
   if (!hostname) return null;
+
+  // Config-gated Feed passthrough. Single origin for pages + API, so no app/api
+  // split. Inert unless FEED_ORIGIN_HOST is set.
+  if (hostname === FEED_ALIAS_HOST) {
+    const feedOrigin = normalizeHostname(env?.FEED_ORIGIN_HOST);
+    if (!feedOrigin) return null;
+    const feedUrl = new URL(url);
+    feedUrl.hostname = feedOrigin;
+    return feedUrl;
+  }
+
   const target = FRONTEND_ALIAS_TARGETS[hostname];
   if (!target) return null;
 
@@ -113,8 +134,12 @@ export function getFrontendAliasProxyTarget(url: URL): URL | null {
 function proxyFrontendAliasRequest(
   request: Request,
   url: URL,
+  env: AppEnv["Bindings"],
 ): Promise<Response> | null {
-  const targetUrl = getFrontendAliasProxyTarget(url);
+  const targetUrl = getFrontendAliasProxyTarget(
+    url,
+    env as { FEED_ORIGIN_HOST?: string },
+  );
   if (!targetUrl) return null;
 
   const headers = new Headers(request.headers);
@@ -162,7 +187,7 @@ export default {
     ctx: ExecutionContext,
   ) => {
     const url = new URL(request.url);
-    const frontendAliasResponse = proxyFrontendAliasRequest(request, url);
+    const frontendAliasResponse = proxyFrontendAliasRequest(request, url, env);
     if (frontendAliasResponse) return frontendAliasResponse;
     const agentProxyResponse = proxyGeneratedAgentRequest(request, env, url);
     if (agentProxyResponse) return agentProxyResponse;

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -346,8 +346,10 @@ workers_dev = false
 # or they hit cloud-api instead of their real backend. The carve-out is a
 # Cloudflare dashboard action (a Worker cannot opt a host out of its own route):
 # add a more-specific Workers route `feed.elizacloud.ai/*` with Worker = None,
-# or set the `feed` DNS record to DNS-only. See packages/feed/RAILWAY.md,
-# "Canonical host: feed.elizacloud.ai".
+# or set the `feed` DNS record to DNS-only. ALTERNATIVELY (CI-deployable, no DNS
+# change): set the `FEED_ORIGIN_HOST` var/secret to the Railway feed host and this
+# Worker reverse-proxies feed.elizacloud.ai → Railway (src/index.ts, inert when
+# unset). See packages/feed/RAILWAY.md, "Canonical host: feed.elizacloud.ai".
 routes = [
   { pattern = "api.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "x402.elizacloud.ai/*", zone_name = "elizacloud.ai" },


### PR DESCRIPTION
## What

The CI-deployable mechanism to make **`feed.elizacloud.ai` serve the Railway Feed app** instead of the cloud-api Worker. Completes the deployment-routing piece of #9301.

> Re-delivery: this shipped in #9424 (merged) but its commit was dropped by a subsequent `develop` force-push. Same change, rebased on the current develop tip.

`feed.elizacloud.ai` is swallowed by cloud-api's `*.elizacloud.ai/*` production Worker route — the Worker had no feed passthrough, so the host fell through to the cloud-api Hono app (returning cloud-api health `{timestamp:<number>,region}` instead of the Feed's `{timestamp:<ISO>,env}`).

This adds a **config-gated alias** to `getFrontendAliasProxyTarget`: when `FEED_ORIGIN_HOST` is set, the Worker reverse-proxies `feed.elizacloud.ai` (pages **and** `/api/*` — single Railway origin) to the Railway host, mirroring the existing `staging.elizacloud.ai` `FRONTEND_ALIAS_TARGETS` path. It streams the upstream response, so **SSE passes through**.

- **Inert when `FEED_ORIGIN_HOST` is unset** → falls through to cloud-api exactly as today (zero regression).
- **CI-deployable** via `wrangler deploy` — set `FEED_ORIGIN_HOST` to the Railway feed host (var/secret) and it's live next deploy. No Cloudflare DNS change.
- The **DNS-only carve-out** (grey-cloud CNAME → Railway, mirroring `headscale`) in `packages/feed/RAILWAY.md` stays the preferred long-term architecture (no Worker hop); this alias is the no-DNS option.

## Tests

`bun test packages/cloud-api/src/index.test.ts` → **9 pass / 0 fail**. New cases: feed alias inert-when-unset, page proxy → Railway origin, `/api/*` → same Railway origin (no app/api split). `typecheck` + biome clean.

## Operator step

Set `FEED_ORIGIN_HOST` (Railway feed-web public host) on the prod Worker → deploy → verify:
`curl -s https://feed.elizacloud.ai/api/health` should return `{"...","timestamp":"<ISO>","env":"production"}` (Feed), not a numeric timestamp + region (cloud-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
