### PR TITLE
test(lifeops): multilingual scenarios — Arabic/Korean/Russian new scripts (#9299 Scope 4)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-arabic.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-arabic.scenario.ts
@@ -1,0 +1,56 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-arabic",
+  title: "Brush teeth from polite Arabic phrasing (RTL)",
+  domain: "tasks",
+  tags: ["lifeops", "tasks", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "whatsapp",
+      title: "LifeOps Brush Teeth Arabic",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth arabic preview",
+      text: "هل يمكنك تذكيري بتنظيف أسناني في الساعة 8 صباحًا و9 مساءً كل يوم؟",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "تنظيف",
+        "أسنان",
+        "تذكير",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth arabic confirm",
+      text: "نعم، من فضلك احفظ روتين تنظيف الأسنان هذا.",
+      responseIncludesAny: ["saved", "brush", "teeth", "حفظ", "أسنان"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-korean.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/brush-teeth-korean.scenario.ts
@@ -1,0 +1,56 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "brush-teeth-korean",
+  title: "Brush teeth from polite Korean phrasing",
+  domain: "tasks",
+  tags: ["lifeops", "tasks", "smoke"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "LifeOps Brush Teeth Korean",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "brush-teeth korean preview",
+      text: "매일 아침 8시랑 저녁 9시에 양치하라고 알려주세요.",
+      responseIncludesAny: [
+        "brush teeth",
+        "brushing habit",
+        "set that up",
+        "양치",
+        "이 닦",
+        "알림",
+      ],
+    },
+    {
+      kind: "message",
+      name: "brush-teeth korean confirm",
+      text: "네, 그 양치 루틴 저장해 주세요.",
+      responseIncludesAny: ["saved", "brush", "teeth", "저장", "양치"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Brush teeth",
+      titleAliases: [
+        "Brush Teeth 8 + 9 Pm",
+        "Brush teeth 8 + 9 pm",
+        "Brush teeth 8 am & 9 pm",
+      ],
+      delta: 1,
+      cadenceKind: "times_per_day",
+      requiredSlots: [{ minuteOfDay: 480 }, { minuteOfDay: 1260 }],
+      requireReminderPlan: true,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/water-russian.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/water-russian.scenario.ts
@@ -1,0 +1,54 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "water-russian",
+  title: "Drink water from Russian phrasing (Cyrillic, neutral)",
+  domain: "tasks",
+  tags: ["lifeops", "tasks"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-agent-skills"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "LifeOps Water Russian",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "water default preview",
+      text: "Помоги мне не забывать пить воду в течение дня.",
+      responseIncludesAny: [
+        "drink water",
+        "water",
+        "reminder",
+        "вода",
+        "воду",
+        "пить",
+        "напомина",
+      ],
+    },
+    {
+      kind: "message",
+      name: "water default confirm",
+      text: "да, сохрани это",
+      responseIncludesAny: ["saved", "drink water", "water", "сохран", "вода"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "interval",
+      requiredEveryMinutes: 180,
+      requiredMaxOccurrencesPerDay: 4,
+      requiredWindows: ["morning", "afternoon", "evening"],
+      requireReminderPlan: true,
+    },
+  ],
+});


### PR DESCRIPTION
## What

Follow-up to #9428 (merged) — extends the multilingual LifeOps scenario coverage to **non-Latin scripts** the merged 14 didn't reach (Latin / Han / Kana only):

| variant | script / language | base |
|---|---|---|
| `brush-teeth-arabic` | Arabic (RTL), polite | brush-teeth-basic |
| `brush-teeth-korean` | Korean (Hangul), polite | brush-teeth-basic |
| `water-russian` | Russian (Cyrillic), neutral | water-default-frequency |

Arabic exercises RTL, Russian exercises Cyrillic, Korean exercises Hangul through the full parse → habit/goal pipeline.

## Contract (identical to #9428)

- Same `lane: "live-only"`, domain, tags, and **byte-identical structural `finalChecks`** (diff-verified): `brush-teeth-basic` → `times_per_day` slots 480 & 1260; `water-default-frequency` → `interval`/180/max-4/morning-afternoon-evening.
- User turns are idiomatic for the register and encode the same times/cadence (AR `8 صباحًا و9 مساءً`, KO `아침 8시랑 저녁 9시` → 480 & 1260; the Russian default-frequency variant introduces no times).
- `responseIncludesAny` keeps base English keywords + adds correct target-language terms.

## Evidence

- All 3 parse + register via `scenario-runner list`; `--validate-scenarios` → `valid: true`; included in the `--lane live-only` selection; biome clean.
- Run for real (with #9428's 14) in the `lifeops-bench` CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
