### PR TITLE
fix(feed): make core-flow e2e cleanup loadable

### DIFF
--- a/packages/feed/packages/db/src/database-service.ts
+++ b/packages/feed/packages/db/src/database-service.ts
@@ -13,7 +13,7 @@
  * ```
  */
 
-import { generateSnowflakeId } from "@feed/shared";
+import { generateSnowflakeId } from "@feed/shared/utils/snowflake";
 import {
   and,
   count,

--- a/packages/feed/packages/db/src/index.ts
+++ b/packages/feed/packages/db/src/index.ts
@@ -89,13 +89,15 @@ export {
 // Drizzle Query Operators
 // ============================================================================
 
-// Re-export snowflake utilities from @feed/shared
+// Re-export snowflake utilities from the concrete module. Playwright validates
+// this barrel during test-file module load; using the shared barrel here can
+// trip named-export resolution before the tests run.
 export {
   generateSnowflakeId,
   isValidSnowflakeId,
   parseSnowflakeId,
   SnowflakeGenerator,
-} from "@feed/shared";
+} from "@feed/shared/utils/snowflake";
 export type { SQL } from "drizzle-orm";
 export {
   aliasedTable,

--- a/packages/feed/packages/shared/package.json
+++ b/packages/feed/packages/shared/package.json
@@ -10,6 +10,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "require": "./src/index.ts"
+    },
+    "./utils/snowflake": {
+      "types": "./src/utils/snowflake.ts",
+      "import": "./src/utils/snowflake.ts",
+      "require": "./src/utils/snowflake.ts"
     }
   },
   "scripts": {

--- a/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
+++ b/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
@@ -42,7 +42,6 @@ import {
   tradingFees,
   users,
 } from "@feed/db";
-import { generateSnowflakeId } from "@feed/shared";
 import { expect, test } from "@playwright/test";
 import {
   type BrowserDevAuthSession,
@@ -59,6 +58,9 @@ const STARTING_BALANCE = 100_000;
 /** A losing NO stake (deposited directly as a Position) so YES wins strictly. */
 const LOSER_NO_SHARES = 200;
 const LOSER_NO_AVG_PRICE = 0.5;
+const SNOWFLAKE_EPOCH = 1_704_067_200_000n;
+const E2E_WORKER_ID = 911n;
+let e2eSnowflakeSequence = 0n;
 
 let serverAvailable = false;
 let authSession: BrowserDevAuthSession | null = null;
@@ -82,6 +84,16 @@ type UserWalletSnapshot = {
 };
 
 let originalUserWallet: UserWalletSnapshot | null = null;
+
+async function generateE2eSnowflakeId(): Promise<string> {
+  e2eSnowflakeSequence = (e2eSnowflakeSequence + 1n) & 4095n;
+  const timestamp = BigInt(Date.now()) - SNOWFLAKE_EPOCH;
+  return (
+    (timestamp << 22n) |
+    (E2E_WORKER_ID << 12n) |
+    e2eSnowflakeSequence
+  ).toString();
+}
 
 async function apiGet<T>(path: string): Promise<T> {
   const response = await fetch(`${BASE_URL}${path}`, {
@@ -215,10 +227,10 @@ async function seedFixtures(userId: string): Promise<void> {
   const now = new Date();
   const endDate = new Date(now.getTime() + 24 * 60 * 60 * 1000); // 1 day out
 
-  seeded.marketId = await generateSnowflakeId();
+  seeded.marketId = await generateE2eSnowflakeId();
   seeded.questionId = seeded.marketId; // shared id convention
-  seeded.loserUserId = await generateSnowflakeId();
-  seeded.loserPositionId = await generateSnowflakeId();
+  seeded.loserUserId = await generateE2eSnowflakeId();
+  seeded.loserPositionId = await generateE2eSnowflakeId();
 
   const [userBeforeTest] = await db
     .select({
@@ -337,9 +349,11 @@ async function teardownFixtures(userId: string): Promise<void> {
     await db
       .delete(tradingFees)
       .where(eq(tradingFees.marketId, seeded.marketId));
-    await db.delete(pointsTransactions).where(
-      sql`${pointsTransactions.metadata} LIKE ${`%"relatedId":"${seeded.marketId}"%`}`,
-    );
+    await db
+      .delete(pointsTransactions)
+      .where(
+        sql`${pointsTransactions.metadata} LIKE ${`%"relatedId":"${seeded.marketId}"%`}`,
+      );
   }
 
   // Positions first (FK-free but logically owned by market + users).
@@ -446,7 +460,10 @@ test.describe("Core loop: bet -> resolve -> PnL", () => {
     const open = snapshot.predictions.positions.find(
       (p) => p.marketId === seeded.marketId,
     );
-    expect(open, "seeded YES position should be in open portfolio").toBeTruthy();
+    expect(
+      open,
+      "seeded YES position should be in open portfolio",
+    ).toBeTruthy();
     if (!open) throw new Error("unreachable");
     expect(open.side).toBe("YES");
     expect(open.shares).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary\n- Fix the Feed DB snowflake re-export path so Playwright can load tests that import @feed/db without tripping the @feed/shared barrel.\n- Add the narrow @feed/shared ./utils/snowflake export used by the DB package.\n- Keep the core-flow e2e fixture IDs test-local and snowflake-shaped, avoiding the fragile shared barrel import in the spec.\n\nFixes follow-up from #9432 for #9301.\n\n## Evidence\n- bun run --cwd packages/feed scripts/typecheck-workspace.ts packages/shared packages/db packages/testing -> passed\n- PLAYWRIGHT_SKIP_WEBSERVER=1 bunx playwright test --config playwright.config.ts --project api-e2e --no-deps e2e/core-flow-bet-resolve-pnl.e2e.test.ts (from packages/feed/packages/testing) -> 4 tests discovered, 4 skipped because no server is running\n- bunx @biomejs/biome check --config-path ../../biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages/shared/package.json packages/db/src/index.ts packages/db/src/database-service.ts packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts RAILWAY.md -> clean apart from pre-existing noNonNullAssertion warnings in untouched database-service.ts bodies\n- git diff --check origin/develop...HEAD -> clean