### PR TITLE
fix(cloud-api): enable Feed production origin proxy

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -377,6 +377,7 @@ NEXT_PUBLIC_APP_URL = "https://elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://elizacloud.ai"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
+FEED_ORIGIN_HOST = "feed-web-production.up.railway.app"
 # Pin the prod Steward tenant explicitly instead of leaning on the implicit
 # DEFAULT_STEWARD_TENANT_ID ("elizacloud") in steward-tenant-config.ts. That
 # implicit fallback is what the prod magic-link bug hinged on — make it explicit


### PR DESCRIPTION
## Summary
- Set the non-secret production Worker var FEED_ORIGIN_HOST=feed-web-production.up.railway.app.
- This activates the already-merged #9437 proxy path for feed.elizacloud.ai so the wildcard elizacloud.ai Worker route stops falling through to the cloud-api app for Feed.

Follow-up for #9301.

## Live verification before this PR
- feed-web-production.up.railway.app/api/health returned Feed health with env=production.
- feed.elizacloud.ai/api/health returned the cloud-api health shape, proving the Worker proxy remained inert without the var.

## Local evidence
- bun test packages/cloud-api/src/index.test.ts -> 9 passed.
- bun run --cwd packages/cloud-api typecheck -> passed.
- bun run --cwd packages/cloud-api lint -> 699 files checked, clean.
- bunx wrangler deploy --env production --dry-run from packages/cloud-api -> passed; dry-run binding list includes FEED_ORIGIN_HOST=feed-web-production.up.railway.app.
- git diff --check -> clean.