### PR TITLE
fix(review): correct GEPA seed shape + harden feed e2e teardown (#9429/#9432 follow-up)

### DIFF
--- a/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
+++ b/packages/feed/packages/testing/e2e/core-flow-bet-resolve-pnl.e2e.test.ts
@@ -80,6 +80,7 @@ type UserWalletSnapshot = {
   lifetimePnL: string;
   earnedPoints: number;
   reputationPoints: number;
+  bonusPoints: number;
   totalFeesPaid: string;
 };
 
@@ -239,6 +240,7 @@ async function seedFixtures(userId: string): Promise<void> {
       lifetimePnL: users.lifetimePnL,
       earnedPoints: users.earnedPoints,
       reputationPoints: users.reputationPoints,
+      bonusPoints: users.bonusPoints,
       totalFeesPaid: users.totalFeesPaid,
     })
     .from(users)
@@ -253,6 +255,7 @@ async function seedFixtures(userId: string): Promise<void> {
     lifetimePnL: String(userBeforeTest.lifetimePnL),
     earnedPoints: userBeforeTest.earnedPoints,
     reputationPoints: userBeforeTest.reputationPoints,
+    bonusPoints: userBeforeTest.bonusPoints,
     totalFeesPaid: String(userBeforeTest.totalFeesPaid),
   };
 
@@ -342,6 +345,26 @@ async function seedFixtures(userId: string): Promise<void> {
 }
 
 async function teardownFixtures(userId: string): Promise<void> {
+  // Restore the SHARED dev-auth user's wallet FIRST. This is the only
+  // cross-run-pollution-critical step, so it must run even if a later
+  // disposable delete throws — leaking a seeded row (unique snowflake marketId,
+  // no collisions) is harmless; leaving the shared user mutated is not.
+  if (originalUserWallet) {
+    await db
+      .update(users)
+      .set({
+        virtualBalance: originalUserWallet.virtualBalance,
+        totalDeposited: originalUserWallet.totalDeposited,
+        lifetimePnL: originalUserWallet.lifetimePnL,
+        earnedPoints: originalUserWallet.earnedPoints,
+        reputationPoints: originalUserWallet.reputationPoints,
+        bonusPoints: originalUserWallet.bonusPoints,
+        totalFeesPaid: originalUserWallet.totalFeesPaid,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
+  }
+
   if (seeded.marketId) {
     await db
       .delete(balanceTransactions)
@@ -368,20 +391,6 @@ async function teardownFixtures(userId: string): Promise<void> {
     await db.delete(positions).where(eq(positions.userId, seeded.loserUserId));
     await db.delete(actorState).where(eq(actorState.id, seeded.loserUserId));
     await db.delete(users).where(inArray(users.id, [seeded.loserUserId]));
-  }
-  if (originalUserWallet) {
-    await db
-      .update(users)
-      .set({
-        virtualBalance: originalUserWallet.virtualBalance,
-        totalDeposited: originalUserWallet.totalDeposited,
-        lifetimePnL: originalUserWallet.lifetimePnL,
-        earnedPoints: originalUserWallet.earnedPoints,
-        reputationPoints: originalUserWallet.reputationPoints,
-        totalFeesPaid: originalUserWallet.totalFeesPaid,
-        updatedAt: new Date(),
-      })
-      .where(eq(users.id, userId));
   }
 }
 

--- a/plugins/plugin-training/scripts/lifeops-gepa-seed.ts
+++ b/plugins/plugin-training/scripts/lifeops-gepa-seed.ts
@@ -26,7 +26,10 @@ import {
   OptimizedPromptService,
   type OptimizedPromptTask,
 } from "@elizaos/core";
-import { getTrainingUseModelAdapter } from "../../plugin-personal-assistant/test/helpers/lifeops-eval-model.ts";
+// Use the in-package training model client. plugin-training ships its own
+// Cerebras/Anthropic adapter precisely so scripts here never import across
+// another package's `test/` boundary (see src/core/cerebras-eval-model.ts).
+import { getTrainingUseModelAdapter } from "../src/core/cerebras-eval-model.ts";
 import {
   createPromptScorer,
   createRuntimeAdapter,
@@ -41,135 +44,102 @@ interface SeedTask {
   dataset: OptimizationExample[];
 }
 
+// The optimized `calendar_extract` prompt AUTO-LOADS into the live calendar
+// planner (plugin-calendar calendar-handler.ts → resolveOptimizedPromptForRuntime
+// (runtime, "calendar_extract", CALENDAR_PLAN_INSTRUCTIONS)), whose output is
+// parsed into a CalendarLlmPlan: { subaction, shouldAct, response, queries,
+// title, tripLocation, timeMin, timeMax, windowLabel }. The seed dataset MUST
+// therefore optimize for that PLAN shape — not a free-form event record — or an
+// --apply'd artifact would emit fields the planner cannot parse and break it.
+//
+// Scoring (scoreStructuredFields) credits the keys present in expectedOutput.
+// We score the deterministic, language-independent ROUTING decision the planner
+// most needs to get right — `subaction` + `shouldAct` — and deliberately omit
+// fields that aren't deterministic from the input alone (timeMin/timeMax need
+// the runtime's date anchors; queries/windowLabel are free-form).
+const CALENDAR_PLAN_FIELDS = [
+  "subaction (one of: feed, next_event, search_events, create_event, update_event, delete_event, trip_window; or null for reply-only)",
+  "shouldAct (boolean; false when the request is too vague to act on)",
+  "response (short natural reply when shouldAct is false, else null)",
+  "queries (array of up to 3 search strings)",
+  "title (optional event title)",
+  "tripLocation (optional place for trip_window)",
+  "timeMin / timeMax (optional ISO 8601 window)",
+  "windowLabel (optional natural-language window label)",
+].join("; ");
+
 const SEED_TASKS: Record<string, SeedTask> = {
-  // calendar_extract — natural-language scheduling request → structured event
-  // JSON. Scored by field agreement (scoreStructuredFields). The baseline is
-  // intentionally terse so GEPA has room to improve recall on date/time/
-  // location/attendees fields across phrasings and languages.
+  // calendar_extract — natural-language request → calendar PLAN (CalendarLlmPlan).
+  // Examples cover the full subaction taxonomy + the shouldAct=false clarify
+  // case, across languages. Scored on subaction + shouldAct.
   calendar_extract: {
     task: "calendar_extract",
-    baseline:
-      "Extract the calendar event from the user message. Output JSON only.",
+    baseline: `Plan the calendar action for the user's request. Return a single JSON object only, with these fields: ${CALENDAR_PLAN_FIELDS}.`,
     dataset: [
       {
-        input: {
-          user: "Set up a dentist appointment on March 3rd at 9am for 30 minutes at Downtown Dental.",
-        },
+        input: { user: "What's on my calendar tomorrow?" },
+        expectedOutput: JSON.stringify({ subaction: "feed", shouldAct: true }),
+      },
+      {
+        input: { user: "What's my next meeting?" },
         expectedOutput: JSON.stringify({
-          title: "Dentist appointment",
-          date: "March 3",
-          startTime: "9:00 AM",
-          endTime: "9:30 AM",
-          location: "Downtown Dental",
+          subaction: "next_event",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: { user: "Find my flight to Denver." },
+        expectedOutput: JSON.stringify({
+          subaction: "search_events",
+          shouldAct: true,
         }),
       },
       {
         input: {
-          user: "Block 2-3pm tomorrow for a 1:1 with Priya in the small conference room.",
+          user: "Set up a dentist appointment on March 3rd at 9am at Downtown Dental.",
         },
         expectedOutput: JSON.stringify({
-          title: "1:1 with Priya",
-          date: "tomorrow",
-          startTime: "2:00 PM",
-          endTime: "3:00 PM",
-          location: "small conference room",
+          subaction: "create_event",
+          shouldAct: true,
         }),
       },
       {
-        input: {
-          user: "Lunch with the Frontier Tower team Friday noon at Tacos El Sol.",
-        },
+        input: { user: "Rename my 2pm standup to sprint sync." },
         expectedOutput: JSON.stringify({
-          title: "Lunch with Frontier Tower team",
-          date: "Friday",
-          startTime: "12:00 PM",
-          endTime: "1:00 PM",
-          location: "Tacos El Sol",
+          subaction: "update_event",
+          shouldAct: true,
         }),
       },
       {
-        input: {
-          user: "Schedule a board prep call next Monday from 4 to 5:30 in the evening, remote.",
-        },
+        input: { user: "Cancel my lunch on Friday." },
         expectedOutput: JSON.stringify({
-          title: "Board prep call",
-          date: "next Monday",
-          startTime: "4:00 PM",
-          endTime: "5:30 PM",
-          location: "remote",
+          subaction: "delete_event",
+          shouldAct: true,
         }),
       },
       {
-        input: {
-          user: "Réserve un rendez-vous chez le médecin mardi à 10h pour une heure à la clinique du centre.",
-        },
+        input: { user: "What's happening while I'm in Tokyo next month?" },
         expectedOutput: JSON.stringify({
-          title: "Rendez-vous médecin",
-          date: "mardi",
-          startTime: "10:00 AM",
-          endTime: "11:00 AM",
-          location: "clinique du centre",
+          subaction: "trip_window",
+          shouldAct: true,
         }),
       },
       {
-        input: {
-          user: "Put a 45-minute gym session on the calendar every day at 7am at the studio.",
-        },
-        expectedOutput: JSON.stringify({
-          title: "Gym session",
-          date: "every day",
-          startTime: "7:00 AM",
-          endTime: "7:45 AM",
-          location: "studio",
-        }),
+        input: { user: "Can you help me with my calendar?" },
+        expectedOutput: JSON.stringify({ subaction: null, shouldAct: false }),
       },
       {
         input: {
-          user: "Coffee with David next Wednesday 8:30am, Blue Bottle on Mission.",
+          user: "Réserve un rendez-vous chez le médecin mardi à 10h à la clinique du centre.",
         },
         expectedOutput: JSON.stringify({
-          title: "Coffee with David",
-          date: "next Wednesday",
-          startTime: "8:30 AM",
-          endTime: "9:00 AM",
-          location: "Blue Bottle on Mission",
+          subaction: "create_event",
+          shouldAct: true,
         }),
       },
       {
-        input: {
-          user: "Investor call Thursday 3pm for an hour, dial-in.",
-        },
-        expectedOutput: JSON.stringify({
-          title: "Investor call",
-          date: "Thursday",
-          startTime: "3:00 PM",
-          endTime: "4:00 PM",
-          location: "dial-in",
-        }),
-      },
-      {
-        input: {
-          user: "Termin beim Friseur am Samstag um 14 Uhr, eine halbe Stunde, im Salon Schmidt.",
-        },
-        expectedOutput: JSON.stringify({
-          title: "Friseurtermin",
-          date: "Samstag",
-          startTime: "2:00 PM",
-          endTime: "2:30 PM",
-          location: "Salon Schmidt",
-        }),
-      },
-      {
-        input: {
-          user: "Family dinner this Sunday 6pm at mom's house.",
-        },
-        expectedOutput: JSON.stringify({
-          title: "Family dinner",
-          date: "this Sunday",
-          startTime: "6:00 PM",
-          endTime: "7:00 PM",
-          location: "mom's house",
-        }),
+        input: { user: "Was steht morgen in meinem Kalender?" },
+        expectedOutput: JSON.stringify({ subaction: "feed", shouldAct: true }),
       },
     ],
   },
@@ -220,6 +190,18 @@ async function main(): Promise<number> {
 
   const generations = Number.parseInt(values.generations ?? "2", 10);
   const population = Number.parseInt(values.population ?? "4", 10);
+  if (!Number.isInteger(generations) || generations < 1) {
+    console.error(
+      `[gepa-seed] --generations must be a positive integer (got "${values.generations}").`,
+    );
+    return 1;
+  }
+  if (!Number.isInteger(population) || population < 1) {
+    console.error(
+      `[gepa-seed] --population must be a positive integer (got "${values.population}").`,
+    );
+    return 1;
+  }
 
   console.log(
     `[gepa-seed] task=${seed.task} dataset=${seed.dataset.length} ` +
@@ -255,6 +237,18 @@ async function main(): Promise<number> {
     return 0;
   }
 
+  // The persisted artifact auto-loads into the live runtime for this task, so
+  // never let --apply DEGRADE the production prompt: refuse to persist unless the
+  // optimized prompt actually beat the baseline on the seed set.
+  if (result.score <= result.baseline) {
+    console.error(
+      `\n[gepa-seed] refusing to persist: optimized score ${result.score.toFixed(3)} ` +
+        `did not beat baseline ${result.baseline.toFixed(3)}. The optimized prompt ` +
+        `auto-loads into the live runtime, so a non-improving artifact is not applied.`,
+    );
+    return 1;
+  }
+
   const artifact: OptimizedPromptArtifact = {
     task: seed.task,
     optimizer: "gepa",
@@ -273,7 +267,9 @@ async function main(): Promise<number> {
     })),
   };
 
-  const service = new OptimizedPromptService({} as never);
+  // Service's runtime arg is optional and setPrompt() only touches the on-disk
+  // store root — no runtime needed (matches scripts/lifeops-gepa-loop.ts).
+  const service = new OptimizedPromptService();
   const path = await service.setPrompt(seed.task, artifact);
   console.log(`\n[gepa-seed] persisted optimized artifact → ${path}`);
   return 0;


### PR DESCRIPTION
Post-merge review fixes from an **8-agent deep review** (22 agents incl. adversarial verification) of #9429 and #9432. Both PRs are already merged; these are the verified follow-up corrections.

## #9429 — GEPA seed optimizer (plugin-training)

- **🔴 Wrong output schema (would break production on `--apply`).** The `calendar_extract` seed dataset optimized for an event record `{title,date,startTime,endTime,location}`, but the **live** `calendar_extract` contract is a `CalendarLlmPlan` `{subaction,shouldAct,queries,title,timeMin,timeMax,windowLabel,...}` (parsed by `plugin-calendar`'s `calendar-handler.ts` → `buildCalendarPlanFromParsed`). An `--apply`'d artifact **auto-loads at boot** and would have emitted fields the planner can't parse → broken calendar planning. Rewrote the seed to the **real plan shape**, scored on the deterministic `subaction` + `shouldAct` routing decision across the full subaction taxonomy + a `shouldAct:false` clarify case + multilingual inputs, with a plan-oriented baseline.
- **🔴 No score-improvement gate.** `--apply` persisted unconditionally. Now **refuses to persist when the optimized score doesn't beat baseline** — the artifact auto-loads into the live runtime, so a non-improving result must never overwrite it.
- **🟠 Cross-`test/`-boundary import.** Imported `getTrainingUseModelAdapter` from `plugin-personal-assistant/test/helpers/` (undeclared cross-plugin dep). plugin-training ships the identical adapter in `src/core/cerebras-eval-model.ts` *specifically to avoid this*; import it from there.
- **🟠 Weak typing / robustness.** `new OptimizedPromptService({} as never)` → `new OptimizedPromptService()` (runtime arg is optional; matches `lifeops-gepa-loop.ts`). `--generations`/`--population` now validated as positive integers (NaN no longer reaches `runGepa`).

## #9432 — feed core-flow e2e teardown

- **🟠 Wallet restore was unguarded and sequenced last.** The shared dev-auth user's wallet restore ran *after* six unguarded deletes; an earlier delete throwing would leave the shared user permanently mutated (cross-run pollution). Restore now runs **first** — leaking a unique-snowflake seeded row is harmless; corrupting the shared user is not. Also snapshot/restore `bonusPoints` (mutated by achievement/points side-effects).

## Review notes (not changed here, deliberately)
- The review confirmed #9432's `RAILWAY.md` deletion is **safe** — it removed a *duplicate* "Canonical host" section; the fuller version is retained in develop. No operator knowledge lost.
- Larger follow-ups the review flagged but out of scope for a safe post-merge fix (no live feed DB to validate): switching the feed e2e to a **throwaway per-run user** (eliminates snapshot/restore entirely) and seeding the **other 7 LifeOps tasks** for #9299 Scope 5.

## Evidence
- biome clean (training script); feed e2e is biome-ignored (feed's own lint runs in CI). Training script parses (bun) + the in-package import resolves + `calendar_extract` is a valid `OptimizedPromptTask`. Feed change is type-safe by construction (`bonusPoints` integer→number, consistent across snapshot/select/assign/restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)