### PR TITLE
fix(voice): make the diarization DER gate real, not a ground-truth copy (#9427)

### DIFF
--- a/packages/app/test/ui-smoke/voice-workbench-diarization.spec.ts
+++ b/packages/app/test/ui-smoke/voice-workbench-diarization.spec.ts
@@ -12,13 +12,20 @@
  * divergence behavior is unit-tested in
  * `packages/ui/src/voice/voice-selftest/voice-workbench-diarization.test.ts`.
  *
+ * The headless lane goes further than these explicit fixture labels: it runs a
+ * real blind acoustic clusterer over per-turn audio and scores it with the
+ * frame-based DER metric — see
+ * `plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts`
+ * and `workbench-logic-services.test.ts` (#9147, #9427).
+ *
  *   bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-diarization.spec.ts
  */
 import { runWorkbenchScenarioSpec } from "./voice-workbench-cases";
 
 runWorkbenchScenarioSpec({
   id: "diarization-two-party",
-  description: "Two speakers alternate; each turn attributed to its label.",
+  description:
+    "Two speakers alternate; each turn attributed to its predicted label.",
   classes: ["diarization"],
   participants: [{ label: "speaker_a", isOwner: true }, { label: "speaker_b" }],
   turns: [

--- a/plugins/plugin-local-inference/src/services/voice/__test-helpers__/synthetic-speech.ts
+++ b/plugins/plugin-local-inference/src/services/voice/__test-helpers__/synthetic-speech.ts
@@ -21,6 +21,21 @@ export interface SpeechFixtureOptions {
 	tailSilenceSec?: number;
 	/** Deterministic seed for the f0 jitter. */
 	seed?: number;
+	/**
+	 * Per-speaker voice colour. Two speakers with different timbres have
+	 * measurably different spectral envelopes, so an acoustic diarizer can tell
+	 * them apart from the audio alone. Omit for the default (shared) voice — the
+	 * VAD/wake-word smoke fixtures don't care who is speaking.
+	 */
+	timbre?: SpeakerTimbre;
+}
+
+/** A speaker's voice colour: fundamental frequency + vocal-tract formants. */
+export interface SpeakerTimbre {
+	/** Base fundamental frequency (Hz) — speaker pitch. */
+	f0Hz: number;
+	/** Three `[centerHz, bandwidthHz]` formants — the vocal-tract resonances. */
+	formants: ReadonlyArray<readonly [number, number]>;
 }
 
 export interface SpeechFixture {
@@ -85,6 +100,57 @@ const DEFAULT_FORMANTS: ReadonlyArray<readonly [number, number]> = [
 	[2600, 120],
 ];
 
+/** The shared (speaker-agnostic) voice used when no `timbre` is supplied. */
+export const DEFAULT_SPEAKER_TIMBRE: SpeakerTimbre = {
+	f0Hz: 110,
+	formants: DEFAULT_FORMANTS,
+};
+
+/**
+ * Deterministic, distinct voice colour for participant `index` of `count`
+ * speakers in a scenario. The speakers are spread EVENLY across a wide
+ * vocal-tract-length (formant-scaling) and pitch range, so every pair in a
+ * scenario is acoustically far apart — a blind acoustic diarizer can split them
+ * from the audio alone — while one participant always gets one timbre, so the
+ * same speaker clusters together. Spreading by position (not by a label hash)
+ * guarantees the separation; two labels could otherwise hash to near-identical
+ * voices and merge.
+ */
+export function speakerTimbreForIndex(
+	index: number,
+	count: number,
+): SpeakerTimbre {
+	const frac = count <= 1 ? 0.5 : index / (count - 1); // 0..1
+	// Vocal-tract scaling 0.72..1.32 (shorter tract → higher formants).
+	const formantScale = 0.72 + frac * 0.6;
+	// Alternate the second formant up/down so even adjacent slots differ in
+	// formant PATTERN (F2 is the most speaker-discriminative resonance), not just
+	// a global shift.
+	const f2Bias = index % 2 === 0 ? 1.06 : 0.94;
+	const formants = DEFAULT_FORMANTS.map(([fc, bw], i) => {
+		const bias = i === 1 ? f2Bias : 1;
+		return [fc * formantScale * bias, bw] as const;
+	});
+	// Pitch 98..202 Hz.
+	const f0Hz = 98 + frac * 104;
+	return { f0Hz, formants };
+}
+
+/**
+ * The agent's own synthetic TTS voice — a fixed timbre, deliberately placed
+ * outside the speaker-seed range so it is acoustically distinct from every
+ * scenario participant. The corpus synthesizes agent-echo turns with this voice,
+ * and the acoustic self-voice gate enrolls it as the agent's imprint.
+ */
+export const AGENT_VOICE_TIMBRE: SpeakerTimbre = {
+	f0Hz: 250,
+	formants: [
+		[1100, 90],
+		[2400, 110],
+		[3800, 150],
+	],
+};
+
 /** Build a `silence + synthesized speech + silence` PCM buffer. */
 export function makeSpeechWithSilenceFixture(
 	opts: SpeechFixtureOptions = {},
@@ -100,12 +166,16 @@ export function makeSpeechWithSilenceFixture(
 	const speechEndSample = Math.floor((leadSec + speechSec) * sampleRate);
 
 	const rng = mulberry32(opts.seed ?? 0xe11a);
-	const bank = new FormantBank(sampleRate, DEFAULT_FORMANTS);
+	const timbre = opts.timbre ?? DEFAULT_SPEAKER_TIMBRE;
+	const bank = new FormantBank(sampleRate, timbre.formants);
 	let phase = 0;
 	for (let i = speechStartSample; i < speechEndSample; i++) {
 		const tInSpeech = (i - speechStartSample) / sampleRate;
+		// Syllable-rate vibrato proportional to the speaker's base pitch (the
+		// original shared voice swung 30 Hz around 110 Hz ≈ ±27%).
 		const f0 =
-			110 + 30 * Math.sin(2 * Math.PI * 5 * tInSpeech) + (rng() - 0.5) * 4;
+			timbre.f0Hz * (1 + 0.27 * Math.sin(2 * Math.PI * 5 * tInSpeech)) +
+			(rng() - 0.5) * 4;
 		phase += f0 / sampleRate;
 		let excitation = 0;
 		if (phase >= 1) {

--- a/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENT_VOICE_TIMBRE,
+	makeSpeechWithSilenceFixture,
+	type SpeakerTimbre,
+	speakerTimbreForIndex,
+} from "./__test-helpers__/synthetic-speech";
+import {
+	extractTimbreEmbedding,
+	OnlineSpeakerClusterer,
+	selfVoiceSimilarity,
+} from "./acoustic-speaker-attribution";
+import { scoreDiarizationTimeline } from "./e2e-harness";
+import { cosineSimilarity } from "./speaker-imprint";
+
+/**
+ * The acoustic speaker attributor (#9427). These tests prove the diarization
+ * gate is NO LONGER tautological: the predicted label comes from the AUDIO, so
+ * it is high only when two clips really sound alike and low when they don't, and
+ * the DER scorer trips on a genuine misattribution. Everything is deterministic
+ * synthetic speech — no model, no network.
+ */
+
+const SR = 16_000;
+function clip(
+	timbre: SpeakerTimbre,
+	seed: number,
+	speechSec = 1,
+): Float32Array {
+	return makeSpeechWithSilenceFixture({
+		sampleRate: SR,
+		leadSilenceSec: 0.05,
+		speechSec,
+		tailSilenceSec: 0.05,
+		seed,
+		timbre,
+	}).pcm;
+}
+
+describe("extractTimbreEmbedding", () => {
+	it("is near-identical for two utterances of the SAME voice", () => {
+		const t = speakerTimbreForIndex(0, 2);
+		const a = extractTimbreEmbedding(clip(t, 1), SR);
+		const b = extractTimbreEmbedding(clip(t, 999, 1.4), SR);
+		expect(cosineSimilarity(a, b)).toBeGreaterThan(0.9);
+	});
+
+	it("clearly separates two DIFFERENT voices", () => {
+		const a = extractTimbreEmbedding(clip(speakerTimbreForIndex(0, 2), 1), SR);
+		const b = extractTimbreEmbedding(clip(speakerTimbreForIndex(1, 2), 1), SR);
+		// Distinct timbres land well below the cluster threshold.
+		expect(cosineSimilarity(a, b)).toBeLessThan(0.5);
+	});
+
+	it("returns a zero vector for silence", () => {
+		const silent = new Float32Array(SR); // 1s of zeros
+		const emb = extractTimbreEmbedding(silent, SR);
+		expect(emb.every((v) => v === 0)).toBe(true);
+	});
+
+	it("is deterministic (byte-stable across calls)", () => {
+		const t = speakerTimbreForIndex(1, 3);
+		expect(extractTimbreEmbedding(clip(t, 7), SR)).toEqual(
+			extractTimbreEmbedding(clip(t, 7), SR),
+		);
+	});
+});
+
+describe("OnlineSpeakerClusterer", () => {
+	it("gives two distinct voices two distinct cluster ids", () => {
+		const c = new OnlineSpeakerClusterer();
+		const a = c.assignAudio(clip(speakerTimbreForIndex(0, 2), 1), SR);
+		const b = c.assignAudio(clip(speakerTimbreForIndex(1, 2), 2), SR);
+		expect(a).not.toBe(b);
+	});
+
+	it("re-uses one cluster for repeated turns of the same voice", () => {
+		const c = new OnlineSpeakerClusterer();
+		const t = speakerTimbreForIndex(0, 2);
+		const first = c.assignAudio(clip(t, 1), SR);
+		const second = c.assignAudio(clip(t, 2, 1.3), SR);
+		const third = c.assignAudio(clip(t, 3, 0.8), SR);
+		expect([second, third]).toEqual([first, first]);
+	});
+
+	it("tracks an A/B/A conversation as spk0/spk1/spk0", () => {
+		const c = new OnlineSpeakerClusterer();
+		const a = speakerTimbreForIndex(0, 2);
+		const b = speakerTimbreForIndex(1, 2);
+		expect([
+			c.assignAudio(clip(a, 1), SR),
+			c.assignAudio(clip(b, 2), SR),
+			c.assignAudio(clip(a, 3), SR),
+		]).toEqual(["spk0", "spk1", "spk0"]);
+	});
+
+	it("returns null for a silent turn (carries no speaker signal)", () => {
+		const c = new OnlineSpeakerClusterer();
+		expect(c.assignAudio(new Float32Array(SR), SR)).toBeNull();
+	});
+});
+
+describe("selfVoiceSimilarity", () => {
+	it("is high for the agent's own voice (an echo) and low for a person", () => {
+		const echo = clip(AGENT_VOICE_TIMBRE, 4242, 1.2);
+		const person = clip(speakerTimbreForIndex(0, 2), 1);
+		expect(selfVoiceSimilarity(echo, SR)).toBeGreaterThan(0.9);
+		expect(selfVoiceSimilarity(person, SR)).toBeLessThan(0.5);
+	});
+
+	it("is 0 for silence", () => {
+		expect(selfVoiceSimilarity(new Float32Array(SR), SR)).toBe(0);
+	});
+});
+
+describe("DER gate is no longer tautological (#9427)", () => {
+	const a = speakerTimbreForIndex(0, 2);
+	const b = speakerTimbreForIndex(1, 2);
+
+	it("PASSES (DER 0) when the clusterer attributes two voices correctly", () => {
+		const c = new OnlineSpeakerClusterer();
+		const turns = [
+			{ expectedLabel: "alice", startMs: 0, endMs: 1000 },
+			{ expectedLabel: "bob", startMs: 1000, endMs: 2000 },
+			{ expectedLabel: "alice", startMs: 2000, endMs: 3000 },
+		];
+		const audio = [clip(a, 1), clip(b, 2), clip(a, 3)];
+		const scored = scoreDiarizationTimeline(
+			turns.map((t, i) => ({
+				...t,
+				predictedLabel: c.assignAudio(audio[i], SR),
+			})),
+			{ maxDer: 0.2 },
+		);
+		expect(scored.der).toBe(0);
+		expect(scored.passed).toBe(true);
+	});
+
+	it("FAILS when two distinct speakers are acoustically merged", () => {
+		// Ground truth says alice then bob, but the SECOND turn's audio is also
+		// alice's voice — the blind clusterer (correctly) merges them, so the DER
+		// gate trips. A tautological gate (predicted = ground-truth label) could
+		// never catch this; this is exactly the defect #9427 closes.
+		const c = new OnlineSpeakerClusterer();
+		const scored = scoreDiarizationTimeline(
+			[
+				{
+					expectedLabel: "alice",
+					predictedLabel: c.assignAudio(clip(a, 1), SR),
+					startMs: 0,
+					endMs: 1000,
+				},
+				{
+					expectedLabel: "bob",
+					predictedLabel: c.assignAudio(clip(a, 2), SR), // alice's voice again
+					startMs: 1000,
+					endMs: 2000,
+				},
+			],
+			{ maxDer: 0.2 },
+		);
+		expect(scored.der).toBeGreaterThan(0.2);
+		expect(scored.passed).toBe(false);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.ts
+++ b/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.ts
@@ -1,0 +1,336 @@
+/**
+ * Model-free acoustic speaker attribution for the Voice Workbench (#9147, #9427).
+ *
+ * The headless decision-logic lane used to copy the ground-truth speaker label
+ * straight into `predictedSpeakerLabel`, so the DER gate compared ground truth
+ * to itself and could never fail (#9427). This module is the real thing it
+ * needed: it derives a speaker label from the AUDIO and nothing else.
+ *
+ *   extractTimbreEmbedding  — a deterministic mean-MFCC voice embedding (the
+ *                             speaker's timbre), via a dependency-free FFT +
+ *                             mel filterbank + DCT. No model, no network.
+ *   OnlineSpeakerClusterer  — blind clustering: each turn is matched to the
+ *                             nearest running speaker centroid by cosine and
+ *                             takes that cluster's id, or seeds a new cluster.
+ *                             It never sees ground truth, so a wrong cluster
+ *                             surfaces as real Diarization Error Rate.
+ *   selfVoiceSimilarity     — cosine of a turn against the agent's own TTS-voice
+ *                             imprint — the acoustic self-echo signal that used
+ *                             to be a hardcoded `0.9`.
+ *
+ * Pure + deterministic (no `Date.now`/`Math.random`), so the gate is byte-stable
+ * in CI yet genuinely able to fail on a misattribution.
+ */
+
+import {
+	AGENT_VOICE_TIMBRE,
+	makeSpeechWithSilenceFixture,
+} from "./__test-helpers__/synthetic-speech";
+import {
+	cosineSimilarity,
+	normalizeVoiceEmbedding,
+	updateVoiceImprintCentroid,
+} from "./speaker-imprint";
+
+const FFT_SIZE = 512;
+const FRAME_LEN = 400; // 25 ms @ 16 kHz
+const HOP = 160; // 10 ms @ 16 kHz
+const N_MELS = 26;
+const MEL_FMIN_HZ = 80;
+/** MFCC coefficients kept (1..N_CEPS); c0 is dropped — it is just frame energy. */
+const N_CEPS = 13;
+
+/**
+ * Cosine at/above which a turn joins an existing speaker cluster. Tuned so that
+ * the same synthetic speaker (even degraded by the corpus's room noise/reverb)
+ * stays in one cluster, while two distinct timbres split — see
+ * `acoustic-speaker-attribution.test.ts`.
+ */
+export const DEFAULT_SPEAKER_CLUSTER_THRESHOLD = 0.5;
+
+/** In-place iterative radix-2 Cooley–Tukey FFT (size must be a power of two). */
+function fftRadix2(re: Float64Array, im: Float64Array): void {
+	const n = re.length;
+	for (let i = 1, j = 0; i < n; i++) {
+		let bit = n >> 1;
+		for (; j & bit; bit >>= 1) j ^= bit;
+		j ^= bit;
+		if (i < j) {
+			const tr = re[i];
+			re[i] = re[j];
+			re[j] = tr;
+			const ti = im[i];
+			im[i] = im[j];
+			im[j] = ti;
+		}
+	}
+	for (let len = 2; len <= n; len <<= 1) {
+		const ang = (-2 * Math.PI) / len;
+		const wRe = Math.cos(ang);
+		const wIm = Math.sin(ang);
+		const half = len >> 1;
+		for (let i = 0; i < n; i += len) {
+			let curRe = 1;
+			let curIm = 0;
+			for (let k = 0; k < half; k++) {
+				const aRe = re[i + k];
+				const aIm = im[i + k];
+				const idx = i + k + half;
+				const bRe = re[idx] * curRe - im[idx] * curIm;
+				const bIm = re[idx] * curIm + im[idx] * curRe;
+				re[i + k] = aRe + bRe;
+				im[i + k] = aIm + bIm;
+				re[idx] = aRe - bRe;
+				im[idx] = aIm - bIm;
+				const nextRe = curRe * wRe - curIm * wIm;
+				curIm = curRe * wIm + curIm * wRe;
+				curRe = nextRe;
+			}
+		}
+	}
+}
+
+function hzToMel(hz: number): number {
+	return 2595 * Math.log10(1 + hz / 700);
+}
+function melToHz(mel: number): number {
+	return 700 * (10 ** (mel / 2595) - 1);
+}
+
+let hannCache: Float64Array | null = null;
+function hannWindow(): Float64Array {
+	if (hannCache) return hannCache;
+	const w = new Float64Array(FRAME_LEN);
+	for (let i = 0; i < FRAME_LEN; i++) {
+		w[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (FRAME_LEN - 1));
+	}
+	hannCache = w;
+	return w;
+}
+
+let melCache: { sampleRate: number; filters: Float64Array[] } | null = null;
+/** Triangular mel filterbank over the `FFT_SIZE/2 + 1` magnitude bins. */
+function melFilterbank(sampleRate: number): Float64Array[] {
+	if (melCache && melCache.sampleRate === sampleRate) return melCache.filters;
+	const nBins = FFT_SIZE / 2 + 1;
+	const melMin = hzToMel(MEL_FMIN_HZ);
+	const melMax = hzToMel(sampleRate / 2);
+	const edges: number[] = [];
+	for (let i = 0; i < N_MELS + 2; i++) {
+		edges.push(melToHz(melMin + ((melMax - melMin) * i) / (N_MELS + 1)));
+	}
+	const binHz = (b: number) => (b * sampleRate) / FFT_SIZE;
+	const filters: Float64Array[] = [];
+	for (let m = 1; m <= N_MELS; m++) {
+		const lo = edges[m - 1];
+		const ctr = edges[m];
+		const hi = edges[m + 1];
+		const f = new Float64Array(nBins);
+		for (let b = 0; b < nBins; b++) {
+			const hz = binHz(b);
+			if (hz >= lo && hz <= ctr && ctr > lo) f[b] = (hz - lo) / (ctr - lo);
+			else if (hz > ctr && hz <= hi && hi > ctr) f[b] = (hi - hz) / (hi - ctr);
+		}
+		filters.push(f);
+	}
+	melCache = { sampleRate, filters };
+	return filters;
+}
+
+/** Sinusoidal cepstral lifter weight; L=22 is the long-standing HTK default. */
+const CEPSTRAL_LIFTER_L = 22;
+let lifterCache: number[] | null = null;
+function cepstralLifter(): number[] {
+	if (lifterCache) return lifterCache;
+	const w: number[] = [];
+	for (let k = 1; k <= N_CEPS; k++) {
+		w.push(
+			1 + (CEPSTRAL_LIFTER_L / 2) * Math.sin((Math.PI * k) / CEPSTRAL_LIFTER_L),
+		);
+	}
+	lifterCache = w;
+	return w;
+}
+
+let dctCache: Float64Array[] | null = null;
+/** DCT-II rows for cepstral coefficients 1..N_CEPS (c0 omitted). */
+function dctRows(): Float64Array[] {
+	if (dctCache) return dctCache;
+	const rows: Float64Array[] = [];
+	for (let k = 1; k <= N_CEPS; k++) {
+		const row = new Float64Array(N_MELS);
+		for (let n = 0; n < N_MELS; n++) {
+			row[n] = Math.cos((Math.PI * k * (n + 0.5)) / N_MELS);
+		}
+		rows.push(row);
+	}
+	dctCache = rows;
+	return rows;
+}
+
+/**
+ * Mean-MFCC voice embedding of a mono PCM clip: the average cepstrum over its
+ * voiced frames, L2-normalized. Captures vocal-tract timbre (the speaker), not
+ * the words. Returns a zero vector for silence / too-short audio.
+ */
+export function extractTimbreEmbedding(
+	pcm: Float32Array,
+	sampleRate: number,
+): number[] {
+	const filters = melFilterbank(sampleRate);
+	const dct = dctRows();
+	const hann = hannWindow();
+	const nBins = FFT_SIZE / 2 + 1;
+
+	// Pass 1: per-frame energy, to keep only voiced frames (relative to the peak).
+	const starts: number[] = [];
+	const energies: number[] = [];
+	let maxEnergy = 0;
+	for (let s = 0; s + FRAME_LEN <= pcm.length; s += HOP) {
+		let e = 0;
+		for (let i = 0; i < FRAME_LEN; i++) {
+			const v = pcm[s + i];
+			e += v * v;
+		}
+		starts.push(s);
+		energies.push(e);
+		if (e > maxEnergy) maxEnergy = e;
+	}
+	if (maxEnergy <= 1e-9) return new Array<number>(N_CEPS).fill(0);
+	const floor = maxEnergy * 0.1;
+
+	const re = new Float64Array(FFT_SIZE);
+	const im = new Float64Array(FFT_SIZE);
+	const accum = new Float64Array(N_CEPS);
+	let voiced = 0;
+	for (let fi = 0; fi < starts.length; fi++) {
+		if (energies[fi] < floor) continue;
+		const s = starts[fi];
+		re.fill(0);
+		im.fill(0);
+		for (let i = 0; i < FRAME_LEN; i++) re[i] = pcm[s + i] * hann[i];
+		fftRadix2(re, im);
+		// Log mel-band energies.
+		const logMel = new Float64Array(N_MELS);
+		for (let m = 0; m < N_MELS; m++) {
+			const filt = filters[m];
+			let acc = 0;
+			for (let b = 0; b < nBins; b++) {
+				const power = re[b] * re[b] + im[b] * im[b];
+				acc += power * filt[b];
+			}
+			logMel[m] = Math.log(acc + 1e-10);
+		}
+		// DCT-II → cepstrum (coefficients 1..N_CEPS).
+		for (let k = 0; k < N_CEPS; k++) {
+			const row = dct[k];
+			let c = 0;
+			for (let n = 0; n < N_MELS; n++) c += logMel[n] * row[n];
+			accum[k] += c;
+		}
+		voiced += 1;
+	}
+	if (voiced === 0) return new Array<number>(N_CEPS).fill(0);
+	const lifter = cepstralLifter();
+	const mean = new Array<number>(N_CEPS);
+	// Sinusoidal liftering de-emphasizes the dominant low-order cepstral tilt (the
+	// glottal source slope, shared by every voice) and emphasizes the mid/high
+	// coefficients that carry the formant pattern — i.e. the speaker signal.
+	for (let k = 0; k < N_CEPS; k++) mean[k] = (accum[k] / voiced) * lifter[k];
+	return normalizeVoiceEmbedding(mean);
+}
+
+function isZeroVector(v: ArrayLike<number>): boolean {
+	for (let i = 0; i < v.length; i++) if (v[i] !== 0) return false;
+	return true;
+}
+
+interface SpeakerCluster {
+	id: string;
+	centroid: number[];
+	count: number;
+}
+
+/**
+ * Blind online speaker clustering. Each turn embedding is matched to the nearest
+ * running centroid; if the best cosine clears the threshold it joins that
+ * cluster (and updates its centroid), otherwise it seeds a new one. The cluster
+ * ids it returns (`spk0`, `spk1`, …) are label-agnostic — DER maps them onto the
+ * ground-truth speakers optimally — so the clusterer never needs (and never
+ * sees) the true labels.
+ */
+export class OnlineSpeakerClusterer {
+	private readonly clusters: SpeakerCluster[] = [];
+	private readonly threshold: number;
+
+	constructor(threshold: number = DEFAULT_SPEAKER_CLUSTER_THRESHOLD) {
+		this.threshold = threshold;
+	}
+
+	/** Assign an embedding to a cluster id, or `null` if it carries no signal. */
+	assign(embedding: ArrayLike<number>): string | null {
+		if (embedding.length === 0 || isZeroVector(embedding)) return null;
+		const emb = normalizeVoiceEmbedding(embedding);
+		let best: SpeakerCluster | null = null;
+		let bestSim = Number.NEGATIVE_INFINITY;
+		for (const cluster of this.clusters) {
+			const sim = cosineSimilarity(emb, cluster.centroid);
+			if (sim > bestSim) {
+				bestSim = sim;
+				best = cluster;
+			}
+		}
+		if (best && bestSim >= this.threshold) {
+			const updated = updateVoiceImprintCentroid({
+				centroidEmbedding: best.centroid,
+				sampleCount: best.count,
+				observationEmbedding: emb,
+			});
+			best.centroid = updated.centroidEmbedding;
+			best.count = updated.sampleCount;
+			return best.id;
+		}
+		const id = `spk${this.clusters.length}`;
+		this.clusters.push({ id, centroid: emb, count: 1 });
+		return id;
+	}
+
+	/** Embed `pcm` and assign it to a cluster id (or `null` for silence). */
+	assignAudio(pcm: Float32Array, sampleRate: number): string | null {
+		return this.assign(extractTimbreEmbedding(pcm, sampleRate));
+	}
+}
+
+let agentVoiceCache: { sampleRate: number; embedding: number[] } | null = null;
+/** The agent's own TTS-voice imprint embedding (memoized per sample rate). */
+function agentVoiceEmbedding(sampleRate: number): number[] {
+	if (agentVoiceCache && agentVoiceCache.sampleRate === sampleRate) {
+		return agentVoiceCache.embedding;
+	}
+	const ref = makeSpeechWithSilenceFixture({
+		sampleRate,
+		leadSilenceSec: 0.05,
+		speechSec: 1.5,
+		tailSilenceSec: 0.05,
+		seed: 0xa6e7,
+		timbre: AGENT_VOICE_TIMBRE,
+	});
+	const embedding = extractTimbreEmbedding(ref.pcm, sampleRate);
+	agentVoiceCache = { sampleRate, embedding };
+	return embedding;
+}
+
+/**
+ * Cosine similarity (clamped to 0..1) of a turn's audio against the agent's own
+ * synthetic-voice imprint. High ⇒ the agent is hearing ITSELF (its TTS bled back
+ * into the mic). This is the acoustic self-echo signal the respond-gate consumes
+ * as `selfVoiceSimilarity` — a real measurement, not a constant.
+ */
+export function selfVoiceSimilarity(
+	pcm: Float32Array,
+	sampleRate: number,
+): number {
+	const emb = extractTimbreEmbedding(pcm, sampleRate);
+	if (isZeroVector(emb)) return 0;
+	return Math.max(0, cosineSimilarity(emb, agentVoiceEmbedding(sampleRate)));
+}

--- a/plugins/plugin-local-inference/src/services/voice/corpus-generator.ts
+++ b/plugins/plugin-local-inference/src/services/voice/corpus-generator.ts
@@ -21,7 +21,12 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { makeSpeechWithSilenceFixture } from "./__test-helpers__/synthetic-speech";
+import {
+	AGENT_VOICE_TIMBRE,
+	makeSpeechWithSilenceFixture,
+	type SpeakerTimbre,
+	speakerTimbreForIndex,
+} from "./__test-helpers__/synthetic-speech";
 import {
 	type AugmentationSpec,
 	augmentPcm,
@@ -207,6 +212,15 @@ export async function generateVoiceCorpus(
 	const participantByLabel = new Map(
 		scenario.participants.map((p) => [p.label, p]),
 	);
+	// Each participant gets a distinct voice colour, spread evenly across the
+	// timbre range so a blind acoustic diarizer can tell co-present speakers apart
+	// from the audio alone (#9427).
+	const timbreByLabel = new Map<string, SpeakerTimbre>(
+		scenario.participants.map((p, i) => [
+			p.label,
+			speakerTimbreForIndex(i, scenario.participants.length),
+		]),
+	);
 
 	const segments: Float32Array[] = [];
 	const labels: CorpusTurnLabel[] = [];
@@ -248,12 +262,19 @@ export async function generateVoiceCorpus(
 				MAX_SPEECH_SEC,
 				Math.max(MIN_SPEECH_SEC, text.length / charsPerSecond),
 			);
+			// An agent-echo turn is the agent's OWN TTS bleeding back through the
+			// mic, so it carries the agent's voice — not the labelled speaker's. Real
+			// speaker turns get their distinct per-speaker timbre (#9427).
+			const timbre = turn.isAgentEcho
+				? AGENT_VOICE_TIMBRE
+				: (timbreByLabel.get(turn.speaker) ?? AGENT_VOICE_TIMBRE);
 			const fixture = makeSpeechWithSilenceFixture({
 				sampleRate,
 				leadSilenceSec: SYNTHETIC_LEAD_SILENCE_SEC,
 				speechSec,
 				tailSilenceSec: SYNTHETIC_TAIL_SILENCE_SEC,
-				seed: labelSeed(turn.speaker),
+				seed: labelSeed(turn.isAgentEcho ? "__agent__" : turn.speaker),
+				timbre,
 			});
 			speech = fixture.pcm;
 			speechStartOffset = fixture.speechStartSample;

--- a/plugins/plugin-local-inference/src/services/voice/e2e-harness.ts
+++ b/plugins/plugin-local-inference/src/services/voice/e2e-harness.ts
@@ -13,6 +13,10 @@
 export { normalizeWerText, wordErrorRate } from "@elizaos/shared/voice-wer";
 
 import { normalizeWerText, wordErrorRate } from "@elizaos/shared/voice-wer";
+import {
+	computeDiarizationErrorRate,
+	type DiarizationSegment,
+} from "./diarization-error-rate";
 import { percentile, round1, round4 } from "./metric-math";
 
 export type VoiceE2eHarnessErrorCode =
@@ -570,6 +574,66 @@ export function scoreDiarization(
 		misses,
 		maxDer,
 		passed: total > 0 && der <= maxDer,
+	};
+}
+
+/** One scored turn for timeline DER: its speech span + predicted/true speaker. */
+export interface DiarizationTurnSample {
+	/** Ground-truth speaker label (the diarization reference). */
+	expectedLabel: string;
+	/** Predicted speaker label from a real attributor, or null when it missed. */
+	predictedLabel: string | null;
+	/** Speech-region start of this turn (ms into the stream). */
+	startMs: number;
+	/** Speech-region end of this turn (ms; must be ≥ startMs). */
+	endMs: number;
+}
+
+/**
+ * Score diarization with the frame-based, label-agnostic {@link
+ * computeDiarizationErrorRate} (#9147) rather than a per-turn string compare.
+ * The predicted labels are an arbitrary cluster-id space (the attributor never
+ * knows the ground-truth names) — DER finds the optimal cluster→speaker mapping,
+ * so a correct partition scores 0 no matter how clusters are named, and a merged
+ * or swapped speaker shows up as real error. `confusions`/`misses` are turn-level
+ * tallies derived from that optimal mapping, for the report.
+ */
+export function scoreDiarizationTimeline(
+	turns: ReadonlyArray<DiarizationTurnSample>,
+	opts: { maxDer?: number } = {},
+): DiarizationResult {
+	const maxDer = opts.maxDer ?? 0.2;
+	const reference: DiarizationSegment[] = turns.map((t) => ({
+		speaker: t.expectedLabel,
+		startMs: t.startMs,
+		endMs: t.endMs,
+	}));
+	const hypothesis: DiarizationSegment[] = turns
+		.filter((t) => t.predictedLabel !== null)
+		.map((t) => ({
+			speaker: t.predictedLabel as string,
+			startMs: t.startMs,
+			endMs: t.endMs,
+		}));
+	const result = computeDiarizationErrorRate(reference, hypothesis);
+	// Turn-level tallies under the optimal mapping (the report's headline is `der`).
+	let confusions = 0;
+	let misses = 0;
+	for (const t of turns) {
+		if (t.predictedLabel === null) {
+			misses += 1;
+		} else if (result.mapping[t.predictedLabel] !== t.expectedLabel) {
+			confusions += 1;
+		}
+	}
+	return {
+		kind: "diarization",
+		total: turns.length,
+		der: round4(result.der),
+		confusions,
+		misses,
+		maxDer,
+		passed: turns.length > 0 && result.der <= maxDer,
 	};
 }
 

--- a/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.ts
@@ -26,7 +26,8 @@ import type {
 	GeneratedVoiceCorpus,
 } from "./corpus-generator";
 import {
-	scoreDiarization,
+	type DiarizationTurnSample,
+	scoreDiarizationTimeline,
 	scoreEchoRejection,
 	scoreEntityExtraction,
 	scoreEotDecision,
@@ -191,10 +192,7 @@ export async function runVoiceScenarioHeadless(
 		expected: boolean;
 		latencyMs?: number;
 	}> = [];
-	const diarSamples: Array<{
-		predictedLabel: string | null;
-		expectedLabel: string;
-	}> = [];
+	const diarTurns: DiarizationTurnSample[] = [];
 	const respondSamples: Array<{ responded: boolean; expectRespond: boolean }> =
 		[];
 	const voiceEntitySamples: Array<{
@@ -256,10 +254,17 @@ export async function runVoiceScenarioHeadless(
 				? { latencyMs: obs.eotLatencyMs }
 				: {}),
 		});
-		diarSamples.push({
-			predictedLabel: obs.predictedSpeakerLabel,
-			expectedLabel: label.speaker,
-		});
+		// Diarization scores REAL speaker turns only — an agent-echo turn is the
+		// agent's own voice bleeding back, not a speaker to attribute, so it is
+		// handled by the echo-rejection scorer instead.
+		if (!label.isAgentEcho) {
+			diarTurns.push({
+				predictedLabel: obs.predictedSpeakerLabel,
+				expectedLabel: label.speaker,
+				startMs: (label.speechStartSample / corpus.sampleRate) * 1000,
+				endMs: (label.speechEndSample / corpus.sampleRate) * 1000,
+			});
+		}
 		respondSamples.push({
 			responded: obs.responded,
 			expectRespond: label.expectRespond,
@@ -303,11 +308,15 @@ export async function runVoiceScenarioHeadless(
 				: {}),
 		}),
 	);
-	cases.push(
-		scoreDiarization(diarSamples, {
-			...(assertions.maxDer !== undefined ? { maxDer: assertions.maxDer } : {}),
-		}),
-	);
+	if (diarTurns.length > 0) {
+		cases.push(
+			scoreDiarizationTimeline(diarTurns, {
+				...(assertions.maxDer !== undefined
+					? { maxDer: assertions.maxDer }
+					: {}),
+			}),
+		);
+	}
 	cases.push(
 		scoreRespondDecision(respondSamples, {
 			...(assertions.minRespondAccuracy !== undefined

--- a/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { generateVoiceCorpus } from "./corpus-generator";
+import type { VoiceScenario } from "./voice-scenario";
 import { buildVoiceWorkbenchReport } from "./voice-workbench-report";
 import { runVoiceScenarioHeadless } from "./workbench-headless-runner";
 import { realDecisionLogicServices } from "./workbench-logic-services";
@@ -21,6 +22,85 @@ describe("realDecisionLogicServices over the built-in scenario matrix", () => {
 		).toEqual([]);
 		expect(report.overall).toBe("pass");
 		expect(report.scenariosRan).toBe(VOICE_WORKBENCH_SCENARIOS.length);
+	});
+
+	it("attributes the multi-speaker scenarios from AUDIO, scoring DER 0", async () => {
+		// The real diarization gate: blind acoustic clustering must partition the
+		// distinct voices correctly — proving `predictedSpeakerLabel` is derived,
+		// not copied from the ground-truth label (#9427).
+		const services = realDecisionLogicServices();
+		for (const id of ["multi-voice-greeting", "multi-speaker-name-capture"]) {
+			const scenario = VOICE_WORKBENCH_SCENARIOS.find((s) => s.id === id);
+			if (!scenario) throw new Error(`scenario ${id} missing`);
+			const corpus = await generateVoiceCorpus(scenario);
+			const run = await runVoiceScenarioHeadless({
+				scenario,
+				corpus,
+				services,
+			});
+			const diar = run.cases.find((c) => c.kind === "diarization");
+			expect(diar, `${id} has a diarization case`).toBeDefined();
+			expect(diar?.kind === "diarization" && diar.der).toBe(0);
+			expect(diar?.passed).toBe(true);
+		}
+	});
+
+	it("the DER gate FAILS on a real misattribution — not a tautology (#9427)", async () => {
+		// Two participants, SAME words so their speech regions are the same length.
+		const scenario: VoiceScenario = {
+			id: "diar-divergence-probe",
+			classes: ["diarization", "multi-speaker"],
+			participants: [
+				{ label: "alice", entityId: "entity-alice" },
+				{ label: "bob", entityId: "entity-bob" },
+			],
+			turns: [
+				{
+					speaker: "alice",
+					text: "eliza what time is it now",
+					expectRespond: true,
+				},
+				{
+					speaker: "bob",
+					text: "eliza what time is it now",
+					expectRespond: true,
+				},
+			],
+			assertions: { maxDer: 0.2 },
+		};
+		const corpus = await generateVoiceCorpus(scenario);
+
+		// Honest: the two distinct voices cluster apart → DER 0, gate passes.
+		const honest = await runVoiceScenarioHeadless({
+			scenario,
+			corpus,
+			services: realDecisionLogicServices(),
+		});
+		const honestDer = honest.cases.find((c) => c.kind === "diarization");
+		expect(honestDer?.der).toBe(0);
+		expect(honestDer?.passed).toBe(true);
+
+		// Tamper ONLY the audio: overwrite bob's speech with alice's voice. Ground
+		// truth still labels the turns alice/bob, so a tautological gate would keep
+		// passing — but the real acoustic clusterer hears one voice, merges the
+		// turns, and the DER gate trips.
+		const [aliceTurn, bobTurn] = corpus.groundTruth.turns;
+		const tamperedPcm = corpus.pcm.slice();
+		tamperedPcm.set(
+			corpus.pcm.subarray(
+				aliceTurn.speechStartSample,
+				aliceTurn.speechEndSample,
+			),
+			bobTurn.speechStartSample,
+		);
+		const tampered = await runVoiceScenarioHeadless({
+			scenario,
+			corpus: { ...corpus, pcm: tamperedPcm },
+			services: realDecisionLogicServices(),
+		});
+		const tamperedDer = tampered.cases.find((c) => c.kind === "diarization");
+		expect(tamperedDer?.der).toBeGreaterThan(0.2);
+		expect(tamperedDer?.passed).toBe(false);
 	});
 
 	it("genuinely SUPPRESSES a confident bystander (not just echoing ground truth)", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.ts
@@ -1,5 +1,5 @@
 /**
- * Voice Workbench real-decision-logic services adapter (#8785).
+ * Voice Workbench real-decision-logic services adapter (#8785, #9427).
  *
  * The ground-truth mock (`groundTruthMockServices`) echoes the corpus labels —
  * it proves the runner → scorers → report wiring, but it can never catch a
@@ -9,15 +9,21 @@
  *   - end-of-turn:        `scoreEndOfTurnHeuristic` (`@elizaos/shared/voice-eot`)
  *   - respond / echo /    `buildVoiceTurnSignal` (`@elizaos/shared/voice/respond-gate`)
  *     bystander / wake-word   — the SAME gate the UI client ships
+ *   - diarization:        `OnlineSpeakerClusterer` clusters each turn BY ITS
+ *                         AUDIO (blind to the ground-truth label), so the DER
+ *                         gate measures a real attribution and can actually fail
+ *                         on a misattribution (#9427).
+ *   - acoustic self-voice: `selfVoiceSimilarity` measures the turn audio against
+ *                         the agent's TTS imprint — the real value the echo gate
+ *                         consumes (no more hardcoded `0.9`).
  *   - name extraction:    the inline patterns below (mirrors IDENTIFY_SPEAKER)
  *
  * — so the workbench catches a regression in the gate the moment it lands. It is
- * CI-runnable with NO models or network: it makes the perfect-ASR /
- * perfect-diarization assumption (transcript + speaker label come from ground
- * truth), so it does NOT measure ASR WER, diarization DER, EOT latency, or
- * acoustic speaker verification — those need the real model lane. What it DOES
- * measure is genuine: EOT decisions, the respond/echo/bystander/wake-word
- * decision, and name extraction.
+ * CI-runnable with NO models or network: it keeps only the perfect-ASR
+ * assumption (the transcript comes from ground truth), so it does NOT measure
+ * ASR WER or EOT latency — those need the real model lane. Everything else is
+ * genuine: EOT decisions, respond/echo/bystander/wake-word, blind speaker
+ * clustering, acoustic self-voice, and name extraction.
  */
 
 import {
@@ -26,6 +32,10 @@ import {
 } from "@elizaos/shared/voice/owner-inference";
 import { buildVoiceTurnSignal } from "@elizaos/shared/voice/respond-gate";
 import { scoreEndOfTurnHeuristic } from "@elizaos/shared/voice-eot";
+import {
+	OnlineSpeakerClusterer,
+	selfVoiceSimilarity,
+} from "./acoustic-speaker-attribution";
 import type { CorpusGroundTruth } from "./corpus-generator";
 import type {
 	VoiceTurnObservation,
@@ -75,21 +85,31 @@ export function realDecisionLogicServices(): VoiceWorkbenchServices {
 	let scenarioId: string | null = null;
 	let lastAgentReply: string | undefined;
 	let ownerObservations: OwnerObservation[] = [];
+	let clusterer = new OnlineSpeakerClusterer();
 
 	return {
-		async observeTurn({ label, groundTruth }): Promise<VoiceTurnObservation> {
-			// New scenario → drop carried-over reply state (the runner reuses one
-			// services instance across the whole matrix).
+		async observeTurn({
+			audio,
+			sampleRate,
+			label,
+			groundTruth,
+		}): Promise<VoiceTurnObservation> {
+			// New scenario → drop carried-over reply state and start a fresh speaker
+			// clustering (the runner reuses one services instance across the matrix).
 			if (groundTruth.scenarioId !== scenarioId || label.index === 0) {
 				scenarioId = groundTruth.scenarioId;
 				lastAgentReply = undefined;
 				ownerObservations = [];
+				clusterer = new OnlineSpeakerClusterer();
 			}
 
-			// Perfect-ASR / perfect-diarization assumption: the transcript and the
-			// speaker identity come from ground truth so the DECISION logic — not
-			// the acoustic models — is what we score here.
+			// Perfect-ASR assumption: the transcript comes from ground truth so the
+			// DECISION logic — not a real ASR model — is what we score here.
 			const transcript = label.referenceTranscript;
+			// Diarization + acoustic self-voice are measured for real, from THIS
+			// turn's audio — never from the ground-truth speaker label (#9427).
+			const predictedSpeakerLabel = clusterer.assignAudio(audio, sampleRate);
+			const selfVoiceSim = selfVoiceSimilarity(audio, sampleRate);
 			const wakeWordActive = WAKE_WORD.test(transcript);
 			const known = knownSpeakerIds(groundTruth);
 
@@ -104,13 +124,12 @@ export function realDecisionLogicServices(): VoiceWorkbenchServices {
 				},
 				wakeWordActive,
 				knownSpeakerEntityIds: known,
-				// Explicitly de-scoped fixture (#9427): in this headless lane no
-				// real speaker-embedding similarity is computed, so an agent-echo
-				// turn is fed a fixed above-threshold value purely to exercise the
-				// downstream self-voice gate's PLUMBING (that it consumes the
-				// signal), NOT to validate acoustic self-voice matching — that
-				// needs a live speaker encoder and belongs to the real-audio lane.
-				...(label.isAgentEcho ? { selfVoiceSimilarity: 0.9 } : {}),
+				// Real acoustic self-voice signal, measured every turn against the
+				// agent's TTS imprint. It clears the gate's threshold only when the
+				// audio actually IS the agent (an echo bleeding back) — this is what
+				// catches a mis-transcribed echo the transcript word-overlap guard
+				// alone would miss, and it is a measurement now, not a constant.
+				selfVoiceSimilarity: selfVoiceSim,
 			});
 			// The server gate suppresses unless `nextSpeaker === "agent"`, which folds
 			// in BOTH the respond/bystander/echo decision AND the EOT gate (a turn that
@@ -152,7 +171,7 @@ export function realDecisionLogicServices(): VoiceWorkbenchServices {
 
 			return {
 				hypothesisTranscript: transcript,
-				predictedSpeakerLabel: label.speaker,
+				predictedSpeakerLabel,
 				eotDecided,
 				responded,
 				inferredEntities,


### PR DESCRIPTION
Closes #9427.

## Root cause

The headless Voice Workbench **DER gate was tautological**. In `realDecisionLogicServices.observeTurn()` (and the plumbing mock), `predictedSpeakerLabel` was set to `label.speaker` — the scenario **ground truth** — and the runner scored that copy against the same field, so `der === 0` always and the gate **could never fail** on a real misattribution.

Three things made it worse:
1. The synthetic corpus gave **every speaker one fixed formant bank** (the per-speaker seed only jittered f0 by ~2 Hz), so no real diarizer could have told speakers apart from the audio anyway.
2. `computeDiarizationErrorRate` (the real, frame-based, overlap-aware DER metric added in #9147) was **dead** — never wired into the workbench path.
3. `echo-mistranscribed` only "passed" because of a hardcoded `selfVoiceSimilarity: 0.9` standing in for a real acoustic measurement — the same class of larp.

## Fix

- **Distinct timbres**: synthetic speakers now get genuinely different voices, spread evenly by participant index so co-present speakers are acoustically far apart. Agent-echo turns carry a dedicated agent voice (`AGENT_VOICE_TIMBRE`).
- **Real attribution** (`acoustic-speaker-attribution.ts`, new): a dependency-free FFT → mel-filterbank → liftered-MFCC voice embedding + **blind online clustering** (reusing the `speaker-imprint` cosine math). It derives `predictedSpeakerLabel` from the **audio** and never sees the ground-truth label.
- **Real metric**: the runner now scores diarization with the frame-based, label-agnostic `computeDiarizationErrorRate` (#9147); agent-echo turns are excluded (they're the agent's own voice — handled by echo-rejection).
- **Real self-voice**: `selfVoiceSimilarity` is now the cosine of the turn audio vs the agent's TTS imprint, replacing the hardcoded `0.9`.
- The headful `voice-workbench-diarization.spec.ts` is **re-scoped honestly** — it covers the player transport path, with a pointer to where diarization correctness is actually gated.

## Evidence (deterministic, no models/network)

`bun run --cwd plugins/plugin-local-inference test` (voice lane): **88 files / 883 pass**. Key new proofs in `acoustic-speaker-attribution.test.ts` + `workbench-logic-services.test.ts`:

- ✅ Two distinct voices → two clusters; same voice across turns → one cluster (A/B/A → `spk0/spk1/spk0`).
- ✅ `selfVoiceSimilarity`: agent echo > 0.9, a person < 0.5.
- ✅ Multi-speaker built-in scenarios are attributed **from audio** with **DER 0**.
- ✅ **The gate now FAILS on a real misattribution**: overwrite one speaker's turn audio with another's → the blind clusterer merges them → DER > maxDer → `passed === false`. A tautological gate could never catch this.

`bun run --cwd plugins/plugin-local-inference typecheck` → clean.

Refs #9147, #9310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)