### PR TITLE
fix(vision): expose declarations for registry typecheck

### DIFF
--- a/packages/ui/src/widgets/WidgetHost.home-launch.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.home-launch.test.tsx
@@ -24,8 +24,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockState = {
   plugins: [] as Array<{ id: string; enabled: boolean; isActive: boolean }>,
   conversations: [
-    { id: "c1", title: "Trip planning", roomId: "r1", createdAt: "x", updatedAt: "2026-06-24T08:00:00.000Z" },
-    { id: "c2", title: "Budget review", roomId: "r2", createdAt: "x", updatedAt: "2026-06-24T07:00:00.000Z" },
+    {
+      id: "c1",
+      title: "Trip planning",
+      roomId: "r1",
+      createdAt: "x",
+      updatedAt: "2026-06-24T08:00:00.000Z",
+    },
+    {
+      id: "c2",
+      title: "Budget review",
+      roomId: "r2",
+      createdAt: "x",
+      updatedAt: "2026-06-24T07:00:00.000Z",
+    },
   ],
   t: (k: string) => k,
 };
@@ -71,7 +83,12 @@ afterEach(() => {
 describe("home WidgetHost on launch (#9304 / #9143)", () => {
   it("mounts the host for the home slot", () => {
     render(
-      <WidgetHost slot="home" layout="grid" events={[]} clearEvents={() => {}} />,
+      <WidgetHost
+        slot="home"
+        layout="grid"
+        events={[]}
+        clearEvents={() => {}}
+      />,
     );
     const host = screen.getByTestId("widget-host-home");
     expect(host.getAttribute("data-slot")).toBe("home");
@@ -83,7 +100,12 @@ describe("home WidgetHost on launch (#9304 / #9143)", () => {
     __ingestNotificationForTests(notification("n2", "PR review requested"), 2);
 
     render(
-      <WidgetHost slot="home" layout="grid" events={[]} clearEvents={() => {}} />,
+      <WidgetHost
+        slot="home"
+        layout="grid"
+        events={[]}
+        clearEvents={() => {}}
+      />,
     );
 
     // Real widgets, resolved by the real registry, rendered into the home host.
@@ -96,13 +118,24 @@ describe("home WidgetHost on launch (#9304 / #9143)", () => {
   it("self-hides every card when there is no data (the #9143 clean home)", () => {
     mockState.conversations = [];
     render(
-      <WidgetHost slot="home" layout="grid" events={[]} clearEvents={() => {}} />,
+      <WidgetHost
+        slot="home"
+        layout="grid"
+        events={[]}
+        clearEvents={() => {}}
+      />,
     );
     expect(screen.queryByTestId("widget-notifications")).toBeNull();
     expect(screen.queryByTestId("widget-messages")).toBeNull();
     // Restore for any later test in the file.
     mockState.conversations = [
-      { id: "c1", title: "Trip planning", roomId: "r1", createdAt: "x", updatedAt: "2026-06-24T08:00:00.000Z" },
+      {
+        id: "c1",
+        title: "Trip planning",
+        roomId: "r1",
+        createdAt: "x",
+        updatedAt: "2026-06-24T08:00:00.000Z",
+      },
     ];
   });
 });

--- a/plugins/plugin-vision/package.json
+++ b/plugins/plugin-vision/package.json
@@ -29,6 +29,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.ts",
       "eliza-source": {
         "types": "./src/index.ts",
         "import": "./src/index.ts",

--- a/plugins/plugin-vision/tsconfig.build.json
+++ b/plugins/plugin-vision/tsconfig.build.json
@@ -1,11 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist",
+    "rootDir": "./src",
     "sourceMap": true,
     "inlineSources": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "noEmit": false
   },


### PR DESCRIPTION
## Summary
- Add a top-level `types` export for `@elizaos/plugin-vision` so TS bundler resolution and plugin-registry consumers can find `dist/index.d.ts`.
- Keep plugin-vision declaration-map emission while preserving the upstream test declaration exclusions.
- Format `WidgetHost.home-launch.test.tsx` so `@elizaos/ui#lint` stays green on current `develop`.

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run --cwd plugins/plugin-vision build`
- `bun run --cwd plugins/plugin-registry typecheck`
- `bun run --cwd packages/ui lint`
- `find plugins/plugin-vision/dist -name "*.test.d.ts" | wc -l` -> `0`
- `git diff --check origin/develop...HEAD`
- `bun run verify` -> `509 successful, 509 total`

## Notes
- No UI runtime behavior changed; the UI file is test-only formatting.