### PR TITLE
fix(feed): suppress live Feed asset and telemetry 404s

### DIFF
--- a/packages/cloud-api/src/index.test.ts
+++ b/packages/cloud-api/src/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { getFrontendAliasProxyTarget, redirectFrontendHost } from "./index";
+import {
+  getFrontendAliasProxyTarget,
+  getFrontendAliasSyntheticResponse,
+  redirectFrontendHost,
+} from "./index";
 
 describe("cloud-api worker entrypoint", () => {
   test("redirects www frontend host to apex without dropping path or query", () => {
@@ -101,5 +105,36 @@ describe("cloud-api worker entrypoint", () => {
     expect(target?.toString()).toBe(
       "https://feed-web-production.up.railway.app/api/health",
     );
+  });
+
+  test("serves empty Feed observability scripts instead of proxying Vercel-only 404s", async () => {
+    const response = getFrontendAliasSyntheticResponse(
+      new URL("https://feed.elizacloud.ai/_vercel/insights/script.js"),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toContain(
+      "application/javascript",
+    );
+    expect(await response?.text()).toBe("");
+  });
+
+  test("redirects missing Feed preset PFP assets to the bundled fallback image", () => {
+    const response = getFrontendAliasSyntheticResponse(
+      new URL("https://feed.elizacloud.ai/assets/user-pfps/pfp-041.png"),
+    );
+
+    expect(response?.status).toBe(302);
+    expect(response?.headers.get("location")).toBe(
+      "https://feed.elizacloud.ai/blankmonkey.png",
+    );
+  });
+
+  test("does not synthesize responses for non-Feed aliases", () => {
+    expect(
+      getFrontendAliasSyntheticResponse(
+        new URL("https://staging.elizacloud.ai/_vercel/insights/script.js"),
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/cloud-api/src/index.ts
+++ b/packages/cloud-api/src/index.ts
@@ -100,6 +100,11 @@ export function redirectFrontendHost(
 // operator sets `FEED_ORIGIN_HOST` (the Railway host) this Worker reverse-proxies
 // the host to Railway; unset = inert (request falls through to cloud-api as before).
 const FEED_ALIAS_HOST = "feed.elizacloud.ai";
+const FEED_OBSERVABILITY_SCRIPT_PATHS = new Set([
+  "/_vercel/insights/script.js",
+  "/_vercel/speed-insights/script.js",
+]);
+const FEED_PRESET_PFP_PATTERN = /^\/assets\/user-pfps\/pfp-\d{3}\.png$/;
 
 export function getFrontendAliasProxyTarget(
   url: URL,
@@ -131,11 +136,38 @@ export function getFrontendAliasProxyTarget(
   return targetUrl;
 }
 
+export function getFrontendAliasSyntheticResponse(url: URL): Response | null {
+  const hostname = normalizeHostname(url.hostname);
+  if (hostname !== FEED_ALIAS_HOST) return null;
+
+  if (FEED_OBSERVABILITY_SCRIPT_PATHS.has(url.pathname)) {
+    return new Response("", {
+      status: 200,
+      headers: {
+        "content-type": "application/javascript; charset=utf-8",
+        "cache-control": "public, max-age=3600",
+      },
+    });
+  }
+
+  if (FEED_PRESET_PFP_PATTERN.test(url.pathname)) {
+    const fallbackUrl = new URL(url);
+    fallbackUrl.pathname = "/blankmonkey.png";
+    fallbackUrl.search = "";
+    return Response.redirect(fallbackUrl.toString(), 302);
+  }
+
+  return null;
+}
+
 function proxyFrontendAliasRequest(
   request: Request,
   url: URL,
   env: AppEnv["Bindings"],
 ): Promise<Response> | null {
+  const syntheticResponse = getFrontendAliasSyntheticResponse(url);
+  if (syntheticResponse) return Promise.resolve(syntheticResponse);
+
   const targetUrl = getFrontendAliasProxyTarget(
     url,
     env as { FEED_ORIGIN_HOST?: string },

--- a/packages/feed/apps/web/README.md
+++ b/packages/feed/apps/web/README.md
@@ -4,6 +4,7 @@ Next.js application: UI, API routes, SSE, auth wiring, and Vercel Analytics/Spee
 
 ## Observability
 
+- **Vercel Analytics / Speed Insights** are opt-in via `NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY=1`. Railway production leaves this unset so `_vercel/*` scripts are not mounted from a non-Vercel host.
 - **Vercel Speed Insights** (real-user Web Vitals) is wrapped in **`GatedSpeedInsights`**: route allowlist + session sampling + optional disable for minimal/embed layout.
 - **Why documented centrally:** Operators tune sampling without reading layout code; rationale for allowlists and defaults lives in one place.
 

--- a/packages/feed/apps/web/src/components/layout/FullAppShellClient.tsx
+++ b/packages/feed/apps/web/src/components/layout/FullAppShellClient.tsx
@@ -10,6 +10,9 @@ import { BottomNav } from "@/components/shared/BottomNav";
 import { MobileHeader } from "@/components/shared/MobileHeader";
 import { Sidebar } from "@/components/shared/Sidebar";
 
+const ENABLE_VERCEL_OBSERVABILITY =
+  process.env.NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY === "1";
+
 export function FullAppShellClient({
   children,
 }: {
@@ -57,8 +60,12 @@ export function FullAppShellClient({
           <FeedAuthBanner />
         </Suspense>
       </div>
-      <Analytics />
-      <GatedSpeedInsights />
+      {ENABLE_VERCEL_OBSERVABILITY ? (
+        <>
+          <Analytics />
+          <GatedSpeedInsights />
+        </>
+      ) : null}
     </Providers>
   );
 }

--- a/packages/feed/packages/shared/src/utils/assets.ts
+++ b/packages/feed/packages/shared/src/utils/assets.ts
@@ -58,6 +58,28 @@ export function getStaticAssetUrl(path: string, cdnBaseUrl?: string): string {
 export const TOTAL_AGENT_DEFAULT_PROFILE_PICTURES = 150;
 
 const AGENT_DEFAULT_PROFILE_DIR = "/assets/user-pfps";
+const BUNDLED_DEFAULT_PROFILE_IMAGE = "/blankmonkey.png";
+
+function hasStaticAssetsCdn(cdnBaseUrl?: string): boolean {
+  return Boolean(
+    cdnBaseUrl ||
+      (typeof process !== "undefined" &&
+        process.env.NEXT_PUBLIC_STATIC_ASSETS_URL),
+  );
+}
+
+function getPresetProfileImageUrl(
+  index1Based: number,
+  cdnBaseUrl?: string,
+): string {
+  if (!hasStaticAssetsCdn(cdnBaseUrl)) {
+    return getStaticAssetUrl(BUNDLED_DEFAULT_PROFILE_IMAGE);
+  }
+  return getStaticAssetUrl(
+    `${AGENT_DEFAULT_PROFILE_DIR}/pfp-${String(index1Based).padStart(3, "0")}.png`,
+    cdnBaseUrl,
+  );
+}
 
 /**
  * Get deterministic fallback profile image based on ID
@@ -78,10 +100,7 @@ export function getFallbackProfileImageUrl(
     0,
   );
   const profileNum = (hash % TOTAL_AGENT_DEFAULT_PROFILE_PICTURES) + 1;
-  return getStaticAssetUrl(
-    `${AGENT_DEFAULT_PROFILE_DIR}/pfp-${String(profileNum).padStart(3, "0")}.png`,
-    cdnBaseUrl,
-  );
+  return getPresetProfileImageUrl(profileNum, cdnBaseUrl);
 }
 
 /**
@@ -96,10 +115,7 @@ export function getAgentDefaultProfileImageUrl(
     TOTAL_AGENT_DEFAULT_PROFILE_PICTURES,
     Math.max(1, Math.floor(index1Based)),
   );
-  return getStaticAssetUrl(
-    `${AGENT_DEFAULT_PROFILE_DIR}/pfp-${String(n).padStart(3, "0")}.png`,
-    cdnBaseUrl,
-  );
+  return getPresetProfileImageUrl(n, cdnBaseUrl);
 }
 
 /** Uniform random index in 1..TOTAL_AGENT_DEFAULT_PROFILE_PICTURES for new agent avatars. */

--- a/packages/feed/packages/testing/unit/shared/assets.test.ts
+++ b/packages/feed/packages/testing/unit/shared/assets.test.ts
@@ -103,20 +103,36 @@ describe("Asset URL Utilities", () => {
   });
 
   describe("getFallbackProfileImageUrl", () => {
-    it("should generate deterministic fallback URL based on ID", () => {
-      const url1 = getFallbackProfileImageUrl("user123");
-      const url2 = getFallbackProfileImageUrl("user123");
-      expect(url1).toBe(url2);
+    it("should use the bundled fallback when no static assets CDN is configured", () => {
+      expect(getFallbackProfileImageUrl("user123")).toBe("/blankmonkey.png");
     });
 
-    it("should generate different URLs for different IDs", () => {
-      const url1 = getFallbackProfileImageUrl("user123");
-      const url2 = getFallbackProfileImageUrl("user456");
+    it("should generate deterministic CDN fallback URL based on ID", () => {
+      const cdn = "https://cdn.example.com";
+      const url1 = getFallbackProfileImageUrl("user123", cdn);
+      const url2 = getFallbackProfileImageUrl("user123", cdn);
+      const url3 = getFallbackProfileImageUrl("user123", cdn);
+      expect(url1).toBe(url2);
+      expect(url2).toBe(url3);
+    });
+
+    it("should generate different CDN URLs for different IDs", () => {
+      const url1 = getFallbackProfileImageUrl(
+        "user123",
+        "https://cdn.example.com",
+      );
+      const url2 = getFallbackProfileImageUrl(
+        "user456",
+        "https://cdn.example.com",
+      );
       expect(url1).not.toBe(url2);
     });
 
-    it("should generate profile number between 1 and TOTAL_AGENT_DEFAULT_PROFILE_PICTURES", () => {
-      const url = getFallbackProfileImageUrl("test-id");
+    it("should generate CDN profile number between 1 and TOTAL_AGENT_DEFAULT_PROFILE_PICTURES", () => {
+      const url = getFallbackProfileImageUrl(
+        "test-id",
+        "https://cdn.example.com",
+      );
       const match = url.match(/pfp-(\d+)\.png$/);
       expect(match).toBeTruthy();
       const captured = match?.[1];
@@ -138,22 +154,21 @@ describe("Asset URL Utilities", () => {
   });
 
   describe("getAgentDefaultProfileImageUrl", () => {
-    it("should return user-pfps path for valid index (zero-padded)", () => {
-      expect(getAgentDefaultProfileImageUrl(7)).toBe(
-        "/assets/user-pfps/pfp-007.png",
-      );
+    it("should use the bundled fallback without a static assets CDN", () => {
+      expect(getAgentDefaultProfileImageUrl(7)).toBe("/blankmonkey.png");
     });
 
-    it("should clamp index to 1..TOTAL_AGENT_DEFAULT_PROFILE_PICTURES", () => {
-      expect(getAgentDefaultProfileImageUrl(0)).toBe(
-        "/assets/user-pfps/pfp-001.png",
+    it("should clamp CDN preset index to 1..TOTAL_AGENT_DEFAULT_PROFILE_PICTURES", () => {
+      expect(getAgentDefaultProfileImageUrl(0, "https://cdn.example.com")).toBe(
+        "https://cdn.example.com/assets/user-pfps/pfp-001.png",
       );
       expect(
         getAgentDefaultProfileImageUrl(
           TOTAL_AGENT_DEFAULT_PROFILE_PICTURES + 50,
+          "https://cdn.example.com",
         ),
       ).toBe(
-        `/assets/user-pfps/pfp-${String(TOTAL_AGENT_DEFAULT_PROFILE_PICTURES).padStart(3, "0")}.png`,
+        `https://cdn.example.com/assets/user-pfps/pfp-${String(TOTAL_AGENT_DEFAULT_PROFILE_PICTURES).padStart(3, "0")}.png`,
       );
     });
 


### PR DESCRIPTION
## Summary
- Add Worker-side Feed alias guards for Vercel-only telemetry script URLs and missing preset PFP asset URLs seen during live QA.
- Gate Feed web Vercel Analytics and Speed Insights behind NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY=1 so Railway builds do not mount _vercel scripts by default.
- Make Feed shared profile-image fallbacks use the bundled fallback image unless a static-assets CDN is configured, while preserving numbered PFP URLs for CDN-backed deployments.

Follow-up for #9301 after live browser QA.

## Live QA finding before this PR
- feed.elizacloud.ai served Feed after #9440 deploy, but browser QA still reported 404s for _vercel/insights/script.js, _vercel/speed-insights/script.js, and /assets/user-pfps/pfp-041.png plus pfp-037.png.

## Local evidence
- bun test packages/cloud-api/src/index.test.ts -> 12 passed.
- bun run --cwd packages/cloud-api typecheck -> passed.
- bun run --cwd packages/cloud-api lint -> 699 files checked, clean.
- bun test packages/feed/packages/testing/unit/shared/assets.test.ts -> 40 passed.
- bun run --cwd packages/feed scripts/typecheck-workspace.ts packages/shared packages/testing apps/web -> passed.
- bunx wrangler deploy --env production --dry-run from packages/cloud-api -> passed with FEED_ORIGIN_HOST binding.
- git diff --check -> clean.