### PR TITLE
ci(dev-smoke): capture Playwright artifacts on failure (diagnose composer-never-paints)

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -131,3 +131,17 @@ jobs:
 
       - name: Run bun dev onboarding chat smoke
         run: bun run --cwd packages/app test:dev-smoke
+
+      # The smoke has historically failed inside gotoChatComposer (the /chat
+      # composer never paints) with no captured renderer state, making the
+      # actual blocking gate impossible to pin down. Upload the Playwright
+      # trace/screenshot/error-context so the failure is diagnosable.
+      - name: Upload dev-smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: dev-smoke-results
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore


### PR DESCRIPTION
Follow-up to #9445 (merged — fixed typecheck / windows app-core / coverage + e2e ship gates).

## The remaining red lane: dev-smoke
`dev-smoke.yml` ("bun run dev onboarding chat") is red **every time it actually executes** (it path-gate-skips otherwise, and `test.skip`s entirely without a live provider key). The dominant, deterministic, branch-independent failure is inside `gotoChatComposer` (`packages/app/test/dev-smoke/live-onboarding.ts:197`):

```
expect(locator).toBeVisible() failed
Locator: [data-testid="chat-composer-textarea"], textarea[aria-label="message"]
Timeout: 90000ms  (retried 3× ≈ 270s)
```

The API boots and onboarding completes (`/api/health` ready, `/api/first-run/status` complete), but the `/chat` renderer never paints the composer — it sits behind App.tsx’s `isShellPaintableNow` startup/agent-warmup gate and the `/api/auth/me` auth gate, which the harness’s `seedCompletedFirstRunStorage` does not appear to clear in the CI dev-server.

## Why this PR does NOT change the test/app logic
The lane currently uploads **no artifacts on failure**, so the renderer state (error-context.md + screenshot proving *which* gate blocks — StartupScreen vs LoginView vs composer-absent) is unrecoverable. Editing `live-onboarding.ts` / the shell-gating without that trace would be a blind guess, and the failure needs a live provider key + full `bun run dev` + Playwright boot that cannot be reproduced or verified outside CI.

So this PR adds **only** the safe, zero-risk diagnostic step (mirrors the sibling `scenario-pr.yml` artifact upload, same pinned `actions/upload-artifact` SHA). Once a failing run uploads its trace, the exact blocking gate can be pinned and fixed safely in a follow-up.

## Verification
YAML validated. No test/app behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)