### PR TITLE
feat(vision): tesseract OCR ships + works on-device — desktop bundle + Android Tesseract4Android (#9105)

### DIFF
--- a/plugins/plugin-vision/scripts/vendor-tesseract-linux.mjs
+++ b/plugins/plugin-vision/scripts/vendor-tesseract-linux.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Stage a PORTABLE tesseract into the app bundle so on-device/desktop OCR
+ * "just ships and works" with no host `apt install tesseract-ocr` (#9105).
+ *
+ * Output layout (consumed by `ocr-service-linux-tesseract.ts` `resolveTesseract`
+ * via `ELIZA_VISION_VENDOR_DIR`):
+ *
+ *   <out>/tesseract/
+ *     bin/tesseract                 the CLI
+ *     lib/libtesseract.so* liblept.so*   the shared libs (rest come from the host)
+ *     tessdata/<lang>.traineddata   the language model(s)
+ *     tessdata/configs/tsv ...      REQUIRED — tesseract reads the `tsv` output
+ *                                   config from here; without configs/ the
+ *                                   `tsv` arg silently fails ("Can't open tsv")
+ *                                   and the OCR returns zero rows.
+ *
+ * Linux x64 only (the desktop build host). macOS uses Apple Vision, Windows uses
+ * Windows.Media.Ocr, Android uses the native Tesseract4Android bridge — each
+ * provider is platform-resolved in plugin-vision/src/index.ts.
+ *
+ * Usage: node scripts/vendor-tesseract-linux.mjs [--out <dir>] [--langs eng,...]
+ * Build-time prereq: `apt-get download` works (no sudo needed — it only fetches
+ * .debs); `dpkg-deb` extracts them. Run on the Linux build host.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+const outDir = arg("--out", join(here, "..", "vendor"));
+const langs = arg("--langs", "eng")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const dest = join(outDir, "tesseract");
+
+if (process.platform !== "linux") {
+  console.log(
+    `[vendor-tesseract] non-linux host (${process.platform}); skipping (platform provider handles OCR).`,
+  );
+  process.exit(0);
+}
+
+const work = mkdtempSync(join(tmpdir(), "vendor-tess-"));
+const pkgs = [
+  "tesseract-ocr",
+  "libtesseract5",
+  "liblept5",
+  ...langs.map((l) => `tesseract-ocr-${l}`),
+];
+console.log(`[vendor-tesseract] downloading: ${pkgs.join(", ")}`);
+execFileSync("apt-get", ["download", ...pkgs], { cwd: work, stdio: "inherit" });
+
+const root = join(work, "root");
+for (const deb of readdirSync(work).filter((f) => f.endsWith(".deb"))) {
+  execFileSync("dpkg-deb", ["-x", join(work, deb), root], { stdio: "inherit" });
+}
+
+mkdirSync(join(dest, "bin"), { recursive: true });
+mkdirSync(join(dest, "lib"), { recursive: true });
+mkdirSync(join(dest, "tessdata"), { recursive: true });
+
+cpSync(join(root, "usr/bin/tesseract"), join(dest, "bin/tesseract"));
+const libDir = join(root, "usr/lib/x86_64-linux-gnu");
+for (const so of readdirSync(libDir).filter((f) =>
+  /^(libtesseract|liblept)\.so/.test(f),
+)) {
+  cpSync(join(libDir, so), join(dest, "lib", so), { dereference: false });
+}
+// tessdata lives under usr/share/tesseract-ocr/<ver>/tessdata — copy the WHOLE
+// dir (traineddata + the REQUIRED configs/ + tessconfigs/).
+const shareTess = join(root, "usr/share/tesseract-ocr");
+const ver = readdirSync(shareTess).find((d) =>
+  existsSync(join(shareTess, d, "tessdata")),
+);
+if (!ver)
+  throw new Error(
+    "[vendor-tesseract] tessdata not found in downloaded package",
+  );
+cpSync(join(shareTess, ver, "tessdata"), join(dest, "tessdata"), {
+  recursive: true,
+});
+
+if (!existsSync(join(dest, "tessdata", "configs", "tsv"))) {
+  throw new Error(
+    "[vendor-tesseract] tessdata/configs/tsv missing — TSV OCR output would fail",
+  );
+}
+for (const l of langs) {
+  if (!existsSync(join(dest, "tessdata", `${l}.traineddata`))) {
+    throw new Error(`[vendor-tesseract] ${l}.traineddata missing`);
+  }
+}
+console.log(
+  `[vendor-tesseract] staged portable tesseract → ${dest} (langs: ${langs.join(", ")})`,
+);
+console.log(
+  `[vendor-tesseract] set ELIZA_VISION_VENDOR_DIR=${outDir} so the runtime resolves it.`,
+);

--- a/plugins/plugin-vision/src/ocr-service-linux-tesseract.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-linux-tesseract.test.ts
@@ -7,11 +7,16 @@
  * host with `tesseract-ocr` present, so we don't exercise it here.
  */
 
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  _resetTesseractAvailabilityForTests,
   LinuxTesseractOcrService,
   mapTesseractTsvToResult,
   parseTesseractTsv,
+  resolveTesseract,
 } from "./ocr-service-linux-tesseract.js";
 
 // A realistic `tesseract <img> stdout --psm 11 tsv` fixture. Columns:
@@ -126,5 +131,73 @@ describe("LinuxTesseractOcrService", () => {
       // way the probe must return a boolean and never throw.
       expect(typeof LinuxTesseractOcrService.isAvailable()).toBe("boolean");
     }
+  });
+});
+
+// #9105: the provider must resolve a SHIPPED tesseract (no host install) so OCR
+// "just works" on a packaged desktop app — verified by exercising the env
+// precedence + the bundled-layout resolution.
+describe("resolveTesseract — ships without a host install", () => {
+  const saved = {
+    bin: process.env.ELIZA_TESSERACT_BIN,
+    vendor: process.env.ELIZA_VISION_VENDOR_DIR,
+    ld: process.env.LD_LIBRARY_PATH,
+  };
+  beforeEach(() => {
+    delete process.env.ELIZA_TESSERACT_BIN;
+    delete process.env.ELIZA_VISION_VENDOR_DIR;
+    _resetTesseractAvailabilityForTests();
+  });
+  afterEach(() => {
+    for (const [k, v] of [
+      ["ELIZA_TESSERACT_BIN", saved.bin],
+      ["ELIZA_VISION_VENDOR_DIR", saved.vendor],
+      ["LD_LIBRARY_PATH", saved.ld],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    _resetTesseractAvailabilityForTests();
+  });
+
+  it("falls back to PATH `tesseract` with no env (legacy system install)", () => {
+    expect(resolveTesseract()).toEqual({ bin: "tesseract", env: {} });
+  });
+
+  it("honors an explicit ELIZA_TESSERACT_BIN override", () => {
+    process.env.ELIZA_TESSERACT_BIN = "/opt/custom/tesseract";
+    expect(resolveTesseract()).toEqual({
+      bin: "/opt/custom/tesseract",
+      env: {},
+    });
+  });
+
+  it("resolves a bundled tesseract (bin + LD_LIBRARY_PATH + TESSDATA_PREFIX) from the vendor dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vendor-tess-"));
+    const root = join(dir, "tesseract");
+    mkdirSync(join(root, "bin"), { recursive: true });
+    writeFileSync(join(root, "bin", "tesseract"), "#!/bin/sh\n");
+    process.env.ELIZA_VISION_VENDOR_DIR = dir;
+    process.env.LD_LIBRARY_PATH = "/pre/existing";
+    const r = resolveTesseract();
+    expect(r.bin).toBe(join(root, "bin", "tesseract"));
+    expect(r.env.TESSDATA_PREFIX).toBe(join(root, "tessdata"));
+    // Bundle lib dir is PREPENDED so the shipped libtesseract/liblept win.
+    expect(r.env.LD_LIBRARY_PATH).toBe(`${join(root, "lib")}:/pre/existing`);
+  });
+
+  it("falls back to PATH when the vendor dir has no bundled binary", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vendor-empty-"));
+    process.env.ELIZA_VISION_VENDOR_DIR = dir;
+    expect(resolveTesseract()).toEqual({ bin: "tesseract", env: {} });
+  });
+
+  it("the explicit binary override wins over a vendor dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vendor-tess-"));
+    mkdirSync(join(dir, "tesseract", "bin"), { recursive: true });
+    writeFileSync(join(dir, "tesseract", "bin", "tesseract"), "#!/bin/sh\n");
+    process.env.ELIZA_VISION_VENDOR_DIR = dir;
+    process.env.ELIZA_TESSERACT_BIN = "/explicit/tesseract";
+    expect(resolveTesseract()).toEqual({ bin: "/explicit/tesseract", env: {} });
   });
 });

--- a/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
+++ b/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
@@ -24,7 +24,7 @@
  */
 
 import { execFile, execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
@@ -219,16 +219,64 @@ export function mapTesseractTsvToResult(
   return { blocks };
 }
 
-/** Resolve the binary name, allowing an override for non-PATH installs. */
-function tesseractBinary(): string {
-  const override = process.env.ELIZA_TESSERACT_BIN;
-  return override && override.length > 0 ? override : "tesseract";
+/** Resolved tesseract invocation: the binary path + the env it must run under. */
+export interface TesseractResolution {
+  bin: string;
+  /** Extra env merged onto `process.env` for child runs (LD_LIBRARY_PATH,
+   * TESSDATA_PREFIX) — non-empty only when a bundled tesseract is used. */
+  env: Record<string, string>;
+}
+
+/**
+ * Resolve a tesseract to run, so the OCR path "just ships and works" without a
+ * system `apt install tesseract-ocr` (#9105). Order:
+ *
+ *   1. `ELIZA_TESSERACT_BIN` — an explicit binary path (CI / power users).
+ *   2. A vendored bundle the app ships, found at
+ *      `${ELIZA_VISION_VENDOR_DIR}/tesseract/{bin/tesseract, lib/*.so*,
+ *      tessdata/<lang>.traineddata}`. The desktop build stages a portable
+ *      tesseract there (binary + libtesseract/libleptonica + eng.traineddata);
+ *      we then run it with that `lib/` on `LD_LIBRARY_PATH` and that `tessdata/`
+ *      as `TESSDATA_PREFIX`, so no host install is needed.
+ *   3. `tesseract` on `PATH` (a system install, the legacy path).
+ *
+ * Pure-ish + exported for tests (it only reads env + the filesystem); cached for
+ * the process lifetime.
+ */
+export function resolveTesseract(): TesseractResolution {
+  const binOverride = process.env.ELIZA_TESSERACT_BIN;
+  if (binOverride && binOverride.length > 0) {
+    return { bin: binOverride, env: {} };
+  }
+  const vendor = process.env.ELIZA_VISION_VENDOR_DIR;
+  if (vendor && vendor.length > 0) {
+    const root = join(vendor, "tesseract");
+    const cand = join(root, "bin", "tesseract");
+    if (existsSync(cand)) {
+      const lib = join(root, "lib");
+      const prior = process.env.LD_LIBRARY_PATH;
+      return {
+        bin: cand,
+        env: {
+          LD_LIBRARY_PATH: prior ? `${lib}:${prior}` : lib,
+          TESSDATA_PREFIX: join(root, "tessdata"),
+        },
+      };
+    }
+  }
+  return { bin: "tesseract", env: {} };
 }
 
 let availabilityCache: boolean | null = null;
+let resolutionCache: TesseractResolution | null = null;
+
+function resolved(): TesseractResolution {
+  if (!resolutionCache) resolutionCache = resolveTesseract();
+  return resolutionCache;
+}
 
 /**
- * Feature-detect the `tesseract` binary by running `tesseract --version`.
+ * Feature-detect the resolved tesseract by running `--version` under its env.
  * Cached for the process lifetime. Synchronous so it slots into the boot-time
  * availability probe; the probe is cheap (one short-lived child process) and
  * only runs once.
@@ -239,10 +287,12 @@ function detectTesseract(): boolean {
     availabilityCache = false;
     return false;
   }
+  const { bin, env } = resolved();
   try {
-    execFileSync(tesseractBinary(), ["--version"], {
+    execFileSync(bin, ["--version"], {
       timeout: 5000,
       stdio: ["ignore", "ignore", "ignore"],
+      env: { ...process.env, ...env },
     });
     availabilityCache = true;
   } catch {
@@ -251,17 +301,23 @@ function detectTesseract(): boolean {
   return availabilityCache;
 }
 
-/** Test-only: reset the cached availability probe between cases. */
+/** Test-only: reset the cached availability + resolution probes between cases. */
 export function _resetTesseractAvailabilityForTests(): void {
   availabilityCache = null;
+  resolutionCache = null;
 }
 
 function runTesseract(imagePath: string): Promise<string> {
+  const { bin, env } = resolved();
   return new Promise((resolve, reject) => {
     execFile(
-      tesseractBinary(),
+      bin,
       [imagePath, "stdout", "--psm", "11", "tsv"],
-      { timeout: 15000, maxBuffer: 16 * 1024 * 1024 },
+      {
+        timeout: 15000,
+        maxBuffer: 16 * 1024 * 1024,
+        env: { ...process.env, ...env },
+      },
       (err, stdout, stderr) => {
         if (err) {
           reject(new Error(`tesseract failed: ${stderr || err.message}`));


### PR DESCRIPTION
Makes tesseract OCR **just ship and work** with no host install, on desktop **and** on-device Android — closing the #9105 Android coord-OCR gap.

## Desktop / Linux (verified)
`resolveTesseract()` auto-resolves a bundled tesseract (`ELIZA_TESSERACT_BIN` → `${ELIZA_VISION_VENDOR_DIR}/tesseract/{bin,lib,tessdata+configs}` → PATH) + a `vendor-tesseract-linux.mjs` staging script (codifies that `tessdata/configs/` must ship or TSV output silently yields zero rows). **Verified:** a self-contained vendor bundle (zero system tesseract) → `LinuxTesseractOcrService.describe()` returned **47 OCR-with-coords blocks** from a real Pixel screenshot.

## Android — native Tesseract4Android, VERIFIED on the Pixel 9a
New `@elizaos/capacitor-tesseract` plugin: native JNI tesseract 5 (no ONNX), **vendored** from jitpack `com.github.adaptech-cz:Tesseract4Android:4.8.0` (classes.jar + arm64 `.so`) so the build needs no network. `eng.traineddata` in assets.

**On-device proof:** `connectedDebugAndroidTest` → `Starting/Finished 1 tests on Pixel 9a - 16` → `BUILD SUCCESSFUL`. The test OCRs a rendered "Eliza OCR" bitmap and asserts the text + 2 word boxes — a real recognition pass on hardware.

**End-to-end wiring:** `OcrBridgeService` + `GET/POST /api/vision/ocr-{requests,result}` (renderer-pulled, mirroring the screen-capture bridge) → `AndroidBridgeOcrService` (`OcrWithCoordsService`, groups native words by (block,par,line) → display-absolute blocks, registered first when `isAndroidMobile()`) ← renderer poller running the Capacitor plugin.

## Tests
5 resolver + 4 mapper unit tests + the on-device instrumented test. Plugin Kotlin compiles clean; plugin-vision typechecks.

## Notes
- The full-app on-device APK build is gated on the unrelated inference/voice native toolchain (llama.cpp omnivoice submodule), so the agent↔renderer↔native path is verified by component (Kotlin compile + TS typecheck/tests + on-device engine test), not one end-to-end app run.
- iOS (gali8/tesseract-ocr-ios style) is a follow-on.
- Includes a complementary commit completing the desktop `.so` closure + publish script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
