### PR TITLE
fix(voice): skip mock diarization scoring

### DIFF
--- a/packages/app/test/ui-smoke/voice-workbench-cases.ts
+++ b/packages/app/test/ui-smoke/voice-workbench-cases.ts
@@ -185,12 +185,15 @@ interface WorkbenchReport {
     detail?: Record<string, unknown>;
   }>;
   diarization: {
+    status: string;
     total: number;
     der: number;
     confusions: number;
-    misses: number;
+    unattributed: number;
     maxDer: number;
+    evaluated: boolean;
     passed: boolean;
+    reason?: string;
   };
 }
 
@@ -233,23 +236,38 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
       scenario,
     );
 
-    // Mocked backends are present, so the scenario must resolve cleanly.
-    // A skipped case in this lane is a missing mock/fixture, not coverage.
+    const expectsRealDiarization = scenario.classes.includes("diarization");
+
+    // Mocked ASR / agent / TTS backends are present, so non-diarization turns
+    // must resolve cleanly. The mock lane has no real speaker-attribution model,
+    // so a scenario whose load-bearing class is diarization must report skipped
+    // rather than a fake pass.
     expect(
       report.overall,
       `turns: ${JSON.stringify(report.turns, null, 2)}`,
-    ).toBe("pass");
+    ).toBe(expectsRealDiarization ? "skipped" : "pass");
     expect(report.scenarioId).toBe(scenario.id);
     expect(report.turns).toHaveLength(scenario.turns.length);
-    expect(report.diarization.passed, "diarization DER gate").toBe(true);
-    expect(report.diarization.der, "diarization DER").toBeLessThanOrEqual(
-      report.diarization.maxDer,
+    expect(report.diarization.status, "mock-lane diarization status").toBe(
+      "skipped",
+    );
+    expect(
+      report.diarization.passed,
+      "mock lane must not fabricate a passing DER",
+    ).toBe(false);
+    expect(report.diarization.total, "diarization scored turns").toBe(0);
+    expect(report.diarization.evaluated, "diarization evaluated").toBe(false);
+    expect(report.diarization.unattributed, "unattributed turns").toBe(
+      scenario.turns.length,
+    );
+    expect(report.diarization.reason ?? "").toContain(
+      "speaker attribution is not available",
     );
 
-    // Every turn's respond + speaker-label decisions must match ground truth
-    // and no turn failed. This keeps the headful lane honest for #9147: a
-    // scenario that declares expectedSpeakerLabel must have it carried into the
-    // report and enforced by the player, not merely mentioned in comments.
+    // Every turn's respond decision must match ground truth and no turn failed.
+    // Speaker labels are still carried into the report, but the mock lane has
+    // no attribution model, so predicted labels stay null and cannot satisfy a
+    // diarization proof.
     for (let i = 0; i < scenario.turns.length; i += 1) {
       const turn = report.turns[i];
       const expected = scenario.turns[i];
@@ -267,12 +285,12 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
       ).toBe(expectedSpeakerLabel);
       expect(
         turn.predictedSpeakerLabel,
-        `turn ${i} predicted speaker label`,
-      ).toBe(expectedSpeakerLabel);
+        `turn ${i} predicted speaker label is unavailable in the mock lane`,
+      ).toBeNull();
       expect(
-        turn.detail?.speakerLabelOk,
-        `turn ${i} speaker label verdict`,
-      ).toBe(true);
+        turn.detail?.speakerAttributionRan,
+        `turn ${i} speaker attribution ran`,
+      ).toBe(false);
     }
 
     // DOM mirror: per-turn elements carry the verdict for a non-JS scraper.
@@ -285,10 +303,7 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
         "data-expected-speaker-label",
         scenario.turns[i].expectedSpeakerLabel ?? scenario.turns[i].speaker,
       );
-      await expect(turnEl).toHaveAttribute(
-        "data-predicted-speaker-label",
-        scenario.turns[i].expectedSpeakerLabel ?? scenario.turns[i].speaker,
-      );
+      await expect(turnEl).toHaveAttribute("data-predicted-speaker-label", "");
     }
 
     // Overall DOM verdict reflects the report.
@@ -299,6 +314,10 @@ export function runWorkbenchScenarioSpec(scenario: SpecScenario): void {
     await expect(page.getByTestId("voice-workbench-overall")).toHaveAttribute(
       "data-der",
       String(report.diarization.der),
+    );
+    await expect(page.getByTestId("voice-workbench-overall")).toHaveAttribute(
+      "data-diarization-status",
+      "skipped",
     );
   });
 }

--- a/packages/app/test/ui-smoke/voice-workbench-diarization.spec.ts
+++ b/packages/app/test/ui-smoke/voice-workbench-diarization.spec.ts
@@ -1,22 +1,11 @@
 /**
- * Voice Workbench — diarization scenario class (#8785, #9427). Overlapping /
- * alternating speakers whose turns must be attributed to the right speaker
- * label; the player runs each turn through attribution and records the
- * PREDICTED label (not the ground-truth `speaker`) in the report.
+ * Voice Workbench — diarization scenario class (#8785, #9427). Alternating
+ * speakers need a real attribution output before DER can be scored.
  *
- * Each turn carries an explicit `predictedSpeakerLabel` — the attribution output
- * the diarization gate scores against `expectedSpeakerLabel`. These are distinct
- * fields, so the gate is NOT tautological: a real misattribution (predicted ≠
- * expected) drives DER up and fails the gate. A live attribution model overrides
- * these via `VoiceWorkbenchOptions.resolvePredictedSpeakerLabel`. The fail-on-
- * divergence behavior is unit-tested in
- * `packages/ui/src/voice/voice-selftest/voice-workbench-diarization.test.ts`.
- *
- * The headless lane goes further than these explicit fixture labels: it runs a
- * real blind acoustic clusterer over per-turn audio and scores it with the
- * frame-based DER metric — see
- * `plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts`
- * and `workbench-logic-services.test.ts` (#9147, #9427).
+ * The mocked headful lane round-trips each turn through the client player, but
+ * intentionally provides no attribution resolver; it must report diarization as
+ * skipped, never as a fake pass from ground-truth labels. Pure scorer and
+ * headless-service tests cover real misattribution failures separately.
  *
  *   bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-diarization.spec.ts
  */
@@ -33,21 +22,18 @@ runWorkbenchScenarioSpec({
       speaker: "speaker_a",
       text: "what is the first item on the agenda",
       expectedSpeakerLabel: "speaker_a",
-      predictedSpeakerLabel: "speaker_a",
       expectRespond: true,
     },
     {
       speaker: "speaker_b",
       text: "lets cover the budget first",
       expectedSpeakerLabel: "speaker_b",
-      predictedSpeakerLabel: "speaker_b",
       expectRespond: true,
     },
     {
       speaker: "speaker_a",
       text: "good idea",
       expectedSpeakerLabel: "speaker_a",
-      predictedSpeakerLabel: "speaker_a",
       expectRespond: true,
     },
   ],

--- a/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
+++ b/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
@@ -166,6 +166,7 @@ export function VoiceWorkbenchShell() {
       <div
         data-testid="voice-workbench-overall"
         data-overall={report?.overall ?? "pending"}
+        data-diarization-status={report?.diarization.status ?? "pending"}
         data-der={report?.diarization.der ?? ""}
         data-max-der={report?.diarization.maxDer ?? ""}
         data-running={running ? "1" : "0"}

--- a/packages/ui/src/voice/voice-selftest/voice-workbench-player.test.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-workbench-player.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ElizaClient } from "../../api/client-base";
+import {
+  isLocalInferenceAsrReady,
+  transcribeLocalInferenceWav,
+} from "../local-asr-transcribe";
+import {
+  runVoiceWorkbench,
+  type WorkbenchScenario,
+} from "./voice-workbench-player";
+
+vi.mock("../local-asr-transcribe", () => ({
+  isLocalInferenceAsrReady: vi.fn(),
+  transcribeLocalInferenceWav: vi.fn(),
+}));
+
+const scenario = {
+  id: "unit-diarization",
+  classes: ["diarization"],
+  participants: [{ label: "alice", isOwner: true }, { label: "bob" }],
+  turns: [
+    {
+      speaker: "alice",
+      text: "first turn",
+      expectedSpeakerLabel: "alice",
+      expectRespond: false,
+    },
+    {
+      speaker: "bob",
+      text: "second turn",
+      expectedSpeakerLabel: "bob",
+      expectRespond: false,
+    },
+  ],
+} satisfies WorkbenchScenario;
+
+function createClient(): ElizaClient {
+  return {
+    createConversation: vi.fn(async () => ({
+      conversation: { id: "voice-workbench-unit" },
+    })),
+    sendConversationMessageStream: vi.fn(async () => ({
+      text: "",
+      completed: true,
+      agentName: "Eliza",
+      noResponseReason: "ignored",
+    })),
+  } as unknown as ElizaClient;
+}
+
+function mockTranscripts() {
+  vi.mocked(transcribeLocalInferenceWav)
+    .mockResolvedValueOnce({ text: "first turn", words: [] })
+    .mockResolvedValueOnce({ text: "second turn", words: [] });
+}
+
+describe("runVoiceWorkbench diarization scoring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isLocalInferenceAsrReady).mockResolvedValue(true);
+    mockTranscripts();
+  });
+
+  it("skips diarization instead of passing when no real speaker-attribution hook is available", async () => {
+    const report = await runVoiceWorkbench({
+      scenario,
+      platform: "web",
+      ttsRoute: "/api/tts/cloud",
+      resolveTurnWav: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      client: createClient(),
+      audioCtx: {} as AudioContext,
+    });
+
+    expect(report.overall).toBe("skipped");
+    expect(report.turns.map((turn) => turn.status)).toEqual(["pass", "pass"]);
+    expect(report.turns.map((turn) => turn.predictedSpeakerLabel)).toEqual([
+      null,
+      null,
+    ]);
+    expect(
+      report.turns.map((turn) => turn.detail.speakerAttributionRan),
+    ).toEqual([false, false]);
+    expect(report.diarization).toMatchObject({
+      status: "skipped",
+      total: 0,
+      der: 0,
+      confusions: 0,
+      unattributed: 2,
+      evaluated: false,
+      passed: false,
+    });
+    expect(report.diarization.reason).toContain(
+      "speaker attribution is not available",
+    );
+  });
+
+  it("scores DER when a real speaker-attribution hook supplies predictions", async () => {
+    const report = await runVoiceWorkbench({
+      scenario,
+      platform: "web",
+      ttsRoute: "/api/tts/cloud",
+      resolveTurnWav: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      resolvePredictedSpeakerLabel: vi
+        .fn()
+        .mockResolvedValueOnce("alice")
+        .mockResolvedValueOnce("alice"),
+      client: createClient(),
+      audioCtx: {} as AudioContext,
+    });
+
+    expect(report.overall).toBe("fail");
+    expect(report.turns.map((turn) => turn.predictedSpeakerLabel)).toEqual([
+      "alice",
+      "alice",
+    ]);
+    expect(report.diarization).toMatchObject({
+      status: "fail",
+      total: 2,
+      der: 0.5,
+      confusions: 1,
+      unattributed: 0,
+      evaluated: true,
+      passed: false,
+    });
+  });
+});

--- a/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
@@ -57,18 +57,6 @@ export interface WorkbenchTurn {
   expectRespond: boolean;
   expectedTranscript?: string;
   expectedSpeakerLabel?: string;
-  /**
-   * The speaker label a diarizer/attribution model is expected to PREDICT for
-   * this turn — distinct from the ground-truth `speaker`. When no live
-   * attribution model runs (`VoiceWorkbenchOptions.resolvePredictedSpeakerLabel`
-   * absent), this drives the diarization gate, so a scenario can encode a
-   * deliberate misattribution (`predictedSpeakerLabel !== expectedSpeakerLabel`)
-   * and the gate will correctly fail. The player NEVER falls back to `speaker`
-   * for the prediction — that would make the DER gate compare ground truth to
-   * itself (tautological). Absent (and no live resolver) → the turn is
-   * UNATTRIBUTED: excluded from DER and the gate reports skipped, never a pass.
-   */
-  predictedSpeakerLabel?: string;
   expectedEntity?: string;
 }
 
@@ -117,6 +105,7 @@ export interface VoiceWorkbenchReport {
   finishedAt: string;
   turns: VoiceWorkbenchTurnReport[];
   diarization: {
+    status: TurnStatus;
     /** Turns with a real attribution output (the DER denominator). */
     total: number;
     der: number;
@@ -128,6 +117,7 @@ export interface VoiceWorkbenchReport {
      * SKIPPED (no diarizer on this host), distinct from a real DER failure. */
     evaluated: boolean;
     passed: boolean;
+    reason?: string;
   };
 }
 
@@ -147,12 +137,13 @@ export interface VoiceWorkbenchOptions {
    * scenario's ground-truth `speaker` — drives the diarization gate, so the gate
    * fails on a real misattribution. Return `null` when the model can't attribute
    * the turn (unattributed: excluded from DER, the gate reports skipped, never a
-   * pass). When absent, the player uses the turn's explicit
-   * `predictedSpeakerLabel`; it never falls back to `speaker`.
+   * pass). When absent, the player records no predicted speaker label; it never
+   * falls back to `speaker`.
    */
   resolvePredictedSpeakerLabel?: (
     turn: WorkbenchTurn,
     index: number,
+    wav: Uint8Array,
   ) => Promise<string | null> | string | null;
   /** TTS route to exercise. local for desktop/android, cloud for web. */
   ttsRoute: "/api/tts/local-inference" | "/api/tts/cloud";
@@ -263,14 +254,6 @@ async function runTurn(
   const t0 = now();
   const expectedTranscript = turnReference(turn);
   const expectedSpeakerLabel = turnSpeakerLabel(turn);
-  // Predicted label comes from an actual attribution output (live model hook or
-  // an explicit per-turn `predictedSpeakerLabel`), NEVER from the ground-truth
-  // `turn.speaker` — comparing ground truth to itself made this gate tautological
-  // (#9427). Absent prediction → null → scored as a miss, never a pass.
-  const predictedSpeakerLabel =
-    (await opts.resolvePredictedSpeakerLabel?.(turn, index)) ??
-    (turn.predictedSpeakerLabel?.trim() || null);
-  const speakerLabelOk = predictedSpeakerLabel === expectedSpeakerLabel;
   const werTolerance = opts.werTolerance ?? 0.34;
 
   let wav: Uint8Array;
@@ -282,7 +265,7 @@ async function runTurn(
       index,
       speaker: turn.speaker,
       expectedSpeakerLabel,
-      predictedSpeakerLabel,
+      predictedSpeakerLabel: null,
       status: "skipped",
       responded: false,
       expectRespond: turn.expectRespond,
@@ -294,6 +277,34 @@ async function runTurn(
       error: error instanceof Error ? error.message : String(error),
     };
   }
+
+  let predictedSpeakerLabel: string | null = null;
+  let speakerAttributionRan = false;
+  try {
+    if (opts.resolvePredictedSpeakerLabel) {
+      const label = await opts.resolvePredictedSpeakerLabel(turn, index, wav);
+      predictedSpeakerLabel = label?.trim() || null;
+      speakerAttributionRan = predictedSpeakerLabel !== null;
+    }
+  } catch (error) {
+    return {
+      index,
+      speaker: turn.speaker,
+      expectedSpeakerLabel,
+      predictedSpeakerLabel: null,
+      status: "fail",
+      responded: false,
+      expectRespond: turn.expectRespond,
+      transcript: "",
+      expectedTranscript,
+      reply: "",
+      durationMs: Math.round(now() - t0),
+      detail: { stage: "speaker-attribution" },
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  const speakerLabelOk =
+    !speakerAttributionRan || predictedSpeakerLabel === expectedSpeakerLabel;
 
   let transcript = "";
   try {
@@ -389,7 +400,11 @@ async function runTurn(
     }
   }
 
-  const ok = transcriptOk && respondDecisionOk && speakerLabelOk && ttsOk;
+  const ok =
+    transcriptOk &&
+    respondDecisionOk &&
+    ttsOk &&
+    (!speakerAttributionRan || speakerLabelOk);
   const detail: Record<string, string | number | boolean> = {
     transcript,
     expectedTranscript,
@@ -401,6 +416,7 @@ async function runTurn(
     predictedSpeakerLabel: predictedSpeakerLabel ?? "",
     expectedSpeakerLabel,
     speakerLabelOk,
+    speakerAttributionRan,
     completed,
     agentName,
     ...ttsDetail,
@@ -430,7 +446,7 @@ async function runTurn(
         ? `ASR WER ${wer.toFixed(3)} exceeds tolerance ${werTolerance}`
         : !respondDecisionOk
           ? `respond decision: got ${responded}, expected ${turn.expectRespond}`
-          : !speakerLabelOk
+          : speakerAttributionRan && !speakerLabelOk
             ? `speaker label: got ${predictedSpeakerLabel ?? "null"}, expected ${expectedSpeakerLabel}`
             : (ttsError ?? "turn failed"),
   };
@@ -454,14 +470,25 @@ export function scoreWorkbenchDiarization(
   }
   const total = attributed.length;
   const der = total > 0 ? confusions / total : 0;
+  const evaluated = total > 0;
+  const passed = evaluated && der <= maxDer;
   return {
+    status: evaluated ? (passed ? "pass" : "fail") : "skipped",
     total,
     der: Number(der.toFixed(4)),
     confusions,
     unattributed: ran.length - attributed.length,
     maxDer,
-    evaluated: total > 0,
-    passed: total > 0 && der <= maxDer,
+    evaluated,
+    passed,
+    ...(evaluated
+      ? {}
+      : {
+          reason:
+            ran.length > 0
+              ? "real speaker attribution is not available on this host"
+              : "no non-skipped turns available for diarization scoring",
+        }),
   };
 }
 
@@ -522,13 +549,16 @@ export async function runVoiceWorkbench(
   const hasFail = turns.some((t) => t.status === "fail");
   const allSkipped =
     turns.length > 0 && turns.every((t) => t.status === "skipped");
-  const overall: VoiceWorkbenchReport["overall"] = hasFail
-    ? "fail"
-    : allSkipped
-      ? "skipped"
-      : diarization.passed
-        ? "pass"
-        : "fail";
+  const requiresDiarization = scenario.classes.includes("diarization");
+  let overall: VoiceWorkbenchReport["overall"] = "pass";
+  if (hasFail || diarization.status === "fail") {
+    overall = "fail";
+  } else if (
+    allSkipped ||
+    (requiresDiarization && diarization.status === "skipped")
+  ) {
+    overall = "skipped";
+  }
 
   return {
     ...base,


### PR DESCRIPTION
## Summary
- Stop the headful Voice Workbench from scoring diarization when no real speaker-attribution resolver produced labels.
- Add explicit diarization status/reason/evaluated/unattributed reporting and mirror the status in the DOM.
- Add focused runVoiceWorkbench regression coverage for skipped mock-lane diarization and real resolver confusion failure.

Fixes #9427

## Verification
- PASS: ./node_modules/.bin/biome check packages/ui/src/voice/voice-selftest/voice-workbench-player.ts packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx packages/ui/src/voice/voice-selftest/voice-workbench-player.test.ts packages/ui/src/voice/voice-selftest/voice-workbench-diarization.test.ts packages/app/test/ui-smoke/voice-workbench-cases.ts packages/app/test/ui-smoke/voice-workbench-diarization.spec.ts
- PASS: bun run --cwd packages/ui test -- --run src/voice/voice-selftest/voice-workbench-player.test.ts src/voice/voice-selftest/voice-workbench-diarization.test.ts (2 files, 6 tests)
- PASS: bun run --cwd packages/ui typecheck
- PASS: git diff --check HEAD^ HEAD
- BLOCKED: bun run --cwd packages/app typecheck currently fails on origin/develop at ../agent/src/runtime/eliza.ts with missing declarations for @elizaos/plugin-vision.
- BLOCKED: bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-diarization.spec.ts in this temp worktree fails before collection with Playwright duplicate-instance/test.beforeEach registration at voice-workbench-cases.ts:206.