### PR TITLE
fix(agent): allow notification event stream

### DIFF
--- a/packages/agent/src/api/misc-routes.agent-event.test.ts
+++ b/packages/agent/src/api/misc-routes.agent-event.test.ts
@@ -1,0 +1,88 @@
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleMiscRoutes, type MiscRouteContext } from "./misc-routes";
+import { AGENT_EVENT_ALLOWED_STREAMS } from "./plugin-discovery-helpers";
+
+function makeAgentEventContext(
+  body: Record<string, unknown>,
+): MiscRouteContext {
+  const req = { url: "/api/agent/event" } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const broadcastWs = vi.fn();
+
+  return {
+    req,
+    res,
+    method: "POST",
+    pathname: "/api/agent/event",
+    url: new URL("http://localhost/api/agent/event"),
+    state: {
+      config: {} as MiscRouteContext["state"]["config"],
+      runtime: {
+        agentId: "00000000-0000-0000-0000-0000000000aa",
+      } as AgentRuntime,
+      agentState: "ready",
+      agentName: "Eliza",
+      shellEnabled: true,
+      broadcastWs,
+      broadcastWsToClientId: vi.fn(),
+      nextEventId: 1,
+      eventBuffer: [],
+      shareIngestQueue: [],
+      startup: {},
+      broadcastStatus: vi.fn(),
+      pendingRestartReasons: [],
+    },
+    json: vi.fn(),
+    error: vi.fn(),
+    readJsonBody: vi.fn().mockResolvedValue(body),
+    AGENT_EVENT_ALLOWED_STREAMS,
+    resolveTerminalRunRejection: vi.fn().mockReturnValue(null),
+    resolveTerminalRunClientId: vi.fn().mockReturnValue(null),
+    isSharedTerminalClientId: vi.fn().mockReturnValue(false),
+    activeTerminalRunCount: 0,
+    setActiveTerminalRunCount: vi.fn(),
+  };
+}
+
+describe("handleMiscRoutes agent events", () => {
+  it("accepts notification stream events for the live notification rail", async () => {
+    const payload = {
+      notification: {
+        id: "n-1",
+        title: "Job complete",
+        category: "workflow",
+        priority: "normal",
+        createdAt: 1,
+        readAt: null,
+      },
+      unreadCount: 1,
+    };
+    const ctx = makeAgentEventContext({
+      stream: "notification",
+      data: payload,
+    });
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.error).not.toHaveBeenCalled();
+    expect(ctx.json).toHaveBeenCalledWith(ctx.res, { ok: true });
+    expect(ctx.state.eventBuffer).toHaveLength(1);
+    expect(ctx.state.eventBuffer[0]).toMatchObject({
+      type: "agent_event",
+      version: 1,
+      eventId: "evt-1",
+      stream: "notification",
+      payload,
+    });
+    expect(ctx.state.broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent_event",
+        stream: "notification",
+        payload,
+      }),
+    );
+  });
+});

--- a/packages/agent/src/api/plugin-discovery-helpers.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.ts
@@ -747,6 +747,7 @@ export const AGENT_EVENT_ALLOWED_STREAMS = new Set([
   "assistant",
   "thought",
   "action",
+  "notification",
   "viewer_stats",
 ]);
 


### PR DESCRIPTION
## Summary
- Add `notification` to `AGENT_EVENT_ALLOWED_STREAMS` so posted agent events on `/api/agent/event` can use the same stream that the notification store already listens for.
- Add a `handleMiscRoutes` regression test that posts a notification stream event and verifies it is accepted, buffered, and broadcast over WebSocket.

Addresses the narrow Pillar A delivery-unblock slice of #9449, and cross-cuts the same allowlist gap called out in #9448/#9450.

## Verification
- PASS: `bun install`
- PASS: `bun run --cwd packages/agent test misc-routes.agent-event.test.ts` (1 file, 1 test)
- PASS: `bun run --cwd packages/agent lint` (exits 0; reports 3 pre-existing warnings in unrelated proactive-interaction tests)
- PASS: `git diff --check`
- BLOCKED (current develop/package-boundary noise): `bun run --cwd packages/agent typecheck` fails before this slice with missing workspace declarations/modules and unrelated UI account-type errors.
- BLOCKED (current develop red lane): `bun run verify` stops at `@elizaos/example-telegram#typecheck` with `Cannot find module '@elizaos/plugin-openai'` after 59 successful tasks / 68 total.