### PR TITLE
fix(ui): export page panel package subpath

### DIFF
--- a/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
@@ -66,9 +66,9 @@ describe("Headscale identity inference", () => {
   });
 
   test("hostname normalizes special chars to a valid DNS label and never empties", () => {
-    expect(
-      inferTailscaleHostname({ agentName: "Test@Agent!", agentId: "UUID-1234-5678" }),
-    ).toBe("test-agent-uuid-1234-56");
+    expect(inferTailscaleHostname({ agentName: "Test@Agent!", agentId: "UUID-1234-5678" })).toBe(
+      "test-agent-uuid-1234-56",
+    );
     expect(inferTailscaleHostname({ agentName: "", agentId: "" })).toBe("agent-agent");
   });
 

--- a/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
@@ -125,7 +125,6 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
   });
 });
 
-
 describe("normalizeHeadscaleSegment + registration-timeout default", () => {
   test("lowercases, trims, replaces invalid chars, collapses + strips hyphens", () => {
     expect(normalizeHeadscaleSegment("  HELLO  ")).toBe("hello");

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -163,6 +163,11 @@
       "import": "./dist/components/index.js",
       "default": "./dist/components/index.js"
     },
+    "./components/composites/page-panel": {
+      "types": "./dist/components/composites/page-panel/index.d.ts",
+      "import": "./dist/components/composites/page-panel/index.js",
+      "default": "./dist/components/composites/page-panel/index.js"
+    },
     "./components/*": {
       "types": "./dist/components/*.d.ts",
       "import": "./dist/components/*.js",

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
-
+import { ShaderBackground } from "../../backgrounds/ShaderBackground";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { MockAppProvider } from "../../storybook/mock-providers";
 import {
@@ -8,7 +8,6 @@ import {
   installHomeWidgetFetchMock,
   seedHomeWidgetNotifications,
 } from "../../widgets/__fixtures__/home-widget-mock-data";
-import { ShaderBackground } from "../../backgrounds/ShaderBackground";
 import { Springboard } from "../pages/Springboard";
 import { HomeScreen } from "./HomeScreen";
 import { HomeSpringboardSurface } from "./HomeSpringboardSurface";

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -67,8 +67,10 @@ export const HOME_WIDGET_MOCK_PLUGINS: PluginInfo[] = [
 // ---------------------------------------------------------------------------
 
 const NOW = () => Date.now();
-const minutesFromNow = (m: number) => new Date(Date.now() + m * 60_000).toISOString();
-const hoursFromNow = (h: number) => new Date(Date.now() + h * 3_600_000).toISOString();
+const minutesFromNow = (m: number) =>
+  new Date(Date.now() + m * 60_000).toISOString();
+const hoursFromNow = (h: number) =>
+  new Date(Date.now() + h * 3_600_000).toISOString();
 const daysFromNow = (d: number) =>
   new Date(Date.now() + d * 24 * 3_600_000).toISOString();
 
@@ -124,7 +126,10 @@ function goalsPayload() {
  *  netUsd < 0 (overdrawn) floats up at escalation weight. A connected source is
  *  required for the card to render. */
 function moneyDashboard() {
-  return { spending: { netUsd: -125.5 }, generatedAt: new Date(NOW()).toISOString() };
+  return {
+    spending: { netUsd: -125.5 },
+    generatedAt: new Date(NOW()).toISOString(),
+  };
 }
 function moneySources() {
   return { sources: [{ id: "src-1", status: "active", label: "Checking" }] };
@@ -168,7 +173,12 @@ function sleepHistory() {
   };
 }
 function sleepRegularity() {
-  return { classification: "irregular", sri: 41.2, sampleSize: 6, windowDays: 14 };
+  return {
+    classification: "irregular",
+    sri: 41.2,
+    sampleSize: 6,
+    windowDays: 14,
+  };
 }
 
 /** RelationshipsAttentionWidget reads client.getRelationshipsPeople() ->
@@ -313,7 +323,10 @@ function routeTable(): RouteMatch[] {
     { test: has("/api/lifeops/sleep/regularity"), body: sleepRegularity },
     { test: has("/api/lifeops/inbox"), body: inboxPayload },
     { test: has("/api/relationships/people"), body: relationshipsPeople },
-    { test: has("/api/relationships/candidates"), body: relationshipsCandidates },
+    {
+      test: has("/api/relationships/candidates"),
+      body: relationshipsCandidates,
+    },
     { test: has("/api/notifications"), body: notificationsPayload },
   ];
 }

--- a/plugins/plugin-local-inference/src/services/recommendation.test.ts
+++ b/plugins/plugin-local-inference/src/services/recommendation.test.ts
@@ -1,6 +1,6 @@
 import type { CatalogModel, HardwareProbe } from "@elizaos/shared";
-import { MODEL_CATALOG } from "./catalog.js";
 import { describe, expect, it } from "vitest";
+import { MODEL_CATALOG } from "./catalog.js";
 import {
 	assessCatalogModelFit,
 	canBundleBeDefaultOnDevice,


### PR DESCRIPTION
## Summary
- Add an exact `@elizaos/ui/components/composites/page-panel` package export so directory subpath imports resolve to `dist/components/composites/page-panel/index.*`.
- Keep the broader `./components/*` export intact.
- Include formatter-only cleanup required for root verify on current `develop`.

## Evidence
- Synced with `origin/develop` at `ace5290700` via `git fetch origin && git rebase origin/develop`.
- `bun install` (no changes)
- `bun run --cwd packages/ui build` -> `[verify-package-runtime-exports] verified 39 runtime export(s) for @elizaos/ui`
- `bun run --cwd plugins/plugin-vector-browser typecheck`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/cloud-shared lint`
- `git diff --check`
- `bun run verify` -> 510 successful, 510 total; 403 cached; 8m7.304s

## Evidence N/A
- Screenshots/video: no runtime UI behavior changed; package export and formatter-only changes.
- Real-LLM trajectories/backend/frontend logs: no agent/action/model/runtime behavior changed.