### PR TITLE
test(scenario-runner): assert simple calendar create effect

### DIFF
--- a/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
@@ -66,9 +66,9 @@ describe("Headscale identity inference", () => {
   });
 
   test("hostname normalizes special chars to a valid DNS label and never empties", () => {
-    expect(
-      inferTailscaleHostname({ agentName: "Test@Agent!", agentId: "UUID-1234-5678" }),
-    ).toBe("test-agent-uuid-1234-56");
+    expect(inferTailscaleHostname({ agentName: "Test@Agent!", agentId: "UUID-1234-5678" })).toBe(
+      "test-agent-uuid-1234-56",
+    );
     expect(inferTailscaleHostname({ agentName: "", agentId: "" })).toBe("agent-agent");
   });
 
@@ -124,7 +124,6 @@ describe("Headscale node lookup is keyed on the node name (not the agentId)", ()
     expect(deletedId).toBe("node-9");
   });
 });
-
 
 describe("normalizeHeadscaleSegment + registration-timeout default", () => {
   test("lowercases, trims, replaces invalid chars, collapses + strips hyphens", () => {

--- a/packages/test/scenarios/calendar/calendar.create.simple.scenario.ts
+++ b/packages/test/scenarios/calendar/calendar.create.simple.scenario.ts
@@ -1,4 +1,43 @@
-import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  type ScenarioContext,
+  scenario,
+} from "@elizaos/scenario-runner/schema";
+import { expectTurnToCallAction } from "../_helpers/action-assertions.ts";
+
+function assertSimpleMeetingCreated(ctx: ScenarioContext): string | undefined {
+  const calls = ctx.actionsCalled.filter(
+    (action) => action.actionName === "CALENDAR",
+  );
+  if (calls.length === 0) {
+    return "expected CALENDAR action result";
+  }
+
+  const payload = JSON.stringify(
+    calls.map((call) => ({
+      parameters: call.parameters ?? null,
+      data: call.result?.data ?? null,
+      text: call.result?.text ?? null,
+    })),
+  ).toLowerCase();
+
+  if (
+    !payload.includes("create_event") &&
+    !payload.includes("created calendar event")
+  ) {
+    return `Expected calendar create-event signal in action payload. Payload: ${payload.slice(0, 400)}`;
+  }
+  if (!payload.includes("alex")) {
+    return `Expected created event payload to reference Alex. Payload: ${payload.slice(0, 400)}`;
+  }
+  if (!payload.includes("meeting")) {
+    return `Expected created event payload to reference the meeting. Payload: ${payload.slice(0, 400)}`;
+  }
+  if (!/\b(?:3\s*(?::\s*00)?\s*(?:pm|p\.m\.)|15:00)\b/u.test(payload)) {
+    return `Expected created event payload to carry a 3pm time signal. Payload: ${payload.slice(0, 400)}`;
+  }
+
+  return undefined;
+}
 
 export default scenario({
   lane: "live-only",
@@ -23,14 +62,19 @@ export default scenario({
       name: "create-simple-event",
       text: "Schedule a meeting with Alex tomorrow at 3pm.",
       expectedActions: ["CALENDAR"],
+      assertTurn: expectTurnToCallAction({
+        acceptedActions: ["CALENDAR"],
+        description: "simple calendar event creation",
+        includesAll: ["Alex", "meeting"],
+      }),
       responseIncludesAny: ["alex", "3", "tomorrow", "meeting", "scheduled"],
     },
   ],
   finalChecks: [
     {
-      type: "actionCalled",
-      actionName: "CALENDAR",
-      minCount: 1,
+      type: "custom",
+      name: "calendar-simple-created-event",
+      predicate: assertSimpleMeetingCreated,
     },
   ],
 });

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
-
+import { ShaderBackground } from "../../backgrounds/ShaderBackground";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { MockAppProvider } from "../../storybook/mock-providers";
 import {
@@ -8,7 +8,6 @@ import {
   installHomeWidgetFetchMock,
   seedHomeWidgetNotifications,
 } from "../../widgets/__fixtures__/home-widget-mock-data";
-import { ShaderBackground } from "../../backgrounds/ShaderBackground";
 import { Springboard } from "../pages/Springboard";
 import { HomeScreen } from "./HomeScreen";
 import { HomeSpringboardSurface } from "./HomeSpringboardSurface";

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -67,8 +67,10 @@ export const HOME_WIDGET_MOCK_PLUGINS: PluginInfo[] = [
 // ---------------------------------------------------------------------------
 
 const NOW = () => Date.now();
-const minutesFromNow = (m: number) => new Date(Date.now() + m * 60_000).toISOString();
-const hoursFromNow = (h: number) => new Date(Date.now() + h * 3_600_000).toISOString();
+const minutesFromNow = (m: number) =>
+  new Date(Date.now() + m * 60_000).toISOString();
+const hoursFromNow = (h: number) =>
+  new Date(Date.now() + h * 3_600_000).toISOString();
 const daysFromNow = (d: number) =>
   new Date(Date.now() + d * 24 * 3_600_000).toISOString();
 
@@ -124,7 +126,10 @@ function goalsPayload() {
  *  netUsd < 0 (overdrawn) floats up at escalation weight. A connected source is
  *  required for the card to render. */
 function moneyDashboard() {
-  return { spending: { netUsd: -125.5 }, generatedAt: new Date(NOW()).toISOString() };
+  return {
+    spending: { netUsd: -125.5 },
+    generatedAt: new Date(NOW()).toISOString(),
+  };
 }
 function moneySources() {
   return { sources: [{ id: "src-1", status: "active", label: "Checking" }] };
@@ -168,7 +173,12 @@ function sleepHistory() {
   };
 }
 function sleepRegularity() {
-  return { classification: "irregular", sri: 41.2, sampleSize: 6, windowDays: 14 };
+  return {
+    classification: "irregular",
+    sri: 41.2,
+    sampleSize: 6,
+    windowDays: 14,
+  };
 }
 
 /** RelationshipsAttentionWidget reads client.getRelationshipsPeople() ->
@@ -313,7 +323,10 @@ function routeTable(): RouteMatch[] {
     { test: has("/api/lifeops/sleep/regularity"), body: sleepRegularity },
     { test: has("/api/lifeops/inbox"), body: inboxPayload },
     { test: has("/api/relationships/people"), body: relationshipsPeople },
-    { test: has("/api/relationships/candidates"), body: relationshipsCandidates },
+    {
+      test: has("/api/relationships/candidates"),
+      body: relationshipsCandidates,
+    },
     { test: has("/api/notifications"), body: notificationsPayload },
   ];
 }

--- a/plugins/plugin-local-inference/src/services/recommendation.test.ts
+++ b/plugins/plugin-local-inference/src/services/recommendation.test.ts
@@ -1,6 +1,6 @@
 import type { CatalogModel, HardwareProbe } from "@elizaos/shared";
-import { MODEL_CATALOG } from "./catalog.js";
 import { describe, expect, it } from "vitest";
+import { MODEL_CATALOG } from "./catalog.js";
 import {
 	assessCatalogModelFit,
 	canBundleBeDefaultOnDevice,


### PR DESCRIPTION
## Summary

Fixes #9310.

- Strengthens `calendar.create.simple` from a generic action-count assertion to payload-level create-event evidence.
- Adds a turn-level `CALENDAR` action assertion requiring the expected Alex/meeting content.
- Carries formatter-only cleanup required for current `develop` verification.

## Evidence

- `bun install` (no dependency changes)
- `bun run --cwd packages/scenario-runner typecheck`
- `bunx @biomejs/biome check packages/test/scenarios/calendar/calendar.create.simple.scenario.ts`
- `bun --conditions eliza-source --tsconfig-override tsconfig.json -e "const mod = await import('./packages/test/scenarios/calendar/calendar.create.simple.scenario.ts'); console.log(mod.default.id);"`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/cloud-shared lint`
- `bun run --cwd plugins/plugin-local-inference lint`
- `git diff --check`
- Final synced verification after `git fetch origin`, `git rebase origin/develop`, and `bun install`: `bun run verify` -> 510 successful / 510 total in 10m7.844s

## N/A

- Screenshots/video: scenario assertion and formatter-only cleanup; no UI behavior changed.
- Real-LLM trajectory/backend/frontend logs: this PR changes test proof, not agent/action/model runtime logic.
