### PR TITLE
fix(vision): complete the portable tesseract bundle (.so closure + publish script + validate tessdata) (#9105)

### DIFF
--- a/plugins/plugin-vision/package.json
+++ b/plugins/plugin-vision/package.json
@@ -55,6 +55,7 @@
   "files": [
     "registry-entry.json",
     "dist",
+    "scripts",
     "README.md",
     ".npmignore",
     "package.json",

--- a/plugins/plugin-vision/scripts/vendor-tesseract-linux.mjs
+++ b/plugins/plugin-vision/scripts/vendor-tesseract-linux.mjs
@@ -80,12 +80,61 @@ for (const so of readdirSync(libDir).filter((f) =>
 )) {
   cpSync(join(libDir, so), join(dest, "lib", so), { dereference: false });
 }
-// tessdata lives under usr/share/tesseract-ocr/<ver>/tessdata — copy the WHOLE
-// dir (traineddata + the REQUIRED configs/ + tessconfigs/).
-const shareTess = join(root, "usr/share/tesseract-ocr");
-const ver = readdirSync(shareTess).find((d) =>
-  existsSync(join(shareTess, d, "tessdata")),
+
+// Copy the FULL transitive shared-lib closure. libtesseract pulls in leptonica,
+// which pulls in libjpeg/png/tiff/webp/openjp2/gif/zlib/... — none of which the
+// two .debs above provide. Without them the bundled binary dlopen-fails on a
+// clean host, defeating the whole "no host install" goal. We let `ldd` resolve
+// the binary's deps with the bundle's own lib/ on the search path (so it can
+// find the libtesseract/leptonica we just staged and recurse into their deps),
+// then copy every resolved .so EXCEPT the glibc/loader set that every Linux
+// target is guaranteed to provide.
+const GLIBC_PROVIDED =
+  /^(ld-linux.*|linux-vdso|libc|libm|libdl|libpthread|librt|libresolv|libgcc_s|libstdc\+\+)\.so/;
+function lddClosure(binPath) {
+  let out = "";
+  try {
+    out = execFileSync("ldd", [binPath], {
+      encoding: "utf8",
+      env: { ...process.env, LD_LIBRARY_PATH: join(dest, "lib") },
+    });
+  } catch (err) {
+    // `ldd` is glibc-only; on a musl/non-glibc build host we can't compute the
+    // closure. Fail loud rather than silently shipping an incomplete bundle.
+    throw new Error(
+      `[vendor-tesseract] ldd failed (${err.message}); cannot compute the shared-lib closure on this host`,
+    );
+  }
+  const resolved = [];
+  for (const line of out.split("\n")) {
+    const m = line.match(/=>\s*(\/\S+\.so\S*)/);
+    if (m) resolved.push(m[1]);
+  }
+  return resolved;
+}
+let bundledExtra = 0;
+for (const soPath of lddClosure(join(dest, "bin", "tesseract"))) {
+  const base = soPath.split("/").pop();
+  if (GLIBC_PROVIDED.test(base)) continue;
+  const target = join(dest, "lib", base);
+  if (existsSync(target)) continue; // already staged (libtesseract/liblept)
+  // dereference: write the SONAME-named file with the real lib bytes, so the
+  // dynamic loader finds it by the name the binary asks for.
+  cpSync(soPath, target, { dereference: true });
+  bundledExtra++;
+}
+console.log(
+  `[vendor-tesseract] bundled ${bundledExtra} transitive shared lib(s) via ldd closure.`,
 );
+
+// tessdata lives under usr/share/tesseract-ocr/<ver>/tessdata — copy the WHOLE
+// dir (traineddata + the REQUIRED configs/ + tessconfigs/). Pick the HIGHEST
+// version dir (numeric-aware) so a host with multiple tesseract data versions
+// installed stages the newest, not whichever readdir happens to list first.
+const shareTess = join(root, "usr/share/tesseract-ocr");
+const ver = readdirSync(shareTess)
+  .filter((d) => existsSync(join(shareTess, d, "tessdata")))
+  .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0];
 if (!ver)
   throw new Error(
     "[vendor-tesseract] tessdata not found in downloaded package",

--- a/plugins/plugin-vision/src/ocr-service-linux-tesseract.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-linux-tesseract.test.ts
@@ -177,6 +177,9 @@ describe("resolveTesseract — ships without a host install", () => {
     const root = join(dir, "tesseract");
     mkdirSync(join(root, "bin"), { recursive: true });
     writeFileSync(join(root, "bin", "tesseract"), "#!/bin/sh\n");
+    // A usable bundle needs a language model, not just the binary.
+    mkdirSync(join(root, "tessdata"), { recursive: true });
+    writeFileSync(join(root, "tessdata", "eng.traineddata"), "");
     process.env.ELIZA_VISION_VENDOR_DIR = dir;
     process.env.LD_LIBRARY_PATH = "/pre/existing";
     const r = resolveTesseract();
@@ -188,6 +191,17 @@ describe("resolveTesseract — ships without a host install", () => {
 
   it("falls back to PATH when the vendor dir has no bundled binary", () => {
     const dir = mkdtempSync(join(tmpdir(), "vendor-empty-"));
+    process.env.ELIZA_VISION_VENDOR_DIR = dir;
+    expect(resolveTesseract()).toEqual({ bin: "tesseract", env: {} });
+  });
+
+  it("falls back to PATH when a half-staged vendor dir has the binary but no tessdata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vendor-half-"));
+    const root = join(dir, "tesseract");
+    mkdirSync(join(root, "bin"), { recursive: true });
+    writeFileSync(join(root, "bin", "tesseract"), "#!/bin/sh\n");
+    // No tessdata/<lang>.traineddata staged → the bundle would fail at OCR
+    // time, so resolution must NOT pick it; the system PATH tesseract wins.
     process.env.ELIZA_VISION_VENDOR_DIR = dir;
     expect(resolveTesseract()).toEqual({ bin: "tesseract", env: {} });
   });

--- a/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
+++ b/plugins/plugin-vision/src/ocr-service-linux-tesseract.ts
@@ -24,7 +24,7 @@
  */
 
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
@@ -252,19 +252,31 @@ export function resolveTesseract(): TesseractResolution {
   if (vendor && vendor.length > 0) {
     const root = join(vendor, "tesseract");
     const cand = join(root, "bin", "tesseract");
-    if (existsSync(cand)) {
+    const tessdata = join(root, "tessdata");
+    // Only select the vendor tier when the bundle is actually usable: a binary
+    // AND a language model. A half-staged dir (binary present, tessdata missing)
+    // would otherwise be chosen and then fail at OCR time; fall through to PATH
+    // so the system tesseract still works.
+    if (existsSync(cand) && hasTraineddata(tessdata)) {
       const lib = join(root, "lib");
       const prior = process.env.LD_LIBRARY_PATH;
       return {
         bin: cand,
         env: {
           LD_LIBRARY_PATH: prior ? `${lib}:${prior}` : lib,
-          TESSDATA_PREFIX: join(root, "tessdata"),
+          TESSDATA_PREFIX: tessdata,
         },
       };
     }
   }
   return { bin: "tesseract", env: {} };
+}
+
+/** A vendored tessdata dir is only usable if it carries at least one language
+ * model (`<lang>.traineddata`); otherwise selecting the bundle fails at OCR time. */
+function hasTraineddata(tessdataDir: string): boolean {
+  if (!existsSync(tessdataDir)) return false;
+  return readdirSync(tessdataDir).some((f) => f.endsWith(".traineddata"));
 }
 
 let availabilityCache: boolean | null = null;


### PR DESCRIPTION
## What

Follow-up to the merged #9453 (tesseract OCR resolver). Review of #9453 surfaced three gaps that left the advertised "just ships and works, no host `apt install`" bundle inert/broken on a clean host. This closes them.

- **Full transitive `.so` closure.** `vendor-tesseract-linux.mjs` previously copied only `libtesseract*`/`liblept*` (the comment even admitted "rest come from the host"), so the bundled binary would `dlopen`-fail on a host without the leptonica dep chain (libjpeg/png/tiff/webp/openjp2/gif/zlib/…). It now runs an `ldd` walk with the bundle's own `lib/` on the search path and copies every resolved `.so` except the glibc/loader set every Linux target provides. On a non-glibc host `ldd` fails loud rather than silently shipping an incomplete bundle.
- **Publish the script.** Added `scripts` to `package.json` `files[]` — otherwise `vendor-tesseract-linux.mjs` isn't in the npm package and a desktop build consuming the installed package can't run it.
- **Validate the bundle before selecting it.** `resolveTesseract()` now only picks the vendor tier when a `<lang>.traineddata` is present, so a half-staged dir cleanly falls back to PATH instead of failing at OCR time (+ regression test).

## Verification
- PASS: `bun run --cwd plugins/plugin-vision test -- --run src/ocr-service-linux-tesseract.test.ts` (13/13, incl. new half-staged fallback case)
- PASS: `biome check` on all 4 files
- PASS: `node --check` on the vendor script

The vendor tier remains opt-in (nothing sets `ELIZA_VISION_VENDOR_DIR` yet — the Electrobun build wiring is the tracked #9105 follow-on); the live system-PATH OCR path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)