### PR TITLE
fix(feed): gate root Vercel observability

### DIFF
--- a/packages/feed/apps/web/src/app/layout.tsx
+++ b/packages/feed/apps/web/src/app/layout.tsx
@@ -22,6 +22,8 @@ export const dynamic = "force-dynamic";
 // Farcaster Mini App frame.
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://feed.elizacloud.ai";
 const OG_IMAGE_PATH = "/assets/images/og-image.png";
+const ENABLE_VERCEL_OBSERVABILITY =
+  process.env.NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY === "1";
 
 export const metadata: Metadata = {
   title: "Feed",
@@ -171,8 +173,12 @@ export default async function RootLayout({
             )}
           </div>
         </Providers>
-        <Analytics />
-        <GatedSpeedInsights disabled={isMinimalLayout} />
+        {ENABLE_VERCEL_OBSERVABILITY ? (
+          <>
+            <Analytics />
+            <GatedSpeedInsights disabled={isMinimalLayout} />
+          </>
+        ) : null}
       </body>
     </html>
   );

--- a/packages/feed/packages/testing/unit/feed-component-wiring.test.ts
+++ b/packages/feed/packages/testing/unit/feed-component-wiring.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 const ROOT = join(import.meta.dir, "..", "..", "..");
 const FEED_CLIENT_PATH = join(ROOT, "apps/web/src/app/feed/FeedClient.tsx");
+const ROOT_LAYOUT_PATH = join(ROOT, "apps/web/src/app/layout.tsx");
 const COMPONENTS_INDEX_PATH = join(
   ROOT,
   "apps/web/src/app/feed/components/index.ts",
@@ -36,5 +37,16 @@ describe("feed component wiring", () => {
     const source = readFileSync(COMPONENTS_INDEX_PATH, "utf8");
 
     expect(source).not.toContain("NarrativeStoryList");
+  });
+
+  it("keeps Vercel observability opt-in from the root layout", () => {
+    const source = readFileSync(ROOT_LAYOUT_PATH, "utf8");
+
+    expect(source).toContain(
+      'process.env.NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY === "1"',
+    );
+    expect(source).toMatch(
+      /ENABLE_VERCEL_OBSERVABILITY \? \(\s*<>\s*<Analytics \/>\s*<GatedSpeedInsights disabled=\{isMinimalLayout\} \/>\s*<\/>/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- gate root-layout Vercel Analytics and Speed Insights behind `NEXT_PUBLIC_ENABLE_VERCEL_OBSERVABILITY=1`
- keep the existing minimal-layout Speed Insights disable behavior when observability is explicitly enabled
- add a Feed wiring regression test so Railway production does not request Vercel-only telemetry scripts by default

Fixes the remaining live `_vercel/insights` and `_vercel/speed-insights` 404s tracked under #9301.

## Evidence
- `bun test packages/feed/packages/testing/unit/feed-component-wiring.test.ts` -> 4 passed
- `bunx @biomejs/biome check --config-path ../../biome.json --files-ignore-unknown=true apps/web/src/app/layout.tsx packages/testing/unit/feed-component-wiring.test.ts`
- `bun run scripts/typecheck-workspace.ts packages/testing apps/web` -> all workspace typechecks passed
- `git diff --check`

## Live pre-fix probe
- `https://feed.elizacloud.ai/api/health` returned Feed production health
- DOM wordmark check passed (`svg text = feed`, no Babylon text)
- browser network still showed 404s for `/_vercel/insights/script.js` and `/_vercel/speed-insights/script.js`; this PR removes those script mounts unless explicitly opted in.
