### PR TITLE
fix(ui): prune dead widget slots

### DIFF
--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -1605,6 +1605,35 @@ describe("capability router", () => {
 		});
 	});
 
+	for (const slot of [
+		"chat-inline",
+		"wallet",
+		"browser",
+		"heartbeats",
+		"settings",
+		"automations",
+	]) {
+		it(`rejects removed remote widget slot '${slot}'`, async () => {
+			const router = new RuntimeBrokerCapabilityRouter({
+				invokeRuntime: async () => ({
+					modules: [
+						{
+							id: "remote-weather",
+							name: "@remote/weather",
+							widgets: [{ id: "weather.widget", slot, label: "Weather" }],
+						},
+					],
+				}),
+			});
+
+			await expect(router.plugin.listModules()).rejects.toMatchObject({
+				code: "CAPABILITY_DECODE_FAILED",
+				method: "plugin.modules.list.modules.widgets",
+				message: "slot must be a valid plugin widget slot.",
+			});
+		});
+	}
+
 	it("rejects remote plugin manifests with invalid background policies", async () => {
 		const router = new RuntimeBrokerCapabilityRouter({
 			invokeRuntime: async () => ({

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -291,16 +291,7 @@ export type RemotePluginComponentTypeManifest = {
 export type RemotePluginWidgetManifest = {
 	id: string;
 	pluginId?: string;
-	slot:
-		| "chat-sidebar"
-		| "chat-inline"
-		| "wallet"
-		| "browser"
-		| "heartbeats"
-		| "character"
-		| "settings"
-		| "nav-page"
-		| "automations";
+	slot: "chat-sidebar" | "character" | "nav-page";
 	label: string;
 	icon?: string;
 	order?: number;
@@ -3043,17 +3034,7 @@ function requireRemotePluginWidget(
 ): RemotePluginWidgetManifest {
 	const object = requireObject(value, method);
 	const slot = requireString(object, "slot", method);
-	if (
-		slot !== "chat-sidebar" &&
-		slot !== "chat-inline" &&
-		slot !== "wallet" &&
-		slot !== "browser" &&
-		slot !== "heartbeats" &&
-		slot !== "character" &&
-		slot !== "settings" &&
-		slot !== "nav-page" &&
-		slot !== "automations"
-	) {
+	if (slot !== "chat-sidebar" && slot !== "character" && slot !== "nav-page") {
 		throw decodeError(method, "slot must be a valid plugin widget slot.");
 	}
 	const pluginId = optionalNonEmptyString(object, "pluginId", method);

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -424,17 +424,7 @@ export interface PluginWidgetDeclaration {
 	/** Owning plugin ID. */
 	pluginId: string;
 	/** Where this widget renders. */
-	slot:
-		| "chat-sidebar"
-		| "chat-inline"
-		| "wallet"
-		| "browser"
-		| "heartbeats"
-		| "character"
-		| "settings"
-		| "nav-page"
-		| "automations"
-		| "home";
+	slot: "chat-sidebar" | "character" | "nav-page" | "home";
 	/** Human-readable label. */
 	label: string;
 	/** Lucide icon name. */

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -91,16 +91,10 @@ ChatView today (see divergence D1).
 
 | Slot | Host mounted? | Widgets registered? | Verdict |
 |---|---|---|---|
-| `home` | yes, ViewCatalog | yes, many | active |
+| `home` | yes, HomeScreen | yes, many | active |
 | `chat-sidebar` | yes, TasksEventsPanel | yes, 5 | active |
 | `character` | yes, CharacterHubView | yes, 1 | active |
-| `heartbeats` | yes, HeartbeatsView | no | **empty mount - remove host or register a widget** |
-| `chat-inline` | no, never mounted | no | **dead slot - the inline-marker registry IS this concept; prune the enum value** |
-| `wallet` | no, never mounted | no | **dead slot** |
-| `browser` | no, never mounted | no | **dead slot** (browser uses `chat-sidebar`) |
-| `settings` | no, never mounted | no | **dead slot** |
-| `nav-page` | no, never mounted | no | **dead slot** |
-| `automations` | no, never mounted | no | **dead slot** |
+| `nav-page` | no WidgetHost mount | no component widgets | active app-navigation contract |
 
 ---
 

--- a/packages/ui/src/components/pages/HeartbeatsView.tsx
+++ b/packages/ui/src/components/pages/HeartbeatsView.tsx
@@ -17,9 +17,6 @@ import { useRegisterViewChatBinding } from "../../state/view-chat-binding";
 import { confirmDesktopAction } from "../../utils";
 import { formatDateTime, formatDurationMs } from "../../utils/format";
 import { detectUiHostCapabilities } from "../../utils/host-capabilities";
-// Direct sub-path import to avoid the widgets/index.ts ↔ WidgetHost.tsx
-// chunk-level circular dependency.
-import { WidgetHost } from "../../widgets/WidgetHost";
 import { ChatSearchHint } from "../composites/chat-search-hint";
 import { PagePanel } from "../composites/page-panel";
 import { SidebarCollapsedActionButton } from "../composites/sidebar/sidebar-collapsed-rail";
@@ -824,7 +821,6 @@ function HeartbeatsLayout() {
         data-testid="heartbeats-shell"
         sidebar={heartbeatsSidebar}
         contentInnerClassName="mx-auto w-full max-w-[96rem]"
-        footer={<WidgetHost slot="heartbeats" className="py-3" />}
         mobileSidebarLabel={mobileSidebarLabel}
       >
         <div className="flex min-h-0 flex-1 flex-col">

--- a/packages/ui/src/widgets/README.md
+++ b/packages/ui/src/widgets/README.md
@@ -3,8 +3,7 @@
 Plugin-contributed UI fragments rendered into named **slots** across the app
 (`packages/ui/src/widgets/types.ts` → `WidgetSlot`):
 
-`chat-sidebar` · `chat-inline` · `wallet` · `browser` · `heartbeats` ·
-`character` · `settings` · `nav-page` · `automations` · **`home`**
+`chat-sidebar` · `character` · `nav-page` · **`home`**
 
 A `<WidgetHost slot="…">` (`WidgetHost.tsx`) resolves every enabled declaration
 for a slot, wraps each in an error boundary, and renders the bundled React

--- a/packages/ui/src/widgets/WidgetHost.tsx
+++ b/packages/ui/src/widgets/WidgetHost.tsx
@@ -3,7 +3,7 @@
  *
  * Drop this into any page view:
  *   <WidgetHost slot="chat-sidebar" />
- *   <WidgetHost slot="wallet" />
+ *   <WidgetHost slot="home" layout="grid" />
  *
  * Queries the widget registry for matching declarations, wraps each in an
  * error boundary, and renders either the bundled React component or falls back

--- a/packages/ui/src/widgets/types.test.ts
+++ b/packages/ui/src/widgets/types.test.ts
@@ -1,0 +1,20 @@
+import type { PluginWidgetDeclaration as CorePluginWidgetDeclaration } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { WidgetSlot } from "./types";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+const widgetSlotsMatchCore: Expect<
+  Equal<WidgetSlot, CorePluginWidgetDeclaration["slot"]>
+> = true;
+
+describe("WidgetSlot contract", () => {
+  it("stays aligned with core PluginWidgetDeclaration", () => {
+    expect(widgetSlotsMatchCore).toBe(true);
+  });
+});

--- a/packages/ui/src/widgets/types.ts
+++ b/packages/ui/src/widgets/types.ts
@@ -7,14 +7,8 @@ import type { ActivityEvent } from "../hooks/useActivityEvents";
 /** Named injection points where plugin widgets can render. */
 export type WidgetSlot =
   | "chat-sidebar"
-  | "chat-inline"
-  | "wallet"
-  | "browser"
-  | "heartbeats"
   | "character"
-  | "settings"
   | "nav-page"
-  | "automations"
   // Frontpage / Springboard home surface (#9143). Plugins opt a widget into the
   // home screen by declaring this slot; the Home/Springboard surface mounts it.
   | "home";

--- a/packages/ui/src/widgets/visibility.ts
+++ b/packages/ui/src/widgets/visibility.ts
@@ -13,9 +13,9 @@ import type { WidgetSlot } from "./types";
  * `declaration.defaultEnabled`, so default flips don't reset users who never
  * touched the toggle.
  *
- * Wallet/browser/home widgets use the same path once their plugin registers
- * them: they appear with `defaultEnabled` and the user can hide them via the
- * same panel.
+ * Home and other mounted widget slots use the same path once their plugin
+ * registers them: they appear with `defaultEnabled` and the user can hide them
+ * via the same panel.
  */
 
 const CHAT_SIDEBAR_VISIBILITY_STORAGE_KEY = "eliza:chat-sidebar:visibility";


### PR DESCRIPTION
## Summary
- Prune unreachable widget slots from the core/UI widget contracts and remote-widget manifest decoder: `chat-inline`, `wallet`, `browser`, `heartbeats`, `settings`, and `automations`.
- Keep `nav-page` because it is still the app-navigation contract, and document that it is not a `WidgetHost` mount.
- Remove the empty `HeartbeatsView` widget footer, refresh the widget README/matrix, and replace the stale `WidgetHost` example.
- Add a type-level UI/core slot sync test plus decoder tests proving removed remote slots are rejected.

## Verification
- PASS: `bun install` after `git fetch origin && git rebase origin/develop`
- PASS: `./node_modules/.bin/biome check packages/core/src/capabilities/index.ts packages/core/src/capabilities/index.test.ts packages/core/src/types/plugin.ts packages/ui/src/components/pages/HeartbeatsView.tsx packages/ui/src/widgets/types.ts packages/ui/src/widgets/types.test.ts packages/ui/src/widgets/WidgetHost.tsx packages/ui/src/widgets/visibility.ts`
- PASS: `bun run --cwd packages/core test -- --run src/capabilities/index.test.ts` (59 tests)
- PASS: `bun run --cwd packages/ui test -- --run src/widgets/types.test.ts src/widgets/registry.home.test.ts src/widgets/visibility.test.ts src/widgets/WidgetHost.test.tsx` (18 tests)
- PASS: `bun run --cwd packages/core typecheck`
- PASS: `bun run --cwd packages/ui typecheck`
- PASS: `bun run --cwd packages/agent typecheck`
- BLOCKED: `bun run verify` still fails on current `develop` at `@elizaos/example-telegram#typecheck`: `packages/examples/telegram/telegram-agent.ts(48,12): error TS2307: Cannot find module '@elizaos/plugin-openai' or its corresponding type declarations.` This run stopped after 61 successful tasks / 70 total; in-flight Capacitor builds were SIGINTed by Turbo after the first failure.

## Evidence Notes
- Screenshots/video: N/A for this narrow cleanup. The removed `HeartbeatsView` footer was an empty `WidgetHost` with `hideWhenEmpty` defaulting to true, so it rendered no visible UI when empty.

Refs #9448
Refs #9450
