### PR TITLE
test(browser): add action parity matrix (#9476)

### DIFF
--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -73,6 +73,9 @@ src/
     workspace-setup.ts             Workspace setup routes
     workspace.ts                   Workspace routes
     workspace-account-gate.ts      Account gate middleware
+  parity/
+    browser-matrix.ts              Machine-checkable BROWSER action parity matrix (#9476)
+    index.ts                       Parity tooling barrel
   targets/
     bridge-target.ts               `bridge` BrowserTarget — dispatches to Chrome/Safari companion
     stagehand-target.ts            `stagehand` BrowserTarget — Playwright/Stagehand fallback

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -73,6 +73,9 @@ src/
     workspace-setup.ts             Workspace setup routes
     workspace.ts                   Workspace routes
     workspace-account-gate.ts      Account gate middleware
+  parity/
+    browser-matrix.ts              Machine-checkable BROWSER action parity matrix (#9476)
+    index.ts                       Parity tooling barrel
   targets/
     bridge-target.ts               `bridge` BrowserTarget — dispatches to Chrome/Safari companion
     stagehand-target.ts            `stagehand` BrowserTarget — Playwright/Stagehand fallback

--- a/plugins/plugin-browser/src/index.ts
+++ b/plugins/plugin-browser/src/index.ts
@@ -44,6 +44,7 @@ export * from "./companion-auth.js";
 export * from "./contracts.js";
 export { BrowserBridgeAdapter } from "./message-adapter.js";
 export * from "./packaging.js";
+export * from "./parity/index.js";
 export * from "./password-manager-bridge.js";
 export { browserPlugin } from "./plugin.js";
 export * from "./routes/bridge.js";
@@ -77,6 +78,7 @@ import {
   BROWSER_SERVICE_TYPE as _bs_1_BROWSER_SERVICE_TYPE,
   BrowserService as _bs_2_BrowserService,
 } from "./browser-service.js";
+import { validateBrowserParityMatrix as _bs_16_validateBrowserParityMatrix } from "./parity/browser-matrix.js";
 import { browserPlugin as _bs_7_browserPlugin } from "./plugin.js";
 import {
   FRAME_FILE as _bs_8_FRAME_FILE,
@@ -86,7 +88,6 @@ import {
 
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name.
-// biome-ignore lint/correctness/noUnusedVariables: bundle-safety sink.
 const __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__ = [
   _bs_1_BROWSER_SERVICE_TYPE,
   _bs_2_BrowserService,
@@ -103,6 +104,7 @@ const __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__ = [
   _bs_13_resolveBrowserBridgeCompanionPairingTokenExpiresAt,
   _bs_14_buildWaitForUrlPredicate,
   _bs_15_waitForUrl,
+  _bs_16_validateBrowserParityMatrix,
 ];
 const bundleSafetyGlobal = globalThis as typeof globalThis & {
   __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__?: typeof __bundle_safety_PLUGINS_PLUGIN_BROWSER_SRC_INDEX__;

--- a/plugins/plugin-browser/src/parity/browser-matrix.test.ts
+++ b/plugins/plugin-browser/src/parity/browser-matrix.test.ts
@@ -1,0 +1,85 @@
+import { listSubactionsFromParameters } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { browserAction } from "../actions/browser.js";
+import { browserPlugin } from "../plugin.js";
+import {
+  BROWSER_PARITY_MATRIX,
+  browserParitySummary,
+  validateBrowserParityMatrix,
+} from "./browser-matrix.js";
+
+const actionNames = (browserPlugin.actions ?? []).map((action) => action.name);
+const browserActionValues = listSubactionsFromParameters(
+  browserAction.parameters,
+);
+
+describe("validateBrowserParityMatrix", () => {
+  it("matches the live promoted BROWSER action surface", () => {
+    const result = validateBrowserParityMatrix(
+      actionNames,
+      browserActionValues,
+    );
+    expect(
+      result.ok,
+      `browser parity drift:\n${result.problems
+        .map((problem) => `  - ${problem.capability}: ${problem.problem}`)
+        .join("\n")}`,
+    ).toBe(true);
+    expect(result.confirmed).toBeGreaterThan(20);
+  });
+
+  it("flags a missing registered browser verb", () => {
+    const result = validateBrowserParityMatrix(
+      actionNames.filter((name) => name !== "BROWSER_OPEN"),
+      browserActionValues,
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      result.problems.some((problem) => problem.capability === "open"),
+    ).toBe(true);
+  });
+
+  it("flags a schema action value that has no matrix row", () => {
+    const result = validateBrowserParityMatrix(actionNames, [
+      ...browserActionValues,
+      "future_browser_action",
+    ]);
+    expect(result.ok).toBe(false);
+    expect(
+      result.problems.some(
+        (problem) => problem.capability === "future_browser_action",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps status counts aligned to the matrix length", () => {
+    const summary = browserParitySummary();
+    expect(summary.have + summary.partial + summary.planned + summary.na).toBe(
+      summary.total,
+    );
+    expect(summary.total).toBe(BROWSER_PARITY_MATRIX.length);
+    expect(summary.have).toBeGreaterThan(20);
+    expect(summary.na).toBe(0);
+  });
+
+  it("does not allow duplicate action values or promoted verbs", () => {
+    const actionValues = new Set<string>();
+    const elizaVerbs = new Set<string>();
+    for (const capability of BROWSER_PARITY_MATRIX) {
+      if (capability.actionValue) {
+        expect(
+          actionValues.has(capability.actionValue),
+          `duplicate actionValue ${capability.actionValue}`,
+        ).toBe(false);
+        actionValues.add(capability.actionValue);
+      }
+      if (capability.elizaVerb) {
+        expect(
+          elizaVerbs.has(capability.elizaVerb),
+          `duplicate elizaVerb ${capability.elizaVerb}`,
+        ).toBe(false);
+        elizaVerbs.add(capability.elizaVerb);
+      }
+    }
+  });
+});

--- a/plugins/plugin-browser/src/parity/browser-matrix.ts
+++ b/plugins/plugin-browser/src/parity/browser-matrix.ts
@@ -1,0 +1,424 @@
+/**
+ * Machine-checkable browser action parity matrix (#9476).
+ *
+ * This is the browser equivalent of plugin-computeruse's parity guard: the
+ * matrix is data, and the validator cross-checks it against the live registered
+ * action surface plus the BROWSER action schema. That keeps browser capability
+ * coverage from drifting silently while real-driver and benchmark lanes are
+ * added.
+ */
+
+import type { Action } from "@elizaos/core";
+import { listSubactionsFromParameters } from "@elizaos/core";
+import { browserAction } from "../actions/browser.js";
+
+export type BrowserParityStatus = "have" | "partial" | "planned" | "na";
+export type BrowserParitySurface =
+  | "workspace"
+  | "legacy-alias"
+  | "credential"
+  | "waiter";
+
+export interface BrowserParityCapability {
+  /** Canonical capability id. Usually the exposed BROWSER action value. */
+  id: string;
+  /** Value declared in the BROWSER action schema. */
+  actionValue?: string;
+  /** Registered promoted action name for this capability. */
+  elizaVerb?: string;
+  /** Runtime command/subaction this capability dispatches to. */
+  dispatchesTo?: string;
+  status: BrowserParityStatus;
+  surface: BrowserParitySurface;
+  note?: string;
+}
+
+const WORKSPACE = "workspace" as const;
+
+export const BROWSER_PARITY_MATRIX: readonly BrowserParityCapability[] = [
+  {
+    id: "open",
+    actionValue: "open",
+    elizaVerb: "BROWSER_OPEN",
+    dispatchesTo: "open",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "navigate",
+    actionValue: "navigate",
+    elizaVerb: "BROWSER_NAVIGATE",
+    dispatchesTo: "navigate",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "click",
+    actionValue: "click",
+    elizaVerb: "BROWSER_CLICK",
+    dispatchesTo: "click",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "type",
+    actionValue: "type",
+    elizaVerb: "BROWSER_TYPE",
+    dispatchesTo: "type",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "press",
+    actionValue: "press",
+    elizaVerb: "BROWSER_PRESS",
+    dispatchesTo: "press",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "get",
+    actionValue: "get",
+    elizaVerb: "BROWSER_GET",
+    dispatchesTo: "get",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "state",
+    actionValue: "state",
+    elizaVerb: "BROWSER_STATE",
+    dispatchesTo: "state",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "snapshot",
+    actionValue: "snapshot",
+    elizaVerb: "BROWSER_SNAPSHOT",
+    dispatchesTo: "snapshot",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "screenshot",
+    actionValue: "screenshot",
+    elizaVerb: "BROWSER_SCREENSHOT",
+    dispatchesTo: "screenshot",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "reload",
+    actionValue: "reload",
+    elizaVerb: "BROWSER_RELOAD",
+    dispatchesTo: "reload",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "back",
+    actionValue: "back",
+    elizaVerb: "BROWSER_BACK",
+    dispatchesTo: "back",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "forward",
+    actionValue: "forward",
+    elizaVerb: "BROWSER_FORWARD",
+    dispatchesTo: "forward",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "close",
+    actionValue: "close",
+    elizaVerb: "BROWSER_CLOSE",
+    dispatchesTo: "close",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "show",
+    actionValue: "show",
+    elizaVerb: "BROWSER_SHOW",
+    dispatchesTo: "show",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "hide",
+    actionValue: "hide",
+    elizaVerb: "BROWSER_HIDE",
+    dispatchesTo: "hide",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "wait",
+    actionValue: "wait",
+    elizaVerb: "BROWSER_WAIT",
+    dispatchesTo: "wait",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "tab",
+    actionValue: "tab",
+    elizaVerb: "BROWSER_TAB",
+    dispatchesTo: "tab",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "realistic-click",
+    actionValue: "realistic_click",
+    elizaVerb: "BROWSER_REALISTIC_CLICK",
+    dispatchesTo: "realistic-click",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "realistic-fill",
+    actionValue: "realistic_fill",
+    elizaVerb: "BROWSER_REALISTIC_FILL",
+    dispatchesTo: "realistic-fill",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "realistic-type",
+    actionValue: "realistic_type",
+    elizaVerb: "BROWSER_REALISTIC_TYPE",
+    dispatchesTo: "realistic-type",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "realistic-press",
+    actionValue: "realistic_press",
+    elizaVerb: "BROWSER_REALISTIC_PRESS",
+    dispatchesTo: "realistic-press",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "cursor-move",
+    actionValue: "cursor_move",
+    elizaVerb: "BROWSER_CURSOR_MOVE",
+    dispatchesTo: "cursor-move",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "cursor-hide",
+    actionValue: "cursor_hide",
+    elizaVerb: "BROWSER_CURSOR_HIDE",
+    dispatchesTo: "cursor-hide",
+    status: "have",
+    surface: WORKSPACE,
+  },
+  {
+    id: "autofill-login",
+    actionValue: "autofill_login",
+    elizaVerb: "BROWSER_AUTOFILL_LOGIN",
+    dispatchesTo: "autofill-login",
+    status: "have",
+    surface: "credential",
+    note: "Vault-gated credential autofill over the active workspace tab.",
+  },
+  {
+    id: "wait-for-url",
+    actionValue: "wait_for_url",
+    elizaVerb: "BROWSER_WAIT_FOR_URL",
+    dispatchesTo: "wait-for-url",
+    status: "have",
+    surface: "waiter",
+    note: "Polls current tab URL against a substring or /regex/ pattern.",
+  },
+
+  // Legacy aliases remain promoted because they are still declared in the
+  // BROWSER action schema. Keep them explicit so removing one is deliberate.
+  {
+    id: "info",
+    actionValue: "info",
+    elizaVerb: "BROWSER_INFO",
+    dispatchesTo: "state",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "context",
+    actionValue: "context",
+    elizaVerb: "BROWSER_CONTEXT",
+    dispatchesTo: "state",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "get-context",
+    actionValue: "get_context",
+    elizaVerb: "BROWSER_GET_CONTEXT",
+    dispatchesTo: "state",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "list-tabs",
+    actionValue: "list_tabs",
+    elizaVerb: "BROWSER_LIST_TABS",
+    dispatchesTo: "tab:list",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "open-tab",
+    actionValue: "open_tab",
+    elizaVerb: "BROWSER_OPEN_TAB",
+    dispatchesTo: "tab:new",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "close-tab",
+    actionValue: "close_tab",
+    elizaVerb: "BROWSER_CLOSE_TAB",
+    dispatchesTo: "tab:close",
+    status: "have",
+    surface: "legacy-alias",
+  },
+  {
+    id: "switch-tab",
+    actionValue: "switch_tab",
+    elizaVerb: "BROWSER_SWITCH_TAB",
+    dispatchesTo: "tab:switch",
+    status: "have",
+    surface: "legacy-alias",
+  },
+];
+
+export interface BrowserParityValidationProblem {
+  capability: string;
+  problem: string;
+}
+
+export interface BrowserParityValidationResult {
+  ok: boolean;
+  problems: BrowserParityValidationProblem[];
+  confirmed: number;
+}
+
+function liveBrowserActionValues(): readonly string[] {
+  return listSubactionsFromParameters(browserAction.parameters);
+}
+
+export function browserParitySummary(): {
+  have: number;
+  partial: number;
+  planned: number;
+  na: number;
+  total: number;
+} {
+  let have = 0;
+  let partial = 0;
+  let planned = 0;
+  let na = 0;
+  for (const cap of BROWSER_PARITY_MATRIX) {
+    if (cap.status === "have") have += 1;
+    else if (cap.status === "partial") partial += 1;
+    else if (cap.status === "planned") planned += 1;
+    else na += 1;
+  }
+  return { have, partial, planned, na, total: BROWSER_PARITY_MATRIX.length };
+}
+
+export function validateBrowserParityMatrix(
+  actionNames: readonly string[],
+  actionValues: readonly string[] = liveBrowserActionValues(),
+): BrowserParityValidationResult {
+  const registered = new Set(actionNames);
+  const schemaValues = new Set(actionValues);
+  const matrixByVerb = new Map<string, BrowserParityCapability>();
+  const matrixByActionValue = new Map<string, BrowserParityCapability>();
+  const problems: BrowserParityValidationProblem[] = [];
+  let confirmed = 0;
+
+  for (const cap of BROWSER_PARITY_MATRIX) {
+    if (cap.elizaVerb) {
+      const existing = matrixByVerb.get(cap.elizaVerb);
+      if (existing) {
+        problems.push({
+          capability: cap.id,
+          problem: `duplicates elizaVerb ${cap.elizaVerb} from ${existing.id}`,
+        });
+      }
+      matrixByVerb.set(cap.elizaVerb, cap);
+    }
+    if (cap.actionValue) {
+      const existing = matrixByActionValue.get(cap.actionValue);
+      if (existing) {
+        problems.push({
+          capability: cap.id,
+          problem: `duplicates action value ${cap.actionValue} from ${existing.id}`,
+        });
+      }
+      matrixByActionValue.set(cap.actionValue, cap);
+    }
+
+    if (cap.status === "na") {
+      if (cap.elizaVerb) {
+        problems.push({
+          capability: cap.id,
+          problem: `status "na" must not declare elizaVerb ${cap.elizaVerb}`,
+        });
+      }
+      continue;
+    }
+
+    if (cap.elizaVerb && !registered.has(cap.elizaVerb)) {
+      problems.push({
+        capability: cap.id,
+        problem: `verb ${cap.elizaVerb} is marked "${cap.status}" but is NOT registered`,
+      });
+    } else if (cap.elizaVerb) {
+      confirmed += 1;
+    }
+
+    if (cap.actionValue && !schemaValues.has(cap.actionValue)) {
+      problems.push({
+        capability: cap.id,
+        problem: `action value ${cap.actionValue} is not declared by the BROWSER action schema`,
+      });
+    }
+  }
+
+  for (const actionValue of schemaValues) {
+    if (!matrixByActionValue.has(actionValue)) {
+      problems.push({
+        capability: actionValue,
+        problem:
+          "BROWSER action schema value is missing from BROWSER_PARITY_MATRIX",
+      });
+    }
+  }
+
+  for (const actionName of registered) {
+    if (actionName.startsWith("BROWSER_") && !matrixByVerb.has(actionName)) {
+      problems.push({
+        capability: actionName,
+        problem:
+          "registered promoted BROWSER action is missing from BROWSER_PARITY_MATRIX",
+      });
+    }
+  }
+
+  return { ok: problems.length === 0, problems, confirmed };
+}
+
+export function browserActionNames(
+  actions: readonly Action[],
+): readonly string[] {
+  return actions.map((action) => action.name);
+}

--- a/plugins/plugin-browser/src/parity/index.ts
+++ b/plugins/plugin-browser/src/parity/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Browser parity tooling (#9476) - public surface.
+ */
+
+export {
+  BROWSER_PARITY_MATRIX,
+  type BrowserParityCapability,
+  type BrowserParityStatus,
+  type BrowserParitySurface,
+  type BrowserParityValidationProblem,
+  type BrowserParityValidationResult,
+  browserActionNames,
+  browserParitySummary,
+  validateBrowserParityMatrix,
+} from "./browser-matrix.js";


### PR DESCRIPTION

## Summary
- Add a machine-checkable browser action parity matrix for the promoted `BROWSER_*` surface and `BROWSER` action schema values.
- Add a focused Vitest guard that fails when registered browser verbs or schema action values drift away from the matrix.
- Export the parity tooling from `plugin-browser` and document the new package-local layout.

Refs #9476.

## Verification
- PASS `git fetch origin && git rebase origin/develop`
- PASS `bun install`
- PASS `bunx @biomejs/biome check plugins/plugin-browser/src/parity/browser-matrix.ts plugins/plugin-browser/src/parity/browser-matrix.test.ts plugins/plugin-browser/src/parity/index.ts plugins/plugin-browser/src/index.ts`
- PASS `bun run --cwd plugins/plugin-browser test -- src/parity/browser-matrix.test.ts`
- PASS `bun run --cwd plugins/plugin-browser test`
- PASS `bun run --cwd plugins/plugin-browser typecheck`
- PASS `bun run --cwd plugins/plugin-browser build`
- PASS `git diff --check`
- FAIL `bun run verify` stopped on unrelated `@elizaos/plugin-vector-browser#typecheck`: `src/register-terminal-view.tsx` cannot resolve `@elizaos/ui/spatial/tui`.
