### PR TITLE
ui: declutter plugin app views

### DIFF
--- a/packages/ui/src/components/apps/extensions/surface.tsx
+++ b/packages/ui/src/components/apps/extensions/surface.tsx
@@ -89,12 +89,14 @@ export function SurfaceEmptyState({
   body,
 }: {
   title: string;
-  body: string;
+  body?: string;
 }) {
   return (
     <div className="px-1 py-2">
       <div className="text-xs-tight font-semibold text-muted">{title}</div>
-      <p className="mt-1 text-xs leading-5 text-muted-strong">{body}</p>
+      {body ? (
+        <p className="mt-1 text-xs leading-5 text-muted-strong">{body}</p>
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/components/apps/extensions/surface.tsx
+++ b/packages/ui/src/components/apps/extensions/surface.tsx
@@ -11,15 +11,15 @@ export interface SelectedAppRun {
 function toneClassName(tone: SurfaceTone): string {
   switch (tone) {
     case "success":
-      return "border-ok/30 bg-ok/10 text-ok";
+      return "text-ok";
     case "accent":
-      return "border-accent/25 bg-accent/10 text-accent";
+      return "text-accent";
     case "warn":
-      return "border-warn/30 bg-warn/10 text-warn";
+      return "text-warn";
     case "danger":
-      return "border-danger/30 bg-danger/10 text-danger";
+      return "text-danger";
     default:
-      return "border-border/35 bg-bg-hover/70 text-muted-strong";
+      return "text-muted-strong";
   }
 }
 
@@ -32,7 +32,7 @@ export function SurfaceBadge({
 }) {
   return (
     <span
-      className={`inline-flex min-h-6 items-center rounded-full border px-2.5 py-1 text-2xs font-medium uppercase tracking-[0.14em] ${toneClassName(tone)}`}
+      className={`inline-flex min-h-6 items-center px-1.5 py-1 text-2xs font-medium ${toneClassName(tone)}`}
     >
       {children}
     </span>
@@ -51,15 +51,13 @@ export function SurfaceCard({
   subtitle?: React.ReactNode;
 }) {
   return (
-    <div className="rounded-sm border border-border/35 bg-card/74 px-4 py-3 ">
-      <div className="text-xs-tight font-medium uppercase tracking-[0.16em] text-muted">
-        {label}
-      </div>
-      <div className={`mt-1 text-xs leading-5 ${toneClassName(tone)}`}>
+    <div className="px-1 py-1.5">
+      <div className="text-xs-tight font-medium text-muted">{label}</div>
+      <div className={`mt-0.5 text-xs leading-5 ${toneClassName(tone)}`}>
         {value}
       </div>
       {subtitle ? (
-        <div className="mt-1 text-xs-tight leading-5 text-muted-strong">
+        <div className="mt-0.5 text-xs-tight leading-5 text-muted-strong">
           {subtitle}
         </div>
       ) : null}
@@ -79,10 +77,8 @@ export function SurfaceSection({
   children: React.ReactNode;
 }) {
   return (
-    <section className="space-y-3 rounded-sm border border-border/35 bg-card/74 p-4 ">
-      <div className="text-xs-tight font-semibold uppercase tracking-[0.18em] text-muted">
-        {title}
-      </div>
+    <section className="space-y-2 py-1">
+      <div className="sr-only">{title}</div>
       {children}
     </section>
   );
@@ -96,11 +92,9 @@ export function SurfaceEmptyState({
   body: string;
 }) {
   return (
-    <div className="rounded-sm border border-border/35 bg-card/74 p-4 ">
-      <div className="text-xs-tight font-semibold uppercase tracking-[0.18em] text-muted">
-        {title}
-      </div>
-      <p className="mt-2 text-xs leading-6 text-muted-strong">{body}</p>
+    <div className="px-1 py-2">
+      <div className="text-xs-tight font-semibold text-muted">{title}</div>
+      <p className="mt-1 text-xs leading-5 text-muted-strong">{body}</p>
     </div>
   );
 }

--- a/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.tsx
@@ -106,7 +106,7 @@ export const PagePanelCollapsibleSection = React.forwardRef<
       className={cn(
         expandOnCollapsedSurfaceClick &&
           !isExpanded &&
-          "cursor-pointer transition-[border-color,box-shadow,transform] hover:border-border/60 ",
+          "cursor-pointer transition-colors hover:text-txt",
         className,
       )}
       onClick={handleSurfaceClick}
@@ -141,9 +141,7 @@ export const PagePanelCollapsibleSection = React.forwardRef<
         bordered={isExpanded && bordered}
       />
       {isExpanded ? (
-        <div className={cn("px-4 pb-4 pt-1 sm:px-5 sm:pb-5", bodyClassName)}>
-          {children}
-        </div>
+        <div className={cn("px-1 pb-3 pt-1", bodyClassName)}>{children}</div>
       ) : null}
     </PagePanelRoot>
   );

--- a/packages/ui/src/components/composites/page-panel/page-panel-empty.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-empty.tsx
@@ -16,18 +16,14 @@ export function PageEmptyState({
     return (
       <PagePanelRoot
         className={cn(
-          "flex min-h-[58vh] flex-col items-center justify-center px-6 py-10 text-center",
+          "flex min-h-[42vh] flex-col items-center justify-center px-4 py-8 text-center",
           className,
         )}
         {...props}
       >
         <div className="max-w-md space-y-2">
           <div className="text-base font-medium text-txt-strong">{title}</div>
-          {description ? (
-            <div className="text-sm leading-relaxed text-muted">
-              {description}
-            </div>
-          ) : null}
+          {description ? <div className="sr-only">{description}</div> : null}
         </div>
         {action ? <div className="mt-4">{action}</div> : null}
         {children}
@@ -39,18 +35,14 @@ export function PageEmptyState({
     return (
       <div
         className={cn(
-          "flex min-h-0 flex-1 flex-col items-center justify-center px-6 py-10 text-center",
+          "flex min-h-0 flex-1 flex-col items-center justify-center px-4 py-8 text-center",
           className,
         )}
         {...props}
       >
         <div className="max-w-md space-y-2">
           <div className="text-base font-medium text-txt-strong">{title}</div>
-          {description ? (
-            <div className="text-sm leading-relaxed text-muted">
-              {description}
-            </div>
-          ) : null}
+          {description ? <div className="sr-only">{description}</div> : null}
         </div>
         {action ? <div className="mt-4">{action}</div> : null}
         {children}
@@ -62,14 +54,15 @@ export function PageEmptyState({
     <EmptyState
       className={cn(
         variant === "inset"
-          ? "min-h-[14rem] rounded-sm border border-dashed border-border bg-card px-5 py-10"
-          : "min-h-[18rem] rounded-sm border border-dashed border-border bg-card px-6 py-12 ",
+          ? "min-h-[10rem] px-4 py-8"
+          : "min-h-[12rem] px-4 py-8",
         className,
       )}
-      description={description}
+      description={undefined}
       title={title}
       {...props}
     >
+      {description ? <span className="sr-only">{description}</span> : null}
       {children}
       {action ? <div className="mt-4">{action}</div> : null}
     </EmptyState>

--- a/packages/ui/src/components/composites/page-panel/page-panel-frame.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-frame.tsx
@@ -13,10 +13,7 @@ export const PagePanelFrame = React.forwardRef<
   return (
     <div
       ref={ref}
-      className={cn(
-        "flex h-full w-full min-h-0 bg-transparent p-0 lg:p-1",
-        className,
-      )}
+      className={cn("flex h-full w-full min-h-0 bg-transparent p-0", className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
@@ -50,8 +50,8 @@ export function PanelHeader({
     <div
       className={cn(
         hasActions
-          ? "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-4 py-3 sm:px-5"
-          : "flex items-start gap-3 px-4 py-3 sm:px-5",
+          ? "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-1 py-2"
+          : "flex items-start gap-2 px-1 py-2",
         className,
       )}
       {...props}
@@ -72,19 +72,14 @@ export function PanelHeader({
           <div
             className={cn(
               "text-sm font-semibold text-txt-strong",
-              eyebrow && "mt-1",
+              eyebrow && "mt-0.5",
               headingClassName,
             )}
           >
             {heading}
           </div>
           {description ? (
-            <div
-              className={cn(
-                "mt-1 text-xs leading-relaxed text-muted",
-                descriptionClassName,
-              )}
-            >
+            <div className={cn("sr-only", descriptionClassName)}>
               {description}
             </div>
           ) : null}
@@ -105,14 +100,7 @@ export function SummaryCard({
   ...props
 }: SummaryCardProps) {
   return (
-    <div
-      className={cn(
-        "rounded-sm border border-border bg-card p-4",
-        compact && "p-3.5",
-        className,
-      )}
-      {...props}
-    />
+    <div className={cn("p-2", compact && "p-1.5", className)} {...props} />
   );
 }
 
@@ -120,7 +108,7 @@ export function PageActionRail({ className, ...props }: PageActionRailProps) {
   return (
     <div
       className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap rounded-sm border border-border bg-card",
+        "inline-flex items-center gap-1 whitespace-nowrap",
         className,
       )}
       {...props}
@@ -138,14 +126,14 @@ export function PanelNotice({
   return (
     <div
       className={cn(
-        "rounded-sm border px-4 py-3 text-sm",
+        "px-1 py-2 text-sm",
         tone === "accent"
-          ? "border-accent bg-accent-subtle text-txt"
+          ? "text-txt"
           : tone === "warning"
-            ? "border-warn/30 bg-warn/10 text-txt"
+            ? "text-txt"
             : tone === "danger"
-              ? "border-danger/30 bg-danger/10 text-danger"
-              : "border-border bg-card text-muted",
+              ? "text-danger"
+              : "text-muted",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/composites/page-panel/page-panel-loading.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-loading.tsx
@@ -14,7 +14,7 @@ export function PageLoadingState({
     return (
       <PagePanelRoot
         className={cn(
-          "flex min-h-[58vh] flex-col items-center justify-center px-6 py-10 text-center",
+          "flex min-h-[42vh] flex-col items-center justify-center px-4 py-8 text-center",
           className,
         )}
         {...props}
@@ -22,11 +22,7 @@ export function PageLoadingState({
         <Spinner className="h-5 w-5 text-muted" />
         <div className="mt-4 max-w-md space-y-2">
           <div className="text-base font-medium text-txt-strong">{heading}</div>
-          {description ? (
-            <div className="text-sm leading-relaxed text-muted">
-              {description}
-            </div>
-          ) : null}
+          {description ? <div className="sr-only">{description}</div> : null}
         </div>
       </PagePanelRoot>
     );
@@ -37,7 +33,7 @@ export function PageLoadingState({
       <PagePanelRoot
         variant="workspace"
         className={cn(
-          "items-center justify-center px-6 py-10 text-center",
+          "items-center justify-center px-4 py-8 text-center",
           className,
         )}
         {...props}
@@ -45,11 +41,7 @@ export function PageLoadingState({
         <Spinner className="h-5 w-5 text-muted" />
         <div className="mt-4 max-w-md space-y-2">
           <div className="text-base font-medium text-txt-strong">{heading}</div>
-          {description ? (
-            <div className="text-sm leading-relaxed text-muted">
-              {description}
-            </div>
-          ) : null}
+          {description ? <div className="sr-only">{description}</div> : null}
         </div>
       </PagePanelRoot>
     );
@@ -58,7 +50,7 @@ export function PageLoadingState({
   return (
     <div
       className={cn(
-        "flex min-h-[18rem] flex-col items-center justify-center rounded-sm border border-dashed border-border bg-card px-6 py-12 text-center ",
+        "flex min-h-[12rem] flex-col items-center justify-center px-4 py-8 text-center",
         className,
       )}
       {...props}
@@ -66,11 +58,7 @@ export function PageLoadingState({
       <Spinner className="h-5 w-5 text-muted" />
       <div className="mt-4 max-w-md space-y-2">
         <div className="text-base font-medium text-txt-strong">{heading}</div>
-        {description ? (
-          <div className="text-sm leading-relaxed text-muted">
-            {description}
-          </div>
-        ) : null}
+        {description ? <div className="sr-only">{description}</div> : null}
       </div>
     </div>
   );

--- a/packages/ui/src/components/composites/page-panel/page-panel-root.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-root.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "../../../lib/utils";
 import type { PagePanelProps } from "./page-panel-types";
 
-const BASE_SURFACE = "border border-border bg-card ";
+const BASE_SURFACE = "bg-transparent";
 
 export const PagePanelRoot = React.forwardRef<HTMLDivElement, PagePanelProps>(
   function PagePanelRoot(
@@ -17,16 +17,16 @@ export const PagePanelRoot = React.forwardRef<HTMLDivElement, PagePanelProps>(
         ref={ref as never}
         className={cn(
           variant === "surface"
-            ? `w-full rounded-sm ${BASE_SURFACE}`
+            ? `w-full ${BASE_SURFACE}`
             : variant === "workspace"
-              ? `flex min-h-[58vh] flex-col overflow-hidden rounded-sm ${BASE_SURFACE}`
+              ? `flex min-h-[58vh] flex-col overflow-hidden ${BASE_SURFACE}`
               : variant === "section"
-                ? `w-full overflow-visible rounded-sm ${BASE_SURFACE}`
+                ? `w-full overflow-visible ${BASE_SURFACE}`
                 : variant === "padded"
-                  ? `rounded-sm px-5 py-4 sm:px-6 sm:py-5 ${BASE_SURFACE}`
+                  ? `px-4 py-3 sm:px-5 sm:py-4 ${BASE_SURFACE}`
                   : variant === "shell"
-                    ? `relative flex min-h-0 flex-1 overflow-hidden rounded-sm ${BASE_SURFACE}`
-                    : `rounded-sm ${BASE_SURFACE}`,
+                    ? `relative flex min-h-0 flex-1 overflow-hidden ${BASE_SURFACE}`
+                    : BASE_SURFACE,
           className,
         )}
         {...props}

--- a/packages/ui/src/spatial/__tests__/integration.test.tsx
+++ b/packages/ui/src/spatial/__tests__/integration.test.tsx
@@ -93,7 +93,7 @@ describe("deep nested + stateful parity", () => {
       <Dashboard title="Ops" />,
     ) as SpatialBoxNode;
     expect(tree.type).toBe("box");
-    expect(tree.title).toBe("Ops");
+    expect(tree.title).toBeUndefined();
     // Card > [header HStack, VStack(rows), Toggle HStack]
     expect(tree.children.map((c) => c.type)).toEqual(["box", "box", "box"]);
     const rows = tree.children[1] as SpatialBoxNode;
@@ -108,7 +108,6 @@ describe("deep nested + stateful parity", () => {
       expect(line.length).toBeGreaterThan(0);
     }
     const flat = lines.join("\n");
-    expect(flat).toContain("Ops");
     expect(flat).toContain("Sessions");
     expect(flat).toContain("alpha");
     expect(flat).toContain("12 msgs");

--- a/packages/ui/src/spatial/__tests__/parity.test.tsx
+++ b/packages/ui/src/spatial/__tests__/parity.test.tsx
@@ -20,8 +20,8 @@ describe("tri-modal parity — one view, three modalities", () => {
   it("IR: the authored view evaluates to a stable layout tree", () => {
     const tree = evaluateToSpatialTree(view) as SpatialBoxNode;
     expect(tree.type).toBe("box");
-    expect(tree.title).toBe("Agent");
-    expect(tree.border).toBe("round");
+    expect(tree.title).toBeUndefined();
+    expect(tree.border).toBe("none");
     // Card > [HStack(name/status), Field, Divider, List, HStack(buttons)]
     const kinds = tree.children.map((c) => c.type);
     expect(kinds).toEqual(["box", "field", "divider", "box", "box"]);
@@ -38,13 +38,12 @@ describe("tri-modal parity — one view, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Agent"); // title in the border
       expect(flat).toContain("Ada"); // name
       expect(flat).toContain("online"); // status
       expect(flat).toContain("eliza-1"); // model field
       expect(flat).toContain("research"); // first skill
       expect(flat).toContain("Configure"); // button
-      expect(flat).toMatch(/╭|╰/); // round border drawn
+      expect(flat).not.toMatch(/╭|╰/); // no decorative card frame
     }
   });
 

--- a/packages/ui/src/spatial/primitives.tsx
+++ b/packages/ui/src/spatial/primitives.tsx
@@ -604,48 +604,21 @@ export const Divider = brand<DividerProps>("divider", function Divider(props) {
   if (spec.orientation === "vertical") {
     return (
       <div
+        aria-hidden="true"
         data-spatial-kind="divider"
         style={{
-          width: "0.375rem",
+          width: "0.25rem",
           alignSelf: "stretch",
         }}
       />
     );
   }
-  if (spec.label) {
-    return (
-      <div
-        data-spatial-kind="divider"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5rem",
-          opacity: 0.7,
-        }}
-      >
-        <div
-          style={{
-            flex: 1,
-            height: 1,
-            background: "var(--border, rgba(128,128,128,0.35))",
-          }}
-        />
-        <span style={{ fontSize: "0.75rem" }}>{spec.label}</span>
-        <div
-          style={{
-            flex: 1,
-            height: 1,
-            background: "var(--border, rgba(128,128,128,0.35))",
-          }}
-        />
-      </div>
-    );
-  }
   return (
     <div
+      aria-hidden="true"
       data-spatial-kind="divider"
       style={{
-        height: "0.375rem",
+        height: spec.label ? "0.25rem" : "0.125rem",
         alignSelf: "stretch",
       }}
     />

--- a/packages/ui/src/spatial/primitives.tsx
+++ b/packages/ui/src/spatial/primitives.tsx
@@ -606,9 +606,8 @@ export const Divider = brand<DividerProps>("divider", function Divider(props) {
       <div
         data-spatial-kind="divider"
         style={{
-          width: 1,
+          width: "0.375rem",
           alignSelf: "stretch",
-          background: "var(--border, rgba(128,128,128,0.35))",
         }}
       />
     );
@@ -646,9 +645,8 @@ export const Divider = brand<DividerProps>("divider", function Divider(props) {
     <div
       data-spatial-kind="divider"
       style={{
-        height: 1,
+        height: "0.375rem",
         alignSelf: "stretch",
-        background: "var(--border, rgba(128,128,128,0.35))",
       }}
     />
   );
@@ -694,14 +692,20 @@ export function HStack(props: Omit<StackProps, "direction">) {
 export function VStack(props: Omit<StackProps, "direction">) {
   return <Stack {...props} direction="column" />;
 }
-/** A bordered, padded surface. */
-export function Card(props: StackProps) {
+/** A compact grouped surface without a visible frame by default. */
+export function Card({
+  border,
+  gap,
+  padding,
+  title: _title,
+  ...props
+}: StackProps) {
   return (
     <Stack
       {...props}
-      border={props.border ?? "round"}
-      padding={props.padding ?? 2}
-      gap={props.gap ?? 1}
+      border={border ?? "none"}
+      padding={padding ?? 1}
+      gap={gap ?? 1}
     />
   );
 }

--- a/packages/ui/src/spatial/tui/engine.ts
+++ b/packages/ui/src/spatial/tui/engine.ts
@@ -274,18 +274,8 @@ function renderField(node: SpatialFieldNode, width: number): string[] {
   return out;
 }
 
-function renderDivider(node: SpatialDividerNode, width: number): string[] {
-  if (node.orientation === "vertical") {
-    return [sgr("│", [90])];
-  }
-  if (node.label) {
-    const caption = ` ${node.label} `;
-    const remaining = Math.max(0, width - visibleWidth(caption));
-    const left = Math.floor(remaining / 2);
-    const right = remaining - left;
-    return [sgr("─".repeat(left) + caption + "─".repeat(right), [90])];
-  }
-  return [sgr("─".repeat(width), [90])];
+function renderDivider(_node: SpatialDividerNode, width: number): string[] {
+  return [blank(width)];
 }
 
 function renderSpacer(_node: SpatialSpacerNode, width: number): string[] {

--- a/plugins/app-model-tester/src/ModelTesterAppView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.tsx
@@ -289,14 +289,14 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
       data-testid="model-tester-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
     >
-      <div className="flex shrink-0 items-center justify-between border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center justify-between px-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             ref={backControl.ref}
             {...backControl.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-lg text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={exitToApps}
             aria-label={t("nav.back", { defaultValue: "Back" })}
           >
@@ -314,7 +314,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
             {...refreshControl.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-lg text-muted hover:text-txt"
+            className="h-9 w-9 text-muted hover:text-txt"
             onClick={refreshStatus}
             aria-label="Refresh model status"
           >
@@ -332,9 +332,9 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
         </div>
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 pb-32 pt-4 sm:px-6">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4">
-          <section className="rounded-lg border border-border/20 bg-bg-accent/60 p-4">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 pb-32 pt-2 sm:px-5">
+        <div className="mx-auto flex max-w-5xl flex-col gap-3">
+          <section className="py-2">
             <div className="grid grid-cols-3 gap-2">
               <MetricBadge
                 icon={CheckCircle2}
@@ -363,7 +363,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
                   type="button"
                   onClick={() => setPrompt(preset.prompt)}
                   aria-pressed={prompt === preset.prompt}
-                  className={`h-12 rounded-lg px-3 text-left text-xs font-semibold transition ${
+                  className={`h-10 px-2 text-left text-xs font-semibold transition ${
                     prompt === preset.prompt
                       ? "bg-accent/10 text-accent"
                       : "text-muted hover:bg-bg-accent hover:text-txt"
@@ -375,7 +375,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
             </div>
 
             <div className="mt-3 grid grid-cols-2 gap-2">
-              <label className="flex min-h-12 cursor-pointer items-center justify-center gap-2 rounded-lg border border-border/24 bg-bg px-3 py-2 text-sm text-txt hover:bg-bg-accent">
+              <label className="flex min-h-10 cursor-pointer items-center justify-center gap-2 px-2 py-1.5 text-sm text-txt hover:bg-bg-accent/50">
                 <ImageIcon
                   className={`h-4 w-4 ${imageDataUrl ? "text-ok" : "text-muted"}`}
                 />
@@ -391,7 +391,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
                   }
                 />
               </label>
-              <label className="flex min-h-12 cursor-pointer items-center justify-center gap-2 rounded-lg border border-border/24 bg-bg px-3 py-2 text-sm text-txt hover:bg-bg-accent">
+              <label className="flex min-h-10 cursor-pointer items-center justify-center gap-2 px-2 py-1.5 text-sm text-txt hover:bg-bg-accent/50">
                 <FileAudio
                   className={`h-4 w-4 ${audioPayload ? "text-ok" : "text-muted"}`}
                 />
@@ -417,12 +417,12 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
               <img
                 src={imageDataUrl}
                 alt=""
-                className="mt-3 aspect-video w-full rounded-lg object-cover"
+                className="mt-3 aspect-video w-full object-cover"
               />
             ) : null}
           </section>
 
-          <main className="divide-y divide-border/15">
+          <main className="flex flex-col gap-1">
             {TEST_ORDER.map((id) => {
               const copy = TEST_COPY[id];
               const Icon = copy.Icon;
@@ -432,10 +432,10 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
               const audio = id === "text-to-speech" ? audioSrc(result) : null;
               const urls = id === "image" ? generatedImageUrls(result) : [];
               return (
-                <section key={id} className="py-4">
+                <section key={id} className="py-3">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex min-w-0 items-center gap-3">
-                      <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-border/20 bg-bg">
+                      <div className="grid h-9 w-9 shrink-0 place-items-center">
                         <Icon className="h-5 w-5 text-txt" />
                       </div>
                       <div className="min-w-0">
@@ -480,10 +480,10 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
                           key={url}
                           src={url}
                           alt=""
-                          className="mt-3 aspect-square w-full rounded-lg object-cover"
+                          className="mt-3 aspect-square w-full object-cover"
                         />
                       ))}
-                      <pre className="mt-3 max-h-60 overflow-auto rounded-lg bg-bg p-3 text-xs leading-relaxed text-muted">
+                      <pre className="mt-3 max-h-60 overflow-auto bg-bg/60 p-3 text-xs leading-relaxed text-muted">
                         {outputText(result.ok ? result.output : result.error)}
                       </pre>
                     </div>
@@ -523,7 +523,7 @@ function TestRunButton({
       {...agentProps}
       variant="outline"
       size="icon"
-      className="h-9 w-9 rounded-lg"
+      className="h-9 w-9"
       disabled={isRunning}
       onClick={onRun}
       aria-label={`Run ${title}`}
@@ -588,7 +588,7 @@ function MetricBadge({
         : "text-muted";
   return (
     <div
-      className="flex min-h-14 items-center justify-center gap-2 rounded-lg border border-border/20 bg-bg px-2"
+      className="flex min-h-12 items-center justify-center gap-2 px-2"
       role="status"
       aria-label={label}
       title={label}

--- a/plugins/app-model-tester/src/ModelTesterView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.test.tsx
@@ -91,7 +91,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
 
   it("renders inside a spatial surface and shows the probe rows after the status fetch", async () => {
     render(React.createElement(ModelTesterView));
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
     // Each probe row renders its label.
     expect(screen.getByText("Text")).toBeTruthy();
     expect(screen.getByText("Activity")).toBeTruthy();
@@ -101,7 +101,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
   it("fetches status once on mount and again on refresh-status", async () => {
     const { calls } = installFetch();
     render(React.createElement(ModelTesterView));
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
 
     const statusCalls = () =>
       calls.filter((c) => c.url === "/api/model-tester/status").length;
@@ -114,7 +114,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
   it("run-all posts every probe in order with the active prompt", async () => {
     const { calls } = installFetch();
     render(React.createElement(ModelTesterView));
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
 
     fireEvent.click(button("run-all"));
     await waitFor(() => {
@@ -128,7 +128,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
   it("selecting the Vision preset sends that prompt on the next run", async () => {
     const { calls } = installFetch();
     render(React.createElement(ModelTesterView));
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
 
     fireEvent.click(button("preset-vision"));
     fireEvent.click(button("run-text-small"));
@@ -145,7 +145,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
     installFetch();
     const exitToApps = vi.fn();
     render(<ModelTesterView exitToApps={exitToApps} />);
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
 
     fireEvent.click(button("back"));
     expect(exitToApps).toHaveBeenCalledTimes(1);
@@ -154,7 +154,7 @@ describe("ModelTesterView — unified GUI/XR/TUI wrapper", () => {
   it("Back without exitToApps dispatches the eliza:navigate:view bus", async () => {
     installFetch();
     render(React.createElement(ModelTesterView));
-    await screen.findByText("Model Tester");
+    await screen.findByText("6 ready");
 
     const events: CustomEvent[] = [];
     const listener = (e: Event) => events.push(e as CustomEvent);

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.test.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.test.tsx
@@ -94,7 +94,6 @@ describe("ModelTesterSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Model Tester");
       expect(flat).toContain("ready");
       expect(flat).toContain("Text");
       expect(flat).toContain("Run all");
@@ -112,7 +111,6 @@ describe("ModelTesterSpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Model Tester");
       expect(html).toContain("Text");
       expect(html).toContain('data-agent-id="run-all"');
       expect(html).toContain('data-agent-id="refresh-status"');
@@ -130,7 +128,6 @@ describe("ModelTesterSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Model Tester");
     } finally {
       unregister();
     }

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
@@ -110,7 +110,7 @@ export function ModelTesterSpatialView({
 }: ModelTesterSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
   return (
-    <Card title="Model Tester" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" wrap>
         <Text style="caption" tone="success">
           {snapshot.readyCount} ready

--- a/plugins/plugin-app-control/src/components/ViewManagerSpatialView.test.tsx
+++ b/plugins/plugin-app-control/src/components/ViewManagerSpatialView.test.tsx
@@ -50,7 +50,6 @@ describe("ViewManagerSpatialView one source, three modalities", () => {
 			const lines = renderViewToLines(view, width);
 			for (const line of lines) expect(visibleWidth(line)).toBe(width);
 			const flat = lines.join("\n");
-			expect(flat).toContain("Views");
 			expect(flat).toContain("ready");
 			expect(flat).toContain("Wallet");
 			expect(flat).toContain("Messages");

--- a/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
+++ b/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
@@ -58,7 +58,7 @@ export function ViewManagerSpatialView({
 						: `${available}/${snapshot.views.length} ready`}
 				</Text>
 				<Text style="caption" tone="muted">
-					registered views
+					views
 				</Text>
 			</HStack>
 
@@ -71,7 +71,7 @@ export function ViewManagerSpatialView({
 			<Divider label="views" />
 			{snapshot.views.length === 0 ? (
 				<Text tone="muted" align="center" style="caption">
-					No views registered
+					None
 				</Text>
 			) : (
 				<List gap={1}>

--- a/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
+++ b/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
@@ -50,7 +50,7 @@ export function ViewManagerSpatialView({
 }: ViewManagerSpatialViewProps) {
 	const available = snapshot.views.filter((view) => view.available).length;
 	return (
-		<Card title="Views" gap={1} padding={1}>
+		<Card gap={1} padding={1}>
 			<HStack gap={1} align="center">
 				<Text style="caption" tone="success" grow={1}>
 					{snapshot.loading

--- a/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
@@ -149,14 +149,14 @@ describe("ViewManagerView (gui/xr) render", () => {
 		});
 	});
 
-	it("renders the EmptyState ('No views') for an empty payload", async () => {
+	it("renders the EmptyState for an empty payload", async () => {
 		stubFetch(({ url }) => {
 			if (url === "/api/views") return jsonResponse({ views: [] });
 			throw new Error(`Unexpected request: ${url}`);
 		});
 
 		render(<ViewManagerView />);
-		await screen.findByText("No views");
+		await screen.findByText("None");
 		// No card buttons should be present.
 		expect(screen.queryByLabelText(/^Open /)).toBeNull();
 	});
@@ -170,10 +170,10 @@ describe("ViewManagerView (gui/xr) render", () => {
 
 		render(<ViewManagerView />);
 		await screen.findByText("HTTP 500");
-		expect(screen.queryByText("No views")).toBeNull();
+		expect(screen.queryByText("None")).toBeNull();
 	});
 
-	it("shows 'Loading views…' before the fetch resolves", async () => {
+	it("shows 'Loading' before the fetch resolves", async () => {
 		let resolveFetch: ((r: Response) => void) | undefined;
 		const pending = new Promise<Response>((r) => {
 			resolveFetch = r;
@@ -183,7 +183,7 @@ describe("ViewManagerView (gui/xr) render", () => {
 
 		render(<ViewManagerView />);
 		// Loading text is rendered synchronously before the promise resolves.
-		expect(screen.getByText("Loading views…")).toBeTruthy();
+		expect(screen.getByText("Loading")).toBeTruthy();
 		// The count span is hidden while loading.
 		expect(screen.queryByText("2")).toBeNull();
 

--- a/plugins/plugin-app-control/src/views/ViewManagerView.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.tsx
@@ -40,16 +40,12 @@ function viewModalities(view: ViewEntry): string[] {
 // dark cyan palette. Fallbacks avoid the forbidden literal colors.
 const viewManagerTheme = {
 	background: "var(--background)",
-	surface: "var(--card)",
 	surfaceMuted: "var(--muted)",
-	border: "var(--border)",
-	borderAccent: "var(--accent)",
 	foreground: "var(--foreground)",
 	muted: "var(--muted-foreground)",
 	accent: "var(--accent)",
 	success: "var(--success, #34d399)",
 	danger: "var(--destructive)",
-	shadowInset: "var(--ring, #1e293b)",
 };
 
 // ─── Sub-components ──────────────────────────────────────────────────────────
@@ -68,11 +64,8 @@ function ModalityChips({ view }: { view: ViewEntry }) {
 					style={{
 						fontSize: 10,
 						lineHeight: 1.4,
-						padding: "0 5px",
-						borderRadius: 4,
+						padding: "0 3px",
 						color: viewManagerTheme.muted,
-						background: viewManagerTheme.surfaceMuted,
-						border: `1px solid ${viewManagerTheme.border}`,
 					}}
 				>
 					{modality}
@@ -113,16 +106,12 @@ function ViewCard({
 			style={{
 				textAlign: "left",
 				font: "inherit",
-				border: `1px solid ${viewManagerTheme.border}`,
-				borderRadius: 8,
 				overflow: "hidden",
-				background: viewManagerTheme.surface,
 				display: "flex",
 				alignItems: "center",
 				gap: 12,
 				cursor: "pointer",
-				padding: 12,
-				transition: "border-color 0.15s",
+				padding: "10px 2px",
 			}}
 		>
 			<img
@@ -133,9 +122,7 @@ function ViewCard({
 					height: 56,
 					objectFit: "cover",
 					display: "block",
-					borderRadius: 8,
 					flexShrink: 0,
-					background: viewManagerTheme.surfaceMuted,
 				}}
 				onError={(e) => {
 					// Hide broken image; the fallback SVG served by the agent
@@ -231,15 +218,13 @@ function RefreshButton({
 			{...agentProps}
 			style={{
 				background: "transparent",
-				border: `1px solid ${viewManagerTheme.border}`,
-				borderRadius: 8,
 				color: viewManagerTheme.muted,
 				cursor: loading ? "not-allowed" : "pointer",
 				display: "flex",
 				alignItems: "center",
 				gap: 6,
 				fontSize: 13,
-				padding: "6px 12px",
+				padding: "6px 8px",
 			}}
 		>
 			<RefreshCw
@@ -295,8 +280,7 @@ export function ViewManagerView() {
 			{/* Header */}
 			<div
 				style={{
-					borderBottom: `1px solid ${viewManagerTheme.border}`,
-					padding: "20px 24px",
+					padding: "12px 16px",
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "space-between",
@@ -320,7 +304,7 @@ export function ViewManagerView() {
 			</div>
 
 			{/* Body */}
-			<div style={{ padding: "24px" }}>
+			<div style={{ padding: "16px" }}>
 				{loading && (
 					<div
 						style={{

--- a/plugins/plugin-app-control/src/views/ViewManagerView.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.tsx
@@ -188,7 +188,7 @@ function EmptyState() {
 			}}
 		>
 			<PackageOpen size={48} strokeWidth={1.2} />
-			<div style={{ fontSize: 15, fontWeight: 500 }}>No views</div>
+			<div style={{ fontSize: 15, fontWeight: 500 }}>None</div>
 		</div>
 	);
 }
@@ -314,7 +314,7 @@ export function ViewManagerView() {
 							fontSize: 14,
 						}}
 					>
-						Loading views…
+						Loading
 					</div>
 				)}
 

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.test.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.test.tsx
@@ -27,7 +27,6 @@ describe("FocusSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Focus");
       expect(flat).toContain("Focus session active");
       expect(flat).toContain("x.com");
       expect(flat).toContain("Match mode: subdomain");

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.test.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.test.tsx
@@ -27,10 +27,10 @@ describe("FocusSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Focus session active");
+      expect(flat).toContain("Focus active");
       expect(flat).toContain("x.com");
-      expect(flat).toContain("Match mode: subdomain");
-      expect(flat).toContain("Release block");
+      expect(flat).toContain("Mode: subdomain");
+      expect(flat).toContain("Release");
     }
   });
 
@@ -44,7 +44,7 @@ describe("FocusSpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Focus session active");
+      expect(html).toContain("Focus active");
       expect(html).toContain("x.com");
       expect(html).toContain('data-agent-id="release"');
     }
@@ -78,7 +78,7 @@ describe("FocusSpatialView one source, three modalities", () => {
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("Focus blocking is unavailable");
+    expect(flat).toContain("Focus unavailable");
     expect(flat).toContain("linux");
     expect(flat).toContain("Could not find the system hosts file");
   });
@@ -95,9 +95,8 @@ describe("FocusSpatialView one source, three modalities", () => {
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("Permission needed");
+    expect(flat).toContain("Permission");
     expect(flat).toContain("pkexec");
-    expect(flat).toContain("enable website blocking");
   });
 
   it("empty phase renders the no-session prompt", () => {
@@ -105,8 +104,7 @@ describe("FocusSpatialView one source, three modalities", () => {
     const lines = renderViewToLines(<FocusSpatialView snapshot={empty} />, 54);
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("No active focus session.");
-    expect(flat).toContain("block distractions for 1 hour");
+    expect(flat).toContain("Idle");
   });
 
   it("hides the Release control when the block cannot be released early", () => {
@@ -125,7 +123,7 @@ describe("FocusSpatialView one source, three modalities", () => {
       </SpatialSurface>,
     );
     expect(gui).not.toContain('data-agent-id="release"');
-    expect(gui).toContain("Releasing this block needs administrator");
+    expect(gui).toContain("Admin approval required");
   });
 
   it("registers as a terminal view the agent terminal can mount and render", () => {
@@ -136,7 +134,7 @@ describe("FocusSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Focus session active");
+      expect(lines.join("\n")).toContain("Focus active");
     } finally {
       unregister();
     }

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
@@ -61,7 +61,7 @@ export function FocusSpatialView({
 }: FocusSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
   return (
-    <Card title="Focus" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <FocusBody snapshot={snapshot} dispatch={dispatch} />
     </Card>
   );

--- a/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusSpatialView.tsx
@@ -78,7 +78,7 @@ function FocusBody({
     case "loading":
       return (
         <Text tone="muted" style="caption">
-          Loading focus status...
+          Loading
         </Text>
       );
     case "error":
@@ -97,10 +97,9 @@ function FocusBody({
     case "unavailable":
       return (
         <>
-          <Text bold>Focus blocking is unavailable</Text>
+          <Text bold>Focus unavailable</Text>
           <Text tone="muted" style="caption">
-            The website-blocking engine is not available on this device
-            (platform: {snapshot.platform ?? "unknown"}).
+            {snapshot.platform ?? "unknown"}
           </Text>
           {snapshot.reason ? (
             <Text tone="muted" style="caption">
@@ -113,40 +112,27 @@ function FocusBody({
       return (
         <>
           <Text bold tone="warning">
-            Permission needed
-          </Text>
-          <Text tone="muted" style="caption">
-            Eliza needs administrator/root approval to edit the system hosts
-            file before it can block websites.
+            Permission
           </Text>
           <Text tone="muted" style="caption">
             {snapshot.elevationPromptMethod
-              ? `Approval method: ${snapshot.elevationPromptMethod}`
-              : "This device can't raise an approval prompt automatically."}
+              ? snapshot.elevationPromptMethod
+              : "Manual approval required"}
           </Text>
           {snapshot.reason ? (
             <Text tone="muted" style="caption">
               {snapshot.reason}
             </Text>
           ) : null}
-          <Text tone="muted" style="caption">
-            Ask the assistant to "enable website blocking" and approve the
-            system prompt when it appears.
-          </Text>
         </>
       );
     case "active":
       return <FocusActiveBody snapshot={snapshot} dispatch={dispatch} />;
     default:
       return (
-        <>
-          <Text tone="muted" style="caption">
-            No active focus session.
-          </Text>
-          <Text tone="muted" style="caption">
-            Say "block distractions for 1 hour" to start one.
-          </Text>
-        </>
+        <Text tone="muted" style="caption">
+          Idle
+        </Text>
       );
   }
 }
@@ -162,7 +148,7 @@ function FocusActiveBody({
   const canRelease = snapshot.canUnblockEarly === true;
   return (
     <>
-      <Text bold>Focus session active</Text>
+      <Text bold>Focus active</Text>
       {canRelease ? (
         <HStack gap={1}>
           <Button
@@ -172,7 +158,7 @@ function FocusActiveBody({
             agent="release"
             onPress={dispatch("release")}
           >
-            {snapshot.releasing ? "Releasing" : "Release block"}
+            {snapshot.releasing ? "Releasing" : "Release"}
           </Button>
         </HStack>
       ) : null}
@@ -182,13 +168,13 @@ function FocusActiveBody({
         {snapshot.endsAt ? ` - ends ${snapshot.endsAt}` : " - no end time"}
       </Text>
       <Text tone="muted" style="caption">
-        Match mode: {snapshot.matchMode ?? "exact"}
+        Mode: {snapshot.matchMode ?? "exact"}
       </Text>
 
       <Divider label={`${sites.length} blocked`} />
       {sites.length === 0 ? (
         <Text tone="muted" style="caption">
-          No websites blocked
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -207,8 +193,7 @@ function FocusActiveBody({
 
       {!canRelease && snapshot.requiresElevation ? (
         <Text tone="muted" style="caption">
-          Releasing this block needs administrator/root approval. Ask the
-          assistant to release it.
+          Admin approval required to release.
         </Text>
       ) : null}
     </>

--- a/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.test.tsx
@@ -102,12 +102,12 @@ describe("FocusView — phases", () => {
         fetchStatus={() => new Promise<SelfControlStatus>(() => {})}
       />,
     );
-    expect(screen.getByText(/Loading focus status/i)).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
   });
 
   it("renders the unavailable state with platform + reason", async () => {
     render(<FocusView fetchStatus={async () => UNAVAILABLE_STATUS} />);
-    await screen.findByText(/Focus blocking is unavailable/i);
+    await screen.findByText(/Focus unavailable/i);
     expect(screen.getByText(/linux/)).toBeTruthy();
     expect(
       screen.getByText(/Could not find the system hosts file/),
@@ -116,20 +116,19 @@ describe("FocusView — phases", () => {
 
   it("renders the permission-needed state mentioning the elevation method", async () => {
     render(<FocusView fetchStatus={async () => PERMISSION_STATUS} />);
-    await screen.findByText(/Permission needed/i);
+    await screen.findByText("Permission");
     expect(screen.getByText(/pkexec/)).toBeTruthy();
-    expect(screen.getByText(/enable website blocking/i)).toBeTruthy();
   });
 
   it("renders the empty state when available, inactive, nothing blocked", async () => {
     render(<FocusView fetchStatus={async () => EMPTY_STATUS} />);
-    await screen.findByText("No active focus session.");
+    await screen.findByText("Idle");
   });
 
   it("renders the active state with times, count, list, and Release control", async () => {
     render(<FocusView fetchStatus={async () => ACTIVE_STATUS} />);
-    await screen.findByText(/Focus session active/i);
-    expect(screen.getByText(/Match mode: subdomain/i)).toBeTruthy();
+    await screen.findByText(/Focus active/i);
+    expect(screen.getByText(/Mode: subdomain/i)).toBeTruthy();
     expect(screen.getByText("x.com")).toBeTruthy();
     expect(screen.getByText("news.google.com")).toBeTruthy();
     expect(agent("release")).toBeTruthy();
@@ -149,7 +148,7 @@ describe("FocusView — actions", () => {
     await screen.findByText("network down");
     fireEvent.click(agent("retry"));
 
-    await screen.findByText("No active focus session.");
+    await screen.findByText("Idle");
     expect(fetchStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -163,11 +162,11 @@ describe("FocusView — actions", () => {
     });
     render(<FocusView fetchStatus={fetchStatus} releaseBlock={releaseBlock} />);
 
-    await screen.findByText(/Focus session active/i);
+    await screen.findByText(/Focus active/i);
     fireEvent.click(agent("release"));
 
     await waitFor(() => expect(releaseBlock).toHaveBeenCalledTimes(1));
-    await screen.findByText("No active focus session.");
+    await screen.findByText("Idle");
     expect(fetchStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -184,10 +183,8 @@ describe("FocusView — actions", () => {
         }
       />,
     );
-    await screen.findByText(/Focus session active/i);
+    await screen.findByText(/Focus active/i);
     expect(document.querySelector('[data-agent-id="release"]')).toBeNull();
-    expect(
-      screen.getByText(/Releasing this block needs administrator/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/Admin approval required/i)).toBeTruthy();
   });
 });

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -383,7 +383,7 @@ describe("CalendarSection", () => {
 
     render(<CalendarSection {...noopProps} />);
 
-    expect(screen.getByRole("status", { name: "Calendar clear" })).toBeTruthy();
+    expect(screen.getByRole("status", { name: "Clear" })).toBeTruthy();
   });
 
   it("renders the error banner when the hook reports an error", () => {

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -415,9 +415,7 @@ function DayColumnHeader({ day, isFirst }: { day: Date; isFirst: boolean }) {
       }`}
       style={{ height: `${HEADER_ROW_HEIGHT_REM}rem` }}
     >
-      <span
-        className={`uppercase tracking-wide ${isToday ? "text-accent" : "text-muted"}`}
-      >
+      <span className={isToday ? "text-accent" : "text-muted"}>
         {formatWeekdayShort(day)}
       </span>
       <span
@@ -461,7 +459,7 @@ function AllDayBandCell({
               mouseEvent.preventDefault();
               onSelectEvent(event);
             }}
-            className="block w-full truncate rounded-md px-1.5 py-0.5 text-left text-[10px] font-medium"
+            className="block w-full truncate px-1.5 py-0.5 text-left text-[10px] font-medium"
             style={{
               background: selected ? color.bg : color.softBg,
               color: selected ? color.text : color.softText,
@@ -573,7 +571,7 @@ function DayColumnGrid({
               onSelectEvent(event);
             }}
             aria-pressed={isSelected}
-            className={`group absolute overflow-hidden rounded-md border px-1.5 py-1 text-left transition-transform ${isSelected ? "ring-2 ring-accent z-10" : "hover:translate-y-[-1px]"}`}
+            className={`group absolute overflow-hidden border px-1.5 py-1 text-left transition-transform ${isSelected ? "ring-2 ring-accent z-10" : "hover:translate-y-[-1px]"}`}
             style={{
               top: `calc(${position.topPct}% + 0.1rem)`,
               height: `calc(${position.heightPct}% - 0.2rem)`,
@@ -646,7 +644,7 @@ function TimeGrid({
   const gridTemplateColumns = `${RAIL_WIDTH_REM}rem repeat(${days.length}, minmax(0, 1fr))`;
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-border/12 bg-bg/20">
+    <div className="overflow-hidden">
       {/* Header row: empty cell above rail, then weekday + date per column */}
       <div
         className="grid border-b border-border/12"
@@ -670,7 +668,7 @@ function TimeGrid({
         >
           <div
             aria-hidden
-            className="flex items-center justify-end px-2 text-[10px] font-semibold uppercase tracking-wide text-muted/70"
+            className="flex items-center justify-end px-2 text-[10px] font-medium text-muted/70"
           >
             all-day
           </div>
@@ -695,7 +693,7 @@ function TimeGrid({
           {hours.map(({ hour, label }) => (
             <div
               key={hour}
-              className="absolute right-2 text-[10px] font-medium uppercase tracking-wide text-muted/70"
+              className="absolute right-2 text-[10px] font-medium text-muted/70"
               style={{
                 top: `${(hour - DAY_START_HOUR) * HOUR_HEIGHT_PX - 6}px`,
               }}
@@ -767,8 +765,8 @@ function MonthGrid({
   );
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-border/12 bg-bg/20">
-      <div className="grid grid-cols-7 border-b border-border/12 bg-bg-muted/20 text-[10px] font-semibold uppercase tracking-wide text-muted">
+    <div className="overflow-hidden">
+      <div className="grid grid-cols-7 border-b border-border/12 text-[10px] font-medium text-muted">
         {weekdayLabels.map((label) => (
           <div key={label} className="px-2 py-1.5 text-center">
             {label}
@@ -784,7 +782,7 @@ function MonthGrid({
           return (
             <div
               key={key}
-              className={`flex min-h-24 flex-col gap-1 bg-bg/40 p-1.5 text-left ${
+              className={`flex min-h-24 flex-col gap-1 bg-bg p-1.5 text-left ${
                 inMonth ? "" : "opacity-55"
               }`}
             >
@@ -812,7 +810,7 @@ function MonthGrid({
                         mouseEvent.preventDefault();
                         onSelectEvent(event);
                       }}
-                      className="flex min-w-0 items-center gap-1 rounded-sm px-1.5 py-0.5 text-left text-[10px] font-medium"
+                      className="flex min-w-0 items-center gap-1 px-1.5 py-0.5 text-left text-[10px] font-medium"
                       style={{
                         background: isSelected ? color.bg : color.softBg,
                         color: isSelected ? color.text : color.softText,
@@ -836,7 +834,7 @@ function MonthGrid({
                     <PopoverTrigger asChild>
                       <button
                         type="button"
-                        className="rounded-sm px-1 text-left text-[10px] font-medium text-muted hover:bg-bg-hover/40 hover:text-txt"
+                        className="px-1 text-left text-[10px] font-medium text-muted hover:text-txt"
                       >
                         +{dayEvents.length - 3} more
                       </button>
@@ -846,7 +844,7 @@ function MonthGrid({
                       className="w-64 p-0"
                       data-testid="lifeops-calendar-day-overflow"
                     >
-                      <div className="border-b border-border/12 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
+                      <div className="px-3 py-2 text-[11px] font-medium text-muted">
                         {formatAgendaDayLabel(day)}
                       </div>
                       <div className="max-h-72 overflow-y-auto py-1">
@@ -975,7 +973,7 @@ function AgendaView({
   return (
     <div className="space-y-5">
       {sections.map((section) => (
-        <div key={section.key} className="border-t border-border/12 pt-3">
+        <div key={section.key} className="pt-3">
           <div className="px-2 pb-1 text-xs font-semibold text-muted">
             {formatAgendaDayLabel(section.day)}
           </div>
@@ -1162,11 +1160,11 @@ export function CalendarSection({
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2">
-            <div className="flex overflow-hidden rounded-xl border border-border/16 bg-card/22">
+            <div className="flex overflow-hidden">
               <button
                 ref={prevNav.ref}
                 type="button"
-                className="flex h-8 w-8 items-center justify-center text-muted hover:bg-bg-muted/40 hover:text-txt"
+                className="flex h-8 w-8 items-center justify-center text-muted hover:text-txt"
                 aria-label={t("lifeopsCalendar.previous", {
                   defaultValue: "Previous",
                 })}
@@ -1178,7 +1176,7 @@ export function CalendarSection({
               <button
                 ref={todayNav.ref}
                 type="button"
-                className="h-8 px-2.5 text-xs font-medium text-txt hover:bg-bg-muted/40"
+                className="h-8 px-2.5 text-xs font-medium text-txt hover:text-accent"
                 onClick={calendar.goToToday}
                 {...todayNav.agentProps}
               >
@@ -1187,7 +1185,7 @@ export function CalendarSection({
               <button
                 ref={nextNav.ref}
                 type="button"
-                className="flex h-8 w-8 items-center justify-center text-muted hover:bg-bg-muted/40 hover:text-txt"
+                className="flex h-8 w-8 items-center justify-center text-muted hover:text-txt"
                 aria-label={t("lifeopsCalendar.next", {
                   defaultValue: "Next",
                 })}
@@ -1197,7 +1195,7 @@ export function CalendarSection({
                 <ChevronRight className="h-4 w-4" aria-hidden />
               </button>
             </div>
-            <h2 className="min-w-0 text-sm font-semibold tracking-tight text-txt sm:text-base">
+            <h2 className="min-w-0 text-sm font-semibold text-txt sm:text-base">
               {rangeLabel}
             </h2>
           </div>
@@ -1210,14 +1208,14 @@ export function CalendarSection({
               value={calendar.viewMode}
               onValueChange={calendar.setViewMode}
               items={VIEW_ITEMS}
-              className="w-full border-border/24 bg-card/24 p-0.5"
+              className="w-full border-0 bg-transparent p-0.5"
               buttonClassName="min-h-8 flex-1 px-3 py-1 text-xs"
               {...viewMode.agentProps}
             />
             <Button
               ref={newEvent.ref}
               size="sm"
-              className="h-8 shrink-0 gap-1 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 shrink-0 gap-1 px-2 text-xs font-semibold"
               onClick={() => {
                 setCreateDefaultDate(new Date(calendar.windowStart));
                 setCreateOpen(true);
@@ -1242,12 +1240,8 @@ export function CalendarSection({
 
         {calendar.error ? (
           <div
-            className="rounded-2xl border px-3 py-2 text-xs"
+            className="px-1 py-1 text-xs"
             style={{
-              borderColor:
-                "color-mix(in srgb, var(--danger, #e5484d) 30%, transparent)",
-              background:
-                "color-mix(in srgb, var(--danger, #e5484d) 10%, transparent)",
               color: "color-mix(in srgb, var(--danger, #e5484d) 70%, white)",
             }}
           >
@@ -1259,7 +1253,7 @@ export function CalendarSection({
           <CalendarStatusIcon
             loading
             label={t("lifeopsCalendar.loading", {
-              defaultValue: "Calendar loading",
+              defaultValue: "Loading",
             })}
           />
         ) : compactLayout ? (
@@ -1269,7 +1263,7 @@ export function CalendarSection({
             selectedEventId={selectedEventId}
             onSelectEvent={handleSelectEvent}
             emptyLabel={t("lifeopsCalendar.empty", {
-              defaultValue: "Calendar clear",
+              defaultValue: "Clear",
             })}
           />
         ) : calendar.viewMode === "month" ? (

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
@@ -690,10 +690,10 @@ export function EventEditorDrawer({
     <>
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
         <DialogContent
-          className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full w-[min(28rem,100vw)] max-w-[100vw] !translate-x-0 !translate-y-0 overflow-y-auto rounded-l-2xl rounded-r-none border-l border-t-0 border-border/16 bg-bg p-0 shadow-xl duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full"
+          className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full w-[min(28rem,100vw)] max-w-[100vw] !translate-x-0 !translate-y-0 overflow-y-auto bg-bg p-0 duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full"
           data-testid="event-editor-drawer"
         >
-          <div className="flex items-center justify-between gap-3 border-b border-border/12 px-5 py-4">
+          <div className="flex items-center justify-between gap-3 px-5 py-4">
             <div>
               <div className="text-sm font-semibold text-txt">{titleLabel}</div>
             </div>
@@ -701,7 +701,7 @@ export function EventEditorDrawer({
               type="button"
               onClick={onClose}
               aria-label={t("common.close", { defaultValue: "Close" })}
-              className="rounded-full p-1.5 text-muted transition-colors hover:bg-bg-hover/40 hover:text-txt"
+              className="p-1.5 text-muted transition-colors hover:text-txt"
             >
               <X className="h-4 w-4" />
             </button>
@@ -709,9 +709,7 @@ export function EventEditorDrawer({
 
           <div className="space-y-4 px-5 py-5">
             {error ? (
-              <div className="rounded-2xl bg-danger/10 px-3 py-2 text-xs text-danger">
-                {error}
-              </div>
+              <div className="px-1 py-1 text-xs text-danger">{error}</div>
             ) : null}
 
             <div className="space-y-1.5">
@@ -886,7 +884,7 @@ export function EventEditorDrawer({
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/12 px-5 py-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
             <div className="flex flex-wrap items-center gap-2">
               {!isCreate && onChat && event ? (
                 <EventEditorActionButton
@@ -895,7 +893,7 @@ export function EventEditorDrawer({
                   description="Open chat about this event"
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-8 rounded-xl p-0 text-muted"
+                  className="h-8 w-8 p-0 text-muted"
                   onClick={() => onChat(event)}
                 >
                   <MessageSquare className="h-3.5 w-3.5" aria-hidden />
@@ -911,7 +909,7 @@ export function EventEditorDrawer({
                   description="Delete this calendar event"
                   variant="surfaceDestructive"
                   size="sm"
-                  className="h-8 w-8 rounded-xl p-0"
+                  className="h-8 w-8 p-0"
                   disabled={deleting || saving}
                   onClick={() => setConfirmDeleteOpen(true)}
                 >
@@ -933,7 +931,7 @@ export function EventEditorDrawer({
                 description="Close the event editor without saving"
                 variant="outline"
                 size="sm"
-                className="h-8 w-8 rounded-xl p-0"
+                className="h-8 w-8 p-0"
                 onClick={onClose}
                 disabled={saving}
               >
@@ -948,7 +946,7 @@ export function EventEditorDrawer({
                 description="Save the event and keep the editor open"
                 variant="outline"
                 size="sm"
-                className="h-8 w-8 rounded-xl p-0"
+                className="h-8 w-8 p-0"
                 disabled={saving || !form.title.trim()}
                 onClick={() => void handleSave({ keepOpen: true })}
               >
@@ -970,7 +968,7 @@ export function EventEditorDrawer({
                 label={isCreate ? "Create event" : "Save event"}
                 description="Save the calendar event and close the editor"
                 size="sm"
-                className="h-8 w-8 rounded-xl p-0"
+                className="h-8 w-8 p-0"
                 disabled={saving || !form.title.trim()}
                 onClick={() => void handleSave()}
               >

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
@@ -89,7 +89,7 @@ describe("CalendarSpatialView one source, three modalities", () => {
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("No events");
+    expect(flat).toContain("None");
   });
 
   it("error state surfaces the error text", () => {

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
@@ -89,7 +89,7 @@ describe("CalendarSpatialView one source, three modalities", () => {
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("No upcoming events");
+    expect(flat).toContain("No events");
   });
 
   it("error state surfaces the error text", () => {

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.test.tsx
@@ -44,7 +44,6 @@ describe("CalendarSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Calendar");
       expect(flat).toContain("Design sync");
       expect(flat).toContain("Lunch with Grace");
       expect(flat).toContain("Today");

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -77,7 +77,7 @@ export function CalendarSpatialView({
   const eventCount = snapshot.events.length;
 
   return (
-    <Card title="Calendar" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="subheading" bold grow={1} wrap={false}>
           {snapshot.periodLabel}
@@ -175,12 +175,7 @@ function CalendarAgendaBody({
   return (
     <List gap={0}>
       {snapshot.events.slice(0, 12).map((event) => (
-        <HStack
-          key={event.id}
-          gap={1}
-          align="center"
-          agent={`row-${event.id}`}
-        >
+        <HStack key={event.id} gap={1} align="center" agent={`row-${event.id}`}>
           <Text tone="muted" wrap={false}>
             {event.selected ? "›" : "•"}
           </Text>

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -167,7 +167,7 @@ function CalendarAgendaBody({
   if (eventCount === 0) {
     return (
       <Text tone="muted" align="center" style="caption">
-        {snapshot.loading ? "Loading events" : "No upcoming events"}
+        {snapshot.loading ? "Loading" : "No events"}
       </Text>
     );
   }

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -167,7 +167,7 @@ function CalendarAgendaBody({
   if (eventCount === 0) {
     return (
       <Text tone="muted" align="center" style="caption">
-        {snapshot.loading ? "Loading" : "No events"}
+        {snapshot.loading ? "Loading" : "None"}
       </Text>
     );
   }

--- a/plugins/plugin-companion/src/components/companion/CompanionAppView.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionAppView.tsx
@@ -40,7 +40,7 @@ const CompanionOverlay = memo(function CompanionOverlay({
       <button
         type="button"
         aria-label="Close companion"
-        className="pointer-events-auto absolute right-4 top-4 z-20 grid h-10 w-10 place-items-center rounded-full border border-white/15 bg-black/55 text-sm font-semibold text-white shadow-lg backdrop-blur-md transition hover:bg-black/75"
+        className="pointer-events-auto absolute right-4 top-4 z-20 grid h-10 w-10 place-items-center text-sm font-semibold text-white transition hover:bg-black/35"
         onClick={exitToApps}
         data-no-camera-drag="true"
       >
@@ -48,7 +48,7 @@ const CompanionOverlay = memo(function CompanionOverlay({
       </button>
 
       <div
-        className="absolute bottom-4 left-4 z-20 flex items-center gap-2 rounded-full border border-white/15 bg-black/50 px-3 py-2 backdrop-blur-md"
+        className="absolute bottom-4 left-4 z-20 flex items-center gap-2 px-1 py-1"
         title={avatarReady ? "Avatar ready" : "Avatar loading"}
       >
         <span
@@ -56,7 +56,7 @@ const CompanionOverlay = memo(function CompanionOverlay({
             avatarReady ? "bg-emerald-400" : "bg-amber-400"
           }`}
         />
-        <span className="text-2xs font-semibold uppercase tracking-normal text-white/80">
+        <span className="sr-only text-2xs font-semibold uppercase tracking-normal text-white/80">
           {avatarReady ? "Companion avatar ready" : "Companion avatar loading"}
         </span>
       </div>

--- a/plugins/plugin-companion/src/components/companion/CompanionPerformanceSettings.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionPerformanceSettings.tsx
@@ -37,7 +37,7 @@ export function CompanionPerformanceSettings() {
         })}
       </h3>
       <div
-        className="flex flex-col gap-3 rounded-xl border border-border bg-card/60 px-3 py-3"
+        className="flex flex-col gap-3"
         data-testid="settings-companion-vrm-power"
       >
         <div className="min-w-0">
@@ -46,7 +46,7 @@ export function CompanionPerformanceSettings() {
               defaultValue: "Companion rendering",
             })}
           </div>
-          <div className="mt-1 text-2xs leading-snug text-muted">
+          <div className="sr-only mt-1 text-2xs leading-snug text-muted">
             {t("settings.companionVrmPower.desc", {
               defaultValue:
                 "Control how much GPU the 3D companion uses while rendering.",
@@ -67,7 +67,7 @@ export function CompanionPerformanceSettings() {
           ))}
         </SegmentedSetting>
         <div
-          className="flex flex-col gap-2 border-t border-border pt-3"
+          className="flex flex-col gap-2 pt-2"
           data-testid="settings-companion-half-framerate"
         >
           <div className="min-w-0">
@@ -76,7 +76,7 @@ export function CompanionPerformanceSettings() {
                 defaultValue: "Companion frame rate",
               })}
             </div>
-            <div className="mt-1 text-2xs leading-snug text-muted">
+            <div className="sr-only mt-1 text-2xs leading-snug text-muted">
               {t("settings.companionHalfFramerate.desc", {
                 defaultValue:
                   "Optionally cap the 3D companion at about half display refresh rate.",
@@ -100,7 +100,7 @@ export function CompanionPerformanceSettings() {
           </SegmentedSetting>
         </div>
         <div
-          className="flex flex-col gap-2 border-t border-border pt-3"
+          className="flex flex-col gap-2 pt-2"
           data-testid="settings-companion-animate-when-hidden"
         >
           <div className="text-xs font-semibold text-txt">
@@ -109,7 +109,7 @@ export function CompanionPerformanceSettings() {
             })}
           </div>
           <div className="flex items-end justify-between gap-3">
-            <div className="min-w-0 flex-1 pr-2 text-2xs leading-snug text-muted">
+            <div className="sr-only min-w-0 flex-1 pr-2 text-2xs leading-snug text-muted">
               {t("settings.companionAnimateWhenHidden.desc", {
                 defaultValue:
                   "Keep the avatar idling while the window or tab is hidden.",

--- a/plugins/plugin-companion/src/components/companion/CompanionSettingsPanel.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionSettingsPanel.tsx
@@ -9,7 +9,7 @@ export function CompanionSettingsPanel() {
         paddingBottom: "calc(var(--safe-area-bottom, 0px) + 0.75rem)",
       }}
     >
-      <div className="w-full max-w-lg rounded-xl border border-border/50 bg-card/90 px-3 py-3 shadow-xl backdrop-blur-xl sm:px-4">
+      <div className="w-full max-w-lg px-3 py-3 sm:px-4">
         <CompanionPerformanceSettings />
       </div>
     </div>

--- a/plugins/plugin-companion/src/components/companion/CompanionSpatialView.test.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionSpatialView.test.tsx
@@ -65,7 +65,6 @@ describe("CompanionSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Companion");
       expect(flat).toContain("avatar-ready");
       expect(flat).toContain("VRM #3");
       expect(flat).toContain("gpt-test"); // last model
@@ -104,7 +103,7 @@ describe("CompanionSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Companion");
+      expect(lines.join("\n")).toContain("avatar-ready");
     } finally {
       unregister();
     }

--- a/plugins/plugin-companion/src/components/companion/CompanionSpatialView.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionSpatialView.tsx
@@ -215,7 +215,7 @@ export function CompanionSpatialView({
       </HStack>
       {categories.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No emote categories
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-companion/src/components/companion/CompanionSpatialView.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionSpatialView.tsx
@@ -123,7 +123,7 @@ export function CompanionSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
   const categories = Object.entries(snapshot.emotesByCategory).slice(0, 6);
   return (
-    <Card title="Companion" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-companion/src/components/companion/CompanionView.tsx
+++ b/plugins/plugin-companion/src/components/companion/CompanionView.tsx
@@ -31,27 +31,16 @@ const CompanionViewOverlay = memo(function CompanionViewOverlay() {
     >
       <EmotePicker />
 
-      {/* Compact aesthetic status chip cluster — theme-token driven, not a
-          devtools panel. Lives top-left, translucent + blurred over the stage.
-          Layout is inline-styled: the companion view bundle ships no compiled
-          Tailwind, so arbitrary/utility classes would have no effect here. */}
+      {/* Status metadata remains in the DOM for agent/a11y inspection without
+          adding visible chrome over the avatar stage. */}
       <div
         style={{
           position: "absolute",
-          left: 16,
-          top: 16,
-          zIndex: 20,
+          width: 1,
+          height: 1,
+          overflow: "hidden",
+          clipPath: "inset(50%)",
           display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 6,
-          maxWidth: "calc(100vw - 32px)",
-          padding: 6,
-          borderRadius: 9999,
-          border: "1px solid var(--border)",
-          background: "var(--bg-elevated)",
-          backdropFilter: "blur(12px)",
-          WebkitBackdropFilter: "blur(12px)",
         }}
         title="Companion avatar surface"
       >
@@ -77,8 +66,7 @@ const CHIP_BASE: CSSProperties = {
   alignItems: "center",
   gap: 6,
   minHeight: 28,
-  padding: "4px 10px",
-  borderRadius: 9999,
+  padding: "0 1px",
   fontSize: 11,
   fontWeight: 600,
   lineHeight: 1,

--- a/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
@@ -226,7 +226,7 @@ describe("ContactsAppView — list → detail navigation", () => {
     await renderView();
 
     fireEvent.click(screen.getByText("Grace Hopper")); // phone only, no email
-    expect(screen.getByText("No email addresses")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
     // The phone it does have renders as in-app Call/Text controls.
     expect(screen.getByText("+15550200")).toBeTruthy();
     expect(screen.getByTestId("contacts-detail-call")).toBeTruthy();
@@ -357,7 +357,7 @@ describe("ContactsAppView — vCard import", () => {
     const { container } = render(
       React.createElement(ContactsAppView, overlayCtx()),
     );
-    await screen.findByText("No contacts");
+    await screen.findByText("None");
     expect(screen.getByRole("button", { name: "Import vCard" })).toBeTruthy();
 
     const fileInput = container.querySelector(
@@ -399,7 +399,7 @@ describe("ContactsAppView — error + non-native gate", () => {
     platform.isNative = false;
     render(React.createElement(ContactsAppView, overlayCtx()));
 
-    await screen.findByText("No contacts");
+    await screen.findByText("None");
     expect(contactsBridge.listContacts).not.toHaveBeenCalled();
     expect(screen.queryByRole("alert")).toBeNull();
   });

--- a/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
@@ -357,7 +357,7 @@ describe("ContactsAppView — vCard import", () => {
     const { container } = render(
       React.createElement(ContactsAppView, overlayCtx()),
     );
-    await screen.findByText("No contacts yet");
+    await screen.findByText("No contacts");
     expect(screen.getByRole("button", { name: "Import vCard" })).toBeTruthy();
 
     const fileInput = container.querySelector(
@@ -399,7 +399,7 @@ describe("ContactsAppView — error + non-native gate", () => {
     platform.isNative = false;
     render(React.createElement(ContactsAppView, overlayCtx()));
 
-    await screen.findByText("No contacts yet");
+    await screen.findByText("No contacts");
     expect(contactsBridge.listContacts).not.toHaveBeenCalled();
     expect(screen.queryByRole("alert")).toBeNull();
   });

--- a/plugins/plugin-contacts/src/components/ContactsAppView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.tsx
@@ -392,12 +392,11 @@ function ContactList({
           <AddressBookMotif />
         </span>
         <div className="mt-2 text-base font-semibold text-txt">
-          {t("contacts.empty.title", { defaultValue: "No contacts yet" })}
+          {t("contacts.empty.title", { defaultValue: "No contacts" })}
         </div>
         <p className="sr-only">
           {t("contacts.empty.body", {
-            defaultValue:
-              "Import a vCard or add someone to start your address book.",
+            defaultValue: "Import vCard or add contact.",
           })}
         </p>
         <ImportVCardButton onImport={onImport} t={t} />

--- a/plugins/plugin-contacts/src/components/ContactsAppView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.tsx
@@ -255,14 +255,14 @@ export function ContactsAppView({ exitToApps, t }: OverlayAppContext) {
         onChange={handleFileChange}
       />
 
-      <header className="flex shrink-0 items-center justify-between border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <header className="flex shrink-0 items-center justify-between px-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             ref={back.ref}
             {...back.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={mode === "list" ? exitToApps : handleBackToList}
             aria-label={backLabel}
           >
@@ -287,7 +287,7 @@ export function ContactsAppView({ exitToApps, t }: OverlayAppContext) {
             {...newEl.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 text-muted hover:text-txt"
             onClick={handleOpenNew}
             aria-label={newLabel}
             data-testid="contacts-new"
@@ -298,10 +298,7 @@ export function ContactsAppView({ exitToApps, t }: OverlayAppContext) {
       </header>
 
       {mode === "list" && (
-        <p
-          data-testid="contacts-search-hint"
-          className="shrink-0 px-4 py-2 text-[13px] leading-relaxed text-txt/60"
-        >
+        <p data-testid="contacts-search-hint" className="sr-only">
           {t("contacts.searchHint", {
             defaultValue: "Search contacts by typing in the chat.",
           })}
@@ -389,7 +386,7 @@ function ContactList({
     return (
       <div className="mx-auto flex max-w-sm flex-col items-center gap-3 px-4 py-16 text-center">
         <span
-          className="flex h-20 w-20 items-center justify-center rounded-3xl"
+          className="flex h-16 w-16 items-center justify-center"
           style={{ background: "var(--accent-subtle)" }}
         >
           <AddressBookMotif />
@@ -397,7 +394,7 @@ function ContactList({
         <div className="mt-2 text-base font-semibold text-txt">
           {t("contacts.empty.title", { defaultValue: "No contacts yet" })}
         </div>
-        <p className="max-w-xs text-sm text-muted">
+        <p className="sr-only">
           {t("contacts.empty.body", {
             defaultValue:
               "Import a vCard or add someone to start your address book.",
@@ -409,7 +406,7 @@ function ContactList({
   }
 
   return (
-    <ul className="divide-y divide-border/20">
+    <ul>
       {contacts.map((contact, index) => (
         <ContactListItem
           key={contact.id}
@@ -537,7 +534,7 @@ function ContactListItem({
         {...agentProps}
         type="button"
         onClick={() => onSelect(contact.id)}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-bg-accent/40 focus:bg-bg-accent/40 focus:outline-none"
+        className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-bg-accent/40 focus:bg-bg-accent/40 focus:outline-none"
       >
         <Avatar name={contact.displayName} photoUri={contact.photoUri} />
         <div className="min-w-0 flex-1">
@@ -615,7 +612,7 @@ function ContactDetail({ contact, t }: { contact: ContactSummary; t: TFn }) {
         })}
       />
 
-      <p className="text-xs text-muted">
+      <p className="sr-only">
         {t("contacts.detail.readOnlyNote", {
           defaultValue:
             "Editing existing contacts is unavailable on this device.",
@@ -697,10 +694,10 @@ function ContactFieldGroup({
   emptyLabel: string;
 }) {
   return (
-    <section className="flex flex-col gap-2 border-t border-border/20 pt-4">
+    <section className="flex flex-col gap-2 pt-2">
       <h3 className="text-sm font-medium text-muted">{label}</h3>
       {items.length === 0 ? (
-        <p className="text-sm text-muted">{emptyLabel}</p>
+        <p className="sr-only">{emptyLabel}</p>
       ) : (
         <ul className="flex flex-col gap-2">
           {dedupePreservingOrder(items).map((value) => (
@@ -772,7 +769,7 @@ function NewContactForm({
   return (
     <form
       onSubmit={onSubmit}
-      className="mx-auto flex max-w-md flex-col gap-4 px-4 py-6"
+      className="mx-auto flex max-w-md flex-col gap-3 px-3 py-4"
     >
       <div className="flex flex-col gap-1.5">
         <label htmlFor={nameId} className="text-sm font-medium text-muted">
@@ -871,14 +868,14 @@ function Avatar({
       <img
         src={photoUri}
         alt=""
-        className={`${dimension} shrink-0 rounded-full object-cover`}
+        className={`${dimension} shrink-0 object-cover`}
       />
     );
   }
   return (
     <div
       aria-hidden="true"
-      className={`${dimension} flex shrink-0 items-center justify-center rounded-full bg-bg-accent font-semibold text-muted`}
+      className={`${dimension} flex shrink-0 items-center justify-center bg-bg-accent font-semibold text-muted`}
     >
       {getInitials(name)}
     </div>

--- a/plugins/plugin-contacts/src/components/ContactsAppView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.tsx
@@ -377,7 +377,7 @@ function ContactList({
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16 text-sm text-muted">
-        {t("contacts.loading", { defaultValue: "Loading contacts…" })}
+        {t("contacts.loading", { defaultValue: "Loading" })}
       </div>
     );
   }
@@ -392,7 +392,7 @@ function ContactList({
           <AddressBookMotif />
         </span>
         <div className="mt-2 text-base font-semibold text-txt">
-          {t("contacts.empty.title", { defaultValue: "No contacts" })}
+          {t("contacts.empty.title", { defaultValue: "None" })}
         </div>
         <p className="sr-only">
           {t("contacts.empty.body", {
@@ -590,7 +590,7 @@ function ContactDetail({ contact, t }: { contact: ContactSummary; t: TFn }) {
           <ContactPhoneRow value={value} contactId={contact.id} t={t} />
         )}
         emptyLabel={t("contacts.noPhones", {
-          defaultValue: "No phone numbers",
+          defaultValue: "None",
         })}
       />
 
@@ -607,7 +607,7 @@ function ContactDetail({ contact, t }: { contact: ContactSummary; t: TFn }) {
           </a>
         )}
         emptyLabel={t("contacts.noEmails", {
-          defaultValue: "No email addresses",
+          defaultValue: "None",
         })}
       />
 

--- a/plugins/plugin-contacts/src/components/ContactsSpatialView.test.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsSpatialView.test.tsx
@@ -43,7 +43,6 @@ describe("ContactsSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Contacts");
       expect(flat).toContain("Ada Lovelace");
       expect(flat).toContain("Grace Hopper");
       expect(flat).toContain("Search");
@@ -103,7 +102,6 @@ describe("ContactsSpatialView one source, three modalities", () => {
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
     const flat = lines.join("\n");
-    expect(flat).toContain("New contact");
     expect(flat).toContain("Name");
     expect(flat).toContain("Save");
   });

--- a/plugins/plugin-contacts/src/components/ContactsSpatialView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsSpatialView.tsx
@@ -184,7 +184,7 @@ function ContactsListBody({
       <Divider label="address book" />
       {snapshot.contacts.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {snapshot.loading ? "Loading contacts" : "No contacts"}
+          {snapshot.loading ? "Loading" : "None"}
         </Text>
       ) : (
         <List gap={0}>
@@ -252,7 +252,7 @@ function ContactsDetailBody({
       <Divider label="phone" />
       {phones.length === 0 ? (
         <Text tone="muted" style="caption">
-          No phone numbers
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -283,7 +283,7 @@ function ContactsDetailBody({
       <Divider label="email" />
       {emails.length === 0 ? (
         <Text tone="muted" style="caption">
-          No email addresses
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-contacts/src/components/ContactsSpatialView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsSpatialView.tsx
@@ -102,15 +102,9 @@ export function ContactsSpatialView({
     snapshot.selectedId != null
       ? (snapshot.contacts.find((c) => c.id === snapshot.selectedId) ?? null)
       : null;
-  const title =
-    mode === "detail" && selected
-      ? selected.displayName || "Unnamed"
-      : mode === "new"
-        ? "New contact"
-        : "Contacts";
 
   return (
-    <Card title={title} gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="caption" tone="muted" grow={1}>
           {snapshot.loading

--- a/plugins/plugin-contacts/src/components/ContactsView.test.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsView.test.tsx
@@ -98,7 +98,7 @@ describe("ContactsView — populated list", () => {
   it("short-circuits to an empty list on non-native platforms without touching the bridge", async () => {
     platform.isNative = false;
     render(React.createElement(ContactsView));
-    await waitFor(() => expect(screen.getByText("No contacts")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("None")).toBeTruthy());
     expect(contactsBridge.listContacts).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.test.ts
@@ -182,9 +182,7 @@ describe("DeviceSettingsAppView — populated data display", () => {
     mockBridgeFull();
     renderView();
 
-    expect(
-      await screen.findByRole("heading", { name: "Device Settings" }),
-    ).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Device" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
     expect(screen.getByTestId("device-settings-refresh")).toBeTruthy();
   });
@@ -557,14 +555,7 @@ describe("DeviceSettingsAppView — interactions", () => {
     });
     renderView();
 
-    expect(
-      await screen.findByText(
-        "Volume streams are not available in this runtime.",
-      ),
-    ).toBeTruthy();
-    expect(
-      screen.getByText("Android role status is not available in this runtime."),
-    ).toBeTruthy();
+    expect(await screen.findAllByText("Unavailable")).toHaveLength(2);
     expect(screen.getByText("0 streams")).toBeTruthy();
     expect(screen.getByText("0 roles")).toBeTruthy();
   });

--- a/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.test.ts
@@ -164,19 +164,12 @@ function renderView(exitToApps = vi.fn()) {
 
 // Returns the card <div> wrapping a volume slider, for scoped label/icon asserts.
 function volumeCard(stream: string): HTMLElement {
-  const slider = screen.getByTestId(`device-settings-volume-${stream}`);
-  // input -> flex row -> mt-3 wrapper's parent is the card div.
-  const card = slider.closest("div.rounded-lg") as HTMLElement | null;
-  if (!card) throw new Error(`volume card not found for ${stream}`);
-  return card;
+  return screen.getByTestId(`device-settings-volume-card-${stream}`);
 }
 
 // Returns the card <div> wrapping a role action button.
 function roleCard(role: string): HTMLElement {
-  const button = screen.getByTestId(`device-settings-request-role-${role}`);
-  const card = button.closest("div.rounded-lg") as HTMLElement | null;
-  if (!card) throw new Error(`role card not found for ${role}`);
-  return card;
+  return screen.getByTestId(`device-settings-role-card-${role}`);
 }
 
 afterEach(() => {

--- a/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.tsx
@@ -233,12 +233,12 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       data-testid="device-settings-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
-      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border/24 bg-bg/90 px-4 py-3 backdrop-blur-sm">
+      <header className="flex shrink-0 items-center justify-between gap-3 px-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-lg text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={exitToApps}
             aria-label={t("nav.back", { defaultValue: "Back" })}
           >
@@ -255,7 +255,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
         <Button
           variant="ghost"
           size="icon"
-          className="h-9 w-9 rounded-lg text-muted hover:text-txt"
+          className="h-9 w-9 text-muted hover:text-txt"
           onClick={() => void refresh()}
           disabled={loading}
           aria-label={t("actions.refresh", { defaultValue: "Refresh" })}
@@ -266,13 +266,11 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       </header>
 
       {(error || notice) && (
-        <div className="shrink-0 px-4 pt-3">
+        <div className="shrink-0 px-3 pt-2">
           <div
             role={error ? "alert" : "status"}
-            className={`mx-auto max-w-3xl rounded-lg border px-3 py-2 text-sm ${
-              error
-                ? "border-danger/40 bg-danger/10 text-danger"
-                : "border-border/30 bg-bg-accent text-muted"
+            className={`mx-auto max-w-3xl px-1 py-2 text-sm ${
+              error ? "text-danger" : "text-muted"
             }`}
           >
             {error ?? notice}
@@ -280,11 +278,11 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
         </div>
       )}
 
-      <main className="chat-native-scrollbar min-h-0 flex-1 overflow-y-auto px-4 py-4">
+      <main className="chat-native-scrollbar min-h-0 flex-1 overflow-y-auto px-3 py-2">
         <div className="mx-auto flex max-w-3xl flex-col gap-4">
-          <section className="rounded-lg border border-border/24 bg-card/30 p-4">
+          <section className="py-2">
             <div className="flex items-center gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-bg-accent">
+              <span className="flex h-9 w-9 items-center justify-center">
                 <Sun className="h-5 w-5 text-muted" />
               </span>
               <div>
@@ -355,20 +353,20 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
             </div>
           </section>
 
-          <section className="rounded-lg border border-border/24 bg-card/30 p-4">
+          <section className="py-2">
             <div className="flex items-center gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-bg-accent">
+              <span className="flex h-9 w-9 items-center justify-center">
                 <Settings className="h-5 w-5 text-muted" />
               </span>
               <div>
                 <h2 className="text-sm font-semibold text-txt">Android</h2>
-                <div className="text-xs text-muted">System panels</div>
+                <div className="sr-only">System panels</div>
               </div>
             </div>
             <div className="mt-4 grid gap-2 sm:grid-cols-2">
               <Button
                 variant="outline"
-                className="justify-start rounded-lg"
+                className="justify-start"
                 onClick={() => void openSetting("settings", "System settings")}
                 data-testid="device-settings-open-system"
               >
@@ -377,7 +375,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               </Button>
               <Button
                 variant="outline"
-                className="justify-start rounded-lg"
+                className="justify-start"
                 onClick={() => void openSetting("display", "Display settings")}
                 data-testid="device-settings-open-display"
               >
@@ -386,7 +384,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               </Button>
               <Button
                 variant="outline"
-                className="justify-start rounded-lg"
+                className="justify-start"
                 onClick={() => void openSetting("sound", "Sound settings")}
                 data-testid="device-settings-open-sound"
               >
@@ -395,7 +393,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               </Button>
               <Button
                 variant="outline"
-                className="justify-start rounded-lg"
+                className="justify-start"
                 onClick={() => void openSetting("network", "Network settings")}
                 data-testid="device-settings-open-network"
               >
@@ -405,9 +403,9 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
             </div>
           </section>
 
-          <section className="rounded-lg border border-border/24 bg-card/30 p-4">
+          <section className="py-2">
             <div className="flex items-center gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-bg-accent">
+              <span className="flex h-9 w-9 items-center justify-center">
                 <Volume2 className="h-5 w-5 text-muted" />
               </span>
               <div>
@@ -424,7 +422,8 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
                 return (
                   <div
                     key={volume.stream}
-                    className="rounded-lg border border-border/20 bg-bg/50 p-3"
+                    data-testid={`device-settings-volume-card-${volume.stream}`}
+                    className="p-2"
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div className="flex items-center gap-2">
@@ -463,7 +462,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
                       <Button
                         variant="outline"
                         size="sm"
-                        className="rounded-lg"
+                        className=""
                         onClick={() => void applyVolume(volume)}
                         disabled={saving === `volume:${volume.stream}`}
                         data-testid={`device-settings-apply-volume-${volume.stream}`}
@@ -475,16 +474,16 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
                 );
               })}
               {!loading && orderedVolumes.length === 0 ? (
-                <div className="rounded-lg border border-border/20 bg-bg/50 px-4 py-6 text-center text-sm text-muted md:col-span-2">
+                <div className="px-4 py-6 text-center text-sm text-muted md:col-span-2">
                   Volume streams are not available in this runtime.
                 </div>
               ) : null}
             </div>
           </section>
 
-          <section className="rounded-lg border border-border/24 bg-card/30 p-4">
+          <section className="py-2">
             <div className="flex items-center gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-bg-accent">
+              <span className="flex h-9 w-9 items-center justify-center">
                 <ShieldCheck className="h-5 w-5 text-muted" />
               </span>
               <div>
@@ -498,7 +497,8 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               {roles.map((role) => (
                 <div
                   key={role.role}
-                  className="rounded-lg border border-border/20 bg-bg/50 p-3"
+                  data-testid={`device-settings-role-card-${role.role}`}
+                  className="p-2"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div>
@@ -518,7 +518,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
                   <Button
                     variant={role.held ? "ghost" : "outline"}
                     size="sm"
-                    className="mt-3 w-full rounded-lg"
+                    className="mt-3 w-full"
                     disabled={
                       !role.available ||
                       role.held ||
@@ -532,7 +532,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
                 </div>
               ))}
               {!loading && roles.length === 0 ? (
-                <div className="rounded-lg border border-border/20 bg-bg/50 px-4 py-6 text-center text-sm text-muted md:col-span-2 xl:col-span-4">
+                <div className="px-4 py-6 text-center text-sm text-muted md:col-span-2 xl:col-span-4">
                   Android role status is not available in this runtime.
                 </div>
               ) : null}

--- a/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-device-settings/src/components/DeviceSettingsAppView.tsx
@@ -247,7 +247,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
           <div className="min-w-0">
             <h1 className="truncate text-base font-semibold text-txt">
               {t("deviceSettings.title", {
-                defaultValue: "Device Settings",
+                defaultValue: "Device",
               })}
             </h1>
           </div>
@@ -475,7 +475,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               })}
               {!loading && orderedVolumes.length === 0 ? (
                 <div className="px-4 py-6 text-center text-sm text-muted md:col-span-2">
-                  Volume streams are not available in this runtime.
+                  Unavailable
                 </div>
               ) : null}
             </div>
@@ -533,7 +533,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
               ))}
               {!loading && roles.length === 0 ? (
                 <div className="px-4 py-6 text-center text-sm text-muted md:col-span-2 xl:col-span-4">
-                  Android role status is not available in this runtime.
+                  Unavailable
                 </div>
               ) : null}
             </div>

--- a/plugins/plugin-device-settings/src/components/device-settings-contract.test.ts
+++ b/plugins/plugin-device-settings/src/components/device-settings-contract.test.ts
@@ -147,11 +147,9 @@ describe("device-settings contract — real SystemWeb output", () => {
     // Each real stream renders a card with the correct label and live percent
     // computed from the real current/max.
     for (const volume of real.volumes) {
-      const card = screen
-        .getByTestId(`device-settings-volume-${volume.stream}`)
-        .closest("div.rounded-lg") as HTMLElement | null;
-      expect(card).toBeTruthy();
-      const scoped = within(card as HTMLElement);
+      const scoped = within(
+        screen.getByTestId(`device-settings-volume-card-${volume.stream}`),
+      );
       expect(scoped.getByText(VOLUME_LABELS[volume.stream])).toBeTruthy();
       const expectedPercent = `${Math.round((volume.current / volume.max) * 100)}%`;
       expect(scoped.getByText(expectedPercent)).toBeTruthy();
@@ -165,8 +163,6 @@ describe("device-settings contract — real SystemWeb output", () => {
 
     // The real web getStatus() returns no Android roles -> the honest empty
     // state, not a fabricated role list.
-    expect(
-      screen.getByText("Android role status is not available in this runtime."),
-    ).toBeTruthy();
+    expect(screen.getByText("Unavailable")).toBeTruthy();
   });
 });

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
@@ -99,7 +99,7 @@ describe("DocumentsSpatialView one source, three modalities", () => {
         <DocumentsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No documents yet");
+    expect(html).toContain("No documents");
   });
 
   it("error state renders the message and a Retry control", () => {

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
@@ -9,9 +9,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   type DocumentCard,
-  EMPTY_DOCUMENTS_SNAPSHOT,
   type DocumentsSnapshot,
   DocumentsSpatialView,
+  EMPTY_DOCUMENTS_SNAPSHOT,
 } from "./DocumentsSpatialView.tsx";
 
 function card(overrides: Partial<DocumentCard> & { id: string }): DocumentCard {
@@ -27,8 +27,16 @@ const snapshot: DocumentsSnapshot = {
   documentCount: 2,
   fragmentCount: 9,
   documents: [
-    card({ id: "d1", title: "Quarterly Plan", meta: "markdown · 4 KB · Jun 16" }),
-    card({ id: "d2", title: "Onboarding Notes", meta: "plain · 1 KB · Jun 18" }),
+    card({
+      id: "d1",
+      title: "Quarterly Plan",
+      meta: "markdown · 4 KB · Jun 16",
+    }),
+    card({
+      id: "d2",
+      title: "Onboarding Notes",
+      meta: "plain · 1 KB · Jun 18",
+    }),
   ],
   query: "",
   search: { kind: "idle" },
@@ -42,7 +50,6 @@ describe("DocumentsSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Documents");
       expect(flat).toContain("Quarterly Plan");
       expect(flat).toContain("Onboarding Notes");
       expect(flat).toContain("document");
@@ -149,7 +156,10 @@ describe("DocumentsSpatialView one source, three modalities", () => {
   });
 
   it("registers as a terminal view the agent terminal can mount and render", () => {
-    const unregister = registerSpatialTerminalView("documents-test", () => view);
+    const unregister = registerSpatialTerminalView(
+      "documents-test",
+      () => view,
+    );
     try {
       const component = getTerminalView("documents-test");
       expect(component).toBeTruthy();

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
@@ -82,7 +82,7 @@ describe("DocumentsSpatialView one source, three modalities", () => {
       54,
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
-    expect(lines.join("\n")).toContain("Loading documents");
+    expect(lines.join("\n")).toContain("Loading");
   });
 
   it("empty state renders the honest no-documents affordance", () => {
@@ -99,7 +99,7 @@ describe("DocumentsSpatialView one source, three modalities", () => {
         <DocumentsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No documents");
+    expect(html).toContain("None");
   });
 
   it("error state renders the message and a Retry control", () => {

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -137,7 +137,7 @@ function DocumentsErrorBody({
 }
 
 function DocumentsEmptyBody() {
-  return <Text bold>No documents yet</Text>;
+  return <Text bold>No documents</Text>;
 }
 
 function DocumentsReadyBody({

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -20,7 +20,6 @@
 import {
   Button,
   Card,
-  Divider,
   Field,
   HStack,
   List,
@@ -99,11 +98,7 @@ export function DocumentsSpatialView({
   onAction,
 }: DocumentsSpatialViewProps) {
   return (
-    <Card title="Documents" gap={1} padding={1}>
-      <Text style="caption" tone="muted">
-        Browse and search the document store.
-      </Text>
-
+    <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading documents
@@ -128,7 +123,6 @@ function DocumentsErrorBody({
 }) {
   return (
     <>
-      <Divider label="error" />
       <Text bold>Could not load documents</Text>
       <Text tone="danger" style="caption">
         {snapshot.error ?? "Could not load documents."}
@@ -143,16 +137,7 @@ function DocumentsErrorBody({
 }
 
 function DocumentsEmptyBody() {
-  return (
-    <>
-      <Divider label="empty" />
-      <Text bold>No documents yet</Text>
-      <Text tone="muted" style="caption">
-        Upload a file or ingest a URL so Eliza can read, search, and answer from
-        your documents. Nothing is shown until a document is added.
-      </Text>
-    </>
-  );
+  return <Text bold>No documents yet</Text>;
 }
 
 function DocumentsReadyBody({
@@ -180,10 +165,12 @@ function DocumentsReadyBody({
 
       <DocumentsSearchBody search={snapshot.search} onAction={onAction} />
 
-      <Divider label={`Documents (${snapshot.documents.length})`} />
+      <Text style="caption" tone="muted">
+        Documents ({snapshot.documents.length})
+      </Text>
       {snapshot.documents.length === 0 ? (
         <Text tone="muted" style="caption">
-          Nothing here.
+          No documents
         </Text>
       ) : (
         <List gap={0}>
@@ -228,7 +215,7 @@ function DocumentRow({
           agent={`open:${doc.id}`}
           onPress={() => onAction?.(`open:${doc.id}`)}
         >
-          Open
+          ›
         </Button>
       </HStack>
     </VStack>
@@ -246,25 +233,24 @@ function DocumentsSearchBody({
 
   if (search.kind === "searching") {
     return (
-      <>
-        <Divider label="search" />
-        <Text tone="muted" style="caption" wrap={false}>
-          Searching for {search.query}
-        </Text>
-      </>
+      <Text tone="muted" style="caption" wrap={false}>
+        Searching for {search.query}
+      </Text>
     );
   }
 
   if (search.kind === "error") {
     return (
       <>
-        <Divider label="search" />
         <Text bold>Search failed</Text>
         <Text tone="danger" style="caption">
           {search.message}
         </Text>
         <HStack gap={1}>
-          <Button agent="clear-search" onPress={() => onAction?.("clear-search")}>
+          <Button
+            agent="clear-search"
+            onPress={() => onAction?.("clear-search")}
+          >
             Clear
           </Button>
         </HStack>
@@ -274,7 +260,9 @@ function DocumentsSearchBody({
 
   return (
     <>
-      <Divider label={`Results (${search.hits.length})`} />
+      <Text style="caption" tone="muted">
+        Results ({search.hits.length})
+      </Text>
       {search.hits.length === 0 ? (
         <Text tone="muted" style="caption" wrap={false}>
           No matches for {search.query}
@@ -327,7 +315,7 @@ function SearchResultRow({
           agent={`open:${hit.id}`}
           onPress={() => onAction?.(`open:${hit.id}`)}
         >
-          Open
+          ›
         </Button>
       </HStack>
     </VStack>

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -101,7 +101,7 @@ export function DocumentsSpatialView({
     <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
-          Loading documents
+          Loading
         </Text>
       ) : snapshot.state === "error" ? (
         <DocumentsErrorBody snapshot={snapshot} onAction={onAction} />
@@ -137,7 +137,7 @@ function DocumentsErrorBody({
 }
 
 function DocumentsEmptyBody() {
-  return <Text bold>No documents</Text>;
+  return <Text bold>None</Text>;
 }
 
 function DocumentsReadyBody({
@@ -170,7 +170,7 @@ function DocumentsReadyBody({
       </Text>
       {snapshot.documents.length === 0 ? (
         <Text tone="muted" style="caption">
-          No documents
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -265,7 +265,7 @@ function DocumentsSearchBody({
       </Text>
       {search.hits.length === 0 ? (
         <Text tone="muted" style="caption" wrap={false}>
-          No matches for {search.query}
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
@@ -124,7 +124,7 @@ describe("DocumentsView — states", () => {
         fetchers: makeFetchers({ fetchDocuments: () => never }),
       }),
     );
-    expect(screen.getByText("Loading documents")).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
   });
 
   it("renders the populated list with titles and the stats line", async () => {
@@ -146,7 +146,7 @@ describe("DocumentsView — states", () => {
         }),
       }),
     );
-    await screen.findByText("No documents yet");
+    await screen.findByText("None");
     expect(screen.queryByText("Quarterly Plan.md")).toBeNull();
   });
 

--- a/plugins/plugin-facewear/src/__tests__/facewear-view.test.tsx
+++ b/plugins/plugin-facewear/src/__tests__/facewear-view.test.tsx
@@ -82,19 +82,18 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     expect(screen.getAllByText("WebXR")).toHaveLength(3);
     expect(screen.getByText("Bluetooth BLE")).toBeTruthy();
 
-    // Descriptions
-    expect(screen.getByText("Passthrough AR/VR")).toBeTruthy();
-    expect(screen.getByText("OLED display and mic")).toBeTruthy();
+    expect(screen.queryByText("Passthrough AR/VR")).toBeNull();
+    expect(screen.queryByText("OLED display and mic")).toBeNull();
   });
 
   it("shows the empty header pill when no devices are connected", async () => {
     stubFetch({ connected: false, devices: [] });
     await renderResolved();
 
-    expect(screen.getByText("No devices connected")).toBeTruthy();
-    // Every card resting state -> Disconnected + a "Connect <name>" button.
+    expect(screen.getByText("0 on")).toBeTruthy();
+    // Every card resting state -> Off + a "Connect <name>" button.
     // (The "Connect" quick-action is an <a>, so scope to card buttons by label.)
-    expect(screen.getAllByText("Disconnected")).toHaveLength(4);
+    expect(screen.getAllByText("Off")).toHaveLength(4);
     expect(screen.getAllByRole("button", { name: /^Connect / })).toHaveLength(
       4,
     );
@@ -124,9 +123,9 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     // present (the rule matches profile.connectionType === "WebXR" && d.kind === "xr").
     // So meta-quest, xreal, apple-vision-pro all read Connected; even-realities
     // reads Connected via the smartglasses rule. => all 4 connected.
-    expect(screen.getAllByText("Connected")).toHaveLength(4);
+    expect(screen.getAllByText("On")).toHaveLength(4);
     expect(screen.getAllByText("Manage")).toHaveLength(4);
-    expect(screen.queryByText("Disconnected")).toBeNull();
+    expect(screen.queryByText("Off")).toBeNull();
   });
 
   it("connects only smartglasses-rule cards when the device list has no xr-kind device", async () => {
@@ -140,10 +139,10 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     });
     await renderResolved();
 
-    // even-realities card -> Connected/Manage; the 3 WebXR cards -> Disconnected/Connect.
-    expect(screen.getAllByText("Connected")).toHaveLength(1);
+    // even-realities card -> On/Manage; the 3 WebXR cards -> Off/Connect.
+    expect(screen.getAllByText("On")).toHaveLength(1);
     expect(screen.getAllByRole("button", { name: /^Manage / })).toHaveLength(1);
-    expect(screen.getAllByText("Disconnected")).toHaveLength(3);
+    expect(screen.getAllByText("Off")).toHaveLength(3);
     expect(screen.getAllByRole("button", { name: /^Connect / })).toHaveLength(
       3,
     );
@@ -159,7 +158,7 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     });
     await renderResolved();
 
-    expect(screen.getByText("2 devices connected")).toBeTruthy();
+    expect(screen.getByText("2 on")).toBeTruthy();
     // Active-device chips show device.deviceType for each (within the chip row).
     expect(screen.getByText("meta-quest")).toBeTruthy();
     expect(screen.getByText("xreal")).toBeTruthy();
@@ -172,7 +171,7 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     });
     await renderResolved();
 
-    expect(screen.getByText("1 device connected")).toBeTruthy();
+    expect(screen.getByText("1 on")).toBeTruthy();
     expect(screen.queryByText(/devices connected/)).toBeNull();
   });
 
@@ -190,7 +189,7 @@ describe("FacewearAppView (facewear overlay dashboard)", () => {
     });
     await renderResolved();
 
-    expect(screen.getByText("6 devices connected")).toBeTruthy();
+    expect(screen.getByText("6 on")).toBeTruthy();
     // Overflow chip shows +2 (6 devices - 4 visible).
     expect(screen.getByText("+2")).toBeTruthy();
   });

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
@@ -111,7 +111,7 @@ describe("SmartglassesView — connection + status display", () => {
     expect(screen.getByText("Offline")).toBeTruthy();
     // Both lens pills read the idle state.
     expect(screen.getAllByText("idle")).toHaveLength(2);
-    expect(screen.getByText("No events")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
     // Report shows the native bridge is available (window.__evenBridge set).
     expect(screen.getByText("available")).toBeTruthy();
   });

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
@@ -111,7 +111,7 @@ describe("SmartglassesView — connection + status display", () => {
     expect(screen.getByText("Offline")).toBeTruthy();
     // Both lens pills read the idle state.
     expect(screen.getAllByText("idle")).toHaveLength(2);
-    expect(screen.getByText("No events yet.")).toBeTruthy();
+    expect(screen.getByText("No events")).toBeTruthy();
     // Report shows the native bridge is available (window.__evenBridge set).
     expect(screen.getByText("available")).toBeTruthy();
   });

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
@@ -43,7 +43,6 @@ describe("FacewearSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Facewear");
       expect(flat).toContain("device connected"); // header pill (singular)
       expect(flat).toContain("Meta Quest"); // a device row
       expect(flat).toContain("Refresh"); // quick action
@@ -61,7 +60,6 @@ describe("FacewearSpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Facewear");
       expect(html).toContain("Meta Quest");
       expect(html).toContain('data-agent-id="connect:meta-quest"');
       expect(html).toContain('data-agent-id="refresh"');
@@ -98,7 +96,6 @@ describe("FacewearSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Facewear");
     } finally {
       unregister();
     }

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
@@ -80,7 +80,7 @@ describe("FacewearSpatialView one source, three modalities", () => {
       />,
       50,
     ).join("\n");
-    expect(empty).toContain("No devices connected");
+    expect(empty).toContain("No devices");
     expect(empty).toContain("network down");
     expect(empty).toContain("No supported devices");
   });

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
@@ -80,9 +80,9 @@ describe("FacewearSpatialView one source, three modalities", () => {
       />,
       50,
     ).join("\n");
-    expect(empty).toContain("No devices");
+    expect(empty).toContain("None");
     expect(empty).toContain("network down");
-    expect(empty).toContain("No supported devices");
+    expect(empty).toContain("None");
   });
 
   it("registers as a terminal view the agent terminal can mount and render", () => {

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
@@ -88,7 +88,7 @@ export function FacewearSpatialView({
   );
 
   return (
-    <Card title="Facewear" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
@@ -97,7 +97,7 @@ export function FacewearSpatialView({
         >
           {connectedCount > 0
             ? `${connectedCount} device${connectedCount === 1 ? "" : "s"} connected`
-            : "No devices"}
+            : "None"}
         </Text>
         <Text style="caption" tone="muted">
           {snapshot.loading ? "loading" : `${snapshot.profiles.length} models`}
@@ -131,7 +131,7 @@ export function FacewearSpatialView({
       <Divider label="devices" />
       {snapshot.profiles.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {snapshot.loading ? "Loading devices" : "No supported devices"}
+          {snapshot.loading ? "Loading" : "None"}
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.tsx
@@ -97,7 +97,7 @@ export function FacewearSpatialView({
         >
           {connectedCount > 0
             ? `${connectedCount} device${connectedCount === 1 ? "" : "s"} connected`
-            : "No devices connected"}
+            : "No devices"}
         </Text>
         <Text style="caption" tone="muted">
           {snapshot.loading ? "loading" : `${snapshot.profiles.length} models`}

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
@@ -110,8 +110,6 @@ describe("SmartglassesPanelView — unified GUI/XR panel", () => {
       fireEvent.click(button("wifi-status"));
       await Promise.resolve();
     });
-    expect(
-      screen.getByText("No native smartglasses bridge is available"),
-    ).toBeTruthy();
+    expect(screen.getByText("Unavailable")).toBeTruthy();
   });
 });

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
@@ -70,7 +70,6 @@ describe("SmartglassesPanelView — unified GUI/XR panel", () => {
     window.facewearSmartglassesReport = makeReport();
     render(<SmartglassesPanelView />);
 
-    expect(screen.getByText("Smartglasses")).toBeTruthy();
     expect(screen.getByText(/sn G1-AB12/)).toBeTruthy();
     // The connected report drives the status caption + lens marks.
     expect(screen.getAllByText(/connected/i).length).toBeGreaterThan(0);
@@ -78,7 +77,6 @@ describe("SmartglassesPanelView — unified GUI/XR panel", () => {
 
   it("falls back to the disconnected default report when none is published", () => {
     render(<SmartglassesPanelView />);
-    expect(screen.getByText("Smartglasses")).toBeTruthy();
     expect(screen.getByText("disconnected")).toBeTruthy();
   });
 

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
@@ -162,9 +162,7 @@ export function SmartglassesPanelView() {
         case "display-test":
         case "clear-display":
           // The transport is owned by the full dashboard; surface the next step.
-          setError(
-            "Open the Smartglasses dashboard to drive the headset transport.",
-          );
+          setError("Open Smartglasses.");
           return;
       }
     },

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
@@ -108,7 +108,7 @@ export function SmartglassesPanelView() {
     ) => {
       const bridge = getBridge();
       if (!bridge) {
-        setError("No native smartglasses bridge is available");
+        setError("Unavailable");
         return;
       }
       setBusy(label);

--- a/plugins/plugin-facewear/src/components/SmartglassesSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesSpatialView.test.tsx
@@ -77,7 +77,6 @@ describe("SmartglassesSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Smartglasses");
       expect(flat).toContain("connected");
       expect(flat).toContain("init"); // a diagnostics test row
       expect(flat).toContain("studio-net"); // wi-fi network
@@ -95,7 +94,6 @@ describe("SmartglassesSpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Smartglasses");
       expect(html).toContain("studio-net");
       expect(html).toContain('data-agent-id="run-check"');
       expect(html).toContain('data-agent-id="connect"');
@@ -113,7 +111,6 @@ describe("SmartglassesSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Smartglasses");
     } finally {
       unregister();
     }

--- a/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
@@ -301,7 +301,7 @@ export function SmartglassesSpatialView({
       </HStack>
       {report.wifi.networks.length === 0 ? (
         <Text style="caption" tone="muted">
-          No networks seen
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -321,7 +321,7 @@ export function SmartglassesSpatialView({
       <Divider label="events" />
       {report.events.length === 0 ? (
         <Text style="caption" tone="muted" align="center">
-          No events
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
@@ -321,7 +321,7 @@ export function SmartglassesSpatialView({
       <Divider label="events" />
       {report.events.length === 0 ? (
         <Text style="caption" tone="muted" align="center">
-          No events yet
+          No events
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesSpatialView.tsx
@@ -133,7 +133,7 @@ export function SmartglassesSpatialView({
     .reverse();
 
   return (
-    <Card title="Smartglasses" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-facewear/src/ui/FacewearAppView.tsx
+++ b/plugins/plugin-facewear/src/ui/FacewearAppView.tsx
@@ -50,20 +50,10 @@ function DeviceCard({
     });
 
   return (
-    <div
-      className={`rounded-lg border p-4 transition-colors ${
-        isConnected
-          ? "border-green-500/30 bg-green-500/5"
-          : "border-border/60 bg-card hover:border-border"
-      }`}
-    >
+    <div className="py-3 transition-colors">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
-          <div
-            className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
-              isConnected ? "bg-green-500/15" : "bg-muted/20"
-            }`}
-          >
+          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center">
             <Icon
               className={`h-5 w-5 ${isConnected ? "text-green-500" : "text-muted"}`}
             />
@@ -76,17 +66,14 @@ function DeviceCard({
           </div>
         </div>
         <span
-          className={`flex-shrink-0 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ${
-            isConnected
-              ? "bg-green-500/10 text-green-600 dark:text-green-400"
-              : "bg-muted/20 text-muted"
+          className={`flex-shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium ${
+            isConnected ? "text-green-600 dark:text-green-400" : "text-muted"
           }`}
         >
-          {isConnected ? "Connected" : "Disconnected"}
+          {isConnected ? "On" : "Off"}
         </span>
       </div>
-      <p className="mt-2 text-xs text-muted">{profile.description}</p>
-      <div className="mt-3 flex items-center justify-between gap-2">
+      <div className="mt-2 flex items-center justify-between gap-2">
         <span className="inline-flex items-center gap-1.5 text-xs text-muted">
           <ConnectionIcon connectionType={profile.connectionType} />
           {profile.connectionType}
@@ -96,7 +83,7 @@ function DeviceCard({
           type="button"
           onClick={() => onConnect(profile.type)}
           aria-label={actionLabel}
-          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
+          className="inline-flex h-8 items-center gap-1.5 px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
           {...connectAgentProps}
         >
           {isConnected ? "Manage" : "Connect"}
@@ -172,7 +159,7 @@ export function FacewearAppView() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-bg text-txt">
-      <div className="border-b border-border/60 px-4 py-3">
+      <div className="px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="flex items-center gap-2">
@@ -181,16 +168,14 @@ export function FacewearAppView() {
             </div>
           </div>
           <span
-            className={`inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium ${
+            className={`inline-flex h-7 items-center gap-1.5 px-1.5 text-xs font-medium ${
               activeCount > 0
-                ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300"
-                : "border-border bg-muted/20 text-muted"
+                ? "text-green-700 dark:text-green-300"
+                : "text-muted"
             }`}
           >
             <Zap className="h-3.5 w-3.5" />
-            {activeCount > 0
-              ? `${activeCount} device${activeCount === 1 ? "" : "s"} connected`
-              : "No devices connected"}
+            {activeCount > 0 ? `${activeCount} on` : "0 on"}
           </span>
         </div>
       </div>
@@ -203,28 +188,26 @@ export function FacewearAppView() {
         )}
 
         {error && (
-          <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            {error}
-          </div>
+          <div className="mb-4 px-1 py-2 text-xs text-destructive">{error}</div>
         )}
 
         {!loading && (
           <>
             {activeCount > 0 && (
-              <div className="mb-4 rounded-lg border border-green-500/20 bg-green-500/5 p-3">
-                <div className="mt-2 flex flex-wrap gap-2">
+              <div className="mb-3">
+                <div className="flex flex-wrap gap-2">
                   {status.devices
                     .slice(0, ACTIVE_DEVICE_LIMIT)
                     .map((device) => (
                       <span
                         key={device.id}
-                        className="inline-flex items-center gap-1 rounded-md bg-green-500/10 px-2 py-0.5 text-xs text-green-700 dark:text-green-300"
+                        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs text-green-700 dark:text-green-300"
                       >
                         {device.deviceType ?? device.kind}
                       </span>
                     ))}
                   {status.devices.length > ACTIVE_DEVICE_LIMIT ? (
-                    <span className="inline-flex items-center rounded-md bg-muted/20 px-2 py-0.5 text-xs text-muted">
+                    <span className="inline-flex items-center px-1.5 py-0.5 text-xs text-muted">
                       +{status.devices.length - ACTIVE_DEVICE_LIMIT}
                     </span>
                   ) : null}
@@ -234,26 +217,24 @@ export function FacewearAppView() {
 
             <div className="grid gap-3">
               {FACEWEAR_DEVICE_PROFILES.map((profile) => (
-                <div key={profile.type}>
-                  <DeviceCard
-                    profile={profile}
-                    connectedDevices={status.devices}
-                    onConnect={handleConnect}
-                  />
-                </div>
+                <DeviceCard
+                  key={profile.type}
+                  profile={profile}
+                  connectedDevices={status.devices}
+                  onConnect={handleConnect}
+                />
               ))}
             </div>
 
-            <div className="mt-4 rounded-lg border border-border/60 bg-card p-4">
-              <h2 className="text-sm font-semibold">Actions</h2>
-              <div className="mt-3 flex flex-wrap gap-2">
+            <div className="mt-4">
+              <div className="flex flex-wrap gap-2">
                 <a
                   ref={xrConnectRef}
                   href="/api/xr/connect"
                   target="_blank"
                   rel="noreferrer"
                   aria-label="XR connect"
-                  className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
+                  className="inline-flex h-8 items-center gap-1.5 px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
                   {...xrConnectAgentProps}
                 >
                   <Zap className="h-3.5 w-3.5" />
@@ -265,7 +246,7 @@ export function FacewearAppView() {
                   target="_blank"
                   rel="noreferrer"
                   aria-label="XR status"
-                  className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
+                  className="inline-flex h-8 items-center gap-1.5 px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
                   {...xrStatusAgentProps}
                 >
                   Status
@@ -275,7 +256,7 @@ export function FacewearAppView() {
                   type="button"
                   onClick={() => void fetchStatus()}
                   aria-label="Refresh"
-                  className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
+                  className="inline-flex h-8 items-center gap-1.5 px-3 text-xs font-medium hover:bg-muted/20 transition-colors"
                   {...refreshAgentProps}
                 >
                   Refresh
@@ -294,7 +275,7 @@ export function FacewearTuiView() {
     <TerminalPluginView
       id="facewear"
       label="Facewear TUI"
-      description="Facewear device status endpoints"
+      description="Status"
       commands={[]}
       endpoints={[
         "/api/facewear/status",
@@ -310,7 +291,7 @@ export function SmartglassesTuiView() {
     <TerminalPluginView
       id="smartglasses"
       label="Smartglasses TUI"
-      description="Smartglasses status endpoints"
+      description="Status"
       commands={[]}
       endpoints={["/api/facewear/status", "/api/facewear/devices"]}
     />

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
@@ -774,7 +774,7 @@ export function SmartglassesView() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-bg text-txt">
-      <div className="border-b border-border/60 px-4 py-3">
+      <div className="px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
@@ -789,7 +789,7 @@ export function SmartglassesView() {
         </div>
       </div>
 
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 p-4">
         <Panel>
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
@@ -813,8 +813,8 @@ export function SmartglassesView() {
             <LensStatus side="right" state={lenses.right} />
           </div>
           {!webBluetoothAvailable && (
-            <p className="mt-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted">
-              Web Bluetooth unavailable. Use a native bridge or Chrome/Edge.
+            <p className="mt-3 px-1 text-xs text-muted">
+              Web Bluetooth unavailable
             </p>
           )}
           <HeadsetStateHint
@@ -826,7 +826,7 @@ export function SmartglassesView() {
 
         <Panel>
           <h2 className="text-sm font-semibold">Platform</h2>
-          <div className="mt-3 grid grid-cols-3 gap-1 rounded-lg border border-border/50 bg-muted/15 p-1">
+          <div className="mt-3 grid grid-cols-3 gap-1">
             {(Object.keys(PLATFORM_COPY) as PlatformKey[]).map((key) => (
               <PlatformTabButton
                 key={key}
@@ -869,10 +869,10 @@ export function SmartglassesView() {
                 type="button"
                 onClick={() => setTestText(preset.text)}
                 aria-pressed={testText === preset.text}
-                className={`h-14 rounded-md border px-3 text-left text-xs font-semibold transition ${
+                className={`h-14 px-3 text-left text-xs font-semibold transition ${
                   testText === preset.text
                     ? preset.className
-                    : "border-border/60 bg-muted/10 text-muted hover:text-txt"
+                    : "text-muted hover:text-txt"
                 }`}
               >
                 {preset.label}
@@ -929,7 +929,7 @@ export function SmartglassesView() {
                 <CheckRow key={id} ok={ok} label={labelForTest(id)} />
               ))}
             {Object.keys(tests).length > VISIBLE_TEST_LIMIT ? (
-              <div className="rounded-md border border-border/50 px-3 py-2 text-xs text-muted">
+              <div className="px-3 py-2 text-xs text-muted">
                 +{Object.keys(tests).length - VISIBLE_TEST_LIMIT} checks
               </div>
             ) : null}
@@ -1008,15 +1008,12 @@ export function SmartglassesView() {
           {wifiNetworks.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1">
               {wifiNetworks.slice(0, VISIBLE_WIFI_LIMIT).map((network) => (
-                <span
-                  key={network}
-                  className="rounded-md bg-muted/30 px-2 py-1 text-xs text-muted"
-                >
+                <span key={network} className="px-1.5 py-1 text-xs text-muted">
                   {network}
                 </span>
               ))}
               {wifiNetworks.length > VISIBLE_WIFI_LIMIT ? (
-                <span className="rounded-md bg-muted/20 px-2 py-1 text-xs text-muted">
+                <span className="px-1.5 py-1 text-xs text-muted">
                   +{wifiNetworks.length - VISIBLE_WIFI_LIMIT}
                 </span>
               ) : null}
@@ -1089,9 +1086,9 @@ export function SmartglassesView() {
             <Settings2 className="h-4 w-4 text-accent" />
             <h2 className="text-sm font-semibold">Events</h2>
           </div>
-          <div className="mt-3 max-h-72 overflow-y-auto rounded-md border border-border/50 bg-muted/10">
+          <div className="mt-3 max-h-72 overflow-y-auto">
             {events.length === 0 ? (
-              <p className="px-3 py-4 text-xs text-muted">No events yet.</p>
+              <p className="px-1 py-2 text-xs text-muted">No events</p>
             ) : (
               events
                 .slice()
@@ -1100,7 +1097,7 @@ export function SmartglassesView() {
                 .map((event) => (
                   <div
                     key={`${event.at}:${event.type}:${event.detail}`}
-                    className="border-b border-border/40 px-3 py-2 last:border-b-0"
+                    className="px-1 py-2"
                   >
                     <p className="text-xs font-medium text-txt">{event.type}</p>
                     <p className="mt-0.5 text-xs text-muted">{event.detail}</p>
@@ -1116,7 +1113,7 @@ export function SmartglassesView() {
         </Panel>
       </div>
       {error && (
-        <div className="mx-4 mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+        <div className="mx-4 mb-4 px-1 py-2 text-xs text-destructive">
           {error}
         </div>
       )}
@@ -1125,11 +1122,7 @@ export function SmartglassesView() {
 }
 
 function Panel({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border border-border/60 bg-card p-4">
-      {children}
-    </div>
-  );
+  return <div className="py-2">{children}</div>;
 }
 
 function ActionButton({
@@ -1164,7 +1157,7 @@ function ActionButton({
       onClick={() => void onClick()}
       disabled={disabled}
       aria-label={agentLabel}
-      className="inline-flex h-9 items-center gap-2 rounded-md border border-border px-3 text-sm font-medium hover:bg-muted/20 disabled:cursor-not-allowed disabled:opacity-50"
+      className="inline-flex h-9 items-center gap-2 px-3 text-sm font-medium hover:bg-muted/20 disabled:cursor-not-allowed disabled:opacity-50"
       {...agentProps}
     >
       {children}
@@ -1199,10 +1192,8 @@ function PlatformTabButton({
       onClick={() => onSelect(platformKey)}
       aria-current={isActive ? "page" : undefined}
       aria-label={`${label} platform`}
-      className={`h-8 rounded-md px-2 text-xs font-medium transition-colors ${
-        isActive
-          ? "bg-bg text-accent shadow-sm ring-1 ring-accent/30"
-          : "text-muted hover:bg-muted/20 hover:text-txt"
+      className={`h-8 px-2 text-xs font-medium transition-colors ${
+        isActive ? "text-accent" : "text-muted hover:bg-muted/20 hover:text-txt"
       }`}
       {...agentProps}
     >
@@ -1214,10 +1205,8 @@ function PlatformTabButton({
 function StatusPill({ ok, label }: { ok: boolean; label: string }) {
   return (
     <span
-      className={`inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium ${
-        ok
-          ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300"
-          : "border-border bg-muted/20 text-muted"
+      className={`inline-flex h-7 items-center gap-1.5 px-1.5 text-xs font-medium ${
+        ok ? "text-green-700 dark:text-green-300" : "text-muted"
       }`}
     >
       {ok ? (
@@ -1233,7 +1222,7 @@ function StatusPill({ ok, label }: { ok: boolean; label: string }) {
 function LensStatus({ side, state }: { side: GlassSide; state: LensState }) {
   const ok = state === "connected";
   return (
-    <div className="flex items-center justify-between rounded-md border border-border/50 px-3 py-2">
+    <div className="flex items-center justify-between px-1 py-2">
       <div className="flex items-center gap-2">
         <Glasses className="h-4 w-4 text-muted" />
         <span className="text-sm capitalize">{side}</span>
@@ -1260,17 +1249,17 @@ function HeadsetStateHint({
   const blocked = isCradleOrChargingState(physicalState, batteryState);
   const ready = physicalState === "wearing";
   const tone = blocked
-    ? "border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200"
+    ? "text-amber-800 dark:text-amber-200"
     : ready
-      ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300"
-      : "border-border/50 bg-muted/15 text-muted";
+      ? "text-green-700 dark:text-green-300"
+      : "text-muted";
   const hint = blocked
     ? "Remove from charger and wear before validation."
     : ready
       ? "Ready for tap/audio validation."
       : "Wear state required for tap/audio validation.";
   return (
-    <div className={`mt-3 rounded-lg border px-3 py-2 ${tone}`}>
+    <div className={`mt-3 px-1 py-2 ${tone}`}>
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="text-2xs font-semibold uppercase tracking-wider opacity-70">
           Headset
@@ -1279,7 +1268,7 @@ function HeadsetStateHint({
           chips.map((chip) => (
             <span
               key={chip.key}
-              className="inline-flex items-center gap-1 rounded-full border border-current/20 bg-current/5 px-2 py-0.5 text-2xs font-medium"
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs font-medium"
             >
               <span
                 className="h-1 w-1 rounded-full bg-current opacity-70"
@@ -1299,13 +1288,7 @@ function HeadsetStateHint({
 
 function CheckRow({ ok, label }: { ok: boolean; label: string; key?: string }) {
   return (
-    <div
-      className={`flex items-center justify-between gap-2 rounded-lg border px-3 py-2 transition-colors ${
-        ok
-          ? "border-green-500/30 bg-green-500/5"
-          : "border-border/40 bg-muted/5"
-      }`}
-    >
+    <div className="flex items-center justify-between gap-2 px-1 py-2 transition-colors">
       <span className={`text-xs ${ok ? "font-medium text-txt" : "text-muted"}`}>
         {label}
       </span>

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
@@ -1084,7 +1084,7 @@ export function SmartglassesView() {
           </div>
           <div className="mt-3 max-h-72 overflow-y-auto">
             {events.length === 0 ? (
-              <p className="px-1 py-2 text-xs text-muted">No events</p>
+              <p className="px-1 py-2 text-xs text-muted">None</p>
             ) : (
               events
                 .slice()

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
@@ -670,8 +670,7 @@ export function SmartglassesView() {
     setBusy("wifi-scan");
     setError(null);
     try {
-      if (!bridge)
-        throw new Error("No native smartglasses bridge is available");
+      if (!bridge) throw new Error("Unavailable");
       const result = await callWifiBridge(bridge, "request_wifi_scan");
       const networks = parseWifiNetworks(result);
       setWifiNetworks(networks);
@@ -694,8 +693,7 @@ export function SmartglassesView() {
     setBusy("wifi-status");
     setError(null);
     try {
-      if (!bridge)
-        throw new Error("No native smartglasses bridge is available");
+      if (!bridge) throw new Error("Unavailable");
       const result = await callWifiBridge(bridge, "request_wifi_status");
       const networks = parseWifiNetworks(result);
       if (networks.length > 0) setWifiNetworks(networks);
@@ -714,8 +712,7 @@ export function SmartglassesView() {
     setBusy("wifi-configure");
     setError(null);
     try {
-      if (!bridge)
-        throw new Error("No native smartglasses bridge is available");
+      if (!bridge) throw new Error("Unavailable");
       if (!wifiSsid.trim()) throw new Error("Enter a Wi-Fi SSID");
       await callWifiBridge(bridge, "set_wifi_credentials", {
         ssid: wifiSsid.trim(),
@@ -736,8 +733,7 @@ export function SmartglassesView() {
     setBusy("wifi-setup");
     setError(null);
     try {
-      if (!bridge)
-        throw new Error("No native smartglasses bridge is available");
+      if (!bridge) throw new Error("Unavailable");
       await callWifiBridge(bridge, "request_wifi_setup", {
         reason: "Smartglasses setup",
       });

--- a/plugins/plugin-feed/src/components/FeedSpatialView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedSpatialView.test.tsx
@@ -122,7 +122,6 @@ describe("FeedSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Feed Operator");
       expect(flat).toContain("Quantum Trader");
       expect(flat).toContain("autonomous");
       expect(flat).toContain("Pause"); // control action button (autonomy active)
@@ -140,7 +139,6 @@ describe("FeedSpatialView one source, three modalities", () => {
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
       expect(html).toContain("Quantum Trader");
-      expect(html).toContain("Feed Operator");
       expect(html).toContain('data-agent-id="toggle-autonomy"');
     }
   });

--- a/plugins/plugin-feed/src/components/FeedSpatialView.tsx
+++ b/plugins/plugin-feed/src/components/FeedSpatialView.tsx
@@ -147,7 +147,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
     return (
       <Card gap={1} padding={1}>
         <Text style="caption" tone="warning">
-          No session yet
+          No session
         </Text>
         <Button
           grow={1}
@@ -329,7 +329,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
 
       <HStack gap={1} align="center">
         <Text grow={1}>
-          {wallet ? formatCurrency(wallet.balance) : "Waiting for wallet"}
+          {wallet ? formatCurrency(wallet.balance) : "No wallet"}
         </Text>
         <Text style="caption" tone="muted">
           {`trading ${formatCurrency(tradingBalance)}`}

--- a/plugins/plugin-feed/src/components/FeedSpatialView.tsx
+++ b/plugins/plugin-feed/src/components/FeedSpatialView.tsx
@@ -147,7 +147,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
     return (
       <Card gap={1} padding={1}>
         <Text style="caption" tone="warning">
-          No session
+          None
         </Text>
         <Button
           grow={1}
@@ -223,7 +223,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </VStack>
       ) : (
         <Text tone="muted" style="caption">
-          No portfolio
+          None
         </Text>
       )}
 
@@ -242,7 +242,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
 
       {predictionMarkets.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No markets
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -264,7 +264,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
 
       {recentTrades.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No trades
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -328,9 +328,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
       ) : null}
 
       <HStack gap={1} align="center">
-        <Text grow={1}>
-          {wallet ? formatCurrency(wallet.balance) : "No wallet"}
-        </Text>
+        <Text grow={1}>{wallet ? formatCurrency(wallet.balance) : "None"}</Text>
         <Text style="caption" tone="muted">
           {`trading ${formatCurrency(tradingBalance)}`}
         </Text>

--- a/plugins/plugin-feed/src/components/FeedSpatialView.tsx
+++ b/plugins/plugin-feed/src/components/FeedSpatialView.tsx
@@ -23,7 +23,6 @@ import type {
 import {
   Button,
   Card,
-  Divider,
   HStack,
   List,
   type SpatialTone,
@@ -146,13 +145,9 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
 
   if (!hasSession) {
     return (
-      <Card title="Feed" gap={1} padding={1}>
+      <Card gap={1} padding={1}>
         <Text style="caption" tone="warning">
           No session yet
-        </Text>
-        <Text tone="muted" style="caption">
-          Waiting for a Feed session. Spawn the trading agent to stream live
-          markets, portfolio PnL, and team coordination here.
         </Text>
         <Button
           grow={1}
@@ -177,7 +172,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
   const recentChat = chatMessages.slice(-2);
 
   return (
-    <Card title="Feed Operator" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"
@@ -214,7 +209,6 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </Text>
       ) : null}
 
-      <Divider label="portfolio" />
       {portfolio ? (
         <VStack gap={0}>
           <HStack gap={1} align="center">
@@ -229,7 +223,7 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </VStack>
       ) : (
         <Text tone="muted" style="caption">
-          Portfolio is not available yet.
+          No portfolio
         </Text>
       )}
 
@@ -246,10 +240,9 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </VStack>
       ) : null}
 
-      <Divider label="markets" />
       {predictionMarkets.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          Market data is not available yet.
+          No markets
         </Text>
       ) : (
         <List gap={0}>
@@ -269,10 +262,9 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </List>
       )}
 
-      <Divider label="recent trades" />
       {recentTrades.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No recent trades
+          No trades
         </Text>
       ) : (
         <List gap={0}>
@@ -296,7 +288,6 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </List>
       )}
 
-      <Divider label="team" />
       <HStack gap={1} align="center">
         <Text grow={1} wrap={false}>
           {team.ownerName ?? `${team.agentCount} agents`}
@@ -336,7 +327,6 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </List>
       ) : null}
 
-      <Divider label="wallet" />
       <HStack gap={1} align="center">
         <Text grow={1}>
           {wallet ? formatCurrency(wallet.balance) : "Waiting for wallet"}
@@ -346,7 +336,6 @@ export function FeedSpatialView({ snapshot, onAction }: FeedSpatialViewProps) {
         </Text>
       </HStack>
 
-      <Divider label="steering" />
       {suggestedPrompts.length > 0 ? (
         <HStack gap={1} wrap>
           {suggestedPrompts.slice(0, 2).map((prompt, index) => (

--- a/plugins/plugin-feed/src/components/FeedView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.test.tsx
@@ -331,7 +331,7 @@ describe("FeedView — no-session waiting state", () => {
     appState.appRuns = [];
     render(React.createElement(FeedView));
 
-    await screen.findByText("Waiting for a Feed session.", { exact: false });
+    await screen.findByText("No session yet");
     const spawn = button("spawn-agent");
     expect(spawn.disabled).toBe(true);
 

--- a/plugins/plugin-feed/src/components/FeedView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.test.tsx
@@ -331,7 +331,7 @@ describe("FeedView — no-session waiting state", () => {
     appState.appRuns = [];
     render(React.createElement(FeedView));
 
-    await screen.findByText("No session");
+    await screen.findByText("None");
     const spawn = button("spawn-agent");
     expect(spawn.disabled).toBe(true);
 

--- a/plugins/plugin-feed/src/components/FeedView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.test.tsx
@@ -331,7 +331,7 @@ describe("FeedView — no-session waiting state", () => {
     appState.appRuns = [];
     render(React.createElement(FeedView));
 
-    await screen.findByText("No session yet");
+    await screen.findByText("No session");
     const spawn = button("spawn-agent");
     expect(spawn.disabled).toBe(true);
 

--- a/plugins/plugin-feed/src/ui/FeedOperatorSurface.render.test.tsx
+++ b/plugins/plugin-feed/src/ui/FeedOperatorSurface.render.test.tsx
@@ -454,8 +454,8 @@ describe("FeedOperatorSurface (gui/xr) — populated data", () => {
 
     const text = container.textContent ?? "";
 
-    // Hero title (live variant) + status label "<status> · <health.state>".
-    expect(text).toContain("Feed Live Dashboard");
+    // Hero title + status label "<status> · <health.state>".
+    expect(text).toContain("Feed");
     expect(text).toContain("running · healthy");
 
     // Live StatChip strip.
@@ -638,8 +638,8 @@ describe("FeedOperatorSurface (gui/xr) — no-run waiting state", () => {
     expect(text).toContain("Portfolio");
     expect(text).toContain("Markets");
     expect(text).toContain("Wallet");
-    // WaitingForSession copy.
-    expect(text).toContain("Waiting for a Feed session");
+    // Compact pending status.
+    expect(text).toContain("None");
 
     // Spawn agent CTA present and disabled.
     const spawn = clickByText(container, "Spawn agent") as HTMLButtonElement;

--- a/plugins/plugin-feed/src/ui/FeedOperatorSurface.tsx
+++ b/plugins/plugin-feed/src/ui/FeedOperatorSurface.tsx
@@ -81,7 +81,7 @@ function formatPnL(value: unknown): string {
 }
 
 function listPreview(items: FeedPredictionMarket[]): string {
-  if (items.length === 0) return "Market data is not available yet.";
+  if (items.length === 0) return "—";
   return items
     .slice(0, 3)
     .map((market) => {
@@ -173,12 +173,7 @@ export function FeedOperatorSurface({
     null;
   const agentPortfolio = agentSummary?.portfolio ?? null;
   const teamTotals = teamDashboard.summary?.totals ?? null;
-  const surfaceTitle =
-    variant === "live"
-      ? "Feed Live Dashboard"
-      : variant === "running"
-        ? "Feed Run Dashboard"
-        : "Feed Operator Dashboard";
+  const surfaceTitle = "Feed";
   const showDashboard = focus !== "chat";
   const showChat = focus !== "dashboard";
   const controlAction = run?.session?.controls?.includes("pause")
@@ -320,7 +315,7 @@ export function FeedOperatorSurface({
 
   if (!run) {
     const chips: StatChip[] = [
-      { icon: "◉", label: "Agent", value: "Session pending", state: "pending" },
+      { icon: "◉", label: "Agent", value: "Pending", state: "pending" },
       { icon: "◒", label: "Portfolio", value: "—", state: "idle" },
       { icon: "▲", label: "Markets", value: "—", state: "idle" },
       { icon: "◇", label: "Wallet", value: "—", state: "idle" },
@@ -335,10 +330,7 @@ export function FeedOperatorSurface({
             cta={<HeroCta label="Spawn agent" accent={FEED_ACCENT} disabled />}
           />
           <GameSurfaceStrip chips={chips} />
-          <WaitingForSession
-            accent={FEED_ACCENT}
-            message="Waiting for a Feed session. Spawn the trading agent to stream live markets, portfolio PnL, and team coordination here."
-          />
+          <WaitingForSession accent={FEED_ACCENT} message="" />
         </GameSurfaceShell>
       </div>
     );
@@ -471,7 +463,7 @@ export function FeedOperatorSurface({
                             ? ` · ${teamTotals.openPositions} open positions`
                             : ""
                         }`
-                      : "Team summary is not available yet."
+                      : undefined
                   }
                 />
               </div>
@@ -551,7 +543,7 @@ export function FeedOperatorSurface({
                 ))}
                 {recentChatMessages.length === 0 ? (
                   <div className="px-1 py-1 text-xs-tight italic text-muted">
-                    No relay yet.
+                    —
                   </div>
                 ) : null}
               </div>
@@ -585,11 +577,7 @@ export function FeedOperatorSurface({
                 />
                 <SurfaceCard
                   label="Wallet"
-                  value={
-                    wallet
-                      ? formatCurrency(wallet.balance)
-                      : "Waiting for wallet"
-                  }
+                  value={wallet ? formatCurrency(wallet.balance) : "—"}
                   subtitle={
                     wallet
                       ? `${wallet.transactions.length} transactions · trading ${formatCurrency(tradingBalance)}`

--- a/plugins/plugin-feed/src/ui/FeedOperatorSurface.tsx
+++ b/plugins/plugin-feed/src/ui/FeedOperatorSurface.tsx
@@ -325,7 +325,7 @@ export function FeedOperatorSurface({
         <GameSurfaceShell>
           <GameSurfaceHero
             title="Feed"
-            statusLabel="No session yet"
+            statusLabel="None"
             statusState="pending"
             cta={<HeroCta label="Spawn agent" accent={FEED_ACCENT} disabled />}
           />

--- a/plugins/plugin-feed/src/ui/game-surface-shell.tsx
+++ b/plugins/plugin-feed/src/ui/game-surface-shell.tsx
@@ -1,10 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 
-// Shared visual shell for game/app operator surfaces: a compact header (title +
-// status + CTA), a horizontal status strip of stat chips, and a content zone.
-// Inline styles only — the view bundle does not ship Tailwind, so utility
-// classes do not paint here. Theme tokens (--accent, --card, --border …) are
-// read via CSS var().
+// Shared visual shell for game/app operator surfaces. Inline styles only: the
+// view bundle does not ship Tailwind, so utility classes do not paint here.
 
 export type ChipState = "ready" | "pending" | "active" | "idle" | "danger";
 
@@ -54,9 +51,7 @@ export function GameSurfaceHero({
         alignItems: "center",
         justifyContent: "space-between",
         gap: 12,
-        padding: "14px 16px",
-        borderBottom: "1px solid var(--border, rgba(0,0,0,0.1))",
-        background: "var(--card, rgba(0,0,0,0.02))",
+        padding: "10px 12px",
       }}
     >
       <div style={{ minWidth: 0 }}>
@@ -64,7 +59,7 @@ export function GameSurfaceHero({
           style={{
             fontSize: 16,
             fontWeight: 600,
-            letterSpacing: "-0.01em",
+            letterSpacing: 0,
             color: "var(--foreground, #111)",
             lineHeight: 1.2,
           }}
@@ -76,7 +71,7 @@ export function GameSurfaceHero({
             display: "inline-flex",
             alignItems: "center",
             gap: 7,
-            marginTop: 6,
+            marginTop: 4,
             fontSize: 12,
             color: "var(--muted, #6b7280)",
           }}
@@ -114,14 +109,14 @@ export function HeroCta({
       onClick={onClick}
       disabled={disabled}
       style={{
-        padding: "9px 16px",
-        borderRadius: 12,
+        padding: "8px 12px",
+        borderRadius: 8,
         border: "none",
         background: accent,
         color: "#fff",
         fontSize: 13,
         fontWeight: 700,
-        letterSpacing: "0.01em",
+        letterSpacing: 0,
         cursor: disabled ? "default" : "pointer",
         opacity: disabled ? 0.55 : 1,
         whiteSpace: "nowrap",
@@ -137,11 +132,9 @@ export function GameSurfaceStrip({ chips }: { chips: StatChip[] }) {
     <div
       style={{
         display: "flex",
-        gap: 10,
-        padding: "12px 16px",
+        gap: 8,
+        padding: "6px 12px 10px",
         overflowX: "auto",
-        borderBottom: "1px solid var(--border, rgba(0,0,0,0.08))",
-        background: "var(--card, rgba(255,255,255,0.5))",
       }}
     >
       {chips.map((chip) => (
@@ -152,22 +145,18 @@ export function GameSurfaceStrip({ chips }: { chips: StatChip[] }) {
             minWidth: 120,
             display: "flex",
             alignItems: "center",
-            gap: 10,
-            padding: "10px 12px",
-            borderRadius: 14,
-            background: "var(--bg, rgba(255,255,255,0.6))",
+            gap: 8,
+            padding: "4px 0",
           }}
         >
           <div
             style={{
               display: "grid",
               placeItems: "center",
-              width: 34,
-              height: 34,
-              borderRadius: 10,
+              width: 24,
+              height: 24,
               fontSize: 17,
               flexShrink: 0,
-              background: `${STATE_COLOR[chip.state ?? "idle"]}1f`,
               color: STATE_COLOR[chip.state ?? "idle"],
             }}
           >
@@ -176,9 +165,15 @@ export function GameSurfaceStrip({ chips }: { chips: StatChip[] }) {
           <div style={{ minWidth: 0 }}>
             <div
               style={{
-                fontSize: 11,
-                fontWeight: 500,
-                color: "var(--muted, #6b7280)",
+                position: "absolute",
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: -1,
+                overflow: "hidden",
+                clip: "rect(0, 0, 0, 0)",
+                whiteSpace: "nowrap",
+                border: 0,
               }}
             >
               {chip.label}
@@ -241,23 +236,20 @@ export function WaitingForSession({
     <div
       style={{
         flex: 1,
-        minHeight: 220,
+        minHeight: 160,
         display: "grid",
         placeItems: "center",
-        padding: "24px 16px",
+        padding: "16px",
       }}
     >
       <div style={{ textAlign: "center", maxWidth: 360 }}>
         <div
           style={{
-            margin: "0 auto 16px",
-            width: 56,
-            height: 56,
-            borderRadius: 18,
+            margin: "0 auto 12px",
+            width: 44,
+            height: 44,
             display: "grid",
             placeItems: "center",
-            background: `${accent}14`,
-            border: `1px solid ${accent}3a`,
           }}
         >
           <span
@@ -270,16 +262,18 @@ export function WaitingForSession({
             }}
           />
         </div>
-        <div
-          style={{
-            fontSize: 13,
-            fontWeight: 600,
-            color: "var(--muted, #6b7280)",
-            lineHeight: 1.5,
-          }}
-        >
-          {message}
-        </div>
+        {message ? (
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--muted, #6b7280)",
+              lineHeight: 1.5,
+            }}
+          >
+            {message}
+          </div>
+        ) : null}
       </div>
       <style>{`@keyframes gsPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.4;transform:scale(.72)}}`}</style>
     </div>

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
@@ -104,7 +104,7 @@ describe("FinancesSpatialView one source, three modalities", () => {
       54,
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
-    expect(lines.join("\n")).toContain("Loading finances");
+    expect(lines.join("\n")).toContain("Loading");
   });
 
   it("empty state renders the connect-a-source affordance", () => {
@@ -117,7 +117,7 @@ describe("FinancesSpatialView one source, three modalities", () => {
         <FinancesSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No sources");
+    expect(html).toContain("None");
     expect(html).toContain('data-agent-id="connect"');
   });
 

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
@@ -117,7 +117,7 @@ describe("FinancesSpatialView one source, three modalities", () => {
         <FinancesSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No money sources connected");
+    expect(html).toContain("No sources");
     expect(html).toContain('data-agent-id="connect"');
   });
 

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.test.tsx
@@ -70,7 +70,6 @@ describe("FinancesSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Finances");
       expect(flat).toContain("Balance");
       expect(flat).toContain("Transactions");
       expect(flat).toContain("Recurring");

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -110,7 +110,7 @@ export function FinancesSpatialView({
     <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
-          Loading finances
+          Loading
         </Text>
       ) : snapshot.state === "error" ? (
         <FinancesErrorBody snapshot={snapshot} dispatch={dispatch} />
@@ -152,7 +152,7 @@ function FinancesEmptyBody({
 }) {
   return (
     <>
-      <Text bold>No sources</Text>
+      <Text bold>None</Text>
       <HStack gap={1}>
         <Button agent="connect" onPress={dispatch("connect")}>
           Connect
@@ -226,7 +226,7 @@ function TransactionsSection({
       </Text>
       {transactions.length === 0 ? (
         <Text tone="muted" style="caption">
-          No transactions
+          None
         </Text>
       ) : (
         <List gap={0}>
@@ -277,7 +277,7 @@ function RecurringSection({
       </Text>
       {recurring.length === 0 ? (
         <Text tone="muted" style="caption">
-          No recurring
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -152,7 +152,7 @@ function FinancesEmptyBody({
 }) {
   return (
     <>
-      <Text bold>No money sources connected</Text>
+      <Text bold>No sources</Text>
       <HStack gap={1}>
         <Button agent="connect" onPress={dispatch("connect")}>
           Connect

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -16,15 +16,7 @@
  * or runs financial math. It displays the snapshot and dispatches actions.
  */
 
-import {
-  Button,
-  Card,
-  Divider,
-  HStack,
-  List,
-  Text,
-  VStack,
-} from "@elizaos/ui/spatial";
+import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
 
 /** Which render state the dashboard is in. */
 export type FinancesViewState = "loading" | "error" | "empty" | "ready";
@@ -115,11 +107,7 @@ export function FinancesSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card title="Finances" gap={1} padding={1}>
-      <Text style="caption" tone="muted">
-        Balance, recent activity, and recurring charges.
-      </Text>
-
+    <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading finances
@@ -144,7 +132,6 @@ function FinancesErrorBody({
 }) {
   return (
     <>
-      <Divider label="error" />
       <Text bold>Could not load finances</Text>
       <Text tone="danger" style="caption">
         {snapshot.error ?? "Could not load finances."}
@@ -165,16 +152,10 @@ function FinancesEmptyBody({
 }) {
   return (
     <>
-      <Divider label="no sources" />
       <Text bold>No money sources connected</Text>
-      <Text tone="muted" style="caption">
-        Connect a bank, PayPal, or CSV so Eliza can track your balance,
-        transactions, and recurring charges. Nothing is shown until a source is
-        linked.
-      </Text>
       <HStack gap={1}>
         <Button agent="connect" onPress={dispatch("connect")}>
-          Connect a source
+          Connect
         </Button>
       </HStack>
     </>
@@ -208,7 +189,9 @@ function FinancesReadyBody({
 function BalanceSection({ balance }: { balance: FinanceBalanceCard }) {
   return (
     <>
-      <Divider label="Balance" />
+      <Text style="caption" tone="muted">
+        Balance
+      </Text>
       <Text bold tone={balance.negative ? "danger" : "primary"} wrap={false}>
         {balance.net}
       </Text>
@@ -238,10 +221,12 @@ function TransactionsSection({
 }) {
   return (
     <>
-      <Divider label={`Transactions (${transactions.length})`} />
+      <Text style="caption" tone="muted">
+        Transactions ({transactions.length})
+      </Text>
       {transactions.length === 0 ? (
         <Text tone="muted" style="caption">
-          No transactions in this window.
+          No transactions
         </Text>
       ) : (
         <List gap={0}>
@@ -287,10 +272,12 @@ function RecurringSection({
 }) {
   return (
     <>
-      <Divider label={`Recurring (${recurring.length})`} />
+      <Text style="caption" tone="muted">
+        Recurring ({recurring.length})
+      </Text>
       {recurring.length === 0 ? (
         <Text tone="muted" style="caption">
-          No recurring charges detected.
+          No recurring
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
@@ -127,7 +127,7 @@ describe("FinancesView — states", () => {
     render(
       <FinancesView fetchers={makeFetchers({ fetchDashboard: () => never })} />,
     );
-    expect(screen.getByText("Loading finances")).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
   });
 
   it("renders the populated dashboard with balance, transactions and recurring charges", async () => {
@@ -236,7 +236,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No sources");
+    await screen.findByText("None");
     expect(agent("connect")).toBeTruthy();
     // No fabricated balance surfaces in the disconnected state.
     expect(screen.queryByText("$2,765.50")).toBeNull();
@@ -250,7 +250,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No sources");
+    await screen.findByText("None");
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });

--- a/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
@@ -236,7 +236,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No money sources connected");
+    await screen.findByText("No sources");
     expect(agent("connect")).toBeTruthy();
     // No fabricated balance surfaces in the disconnected state.
     expect(screen.queryByText("$2,765.50")).toBeNull();
@@ -250,7 +250,7 @@ describe("FinancesView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No money sources connected");
+    await screen.findByText("No sources");
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
@@ -125,7 +125,7 @@ describe("GoalsSpatialView one source, three modalities", () => {
         <GoalsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(gui).toContain("No goals yet");
+    expect(gui).toContain("No goals");
     expect(gui).toContain('data-agent-id="new"');
   });
 

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
@@ -125,7 +125,7 @@ describe("GoalsSpatialView one source, three modalities", () => {
         <GoalsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(gui).toContain("No goals");
+    expect(gui).toContain("None");
     expect(gui).toContain('data-agent-id="new"');
   });
 

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
@@ -60,7 +60,6 @@ describe("GoalsSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Goals");
       expect(flat).toContain("Run 5k");
       expect(flat).toContain("Read more");
       expect(flat).toContain("Active");

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -169,7 +169,7 @@ function GoalsReadyBody({
   if (snapshot.goals.length === 0) {
     return (
       <>
-        <Text bold>No goals yet</Text>
+        <Text bold>No goals</Text>
         <HStack gap={1}>
           <Button agent="new" onPress={dispatch("new")}>
             Set a goal

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -169,7 +169,7 @@ function GoalsReadyBody({
   if (snapshot.goals.length === 0) {
     return (
       <>
-        <Text bold>No goals</Text>
+        <Text bold>None</Text>
         <HStack gap={1}>
           <Button agent="new" onPress={dispatch("new")}>
             Set a goal
@@ -213,7 +213,7 @@ function GoalsReadyBody({
 
       {groups.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No matches
+          None
         </Text>
       ) : (
         groups.map((group) => (

--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx
@@ -17,15 +17,7 @@
  * goal" chat affordance on the empty state.
  */
 
-import {
-  Button,
-  Card,
-  Divider,
-  HStack,
-  List,
-  Text,
-  VStack,
-} from "@elizaos/ui/spatial";
+import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
 import {
   GOAL_STATUSES,
   type GoalItem,
@@ -121,7 +113,7 @@ export function GoalsSpatialView({
   const active = new Set(snapshot.activeStatuses);
 
   return (
-    <Card title="Goals" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       {snapshot.status === "loading" ? (
         <Text tone="muted" style="caption">
           Loading goals
@@ -178,10 +170,6 @@ function GoalsReadyBody({
     return (
       <>
         <Text bold>No goals yet</Text>
-        <Text tone="muted" style="caption">
-          Ask Eliza to set a goal — tell her what you want to head toward this
-          quarter and she will keep you on it.
-        </Text>
         <HStack gap={1}>
           <Button agent="new" onPress={dispatch("new")}>
             Set a goal
@@ -209,7 +197,6 @@ function GoalsReadyBody({
         </Text>
       ) : null}
 
-      <Divider label="filter" />
       <HStack gap={1} wrap>
         {GOAL_STATUSES.map((status) => (
           <Button
@@ -226,7 +213,7 @@ function GoalsReadyBody({
 
       {groups.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No goals match the selected status filters.
+          No matches
         </Text>
       ) : (
         groups.map((group) => (
@@ -244,9 +231,9 @@ function GoalsStatusGroup({
 }) {
   return (
     <>
-      <Divider
-        label={`${STATUS_LABELS[group.status]} (${group.goals.length})`}
-      />
+      <Text style="caption" tone="muted">
+        {STATUS_LABELS[group.status]} ({group.goals.length})
+      </Text>
       <List gap={0}>
         {group.goals.map((goal) => (
           <GoalRow key={goal.id} goal={goal} />
@@ -271,11 +258,6 @@ function GoalRow({ goal }: { goal: GoalItem }) {
         <Text bold wrap={false}>
           {goal.title}
         </Text>
-        {goal.description ? (
-          <Text style="caption" tone="muted" wrap={false}>
-            {goal.description}
-          </Text>
-        ) : null}
         {meta.length > 0 ? (
           <Text style="caption" tone="muted" wrap={false}>
             {meta.join(" · ")}

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
@@ -67,7 +67,6 @@ describe("HealthSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Health");
       expect(flat).toContain("Last sleep");
       expect(flat).toContain("Regularity");
       expect(flat).toContain("Baseline");

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
@@ -127,7 +127,7 @@ describe("HealthSpatialView one source, three modalities", () => {
         <HealthSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No sleep");
+    expect(html).toContain("None");
     expect(html).not.toContain("Nothing was recorded in the last 14 days.");
   });
 

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.test.tsx
@@ -113,7 +113,7 @@ describe("HealthSpatialView one source, three modalities", () => {
       54,
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
-    expect(lines.join("\n")).toContain("Loading sleep data");
+    expect(lines.join("\n")).toContain("Loading");
   });
 
   it("empty state renders the connect-a-source body", () => {
@@ -127,8 +127,8 @@ describe("HealthSpatialView one source, three modalities", () => {
         <HealthSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No sleep data yet");
-    expect(html).toContain("Nothing was recorded in the last 14 days.");
+    expect(html).toContain("No sleep");
+    expect(html).not.toContain("Nothing was recorded in the last 14 days.");
   });
 
   it("error state renders the message and a Retry control", () => {

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
@@ -148,7 +148,7 @@ function HealthErrorBody({
 }
 
 function HealthEmptyBody() {
-  return <Text bold>No sleep</Text>;
+  return <Text bold>None</Text>;
 }
 
 function HealthReadyBody({ snapshot }: { snapshot: HealthSnapshot }) {

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
@@ -16,7 +16,7 @@
  * or computes — it displays label/value rows and dispatches actions.
  */
 
-import { Button, Card, Divider, HStack, List, Text } from "@elizaos/ui/spatial";
+import { Button, Card, HStack, List, Text } from "@elizaos/ui/spatial";
 
 /** A single label/value summary row, already projected to display strings. */
 export interface StatRow {
@@ -80,11 +80,7 @@ export function HealthSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card title="Health" gap={1} padding={1}>
-      <Text style="caption" tone="muted">
-        Sleep, circadian rhythm, and the rolling baseline.
-      </Text>
-
+    <Card gap={1} padding={1}>
       <WindowRange windowDays={snapshot.windowDays} dispatch={dispatch} />
 
       {snapshot.state === "loading" ? (
@@ -138,7 +134,6 @@ function HealthErrorBody({
 }) {
   return (
     <>
-      <Divider label="error" />
       <Text bold>Could not load sleep data</Text>
       <Text tone="danger" style="caption">
         {snapshot.error ?? "Could not load sleep data."}
@@ -155,14 +150,12 @@ function HealthErrorBody({
 function HealthEmptyBody({ snapshot }: { snapshot: HealthSnapshot }) {
   return (
     <>
-      <Divider label="empty" />
       <Text bold>No sleep data yet</Text>
-      <Text tone="muted" style="caption">
-        {snapshot.emptyDetail}
-      </Text>
-      <Text tone="muted" style="caption">
-        Ask Eliza to connect a health source to get started.
-      </Text>
+      {snapshot.emptyDetail ? (
+        <Text tone="muted" style="caption">
+          {snapshot.emptyDetail}
+        </Text>
+      ) : null}
     </>
   );
 }
@@ -184,32 +177,30 @@ function HealthReadyBody({ snapshot }: { snapshot: HealthSnapshot }) {
 }
 
 function Section({ label, rows }: { label: string; rows: StatRow[] }) {
+  if (rows.length === 0) return null;
+
   return (
     <>
-      <Divider label={label} />
-      {rows.length === 0 ? (
-        <Text tone="muted" style="caption">
-          Nothing here.
-        </Text>
-      ) : (
-        <List gap={0}>
-          {rows.map((row) => (
-            <HStack
-              key={row.label}
-              gap={1}
-              align="center"
-              agent={`row-${row.label}`}
-            >
-              <Text tone="muted" grow={1}>
-                {row.label}
-              </Text>
-              <Text bold wrap={false}>
-                {row.value}
-              </Text>
-            </HStack>
-          ))}
-        </List>
-      )}
+      <Text style="caption" tone="muted">
+        {label}
+      </Text>
+      <List gap={0}>
+        {rows.map((row) => (
+          <HStack
+            key={row.label}
+            gap={1}
+            align="center"
+            agent={`row-${row.label}`}
+          >
+            <Text tone="muted" grow={1}>
+              {row.label}
+            </Text>
+            <Text bold wrap={false}>
+              {row.value}
+            </Text>
+          </HStack>
+        ))}
+      </List>
     </>
   );
 }

--- a/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthSpatialView.tsx
@@ -85,12 +85,12 @@ export function HealthSpatialView({
 
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
-          Loading sleep data
+          Loading
         </Text>
       ) : snapshot.state === "error" ? (
         <HealthErrorBody snapshot={snapshot} dispatch={dispatch} />
       ) : snapshot.state === "empty" ? (
-        <HealthEmptyBody snapshot={snapshot} />
+        <HealthEmptyBody />
       ) : (
         <HealthReadyBody snapshot={snapshot} />
       )}
@@ -147,17 +147,8 @@ function HealthErrorBody({
   );
 }
 
-function HealthEmptyBody({ snapshot }: { snapshot: HealthSnapshot }) {
-  return (
-    <>
-      <Text bold>No sleep data yet</Text>
-      {snapshot.emptyDetail ? (
-        <Text tone="muted" style="caption">
-          {snapshot.emptyDetail}
-        </Text>
-      ) : null}
-    </>
-  );
+function HealthEmptyBody() {
+  return <Text bold>No sleep</Text>;
 }
 
 function HealthReadyBody({ snapshot }: { snapshot: HealthSnapshot }) {

--- a/plugins/plugin-health/src/components/health/HealthView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.test.tsx
@@ -163,12 +163,7 @@ describe("HealthView (fetch-driven)", () => {
     render(<HealthView fetchers={makeFetchers(emptyHistory())} />);
 
     await screen.findByText(/No sleep data yet/i);
-    expect(
-      screen.getByText(/Connect a health source \(Apple Health/i),
-    ).toBeTruthy();
-    expect(
-      screen.getByText(/connect a health source to get started/i),
-    ).toBeTruthy();
+    expect(screen.getByText("14d empty")).toBeTruthy();
   });
 
   it("renders the populated state with last sleep, regularity, baseline, and window summary", async () => {

--- a/plugins/plugin-health/src/components/health/HealthView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.test.tsx
@@ -134,7 +134,7 @@ describe("HealthView (fetch-driven)", () => {
       fetchBaseline: () => new Promise(() => {}),
     };
     render(<HealthView fetchers={fetchers} />);
-    expect(screen.getByText(/Loading sleep data/i)).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
   });
 
   it("renders the error state and refetches when Retry is clicked", async () => {
@@ -155,15 +155,15 @@ describe("HealthView (fetch-driven)", () => {
     await screen.findByText("network down");
     fireEvent.click(agent("retry"));
 
-    await screen.findByText(/No sleep data yet/i);
+    await screen.findByText("None");
     expect(fetchHistory).toHaveBeenCalledTimes(2);
   });
 
   it("renders the empty (connect-a-source) state when no episodes exist", async () => {
     render(<HealthView fetchers={makeFetchers(emptyHistory())} />);
 
-    await screen.findByText(/No sleep data yet/i);
-    expect(screen.getByText("14d empty")).toBeTruthy();
+    await screen.findByText("None");
+    expect(screen.queryByText("14d empty")).toBeNull();
   });
 
   it("renders the populated state with last sleep, regularity, baseline, and window summary", async () => {

--- a/plugins/plugin-health/src/components/health/HealthView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.tsx
@@ -304,7 +304,7 @@ export function HealthView(props: HealthViewProps = {}): ReactNode {
         ...EMPTY_HEALTH_SNAPSHOT,
         state: "empty",
         windowDays,
-        emptyDetail: `Nothing was recorded in the last ${history.windowDays} days. Connect a health source (Apple Health, Google Fit, Oura, Fitbit, Withings, or Strava) so Eliza can track your sleep.`,
+        emptyDetail: `${history.windowDays}d empty`,
       };
     }
     return {

--- a/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.test.tsx
+++ b/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.test.tsx
@@ -250,7 +250,7 @@ describe("HyperliquidAppView (standard/XR)", () => {
     expect(screen.getByText("Local key")).toBeTruthy();
   });
 
-  it("maps missing account -> 'No account' tile", async () => {
+  it("maps missing account -> compact account tile", async () => {
     mockReads(
       makeStatus({
         accountAddress: null,
@@ -259,7 +259,7 @@ describe("HyperliquidAppView (standard/XR)", () => {
     );
     render(React.createElement(HyperliquidAppView, ctx()));
     await screen.findByText("ETH");
-    expect(screen.getByText("No account")).toBeTruthy();
+    expect(screen.getByText("Account")).toBeTruthy();
   });
 
   it("renders the executionBlockedReason banner", async () => {
@@ -381,7 +381,7 @@ describe("HyperliquidAppView (standard/XR)", () => {
     // While loading-with-no-data the whole surface is the spinner (the manual
     // refresh control is only rendered alongside loaded data — law-8 de-slop).
     expect(await screen.findByTestId("spinner")).toBeTruthy();
-    expect(screen.getByText("Loading Hyperliquid state")).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /refresh/i })).toBeNull();
   });
 

--- a/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.tsx
+++ b/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.tsx
@@ -173,7 +173,7 @@ function HyperliquidReady({
         />
         <StatusItem
           icon={Shield}
-          label={status?.account.address ? "Account" : "No account"}
+          label="Account"
           ready={Boolean(status?.account.address)}
         />
       </section>
@@ -198,7 +198,7 @@ function HyperliquidReady({
       {loading && !markets ? (
         <div className="flex items-center justify-center py-16 text-sm text-muted">
           <Spinner className="mr-3 h-5 w-5" />
-          Loading Hyperliquid state
+          Loading
         </div>
       ) : (
         <div className="space-y-4">

--- a/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.tsx
+++ b/plugins/plugin-hyperliquid-app/src/HyperliquidAppView.tsx
@@ -85,7 +85,7 @@ export function HyperliquidAppView({ exitToApps }: OverlayAppContext) {
       data-testid="hyperliquid-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
     >
-      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center gap-3 px-3 py-2">
         <Button
           ref={backButton.ref}
           {...backButton.agentProps}
@@ -105,15 +105,15 @@ export function HyperliquidAppView({ exitToApps }: OverlayAppContext) {
         <div className="flex-1" />
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
-        <div className="mx-auto max-w-5xl space-y-5">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-2 sm:px-5">
+        <div className="mx-auto max-w-5xl space-y-4">
           {unavailable ? (
             <div className="flex flex-col items-center justify-center gap-2 py-20 text-center">
               <ShieldX className="h-8 w-8 text-muted" />
               <p className="text-sm font-medium text-txt">
                 Hyperliquid is unavailable on this device
               </p>
-              <p className="max-w-sm text-xs text-muted">
+              <p className="sr-only">
                 Markets and account reads run on a desktop or cloud agent.
               </p>
             </div>
@@ -202,19 +202,19 @@ function HyperliquidReady({
         </div>
       ) : (
         <div className="space-y-4">
-          <section className="rounded-lg border border-border/24">
-            <div className="flex items-center gap-2 border-b border-border/20 px-4 py-3">
+          <section>
+            <div className="flex items-center gap-2 px-1 py-2">
               <BarChart3 className="h-4 w-4 text-muted" />
               <h2 className="text-sm font-semibold text-txt">Markets</h2>
               <span className="ml-auto text-xs text-muted">
                 {markets?.markets.length ?? 0}
               </span>
             </div>
-            <div className="divide-y divide-border/14">
+            <div>
               {(markets?.markets ?? []).slice(0, 24).map((market) => (
                 <div
                   key={market.name}
-                  className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-4 py-2.5 text-sm"
+                  className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-1 py-2 text-sm"
                 >
                   <span className="min-w-0 truncate font-medium text-txt">
                     {market.name}
@@ -230,7 +230,7 @@ function HyperliquidReady({
             </div>
           </section>
 
-          <section className="divide-y divide-border/14">
+          <section>
             <HyperliquidPositionsPanel
               positions={positions?.positions ?? []}
               summary={positions?.summary ?? null}

--- a/plugins/plugin-hyperliquid-app/src/HyperliquidPositionsPanel.tsx
+++ b/plugins/plugin-hyperliquid-app/src/HyperliquidPositionsPanel.tsx
@@ -103,11 +103,7 @@ function pnlTone(value: number | null): string {
 function ReadinessPill({ ready, label }: { ready: boolean; label: string }) {
   return (
     <span
-      className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border ${
-        ready
-          ? "border-ok/35 bg-ok/12 text-ok"
-          : "border-border bg-bg-accent text-muted"
-      }`}
+      className={`inline-flex h-8 w-8 items-center justify-center ${ready ? "text-ok" : "text-muted"}`}
       role="status"
       aria-label={label}
       title={label}
@@ -131,7 +127,7 @@ function StatTile({
   tone?: string;
 }) {
   return (
-    <div className="flex flex-col gap-1 rounded-lg border border-border/24 bg-card/50 px-3 py-2.5">
+    <div className="flex flex-col gap-1 px-1 py-2">
       <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
         {label}
       </span>
@@ -183,14 +179,14 @@ function PositionRow({ position }: { position: HyperliquidPosition }) {
           {position.coin}
         </span>
         <span
-          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+          className={`px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
             isLong ? "bg-ok/12 text-ok" : "bg-danger/12 text-danger"
           }`}
         >
           {isLong ? "long" : "short"}
         </span>
         {position.leverageValue !== null && (
-          <span className="rounded bg-bg-accent px-1.5 py-0.5 font-mono text-[10px] text-muted">
+          <span className="px-1.5 py-0.5 font-mono text-[10px] text-muted">
             {position.leverageValue}x
           </span>
         )}
@@ -258,8 +254,8 @@ export function HyperliquidPositionsPanel({
     <section className="space-y-3">
       <AccountHealthStrip summary={summary} />
 
-      <div className="rounded-lg border border-border/24 bg-card/50">
-        <div className="flex items-center gap-2 border-b border-border/20 px-4 py-3">
+      <div>
+        <div className="flex items-center gap-2 px-1 py-2">
           {totalPnl !== null && totalPnl < 0 ? (
             <TrendingDown className="h-4 w-4 text-danger" />
           ) : (
@@ -276,7 +272,7 @@ export function HyperliquidPositionsPanel({
         </div>
 
         {readBlockedReason ? (
-          <div className="px-4 py-6 text-center text-xs text-muted">
+          <div className="px-1 py-6 text-center text-xs text-muted">
             {readBlockedReason}
           </div>
         ) : openPositions.length === 0 ? (
@@ -286,14 +282,14 @@ export function HyperliquidPositionsPanel({
           </div>
         ) : (
           <>
-            <div className="grid grid-cols-[minmax(0,1.2fr)_repeat(4,minmax(0,1fr))] gap-3 border-b border-border/14 px-4 py-2 text-[10px] font-medium uppercase tracking-wide text-muted">
+            <div className="grid grid-cols-[minmax(0,1.2fr)_repeat(4,minmax(0,1fr))] gap-3 px-1 py-2 text-[10px] font-medium uppercase tracking-wide text-muted">
               <span>Asset</span>
               <span className="text-right">Size</span>
               <span className="text-right">Notional</span>
               <span className="text-right">Entry</span>
               <span className="text-right">uPnL</span>
             </div>
-            <div className="divide-y divide-border/14">
+            <div>
               {openPositions.map((position) => (
                 <PositionRow key={position.coin} position={position} />
               ))}

--- a/plugins/plugin-hyperliquid-app/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid-app/src/HyperliquidView.test.tsx
@@ -43,8 +43,8 @@ vi.mock("@elizaos/app-core", () => ({ client: hyperliquidClient }));
 vi.mock("@elizaos/ui", () => ({ ApiError }));
 vi.mock("./client", () => ({}));
 
-import { HyperliquidView } from "./HyperliquidView";
 import { interact } from "./HyperliquidAppView.interact";
+import { HyperliquidView } from "./HyperliquidView";
 
 const sampleStatus = {
   publicReadReady: true,
@@ -311,7 +311,7 @@ describe("HyperliquidView — error + unavailable paths", () => {
   it("degrades to the unavailable state on a 404/503 ApiError (routes not mounted)", async () => {
     hyperliquidClient.hyperliquidStatus.mockRejectedValue(new ApiError(404));
     render(React.createElement(HyperliquidView));
-    await screen.findByText("Unavailable on this device");
+    await screen.findByText("Unavailable");
     // The Back control is still reachable in the unavailable state.
     expect(agent("back")).toBeTruthy();
   });

--- a/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.test.tsx
+++ b/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.test.tsx
@@ -80,7 +80,6 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Hyperliquid");
       expect(flat).toContain("read-ready");
       expect(flat).toContain("BTC");
       expect(flat).toContain("Refresh");

--- a/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
@@ -112,10 +112,7 @@ export function HyperliquidSpatialView({
     return (
       <Card gap={1} padding={1}>
         <Text tone="muted" align="center">
-          Unavailable on this device
-        </Text>
-        <Text style="caption" tone="muted" align="center">
-          Markets and account reads run on a desktop or cloud agent.
+          Unavailable
         </Text>
         <Divider />
         <HStack gap={1} wrap>

--- a/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
@@ -165,10 +165,7 @@ export function HyperliquidSpatialView({
           label={credentialModeLabel(status.credentialMode)}
           ready={status.signerReady}
         />
-        <StatusTile
-          label={accountReady ? "Account" : "No account"}
-          ready={accountReady}
-        />
+        <StatusTile label="Account" ready={accountReady} />
       </VStack>
 
       {status.executionBlockedReason ? (
@@ -188,7 +185,7 @@ export function HyperliquidSpatialView({
       <Divider label="markets" />
       {snapshot.markets.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No markets
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid-app/src/components/HyperliquidSpatialView.tsx
@@ -110,7 +110,7 @@ export function HyperliquidSpatialView({
 
   if (snapshot.unavailable) {
     return (
-      <Card title="Hyperliquid" gap={1} padding={1}>
+      <Card gap={1} padding={1}>
         <Text tone="muted" align="center">
           Unavailable on this device
         </Text>
@@ -136,7 +136,7 @@ export function HyperliquidSpatialView({
   }
 
   return (
-    <Card title="Hyperliquid" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
@@ -123,7 +123,7 @@ describe("InboxSpatialView one source, three modalities", () => {
         <InboxSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No channels connected");
+    expect(html).toContain("No channels");
     expect(html).toContain('data-agent-id="connect"');
   });
 
@@ -140,7 +140,7 @@ describe("InboxSpatialView one source, three modalities", () => {
     const lines = renderViewToLines(<InboxSpatialView snapshot={zero} />, 54);
     const flat = lines.join("\n");
     expect(flat).toContain("Inbox zero");
-    expect(flat).not.toContain("No channels connected");
+    expect(flat).not.toContain("No channels");
   });
 
   it("an active channel filter is marked on its chip", () => {

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
@@ -123,7 +123,7 @@ describe("InboxSpatialView one source, three modalities", () => {
         <InboxSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No channels");
+    expect(html).toContain("None");
     expect(html).toContain('data-agent-id="connect"');
   });
 
@@ -140,7 +140,7 @@ describe("InboxSpatialView one source, three modalities", () => {
     const lines = renderViewToLines(<InboxSpatialView snapshot={zero} />, 54);
     const flat = lines.join("\n");
     expect(flat).toContain("Inbox zero");
-    expect(flat).not.toContain("No channels");
+    expect(flat).not.toContain("None");
   });
 
   it("an active channel filter is marked on its chip", () => {

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.test.tsx
@@ -61,7 +61,6 @@ describe("InboxSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Inbox");
       expect(flat).toContain("Invoice 42 overdue");
       expect(flat).toContain("guildmate");
       expect(flat).toContain("Email");

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
@@ -124,7 +124,7 @@ export function InboxSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card title="Inbox" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <InboxChannelFilters filters={snapshot.filters} dispatch={dispatch} />
       <InboxBody snapshot={snapshot} dispatch={dispatch} />
     </Card>

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
@@ -203,7 +203,7 @@ function InboxEmptyBody({
   if (noChannels) {
     return (
       <VStack gap={1}>
-        <Text bold>No channels</Text>
+        <Text bold>None</Text>
         <Button width="100%" agent="connect" onPress={dispatch("connect")}>
           Connect
         </Button>

--- a/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxSpatialView.tsx
@@ -203,14 +203,9 @@ function InboxEmptyBody({
   if (noChannels) {
     return (
       <VStack gap={1}>
-        <Text bold>No channels connected</Text>
-        <Text tone="muted" style="caption">
-          Connect email, Discord, Telegram, WhatsApp, Signal, iMessage, or X so
-          Eliza can triage your inbox. Nothing is shown until a channel is
-          linked.
-        </Text>
+        <Text bold>No channels</Text>
         <Button width="100%" agent="connect" onPress={dispatch("connect")}>
-          Connect a channel
+          Connect
         </Button>
       </VStack>
     );
@@ -218,11 +213,6 @@ function InboxEmptyBody({
   return (
     <VStack gap={1}>
       <Text bold>Inbox zero</Text>
-      <Text tone="muted" style="caption">
-        {snapshot.activeFilterCount > 0
-          ? "Nothing to triage in the selected channels."
-          : "Nothing to triage right now. You're all caught up."}
-      </Text>
     </VStack>
   );
 }

--- a/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
@@ -156,7 +156,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText(/No channels/i);
+    await screen.findByText("None");
     expect(agent("connect")).toBeTruthy();
   });
 
@@ -166,7 +166,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText(/No channels/i);
+    await screen.findByText("None");
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -178,7 +178,7 @@ describe("InboxView — empty states", () => {
       />,
     );
     await screen.findByText(/Inbox zero/i);
-    expect(screen.queryByText(/No channels/i)).toBeNull();
+    expect(screen.queryByText("None")).toBeNull();
   });
 });
 

--- a/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxView.test.tsx
@@ -156,7 +156,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText(/No channels connected/i);
+    await screen.findByText(/No channels/i);
     expect(agent("connect")).toBeTruthy();
   });
 
@@ -166,7 +166,7 @@ describe("InboxView — empty states", () => {
         fetchers={makeFetchers({ fetchInbox: async () => emptyInbox(false) })}
       />,
     );
-    await screen.findByText(/No channels connected/i);
+    await screen.findByText(/No channels/i);
     fireEvent.click(agent("connect"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
@@ -178,7 +178,7 @@ describe("InboxView — empty states", () => {
       />,
     );
     await screen.findByText(/Inbox zero/i);
-    expect(screen.queryByText(/No channels connected/i)).toBeNull();
+    expect(screen.queryByText(/No channels/i)).toBeNull();
   });
 });
 

--- a/plugins/plugin-messages/src/components/MessagesAppView.gui.test.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.gui.test.tsx
@@ -243,7 +243,7 @@ describe("MessagesAppView — empty state", () => {
 
     render(React.createElement(MessagesAppView, overlayContext()));
 
-    expect(await screen.findByText("No messages yet")).toBeTruthy();
+    expect(await screen.findByText("No messages")).toBeTruthy();
     // Empty-state stat chips: "0 threads" + the bridge mode chip (the bridge
     // label also appears as the header subtitle, hence getAllByText).
     expect(screen.getByText("0 threads")).toBeTruthy();

--- a/plugins/plugin-messages/src/components/MessagesAppView.gui.test.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.gui.test.tsx
@@ -243,7 +243,7 @@ describe("MessagesAppView — empty state", () => {
 
     render(React.createElement(MessagesAppView, overlayContext()));
 
-    expect(await screen.findByText("No messages")).toBeTruthy();
+    expect(await screen.findByText("None")).toBeTruthy();
     // Empty-state stat chips: "0 threads" + the bridge mode chip (the bridge
     // label also appears as the header subtitle, hence getAllByText).
     expect(screen.getByText("0 threads")).toBeTruthy();

--- a/plugins/plugin-messages/src/components/MessagesAppView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.tsx
@@ -527,7 +527,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
         >
           {loading && threads.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-4 text-sm text-muted">
-              {t("messages.loading", { defaultValue: "Loading messages…" })}
+              {t("messages.loading", { defaultValue: "Loading" })}
             </div>
           ) : threads.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center px-6 pb-32 text-center">
@@ -535,7 +535,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                 <ChatBubblesMotif />
               </span>
               <h2 className="mt-5 text-base font-semibold text-txt">
-                {t("messages.empty.title", { defaultValue: "No messages" })}
+                {t("messages.empty.title", { defaultValue: "None" })}
               </h2>
               <p className="sr-only mt-1 max-w-xs text-sm text-muted">
                 {t("messages.empty.body", {

--- a/plugins/plugin-messages/src/components/MessagesAppView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.tsx
@@ -461,7 +461,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
               <div>
                 <div className="font-medium text-txt">
                   {t("messages.smsRoleTitle", {
-                    defaultValue: "SMS role is not assigned to this app",
+                    defaultValue: "SMS role",
                   })}
                 </div>
                 <div className="sr-only text-xs text-muted">

--- a/plugins/plugin-messages/src/components/MessagesAppView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.tsx
@@ -84,9 +84,8 @@ function StatChip({
 }) {
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium"
+      className="inline-flex items-center gap-1.5 px-1 py-1 text-xs font-medium"
       style={{
-        background: accent ? "var(--accent-subtle)" : "var(--surface)",
         color: accent ? "var(--accent)" : "var(--muted)",
       }}
     >
@@ -163,7 +162,7 @@ const MessagesThreadButton = memo(function MessagesThreadButton({
       type="button"
       onClick={() => onOpen(thread)}
       aria-current={selected ? "true" : undefined}
-      className="flex w-full items-start gap-3 border-b border-border/16 px-4 py-3 text-left transition-colors focus:outline-none"
+      className="flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors focus:outline-none"
       style={selected ? { background: "var(--accent-subtle)" } : undefined}
       data-testid={`messages-thread-${thread.id}`}
     >
@@ -178,10 +177,7 @@ const MessagesThreadButton = memo(function MessagesThreadButton({
           <span className="truncate text-sm font-semibold text-txt">
             {thread.address || "Unknown"}
           </span>
-          <span
-            className="shrink-0 rounded-full px-2 py-0.5 text-2xs text-muted"
-            style={{ background: "var(--surface)" }}
-          >
+          <span className="shrink-0 px-1 py-0.5 text-2xs text-muted">
             {formatTime(thread.lastMessage.date)}
           </span>
         </span>
@@ -411,14 +407,14 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
       data-testid="messages-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
-      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border/24 bg-bg/90 px-4 py-3 backdrop-blur-sm">
+      <header className="flex shrink-0 items-center justify-between gap-3 px-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             ref={back.ref}
             {...back.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-lg text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={showComposer ? backToThreads : exitToApps}
             aria-label={backLabel}
           >
@@ -432,7 +428,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
             <h1 className="truncate text-base font-semibold text-txt">
               {title}
             </h1>
-            <p className="truncate text-xs text-muted">
+            <p className="sr-only truncate text-xs text-muted">
               {ownsSmsRole
                 ? t("messages.smsReady", { defaultValue: "Default SMS app" })
                 : t("messages.smsBridge", {
@@ -447,7 +443,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
             {...newMessage.agentProps}
             variant="default"
             size="sm"
-            className="rounded-lg"
+            className="px-3"
             onClick={openNewComposer}
             data-testid="messages-new"
           >
@@ -458,7 +454,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
       </header>
 
       {currentSmsRole && !ownsSmsRole ? (
-        <div className="shrink-0 border-b border-border/24 bg-bg-accent/40 px-4 py-3">
+        <div className="shrink-0 px-3 py-2">
           <div className="mx-auto flex max-w-5xl flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="flex items-start gap-3 text-sm">
               <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
@@ -468,7 +464,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                     defaultValue: "SMS role is not assigned to this app",
                   })}
                 </div>
-                <div className="text-xs text-muted">
+                <div className="sr-only text-xs text-muted">
                   {t("messages.smsRoleBody", {
                     defaultValue:
                       "Reading and sending real SMS requires Android to grant the default SMS role.",
@@ -513,10 +509,8 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
         <div className="shrink-0 px-4 pt-3">
           <div
             role={error ? "alert" : "status"}
-            className={`mx-auto max-w-5xl rounded-lg border px-3 py-2 text-sm ${
-              error
-                ? "border-danger/40 bg-danger/10 text-danger"
-                : "border-border/30 bg-bg-accent text-muted"
+            className={`mx-auto max-w-5xl px-1 py-2 text-sm ${
+              error ? "text-danger" : "text-muted"
             }`}
           >
             {error ?? notice}
@@ -546,13 +540,13 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
               <h2 className="mt-5 text-base font-semibold text-txt">
                 {t("messages.empty.title", { defaultValue: "No messages yet" })}
               </h2>
-              <p className="mt-1 max-w-xs text-sm text-muted">
+              <p className="sr-only mt-1 max-w-xs text-sm text-muted">
                 {t("messages.empty.body", {
                   defaultValue:
                     "Start a conversation — texts you send and receive show up here.",
                 })}
               </p>
-              <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+              <div className="sr-only mt-4 flex flex-wrap items-center justify-center gap-2">
                 <StatChip
                   label={t("messages.threadCount", {
                     defaultValue: "0 threads",
@@ -564,7 +558,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                 {...emptyNewMessage.agentProps}
                 type="button"
                 onClick={openNewComposer}
-                className="mt-6 inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold transition-colors"
+                className="mt-6 inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold transition-colors"
                 style={{
                   background: "var(--accent)",
                   color: "var(--accent-foreground)",
@@ -582,7 +576,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
             </div>
           ) : (
             <div className="chat-native-scrollbar min-h-0 flex-1 overflow-y-auto pb-32">
-              <div className="flex flex-wrap items-center gap-1.5 px-4 py-3">
+              <div className="flex flex-wrap items-center gap-3 px-3 py-2">
                 <StatChip
                   label={t("messages.threadCountN", {
                     defaultValue: `${threads.length} threads`,
@@ -615,7 +609,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
         >
           {showComposer ? (
             <>
-              <div className="shrink-0 border-b border-border/24 px-4 py-3">
+              <div className="shrink-0 px-3 py-2">
                 <label
                   htmlFor="messages-compose-address"
                   className="text-xs text-muted"
@@ -689,7 +683,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                           defaultValue: "Start a text message",
                         })}
                       </div>
-                      <p className="mt-1 text-xs text-muted">
+                      <p className="sr-only mt-1 text-xs text-muted">
                         {t("messages.composeBody", {
                           defaultValue:
                             "Enter a phone number and message body. Android handles carrier delivery through the SMS bridge.",
@@ -700,7 +694,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                 )}
               </div>
 
-              <div className="shrink-0 border-t border-border/24 bg-bg/95 px-4 py-3">
+              <div className="shrink-0 bg-bg/95 px-3 py-2">
                 <div className="mx-auto flex max-w-2xl items-end gap-2">
                   <Textarea
                     ref={bodyInput.ref}
@@ -718,7 +712,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                     ref={sendButton.ref}
                     {...sendButton.agentProps}
                     size="icon"
-                    className="h-11 w-11 shrink-0 rounded-lg"
+                    className="h-11 w-11 shrink-0"
                     onClick={() => void send()}
                     disabled={!canSend}
                     aria-label={t("messages.send", { defaultValue: "Send" })}
@@ -738,7 +732,7 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
                     defaultValue: "Select a conversation",
                   })}
                 </div>
-                <p className="mt-1 text-xs text-muted">
+                <p className="sr-only mt-1 text-xs text-muted">
                   {t("messages.selectBody", {
                     defaultValue:
                       "Review existing SMS threads or start a new text message.",

--- a/plugins/plugin-messages/src/components/MessagesAppView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesAppView.tsx
@@ -531,14 +531,11 @@ export function MessagesAppView({ exitToApps, t }: OverlayAppContext) {
             </div>
           ) : threads.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center px-6 pb-32 text-center">
-              <span
-                className="flex h-20 w-20 items-center justify-center rounded-3xl"
-                style={{ background: "var(--accent-subtle)" }}
-              >
+              <span className="flex h-20 w-20 items-center justify-center">
                 <ChatBubblesMotif />
               </span>
               <h2 className="mt-5 text-base font-semibold text-txt">
-                {t("messages.empty.title", { defaultValue: "No messages yet" })}
+                {t("messages.empty.title", { defaultValue: "No messages" })}
               </h2>
               <p className="sr-only mt-1 max-w-xs text-sm text-muted">
                 {t("messages.empty.body", {

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.test.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.test.tsx
@@ -89,7 +89,6 @@ describe("MessagesSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Messages");
       expect(flat).toContain("sms-default");
       expect(flat).toContain("+15550100");
       expect(flat).toContain("see you at noon");

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
@@ -125,7 +125,7 @@ export function MessagesSpatialView({
       <Divider label="threads" />
       {snapshot.threads.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No SMS threads
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
@@ -95,7 +95,7 @@ export function MessagesSpatialView({
     snapshot.composeBody.trim().length > 0;
 
   return (
-    <Card title="Messages" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="caption" tone={roleTone(snapshot)} grow={1}>
           {roleLabel(snapshot)}

--- a/plugins/plugin-messages/src/components/MessagesView.test.tsx
+++ b/plugins/plugin-messages/src/components/MessagesView.test.tsx
@@ -134,10 +134,10 @@ describe("MessagesView — unified GUI/XR thread list", () => {
     expect(screen.getByText("1")).toBeTruthy();
   });
 
-  it("shows the 'No SMS threads' empty line when the inbox is empty", async () => {
+  it("shows the compact empty line when the inbox is empty", async () => {
     bridge.listMessages.mockResolvedValue({ messages: [] });
     render(React.createElement(MessagesView));
-    await screen.findByText("No SMS threads");
+    await screen.findByText("None");
   });
 });
 

--- a/plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx
+++ b/plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, client, useAppSelector } from "@elizaos/ui";
+import { Button, client, useAppSelector } from "@elizaos/ui";
 import {
   CheckCircle2,
   Clock3,
@@ -263,17 +263,17 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
 
   if (mode !== "mobile") {
     return (
-      <div className="rounded-xl border border-border/60 bg-card/92 px-4 py-4 shadow-sm">
+      <div className="px-1 py-2">
         <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-bg/40">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center">
             <Smartphone className="h-5 w-5 text-muted" aria-hidden />
           </div>
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
               <div className="font-bold text-sm text-txt">{title}</div>
-              <Badge variant="outline">
+              <span className="text-xs text-muted">
                 {translate(t, "permissionssection.mobileOnly", "Mobile only")}
-              </Badge>
+              </span>
             </div>
             <div className="text-xs-tight leading-5 text-muted">
               {translate(
@@ -289,33 +289,39 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
   }
 
   return (
-    <div className="rounded-xl border border-border/60 bg-card/92 shadow-sm">
-      <div className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+    <div className="px-1 py-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-bg/40">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center">
             <ShieldBan className="h-5 w-5 text-txt" aria-hidden />
           </div>
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
               <div className="font-bold text-sm text-txt">{title}</div>
-              <Badge variant={badge.variant}>
+              <span
+                className={`inline-flex items-center gap-1 text-xs ${
+                  badge.ready ? "text-ok" : "text-muted"
+                }`}
+              >
                 {badge.ready ? (
                   <CheckCircle2 className="mr-1 h-3 w-3" aria-hidden />
                 ) : null}
                 {badge.label}
-              </Badge>
+              </span>
               {status?.platform ? (
-                <Badge variant="outline">{status.platform.toUpperCase()}</Badge>
+                <span className="text-xs text-muted">
+                  {status.platform.toUpperCase()}
+                </span>
               ) : null}
               {status?.active ? (
-                <Badge variant="secondary">
+                <span className="inline-flex items-center gap-1 text-xs text-muted">
                   <Timer className="mr-1 h-3 w-3" aria-hidden />
                   {translate(
                     t,
                     "permissionssection.appBlocking.active",
                     "Blocking",
                   )}
-                </Badge>
+                </span>
               ) : null}
             </div>
             <div className="flex flex-wrap gap-2 text-xs-tight text-muted">
@@ -334,7 +340,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
               </span>
             </div>
             <div className="flex flex-wrap items-center gap-2 pt-1">
-              <span className="inline-flex items-center gap-1 rounded-md border border-border/60 bg-bg/35 px-2 py-1 text-xs text-muted">
+              <span className="inline-flex items-center gap-1 text-xs text-muted">
                 <ListChecks className="h-3.5 w-3.5" aria-hidden />
                 {status?.active
                   ? `${status.blockedCount}`
@@ -342,7 +348,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
                 {translate(t, "permissionssection.appBlocking.apps", "apps")}
               </span>
               {status?.active && status.endsAt ? (
-                <span className="inline-flex items-center gap-1 rounded-md border border-border/60 bg-bg/35 px-2 py-1 text-xs text-muted">
+                <span className="inline-flex items-center gap-1 text-xs text-muted">
                   <Clock3 className="h-3.5 w-3.5" aria-hidden />
                   {formatEndsAt(status.endsAt)}
                 </span>
@@ -408,7 +414,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
       </div>
 
       {loading ? (
-        <div className="border-t border-border/50 px-4 py-4 text-xs-tight text-muted">
+        <div className="py-3 text-xs-tight text-muted">
           {translate(
             t,
             "permissionssection.LoadingPermissions",
@@ -420,7 +426,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
       {!loading &&
       permission?.status === "granted" &&
       status?.platform === "android" ? (
-        <div className="border-t border-border/50 px-4 py-4">
+        <div className="py-3">
           <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
             <div className="space-y-3">
               <label className="block">
@@ -445,7 +451,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
                   />
                 </div>
               </label>
-              <div className="max-h-72 space-y-2 overflow-y-auto rounded-xl border border-border/60 bg-bg/25 p-2">
+              <div className="max-h-72 space-y-1 overflow-y-auto">
                 {filteredApps.map((app) => {
                   const checked = selectedPackageNames.includes(
                     app.packageName,
@@ -484,7 +490,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
               </div>
             </div>
 
-            <div className="space-y-3 rounded-xl border border-border/60 bg-bg/25 p-3">
+            <div className="space-y-3">
               <div>
                 <div className="text-xs font-semibold uppercase tracking-wide text-muted">
                   {translate(
@@ -552,7 +558,7 @@ export function AppBlockerSettingsCard({ mode }: AppBlockerSettingsCardProps) {
       {!loading &&
       permission?.status === "granted" &&
       status?.platform === "ios" ? (
-        <div className="border-t border-border/50 px-4 py-4">
+        <div className="py-3">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-1">
               <div className="text-xs font-semibold uppercase tracking-wide text-muted">

--- a/plugins/plugin-personal-assistant/src/components/WebsiteBlockerSettingsCard.tsx
+++ b/plugins/plugin-personal-assistant/src/components/WebsiteBlockerSettingsCard.tsx
@@ -1,5 +1,5 @@
 import type { PermissionStatus } from "@elizaos/shared";
-import { Badge, Button, useAppSelector } from "@elizaos/ui";
+import { Button, useAppSelector } from "@elizaos/ui";
 import { CheckCircle2, Monitor, Settings, ShieldBan } from "lucide-react";
 import type { WebsiteBlockerSettingsCardProps } from "../types/website-blocker-settings-card";
 
@@ -102,9 +102,9 @@ export function WebsiteBlockerSettingsCard({
         <div className="min-w-0 flex-1 text-sm font-medium text-txt">
           {title}
         </div>
-        <Badge variant="outline">
+        <span className="text-xs text-muted">
           {translate(t, "permissionssection.desktopOnly", "Desktop only")}
-        </Badge>
+        </span>
       </div>
     );
   }
@@ -139,24 +139,30 @@ export function WebsiteBlockerSettingsCard({
       : null;
 
   return (
-    <div className="rounded-xl border border-border/60 bg-card/92 shadow-sm">
-      <div className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+    <div className="px-1 py-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-bg/40">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center">
             <ShieldBan className="h-5 w-5 text-txt" aria-hidden />
           </div>
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
               <div className="font-bold text-sm text-txt">{title}</div>
               {permission ? (
-                <Badge variant={badge.variant}>
+                <span
+                  className={`inline-flex items-center gap-1 text-xs ${
+                    badge.ready ? "text-ok" : "text-muted"
+                  }`}
+                >
                   {badge.ready ? (
                     <CheckCircle2 className="mr-1 h-3 w-3" aria-hidden />
                   ) : null}
                   {badge.label}
-                </Badge>
+                </span>
               ) : null}
-              {platform ? <Badge variant="outline">{platform}</Badge> : null}
+              {platform ? (
+                <span className="text-xs text-muted">{platform}</span>
+              ) : null}
             </div>
             <div className="max-w-2xl text-xs-tight leading-5 text-muted">
               {description}

--- a/plugins/plugin-phone/src/components/PhoneAppView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneAppView.tsx
@@ -132,11 +132,11 @@ function PhoneTabTrigger({
       value={tab}
       disabled={disabled}
       aria-current={active ? "true" : undefined}
-      className="rounded-full font-semibold transition-colors"
+      className="font-semibold transition-colors"
       style={{
-        backgroundColor: active ? "var(--accent-subtle)" : "transparent",
+        backgroundColor: "transparent",
         color: active ? "var(--accent)" : "var(--muted)",
-        border: active ? "1px solid var(--accent)" : "1px solid transparent",
+        border: "1px solid transparent",
       }}
       {...agentProps}
     >
@@ -163,11 +163,11 @@ function PhoneDialKey({
     <button
       ref={ref}
       type="button"
-      className="h-16 rounded-full text-2xl font-semibold transition active:scale-95 sm:h-20"
+      className="h-16 text-2xl font-semibold transition active:scale-95 sm:h-20"
       style={{
-        backgroundColor: "var(--surface)",
+        backgroundColor: "transparent",
         color: "var(--text)",
-        border: "1px solid var(--border)",
+        border: "none",
       }}
       onClick={() => onPress(digit)}
       aria-label={`Dial ${digit}`}
@@ -204,10 +204,10 @@ function RecentCallButton({
       ref={ref}
       type="button"
       onClick={() => onCall(entry.number)}
-      className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition active:scale-[0.99]"
+      className="flex w-full items-center gap-3 px-2 py-2 text-left transition active:scale-[0.99]"
       style={{
-        backgroundColor: "var(--surface)",
-        border: "1px solid transparent",
+        backgroundColor: "transparent",
+        border: "none",
       }}
       {...agentProps}
     >
@@ -416,13 +416,13 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
       {/* Header */}
-      <div className="flex shrink-0 items-center justify-between border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center justify-between px-3 py-2">
         <div className="flex items-center gap-3">
           <Button
             ref={backAgent.ref}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 text-muted hover:text-txt"
             onClick={exitToApps}
             aria-label={backLabel}
             {...backAgent.agentProps}
@@ -433,7 +433,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
             <h1 className="text-base font-semibold text-txt">
               {t("phone.title", { defaultValue: "Phone" })}
             </h1>
-            <p className="text-xs-tight text-muted leading-none">
+            <p className="sr-only text-xs-tight text-muted leading-none">
               {t("phone.subtitle", {
                 defaultValue: "Dialer and recent calls",
               })}
@@ -445,7 +445,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
             ref={contactsNavAgent.ref}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 text-muted hover:text-txt"
             onClick={openContacts}
             aria-label={contactsLabel}
             data-testid="phone-open-contacts"
@@ -462,11 +462,8 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
         onValueChange={(v: string) => setActiveTab(v as PhoneTab)}
         className="flex flex-1 min-h-0 flex-col"
       >
-        <div className="shrink-0 border-b border-border/20 bg-bg/60 px-3 py-2">
-          <TabsList
-            className="grid w-full max-w-sm grid-cols-2 gap-1"
-            style={{ backgroundColor: "var(--surface)" }}
-          >
+        <div className="shrink-0 px-3 py-1">
+          <TabsList className="grid w-full max-w-sm grid-cols-2 gap-1 bg-transparent">
             <PhoneTabTrigger
               tab="dialer"
               label={t("phone.tabs.dialer", { defaultValue: "Dialer" })}
@@ -488,10 +485,10 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
           <div className="flex min-h-full flex-col items-center px-4 pb-32 pt-6">
             <div className="flex w-full max-w-sm flex-col items-center gap-3 pt-2">
               <output
-                className="block min-h-[3rem] w-full select-text rounded-xl px-4 py-3 text-center font-mono text-2xl"
+                className="block min-h-[3rem] w-full select-text px-4 py-3 text-center font-mono text-2xl"
                 style={{
-                  backgroundColor: "var(--surface)",
-                  border: "1px solid var(--border)",
+                  backgroundColor: "transparent",
+                  border: "none",
                   color: "var(--text)",
                 }}
                 aria-live="polite"
@@ -538,10 +535,10 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
               <button
                 ref={plusAgent.ref}
                 type="button"
-                className="h-12 rounded-full text-lg font-semibold active:scale-95"
+                className="h-12 text-lg font-semibold active:scale-95"
                 style={{
-                  backgroundColor: "var(--surface)",
-                  border: "1px solid var(--border)",
+                  backgroundColor: "transparent",
+                  border: "none",
                   color: "var(--text)",
                 }}
                 onClick={appendPlus}
@@ -576,10 +573,10 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
               <button
                 ref={backspaceAgent.ref}
                 type="button"
-                className="flex h-12 items-center justify-center rounded-full active:scale-95 disabled:opacity-50"
+                className="flex h-12 items-center justify-center active:scale-95 disabled:opacity-50"
                 style={{
-                  backgroundColor: "var(--surface)",
-                  border: "1px solid var(--border)",
+                  backgroundColor: "transparent",
+                  border: "none",
                   color: "var(--text)",
                 }}
                 onClick={backspace}
@@ -613,9 +610,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
                 testId="phone-recent-permission-callout"
               />
             ) : callsError ? (
-              <p className="rounded-lg border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
-                {callsError}
-              </p>
+              <p className="px-1 py-2 text-sm text-danger">{callsError}</p>
             ) : null}
             {!callsError && calls.length === 0 && callsLoading ? (
               <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted">
@@ -633,7 +628,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
                       defaultValue: "No recent calls.",
                     })}
                   </div>
-                  <p className="mt-1 text-xs text-muted">
+                  <p className="sr-only mt-1 text-xs text-muted">
                     {t("phone.recent.emptyBody", {
                       defaultValue:
                         "Recent incoming, outgoing, and missed calls will appear here after Android grants call-log access.",
@@ -642,7 +637,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
                   <div className="mt-4 flex justify-center gap-2">
                     <Button
                       ref={emptyDialerAgent.ref}
-                      variant="outline"
+                      variant="ghost"
                       size="sm"
                       onClick={() => setActiveTab("dialer")}
                       {...emptyDialerAgent.agentProps}

--- a/plugins/plugin-phone/src/components/PhoneAppView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneAppView.tsx
@@ -625,7 +625,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
                   <PhoneIcon className="mx-auto h-12 w-12 text-muted" />
                   <div className="mt-3 text-sm font-medium text-txt">
                     {t("phone.recent.empty", {
-                      defaultValue: "No recent calls.",
+                      defaultValue: "No recent",
                     })}
                   </div>
                   <p className="sr-only mt-1 text-xs text-muted">

--- a/plugins/plugin-phone/src/components/PhoneAppView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneAppView.tsx
@@ -625,7 +625,7 @@ export function PhoneAppView({ exitToApps, t }: OverlayAppContext) {
                   <PhoneIcon className="mx-auto h-12 w-12 text-muted" />
                   <div className="mt-3 text-sm font-medium text-txt">
                     {t("phone.recent.empty", {
-                      defaultValue: "No recent",
+                      defaultValue: "None",
                     })}
                   </div>
                   <p className="sr-only mt-1 text-xs text-muted">

--- a/plugins/plugin-phone/src/components/PhoneSpatialView.test.tsx
+++ b/plugins/plugin-phone/src/components/PhoneSpatialView.test.tsx
@@ -45,7 +45,6 @@ describe("PhoneSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Phone");
       expect(flat).toContain("call-ready");
       expect(flat).toContain("Ada Lovelace");
       expect(flat).toContain("555-0100"); // dialed number

--- a/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
@@ -125,7 +125,7 @@ export function PhoneSpatialView({
 }: PhoneSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
   return (
-    <Card title="Phone" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
@@ -208,7 +208,7 @@ export function PhoneSpatialView({
       <Divider label="recent" />
       {snapshot.calls.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No recent
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneSpatialView.tsx
@@ -208,7 +208,7 @@ export function PhoneSpatialView({
       <Divider label="recent" />
       {snapshot.calls.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No recent calls
+          No recent
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.desktop.test.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.desktop.test.tsx
@@ -358,7 +358,7 @@ describe("PolymarketAppView (desktop/xr)", () => {
     const { container } = render(
       React.createElement(PolymarketAppView, overlayContext),
     );
-    await waitForText(container, "No markets");
+    await waitForText(container, "None");
 
     const text = container.textContent ?? "";
     expect(text).not.toContain("Unavailable");
@@ -382,6 +382,6 @@ describe("PolymarketAppView (desktop/xr)", () => {
     expect(container.textContent).toContain(
       "Couldn't reach Polymarket right now.",
     );
-    expect(container.textContent).not.toContain("No markets");
+    expect(container.textContent).not.toContain("None");
   });
 });

--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.desktop.test.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.desktop.test.tsx
@@ -348,7 +348,7 @@ describe("PolymarketAppView (desktop/xr)", () => {
     expect(exitToApps).toHaveBeenCalledTimes(1);
   });
 
-  it("DisconnectedState: empty markets shows 'No markets loaded' + missing trading vars", async () => {
+  it("DisconnectedState: empty markets shows compact state + missing trading vars", async () => {
     polymarketClient.polymarketStatus.mockResolvedValue(sampleStatus);
     polymarketClient.polymarketMarkets.mockResolvedValue({
       markets: [],
@@ -358,17 +358,17 @@ describe("PolymarketAppView (desktop/xr)", () => {
     const { container } = render(
       React.createElement(PolymarketAppView, overlayContext),
     );
-    await waitForText(container, "No markets loaded");
+    await waitForText(container, "No markets");
 
     const text = container.textContent ?? "";
-    expect(text).not.toContain("Markets unavailable");
+    expect(text).not.toContain("Unavailable");
     // The missing-trading-vars <code> list joins status.trading.missing.
     expect(text).toContain("POLYMARKET_PRIVATE_KEY, CLOB_API_KEY");
     const code = container.querySelector("code");
     expect(code?.textContent).toBe("POLYMARKET_PRIVATE_KEY, CLOB_API_KEY");
   });
 
-  it("DisconnectedState: fetch rejection shows 'Markets unavailable' error copy", async () => {
+  it("DisconnectedState: fetch rejection shows compact unavailable copy", async () => {
     polymarketClient.polymarketStatus.mockResolvedValue(sampleStatus);
     polymarketClient.polymarketMarkets.mockRejectedValue(
       new Error("network down"),
@@ -377,11 +377,11 @@ describe("PolymarketAppView (desktop/xr)", () => {
     const { container } = render(
       React.createElement(PolymarketAppView, overlayContext),
     );
-    await waitForText(container, "Markets unavailable");
+    await waitForText(container, "Unavailable");
 
     expect(container.textContent).toContain(
       "Couldn't reach Polymarket right now.",
     );
-    expect(container.textContent).not.toContain("No markets loaded");
+    expect(container.textContent).not.toContain("No markets");
   });
 });

--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
@@ -288,6 +288,7 @@ function DisconnectedState({
       </div>
       <div style={{ maxWidth: 360 }}>
         <h2
+          title={error ? "Markets unavailable" : "No markets loaded"}
           style={{
             margin: 0,
             fontSize: 19,
@@ -295,7 +296,7 @@ function DisconnectedState({
             color: TXT,
           }}
         >
-          {error ? "Markets unavailable" : "No markets loaded"}
+          {error ? "Unavailable" : "No markets"}
         </h2>
         {error ? (
           <p

--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
@@ -78,14 +78,14 @@ export function PolymarketAppView({ exitToApps, t }: OverlayAppContext) {
           "@keyframes pmShimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}"
         }
       </style>
-      <div className="flex shrink-0 items-center justify-between border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center justify-between px-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             ref={back.ref}
             {...back.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={exitToApps}
             aria-label={backLabel}
           >
@@ -103,8 +103,8 @@ export function PolymarketAppView({ exitToApps, t }: OverlayAppContext) {
         </div>
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
-        <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-3 sm:px-5">
+        <div className="mx-auto flex max-w-3xl flex-col gap-3">
           {selectedMarket ? (
             <MarketDetail
               market={selectedMarket}
@@ -217,10 +217,7 @@ function CapabilityChip({
         display: "inline-flex",
         alignItems: "center",
         gap: 7,
-        padding: "7px 12px",
-        borderRadius: 99,
-        border: `1px solid ${BORDER}`,
-        background: SURFACE,
+        padding: "4px 2px",
         fontSize: 13,
         fontWeight: 600,
         color: TXT,
@@ -286,19 +283,7 @@ function DisconnectedState({
         margin: "auto 0",
       }}
     >
-      <div
-        style={{
-          position: "relative",
-          width: 96,
-          height: 96,
-          borderRadius: 28,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          background: "var(--accent-subtle, rgba(255,138,36,0.14))",
-          border: `1px solid ${BORDER}`,
-        }}
-      >
+      <div>
         <PolymarketGlyph size={52} />
       </div>
       <div style={{ maxWidth: 360 }}>
@@ -314,6 +299,7 @@ function DisconnectedState({
         </h2>
         {error ? (
           <p
+            className="sr-only"
             style={{
               margin: "8px 0 0",
               fontSize: 14,
@@ -346,6 +332,7 @@ function DisconnectedState({
       </div>
       {!trading && status?.trading.missing.length ? (
         <p
+          className="sr-only"
           style={{
             margin: 0,
             fontSize: 12,
@@ -368,9 +355,7 @@ function MarketSkeleton() {
   return (
     <div
       style={{
-        height: 86,
-        borderRadius: 16,
-        border: `1px solid ${BORDER}`,
+        height: 66,
         background: `linear-gradient(90deg, ${SURFACE} 0%, var(--bg-hover, rgba(0,0,0,0.06)) 50%, ${SURFACE} 100%)`,
         backgroundSize: "200% 100%",
         animation: "pmShimmer 1.4s ease-in-out infinite",
@@ -395,12 +380,7 @@ function OutcomeChip({
         display: "inline-flex",
         alignItems: "center",
         gap: 6,
-        padding: "5px 10px",
-        borderRadius: 99,
-        border: `1px solid ${lead ? "var(--accent-subtle, rgba(255,138,36,0.3))" : BORDER}`,
-        background: lead
-          ? "var(--accent-subtle, rgba(255,138,36,0.14))"
-          : SURFACE,
+        padding: "2px 0",
         fontSize: 12.5,
         fontWeight: 600,
         color: TXT,
@@ -464,12 +444,10 @@ function MarketCard({
         gap: 12,
         width: "100%",
         textAlign: "left",
-        padding: 14,
-        borderRadius: 16,
-        border: `1px solid ${active ? ACCENT : BORDER}`,
-        background: active
-          ? "var(--accent-subtle, rgba(255,138,36,0.08))"
-          : "var(--card, #fff)",
+        padding: "10px 4px",
+        border: "none",
+        borderLeft: active ? `2px solid ${ACCENT}` : "2px solid transparent",
+        background: "transparent",
         cursor: "pointer",
         font: "inherit",
         color: TXT,
@@ -480,13 +458,10 @@ function MarketCard({
         style={{
           width: 40,
           height: 40,
-          borderRadius: 12,
           flexShrink: 0,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: SURFACE,
-          border: `1px solid ${BORDER}`,
           overflow: "hidden",
         }}
       >
@@ -577,13 +552,10 @@ function MarketDetail({
           style={{
             width: 44,
             height: 44,
-            borderRadius: 12,
             flexShrink: 0,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            background: SURFACE,
-            border: `1px solid ${BORDER}`,
             overflow: "hidden",
           }}
         >
@@ -646,7 +618,6 @@ function MarketDetail({
               key={outcome.name}
               style={{
                 padding: "11px 0",
-                borderTop: `1px solid ${BORDER}`,
                 display: "flex",
                 flexDirection: "column",
                 gap: 6,
@@ -673,7 +644,6 @@ function MarketDetail({
                 <div
                   style={{
                     height: 6,
-                    borderRadius: 99,
                     background: SURFACE,
                     overflow: "hidden",
                   }}
@@ -682,7 +652,6 @@ function MarketDetail({
                     style={{
                       width: `${pct}%`,
                       height: "100%",
-                      borderRadius: 99,
                       background: i === 0 ? ACCENT : MUTED,
                     }}
                   />

--- a/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketAppView.tsx
@@ -288,7 +288,7 @@ function DisconnectedState({
       </div>
       <div style={{ maxWidth: 360 }}>
         <h2
-          title={error ? "Markets unavailable" : "No markets loaded"}
+          title={error ? "Markets unavailable" : "None"}
           style={{
             margin: 0,
             fontSize: 19,
@@ -296,7 +296,7 @@ function DisconnectedState({
             color: TXT,
           }}
         >
-          {error ? "Unavailable" : "No markets"}
+          {error ? "Unavailable" : "None"}
         </h2>
         {error ? (
           <p

--- a/plugins/plugin-polymarket-app/src/PolymarketPositionsPanel.tsx
+++ b/plugins/plugin-polymarket-app/src/PolymarketPositionsPanel.tsx
@@ -378,7 +378,7 @@ export function PolymarketPositionsPanel({
               color: MUTED,
             }}
           >
-            No open positions
+            None
           </div>
         ) : (
           <>

--- a/plugins/plugin-polymarket-app/src/components/PolymarketSpatialView.test.tsx
+++ b/plugins/plugin-polymarket-app/src/components/PolymarketSpatialView.test.tsx
@@ -107,7 +107,6 @@ describe("PolymarketSpatialView one source, three modalities", () => {
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
       // Survives even the narrow 32-cell layout.
-      expect(flat).toContain("Polymarket");
       expect(flat).toContain("reads ready");
       expect(flat).toContain("trading off");
     }

--- a/plugins/plugin-polymarket-app/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket-app/src/components/PolymarketSpatialView.tsx
@@ -353,7 +353,7 @@ export function PolymarketSpatialView({
   const accountReady = status?.account?.ready ?? false;
   const selectedId = selectedMarket?.id ?? null;
   return (
-    <Card title="Polymarket" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" wrap>
         <ReadinessRow status={status} />
         <Text style="caption" tone="muted" grow={1}>

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
@@ -70,7 +70,7 @@ describe("RelationshipsSpatialView one source, three modalities", () => {
     for (const width of [54, 32]) {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
-      expect(lines.join("\n")).toContain("Relationships");
+      expect(lines.join("\n")).not.toContain("Relationships");
     }
     const flat = renderViewToLines(view, 54).join("\n");
     expect(flat).toContain("Owner");

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
@@ -122,7 +122,7 @@ describe("RelationshipsSpatialView one source, three modalities", () => {
         <RelationshipsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No people");
+    expect(html).toContain("None");
     expect(html).toContain('data-agent-id="add"');
   });
 

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
@@ -122,7 +122,7 @@ describe("RelationshipsSpatialView one source, three modalities", () => {
         <RelationshipsSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No people yet");
+    expect(html).toContain("No people");
     expect(html).toContain('data-agent-id="add"');
   });
 

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
@@ -142,7 +142,7 @@ function RelationshipsEmptyBody({
 }) {
   return (
     <>
-      <Text bold>No people yet</Text>
+      <Text bold>No people</Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
           Add someone

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
@@ -142,7 +142,7 @@ function RelationshipsEmptyBody({
 }) {
   return (
     <>
-      <Text bold>No people</Text>
+      <Text bold>None</Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
           Add someone
@@ -183,7 +183,7 @@ function RelationshipsReadyBody({
       </Text>
       {visible.length === 0 ? (
         <Text tone="muted" style="caption">
-          No matches
+          None
         </Text>
       ) : (
         <List gap={1}>

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
@@ -22,7 +22,6 @@
 import {
   Button,
   Card,
-  Divider,
   HStack,
   List,
   Text,
@@ -98,11 +97,7 @@ export function RelationshipsSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card title="Relationships" gap={1} padding={1}>
-      <Text style="caption" tone="muted">
-        People, organizations, and the edges between them.
-      </Text>
-
+    <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading relationships
@@ -127,7 +122,6 @@ function RelationshipsErrorBody({
 }) {
   return (
     <>
-      <Divider label="error" />
       <Text bold>Could not load relationships</Text>
       <Text tone="danger" style="caption">
         {snapshot.error ?? "Could not load relationships."}
@@ -148,12 +142,7 @@ function RelationshipsEmptyBody({
 }) {
   return (
     <>
-      <Divider label="empty" />
       <Text bold>No people yet</Text>
-      <Text tone="muted" style="caption">
-        Eliza has not learned about anyone in your network yet. Tell her about
-        the people you work with and she will start mapping them.
-      </Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
           Add someone
@@ -189,10 +178,12 @@ function RelationshipsReadyBody({
           onSelect={setActiveKind}
         />
       ) : null}
-      <Divider label={`Graph (${visible.length})`} />
+      <Text style="caption" tone="muted">
+        Graph ({visible.length})
+      </Text>
       {visible.length === 0 ? (
         <Text tone="muted" style="caption">
-          No entities match that filter.
+          No matches
         </Text>
       ) : (
         <List gap={1}>
@@ -259,7 +250,7 @@ function EntityNodeBlock({
           agent={`open-${node.id}`}
           onPress={() => onAction?.(`open:${node.id}`)}
         >
-          Open
+          ›
         </Button>
       </HStack>
       {node.identityLine ? (
@@ -267,25 +258,21 @@ function EntityNodeBlock({
           {node.identityLine}
         </Text>
       ) : null}
-      {node.edges.length === 0 ? (
-        <Text style="caption" tone="muted">
-          No relationships recorded yet.
-        </Text>
-      ) : (
-        node.edges.map((edge) => (
-          <HStack key={edge.id} gap={1} align="center">
-            <Text tone="muted" wrap={false}>
-              ›
-            </Text>
-            <VStack gap={0} grow={1}>
-              <Text wrap={false}>{edge.toName}</Text>
-            </VStack>
-            <Text style="caption" tone="muted" wrap={false}>
-              {edge.meta}
-            </Text>
-          </HStack>
-        ))
-      )}
+      {node.edges.length > 0
+        ? node.edges.map((edge) => (
+            <HStack key={edge.id} gap={1} align="center">
+              <Text tone="muted" wrap={false}>
+                ›
+              </Text>
+              <VStack gap={0} grow={1}>
+                <Text wrap={false}>{edge.toName}</Text>
+              </VStack>
+              <Text style="caption" tone="muted" wrap={false}>
+                {edge.meta}
+              </Text>
+            </HStack>
+          ))
+        : null}
     </VStack>
   );
 }

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
@@ -190,7 +190,7 @@ describe("RelationshipsView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No people yet");
+    await screen.findByText("None");
     expect(screen.queryByText("Pat Doe")).toBeNull();
   });
 
@@ -203,7 +203,7 @@ describe("RelationshipsView — states", () => {
         })}
       />,
     );
-    await screen.findByText("No people yet");
+    await screen.findByText("None");
     fireEvent.click(agent("add"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });

--- a/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.test.tsx
+++ b/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.test.tsx
@@ -49,7 +49,6 @@ describe("ScreenshareSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Screen Share");
       expect(flat).toContain("active");
       expect(flat).toContain("This machine");
       expect(flat).toContain("headfulGui");

--- a/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
+++ b/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
@@ -159,7 +159,7 @@ export function ScreenshareSpatialView({
         </VStack>
       ) : (
         <Text tone="muted" align="center" style="caption">
-          No active session
+          Idle
         </Text>
       )}
 
@@ -208,7 +208,7 @@ export function ScreenshareSpatialView({
       </Text>
       {snapshot.capabilities.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No capabilities reported
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
+++ b/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
@@ -106,7 +106,7 @@ export function ScreenshareSpatialView({
   );
 
   return (
-    <Card title="Screen Share" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-screenshare/src/ui/ScreenshareOperatorSurface.test.tsx
+++ b/plugins/plugin-screenshare/src/ui/ScreenshareOperatorSurface.test.tsx
@@ -207,9 +207,9 @@ describe("ScreenshareOperatorSurface — populated data", () => {
     // Platform value comes from capabilities.platform.
     expect(screen.getByLabelText("Platform: linux")).toBeTruthy();
     // GUI tile value is the literal "GUI" string; the icon is driven by
-    // headfulGui.available. We assert the active class on the tile container.
+    // headfulGui.available without adding frame chrome.
     const guiTile = screen.getByLabelText("GUI: GUI");
-    expect(guiTile.className).toContain("border-ok/35");
+    expect(guiTile.className).not.toContain("border-ok/35");
 
     // Capabilities section renders one tile per REAL capability key.
     const capsSection = screen.getByRole("region", { name: "Capabilities" });
@@ -242,11 +242,7 @@ describe("ScreenshareOperatorSurface — populated data", () => {
       }),
     );
 
-    expect(
-      screen.getByText(
-        "Screen Share Remote desktop control is available from the actions surface.",
-      ),
-    ).toBeTruthy();
+    expect(screen.getByText("Screen Share")).toBeTruthy();
     // No host controls in the chat branch.
     expect(screen.queryByText("Start session")).toBeNull();
   });

--- a/plugins/plugin-screenshare/src/ui/ScreenshareOperatorSurface.tsx
+++ b/plugins/plugin-screenshare/src/ui/ScreenshareOperatorSurface.tsx
@@ -72,9 +72,7 @@ function ScreenshareMetric({
 }) {
   return (
     <div
-      className={`flex min-h-16 flex-col items-center justify-center gap-1.5 px-3 py-2 ${
-        active ? "border-ok/35" : ""
-      }`}
+      className="flex min-h-16 flex-col items-center justify-center gap-1.5 px-3 py-2"
       title={label}
       role="status"
       aria-label={`${label}: ${value}`}
@@ -322,12 +320,7 @@ export function ScreenshareOperatorSurface({
       : null;
 
   if (focus === "chat") {
-    return (
-      <SurfaceEmptyState
-        title="Screen Share"
-        body="Remote desktop control is available from the actions surface."
-      />
-    );
+    return <SurfaceEmptyState title="Screen Share" body="" />;
   }
 
   return (
@@ -469,7 +462,7 @@ export function ScreenshareOperatorSurface({
             value={remoteBase}
             onChange={(event) => setRemoteBase(event.target.value)}
             placeholder="Server URL"
-            className="h-9 rounded-lg border-border/45 bg-bg/60 text-xs"
+            className="h-9 border-0 bg-transparent text-xs"
           />
           <ScreenshareField
             agentId="input-remote-session"
@@ -479,7 +472,7 @@ export function ScreenshareOperatorSurface({
             value={remoteSessionId}
             onChange={(event) => setRemoteSessionId(event.target.value)}
             placeholder="Session"
-            className="h-9 rounded-lg border-border/45 bg-bg/60 text-xs"
+            className="h-9 border-0 bg-transparent text-xs"
           />
           <ScreenshareField
             agentId="input-remote-token"
@@ -489,7 +482,7 @@ export function ScreenshareOperatorSurface({
             value={remoteToken}
             onChange={(event) => setRemoteToken(event.target.value)}
             placeholder="Token"
-            className="h-9 rounded-lg border-border/45 bg-bg/60 text-xs"
+            className="h-9 border-0 bg-transparent text-xs"
           />
         </div>
         <div className="mt-3 flex gap-2">
@@ -632,12 +625,9 @@ export function ScreenshareTuiView() {
         padding: 20,
       }}
     >
-      <div style={{ color: "#7dd3fc", marginBottom: 4 }}>
-        elizaos://screenshare --type=tui
-      </div>
       <div
         data-status={loading ? "loading" : "ready"}
-        style={{ color: "#475569", marginBottom: 16 }}
+        style={{ color: "#94a3b8", marginBottom: 16 }}
       >
         {loading ? "loading" : (state?.capabilities.platform ?? "unknown")} |{" "}
         {activeSessions.length} active sessions | {lastAction}
@@ -653,10 +643,7 @@ export function ScreenshareTuiView() {
         <section
           aria-label="Screen share sessions"
           style={{
-            border: "1px solid rgba(125,211,252,0.3)",
-            borderRadius: 6,
-            padding: 16,
-            minHeight: 420,
+            padding: "8px 0",
           }}
         >
           <div
@@ -677,8 +664,7 @@ export function ScreenshareTuiView() {
               style={{
                 background: "transparent",
                 color: "#a7f3d0",
-                border: "1px solid rgba(167,243,208,0.45)",
-                borderRadius: 4,
+                border: 0,
                 padding: "4px 8px",
                 cursor: loading ? "not-allowed" : "pointer",
                 fontFamily: "inherit",
@@ -693,7 +679,6 @@ export function ScreenshareTuiView() {
             <div
               key={session.id}
               style={{
-                borderTop: "1px solid rgba(125,211,252,0.14)",
                 padding: "8px 0",
               }}
             >
@@ -715,10 +700,7 @@ export function ScreenshareTuiView() {
         <section
           aria-label="Screen share capabilities"
           style={{
-            border: "1px solid rgba(125,211,252,0.3)",
-            borderRadius: 6,
-            padding: 16,
-            minHeight: 420,
+            padding: "8px 0",
           }}
         >
           <strong style={{ color: "#e2e8f0" }}>capabilities</strong>

--- a/plugins/plugin-shopify-ui/src/CustomersPanel.test.tsx
+++ b/plugins/plugin-shopify-ui/src/CustomersPanel.test.tsx
@@ -91,7 +91,7 @@ describe("CustomersPanel", () => {
         search: "zzz",
       }),
     );
-    expect(screen.getByText("No customers match your search.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 
   it("shows the generic empty state with no query", () => {
@@ -104,7 +104,7 @@ describe("CustomersPanel", () => {
         search: "",
       }),
     );
-    expect(screen.getByText("No customers found.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 
   it("renders loading skeletons while empty + loading", () => {

--- a/plugins/plugin-shopify-ui/src/CustomersPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/CustomersPanel.tsx
@@ -66,7 +66,6 @@ export function CustomersPanel({
   total,
   loading,
   error,
-  search,
 }: CustomersPanelProps) {
   return (
     <div className="space-y-3">
@@ -97,9 +96,7 @@ export function CustomersPanel({
       ) : customers.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Users className="h-8 w-8 text-muted/40" />
-          <div className="text-sm text-muted">
-            {search ? "No customers match your search." : "No customers found."}
-          </div>
+          <div className="text-sm text-muted">None</div>
         </div>
       ) : (
         <div className="space-y-1.5">

--- a/plugins/plugin-shopify-ui/src/CustomersPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/CustomersPanel.tsx
@@ -12,8 +12,8 @@ function CustomerRow({ customer }: { customer: ShopifyCustomer }) {
     [customer.firstName, customer.lastName].filter(Boolean).join(" ") || "—";
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-xl border border-border/20 bg-card/30 px-3 py-3 transition-colors hover:bg-card/50">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/30 bg-bg-accent text-xs-tight font-semibold uppercase text-muted-strong">
+    <div className="flex flex-wrap items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center text-xs-tight font-semibold uppercase text-muted-strong">
         {(customer.firstName?.[0] ?? customer.email[0] ?? "?").toUpperCase()}
       </div>
 
@@ -73,7 +73,7 @@ export function CustomersPanel({
       <div className="flex items-center justify-between gap-2">
         <p
           data-testid="chat-search-hint"
-          className="text-[13px] leading-relaxed text-txt/60"
+          className="sr-only text-[13px] leading-relaxed text-txt/60"
         >
           Search customers by typing in the chat.
         </p>
@@ -85,19 +85,17 @@ export function CustomersPanel({
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {error}
-        </div>
+        <div className="px-1 py-2 text-sm text-danger">{error}</div>
       ) : null}
 
       {loading && customers.length === 0 ? (
         <div className="space-y-2">
           {Array.from({ length: 8 }, (_, i) => i).map((i) => (
-            <Skeleton key={i} className="h-14 w-full rounded-xl" />
+            <Skeleton key={i} className="h-14 w-full" />
           ))}
         </div>
       ) : customers.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-card/20 py-12 text-center">
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Users className="h-8 w-8 text-muted/40" />
           <div className="text-sm text-muted">
             {search ? "No customers match your search." : "No customers found."}

--- a/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.test.tsx
+++ b/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.test.tsx
@@ -123,7 +123,7 @@ describe("InventoryLevelsPanel", () => {
     );
     const select = screen.getByLabelText("Location") as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "Outlet" } });
-    expect(screen.getByText("No items at Outlet.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 
   it("adjusts inventory up: POSTs {delta, locationId} and optimistically increments", async () => {

--- a/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.tsx
@@ -221,11 +221,7 @@ export function InventoryLevelsPanel({
       ) : displayedItems.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Package className="h-8 w-8 text-muted/40" />
-          <div className="text-sm text-muted">
-            {selectedLocation === "all"
-              ? "No inventory items found."
-              : `No items at ${selectedLocation}.`}
-          </div>
+          <div className="text-sm text-muted">None</div>
         </div>
       ) : (
         <div className="space-y-1.5">

--- a/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/InventoryLevelsPanel.tsx
@@ -37,11 +37,7 @@ function InventoryAdjustButton({
       aria-label={`${delta > 0 ? "Increase" : "Decrease"} inventory by 1`}
       {...agentProps}
     >
-      {delta > 0 ? (
-        <Plus className="h-3 w-3" />
-      ) : (
-        <Minus className="h-3 w-3" />
-      )}
+      {delta > 0 ? <Plus className="h-3 w-3" /> : <Minus className="h-3 w-3" />}
     </Button>
   );
 }
@@ -79,7 +75,7 @@ function InventoryRow({ item, onAdjust }: InventoryRowProps) {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-xl border border-border/20 bg-card/30 px-3 py-3">
+    <div className="flex flex-wrap items-center gap-3 px-2 py-2">
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-semibold text-txt">
           {item.productTitle}
@@ -213,19 +209,17 @@ export function InventoryLevelsPanel({
       ) : null}
 
       {error ? (
-        <div className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {error}
-        </div>
+        <div className="px-1 py-2 text-sm text-danger">{error}</div>
       ) : null}
 
       {loading && items.length === 0 ? (
         <div className="space-y-2">
           {Array.from({ length: 6 }, (_, i) => i).map((i) => (
-            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+            <Skeleton key={i} className="h-16 w-full" />
           ))}
         </div>
       ) : displayedItems.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-card/20 py-12 text-center">
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Package className="h-8 w-8 text-muted/40" />
           <div className="text-sm text-muted">
             {selectedLocation === "all"

--- a/plugins/plugin-shopify-ui/src/OrdersPanel.test.tsx
+++ b/plugins/plugin-shopify-ui/src/OrdersPanel.test.tsx
@@ -200,7 +200,7 @@ describe("OrdersPanel", () => {
         onStatusFilterChange: vi.fn(),
       }),
     );
-    expect(screen.getByText("No orders found.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
 
     rerender(
       React.createElement(OrdersPanel, {
@@ -212,7 +212,7 @@ describe("OrdersPanel", () => {
         onStatusFilterChange: vi.fn(),
       }),
     );
-    expect(screen.getByText("No unfulfilled orders.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
 
     rerender(
       React.createElement(OrdersPanel, {
@@ -224,6 +224,6 @@ describe("OrdersPanel", () => {
         onStatusFilterChange: vi.fn(),
       }),
     );
-    expect(screen.getByText("No fulfilled orders.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 });

--- a/plugins/plugin-shopify-ui/src/OrdersPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/OrdersPanel.tsx
@@ -220,13 +220,7 @@ export function OrdersPanel({
       ) : orders.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-10 text-center">
           <ShoppingCart className="h-8 w-8 text-muted/40" />
-          <div className="text-sm text-muted">
-            {activeTab === "unfulfilled"
-              ? "No unfulfilled orders."
-              : activeTab === "fulfilled"
-                ? "No fulfilled orders."
-                : "No orders found."}
-          </div>
+          <div className="text-sm text-muted">None</div>
         </div>
       ) : (
         <div className="space-y-1.5">

--- a/plugins/plugin-shopify-ui/src/OrdersPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/OrdersPanel.tsx
@@ -79,13 +79,13 @@ function OrderRow({ order }: { order: ShopifyOrder }) {
   });
 
   return (
-    <div className="rounded-xl">
+    <div>
       <button
         ref={toggle.ref}
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-card/40 rounded-xl"
+        className="flex w-full items-center gap-3 px-2 py-2 text-left transition-colors hover:bg-bg-muted/20"
         {...toggle.agentProps}
       >
         <div className="min-w-[4rem] shrink-0">
@@ -208,19 +208,17 @@ export function OrdersPanel({
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {error}
-        </div>
+        <div className="px-1 py-2 text-sm text-danger">{error}</div>
       ) : null}
 
       {loading && orders.length === 0 ? (
         <div className="space-y-2">
           {Array.from({ length: 6 }, (_, i) => i).map((i) => (
-            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+            <Skeleton key={i} className="h-16 w-full" />
           ))}
         </div>
       ) : orders.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-card/20 py-12 text-center">
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
           <ShoppingCart className="h-8 w-8 text-muted/40" />
           <div className="text-sm text-muted">
             {activeTab === "unfulfilled"

--- a/plugins/plugin-shopify-ui/src/ProductsPanel.test.tsx
+++ b/plugins/plugin-shopify-ui/src/ProductsPanel.test.tsx
@@ -199,7 +199,7 @@ describe("ProductsPanel", () => {
         onPageChange: vi.fn(),
       }),
     );
-    expect(screen.getByText("No products match your search.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
     rerender(
       React.createElement(ProductsPanel, {
         products: [],
@@ -211,7 +211,7 @@ describe("ProductsPanel", () => {
         onPageChange: vi.fn(),
       }),
     );
-    expect(screen.getByText("No products found.")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 
   it("creates a product: opens dialog, gates submit on title, POSTs body, closes on success", async () => {

--- a/plugins/plugin-shopify-ui/src/ProductsPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/ProductsPanel.tsx
@@ -226,9 +226,7 @@ function CreateProductDialog({ open, onClose }: CreateProductDialogProps) {
           </div>
 
           {submitError ? (
-            <div className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-              {submitError}
-            </div>
+            <div className="px-1 py-2 text-xs text-danger">{submitError}</div>
           ) : null}
 
           <DialogFooter>
@@ -263,8 +261,8 @@ function ProductRow({ product }: { product: ShopifyProduct }) {
       : `${product.priceRange.min} – ${product.priceRange.max}`;
 
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-border/20 bg-card/30 px-3 py-3 transition-colors hover:bg-card/50">
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/20 bg-bg-accent overflow-hidden">
+    <div className="flex items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden">
         {product.imageUrl ? (
           <img
             src={product.imageUrl}
@@ -358,7 +356,7 @@ export function ProductsPanel({
       <div className="flex items-center justify-between gap-2">
         <p
           data-testid="chat-search-hint"
-          className="text-[13px] leading-relaxed text-txt/60"
+          className="sr-only text-[13px] leading-relaxed text-txt/60"
         >
           Search products by typing in the chat.
         </p>
@@ -376,19 +374,17 @@ export function ProductsPanel({
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {error}
-        </div>
+        <div className="px-1 py-2 text-sm text-danger">{error}</div>
       ) : null}
 
       {loading && products.length === 0 ? (
         <div className="space-y-2">
           {Array.from({ length: 6 }, (_, i) => i).map((i) => (
-            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+            <Skeleton key={i} className="h-16 w-full" />
           ))}
         </div>
       ) : products.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border/20 bg-card/20 py-12 text-center">
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Package className="h-8 w-8 text-muted/40" />
           <div className="text-sm text-muted">
             {search ? "No products match your search." : "No products found."}

--- a/plugins/plugin-shopify-ui/src/ProductsPanel.tsx
+++ b/plugins/plugin-shopify-ui/src/ProductsPanel.tsx
@@ -321,7 +321,6 @@ export function ProductsPanel({
   page,
   loading,
   error,
-  search,
   onPageChange,
 }: ProductsPanelProps) {
   const [createOpen, setCreateOpen] = useState(false);
@@ -386,9 +385,7 @@ export function ProductsPanel({
       ) : products.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-10 text-center">
           <Package className="h-8 w-8 text-muted/40" />
-          <div className="text-sm text-muted">
-            {search ? "No products match your search." : "No products found."}
-          </div>
+          <div className="text-sm text-muted">None</div>
         </div>
       ) : (
         <div className="space-y-1.5">

--- a/plugins/plugin-shopify-ui/src/ShopifyAppView.test.tsx
+++ b/plugins/plugin-shopify-ui/src/ShopifyAppView.test.tsx
@@ -456,7 +456,6 @@ describe("ShopifyAppView (gui + xr)", () => {
     // env hints for the two required vars.
     expect(screen.getByText("SHOPIFY_STORE_DOMAIN")).toBeTruthy();
     expect(screen.getByText("SHOPIFY_ACCESS_TOKEN")).toBeTruthy();
-    // Configure-in-Settings link.
-    expect(screen.getByText("Configure in Settings")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
   });
 });

--- a/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
+++ b/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
@@ -35,8 +35,6 @@ import { useShopifyDashboard } from "./useShopifyDashboard";
 const SH_ACCENT = "var(--accent, #ff8a24)";
 const SH_TXT = "var(--txt, #111)";
 const SH_MUTED = "var(--muted, rgba(0,0,0,0.58))";
-const SH_BORDER = "var(--border, rgba(0,0,0,0.12))";
-const SH_SURFACE = "var(--surface, rgba(0,0,0,0.04))";
 
 function SetupField({
   icon: Icon,
@@ -54,10 +52,7 @@ function SetupField({
       style={{
         display: "flex",
         gap: 12,
-        padding: 14,
-        borderRadius: 14,
-        border: `1px solid ${SH_BORDER}`,
-        background: SH_SURFACE,
+        padding: "10px 2px",
       }}
     >
       <span
@@ -65,11 +60,9 @@ function SetupField({
           width: 34,
           height: 34,
           flexShrink: 0,
-          borderRadius: 10,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "var(--accent-subtle, rgba(255,138,36,0.14))",
           color: SH_ACCENT,
         }}
       >
@@ -86,7 +79,10 @@ function SetupField({
         <span style={{ fontSize: 13.5, fontWeight: 600, color: SH_TXT }}>
           {label}
         </span>
-        <span style={{ fontSize: 12, color: SH_MUTED, lineHeight: 1.4 }}>
+        <span
+          className="sr-only"
+          style={{ fontSize: 12, color: SH_MUTED, lineHeight: 1.4 }}
+        >
           {description}
         </span>
         <code
@@ -120,15 +116,11 @@ function ShopifySetupCard() {
       >
         <div
           style={{
-            position: "relative",
             width: 84,
             height: 84,
-            borderRadius: 24,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            background: "var(--accent-subtle, rgba(255,138,36,0.14))",
-            border: `1px solid ${SH_BORDER}`,
           }}
         >
           <ShoppingBag style={{ width: 38, height: 38, color: SH_ACCENT }} />
@@ -144,6 +136,7 @@ function ShopifySetupCard() {
           Connect your store
         </h2>
         <p
+          className="sr-only"
           style={{
             margin: 0,
             maxWidth: 320,
@@ -159,10 +152,7 @@ function ShopifySetupCard() {
 
       <div
         style={{
-          borderRadius: 18,
-          border: `1px solid ${SH_BORDER}`,
-          background: "var(--card, #fff)",
-          padding: 16,
+          padding: 4,
           display: "flex",
           flexDirection: "column",
           gap: 10,
@@ -200,10 +190,7 @@ function ShopifySetupCard() {
                 display: "inline-flex",
                 alignItems: "center",
                 gap: 6,
-                padding: "5px 10px",
-                borderRadius: 99,
-                border: `1px solid ${SH_BORDER}`,
-                background: SH_SURFACE,
+                padding: "3px 0",
                 fontSize: 12,
                 fontWeight: 600,
                 color: SH_TXT,
@@ -223,7 +210,6 @@ function ShopifySetupCard() {
             justifyContent: "center",
             gap: 8,
             height: 42,
-            borderRadius: 12,
             background: SH_ACCENT,
             color: "var(--accent-foreground, #fff)",
             fontSize: 14,
@@ -249,12 +235,12 @@ function ConnectionStatus({
   domain?: string;
 }) {
   if (loading) {
-    return <Skeleton className="h-6 w-24 rounded-full" />;
+    return <Skeleton className="h-6 w-24" />;
   }
 
   if (connected && domain) {
     return (
-      <div className="flex items-center gap-1.5 rounded-full border border-ok/20 bg-ok/10 px-2.5 py-1">
+      <div className="flex items-center gap-1.5 px-1 py-1">
         <Wifi className="h-3.5 w-3.5 text-ok" />
         <span className="max-w-[10rem] truncate text-xs font-medium text-ok">
           {domain}
@@ -264,7 +250,7 @@ function ConnectionStatus({
   }
 
   return (
-    <div className="flex items-center gap-1.5 rounded-full border border-danger/20 bg-danger/10 px-2.5 py-1">
+    <div className="flex items-center gap-1.5 px-1 py-1">
       <WifiOff className="h-3.5 w-3.5 text-danger" />
       <span className="text-xs font-medium text-danger">Offline</span>
     </div>
@@ -341,11 +327,11 @@ function OverviewTile({
     <button
       type="button"
       onClick={onClick}
-      className="group flex min-h-24 items-start gap-3 rounded-xl border border-border/24 bg-card/35 px-3 py-3 text-left transition-colors hover:bg-card/55"
+      className="group flex min-h-20 items-start gap-3 px-2 py-2 text-left transition-colors hover:bg-bg-muted/20"
       title={label}
     >
       <span
-        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border ${accent}`}
+        className={`flex h-9 w-9 shrink-0 items-center justify-center ${accent}`}
       >
         <Icon className="h-4 w-4" />
       </span>
@@ -436,7 +422,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
       data-testid="shopify-shell"
       className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
-      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/85 px-4 py-3 backdrop-blur-md">
+      <div className="flex shrink-0 items-center gap-3 px-3 py-2">
         <Button
           ref={backButton.ref}
           type="button"
@@ -452,10 +438,8 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
 
         <div className="flex min-w-0 items-center gap-2">
           <span
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+            className="flex h-8 w-8 shrink-0 items-center justify-center"
             style={{
-              borderColor: SH_BORDER,
-              background: "var(--accent-subtle, rgba(255,138,36,0.14))",
               color: SH_ACCENT,
             }}
           >
@@ -477,9 +461,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
 
       <div className="min-h-0 flex-1 overflow-y-auto pb-[calc(7rem+var(--safe-area-bottom,0px))]">
         {statusError ? (
-          <div className="m-4 rounded-xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-            {statusError}
-          </div>
+          <div className="m-3 px-1 py-2 text-sm text-danger">{statusError}</div>
         ) : null}
 
         {!statusLoading && !connected ? (
@@ -488,7 +470,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
           </div>
         ) : statusLoading && !connected ? (
           <div className="flex min-h-full items-center justify-center">
-            <Skeleton className="h-80 w-full max-w-lg rounded-2xl mx-4" />
+            <Skeleton className="mx-4 h-80 w-full max-w-lg" />
           </div>
         ) : (
           <div className="mx-auto w-full max-w-3xl px-4 py-4">
@@ -496,7 +478,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
               value={activeTab}
               onValueChange={(v) => setActiveTab(v as DashboardTab)}
             >
-              <TabsList className="sticky top-3 z-10 mb-4 h-auto w-full justify-between gap-1 rounded-2xl border border-border/30 bg-bg/80 p-1 shadow-sm backdrop-blur sm:w-auto sm:justify-start">
+              <TabsList className="sticky top-3 z-10 mb-3 h-auto w-full justify-between gap-1 bg-transparent p-0 sm:w-auto sm:justify-start">
                 {DASHBOARD_TABS.map((tab) => (
                   <ShopifyDashboardTabTrigger
                     key={tab.value}
@@ -517,14 +499,14 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       icon={Package}
                       label="Products"
                       value={counts.productCount.toLocaleString()}
-                      accent="border-border/30 bg-bg-accent text-muted-strong"
+                      accent="text-muted-strong"
                       onClick={() => setActiveTab("products")}
                     />
                     <OverviewTile
                       icon={ShoppingCart}
                       label="Orders"
                       value={counts.orderCount.toLocaleString()}
-                      accent="border-border/30 bg-bg-accent text-muted-strong"
+                      accent="text-muted-strong"
                       onClick={() => setActiveTab("orders")}
                     />
                     <OverviewTile
@@ -532,9 +514,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       label="Low stock"
                       value={lowInventoryItems.length.toLocaleString()}
                       accent={
-                        urgentInventoryCount > 0
-                          ? "border-danger/20 bg-danger/10 text-danger"
-                          : "border-warn/20 bg-warn/10 text-warn"
+                        urgentInventoryCount > 0 ? "text-danger" : "text-warn"
                       }
                       onClick={() => setActiveTab("inventory")}
                     />
@@ -542,16 +522,16 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       icon={Users}
                       label="Customers"
                       value={counts.customerCount.toLocaleString()}
-                      accent="border-border/30 bg-bg-accent text-muted-strong"
+                      accent="text-muted-strong"
                       onClick={() => setActiveTab("customers")}
                     />
                   </div>
 
                   <div className="space-y-3">
-                    <div className="rounded-xl border border-border/24 bg-card/32 px-3 py-3">
+                    <div className="px-2 py-2">
                       <div className="flex items-center justify-between gap-2">
                         <span
-                          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-bg-accent text-muted-strong"
+                          className="inline-flex h-8 w-8 items-center justify-center text-muted-strong"
                           title="Recent orders"
                         >
                           <ShoppingCart className="h-4 w-4" aria-hidden />
@@ -562,7 +542,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="h-7 rounded-full px-2 text-xs-tight"
+                            className="h-7 px-2 text-xs-tight"
                             onClick={() => setActiveTab("orders")}
                             title={`View all ${ordersTotal.toLocaleString()} orders`}
                             {...viewAllOrdersButton.agentProps}
@@ -574,15 +554,15 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       <div className="mt-2 space-y-1.5">
                         {ordersLoading && orders.length === 0 ? (
                           <>
-                            <Skeleton className="h-8 w-full rounded-lg" />
-                            <Skeleton className="h-8 w-full rounded-lg" />
-                            <Skeleton className="h-8 w-full rounded-lg" />
+                            <Skeleton className="h-8 w-full" />
+                            <Skeleton className="h-8 w-full" />
+                            <Skeleton className="h-8 w-full" />
                           </>
                         ) : (
                           orders.slice(0, 3).map((order) => (
                             <div
                               key={order.id}
-                              className="grid grid-cols-[5rem_minmax(0,1fr)_auto] items-center gap-2 rounded-lg bg-card/40 px-3 py-2"
+                              className="grid grid-cols-[5rem_minmax(0,1fr)_auto] items-center gap-2 px-2 py-1.5"
                             >
                               <span className="text-xs font-semibold text-txt">
                                 {order.name}
@@ -604,10 +584,10 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       </div>
                     </div>
 
-                    <div className="rounded-xl border border-border/24 bg-card/32 px-3 py-3">
+                    <div className="px-2 py-2">
                       <div className="flex items-center justify-between gap-2">
                         <span
-                          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-bg-accent text-muted-strong"
+                          className="inline-flex h-8 w-8 items-center justify-center text-muted-strong"
                           title="Low inventory"
                         >
                           <Package className="h-4 w-4" aria-hidden />
@@ -618,7 +598,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="h-7 rounded-full px-2 text-xs-tight"
+                            className="h-7 px-2 text-xs-tight"
                             onClick={() => setActiveTab("inventory")}
                             title="View inventory"
                             {...viewAllInventoryButton.agentProps}
@@ -630,14 +610,14 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                       <div className="mt-2 space-y-1.5">
                         {inventoryLoading && inventoryItems.length === 0 ? (
                           <>
-                            <Skeleton className="h-8 w-full rounded-lg" />
-                            <Skeleton className="h-8 w-full rounded-lg" />
+                            <Skeleton className="h-8 w-full" />
+                            <Skeleton className="h-8 w-full" />
                           </>
                         ) : (
                           lowInventoryItems.slice(0, 3).map((item) => (
                             <div
                               key={`${item.id}:${item.locationName}`}
-                              className="flex items-center justify-between gap-2 rounded-lg bg-card/40 px-3 py-2"
+                              className="flex items-center justify-between gap-2 px-2 py-1.5"
                             >
                               <span className="min-w-0 flex-1 truncate text-xs font-semibold text-txt">
                                 {item.productTitle}
@@ -651,7 +631,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                                     ? "destructive"
                                     : "secondary"
                                 }
-                                className="shrink-0 rounded-full text-2xs"
+                                className="shrink-0 text-2xs"
                               >
                                 {item.available}
                               </Badge>

--- a/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
+++ b/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
@@ -577,9 +577,7 @@ export function ShopifyAppView({ exitToApps }: OverlayAppContext) {
                           ))
                         )}
                         {orders.length === 0 && !ordersLoading ? (
-                          <p className="text-xs text-muted">
-                            No recent orders.
-                          </p>
+                          <p className="text-xs text-muted">None</p>
                         ) : null}
                       </div>
                     </div>

--- a/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
+++ b/plugins/plugin-shopify-ui/src/ShopifyAppView.tsx
@@ -218,7 +218,7 @@ function ShopifySetupCard() {
           }}
         >
           <Store className="h-4 w-4" />
-          Configure in Settings
+          Settings
         </a>
       </div>
     </div>

--- a/plugins/plugin-shopify-ui/src/StoreOverviewCard.tsx
+++ b/plugins/plugin-shopify-ui/src/StoreOverviewCard.tsx
@@ -14,9 +14,9 @@ interface StoreOverviewCardProps {
 
 export function StoreOverviewCard({ shop }: StoreOverviewCardProps) {
   return (
-    <div className="rounded-2xl bg-card/40 px-4 py-4">
+    <div className="px-2 py-2">
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-border/24 bg-bg-accent">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center">
           <Store className="h-5 w-5 text-muted-strong" />
         </div>
         <div className="min-w-0 flex-1">
@@ -32,7 +32,7 @@ export function StoreOverviewCard({ shop }: StoreOverviewCardProps) {
             <span>{shop.currencyCode}</span>
           </div>
         </div>
-        <div className="rounded-full bg-bg-accent px-2.5 py-1 text-xs font-medium text-muted-strong">
+        <div className="px-1 py-1 text-xs font-medium text-muted-strong">
           {shop.plan}
         </div>
       </div>

--- a/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.test.tsx
+++ b/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.test.tsx
@@ -93,7 +93,6 @@ describe("ShopifySpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Shopify");
       expect(flat).toContain("connected");
       expect(flat).toContain("eliza.myshopify.com");
       expect(flat).toContain("#1001"); // recent order

--- a/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.tsx
+++ b/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.tsx
@@ -179,7 +179,7 @@ function OverviewSection({
       <Divider label="recent orders" />
       {snapshot.orders.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No recent orders
+          None
         </Text>
       ) : (
         <List gap={0} width="100%">
@@ -276,7 +276,7 @@ function ProductsSection({
       </Text>
       {snapshot.products.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No products
+          None
         </Text>
       ) : (
         <List gap={0} width="100%">
@@ -369,7 +369,7 @@ function OrdersSection({
       </Text>
       {snapshot.orders.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No orders
+          None
         </Text>
       ) : (
         <List gap={0} width="100%">
@@ -406,7 +406,7 @@ function InventorySection({ snapshot }: { snapshot: ShopifySnapshot }) {
       </Text>
       {snapshot.inventoryItems.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No inventory
+          None
         </Text>
       ) : (
         <List gap={0} width="100%">
@@ -464,7 +464,7 @@ function CustomersSection({
       </Text>
       {snapshot.customers.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No customers
+          None
         </Text>
       ) : (
         <List gap={0} width="100%">

--- a/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.tsx
+++ b/plugins/plugin-shopify-ui/src/components/ShopifySpatialView.tsx
@@ -271,8 +271,8 @@ function ProductsSection({
         {snapshot.productSearch
           ? `search "${snapshot.productSearch}"`
           : "all products"}{" "}
-        | page {snapshot.productsPage} of {totalPages} | {snapshot.productsTotal}{" "}
-        total
+        | page {snapshot.productsPage} of {totalPages} |{" "}
+        {snapshot.productsTotal} total
       </Text>
       {snapshot.products.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
@@ -351,8 +351,12 @@ function OrdersSection({
         {ORDER_FILTERS.map((filter) => (
           <Button
             key={filter.id}
-            variant={snapshot.orderStatusFilter === filter.id ? "solid" : "outline"}
-            tone={snapshot.orderStatusFilter === filter.id ? "primary" : "default"}
+            variant={
+              snapshot.orderStatusFilter === filter.id ? "solid" : "outline"
+            }
+            tone={
+              snapshot.orderStatusFilter === filter.id ? "primary" : "default"
+            }
             agent={`orders-filter-${filter.id}`}
             onPress={() => onAction?.(`orders:filter:${filter.id}`)}
           >
@@ -532,7 +536,7 @@ export function ShopifySpatialView({
   const shop = snapshot.status?.shop ?? null;
 
   return (
-    <Card title="Shopify" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" width="100%">
         <Text
           style="caption"

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
@@ -46,12 +46,10 @@ describe("SocialAlphaSpatialView one source, three modalities", () => {
 			const lines = renderViewToLines(view, width);
 			for (const line of lines) expect(visibleWidth(line)).toBe(width);
 			const flat = lines.join("\n");
-			expect(flat).toContain("Alpha Leaderboard");
 			expect(flat).toContain("alice");
 			expect(flat).toContain("12.50");
 			expect(flat).toContain("carol");
 			expect(flat).toContain("leading");
-			expect(flat).toContain("callers");
 		}
 	});
 

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
@@ -111,7 +111,7 @@ describe("SocialAlphaSpatialView one source, three modalities", () => {
 			54,
 		);
 		for (const line of lines) expect(visibleWidth(line)).toBe(54);
-		expect(lines.join("\n")).toContain("No callers yet");
+		expect(lines.join("\n")).toContain("No callers");
 	});
 
 	it("error state renders the message and a Retry control", () => {

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.test.tsx
@@ -111,7 +111,7 @@ describe("SocialAlphaSpatialView one source, three modalities", () => {
 			54,
 		);
 		for (const line of lines) expect(visibleWidth(line)).toBe(54);
-		expect(lines.join("\n")).toContain("No callers");
+		expect(lines.join("\n")).toContain("None");
 	});
 
 	it("error state renders the message and a Retry control", () => {

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
@@ -16,15 +16,7 @@
  * displays the snapshot and dispatches actions.
  */
 
-import {
-	Button,
-	Card,
-	Divider,
-	HStack,
-	List,
-	Text,
-	VStack,
-} from "@elizaos/ui/spatial";
+import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
 
 /** A single leaderboard caller, already projected to display shape. */
 export interface LeaderRow {
@@ -80,11 +72,7 @@ export function SocialAlphaSpatialView({
 	const dispatch = (action: string) => () => onAction?.(action);
 
 	return (
-		<Card title="Alpha Leaderboard" gap={1} padding={1}>
-			<Text style="caption" tone="muted">
-				Top callers ranked by trust score.
-			</Text>
-
+		<Card gap={1} padding={1}>
 			{snapshot.state === "loading" ? (
 				<Text tone="muted" align="center" style="caption">
 					Loading leaderboard
@@ -109,15 +97,10 @@ function WalletRequiredBody({
 }) {
 	return (
 		<>
-			<Divider label="wallet" />
 			<Text bold>Wallet required</Text>
-			<Text tone="muted" style="caption">
-				Social Alpha tracks token calls against on-chain outcomes. Configure the
-				agent wallet to enable it.
-			</Text>
 			<HStack gap={1}>
 				<Button agent="connect-wallet" onPress={dispatch("connect-wallet")}>
-					Connect wallet
+					Wallet
 				</Button>
 			</HStack>
 		</>
@@ -133,7 +116,6 @@ function ErrorBody({
 }) {
 	return (
 		<>
-			<Divider label="error" />
 			<Text bold>Could not load leaderboard</Text>
 			<Text tone="danger" style="caption">
 				{snapshot.error ?? "Could not load leaderboard."}
@@ -148,16 +130,7 @@ function ErrorBody({
 }
 
 function EmptyBody() {
-	return (
-		<>
-			<Divider label="empty" />
-			<Text bold>No callers yet</Text>
-			<Text tone="muted" style="caption">
-				No leaderboard data available yet. Be the first to make a
-				recommendation.
-			</Text>
-		</>
-	);
+	return <Text bold>No callers yet</Text>;
 }
 
 function ReadyBody({
@@ -174,7 +147,6 @@ function ReadyBody({
 					{snapshot.leading}
 				</Text>
 			) : null}
-			<Divider label={`callers (${snapshot.rows.length})`} />
 			<List gap={0}>
 				{snapshot.rows.map((row) => (
 					<LeaderRowView key={row.userId} row={row} dispatch={dispatch} />
@@ -213,7 +185,7 @@ function LeaderRowView({
 					variant="ghost"
 					onPress={dispatch(`open:${row.userId}`)}
 				>
-					Open
+					›
 				</Button>
 			</HStack>
 		</VStack>

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
@@ -130,7 +130,7 @@ function ErrorBody({
 }
 
 function EmptyBody() {
-	return <Text bold>No callers</Text>;
+	return <Text bold>None</Text>;
 }
 
 function ReadyBody({

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaSpatialView.tsx
@@ -130,7 +130,7 @@ function ErrorBody({
 }
 
 function EmptyBody() {
-	return <Text bold>No callers yet</Text>;
+	return <Text bold>No callers</Text>;
 }
 
 function ReadyBody({

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.test.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.test.tsx
@@ -143,7 +143,7 @@ describe("SocialAlphaView — states", () => {
 				fetchers: makeFetchers({ fetchLeaderboard: async () => [] }),
 			}),
 		);
-		await screen.findByText("No callers");
+		await screen.findByText("None");
 		expect(screen.queryByText("alice")).toBeNull();
 	});
 

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.test.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.test.tsx
@@ -143,7 +143,7 @@ describe("SocialAlphaView — states", () => {
 				fetchers: makeFetchers({ fetchLeaderboard: async () => [] }),
 			}),
 		);
-		await screen.findByText("No callers yet");
+		await screen.findByText("No callers");
 		expect(screen.queryByText("alice")).toBeNull();
 	});
 

--- a/plugins/plugin-steward-app/src/ApprovalQueue.test.tsx
+++ b/plugins/plugin-steward-app/src/ApprovalQueue.test.tsx
@@ -121,7 +121,7 @@ describe("ApprovalQueue — populated data", () => {
   it("shows the empty state when there are no pending approvals", async () => {
     const props = makeProps([]);
     render(React.createElement(ApprovalQueue, props));
-    expect(await screen.findByText("No pending approvals")).toBeTruthy();
+    expect(await screen.findByText("None")).toBeTruthy();
   });
 
   it("shows an error notice when loading fails", async () => {
@@ -153,7 +153,7 @@ describe("ApprovalQueue — interactive controls", () => {
       3000,
     );
     // Optimistic removal -> empty state appears.
-    expect(await screen.findByText("No pending approvals")).toBeTruthy();
+    expect(await screen.findByText("None")).toBeTruthy();
     // Count decremented (items.length - 1 == 0).
     expect(props.onPendingCountChange).toHaveBeenLastCalledWith(0);
   });

--- a/plugins/plugin-steward-app/src/ApprovalQueue.tsx
+++ b/plugins/plugin-steward-app/src/ApprovalQueue.tsx
@@ -64,7 +64,7 @@ function PendingApprovalActions({
         {...approveElement.agentProps}
         variant="default"
         size="sm"
-        className="h-9 rounded-xl bg-accent px-4 text-xs font-semibold text-accent-fg hover:bg-accent/90"
+        className="h-9 rounded-md bg-accent px-4 text-xs font-semibold text-accent-fg hover:bg-accent/90"
         onClick={() => onApprove(txId)}
         aria-label={`Approve transaction ${txId}`}
       >
@@ -76,7 +76,7 @@ function PendingApprovalActions({
         {...rejectElement.agentProps}
         variant="outline"
         size="sm"
-        className="h-9 rounded-xl border-status-danger/30 px-4 text-xs font-semibold text-status-danger hover:bg-status-danger-bg hover:text-status-danger"
+        className="h-9 rounded-md border-status-danger/30 px-4 text-xs font-semibold text-status-danger hover:bg-status-danger-bg hover:text-status-danger"
         onClick={() => onReject(txId)}
         aria-label={`Reject transaction ${txId}`}
       >
@@ -117,7 +117,7 @@ function RejectReasonInput({
       onChange={(e) => onChange(e.target.value)}
       placeholder="e.g., Unauthorized recipient"
       aria-label="Rejection reason"
-      className="mt-1 h-9 w-full rounded-lg border border-border/40 bg-card/60 px-3 text-sm text-txt placeholder:text-muted/40 focus:border-accent/40 focus:outline-none"
+      className="mt-1 h-9 w-full rounded-md border border-border/40 bg-transparent px-3 text-sm text-txt placeholder:text-muted/40 focus:border-accent/40 focus:outline-none"
     />
   );
 }
@@ -390,7 +390,7 @@ export function ApprovalQueue({
         <PagePanel.Toolbar>
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-txt">Pending</span>
-            <span className="inline-flex min-w-[20px] items-center justify-center rounded-full bg-accent px-1.5 py-0.5 text-2xs font-bold text-accent-fg">
+            <span className="text-2xs font-bold text-muted">
               {items.length}
             </span>
           </div>
@@ -398,7 +398,7 @@ export function ApprovalQueue({
       ) : null}
 
       {/* Approval rows */}
-      <div className="divide-y divide-border/15">
+      <div className="space-y-3">
         {items.map((item) => {
           const tx = item.transaction;
           const reasons = getPolicyReasons(tx.policyResults ?? []);
@@ -471,7 +471,7 @@ export function ApprovalQueue({
 
               {/* Reject reason dialog inline */}
               {rejectDialogTxId === tx.id && (
-                <div className="mt-3 flex items-end gap-2 border-t border-border/15 pt-3">
+                <div className="mt-3 flex items-end gap-2 pt-3">
                   <div className="flex-1">
                     <label
                       className="block text-2xs font-medium text-muted mb-1"

--- a/plugins/plugin-steward-app/src/ApprovalQueue.tsx
+++ b/plugins/plugin-steward-app/src/ApprovalQueue.tsx
@@ -382,7 +382,7 @@ export function ApprovalQueue({
       {!loading && items.length === 0 && !error ? (
         <PagePanel.Empty
           variant={embedded ? "workspace" : "panel"}
-          title="No pending approvals"
+          title="None"
         />
       ) : null}
 

--- a/plugins/plugin-steward-app/src/TransactionHistory.test.tsx
+++ b/plugins/plugin-steward-app/src/TransactionHistory.test.tsx
@@ -147,7 +147,7 @@ describe("TransactionHistory — populated rows", () => {
         setActionNotice: vi.fn(),
       }),
     );
-    expect(await screen.findByText("No transactions yet")).toBeTruthy();
+    expect(await screen.findByText("None")).toBeTruthy();
   });
 
   it("renders an error notice when the fetch rejects", async () => {
@@ -304,7 +304,9 @@ describe("TransactionHistory — interactive controls", () => {
       await Promise.resolve();
     });
 
-    expect(getStewardHistory.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    expect(getStewardHistory.mock.calls.length).toBeGreaterThan(
+      callsAfterMount,
+    );
 
     vi.useRealTimers();
   });

--- a/plugins/plugin-steward-app/src/TransactionHistory.tsx
+++ b/plugins/plugin-steward-app/src/TransactionHistory.tsx
@@ -266,7 +266,7 @@ export function TransactionHistory({
       {!loading && filtered.length === 0 ? (
         <PagePanel.Empty
           variant={embedded ? "workspace" : "panel"}
-          title="No transactions yet"
+          title="None"
         />
       ) : null}
 

--- a/plugins/plugin-steward-app/src/TransactionHistory.tsx
+++ b/plugins/plugin-steward-app/src/TransactionHistory.tsx
@@ -2,7 +2,14 @@
  * Transaction history table — lists all transactions for the agent from Steward vault.
  */
 
-import { Button, PagePanel, Spinner, StatusBadge, statusLabelForState, statusToneForState } from "@elizaos/ui";
+import {
+  Button,
+  PagePanel,
+  Spinner,
+  StatusBadge,
+  statusLabelForState,
+  statusToneForState,
+} from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Copy, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -276,7 +283,7 @@ export function TransactionHistory({
                 setPage(0);
               }}
               aria-label="Status filter"
-              className="h-9 rounded-xl border border-border/50 bg-card/80 px-3 text-sm text-txt focus:border-accent/40 focus:outline-none"
+              className="h-9 rounded-md border border-border/50 bg-transparent px-3 text-sm text-txt focus:border-accent/40 focus:outline-none"
             >
               {STATUS_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -296,7 +303,7 @@ export function TransactionHistory({
                 setPage(0);
               }}
               aria-label="Chain filter"
-              className="h-9 rounded-xl border border-border/50 bg-card/80 px-3 text-sm text-txt focus:border-accent/40 focus:outline-none"
+              className="h-9 rounded-md border border-border/50 bg-transparent px-3 text-sm text-txt focus:border-accent/40 focus:outline-none"
             >
               {CHAIN_OPTIONS.map((opt) => (
                 <option key={String(opt.value)} value={opt.value}>
@@ -314,7 +321,7 @@ export function TransactionHistory({
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-border/20 text-left text-xs font-semibold uppercase tracking-wider text-muted/70">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wider text-muted/70">
                     <th className="px-4 py-3">Time</th>
                     <th className="px-4 py-3">Status</th>
                     <th className="px-4 py-3">To</th>
@@ -323,7 +330,7 @@ export function TransactionHistory({
                     <th className="px-4 py-3">Tx Hash</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-border/10">
+                <tbody>
                   {paginated.map((tx) => (
                     <tr
                       key={tx.id}
@@ -384,7 +391,7 @@ export function TransactionHistory({
 
             {/* Pagination */}
             {pageCount > 1 && (
-              <div className="flex items-center justify-between border-t border-border/20 px-4 py-3">
+              <div className="flex items-center justify-between px-4 py-3">
                 <Button
                   ref={prevPageElement.ref}
                   {...prevPageElement.agentProps}

--- a/plugins/plugin-steward-app/src/components/StewardSpatialView.test.tsx
+++ b/plugins/plugin-steward-app/src/components/StewardSpatialView.test.tsx
@@ -65,7 +65,6 @@ describe("StewardSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(approvalsView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Steward");
       expect(flat).toContain("connected");
       expect(flat).toContain("tx-1");
       expect(flat).toContain("Approve");
@@ -78,7 +77,6 @@ describe("StewardSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(historyView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Steward");
       expect(flat).toContain("tx-1");
       expect(flat).toContain("confirmed");
       expect(flat).toContain("Prev");

--- a/plugins/plugin-steward-app/src/components/StewardSpatialView.tsx
+++ b/plugins/plugin-steward-app/src/components/StewardSpatialView.tsx
@@ -181,7 +181,7 @@ function ApprovalsBody({
       <Divider label="pending approvals" />
       {snapshot.pendingApprovals.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {snapshot.loading ? "loading" : "No pending approvals"}
+          {snapshot.loading ? "Loading" : "None"}
         </Text>
       ) : (
         <List gap={1} width="100%">
@@ -280,7 +280,7 @@ function HistoryBody({
       <Divider label="transaction history" />
       {snapshot.history.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {snapshot.loading ? "loading" : "No transactions"}
+          {snapshot.loading ? "Loading" : "None"}
         </Text>
       ) : (
         <List gap={1} width="100%">

--- a/plugins/plugin-steward-app/src/components/StewardSpatialView.tsx
+++ b/plugins/plugin-steward-app/src/components/StewardSpatialView.tsx
@@ -349,7 +349,7 @@ export function StewardSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
   const title = snapshot.tab === "approvals" ? "Approvals" : "History";
   return (
-    <Card title="Steward" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" width="100%">
         <Text
           style="caption"

--- a/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
@@ -367,7 +367,7 @@ describe("CodingAgentTasksPanel — list", () => {
     listCodingAgentTaskThreads.mockResolvedValue([]);
     render(<CodingAgentTasksPanel />);
     expect(await screen.findByTestId("task-empty-state")).toBeTruthy();
-    expect(screen.getByText("No coding tasks yet")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
   });
 });
 

--- a/plugins/plugin-task-coordinator/src/AgentTabsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/AgentTabsSection.tsx
@@ -76,12 +76,12 @@ export function AgentTabsSection({
               key={agent}
               variant={active ? "default" : "ghost"}
               size="sm"
-              className={`flex-1 h-9 rounded-lg border px-3 py-2 text-xs font-semibold ${
+              className={`h-8 flex-1 px-2 text-xs font-semibold ${
                 active
                   ? "bg-accent text-accent-fg dark:text-accent-fg shadow-sm"
                   : needsAuth
-                    ? "border-warn/30 text-warn hover:bg-warn/10 hover:text-warn"
-                    : "border-transparent text-muted hover:bg-bg-hover hover:text-txt"
+                    ? "text-warn hover:bg-warn/10 hover:text-warn"
+                    : "text-muted hover:bg-bg-hover hover:text-txt"
               }`}
               onClick={() => onSelectAgent(agent)}
               aria-label={`${AGENT_LABELS[agent]} ${statusLabel}`}
@@ -102,7 +102,7 @@ export function AgentTabsSection({
       </SettingsControls.SegmentedGroup>
 
       {activeTab && activeNeedsAuth && (
-        <div className="mt-1.5 flex items-center justify-between gap-2 rounded-lg border border-warn/25 bg-warn/5 px-2.5 py-2 text-xs text-warn">
+        <div className="mt-1.5 flex items-center justify-between gap-2 px-1 py-1 text-xs text-warn">
           <div className="inline-flex min-w-0 items-center gap-1.5">
             <KeyRound className="h-3.5 w-3.5 shrink-0" aria-hidden />
             <span className="truncate">
@@ -115,7 +115,7 @@ export function AgentTabsSection({
             variant="ghost"
             size="sm"
             disabled={activeAuthenticating}
-            className="h-7 shrink-0 rounded-md px-2 text-xs font-semibold text-warn hover:bg-warn/10 hover:text-warn"
+            className="h-7 shrink-0 px-2 text-xs font-semibold text-warn hover:bg-warn/10 hover:text-warn"
             onClick={() => onAuth(activeTab)}
           >
             {activeAuthenticating ? (
@@ -166,7 +166,7 @@ export function AgentTabsSection({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 rounded-md"
+                className="h-7 w-7"
                 aria-label={t("codingagentsettingssection.Retry", {
                   defaultValue: "Retry",
                 })}

--- a/plugins/plugin-task-coordinator/src/CodingAgentControlChip.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentControlChip.tsx
@@ -41,7 +41,7 @@ export function CodingAgentControlChip() {
   if (sessions.length === 0) return null;
 
   return (
-    <div className="mb-2 flex items-center justify-between gap-2 rounded-2xl border border-border/28 bg-card/50 px-3 py-1.5 ring-1 ring-inset ring-white/6">
+    <div className="mb-2 flex items-center justify-between gap-2 px-1 py-1">
       <div className="flex min-w-0 items-center gap-1.5 text-xs-tight text-muted">
         <Terminal
           className="h-3.5 w-3.5 shrink-0 text-muted-strong"
@@ -58,7 +58,7 @@ export function CodingAgentControlChip() {
         type="button"
         variant="outline"
         size="sm"
-        className="h-7 shrink-0 gap-1 px-2.5 text-xs-tight"
+        className="h-7 shrink-0 gap-1 px-2 text-xs-tight"
         onClick={stopAll}
         title={t("codingagentcontrolchip.StopAllTitle", {
           defaultValue: "Stop all coding agent sessions",

--- a/plugins/plugin-task-coordinator/src/CodingAgentSettingsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentSettingsSection.tsx
@@ -33,13 +33,11 @@ function AgentAdvancedSettingsDisclosure({
   children: ReactNode;
 }) {
   return (
-    <details className="group rounded-xl border border-border/60 bg-card/45 px-3 py-2">
-      <summary className="cursor-pointer select-none list-none text-xs font-semibold uppercase tracking-wide text-muted transition-colors hover:text-txt">
+    <details className="group px-1 py-1">
+      <summary className="cursor-pointer select-none list-none text-xs font-medium text-muted transition-colors hover:text-txt">
         Defaults and workspace
       </summary>
-      <div className="mt-3 flex flex-col gap-4 border-t border-border/40 pt-3">
-        {children}
-      </div>
+      <div className="mt-3 flex flex-col gap-4">{children}</div>
     </details>
   );
 }
@@ -385,14 +383,14 @@ export function CodingAgentSettingsSection() {
             return (
               <div
                 key={agent}
-                className="flex items-center justify-between gap-3 rounded-lg border border-border/40 bg-card/40 px-3 py-2"
+                className="flex items-center justify-between gap-3 px-1 py-1.5"
               >
                 <div className="min-w-0">
                   <div className="font-semibold text-txt">
                     {AGENT_LABELS[agent]}
                   </div>
                   {preflight?.installCommand ? (
-                    <code className="inline-flex max-w-full items-center gap-1 truncate rounded border border-border/50 bg-bg px-1.5 py-0.5 text-2xs text-muted-strong">
+                    <code className="inline-flex max-w-full items-center gap-1 truncate text-2xs text-muted-strong">
                       <Terminal className="h-3 w-3 shrink-0" aria-hidden />
                       <span className="truncate">
                         {preflight.installCommand}

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -276,7 +276,7 @@ function ThreadDetailContent({
         {(detail.sessions ?? []).length === 0 ? (
           <div className="text-xs-tight text-muted">
             {t("codingagenttaskspanel.noSessionsRecorded", {
-              defaultValue: "No sessions recorded.",
+              defaultValue: "None",
             })}
           </div>
         ) : (
@@ -297,7 +297,7 @@ function ThreadDetailContent({
                     {session.workdir ||
                       session.repo ||
                       t("codingagenttaskspanel.noWorkspace", {
-                        defaultValue: "No workspace",
+                        defaultValue: "None",
                       })}
                   </div>
                   {getWorkspaceChangesSummary(session.metadata) ? (
@@ -940,13 +940,13 @@ export function CodingAgentTasksPanel(_props: { fullPage?: boolean } = {}) {
       ) : loading ? (
         <div className="text-sm text-muted">
           {t("codingagenttaskspanel.loadingTasks", {
-            defaultValue: "Loading tasks…",
+            defaultValue: "Loading",
           })}
         </div>
       ) : (
         <TaskEmptyState
           title={t("codingagenttaskspanel.empty.title", {
-            defaultValue: "No coding tasks yet",
+            defaultValue: "None",
           })}
           hint={t("codingagenttaskspanel.empty.hint", {
             defaultValue:

--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
@@ -94,7 +94,7 @@ export function GitHubConnectionCard() {
     submitState.kind === "error" ? submitState.message : null;
 
   return (
-    <div className="space-y-3 rounded-lg border border-border/20 bg-card/14 px-3 py-3">
+    <div className="space-y-3 px-1 py-1">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <GitPullRequest className="h-4 w-4 text-muted" aria-hidden />
@@ -138,11 +138,11 @@ export function GitHubConnectionCard() {
             </div>
           ) : (
             <div className="text-muted">
-              Scopes: <span className="text-amber-500">(none reported)</span>
+              Scopes: <span className="text-amber-500">none</span>
             </div>
           )}
           <div className="flex items-center justify-between pt-1">
-            <span className="text-muted">
+            <span className="sr-only">
               Coding sub-agents will use this token for git/gh operations.
             </span>
             <Button
@@ -158,7 +158,7 @@ export function GitHubConnectionCard() {
         </div>
       ) : (
         <div className="flex flex-col gap-2 text-xs">
-          <p className="text-muted">
+          <p className="sr-only">
             Paste a personal access token so coding sub-agents can clone private
             repos, push commits, and open pull requests.
           </p>

--- a/plugins/plugin-task-coordinator/src/GlobalPrefsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/GlobalPrefsSection.tsx
@@ -84,7 +84,7 @@ export function GlobalPrefsSection({
             </SelectItem>
           </SelectContent>
         </Select>
-        <SettingsControls.FieldDescription className="mt-1.5">
+        <SettingsControls.FieldDescription className="sr-only">
           {selectionStrategy === "fixed"
             ? t("codingagentsettingssection.AgentUsedWhenNoEStrategyFixed")
             : t("codingagentsettingssection.AgentUsedWhenNoEStrategyRanked")}
@@ -118,7 +118,7 @@ export function GlobalPrefsSection({
             ))}
           </SelectContent>
         </Select>
-        <SettingsControls.FieldDescription className="mt-1.5">
+        <SettingsControls.FieldDescription className="sr-only">
           {t("codingagentsettingssection.AccountPoolStrategyDesc", {
             defaultValue:
               "How to select between multiple accounts for the same coding agent. This sets ELIZA_CODING_ACCOUNT_STRATEGY for spawned agents.",
@@ -147,7 +147,7 @@ export function GlobalPrefsSection({
             ))}
           </SelectContent>
         </Select>
-        <SettingsControls.FieldDescription className="mt-1.5">
+        <SettingsControls.FieldDescription className="sr-only">
           {APPROVAL_PRESETS.find((preset) => preset.value === approvalPreset)
             ?.descKey
             ? t(
@@ -195,7 +195,7 @@ export function GlobalPrefsSection({
             </SelectItem>
           </SelectContent>
         </Select>
-        <SettingsControls.FieldDescription>
+        <SettingsControls.FieldDescription className="sr-only">
           {t("codingagentsettingssection.ScratchRetentionDesc", {
             defaultValue:
               "What happens to scratch workspace code when a task finishes.",
@@ -213,7 +213,7 @@ export function GlobalPrefsSection({
           initial={prefs.ELIZA_CODING_DIRECTORY || ""}
           onCommit={(val) => setPref("ELIZA_CODING_DIRECTORY", val)}
         />
-        <SettingsControls.FieldDescription>
+        <SettingsControls.FieldDescription className="sr-only">
           {t("codingagentsettingssection.CodingDirectoryDesc", {
             defaultValue:
               "Where scratch task code is saved. Leave empty for default (~/.eliza/workspaces/).",

--- a/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
+++ b/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
@@ -167,15 +167,13 @@ export function LlmProviderSection({
             <SettingsControls.MutedText
               className="inline-flex items-center gap-1.5 text-xs text-warn"
               title={t("codingagentsettingssection.CloudUnpaired", {
-                defaultValue:
-                  "No Eliza Cloud account connected. Pair your account in the Cloud settings section first.",
+                defaultValue: "Unavailable",
               })}
             >
               <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
               <span className="sr-only">
                 {t("codingagentsettingssection.CloudUnpaired", {
-                  defaultValue:
-                    "No Eliza Cloud account connected. Pair your account in the Cloud settings section first.",
+                  defaultValue: "Unavailable",
                 })}
               </span>
             </SettingsControls.MutedText>

--- a/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
+++ b/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
@@ -67,9 +67,9 @@ export function LlmProviderSection({
               <Button
                 key={option.value}
                 type="button"
-                variant={active ? "default" : "outline"}
+                variant={active ? "default" : "ghost"}
                 size="sm"
-                className="h-9 justify-start rounded-lg px-2.5 text-xs font-semibold"
+                className="h-8 justify-start px-2 text-xs font-semibold"
                 onClick={() => setPref("ELIZA_LLM_PROVIDER", option.value)}
                 aria-pressed={active}
               >
@@ -148,20 +148,36 @@ export function LlmProviderSection({
       {isCloud && (
         <div className="flex flex-col gap-3">
           {prefs._CLOUD_API_KEY ? (
-            <SettingsControls.MutedText className="inline-flex items-center gap-1.5 text-xs text-ok">
-              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-              {t("codingagentsettingssection.CloudPaired", {
+            <SettingsControls.MutedText
+              className="inline-flex items-center gap-1.5 text-xs text-ok"
+              title={t("codingagentsettingssection.CloudPaired", {
                 defaultValue:
                   "Using your Eliza Cloud account for coding agent LLM calls.",
               })}
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+              <span className="sr-only">
+                {t("codingagentsettingssection.CloudPaired", {
+                  defaultValue:
+                    "Using your Eliza Cloud account for coding agent LLM calls.",
+                })}
+              </span>
             </SettingsControls.MutedText>
           ) : (
-            <SettingsControls.MutedText className="inline-flex items-center gap-1.5 text-xs text-warn">
-              <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
-              {t("codingagentsettingssection.CloudUnpaired", {
+            <SettingsControls.MutedText
+              className="inline-flex items-center gap-1.5 text-xs text-warn"
+              title={t("codingagentsettingssection.CloudUnpaired", {
                 defaultValue:
                   "No Eliza Cloud account connected. Pair your account in the Cloud settings section first.",
               })}
+            >
+              <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+              <span className="sr-only">
+                {t("codingagentsettingssection.CloudUnpaired", {
+                  defaultValue:
+                    "No Eliza Cloud account connected. Pair your account in the Cloud settings section first.",
+                })}
+              </span>
             </SettingsControls.MutedText>
           )}
         </div>

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -920,7 +920,7 @@ function SubAgentCard({
   const workspace =
     session.repo ||
     session.workdir ||
-    t("orchestrator.noWorkspace", { defaultValue: "No workspace" });
+    t("orchestrator.noWorkspace", { defaultValue: "None" });
   const stopLabel = t("orchestrator.action.stopAgent", {
     defaultValue: "Stop agent",
   });
@@ -3578,13 +3578,13 @@ export function OrchestratorWorkbench() {
               loading ? (
                 <p className="p-2 text-sm text-muted">
                   {t("orchestrator.loadingTasks", {
-                    defaultValue: "Loading tasks…",
+                    defaultValue: "Loading",
                   })}
                 </p>
               ) : (
                 <TaskEmptyState
                   title={t("orchestrator.empty.title", {
-                    defaultValue: "No tasks yet",
+                    defaultValue: "None",
                   })}
                   hint={t("orchestrator.empty.hint", {
                     defaultValue:

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -570,10 +570,8 @@ function renderCost(
     : value;
 }
 
-/** A vertical hairline divider between header summary segments (the token kit
- * has no Separator export, so this is a thin local primitive). */
 /** One labeled count in the header summary — a baseline-aligned number + tiny
- * uppercase label, no pill/border (replaces the old cryptic icon chips). */
+ * label, no pill/border. */
 function HeaderStat({
   value,
   label,
@@ -588,15 +586,12 @@ function HeaderStat({
       <span className={`text-sm font-semibold tabular-nums ${toneClass}`}>
         {value}
       </span>
-      <span className="text-2xs uppercase tracking-[0.08em] text-muted">
-        {label}
-      </span>
+      <span className="text-2xs text-muted">{label}</span>
     </span>
   );
 }
 
-/** A borderless inspector section: a small uppercase label over its content,
- * separated from its neighbours by whitespace alone — no card, no border. */
+/** Borderless inspector section separated by whitespace alone. */
 function InspectorSection({
   title,
   action,
@@ -609,9 +604,7 @@ function InspectorSection({
   return (
     <section className="space-y-1.5">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted/70">
-          {title}
-        </h3>
+        <h3 className="text-xs font-medium text-muted">{title}</h3>
         {action}
       </div>
       {children}
@@ -639,7 +632,7 @@ function WorkbenchHeader({
   const title = (
     <div className="flex shrink-0 items-center gap-2">
       <Layers className="h-4 w-4 text-accent" />
-      <span className="text-sm font-semibold tracking-tight text-txt-strong">
+      <span className="text-sm font-semibold text-txt-strong">
         {t("orchestrator.title", { defaultValue: "Orchestrator" })}
       </span>
     </div>
@@ -829,7 +822,7 @@ function FilterSelect({
         ref={ref}
         aria-label={filterLabel}
         data-testid="orchestrator-filter"
-        className="h-9 rounded-xl border-0 bg-bg-accent/30 text-xs"
+        className="h-9 border-0 bg-transparent px-1 text-xs"
         {...agentProps}
       >
         <span className="flex items-center gap-2">
@@ -861,7 +854,7 @@ function FilterSelect({
   );
 }
 
-/** Visual metadata chips for an orchestrator task card. */
+/** Visual metadata for an orchestrator task row. */
 function orchestratorTaskChips(
   thread: CodingAgentTaskThread,
   t: Translate,
@@ -951,7 +944,7 @@ function SubAgentCard({
       description: `Stop the "${session.label}" sub-agent`,
     });
   return (
-    <div className="rounded-md bg-bg/40 p-2">
+    <div className="py-1">
       <div className="flex items-center gap-1.5">
         <SessionGlyph status={session.status} t={t} />
         <span className="min-w-0 flex-1 truncate text-xs font-medium text-txt">
@@ -961,7 +954,7 @@ function SubAgentCard({
           ref={inspectRef}
           type="button"
           onClick={() => onInspect(session.sessionId)}
-          className="flex items-center gap-0.5 rounded px-1 py-0.5 text-2xs text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+          className="flex items-center gap-0.5 px-1 py-0.5 text-2xs text-muted transition-colors hover:text-txt"
           data-testid="orchestrator-inspect-session"
           aria-label={inspectLabel}
           title={inspectLabel}
@@ -975,7 +968,7 @@ function SubAgentCard({
             type="button"
             disabled={busy}
             onClick={() => onStop(session.sessionId)}
-            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-2xs text-muted transition-colors hover:bg-danger/10 hover:text-danger disabled:opacity-50"
+            className="flex items-center gap-0.5 px-1 py-0.5 text-2xs text-muted transition-colors hover:text-danger disabled:opacity-50"
             data-testid="orchestrator-stop-agent"
             aria-label={stopLabel}
             {...stopAgentProps}
@@ -1151,7 +1144,7 @@ function EditedPlanRestartSection({
           type="button"
           disabled={busy}
           onClick={() => setOpen((prev) => !prev)}
-          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-2xs font-semibold text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt disabled:opacity-50"
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 px-1 text-2xs font-semibold text-muted transition-colors hover:text-txt disabled:opacity-50"
           data-testid="orchestrator-plan-edit-toggle"
           {...toggleAgentProps}
         >
@@ -1326,11 +1319,11 @@ function UsageSection({
 }
 
 const FIELD_CLASS =
-  "w-full rounded-sm bg-bg-accent/40 px-2.5 py-1.5 text-xs text-txt outline-none transition-colors placeholder:text-muted focus:bg-bg-accent/70";
+  "w-full border-border/35 border-b bg-transparent px-1 py-1.5 text-xs text-txt outline-none transition-colors placeholder:text-muted focus:border-accent/60";
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return (
-    <span className="mb-1 block text-2xs font-semibold uppercase tracking-[0.08em] text-muted">
+    <span className="mb-1 block text-xs font-medium text-muted">
       {children}
     </span>
   );
@@ -1468,7 +1461,7 @@ function AddAgentForm({
     });
 
   return (
-    <div className="mt-1.5 space-y-1.5 rounded-md bg-bg/40 p-2">
+    <div className="mt-1.5 space-y-1.5">
       <input
         ref={labelRef}
         value={label}
@@ -1588,10 +1581,10 @@ function ControlButton({
       onClick={onClick}
       aria-label={label}
       title={label}
-      className={`flex items-center justify-center rounded-md p-1.5 transition-colors disabled:opacity-50 ${
+      className={`flex items-center justify-center p-1.5 transition-colors disabled:opacity-50 ${
         tone === "danger"
-          ? "text-muted hover:bg-danger/10 hover:text-danger"
-          : "text-muted hover:bg-bg-hover/60 hover:text-txt"
+          ? "text-muted hover:text-danger"
+          : "text-muted hover:text-txt"
       }`}
       data-testid={testId}
       {...agentProps}
@@ -1631,7 +1624,7 @@ function RecoveryActionButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-2xs font-semibold text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt disabled:opacity-50"
+      className="inline-flex h-7 items-center gap-1.5 px-1 text-2xs font-semibold text-muted transition-colors hover:text-txt disabled:opacity-50"
       data-testid={testId}
       {...agentProps}
     >
@@ -1756,14 +1749,14 @@ export function TaskInspector({
     >
       {onClose ? (
         <div className="flex items-center justify-between">
-          <h3 className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted">
+          <h3 className="text-xs font-medium text-muted">
             {t("orchestrator.inspector.title", { defaultValue: "Details" })}
           </h3>
           <button
             ref={closeRef}
             type="button"
             onClick={onClose}
-            className="-mr-1 rounded p-1 text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+            className="-mr-1 p-1 text-muted transition-colors hover:text-txt"
             aria-label={closeDetailsLabel}
             data-testid="orchestrator-close-inspector"
             {...closeAgentProps}
@@ -1902,7 +1895,7 @@ export function TaskInspector({
               const next = paramPriority(event.target.value);
               if (next && next !== detail.priority) onSetPriority(next);
             }}
-            className="rounded-md bg-bg-accent/30 px-2 py-1 text-2xs text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt disabled:opacity-50"
+            className="border-border/35 border-b bg-transparent px-1 py-1 text-2xs text-muted transition-colors hover:border-accent/60 hover:text-txt disabled:opacity-50"
             data-testid="orchestrator-priority-select"
             {...priorityAgentProps}
           >
@@ -2097,7 +2090,7 @@ function JsonBlock({
     typeof value === "string" ? value : JSON.stringify(value, null, 2);
   return (
     <pre
-      className="max-h-72 overflow-auto rounded-md bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-muted"
+      className="max-h-72 overflow-auto bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-muted"
       data-testid="orchestrator-detail-json"
     >
       {compactText(text)}
@@ -2144,7 +2137,7 @@ function OperatorTabs({
   ];
   return (
     <div
-      className="flex rounded-md bg-bg/40 p-0.5"
+      className="flex gap-2"
       role="tablist"
       aria-label={t("orchestrator.detail.tabsLabel", {
         defaultValue: "Detail tabs",
@@ -2157,10 +2150,8 @@ function OperatorTabs({
           role="tab"
           aria-selected={active === tab.id}
           onClick={() => onSelect(tab.id)}
-          className={`flex-1 rounded px-2 py-1 text-2xs font-semibold uppercase tracking-[0.08em] transition-colors ${
-            active === tab.id
-              ? "bg-bg-hover text-txt-strong"
-              : "text-muted hover:bg-bg-hover/50 hover:text-txt"
+          className={`flex-1 px-1 py-1 text-xs font-medium transition-colors ${
+            active === tab.id ? "text-accent" : "text-muted hover:text-txt"
           }`}
         >
           {tab.label}
@@ -2358,9 +2349,7 @@ function OperatorDrawerShell({
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <h3 className="truncate text-2xs font-semibold uppercase tracking-[0.08em] text-muted">
-            {title}
-          </h3>
+          <h3 className="truncate text-xs font-medium text-muted">{title}</h3>
           <p className="mt-0.5 truncate text-xs-tight font-medium text-txt">
             {subtitle}
           </p>
@@ -2368,7 +2357,7 @@ function OperatorDrawerShell({
         <button
           type="button"
           onClick={onClose}
-          className="-mr-1 rounded p-1 text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+          className="-mr-1 p-1 text-muted transition-colors hover:text-txt"
           aria-label={closeLabel}
           data-testid="orchestrator-close-operator-detail"
         >
@@ -2420,10 +2409,7 @@ function EventList({
         if (item.kind === "message") {
           const message = item.record;
           return (
-            <div
-              key={`message-${message.id}`}
-              className="rounded-md bg-bg/40 p-2"
-            >
+            <div key={`message-${message.id}`} className="py-1">
               <div className="mb-1 flex items-center gap-2 text-2xs text-muted">
                 <span className="font-semibold text-txt">
                   {message.senderKind}
@@ -2444,7 +2430,7 @@ function EventList({
         }
         const event = item.record;
         return (
-          <div key={`event-${event.id}`} className="rounded-md bg-bg/40 p-2">
+          <div key={`event-${event.id}`} className="py-1">
             <div className="mb-1 flex items-center gap-2 text-2xs text-muted">
               <span className="font-semibold text-txt">
                 {event.eventType.replace(/_/g, " ")}
@@ -2711,7 +2697,7 @@ function OperatorDetailDrawer({
       );
     } else if (block?.kind === "user") {
       body = (
-        <pre className="whitespace-pre-wrap rounded-md bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
+        <pre className="whitespace-pre-wrap bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
           {block.content}
         </pre>
       );
@@ -2791,13 +2777,13 @@ function OperatorDetailDrawer({
       );
     } else if (block?.kind === "agent" || block?.kind === "user") {
       body = (
-        <pre className="whitespace-pre-wrap rounded-md bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
+        <pre className="whitespace-pre-wrap bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
           {compactText(block.content)}
         </pre>
       );
     } else if (block?.kind === "reasoning") {
       body = (
-        <pre className="whitespace-pre-wrap rounded-md bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
+        <pre className="whitespace-pre-wrap bg-bg/60 px-2.5 py-1.5 text-xs-tight text-txt">
           {compactText(block.text)}
         </pre>
       );
@@ -2831,7 +2817,7 @@ function OperatorDetailDrawer({
       onClose={onClose}
     >
       <ErrorFirstBanner text={errorText} />
-      <div className="space-y-1.5 rounded-md bg-bg/40 p-2">
+      <div className="space-y-1.5">
         {session ? (
           <>
             <DetailRow
@@ -2855,11 +2841,8 @@ function OperatorDetailDrawer({
         ) : null}
       </div>
       {recoveryActions.length > 0 ? (
-        <div
-          className="space-y-1.5 rounded-md bg-bg/40 p-2"
-          data-testid="orchestrator-detail-recovery"
-        >
-          <div className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted">
+        <div className="space-y-1.5" data-testid="orchestrator-detail-recovery">
+          <div className="text-xs font-medium text-muted">
             {label("recovery", "Recovery")}
           </div>
           <div className="flex flex-wrap gap-1.5">{recoveryActions}</div>
@@ -2989,7 +2972,7 @@ function TimelineHeader({
             ref={backRef}
             type="button"
             onClick={onBack}
-            className="-ml-1 shrink-0 rounded p-1 text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+            className="-ml-1 shrink-0 p-1 text-muted transition-colors hover:text-txt"
             aria-label={backLabel}
             data-testid="orchestrator-back"
             {...backAgentProps}
@@ -3002,7 +2985,7 @@ function TimelineHeader({
             ref={detailsRef}
             type="button"
             onClick={onOpenInspector}
-            className="shrink-0 rounded-md p-1 text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+            className="shrink-0 p-1 text-muted transition-colors hover:text-txt"
             aria-label={detailsLabel}
             title={detailsLabel}
             data-testid="orchestrator-open-inspector"
@@ -3028,7 +3011,7 @@ function TimelineHeader({
         ref={detailsRef}
         type="button"
         onClick={onOpenInspector}
-        className="shrink-0 rounded-md p-1 text-muted transition-colors hover:bg-bg-hover/60 hover:text-txt"
+        className="shrink-0 p-1 text-muted transition-colors hover:text-txt"
         aria-label={detailsLabel}
         title={detailsLabel}
         data-testid="orchestrator-open-inspector"
@@ -3579,10 +3562,8 @@ export function OrchestratorWorkbench() {
                   type="button"
                   onClick={() => setShowArchived((value) => !value)}
                   aria-pressed={showArchived}
-                  className={`inline-flex h-9 items-center gap-2 rounded-xl px-3 text-xs font-medium transition-colors ${
-                    showArchived
-                      ? "bg-accent-subtle text-accent"
-                      : "bg-bg-accent/30 text-muted hover:text-txt"
+                  className={`inline-flex h-9 items-center gap-2 px-2 text-xs font-medium transition-colors ${
+                    showArchived ? "text-accent" : "text-muted hover:text-txt"
                   }`}
                   data-testid="orchestrator-show-archived"
                   {...showArchivedAgentProps}
@@ -3635,7 +3616,7 @@ export function OrchestratorWorkbench() {
 
         {/* Task room — full-pane detail, entered by clicking a card. */}
         <main
-          className="flex min-h-0 min-w-0 flex-1 flex-col bg-bg-accent/10"
+          className="flex min-h-0 min-w-0 flex-1 flex-col bg-bg"
           data-testid="orchestrator-timeline"
           style={selectedId ? undefined : HIDDEN_STYLE}
         >
@@ -3663,7 +3644,7 @@ export function OrchestratorWorkbench() {
                       ref={loadOlderRef}
                       type="button"
                       onClick={() => void loadOlderTimeline()}
-                      className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-2xs text-muted transition-colors hover:bg-bg-hover/50"
+                      className="flex items-center gap-1 px-1 py-0.5 text-2xs text-muted transition-colors hover:text-txt"
                       data-testid="orchestrator-load-older"
                       aria-label={loadOlderLabel}
                       {...loadOlderAgentProps}
@@ -3687,17 +3668,15 @@ export function OrchestratorWorkbench() {
                     return (
                       <div
                         key={block.key}
-                        className={`group flex gap-1.5 rounded-md transition-colors ${
-                          selected
-                            ? "bg-accent-subtle ring-1 ring-accent/60"
-                            : "hover:bg-bg-hover/30"
+                        className={`group flex gap-1.5 transition-colors ${
+                          selected ? "text-accent" : "hover:bg-bg-hover/30"
                         }`}
                         data-testid="orchestrator-conversation-block"
                       >
                         <button
                           type="button"
                           onClick={() => handleSelectBlock(block)}
-                          className="mt-1.5 flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted opacity-0 transition-colors hover:bg-bg-hover/60 hover:text-txt focus:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+                          className="mt-1.5 flex h-6 w-6 shrink-0 items-center justify-center text-muted opacity-0 transition-colors hover:text-txt focus:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
                           aria-label={t("orchestrator.action.inspectBlock", {
                             defaultValue: `Inspect ${blockTitle(block, t)}`,
                           })}
@@ -3736,14 +3715,14 @@ export function OrchestratorWorkbench() {
                     type="button"
                     onClick={handleStopActive}
                     disabled={mutating}
-                    className="flex items-center gap-1 rounded-md px-2 py-0.5 text-2xs text-txt transition-colors hover:bg-danger/10 hover:text-danger disabled:opacity-50"
+                    className="flex items-center gap-1 px-1 py-0.5 text-2xs text-txt transition-colors hover:text-danger disabled:opacity-50"
                     data-testid="orchestrator-stop-active"
                     aria-label={stopLabel}
                     {...stopActiveAgentProps}
                   >
                     <CircleStop className="h-3 w-3" />
                     {stopLabel}
-                    <kbd className="ml-0.5 rounded bg-bg-hover/60 px-1 text-[0.9em] text-muted">
+                    <kbd className="ml-0.5 px-1 text-[0.9em] text-muted">
                       Esc
                     </kbd>
                   </button>

--- a/plugins/plugin-task-coordinator/src/PtyConsoleDrawer.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyConsoleDrawer.tsx
@@ -90,7 +90,7 @@ export function PtyConsoleDrawer({
           />
         ) : (
           <div className="flex h-full items-center justify-center text-xs text-muted">
-            No terminal session selected
+            None
           </div>
         )}
       </div>

--- a/plugins/plugin-task-coordinator/src/TaskCardList.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCardList.tsx
@@ -35,87 +35,65 @@ interface StatusVisual {
   icon: LucideIcon;
   /** Foreground icon tone. */
   fg: string;
-  /** Medallion background tint. */
-  tint: string;
-  /** Medallion ring tone — keeps the circle legible against the card. */
-  ring: string;
   /** Status-dot color for the trailing chip. */
   dot: string;
   pulse: boolean;
 }
 
-// Single source of per-status visuals. Tints lean on theme tokens only — orange
-// accent for in-flight, ok/warn/danger for terminal/attention, muted for idle.
+// Single source of per-status visuals. Use color and iconography instead of
+// boxed badges so the task lists stay dense.
 const STATUS_VISUAL: Record<TaskCardStatus, StatusVisual> = {
   open: {
     icon: Circle,
     fg: "text-accent",
-    tint: "bg-accent-subtle",
-    ring: "ring-accent/25",
     dot: "bg-accent",
     pulse: false,
   },
   active: {
     icon: CirclePlay,
     fg: "text-ok",
-    tint: "bg-ok/12",
-    ring: "ring-ok/25",
     dot: "bg-ok",
     pulse: true,
   },
   validating: {
     icon: CircleDashed,
     fg: "text-accent",
-    tint: "bg-accent-subtle",
-    ring: "ring-accent/25",
     dot: "bg-accent",
     pulse: true,
   },
   waiting_on_user: {
     icon: UserRound,
     fg: "text-warn",
-    tint: "bg-warn/12",
-    ring: "ring-warn/25",
     dot: "bg-warn",
     pulse: false,
   },
   blocked: {
     icon: OctagonX,
     fg: "text-warn",
-    tint: "bg-warn/12",
-    ring: "ring-warn/25",
     dot: "bg-warn",
     pulse: false,
   },
   interrupted: {
     icon: CircleAlert,
     fg: "text-warn",
-    tint: "bg-warn/12",
-    ring: "ring-warn/25",
     dot: "bg-warn",
     pulse: false,
   },
   done: {
     icon: CircleCheck,
     fg: "text-ok",
-    tint: "bg-ok/12",
-    ring: "ring-ok/25",
     dot: "bg-ok",
     pulse: false,
   },
   failed: {
     icon: CircleX,
     fg: "text-danger",
-    tint: "bg-danger/12",
-    ring: "ring-danger/25",
     dot: "bg-danger",
     pulse: false,
   },
   archived: {
     icon: Archive,
     fg: "text-muted",
-    tint: "bg-surface",
-    ring: "ring-border",
     dot: "bg-muted",
     pulse: false,
   },
@@ -131,11 +109,11 @@ export function statusLabel(status: string, t: Translate): string {
   });
 }
 
-/** Round status medallion — the card's primary visual anchor. */
+/** Status icon — the row's primary visual anchor. */
 export function TaskStatusMedallion({
   status,
-  size = "h-11 w-11",
-  iconSize = "h-5 w-5",
+  size = "h-8 w-8",
+  iconSize = "h-4 w-4",
 }: {
   status: string;
   size?: string;
@@ -145,7 +123,7 @@ export function TaskStatusMedallion({
   const Icon = visual.icon;
   return (
     <span
-      className={`relative inline-flex shrink-0 items-center justify-center rounded-2xl ring-1 ${size} ${visual.tint} ${visual.ring}`}
+      className={`relative inline-flex shrink-0 items-center justify-center ${size}`}
     >
       <Icon
         className={`${iconSize} ${visual.fg}${visual.pulse ? " animate-pulse" : ""}`}
@@ -166,7 +144,7 @@ export function TaskStatusChip({
   const visual = statusVisual(status);
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-2xs font-semibold ${visual.tint} ${visual.fg}`}
+      className={`inline-flex items-center gap-1.5 text-2xs font-medium ${visual.fg}`}
     >
       <span
         className={`h-1.5 w-1.5 rounded-full ${visual.dot}${visual.pulse ? " animate-pulse" : ""}`}
@@ -188,7 +166,7 @@ export function TaskMetaChip({
 }) {
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-md bg-surface px-1.5 py-0.5 text-2xs tabular-nums ${
+      className={`inline-flex items-center gap-1 text-2xs tabular-nums ${
         tone === "accent" ? "text-accent" : "text-muted"
       }`}
     >
@@ -200,8 +178,7 @@ export function TaskMetaChip({
   );
 }
 
-/** Softened search field — rounded surface pill with an inset search glyph.
- * Shared so both landings read identically. */
+/** Search field shared so both landings read identically. */
 export function TaskSearchInput({
   value,
   onChange,
@@ -221,10 +198,10 @@ export function TaskSearchInput({
 }) {
   return (
     <div
-      className={`relative flex h-9 items-center rounded-full border border-border/50 bg-surface/60 transition-colors focus-within:border-accent/50 focus-within:bg-surface ${className ?? "flex-1"}`}
+      className={`relative flex h-9 items-center border-border/35 border-b transition-colors focus-within:border-accent/60 ${className ?? "flex-1"}`}
     >
       <Search
-        className="pointer-events-none absolute left-3 h-3.5 w-3.5 text-muted"
+        className="pointer-events-none absolute left-1 h-3.5 w-3.5 text-muted"
         aria-hidden
       />
       <input
@@ -234,7 +211,7 @@ export function TaskSearchInput({
         placeholder={placeholder}
         aria-label={placeholder}
         data-testid={testId}
-        className="h-full w-full bg-transparent pl-9 pr-3 text-sm text-txt outline-none placeholder:text-muted"
+        className="h-full w-full bg-transparent pl-7 pr-1 text-sm text-txt outline-none placeholder:text-muted"
         {...agentProps}
       />
     </div>
@@ -255,7 +232,7 @@ export function SparseWatermark({ icon }: { icon: LucideIcon }) {
   );
 }
 
-/** The shared visual task card. Clicking opens the view's full-pane detail. */
+/** Shared task row. Clicking opens the view's full-pane detail. */
 export function TaskCard({
   id,
   title,
@@ -275,7 +252,6 @@ export function TaskCard({
   onOpen: (id: string) => void;
   t: Translate;
 }) {
-  const visual = statusVisual(status);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: `task-card-${id}`,
     role: "list-item",
@@ -289,13 +265,9 @@ export function TaskCard({
       type="button"
       onClick={() => onOpen(id)}
       data-testid="task-card"
-      className="group relative flex w-full items-start gap-3 overflow-hidden rounded-2xl bg-bg-accent/20 p-3 text-left transition-colors hover:bg-bg-hover/50"
+      className="group relative flex w-full items-start gap-2 px-1 py-2 text-left transition-colors hover:bg-bg-hover/30"
       {...agentProps}
     >
-      <span
-        className={`absolute inset-y-0 left-0 w-1 ${visual.dot}`}
-        aria-hidden
-      />
       <TaskStatusMedallion status={status} />
       <span className="flex min-w-0 flex-1 flex-col gap-1.5">
         <span className="flex items-center gap-2">
@@ -319,7 +291,7 @@ export function TaskCard({
   );
 }
 
-/** Page header: medallion + title + count chips. Shared across both views. */
+/** Compact page header shared across both views. */
 export function TaskListHeader({
   icon,
   title,
@@ -332,22 +304,22 @@ export function TaskListHeader({
   action?: ReactNode;
 }) {
   return (
-    <header className="flex items-center gap-3 px-1 py-1">
-      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-accent-subtle text-accent">
+    <header className="flex items-center gap-2 px-1 py-0.5">
+      <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center text-accent">
         {icon}
       </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <h1 className="truncate text-lg font-semibold tracking-tight text-txt-strong">
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+        <h1 className="truncate text-base font-semibold text-txt-strong">
           {title}
         </h1>
-        <div className="flex flex-wrap items-center gap-1.5">{counts}</div>
+        <div className="flex flex-wrap items-center gap-2">{counts}</div>
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}
     </header>
   );
 }
 
-/** A labeled count pill for the header (e.g. "3 active"). */
+/** Labeled count text for the header (e.g. "3 active"). */
 export function TaskCountChip({
   value,
   label,
@@ -359,18 +331,16 @@ export function TaskCountChip({
 }) {
   const toneClass =
     tone === "active"
-      ? "bg-ok/12 text-ok"
+      ? "text-ok"
       : tone === "accent"
-        ? "bg-accent-subtle text-accent"
+        ? "text-accent"
         : tone === "warn"
-          ? "bg-warn/12 text-warn"
-          : "bg-surface text-muted";
+          ? "text-warn"
+          : "text-muted";
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-2xs ${toneClass}`}
-    >
+    <span className={`inline-flex items-baseline gap-1 text-2xs ${toneClass}`}>
       <span className="font-semibold tabular-nums">{value}</span>
-      <span className="uppercase tracking-[0.08em] opacity-70">{label}</span>
+      <span className="opacity-70">{label}</span>
     </span>
   );
 }
@@ -403,7 +373,7 @@ export function TaskEmptyState({
   );
 }
 
-/** A back-to-list chip used to leave a full-pane detail. */
+/** Back-to-list control used to leave a full-pane detail. */
 export function BackChip({
   label,
   onClick,
@@ -426,7 +396,7 @@ export function BackChip({
       type="button"
       onClick={onClick}
       data-testid={testId}
-      className="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-bg-accent/40 px-3 py-1 text-xs font-medium text-muted transition-colors hover:border-accent/40 hover:text-txt"
+      className="inline-flex items-center gap-1.5 py-1 text-xs font-medium text-muted transition-colors hover:text-txt"
       {...agentProps}
     >
       <span aria-hidden>←</span>

--- a/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.test.tsx
+++ b/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.test.tsx
@@ -260,7 +260,6 @@ describe("OrchestratorSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(listView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Orchestrator");
       expect(flat).toContain("Refactor auth pipeline");
       expect(flat).toContain("Fix flaky test suite");
       // Tasks are created conversationally in chat — the workbench is a
@@ -293,7 +292,6 @@ describe("OrchestratorSpatialView one source, three modalities", () => {
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
       expect(html).toContain("Refactor auth pipeline");
-      expect(html).toContain("Orchestrator");
       expect(html).toContain('data-agent-id="open-t1"');
     }
   });

--- a/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.tsx
@@ -267,7 +267,7 @@ function OrchestratorList({
       <Divider label="tasks" />
       {threads.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No task threads
+          None
         </Text>
       ) : (
         <List gap={1}>
@@ -578,7 +578,7 @@ function SessionsSection({
       <Divider label={`sessions (${sessions.length})`} />
       {sessions.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No sessions
+          None
         </Text>
       ) : (
         <List gap={1}>

--- a/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.tsx
@@ -208,7 +208,7 @@ function OrchestratorList({
   dispatch: (action: string) => () => void;
 }) {
   return (
-    <Card title="Orchestrator" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" wrap>
         <Text style="caption" tone="muted" grow={1}>
           {loading ? "loading" : `${threads.length} threads`}
@@ -354,7 +354,7 @@ function OrchestratorDetail({
     detail.status === "failed" ||
     detail.status === "archived";
   return (
-    <Card title="Task" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Button
           variant="ghost"

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.test.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.test.tsx
@@ -180,7 +180,6 @@ describe("TaskCoordinatorSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(listView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Coding Tasks");
       // Long titles truncate to fit the width contract; match a stable prefix.
       expect(flat).toContain("Refactor auth");
       expect(flat).toContain("Fix flaky test");
@@ -212,7 +211,6 @@ describe("TaskCoordinatorSpatialView one source, three modalities", () => {
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
       expect(html).toContain("Refactor auth pipeline");
-      expect(html).toContain("Coding Tasks");
       expect(html).toContain('data-agent-id="open-t1"');
       expect(html).toContain('data-agent-id="search"');
       expect(html).toContain('data-agent-id="toggle-archived"');

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
@@ -239,7 +239,7 @@ function TaskList({
       <Divider label="tasks" />
       {threads.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {loading ? "Loading tasks…" : "No coding tasks yet"}
+          {loading ? "Loading" : "No tasks"}
         </Text>
       ) : (
         <List gap={1}>
@@ -397,7 +397,7 @@ function SessionsSection({
       <Divider label={`sessions (${sessions.length})`} />
       {sessions.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No sessions recorded
+          No sessions
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
@@ -239,7 +239,7 @@ function TaskList({
       <Divider label="tasks" />
       {threads.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          {loading ? "Loading" : "No tasks"}
+          {loading ? "Loading" : "None"}
         </Text>
       ) : (
         <List gap={1}>
@@ -397,7 +397,7 @@ function SessionsSection({
       <Divider label={`sessions (${sessions.length})`} />
       {sessions.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No sessions
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
@@ -187,7 +187,7 @@ function TaskList({
   const activeCount = threads.filter((t) => t.status === "active").length;
   const doneCount = threads.filter((t) => t.status === "done").length;
   return (
-    <Card title="Coding Tasks" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center" wrap>
         <Text style="caption" tone="muted" grow={1}>
           {loading ? "loading" : `${threads.length} total`}
@@ -310,7 +310,7 @@ function TaskDetail({
   onAction?: (action: string) => void;
 }) {
   return (
-    <Card title="Task" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Button
           variant="ghost"

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
@@ -82,7 +82,7 @@ describe("TodosSpatialView one source, three modalities", () => {
       54,
     );
     for (const line of lines) expect(visibleWidth(line)).toBe(54);
-    expect(lines.join("\n")).toContain("Loading todos");
+    expect(lines.join("\n")).toContain("Loading");
   });
 
   it("empty state renders the add-a-todo affordance", () => {
@@ -96,7 +96,7 @@ describe("TodosSpatialView one source, three modalities", () => {
         <TodosSpatialView snapshot={empty} />
       </SpatialSurface>,
     );
-    expect(html).toContain("No todos");
+    expect(html).toContain("None");
     expect(html).toContain('data-agent-id="add"');
   });
 

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
@@ -44,7 +44,6 @@ describe("TodosSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Todos");
       expect(flat).toContain("Today");
       expect(flat).toContain("Upcoming");
       expect(flat).toContain("Someday");

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
@@ -15,15 +15,7 @@
  * fetches or computes — it displays the snapshot and dispatches actions.
  */
 
-import {
-  Button,
-  Card,
-  Divider,
-  HStack,
-  List,
-  Text,
-  VStack,
-} from "@elizaos/ui/spatial";
+import { Button, Card, HStack, List, Text, VStack } from "@elizaos/ui/spatial";
 
 export type LaneId = "today" | "upcoming" | "someday";
 
@@ -74,15 +66,14 @@ export interface TodosSpatialViewProps {
   onAction?: (action: string) => void;
 }
 
-export function TodosSpatialView({ snapshot, onAction }: TodosSpatialViewProps) {
+export function TodosSpatialView({
+  snapshot,
+  onAction,
+}: TodosSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card title="Todos" gap={1} padding={1}>
-      <Text style="caption" tone="muted">
-        Three lanes: Today, Upcoming, Someday.
-      </Text>
-
+    <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading todos
@@ -107,7 +98,6 @@ function TodosErrorBody({
 }) {
   return (
     <>
-      <Divider label="error" />
       <Text bold>Could not load todos</Text>
       <Text tone="danger" style="caption">
         {snapshot.error ?? "Could not load todos."}
@@ -128,12 +118,7 @@ function TodosEmptyBody({
 }) {
   return (
     <>
-      <Divider label="empty" />
       <Text bold>No todos</Text>
-      <Text tone="muted" style="caption">
-        Nothing on the board yet. Ask Eliza to add one and she will track it for
-        you.
-      </Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
           Add a todo
@@ -163,12 +148,10 @@ function TodosReadyBody({ snapshot }: { snapshot: TodosSnapshot }) {
 function Lane({ lane, todos }: { lane: LaneDef; todos: TodoCard[] }) {
   return (
     <>
-      <Divider label={`${lane.label} (${todos.length})`} />
-      {todos.length === 0 ? (
-        <Text tone="muted" style="caption">
-          Nothing here.
-        </Text>
-      ) : (
+      <Text style="caption" tone="muted">
+        {lane.label} ({todos.length})
+      </Text>
+      {todos.length > 0 ? (
         <List gap={0}>
           {todos.map((todo) => (
             <HStack
@@ -193,7 +176,7 @@ function Lane({ lane, todos }: { lane: LaneDef; todos: TodoCard[] }) {
             </HStack>
           ))}
         </List>
-      )}
+      ) : null}
     </>
   );
 }

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.tsx
@@ -76,7 +76,7 @@ export function TodosSpatialView({
     <Card gap={1} padding={1}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
-          Loading todos
+          Loading
         </Text>
       ) : snapshot.state === "error" ? (
         <TodosErrorBody snapshot={snapshot} dispatch={dispatch} />
@@ -118,10 +118,10 @@ function TodosEmptyBody({
 }) {
   return (
     <>
-      <Text bold>No todos</Text>
+      <Text bold>None</Text>
       <HStack gap={1}>
         <Button agent="add" onPress={dispatch("add")}>
-          Add a todo
+          Add
         </Button>
       </HStack>
     </>

--- a/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
@@ -120,7 +120,7 @@ describe("TodosView — states", () => {
         fetchers: makeFetchers({ fetchTodos: () => never }),
       }),
     );
-    expect(screen.getByText("Loading todos")).toBeTruthy();
+    expect(screen.getByText("Loading")).toBeTruthy();
   });
 
   it("renders the populated three-lane board", async () => {
@@ -140,7 +140,7 @@ describe("TodosView — states", () => {
         fetchers: makeFetchers({ fetchTodos: async () => ({ todos: [] }) }),
       }),
     );
-    await screen.findByText("No todos");
+    await screen.findByText("None");
     expect(screen.queryByText("Overdue task")).toBeNull();
   });
 
@@ -154,7 +154,7 @@ describe("TodosView — states", () => {
         }),
       }),
     );
-    await screen.findByText("No todos");
+    await screen.findByText("None");
     expect(screen.queryByText("Done")).toBeNull();
   });
 
@@ -164,7 +164,7 @@ describe("TodosView — states", () => {
         fetchers: makeFetchers({ fetchTodos: async () => ({ todos: [] }) }),
       }),
     );
-    await screen.findByText("No todos");
+    await screen.findByText("None");
     fireEvent.click(agent("add"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });

--- a/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
@@ -24,13 +24,7 @@
  * timers below) — there is no manual refresh control.
  */
 
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -135,7 +129,9 @@ describe("TodosView — states", () => {
     expect(screen.getByText("Today (2)")).toBeTruthy();
     expect(screen.getByText("Upcoming (1)")).toBeTruthy();
     expect(screen.getByText("Someday (1)")).toBeTruthy();
-    expect(screen.getByText("Three lanes: Today, Upcoming, Someday.")).toBeTruthy();
+    expect(
+      screen.queryByText("Three lanes: Today, Upcoming, Someday."),
+    ).toBeNull();
   });
 
   it("shows the empty state when the route returns no active todos", async () => {
@@ -229,7 +225,7 @@ describe("TodosView — lane assignment + filtering", () => {
     expect(screen.getByText("Someday (1)")).toBeTruthy();
   });
 
-  it("shows 'Nothing here.' in lanes with no active items", async () => {
+  it("keeps empty lanes compact", async () => {
     render(
       React.createElement(TodosView, {
         fetchers: makeFetchers({
@@ -246,7 +242,9 @@ describe("TodosView — lane assignment + filtering", () => {
     );
     await screen.findByText("Only today");
     // Today has the item, Upcoming + Someday are empty.
-    expect(screen.getAllByText("Nothing here.").length).toBe(2);
+    expect(screen.queryByText("Nothing here.")).toBeNull();
+    expect(screen.getByText("Upcoming (0)")).toBeTruthy();
+    expect(screen.getByText("Someday (0)")).toBeTruthy();
   });
 });
 

--- a/plugins/plugin-training/src/ui/FineTuningSpatialView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningSpatialView.tsx
@@ -87,7 +87,7 @@ export function FineTuningSpatialView({
     (job) => job.status === "running" || job.status === "queued",
   );
   return (
-    <Card title="Training" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-training/src/ui/FineTuningSpatialView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningSpatialView.tsx
@@ -150,7 +150,7 @@ export function FineTuningSpatialView({
         </VStack>
       ) : (
         <Text tone="muted" align="center" style="caption">
-          No active job
+          None
         </Text>
       )}
 
@@ -182,7 +182,7 @@ export function FineTuningSpatialView({
       <Divider label="jobs" />
       {snapshot.jobs.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No training jobs
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -3506,9 +3506,7 @@ export function FineTuningView({
                     ))}
                   </div>
                 ) : (
-                  <div className="font-mono text-xs text-muted">
-                    No saved collection runs found.
-                  </div>
+                  <div className="font-mono text-xs text-muted">No runs</div>
                 )}
               </div>
             ) : null}
@@ -5485,7 +5483,7 @@ export function FineTuningDetailExtension({ app }: AppDetailExtensionProps) {
   return (
     <div
       data-testid="fine-tuning-detail-extension"
-      className="flex flex-col gap-3 rounded-md border border-border/45 bg-card/25 p-4"
+      className="flex flex-col gap-3 px-1 py-2"
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
@@ -5498,7 +5496,7 @@ export function FineTuningDetailExtension({ app }: AppDetailExtensionProps) {
           <p className="mt-1 text-xs text-muted">
             {latest
               ? `${latest.readinessStatus} readiness, ${latest.artifactCount} artifacts`
-              : "No saved collection runs found yet."}
+              : "No runs"}
           </p>
         </div>
         <Button

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -702,7 +702,7 @@ function ReadinessCheckRow({
     },
   });
   return (
-    <div className="grid gap-2 border-t border-border/40 pt-2">
+    <div className="grid gap-2 pt-2">
       <div>
         <div className="font-mono text-xs text-txt">
           {check.label} · {check.status}
@@ -2251,7 +2251,7 @@ export function FineTuningView({
   return (
     <ContentLayout contentHeader={contentHeader}>
       <div data-testid="fine-tuning-view" className="space-y-4 pb-32">
-        <section className="rounded-xl border border-border/50 bg-card/65 px-4 py-3 shadow-sm ring-1 ring-border/10">
+        <section className="px-2 py-2">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-semibold text-txt">
@@ -2271,7 +2271,7 @@ export function FineTuningView({
             </TrainingActionButton>
           </div>
           {errorMessage && (
-            <div className="mt-3 rounded-xl border border-danger/35 bg-danger/10 px-3 py-2 text-sm text-danger">
+            <div className="mt-3 px-1 py-2 text-sm text-danger">
               {errorMessage}
             </div>
           )}
@@ -2438,8 +2438,8 @@ export function FineTuningView({
             </div>
           </div>
           <div className={`${FINE_TUNING_PANEL_CLASS} p-3 text-sm`}>
-            <div className="mb-3 border-b border-border/50 pb-3">
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+            <div className="mb-3 pb-2">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="analysis-probe-endpoints"
                   label="Probe live endpoints"
@@ -2451,7 +2451,7 @@ export function FineTuningView({
                 Probe live endpoints
               </div>
             </div>
-            <div className="mb-3 border-b border-border/50 pb-3">
+            <div className="mb-3 pb-2">
               <div className="mb-2 text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/70">
                 Natural trajectory import
               </div>
@@ -2516,7 +2516,7 @@ export function FineTuningView({
                     placeholder="response,action_planner"
                   />
                 </div>
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="natural-include-raw"
                     label="Include raw trajectories"
@@ -2530,7 +2530,7 @@ export function FineTuningView({
               </div>
             </div>
             {readinessReport ? (
-              <div className="mb-3 border-b border-border/50 pb-3">
+              <div className="mb-3 pb-2">
                 <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                   <div>
                     <div className="text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/70">
@@ -2635,7 +2635,7 @@ export function FineTuningView({
               </div>
             ) : null}
             {collectionPreflightResult ? (
-              <div className="mb-3 border-b border-border/50 pb-3">
+              <div className="mb-3 pb-2">
                 <div className="text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/70">
                   Collection preflight
                 </div>
@@ -2653,7 +2653,7 @@ export function FineTuningView({
               </div>
             ) : null}
             {collectionResult ? (
-              <div className="mb-3 grid gap-3 border-b border-border/50 pb-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="mb-3 grid gap-3 pb-2 md:grid-cols-2 xl:grid-cols-4">
                 <div>
                   <div className="text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/70">
                     {t("finetuningview.Collection")}
@@ -3154,7 +3154,7 @@ export function FineTuningView({
               </div>
             ) : null}
             {collectionHistory ? (
-              <div className="mb-3 border-b border-border/50 pb-3">
+              <div className="mb-3 pb-2">
                 <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <div className="text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/70">
@@ -3200,10 +3200,7 @@ export function FineTuningView({
                 {collectionHistory.collections.length > 0 ? (
                   <div className="grid gap-2">
                     {collectionHistory.collections.slice(0, 5).map((run) => (
-                      <div
-                        key={run.manifestPath}
-                        className="rounded border border-border/50 p-2"
-                      >
+                      <div key={run.manifestPath} className="p-2">
                         <div className="flex flex-wrap items-start justify-between gap-2">
                           <div className="min-w-0">
                             <div className="break-all font-mono text-xs text-txt">
@@ -3731,14 +3728,14 @@ export function FineTuningView({
                     label="HuggingFace files"
                     group="hf-ingest"
                     description="Newline-separated dataset files to ingest"
-                    className="min-h-24 w-full rounded-xl border border-border/60 bg-bg/50 px-3 py-2 font-mono text-xs text-txt outline-none focus:border-accent"
+                    className="min-h-24 w-full border-border/60 bg-transparent px-3 py-2 font-mono text-xs text-txt outline-none focus:border-accent"
                     value={hfFiles}
                     onChange={setHfFiles}
                   />
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-3">
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="hf-dry-run"
                     label="HuggingFace ingest dry run"
@@ -3915,7 +3912,7 @@ export function FineTuningView({
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-3">
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="feed-cleanup"
                     label="Feed cleanup"
@@ -3926,7 +3923,7 @@ export function FineTuningView({
                   />
                   {t("finetuningview.Cleanup")}
                 </div>
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="feed-dry-run"
                     label="Feed generation dry run"
@@ -4099,7 +4096,7 @@ export function FineTuningView({
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-3">
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="scenario-export-native"
                     label="Export native trajectories"
@@ -4110,7 +4107,7 @@ export function FineTuningView({
                   />
                   {t("finetuningview.ExportNative")}
                 </div>
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="scenario-deterministic-proxy"
                     label="Deterministic proxy"
@@ -4121,7 +4118,7 @@ export function FineTuningView({
                   />
                   {t("finetuningview.Proxy")}
                 </div>
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="scenario-dry-run"
                     label="Scenario dry run"
@@ -4343,7 +4340,7 @@ export function FineTuningView({
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-3">
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="eval-include-in-collection"
                     label="Include eval in collection"
@@ -4354,7 +4351,7 @@ export function FineTuningView({
                   />
                   {t("finetuningview.IncludeInCollection")}
                 </div>
-                <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+                <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                   <AgentCheckboxField
                     agentId="eval-dry-run"
                     label="Eval comparison dry run"
@@ -4610,7 +4607,7 @@ export function FineTuningView({
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="benchmark-dry-run"
                   label="Benchmark dry run"
@@ -4814,7 +4811,7 @@ export function FineTuningView({
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="bundle-apply"
                   label="Apply bundle"
@@ -5166,7 +5163,7 @@ export function FineTuningView({
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="action-benchmark-pair-enabled"
                   label="Pair base and trained"
@@ -5177,7 +5174,7 @@ export function FineTuningView({
                 />
                 {t("finetuningview.PairBaseTrained")}
               </div>
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="action-benchmark-use-mocks"
                   label="Use mocks"
@@ -5188,7 +5185,7 @@ export function FineTuningView({
                 />
                 {t("finetuningview.UseMocks")}
               </div>
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="action-benchmark-capture"
                   label="Capture trajectories"
@@ -5199,7 +5196,7 @@ export function FineTuningView({
                 />
                 {t("finetuningview.CaptureTrajectories")}
               </div>
-              <div className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-bg/30 px-3 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
+              <div className="flex h-10 items-center gap-2 px-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted">
                 <AgentCheckboxField
                   agentId="action-benchmark-dry-run"
                   label="Action benchmark dry run"

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -3506,7 +3506,7 @@ export function FineTuningView({
                     ))}
                   </div>
                 ) : (
-                  <div className="font-mono text-xs text-muted">No runs</div>
+                  <div className="font-mono text-xs text-muted">None</div>
                 )}
               </div>
             ) : null}
@@ -5496,7 +5496,7 @@ export function FineTuningDetailExtension({ app }: AppDetailExtensionProps) {
           <p className="mt-1 text-xs text-muted">
             {latest
               ? `${latest.readinessStatus} readiness, ${latest.artifactCount} artifacts`
-              : "No runs"}
+              : "None"}
           </p>
         </div>
         <Button

--- a/plugins/plugin-trajectory-logger/src/components/PhaseChip.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/PhaseChip.tsx
@@ -27,27 +27,27 @@ const MEDALLION: Record<
   { ring: string; icon: string; label: string }
 > = {
   idle: {
-    ring: "border-border/40 bg-card/40",
+    ring: "",
     icon: "text-muted/70",
     label: "text-muted/70",
   },
   active: {
-    ring: "border-accent bg-accent/15 shadow-[0_0_0_3px_var(--accent-subtle,rgba(255,88,0,0.14))]",
+    ring: "bg-accent/15 shadow-[0_0_0_3px_var(--accent-subtle,rgba(255,88,0,0.14))]",
     icon: "text-accent",
     label: "text-accent",
   },
   done: {
-    ring: "border-ok/55 bg-ok/12",
+    ring: "bg-ok/12",
     icon: "text-ok",
     label: "text-txt",
   },
   skipped: {
-    ring: "border-warn/45 bg-warn/10",
+    ring: "bg-warn/10",
     icon: "text-warn",
     label: "text-muted",
   },
   error: {
-    ring: "border-danger/55 bg-danger/12",
+    ring: "bg-danger/12",
     icon: "text-danger",
     label: "text-danger",
   },
@@ -81,13 +81,13 @@ export function PhaseChip({
       aria-current={selected ? "true" : undefined}
       {...agentProps}
       className={[
-        "group flex min-w-0 flex-col items-center gap-1.5 rounded-xl px-1 py-2 text-center transition-colors",
-        selected ? "bg-card/70 ring-1 ring-accent/40" : "hover:bg-card/40",
+        "group flex min-w-0 flex-col items-center gap-1 px-1 py-1.5 text-center transition-colors",
+        selected ? "text-accent" : "hover:text-txt",
       ].join(" ")}
     >
       <span
         className={[
-          "relative grid h-9 w-9 place-items-center rounded-full border-2 transition-all",
+          "relative grid h-9 w-9 place-items-center rounded-full transition-all",
           tone.ring,
           status === "active" ? "animate-pulse" : "",
         ].join(" ")}
@@ -104,7 +104,9 @@ export function PhaseChip({
         {phase}
       </span>
       {summary ? (
-        <span className="w-full truncate text-2xs text-muted">{summary}</span>
+        <span className="sr-only w-full truncate text-2xs text-muted">
+          {summary}
+        </span>
       ) : (
         <span className="h-1 w-1 rounded-full bg-muted/30" aria-hidden />
       )}

--- a/plugins/plugin-trajectory-logger/src/components/PhaseDrilldown.render.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/PhaseDrilldown.render.test.tsx
@@ -149,14 +149,16 @@ describe("PhaseDrilldown ACTION body", () => {
     expect(screen.getByText(/"text": "hello world"/)).toBeTruthy();
     expect(screen.getByText(/"sent": true/)).toBeTruthy();
 
-    // STATUS_BORDER tone: ok event = green border, error event = red border.
-    const okCard = screen.getByText("REPLY").closest("div.rounded");
-    expect(okCard?.className).toContain("border-green-500/40");
-    const errCard = screen.getByText("POSTGRES_QUERY").closest("div.rounded");
-    expect(errCard?.className).toContain("border-red-500/40");
+    // STATUS tone: ok event = green, error event = red.
+    const okCard = screen.getByText("REPLY").closest("[data-phase-status]");
+    expect(okCard?.className).toContain("text-green-500");
+    const errCard = screen
+      .getByText("POSTGRES_QUERY")
+      .closest("[data-phase-status]");
+    expect(errCard?.className).toContain("text-red-500");
   });
 
-  it("maps a skipped tool status to the yellow border and a running one to blue", () => {
+  it("maps a skipped tool status to yellow and a running one to blue", () => {
     const events: UIToolEvent[] = [
       { id: "sk", type: "tool_call", actionName: "MUTE", status: "skipped" },
       { id: "rn", type: "tool_call", actionName: "SEARCH", status: "running" },
@@ -166,10 +168,10 @@ describe("PhaseDrilldown ACTION body", () => {
         phase={summary("ACTION", "active", { toolEvents: events })}
       />,
     );
-    const skipped = screen.getByText("MUTE").closest("div.rounded");
-    expect(skipped?.className).toContain("border-yellow-500/40");
-    const running = screen.getByText("SEARCH").closest("div.rounded");
-    expect(running?.className).toContain("border-blue-500/40");
+    const skipped = screen.getByText("MUTE").closest("[data-phase-status]");
+    expect(skipped?.className).toContain("text-yellow-500");
+    const running = screen.getByText("SEARCH").closest("[data-phase-status]");
+    expect(running?.className).toContain("text-blue-500");
   });
 
   it("returns null when there are no tool events", () => {
@@ -210,11 +212,15 @@ describe("PhaseDrilldown EVALUATE body", () => {
     expect(screen.getByText("FACT_CHECK")).toBeTruthy();
     expect(screen.getByText("evaluator timed out")).toBeTruthy();
 
-    // status border: ok = green, error = red.
-    const okCard = screen.getByText("REFLECTION").closest("div.rounded");
-    expect(okCard?.className).toContain("border-green-500/40");
-    const errCard = screen.getByText("FACT_CHECK").closest("div.rounded");
-    expect(errCard?.className).toContain("border-red-500/40");
+    // status tone: ok = green, error = red.
+    const okCard = screen
+      .getByText("REFLECTION")
+      .closest("[data-phase-status]");
+    expect(okCard?.className).toContain("text-green-500");
+    const errCard = screen
+      .getByText("FACT_CHECK")
+      .closest("[data-phase-status]");
+    expect(errCard?.className).toContain("text-red-500");
   });
 
   it("renders nothing when both evaluation calls and events are empty", () => {

--- a/plugins/plugin-trajectory-logger/src/components/PhaseDrilldown.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/PhaseDrilldown.tsx
@@ -22,10 +22,10 @@ export function PhaseDrilldown({ phase }: { phase: PhaseSummary }) {
 }
 
 const STATUS_BORDER: Record<"ok" | "error" | "running" | "skipped", string> = {
-  ok: "border-green-500/40",
-  error: "border-red-500/40",
-  running: "border-blue-500/40 animate-pulse",
-  skipped: "border-yellow-500/40",
+  ok: "text-green-500",
+  error: "text-red-500",
+  running: "text-blue-500 animate-pulse",
+  skipped: "text-yellow-500",
 };
 
 function jsonBlock(value: unknown): string {
@@ -68,10 +68,7 @@ function HandleBody({
       {providers.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {providers.map((n) => (
-            <span
-              key={n}
-              className="rounded-full border border-border/24 bg-card/40 px-1.5 py-0.5 text-2xs text-txt"
-            >
+            <span key={n} className="px-1 py-0.5 text-2xs text-txt">
               {n}
             </span>
           ))}
@@ -91,7 +88,7 @@ function PlanBody({ calls }: { calls: UILlmCall[] }) {
         <div className="font-mono text-txt">{last.actionType}</div>
       ) : null}
       {text ? (
-        <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded border border-border/24 bg-bg/40 p-2 text-2xs text-muted">
+        <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words bg-transparent p-1 text-2xs text-muted">
           {text}
         </pre>
       ) : null}
@@ -120,10 +117,8 @@ function ActionBody({ events }: { events: UIToolEvent[] }) {
         return (
           <div
             key={e.id}
-            className={[
-              "rounded border-l-2 bg-card/30 p-2",
-              STATUS_BORDER[status],
-            ].join(" ")}
+            data-phase-status={status}
+            className={["p-1.5", STATUS_BORDER[status]].join(" ")}
           >
             <div className="flex items-baseline justify-between gap-2">
               <span className="font-mono text-txt">{name}</span>
@@ -135,12 +130,12 @@ function ActionBody({ events }: { events: UIToolEvent[] }) {
               <div className="mt-1 text-2xs text-red-400">{e.error}</div>
             ) : null}
             {args && Object.keys(args).length > 0 ? (
-              <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words rounded bg-bg/40 p-1 text-2xs text-muted">
+              <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words bg-transparent p-1 text-2xs text-muted">
                 {jsonBlock(args)}
               </pre>
             ) : null}
             {result !== null && result !== undefined ? (
-              <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words rounded bg-bg/40 p-1 text-2xs text-muted">
+              <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words bg-transparent p-1 text-2xs text-muted">
                 {jsonBlock(result)}
               </pre>
             ) : null}
@@ -174,10 +169,8 @@ function EvaluateBody({
         return (
           <div
             key={e.id}
-            className={[
-              "rounded border-l-2 bg-card/30 p-2",
-              STATUS_BORDER[status],
-            ].join(" ")}
+            data-phase-status={status}
+            className={["p-1.5", STATUS_BORDER[status]].join(" ")}
           >
             <div className="flex items-baseline justify-between gap-2">
               <span className="font-mono text-txt">{name}</span>

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerAppView.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerAppView.tsx
@@ -48,7 +48,7 @@ export function TrajectoryLoggerAppView({ exitToApps }: OverlayAppContext) {
 
   return (
     <div className="flex h-full w-full flex-col bg-bg text-xs">
-      <header className="flex items-center justify-between gap-2 border-b border-border/24 px-2 py-2">
+      <header className="flex items-center justify-between gap-2 px-2 py-2">
         <div className="flex items-center gap-2">
           <Button
             ref={backButton.ref}
@@ -60,13 +60,13 @@ export function TrajectoryLoggerAppView({ exitToApps }: OverlayAppContext) {
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <span className="grid h-7 w-7 place-items-center rounded-lg border border-accent/30 bg-accent/10">
+          <span className="grid h-7 w-7 place-items-center">
             <Route className="h-3.5 w-3.5 text-accent" aria-hidden />
           </span>
           <span className="text-sm font-semibold text-txt">Trajectories</span>
         </div>
         {state.unavailable ? (
-          <span className="max-w-[42vw] truncate text-2xs text-muted/60">
+          <span className="sr-only max-w-[42vw] truncate text-2xs text-muted/60">
             Trajectory logging unavailable on this surface
           </span>
         ) : state.error ? (
@@ -74,13 +74,13 @@ export function TrajectoryLoggerAppView({ exitToApps }: OverlayAppContext) {
             {state.error}
           </span>
         ) : !state.ready ? (
-          <span className="text-2xs text-muted/60">loading…</span>
+          <span className="sr-only text-2xs text-muted/60">loading…</span>
         ) : (
           <LoggingStatusBadge active={!!state.active} />
         )}
       </header>
 
-      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3 pb-32">
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-2 pb-32">
         <PhaseStrip
           live
           slot="now"
@@ -110,7 +110,7 @@ export function TrajectoryLoggerAppView({ exitToApps }: OverlayAppContext) {
           }
         />
         {selected ? (
-          <div className="max-h-[52vh] overflow-auto rounded border border-border/24 bg-card/30 p-2">
+          <div className="max-h-[52vh] overflow-auto px-1 py-2">
             <PhaseDrilldown phase={selected} />
           </div>
         ) : null}
@@ -147,10 +147,8 @@ function PhaseStrip({
   return (
     <div
       className={[
-        "flex min-w-0 flex-col gap-3 rounded-xl border bg-card/40 px-3 py-3 shadow-sm transition-colors",
-        recording
-          ? "border-accent/30 animate-[pulse_2.4s_ease-in-out_infinite]"
-          : "border-border/24",
+        "flex min-w-0 flex-col gap-2 px-2 py-2 transition-colors",
+        recording ? "animate-[pulse_2.4s_ease-in-out_infinite]" : "",
       ].join(" ")}
     >
       <div className="flex items-center justify-between">
@@ -170,7 +168,7 @@ function PhaseStrip({
           {live ? "Now" : "Last"}
         </span>
         {!trajectory ? (
-          <span className="text-2xs text-muted/50">no turn yet</span>
+          <span className="sr-only text-2xs text-muted/50">no turn yet</span>
         ) : null}
       </div>
       <div
@@ -178,10 +176,10 @@ function PhaseStrip({
         title={trajectory ? undefined : "No trajectory captured yet"}
       >
         {/* Progress rail behind the medallion row */}
-        <div className="pointer-events-none absolute inset-x-[12.5%] top-[18px] h-0.5 rounded-full bg-border/30">
+        <div className="pointer-events-none absolute inset-x-[12.5%] top-[18px] h-0.5 bg-border/20">
           <div
             className={[
-              "h-full rounded-full transition-all duration-500",
+              "h-full transition-all duration-500",
               recording ? "bg-accent/70" : "bg-ok/55",
             ].join(" ")}
             style={{ width: `${fillPct}%` }}
@@ -209,14 +207,12 @@ function PhaseStrip({
  * Compact status badge for the overlay header.
  */
 function LoggingStatusBadge({ active }: { active: boolean }) {
-  const tone = active
-    ? "border-danger/40 bg-danger/10 text-danger"
-    : "border-border/30 bg-bg-elevated text-muted";
+  const tone = active ? "text-danger" : "text-muted";
   const label = active ? "recording" : "idle";
   return (
     <span
       title="Trajectory logging status"
-      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-wide ${tone}`}
+      className={`inline-flex items-center gap-1.5 px-1 py-1 text-2xs font-semibold uppercase tracking-wide ${tone}`}
       data-testid="trajectory-logging-badge"
     >
       <span

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerAppView.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerAppView.tsx
@@ -171,10 +171,7 @@ function PhaseStrip({
           <span className="sr-only text-2xs text-muted/50">no turn yet</span>
         ) : null}
       </div>
-      <div
-        className="relative min-w-0"
-        title={trajectory ? undefined : "No trajectory captured yet"}
-      >
+      <div className="relative min-w-0" title={trajectory ? undefined : "None"}>
         {/* Progress rail behind the medallion row */}
         <div className="pointer-events-none absolute inset-x-[12.5%] top-[18px] h-0.5 bg-border/20">
           <div

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.test.tsx
@@ -129,7 +129,6 @@ describe("TrajectoryLoggerSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Trajectories");
       expect(flat).toContain("recording");
       expect(flat).toContain("now");
       expect(flat).toContain("last");
@@ -149,7 +148,6 @@ describe("TrajectoryLoggerSpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Trajectories");
       expect(html).toContain("HANDLE");
       expect(html).toContain("sendMessage");
       expect(html).toContain('data-agent-id="strip-now"');
@@ -168,7 +166,6 @@ describe("TrajectoryLoggerSpatialView one source, three modalities", () => {
       const lines = component?.render(50) ?? [];
       expect(lines.length).toBeGreaterThan(0);
       for (const line of lines) expect(visibleWidth(line)).toBe(50);
-      expect(lines.join("\n")).toContain("Trajectories");
     } finally {
       unregister();
     }

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.tsx
@@ -128,7 +128,7 @@ export function TrajectoryLoggerSpatialView({
 }: TrajectoryLoggerSpatialViewProps) {
   const selected = resolveSelected(snapshot);
   return (
-    <Card title="Trajectories" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Button
           variant="ghost"

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.render.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.render.test.tsx
@@ -298,12 +298,10 @@ afterEach(() => {
 });
 
 describe("TrajectoryLoggerAppView populated render", () => {
-  it("renders the header brand block, both Now/Last strips, and the recording badge", async () => {
+  it("renders the overlay controls, both Now/Last strips, and the recording badge", async () => {
     installFetch();
     render(<TrajectoryLoggerAppView {...overlayContext()} />);
 
-    // Header brand title.
-    expect(screen.getByText("Trajectories")).toBeTruthy();
     // Back button (Button mock forwards aria-label).
     expect(screen.getByLabelText("Back")).toBeTruthy();
 

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
@@ -197,11 +197,11 @@ afterEach(() => {
 });
 
 describe("TrajectoryLoggerView — unified GUI/XR wrapper", () => {
-  it("renders the SpatialSurface-wrapped spatial view with the brand title", async () => {
+  it("renders the SpatialSurface-wrapped spatial view", async () => {
     installFetch();
     render(React.createElement(TrajectoryLoggerView));
-    expect(screen.getByText("Trajectories")).toBeTruthy();
     expect(document.querySelector("[data-spatial-surface]")).toBeTruthy();
+    expect(screen.getByText("Back")).toBeTruthy();
   });
 
   it("polls real-shape data into the snapshot (recording state + populated phase)", async () => {

--- a/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
@@ -81,7 +81,7 @@ export function VectorBrowserSpatialView({
   } = snapshot;
 
   return (
-    <Card title="Vector Browser" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="caption" tone="success" grow={1}>
           {loading ? "loading" : `${vectorCount} vectors`}

--- a/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
@@ -124,7 +124,7 @@ export function VectorBrowserSpatialView({
       <Divider label="points" />
       {points.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No vectors loaded
+          No vectors
         </Text>
       ) : (
         <List gap={1}>

--- a/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserSpatialView.tsx
@@ -124,7 +124,7 @@ export function VectorBrowserSpatialView({
       <Divider label="points" />
       {points.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No vectors
+          None
         </Text>
       ) : (
         <List gap={1}>

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -1494,10 +1494,10 @@ export function VectorBrowserView({
         <div className="px-4 py-10 text-center text-sm text-muted">
           {search
             ? t("vectorbrowserview.NoRecordsMatchSearchQuery", {
-                defaultValue: "No records match your search query.",
+                defaultValue: "None",
               })
             : t("vectorbrowserview.NoMemoryRecordsDetected", {
-                defaultValue: "No records.",
+                defaultValue: "None",
               })}
         </div>
       ) : (

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -1497,7 +1497,7 @@ export function VectorBrowserView({
                 defaultValue: "No records match your search query.",
               })
             : t("vectorbrowserview.NoMemoryRecordsDetected", {
-                defaultValue: "No memory records detected in the database.",
+                defaultValue: "No records.",
               })}
         </div>
       ) : (

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -851,7 +851,7 @@ export function VectorGraph3D({
       <div className="px-4 py-10 text-center">
         <div className="text-sm text-txt">
           {t("vectorbrowserview.RendererUnavailable", {
-            defaultValue: "3D view unavailable in this environment.",
+            defaultValue: "Unavailable",
           })}
         </div>
         <div className="sr-only mt-2 text-xs text-muted">

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -848,13 +848,13 @@ export function VectorGraph3D({
 
   if (rendererUnavailable) {
     return (
-      <div className="border border-border bg-card px-4 py-10 text-center">
+      <div className="px-4 py-10 text-center">
         <div className="text-sm text-txt">
           {t("vectorbrowserview.RendererUnavailable", {
             defaultValue: "3D view unavailable in this environment.",
           })}
         </div>
-        <div className="mt-2 text-xs text-muted">
+        <div className="sr-only mt-2 text-xs text-muted">
           {t("vectorbrowserview.RendererUnavailableDescription", {
             defaultValue:
               "The current runtime could not initialize a renderer.",
@@ -879,7 +879,7 @@ export function VectorGraph3D({
       {/* Tooltip */}
       {hoveredMem && tooltipPos && (
         <div
-          className="absolute pointer-events-none bg-card/95 text-txt backdrop-blur-sm border border-border/30 rounded-sm text-xs-tight px-3 py-2 max-w-[300px] z-10"
+          className="pointer-events-none absolute z-10 max-w-[300px] bg-bg/95 px-3 py-2 text-txt text-xs-tight backdrop-blur-sm"
           style={{
             left: tooltipPos.x + 15,
             top: tooltipPos.y + 15,
@@ -888,7 +888,7 @@ export function VectorGraph3D({
         >
           <div className="font-medium mb-1 truncate">
             {hoveredMem.type && hoveredMem.type !== "undefined" && (
-              <span className="px-1.5 py-0.5 bg-accent/30 text-accent mr-2 text-2xs">
+              <span className="mr-2 px-1.5 py-0.5 text-2xs text-accent">
                 {hoveredMem.type}
               </span>
             )}
@@ -1368,7 +1368,7 @@ export function VectorBrowserView({
                 tableSelect.ref.current = node as HTMLButtonElement | null;
               }}
               {...tableSelect.agentProps}
-              className="h-9 w-full rounded-sm border border-border bg-card px-2.5 py-1.5 text-xs transition-[border-color,box-shadow,background-color] focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent"
+              className="h-9 w-full border-border bg-transparent px-2.5 py-1.5 text-xs transition-[border-color,box-shadow,background-color] focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent"
             >
               <SelectValue />
             </SelectTrigger>
@@ -1382,17 +1382,17 @@ export function VectorBrowserView({
           </Select>
         )}
 
-        <div className="inline-flex w-full rounded-sm border border-border/50 bg-card/40 p-0.5 md:w-auto">
+        <div className="inline-flex w-full gap-1 md:w-auto">
           <Button
             ref={listTab.ref}
             {...listTab.agentProps}
             aria-current={viewMode === "list" ? "true" : undefined}
             variant="ghost"
             size="sm"
-            className={`h-auto min-h-[1.75rem] flex-1 rounded-sm border px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
+            className={`h-auto min-h-[1.75rem] flex-1 px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
               viewMode === "list"
-                ? "border-accent/45 bg-accent/16 text-txt-strong "
-                : "border-transparent text-muted-strong hover:border-border/50 hover:bg-bg-hover hover:text-txt"
+                ? "text-accent "
+                : "text-muted-strong hover:text-txt"
             }`}
             onClick={() => setViewMode("list")}
           >
@@ -1404,10 +1404,10 @@ export function VectorBrowserView({
             aria-current={viewMode === "graph" ? "true" : undefined}
             variant="ghost"
             size="sm"
-            className={`h-auto min-h-[1.75rem] flex-1 rounded-sm border px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
+            className={`h-auto min-h-[1.75rem] flex-1 px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
               viewMode === "graph"
-                ? "border-accent/45 bg-accent/16 text-txt-strong "
-                : "border-transparent text-muted-strong hover:border-border/50 hover:bg-bg-hover hover:text-txt"
+                ? "text-accent "
+                : "text-muted-strong hover:text-txt"
             }`}
             onClick={() => setViewMode("graph")}
           >
@@ -1419,10 +1419,10 @@ export function VectorBrowserView({
             aria-current={viewMode === "3d" ? "true" : undefined}
             variant="ghost"
             size="sm"
-            className={`h-auto min-h-[1.75rem] flex-1 rounded-sm border px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
+            className={`h-auto min-h-[1.75rem] flex-1 px-3 py-1 text-xs font-medium transition-all duration-300 md:flex-none ${
               viewMode === "3d"
-                ? "border-accent/45 bg-accent/16 text-txt-strong "
-                : "border-transparent text-muted-strong hover:border-border/50 hover:bg-bg-hover hover:text-txt"
+                ? "text-accent "
+                : "text-muted-strong hover:text-txt"
             }`}
             onClick={() => setViewMode("3d")}
           >
@@ -1441,7 +1441,7 @@ export function VectorBrowserView({
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-            className="h-10 min-w-0 flex-1 rounded-sm border border-border/60 bg-card/50 px-3 py-2 text-sm placeholder:text-muted/65 transition-[border-color,box-shadow,background-color] focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent"
+            className="h-10 min-w-0 flex-1 border-border/60 bg-transparent px-3 py-2 text-sm placeholder:text-muted/65 transition-[border-color,box-shadow,background-color] focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent"
           />
           <Button
             ref={searchButton.ref}
@@ -1487,11 +1487,11 @@ export function VectorBrowserView({
   const masterList = (
     <div className="flex flex-col gap-1.5">
       {loading ? (
-        <div className="rounded-sm border border-border/35 bg-bg/35 px-4 py-10 text-center text-sm text-muted">
+        <div className="px-4 py-10 text-center text-sm text-muted">
           {t("vectorbrowserview.LoadingMemories")}
         </div>
       ) : memories.length === 0 ? (
-        <div className="rounded-sm border border-border/35 bg-bg/35 px-4 py-10 text-center text-sm text-muted">
+        <div className="px-4 py-10 text-center text-sm text-muted">
           {search
             ? t("vectorbrowserview.NoRecordsMatchSearchQuery", {
                 defaultValue: "No records match your search query.",
@@ -1509,11 +1509,11 @@ export function VectorBrowserView({
               type="button"
               key={mem.id || `${mem.content.slice(0, 30)}-${mem.createdAt}`}
               onClick={() => openDetail(mem)}
-              className={`flex w-full items-center gap-3 rounded-sm px-3 py-2.5 text-left transition-colors ${
+              className={`flex w-full items-center gap-3 px-2 py-2 text-left transition-colors ${
                 isActive ? "bg-accent/12 text-txt" : "hover:bg-bg-hover"
               }`}
             >
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-bg-muted/55 text-xs font-semibold uppercase text-muted">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center text-xs font-semibold uppercase text-muted">
                 {mem.type && mem.type !== "undefined"
                   ? mem.type.slice(0, 1)
                   : "M"}
@@ -1524,13 +1524,13 @@ export function VectorBrowserView({
                 </span>
                 <span className="mt-1 flex flex-wrap gap-1.5 text-2xs text-muted">
                   {mem.embedding ? (
-                    <span className="inline-flex items-center gap-1 rounded-sm bg-bg-muted/55 px-1.5 py-0.5">
+                    <span className="inline-flex items-center gap-1 px-1 py-0.5">
                       <Layers3 className="h-3 w-3" aria-hidden />
                       {mem.embedding.length}D
                     </span>
                   ) : null}
                   {createdLabel ? (
-                    <span className="inline-flex items-center gap-1 rounded-sm bg-bg-muted/55 px-1.5 py-0.5">
+                    <span className="inline-flex items-center gap-1 px-1 py-0.5">
                       <Clock3 className="h-3 w-3" aria-hidden />
                       {createdLabel}
                     </span>
@@ -1586,7 +1586,7 @@ export function VectorBrowserView({
             />
           )}
         </PagePanel>
-        <div className="max-h-[42vh] min-h-[14rem] overflow-auto rounded-sm border border-border/40 bg-card/45">
+        <div className="max-h-[42vh] min-h-[14rem] overflow-auto">
           <MemoryDetailPanel memory={selectedMemory} />
         </div>
       </>
@@ -1604,7 +1604,7 @@ export function VectorBrowserView({
             />
           )}
         </PagePanel>
-        <div className="max-h-[42vh] min-h-[14rem] overflow-auto rounded-sm border border-border/40 bg-card/45">
+        <div className="max-h-[42vh] min-h-[14rem] overflow-auto">
           <MemoryDetailPanel memory={selectedMemory} />
         </div>
       </>
@@ -1623,7 +1623,7 @@ export function VectorBrowserView({
             })}
           </Button>
         </div>
-        <div className="max-h-[70vh] min-h-[14rem] overflow-auto rounded-sm border border-border/40 bg-card/45">
+        <div className="max-h-[70vh] min-h-[14rem] overflow-auto">
           <MemoryDetailPanel memory={selectedMemory} />
         </div>
       </>
@@ -1636,11 +1636,11 @@ export function VectorBrowserView({
     <WorkspaceLayout contentHeader={contentHeader} contentPadding={false}>
       {isConnectionError ? (
         <div className="flex flex-1 items-center justify-center p-6">
-          <div className="rounded-sm border border-border/35 bg-bg/35 px-8 py-10 text-center ">
+          <div className="px-8 py-10 text-center">
             <div className="text-base font-semibold text-txt">
               {t("databaseview.DatabaseNotAvailab")}
             </div>
-            <div className="mt-2 max-w-sm text-sm text-muted">
+            <div className="sr-only mt-2 max-w-sm text-sm text-muted">
               {t("vectorbrowserview.StartTheAgentToB")}
             </div>
             <Button
@@ -1663,9 +1663,7 @@ export function VectorBrowserView({
           {summaryHeader}
           {toolbar}
           {error ? (
-            <div className="rounded-sm border border-danger/35 bg-danger/10 px-4 py-3 text-sm text-danger">
-              {error}
-            </div>
+            <div className="px-1 py-2 text-sm text-danger">{error}</div>
           ) : null}
           {mainSection}
         </div>

--- a/plugins/plugin-vector-browser/test/VectorBrowserView.test.tsx
+++ b/plugins/plugin-vector-browser/test/VectorBrowserView.test.tsx
@@ -415,9 +415,7 @@ describe("VectorBrowserView — populated list", () => {
     backend.total = 0;
     backend.memoryRows = () => [];
     render(<VectorBrowserView />);
-    expect(
-      await screen.findByText("No memory records detected in the database."),
-    ).toBeTruthy();
+    expect(await screen.findByText("No records.")).toBeTruthy();
   });
 
   it("falls back content to (empty) when content is blank", async () => {

--- a/plugins/plugin-vincent/src/TradingProfileCard.test.tsx
+++ b/plugins/plugin-vincent/src/TradingProfileCard.test.tsx
@@ -46,9 +46,9 @@ describe("TradingProfileCard — null profile", () => {
   it("renders the minimal placeholder with no stat tiles", () => {
     render(<TradingProfileCard tradingProfile={null} />);
 
-    // The placeholder shows a "No analytics" dot but none of the populated
+    // The placeholder shows a compact empty dot but none of the populated
     // tile values / labels.
-    expect(screen.getByTitle("No analytics")).toBeTruthy();
+    expect(screen.getByTitle("None")).toBeTruthy();
     expect(screen.queryByText("Swaps")).toBeNull();
     expect(screen.queryByText("Win")).toBeNull();
     expect(screen.queryByText(/%$/)).toBeNull();

--- a/plugins/plugin-vincent/src/TradingProfileCard.tsx
+++ b/plugins/plugin-vincent/src/TradingProfileCard.tsx
@@ -46,10 +46,7 @@ export const TradingProfileCard = memo(function TradingProfileCard({
       <div className="px-1 py-3">
         <div className="flex items-center justify-between gap-3">
           <TrendingUp className="h-4 w-4 text-muted/50" />
-          <span
-            className="h-2 w-2 rounded-full bg-muted/50"
-            title="No analytics"
-          />
+          <span className="h-2 w-2 rounded-full bg-muted/50" title="None" />
         </div>
       </div>
     );

--- a/plugins/plugin-vincent/src/TradingProfileCard.tsx
+++ b/plugins/plugin-vincent/src/TradingProfileCard.tsx
@@ -43,7 +43,7 @@ export const TradingProfileCard = memo(function TradingProfileCard({
 }: TradingProfileCardProps) {
   if (!tradingProfile) {
     return (
-      <div className="rounded-2xl border border-border/18 px-4 py-3">
+      <div className="px-1 py-3">
         <div className="flex items-center justify-between gap-3">
           <TrendingUp className="h-4 w-4 text-muted/50" />
           <span
@@ -59,7 +59,7 @@ export const TradingProfileCard = memo(function TradingProfileCard({
     tradingProfile;
 
   return (
-    <div className="space-y-3 rounded-2xl border border-border/18 px-4 py-4">
+    <div className="space-y-3 px-1 py-3">
       {/* Header */}
       <div className="flex items-center gap-2">
         <TrendingUp className="h-4 w-4 text-accent" />
@@ -88,7 +88,7 @@ export const TradingProfileCard = memo(function TradingProfileCard({
           {tokenBreakdown.slice(0, 8).map((tok) => (
             <span
               key={tok.symbol}
-              className="inline-flex items-center gap-2 rounded-full border border-border/25 bg-card/55 px-3 py-1.5 text-xs font-semibold text-muted"
+              className="inline-flex items-center gap-2 px-1 py-1.5 text-xs font-semibold text-muted"
             >
               <span className="h-1.5 w-1.5 rounded-full bg-ok" />
               <span className="text-txt">{tok.symbol}</span>

--- a/plugins/plugin-vincent/src/TradingStrategyPanel.tsx
+++ b/plugins/plugin-vincent/src/TradingStrategyPanel.tsx
@@ -43,7 +43,7 @@ export const TradingStrategyPanel = memo(function TradingStrategyPanel({
   });
 
   return (
-    <div className="space-y-3 rounded-2xl border border-border/18 px-4 py-4">
+    <div className="space-y-3 px-1 py-3">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Activity className="h-4 w-4 text-accent" />
@@ -109,7 +109,7 @@ export const TradingStrategyPanel = memo(function TradingStrategyPanel({
             {paramEntries.slice(0, 6).map(([key, val]) => (
               <span
                 key={key}
-                className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-border/25 bg-card/55 px-3 py-1.5 text-xs font-semibold text-muted"
+                className="inline-flex max-w-full items-center gap-1.5 px-1 py-1.5 text-xs font-semibold text-muted"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-accent/70" />
                 <span className="truncate">{key}</span>
@@ -119,7 +119,7 @@ export const TradingStrategyPanel = memo(function TradingStrategyPanel({
               </span>
             ))}
             {paramEntries.length > 6 ? (
-              <span className="inline-flex items-center rounded-full border border-border/25 bg-card/55 px-3 py-1.5 text-xs font-semibold text-muted">
+              <span className="inline-flex items-center px-1 py-1.5 text-xs font-semibold text-muted">
                 +{paramEntries.length - 6}
               </span>
             ) : null}
@@ -129,7 +129,7 @@ export const TradingStrategyPanel = memo(function TradingStrategyPanel({
             asChild
             variant="outline"
             size="sm"
-            className="h-9 w-fit rounded-xl px-4 text-xs font-semibold"
+            className="h-9 w-fit px-4 text-xs font-semibold"
           >
             <a
               ref={openVincent.ref}

--- a/plugins/plugin-vincent/src/VincentAppView.tsx
+++ b/plugins/plugin-vincent/src/VincentAppView.tsx
@@ -56,14 +56,14 @@ export function VincentAppView({ exitToApps, t }: OverlayAppContext) {
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
       {/* Header */}
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center justify-between gap-3 px-3 py-2">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Button
             ref={back.ref}
             {...back.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 shrink-0 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 shrink-0 text-muted hover:text-txt"
             onClick={exitToApps}
             aria-label={backLabel}
           >
@@ -78,10 +78,8 @@ export function VincentAppView({ exitToApps, t }: OverlayAppContext) {
           {/* Connection status pill */}
           <span
             data-testid="vincent-status-card"
-            className={`inline-flex max-w-[8.5rem] items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs-tight font-semibold ${
-              vincentConnected
-                ? "border-ok/35 bg-ok/12 text-ok"
-                : "border-border bg-bg-accent text-muted"
+            className={`inline-flex max-w-[8.5rem] items-center gap-1.5 px-1 py-1 text-xs-tight font-semibold ${
+              vincentConnected ? "text-ok" : "text-muted"
             }`}
           >
             <span
@@ -101,7 +99,7 @@ export function VincentAppView({ exitToApps, t }: OverlayAppContext) {
             {...refreshControl.agentProps}
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-xl text-muted hover:text-txt"
+            className="h-9 w-9 text-muted hover:text-txt"
             onClick={refresh}
             disabled={loading}
             aria-label={refreshLabel}
@@ -112,7 +110,7 @@ export function VincentAppView({ exitToApps, t }: OverlayAppContext) {
       </div>
 
       {/* Scrollable content */}
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 pb-32 pt-4 sm:px-6 sm:pb-36">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 pb-32 pt-2 sm:px-5 sm:pb-36">
         <div className="mx-auto max-w-5xl">
           {/* Error banner */}
           {error && <PagePanel.Notice tone="danger">{error}</PagePanel.Notice>}
@@ -126,7 +124,7 @@ export function VincentAppView({ exitToApps, t }: OverlayAppContext) {
           )}
 
           <div className="flex flex-col gap-4">
-            <div className="space-y-4">
+            <div className="space-y-3">
               <VincentConnectionCard setActionNotice={setActionNotice} t={t} />
 
               {vincentConnected && (

--- a/plugins/plugin-vincent/src/VincentConnectionCard.tsx
+++ b/plugins/plugin-vincent/src/VincentConnectionCard.tsx
@@ -66,7 +66,7 @@ export const VincentConnectionCard = memo(function VincentConnectionCard({
   });
 
   return (
-    <div className="rounded-2xl border border-border/18 px-4 py-4">
+    <div className="px-1 py-3">
       <div className="flex items-center justify-between gap-4">
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-5 gap-y-1.5 text-xs font-semibold">
           <span
@@ -104,7 +104,7 @@ export const VincentConnectionCard = memo(function VincentConnectionCard({
               {...disconnect.agentProps}
               variant="outline"
               size="sm"
-              className="h-9 rounded-xl px-4 text-xs font-semibold text-status-danger border-status-danger/30 hover:bg-status-danger-bg hover:text-status-danger"
+              className="h-9 px-4 text-xs font-semibold text-status-danger border-status-danger/30 hover:bg-status-danger-bg hover:text-status-danger"
               onClick={() => void handleVincentDisconnect()}
               aria-label={disconnectLabel}
             >
@@ -117,7 +117,7 @@ export const VincentConnectionCard = memo(function VincentConnectionCard({
               {...connect.agentProps}
               variant="default"
               size="sm"
-              className="h-9 rounded-xl px-4 text-xs font-semibold"
+              className="h-9 px-4 text-xs font-semibold"
               onClick={() => void handleVincentLogin()}
               disabled={vincentLoginBusy}
               aria-label={connectLabel}
@@ -136,7 +136,7 @@ export const VincentConnectionCard = memo(function VincentConnectionCard({
       </div>
 
       {vincentLoginError && (
-        <div className="mt-3 rounded-lg border border-status-danger/20 bg-status-danger-bg px-3 py-2 text-xs text-status-danger">
+        <div className="mt-3 px-1 py-2 text-xs text-status-danger">
           {vincentLoginError}
         </div>
       )}

--- a/plugins/plugin-vincent/src/WalletStatusCard.tsx
+++ b/plugins/plugin-vincent/src/WalletStatusCard.tsx
@@ -181,10 +181,7 @@ export const WalletStatusCard = memo(function WalletStatusCard({
 
   if (!hasAddresses && !walletBalances) {
     return (
-      <div
-        data-testid="vincent-wallet-status-card"
-        className="rounded-2xl border border-border/18 px-5 py-4"
-      >
+      <div data-testid="vincent-wallet-status-card" className="px-1 py-3">
         <div className="flex items-center gap-2">
           <Wallet className="h-4 w-4 text-muted/50" />
           <span className="text-sm text-muted">Wallet loading</span>
@@ -196,7 +193,7 @@ export const WalletStatusCard = memo(function WalletStatusCard({
   return (
     <div
       data-testid="vincent-wallet-status-card"
-      className="space-y-3 rounded-2xl border border-border/18 px-4 py-4"
+      className="space-y-3 px-1 py-3"
     >
       {/* Header row */}
       <div className="flex items-center justify-between gap-3">

--- a/plugins/plugin-vincent/src/components/VincentSpatialView.test.tsx
+++ b/plugins/plugin-vincent/src/components/VincentSpatialView.test.tsx
@@ -45,7 +45,6 @@ describe("VincentSpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Vincent");
       expect(flat).toContain("connected");
       expect(flat).toContain("threshold");
       expect(flat).toContain("running");

--- a/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
+++ b/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
@@ -258,7 +258,7 @@ export function VincentSpatialView({
             </List>
           ) : (
             <Text tone="muted" style="caption">
-              No P&amp;L data yet.
+              No P&amp;L
             </Text>
           )}
           <HStack gap={1} wrap>
@@ -274,7 +274,7 @@ export function VincentSpatialView({
         </VStack>
       ) : (
         <Text tone="muted" align="center" style="caption">
-          No strategy configured
+          No strategy
         </Text>
       )}
     </Card>

--- a/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
+++ b/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
@@ -90,7 +90,7 @@ export function VincentSpatialView({
   } = snapshot;
 
   return (
-    <Card title="Vincent" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text
           style="caption"

--- a/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
+++ b/plugins/plugin-vincent/src/components/VincentSpatialView.tsx
@@ -274,7 +274,7 @@ export function VincentSpatialView({
         </VStack>
       ) : (
         <Text tone="muted" align="center" style="caption">
-          No strategy
+          None
         </Text>
       )}
     </Card>

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.test.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.test.tsx
@@ -124,7 +124,7 @@ describe("ImageGenAppView", () => {
   it("warns when no agent token is configured", () => {
     delete (window as unknown as Record<string, unknown>).__WAIFU_IMAGEGEN__;
     render(React.createElement(ImageGenAppView, ctx()));
-    expect(screen.getByText("No agent configured.")).toBeTruthy();
+    expect(screen.getByText("Unavailable")).toBeTruthy();
     expect(invokeImageGen).not.toHaveBeenCalled();
   });
 

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.test.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.test.tsx
@@ -124,9 +124,7 @@ describe("ImageGenAppView", () => {
   it("warns when no agent token is configured", () => {
     delete (window as unknown as Record<string, unknown>).__WAIFU_IMAGEGEN__;
     render(React.createElement(ImageGenAppView, ctx()));
-    expect(
-      screen.getByText("No agent is configured for image generation."),
-    ).toBeTruthy();
+    expect(screen.getByText("No agent configured.")).toBeTruthy();
     expect(invokeImageGen).not.toHaveBeenCalled();
   });
 

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
@@ -142,7 +142,7 @@ export function ImageGenAppView({
         <div className="mx-auto max-w-3xl space-y-3">
           {!config.agentTokenAddress && (
             <PagePanel.Notice tone="warning">
-              No agent is configured for image generation.
+              No agent configured.
             </PagePanel.Notice>
           )}
 

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
@@ -141,9 +141,7 @@ export function ImageGenAppView({
       <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-2 sm:px-5">
         <div className="mx-auto max-w-3xl space-y-3">
           {!config.agentTokenAddress && (
-            <PagePanel.Notice tone="warning">
-              No agent configured.
-            </PagePanel.Notice>
+            <PagePanel.Notice tone="warning">Unavailable</PagePanel.Notice>
           )}
 
           <PriceStrip metadata={config.metadata} />

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenAppView.tsx
@@ -15,7 +15,7 @@ import { useImageGenState } from "./useImageGenState";
 function SettlementPill() {
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full border border-ok/35 bg-ok/12 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ok"
+      className="inline-flex items-center gap-1.5 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ok"
       role="status"
       aria-label="Settled in credits"
     >
@@ -120,7 +120,7 @@ export function ImageGenAppView({
       data-testid="imagegen-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
     >
-      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center gap-3 px-3 py-2">
         <Button
           ref={backButton.ref}
           {...backButton.agentProps}
@@ -138,8 +138,8 @@ export function ImageGenAppView({
         </div>
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
-        <div className="mx-auto max-w-3xl space-y-4">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-2 sm:px-5">
+        <div className="mx-auto max-w-3xl space-y-3">
           {!config.agentTokenAddress && (
             <PagePanel.Notice tone="warning">
               No agent is configured for image generation.
@@ -148,7 +148,7 @@ export function ImageGenAppView({
 
           <PriceStrip metadata={config.metadata} />
 
-          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+          <section className="py-2">
             <label
               htmlFor={promptId}
               className="mb-1.5 block text-xs font-semibold uppercase tracking-[0.12em] text-muted"
@@ -165,7 +165,7 @@ export function ImageGenAppView({
               rows={3}
               placeholder="describe the image you want"
               disabled={busy}
-              className="w-full resize-none rounded-md border border-border bg-bg-accent px-3 py-2 text-sm text-txt outline-none transition-colors placeholder:text-muted focus:border-accent/50 disabled:opacity-60"
+              className="w-full resize-none border border-border/40 bg-bg/60 px-3 py-2 text-sm text-txt outline-none transition-colors placeholder:text-muted focus:border-accent/50 disabled:opacity-60"
             />
             <div className="mt-1 flex items-center justify-between text-[11px] uppercase tracking-[0.12em] text-muted">
               <span>aspect</span>
@@ -256,11 +256,11 @@ export function ImageGenAppView({
           )}
 
           {result?.imageUrl && (
-            <figure className="rounded-lg border border-border/24 bg-card/50 p-3">
+            <figure className="p-1">
               <img
                 src={result.imageUrl}
                 alt={result.prompt}
-                className="w-full rounded-md border border-border object-contain"
+                className="w-full object-contain"
               />
               <figcaption className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs uppercase tracking-[0.12em] text-muted">
                 <span className="inline-flex items-center gap-1.5">

--- a/plugins/plugin-waifu-imagegen-app/src/ImageGenSpatialView.tsx
+++ b/plugins/plugin-waifu-imagegen-app/src/ImageGenSpatialView.tsx
@@ -79,13 +79,15 @@ export function ImageGenSpatialView({
   const balance = formatUsd(result?.charge?.balance);
 
   return (
-    <Card title="Image Generation" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="caption" tone="success" grow={1}>
           credits-settled
         </Text>
         <Text style="caption" tone="muted">
-          {snapshot.markupPct == null ? "markup n/a" : `markup +${snapshot.markupPct}%`}
+          {snapshot.markupPct == null
+            ? "markup n/a"
+            : `markup +${snapshot.markupPct}%`}
         </Text>
       </HStack>
 

--- a/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
+++ b/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
@@ -223,9 +223,7 @@ export function SwapAppView({
       <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-2 sm:px-5">
         <div className="mx-auto max-w-xl space-y-3">
           {!config.agentTokenAddress && (
-            <PagePanel.Notice tone="warning">
-              No agent configured.
-            </PagePanel.Notice>
+            <PagePanel.Notice tone="warning">Unavailable</PagePanel.Notice>
           )}
 
           {/* From */}

--- a/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
+++ b/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
@@ -38,8 +38,8 @@ function shortAddress(address: string): string {
 
 function TokenChip({ token }: { token: SwapToken }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-md border border-border bg-bg-accent px-2.5 py-1.5">
-      <span className="grid h-5 w-5 place-items-center rounded-full border border-border/40 bg-card text-[10px] font-semibold text-muted">
+    <span className="inline-flex items-center gap-2 px-1 py-1.5">
+      <span className="grid h-5 w-5 place-items-center text-[10px] font-semibold text-muted">
         {token.symbol.slice(0, 2).toUpperCase()}
       </span>
       <span className="font-mono text-xs text-txt">{token.symbol}</span>
@@ -196,7 +196,7 @@ export function SwapAppView({
       data-testid="swap-shell"
       className="fixed inset-0 z-50 flex h-[100vh] flex-col overflow-hidden bg-bg supports-[height:100dvh]:h-[100dvh]"
     >
-      <div className="flex shrink-0 items-center gap-3 border-b border-border/20 bg-bg/80 px-4 py-3 backdrop-blur-sm">
+      <div className="flex shrink-0 items-center gap-3 px-3 py-2">
         <Button
           ref={backButton.ref}
           {...backButton.agentProps}
@@ -215,13 +215,13 @@ export function SwapAppView({
 
         <div className="flex-1" />
 
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-border/35 bg-bg-accent px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted">
+        <span className="inline-flex items-center gap-1.5 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted">
           PancakeSwap v3
         </span>
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-4 py-4 sm:px-6">
-        <div className="mx-auto max-w-xl space-y-4">
+      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 py-2 sm:px-5">
+        <div className="mx-auto max-w-xl space-y-3">
           {!config.agentTokenAddress && (
             <PagePanel.Notice tone="warning">
               No agent is configured for swapping.
@@ -229,7 +229,7 @@ export function SwapAppView({
           )}
 
           {/* From */}
-          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+          <section className="py-2">
             <div className="mb-2 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
               <span>from</span>
             </div>
@@ -264,7 +264,7 @@ export function SwapAppView({
               {...reverseButton.agentProps}
               variant="ghost"
               size="icon"
-              className="h-9 w-9 rounded-full border border-border/40 bg-bg text-muted hover:text-accent"
+              className="h-9 w-9 text-muted hover:text-accent"
               onClick={reverse}
               disabled={executing}
               aria-label="Reverse direction"
@@ -274,7 +274,7 @@ export function SwapAppView({
           </div>
 
           {/* To */}
-          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+          <section className="py-2">
             <div className="mb-2 flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
               <span>to (estimate)</span>
               {quoting ? (
@@ -304,7 +304,7 @@ export function SwapAppView({
           </section>
 
           {/* Slippage + fee controls */}
-          <section className="rounded-lg border border-border/24 bg-card/50 p-4">
+          <section className="py-2">
             <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
               <Settings2 className="h-3.5 w-3.5" />
               slippage tolerance
@@ -349,7 +349,7 @@ export function SwapAppView({
 
           {/* Route detail */}
           {quote && amountValid ? (
-            <dl className="space-y-2 rounded-lg border border-border/24 bg-bg-accent px-4 py-3 text-xs">
+            <dl className="space-y-2 px-1 py-2 text-xs">
               <DetailRow label="route">
                 <span className="inline-flex items-center gap-1.5">
                   <ArrowLeftRight className="h-3.5 w-3.5 text-muted" />
@@ -380,13 +380,13 @@ export function SwapAppView({
 
           {/* Outcome */}
           {outcome?.kind === "stubbed" && (
-            <div className="flex items-start gap-2 rounded-lg border border-border/24 bg-bg-accent px-4 py-3 text-sm text-muted">
+            <div className="flex items-start gap-2 px-1 py-2 text-sm text-muted">
               <Info className="mt-0.5 h-4 w-4 shrink-0" />
               <span>{outcome.message}</span>
             </div>
           )}
           {outcome?.kind === "prepared" && (
-            <div className="flex items-start gap-2 rounded-lg border border-ok/35 bg-ok/12 px-4 py-3 text-sm text-ok">
+            <div className="flex items-start gap-2 px-1 py-2 text-sm text-ok">
               <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
               <span>
                 transaction prepared for {shortAddress(outcome.to)} — sign in
@@ -419,7 +419,7 @@ export function SwapAppView({
           </Button>
 
           {!executeEnabled && (
-            <p className="text-center text-xs text-muted">
+            <p className="sr-only">
               quote-only preview — on-chain execution lands when the agent
               signer is enabled
             </p>

--- a/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
+++ b/plugins/plugin-waifu-swap-app/src/SwapAppView.tsx
@@ -224,7 +224,7 @@ export function SwapAppView({
         <div className="mx-auto max-w-xl space-y-3">
           {!config.agentTokenAddress && (
             <PagePanel.Notice tone="warning">
-              No agent is configured for swapping.
+              No agent configured.
             </PagePanel.Notice>
           )}
 

--- a/plugins/plugin-waifu-swap-app/src/SwapSpatialView.tsx
+++ b/plugins/plugin-waifu-swap-app/src/SwapSpatialView.tsx
@@ -16,7 +16,14 @@
  * rather than fabricating a money path.
  */
 
-import { Button, Card, Divider, Field, HStack, Text } from "@elizaos/ui/spatial";
+import {
+  Button,
+  Card,
+  Divider,
+  Field,
+  HStack,
+  Text,
+} from "@elizaos/ui/spatial";
 
 /** Projected, display-only quote numbers. */
 export interface SwapSnapshotQuote {
@@ -69,7 +76,7 @@ export function SwapSpatialView({ snapshot, onAction }: SwapSpatialViewProps) {
   const impactDanger = (quote?.priceImpactPct ?? 0) < -1;
 
   return (
-    <Card title="Swap" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="caption" tone="muted" grow={1}>
           PancakeSwap v3

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -562,11 +562,11 @@ describe("InventoryView GUI — P&L window selector + chart", () => {
     await screen.findByTestId("wallets-sidebar");
 
     // PnlChart renders a polyline (pnlSeries has >=2 finite points), not the
-    // empty "No realized P&L yet" placeholder.
+    // empty "P&L pending" placeholder.
     await waitFor(() =>
       expect(container.querySelector("polyline")).toBeTruthy(),
     );
-    expect(screen.queryByText("No realized P&L yet")).toBeNull();
+    expect(screen.queryByText("P&L pending")).toBeNull();
 
     // SummaryChip shows the formatted realized P&L (1.5 BNB, positive).
     expect(screen.getByText("+1.5 BNB")).toBeTruthy();
@@ -601,7 +601,7 @@ describe("InventoryView GUI — P&L window selector + chart", () => {
     appHooks.useApp.mockReturnValue(makeAppState());
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
-    expect(await screen.findByText("No realized P&L yet")).toBeTruthy();
+    expect(await screen.findByText("P&L pending")).toBeTruthy();
   });
 });
 
@@ -657,7 +657,7 @@ describe("InventoryView GUI — dashboard panels", () => {
     // Danger banner.
     expect(screen.getByText("RPC provider unreachable")).toBeTruthy();
     // Empty panels.
-    expect(await screen.findByText("No activity yet")).toBeTruthy();
+    expect(await screen.findByText("No activity")).toBeTruthy();
     expect(screen.getByText("No positions")).toBeTruthy();
     expect(screen.getByText("No NFTs")).toBeTruthy();
   });
@@ -679,8 +679,8 @@ describe("InventoryView GUI — empty wallet / market pulse hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    // WalletEmptyHero "not configured" variant + Configure keys CTA.
-    expect(await screen.findByText("Wallet not configured")).toBeTruthy();
+    // WalletEmptyHero unconfigured variant + Configure keys CTA.
+    expect(await screen.findByText("Configure wallet")).toBeTruthy();
     const configure = screen.getByRole("button", { name: "Configure keys" });
     fireEvent.click(configure);
     expect(state.setTab).toHaveBeenCalledWith("settings");
@@ -734,7 +734,7 @@ describe("InventoryView GUI — empty wallet / market pulse hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    expect(await screen.findByText("Top movers unavailable")).toBeTruthy();
-    expect(screen.getByText("CoinGecko rate limited")).toBeTruthy();
+    expect(await screen.findByText("Unavailable")).toBeTruthy();
+    expect(screen.getByTitle("Top movers unavailable")).toBeTruthy();
   });
 });

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -406,7 +406,7 @@ describe("InventoryView GUI — rail tab switching", () => {
 
     // DeFi: no LP-like positions in the fixture -> empty state.
     fireEvent.click(within(sidebar).getByRole("button", { name: "DeFi" }));
-    expect(within(sidebar).getByText("No positions")).toBeTruthy();
+    expect(within(sidebar).getByText("None")).toBeTruthy();
     expect(
       within(sidebar).queryByText(hasFlatText("100.0000 USDC")),
     ).toBeNull();
@@ -479,7 +479,7 @@ describe("InventoryView GUI — address copy buttons", () => {
     const sidebar = await screen.findByTestId("wallets-sidebar");
 
     const evmCopy = within(sidebar).getByRole("button", {
-      name: "Copy No EVM address",
+      name: "Copy EVM address",
     });
     fireEvent.click(evmCopy);
     await waitFor(() =>
@@ -487,7 +487,7 @@ describe("InventoryView GUI — address copy buttons", () => {
     );
 
     const solCopy = within(sidebar).getByRole("button", {
-      name: "Copy No SOL address",
+      name: "Copy SOL address",
     });
     fireEvent.click(solCopy);
     await waitFor(() =>
@@ -657,9 +657,7 @@ describe("InventoryView GUI — dashboard panels", () => {
     // Danger banner.
     expect(screen.getByText("RPC provider unreachable")).toBeTruthy();
     // Empty panels.
-    expect(await screen.findByText("No activity")).toBeTruthy();
-    expect(screen.getByText("No positions")).toBeTruthy();
-    expect(screen.getByText("No NFTs")).toBeTruthy();
+    expect(await screen.findAllByText("None")).not.toHaveLength(0);
   });
 });
 
@@ -679,9 +677,9 @@ describe("InventoryView GUI — empty wallet / market pulse hero", () => {
     render(React.createElement(InventoryAppView));
     await screen.findByTestId("wallets-sidebar");
 
-    // WalletEmptyHero unconfigured variant + Configure keys CTA.
-    expect(await screen.findByText("Configure wallet")).toBeTruthy();
-    const configure = screen.getByRole("button", { name: "Configure keys" });
+    // WalletEmptyHero unconfigured variant + keys CTA.
+    expect((await screen.findAllByText("Wallet")).length).toBeGreaterThan(0);
+    const configure = screen.getByRole("button", { name: "Keys" });
     fireEvent.click(configure);
     expect(state.setTab).toHaveBeenCalledWith("settings");
     expect(window.location.hash).toBe("#wallet-rpc");

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -676,7 +676,7 @@ function PortfolioMoversPanel({
       );
     }
 
-    return <EmptyState icon={TrendingUp} title="No movers yet" />;
+    return <EmptyState icon={TrendingUp} title="No movers" />;
   }
 
   return (
@@ -783,9 +783,9 @@ function MarketDataUnavailable({
   source: WalletMarketOverviewSource;
 }) {
   return (
-    <div className="px-1 py-2">
-      <div className="text-sm font-semibold text-warn">{title} unavailable</div>
-      <div className="mt-1 text-xs text-muted">
+    <div className="px-1 py-2" title={`${title} unavailable`}>
+      <div className="text-sm font-semibold text-warn">Unavailable</div>
+      <div className="sr-only mt-1 text-xs text-muted">
         {source.error ?? `${source.providerName} did not return live data.`}
       </div>
     </div>
@@ -837,7 +837,7 @@ function MarketPriceGrid({
   }
 
   if (prices.length === 0) {
-    return <EmptyState icon={BarChart3} title="No price snapshots yet" />;
+    return <EmptyState icon={BarChart3} title="No prices" />;
   }
 
   return (
@@ -861,7 +861,7 @@ function MarketMoverList({
   }
 
   if (movers.length === 0) {
-    return <EmptyState icon={TrendingUp} title="No market movers yet" />;
+    return <EmptyState icon={TrendingUp} title="No movers" />;
   }
 
   return (
@@ -965,7 +965,7 @@ function WalletEmptyHero({
     <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
       <WalletMotif />
       <div className="text-base font-semibold text-txt">
-        {hasKeys ? "No assets yet" : "Wallet not configured"}
+        {hasKeys ? "No assets" : "Configure wallet"}
       </div>
       {hasKeys ? null : (
         <Button
@@ -1108,7 +1108,7 @@ function PnlChart({
   if (values.length < 2) {
     return (
       <div className="flex h-40 items-center justify-center text-xs text-muted">
-        No realized P&L yet
+        P&amp;L pending
       </div>
     );
   }
@@ -1846,7 +1846,7 @@ function ActivityLog({
   );
 
   if (entries.length === 0) {
-    return <EmptyState icon={Activity} title="No activity yet" />;
+    return <EmptyState icon={Activity} title="No activity" />;
   }
 
   return (

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -676,7 +676,7 @@ function PortfolioMoversPanel({
       );
     }
 
-    return <EmptyState icon={TrendingUp} title="No movers" />;
+    return <EmptyState icon={TrendingUp} title="None" />;
   }
 
   return (
@@ -837,7 +837,7 @@ function MarketPriceGrid({
   }
 
   if (prices.length === 0) {
-    return <EmptyState icon={BarChart3} title="No prices" />;
+    return <EmptyState icon={BarChart3} title="None" />;
   }
 
   return (
@@ -861,7 +861,7 @@ function MarketMoverList({
   }
 
   if (movers.length === 0) {
-    return <EmptyState icon={TrendingUp} title="No movers" />;
+    return <EmptyState icon={TrendingUp} title="None" />;
   }
 
   return (
@@ -965,7 +965,7 @@ function WalletEmptyHero({
     <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
       <WalletMotif />
       <div className="text-base font-semibold text-txt">
-        {hasKeys ? "No assets" : "Configure wallet"}
+        {hasKeys ? "None" : "Wallet"}
       </div>
       {hasKeys ? null : (
         <Button
@@ -974,7 +974,7 @@ function WalletEmptyHero({
           size="sm"
           onClick={onConfigureKeys}
         >
-          Configure keys
+          Keys
         </Button>
       )}
     </div>
@@ -1305,7 +1305,7 @@ function WalletAddressCluster({
       <WalletRailAddress
         address={addresses.evmAddress}
         chains={SUPPORTED_WALLET_CHAINS.filter((chain) => chain !== "solana")}
-        emptyLabel="No EVM"
+        emptyLabel="EVM"
         label="EVM"
         agentId="account-copy-evm-address"
         agentLabel="EVM address"
@@ -1313,7 +1313,7 @@ function WalletAddressCluster({
       <WalletRailAddress
         address={addresses.solanaAddress}
         chains={["solana"]}
-        emptyLabel="No SOL"
+        emptyLabel="SOL"
         label="SOL"
         agentId="account-copy-solana-address"
         agentLabel="Solana address"
@@ -1478,9 +1478,7 @@ function WalletRailEmpty({
     <div className="flex min-h-[13rem] flex-col items-center justify-center px-5 text-center">
       <Icon className="mb-3 h-5 w-5 text-muted" />
       <div className="text-sm font-semibold text-txt">{title}</div>
-      {body ? (
-        <div className="mt-1 text-xs-tight text-muted">{body}</div>
-      ) : null}
+      {body ? <div className="sr-only">{body}</div> : null}
     </div>
   );
 }
@@ -1564,7 +1562,7 @@ const TokenRailRow = memo(
 
 function RailNftList({ nfts }: { nfts: NftItem[] }) {
   if (nfts.length === 0) {
-    return <WalletRailEmpty icon={ImageIcon} title="No NFTs" />;
+    return <WalletRailEmpty icon={ImageIcon} title="None" />;
   }
 
   return (
@@ -1606,7 +1604,7 @@ function RailPositionList({
   positions: InventoryPositionAsset[];
 }) {
   if (positions.length === 0) {
-    return <WalletRailEmpty icon={Layers3} title="No positions" />;
+    return <WalletRailEmpty icon={Layers3} title="None" />;
   }
 
   return (
@@ -1751,7 +1749,7 @@ function WalletHoldingsSection({
         <div className="space-y-1">
           {activeTab === "tokens" ? (
             visibleRows.length === 0 ? (
-              <WalletRailEmpty icon={Wallet} title="No assets" />
+              <WalletRailEmpty icon={Wallet} title="None" />
             ) : (
               visibleRows.map((row) => (
                 <TokenRailRow
@@ -1846,7 +1844,7 @@ function ActivityLog({
   );
 
   if (entries.length === 0) {
-    return <EmptyState icon={Activity} title="No activity" />;
+    return <EmptyState icon={Activity} title="None" />;
   }
 
   return (
@@ -1909,7 +1907,7 @@ function NftPreview({ nfts }: { nfts: NftItem[] }) {
   const visible = nfts.slice(0, 6);
 
   if (visible.length === 0) {
-    return <EmptyState icon={ImageIcon} title="No NFTs" />;
+    return <EmptyState icon={ImageIcon} title="None" />;
   }
 
   return (
@@ -1951,7 +1949,7 @@ function LpPositionsPanel({
   positions: InventoryPositionAsset[];
 }) {
   if (positions.length === 0) {
-    return <EmptyState icon={Layers3} title="No positions" />;
+    return <EmptyState icon={Layers3} title="None" />;
   }
 
   return (

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -42,8 +42,8 @@ import {
   Wallet,
 } from "lucide-react";
 import {
-  type ReactNode,
   memo,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -707,11 +707,13 @@ function EmptyState({
   body?: string;
 }) {
   return (
-    <div className="flex min-h-[8rem] flex-col items-center justify-center rounded-2xl bg-bg/30 px-4 py-6 text-center">
+    <div className="flex min-h-[8rem] flex-col items-center justify-center px-4 py-6 text-center">
       <Icon className="mb-3 h-5 w-5 text-muted" />
       <div className="text-sm font-semibold text-txt">{title}</div>
       {body ? (
-        <div className="mt-1 max-w-sm text-xs-tight text-muted">{body}</div>
+        <div className="sr-only mt-1 max-w-sm text-xs-tight text-muted">
+          {body}
+        </div>
       ) : null}
     </div>
   );
@@ -729,14 +731,14 @@ function MarketAvatar({
       <img
         src={imageUrl}
         alt={label}
-        className="h-11 w-11 shrink-0 rounded-2xl object-cover"
+        className="h-11 w-11 shrink-0 object-cover"
         loading="lazy"
       />
     );
   }
 
   return (
-    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-bg/65 text-sm font-semibold text-txt">
+    <div className="flex h-11 w-11 shrink-0 items-center justify-center text-sm font-semibold text-txt">
       {label.slice(0, 1).toUpperCase()}
     </div>
   );
@@ -781,7 +783,7 @@ function MarketDataUnavailable({
   source: WalletMarketOverviewSource;
 }) {
   return (
-    <div className="rounded-2xl border border-warn/20 bg-warn/10 px-4 py-3">
+    <div className="px-1 py-2">
       <div className="text-sm font-semibold text-warn">{title} unavailable</div>
       <div className="mt-1 text-xs text-muted">
         {source.error ?? `${source.providerName} did not return live data.`}
@@ -794,11 +796,13 @@ function MajorPriceCard({ snapshot }: { snapshot: WalletMarketPriceSnapshot }) {
   const isPositive = snapshot.change24hPct >= 0;
 
   return (
-    <div className="min-w-0 rounded-[26px] bg-bg/40 p-4">
+    <div className="min-w-0 p-2">
       <div className="flex items-center gap-3">
         <MarketAvatar imageUrl={snapshot.imageUrl} label={snapshot.symbol} />
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-txt">{snapshot.symbol}</div>
+          <div className="text-sm font-semibold text-txt">
+            {snapshot.symbol}
+          </div>
           <div className="truncate text-xs-tight text-muted">
             {snapshot.name}
           </div>
@@ -958,7 +962,7 @@ function WalletEmptyHero({
   onConfigureKeys: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center gap-4 rounded-[28px] border border-border/30 bg-bg/30 px-6 py-12 text-center">
+    <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
       <WalletMotif />
       <div className="text-base font-semibold text-txt">
         {hasKeys ? "No assets yet" : "Wallet not configured"}
@@ -1023,10 +1027,7 @@ function MarketPulseHero({
       ) : loading ? (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13.5rem),1fr))] gap-3">
           {["btc", "eth", "sol"].map((loadingCardId) => (
-            <div
-              key={loadingCardId}
-              className="h-28 animate-pulse rounded-[26px] border border-border/30 bg-bg/35"
-            />
+            <div key={loadingCardId} className="h-28 animate-pulse bg-bg/20" />
           ))}
         </div>
       ) : null}
@@ -1106,7 +1107,7 @@ function PnlChart({
 
   if (values.length < 2) {
     return (
-      <div className="flex h-40 items-center justify-center rounded-3xl bg-bg/30 text-xs text-muted">
+      <div className="flex h-40 items-center justify-center text-xs text-muted">
         No realized P&L yet
       </div>
     );
@@ -1127,7 +1128,7 @@ function PnlChart({
 
   return (
     <svg
-      className="h-40 w-full rounded-3xl bg-bg/30"
+      className="h-40 w-full"
       viewBox="0 0 100 100"
       preserveAspectRatio="none"
       aria-label="Trade P&L chart"
@@ -1159,7 +1160,7 @@ function SummaryChip({
   return (
     <div
       className={cn(
-        "inline-flex items-center gap-2 rounded-full bg-bg/45 px-3 py-1.5 text-sm font-medium",
+        "inline-flex items-center gap-2 px-1 py-1.5 text-sm font-medium",
         tone === "loss" ? "text-danger" : "text-txt",
       )}
       title={title}
@@ -1211,8 +1212,8 @@ function WalletRailAddress({
       ref={ref}
       type="button"
       className={cn(
-        "group inline-flex min-w-0 items-center gap-2 rounded-full px-2.5 py-1.5 text-left transition-colors",
-        address ? "text-txt hover:bg-bg/55" : "text-muted",
+        "group inline-flex min-w-0 items-center gap-2 px-1 py-1.5 text-left transition-colors",
+        address ? "text-txt hover:text-accent" : "text-muted",
       )}
       onClick={handleCopy}
       disabled={!address}
@@ -1367,7 +1368,7 @@ function WalletRailRpcButton({
     <button
       ref={ref}
       type="button"
-      className="inline-flex h-9 items-center gap-2 rounded-full bg-bg/45 px-3 text-xs font-semibold text-txt transition-colors hover:bg-bg/65"
+      className="inline-flex h-9 items-center gap-2 px-2 text-xs font-semibold text-txt transition-colors hover:text-accent"
       onClick={onOpenSettings}
       title={`RPC providers: EVM ${evmProvider}, Solana ${solanaProvider}`}
       aria-label="Open RPC settings"
@@ -1395,7 +1396,7 @@ function WalletRailAccount({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-start gap-4">
-        <div className="relative flex h-16 w-16 items-center justify-center rounded-[24px] bg-bg/55">
+        <div className="relative flex h-16 w-16 items-center justify-center">
           <Wallet className="h-7 w-7 text-accent" />
         </div>
         <div className="min-w-0 flex-1 basis-64">
@@ -1444,8 +1445,8 @@ function WalletRailTabButton({
       ref={ref}
       type="button"
       className={cn(
-        "inline-flex min-w-0 items-center justify-center gap-1.5 rounded-[calc(var(--radius-lg)_-_4px)] px-3 py-2 text-sm font-semibold transition-colors",
-        active ? "bg-bg text-txt" : "text-muted hover:text-txt",
+        "inline-flex min-w-0 items-center justify-center gap-1.5 px-2 py-2 text-sm font-semibold transition-colors",
+        active ? "text-txt" : "text-muted hover:text-txt",
       )}
       onClick={() => onSelect(tab.id)}
       aria-label={tab.label}
@@ -1456,10 +1457,7 @@ function WalletRailTabButton({
       <tab.icon className="h-3.5 w-3.5 shrink-0" />
       <span className="truncate">{tab.label}</span>
       <span
-        className={cn(
-          "ml-0.5 rounded-full px-1.5 py-0.5 font-mono text-[0.62rem]",
-          active ? "bg-bg/60 text-muted" : "bg-bg/35 text-muted",
-        )}
+        className={cn("ml-0.5 px-1 py-0.5 font-mono text-[0.62rem] text-muted")}
       >
         {tab.count}
       </span>
@@ -1508,7 +1506,7 @@ function TokenRailRowImpl({
       description: `Hide the ${row.symbol} token from the list`,
     });
   return (
-    <div className="group flex min-w-0 items-center gap-3 rounded-2xl px-2.5 py-2.5 transition-colors hover:bg-bg/55">
+    <div className="group flex min-w-0 items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20">
       <TokenIdentityIcon row={row} size={46} />
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-semibold text-txt">
@@ -1529,7 +1527,7 @@ function TokenRailRowImpl({
           <button
             ref={hideRef}
             type="button"
-            className="flex h-7 w-7 items-center justify-center rounded-full bg-bg/65 text-muted transition-colors hover:text-danger"
+            className="flex h-7 w-7 items-center justify-center text-muted transition-colors hover:text-danger"
             onClick={() => onHideToken(row)}
             aria-label={`Hide ${row.symbol}`}
             title={`Hide ${row.symbol}`}
@@ -1574,17 +1572,17 @@ function RailNftList({ nfts }: { nfts: NftItem[] }) {
       {nfts.slice(0, 20).map((nft) => (
         <div
           key={`${nft.chain}:${nft.collectionName}:${nft.name}:${nft.imageUrl}`}
-          className="flex min-w-0 items-center gap-3 rounded-2xl px-2.5 py-2.5 transition-colors hover:bg-bg/55"
+          className="flex min-w-0 items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20"
         >
           {nft.imageUrl ? (
             <img
               src={nft.imageUrl}
               alt={nft.name}
-              className="h-11 w-11 shrink-0 rounded-2xl object-cover"
+              className="h-11 w-11 shrink-0 object-cover"
               loading="lazy"
             />
           ) : (
-            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-bg/65">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center">
               <ImageIcon className="h-4 w-4 text-muted" />
             </div>
           )}
@@ -1616,17 +1614,17 @@ function RailPositionList({
       {positions.map((position) => (
         <div
           key={position.id}
-          className="flex min-w-0 items-center gap-3 rounded-2xl px-2.5 py-2.5 transition-colors hover:bg-bg/55"
+          className="flex min-w-0 items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20"
         >
           {position.imageUrl ? (
             <img
               src={position.imageUrl}
               alt={position.label}
-              className="h-11 w-11 shrink-0 rounded-2xl object-cover"
+              className="h-11 w-11 shrink-0 object-cover"
               loading="lazy"
             />
           ) : (
-            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-bg/65">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center">
               <Layers3 className="h-4 w-4 text-muted" />
             </div>
           )}
@@ -1716,10 +1714,7 @@ function WalletHoldingsSection({
     });
 
   return (
-    <section
-      data-testid="wallets-sidebar"
-      className="rounded-[28px] bg-bg/40 px-5 py-5 md:px-6"
-    >
+    <section data-testid="wallets-sidebar" className="px-3 py-3 md:px-4">
       <WalletRailAccount
         addresses={addresses}
         portfolioValueUsd={totalUsd}
@@ -1734,7 +1729,7 @@ function WalletHoldingsSection({
         {walletEnabled === false ? (
           <Button
             ref={enableWalletRef}
-            className="w-full rounded-2xl"
+            className="w-full"
             onClick={onEnableWallet}
             {...enableWalletAgentProps}
           >
@@ -1742,7 +1737,7 @@ function WalletHoldingsSection({
           </Button>
         ) : null}
 
-        <div className="grid min-w-0 grid-cols-3 rounded-2xl bg-bg/45 p-1">
+        <div className="grid min-w-0 grid-cols-3 gap-1">
           {tabs.map((tab) => (
             <WalletRailTabButton
               key={tab.id}
@@ -1801,10 +1796,8 @@ function DashboardWindowButton({
       ref={ref}
       type="button"
       className={cn(
-        "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
-        active
-          ? "bg-accent text-[color:var(--accent-foreground)]"
-          : "text-muted hover:text-txt",
+        "px-2 py-1.5 text-xs font-medium transition-colors",
+        active ? "text-accent" : "text-muted hover:text-txt",
       )}
       onClick={() => onSelect(window)}
       aria-current={active ? "true" : undefined}
@@ -1868,10 +1861,10 @@ function ActivityLog({
                 ? "bg-danger/10 text-danger"
                 : "bg-bg/55 text-muted";
         const body = (
-          <div className="flex min-w-0 items-center gap-3 rounded-2xl px-2.5 py-2.5 text-sm transition-colors hover:bg-bg/55">
+          <div className="flex min-w-0 items-center gap-3 px-2 py-2 text-sm transition-colors hover:bg-bg-muted/20">
             <span
               className={cn(
-                "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                "flex h-8 w-8 shrink-0 items-center justify-center",
                 toneClass,
               )}
             >
@@ -1924,7 +1917,7 @@ function NftPreview({ nfts }: { nfts: NftItem[] }) {
       {visible.map((nft) => (
         <div
           key={`${nft.chain}:${nft.collectionName}:${nft.name}:${nft.imageUrl}`}
-          className="overflow-hidden rounded-2xl bg-bg/35"
+          className="overflow-hidden"
         >
           {nft.imageUrl ? (
             <img
@@ -1934,7 +1927,7 @@ function NftPreview({ nfts }: { nfts: NftItem[] }) {
               loading="lazy"
             />
           ) : (
-            <div className="flex aspect-square items-center justify-center bg-bg/50">
+            <div className="flex aspect-square items-center justify-center">
               <ImageIcon className="h-5 w-5 text-muted" />
             </div>
           )}
@@ -1966,17 +1959,17 @@ function LpPositionsPanel({
       {positions.map((position) => (
         <div
           key={position.id}
-          className="flex min-w-0 items-center gap-3 rounded-2xl px-2.5 py-2.5 transition-colors hover:bg-bg/55"
+          className="flex min-w-0 items-center gap-3 px-2 py-2 transition-colors hover:bg-bg-muted/20"
         >
           {position.imageUrl ? (
             <img
               src={position.imageUrl}
               alt={position.label}
-              className="h-10 w-10 shrink-0 rounded-2xl object-cover"
+              className="h-10 w-10 shrink-0 object-cover"
               loading="lazy"
             />
           ) : (
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-bg/50">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center">
               {position.kind === "nft" ? (
                 <ImageIcon className="h-4 w-4 text-muted" />
               ) : (
@@ -2227,9 +2220,7 @@ export function InventoryAppView() {
     >
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-5 pt-6 pb-28">
         {walletError ? (
-          <div className="rounded-2xl bg-danger/10 px-4 py-3 text-sm text-danger">
-            {walletError}
-          </div>
+          <div className="px-1 py-2 text-sm text-danger">{walletError}</div>
         ) : null}
 
         <WalletHoldingsSection
@@ -2263,7 +2254,7 @@ export function InventoryAppView() {
               title="P&L"
               icon={BarChart3}
               action={
-                <div className="flex rounded-full bg-bg/40 p-1">
+                <div className="flex gap-1">
                   {DASHBOARD_WINDOWS.map((window) => (
                     <DashboardWindowButton
                       key={window}
@@ -2326,4 +2317,3 @@ export function InventoryAppView() {
     </main>
   );
 }
-

--- a/plugins/plugin-wallet-ui/src/components/InventorySpatialView.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventorySpatialView.test.tsx
@@ -81,7 +81,6 @@ describe("InventorySpatialView one source, three modalities", () => {
       const lines = renderViewToLines(view, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
-      expect(flat).toContain("Wallet");
       expect(flat).toContain("$1,235"); // portfolio value, rounded
       expect(flat).toContain("BNB");
       expect(flat).toContain("Agent NFT");
@@ -99,7 +98,6 @@ describe("InventorySpatialView one source, three modalities", () => {
     expect(gui).toContain('data-spatial-surface="gui"');
     expect(xr).toContain('data-spatial-surface="xr"');
     for (const html of [gui, xr]) {
-      expect(html).toContain("Wallet");
       expect(html).toContain("Agent NFT");
       expect(html).toContain('data-agent-id="refresh"');
     }

--- a/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
@@ -269,7 +269,7 @@ export function InventorySpatialView({
       <Divider label="movers" />
       {marketMovers.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No market data
+          —
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
@@ -159,7 +159,7 @@ export function InventorySpatialView({
       : "default";
 
   return (
-    <Card title="Wallet" gap={1} padding={1}>
+    <Card gap={1} padding={1}>
       <HStack gap={1} align="center">
         <Text style="subheading" grow={1}>
           {formatUsd(portfolioValueUsd)}
@@ -200,7 +200,11 @@ export function InventorySpatialView({
       ) : null}
 
       {walletEnabled === false ? (
-        <Button grow={1} agent="enable-wallet" onPress={dispatch("enable-wallet")}>
+        <Button
+          grow={1}
+          agent="enable-wallet"
+          onPress={dispatch("enable-wallet")}
+        >
           Enable wallet
         </Button>
       ) : null}

--- a/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
@@ -230,7 +230,7 @@ export function InventorySpatialView({
       <Divider label="tokens" />
       {tokenRows.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No tokens
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventorySpatialView.tsx
@@ -316,7 +316,7 @@ export function InventorySpatialView({
       <Divider label="nfts" />
       {walletNfts.length === 0 ? (
         <Text tone="muted" align="center" style="caption">
-          No NFTs
+          None
         </Text>
       ) : (
         <List gap={0}>

--- a/plugins/plugin-wallet-ui/src/widgets/wallet-status.test.tsx
+++ b/plugins/plugin-wallet-ui/src/widgets/wallet-status.test.tsx
@@ -29,15 +29,12 @@ const appHooks = vi.hoisted(() => {
   // reads the widget now uses. Each `mockReturnValue` updates the ref; selectors
   // read from it synchronously.
   const ref: { current: Record<string, unknown> } = { current: {} };
-  const useApp = Object.assign(
-    () => ref.current,
-    {
-      mockReturnValue(state: Record<string, unknown>) {
-        ref.current = state;
-        return useApp;
-      },
+  const useApp = Object.assign(() => ref.current, {
+    mockReturnValue(state: Record<string, unknown>) {
+      ref.current = state;
+      return useApp;
     },
-  );
+  });
   return {
     useApp,
     useAppSelector: <T,>(selector: (s: Record<string, unknown>) => T): T =>
@@ -232,7 +229,7 @@ describe("WalletStatusSidebarWidget — empty / disabled / auto-load", () => {
       }),
     );
     render(React.createElement(WalletStatusSidebarWidget, {} as never));
-    expect(screen.getByText("No wallet addresses yet")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
     expect(
       screen.queryByTestId("chat-widget-wallet-row-evm-address"),
     ).toBeNull();

--- a/plugins/plugin-wallet-ui/src/widgets/wallet-status.tsx
+++ b/plugins/plugin-wallet-ui/src/widgets/wallet-status.tsx
@@ -92,7 +92,7 @@ function ChainBadge({ chain }: { chain: ChainKey }) {
         title={label}
         width={16}
         height={16}
-        className="inline-flex h-4 w-4 shrink-0 rounded-full bg-bg/40 object-cover"
+        className="inline-flex h-4 w-4 shrink-0 object-contain"
         onError={() => setErrored(true)}
       />
     );
@@ -100,7 +100,7 @@ function ChainBadge({ chain }: { chain: ChainKey }) {
   // Tiny initials fallback when the logo URL fails or is missing.
   return (
     <span
-      className="inline-flex h-4 shrink-0 items-center rounded-full border border-border/35 bg-bg/40 px-1.5 font-mono text-[0.52rem] font-semibold leading-none text-muted"
+      className="inline-flex h-4 shrink-0 items-center px-0.5 font-mono text-[0.52rem] font-semibold leading-none text-muted"
       title={label}
       role="img"
       aria-label={label}
@@ -154,7 +154,7 @@ function CopyAddressButton({ value, label }: CopyButtonProps) {
       onClick={onClick}
       aria-label={copied ? `${label} copied` : `Copy ${label}`}
       title={copied ? "Copied" : "Copy"}
-      className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-transparent text-muted transition-colors hover:text-txt"
+      className="inline-flex h-5 w-5 shrink-0 items-center justify-center text-muted transition-colors hover:text-txt"
     >
       {copied ? (
         <Check className="h-3 w-3" aria-hidden />
@@ -305,7 +305,7 @@ export function WalletStatusSidebarWidget(_props: ChatSidebarWidgetProps) {
           ) : null}
 
           {hasAnyBalanceRow ? (
-            <div className="mt-1 flex flex-col gap-1 border-t border-border/20 pt-1.5">
+            <div className="mt-1 flex flex-col gap-1 pt-1">
               <div
                 className="flex items-center justify-between text-3xs"
                 data-testid="chat-widget-wallet-row-assets"
@@ -328,10 +328,7 @@ export function WalletStatusSidebarWidget(_props: ChatSidebarWidgetProps) {
           ) : null}
         </div>
       ) : (
-        <EmptyWidgetState
-          icon={<Wallet className="h-5 w-5" />}
-          title="No wallet addresses yet"
-        />
+        <EmptyWidgetState icon={<Wallet className="h-5 w-5" />} title="None" />
       )}
     </WidgetSection>
   );

--- a/plugins/plugin-wifi/src/components/WifiAppView.test.ts
+++ b/plugins/plugin-wifi/src/components/WifiAppView.test.ts
@@ -274,7 +274,7 @@ describe("WifiAppView — network list", () => {
 
     renderView();
 
-    expect(await screen.findByText("No networks")).toBeTruthy();
+    expect(await screen.findByText("None")).toBeTruthy();
     expect(screen.getByText("Check Wi-Fi and location access.")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Scan again/ })).toBeTruthy();
     expect(

--- a/plugins/plugin-wifi/src/components/WifiAppView.test.ts
+++ b/plugins/plugin-wifi/src/components/WifiAppView.test.ts
@@ -274,7 +274,7 @@ describe("WifiAppView — network list", () => {
 
     renderView();
 
-    expect(await screen.findByText("No networks found")).toBeTruthy();
+    expect(await screen.findByText("No networks")).toBeTruthy();
     expect(screen.getByText("Check Wi-Fi and location access.")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Scan again/ })).toBeTruthy();
     expect(

--- a/plugins/plugin-wifi/src/components/WifiAppView.tsx
+++ b/plugins/plugin-wifi/src/components/WifiAppView.tsx
@@ -340,7 +340,7 @@ export function WifiAppView(props: OverlayAppContext) {
             <div className="px-4 py-8 text-center">
               <WifiOff className="mx-auto h-9 w-9 text-muted" />
               <div className="mt-3 text-sm font-medium text-txt">
-                No networks found
+                No networks
               </div>
               <div className="sr-only">Check Wi-Fi and location access.</div>
               <div className="mt-4 flex flex-col justify-center gap-2 sm:flex-row">

--- a/plugins/plugin-wifi/src/components/WifiAppView.tsx
+++ b/plugins/plugin-wifi/src/components/WifiAppView.tsx
@@ -86,20 +86,18 @@ function ConnectedCard({
 }: ConnectedCardProps) {
   if (!state?.enabled) {
     return (
-      <div className="rounded-lg border border-border/30 bg-card/40 p-4">
+      <div className="px-1 py-2">
         <div className="flex items-start gap-3">
-          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-bg-accent">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center">
             <WifiOff className="h-5 w-5 text-muted-strong" />
           </span>
           <div className="min-w-0 flex-1">
             <div className="text-sm font-medium text-txt">Wi-Fi is off</div>
-            <div className="mt-1 text-xs text-muted">
-              Enable it in Android settings.
-            </div>
+            <div className="sr-only">Enable it in Android settings.</div>
             <Button
               variant="outline"
               size="sm"
-              className="mt-3 rounded-lg"
+              className="mt-3"
               onClick={onOpenSettings}
             >
               <Settings className="mr-2 h-4 w-4" />
@@ -112,7 +110,7 @@ function ConnectedCard({
   }
   if (!network) {
     return (
-      <div className="rounded-lg border border-border/30 bg-card/40 p-4">
+      <div className="px-1 py-2">
         <div className="flex items-center gap-3">
           <WifiIcon className="h-5 w-5 text-muted-strong" />
           <div className="text-sm text-muted">Not connected</div>
@@ -121,7 +119,7 @@ function ConnectedCard({
     );
   }
   return (
-    <div className="rounded-lg border border-border/30 bg-card/40 p-4">
+    <div className="px-1 py-2">
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <CheckCircle2 className="h-5 w-5 text-ok" />
@@ -163,7 +161,7 @@ function NetworkRow({ network, onSelect }: NetworkRowProps) {
     <button
       type="button"
       onClick={() => onSelect(network)}
-      className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/24 bg-bg/60 px-4 py-3 text-left transition-colors hover:bg-bg-accent"
+      className="flex w-full items-center justify-between gap-3 px-2 py-2 text-left transition-colors hover:bg-bg-accent/50"
       data-testid={`wifi-network-${network.bssid || network.ssid || "hidden"}`}
     >
       <div className="flex min-w-0 items-center gap-3">
@@ -284,7 +282,7 @@ export function WifiAppView(props: OverlayAppContext) {
       data-testid="wifi-shell"
       className="fixed inset-0 z-50 flex h-[100vh] w-full flex-col overflow-hidden bg-bg pb-[var(--safe-area-bottom,0px)] pl-[var(--safe-area-left,0px)] pr-[var(--safe-area-right,0px)] pt-[var(--safe-area-top,0px)] supports-[height:100dvh]:h-[100dvh]"
     >
-      <header className="flex items-center justify-between gap-3 border-b border-border/24 px-4 py-3">
+      <header className="flex items-center justify-between gap-3 px-3 py-2">
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"
@@ -312,7 +310,7 @@ export function WifiAppView(props: OverlayAppContext) {
         </Button>
       </header>
 
-      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-3 overflow-y-auto px-3 py-2">
         <ConnectedCard
           state={state}
           network={connected}
@@ -322,9 +320,7 @@ export function WifiAppView(props: OverlayAppContext) {
         />
 
         {error ? (
-          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
-            {error}
-          </div>
+          <div className="px-1 py-2 text-sm text-red-400">{error}</div>
         ) : null}
 
         <div className="flex flex-col gap-2">
@@ -341,19 +337,17 @@ export function WifiAppView(props: OverlayAppContext) {
             </span>
           </div>
           {sortedNetworks.length === 0 && !scanning ? (
-            <div className="rounded-lg border border-border/24 bg-bg/40 px-4 py-8 text-center">
+            <div className="px-4 py-8 text-center">
               <WifiOff className="mx-auto h-9 w-9 text-muted" />
               <div className="mt-3 text-sm font-medium text-txt">
                 No networks found
               </div>
-              <div className="mx-auto mt-1 max-w-sm text-xs text-muted">
-                Check Wi-Fi and location access.
-              </div>
+              <div className="sr-only">Check Wi-Fi and location access.</div>
               <div className="mt-4 flex flex-col justify-center gap-2 sm:flex-row">
                 <Button
                   variant="outline"
                   size="sm"
-                  className="rounded-lg"
+                  className=""
                   onClick={() => {
                     void scan();
                   }}
@@ -364,7 +358,7 @@ export function WifiAppView(props: OverlayAppContext) {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="rounded-lg"
+                  className=""
                   onClick={openNetworkSettings}
                 >
                   <Settings className="mr-2 h-4 w-4" />
@@ -387,7 +381,7 @@ export function WifiAppView(props: OverlayAppContext) {
       </div>
 
       {selected ? (
-        <div className="border-t border-border/24 bg-card/40 px-4 py-3">
+        <div className="px-4 py-3">
           <div className="flex flex-col gap-3">
             <div className="text-sm text-txt">
               Connect to{" "}

--- a/plugins/plugin-wifi/src/components/WifiAppView.tsx
+++ b/plugins/plugin-wifi/src/components/WifiAppView.tsx
@@ -339,9 +339,7 @@ export function WifiAppView(props: OverlayAppContext) {
           {sortedNetworks.length === 0 && !scanning ? (
             <div className="px-4 py-8 text-center">
               <WifiOff className="mx-auto h-9 w-9 text-muted" />
-              <div className="mt-3 text-sm font-medium text-txt">
-                No networks
-              </div>
+              <div className="mt-3 text-sm font-medium text-txt">None</div>
               <div className="sr-only">Check Wi-Fi and location access.</div>
               <div className="mt-4 flex flex-col justify-center gap-2 sm:flex-row">
                 <Button


### PR DESCRIPTION
Closes #9465.

## Summary
- Flattened shared plugin view surfaces and reduced repeated card, border, chip, divider, and header chrome across app/spatial/plugin views.
- Removed or shortened explanatory visible copy in empty/loading/status states across wallet, screenshare, documents, finances, health, comms, market/browser, Shopify, utilities/device/spatial, and task/training plugin surfaces.
- Updated focused UI tests to assert compact labels and kept semantic controls, error text, placeholders, and screen-reader-only copy where they still serve interaction or accessibility.

## Verification
- `bun install`
- `bun run verify` passed: 510 successful tasks / 510 total.
- Focused Vitest/build gates were run while landing each plugin group, including wallet, screenshare, documents, finances, health, wifi/messages/contacts/phone, feed/market/browser surfaces, Shopify, steward/waifu/companion/relationships/goals/inbox/trajectory/facewear, and task/training.
- Post-cleanup scans: visible `No ...` / `Loading ...` view-copy scan only found comments; remaining long-copy hits are errors, placeholders, comments, or screen-reader-only text.
- `packages/cloud-frontend` was not touched, so `bun run --cwd packages/cloud-frontend audit:cloud` is N/A.
