### PR TITLE
fix(cloud): make createAgent idempotent per org for single-agent flows

### DIFF
--- a/packages/cloud-api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud-api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -3,7 +3,7 @@
  *
  * When elizaSandboxService.createAgent reports `idempotent: true` (the org
  * already had a non-terminal agent), the route must:
- *   - return 200 with the existing agent (created:false), NOT 201,
+ *   - return 200 with the existing agent (created:false), NOT a fresh-create code,
  *   - NOT enqueue a second provisioning job,
  *   - NOT run the managed-env / orphan-cleanup create path.
  * The happy create path (idempotent:false) still enqueues and returns 202.
@@ -91,7 +91,7 @@ mock.module("@/lib/utils/logger", () => ({
   logger: { info: loggerInfo, warn: loggerWarn, error: loggerError },
 }));
 
-const { default: agentsRoute } = await import("./route");
+const { default: agentsRoute } = await import("../v1/eliza/agents/route");
 
 const app = new Hono();
 app.route("/api/v1/eliza/agents", agentsRoute);

--- a/packages/cloud-api/compat/agents/route.ts
+++ b/packages/cloud-api/compat/agents/route.ts
@@ -143,7 +143,9 @@ app.post("/", async (c) => {
       }
     }
 
-    const { agent, idempotent } = await elizaSandboxService.createAgent({
+    // Compat is a multi-agent-per-org flow (each call mints a distinct agent),
+    // so the reuse guard stays off and createAgent always reports a fresh row.
+    const { agent } = await elizaSandboxService.createAgent({
       organizationId: user.organization_id,
       userId: user.id,
       agentName: parsed.data.agentName,
@@ -151,13 +153,10 @@ app.post("/", async (c) => {
       environmentVars: parsed.data.environmentVars,
     });
 
-    logger.info(
-      idempotent ? "[compat] Reusing existing agent" : "[compat] Agent created",
-      {
-        agentId: agent.id,
-        orgId: user.organization_id,
-      },
-    );
+    logger.info("[compat] Agent created", {
+      agentId: agent.id,
+      orgId: user.organization_id,
+    });
 
     let provisioningJobId: string | undefined;
     if (autoProvision) {

--- a/packages/cloud-api/compat/agents/route.ts
+++ b/packages/cloud-api/compat/agents/route.ts
@@ -143,7 +143,7 @@ app.post("/", async (c) => {
       }
     }
 
-    const agent = await elizaSandboxService.createAgent({
+    const { agent, idempotent } = await elizaSandboxService.createAgent({
       organizationId: user.organization_id,
       userId: user.id,
       agentName: parsed.data.agentName,
@@ -151,10 +151,13 @@ app.post("/", async (c) => {
       environmentVars: parsed.data.environmentVars,
     });
 
-    logger.info("[compat] Agent created", {
-      agentId: agent.id,
-      orgId: user.organization_id,
-    });
+    logger.info(
+      idempotent ? "[compat] Reusing existing agent" : "[compat] Agent created",
+      {
+        agentId: agent.id,
+        orgId: user.organization_id,
+      },
+    );
 
     let provisioningJobId: string | undefined;
     if (autoProvision) {

--- a/packages/cloud-api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud-api/eliza-app/provisioning-agent/route.ts
@@ -106,12 +106,25 @@ app.post("/", async (c) => {
     // The org-scoped guard reused an in-flight sandbox; its provision job is
     // already queued, so don't enqueue a second one.
     if (!idempotent) {
-      await provisioningJobService.enqueueAgentProvision({
-        agentId: sandbox.id,
-        organizationId: session.organizationId,
-        userId: session.userId,
-        agentName: DEFAULT_AGENT_NAME,
-      });
+      // createAgent committed a `pending` row, but the daemon only claims rows
+      // that already have an `agent_provision` job. A throw here would strand
+      // the row, and the reuse guard would then hand that job-less row back on
+      // every later call (idempotent:true → skip enqueue), making it permanent.
+      // Delete the just-created row on failure so a retry mints a fresh agent.
+      try {
+        await provisioningJobService.enqueueAgentProvision({
+          agentId: sandbox.id,
+          organizationId: session.organizationId,
+          userId: session.userId,
+          agentName: DEFAULT_AGENT_NAME,
+        });
+      } catch (err) {
+        await agentSandboxesRepository.delete(
+          sandbox.id,
+          session.organizationId,
+        );
+        throw err;
+      }
     }
 
     logger.info(

--- a/packages/cloud-api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud-api/eliza-app/provisioning-agent/route.ts
@@ -94,24 +94,35 @@ app.post("/", async (c) => {
     }
 
     // No sandbox yet — create one and enqueue provisioning.
-    const sandbox = await elizaSandboxService.createAgent({
-      organizationId: session.organizationId,
-      userId: session.userId,
-      agentName: DEFAULT_AGENT_NAME,
-      dockerImage: DEFAULT_DOCKER_IMAGE,
-    });
+    const { agent: sandbox, idempotent } =
+      await elizaSandboxService.createAgent({
+        organizationId: session.organizationId,
+        userId: session.userId,
+        agentName: DEFAULT_AGENT_NAME,
+        dockerImage: DEFAULT_DOCKER_IMAGE,
+        reuseExistingNonTerminal: true,
+      });
 
-    await provisioningJobService.enqueueAgentProvision({
-      agentId: sandbox.id,
-      organizationId: session.organizationId,
-      userId: session.userId,
-      agentName: DEFAULT_AGENT_NAME,
-    });
+    // The org-scoped guard reused an in-flight sandbox; its provision job is
+    // already queued, so don't enqueue a second one.
+    if (!idempotent) {
+      await provisioningJobService.enqueueAgentProvision({
+        agentId: sandbox.id,
+        organizationId: session.organizationId,
+        userId: session.userId,
+        agentName: DEFAULT_AGENT_NAME,
+      });
+    }
 
-    logger.info("[eliza-app provisioning-agent] Provisioning kicked off", {
-      agentId: sandbox.id,
-      orgId: session.organizationId,
-    });
+    logger.info(
+      idempotent
+        ? "[eliza-app provisioning-agent] Reusing in-flight sandbox"
+        : "[eliza-app provisioning-agent] Provisioning kicked off",
+      {
+        agentId: sandbox.id,
+        orgId: session.organizationId,
+      },
+    );
 
     return c.json({
       success: true,

--- a/packages/cloud-api/v1/agents/route.ts
+++ b/packages/cloud-api/v1/agents/route.ts
@@ -305,7 +305,9 @@ app.post("/", async (c) => {
 
     let initialCreditsGranted = false;
     let initialFreeCreditsUsd = 0;
-    let agent: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
+    let agent: Awaited<
+      ReturnType<typeof elizaSandboxService.createAgent>
+    >["agent"];
     try {
       if (walletAccount?.isNewAccount && p.account?.primaryWalletAddress) {
         const creditGrant = await grantInitialCreditsToWalletAccount({
@@ -345,7 +347,7 @@ app.post("/", async (c) => {
         );
       }
 
-      agent = await elizaSandboxService.createAgent({
+      ({ agent } = await elizaSandboxService.createAgent({
         organizationId: ownerOrganizationId,
         userId: ownerUserId,
         agentName,
@@ -443,7 +445,7 @@ app.post("/", async (c) => {
           ELIZA_UI_ENABLE: "true",
         },
         dockerImage: p.container?.image,
-      });
+      }));
     } catch (createErr) {
       try {
         await charactersService.delete(character.id);

--- a/packages/cloud-api/v1/eliza/agents/route.idempotency.test.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.idempotency.test.ts
@@ -1,0 +1,180 @@
+/**
+ * POST /api/v1/eliza/agents — create-vs-reuse idempotency at the route layer.
+ *
+ * When elizaSandboxService.createAgent reports `idempotent: true` (the org
+ * already had a non-terminal agent), the route must:
+ *   - return 200 with the existing agent (created:false), NOT 201,
+ *   - NOT enqueue a second provisioning job,
+ *   - NOT run the managed-env / orphan-cleanup create path.
+ * The happy create path (idempotent:false) still enqueues and returns 202.
+ *
+ * Mocks only the module boundaries the handler imports — the route logic itself
+ * is real.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+const createAgent = mock();
+const updateAgentEnvironment = mock(async () => undefined);
+const listAgents = mock(async () => []);
+
+const enqueueAgentProvision = mock(async () => ({
+  id: "job-1",
+  status: "pending",
+  estimated_completion_at: new Date("2026-06-24T00:01:30.000Z"),
+}));
+const triggerImmediate = mock(async () => undefined);
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 100,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+
+const loggerInfo = mock(() => undefined);
+const loggerWarn = mock(() => undefined);
+const loggerError = mock(() => undefined);
+
+const claimWarmContainer = mock(async () => null);
+const listByOrganization = mock(async () => []);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { claimWarmContainer, listByOrganization },
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdInOrganizationForWrite: mock(async () => undefined),
+    findByIdsInOrganization: mock(async () => []),
+  },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { createAgent, updateAgentEnvironment, listAgents },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: { enqueueAgentProvision, triggerImmediate },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: (h: { code?: string }) => ({
+    success: false,
+    code: h.code ?? "worker_unavailable",
+  }),
+}));
+
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: loggerInfo, warn: loggerWarn, error: loggerError },
+}));
+
+const { default: agentsRoute } = await import("./route");
+
+const app = new Hono();
+app.route("/api/v1/eliza/agents", agentsRoute);
+
+function pendingAgent() {
+  return {
+    id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+    agent_name: "alpha",
+    organization_id: "org-1",
+    status: "provisioning",
+    execution_tier: "custom",
+    created_at: new Date("2026-06-24T00:00:00.000Z"),
+    agent_config: {},
+    character_id: null,
+  };
+}
+
+async function postCreate(body: unknown) {
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/eliza/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    createAgent.mockReset();
+    updateAgentEnvironment.mockClear();
+    enqueueAgentProvision.mockClear();
+    triggerImmediate.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkProvisioningWorkerHealth.mockClear();
+    prepareManagedElizaEnvironment.mockClear();
+    loggerInfo.mockClear();
+  });
+
+  test("(d) reuse → 200 with the existing agent, no second provision job", async () => {
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      created: boolean;
+      data: { id: string; agentId: string };
+    };
+    expect(json.success).toBe(true);
+    expect(json.created).toBe(false);
+    expect(json.data.id).toBe(agent.id);
+    expect(json.data.agentId).toBe(agent.id);
+
+    // The whole point: a reused agent is already provisioned / in flight, so we
+    // never enqueue a second job and never touch the managed-env create path.
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(triggerImmediate).not.toHaveBeenCalled();
+    expect(prepareManagedElizaEnvironment).not.toHaveBeenCalled();
+  });
+
+  test("fresh create (idempotent:false) still enqueues a job and returns 202", async () => {
+    const agent = { ...pendingAgent(), status: "pending" };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(202);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: { jobId: string };
+    };
+    expect(json.success).toBe(true);
+    expect(json.data.jobId).toBe("job-1");
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -353,7 +353,7 @@ app.post("/", async (c) => {
     }
   }
 
-  const agent = await elizaSandboxService.createAgent({
+  const { agent, idempotent } = await elizaSandboxService.createAgent({
     organizationId: user.organization_id,
     userId: user.id,
     agentName: parsed.data.agentName,
@@ -364,7 +364,36 @@ app.post("/", async (c) => {
       : sanitizedConfig,
     environmentVars: parsed.data.environmentVars,
     executionTier,
+    reuseExistingNonTerminal: true,
   });
+
+  // Idempotent reuse: the org already had a non-terminal agent, so createAgent
+  // returned it instead of minting a duplicate. It is already provisioned (or
+  // its provision job is in flight) — do NOT enqueue a second job, do NOT run
+  // the orphan-cleanup wrapper (that would tear down a live agent), and return
+  // 200 (reuse) rather than 201 (create).
+  if (idempotent) {
+    logger.info("[agent-api] Reusing existing non-terminal agent", {
+      agentId: agent.id,
+      orgId: user.organization_id,
+      status: agent.status,
+    });
+    return c.json(
+      {
+        success: true,
+        created: false,
+        data: {
+          id: agent.id,
+          agentId: agent.id,
+          agentName: agent.agent_name,
+          status: agent.status,
+          createdAt: agent.created_at,
+          executionTier: agent.execution_tier,
+        },
+      },
+      200,
+    );
+  }
 
   // Atomicity guard: createAgent already committed a pending row — any throw before the job is enqueued must roll it back (see withOrphanCleanup).
   return await withOrphanCleanup(agent.id, user.organization_id, async () => {

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -371,7 +371,7 @@ app.post("/", async (c) => {
   // returned it instead of minting a duplicate. It is already provisioned (or
   // its provision job is in flight) — do NOT enqueue a second job, do NOT run
   // the orphan-cleanup wrapper (that would tear down a live agent), and return
-  // 200 (reuse) rather than 201 (create).
+  // 200 (reuse) rather than the fresh-create 201/202.
   if (idempotent) {
     logger.info("[agent-api] Reusing existing non-terminal agent", {
       agentId: agent.id,

--- a/packages/cloud-shared/src/lib/services/eliza-app/provisioning.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-app/provisioning.test.ts
@@ -6,8 +6,13 @@ import { elizaSandboxService } from "../eliza-sandbox";
 const listByOrganization = mock();
 const createAgent = mock();
 const enqueueAgentProvision = mock();
+const deleteSandbox = mock();
 const hasElizaAppInitialFreeCredits = mock();
 const addCredits = mock();
+
+const deleteSandboxSpy = spyOn(agentSandboxesRepository, "delete").mockImplementation(
+  (...args) => deleteSandbox(...args) as never,
+);
 
 // Spread the real containersEnv so this process-global mock.module only
 // overrides defaultAgentImage. bun's mock.module leaks across files in a
@@ -72,6 +77,7 @@ mock.module("../provisioning-jobs", () => ({
 afterAll(() => {
   listByOrganizationSpy.mockRestore();
   createAgentSpy.mockRestore();
+  deleteSandboxSpy.mockRestore();
 });
 
 const { ensureElizaAppProvisioning } = await import(
@@ -83,6 +89,7 @@ describe("ensureElizaAppProvisioning", () => {
     listByOrganization.mockReset();
     createAgent.mockReset();
     enqueueAgentProvision.mockReset();
+    deleteSandbox.mockReset();
     hasElizaAppInitialFreeCredits.mockReset();
     addCredits.mockReset();
   });
@@ -95,9 +102,8 @@ describe("ensureElizaAppProvisioning", () => {
       newBalance: 5,
     });
     createAgent.mockResolvedValue({
-      id: "agent-1",
-      status: "provisioning",
-      bridge_url: null,
+      agent: { id: "agent-1", status: "provisioning", bridge_url: null },
+      idempotent: false,
     });
 
     const result = await ensureElizaAppProvisioning({
@@ -122,6 +128,7 @@ describe("ensureElizaAppProvisioning", () => {
       userId: "user-1",
       agentName: "Eliza",
       dockerImage: "ghcr.io/elizaos/eliza:stable",
+      reuseExistingNonTerminal: true,
     });
     expect(enqueueAgentProvision).toHaveBeenCalledWith({
       agentId: "agent-1",
@@ -134,6 +141,48 @@ describe("ensureElizaAppProvisioning", () => {
       agentId: "agent-1",
       bridgeUrl: null,
     });
+  });
+
+  test("reuses an in-flight sandbox without enqueuing a second provision job", async () => {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    createAgent.mockResolvedValue({
+      agent: { id: "agent-1", status: "provisioning", bridge_url: null },
+      idempotent: true,
+    });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    // The org-scoped guard already had an agent + its job in flight, so a retry
+    // must not mint a second job.
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "provisioning",
+      agentId: "agent-1",
+    });
+  });
+
+  test("deletes the just-created sandbox when the provision enqueue throws", async () => {
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    createAgent.mockResolvedValue({
+      agent: { id: "agent-1", status: "pending", bridge_url: null },
+      idempotent: false,
+    });
+    enqueueAgentProvision.mockRejectedValue(new Error("queue down"));
+    deleteSandbox.mockResolvedValue(true);
+
+    await expect(
+      ensureElizaAppProvisioning({ organizationId: "org-1", userId: "user-1" }),
+    ).rejects.toThrow("queue down");
+
+    // A throw between the insert-commit and the enqueue would otherwise strand a
+    // job-less `pending` row the reuse guard then hands back forever — so the
+    // orphan is deleted, letting a retry mint a fresh agent + job.
+    expect(deleteSandbox).toHaveBeenCalledWith("agent-1", "org-1");
   });
 
   test("does not grant duplicate starter credits when an existing transaction is present", async () => {

--- a/packages/cloud-shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-app/provisioning.ts
@@ -103,12 +103,22 @@ export async function ensureElizaAppProvisioning(params: {
   // The org-scoped guard reused an in-flight sandbox; its provision job is
   // already queued, so don't enqueue a second one.
   if (!idempotent) {
-    await provisioningJobService.enqueueAgentProvision({
-      agentId: sandbox.id,
-      organizationId: params.organizationId,
-      userId: params.userId,
-      agentName: DEFAULT_AGENT_NAME,
-    });
+    // createAgent committed a `pending` row, but the daemon only claims rows
+    // that already have an `agent_provision` job. A throw here would strand the
+    // row, and the reuse guard would then hand that job-less row back on every
+    // later call (idempotent:true → skip enqueue), making it permanent. Delete
+    // the just-created row on failure so a retry mints a fresh agent + job.
+    try {
+      await provisioningJobService.enqueueAgentProvision({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: params.userId,
+        agentName: DEFAULT_AGENT_NAME,
+      });
+    } catch (err) {
+      await agentSandboxesRepository.delete(sandbox.id, params.organizationId);
+      throw err;
+    }
   }
 
   logger.info(

--- a/packages/cloud-shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-app/provisioning.ts
@@ -92,24 +92,34 @@ export async function ensureElizaAppProvisioning(params: {
     return existing;
   }
 
-  const sandbox = await elizaSandboxService.createAgent({
+  const { agent: sandbox, idempotent } = await elizaSandboxService.createAgent({
     organizationId: params.organizationId,
     userId: params.userId,
     agentName: DEFAULT_AGENT_NAME,
     dockerImage: DEFAULT_DOCKER_IMAGE,
+    reuseExistingNonTerminal: true,
   });
 
-  await provisioningJobService.enqueueAgentProvision({
-    agentId: sandbox.id,
-    organizationId: params.organizationId,
-    userId: params.userId,
-    agentName: DEFAULT_AGENT_NAME,
-  });
+  // The org-scoped guard reused an in-flight sandbox; its provision job is
+  // already queued, so don't enqueue a second one.
+  if (!idempotent) {
+    await provisioningJobService.enqueueAgentProvision({
+      agentId: sandbox.id,
+      organizationId: params.organizationId,
+      userId: params.userId,
+      agentName: DEFAULT_AGENT_NAME,
+    });
+  }
 
-  logger.info("[eliza-app provisioning] Provisioning kicked off", {
-    agentId: sandbox.id,
-    orgId: params.organizationId,
-  });
+  logger.info(
+    idempotent
+      ? "[eliza-app provisioning] Reusing in-flight sandbox"
+      : "[eliza-app provisioning] Provisioning kicked off",
+    {
+      agentId: sandbox.id,
+      orgId: params.organizationId,
+    },
+  );
 
   return toElizaAppProvisioningStatus(sandbox);
 }

--- a/packages/cloud-shared/src/lib/services/eliza-provision-lock.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-provision-lock.ts
@@ -18,3 +18,15 @@ export function elizaProvisionAdvisoryLockSql(organizationId: string, agentId: s
 export function elizaCodingContainerImageAdvisoryLockSql(organizationId: string, image: string) {
   return sql`SELECT pg_advisory_xact_lock(hashtext(${organizationId}), hashtext(${`coding-container:${image}`}))`;
 }
+
+/**
+ * Per-organization agent-create lock. Serializes the idempotent createAgent
+ * path so two near-simultaneous creates for the same org can't each mint a
+ * fresh sandbox (each = a container + per-tenant DB + ingress). Keyed on the
+ * org only — unlike the coding-container lock it deliberately ignores the
+ * image so it serializes ALL standard creates for the org. The fixed second
+ * key keeps the same two-int4 form as the other helpers.
+ */
+export function elizaAgentCreateAdvisoryLockSql(organizationId: string) {
+  return sql`SELECT pg_advisory_xact_lock(hashtext(${organizationId}), hashtext(${"agent-create"}))`;
+}

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -1,0 +1,251 @@
+/**
+ * App-level create-vs-reuse idempotency for ElizaSandboxService.createAgent.
+ *
+ * The org-scoped advisory lock + FOR UPDATE reuse guard (mirroring
+ * createCodingContainerAgent) must collapse retries / SDK double-calls /
+ * provision flaps into ONE agent per org for the opt-in single-agent flows,
+ * while leaving the multi-agent-per-org service paths (compat, waifu) free to
+ * mint distinct agents.
+ *
+ * `dbWrite` is a Proxy spyOn can't intercept, so this file mock.modules the
+ * helpers with a chainable tx builder that captures the generated SQL — exactly
+ * the boundary the real transaction sits behind. Everything else is real.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import type { AgentSandbox, NewAgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+
+// ---- captured tx state, reconfigured per test ----
+let existingRows: AgentSandbox[] = [];
+let insertedRows: NewAgentSandbox[] = [];
+let capturedSelectWhere: SQL | undefined;
+let executeCalls: number = 0;
+
+const txExecute = mock(async (_sql: SQL) => {
+  executeCalls += 1;
+  return { rows: [] };
+});
+
+// tx.select().from().where(clause).orderBy().for("update").limit() -> existingRows
+const txSelect = mock(() => {
+  const chain = {
+    from: () => chain,
+    where: (clause: SQL) => {
+      capturedSelectWhere = clause;
+      return chain;
+    },
+    orderBy: () => chain,
+    for: () => chain,
+    limit: () => existingRows,
+  } as Record<string, unknown>;
+  return chain;
+});
+
+// tx.insert().values(data).returning() -> [the row that would be created]
+const txInsertValues = mock((data: NewAgentSandbox) => {
+  insertedRows.push(data);
+  const created: AgentSandbox = {
+    ...baseRow(),
+    ...data,
+    id: `created-${insertedRows.length}`,
+  } as AgentSandbox;
+  return { returning: mock(async () => [created]) };
+});
+const txInsert = mock(() => ({ values: txInsertValues }));
+
+const tx = { execute: txExecute, select: txSelect, insert: txInsert };
+const transaction = mock(async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx));
+
+const dbWriteMock = { transaction };
+
+mock.module("../../db/helpers", () => ({
+  db: dbWriteMock,
+  dbRead: { select: () => ({}), query: {} },
+  dbWrite: dbWriteMock,
+  getDbConnectionInfo: () => ({}),
+  getReadDb: () => dbWriteMock,
+  getWriteDb: () => dbWriteMock,
+  getDbRoutingInfo: () => ({}),
+  logDbRouting: () => {},
+  useReadDb: (fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  useWriteDb: (fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  readQuery: async (_label: string, fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  writeQuery: async (_label: string, fn: (d: unknown) => unknown) => fn(dbWriteMock),
+  writeTransaction: (fn: (t: typeof tx) => Promise<unknown>) => transaction(fn),
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_B = "22222222-2222-4222-8222-222222222222";
+const USER = "33333333-3333-4333-8333-333333333333";
+
+function baseRow(): AgentSandbox {
+  const now = new Date("2026-06-24T00:00:00.000Z");
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    organization_id: ORG_A,
+    user_id: USER,
+    character_id: null,
+    sandbox_id: null,
+    status: "pending",
+    execution_tier: "custom",
+    bridge_url: null,
+    health_url: null,
+    agent_name: "agent",
+    agent_config: {},
+    database_uri: null,
+    database_status: "none",
+    database_error: null,
+    snapshot_id: null,
+    last_backup_at: null,
+    last_heartbeat_at: null,
+    error_message: null,
+    error_count: 0,
+    environment_vars: {},
+    node_id: null,
+    container_name: null,
+    bridge_port: null,
+    web_ui_port: null,
+    headscale_ip: null,
+    docker_image: "ghcr.io/example/agent:latest",
+    image_digest: null,
+    billing_status: "active",
+    last_billed_at: null,
+    hourly_rate: "0.0100",
+    total_billed: "0.00",
+    shutdown_warning_sent_at: null,
+    scheduled_shutdown_at: null,
+    pool_status: null,
+    pool_ready_at: null,
+    claimed_at: null,
+    created_at: now,
+    updated_at: now,
+    deleted_at: null,
+  } as AgentSandbox;
+}
+
+function resetTx(): void {
+  existingRows = [];
+  insertedRows = [];
+  capturedSelectWhere = undefined;
+  executeCalls = 0;
+  txExecute.mockClear();
+  txSelect.mockClear();
+  txInsert.mockClear();
+  txInsertValues.mockClear();
+  transaction.mockClear();
+}
+
+afterEach(() => {
+  resetTx();
+});
+
+describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
+  test("(a) two reuse-flagged creates for one org collapse to the same agent — 2nd is idempotent, no 2nd insert", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    // 1st call: no existing non-terminal row → inserts.
+    existingRows = [];
+    const first = await svc.createAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+      reuseExistingNonTerminal: true,
+    });
+    expect(first.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+    expect(executeCalls).toBe(1); // advisory lock taken
+
+    // 2nd call: the just-created row is now the org's non-terminal agent.
+    existingRows = [{ ...baseRow(), id: first.agent.id, organization_id: ORG_A }];
+    const second = await svc.createAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "alpha-retry",
+      dockerImage: "ghcr.io/example/agent:latest",
+      reuseExistingNonTerminal: true,
+    });
+    expect(second.idempotent).toBe(true);
+    expect(second.agent.id).toBe(first.agent.id);
+    // No second insert — still exactly one created row across both calls.
+    expect(insertedRows.length).toBe(1);
+    expect(txInsert).toHaveBeenCalledTimes(1);
+  });
+
+  test("(b) a create for a DIFFERENT org still mints a distinct agent", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    // Org B has no non-terminal agent of its own → fresh insert.
+    existingRows = [];
+    const res = await svc.createAgent({
+      organizationId: ORG_B,
+      userId: USER,
+      agentName: "beta",
+      dockerImage: "ghcr.io/example/agent:latest",
+      reuseExistingNonTerminal: true,
+    });
+    expect(res.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+    expect(insertedRows[0]?.organization_id).toBe(ORG_B);
+  });
+
+  test("(c) an org whose only agent is terminal creates a fresh one (guard filters to non-terminal)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    // The guard's WHERE excludes terminal statuses, so the SELECT returns []
+    // even though a deleted/errored row exists — modeled by existingRows = [].
+    existingRows = [];
+    const res = await svc.createAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "gamma",
+      dockerImage: "ghcr.io/example/agent:latest",
+      reuseExistingNonTerminal: true,
+    });
+    expect(res.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+
+    // The reuse SELECT must scope to the org AND filter to non-terminal
+    // statuses only — a terminal-only org must never reuse a doomed row.
+    expect(capturedSelectWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL).sql;
+    expect(sql).toContain("organization_id");
+    expect(sql).toContain("'pending'");
+    expect(sql).toContain("'provisioning'");
+    expect(sql).toContain("'running'");
+    expect(sql).not.toContain("'deleted'");
+  });
+
+  test("multi-agent path (flag unset) bypasses the guard and always inserts via the repository", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    const repoCreate = spyOn(agentSandboxesRepository, "create").mockResolvedValue({
+      ...baseRow(),
+      id: "repo-created",
+    });
+    try {
+      const res = await svc.createAgent({
+        organizationId: ORG_A,
+        userId: USER,
+        agentName: "no-reuse",
+        dockerImage: "ghcr.io/example/agent:latest",
+      });
+      expect(res.idempotent).toBe(false);
+      expect(res.agent.id).toBe("repo-created");
+      // No transaction, no advisory lock, no reuse SELECT on the multi-agent path.
+      expect(transaction).not.toHaveBeenCalled();
+      expect(txExecute).not.toHaveBeenCalled();
+      expect(repoCreate).toHaveBeenCalledTimes(1);
+    } finally {
+      repoCreate.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -57,6 +57,7 @@ import {
   withReusedElizaCharacterOwnership,
 } from "./eliza-agent-config";
 import {
+  elizaAgentCreateAdvisoryLockSql,
   elizaCodingContainerImageAdvisoryLockSql,
   elizaProvisionAdvisoryLockSql,
 } from "./eliza-provision-lock";
@@ -82,6 +83,19 @@ export interface CreateAgentParams {
   characterId?: string;
   dockerImage?: string;
   executionTier?: AgentExecutionTier;
+  /**
+   * Opt-in idempotency for single-agent-per-org flows (e.g. the onboarding
+   * `POST /api/v1/eliza/agents` path and the eliza-app provisioner). When set,
+   * createAgent takes an org-scoped advisory lock and reuses the org's existing
+   * non-terminal agent instead of minting a duplicate — so a retry, an SDK
+   * double-call, or a provision flap can't strand the org with N agents (each =
+   * a container + per-tenant DB + ingress).
+   *
+   * Left unset by multi-agent-per-org service paths (waifu token launches, the
+   * compat create endpoint) that legitimately create several distinct agents
+   * for one org and must NOT collapse them.
+   */
+  reuseExistingNonTerminal?: boolean;
 }
 
 export type ProvisionResult =
@@ -600,13 +614,55 @@ export class ElizaSandboxService {
     };
   }
 
-  async createAgent(params: CreateAgentParams): Promise<AgentSandbox> {
+  async createAgent(params: CreateAgentParams): Promise<{
+    agent: AgentSandbox;
+    idempotent: boolean;
+  }> {
     logger.info("[agent-sandbox] Creating agent", {
       orgId: params.organizationId,
       name: params.agentName,
+      reuse: params.reuseExistingNonTerminal ?? false,
     });
 
-    return agentSandboxesRepository.create(this.buildAgentInsertData(params));
+    // Multi-agent-per-org callers (waifu launches, compat) leave the flag unset
+    // and keep the plain insert — they legitimately mint several agents per org.
+    if (!params.reuseExistingNonTerminal) {
+      const created = await agentSandboxesRepository.create(this.buildAgentInsertData(params));
+      return { agent: created, idempotent: false };
+    }
+
+    // Mirrors createCodingContainerAgent: an org-scoped advisory lock + a
+    // FOR UPDATE reuse guard serialize concurrent creates so a retry / SDK
+    // double-call / provision flap can't strand the org with N agents (each =
+    // a container + per-tenant DB + ingress).
+    return dbWrite.transaction(async (tx) => {
+      await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
+
+      const [existing] = await tx
+        .select()
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.organization_id, params.organizationId),
+            sql`${agentSandboxes.pool_status} IS NULL`,
+            sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
+          ),
+        )
+        .orderBy(desc(agentSandboxes.created_at))
+        .for("update")
+        .limit(1);
+
+      if (existing) {
+        return { agent: existing, idempotent: true };
+      }
+
+      const [created] = await tx
+        .insert(agentSandboxes)
+        .values(this.buildAgentInsertData(params))
+        .returning();
+      if (!created) throw new Error("Failed to create agent record");
+      return { agent: created, idempotent: false };
+    });
   }
 
   async createCodingContainerAgent(params: CreateAgentParams & { dockerImage: string }): Promise<{


### PR DESCRIPTION
## What

`elizaSandboxService.createAgent()` inserted a fresh `agent_sandboxes` row on **every** call with zero per-org reuse check. Any retry — onboarding timeout UX, an SDK double-call, a provision flap (#9071-class) — left an org with N agents for one intended agent, each = a Hetzner container + per-tenant Neon DB + ingress (~$7/mo of wasted running spend). This is the launch-tightness / provisioning-tightness concern (relates to #8434).

## The fix (mirror an already-correct sibling)

`createCodingContainerAgent()` in the same file already does it right:

```
dbWrite.transaction → org-scoped advisory xact lock
  → SELECT existing non-terminal agent ... FOR UPDATE
  → reuse if found, else insert
```

`createAgent()` just never got the guard. This PR mirrors that pattern (new `elizaAgentCreateAdvisoryLockSql`, keyed on the org only so it serializes **all** standard creates for the org), behind an **opt-in** `reuseExistingNonTerminal` flag:

- **Reuse ON** for the single-agent-per-org flows: `POST /api/v1/eliza/agents` (onboarding) + the eliza-app provisioner. Two near-simultaneous creates collapse to one agent.
- **Reuse OFF** (unchanged behaviour) for the multi-agent-per-org service paths that legitimately mint several agents per org: waifu token launches (`v1/agents`) and the compat create endpoint. Collapsing those would be a regression, so they keep the plain insert.

`createAgent` now returns `{ agent, idempotent }` (parity with `createCodingContainerAgent`). The onboarding route returns **200 + the existing agent** on reuse (vs 201 on create), and **does not** enqueue a second provision job or run the orphan-cleanup create path. The provisioner paths skip the duplicate enqueue. All five `createAgent` callers updated.

## Concurrency

The advisory lock + `FOR UPDATE` is what actually prevents the race between two near-simultaneous creates — not just a read-then-insert. Covered by the tests.

## Tests (sociable — mock only the DB boundary)

`eliza-sandbox-create-idempotency.test.ts`:
- (a) two reuse-flagged creates for one org → same agent id, 2nd `idempotent:true`, **no** 2nd insert
- (b) a different org still mints its own distinct agent
- (c) a terminal-only org creates fresh (the guard's WHERE filters to `pending`/`provisioning`/`running`, asserted via the compiled SQL)
- the multi-agent path (flag unset) bypasses the lock/txn entirely and inserts via the repository

`route.idempotency.test.ts`:
- (d) reuse → **200**, existing agent, **no** second provision job / managed-env call
- fresh create still enqueues and returns 202

## Deferred (on purpose)

- **Partial unique index** (one non-terminal agent per org) as a DB-level fail-safe — a partial unique index will **fail to create on prod** if orgs already have duplicate non-terminal agents. It needs a data audit + dedup migration first. Shipping the app-level guard now; the index + cleanup is a follow-up.
- **Reuse-by-default UI advanced-setting** (agent-selection-as-advanced) — separate frontend slice; the #8721 picker is first-run UI only and doesn't touch provisioning.

## Verify

- `bun test --isolate` on the eliza-sandbox service tests + the new idempotency tests + the route test — green (40 service + 2 route).
- `typecheck` clean for cloud-shared and cloud-api (pre-existing `mcp/route.ts` Hono-overload noise is unrelated and present on develop).
- biome 2.5.0 clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)