### PR TITLE
test(benchmarks): enforce canonical MMAU audio path

### DIFF
--- a/packages/benchmarks/mmau-audio/README.md
+++ b/packages/benchmarks/mmau-audio/README.md
@@ -4,8 +4,9 @@
 > ICLR 2025, gamma-lab-umd/MMAU-test-mini). It is **not** related to
 > Salesforce's MMAU agent-capability benchmark (Yin et al.,
 > arXiv:2407.18961). The PyPI distribution is published as
-> `elizaos-mmau-audio` to reflect this. The legacy CLI entries
-> `elizaos-mmau` and `mmau` are kept temporarily as aliases.
+> `elizaos-mmau-audio` to reflect this. Use the `mmau-audio` package path,
+> `python -m elizaos_mmau_audio`, or the installed `mmau-audio` /
+> `elizaos-mmau-audio` console scripts.
 
 Vendored Python implementation of Audio MMAU (ICLR 2025) for the elizaOS
 benchmark suite.
@@ -52,8 +53,9 @@ packages/benchmarks/
 
 ## Run
 
-Two equivalent invocations work — pick whichever fits the calling
-context. Run from this package root or with it on `PYTHONPATH`:
+Use the canonical module path from scripts and the registry, or the installed
+console scripts when the package is installed. Run from this package root or
+with it on `PYTHONPATH`:
 
 ```bash
 # canonical module path (preferred from scripts / the registry)
@@ -63,10 +65,6 @@ python -m elizaos_mmau_audio --mock --output ./results --json
 # installed console scripts (preferred when installed)
 mmau-audio --mock --limit 2
 elizaos-mmau-audio --mock --output ./results --json
-
-# legacy aliases kept temporarily for downstream compatibility
-mmau --mock --limit 2
-elizaos-mmau --mock --output ./results --json
 ```
 
 Run through the elizaOS bridge (cascaded STT -> text agent baseline):

--- a/packages/benchmarks/mmau-audio/elizaos_mmau_audio/dataset.py
+++ b/packages/benchmarks/mmau-audio/elizaos_mmau_audio/dataset.py
@@ -106,7 +106,7 @@ class MMAUDataset:
         except ImportError as exc:
             raise RuntimeError(
                 "Hugging Face loading requires the optional 'datasets' package. "
-                "Install elizaos-mmau[hf] or pass --fixture."
+                "Install elizaos-mmau-audio[hf] or pass --fixture."
             ) from exc
 
         # Bounded benchmark cells should materialise the parquet shard instead

--- a/packages/benchmarks/mmau-audio/pyproject.toml
+++ b/packages/benchmarks/mmau-audio/pyproject.toml
@@ -36,10 +36,6 @@ all = [
 [project.scripts]
 mmau-audio = "elizaos_mmau_audio.cli:main"
 elizaos-mmau-audio = "elizaos_mmau_audio.cli:main"
-# Kept for backward compatibility with existing invocations; will be
-# removed once downstream callers migrate to the disambiguated names.
-mmau = "elizaos_mmau_audio.cli:main"
-elizaos-mmau = "elizaos_mmau_audio.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["elizaos_mmau_audio"]

--- a/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
+++ b/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import tomllib
 import types
 from pathlib import Path
 
@@ -89,7 +90,8 @@ def test_discovery_covers_all_real_benchmark_directories() -> None:
 
 
 def test_discovery_includes_directory_name_mismatches_and_special_tracks() -> None:
-    adapters = discover_adapters(_workspace_root()).adapters
+    discovery = discover_adapters(_workspace_root())
+    adapters = discovery.adapters
 
     assert adapters["app-eval"].directory == "app-eval"
     assert adapters["openclaw_bench"].directory == "openclaw-benchmark"
@@ -100,9 +102,8 @@ def test_discovery_includes_directory_name_mismatches_and_special_tracks() -> No
     assert adapters["mmau"].directory == "mmau-audio"
     assert adapters["voicebench_quality"].directory == "voicebench-quality"
     assert adapters["voiceagentbench"].directory == "voiceagentbench"
-    discovered_dirs = discover_adapters(_workspace_root()).all_directories
-    assert "mmau" not in discovered_dirs
-    assert "elizaos_mmau" not in discovered_dirs
+    assert "mmau" not in discovery.all_directories
+    assert "elizaos_mmau" not in discovery.all_directories
 
 
 def test_voice_audio_defaults_do_not_publish_mock_fixture_runs(
@@ -1166,6 +1167,24 @@ def test_mmau_uses_canonical_audio_package_without_legacy_shims(tmp_path: Path) 
     benchmarks_root = _workspace_root() / "benchmarks"
     assert not (benchmarks_root / "mmau").exists()
     assert not (benchmarks_root / "elizaos_mmau").exists()
+
+    importlib.invalidate_caches()
+    benchmarks_package = importlib.import_module("benchmarks")
+    assert importlib.machinery.PathFinder.find_spec(
+        "benchmarks.mmau", list(benchmarks_package.__path__)
+    ) is None
+    assert (
+        importlib.machinery.PathFinder.find_spec("elizaos_mmau", [str(benchmarks_root)])
+        is None
+    )
+
+    pyproject = tomllib.loads(
+        (benchmarks_root / "mmau-audio" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert pyproject["project"]["scripts"] == {
+        "mmau-audio": "elizaos_mmau_audio.cli:main",
+        "elizaos-mmau-audio": "elizaos_mmau_audio.cli:main",
+    }
 
     env = dict(os.environ)
     env["PYTHONPATH"] = str(benchmarks_root / "mmau-audio")


### PR DESCRIPTION
## Summary

- Removes the legacy `mmau` and `elizaos-mmau` console entrypoints from the canonical `mmau-audio` benchmark package.
- Updates MMAU audio docs and optional dependency guidance to use `elizaos-mmau-audio` only.
- Extends orchestrator discovery coverage to assert the legacy local `packages/benchmarks/mmau` and `packages/benchmarks/elizaos_mmau` paths/modules stay absent, while the canonical module smoke still works.

Note: `origin/develop` already contains the physical legacy directory removal; this PR completes the claimed slice by removing the remaining public aliases/docs and adding a regression test.

Refs #9475.

## Verification

- PASS `git fetch origin && git rebase origin/develop` (`fix/9475-mmau-canonical-path` rebased onto `3858ebcb03`)
- PASS `bun install`
- PASS `bun run verify` (510/510 tasks)
- PASS `python -m pytest tests/ -q` from `packages/benchmarks/mmau-audio` (58 passed)
- PASS `PYTHONPATH=packages/benchmarks/mmau-audio python -m elizaos_mmau_audio --mock --limit 2 --output /tmp/eliza-pr9475-mmau-smoke --json`
- PASS `PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py -q` (127 passed)
- PASS `PYTHONPATH=packages python -m benchmarks.orchestrator list-benchmarks` (53 adapters, 44 benchmark dirs, all covered)
- PASS `python -m py_compile packages/benchmarks/orchestrator/tests/test_adapter_discovery.py packages/benchmarks/mmau-audio/elizaos_mmau_audio/dataset.py`
- PASS `git diff --check`
