### PR TITLE
fix(vision): include OCR text in scene prompt

### DIFF
--- a/plugins/plugin-vision/src/eliza1-bridge.test.ts
+++ b/plugins/plugin-vision/src/eliza1-bridge.test.ts
@@ -55,6 +55,49 @@ describe("VisionService eliza-1 IMAGE_DESCRIPTION bridge", () => {
         prompt: expect.any(String),
       }),
     );
+    const prompt = JSON.parse(
+      (useModel.mock.calls[0]?.[1] as { prompt: string }).prompt,
+    ) as Record<string, unknown>;
+    expect(prompt.detectedText).toBeUndefined();
+  });
+
+  it("adds current OCR text to the scene description prompt", async () => {
+    const { runtime, useModel } = createRuntime({
+      imageDescriptionResult: { description: "The settings panel is open." },
+    });
+    const service = new VisionService(runtime);
+    Object.defineProperty(service, "lastEnhancedScene", {
+      configurable: true,
+      value: {
+        timestamp: Date.now(),
+        description: "",
+        objects: [],
+        people: [],
+        sceneChanged: true,
+        changePercentage: 0,
+        screenAnalysis: {
+          fullScreenOCR: "Save\nSave\n  Project   settings\n\nDeploy now",
+          activeTile: {
+            timestamp: Date.now(),
+            text: "Deploy now",
+          },
+        },
+      },
+    });
+
+    const describeFn = Reflect.get(service, "describeSceneWithVLM") as (
+      imageUrl: string,
+    ) => Promise<string>;
+    const result = await describeFn.call(
+      service,
+      `data:image/jpeg;base64,${Buffer.from("img").toString("base64")}`,
+    );
+
+    expect(result).toBe("The settings panel is open.");
+    const prompt = JSON.parse(
+      (useModel.mock.calls[0]?.[1] as { prompt: string }).prompt,
+    ) as { detectedText?: string };
+    expect(prompt.detectedText).toBe("Save\nProject settings\nDeploy now");
   });
 
   it("falls through to detected-objects synthesis when IMAGE_DESCRIPTION returns the unhelpful sentinel", async () => {

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -55,6 +55,8 @@ const execAsync = promisify(exec);
 const VISION_CONTEXT_SERVICE_TYPE = "vision-context";
 const SCENE_CONTEXT_OPEN_APPS_LIMIT = 20;
 const SCENE_CONTEXT_RECENT_ACTIONS_LIMIT = 10;
+const SCENE_DESCRIPTION_OCR_LINE_LIMIT = 40;
+const SCENE_DESCRIPTION_OCR_TEXT_LIMIT = 2000;
 
 interface VisionContextSnapshot {
   openApps: string[];
@@ -101,13 +103,38 @@ function trimVisionContextForPrompt(
 
 function buildSceneDescriptionPrompt(
   context: VisionContextSnapshot | null,
+  ocrText?: string | null,
 ): string {
   const payload: Record<string, unknown> = {
     task: "describe_visual_scene",
     instructions: SCENE_DESCRIPTION_INSTRUCTIONS,
   };
   if (context) payload.context = trimVisionContextForPrompt(context);
+  const detectedText = normalizeOcrTextForPrompt(ocrText);
+  if (detectedText) payload.detectedText = detectedText;
   return JSON.stringify(payload, null, 2);
+}
+
+function normalizeOcrTextForPrompt(text?: string | null): string | null {
+  if (!text) return null;
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+/g, " ").trim();
+    if (line.length === 0) continue;
+    const dedupeKey = line.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    lines.push(line);
+    if (lines.length >= SCENE_DESCRIPTION_OCR_LINE_LIMIT) break;
+  }
+
+  const normalized = lines
+    .join("\n")
+    .slice(0, SCENE_DESCRIPTION_OCR_TEXT_LIMIT)
+    .trim();
+  return normalized.length > 0 ? normalized : null;
 }
 
 interface CameraDevice {
@@ -1023,6 +1050,19 @@ export class VisionService extends Service {
     }
   }
 
+  private collectCurrentOcrTextForPrompt(): string | null {
+    const screenAnalysis = this.lastEnhancedScene?.screenAnalysis;
+    const candidates = [
+      screenAnalysis?.fullScreenOCR,
+      screenAnalysis?.activeTile?.ocr?.fullText,
+      screenAnalysis?.activeTile?.text,
+    ];
+    const text = candidates
+      .filter((candidate): candidate is string => Boolean(candidate?.trim()))
+      .join("\n");
+    return text.length > 0 ? text : null;
+  }
+
   private async describeSceneWithVLM(imageUrl: string): Promise<string> {
     return withStandaloneTrajectory(
       this.runtime,
@@ -1054,7 +1094,10 @@ export class VisionService extends Service {
       // has registered IMAGE_DESCRIPTION. plugin-vision no longer ships its
       // own VLM.
       const sceneContext = await this.collectVisionContext();
-      const prompt = buildSceneDescriptionPrompt(sceneContext);
+      const prompt = buildSceneDescriptionPrompt(
+        sceneContext,
+        this.collectCurrentOcrTextForPrompt(),
+      );
       try {
         const result = await this.runtime.useModel(
           ModelType.IMAGE_DESCRIPTION,


### PR DESCRIPTION
## Summary

- Adds bounded, deduped OCR text to the plugin-vision scene description JSON prompt as `detectedText` when current screen OCR is available.
- Sources the prompt context from the existing enhanced scene OCR aggregate / active tile OCR only; OCR text and coordinates remain exported separately for grounding.
- Extends the IMAGE_DESCRIPTION bridge tests to prove prompts stay unchanged without OCR and include normalized text with OCR.

Refs #9105.

## Verification

- PASS `git fetch origin && git rebase origin/develop`
- PASS `bun install`
- PASS `bun run --cwd plugins/plugin-vision test -- eliza1-bridge.test.ts` (4 passed)
- PASS `bun run --cwd plugins/plugin-vision test` (174 passed, 1 skipped)
- PASS `bun run --cwd plugins/plugin-vision build`
- PASS `bun run --cwd plugins/plugin-vision format:check`
- PASS `git diff --check origin/develop...HEAD`
- PASS `bun run verify` (exit 0)
