### PR TITLE
perf(elizacloud): suppress cerebras gpt-oss reasoning when caller asks for none

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
@@ -47,7 +47,10 @@ function cannedResponse(): Response {
   );
 }
 
-async function captureResponseFormat(modelName: string): Promise<unknown> {
+async function captureBody(
+  modelName: string,
+  params: Record<string, unknown> = { responseSchema: RESPONSE_SCHEMA }
+): Promise<Record<string, unknown> | null> {
   let captured: Record<string, unknown> | null = null;
   vi.spyOn(globalThis, "fetch").mockImplementation(
     async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -61,11 +64,11 @@ async function captureResponseFormat(modelName: string): Promise<unknown> {
   await generateNativeChatCompletion(
     runtime(),
     "TEXT_SMALL",
-    { prompt: "hi", responseSchema: RESPONSE_SCHEMA } as never,
+    { prompt: "hi", ...params } as never,
     { modelName, prompt: "hi" }
   );
 
-  return (captured as Record<string, unknown> | null)?.response_format;
+  return captured;
 }
 
 describe("native /chat/completions response_format gate", () => {
@@ -78,15 +81,51 @@ describe("native /chat/completions response_format gate", () => {
   });
 
   it("emits json_object for cerebras-served gpt-oss models", async () => {
-    const responseFormat = await captureResponseFormat("gpt-oss-120b");
-    expect(responseFormat).toEqual({ type: "json_object" });
+    const body = await captureBody("gpt-oss-120b");
+    expect(body?.response_format).toEqual({ type: "json_object" });
   });
 
   it("keeps json_schema for non-cerebras models", async () => {
-    const responseFormat = await captureResponseFormat("zai-glm-4.7");
-    expect(responseFormat).toMatchObject({
+    const body = await captureBody("zai-glm-4.7");
+    expect(body?.response_format).toMatchObject({
       type: "json_schema",
       json_schema: { name: "reply_envelope" },
     });
+  });
+});
+
+/**
+ * gpt-oss runs a hidden reasoning pass before answering even when the caller
+ * wants none (~4s/call vs ~0.7s suppressed). The runtime asks for none via
+ * `providerOptions.eliza.thinking="off"`; the native request must translate that
+ * into cerebras's `reasoning_effort:"low"`. The knob is cerebras-only — other
+ * providers (e.g. zai-glm-4.7) ignore it, so it must not leak onto their wire.
+ */
+describe("native /chat/completions reasoning_effort gate", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps eliza.thinking=off to reasoning_effort:low for cerebras gpt-oss", async () => {
+    const body = await captureBody("gpt-oss-120b", {
+      providerOptions: { eliza: { thinking: "off" } },
+    });
+    expect(body?.reasoning_effort).toBe("low");
+  });
+
+  it("omits reasoning_effort when thinking is not suppressed", async () => {
+    const body = await captureBody("gpt-oss-120b", { providerOptions: {} });
+    expect(body?.reasoning_effort).toBeUndefined();
+  });
+
+  it("never sets reasoning_effort for non-cerebras models", async () => {
+    const body = await captureBody("zai-glm-4.7", {
+      providerOptions: { eliza: { thinking: "off" } },
+    });
+    expect(body?.reasoning_effort).toBeUndefined();
   });
 });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -696,6 +696,19 @@ function buildNativeRequestBody(
   if (!isReasoningModel(modelName) && typeof params.temperature === "number") {
     requestBody.temperature = params.temperature;
   }
+  // cerebras gpt-oss runs a hidden-reasoning pass before answering even when the
+  // caller wants none — measured ~4s/call vs ~0.7s with reasoning suppressed. The
+  // runtime signals "don't reason" via providerOptions.eliza.thinking="off" (e.g.
+  // the Stage-1 RESPONSE_HANDLER formatting call), but resolveNativeProviderOptions
+  // drops the eliza block, so it never reached the wire. Honor it as cerebras's
+  // reasoning_effort:"low". Cerebras-gated (the plugin's isReasoningModel does NOT
+  // match gpt-oss); other providers ignore the field.
+  if (
+    isCerebrasServedModel(modelName) &&
+    recordAt(asRecord(params.providerOptions), "eliza").thinking === "off"
+  ) {
+    requestBody.reasoning_effort = "low";
+  }
   if (tools) {
     requestBody.tools = tools;
   }


### PR DESCRIPTION
## What

`gpt-oss-120b` (the cerebras-served Stage-1 model) runs a **hidden reasoning pass before it answers, even when the caller wants none.** The runtime already asks for none — core sets `providerOptions.eliza.thinking="off"` on the Stage-1 `RESPONSE_HANDLER` formatting call (`packages/core/src/services/message.ts`) — but `resolveNativeProviderOptions` strips the whole `eliza` block before the wire body is built, so the signal never reached cerebras.

`buildNativeRequestBody` now translates `eliza.thinking="off"` → cerebras `reasoning_effort:"low"`, **gated to cerebras-served gpt-oss only** (reusing the existing `isCerebrasServedModel` / `recordAt` / `asRecord` helpers — no new functions). Other providers (e.g. `zai-glm-4.7`) ignore the knob, and the gate keeps it off their wire entirely.

## Why — measured on the real Worker path

Same 15k-token prompt, the agent's actual gateway path:

| call | time |
|---|---|
| cerebras direct (no gateway) | ~1.1s |
| Worker (agent path), default | **4.1s** |
| Worker + `reasoning_effort:low` | **0.73s** ⚡ |

A **5.6× cut** on the Stage-1 call — gpt-oss spends ~3–4s "thinking" before emitting a token, even on trivial prompts, unless told not to.

This stacks on top of #9354 (the cerebras streaming double-emit fix, already merged + shipped fleet-wide). Combined expectation for dedicated-chat **TTFT: 8–12s → ~2–4s**.

## Test

Adds 3 cases to the existing native `/chat/completions` gate test (`text-cerebras-response-format.test.ts`), reusing a generalized `captureBody` helper:
- gpt-oss + `eliza.thinking="off"` → `reasoning_effort:"low"`
- gpt-oss without the suppress signal → no `reasoning_effort`
- `zai-glm-4.7` + `eliza.thinking="off"` → no `reasoning_effort` (gate holds)

`bun run --cwd plugins/plugin-elizacloud test:unit` → 98 passed / 2 skipped. typecheck + biome clean. Rebased on `develop` tip.

## Notes
- Follow-ons (separate, not in this PR): live agent shows `cached:0` → prompt isn't byte-stable so it re-prefills 15k every turn; and trimming the 15k Stage-1 context.

cc @elizaOS — cloud-agent for review (validated complementary to #9278 / #9354). Tracking on #8434.