### PR TITLE
fix(ui): never provision a duplicate cloud agent on a failed lookup

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+import { ElizaClient } from "./client-base";
+// Side-effect import: patches selectOrProvisionCloudAgent onto the prototype.
+import "./client-cloud";
+import type { CloudCompatAgent } from "./client-types-cloud";
+
+/**
+ * selectOrProvisionCloudAgent reuses an existing cloud agent instead of minting
+ * a new (billed, dedicated) one on every sign-in. The launch-blocking failure
+ * mode shaw reported as "it creates multiple agents" was a swallowed list-fetch
+ * error: a transient failure (expired token, network blip, or a success:false
+ * body) collapsed to an empty list and fell through to provisioning — so an
+ * existing agent silently became a duplicate. The contract under test: ONLY an
+ * authoritative success list may conclude the user has no agent to reuse.
+ */
+
+function makeAgent(
+  overrides: Partial<CloudCompatAgent> = {},
+): CloudCompatAgent {
+  return {
+    agent_id: "agent-existing",
+    agent_name: "Eliza",
+    node_id: null,
+    container_id: null,
+    headscale_ip: null,
+    bridge_url: null,
+    web_ui_url: "https://agent-existing.example.test",
+    status: "running",
+    agent_config: {},
+    created_at: "2026-06-24T00:00:00.000Z",
+    updated_at: "2026-06-24T00:00:00.000Z",
+    containerUrl: "",
+    webUiUrl: "https://agent-existing.example.test",
+    database_status: "ok",
+    error_message: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+function fakeClient() {
+  const getCloudCompatAgents = vi.fn();
+  const createCloudCompatAgent = vi.fn();
+  const getCloudCompatAgent = vi.fn();
+  const client = Object.create(ElizaClient.prototype) as ElizaClient;
+  Object.assign(client, {
+    getCloudCompatAgents,
+    createCloudCompatAgent,
+    getCloudCompatAgent,
+  });
+  return { client, getCloudCompatAgents, createCloudCompatAgent };
+}
+
+const BASE_OPTS = {
+  cloudApiBase: "https://api.elizacloud.ai/api/v1",
+  authToken: "test-token",
+  name: "Eliza",
+};
+
+describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", () => {
+  it("reuses the existing agent and never provisions when the list succeeds", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [makeAgent()],
+    });
+
+    const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
+
+    expect(result.created).toBe(false);
+    expect(result.agentId).toBe("agent-existing");
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT provision when the list fetch throws (transient/network error)", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockRejectedValue(new Error("network down"));
+
+    await expect(client.selectOrProvisionCloudAgent(BASE_OPTS)).rejects.toThrow(
+      /network down|find your agents/i,
+    );
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT provision when the list returns success:false (e.g. expired auth)", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: false,
+      data: [],
+      error: "unauthorized",
+    });
+
+    await expect(client.selectOrProvisionCloudAgent(BASE_OPTS)).rejects.toThrow(
+      /unauthorized|find your agents/i,
+    );
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("provisions exactly once for a confirmed-empty list (genuine first-time user)", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "agent-new",
+        agentName: "Eliza",
+        jobId: "job-1",
+        status: "provisioning",
+        nodeId: null,
+        message: "",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-new",
+        web_ui_url: "https://agent-new.example.test",
+        webUiUrl: "https://agent-new.example.test",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
+
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe("agent-new");
+    expect(createCloudCompatAgent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -2839,9 +2839,25 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // path only runs when the user has no agent yet.
   if (!forceCreate) {
     onProgress?.("creating", "Finding your agents...");
-    const list = await this.getCloudCompatAgents().catch(() => null);
-    const agents = list?.success ? list.data : [];
-    const chosen = pickPreferredCloudAgent(agents, preferAgentId);
+    // A failed agent-list lookup must NOT fall through to provisioning. A
+    // transient error (expired token, network blip, or a success:false body)
+    // previously collapsed to an empty list and minted a brand-new billed agent
+    // even though the user already had one — the root of the "it creates
+    // multiple agents" report. Only an authoritative success list may conclude
+    // the user has no agent to reuse; otherwise surface the error so the caller
+    // can retry rather than duplicate.
+    const list = await this.getCloudCompatAgents().catch((cause) => ({
+      success: false as const,
+      data: [] as CloudCompatAgent[],
+      error: cause instanceof Error ? cause.message : undefined,
+    }));
+    if (!list.success) {
+      throw new Error(
+        list.error ||
+          "Couldn't reach Eliza Cloud to find your agents. Check your connection and try again.",
+      );
+    }
+    const chosen = pickPreferredCloudAgent(list.data, preferAgentId);
     if (chosen) {
       const apiBase = resolveCloudAgentApiBase({
         bridgeUrl: chosen.bridge_url,


### PR DESCRIPTION
## What

`selectOrProvisionCloudAgent` (`packages/ui/src/api/client-cloud.ts`) is meant to **reuse the user's one existing dedicated (billed) cloud agent** instead of minting a new one on every sign-in. The reuse branch did:

```ts
const list = await this.getCloudCompatAgents().catch(() => null);
const agents = list?.success ? list.data : [];
const chosen = pickPreferredCloudAgent(agents, preferAgentId);
if (chosen) { /* reuse */ }
// else → CREATE A NEW DEDICATED AGENT
```

So **both** a thrown error (network blip, expired token) and a `success:false` body collapsed to an empty list → `chosen` is `null` → it **provisioned a brand-new agent even though the user already had one.** This is the root of @shaw's *"right now we have it create multiple agents but it should really just go to your one existing agent"* — a billing + launch blocker.

## Fix

Only an **authoritative `success` list** may conclude the user has no agent to reuse:
- a thrown lookup error is normalized to `success:false` (so it can't fall through),
- a non-success result throws a clear, **retryable** error instead of silently duplicating,
- drops the now-redundant `agents` intermediate.

First-time users (a confirmed `success:true` empty list) still provision exactly once.

## Test — `client-cloud-select-or-provision.test.ts`

Drives the real prototype method with stubbed `getCloudCompatAgents`/`createCloudCompatAgent`:
- list succeeds with an agent → **reuses**, `createCloudCompatAgent` never called
- list **throws** → rejects, `createCloudCompatAgent` **never called**
- list returns **`success:false`** → rejects, `createCloudCompatAgent` **never called**
- list is a confirmed-empty success → provisions **exactly once**

`bun run --cwd packages/ui test src/api/client-cloud-select-or-provision.test.ts` → 4/4. typecheck (exit 0) + biome clean. Branched on `develop` tip.

cc @elizaOS — surfaced by the launch-QA audit; tracking on #8434. Pairs with shaw's "agent selection as an advanced setting" direction (the explicit `forceCreate`/`preferAgentId` path is untouched).