### PR TITLE
test(cloud): real billing-deduct + container-billing-cron coverage (LARP H1/M1)

### DIFF
--- a/packages/cloud-api/cron/container-billing/route.test.ts
+++ b/packages/cloud-api/cron/container-billing/route.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Container-billing cron driver coverage.
+ *
+ * The daily container-billing cron (`route.ts`) is the real-money debit driver
+ * for hosted containers, and it had no test. It owns the orchestration that the
+ * pure policy/repository units can't cover on their own:
+ *  - computing each container's dailyCost,
+ *  - the earnings-first-then-credits split,
+ *  - draining the in-memory earnings/credit pools ACROSS containers in the same
+ *    org within a single run,
+ *  - the documented fallback that charges the full day to credits when the
+ *    earnings conversion throws (a prior bug-fix — guarded here against
+ *    regression),
+ *  - isolating a per-container failure so the rest of the run still bills,
+ *  - skipping an already-billed period without charging.
+ *
+ * Mirrors the sibling `agent-billing/route.test.ts`: mock ONLY the repo/data
+ * seam (`listBillableContainers`, `listBillingOrganizations`,
+ * `recordSuccessfulDailyBilling`, earnings/users) and drive the REAL Hono route
+ * handler so the real split + pool-drain + fallback orchestration executes.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Repo/data seam mocks (the ONLY things stubbed) ─────────────────────────────
+
+const listBillableContainers = mock(
+  async (_now: Date): Promise<unknown[]> => [],
+);
+const listBillingOrganizations = mock(
+  async (_ids: string[]): Promise<unknown[]> => [],
+);
+const scheduleShutdownWarning = mock(async () => undefined);
+const recordBillingFailure = mock(async () => undefined);
+const suspendContainer = mock(async () => undefined);
+
+/**
+ * Faithful stand-in for the real `recordSuccessfulDailyBilling`: it returns the
+ * route-computed `newBalance` (= currentBalance - fromCredits) and a transaction
+ * id, exactly like the real repo's relative-decrement write. Per-call behavior
+ * (already-billed / throwing) is overridden in individual tests.
+ */
+const recordSuccessfulDailyBilling = mock(
+  async (input: {
+    newBalance: number;
+    fromCredits: number;
+    fromEarnings: number;
+    dailyCost: number;
+  }) => ({
+    newBalance: input.newBalance,
+    transactionId: "tx-mock",
+    alreadyBilled: false,
+  }),
+);
+
+const convertToCredits = mock(async (_params: unknown) => ({
+  success: true,
+  newBalance: 0,
+  ledgerEntryId: "ledger-mock",
+}));
+const getBalance = mock(async (_userId: string) => ({ availableBalance: 0 }));
+
+const listByOrganization = mock(
+  async (
+    _orgId: string,
+  ): Promise<
+    { id: string; role: string; email: string | null; created_at: Date }[]
+  > => [
+    {
+      id: "owner-user",
+      role: "owner",
+      email: "owner@example.test",
+      created_at: new Date("2020-01-01T00:00:00Z"),
+    },
+  ],
+);
+
+mock.module("@/db/repositories/container-billing", () => ({
+  containerBillingRepository: {
+    listBillableContainers,
+    listBillingOrganizations,
+    scheduleShutdownWarning,
+    recordBillingFailure,
+    suspendContainer,
+    recordSuccessfulDailyBilling,
+  },
+}));
+
+mock.module("@/db/repositories", () => ({
+  usersRepository: {
+    listByOrganization,
+  },
+}));
+
+mock.module("@/lib/services/redeemable-earnings", () => ({
+  redeemableEarningsService: {
+    convertToCredits,
+    getBalance,
+  },
+}));
+
+mock.module("@/lib/services/email", () => ({
+  emailService: {
+    sendContainerShutdownWarningEmail: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/services/container-stop-job-service", () => ({
+  enqueueContainerStop: mock(async () => undefined),
+}));
+
+mock.module("@/lib/services/container-jobs-writer", () => ({
+  containerJobsWriter: {},
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    triggerImmediate: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeContainer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "c-1",
+    name: "web",
+    project_name: "proj",
+    organization_id: ORG_ID,
+    user_id: "owner-user",
+    status: "running",
+    billing_status: "active",
+    desired_count: 1,
+    cpu: 1,
+    memory: 1024,
+    shutdown_warning_sent_at: null,
+    scheduled_shutdown_at: null,
+    total_billed: "0",
+    ...overrides,
+  };
+}
+
+function makeOrg(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ORG_ID,
+    name: "Acme",
+    credit_balance: "100",
+    billing_email: "billing@example.test",
+    pay_as_you_go_from_earnings: true,
+    ...overrides,
+  };
+}
+
+async function runCron(): Promise<Response> {
+  return await app.fetch(
+    new Request("https://api.example.test/", {
+      headers: { authorization: "Bearer cron-secret" },
+    }),
+    {
+      CRON_SECRET: "cron-secret",
+      NEXT_PUBLIC_APP_URL: "https://www.elizacloud.ai",
+    },
+  );
+}
+
+describe("container-billing cron", () => {
+  beforeEach(() => {
+    listBillableContainers.mockReset();
+    listBillingOrganizations.mockReset();
+    scheduleShutdownWarning.mockReset();
+    recordBillingFailure.mockReset();
+    suspendContainer.mockReset();
+    recordSuccessfulDailyBilling.mockReset();
+    convertToCredits.mockReset();
+    getBalance.mockReset();
+    listByOrganization.mockReset();
+
+    // Default happy-path behaviors.
+    recordSuccessfulDailyBilling.mockImplementation(async (input) => ({
+      newBalance: input.newBalance,
+      transactionId: "tx-mock",
+      alreadyBilled: false,
+    }));
+    convertToCredits.mockImplementation(async () => ({
+      success: true,
+      newBalance: 0,
+      ledgerEntryId: "ledger-mock",
+    }));
+    getBalance.mockImplementation(async () => ({ availableBalance: 0 }));
+    listByOrganization.mockImplementation(async () => [
+      {
+        id: "owner-user",
+        role: "owner",
+        email: "owner@example.test",
+        created_at: new Date("2020-01-01T00:00:00Z"),
+      },
+    ]);
+  });
+
+  test("bills a single container at the $0.67 daily cost, charged purely to credits when no earnings", async () => {
+    listBillableContainers.mockImplementation(async () => [makeContainer()]);
+    listBillingOrganizations.mockImplementation(async () => [
+      makeOrg({ credit_balance: "100" }),
+    ]);
+    getBalance.mockImplementation(async () => ({ availableBalance: 0 }));
+
+    const response = await runCron();
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: {
+        containersProcessed: number;
+        containersBilled: number;
+        totalRevenue: number;
+        errors: number;
+        results: {
+          action: string;
+          amount?: number;
+          paidFromEarnings?: number;
+        }[];
+      };
+    };
+
+    expect(json.data.containersProcessed).toBe(1);
+    expect(json.data.containersBilled).toBe(1);
+    expect(json.data.totalRevenue).toBeCloseTo(0.67, 2);
+    expect(json.data.errors).toBe(0);
+    expect(json.data.results[0].action).toBe("billed");
+    expect(json.data.results[0].amount).toBeCloseTo(0.67, 4);
+    expect(json.data.results[0].paidFromEarnings).toBeCloseTo(0, 4);
+
+    // No earnings → nothing converted; the full day was charged to credits.
+    expect(convertToCredits).not.toHaveBeenCalled();
+    expect(recordSuccessfulDailyBilling).toHaveBeenCalledTimes(1);
+    const billArg = recordSuccessfulDailyBilling.mock.calls[0][0] as {
+      fromEarnings: number;
+      fromCredits: number;
+      dailyCost: number;
+    };
+    expect(billArg.dailyCost).toBeCloseTo(0.67, 4);
+    expect(billArg.fromEarnings).toBeCloseTo(0, 4);
+    expect(billArg.fromCredits).toBeCloseTo(0.67, 4);
+  });
+
+  test("drains earnings first, then the in-memory pool ACROSS two same-org containers in one run", async () => {
+    // One org, $1.00 of owner earnings, plenty of credits. Two $0.67 containers.
+    // Container A: earnings cover the full $0.67 (fromEarnings=0.67, fromCredits=0).
+    // Pool drains to $0.33 earnings → Container B: earnings cover $0.33, credits cover $0.34.
+    listBillableContainers.mockImplementation(async () => [
+      makeContainer({ id: "c-A", name: "A" }),
+      makeContainer({ id: "c-B", name: "B" }),
+    ]);
+    listBillingOrganizations.mockImplementation(async () => [
+      makeOrg({ credit_balance: "100" }),
+    ]);
+    getBalance.mockImplementation(async () => ({ availableBalance: 1.0 }));
+
+    const response = await runCron();
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: { containersBilled: number; results: { action: string }[] };
+    };
+    expect(json.data.containersBilled).toBe(2);
+    expect(json.data.results.every((r) => r.action === "billed")).toBe(true);
+
+    expect(recordSuccessfulDailyBilling).toHaveBeenCalledTimes(2);
+    const a = recordSuccessfulDailyBilling.mock.calls[0][0] as {
+      fromEarnings: number;
+      fromCredits: number;
+    };
+    const b = recordSuccessfulDailyBilling.mock.calls[1][0] as {
+      fromEarnings: number;
+      fromCredits: number;
+    };
+
+    // Container A: earnings absorb the whole bill.
+    expect(a.fromEarnings).toBeCloseTo(0.67, 4);
+    expect(a.fromCredits).toBeCloseTo(0, 4);
+
+    // Container B sees the DRAINED pool ($1.00 - $0.67 = $0.33 left).
+    expect(b.fromEarnings).toBeCloseTo(0.33, 4);
+    expect(b.fromCredits).toBeCloseTo(0.34, 4);
+
+    // Both earnings portions were converted (one per container).
+    expect(convertToCredits).toHaveBeenCalledTimes(2);
+  });
+
+  test("FALLBACK: when convertToCredits throws, the full day is charged to credits (regression guard)", async () => {
+    listBillableContainers.mockImplementation(async () => [makeContainer()]);
+    listBillingOrganizations.mockImplementation(async () => [
+      makeOrg({ credit_balance: "100" }),
+    ]);
+    // Owner has earnings, so the route attempts an earnings conversion...
+    getBalance.mockImplementation(async () => ({ availableBalance: 1.0 }));
+    // ...but the conversion THROWS (insufficient/contended earnings ledger).
+    convertToCredits.mockImplementation(async () => {
+      throw new Error("earnings ledger contended");
+    });
+
+    const response = await runCron();
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: {
+        containersBilled: number;
+        errors: number;
+        results: { action: string }[];
+      };
+    };
+
+    // The container is STILL billed (not left unbilled / free hosting), and it
+    // is NOT an error — the fallback caught the throw.
+    expect(json.data.containersBilled).toBe(1);
+    expect(json.data.errors).toBe(0);
+    expect(json.data.results[0].action).toBe("billed");
+
+    // The whole $0.67 went to credits (fromEarnings reset to 0), because the
+    // earnings were never actually debited.
+    const billArg = recordSuccessfulDailyBilling.mock.calls[0][0] as {
+      fromEarnings: number;
+      fromCredits: number;
+      dailyCost: number;
+    };
+    expect(billArg.fromEarnings).toBeCloseTo(0, 4);
+    expect(billArg.fromCredits).toBeCloseTo(0.67, 4);
+    expect(billArg.dailyCost).toBeCloseTo(0.67, 4);
+  });
+
+  test("isolates a per-container failure: errors:1 / action:error while the other container still bills", async () => {
+    listBillableContainers.mockImplementation(async () => [
+      makeContainer({ id: "c-good", name: "good" }),
+      makeContainer({ id: "c-bad", name: "bad" }),
+    ]);
+    listBillingOrganizations.mockImplementation(async () => [
+      makeOrg({ credit_balance: "100" }),
+    ]);
+    getBalance.mockImplementation(async () => ({ availableBalance: 0 }));
+
+    // The billing write throws for the SECOND container only.
+    recordSuccessfulDailyBilling.mockImplementation(
+      async (input: { containerId: string; newBalance: number }) => {
+        if (input.containerId === "c-bad") {
+          throw new Error("db write failed for bad container");
+        }
+        return {
+          newBalance: input.newBalance,
+          transactionId: "tx-mock",
+          alreadyBilled: false,
+        };
+      },
+    );
+
+    const response = await runCron();
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: {
+        containersBilled: number;
+        errors: number;
+        results: { action: string; error?: string }[];
+      };
+    };
+
+    // One billed, one errored — the failure did NOT abort the whole run.
+    expect(json.data.containersBilled).toBe(1);
+    expect(json.data.errors).toBe(1);
+
+    const good = json.data.results.find((r) => r.action === "billed");
+    const bad = json.data.results.find((r) => r.action === "error");
+    expect(good).toBeDefined();
+    expect(bad).toBeDefined();
+    expect(bad?.error).toContain("db write failed");
+  });
+
+  test("alreadyBilled period → action:skipped, NOT billed (no revenue, no double-charge)", async () => {
+    listBillableContainers.mockImplementation(async () => [makeContainer()]);
+    listBillingOrganizations.mockImplementation(async () => [
+      makeOrg({ credit_balance: "100" }),
+    ]);
+    getBalance.mockImplementation(async () => ({ availableBalance: 0 }));
+
+    // The row-lock guard found this period already paid.
+    recordSuccessfulDailyBilling.mockImplementation(
+      async (input: { newBalance: number }) => ({
+        newBalance: input.newBalance,
+        transactionId: null,
+        alreadyBilled: true,
+      }),
+    );
+
+    const response = await runCron();
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      data: {
+        containersBilled: number;
+        totalRevenue: number;
+        errors: number;
+        results: { action: string; error?: string }[];
+      };
+    };
+
+    expect(json.data.containersBilled).toBe(0);
+    expect(json.data.totalRevenue).toBeCloseTo(0, 2);
+    expect(json.data.errors).toBe(0);
+    expect(json.data.results[0].action).toBe("skipped");
+    expect(json.data.results[0].error).toContain("Already billed");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Real-DB coverage for the atomic credit-deduct + insufficient-credits guard.
+ *
+ * The credit-deduction SQL in `credits.ts` is the gate that protects real money:
+ * `reserveAndDeductCredits` is the single atomic `FOR UPDATE` mutation that every
+ * inference/reservation/overage charge funnels through, and its WHERE clause
+ * (`current_balance >= amount`) is the insufficient-credits guard. Until now that
+ * SQL ran in ZERO tests — every billing suite mocked the mutation seam, so a
+ * regression (a flipped comparison, a dropped guard, a wrong sign on the debit
+ * row) would have shipped green.
+ *
+ * This suite runs the REAL `CreditsService` SQL against in-process PGlite, the
+ * same honest pattern as `container-billing-idempotency.test.ts`. It seeds a real
+ * `organizations` row + `credit_transactions` table and asserts the observable
+ * effects on the DB, so each test FAILS if the real logic regresses. The only
+ * things stubbed are the fire-and-forget, non-billing side-effects on the success
+ * path (email/webhook/auto-top-up) — never the deduct/guard arithmetic itself.
+ *
+ * Self-skips if PGlite is unavailable (mirrors the sibling suite).
+ */
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+// Force the cache client onto its in-memory backend so the awaited
+// `CacheInvalidation.onCreditMutation` on the success path never reaches a real
+// Redis (deterministic + offline).
+process.env.MOCK_REDIS ||= "1";
+
+// Stub the non-billing fire-and-forget side-effects the success path kicks off.
+// These are NOT the code under test — they are downstream notifications. Leaving
+// them real would make the test depend on email/webhook/auto-top-up infra. The
+// deduct + guard SQL in credits.ts runs entirely real against PGlite below.
+mock.module("../email", () => ({
+  emailService: {
+    sendLowCreditsEmail: mock(async () => false),
+  },
+}));
+mock.module("../waifu-webhook", () => ({
+  resolveWaifuWebhookTarget: mock(() => null),
+  classifyCreditBalance: mock(() => null),
+  emitWaifuCreditWebhook: mock(async () => undefined),
+}));
+mock.module("../auto-top-up", () => ({
+  autoTopUpService: {
+    executeAutoTopUp: mock(async () => undefined),
+  },
+}));
+
+const PGLITE_TIMEOUT = 60000;
+
+const ORG_ID = "00000000-0000-0000-0000-0000000000d1";
+const USER_ID = "00000000-0000-0000-0000-0000000000d2";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let creditsService: typeof import("../credits").creditsService;
+let InsufficientCreditsError: typeof import("../credits").InsufficientCreditsError;
+let pgliteReady = true;
+
+async function seedOrg(balance: string): Promise<void> {
+  await dbWrite.execute(`DELETE FROM credit_transactions;`);
+  await dbWrite.execute(`DELETE FROM organizations;`);
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, name, slug, credit_balance, pay_as_you_go_from_earnings, is_active)
+     VALUES ('${ORG_ID}', 'Acme', 'acme-${ORG_ID}', '${balance}', true, true);`,
+  );
+}
+
+async function readBalance(): Promise<number> {
+  const rows = await dbWrite.execute(
+    `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+  );
+  return Number((rows.rows[0] as { credit_balance: string }).credit_balance);
+}
+
+async function listDebits(): Promise<{ amount: number; type: string }[]> {
+  const rows = await dbWrite.execute(
+    `SELECT amount, type FROM credit_transactions WHERE organization_id = '${ORG_ID}' ORDER BY created_at ASC;`,
+  );
+  return (rows.rows as { amount: string; type: string }[]).map((r) => ({
+    amount: Number(r.amount),
+    type: r.type,
+  }));
+}
+
+beforeAll(async () => {
+  try {
+    ({ dbWrite } = await import("../../../db/client"));
+    ({ creditsService, InsufficientCreditsError } = await import("../credits"));
+
+    // The columns the real credit-deduct SQL + the auto-top-up findById
+    // relational read touch. Full organizations shape so the success-path
+    // `organizationsRepository.findById` (auto-top-up check) returns cleanly.
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS organizations (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        slug text NOT NULL,
+        credit_balance numeric(12,6) NOT NULL DEFAULT '0',
+        settings jsonb DEFAULT '{}',
+        stripe_customer_id text,
+        billing_email text,
+        stripe_payment_method_id text,
+        stripe_default_payment_method text,
+        auto_top_up_enabled boolean DEFAULT false,
+        auto_top_up_threshold numeric(10,2),
+        auto_top_up_amount numeric(10,2),
+        pay_as_you_go_from_earnings boolean NOT NULL DEFAULT true,
+        steward_tenant_id text,
+        steward_tenant_api_key text,
+        is_active boolean NOT NULL DEFAULT true,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS credit_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        amount numeric(12,6) NOT NULL,
+        type text NOT NULL,
+        description text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        stripe_payment_intent_id text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      // The refund/credit path's `applyCreditIncrease` uses
+      // `ON CONFLICT (stripe_payment_intent_id) DO NOTHING`, which requires this
+      // unique index to exist (mirrors the real schema's
+      // `credit_transactions_stripe_payment_intent_idx`). Multiple NULLs are
+      // allowed by a standard UNIQUE index, so debit rows are unaffected.
+      `CREATE UNIQUE INDEX IF NOT EXISTS credit_transactions_stripe_payment_intent_idx
+        ON credit_transactions (stripe_payment_intent_id)`,
+    ];
+    for (const stmt of ddl) {
+      await dbWrite.execute(stmt);
+    }
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[credits-deduct-guard] PGlite unavailable, skipping DB cases:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+describe("reserveAndDeductCredits — atomic debit", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("10.000000");
+  });
+
+  test(
+    "(a) a sufficient debit moves the balance by exactly -amount and writes ONE matching debit row",
+    async () => {
+      if (!pgliteReady) return;
+
+      const result = await creditsService.reserveAndDeductCredits({
+        organizationId: ORG_ID,
+        amount: 3.25,
+        description: "inference charge",
+        metadata: { user_id: USER_ID },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.reason).toBeUndefined();
+      // Balance moved by exactly -amount.
+      expect(result.newBalance).toBeCloseTo(6.75, 6);
+      expect(await readBalance()).toBeCloseTo(6.75, 6);
+
+      // Exactly one debit row, recorded as -amount (negative), typed "debit".
+      const debits = await listDebits();
+      expect(debits).toHaveLength(1);
+      expect(debits[0].type).toBe("debit");
+      expect(debits[0].amount).toBeCloseTo(-3.25, 6);
+
+      // The returned transaction mirrors the persisted row.
+      expect(result.transaction).not.toBeNull();
+      expect(Number(result.transaction?.amount)).toBeCloseTo(-3.25, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(b) amount > balance fails CLOSED: success:false, reason:insufficient_balance, balance + ledger untouched",
+    async () => {
+      if (!pgliteReady) return;
+
+      const result = await creditsService.reserveAndDeductCredits({
+        organizationId: ORG_ID,
+        amount: 10.000001, // one micro-dollar over the $10 balance
+        description: "over-budget charge",
+        metadata: { user_id: USER_ID },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe("insufficient_balance");
+      expect(result.transaction).toBeNull();
+      // The guard returns the live (unchanged) balance.
+      expect(result.newBalance).toBeCloseTo(10, 6);
+
+      // The guard fails CLOSED — no money moved, no debit row written.
+      expect(await readBalance()).toBeCloseTo(10, 6);
+      expect(await listDebits()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(b2) a debit for exactly the full balance succeeds and lands at zero (boundary of the >= guard)",
+    async () => {
+      if (!pgliteReady) return;
+
+      const result = await creditsService.reserveAndDeductCredits({
+        organizationId: ORG_ID,
+        amount: 10,
+        description: "drain to zero",
+        metadata: { user_id: USER_ID },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.newBalance).toBeCloseTo(0, 6);
+      expect(await readBalance()).toBeCloseTo(0, 6);
+      const debits = await listDebits();
+      expect(debits).toHaveLength(1);
+      expect(debits[0].amount).toBeCloseTo(-10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an unknown organization fails with reason:org_not_found and writes nothing",
+    async () => {
+      if (!pgliteReady) return;
+
+      const result = await creditsService.reserveAndDeductCredits({
+        organizationId: "00000000-0000-0000-0000-0000deadbeef",
+        amount: 1,
+        description: "ghost org",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe("org_not_found");
+      // The seeded org is untouched.
+      expect(await readBalance()).toBeCloseTo(10, 6);
+      expect(await listDebits()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("reserve() — high-level reservation gate", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("2.000000");
+  });
+
+  test(
+    "(c) reserve() throws InsufficientCreditsError when the reservation exceeds the balance (no debit)",
+    async () => {
+      if (!pgliteReady) return;
+
+      let thrown: unknown;
+      try {
+        await creditsService.reserve({
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          description: "expensive job",
+          amount: 5, // > $2 balance
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(InsufficientCreditsError);
+      const err = thrown as InstanceType<typeof InsufficientCreditsError>;
+      expect(err.required).toBeCloseTo(5, 6);
+      expect(err.available).toBeCloseTo(2, 6);
+      expect(err.reason).toBe("insufficient_balance");
+
+      // Nothing was reserved/debited — the balance is intact.
+      expect(await readBalance()).toBeCloseTo(2, 6);
+      expect(await listDebits()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "reserve() succeeds within budget, debiting the reserved amount once",
+    async () => {
+      if (!pgliteReady) return;
+
+      const reservation = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        description: "in-budget job",
+        amount: 1.5,
+      });
+
+      expect(reservation.reservedAmount).toBeCloseTo(1.5, 6);
+      expect(reservation.reservationTransactionId).toBeTruthy();
+      expect(await readBalance()).toBeCloseTo(0.5, 6);
+
+      const debits = await listDebits();
+      expect(debits).toHaveLength(1);
+      expect(debits[0].amount).toBeCloseTo(-1.5, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("reconcile() — settle reserved vs actual", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("20.000000");
+  });
+
+  test(
+    "(d) actual < reserved → refunds the difference (credit_balance goes UP by the refund)",
+    async () => {
+      if (!pgliteReady) return;
+
+      // Reserve $5 (balance 20 -> 15).
+      const reservation = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        description: "job",
+        amount: 5,
+      });
+      expect(await readBalance()).toBeCloseTo(15, 6);
+
+      // Actual cost was only $2 → refund $3 (balance 15 -> 18).
+      const result = await reservation.reconcile(2);
+
+      expect(result.adjustmentType).toBe("refund");
+      expect(result.reservedAmount).toBeCloseTo(5, 6);
+      expect(result.actualCost).toBeCloseTo(2, 6);
+      expect(result.settlementTransactionIds).toHaveLength(1);
+      expect(await readBalance()).toBeCloseTo(18, 6);
+
+      // A refund (+3) ledger row exists alongside the original reservation debit.
+      const txns = await listDebits();
+      const refundRow = txns.find((t) => t.type === "refund");
+      expect(refundRow).toBeDefined();
+      expect(refundRow?.amount).toBeCloseTo(3, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(d) actual > reserved → charges the overage (credit_balance goes DOWN by the overage)",
+    async () => {
+      if (!pgliteReady) return;
+
+      // Reserve $5 (balance 20 -> 15).
+      const reservation = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        description: "job",
+        amount: 5,
+      });
+      expect(await readBalance()).toBeCloseTo(15, 6);
+
+      // Actual cost was $8 → charge $3 overage (balance 15 -> 12).
+      const result = await reservation.reconcile(8);
+
+      expect(result.adjustmentType).toBe("overage");
+      expect(result.reservedAmount).toBeCloseTo(5, 6);
+      expect(result.actualCost).toBeCloseTo(8, 6);
+      expect(result.settlementTransactionIds).toHaveLength(1);
+      expect(await readBalance()).toBeCloseTo(12, 6);
+
+      // Two debit rows now: the $5 reservation + the $3 overage.
+      const debits = (await listDebits()).filter((t) => t.type === "debit");
+      expect(debits).toHaveLength(2);
+      expect(debits.some((d) => Math.abs(d.amount - -3) < 1e-6)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "actual == reserved (within epsilon) → no-op, balance unchanged, no settlement rows",
+    async () => {
+      if (!pgliteReady) return;
+
+      const reservation = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        description: "job",
+        amount: 4,
+      });
+      expect(await readBalance()).toBeCloseTo(16, 6);
+
+      const result = await reservation.reconcile(4);
+
+      expect(result.adjustmentType).toBe("none");
+      expect(result.settlementTransactionIds).toHaveLength(0);
+      // Only the original reservation debit moved the balance.
+      expect(await readBalance()).toBeCloseTo(16, 6);
+      expect(await listDebits()).toHaveLength(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});


### PR DESCRIPTION
## What

Adds **real** test coverage for two billing-correctness gaps a LARP audit flagged as launch-blocking. Both code paths previously ran in **zero honest tests** — every existing billing suite mocked the very mutation under test, so a regression (a flipped sign, a dropped guard, a broken fallback) would have shipped green. shaw flagged "billing is tight" and there was an Actions-budget overrun; this closes the audit's H1 + M1 items.

Refs #8434.

## The gaps

- **H1 — the atomic deduct + insufficient-credits guard was never run against a real DB.** `reserveAndDeductCredits` (the single `FOR UPDATE` mutation every inference/reservation/overage charge funnels through), `reserve`, and `reconcile` in `packages/cloud-shared/src/lib/services/credits.ts` had no test exercising the real SQL. The guard's `current_balance >= amount` WHERE clause **is** the insufficient-credits gate, and it was unverified.
- **M1 — the daily real-money container-billing cron driver had no test.** `packages/cloud-api/cron/container-billing/route.ts` owns the earnings/credits split, the cross-container in-memory pool drain, and a documented fallback (a prior bug-fix), none of which were covered.

## Real coverage added

### H1 — `packages/cloud-shared/src/lib/services/__tests__/credits-deduct-guard.test.ts` (9 tests)
Runs the **real** `CreditsService` SQL against in-process **PGlite** — the same honest pattern as the existing `container-billing-idempotency.test.ts` (seeds a real `organizations` row + `credit_transactions` table, including the `stripe_payment_intent_id` unique index the refund path's `ON CONFLICT` needs). Asserts the observable DB effects:

- **(a)** a sufficient debit moves the balance by **exactly −amount** and writes **one** matching −amount `debit` row;
- **(b)** `amount > balance` fails **closed**: `success:false`, `reason:'insufficient_balance'`, balance **and** ledger untouched (plus the `== balance` boundary succeeds to zero, and an unknown org → `org_not_found`);
- **(c)** `reserve()` throws `InsufficientCreditsError` (with `required`/`available`/`reason`) when over-budget, debiting nothing;
- **(d)** `reconcile()` **refunds** the difference when actual < reserved (balance up, real `refund` row) and **charges the overage** when actual > reserved (balance down, second debit row); `actual == reserved` is a no-op.

Only the non-billing fire-and-forget side-effects (email / waifu webhook / auto-top-up) are stubbed — never the deduct/guard/refund arithmetic.

### M1 — `packages/cloud-api/cron/container-billing/route.test.ts` (5 tests)
Mirrors the sibling `agent-billing/route.test.ts`: mocks **only** the repo/data seam (`listBillableContainers`, `listBillingOrganizations`, `recordSuccessfulDailyBilling`, earnings/users) and drives the **real Hono route handler**, so the real orchestration runs. Asserts:

- correct **$0.67** `dailyCost`, charged purely to credits when there are no earnings;
- earnings-first-then-credits split **+ the cross-container in-memory pool drain** across two same-org containers in one run (container B sees the drained earnings pool);
- the `convertToCredits`-throws **fallback** charging the full day to credits — a documented prior bug-fix, guarded here against regression;
- a per-container failure → `errors:1` / `action:"error"` while the other container **still bills**;
- `alreadyBilled` → `action:"skipped"`, **not** billed (no revenue, no double-charge).

## Evidence each test would catch a regression

Mutation-checked each suite against the real code (changes reverted after):

| Mutation | Result |
|---|---|
| Drop the `current_balance >= amount` guard | 2 H1 tests fail |
| Flip the debit row sign (`-amount` → `amount`) | 4 H1 tests fail |
| Remove the `fromCredits = dailyCost` fallback reset | the M1 FALLBACK test fails |
| Remove the in-memory earnings pool drain | the M1 pool-drain test fails |

## Test results

```
H1 (cloud-shared): 9 pass, 0 fail   — real SQL vs PGlite
M1 (cloud-api):    5 pass, 0 fail   — real Hono route, repo seam mocked
```

biome clean on both touched files. No production code changed.
