### PR TITLE
fix(ui): tighten home widget section chrome

### DIFF
--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -21,13 +21,13 @@ export function WidgetSection({
       <span className="inline-flex shrink-0 items-center justify-center text-muted [&>svg]:h-3.5 [&>svg]:w-3.5">
         {icon}
       </span>
-      <span className="truncate text-[11px] leading-none font-semibold uppercase tracking-[0.16em] text-muted">
+      <span className="truncate text-[11px] leading-none font-semibold text-muted">
         {title}
       </span>
     </>
   );
   return (
-    <section data-testid={testId} className="space-y-1">
+    <section data-testid={testId} className="space-y-0.5">
       <div className="flex items-center justify-between gap-2 pr-1">
         {onTitleClick ? (
           <button


### PR DESCRIPTION
## Summary

- Remove uppercase styling and wide letter tracking from shared home widget section titles.
- Tighten the shared widget section vertical gap from `space-y-1` to `space-y-0.5`.
- Keep the change scoped to `WidgetSection` chrome; no layout rewrite or widget behavior changes.

Refs #9448

## Verification

- PASS `git fetch origin && git rebase origin/develop`
- PASS `bun install`
- PASS `bun run --cwd packages/core prebuild`
- PASS `bun run --cwd plugins/plugin-sql build`
- PASS `bun run --cwd packages/ui lint`
- PASS `bun run --cwd packages/ui typecheck`
- PASS `bun run --cwd packages/ui test -- --run src/widgets/WidgetHost.test.tsx src/widgets/WidgetHost.home-rank.test.tsx src/components/shell/HomeScreen.test.tsx` (11 tests)
- PASS `bun run --cwd packages/ui test:home-screen-e2e` (`HOME-SCREEN E2E PASSED`; screenshots/videos generated locally and not committed)
- PASS `bun run --cwd plugins/plugin-commands build`
- PASS `bun run --cwd plugins/plugin-registry typecheck`
- PASS `git diff --check origin/develop...HEAD`
- PASS `bun run verify` after final rebase onto `origin/develop` (510/510 tasks)

## Evidence Notes

- Committed diff is one source file: `packages/ui/src/components/chat/widgets/shared.tsx`.
- Local e2e output and install-generated plugin directories were left uncommitted.
