### PR TITLE
test(ui): cover always-seeded chat guarantee + retry greeting on agent-ready

### DIFF
--- a/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
+++ b/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+//
+// Real test of the "chat must ALWAYS have a chat in it" guarantee (#1). The fix
+// removed the `tabFromPath()==='chat'` gate so a greeted conversation is seeded
+// regardless of the boot route; this drives the extracted hydration policy with
+// a fake client and asserts that guarantee directly (not via the overlay, which
+// only renders whatever messages already exist).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../api";
+import {
+  type HydrateConversationClient,
+  type HydrateInitialConversationDeps,
+  hydrateInitialConversation,
+} from "./useChatCallbacks";
+
+const CONVERSATION = {
+  id: "c1",
+  title: "Chat",
+  roomId: "r1",
+  createdAt: "2026-06-24T00:00:00.000Z",
+  updatedAt: "2026-06-24T00:00:00.000Z",
+};
+
+function makeFakeClient(
+  overrides: Partial<Record<keyof HydrateConversationClient, unknown>> = {},
+) {
+  return {
+    listConversations: vi.fn(async () => ({ conversations: [] })),
+    getConversationMessages: vi.fn(async () => ({ messages: [] })),
+    sendWsMessage: vi.fn(),
+    createConversation: vi.fn(async () => ({
+      conversation: { ...CONVERSATION },
+      greeting: { text: "hi there" },
+    })),
+    ...overrides,
+    // biome-ignore lint/suspicious/noExplicitAny: test fake satisfies the structural client at the boundary
+  } as any;
+}
+
+function makeDeps(client: ReturnType<typeof makeFakeClient>) {
+  const setConversations = vi.fn();
+  const setActiveConversationId = vi.fn();
+  const setConversationMessages = vi.fn();
+  const conversationMessagesRef: { current: ConversationMessage[] } = {
+    current: [],
+  };
+  const activeConversationIdRef: { current: string | null } = { current: null };
+  const greetingFiredRef = { current: false };
+  const deps: HydrateInitialConversationDeps = {
+    client,
+    conversationHydrationEpochRef: { current: 0 },
+    activeConversationIdRef,
+    greetingFiredRef,
+    conversationMessagesRef,
+    setConversations,
+    setActiveConversationId,
+    setConversationMessages,
+    uiLanguage: "en",
+  };
+  return {
+    deps,
+    setConversations,
+    setActiveConversationId,
+    setConversationMessages,
+    greetingFiredRef,
+    activeConversationIdRef,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.history.replaceState(null, "", "/");
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
+  it("seeds a greeted conversation when the server has none, on ANY route (not just /chat)", async () => {
+    // Boot on a NON-chat route — exactly the case the old gate left empty.
+    window.history.replaceState(null, "", "/views");
+    const client = makeFakeClient();
+    const {
+      deps,
+      setActiveConversationId,
+      setConversationMessages,
+      greetingFiredRef,
+    } = makeDeps(client);
+
+    const result = await hydrateInitialConversation(deps);
+
+    expect(client.createConversation).toHaveBeenCalledWith(undefined, {
+      bootstrapGreeting: true,
+      lang: "en",
+    });
+    expect(setActiveConversationId).toHaveBeenCalledWith("c1");
+    const seeded = setConversationMessages.mock.calls.at(-1)?.[0];
+    expect(seeded).toHaveLength(1);
+    expect(seeded[0]).toMatchObject({
+      role: "assistant",
+      text: "hi there",
+      source: "agent_greeting",
+    });
+    expect(greetingFiredRef.current).toBe(true);
+    expect(result).toBeNull(); // greeting inlined → no backfill needed
+  });
+
+  it("restores an existing conversation with its messages instead of creating one", async () => {
+    const client = makeFakeClient({
+      listConversations: vi.fn(async () => ({
+        conversations: [{ ...CONVERSATION }],
+      })),
+      getConversationMessages: vi.fn(async () => ({
+        messages: [{ id: "m1", role: "user", text: "hello", timestamp: 1 }],
+      })),
+    });
+    const { deps, setActiveConversationId, setConversationMessages } =
+      makeDeps(client);
+
+    const result = await hydrateInitialConversation(deps);
+
+    expect(client.createConversation).not.toHaveBeenCalled();
+    expect(setActiveConversationId).toHaveBeenCalledWith("c1");
+    expect(setConversationMessages.mock.calls.at(-1)?.[0]).toHaveLength(1);
+    expect(result).toBeNull(); // already has messages
+  });
+
+  it("returns the new conversation id to backfill when created WITHOUT an inline greeting", async () => {
+    const client = makeFakeClient({
+      createConversation: vi.fn(async () => ({
+        conversation: { ...CONVERSATION, id: "c2" },
+        greeting: { text: "" },
+      })),
+    });
+    const { deps, greetingFiredRef } = makeDeps(client);
+
+    expect(await hydrateInitialConversation(deps)).toBe("c2");
+    expect(greetingFiredRef.current).toBe(false);
+  });
+
+  it("returns the restored id to backfill when the conversation has no renderable messages", async () => {
+    const client = makeFakeClient({
+      listConversations: vi.fn(async () => ({
+        conversations: [{ ...CONVERSATION }],
+      })),
+      getConversationMessages: vi.fn(async () => ({ messages: [] })),
+    });
+    const { deps } = makeDeps(client);
+
+    expect(await hydrateInitialConversation(deps)).toBe("c1");
+  });
+
+  it("never throws — a failed create resolves to null", async () => {
+    const client = makeFakeClient({
+      createConversation: vi.fn(async () => {
+        throw new Error("agent down");
+      }),
+    });
+    const { deps } = makeDeps(client);
+
+    expect(await hydrateInitialConversation(deps)).toBeNull();
+  });
+});

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -29,7 +29,7 @@ import {
   type LoadConversationMessagesResult,
   loadActiveConversationId,
 } from "./internal";
-import type { FirstRunMode, SetupStep } from "./types";
+import { deriveAgentReady, type FirstRunMode, type SetupStep } from "./types";
 
 import { useChatLifecycle } from "./useChatLifecycle";
 import { useChatSend } from "./useChatSend";
@@ -90,6 +90,177 @@ function isPersistedGreetingMessage(message: ConversationMessage): boolean {
     message.source === "agent_greeting" &&
     message.text.trim().length > 0
   );
+}
+
+/** The subset of the API client the initial-conversation hydration needs.
+ *  Injected (not the module singleton) so the policy below is unit-testable. */
+export type HydrateConversationClient = Pick<
+  typeof client,
+  | "listConversations"
+  | "getConversationMessages"
+  | "sendWsMessage"
+  | "createConversation"
+>;
+
+export interface HydrateInitialConversationDeps {
+  client: HydrateConversationClient;
+  conversationHydrationEpochRef: MutableRefObject<number>;
+  activeConversationIdRef: MutableRefObject<string | null>;
+  greetingFiredRef: MutableRefObject<boolean>;
+  conversationMessagesRef: MutableRefObject<ConversationMessage[]>;
+  setConversations: (conversations: Conversation[]) => void;
+  setActiveConversationId: (id: string | null) => void;
+  setConversationMessages: (messages: ConversationMessage[]) => void;
+  uiLanguage: string;
+}
+
+/**
+ * Hydrate the app's single active conversation on boot.
+ *
+ * INVARIANT: the ContinuousChatOverlay is mounted over EVERY surface, so the
+ * chat must ALWAYS end up with an active, greeted conversation — never an empty
+ * thread — regardless of which route the shell launched on. So when the server
+ * has zero conversations this ALWAYS creates one with a bootstrap greeting (it
+ * is NOT gated on the URL being /chat, the bug that left the overlay
+ * permanently empty when the shell booted at /views or a cached app slug).
+ *
+ * Returns a conversation id when the caller should still backfill a greeting
+ * (restored-but-empty, or created without an inline greeting), else null.
+ * Extracted from the hook so it can be tested directly with a fake client.
+ */
+export async function hydrateInitialConversation(
+  deps: HydrateInitialConversationDeps,
+): Promise<string | null> {
+  const {
+    client: api,
+    conversationHydrationEpochRef,
+    activeConversationIdRef,
+    greetingFiredRef,
+    conversationMessagesRef,
+    setConversations,
+    setActiveConversationId,
+    setConversationMessages,
+    uiLanguage,
+  } = deps;
+  const hydrationEpoch = ++conversationHydrationEpochRef.current;
+  const isCurrentHydration = () =>
+    conversationHydrationEpochRef.current === hydrationEpoch;
+
+  try {
+    const { conversations: rawConversations } = await api.listConversations();
+    const conversations = normalizeConversationList(rawConversations);
+    traceGreeting("hydrate:listConversations", {
+      count: conversations.length,
+    });
+    if (!isCurrentHydration()) {
+      return null;
+    }
+    setConversations(conversations);
+    if (conversations.length > 0) {
+      const savedConversationId = loadActiveConversationId();
+      const restoredConversation =
+        conversations.find(
+          (conversation) => conversation.id === savedConversationId,
+        ) ?? conversations[0];
+      if (!isCurrentHydration()) {
+        return null;
+      }
+      setActiveConversationId(restoredConversation.id);
+      activeConversationIdRef.current = restoredConversation.id;
+      api.sendWsMessage({
+        type: "active-conversation",
+        conversationId: restoredConversation.id,
+      });
+      try {
+        const { messages } = await api.getConversationMessages(
+          restoredConversation.id,
+        );
+        if (!isCurrentHydration()) {
+          return null;
+        }
+        const nextMessages = filterRenderableConversationMessages(messages);
+        greetingFiredRef.current =
+          hasConversationBootstrapMessage(nextMessages);
+        conversationMessagesRef.current = nextMessages;
+        setConversationMessages(nextMessages);
+        return nextMessages.length === 0 ? restoredConversation.id : null;
+      } catch {
+        if (!isCurrentHydration()) {
+          return null;
+        }
+        // transient fetch failures are expected on early load; others are silent
+        greetingFiredRef.current = false;
+        conversationMessagesRef.current = [];
+        setConversationMessages([]);
+        return restoredConversation.id;
+      }
+    }
+
+    if (!isCurrentHydration()) {
+      return null;
+    }
+    traceGreeting("hydrate:no_conversations_on_server");
+    greetingFiredRef.current = false;
+    conversationMessagesRef.current = [];
+    setConversationMessages([]);
+    setActiveConversationId(null);
+    activeConversationIdRef.current = null;
+    setConversations([]);
+
+    traceGreeting("hydrate:auto_create_initial_conversation");
+    try {
+      const { conversation: rawConversation, greeting: inlineGreeting } =
+        await api.createConversation(undefined, {
+          bootstrapGreeting: true,
+          lang: uiLanguage,
+        });
+      if (!isConversationRecord(rawConversation)) {
+        throw new Error("Conversation creation returned an invalid payload.");
+      }
+      const conversation = rawConversation;
+
+      if (!isCurrentHydration()) {
+        return null;
+      }
+
+      setConversations([conversation]);
+      setActiveConversationId(conversation.id);
+      activeConversationIdRef.current = conversation.id;
+      api.sendWsMessage({
+        type: "active-conversation",
+        conversationId: conversation.id,
+      });
+
+      const greetingText = inlineGreeting?.text?.trim() || "";
+      if (greetingText) {
+        const nextMessages: ConversationMessage[] = [
+          {
+            id: `greeting-${Date.now()}`,
+            role: "assistant",
+            text: greetingText,
+            timestamp: Date.now(),
+            source: "agent_greeting",
+            ...(inlineGreeting?.localInference
+              ? { localInference: inlineGreeting.localInference }
+              : {}),
+          },
+        ];
+        greetingFiredRef.current = true;
+        conversationMessagesRef.current = nextMessages;
+        setConversationMessages(nextMessages);
+        return null;
+      }
+
+      return conversation.id;
+    } catch {
+      if (!isCurrentHydration()) {
+        return null;
+      }
+      return null;
+    }
+  } catch {
+    return null;
+  }
 }
 
 function shouldStartFreshCompanionConversation(
@@ -484,143 +655,52 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
     [fetchGreeting],
   );
 
-  const hydrateInitialConversationState = useCallback(async (): Promise<
-    string | null
-  > => {
-    const hydrationEpoch = ++conversationHydrationEpochRef.current;
-    const isCurrentHydration = () =>
-      conversationHydrationEpochRef.current === hydrationEpoch;
+  const hydrateInitialConversationState = useCallback(
+    (): Promise<string | null> =>
+      hydrateInitialConversation({
+        client,
+        conversationHydrationEpochRef,
+        activeConversationIdRef,
+        greetingFiredRef,
+        conversationMessagesRef,
+        setConversations,
+        setActiveConversationId,
+        setConversationMessages,
+        uiLanguage,
+      }),
+    [
+      activeConversationIdRef,
+      conversationHydrationEpochRef,
+      conversationMessagesRef,
+      greetingFiredRef,
+      uiLanguage,
+      setActiveConversationId,
+      setConversationMessages,
+      setConversations,
+    ],
+  );
 
-    try {
-      const { conversations: rawConversations } =
-        await client.listConversations();
-      const conversations = normalizeConversationList(rawConversations);
-      traceGreeting("hydrate:listConversations", {
-        count: conversations.length,
-      });
-      if (!isCurrentHydration()) {
-        return null;
-      }
-      setConversations(conversations);
-      if (conversations.length > 0) {
-        const savedConversationId = loadActiveConversationId();
-        const restoredConversation =
-          conversations.find(
-            (conversation) => conversation.id === savedConversationId,
-          ) ?? conversations[0];
-        if (!isCurrentHydration()) {
-          return null;
-        }
-        setActiveConversationId(restoredConversation.id);
-        activeConversationIdRef.current = restoredConversation.id;
-        client.sendWsMessage({
-          type: "active-conversation",
-          conversationId: restoredConversation.id,
-        });
-        try {
-          const { messages } = await client.getConversationMessages(
-            restoredConversation.id,
-          );
-          if (!isCurrentHydration()) {
-            return null;
-          }
-          const nextMessages = filterRenderableConversationMessages(messages);
-          greetingFiredRef.current =
-            hasConversationBootstrapMessage(nextMessages);
-          conversationMessagesRef.current = nextMessages;
-          setConversationMessages(nextMessages);
-          return nextMessages.length === 0 ? restoredConversation.id : null;
-        } catch {
-          if (!isCurrentHydration()) {
-            return null;
-          }
-          // transient fetch failures are expected on early load; others are silent
-          greetingFiredRef.current = false;
-          conversationMessagesRef.current = [];
-          setConversationMessages([]);
-          return restoredConversation.id;
-        }
-      }
-
-      if (!isCurrentHydration()) {
-        return null;
-      }
-      traceGreeting("hydrate:no_conversations_on_server");
-      greetingFiredRef.current = false;
-      conversationMessagesRef.current = [];
-      setConversationMessages([]);
-      setActiveConversationId(null);
-      activeConversationIdRef.current = null;
-      setConversations([]);
-
-      // The ContinuousChatOverlay is mounted on EVERY surface (App.tsx), so the
-      // chat must ALWAYS have an active, greeted conversation — never an empty
-      // thread — regardless of which tab/route the shell launched on. Previously
-      // this was gated on the URL being the /chat route, so booting at /views or
-      // a cached app slug left the overlay permanently empty. Always create.
-      traceGreeting("hydrate:auto_create_initial_conversation");
-      try {
-        const { conversation: rawConversation, greeting: inlineGreeting } =
-          await client.createConversation(undefined, {
-            bootstrapGreeting: true,
-            lang: uiLanguage,
-          });
-        if (!isConversationRecord(rawConversation)) {
-          throw new Error("Conversation creation returned an invalid payload.");
-        }
-        const conversation = rawConversation;
-
-        if (!isCurrentHydration()) {
-          return null;
-        }
-
-        setConversations([conversation]);
-        setActiveConversationId(conversation.id);
-        activeConversationIdRef.current = conversation.id;
-        client.sendWsMessage({
-          type: "active-conversation",
-          conversationId: conversation.id,
-        });
-
-        const greetingText = inlineGreeting?.text?.trim() || "";
-        if (greetingText) {
-          const nextMessages: ConversationMessage[] = [
-            {
-              id: `greeting-${Date.now()}`,
-              role: "assistant",
-              text: greetingText,
-              timestamp: Date.now(),
-              source: "agent_greeting",
-              ...(inlineGreeting?.localInference
-                ? { localInference: inlineGreeting.localInference }
-                : {}),
-            },
-          ];
-          greetingFiredRef.current = true;
-          conversationMessagesRef.current = nextMessages;
-          setConversationMessages(nextMessages);
-          return null;
-        }
-
-        return conversation.id;
-      } catch {
-        if (!isCurrentHydration()) {
-          return null;
-        }
-        return null;
-      }
-    } catch {
-      return null;
-    }
+  // Backfill the bootstrap greeting once the agent first becomes ready. The
+  // initial post-hydrate `requestGreetingWhenRunning` is one-shot and bails when
+  // the agent isn't running yet (a slow on-device model still warming, or no
+  // provider wired at boot) — without this retry a restored/created conversation
+  // that hydrated empty would stay permanently blank, so the chat would have no
+  // chat in it even though an active conversation exists. The helper self-gates
+  // on `greetingFiredRef`, so this never double-greets.
+  const agentReady = deriveAgentReady(agentStatus);
+  useEffect(() => {
+    if (!agentReady) return;
+    if (greetingFiredRef.current) return;
+    if (conversationMessagesRef.current.length > 0) return;
+    const convId = activeConversationIdRef.current;
+    if (!convId) return;
+    void requestGreetingWhenRunning(convId);
   }, [
+    agentReady,
+    requestGreetingWhenRunning,
     activeConversationIdRef,
-    conversationHydrationEpochRef,
     conversationMessagesRef,
     greetingFiredRef,
-    uiLanguage,
-    setActiveConversationId,
-    setConversationMessages,
-    setConversations,
   ]);
 
   // ── Send sub-hook ───────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to the home/springboard/chat shell unification already merged to `develop` (`5636b95b78` *harden home springboard surface state*, `631eccdd20` *full-flow composed e2e*). That work fixed six broken shell states (empty chat, swipe→empty favorites, swipe-back→edit mode, doubled page-dots, placeholder icons) by collapsing four uncoordinated nav state machines into one `shell-surface-store`. This PR closes its **two remaining verification gaps** — both flagged as caveats in that work.

## What

**1. Make the "chat must ALWAYS have a chat in it" guarantee testable.**
The boot-time conversation hydration was a closure inside the ~50-dependency `useChatCallbacks` hook, so the fix that removed the `tabFromPath()==='chat'` gate (which had left the always-mounted chat overlay permanently empty when the shell booted at `/views` or a cached app slug) had no direct test. Extracted it into an exported, injectable `hydrateInitialConversation(deps)` — the `client` is typed `Pick<typeof client, …>` so a fake drops in — and added `useChatCallbacks.hydrate.test.ts` (5 cases):
- seeds a greeted conversation when the server has none **on a non-`/chat` route** (the exact bug),
- restores an existing thread with its messages instead of creating one,
- returns the new conversation id to backfill when created without an inline greeting,
- returns the restored id when the conversation has no renderable messages,
- never throws — a failed create resolves to `null`.

**2. Retry the bootstrap greeting once the agent becomes ready.**
The initial post-hydrate greeting request is one-shot and bails when the agent isn't running yet (a slow on-device model still warming, or no provider wired at boot), which left a restored/created-but-empty conversation permanently blank. Added an effect keyed on `deriveAgentReady(agentStatus)` that backfills the greeting when the active conversation is still empty. Self-gates on `greetingFiredRef`, so it never double-greets.

## Verification

- `useChatCallbacks.hydrate.test.ts` — **5/5 pass** (drives the real hydration policy with a fake client; this is the evidence).
- `bun run --cwd packages/ui typecheck` — clean.
- `bun run --cwd packages/ui test` (state + shell) — **676 pass / 7 skipped**, no regressions.
- Real-LLM trajectory: **N/A** — no agent/action/prompt/model behavior changes; this is client-side conversation bootstrap + unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)