### PR TITLE
chore(types): gate @ts-expect-error/@ts-ignore in the type-safety ratchet (#9474)

### DIFF
--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-24T21:07:32.316Z",
+  "updatedAt": "2026-06-24T22:34:08.580Z",
   "scope": {
     "trackedOnly": true,
     "globs": [
@@ -37,7 +37,8 @@
   },
   "limits": {
     "asUnknownAs": 488,
-    "asAny": 6
+    "asAny": 6,
+    "tsSuppress": 2
   },
-  "filesScanned": 10010
+  "filesScanned": 10013
 }

--- a/packages/scripts/type-safety-ratchet.mjs
+++ b/packages/scripts/type-safety-ratchet.mjs
@@ -2,9 +2,13 @@
 /**
  * Fails when production source adds new unsafe TypeScript escape hatches.
  *
- * The gate is deliberately narrow: it tracks explicit cast escapes that are
- * easy to classify by AST and were called out in #9474. Broader strict-mode
- * migrations should tighten this baseline over time.
+ * The gate is deliberately narrow: it tracks explicit cast escapes
+ * (`as any`, `as unknown as`) and the TypeScript error-suppression directives
+ * (expect-error and its legacy ignore form) that are easy to classify by AST
+ * and were called out in #9474. Suppressions are read from TypeScript's own
+ * `sourceFile.commentDirectives`, so a directive token inside a string or a
+ * comment about directives is not miscounted. Broader strict-mode migrations
+ * should tighten this baseline over time.
  */
 
 import { execFileSync } from "node:child_process";
@@ -31,6 +35,7 @@ const UPDATE_BASELINE = args.has("--update-baseline");
 const KIND_LABELS = {
   asUnknownAs: "as unknown as",
   asAny: "as any",
+  tsSuppress: "@ts-expect-error / @ts-ignore",
 };
 
 const EXCLUDED_SEGMENTS = new Set([
@@ -146,11 +151,28 @@ function collectUnsafeCasts(sourceText, relPath) {
   }
 
   visit(sourceFile);
+
+  // Type-error suppression directives, read from TypeScript's own directive
+  // table so we never miscount directive text that appears inside a string or
+  // an unrelated comment. Covers expect-error and its legacy ignore form.
+  for (const directive of sourceFile.commentDirectives ?? []) {
+    const pos = sourceFile.getLineAndCharacterOfPosition(directive.range.pos);
+    findings.push({
+      kind: "tsSuppress",
+      file: relPath,
+      line: pos.line + 1,
+      snippet: sourceText
+        .slice(directive.range.pos, directive.range.end)
+        .replace(/\s+/g, " ")
+        .slice(0, 160),
+    });
+  }
+
   return findings;
 }
 
 function summarize(findings) {
-  const counts = { asUnknownAs: 0, asAny: 0 };
+  const counts = { asUnknownAs: 0, asAny: 0, tsSuppress: 0 };
   for (const finding of findings) {
     counts[finding.kind] += 1;
   }
@@ -319,9 +341,18 @@ function runSelfTest() {
     // const four = value as unknown as Result;
     const five = value as unknown;
     const six = (value as unknown) as Result;
+    // @ts-expect-error self-test directive
+    const seven: string = 1;
+    // @ts-ignore self-test directive
+    const eight: number = "x";
+    const nine = "// @ts-ignore inside a string is not a directive";
   `;
   const counts = summarize(collectUnsafeCasts(sample, "sample.ts"));
-  if (counts.asUnknownAs !== 2 || counts.asAny !== 1) {
+  if (
+    counts.asUnknownAs !== 2 ||
+    counts.asAny !== 1 ||
+    counts.tsSuppress !== 2
+  ) {
     console.error(
       `[type-safety-ratchet] self-test failed: ${JSON.stringify(counts)}`,
     );


### PR DESCRIPTION
Advances #9474 by closing an enforcement gap in the **existing** ratchet — not adding a parallel one.

## Context
The repo already has an AST-based unsafe-cast ratchet (`packages/scripts/type-safety-ratchet.mjs`, wired into `bun run verify`) that freezes `as any` (≤6) and `as unknown as` (≤488) in production source. But **type-error suppressions** — `@ts-expect-error` / `@ts-ignore`, the other escape hatch #9474 explicitly targets — were **ungated**: a new suppression passed CI silently.

## What
Extends that same ratchet (no new mechanism, no duplication) to also count suppressions:
- Reads them from TypeScript's own `sourceFile.commentDirectives` table — so a directive token inside a string or an unrelated comment is **never miscounted** (the self-test includes a decoy string that is correctly ignored).
- Adds a `tsSuppress` kind to the baseline at its current floor of **2**, freezing a near-zero surface so it can't regress.

## Verification (all run locally)
- `--self-test` passes: `asUnknownAs 2, asAny 1, tsSuppress 2` (decoy string not counted).
- Negative path: staging a new `@ts-expect-error` in `src/` makes the ratchet report `tsSuppress 3 / 2`, "baseline exceeded", exit 1.
- The cast baselines (488 / 6) are unchanged — only `tsSuppress` is added.
- `bunx biome check` clean. (Note: biome's `--write` assist rewrites a literal `@ts-ignore` *inside comments* into `@ts-expect-error`; the doc comments here are worded to avoid that token so the file is format-stable.)

## Remaining #9474 work (tracked in the issue)
Phase 1–6 — restoring `strict: true` in `packages/agent`, removing `noImplicitAny: false` in the app-core typecheck lane, giving `plugin-personal-assistant` a real typecheck (not `--noCheck`), and burning down the 488 `as unknown as` at the model-output/transport/DB boundaries to ratchet the baseline down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)