### PR TITLE
docs(benchmarks): de-larp the '40+ integrated harnesses' README claim (#9475)

### DIFF
--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -1,12 +1,41 @@
 # `packages/benchmarks`
 
-The elizaOS evaluation suite — 40+ integrated benchmark harnesses spanning agent
+The elizaOS evaluation suite — 40+ benchmark harness directories spanning agent
 autonomy, tool-call correctness, long-horizon reasoning, voice/vision multimodal,
 embodied control, onchain trading, and adversarial robustness.
 
 Primarily Python, with several TypeScript/Bun and Rust harnesses. Lives outside
 the TypeScript workspace; not an npm package. Each benchmark is self-contained in
 its own directory and carries `README.md` + `AGENTS.md` + `CLAUDE.md`.
+
+> **"Integrated" is not uniform across these directories** (#9475). The "40+"
+> counts harness *directories present in the tree*, which is larger than the set
+> that actually benchmark Eliza against a live runtime today. The honest
+> breakdown:
+>
+> - **Bridge-wired & real** — route through the `eliza-adapter` (which boots a
+>   real `AgentRuntime` + real model plugins and serves `/api/benchmark/message`)
+>   or a `_matrix`/extra adapter that imports `ElizaClient` / `ElizaServerManager`:
+>   the registry's bridge benchmarks plus the code-agent `_matrix` wrappers
+>   (`clawbench_matrix`, `claw_eval_matrix`, `qwen_claw_bench_matrix`,
+>   `swe_bench_pro_matrix`, `openclaw_benchmark`) and the runtime adapters
+>   `loca-bench`, `compactbench`, `evm`.
+> - **Vendored task/dataset directories** consumed *by* those bridges but with no
+>   Eliza code inside them (`claw-eval`, `qwen-claw-bench`, `swe-bench-pro`,
+>   `swe-bench-multilingual`).
+> - **Vendored-but-not-yet-integrated** — present and registry/coverage-tracked or
+>   skip-listed, but with no working adapter yet; see each dir's `INTEGRATION.md`
+>   (`qwen-web-bench`, `skillsbench`).
+> - **Runs in CI** — only a small subset has its own scheduled/gated lane
+>   (`memperf`, `lifeops-bench`, `hyperliquid-bench-live`, voice, mobile-resource).
+>   The registry-driven orchestrator suite as a whole is **not** scheduled against
+>   real models — `python -m benchmarks.orchestrator run` is invoked from CI only
+>   by `hyperliquid-bench-live.yml` (one benchmark). Closing that gap (a scheduled
+>   orchestrator lane over a core subset) is the main open de-larp task in #9475.
+>
+> Treat "40+" as the count of vendored harness directories, several deferred or
+> integration-pending rather than wired end-to-end. Update this when adapters are
+> added or vendored snapshots are dropped.
 
 ## How it fits together
 


### PR DESCRIPTION
Addresses the one genuinely actionable, safe finding of #9475.

## What the audit found
I ran an adversarial per-directory verification of the 17 dirs the #9475 audit flagged as larp/deletable (one verifier per dir, each checking registry/CI/imports/Eliza-wiring before greenlighting deletion). The result **corrected the audit**:

- **Only 2 dirs are "safe to delete"** (`elizaos_mmau`, `mmau`) — and both contain **zero git-tracked files** (the real source was already removed in `828d5ccafa`); only gitignored `.pyc`/`.pytest_cache` cruft remains, so `git rm` is a no-op. Existing no-shim guard tests already assert their absence.
- **2 are maintainer-decision** (`qwen-web-bench`, `skillsbench`) — unreferenced vendored upstreams, but deleting them requires coupled registry + existence-audit-test edits (`existing_directory_count == 19`), not a mechanical delete.
- **The remaining 14 are load-bearing** — `_matrix` wrappers + runtime extra-adapters (`loca-bench`, `compactbench`, `evm` import `ElizaClient`/`ElizaServerManager`), vendored task-data consumed at runtime by the `_matrix` siblings, and existence-audit tests.

So there is **nothing safe to delete in a PR**. The genuine de-larp target is the README's inaccurate framing.

## This PR
Rewrites `packages/benchmarks/README.md`'s opening "40+ integrated benchmark harnesses" into an honest breakdown — bridge-wired-&-real vs vendored task-data vs vendored-not-yet-integrated vs runs-in-CI — and states the real CI situation (verified): the registry-driven orchestrator suite is **not** scheduled against real models; `python -m benchmarks.orchestrator run` is invoked from CI only by `hyperliquid-bench-live.yml`.

## Verified facts behind the copy
- `eliza-adapter` bridge boots a real `AgentRuntime` + real model plugins (`packages/app-core/src/benchmark/server.ts`).
- CI benchmark lanes that exist: `memperf.yml`, `lifeops-bench*.yml`, `hyperliquid-bench-live.yml`, `voice-live-e2e.yml`, `mobile-resource-workbench.yml`.
- Only `hyperliquid-bench-live.yml:160` runs `python -m benchmarks.orchestrator run`.

## Remaining #9475 work (tracked in the issue; not safe to do blindly)
The deletion checklist in the issue body is **over-broad** — I'll comment there with the per-dir verdicts. The real open task is a scheduled orchestrator CI lane over a core subset (bfcl/action-calling/agentbench/tau-bench/mint/context-bench) with real keys — needs secrets/infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)