### PR TITLE
test(ui): remove dead assertion from story smoke harness; document why null renders are valid

### DIFF
--- a/packages/ui/test/portable-stories.tsx
+++ b/packages/ui/test/portable-stories.tsx
@@ -109,8 +109,15 @@ export function smokeStoryModules(
       for (const [storyName, Story] of stories) {
         const testFn = skip.has(`${name}/${storyName}`) ? it.skip : it;
         testFn(`${storyName} renders without throwing`, async () => {
+          // The coverage here IS the absence of a throw: composing the story
+          // (above) and mounting it must not error. There is intentionally no
+          // "produced DOM" assertion — null/empty renders are valid in this jsdom
+          // lane. Many stories are empty-by-design (Closed/Disabled/Empty states)
+          // or render nothing without the full app runtime (browser-status,
+          // ShortcutsOverlay/Open, …). Blank-render detection that needs that
+          // runtime lives in the browser story gate (its needs-runtime path) and
+          // the live audit:app — not this fast offline smoke.
           const { container } = render(wrap(<Story />) as ReactElement);
-          expect(container.firstChild ?? container).toBeTruthy();
           // If the story defines an interaction (`play`), run it — so authoring a
           // play function automatically gets it exercised in this lane, with no
           // per-component test to wire up.


### PR DESCRIPTION
## What

Part of the launch de-larp sweep (@shaw's *"find LARP in the tests, scenarios, e2e"*). The shared portable-stories smoke harness asserted, per story:

```ts
expect(container.firstChild ?? container).toBeTruthy();
```

`container` is the testing-library mount `<div>` — **always truthy** — so the `?? container` fallback made this assertion impossible to fail. It looked like an output check but verified nothing; a story rendering completely blank passed silently.

## Why remove rather than tighten

I first tried tightening it to require real DOM (`container.firstChild != null || baseElement.childElementCount > 1`). Running it across the suite flagged **20 stories** — and investigating them showed a *"rendered DOM"* invariant over-reaches:

- **~13 are empty-by-design** — `Closed` dialogs, `Disabled` widgets, `Empty`/`NotOwner`/`Clean`/`Undefined` states. Rendering null is the point of the story.
- **~7 need the full app runtime** — all `browser-status/*` (incl. `Populated`/`ManyTabs`) and `ShortcutsOverlay/Open` render nothing in bare jsdom because they read app-runtime context the offline harness doesn't supply. (They did **not** portal into the document body — a portal would've satisfied the check — they genuinely render null without the runtime.)

Both populations render null **legitimately**, so blank-render detection belongs in the **browser story gate** (which has the `needs-runtime` classification) and the live `audit:app` — not this fast offline lane. The original `?? container` leniency was a deliberate accommodation of that, just written as a dead assertion.

So this removes the misleading line and **documents** why null renders are valid, so it isn't re-flagged as fake coverage later.

## Coverage is unchanged

The genuine checks all remain: `composeStories` succeeding, `render()` not throwing, `play()` not throwing, and the per-directory `minModules` count assertion. 

`bun run --cwd packages/ui test stories-smoke` → **30 files / 1498 passed, 14 skipped** (same as before, minus the impossible-to-fail assertion). biome clean.

cc @elizaOS — tracking on #8434.