### PR TITLE
ci(cloud): invoke the EDAD real-deploy driver in the nightly real-Hetzner job (#9300)

### DIFF
--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Run monetized full loop + example-apps showcase (real Hetzner)
         if: steps.secret_config.outputs.configured == 'true' && steps.cloud_auth.outputs.ready == 'true'
-        run: bun run cloud:e2e -- monetized-full-loop.spec.ts example-apps-showcase.spec.ts
+        run: bun run cloud:e2e -- monetized-full-loop.spec.ts example-apps-showcase.spec.ts example-edad-real-deploy.spec.ts
         env:
           CI: "true"
           E2E_RECORD: "1"


### PR DESCRIPTION
#9484 added `example-edad-real-deploy.spec.ts` but the nightly real-job (`MONETIZED_LOOP_REAL=1`, monetized-loop-nightly.yml:153) only ran `monetized-full-loop` + `example-apps-showcase` — so the new real-ingress/TLS deploy-and-serve driver was invoked by **no CI job**. This wires it into the real-job spec list (it honest-skips until `MONETIZED_LOOP_BASE_URL` + `CLOUD_E2E_API_KEY` are set), completing the CI-wiring half of #9300 slice 1. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)