### PR TITLE
test(cloud): close medium LARP gaps (cerebras tool-call shape, bounded-teardown timeout, pull-timeout tautology)

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -400,7 +400,7 @@ const HEALTH_CHECK_POLL_INTERVAL_MS = 3_000;
 const HEALTH_CHECK_TIMEOUT_MS = 360_000;
 
 /** SSH command timeout for docker pull (can be slow on first pull). */
-const PULL_TIMEOUT_MS = 300_000; // 5 min
+export const PULL_TIMEOUT_MS = 300_000; // 5 min
 
 /** SSH command timeout for docker run / stop / rm. */
 const DOCKER_CMD_TIMEOUT_MS = 60_000;

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, jest, mock, spyOn, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -1047,6 +1047,44 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
       // failure, not abandon-and-proceed.
       expect("timedOut" in res).toBe(false);
     } finally {
+      getProvider.mockRestore();
+    }
+  });
+
+  // The whole reason #9066 exists: a provider.stop that genuinely never
+  // settles (SSH connect / provider init wedge) must be cut off at the hard
+  // cap so a single stuck node can't hang the delete past the job watchdog and
+  // wedge the provisioning worker. The two tests above cover clean/error; this
+  // one drives the REAL withTimeout branch — a never-settling stop raced under
+  // fake timers — and asserts the abandon-and-proceed { error, timedOut }
+  // shape that deleteAgent keys "ABANDON + LEAK" on.
+  test("runBoundedSandboxStop cuts off a never-settling provider stop with { error, timedOut }", async () => {
+    const svc = await makeSvc();
+    // Never resolves and never rejects: the only way out is the timeout race.
+    const getProvider = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      stop: () => new Promise<void>(() => {}),
+    } as unknown as SandboxProvider);
+    jest.useFakeTimers();
+    try {
+      const pending = svc.runBoundedSandboxStop(SANDBOX_ID) as Promise<{
+        error: unknown;
+        timedOut?: true;
+      }>;
+      // Let getProvider() + the try-body microtasks settle so the timeout
+      // timer is actually armed, then blow past the 120s hard cap.
+      await Promise.resolve();
+      jest.advanceTimersByTime(120_001);
+      const res = await pending;
+      // Abandon-and-proceed: a genuine hang is reported as a TIMEOUT, distinct
+      // from a captured provider error (no `timedOut` flag on that path).
+      expect(res.timedOut).toBe(true);
+      expect(res.error).toBeInstanceOf(Error);
+      expect((res.error as Error).message).toContain("timed out after");
+    } finally {
+      jest.useRealTimers();
       getProvider.mockRestore();
     }
   });

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
@@ -26,6 +26,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { withTimeout } from "../utils/with-timeout";
+// Import the provider's REAL pull ceiling so this test tracks the production
+// constant (and goes red if either drifts), rather than asserting against a
+// hand-copied literal that can silently diverge.
+import { PULL_TIMEOUT_MS } from "./docker-sandbox-provider";
 import { PER_JOB_TIMEOUT_MS } from "./provisioning-jobs";
 
 /** A cold `docker pull` of a freshly-pinned image takes ~2.5 min on the node. */
@@ -42,8 +46,10 @@ const OLD_PER_JOB_TIMEOUT_MS = 120_000;
  * PER_JOB_TIMEOUT_MS, and the watchdog invariant
  * (WORK_CYCLE_TIMEOUT_MS 240s + poll 30s < WATCHDOG_MAX_CYCLE_MS 300s) does not
  * reference it. Raising PER_JOB_TIMEOUT_MS to 300s therefore stays watchdog-safe.
+ *
+ * `PULL_TIMEOUT_MS` is imported from `docker-sandbox-provider` (not redeclared)
+ * so this assertion catches real drift in the provider's pull ceiling.
  */
-const PULL_TIMEOUT_MS = 300_000;
 /** Shared 1000x scale-down so the timing tests run instantly. */
 const SCALE = 1000;
 

--- a/plugins/plugin-elizacloud/__tests__/unit/text-native-tool-call-shape.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-native-tool-call-shape.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Offline unit coverage for the non-streaming planner tool-call contract.
+ *
+ * The real cerebras `/chat/completions` (non-streaming) response carries the
+ * planner's decision as `choices[0].message.tool_calls[]`, where each entry is
+ * an OpenAI-shaped `{ id, type:"function", function:{ name, arguments } }` and
+ * `arguments` is a JSON *string*. `extractNativeToolCalls` (in
+ * `src/models/text.ts`) is the private parser that turns that wire shape into
+ * the runtime's `{ toolName, input }` tool calls — the thing the action planner
+ * actually consumes.
+ *
+ * Until now that contract was only checked by the LIVE suite in
+ * `text-native-plumbing.test.ts`, which is `it.skip`-ped whenever
+ * `ELIZAOS_CLOUD_API_KEY` is unset (CI default) — so the parser was never
+ * CI-tested against a representative cerebras body. This drives the same
+ * non-streaming planner path with a mocked `globalThis.fetch` (same technique
+ * as `text-cerebras-response-format.test.ts`) and pins the parse result.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleActionPlanner } from "../../src/models/text";
+
+type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
+  Partial<IAgentRuntime>;
+
+function runtime(): IAgentRuntime {
+  const settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  };
+  const fixture: RuntimeFixture = {
+    character: { name: "Eliza", bio: [] },
+    getSetting: (key: string) => settings[key],
+    emitEvent: vi.fn(),
+  };
+  return fixture as IAgentRuntime;
+}
+
+/**
+ * A representative real cerebras NON-streaming `/chat/completions` body: the
+ * planner's tool decision lands in `message.tool_calls[0]` as an OpenAI-shaped
+ * function call whose `arguments` is a JSON *string* (not an object).
+ */
+function cerebrasToolCallResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      model: "gpt-oss-120b",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "tool_calls",
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_abc123",
+                type: "function",
+                function: {
+                  name: "PLAN_ACTIONS",
+                  arguments: JSON.stringify({
+                    actions: [{ action: "REPLY", thought: "greet the user" }],
+                  }),
+                },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+const PLANNER_PARAMS = {
+  prompt: "fallback prompt",
+  system: "You are a planner. You MUST call the PLAN_ACTIONS tool.",
+  messages: [{ role: "user", content: "Plan one REPLY action." }],
+  tools: [
+    {
+      type: "function",
+      function: {
+        name: "PLAN_ACTIONS",
+        description: "Plan actions",
+        parameters: {
+          type: "object",
+          properties: { actions: { type: "array" } },
+          required: ["actions"],
+        },
+      },
+    },
+  ],
+  toolChoice: { type: "tool", toolName: "PLAN_ACTIONS" },
+};
+
+describe("non-streaming planner tool-call shape (offline)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses cerebras choices[0].message.tool_calls into { toolName, input }", async () => {
+    let chatCompletionsHit = false;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes("/chat/completions")) {
+          chatCompletionsHit = true;
+          return cerebrasToolCallResponse();
+        }
+        throw new Error(`unexpected fetch to ${url}`);
+      }
+    );
+
+    const result = await handleActionPlanner(runtime(), PLANNER_PARAMS as never);
+
+    // The planner path must hit the native /chat/completions route, not /responses.
+    expect(chatCompletionsHit).toBe(true);
+
+    // tools/toolChoice make this a native call that returns the rich result
+    // object (not a bare string), with parsed tool calls.
+    expect(result).toBeTypeOf("object");
+    expect(result).not.toBeNull();
+    const toolCalls = (result as { toolCalls?: Array<{ toolName: string; input: unknown }> })
+      .toolCalls;
+    expect(Array.isArray(toolCalls)).toBe(true);
+    expect(toolCalls).toHaveLength(1);
+
+    const call = toolCalls?.[0];
+    // The toolName comes from the OpenAI `function.name`.
+    expect(call?.toolName).toBe("PLAN_ACTIONS");
+    // The JSON-string `arguments` is parsed into a real object (the planner
+    // consumes `input`, not a raw string).
+    expect(call?.input).toEqual({
+      actions: [{ action: "REPLY", thought: "greet the user" }],
+    });
+  });
+});


### PR DESCRIPTION
A LARP audit flagged three MEDIUM test-coverage gaps where the test either never ran in CI or proved nothing about the real code. Each fix adds a **real** test that goes red when its target branch breaks (every one is mutation-verified, see below). No new larp; no production behavior changed except a single `export` keyword for M4.

Builds on #9503 (provision/upgrade tests in `eliza-sandbox.test.ts`) — the M3 addition layers cleanly on top of it after a clean rebase onto `develop`.

## M2 — chat-path: cerebras non-streaming tool-call shape was only "verified" by a CI-skipped live suite

`plugins/plugin-elizacloud/__tests__/text-native-plumbing.test.ts` is `it.skip`-ped whenever `ELIZAOS_CLOUD_API_KEY` is unset (CI default), so the non-streaming planner tool-call contract was **never** CI-tested. The private parser `extractNativeToolCalls` (`src/models/text.ts`) turns `choices[0].message.tool_calls` into `{ toolName, input }`.

**Fix:** new offline unit test `plugins/plugin-elizacloud/__tests__/unit/text-native-tool-call-shape.test.ts`. It mocks `globalThis.fetch` (same technique as `text-cerebras-response-format.test.ts`) to return a representative real cerebras non-streaming body with `choices[0].message.tool_calls` (`function.name` = `PLAN_ACTIONS`, JSON-string `arguments`), drives the non-streaming planner path via `handleActionPlanner`, and asserts it yields `{ toolName: "PLAN_ACTIONS", input: { actions: [...] } }`. The existing `it.skip` live suite is untouched.

## M3 — bounded-teardown timeout (#9066 anti-wedge cap): the "real hang → cut off" branch was never exercised

`eliza-sandbox.ts`'s `runBoundedSandboxStop` wraps `provider.stop` with `withTimeout(..., SANDBOX_DELETE_STOP_TIMEOUT_MS)` and converts a genuine hang into `{ error, timedOut: true }` — the whole reason #9066 exists. Existing tests only fed a pre-fabricated `{ timedOut: true }` or covered the clean/error branches.

**Fix:** a direct `runBoundedSandboxStop` test (in `eliza-sandbox.test.ts`, layered on top of #9503's additions) that injects a provider whose `stop()` returns a never-settling promise, races it under bun fake timers past the hard cap, and asserts the result is `{ error, timedOut: true }` with `error.message` containing `"timed out after"`. The existing clean/error tests are left as-is.

## M4 — pull-timeout tautology

`provisioning-jobs-per-job-timeout.test.ts` redeclared a LOCAL `const PULL_TIMEOUT_MS = 300_000` and asserted `PER_JOB_TIMEOUT_MS <= PULL_TIMEOUT_MS` against that hand-copy — a tautology blind to drift in the provider's real constant.

**Fix:** `export` the real `PULL_TIMEOUT_MS` from `docker-sandbox-provider.ts` (one-word prod change), import it in the per-job test, and delete the local copy so the assertion now tracks the production constant.

## Verification

- Touched test files run green:
  - `eliza-sandbox.test.ts` — 46 pass / 0 fail (includes #9503's tests + the new timeout test)
  - `provisioning-jobs-per-job-timeout.test.ts` — 3 pass / 0 fail
  - `text-native-tool-call-shape.test.ts` — 1 pass / 0 fail
  - `text-native-plumbing.test.ts` — still 1 skipped (untouched)
- biome clean on all touched files; `cloud-shared` and `plugin-elizacloud` typecheck pass.
- **Mutation-verified** — each test goes red when its target branch breaks:
  - M2: dropping `fn.name` from `extractNativeToolCalls` → tool call is filtered out → test fails (`returned no text or tool calls`).
  - M3: dropping the `timedOut: true` flag from the `.catch` → `res.timedOut` is `undefined` → test fails; the 6 pre-existing teardown-cap tests stay green (proving they never covered this branch).
  - M4: drifting the provider's real `PULL_TIMEOUT_MS` to `100_000` → `PER_JOB_TIMEOUT_MS (300000) <= 100000` fails (the old hand-copy tautology would have stayed green).

Refs #8434