### PR TITLE
feat(local-inference): stream TRANSCRIPTION partials through the chat pipe (#9105)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -886,7 +886,30 @@ function makeTranscriptionHandler(): TranscriptionHandler {
 		// there is no whisper.cpp second attempt and no silent empty transcript.
 		await localInferenceEngine.ensureActiveBundleVoiceReady();
 		throwIfAborted(signal);
-		const transcript = await localInferenceEngine.transcribePcm(audio, signal);
+		// Stream partial transcripts through the same pipe as chat text when the
+		// runtime wired a chunk sink (useModel injects onStreamChunk into local
+		// model params inside a streaming reply turn). The fused streaming-ASR
+		// session surfaces each running partial; we forward the deltas. Read the
+		// sink structurally so this stays robust to the core param type surface.
+		const streamSink =
+			params && typeof params === "object"
+				? (
+						params as {
+							onStreamChunk?: (chunk: string) => void | Promise<void>;
+						}
+					).onStreamChunk
+				: undefined;
+		const onPartial =
+			typeof streamSink === "function"
+				? (delta: string) => {
+						void streamSink(delta);
+					}
+				: undefined;
+		const transcript = await localInferenceEngine.transcribePcm(
+			audio,
+			signal,
+			onPartial,
+		);
 		throwIfAborted(signal);
 		return transcript;
 	};

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1545,6 +1545,7 @@ export class LocalInferenceEngine {
 	async transcribePcm(
 		args: TranscriptionAudio,
 		signal?: AbortSignal,
+		onPartial?: (delta: string) => void,
 	): Promise<string> {
 		this.markActivity();
 		if (signal?.aborted) {
@@ -1554,7 +1555,7 @@ export class LocalInferenceEngine {
 		}
 		const transcript = await this.requireVoiceBridge(
 			"transcribe audio",
-		).transcribePcm(args, signal);
+		).transcribePcm(args, signal, onPartial);
 		if (signal?.aborted) {
 			throw signal.reason instanceof Error
 				? signal.reason

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -1782,12 +1782,61 @@ export class EngineVoiceBridge {
 	async transcribePcm(
 		args: TranscriptionAudio,
 		signal?: AbortSignal,
+		onPartial?: (delta: string) => void,
 	): Promise<string> {
 		this.assertVoiceOn("transcribe audio");
 		if (signal?.aborted) {
 			throw signal.reason instanceof Error
 				? signal.reason
 				: new DOMException("Aborted", "AbortError");
+		}
+		// Streaming path: when the caller wants partial transcripts (the
+		// TRANSCRIPTION model handler forwards the runtime's onStreamChunk here),
+		// drive the fused streaming-ASR session and emit each running partial as a
+		// delta — the same per-token pipe as chat text. Feed in ~1s windows so the
+		// decode surfaces partials progressively. Degrades gracefully: when the
+		// fused build's streaming-ASR decoder is a stub, createStreamingTranscriber
+		// resolves the fused batch adapter and the final transcript is emitted once.
+		if (onPartial) {
+			const transcriber = this.createStreamingTranscriber();
+			let shown = 0;
+			const emit = (full: string): void => {
+				if (typeof full === "string" && full.length > shown) {
+					const delta = full.slice(shown);
+					shown = full.length;
+					onPartial(delta);
+				}
+			};
+			const unsub = transcriber.on((ev) => {
+				if (ev.kind === "partial" || ev.kind === "final") {
+					emit(ev.update.partial);
+				}
+			});
+			const abort = () => transcriber.dispose();
+			try {
+				signal?.addEventListener("abort", abort, { once: true });
+				const win = Math.max(1600, Math.round(args.sampleRate));
+				for (let off = 0; off < args.pcm.length; off += win) {
+					if (signal?.aborted) break;
+					transcriber.feed({
+						pcm: args.pcm.subarray(off, Math.min(off + win, args.pcm.length)),
+						sampleRate: args.sampleRate,
+						timestampMs: Math.round((off / args.sampleRate) * 1000),
+					});
+				}
+				const final = await transcriber.flush();
+				emit(final.partial);
+				if (signal?.aborted) {
+					throw signal.reason instanceof Error
+						? signal.reason
+						: new DOMException("Aborted", "AbortError");
+				}
+				return final.partial;
+			} finally {
+				unsub();
+				signal?.removeEventListener("abort", abort);
+				transcriber.dispose();
+			}
 		}
 		const backendBatch = this.backend as OmniVoiceBackend & {
 			transcribe?: (args: TranscriptionAudio) => Promise<string>;


### PR DESCRIPTION
Routes the local **TRANSCRIPTION** model handler onto the **same streaming pipe as chat text** (`onTextChunk → onStreamChunk → SSE → frontend`). When `useModel` injects `onStreamChunk` into the model params (inside a streaming reply turn), the handler drives the fused streaming-ASR session and forwards each running partial transcript as a delta.

## Changes
- `engine-bridge.transcribePcm`: new `onPartial` param → drives `createStreamingTranscriber` (feed in ~1s windows, subscribe to partial/final events, emit deltas).
- `engine.transcribePcm` + the `TRANSCRIPTION` handler thread `onPartial` through (handler reads `onStreamChunk` structurally).

## Graceful degradation
The current fused build's streaming-ASR decoder is a stub (`asr_stream_supported()==0`), so `createStreamingTranscriber` resolves the **fused batch** adapter and the final transcript is emitted once — still through the pipe. Token-by-token partials light up automatically when the native streaming-ASR decoder lands (symmetric with the ABI-v13 `describe_image_stream` for vision).

## Validation (Windows CPU)
Kokoro TTS → WAV → fused ASR transcribes accurately: *"The quick brown fox jumps over the lazy dog. Eliza is transcribing this sentence."* — delivered through `onStreamChunk`.

Part of "every model — including vision + transcription — through one streaming pipe" (#9105). Core `TranscriptionParams.onStreamChunk` landed in #9289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)