### PR TITLE
fix(ui): prune dead plugin widget slots

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -418,13 +418,22 @@ export interface PluginAppNavTab {
  * client-side type in `@elizaos/app-core/widgets` but lives here so plugins
  * can self-declare without depending on app-core.
  */
+export const PLUGIN_WIDGET_SLOTS = [
+	"chat-sidebar",
+	"character",
+	"nav-page",
+	"home",
+] as const;
+
+export type PluginWidgetSlot = (typeof PLUGIN_WIDGET_SLOTS)[number];
+
 export interface PluginWidgetDeclaration {
 	/** Unique within the owning plugin, e.g. "lifeops-overview". */
 	id: string;
 	/** Owning plugin ID. */
 	pluginId: string;
 	/** Where this widget renders. */
-	slot: "chat-sidebar" | "character" | "nav-page" | "home";
+	slot: PluginWidgetSlot;
 	/** Human-readable label. */
 	label: string;
 	/** Lucide icon name. */

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -96,6 +96,12 @@ ChatView today (see divergence D1).
 | `character` | yes, CharacterHubView | yes, 1 | active |
 | `nav-page` | no WidgetHost mount | no component widgets | active app-navigation contract |
 
+
+Retired slots pruned in #9448: `chat-inline`, `wallet`, `browser`,
+`heartbeats`, `settings`, `automations`. Browser and wallet status now render
+through active `chat-sidebar` / `home` declarations instead of their own dead
+slots.
+
 ---
 
 ## Interaction handler contract (single source of truth)

--- a/packages/ui/src/widgets/types.ts
+++ b/packages/ui/src/widgets/types.ts
@@ -5,13 +5,14 @@ import type { UiSpec } from "../config/ui-spec";
 import type { ActivityEvent } from "../hooks/useActivityEvents";
 
 /** Named injection points where plugin widgets can render. */
-export type WidgetSlot =
-  | "chat-sidebar"
-  | "character"
-  | "nav-page"
-  // Frontpage / Springboard home surface (#9143). Plugins opt a widget into the
-  // home screen by declaring this slot; the Home/Springboard surface mounts it.
-  | "home";
+export const WIDGET_SLOTS = [
+  "chat-sidebar",
+  "character",
+  "nav-page",
+  "home",
+] as const;
+
+export type WidgetSlot = (typeof WIDGET_SLOTS)[number];
 
 /**
  * Serializable widget metadata declared by a plugin.

--- a/packages/ui/src/widgets/visibility.ts
+++ b/packages/ui/src/widgets/visibility.ts
@@ -13,9 +13,8 @@ import type { WidgetSlot } from "./types";
  * `declaration.defaultEnabled`, so default flips don't reset users who never
  * touched the toggle.
  *
- * Home and other mounted widget slots use the same path once their plugin
- * registers them: they appear with `defaultEnabled` and the user can hide them
- * via the same panel.
+ * Active widget slots use the same path once their plugin registers them: they
+ * appear with `defaultEnabled` and the user can hide them via the same panel.
  */
 
 const CHAT_SIDEBAR_VISIBILITY_STORAGE_KEY = "eliza:chat-sidebar:visibility";

--- a/packages/ui/src/widgets/widget-coverage.test.ts
+++ b/packages/ui/src/widgets/widget-coverage.test.ts
@@ -7,7 +7,7 @@ import {
   resolveWidgetsForSlot,
   type WidgetPluginState,
 } from "./registry";
-import type { PluginWidgetDeclaration } from "./types";
+import { type PluginWidgetDeclaration, WIDGET_SLOTS } from "./types";
 
 // #9143 — per-plugin home-widget coverage gate.
 //
@@ -187,5 +187,26 @@ describe("chat-sidebar slot coverage gate (#9304)", () => {
       (id) => !rendered.has(id),
     );
     expect(missing).toEqual([]);
+  });
+});
+
+// #9448 — dead slot cleanup gate.
+describe("widget slot contract (#9448)", () => {
+  it("keeps the active widget slot list limited to supported surfaces", () => {
+    expect(WIDGET_SLOTS).toEqual([
+      "chat-sidebar",
+      "character",
+      "nav-page",
+      "home",
+    ]);
+  });
+
+  it("keeps bundled widget declarations off retired slots", () => {
+    const active = new Set<string>(WIDGET_SLOTS);
+    const retired = BUILTIN_WIDGET_DECLARATIONS.filter(
+      (decl) => !active.has(decl.slot),
+    ).map((decl) => `${decl.pluginId}/${decl.id}:${decl.slot}`);
+
+    expect(retired).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- prune retired plugin widget slots from the shared core/UI slot contract
- keep `nav-page` in the active slot list because current `develop` treats it as an app-navigation contract, even though it has no `WidgetHost` mount
- add #9448 regression coverage that locks the active slot list and fails if bundled widget declarations use retired slots

## Verification

- PASS `./node_modules/.bin/biome check packages/core/src/types/plugin.ts packages/ui/src/widgets/types.ts packages/ui/src/widgets/widget-coverage.test.ts packages/ui/src/widgets/visibility.ts packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md`
- PASS `bun run --cwd packages/ui test -- --run src/widgets/widget-coverage.test.ts` (1 file, 7 tests)
- PASS `git diff --check HEAD^ HEAD`

Relates to #9448
