### PR TITLE
feat(core): notification TTL (#9449) + lock type-safety ratchet (#9474)

### DIFF
--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -163,6 +163,33 @@ describe("NotificationService", () => {
 		expect(restarted.getUnreadCount()).toBe(1);
 	});
 
+	it("excludes a notification whose explicit expiresAt has passed", async () => {
+		await service.notify({ title: "Gone", expiresAt: Date.now() - 1000 });
+		await service.notify({ title: "Stays" });
+		const list = service.list();
+		expect(list).toHaveLength(1);
+		expect(list[0].title).toBe("Stays");
+		expect(service.getUnreadCount()).toBe(1);
+	});
+
+	it("retains a notification with a future expiresAt", async () => {
+		await service.notify({ title: "Later", expiresAt: Date.now() + 60_000 });
+		expect(service.list()).toHaveLength(1);
+		expect(service.getUnreadCount()).toBe(1);
+	});
+
+	it("drops expired notifications on rehydrate", async () => {
+		await service.notify({ title: "Expired", expiresAt: Date.now() - 1000 });
+		await service.notify({ title: "Alive" });
+		const restarted = (await NotificationService.start(
+			ctx.runtime,
+		)) as NotificationService;
+		const list = restarted.list();
+		expect(list).toHaveLength(1);
+		expect(list[0].title).toBe("Alive");
+		expect(restarted.getUnreadCount()).toBe(1);
+	});
+
 	it("hydrates empty when the cache adapter throws", async () => {
 		const throwing = createRuntime();
 		(

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -35,6 +35,14 @@ import { Service, ServiceType } from "../types/service.ts";
 /** Max notifications retained per agent in the inbox (oldest evicted). */
 const MAX_NOTIFICATIONS = 300;
 
+/**
+ * True once a notification's explicit `expiresAt` (unix ms) has passed. Only
+ * caller-set expiry is honored — there is no per-category default retention.
+ */
+function isExpired(n: AgentNotification, now: number): boolean {
+	return n.expiresAt != null && n.expiresAt <= now;
+}
+
 /** Minimal structural view of the event bus we publish onto. */
 interface EventBusLike {
 	emit: (event: {
@@ -92,8 +100,10 @@ export class NotificationService extends Service {
 				this.cacheKey,
 			);
 			if (Array.isArray(stored)) {
+				const now = Date.now();
 				this.notifications = stored
 					.filter((n) => n && typeof n.id === "string" && n.title)
+					.filter((n) => !isExpired(n, now))
 					.slice(-MAX_NOTIFICATIONS);
 			}
 		} catch (error) {
@@ -131,6 +141,7 @@ export class NotificationService extends Service {
 			data: input.data,
 			createdAt: Date.now(),
 			readAt: null,
+			expiresAt: input.expiresAt ?? undefined,
 			agentId: input.agentId ?? (this.runtime.agentId as UUID),
 		};
 
@@ -141,6 +152,9 @@ export class NotificationService extends Service {
 				(n) => n.groupKey !== notification.groupKey,
 			);
 		}
+		// Drop any entries whose explicit expiry has passed before appending.
+		const nowMs = Date.now();
+		this.notifications = this.notifications.filter((n) => !isExpired(n, nowMs));
 		this.notifications.push(notification);
 		if (this.notifications.length > MAX_NOTIFICATIONS) {
 			this.notifications = this.notifications.slice(-MAX_NOTIFICATIONS);
@@ -182,7 +196,10 @@ export class NotificationService extends Service {
 
 	/** List notifications, newest first, with optional filtering. */
 	list(query: NotificationQuery = {}): AgentNotification[] {
-		let result = [...this.notifications].reverse();
+		const now = Date.now();
+		let result = [...this.notifications]
+			.filter((n) => !isExpired(n, now))
+			.reverse();
 		if (query.unreadOnly) {
 			result = result.filter((n) => !n.readAt);
 		}
@@ -196,9 +213,10 @@ export class NotificationService extends Service {
 	}
 
 	getUnreadCount(): number {
+		const now = Date.now();
 		let count = 0;
 		for (const n of this.notifications) {
-			if (!n.readAt) count++;
+			if (!n.readAt && !isExpired(n, now)) count++;
 		}
 		return count;
 	}

--- a/packages/core/src/types/notification.ts
+++ b/packages/core/src/types/notification.ts
@@ -73,6 +73,12 @@ export interface AgentNotification {
 	createdAt: number;
 	/** Unix ms when the user marked it read; `null`/absent means unread. */
 	readAt?: number | null;
+	/**
+	 * Optional unix ms after which this notification self-destroys (dropped from
+	 * the inbox on the next hydrate/notify/read). Honored only when explicitly
+	 * set by the caller; `null`/absent means it never expires.
+	 */
+	expiresAt?: number | null;
 	/** Agent that produced it (multi-agent hosts). */
 	agentId?: UUID;
 }
@@ -91,6 +97,8 @@ export interface NotificationInput {
 	icon?: string;
 	groupKey?: string;
 	data?: Record<string, JsonValue>;
+	/** Optional unix ms self-destroy time; absent/null means it never expires. */
+	expiresAt?: number | null;
 	agentId?: UUID;
 }
 

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-24T22:34:08.580Z",
+  "updatedAt": "2026-06-24T23:28:54.294Z",
   "scope": {
     "trackedOnly": true,
     "globs": [
@@ -36,9 +36,9 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 488,
+    "asUnknownAs": 480,
     "asAny": 6,
     "tsSuppress": 2
   },
-  "filesScanned": 10013
+  "filesScanned": 9966
 }


### PR DESCRIPTION
Two core increments from the open-issue sweep, each verified locally.

**#9449 — explicit per-notification TTL (Pillar A inbox auto-destroy).** Adds optional `expiresAt?: number|null` (unix ms) to `AgentNotification` + `NotificationInput`; `NotificationService` prunes expired entries on hydrate, before notify-push, and filters them from `list()`/`getUnreadCount()`. Only caller-set expiry is honored — **no** per-category default retention (issue out-of-scope). +3 tests → **17/17** in `notification.test.ts`; core typecheck green.

**#9474 — tighten the type-safety ratchet.** The 3 `as unknown as` casts in message.ts's retrieval recorder were already removed on develop concurrently (rrfScore/matchedBy direct; stageScores kept a justified plain `as Record<string,number>` because `Partial<Record>` values are `number|undefined` under exactOptionalPropertyTypes). This locks that win by lowering the ratchet baseline `asUnknownAs` **488 → 480** (current actual count = 480). Ratchet passes 480/480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)