### PR TITLE
docs(skill): fix stale path + document gated deploy surface (#9477)

### DIFF
--- a/packages/skills/skills/build-monetized-app/references/sdk-flow.md
+++ b/packages/skills/skills/build-monetized-app/references/sdk-flow.md
@@ -127,6 +127,17 @@ until the response has a usable `load_balancer_url` / `publicUrl`, then verify
 bind to `$PORT` correctly — pull `cloud.getContainerLogs(container.id, tail?)` when
 the sidecar is available and surface the logs to the human.
 
+> **Two deploy surfaces — pick the right one.** `createContainer`
+> (`POST /api/v1/containers`) deploys a prebuilt image you push yourself, and is
+> the path this flow uses. The managed build pipeline,
+> `POST /api/v1/apps/:id/deploy` (`BUILDING → READY`), is a *separate* surface
+> and is **gated**: it returns `503 { code: "apps_deploy_disabled" }` unless
+> `APPS_DEPLOY_ENABLED=1` on the Worker, plus a production org allowlist (`403`)
+> — see `packages/cloud-api/v1/apps/[id]/deploy/route.ts`. The cloud-e2e specs
+> drive the `/apps/:id/deploy` route, so a from-scratch manual test that follows
+> *this* flow uses `/containers` and won't hit that gate; a tester exercising
+> `/apps/:id/deploy` directly must set the flag first.
+
 ## 4. Set markup
 
 ```ts

--- a/packages/skills/skills/build-monetized-app/references/survival-economics.md
+++ b/packages/skills/skills/build-monetized-app/references/survival-economics.md
@@ -17,7 +17,7 @@ The dashboard view at `https://www.elizacloud.ai/dashboard/earnings` shows the r
 
 ## Container billing
 
-Container hosting is pay-as-you-go, billed daily. The cron at `app/api/cron/container-billing/route.ts` runs once per day and, for each container:
+Container hosting is pay-as-you-go, billed daily. The cron at `packages/cloud-api/cron/container-billing/route.ts` runs once per day and, for each container:
 
 1. Computes the day's hosting cost (CPU + RAM at the tier's per-second rate)
 2. Pulls from `redeemable_earnings_ledger` first (if `pay_as_you_go_from_earnings = true`, which is the org default)


### PR DESCRIPTION
Surfaced while executing the manual monetized-app test of #9477.

## Manual test result (evidence)
I ran the deterministic monetized loop against the in-process mock stack:
```
bun --conditions=eliza-source --bun playwright test \
  monetized-full-loop.spec.ts:108 example-apps-showcase.spec.ts:192
→ 2 passed (22.0s)
```
Both exercise the **real** `appCreditsService.deductCredits` — `creatorMarkup > 0` computed from the monetization config, org debited by exactly the computed total, app-scoped earnings and creator redeemable each up by exactly the markup. (The `[Cache] DEL failed` lines are benign mock-Redis degradation; the circuit breaker opens and the run still passes.) Full evidence is posted on #9477.

Note: the research-flagged "de-tautologize `monetized-full-loop.spec.ts` step (f)" is **already done on develop** — it now calls the real `appCreditsService.deductCredits` (line 251) and asserts the computed markup flows through.

## This PR — doc accuracy gaps that block a clean from-scratch manual test
- `survival-economics.md` cited the Next.js-era `app/api/cron/container-billing/route.ts`; corrected to `packages/cloud-api/cron/container-billing/route.ts` (the path SKILL.md already uses).
- `sdk-flow.md` documented only `POST /api/v1/containers` and never mentioned that the managed `POST /api/v1/apps/:id/deploy` route is **gated** by `APPS_DEPLOY_ENABLED=1` (503 `apps_deploy_disabled`) + a prod org allowlist (403) — `packages/cloud-api/v1/apps/[id]/deploy/route.ts:34`. Added a note clarifying the two deploy surfaces.

## Remaining #9477 follow-up (tracked in the issue)
The only always-on real-revenue-path coverage is still the `POST /api/v1/messages` + `x-app-id` seam, which is exercised only by `creator-monetization-journey.spec.ts` behind `CEREBRAS_API_KEY`. A mock-LLM variant that drives that route deterministically would close the last gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)