### PR TITLE
fix(vision): resolve model weights under os.homedir() not HOME ?? "/tmp" (Windows)

### DIFF
--- a/plugins/plugin-vision/src/face-detector-ggml.ts
+++ b/plugins/plugin-vision/src/face-detector-ggml.ts
@@ -17,6 +17,7 @@
 // See `packages/native/plugins/face-cpp/AGENTS.md` for the port plan.
 
 import { promises as fs } from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "@elizaos/core";
@@ -82,7 +83,7 @@ function defaultLibraryPath(): string {
 function defaultModelDir(): string {
   const stateDir =
     process.env.ELIZA_STATE_DIR ??
-    path.join(process.env.HOME ?? "/tmp", ".eliza");
+    path.join(os.homedir(), ".eliza");
   return path.join(stateDir, "models", "face-cpp");
 }
 

--- a/plugins/plugin-vision/src/face-recognition-ggml.ts
+++ b/plugins/plugin-vision/src/face-recognition-ggml.ts
@@ -19,6 +19,7 @@
 // `face_embed_distance` / `face_embed_distance_l2`.
 
 import { promises as fs } from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "@elizaos/core";
@@ -64,7 +65,7 @@ function defaultLibraryPath(): string {
 function defaultModelDir(): string {
   const stateDir =
     process.env.ELIZA_STATE_DIR ??
-    path.join(process.env.HOME ?? "/tmp", ".eliza");
+    path.join(os.homedir(), ".eliza");
   return path.join(stateDir, "models", "face-cpp");
 }
 

--- a/plugins/plugin-vision/src/native/doctr-ffi.ts
+++ b/plugins/plugin-vision/src/native/doctr-ffi.ts
@@ -8,6 +8,7 @@
 // public function here throws a clear error. There is no silent fallback.
 
 import { promises as fs } from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "@elizaos/core";
@@ -43,7 +44,7 @@ function defaultLibraryPath(): string {
 export function defaultDetWeightsPath(): string {
   const stateDir =
     process.env.ELIZA_STATE_DIR ??
-    path.join(process.env.HOME ?? "/tmp", ".eliza");
+    path.join(os.homedir(), ".eliza");
   return (
     process.env.ELIZA_DOCTR_DET_GGUF ??
     path.join(stateDir, "models", "vision", "doctr-det.gguf")
@@ -53,7 +54,7 @@ export function defaultDetWeightsPath(): string {
 export function defaultRecWeightsPath(): string {
   const stateDir =
     process.env.ELIZA_STATE_DIR ??
-    path.join(process.env.HOME ?? "/tmp", ".eliza");
+    path.join(os.homedir(), ".eliza");
   return (
     process.env.ELIZA_DOCTR_REC_GGUF ??
     path.join(stateDir, "models", "vision", "doctr-rec.gguf")


### PR DESCRIPTION
## Problem

Three plugin-vision native bindings compute the Eliza state dir (where GGUF model weights live) as:

```ts
const stateDir =
  process.env.ELIZA_STATE_DIR ??
  path.join(process.env.HOME ?? "/tmp", ".eliza");
```

`process.env.HOME` is normally **unset on Windows** (the home var is `USERPROFILE`). When `ELIZA_STATE_DIR` is also unset, the fallback becomes `path.join("/tmp", ".eliza")`, which `path.win32` resolves against the current drive as `C:\tmp\.eliza` — not the real per-user state dir. The doctr DET/REC, BlazeFace detector, and face-embedding GGUF weights are then looked up at the wrong path, so OCR / face detection / face recognition report their weights missing even when correctly installed under the user's home dir.

The sibling binding `plugin-vision/src/native/yolo-ffi.ts:42` already does the right thing:

```ts
process.env.ELIZA_STATE_DIR ?? path.join(os.homedir(), ".eliza");
```

The `os.homedir()` migration simply never reached the doctr / face bindings.

## Fix

Replace `path.join(process.env.HOME ?? "/tmp", ".eliza")` with `path.join(os.homedir(), ".eliza")` in all three files (4 sites), and add the `import * as os from "node:os";` each was missing — matching `yolo-ffi.ts`. `os.homedir()` is correct on every platform (USERPROFILE on Windows, getpwuid on POSIX) and removes the bogus `/tmp` fallback.

- `plugins/plugin-vision/src/native/doctr-ffi.ts` (2 sites)
- `plugins/plugin-vision/src/face-detector-ggml.ts` (1 site)
- `plugins/plugin-vision/src/face-recognition-ggml.ts` (1 site)

No behavior change on Linux/macOS (where `HOME` is set, `os.homedir()` returns the same path); on Windows the weights now resolve under `%USERPROFILE%\.eliza` instead of `C:\tmp\.eliza`.

Follow-on to the Windows prod-source audit (#9372 / #9374).