### PR TITLE
fix(app-core): open EDITOR via shell on Windows so plugins-cli editor launch works

### DIFF
--- a/packages/app-core/src/cli/plugins-cli.ts
+++ b/packages/app-core/src/cli/plugins-cli.ts
@@ -1170,6 +1170,11 @@ export function registerPluginsCli(program: Command): void {
         try {
           const result = spawnSync(editorCmd, [...editorArgs, targetDir], {
             stdio: "inherit",
+            // Editors are usually `.cmd`/`.bat` shims on Windows (e.g. `code`),
+            // which Node cannot spawn without a shell (ENOENT) — the editor would
+            // silently never open. Route through the shell on win32 so EDITOR
+            // actually launches. EDITOR is local, user-controlled config.
+            shell: process.platform === "win32",
           });
           if (result.error) throw result.error;
         } catch {


### PR DESCRIPTION
## Problem

`elizaos`/app-core plugins-cli opens the scaffolded plugin dir in the user's editor with:

```ts
const result = spawnSync(editorCmd, [...editorArgs, targetDir], {
  stdio: "inherit",
});
```

`editorCmd` defaults to `code` (or `$EDITOR`). On Windows the launcher is `code.cmd` (and most editor CLIs are `.cmd`/`.bat` shims). Node's `spawnSync` only auto-appends `.exe`, not `.cmd`, so without a shell it fails with `ENOENT`. The call is wrapped in a `try/catch` that deliberately swallows editor-launch failures, so the symptom on Windows is the editor **silently never opening** — no error, no editor.

The sibling launcher `register.dashboard.ts` already uses `shell: process.platform === "win32"` for exactly this reason.

## Fix

Add `shell: process.platform === "win32"` to the editor `spawnSync` options. On Windows the editor command is routed through the shell so the `.cmd` shim resolves and the editor actually launches; on POSIX behavior is unchanged (`shell` stays `false`). `EDITOR` is local, user-controlled configuration — not remote input — so the conditional shell carries no injection exposure (same posture as the existing dashboard launcher).

Follow-on to the Windows prod-source audit (#9372 / #9374).