### PR TITLE
test: load-bearing health_checkin scenario (#8795) + benchmark smoke-lane gate (#9475)

### DIFF
--- a/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
+++ b/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
@@ -3784,3 +3784,50 @@ def test_app_eval_score_normalizes_ten_point_summary(tmp_path: Path) -> None:
     assert score.score == 0.75
     assert score.unit == "ratio"
     assert score.metrics["overall_score"] == 7.5
+
+
+# Benchmarks with no keyless (no-API-key) smoke route, with the reason they
+# cannot run in the always-on no-key CI lane. Each MUST be deliberately listed
+# here, so a newly added benchmark either is keyless-smoke-runnable or is an
+# explicit, justified manual-only entry — the de-larp guard for #9475.
+MANUAL_ONLY_BENCHMARKS = frozenset(
+    {
+        # Requires extra.traj_set: a directory of pre-recorded trajectory JSON
+        # files to replay; there is no synthetic keyless input, so it cannot run
+        # in the no-key smoke lane.
+        "trajectory_replay",
+    }
+)
+
+
+def test_every_registered_benchmark_has_smoke_lane_or_manual_only_marker(
+    tmp_path: Path,
+) -> None:
+    """Every registered benchmark must build a keyless (mock) smoke command, or
+    be an explicit, justified MANUAL_ONLY_BENCHMARKS entry. This keeps the suite
+    self-policing: a new benchmark can't silently inflate the registry without a
+    no-key smoke route or a deliberate manual-only marker (#9475)."""
+    registry = get_benchmark_registry(_workspace_root())
+    registry_ids = {entry.id for entry in registry}
+
+    # No stale markers: every manual-only id must still exist in the registry.
+    assert MANUAL_ONLY_BENCHMARKS <= registry_ids, (
+        "stale MANUAL_ONLY_BENCHMARKS entries: "
+        f"{sorted(MANUAL_ONLY_BENCHMARKS - registry_ids)}"
+    )
+
+    mock_model = ModelSpec(provider="mock", model="mock")
+    smoke_extra = {"mock": True, "max_tasks": 1, "iterations": 1}
+
+    for entry in registry:
+        if entry.id in MANUAL_ONLY_BENCHMARKS:
+            # Confirm it genuinely has no keyless smoke route (else drop the marker).
+            with pytest.raises(Exception):
+                entry.build_command(tmp_path / entry.id, mock_model, smoke_extra)
+            continue
+        command = entry.build_command(tmp_path / entry.id, mock_model, smoke_extra)
+        assert isinstance(command, list) and command, (
+            f"benchmark {entry.id!r} produced no keyless smoke command; "
+            "give it a no-key smoke route or add it to MANUAL_ONLY_BENCHMARKS"
+        )
+        assert isinstance(command[0], str)

--- a/plugins/plugin-health/test/scenarios/health-checkin-sleep-recovery.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/health-checkin-sleep-recovery.scenario.ts
@@ -15,9 +15,24 @@ export default scenario({
       kind: "message",
       name: "health check-in",
       text: "Check in on my sleep and recovery today. If anything looks off, ask one focused follow-up instead of giving medical advice.",
-      plannerIncludesAny: ["OWNER_HEALTH", "health", "sleep"],
-      responseIncludesAny: ["sleep", "recovery", "check"],
-      plannerExcludes: ["OWNER_SCREENTIME"],
+    },
+  ],
+  // Load-bearing assertion. The previous turn-level
+  // plannerIncludesAny/responseIncludesAny/plannerExcludes are NOT registered
+  // final-check handlers (packages/scenario-runner/src/final-checks/index.ts),
+  // so a regression in the optimized `health_checkin` prompt path would not fail
+  // the run. `selectedActionArguments` IS consumed by the executor: it requires
+  // OWNER_HEALTH to be selected AND a resolved subaction token to appear in the
+  // captured action options. For an NL health request with no explicit subaction,
+  // OWNER_HEALTH's runner (createHealthActionRunner) calls resolveHealthPlanWithLlm
+  // — the sole caller of resolveOptimizedPromptForRuntime(..., "health_checkin", ...)
+  // — so selecting OWNER_HEALTH with a real subaction proves that path ran.
+  finalChecks: [
+    {
+      type: "selectedActionArguments",
+      name: "health request routes to OWNER_HEALTH (exercises health_checkin prompt path)",
+      actionName: "OWNER_HEALTH",
+      includesAny: ["today", "trend", "by_metric", "status"],
     },
   ],
 });


### PR DESCRIPTION
Two test-only increments from the open-issue sweep.

**#8795** — the only `health_checkin` capability scenario asserted only turn-level `plannerIncludesAny`/`responseIncludesAny`/`plannerExcludes`, which are **not** registered final-check handlers, so a regression in the optimized prompt path wouldn't fail the run. Replaced with a real `finalChecks:[selectedActionArguments OWNER_HEALTH …]` — load-bearing because an NL health request routes through `OWNER_HEALTH → resolveHealthPlanWithLlm`, the sole caller of the `health_checkin` optimized prompt. Verified: scenario parses via `scenario-runner list`.

**#9475** — closes the open de-larp checklist item. A parametrized test over `get_benchmark_registry()` requires each of the 43 benchmarks to build a keyless (mock) smoke command, or to be an explicit `MANUAL_ONLY_BENCHMARKS` entry (empirically only `trajectory_replay`, which needs a `traj_set` input dir). The suite is now self-policing — a new benchmark can't silently inflate the registry without a no-key smoke route. Verified: 128 pass (was 127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)