### PR TITLE
chore(lint): enforce noExplicitAny=error for verified-clean leaf plugins (#9474 Phase 1)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -140,6 +140,24 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "plugins/plugin-task-coordinator/src/**/*.ts",
+        "plugins/plugin-calendar/src/**/*.ts",
+        "plugins/plugin-scheduling/src/**/*.ts",
+        "plugins/plugin-blocker/src/**/*.ts",
+        "plugins/plugin-relationships/src/**/*.ts",
+        "plugins/plugin-health/src/**/*.ts",
+        "plugins/plugin-sql/src/**/*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "error"
+          }
+        }
+      }
     }
   ],
   "formatter": {


### PR DESCRIPTION
Part of #9474 (enforce strict TypeScript / eliminate `any`).

## What

Adds a root `biome.json` override that escalates `suspicious.noExplicitAny` from the global `warn` to **`error`** for seven leaf plugins whose `src/` is already 100% free of explicit `any`:

- `plugins/plugin-task-coordinator/src`
- `plugins/plugin-calendar/src`
- `plugins/plugin-scheduling/src`
- `plugins/plugin-blocker/src`
- `plugins/plugin-relationships/src`
- `plugins/plugin-health/src`
- `plugins/plugin-sql/src`

## Why this is safe (no-op today, guard for tomorrow)

Each of these packages has **zero** `noExplicitAny` occurrences in `src/` and **no package-local `biome.json`** (so the root override governs them). Flipping the rule to `error` is therefore a no-op against the current tree and only **prevents new `any` from regressing in** — exactly the Phase-1 ratchet #9474 asks for.

Verified locally on this machine:

```
bunx @biomejs/biome lint --only=suspicious/noExplicitAny plugins/plugin-*/src  -> 0 hits each
```

And diagnostic-neutrality of the override (same workspace lint, with vs without the change):

```
WITH override:    11 lint diagnostics, 0 noExplicitAny
WITHOUT override: 11 lint diagnostics, 0 noExplicitAny   (identical)
```

(The 11 pre-existing diagnostics are unrelated `noUnusedImports` / `noNonNullAssertion` baseline items in those packages — untouched by this change.)

Deliberately **excluded** `plugin-discord` (flat layout + its own `biome.json`) and `plugin-discord-local` (has a package-local `biome.json`, so a root override would not apply); those need a per-package config change instead and are out of scope for this PR.