### PR TITLE
fix(vision): parse Windows command output with CRLF-tolerant line split

### DIFF
--- a/plugins/plugin-vision/src/audio-capture.ts
+++ b/plugins/plugin-vision/src/audio-capture.ts
@@ -287,7 +287,7 @@ export class AudioCaptureService {
           const { stdout } = await execAsync(
             "ffmpeg -list_devices true -f dshow -i dummy 2>&1",
           );
-          const lines = stdout.split("\n");
+          const lines = stdout.split(/\r?\n/u);
           let isAudioSection = false;
 
           for (const line of lines) {

--- a/plugins/plugin-vision/src/workers/screen-capture-worker.ts
+++ b/plugins/plugin-vision/src/workers/screen-capture-worker.ts
@@ -147,7 +147,7 @@ class ScreenCaptureWorker {
           "wmic path Win32_DesktopMonitor get DeviceID,ScreenWidth,ScreenHeight /format:csv",
         );
         const displays: DisplayInfo[] = [];
-        const lines = stdout.trim().split("\n").slice(2); // Skip headers
+        const lines = stdout.trim().split(/\r?\n/u).slice(2); // Skip headers
 
         lines.forEach((line, index) => {
           const parts = line.split(",");


### PR DESCRIPTION
## Problem

Two Windows device-enumeration paths in plugin-vision parse the stdout of Windows CLI tools (`wmic`, `ffmpeg -f dshow`) with `stdout.split("\n")`. Those tools emit **CRLF** (`\r\n`), so every parsed line carries a trailing `\r`.

Today this happens to be tolerated by luck — `parseInt("1920\r", 10)` stops at the `\r`, `line.includes(...)` and the `/"([^"]+)"/` device-name regex don't span the trailing `\r` — so it isn't currently broken. But it's fragile: any field that ends up last in the row (e.g. if `wmic`'s CSV column order shifts) would silently carry a `\r`, and any future exact-match/compare on a parsed field would fail on Windows only.

## Fix

Split those two Windows command outputs on `/\r?\n/u` instead of `"\n"`, so the `\r` is consumed with the line break and every field is clean:

- `plugins/plugin-vision/src/workers/screen-capture-worker.ts` — win32 `wmic Win32_DesktopMonitor` CSV parse.
- `plugins/plugin-vision/src/audio-capture.ts` — win32 `ffmpeg dshow` device-list parse.

`/\r?\n/u` is identical to `"\n"` on LF-only input (the `\r?` matches nothing), so the macOS/Linux branches in these files are untouched and there is no behavior change off Windows. Pure robustness hardening of the Windows paths.

Follow-on to the Windows prod-source audit (#9372 / #9374).