### PR TITLE
fix(ui): type injected companion globals

### DIFF
--- a/packages/ui/src/companion/desktop-bar/platform/electrobun-tray.ts
+++ b/packages/ui/src/companion/desktop-bar/platform/electrobun-tray.ts
@@ -19,15 +19,17 @@ interface ElectrobunGlobal {
   tray?: ElectrobunTrayApi;
 }
 
-interface WindowWithElectrobun {
-  electrobun?: ElectrobunGlobal;
+declare global {
+  interface Window {
+    electrobun?: ElectrobunGlobal;
+  }
 }
 
 function getElectrobun(): ElectrobunGlobal | null {
   if (typeof window === "undefined") {
     return null;
   }
-  const candidate = (window as unknown as WindowWithElectrobun).electrobun;
+  const candidate = window.electrobun;
   return candidate ?? null;
 }
 

--- a/packages/ui/src/companion/desktop-bar/platform/index.ts
+++ b/packages/ui/src/companion/desktop-bar/platform/index.ts
@@ -5,15 +5,11 @@ import {
 } from "./electrobun-tray";
 import { registerTrayIcon as webRegister } from "./web-fallback";
 
-interface WindowWithElectrobun {
-  electrobun?: unknown;
-}
-
 function hasElectrobunRuntime(): boolean {
   if (typeof window === "undefined") {
     return false;
   }
-  return Boolean((window as unknown as WindowWithElectrobun).electrobun);
+  return Boolean(window.electrobun);
 }
 
 export function registerTrayIcon(

--- a/packages/ui/src/perf/PerfOverlay.tsx
+++ b/packages/ui/src/perf/PerfOverlay.tsx
@@ -4,13 +4,18 @@ import {
   type FrameBudgetSummary,
 } from "../hooks/frame-budget";
 
-const PERF_FLAG = "__ELIZA_PERF_HUD__";
 /** Dispatch on `window` after flipping `window.__ELIZA_PERF_HUD__` to toggle live. */
 export const PERF_TOGGLE_EVENT = "eliza:perf-toggle";
 
+declare global {
+  interface Window {
+    __ELIZA_PERF_HUD__?: boolean;
+  }
+}
+
 function perfEnabled(): boolean {
   if (typeof window === "undefined") return false;
-  return (window as unknown as Record<string, unknown>)[PERF_FLAG] === true;
+  return window.__ELIZA_PERF_HUD__ === true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Declare the UI perf HUD opt-in as `Window.__ELIZA_PERF_HUD__` and read it directly in `PerfOverlay`.
- Declare the companion tray bridge as `Window.electrobun` and read it directly in the desktop-bar platform selector.
- Remove three production `as unknown as` casts without changing runtime behavior.

## Verification
- `git fetch origin` and `git rebase origin/develop` onto `d705346b2d`
- `bun install`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test -- src/perf/PerfOverlay.test.tsx` - 1 file, 2 tests passed
- `bunx @biomejs/biome check packages/ui/src/perf/PerfOverlay.tsx packages/ui/src/companion/desktop-bar/platform/index.ts packages/ui/src/companion/desktop-bar/platform/electrobun-tray.ts`
- `bun run audit:type-safety-ratchet` - `as unknown as: 465 / 468`, `as any: 6 / 6`, `@ts-expect-error / @ts-ignore: 2 / 2`
- `git diff --check origin/develop...HEAD`

`bun run verify` was attempted on this rebased branch and is currently blocked by unrelated `@elizaos/ui#lint` errors already present on current `develop`: formatter/import-order errors in `src/components/chat/widgets/finances-alerts.stories.tsx`, `src/components/chat/widgets/home-widget-card.stories.tsx`, `src/components/chat/widgets/relationships-attention.stories.tsx`, and `src/components/pages/Springboard.stories.tsx`.

N/A: screenshots, video, and real-LLM trajectories; this is a type-only cleanup for injected UI globals.
