### PR TITLE
feat: voice echo-canceller (#9455) + browser error contract (#9476) + computeruse token telemetry (#9105)

### DIFF
--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertBrowserWorkspaceConnectorSecretsNotExported,
+  assertBrowserWorkspaceUrl,
+  createBrowserWorkspaceCommandTargetError,
+  createBrowserWorkspaceDesktopOnlyMessage,
+  createBrowserWorkspaceJsdomScriptExecutionError,
+  createBrowserWorkspaceNotFoundError,
+} from "../browser-workspace-helpers.ts";
+import {
+  type BrowserWorkspaceErrorCode,
+  classifyBrowserWorkspaceErrorCode,
+  createBrowserWorkspaceError,
+  isBrowserWorkspaceError,
+  tagBrowserWorkspaceError,
+} from "../browser-workspace-errors.ts";
+
+/** Capture the Error thrown by a thunk. */
+function thrown(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the thunk to throw");
+}
+
+describe("classifyBrowserWorkspaceErrorCode", () => {
+  const cases: Array<[BrowserWorkspaceErrorCode, unknown]> = [
+    ["invalid_url", thrown(() => assertBrowserWorkspaceUrl("not a url"))],
+    ["invalid_url", thrown(() => assertBrowserWorkspaceUrl("ftp://x.test"))],
+    ["tab_not_found", createBrowserWorkspaceNotFoundError("tab-1")],
+    ["target_missing", createBrowserWorkspaceCommandTargetError("navigate")],
+    [
+      "desktop_only",
+      new Error(createBrowserWorkspaceDesktopOnlyMessage("navigate")),
+    ],
+    [
+      "script_forbidden",
+      createBrowserWorkspaceJsdomScriptExecutionError("eval"),
+    ],
+    [
+      "script_forbidden",
+      createBrowserWorkspaceJsdomScriptExecutionError("wait"),
+    ],
+    [
+      "connector_secret_export_forbidden",
+      thrown(() =>
+        assertBrowserWorkspaceConnectorSecretsNotExported(
+          "persist:connector-gmail",
+          "export-cookies",
+        ),
+      ),
+    ],
+    [
+      "unknown_element_ref",
+      new Error(
+        "Unknown browser snapshot element ref e7. Run snapshot or inspect again before reusing element refs.",
+      ),
+    ],
+    ["timeout", new Error("navigation timed out after 30000ms")],
+    ["command_failed", new Error("something else entirely")],
+    ["command_failed", "a bare string, not an Error"],
+  ];
+
+  for (const [code, error] of cases) {
+    it(`maps to ${code}`, () => {
+      expect(classifyBrowserWorkspaceErrorCode(error)).toBe(code);
+    });
+  }
+});
+
+describe("tagBrowserWorkspaceError", () => {
+  it("annotates an existing Error in place, preserving message + identity", () => {
+    const original = createBrowserWorkspaceNotFoundError("tab-9");
+    const tagged = tagBrowserWorkspaceError(original, "navigate");
+    expect(tagged).toBe(original); // same object
+    expect(tagged.message).toBe(original.message); // message preserved
+    expect(tagged.browserWorkspaceErrorCode).toBe("tab_not_found");
+    expect(tagged.operation).toBe("navigate");
+    expect(isBrowserWorkspaceError(tagged)).toBe(true);
+  });
+
+  it("is idempotent (keeps the first code/operation)", () => {
+    const original = new Error("browser workspace rejected invalid URL: x");
+    const once = tagBrowserWorkspaceError(original, "open");
+    const twice = tagBrowserWorkspaceError(once, "navigate");
+    expect(twice).toBe(once);
+    expect(twice.browserWorkspaceErrorCode).toBe("invalid_url");
+    expect(twice.operation).toBe("open");
+  });
+
+  it("wraps a non-Error value in a BrowserWorkspaceError", () => {
+    const tagged = tagBrowserWorkspaceError("plain failure", "click");
+    expect(isBrowserWorkspaceError(tagged)).toBe(true);
+    expect(tagged.message).toBe("plain failure");
+    expect(tagged.browserWorkspaceErrorCode).toBe("command_failed");
+    expect(tagged.operation).toBe("click");
+  });
+
+  it("createBrowserWorkspaceError builds a typed error", () => {
+    const e = createBrowserWorkspaceError(
+      "timeout",
+      "wait",
+      "timed out",
+      "underlying",
+    );
+    expect(isBrowserWorkspaceError(e)).toBe(true);
+    expect(e.browserWorkspaceErrorCode).toBe("timeout");
+    expect(e.operation).toBe("wait");
+    expect(e.details).toBe("underlying");
+  });
+});

--- a/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
@@ -1,0 +1,149 @@
+/**
+ * Structured browser-workspace error contract (issue #9476).
+ *
+ * The workspace command path (`executeBrowserWorkspaceCommand` and the helpers
+ * in `browser-workspace-helpers.ts`) throws bare `new Error(...)` for many
+ * distinct failure modes — an invalid URL, a missing tab, a desktop-only
+ * subaction, a forbidden user script, a connector secret-export attempt — so
+ * callers today must regex the human-readable message to react. This mirrors the
+ * CUA `screenshot-errors.ts` contract: a machine-readable
+ * {@link BrowserWorkspaceErrorCode} added **additively** via
+ * {@link tagBrowserWorkspaceError} (annotates the existing Error in place,
+ * preserving its identity/message) plus a pure {@link classifyBrowserWorkspaceErrorCode}
+ * that maps the well-known thrown-message shapes to a code — one testable source
+ * of truth. This increment is the contract + classifier only; wiring
+ * `tagBrowserWorkspaceError` into the `executeBrowserWorkspaceCommand` catch
+ * boundary is a follow-up.
+ */
+
+export type BrowserWorkspaceErrorCode =
+  /** URL rejected: not a valid URL, or not http/https. */
+  | "invalid_url"
+  /** The referenced tab id does not exist (404). */
+  | "tab_not_found"
+  /** The subaction needs a current/target tab and none was available. */
+  | "target_missing"
+  /** The subaction is only available in the desktop app / bridge. */
+  | "desktop_only"
+  /** Arbitrary user/JSDOM script execution is disabled (GHSA-mhhr-9ph9-64j7). */
+  | "script_forbidden"
+  /** A connector session tried to export raw cookies/tokens/storage/state. */
+  | "connector_secret_export_forbidden"
+  /** A snapshot element ref is stale/unknown (re-snapshot needed). */
+  | "unknown_element_ref"
+  /** The operation exceeded its timeout. */
+  | "timeout"
+  /** Any other workspace command failure. */
+  | "command_failed";
+
+/** An `Error` carrying a machine-readable {@link BrowserWorkspaceErrorCode}. */
+export interface BrowserWorkspaceError extends Error {
+  readonly browserWorkspaceErrorCode: BrowserWorkspaceErrorCode;
+  /** The workspace operation that failed (e.g. `navigate`, `eval`). */
+  readonly operation: string;
+  /** Underlying message, when this wraps a lower-level failure. */
+  readonly details?: string;
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isBrowserWorkspaceError(
+  value: unknown,
+): value is BrowserWorkspaceError {
+  return (
+    value instanceof Error &&
+    "browserWorkspaceErrorCode" in value &&
+    typeof (value as { browserWorkspaceErrorCode?: unknown })
+      .browserWorkspaceErrorCode === "string"
+  );
+}
+
+export function createBrowserWorkspaceError(
+  code: BrowserWorkspaceErrorCode,
+  operation: string,
+  message: string,
+  details?: string,
+): BrowserWorkspaceError {
+  const error = new Error(message) as Mutable<BrowserWorkspaceError>;
+  error.name = "BrowserWorkspaceError";
+  error.browserWorkspaceErrorCode = code;
+  error.operation = operation;
+  if (details !== undefined) error.details = details;
+  return error;
+}
+
+/**
+ * Map any thrown value to a {@link BrowserWorkspaceErrorCode} from the
+ * well-known message shapes the workspace helpers throw. Already-tagged errors
+ * return their own code. Pure — the single source of truth for the mapping.
+ */
+export function classifyBrowserWorkspaceErrorCode(
+  error: unknown,
+): BrowserWorkspaceErrorCode {
+  if (isBrowserWorkspaceError(error)) return error.browserWorkspaceErrorCode;
+  const message = toMessage(error);
+
+  if (/rejected invalid URL|only supports http\/https/i.test(message)) {
+    return "invalid_url";
+  }
+  if (/\(404\)|Tab .+ was not found/i.test(message)) {
+    return "tab_not_found";
+  }
+  if (/requires a current tab/i.test(message)) {
+    return "target_missing";
+  }
+  if (
+    /only available in the desktop app|desktop bridge is unavailable/i.test(
+      message,
+    )
+  ) {
+    return "desktop_only";
+  }
+  if (
+    /arbitrary (script execution|user script) is disabled|not supported on the web backend/i.test(
+      message,
+    )
+  ) {
+    return "script_forbidden";
+  }
+  if (
+    /do not allow raw cookie, token, storage, or state export/i.test(message)
+  ) {
+    return "connector_secret_export_forbidden";
+  }
+  if (/Unknown browser snapshot element ref/i.test(message)) {
+    return "unknown_element_ref";
+  }
+  if (/timed out|timeout|\bETIMEDOUT\b/i.test(message)) {
+    return "timeout";
+  }
+  return "command_failed";
+}
+
+/**
+ * Tag an existing thrown value with its {@link BrowserWorkspaceErrorCode} +
+ * operation, **in place and additively** (preserves the original Error identity
+ * and message). Idempotent: re-tagging keeps the first code. A non-Error value
+ * is wrapped in a fresh `BrowserWorkspaceError`.
+ */
+export function tagBrowserWorkspaceError(
+  error: unknown,
+  operation: string,
+): BrowserWorkspaceError {
+  if (isBrowserWorkspaceError(error)) return error; // idempotent
+  if (error instanceof Error) {
+    const tagged = error as Mutable<BrowserWorkspaceError>;
+    tagged.browserWorkspaceErrorCode = classifyBrowserWorkspaceErrorCode(error);
+    tagged.operation = operation;
+    return tagged;
+  }
+  return createBrowserWorkspaceError(
+    classifyBrowserWorkspaceErrorCode(error),
+    operation,
+    toMessage(error),
+  );
+}

--- a/plugins/plugin-browser/src/workspace/index.ts
+++ b/plugins/plugin-browser/src/workspace/index.ts
@@ -23,4 +23,5 @@
  */
 
 export * from "./browser-capture.js";
+export * from "./browser-workspace-errors.js";
 export * from "./browser-workspace.js";

--- a/plugins/plugin-computeruse/src/__tests__/use-computer-agent.tokens.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/use-computer-agent.tokens.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #9105 — per-run model-call telemetry.
+ *
+ * The default `LocalGrounderLoop` exposes `getStats()` (delegating to the
+ * wrapped `Brain`); `runComputerUseAgentLoop` reads it in `finalize()`,
+ * attaches `report.modelStats`, and logs `evt:"computeruse.agent.tokens"`.
+ * A loop that does not implement the optional `getStats()` leaves
+ * `report.modelStats` undefined.
+ *
+ * Synthetic-deps style mirrors `computer-use-agent.test.ts` (fake Brain via
+ * `invokeModel`, fake `captureAll`, fake service).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type ComputerUseAgentReport,
+  runComputerUseAgentLoop,
+} from "../actions/use-computer-agent.js";
+import type {
+  AgentLoop,
+  AgentStepInput,
+  PredictClickInput,
+} from "../actor/agent-loop.js";
+import { Brain } from "../actor/brain.js";
+import type { CascadeResult, GroundingResult } from "../actor/types.js";
+import type { DisplayCapture } from "../platform/capture.js";
+import type { Scene } from "../scene/scene-types.js";
+import type { ComputerUseService } from "../services/computer-use-service.js";
+import type { DisplayDescriptor } from "../types.js";
+
+function display(): DisplayDescriptor {
+  return {
+    id: 0,
+    bounds: [0, 0, 1920, 1080],
+    scaleFactor: 1,
+    primary: true,
+    name: "fake",
+  };
+}
+
+function syntheticScene(): Scene {
+  return {
+    timestamp: Date.now(),
+    displays: [display()],
+    focused_window: null,
+    apps: [],
+    ocr: [],
+    ax: [],
+    vlm_scene: null,
+    vlm_elements: null,
+  };
+}
+
+function fakeService(): ComputerUseService {
+  return {
+    getCurrentScene: () => syntheticScene(),
+    refreshScene: async () => syntheticScene(),
+    getDisplays: () => [display()],
+    setSceneVlmAnnotations: () => {},
+  } as unknown as ComputerUseService;
+}
+
+async function captureAll(): Promise<DisplayCapture[]> {
+  return [
+    {
+      display: { ...display(), id: 0 },
+      frame: Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        Buffer.alloc(64, 0),
+      ]),
+    },
+  ];
+}
+
+function finishBrain(): Brain {
+  return new Brain(null, {
+    invokeModel: async () =>
+      JSON.stringify({
+        scene_summary: "done",
+        target_display_id: 0,
+        roi: [],
+        proposed_action: { kind: "finish", rationale: "ok" },
+      }),
+  });
+}
+
+describe("runComputerUseAgentLoop — model-call telemetry (#9105)", () => {
+  it("attaches modelStats from the default loop's Brain", async () => {
+    const report: ComputerUseAgentReport = await runComputerUseAgentLoop(
+      null,
+      { goal: "g" },
+      fakeService(),
+      { brain: finishBrain(), captureAll },
+    );
+
+    expect(report.reason).toBe("finish");
+    // First (and only) model call cannot be a cache hit.
+    expect(report.modelStats).toEqual({ invocations: 1, cacheHits: 0 });
+  });
+
+  it("counts one model invocation per planning step", async () => {
+    const report = await runComputerUseAgentLoop(
+      null,
+      { goal: "g", maxSteps: 3 },
+      fakeService(),
+      {
+        // Always `wait` → never finishes → runs the full maxSteps budget.
+        brain: new Brain(null, {
+          invokeModel: async () =>
+            JSON.stringify({
+              scene_summary: "thinking",
+              target_display_id: 0,
+              roi: [],
+              proposed_action: { kind: "wait", rationale: "loading" },
+            }),
+        }),
+        captureAll,
+      },
+    );
+
+    expect(report.reason).toBe("max_steps");
+    expect(report.steps.length).toBe(3);
+    // One invocation per step; the synthetic frame is not a decodable PNG so
+    // the dHash cache never engages.
+    expect(report.modelStats?.invocations).toBe(3);
+    expect(report.modelStats?.cacheHits).toBe(0);
+  });
+
+  it("leaves modelStats undefined when the loop does not implement getStats()", async () => {
+    const statelessLoop: AgentLoop = {
+      name: "test/stateless",
+      predictStep: async (_input: AgentStepInput): Promise<CascadeResult> => ({
+        scene_summary: "stateless",
+        rois: [],
+        proposed: { kind: "finish", rationale: "ok", displayId: 0 },
+      }),
+      predictClick: async (
+        _input: PredictClickInput,
+      ): Promise<GroundingResult | null> => null,
+    };
+
+    const report = await runComputerUseAgentLoop(
+      null,
+      { goal: "g" },
+      fakeService(),
+      { loop: statelessLoop, captureAll },
+    );
+
+    expect(report.reason).toBe("finish");
+    expect(report.modelStats).toBeUndefined();
+  });
+});

--- a/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
@@ -50,6 +50,7 @@ import {
 import {
   AGENT_LOOP_SETTING,
   type AgentLoop,
+  type AgentLoopStats,
   createAgentLoop,
   DEFAULT_AGENT_LOOP_MODEL,
 } from "../actor/agent-loop.js";
@@ -144,6 +145,8 @@ export interface ComputerUseAgentReport {
   error?: string;
   /** Per-step transcript recorded by the trajectory middleware (#9170 M11). */
   trajectory?: TrajectoryEntry[];
+  /** Per-run model-call accounting, when the loop reports it (#9105). */
+  modelStats?: AgentLoopStats;
 }
 
 export function formatComputerUseAgentProgress(
@@ -240,6 +243,21 @@ export async function runComputerUseAgentLoop(
 
   const finalize = async (): Promise<ComputerUseAgentReport> => {
     if (!deps.middleware) report.trajectory = trajectoryMw.entries();
+    const stats = loop.getStats?.();
+    if (stats) {
+      report.modelStats = stats;
+      logger.info(
+        {
+          evt: "computeruse.agent.tokens",
+          goal,
+          loop: loop.name,
+          invocations: stats.invocations,
+          cacheHits: stats.cacheHits,
+          steps: report.steps.length,
+        },
+        `[computeruse/agent] ${stats.invocations} model call(s), ${stats.cacheHits} cache hit(s) over ${report.steps.length} step(s)`,
+      );
+    }
     await runOnRunEnd(middlewares, {
       goal,
       steps: report.steps.length,

--- a/plugins/plugin-computeruse/src/actor/agent-loop.ts
+++ b/plugins/plugin-computeruse/src/actor/agent-loop.ts
@@ -60,10 +60,24 @@ export interface PredictClickInput {
  * loops that plan elsewhere but reuse our grounding, and by callers that want
  * grounding without a full step).
  */
+/**
+ * Per-run model-call accounting (#9105). `invocations` counts the token-bearing
+ * model calls a loop actually issued; `cacheHits` counts calls served without a
+ * model round-trip. Reported once per run as `evt:"computeruse.agent.tokens"`.
+ */
+export interface AgentLoopStats {
+  /** Token-bearing model calls actually issued during the run. */
+  invocations: number;
+  /** Calls served from cache (no model call, no tokens). */
+  cacheHits: number;
+}
+
 export interface AgentLoop {
   readonly name: string;
   predictStep(input: AgentStepInput): Promise<CascadeResult>;
   predictClick(input: PredictClickInput): Promise<GroundingResult | null>;
+  /** Per-run model-call accounting, when the loop tracks it (#9105). */
+  getStats?(): AgentLoopStats;
 }
 
 export interface AgentLoopDeps {
@@ -97,9 +111,11 @@ export interface AgentLoopRegistration {
 export class LocalGrounderLoop implements AgentLoop {
   readonly name = DEFAULT_AGENT_LOOP_MODEL;
   private readonly cascade: Cascade;
+  private readonly brain: Brain;
 
   constructor(deps: AgentLoopDeps) {
     const brain = deps.brain ?? new Brain(deps.runtime);
+    this.brain = brain;
     const actor =
       deps.actor ??
       getRegisteredActor() ??
@@ -134,6 +150,11 @@ export class LocalGrounderLoop implements AgentLoop {
   /** Grounding cache hit/miss snapshot (delegates to the wrapped cascade). */
   getGroundStats() {
     return this.cascade.getGroundStats();
+  }
+
+  /** Model-call accounting from the wrapped Brain (#9105). */
+  getStats(): AgentLoopStats {
+    return this.brain.getStats();
   }
 }
 

--- a/plugins/plugin-local-inference/src/services/voice/echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-canceller.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { computeErle, NlmsEchoCanceller } from "./echo-canceller.ts";
+
+/** Deterministic PRNG so the test is reproducible. */
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** White-noise far-end in [-amp, amp]. */
+function whiteNoise(n: number, amp: number, rng: () => number): Float32Array {
+	const out = new Float32Array(n);
+	for (let i = 0; i < n; i++) out[i] = (rng() * 2 - 1) * amp;
+	return out;
+}
+
+/** Convolve `signal` with a short FIR room impulse to synthesize the echo. */
+function applyEcho(signal: Float32Array, impulse: number[]): Float32Array {
+	const out = new Float32Array(signal.length);
+	for (let n = 0; n < signal.length; n++) {
+		let acc = 0;
+		for (let k = 0; k < impulse.length; k++) {
+			if (n - k >= 0) acc += impulse[k] * signal[n - k];
+		}
+		out[n] = acc;
+	}
+	return out;
+}
+
+const ROOM_IMPULSE = [
+	0.0, 0.0, 0.0, 0.0, 0.0, 0.6, 0.0, -0.3, 0.15, 0.0, -0.05,
+];
+
+describe("NlmsEchoCanceller", () => {
+	it("converges to high ERLE on single-talk (echo only)", () => {
+		const rng = mulberry32(1);
+		const far = whiteNoise(16_000, 0.3, rng);
+		const near = applyEcho(far, ROOM_IMPULSE); // pure echo, no near speech
+		const aec = new NlmsEchoCanceller({ tailMs: 16, mu: 0.7 }); // 256 taps @16k
+		const residual = aec.process(far, near);
+
+		// Measure on the converged tail (last quarter).
+		const start = Math.floor(near.length * 0.75);
+		const erle = computeErle(near.subarray(start), residual.subarray(start));
+		expect(erle).toBeGreaterThanOrEqual(15);
+	});
+
+	it("preserves near-end speech during double-talk (adaptation freezes)", () => {
+		const rng = mulberry32(2);
+		const far = whiteNoise(16_000, 0.3, rng);
+		const echo = applyEcho(far, ROOM_IMPULSE);
+		// Loud near-end speech present from the start -> Geigel should freeze.
+		const nearSpeech = new Float32Array(far.length);
+		for (let i = 0; i < far.length; i++) {
+			nearSpeech[i] = 0.5 * Math.sin((2 * Math.PI * 220 * i) / 16_000);
+		}
+		const near = new Float32Array(far.length);
+		for (let i = 0; i < far.length; i++) near[i] = echo[i] + nearSpeech[i];
+
+		const aec = new NlmsEchoCanceller({ tailMs: 16, mu: 0.7 });
+		const residual = aec.process(far, near);
+
+		// With adaptation frozen, the canceller must NOT cancel the user: the
+		// near speech survives, so ERLE stays low (output ~= input).
+		const start = Math.floor(near.length * 0.75);
+		const dtErle = computeErle(near.subarray(start), residual.subarray(start));
+		expect(dtErle).toBeLessThan(6);
+		// The user's speech energy is retained in the output (not adapted away).
+		let residualSpeechEnergy = 0;
+		let speechEnergy = 0;
+		for (let i = start; i < near.length; i++) {
+			residualSpeechEnergy += residual[i] * residual[i];
+			speechEnergy += nearSpeech[i] * nearSpeech[i];
+		}
+		expect(residualSpeechEnergy).toBeGreaterThan(speechEnergy * 0.5);
+	});
+
+	it("computeErle returns dB and handles edge cases", () => {
+		const near = new Float32Array([1, 1, 1, 1]);
+		const halfResidual = new Float32Array([0.5, 0.5, 0.5, 0.5]);
+		// near energy / residual energy = 4 -> 10*log10(4) ~= 6.02 dB
+		expect(computeErle(near, halfResidual)).toBeCloseTo(6.0206, 2);
+		expect(
+			computeErle(new Float32Array([0, 0]), new Float32Array([1, 1])),
+		).toBe(0);
+		expect(
+			computeErle(new Float32Array([1, 1]), new Float32Array([0, 0])),
+		).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("rejects mismatched frame lengths", () => {
+		const aec = new NlmsEchoCanceller();
+		expect(() => aec.process(new Float32Array(4), new Float32Array(8))).toThrow(
+			/same length/,
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/echo-canceller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-canceller.ts
@@ -1,0 +1,146 @@
+/**
+ * Sample-level acoustic echo cancellation (AEC) for the half-duplex voice path.
+ *
+ * Part (1) of #9455: a pure, dependency-free block/sample NLMS adaptive filter
+ * with a Geigel double-talk detector and a quantified ERLE metric. Given an
+ * aligned far-end reference (what the agent is playing through the speaker) and
+ * the near-end microphone capture, it subtracts the linear echo of the far-end
+ * from the mic so the agent can be cleanly barged-in while it is speaking.
+ *
+ * No FFI, no fs, no network — runs in the fast unit-test lane. Part (2) (wiring
+ * a live far-end playback tap into mic-source/audio-frame-consumer) is separate
+ * and is the real engineering; it is NOT implemented here.
+ *
+ * The adaptive filter is NLMS (normalized least-mean-squares): for each sample
+ *   echoEst[n] = wᵀ · x[n-L+1 .. n]              (x = far-end tap-delay line)
+ *   e[n]       = near[n] - echoEst[n]            (echo-cancelled output)
+ *   w         += (mu · e[n] / (‖x‖² + delta)) · x   (only when NOT double-talk)
+ * A Geigel detector freezes adaptation when near-end speech is present, so a
+ * real barge-in passes through uncancelled instead of being adapted away.
+ */
+
+export interface NlmsEchoCancellerConfig {
+	/** Sample rate of both far/near streams (Hz). Default 16000. */
+	sampleRate?: number;
+	/** Adaptive filter tail length in ms (echo path length). Default 150ms. */
+	tailMs?: number;
+	/** NLMS step size (0<mu<=1). Smaller = slower but more stable. Default 0.5. */
+	mu?: number;
+	/** Regularization added to the far-end energy to avoid div-by-zero. Default 1e-3. */
+	delta?: number;
+	/**
+	 * Geigel double-talk threshold: near-end is considered active (freeze
+	 * adaptation) when |near[n]| exceeds this fraction of the recent far-end
+	 * peak. Default 0.5.
+	 */
+	doubleTalkThreshold?: number;
+}
+
+const DEFAULTS = {
+	sampleRate: 16_000,
+	tailMs: 150,
+	mu: 0.5,
+	delta: 1e-3,
+	doubleTalkThreshold: 0.5,
+} as const;
+
+export class NlmsEchoCanceller {
+	private readonly taps: number;
+	private readonly mu: number;
+	private readonly delta: number;
+	private readonly doubleTalkThreshold: number;
+	/** Adaptive filter weights (length = taps). */
+	private readonly w: Float32Array;
+	/** Far-end tap-delay line (most-recent-last). */
+	private readonly x: Float32Array;
+	/** Running max |far-end| over the tap window, for the Geigel detector. */
+	private farPeak = 0;
+
+	constructor(config: NlmsEchoCancellerConfig = {}) {
+		const sampleRate = config.sampleRate ?? DEFAULTS.sampleRate;
+		const tailMs = config.tailMs ?? DEFAULTS.tailMs;
+		this.taps = Math.max(1, Math.round((sampleRate * tailMs) / 1000));
+		this.mu = config.mu ?? DEFAULTS.mu;
+		this.delta = config.delta ?? DEFAULTS.delta;
+		this.doubleTalkThreshold =
+			config.doubleTalkThreshold ?? DEFAULTS.doubleTalkThreshold;
+		this.w = new Float32Array(this.taps);
+		this.x = new Float32Array(this.taps);
+	}
+
+	/**
+	 * Process one aligned far/near frame and return the echo-cancelled near-end.
+	 * `farEnd` and `nearEnd` must be the same length and time-aligned.
+	 */
+	process(farEnd: Float32Array, nearEnd: Float32Array): Float32Array {
+		if (farEnd.length !== nearEnd.length) {
+			throw new Error(
+				"[NlmsEchoCanceller] far-end and near-end frames must be the same length",
+			);
+		}
+		const out = new Float32Array(nearEnd.length);
+		const { w, x, taps, mu, delta, doubleTalkThreshold } = this;
+
+		for (let n = 0; n < nearEnd.length; n++) {
+			// Shift the far-end sample into the tap-delay line (most-recent-last).
+			x.copyWithin(0, 1);
+			x[taps - 1] = farEnd[n];
+
+			// Echo estimate = wᵀ·x, plus the far-end energy for normalization.
+			let echoEst = 0;
+			let energy = 0;
+			for (let k = 0; k < taps; k++) {
+				const xv = x[k];
+				echoEst += w[k] * xv;
+				energy += xv * xv;
+			}
+
+			const error = nearEnd[n] - echoEst;
+			out[n] = error;
+
+			// Geigel double-talk: freeze adaptation when near-end clearly exceeds
+			// the far-end's recent peak (i.e. the user is talking over the agent),
+			// so the user's speech survives instead of being adapted out.
+			this.farPeak = Math.max(this.farPeak * 0.999, Math.abs(farEnd[n]));
+			const nearActive =
+				Math.abs(nearEnd[n]) > doubleTalkThreshold * this.farPeak;
+
+			if (!nearActive) {
+				const norm = mu / (energy + delta);
+				const step = norm * error;
+				for (let k = 0; k < taps; k++) {
+					w[k] += step * x[k];
+				}
+			}
+		}
+		return out;
+	}
+
+	/** Reset the adaptive state (weights, delay line, peak tracker). */
+	reset(): void {
+		this.w.fill(0);
+		this.x.fill(0);
+		this.farPeak = 0;
+	}
+}
+
+/**
+ * Echo Return Loss Enhancement in dB: 10·log10(Σ near² / Σ residual²). Higher is
+ * better (more echo removed). Returns +Infinity if the residual is silent and 0
+ * when there is no near-end energy to enhance.
+ */
+export function computeErle(
+	nearEnd: Float32Array,
+	residual: Float32Array,
+): number {
+	let nearEnergy = 0;
+	let residualEnergy = 0;
+	const len = Math.min(nearEnd.length, residual.length);
+	for (let i = 0; i < len; i++) {
+		nearEnergy += nearEnd[i] * nearEnd[i];
+		residualEnergy += residual[i] * residual[i];
+	}
+	if (nearEnergy === 0) return 0;
+	if (residualEnergy === 0) return Number.POSITIVE_INFINITY;
+	return 10 * Math.log10(nearEnergy / residualEnergy);
+}

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -122,6 +122,11 @@ export {
 	type LiveKitGgmlTurnDetectorOptions,
 	turnDetectorGgufForTier,
 } from "./eot-classifier-ggml";
+export {
+	computeErle,
+	NlmsEchoCanceller,
+	type NlmsEchoCancellerConfig,
+} from "./echo-canceller";
 export { VoiceStartupError } from "./errors";
 export * from "./ffi-bindings";
 export {


### PR DESCRIPTION
Three small, independent, fully-tested plugin increments — each closes a concrete TODO/unfinished-work item tracked on its issue. No cross-package surface changes; each is additive and typechecks + tests clean in isolation.

### `#9455` — voice NLMS acoustic echo canceller (part 1)
`plugins/plugin-local-inference/src/services/voice/echo-canceller.ts` — a pure, dependency-free `NlmsEchoCanceller` (normalized LMS adaptive filter + Geigel double-talk detection that freezes adaptation so the near-end speaker is never cancelled) plus `computeErle()` (ERLE in dB). No FFI / fs / network. Exported from the voice barrel.

- **Tests** (`echo-canceller.test.ts`, 4): single-talk converges to ≥15 dB ERLE; double-talk preserves the near-end speaker (ERLE < 6 dB, ≥50 % speech energy retained); `computeErle` edge cases (6.02 dB / 0 / +∞); length-mismatch throws.

### `#9476` — typed browser-workspace error contract + classifier
`plugins/plugin-browser/src/workspace/browser-workspace-errors.ts` — a machine-readable `BrowserWorkspaceErrorCode` union, a pure `classifyBrowserWorkspaceErrorCode()` (the single source of truth mapping the well-known thrown-message shapes), and additive/idempotent `tagBrowserWorkspaceError()` (annotates the existing `Error` in place, preserving identity + message). Mirrors the CUA `screenshot-errors.ts` contract. Exported from the workspace barrel. This increment is the contract + classifier; wiring it into the command catch-boundary is a follow-up.

- **Tests** (`browser-workspace-errors.test.ts`, 16): classification driven by the *real* helper-thrown messages (not hand-typed strings); in-place tagging, idempotency, non-Error wrapping, typed-error construction.

### `#9105` — per-run computer-use model-call telemetry
Adds an optional `getStats()` to the `AgentLoop` interface; `LocalGrounderLoop` delegates to the wrapped `Brain`'s invocation / cache-hit counters. `runComputerUseAgentLoop` reads it in `finalize()`, attaches `report.modelStats`, and logs `evt:"computeruse.agent.tokens"` once per run. Loops that don't track stats leave `modelStats` undefined.

- **Tests** (`use-computer-agent.tokens.test.ts`, 3): populated path (`{invocations:1,cacheHits:0}` on a single finish step), one invocation per planning step over a 3-step budget, and the undefined optional path for a stateless loop.

## Verification
- `plugin-local-inference` + `plugin-browser` typecheck: exit 0
- `plugin-computeruse` typecheck: 11/11 tasks pass
- echo-canceller 4/4 · browser-workspace-errors 16/16 · use-computer-agent.tokens 3/3
- biome format clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
