### PR TITLE
fix(music): discover yt-dlp on Windows (where + .exe candidates)

### DIFF
--- a/plugins/plugin-music/src/utils/ytdlpCheck.ts
+++ b/plugins/plugin-music/src/utils/ytdlpCheck.ts
@@ -80,6 +80,9 @@ function getCandidatePaths(): string[] {
     }
   };
 
+  // On Windows the bundled/installed binary is `yt-dlp.exe`, not `yt-dlp`.
+  const binName = process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
+
   // Walk up from module dir (handles both source and bundled dist layouts)
   for (let depth = 2; depth <= 5; depth++) {
     add(
@@ -88,11 +91,17 @@ function getCandidatePaths(): string[] {
         ...Array(depth).fill(".."),
         "scripts",
         "bin",
-        "yt-dlp",
+        binName,
       ),
     );
   }
-  add(resolve(process.cwd(), "scripts", "bin", "yt-dlp"));
+  add(resolve(process.cwd(), "scripts", "bin", binName));
+
+  if (process.platform === "win32") {
+    // Windows relies on `where`-based PATH discovery below (winget/scoop/choco/
+    // pip shims all register on PATH); the POSIX system dirs do not exist here.
+    return candidates;
+  }
 
   add("/usr/local/bin/yt-dlp");
   add("/usr/bin/yt-dlp");
@@ -132,12 +141,18 @@ export async function checkYtdlpAvailable(): Promise<YtdlpCheckResult> {
     }
   }
 
-  // 3. Try PATH via `command -v` (fast, no cold-start penalty)
+  // 3. Try PATH discovery (fast, no cold-start penalty). Windows' cmd.exe has
+  //    no `command` builtin, so use `where`; `command -v` on POSIX.
   try {
-    const commandPath = execSync("command -v yt-dlp", {
+    const probe =
+      process.platform === "win32" ? "where yt-dlp" : "command -v yt-dlp";
+    // `where` can list multiple matches; take the first resolvable one.
+    const commandPath = execSync(probe, {
       encoding: "utf-8",
       timeout: 3000,
-    }).trim();
+    })
+      .split(/\r?\n/)[0]
+      .trim();
     if (commandPath && existsSync(commandPath)) {
       logger.debug(`Found yt-dlp via PATH: ${commandPath}`);
       cachedPath = commandPath;
@@ -194,10 +209,14 @@ export function checkYtdlpAvailableSync(): YtdlpCheckResult {
   }
 
   try {
-    const commandPath = execSync("command -v yt-dlp", {
+    const probe =
+      process.platform === "win32" ? "where yt-dlp" : "command -v yt-dlp";
+    const commandPath = execSync(probe, {
       encoding: "utf-8",
       timeout: 3000,
-    }).trim();
+    })
+      .split(/\r?\n/)[0]
+      .trim();
     if (commandPath && existsSync(commandPath)) {
       cachedPath = commandPath;
       return { found: true, path: commandPath };


### PR DESCRIPTION
## Problem

`plugin-music` requires `yt-dlp` at runtime for audio download/caching. Its binary discovery (`src/utils/ytdlpCheck.ts`) is POSIX-only, so on Windows yt-dlp is found **only** if `YT_DLP_PATH` is explicitly set — normal "it's on PATH / it's bundled" discovery silently fails (and the plugin has no `eliza.platforms` gate, so it does run on Windows):

1. **PATH probe uses `command -v yt-dlp`** (both `checkYtdlpAvailable` and `checkYtdlpAvailableSync`). `command` is a POSIX shell builtin; on Windows `execSync` runs via `cmd.exe`, which has no `command` builtin, so the probe **always throws** and PATH discovery never succeeds. Confirmed on Windows 11: `command -v` → `'command' is not recognized…`.
2. **Candidate paths** only ever look for `scripts/bin/yt-dlp` (no `.exe`) plus `/usr/local/bin`, `/usr/bin`, `/opt/homebrew/bin` — none valid on Windows, where the bundled/installed binary is `yt-dlp.exe`.

## Fix

- PATH discovery now uses **`where yt-dlp`** on win32 (`command -v` on POSIX), taking the first `\r?\n`-split match. `where` is the native PATH resolver and catches winget/scoop/choco/pip-installed yt-dlp.
- Candidate paths use **`yt-dlp.exe`** on win32 for the bundled/cwd `scripts/bin` locations, and skip the POSIX-only system dirs on Windows (they don't exist there; `where` covers PATH installs).

No behavior change off Windows (`command -v` + `yt-dlp` + the POSIX system dirs are preserved exactly).

## Evidence (verified on Windows 11)

The real exported functions were exercised on this box (not a mock):

```
# negative: yt-dlp not on PATH -> clean false (where invoked, not the old throwing command -v)
checkYtdlpAvailableSync() -> { found: false, path: null, error: "yt-dlp executable not found in PATH" }

# positive: dummy yt-dlp.exe prepended to PATH -> discovered via `where`
checkYtdlpAvailable() -> { found: true, path: "C:\\...\\yt-dlp.exe" }
PASS: where-based discovery found yt-dlp.exe on PATH
```

`typecheck` + `biome lint` clean. Follow-on to the Windows prod-source audit (#9372 / #9374).