### PR TITLE
fix(android): fail-closed gate for the Mali flash-attn mitigation in the fused Vulkan lib (#9508)

### DIFF
--- a/.github/issue-evidence/9508-mali-fa-mitigation-gate.md
+++ b/.github/issue-evidence/9508-mali-fa-mitigation-gate.md
@@ -1,0 +1,55 @@
+# #9508 — Mali flash-attn fix: device verification + build-time mitigation gate
+
+## Root cause (confirmed)
+On-device text generate via the bionic Vulkan host intermittently `ggml_abort`s
+(SIGABRT) mid-decode on Mali GPUs (Pixel 9a / Tensor G4 / Mali-G715). The cause is
+the scalar flash-attention subgroup race: nothing sets `flash_attn`, so it defaults
+to AUTO → FA on, and Mali (no cooperative-matrix) takes the scalar path whose
+`subgroupShuffleXor` reduction reads the wrong lanes when the runtime subgroup size
+diverges from the compiled size.
+
+The mitigation already exists in the llama.cpp fork at `0864259` (the
+`VK_VENDOR_ID_ARM` branch → `disable_subgroups=true`, the deterministic
+shared-memory reduction, overridable with `GGML_VK_FA_ALLOW_SUBGROUPS`). The bug
+was that the **prebuilt fused-lib artifact shipped stale** — built before that
+landed, so its `libggml-vulkan.so` had zero mitigation markers.
+
+## Device verification (real Pixel 9a, Mali-G715)
+Rebuilt `libggml-vulkan.so` from develop's fork source (which carries the ARM
+mitigation), pushed `llama-completion` + the rebuilt fused lib set + a Q4 GGUF to
+the device, and ran `-fa on -ngl 99` (Mali Vulkan, flash-attn forced on) 12×:
+
+```
+run 1  exit=0 aborts=0 paris=1
+run 2  exit=0 aborts=0 paris=1
+...
+run 12 exit=0 aborts=0 paris=1
+ALL_DONE
+```
+
+**12/12 clean, 0 SIGABRT, correct generation every run** (`The capital of France
+is → Paris`, ~20 t/s, `n_ctx=32768, n_predict=48` on the Mali GPU). The pre-fix
+lib aborted up to ~84× in some runs with identical config.
+
+Marker proof:
+- rebuilt arm64 `libggml-vulkan.so` → `GGML_VK_FA_ALLOW_SUBGROUPS` markers: **1**
+- stale prebuilt `libggml-vulkan.so` → markers: **0**
+
+## What this PR changes
+A **fail-closed build-time gate** in `verify-fused-symbols.mjs` (run post-build by
+`compile-libllama.mjs`): for any Vulkan fused target, the sibling
+`libggml-vulkan.so` MUST carry the `GGML_VK_FA_ALLOW_SUBGROUPS` marker, or the
+build throws. The marker only exists in source with the `VK_VENDOR_ID_ARM`
+`disable_subgroups` branch, so its presence proves the GPU backend was compiled
+from mitigated source rather than copied from a stale prebuilt — the stale lib can
+never silently pass fused-symbol verification again.
+
+Validated locally: the gate **passes** on the rebuilt (mitigated) backend and
+**throws** on the stale one.
+
+## Follow-up (not in this PR)
+The structural completion is to have the local-agent Android release build
+**compile the fused Vulkan lib from source** (`compile-libllama.mjs --target
+android-arm64-vulkan-fused`) so the freshly-built, mitigated `.so` is baked into
+the released APK — no prebuilt artifact, no HF/archive download. The gate added
+here is the enforcement that makes a stale GPU backend a hard build failure.

--- a/packages/app-core/scripts/build-helpers/verify-fused-symbols.mjs
+++ b/packages/app-core/scripts/build-helpers/verify-fused-symbols.mjs
@@ -53,6 +53,13 @@ const STUB_MARKERS = Object.freeze([
   "unsupported in ABI-only build",
 ]);
 
+// #9508: the presence of this env-var name in libggml-vulkan.so proves the Mali
+// scalar-flash-attn subgroup-race mitigation is compiled in — it is only emitted
+// by source carrying the `VK_VENDOR_ID_ARM` `disable_subgroups` branch (the
+// override knob for it). A Vulkan backend WITHOUT this marker is the stale
+// pre-#9508 prebuilt that SIGABRTs mid-decode on Mali GPUs.
+const MALI_FA_MITIGATION_MARKER = "GGML_VK_FA_ALLOW_SUBGROUPS";
+
 function pickToolForPlatform(target) {
   // target is e.g. "darwin-arm64-metal-fused", "linux-x64-vulkan-fused", etc.
   if (target.startsWith("darwin-") || target.startsWith("ios-")) {
@@ -419,6 +426,25 @@ function verifyFusedSymbolsInner({ outDir, target }) {
     throw new Error(
       `[omnivoice-verify] symbol-verify: libelizainference at ${lib} is missing required ABI symbol(s): ${missingAbiSymbols.join(", ")}. The fused libelizainference is the SOLE on-device inference library (standalone libllama.so is retired), so a missing text/voice/embed/vision symbol is a hard build error with no fallback. Rebuild the fused target against the FFI header at plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h.`,
     );
+  }
+
+  // Mali flash-attn mitigation gate (#9508). A Vulkan fused build MUST ship a
+  // libggml-vulkan.so that carries the ARM subgroup-race mitigation, or it
+  // SIGABRTs mid-decode on Mali GPUs (Tensor G-series etc.). Building from
+  // source emits the mitigation; copying a stale prebuilt does not. Fail-closed
+  // so a stale GPU backend can never be baked into a release APK.
+  if (target.includes("vulkan")) {
+    const vulkanBackend = path.join(path.dirname(lib), "libggml-vulkan.so");
+    if (!fs.existsSync(vulkanBackend)) {
+      throw new Error(
+        `[omnivoice-verify] symbol-verify: target=${target} is a Vulkan build but libggml-vulkan.so is missing next to ${lib} — the GPU backend did not build, so the fused lib would silently run CPU-only on device.`,
+      );
+    }
+    if (!binaryContainsAnyMarker(vulkanBackend, [MALI_FA_MITIGATION_MARKER])) {
+      throw new Error(
+        `[omnivoice-verify] symbol-verify: ${vulkanBackend} lacks the '${MALI_FA_MITIGATION_MARKER}' Mali flash-attn mitigation marker — this is a stale pre-#9508 GPU backend that SIGABRTs mid-decode on Mali. Build libggml-vulkan.so from source carrying the VK_VENDOR_ID_ARM disable_subgroups branch; never stage a prebuilt artifact into a release.`,
+      );
+    }
   }
 
   if (isIos) {


### PR DESCRIPTION
Refs #9508.

## Problem
On-device generate via the bionic Vulkan host `ggml_abort`s (SIGABRT) mid-decode on Mali GPUs (Pixel 9a / Tensor G4 / Mali-G715) — the scalar flash-attn subgroup race. The fork already has the mitigation (`VK_VENDOR_ID_ARM` → `disable_subgroups`, overridable via `GGML_VK_FA_ALLOW_SUBGROUPS`), but the **prebuilt fused-lib artifact shipped stale** (built before it landed) → its `libggml-vulkan.so` had zero mitigation markers.

## This PR
A **fail-closed gate** in `verify-fused-symbols.mjs` (run post-build by `compile-libllama.mjs`): a Vulkan fused target's `libggml-vulkan.so` MUST carry the `GGML_VK_FA_ALLOW_SUBGROUPS` marker or the build throws. The marker only exists in source with the ARM `disable_subgroups` branch, so its presence proves the GPU backend was compiled from mitigated source — a stale prebuilt can never silently pass fused-symbol verification again.

## Verification (real hardware)
Rebuilt `libggml-vulkan.so` from develop's fork source (carries the ARM mitigation), pushed `llama-completion` + the fused lib set + a Q4 GGUF to a **real Pixel 9a (Mali-G715)**, ran Mali Vulkan `-fa on -ngl 99` generate **12×**:

```
run 1..12  exit=0 aborts=0 paris=1
ALL_DONE
```

**12/12 clean, 0 SIGABRT, correct generation every run** (`→ Paris`, ~20 t/s on the Mali GPU). Pre-fix: up to ~84 aborts. Gate validated locally: **passes** on the mitigated backend, **throws** on the stale one. Full evidence: `.github/issue-evidence/9508-mali-fa-mitigation-gate.md`.

## Follow-up (separate, needs an Android release-build run to verify)
Wire the local-agent Android release to **compile the fused Vulkan lib from source** (`compile-libllama.mjs --target android-arm64-vulkan-fused`) so the freshly-built mitigated `.so` is baked into the released APK — no prebuilt artifact, no external download. This gate is the enforcement that makes a stale GPU backend a hard build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)