### PR TITLE
fix(test): dev-smoke seeds the same-origin base so the chat composer paints (#9452)

### DIFF
--- a/packages/app/test/dev-smoke/live-onboarding.ts
+++ b/packages/app/test/dev-smoke/live-onboarding.ts
@@ -165,26 +165,35 @@ export async function ensureOnboarded(): Promise<void> {
   );
 }
 
-function seedCompletedFirstRunStorageForOrigin(apiBase: string): void {
+function seedCompletedFirstRunStorageForOrigin(): void {
   localStorage.setItem("eliza:first-run-complete", "1");
   localStorage.setItem("eliza:setup:step", "activate");
   localStorage.setItem("eliza:ui-shell-mode", "native");
   localStorage.setItem("eliza:chat:voiceMuted", "true");
+  // Pin the active server to THIS page's origin, not the raw agent port. The dev
+  // UI server proxies /api -> the agent (see packages/app/vite.config.ts), so a
+  // same-origin base reaches the agent through that proxy. Pinning the raw
+  // loopback (127.0.0.1:31337) instead makes the browser hit the agent
+  // cross-origin, which 401s /api/auth/status; with no token that strands
+  // startup at `pairing-required` — the shell never paints and the chat composer
+  // never appears (the dev-smoke red, #9452). location.origin is also how a real
+  // `bun run dev` browser session reaches the agent, so this matches production.
+  const base = location.origin;
   localStorage.setItem(
     "elizaos:active-server",
     JSON.stringify({
-      id: `remote:${apiBase}`,
+      id: `remote:${base}`,
       kind: "remote",
       label: "Dev smoke API",
-      apiBase,
+      apiBase: base,
     }),
   );
 }
 
 export async function seedCompletedFirstRunStorage(page: Page): Promise<void> {
-  await page.addInitScript(seedCompletedFirstRunStorageForOrigin, API_BASE);
+  await page.addInitScript(seedCompletedFirstRunStorageForOrigin);
   if (page.url() !== "about:blank") {
-    await page.evaluate(seedCompletedFirstRunStorageForOrigin, API_BASE);
+    await page.evaluate(seedCompletedFirstRunStorageForOrigin);
   }
 }
 


### PR DESCRIPTION
Fixes #9452.

## Symptom
The `bun run dev onboarding chat` dev-smoke (`packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts`) is red **every time it actually executes** (path-gate-skips on unrelated PRs, `test.skip`s without a live key — so it shows green-via-skip otherwise). `gotoChatComposer` hangs 90s × 3 ≈ 270s because `/chat` never paints the composer, even though `/api/health` is ready and `/api/first-run/status` is complete.

## Root cause — harness, not product
`seedCompletedFirstRunStorage` pinned `elizaos:active-server.apiBase` to the **raw agent port** `http://127.0.0.1:31337`. But the page is served from the dev UI origin `http://127.0.0.1:2138`, which **proxies `/api` → the agent** (`packages/app/vite.config.ts`). Pinning the raw port makes the browser reach the agent **cross-origin**, which 401s `/api/auth/status`; with no token, the startup coordinator enters the auth/pairing branch and resolves to phase **`pairing-required`** — which is **not shell-paintable** (`isShellPaintable`, `startup-coordinator.ts:454`), so the composer never mounts.

The product already documents this exact trap (`startup-phase-poll.ts:397-402`):
> a base pinned at the agent's raw loopback port (e.g. dev-in-browser at 127.0.0.1:31337) 401s the browser cross-origin and lands here too

The product's recover-to-same-origin path only fires when pairing is **disabled**, so a pairing-enabled dev agent stays stranded.

## Fix
Seed the active server with **`location.origin`** — the page's own origin, which reaches the agent through the same-origin `/api` proxy exactly like a real `bun run dev` browser session. This bypasses the cross-origin auth branch entirely, so it's robust **regardless** of the agent's `pairingEnabled`. Also drops the now-unused `apiBase` parameter from the seed helper. **Test-only; no production code touched.**

## Verification status
- **Static**: traced end-to-end — seed → cross-origin `/api/auth/status` 401 → `pairing-required` → `!isShellPaintable` → composer never mounts; the fix removes the cross-origin hop. The product's own comment (poll.ts:397-402) corroborates the failure mode.
- **Local full-stack run**: attempted twice (`test:dev-smoke` with a live cerebras key); both were **SIGKILL'd during cold vite optimize** under CPU contention from a concurrent worktree's Playwright stack on this machine — an environment limitation, not a result about the change (the composer assertion never ran). Bumping `ELIZA_DEV_VITE_READY_BUDGET_MS` did not change it.
- **CI gate**: the dev-smoke lane (with the failure artifacts wired up by #9447) is the authoritative confirmation — this PR makes that lane go green when a live key is present. Happy to re-run locally in a quiet window if preferred before merge.

cc @elizaOS — surfaced by vps-agent's launch-readiness audit on #8434.