### PR TITLE
fix(os-setup): build renderer file URL with pathToFileURL (Windows blank-app)

### DIFF
--- a/packages/os/setup/src/main/electrobun-main.ts
+++ b/packages/os/setup/src/main/electrobun-main.ts
@@ -19,7 +19,7 @@
 
 import { createServer as createNetServer } from "node:net";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import Electrobun, { BrowserWindow } from "electrobun/bun";
 import { createServer } from "../../server";
 
@@ -72,7 +72,10 @@ function resolveRendererIndexUrl(): string {
   // compiled entrypoint location.
   const here = path.dirname(fileURLToPath(import.meta.url));
   const indexPath = path.join(here, "..", "renderer", "index.html");
-  return `file://${indexPath}`;
+  // Build a proper file URL: on Windows `file://${winPath}` yields a malformed
+  // URL (backslashes, drive letter parsed as host) that the webview can't load.
+  // pathToFileURL produces file:///C:/… on Windows and file:///abs on POSIX.
+  return pathToFileURL(indexPath).href;
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Problem

`@elizaos/setup` (the Electrobun AOSP-flasher microapp, which ships a Windows package via `package:windows`) builds its renderer URL as:

```ts
const indexPath = path.join(here, "..", "renderer", "index.html");
return `file://${indexPath}`;
```

On Windows `path.join` yields a backslash drive-letter path (`C:\\…\\renderer\\index.html`), so `file://${indexPath}` becomes a **malformed** URL — the drive letter is parsed as the URL authority/host and the backslashes are invalid:

```
file://C:\Users\…\renderer\index.html   (malformed — wrong host, backslashes, only 2 slashes)
```

The Electrobun `BrowserWindow` is then handed a broken URL and fails to load the renderer → **blank app on Windows**. macOS/Linux happen to work because their forward-slash absolute paths already form `file:///abs/path`.

## Fix

Use `pathToFileURL(indexPath).href`, which produces a correct host-agnostic file URL on every platform:

```
file:///C:/Users/…/renderer/index.html   (Windows)
file:///Users/…/renderer/index.html      (POSIX)
```

## Evidence (verified on Windows 11)

```
OLD malformed: file://C:\Users\…\renderer\index.html
NEW correct:   file:///C:/Users/…/renderer/index.html   (pathToFileURL(path.win32.join(...)).href)
```

`biome lint` + `typecheck` clean. Found by an adversarially-verified Windows source sweep (follow-on to #9372 / #9374).