### PR TITLE
test+feat: schedule_plan GEPA seed (#9299) + keyless mock-LLM monetization journey (#9477)

### DIFF
--- a/packages/test/cloud-e2e/src/fixtures/mock-llm.ts
+++ b/packages/test/cloud-e2e/src/fixtures/mock-llm.ts
@@ -1,0 +1,134 @@
+/**
+ * Minimal OpenAI-compatible mock LLM server for the cloud-e2e stack.
+ *
+ * The real creator-monetization journey (`creator-monetization-journey.spec.ts`)
+ * is gated behind `CEREBRAS_API_KEY` because the cloud's default provider is
+ * Cerebras and there is no keyless path through `POST /api/v1/messages`. This
+ * mock fills that gap: it answers the OpenAI chat-completions API with a
+ * deterministic completion and realistic non-zero token usage, so the messages
+ * route's `getLanguageModel("openai/<model>")` → `getOpenAIClient().chat()`
+ * call (which honours `OPENAI_BASE_URL`) hits this server instead of a paid
+ * upstream. The billing/markup/earnings seam downstream is fully real.
+ *
+ * Wire it in by booting it before the cloud-api worker and exporting its
+ * `/v1` URL as `OPENAI_BASE_URL` (+ any `OPENAI_API_KEY`); see the `mockLlm`
+ * option in `stack.ts`. Non-streaming only — `/api/v1/messages` uses
+ * `generateText`, which never opens an SSE stream to the upstream.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface RunningMockLlm {
+  /** Base URL including the `/v1` suffix — use as `OPENAI_BASE_URL`. */
+  url: string;
+  port: number;
+  /** Completions served so far (lets a spec assert the seam was exercised). */
+  requestCount: () => number;
+  stop: () => Promise<void>;
+}
+
+export interface MockLlmOptions {
+  /** Fixed assistant reply. Default `"PONG"`. */
+  reply?: string;
+  /** Reported completion tokens. Default `8`. */
+  completionTokens?: number;
+}
+
+interface ChatCompletionRequestBody {
+  model?: string;
+  messages?: Array<{ role: string; content: unknown }>;
+}
+
+/** Rough token estimate so prompt_tokens scales with the request (never 0). */
+function estimatePromptTokens(body: ChatCompletionRequestBody): number {
+  const text = (body.messages ?? [])
+    .map((m) =>
+      typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+    )
+    .join(" ");
+  return Math.max(8, Math.ceil(text.length / 4));
+}
+
+async function readBody(
+  req: Parameters<Parameters<typeof createServer>[1]>[0],
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * Boot the mock on a free loopback port. Resolves once it is accepting
+ * connections. The returned `url` is the `/v1` base the OpenAI SDK appends
+ * `/chat/completions` to.
+ */
+export async function startMockLlm(
+  options: MockLlmOptions = {},
+): Promise<RunningMockLlm> {
+  const reply = options.reply ?? "PONG";
+  const completionTokens = options.completionTokens ?? 8;
+  let count = 0;
+
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      const url = req.url ?? "";
+      if (req.method === "POST" && url.endsWith("/chat/completions")) {
+        const raw = await readBody(req);
+        let body: ChatCompletionRequestBody = {};
+        try {
+          body = raw ? (JSON.parse(raw) as ChatCompletionRequestBody) : {};
+        } catch {
+          body = {};
+        }
+        count += 1;
+        const promptTokens = estimatePromptTokens(body);
+        const payload = {
+          id: "chatcmpl-mock",
+          object: "chat.completion",
+          created: 0,
+          model: body.model ?? "mock-model",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: reply },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            total_tokens: promptTokens + completionTokens,
+          },
+        };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(payload));
+        return;
+      }
+      // /v1/models and anything else: minimal OK so SDK probes don't error.
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ object: "list", data: [] }));
+    })().catch(() => {
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    port,
+    requestCount: () => count,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/packages/test/cloud-e2e/src/fixtures/stack.ts
+++ b/packages/test/cloud-e2e/src/fixtures/stack.ts
@@ -26,6 +26,7 @@ import {
   type RunningHetznerMock,
   startHetznerMock,
 } from "@elizaos/cloud-test-mocks/hetzner";
+import { type RunningMockLlm, startMockLlm } from "./mock-llm";
 
 import { buildSharedEnv } from "./env";
 
@@ -65,6 +66,8 @@ export interface StackHandle {
     hetzner: string;
     controlPlane: string;
     pglite: string;
+    /** Mock LLM `/v1` base URL — present only when started with `mockLlm`. */
+    mockLlm?: string;
   };
   /**
    * True when the frontend Vite dev was NOT booted (API-only stacks started
@@ -78,6 +81,7 @@ export interface StackHandle {
   mocks: {
     hetzner: RunningHetznerMock;
     controlPlane: RunningControlPlaneMock;
+    mockLlm?: RunningMockLlm;
   };
   dataDir: string;
   logDir: string;
@@ -245,6 +249,13 @@ export interface StartCloudStackOptions {
    * — skips the Vite spawn + health wait, and leaves `urls.frontend` empty.
    */
   frontend?: boolean;
+  /**
+   * Boot an in-process OpenAI-compatible mock LLM and point the worker's
+   * `OPENAI_BASE_URL` / `OPENAI_API_KEY` at it. Lets `POST /api/v1/messages`
+   * run the real billing/markup/earnings seam against an `openai/<model>` id
+   * with no paid provider key. Defaults to false.
+   */
+  mockLlm?: boolean;
 }
 
 /**
@@ -274,6 +285,13 @@ export async function startCloudStack(
     hetznerUrl: hetzner.url,
     tickMs: Number(process.env.CONTROL_PLANE_TICK_MS ?? "50"),
   });
+  const mockLlm = opts.mockLlm ? await startMockLlm() : undefined;
+  const mockLlmEnv: Record<string, string> = mockLlm
+    ? {
+        OPENAI_API_KEY: "mock-llm-key",
+        OPENAI_BASE_URL: mockLlm.url,
+      }
+    : {};
 
   const sharedEnv = buildSharedEnv(
     {
@@ -324,6 +342,10 @@ export async function startCloudStack(
     ...sharedEnv,
     DATABASE_URL: databaseUrl,
     TEST_DATABASE_URL: databaseUrl,
+    // Provider override → the cloud-api dev wrapper syncs OPENAI_API_KEY/
+    // OPENAI_BASE_URL into .dev.vars (providerOverrideKeys), so the worker's
+    // getOpenAIClient() targets the in-process mock for `openai/<model>` ids.
+    ...mockLlmEnv,
   };
   const previousDatabaseUrl = process.env.DATABASE_URL;
   const previousTestDatabaseUrl = process.env.TEST_DATABASE_URL;
@@ -449,6 +471,7 @@ export async function startCloudStack(
     }
     await controlPlane.stop().catch(() => undefined);
     await hetzner.stop().catch(() => undefined);
+    await mockLlm?.stop().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
     if (dbCloseError) {
       throw dbCloseError;
@@ -470,10 +493,11 @@ export async function startCloudStack(
       hetzner: hetzner.url,
       controlPlane: controlPlane.url,
       pglite: `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`,
+      ...(mockLlm ? { mockLlm: mockLlm.url } : {}),
     },
     frontendSkipped: frontendSkipReason !== undefined,
     frontendSkipReason,
-    mocks: { hetzner, controlPlane },
+    mocks: { hetzner, controlPlane, ...(mockLlm ? { mockLlm } : {}) },
     dataDir,
     logDir: LOG_DIR,
   };

--- a/packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts
+++ b/packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Creator-monetization journey — KEYLESS mock-LLM variant (#9477).
+ *
+ * The marquee `creator-monetization-journey.spec.ts` proves the real revenue
+ * loop but is gated behind `CEREBRAS_API_KEY` and skips silently otherwise, so
+ * no always-on run exercises the `POST /api/v1/messages` + `x-app-id` billing
+ * seam. This spec closes that gap: it boots the stack with an in-process
+ * OpenAI-compatible mock LLM (`mockLlm` stack option → `OPENAI_BASE_URL`), then
+ * drives the SAME loop against an `openai/<model>` id — register → monetize →
+ * independent end-user pays via real inference billing → end-user org is
+ * debited → the creator earns the computed markup → it lands in the redeemable
+ * balance. Only the LLM bytes are mocked; the credits/markup/earnings path is
+ * fully real and runs without any paid key.
+ */
+
+import { seedTestUser } from "../src/fixtures/seed";
+import { authedClient } from "../src/helpers/monetization";
+import { seedModelPricing } from "../src/helpers/seed-pricing";
+import { expect, test } from "../src/helpers/test-fixtures";
+
+// API-only stack with the mock LLM wired into the worker's OPENAI_BASE_URL.
+test.use({ stackOptions: { frontend: false, mockLlm: true } });
+
+// `openai/<model>` → isOpenAINativeModel → getOpenAIClient().chat() honours
+// OPENAI_BASE_URL → the mock. resolveAiProviderSource bills it to `openai`,
+// which the seeded `openai`-source pricing row short-circuits (no BitRouter).
+const MODEL = "openai/gpt-4o-mini";
+
+interface CreateAppResponse {
+  success?: boolean;
+  app?: { id?: string };
+  apiKey?: string;
+}
+
+interface MessagesResponse {
+  content?: Array<{ type: string; text?: string }>;
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+interface BalanceResponse {
+  balance?: number;
+}
+
+test.describe("creator-monetization journey (mock LLM, keyless)", () => {
+  test("creator monetizes an app → end-user pays via mock inference → creator earns", async ({
+    stack,
+    seededUser,
+  }) => {
+    const api = stack.urls.api;
+    expect(
+      stack.urls.mockLlm,
+      "stack booted with the mock LLM wired in",
+    ).toBeTruthy();
+
+    await seedModelPricing({
+      model: MODEL,
+      billingSource: "openai",
+      provider: "openai",
+    });
+
+    // ---- Creator (org A) ----
+    const creator = authedClient(api, seededUser.apiKey);
+
+    const created = await creator<CreateAppResponse>("POST", "/api/v1/apps", {
+      name: `Mock Journey App ${Date.now().toString(36)}`,
+      app_url: "https://placeholder.invalid",
+      skipGitHubRepo: true,
+    });
+    expect([200, 201]).toContain(created.status);
+    const appId = created.json.app?.id;
+    expect(appId, "apps.create returns an app id").toBeTruthy();
+    if (!appId) throw new Error("apps.create did not return an app id");
+
+    const monetize = await creator(
+      "PUT",
+      `/api/v1/apps/${appId}/monetization`,
+      {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 100,
+        purchaseSharePercentage: 10,
+      },
+    );
+    expect([200, 201]).toContain(monetize.status);
+
+    // ---- Independent end-user (org B) ----
+    const endUser = await seedTestUser({
+      slug: `mockenduser-${Date.now().toString(36)}`,
+    });
+    const buyer = authedClient(api, endUser.apiKey);
+
+    const balBefore = await buyer<BalanceResponse>(
+      "GET",
+      "/api/v1/credits/balance",
+    );
+    expect(balBefore.status).toBe(200);
+    const beforeBalance = balBefore.json.balance ?? 0;
+    expect(beforeBalance).toBeGreaterThan(0);
+
+    // Creator earnings BEFORE the paid inference.
+    const { redeemableEarningsService } = await import(
+      "@elizaos/cloud-shared/lib/services/redeemable-earnings"
+    );
+    const { appEarningsService } = await import(
+      "@elizaos/cloud-shared/lib/services/app-earnings"
+    );
+    const creatorEarnBefore =
+      (await redeemableEarningsService.getBalance(seededUser.userId))
+        ?.availableBalance ?? 0;
+    const appEarnBefore =
+      (await appEarningsService.getEarningsSummary(appId))
+        ?.totalLifetimeEarnings ?? 0;
+
+    // ---- Paid inference: end-user calls the monetized app (mock LLM) ----
+    const inference = await buyer<MessagesResponse>(
+      "POST",
+      "/api/v1/messages",
+      {
+        model: MODEL,
+        max_tokens: 256,
+        messages: [
+          { role: "user", content: "Reply with exactly the word: PONG" },
+        ],
+      },
+      { "X-App-Id": appId },
+    );
+    expect(inference.status, "monetized inference returns 200").toBe(200);
+    const text =
+      inference.json.content?.find((b) => b.type === "text")?.text ?? "";
+    expect(text, "mock LLM returned the deterministic completion").toBe("PONG");
+    expect(
+      (inference.json.usage?.output_tokens ?? 0) > 0,
+      "token usage reported",
+    ).toBe(true);
+
+    // The mock actually served the request (the billing seam was exercised).
+    expect(
+      stack.mocks.mockLlm?.requestCount() ?? 0,
+      "the mock LLM served the inference",
+    ).toBeGreaterThan(0);
+
+    // ---- End-user org was debited (base + markup) ----
+    const balAfter = await buyer<BalanceResponse>(
+      "GET",
+      "/api/v1/credits/balance",
+    );
+    expect(balAfter.status).toBe(200);
+    const afterBalance = balAfter.json.balance ?? 0;
+    const debited = beforeBalance - afterBalance;
+    console.log(
+      `[mock-journey] end-user debited ${debited} (before=${beforeBalance} after=${afterBalance})`,
+    );
+    expect(
+      debited,
+      "mock inference debited the end-user's org credits",
+    ).toBeGreaterThan(0);
+
+    // ---- Creator earned the markup (both ledgers) ----
+    const creatorEarnAfter =
+      (await redeemableEarningsService.getBalance(seededUser.userId))
+        ?.availableBalance ?? 0;
+    const appEarnAfter =
+      (await appEarningsService.getEarningsSummary(appId))
+        ?.totalLifetimeEarnings ?? 0;
+    console.log(
+      `[mock-journey] creator redeemable ${creatorEarnBefore}->${creatorEarnAfter}, app_earnings ${appEarnBefore}->${appEarnAfter}`,
+    );
+    expect(
+      creatorEarnAfter + appEarnAfter,
+      "creator earnings increased from the paid inference",
+    ).toBeGreaterThan(creatorEarnBefore + appEarnBefore);
+
+    // ---- Creator reads earnings + redeemable balance via the API ----
+    const earningsApi = await creator<{
+      success?: boolean;
+      earnings?: { summary?: { totalLifetimeEarnings?: number } };
+    }>("GET", `/api/v1/apps/${appId}/earnings`);
+    expect(earningsApi.status).toBe(200);
+    expect(earningsApi.json.success).toBe(true);
+
+    const redeemBal = await creator<{ success?: boolean }>(
+      "GET",
+      "/api/v1/redemptions/balance",
+    );
+    expect(redeemBal.status).toBe(200);
+  });
+});

--- a/plugins/plugin-training/scripts/lifeops-gepa-seed.ts
+++ b/plugins/plugin-training/scripts/lifeops-gepa-seed.ts
@@ -30,7 +30,10 @@ import {
   type OptimizedPromptTask,
 } from "@elizaos/core";
 import { CALENDAR_PLAN_INSTRUCTIONS } from "../../plugin-calendar/src/actions/optimized-prompt-instructions.ts";
-import { GMAIL_PLAN_INSTRUCTIONS } from "../../plugin-personal-assistant/src/lifeops/optimized-prompt-instructions.ts";
+import {
+  GMAIL_PLAN_INSTRUCTIONS,
+  SCHEDULE_PLAN_INSTRUCTIONS,
+} from "../../plugin-personal-assistant/src/lifeops/optimized-prompt-instructions.ts";
 import { getTrainingUseModelAdapter } from "../src/core/cerebras-eval-model.ts";
 import {
   createPromptScorer,
@@ -75,6 +78,31 @@ function calendarPlannerInput(args: CalendarPlannerInputArgs): string {
 }
 
 function expectedCalendarPlan(fields: Record<string, unknown>): string {
+  return JSON.stringify(fields);
+}
+
+interface SchedulingPlannerInputArgs {
+  currentMessage: string;
+  intent?: string;
+  params?: Record<string, unknown>;
+  recentConversation?: string;
+}
+
+function schedulingPlannerInput(args: SchedulingPlannerInputArgs): string {
+  const intent = args.intent ?? args.currentMessage;
+  const params = args.params ?? {};
+  const paramLines = Object.entries(params)
+    .map(([key, value]) => `${key}: ${String(value)}`)
+    .join("\n");
+  return [
+    `Current request:\n${args.currentMessage}`,
+    `Resolved intent:\n${intent}`,
+    `Structured parameters:\n${paramLines || "(none)"}`,
+    `Recent conversation:\n${args.recentConversation ?? "(none)"}`,
+  ].join("\n");
+}
+
+function expectedSchedulePlan(fields: Record<string, unknown>): string {
   return JSON.stringify(fields);
 }
 
@@ -240,6 +268,145 @@ export const SEED_TASKS: Record<string, SeedTask> = {
           }),
         },
         expectedOutput: expectedCalendarPlan({
+          subaction: null,
+          shouldAct: false,
+        }),
+      },
+    ],
+  },
+  // schedule_plan is the live scheduling-negotiation planner
+  // (buildSchedulingPlanPrompt → SCHEDULE_PLAN_INSTRUCTIONS). It returns a JSON
+  // object with subaction / shouldAct / response. Rows cover every subaction,
+  // the wrong-tool and vague guards (shouldAct=false), and multilingual,
+  // formal+informal phrasing per the GEPA-real-conversation requirement (#9299).
+  schedule_plan: {
+    task: "schedule_plan",
+    baseline: SCHEDULE_PLAN_INSTRUCTIONS,
+    dataset: [
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Set up a time to meet with Jordan next week for a 30-minute sync.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "start",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Propose Thursday at 2pm for the budget review negotiation.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "propose",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage: "Accept the 3pm slot Dana proposed.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "respond",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Lock in the Tuesday 10am option for the design sync.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "finalize",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Cancel the scheduling negotiation for the offsite planning call.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "cancel",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage: "Which scheduling negotiations are still open?",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "list_active",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Show me the proposed times for the Q3 roadmap meeting.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "list_proposals",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Trouve un créneau avec Camille la semaine prochaine pour caler une réunion d'une heure.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "start",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage:
+              "Acepto la propuesta de las 4 de la tarde de Marco.",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: "respond",
+          shouldAct: true,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage: "What's on my calendar today?",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
+          subaction: null,
+          shouldAct: false,
+        }),
+      },
+      {
+        input: {
+          user: schedulingPlannerInput({
+            currentMessage: "Can you help me with scheduling stuff?",
+          }),
+        },
+        expectedOutput: expectedSchedulePlan({
           subaction: null,
           shouldAct: false,
         }),
@@ -432,6 +599,18 @@ function validateOptimizedPromptForTask(
       "read",
       "draft_reply",
       "send_reply",
+    ],
+    schedule_plan: [
+      "subaction",
+      "shouldAct",
+      "response",
+      "start",
+      "propose",
+      "respond",
+      "finalize",
+      "cancel",
+      "list_active",
+      "list_proposals",
     ],
   };
   const requiredFragments = requiredFragmentsByTask[task] ?? [];

--- a/plugins/plugin-training/src/scripts/lifeops-gepa-seed.test.ts
+++ b/plugins/plugin-training/src/scripts/lifeops-gepa-seed.test.ts
@@ -20,10 +20,11 @@ function makeResult(
 }
 
 describe("lifeops-gepa-seed", () => {
-  it("exposes calendar and inbox seed tasks", () => {
+  it("exposes calendar, schedule, and inbox seed tasks", () => {
     expect(Object.keys(SEED_TASKS).sort()).toEqual([
       "calendar_extract",
       "inbox_triage",
+      "schedule_plan",
     ]);
   });
 
@@ -47,6 +48,74 @@ describe("lifeops-gepa-seed", () => {
       expect(parsed).not.toHaveProperty("startTime");
       expect(parsed).not.toHaveProperty("endTime");
     }
+  });
+
+  it("uses the live scheduling planner baseline and JSON-shaped examples", () => {
+    const seed = SEED_TASKS.schedule_plan;
+    expect(seed.baseline).toContain("Plan the scheduling negotiation action");
+    expect(seed.baseline).toContain("subaction");
+    expect(seed.baseline).toContain("finalize");
+
+    expect(seed.dataset.length).toBeGreaterThanOrEqual(8);
+
+    const subactions = seed.dataset.map(
+      (example) =>
+        (JSON.parse(example.expectedOutput) as { subaction: string | null })
+          .subaction,
+    );
+    // Every actionable subaction appears at least once.
+    for (const subaction of [
+      "start",
+      "propose",
+      "respond",
+      "finalize",
+      "cancel",
+      "list_active",
+      "list_proposals",
+    ]) {
+      expect(subactions).toContain(subaction);
+    }
+    // The wrong-tool / vague guard (shouldAct=false) is represented.
+    expect(
+      seed.dataset.some((example) => {
+        const parsed = JSON.parse(example.expectedOutput) as {
+          subaction: string | null;
+          shouldAct: boolean;
+        };
+        return parsed.subaction === null && parsed.shouldAct === false;
+      }),
+    ).toBe(true);
+    // Multilingual coverage per the GEPA real-conversation requirement.
+    expect(
+      seed.dataset.some((example) =>
+        /créneau|Acepto|propuesta/.test(example.input.user),
+      ),
+    ).toBe(true);
+
+    for (const example of seed.dataset) {
+      expect(example.input.user).toContain("Current request:");
+      const parsed = JSON.parse(example.expectedOutput) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed).toHaveProperty("subaction");
+      expect(parsed).toHaveProperty("shouldAct");
+    }
+  });
+
+  it("blocks malformed scheduling prompts from persistence", () => {
+    const seed = SEED_TASKS.schedule_plan;
+    const malformed = validatePersistableResult(
+      seed,
+      makeResult("Return JSON with subaction and shouldAct.", 0.9, 0.1),
+    );
+    expect(malformed).toEqual(
+      expect.arrayContaining([expect.stringContaining('"finalize"')]),
+    );
+
+    expect(
+      validatePersistableResult(seed, makeResult(seed.baseline, 0.9, 0.1)),
+    ).toEqual([]);
   });
 
   it("uses the live Gmail planner baseline and line-shaped examples", () => {


### PR DESCRIPTION
Two independent, fully-tested increments closing the actionable code follow-ups on their issues.

### `#9299` — `schedule_plan` LifeOps GEPA seed
The scheduling-negotiation planner (`SCHEDULE_PLAN_INSTRUCTIONS`) becomes a third lifeops GEPA seed task in `plugins/plugin-training/scripts/lifeops-gepa-seed.ts`, alongside `calendar_extract` and `inbox_triage`. The 11-row dataset covers every subaction (`start`/`propose`/`respond`/`finalize`/`cancel`/`list_active`/`list_proposals`), the wrong-tool + vague guards (`shouldAct=false`), and multilingual formal/informal phrasing (FR/ES) per the #9299 real-conversation requirement. The per-task persistence guard is extended so a degenerate optimized prompt that drops the subaction vocabulary can't replace the working baseline.

- **Test** (`lifeops-gepa-seed.test.ts`, 8/8, was 6): keys assertion updated; schedule_plan baseline/shape coverage; every-subaction-present check; multilingual check; malformed-persistence guard.

### `#9477` — keyless mock-LLM creator-monetization journey
Closes the two open code follow-ups on the (otherwise manual) #9477:
- An in-process OpenAI-compatible **mock LLM** (`mock-llm.ts`) + a `mockLlm` stack option that points the worker's `OPENAI_BASE_URL`/`OPENAI_API_KEY` at it (synced into `.dev.vars` via `providerOverrideKeys`). The new `monetized-mock-llm-journey.spec.ts` drives the **real** `POST /api/v1/messages` + `x-app-id` billing/markup/earnings seam against an `openai/<model>` id with **no paid key** — the gap the `CEREBRAS_API_KEY`-gated `creator-monetization-journey.spec.ts` left.
- Fixes the stale doc path `app/api/cron/container-billing/route.ts` → `packages/cloud-api/cron/container-billing/route.ts` in `survival-economics.md`.

- **Verified** (1 passed, 8.7s): end-user org debited `0.000016` (base + 100% markup), creator `app_earnings` `0 → 0.000008`, the mock served the inference. Only the LLM bytes are mocked; credits/markup/earnings are fully real.

## Verification
- `plugin-training` typecheck: turbo 30/30 green; `lifeops-gepa-seed.test.ts` 8/8
- `monetized-mock-llm-journey.spec.ts`: 1 passed (real debit + markup asserted)
- `cloud-e2e` tsc: only the pre-existing tsconfig `baseUrl` deprecation; no errors in touched files
- biome format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
