### PR TITLE
fix(agent): spawn the global package-manager via shell on Windows for self-update

### DIFF
--- a/packages/agent/src/services/self-updater.ts
+++ b/packages/agent/src/services/self-updater.ts
@@ -269,8 +269,13 @@ function runCommand(
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ["inherit", "inherit", "pipe"],
-      // shell:true removed — all update commands are safe to run directly.
-      // The apt case uses sh -c explicitly, so no shell wrapper is needed.
+      // The global launcher is a `.cmd` shim on Windows (npm.cmd / bun.cmd),
+      // which Node cannot spawn without a shell (ENOENT) — every npm-global
+      // auto-update would fail. Route through the shell on win32 so the shim
+      // resolves. Update args are static/internal (e.g. `install -g <spec>`),
+      // so there is no injection surface; the Linux apt case uses an explicit
+      // `sh -c` and is unaffected.
+      shell: process.platform === "win32",
     });
 
     let stderr = "";


### PR DESCRIPTION
## Problem

`eliza update` (and the auto-updater) runs the resolved upgrade command through `self-updater.ts` `runCommand`:

```ts
const child = spawn(command, args, { stdio: ["inherit", "inherit", "pipe"] });
// shell:true removed — all update commands are safe to run directly.
```

For an `npm install -g` install (`detectInstallMethod()` -> `npm-global`, the common case, and the `unknown` fallback) `buildUpdateCommand()` returns `command: "npm"`. On Windows the global npm launcher is **`npm.cmd`**, and `spawn()` **without** `shell:true` cannot resolve a `.cmd` shim (Node only auto-resolves `.cmd` when `shell` is set) — the child emits an `error` event with `ENOENT`, `runCommand` resolves `{ exitCode: 1 }`, and **every npm-global self-update fails on Windows** ("Update failed", exit 1). The earlier removal of `shell:true` didn't account for `.cmd` shims.

## Fix

Pass `shell: process.platform === "win32"` so the `.cmd`/`.bat` shim (npm.cmd, bun.cmd, brew on global installs) resolves on Windows. The update args are static/internal (`install -g <spec>`, `upgrade eliza`, …) so there is no injection surface; the Linux `apt` case uses an explicit `sh -c` and is unaffected. No behavior change off Windows (`shell` stays `false`).

This mirrors the established repo pattern (`register.dashboard.ts`, `plugins-cli.ts`, agent-skills `install.ts` already use `shell: process.platform === "win32"`).

## Evidence (verified on Windows 11)

```
where npm  -> C:\Program Files\nodejs\npm  AND  …\npm.cmd
spawn("npm", ["--version"])                      -> error ENOENT (errno -4058)
spawn("npm", ["--version"], { shell: true })     -> 11.12.1
```

`biome lint` + `tsgo` clean. Found by an adversarially-verified Windows source sweep (follow-on to #9372 / #9374).