### PR TITLE
fix(android): bump fused-lib build pin past the Mali flash-attn fix (#9508)

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -212,7 +212,13 @@ const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
 // baked in. apply-patches.mjs is kept around for one release as a
 // rollback path; see scripts/aosp/llama-cpp-patches/README.md.
 export const LLAMA_CPP_TAG = "v1.2.0-eliza";
-export const LLAMA_CPP_COMMIT = "33c888a7be0b0b8ffb54cd3f0e05b4bed20cc52e";
+// Must track the `plugins/plugin-local-inference/native/llama.cpp` submodule
+// gitlink on develop. The old pin `33c888a7be` predated the Mali flash-attn
+// subgroup-race fix (the `VK_VENDOR_ID_ARM` `disable_subgroups` branch), so the
+// fused Vulkan lib built from it SIGABRTed mid-decode on Mali GPUs (#9508). This
+// commit is a forward descendant that bakes the mitigation in; the
+// `verify-fused-symbols` gate enforces the marker is present post-build.
+export const LLAMA_CPP_COMMIT = "32a7911dced6230ce544c43a6399f5bd721cab90";
 export const LLAMA_CPP_REMOTE = "https://github.com/elizaOS/llama.cpp.git";
 export const MIN_ZIG_VERSION = "0.13.0";
 // Floor for the RVV-on riscv64 build. Zig 0.13's bundled LLVM rejects the


### PR DESCRIPTION
Refs #9508. Pairs with the already-merged verify-fused-symbols gate (#9528).

## The actual root cause
`compile-libllama.mjs` (the production build for the bionic fused Vulkan lib) checks out a **pinned fork commit** `LLAMA_CPP_COMMIT` and builds from it. The pin was `33c888a7be`, which **predates the Mali flash-attn subgroup-race fix** (`VK_VENDOR_ID_ARM` → `disable_subgroups`). So the build itself produced a `libggml-vulkan.so` without the mitigation → SIGABRT mid-decode on Mali. The "stale prebuilt artifact" was a *symptom*; the stale **build pin** is the cause.

## Fix
Bump the pin to `32a7911dced` — develop's current llama.cpp submodule gitlink, a forward descendant of the old pin that includes the ARM mitigation (5 refs) + the #9460 diarizer fix. The build now compiles the mitigated GPU backend into the APK from source (no prebuilt, no HF/archive). The merged `verify-fused-symbols` gate enforces the marker post-build, so reverting to a non-mitigated pin hard-fails.

## Verification
- `32a7911dced` has the ARM mitigation (5 `VK_VENDOR_ID_ARM`/`GGML_VK_FA_ALLOW_SUBGROUPS` refs); old pin had 0. Forward-only bump (ancestor check ✓).
- Device-verified the lib from this fork lineage on a **real Pixel 9a (Mali-G715)**: Mali Vulkan `-fa on` generate **12/12 clean, 0 SIGABRT** (pre-fix ~84 aborts).
- Lint clean; `run-mobile-build-mtp-staleness` 11/11 (the fork-revision rebuild logic correctly triggers on the bump).
- The musl-agent `distro-android` pin is a separate non-Vulkan lib, intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)