### PR TITLE
fix(agent): spawn npm via shell on Windows in plugin-installer (.cmd shim)

### DIFF
--- a/packages/agent/src/services/plugin-installer.ts
+++ b/packages/agent/src/services/plugin-installer.ts
@@ -206,7 +206,10 @@ function resolveInstallVersion(
 export async function detectPackageManager(): Promise<"bun" | "npm"> {
   for (const cmd of ["bun", "npm"] as const) {
     try {
-      await execFileAsync(cmd, ["--version"]);
+      await execFileAsync(cmd, ["--version"], {
+        // npm is a `.cmd` shim on Windows; Node can't spawn it without a shell.
+        shell: process.platform === "win32",
+      });
       return cmd;
     } catch (err) {
       logger.debug(
@@ -580,13 +583,13 @@ async function runInstallSpec(
       });
       break;
     default:
-      await execFileAsync("npm", [
-        "install",
-        "--ignore-scripts",
-        spec,
-        "--prefix",
-        targetDir,
-      ]);
+      await execFileAsync(
+        "npm",
+        ["install", "--ignore-scripts", spec, "--prefix", targetDir],
+        // npm is a `.cmd` shim on Windows; Node can't spawn it without a shell.
+        // `spec` is validated by assertValidPackageName/assertValidVersion.
+        { shell: process.platform === "win32" },
+      );
   }
 }
 
@@ -747,12 +750,19 @@ async function gitCloneInstall(
     });
 
     const pm = await detectPackageManager();
-    await execFileAsync(pm, ["install", "--ignore-scripts"], { cwd: tempDir });
+    await execFileAsync(pm, ["install", "--ignore-scripts"], {
+      cwd: tempDir,
+      // `pm` is npm.cmd on Windows when bun is absent; needs a shell to resolve.
+      shell: process.platform === "win32",
+    });
 
     const registrySourceDir = resolveRegistrySourceDir(tempDir, info.directory);
     if (registrySourceDir !== tempDir) {
       try {
-        await execFileAsync(pm, ["run", "build"], { cwd: registrySourceDir });
+        await execFileAsync(pm, ["run", "build"], {
+          cwd: registrySourceDir,
+          shell: process.platform === "win32",
+        });
       } catch (buildErr) {
         logger.warn(
           `[plugin-installer] build step failed for ${info.name}: ${buildErr instanceof Error ? buildErr.message : String(buildErr)}`,
@@ -777,7 +787,10 @@ async function gitCloneInstall(
     }
     let buildFailed = false;
     try {
-      await execFileAsync(pm, ["run", "build"], { cwd: tsDir });
+      await execFileAsync(pm, ["run", "build"], {
+        cwd: tsDir,
+        shell: process.platform === "win32",
+      });
     } catch (buildErr) {
       buildFailed = true;
       logger.warn(


### PR DESCRIPTION
## Problem

`plugin-installer.ts` installs plugins via `execFileAsync` (= `promisify(execFile)`) with **no** `shell` option. On Windows, npm is **`npm.cmd`** (a batch shim) and `execFile` cannot launch a `.cmd` without a shell — it rejects with `ENOENT`. `detectPackageManager()` returns `"npm"` whenever `bun` is absent (the common Node/npm-only Windows case) or as the final fallback, so on a bun-less Windows box **the entire plugin-install feature is broken**:

- `runPackageInstall` (the primary install path) — `execFileAsync("npm", ["install", "--ignore-scripts", spec, "--prefix", targetDir])` → ENOENT.
- `gitCloneInstall` (the git fallback) — `execFileAsync(pm, ["install", …])` and the two `execFileAsync(pm, ["run", "build"], …)` steps → ENOENT.
- `detectPackageManager()`'s `npm --version` probe also ENOENTs (harmless — npm is the fallback — but now accurate).

## Fix

Pass `shell: process.platform === "win32"` to the five npm/`pm` `execFileAsync` call sites (probe + primary install + git-clone install/build×2) so the `.cmd` shim resolves on Windows. `bun` is a real `.exe` and is unaffected. The dynamic `spec` is already validated by `assertValidPackageName`/`assertValidVersion`, so the win32 shell introduces no injection surface. No behavior change off Windows (`shell` stays `false`). Mirrors the existing repo pattern (`register.dashboard.ts`, `plugins-cli.ts`, agent-skills `install.ts`).

## Evidence (verified on Windows 11)

```
execFile("npm", ["--version"])                   -> spawn npm ENOENT (errno -4058)
execFile("npm", ["--version"], { shell: true })  -> 11.12.1
git / bun / node (real .exe)                     -> work without shell
```

`biome lint` + `tsgo` clean (5 sites patched). Found by an adversarially-verified Windows source sweep (follow-on to #9372 / #9374).