### PR TITLE
test(cloud-shared): cover app-credits money-safety branches (post-debit compensation + reconcile loss-absorb)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -239,6 +239,40 @@ describe("deductCredits — debits the same org ledger", () => {
     expect(spend.success).toBe(false);
     expect(spend.message).toContain("Insufficient cloud credits");
   });
+
+  // Money-safety: the org balance is debited BEFORE the earnings/activity
+  // accounting runs. If that post-debit accounting throws, the user has already
+  // paid for an inference whose bookkeeping failed — they must be made whole, or
+  // they're charged with nothing to show for it. deductCredits() compensates the
+  // full totalCost and rethrows so the caller still sees the failure.
+  test("compensates the full charge and rethrows when post-debit accounting fails", async () => {
+    // The atomic debit succeeds...
+    reserveAndDeductCredits.mockResolvedValue({
+      success: true,
+      newBalance: 41.4,
+      transaction: { id: "tx-2" },
+    });
+    // ...but the very next step (earnings/activity bookkeeping) blows up.
+    trackAppUserActivity.mockRejectedValue(new Error("accounting down"));
+
+    await expect(
+      freshService().deductCredits({
+        appId: APP_ID,
+        userId: USER_ID,
+        baseCost: 1,
+        description: "inference",
+      }),
+    ).rejects.toThrow("accounting down");
+
+    // The $1.10 debit (base $1 + 10% markup) MUST be refunded — exactly once,
+    // to the same org, tagged so it reconciles against the original charge.
+    expect(addCredits).toHaveBeenCalledTimes(1);
+    const refund = addCredits.mock.calls[0][0];
+    expect(refund.organizationId).toBe(ORG_ID);
+    expect(refund.amount).toBeCloseTo(1.1, 10);
+    expect(refund.metadata.reason).toBe("post_debit_accounting_failed");
+    expect(refund.metadata.originalChargeTransactionId).toBe("tx-2");
+  });
 });
 
 describe("reconcileCredits — charges/refunds the estimate↔actual delta (#9145)", () => {
@@ -314,6 +348,30 @@ describe("reconcileCredits — charges/refunds the estimate↔actual delta (#914
     });
     expect(result.reconciled).toBe(false);
     expect(result.action).toBe("none");
+  });
+
+  // Money-safety: the inference already ran, so when the upward reconcile charge
+  // can't be collected (org out of credits), the platform absorbs the delta. It
+  // must NOT credit the creator for revenue that was never collected, and must
+  // report the charge as un-reconciled (adjustedAmount 0) for loss tracking.
+  test("absorbs the loss without crediting the creator when the reconcile charge is uncollectable", async () => {
+    reserveAndDeductCredits.mockResolvedValue({ success: false, newBalance: 0.05 });
+
+    const result = await freshService().reconcileCredits({
+      appId: APP_ID,
+      userId: USER_ID,
+      estimatedBaseCost: 1,
+      actualBaseCost: 2,
+      description: "recon",
+    });
+
+    expect(result.reconciled).toBe(false);
+    expect(result.action).toBe("charge");
+    expect(result.adjustedAmount).toBe(0);
+    expect(result.newBalance).toBe(0.05);
+    // No revenue was collected — the creator's earnings ledgers stay untouched.
+    expect(addInferenceEarnings).not.toHaveBeenCalled();
+    expect(addEarnings).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Adds mutation-verified coverage for **two load-bearing, previously-untested money-safety branches** in `AppCreditsService` (`packages/cloud-shared/src/lib/services/app-credits.ts`). Both are invariants that only matter *after the user's org balance has already moved* — exactly the kind of "written once, never exercised" path that silently rots.

Test-only change — **no production code touched**.

### 1. `deductCredits()` — compensation refund on post-debit failure
The org balance is debited (`reserveAndDeductCredits`) **before** the earnings/activity bookkeeping runs. If that post-debit accounting throws, the user has paid for an inference whose recording failed. The service must refund the full `totalCost` and rethrow so the caller still sees the error. New test asserts the refund hits the same org, for the exact `totalCost`, tagged `reason: "post_debit_accounting_failed"` + `originalChargeTransactionId`.

### 2. `reconcileCredits()` — platform loss-absorb when the up-charge is uncollectable
When actual usage exceeds the estimate but the org is out of credits, the inference already ran, so the platform absorbs the delta. It must **not** credit the creator for revenue never collected, and must report the charge un-reconciled (`adjustedAmount: 0`). New test asserts `reconciled:false`, `adjustedAmount:0`, and that the creator earnings ledgers (`addInferenceEarnings`, `redeemableEarnings.addEarnings`) stay untouched.

## Why it's not LARP — mutation verification

Each test was proven to fail when its target branch is broken, and only that test:

| Mutation | Result |
|---|---|
| Neuter the compensation `addCredits(...)` (keep the rethrow) | ❌ only *"compensates the full charge…"* fails (12 pass / 1 fail) |
| Flip the loss-absorb return to `reconciled: true` | ❌ only *"absorbs the loss…"* fails (12 pass / 1 fail) |
| Both reverted | ✅ 13 pass / 0 fail |

```
$ bun test src/lib/services/__tests__/app-credits-ledger.test.ts
 13 pass
 0 fail
 57 expect() calls
```

## Scope / non-duplication

Complements, doesn't duplicate:
- **#9423** `example-apps-showcase.spec.ts` — e2e *happy-path* ledger effects (org debit + creator earnings move by the computed markup).
- **#9494** `container-billing-idempotency.test.ts` — the `creditsService.reserveAndDeductCredits` primitive `deductCredits` delegates to.
- Existing `app-credits-ledger.test.ts` — purchase, markup math, reconcile charge/refund happy paths.

These two failure/compensation branches were the gap. Context: launch-readiness money-loop hardening (#8434, #9300).