### PR TITLE
test(cloud): cover keyless mock-LLM /messages seam in nightly net + docs (#9477)

### DIFF
--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -210,7 +210,11 @@ jobs:
         run: bun run --cwd packages/cloud-shared build || true
 
       - name: Run example-apps showcase + monetized full loop (mock stack)
-        run: bun run cloud:e2e -- example-apps-showcase.spec.ts monetized-full-loop.spec.ts
+        # monetized-mock-llm-journey drives the real POST /api/v1/messages +
+        # x-app-id billing seam through an in-process OpenAI mock (keyless), the
+        # always-on counterpart to the CEREBRAS-gated real-LLM journey — included
+        # here so the scheduled regression net also guards the messages route.
+        run: bun run cloud:e2e -- example-apps-showcase.spec.ts monetized-full-loop.spec.ts monetized-mock-llm-journey.spec.ts
         env:
           CI: "true"
           CLOUD_E2E: "1"

--- a/packages/test/cloud-e2e/docs/monetized-loop-coverage.md
+++ b/packages/test/cloud-e2e/docs/monetized-loop-coverage.md
@@ -38,7 +38,7 @@ honest scaffold (green-but-skipped), never mock assertions masquerading as real.
 | c | Deploy / provision a node | **covered (mock)** | scaffold (skipped) | control-plane provision job → Hetzner mock server `initializing → running`; pool +1 running node. The live driver (follow-up) would stand up an actual Hetzner server. |
 | d | `domains.check` + `domains.buy` | **covered** | scaffold (skipped) | CF registrar dev-stub debits exactly $14.95 (1099¢ + 396¢ margin); buy `success && verified`. The live driver (follow-up) would use the real registrar. |
 | e | `apps.monetization.update` | **covered** | scaffold (skipped) | `PUT …/monetization` enables markup + purchase share; `GET …/monetization` reads back `monetizationEnabled: true`. |
-| f | Charge (paid inference billing) | **covered** | scaffold (skipped) | deterministic ledger effects through the real per-app billing service: `appCreditsService.deductCredits` computes markup from the app monetization config, debits base+markup from the org ledger, records app-scoped earnings, and raises the creator redeemable balance by exactly the computed markup. A REAL-LLM charge (end-user org debit + creator markup via Cerebras) is covered by [`creator-monetization-journey.spec.ts`](../tests/creator-monetization-journey.spec.ts) behind `CEREBRAS_API_KEY`. |
+| f | Charge (paid inference billing) | **covered** | scaffold (skipped) | deterministic ledger effects through the real per-app billing service: `appCreditsService.deductCredits` computes markup from the app monetization config, debits base+markup from the org ledger, records app-scoped earnings, and raises the creator redeemable balance by exactly the computed markup. The full `POST /api/v1/messages` + `x-app-id` HTTP seam (route → `calculateCostWithMarkup` → `generateText` → `billUsage` → `reconcileCredits`) runs **always-on, no paid key** in [`monetized-mock-llm-journey.spec.ts`](../tests/monetized-mock-llm-journey.spec.ts) via an in-process OpenAI mock (`stackOptions.mockLlm`, asserting the mock served the request so the charge is from real usage); the same seam against a REAL LLM (Cerebras) is in [`creator-monetization-journey.spec.ts`](../tests/creator-monetization-journey.spec.ts) behind `CEREBRAS_API_KEY`. |
 | g | Autoscale (daemon-driven) | **covered** | scaffold (skipped) | `node-autoscale` cron tick is observable, and the `agent-hot-pool` daemon cron tick **alone** replenishes the warm pool to its target (`replenishWarmPool`) — no test-enqueued provision job. The real Hetzner node `initializing → running` transition is asserted in step (c). |
 | h | Payout (fiat) | **covered** | scaffold (skipped) | the redeemable balance is the payout-readiness proxy, and a dedicated test exercises the full Stripe Connect fiat withdrawal: onboarding → account.updated webhook → ledger debit → transfer → **balance draws down by exactly the payout**, plus the compensating refund on a simulated Stripe failure and the `payout.paid` webhook. Runs against the live PGlite DB + real ledger/repo/service; only the Stripe SDK boundary is mocked (the injectable client). See #8922 below. |
 
@@ -97,6 +97,9 @@ bun run cloud:e2e
 
 # just the full loop (the registrar dev-stub is on by default via the env fixture)
 bun run cloud:e2e -- monetized-full-loop.spec.ts
+
+# the always-on real-HTTP-seam charge test (boots an in-process OpenAI mock; no key)
+bun run cloud:e2e -- monetized-mock-llm-journey.spec.ts
 ```
 
 Relevant env (defaulted by `src/fixtures/env.ts`, override to tune): `MOCK_HETZNER_ACTION_MS`


### PR DESCRIPTION
## What

Follow-through on #9531, which landed the always-on **keyless mock-LLM monetization journey** (`monetized-mock-llm-journey.spec.ts`) that drives the `POST /api/v1/messages` + `x-app-id` billing seam with no paid key — the last open item on #9477.

That spec runs per-PR (`cloud-e2e.yml` globs every spec), but two follow-through gaps remained:

1. **Nightly regression net.** The scheduled `showcase-mock` job — the one that catches monetization/billing drift even when no PR touches cloud paths — only ran `example-apps-showcase` + `monetized-full-loop`. This PR adds `monetized-mock-llm-journey.spec.ts` to that list so the messages-route billing seam is guarded by the scheduled net too.
2. **Docs.** The monetized-loop coverage doc step (f) didn't mention the keyless seam test. This PR documents it (plus a local run command) next to the CEREBRAS-gated real-LLM journey.

## Why this started as a dup

I independently built the same keyless mock-LLM seam test; mid-flight #9531 merged the equivalent to `develop`. After adversarially verifying the merged version is genuine (real `0.000016` org debit + `0.000008` markup→earnings, `mock.requestCount() > 0` asserting the HTTP seam actually ran — not a fabricated charge), I dropped my duplicate spec/mock and kept only these two additive improvements on top of it.

## Evidence

develop's merged spec runs green locally (keyless):
```
$ bun run cloud:e2e -- monetized-mock-llm-journey.spec.ts
[mock-journey] end-user debited 0.000015999999959603883 (before=1000 after=999.999984)
[mock-journey] creator redeemable 0->0, app_earnings 0->0.000008
  ✓  creator monetizes an app → end-user pays via mock inference → creator earns (2.5s)
  1 passed (20.6s)
```

## Scope

CI workflow + docs only. No production, spec, or fixture code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)