### PR TITLE
fix(vault): launch the Bitwarden CLI (.cmd shim) via shell on Windows

### DIFF
--- a/packages/vault/src/external-credentials.ts
+++ b/packages/vault/src/external-credentials.ts
@@ -276,6 +276,13 @@ export async function revealBitwardenLogin(
 ): Promise<ExternalLoginReveal> {
   if (!externalId)
     throw new TypeError("revealBitwardenLogin: externalId required");
+  // The id is interpolated into a shelled `bw get item <id>` on Windows (bw is
+  // a `.cmd` shim), so restrict it to Bitwarden's UUID charset — it can then
+  // carry no shell metacharacters. Bitwarden item ids are always UUIDs.
+  if (!/^[A-Za-z0-9-]+$/.test(externalId))
+    throw new TypeError(
+      `revealBitwardenLogin: invalid externalId "${externalId}"`,
+    );
   const session = await readSessionToken(vault, "bitwarden");
 
   const out = await exec("bw", ["get", "item", externalId], {
@@ -467,6 +474,12 @@ export function defaultExecFn(): ExecFn {
   // subprocesses if a test forgets to inject a test executor.
   return async (cmd, args, opts) => {
     const childProcess = await import("node:child_process");
+    // `bw` is installed on Windows as an npm `.cmd` shim (see install.ts), which
+    // Node's execFile cannot launch without a shell. `op`/`pass-cli` are real
+    // .exe and must NOT use a shell. The only dynamic arg reaching `bw` (the
+    // item id) is validated to a UUID charset by revealBitwardenLogin, so the
+    // win32 shell carries no injection surface.
+    const useShell = process.platform === "win32" && cmd === "bw";
     return new Promise((resolve, reject) => {
       const child = childProcess.execFile(
         cmd,
@@ -476,6 +489,7 @@ export function defaultExecFn(): ExecFn {
           timeout: opts.timeoutMs ?? 10_000,
           maxBuffer: 16 * 1024 * 1024,
           encoding: "utf8",
+          ...(useShell ? { shell: true } : {}),
         },
         (error, stdout, stderr) => {
           if (error) {

--- a/packages/vault/src/install.ts
+++ b/packages/vault/src/install.ts
@@ -162,7 +162,13 @@ export function resetInstallerCache(): void {
 
 async function isCommandRunnable(cmd: string): Promise<boolean> {
   try {
-    await exec(cmd, ["--version"], { timeout: 5000 });
+    await exec(cmd, ["--version"], {
+      timeout: 5000,
+      // npm is a `.cmd` shim on Windows; execFile can't launch it without a
+      // shell, so detection would wrongly report npm absent (and hide the only
+      // Windows Bitwarden install method). Args are static — no injection.
+      shell: process.platform === "win32",
+    });
     return true;
   } catch {
     return false;

--- a/packages/vault/src/manager.ts
+++ b/packages/vault/src/manager.ts
@@ -632,7 +632,8 @@ async function detectProtonPass(): Promise<BackendStatus> {
       available: false,
       signedIn: false,
       authMode: null,
-      detail: "`pass-cli` not installed. https://protonpass.github.io/pass-cli/",
+      detail:
+        "`pass-cli` not installed. https://protonpass.github.io/pass-cli/",
     };
   }
 
@@ -650,7 +651,9 @@ async function detectProtonPass(): Promise<BackendStatus> {
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (/not signed in|not authenticated|not logged in|login required/i.test(msg)) {
+    if (
+      /not signed in|not authenticated|not logged in|login required/i.test(msg)
+    ) {
       return {
         id: "protonpass",
         label: "Proton Pass",
@@ -689,6 +692,10 @@ async function detectBitwarden(vault: Vault): Promise<BackendStatus> {
       timeout: 3000,
       encoding: "utf8",
       env,
+      // bw is an npm `.cmd` shim on Windows (install.ts steers Windows users to
+      // `npm i -g @bitwarden/cli`); execFile can't launch it without a shell, so
+      // `where` finds it but `bw status` throws ENOENT. Args are static.
+      shell: process.platform === "win32",
     });
     const status = JSON.parse(stdout.trim()) as { status?: string };
     if (status.status === "unlocked") {


### PR DESCRIPTION
## Problem

The vault's own install guidance (`install.ts:103`) steers Windows users to install the Bitwarden CLI via `npm i -g @bitwarden/cli`, which produces a **`bw.cmd`** npm shim. But every `bw` invocation uses `execFile` with **no** `shell`, and Node's `execFile` cannot launch a `.cmd`/`.bat` on Windows (it throws `ENOENT`/`EINVAL` — CVE-2024-27980 hardening). So on Windows, even with the CLI installed, Bitwarden is completely non-functional:

- `manager.ts:688` `exec("bw", ["status"])` — `where` finds `bw.cmd` so detection *thinks* it's present, then `bw status` throws → always reports "`bw` may need an update" / signed-out → **gates the list/reveal adapters off**.
- `external-credentials.ts` `defaultExecFn` — `bw list items` / `bw get item <id>` throw, so listing/revealing saved logins fails.
- `install.ts:165` `exec("npm", ["--version"])` — npm is also `npm.cmd`; the probe wrongly reports npm absent, **hiding the only Windows Bitwarden install method** the UI can offer.

## Fix

Route the `.cmd`-shim commands through a shell on Windows only:

- `install.ts` — `shell: process.platform === "win32"` on the `--version` probe (static args).
- `manager.ts` — `shell: process.platform === "win32"` on `bw status` (static args).
- `external-credentials.ts` `defaultExecFn` — `shell` **only when** `process.platform === "win32" && cmd === "bw"`. `op`/`pass-cli` are real `.exe` (winget/MSI/manual) and stay unshelled.

**Injection safety:** the only dynamic arg that reaches a shelled `bw` is the item id in `bw get item <id>`. `revealBitwardenLogin` now validates `externalId` against Bitwarden's UUID charset (`/^[A-Za-z0-9-]+$/`) before the call, so it can carry no shell metacharacters. All other shelled args are static literals.

No behavior change off Windows (`shell` stays `false` everywhere).

## Evidence (verified on Windows 11)

- `vitest run external-credentials manager install` → **51 passed** (the UUID guard accepts existing test ids; op/pass-cli paths unchanged).
- Real end-to-end shell path: created a `bw.cmd` shim on PATH and called the production `defaultExecFn`:

```
exec("bw", ["status"])  ->  {"status":"unlocked"}   (PASS: bw.cmd launched via win32 shell path)
```

(Without the fix the same call throws `EINVAL`/`ENOENT`.) `biome lint` + `tsgo` clean. Found by an adversarially-verified Windows source sweep (follow-on to #9372 / #9374).