### PR TITLE
fix(browser): wire workspace error codes

### DIFF
--- a/plugins/plugin-browser/AGENTS.md
+++ b/plugins/plugin-browser/AGENTS.md
@@ -83,6 +83,7 @@ src/
     browser-workspace.ts           Public API surface and main command router (executeBrowserWorkspaceCommand)
     browser-workspace-types.ts     All workspace types and interfaces
     browser-workspace-state.ts     Mutable tab/session state
+    browser-workspace-errors.ts    Structured workspace error codes
     browser-workspace-helpers.ts   Utilities and command normalization
     browser-workspace-desktop.ts   Desktop bridge HTTP client
     browser-workspace-jsdom.ts     JSDOM document loading and DOM setup

--- a/plugins/plugin-browser/CLAUDE.md
+++ b/plugins/plugin-browser/CLAUDE.md
@@ -83,6 +83,7 @@ src/
     browser-workspace.ts           Public API surface and main command router (executeBrowserWorkspaceCommand)
     browser-workspace-types.ts     All workspace types and interfaces
     browser-workspace-state.ts     Mutable tab/session state
+    browser-workspace-errors.ts    Structured workspace error codes
     browser-workspace-helpers.ts   Utilities and command normalization
     browser-workspace-desktop.ts   Desktop bridge HTTP client
     browser-workspace-jsdom.ts     JSDOM document loading and DOM setup

--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -182,7 +182,24 @@ describe("browser workspace HTTP routes", () => {
 
     expect(res.statusCode).toBe(503);
     expect(res.body).toEqual({
+      code: "desktop_only",
       error: expect.stringContaining("browser workspace desktop bridge"),
+    });
+  });
+
+  it("returns structured browser workspace error codes from command failures", async () => {
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/browser-workspace/command",
+      body: { subaction: "navigate", url: "about:blank" },
+    });
+
+    await expect(handleBrowserWorkspaceRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({
+      code: "target_missing",
+      error: expect.stringContaining("requires a current tab"),
     });
   });
 

--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -8,6 +8,11 @@
 
 import type { IAgentRuntime, RouteRequestContext } from "@elizaos/core";
 import { requestBrowserWorkspace } from "../workspace/browser-workspace-desktop.js";
+import {
+  type BrowserWorkspaceErrorCode,
+  createBrowserWorkspaceError,
+  isBrowserWorkspaceError,
+} from "../workspace/browser-workspace-errors.js";
 import { assertBrowserWorkspaceUserScriptAllowed } from "../workspace/browser-workspace-helpers.js";
 import type { BrowserWorkspaceEventLogSnapshot } from "../workspace/browser-workspace-types.js";
 import {
@@ -70,10 +75,42 @@ export interface BrowserWorkspaceRouteContext extends RouteRequestContext {
   };
 }
 
+function statusFromBrowserWorkspaceErrorCode(
+  code: BrowserWorkspaceErrorCode,
+  message: string,
+): number {
+  switch (code) {
+    case "invalid_url":
+    case "unknown_element_ref":
+      return 400;
+    case "tab_not_found":
+      return 404;
+    case "target_missing":
+      return 409;
+    case "desktop_only":
+      return message.includes(getBrowserWorkspaceUnavailableMessage())
+        ? 503
+        : 409;
+    case "script_forbidden":
+    case "connector_secret_export_forbidden":
+      return 403;
+    case "timeout":
+      return 504;
+    case "command_failed":
+      return 500;
+  }
+}
+
 function statusFromBrowserWorkspaceError(
   error: unknown,
   message: string,
 ): number {
+  if (isBrowserWorkspaceError(error)) {
+    return statusFromBrowserWorkspaceErrorCode(
+      error.browserWorkspaceErrorCode,
+      message,
+    );
+  }
   if (
     error instanceof Error &&
     "status" in error &&
@@ -181,7 +218,11 @@ export async function handleBrowserWorkspaceRoutes(
 
     if (pathname === "/api/browser-workspace/events" && method === "GET") {
       if (!isBrowserWorkspaceBridgeConfigured()) {
-        throw new Error(getBrowserWorkspaceUnavailableMessage());
+        throw createBrowserWorkspaceError(
+          "desktop_only",
+          "events",
+          getBrowserWorkspaceUnavailableMessage(),
+        );
       }
       json(
         res,
@@ -354,7 +395,13 @@ export async function handleBrowserWorkspaceRoutes(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const status = statusFromBrowserWorkspaceError(error, message);
-    json(res, { error: message }, status);
+    const body: { code?: BrowserWorkspaceErrorCode; error: string } = {
+      error: message,
+    };
+    if (isBrowserWorkspaceError(error)) {
+      body.code = error.browserWorkspaceErrorCode;
+    }
+    json(res, body, status);
     return true;
   }
 }

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
-  assertBrowserWorkspaceConnectorSecretsNotExported,
-  assertBrowserWorkspaceUrl,
-  createBrowserWorkspaceCommandTargetError,
-  createBrowserWorkspaceDesktopOnlyMessage,
-  createBrowserWorkspaceJsdomScriptExecutionError,
-  createBrowserWorkspaceNotFoundError,
-} from "../browser-workspace-helpers.ts";
-import {
   type BrowserWorkspaceErrorCode,
   classifyBrowserWorkspaceErrorCode,
   createBrowserWorkspaceError,
   isBrowserWorkspaceError,
   tagBrowserWorkspaceError,
 } from "../browser-workspace-errors.ts";
+import {
+  assertBrowserWorkspaceConnectorSecretsNotExported,
+  assertBrowserWorkspaceUrl,
+  createBrowserWorkspaceCommandTargetError,
+  createBrowserWorkspaceDesktopOnlyMessage,
+  createBrowserWorkspaceJsdomScriptExecutionError,
+  createBrowserWorkspaceNotFoundError,
+  resolveBrowserWorkspaceCommandElementRefs,
+} from "../browser-workspace-helpers.ts";
 
 /** Capture the Error thrown by a thunk. */
 function thrown(fn: () => unknown): unknown {
@@ -23,6 +24,19 @@ function thrown(fn: () => unknown): unknown {
     return e;
   }
   throw new Error("expected the thunk to throw");
+}
+
+function expectBrowserWorkspaceError(
+  error: unknown,
+  code: BrowserWorkspaceErrorCode,
+  operation: string,
+): void {
+  expect(isBrowserWorkspaceError(error)).toBe(true);
+  if (!isBrowserWorkspaceError(error)) {
+    throw new Error("expected BrowserWorkspaceError");
+  }
+  expect(error.browserWorkspaceErrorCode).toBe(code);
+  expect(error.operation).toBe(operation);
 }
 
 describe("classifyBrowserWorkspaceErrorCode", () => {
@@ -72,7 +86,9 @@ describe("classifyBrowserWorkspaceErrorCode", () => {
 
 describe("tagBrowserWorkspaceError", () => {
   it("annotates an existing Error in place, preserving message + identity", () => {
-    const original = createBrowserWorkspaceNotFoundError("tab-9");
+    const original = new Error(
+      "Browser workspace request failed (404): Tab tab-9 was not found.",
+    );
     const tagged = tagBrowserWorkspaceError(original, "navigate");
     expect(tagged).toBe(original); // same object
     expect(tagged.message).toBe(original.message); // message preserved
@@ -109,5 +125,51 @@ describe("tagBrowserWorkspaceError", () => {
     expect(e.browserWorkspaceErrorCode).toBe("timeout");
     expect(e.operation).toBe("wait");
     expect(e.details).toBe("underlying");
+  });
+});
+
+describe("helper-created BrowserWorkspaceError values", () => {
+  it("creates typed errors at helper boundaries", () => {
+    expectBrowserWorkspaceError(
+      thrown(() => assertBrowserWorkspaceUrl("ftp://x.test")),
+      "invalid_url",
+      "url_validation",
+    );
+    expectBrowserWorkspaceError(
+      createBrowserWorkspaceNotFoundError("tab-1"),
+      "tab_not_found",
+      "tab_lookup",
+    );
+    expectBrowserWorkspaceError(
+      createBrowserWorkspaceCommandTargetError("navigate"),
+      "target_missing",
+      "navigate",
+    );
+    expectBrowserWorkspaceError(
+      createBrowserWorkspaceJsdomScriptExecutionError("eval"),
+      "script_forbidden",
+      "eval",
+    );
+    expectBrowserWorkspaceError(
+      thrown(() =>
+        assertBrowserWorkspaceConnectorSecretsNotExported(
+          "persist:connector-gmail",
+          "export-cookies",
+        ),
+      ),
+      "connector_secret_export_forbidden",
+      "export-cookies",
+    );
+    expectBrowserWorkspaceError(
+      thrown(() =>
+        resolveBrowserWorkspaceCommandElementRefs(
+          { selector: "@e7", subaction: "click" },
+          "web",
+          "tab-1",
+        ),
+      ),
+      "unknown_element_ref",
+      "element_ref",
+    );
   });
 });

--- a/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
@@ -1,3 +1,4 @@
+import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";
 import {
   assertBrowserWorkspaceConnectorSecretsNotExported,
   assertBrowserWorkspaceUserScriptAllowed,
@@ -74,7 +75,11 @@ export async function requestBrowserWorkspace<T>(
 ): Promise<T> {
   const config = resolveBrowserWorkspaceBridgeConfig(env);
   if (!config) {
-    throw new Error(getBrowserWorkspaceUnavailableMessage());
+    throw createBrowserWorkspaceError(
+      "desktop_only",
+      "desktop_bridge",
+      getBrowserWorkspaceUnavailableMessage(),
+    );
   }
 
   const headers = new Headers(init?.headers ?? {});
@@ -94,8 +99,12 @@ export async function requestBrowserWorkspace<T>(
 
   if (!response.ok) {
     const details = await readErrorBody(response);
-    throw new Error(
-      `Browser workspace request failed (${response.status})${details ? `: ${details}` : ""}`,
+    const message = `Browser workspace request failed (${response.status})${details ? `: ${details}` : ""}`;
+    throw createBrowserWorkspaceError(
+      response.status === 404 ? "tab_not_found" : "command_failed",
+      path,
+      message,
+      details || undefined,
     );
   }
 
@@ -107,7 +116,9 @@ export async function evaluateBrowserWorkspaceTab(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<unknown> {
   if (!isBrowserWorkspaceBridgeConfigured(env)) {
-    throw new Error(
+    throw createBrowserWorkspaceError(
+      "desktop_only",
+      "eval",
       "Eliza browser workspace eval is only available in the desktop app.",
     );
   }
@@ -135,7 +146,9 @@ export async function snapshotBrowserWorkspaceTab(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ data: string }> {
   if (!isBrowserWorkspaceBridgeConfigured(env)) {
-    throw new Error(
+    throw createBrowserWorkspaceError(
+      "desktop_only",
+      "snapshot",
       "Eliza browser workspace snapshot is only available in the desktop app.",
     );
   }

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -1,5 +1,6 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";
 import { resolveBrowserWorkspaceElementRef } from "./browser-workspace-state.js";
 import type {
   BrowserWorkspaceCommand,
@@ -53,11 +54,17 @@ export function assertBrowserWorkspaceUrl(rawUrl: string): string {
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error(`browser workspace rejected invalid URL: ${rawUrl}`);
+    throw createBrowserWorkspaceError(
+      "invalid_url",
+      "url_validation",
+      `browser workspace rejected invalid URL: ${rawUrl}`,
+    );
   }
 
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(
+    throw createBrowserWorkspaceError(
+      "invalid_url",
+      "url_validation",
       `browser workspace only supports http/https URLs, got ${parsed.protocol}`,
     );
   }
@@ -158,7 +165,9 @@ export function assertBrowserWorkspaceConnectorSecretsNotExported(
   if (!isConnectorBrowserWorkspacePartition(partition)) {
     return;
   }
-  throw new Error(
+  throw createBrowserWorkspaceError(
+    "connector_secret_export_forbidden",
+    operation,
     `Connector browser sessions do not allow raw cookie, token, storage, or state export (${operation}). Use the returned partition/profile/session handle instead.`,
   );
 }
@@ -170,7 +179,9 @@ export function createBrowserWorkspaceDesktopOnlyMessage(
 }
 
 export function createBrowserWorkspaceNotFoundError(tabId: string): Error {
-  return new Error(
+  return createBrowserWorkspaceError(
+    "tab_not_found",
+    "tab_lookup",
     `Browser workspace request failed (404): Tab ${tabId} was not found.`,
   );
 }
@@ -178,7 +189,9 @@ export function createBrowserWorkspaceNotFoundError(tabId: string): Error {
 export function createBrowserWorkspaceCommandTargetError(
   subaction: BrowserWorkspaceSubaction,
 ): Error {
-  return new Error(
+  return createBrowserWorkspaceError(
+    "target_missing",
+    subaction,
     `Eliza browser workspace ${subaction} requires a current tab. Open or show a tab first, or pass an explicit id.`,
   );
 }
@@ -249,7 +262,9 @@ export function resolveBrowserWorkspaceCommandElementRefs(
     match[1],
   );
   if (!resolvedSelector) {
-    throw new Error(
+    throw createBrowserWorkspaceError(
+      "unknown_element_ref",
+      "element_ref",
       `Unknown browser snapshot element ref ${match[1]}. Run snapshot or inspect again before reusing element refs.`,
     );
   }
@@ -297,7 +312,9 @@ export function assertBrowserWorkspaceUserScriptAllowed(
       context === "eval"
         ? "Eval subactions with a user `script` are disabled by default."
         : "Wait conditions with a user `script` are disabled by default.";
-    throw new Error(
+    throw createBrowserWorkspaceError(
+      "script_forbidden",
+      context,
       `${BROWSER_WORKSPACE_USER_SCRIPT_FORBIDDEN} ${suffix} Set ELIZA_BROWSER_WORKSPACE_ALLOW_USER_SCRIPT=1 only on trusted single-user hosts.`,
     );
   }
@@ -310,7 +327,11 @@ export function createBrowserWorkspaceJsdomScriptExecutionError(
     context === "eval"
       ? "Eval subactions are not supported on the web backend."
       : "Wait conditions with `script` are not supported on the web backend.";
-  return new Error(`${BROWSER_WORKSPACE_JSDOM_SCRIPT_FORBIDDEN} ${suffix}`);
+  return createBrowserWorkspaceError(
+    "script_forbidden",
+    context,
+    `${BROWSER_WORKSPACE_JSDOM_SCRIPT_FORBIDDEN} ${suffix}`,
+  );
 }
 
 export function assertBrowserWorkspaceJsdomScriptNotRequested(


### PR DESCRIPTION
## Summary
- Wire the browser workspace error contract into helper-created failures so action and route callers receive stable `browserWorkspaceErrorCode` values instead of parsing messages.
- Surface typed workspace `code` values from `/api/browser-workspace/*` error responses and map typed codes to HTTP statuses.
- Extend workspace error and route tests; document the structured error module in the browser package guide.

## Verification
- `git fetch origin && git rebase origin/develop` onto `05a48a2af5`
- `bun install`
- `bunx @biomejs/biome check plugins/plugin-browser/AGENTS.md plugins/plugin-browser/CLAUDE.md plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts plugins/plugin-browser/src/routes/workspace.ts plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts plugins/plugin-browser/src/routes/workspace-routes.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run --cwd plugins/plugin-browser test -- src/workspace/__tests__/browser-workspace-errors.test.ts src/routes/workspace-routes.test.ts` - 2 files, 30 tests passed
- `bun run --cwd plugins/plugin-browser test` - 22 files, 122 tests passed
- `bun run --cwd plugins/plugin-browser typecheck`
- `bun run --cwd plugins/plugin-browser build`
- `bun run verify` - attempted on the latest rebased branch; currently blocked by unrelated current `develop` `@elizaos/cloud-e2e#typecheck` in `packages/test/cloud-e2e/src/fixtures/mock-llm.ts:54` (`RequestListener<...> | undefined` does not satisfy `(...args: any) => any`), after 427/445 tasks in this run.

N/A: screenshots/video/real-LLM trajectories, because this is a typed route/helper error contract change with no UI or LLM behavior.
