### PR TITLE
fix(cloud): pricing-catalog fetch failure must not 500 inference (cerebras 404 — LIVE OUTAGE)

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../../utils/logger";
 import type { PreparedPricingEntry, PriceLookupSource } from "../types";
 import { fetchAtlasCloudCatalogEntries } from "./atlascloud";
 import { fetchBitRouterCatalogEntries } from "./bitrouter";
@@ -7,7 +8,7 @@ import { fetchFalCatalogEntries } from "./fal";
 import { fetchSunoEntries } from "./suno";
 import { fetchVastSnapshotEntries } from "./vast";
 
-export async function fetchEntriesForSource(
+async function dispatchEntriesForSource(
   source: PriceLookupSource,
 ): Promise<PreparedPricingEntry[]> {
   switch (source) {
@@ -34,5 +35,24 @@ export async function fetchEntriesForSource(
       return [];
     default:
       return [];
+  }
+}
+
+export async function fetchEntriesForSource(
+  source: PriceLookupSource,
+): Promise<PreparedPricingEntry[]> {
+  // External pricing-catalog fetches are best-effort METADATA. A provider
+  // outage — e.g. Cerebras retiring its public `/public/v1/models?format=openrouter`
+  // endpoint (now 404) — must degrade pricing, never propagate and 500 the
+  // inference path that prices a completion. Fall back to no fresh entries;
+  // cached/seed pricing still applies.
+  try {
+    return await dispatchEntriesForSource(source);
+  } catch (error) {
+    logger.warn("[AI Pricing] external catalog fetch failed; using cached/seed pricing", {
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
   }
 }


### PR DESCRIPTION
## 🔴 Live prod outage — cloud chat down for all cerebras (gpt-oss) users

Measured just now on prod:
```
POST https://api.elizacloud.ai/api/v1/chat/completions  →  HTTP 500
{"error":{"message":"Request failed for https://api.cerebras.ai/public/v1/models?format=openrouter: 404","type":"api_error"}}
```
Dedicated agents are healthy (their `/api/health` returns 200) but every completion 500s, so agents reply **"Sorry, I'm having a provider issue."** (Caught on-device on Seeker during launch QA.)

## Root cause
Cerebras **retired its unauthenticated public-models catalog**. All variants now 404 (`/public/v1/models?format=openrouter`, `/public/v1/models`); `/v1/models` is auth-only with no openrouter-format pricing — there is **no drop-in URL replacement**.

`fetchCerebrasPublicCatalogEntries()` (`ai-pricing/providers/cerebras.ts`) throws on that 404, and the throw propagates out of `fetchEntriesForSource` **uncaught**, all the way to the chat-completion handler → 500. A best-effort **pricing-metadata** fetch is taking down **inference**.

## Fix
Wrap the provider dispatch in `fetchEntriesForSource` (the single choke point for all external pricing sources) so **any** provider outage — cerebras today, BitRouter/fal/suno/elevenlabs tomorrow — logs a warning and returns no fresh entries. Cached/seed pricing still applies and the completion proceeds. This is the architectural invariant: external pricing-catalog availability must never gate inference.

```
try { return await dispatchEntriesForSource(source); }
catch (error) { logger.warn("[AI Pricing] external catalog fetch failed; using cached/seed pricing", {source, error}); return []; }
```

## Verification
- Repro: the prod 500 above, with the exact cerebras URL in the error.
- Endpoint probe: `/public/v1/models?format=openrouter` → 404, `/public/v1/models` → 404, `/v1/models` → 403 (auth-only) — confirms the public catalog is gone.
- `bun run --cwd packages/cloud-shared typecheck` clean for the file; biome clean.
- Post-deploy check: `POST /api/v1/chat/completions {model:"gpt-oss-120b"}` should 200 instead of 500.

## ⚠️ Needs urgent prod Worker deploy
This is in `cloud-shared` (consumed by the `cloud-api` Worker) — it only takes effect after a Worker redeploy (`cloud-cf-deploy`, production). @cloud-agent / @standujar — this is the cloud lane; requesting an urgent deploy once merged (or fast-track). 

**Follow-up (not launch-blocking):** restore a fresh cerebras price source via authenticated `/v1/models` + a pricing map, since the public catalog is gone.