### PR TITLE
fix(health): tag health_checkin planner trajectory with its own task (#8795)

### DIFF
--- a/plugins/plugin-health/src/actions/health.test.ts
+++ b/plugins/plugin-health/src/actions/health.test.ts
@@ -1,10 +1,28 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+
+// The health planner routes its instructions through
+// `resolveOptimizedPromptForRuntime`. Pin it to the identity (return the
+// baseline) so this unit test of the trajectory `purpose` tag is hermetic and
+// does not depend on the OptimizedPromptService resolution in the test env.
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    resolveOptimizedPromptForRuntime: (
+      _runtime: unknown,
+      _task: unknown,
+      baseline: string,
+    ) => baseline,
+  };
+});
+
 import {
   createHealthActionRunner,
   createOwnerHealthAction,
   HEALTH_PARAMETERS,
   HEALTH_SIMILES,
+  type HealthActionRunJsonModelArgs,
   type HealthActionService,
 } from "./health.js";
 
@@ -65,6 +83,72 @@ describe("health action runner", () => {
     });
     expect(validate).toHaveBeenCalled();
     expect(handler).toHaveBeenCalled();
+  });
+
+  it("tags the planner LLM call with the health_checkin trajectory purpose (#8795)", async () => {
+    // A natural-language health request with NO explicit subaction routes
+    // through resolveHealthPlanWithLlm → runJsonModel. The trajectory purpose
+    // must be "health_checkin" (not the generic "planner") so it buckets into
+    // the health_checkin training dataset that feeds the optimization loop —
+    // matching the resolveOptimizedPromptForRuntime("health_checkin", ...) call.
+    const runJsonModel = vi.fn(
+      async (
+        _args: HealthActionRunJsonModelArgs,
+      ): Promise<{ parsed: Record<string, unknown> }> => ({
+        parsed: {
+          subaction: "status",
+          metric: null,
+          days: null,
+          shouldAct: true,
+        },
+      }),
+    );
+    const runner = createHealthActionRunner({
+      hasAccess: async () => true,
+      createService: () => ({
+        getHealthConnectorStatus: vi.fn(async () => ({
+          available: false,
+          backend: "none" as const,
+        })),
+        getHealthSummary: vi.fn(async () => ({
+          providers: [],
+          summaries: [],
+          samples: [],
+          workouts: [],
+          sleepEpisodes: [],
+          syncedAt: "2026-05-30T12:00:00.000Z",
+        })),
+        getHealthTrend: vi.fn(),
+        getHealthDataPoints: vi.fn(),
+        getHealthDailySummary: vi.fn(),
+      }),
+      messageText: (m) =>
+        typeof m.content.text === "string" ? m.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      recentConversationTexts: async () => [],
+      runJsonModel,
+    });
+
+    // resolveHealthPlanWithLlm short-circuits unless runtime.useModel exists.
+    const plannerRuntime = {
+      logger: { warn: vi.fn() },
+      useModel: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    // No `subaction` in options → the planner LLM call fires.
+    await runner(
+      plannerRuntime,
+      { content: { text: "how have i been sleeping lately" } } as Memory,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(runJsonModel).toHaveBeenCalledTimes(1);
+    expect(runJsonModel.mock.calls[0][0]).toMatchObject({
+      purpose: "health_checkin",
+      actionType: "HEALTH.plan",
+    });
   });
 
   it("runs status through injected service and renderer adapters", async () => {

--- a/plugins/plugin-health/src/actions/health.ts
+++ b/plugins/plugin-health/src/actions/health.ts
@@ -221,7 +221,12 @@ async function resolveHealthPlanWithLlm(args: {
     failureMessage: "Health planning model call failed",
     source: "action:health",
     modelType: ModelType.TEXT_SMALL,
-    purpose: "planner",
+    // Tag this trajectory with the `health_checkin` LifeOps task (#8795) so it
+    // buckets into the health_checkin training dataset — matching the
+    // resolveOptimizedPromptForRuntime task above. The generic "planner" tag
+    // normalizes to no known training task and was dropped on ingest, so the
+    // health_checkin optimization loop collected zero real trajectories.
+    purpose: "health_checkin",
   });
   const parsed = result?.parsed;
   if (!parsed) {


### PR DESCRIPTION
## The bug (data-collection end of the health_checkin optimization loop was dead)

The health planner's sole LLM call (`resolveHealthPlanWithLlm` → `runJsonModel`, `plugins/plugin-health/src/actions/health.ts`) already routes its instructions through `resolveOptimizedPromptForRuntime(runtime, "health_checkin", …)` — but it recorded the trajectory with `purpose: "planner"`.

On ingest (`plugins/plugin-training/src/core/trajectory-task-datasets.ts`), the task is resolved as `task_type ?? purpose ?? stepType ?? actionType`, then `if (!task || !requestedTasks.has(task)) continue`. And:
- `normalizeTrainingTask("planner")` → **null** (it is not `action_planner`; "planner" is not in the training-task set),
- `actionType: "HEALTH.plan"` → also **null**.

So the row was **dropped entirely**. The `health_checkin` capability is wired for *prompt loading* (it reads the optimized artifact) but collected **zero real trajectories** to ever optimize from — the GEPA/dataset loop for this capability was dead at the data-collection end.

## The fix

Tag the call `purpose: "health_checkin"` so it buckets into the `health_checkin` dataset — matching the **5 other wired LifeOps consumers**, each of which already tags `purpose ==` its optimized-prompt task:

| consumer | task | purpose tag |
|---|---|---|
| service-mixin-reminders.ts:1393 | reminder_dispatch | ✅ |
| extract-gmail-plan.ts:86/101 | inbox_triage | ✅ |
| brief.ts:505 | morning_brief | ✅ |
| scheduling-handler.ts:909 | schedule_plan | ✅ |
| **health.ts (this PR)** | **health_checkin** | ✅ (was `"planner"`) |

(This is the one-line tagging fix the maintainer flagged in the #8795 thread.)

## Test

Adds the **first** unit test that drives the health planner path — `resolveHealthPlanWithLlm` was previously never exercised (every existing health test hits the explicit-subaction fast-path). It asserts the planner LLM call is tagged `purpose: "health_checkin"` / `actionType: "HEALTH.plan"`, and pins `resolveOptimizedPromptForRuntime` to identity so the unit is hermetic.

`bun run --cwd plugins/plugin-health test` → **14/14**; typecheck (plugin-health) + biome clean. Touches only `plugin-health`.

Part of a deeper #8795 audit pass (full research report to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)