### PR TITLE
fix(coding-tools): cross-platform source search/list (PowerShell on Windows)

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -645,6 +645,7 @@ describeIfPosix("shellAction", () => {
       messageText:
         "does the vendored opencode source include Cerebras endpoint detection? concise",
       command: 'grep -R "Cerebras" /home/example -n 2>/dev/null | head -n 20',
+      platform: "linux",
     });
 
     expect(result.rewritten).toBe(true);
@@ -664,6 +665,7 @@ describeIfPosix("shellAction", () => {
       messageText:
         "does the local vendored opencode source include gpt-oss Cerebras reasoning replay handling? answer with what you find",
       command: "find /home/example -type d -name '*opencode*' 2>/dev/null",
+      platform: "linux",
     });
 
     expect(result.rewritten).toBe(true);
@@ -680,6 +682,7 @@ describeIfPosix("shellAction", () => {
       messageText:
         "does the local vendored opencode source include gpt-oss Cerebras reasoning replay handling? answer with what you find",
       command: "ls -R . | head -n 50",
+      platform: "linux",
     });
 
     expect(result.rewritten).toBe(true);
@@ -697,6 +700,7 @@ describeIfPosix("shellAction", () => {
       messageText:
         "does the local vendored opencode source include gpt-oss Cerebras reasoning replay handling? answer with what you find",
       command: "ls -R /home/example | grep -i opencode -n",
+      platform: "linux",
     });
 
     expect(result.rewritten).toBe(true);
@@ -714,6 +718,7 @@ describeIfPosix("shellAction", () => {
         "does the local vendored opencode source include gpt-oss Cerebras reasoning replay handling? answer with what you find",
       command:
         'grep -R "cerebrasReasoning" -n plugins/plugin-agent-orchestrator/vendor/opencode | head -n 20',
+      platform: "linux",
     });
 
     expect(result.rewritten).toBe(true);
@@ -1206,6 +1211,43 @@ describe("platform-aware canned resource commands", () => {
     it("resolves the host shell to a known platform dialect", () => {
       const platform: CommandPlatform = resolveCommandPlatform();
       expect(["windows", "macos", "linux"]).toContain(platform);
+    });
+  });
+
+  describe("windows (PowerShell) source inspection", () => {
+    it("rewrites a broad source grep to a PowerShell git-grep/rg/Select-String chain (no POSIX find)", () => {
+      const result = resolveSourceInspectionCommand({
+        messageText:
+          "does the vendored opencode source include Cerebras endpoint detection? concise",
+        command: 'grep -R "Cerebras" /home/example -n 2>/dev/null | head -n 20',
+        platform: "windows",
+      });
+      expect(result.rewritten).toBe(true);
+      expect(result.command).toContain("git grep -n --recurse-submodules");
+      expect(result.command).toContain("Get-Command rg");
+      expect(result.command).toContain("Select-String");
+      expect(result.command).toContain("$LASTEXITCODE");
+      expect(result.command).toContain("'Cerebras'");
+      // none of the POSIX-only forms survive
+      expect(result.command).not.toContain("command -v");
+      expect(result.command).not.toContain("2>/dev/null");
+      expect(result.command).not.toContain("|| true");
+      expect(result.command).not.toContain('[ -d "$SEARCH_ROOT" ]');
+    });
+
+    it("rewrites a broad source directory walk to a PowerShell Get-ChildItem listing (no sed)", () => {
+      const result = resolveSourceInspectionCommand({
+        messageText:
+          "does the local vendored opencode source include gpt-oss Cerebras reasoning replay handling? answer with what you find",
+        command: "find /home/example -type d -name '*opencode*' 2>/dev/null",
+        platform: "windows",
+      });
+      expect(result.rewritten).toBe(true);
+      expect(result.command).toContain("Get-ChildItem");
+      expect(result.command).toContain("-notmatch");
+      expect(result.command).toContain("node_modules");
+      expect(result.command).not.toContain("sed -n");
+      expect(result.command).not.toContain('find "$SEARCH_ROOT"');
     });
   });
 });

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -510,7 +510,72 @@ function usesBroadSourceDirectoryWalk(command: string): boolean {
   );
 }
 
-function boundedSourceListCommand(root: string): string {
+function pwshSingleQuote(token: string): string {
+  // PowerShell single-quoted string: only the single quote needs escaping
+  // (doubled). No variable/subexpression expansion happens inside.
+  return `'${token.replace(/'/g, "''")}'`;
+}
+
+const SOURCE_EXCLUDE_DIRS = [
+  ".git",
+  "node_modules",
+  "dist",
+  ".turbo",
+  ".cache",
+  "coverage",
+  ".next",
+] as const;
+
+// PowerShell `-notmatch` regex (emitted inside a single-quoted string, so the
+// backslashes stay literal): match any excluded directory as a `\`- or `/`-
+// delimited path segment.
+function pwshSourceExcludeRegex(): string {
+  const alt = SOURCE_EXCLUDE_DIRS.map((dir) => dir.replace(/\./g, "\\.")).join(
+    "|",
+  );
+  return `'[\\\\/](${alt})[\\\\/]'`;
+}
+
+// --- Windows (PowerShell) source list/search. The SHELL action dispatches to
+// PowerShell on Windows (resolveHostShell), where the POSIX `find` / `if … fi`
+// / `command -v` forms below do not run. `git`/`rg` are the same cross-platform
+// binaries; only the control flow and the find/grep fallback are reshaped. The
+// output keeps the `path:line:match` shape the agent already reads. ---
+function boundedSourceListCommandPwsh(root: string): string {
+  return [
+    `$root = ${pwshSingleQuote(root)}`,
+    "if (-not (Test-Path -LiteralPath $root)) { $root = '.' }",
+    `Get-ChildItem -LiteralPath $root -Recurse -Depth 4 -File -Force -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch ${pwshSourceExcludeRegex()} } | Select-Object -First 120 -ExpandProperty FullName`,
+  ].join("\n");
+}
+
+function boundedSourceSearchCommandPwsh(pattern: string, root: string): string {
+  const quotedPattern = pwshSingleQuote(pattern);
+  const gitExcludes = SOURCE_SEARCH_EXCLUDES.map((glob) =>
+    pwshSingleQuote(`:(exclude)${glob.slice(1)}`),
+  ).join(" ");
+  const rgGlobs = SOURCE_SEARCH_EXCLUDES.map(
+    (glob) => `--glob ${pwshSingleQuote(glob)}`,
+  ).join(" ");
+  return [
+    `$root = ${pwshSingleQuote(root)}`,
+    "if (-not (Test-Path -LiteralPath $root)) { $root = '.' }",
+    "git rev-parse --show-toplevel 2>$null | Out-Null",
+    "if ($LASTEXITCODE -eq 0) {",
+    `  git grep -n --recurse-submodules -- ${quotedPattern} -- $root ${gitExcludes}`,
+    "} elseif (Get-Command rg -ErrorAction SilentlyContinue) {",
+    `  rg -n --hidden ${rgGlobs} -- ${quotedPattern} $root`,
+    "} else {",
+    `  Get-ChildItem -LiteralPath $root -Recurse -File -Force -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch ${pwshSourceExcludeRegex()} } | Select-String -Pattern ${quotedPattern} -List -ErrorAction SilentlyContinue | Select-Object -First 200 | ForEach-Object { "$($_.Path):$($_.LineNumber):$($_.Line)" }`,
+    "}",
+  ].join("\n");
+}
+
+function boundedSourceListCommand(
+  root: string,
+  platform: CommandPlatform,
+): string {
+  if (platform === "windows") return boundedSourceListCommandPwsh(root);
   const quotedRoot = shellSingleQuote(root);
   const findPrunes = [
     "*/.git/*",
@@ -530,7 +595,14 @@ function boundedSourceListCommand(root: string): string {
   ].join(" ");
 }
 
-function boundedSourceSearchCommand(pattern: string, root: string): string {
+function boundedSourceSearchCommand(
+  pattern: string,
+  root: string,
+  platform: CommandPlatform,
+): string {
+  if (platform === "windows") {
+    return boundedSourceSearchCommandPwsh(pattern, root);
+  }
   const quotedPattern = shellSingleQuote(pattern);
   const quotedRoot = shellSingleQuote(root);
   const gitExcludes = SOURCE_SEARCH_EXCLUDES.map((glob) =>
@@ -566,10 +638,12 @@ function boundedSourceSearchCommand(pattern: string, root: string): string {
 export function resolveSourceInspectionCommand(args: {
   command: string;
   messageText: string;
+  platform?: CommandPlatform;
 }): SourceInspectionCommandResolution {
   if (!asksForLocalSourceInspection(args.messageText)) {
     return { command: args.command, rewritten: false };
   }
+  const platform = args.platform ?? resolveCommandPlatform();
   const root = sourceInspectionRoot(args.messageText);
   const pattern = broadRecursiveGrepPattern(args.command);
   if (!pattern) {
@@ -577,12 +651,12 @@ export function resolveSourceInspectionCommand(args: {
       return { command: args.command, rewritten: false };
     }
     return {
-      command: boundedSourceListCommand(root),
+      command: boundedSourceListCommand(root, platform),
       rewritten: true,
     };
   }
   return {
-    command: boundedSourceSearchCommand(pattern, root),
+    command: boundedSourceSearchCommand(pattern, root, platform),
     rewritten: true,
   };
 }


### PR DESCRIPTION
## Problem

Follow-on to #9514 (which made the memory/disk/health canned commands cross-platform). The SHELL action also canonicalizes broad source *search* and *list* requests to canned commands — but those two were still **POSIX-only**:

```sh
# boundedSourceSearchCommand
if git rev-parse --show-toplevel >/dev/null 2>&1; then git grep … ;
elif command -v rg >/dev/null 2>&1; then rg … ;
else find "$SEARCH_ROOT" \( … \) -prune -o -type f -exec grep … ; fi
# boundedSourceListCommand
find "$SEARCH_ROOT" -maxdepth 5 \( … \) -prune -o -type f -print | sed -n '1,120p'
```

On Windows the SHELL action dispatches to **PowerShell** (`resolveHostShell()`), where `if … fi`, `[ -d … ]`, `command -v`, `>/dev/null`, `find`, and `sed` are all invalid — so an agent asked to "search/grep the local source" on Windows got a command that errored out.

## Fix

`boundedSourceSearchCommand`/`boundedSourceListCommand` are now platform-aware (mirroring #9514), and `resolveSourceInspectionCommand` threads the resolved `CommandPlatform`:

- **windows** — PowerShell: `git rev-parse` guarded by `$LASTEXITCODE` → `git grep` (git is cross-platform); else `Get-Command rg` → `rg`; else `Get-ChildItem -Recurse | Where-Object {-notmatch <excludes>} | Select-String`. The list path uses `Get-ChildItem … | Where-Object … | Select-Object -First 120`. Output keeps the same `path:line:match` shape the agent already reads, and the same VCS/build-dir exclusions.
- **macos / linux** — byte-for-byte the previous POSIX commands (git/rg/find all exist there; no behavior change).

Argument quoting uses a PowerShell single-quote helper (`pwshSingleQuote`); the search pattern and root are the same already-bounded values the POSIX path uses.

## Evidence (verified on Windows 11)

The generated PowerShell commands were dispatched **exactly** as `run-shell` does (`powershell.exe -NoProfile -NonInteractive -Command <single argv>`) against the real repo:

```
SEARCH  exit 0  | 135 lines | e.g. plugins/plugin-agent-orchestrator/vendor/opencode/.../models-snapshot.js:132  (correct path:line:match)
LIST    exit 0  |  59 files | excludes node_modules ✓  excludes .git ✓
```

New platform-parameterized tests (run on every OS incl. win32; the POSIX suite stays skipped on Windows): the existing 5 POSIX source-inspection tests are pinned to `platform: "linux"` for determinism, plus 2 new Windows tests assert the PowerShell git-grep/rg/Select-String + Get-ChildItem shapes. `bash.test.ts` → 10 passed / 43 skipped. `lint` + `format` + `typecheck` clean.