### PR TITLE
fix(app-core): build desktop renderer fallback URL with pathToFileURL (Windows)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   formatError,
   resolveApiToken,
@@ -929,8 +930,12 @@ async function resolveRendererUrl(): Promise<string> {
   }
 
   if (!rendererUrl) {
-    // Last resort: file:// (may have CORS issues with crossorigin module scripts)
-    rendererUrl = `file://${path.join(resolveRendererAssetDir(import.meta.dir), "index.html")}`;
+    // Last resort: file:// (may have CORS issues with crossorigin module scripts).
+    // pathToFileURL builds a valid file:///C:/… URL on Windows; `file://${winPath}`
+    // would be malformed (backslashes, drive letter parsed as host) and not load.
+    rendererUrl = pathToFileURL(
+      path.join(resolveRendererAssetDir(import.meta.dir), "index.html"),
+    ).href;
     logger.warn(
       "[Main] Falling back to file:// renderer URL — CORS issues possible",
     );


### PR DESCRIPTION
## Problem

The main elizaOS desktop app (Electrobun platform) has the same malformed-`file://`-URL bug just fixed in `@elizaos/setup` (#9530), but in the **primary app**. `resolveRendererUrl()`'s last-resort fallback (used when the local renderer HTTP server fails to start and no dev URL is set) builds:

```ts
rendererUrl = `file://${path.join(resolveRendererAssetDir(import.meta.dir), "index.html")}`;
```

On Windows `path.join` yields a backslash drive-letter path, so `file://${winPath}` becomes `file://C:\Users\…\index.html` — malformed (the drive letter is parsed as the URL host, backslashes are invalid). The Electrobun `BrowserWindow` can't load it → blank app on the file:// fallback path on Windows. Not win32-gated.

## Fix

Use `pathToFileURL(...).href`, which yields a valid `file:///C:/…/index.html` on Windows (and `file:///abs` on POSIX):

```
OLD: file://C:\Users\x\app\renderer\index.html   (malformed)
NEW: file:///C:/Users/x/app/renderer/index.html      (valid)
```

`biome lint` clean; mirrors the #9530 fix exactly. Found by a completeness grep after the adversarially-verified Windows source sweep (follow-on to #9372 / #9374).