### PR TITLE
fix(cloud-e2e): type mock llm body reader

### DIFF
--- a/packages/test/cloud-e2e/src/fixtures/mock-llm.ts
+++ b/packages/test/cloud-e2e/src/fixtures/mock-llm.ts
@@ -16,7 +16,7 @@
  * `generateText`, which never opens an SSE stream to the upstream.
  */
 
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 
 export interface RunningMockLlm {
@@ -50,9 +50,7 @@ function estimatePromptTokens(body: ChatCompletionRequestBody): number {
   return Math.max(8, Math.ceil(text.length / 4));
 }
 
-async function readBody(
-  req: Parameters<Parameters<typeof createServer>[1]>[0],
-): Promise<string> {
+async function readBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
     chunks.push(chunk as Buffer);


### PR DESCRIPTION
## Summary
- Replace the mock-LLM body reader's listener-derived request type with `IncomingMessage`.
- Avoid `createServer`'s optional listener overload leaking `undefined` into `Parameters<...>`, which broke `@elizaos/cloud-e2e#typecheck` on current `develop`.

## Verification
- `git fetch origin && git rebase origin/develop` onto `726946a357`
- `bun install` - no changes
- `bunx @biomejs/biome check packages/test/cloud-e2e/src/fixtures/mock-llm.ts`
- `bun run --cwd packages/test/cloud-e2e typecheck`
- `bun run --cwd packages/test/cloud-e2e test -- monetized-mock-llm-journey.spec.ts` - 1 passed; mock journey logged end-user debit and app earnings
- `git diff --check origin/develop...HEAD`
- `bun run verify` - 510/510 tasks passed; `@elizaos/cloud-e2e:typecheck` ran cleanly

N/A: screenshots/video/real-LLM trajectories, because this is a TypeScript-only test fixture unblocker and the keyless mock-LLM route spec is the relevant behavioral proof.
