### PR TITLE
fix(calendar): resolve everyday relative dates ("tomorrow", "in 2 days") (#8795)

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -1190,7 +1190,72 @@ function resolveStructuredCalendarSubaction(
   return null;
 }
 
-function parseExplicitLocalDate(
+/**
+ * Small spelled-out cardinals so everyday/child/elderly phrasing like "in two
+ * days" or "a week from today" resolves deterministically, not just digits.
+ */
+const RELATIVE_NUMBER_WORDS: Record<string, number> = {
+  a: 1,
+  an: 1,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+};
+
+function relativeCountToNumber(token: string): number | null {
+  if (/^\d{1,3}$/.test(token)) return Number(token);
+  return RELATIVE_NUMBER_WORDS[token] ?? null;
+}
+
+/**
+ * Resolve common relative-date phrasing to a day offset from today, or null.
+ * Handles "today", "tomorrow", "yesterday", "day after tomorrow",
+ * "day before yesterday", "in N days/weeks", and "N days/weeks from now|today"
+ * (#8795). These are everyday phrasings the calendar action's own examples use
+ * (e.g. "Schedule a meeting with Alex at 3pm tomorrow") that the deterministic
+ * resolver previously returned null for, forcing an avoidable LLM round-trip.
+ *
+ * Multi-word and count patterns are checked before the bare "today"/"tomorrow"
+ * words so "3 days from today" is +3, not 0.
+ */
+function parseRelativeDayOffset(text: string): number | null {
+  if (/\bday after tomorrow\b/.test(text)) return 2;
+  if (/\bday before yesterday\b/.test(text)) return -2;
+
+  const inMatch = text.match(
+    /\bin (\d{1,3}|a|an|one|two|three|four|five|six|seven|eight|nine|ten) (days?|weeks?)\b/,
+  );
+  if (inMatch?.[1] && inMatch[2]) {
+    const count = relativeCountToNumber(inMatch[1]);
+    if (count !== null) {
+      return inMatch[2].startsWith("week") ? count * 7 : count;
+    }
+  }
+
+  const fromNowMatch = text.match(
+    /\b(\d{1,3}|a|an|one|two|three|four|five|six|seven|eight|nine|ten) (days?|weeks?) from (?:now|today)\b/,
+  );
+  if (fromNowMatch?.[1] && fromNowMatch[2]) {
+    const count = relativeCountToNumber(fromNowMatch[1]);
+    if (count !== null) {
+      return fromNowMatch[2].startsWith("week") ? count * 7 : count;
+    }
+  }
+
+  if (/\btomorrow\b/.test(text)) return 1;
+  if (/\byesterday\b/.test(text)) return -1;
+  if (/\btoday\b/.test(text)) return 0;
+  return null;
+}
+
+export function parseExplicitLocalDate(
   value: string,
   timeZone: string,
 ): { year: number; month: number; day: number } | null {
@@ -1270,6 +1335,21 @@ function parseExplicitLocalDate(
         delta,
       );
     }
+  }
+
+  // Relative-date phrasing fallback ("tomorrow", "in 2 days", "a week from
+  // today", …) — checked after the specific date patterns so e.g. an ISO date
+  // still wins (#8795).
+  const relativeOffset = parseRelativeDayOffset(normalized);
+  if (relativeOffset !== null) {
+    return addDaysToLocalDate(
+      {
+        year: localToday.year,
+        month: localToday.month,
+        day: localToday.day,
+      },
+      relativeOffset,
+    );
   }
 
   return null;

--- a/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
+++ b/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseExplicitLocalDate } from "../src/actions/calendar-handler.js";
+import { addDaysToLocalDate, getZonedDateParts } from "../src/internal/time.js";
+
+/**
+ * Relative-date phrasing coverage (#8795). The deterministic date resolver used
+ * by the CALENDAR action previously returned null for "today"/"tomorrow"/"in N
+ * days" — the exact everyday phrasing in the action's own examples ("Schedule a
+ * meeting with Alex at 3pm tomorrow") — forcing an avoidable LLM round-trip.
+ * These assert the offsets relative to "today" in a fixed timezone, computed
+ * with the same time helpers the resolver uses so the test is clock-independent.
+ */
+const TZ = "America/New_York";
+
+function expectedFromToday(offset: number) {
+  const today = getZonedDateParts(new Date(), TZ);
+  const { year, month, day } = addDaysToLocalDate(
+    { year: today.year, month: today.month, day: today.day },
+    offset,
+  );
+  return { year, month, day };
+}
+
+describe("parseExplicitLocalDate — relative phrasing (#8795)", () => {
+  it.each([
+    ["today", 0],
+    ["tomorrow", 1],
+    ["yesterday", -1],
+    ["day after tomorrow", 2],
+    ["day before yesterday", -2],
+    ["in 3 days", 3],
+    ["in 1 day", 1],
+    ["in 2 weeks", 14],
+    ["a week from today", 7],
+    ["two days from now", 2],
+    ["in ten days", 10],
+  ])("resolves %j to today%+d", (phrase, offset) => {
+    expect(parseExplicitLocalDate(phrase, TZ)).toEqual(
+      expectedFromToday(offset),
+    );
+  });
+
+  it("resolves relative phrasing embedded in a fuller request", () => {
+    expect(
+      parseExplicitLocalDate("schedule a dentist appointment tomorrow", TZ),
+    ).toEqual(expectedFromToday(1));
+  });
+
+  it("does not match '3 days from today' as the bare word 'today'", () => {
+    // The N-count pattern must win over the bare 'today' word.
+    expect(parseExplicitLocalDate("3 days from today", TZ)).toEqual(
+      expectedFromToday(3),
+    );
+  });
+
+  it("still prefers an explicit ISO date over relative words", () => {
+    expect(parseExplicitLocalDate("2030-01-15 (tomorrow-ish)", TZ)).toEqual({
+      year: 2030,
+      month: 1,
+      day: 15,
+    });
+  });
+
+  it("returns null when there is no resolvable date", () => {
+    expect(parseExplicitLocalDate("sometime soon maybe", TZ)).toBeNull();
+    expect(parseExplicitLocalDate("", TZ)).toBeNull();
+  });
+});


### PR DESCRIPTION
From the #8795 audit (report in #9545): the CALENDAR action's deterministic date resolver `parseExplicitLocalDate` handled ISO dates, month names, numeric dates, and weekday names — but returned **null** for the most common everyday phrasing: "today", "tomorrow", "yesterday", "day after tomorrow", "in N days/weeks", "N days from now/today".

That's the exact wording the action's **own examples** use — `"Schedule a meeting with Alex at 3pm tomorrow"`, `"Delete the team meeting tomorrow"` — so the deterministic path missed it and fell back to an avoidable LLM round-trip. Per the audit's persona/fuzz lens, this is precisely the normie/child/elderly phrasing the system should resolve without a model call.

## Fix
- `parseRelativeDayOffset(text)` resolves relative phrasing to a day offset from *today* (in the owner timezone, via the existing `getZonedDateParts` + `addDaysToLocalDate`), including **spelled-out cardinals** ("in two days", "a week from today") for spoken/child/elderly phrasing.
- Count/multi-word patterns are checked **before** the bare "today"/"tomorrow" words, so `"3 days from today"` is +3, not 0. Explicit ISO/numeric/month/weekday dates still win (the relative fallback runs last).
- Exports `parseExplicitLocalDate` and adds `parse-explicit-local-date.test.ts` — **15 cases**: every relative phrase, embedded-in-a-fuller-request, the count-vs-bare-word precedence, ISO precedence, and the null fallthrough. The expected dates are computed with the same time helpers the resolver uses, so the test is clock-independent.

`bun run --cwd plugins/plugin-calendar test -- parse-explicit-local-date` → **15/15**; typecheck (plugin-calendar) + biome clean. Touches only `plugin-calendar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)