### PR TITLE
fix(lifeops): coerce hallucinated Gmail subaction to the safe default (#8795)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/llm/extract-gmail-plan.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/llm/extract-gmail-plan.ts
@@ -24,6 +24,29 @@ export type GmailPlanSubaction =
   | "draft_reply"
   | "send_reply";
 
+const GMAIL_PLAN_SUBACTIONS: ReadonlySet<GmailPlanSubaction> = new Set([
+  "triage",
+  "needs_response",
+  "search",
+  "read",
+  "draft_reply",
+  "send_reply",
+]);
+
+/**
+ * Coerce a model-emitted subaction string to a known {@link GmailPlanSubaction},
+ * falling back to the safe read-shaped default "triage" for a missing/invalid
+ * value (#8795). Without this, a malformed model output (e.g. a hallucinated
+ * "delete_everything") was blind-cast and flowed downstream as if valid.
+ */
+function coerceGmailSubaction(value: string | undefined): GmailPlanSubaction {
+  const normalized = value?.trim().toLowerCase();
+  return normalized &&
+    GMAIL_PLAN_SUBACTIONS.has(normalized as GmailPlanSubaction)
+    ? (normalized as GmailPlanSubaction)
+    : "triage";
+}
+
 export interface GmailPlan {
   subaction: GmailPlanSubaction;
   shouldAct: boolean;
@@ -56,7 +79,7 @@ function parseGmailPlan(text: string): GmailPlan {
     if (match) fields.set(match[1].toLowerCase(), match[2].trim());
   }
 
-  const subaction = (fields.get("subaction") || "triage") as GmailPlanSubaction;
+  const subaction = coerceGmailSubaction(fields.get("subaction"));
   const shouldAct = fields.get("shouldact")?.toLowerCase() !== "false";
   const responseRaw = fields.get("response");
   const response =

--- a/plugins/plugin-personal-assistant/test/lifeops-optimized-prompts.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-optimized-prompts.test.ts
@@ -161,4 +161,52 @@ describe("LifeOps optimized prompt routing", () => {
     expect(capturedPrompts[0]).toContain("- title: Take medication");
     expect(capturedPrompts[0]).toContain("Other reminders around this time:");
   });
+
+  it("coerces a hallucinated Gmail subaction to the safe triage default (#8795)", async () => {
+    const { extractGmailPlanWithLlm } = await import(
+      "../src/lifeops/llm/extract-gmail-plan.js"
+    );
+    const capturedPrompts: string[] = [];
+    const runtime = optimizedPromptRuntime({
+      task: "inbox_triage",
+      optimizedPrompt: "OPTIMIZED INBOX",
+      modelResponses: [
+        // A malformed/hallucinated plan: an invalid subaction the type does not
+        // allow. It must not flow downstream as a valid subaction.
+        ["subaction: delete_everything", "shouldAct: true"].join("\n"),
+      ],
+      capturedPrompts,
+    });
+
+    const plan = await extractGmailPlanWithLlm(
+      runtime,
+      userMessage("clean up my inbox"),
+      undefined,
+      "clean up my inbox",
+    );
+
+    expect(plan.subaction).toBe("triage");
+    expect(plan.replyNeededOnly).toBeUndefined();
+  });
+
+  it("defaults a missing Gmail subaction to triage (#8795)", async () => {
+    const { extractGmailPlanWithLlm } = await import(
+      "../src/lifeops/llm/extract-gmail-plan.js"
+    );
+    const runtime = optimizedPromptRuntime({
+      task: "inbox_triage",
+      optimizedPrompt: "OPTIMIZED INBOX",
+      modelResponses: ["response: null"],
+      capturedPrompts: [],
+    });
+
+    const plan = await extractGmailPlanWithLlm(
+      runtime,
+      userMessage("what's in my inbox"),
+      undefined,
+      "what's in my inbox",
+    );
+
+    expect(plan.subaction).toBe("triage");
+  });
 });


### PR DESCRIPTION
From the #8795 audit (#9545): `parseGmailPlan` blind-cast the model's `subaction` line — `(fields.get("subaction") || "triage") as GmailPlanSubaction` — so a malformed/hallucinated value (e.g. `"delete_everything"`) flowed downstream into the inbox-triage routing as if it were one of the 6 valid subactions.

## Fix
`coerceGmailSubaction` validates against the allowlist and falls back to the safe read-shaped default `"triage"` for any missing/invalid value. **No happy-path behavior change** — valid subactions pass through unchanged; invalid ones resolve to the same default an *absent* subaction already produced.

## Tests (through the public `extractGmailPlanWithLlm`)
- a hallucinated `"delete_everything"` coerces to `"triage"` and does not set `replyNeededOnly`;
- a missing subaction defaults to `"triage"`.

`bun run --cwd plugins/plugin-personal-assistant test -- lifeops-optimized-prompts` → **5/5**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)