### PR TITLE
feat(ui): filter notifications by category

### DIFF
--- a/packages/ui/src/components/shell/NotificationCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import type { AgentNotification } from "@elizaos/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+} from "../../state/notifications/notification-store";
+import { NotificationCenter } from "./NotificationCenter";
+
+const appState = {
+  setActionNotice: vi.fn(),
+};
+
+const listNotifications = vi.fn();
+const markNotificationReadApi = vi.fn();
+const markAllNotificationsReadApi = vi.fn();
+const removeNotificationApi = vi.fn();
+const clearNotificationsApi = vi.fn();
+const onWsEvent = vi.fn();
+
+vi.mock("../../state", () => ({
+  useAppSelector: <T,>(selector: (state: typeof appState) => T): T =>
+    selector(appState),
+}));
+
+vi.mock("../../api/client", () => ({
+  client: {
+    listNotifications: (...args: unknown[]) => listNotifications(...args),
+    markNotificationRead: (...args: unknown[]) =>
+      markNotificationReadApi(...args),
+    markAllNotificationsRead: (...args: unknown[]) =>
+      markAllNotificationsReadApi(...args),
+    removeNotification: (...args: unknown[]) => removeNotificationApi(...args),
+    clearNotifications: (...args: unknown[]) => clearNotificationsApi(...args),
+    onWsEvent: (...args: unknown[]) => onWsEvent(...args),
+  },
+}));
+
+const invokeDesktopBridgeRequest = vi.fn();
+vi.mock("../../bridge/electrobun-rpc", () => ({
+  invokeDesktopBridgeRequest: (...args: unknown[]) =>
+    invokeDesktopBridgeRequest(...args),
+}));
+
+const showNativeNotification = vi.fn();
+vi.mock("../../bridge/native-notifications", () => ({
+  showNativeNotification: (...args: unknown[]) =>
+    showNativeNotification(...args),
+}));
+
+function notification(
+  id: string,
+  title: string,
+  category: AgentNotification["category"],
+): AgentNotification {
+  return {
+    id: id as AgentNotification["id"],
+    title,
+    category,
+    priority: "normal",
+    source: "test",
+    createdAt: Date.UTC(2026, 0, 1),
+    readAt: null,
+  };
+}
+
+describe("NotificationCenter", () => {
+  beforeEach(() => {
+    __resetNotificationStoreForTests();
+    appState.setActionNotice.mockReset();
+    listNotifications.mockReset().mockResolvedValue({
+      notifications: [],
+      unreadCount: 0,
+    });
+    markNotificationReadApi.mockReset().mockResolvedValue({ ok: true });
+    markAllNotificationsReadApi.mockReset().mockResolvedValue({ changed: 0 });
+    removeNotificationApi.mockReset().mockResolvedValue({ ok: true });
+    clearNotificationsApi.mockReset().mockResolvedValue({ ok: true });
+    onWsEvent.mockReset();
+    invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+    showNativeNotification.mockReset().mockResolvedValue("none");
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetNotificationStoreForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("filters notification rows by category without losing the all view", async () => {
+    const notifications = [
+      notification("reminder-1", "Take medication", "reminder"),
+      notification("message-1", "Discord reply waiting", "message"),
+      notification("system-1", "Update installed", "system"),
+    ];
+    listNotifications.mockResolvedValue({
+      notifications,
+      unreadCount: notifications.length,
+    });
+    for (const item of notifications) {
+      __ingestNotificationForTests(item, notifications.length);
+    }
+
+    const user = userEvent.setup();
+    render(<NotificationCenter />);
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    await screen.findByText("Take medication");
+    expect(screen.queryByText("Discord reply waiting")).not.toBeNull();
+    expect(screen.queryByText("Update installed")).not.toBeNull();
+
+    await user.click(screen.getByRole("tab", { name: /reminders\s*1/i }));
+    expect(screen.queryByText("Take medication")).not.toBeNull();
+    expect(screen.queryByText("Discord reply waiting")).toBeNull();
+    expect(screen.queryByText("Update installed")).toBeNull();
+
+    await user.click(screen.getByRole("tab", { name: /all\s*3/i }));
+    expect(screen.queryByText("Take medication")).not.toBeNull();
+    expect(screen.queryByText("Discord reply waiting")).not.toBeNull();
+    expect(screen.queryByText("Update installed")).not.toBeNull();
+  });
+
+  it("resets an active category filter when that category disappears", async () => {
+    const notifications = [
+      notification("reminder-1", "Take medication", "reminder"),
+      notification("system-1", "Update installed", "system"),
+    ];
+    listNotifications.mockResolvedValue({
+      notifications,
+      unreadCount: notifications.length,
+    });
+    for (const item of notifications) {
+      __ingestNotificationForTests(item, notifications.length);
+    }
+
+    const user = userEvent.setup();
+    render(<NotificationCenter />);
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    await user.click(screen.getByRole("tab", { name: /reminders\s*1/i }));
+    expect(screen.queryByText("Update installed")).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss notification" }),
+    );
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("tab", { name: /all\s*1/i })
+          .getAttribute("aria-selected"),
+      ).toBe("true");
+    });
+    expect(screen.queryByText("Update installed")).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/NotificationCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.tsx
@@ -16,7 +16,13 @@ import {
   Workflow,
   X,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
 import {
@@ -44,8 +50,38 @@ const CATEGORY_ICON: Record<NotificationCategory, ReactNode> = {
   general: <CircleAlert className="h-4 w-4" />,
 };
 
+const CATEGORY_LABEL: Record<NotificationCategory, string> = {
+  reminder: "Reminders",
+  task: "Tasks",
+  workflow: "Workflows",
+  agent: "Agents",
+  approval: "Approvals",
+  message: "Messages",
+  health: "Health",
+  system: "System",
+  general: "General",
+};
+
+const CATEGORY_ORDER: readonly NotificationCategory[] = [
+  "approval",
+  "reminder",
+  "task",
+  "workflow",
+  "message",
+  "health",
+  "agent",
+  "system",
+  "general",
+];
+
+type NotificationCategoryFilter = NotificationCategory | "all";
+
 function categoryIcon(category: NotificationCategory): ReactNode {
   return CATEGORY_ICON[category] ?? CATEGORY_ICON.general;
+}
+
+function categoryLabel(category: NotificationCategory): string {
+  return CATEGORY_LABEL[category] ?? CATEGORY_LABEL.general;
 }
 
 /** Best-effort navigation for a notification deep link. */
@@ -162,6 +198,8 @@ export function NotificationCenter({
 }): ReactNode {
   const { notifications, unreadCount } = useNotifications();
   const setActionNotice = useAppSelector((s) => s.setActionNotice);
+  const [categoryFilter, setCategoryFilter] =
+    useState<NotificationCategoryFilter>("all");
 
   // Boot the notification store (hydrate + subscribe to the live stream) and
   // route its interrupt toasts through the shell's ActionNotice. Idempotent —
@@ -180,6 +218,42 @@ export function NotificationCenter({
   }, []);
 
   const hasUnread = unreadCount > 0;
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<NotificationCategory, number>();
+    for (const notification of notifications) {
+      counts.set(
+        notification.category,
+        (counts.get(notification.category) ?? 0) + 1,
+      );
+    }
+    return counts;
+  }, [notifications]);
+  const categoryOptions = useMemo(
+    () => CATEGORY_ORDER.filter((category) => categoryCounts.has(category)),
+    [categoryCounts],
+  );
+  const filteredNotifications = useMemo(
+    () =>
+      categoryFilter === "all"
+        ? notifications
+        : notifications.filter(
+            (notification) => notification.category === categoryFilter,
+          ),
+    [categoryFilter, notifications],
+  );
+  const emptyFilterLabel =
+    categoryFilter === "all" ? "matching" : categoryLabel(categoryFilter);
+
+  useEffect(() => {
+    if (
+      categoryFilter !== "all" &&
+      !notifications.some(
+        (notification) => notification.category === categoryFilter,
+      )
+    ) {
+      setCategoryFilter("all");
+    }
+  }, [categoryFilter, notifications]);
 
   // Hidden for now: keep the store + toast routing live (the effect above) but
   // render no bell. Drop the `headless` prop to bring the button back.
@@ -250,17 +324,71 @@ export function NotificationCenter({
             <span className="text-sm text-muted">You're all caught up</span>
           </div>
         ) : (
-          <ul className="max-h-[min(440px,60vh)] overflow-y-auto p-1.5">
-            {notifications.map((notification) => (
-              <NotificationRow
-                key={notification.id}
-                notification={notification}
-                onClose={() => {
-                  /* popover closes on navigation via deep-link below */
-                }}
-              />
-            ))}
-          </ul>
+          <>
+            <div
+              aria-label="Notification category"
+              className="flex gap-1 overflow-x-auto border-b border-border px-2 py-2"
+              role="tablist"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={categoryFilter === "all"}
+                onClick={() => setCategoryFilter("all")}
+                className={cn(
+                  "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-sm px-2.5 text-xs font-medium transition-colors",
+                  categoryFilter === "all"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-strong hover:bg-surface hover:text-txt",
+                )}
+              >
+                All
+                <span className="text-[11px] opacity-75">
+                  {notifications.length}
+                </span>
+              </button>
+              {categoryOptions.map((category) => (
+                <button
+                  key={category}
+                  type="button"
+                  role="tab"
+                  aria-selected={categoryFilter === category}
+                  onClick={() => setCategoryFilter(category)}
+                  className={cn(
+                    "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-sm px-2.5 text-xs font-medium transition-colors",
+                    categoryFilter === category
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-strong hover:bg-surface hover:text-txt",
+                  )}
+                >
+                  {categoryLabel(category)}
+                  <span className="text-[11px] opacity-75">
+                    {categoryCounts.get(category)}
+                  </span>
+                </button>
+              ))}
+            </div>
+            {filteredNotifications.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 px-4 py-10 text-center">
+                <Inbox className="h-7 w-7 text-muted/70" />
+                <span className="text-sm text-muted">
+                  No {emptyFilterLabel} notifications
+                </span>
+              </div>
+            ) : (
+              <ul className="max-h-[min(440px,60vh)] overflow-y-auto p-1.5">
+                {filteredNotifications.map((notification) => (
+                  <NotificationRow
+                    key={notification.id}
+                    notification={notification}
+                    onClose={() => {
+                      /* popover closes on navigation via deep-link below */
+                    }}
+                  />
+                ))}
+              </ul>
+            )}
+          </>
         )}
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Summary

- Adds category filter tabs to `NotificationCenter`, driven by `AgentNotification.category`.
- Shows only categories present in the current inbox, with an `All` tab and per-category counts.
- Resets the selected filter to `All` when the selected category disappears after dismissing/clearing notifications.
- Adds focused jsdom component coverage for category filtering and filter reset behavior.

Refs #9449.

## Evidence

- Synced before PR: `git fetch origin && git rebase origin/develop` onto `9e5313df89`.
- Install: `bun install` passed.
- Whitespace: `git diff --check` passed.
- Focused test: `bun run --cwd packages/ui test -- src/components/shell/NotificationCenter.test.tsx` passed (1 file, 2 tests).
- UI lint: `bun run --cwd packages/ui lint` passed (2089 files).
- Package typecheck: `bun run --cwd packages/ui typecheck` fails on current `develop` issues outside this slice, including unresolved `@elizaos/plugin-sql` / `@elizaos/contracts`, `AccountWithCredentialFlag` property errors, and `useWalletState.ts` implicit-any. No errors reference the changed notification files.
- Required root gate: `bun run verify` was run twice after sync/install and fails before this branch's UI package is involved: `@elizaos/example-bluesky#typecheck` / `@elizaos/example-telegram#typecheck` cannot resolve `@elizaos/plugin-openai` (and related example export typings). Branch diff versus `origin/develop` is only the two notification-center files.

## Screenshots / Video

N/A: this is a shared `packages/ui` component-only change covered by focused jsdom interaction tests; it does not touch `packages/cloud-frontend/` or start a standalone route/dev server.