### PR TITLE
fix(ci): build model plugins before example typecheck

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -464,11 +464,18 @@
       "outputs": []
     },
     "@elizaos/example-telegram#typecheck": {
-      "dependsOn": ["@elizaos/plugin-sql#build"],
+      "dependsOn": [
+        "@elizaos/plugin-openai#build",
+        "@elizaos/plugin-sql#build"
+      ],
       "outputs": []
     },
     "@elizaos/example-bluesky#typecheck": {
-      "dependsOn": ["@elizaos/plugin-sql#build"],
+      "dependsOn": [
+        "@elizaos/plugin-bluesky#build",
+        "@elizaos/plugin-openai#build",
+        "@elizaos/plugin-sql#build"
+      ],
       "outputs": []
     },
     "@elizaos/example-chat#typecheck": {


### PR DESCRIPTION
## Summary

- Adds missing Turbo typecheck prerequisites for the example packages that statically import workspace plugins emitted to `dist`.
- `@elizaos/example-bluesky#typecheck` now waits for `plugin-bluesky`, `plugin-openai`, and `plugin-sql` builds.
- `@elizaos/example-telegram#typecheck` now waits for `plugin-openai` and `plugin-sql` builds.

Refs #9474.

## Evidence

- Claimed narrow slice on #9474: https://github.com/elizaOS/eliza/issues/9474#issuecomment-4795053334
- Synced before PR: `git fetch origin && git rebase origin/develop`, rebased onto `f701b7a568`.
- Install after sync: `bun install` passed.
- Formatting/whitespace:
  - `bunx @biomejs/biome check turbo.json` passed.
  - `git diff --check` passed.
- Focused Turbo check passed:
  - `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --filter='@elizaos/example-bluesky' --filter='@elizaos/example-telegram' --filter='@elizaos/example-chat'`
  - Result: 11/11 tasks successful.
- Required root gate passed:
  - `bun run verify`
  - Result: 510/510 tasks successful.

## Notes

No screenshots/video: this is CI task-graph wiring only; no runtime UI or user flow changed.