### PR TITLE
test(ui): cover notification category filter

### DIFF
--- a/packages/ui/src/components/shell/NotificationCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import type { AgentNotification } from "@elizaos/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+} from "../../state/notifications/notification-store";
+import { NotificationCenter } from "./NotificationCenter";
+
+const mocks = vi.hoisted(() => ({
+  appState: {
+    setActionNotice: vi.fn(),
+  },
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  removeNotification: vi.fn(),
+  clearNotifications: vi.fn(),
+  onWsEvent: vi.fn(),
+  invokeDesktopBridgeRequest: vi.fn(),
+  showNativeNotification: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: <T,>(selector: (state: typeof mocks.appState) => T): T =>
+    selector(mocks.appState),
+}));
+
+vi.mock("../../api/client", () => ({
+  client: {
+    listNotifications: (...args: unknown[]) => mocks.listNotifications(...args),
+    markNotificationRead: (...args: unknown[]) =>
+      mocks.markNotificationRead(...args),
+    markAllNotificationsRead: (...args: unknown[]) =>
+      mocks.markAllNotificationsRead(...args),
+    removeNotification: (...args: unknown[]) =>
+      mocks.removeNotification(...args),
+    clearNotifications: (...args: unknown[]) =>
+      mocks.clearNotifications(...args),
+    onWsEvent: (...args: unknown[]) => mocks.onWsEvent(...args),
+  },
+}));
+
+vi.mock("../../bridge/electrobun-rpc", () => ({
+  invokeDesktopBridgeRequest: (...args: unknown[]) =>
+    mocks.invokeDesktopBridgeRequest(...args),
+}));
+
+vi.mock("../../bridge/native-notifications", () => ({
+  showNativeNotification: (...args: unknown[]) =>
+    mocks.showNativeNotification(...args),
+}));
+
+function notification(
+  id: string,
+  title: string,
+  category: AgentNotification["category"],
+): AgentNotification {
+  return {
+    id: id as AgentNotification["id"],
+    title,
+    category,
+    priority: "normal",
+    source: "test",
+    createdAt: Date.UTC(2026, 0, 1),
+    readAt: null,
+  };
+}
+
+function seedNotifications(notifications: AgentNotification[]): void {
+  mocks.listNotifications.mockResolvedValue({
+    notifications,
+    unreadCount: notifications.length,
+  });
+  for (const item of notifications) {
+    __ingestNotificationForTests(item, notifications.length);
+  }
+}
+
+describe("NotificationCenter", () => {
+  beforeEach(() => {
+    __resetNotificationStoreForTests();
+    mocks.appState.setActionNotice.mockReset();
+    mocks.listNotifications.mockReset().mockResolvedValue({
+      notifications: [],
+      unreadCount: 0,
+    });
+    mocks.markNotificationRead.mockReset().mockResolvedValue({ ok: true });
+    mocks.markAllNotificationsRead
+      .mockReset()
+      .mockResolvedValue({ changed: 0 });
+    mocks.removeNotification.mockReset().mockResolvedValue({ ok: true });
+    mocks.clearNotifications.mockReset().mockResolvedValue({ ok: true });
+    mocks.onWsEvent.mockReset();
+    mocks.invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+    mocks.showNativeNotification.mockReset().mockResolvedValue("none");
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetNotificationStoreForTests();
+  });
+
+  it("filters notification rows by category without losing the all view", async () => {
+    seedNotifications([
+      notification("reminder-1", "Take medication", "reminder"),
+      notification("message-1", "Discord reply waiting", "message"),
+      notification("system-1", "Update installed", "system"),
+    ]);
+
+    const user = userEvent.setup();
+    render(<NotificationCenter />);
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    await screen.findByText("Take medication");
+    expect(screen.queryByText("Discord reply waiting")).not.toBeNull();
+    expect(screen.queryByText("Update installed")).not.toBeNull();
+
+    await user.click(screen.getByRole("tab", { name: "Reminders" }));
+    expect(screen.queryByText("Take medication")).not.toBeNull();
+    expect(screen.queryByText("Discord reply waiting")).toBeNull();
+    expect(screen.queryByText("Update installed")).toBeNull();
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+    expect(screen.queryByText("Take medication")).not.toBeNull();
+    expect(screen.queryByText("Discord reply waiting")).not.toBeNull();
+    expect(screen.queryByText("Update installed")).not.toBeNull();
+  });
+
+  it("falls back to all notifications when an active category disappears", async () => {
+    seedNotifications([
+      notification("reminder-1", "Take medication", "reminder"),
+      notification("system-1", "Update installed", "system"),
+    ]);
+
+    const user = userEvent.setup();
+    render(<NotificationCenter />);
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    await user.click(screen.getByRole("tab", { name: "Reminders" }));
+    expect(screen.queryByText("Update installed")).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss notification" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Take medication")).toBeNull();
+      expect(screen.queryByText("Update installed")).not.toBeNull();
+    });
+    expect(
+      screen.queryByRole("tablist", {
+        name: "Filter notifications by category",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused jsdom coverage for the `NotificationCenter` category filter that is already on `develop`:

- verifies selecting a notification category hides other category rows and returning to `All` restores the list;
- verifies the center falls back to the full list when the active category disappears after dismissing its last notification;
- uses the real notification store via its test ingest/reset hooks, with mocked API/native notification sinks.

This is a test-only follow-up for #9449. The implementation and toast TTL contract already landed on `develop` in `e760981fbf` / `a31a860d68`; the stale implementation PR #9550 is superseded by those commits.

## Evidence

- Synced with `git fetch origin && git rebase origin/develop` onto `61647af7b9`.
- `bun install` passed after rebase.
- `bun run --cwd packages/ui test -- src/components/shell/NotificationCenter.test.tsx` passed: 1 file, 2 tests.
- `bun run --cwd packages/ui lint` passed.
- `git diff --check origin/develop...HEAD` passed.

## Root Verify

`bun run verify` currently fails on current `develop` before this UI package is involved:

- failing task: `@elizaos/example-telegram#typecheck`
- error: `packages/examples/telegram/telegram-agent.ts(48,12): Cannot find module '@elizaos/plugin-openai' or its corresponding type declarations.`
- this is the known Turbo typecheck dependency gap addressed by open PR #9552.

At failure, verify had completed `type-safety-ratchet` successfully (`390 / 390`) and stopped after 53 successful Turbo tasks.
