### PR TITLE
fix(cloud-shared): raise credit-markup ceiling to the validated 1000% (A2A/MCP 500 for >100% creators)

### DIFF
--- a/packages/cloud-shared/src/billing/credit-markup.test.ts
+++ b/packages/cloud-shared/src/billing/credit-markup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { calculateCreditMarkup, DEFAULT_PLATFORM_FEE_RATE } from "./credit-markup";
+import { calculateCreditMarkup, DEFAULT_PLATFORM_FEE_RATE, MAX_MARKUP_PERCENT } from "./credit-markup";
 
 describe("calculateCreditMarkup", () => {
   test("applies basic creator markup with no platform fee", () => {
@@ -93,10 +93,26 @@ describe("calculateCreditMarkup", () => {
     ).toThrow(RangeError);
   });
 
-  test("rejects values above documented markup and platform fee bounds", () => {
-    expect(() => calculateCreditMarkup({ baseCredits: 1, markupPercent: 100.0001 })).toThrow(
-      RangeError,
-    );
+  test("applies creator markup above 100%, up to the validated ceiling", () => {
+    // The monetization settings accept 0..1000%; the A2A-skill + MCP routes feed
+    // that markup straight into this helper. A 500% markup must compute, not throw
+    // (it used to RangeError at the old 100% cap → a 500 for those creators).
+    expect(calculateCreditMarkup({ baseCredits: 10, markupPercent: 500 })).toEqual({
+      baseCredits: 10,
+      markupCredits: 50,
+      platformFeeCredits: 0,
+      totalCredits: 60,
+    });
+    // The ceiling itself is allowed.
+    expect(() =>
+      calculateCreditMarkup({ baseCredits: 1, markupPercent: MAX_MARKUP_PERCENT }),
+    ).not.toThrow();
+  });
+
+  test("rejects values above the markup ceiling and platform fee bounds", () => {
+    expect(() =>
+      calculateCreditMarkup({ baseCredits: 1, markupPercent: MAX_MARKUP_PERCENT + 0.0001 }),
+    ).toThrow(RangeError);
     expect(() =>
       calculateCreditMarkup({
         baseCredits: 1,

--- a/packages/cloud-shared/src/billing/credit-markup.ts
+++ b/packages/cloud-shared/src/billing/credit-markup.ts
@@ -13,13 +13,23 @@
  *   totalCredits       = baseCredits + markupCredits + platformFeeCredits
  *
  * `markupPercent` is the creator / affiliate markup expressed as a percentage
- * (0..100). `platformFeeRate` is the platform's cut expressed as a fraction
+ * (0..`MAX_MARKUP_PERCENT`). `platformFeeRate` is the platform's cut expressed as a fraction
  * (0..1) and defaults to `0` so routes that only charge a creator markup do
  * not accidentally pick up a platform fee. The MCP-proxy affiliate flow opts
  * in by passing `platformFeeRate: DEFAULT_PLATFORM_FEE_RATE`.
  */
 
 export const DEFAULT_PLATFORM_FEE_RATE = 0.2;
+
+/**
+ * Maximum creator markup percentage. Matches the ceiling the monetization
+ * settings validate (`agent-monetization` + `app-credits`: "0% .. 1000%") and
+ * the inline inference-billing math, which apply no cap. This helper — used by
+ * the A2A-skill + MCP routes — previously capped at 100%, which `RangeError`-d
+ * (→ 500) those routes for any creator who set 101–1000%, a range the product
+ * explicitly accepts.
+ */
+export const MAX_MARKUP_PERCENT = 1000;
 
 export interface CreditMarkupBreakdown {
   /** Base cost (credits or USD) before markups. */
@@ -72,7 +82,7 @@ export function calculateCreditMarkup(input: CreditMarkupInput): CreditMarkupBre
   assertFiniteNonNegative(baseCredits, "baseCredits");
   assertFiniteNonNegative(markupPercent, "markupPercent");
   assertFiniteNonNegative(platformFeeRate, "platformFeeRate");
-  assertAtMost(markupPercent, 100, "markupPercent");
+  assertAtMost(markupPercent, MAX_MARKUP_PERCENT, "markupPercent");
   assertAtMost(platformFeeRate, 1, "platformFeeRate");
 
   const markupCredits = baseCredits * (markupPercent / 100);


### PR DESCRIPTION
## The bug (verified on live develop)

`calculateCreditMarkup` (`billing/credit-markup.ts`) capped `markupPercent` at **100%** and threw `RangeError` above it. It's called by the **A2A-skill** and **MCP** billing routes:

- `cloud-api/agents/[id]/a2a/route.ts:294` — `markupPct = character.inference_markup_percentage`, fed straight in
- `cloud-api/agents/[id]/mcp/route.ts`, `cloud-api/mcp/proxy/[mcpId]/route.ts`

But the monetization-settings validators accept **0–1000%**:
- `agent-monetization.ts:354` → `> 1000` rejects ("Markup must be between 0% and 1000%")
- `app-credits.ts:975` → `> 1000` throws ("Inference markup must be between 0% and 1000%")

…and the **inline inference-billing math** (regular chat, `baseCost * (markupPercentage/100)`) applies no cap. So a creator who sets **101–1000%** markup — which the product explicitly allows, and which normal chat bills correctly — gets **every A2A-skill and MCP call to their agent 500'd** (`RangeError: markupPercent must be <= 100`).

## The fix

Align the shared helper to the product's validated ceiling: introduce a named `MAX_MARKUP_PERCENT = 1000` (kills the magic number) and use it in the cap, update the stale `(0..100)` docstring, and add coverage that a >100% markup **computes** (500% → 6× base) instead of throwing.

## ⚠️ This resolves a genuine conflict — billing owners please confirm direction

This is **two deliberate, conflicting decisions** in the codebase, not a one-sided bug:
- This helper + its test + docstring deliberately documented **100%**.
- Two validators + the user-facing copy + the primary chat-inference path deliberately allow **1000%**.

I aligned to **1000%** because the weight of evidence (both validators, the user-facing "0% .. 1000%" copy, and the main inference path) says the product moved to 1000% and this secondary-path helper was left stale. **If the intended ceiling is actually 100%, the correct fix flips** to capping the validators at 100% instead (and there's then a data-migration question for existing >100% agents). @lalalune / @standujar — confirm the ceiling, and I'll finalize whichever direction.

## Mutation verification

```
revert MAX_MARKUP_PERCENT → 100  ⇒  ✗ "applies creator markup above 100%" fails (9 pass / 1 fail)
restore                           ⇒  ✓ 10 pass / 0 fail
```

## Follow-up (out of scope here)
The two validators still carry their own literal `1000`; importing `MAX_MARKUP_PERCENT` there would make it a single source of truth (rule: one ceiling, one place). Left out to keep this fix surgical.

Found via the launch-readiness coverage audit (#8434).