### PR TITLE
test(browser): cover LifeOps workspace cancellation

### DIFF
--- a/packages/test/scenarios/browser.lifeops/subscriptions.cancel-google-play.scenario.ts
+++ b/packages/test/scenarios/browser.lifeops/subscriptions.cancel-google-play.scenario.ts
@@ -1,9 +1,59 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { browserPlugin } from "../../../../plugins/plugin-browser/src/plugin.ts";
 import {
-  attachFakeSubscriptionComputerUse,
-  FakeSubscriptionComputerUseService,
-} from "../../helpers/subscription-computer-use-fixture";
+  __resetBrowserWorkspaceStateForTests,
+  executeBrowserWorkspaceCommand,
+} from "../../../../plugins/plugin-browser/src/workspace/browser-workspace.ts";
 import { expectScenarioBrowserTask } from "../_helpers/browser-task-assertions.ts";
+
+type RuntimeWithBrowserPlugin = {
+  plugins?: Array<{ name?: string }>;
+  registerPlugin?: (plugin: typeof browserPlugin) => Promise<void>;
+};
+
+const GOOGLE_PLAY_SUBSCRIPTIONS_URL =
+  "https://play.google.com/store/account/subscriptions";
+
+const googlePlayFixtureRoutes = [
+  {
+    url: GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+    title: "Google Play Subscriptions",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<h2>Subscriptions</h2>",
+      `<form method="get" action="${GOOGLE_PLAY_SUBSCRIPTIONS_URL}">`,
+      '<input type="hidden" name="confirm" value="1" />',
+      '<button data-lifeops-action="cancel-subscription" type="submit">Cancel subscription</button>',
+      "</form>",
+      "</main>",
+    ].join(""),
+  },
+  {
+    url: `${GOOGLE_PLAY_SUBSCRIPTIONS_URL}?canceled=1`,
+    title: "Google Play Cancellation Complete",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<p>subscription canceled</p>",
+      "</main>",
+    ].join(""),
+  },
+  {
+    url: `${GOOGLE_PLAY_SUBSCRIPTIONS_URL}?confirm=1`,
+    title: "Google Play Confirm Cancellation",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<p>Confirm cancellation</p>",
+      `<form method="get" action="${GOOGLE_PLAY_SUBSCRIPTIONS_URL}">`,
+      '<input type="hidden" name="canceled" value="1" />',
+      '<button data-lifeops-action="confirm-cancellation" type="submit">Confirm cancellation</button>',
+      "</form>",
+      "</main>",
+    ].join(""),
+  },
+] as const;
 
 export default scenario({
   lane: "live-only",
@@ -14,18 +64,59 @@ export default scenario({
   description:
     "The agent should run the subscription cancellation flow through the browser executor, finish the flow, and return completion evidence.",
   isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-browser"],
+  },
   seed: [
     {
       type: "custom",
-      name: "attach-fake-computeruse",
-      apply: (ctx) => {
-        const runtime = ctx.runtime as {
-          getService?: (serviceType: string) => unknown;
-        };
-        attachFakeSubscriptionComputerUse(
-          runtime,
-          new FakeSubscriptionComputerUseService("google_play"),
-        );
+      name: "seed-browser-workspace-google-play-subscription-flow",
+      apply: async (ctx) => {
+        delete process.env.ELIZA_BROWSER_WORKSPACE_URL;
+        delete process.env.ELIZA_BROWSER_WORKSPACE_TOKEN;
+        __resetBrowserWorkspaceStateForTests();
+
+        const runtime = ctx.runtime as RuntimeWithBrowserPlugin | undefined;
+        if (!runtime?.registerPlugin) {
+          return "runtime.registerPlugin unavailable";
+        }
+        if (
+          !runtime.plugins?.some(
+            (plugin) =>
+              plugin.name === "@elizaos/plugin-browser" ||
+              plugin.name === "browser",
+          )
+        ) {
+          await runtime.registerPlugin(browserPlugin);
+        }
+
+        const opened = await executeBrowserWorkspaceCommand({
+          show: true,
+          subaction: "open",
+          title: "Google Play Fixture",
+          url: "about:blank",
+        });
+        const tabId = opened.tab?.id;
+        if (!tabId) {
+          return "browser workspace did not create a Google Play fixture tab";
+        }
+
+        for (const route of googlePlayFixtureRoutes) {
+          await executeBrowserWorkspaceCommand({
+            id: tabId,
+            networkAction: "route",
+            responseBody: [
+              "<!doctype html>",
+              "<html>",
+              `<head><title>${route.title}</title></head>`,
+              `<body>${route.body}</body>`,
+              "</html>",
+            ].join(""),
+            responseStatus: 200,
+            subaction: "network",
+            url: route.url,
+          });
+        }
         return undefined;
       },
     },

--- a/plugins/plugin-finances/src/services/subscriptions-service.ts
+++ b/plugins/plugin-finances/src/services/subscriptions-service.ts
@@ -22,7 +22,13 @@
  */
 
 import { type IAgentRuntime, logger } from "@elizaos/core";
-import type { BrowserBridgeAction } from "@elizaos/plugin-browser";
+import {
+  BROWSER_SERVICE_TYPE,
+  type BrowserBridgeAction,
+  type BrowserService,
+  type BrowserWorkspaceCommand,
+  type BrowserWorkspaceCommandResult,
+} from "@elizaos/plugin-browser";
 import type { CreateLifeOpsBrowserSessionRequest } from "@elizaos/plugin-browser/lifeops-session-contracts";
 import type { LifeOpsGmailMessageSummary } from "@elizaos/shared";
 import {
@@ -102,6 +108,14 @@ type ComputerUseBrowserService = {
   ): Promise<BrowserActionResult>;
 };
 
+type BrowserActionExecutor = {
+  executeBrowserAction(
+    params: BrowserActionParams,
+  ): Promise<BrowserActionResult>;
+};
+
+const DEFAULT_SUBSCRIPTION_BROWSER_WAIT_MS = 5_000;
+
 function isComputerUseBrowserService(
   service: unknown,
 ): service is ComputerUseBrowserService {
@@ -111,6 +125,185 @@ function isComputerUseBrowserService(
     typeof (service as { executeBrowserAction?: unknown })
       .executeBrowserAction === "function"
   );
+}
+
+function isBrowserService(service: unknown): service is BrowserService {
+  return (
+    Boolean(service) &&
+    typeof service === "object" &&
+    typeof (service as { execute?: unknown }).execute === "function"
+  );
+}
+
+function resultRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function resultStringField(
+  value: unknown,
+  field: "title" | "url",
+): string | null {
+  const record = resultRecord(value);
+  const candidate = record?.[field];
+  return typeof candidate === "string" && candidate.trim() ? candidate : null;
+}
+
+function workspaceResultContent(
+  result: BrowserWorkspaceCommandResult,
+): string | null {
+  if (typeof result.value === "string") {
+    return result.value;
+  }
+  if (result.snapshot?.data) {
+    return result.snapshot.data;
+  }
+  if (result.value !== undefined) {
+    return JSON.stringify(result.value);
+  }
+  if (result.elements) {
+    return JSON.stringify(result.elements);
+  }
+  if (result.tab) {
+    return `${result.tab.title} ${result.tab.url}`.trim();
+  }
+  return null;
+}
+
+function workspaceResultToBrowserActionResult(
+  result: BrowserWorkspaceCommandResult,
+): BrowserActionResult {
+  const content = workspaceResultContent(result);
+  return {
+    success: true,
+    message: `browser workspace ${result.subaction} completed`,
+    content,
+    url: result.tab?.url ?? resultStringField(result.value, "url"),
+    title: result.tab?.title ?? resultStringField(result.value, "title"),
+    data: {
+      mode: result.mode,
+      subaction: result.subaction,
+      value: result.value,
+      tab: result.tab,
+      elements: result.elements,
+    },
+    screenshot: result.snapshot?.data ?? null,
+  };
+}
+
+class BrowserServiceActionExecutor implements BrowserActionExecutor {
+  private currentTabId: string | null = null;
+
+  constructor(private readonly browser: BrowserService) {}
+
+  async executeBrowserAction(
+    params: BrowserActionParams,
+  ): Promise<BrowserActionResult> {
+    try {
+      const command = await this.toWorkspaceCommand(params);
+      const result = await this.browser.execute(command, "workspace");
+      if (result.tab?.id) {
+        this.currentTabId = result.tab.id;
+      }
+      return workspaceResultToBrowserActionResult(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        message,
+        error: message,
+      };
+    }
+  }
+
+  private async toWorkspaceCommand(
+    params: BrowserActionParams,
+  ): Promise<BrowserWorkspaceCommand> {
+    const id = this.currentTabId ?? undefined;
+    switch (params.action) {
+      case "open": {
+        const reusableId = await this.findReusableBlankWorkspaceTabId();
+        if (reusableId) {
+          return { id: reusableId, subaction: "navigate", url: params.url };
+        }
+        return { show: true, subaction: "open", url: params.url };
+      }
+      case "navigate":
+        return id
+          ? { id, subaction: "navigate", url: params.url }
+          : { show: true, subaction: "open", url: params.url };
+      case "wait":
+        return {
+          ...(id ? { id } : {}),
+          ...(params.selector ? { selector: params.selector } : {}),
+          ...(params.text ? { text: params.text } : {}),
+          subaction: "wait",
+          timeoutMs: params.timeout ?? DEFAULT_SUBSCRIPTION_BROWSER_WAIT_MS,
+        };
+      case "click":
+        return {
+          ...(id ? { id } : {}),
+          ...(params.selector
+            ? { selector: params.selector }
+            : { findBy: "text", text: params.text }),
+          subaction: "click",
+        };
+      case "get_dom":
+        return {
+          ...(id ? { id } : {}),
+          getMode: "html",
+          selector: "body",
+          subaction: "get",
+        };
+      case "screenshot":
+        return {
+          ...(id ? { id } : {}),
+          fullPage: true,
+          subaction: "screenshot",
+        };
+    }
+  }
+
+  private async findReusableBlankWorkspaceTabId(): Promise<string | null> {
+    try {
+      const result = await this.browser.execute(
+        { subaction: "list" },
+        "workspace",
+      );
+      const tabs = result.tabs ?? [];
+      const current = this.currentTabId
+        ? tabs.find(
+            (candidate) =>
+              candidate.id === this.currentTabId &&
+              candidate.visible &&
+              candidate.url.trim() === "about:blank",
+          )
+        : null;
+      const tab =
+        current ??
+        tabs.find(
+          (candidate) =>
+            candidate.visible && candidate.url.trim() === "about:blank",
+        );
+      return tab?.id ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function resolveAgentBrowserExecutor(
+  runtime: IAgentRuntime,
+): BrowserActionExecutor | null {
+  const computerUseService = runtime.getService("computeruse");
+  if (isComputerUseBrowserService(computerUseService)) {
+    return computerUseService;
+  }
+  const browserService = runtime.getService(BROWSER_SERVICE_TYPE);
+  return isBrowserService(browserService)
+    ? new BrowserServiceActionExecutor(browserService)
+    : null;
 }
 
 type BrowserSignalProbe = {
@@ -420,10 +613,10 @@ function extractEvidenceMessages(
 }
 
 async function probeBrowserSignals(
-  computerUse: ComputerUseBrowserService,
+  browser: BrowserActionExecutor,
   playbook: LifeOpsSubscriptionPlaybook,
 ): Promise<BrowserSignalProbe> {
-  const dom = await computerUse.executeBrowserAction({ action: "get_dom" });
+  const dom = await browser.executeBrowserAction({ action: "get_dom" });
   const blob = browserResultText(dom);
   for (const marker of playbook.cancellationMarkers) {
     if (blob.includes(marker.toLowerCase())) {
@@ -453,8 +646,23 @@ async function probeBrowserSignals(
   return { status: "clear", detail: null };
 }
 
+function selectorForBrowserClickTextStep(
+  playbook: LifeOpsSubscriptionPlaybook,
+  step: Extract<SubscriptionAutomationStep, { kind: "click_text" }>,
+): string | undefined {
+  const clickText = step.text.trim().toLowerCase();
+  if (clickText === "cancel subscription") {
+    return playbook.companionSelectors?.cancel;
+  }
+  if (clickText === "confirm cancellation") {
+    return playbook.companionSelectors?.confirm;
+  }
+  return undefined;
+}
+
 async function executeBrowserStep(
-  computerUse: ComputerUseBrowserService,
+  browser: BrowserActionExecutor,
+  playbook: LifeOpsSubscriptionPlaybook,
   step: SubscriptionAutomationStep,
 ): Promise<BrowserActionResult> {
   const params: BrowserActionParams = ((): BrowserActionParams => {
@@ -471,8 +679,10 @@ async function executeBrowserStep(
           selector: step.selector,
           timeout: step.timeoutMs,
         };
-      case "click_text":
-        return { action: "click", text: step.text };
+      case "click_text": {
+        const selector = selectorForBrowserClickTextStep(playbook, step);
+        return { action: "click", selector, text: step.text };
+      }
       case "click_selector":
         return { action: "click", selector: step.selector };
       case "assert_text":
@@ -481,7 +691,7 @@ async function executeBrowserStep(
         return { action: "screenshot" };
     }
   })();
-  return computerUse.executeBrowserAction(params);
+  return browser.executeBrowserAction(params);
 }
 
 function findServiceInText(
@@ -951,15 +1161,12 @@ export class SubscriptionsService {
       return { cancellation, candidate };
     }
 
-    const computerUseService = this.runtime.getService("computeruse");
-    const computerUse = isComputerUseBrowserService(computerUseService)
-      ? computerUseService
-      : null;
-    if (!computerUse) {
+    const browser = resolveAgentBrowserExecutor(this.runtime);
+    if (!browser) {
       cancellation = {
         ...cancellation,
         status: "failed",
-        error: "Computer-use service is not available.",
+        error: "Agent browser service is not available.",
         updatedAt: new Date().toISOString(),
         finishedAt: new Date().toISOString(),
       };
@@ -1001,7 +1208,7 @@ export class SubscriptionsService {
         return { cancellation, candidate };
       }
 
-      const result = await executeBrowserStep(computerUse, step);
+      const result = await executeBrowserStep(browser, playbook, step);
       if (!result.success) {
         cancellation = {
           ...cancellation,
@@ -1029,7 +1236,7 @@ export class SubscriptionsService {
         });
       }
 
-      const probe = await probeBrowserSignals(computerUse, playbook);
+      const probe = await probeBrowserSignals(browser, playbook);
       if (probe.status === "needs_login") {
         cancellation = {
           ...cancellation,
@@ -1083,7 +1290,7 @@ export class SubscriptionsService {
       }
     }
 
-    const finalProbe = await probeBrowserSignals(computerUse, playbook);
+    const finalProbe = await probeBrowserSignals(browser, playbook);
     cancellation = {
       ...cancellation,
       status: finalProbe.status === "completed" ? "completed" : "blocked",

--- a/plugins/plugin-finances/test/subscriptions-service.real-db.test.ts
+++ b/plugins/plugin-finances/test/subscriptions-service.real-db.test.ts
@@ -19,6 +19,11 @@ import {
   createRealTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../packages/test/helpers/real-runtime.ts";
+import { browserPlugin } from "../../plugin-browser/src/plugin.ts";
+import {
+  __resetBrowserWorkspaceStateForTests,
+  executeBrowserWorkspaceCommand,
+} from "../../plugin-browser/src/workspace/browser-workspace.ts";
 import financesPlugin from "../src/plugin.ts";
 import type { SubscriptionsBrowserGateway } from "../src/services/browser-bridge-seam.ts";
 import type { SubscriptionsGmailGateway } from "../src/services/gmail-seam.ts";
@@ -73,6 +78,86 @@ const noCompanionBrowser: SubscriptionsBrowserGateway = {
   },
 };
 
+const GOOGLE_PLAY_SUBSCRIPTIONS_URL =
+  "https://play.google.com/store/account/subscriptions";
+
+const googlePlayFixtureRoutes = [
+  {
+    url: GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+    title: "Google Play Subscriptions",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<h2>Subscriptions</h2>",
+      `<form method="get" action="${GOOGLE_PLAY_SUBSCRIPTIONS_URL}">`,
+      '<input type="hidden" name="confirm" value="1" />',
+      '<button data-lifeops-action="cancel-subscription" type="submit">Cancel subscription</button>',
+      "</form>",
+      "</main>",
+    ].join(""),
+  },
+  {
+    url: `${GOOGLE_PLAY_SUBSCRIPTIONS_URL}?canceled=1`,
+    title: "Google Play Cancellation Complete",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<p>subscription canceled</p>",
+      "</main>",
+    ].join(""),
+  },
+  {
+    url: `${GOOGLE_PLAY_SUBSCRIPTIONS_URL}?confirm=1`,
+    title: "Google Play Confirm Cancellation",
+    body: [
+      "<main>",
+      "<h1>Google Play</h1>",
+      "<p>Confirm cancellation</p>",
+      `<form method="get" action="${GOOGLE_PLAY_SUBSCRIPTIONS_URL}">`,
+      '<input type="hidden" name="canceled" value="1" />',
+      '<button data-lifeops-action="confirm-cancellation" type="submit">Confirm cancellation</button>',
+      "</form>",
+      "</main>",
+    ].join(""),
+  },
+] as const;
+
+async function seedGooglePlayWorkspaceFixture(): Promise<void> {
+  delete process.env.ELIZA_BROWSER_WORKSPACE_URL;
+  delete process.env.ELIZA_BROWSER_WORKSPACE_TOKEN;
+  __resetBrowserWorkspaceStateForTests();
+
+  const opened = await executeBrowserWorkspaceCommand({
+    show: true,
+    subaction: "open",
+    title: "Google Play Fixture",
+    url: "about:blank",
+  });
+  const tabId = opened.tab?.id;
+  if (!tabId) {
+    throw new Error(
+      "browser workspace did not create a Google Play fixture tab",
+    );
+  }
+
+  for (const route of googlePlayFixtureRoutes) {
+    await executeBrowserWorkspaceCommand({
+      id: tabId,
+      networkAction: "route",
+      responseBody: [
+        "<!doctype html>",
+        "<html>",
+        `<head><title>${route.title}</title></head>`,
+        `<body>${route.body}</body>`,
+        "</html>",
+      ].join(""),
+      responseStatus: 200,
+      subaction: "network",
+      url: route.url,
+    });
+  }
+}
+
 describe("SubscriptionsService — real PGLite", () => {
   let runtime: AgentRuntime;
   let testResult: RealTestRuntimeResult;
@@ -80,7 +165,7 @@ describe("SubscriptionsService — real PGLite", () => {
   beforeAll(async () => {
     testResult = await createRealTestRuntime({
       characterName: "subscriptions-real-db-tests",
-      plugins: [financesPlugin],
+      plugins: [financesPlugin, browserPlugin],
     });
     runtime = testResult.runtime;
   }, 180_000);
@@ -197,7 +282,10 @@ describe("SubscriptionsService — real PGLite", () => {
         executor: "agent_browser",
         confirmed: true,
       });
-      expect(summary.cancellation.status).toBe("completed");
+      expect(
+        summary.cancellation.status,
+        JSON.stringify(summary.cancellation, null, 2),
+      ).toBe("completed");
 
       // Round-trips through the real DB.
       const status = await service.getSubscriptionCancellationStatus({
@@ -209,6 +297,51 @@ describe("SubscriptionsService — real PGLite", () => {
       (runtime as any).getService = originalGetService;
     }
   });
+
+  it("drives an agent_browser cancellation through BrowserService workspace when computeruse is absent", async () => {
+    await seedGooglePlayWorkspaceFixture();
+
+    type RuntimeGetService = AgentRuntime["getService"];
+    const mutableRuntime = runtime as AgentRuntime & {
+      getService: RuntimeGetService;
+    };
+    const originalGetService = mutableRuntime.getService.bind(runtime);
+    mutableRuntime.getService = ((serviceType: string) => {
+      if (serviceType === "computeruse") {
+        return null;
+      }
+      return originalGetService(serviceType);
+    }) as RuntimeGetService;
+
+    try {
+      const service = new SubscriptionsService(runtime, {
+        gmailGateway: emptyGmail,
+        browserGateway: noCompanionBrowser,
+      });
+      const summary = await service.cancelSubscription({
+        serviceSlug: "google_play",
+        executor: "agent_browser",
+        confirmed: true,
+      });
+
+      if (summary.cancellation.status !== "completed") {
+        throw new Error(JSON.stringify(summary.cancellation, null, 2));
+      }
+      expect(summary.cancellation.artifactCount).toBeGreaterThanOrEqual(1);
+      expect(summary.cancellation.evidenceSummary).toBe(
+        "subscription canceled",
+      );
+      expect(summary.cancellation.metadata.artifacts).toEqual([
+        expect.objectContaining({
+          kind: "screenshot",
+          label: "google-play-cancelled",
+        }),
+      ]);
+    } finally {
+      mutableRuntime.getService = originalGetService as RuntimeGetService;
+      __resetBrowserWorkspaceStateForTests();
+    }
+  }, 30_000);
 
   it("creates a user_browser session via the mocked browser gateway", async () => {
     const created: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Adds a BrowserService-backed `agent_browser` adapter for subscription cancellation when `computeruse` is absent.
- Upgrades the Google Play subscription cancellation scenario from fake `computeruse` to the Browser Workspace backend with seeded JSDOM routes.
- Adds a real PGLite integration test proving the Google Play playbook completes through BrowserService workspace execution and records screenshot evidence.

## Evidence
- `bun install` after rebasing onto `origin/develop`
- `bunx @biomejs/biome check plugins/plugin-finances/src/services/subscriptions-service.ts plugins/plugin-finances/test/subscriptions-service.real-db.test.ts packages/test/scenarios/browser.lifeops/subscriptions.cancel-google-play.scenario.ts`
- `git diff --check origin/develop...HEAD`
- `bun run --cwd plugins/plugin-finances test -- test/subscriptions-service.real-db.test.ts` → 6 tests passed
- `bun run --cwd plugins/plugin-finances build`
- `bun run verify` → 508 successful / 508 total

## Notes
- This covers the real BrowserService → Browser Workspace JSDOM backend path. Live Chromium/Stagehand/browser-driver evidence remains out of scope for this slice.

Fixes #9476