### PR TITLE
fix(cloud): deploy-status 500 on cached app reads (real-staging #9300 blocker)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
@@ -42,6 +42,18 @@ describe("deploymentIdFor", () => {
   test("uses 0 sentinel when last_deployed_at is null", () => {
     expect(deploymentIdFor({ id: "app_2", last_deployed_at: null })).toBe("app_2:0");
   });
+  // Regression (#9300): a cached `appsService.getById` read round-trips the
+  // timestamp through JSON, so `last_deployed_at` arrives as an ISO STRING.
+  // Calling `.toISOString()` on it threw → the deploy-status route 500'd on
+  // real staging. The helper must coerce a string the same as a Date.
+  test("coerces an ISO-string last_deployed_at (cached read) without throwing", () => {
+    expect(
+      deploymentIdFor({
+        id: "app_3",
+        last_deployed_at: "2026-05-19T15:00:00.000Z",
+      }),
+    ).toBe("app_3:2026-05-19T15:00:00.000Z");
+  });
 });
 
 describe("assertDeployable", () => {

--- a/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
@@ -32,8 +32,17 @@ export function publicStatusFor(persisted: AppDeploymentStatus): DeploymentStatu
   return PERSISTED_TO_PUBLIC[persisted];
 }
 
-export function deploymentIdFor(app: { id: string; last_deployed_at: Date | null }): string {
-  const ts = app.last_deployed_at?.toISOString() ?? "0";
+export function deploymentIdFor(app: {
+  id: string;
+  // Cached reads (`appsService.getById` → Redis/KV) round-trip the timestamp
+  // through JSON, so `last_deployed_at` arrives as an ISO STRING, not a Date.
+  // Accept both and coerce — calling `.toISOString()` on a string 500s the
+  // deploy-status route (the real-staging deploy bug behind #9300).
+  last_deployed_at: Date | string | null;
+}): string {
+  const ts = app.last_deployed_at
+    ? new Date(app.last_deployed_at).toISOString()
+    : "0";
   return `${app.id}:${ts}`;
 }
 

--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -186,7 +186,12 @@ export class AppDeploymentsService {
       status: publicStatusFor(app.deployment_status),
       vercelUrl: app.production_url ?? null,
       error: null,
-      startedAt: app.last_deployed_at?.toISOString() ?? new Date(0).toISOString(),
+      // `app` may come from the Redis/KV cache (`getById`), where the timestamp
+      // round-tripped through JSON to an ISO STRING — `new Date(...)` coerces both
+      // a Date and a string; calling `.toISOString()` on the raw string 500s.
+      startedAt: app.last_deployed_at
+        ? new Date(app.last_deployed_at).toISOString()
+        : new Date(0).toISOString(),
     };
   }
 }


### PR DESCRIPTION
## What & why

The real-Hetzner nightly (`monetized-loop-nightly.yml`, dispatched run
[28136578239](https://github.com/elizaOS/eliza/actions/runs/28136578239)) failed:
the EDAD real-deploy driver got a clean `POST /deploy` → `202 BUILDING`, then
**`GET /api/v1/apps/:id/deploy/status` returned `500` for the entire ~5-minute
poll** (both attempts), so it never reached READY. This is the last blocker to
proving #9300's real `*.apps.elizacloud.ai` deploy from CI.

## Root cause

`appsService.getById` serves the app from a Redis/KV **cache**. A cached read
round-trips through JSON, so the `last_deployed_at` timestamp comes back as an ISO
**string**, not a `Date`. Both `getLatestDeployment` and `deploymentIdFor` then
called `last_deployed_at.toISOString()` — which throws `TypeError` on a string →
`failureResponse` → **500 on every status poll**.

The mock-stack e2e (`remote-app-deploy.spec.ts`, `example-apps-showcase.spec.ts`)
never caught it because `MOCK_REDIS` keeps `Date` objects in memory; only the real
cache JSON-serializes the date. That's the exact "green locally, 500 on staging"
split we saw.

## Fix

Coerce with `new Date(value)` (accepts both a `Date` and an ISO string) in
`getLatestDeployment` and `deploymentIdFor`, and widen `deploymentIdFor`'s param
type to `Date | string | null`. Regression test added for the cached string-date
case.

## Verification

- `app-deployments-helpers.test.ts` — **15/15 green** (incl. the new
  cached-string-date regression), 100% helper coverage.
- `cloud:e2e -- remote-app-deploy.spec.ts` — green (no regression on the Date path).
- cloud-shared typecheck clean on the changed files.
- Once merged, the next nightly real-Hetzner run (or a dispatch) should poll past
  BUILDING → READY instead of 500ing.

Fixes the deploy-status 500 blocking #9300's real-staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
