### PR TITLE
fix(health): fitbit distance reads only the 'total' summary row (not the sum) (#8795)

### DIFF
--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -441,10 +441,19 @@ async function syncFitbit(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
     const dayAt = `${date}T12:00:00.000Z`;
     const summary = getRecord(activity, "summary") ?? {};
     const distances = getArray(summary, "distances");
-    const totalDistance = distances.reduce((sum, entry) => {
-      const distance = getNumber(entry, "distance");
-      return sum + (distance ?? 0);
-    }, 0);
+    // Fitbit's summary.distances[] carries the day total as the
+    // `activity: "total"` row; the other rows (tracker, veryActive, …) are
+    // breakdowns OF that total, not additional distance. Read the "total" row;
+    // if a provider omits it, fall back to the largest single row.
+    const totalRow = distances.find(
+      (entry) => getText(entry, "activity") === "total",
+    );
+    const totalDistance = totalRow
+      ? (getNumber(totalRow, "distance") ?? 0)
+      : distances.reduce(
+          (max, entry) => Math.max(max, getNumber(entry, "distance") ?? 0),
+          0,
+        );
     samples.push(
       ...compactSamples([
         sample({

--- a/plugins/plugin-health/test/fitbit-connector.contract.test.ts
+++ b/plugins/plugin-health/test/fitbit-connector.contract.test.ts
@@ -129,16 +129,16 @@ describe("Fitbit connector — recorded real API contract", () => {
     expect(calories?.value).toBe(2415);
     expect(calories?.unit).toBe("kcal");
 
-    // distance_meters: the normalizer SUMS every summary.distances[] entry
-    // (not just the `activity: "total"` row) and converts km->m. With total
-    // 8.52 + tracker 8.52 + veryActive 4.1 = 21.14 km -> 21140 m. This is the
-    // genuine syncFitbit behavior (it double-counts the total + per-type rows);
-    // the contract test pins it so any future change to that aggregation is
-    // caught against the real multi-entry Fitbit distances shape.
+    // distance_meters: the normalizer reads ONLY the `activity: "total"` row of
+    // summary.distances[] and converts km->m. The other rows (tracker 8.52,
+    // veryActive 4.1) are breakdowns OF the day total, not additional distance,
+    // so the day's 8.52 km -> 8520 m. The contract test pins this against the
+    // real multi-entry Fitbit distances shape so a regression back to summing
+    // every row (which 2.5x-inflated the distance) is caught.
     const distance = payload.samples.find(
       (s) => s.metric === "distance_meters",
     );
-    expect(distance?.value).toBeCloseTo((8.52 + 8.52 + 4.1) * 1000, 5);
+    expect(distance?.value).toBeCloseTo(8.52 * 1000, 5);
     expect(distance?.unit).toBe("m");
 
     // activities-heart[0].value.restingHeartRate -> resting_heart_rate.
@@ -232,5 +232,80 @@ describe("Fitbit connector — recorded real API contract", () => {
       expect(typeof s.startAt).toBe("string");
       expect(s.localDate).toBe(s.startAt.slice(0, 10));
     }
+  });
+
+  // Reads ONLY the `activity: "total"` row even when extra breakdown rows are
+  // present. tracker/veryActive/loggedActivities are subsets OF the total, so
+  // adding more of them must not change the reported distance.
+  it("takes only the 'total' summary.distances row, ignoring extra breakdown rows", async () => {
+    const activity = {
+      summary: {
+        distances: [
+          { activity: "total", distance: 8.52 },
+          { activity: "tracker", distance: 8.52 },
+          { activity: "veryActive", distance: 4.1 },
+          { activity: "loggedActivities", distance: 2.0 },
+        ],
+      },
+    };
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/activities/heart/")) return jsonResponse({});
+      if (url.includes("/activities/date/")) return jsonResponse(activity);
+      if (url.includes("/sleep/date/")) return jsonResponse({});
+      if (url.includes("/body/log/weight/")) return jsonResponse({});
+      if (url.includes("/profile.json")) return jsonResponse(recorded.profile);
+      throw new Error(`unexpected Fitbit fetch: ${url}`);
+    });
+
+    const payload = await syncHealthConnectorData({
+      token,
+      grantId: "grant-fitbit",
+      startDate: "2026-05-01",
+      endDate: "2026-05-01",
+    });
+
+    const distance = payload.samples.find(
+      (s) => s.metric === "distance_meters",
+    );
+    // Only the "total" row (8.52 km) is read; the extra breakdown rows are ignored.
+    expect(distance?.value).toBeCloseTo(8.52 * 1000, 5);
+    expect(distance?.unit).toBe("m");
+  });
+
+  // Fallback: a provider that omits the "total" row -> take the largest single
+  // row rather than summing (the largest is the best proxy for the day total).
+  it("falls back to the maximum single distance row when no 'total' row is present", async () => {
+    const activity = {
+      summary: {
+        distances: [
+          { activity: "tracker", distance: 8.52 },
+          { activity: "veryActive", distance: 4.1 },
+        ],
+      },
+    };
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/activities/heart/")) return jsonResponse({});
+      if (url.includes("/activities/date/")) return jsonResponse(activity);
+      if (url.includes("/sleep/date/")) return jsonResponse({});
+      if (url.includes("/body/log/weight/")) return jsonResponse({});
+      if (url.includes("/profile.json")) return jsonResponse(recorded.profile);
+      throw new Error(`unexpected Fitbit fetch: ${url}`);
+    });
+
+    const payload = await syncHealthConnectorData({
+      token,
+      grantId: "grant-fitbit",
+      startDate: "2026-05-01",
+      endDate: "2026-05-01",
+    });
+
+    const distance = payload.samples.find(
+      (s) => s.metric === "distance_meters",
+    );
+    // No "total" row -> max single row (8.52 km), NOT the sum (12.62 km).
+    expect(distance?.value).toBeCloseTo(8.52 * 1000, 5);
+    expect(distance?.unit).toBe("m");
   });
 });


### PR DESCRIPTION
Refs #8795. Finding id: **fitbit-distance-triple-counts-summary-rows** [high/bug].

## Root cause
`plugins/plugin-health/src/health-bridge/health-connectors.ts` (~L443) normalized the Fitbit `/1/user/-/activities/date/{date}.json` payload by **summing every** `summary.distances[]` entry:

```ts
const totalDistance = distances.reduce(
  (sum, entry) => sum + (getNumber(entry, "distance") ?? 0),
  0,
);
```

But the real Fitbit payload is:

```json
"distances": [
  { "activity": "total",      "distance": 8.52 },
  { "activity": "tracker",    "distance": 8.52 },
  { "activity": "veryActive", "distance": 4.1 }
]
```

The non-`total` rows are **breakdowns of** the day total, not additional distance. So an 8.52 km day was emitted as `(8.52 + 8.52 + 4.1) * 1000 = 21140 m` — ~2.5x the truth. The contract test at `plugins/plugin-health/test/fitbit-connector.contract.test.ts` had **enshrined** this bug (asserting `21140`).

## Fix
- Read the `activity: "total"` row and convert km→m. When a provider omits a `total` row, fall back to the **largest single row** (robust proxy for the day total) instead of summing. Same `> 0 ? *1000 : null` shape/units, using the existing `getText`/`getNumber` helpers.
- Updated the contract test to assert `8.52 * 1000 = 8520` and corrected its stale comment.
- Added two new cases: an extra non-total breakdown row (`loggedActivities` 2.0) still yields `8520` (only `total` read), and a no-`total` payload that exercises the max-row fallback.

## Before / after test output
Command: `bunx vitest run test/fitbit-connector.contract.test.ts` (in `plugins/plugin-health`)

**Before (buggy source, new+updated tests):** all 3 fail
```
AssertionError: expected 21140 to be close to 8520, received difference is 12620 ... :141
AssertionError: expected 23140 to be close to 8520, received difference is 14620 ... :272  (extra breakdown row)
AssertionError: expected 12620 to be close to 8520, received difference is 4100  ... :308  (no-total fallback: max-row, not sum)
 Test Files  1 failed (1)
      Tests  3 failed (3)
```

**After (fix applied):**
```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full plugin suite stays green: `bunx vitest run` → `Test Files 28 passed | 4 skipped (32)`, `Tests 136 passed | 4 skipped (140)` (the 4 skipped are the keyed `*.real.test.ts` live-API tests). Biome clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)