### PR TITLE
fix(core): optimized-prompt refresh isolates per-task artifact errors (#8795)

### DIFF
--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -11,7 +11,13 @@
  *     scan when no symlink is present (legacy stores).
  */
 
-import { existsSync, mkdirSync, readlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readlinkSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -325,5 +331,62 @@ describe("OptimizedPromptService — HMAC integrity (SOC2 CC6.8)", () => {
 		);
 		await service.refresh();
 		expect(service.getPrompt("action_planner")).toBeNull();
+	});
+});
+
+describe("OptimizedPromptService — per-task error isolation (#8795)", () => {
+	let storeRoot: string;
+	let service: OptimizedPromptService;
+
+	beforeEach(async () => {
+		storeRoot = await mkdtemp(join(tmpdir(), "optimized-prompt-isolation-"));
+		service = new OptimizedPromptService();
+		service.setStoreRoot(storeRoot);
+	});
+
+	afterEach(async () => {
+		await rm(storeRoot, { recursive: true, force: true });
+	});
+
+	it("isolates a self-referential `current` symlink (ELOOP) — other tasks still load", async () => {
+		// One healthy task writes a real artifact via setPrompt.
+		await service.setPrompt("action_planner", makeArtifact(1));
+
+		// A second task's `current` symlink loops onto itself: reading it via
+		// readFile throws ELOOP. Before the fix this rethrew out of refresh()
+		// and disabled optimized prompts for ALL tasks.
+		const loopingDir = join(storeRoot, "should_respond");
+		mkdirSync(loopingDir, { recursive: true });
+		symlinkSync(
+			OPTIMIZED_PROMPT_CURRENT_LINK,
+			join(loopingDir, OPTIMIZED_PROMPT_CURRENT_LINK),
+		);
+
+		// refresh() must RESOLVE, not reject.
+		await expect(service.refresh()).resolves.toBeUndefined();
+
+		// The healthy task is cached; the looping task falls back to null.
+		expect(service.getPrompt("action_planner")?.prompt).toBe(
+			"optimized prompt v1",
+		);
+		expect(service.getPrompt("should_respond")).toBeNull();
+	});
+
+	it("isolates a directory named `X.json` (EISDIR) during the legacy scan — other tasks still load", async () => {
+		// Healthy task.
+		await service.setPrompt("action_planner", makeArtifact(1));
+
+		// Legacy-style task dir (no `current` symlink) where a directory is
+		// named like an artifact file. The fallback scan calls readFile on it,
+		// which throws EISDIR. Before the fix this rethrew out of refresh().
+		const brokenDir = join(storeRoot, "response");
+		mkdirSync(join(brokenDir, "v1.json"), { recursive: true });
+
+		await expect(service.refresh()).resolves.toBeUndefined();
+
+		expect(service.getPrompt("action_planner")?.prompt).toBe(
+			"optimized prompt v1",
+		);
+		expect(service.getPrompt("response")).toBeNull();
 	});
 });

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -617,41 +617,72 @@ export class OptimizedPromptService extends Service {
 	async refresh(): Promise<void> {
 		const next: Partial<Record<OptimizedPromptTask, CachedEntry>> = {};
 		for (const task of OPTIMIZED_PROMPT_TASKS) {
-			const dir = join(this.storeRoot, task);
-			if (!existsSync(dir)) continue;
-
-			// Preferred path: read via the `current` symlink. This is the
-			// declared live version after a `setPrompt` or `rollback` call.
-			const currentLink = join(dir, OPTIMIZED_PROMPT_CURRENT_LINK);
-			const fromCurrent = await loadArtifactFromPath(currentLink, task);
-			if (fromCurrent) {
-				next[task] = { artifact: fromCurrent, loadedAt: Date.now() };
-				continue;
-			}
-
-			// Fallback: directory may pre-date the symlink layout (legacy
-			// timestamp-named files), or `current` may have been deleted.
-			// Walk the directory and pick the artifact with the most recent
-			// `generatedAt`.
-			const entries = readdirSync(dir);
-			let bestArtifact: OptimizedPromptArtifact | null = null;
-			let bestStamp = -Infinity;
-			for (const name of entries) {
-				if (!name.endsWith(".json")) continue;
-				const path = join(dir, name);
-				const artifact = await loadArtifactFromPath(path, task);
-				if (!artifact) continue;
-				const stamp = Date.parse(artifact.generatedAt);
-				if (Number.isFinite(stamp) && stamp > bestStamp) {
-					bestStamp = stamp;
-					bestArtifact = artifact;
-				}
-			}
-			if (bestArtifact) {
-				next[task] = { artifact: bestArtifact, loadedAt: Date.now() };
+			// A corrupt / looping / permission-denied artifact for ONE task
+			// (ELOOP, EACCES, EISDIR, etc.) must not poison the other tasks or
+			// fail service start: an absent or unreadable artifact is a no-op,
+			// the task simply falls back to its baseline prompt. Isolate each
+			// task's disk reads so one bad directory leaves the rest cached.
+			try {
+				const entry = await this.loadTaskEntry(task);
+				if (entry) next[task] = entry;
+			} catch (err) {
+				const code = (err as NodeJS.ErrnoException).code;
+				logger.warn(
+					{
+						src: "service:optimized_prompt",
+						task,
+						code,
+						err,
+					},
+					"[OptimizedPromptService] Skipping task: artifact store unreadable — falling back to baseline",
+				);
 			}
 		}
 		this.cache = next;
+	}
+
+	/**
+	 * Load the live cache entry for a single task by reading its on-disk store.
+	 * Returns null when the task has no usable artifact. Throws only on
+	 * unexpected filesystem errors (e.g. ELOOP/EACCES/EISDIR), which
+	 * {@link refresh} isolates per task.
+	 */
+	private async loadTaskEntry(
+		task: OptimizedPromptTask,
+	): Promise<CachedEntry | null> {
+		const dir = join(this.storeRoot, task);
+		if (!existsSync(dir)) return null;
+
+		// Preferred path: read via the `current` symlink. This is the
+		// declared live version after a `setPrompt` or `rollback` call.
+		const currentLink = join(dir, OPTIMIZED_PROMPT_CURRENT_LINK);
+		const fromCurrent = await loadArtifactFromPath(currentLink, task);
+		if (fromCurrent) {
+			return { artifact: fromCurrent, loadedAt: Date.now() };
+		}
+
+		// Fallback: directory may pre-date the symlink layout (legacy
+		// timestamp-named files), or `current` may have been deleted.
+		// Walk the directory and pick the artifact with the most recent
+		// `generatedAt`.
+		const entries = readdirSync(dir);
+		let bestArtifact: OptimizedPromptArtifact | null = null;
+		let bestStamp = -Infinity;
+		for (const name of entries) {
+			if (!name.endsWith(".json")) continue;
+			const path = join(dir, name);
+			const artifact = await loadArtifactFromPath(path, task);
+			if (!artifact) continue;
+			const stamp = Date.parse(artifact.generatedAt);
+			if (Number.isFinite(stamp) && stamp > bestStamp) {
+				bestStamp = stamp;
+				bestArtifact = artifact;
+			}
+		}
+		if (bestArtifact) {
+			return { artifact: bestArtifact, loadedAt: Date.now() };
+		}
+		return null;
 	}
 }
 


### PR DESCRIPTION
Refs #8795. Finding id: **refresh-rethrows-corrupt-symlink-disables-all-tasks** (high / robustness, subsystem `optimized-prompt-service`).

## Root cause
`OptimizedPromptService.refresh()` (`packages/core/src/services/optimized-prompt.ts`) looped over every task with **no per-task error handling** and called `loadArtifactFromPath()`, which returns `null` only for `ENOENT` and **rethrows every other errno** (`ELOOP`, `EACCES`, `EISDIR`, ...) — both on the artifact `readFile` and the `.mac` sidecar read.

`start()` does `await service.refresh()` uncaught. `_runServiceStart` (runtime.ts) turns that throw into service status `"failed"`, and `optimized-prompt-resolver.ts` falls back to the baseline prompt when the service is null.

Net effect: a **single** task's corrupt / looping / permission-denied artifact (e.g. a self-referential `current` symlink → `ELOOP`, or a directory named `vN.json` → `EISDIR`) threw out of `refresh()`, failed service start, and disabled optimized prompts for **all 14+ tasks** — violating the documented contract that "an absent artifact is a no-op (never a failure)".

## Fix
- Extracted the per-task disk reads into a private `loadTaskEntry(task)`.
- Wrapped each task in `refresh()` in a `try/catch`: one unreadable task is **logged-and-skipped** (structured `logger.warn`, `[OptimizedPromptService]` prefix, `task` + errno `code` in context) and falls back to its baseline / stays null, while every other task stays cached and the **service stays alive**.
- The success path and the `this.cache = next` semantics are unchanged. Programmer errors are not silently swallowed — they're logged at warn with full context.

## Tests
New suite `OptimizedPromptService — per-task error isolation (#8795)` in `packages/core/src/services/optimized-prompt.test.ts`:
1. Self-referential `current` symlink (`ELOOP`) in one task dir + a valid artifact written via `setPrompt` in another: `refresh()` must resolve, the valid task is cached, the looping task is `null`.
2. A directory named `v1.json` (`EISDIR`) during the legacy directory scan: `refresh()` must resolve and other tasks still load.

### Before (on origin/develop source, new tests present)
```
 ❯ src/services/optimized-prompt.test.ts (16 tests | 2 failed)
   × isolates a self-referential `current` symlink (ELOOP) — other tasks still load
   × isolates a directory named `X.json` (EISDIR) during the legacy scan — other tasks still load

AssertionError: promise rejected "Error: ELOOP: too many symbolic links enc…" instead of resolving
 ❯ loadArtifactFromPath src/services/optimized-prompt.ts:791:9
 ❯ OptimizedPromptService.refresh src/services/optimized-prompt.ts:626:24

AssertionError: promise rejected "Error: EISDIR: illegal operation on a dir…" instead of resolving
 ❯ loadArtifactFromPath src/services/optimized-prompt.ts:791:9
 ❯ OptimizedPromptService.refresh src/services/optimized-prompt.ts:642:22

 Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 82 passed (84)
```

### After (with the fix)
```
$ bun run --cwd packages/core test -- optimized-prompt

 Test Files  2 passed (2)
      Tests  84 passed (84)
   Duration  359ms
```

## Verification
- `bun run --cwd packages/core test -- optimized-prompt` — 84 passed (82 pre-existing + 2 new).
- `bun run --cwd packages/core typecheck` — clean (after generating the gitignored `src/i18n/generated/` prebuild artifacts; the only modified source files are the two `optimized-prompt` files).
- `biome check` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)