### PR TITLE
fix(scheduling): register personal_baseline_sufficient gate so sleep-recap pack can fire (#8795)

### DIFF
--- a/plugins/plugin-health/package.json
+++ b/plugins/plugin-health/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
+    "@elizaos/plugin-scheduling": "workspace:*",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/plugins/plugin-health/src/default-packs/gate-coverage.test.ts
+++ b/plugins/plugin-health/src/default-packs/gate-coverage.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Cross-plugin guard: every `shouldFire.gate` kind referenced by any health
+ * default pack MUST resolve in plugin-scheduling's built-in gate registry.
+ *
+ * Why this lives here (#8795): `sleep-recap` referenced
+ * `personal_baseline_sufficient`, which `registerBuiltInGates` never
+ * registered. The runner treats an unregistered gate kind as a hard `deny`
+ * ("unknown gate kind: <kind>") → `status="skipped"` with no dispatch, so the
+ * pack could never fire. A zero-registrar gate is invisible to single-plugin
+ * tests; only a cross-plugin coverage check catches it. This guard fails the
+ * moment a pack adds a gate kind nobody registers.
+ */
+
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+
+import { HEALTH_DEFAULT_PACKS } from "./index.js";
+
+function collectReferencedGateKinds(): string[] {
+  const kinds = new Set<string>();
+  for (const pack of HEALTH_DEFAULT_PACKS) {
+    for (const record of pack.records) {
+      for (const gate of record.shouldFire?.gates ?? []) {
+        kinds.add(gate.kind);
+      }
+    }
+  }
+  return [...kinds];
+}
+
+describe("health default packs: gate coverage (#8795)", () => {
+  it("references at least one gate kind (guard is meaningful)", () => {
+    expect(collectReferencedGateKinds().length).toBeGreaterThan(0);
+  });
+
+  it("every referenced gate kind resolves in the built-in registry", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+
+    const unresolved = collectReferencedGateKinds().filter(
+      (kind) => reg.get(kind) === null,
+    );
+
+    // If this fails, a default pack references a gate kind that no plugin
+    // registers — that pack can NEVER fire (runner denies "unknown gate kind").
+    // Either register the gate in plugin-scheduling's registerBuiltInGates or
+    // remove the gate from the pack.
+    expect(unresolved).toEqual([]);
+  });
+
+  it("specifically resolves personal_baseline_sufficient (sleep-recap)", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    expect(collectReferencedGateKinds()).toContain(
+      "personal_baseline_sufficient",
+    );
+    expect(reg.get("personal_baseline_sufficient")).not.toBeNull();
+  });
+});

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -1,16 +1,29 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import {
   providerSdkAliases,
   providerSdkShimPlugin,
 } from "../../packages/test/vitest/provider-sdk-aliases";
 
+// Resolve `@elizaos/plugin-scheduling` to its in-repo source so the
+// cross-plugin gate-coverage guard (default-packs/gate-coverage.test.ts)
+// exercises the sibling package's actual `registerBuiltInGates` — not a
+// stale prebuilt `dist` or a hoisted node_modules copy. Keyed on the package
+// root so subpath imports still resolve normally.
+const aliases = {
+  ...providerSdkAliases,
+  "@elizaos/plugin-scheduling": fileURLToPath(
+    new URL("../plugin-scheduling/src/index.ts", import.meta.url),
+  ),
+};
+
 export default defineConfig({
   plugins: [providerSdkShimPlugin()],
   resolve: {
-    alias: providerSdkAliases,
+    alias: aliases,
   },
   test: {
-    alias: providerSdkAliases,
+    alias: aliases,
     // screen-time range helpers compute from the machine-local start of day;
     // pin the zone so these assertions are deterministic across dev + CI.
     env: { TZ: "America/Los_Angeles" },

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the built-in TaskGateRegistry.
+ *
+ * Regression coverage for the `personal_baseline_sufficient` gate (#8795):
+ * plugin-health's `sleep-recap` default pack references this gate kind, but it
+ * was never registered in `registerBuiltInGates`. The runner treats an
+ * unregistered gate kind as a hard `deny` ("unknown gate kind: <kind>"), so the
+ * pack could NEVER fire — every attempt skipped. These tests assert the gate
+ * resolves and that driving the sleep-recap gate kinds through the registry
+ * (the same lookup the runner performs) yields no "unknown gate kind" decision.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./gate-registry.js";
+import type {
+  GateDecision,
+  GateEvaluationContext,
+  ScheduledTask,
+} from "./types.js";
+
+/**
+ * The exact lookup the runner performs in `evaluateGates` — an unregistered
+ * kind resolves to a hard `deny`. Mirroring it here lets us prove the
+ * permanent-skip path is closed without standing up the full runner.
+ */
+function lookupGateDecision(
+  reg: ReturnType<typeof createTaskGateRegistry>,
+  kind: string,
+): GateDecision {
+  const contrib = reg.get(kind);
+  if (!contrib) {
+    return { kind: "deny", reason: `unknown gate kind: ${kind}` };
+  }
+  return { kind: "allow" };
+}
+
+function makeContext(task: ScheduledTask): GateEvaluationContext {
+  return {
+    task,
+    nowIso: "2026-05-09T12:00:00.000Z",
+    ownerFacts: { timezone: "UTC" },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+  };
+}
+
+/** Minimal sleep-recap-shaped task carrying the two gate kinds the pack uses. */
+function sleepRecapTask(): ScheduledTask {
+  return {
+    taskId: "t-sleep-recap",
+    kind: "recap",
+    promptInstructions: "recap",
+    trigger: {
+      kind: "relative_to_anchor",
+      anchorKey: "wake.confirmed",
+      offsetMinutes: 240,
+    },
+    priority: "low",
+    shouldFire: {
+      compose: "all",
+      gates: [
+        { kind: "personal_baseline_sufficient", params: { minSamples: 5 } },
+        { kind: "circadian_state_in", params: { states: ["awake"] } },
+      ],
+    },
+    respectsGlobalPause: true,
+    state: { status: "scheduled", followupCount: 0 },
+    source: "default_pack",
+    createdBy: "plugin-health",
+    ownerVisible: true,
+  };
+}
+
+describe("registerBuiltInGates: personal_baseline_sufficient (#8795)", () => {
+  it("registers a resolvable personal_baseline_sufficient gate", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    expect(reg.get("personal_baseline_sufficient")).not.toBeNull();
+  });
+
+  it("evaluates personal_baseline_sufficient to allow (warn-once fallthrough)", async () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const gate = reg.get("personal_baseline_sufficient");
+    expect(gate).not.toBeNull();
+    const decision = await gate?.evaluate(
+      sleepRecapTask(),
+      makeContext(sleepRecapTask()),
+    );
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("does not yield an 'unknown gate kind' decision for any sleep-recap gate", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const task = sleepRecapTask();
+    for (const gateRef of task.shouldFire?.gates ?? []) {
+      const decision = lookupGateDecision(reg, gateRef.kind);
+      expect(decision.kind).toBe("allow");
+      if (decision.kind === "deny") {
+        expect(decision.reason).not.toMatch(/unknown gate kind/);
+      }
+    }
+  });
+
+  it("still denies a genuinely unknown gate kind", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const decision = lookupGateDecision(reg, "does_not_exist");
+    expect(decision).toEqual({
+      kind: "deny",
+      reason: "unknown gate kind: does_not_exist",
+    });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
@@ -1,7 +1,8 @@
 /**
  * TaskGateRegistry. Built-in kinds: `weekend_skip`, `weekend_only`,
  * `weekday_only`, `late_evening_skip`, `quiet_hours`, `during_travel`,
- * `circadian_state_in`, `no_recent_user_message_in`.
+ * `circadian_state_in`, `no_recent_user_message_in`,
+ * `personal_baseline_sufficient`.
  *
  * The runner uses these gates in `shouldFire.gates`; composition is
  * the responsibility of the runner (`compose: "all" | "any" | "first_deny"`).
@@ -268,6 +269,18 @@ const noRecentUserMessageInGate = makeWarnOnceFallthroughGate(
   "Register a message-activity-aware contribution via TaskGateRegistry.register, or remove this gate from default packs.",
 );
 
+// `personal_baseline_sufficient` is referenced by plugin-health's
+// `sleep-recap` default pack (minSamples: 5) but the concrete data reader —
+// the sealed sleep-episode / baseline sample count exposed through the
+// circadian/sleep contract seam (`CircadianInsightContract`) — is not yet
+// wired into the runner. Until a caller registers a real contribution
+// (overwriting this), the gate falls through to `allow` and warns once so the
+// pack stops being permanently skipped as an UNKNOWN gate kind. Loud > silent.
+const personalBaselineSufficientGate = makeWarnOnceFallthroughGate(
+  "personal_baseline_sufficient",
+  "Register a baseline-sample-count-aware contribution (sleep-sample-count via the circadian/sleep contract seam) via TaskGateRegistry.register before plugin-health default packs load, or remove this gate from those packs.",
+);
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
@@ -313,4 +326,5 @@ export function registerBuiltInGates(reg: TaskGateRegistry): void {
   reg.register(duringTravelGate);
   reg.register(circadianStateInGate);
   reg.register(noRecentUserMessageInGate);
+  reg.register(personalBaselineSufficientGate);
 }


### PR DESCRIPTION
## Finding

`sleep-recap-pack-can-never-fire-unregistered-gate` [high/bug] — referenced in #8795.

## Root cause

`plugins/plugin-health/src/default-packs/sleep-recap.ts` declares a `shouldFire` gate of kind **`personal_baseline_sufficient`**:

```ts
shouldFire: {
  compose: "all",
  gates: [
    { kind: "personal_baseline_sufficient", params: { minSamples: 5 } },
    { kind: "circadian_state_in", params: { states: ["awake"] } },
  ],
},
```

`registerBuiltInGates` in `plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts` registered **8** gates but **not** `personal_baseline_sufficient`. The other two health gates (`circadian_state_in`, `no_recent_user_message_in`) are registered as warn-once fallthrough gates via `makeWarnOnceFallthroughGate`; `personal_baseline_sufficient` was missing entirely.

The runner's gate evaluation (`runner.ts`) returns a hard `deny` with reason `unknown gate kind: <kind>` on a null registry lookup, which `runner.ts` then converts to `status="skipped"` with **no dispatch**. Net: the `sleep-recap` pack could **never** fire. A repo grep confirms `personal_baseline_sufficient` appears only in `sleep-recap.ts` with zero registrars.

## Fix

Register `personal_baseline_sufficient` in `registerBuiltInGates` exactly the way `circadian_state_in` / `no_recent_user_message_in` are registered — as a `makeWarnOnceFallthroughGate` (resolves to `allow` with a documented one-time warn + a reader-seam comment noting the concrete data reader, sleep-sample-count via the circadian/sleep contract seam, is not yet wired). This only stops the permanent-skip; it makes **no** product/safety-behavior decision.

This is purely additive — one new gate registration. No runtime fire/deny semantics of the already-registered gates were altered (full plugin-scheduling suite stays at 106 passing; full plugin-health suite at 137 passing / 4 skipped).

### Tests added

1. `plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts` — asserts `registerBuiltInGates(...).get('personal_baseline_sufficient')` is non-null and that driving `sleepRecapDefaultPack`'s gate kinds through the runner's exact lookup yields no `unknown gate kind` decision (a genuinely unknown kind still denies).
2. `plugins/plugin-health/src/default-packs/gate-coverage.test.ts` — a **cross-plugin** guard importing `HEALTH_DEFAULT_PACKS` + `registerBuiltInGates`, asserting **every** gate kind referenced by every pack record resolves in the registry. This prevents future zero-registrar gates. (Resolves `@elizaos/plugin-scheduling` to its in-repo source via a vitest alias + workspace `devDependency`.)

## Before / after test output

**Before the fix** (registration line removed to simulate pre-fix state):

plugin-scheduling:
```
 FAIL  src/scheduled-task/gate-registry.test.ts > ... evaluates personal_baseline_sufficient to allow
AssertionError: expected null not to be null
 FAIL  src/scheduled-task/gate-registry.test.ts > ... does not yield an 'unknown gate kind' decision for any sleep-recap gate
AssertionError: expected 'deny' to be 'allow'
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

plugin-health (cross-plugin guard):
```
 FAIL  src/default-packs/gate-coverage.test.ts > ... every referenced gate kind resolves in the built-in registry
AssertionError: expected [ 'personal_baseline_sufficient' ] to deeply equal []
 FAIL  src/default-packs/gate-coverage.test.ts > ... specifically resolves personal_baseline_sufficient (sleep-recap)
AssertionError: expected null not to be null
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

**After the fix:**

plugin-scheduling:
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

plugin-health:
```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suites (no regressions):
```
plugin-scheduling: Test Files 9 passed (9) | Tests 106 passed (106)
plugin-health:     Test Files 29 passed | 4 skipped (33) | Tests 137 passed | 4 skipped (141)
```

### Test commands

```bash
bun run --cwd plugins/plugin-scheduling exec vitest run src/scheduled-task/gate-registry.test.ts
bun run --cwd plugins/plugin-health     exec vitest run src/default-packs/gate-coverage.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
