### PR TITLE
fix(dev-smoke): pre-bundle buffer so the vite dev app mounts (#9452)

### DIFF
--- a/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Provider-INDEPENDENT dev-server render guard (#9452).
+ *
+ * The sibling `bun-dev-onboarding-chat.spec.ts` `test.skip()`s without a live
+ * provider key, so on most CI runs the dev-smoke lane went green-via-skip — and
+ * a whole class of "the app never mounts" regression slipped through unseen. The
+ * concrete one (#9452): a workspace `import { Buffer } from "node:buffer"`
+ * (e.g. `@elizaos/core`'s `features/documents/utils`, re-exported from both core
+ * barrels and therefore eager) was served by the vite dev server as raw,
+ * untransformed CommonJS — `noDiscovery` is on and `buffer` was not pre-bundled,
+ * so the `buffer`/`node:buffer` → feross-`index.js` alias resolved to a CJS file
+ * the browser's ESM loader can't evaluate. It threw "does not provide an export
+ * named 'Buffer'" at module-eval, blanking the ENTIRE React tree on every route
+ * (the production rollup build is unaffected, which is why only this lane was
+ * red). The chat composer never painting was just the visible symptom.
+ *
+ * This spec runs unconditionally and asserts the cheapest invariant that the
+ * crash violates: the shell mounts *something* into `#root` and no fatal
+ * module-eval error fires. It needs no onboarding, no provider, and no model —
+ * the startup/first-run screen is enough to prove the bundle evaluates.
+ */
+test.describe("bun run dev app shell renders", () => {
+  test("mounts the React shell without a fatal module-eval error", async ({
+    page,
+  }) => {
+    const fatalErrors: string[] = [];
+    page.on("pageerror", (error) => {
+      fatalErrors.push(error.message);
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // A blank `#root` means a module-eval crash blanked the tree (the #9452
+    // failure mode). Any startup/onboarding/app content satisfies this.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.getElementById("root")?.childElementCount ?? 0,
+          ),
+        { timeout: 60_000 },
+      )
+      .toBeGreaterThan(0);
+
+    expect(
+      fatalErrors,
+      `fatal page errors during boot:\n${fatalErrors.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2811,6 +2811,18 @@ export const INVALID_TRACER_PROVIDER = {};
       "date-fns-jalali/locale",
       // Resolvable via the resolve.alias above (transitive through @elizaos/core).
       "@opentelemetry/api",
+      // Pre-bundle the feross `buffer` so the dev server serves it as ESM with a
+      // named `Buffer` export. `noDiscovery` is on, so without this the
+      // `resolve.alias` (buffer/node:buffer → the raw `.bun/buffer/index.js`)
+      // serves untransformed CommonJS; a workspace source's
+      // `import { Buffer } from "node:buffer"` (e.g. core's documents/utils, in
+      // BOTH core barrels and therefore eager) then throws "does not provide an
+      // export named 'Buffer'" at module-eval and blanks the whole app — only in
+      // the vite dev server (`bun run dev`), which is why the dev-smoke lane is
+      // red while production rollup builds are fine. esbuild's CJS interop on
+      // the pre-bundle exposes the static `exports.Buffer = Buffer` as a named
+      // ESM export. See #9452.
+      ...(bufferEntry ? ["buffer", "node:buffer"] : []),
     ],
     // Remap node: builtins to npm polyfills during dep optimization so
     // Rolldown doesn't externalize them as browser-incompatible node:* imports.


### PR DESCRIPTION
Fixes #9452.

## Root cause (captured, not hypothesized)

I reproduced the failure locally end-to-end with a live provider (`bun run --cwd packages/app test:dev-smoke` against Cerebras) and captured the artifact the issue was blocked on. The `/chat` composer never paints because the **entire React tree is blank** — not a startup/auth gate as earlier hypothesized.

The Playwright trace + screenshot show an empty `#root` (innerHTML length 0) and exactly one fatal `pageerror`:

```
The requested module '/@fs/.../node_modules/.bun/buffer@6.0.3/node_modules/buffer/index.js?v=...'
does not provide an export named 'Buffer'
```

Mechanism:
- `packages/app/vite.config.ts` aliases `buffer`/`node:buffer` → the raw feross `.bun/.../buffer/index.js` (added to give the crypto graph a callable `Buffer`).
- `optimizeDeps.noDiscovery` is on, and `buffer` was **not** in `optimizeDeps.include`, so the dev server served that alias target as **untransformed CommonJS** (`require('base64-js')`, `exports.Buffer = …`).
- A workspace source's eager `import { Buffer } from "node:buffer"` — e.g. `@elizaos/core`'s `features/documents/utils`, re-exported from **both** core barrels and pulled in via `--conditions=eliza-source` — fails to resolve the named `Buffer` ESM export, throws at module-eval, and blanks the whole app on every route.
- Production rollup builds handle the CJS→ESM interop, so **only `bun run dev`** (the dev-smoke path) is affected — exactly why this one lane was deterministically red.

## Fix

Add `buffer`/`node:buffer` to `optimizeDeps.include` so esbuild's CJS interop pre-bundles the static `exports.Buffer = Buffer` into a proper named ESM export the dev server serves.

## Regression guard

`test/dev-smoke/bun-dev-app-shell.spec.ts` — a **provider-independent** render guard. The existing chat spec `test.skip()`s without a live provider key, so this "app never mounts" class of bug slipped through as green-via-skip. The new spec asserts the shell mounts content into `#root` with no fatal module-eval error, and runs on **every** dev-smoke execution.

## Verification (local)

| | before fix | after fix |
|---|---|---|
| `#root` innerHTML length | **0** (blank) | **30202** |
| composer visible | no | **yes** |
| `pageerror` count | 1 (buffer SyntaxError) | **0** |
| `bun-dev-app-shell.spec.ts` | fails (blank) | **passes (5.5s)** |

```
Running 2 tests using 1 worker
  ✓  1 … bun-dev-app-shell.spec.ts … mounts the React shell without a fatal module-eval error (5.5s)
  -  2 … bun-dev-onboarding-chat.spec.ts … (skipped — no provider)
  1 skipped
  1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)