### PR TITLE
feat(#9449 Pillar C): needs-attention surface — PendingUserAction + GET /api/approvals + home widget

### DIFF
--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -1,0 +1,198 @@
+import type http from "node:http";
+import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
+import { ApprovalService, ServiceType } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  approvalTaskToPendingAction,
+  handleApprovalRoute,
+} from "./approval-routes";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+/**
+ * Minimal runtime exposing the `getTasks` query the ApprovalService uses, seeded
+ * with a fixed task list. `getTasks` honors the agentIds filter (multi-tenant
+ * safety) so the route only ever sees this agent's pending approvals.
+ */
+async function makeRuntimeWithService(tasks: Task[]): Promise<{
+  runtime: { getService: (t: string) => unknown };
+  service: ApprovalService;
+}> {
+  const baseRuntime = {
+    agentId: AGENT_ID,
+    getTasks: vi.fn(
+      async (params: { tags?: string[]; agentIds: UUID[] }): Promise<Task[]> => {
+        if (!params.agentIds.includes(AGENT_ID)) return [];
+        const wanted = new Set(params.tags ?? []);
+        return tasks.filter((task) =>
+          [...wanted].every((tag) => task.tags?.includes(tag)),
+        );
+      },
+    ),
+  } as unknown as IAgentRuntime;
+  const service = (await ApprovalService.start(
+    baseRuntime,
+  )) as ApprovalService;
+  const runtime = {
+    getService: (t: string) => (t === ServiceType.APPROVAL ? service : null),
+  };
+  return { runtime, service };
+}
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  return { json, error, readJsonBody };
+}
+
+const req = (url: string) => ({ url }) as http.IncomingMessage;
+const res = {} as http.ServerResponse;
+
+function approvalTask(patch: Partial<Task> & { id: string }): Task {
+  return {
+    id: patch.id as UUID,
+    name: patch.name ?? "EXEC_APPROVAL",
+    description: patch.description ?? "Run rm -rf /tmp/cache?",
+    roomId: (patch.roomId ?? "11111111-1111-1111-1111-111111111111") as UUID,
+    tags: patch.tags ?? ["AWAITING_CHOICE", "APPROVAL"],
+    createdAt: patch.createdAt ?? 1_000,
+    metadata: patch.metadata,
+  };
+}
+
+describe("approvalTaskToPendingAction", () => {
+  it("projects a task into a PendingUserAction with options + createdAt", () => {
+    const action = approvalTaskToPendingAction(
+      approvalTask({
+        id: "aaaaaaaa-0000-0000-0000-000000000001",
+        description: "Post this tweet?",
+        metadata: {
+          options: [
+            { name: "approve", description: "Approve the request" },
+            { name: "deny", description: "Deny", isCancel: true },
+          ],
+          approvalRequest: { createdAt: 4_242 },
+        },
+      }),
+    );
+    expect(action).not.toBeNull();
+    expect(action?.kind).toBe("approval");
+    expect(action?.title).toBe("Post this tweet?");
+    expect(action?.createdAt).toBe(4_242);
+    expect(action?.options).toEqual([
+      { name: "approve", description: "Approve the request", isCancel: false },
+      { name: "deny", description: "Deny", isCancel: true },
+    ]);
+  });
+
+  it("drops a malformed task missing id or roomId (no placeholder data)", () => {
+    expect(
+      approvalTaskToPendingAction({
+        name: "X",
+        tags: ["APPROVAL"],
+      } as Task),
+    ).toBeNull();
+  });
+
+  it("falls back to the row createdAt and the task name when metadata is absent", () => {
+    const action = approvalTaskToPendingAction(
+      approvalTask({
+        id: "aaaaaaaa-0000-0000-0000-000000000002",
+        name: "CONFIRM_123",
+        description: "   ",
+        createdAt: 999,
+      }),
+    );
+    expect(action?.createdAt).toBe(999);
+    expect(action?.title).toBe("CONFIRM_123");
+    expect(action?.options).toBeUndefined();
+  });
+});
+
+describe("handleApprovalRoute", () => {
+  let runtime: { getService: (t: string) => unknown };
+
+  beforeEach(async () => {
+    ({ runtime } = await makeRuntimeWithService([
+      approvalTask({
+        id: "aaaaaaaa-0000-0000-0000-000000000010",
+        description: "Older request",
+        createdAt: 1_000,
+      }),
+      approvalTask({
+        id: "aaaaaaaa-0000-0000-0000-000000000011",
+        description: "Newer request",
+        createdAt: 5_000,
+        metadata: { approvalRequest: { createdAt: 5_000 } },
+      }),
+      // A non-approval task in the store must NOT leak into the surface.
+      approvalTask({
+        id: "aaaaaaaa-0000-0000-0000-000000000012",
+        description: "unrelated",
+        tags: ["SOME_OTHER_TAG"],
+      }),
+    ]));
+  });
+
+  it("ignores non-approval paths", async () => {
+    const helpers = makeHelpers();
+    const handled = await handleApprovalRoute(
+      req("/api/other"),
+      res,
+      "/api/other",
+      "GET",
+      { runtime },
+      helpers,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("GET returns pending approvals newest-first as PendingUserAction[]", async () => {
+    const helpers = makeHelpers();
+    await handleApprovalRoute(
+      req("/api/approvals"),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.json).toHaveBeenCalledTimes(1);
+    const payload = helpers.json.mock.calls[0][1] as {
+      pending: Array<{ id: string; title: string; kind: string }>;
+    };
+    expect(payload.pending.map((p) => p.title)).toEqual([
+      "Newer request",
+      "Older request",
+    ]);
+    expect(payload.pending.every((p) => p.kind === "approval")).toBe(true);
+  });
+
+  it("rejects non-GET methods with 404", async () => {
+    const helpers = makeHelpers();
+    await handleApprovalRoute(
+      req("/api/approvals"),
+      res,
+      "/api/approvals",
+      "POST",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(res, expect.any(String), 404);
+  });
+
+  it("serves an empty surface when the approval service is not registered", async () => {
+    const helpers = makeHelpers();
+    const emptyRuntime = { getService: () => null };
+    await handleApprovalRoute(
+      req("/api/approvals"),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime: emptyRuntime },
+      helpers,
+    );
+    expect(helpers.json).toHaveBeenCalledWith(res, { pending: [] });
+  });
+});

--- a/packages/agent/src/api/approval-routes.ts
+++ b/packages/agent/src/api/approval-routes.ts
@@ -1,0 +1,121 @@
+/**
+ * Approval routes — the HTTP surface for the canonical "actions requiring your
+ * response" home surface (#9449 PILLAR C).
+ *
+ * The agent's `ApprovalService` holds the live pending-decision store (task
+ * rows tagged `AWAITING_CHOICE`/`APPROVAL`). This route exposes them, projected
+ * into the transport DTO the client renders — {@link PendingUserAction}. The
+ * projection (task → DTO) happens here in the route so the widget only renders:
+ * it never reads raw task metadata.
+ *
+ * Routes:
+ *
+ *   GET /api/approvals
+ *     List every pending user action (across rooms) newest-first.
+ *     Returns `{ pending: PendingUserAction[] }`.
+ */
+
+import type http from "node:http";
+import type {
+  PendingUserAction,
+  PendingUserActionOption,
+  RouteHelpers,
+  Task,
+  UUID,
+} from "@elizaos/core";
+import { ApprovalService, ServiceType } from "@elizaos/core";
+
+export interface ApprovalRouteState {
+  runtime: { getService: (type: string) => unknown } | null;
+}
+
+function getService(state: ApprovalRouteState): ApprovalService | null {
+  const svc = state.runtime?.getService(ServiceType.APPROVAL);
+  return svc instanceof ApprovalService ? svc : null;
+}
+
+/** Read an option list off a task's metadata, narrowing the untrusted shape. */
+function parseOptions(task: Task): PendingUserActionOption[] | undefined {
+  const raw = task.metadata?.options;
+  if (!Array.isArray(raw)) return undefined;
+  const options: PendingUserActionOption[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.name !== "string") continue;
+    options.push({
+      name: record.name,
+      description:
+        typeof record.description === "string" && record.description
+          ? record.description
+          : undefined,
+      isCancel: record.isCancel === true,
+    });
+  }
+  return options.length > 0 ? options : undefined;
+}
+
+/** Resolve the request's creation time from metadata, falling back to the row. */
+function resolveCreatedAt(task: Task): number {
+  const approvalRequest = task.metadata?.approvalRequest;
+  if (approvalRequest && typeof approvalRequest === "object") {
+    const createdAt = (approvalRequest as Record<string, unknown>).createdAt;
+    if (typeof createdAt === "number" && Number.isFinite(createdAt)) {
+      return createdAt;
+    }
+  }
+  return typeof task.createdAt === "number" ? task.createdAt : Date.now();
+}
+
+/**
+ * Project an ApprovalService task into the canonical {@link PendingUserAction}.
+ * Returns null for a task missing the fields a pending action requires (id +
+ * room) — a malformed row is dropped, not surfaced with placeholder data.
+ */
+export function approvalTaskToPendingAction(
+  task: Task,
+): PendingUserAction | null {
+  if (!task.id || !task.roomId) return null;
+  return {
+    id: task.id as UUID,
+    kind: "approval",
+    title: task.description?.trim() || task.name,
+    createdAt: resolveCreatedAt(task),
+    roomId: task.roomId as UUID,
+    options: parseOptions(task),
+  };
+}
+
+export async function handleApprovalRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  pathname: string,
+  method: string,
+  state: ApprovalRouteState,
+  helpers: RouteHelpers,
+): Promise<boolean> {
+  if (pathname !== "/api/approvals") return false;
+
+  if (method !== "GET") {
+    helpers.error(res, "approval route not found", 404);
+    return true;
+  }
+
+  const service = getService(state);
+  if (!service) {
+    // Runtime is up but the approval service isn't registered (early boot, or a
+    // build without it). Serve an empty surface rather than 500 so the home
+    // widget degrades gracefully and retries.
+    helpers.json(res, { pending: [] });
+    return true;
+  }
+
+  const tasks = await service.getAllPendingApprovals();
+  const pending = tasks
+    .map(approvalTaskToPendingAction)
+    .filter((action): action is PendingUserAction => action !== null)
+    .sort((a, b) => b.createdAt - a.createdAt);
+
+  helpers.json(res, { pending });
+  return true;
+}

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -555,6 +555,7 @@ export async function handleInboxAndCloudRelayRouteGroup(
     !(
       ctx.pathname.startsWith("/api/notifications") ||
       ctx.pathname.startsWith("/api/inbox") ||
+      ctx.pathname === "/api/approvals" ||
       ctx.pathname === "/api/cloud/relay-status"
     )
   ) {

--- a/packages/agent/src/api/server-route-dispatch.ts
+++ b/packages/agent/src/api/server-route-dispatch.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
+import { handleApprovalRoute } from "./approval-routes.ts";
 import { handleChatRoutes } from "./chat-routes.ts";
 import { handleConversationRoutes } from "./conversation-routes.ts";
 import { handleDatabaseRoute } from "./database.ts";
@@ -113,6 +114,17 @@ export async function handleInboxAndCloudRelayRouteGroup({
 
   if (pathname.startsWith("/api/inbox")) {
     return handleInboxRoute(
+      req,
+      res,
+      pathname,
+      method,
+      { runtime: state.runtime ?? null },
+      { json, error, readJsonBody },
+    );
+  }
+
+  if (pathname === "/api/approvals") {
+    return handleApprovalRoute(
       req,
       res,
       pathname,

--- a/packages/core/src/services/approval.ts
+++ b/packages/core/src/services/approval.ts
@@ -367,6 +367,18 @@ export class ApprovalService extends Service {
 	}
 
 	/**
+	 * Get every pending approval across all rooms for this agent. Powers the
+	 * canonical "needs your response" surface (#9449), which aggregates the
+	 * agent's blocked-on-user decisions rather than scoping to one room.
+	 */
+	async getAllPendingApprovals(): Promise<Task[]> {
+		return this.runtime.getTasks({
+			tags: ["AWAITING_CHOICE", "APPROVAL"],
+			agentIds: [this.runtime.agentId],
+		});
+	}
+
+	/**
 	 * Handle timeout for a pending approval
 	 */
 	private async handleTimeout(taskId: UUID): Promise<void> {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -142,3 +142,64 @@ export interface TaskRunStatus {
 	nextRunAt?: number;
 	lastError?: string;
 }
+
+/**
+ * What kind of user response a {@link PendingUserAction} is waiting on. Drives
+ * how the canonical "needs your response" surface routes the user back to the
+ * handler:
+ *  - `approval`   — a yes/no or pick-an-option decision (ApprovalService task).
+ *  - `prompt`     — a free-text answer the agent asked for.
+ *  - `credential` — a secret/OAuth/QR the agent needs (the credential bridge).
+ *  - `clarifying` — a disambiguation question (which X did you mean?).
+ *
+ * This pass (#9449 PILLAR C) wires only the `approval` path end-to-end; the
+ * other kinds are part of the type so the prompt/credential/clarifying stores
+ * can be folded into the same surface later without a contract change.
+ */
+export type PendingUserActionKind =
+	| "approval"
+	| "prompt"
+	| "credential"
+	| "clarifying";
+
+/**
+ * One option the user can pick to resolve a {@link PendingUserAction} (mirrors
+ * an ApprovalService option). The `name` is the value routed back to the
+ * handler; `description` is the human-readable label.
+ */
+export interface PendingUserActionOption {
+	name: string;
+	description?: string;
+	/** This option cancels/denies the request. */
+	isCancel?: boolean;
+}
+
+/**
+ * A single action that is blocked waiting on the user — the canonical transport
+ * DTO behind the one "needs your response" surface (#9449 PILLAR C).
+ *
+ * It is a read-model projection (computed in the route/use-case, rendered by
+ * the client) over whatever store actually holds the pending request — for the
+ * approval path, an ApprovalService task (`AWAITING_CHOICE`/`APPROVAL`). Fields
+ * are required by default; only `expectedReplyKind`/`options` are genuinely
+ * optional (a confirm has neither).
+ */
+export interface PendingUserAction {
+	/** Stable identifier (the underlying task id for the approval path). */
+	id: UUID;
+	/** Which response the surface should solicit + how it routes back. */
+	kind: PendingUserActionKind;
+	/** One-line, human-readable description of what is being asked. */
+	title: string;
+	/** Epoch-ms when the request was created (drives age-based escalation). */
+	createdAt: number;
+	/** Room the request belongs to — where the resolving reply must land. */
+	roomId: UUID;
+	/**
+	 * For `prompt`/`clarifying`: the shape of reply expected (e.g. "text",
+	 * "date", "amount"). Omitted for `approval`/`credential`.
+	 */
+	expectedReplyKind?: string;
+	/** Selectable options (approval picks). Absent for free-text prompts. */
+	options?: PendingUserActionOption[];
+}

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -98,6 +98,8 @@ export interface TaskMetadata {
 	options?: {
 		name: string;
 		description: string;
+		/** This option cancels/denies the request (approval/needs-attention flows). */
+		isCancel?: boolean;
 	}[];
 	/** Allows for other dynamic metadata properties related to the task. */
 	values?: Record<string, JsonValue | object>;

--- a/packages/ui/src/api/client-approvals.ts
+++ b/packages/ui/src/api/client-approvals.ts
@@ -1,0 +1,24 @@
+import type { PendingUserAction } from "@elizaos/core";
+import { ElizaClient } from "./client-base";
+
+/**
+ * Typed client for the canonical "actions requiring your response" surface
+ * (#9449 PILLAR C). The agent route (`GET /api/approvals`) already projects the
+ * pending ApprovalService tasks into {@link PendingUserAction}s; the client just
+ * fetches that read model — no transformation here.
+ */
+export interface PendingActionsResponse {
+  pending: PendingUserAction[];
+}
+
+declare module "./client-base" {
+  interface ElizaClient {
+    listPendingActions(): Promise<PendingActionsResponse>;
+  }
+}
+
+ElizaClient.prototype.listPendingActions = async function (
+  this: ElizaClient,
+): Promise<PendingActionsResponse> {
+  return this.fetch<PendingActionsResponse>("/api/approvals");
+};

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -230,6 +230,7 @@ export {
 // ---------------------------------------------------------------------------
 
 import "./client-agent";
+import "./client-approvals";
 import "./client-automations";
 import "./client-background";
 import "./client-browser-workspace";

--- a/packages/ui/src/components/chat/widgets/needs-attention.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CHAT_PREFILL_EVENT } from "../../../events";
+import {
+  assert,
+  waitForTestId,
+  withSeededHomeWidget,
+} from "../../../storybook/home-widget-decorator";
+import { NeedsAttentionWidget } from "./needs-attention";
+
+// The canonical "actions requiring your response" home card (#9449): shows the
+// ONE oldest pending decision the agent is blocked on, with a count badge, and
+// self-hides when nothing is pending. Seeded with the shared home-widget mock
+// data (GET /api/approvals -> { pending: PendingUserAction[] }).
+
+const meta = {
+  title: "Shell/Home Widgets/Needs Attention",
+  component: NeedsAttentionWidget,
+  parameters: { layout: "centered" },
+  decorators: [withSeededHomeWidget],
+  args: { slot: "home" },
+} satisfies Meta<typeof NeedsAttentionWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The oldest pending decision is the single datum; the mock's oldest is stale. */
+export const NeedsAttention: Story = {
+  play: async ({ canvasElement }) => {
+    const card = await waitForTestId(
+      canvasElement,
+      "chat-widget-needs-attention",
+    );
+    assert(card instanceof HTMLButtonElement, "the whole card is a button");
+    assert(
+      /need your response/i.test(card.getAttribute("aria-label") ?? ""),
+      "the aria-label carries the needs-response meaning",
+    );
+    assert(
+      (card.getAttribute("aria-label") ?? "").includes(
+        "Send the signed contract to Acme",
+      ),
+      "shows the OLDEST pending decision as the datum",
+    );
+  },
+};
+
+/**
+ * Clicking the card routes back to the handler: it prefills the floating chat
+ * composer with an approval message so the agent's RESOLVE_REQUEST action
+ * resolves it — the single tap-to-resolve contract for this surface.
+ */
+export const ClickPrefillsChat: Story = {
+  play: async ({ canvasElement }) => {
+    const card = await waitForTestId(
+      canvasElement,
+      "chat-widget-needs-attention",
+    );
+    const prefilled: string[] = [];
+    const onPrefill = (e: Event) => {
+      const detail = (e as CustomEvent<{ text?: string }>).detail;
+      if (detail?.text) prefilled.push(detail.text);
+    };
+    window.addEventListener(CHAT_PREFILL_EVENT, onPrefill);
+    card.click();
+    window.removeEventListener(CHAT_PREFILL_EVENT, onPrefill);
+    assert(
+      prefilled.some((text) => text.startsWith("Approve:")),
+      `click prefills an approval (saw ${prefilled.join(",") || "nothing"})`,
+    );
+  },
+};

--- a/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import type { PendingUserAction } from "@elizaos/core";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listPendingActionsMock, publishHomeAttentionSpy, dispatchChatPrefillSpy } =
+  vi.hoisted(() => ({
+    listPendingActionsMock: vi.fn(),
+    publishHomeAttentionSpy: vi.fn(),
+    dispatchChatPrefillSpy: vi.fn(),
+  }));
+
+// The widget reads the canonical surface through the typed client; mock only
+// the one method it calls.
+vi.mock("../../../api", () => ({
+  client: { listPendingActions: listPendingActionsMock },
+}));
+
+// Spy on the self-signal hook so we can assert the published weight without
+// reaching into the store internals.
+vi.mock("../../../widgets/home-attention-store", () => ({
+  usePublishHomeAttention: (widgetKey: string, weight: number | null) =>
+    publishHomeAttentionSpy(widgetKey, weight),
+}));
+
+// The round-trip hands the user back to the agent's RESOLVE_REQUEST action via a
+// prefilled chat composer; stub the rail so the click test asserts the dispatch.
+vi.mock("../../../events", () => ({
+  dispatchChatPrefill: dispatchChatPrefillSpy,
+}));
+
+import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
+import type { WidgetProps } from "../../../widgets/types";
+import { NeedsAttentionWidget, STALE_PENDING_AGE_MS } from "./needs-attention";
+
+function pending(
+  patch: { id: string; title?: string; ageMs?: number } & Partial<
+    PendingUserAction
+  >,
+): PendingUserAction {
+  return {
+    id: patch.id as PendingUserAction["id"],
+    kind: patch.kind ?? "approval",
+    title: patch.title ?? "Post this tweet?",
+    createdAt: Date.now() - (patch.ageMs ?? 0),
+    roomId: (patch.roomId ??
+      "11111111-1111-1111-1111-111111111111") as PendingUserAction["roomId"],
+    options: patch.options,
+  };
+}
+
+function mockPending(items: PendingUserAction[]): void {
+  listPendingActionsMock.mockResolvedValue({ pending: items });
+}
+
+const fetchProps: Partial<WidgetProps> = { slot: "home" };
+const WIDGET_KEY = "needs-attention/needs-attention.pending";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  publishHomeAttentionSpy.mockReset();
+  dispatchChatPrefillSpy.mockReset();
+  listPendingActionsMock.mockReset();
+});
+
+describe("NeedsAttentionWidget (#9449)", () => {
+  it("shows the oldest pending action as a clickable card with a count badge (minimal, icon-first)", async () => {
+    mockPending([
+      pending({ id: "a-1", title: "Send the contract", ageMs: 60_000 }),
+      pending({ id: "a-2", title: "Confirm the deploy", ageMs: 10_000 }),
+    ]);
+
+    render(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+
+    const widget = screen.getByTestId("chat-widget-needs-attention");
+    // Whole-card button, minimal: the OLDEST request is the single datum.
+    expect(widget.tagName).toBe("BUTTON");
+    expect(widget.textContent).toContain("Send the contract");
+    expect(widget.textContent).not.toContain("Confirm the deploy");
+    // The full meaning lives in the aria-label since visible text is minimal.
+    expect(widget.getAttribute("aria-label")).toMatch(/2 actions need your response/i);
+    expect(widget.getAttribute("aria-label")).toMatch(/Send the contract/);
+  });
+
+  it("renders nothing when no actions are pending", async () => {
+    mockPending([]);
+
+    const { container } = render(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(listPendingActionsMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("chat-widget-needs-attention")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("publishes the approval weight while a fresh decision is pending", async () => {
+    mockPending([pending({ id: "a-1", ageMs: 1_000 })]);
+
+    render(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+    expect(publishHomeAttentionSpy).toHaveBeenLastCalledWith(
+      WIDGET_KEY,
+      HOME_SIGNAL_WEIGHTS.approval,
+    );
+  });
+
+  it("escalates the weight once the oldest decision goes stale", async () => {
+    mockPending([
+      pending({ id: "a-1", title: "Old decision", ageMs: STALE_PENDING_AGE_MS + 60_000 }),
+    ]);
+
+    render(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+    expect(publishHomeAttentionSpy).toHaveBeenLastCalledWith(
+      WIDGET_KEY,
+      HOME_SIGNAL_WEIGHTS.escalation,
+    );
+    // Stale → warn tone marker.
+    const widget = screen.getByTestId("chat-widget-needs-attention");
+    expect(widget.getAttribute("aria-label")).toMatch(/Old decision/);
+  });
+
+  it("routes back to the handler by prefilling chat with an approval on click", async () => {
+    mockPending([pending({ id: "a-1", title: "Send the contract", ageMs: 5_000 })]);
+
+    render(<NeedsAttentionWidget {...fetchProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("chat-widget-needs-attention"));
+
+    expect(dispatchChatPrefillSpy).toHaveBeenCalledWith({
+      text: "Approve: Send the contract",
+      select: true,
+    });
+  });
+});

--- a/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
@@ -30,8 +30,10 @@ vi.mock("../../../widgets/home-attention-store", () => ({
 }));
 
 // The round-trip hands the user back to the agent's RESOLVE_REQUEST action via a
-// prefilled chat composer; stub the rail so the click test asserts the dispatch.
-vi.mock("../../../events", () => ({
+// prefilled chat composer; spy on that one rail while preserving the module's
+// other exports (client-base imports NETWORK_STATUS_CHANGE_EVENT et al.).
+vi.mock("../../../events", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../events")>()),
   dispatchChatPrefill: dispatchChatPrefillSpy,
 }));
 

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -1,0 +1,139 @@
+import type { PendingUserAction } from "@elizaos/core";
+import { CircleHelp } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { client } from "../../../api";
+import { dispatchChatPrefill } from "../../../events";
+import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
+import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
+import type { WidgetProps } from "../../../widgets/types";
+import { HomeWidgetCard } from "./home-widget-card";
+
+// The canonical "actions requiring your response" home card (#9449 PILLAR C):
+// the ONE oldest decision the agent is blocked waiting on you for, with a badge
+// of how many are pending. Data source is GET /api/approvals (served by the
+// agent's approval-routes), which already projects the ApprovalService tasks
+// into PendingUserAction[] — so this card only renders, no business logic.
+//
+// Renders null when nothing is pending, and self-publishes a home-attention
+// signal so it floats up: `approval` weight while pending items exist, escalated
+// to `escalation` weight once the oldest one has been waiting longer than the
+// stale threshold (a decision left unanswered is more urgent over time).
+
+const NEEDS_ATTENTION_WIDGET_KEY = "needs-attention/needs-attention.pending";
+const REFRESH_INTERVAL_MS = 20_000;
+/** A pending decision older than this escalates above the standard approval rank. */
+export const STALE_PENDING_AGE_MS = 30 * 60_000; // 30 min
+
+/** Shallow content equality so an unchanged poll doesn't re-render. */
+function pendingEqual(
+  a: readonly PendingUserAction[],
+  b: readonly PendingUserAction[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((item, i) => {
+    const other = b[i];
+    return (
+      item.id === other.id &&
+      item.title === other.title &&
+      item.createdAt === other.createdAt
+    );
+  });
+}
+
+/**
+ * Poll the canonical pending-actions surface. Returns the live list plus a
+ * `loaded` flag so the widget can stay invisible until the first fetch resolves
+ * (the home surface must not flash an empty placeholder).
+ */
+export function useApprovals(): {
+  pending: PendingUserAction[];
+  loaded: boolean;
+} {
+  const [pending, setPending] = useState<PendingUserAction[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const { pending: next } = await client.listPendingActions();
+      setPending((prev) => (pendingEqual(prev, next) ? prev : next));
+    } catch {
+      // Best-effort: keep the last good data on a transient fetch failure.
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+  useIntervalWhenDocumentVisible(() => void load(), REFRESH_INTERVAL_MS);
+
+  return { pending, loaded };
+}
+
+/**
+ * The single high-priority datum: the OLDEST pending action (waiting longest =
+ * most overdue). Computed once per snapshot so an unchanged poll keeps a stable
+ * reference.
+ */
+function oldestPending(
+  pending: readonly PendingUserAction[],
+): PendingUserAction | null {
+  if (pending.length === 0) return null;
+  return pending.reduce((oldest, item) =>
+    item.createdAt < oldest.createdAt ? item : oldest,
+  );
+}
+
+export function NeedsAttentionWidget(_props: Partial<WidgetProps>) {
+  const { pending, loaded } = useApprovals();
+
+  const top = useMemo(() => oldestPending(pending), [pending]);
+
+  // Float up at `approval` weight while anything is pending; escalate to
+  // `escalation` weight once the oldest decision has been waiting past the stale
+  // threshold (age is read at render — the home ranker stamps `now`, so the
+  // store holds the steady-state weight, not a clock value).
+  const weight = useMemo(() => {
+    if (top == null) return null;
+    const stale = Date.now() - top.createdAt >= STALE_PENDING_AGE_MS;
+    return stale ? HOME_SIGNAL_WEIGHTS.escalation : HOME_SIGNAL_WEIGHTS.approval;
+  }, [top]);
+  usePublishHomeAttention(NEEDS_ATTENTION_WIDGET_KEY, weight);
+
+  // Route back to the handler: prefill the chat composer with a natural-language
+  // approval so the agent's RESOLVE_REQUEST action resolves it in the same room
+  // the request lives in. The widget never resolves the decision itself — it
+  // hands the user to the canonical action.
+  const onActivate = useCallback(() => {
+    if (top == null) return;
+    dispatchChatPrefill({ text: `Approve: ${top.title}`, select: true });
+  }, [top]);
+
+  // Render nothing until the first load resolves with pending items (#9143).
+  if (!loaded || top == null) return null;
+
+  const count = pending.length;
+  const stale = Date.now() - top.createdAt >= STALE_PENDING_AGE_MS;
+  return (
+    <HomeWidgetCard
+      icon={<CircleHelp />}
+      label="Needs response"
+      value={top.title}
+      badge={count}
+      tone={stale ? "warn" : "default"}
+      testId="chat-widget-needs-attention"
+      ariaLabel={`${count} action${count === 1 ? "" : "s"} need your response, oldest: ${top.title}. Respond in chat.`}
+      onActivate={onActivate}
+    />
+  );
+}
+
+export const NEEDS_ATTENTION_HOME_WIDGET = {
+  pluginId: "needs-attention",
+  id: "needs-attention.pending",
+  order: 60,
+  signalKinds: ["approval", "escalation"],
+  Component: NeedsAttentionWidget,
+} as const;

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -276,6 +276,34 @@ function notificationsPayload() {
   };
 }
 
+/** NeedsAttentionWidget reads GET /api/approvals; the wire shape is
+ *  { pending: PendingUserAction[] } (see needs-attention.tsx / approval-routes).
+ *  Two pending decisions; the older one is the single datum the card shows. */
+function approvalsPayload() {
+  return {
+    pending: [
+      {
+        id: "approval-1",
+        kind: "approval",
+        title: "Send the signed contract to Acme",
+        createdAt: Date.now() - 45 * 60_000,
+        roomId: "11111111-1111-1111-1111-111111111111",
+        options: [
+          { name: "approve", description: "Approve and send" },
+          { name: "deny", description: "Don't send", isCancel: true },
+        ],
+      },
+      {
+        id: "approval-2",
+        kind: "approval",
+        title: "Confirm the production deploy",
+        createdAt: Date.now() - 5 * 60_000,
+        roomId: "11111111-1111-1111-1111-111111111111",
+      },
+    ],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Direct accessors for the relationships widget, which fetches via the typed
 // `client.getRelationshipsPeople()` / `client.getRelationshipsCandidates()`
@@ -328,6 +356,7 @@ function routeTable(): RouteMatch[] {
       body: relationshipsCandidates,
     },
     { test: has("/api/notifications"), body: notificationsPayload },
+    { test: has("/api/approvals"), body: approvalsPayload },
   ];
 }
 

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -39,6 +39,7 @@ import { HEALTH_HOME_WIDGET } from "../components/chat/widgets/health-sleep";
 import { INBOX_HOME_WIDGET } from "../components/chat/widgets/inbox-unread";
 import { MessagesWidget } from "../components/chat/widgets/messages";
 import { MUSIC_PLAYER_WIDGET } from "../components/chat/widgets/music-player.helpers";
+import { NEEDS_ATTENTION_HOME_WIDGET } from "../components/chat/widgets/needs-attention";
 import { NotificationsWidget } from "../components/chat/widgets/notifications";
 import { RELATIONSHIPS_HOME_WIDGET } from "../components/chat/widgets/relationships-attention";
 import { TODO_PLUGIN_WIDGETS } from "../components/chat/widgets/todo";
@@ -78,6 +79,7 @@ for (const w of [
   HEALTH_HOME_WIDGET,
   RELATIONSHIPS_HOME_WIDGET,
   INBOX_HOME_WIDGET,
+  NEEDS_ATTENTION_HOME_WIDGET,
 ]) {
   registerWidgetComponent(w.pluginId, w.id, w.Component);
 }
@@ -401,6 +403,21 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     defaultEnabled: true,
     signalKinds: INBOX_HOME_WIDGET.signalKinds,
   },
+  // Needs response — the canonical "actions requiring your response" card
+  // (#9449). Backed by the core ApprovalService (GET /api/approvals), not a
+  // loadable plugin, so it is always-visible (see
+  // ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS) and self-hides when nothing is
+  // pending. Floats up at approval/escalation weight on its own data.
+  {
+    id: NEEDS_ATTENTION_HOME_WIDGET.id,
+    pluginId: NEEDS_ATTENTION_HOME_WIDGET.pluginId,
+    slot: "home",
+    label: "Needs response",
+    icon: "CircleHelp",
+    order: NEEDS_ATTENTION_HOME_WIDGET.order,
+    defaultEnabled: true,
+    signalKinds: NEEDS_ATTENTION_HOME_WIDGET.signalKinds,
+  },
   {
     id: RELATIONSHIPS_HOME_WIDGET.id,
     pluginId: RELATIONSHIPS_HOME_WIDGET.pluginId,
@@ -518,6 +535,10 @@ const ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS = new Set([
   // plugin snapshot. (#9143). Messages was removed (#9304) — redundant with the
   // always-present chat overlay.
   "notifications",
+  // Needs-response is backed by the core ApprovalService (not a loadable
+  // plugin), so its frontpage widget must render regardless of the plugin
+  // snapshot — it self-hides when no decisions are pending (#9449).
+  "needs-attention",
 ]);
 
 export interface ResolvedWidget {


### PR DESCRIPTION
Implements #9449 Pillar C (the one genuinely-undone pillar): a canonical 'actions requiring your response' surface. Pillars A (WS allowlist, TTL, toast-tone, category filter) and B (activity/trajectory serializers, AgentActivityBox dedup #9557) are already on develop.

- **core**: `PendingUserAction` type (id, kind `approval|prompt|credential|clarifying`, title, createdAt, roomId, expectedReplyKind, options).
- **agent**: `GET /api/approvals` projecting `ApprovalService` pending decisions (task rows tagged AWAITING_CHOICE/APPROVAL) → `PendingUserAction[]` (route does the task→DTO projection; widget only renders) + route test.
- **ui**: typed client GET + an icon-first **needs-attention home widget** (self-hides when empty, escalation weight via `usePublishHomeAttention` when items age) registered on the home slot + story + test.

Approvals path is the representative vertical slice; `PendingUserAction` is shaped to extend to prompts/credentials later. The 27-connector activity-emission sweep + `tool`/`evaluator`/`provider` broadcast remain as a separate Pillar-B chunk (tracked on #9449).

CI verifies (build + route test + widget test + typecheck/lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)