### PR TITLE
fix(lifeops-bench): LIVE scoring no longer rewards an unchanged world / inaction (#8795)

### DIFF
--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scorer.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scorer.py
@@ -7,8 +7,10 @@ HumanEval/Chen-2021 unbiased estimator.
 Score formula:
     STATIC mode: 0.5 * state_hash_match + 0.4 * action_score
                  + 0.1 * mean(output_substring_matches)
-    LIVE  mode: 0.7 * state_hash_match
-                 + 0.3 * mean(output_substring_matches)
+    LIVE  mode: gated on terminated_reason == "satisfied", then
+                 0.7 * (world was mutated) + 0.3 * mean(output_substring_matches).
+      LIVE has no ground-truth actions, so an unchanged world hashes equal to
+      the seed; crediting state_hash_match there rewards inaction (#8795).
 
 PerfectAgent must produce 1.0 on every supported scenario.
 WrongAgent must produce 0.0 on every scenario.
@@ -1157,8 +1159,28 @@ def score_scenario(result: ScenarioResult, scenario: Scenario) -> float:
       penalizing wrong reads — 0.35 state_hash + 0.5 action_score +
       0.15 substring_score.
 
-    LIVE weighting (no GT actions, judged by world hash + judge):
-          0.7 state_hash + 0.3 substring_score.
+    LIVE weighting (no GT actions, judged by the simulated user + judge):
+          gated on terminated_reason == "satisfied", then
+          0.7 mutation_component + 0.3 substring_score.
+
+      LIVE scenarios carry no ground-truth actions, so `_replay_ground_truth`
+      replays an empty action list and returns the UNCHANGED seed hash. That
+      makes `state_hash_match` True exactly when the agent left the world
+      untouched — i.e. the raw state-hash signal rewards inaction. A
+      do-nothing agent that the judge nonetheless marks "satisfied" would
+      score the full state bonus (1.0) while a correct world-mutating agent
+      (whose final hash differs from the seed, so `state_hash_match` is False)
+      would lose it (0.3). That inversion is the #8795 bug.
+
+      Conservative fix: for LIVE, the state component is INVERTED into a
+      `mutation_component` — a *changed* world earns the bonus, an unchanged
+      world does not. The judge `satisfied` gate remains the authoritative
+      pass/fail; the mutation term simply stops paying out the state bonus for
+      a world the agent never touched, so a correct mutation always scores
+      strictly above a do-nothing run. Parsing `world_assertions` into
+      per-scenario checkable predicates (so LIVE *read* tasks can keep crediting
+      a legitimately-unchanged world) is the documented option (b) future
+      enhancement — see #8795.
 
     Errors / timeouts / cost overruns force 0.
     """
@@ -1241,7 +1263,15 @@ def score_scenario(result: ScenarioResult, scenario: Scenario) -> float:
 
     if result.terminated_reason != "satisfied":
         return 0.0
-    return 0.7 * state_component + 0.3 * substring_component
+    # LIVE scenarios have no ground-truth actions, so the replayed expected
+    # hash equals the seed and `state_hash_match` is True exactly when the
+    # agent left the world UNCHANGED. Crediting that rewards inaction (#8795):
+    # a do-nothing "satisfied" run would score the full state bonus while a
+    # correct world-mutating run would lose it. Invert the term so the bonus
+    # accrues to a *changed* world, guaranteeing a correct mutation scores
+    # strictly above a do-nothing run.
+    mutation_component = 0.0 if result.state_hash_match else 1.0
+    return 0.7 * mutation_component + 0.3 * substring_component
 
 
 def pass_at_k(c: int, n: int, k: int) -> float:

--- a/packages/benchmarks/lifeops-bench/tests/test_scorer_fixes.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_scorer_fixes.py
@@ -1754,3 +1754,105 @@ def test_p2_9_health_today_still_pure_read() -> None:
 def test_p2_9_life_review_not_read_only() -> None:
     """LIFE/review is no longer classified as pure read-only."""
     assert not _is_read_only_action(Action(name="LIFE", kwargs={"subaction": "review"}))
+
+
+# ---------------------------------------------------------------------------
+# #8795: LIVE scoring must not reward an unchanged world / inaction
+#
+# LIVE scenarios carry no ground-truth actions, so `_replay_ground_truth`
+# replays an empty action list and returns the UNCHANGED seed hash. That makes
+# `state_hash_match` True exactly when the agent left the world untouched, so
+# crediting it rewarded a do-nothing run (1.0) over a correct world-mutating
+# run (0.3). The fix inverts the LIVE state term: a *changed* world earns the
+# bonus, an unchanged world does not.
+# ---------------------------------------------------------------------------
+
+
+def _live_scenario() -> Scenario:
+    """A LIVE write scenario: no ground truth, judged by the simulated user."""
+    return Scenario(
+        id="live.calendar.find_focus_block_tomorrow",
+        name="t",
+        domain=Domain.CALENDAR,
+        mode=ScenarioMode.LIVE,
+        persona=_PERSONA,
+        instruction="put a 1-hour focus block on my work calendar tomorrow",
+        ground_truth_actions=[],
+        required_outputs=[],
+        first_question_fallback=None,
+        world_seed=0,
+        max_turns=8,
+        world_assertions=[
+            "a new focus-block event exists on the work calendar tomorrow",
+        ],
+    )
+
+
+def test_live_correct_mutation_scores_above_do_nothing() -> None:
+    """#8795: a correct world-mutating run must beat a do-nothing run.
+
+    Both runs are judged "satisfied" to isolate the scorer: the only
+    difference is whether the agent changed the world. A do-nothing agent
+    leaves the world equal to the seed (state_hash_match True); a correct
+    write agent changes it (state_hash_match False). The correct run must
+    score strictly higher.
+    """
+    scenario = _live_scenario()
+    do_nothing = _result(
+        state_hash_match=True,  # world unchanged == seed == replay of empty GT
+        agent_actions=[],
+        terminated_reason="satisfied",
+    )
+    correct = _result(
+        state_hash_match=False,  # world mutated, no longer equal to the seed
+        agent_actions=[],
+        terminated_reason="satisfied",
+    )
+    do_nothing_score = score_scenario(do_nothing, scenario)
+    correct_score = score_scenario(correct, scenario)
+
+    assert correct_score == pytest.approx(1.0)
+    assert do_nothing_score == pytest.approx(0.3)
+    assert correct_score > do_nothing_score
+
+
+def test_live_unsatisfied_run_scores_zero() -> None:
+    """#8795: the judge `satisfied` gate is still authoritative for LIVE.
+
+    A run the judge did not mark satisfied scores 0 regardless of the world
+    state, so the inverted mutation term never resurrects a failed run.
+    """
+    scenario = _live_scenario()
+    unsatisfied_unchanged = _result(
+        state_hash_match=True,
+        agent_actions=[],
+        terminated_reason="respond",
+    )
+    unsatisfied_changed = _result(
+        state_hash_match=False,
+        agent_actions=[],
+        terminated_reason="respond",
+    )
+    assert score_scenario(unsatisfied_unchanged, scenario) == 0.0
+    assert score_scenario(unsatisfied_changed, scenario) == 0.0
+
+
+def test_static_scoring_unchanged_by_live_fix() -> None:
+    """Regression guard: STATIC scoring is untouched by the LIVE #8795 fix.
+
+    A STATIC write scenario with a matching action and matching final state
+    still scores 1.0 (0.5 state + 0.4 action + 0.1 substring), and crucially
+    its state_hash_match=True still pays the full state bonus — the inversion
+    is LIVE-only.
+    """
+    action = Action(name="CALENDAR", kwargs={"subaction": "create_event", "title": "x"})
+    scenario = _scenario(ground_truth_actions=[action])  # mode=STATIC
+    assert scenario.mode is ScenarioMode.STATIC
+    matched = _result(state_hash_match=True, agent_actions=[action])
+    assert score_scenario(matched, scenario) == pytest.approx(1.0)
+
+    # And a STATIC write where the world did NOT reach the target state loses
+    # the state bonus (0.4 action + 0.1 substring = 0.5), proving the STATIC
+    # path still credits an unchanged-vs-target world the opposite way from LIVE.
+    unmatched = _result(state_hash_match=False, agent_actions=[action])
+    assert score_scenario(unmatched, scenario) == pytest.approx(0.5)


### PR DESCRIPTION
Fixes a CRITICAL scoring inversion in LifeOpsBench LIVE mode. Refs #8795. Finding id: `live-state-hash-rewards-inaction`.

## Root cause

LIVE scenarios carry **no** ground-truth actions. The runner derives the expected post-state by replaying `scenario.ground_truth_actions` on a fresh seeded world (`runner.py` `_replay_ground_truth`, ~L2849). With an empty action list the replay returns the **unchanged seed hash**, so `state_hash_match` is `True` exactly when the agent left the world **untouched**.

`score_scenario` (`scorer.py`, the LIVE branch, ~L1242) then computed:

```python
return 0.7 * state_component + 0.3 * substring_component   # state_component = 1.0 iff state_hash_match
```

gated only on `terminated_reason == "satisfied"`. Because LIVE `required_outputs == []`, `substring_component` defaults to `1.0`. The net effect: a **do-nothing** agent that the judge nonetheless marks `satisfied` scored the full state bonus → **1.0**, while a **correct world-mutating** agent (final hash differs from the seed, so `state_hash_match` is `False`) scored only **0.3**. The state-hash signal literally rewarded inaction. `world_assertions` are judge-advisory only (`evaluator.py` ~L425) and never gate the numeric score.

Reproduced on `live.calendar.find_focus_block_tomorrow` (both runs judged `satisfied`):

```
BEFORE FIX:
  do-nothing (unchanged world) score = 1.0
  correct    (mutated world)   score = 0.3
```

## Fix (conservative — option a)

For LIVE scenarios, the seed-vs-final state hash can no longer contribute the state bonus to inaction. The state term is inverted into a `mutation_component`: a **changed** world earns the bonus, an **unchanged** world does not. The judge `satisfied` gate stays authoritative (an unsatisfied run is still 0). This guarantees a correct mutation scores strictly above a do-nothing run, and **STATIC scoring is untouched** (the inversion lives only in the LIVE branch).

```python
if result.terminated_reason != "satisfied":
    return 0.0
mutation_component = 0.0 if result.state_hash_match else 1.0
return 0.7 * mutation_component + 0.3 * substring_component
```

Parsing `world_assertions` into per-scenario checkable predicates — so LIVE *read* tasks could keep crediting a legitimately-unchanged world — is documented in the code as the **option (b)** future enhancement (see #8795).

```
AFTER FIX:
  do-nothing (unchanged world) score = 0.3
  correct    (mutated world)   score = 1.0
  correct strictly > do-nothing: True
  do-nothing NOT satisfied      score = 0.0
```

## Tests

Added to `tests/test_scorer_fixes.py`:
- `test_live_correct_mutation_scores_above_do_nothing` — correct mutation (1.0) strictly > do-nothing (0.3), both judged `satisfied`.
- `test_live_unsatisfied_run_scores_zero` — judge `satisfied` gate remains authoritative.
- `test_static_scoring_unchanged_by_live_fix` — regression guard: STATIC write still scores 1.0 with `state_hash_match=True` and 0.5 with `state_hash_match=False`.

### Before (revert only the LIVE logic, run the new test)

```
>       assert correct_score == pytest.approx(1.0)
E       assert 0.3 == 1.0 ± 1.0e-06
E         Obtained: 0.3
E         Expected: 1.0 ± 1.0e-06
tests/test_scorer_fixes.py:1814: AssertionError
FAILED tests/test_scorer_fixes.py::test_live_correct_mutation_scores_above_do_nothing
```

### After (`python3 -m pytest tests/test_scorer_fixes.py tests/test_live_scenarios.py -q`)

```
........................................................................ [ 26%]
........................................................................ [ 53%]
........................................................................ [ 80%]
.....................................................                    [100%]
EXIT=0
```

(scorer file alone: 253 passed; targeted new tests: 3 passed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
