### PR TITLE
feat(#9449 Pillar B): bridge connector inbound messages onto the activity stream

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -25,6 +25,7 @@ import {
 	bridgeActionStartedToStreams,
 	bridgeEvaluatorCompletedToStreams,
 	bridgeEvaluatorStartedToStreams,
+	bridgeMessageReceivedToStreams,
 	bridgeRunEndedToStreams,
 	bridgeRunStartedToStreams,
 } from "../../services/agent-event-bridge.ts";
@@ -950,6 +951,14 @@ const controlMessageHandler = async ({
 // ============================================================================
 
 const events: PluginEvents = {
+	// Bridge every connector's inbound message onto the AgentEventService
+	// `message` stream so the home activity rail shows the agent fielding
+	// messages (Discord/Telegram/etc.), not just orchestrator tasks (#9449).
+	[EventType.MESSAGE_RECEIVED]: [
+		async (payload: MessagePayload) => {
+			bridgeMessageReceivedToStreams(payload);
+		},
+	],
 	[EventType.REACTION_RECEIVED]: [
 		async (payload: MessagePayload) => {
 			await reactionReceivedHandler(payload);

--- a/packages/core/src/services/agent-event-bridge.test.ts
+++ b/packages/core/src/services/agent-event-bridge.test.ts
@@ -3,6 +3,7 @@ import type { AgentEventPayload } from "../types/agentEvent.ts";
 import type {
 	ActionEventPayload,
 	EvaluatorEventPayload,
+	MessagePayload,
 } from "../types/events.ts";
 import type { IAgentRuntime } from "../types/runtime.ts";
 import { ServiceType } from "../types/service.ts";
@@ -11,6 +12,7 @@ import {
 	bridgeActionStartedToStreams,
 	bridgeEvaluatorCompletedToStreams,
 	bridgeEvaluatorStartedToStreams,
+	bridgeMessageReceivedToStreams,
 	bridgeRunEndedToStreams,
 	bridgeRunStartedToStreams,
 } from "./agent-event-bridge.ts";
@@ -105,6 +107,41 @@ describe("agent-event-bridge", () => {
 		bridgeActionCompletedToStreams(actionPayload(runtime, "REPLY", "failed"));
 		const action = events.find((e) => e.stream === "action");
 		expect(action?.data).toMatchObject({ type: "complete", success: false });
+	});
+
+	it("populates the message stream on MESSAGE_RECEIVED (connector inbound)", async () => {
+		const { runtime, events } = await createCtx();
+		bridgeMessageReceivedToStreams({
+			runtime,
+			message: {
+				id: "44444444-4444-4444-4444-444444444444",
+				roomId: ROOM_ID,
+				entityId: "55555555-5555-5555-5555-555555555555",
+				content: { text: "hello from discord", attachments: [] },
+			},
+		} as unknown as MessagePayload);
+
+		const message = events.find((e) => e.stream === "message");
+		expect(message).toBeDefined();
+		expect(message?.runId).toBe(RUN_ID);
+		expect(message?.data).toMatchObject({
+			type: "received",
+			content: "hello from discord",
+			roomId: ROOM_ID,
+			hasAttachments: false,
+		});
+	});
+
+	it("no-ops MESSAGE_RECEIVED when the AgentEventService is absent", async () => {
+		const { runtime, events } = await createCtx({ withService: false });
+		bridgeMessageReceivedToStreams({
+			runtime,
+			message: {
+				id: "44444444-4444-4444-4444-444444444444",
+				content: { text: "x" },
+			},
+		} as unknown as MessagePayload);
+		expect(events).toHaveLength(0);
 	});
 
 	it("populates the lifecycle stream on RUN_STARTED / RUN_ENDED", async () => {

--- a/packages/core/src/services/agent-event-bridge.ts
+++ b/packages/core/src/services/agent-event-bridge.ts
@@ -23,6 +23,7 @@ import { logger } from "../logger.ts";
 import type {
 	ActionEventPayload,
 	EvaluatorEventPayload,
+	MessagePayload,
 	RunEventPayload,
 } from "../types/events.ts";
 import type { IAgentRuntime } from "../types/index.ts";
@@ -274,6 +275,52 @@ export function bridgeEvaluatorCompletedToStreams(
 				err: err instanceof Error ? err.message : String(err),
 			},
 			"Failed to bridge EVALUATOR_COMPLETED to AgentEventService",
+		);
+	}
+}
+
+/**
+ * Bridge `MESSAGE_RECEIVED` → AgentEventService `message` stream (#9449).
+ *
+ * Every connector's inbound path emits `MESSAGE_RECEIVED` (via the shared
+ * message pipeline), but nothing translated it into the user-facing activity
+ * stream — so the home activity rail only ever saw orchestrator tasks, never
+ * the agent fielding a message from Discord/Telegram/etc. One central bridge
+ * here covers all connectors at once (no per-connector boilerplate). The
+ * `message` stream is already in `AGENT_EVENT_ALLOWED_STREAMS`, so the client
+ * `useActivityEvents` rail renders it via `activityEventToPlaintext`.
+ *
+ * `MESSAGE_RECEIVED` fires before a run id exists, so we correlate by the
+ * current run when present and fall back to the message id otherwise.
+ */
+export function bridgeMessageReceivedToStreams(payload: MessagePayload): void {
+	const runtime = payload.runtime;
+	const service = resolveAgentEventService(runtime);
+	if (!service) {
+		return;
+	}
+	const message = payload.message;
+	const runId = resolveRunId(runtime) ?? message?.id;
+	if (!runId) {
+		return;
+	}
+	const text = message?.content?.text;
+	const attachments = message?.content?.attachments;
+	try {
+		service.emitMessageReceived(runId, {
+			messageId: message?.id,
+			roomId: message?.roomId,
+			userId: message?.entityId,
+			content: typeof text === "string" ? text : undefined,
+			hasAttachments: Array.isArray(attachments) && attachments.length > 0,
+		});
+	} catch (err) {
+		logger.debug(
+			{
+				src: "agent-event-bridge",
+				err: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to bridge MESSAGE_RECEIVED to AgentEventService",
 		);
 	}
 }


### PR DESCRIPTION
Central MESSAGE_RECEIVED → AgentEventService `message` stream bridge — covers all 27 connectors' inbound path at once (the `message` stream is already broadcast + `activityEventToPlaintext` renders `message_received`). Wires up the dead `emitMessageReceived`. Meets #9449's 'inbound-message path for all connectors emits activity' DoD alongside the existing action bridge. Verified: agent-event-bridge 10/10, core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)