### PR TITLE
feat(plugin-embeddings): provider-agnostic standalone TEXT_EMBEDDING plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3551,6 +3551,21 @@
         "tsup": "^8.5.1",
       },
     },
+    "plugins/plugin-embeddings": {
+      "name": "@elizaos/plugin-embeddings",
+      "version": "2.0.3-beta.2",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
+        "@elizaos/core": "workspace:*",
+        "@types/node": "^25.0.3",
+        "bun-types": "^1.3.12",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
+      },
+    },
     "plugins/plugin-facewear": {
       "name": "@elizaos/plugin-facewear",
       "version": "2.0.3-beta.2",
@@ -6584,6 +6599,8 @@
     "@elizaos/plugin-elizacloud": ["@elizaos/plugin-elizacloud@workspace:plugins/plugin-elizacloud"],
 
     "@elizaos/plugin-elizamaker": ["@elizaos/plugin-elizamaker@workspace:plugins/plugin-elizamaker"],
+
+    "@elizaos/plugin-embeddings": ["@elizaos/plugin-embeddings@workspace:plugins/plugin-embeddings"],
 
     "@elizaos/plugin-facewear": ["@elizaos/plugin-facewear@workspace:plugins/plugin-facewear"],
 

--- a/plugins/plugin-embeddings/AGENTS.md
+++ b/plugins/plugin-embeddings/AGENTS.md
@@ -1,0 +1,114 @@
+# @elizaos/plugin-embeddings
+
+Provider-agnostic ("bring your own") `TEXT_EMBEDDING` provider for elizaOS agents. Points a single set of `EMBEDDING_*` vars at any OpenAI-compatible `/embeddings` endpoint, independent of the chat brain.
+
+## Purpose / role
+
+Decouples embeddings from text generation. A self-hosted bot whose chat provider serves no good embeddings — Claude (no embeddings API), Cerebras (no embeddings) — can still get high-quality vectors by setting `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY` to a personal OpenAI key, an Eliza Cloud URL, Voyage, or a local TEI / Infinity / vLLM / LM Studio server.
+
+**Purely additive.** The plugin auto-enables **only** when `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is set (see `auto-enable.ts`). With neither set it never loads, so existing deployments — which use their chat provider's embedding slot, local inference, or Eliza Cloud — are unaffected.
+
+It registers **only the embedding slots** — no text/image/audio handlers, no actions, providers, services, or evaluators.
+
+## Plugin surface
+
+| Model type | Handler | File |
+|---|---|---|
+| `ModelType.TEXT_EMBEDDING` | `handleTextEmbedding` | `src/models/embedding.ts` |
+| `ModelType.TEXT_EMBEDDING_BATCH` | `handleBatchTextEmbedding` | `src/models/embedding.ts` |
+
+Both POST `{ model, input, ...(explicit dimensions ? { dimensions } : {}) }` to `` `${EMBEDDING_BASE_URL}/embeddings` `` using raw `fetch` (no `@ai-sdk` dependency), parse the OpenAI-compatible response, validate the returned width against the configured dimension, and emit a `MODEL_USED` event.
+
+### Registration priority
+
+The plugin registers at **`priority: 1`**. The native priority sort for the embedding slot is:
+
+```
+local-inference @ 0  <  plugin-embeddings @ 1  <  Eliza Cloud @ 50
+```
+
+So a bring-your-own endpoint **beats a bare local embedder** but **yields to a paired Eliza Cloud**. This is the desired default; override per-slot via the runtime routing preferences when a different precedence is wanted.
+
+### Error policy (Commandment 8 / issue #9324)
+
+On **any** HTTP, config, or response-shape error the handler **THROWS** — it never returns a zero or fabricated vector, which would silently corrupt the embedding store. The single legitimate synthetic return is the boot dimension-probe: the runtime calls `useModel(TEXT_EMBEDDING, null)` purely to read `.length`, so a correctly-sized marker vector (`[0.1, 0, 0, …]`) is returned for `null` input only. There is **no Cerebras deterministic-fallback branch** (dropped from the lifted OpenAI handler) and **no default endpoint** — a missing `EMBEDDING_BASE_URL` throws.
+
+## Layout
+
+```
+plugins/plugin-embeddings/
+  index.ts / index.node.ts / index.browser.ts   Build entrypoints (re-export src/index)
+  auto-enable.ts        Manifest entry-point — env-only shouldEnable (no transitive imports)
+  build.ts              Bun.build (node + browser + cjs) + tsc declarations
+  src/
+    index.ts            embeddingsPlugin — models map + init() config validation/logging
+    models/
+      embedding.ts      handleTextEmbedding + handleBatchTextEmbedding (raw fetch, THROW on error)
+      index.ts          Re-exports handlers
+    utils/
+      config.ts         Provider-neutral getSetting-based getters
+      events.ts         emitModelUsageEvent (MODEL_USED)
+    types/
+      index.ts          EmbeddingResponse, TokenUsage
+  __tests__/
+    embedding.test.ts   Null-probe width, wire-mocked vector, dimension-mismatch/empty/unsupported throws, batch, VECTOR_DIMS contract
+    config.test.ts      Provider-neutral getter resolution + no chat fallback
+    auto-enable.test.ts shouldEnable opt-in semantics
+```
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-embeddings build        # Bun.build (node + browser + cjs) + tsc d.ts
+bun run --cwd plugins/plugin-embeddings dev          # watch build
+bun run --cwd plugins/plugin-embeddings test         # vitest unit suite
+bun run --cwd plugins/plugin-embeddings typecheck    # tsc --noEmit --noCheck
+bun run --cwd plugins/plugin-embeddings lint         # biome check --write --unsafe
+bun run --cwd plugins/plugin-embeddings lint:check   # biome check (read-only)
+bun run --cwd plugins/plugin-embeddings format       # biome format --write
+bun run --cwd plugins/plugin-embeddings clean        # rm -rf dist .turbo …
+```
+
+## Config / env vars
+
+All read via `getSetting(runtime, key)` (runtime/character config first, then `process.env`), so every value is per-character overridable. There is **no fallback** to a chat provider's settings (`OPENAI_*`, `ELIZAOS_CLOUD_*`, …) — this plugin owns the embedding slot independently.
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `EMBEDDING_BASE_URL` | one-of* | — | Base URL of an OpenAI-compatible `/embeddings` endpoint. No default — unset throws. |
+| `EMBEDDING_API_KEY` | one-of* | — | Bearer token for the endpoint. Omit for local servers needing no auth. |
+| `EMBEDDING_MODEL` | no | `text-embedding-3-small` | Model id sent as the request `model` field. |
+| `EMBEDDING_DIMENSIONS` | no | `1536` | Vector width. When explicitly set, sent as the request `dimensions` field. |
+| `EMBEDDING_BROWSER_URL` | no | — | Browser-only server-side proxy URL. In a browser build the `Authorization` header is sent **only** when this is set, keeping the key server-side. |
+
+\* Setting **either** `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is what activates the plugin. For real (non-probe) embedding calls a `EMBEDDING_BASE_URL` is required or the handler throws.
+
+### Supported dimensions
+
+`EMBEDDING_DIMENSIONS` must be one of the elizaOS `VECTOR_DIMS` (imported from `@elizaos/core`):
+
+```
+384, 512, 768, 1024, 1536, 2048, 3072
+```
+
+An unsupported value throws at boot and on every call.
+
+### Stable-dimension-per-DB caveat
+
+The embedding dimension is part of the database vector schema. **Keep `EMBEDDING_DIMENSIONS` (and the model) stable for the lifetime of a database.** Changing the width invalidates every stored vector — existing rows become unsearchable / get dropped on dimension mismatch. To switch dimensions, re-embed the corpus into a fresh store.
+
+## How to extend
+
+This plugin is intentionally embedding-only. To add another OpenAI-compatible embedding behavior, add a helper in `src/models/embedding.ts`, re-export from `src/models/index.ts`, and (if a new slot) wire it into the `models` map in `src/index.ts`. Add any new env var to `src/utils/config.ts` (follow the `getSetting` pattern) and to `agentConfig.pluginParameters` in `package.json`.
+
+## Registration / discovery
+
+No central list edit is needed. The plugin lives under the repo `plugins/*` workspace glob (so `bun install` symlinks it into `node_modules`) and declares `elizaos.plugin.autoEnableModule` in `package.json`. The agent's plugin-candidate discovery (`packages/agent/src/runtime/plugin-resolver.ts → discoverPluginCandidates`) walks `node_modules` **and** the workspace `plugins/` dir, reads each `elizaos.plugin` manifest, and the auto-enable engine (`packages/shared/src/config/plugin-manifest.ts`) runs `shouldEnable`. This is identical to how `plugin-lmstudio` is wired — neither plugin appears in `core-plugins.ts` nor as a dep of `packages/agent`.
+
+## Conventions / gotchas
+
+- **Raw `fetch`, no `@ai-sdk`.** Mirrors plugin-openai's transport. The only runtime dependency is `@elizaos/core` (peer/`workspace:*`).
+- **THROW, never fabricate.** Any failure throws so the runtime falls through to another provider instead of persisting a corrupt vector.
+- **Browser key safety.** The `Authorization` header is suppressed in browser builds unless `EMBEDDING_BROWSER_URL` is set (the proxy injects auth server-side).
+- **Dual build (node + browser).** `dist/node/index.node.js` and `dist/browser/index.browser.js`.
+- See the repo-root `AGENTS.md` for logger-only, ESM, naming, and architecture rules.

--- a/plugins/plugin-embeddings/CLAUDE.md
+++ b/plugins/plugin-embeddings/CLAUDE.md
@@ -1,0 +1,114 @@
+# @elizaos/plugin-embeddings
+
+Provider-agnostic ("bring your own") `TEXT_EMBEDDING` provider for elizaOS agents. Points a single set of `EMBEDDING_*` vars at any OpenAI-compatible `/embeddings` endpoint, independent of the chat brain.
+
+## Purpose / role
+
+Decouples embeddings from text generation. A self-hosted bot whose chat provider serves no good embeddings — Claude (no embeddings API), Cerebras (no embeddings) — can still get high-quality vectors by setting `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY` to a personal OpenAI key, an Eliza Cloud URL, Voyage, or a local TEI / Infinity / vLLM / LM Studio server.
+
+**Purely additive.** The plugin auto-enables **only** when `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is set (see `auto-enable.ts`). With neither set it never loads, so existing deployments — which use their chat provider's embedding slot, local inference, or Eliza Cloud — are unaffected.
+
+It registers **only the embedding slots** — no text/image/audio handlers, no actions, providers, services, or evaluators.
+
+## Plugin surface
+
+| Model type | Handler | File |
+|---|---|---|
+| `ModelType.TEXT_EMBEDDING` | `handleTextEmbedding` | `src/models/embedding.ts` |
+| `ModelType.TEXT_EMBEDDING_BATCH` | `handleBatchTextEmbedding` | `src/models/embedding.ts` |
+
+Both POST `{ model, input, ...(explicit dimensions ? { dimensions } : {}) }` to `` `${EMBEDDING_BASE_URL}/embeddings` `` using raw `fetch` (no `@ai-sdk` dependency), parse the OpenAI-compatible response, validate the returned width against the configured dimension, and emit a `MODEL_USED` event.
+
+### Registration priority
+
+The plugin registers at **`priority: 1`**. The native priority sort for the embedding slot is:
+
+```
+local-inference @ 0  <  plugin-embeddings @ 1  <  Eliza Cloud @ 50
+```
+
+So a bring-your-own endpoint **beats a bare local embedder** but **yields to a paired Eliza Cloud**. This is the desired default; override per-slot via the runtime routing preferences when a different precedence is wanted.
+
+### Error policy (Commandment 8 / issue #9324)
+
+On **any** HTTP, config, or response-shape error the handler **THROWS** — it never returns a zero or fabricated vector, which would silently corrupt the embedding store. The single legitimate synthetic return is the boot dimension-probe: the runtime calls `useModel(TEXT_EMBEDDING, null)` purely to read `.length`, so a correctly-sized marker vector (`[0.1, 0, 0, …]`) is returned for `null` input only. There is **no Cerebras deterministic-fallback branch** (dropped from the lifted OpenAI handler) and **no default endpoint** — a missing `EMBEDDING_BASE_URL` throws.
+
+## Layout
+
+```
+plugins/plugin-embeddings/
+  index.ts / index.node.ts / index.browser.ts   Build entrypoints (re-export src/index)
+  auto-enable.ts        Manifest entry-point — env-only shouldEnable (no transitive imports)
+  build.ts              Bun.build (node + browser + cjs) + tsc declarations
+  src/
+    index.ts            embeddingsPlugin — models map + init() config validation/logging
+    models/
+      embedding.ts      handleTextEmbedding + handleBatchTextEmbedding (raw fetch, THROW on error)
+      index.ts          Re-exports handlers
+    utils/
+      config.ts         Provider-neutral getSetting-based getters
+      events.ts         emitModelUsageEvent (MODEL_USED)
+    types/
+      index.ts          EmbeddingResponse, TokenUsage
+  __tests__/
+    embedding.test.ts   Null-probe width, wire-mocked vector, dimension-mismatch/empty/unsupported throws, batch, VECTOR_DIMS contract
+    config.test.ts      Provider-neutral getter resolution + no chat fallback
+    auto-enable.test.ts shouldEnable opt-in semantics
+```
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-embeddings build        # Bun.build (node + browser + cjs) + tsc d.ts
+bun run --cwd plugins/plugin-embeddings dev          # watch build
+bun run --cwd plugins/plugin-embeddings test         # vitest unit suite
+bun run --cwd plugins/plugin-embeddings typecheck    # tsc --noEmit --noCheck
+bun run --cwd plugins/plugin-embeddings lint         # biome check --write --unsafe
+bun run --cwd plugins/plugin-embeddings lint:check   # biome check (read-only)
+bun run --cwd plugins/plugin-embeddings format       # biome format --write
+bun run --cwd plugins/plugin-embeddings clean        # rm -rf dist .turbo …
+```
+
+## Config / env vars
+
+All read via `getSetting(runtime, key)` (runtime/character config first, then `process.env`), so every value is per-character overridable. There is **no fallback** to a chat provider's settings (`OPENAI_*`, `ELIZAOS_CLOUD_*`, …) — this plugin owns the embedding slot independently.
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `EMBEDDING_BASE_URL` | one-of* | — | Base URL of an OpenAI-compatible `/embeddings` endpoint. No default — unset throws. |
+| `EMBEDDING_API_KEY` | one-of* | — | Bearer token for the endpoint. Omit for local servers needing no auth. |
+| `EMBEDDING_MODEL` | no | `text-embedding-3-small` | Model id sent as the request `model` field. |
+| `EMBEDDING_DIMENSIONS` | no | `1536` | Vector width. When explicitly set, sent as the request `dimensions` field. |
+| `EMBEDDING_BROWSER_URL` | no | — | Browser-only server-side proxy URL. In a browser build the `Authorization` header is sent **only** when this is set, keeping the key server-side. |
+
+\* Setting **either** `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is what activates the plugin. For real (non-probe) embedding calls a `EMBEDDING_BASE_URL` is required or the handler throws.
+
+### Supported dimensions
+
+`EMBEDDING_DIMENSIONS` must be one of the elizaOS `VECTOR_DIMS` (imported from `@elizaos/core`):
+
+```
+384, 512, 768, 1024, 1536, 2048, 3072
+```
+
+An unsupported value throws at boot and on every call.
+
+### Stable-dimension-per-DB caveat
+
+The embedding dimension is part of the database vector schema. **Keep `EMBEDDING_DIMENSIONS` (and the model) stable for the lifetime of a database.** Changing the width invalidates every stored vector — existing rows become unsearchable / get dropped on dimension mismatch. To switch dimensions, re-embed the corpus into a fresh store.
+
+## How to extend
+
+This plugin is intentionally embedding-only. To add another OpenAI-compatible embedding behavior, add a helper in `src/models/embedding.ts`, re-export from `src/models/index.ts`, and (if a new slot) wire it into the `models` map in `src/index.ts`. Add any new env var to `src/utils/config.ts` (follow the `getSetting` pattern) and to `agentConfig.pluginParameters` in `package.json`.
+
+## Registration / discovery
+
+No central list edit is needed. The plugin lives under the repo `plugins/*` workspace glob (so `bun install` symlinks it into `node_modules`) and declares `elizaos.plugin.autoEnableModule` in `package.json`. The agent's plugin-candidate discovery (`packages/agent/src/runtime/plugin-resolver.ts → discoverPluginCandidates`) walks `node_modules` **and** the workspace `plugins/` dir, reads each `elizaos.plugin` manifest, and the auto-enable engine (`packages/shared/src/config/plugin-manifest.ts`) runs `shouldEnable`. This is identical to how `plugin-lmstudio` is wired — neither plugin appears in `core-plugins.ts` nor as a dep of `packages/agent`.
+
+## Conventions / gotchas
+
+- **Raw `fetch`, no `@ai-sdk`.** Mirrors plugin-openai's transport. The only runtime dependency is `@elizaos/core` (peer/`workspace:*`).
+- **THROW, never fabricate.** Any failure throws so the runtime falls through to another provider instead of persisting a corrupt vector.
+- **Browser key safety.** The `Authorization` header is suppressed in browser builds unless `EMBEDDING_BROWSER_URL` is set (the proxy injects auth server-side).
+- **Dual build (node + browser).** `dist/node/index.node.js` and `dist/browser/index.browser.js`.
+- See the repo-root `AGENTS.md` for logger-only, ESM, naming, and architecture rules.

--- a/plugins/plugin-embeddings/README.md
+++ b/plugins/plugin-embeddings/README.md
@@ -1,0 +1,98 @@
+# @elizaos/plugin-embeddings
+
+A provider-agnostic ("bring your own") `TEXT_EMBEDDING` provider for elizaOS agents. Point one set of `EMBEDDING_*` variables at **any** OpenAI-compatible `/embeddings` endpoint and get embeddings independently of your chat provider.
+
+## Why
+
+Embeddings power memory, recall, and semantic search — but they don't have to come from the same provider as the chat brain. If your agent runs on a provider that serves no good embeddings (e.g. **Claude**, which has no embeddings API, or **Cerebras**, which serves none), this plugin lets you keep your chat brain where it is and route embeddings to something that does it well:
+
+- a personal **OpenAI** key (`text-embedding-3-small` / `-large`)
+- **Eliza Cloud** embeddings
+- **Voyage AI** (via an OpenAI-compatible proxy)
+- a local **TEI**, **Infinity**, **vLLM**, or **LM Studio** server
+
+## Purely additive
+
+The plugin activates **only** when you set `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY`. With neither set it never loads, so dropping it into an existing deployment changes nothing until you opt in.
+
+## What it registers
+
+Only the embedding slots — nothing else (no text/image/audio, no actions/providers/services):
+
+| Slot | Behavior |
+|---|---|
+| `TEXT_EMBEDDING` | Embed one text → one vector. |
+| `TEXT_EMBEDDING_BATCH` | Embed many texts in one request → one vector each. |
+
+Both use raw `fetch` (no `@ai-sdk` dependency) to POST to `${EMBEDDING_BASE_URL}/embeddings`.
+
+### Priority
+
+Registered at `priority: 1`:
+
+```
+local-inference @ 0  <  plugin-embeddings @ 1  <  Eliza Cloud @ 50
+```
+
+A bring-your-own endpoint beats a bare local embedder but yields to a paired Eliza Cloud. Override per-slot via runtime routing preferences if you want a different order.
+
+### Fail loudly, never fabricate
+
+On any HTTP / config / response-shape error the handler **throws** — it never returns a zero or garbage vector that would silently corrupt the embedding store. The only synthetic return is the boot dimension-probe (`null` input), where a correctly-sized marker vector is the expected, legitimate response.
+
+## Configuration
+
+All variables are read via `runtime.getSetting(key)` first, then `process.env`, so they are per-character overridable. They do **not** fall back to any chat provider's settings.
+
+| Variable | Default | Description |
+|---|---|---|
+| `EMBEDDING_BASE_URL` | _(none)_ | OpenAI-compatible `/embeddings` base URL. **Required** for real embedding calls — no default endpoint. |
+| `EMBEDDING_API_KEY` | _(none)_ | Bearer token. Omit for local servers that need no auth. |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` | Model id sent as the request `model` field. |
+| `EMBEDDING_DIMENSIONS` | `1536` | Vector width (see below). Sent as the request `dimensions` field when explicitly set. |
+| `EMBEDDING_BROWSER_URL` | _(none)_ | Browser-only server-side proxy URL. In a browser build the `Authorization` header is sent only when this is set, keeping the key off the client. |
+
+Setting **either** `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` activates the plugin.
+
+### Supported dimensions
+
+`EMBEDDING_DIMENSIONS` must be one of:
+
+```
+384, 512, 768, 1024, 1536, 2048, 3072
+```
+
+Any other value throws.
+
+### ⚠️ Keep the dimension stable per database
+
+The embedding dimension is baked into your database's vector schema. **Do not change `EMBEDDING_DIMENSIONS` (or the model's native width) after a database has stored vectors** — doing so invalidates every existing vector and they will fail to match on dimension. To change dimensions, re-embed your corpus into a fresh store.
+
+## Example `.env`
+
+Personal OpenAI key for embeddings, while chat stays on another provider:
+
+```
+EMBEDDING_BASE_URL=https://api.openai.com/v1
+EMBEDDING_API_KEY=sk-...
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMENSIONS=1536
+```
+
+Local TEI / Infinity / vLLM server (no auth):
+
+```
+EMBEDDING_BASE_URL=http://localhost:8080/v1
+EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+EMBEDDING_DIMENSIONS=384
+```
+
+## Installation
+
+The plugin is picked up automatically when `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is present. To reference it explicitly in a character file:
+
+```json
+{
+  "plugins": ["@elizaos/plugin-embeddings"]
+}
+```

--- a/plugins/plugin-embeddings/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-embeddings/__tests__/auto-enable.test.ts
@@ -1,0 +1,28 @@
+import type { PluginAutoEnableContext } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import { shouldEnable } from "../auto-enable";
+
+function ctx(env: Record<string, string | undefined>): PluginAutoEnableContext {
+  return { env } as unknown as PluginAutoEnableContext;
+}
+
+describe("plugin-embeddings auto-enable", () => {
+  it("is false when neither EMBEDDING_BASE_URL nor EMBEDDING_API_KEY is set", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ OPENAI_API_KEY: "k" }))).toBe(false);
+  });
+
+  it("is false when the opt-in vars are empty/whitespace", () => {
+    expect(shouldEnable(ctx({ EMBEDDING_BASE_URL: "" }))).toBe(false);
+    expect(shouldEnable(ctx({ EMBEDDING_API_KEY: "   " }))).toBe(false);
+  });
+
+  it("is true when EMBEDDING_BASE_URL is a non-empty string", () => {
+    expect(shouldEnable(ctx({ EMBEDDING_BASE_URL: "https://x/v1" }))).toBe(true);
+  });
+
+  it("is true when EMBEDDING_API_KEY is a non-empty string", () => {
+    expect(shouldEnable(ctx({ EMBEDDING_API_KEY: "sk-test" }))).toBe(true);
+  });
+});

--- a/plugins/plugin-embeddings/__tests__/config.test.ts
+++ b/plugins/plugin-embeddings/__tests__/config.test.ts
@@ -1,0 +1,72 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getEmbeddingApiKey,
+  getEmbeddingBaseURL,
+  getEmbeddingDimensions,
+  getEmbeddingModel,
+  hasEmbeddingConfig,
+} from "../src/utils/config";
+
+type Setting = string | number | boolean | null;
+function makeRuntime(settings: Record<string, Setting> = {}): IAgentRuntime {
+  return {
+    getSetting: (key: string) => (key in settings ? settings[key] : null),
+  } as unknown as IAgentRuntime;
+}
+
+const ORIGINAL_ENV = { ...process.env };
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("plugin-embeddings config", () => {
+  it("returns undefined base URL when nothing is configured (no default endpoint)", () => {
+    expect(getEmbeddingBaseURL(makeRuntime())).toBeUndefined();
+  });
+
+  it("reads and trims EMBEDDING_BASE_URL", () => {
+    expect(getEmbeddingBaseURL(makeRuntime({ EMBEDDING_BASE_URL: "  https://x/v1  " }))).toBe(
+      "https://x/v1"
+    );
+  });
+
+  it("does NOT fall back to a chat provider base URL", () => {
+    // Only an unrelated chat-provider var is set — the embedding URL stays unset.
+    expect(getEmbeddingBaseURL(makeRuntime({ OPENAI_BASE_URL: "https://api.openai.com/v1" }))).toBe(
+      undefined
+    );
+  });
+
+  it("reads EMBEDDING_API_KEY", () => {
+    expect(getEmbeddingApiKey(makeRuntime({ EMBEDDING_API_KEY: "k-123" }))).toBe("k-123");
+    expect(getEmbeddingApiKey(makeRuntime())).toBeUndefined();
+  });
+
+  it("defaults the model to text-embedding-3-small", () => {
+    expect(getEmbeddingModel(makeRuntime())).toBe("text-embedding-3-small");
+    expect(getEmbeddingModel(makeRuntime({ EMBEDDING_MODEL: "voyage-3" }))).toBe("voyage-3");
+  });
+
+  it("defaults dimensions to 1536", () => {
+    expect(getEmbeddingDimensions(makeRuntime())).toBe(1536);
+    expect(getEmbeddingDimensions(makeRuntime({ EMBEDDING_DIMENSIONS: "768" }))).toBe(768);
+  });
+
+  it("hasEmbeddingConfig is true when EITHER url or key is set", () => {
+    expect(hasEmbeddingConfig(makeRuntime())).toBe(false);
+    expect(hasEmbeddingConfig(makeRuntime({ EMBEDDING_BASE_URL: "https://x/v1" }))).toBe(true);
+    expect(hasEmbeddingConfig(makeRuntime({ EMBEDDING_API_KEY: "k" }))).toBe(true);
+  });
+
+  it("falls back to process.env when the runtime setting is absent", () => {
+    process.env.EMBEDDING_BASE_URL = "https://env-host/v1";
+    expect(getEmbeddingBaseURL(makeRuntime())).toBe("https://env-host/v1");
+  });
+
+  it("per-character runtime setting wins over process.env", () => {
+    process.env.EMBEDDING_MODEL = "env-model";
+    expect(getEmbeddingModel(makeRuntime({ EMBEDDING_MODEL: "char-model" }))).toBe("char-model");
+  });
+});

--- a/plugins/plugin-embeddings/__tests__/embedding.test.ts
+++ b/plugins/plugin-embeddings/__tests__/embedding.test.ts
@@ -1,0 +1,203 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { VECTOR_DIMS } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleBatchTextEmbedding, handleTextEmbedding } from "../src/models/embedding";
+
+function createRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+  const values: Record<string, string> = {
+    EMBEDDING_BASE_URL: "https://embeddings.example/v1",
+    EMBEDDING_API_KEY: "test-key",
+    ...settings,
+  };
+  return {
+    character: { name: "Ada" },
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn((key: string) => values[key] ?? null),
+  } as unknown as IAgentRuntime;
+}
+
+function vectorOf(length: number): number[] {
+  return Array.from({ length }, (_v, i) => (i + 1) / length);
+}
+
+function mockEmbeddingsResponse(vectors: number[][]): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({
+      object: "list",
+      data: vectors.map((embedding, index) => ({ object: "embedding", embedding, index })),
+      model: "text-embedding-3-small",
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    }),
+    text: async () => "",
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("plugin-embeddings handleTextEmbedding", () => {
+  it("returns an EMBEDDING_DIMENSIONS-wide vector for the null init-probe", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    const probe = await handleTextEmbedding(createRuntime({ EMBEDDING_DIMENSIONS: "768" }), null);
+
+    expect(probe).toHaveLength(768);
+    expect(probe[0]).toBeCloseTo(0.1);
+    // The null probe must never hit the network — it only reports the width.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("defaults the probe width to 1536 when EMBEDDING_DIMENSIONS is unset", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(vi.fn() as typeof fetch);
+    const probe = await handleTextEmbedding(createRuntime(), null);
+    expect(probe).toHaveLength(1536);
+  });
+
+  it("returns the parsed vector from a wire-mocked /embeddings response", async () => {
+    const expected = vectorOf(1536);
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([expected]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    const result = await handleTextEmbedding(createRuntime(), { text: "hello world" });
+
+    expect(result).toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://embeddings.example/v1/embeddings");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer test-key");
+    const body = JSON.parse(init.body as string);
+    expect(body.input).toBe("hello world");
+    expect(body.model).toBe("text-embedding-3-small");
+  });
+
+  it("omits the dimensions field when EMBEDDING_DIMENSIONS is not explicitly set", async () => {
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(1536)]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await handleTextEmbedding(createRuntime(), { text: "hi" });
+
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body).not.toHaveProperty("dimensions");
+  });
+
+  it("sends the dimensions field when EMBEDDING_DIMENSIONS is explicitly set", async () => {
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(512)]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await handleTextEmbedding(createRuntime({ EMBEDDING_DIMENSIONS: "512" }), { text: "hi" });
+
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.dimensions).toBe(512);
+  });
+
+  it("throws on a dimension mismatch (never returns the wrong-width vector)", async () => {
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(768)]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      handleTextEmbedding(createRuntime({ EMBEDDING_DIMENSIONS: "1536" }), { text: "hi" })
+    ).rejects.toThrow(/dimension mismatch/i);
+  });
+
+  it("throws on empty text before calling the provider", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(handleTextEmbedding(createRuntime(), { text: "   " })).rejects.toThrow(
+      /empty text/i
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on an unsupported configured dimension", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+
+    await expect(
+      handleTextEmbedding(createRuntime({ EMBEDDING_DIMENSIONS: "999" }), { text: "hi" })
+    ).rejects.toThrow(/Invalid embedding dimension/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when no endpoint is configured (no silent default, no zero vector)", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+    // Only a key, no base URL — a real text embed cannot resolve an endpoint.
+    const runtime = {
+      character: { name: "Ada" },
+      emitEvent: vi.fn(),
+      getSetting: vi.fn((key: string) => (key === "EMBEDDING_API_KEY" ? "k" : null)),
+    } as unknown as IAgentRuntime;
+
+    await expect(handleTextEmbedding(runtime, { text: "hi" })).rejects.toThrow(
+      /No embedding endpoint configured/i
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a non-OK HTTP response instead of returning a fabricated vector", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: async () => "upstream down",
+    }));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextEmbedding(createRuntime(), { text: "hi" })).rejects.toThrow(/502/);
+  });
+
+  it("emits the configured dimension as a member of VECTOR_DIMS (contract)", async () => {
+    const dims = Object.values(VECTOR_DIMS) as number[];
+    for (const dim of dims) {
+      const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(dim)]));
+      vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+      const result = await handleTextEmbedding(
+        createRuntime({ EMBEDDING_DIMENSIONS: String(dim) }),
+        { text: "contract" }
+      );
+      expect(result).toHaveLength(dim);
+      expect(dims).toContain(result.length);
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe("plugin-embeddings handleBatchTextEmbedding", () => {
+  it("returns one vector per input in order from a single request", async () => {
+    const v0 = vectorOf(1536).map((x) => x * 0.5);
+    const v1 = vectorOf(1536);
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([v0, v1]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    const result = await handleBatchTextEmbedding(createRuntime(), ["a", "b"]);
+
+    expect(result).toEqual([v0, v1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.input).toEqual(["a", "b"]);
+  });
+
+  it("returns [] for an empty batch without calling the provider", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+    await expect(handleBatchTextEmbedding(createRuntime(), [])).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on an empty text inside a batch", async () => {
+    const fetchMock = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+    await expect(handleBatchTextEmbedding(createRuntime(), ["ok", "  "])).rejects.toThrow(
+      /empty text at index 1/i
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-embeddings/auto-enable.ts
+++ b/plugins/plugin-embeddings/auto-enable.ts
@@ -1,0 +1,23 @@
+// Auto-enable check for @elizaos/plugin-embeddings.
+//
+// Plugin manifest entry-point — referenced by package.json's
+// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
+// no service init, no transitive imports of the full plugin runtime. The
+// auto-enable engine loads dozens of these per boot.
+//
+// This plugin is a provider-agnostic ("bring your own") TEXT_EMBEDDING slot. It
+// is purely additive: it activates ONLY when the operator opts in by setting
+// `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY`. Without either, the plugin never
+// loads, so existing deployments (which rely on their chat provider's embedding
+// slot, or on local inference / Eliza Cloud) are unaffected.
+
+import type { PluginAutoEnableContext } from "@elizaos/core";
+
+const ENV_KEYS = ["EMBEDDING_BASE_URL", "EMBEDDING_API_KEY"] as const;
+
+export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
+  return ENV_KEYS.some((k) => {
+    const v = ctx.env[k];
+    return typeof v === "string" && v.trim() !== "";
+  });
+}

--- a/plugins/plugin-embeddings/biome.json
+++ b/plugins/plugin-embeddings/biome.json
@@ -1,0 +1,42 @@
+{
+  "root": false,
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "files": {
+    "includes": ["**", "!!dist", "!!node_modules"]
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "a11y": {
+        "useButtonType": "off"
+      },
+      "complexity": {
+        "noCommaOperator": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentWidth": 2,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  }
+}

--- a/plugins/plugin-embeddings/build.ts
+++ b/plugins/plugin-embeddings/build.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { build } from "bun";
+
+const ROOT = resolve(dirname(import.meta.path));
+const DIST = join(ROOT, "dist");
+
+rmSync(DIST, { recursive: true, force: true });
+mkdirSync(DIST, { recursive: true });
+mkdirSync(join(DIST, "node"), { recursive: true });
+mkdirSync(join(DIST, "browser"), { recursive: true });
+mkdirSync(join(DIST, "cjs"), { recursive: true });
+
+const EXTERNAL = ["@elizaos/core"];
+
+console.log("Building Node.js ESM bundle...");
+await build({
+  entrypoints: [join(ROOT, "index.node.ts")],
+  outdir: join(DIST, "node"),
+  target: "node",
+  format: "esm",
+  splitting: false,
+  sourcemap: "linked",
+  minify: false,
+  external: EXTERNAL,
+  naming: {
+    entry: "index.node.js",
+  },
+});
+
+console.log("Building Browser ESM bundle...");
+await build({
+  entrypoints: [join(ROOT, "index.browser.ts")],
+  outdir: join(DIST, "browser"),
+  target: "browser",
+  format: "esm",
+  splitting: false,
+  sourcemap: "linked",
+  minify: false,
+  external: EXTERNAL,
+  naming: {
+    entry: "index.browser.js",
+  },
+});
+
+console.log("Building CJS bundle...");
+await build({
+  entrypoints: [join(ROOT, "index.node.ts")],
+  outdir: join(DIST, "cjs"),
+  target: "node",
+  format: "cjs",
+  splitting: false,
+  sourcemap: "linked",
+  minify: false,
+  external: EXTERNAL,
+  naming: {
+    entry: "index.node.cjs",
+  },
+});
+
+console.log("Generating TypeScript declarations...");
+const { mkdir, writeFile } = await import("node:fs/promises");
+const { $ } = await import("bun");
+const tscPath = join(
+  ROOT,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsc.exe" : "tsc"
+);
+
+try {
+  await $`${tscPath} --project tsconfig.build.json`;
+} catch {
+  console.warn(
+    "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."
+  );
+}
+
+await mkdir("dist/node", { recursive: true });
+await mkdir("dist/browser", { recursive: true });
+await mkdir("dist/cjs", { recursive: true });
+
+const reexportDeclaration = `export * from '../index';
+export { default } from '../index';
+`;
+
+await writeFile("dist/node/index.d.ts", reexportDeclaration);
+await writeFile("dist/browser/index.d.ts", reexportDeclaration);
+await writeFile("dist/cjs/index.d.ts", reexportDeclaration);
+
+console.log("Build complete!");

--- a/plugins/plugin-embeddings/index.browser.ts
+++ b/plugins/plugin-embeddings/index.browser.ts
@@ -1,0 +1,8 @@
+import { embeddingsPlugin } from "./src/index";
+
+export * from "./src/index";
+export { embeddingsPlugin };
+
+const defaultEmbeddingsPlugin = embeddingsPlugin;
+
+export default defaultEmbeddingsPlugin;

--- a/plugins/plugin-embeddings/index.node.ts
+++ b/plugins/plugin-embeddings/index.node.ts
@@ -1,0 +1,8 @@
+import { embeddingsPlugin } from "./src/index";
+
+export * from "./src/index";
+export { embeddingsPlugin };
+
+const defaultEmbeddingsPlugin = embeddingsPlugin;
+
+export default defaultEmbeddingsPlugin;

--- a/plugins/plugin-embeddings/index.ts
+++ b/plugins/plugin-embeddings/index.ts
@@ -1,0 +1,8 @@
+import { embeddingsPlugin } from "./src/index";
+
+export * from "./src/index";
+export { embeddingsPlugin };
+
+const defaultEmbeddingsPlugin = embeddingsPlugin;
+
+export default defaultEmbeddingsPlugin;

--- a/plugins/plugin-embeddings/package.json
+++ b/plugins/plugin-embeddings/package.json
@@ -1,0 +1,129 @@
+{
+  "name": "@elizaos/plugin-embeddings",
+  "version": "2.0.3-beta.2",
+  "type": "module",
+  "main": "dist/node/index.node.js",
+  "module": "dist/node/index.node.js",
+  "types": "dist/node/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elizaOS/eliza.git",
+    "directory": "plugins/plugin-embeddings"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "import": "./dist/browser/index.browser.js",
+        "default": "./dist/browser/index.browser.js"
+      },
+      "node": {
+        "types": "./dist/node/index.d.ts",
+        "import": "./dist/node/index.node.js",
+        "default": "./dist/node/index.node.js"
+      },
+      "bun": {
+        "types": "./dist/node/index.d.ts",
+        "default": "./dist/node/index.node.js"
+      },
+      "default": "./dist/node/index.node.js"
+    },
+    "./*.css": "./dist/*.css",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist",
+    "auto-enable.ts"
+  ],
+  "elizaos": {
+    "plugin": {
+      "autoEnableModule": "./auto-enable.ts",
+      "capabilities": [
+        "embedding"
+      ]
+    }
+  },
+  "sideEffects": false,
+  "dependencies": {},
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
+    "@elizaos/core": "workspace:*",
+    "@types/node": "^25.0.3",
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "workspace:*"
+  },
+  "scripts": {
+    "dev": "bun run build.ts --watch",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsc --noEmit --noCheck -p tsconfig.json",
+    "test": "vitest run --config ./vitest.config.ts __tests__/",
+    "test:unit": "vitest run --config ./vitest.config.ts __tests__/",
+    "lint:check": "bunx @biomejs/biome check .",
+    "build": "bun run build.ts",
+    "build:ts": "bun run build.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "EMBEDDING_BASE_URL": {
+        "type": "string",
+        "description": "Base URL of an OpenAI-compatible /embeddings endpoint (e.g. https://api.openai.com/v1, an Eliza Cloud URL, a Voyage proxy, or a local TEI/Infinity/vLLM server). Setting this (or EMBEDDING_API_KEY) is what activates the plugin.",
+        "required": false,
+        "sensitive": false
+      },
+      "EMBEDDING_API_KEY": {
+        "type": "string",
+        "description": "Bearer token for the embedding endpoint. Setting this (or EMBEDDING_BASE_URL) is what activates the plugin. Omit for local servers that need no auth.",
+        "required": false,
+        "sensitive": true
+      },
+      "EMBEDDING_MODEL": {
+        "type": "string",
+        "description": "Embedding model identifier sent as the request `model` field.",
+        "required": false,
+        "default": "text-embedding-3-small",
+        "sensitive": false
+      },
+      "EMBEDDING_DIMENSIONS": {
+        "type": "string",
+        "description": "Vector width. Must be one of 384, 512, 768, 1024, 1536, 2048, 3072. Keep this stable for the lifetime of a database — changing it invalidates stored vectors.",
+        "required": false,
+        "default": "1536",
+        "sensitive": false
+      },
+      "EMBEDDING_BROWSER_URL": {
+        "type": "string",
+        "description": "Browser-only server-side proxy URL for /embeddings. In a browser build the Authorization header is never sent unless this is set, so the API key stays server-side.",
+        "required": false,
+        "sensitive": false
+      }
+    }
+  },
+  "eliza": {
+    "platforms": [
+      "browser",
+      "node"
+    ],
+    "runtime": "both",
+    "platformDetails": {
+      "browser": "Browser-compatible build available via exports.browser",
+      "node": "Node.js build available via exports.node"
+    }
+  }
+}

--- a/plugins/plugin-embeddings/src/index.ts
+++ b/plugins/plugin-embeddings/src/index.ts
@@ -1,0 +1,110 @@
+/**
+ * `@elizaos/plugin-embeddings` — provider-agnostic ("bring your own")
+ * `TEXT_EMBEDDING` provider.
+ *
+ * Decouples embeddings from the chat brain. A self-hosted bot running on a
+ * provider that serves no good embeddings (Claude, Cerebras, …) can point the
+ * `EMBEDDING_*` vars at ANY OpenAI-compatible `/embeddings` endpoint (a personal
+ * OpenAI key, Eliza Cloud, Voyage, or a local TEI / Infinity / vLLM / LM Studio
+ * server) and get embeddings independently of chat.
+ *
+ * Purely additive: the plugin only loads when `EMBEDDING_BASE_URL` or
+ * `EMBEDDING_API_KEY` is set (see auto-enable.ts), so existing deployments are
+ * unaffected. It registers ONLY the embedding slots — no text/image/audio
+ * handlers, no actions, providers, services, or evaluators.
+ */
+
+import type {
+  BatchTextEmbeddingParams,
+  IAgentRuntime,
+  Plugin,
+  ProcessEnvLike,
+  TextEmbeddingParams,
+} from "@elizaos/core";
+import { logger, ModelType } from "@elizaos/core";
+
+import { handleBatchTextEmbedding, handleTextEmbedding } from "./models/embedding";
+import {
+  getEmbeddingBaseURL,
+  getEmbeddingDimensions,
+  hasEmbeddingConfig,
+  logResolvedConfig,
+} from "./utils/config";
+
+function getProcessEnv(): ProcessEnvLike {
+  if (typeof process === "undefined" || !process.env) {
+    return {};
+  }
+  return process.env as ProcessEnvLike;
+}
+
+const env = getProcessEnv();
+
+export const embeddingsPlugin: Plugin = {
+  name: "embeddings",
+  description:
+    "Provider-agnostic (bring-your-own) TEXT_EMBEDDING provider for any OpenAI-compatible /embeddings endpoint",
+
+  // Manifest-driven auto-enable: see auto-enable.ts. Mirrored here so a runtime
+  // that consults the inline `autoEnable.envKeys` (rather than the package
+  // manifest) activates the plugin on the same signal.
+  autoEnable: {
+    envKeys: ["EMBEDDING_BASE_URL", "EMBEDDING_API_KEY"],
+  },
+
+  // Registration priority for the embedding slot. The native priority sort is:
+  //   local-inference @ 0  <  this @ 1  <  Eliza Cloud @ 50
+  // So a bring-your-own endpoint beats a bare local embedder but yields to a
+  // paired Eliza Cloud, which is the desired default. Override per-slot via the
+  // runtime routing preferences when a different precedence is wanted.
+  priority: 1,
+
+  config: {
+    EMBEDDING_BASE_URL: env.EMBEDDING_BASE_URL ?? null,
+    EMBEDDING_API_KEY: env.EMBEDDING_API_KEY ?? null,
+    EMBEDDING_MODEL: env.EMBEDDING_MODEL ?? null,
+    EMBEDDING_DIMENSIONS: env.EMBEDDING_DIMENSIONS ?? null,
+    EMBEDDING_BROWSER_URL: env.EMBEDDING_BROWSER_URL ?? null,
+  },
+
+  async init(_config, runtime) {
+    if (!hasEmbeddingConfig(runtime)) {
+      logger.warn(
+        "[Embeddings] Neither EMBEDDING_BASE_URL nor EMBEDDING_API_KEY is set — " +
+          "embedding calls will throw until one is configured."
+      );
+      return;
+    }
+    // Validate the dimension up-front so a misconfiguration surfaces at boot,
+    // not on the first embedding call.
+    getEmbeddingDimensions(runtime);
+    if (!getEmbeddingBaseURL(runtime)) {
+      logger.warn(
+        "[Embeddings] EMBEDDING_API_KEY is set but EMBEDDING_BASE_URL is not — " +
+          "set the endpoint URL for embedding calls to succeed."
+      );
+    }
+    logResolvedConfig(runtime);
+  },
+
+  // ONLY the embedding slots are registered — this plugin is embedding-only.
+  models: {
+    [ModelType.TEXT_EMBEDDING]: async (
+      runtime: IAgentRuntime,
+      params: TextEmbeddingParams | string | null
+    ): Promise<number[]> => handleTextEmbedding(runtime, params),
+
+    [ModelType.TEXT_EMBEDDING_BATCH]: async (
+      runtime: IAgentRuntime,
+      params: BatchTextEmbeddingParams
+    ): Promise<number[][]> => handleBatchTextEmbedding(runtime, params.texts),
+  },
+};
+
+export { handleBatchTextEmbedding, handleTextEmbedding } from "./models/embedding";
+export * from "./types";
+export * from "./utils/config";
+
+const defaultEmbeddingsPlugin = embeddingsPlugin;
+
+export default defaultEmbeddingsPlugin;

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -1,0 +1,211 @@
+import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
+import { logger, ModelType, VECTOR_DIMS } from "@elizaos/core";
+
+import type { EmbeddingResponse } from "../types";
+import {
+  getAuthHeader,
+  getEmbeddingBaseURL,
+  getEmbeddingDimensions,
+  getEmbeddingModel,
+  getSetting,
+} from "../utils/config";
+import { emitModelUsageEvent } from "../utils/events";
+
+type VectorDimension = (typeof VECTOR_DIMS)[keyof typeof VECTOR_DIMS];
+
+// OpenAI embedding models support up to 8191 tokens per input; 8000 provides a
+// safe buffer at the conventional ~4 chars/token estimate.
+const MAX_EMBEDDING_CHARS = 8_000 * 4;
+
+function validateDimension(dimension: number): VectorDimension {
+  const validDimensions = Object.values(VECTOR_DIMS) as number[];
+  if (!validDimensions.includes(dimension)) {
+    throw new Error(
+      `Invalid embedding dimension: ${dimension}. Must be one of: ${validDimensions.join(", ")}`
+    );
+  }
+  return dimension as VectorDimension;
+}
+
+function extractText(params: TextEmbeddingParams | string | null): string | null {
+  if (params === null) {
+    return null;
+  }
+  if (typeof params === "string") {
+    return params;
+  }
+  if (typeof params === "object" && typeof params.text === "string") {
+    return params.text;
+  }
+  throw new Error("Invalid embedding params: expected string, { text: string }, or null");
+}
+
+/**
+ * True only when the operator set `EMBEDDING_DIMENSIONS` explicitly. When unset
+ * we omit the `dimensions` request field entirely so the endpoint returns its
+ * model-native width (some servers reject an unsupported `dimensions` value).
+ */
+function hasExplicitDimensions(runtime: IAgentRuntime): boolean {
+  const value = getSetting(runtime, "EMBEDDING_DIMENSIONS");
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function requireBaseURL(runtime: IAgentRuntime): string {
+  const baseURL = getEmbeddingBaseURL(runtime);
+  if (!baseURL) {
+    // No silent default endpoint. Without a configured URL we cannot produce a
+    // real vector — throw so the runtime falls through to another provider
+    // instead of persisting a wrong/garbage vector (Commandment 8).
+    throw new Error(
+      "No embedding endpoint configured. Set EMBEDDING_BASE_URL " +
+        "(or EMBEDDING_BROWSER_URL in a browser build)."
+    );
+  }
+  return baseURL.replace(/\/+$/, "");
+}
+
+function truncate(text: string): string {
+  if (text.length <= MAX_EMBEDDING_CHARS) {
+    return text;
+  }
+  logger.warn(
+    `[Embeddings] Input too long (~${Math.ceil(text.length / 4)} tokens), truncating to ~8000 tokens`
+  );
+  return text.slice(0, MAX_EMBEDDING_CHARS);
+}
+
+/**
+ * Embed `input` (a single string or an array of strings) against the configured
+ * OpenAI-compatible `/embeddings` endpoint. Returns one numeric vector per
+ * input, in input order. Throws on any HTTP/config/shape error — never returns
+ * a zero or fabricated vector (issue #9324, Commandment 8).
+ */
+async function requestEmbeddings(
+  runtime: IAgentRuntime,
+  input: string | string[],
+  embeddingDimension: VectorDimension
+): Promise<number[][]> {
+  const baseURL = requireBaseURL(runtime);
+  const embeddingModel = getEmbeddingModel(runtime);
+  const url = `${baseURL}/embeddings`;
+  const expectedCount = Array.isArray(input) ? input.length : 1;
+
+  logger.debug(`[Embeddings] POST ${url} model=${embeddingModel}`);
+
+  // @trajectory-allow Embeddings return numeric retrieval vectors, not generative LLM text.
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...getAuthHeader(runtime),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: embeddingModel,
+      input,
+      ...(hasExplicitDimensions(runtime) ? { dimensions: embeddingDimension } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Unknown error");
+    throw new Error(
+      `Embedding API error: ${response.status} ${response.statusText} - ${errorText}`
+    );
+  }
+
+  const data = (await response.json()) as EmbeddingResponse;
+
+  if (!Array.isArray(data.data) || data.data.length !== expectedCount) {
+    throw new Error(
+      `Embedding API returned ${
+        Array.isArray(data.data) ? data.data.length : "non-array"
+      } vectors, expected ${expectedCount}`
+    );
+  }
+
+  // The response `index` field addresses the input order; honor it so a
+  // reordered response still maps back to the right input slot.
+  const vectors: number[][] = new Array(expectedCount);
+  for (const item of data.data) {
+    const idx = typeof item.index === "number" ? item.index : undefined;
+    if (idx === undefined || idx < 0 || idx >= expectedCount) {
+      throw new Error(
+        `Embedding API returned out-of-range index ${String(item.index)} (expected 0..${expectedCount - 1})`
+      );
+    }
+    if (!Array.isArray(item.embedding) || item.embedding.length !== embeddingDimension) {
+      throw new Error(
+        `Embedding dimension mismatch: got ${
+          Array.isArray(item.embedding) ? item.embedding.length : "non-array"
+        }, expected ${embeddingDimension}. Check EMBEDDING_DIMENSIONS / EMBEDDING_MODEL.`
+      );
+    }
+    vectors[idx] = item.embedding;
+  }
+
+  if (data.usage) {
+    const promptText = Array.isArray(input) ? `batch:${input.length}` : input;
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, promptText, {
+      promptTokens: data.usage.prompt_tokens,
+      completionTokens: 0,
+      totalTokens: data.usage.total_tokens,
+    });
+  }
+
+  return vectors;
+}
+
+/**
+ * `TEXT_EMBEDDING` handler. Returns one vector for the given text.
+ *
+ * The runtime boot dimension-probe calls this with `null` purely to learn the
+ * vector length (it reads `.length`), so a correctly-sized marker vector is the
+ * only legitimate synthetic return — every real failure throws.
+ */
+export async function handleTextEmbedding(
+  runtime: IAgentRuntime,
+  params: TextEmbeddingParams | string | null
+): Promise<number[]> {
+  const embeddingDimension = validateDimension(getEmbeddingDimensions(runtime));
+
+  const text = extractText(params);
+  if (text === null) {
+    logger.debug("[Embeddings] Returning init-probe vector");
+    const probe = new Array(embeddingDimension).fill(0);
+    probe[0] = 0.1;
+    return probe;
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Cannot generate embedding for empty text");
+  }
+
+  const vectors = await requestEmbeddings(runtime, truncate(trimmed), embeddingDimension);
+  return vectors[0];
+}
+
+/**
+ * `TEXT_EMBEDDING_BATCH` handler. Embeds many texts in one request. Demands a
+ * vector per input (no holes); throws on any failure so the runtime can fall
+ * through to another provider instead of persisting corrupt vectors.
+ */
+export async function handleBatchTextEmbedding(
+  runtime: IAgentRuntime,
+  texts: string[]
+): Promise<number[][]> {
+  if (!Array.isArray(texts) || texts.length === 0) {
+    return [];
+  }
+
+  const embeddingDimension = validateDimension(getEmbeddingDimensions(runtime));
+
+  const prepared = texts.map((text, i) => {
+    if (typeof text !== "string" || text.trim().length === 0) {
+      throw new Error(`Cannot generate embedding for empty text at index ${i}`);
+    }
+    return truncate(text.trim());
+  });
+
+  return requestEmbeddings(runtime, prepared, embeddingDimension);
+}

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -182,7 +182,11 @@ export async function handleTextEmbedding(
   }
 
   const vectors = await requestEmbeddings(runtime, truncate(trimmed), embeddingDimension);
-  return vectors[0];
+  const vector = vectors[0];
+  if (!vector) {
+    throw new Error("Embedding provider returned no vector for the input");
+  }
+  return vector;
 }
 
 /**

--- a/plugins/plugin-embeddings/src/models/index.ts
+++ b/plugins/plugin-embeddings/src/models/index.ts
@@ -1,0 +1,1 @@
+export { handleBatchTextEmbedding, handleTextEmbedding } from "./embedding";

--- a/plugins/plugin-embeddings/src/types/index.ts
+++ b/plugins/plugin-embeddings/src/types/index.ts
@@ -1,0 +1,26 @@
+/** Plugin-local types for `@elizaos/plugin-embeddings`. */
+
+/** Token usage as reported by an OpenAI-compatible embeddings response. */
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * OpenAI-compatible `/embeddings` response shape. Voyage, TEI, Infinity, vLLM,
+ * LM Studio, and Eliza Cloud all return this same structure.
+ */
+export interface EmbeddingResponse {
+  object: "list";
+  data: Array<{
+    object: "embedding";
+    embedding: number[];
+    index: number;
+  }>;
+  model: string;
+  usage?: {
+    prompt_tokens: number;
+    total_tokens: number;
+  };
+}

--- a/plugins/plugin-embeddings/src/utils/config.ts
+++ b/plugins/plugin-embeddings/src/utils/config.ts
@@ -1,0 +1,141 @@
+/**
+ * Setting resolution for `@elizaos/plugin-embeddings`.
+ *
+ * Every getter is provider-NEUTRAL and resolved through `getSetting`, so the
+ * values are per-character overridable (`runtime.getSetting(key)` first, then
+ * `process.env[key]`, then a default). There is intentionally NO fallback to a
+ * chat provider's settings (`OPENAI_*`, `ELIZAOS_CLOUD_*`, …): this plugin owns
+ * the embedding slot independently of the chat brain. If `EMBEDDING_BASE_URL`
+ * is not configured, the handler throws rather than silently inheriting an
+ * unrelated endpoint.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+
+function getEnvValue(key: string): string | undefined {
+  if (typeof process === "undefined" || !process.env) {
+    return undefined;
+  }
+  const value = process.env[key];
+  return value === undefined ? undefined : String(value);
+}
+
+/**
+ * Runtime config first, then `process.env`, then the supplied default.
+ * Returns `undefined` when unset and no default is given.
+ */
+export function getSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  defaultValue?: string
+): string | undefined {
+  const value = runtime.getSetting(key);
+  if (value !== undefined && value !== null) {
+    return String(value);
+  }
+  return getEnvValue(key) ?? defaultValue;
+}
+
+export function getNumericSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  defaultValue: number
+): number {
+  const value = getSetting(runtime, key);
+  if (value === undefined || value.trim() === "") {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Setting '${key}' must be a valid integer, got: ${value}`);
+  }
+  return parsed;
+}
+
+export function getBooleanSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  defaultValue: boolean
+): boolean {
+  const value = getSetting(runtime, key);
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const normalized = value.toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes";
+}
+
+export function isBrowser(): boolean {
+  return (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { document?: Document }).document !== "undefined"
+  );
+}
+
+/**
+ * Resolved base URL of the OpenAI-compatible embedding endpoint.
+ *
+ * In a browser build the server-side proxy URL (`EMBEDDING_BROWSER_URL`) is
+ * preferred so the real endpoint/key stay server-side. There is NO default
+ * endpoint and NO chat-provider fallback: when nothing is configured this
+ * returns `undefined` and the handler throws (Commandment 8 — never invent an
+ * endpoint that could silently produce or persist a wrong vector).
+ */
+export function getEmbeddingBaseURL(runtime: IAgentRuntime): string | undefined {
+  if (isBrowser()) {
+    const browserURL = getSetting(runtime, "EMBEDDING_BROWSER_URL");
+    if (browserURL && browserURL.trim() !== "") {
+      return browserURL.trim();
+    }
+  }
+  const baseURL = getSetting(runtime, "EMBEDDING_BASE_URL");
+  return baseURL && baseURL.trim() !== "" ? baseURL.trim() : undefined;
+}
+
+export function getEmbeddingApiKey(runtime: IAgentRuntime): string | undefined {
+  const apiKey = getSetting(runtime, "EMBEDDING_API_KEY");
+  return apiKey && apiKey.trim() !== "" ? apiKey.trim() : undefined;
+}
+
+export function getEmbeddingModel(runtime: IAgentRuntime): string {
+  return getSetting(runtime, "EMBEDDING_MODEL") ?? "text-embedding-3-small";
+}
+
+export function getEmbeddingDimensions(runtime: IAgentRuntime): number {
+  return getNumericSetting(runtime, "EMBEDDING_DIMENSIONS", 1536);
+}
+
+/**
+ * Auth header for the embedding request.
+ *
+ * In a browser build the `Authorization` header is NOT sent unless an explicit
+ * browser proxy URL (`EMBEDDING_BROWSER_URL`) is configured — mirrors
+ * plugin-openai's `isBrowser` gating so a frontend bundle never leaks the key.
+ * The proxy is expected to inject auth server-side.
+ */
+export function getAuthHeader(runtime: IAgentRuntime): Record<string, string> {
+  if (isBrowser() && !getSetting(runtime, "EMBEDDING_BROWSER_URL")) {
+    return {};
+  }
+  const key = getEmbeddingApiKey(runtime);
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+/** True when the operator has opted in by configuring a URL or a key. */
+export function hasEmbeddingConfig(runtime: IAgentRuntime): boolean {
+  return Boolean(getEmbeddingBaseURL(runtime) || getEmbeddingApiKey(runtime));
+}
+
+/**
+ * Log the resolved model + dimension once at init. Kept here so `init()` in
+ * index.ts stays a thin wiring layer.
+ */
+export function logResolvedConfig(runtime: IAgentRuntime): void {
+  const baseURL = getEmbeddingBaseURL(runtime);
+  logger.info(
+    `[Embeddings] model=${getEmbeddingModel(runtime)} dimensions=${getEmbeddingDimensions(
+      runtime
+    )} endpoint=${baseURL ?? "(unset)"}`
+  );
+}

--- a/plugins/plugin-embeddings/src/utils/events.ts
+++ b/plugins/plugin-embeddings/src/utils/events.ts
@@ -1,0 +1,54 @@
+import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
+import { EventType } from "@elizaos/core";
+
+const MAX_PROMPT_LENGTH = 200;
+
+interface ModelUsageEventPayload {
+  runtime: IAgentRuntime;
+  source: "embeddings";
+  provider: "embeddings";
+  type: ModelTypeName;
+  prompt: string;
+  tokens: {
+    prompt: number;
+    completion: number;
+    total: number;
+  };
+}
+
+interface EmbeddingUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+function truncatePrompt(prompt: string): string {
+  if (prompt.length <= MAX_PROMPT_LENGTH) {
+    return prompt;
+  }
+  return `${prompt.slice(0, MAX_PROMPT_LENGTH)}…`;
+}
+
+export function emitModelUsageEvent(
+  runtime: IAgentRuntime,
+  type: ModelTypeName,
+  prompt: string,
+  usage: EmbeddingUsage
+): void {
+  const promptTokens = usage.promptTokens ?? 0;
+  const completionTokens = usage.completionTokens ?? 0;
+  const payload: ModelUsageEventPayload = {
+    runtime,
+    source: "embeddings",
+    provider: "embeddings",
+    type,
+    prompt: truncatePrompt(prompt),
+    tokens: {
+      prompt: promptTokens,
+      completion: completionTokens,
+      total: usage.totalTokens ?? promptTokens + completionTokens,
+    },
+  };
+
+  runtime.emitEvent(EventType.MODEL_USED, payload);
+}

--- a/plugins/plugin-embeddings/tsconfig.build.json
+++ b/plugins/plugin-embeddings/tsconfig.build.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist/node",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "composite": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun-types", "node"],
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
+    "paths": {
+      "@elizaos/core": ["../../../packages/core/dist"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist", "__tests__", "**/*.test.ts"]
+}

--- a/plugins/plugin-embeddings/tsconfig.json
+++ b/plugins/plugin-embeddings/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node", "bun-types"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/plugins/plugin-embeddings/vitest.config.ts
+++ b/plugins/plugin-embeddings/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+  },
+});


### PR DESCRIPTION
Closes #9567.

## What
A new standalone **`@elizaos/plugin-embeddings`** — a provider-agnostic ("bring your own") `TEXT_EMBEDDING` provider. Point one set of `EMBEDDING_*` vars at **any** OpenAI-compatible `/embeddings` endpoint (personal OpenAI key, Eliza Cloud, Voyage, Together, local TEI/Infinity/vLLM/LM Studio) and embeddings work **independent of the chat brain**.

## Why
Embeddings were coupled to the chat provider. A self-hosted bot on **Claude** (no embeddings API) or **Cerebras** (no `/embeddings`) had no clean path to real embeddings — `plugin-elizacloud` bundles `TEXT_EMBEDDING` with priority-50 text handlers that hijack the chat brain and is gated to a cloud `eliza_xxx` key; `plugin-openai`'s `OPENAI_EMBEDDING_*` override only works when plugin-openai is itself enabled and smuggles non-OpenAI providers under an `OPENAI_` namespace. This generalizes the existing `plugin-lmstudio` (`capabilities:["embedding"]`) pattern into a chat-agnostic one.

## Design (purely additive, zero regression)
- Registers **only** `TEXT_EMBEDDING` + `TEXT_EMBEDDING_BATCH` — no text/image/audio handlers, no actions/providers/services.
- **Load-gated**: auto-enables only when `EMBEDDING_BASE_URL` or `EMBEDDING_API_KEY` is set → not loaded on any existing deployment.
- **Priority `1`**: `local-inference @0 < plugin-embeddings @1 < Eliza Cloud @50` — opt-in beats a bare local embedder, yields to a paired Cloud. (This is the one product call from #9567 — happy to change the band.)
- **Throws on every real failure** (issue #9324 / Commandment 8) — never a zero/garbage vector. Null boot-probe returns a correctly-sized marker for the dimension probe only.
- Raw `fetch` (no `@ai-sdk` dep); `@elizaos/core` peer only. Browser build suppresses the `Authorization` header unless `EMBEDDING_BROWSER_URL` (server proxy) is set.
- **Zero changes** to core / plugin-sql / plugin-openai / plugin-elizacloud / plugin-local-inference.

### Mode matrix
| Mode (no `EMBEDDING_*`) | embeddings | Δ |
|---|---|---|
| cloud | plugin-elizacloud @50 | **identical** |
| local | plugin-local-inference @0 | **identical** |
| self-hosted Claude/Cerebras (opt in) | this plugin → any endpoint | **new capability** |

## Evidence (real, live)
Live-tested on a self-hosted **Claude-chat** bot (`provider=anthropic` throughout), same plugin, two providers by swapping one var:
- **OpenAI Direct** (`EMBEDDING_BASE_URL=https://api.openai.com/v1`): `[Embeddings] POST https://api.openai.com/v1/embeddings model=text-embedding-3-small` ×2 (store + recall), stored a memory, Claude chat unaffected.
- **Eliza Cloud** (`EMBEDDING_BASE_URL=https://www.elizacloud.ai/api/v1`): boot init resolved the cloud endpoint; a recall query returned **"Teal."** — correctly recalling the memory stored under OpenAI embeddings (same model/dim → compatible vectors). Zero embedding errors.
- 27/27 unit tests (null-probe width, wire-mocked vector, dimension-mismatch/empty/unsupported/no-endpoint/non-OK throws, batch ordering, `VECTOR_DIMS` contract), build + lint clean.

Screenshots/video N/A (server-side embedding plumbing; backend logs above are the evidence). Audio N/A.

## Follow-up (not this PR)
openai/openrouter/elizacloud ~95% duplicate a hand-rolled `fetch(${baseURL}/embeddings)` — a shared OpenAI-compatible embeddings client is a worthwhile separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
