### PR TITLE
feat(#9105): GET_SCREEN set-of-marks numbering + wire DirtyTileDescriber

### DIFF
--- a/plugins/plugin-vision/src/dirty-tile-integration.test.ts
+++ b/plugins/plugin-vision/src/dirty-tile-integration.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Dirty-tile scene-describe integration (#9105 efficiency).
+ *
+ * Proves the wiring `VisionService` uses end-to-end: a `DirtyTileDescriber`
+ * built from `createTileDescribeFn` — the real per-tile describe factory the
+ * service injects — driving a stub IMAGE_DESCRIPTION model. Two frames that
+ * differ in exactly ONE quadrant must re-describe only the changed tile; the
+ * unchanged tiles reuse their cached description.
+ *
+ * This drives the production seam — the same `createTileDescribeFn` +
+ * `tilePngToImageUrl` + `DirtyTileDescriber` composition the service builds —
+ * not a re-implementation of it, so a regression in the factory, the data-URL
+ * encoder, or the describer surfaces here. The injected tile hash is a
+ * deterministic content hash (identical pixels hash equal); the production hash
+ * (`frameDhash`) is exercised by plugin-computeruse's own dHash tests.
+ */
+
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+import { DirtyTileDescriber } from "./dirty-tile-describer";
+import { createTileDescribeFn, tilePngToImageUrl } from "./dirty-tile-scene";
+
+/** Deterministic 64-bit FNV-1a over the tile bytes: identical tiles hash equal. */
+function contentHash(png: Buffer): bigint {
+  let h = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = (1n << 64n) - 1n;
+  for (let i = 0; i < png.length; i += 1) {
+    h = (h ^ BigInt(png[i] ?? 0)) & mask;
+    h = (h * prime) & mask;
+  }
+  return h;
+}
+
+const EDGE = 256;
+const MAX_EDGE = 128; // forces a 2x2 tile grid like the screen tiler at scale
+
+/** Solid-color PNG used to compose quadrants. */
+async function solid(
+  w: number,
+  h: number,
+  c: [number, number, number],
+): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: w,
+      height: h,
+      channels: 3,
+      background: { r: c[0], g: c[1], b: c[2] },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+/** A four-quadrant PNG so a >maxEdge frame tiles into a real 2x2 grid. */
+async function makeQuadrantPng(
+  edge: number,
+  colors: [number, number, number][],
+): Promise<Buffer> {
+  const half = Math.floor(edge / 2);
+  const top = await sharp({
+    create: {
+      width: edge,
+      height: half,
+      channels: 3,
+      background: bg(colors[0]),
+    },
+  })
+    .composite([
+      { input: await solid(half, half, colors[0]), left: 0, top: 0 },
+      { input: await solid(half, half, colors[1]), left: half, top: 0 },
+    ])
+    .png()
+    .toBuffer();
+  const bottom = await sharp({
+    create: {
+      width: edge,
+      height: half,
+      channels: 3,
+      background: bg(colors[2]),
+    },
+  })
+    .composite([
+      { input: await solid(half, half, colors[2]), left: 0, top: 0 },
+      { input: await solid(half, half, colors[3]), left: half, top: 0 },
+    ])
+    .png()
+    .toBuffer();
+  return sharp({
+    create: {
+      width: edge,
+      height: edge,
+      channels: 3,
+      background: bg(colors[0]),
+    },
+  })
+    .composite([
+      { input: top, left: 0, top: 0 },
+      { input: bottom, left: 0, top: half },
+    ])
+    .png()
+    .toBuffer();
+}
+
+function bg(c: [number, number, number]): { r: number; g: number; b: number } {
+  return { r: c[0], g: c[1], b: c[2] };
+}
+
+interface WiredDescriber {
+  describer: DirtyTileDescriber;
+  describeCalls: () => number;
+  describedIds: () => string[];
+  imageUrls: () => string[];
+  prompts: () => string[];
+}
+
+/**
+ * Build a describer wired the way `VisionService.ensureDirtyTileDescriber`
+ * does: the real `createTileDescribeFn` factory for the per-tile describe, plus
+ * a deterministic content hash standing in for the production `frameDhash`. The
+ * model call is a stub that records what it was asked to describe.
+ */
+function wireDescriber(): WiredDescriber {
+  let calls = 0;
+  const ids: string[] = [];
+  const urls: string[] = [];
+  const prompts: string[] = [];
+  const describeTile = createTileDescribeFn({
+    buildTileImageUrl: tilePngToImageUrl,
+    buildTilePrompt: async (tile) => `describe ${tile.id}`,
+    invokeModel: async (imageUrl, prompt) => {
+      calls += 1;
+      urls.push(imageUrl);
+      prompts.push(prompt);
+      // The factory tags the call by id via the prompt; echo a stable text.
+      return { description: prompt.replace("describe ", "desc:") };
+    },
+    extractDescription: (result) => {
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "description" in result
+      ) {
+        const d = (result as { description?: unknown }).description;
+        if (typeof d === "string") return d;
+      }
+      return null;
+    },
+  });
+  const describer = new DirtyTileDescriber({
+    hashTile: (png) => contentHash(png),
+    describeTile: async (tile) => {
+      ids.push(tile.id);
+      return describeTile(tile);
+    },
+    maxEdge: MAX_EDGE,
+  });
+  return {
+    describer,
+    describeCalls: () => calls,
+    describedIds: () => ids,
+    imageUrls: () => urls,
+    prompts: () => prompts,
+  };
+}
+
+describe("dirty-tile scene-describe integration (#9105)", () => {
+  it("describes every tile on the first frame, then nothing on an identical frame", async () => {
+    const colors: [number, number, number][] = [
+      [10, 20, 30],
+      [40, 50, 60],
+      [70, 80, 90],
+      [100, 110, 120],
+    ];
+    const png1 = await makeQuadrantPng(EDGE, colors);
+    const png2 = await makeQuadrantPng(EDGE, colors); // identical pixels
+    const { describer, describeCalls } = wireDescriber();
+
+    const first = await describer.describe({
+      displayId: 0,
+      width: EDGE,
+      height: EDGE,
+      pngBytes: png1,
+    });
+    expect(first.tiles).toHaveLength(4);
+    expect(describeCalls()).toBe(4);
+    expect(first.tiles.every((t) => !t.cached)).toBe(true);
+
+    const second = await describer.describe({
+      displayId: 0,
+      width: EDGE,
+      height: EDGE,
+      pngBytes: png2,
+    });
+    // No new model calls on the identical frame — every tile reused from cache.
+    expect(describeCalls()).toBe(4);
+    expect(second.tiles.every((t) => t.cached)).toBe(true);
+    const stats = describer.getStats();
+    expect(stats.tilesDescribed).toBe(4);
+    expect(stats.tilesSkipped).toBe(4);
+    expect(stats.describeCallsSaved).toBe(4);
+    expect(stats.approxTokensSaved).toBeGreaterThan(0);
+  });
+
+  it("re-describes ONLY the changed tile and reuses the cache for the rest", async () => {
+    const base: [number, number, number][] = [
+      [10, 20, 30],
+      [40, 50, 60],
+      [70, 80, 90],
+      [100, 110, 120],
+    ];
+    // Flip only the bottom-right quadrant (tile-1-1) on the second frame.
+    const changed: [number, number, number][] = [
+      [10, 20, 30],
+      [40, 50, 60],
+      [70, 80, 90],
+      [220, 30, 240],
+    ];
+    const png1 = await makeQuadrantPng(EDGE, base);
+    const png2 = await makeQuadrantPng(EDGE, changed);
+    const { describer, describeCalls, describedIds, imageUrls, prompts } =
+      wireDescriber();
+
+    const first = await describer.describe({
+      displayId: 0,
+      width: EDGE,
+      height: EDGE,
+      pngBytes: png1,
+    });
+    const tileCount = first.tiles.length;
+    expect(tileCount).toBe(4);
+    expect(describeCalls()).toBe(tileCount); // full describe on frame 1
+
+    const second = await describer.describe({
+      displayId: 0,
+      width: EDGE,
+      height: EDGE,
+      pngBytes: png2,
+    });
+
+    const stats = describer.getStats();
+    // The efficiency win: far fewer describe calls than tiles across both
+    // frames, and most tiles served from cache on the incremental update.
+    expect(describeCalls()).toBeLessThan(tileCount * 2);
+    expect(stats.tilesSkipped).toBeGreaterThan(0);
+
+    // Exactly one extra describe call on the incremental frame: the dirty tile.
+    expect(describeCalls()).toBe(tileCount + 1);
+    const reDescribed = describedIds().slice(tileCount);
+    expect(reDescribed).toEqual(["tile-1-1"]);
+
+    const changedTile = second.tiles.find((t) => t.id === "tile-1-1");
+    expect(changedTile?.cached).toBe(false);
+    const unchanged = second.tiles.filter((t) => t.id !== "tile-1-1");
+    expect(unchanged.every((t) => t.cached)).toBe(true);
+    expect(stats.tilesSkipped).toBe(tileCount - 1); // 3 reused on frame 2
+
+    // The re-describe went through the real factory: a per-tile PNG data URL
+    // and a per-tile prompt for the changed tile.
+    const lastUrl = imageUrls()[imageUrls().length - 1] ?? "";
+    expect(lastUrl.startsWith("data:image/png;base64,")).toBe(true);
+    const lastPrompt = prompts()[prompts().length - 1] ?? "";
+    expect(lastPrompt).toBe("describe tile-1-1");
+
+    // The composed scene reflects the re-described tile's fresh text.
+    expect(second.vlmScene).toContain("desc:tile-1-1");
+  });
+});

--- a/plugins/plugin-vision/src/dirty-tile-scene.ts
+++ b/plugins/plugin-vision/src/dirty-tile-scene.ts
@@ -1,0 +1,70 @@
+/**
+ * Wiring seam for the change-gated per-tile scene describe (#9105 efficiency).
+ *
+ * `DirtyTileDescriber` (dirty-tile-describer.ts) is pure + injectable: it owns
+ * the per-tile hash cache and the "only re-describe changed tiles" loop, but it
+ * does not know how to hash a tile or how to ask the VLM to describe one. This
+ * module supplies those two collaborators from the live runtime so
+ * `VisionService` can build a describer that re-describes only the screen
+ * regions that actually changed since the previous frame instead of paying for
+ * a whole-frame VLM pass every scene tick.
+ *
+ * Two collaborators:
+ *   - `hashTile`: a perceptual hash. We reuse plugin-computeruse's `frameDhash`
+ *     (the same dHash the Brain frame-cache uses), resolved via a best-effort
+ *     dynamic import so plugin-vision never eagerly pulls computeruse's module
+ *     graph at boot — exactly the idiom the OCR bridge already uses. When
+ *     computeruse is absent the resolve returns `null` and the caller degrades
+ *     to the existing full-frame describe.
+ *   - `describeTile`: one `runtime.useModel(IMAGE_DESCRIPTION, …)` call per
+ *     changed tile, built from a caller-supplied prompt + result normalizer so
+ *     the per-tile path reuses the same prompt plumbing as the full-frame path.
+ */
+
+import type { ScreenTile } from "./screen-tiler.js";
+
+/** PNG perceptual hash. Identical pixels MUST hash equal; `null` = undecodable. */
+export type FrameHash = (png: Buffer) => bigint | null;
+
+/** Per-tile describe call. Returns the model's description text for one tile. */
+export type TileDescribeFn = (tile: ScreenTile) => Promise<string>;
+
+export interface TileDescribeDeps {
+  /**
+   * Build the per-tile image URL the VLM is asked to describe. The tile carries
+   * PNG bytes (`tile.pngBytes`), so this is a `data:image/png;base64,…` URL.
+   */
+  buildTileImageUrl: (tile: ScreenTile) => string;
+  /**
+   * Build the per-tile prompt. Receives the tile so callers can include bounds.
+   * Async because the scene context is pulled from a peer provider per call.
+   */
+  buildTilePrompt: (tile: ScreenTile) => Promise<string>;
+  /** Invoke the IMAGE_DESCRIPTION model and return its raw result. */
+  invokeModel: (imageUrl: string, prompt: string) => Promise<unknown>;
+  /**
+   * Normalize a model result into a description string, or `null` when the
+   * result is unusable (sentinel / empty). A `null` result yields an empty tile
+   * description, which the describer treats as "nothing to compose for this
+   * tile" while still caching the (empty) result against the tile hash.
+   */
+  extractDescription: (result: unknown) => string | null;
+}
+
+/**
+ * Build a `describeTile` function bound to the runtime's IMAGE_DESCRIPTION
+ * model. The describer calls this only for tiles whose hash changed.
+ */
+export function createTileDescribeFn(deps: TileDescribeDeps): TileDescribeFn {
+  return async (tile: ScreenTile): Promise<string> => {
+    const imageUrl = deps.buildTileImageUrl(tile);
+    const prompt = await deps.buildTilePrompt(tile);
+    const result = await deps.invokeModel(imageUrl, prompt);
+    return deps.extractDescription(result) ?? "";
+  };
+}
+
+/** Encode a tile's PNG bytes into a base64 data URL for the VLM. */
+export function tilePngToImageUrl(tile: ScreenTile): string {
+  return `data:image/png;base64,${tile.pngBytes.toString("base64")}`;
+}

--- a/plugins/plugin-vision/src/get-screen.test.ts
+++ b/plugins/plugin-vision/src/get-screen.test.ts
@@ -78,11 +78,16 @@ describe("buildGetScreen", () => {
     expect(r.elementCount).toBe(2);
     expect(r.elements.map((e) => e.text)).toEqual(["Save", "Open File"]);
     expect(r.elements[0]).toMatchObject({
+      index: 1,
       id: "el-1",
       bbox: [10, 20, 40, 16],
+      center: { x: 30, y: 28 },
       semantic_position: "upper-left",
       displayId: 0,
     });
+    // Set-of-Marks numbering is monotonic and 1-based.
+    expect(r.elements.map((e) => e.index)).toEqual([1, 2]);
+    expect(r.elements[1]?.center).toEqual({ x: 115, y: 28 });
     expect(r.ocrText).toBe("Save\nOpen File");
     expect(r.image).toBeUndefined();
   });
@@ -131,16 +136,20 @@ describe("summarizeGetScreen", () => {
       ocrText: "Save\nOpen",
       elements: [
         {
+          index: 1,
           id: "el-1",
           text: "Save",
           bbox: [0, 0, 1, 1],
+          center: { x: 0, y: 0 },
           semantic_position: "center",
           displayId: 0,
         },
         {
+          index: 2,
           id: "el-2",
           text: "Open",
           bbox: [0, 0, 1, 1],
+          center: { x: 0, y: 0 },
           semantic_position: "center",
           displayId: 0,
         },
@@ -148,7 +157,8 @@ describe("summarizeGetScreen", () => {
       elementCount: 2,
     };
     expect(summarizeGetScreen(r)).toContain("2 text element");
-    expect(summarizeGetScreen(r)).toContain("Save | Open");
+    // Summary lists the Set-of-Marks numbers so a model can pick "[1]" / "[2]".
+    expect(summarizeGetScreen(r)).toContain("[1] Save | [2] Open");
   });
 
   it("notes when no OCR provider is present", () => {

--- a/plugins/plugin-vision/src/get-screen.ts
+++ b/plugins/plugin-vision/src/get-screen.ts
@@ -18,11 +18,18 @@ import {
 } from "./ocr-with-coords.js";
 
 export interface GetScreenElement {
+  /**
+   * Monotonic 1-based Set-of-Marks number (reading order). A model can pick
+   * `[3]` instead of regressing raw coordinates.
+   */
+  index: number;
   /** Stable per-result id. */
   id: string;
   text: string;
   /** Display-absolute [x, y, width, height]. */
   bbox: [number, number, number, number];
+  /** Click target — the integer center of `bbox`, the point `index` resolves to. */
+  center: { x: number; y: number };
   semantic_position: string;
   displayId: number;
 }
@@ -82,9 +89,14 @@ export async function buildGetScreen(
       pngBytes: opts.pngBytes,
     });
     elements = result.blocks.map((block, i) => ({
+      index: i + 1,
       id: `el-${i + 1}`,
       text: block.text,
       bbox: [block.bbox.x, block.bbox.y, block.bbox.width, block.bbox.height],
+      center: {
+        x: Math.round(block.bbox.x + block.bbox.width / 2),
+        y: Math.round(block.bbox.y + block.bbox.height / 2),
+      },
       semantic_position: block.semantic_position,
       displayId,
     }));
@@ -118,8 +130,8 @@ export function summarizeGetScreen(r: GetScreenResult): string {
   }
   const preview = r.elements
     .slice(0, 8)
-    .map((e) => e.text)
-    .filter(Boolean)
+    .filter((e) => e.text)
+    .map((e) => `[${e.index}] ${e.text}`)
     .join(" | ");
   return `Screen captured (${r.width}x${r.height}). ${r.elementCount} text element(s) detected: ${preview}${r.elementCount > 8 ? " …" : ""}`;
 }

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -17,6 +17,13 @@ import {
   StreamingAudioCaptureService,
   type StreamingAudioConfig,
 } from "./audio-capture-stream";
+import { DirtyTileDescriber } from "./dirty-tile-describer";
+import {
+  createTileDescribeFn,
+  type FrameHash,
+  type TileDescribeFn,
+  tilePngToImageUrl,
+} from "./dirty-tile-scene";
 import { EntityTracker } from "./entity-tracker";
 import type { FaceRecognition } from "./face-recognition-ggml";
 import { getSharp } from "./image/sharp-compat";
@@ -235,6 +242,20 @@ export class VisionService extends Service {
   private lastTfUpdateTime = 0;
   private lastVlmUpdateTime = 0;
   private lastTfDescription = "";
+
+  // Change-gated per-tile describe (#9105). Built lazily on first VLM tick:
+  // null until we know whether a perceptual hash is available. When present it
+  // re-describes only the screen tiles that changed since the previous frame;
+  // when absent the VLM path stays exactly as before (full-frame describe).
+  private dirtyTileDescriber: DirtyTileDescriber | null = null;
+  private dirtyTileDescriberInit = false;
+  // Per-frame prompt context for the per-tile describe. Set immediately before
+  // each `dirtyTileDescriber.describe(...)` and read by the bound describeTile
+  // closure (screen/camera processing is serialized, so there is no overlap).
+  private dirtyTileDescribeContext: {
+    detectedObjects: DetectedObject[];
+    recognizedFaces: RecognizedFace[];
+  } = { detectedObjects: [], recognizedFaces: [] };
 
   // Default configuration
   private readonly DEFAULT_CONFIG: VisionConfig = {
@@ -993,15 +1014,43 @@ export class VisionService extends Service {
       // feed the model the freshly-computed YOLO objects + recognized faces
       // as additional context alongside the image.
       if (shouldUpdateVlm) {
-        description = await this.describeSceneWithVLM(
-          imageUrl,
-          detectedObjects,
-          recognizedFaces,
-        );
+        // Prefer the change-gated per-tile describe on incremental updates: once
+        // a prior scene description exists we only re-describe the tiles that
+        // changed since the last frame (the rest reuse cached tile text), which
+        // avoids paying for a full-frame VLM pass every tick. The first frame,
+        // the test-image override, and any unavailable/empty result fall back to
+        // the full-frame describe below.
+        const incremental =
+          !testImage && this.lastSceneDescription
+            ? await this.describeSceneWithDirtyTiles(
+                await sharp(frame.data, {
+                  raw: {
+                    width: frame.width,
+                    height: frame.height,
+                    channels: 4,
+                  },
+                })
+                  .png()
+                  .toBuffer(),
+                frame.width,
+                frame.height,
+                detectedObjects,
+                recognizedFaces,
+              )
+            : null;
+        description =
+          incremental ??
+          (await this.describeSceneWithVLM(
+            imageUrl,
+            detectedObjects,
+            recognizedFaces,
+          ));
         this.lastVlmUpdateTime = currentTime;
         this.lastTfDescription = description;
         logger.debug(
-          `[VisionService] VLM updated: ${timeSinceVlmUpdate}ms since last update, ${changePercentage.toFixed(1)}% change`,
+          `[VisionService] VLM updated: ${timeSinceVlmUpdate}ms since last update, ${changePercentage.toFixed(1)}% change${
+            incremental ? " (per-tile)" : " (full-frame)"
+          }`,
         );
       }
 
@@ -1127,6 +1176,116 @@ export class VisionService extends Service {
       .filter((candidate): candidate is string => Boolean(candidate?.trim()))
       .join("\n");
     return text.length > 0 ? text : null;
+  }
+
+  /**
+   * Resolve the change-gated per-tile describer, building it once. Returns
+   * `null` (and degrades to full-frame describe) when no perceptual hash is
+   * available — i.e. plugin-computeruse's `frameDhash` cannot be imported.
+   *
+   * The dHash is resolved via a best-effort dynamic import so plugin-vision
+   * never eagerly pulls computeruse's module graph at boot (same idiom as the
+   * coord-OCR bridge wiring in `index.ts`).
+   */
+  private async ensureDirtyTileDescriber(): Promise<DirtyTileDescriber | null> {
+    if (this.dirtyTileDescriberInit) {
+      return this.dirtyTileDescriber;
+    }
+    this.dirtyTileDescriberInit = true;
+    const hashTile = await this.resolveFrameHash();
+    if (!hashTile) {
+      logger.debug(
+        "[VisionService] per-tile dHash unavailable; using full-frame VLM describe",
+      );
+      return null;
+    }
+    const describeTile = this.buildTileDescribeFn();
+    this.dirtyTileDescriber = new DirtyTileDescriber({
+      hashTile,
+      describeTile,
+    });
+    logger.info(
+      "[VisionService] change-gated per-tile describe enabled (#9105)",
+    );
+    return this.dirtyTileDescriber;
+  }
+
+  private async resolveFrameHash(): Promise<FrameHash | null> {
+    // Indirect the specifier through a const so the bundler does not eagerly
+    // resolve the optional peer at build time (same idiom as the OCR-bridge
+    // dynamic import in index.ts) — plugin-computeruse is an optional peer.
+    const computerUseSpecifier = "@elizaos/plugin-computeruse";
+    try {
+      const mod = (await import(/* @vite-ignore */ computerUseSpecifier)) as {
+        frameDhash?: FrameHash;
+      };
+      return typeof mod.frameDhash === "function" ? mod.frameDhash : null;
+    } catch (err) {
+      logger.debug(
+        `[VisionService] plugin-computeruse dHash not available (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Build the per-tile describe call bound to this service's runtime. Reads the
+   * current frame's prompt context (`dirtyTileDescribeContext`) so each tile is
+   * described with the same context the full-frame path would use.
+   */
+  private buildTileDescribeFn(): TileDescribeFn {
+    return createTileDescribeFn({
+      buildTileImageUrl: tilePngToImageUrl,
+      buildTilePrompt: async () => {
+        const sceneContext = await this.collectVisionContext();
+        return buildSceneDescriptionPrompt(
+          sceneContext,
+          this.collectCurrentOcrTextForPrompt(),
+          this.dirtyTileDescribeContext.detectedObjects,
+          this.dirtyTileDescribeContext.recognizedFaces,
+        );
+      },
+      invokeModel: (imageUrl, prompt) =>
+        this.runtime.useModel(ModelType.IMAGE_DESCRIPTION, {
+          imageUrl,
+          prompt,
+        }),
+      extractDescription: (result) =>
+        this.extractDescriptionFromUseModel(result),
+    });
+  }
+
+  /**
+   * Per-tile incremental scene describe. Re-describes only the tiles whose
+   * perceptual hash changed since the previous frame; unchanged tiles reuse
+   * their cached description. Returns `null` when the per-tile path is
+   * unavailable or yields no usable text, so the caller falls back to the
+   * full-frame describe.
+   */
+  private async describeSceneWithDirtyTiles(
+    pngBytes: Buffer,
+    width: number,
+    height: number,
+    detectedObjects: DetectedObject[],
+    recognizedFaces: RecognizedFace[],
+  ): Promise<string | null> {
+    const describer = await this.ensureDirtyTileDescriber();
+    if (!describer) return null;
+    this.dirtyTileDescribeContext = { detectedObjects, recognizedFaces };
+    const out = await describer.describe({
+      displayId: 0,
+      width,
+      height,
+      pngBytes,
+    });
+    const stats = describer.getStats();
+    logger.debug(
+      `[VisionService] dirty-tile describe: ${out.tiles.length} tiles, ${stats.tilesSkipped} reused, ~${stats.approxTokensSaved} tokens saved`,
+    );
+    const scene = out.vlmScene.trim();
+    return scene.length > 0 ? scene : null;
   }
 
   private async describeSceneWithVLM(
@@ -1762,6 +1921,8 @@ export class VisionService extends Service {
     this.lastSceneDescription = null;
     this.lastScreenCapture = null;
     this.lastEnhancedScene = null;
+    this.dirtyTileDescriber = null;
+    this.dirtyTileDescriberInit = false;
     this.isProcessing = false;
     this.isProcessingScreen = false;
 


### PR DESCRIPTION
## #9105 vision pipeline follow-ups — GET_SCREEN set-of-marks numbering + DirtyTileDescriber wiring

Follow-up to #9574 (merged). Two further pipeline-efficiency/grounding items.

### Changes
1. **`feat(vision)`: set-of-marks numbering on GET_SCREEN elements** — every GET_SCREEN element gets a monotonic 1-based `index` + integer `center {x,y}`, and `summarizeGetScreen` prefixes `[index]`, so a remote model can reference `[3]` instead of regressing raw coordinates. Still text-only, image omitted by default — no token regression.
2. **`feat(vision)`: wire DirtyTileDescriber to re-describe only changed tiles** — the `DirtyTileDescriber` (per-tile dHash + LRU cache) was implemented and unit-tested but had **no production owner**; every scene tick ran a full-frame VLM describe. `VisionService` now owns it: on an incremental update it re-describes only tiles whose dHash changed and reuses cached descriptions for the rest, falling back to the full-frame describe on the first frame, an undecodable hash, or when the optional `frameDhash` peer (`@elizaos/plugin-computeruse`) is unavailable — off-by-default-safe. The cross-plugin glue (`dirty-tile-scene.ts`) keeps the describer pure.

### Verification (local, Linux)
- `get-screen.test.ts` + `dirty-tile-integration.test.ts` **8/8**; full **plugin-vision 182 passed / 1 skip / 0 fail**.
- The integration test drives the real production seam (`createTileDescribeFn` + `tilePngToImageUrl` + `DirtyTileDescriber`): frame 1 describes all tiles, an identical frame 2 describes 0, and a one-quadrant change re-describes exactly that tile and reuses the other 3 (`tilesSkipped===3`).

Adversarially reviewed: Change 2 correct and ship-ready (full-frame fallback preserved, no cross-plugin over-reach, genuine integration test). 

### Follow-up (descoped from this PR)
Routing the live GET_SCREEN path through `mergeScreenElements` to add YOLO objects + AX as additional grounding sources needs a type-unification refactor (the live `GetScreenElement` requires `semantic_position`; the merge core carries `kind`/`groundingSources`). Deferred to a focused PR rather than shipped as an unwired enhancement. The core "YOLO+face → Gemma describe prompt" fusion already landed in #9574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)