### PR TITLE
fix(boot): launch/splash surfaces track home background #ef5a1f, not accent #FF5800 (#9565)

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -270,16 +270,17 @@
   </script>
   <style>
     /* FOUC guard — runs before external CSS so we use concrete values.
-       The fallback is the brand orange (#FF5800) the StartupShell loader uses
-       (packages/ui/src/components/shell/StartupShell.tsx): until base.css
-       defines --bg, the first paint is orange in every theme, so the page
-       never flashes black/white before the loader appears. Once --bg resolves
-       the body follows the theme, and #root paints its own --bg over this
-       anyway once the app mounts. */
+       The fallback is the home background orange (#ef5a1f — DEFAULT_BACKGROUND_COLOR,
+       the color the home ShaderBackground and the StartupShell loader paint,
+       packages/ui/src/components/shell/StartupShell.tsx): until base.css defines
+       --bg, the first paint is the home orange in every theme, so the page never
+       flashes black/white — nor a *different* orange (#9565) — before the loader
+       appears. Once --bg resolves the body follows the theme, and #root paints its
+       own --bg over this anyway once the app mounts. */
     html, body {
       margin: 0;
       padding: 0;
-      background-color: var(--bg, #FF5800);
+      background-color: var(--bg, #ef5a1f);
       color: #ffffff;
       font-family: var(--font-sans, "Poppins", Arial, system-ui, sans-serif);
       -webkit-font-smoothing: antialiased;

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -8,11 +8,13 @@ import type { StartupShellProps } from "./startup-shell-types";
 
 const FONT = "'Poppins', Arial, system-ui, sans-serif";
 
-// Brand surface for the startup splash: the active theme's accent (the
-// elizaOS accent by default) with its readable foreground. Whitelabel seam —
-// no hardcoded brand color.
-const BRAND_SURFACE =
-  "bg-[var(--accent,#FF5800)] text-[var(--accent-foreground,#fff)]";
+// Launch surface for the startup splash + loading: the background tracks the
+// HOME background (--bg, default #ef5a1f) — NOT the brand accent — so boot/launch
+// does not flash a different orange before the home background paints (#9565).
+// The brand mark and foreground stay the brand color. Whitelabel seam: both --bg
+// and --accent-foreground are themeable, no hardcoded brand color.
+const LAUNCH_SURFACE =
+  "bg-[var(--bg,#ef5a1f)] text-[var(--accent-foreground,#fff)]";
 
 function brandName(): string {
   return getBootConfig().branding?.appName ?? "elizaOS";
@@ -56,7 +58,7 @@ function StartupFirstRunBackground({ children }: { children: ReactNode }) {
   return (
     <div
       data-testid="startup-first-run-background"
-      className={`fixed inset-0 overflow-hidden ${BRAND_SURFACE}`}
+      className={`fixed inset-0 overflow-hidden ${LAUNCH_SURFACE}`}
       style={{ fontFamily: FONT }}
     >
       {children}
@@ -72,7 +74,7 @@ function StartupLoading(props: { phase: string; status: string }) {
       role="status"
       aria-live="polite"
       aria-busy="true"
-      className={`fixed inset-0 flex items-center justify-center overflow-hidden ${BRAND_SURFACE}`}
+      className={`fixed inset-0 flex items-center justify-center overflow-hidden ${LAUNCH_SURFACE}`}
       style={{ fontFamily: FONT }}
     >
       <div className="relative z-10 flex w-full max-w-[24rem] flex-col items-center gap-5 px-6 text-center">


### PR DESCRIPTION
Addresses the visual requirement called out in #9565: *"startup/launch orange must match the default home background orange `#ef5a1f`, not the older brand accent `#FF5800` … boot/loading/launch surfaces should not flash a different orange before the home background appears."*

## Problem
On cold start the boot path painted the **brand accent** orange (`#FF5800`) before the home background's `#ef5a1f` appeared — two different oranges flashing in sequence:
- `packages/app/index.html` FOUC guard fell back to `var(--bg, #FF5800)` (the very first paint, before external CSS).
- `StartupShell`'s splash + loading full-screen surface was `bg-[var(--accent,#FF5800)]`.

## Fix
Both boot surfaces now fall back to the **home background** color `#ef5a1f` (= `DEFAULT_BACKGROUND_COLOR` in `packages/ui/src/state/ui-preferences.ts`, what the home `ShaderBackground` paints). So first-paint → loader → home is **one continuous orange, no flash**.

- The brand **mark/logo** (`BrandMark`/`ElizaMark`) and the accent **foreground** stay the brand color — per the issue's *"brand/logo accent can remain #FF5800"*.
- Both surfaces still resolve `--bg` / `--accent-foreground` first, so themed and **whitelabel** backgrounds are unaffected (the change is only to the fallback + which themeable var the background tracks). `BRAND_SURFACE` → `LAUNCH_SURFACE` with a comment explaining why it tracks `--bg`.

## Scope notes
- The other `#FF5800` usages (`ContinuousChatOverlay`, image-gen loading states) are **in-app, post-boot** surfaces — not the launch flash — so they're intentionally left alone.
- This is the visual slice of #9565; the broader boot-time/readiness optimization epic is separate.

## Verification
- `StartupShell.tsx`: biome-clean; `BRAND_SURFACE`→`LAUNCH_SURFACE` rename is consistent (0 stray refs); string-const change, trivially type-safe.
- `index.html`: only the FOUC comment + `background-color` fallback changed (the pre-existing biome lint on the inline theme-script IIFE is untouched).
- **Screenshots:** boot first-paint flash is inherently hard to capture as a static image; the change is a deterministic CSS-value swap to the documented home-bg constant, and `packages/ui`'s story-gate / `packages/app`'s `audit:app` cover any StartupShell visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)