### PR TITLE
test(lifeops-bench): honest base-vs-robustness scenario counts + edge-variant clone guard (#8795)

### DIFF
--- a/packages/benchmarks/lifeops-bench/AGENTS.md
+++ b/packages/benchmarks/lifeops-bench/AGENTS.md
@@ -50,7 +50,7 @@ pytest tests/ -v
 | `eliza_lifeops_bench/evaluator.py` | LIVE-mode simulated-user + judge wiring |
 | `eliza_lifeops_bench/scorer.py` | state_hash, output_substring, pass@k |
 | `eliza_lifeops_bench/lifeworld/` | Deterministic in-memory world state |
-| `eliza_lifeops_bench/scenarios/` | 492 static + 528 live scenarios by domain |
+| `eliza_lifeops_bench/scenarios/` | 1020 base scenarios (492 static + 528 live) by domain; `__init__.py` expands each 10x under fixed prompt-prefix framings into 11220 robustness runs (variant keeps its base's ground-truth/required-outputs/world-seed) |
 | `eliza_lifeops_bench/agents/` | Adapters: eliza, hermes, openclaw, cerebras-direct, perfect, smithers, wrong |
 | `eliza_lifeops_bench/clients/` | Provider clients (Cerebras, Anthropic, Hermes) |
 | `data/snapshots/` | Seeded deterministic LifeWorld snapshots |

--- a/packages/benchmarks/lifeops-bench/CLAUDE.md
+++ b/packages/benchmarks/lifeops-bench/CLAUDE.md
@@ -50,7 +50,7 @@ pytest tests/ -v
 | `eliza_lifeops_bench/evaluator.py` | LIVE-mode simulated-user + judge wiring |
 | `eliza_lifeops_bench/scorer.py` | state_hash, output_substring, pass@k |
 | `eliza_lifeops_bench/lifeworld/` | Deterministic in-memory world state |
-| `eliza_lifeops_bench/scenarios/` | 492 static + 528 live scenarios by domain |
+| `eliza_lifeops_bench/scenarios/` | 1020 base scenarios (492 static + 528 live) by domain; `__init__.py` expands each 10x under fixed prompt-prefix framings into 11220 robustness runs (variant keeps its base's ground-truth/required-outputs/world-seed) |
 | `eliza_lifeops_bench/agents/` | Adapters: eliza, hermes, openclaw, cerebras-direct, perfect, smithers, wrong |
 | `eliza_lifeops_bench/clients/` | Provider clients (Cerebras, Anthropic, Hermes) |
 | `data/snapshots/` | Seeded deterministic LifeWorld snapshots |

--- a/packages/benchmarks/lifeops-bench/README.md
+++ b/packages/benchmarks/lifeops-bench/README.md
@@ -59,7 +59,11 @@ uv sync
 # or
 pip install -e .[anthropic,test]
 
-# List all registered scenarios (1020 total at time of writing)
+# List all scenarios. 1020 base scenarios are expanded 10x under fixed
+# prompt-prefix framings (polite/urgent/mobile/…) into 11220 robustness runs;
+# each edge variant shares its base's ground-truth actions, required outputs
+# and world seed — only the prompt wording differs. `--count-scenarios` prints
+# the base-vs-variant split explicitly.
 python3 -m eliza_lifeops_bench --list-scenarios
 
 # Run the calendar smoke scenario against the perfect oracle
@@ -142,7 +146,10 @@ packages/benchmarks/lifeops-bench/
     evaluator.py             LIVE-mode simulated-user + judge wiring
     scorer.py                state_hash, output_substring, pass@k aggregation
     lifeworld/               In-memory hashable world (entities + snapshots)
-    scenarios/               492 static + 528 live scenarios, organized by domain
+    scenarios/               1020 base scenarios (492 static + 528 live) by domain;
+                             __init__.py expands each 10x under fixed prompt-prefix
+                             framings into 11220 robustness runs (variant shares its
+                             base's ground-truth/required-outputs/world-seed)
       _personas.py           10 reusable personas
       _smoke_scenarios.py    Two original smoke scenarios (kept at front of list)
       _authoring/            Candidate-generator pipeline + spec

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/__main__.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/__main__.py
@@ -252,8 +252,17 @@ def _list_scenarios() -> None:
         print(
             f"  {s.id:<40} {s.domain.value:<10} {s.mode.value:<7} {s.name}"
         )
-    print(f"\nTotal: {len(ALL_SCENARIOS)} scenarios\n")
-    print("By domain:")
+    counts = count_lifeops_scenarios()
+    print(
+        f"\n{counts['base']} base scenarios; "
+        f"{counts['variantsPerBase']}x prompt-prefix robustness variants "
+        f"= {counts['totalRuns']} runs total\n"
+    )
+    print(
+        "  (an edge variant re-frames a base scenario's prompt only; "
+        "ground-truth actions, required outputs and world seed are identical)\n"
+    )
+    print("By domain (run counts, including edge variants):")
     for domain, scenarios in sorted(SCENARIOS_BY_DOMAIN.items(), key=lambda kv: kv[0].value):
         print(f"  {domain.value:<12} {len(scenarios)} scenarios")
     print()

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/__init__.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/__init__.py
@@ -97,12 +97,40 @@ for _scenario in ALL_SCENARIOS:
 
 
 def count_lifeops_scenarios() -> dict[str, int | str | float]:
+    """Honest base-vs-robustness scenario accounting.
+
+    The corpus has ``len(CORE_SCENARIOS)`` distinct, hand-authored *base*
+    scenarios. Each base is then re-emitted ``EDGE_EXPANSION_MULTIPLIER``
+    times under fixed prompt-prefix framings (polite/urgent/mobile/…). An
+    edge variant shares the SAME ``ground_truth_actions``,
+    ``required_outputs`` and ``world_seed`` as its base — only the prompt
+    wording (``id``/``name``/``instruction``/``description``) differs. They
+    are prompt-robustness *runs*, not new distinct scenarios, so the count
+    must not present ``total`` as if it were a count of distinct scenarios.
+
+    Legacy numeric keys (``existing`` / ``added`` / ``total`` /
+    ``multiplierAdded``) are kept for back-compat. The ``base`` /
+    ``variantsPerBase`` / ``totalRuns`` keys and ``summary`` string state the
+    base-vs-variant split explicitly.
+    """
+    base = len(CORE_SCENARIOS)
+    variants_per_base = EDGE_EXPANSION_MULTIPLIER
+    total_runs = len(ALL_SCENARIOS)
     return {
         "suite": "lifeops-bench",
-        "existing": len(CORE_SCENARIOS),
+        # Legacy keys (kept for back-compat with existing consumers/tests).
+        "existing": base,
         "added": len(EDGE_EXPANDED_SCENARIOS),
-        "total": len(ALL_SCENARIOS),
-        "multiplierAdded": len(EDGE_EXPANDED_SCENARIOS) / len(CORE_SCENARIOS),
+        "total": total_runs,
+        "multiplierAdded": len(EDGE_EXPANDED_SCENARIOS) / base,
+        # Honest, explicitly-labelled split.
+        "base": base,
+        "variantsPerBase": variants_per_base,
+        "totalRuns": total_runs,
+        "summary": (
+            f"{base} base scenarios; {variants_per_base}x prompt-prefix "
+            f"robustness variants = {total_runs} runs"
+        ),
     }
 
 

--- a/packages/benchmarks/lifeops-bench/tests/test_edge_expansion_identity.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_edge_expansion_identity.py
@@ -1,0 +1,130 @@
+"""Guard: edge-expanded scenarios are prompt-robustness clones, not new work.
+
+LifeOpsBench inflates its corpus 10x by re-emitting every base scenario under
+fixed prompt-prefix framings (polite/urgent/mobile/…). That is honest
+*prompt-robustness* coverage **only if** a variant changes the prompt wording
+and nothing else: it must share its base's ``ground_truth_actions``,
+``required_outputs`` and ``world_seed``. If a variant ever diverged on any of
+those, the 10x count would silently become uncredited "new" scenarios — the
+exact dishonesty this guard exists to prevent (#8795).
+
+These tests pin the contract so the expansion can never quietly drift.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from eliza_lifeops_bench.scenarios import (
+    CORE_SCENARIOS,
+    EDGE_EXPANDED_SCENARIOS,
+    EDGE_EXPANSION_MULTIPLIER,
+    EDGE_VARIANTS,
+    count_lifeops_scenarios,
+)
+
+# Fields the expansion is allowed to rewrite (prompt wording / identity only).
+PROMPT_FIELDS: frozenset[str] = frozenset({"id", "name", "instruction", "description"})
+
+# Fields that MUST be byte-identical between a base and each of its variants.
+# Everything in the Scenario dataclass that is not a prompt field — most
+# importantly the scored ground truth, required outputs, and world seed.
+IDENTITY_FIELDS: tuple[str, ...] = tuple(
+    f.name for f in dataclasses.fields(CORE_SCENARIOS[0]) if f.name not in PROMPT_FIELDS
+)
+
+
+def _variants_for(base_id: str) -> list:
+    prefix = f"{base_id}--edge-"
+    return [s for s in EDGE_EXPANDED_SCENARIOS if s.id.startswith(prefix)]
+
+
+def test_identity_fields_cover_the_scored_contract() -> None:
+    # The three fields #8795 calls out must be in the identity set, not the
+    # prompt set — otherwise the guard would be vacuous.
+    for required in ("ground_truth_actions", "required_outputs", "world_seed"):
+        assert required in IDENTITY_FIELDS, (
+            f"{required} must be an identity field, not a prompt field"
+        )
+    assert "persona" in IDENTITY_FIELDS  # scored personas must not drift either
+
+
+def test_each_base_has_exactly_the_declared_variants() -> None:
+    assert len(EDGE_VARIANTS) == EDGE_EXPANSION_MULTIPLIER
+    variant_ids = {vid for vid, _desc, _tmpl in EDGE_VARIANTS}
+    assert len(variant_ids) == EDGE_EXPANSION_MULTIPLIER, "duplicate edge-variant ids"
+
+    for base in CORE_SCENARIOS:
+        variants = _variants_for(base.id)
+        assert len(variants) == EDGE_EXPANSION_MULTIPLIER, (
+            f"{base.id} has {len(variants)} edge variants, "
+            f"expected {EDGE_EXPANSION_MULTIPLIER}"
+        )
+        got = {v.id[len(f"{base.id}--edge-"):] for v in variants}
+        assert got == variant_ids, (
+            f"{base.id} variant suffixes {sorted(got)} != {sorted(variant_ids)}"
+        )
+
+
+def test_variants_share_base_identity_fields() -> None:
+    """Every non-prompt field is identical between a base and each variant."""
+    bad: list[str] = []
+    for base in CORE_SCENARIOS:
+        for variant in _variants_for(base.id):
+            for field_name in IDENTITY_FIELDS:
+                if getattr(base, field_name) != getattr(variant, field_name):
+                    bad.append(
+                        f"{variant.id}: field {field_name!r} diverged from base "
+                        f"{base.id!r}"
+                    )
+    assert not bad, (
+        "edge variants must be prompt-only clones of their base; diverged on:\n"
+        + "\n".join(bad)
+    )
+
+
+def test_variants_actually_change_the_prompt() -> None:
+    """The expansion is real robustness coverage: prompt fields DO differ."""
+    bad: list[str] = []
+    for base in CORE_SCENARIOS:
+        for variant in _variants_for(base.id):
+            if variant.id == base.id:
+                bad.append(f"{variant.id}: id not rewritten")
+            if variant.instruction == base.instruction:
+                bad.append(f"{variant.id}: instruction not reframed")
+            if base.instruction not in variant.instruction:
+                bad.append(
+                    f"{variant.id}: reframed instruction dropped the base instruction"
+                )
+    assert not bad, "edge variants must reframe the prompt:\n" + "\n".join(bad)
+
+
+def test_count_summary_states_base_vs_runs() -> None:
+    counts = count_lifeops_scenarios()
+    assert counts["base"] == len(CORE_SCENARIOS)
+    assert counts["variantsPerBase"] == EDGE_EXPANSION_MULTIPLIER
+    assert counts["totalRuns"] == len(CORE_SCENARIOS) * (1 + EDGE_EXPANSION_MULTIPLIER)
+    # The human-facing summary must distinguish base scenarios from runs so the
+    # 10x inflation can never read as 11220 distinct scenarios.
+    summary = counts["summary"]
+    assert isinstance(summary, str)
+    assert "base" in summary and "robustness" in summary and "runs" in summary
+
+
+@pytest.mark.parametrize("seed_field", ["world_seed", "ground_truth_actions", "required_outputs"])
+def test_guard_is_not_vacuous(seed_field: str) -> None:
+    """If a variant's scored field diverged, the identity check must catch it.
+
+    We never mutate the real corpus — we build a one-off diverged variant in
+    memory and assert the same comparison the guard uses would flag it.
+    """
+    base = CORE_SCENARIOS[0]
+    if seed_field == "world_seed":
+        diverged = dataclasses.replace(base, world_seed=base.world_seed + 1)
+    elif seed_field == "ground_truth_actions":
+        diverged = dataclasses.replace(base, ground_truth_actions=[])
+    else:
+        diverged = dataclasses.replace(base, required_outputs=["__divergent__"])
+    assert getattr(diverged, seed_field) != getattr(base, seed_field)

--- a/packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
@@ -68,12 +68,20 @@ def test_corpus_size_meets_minimum() -> None:
 
 
 def test_corpus_expands_current_core_by_exactly_10x() -> None:
+    # 1020 distinct base scenarios, each re-emitted 10x under fixed
+    # prompt-prefix framings = 11220 robustness runs. The legacy keys
+    # (existing/added/total/multiplierAdded) stay pinned for back-compat;
+    # the base/variantsPerBase/totalRuns/summary keys state the split.
     assert count_lifeops_scenarios() == {
         "suite": "lifeops-bench",
         "existing": 1020,
         "added": 10200,
         "total": 11220,
         "multiplierAdded": 10,
+        "base": 1020,
+        "variantsPerBase": 10,
+        "totalRuns": 11220,
+        "summary": "1020 base scenarios; 10x prompt-prefix robustness variants = 11220 runs",
     }
     assert validate_lifeops_scenarios() == {
         "valid": True,


### PR DESCRIPTION
Closes #8795.

## Root cause

`packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/__init__.py` expands **1020** hand-authored *base* scenarios **10x** under fixed prompt-prefix framings (`polite`/`urgent`/`mobile`/…) using `dataclasses.replace`, rewriting **only** `id` / `name` / `instruction` / `description`. The `ground_truth_actions`, `required_outputs` and `world_seed` of every `--edge-<variant>` are **identical** to its base.

But the count and CLI presented the resulting **11220** entries as if they were 11220 distinct scenarios:

- `count_lifeops_scenarios()` returned `total: 11220` with no label separating base from variants.
- `__main__.py --list-scenarios` printed `Total: 11220 scenarios`.
- `README.md` claimed `1020 total at time of writing` right above the `--list-scenarios` invocation that prints 11220 — internally contradictory.

These are prompt-**robustness** variants, not new scenarios. No test pinned the `(ground_truth_actions, required_outputs, world_seed)` identity of edge variants, so the expansion could silently drift into uncredited "new" scenarios.

## Fix (honesty + guard only — the scenario set and the 10x multiplier are unchanged)

- **`count_lifeops_scenarios()`**: legacy `existing` / `added` / `total` / `multiplierAdded` keys kept for back-compat; added explicit `base` / `variantsPerBase` / `totalRuns` fields and a `summary` string: `"1020 base scenarios; 10x prompt-prefix robustness variants = 11220 runs"`.
- **`--list-scenarios`**: prints the base-vs-runs split instead of a bare total, and labels the by-domain table as run counts.
- **README / AGENTS / CLAUDE**: state `1020 base (492 static + 528 live)` expanded `10x` into `11220 robustness runs`; removed the stale `1020 total` line.
- **New guard `tests/test_edge_expansion_identity.py`**: for every base id, its 10 edge variants must share IDENTICAL `ground_truth_actions` / `required_outputs` / `world_seed` (and all other non-prompt fields); only the prompt wording may differ. Pinned the new count keys in `test_scenarios_corpus.py`.

Touches only `packages/benchmarks/lifeops-bench/`.

## Real test output

Manifest/snapshot artifacts (gitignored, generated) symlinked from the main checkout to run offline.

**Green — all touched test files:**
```
$ python3 -m pytest tests/test_scenarios_corpus.py tests/test_suites.py tests/test_edge_expansion_identity.py -q
..............................                                           [100%]
30 passed
```

**Red-before / green-after — the new guard catches divergence.** Temporarily bumping one variant's `world_seed`:
```
$ python3 -m pytest tests/test_edge_expansion_identity.py::test_variants_share_base_identity_fields -q
E   smoke_static_calendar_01--edge-polite: field 'world_seed' diverged from base 'smoke_static_calendar_01'
E   calendar.check_availability_thursday_morning--edge-polite: field 'world_seed' diverged from base ...
   ... (every diverged variant flagged by id + field)
FAILED tests/test_edge_expansion_identity.py::test_variants_share_base_identity_fields
```
After restoring the file:
```
$ python3 -m pytest tests/test_edge_expansion_identity.py -q
........                                                                  [100%]
8 passed
```

**Honest CLI output after the fix:**
```
$ python3 -m eliza_lifeops_bench --count-scenarios
{"added": 10200, "base": 1020, "existing": 1020, "multiplierAdded": 10.0, "suite": "lifeops-bench", "summary": "1020 base scenarios; 10x prompt-prefix robustness variants = 11220 runs", "total": 11220, "totalRuns": 11220, "variantsPerBase": 10}

$ python3 -m eliza_lifeops_bench --list-scenarios | tail
1020 base scenarios; 10x prompt-prefix robustness variants = 11220 runs total
  (an edge variant re-frames a base scenario's prompt only; ground-truth actions, required outputs and world seed are identical)
By domain (run counts, including edge variants):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)