### PR TITLE
feat(voice): playback→mic echo-delay calibration primitive (#9583)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { estimateEchoDelaySamples } from "./echo-delay.ts";
+
+/** Deterministic PRNG so fixtures are reproducible across runs/CI. */
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function whiteNoise(n: number, amp: number, rng: () => number): Float32Array {
+	const out = new Float32Array(n);
+	for (let i = 0; i < n; i++) out[i] = (rng() * 2 - 1) * amp;
+	return out;
+}
+
+describe("estimateEchoDelaySamples (#9583)", () => {
+	it("recovers a known playback→mic delay", () => {
+		const rng = mulberry32(7);
+		const far = whiteNoise(8000, 0.5, rng);
+		const delay = 137;
+		const gain = 0.6;
+		const near = new Float32Array(far.length);
+		for (let i = delay; i < far.length; i++) {
+			near[i] = gain * far[i - delay] + (rng() * 2 - 1) * 0.01; // tiny near noise
+		}
+
+		const est = estimateEchoDelaySamples(near, far, { maxLagSamples: 400 });
+		expect(est.lagSamples).toBe(delay);
+		// Scale-invariant correlation: the 0.6 gain does not lower confidence.
+		expect(est.confidence).toBeGreaterThan(0.9);
+	});
+
+	it("recovers a zero delay (synchronous reference)", () => {
+		const rng = mulberry32(3);
+		const far = whiteNoise(8000, 0.5, rng);
+		const near = new Float32Array(far.length);
+		for (let i = 0; i < far.length; i++) near[i] = 0.7 * far[i];
+
+		const est = estimateEchoDelaySamples(near, far, { maxLagSamples: 200 });
+		expect(est.lagSamples).toBe(0);
+		expect(est.confidence).toBeGreaterThan(0.95);
+	});
+
+	it("reports low confidence when near is independent of far (no echo)", () => {
+		const far = whiteNoise(8000, 0.5, mulberry32(1));
+		const near = whiteNoise(8000, 0.5, mulberry32(2)); // independent signal
+
+		const est = estimateEchoDelaySamples(near, far, { maxLagSamples: 400 });
+		expect(est.confidence).toBeLessThan(0.3);
+	});
+
+	it("returns zero on empty input", () => {
+		expect(
+			estimateEchoDelaySamples(new Float32Array(0), new Float32Array(0)),
+		).toEqual({ lagSamples: 0, confidence: 0 });
+	});
+
+	it("honors a minLagSamples floor", () => {
+		const rng = mulberry32(9);
+		const far = whiteNoise(8000, 0.5, rng);
+		const delay = 40;
+		const near = new Float32Array(far.length);
+		for (let i = delay; i < far.length; i++) near[i] = 0.5 * far[i - delay];
+
+		// Floor above the true delay forces the search to start past it.
+		const est = estimateEchoDelaySamples(near, far, {
+			minLagSamples: 100,
+			maxLagSamples: 400,
+		});
+		expect(est.lagSamples).toBeGreaterThanOrEqual(100);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
@@ -1,0 +1,82 @@
+/**
+ * Playback→mic echo-delay calibration (#9583, follow-up to #9455).
+ *
+ * The NLMS echo canceller's adaptive taps model only the room impulse response;
+ * the bulk transport delay between TTS playback and the mic capture window
+ * (audio-HAL buffering, Bluetooth, resampling, …) should be removed FIRST so the
+ * finite tap span (and the adaptation budget) isn't spent modelling pure
+ * latency. This finds that bulk lag by normalized cross-correlation of the mic
+ * (near-end) against the playback reference (far-end): the lag that maximizes
+ * correlation is the playback→mic delay, which the caller then applies as a
+ * fixed pre-alignment before the adaptive filter.
+ *
+ * Pure DSP — no FFI, no device. The per-platform default delay still needs to be
+ * tuned on hardware, but the estimator itself is deterministic and testable.
+ */
+
+export interface EchoDelayEstimate {
+	/** Best playback→mic delay in samples (far leads near by this much). */
+	lagSamples: number;
+	/** Peak normalized cross-correlation at that lag, in [0, 1]. */
+	confidence: number;
+}
+
+export interface EchoDelayOptions {
+	/** Largest lag to search, in samples. Default 4800 (300 ms @ 16 kHz). */
+	maxLagSamples?: number;
+	/** Smallest lag to search, in samples. Default 0. */
+	minLagSamples?: number;
+}
+
+/**
+ * Estimate the bulk playback→mic delay: the lag `d` (in samples) that best
+ * aligns the far-end reference into the near-end mic signal, i.e.
+ * `near[n] ≈ g · far[n - d]`. Returns that lag plus its normalized
+ * cross-correlation as a `[0, 1]` confidence.
+ *
+ * Normalized correlation is scale-invariant, so the playback gain `g` does not
+ * bias the result. A low confidence (e.g. `< 0.3`) means no detectable echo
+ * (the signals are independent) — the caller should keep its previous
+ * calibration rather than trust a spurious peak.
+ */
+export function estimateEchoDelaySamples(
+	near: Float32Array,
+	far: Float32Array,
+	options: EchoDelayOptions = {},
+): EchoDelayEstimate {
+	const maxLag = Math.max(0, Math.floor(options.maxLagSamples ?? 4800));
+	const minLag = Math.max(0, Math.floor(options.minLagSamples ?? 0));
+	const n = Math.min(near.length, far.length);
+	if (n === 0 || minLag > maxLag) {
+		return { lagSamples: 0, confidence: 0 };
+	}
+
+	// Per-lag normalized cross-correlation over the overlapping window. O((maxLag
+	// − minLag) · n) — fine for a short calibration burst (a few hundred ms of
+	// audio, run rarely, not per-frame).
+	let bestLag = minLag;
+	let bestCorr = -Infinity;
+	for (let lag = minLag; lag <= maxLag; lag++) {
+		let dot = 0;
+		let nearEnergy = 0;
+		let farEnergy = 0;
+		for (let i = lag; i < n; i++) {
+			const a = near[i];
+			const b = far[i - lag];
+			dot += a * b;
+			nearEnergy += a * a;
+			farEnergy += b * b;
+		}
+		const denom = Math.sqrt(nearEnergy * farEnergy);
+		const corr = denom > 0 ? dot / denom : 0;
+		if (corr > bestCorr) {
+			bestCorr = corr;
+			bestLag = lag;
+		}
+	}
+
+	return {
+		lagSamples: bestLag,
+		confidence: bestCorr === -Infinity ? 0 : Math.max(0, Math.min(1, bestCorr)),
+	};
+}

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -54,6 +54,11 @@ export {
 	NlmsEchoCanceller,
 	type NlmsEchoCancellerConfig,
 } from "./echo-canceller";
+export {
+	type EchoDelayEstimate,
+	type EchoDelayOptions,
+	estimateEchoDelaySamples,
+} from "./echo-delay";
 export type {
 	LlamaContextLike as Eliza1EotLlamaContext,
 	LlamaContextSequenceLike as Eliza1EotLlamaSequence,


### PR DESCRIPTION
Follow-up to #9455 / #9583: the **playback→mic delay calibration** primitive.

`estimateEchoDelaySamples(near, far, opts)` finds the bulk transport delay between TTS playback and the mic window by normalized cross-correlation, so the NLMS canceller's adaptive taps only model the room impulse response (not pure latency). Scale-invariant (playback gain doesn't bias it) + a `[0,1]` confidence so the caller ignores spurious peaks when there's no echo. Pure DSP — no FFI/device — exported from the voice barrel.

**Verified:** 5 vitest tests (`echo-delay.test.ts`) — recovers a known 137-sample delay, zero delay, low-confidence on independent signals, empty input, `minLag` floor. `5 passed`.

Closes the delay-calibration line of #9583. The remaining #9583 items (wiring the live `echoReference` PCM capture + per-platform default tuning) need on-device audio and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
