### PR TITLE
test(boot): brand-surface FOUC assertion accepts home-bg orange #ef5a1f (#9565)

### DIFF
--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -70,13 +70,15 @@ describe("brand surfaces", () => {
     expect(xml).toMatch(/red="1\.0"\s+green="0\.345"\s+blue="0\.0"/);
   });
 
-  it("index.html FOUC fallback is unified with the dark chat shell, not a foreign color", () => {
+  it("index.html FOUC fallback is the home background orange, not a foreign color", () => {
     const html = read("index.html");
-    // Either pure black or the brand orange is acceptable. The previous
+    // The FOUC fallback tracks the home background orange (#ef5a1f, #9565) so
+    // boot does not flash a different orange before the home background paints;
+    // pure black or the legacy brand orange remain acceptable. The previous
     // `#08080a` near-black is a slop value and should not regress.
     expect(html).not.toContain("#08080a");
     expect(html).toMatch(
-      /background-color:\s*var\(--bg,\s*(#000000|#FF5800)\)/,
+      /background-color:\s*var\(--bg,\s*(#000000|#FF5800|#ef5a1f)\)/,
     );
   });
 


### PR DESCRIPTION
**Fixes a red test on develop** introduced by the merged #9582.

#9582 set the index.html FOUC fallback to `var(--bg, #ef5a1f)` (the home background color, so boot doesn't flash a different orange before home paints — #9565). But `packages/app/test/brand-surface.test.ts` still asserted the FOUC fallback was `#000000|#FF5800`, so `packages/app` test went red:

```
× index.html FOUC fallback ... 
  expected '…var(--bg, #ef5a1f)…' to match /var\(--bg,\s*(#000000|#FF5800)\)/
```

This adds `#ef5a1f` to the accepted set and updates the case name/comment to reflect the #9565 intent (FOUC tracks the home background orange). The **native splash surfaces** (capacitor `SplashScreen`, Android `colors.xml`, iOS `LaunchScreen`, `app.config` theme) intentionally **stay brand `#FF5800`** — the OS launch image is a brand moment shown before the webview loads — so those assertions are unchanged.

## Verification
`packages/app/test/brand-surface.test.ts`: **8/8 passing** after the fix (was 1 failed on develop). Biome-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)