### PR TITLE
test(health): cover untested permission-denied / clarification / missing-arg action branches (#8795)

### DIFF
--- a/plugins/plugin-health/src/actions/health.test.ts
+++ b/plugins/plugin-health/src/actions/health.test.ts
@@ -151,6 +151,136 @@ describe("health action runner", () => {
     });
   });
 
+  it("denies access → PERMISSION_DENIED before touching the service (#8795)", async () => {
+    const service = {
+      getHealthConnectorStatus: vi.fn(),
+      getHealthSummary: vi.fn(),
+      getHealthTrend: vi.fn(),
+      getHealthDataPoints: vi.fn(),
+      getHealthDailySummary: vi.fn(),
+    } satisfies HealthActionService;
+    const runner = createHealthActionRunner({
+      hasAccess: async () => false,
+      createService: () => service,
+      messageText: (m) =>
+        typeof m.content.text === "string" ? m.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      recentConversationTexts: async () => [],
+      runJsonModel: async () => null,
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      { parameters: { subaction: "today" } },
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({ error: "PERMISSION_DENIED" });
+    expect(result.text).toContain("Health data is restricted to the owner");
+    // No service work should run once access is denied.
+    expect(service.getHealthConnectorStatus).not.toHaveBeenCalled();
+  });
+
+  it("planner shouldAct:false → planner_clarification carrying the clarifying text (#8795)", async () => {
+    const service = {
+      getHealthConnectorStatus: vi.fn(),
+      getHealthSummary: vi.fn(),
+      getHealthTrend: vi.fn(),
+      getHealthDataPoints: vi.fn(),
+      getHealthDailySummary: vi.fn(),
+    } satisfies HealthActionService;
+    const runJsonModel = vi.fn(
+      async (): Promise<{ parsed: Record<string, unknown> }> => ({
+        parsed: {
+          subaction: null,
+          metric: null,
+          days: null,
+          shouldAct: false,
+          response: "Which metric — steps, sleep, or heart rate?",
+        },
+      }),
+    );
+    const runner = createHealthActionRunner({
+      hasAccess: async () => true,
+      createService: () => service,
+      messageText: (m) =>
+        typeof m.content.text === "string" ? m.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      recentConversationTexts: async () => [],
+      runJsonModel,
+    });
+
+    // resolveHealthPlanWithLlm only fires when runtime.useModel exists.
+    const plannerRuntime = {
+      logger: { warn: vi.fn() },
+      useModel: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    // No explicit subaction → the planner runs and returns shouldAct:false.
+    const result = await runner(
+      plannerRuntime,
+      { content: { text: "tell me about my health" } } as Memory,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(runJsonModel).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    // renderReply echoes the fallback, which is the planner's clarifying text.
+    expect(result.text).toBe("Which metric — steps, sleep, or heart rate?");
+    expect(result.values).toMatchObject({
+      success: false,
+      error: "PLANNER_SHOULDACT_FALSE",
+      skipped: true,
+    });
+    expect(result.data).toMatchObject({
+      skipped: true,
+      error: "PLANNER_SHOULDACT_FALSE",
+    });
+    // Clarification short-circuits before any health data is fetched.
+    expect(service.getHealthConnectorStatus).not.toHaveBeenCalled();
+  });
+
+  it("by_metric with no metric → MISSING_METRIC (#8795)", async () => {
+    const service = {
+      getHealthConnectorStatus: vi.fn(async () => ({
+        available: true,
+        backend: "healthkit" as const,
+      })),
+      getHealthSummary: vi.fn(async () => ({
+        providers: [],
+        summaries: [],
+        samples: [],
+        workouts: [],
+        sleepEpisodes: [],
+        syncedAt: "2026-05-30T12:00:00.000Z",
+      })),
+      getHealthTrend: vi.fn(),
+      getHealthDataPoints: vi.fn(),
+      getHealthDailySummary: vi.fn(),
+    } satisfies HealthActionService;
+    const runner = makeRunner(service);
+
+    // Explicit by_metric subaction, but no metric param → MISSING_METRIC.
+    const result = await runner(
+      runtime,
+      { content: { text: "how much of that metric" } } as Memory,
+      undefined,
+      { parameters: { subaction: "by_metric" } },
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({ error: "MISSING_METRIC" });
+    expect(result.text).toContain("Specify a metric");
+    // Reached the metric guard, so no data points were ever requested.
+    expect(service.getHealthDataPoints).not.toHaveBeenCalled();
+  });
+
   it("runs status through injected service and renderer adapters", async () => {
     const service = {
       getHealthConnectorStatus: vi.fn(async () => ({

--- a/plugins/plugin-health/src/actions/screen-time.test.ts
+++ b/plugins/plugin-health/src/actions/screen-time.test.ts
@@ -145,6 +145,186 @@ describe("screen-time action runner", () => {
     });
   });
 
+  it("denies access → PERMISSION_DENIED before resolving args (#8795)", async () => {
+    const resolveActionArgs = vi.fn();
+    const runner = createScreenTimeActionRunner({
+      hasAccess: async () => false,
+      createService: () => makeService(),
+      messageText: (input) =>
+        typeof input.content.text === "string" ? input.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      resolveActionArgs,
+      isDarwin: () => false,
+      getActivityReport: vi.fn(),
+      getTimeOnApp: vi.fn(),
+      getBrowserDomainActivity: vi.fn(),
+      getBrowserActivitySnapshot: vi.fn(),
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({ error: "PERMISSION_DENIED" });
+    expect(result.text).toContain(
+      "Screen time data is restricted to the owner",
+    );
+    // Access denial short-circuits before argument resolution.
+    expect(resolveActionArgs).not.toHaveBeenCalled();
+  });
+
+  it("resolveActionArgs ok:false → INVALID_SUBACTION (#8795)", async () => {
+    const runner = createScreenTimeActionRunner({
+      hasAccess: async () => true,
+      createService: () => makeService(),
+      messageText: (input) =>
+        typeof input.content.text === "string" ? input.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      resolveActionArgs: async () => ({
+        ok: false as const,
+        missing: ["appNameOrBundleId"],
+        clarification: "Which app should I check?",
+      }),
+      isDarwin: () => false,
+      getActivityReport: vi.fn(),
+      getTimeOnApp: vi.fn(),
+      getBrowserDomainActivity: vi.fn(),
+      getBrowserActivitySnapshot: vi.fn(),
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("Which app should I check?");
+    expect(result.data).toEqual({
+      error: "INVALID_SUBACTION",
+      missing: ["appNameOrBundleId"],
+    });
+  });
+
+  it("time_on_app with empty app id → MISSING_APP (#8795)", async () => {
+    const getTimeOnApp = vi.fn();
+    const runner = createScreenTimeActionRunner({
+      hasAccess: async () => true,
+      createService: () => makeService(),
+      messageText: (input) =>
+        typeof input.content.text === "string" ? input.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      resolveActionArgs: async <TSubaction extends string, TParams>() => ({
+        ok: true as const,
+        subaction: "time_on_app" as TSubaction,
+        // Blank app id reaches the (params.appNameOrBundleId ?? "").trim() guard.
+        params: { appNameOrBundleId: "   " } as unknown as TParams,
+      }),
+      isDarwin: () => true,
+      getActivityReport: vi.fn(),
+      getTimeOnApp,
+      getBrowserDomainActivity: vi.fn(),
+      getBrowserActivitySnapshot: vi.fn(),
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({ error: "MISSING_APP" });
+    expect(result.text).toContain("Specify an app name or bundle id");
+    // Empty target short-circuits before querying activity data.
+    expect(getTimeOnApp).not.toHaveBeenCalled();
+  });
+
+  it("time_on_site with un-parseable domain → MISSING_DOMAIN (#8795)", async () => {
+    const getBrowserDomainActivity = vi.fn();
+    const runner = createScreenTimeActionRunner({
+      hasAccess: async () => true,
+      createService: () => makeService(),
+      messageText: (input) =>
+        typeof input.content.text === "string" ? input.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      resolveActionArgs: async <TSubaction extends string, TParams>() => ({
+        ok: true as const,
+        subaction: "time_on_site" as TSubaction,
+        // A URL with no host normalizes to "" → MISSING_DOMAIN.
+        params: { domain: "https://" } as unknown as TParams,
+      }),
+      isDarwin: () => false,
+      getActivityReport: vi.fn(),
+      getTimeOnApp: vi.fn(),
+      getBrowserDomainActivity,
+      getBrowserActivitySnapshot: vi.fn(),
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual({ error: "MISSING_DOMAIN" });
+    expect(result.text).toContain("Specify a site domain");
+    expect(getBrowserDomainActivity).not.toHaveBeenCalled();
+  });
+
+  it("browser_activity with empty snapshot → browser_activity_empty (#8795)", async () => {
+    const getBrowserActivitySnapshot = vi.fn(async () => ({
+      deviceId: null,
+      windowEnd: "2026-05-30T12:00:00.000Z",
+      domains: [],
+    }));
+    const runner = createScreenTimeActionRunner({
+      hasAccess: async () => true,
+      createService: () => makeService(),
+      messageText: (input) =>
+        typeof input.content.text === "string" ? input.content.text : "",
+      renderReply: async ({ fallback }) => fallback,
+      resolveActionArgs: async <TSubaction extends string, TParams>() => ({
+        ok: true as const,
+        subaction: "browser_activity" as TSubaction,
+        params: {} as unknown as TParams,
+      }),
+      isDarwin: () => false,
+      getActivityReport: vi.fn(),
+      getTimeOnApp: vi.fn(),
+      getBrowserDomainActivity: vi.fn(),
+      getBrowserActivitySnapshot,
+    });
+
+    const result = await runner(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(getBrowserActivitySnapshot).toHaveBeenCalledTimes(1);
+    // Empty-domain snapshot succeeds with the empty-state scenario text.
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("No browser activity has been reported yet");
+    expect(result.data).toMatchObject({
+      snapshot: { domains: [], deviceId: null },
+    });
+  });
+
   it("swaps in optimized screentime_recap instructions for reply rendering", () => {
     const optimizedRuntime = {
       getService: (name: string) =>


### PR DESCRIPTION
## Problem (#8795)

The `plugin-health` action runners (`OWNER_HEALTH`, `OWNER_SCREENTIME`) ship a set of error / clarification / missing-argument branches that **no test asserts**. The existing tests pin only happy paths:

- `health.test.ts` — `makeRunner` hard-pins `hasAccess: true`; the planner test stubs `shouldAct: TRUE` only.
- `screen-time.test.ts` — `makeRunner` hard-pins `hasAccess: true` and always returns `ok: true` from `resolveActionArgs`.

So these shipped guards could regress silently:

- `src/actions/health.ts`: `PERMISSION_DENIED` (access denied), `planner_clarification` / `PLANNER_SHOULDACT_FALSE`, `MISSING_METRIC`.
- `src/actions/screen-time.ts`: `PERMISSION_DENIED`, `INVALID_SUBACTION`, `MISSING_APP`, `MISSING_DOMAIN`, `browser_activity_empty`.

## Fix

Tests only — **no production behavior changed** (`git diff` touches only the two `*.test.ts` files). The new cases mirror the existing `makeRunner` / `makeService` harness style.

**health-runner**
- `hasAccess: false` → `success: false`, `data.error === "PERMISSION_DENIED"`, service never touched.
- `runJsonModel` → `{ parsed: { shouldAct: false, response: "<clarify>" } }` → `planner_clarification` carrying the clarifying text, `PLANNER_SHOULDACT_FALSE` in `values`/`data`, no health data fetched.
- `by_metric` with no metric → `MISSING_METRIC`, `getHealthDataPoints` never called.

**screen-time**
- `hasAccess: false` → `PERMISSION_DENIED` before `resolveActionArgs` runs.
- `resolveActionArgs` `ok: false` → `INVALID_SUBACTION` (+ `missing`).
- `time_on_app` with blank app id → `MISSING_APP`, `getTimeOnApp` never called.
- `time_on_site` with un-parseable domain (`https://` → empty host) → `MISSING_DOMAIN`.
- `browser_activity` empty snapshot → `browser_activity_empty`.

## Evidence

Each new test was verified to **genuinely exercise its branch** — temporarily disabling the guard in source makes exactly that test (and only that test) fail. Example mutations:

| Branch | Mutation | Result |
|---|---|---|
| health PERMISSION_DENIED | `if (false && !(await adapters.hasAccess(...)))` | FAIL |
| health planner_clarification | `if (false && (plan.shouldAct === false || !subaction))` | FAIL |
| health MISSING_METRIC | `if (false && !metric)` | FAIL |
| screen-time PERMISSION_DENIED | `if (false && !(await adapters.hasAccess(...)))` | FAIL |
| screen-time INVALID_SUBACTION | `if (false && !resolved.ok)` | FAIL |
| screen-time MISSING_APP | `if (false && !target)` | FAIL |
| screen-time MISSING_DOMAIN | `if (false && !domain)` | FAIL |
| screen-time browser_activity_empty | `if (false && snapshot.domains.length === 0)` | FAIL (`AssertionError: expected 'Browser activity (device any…' to contain 'No browser activity has been reported…'`) |

All mutations reverted; source is unchanged on the final branch.

Full focused run (`bun run --cwd plugins/plugin-health test`):

```
 Test Files  29 passed | 4 skipped (33)
      Tests  146 passed | 4 skipped (150)
```

(Baseline before this change: 138 passed → +8 new tests.) `biome check` on both test files is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)