### PR TITLE
fix(core): serialize optimized-prompt setPrompt version claims + warn on unknown disable token (#8795)

### DIFF
--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -18,10 +18,11 @@ import {
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
 import {
 	_computeOptimizedPromptMacForTest,
 	OPTIMIZED_PROMPT_CURRENT_LINK,
@@ -30,6 +31,7 @@ import {
 	OPTIMIZED_PROMPT_RETAIN_VERSIONS,
 	type OptimizedPromptArtifact,
 	OptimizedPromptService,
+	parseDisabledTasksEnv,
 } from "./optimized-prompt";
 
 /**
@@ -388,5 +390,139 @@ describe("OptimizedPromptService — per-task error isolation (#8795)", () => {
 			"optimized prompt v1",
 		);
 		expect(service.getPrompt("response")).toBeNull();
+	});
+});
+
+describe("OptimizedPromptService — concurrent setPrompt version claims (#8795)", () => {
+	let storeRoot: string;
+	let service: OptimizedPromptService;
+
+	beforeEach(async () => {
+		storeRoot = await mkdtemp(join(tmpdir(), "optimized-prompt-concurrent-"));
+		service = new OptimizedPromptService();
+		service.setStoreRoot(storeRoot);
+	});
+
+	afterEach(async () => {
+		await rm(storeRoot, { recursive: true, force: true });
+	});
+
+	/**
+	 * Fire N setPrompt calls concurrently against the same task dir and assert
+	 * that every claimed vN.json is intact: distinct version per write, a
+	 * matching valid .mac for every artifact, no clobbered/orphaned file. The
+	 * same taxonomy is registered by both basicServices and plugin-training
+	 * register-runtime, and trigger/CLI train also call setPrompt — so two
+	 * concurrent claims for one task are a real production scenario.
+	 */
+	async function assertConcurrentClaimsIntact(concurrency: number) {
+		// concurrency <= retention so the final count is exactly N (no pruning).
+		expect(concurrency).toBeLessThanOrEqual(OPTIMIZED_PROMPT_RETAIN_VERSIONS);
+
+		const paths = await Promise.all(
+			Array.from({ length: concurrency }, (_, i) =>
+				service.setPrompt("action_planner", makeArtifact(i + 1)),
+			),
+		);
+
+		// Every call returned a DISTINCT version path — no two claims collided.
+		const uniquePaths = new Set(paths);
+		expect(uniquePaths.size).toBe(concurrency);
+
+		const dir = join(storeRoot, "action_planner");
+		const entries = await readdir(dir);
+		const versionFiles = entries
+			.filter((name) => /^v\d+\.json$/.test(name))
+			.sort();
+
+		// Exactly N artifacts persisted (no clobber, no loss).
+		expect(versionFiles.length).toBe(concurrency);
+
+		// Versions are the contiguous claim set v1..vN — nobody reused a slot.
+		const versionNumbers = versionFiles
+			.map((name) => Number.parseInt(name.slice(1, -5), 10))
+			.sort((a, b) => a - b);
+		expect(versionNumbers).toEqual(
+			Array.from({ length: concurrency }, (_, i) => i + 1),
+		);
+
+		// Every vN.json has a matching, VALID .mac over its exact bytes — i.e.
+		// no artifact was left without its sidecar and no payload/mac pair was
+		// crossed by a racing rename.
+		for (const name of versionFiles) {
+			const artifactPath = join(dir, name);
+			const macPath = `${artifactPath}.mac`;
+			expect(existsSync(macPath)).toBe(true);
+			const payload = await readFile(artifactPath, "utf-8");
+			const macHex = (await readFile(macPath, "utf-8")).trim();
+			expect(macHex).toBe(_computeOptimizedPromptMacForTest(payload));
+			// Payload is intact JSON, not a half-written/empty claim file.
+			const parsed = JSON.parse(payload) as { task?: string };
+			expect(parsed.task).toBe("action_planner");
+		}
+
+		// No leftover .tmp- claim/rename scratch files survived.
+		expect(entries.some((name) => name.includes(".tmp-"))).toBe(false);
+
+		// `current` resolves to a real, MAC-valid artifact that loads.
+		await service.refresh();
+		expect(service.getPrompt("action_planner")).not.toBeNull();
+	}
+
+	// Run several times for stability — a claim race is nondeterministic, so a
+	// single green run isn't proof. beforeEach gives each `it` a fresh dir.
+	for (let run = 1; run <= 8; run += 1) {
+		it(`keeps every concurrent claim intact (run ${run})`, async () => {
+			await assertConcurrentClaimsIntact(OPTIMIZED_PROMPT_RETAIN_VERSIONS);
+		});
+	}
+});
+
+describe("OptimizedPromptService — OPTIMIZED_PROMPT_DISABLE unknown-token warning (#8795)", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("warns once for an unknown (typo'd) disable token and does not disable it", () => {
+		const disabled = parseDisabledTasksEnv("should_respnose");
+		// The typo disabled nothing.
+		expect(disabled.size).toBe(0);
+
+		// Exactly one warn for the one unknown token, with the documented message.
+		const matching = warnSpy.mock.calls.filter(([, msg]) =>
+			typeof msg === "string"
+				? msg.includes('OPTIMIZED_PROMPT_DISABLE entry "should_respnose"')
+				: false,
+		);
+		expect(matching.length).toBe(1);
+	});
+
+	it("does not disable the real task a typo was meant to name", () => {
+		const service = new OptimizedPromptService();
+		service.setDisabledTasksFromEnv("should_respnose");
+		// `should_respond` must NOT have been disabled by the typo.
+		expect(service.isTaskDisabled("should_respond")).toBe(false);
+	});
+
+	it("keeps valid tokens, warns only for the unknown ones, and ignores empties", () => {
+		const disabled = parseDisabledTasksEnv(
+			"should_respond, , bogus_task ,response",
+		);
+		expect([...disabled].sort()).toEqual(["response", "should_respond"]);
+
+		// One warn for `bogus_task`; the empty token is silent.
+		const warnings = warnSpy.mock.calls.filter(([, msg]) =>
+			typeof msg === "string"
+				? msg.includes("OPTIMIZED_PROMPT_DISABLE entry")
+				: false,
+		);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]?.[1]).toContain('entry "bogus_task"');
 	});
 });

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -37,9 +37,10 @@
  * `@elizaos/plugin-training` and adding the dependency would invert the layering.
  */
 
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import {
+	open,
 	readFile,
 	readlink,
 	rename,
@@ -184,6 +185,37 @@ export interface OptimizedPromptMetadata {
 
 function defaultStoreRoot(): string {
 	return join(resolveStateDir(), "optimized-prompts");
+}
+
+/** Collision-proof temp filename suffix for write-then-rename scratch files. */
+function uniqueTempSuffix(): string {
+	return `${process.pid}-${Date.now()}-${randomBytes(6).toString("hex")}`;
+}
+
+/**
+ * Per-key serialization. setPrompt for a given task dir mutates shared
+ * symlinks + the retention window; overlapping in-process writes for the same
+ * dir would race the repoint/prune. Each key (the task dir) gets a tail
+ * promise; callers chain onto it so writes for one dir run one-at-a-time,
+ * while different dirs stay fully parallel. The map self-cleans when a key's
+ * chain drains.
+ */
+const dirWriteChains = new Map<string, Promise<unknown>>();
+
+async function runExclusive<T>(
+	key: string,
+	work: () => Promise<T>,
+): Promise<T> {
+	const prior = dirWriteChains.get(key) ?? Promise.resolve();
+	// Swallow the prior result/rejection for chaining purposes only — the
+	// originating caller still observes its own outcome.
+	const run = prior.then(work, work);
+	dirWriteChains.set(key, run);
+	try {
+		return await run;
+	} finally {
+		if (dirWriteChains.get(key) === run) dirWriteChains.delete(key);
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -381,11 +413,13 @@ interface CachedEntry {
 
 /**
  * Parse the `OPTIMIZED_PROMPT_DISABLE` env var into a strongly-typed set of
- * disabled tasks. Unknown task names are silently dropped — an operator
- * disabling a misspelled task should not crash the runtime, but the
- * misspelling should also not accidentally disable some other task.
+ * disabled tasks. Unknown task names are dropped — an operator disabling a
+ * misspelled task should not crash the runtime, and the misspelling must not
+ * accidentally disable some other task — but each dropped token is logged so a
+ * typo doesn't silently disable nothing.
  *
- * Format: comma-separated list of task names. Whitespace is trimmed.
+ * Format: comma-separated list of task names. Whitespace is trimmed; empty
+ * tokens are ignored without a warning.
  * Example: `OPTIMIZED_PROMPT_DISABLE=should_respond,response`.
  */
 export function parseDisabledTasksEnv(
@@ -395,8 +429,14 @@ export function parseDisabledTasksEnv(
 	const tasks = new Set<OptimizedPromptTask>();
 	for (const part of raw.split(",")) {
 		const trimmed = part.trim();
+		if (trimmed === "") continue;
 		if (isTask(trimmed)) {
 			tasks.add(trimmed);
+		} else {
+			logger.warn(
+				{ src: "service:optimized_prompt", entry: trimmed },
+				`[OptimizedPromptService] OPTIMIZED_PROMPT_DISABLE entry "${trimmed}" is not a known task — ignored`,
+			);
 		}
 	}
 	return tasks;
@@ -499,6 +539,14 @@ export class OptimizedPromptService extends Service {
 	 * repoints `current` / `previous` / `previous2` symlinks, prunes the
 	 * directory to the last `OPTIMIZED_PROMPT_RETAIN_VERSIONS` artifacts, and
 	 * refreshes the cache for the task.
+	 *
+	 * The same taxonomy is registered by both core basicServices and
+	 * plugin-training register-runtime, and trigger/CLI train also call this —
+	 * so two setPrompt calls for one task can overlap in-process. The version
+	 * claim is made cross-process-safe with O_EXCL; the symlink-repoint and
+	 * prune steps mutate shared `current`/`previous` links and the retention
+	 * window, so the whole write is serialized per task dir via an in-process
+	 * lock to keep those mutations consistent.
 	 */
 	async setPrompt(
 		task: OptimizedPromptTask,
@@ -510,27 +558,47 @@ export class OptimizedPromptService extends Service {
 			);
 		}
 		const dir = join(this.storeRoot, task);
+		return runExclusive(dir, () => this.writeArtifact(task, dir, artifact));
+	}
+
+	private async writeArtifact(
+		task: OptimizedPromptTask,
+		dir: string,
+		artifact: OptimizedPromptArtifact,
+	): Promise<string> {
 		mkdirSync(dir, { recursive: true });
 
-		const existingVersions = listVersionNumbers(dir);
-		const nextVersion = (existingVersions.at(-1) ?? 0) + 1;
-		const finalName = `v${nextVersion}.json`;
-		const finalPath = join(dir, finalName);
-		const tempPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
 		const payload = `${JSON.stringify(artifact, null, 2)}\n`;
+		const macHex = computeArtifactMac(payload);
+
+		// Atomically claim the next `vN.json` slot. Two concurrent setPrompt
+		// calls for the same task (e.g. basicServices + plugin-training, or a
+		// CLI/trigger train) read the same version list and would otherwise
+		// both target the same vN — clobbering one artifact and/or leaving a
+		// vN.json without a matching .mac. Claiming the filename with O_EXCL
+		// ('wx') serializes the race: the loser gets EEXIST, re-reads the
+		// directory, and bumps to the next free version.
+		const { nextVersion, finalPath } = await claimNextVersionPath(dir);
+
+		// The slot is reserved (empty vN.json exists). Write the payload to a
+		// temp file and rename over the reserved name for write durability —
+		// the rename target equals the reserved path, so no other claimant can
+		// own it.
+		const tempPath = `${finalPath}.tmp-${uniqueTempSuffix()}`;
 		await writeFile(tempPath, payload, "utf-8");
 		await rename(tempPath, finalPath);
 
 		// SOC2 CC6.8: persist HMAC sidecar so getPrompt() can detect
 		// tampering. The MAC covers the on-disk payload bytes verbatim.
-		const macHex = computeArtifactMac(payload);
 		const macPath = macPathFor(finalPath);
-		const macTemp = `${macPath}.tmp-${process.pid}-${Date.now()}`;
+		const macTemp = `${macPath}.tmp-${uniqueTempSuffix()}`;
 		await writeFile(macTemp, `${macHex}\n`, "utf-8");
 		await rename(macTemp, macPath);
 
 		// Repoint symlinks: current → vN, previous → vN-1, previous2 → vN-2.
-		const allVersions = [...existingVersions, nextVersion];
+		// Re-scan the directory: concurrent claims may have created versions
+		// between our claim and now, so the on-disk list is authoritative.
+		const allVersions = listVersionNumbers(dir);
 		await repointVersionLinks(dir, allVersions);
 
 		// Prune older artifacts beyond the retention window. Done after the
@@ -704,6 +772,47 @@ function listVersionNumbers(dir: string): number[] {
 }
 
 /**
+ * Maximum O_EXCL retries when claiming a version slot. Each attempt is one
+ * concurrent setPrompt losing the race; the number of contenders for a single
+ * task dir is tiny (basicServices + plugin-training + at most one CLI/trigger
+ * train), so this is comfortably above any real-world contention. Exhausting
+ * it means the directory is genuinely wedged — surface that as an error rather
+ * than spinning forever.
+ */
+const VERSION_CLAIM_MAX_ATTEMPTS = 64;
+
+/**
+ * Atomically reserve the next free `vN.json` slot in `dir`. Reads the current
+ * version list, then tries to create `v(last+1).json` with `O_EXCL` ('wx') so
+ * exactly one concurrent caller can own a given version. On `EEXIST` (another
+ * setPrompt claimed it first) re-read the directory and bump. Returns the
+ * claimed version number and its absolute path; the empty file now exists on
+ * disk and the caller overwrites it via temp-then-rename.
+ */
+async function claimNextVersionPath(
+	dir: string,
+): Promise<{ nextVersion: number; finalPath: string }> {
+	let candidate = (listVersionNumbers(dir).at(-1) ?? 0) + 1;
+	for (let attempt = 0; attempt < VERSION_CLAIM_MAX_ATTEMPTS; attempt += 1) {
+		const finalPath = join(dir, `v${candidate}.json`);
+		try {
+			const handle = await open(finalPath, "wx");
+			await handle.close();
+			return { nextVersion: candidate, finalPath };
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+			// Lost the claim race: re-read the directory and target the next
+			// free version above whatever the winner(s) just wrote.
+			const highest = listVersionNumbers(dir).at(-1) ?? 0;
+			candidate = Math.max(candidate + 1, highest + 1);
+		}
+	}
+	throw new Error(
+		`[OptimizedPromptService] could not claim a version slot in ${dir} after ${VERSION_CLAIM_MAX_ATTEMPTS} attempts`,
+	);
+}
+
+/**
  * Repoint `current`, `previous`, and `previous2` symlinks based on the
  * sorted-ascending list of version numbers. `current` always points at the
  * largest. `previous` and `previous2` are unset when the corresponding
@@ -763,13 +872,8 @@ async function pruneOldVersions(
  * absent during the swap.
  */
 async function replaceSymlink(linkPath: string, target: string): Promise<void> {
-	const tempPath = `${linkPath}.tmp-${process.pid}-${Date.now()}`;
+	const tempPath = `${linkPath}.tmp-${uniqueTempSuffix()}`;
 	mkdirSync(dirname(tempPath), { recursive: true });
-	try {
-		await unlink(tempPath);
-	} catch {
-		// nothing to clean up
-	}
 	await symlink(target, tempPath);
 	await rename(tempPath, linkPath);
 }


### PR DESCRIPTION
Closes two `OptimizedPromptService` findings from #8795 in `packages/core/src/services/optimized-prompt.ts`.

## (1) concurrent-setprompt-version-race-clobber [low / robustness]

**Root cause.** `setPrompt` computed the next version **non-atomically**: read `listVersionNumbers(dir)`, pick `last+1`, `writeFile(temp)` + `rename` to `vN.json` — no lock, no `O_EXCL`, no mutex. The same task taxonomy is registered by **both** core `basicServices` and `plugin-training` `register-runtime`, and trigger/CLI train also call `setPrompt` (`promotion-persist.ts`, `train.ts`, `lifeops-gepa-seed.ts`). Two concurrent `setPrompt` calls for the same task read the same version list and both target the same `vN` → one artifact clobbers the other, and/or a `vN.json` is produced without its matching `.mac` sidecar.

**Fix.**
- **Atomic slot claim:** `claimNextVersionPath` opens `v(last+1).json` with `O_EXCL` (`'wx'`) in a retry loop. The loser of a race gets `EEXIST`, re-reads the directory, and bumps — so exactly one caller owns a given version (cross-process safe). The reserved empty file is then overwritten via temp-then-rename, with the rename target equal to the reserved path so no other claimant can own it.
- **In-process serialization:** the symlink-repoint (`current`/`previous`/`previous2`) and prune steps mutate shared per-dir state, so the whole write runs under a per-task-dir async lock (`runExclusive`). Different task dirs stay fully parallel.
- Temp scratch filenames now carry a random suffix (`uniqueTempSuffix`) so concurrent renames never collide on a shared temp name.

Public `setPrompt` signature/return, the on-disk artifact format, and temp-then-rename durability are all unchanged.

## (2) no-baseline-task-and-disable-typo-silent [low / edge-case]

**Root cause.** `parseDisabledTasksEnv` dropped non-`isTask` tokens with **no** `logger.warn`, so an `OPTIMIZED_PROMPT_DISABLE` typo silently disabled nothing.

**Fix.** Each unknown token now logs once:
`[OptimizedPromptService] OPTIMIZED_PROMPT_DISABLE entry "X" is not a known task — ignored`. Empty tokens stay silent.

## Real evidence

New tests in `optimized-prompt.test.ts`:

- **Concurrency (run 8×):** fire N=`OPTIMIZED_PROMPT_RETAIN_VERSIONS` concurrent `setPrompt` via `Promise.all` on a shared store, asserting distinct version per call, exactly N artifacts, contiguous `v1..vN`, **every** `vN.json` has a matching **valid** `.mac` over its exact bytes, intact JSON payloads, no leftover `.tmp-` scratch files, and `current` loads.
- **Disable warn:** `parseDisabledTasksEnv` warns exactly once for an unknown token (with the documented message), keeps valid tokens, ignores empties silently, and the real task a typo names is not disabled.

Both proven **load-bearing** — red when the fix is reverted:

```
# fix reverted (non-atomic version pick):
× keeps every concurrent claim intact (run 1..8)
AssertionError: expected 1 to be 5   # all 5 concurrent writes claimed v1 → clobber

# warn removed:
× warns once for an unknown (typo'd) disable token ...
AssertionError: expected +0 to be 1
```

Green with the fix:

```
$ bun run --cwd packages/core test -- optimized-prompt
 Test Files  2 passed (2)
      Tests  95 passed (95)
```

`bun run --cwd packages/core typecheck` and `biome check` on both changed files are clean. No regression to the existing optimized-prompt symlink/versioning/HMAC/isolation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
