### PR TITLE
fix(health): convert Fitbit imperial-locale distance/weight instead of assuming metric (#8795)

### DIFF
--- a/plugins/plugin-health/src/health-bridge/__fixtures__/fitbit.imperial.recorded.json
+++ b/plugins/plugin-health/src/health-bridge/__fixtures__/fitbit.imperial.recorded.json
@@ -1,0 +1,68 @@
+{
+  "_source": "Fitbit Web API (api.fitbit.com) documented response shapes for a US-locale (en_US) account — same endpoints as fitbit.recorded.json. With profile.user.distanceUnit / weightUnit = `en_US` and no Accept-Language override, summary.distances[].distance is in MILES and body.log.weight[].weight is in POUNDS. See https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Localization (en_US => United States: distance miles, weight pounds).",
+  "_why": "Imperial-locale variant. Replayed through syncHealthConnectorData({token:{provider:'fitbit'}}) to assert distance_meters/weight_kg are CONVERTED to SI (5.0 mi => 8046.72 m, 150 lb => 68.0388... kg) instead of passed through as if metric.",
+  "_captured": "2026-06-24",
+  "profile": {
+    "user": {
+      "encodedId": "GGNJL9",
+      "fullName": "Grace Hopper",
+      "displayName": "Grace",
+      "gender": "FEMALE",
+      "age": 41,
+      "height": 65.7,
+      "weight": 150.0,
+      "timezone": "America/New_York",
+      "distanceUnit": "en_US",
+      "weightUnit": "en_US",
+      "memberSince": "2024-01-02"
+    }
+  },
+  "activity": {
+    "summary": {
+      "steps": 11842,
+      "caloriesOut": 2415,
+      "activityCalories": 1180,
+      "fairlyActiveMinutes": 28,
+      "veryActiveMinutes": 41,
+      "lightlyActiveMinutes": 210,
+      "sedentaryMinutes": 640,
+      "distances": [
+        { "activity": "total", "distance": 5.0 },
+        { "activity": "tracker", "distance": 5.0 },
+        { "activity": "veryActive", "distance": 2.4 }
+      ]
+    },
+    "goals": { "steps": 10000, "caloriesOut": 2300 }
+  },
+  "sleep": {
+    "summary": {
+      "totalMinutesAsleep": 456,
+      "totalSleepRecords": 1,
+      "totalTimeInBed": 486,
+      "stages": { "deep": 108, "light": 252, "rem": 96, "wake": 30 }
+    },
+    "sleep": []
+  },
+  "heart": {
+    "activities-heart": [
+      {
+        "dateTime": "2026-05-01",
+        "value": { "restingHeartRate": 54, "heartRateZones": [] }
+      }
+    ]
+  },
+  "weight": {
+    "weight": [
+      {
+        "logId": 38291077001,
+        "date": "2026-05-01",
+        "time": "07:15:00",
+        "weight": 150.0,
+        "bmi": 24.45,
+        "fat": 23.1,
+        "source": "API",
+        "weightUnit": "POUND"
+      }
+    ]
+  }
+}

--- a/plugins/plugin-health/src/health-bridge/__fixtures__/fitbit.recorded.json
+++ b/plugins/plugin-health/src/health-bridge/__fixtures__/fitbit.recorded.json
@@ -1,5 +1,5 @@
 {
-  "_source": "Fitbit Web API (api.fitbit.com) documented response shapes — https://dev.fitbit.com/build/reference/web-api/. `profile` is GET /1/user/-/profile.json; `activity` is GET /1/user/-/activities/date/{date}.json; `sleep` is GET /1.2/user/-/sleep/date/{date}.json; `heart` is GET /1/user/-/activities/heart/date/{date}/1d.json; `weight` is GET /1/user/-/body/log/weight/date/{date}.json. Field names + units match the real wire shape: activities-heart restingHeartRate bpm, summary.distances[].distance km, summary.caloriesOut kcal, summary.{fairlyActive,veryActive}Minutes minutes, sleep[].duration milliseconds, sleep[].timeInBed/minutesAwake/minutesToFallAsleep minutes, sleep[].levels.data[].seconds seconds, body.log.weight[].weight kg.",
+  "_source": "Fitbit Web API (api.fitbit.com) documented response shapes — https://dev.fitbit.com/build/reference/web-api/. `profile` is GET /1/user/-/profile.json; `activity` is GET /1/user/-/activities/date/{date}.json; `sleep` is GET /1.2/user/-/sleep/date/{date}.json; `heart` is GET /1/user/-/activities/heart/date/{date}/1d.json; `weight` is GET /1/user/-/body/log/weight/date/{date}.json. Field names + units match the real wire shape: activities-heart restingHeartRate bpm, summary.distances[].distance km, summary.caloriesOut kcal, summary.{fairlyActive,veryActive}Minutes minutes, sleep[].duration milliseconds, sleep[].timeInBed/minutesAwake/minutesToFallAsleep minutes, sleep[].levels.data[].seconds seconds, body.log.weight[].weight kg. profile.user.distanceUnit / profile.user.weightUnit carry the account locale (`METRIC` => km/kg, `en_US` => miles/pounds, `en_GB` => miles/stone); with no Accept-Language override the wire distance/weight values are in those units. See https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Localization.",
   "_why": "Replayed through syncHealthConnectorData({token:{provider:'fitbit'}}) so the normalized HealthConnectorSyncPayload (samples + sleepEpisodes + identity) is validated against the real Fitbit per-date shapes. fitbit-connector.real.test.ts re-fetches the live API with a token to detect drift from this recording.",
   "_captured": "2026-06-17",
   "profile": {
@@ -12,6 +12,8 @@
       "height": 167.0,
       "weight": 61.2,
       "timezone": "Europe/London",
+      "distanceUnit": "METRIC",
+      "weightUnit": "METRIC",
       "memberSince": "2024-01-02"
     }
   },

--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -410,12 +410,49 @@ async function syncStrava(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
   };
 }
 
+// Fitbit reports distance/weight in the unit system tied to the account's
+// locale, surfaced on the profile as `distanceUnit` / `weightUnit` with the
+// values `en_US` (US: miles, pounds), `en_GB` (UK: miles, stone), or `METRIC`
+// (km, kg). Because we send no `Accept-Language` override, the wire values are
+// exactly those profile-configured units, so the profile is the source of
+// truth for how to read them. See
+// https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Localization
+const METERS_PER_MILE = 1_609.344;
+const KG_PER_POUND = 0.45359237;
+const KG_PER_STONE = 6.35029318;
+
+function fitbitUsesImperialDistance(distanceUnit: string | null): boolean {
+  return distanceUnit === "en_US" || distanceUnit === "en_GB";
+}
+
+function fitbitDistanceMeters(
+  distance: number,
+  distanceUnit: string | null,
+): number {
+  return fitbitUsesImperialDistance(distanceUnit)
+    ? distance * METERS_PER_MILE
+    : distance * 1_000;
+}
+
+function fitbitWeightKg(weight: number, weightUnit: string | null): number {
+  if (weightUnit === "en_US") {
+    return weight * KG_PER_POUND;
+  }
+  if (weightUnit === "en_GB") {
+    return weight * KG_PER_STONE;
+  }
+  return weight;
+}
+
 async function syncFitbit(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
   const dates = dateRange(args.startDate, args.endDate);
   const identityJson = await fetchHealthJson({
     token: args.token,
     path: "/1/user/-/profile.json",
   });
+  const profileUser = getRecord(identityJson, "user");
+  const distanceUnit = profileUser ? getText(profileUser, "distanceUnit") : null;
+  const weightUnit = profileUser ? getText(profileUser, "weightUnit") : null;
   const samples: LifeOpsHealthMetricSample[] = [];
   const sleepEpisodes: LifeOpsHealthSleepEpisode[] = [];
   const workouts: LifeOpsHealthWorkout[] = [];
@@ -489,10 +526,14 @@ async function syncFitbit(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
           token: args.token,
           grantId: args.grantId,
           metric: "distance_meters",
-          value: totalDistance > 0 ? totalDistance * 1_000 : null,
+          value:
+            totalDistance > 0
+              ? fitbitDistanceMeters(totalDistance, distanceUnit)
+              : null,
           unit: "m",
           startAt: dayAt,
           sourceExternalId: `${date}:fitbit:distance_meters`,
+          metadata: { providerUnit: distanceUnit },
         }),
       ]),
     );
@@ -591,18 +632,25 @@ async function syncFitbit(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
       const loggedAt = normalizeIso(
         `${getText(log, "date") ?? date}T${getText(log, "time") ?? "12:00:00"}`,
       );
+      const rawWeight = getNumber(log, "weight");
       samples.push(
         ...compactSamples([
           sample({
             token: args.token,
             grantId: args.grantId,
             metric: "weight_kg",
-            value: getNumber(log, "weight"),
+            value:
+              rawWeight !== null ? fitbitWeightKg(rawWeight, weightUnit) : null,
             unit: "kg",
             startAt: loggedAt,
             sourceExternalId:
               getText(log, "logId") ?? `${date}:fitbit:weight_kg`,
-            metadata: { providerUnit: getText(log, "weightUnit") },
+            // providerUnit is the unit label Fitbit attached to THIS weight log;
+            // the value is converted to kg using the account locale (weightUnit).
+            metadata: {
+              providerUnit: getText(log, "weightUnit"),
+              providerLocaleUnit: weightUnit,
+            },
           }),
         ]),
       );

--- a/plugins/plugin-health/test/fitbit-connector.contract.test.ts
+++ b/plugins/plugin-health/test/fitbit-connector.contract.test.ts
@@ -130,15 +130,17 @@ describe("Fitbit connector — recorded real API contract", () => {
     expect(calories?.unit).toBe("kcal");
 
     // distance_meters: take ONLY the canonical activity:"total" row (the day
-    // total) and convert km->m. tracker/veryActive/... are per-activity
-    // breakdowns OF that total, so summing them double/triple-counts. The
-    // fixture's multi-entry shape discriminates: a correct total-only read is
-    // 8520 m; a summing regression (8.52 + 8.52 + 4.1 km) would be 21140 m.
+    // total) and convert to meters via the account locale. tracker/veryActive/...
+    // are per-activity breakdowns OF that total, so summing them double/triple-
+    // counts. The fixture's multi-entry shape discriminates: a correct total-only
+    // read is 8520 m; a summing regression (8.52 + 8.52 + 4.1 km) would be 21140 m.
+    // profile.user.distanceUnit is "METRIC" here, so km->m (*1000).
     const distance = payload.samples.find(
       (s) => s.metric === "distance_meters",
     );
     expect(distance?.value).toBe(8.52 * 1000);
     expect(distance?.unit).toBe("m");
+    expect(distance?.metadata.providerUnit).toBe("METRIC");
 
     // activities-heart[0].value.restingHeartRate -> resting_heart_rate.
     const resting = payload.samples.find(
@@ -153,11 +155,15 @@ describe("Fitbit connector — recorded real API contract", () => {
     expect(sleepHours?.unit).toBe("h");
 
     // body.log.weight[0].weight kg -> weight_kg; logId -> sourceExternalId.
+    // profile.user.weightUnit is "METRIC", so the value passes through unchanged.
     const weight = payload.samples.find((s) => s.metric === "weight_kg");
     expect(weight?.value).toBe(61.2);
     expect(weight?.unit).toBe("kg");
     expect(weight?.sourceExternalId).toBe("38291077001");
+    // providerUnit is the per-log unit label; providerLocaleUnit is the account
+    // locale that drives the conversion.
     expect(weight?.metadata.providerUnit).toBe("kg");
+    expect(weight?.metadata.providerLocaleUnit).toBe("METRIC");
 
     // One recorded sleep log -> one normalized sleep episode.
     expect(payload.sleepEpisodes).toHaveLength(1);
@@ -231,5 +237,79 @@ describe("Fitbit connector — recorded real API contract", () => {
       expect(typeof s.startAt).toBe("string");
       expect(s.localDate).toBe(s.startAt.slice(0, 10));
     }
+  });
+});
+
+// An imperial (en_US) Fitbit account reports summary.distances[].distance in
+// MILES and body.log.weight[].weight in POUNDS — the units are tied to
+// profile.user.distanceUnit / weightUnit, NOT to the wire field names. The
+// normalizer must convert to SI, not pass them through as if metric.
+const imperialRecorded = JSON.parse(
+  readFileSync(
+    resolve(
+      import.meta.dirname,
+      "../src/health-bridge/__fixtures__/fitbit.imperial.recorded.json",
+    ),
+    "utf8",
+  ),
+) as {
+  profile: Record<string, unknown>;
+  activity: Record<string, unknown>;
+  sleep: Record<string, unknown>;
+  heart: Record<string, unknown>;
+  weight: Record<string, unknown>;
+};
+
+describe("Fitbit connector — imperial (en_US) locale conversion", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/activities/heart/")) {
+        return jsonResponse(imperialRecorded.heart);
+      }
+      if (url.includes("/activities/date/")) {
+        return jsonResponse(imperialRecorded.activity);
+      }
+      if (url.includes("/sleep/date/")) {
+        return jsonResponse(imperialRecorded.sleep);
+      }
+      if (url.includes("/body/log/weight/")) {
+        return jsonResponse(imperialRecorded.weight);
+      }
+      if (url.includes("/profile.json")) {
+        return jsonResponse(imperialRecorded.profile);
+      }
+      throw new Error(`unexpected Fitbit fetch: ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("converts miles->meters and pounds->kg using the account locale", async () => {
+    const payload = await syncHealthConnectorData({
+      token,
+      grantId: "grant-fitbit",
+      startDate: "2026-05-01",
+      endDate: "2026-05-01",
+    });
+
+    // distances[total].distance = 5.0 (MILES, because distanceUnit = en_US).
+    // 5.0 mi * 1609.344 = 8046.72 m — NOT 5000 m (the metric-assumption bug).
+    const distance = payload.samples.find(
+      (s) => s.metric === "distance_meters",
+    );
+    expect(distance?.value).toBeCloseTo(8046.72, 6);
+    expect(distance?.unit).toBe("m");
+    expect(distance?.metadata.providerUnit).toBe("en_US");
+
+    // weight[0].weight = 150 (POUNDS, because weightUnit = en_US).
+    // 150 lb * 0.45359237 = 68.0388555 kg — NOT 150 kg.
+    const weight = payload.samples.find((s) => s.metric === "weight_kg");
+    expect(weight?.value).toBeCloseTo(68.0388555, 6);
+    expect(weight?.unit).toBe("kg");
+    expect(weight?.metadata.providerUnit).toBe("POUND");
+    expect(weight?.metadata.providerLocaleUnit).toBe("en_US");
   });
 });


### PR DESCRIPTION
## Problem (#8795)

`plugins/plugin-health/src/health-bridge/health-connectors.ts` — the Fitbit normalizer assumed **metric** unconditionally:

- distance: `totalDistance * 1_000`, unit `"m"` (assumes the wire value is **km**)
- weight: passed through as `unit: "kg"`

But Fitbit reports distance/weight in the unit system tied to the **account locale**. For an imperial-locale account, `summary.distances[].distance` is in **miles** and `body.log.weight[].weight` is in **pounds** (`en_US`) or **stone** (`en_GB`). So `distance_meters` and `weight_kg` came out wrong (e.g. a 5-mile day was recorded as 5000 m instead of 8046.72 m; a 150 lb log as 150 kg instead of 68 kg).

## Root cause

The account's unit system is documented on `GET /1/user/-/profile.json` as `profile.user.distanceUnit` / `profile.user.weightUnit`, with values `en_US` (US: miles, pounds), `en_GB` (UK: miles, stone), or `METRIC` (km, kg) — see the [Fitbit Localization docs](https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Localization). The connector sends **no `Accept-Language` override**, so the wire distance/weight values are exactly those profile-configured units. The profile fields were never read; the real provider unit was only stored as `metadata.providerUnit` and never used.

## Fix

The Fitbit profile is already fetched. Read `profile.user.distanceUnit` / `weightUnit` and convert explicitly when imperial:

- miles → meters: `× 1609.344`
- pounds (`en_US`) → kg: `× 0.45359237`
- stone (`en_GB`) → kg: `× 6.35029318`

Metric keeps the existing behavior verbatim. `metadata.providerUnit` on the weight sample stays the per-log unit label Fitbit attaches; the account locale that drives the conversion is recorded as `metadata.providerLocaleUnit`. Distance carries the locale as `providerUnit` (Fitbit attaches no per-row unit to distance).

Builds **on top of** the already-landed `f388af36c9` (take the `activity:"total"` distance row, not the sum) — does not revert it.

## Evidence (real, keyless)

Drives the **real `syncFitbit` normalizer** via `syncHealthConnectorData` against recorded Fitbit Web API shapes (replayed through stubbed `fetch`).

- Extended the existing metric contract test to assert the locale is read (`providerUnit`/`providerLocaleUnit`).
- Added an imperial (`en_US`) fixture `src/health-bridge/__fixtures__/fitbit.imperial.recorded.json` (5.0 mi total distance, 150 lb weight log) and a new contract case asserting conversion: `5.0 mi → 8046.72 m`, `150 lb → 68.0388555 kg`.
- Added `distanceUnit`/`weightUnit: "METRIC"` to the existing metric fixture so the documented-shape recording matches the real profile fields.

```
$ bun run --cwd plugins/plugin-health test -- fitbit-connector.contract --reporter=verbose
 ✓ Fitbit connector — recorded real API contract > normalizes the real Fitbit per-date shapes into a contract-shaped payload
 ✓ Fitbit connector — imperial (en_US) locale conversion > converts miles->meters and pounds->kg using the account locale
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Meaningfulness proof** — temporarily reverting the conversion to the old metric-assumption code turns the imperial test red exactly on the bug:

```
× converts miles->meters and pounds->kg using the account locale
  → expected 5000 to be close to 8046.72, received difference is 3046.72
```

Full plugin suite + lint + typecheck:

```
$ bun run --cwd plugins/plugin-health test        # 139 passed | 4 skipped
$ bun run --cwd plugins/plugin-health lint:check   # Checked 111 files. No fixes applied.
$ bunx tsc --noEmit -p tsconfig.json               # TS errors: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)