### PR TITLE
test(pa): malformed/empty/throwing useModel coverage for LifeOps LLM consumers (#8795)

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -549,10 +549,26 @@ async function composeNarrative(args: {
   });
   // Tag the trajectory with the exact LifeOps prompt task resolved above so the
   // call buckets into its per-capability dataset for the GEPA loop (#8795).
-  const raw = await runWithTrajectoryContext(
-    { purpose: args.optimizationTask },
-    () => args.runtime.useModel(ModelType.TEXT_LARGE, { prompt }),
-  );
+  // A failed compose pass degrades to a narrative-less structured briefing —
+  // symmetric with the other LifeOps LLM consumers (scheduling, reminders),
+  // which all fall back to a safe default rather than propagating the error.
+  let raw: unknown;
+  try {
+    raw = await runWithTrajectoryContext(
+      { purpose: args.optimizationTask },
+      () => args.runtime.useModel(ModelType.TEXT_LARGE, { prompt }),
+    );
+  } catch (error) {
+    logger.warn(
+      {
+        src: "action:brief",
+        task: args.optimizationTask,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[BRIEF] narrative compose model call failed; returning structured briefing without a narrative",
+    );
+    return undefined;
+  }
   return typeof raw === "string" ? raw.trim() : undefined;
 }
 

--- a/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Robustness matrix for the LifeOps LLM consumers (#8795).
+ *
+ * The optimized-prompt routing tests (lifeops-optimized-prompts.test.ts,
+ * brief-optimized-prompt.test.ts) are happy-path only: their `useModel` mock
+ * always returns a well-formed string. This suite covers the *failure* axis —
+ * malformed JSON, empty / non-string output, and a thrown `useModel` — and
+ * asserts each surviving consumer degrades to its documented safe default
+ * instead of leaking an unhandled rejection or fabricating data.
+ *
+ * Consumers under test (extract-gmail-plan was removed on develop, #9576):
+ *   - resolveSchedulingPlanWithLlm (src/actions/lib/scheduling-handler.ts)
+ *   - renderReminderBody         (src/lifeops/service-mixin-reminders.ts)
+ *   - composeNarrative           (src/actions/brief.ts, via the BRIEF handler)
+ */
+import type {
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LifeOpsServiceBase } from "../src/lifeops/service-mixin-core.js";
+import { withReminders } from "../src/lifeops/service-mixin-reminders.js";
+
+const ReminderService = withReminders(LifeOpsServiceBase);
+
+const mocks = vi.hoisted(() => ({
+  hasOwnerAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@elizaos/agent", async () => {
+  const actual =
+    await vi.importActual<typeof import("@elizaos/agent")>("@elizaos/agent");
+  return { ...actual, hasOwnerAccess: mocks.hasOwnerAccess };
+});
+
+function userMessage(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000201" as UUID,
+    entityId: "00000000-0000-0000-0000-000000000202" as UUID,
+    roomId: "00000000-0000-0000-0000-000000000203" as UUID,
+    content: { text },
+  } as unknown as Memory;
+}
+
+/**
+ * Runtime whose `useModel` is supplied by the test. Mirrors the shape used by
+ * the happy-path harness (`lifeops-optimized-prompts.test.ts`) but lets each
+ * case decide what the model returns or whether it throws.
+ */
+function runtimeWithModel(
+  useModel: (modelType: unknown, params: { prompt?: string }) => Promise<unknown>,
+): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000204" as UUID,
+    character: { name: "Eliza", settings: {} },
+    logger: { warn: vi.fn(), debug: vi.fn(), error: vi.fn(), info: vi.fn() },
+    getService: () => null,
+    getMemories: vi.fn(async () => []),
+    useModel: vi.fn(useModel),
+  } as unknown as IAgentRuntime;
+}
+
+afterEach(() => {
+  mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
+});
+
+describe("resolveSchedulingPlanWithLlm — malformed / empty / throwing model", () => {
+  async function runScheduling(
+    useModel: (
+      modelType: unknown,
+      params: { prompt?: string },
+    ) => Promise<unknown>,
+  ) {
+    const { runSchedulingNegotiationHandler } = await import(
+      "../src/actions/lib/scheduling-handler.js"
+    );
+    const runtime = runtimeWithModel(useModel);
+    // No explicit subaction in params, so routing depends entirely on the
+    // (failing) planner — exactly the path the safe default protects.
+    return runSchedulingNegotiationHandler(
+      runtime,
+      userMessage("Start a scheduling thread with Mia for next week"),
+      undefined,
+      { parameters: {} } as unknown as HandlerOptions,
+    );
+  }
+
+  // The safe default is structural: the planner yields no subaction / no
+  // shouldAct, so the handler returns a clarify ActionResult
+  // (success=false, requiresConfirmation) instead of starting a negotiation
+  // on garbage. The user-facing reply text is rendered downstream by the
+  // grounded-reply layer and is not part of this consumer's contract.
+  it("(a) invalid JSON → safe clarify default, no negotiation started", async () => {
+    const result = await runScheduling(async () => "this is not json at all");
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MISSING_SUBACTION",
+      requiresConfirmation: true,
+    });
+  });
+
+  it("(b) empty string → safe clarify default", async () => {
+    const result = await runScheduling(async () => "");
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MISSING_SUBACTION",
+      requiresConfirmation: true,
+    });
+  });
+
+  it("(c) useModel throws → no unhandled rejection, safe clarify default", async () => {
+    const result = await runScheduling(async () => {
+      throw new Error("model exploded");
+    });
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MISSING_SUBACTION",
+      requiresConfirmation: true,
+    });
+  });
+});
+
+describe("renderReminderBody — malformed / empty / throwing model", () => {
+  const reminderArgs = {
+    title: "Take medication",
+    scheduledFor: "2026-06-23T15:00:00.000Z",
+    dueAt: "2026-06-23T15:00:00.000Z",
+    channel: "push" as const,
+    lifecycle: "initial" as const,
+    urgency: "normal" as const,
+    subjectType: "owner" as const,
+    nearbyReminderTitles: ["Drink water"],
+  };
+
+  // Deterministic fallback produced by buildReminderBody for these args.
+  const deterministicFallback = "Reminder: Take medication";
+
+  it("useModel throws → deterministic fallback body", async () => {
+    const service = new ReminderService(
+      runtimeWithModel(async () => {
+        throw new Error("model exploded");
+      }),
+    );
+    const text = await service.renderReminderBody(reminderArgs);
+    expect(text).toContain(deterministicFallback);
+  });
+
+  it("non-string (malformed) model output → deterministic fallback body", async () => {
+    const service = new ReminderService(
+      runtimeWithModel(async () => ({ unexpected: "object" })),
+    );
+    const text = await service.renderReminderBody(reminderArgs);
+    expect(text).toContain(deterministicFallback);
+  });
+
+  it("empty / whitespace model output → deterministic fallback body", async () => {
+    const service = new ReminderService(runtimeWithModel(async () => "   "));
+    const text = await service.renderReminderBody(reminderArgs);
+    expect(text).toContain(deterministicFallback);
+  });
+});
+
+describe("composeNarrative (BRIEF) — throwing / malformed model", () => {
+  async function runBrief(
+    useModel: (
+      modelType: unknown,
+      params: { prompt?: string },
+    ) => Promise<unknown>,
+  ) {
+    const { briefAction } = await import("../src/actions/brief.js");
+    const runtime = runtimeWithModel(useModel);
+    return briefAction.handler(
+      runtime,
+      userMessage("give me my morning brief"),
+      undefined,
+      { parameters: { subaction: "compose_morning" } } as unknown as HandlerOptions,
+      async () => undefined,
+    );
+  }
+
+  it("useModel throws → structured briefing without a narrative (no unhandled rejection)", async () => {
+    const result = await runBrief(async () => {
+      throw new Error("model exploded");
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      briefing: { kind: string; narrative?: string; sections: unknown };
+    };
+    expect(data.briefing.kind).toBe("morning");
+    expect(data.briefing.narrative).toBeUndefined();
+    expect(data.briefing.sections).toBeDefined();
+    // Action still returns a usable text even with no LLM narrative.
+    expect(typeof result.text).toBe("string");
+    expect(result.text?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("non-string (malformed) model output → structured briefing without a narrative", async () => {
+    const result = await runBrief(async () => ({ unexpected: "object" }));
+    expect(result.success).toBe(true);
+    const data = result.data as { briefing: { narrative?: string } };
+    expect(data.briefing.narrative).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context (#8795 — pa-llm-consumers)

The LifeOps LLM consumers had **asymmetric malformed-input handling and zero malformed-input tests**. The existing optimized-prompt routing suites (`test/lifeops-optimized-prompts.test.ts`, `test/brief-optimized-prompt.test.ts`) are happy-path only — their `useModel` mock always returns a well-formed string — so the failure axis (invalid JSON, empty / non-string output, a thrown `useModel`) was never exercised.

`extract-gmail-plan.ts` was removed on develop (#9576); this PR covers the three surviving consumers.

## Root cause

| Consumer | File | Prior behavior |
|---|---|---|
| `resolveSchedulingPlanWithLlm` | `src/actions/lib/scheduling-handler.ts` | try/catch + `if (!parsed)` invalid-JSON guard → clarify safe default ✅ |
| `renderReminderBody` | `src/lifeops/service-mixin-reminders.ts` | try/catch + `?? fallback` → deterministic `buildReminderBody` body ✅ |
| `composeNarrative` | `src/actions/brief.ts` | **No error handling** ❌ |

`composeNarrative` had no try/catch: a thrown `useModel` (rate limit, network, model error) propagated **unhandled straight out of the `BRIEF` action handler** instead of degrading to a narrative-less structured briefing. This is a real defect — the documented contract is that a missing narrative is a no-op, never a failure (the handler already falls back to a generated text when `briefing.narrative` is undefined).

## Fix

Wrap `composeNarrative`'s `useModel` call narrowly so a throw returns `undefined` (narrative omitted, structured briefing preserved) with a structured `[BRIEF]` `logger.warn` — making the brief path **symmetric** with the scheduling and reminder consumers.

```ts
let raw: unknown;
try {
  raw = await runWithTrajectoryContext(
    { purpose: args.optimizationTask },
    () => args.runtime.useModel(ModelType.TEXT_LARGE, { prompt }),
  );
} catch (error) {
  logger.warn({ src: "action:brief", task: args.optimizationTask, error: ... },
    "[BRIEF] narrative compose model call failed; returning structured briefing without a narrative");
  return undefined;
}
return typeof raw === "string" ? raw.trim() : undefined;
```

## Coverage — new robustness matrix

`test/lifeops-llm-consumer-robustness.test.ts` drives each consumer end-to-end with a malformed / empty / throwing `useModel` and asserts the documented safe default:

- **resolveSchedulingPlanWithLlm**: (a) invalid JSON, (b) empty string, (c) `useModel` throws → all yield `success:false` + `{ error: MISSING_SUBACTION, requiresConfirmation: true }` (no negotiation started, no unhandled rejection).
- **renderReminderBody**: throws / non-string / empty-whitespace → deterministic fallback body (`Reminder: <title>`).
- **composeNarrative (BRIEF)**: throws / non-string → `success:true`, structured briefing with `narrative` undefined, action still returns usable text.

### Meaningfulness — each test fails if its guard is removed (real evidence)

\`\`\`
# brief fix reverted → throw leaks out of the handler:
× composeNarrative (BRIEF) > useModel throws → ...
  Error: model exploded
   ❯ briefAction.handler src/actions/brief.ts:719:22

# reminders try/catch + `?? fallback` removed:
× renderReminderBody > useModel throws → deterministic fallback body
× renderReminderBody > non-string (malformed) model output → deterministic fallback body
× renderReminderBody > empty / whitespace model output → deterministic fallback body

# scheduling try/catch + `if (!parsed)` guard removed:
× resolveSchedulingPlanWithLlm > (a) invalid JSON → ...
× resolveSchedulingPlanWithLlm > (b) empty string → ...
× resolveSchedulingPlanWithLlm > (c) useModel throws → ...
\`\`\`

Each was restored after the proof.

## Verification

\`\`\`
$ bun run --cwd plugins/plugin-personal-assistant test -- \
    lifeops-llm-consumer-robustness lifeops-optimized-prompts brief-optimized-prompt brief-action

 Test Files  4 passed (4)
      Tests  26 passed (26)
\`\`\`

- biome lint clean on both touched files.
- Only `src/actions/brief.ts` changed under `src/` (scheduling + reminders consumers untouched — they already had safe defaults).
- The 471 pre-existing PA mixin-baseline typecheck observations are unrelated; this change introduces no new typecheck errors in the touched files (`build:types` is `--noCheck`; tests compile + run clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)