### PR TITLE
feat(voice): echo-reference alignment buffer for the AEC far-end (#9583)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { EchoReferenceBuffer } from "./echo-reference-buffer.ts";
+
+/** Ramp where sample i has value i+1 (so 0 = "not filled"). */
+function ramp(from: number, count: number): Float32Array {
+	const out = new Float32Array(count);
+	for (let i = 0; i < count; i++) out[i] = from + i + 1;
+	return out;
+}
+
+describe("EchoReferenceBuffer (#9583)", () => {
+	it("returns the last `length` samples at zero delay", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 1000 });
+		buf.push(ramp(0, 500)); // values 1..500
+		const ref = buf.referenceFor(4, 0);
+		expect(Array.from(ref)).toEqual([497, 498, 499, 500]);
+	});
+
+	it("shifts the window back by the delay", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 1000 });
+		buf.push(ramp(0, 500)); // values 1..500
+		// delay 10 → window ends at sample (500-10)=490 → [487,488,489,490]
+		expect(Array.from(buf.referenceFor(4, 10))).toEqual([487, 488, 489, 490]);
+	});
+
+	it("zero-fills samples not yet pushed (delay+length exceeds stream)", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 1000 });
+		buf.push(ramp(0, 3)); // values 1,2,3
+		// length 5, delay 0 → window [-2,3): two leading zeros then 1,2,3
+		expect(Array.from(buf.referenceFor(5, 0))).toEqual([0, 0, 1, 2, 3]);
+	});
+
+	it("zero-fills the part evicted past capacity", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 8 });
+		buf.push(ramp(0, 12)); // values 1..12; only the last 8 (5..12) retained
+		// delay 0, length 8 → the retained window is values 5..12
+		expect(Array.from(buf.referenceFor(8, 0))).toEqual([
+			5, 6, 7, 8, 9, 10, 11, 12,
+		]);
+		// Asking for 10 reaches before the retained window → 2 leading zeros.
+		expect(Array.from(buf.referenceFor(10, 0))).toEqual([
+			0, 0, 5, 6, 7, 8, 9, 10, 11, 12,
+		]);
+	});
+
+	it("accumulates across multiple pushes and tracks position", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 1000 });
+		buf.push(ramp(0, 100));
+		buf.push(ramp(100, 100)); // values 101..200, position now 200
+		expect(buf.position).toBe(200);
+		expect(Array.from(buf.referenceFor(3, 0))).toEqual([198, 199, 200]);
+	});
+
+	it("reset clears the buffer", () => {
+		const buf = new EchoReferenceBuffer({ capacitySamples: 1000 });
+		buf.push(ramp(0, 50));
+		buf.reset();
+		expect(buf.position).toBe(0);
+		expect(Array.from(buf.referenceFor(3, 0))).toEqual([0, 0, 0]);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
@@ -1,0 +1,78 @@
+/**
+ * Echo-reference alignment buffer (#9583, follow-up to #9455/#9586).
+ *
+ * The NLMS echo canceller's `process(nearEnd, farEnd)` needs the far-end
+ * (the agent's TTS playback) **time-aligned** to the current mic frame: the
+ * echo in `nearEnd[t]` is the room-filtered playback from `t − delay`, where
+ * `delay` is the bulk playback→mic transport delay (estimated by
+ * {@link estimateEchoDelaySamples} in `echo-delay.ts`).
+ *
+ * The caller renders playback PCM in real time and `push()`es it here as it goes;
+ * per mic frame it then asks for the aligned far-end slice. This is the
+ * "caller must supply the reference" primitive the consumer seam was missing —
+ * a fixed-capacity delay line, pure logic (no FFI, no device, no audio I/O).
+ * Samples not yet rendered, or already evicted past capacity, are zero-filled
+ * (no echo reference ⇒ the adaptive filter simply has nothing to cancel there).
+ */
+
+export interface EchoReferenceBufferOptions {
+	/**
+	 * Ring-buffer capacity in samples. Must comfortably exceed
+	 * `maxDelaySamples + frameLength`. Default 24000 (1.5 s @ 16 kHz).
+	 */
+	capacitySamples?: number;
+}
+
+export class EchoReferenceBuffer {
+	private readonly buffer: Float32Array;
+	private readonly capacity: number;
+	/** Total samples ever pushed (monotonic); the logical "now" cursor. */
+	private pushed = 0;
+
+	constructor(options: EchoReferenceBufferOptions = {}) {
+		this.capacity = Math.max(1, Math.floor(options.capacitySamples ?? 24000));
+		this.buffer = new Float32Array(this.capacity);
+	}
+
+	/** Append rendered playback (far-end) PCM as it is produced. */
+	push(playback: Float32Array): void {
+		for (let i = 0; i < playback.length; i++) {
+			this.buffer[(this.pushed + i) % this.capacity] = playback[i];
+		}
+		this.pushed += playback.length;
+	}
+
+	/**
+	 * The far-end reference frame aligned to a mic frame of `length` samples
+	 * captured `delaySamples` after the corresponding playback. Returns the
+	 * playback window `[pushed − delaySamples − length, pushed − delaySamples)`.
+	 * Indices before the retained window (not yet pushed, or evicted past
+	 * capacity) are zero-filled.
+	 */
+	referenceFor(length: number, delaySamples: number): Float32Array {
+		const out = new Float32Array(Math.max(0, Math.floor(length)));
+		const delay = Math.max(0, Math.floor(delaySamples));
+		// Absolute index (in the monotonic stream) of the first output sample.
+		const start = this.pushed - delay - out.length;
+		const oldest = Math.max(0, this.pushed - this.capacity);
+		for (let i = 0; i < out.length; i++) {
+			const abs = start + i;
+			// Available only if within [oldest, pushed) — else leave the 0 fill.
+			if (abs >= oldest && abs >= 0 && abs < this.pushed) {
+				out[i] = this.buffer[abs % this.capacity];
+			}
+		}
+		return out;
+	}
+
+	/** Samples pushed so far (the monotonic stream position). */
+	get position(): number {
+		return this.pushed;
+	}
+
+	/** Drop all buffered playback (e.g. on a new turn / barge-in flush). */
+	reset(): void {
+		this.buffer.fill(0);
+		this.pushed = 0;
+	}
+}

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -59,6 +59,10 @@ export {
 	type EchoDelayOptions,
 	estimateEchoDelaySamples,
 } from "./echo-delay";
+export {
+	EchoReferenceBuffer,
+	type EchoReferenceBufferOptions,
+} from "./echo-reference-buffer";
 export type {
 	LlamaContextLike as Eliza1EotLlamaContext,
 	LlamaContextSequenceLike as Eliza1EotLlamaSequence,


### PR DESCRIPTION
Second pure-logic slice for #9583 (after the delay estimator #9586): the **echoReference alignment buffer** — the "caller must supply the time-aligned reference" primitive the AEC consumer seam was missing.

`EchoReferenceBuffer` is a fixed-capacity delay line: `push()` accumulates rendered playback (far-end) PCM in real time; `referenceFor(length, delaySamples)` returns the far-end window aligned to the current mic frame using the calibrated delay (from `estimateEchoDelaySamples`), zero-filling not-yet-rendered or evicted-past-capacity samples. Pure logic — no FFI/device/audio I/O — exported from the voice barrel.

**Verified:** 6 vitest tests — zero-delay last-N, delay shift, not-yet-pushed zero-fill, capacity-eviction zero-fill, multi-push accumulation + position, reset. `6 passed`.

Advances #9583's echoReference line; the remaining device-audio capture wiring (feeding live playback PCM into `push()` from the platform audio renderer) still needs on-device work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
