### PR TITLE
fix(#9584): pin zig 0.13 for the aarch64-linux-musl fused-lib link (zig 0.16 lld SIGSEGV)

### DIFF
--- a/packages/app-core/scripts/aosp/README.md
+++ b/packages/app-core/scripts/aosp/README.md
@@ -65,6 +65,15 @@ Each script accepts `--app-config <PATH>` to override
 ## Hardware requirements
 
 - AOSP build: Linux x86_64, KVM, ≥30 GB RAM, ≥ 600 GB free disk.
-- libllama compile: zig 0.13+ on PATH, cmake.
+- libllama compile: zig **0.13.x** on PATH (pinned series), cmake. The
+  `aarch64-linux-musl` / `x86_64-linux-musl` cross-link is pinned to the 0.13
+  series because zig 0.16's bundled `lld` SIGSEGVs that link and aborts the
+  fused/Android build with no actionable diagnostic. `compile-libllama.mjs` and
+  `compile-shim.mjs` fail loudly (via `assertZigPinForTargets`) if the detected
+  zig is outside 0.13.x; download the 0.13.x tarball from
+  <https://ziglang.org/download/> (the package-manager `zig` is frequently
+  0.16). Override only after independently verifying your lld links
+  aarch64-linux-musl: `ELIZA_ALLOW_UNPINNED_ZIG=1`. (The riscv64 RVV build path
+  is exempt — it needs zig 0.14+, gated by `MIN_ZIG_RVV_VERSION`.)
 - Cuttlefish runtime: cuttlefish host package (`cvd`), `/dev/kvm`.
 - Boot validation: `adb` on PATH or under `$ANDROID_HOME/platform-tools/`.

--- a/packages/app-core/scripts/aosp/compile-libllama-zig-pin.test.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama-zig-pin.test.mjs
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ABI_TARGETS,
+  ALLOW_UNPINNED_ZIG_ENV,
+  assertZigPinForTargets,
+  PINNED_ZIG_LINK_TRIPLES,
+  PINNED_ZIG_SERIES_FOR_MUSL_LINK,
+  zigSeries,
+  zigTriplesForAbis,
+} from "./compile-libllama.mjs";
+
+// Pins zig to the 0.13.x series for the aarch64/x86_64 `*-linux-musl` link.
+// zig 0.16's bundled lld SIGSEGVs that link (a silent host-toolchain break);
+// 0.13.x links it cleanly. The riscv64 RVV path is exempt (it needs 0.14+).
+// See issue #9584.
+describe("compile-libllama zig 0.13 pin", () => {
+  describe("zigSeries", () => {
+    it("extracts MAJOR.MINOR from stable versions", () => {
+      expect(zigSeries("0.13.0")).toBe("0.13");
+      expect(zigSeries("0.13.7")).toBe("0.13");
+      expect(zigSeries("0.16.0")).toBe("0.16");
+    });
+
+    it("strips dev/build suffixes", () => {
+      expect(zigSeries("0.13.0-dev.46+abc123")).toBe("0.13");
+      expect(zigSeries("v0.13.0")).toBe("0.13");
+    });
+
+    it("returns null for unparseable input", () => {
+      expect(zigSeries("not-a-version")).toBeNull();
+      // @ts-expect-error — exercising the non-string guard at the boundary.
+      expect(zigSeries(undefined)).toBeNull();
+    });
+  });
+
+  describe("pin constants", () => {
+    it("pins the 0.13 series", () => {
+      expect(PINNED_ZIG_SERIES_FOR_MUSL_LINK).toBe("0.13");
+    });
+
+    it("covers the aarch64/x86_64 musl link triples but not riscv64", () => {
+      expect(PINNED_ZIG_LINK_TRIPLES).toContain("aarch64-linux-musl");
+      expect(PINNED_ZIG_LINK_TRIPLES).toContain("x86_64-linux-musl");
+      expect(PINNED_ZIG_LINK_TRIPLES).not.toContain("riscv64-linux-musl");
+    });
+  });
+
+  describe("zigTriplesForAbis", () => {
+    it("maps each Android ABI to its zig triple", () => {
+      expect(zigTriplesForAbis(["arm64-v8a"])).toEqual(["aarch64-linux-musl"]);
+      expect(zigTriplesForAbis(["arm64-v8a", "x86_64", "riscv64"])).toEqual([
+        "aarch64-linux-musl",
+        "x86_64-linux-musl",
+        "riscv64-linux-musl",
+      ]);
+    });
+
+    it("dedupes repeated ABIs", () => {
+      expect(zigTriplesForAbis(["arm64-v8a", "arm64-v8a"])).toEqual([
+        "aarch64-linux-musl",
+      ]);
+    });
+
+    it("stays in sync with ABI_TARGETS", () => {
+      const abis = ABI_TARGETS.map((t) => t.androidAbi);
+      expect(zigTriplesForAbis(abis)).toEqual(ABI_TARGETS.map((t) => t.zigTarget));
+    });
+
+    it("throws on an unknown ABI rather than dropping it", () => {
+      expect(() => zigTriplesForAbis(["mips"])).toThrow(/unknown Android ABI/);
+    });
+  });
+
+  describe("assertZigPinForTargets", () => {
+    const arm = ["aarch64-linux-musl"];
+    const x86 = ["x86_64-linux-musl"];
+    const riscv = ["riscv64-linux-musl"];
+
+    it("accepts zig 0.13.x for the pinned musl link triples", () => {
+      expect(() =>
+        assertZigPinForTargets({ version: "0.13.0", zigTriples: arm, env: {} }),
+      ).not.toThrow();
+      expect(() =>
+        assertZigPinForTargets({ version: "0.13.7", zigTriples: x86, env: {} }),
+      ).not.toThrow();
+    });
+
+    it("rejects zig 0.16 (lld SIGSEGV) for the pinned link", () => {
+      expect(() =>
+        assertZigPinForTargets({ version: "0.16.0", zigTriples: arm, env: {} }),
+      ).toThrow(/0\.13\.x/);
+    });
+
+    it("rejects zig 0.14 for the pinned link (series must match exactly)", () => {
+      expect(() =>
+        assertZigPinForTargets({ version: "0.14.0", zigTriples: arm, env: {} }),
+      ).toThrow();
+    });
+
+    it("exempts a riscv64-only run (RVV path needs 0.14+)", () => {
+      expect(() =>
+        assertZigPinForTargets({ version: "0.16.0", zigTriples: riscv, env: {} }),
+      ).not.toThrow();
+      expect(() =>
+        assertZigPinForTargets({ version: "0.14.0", zigTriples: riscv, env: {} }),
+      ).not.toThrow();
+    });
+
+    it("still rejects when a pinned triple is mixed with riscv64", () => {
+      expect(() =>
+        assertZigPinForTargets({
+          version: "0.16.0",
+          zigTriples: [...arm, ...riscv],
+          env: {},
+        }),
+      ).toThrow();
+    });
+
+    it("honors the explicit override env", () => {
+      expect(() =>
+        assertZigPinForTargets({
+          version: "0.16.0",
+          zigTriples: arm,
+          env: { [ALLOW_UNPINNED_ZIG_ENV]: "1" },
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects a garbage version for the pinned link", () => {
+      expect(() =>
+        assertZigPinForTargets({ version: "weird", zigTriples: arm, env: {} }),
+      ).toThrow();
+    });
+
+    it("error names the version, the lld SIGSEGV cause, and the override", () => {
+      let message = "";
+      try {
+        assertZigPinForTargets({ version: "0.16.0", zigTriples: arm, env: {} });
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).toMatch(/0\.16\.0/);
+      expect(message).toMatch(/lld SIGSEGV/i);
+      expect(message).toContain(ALLOW_UNPINNED_ZIG_ENV);
+    });
+  });
+});

--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -234,6 +234,31 @@ export const MIN_ZIG_VERSION = "0.13.0";
 // ggml/src/ggml-cpu/arch/riscv/quants.c) light up.
 export const MIN_ZIG_RVV_VERSION = "0.14.0";
 
+// Pinned zig series (MAJOR.MINOR) for the aarch64/x86_64 `*-linux-musl`
+// cross-link that produces the Android/cuttlefish + fused (libelizainference)
+// libs. zig 0.16 bundles an LLVM whose `lld` SIGSEGVs while linking the
+// aarch64-linux-musl shared object — a host-toolchain regression that aborts
+// the link with no actionable diagnostic (it looks like an OOM / random crash,
+// not a config error). zig 0.13.x links these targets cleanly, so we pin the
+// series rather than only enforcing a floor: a newer-is-fine `>=` check would
+// silently route an operator's `brew install zig` (0.16) straight into the
+// SIGSEGV. This is intentionally a series pin, not an exact-patch pin — any
+// 0.13.x patch release links fine. The riscv64 RVV path keeps its own
+// MIN_ZIG_RVV_VERSION floor (it needs 0.14+ for the RVV ISA string) and is a
+// distinct musl triple, so it is exempt from this pin (see
+// `assertZigPinForTargets`). An operator who has independently verified their
+// zig's lld links aarch64-linux-musl can override with
+// ELIZA_ALLOW_UNPINNED_ZIG=1, but the default refuses the broken toolchain.
+export const PINNED_ZIG_SERIES_FOR_MUSL_LINK = "0.13";
+// zig triples whose lld link is covered by the 0.13.x pin above. riscv64 is
+// deliberately absent: its RVV build path requires 0.14+ and is gated by
+// MIN_ZIG_RVV_VERSION instead.
+export const PINNED_ZIG_LINK_TRIPLES = Object.freeze([
+  "aarch64-linux-musl",
+  "x86_64-linux-musl",
+]);
+export const ALLOW_UNPINNED_ZIG_ENV = "ELIZA_ALLOW_UNPINNED_ZIG";
+
 // The in-repo submodule checkout of the fork.
 // `repoRoot` resolves to the repo root that contains a top-level package.json.
 const LLAMA_CPP_SUBMODULE_DIR = path.join(
@@ -273,6 +298,33 @@ export const ABI_TARGETS = [
     cmakeProcessor: "riscv64",
   },
 ];
+
+/**
+ * Map a list of Android ABI directory names (`arm64-v8a` | `x86_64` |
+ * `riscv64`) to the distinct zig cross-link triples (`zigTarget`) they build
+ * through. Used to decide which targets the zig-series pin applies to. Throws
+ * on an unknown ABI rather than silently dropping it.
+ *
+ * Exported for tests.
+ *
+ * @param {readonly string[]} abis
+ * @returns {string[]}
+ */
+export function zigTriplesForAbis(abis) {
+  const triples = new Set();
+  for (const abi of abis) {
+    const target = ABI_TARGETS.find((t) => t.androidAbi === abi);
+    if (!target) {
+      throw new Error(
+        `[compile-libllama] unknown Android ABI ${abi}; expected one of ${ABI_TARGETS.map(
+          (t) => t.androidAbi,
+        ).join(", ")}.`,
+      );
+    }
+    triples.add(target.zigTarget);
+  }
+  return [...triples];
+}
 
 // `*-fused` android targets that are wired to real AOSP artifacts.
 // Membership in this set is the only way the fused (omnivoice-grafted) build
@@ -688,6 +740,86 @@ export function probeZig({
     );
   }
   return version;
+}
+
+/**
+ * Extract the MAJOR.MINOR series from a zig version string. `0.13.0` -> `0.13`,
+ * `0.13.0-dev.46+abc` -> `0.13`. Returns `null` for an unparseable input so
+ * callers can decide how to treat a missing/garbage version.
+ *
+ * Exported for tests.
+ *
+ * @param {string} version
+ * @returns {string | null}
+ */
+export function zigSeries(version) {
+  if (typeof version !== "string") return null;
+  const parts = version
+    .replace(/^v/, "")
+    .split(/[-+]/)[0]
+    .split(".")
+    .map((n) => Number.parseInt(n, 10));
+  if (parts.length < 2 || !Number.isFinite(parts[0]) || !Number.isFinite(parts[1])) {
+    return null;
+  }
+  return `${parts[0]}.${parts[1]}`;
+}
+
+/**
+ * Enforce the zig-series pin (PINNED_ZIG_SERIES_FOR_MUSL_LINK) for any requested
+ * target whose link goes through one of PINNED_ZIG_LINK_TRIPLES (the
+ * aarch64/x86_64 `*-linux-musl` Android / fused libs). zig 0.16's bundled lld
+ * SIGSEGVs that link, so a plain `>=` floor is not enough — we must reject a
+ * newer-but-broken toolchain too. riscv64-only target sets are exempt (their
+ * RVV path needs 0.14+, gated separately by MIN_ZIG_RVV_VERSION).
+ *
+ * Pure + deterministic: takes the detected version + the resolved triple list +
+ * env, throws on a pin violation, returns nothing on success. No side effects.
+ *
+ * Exported for tests.
+ *
+ * @param {object} params
+ * @param {string} params.version    zig version string from probeZig().
+ * @param {readonly string[]} params.zigTriples  the `zigTarget` triples the run
+ *   will cross-link (e.g. ["aarch64-linux-musl"]).
+ * @param {NodeJS.ProcessEnv} [params.env]
+ */
+export function assertZigPinForTargets({
+  version,
+  zigTriples,
+  env = process.env,
+}) {
+  const pinnedTriples = zigTriples.filter((t) =>
+    PINNED_ZIG_LINK_TRIPLES.includes(t),
+  );
+  if (pinnedTriples.length === 0) {
+    // No pinned-link triple in this run (e.g. riscv64-only) — nothing to pin.
+    return;
+  }
+  if (env[ALLOW_UNPINNED_ZIG_ENV] === "1") {
+    console.warn(
+      `[compile-libllama] ${ALLOW_UNPINNED_ZIG_ENV}=1 set; skipping the zig ` +
+        `${PINNED_ZIG_SERIES_FOR_MUSL_LINK}.x pin for ${pinnedTriples.join(", ")} ` +
+        `(zig ${version}). Only safe if you have verified this zig's lld links ` +
+        `aarch64-linux-musl without SIGSEGV.`,
+    );
+    return;
+  }
+  const series = zigSeries(version);
+  if (series !== PINNED_ZIG_SERIES_FOR_MUSL_LINK) {
+    throw new Error(
+      `[compile-libllama] zig ${version} (series ${series ?? "unknown"}) is not ` +
+        `the pinned zig ${PINNED_ZIG_SERIES_FOR_MUSL_LINK}.x required to link ` +
+        `${pinnedTriples.join(", ")}.\n` +
+        `zig 0.16's bundled lld SIGSEGVs the aarch64-linux-musl link, aborting ` +
+        `the fused/Android build with no actionable diagnostic; zig 0.13.x links ` +
+        `it cleanly. Install zig ${PINNED_ZIG_SERIES_FOR_MUSL_LINK}.x and re-run:\n` +
+        `  download the 0.13.x tarball from https://ziglang.org/download/ and put ` +
+        `\`zig\` on PATH (the package-manager \`zig\` is frequently 0.16).\n` +
+        `If you have independently verified your zig's lld links ` +
+        `aarch64-linux-musl, override with ${ALLOW_UNPINNED_ZIG_ENV}=1.`,
+    );
+  }
 }
 
 /**
@@ -2118,6 +2250,10 @@ export async function main(argv = process.argv.slice(2)) {
   if (!args.dryRun) {
     const zigVersion = probeZig();
     console.log(`[compile-libllama] Found zig ${zigVersion}`);
+    assertZigPinForTargets({
+      version: zigVersion,
+      zigTriples: zigTriplesForAbis(args.abis),
+    });
   } else {
     console.log(`[compile-libllama] (dry-run) skipping zig toolchain probe`);
   }
@@ -2322,6 +2458,10 @@ export async function mainTargets(args) {
   if (!args.dryRun) {
     const zigVersion = probeZig();
     console.log(`[compile-libllama] Found zig ${zigVersion}`);
+    assertZigPinForTargets({
+      version: zigVersion,
+      zigTriples: zigTriplesForAbis(args.targets.map((t) => t.androidAbi)),
+    });
   } else {
     console.log(`[compile-libllama] (dry-run) skipping zig toolchain probe`);
   }

--- a/packages/app-core/scripts/aosp/compile-shim.mjs
+++ b/packages/app-core/scripts/aosp/compile-shim.mjs
@@ -62,7 +62,11 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { ensureZigDrivers, probeZig } from "./compile-libllama.mjs";
+import {
+  assertZigPinForTargets,
+  ensureZigDrivers,
+  probeZig,
+} from "./compile-libllama.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -329,6 +333,22 @@ export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const zigVersion = probeZig();
   console.log(`[compile-shim] Found zig ${zigVersion}`);
+  // Same aarch64/x86_64 `*-linux-musl` lld link as compile-libllama — pin the
+  // zig 0.13.x series so a 0.16 toolchain's lld doesn't SIGSEGV the link.
+  assertZigPinForTargets({
+    version: zigVersion,
+    zigTriples: args.abis.map((abi) => {
+      const target = SHIM_ABI_TARGETS.find((t) => t.androidAbi === abi);
+      if (!target) {
+        throw new Error(
+          `[compile-shim] unknown ABI ${abi}; expected one of ${SHIM_ABI_TARGETS.map(
+            (t) => t.androidAbi,
+          ).join(", ")}.`,
+        );
+      }
+      return target.zigTarget;
+    }),
+  });
 
   for (const abi of args.abis) {
     if (args.skipIfPresent) {

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -157,6 +157,8 @@ export default defineConfig({
       "scripts/stage-android-agent.test.mjs",
       // Uses bun:test, not vitest.
       "scripts/aosp/stage-default-models.test.mjs",
+      // Uses bun:test, not vitest.
+      "scripts/aosp/compile-libllama-zig-pin.test.mjs",
       ...(process.platform === "win32"
         ? [
             "scripts/lib/apple-entitlement-audit.test.mjs",


### PR DESCRIPTION
Bounded code-doable part of #9584: pin zig 0.13 in the AOSP fused-lib compile scripts so zig 0.16's lld doesn't silently SIGSEGV the aarch64-linux-musl link. `assertZigPinForTargets` (0.13.x accept; 0.16/0.14 reject with a clear lld-SIGSEGV+override message; riscv64-only exempt; ELIZA_ALLOW_UNPINNED_ZIG=1 override). Verified: 17/17 bun:test, biome clean, node --check OK. The Mali/CUDA/NPU tuning + #9508 republish remain hardware/creds-gated (tracked on #9584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)