### PR TITLE
fix(#9565): boot/launch/splash surfaces use home-bg orange #ef5a1f, not brand #FF5800

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/res/values/colors.xml
+++ b/packages/app-core/platforms/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Brand accent (logo / App Actions widget). Stays the brand orange. -->
     <color name="eliza_orange">#FF5800</color>
-    <color name="splash_background">#FF5800</color>
+    <!-- Launch-splash surface + launch status bar. Tracks the home background
+         orange (#ef5a1f, DEFAULT_BACKGROUND_COLOR) so the native splash does not
+         flash a different orange before the home background paints (#9565). -->
+    <color name="splash_background">#ef5a1f</color>
+    <!-- Theme accent colors (brand). -->
     <color name="colorPrimary">#FF5800</color>
     <color name="colorPrimaryDark">#FF5800</color>
     <color name="colorAccent">#FF5800</color>

--- a/packages/app-core/platforms/android/app/src/main/res/values/styles.xml
+++ b/packages/app-core/platforms/android/app/src/main/res/values/styles.xml
@@ -30,7 +30,10 @@
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
         <item name="android:windowSplashScreenBackground">@color/splash_background</item>
-        <item name="android:statusBarColor">@color/eliza_orange</item>
+        <!-- Launch status bar tracks the launch-splash (home-background) color so
+             it does not flash the brand accent before the home background paints
+             (#9565). @color/splash_background is the home orange #ef5a1f. -->
+        <item name="android:statusBarColor">@color/splash_background</item>
         <!-- After the launch splash, swap to the no-action-bar app theme so the
              Capacitor WebView fills the window. Without this (paired with the
              installSplashScreen() call in MainActivity) the activity keeps this

--- a/packages/app-core/platforms/ios/App/App/Base.lproj/LaunchScreen.storyboard
+++ b/packages/app-core/platforms/ios/App/App/Base.lproj/LaunchScreen.storyboard
@@ -15,7 +15,11 @@
                     <imageView key="view" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Splash" id="snD-IY-ifK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" red="1.0" green="0.345" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <!-- Home-background orange (#ef5a1f, DEFAULT_BACKGROUND_COLOR): the launch
+                             backdrop tracks the home background so iOS does not flash a different
+                             orange before the home background paints (#9565). 0.937/0.353/0.122 is
+                             #ef5a1f in sRGB to 3 decimals. -->
+                        <color key="backgroundColor" red="0.937" green="0.353" blue="0.122" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </imageView>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/packages/app/app.config.ts
+++ b/packages/app/app.config.ts
@@ -36,10 +36,13 @@ const config = {
 
   web: {
     shortName: "Eliza",
-    // Eliza brand orange used by manifest theme_color, <meta name="theme-color">,
-    // and native launch surfaces.
-    themeColor: "#FF5800",
-    backgroundColor: "#FF5800",
+    // Home-background orange (#ef5a1f, DEFAULT_BACKGROUND_COLOR) used by manifest
+    // theme_color / background_color, <meta name="theme-color">, and native launch
+    // surfaces. These are boot/launch first-paint surfaces (PWA splash, OS launch
+    // chrome), so they track the home background — not the brand accent #FF5800 —
+    // to avoid flashing a different orange before the home background paints (#9565).
+    themeColor: "#ef5a1f",
+    backgroundColor: "#ef5a1f",
     shareImagePath: "/brand/ogembeds/eliza_ogembed.svg",
   },
 

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -147,9 +147,12 @@ const config: CapacitorConfig = {
       apiBase: iosApiBase,
     },
     // Native launch screen color. The app's real startup UI is rendered by React.
+    // Tracks the home background orange (#ef5a1f, DEFAULT_BACKGROUND_COLOR) — NOT
+    // the brand accent #FF5800 — so the native splash does not flash a different
+    // orange before the home background paints (#9565).
     SplashScreen: {
       launchShowDuration: 0,
-      backgroundColor: "#FF5800",
+      backgroundColor: "#ef5a1f",
       androidScaleType: "CENTER_CROP",
       splashFullScreen: true,
       splashImmersive: true,
@@ -163,7 +166,9 @@ const config: CapacitorConfig = {
     // own bottom inset so it stays clear of the home indicator.
     contentInset: "never",
     preferredContentMode: "mobile",
-    backgroundColor: "#FF5800",
+    // Home-background orange (#ef5a1f) so the WKWebView host background matches
+    // the home field on launch rather than flashing the brand accent (#9565).
+    backgroundColor: "#ef5a1f",
     allowsLinkPreview: false,
     webContentsDebuggingEnabled: webViewDebuggingEnabled,
   },
@@ -172,7 +177,9 @@ const config: CapacitorConfig = {
     // package. Upstream elizaOS owns the shared app-core tree; white-label or
     // explicitly isolated builds use the app-local ignored android/ project.
     path: androidProjectPath,
-    backgroundColor: "#FF5800",
+    // Home-background orange (#ef5a1f) so the Android WebView host background
+    // matches the home field on launch rather than flashing the brand accent (#9565).
+    backgroundColor: "#ef5a1f",
     allowMixedContent: false,
     captureInput: true,
     webContentsDebuggingEnabled: webViewDebuggingEnabled,

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -6,6 +6,11 @@
  * <App /> (packages/ui/src/App.tsx) and `@elizaos/app-core` window
  * orchestration; this test asserts the shell-owned surfaces this package
  * actually controls.
+ *
+ * Two distinct oranges (#9565): boot/launch/loading/splash surfaces use the
+ * HOME-BACKGROUND orange (#ef5a1f, DEFAULT_BACKGROUND_COLOR) so they do not
+ * flash a different orange before the home background paints; the brand/logo
+ * accent (theme accent, App Actions widget, launcher icon) stays #FF5800.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -16,6 +21,10 @@ const root = join(here, "..");
 const appCorePlatformsRoot = join(root, "..", "app-core", "platforms");
 
 const BRAND_ORANGE = "#FF5800";
+// DEFAULT_BACKGROUND_COLOR from @elizaos/ui (packages/ui/src/state/ui-preferences.ts):
+// the color the home ShaderBackground + StartupShell loader paint. Boot/launch
+// surfaces track this so boot never flashes the brand accent first (#9565).
+const HOME_BACKGROUND_ORANGE = "#ef5a1f";
 
 function read(rel: string): string {
   return readFileSync(join(root, rel), "utf8");
@@ -33,41 +42,51 @@ function readGeneratedOrTemplate(rel: string): string {
 }
 
 describe("brand surfaces", () => {
-  it("app.config web/theme colors are brand orange", () => {
+  it("app.config web/theme colors are the home-background orange (launch surface)", () => {
     const src = read("app.config.ts");
-    expect(src).toMatch(/themeColor:\s*"#FF5800"/);
-    expect(src).toMatch(/backgroundColor:\s*"#FF5800"/);
+    // theme_color / background_color feed the PWA manifest + <meta theme-color>
+    // + native launch surfaces — all boot/first-paint, so they track the home
+    // background, not the brand accent (#9565).
+    expect(src).toMatch(/themeColor:\s*"#ef5a1f"/);
+    expect(src).toMatch(/backgroundColor:\s*"#ef5a1f"/);
     expect(BRAND_ORANGE).toBe("#FF5800");
+    expect(HOME_BACKGROUND_ORANGE).toBe("#ef5a1f");
   });
 
-  it("capacitor config and native backgrounds are brand orange", () => {
+  it("capacitor config native backgrounds are the home-background orange (launch surface)", () => {
     const src = read("capacitor.config.ts");
-    expect(src).toMatch(/SplashScreen:\s*\{[^}]*backgroundColor:\s*"#FF5800"/s);
-    expect(src).toMatch(/ios:\s*\{[^}]*backgroundColor:\s*"#FF5800"/s);
-    expect(src).toMatch(/android:\s*\{[^}]*backgroundColor:\s*"#FF5800"/s);
+    expect(src).toMatch(/SplashScreen:\s*\{[^}]*backgroundColor:\s*"#ef5a1f"/s);
+    expect(src).toMatch(/ios:\s*\{[^}]*backgroundColor:\s*"#ef5a1f"/s);
+    expect(src).toMatch(/android:\s*\{[^}]*backgroundColor:\s*"#ef5a1f"/s);
   });
 
-  it("Android colors.xml + styles.xml use brand orange for launch + status bar", () => {
+  it("Android colors.xml + styles.xml: launch surfaces home-orange, accents brand-orange", () => {
     const colors = readGeneratedOrTemplate(
       "android/app/src/main/res/values/colors.xml",
     );
+    // Launch splash + launch status bar track the home background.
+    expect(colors).toContain(
+      '<color name="splash_background">#ef5a1f</color>',
+    );
+    // Brand accent (App Actions widget) + theme accent stay brand orange.
     expect(colors).toContain('<color name="eliza_orange">#FF5800</color>');
-    expect(colors).toContain('<color name="splash_background">#FF5800</color>');
     expect(colors).toContain('<color name="colorPrimary">#FF5800</color>');
 
     const styles = readGeneratedOrTemplate(
       "android/app/src/main/res/values/styles.xml",
     );
-    expect(styles).toContain("@color/eliza_orange");
-    expect(styles).toMatch(/statusBarColor[^<]*@color\/eliza_orange/);
+    // The launch status bar points at the launch-splash (home) color so it does
+    // not flash the brand accent before the home background paints (#9565).
+    expect(styles).toMatch(/statusBarColor[^<]*@color\/splash_background/);
   });
 
-  it("iOS LaunchScreen.storyboard backdrop is brand orange", () => {
+  it("iOS LaunchScreen.storyboard backdrop is the home-background orange (launch surface)", () => {
     const xml = readGeneratedOrTemplate(
       "ios/App/App/Base.lproj/LaunchScreen.storyboard",
     );
-    // 1.0 / 0.345 / 0.0 is #FF5800 in sRGB to 3 decimals.
-    expect(xml).toMatch(/red="1\.0"\s+green="0\.345"\s+blue="0\.0"/);
+    // 0.937 / 0.353 / 0.122 is #ef5a1f in sRGB to 3 decimals — the home
+    // background, so iOS does not flash the brand accent on launch (#9565).
+    expect(xml).toMatch(/red="0\.937"\s+green="0\.353"\s+blue="0\.122"/);
   });
 
   it("index.html FOUC fallback is the home background orange, not a foreign color", () => {


### PR DESCRIPTION
Bounded code-doable part of #9565: startup/launch/splash surfaces (app.config themeColor/bg, capacitor SplashScreen, Android splash_background + launch statusBar, iOS LaunchScreen) use the home-background orange `#ef5a1f` so boot doesn't flash a different orange before the home paints. Brand/logo accent (eliza_orange/colorPrimary/icon bg) intentionally stays `#FF5800`. brand-surface.test extended; 12/12 assertions verified, XML well-formed, configs parse. The broad cross-platform boot-time baselining/profiling is hardware-gated (tracked on #9565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)