### PR TITLE
test(lifeops): drive real default packs through the actual scheduled-task runner (#8795)

### DIFF
--- a/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
@@ -7,22 +7,25 @@
  *    gn + morning brief + sleep recap from plugin-health, all consolidated
  *    on anchor where applicable)."
  *
- * The W1-A spine (`ScheduledTaskRunner`) does not exist in this worktree
- * yet, so the smoke is a **simulation**: we walk every owner-visible
+ * This is a budget/consolidation **simulation**: we walk every owner-visible
  * record's trigger, inject the wake.confirmed and bedtime.target anchors,
  * apply consolidation policies to co-firing tasks, and count the resulting
- * user-facing nudges.
+ * user-facing nudges. It deliberately stays at the anchor-arithmetic layer —
+ * the actual `ScheduledTaskRunner` spine (gate evaluation, fire decisions) is
+ * exercised against the real imported packs in
+ * `health-default-packs-runner.test.ts`.
  *
- * The plugin-health (W1-B) sleep-recap pack is referenced as a phantom
- * record so the consolidation policy on `bedtime.target` is exercised even
- * though the W1-D package does not own it.
+ * The plugin-health (W1-B) sleep-recap pack is pulled in as the real imported
+ * `sleepRecapDefaultPack` record so the cross-plugin nudge budget includes the
+ * pack health actually ships (not a fabricated stand-in).
  */
 
+import {
+  type ScheduledTaskSeed,
+  sleepRecapDefaultPack,
+} from "@elizaos/plugin-health";
 import { describe, expect, it } from "vitest";
-import type {
-  AnchorConsolidationPolicy,
-  ScheduledTaskSeed,
-} from "../src/default-packs/index.js";
+import type { AnchorConsolidationPolicy } from "../src/default-packs/index.js";
 import {
   DEFAULT_CONSOLIDATION_POLICIES,
   dailyRhythmPack,
@@ -155,31 +158,15 @@ describe("W1-D default-pack smoke — 24h simulated nudge budget", () => {
       connectorRegistry: null,
     });
 
-    // Add a phantom plugin-health sleep-recap record so the bedtime.target
-    // consolidation policy is exercised. Wave-1 expects plugin-health to
-    // ship this; W1-D's smoke test guards the consolidation invariant.
-    const phantomSleepRecap: ScheduledTaskSeed = {
-      kind: "recap",
-      promptInstructions: "Phantom sleep recap (plugin-health W1-B record).",
-      trigger: {
-        kind: "relative_to_anchor",
-        anchorKey: "bedtime.target",
-        offsetMinutes: 0,
-      },
-      priority: "low",
-      respectsGlobalPause: true,
-      source: "plugin",
-      createdBy: "plugin-health:sleep-recap",
-      ownerVisible: true,
-      idempotencyKey: "plugin-health:sleep-recap:nightly",
-      metadata: {
-        recordKey: "sleep-recap",
-        packKey: "plugin-health:sleep-recap",
-      },
-    };
+    // Include the REAL plugin-health sleep-recap pack so the cross-plugin
+    // nudge budget reflects the record health actually ships (fires on
+    // wake.confirmed +240) rather than a fabricated stand-in.
+    const sleepRecapRecords: ScheduledTaskSeed[] = [
+      ...sleepRecapDefaultPack.records,
+    ];
     const packs = [
       ...enabledPacks,
-      { key: "plugin-health:sleep-recap", records: [phantomSleepRecap] },
+      { key: sleepRecapDefaultPack.key, records: sleepRecapRecords },
     ];
 
     const fires = simulateOneDay({

--- a/plugins/plugin-personal-assistant/test/health-default-packs-runner.test.ts
+++ b/plugins/plugin-personal-assistant/test/health-default-packs-runner.test.ts
@@ -1,0 +1,217 @@
+// @journey-16
+/**
+ * Real-runner integration for plugin-health default packs (#8795).
+ *
+ * Before this test the default packs were only exercised by SHAPE asserts
+ * (`plugins/plugin-health/src/__tests__/smoke.test.ts`) and a hand-written
+ * SIMULATION that fabricated a phantom sleep-recap record
+ * (`plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts`).
+ * Neither ever drove a real pack record through the actual scheduled-task
+ * spine, so the gates each pack references were never evaluated by the
+ * runner. That is exactly how the `sleep-recap` pack shipped referencing an
+ * UNREGISTERED `personal_baseline_sufficient` gate kind: a runner-less test
+ * cannot catch an unknown-gate skip.
+ *
+ * This file constructs the production `createScheduledTaskRunner` with the
+ * real `registerBuiltInGates`, schedules the ACTUAL imported pack records
+ * (`bedtimeDefaultPack` / `wakeUpDefaultPack` / `sleepRecapDefaultPack`),
+ * and drives each one through `fireWithResult` so the runner's real
+ * `evaluateGates` runs. The assertion is the fire outcome:
+ *   - `kind: "fired"`  → every gate the pack references resolved to allow.
+ *   - `kind: "skipped"` with reason `"<gate>: unknown gate kind: <gate>"`
+ *                       → the pack references a gate the runner never
+ *                         registered (the original #8795 / pre-#9563 bug).
+ *
+ * The final test removes `personal_baseline_sufficient` from the registry to
+ * prove this harness WOULD have caught the original unregistered-gate
+ * regression — i.e. the coverage is real, not tautological.
+ */
+
+import {
+  bedtimeDefaultPack,
+  HEALTH_DEFAULT_PACKS,
+  sleepRecapDefaultPack,
+  wakeUpDefaultPack,
+} from "@elizaos/plugin-health";
+import type {
+  ActivitySignalBusView,
+  GlobalPauseView,
+  OwnerFactsView,
+  ScheduledTask,
+  SubjectStoreView,
+  TaskGateRegistry,
+} from "@elizaos/plugin-scheduling";
+import {
+  createAnchorRegistry,
+  createCompletionCheckRegistry,
+  createConsolidationRegistry,
+  createEscalationLadderRegistry,
+  createInMemoryScheduledTaskLogStore,
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  createTaskGateRegistry,
+  registerBuiltInCompletionChecks,
+  registerBuiltInGates,
+  registerDefaultEscalationLadders,
+  type ScheduledTaskRunnerHandle,
+  TestNoopScheduledTaskDispatcher,
+} from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+
+const FIXED_NOW_ISO = "2026-05-09T07:30:00.000Z";
+
+/**
+ * Construct a real runner. Callers can mutate the supplied `gates` registry
+ * before scheduling to model "this gate was never registered" — the bug the
+ * default packs originally shipped with.
+ */
+function makeRunner(gates: TaskGateRegistry): ScheduledTaskRunnerHandle {
+  const ownerFacts: OwnerFactsView = {
+    timezone: "UTC",
+    morningWindow: { start: "07:00", end: "10:00" },
+    eveningWindow: { start: "21:00", end: "23:30" },
+  };
+  const globalPause: GlobalPauseView = {
+    current: async () => ({ active: false }),
+  };
+  const activity: ActivitySignalBusView = { hasSignalSince: () => false };
+  const subjectStore: SubjectStoreView = { wasUpdatedSince: () => false };
+
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+
+  let counter = 0;
+  return createScheduledTaskRunner({
+    agentId: "test-agent-health-packs",
+    store: createInMemoryScheduledTaskStore(),
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ownerFacts,
+    globalPause,
+    activity,
+    subjectStore,
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    newTaskId: () => {
+      counter += 1;
+      return `hpk_${counter}`;
+    },
+    now: () => new Date(FIXED_NOW_ISO),
+  });
+}
+
+/**
+ * Schedule the single record a default pack ships and drive it through the
+ * runner's real fire path. Returns the strict fire result so callers can
+ * assert the actual gate outcome (`fired` vs `skipped` with a gate reason)
+ * instead of a simulated approximation.
+ */
+async function fireFirstRecord(
+  runner: ScheduledTaskRunnerHandle,
+  record: Omit<ScheduledTask, "taskId" | "state">,
+) {
+  const scheduled = await runner.schedule(record);
+  expect(scheduled.state.status).toBe("scheduled");
+  return runner.fireWithResult(scheduled.taskId);
+}
+
+describe("plugin-health default packs through the real scheduled-task runner (#8795)", () => {
+  it("registerBuiltInGates registers every gate kind the packs reference", () => {
+    const gates = createTaskGateRegistry();
+    registerBuiltInGates(gates);
+
+    const referenced = new Set<string>();
+    for (const pack of HEALTH_DEFAULT_PACKS) {
+      for (const record of pack.records) {
+        for (const gate of record.shouldFire?.gates ?? []) {
+          referenced.add(gate.kind);
+        }
+      }
+    }
+    // The packs use these three; each must resolve to a registered
+    // contribution or the runner denies with "unknown gate kind".
+    expect([...referenced].sort()).toEqual([
+      "circadian_state_in",
+      "no_recent_user_message_in",
+      "personal_baseline_sufficient",
+    ]);
+    for (const kind of referenced) {
+      expect(gates.get(kind)).not.toBeNull();
+    }
+  });
+
+  it("sleep-recap fires through the real runner (personal_baseline_sufficient now resolves, post-#9563)", async () => {
+    const gates = createTaskGateRegistry();
+    registerBuiltInGates(gates);
+    const runner = makeRunner(gates);
+
+    const record = sleepRecapDefaultPack.records[0];
+    if (!record) throw new Error("sleepRecapDefaultPack should ship a record");
+    // Guard the precondition that made this pack the #8795 canary: it
+    // references the gate that used to be unregistered.
+    expect(record.shouldFire?.gates?.map((g) => g.kind)).toContain(
+      "personal_baseline_sufficient",
+    );
+
+    const result = await fireFirstRecord(runner, record);
+
+    expect(result.kind).toBe("fired");
+    if (result.kind === "skipped") {
+      throw new Error(
+        `sleep-recap was skipped by the real runner: ${result.reason}`,
+      );
+    }
+  });
+
+  it("bedtime and wake-up packs reach a real fire decision (no unknown-gate skip)", async () => {
+    for (const pack of [bedtimeDefaultPack, wakeUpDefaultPack]) {
+      const gates = createTaskGateRegistry();
+      registerBuiltInGates(gates);
+      const runner = makeRunner(gates);
+
+      const record = pack.records[0];
+      if (!record) throw new Error(`${pack.key} should ship a record`);
+
+      const result = await fireFirstRecord(runner, record);
+
+      expect(
+        result.kind,
+        `${pack.key} should fire, not skip on an unknown gate`,
+      ).toBe("fired");
+    }
+  });
+
+  it("REGRESSION GUARD: dropping personal_baseline_sufficient makes sleep-recap skip on the unknown gate", async () => {
+    // Build the registry the way develop shipped BEFORE #9563: every
+    // built-in gate EXCEPT the one sleep-recap depends on. The real runner
+    // must surface the unregistered gate as a skip — proving the test above
+    // is load-bearing and would have caught the original bug.
+    const fullGates = createTaskGateRegistry();
+    registerBuiltInGates(fullGates);
+    const partialGates = createTaskGateRegistry();
+    for (const contribution of fullGates.list()) {
+      if (contribution.kind === "personal_baseline_sufficient") continue;
+      partialGates.register(contribution);
+    }
+    expect(partialGates.get("personal_baseline_sufficient")).toBeNull();
+
+    const runner = makeRunner(partialGates);
+    const record = sleepRecapDefaultPack.records[0];
+    if (!record) throw new Error("sleepRecapDefaultPack should ship a record");
+
+    const result = await fireFirstRecord(runner, record);
+
+    expect(result.kind).toBe("skipped");
+    if (result.kind !== "skipped") {
+      throw new Error("expected the unregistered gate to skip the fire");
+    }
+    expect(result.reason).toContain(
+      "unknown gate kind: personal_baseline_sufficient",
+    );
+  });
+});


### PR DESCRIPTION
Refs #8795.

## Root cause

The plugin-health default packs (`bedtime` / `wake-up` / `sleep-recap`) were never exercised by the real scheduled-task runner — they were only "tested" by:

- **Shape asserts** — `plugins/plugin-health/src/__tests__/smoke.test.ts`: validates trigger anchors/offsets, no runner construction (`createScheduledTaskRunner` / `.schedule` / `fireWithResult` never appear in the file).
- **A phantom simulation** — `plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts`: its header literally said *"The W1-A spine (`ScheduledTaskRunner`) does not exist in this worktree yet"* and it walked anchor arithmetic over a **fabricated** `phantomSleepRecap` `ScheduledTaskSeed` (wrong anchor `bedtime.target` vs the real `wake.confirmed`, fake idempotency key) — never a real pack record, never the real `evaluateGates`.

Because no test drove a pack record through the spine, the `sleep-recap` pack was able to ship referencing the `personal_baseline_sufficient` gate kind while that gate was **unregistered** in `registerBuiltInGates` — the runner would `deny` with `"unknown gate kind: personal_baseline_sufficient"` and the pack would be silently, permanently skipped. (The gate was registered as a warn-once fallthrough in #9563.) A runner-less test structurally cannot catch this.

## Change (tests only — no production change)

- **New** `plugins/plugin-personal-assistant/test/health-default-packs-runner.test.ts`: constructs the production `createScheduledTaskRunner` with the real `registerBuiltInGates`, schedules the **actual imported** `bedtimeDefaultPack` / `wakeUpDefaultPack` / `sleepRecapDefaultPack` records, and drives each through `fireWithResult` so the runner's real `evaluateGates` runs. Asserts:
  - `sleep-recap` resolves to `kind: "fired"` (the `personal_baseline_sufficient` gate now resolves post-#9563) rather than skipping on an unknown gate.
  - `bedtime` / `wake-up` reach a real fire decision (no unknown-gate skip).
  - every gate kind the packs reference is registered.
  - **Regression guard:** a runner built without `personal_baseline_sufficient` registered makes `sleep-recap` `skip` with reason containing `"unknown gate kind: personal_baseline_sufficient"` — proving the coverage is load-bearing.
- **Modified** `plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts`: replaced the fabricated `phantomSleepRecap` with the **real imported** `sleepRecapDefaultPack` record and dropped the stale "spine does not exist in this worktree yet" comment. The simulation still guards the 24h nudge-budget invariant, now over the record health actually ships.

## Meaningfulness proof

Temporarily commenting out `reg.register(personalBaselineSufficientGate)` in `gate-registry.ts` (the pre-#9563 state) makes the new test fail exactly as it should:

```
× registerBuiltInGates registers every gate kind the packs reference
    AssertionError: expected null not to be null  (gates.get("personal_baseline_sufficient"))
× sleep-recap fires through the real runner (...post-#9563)
    AssertionError: expected 'skipped' to be 'fired'  // the real runner skips on the unknown gate
 Tests  2 failed | 2 passed (4)
```

The two control tests (bedtime/wake-up, which don't use that gate, and the regression-guard, which deliberately drops it) keep passing. The gate-registry edit was reverted; the runner spine is untouched.

## Verification

`bun run --cwd plugins/plugin-personal-assistant test -- default-packs`
```
[lint-default-packs] clean — 0 findings across default packs.
 Test Files  6 passed (6)
      Tests  109 passed (109)
```

`bun run --cwd plugins/plugin-health test -- smoke`
```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Biome: 0 errors on both touched files (6 pre-existing `noNonNullAssertion` warnings in untouched test bodies, present on `develop`). `tsc --noEmit` over both files: 0 type errors — the cross-package `ScheduledTask` record passes `runner.schedule()` with strong typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)