### PR TITLE
chore(local-inference): biome-format pre-existing voice/test files

### DIFF
--- a/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
@@ -122,5 +122,4 @@ describe("resolveLocalInferenceLoadArgs — runtime context fit", () => {
 			else process.env.ELIZA_MOBILE_CONTEXT_CEILING = prevCeiling;
 		}
 	});
-
 });

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -36,12 +36,12 @@ import {
 	handleLiveVoiceAttribution,
 } from "../../runtime/voice-entity-binding.js";
 import type { VoiceTurnSignal } from "./eot-classifier.js";
+import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
 import type {
 	VoiceAttributionOutput,
 	VoiceAttributionPipeline,
 } from "./speaker/attribution-pipeline.js";
 import type { PcmFrame, VadEvent, VoiceInputSource } from "./types.js";
-import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
 
 /** Shared empty reference — agent silent → echo canceller passes the mic through. */
 const NO_ECHO_REFERENCE = new Float32Array(0);

--- a/plugins/plugin-local-inference/src/services/voice/echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-canceller.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { computeErle, NlmsEchoCanceller } from "./echo-canceller.ts";
 import { applyReverb } from "./corpus-augment.ts";
+import { computeErle, NlmsEchoCanceller } from "./echo-canceller.ts";
 
 /** Deterministic PRNG so the test is reproducible. */
 function mulberry32(seed: number): () => number {
@@ -107,10 +107,10 @@ describe("NlmsEchoCanceller", () => {
 
 		// Clean path: a short FIR room impulse (same family as the single-talk test).
 		const cleanNear = applyEcho(far, ROOM_IMPULSE);
-		const cleanResidual = new NlmsEchoCanceller({ tailMs: 16, mu: 0.7 }).process(
-			far,
-			cleanNear,
-		);
+		const cleanResidual = new NlmsEchoCanceller({
+			tailMs: 16,
+			mu: 0.7,
+		}).process(far, cleanNear);
 
 		// Reverberant path: Freeverb/Schroeder leaves a long decaying tail, so the
 		// echo is no longer a short FIR — the hard case for a fixed-tail NLMS. Trim
@@ -141,5 +141,4 @@ describe("NlmsEchoCanceller", () => {
 		expect(revErle).toBeGreaterThanOrEqual(0.8);
 		expect(revErle).toBeLessThan(cleanErle);
 	});
-
 });

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
@@ -6,127 +6,136 @@ const BLOCK = 320; // 20 ms @ 16 kHz — the pipeline's frame size
 
 /** Speech-like signal: two-pole low-passed pseudo-random noise (deterministic). */
 function signal(n: number, seed: number): Float32Array {
-  const x = new Float32Array(n);
-  let s = seed >>> 0;
-  let p1 = 0;
-  let p2 = 0;
-  for (let i = 0; i < n; i++) {
-    s = (s * 1103515245 + 12345) & 0x7fffffff;
-    const w = s / 0x3fffffff - 1;
-    p1 = 0.92 * p1 + 0.08 * w;
-    p2 = 0.85 * p2 + 0.15 * p1;
-    x[i] = p2 * 3;
-  }
-  return x;
+	const x = new Float32Array(n);
+	let s = seed >>> 0;
+	let p1 = 0;
+	let p2 = 0;
+	for (let i = 0; i < n; i++) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		const w = s / 0x3fffffff - 1;
+		p1 = 0.92 * p1 + 0.08 * w;
+		p2 = 0.85 * p2 + 0.15 * p1;
+		x[i] = p2 * 3;
+	}
+	return x;
 }
 
 /** Realistic (attenuated) playback→mic path: bulk delay + decaying reverb. */
 function echoOf(x: Float32Array, gain = 0.22): Float32Array {
-  const delay = 35;
-  const tail = 90;
-  const h = new Float32Array(delay + tail);
-  for (let k = 0; k < tail; k++) {
-    h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * gain;
-  }
-  const y = new Float32Array(x.length);
-  for (let n = 0; n < x.length; n++) {
-    let acc = 0;
-    for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
-    y[n] = acc;
-  }
-  return y;
+	const delay = 35;
+	const tail = 90;
+	const h = new Float32Array(delay + tail);
+	for (let k = 0; k < tail; k++) {
+		h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * gain;
+	}
+	const y = new Float32Array(x.length);
+	for (let n = 0; n < x.length; n++) {
+		let acc = 0;
+		for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
+		y[n] = acc;
+	}
+	return y;
 }
 
 function power(a: Float32Array, from = 0, to = a.length): number {
-  let p = 0;
-  for (let i = from; i < to; i++) p += a[i] * a[i];
-  return p / Math.max(1, to - from);
+	let p = 0;
+	for (let i = from; i < to; i++) p += a[i] * a[i];
+	return p / Math.max(1, to - from);
 }
 
 function runBlocks(
-  aec: NlmsEchoCanceller,
-  near: Float32Array,
-  far: Float32Array,
+	aec: NlmsEchoCanceller,
+	near: Float32Array,
+	far: Float32Array,
 ): Float32Array {
-  const out = new Float32Array(near.length);
-  for (let off = 0; off + BLOCK <= near.length; off += BLOCK) {
-    out.set(
-      aec.process(near.subarray(off, off + BLOCK), far.subarray(off, off + BLOCK)),
-      off,
-    );
-  }
-  return out;
+	const out = new Float32Array(near.length);
+	for (let off = 0; off + BLOCK <= near.length; off += BLOCK) {
+		out.set(
+			aec.process(
+				near.subarray(off, off + BLOCK),
+				far.subarray(off, off + BLOCK),
+			),
+			off,
+		);
+	}
+	return out;
 }
 
 describe("NlmsEchoCanceller", () => {
-  it("cancels the agent's echo by >=10 dB ERLE after convergence (echo-only)", () => {
-    const N = SR * 4;
-    const far = signal(N, 1);
-    const echo = echoOf(far);
-    const out = runBlocks(new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5 }), echo, far);
-    const from = SR * 2; // ignore the first 2 s of adaptation
-    const to = N - (N % BLOCK);
-    const erleDb = 10 * Math.log10(power(echo, from, to) / power(out, from, to));
-    expect(erleDb).toBeGreaterThan(10);
-  });
+	it("cancels the agent's echo by >=10 dB ERLE after convergence (echo-only)", () => {
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5 }),
+			echo,
+			far,
+		);
+		const from = SR * 2; // ignore the first 2 s of adaptation
+		const to = N - (N % BLOCK);
+		const erleDb =
+			10 * Math.log10(power(echo, from, to) / power(out, from, to));
+		expect(erleDb).toBeGreaterThan(10);
+	});
 
-  it("passes the mic through unchanged while the agent is silent", () => {
-    const aec = new NlmsEchoCanceller({ filterTaps: 256 });
-    const micOnly = signal(BLOCK, 777);
-    const out = aec.process(micOnly, new Float32Array(BLOCK)); // far-end = silence
-    let maxDiff = 0;
-    for (let i = 0; i < BLOCK; i++) {
-      maxDiff = Math.max(maxDiff, Math.abs(out[i] - micOnly[i]));
-    }
-    expect(maxDiff).toBeLessThan(1e-6);
-  });
+	it("passes the mic through unchanged while the agent is silent", () => {
+		const aec = new NlmsEchoCanceller({ filterTaps: 256 });
+		const micOnly = signal(BLOCK, 777);
+		const out = aec.process(micOnly, new Float32Array(BLOCK)); // far-end = silence
+		let maxDiff = 0;
+		for (let i = 0; i < BLOCK; i++) {
+			maxDiff = Math.max(maxDiff, Math.abs(out[i] - micOnly[i]));
+		}
+		expect(maxDiff).toBeLessThan(1e-6);
+	});
 
-  it("never touches the user's voice when only the user is speaking (no playback)", () => {
-    // Pure near-end speech, agent silent for the whole run → exact passthrough,
-    // so the canceller can never suppress a barge-in while no echo exists.
-    const N = SR * 2;
-    const speech = signal(N, 99);
-    const out = runBlocks(
-      new NlmsEchoCanceller({ filterTaps: 256 }),
-      speech,
-      new Float32Array(N),
-    );
-    let maxDiff = 0;
-    for (let i = 0; i < out.length; i++) {
-      maxDiff = Math.max(maxDiff, Math.abs(out[i] - speech[i]));
-    }
-    expect(maxDiff).toBeLessThan(1e-6);
-  });
+	it("never touches the user's voice when only the user is speaking (no playback)", () => {
+		// Pure near-end speech, agent silent for the whole run → exact passthrough,
+		// so the canceller can never suppress a barge-in while no echo exists.
+		const N = SR * 2;
+		const speech = signal(N, 99);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256 }),
+			speech,
+			new Float32Array(N),
+		);
+		let maxDiff = 0;
+		for (let i = 0; i < out.length; i++) {
+			maxDiff = Math.max(maxDiff, Math.abs(out[i] - speech[i]));
+		}
+		expect(maxDiff).toBeLessThan(1e-6);
+	});
 
-  it("stays stable (does not diverge) under sustained double-talk", () => {
-    // Agent speaks the whole time; the user also speaks from 2 s. The filter
-    // must not blow up — the output power stays bounded near the input power.
-    const N = SR * 4;
-    const far = signal(N, 1);
-    const echo = echoOf(far);
-    const speech = signal(N, 99);
-    const near = new Float32Array(N);
-    for (let i = 0; i < N; i++) near[i] = echo[i] + (i >= SR * 2 ? speech[i] : 0);
-    const out = runBlocks(
-      new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5, dtdRatio: 1.5 }),
-      near,
-      far,
-    );
-    const from = SR * 2;
-    const to = N - (N % BLOCK);
-    // No divergence: output energy is the same order as the input, not exploding.
-    expect(power(out, from, to)).toBeLessThan(power(near, from, to) * 4);
-    for (let i = from; i < to; i++) expect(Number.isFinite(out[i])).toBe(true);
-  });
+	it("stays stable (does not diverge) under sustained double-talk", () => {
+		// Agent speaks the whole time; the user also speaks from 2 s. The filter
+		// must not blow up — the output power stays bounded near the input power.
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const speech = signal(N, 99);
+		const near = new Float32Array(N);
+		for (let i = 0; i < N; i++)
+			near[i] = echo[i] + (i >= SR * 2 ? speech[i] : 0);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5, dtdRatio: 1.5 }),
+			near,
+			far,
+		);
+		const from = SR * 2;
+		const to = N - (N % BLOCK);
+		// No divergence: output energy is the same order as the input, not exploding.
+		expect(power(out, from, to)).toBeLessThan(power(near, from, to) * 4);
+		for (let i = from; i < to; i++) expect(Number.isFinite(out[i])).toBe(true);
+	});
 
-  it("reset() clears adaptation (first post-reset sample is exact passthrough)", () => {
-    const far = signal(SR, 1);
-    const echo = echoOf(far);
-    const aec = new NlmsEchoCanceller({ filterTaps: 128 });
-    runBlocks(aec, echo, far);
-    aec.reset();
-    const out = aec.process(echo.subarray(0, BLOCK), far.subarray(0, BLOCK));
-    // weights + reference history are zero → ŷ[0]=0 → out[0]==in[0] exactly.
-    expect(out[0]).toBe(echo[0]);
-  });
+	it("reset() clears adaptation (first post-reset sample is exact passthrough)", () => {
+		const far = signal(SR, 1);
+		const echo = echoOf(far);
+		const aec = new NlmsEchoCanceller({ filterTaps: 128 });
+		runBlocks(aec, echo, far);
+		aec.reset();
+		const out = aec.process(echo.subarray(0, BLOCK), far.subarray(0, BLOCK));
+		// weights + reference history are zero → ŷ[0]=0 → out[0]==in[0] exactly.
+		expect(out[0]).toBe(echo[0]);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
@@ -33,165 +33,168 @@
  */
 
 export interface NlmsEchoCancellerOptions {
-  /** Adaptive FIR length in samples. 256 ≈ 16 ms of impulse response @16 kHz. */
-  filterTaps?: number;
-  /** NLMS step size in (0, 2). Larger = faster adaptation, less stable. */
-  mu?: number;
-  /** Regularization added to the reference energy to avoid divide-by-zero. */
-  epsilon?: number;
-  /**
-   * Bulk playback→mic transport delay in samples. The reference is consumed
-   * `delaySamples` ahead of the near-end so the adaptive taps only model the
-   * residual room impulse, not the (potentially large) transport latency.
-   */
-  delaySamples?: number;
-  /**
-   * Double-talk detector ratio. When the smoothed near-end power exceeds
-   * `dtdRatio`× the smoothed far-end reference power (a passive echo path
-   * attenuates, so echo power stays below the reference), a local talker is
-   * assumed active and adaptation is frozen so the filter cannot learn (and
-   * cancel) the user's voice. Set 0 to disable.
-   */
-  dtdRatio?: number;
+	/** Adaptive FIR length in samples. 256 ≈ 16 ms of impulse response @16 kHz. */
+	filterTaps?: number;
+	/** NLMS step size in (0, 2). Larger = faster adaptation, less stable. */
+	mu?: number;
+	/** Regularization added to the reference energy to avoid divide-by-zero. */
+	epsilon?: number;
+	/**
+	 * Bulk playback→mic transport delay in samples. The reference is consumed
+	 * `delaySamples` ahead of the near-end so the adaptive taps only model the
+	 * residual room impulse, not the (potentially large) transport latency.
+	 */
+	delaySamples?: number;
+	/**
+	 * Double-talk detector ratio. When the smoothed near-end power exceeds
+	 * `dtdRatio`× the smoothed far-end reference power (a passive echo path
+	 * attenuates, so echo power stays below the reference), a local talker is
+	 * assumed active and adaptation is frozen so the filter cannot learn (and
+	 * cancel) the user's voice. Set 0 to disable.
+	 */
+	dtdRatio?: number;
 }
 
 const DEFAULTS = {
-  filterTaps: 256,
-  mu: 0.3,
-  epsilon: 1e-6,
-  delaySamples: 0,
-  dtdRatio: 2,
+	filterTaps: 256,
+	mu: 0.3,
+	epsilon: 1e-6,
+	delaySamples: 0,
+	dtdRatio: 2,
 } as const;
 
 export class NlmsEchoCanceller {
-  private readonly w: Float32Array; // adaptive filter weights
-  private readonly x: Float32Array; // far-end ring buffer (most-recent-first)
-  private readonly taps: number;
-  private readonly mu: number;
-  private readonly eps: number;
-  private readonly delay: number;
-  private readonly dtdRatio: number;
-  /** Pending far-end samples not yet aligned to a near-end sample (delay line). */
-  private readonly delayLine: number[] = [];
-  private xEnergy = 0; // running ‖x‖² over the active window (incremental)
-  private pNear = 0; // smoothed near-end power (DTD)
-  private pFar = 0; // smoothed far-end reference power (DTD)
-  private hangover = 0; // samples to stay frozen after a double-talk trigger
-  private lastEchoPow = 0;
+	private readonly w: Float32Array; // adaptive filter weights
+	private readonly x: Float32Array; // far-end ring buffer (most-recent-first)
+	private readonly taps: number;
+	private readonly mu: number;
+	private readonly eps: number;
+	private readonly delay: number;
+	private readonly dtdRatio: number;
+	/** Pending far-end samples not yet aligned to a near-end sample (delay line). */
+	private readonly delayLine: number[] = [];
+	private xEnergy = 0; // running ‖x‖² over the active window (incremental)
+	private pNear = 0; // smoothed near-end power (DTD)
+	private pFar = 0; // smoothed far-end reference power (DTD)
+	private hangover = 0; // samples to stay frozen after a double-talk trigger
+	private lastEchoPow = 0;
 
-  /** Stay frozen ~30 ms after the last double-talk trigger so the filter is not
-   * corrupted by the bursty onset/offset of the near-end talker. */
-  private static readonly HANGOVER_SAMPLES = 480;
-  private lastResidualPow = 0;
+	/** Stay frozen ~30 ms after the last double-talk trigger so the filter is not
+	 * corrupted by the bursty onset/offset of the near-end talker. */
+	private static readonly HANGOVER_SAMPLES = 480;
+	private lastResidualPow = 0;
 
-  constructor(opts: NlmsEchoCancellerOptions = {}) {
-    this.taps = Math.max(1, Math.floor(opts.filterTaps ?? DEFAULTS.filterTaps));
-    this.mu = opts.mu ?? DEFAULTS.mu;
-    this.eps = opts.epsilon ?? DEFAULTS.epsilon;
-    this.delay = Math.max(0, Math.floor(opts.delaySamples ?? DEFAULTS.delaySamples));
-    this.dtdRatio = opts.dtdRatio ?? DEFAULTS.dtdRatio;
-    this.w = new Float32Array(this.taps);
-    this.x = new Float32Array(this.taps);
-  }
+	constructor(opts: NlmsEchoCancellerOptions = {}) {
+		this.taps = Math.max(1, Math.floor(opts.filterTaps ?? DEFAULTS.filterTaps));
+		this.mu = opts.mu ?? DEFAULTS.mu;
+		this.eps = opts.epsilon ?? DEFAULTS.epsilon;
+		this.delay = Math.max(
+			0,
+			Math.floor(opts.delaySamples ?? DEFAULTS.delaySamples),
+		);
+		this.dtdRatio = opts.dtdRatio ?? DEFAULTS.dtdRatio;
+		this.w = new Float32Array(this.taps);
+		this.x = new Float32Array(this.taps);
+	}
 
-  /**
-   * Cancel echo from one block of mic audio.
-   *
-   * @param nearEnd raw mic block (local speech + echo), Float32 [-1, 1]
-   * @param farEnd  agent playback reference for the same time window. Pass an
-   *                empty/zero array when the agent is NOT speaking — the filter
-   *                then passes the mic through unchanged (output ≈ input).
-   * @returns echo-cancelled near-end block (same length as `nearEnd`).
-   */
-  process(nearEnd: Float32Array, farEnd: Float32Array): Float32Array {
-    const n = nearEnd.length;
-    const out = new Float32Array(n);
-    let echoPow = 0;
-    let residualPow = 0;
+	/**
+	 * Cancel echo from one block of mic audio.
+	 *
+	 * @param nearEnd raw mic block (local speech + echo), Float32 [-1, 1]
+	 * @param farEnd  agent playback reference for the same time window. Pass an
+	 *                empty/zero array when the agent is NOT speaking — the filter
+	 *                then passes the mic through unchanged (output ≈ input).
+	 * @returns echo-cancelled near-end block (same length as `nearEnd`).
+	 */
+	process(nearEnd: Float32Array, farEnd: Float32Array): Float32Array {
+		const n = nearEnd.length;
+		const out = new Float32Array(n);
+		let echoPow = 0;
+		let residualPow = 0;
 
-    for (let i = 0; i < n; i++) {
-      // Feed the (delay-aligned) far-end sample into the ring buffer.
-      const incoming = i < farEnd.length ? farEnd[i] : 0;
-      this.delayLine.push(incoming);
-      const ref =
-        this.delayLine.length > this.delay
-          ? (this.delayLine.shift() as number)
-          : 0;
-      this.pushRef(ref);
+		for (let i = 0; i < n; i++) {
+			// Feed the (delay-aligned) far-end sample into the ring buffer.
+			const incoming = i < farEnd.length ? farEnd[i] : 0;
+			this.delayLine.push(incoming);
+			const ref =
+				this.delayLine.length > this.delay
+					? (this.delayLine.shift() as number)
+					: 0;
+			this.pushRef(ref);
 
-      // Estimate echo ŷ = wᵀ·x and the error e = d − ŷ (the cleaned sample).
-      let yhat = 0;
-      for (let k = 0; k < this.taps; k++) yhat += this.w[k] * this.x[k];
-      const d = nearEnd[i];
-      const e = d - yhat;
-      out[i] = e;
+			// Estimate echo ŷ = wᵀ·x and the error e = d − ŷ (the cleaned sample).
+			let yhat = 0;
+			for (let k = 0; k < this.taps; k++) yhat += this.w[k] * this.x[k];
+			const d = nearEnd[i];
+			const e = d - yhat;
+			out[i] = e;
 
-      // Double-talk detection by near-end vs far-end power. A passive
-      // playback→mic path attenuates, so the echo power stays below the
-      // far-end reference power; when the smoothed near-end power instead
-      // exceeds `dtdRatio`× the far-end power, a local talker is active. This is
-      // independent of the filter's convergence state, so it never blocks
-      // initial adaptation (unlike comparing against the echo estimate).
-      // Fast smoothing (~6 ms) so the detector reacts at the onset of the
-      // near-end burst, plus a hangover so it stays frozen through it.
-      this.pNear = 0.99 * this.pNear + 0.01 * d * d;
-      this.pFar = 0.99 * this.pFar + 0.01 * ref * ref;
-      if (
-        this.dtdRatio > 0 &&
-        this.pFar > this.eps &&
-        this.pNear > this.dtdRatio * this.pFar
-      ) {
-        this.hangover = NlmsEchoCanceller.HANGOVER_SAMPLES;
-      }
-      const doubleTalk = this.hangover > 0;
-      if (this.hangover > 0) this.hangover--;
+			// Double-talk detection by near-end vs far-end power. A passive
+			// playback→mic path attenuates, so the echo power stays below the
+			// far-end reference power; when the smoothed near-end power instead
+			// exceeds `dtdRatio`× the far-end power, a local talker is active. This is
+			// independent of the filter's convergence state, so it never blocks
+			// initial adaptation (unlike comparing against the echo estimate).
+			// Fast smoothing (~6 ms) so the detector reacts at the onset of the
+			// near-end burst, plus a hangover so it stays frozen through it.
+			this.pNear = 0.99 * this.pNear + 0.01 * d * d;
+			this.pFar = 0.99 * this.pFar + 0.01 * ref * ref;
+			if (
+				this.dtdRatio > 0 &&
+				this.pFar > this.eps &&
+				this.pNear > this.dtdRatio * this.pFar
+			) {
+				this.hangover = NlmsEchoCanceller.HANGOVER_SAMPLES;
+			}
+			const doubleTalk = this.hangover > 0;
+			if (this.hangover > 0) this.hangover--;
 
-      // NLMS weight update: w += μ·e·x / (‖x‖² + ε), frozen during double-talk.
-      if (!doubleTalk) {
-        const norm = this.xEnergy + this.eps;
-        const step = (this.mu * e) / norm;
-        if (Number.isFinite(step)) {
-          for (let k = 0; k < this.taps; k++) this.w[k] += step * this.x[k];
-        }
-      }
+			// NLMS weight update: w += μ·e·x / (‖x‖² + ε), frozen during double-talk.
+			if (!doubleTalk) {
+				const norm = this.xEnergy + this.eps;
+				const step = (this.mu * e) / norm;
+				if (Number.isFinite(step)) {
+					for (let k = 0; k < this.taps; k++) this.w[k] += step * this.x[k];
+				}
+			}
 
-      echoPow += yhat * yhat;
-      residualPow += e * e;
-    }
+			echoPow += yhat * yhat;
+			residualPow += e * e;
+		}
 
-    this.lastEchoPow = echoPow / Math.max(1, n);
-    this.lastResidualPow = residualPow / Math.max(1, n);
-    return out;
-  }
+		this.lastEchoPow = echoPow / Math.max(1, n);
+		this.lastResidualPow = residualPow / Math.max(1, n);
+		return out;
+	}
 
-  /** Echo-return-loss-enhancement (dB) over the last processed block. Higher is
-   * better; >10 dB is a meaningful cancellation. Returns 0 when there is no
-   * modeled echo (agent silent) so a passthrough block reads as "no gain". */
-  get lastErleDb(): number {
-    if (this.lastResidualPow <= 0 || this.lastEchoPow <= 0) return 0;
-    return 10 * Math.log10(this.lastEchoPow / this.lastResidualPow);
-  }
+	/** Echo-return-loss-enhancement (dB) over the last processed block. Higher is
+	 * better; >10 dB is a meaningful cancellation. Returns 0 when there is no
+	 * modeled echo (agent silent) so a passthrough block reads as "no gain". */
+	get lastErleDb(): number {
+		if (this.lastResidualPow <= 0 || this.lastEchoPow <= 0) return 0;
+		return 10 * Math.log10(this.lastEchoPow / this.lastResidualPow);
+	}
 
-  /** Reset adaptation (e.g. when the playback path changes). */
-  reset(): void {
-    this.w.fill(0);
-    this.x.fill(0);
-    this.delayLine.length = 0;
-    this.xEnergy = 0;
-    this.pNear = 0;
-    this.pFar = 0;
-    this.hangover = 0;
-    this.lastEchoPow = 0;
-    this.lastResidualPow = 0;
-  }
+	/** Reset adaptation (e.g. when the playback path changes). */
+	reset(): void {
+		this.w.fill(0);
+		this.x.fill(0);
+		this.delayLine.length = 0;
+		this.xEnergy = 0;
+		this.pNear = 0;
+		this.pFar = 0;
+		this.hangover = 0;
+		this.lastEchoPow = 0;
+		this.lastResidualPow = 0;
+	}
 
-  /** Shift a new far-end sample into the ring buffer, maintaining ‖x‖²
-   * incrementally (drop the oldest sample's energy, add the newest). */
-  private pushRef(sample: number): void {
-    const dropped = this.x[this.taps - 1];
-    this.xEnergy += sample * sample - dropped * dropped;
-    if (this.xEnergy < 0) this.xEnergy = 0; // guard fp drift
-    for (let k = this.taps - 1; k > 0; k--) this.x[k] = this.x[k - 1];
-    this.x[0] = sample;
-  }
+	/** Shift a new far-end sample into the ring buffer, maintaining ‖x‖²
+	 * incrementally (drop the oldest sample's energy, add the newest). */
+	private pushRef(sample: number): void {
+		const dropped = this.x[this.taps - 1];
+		this.xEnergy += sample * sample - dropped * dropped;
+		if (this.xEnergy < 0) this.xEnergy = 0; // guard fp drift
+		for (let k = this.taps - 1; k > 0; k--) this.x[k] = this.x[k - 1];
+		this.x[0] = sample;
+	}
 }


### PR DESCRIPTION
Brings 5 pre-existing files to the repo's tab-indent biome standard — the plugin `lint:check` flagged them (import-sort + space→tab reindent, **pure formatting, no logic**). Makes `bun run --cwd plugins/plugin-local-inference lint:check` green (was 6 errors). Not part of the vision/transcription feature work — split out so it's trivially reviewable/revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)