### PR TITLE
feat(#9583): wire echoReference provider on the device audio path (AEC follow-up to #9575)

### DIFF
--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
@@ -211,3 +211,115 @@ describe("handleLiveDiarizationRoute", () => {
 		expect(res.statusCode).toBe(503);
 	});
 });
+
+describe("handleLiveDiarizationRoute — playback-frames (#9583)", () => {
+	/** A well-formed PlaybackFrameEvent (20 ms of played PCM at 16 kHz). */
+	function playbackFrame(atMs: number, samples = 320) {
+		const pcm16 = Buffer.alloc(samples * 2).toString("base64");
+		return { pcm16, sampleRate: 16_000, atMs };
+	}
+
+	it("accepts a well-formed playback batch (no models needed) and counts samples", async () => {
+		// observePlayback only touches the in-memory echo reference, so the route
+		// returns 200 even on a host with no on-device voice GGUFs.
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [playbackFrame(1000), playbackFrame(1020)] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(200);
+		const body = res.json() as { ok: boolean; playbackSamplesObserved: number };
+		expect(body.ok).toBe(true);
+		expect(body.playbackSamplesObserved).toBe(640);
+	});
+
+	it("surfaces the observed playback in the status payload", async () => {
+		await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [playbackFrame(2000)] },
+			}),
+			new FakeRes() as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		const res = new FakeRes();
+		await handleLiveDiarizationRoute(
+			makeReq({ method: "GET", url: "/api/voice/audio-frames/status" }),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		const status = res.json() as { playbackSamplesObserved: number };
+		expect(status.playbackSamplesObserved).toBe(320);
+	});
+
+	it("rejects a malformed playback frame with 400", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [{ pcm16: "AA==" /* missing sampleRate/atMs */ }] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(400);
+		expect((res.json() as { error: string }).error).toMatch(/Malformed/);
+	});
+
+	it("rejects a wrong-rate playback frame with 400 (no silent resample)", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [{ ...playbackFrame(1000), sampleRate: 48_000 }] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(400);
+		expect((res.json() as { error: string }).error).toMatch(/48000 Hz/);
+	});
+
+	it("rejects a non-array playback frames field with 400", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: "nope" },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(400);
+	});
+
+	it("rejects a non-loopback caller with 401", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [playbackFrame(1000)] },
+				remoteAddress: "10.0.0.5",
+				host: "example.com",
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(401);
+	});
+});

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -12,6 +12,12 @@
  *   POST /api/voice/audio-frames        body: { frames: AudioFrameEvent[],
  *                                               flush?: boolean }
  *                                       → { ok, framesReceived, turnsObserved }
+ *   POST /api/voice/playback-frames     body: { frames: PlaybackFrameEvent[],
+ *                                               reset?: boolean }
+ *                                       → { ok, playbackSamplesObserved }
+ *                                       (#9583: the agent's TTS playback PCM,
+ *                                        the far-end echo reference the canceller
+ *                                        subtracts from the mic)
  *   GET  /api/voice/audio-frames/status → LiveDiarizationStatus (device evidence)
  *
  * Auth follows the compat pattern: trusted-loopback OR the compat API token.
@@ -20,7 +26,13 @@
  */
 
 import type http from "node:http";
-import type { AudioFrameEvent } from "../services/voice/audio-frame-consumer.js";
+import {
+	AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	AudioFrameDecodeError,
+	type AudioFrameEvent,
+	decodePlaybackFramePcm,
+	type PlaybackFrameEvent,
+} from "../services/voice/audio-frame-consumer.js";
 import {
 	LiveDiarizationSession,
 	type RuntimeEventSink,
@@ -64,6 +76,16 @@ function isAudioFrameEvent(value: unknown): value is AudioFrameEvent {
 	);
 }
 
+function isPlaybackFrameEvent(value: unknown): value is PlaybackFrameEvent {
+	if (!value || typeof value !== "object") return false;
+	const f = value as Partial<PlaybackFrameEvent>;
+	return (
+		typeof f.pcm16 === "string" &&
+		typeof f.sampleRate === "number" &&
+		typeof f.atMs === "number"
+	);
+}
+
 export async function handleLiveDiarizationRoute(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
@@ -80,6 +102,51 @@ export async function handleLiveDiarizationRoute(
 			return true;
 		}
 		sendJson(res, 200, await current.status());
+		return true;
+	}
+
+	if (url.pathname === "/api/voice/playback-frames" && method === "POST") {
+		// #9583: the far-end (agent TTS playback) report. The playback path POSTs
+		// the PCM it actually played, time-stamped to the playback clock, so the
+		// echo canceller can subtract the agent's own voice from the mic.
+		if (!ensureCompatApiAuthorized(req, res)) return true;
+		const current = getSession(state);
+		if (!current) {
+			sendJsonError(res, 503, "Runtime not ready");
+			return true;
+		}
+		const body = await readCompatJsonBody(req, res);
+		if (!body) return true;
+		const rawFrames = body.frames;
+		if (!Array.isArray(rawFrames)) {
+			sendJsonError(res, 400, "Expected { frames: PlaybackFrameEvent[] }");
+			return true;
+		}
+		const frames = rawFrames.filter(isPlaybackFrameEvent);
+		if (frames.length !== rawFrames.length) {
+			sendJsonError(
+				res,
+				400,
+				`Malformed frame(s): ${rawFrames.length - frames.length} of ${rawFrames.length} did not match PlaybackFrameEvent`,
+			);
+			return true;
+		}
+		let observed = 0;
+		try {
+			for (const frame of frames) {
+				const pcm = decodePlaybackFramePcm(frame);
+				current.observePlayback(pcm, AUDIO_FRAME_PIPELINE_SAMPLE_RATE, frame.atMs);
+				observed += pcm.length;
+			}
+		} catch (err) {
+			if (err instanceof AudioFrameDecodeError) {
+				sendJsonError(res, 400, err.message);
+				return true;
+			}
+			throw err;
+		}
+		if (body.reset === true) current.resetPlayback();
+		sendJson(res, 200, { ok: true, playbackSamplesObserved: observed });
 		return true;
 	}
 

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
@@ -28,6 +28,7 @@ import {
 	type TurnTranscriber,
 	type VadSegmenter,
 } from "./audio-frame-consumer";
+import { PlaybackEchoReference } from "./playback-echo-reference";
 import type { VoiceAttributionOutput } from "./speaker/attribution-pipeline";
 import type { PcmFrame, VadEvent } from "./types";
 import { VadDetector } from "./vad";
@@ -569,5 +570,99 @@ describe("AudioFrameConsumer — echo cancellation (#9455)", () => {
 		const frame = farSignal(BLOCK, 7);
 		await consumer.pushDecodedFrame(frame, 1000);
 		expect(Array.from(vad.frames[0])).toEqual(Array.from(frame));
+	});
+});
+
+// --- echoReference wiring via the real PlaybackEchoReference store (#9583) ----
+
+describe("AudioFrameConsumer × PlaybackEchoReference wiring (#9583)", () => {
+	const SR = 16000;
+	const BLOCK = 320; // 20 ms mic frame
+
+	// A spectrally-rich far-end (the agent's TTS), reused from the #9455 model.
+	function farSignal(n: number, seed = 1): Float32Array {
+		const x = new Float32Array(n);
+		let s = seed >>> 0;
+		let p1 = 0;
+		let p2 = 0;
+		for (let i = 0; i < n; i++) {
+			s = (s * 1103515245 + 12345) & 0x7fffffff;
+			const w = s / 0x3fffffff - 1;
+			p1 = 0.92 * p1 + 0.08 * w;
+			p2 = 0.85 * p2 + 0.15 * p1;
+			x[i] = p2 * 3;
+		}
+		return x;
+	}
+	function echoOf(x: Float32Array): Float32Array {
+		const delay = 35;
+		const tail = 90;
+		const h = new Float32Array(delay + tail);
+		for (let k = 0; k < tail; k++)
+			h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * 0.22;
+		const y = new Float32Array(x.length);
+		for (let n = 0; n < x.length; n++) {
+			let acc = 0;
+			for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
+			y[n] = acc;
+		}
+		return y;
+	}
+	const power = (a: Float32Array) =>
+		a.reduce((p, v) => p + v * v, 0) / Math.max(1, a.length);
+
+	it("cancels the agent's echo when the store is the echoReference provider", async () => {
+		// The store is fed the far-end playback chunk-by-chunk on the playback
+		// clock, and the consumer's echoReference reads it back per mic frame — the
+		// real device wiring, end to end, with no test-only alignment closure.
+		const store = new PlaybackEchoReference();
+		const vad = new RecordingVad();
+		const consumer = new AudioFrameConsumer(
+			{
+				vad,
+				pipeline: new FakePipeline("e"),
+				runtime: new FakeRuntime(),
+				echoReference: (ts, samples) => store.reference(ts, samples),
+			},
+			{ source: { kind: "device", deviceId: "pixel" }, preRollSeconds: 0 },
+		);
+
+		const N = SR * 3;
+		const far = farSignal(N);
+		const echo = echoOf(far); // the agent's TTS leaking into the mic
+		let ts = 1000;
+		for (let off = 0; off + BLOCK <= N; off += BLOCK) {
+			// Observe the playback for this 20 ms window at the same clock the mic
+			// frame is stamped with, then push the (echo-contaminated) mic frame.
+			store.observePlayback(far.subarray(off, off + BLOCK), SR, ts);
+			await consumer.pushDecodedFrame(echo.subarray(off, off + BLOCK), ts);
+			ts += 20;
+		}
+
+		// After convergence the recorded (post-AEC) frame carries far less echo
+		// energy than the raw mic frame did — >10 dB ERLE, matching #9455's gate.
+		const lateOut = vad.frames[vad.frames.length - 1];
+		const lateRawOff = (vad.frames.length - 1) * BLOCK;
+		const lateRaw = echo.subarray(lateRawOff, lateRawOff + BLOCK);
+		expect(power(lateOut)).toBeLessThan(power(lateRaw) * 0.1);
+	});
+
+	it("passes the mic through unchanged when no playback was observed", async () => {
+		// Store wired but never fed (agent silent) → reference() is null → the
+		// canceller is a byte-identical passthrough, never suppressing a barge-in.
+		const store = new PlaybackEchoReference();
+		const vad = new RecordingVad();
+		const consumer = new AudioFrameConsumer(
+			{
+				vad,
+				pipeline: new FakePipeline("e"),
+				runtime: new FakeRuntime(),
+				echoReference: (ts, samples) => store.reference(ts, samples),
+			},
+			{ source: { kind: "device", deviceId: "pixel" }, preRollSeconds: 0 },
+		);
+		const userSpeech = farSignal(BLOCK, 7);
+		await consumer.pushDecodedFrame(userSpeech, 1000);
+		expect(Array.from(vad.frames[0])).toEqual(Array.from(userSpeech));
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -101,7 +101,17 @@ export function decodeAudioFramePcm(frame: AudioFrameEvent): Float32Array {
 			`[audio-frame-consumer] expected ${AUDIO_FRAME_PIPELINE_SAMPLE_RATE} Hz; got ${frame.sampleRate} Hz. Capture at 16 kHz (startAudioFrames default).`,
 		);
 	}
-	const bytes = base64ToBytes(frame.pcm16);
+	return decodeBase64Le16(frame.pcm16);
+}
+
+/**
+ * Decode a base64 little-endian s16 PCM payload into a Float32 [-1, 1] window.
+ * Shared by the mic (`decodeAudioFramePcm`) and far-end playback
+ * (`decodePlaybackFramePcm`) wire boundaries — both transports carry the same
+ * LE-s16 encoding.
+ */
+function decodeBase64Le16(pcm16: string): Float32Array {
+	const bytes = base64ToBytes(pcm16);
 	if (bytes.length % 2 !== 0) {
 		throw new AudioFrameDecodeError(
 			`[audio-frame-consumer] PCM byte length ${bytes.length} is odd — not a whole number of s16 samples`,
@@ -116,6 +126,35 @@ export function decodeAudioFramePcm(frame: AudioFrameEvent): Float32Array {
 		out[i] = view.getInt16(i * 2, true) / 32_768;
 	}
 	return out;
+}
+
+/**
+ * The agent's TTS playback (far-end) PCM for one report, mirroring the mic
+ * `AudioFrameEvent` wire shape (#9583). The WebView/native playback path reports
+ * the PCM it actually played so the agent's echo canceller can subtract the
+ * time-aligned far-end from the mic.
+ */
+export interface PlaybackFrameEvent {
+	/** Base64-encoded little-endian signed 16-bit mono PCM that was played. */
+	pcm16: string;
+	/** Sample rate of the played PCM in Hz (must be 16000 — the pipeline rate). */
+	sampleRate: number;
+	/** Playback-clock ms at which the first sample of this chunk was played. */
+	atMs: number;
+}
+
+/**
+ * Decode a {@link PlaybackFrameEvent} into the Float32 [-1, 1] window the
+ * playback echo-reference store buffers. Asserts the 16 kHz pipeline rate rather
+ * than resampling silently (a wrong far-end rate would mis-align the canceller).
+ */
+export function decodePlaybackFramePcm(frame: PlaybackFrameEvent): Float32Array {
+	if (frame.sampleRate !== AUDIO_FRAME_PIPELINE_SAMPLE_RATE) {
+		throw new AudioFrameDecodeError(
+			`[audio-frame-consumer] expected ${AUDIO_FRAME_PIPELINE_SAMPLE_RATE} Hz playback; got ${frame.sampleRate} Hz`,
+		);
+	}
+	return decodeBase64Le16(frame.pcm16);
 }
 
 /**

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -9,6 +9,9 @@ export {
 	AudioFrameDecodeError,
 	type AudioFrameEvent,
 	decodeAudioFramePcm,
+	decodePlaybackFramePcm,
+	type EchoReferenceProvider,
+	type PlaybackFrameEvent,
 	type RuntimeEventSink,
 	type VadSegmenter,
 } from "./audio-frame-consumer";
@@ -59,6 +62,10 @@ export {
 	type EchoDelayOptions,
 	estimateEchoDelaySamples,
 } from "./echo-delay";
+export {
+	PlaybackEchoReference,
+	type PlaybackEchoReferenceConfig,
+} from "./playback-echo-reference";
 export type {
 	LlamaContextLike as Eliza1EotLlamaContext,
 	LlamaContextSequenceLike as Eliza1EotLlamaSequence,

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -40,6 +40,7 @@ import type {
 	ElizaInferenceFfi,
 } from "./ffi-bindings.js";
 import { loadElizaInferenceFfi } from "./ffi-bindings.js";
+import { PlaybackEchoReference } from "./playback-echo-reference.js";
 import { VoiceProfileStore } from "./profile-store.js";
 import { VoiceAttributionPipeline } from "./speaker/attribution-pipeline.js";
 import { FusedDiarizer } from "./speaker/diarizer-fused.js";
@@ -47,6 +48,19 @@ import { FusedSpeakerEncoder } from "./speaker/encoder-fused.js";
 import { GgmlSileroVad, VadDetector } from "./vad.js";
 
 export type { RuntimeEventSink } from "./audio-frame-consumer.js";
+
+/**
+ * Resolve the fixed playback→mic transport delay (ms) for echo-reference
+ * alignment from the environment. The per-platform value is tuned on a device
+ * (the bulk-delay calibration in #9583); absent or invalid → 0 (the adaptive
+ * taps absorb the residual lag within their tail).
+ */
+function playbackToMicDelayMs(): number {
+	const raw = process.env.ELIZA_VOICE_PLAYBACK_TO_MIC_DELAY_MS?.trim();
+	if (!raw) return 0;
+	const value = Number(raw);
+	return Number.isFinite(value) && value >= 0 ? value : 0;
+}
 
 /** Resolve the on-device voice-model directory (env override wins). Doubles as
  *  the fused context bundle root — the runtime resolves per-model GGUFs from it. */
@@ -100,6 +114,8 @@ export interface LiveDiarizationStatus {
 	framesDropped: number;
 	/** Turns segmented + attributed so far. */
 	turnsObserved: number;
+	/** Agent TTS playback samples observed as the AEC far-end reference (#9583). */
+	playbackSamplesObserved: number;
 	/** The most recent attributed turns (capped), for device-evidence reads. */
 	recentTurns: LiveDiarizationTurnSummary[];
 	/** Populated only when readiness failed — the precise blocker. */
@@ -142,6 +158,17 @@ export class LiveDiarizationSession {
 	private buildError: string | null = null;
 	/** True once the fused ASR region is mmap-acquired for per-turn transcribe. */
 	private asrRegionAcquired = false;
+	/**
+	 * Far-end (agent TTS playback) reference for acoustic echo cancellation
+	 * (#9583). Fed by `observePlayback` from the playback tap; its `reference`
+	 * read is the consumer's `echoReference` provider, so every mic frame is
+	 * echo-cancelled against the time-aligned playback before VAD/attribution.
+	 */
+	private readonly playbackReference = new PlaybackEchoReference({
+		playbackToMicDelayMs: playbackToMicDelayMs(),
+	});
+	/** Cumulative playback samples observed (status / device evidence). */
+	private playbackSamplesObserved = 0;
 
 	constructor(private readonly runtime: RuntimeEventSink) {}
 
@@ -225,6 +252,12 @@ export class LiveDiarizationSession {
 				pipeline,
 				runtime: this.runtime,
 				...(transcribe ? { transcribe } : {}),
+				// #9583: cancel the agent's own TTS echo off the mic before VAD.
+				// `observePlayback` feeds the far-end; this answers each mic frame's
+				// window with the time-aligned playback (null when the agent is
+				// silent → byte-identical passthrough).
+				echoReference: (timestampMs, samples) =>
+					this.playbackReference.reference(timestampMs, samples),
 			},
 			config,
 		);
@@ -288,6 +321,24 @@ export class LiveDiarizationSession {
 		}
 	}
 
+	/**
+	 * Record a chunk of the agent's TTS playback PCM (the far-end echo reference),
+	 * anchored to the playback-clock ms at which its first sample is played
+	 * (#9583). The echo canceller subtracts the time-aligned playback from each
+	 * mic frame, so the agent never transcribes its own voice. Fed from the
+	 * playback tap (the same audio the scheduler hands to output). PCM must be
+	 * 16 kHz mono Float32 [-1, 1] — the mic pipeline's single rate.
+	 */
+	observePlayback(pcm: Float32Array, sampleRate: number, atMs: number): void {
+		this.playbackReference.observePlayback(pcm, sampleRate, atMs);
+		this.playbackSamplesObserved += pcm.length;
+	}
+
+	/** Drop all buffered playback (call when playback stops / on a hard boundary). */
+	resetPlayback(): void {
+		this.playbackReference.reset();
+	}
+
 	/** Flush any open segment (call on stopAudioFrames) and await attribution. */
 	async flush(): Promise<void> {
 		if (this.consumer) await this.consumer.flush();
@@ -307,6 +358,7 @@ export class LiveDiarizationSession {
 			framesReceived: this.framesReceived,
 			framesDropped: this.consumer?.droppedFrames ?? 0,
 			turnsObserved: this.turnsObserved,
+			playbackSamplesObserved: this.playbackSamplesObserved,
 			recentTurns: [...this.recentTurns],
 			...(this.buildError ? { error: this.buildError } : {}),
 		};
@@ -314,6 +366,7 @@ export class LiveDiarizationSession {
 
 	/** Release native handles + listeners. */
 	async close(): Promise<void> {
+		this.playbackReference.reset();
 		await this.consumer?.close();
 		if (this.asrRegionAcquired && this.ffi && this.ctx !== null) {
 			try {

--- a/plugins/plugin-local-inference/src/services/voice/playback-echo-reference.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/playback-echo-reference.test.ts
@@ -1,0 +1,129 @@
+/**
+ * PlaybackEchoReference unit tests (#9583) — the far-end provider that captures
+ * the agent's TTS playback PCM and answers a mic frame's `(timestampMs,
+ * samples)` window with the time-aligned playback, so the NLMS canceller in
+ * `echo-canceller.ts` can subtract the agent's own voice off the mic.
+ *
+ * Pure store: no models, no FFI — runs in the fast lane. Asserts the windowed
+ * read (exact alignment, chunk-spanning, zero-padded partial overlap, silent
+ * gaps), the playback→mic delay shift, retention eviction, and rate guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { PlaybackEchoReference } from "./playback-echo-reference";
+
+const SR = 16_000;
+
+/** A ramp `[atIndex, atIndex+n)` so a returned window is identifiable by value. */
+function ramp(start: number, n: number): Float32Array {
+	const out = new Float32Array(n);
+	for (let i = 0; i < n; i++) out[i] = (start + i) / 1000;
+	return out;
+}
+
+/** ms at which playback-timeline sample `idx` plays, given an origin ms. */
+function msOf(originMs: number, idx: number): number {
+	return originMs + (idx / SR) * 1000;
+}
+
+describe("PlaybackEchoReference", () => {
+	it("returns the exact playback window for an aligned mic frame", () => {
+		const store = new PlaybackEchoReference();
+		// One 320-sample chunk played at t=1000 ms.
+		store.observePlayback(ramp(0, 320), SR, 1000);
+		const out = store.reference(1000, 320);
+		expect(out).not.toBeNull();
+		expect(out?.length).toBe(320);
+		expect(Array.from(out as Float32Array)).toEqual(Array.from(ramp(0, 320)));
+	});
+
+	it("returns null when the agent was silent over the queried window", () => {
+		const store = new PlaybackEchoReference();
+		store.observePlayback(ramp(0, 320), SR, 1000);
+		// A window entirely before the playback started.
+		expect(store.reference(500, 320)).toBeNull();
+		// A window entirely after the single chunk ended (320 samples = 20 ms).
+		expect(store.reference(2000, 320)).toBeNull();
+		// And the empty store answers null for anything.
+		expect(new PlaybackEchoReference().reference(1000, 320)).toBeNull();
+	});
+
+	it("spans contiguous chunks into one window", () => {
+		const store = new PlaybackEchoReference();
+		// Two back-to-back 160-sample chunks: [0,160) at 1000ms, [160,320) at the
+		// ms 160 samples later. A 320-sample read from 1000ms must stitch both.
+		store.observePlayback(ramp(0, 160), SR, 1000);
+		store.observePlayback(ramp(160, 160), SR, msOf(1000, 160));
+		const out = store.reference(1000, 320);
+		expect(out).not.toBeNull();
+		expect(Array.from(out as Float32Array)).toEqual(Array.from(ramp(0, 320)));
+	});
+
+	it("zero-pads a partial overlap (silence where nothing played)", () => {
+		const store = new PlaybackEchoReference();
+		// 160 samples played at 1000ms. A 320-sample window from 1000ms overlaps
+		// the first 160 and is silent (0) for the trailing 160.
+		store.observePlayback(ramp(1, 160), SR, 1000);
+		const out = store.reference(1000, 320);
+		expect(out).not.toBeNull();
+		const arr = out as Float32Array;
+		expect(arr.length).toBe(320);
+		expect(Array.from(arr.subarray(0, 160))).toEqual(Array.from(ramp(1, 160)));
+		for (let i = 160; i < 320; i++) expect(arr[i]).toBe(0);
+	});
+
+	it("shifts the query back by the playback→mic transport delay", () => {
+		// 10 ms (160 samples) of delay: a mic frame timestamped 10ms later than the
+		// playback start must read the playback's first samples (the echo arrives
+		// at the mic 10ms after it left the speaker).
+		const store = new PlaybackEchoReference({ playbackToMicDelayMs: 10 });
+		store.observePlayback(ramp(0, 320), SR, 1000);
+		// Without the shift, a 1010ms query would land 160 samples in; with the
+		// 10ms shift it realigns to the playback start.
+		const out = store.reference(1010, 160);
+		expect(out).not.toBeNull();
+		expect(Array.from(out as Float32Array)).toEqual(Array.from(ramp(0, 160)));
+	});
+
+	it("evicts old playback past the retention budget but keeps recent reads", () => {
+		// 1 s retention: ~50 chunks of 320 samples = 1 s. Push well past it.
+		const store = new PlaybackEchoReference({ retentionSeconds: 1 });
+		let originMs = 1000;
+		let idx = 0;
+		for (let c = 0; c < 100; c++) {
+			store.observePlayback(ramp(idx, 320), SR, msOf(1000, idx));
+			idx += 320;
+			originMs = msOf(1000, idx);
+		}
+		// Retained span is bounded ~1 s (≤ retention + one chunk).
+		expect(store.samples).toBeLessThanOrEqual(SR + 320);
+		// The most recent chunk is still readable...
+		const lastStartMs = msOf(1000, idx - 320);
+		const out = store.reference(lastStartMs, 320);
+		expect(out).not.toBeNull();
+		expect(Array.from(out as Float32Array)).toEqual(
+			Array.from(ramp(idx - 320, 320)),
+		);
+		// ...while the very first chunk (long evicted) reads as silence.
+		expect(store.reference(1000, 320)).toBeNull();
+		void originMs;
+	});
+
+	it("reset() drops all buffered playback", () => {
+		const store = new PlaybackEchoReference();
+		store.observePlayback(ramp(0, 320), SR, 1000);
+		expect(store.samples).toBe(320);
+		store.reset();
+		expect(store.samples).toBe(0);
+		expect(store.reference(1000, 320)).toBeNull();
+	});
+
+	it("ignores empty chunks and rejects a wrong sample rate", () => {
+		const store = new PlaybackEchoReference();
+		store.observePlayback(new Float32Array(0), SR, 1000);
+		expect(store.samples).toBe(0);
+		expect(() => store.observePlayback(ramp(0, 8), 48_000, 1000)).toThrow(
+			/16000 Hz/,
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/playback-echo-reference.ts
+++ b/plugins/plugin-local-inference/src/services/voice/playback-echo-reference.ts
@@ -1,0 +1,179 @@
+/**
+ * Playback echo reference store (#9583, follow-up to #9455).
+ *
+ * The NLMS echo canceller in `echo-canceller.ts` needs the agent's TTS playback
+ * PCM (the far-end reference) time-aligned to each mic frame so it can subtract
+ * the agent's own voice from the mic before VAD/attribution. The canceller seam
+ * in `audio-frame-consumer.ts` accepts an injected `EchoReferenceProvider`:
+ *
+ *     (timestampMs: number, samples: number) => Float32Array | null
+ *
+ * This store IS that provider. It is fed every TTS playback chunk the agent
+ * hands to audio output — the same tap that feeds {@link AgentSelfVoiceImprint}
+ * (`VoiceScheduler` `onAudio`) — and it answers a mic frame's `(timestampMs,
+ * samples)` query with the playback PCM that was playing during that exact mic
+ * window, or `null` when the agent was silent then.
+ *
+ * Clock domains. Playback PCM is observed in the playback wall clock; the mic
+ * frame carries the capture (near-end) clock. Both are `Date.now()`-style ms on
+ * the same device, so they share an origin, but the audio leaving the speaker
+ * reaches the mic only after a fixed transport lag (audio-HAL buffering,
+ * Bluetooth, resampling). `playbackToMicDelayMs` shifts the query window back by
+ * that lag so the far-end aligns with the near-end the adaptive filter sees. The
+ * per-platform value of that delay must be measured on hardware (the bulk-delay
+ * calibration is the device-gated part of #9583 — `echo-delay.ts` estimates it
+ * by cross-correlation); the default here is 0 (no pre-alignment), leaving the
+ * adaptive taps to absorb the residual within their tail.
+ *
+ * Pure: no FFI, no fs, no network, no timers — it just buffers Float32 PCM and
+ * answers windowed reads, so it runs in the fast unit-test lane like the
+ * canceller it feeds. The caller owns the playback tap and the delay value.
+ */
+
+import { AUDIO_FRAME_PIPELINE_SAMPLE_RATE } from "./audio-frame-consumer.js";
+
+export interface PlaybackEchoReferenceConfig {
+	/**
+	 * Sample rate the reference is dimensioned for (Hz). Must match the mic
+	 * pipeline so a query's `samples` maps 1:1 to playback samples. Default
+	 * 16000 (the only rate the on-device voice graphs accept).
+	 */
+	sampleRate?: number;
+	/**
+	 * Fixed playback→mic transport delay (ms): the bulk lag between a sample
+	 * leaving the speaker and the mic capturing its echo. The query window is
+	 * shifted back by this much so the returned far-end lines up with the
+	 * near-end. Default 0 (no pre-alignment; the adaptive taps absorb the lag).
+	 * The real per-platform value is tuned on a device (see `echo-delay.ts`).
+	 */
+	playbackToMicDelayMs?: number;
+	/**
+	 * Seconds of playback PCM retained. Bounds memory and caps how far back a
+	 * late mic frame can be answered. Default 8 s — far longer than the
+	 * canceller's tail plus any plausible transport delay, so an in-order mic
+	 * frame is always covered while a long playback never grows unbounded.
+	 */
+	retentionSeconds?: number;
+}
+
+const DEFAULTS = {
+	sampleRate: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	playbackToMicDelayMs: 0,
+	retentionSeconds: 8,
+} as const;
+
+/** One observed playback chunk, anchored to its playback-clock start time. */
+interface PlaybackChunk {
+	/** Playback-clock ms at which this chunk's first sample left the speaker. */
+	startMs: number;
+	/** Float32 PCM [-1, 1] at the store's sample rate. */
+	pcm: Float32Array;
+}
+
+export class PlaybackEchoReference {
+	private readonly sampleRate: number;
+	private readonly playbackToMicDelayMs: number;
+	private readonly retentionSamples: number;
+	/** Observed playback chunks, oldest first, contiguous in playback time. */
+	private readonly chunks: PlaybackChunk[] = [];
+	private bufferedSamples = 0;
+	/** Playback-clock ms of the first still-retained sample (chunks[0].startMs). */
+	private get oldestMs(): number {
+		return this.chunks.length > 0 ? this.chunks[0].startMs : 0;
+	}
+
+	constructor(config: PlaybackEchoReferenceConfig = {}) {
+		this.sampleRate = config.sampleRate ?? DEFAULTS.sampleRate;
+		this.playbackToMicDelayMs =
+			config.playbackToMicDelayMs ?? DEFAULTS.playbackToMicDelayMs;
+		const retentionSeconds =
+			config.retentionSeconds ?? DEFAULTS.retentionSeconds;
+		this.retentionSamples = Math.max(
+			this.sampleRate,
+			Math.round(retentionSeconds * this.sampleRate),
+		);
+	}
+
+	/**
+	 * Record one chunk of TTS playback PCM, anchored to the playback-clock ms at
+	 * which its first sample is played. `sampleRate` must match the store's rate
+	 * — a mismatch is a bug (the on-device pipeline is single-rate), not a thing
+	 * to resample silently. Empty chunks are ignored.
+	 */
+	observePlayback(pcm: Float32Array, sampleRate: number, atMs: number): void {
+		if (sampleRate !== this.sampleRate) {
+			throw new Error(
+				`[PlaybackEchoReference] expected ${this.sampleRate} Hz playback; got ${sampleRate} Hz`,
+			);
+		}
+		if (pcm.length === 0) return;
+		this.chunks.push({ startMs: atMs, pcm });
+		this.bufferedSamples += pcm.length;
+		this.evictOld();
+	}
+
+	/**
+	 * The {@link EchoReferenceProvider} read: the playback PCM aligned to the mic
+	 * window `[timestampMs, timestampMs + samples/sampleRate)`, or `null` when no
+	 * playback covers it (agent silent → canceller passes the mic through).
+	 *
+	 * The mic window is shifted back by `playbackToMicDelayMs` to undo the bulk
+	 * transport lag, then mapped onto the buffered playback timeline. A partial
+	 * overlap is zero-padded to exactly `samples` (the leading/trailing silence
+	 * is correct: nothing was playing there). A window with no overlap at all
+	 * returns `null` so the canceller skips adaptation on a silent reference.
+	 */
+	reference(timestampMs: number, samples: number): Float32Array | null {
+		if (samples <= 0 || this.chunks.length === 0) return null;
+		const farStartMs = timestampMs - this.playbackToMicDelayMs;
+		// Sample index of the window start on the playback timeline, relative to
+		// the oldest retained sample.
+		const startIdx = Math.round(
+			((farStartMs - this.oldestMs) * this.sampleRate) / 1000,
+		);
+		const endIdx = startIdx + samples;
+		// No overlap with the retained playback timeline → agent was silent.
+		if (endIdx <= 0 || startIdx >= this.bufferedSamples) return null;
+
+		const out = new Float32Array(samples);
+		// Walk the contiguous chunks, copying the overlapping span of each into the
+		// output at its window-relative offset. `cursor` is the playback-timeline
+		// index of the current chunk's first sample.
+		let cursor = 0;
+		for (const chunk of this.chunks) {
+			const chunkStart = cursor;
+			const chunkEnd = cursor + chunk.pcm.length;
+			cursor = chunkEnd;
+			const overlapStart = Math.max(startIdx, chunkStart);
+			const overlapEnd = Math.min(endIdx, chunkEnd);
+			if (overlapEnd <= overlapStart) continue;
+			out.set(
+				chunk.pcm.subarray(overlapStart - chunkStart, overlapEnd - chunkStart),
+				overlapStart - startIdx,
+			);
+		}
+		return out;
+	}
+
+	/** Drop all buffered playback (call when playback stops / on a hard boundary). */
+	reset(): void {
+		this.chunks.length = 0;
+		this.bufferedSamples = 0;
+	}
+
+	/** Retained playback samples (test/observability). */
+	get samples(): number {
+		return this.bufferedSamples;
+	}
+
+	/** Evict oldest whole chunks once the retained span exceeds the budget. */
+	private evictOld(): void {
+		while (
+			this.chunks.length > 1 &&
+			this.bufferedSamples - this.chunks[0].pcm.length >= this.retentionSamples
+		) {
+			const dropped = this.chunks.shift();
+			if (dropped) this.bufferedSamples -= dropped.pcm.length;
+		}
+	}
+}


### PR DESCRIPTION
Code-doable part of #9583 (NLMS canceller core was merged in #9575): server-side `PlaybackEchoReference` provider + `/api/voice/playback-frames` ingest + the in-process tap point, feeding the time-aligned TTS playback PCM into the canceller seam in `audio-frame-consumer.ts`. Exposes `ELIZA_VOICE_PLAYBACK_TO_MIC_DELAY_MS`. Verified: 39/39 vitest (playback-echo-reference + audio-frame-consumer + live-diarization-route) on the develop base. The per-platform playback→mic delay CALIBRATION + the device-side producer that POSTs playback frames are hardware-gated (tracked on #9583); AEC3 residual-suppression is out of scope (barge-in handled upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)