### PR TITLE
feat(voice): wire live AEC echoReference + on-device delay calibration (#9583)

### DIFF
--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -159,6 +159,7 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `ELIZA_NETWORK_POLICY` | No | Network access policy override for inference routing |
 | `ELIZA_VOICE_EOT_BACKEND` | No | End-of-turn detector backend selection for voice pipeline |
 | `ELIZA_VOICE_UPDATE_INTERVAL_MS` | No | Polling interval (ms) for voice model update checks |
+| `ELIZA_VOICE_AEC_RESIDUAL_SUPPRESSION` | No | Set truthy (`1`/`true`/`yes`/`on`) to enable the opt-in AEC3-class residual-echo suppressor on the live diarization path (#9583). Default off. Only attenuates echo-only frames; never touches double-talk. |
 | `SD_CPP_BIN` | No | Absolute path to sd.cpp binary |
 | `MFLUX_BIN` | No | Absolute path to mflux binary |
 | `IMAGEGEN_TRT_BIN` | No | Absolute path to TensorRT image-gen binary |

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -159,6 +159,7 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `ELIZA_NETWORK_POLICY` | No | Network access policy override for inference routing |
 | `ELIZA_VOICE_EOT_BACKEND` | No | End-of-turn detector backend selection for voice pipeline |
 | `ELIZA_VOICE_UPDATE_INTERVAL_MS` | No | Polling interval (ms) for voice model update checks |
+| `ELIZA_VOICE_AEC_RESIDUAL_SUPPRESSION` | No | Set truthy (`1`/`true`/`yes`/`on`) to enable the opt-in AEC3-class residual-echo suppressor on the live diarization path (#9583). Default off. Only attenuates echo-only frames; never touches double-talk. |
 | `SD_CPP_BIN` | No | Absolute path to sd.cpp binary |
 | `MFLUX_BIN` | No | Absolute path to mflux binary |
 | `IMAGEGEN_TRT_BIN` | No | Absolute path to TensorRT image-gen binary |

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -12,6 +12,9 @@
  *   POST /api/voice/audio-frames        body: { frames: AudioFrameEvent[],
  *                                               flush?: boolean }
  *                                       → { ok, framesReceived, turnsObserved }
+ *   POST /api/voice/audio-frames/playback  body: { frames: AudioFrameEvent[] }
+ *                                       → { ok, playbackFramesReceived } — the
+ *                                         agent-TTS far-end echo reference (#9583)
  *   GET  /api/voice/audio-frames/status → LiveDiarizationStatus (device evidence)
  *
  * Auth follows the compat pattern: trusted-loopback OR the compat API token.
@@ -80,6 +83,41 @@ export async function handleLiveDiarizationRoute(
 			return true;
 		}
 		sendJson(res, 200, await current.status());
+		return true;
+	}
+
+	if (
+		url.pathname === "/api/voice/audio-frames/playback" &&
+		method === "POST"
+	) {
+		if (!ensureCompatApiAuthorized(req, res)) return true;
+		const current = getSession(state);
+		if (!current) {
+			sendJsonError(res, 503, "Runtime not ready");
+			return true;
+		}
+		const body = await readCompatJsonBody(req, res);
+		if (!body) return true;
+		const rawFrames = body.frames;
+		if (!Array.isArray(rawFrames)) {
+			sendJsonError(res, 400, "Expected { frames: AudioFrameEvent[] }");
+			return true;
+		}
+		const frames = rawFrames.filter(isAudioFrameEvent);
+		if (frames.length !== rawFrames.length) {
+			sendJsonError(
+				res,
+				400,
+				`Malformed frame(s): ${rawFrames.length - frames.length} of ${rawFrames.length} did not match AudioFrameEvent`,
+			);
+			return true;
+		}
+		await current.ingestPlayback(frames);
+		const status = await current.status();
+		sendJson(res, 200, {
+			ok: true,
+			playbackFramesReceived: status.aec.playbackFramesReceived,
+		});
 		return true;
 	}
 

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -36,15 +36,15 @@ import {
 	handleLiveVoiceAttribution,
 } from "../../runtime/voice-entity-binding.js";
 import type { VoiceTurnSignal } from "./eot-classifier.js";
+import {
+	NlmsEchoCanceller,
+	type NlmsEchoCancellerOptions,
+} from "./nlms-echo-canceller.js";
 import type {
 	VoiceAttributionOutput,
 	VoiceAttributionPipeline,
 } from "./speaker/attribution-pipeline.js";
 import type { PcmFrame, VadEvent, VoiceInputSource } from "./types.js";
-import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
-
-/** Shared empty reference — agent silent → echo canceller passes the mic through. */
-const NO_ECHO_REFERENCE = new Float32Array(0);
 
 // ---------------------------------------------------------------------------
 // Wire format → Float32 boundary
@@ -236,6 +236,14 @@ export interface AudioFrameConsumerDeps {
 	 * owns the playback capture + the playback→mic delay calibration.
 	 */
 	echoReference?: EchoReferenceProvider;
+	/**
+	 * Tuning for the NLMS echo canceller (#9583). Only consulted when
+	 * `echoReference` is also wired. Lets the caller set the residual-impulse
+	 * filter span / step size and enable the optional residual-echo suppressor.
+	 * The bulk playback→mic delay is applied caller-side in the `echoReference`
+	 * provider, so `delaySamples` here normally stays 0.
+	 */
+	echoCancellerOptions?: NlmsEchoCancellerOptions;
 }
 
 /**
@@ -326,6 +334,10 @@ export class AudioFrameConsumer {
 	 *  turn rather than dropping the diarized turn). */
 	transcriptionErrors = 0;
 
+	/** Count of mic frames the echo canceller actually processed (agent was
+	 *  playing). Stays 0 when no `echoReference` is wired or the agent is silent. */
+	echoFramesCancelled = 0;
+
 	constructor(
 		deps: AudioFrameConsumerDeps,
 		config: AudioFrameConsumerConfig = {},
@@ -336,7 +348,9 @@ export class AudioFrameConsumer {
 		this.transcribe = deps.transcribe ?? null;
 		this.resolveSelfVoiceSimilarity = deps.resolveSelfVoiceSimilarity ?? null;
 		this.echoReference = deps.echoReference ?? null;
-		this.echoCanceller = this.echoReference ? new NlmsEchoCanceller() : null;
+		this.echoCanceller = this.echoReference
+			? new NlmsEchoCanceller(deps.echoCancellerOptions ?? {})
+			: null;
 		this.source = config.source;
 		this.attributionOptions = config.attributionOptions ?? {};
 		const sr = AUDIO_FRAME_PIPELINE_SAMPLE_RATE;
@@ -398,16 +412,12 @@ export class AudioFrameConsumer {
 		timestampMs: number,
 	): Promise<void> {
 		if (this.closed) return;
-		// #9455: cancel the agent's TTS echo before VAD/attribution so the agent
-		// never transcribes its own playback. Passthrough (out == in) when the
-		// agent is silent — verified by nlms-echo-canceller.test.ts.
-		const micPcm =
-			this.echoCanceller && this.echoReference
-				? this.echoCanceller.process(
-						pcm,
-						this.echoReference(timestampMs, pcm.length) ?? NO_ECHO_REFERENCE,
-					)
-				: pcm;
+		// #9455/#9583: cancel the agent's TTS echo before VAD/attribution so the
+		// agent never transcribes its own playback. When the reference provider
+		// returns null the agent is silent — skip the canceller entirely so AEC is
+		// zero-cost on the common (no-playback) path, exactly passing the mic
+		// through (verified by nlms-echo-canceller.test.ts).
+		const micPcm = this.cancelEcho(pcm, timestampMs);
 		this.lastFrameEndMs =
 			timestampMs + (micPcm.length / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000;
 		if (this.capturing) {
@@ -420,6 +430,27 @@ export class AudioFrameConsumer {
 			sampleRate: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
 			timestampMs,
 		});
+	}
+
+	/**
+	 * Run the echo canceller on one mic frame when (and only when) the agent is
+	 * playing. The reference provider returns null while the agent is silent, in
+	 * which case the mic is passed through verbatim and the canceller is not
+	 * invoked at all (zero idle cost). Returns the echo-cancelled (or untouched)
+	 * mic frame.
+	 */
+	private cancelEcho(pcm: Float32Array, timestampMs: number): Float32Array {
+		if (!this.echoCanceller || !this.echoReference) return pcm;
+		const reference = this.echoReference(timestampMs, pcm.length);
+		if (!reference || reference.length === 0) return pcm;
+		this.echoFramesCancelled += 1;
+		return this.echoCanceller.process(pcm, reference);
+	}
+
+	/** Echo-return-loss-enhancement (dB) over the last cancelled frame, or 0 when
+	 *  AEC is not wired or the agent is currently silent. */
+	get lastEchoErleDb(): number {
+		return this.echoCanceller?.lastErleDb ?? 0;
 	}
 
 	/**

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay-calibrator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay-calibrator.test.ts
@@ -1,0 +1,98 @@
+/**
+ * echo-delay-calibrator tests (#9583): cross-correlation delay recovery +
+ * per-platform seed table.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_PLAYBACK_DELAY_MS,
+	estimatePlaybackDelaySamples,
+	PLATFORM_PLAYBACK_DELAY_DEFAULTS,
+	platformPlaybackDelayMs,
+	platformPlaybackDelaySamples,
+} from "./echo-delay-calibrator";
+
+const SR = 16_000;
+
+function speechLike(n: number, seed: number): Float32Array {
+	const x = new Float32Array(n);
+	let s = seed >>> 0;
+	let p1 = 0;
+	let p2 = 0;
+	for (let i = 0; i < n; i++) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		const w = s / 0x3fffffff - 1;
+		p1 = 0.92 * p1 + 0.08 * w;
+		p2 = 0.85 * p2 + 0.15 * p1;
+		x[i] = p2 * 3;
+	}
+	return x;
+}
+
+describe("estimatePlaybackDelaySamples", () => {
+	it("recovers a known bulk playback→mic delay", () => {
+		const N = SR; // 1 s
+		const far = speechLike(N, 7);
+		const D = 120; // the delay we expect to recover
+		const mic = new Float32Array(N);
+		for (let i = D; i < N; i++) mic[i] = 0.5 * far[i - D]; // echo = attenuated, delayed far
+		const result = estimatePlaybackDelaySamples(mic, far, {
+			maxLagSamples: 400,
+		});
+		expect(Math.abs(result.delaySamples - D)).toBeLessThanOrEqual(2);
+		expect(result.confidence).toBeGreaterThan(0.7);
+		expect(result.delayMs).toBeCloseTo((result.delaySamples / SR) * 1000, 3);
+	});
+
+	it("recovers a zero delay (reference already aligned)", () => {
+		const N = SR;
+		const far = speechLike(N, 11);
+		const mic = new Float32Array(N);
+		for (let i = 0; i < N; i++) mic[i] = 0.4 * far[i];
+		const result = estimatePlaybackDelaySamples(mic, far, {
+			maxLagSamples: 400,
+		});
+		expect(result.delaySamples).toBeLessThanOrEqual(2);
+		expect(result.confidence).toBeGreaterThan(0.7);
+	});
+
+	it("returns zero confidence for silence", () => {
+		const result = estimatePlaybackDelaySamples(
+			new Float32Array(SR),
+			new Float32Array(SR),
+		);
+		expect(result.confidence).toBe(0);
+		expect(result.delaySamples).toBe(0);
+	});
+
+	it("is not fooled into a high-confidence lock by uncorrelated near-end speech", () => {
+		const N = SR;
+		const far = speechLike(N, 3);
+		const nearOnly = speechLike(N, 9999); // user speech, no echo of `far`
+		const result = estimatePlaybackDelaySamples(nearOnly, far, {
+			maxLagSamples: 400,
+		});
+		expect(result.confidence).toBeLessThan(0.3);
+	});
+});
+
+describe("platform playback-delay seeds", () => {
+	it("maps known platforms to their seed and samples", () => {
+		expect(platformPlaybackDelayMs("darwin")).toBe(
+			PLATFORM_PLAYBACK_DELAY_DEFAULTS.darwin,
+		);
+		expect(platformPlaybackDelaySamples("darwin")).toBe(
+			Math.round((PLATFORM_PLAYBACK_DELAY_DEFAULTS.darwin / 1000) * SR),
+		);
+		expect(platformPlaybackDelayMs("ios")).toBe(
+			PLATFORM_PLAYBACK_DELAY_DEFAULTS.ios,
+		);
+	});
+
+	it("falls back to the default for an unknown platform", () => {
+		expect(platformPlaybackDelayMs("plan9")).toBe(DEFAULT_PLAYBACK_DELAY_MS);
+		expect(platformPlaybackDelaySamples("plan9")).toBe(
+			Math.round((DEFAULT_PLAYBACK_DELAY_MS / 1000) * SR),
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay-calibrator.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay-calibrator.ts
@@ -1,0 +1,154 @@
+/**
+ * echo-delay-calibrator.ts — estimate the bulk playback→mic delay so the
+ * acoustic echo canceller starts already aligned (#9583, follow-up to #9455).
+ *
+ * The {@link NlmsEchoCanceller} adapts a short FIR (default 256 taps ≈ 16 ms) to
+ * the residual room impulse. It is NOT meant to model the much larger, mostly
+ * constant playback→mic *transport* delay (capture buffering + speaker/mic
+ * hardware latency), which on real devices ranges from ~15 ms (CoreAudio) to
+ * ~80 ms (some Android stacks). Feeding the canceller a reference that is
+ * already delay-aligned (see {@link createEchoReferenceProvider}) keeps the
+ * adaptive taps small and convergence fast.
+ *
+ * Two layers:
+ *  1. {@link PLATFORM_PLAYBACK_DELAY_DEFAULTS} / {@link platformPlaybackDelaySamples}
+ *     — per-platform SEED delays, applied before any audio is seen.
+ *  2. {@link estimatePlaybackDelaySamples} — a normalized cross-correlation
+ *     (GCC-style) delay estimate over an *echo-only* window (agent speaking,
+ *     user silent). The peak-lag is the measured delay; the peak value is a
+ *     confidence the caller can gate on before replacing the seed.
+ *
+ * Pure DSP, zero dependencies — verified by echo-delay-calibrator.test.ts.
+ */
+
+import { AUDIO_FRAME_PIPELINE_SAMPLE_RATE } from "./audio-frame-consumer.js";
+
+/**
+ * Per-platform SEED playback→mic delays (ms). These are conservative starting
+ * points used until an on-device {@link estimatePlaybackDelaySamples} calibrates
+ * a real value; they are NOT precise device characterizations. Sources of the
+ * delay: OS audio-capture buffering + speaker/mic hardware latency + (for the
+ * device-bridge path) the WebView→agent frame batching. Refine per device.
+ */
+export const PLATFORM_PLAYBACK_DELAY_DEFAULTS: Readonly<
+	Record<string, number>
+> = {
+	/** macOS CoreAudio — low, stable hardware path. */
+	darwin: 20,
+	/** iOS AVAudioEngine (when its voice-processing IO AEC is not the source). */
+	ios: 25,
+	/** Android AudioTrack/AudioRecord — variable; a mid seed. */
+	android: 45,
+	/** Windows WASAPI shared-mode. */
+	win32: 30,
+	/** Desktop Linux ALSA/Pulse/Pipewire. */
+	linux: 30,
+};
+
+/** Fallback seed (ms) for an unrecognized platform. */
+export const DEFAULT_PLAYBACK_DELAY_MS = 25;
+
+/** Resolve the seed playback→mic delay (ms) for a platform id (e.g. `process.platform`). */
+export function platformPlaybackDelayMs(platform: string): number {
+	return (
+		PLATFORM_PLAYBACK_DELAY_DEFAULTS[platform] ?? DEFAULT_PLAYBACK_DELAY_MS
+	);
+}
+
+/** Resolve the seed playback→mic delay in samples (16 kHz) for a platform id. */
+export function platformPlaybackDelaySamples(platform: string): number {
+	return Math.round(
+		(platformPlaybackDelayMs(platform) / 1000) *
+			AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	);
+}
+
+export interface DelayCalibrationOptions {
+	/** Largest delay to search, samples. Default 1920 (120 ms @ 16 kHz). */
+	maxLagSamples?: number;
+	/** Smallest delay to search, samples. Default 0. */
+	minLagSamples?: number;
+	/** Sample rate of the supplied PCM (Hz). Default 16 000. */
+	sampleRate?: number;
+}
+
+export interface DelayCalibrationResult {
+	/** Estimated bulk playback→mic delay (samples) — the peak-correlation lag. */
+	delaySamples: number;
+	/** Same delay in milliseconds, for logging/diagnostics. */
+	delayMs: number;
+	/** Peak normalized cross-correlation in [0, 1]; a calibration confidence. */
+	confidence: number;
+}
+
+/**
+ * Estimate the playback→mic delay by normalized cross-correlation of an
+ * echo-only mic window against the far-end (playback) reference for the same
+ * nominal time window.
+ *
+ * For each candidate lag `L`, correlate `mic[n]` with `far[n − L]` (the echo at
+ * `n` is the playback from `L` samples earlier). The lag maximizing the
+ * normalized correlation is the delay; the peak value is the confidence. Call
+ * this ONLY on an echo-only span (agent speaking, user silent) — near-end speech
+ * decorrelates the estimate.
+ *
+ * Returns `{ delaySamples: 0, confidence: 0 }` when either signal is silent.
+ */
+export function estimatePlaybackDelaySamples(
+	mic: Float32Array,
+	far: Float32Array,
+	opts: DelayCalibrationOptions = {},
+): DelayCalibrationResult {
+	const sampleRate = opts.sampleRate ?? AUDIO_FRAME_PIPELINE_SAMPLE_RATE;
+	const n = Math.min(mic.length, far.length);
+	const maxLag = Math.min(
+		Math.max(0, Math.floor(opts.maxLagSamples ?? 1920)),
+		Math.max(0, n - 1),
+	);
+	const minLag = Math.min(
+		Math.max(0, Math.floor(opts.minLagSamples ?? 0)),
+		maxLag,
+	);
+
+	const micEnergy = energy(mic, 0, n);
+	if (micEnergy <= 0 || energy(far, 0, n) <= 0) {
+		return { delaySamples: 0, delayMs: 0, confidence: 0 };
+	}
+
+	let bestLag = minLag;
+	let bestCorr = -Infinity;
+	for (let lag = minLag; lag <= maxLag; lag++) {
+		// Sum over the overlap where both mic[i] and far[i - lag] exist.
+		let dot = 0;
+		let farEnergy = 0;
+		for (let i = lag; i < n; i++) {
+			const f = far[i - lag];
+			dot += mic[i] * f;
+			farEnergy += f * f;
+		}
+		if (farEnergy <= 0) continue;
+		// Normalize by the lagged far energy and the (fixed) mic energy so the
+		// correlation is a true [-1, 1] coefficient comparable across lags.
+		const norm = Math.sqrt(micEnergy * farEnergy);
+		const corr = norm > 0 ? dot / norm : 0;
+		if (corr > bestCorr) {
+			bestCorr = corr;
+			bestLag = lag;
+		}
+	}
+
+	const confidence = Number.isFinite(bestCorr)
+		? Math.max(0, Math.min(1, bestCorr))
+		: 0;
+	return {
+		delaySamples: bestLag,
+		delayMs: (bestLag / sampleRate) * 1000,
+		confidence,
+	};
+}
+
+function energy(a: Float32Array, from: number, to: number): number {
+	let e = 0;
+	for (let i = from; i < to; i++) e += a[i] * a[i];
+	return e;
+}

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -32,14 +32,23 @@ import {
 	AudioFrameConsumer,
 	type AudioFrameConsumerConfig,
 	type AudioFrameEvent,
+	decodeAudioFramePcm,
 	type RuntimeEventSink,
 	type TurnTranscriber,
 } from "./audio-frame-consumer.js";
+import {
+	estimatePlaybackDelaySamples,
+	platformPlaybackDelaySamples,
+} from "./echo-delay-calibrator.js";
 import type {
 	ElizaInferenceContextHandle,
 	ElizaInferenceFfi,
 } from "./ffi-bindings.js";
 import { loadElizaInferenceFfi } from "./ffi-bindings.js";
+import {
+	createEchoReferenceProvider,
+	PlaybackReferenceBuffer,
+} from "./playback-reference-buffer.js";
 import { VoiceProfileStore } from "./profile-store.js";
 import { VoiceAttributionPipeline } from "./speaker/attribution-pipeline.js";
 import { FusedDiarizer } from "./speaker/diarizer-fused.js";
@@ -102,8 +111,30 @@ export interface LiveDiarizationStatus {
 	turnsObserved: number;
 	/** The most recent attributed turns (capped), for device-evidence reads. */
 	recentTurns: LiveDiarizationTurnSummary[];
+	/** Acoustic-echo-cancellation state (#9583). */
+	aec: LiveDiarizationAecStatus;
 	/** Populated only when readiness failed — the precise blocker. */
 	error?: string;
+}
+
+/** AEC wiring + live calibration state for the device-evidence read (#9583). */
+export interface LiveDiarizationAecStatus {
+	/** True once an echoReference is wired to the consumer. */
+	enabled: boolean;
+	/** Active bulk playback→mic delay (samples) the reference is aligned by. */
+	delaySamples: number;
+	/** Same delay in ms. */
+	delayMs: number;
+	/** True once an on-device echo-only window refined the delay past the seed. */
+	calibrated: boolean;
+	/** Cross-correlation confidence [0,1] of the last calibration attempt. */
+	lastCalibrationConfidence: number;
+	/** Far-end (agent TTS) playback frames received from the device. */
+	playbackFramesReceived: number;
+	/** Far-end samples currently buffered for mic-frame alignment. */
+	bufferedReferenceSamples: number;
+	/** Mic frames the canceller actually processed (agent was playing). */
+	framesCancelled: number;
 }
 
 /** A compact, JSON-safe summary of one attributed turn (no PCM/embeddings). */
@@ -122,6 +153,32 @@ export interface LiveDiarizationTurnSummary {
 }
 
 const MAX_RECENT_TURNS = 20;
+
+/** Echo-only audio needed before a delay calibration is attempted (~0.5 s @ 16 kHz). */
+const CALIBRATION_WINDOW_SAMPLES = 8_000;
+/** Minimum cross-correlation confidence before the measured delay replaces the seed. */
+const AEC_CALIBRATION_MIN_CONFIDENCE = 0.3;
+
+/** Truthy-env check for opt-in flags (`1`/`true`/`yes`/`on`, case-insensitive). */
+function isTruthyEnv(value: string | undefined): boolean {
+	if (!value) return false;
+	const v = value.trim().toLowerCase();
+	return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/** Concatenate Float32 chunks into one buffer of known total length. */
+function concatPcm(
+	chunks: readonly Float32Array[],
+	total: number,
+): Float32Array {
+	const out = new Float32Array(total);
+	let cursor = 0;
+	for (const c of chunks) {
+		out.set(c, cursor);
+		cursor += c.length;
+	}
+	return out;
+}
 
 /**
  * Owns the single live diarization consumer for the agent process. Built
@@ -142,6 +199,21 @@ export class LiveDiarizationSession {
 	private buildError: string | null = null;
 	/** True once the fused ASR region is mmap-acquired for per-turn transcribe. */
 	private asrRegionAcquired = false;
+
+	// ---- AEC (#9583): far-end playback reference + live delay calibration ----
+	/** Timestamped agent-TTS playback ring the echo canceller aligns against. */
+	private readonly playbackRef = new PlaybackReferenceBuffer();
+	/** Active bulk playback→mic delay (samples). Seeded per-platform, then
+	 *  refined on-device by cross-correlation when an echo-only window appears. */
+	private aecDelaySamples = platformPlaybackDelaySamples(process.platform);
+	private playbackFramesReceived = 0;
+	private aecCalibrated = false;
+	private aecLastConfidence = 0;
+	/** Rolling raw (un-cancelled) mic + far pairs accumulated while the agent is
+	 *  playing and the delay is not yet calibrated; consumed by calibration. */
+	private calibMic: Float32Array[] = [];
+	private calibFar: Float32Array[] = [];
+	private calibSamples = 0;
 
 	constructor(private readonly runtime: RuntimeEventSink) {}
 
@@ -219,12 +291,28 @@ export class LiveDiarizationSession {
 		// on VOICE_TURN_OBSERVED (#8786). Null when the fused build has no ASR
 		// decoder — the path then stays diarization-only, as before.
 		const transcribe = this.buildTurnTranscriber(ffi, ctx);
+		// #9583: wire the far-end echo reference on the live device path. The
+		// provider reads the agent's TTS playback (fed via `ingestPlayback`)
+		// aligned to each mic frame, offset by the live `aecDelaySamples`. When no
+		// playback has arrived for a window it returns null and the consumer passes
+		// the mic through untouched. Residual-echo suppression is opt-in per device
+		// via $ELIZA_VOICE_AEC_RESIDUAL_SUPPRESSION (default off).
+		const echoReference = createEchoReferenceProvider(this.playbackRef, () => ({
+			delaySamples: this.aecDelaySamples,
+		}));
+		const residualSuppression = isTruthyEnv(
+			process.env.ELIZA_VOICE_AEC_RESIDUAL_SUPPRESSION,
+		);
 		const consumer = new AudioFrameConsumer(
 			{
 				vad: detector,
 				pipeline,
 				runtime: this.runtime,
 				...(transcribe ? { transcribe } : {}),
+				echoReference,
+				...(residualSuppression
+					? { echoCancellerOptions: { residualSuppression: true } }
+					: {}),
 			},
 			config,
 		);
@@ -285,7 +373,65 @@ export class LiveDiarizationSession {
 		for (const frame of frames) {
 			this.framesReceived += 1;
 			await this.consumer.onAudioFrame(frame);
+			if (!this.aecCalibrated) this.accumulateCalibration(frame);
 		}
+	}
+
+	/**
+	 * Feed a batch of agent-TTS playback frames (the far-end echo reference)
+	 * captured on the device, time-stamped in the SAME mic clock as
+	 * {@link ingest}'s frames (#9583). Wiring this is what makes the live echo
+	 * canceller actually cancel: until playback arrives the reference provider
+	 * returns null and the mic passes through untouched. Does not require the
+	 * fused voice models — playback can be buffered before the first mic frame.
+	 */
+	async ingestPlayback(frames: AudioFrameEvent[]): Promise<void> {
+		for (const frame of frames) {
+			const pcm = decodeAudioFramePcm(frame);
+			this.playbackRef.write(pcm, frame.timestamp);
+			this.playbackFramesReceived += 1;
+		}
+	}
+
+	/**
+	 * While the playback→mic delay is not yet calibrated, accumulate the raw mic
+	 * (with echo) against the playback aligned to the same nominal window. Once a
+	 * contiguous echo-only burst is long enough, cross-correlate to measure the
+	 * real bulk delay and lock it in. A silence gap resets the accumulation so we
+	 * only ever correlate one continuous agent-playing burst.
+	 */
+	private accumulateCalibration(frame: AudioFrameEvent): void {
+		const far = this.playbackRef.read(frame.timestamp, frame.samples);
+		if (!far) {
+			this.resetCalibAccum();
+			return;
+		}
+		// The consumer already decoded this frame without throwing, so decoding the
+		// raw mic here for calibration cannot fail.
+		const mic = decodeAudioFramePcm(frame);
+		this.calibMic.push(mic);
+		this.calibFar.push(far);
+		this.calibSamples += mic.length;
+		if (this.calibSamples >= CALIBRATION_WINDOW_SAMPLES) this.runCalibration();
+	}
+
+	private runCalibration(): void {
+		const mic = concatPcm(this.calibMic, this.calibSamples);
+		const far = concatPcm(this.calibFar, this.calibSamples);
+		const result = estimatePlaybackDelaySamples(mic, far);
+		this.aecLastConfidence = result.confidence;
+		if (result.confidence >= AEC_CALIBRATION_MIN_CONFIDENCE) {
+			this.aecDelaySamples = result.delaySamples;
+			this.aecCalibrated = true;
+		}
+		this.resetCalibAccum();
+	}
+
+	private resetCalibAccum(): void {
+		if (this.calibSamples === 0) return;
+		this.calibMic = [];
+		this.calibFar = [];
+		this.calibSamples = 0;
 	}
 
 	/** Flush any open segment (call on stopAudioFrames) and await attribution. */
@@ -308,6 +454,16 @@ export class LiveDiarizationSession {
 			framesDropped: this.consumer?.droppedFrames ?? 0,
 			turnsObserved: this.turnsObserved,
 			recentTurns: [...this.recentTurns],
+			aec: {
+				enabled: this.consumer != null,
+				delaySamples: this.aecDelaySamples,
+				delayMs: Math.round((this.aecDelaySamples / 16_000) * 1000),
+				calibrated: this.aecCalibrated,
+				lastCalibrationConfidence: this.aecLastConfidence,
+				playbackFramesReceived: this.playbackFramesReceived,
+				bufferedReferenceSamples: this.playbackRef.bufferedSamples,
+				framesCancelled: this.consumer?.echoFramesCancelled ?? 0,
+			},
 			...(this.buildError ? { error: this.buildError } : {}),
 		};
 	}
@@ -331,5 +487,7 @@ export class LiveDiarizationSession {
 		this.consumer = null;
 		this.ffi = null;
 		this.ctx = null;
+		this.playbackRef.clear();
+		this.resetCalibAccum();
 	}
 }

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
@@ -6,127 +6,215 @@ const BLOCK = 320; // 20 ms @ 16 kHz — the pipeline's frame size
 
 /** Speech-like signal: two-pole low-passed pseudo-random noise (deterministic). */
 function signal(n: number, seed: number): Float32Array {
-  const x = new Float32Array(n);
-  let s = seed >>> 0;
-  let p1 = 0;
-  let p2 = 0;
-  for (let i = 0; i < n; i++) {
-    s = (s * 1103515245 + 12345) & 0x7fffffff;
-    const w = s / 0x3fffffff - 1;
-    p1 = 0.92 * p1 + 0.08 * w;
-    p2 = 0.85 * p2 + 0.15 * p1;
-    x[i] = p2 * 3;
-  }
-  return x;
+	const x = new Float32Array(n);
+	let s = seed >>> 0;
+	let p1 = 0;
+	let p2 = 0;
+	for (let i = 0; i < n; i++) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		const w = s / 0x3fffffff - 1;
+		p1 = 0.92 * p1 + 0.08 * w;
+		p2 = 0.85 * p2 + 0.15 * p1;
+		x[i] = p2 * 3;
+	}
+	return x;
 }
 
 /** Realistic (attenuated) playback→mic path: bulk delay + decaying reverb. */
 function echoOf(x: Float32Array, gain = 0.22): Float32Array {
-  const delay = 35;
-  const tail = 90;
-  const h = new Float32Array(delay + tail);
-  for (let k = 0; k < tail; k++) {
-    h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * gain;
-  }
-  const y = new Float32Array(x.length);
-  for (let n = 0; n < x.length; n++) {
-    let acc = 0;
-    for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
-    y[n] = acc;
-  }
-  return y;
+	const delay = 35;
+	const tail = 90;
+	const h = new Float32Array(delay + tail);
+	for (let k = 0; k < tail; k++) {
+		h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * gain;
+	}
+	const y = new Float32Array(x.length);
+	for (let n = 0; n < x.length; n++) {
+		let acc = 0;
+		for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
+		y[n] = acc;
+	}
+	return y;
 }
 
 function power(a: Float32Array, from = 0, to = a.length): number {
-  let p = 0;
-  for (let i = from; i < to; i++) p += a[i] * a[i];
-  return p / Math.max(1, to - from);
+	let p = 0;
+	for (let i = from; i < to; i++) p += a[i] * a[i];
+	return p / Math.max(1, to - from);
 }
 
 function runBlocks(
-  aec: NlmsEchoCanceller,
-  near: Float32Array,
-  far: Float32Array,
+	aec: NlmsEchoCanceller,
+	near: Float32Array,
+	far: Float32Array,
 ): Float32Array {
-  const out = new Float32Array(near.length);
-  for (let off = 0; off + BLOCK <= near.length; off += BLOCK) {
-    out.set(
-      aec.process(near.subarray(off, off + BLOCK), far.subarray(off, off + BLOCK)),
-      off,
-    );
-  }
-  return out;
+	const out = new Float32Array(near.length);
+	for (let off = 0; off + BLOCK <= near.length; off += BLOCK) {
+		out.set(
+			aec.process(
+				near.subarray(off, off + BLOCK),
+				far.subarray(off, off + BLOCK),
+			),
+			off,
+		);
+	}
+	return out;
 }
 
 describe("NlmsEchoCanceller", () => {
-  it("cancels the agent's echo by >=10 dB ERLE after convergence (echo-only)", () => {
-    const N = SR * 4;
-    const far = signal(N, 1);
-    const echo = echoOf(far);
-    const out = runBlocks(new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5 }), echo, far);
-    const from = SR * 2; // ignore the first 2 s of adaptation
-    const to = N - (N % BLOCK);
-    const erleDb = 10 * Math.log10(power(echo, from, to) / power(out, from, to));
-    expect(erleDb).toBeGreaterThan(10);
-  });
+	it("cancels the agent's echo by >=10 dB ERLE after convergence (echo-only)", () => {
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5 }),
+			echo,
+			far,
+		);
+		const from = SR * 2; // ignore the first 2 s of adaptation
+		const to = N - (N % BLOCK);
+		const erleDb =
+			10 * Math.log10(power(echo, from, to) / power(out, from, to));
+		expect(erleDb).toBeGreaterThan(10);
+	});
 
-  it("passes the mic through unchanged while the agent is silent", () => {
-    const aec = new NlmsEchoCanceller({ filterTaps: 256 });
-    const micOnly = signal(BLOCK, 777);
-    const out = aec.process(micOnly, new Float32Array(BLOCK)); // far-end = silence
-    let maxDiff = 0;
-    for (let i = 0; i < BLOCK; i++) {
-      maxDiff = Math.max(maxDiff, Math.abs(out[i] - micOnly[i]));
-    }
-    expect(maxDiff).toBeLessThan(1e-6);
-  });
+	it("passes the mic through unchanged while the agent is silent", () => {
+		const aec = new NlmsEchoCanceller({ filterTaps: 256 });
+		const micOnly = signal(BLOCK, 777);
+		const out = aec.process(micOnly, new Float32Array(BLOCK)); // far-end = silence
+		let maxDiff = 0;
+		for (let i = 0; i < BLOCK; i++) {
+			maxDiff = Math.max(maxDiff, Math.abs(out[i] - micOnly[i]));
+		}
+		expect(maxDiff).toBeLessThan(1e-6);
+	});
 
-  it("never touches the user's voice when only the user is speaking (no playback)", () => {
-    // Pure near-end speech, agent silent for the whole run → exact passthrough,
-    // so the canceller can never suppress a barge-in while no echo exists.
-    const N = SR * 2;
-    const speech = signal(N, 99);
-    const out = runBlocks(
-      new NlmsEchoCanceller({ filterTaps: 256 }),
-      speech,
-      new Float32Array(N),
-    );
-    let maxDiff = 0;
-    for (let i = 0; i < out.length; i++) {
-      maxDiff = Math.max(maxDiff, Math.abs(out[i] - speech[i]));
-    }
-    expect(maxDiff).toBeLessThan(1e-6);
-  });
+	it("never touches the user's voice when only the user is speaking (no playback)", () => {
+		// Pure near-end speech, agent silent for the whole run → exact passthrough,
+		// so the canceller can never suppress a barge-in while no echo exists.
+		const N = SR * 2;
+		const speech = signal(N, 99);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256 }),
+			speech,
+			new Float32Array(N),
+		);
+		let maxDiff = 0;
+		for (let i = 0; i < out.length; i++) {
+			maxDiff = Math.max(maxDiff, Math.abs(out[i] - speech[i]));
+		}
+		expect(maxDiff).toBeLessThan(1e-6);
+	});
 
-  it("stays stable (does not diverge) under sustained double-talk", () => {
-    // Agent speaks the whole time; the user also speaks from 2 s. The filter
-    // must not blow up — the output power stays bounded near the input power.
-    const N = SR * 4;
-    const far = signal(N, 1);
-    const echo = echoOf(far);
-    const speech = signal(N, 99);
-    const near = new Float32Array(N);
-    for (let i = 0; i < N; i++) near[i] = echo[i] + (i >= SR * 2 ? speech[i] : 0);
-    const out = runBlocks(
-      new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5, dtdRatio: 1.5 }),
-      near,
-      far,
-    );
-    const from = SR * 2;
-    const to = N - (N % BLOCK);
-    // No divergence: output energy is the same order as the input, not exploding.
-    expect(power(out, from, to)).toBeLessThan(power(near, from, to) * 4);
-    for (let i = from; i < to; i++) expect(Number.isFinite(out[i])).toBe(true);
-  });
+	it("stays stable (does not diverge) under sustained double-talk", () => {
+		// Agent speaks the whole time; the user also speaks from 2 s. The filter
+		// must not blow up — the output power stays bounded near the input power.
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const speech = signal(N, 99);
+		const near = new Float32Array(N);
+		for (let i = 0; i < N; i++)
+			near[i] = echo[i] + (i >= SR * 2 ? speech[i] : 0);
+		const out = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5, dtdRatio: 1.5 }),
+			near,
+			far,
+		);
+		const from = SR * 2;
+		const to = N - (N % BLOCK);
+		// No divergence: output energy is the same order as the input, not exploding.
+		expect(power(out, from, to)).toBeLessThan(power(near, from, to) * 4);
+		for (let i = from; i < to; i++) expect(Number.isFinite(out[i])).toBe(true);
+	});
 
-  it("reset() clears adaptation (first post-reset sample is exact passthrough)", () => {
-    const far = signal(SR, 1);
-    const echo = echoOf(far);
-    const aec = new NlmsEchoCanceller({ filterTaps: 128 });
-    runBlocks(aec, echo, far);
-    aec.reset();
-    const out = aec.process(echo.subarray(0, BLOCK), far.subarray(0, BLOCK));
-    // weights + reference history are zero → ŷ[0]=0 → out[0]==in[0] exactly.
-    expect(out[0]).toBe(echo[0]);
-  });
+	it("reset() clears adaptation (first post-reset sample is exact passthrough)", () => {
+		const far = signal(SR, 1);
+		const echo = echoOf(far);
+		const aec = new NlmsEchoCanceller({ filterTaps: 128 });
+		runBlocks(aec, echo, far);
+		aec.reset();
+		const out = aec.process(echo.subarray(0, BLOCK), far.subarray(0, BLOCK));
+		// weights + reference history are zero → ŷ[0]=0 → out[0]==in[0] exactly.
+		expect(out[0]).toBe(echo[0]);
+	});
+});
+
+describe("NlmsEchoCanceller residual-echo suppressor (#9583)", () => {
+	it("is a no-op by default (suppression gain stays 1)", () => {
+		const far = signal(SR, 1);
+		const echo = echoOf(far);
+		const aec = new NlmsEchoCanceller({ filterTaps: 256 });
+		runBlocks(aec, echo, far);
+		expect(aec.lastSuppressionGain).toBe(1);
+	});
+
+	it("further attenuates the echo-only residual when enabled", () => {
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const from = SR * 2; // post-convergence
+		const to = N - (N % BLOCK);
+
+		const base = runBlocks(
+			new NlmsEchoCanceller({ filterTaps: 256, mu: 0.5 }),
+			echo,
+			far,
+		);
+		const res = runBlocks(
+			new NlmsEchoCanceller({
+				filterTaps: 256,
+				mu: 0.5,
+				residualSuppression: true,
+			}),
+			echo,
+			far,
+		);
+		// The suppressor only acts in echo-only frames, so the residual drops further.
+		expect(power(res, from, to)).toBeLessThan(power(base, from, to));
+	});
+
+	it("never attenuates the user while the agent is silent (gain stays 1)", () => {
+		const aec = new NlmsEchoCanceller({
+			filterTaps: 256,
+			residualSuppression: true,
+		});
+		const micOnly = signal(SR, 777);
+		const out = runBlocks(aec, micOnly, new Float32Array(SR)); // far-end = silence
+		let maxDiff = 0;
+		for (let i = 0; i < out.length; i++) {
+			maxDiff = Math.max(maxDiff, Math.abs(out[i] - micOnly[i]));
+		}
+		expect(maxDiff).toBeLessThan(1e-6);
+		expect(aec.lastSuppressionGain).toBe(1);
+	});
+
+	it("does not crush the user's voice during double-talk", () => {
+		// Agent echoes throughout; the user also speaks from 2 s. The suppressor must
+		// back off (it is gated to echo-only frames) so the user's energy survives.
+		const N = SR * 4;
+		const far = signal(N, 1);
+		const echo = echoOf(far);
+		const speech = signal(N, 99);
+		const near = new Float32Array(N);
+		for (let i = 0; i < N; i++)
+			near[i] = echo[i] + (i >= SR * 2 ? speech[i] : 0);
+		const out = runBlocks(
+			new NlmsEchoCanceller({
+				filterTaps: 256,
+				mu: 0.5,
+				dtdRatio: 1.5,
+				residualSuppression: { floorDb: -24 },
+			}),
+			near,
+			far,
+		);
+		const from = SR * 2;
+		const to = N - (N % BLOCK);
+		// The user's speech is not suppressed to the floor: output retains a large
+		// fraction of the near-end (user-present) energy.
+		expect(power(out, from, to)).toBeGreaterThan(
+			power(speech, from, to) * 0.25,
+		);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
@@ -33,165 +33,245 @@
  */
 
 export interface NlmsEchoCancellerOptions {
-  /** Adaptive FIR length in samples. 256 ≈ 16 ms of impulse response @16 kHz. */
-  filterTaps?: number;
-  /** NLMS step size in (0, 2). Larger = faster adaptation, less stable. */
-  mu?: number;
-  /** Regularization added to the reference energy to avoid divide-by-zero. */
-  epsilon?: number;
-  /**
-   * Bulk playback→mic transport delay in samples. The reference is consumed
-   * `delaySamples` ahead of the near-end so the adaptive taps only model the
-   * residual room impulse, not the (potentially large) transport latency.
-   */
-  delaySamples?: number;
-  /**
-   * Double-talk detector ratio. When the smoothed near-end power exceeds
-   * `dtdRatio`× the smoothed far-end reference power (a passive echo path
-   * attenuates, so echo power stays below the reference), a local talker is
-   * assumed active and adaptation is frozen so the filter cannot learn (and
-   * cancel) the user's voice. Set 0 to disable.
-   */
-  dtdRatio?: number;
+	/** Adaptive FIR length in samples. 256 ≈ 16 ms of impulse response @16 kHz. */
+	filterTaps?: number;
+	/** NLMS step size in (0, 2). Larger = faster adaptation, less stable. */
+	mu?: number;
+	/** Regularization added to the reference energy to avoid divide-by-zero. */
+	epsilon?: number;
+	/**
+	 * Bulk playback→mic transport delay in samples. The reference is consumed
+	 * `delaySamples` ahead of the near-end so the adaptive taps only model the
+	 * residual room impulse, not the (potentially large) transport latency.
+	 */
+	delaySamples?: number;
+	/**
+	 * Double-talk detector ratio. When the smoothed near-end power exceeds
+	 * `dtdRatio`× the smoothed far-end reference power (a passive echo path
+	 * attenuates, so echo power stays below the reference), a local talker is
+	 * assumed active and adaptation is frozen so the filter cannot learn (and
+	 * cancel) the user's voice. Set 0 to disable.
+	 */
+	dtdRatio?: number;
+	/**
+	 * Optional residual-echo suppressor (#9583, the "AEC3-class double-talk"
+	 * follow-up). Off by default. When enabled, a single-band time-domain gate
+	 * further attenuates the canceller OUTPUT during frames where the agent is
+	 * provably playing (far-end active) and the user is provably NOT (no
+	 * double-talk) — exactly the echo-only periods where any surviving residual is
+	 * leak, not the user. It never touches double-talk frames, so it cannot
+	 * suppress a barge-in. This is a conservative first-stage RES, not a full
+	 * spectral AEC3 suppressor. Pass `true` for defaults or tune the floor/ramps.
+	 */
+	residualSuppression?: boolean | ResidualSuppressionOptions;
+}
+
+export interface ResidualSuppressionOptions {
+	/** Suppression floor in dB (how far the residual is pulled down). Default −18. */
+	floorDb?: number;
+	/** Ramp-down time constant toward the floor, ms. Default 20. */
+	attackMs?: number;
+	/** Ramp-up time constant back to unity, ms. Fast to protect the user. Default 8. */
+	releaseMs?: number;
 }
 
 const DEFAULTS = {
-  filterTaps: 256,
-  mu: 0.3,
-  epsilon: 1e-6,
-  delaySamples: 0,
-  dtdRatio: 2,
+	filterTaps: 256,
+	mu: 0.3,
+	epsilon: 1e-6,
+	delaySamples: 0,
+	dtdRatio: 2,
+} as const;
+
+const RES_DEFAULTS = {
+	floorDb: -18,
+	attackMs: 20,
+	releaseMs: 8,
 } as const;
 
 export class NlmsEchoCanceller {
-  private readonly w: Float32Array; // adaptive filter weights
-  private readonly x: Float32Array; // far-end ring buffer (most-recent-first)
-  private readonly taps: number;
-  private readonly mu: number;
-  private readonly eps: number;
-  private readonly delay: number;
-  private readonly dtdRatio: number;
-  /** Pending far-end samples not yet aligned to a near-end sample (delay line). */
-  private readonly delayLine: number[] = [];
-  private xEnergy = 0; // running ‖x‖² over the active window (incremental)
-  private pNear = 0; // smoothed near-end power (DTD)
-  private pFar = 0; // smoothed far-end reference power (DTD)
-  private hangover = 0; // samples to stay frozen after a double-talk trigger
-  private lastEchoPow = 0;
+	private readonly w: Float32Array; // adaptive filter weights
+	private readonly x: Float32Array; // far-end ring buffer (most-recent-first)
+	private readonly taps: number;
+	private readonly mu: number;
+	private readonly eps: number;
+	private readonly delay: number;
+	private readonly dtdRatio: number;
+	/** Pending far-end samples not yet aligned to a near-end sample (delay line). */
+	private readonly delayLine: number[] = [];
+	private xEnergy = 0; // running ‖x‖² over the active window (incremental)
+	private pNear = 0; // smoothed near-end power (DTD)
+	private pFar = 0; // smoothed far-end reference power (DTD)
+	private hangover = 0; // samples to stay frozen after a double-talk trigger
+	private lastEchoPow = 0;
 
-  /** Stay frozen ~30 ms after the last double-talk trigger so the filter is not
-   * corrupted by the bursty onset/offset of the near-end talker. */
-  private static readonly HANGOVER_SAMPLES = 480;
-  private lastResidualPow = 0;
+	/** Stay frozen ~30 ms after the last double-talk trigger so the filter is not
+	 * corrupted by the bursty onset/offset of the near-end talker. */
+	private static readonly HANGOVER_SAMPLES = 480;
+	private lastResidualPow = 0;
 
-  constructor(opts: NlmsEchoCancellerOptions = {}) {
-    this.taps = Math.max(1, Math.floor(opts.filterTaps ?? DEFAULTS.filterTaps));
-    this.mu = opts.mu ?? DEFAULTS.mu;
-    this.eps = opts.epsilon ?? DEFAULTS.epsilon;
-    this.delay = Math.max(0, Math.floor(opts.delaySamples ?? DEFAULTS.delaySamples));
-    this.dtdRatio = opts.dtdRatio ?? DEFAULTS.dtdRatio;
-    this.w = new Float32Array(this.taps);
-    this.x = new Float32Array(this.taps);
-  }
+	/** Residual-echo suppressor state (no-op unless `residualSuppression` is set). */
+	private readonly resEnabled: boolean;
+	private readonly resFloor: number; // linear suppression floor (0, 1]
+	private readonly resAttackCoef: number; // one-pole coef toward the floor
+	private readonly resReleaseCoef: number; // one-pole coef back to unity
+	private resGain = 1; // smoothed output gain in [resFloor, 1]
 
-  /**
-   * Cancel echo from one block of mic audio.
-   *
-   * @param nearEnd raw mic block (local speech + echo), Float32 [-1, 1]
-   * @param farEnd  agent playback reference for the same time window. Pass an
-   *                empty/zero array when the agent is NOT speaking — the filter
-   *                then passes the mic through unchanged (output ≈ input).
-   * @returns echo-cancelled near-end block (same length as `nearEnd`).
-   */
-  process(nearEnd: Float32Array, farEnd: Float32Array): Float32Array {
-    const n = nearEnd.length;
-    const out = new Float32Array(n);
-    let echoPow = 0;
-    let residualPow = 0;
+	constructor(opts: NlmsEchoCancellerOptions = {}) {
+		this.taps = Math.max(1, Math.floor(opts.filterTaps ?? DEFAULTS.filterTaps));
+		this.mu = opts.mu ?? DEFAULTS.mu;
+		this.eps = opts.epsilon ?? DEFAULTS.epsilon;
+		this.delay = Math.max(
+			0,
+			Math.floor(opts.delaySamples ?? DEFAULTS.delaySamples),
+		);
+		this.dtdRatio = opts.dtdRatio ?? DEFAULTS.dtdRatio;
+		this.w = new Float32Array(this.taps);
+		this.x = new Float32Array(this.taps);
 
-    for (let i = 0; i < n; i++) {
-      // Feed the (delay-aligned) far-end sample into the ring buffer.
-      const incoming = i < farEnd.length ? farEnd[i] : 0;
-      this.delayLine.push(incoming);
-      const ref =
-        this.delayLine.length > this.delay
-          ? (this.delayLine.shift() as number)
-          : 0;
-      this.pushRef(ref);
+		const res = opts.residualSuppression;
+		this.resEnabled = res === true || (typeof res === "object" && res !== null);
+		const resOpts: ResidualSuppressionOptions =
+			typeof res === "object" && res !== null ? res : {};
+		this.resFloor = 10 ** ((resOpts.floorDb ?? RES_DEFAULTS.floorDb) / 20);
+		const sr = 16_000;
+		this.resAttackCoef = onePoleCoef(
+			resOpts.attackMs ?? RES_DEFAULTS.attackMs,
+			sr,
+		);
+		this.resReleaseCoef = onePoleCoef(
+			resOpts.releaseMs ?? RES_DEFAULTS.releaseMs,
+			sr,
+		);
+	}
 
-      // Estimate echo ŷ = wᵀ·x and the error e = d − ŷ (the cleaned sample).
-      let yhat = 0;
-      for (let k = 0; k < this.taps; k++) yhat += this.w[k] * this.x[k];
-      const d = nearEnd[i];
-      const e = d - yhat;
-      out[i] = e;
+	/**
+	 * Cancel echo from one block of mic audio.
+	 *
+	 * @param nearEnd raw mic block (local speech + echo), Float32 [-1, 1]
+	 * @param farEnd  agent playback reference for the same time window. Pass an
+	 *                empty/zero array when the agent is NOT speaking — the filter
+	 *                then passes the mic through unchanged (output ≈ input).
+	 * @returns echo-cancelled near-end block (same length as `nearEnd`).
+	 */
+	process(nearEnd: Float32Array, farEnd: Float32Array): Float32Array {
+		const n = nearEnd.length;
+		const out = new Float32Array(n);
+		let echoPow = 0;
+		let residualPow = 0;
 
-      // Double-talk detection by near-end vs far-end power. A passive
-      // playback→mic path attenuates, so the echo power stays below the
-      // far-end reference power; when the smoothed near-end power instead
-      // exceeds `dtdRatio`× the far-end power, a local talker is active. This is
-      // independent of the filter's convergence state, so it never blocks
-      // initial adaptation (unlike comparing against the echo estimate).
-      // Fast smoothing (~6 ms) so the detector reacts at the onset of the
-      // near-end burst, plus a hangover so it stays frozen through it.
-      this.pNear = 0.99 * this.pNear + 0.01 * d * d;
-      this.pFar = 0.99 * this.pFar + 0.01 * ref * ref;
-      if (
-        this.dtdRatio > 0 &&
-        this.pFar > this.eps &&
-        this.pNear > this.dtdRatio * this.pFar
-      ) {
-        this.hangover = NlmsEchoCanceller.HANGOVER_SAMPLES;
-      }
-      const doubleTalk = this.hangover > 0;
-      if (this.hangover > 0) this.hangover--;
+		for (let i = 0; i < n; i++) {
+			// Feed the (delay-aligned) far-end sample into the ring buffer.
+			const incoming = i < farEnd.length ? farEnd[i] : 0;
+			this.delayLine.push(incoming);
+			const ref =
+				this.delayLine.length > this.delay
+					? (this.delayLine.shift() as number)
+					: 0;
+			this.pushRef(ref);
 
-      // NLMS weight update: w += μ·e·x / (‖x‖² + ε), frozen during double-talk.
-      if (!doubleTalk) {
-        const norm = this.xEnergy + this.eps;
-        const step = (this.mu * e) / norm;
-        if (Number.isFinite(step)) {
-          for (let k = 0; k < this.taps; k++) this.w[k] += step * this.x[k];
-        }
-      }
+			// Estimate echo ŷ = wᵀ·x and the error e = d − ŷ (the cleaned sample).
+			let yhat = 0;
+			for (let k = 0; k < this.taps; k++) yhat += this.w[k] * this.x[k];
+			const d = nearEnd[i];
+			const e = d - yhat;
 
-      echoPow += yhat * yhat;
-      residualPow += e * e;
-    }
+			// Double-talk detection by near-end vs far-end power. A passive
+			// playback→mic path attenuates, so the echo power stays below the
+			// far-end reference power; when the smoothed near-end power instead
+			// exceeds `dtdRatio`× the far-end power, a local talker is active. This is
+			// independent of the filter's convergence state, so it never blocks
+			// initial adaptation (unlike comparing against the echo estimate).
+			// Fast smoothing (~6 ms) so the detector reacts at the onset of the
+			// near-end burst, plus a hangover so it stays frozen through it.
+			this.pNear = 0.99 * this.pNear + 0.01 * d * d;
+			this.pFar = 0.99 * this.pFar + 0.01 * ref * ref;
+			if (
+				this.dtdRatio > 0 &&
+				this.pFar > this.eps &&
+				this.pNear > this.dtdRatio * this.pFar
+			) {
+				this.hangover = NlmsEchoCanceller.HANGOVER_SAMPLES;
+			}
+			const doubleTalk = this.hangover > 0;
+			if (this.hangover > 0) this.hangover--;
 
-    this.lastEchoPow = echoPow / Math.max(1, n);
-    this.lastResidualPow = residualPow / Math.max(1, n);
-    return out;
-  }
+			// Residual-echo suppressor (opt-in). Pull the output toward the floor ONLY
+			// in echo-only frames — the agent is clearly playing (far dominates the
+			// smoothed near power) and there is no double-talk — so any surviving
+			// residual is leak. Smoothed with a fast release so the gain is already
+			// back at unity the instant the user starts or the agent stops.
+			if (this.resEnabled) {
+				const echoOnly =
+					!doubleTalk && this.pFar > this.eps && this.pFar > this.pNear;
+				const target = echoOnly ? this.resFloor : 1;
+				const coef =
+					target < this.resGain ? this.resAttackCoef : this.resReleaseCoef;
+				this.resGain = coef * this.resGain + (1 - coef) * target;
+				out[i] = e * this.resGain;
+			} else {
+				out[i] = e;
+			}
 
-  /** Echo-return-loss-enhancement (dB) over the last processed block. Higher is
-   * better; >10 dB is a meaningful cancellation. Returns 0 when there is no
-   * modeled echo (agent silent) so a passthrough block reads as "no gain". */
-  get lastErleDb(): number {
-    if (this.lastResidualPow <= 0 || this.lastEchoPow <= 0) return 0;
-    return 10 * Math.log10(this.lastEchoPow / this.lastResidualPow);
-  }
+			// NLMS weight update: w += μ·e·x / (‖x‖² + ε), frozen during double-talk.
+			if (!doubleTalk) {
+				const norm = this.xEnergy + this.eps;
+				const step = (this.mu * e) / norm;
+				if (Number.isFinite(step)) {
+					for (let k = 0; k < this.taps; k++) this.w[k] += step * this.x[k];
+				}
+			}
 
-  /** Reset adaptation (e.g. when the playback path changes). */
-  reset(): void {
-    this.w.fill(0);
-    this.x.fill(0);
-    this.delayLine.length = 0;
-    this.xEnergy = 0;
-    this.pNear = 0;
-    this.pFar = 0;
-    this.hangover = 0;
-    this.lastEchoPow = 0;
-    this.lastResidualPow = 0;
-  }
+			echoPow += yhat * yhat;
+			residualPow += e * e;
+		}
 
-  /** Shift a new far-end sample into the ring buffer, maintaining ‖x‖²
-   * incrementally (drop the oldest sample's energy, add the newest). */
-  private pushRef(sample: number): void {
-    const dropped = this.x[this.taps - 1];
-    this.xEnergy += sample * sample - dropped * dropped;
-    if (this.xEnergy < 0) this.xEnergy = 0; // guard fp drift
-    for (let k = this.taps - 1; k > 0; k--) this.x[k] = this.x[k - 1];
-    this.x[0] = sample;
-  }
+		this.lastEchoPow = echoPow / Math.max(1, n);
+		this.lastResidualPow = residualPow / Math.max(1, n);
+		return out;
+	}
+
+	/** Echo-return-loss-enhancement (dB) over the last processed block. Higher is
+	 * better; >10 dB is a meaningful cancellation. Returns 0 when there is no
+	 * modeled echo (agent silent) so a passthrough block reads as "no gain". */
+	get lastErleDb(): number {
+		if (this.lastResidualPow <= 0 || this.lastEchoPow <= 0) return 0;
+		return 10 * Math.log10(this.lastEchoPow / this.lastResidualPow);
+	}
+
+	/** Current residual-suppressor output gain in [floor, 1]. 1 when disabled or
+	 * not currently suppressing. Exposed for diagnostics/tests. */
+	get lastSuppressionGain(): number {
+		return this.resEnabled ? this.resGain : 1;
+	}
+
+	/** Reset adaptation (e.g. when the playback path changes). */
+	reset(): void {
+		this.w.fill(0);
+		this.x.fill(0);
+		this.delayLine.length = 0;
+		this.xEnergy = 0;
+		this.pNear = 0;
+		this.pFar = 0;
+		this.hangover = 0;
+		this.lastEchoPow = 0;
+		this.lastResidualPow = 0;
+		this.resGain = 1;
+	}
+
+	/** Shift a new far-end sample into the ring buffer, maintaining ‖x‖²
+	 * incrementally (drop the oldest sample's energy, add the newest). */
+	private pushRef(sample: number): void {
+		const dropped = this.x[this.taps - 1];
+		this.xEnergy += sample * sample - dropped * dropped;
+		if (this.xEnergy < 0) this.xEnergy = 0; // guard fp drift
+		for (let k = this.taps - 1; k > 0; k--) this.x[k] = this.x[k - 1];
+		this.x[0] = sample;
+	}
+}
+
+/** One-pole smoothing coefficient for a `tauMs` time constant at `sampleRate`. */
+function onePoleCoef(tauMs: number, sampleRate: number): number {
+	const tauSamples = Math.max(1, (tauMs / 1000) * sampleRate);
+	return Math.exp(-1 / tauSamples);
 }

--- a/plugins/plugin-local-inference/src/services/voice/playback-reference-buffer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/playback-reference-buffer.test.ts
@@ -1,0 +1,253 @@
+/**
+ * PlaybackReferenceBuffer + createEchoReferenceProvider tests (#9583).
+ *
+ * Covers the caller-side far-end store and provider in isolation (write/read
+ * alignment, gaps → null, eviction, the delay offset), plus an END-TO-END proof
+ * that the buffer → provider → AudioFrameConsumer → NlmsEchoCanceller wiring
+ * actually cancels the agent's echo on the live consumer path.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	type AttributionPipelineLike,
+	AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	AudioFrameConsumer,
+	type RuntimeEventSink,
+	type VadSegmenter,
+} from "./audio-frame-consumer";
+import {
+	createEchoReferenceProvider,
+	PlaybackReferenceBuffer,
+} from "./playback-reference-buffer";
+import type { VoiceAttributionOutput } from "./speaker/attribution-pipeline";
+import type { PcmFrame, VadEvent } from "./types";
+
+const SR = AUDIO_FRAME_PIPELINE_SAMPLE_RATE;
+
+function ramp(n: number, base = 0): Float32Array {
+	const a = new Float32Array(n);
+	for (let i = 0; i < n; i++) a[i] = (base + i) / 1000;
+	return a;
+}
+
+function energy(a: Float32Array): number {
+	let e = 0;
+	for (let i = 0; i < a.length; i++) e += a[i] * a[i];
+	return e / Math.max(1, a.length);
+}
+
+describe("PlaybackReferenceBuffer", () => {
+	it("reads back the exact playback window written at a timestamp", () => {
+		const buf = new PlaybackReferenceBuffer();
+		const pcm = ramp(320, 1);
+		buf.write(pcm, 1000);
+		const got = buf.read(1000, 320);
+		expect(got).not.toBeNull();
+		expect(Array.from(got as Float32Array)).toEqual(Array.from(pcm));
+	});
+
+	it("returns null for a window with no playback (agent silent)", () => {
+		const buf = new PlaybackReferenceBuffer();
+		buf.write(ramp(320, 1), 1000);
+		// A window entirely after the written chunk → no overlap → null.
+		expect(buf.read(2000, 320)).toBeNull();
+		// A window entirely before → null.
+		expect(buf.read(0, 320)).toBeNull();
+	});
+
+	it("fills only the covered samples and zeros the gap on partial overlap", () => {
+		const buf = new PlaybackReferenceBuffer();
+		// 10 ms (160 samples) of 0.5 starting at t=1000 ms.
+		buf.write(new Float32Array(160).fill(0.5), 1000);
+		// Query a 20 ms (320-sample) window aligned to t=1000: first 160 covered,
+		// last 160 are silence (gap) → zeros.
+		const got = buf.read(1000, 320);
+		expect(got).not.toBeNull();
+		const out = got as Float32Array;
+		expect(out[0]).toBeCloseTo(0.5, 5);
+		expect(out[159]).toBeCloseTo(0.5, 5);
+		expect(out[160]).toBe(0);
+		expect(out[319]).toBe(0);
+	});
+
+	it("does not bridge one burst's audio into a later burst's silence", () => {
+		const buf = new PlaybackReferenceBuffer();
+		buf.write(new Float32Array(320).fill(0.4), 1000); // burst A
+		buf.write(new Float32Array(320).fill(0.9), 3000); // burst B, after a gap
+		// The 1500 ms window sits in the gap between A and B → null.
+		expect(buf.read(1500, 320)).toBeNull();
+		// Each burst still reads back its own value.
+		expect((buf.read(1000, 320) as Float32Array)[0]).toBeCloseTo(0.4, 5);
+		expect((buf.read(3000, 320) as Float32Array)[0]).toBeCloseTo(0.9, 5);
+	});
+
+	it("evicts oldest playback once over the retained history budget", () => {
+		const buf = new PlaybackReferenceBuffer({ historySeconds: 0.5 }); // 8000 samples
+		let t = 0;
+		for (let i = 0; i < 100; i++) {
+			buf.write(new Float32Array(320).fill(0.1), t);
+			t += 20;
+		}
+		// 100 * 320 = 32000 samples written; retained capped near 8000.
+		expect(buf.bufferedSamples).toBeLessThanOrEqual(8000 + 320);
+		expect(buf.bufferedSamples).toBeGreaterThan(0);
+	});
+
+	it("provider offsets the read by the bulk playback→mic delay", () => {
+		const buf = new PlaybackReferenceBuffer();
+		// 10 ms (160 samples) of playback at t=1000, covering [1000, 1010) ms.
+		buf.write(new Float32Array(160).fill(0.7), 1000);
+		// 10 ms delay = 160 samples @ 16 kHz. A mic frame at t=1010 ms echoes the
+		// playback from t=1000 ms, so the provider must read t=1000 → covered.
+		const provider = createEchoReferenceProvider(buf, { delaySamples: 160 });
+		const got = provider(1010, 320);
+		expect(got).not.toBeNull();
+		expect((got as Float32Array)[0]).toBeCloseTo(0.7, 5);
+		// With zero delay the same mic time reads the [1010, 1030) window, which the
+		// [1000, 1010) playback does not reach → null.
+		const noDelay = createEchoReferenceProvider(buf, { delaySamples: 0 });
+		expect(noDelay(1010, 320)).toBeNull();
+	});
+
+	it("provider re-reads a live delay getter so re-calibration takes effect", () => {
+		const buf = new PlaybackReferenceBuffer();
+		buf.write(new Float32Array(160).fill(0.3), 1000); // [1000, 1010) ms
+		let delaySamples = 0;
+		const provider = createEchoReferenceProvider(buf, () => ({ delaySamples }));
+		expect(provider(1010, 320)).toBeNull(); // delay 0 → reads [1010,1030) → empty
+		delaySamples = 160; // a re-calibration lands
+		expect(provider(1010, 320)).not.toBeNull(); // now reads [1000,…) → covered
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: buffer → provider → AudioFrameConsumer → NlmsEchoCanceller
+// ---------------------------------------------------------------------------
+
+/** Speech-like signal: two-pole low-passed pseudo-random noise (deterministic). */
+function speechLike(n: number, seed: number): Float32Array {
+	const x = new Float32Array(n);
+	let s = seed >>> 0;
+	let p1 = 0;
+	let p2 = 0;
+	for (let i = 0; i < n; i++) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		const w = s / 0x3fffffff - 1;
+		p1 = 0.92 * p1 + 0.08 * w;
+		p2 = 0.85 * p2 + 0.15 * p1;
+		x[i] = p2 * 3;
+	}
+	return x;
+}
+
+/** Attenuated playback→mic path: bulk delay + decaying reverb tail. */
+function echoOf(x: Float32Array, gain = 0.22): Float32Array {
+	const delay = 35;
+	const tail = 90;
+	const h = new Float32Array(delay + tail);
+	for (let k = 0; k < tail; k++) {
+		h[delay + k] = Math.exp(-k / 25) * (k % 2 ? -0.6 : 0.8) * gain;
+	}
+	const y = new Float32Array(x.length);
+	for (let n = 0; n < x.length; n++) {
+		let acc = 0;
+		for (let k = 0; k < h.length; k++) if (n - k >= 0) acc += h[k] * x[n - k];
+		y[n] = acc;
+	}
+	return y;
+}
+
+/** Captures the (post-AEC) PCM frames the consumer feeds to VAD. Emits no VAD
+ *  events, so no turn finalizes — we only inspect the mic stream the AEC produced. */
+class CapturingVad implements VadSegmenter {
+	readonly inSpeech = false;
+	readonly frames: Float32Array[] = [];
+	onVadEvent(_listener: (event: VadEvent) => void): () => void {
+		return () => {};
+	}
+	async pushFrame(frame: PcmFrame): Promise<void> {
+		this.frames.push(frame.pcm);
+	}
+	async flush(): Promise<void> {}
+	reset(): void {}
+}
+
+class InertPipeline implements AttributionPipelineLike {
+	async attribute(
+		req: Parameters<AttributionPipelineLike["attribute"]>[0],
+	): Promise<VoiceAttributionOutput> {
+		return {
+			turnId: req.turnId,
+			segments: [],
+			turn: { turnId: req.turnId },
+		} as VoiceAttributionOutput;
+	}
+}
+
+class InertRuntime implements RuntimeEventSink {
+	async emitEvent(): Promise<void> {}
+}
+
+describe("AudioFrameConsumer AEC wiring (#9583)", () => {
+	it("cancels the agent echo through the wired buffer+provider path", async () => {
+		const SECONDS = 4;
+		const N = SR * SECONDS;
+		const BLOCK = 320; // 20 ms mic frame
+		const far = speechLike(N, 1);
+		const echo = echoOf(far);
+
+		const buffer = new PlaybackReferenceBuffer();
+		const echoReference = createEchoReferenceProvider(buffer, {
+			delaySamples: 0, // the 35-sample path delay is absorbed by the NLMS taps
+		});
+		const vad = new CapturingVad();
+		const consumer = new AudioFrameConsumer({
+			vad,
+			pipeline: new InertPipeline(),
+			runtime: new InertRuntime(),
+			echoReference,
+		});
+
+		for (let off = 0; off + BLOCK <= N; off += BLOCK) {
+			const tMs = (off / SR) * 1000;
+			// The device supplies the far-end playback aligned to this mic window…
+			buffer.write(far.subarray(off, off + BLOCK), tMs);
+			// …then the mic frame (which contains the echo) arrives.
+			await consumer.pushDecodedFrame(echo.subarray(off, off + BLOCK), tMs);
+		}
+
+		// Every frame had playback → the canceller ran on all of them.
+		expect(consumer.echoFramesCancelled).toBe(vad.frames.length);
+
+		// After convergence (ignore the first 2 s), the mic stream the consumer
+		// handed to VAD is >=10 dB quieter than the raw echo it was fed.
+		const fromFrame = Math.floor((SR * 2) / BLOCK);
+		const cancelled = new Float32Array((vad.frames.length - fromFrame) * BLOCK);
+		let c = 0;
+		for (let f = fromFrame; f < vad.frames.length; f++) {
+			cancelled.set(vad.frames[f], c);
+			c += vad.frames[f].length;
+		}
+		const erleDb =
+			10 * Math.log10(energy(echo.subarray(SR * 2)) / energy(cancelled));
+		expect(erleDb).toBeGreaterThan(10);
+	});
+
+	it("passes the mic through and never invokes the canceller when no playback arrives", async () => {
+		const buffer = new PlaybackReferenceBuffer();
+		const echoReference = createEchoReferenceProvider(buffer, {
+			delaySamples: 0,
+		});
+		const vad = new CapturingVad();
+		const consumer = new AudioFrameConsumer({
+			vad,
+			pipeline: new InertPipeline(),
+			runtime: new InertRuntime(),
+			echoReference,
+		});
+		const mic = speechLike(320, 42);
+		await consumer.pushDecodedFrame(mic, 1000); // buffer empty → provider null
+		expect(consumer.echoFramesCancelled).toBe(0);
+		expect(Array.from(vad.frames[0])).toEqual(Array.from(mic)); // exact passthrough
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/playback-reference-buffer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/playback-reference-buffer.ts
@@ -1,0 +1,186 @@
+/**
+ * playback-reference-buffer.ts — the caller-side far-end (agent TTS playback)
+ * store that feeds the live acoustic echo canceller (#9583, follow-up to #9455).
+ *
+ * The {@link NlmsEchoCanceller} in `audio-frame-consumer.ts` needs the agent's
+ * TTS playback PCM time-aligned to each mic frame so it can subtract the agent's
+ * own voice before VAD / ASR / diarization. The canceller seam is ready; the
+ * caller must SUPPLY that reference. This module is that supply: a small
+ * ring of timestamped far-end PCM chunks that the on-device playback-capture
+ * path writes into, plus a factory that turns the ring into the
+ * {@link EchoReferenceProvider} the consumer consumes.
+ *
+ * Clock model: both the mic frames (`AudioFrameEvent.timestamp`) and the
+ * playback chunks are stamped in the SAME device monotonic-clock domain (ms).
+ * "What was playing at mic-clock time T" is answered by {@link
+ * PlaybackReferenceBuffer.read}. The bulk playback→mic acoustic+transport delay
+ * is NOT modeled here — it is applied by {@link createEchoReferenceProvider}
+ * (`delaySamples`), so the NLMS taps only have to model the short residual room
+ * impulse. That delay is what {@link estimatePlaybackDelaySamples} calibrates.
+ *
+ * Gaps (the agent speaks in bursts) are first-class: a `read` window that no
+ * stored playback overlaps returns `null`, which the consumer treats as "agent
+ * silent → pass the mic through unchanged". Out-of-order and partially-covered
+ * windows are handled by integer sample-overlap math, so this never aliases one
+ * burst's audio into a later burst's silence.
+ *
+ * Pure data structure, zero dependencies — verified by
+ * playback-reference-buffer.test.ts.
+ */
+
+import {
+	AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	type EchoReferenceProvider,
+} from "./audio-frame-consumer.js";
+
+/** One contiguous span of far-end playback PCM, stamped in the mic clock. */
+interface PlaybackChunk {
+	/** Device-clock timestamp (ms) of this chunk's first sample. */
+	startMs: number;
+	/** Absolute sample index of the first sample (round(startMs/1000 * SR)). */
+	startSample: number;
+	/** Far-end PCM, Float32 [-1, 1] @ 16 kHz. */
+	pcm: Float32Array;
+}
+
+export interface PlaybackReferenceBufferOptions {
+	/**
+	 * Retained far-end history in seconds. Reads older than this are dropped, so
+	 * the buffer cannot grow without bound while the agent talks. Default 8 s —
+	 * comfortably covers the largest plausible playback→mic delay plus the NLMS
+	 * filter span and a few mic frames of jitter.
+	 */
+	historySeconds?: number;
+}
+
+/**
+ * A bounded, timestamped ring of the agent's far-end (TTS playback) PCM.
+ *
+ * Writers (the device playback-capture path) call {@link write} with each
+ * playback block and the device-clock time it began playing. The echo canceller
+ * (via {@link createEchoReferenceProvider}) calls {@link read} once per mic
+ * frame to fetch the far-end window aligned to that frame.
+ */
+export class PlaybackReferenceBuffer {
+	private readonly sampleRate = AUDIO_FRAME_PIPELINE_SAMPLE_RATE;
+	private readonly maxSamples: number;
+	/** Oldest-first chunks; total retained samples capped at `maxSamples`. */
+	private chunks: PlaybackChunk[] = [];
+	private retainedSamples = 0;
+
+	constructor(opts: PlaybackReferenceBufferOptions = {}) {
+		const seconds = Math.max(0.5, opts.historySeconds ?? 8);
+		this.maxSamples = Math.round(seconds * this.sampleRate);
+	}
+
+	/** Total far-end samples currently retained (diagnostics). */
+	get bufferedSamples(): number {
+		return this.retainedSamples;
+	}
+
+	/**
+	 * Append a far-end playback block that began playing at `startMs`
+	 * (device monotonic clock, ms). Non-contiguous writes are fine — a gap
+	 * between the previous chunk's end and `startMs` is real silence and is
+	 * preserved as "no coverage", not zero-filled.
+	 */
+	write(pcm: Float32Array, startMs: number): void {
+		if (pcm.length === 0) return;
+		const startSample = Math.round((startMs / 1000) * this.sampleRate);
+		// Drop a write that is entirely older than the retained window — it can
+		// never be read (the mic frame that needed it has long passed).
+		const newestSample = this.newestSample();
+		if (
+			newestSample !== null &&
+			startSample + pcm.length <= newestSample - this.maxSamples
+		) {
+			return;
+		}
+		this.chunks.push({ startMs, startSample, pcm });
+		this.retainedSamples += pcm.length;
+		this.evictOldest();
+	}
+
+	/**
+	 * Return the far-end PCM covering the mic-clock window
+	 * `[startMs, startMs + samples/SR*1000)`. Covered samples are filled from the
+	 * stored playback; gaps (silence) stay zero. Returns `null` when NO stored
+	 * playback overlaps the window — the agent was silent and the mic should pass
+	 * through unchanged.
+	 */
+	read(startMs: number, samples: number): Float32Array | null {
+		if (samples <= 0) return null;
+		const qStart = Math.round((startMs / 1000) * this.sampleRate);
+		const qEnd = qStart + samples;
+		const out = new Float32Array(samples);
+		let covered = false;
+		for (const chunk of this.chunks) {
+			const cStart = chunk.startSample;
+			const cEnd = cStart + chunk.pcm.length;
+			const lo = Math.max(qStart, cStart);
+			const hi = Math.min(qEnd, cEnd);
+			if (lo >= hi) continue; // no overlap
+			out.set(chunk.pcm.subarray(lo - cStart, hi - cStart), lo - qStart);
+			covered = true;
+		}
+		return covered ? out : null;
+	}
+
+	/** Drop all retained playback (e.g. on a hard capture boundary). */
+	clear(): void {
+		this.chunks = [];
+		this.retainedSamples = 0;
+	}
+
+	private newestSample(): number | null {
+		const last = this.chunks[this.chunks.length - 1];
+		return last ? last.startSample + last.pcm.length : null;
+	}
+
+	private evictOldest(): void {
+		while (
+			this.chunks.length > 1 &&
+			this.retainedSamples - this.chunks[0].pcm.length >= this.maxSamples
+		) {
+			const dropped = this.chunks.shift();
+			if (dropped) this.retainedSamples -= dropped.pcm.length;
+		}
+	}
+}
+
+export interface EchoReferenceProviderOptions {
+	/**
+	 * Bulk playback→mic delay in samples. The echo in the mic at time T was
+	 * played `delaySamples` earlier, so the reference for a mic frame at T is the
+	 * playback at `T − delaySamples`. Seed from {@link
+	 * PLATFORM_PLAYBACK_DELAY_DEFAULTS} and refine with {@link
+	 * estimatePlaybackDelaySamples}. Default 0 (the NLMS taps then absorb the
+	 * whole short delay themselves).
+	 */
+	delaySamples?: number;
+}
+
+/**
+ * Build the {@link EchoReferenceProvider} the {@link AudioFrameConsumer} wants
+ * from a {@link PlaybackReferenceBuffer}. The provider applies the bulk
+ * playback→mic delay (`delaySamples`) by reading the playback window from
+ * `delaySamples` earlier than the mic frame, so the canceller's adaptive taps
+ * only model the residual room impulse — not the transport latency.
+ *
+ * `delaySamples` may be a live getter so a re-calibration takes effect without
+ * rebuilding the provider.
+ */
+export function createEchoReferenceProvider(
+	buffer: PlaybackReferenceBuffer,
+	opts:
+		| EchoReferenceProviderOptions
+		| (() => EchoReferenceProviderOptions) = {},
+): EchoReferenceProvider {
+	const resolve = typeof opts === "function" ? opts : () => opts;
+	const delayMsOf = (delaySamples: number): number =>
+		(delaySamples / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000;
+	return (timestampMs: number, samples: number): Float32Array | null => {
+		const delaySamples = Math.max(0, Math.floor(resolve().delaySamples ?? 0));
+		return buffer.read(timestampMs - delayMsOf(delaySamples), samples);
+	};
+}


### PR DESCRIPTION
Follow-up to #9455 / #9575. The NLMS echo canceller seam in `audio-frame-consumer.ts` was ready, but on the live device path nothing supplied the far-end reference and the playback→mic delay was never calibrated. This wires both.

## What this delivers (the three #9583 checkboxes)

- [x] **Wire the `echoReference` provider on the live device path.** New `PlaybackReferenceBuffer` (a bounded, timestamped ring of the agent's TTS playback PCM) + `createEchoReferenceProvider` factory, owned by `LiveDiarizationSession` and passed to the `AudioFrameConsumer`. The device feeds the far-end via a new `POST /api/voice/audio-frames/playback` route. When no playback covers a mic window the provider returns `null` and the canceller is skipped entirely (zero idle cost, exact passthrough).
- [x] **On-device playback→mic delay calibration per platform.** `echo-delay-calibrator.ts` estimates the bulk delay by normalized cross-correlation (GCC-style) over an echo-only window, with a per-platform seed table (`darwin`/`ios`/`android`/`win32`/`linux`). The session seeds from `process.platform` and auto-refines on the first echo-only burst; the active delay + confidence are surfaced in `/api/voice/audio-frames/status`.
- [x] **(Optional) AEC3-class residual-echo suppression.** Opt-in single-band residual suppressor on the canceller output, gated strictly to echo-only frames (far-end active, no double-talk) so it can never suppress a barge-in. Default off; enabled per device via `ELIZA_VOICE_AEC_RESIDUAL_SUPPRESSION`.

## Evidence

40 vitest tests, all green, typecheck clean:
- `playback-reference-buffer.test.ts` — write/read alignment, gaps→null, eviction, delay offset, **end-to-end** proof that buffer→provider→consumer→canceller cancels the agent echo by **>10 dB ERLE**.
- `echo-delay-calibrator.test.ts` — recovers a known delay (±2 samples, confidence >0.7), zero-delay, silence→0, and does **not** false-lock on uncorrelated near-end speech.
- `nlms-echo-canceller.test.ts` — residual suppressor is a no-op by default, further attenuates echo-only residual when on, never attenuates the user while the agent is silent, and does not crush the user during double-talk.

```
Test Files  4 passed (4)
     Tests  40 passed (40)
```

The actual playback-capture wiring (device-side) and per-device delay tuning still happen on hardware; this lands the reusable agent-side machinery + seams + auto-calibration so a device run just supplies frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)