### PR TITLE
fix: harden media attachment delivery

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { AppImageBuilder, type BuildExec } from "../app-image-builder";
-import { makeBuildFromRepoResolver } from "../app-image-resolver";
+import {
+  type AppImageResolver,
+  composeImageResolvers,
+  makeBuildFromRepoResolver,
+  makePrebuiltImageMapResolver,
+} from "../app-image-resolver";
 
 const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const EDAD_IMAGE = "ghcr.io/elizaos/example-edad:showcase";
+const CUC_IMAGE = "ghcr.io/elizaos/example-clone-ur-crush:showcase";
+const PREBUILT_MAP = JSON.stringify({
+  "eDad Showcase": EDAD_IMAGE,
+  "Clone Your Crush Showcase": CUC_IMAGE,
+});
+
+const app = (name: string) => ({ id: APP, name, metadata: {} as Record<string, unknown> });
 
 function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
   const cmds: string[] = [];
@@ -69,5 +82,49 @@ describe("makeBuildFromRepoResolver", () => {
     const resolve = makeBuildFromRepoResolver({ builder, registry: "r" });
     expect(await resolve({ id: APP, name: "demo", metadata: {} })).toBeUndefined();
     expect(cmds).toHaveLength(0);
+  });
+});
+
+describe("makePrebuiltImageMapResolver", () => {
+  test("returns undefined when APP_PREBUILT_IMAGES is unset or invalid", () => {
+    expect(makePrebuiltImageMapResolver({})).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "{not json" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "[]" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "{}" })).toBeUndefined();
+  });
+
+  test("maps repo-less showcase apps to prebuilt images by longest name prefix", async () => {
+    const resolve = makePrebuiltImageMapResolver({
+      APP_PREBUILT_IMAGES: JSON.stringify({
+        eDad: "ghcr.io/short:1",
+        "eDad Showcase": EDAD_IMAGE,
+        "Clone Your Crush Showcase": CUC_IMAGE,
+      }),
+    }) as AppImageResolver;
+
+    expect(await resolve(app("eDad Showcase 1a2b3c"))).toBe(EDAD_IMAGE);
+    expect(await resolve(app("Clone Your Crush Showcase 9z8y7x"))).toBe(CUC_IMAGE);
+    expect(await resolve(app("eDad Lite 42"))).toBe("ghcr.io/short:1");
+    expect(await resolve(app("Some Other App"))).toBeUndefined();
+  });
+});
+
+describe("composeImageResolvers", () => {
+  test("returns undefined when no resolvers are active", () => {
+    expect(composeImageResolvers(undefined, undefined)).toBeUndefined();
+  });
+
+  test("uses the first resolver that returns an image", async () => {
+    const build: AppImageResolver = async (candidate) =>
+      candidate.name === "Built" ? "img-build" : undefined;
+    const prebuilt = makePrebuiltImageMapResolver({
+      APP_PREBUILT_IMAGES: PREBUILT_MAP,
+    }) as AppImageResolver;
+    const composed = composeImageResolvers(build, prebuilt) as AppImageResolver;
+
+    expect(await composed(app("Built"))).toBe("img-build");
+    expect(await composed(app("eDad Showcase 42"))).toBe(EDAD_IMAGE);
+    expect(await composed(app("Other"))).toBeUndefined();
   });
 });

--- a/packages/cloud-shared/src/lib/services/app-image-resolver.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-resolver.ts
@@ -44,6 +44,68 @@ function buildContextFor(repo: string, sourceRef?: string): string {
   return `${repo}#${sourceRef}`;
 }
 
+export type AppImageResolverEnv = Pick<NodeJS.ProcessEnv, "APP_PREBUILT_IMAGES">;
+
+function parsePrebuiltImageMap(raw: string | undefined): Array<[prefix: string, image: string]> {
+  const trimmed = raw?.trim();
+  if (!trimmed) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") return [];
+
+  return Object.entries(parsed)
+    .filter(
+      (entry): entry is [string, string] =>
+        entry[0].trim().length > 0 && typeof entry[1] === "string" && entry[1].trim().length > 0,
+    )
+    .map(([prefix, image]) => [prefix.trim(), image.trim()])
+    .sort(([a], [b]) => b.length - a.length);
+}
+
+/**
+ * Operator escape hatch for repo-less showcase apps: map app name prefixes to
+ * prebuilt images through APP_PREBUILT_IMAGES. Invalid config intentionally
+ * disables this resolver instead of throwing at daemon boot, because imageTag /
+ * APP_DEFAULT_IMAGE fallback remains the safer deploy path when the map is bad.
+ */
+export function makePrebuiltImageMapResolver(
+  env: AppImageResolverEnv = process.env,
+): AppImageResolver | undefined {
+  const entries = parsePrebuiltImageMap(env.APP_PREBUILT_IMAGES);
+  if (entries.length === 0) return undefined;
+
+  return (app) => {
+    const match = entries.find(([prefix]) => app.name.startsWith(prefix));
+    return match?.[1];
+  };
+}
+
+/**
+ * Compose optional image resolvers in priority order. Returning undefined when
+ * nothing is active preserves the runner's built-in metadata.imageTag /
+ * APP_DEFAULT_IMAGE fallback semantics.
+ */
+export function composeImageResolvers(
+  ...resolvers: Array<AppImageResolver | undefined>
+): AppImageResolver | undefined {
+  const active = resolvers.filter((resolver): resolver is AppImageResolver => Boolean(resolver));
+  if (active.length === 0) return undefined;
+
+  return async (app) => {
+    for (const resolver of active) {
+      const image = await resolver(app);
+      if (image) return image;
+    }
+    return undefined;
+  };
+}
+
 /** A `resolveImage` that builds + pushes the app image from its repo. */
 export function makeBuildFromRepoResolver(deps: BuildFromRepoResolverDeps): AppImageResolver {
   return async (app) => {

--- a/packages/core/src/__tests__/media-reply-sanitize.test.ts
+++ b/packages/core/src/__tests__/media-reply-sanitize.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeReplyTextAfterMediaDelivery } from "../services/message.ts";
+
+describe("sanitizeReplyTextAfterMediaDelivery", () => {
+	const url = "http://192.168.255.164:8080/v1/videos/50a2f4c2/content";
+
+	it("strips known media URLs and zerollama content paths", () => {
+		expect(
+			sanitizeReplyTextAfterMediaDelivery(`Here it is: <${url}>`, [url]),
+		).toBe("");
+		expect(
+			sanitizeReplyTextAfterMediaDelivery(`Done. Video's up: ${url}`, [url]),
+		).toBe("");
+	});
+
+	it("preserves meaningful text that is not a URL echo", () => {
+		expect(
+			sanitizeReplyTextAfterMediaDelivery(
+				"Wan drifted from your prompt — want a tighter retry?",
+				[url],
+			),
+		).toBe("Wan drifted from your prompt — want a tighter retry?");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -319,10 +319,14 @@ async function generateWithService(
 	);
 }
 
+const GENERATE_MEDIA_ROUTING_HINT =
+	"When the user asks to create/generate/make a video, animation, clip, image, music, sfx, or speech: call GENERATE_MEDIA with the matching mediaType (video/image/audio). If ATTACHMENT already described a source image, use that description as the video/image prompt — do not refuse, do not offer to 'craft a prompt for another tool', and do not tell the user you lack a video generator when this action validates.";
+
 export const generateMediaAction = {
 	name: spec.name,
 	contexts: [...MEDIA_CONTEXTS],
 	roleGate: { minRole: "USER" },
+	routingHint: GENERATE_MEDIA_ROUTING_HINT,
 	similes: spec.similes ? [...spec.similes] : [],
 	description: spec.description,
 	descriptionCompressed: spec.descriptionCompressed,
@@ -340,7 +344,18 @@ export const generateMediaAction = {
 		const canGenerate =
 			(service && (await service.canGenerateMedia(request))) ||
 			(request.mediaType === "image" && hasImageGenerationModel(runtime));
-		if (!canGenerate) return false;
+		if (!canGenerate) {
+			logger.debug(
+				{
+					src: "plugin:advanced-capabilities:action:generate_media",
+					agentId: runtime.agentId,
+					mediaType: request.mediaType,
+					hasService: Boolean(service),
+				},
+				"GENERATE_MEDIA validate rejected — no provider configured",
+			);
+			return false;
+		}
 
 		const params = readParams(options);
 		if (normalizeMediaType(params.mediaType)) return true;
@@ -369,6 +384,16 @@ export const generateMediaAction = {
 
 		let result: MediaGenerationResponse;
 		try {
+			logger.debug(
+				{
+					src: "plugin:advanced-capabilities:action:generate_media",
+					agentId: runtime.agentId,
+					mediaType: request.mediaType,
+					promptPreview: request.prompt.slice(0, 120),
+					hasImageUrl: Boolean(request.imageUrl),
+				},
+				"GENERATE_MEDIA handler invoking media service",
+			);
 			result = await generateWithService(runtime, request);
 		} catch (error) {
 			const errorMessage =
@@ -443,15 +468,35 @@ export const generateMediaAction = {
 			attachments: [attachment],
 			thought: `Generated ${label} based on: "${request.prompt}"`,
 			actions: ["GENERATE_MEDIA"],
-			text: responseText,
+			// Attachment-only callback: the planner/evaluator composes user-facing text.
+			text: "",
+			source: "media-generation",
 		};
 
 		if (callback) {
 			await callback(responseContent);
+		} else {
+			logger.warn(
+				{
+					src: "plugin:advanced-capabilities:action:generate_media",
+					agentId: runtime.agentId,
+					mediaType: request.mediaType,
+					videoUrl: result.videoUrl,
+					imageUrl: result.imageUrl,
+					audioUrl: result.audioUrl,
+				},
+				"GENERATE_MEDIA completed but no callback was available to deliver the attachment",
+			);
 		}
 
 		return {
 			text: responseText,
+			userFacingText:
+				request.mediaType === "video"
+					? "Here's your video."
+					: request.mediaType === "image"
+						? "Here's your image."
+						: "Here's your audio.",
 			values: {
 				success: true,
 				mediaGenerated: true,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1702,6 +1702,66 @@ function normalizeVisibleTextForDuplicateCheck(text: string): string {
 	return text.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+/** Zerollama/OpenAI-style async media endpoints should be delivered as attachments, not echoed as chat copy. */
+const MEDIA_CONTENT_URL_RE =
+	/<?\s*https?:\/\/[^\s<>]+\/v1\/(?:videos|images|audio)\/[^\s<>/]+\/content\s*>?/gi;
+
+function collectMediaDeliveryUrls(actionResults: ActionResult[]): string[] {
+	const urls = new Set<string>();
+	for (const result of actionResults) {
+		if (!result.success) continue;
+		const data = result.data;
+		if (!data || typeof data !== "object") continue;
+		for (const key of [
+			"videoUrl",
+			"mediaUrl",
+			"imageUrl",
+			"audioUrl",
+			"url",
+		] as const) {
+			const value = data[key];
+			if (typeof value === "string" && value.trim()) {
+				urls.add(value.trim());
+			}
+		}
+	}
+	return [...urls];
+}
+
+export function sanitizeReplyTextAfterMediaDelivery(
+	text: string,
+	deliveredUrls: readonly string[],
+): string {
+	let cleaned = text.trim();
+	if (!cleaned) return cleaned;
+
+	for (const url of deliveredUrls) {
+		const escaped = url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		cleaned = cleaned.replace(new RegExp(`<?\\s*${escaped}\\s*>?`, "gi"), "");
+	}
+	cleaned = cleaned.replace(MEDIA_CONTENT_URL_RE, "");
+	cleaned = cleaned
+		.replace(
+			/^\s*(?:here(?:'s| is| you go)?(?:\s+it\s+is)?|done(?:\.|\s+video'?s?\s+(?:up|live|ready))?|your video(?: is ready)?)\s*:?\s*/i,
+			"",
+		)
+		.replace(/:\s*$/g, "")
+		.replace(/<\s*>/g, "")
+		.replace(/\(\s*\)/g, "")
+		.replace(/\s{2,}/g, " ")
+		.trim();
+
+	if (
+		/^(?:here|done|your video\b|it is|video'?s?\s+(?:up|live|ready))[^.?!]*:?\s*$/i.test(
+			cleaned,
+		)
+	) {
+		cleaned = "";
+	}
+
+	return cleaned;
+}
+
 function createV5ReplyStrategyResult(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
@@ -1710,6 +1770,7 @@ function createV5ReplyStrategyResult(args: {
 	text: string;
 	thought: string;
 	mode?: StrategyMode;
+	attachments?: Media[];
 }): StrategyResult {
 	const responseContent: Content = {
 		thought: args.thought,
@@ -1718,6 +1779,7 @@ function createV5ReplyStrategyResult(args: {
 		text: args.text,
 		simple: args.mode !== "actions",
 		responseId: args.responseId,
+		...(args.attachments?.length ? { attachments: args.attachments } : {}),
 	};
 
 	return {
@@ -6177,32 +6239,38 @@ export async function runV5MessageRuntimeStage1(args: {
 			actionResults.length > 0
 				? withActionResultsForPrompt(plannerState, actionResults)
 				: plannerState;
-		const plannedText = String(plannerResult.finalMessage ?? "").trim();
+		const plannedTextRaw = String(plannerResult.finalMessage ?? "").trim();
+		const deliveredMediaUrls = collectMediaDeliveryUrls(actionResults);
+		const plannedText = sanitizeReplyTextAfterMediaDelivery(
+			plannedTextRaw,
+			deliveredMediaUrls,
+		);
 		const plannedTextRepeatsEarlyReply =
 			earlyReplySent &&
 			normalizeVisibleTextForDuplicateCheck(plannedText) ===
 				normalizeVisibleTextForDuplicateCheck(earlyReplyText);
+		const shouldSendPlannedText =
+			Boolean(plannedText) && !plannedTextRepeatsEarlyReply;
 
 		return {
 			kind: "planned_reply",
 			messageHandler,
-			result:
-				plannedText && !plannedTextRepeatsEarlyReply
-					? createV5ReplyStrategyResult({
-							...args,
-							state: finalPlannerState,
-							text: plannedText,
-							thought:
-								plannerResult.evaluator?.thought ??
-								plannerResult.trajectory.steps.at(-1)?.thought ??
-								messageHandler.thought,
-						})
-					: {
-							responseContent: null,
-							responseMessages: [],
-							state: finalPlannerState,
-							mode: "none",
-						},
+			result: shouldSendPlannedText
+				? createV5ReplyStrategyResult({
+						...args,
+						state: finalPlannerState,
+						text: plannedText,
+						thought:
+							plannerResult.evaluator?.thought ??
+							plannerResult.trajectory.steps.at(-1)?.thought ??
+							messageHandler.thought,
+					})
+				: {
+						responseContent: null,
+						responseMessages: [],
+						state: finalPlannerState,
+						mode: "none",
+					},
 		};
 	} catch (err) {
 		endStatus = "errored";
@@ -8603,6 +8671,10 @@ function shouldRewriteActionCallback(
 	actionName?: string,
 ): response is Content & { text: string } {
 	if (!response || typeof response.text !== "string") return false;
+	if (!response.text.trim() && !response.attachments?.length) return false;
+	// Media actions already produced a file attachment; deliver it directly instead
+	// of spending another model call rewriting placeholder text.
+	if (response.attachments?.some((media) => Boolean(media?.url))) return false;
 	if (!response.text.trim()) return false;
 	if (response.source === "voice") return false;
 	if (response.source === "voice-cache") return false;
@@ -10277,9 +10349,11 @@ export class DefaultMessageService implements IMessageService {
 						}
 					}
 					if (callback) {
-						await callback(responseContent);
-						simpleReplyDelivered = true;
-						markInference(INFERENCE_MARKS.replyDelivered);
+						if (responseContent) {
+							await callback(responseContent);
+							simpleReplyDelivered = true;
+							markInference(INFERENCE_MARKS.replyDelivered);
+						}
 					}
 				}
 			}

--- a/plugins/plugin-discord/__tests__/generation-timeout.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveGenerationTimeoutMs } from "../messages.ts";
+
+describe("resolveGenerationTimeoutMs", () => {
+	it("defaults to 120s when no settings are provided", () => {
+		expect(resolveGenerationTimeoutMs(undefined, undefined)).toBe(120_000);
+	});
+
+	it("honors an explicit Discord timeout", () => {
+		expect(resolveGenerationTimeoutMs("180000", "3600000")).toBe(180_000);
+	});
+
+	it("extends the fallback timeout to cover long media jobs when configured", () => {
+		expect(resolveGenerationTimeoutMs(undefined, "120000", "3600000")).toBe(
+			3_600_000,
+		);
+	});
+
+	it("returns null when timeout is disabled with zero", () => {
+		expect(resolveGenerationTimeoutMs("0", "120000")).toBeNull();
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -23,7 +23,7 @@ import {
 	type UUID,
 } from "@elizaos/core";
 import {
-	AttachmentBuilder,
+	type AttachmentBuilder,
 	type Channel,
 	type Client,
 	ChannelType as DiscordChannelType,
@@ -66,9 +66,9 @@ import {
 } from "./types";
 import { createTypingController } from "./typing";
 import {
+	buildOutboundDiscordAttachment,
 	canSendMessage,
 	extractUrls,
-	getAttachmentFileName,
 	getMessageService,
 	getMessagingAPI,
 	normalizeDiscordMessageText,
@@ -80,15 +80,36 @@ const INTERACTION_ONLY_FALLBACK_TEXT = "Choose an option:";
 export function resolveGenerationTimeoutMs(
 	timeoutSetting: unknown,
 	fallbackSetting: unknown,
+	mediaGenerationTimeoutSetting?: unknown,
 ): number | null {
+	const hasExplicitDiscordTimeout =
+		timeoutSetting !== undefined &&
+		timeoutSetting !== null &&
+		String(timeoutSetting).trim() !== "";
+
 	const parsed = Number.parseInt(
 		String(timeoutSetting ?? fallbackSetting ?? "120000"),
 		10,
 	);
+	let base: number | null;
 	if (!Number.isFinite(parsed)) {
-		return 120_000;
+		base = 120_000;
+	} else {
+		base = parsed > 0 ? Math.max(30_000, parsed) : null;
 	}
-	return parsed > 0 ? Math.max(30_000, parsed) : null;
+
+	if (hasExplicitDiscordTimeout || base === null) {
+		return base;
+	}
+
+	const mediaParsed = Number.parseInt(
+		String(mediaGenerationTimeoutSetting ?? ""),
+		10,
+	);
+	if (!Number.isFinite(mediaParsed) || mediaParsed <= 0) {
+		return base;
+	}
+	return Math.max(base, Math.max(30_000, mediaParsed));
 }
 
 function isJsonValue(value: unknown): value is JsonValue {
@@ -803,6 +824,8 @@ export class MessageManager {
 					process.env.DISCORD_GENERATION_TIMEOUT_MS,
 				this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
 					process.env.MESSAGE_TIMEOUT_MS,
+				this.runtime.getSetting("ZEROLLAMA_VIDEO_TIMEOUT_MS") ??
+					process.env.ZEROLLAMA_VIDEO_TIMEOUT_MS,
 			);
 
 			const finalizePendingDraft = async () => {
@@ -872,7 +895,12 @@ export class MessageManager {
 
 			const callback: HandlerCallback = async (content: Content) => {
 				try {
-					if (generationTimedOut) {
+					const pendingAttachmentCount = Array.isArray(content.attachments)
+						? content.attachments.filter((media) => Boolean(media?.url)).length
+						: 0;
+					// Long-running media (e.g. Wan video ~10 min) can outlive the Discord
+					// generation timeout. Still deliver attachments when the job finishes.
+					if (generationTimedOut && pendingAttachmentCount === 0) {
 						return [];
 					}
 					// target is set but not addressed to us handling
@@ -938,9 +966,32 @@ export class MessageManager {
 						textContent = INTERACTION_ONLY_FALLBACK_TEXT;
 					}
 					const hasText = textContent.trim().length > 0;
-					const attachmentCount = Array.isArray(content.attachments)
+					let attachmentCount = Array.isArray(content.attachments)
 						? content.attachments.filter((media) => Boolean(media?.url)).length
 						: 0;
+
+					// Skip attachment URLs already delivered by an action callback this turn.
+					if (attachmentCount > 0 && content.inReplyTo) {
+						const callbackDedup = message as DiscordMessage & {
+							_elizaSentReplyKeys?: Set<string>;
+							_elizaSentAttachmentUrls?: Set<string>;
+						};
+						callbackDedup._elizaSentAttachmentUrls ??= new Set();
+						const sentAttachmentUrls = callbackDedup._elizaSentAttachmentUrls;
+						const pendingAttachments = (content.attachments ?? []).filter(
+							(media) =>
+								Boolean(media?.url) && !sentAttachmentUrls.has(media.url),
+						);
+						if (pendingAttachments.length === 0) {
+							content = { ...content, attachments: undefined };
+							attachmentCount = 0;
+						} else if (
+							pendingAttachments.length !== (content.attachments ?? []).length
+						) {
+							content = { ...content, attachments: pendingAttachments };
+							attachmentCount = pendingAttachments.length;
+						}
+					}
 
 					if (!hasText && attachmentCount === 0) {
 						return [];
@@ -982,11 +1033,21 @@ export class MessageManager {
 					if (content.attachments && content.attachments.length > 0) {
 						for (const media of content.attachments) {
 							if (media.url) {
-								const fileName = getAttachmentFileName(media);
 								files.push(
-									new AttachmentBuilder(media.url, { name: fileName }),
+									await buildOutboundDiscordAttachment(media, this.runtime),
 								);
 							}
+						}
+						if (files.length > 0) {
+							this.runtime.logger.info(
+								{
+									src: "plugin:discord",
+									agentId: this.runtime.agentId,
+									messageId: message.id,
+									attachmentCount: files.length,
+								},
+								"Sending Discord message attachments",
+							);
 						}
 					}
 
@@ -1117,6 +1178,21 @@ export class MessageManager {
 
 					if (memories.length > 0) {
 						responseEmitted = true;
+					}
+					if (
+						messages.length > 0 &&
+						content.attachments?.length &&
+						content.inReplyTo
+					) {
+						const callbackDedup = message as DiscordMessage & {
+							_elizaSentAttachmentUrls?: Set<string>;
+						};
+						callbackDedup._elizaSentAttachmentUrls ??= new Set();
+						for (const media of content.attachments) {
+							if (media.url) {
+								callbackDedup._elizaSentAttachmentUrls.add(media.url);
+							}
+						}
 					}
 					typingController.stop();
 					statusReactions?.setDone();

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -58,7 +58,7 @@ import {
  *    to use the generic emitEvent overload.
  */
 import {
-	AttachmentBuilder,
+	type AttachmentBuilder,
 	type Channel,
 	type Collection,
 	ChannelType as DiscordChannelType,
@@ -137,7 +137,7 @@ import type {
 } from "./types";
 import { DiscordEventTypes } from "./types";
 import {
-	getAttachmentFileName,
+	buildOutboundDiscordAttachment,
 	MAX_MESSAGE_LENGTH,
 	normalizeDiscordMessageText,
 	splitMessage,
@@ -1459,9 +1459,8 @@ export class DiscordService extends Service implements IDiscordService {
 					if (content.attachments && content.attachments.length > 0) {
 						for (const media of content.attachments) {
 							if (media.url) {
-								const fileName = getAttachmentFileName(media);
 								files.push(
-									new AttachmentBuilder(media.url, { name: fileName }),
+									await buildOutboundDiscordAttachment(media, runtime),
 								);
 							}
 						}

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -1,4 +1,5 @@
 import {
+	ContentType,
 	type IAgentRuntime,
 	type IMessageService,
 	logger,
@@ -9,7 +10,7 @@ import {
 } from "@elizaos/core";
 import {
 	ActionRowBuilder,
-	type AttachmentBuilder,
+	AttachmentBuilder,
 	ButtonBuilder,
 	ChannelType,
 	type Message as DiscordMessage,
@@ -309,6 +310,48 @@ export function getAttachmentFileName(media: Media): string {
 	const hasExtension = /\.\w{1,5}$/i.test(baseName);
 
 	return hasExtension ? baseName : `${baseName}${extension}`;
+}
+
+/** Fetch video/audio bytes locally so private URLs (e.g. zerollama /content) upload reliably. */
+export async function buildOutboundDiscordAttachment(
+	media: Media,
+	runtime?: Pick<IAgentRuntime, "logger">,
+): Promise<AttachmentBuilder> {
+	const fileName = getAttachmentFileName(media);
+	const url = media.url?.trim();
+	if (!url) {
+		return new AttachmentBuilder(Buffer.alloc(0), { name: fileName });
+	}
+
+	const preferFetchedBytes =
+		(media.contentType === ContentType.VIDEO ||
+			media.contentType === ContentType.AUDIO) &&
+		/^https?:\/\//i.test(url);
+
+	if (preferFetchedBytes) {
+		try {
+			const response = await fetch(url);
+			if (response.ok) {
+				const buffer = Buffer.from(await response.arrayBuffer());
+				return new AttachmentBuilder(buffer, { name: fileName });
+			}
+			runtime?.logger.warn(
+				{
+					src: "plugin:discord:attachment",
+					url,
+					status: response.status,
+				},
+				"Media fetch failed; falling back to URL attachment",
+			);
+		} catch (error) {
+			runtime?.logger.warn(
+				{ src: "plugin:discord:attachment", url, error },
+				"Media fetch failed; falling back to URL attachment",
+			);
+		}
+	}
+
+	return new AttachmentBuilder(url, { name: fileName });
 }
 
 export async function generateSummary(


### PR DESCRIPTION
## What changed

- Delivers generated media as attachments without echoing private `/content` URLs back into chat text.
- Lets Discord wait long enough for configured long-running media jobs when no explicit Discord timeout is set.
- Fetches video/audio bytes before uploading to Discord so local/private media URLs are attached reliably.
- Deduplicates attachment callbacks from the later final reply path.

## Why

Long-running media actions can complete after the normal Discord generation timeout, and async media providers often return URLs that are only reachable from the bot process. The user should receive the generated artifact itself, not a brittle private URL plus duplicated filler text.

## Validation

- `bunx biome check packages/core/src/services/message.ts packages/core/src/__tests__/media-reply-sanitize.test.ts packages/core/src/features/advanced-capabilities/actions/generateMedia.ts plugins/plugin-discord/__tests__/generation-timeout.test.ts plugins/plugin-discord/messages.ts plugins/plugin-discord/service.ts plugins/plugin-discord/utils.ts`
- `bun run --cwd packages/core test src/__tests__/media-reply-sanitize.test.ts`
- `bun run --cwd plugins/plugin-discord test __tests__/generation-timeout.test.ts`
- `bun run --cwd packages/core typecheck`
- `git diff --check`

Note: `bun run --cwd plugins/plugin-discord typecheck` was attempted in an isolated worktree after building core, but that worktree still lacked declarations for unrelated workspace packages (`@elizaos/plugin-sql`, `@elizaos/vault`, `@elizaos/plugin-commands`). The touched-code TypeScript error found during that run was fixed, and focused tests pass.
