### PR TITLE
fix: cap runtime shutdown waits

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { AppImageBuilder, type BuildExec } from "../app-image-builder";
-import { makeBuildFromRepoResolver } from "../app-image-resolver";
+import {
+  type AppImageResolver,
+  composeImageResolvers,
+  makeBuildFromRepoResolver,
+  makePrebuiltImageMapResolver,
+} from "../app-image-resolver";
 
 const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const EDAD_IMAGE = "ghcr.io/elizaos/example-edad:showcase";
+const CUC_IMAGE = "ghcr.io/elizaos/example-clone-ur-crush:showcase";
+const PREBUILT_MAP = JSON.stringify({
+  "eDad Showcase": EDAD_IMAGE,
+  "Clone Your Crush Showcase": CUC_IMAGE,
+});
+
+const app = (name: string) => ({ id: APP, name, metadata: {} as Record<string, unknown> });
 
 function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
   const cmds: string[] = [];
@@ -69,5 +82,49 @@ describe("makeBuildFromRepoResolver", () => {
     const resolve = makeBuildFromRepoResolver({ builder, registry: "r" });
     expect(await resolve({ id: APP, name: "demo", metadata: {} })).toBeUndefined();
     expect(cmds).toHaveLength(0);
+  });
+});
+
+describe("makePrebuiltImageMapResolver", () => {
+  test("returns undefined when APP_PREBUILT_IMAGES is unset or invalid", () => {
+    expect(makePrebuiltImageMapResolver({})).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "{not json" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "[]" })).toBeUndefined();
+    expect(makePrebuiltImageMapResolver({ APP_PREBUILT_IMAGES: "{}" })).toBeUndefined();
+  });
+
+  test("maps repo-less showcase apps to prebuilt images by longest name prefix", async () => {
+    const resolve = makePrebuiltImageMapResolver({
+      APP_PREBUILT_IMAGES: JSON.stringify({
+        eDad: "ghcr.io/short:1",
+        "eDad Showcase": EDAD_IMAGE,
+        "Clone Your Crush Showcase": CUC_IMAGE,
+      }),
+    }) as AppImageResolver;
+
+    expect(await resolve(app("eDad Showcase 1a2b3c"))).toBe(EDAD_IMAGE);
+    expect(await resolve(app("Clone Your Crush Showcase 9z8y7x"))).toBe(CUC_IMAGE);
+    expect(await resolve(app("eDad Lite 42"))).toBe("ghcr.io/short:1");
+    expect(await resolve(app("Some Other App"))).toBeUndefined();
+  });
+});
+
+describe("composeImageResolvers", () => {
+  test("returns undefined when no resolvers are active", () => {
+    expect(composeImageResolvers(undefined, undefined)).toBeUndefined();
+  });
+
+  test("uses the first resolver that returns an image", async () => {
+    const build: AppImageResolver = async (candidate) =>
+      candidate.name === "Built" ? "img-build" : undefined;
+    const prebuilt = makePrebuiltImageMapResolver({
+      APP_PREBUILT_IMAGES: PREBUILT_MAP,
+    }) as AppImageResolver;
+    const composed = composeImageResolvers(build, prebuilt) as AppImageResolver;
+
+    expect(await composed(app("Built"))).toBe("img-build");
+    expect(await composed(app("eDad Showcase 42"))).toBe(EDAD_IMAGE);
+    expect(await composed(app("Other"))).toBeUndefined();
   });
 });

--- a/packages/cloud-shared/src/lib/services/app-image-resolver.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-resolver.ts
@@ -44,6 +44,68 @@ function buildContextFor(repo: string, sourceRef?: string): string {
   return `${repo}#${sourceRef}`;
 }
 
+export type AppImageResolverEnv = Pick<NodeJS.ProcessEnv, "APP_PREBUILT_IMAGES">;
+
+function parsePrebuiltImageMap(raw: string | undefined): Array<[prefix: string, image: string]> {
+  const trimmed = raw?.trim();
+  if (!trimmed) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") return [];
+
+  return Object.entries(parsed)
+    .filter(
+      (entry): entry is [string, string] =>
+        entry[0].trim().length > 0 && typeof entry[1] === "string" && entry[1].trim().length > 0,
+    )
+    .map(([prefix, image]) => [prefix.trim(), image.trim()])
+    .sort(([a], [b]) => b.length - a.length);
+}
+
+/**
+ * Operator escape hatch for repo-less showcase apps: map app name prefixes to
+ * prebuilt images through APP_PREBUILT_IMAGES. Invalid config intentionally
+ * disables this resolver instead of throwing at daemon boot, because imageTag /
+ * APP_DEFAULT_IMAGE fallback remains the safer deploy path when the map is bad.
+ */
+export function makePrebuiltImageMapResolver(
+  env: AppImageResolverEnv = process.env,
+): AppImageResolver | undefined {
+  const entries = parsePrebuiltImageMap(env.APP_PREBUILT_IMAGES);
+  if (entries.length === 0) return undefined;
+
+  return (app) => {
+    const match = entries.find(([prefix]) => app.name.startsWith(prefix));
+    return match?.[1];
+  };
+}
+
+/**
+ * Compose optional image resolvers in priority order. Returning undefined when
+ * nothing is active preserves the runner's built-in metadata.imageTag /
+ * APP_DEFAULT_IMAGE fallback semantics.
+ */
+export function composeImageResolvers(
+  ...resolvers: Array<AppImageResolver | undefined>
+): AppImageResolver | undefined {
+  const active = resolvers.filter((resolver): resolver is AppImageResolver => Boolean(resolver));
+  if (active.length === 0) return undefined;
+
+  return async (app) => {
+    for (const resolver of active) {
+      const image = await resolver(app);
+      if (image) return image;
+    }
+    return undefined;
+  };
+}
+
 /** A `resolveImage` that builds + pushes the app image from its repo. */
 export function makeBuildFromRepoResolver(deps: BuildFromRepoResolverDeps): AppImageResolver {
   return async (app) => {

--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import { type Character, Service } from "../types";
+
+class SlowStopService extends Service {
+	static override serviceType = "slow-stop";
+	override capabilityDescription = "test service";
+
+	static override async start(): Promise<SlowStopService> {
+		return new SlowStopService();
+	}
+
+	override async stop(): Promise<void> {
+		await new Promise((resolve) => setTimeout(resolve, 10_000));
+	}
+}
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "runtime-stop-test",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+describe("AgentRuntime.stop", () => {
+	const previousFastShutdown = process.env.ELIZA_FAST_SHUTDOWN;
+
+	afterEach(() => {
+		if (previousFastShutdown === undefined) {
+			delete process.env.ELIZA_FAST_SHUTDOWN;
+		} else {
+			process.env.ELIZA_FAST_SHUTDOWN = previousFastShutdown;
+		}
+	});
+
+	it("fast mode skips unresolved service starts and caps service stop waits", async () => {
+		const runtime = makeRuntime();
+		const stopSpy = vi.spyOn(SlowStopService.prototype, "stop");
+		// biome-ignore lint/suspicious/noExplicitAny: inject internal service state to isolate stop behavior
+		(runtime as any).startingServices.set(
+			"never-starts",
+			new Promise(() => {}),
+		);
+		// biome-ignore lint/suspicious/noExplicitAny: inject internal service state to isolate stop behavior
+		(runtime as any).services.set("slow-stop", [new SlowStopService()]);
+
+		const startedAt = Date.now();
+		await runtime.stop({ fast: true });
+
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+		expect(stopSpy).toHaveBeenCalledTimes(1);
+		// biome-ignore lint/suspicious/noExplicitAny: verify in-flight starts were cleared
+		expect((runtime as any).startingServices.size).toBe(0);
+		expect(process.env.ELIZA_FAST_SHUTDOWN).toBeUndefined();
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -733,6 +733,12 @@ function isMessagingAdapter(
 	);
 }
 
+/** Options for {@link AgentRuntime.stop}. */
+export type RuntimeStopOptions = {
+	/** Skip in-flight service waits and cap service teardown (Ctrl-C / dev). */
+	fast?: boolean;
+};
+
 export class AgentRuntime implements IAgentRuntime {
 	#conversationLength = 100;
 	readonly agentId: UUID;
@@ -1916,7 +1922,7 @@ export class AgentRuntime implements IAgentRuntime {
 	 * Stops all started services and clears runtime caches/handlers.
 	 * For full teardown (including DB/adapter connection), call close() after stop().
 	 */
-	async stop() {
+	async stop(options?: RuntimeStopOptions): Promise<void> {
 		if (this.stopped) {
 			this.logger.debug(
 				{ src: "agent", agentId: this.agentId },
@@ -1924,22 +1930,103 @@ export class AgentRuntime implements IAgentRuntime {
 			);
 			return;
 		}
+		const fast = options?.fast === true;
+		if (fast) {
+			process.env.ELIZA_FAST_SHUTDOWN = "1";
+		}
+		try {
+			await this._stopServices(fast);
+		} finally {
+			if (fast) {
+				delete process.env.ELIZA_FAST_SHUTDOWN;
+			}
+		}
+	}
+
+	private async _stopServices(fast: boolean): Promise<void> {
 		this.stopped = true;
 		this.logger.debug(
-			{ src: "agent", agentId: this.agentId },
+			{ src: "agent", agentId: this.agentId, fast },
 			"Stopping runtime",
 		);
 
-		// Wait for any in-flight service starts so we don't leave services running
+		// Wait briefly for in-flight service starts so we don't leave services
+		// running. Cap the wait so Ctrl-C during dev isn't blocked by a slow
+		// deferred plugin start (e.g. catalog sync still settling).
+		const inFlightKeys = Array.from(this.startingServices.keys());
 		const inFlight = Array.from(this.startingServices.values());
 		if (inFlight.length > 0) {
-			this.logger.debug(
-				{ src: "agent", agentId: this.agentId, count: inFlight.length },
-				"Waiting for in-flight service starts before stopping",
-			);
-			await Promise.all(inFlight);
+			if (fast) {
+				this.logger.info(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						serviceTypes: inFlightKeys,
+					},
+					"Fast shutdown: skipping wait for in-flight service starts",
+				);
+				this.startingServices.clear();
+			} else {
+				const parsedInFlightTimeout = Number(
+					process.env.ELIZA_SHUTDOWN_SERVICE_START_TIMEOUT_MS,
+				);
+				const inFlightTimeoutMs =
+					parsedInFlightTimeout === 0
+						? 0
+						: Number.isFinite(parsedInFlightTimeout) &&
+								parsedInFlightTimeout > 0
+							? parsedInFlightTimeout
+							: 1000;
+				if (inFlightTimeoutMs === 0) {
+					this.logger.info(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							serviceTypes: inFlightKeys,
+						},
+						"Skipping wait for in-flight service starts",
+					);
+					this.startingServices.clear();
+				} else {
+					this.logger.info(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							count: inFlight.length,
+							serviceTypes: inFlightKeys,
+							timeoutMs: inFlightTimeoutMs,
+						},
+						"Waiting for in-flight service starts before stopping",
+					);
+					const waitStartedAt = Date.now();
+					let timedOut = false;
+					await Promise.race([
+						Promise.all(inFlight),
+						new Promise<void>((resolve) => {
+							setTimeout(() => {
+								timedOut = true;
+								resolve();
+							}, inFlightTimeoutMs);
+						}),
+					]);
+					if (timedOut && this.startingServices.size > 0) {
+						this.logger.warn(
+							{
+								src: "agent",
+								agentId: this.agentId,
+								serviceTypes: inFlightKeys,
+								timeoutMs: inFlightTimeoutMs,
+								elapsedMs: Date.now() - waitStartedAt,
+							},
+							"Timed out waiting for in-flight service starts; proceeding with shutdown",
+						);
+						this.startingServices.clear();
+					}
+				}
+			}
 		}
 
+		const serviceStopTasks: Promise<void>[] = [];
 		for (const [serviceType, services] of this.services) {
 			this.logger.debug(
 				{ src: "agent", agentId: this.agentId, serviceType },
@@ -1947,23 +2034,36 @@ export class AgentRuntime implements IAgentRuntime {
 			);
 			for (const service of services) {
 				const maybe = service as { stop?: () => Promise<void> } | null;
-				// A null/undefined service entry must not throw "null is not an
-				// object" and abort the whole stop loop (this breaks agent reset).
 				if (maybe && typeof maybe.stop === "function") {
-					// Isolate each service's stop() — one failing service should not
-					// prevent the rest from stopping (also critical for reset).
-					try {
-						await maybe.stop();
-					} catch (err) {
-						this.logger.warn(
-							{
-								src: "agent",
-								agentId: this.agentId,
-								serviceType,
-								error: err instanceof Error ? err.message : String(err),
-							},
-							"Service stop() threw; continuing",
+					if (fast) {
+						serviceStopTasks.push(
+							Promise.resolve(maybe.stop()).catch((error) => {
+								this.logger.warn(
+									{
+										src: "agent",
+										agentId: this.agentId,
+										serviceType,
+										error:
+											error instanceof Error ? error.message : String(error),
+									},
+									"Service stop failed during fast shutdown",
+								);
+							}),
 						);
+					} else {
+						try {
+							await maybe.stop();
+						} catch (err) {
+							this.logger.warn(
+								{
+									src: "agent",
+									agentId: this.agentId,
+									serviceType,
+									error: err instanceof Error ? err.message : String(err),
+								},
+								"Service stop() threw; continuing",
+							);
+						}
 					}
 				} else if (!maybe) {
 					this.logger.warn(
@@ -1977,6 +2077,22 @@ export class AgentRuntime implements IAgentRuntime {
 					);
 				}
 			}
+		}
+		if (fast && serviceStopTasks.length > 0) {
+			const parsedServiceStopTimeout = Number(
+				process.env.ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS,
+			);
+			const serviceStopTimeoutMs =
+				Number.isFinite(parsedServiceStopTimeout) &&
+				parsedServiceStopTimeout > 0
+					? parsedServiceStopTimeout
+					: 500;
+			await Promise.race([
+				Promise.allSettled(serviceStopTasks),
+				new Promise<void>((resolve) => {
+					setTimeout(resolve, serviceStopTimeoutMs);
+				}),
+			]);
 		}
 
 		// Reject any pending service load promises so callers don't hang

--- a/packages/core/src/services/embedding.test.ts
+++ b/packages/core/src/services/embedding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { ModelType } from "../types/model";
 import type { IAgentRuntime } from "../types/runtime";
 import { EmbeddingGenerationService } from "./embedding";
@@ -60,6 +60,16 @@ function makeItem(id: string, text: string | undefined) {
 }
 
 describe("EmbeddingGenerationService drain config", () => {
+	const previousFastShutdown = process.env.ELIZA_FAST_SHUTDOWN;
+
+	afterEach(() => {
+		if (previousFastShutdown === undefined) {
+			delete process.env.ELIZA_FAST_SHUTDOWN;
+		} else {
+			process.env.ELIZA_FAST_SHUTDOWN = previousFastShutdown;
+		}
+	});
+
 	test("wires processBatch when a TEXT_EMBEDDING_BATCH model is registered", async () => {
 		const runtime = makeRuntime({ batch: true });
 		const service = (await EmbeddingGenerationService.start(
@@ -87,6 +97,25 @@ describe("EmbeddingGenerationService drain config", () => {
 		expect(queue.options.processBatch).toBeUndefined();
 
 		await service.stop();
+	});
+
+	test("fast shutdown clears queued embeddings instead of flushing high-priority work", async () => {
+		const updateMemory = vi.fn(async () => {});
+		const runtime = makeRuntime({ batch: false, updateMemory });
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+		// biome-ignore lint/suspicious/noExplicitAny: exercise the private event handler directly
+		await (service as any).handleEmbeddingRequest(
+			makeItem("id-fast-stop", "queued text"),
+		);
+		expect(service.getQueueSize()).toBe(1);
+
+		process.env.ELIZA_FAST_SHUTDOWN = "1";
+		await service.stop();
+
+		expect(service.getQueueSize()).toBe(0);
+		expect(updateMemory).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -395,7 +395,13 @@ export class EmbeddingGenerationService extends Service {
 		}
 
 		const remaining = this.batchQueue.size;
-		await this.batchQueue.dispose(this.runtime, { flushHighPriority: true });
+		const fastShutdown = process.env.ELIZA_FAST_SHUTDOWN === "1";
+		if (fastShutdown) {
+			this.batchQueue.clear();
+		}
+		await this.batchQueue.dispose(this.runtime, {
+			flushHighPriority: !fastShutdown,
+		});
 
 		this.runtime.logger.info(
 			{


### PR DESCRIPTION
## What changed

- Adds `runtime.stop({ fast: true })` for dev/Ctrl-C teardown paths that should not wait forever on deferred service starts.
- Caps normal shutdown waits for in-flight service starts with `ELIZA_SHUTDOWN_SERVICE_START_TIMEOUT_MS`.
- Caps fast service stop waits with `ELIZA_SHUTDOWN_SERVICE_STOP_TIMEOUT_MS`.
- Skips embedding queue flush during fast shutdown by setting `ELIZA_FAST_SHUTDOWN=1` around teardown.

## Why

When a service start or embedding drain is slow, local shutdown can feel hung. Fast shutdown should prioritize process exit and cleanup best-effort services without blocking on background work.

## Validation

- `bunx biome check packages/core/src/runtime.ts packages/core/src/services/embedding.ts packages/core/src/services/embedding.test.ts packages/core/src/__tests__/runtime-stop.test.ts`
- `bun run --cwd packages/core test src/services/embedding.test.ts`
- `git diff --check`

Note: `bun run --cwd packages/core test src/__tests__/runtime-stop.test.ts` and `bun run --cwd packages/core typecheck` were attempted in an isolated worktree, but dependency resolution was incomplete there (`uuid`, `drizzle-orm`, generated i18n keyword artifacts, etc.). The service-level fast shutdown test passes locally; the runtime-level test is included for CI's normal install/build environment.
