### PR TITLE
docs(verify): per-tier Metal throughput matrix on M4 Max + reusable harness (#9580)

### DIFF
--- a/plugins/plugin-local-inference/native/verify/PLATFORM_MATRIX.md
+++ b/plugins/plugin-local-inference/native/verify/PLATFORM_MATRIX.md
@@ -110,6 +110,14 @@ packages/training/benchmarks` is 140 passed / 1 skipped.
 > directly. Records:
 > [`evidence/platform/darwin-arm64-metal.json`](evidence/platform/darwin-arm64-metal.json)
 > (+ `darwin-arm64-metal-verify.log`, `darwin-arm64-metal-gemma-gen.log`).
+>
+> **2026-06-25 — per-tier Metal throughput matrix (#9580).** The single
+> gemma-4-E2B point above is one model; the full **per-tier** sweep (the
+> Qwen3.5-era Eliza-1 bundles staged on the M4 Max — `0_6b`→`9b`, pp512
+> 9307→724 / tg128 103→41 t/s) + the §8 kernel gate re-verified 8/8 today live
+> in [`metal-per-tier-perf-matrix.md`](metal-per-tier-perf-matrix.md), reproducible
+> via [`metal-perf-matrix.mjs`](metal-perf-matrix.mjs). Re-run once the Gemma-4
+> bundles are staged for per-tier Gemma numbers.
 
 | Target | Build | Kernel verify | Bench | Status | Prereq if not done |
 | --- | --- | --- | --- | --- | --- |

--- a/plugins/plugin-local-inference/native/verify/evidence/platform/darwin-arm64-metal-perf-matrix-2026-06-25.json
+++ b/plugins/plugin-local-inference/native/verify/evidence/platform/darwin-arm64-metal-perf-matrix-2026-06-25.json
@@ -1,0 +1,116 @@
+{
+  "host": "Apple M4 Max",
+  "os": "macOS 26.2 (Darwin 25.2.0)",
+  "ramGB": 128,
+  "bench": "llama-bench (stock build 9ab5989e8 / b9854)",
+  "date": "2026-06-25",
+  "flags": "-ngl 99 -fa 1 -p 512 -n 128",
+  "tiers": [
+    {
+      "tier": "0_6b",
+      "arch": "qwen3 0.6B Q8_0",
+      "sizeMiB": 604.1,
+      "params_M": 596.0,
+      "pp512_ts": {
+        "avg": 9307.386259,
+        "sd": 375.136422
+      },
+      "tg128_ts": {
+        "avg": 103.161973,
+        "sd": 12.958364
+      }
+    },
+    {
+      "tier": "0_8b",
+      "arch": "qwen35 0.8B Q4_K - Medium",
+      "sizeMiB": 520.7,
+      "params_M": 752.4,
+      "pp512_ts": {
+        "avg": 7059.28579,
+        "sd": 255.180285
+      },
+      "tg128_ts": {
+        "avg": 91.779168,
+        "sd": 11.663773
+      },
+      "tg128_by_depth": {
+        "0": 89.2,
+        "4096": 84.0,
+        "16000": 95.8
+      }
+    },
+    {
+      "tier": "1_7b",
+      "arch": "qwen3 1.7B Q8_0",
+      "sizeMiB": 1743.8,
+      "params_M": 1720.6,
+      "pp512_ts": {
+        "avg": 4017.229951,
+        "sd": 108.03193
+      },
+      "tg128_ts": {
+        "avg": 77.189198,
+        "sd": 6.155101
+      }
+    },
+    {
+      "tier": "2b",
+      "arch": "qwen35 2B Q4_K - Medium",
+      "sizeMiB": 1201.5,
+      "params_M": 1881.8,
+      "pp512_ts": {
+        "avg": 2872.058119,
+        "sd": 326.826512
+      },
+      "tg128_ts": {
+        "avg": 67.192507,
+        "sd": 6.250891
+      },
+      "tg128_by_depth": {
+        "0": 83.7,
+        "4096": 78.0,
+        "16000": 67.8
+      }
+    },
+    {
+      "tier": "4b",
+      "arch": "qwen35 4B Q4_K - Medium",
+      "sizeMiB": 2728.2,
+      "params_M": 4205.8,
+      "pp512_ts": {
+        "avg": 1030.478227,
+        "sd": 85.792962
+      },
+      "tg128_ts": {
+        "avg": 48.133116,
+        "sd": 2.697262
+      },
+      "tg128_by_depth": {
+        "0": 49.1,
+        "4096": 49.1,
+        "16000": 38.7
+      }
+    },
+    {
+      "tier": "9b",
+      "arch": "qwen35 9B Q4_K - Medium",
+      "sizeMiB": 5406.9,
+      "params_M": 8953.8,
+      "pp512_ts": {
+        "avg": 723.729314,
+        "sd": 43.377314
+      },
+      "tg128_ts": {
+        "avg": 40.781372,
+        "sd": 1.130544
+      }
+    }
+  ],
+  "kernelGate": {
+    "metal-verify": "8/8 PASS (24 scalar kernels: turbo3/turbo4/turbo3_tcq/qjl/polar+preht)",
+    "metal-verify-fused": "1536/1536 PASS (2 GQA/MQA cases)",
+    "metal-verify-multiblock": "1920/1920 PASS (4 cases)",
+    "date": "2026-06-25",
+    "maxDiff": "<=7.6e-6"
+  }
+}

--- a/plugins/plugin-local-inference/native/verify/metal-per-tier-perf-matrix.md
+++ b/plugins/plugin-local-inference/native/verify/metal-per-tier-perf-matrix.md
@@ -1,0 +1,93 @@
+# Metal per-tier performance matrix — Apple M4 Max (#9580)
+
+`PLATFORM_MATRIX.md` records the §8 **kernel-correctness** gate and a single
+model-graph throughput point. This doc adds the missing **per-tier** Metal
+throughput row #9580 asks for ("Metal per-tier (M-series) — produce the real
+perf/overhead numbers per backend"), produced on real hardware and reproducible
+with [`metal-perf-matrix.mjs`](metal-perf-matrix.mjs).
+
+## Host
+
+- **Apple M4 Max**, macOS 26.2 (Darwin 25.2.0), 128 GB unified memory.
+- GPU: `MTLGPUFamilyApple9` / `Metal4`, unified memory, bfloat, residency sets,
+  `recommendedMaxWorkingSetSize ≈ 115 GB`.
+- `llama-bench`, all layers on GPU (`-ngl 99`), **flash attention on** (`-fa 1`),
+  prefill `pp512`, decode `tg128`. Run date **2026-06-25**.
+- Evidence: [`evidence/platform/darwin-arm64-metal-perf-matrix-2026-06-25.json`](evidence/platform/darwin-arm64-metal-perf-matrix-2026-06-25.json).
+
+## Kernel-correctness gate (re-verified 2026-06-25, M4 Max)
+
+| Gate | Result |
+| --- | --- |
+| `make metal-verify` | **8/8 PASS** on every scalar kernel — turbo3 / turbo4 / turbo3_tcq / qjl / polar (incl. polar pre-Hadamard + QJL-residual variants), max diff ≤ 7.6e-6 |
+| `make metal-verify-fused` | **1536/1536 PASS** across 2 GQA/MQA cases (`n_kv_heads=2`) |
+| `make metal-verify-multiblock` | **1920/1920 PASS** across 4 cases |
+
+The §8 gate is correctness only; the numbers below are throughput.
+
+## Per-tier throughput (staged Eliza-1 text bundles)
+
+> **Arch labeling is honest.** The bundles currently staged on this host are the
+> **Qwen3.5-era** Eliza-1 tiers (what `llama-bench` reports as the loaded arch),
+> not the Gemma-4 cutover base. The Gemma-4 numbers (`gemma-4-E2B` pp512 636 /
+> tg128 23, head_dim 512) in `PLATFORM_MATRIX.md` are a *different model* and are
+> slower because Gemma-4's `head_dim=512` attention is much heavier than
+> Qwen3.5's. Both are real; do not conflate them. Re-run this matrix once the
+> Gemma-4 bundles are staged to get the per-tier Gemma numbers.
+
+| tier | arch (as loaded) | quant | size (MiB) | params | **pp512 t/s** | **tg128 t/s** |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| `0_6b` | qwen3 0.6B | Q8_0 | 604 | 596 M | **9307 ± 375** | **103.2 ± 13** |
+| `0_8b` | qwen35 0.8B | Q4_K_M | 521 | 752 M | **7059 ± 255** | **91.8 ± 12** |
+| `1_7b` | qwen3 1.7B | Q8_0 | 1744 | 1.72 B | **4017 ± 108** | **77.2 ± 6** |
+| `2b` | qwen35 2B | Q4_K_M | 1201 | 1.88 B | **2872 ± 327** | **67.2 ± 6** |
+| `4b` | qwen35 4B | Q4_K_M | 2728 | 4.21 B | **1030 ± 86** | **48.1 ± 3** |
+| `9b` | qwen35 9B | Q4_K_M | 5407 | 8.95 B | **724 ± 43** | **40.8 ± 1** |
+
+`27b` / `27b-256k` are stageable on the 128 GB host but were out of scope for
+this pass (the matrix script picks them up automatically when present).
+
+## Decode throughput vs context depth (tg128 @ depth)
+
+KV-cache scaling on the Metal FA path (separate run; absolute numbers carry
+run-to-run variance, the *trend* is the signal):
+
+| tier | d=0 | d=4096 | d=16000 |
+| --- | ---: | ---: | ---: |
+| `0_8b` | 89.2 | 84.0 | 95.8 |
+| `2b` | 83.7 | 78.0 | 67.8 |
+| `4b` | 49.1 | 49.1 | 38.7 |
+
+Decode stays well above real-time (≈ tens of tok/s) out to 16 k context on every
+tier the desktop default would pick; the larger tiers fall off more steeply as
+the KV cache grows, as expected.
+
+## Reproduce
+
+```bash
+# kernel gate (correctness, no weights needed)
+make -C plugins/plugin-local-inference/native/verify \
+  metal-verify metal-verify-multiblock metal-verify-fused
+
+# per-tier throughput (auto-discovers staged Eliza-1 bundles + llama-bench)
+node plugins/plugin-local-inference/native/verify/metal-perf-matrix.mjs \
+  --depths 0,4096,16000 --out plugins/plugin-local-inference/native/verify/reports
+
+# explicit bench / models dir:
+LLAMA_BENCH=/path/to/llama-bench \
+  node …/metal-perf-matrix.mjs --models-dir ~/.eliza/local-inference/models
+```
+
+The harness resolves `llama-bench` from `--bench` / `$LLAMA_BENCH` / common
+fork-build locations, discovers each `eliza-1-<tier>.bundle/text/*.gguf`, and
+emits a markdown table + JSON report.
+
+## iOS Metal (A18 Pro) — status
+
+iOS Metal throughput is **not** measured by this CLI harness: the iOS runtime is
+the static lib + `eliza_inference_*` ABI (no `llama-bench` on device, see
+`PLATFORM_MATRIX.md` `ios-arm64-metal`). The kernel-symbol / structure / runtime
+audits pass (`build-xcframework.mjs --verify`) and the XCTest device smoke passes
+on iPhone 15 Pro; the remaining iOS perf gate is a weight-backed bundle smoke
+from the Capacitor app shell (first-token / first-audio / peak-RSS / thermal),
+which is device-app work, not a host CLI run.

--- a/plugins/plugin-local-inference/native/verify/metal-perf-matrix.mjs
+++ b/plugins/plugin-local-inference/native/verify/metal-perf-matrix.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * metal-perf-matrix.mjs — per-tier Metal (Apple GPU) throughput matrix for the
+ * staged Eliza-1 text bundles (#9580).
+ *
+ * The §8 kernel gate (`make metal-verify`) proves correctness; this proves
+ * *throughput per tier* on real hardware — the "Metal per-tier (M-series)"
+ * verification-matrix row #9580 asks for. It discovers the text GGUF for each
+ * Eliza-1 tier on disk, runs `llama-bench` (prefill pp512 + decode tg128, flash
+ * attention on, all layers on GPU), and emits a markdown table + JSON report.
+ *
+ * Usage:
+ *   node metal-perf-matrix.mjs [--bench <llama-bench>] [--models-dir <dir>]
+ *                              [--depths 0,4096,16000] [--out <dir>] [--json]
+ *
+ * Resolution (first hit wins):
+ *   --bench / $LLAMA_BENCH, else common fork-build locations.
+ *   --models-dir / $MODELS_DIR, else the curated Eliza-1 model dirs.
+ *
+ * This is read-only w.r.t. the repo: it shells out to `llama-bench` and writes
+ * only under the chosen `--out` dir. It does NOT build anything.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const TIER_ORDER = [
+	"0_6b",
+	"0_8b",
+	"1_7b",
+	"2b",
+	"4b",
+	"9b",
+	"27b",
+	"27b-256k",
+];
+
+function parseArgs(argv) {
+	const args = {
+		bench: process.env.LLAMA_BENCH ?? null,
+		modelsDir: process.env.MODELS_DIR ?? null,
+		depths: null,
+		out: null,
+		json: false,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--bench") args.bench = argv[++i];
+		else if (a === "--models-dir") args.modelsDir = argv[++i];
+		else if (a === "--depths") args.depths = argv[++i];
+		else if (a === "--out") args.out = argv[++i];
+		else if (a === "--json") args.json = true;
+		else if (a === "--help" || a === "-h") {
+			console.log(
+				"Usage: metal-perf-matrix.mjs [--bench <path>] [--models-dir <dir>] [--depths 0,4096,16000] [--out <dir>] [--json]",
+			);
+			process.exit(0);
+		}
+	}
+	return args;
+}
+
+function resolveBench(explicit) {
+	const candidates = [
+		explicit,
+		path.join(
+			process.cwd(),
+			".tmp/llama-mtp-build/bin/llama-bench",
+		),
+		path.join(homedir(), "eliza-workspace/llama-build-test/build/bin/llama-bench"),
+	].filter(Boolean);
+	// Plus any fork install under ~/.eliza/local-inference/bin/mtp/<triple>/.
+	const mtpRoot = path.join(homedir(), ".eliza/local-inference/bin/mtp");
+	if (existsSync(mtpRoot)) {
+		for (const triple of safeReaddir(mtpRoot)) {
+			candidates.push(path.join(mtpRoot, triple, "llama-bench"));
+		}
+	}
+	for (const c of candidates) if (c && existsSync(c)) return c;
+	throw new Error(
+		`llama-bench not found. Pass --bench <path> or set $LLAMA_BENCH. Tried:\n  ${candidates.join("\n  ")}`,
+	);
+}
+
+function defaultModelDirs() {
+	return [
+		path.join(homedir(), ".eliza/local-inference/models"),
+		path.join(homedir(), "elizacache/local-inference/models"),
+	].filter(existsSync);
+}
+
+function safeReaddir(dir) {
+	try {
+		return readdirSync(dir);
+	} catch {
+		return [];
+	}
+}
+
+/** Find the text GGUF for each tier: `<dir>/eliza-1-<tier>.bundle/text/*.gguf`. */
+function discoverTierModels(modelDirs) {
+	const found = new Map(); // tier -> gguf path
+	for (const root of modelDirs) {
+		for (const entry of safeReaddir(root)) {
+			const m = /^eliza-1-(.+)\.bundle$/.exec(entry);
+			if (!m) continue;
+			const tier = m[1];
+			if (found.has(tier)) continue; // first dir wins
+			const textDir = path.join(root, entry, "text");
+			const gguf = safeReaddir(textDir)
+				.filter((f) => f.endsWith(".gguf"))
+				.sort()[0];
+			if (gguf) found.set(tier, path.join(textDir, gguf));
+		}
+	}
+	// Stable, catalog-ordered output.
+	const ordered = [];
+	for (const tier of TIER_ORDER) {
+		if (found.has(tier)) ordered.push([tier, found.get(tier)]);
+	}
+	for (const [tier, p] of found) {
+		if (!TIER_ORDER.includes(tier)) ordered.push([tier, p]);
+	}
+	return ordered;
+}
+
+function runBench(bench, model, depths) {
+	const args = ["-m", model, "-p", "512", "-n", "128", "-ngl", "99", "-fa", "1"];
+	if (depths) args.push("-d", depths);
+	args.push("-o", "json");
+	const stdout = execFileSync(bench, args, {
+		encoding: "utf8",
+		maxBuffer: 64 * 1024 * 1024,
+		env: { ...process.env, DYLD_LIBRARY_PATH: path.dirname(bench) },
+	});
+	return JSON.parse(stdout);
+}
+
+/** Reduce llama-bench rows into {arch, sizeMiB, params, pp512, tg128, depthDecode}. */
+function summarize(rows) {
+	const r0 = rows[0] ?? {};
+	const out = {
+		arch: r0.model_type ?? "?",
+		sizeMiB: (r0.model_size ?? 0) / (1024 * 1024),
+		params: (r0.model_n_params ?? 0) / 1e6,
+		flashAttn: r0.flash_attn ?? 0,
+		pp512: null,
+		tg128: null,
+		depthDecode: {}, // depth -> tg t/s
+	};
+	for (const r of rows) {
+		const ts = { avg: r.avg_ts, sd: r.stddev_ts };
+		if (r.n_prompt > 0 && r.n_gen === 0 && r.n_depth === 0) out.pp512 = ts;
+		else if (r.n_gen > 0 && r.n_prompt === 0) {
+			if ((r.n_depth ?? 0) === 0) out.tg128 = ts;
+			out.depthDecode[r.n_depth ?? 0] = ts;
+		}
+	}
+	return out;
+}
+
+function fmt(ts) {
+	return ts ? `${ts.avg.toFixed(1)} ± ${ts.sd.toFixed(0)}` : "—";
+}
+
+function buildMarkdown(results, meta) {
+	const depths = meta.depths
+		? meta.depths.split(",").map((d) => Number.parseInt(d, 10))
+		: [];
+	const header = [
+		"| tier | arch (as loaded) | size (MiB) | params | pp512 t/s | tg128 t/s",
+		...depths.map((d) => ` | tg@d=${d}`),
+		" |",
+	].join("");
+	const sep = `|${"---|".repeat(6 + depths.length)}`;
+	const lines = [header, sep];
+	for (const { tier, summary } of results) {
+		const cells = [
+			tier,
+			summary.arch,
+			summary.sizeMiB.toFixed(0),
+			`${summary.params.toFixed(0)}M`,
+			fmt(summary.pp512),
+			fmt(summary.tg128),
+			...depths.map((d) => fmt(summary.depthDecode[d])),
+		];
+		lines.push(`| ${cells.join(" | ")} |`);
+	}
+	return lines.join("\n");
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const bench = resolveBench(args.bench);
+	const modelDirs = args.modelsDir ? [args.modelsDir] : defaultModelDirs();
+	if (modelDirs.length === 0) {
+		throw new Error(
+			"No model dirs found. Pass --models-dir <dir> or set $MODELS_DIR.",
+		);
+	}
+	const tiers = discoverTierModels(modelDirs);
+	if (tiers.length === 0) {
+		throw new Error(`No eliza-1-*.bundle text GGUFs under: ${modelDirs.join(", ")}`);
+	}
+
+	console.error(`[metal-perf-matrix] bench: ${bench}`);
+	console.error(`[metal-perf-matrix] tiers: ${tiers.map(([t]) => t).join(", ")}`);
+
+	const results = [];
+	for (const [tier, model] of tiers) {
+		console.error(`[metal-perf-matrix] benchmarking ${tier} …`);
+		try {
+			const rows = runBench(bench, model, args.depths);
+			results.push({ tier, model, summary: summarize(rows), rows });
+		} catch (err) {
+			console.error(`[metal-perf-matrix] tier ${tier} FAILED: ${err.message}`);
+			results.push({ tier, model, error: err.message });
+		}
+	}
+
+	const ok = results.filter((r) => !r.error);
+	const meta = { bench, depths: args.depths, modelDirs };
+	const markdown = buildMarkdown(ok, meta);
+	console.log(markdown);
+
+	if (args.out) {
+		mkdirSync(args.out, { recursive: true });
+		const report = { meta, results };
+		const jsonPath = path.join(args.out, "metal-perf-matrix.json");
+		writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+		const mdPath = path.join(args.out, "metal-perf-matrix.md");
+		writeFileSync(mdPath, `${markdown}\n`);
+		console.error(`[metal-perf-matrix] wrote ${jsonPath} + ${mdPath}`);
+	}
+	if (args.json) console.error(JSON.stringify({ meta, results }, null, 2));
+}
+
+main().catch((err) => {
+	console.error(err.stack ?? String(err));
+	process.exit(1);
+});


### PR DESCRIPTION
Addresses the **"Per-backend GPU verification matrix … Metal per-tier (M-series)"** checkbox of #9580 with real numbers from an Apple **M4 Max** (macOS 26.2, 128 GB).

`PLATFORM_MATRIX.md` already had the §8 kernel-correctness gate and a *single* model-graph point (gemma-4-E2B pp512 636 / tg128 23). This adds the missing **per-tier** throughput sweep.

## Real numbers (M4 Max, 2026-06-25, `-ngl 99 -fa 1`)

| tier | arch (as loaded) | pp512 t/s | tg128 t/s |
| --- | --- | ---: | ---: |
| `0_6b` | qwen3 0.6B Q8_0 | **9307 ± 375** | **103.2 ± 13** |
| `0_8b` | qwen35 0.8B Q4_K_M | **7059 ± 255** | **91.8 ± 12** |
| `1_7b` | qwen3 1.7B Q8_0 | **4017 ± 108** | **77.2 ± 6** |
| `2b` | qwen35 2B Q4_K_M | **2872 ± 327** | **67.2 ± 6** |
| `4b` | qwen35 4B Q4_K_M | **1030 ± 86** | **48.1 ± 3** |
| `9b` | qwen35 9B Q4_K_M | **724 ± 43** | **40.8 ± 1** |

Plus decode-vs-context-depth scaling (tg128 @ d=0/4096/16000) for representative tiers, and the **§8 kernel gate re-verified 8/8 today** (`metal-verify` + `metal-verify-fused` 1536/1536 + `metal-verify-multiblock` 1920/1920, max diff ≤ 7.6e-6).

## What's in the PR

- `metal-perf-matrix.mjs` — reusable harness: auto-discovers `eliza-1-<tier>.bundle` text GGUFs + `llama-bench`, runs pp512/tg128 (+ optional depths), emits markdown + JSON.
- `metal-per-tier-perf-matrix.md` — the captured run + reproduce instructions.
- `evidence/platform/darwin-arm64-metal-perf-matrix-2026-06-25.json` — raw numbers.
- `PLATFORM_MATRIX.md` — pointer to the new per-tier matrix.

## Honesty notes

- The bundles staged on this host report as the **Qwen3.5-era** Eliza-1 tiers (what `llama-bench` loads), **not** the Gemma-4 cutover base. The gemma-4-E2B point (head_dim 512, slower) is a *different model* and is kept distinct — re-run the harness once the Gemma-4 bundles are staged for per-tier Gemma numbers.
- **iOS Metal (A18 Pro)** throughput is not measured by this CLI harness — the iOS runtime is the static lib + `eliza_inference_*` ABI (no `llama-bench` on device); the kernel/symbol/XCTest audits already pass per `PLATFORM_MATRIX.md`. That gate is device-app work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)