### PR TITLE
fix(vision): YOLO converter torch.load fallback when ultralytics import fails (#9105)

### DIFF
--- a/plugins/plugin-vision/native/yolo.cpp/scripts/convert.py
+++ b/plugins/plugin-vision/native/yolo.cpp/scripts/convert.py
@@ -90,11 +90,6 @@ def main() -> int:
         print(f"missing dependency: {exc}. pip install torch numpy", file=sys.stderr)
         return 2
     try:
-        from ultralytics import YOLO
-    except ImportError:
-        print("ultralytics not installed. pip install ultralytics", file=sys.stderr)
-        return 2
-    try:
         import gguf
     except ImportError:
         print("gguf not installed. pip install gguf", file=sys.stderr)
@@ -110,7 +105,21 @@ def main() -> int:
 
     weights = args.weights or f"{args.variant}.pt"
     print(f"[convert] loading {weights}", file=sys.stderr)
-    model = YOLO(weights).model  # DetectionModel (nn.Module)
+    # Prefer ultralytics; fall back to loading the DetectionModel straight from
+    # the checkpoint when ultralytics/torchvision can't import (a broken
+    # torchvision<->torch ABI raises at import, not ImportError). The .pt already
+    # pickles the full DetectionModel, so torch alone can recover the weights.
+    try:
+        from ultralytics import YOLO
+
+        model = YOLO(weights).model  # DetectionModel (nn.Module)
+    except Exception as exc:  # noqa: BLE001 - any import/registration failure
+        print(
+            f"[convert] ultralytics unavailable ({exc}); "
+            "loading the DetectionModel directly from the checkpoint",
+            file=sys.stderr,
+        )
+        model = torch.load(weights, map_location="cpu", weights_only=False)["model"]
     model.eval().float()
 
     out_dir = os.path.dirname(os.path.abspath(args.out))


### PR DESCRIPTION
## YOLO GGUF converter: fall back to torch.load when ultralytics can't import

While verifying the real on-device YOLO path on Linux (build `libyolo.so` → convert `yolov8n.pt` → `gguf` → run the detector), `scripts/convert.py` failed at `from ultralytics import YOLO` with `RuntimeError: operator torchvision::nms does not exist` — a torchvision↔torch ABI mismatch that raises at **import** (not `ImportError`), so the existing guard didn't catch it and conversion was completely blocked.

The `.pt` checkpoint already pickles the full `DetectionModel`, so this falls back to `torch.load(weights, weights_only=False)["model"]` — recovering the weights with **torch alone**, no ultralytics/torchvision needed. The ultralytics path stays preferred when it imports cleanly.

### Verified end-to-end (Linux)
- Converted `yolov8n.pt` → `yolov8n.gguf` (12.6 MB) via the fallback.
- Built `plugins/plugin-vision/native/yolo.cpp` → `libyolo.so`, staged the gguf, and ran the real TS detector (`verify/run_ts.mjs`, the `yolo-detector.ts → yolo-ffi → libyolo.so → NMS` path) on the classic `bus.jpg`:
  ```
  detections: 5
    person 0.894 | person 0.882 | person 0.867 | bus 0.839 | person 0.426
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)