### PR TITLE
fix(local-inference): wire the live AEC echo-reference on the diarization path (#9583)

### DIFF
--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
@@ -210,4 +210,70 @@ describe("handleLiveDiarizationRoute", () => {
 		expect(handled).toBe(true);
 		expect(res.statusCode).toBe(503);
 	});
+
+	it("accepts agent-playback (far-end) frames for echo cancellation", async () => {
+		// Unlike the mic path, pushing playback needs no model build — it only
+		// decodes + appends to the alignment buffer — so this exercises the full
+		// route end-to-end on a host with no on-device GGUFs.
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [silentFrame(0), silentFrame(1)] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toMatchObject({ ok: true, framesPushed: 2 });
+	});
+
+	it("accepts a reset-only playback request (barge-in / playback stop)", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { reset: true },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toMatchObject({ ok: true, framesPushed: 0 });
+	});
+
+	it("rejects malformed playback frames with 400", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [{ pcm16: "AA==" /* missing fields */ }] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(400);
+		expect((res.json() as { error: string }).error).toMatch(/Malformed/);
+	});
+
+	it("rejects a non-array playback frames field with 400", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: "nope" },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(400);
+	});
 });

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -12,6 +12,13 @@
  *   POST /api/voice/audio-frames        body: { frames: AudioFrameEvent[],
  *                                               flush?: boolean }
  *                                       → { ok, framesReceived, turnsObserved }
+ *   POST /api/voice/playback-frames     body: { frames?: AudioFrameEvent[],
+ *                                               reset?: boolean }
+ *                                       → { ok, framesPushed }
+ *     The agent's own TTS playback (far-end) in the same base64 LE-s16 16 kHz
+ *     mono wire format, streamed in real time so the session's NLMS canceller
+ *     removes the agent's echo before VAD/attribution (#9455/#9583). Send
+ *     `reset: true` when playback stops / on barge-in.
  *   GET  /api/voice/audio-frames/status → LiveDiarizationStatus (device evidence)
  *
  * Auth follows the compat pattern: trusted-loopback OR the compat API token.
@@ -115,6 +122,41 @@ export async function handleLiveDiarizationRoute(
 			framesDropped: status.framesDropped,
 			turnsObserved: status.turnsObserved,
 		});
+		return true;
+	}
+
+	if (url.pathname === "/api/voice/playback-frames" && method === "POST") {
+		if (!ensureCompatApiAuthorized(req, res)) return true;
+		const current = getSession(state);
+		if (!current) {
+			sendJsonError(res, 503, "Runtime not ready");
+			return true;
+		}
+		const body = await readCompatJsonBody(req, res);
+		if (!body) return true;
+		if (body.reset === true) current.resetPlayback();
+		const rawFrames = body.frames;
+		if (rawFrames !== undefined && !Array.isArray(rawFrames)) {
+			sendJsonError(
+				res,
+				400,
+				"Expected { frames?: AudioFrameEvent[], reset?: boolean }",
+			);
+			return true;
+		}
+		const frames = Array.isArray(rawFrames)
+			? rawFrames.filter(isAudioFrameEvent)
+			: [];
+		if (Array.isArray(rawFrames) && frames.length !== rawFrames.length) {
+			sendJsonError(
+				res,
+				400,
+				`Malformed playback frame(s): ${rawFrames.length - frames.length} of ${rawFrames.length} did not match AudioFrameEvent`,
+			);
+			return true;
+		}
+		current.pushPlayback(frames);
+		sendJson(res, 200, { ok: true, framesPushed: frames.length });
 		return true;
 	}
 

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
@@ -1,0 +1,97 @@
+/**
+ * LiveDiarizationSession echo-reference wiring (#9455/#9583).
+ *
+ * Proves the agent-side AEC seam without the fused FFI: the session decodes
+ * agent-playback (far-end) frames into its alignment buffer, and the
+ * `echoReference` read seam (the closure handed to AudioFrameConsumer) returns
+ * the time-aligned far-end slice — zero-filled until playback is pushed, and
+ * reset on barge-in. The model-heavy path (real NLMS cancellation over the
+ * fused VAD/encoder/diarizer) is covered by the host smoke harness.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AudioFrameEvent } from "./audio-frame-consumer.js";
+import {
+	LiveDiarizationSession,
+	type RuntimeEventSink,
+} from "./live-diarization-session.js";
+
+const SAMPLE_RATE = 16_000;
+
+function fakeRuntime(): RuntimeEventSink {
+	return { emitEvent: async () => {} } as unknown as RuntimeEventSink;
+}
+
+/** Build a well-formed playback frame from Float32 [-1,1] samples. */
+function playbackFrame(samples: Float32Array, frameIndex: number): AudioFrameEvent {
+	const buf = Buffer.alloc(samples.length * 2);
+	for (let i = 0; i < samples.length; i += 1) {
+		const clamped = Math.max(-1, Math.min(1, samples[i] ?? 0));
+		buf.writeInt16LE(Math.round(clamped * 32_768) | 0, i * 2);
+	}
+	return {
+		pcm16: buf.toString("base64"),
+		sampleRate: SAMPLE_RATE,
+		channels: 1,
+		samples: samples.length,
+		rms: 0,
+		timestamp: frameIndex * 20,
+		frameIndex,
+	};
+}
+
+/** A deterministic ramp in [-0.5, 0.5]. */
+function ramp(n: number): Float32Array {
+	const out = new Float32Array(n);
+	for (let i = 0; i < n; i += 1) out[i] = (i / n) - 0.5;
+	return out;
+}
+
+describe("LiveDiarizationSession echo reference", () => {
+	it("returns a zero far-end reference before any playback is pushed", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		const ref = session.echoReferenceFrame(320);
+		expect(ref).toHaveLength(320);
+		expect(ref.every((v) => v === 0)).toBe(true);
+	});
+
+	it("aligns the most-recent pushed playback as the far-end (delay 0)", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		const playback = ramp(320);
+		session.pushPlayback([playbackFrame(playback, 0)]);
+
+		const ref = session.echoReferenceFrame(320);
+		expect(ref).toHaveLength(320);
+		// Not zero-filled — the canceller now has a real far-end to cancel.
+		expect(ref.some((v) => v !== 0)).toBe(true);
+		// s16 round-trip is exact to ~1/32768; assert close alignment to the
+		// pushed ramp, not silence.
+		for (let i = 0; i < 320; i += 1) {
+			expect(Math.abs((ref[i] ?? 0) - (playback[i] ?? 0))).toBeLessThan(1e-3);
+		}
+	});
+
+	it("returns the trailing window when asked for fewer samples than pushed", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		const playback = ramp(640);
+		session.pushPlayback([playbackFrame(playback, 0)]);
+
+		const ref = session.echoReferenceFrame(320);
+		expect(ref).toHaveLength(320);
+		// The aligned window is the LAST 320 of the 640 pushed (delay 0).
+		for (let i = 0; i < 320; i += 1) {
+			expect(Math.abs((ref[i] ?? 0) - (playback[320 + i] ?? 0))).toBeLessThan(
+				1e-3,
+			);
+		}
+	});
+
+	it("resetPlayback drops buffered far-end (barge-in / playback stop)", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		session.pushPlayback([playbackFrame(ramp(320), 0)]);
+		expect(session.echoReferenceFrame(320).some((v) => v !== 0)).toBe(true);
+
+		session.resetPlayback();
+		expect(session.echoReferenceFrame(320).every((v) => v === 0)).toBe(true);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -32,9 +32,11 @@ import {
 	AudioFrameConsumer,
 	type AudioFrameConsumerConfig,
 	type AudioFrameEvent,
+	decodeAudioFramePcm,
 	type RuntimeEventSink,
 	type TurnTranscriber,
 } from "./audio-frame-consumer.js";
+import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
 import type {
 	ElizaInferenceContextHandle,
 	ElizaInferenceFfi,
@@ -123,6 +125,21 @@ export interface LiveDiarizationTurnSummary {
 
 const MAX_RECENT_TURNS = 20;
 
+const AUDIO_FRAME_SAMPLE_RATE = 16_000;
+
+/**
+ * Playback→mic transport delay used to time-align the far-end echo reference,
+ * in samples @ 16 kHz. Device-tunable via `ELIZA_VOICE_ECHO_DELAY_MS`; the
+ * on-device calibration (`estimateEchoDelaySamples`, #9586) is the device-side
+ * follow-up. Default 0 — the canceller aligns to the most-recently-rendered
+ * playback and the NLMS filter adapts the residual.
+ */
+function resolveEchoDelaySamples(): number {
+	const ms = Number(process.env.ELIZA_VOICE_ECHO_DELAY_MS);
+	if (!Number.isFinite(ms) || ms <= 0) return 0;
+	return Math.round((ms / 1000) * AUDIO_FRAME_SAMPLE_RATE);
+}
+
 /**
  * Owns the single live diarization consumer for the agent process. Built
  * lazily on first frame batch so it does not load voice models at boot.
@@ -142,6 +159,15 @@ export class LiveDiarizationSession {
 	private buildError: string | null = null;
 	/** True once the fused ASR region is mmap-acquired for per-turn transcribe. */
 	private asrRegionAcquired = false;
+	/**
+	 * Far-end (agent TTS playback) alignment buffer for echo cancellation
+	 * (#9583/#9455). Fed by {@link pushPlayback}; read per mic frame via the
+	 * consumer's `echoReference` seam. Inert (zero far-end ⇒ NLMS passthrough)
+	 * until the device streams playback, so wiring it never regresses the
+	 * no-playback case.
+	 */
+	private readonly echoBuffer = new EchoReferenceBuffer();
+	private readonly echoDelaySamples = resolveEchoDelaySamples();
 
 	constructor(private readonly runtime: RuntimeEventSink) {}
 
@@ -224,6 +250,12 @@ export class LiveDiarizationSession {
 				vad: detector,
 				pipeline,
 				runtime: this.runtime,
+				// Cancel the agent's own TTS playback before VAD/attribution so the
+				// live path never transcribes its echo (#9455/#9583). The reference
+				// is zero-filled (⇒ NLMS passthrough) until the device streams
+				// playback via pushPlayback.
+				echoReference: (_timestampMs, samples) =>
+					this.echoReferenceFrame(samples),
 				...(transcribe ? { transcribe } : {}),
 			},
 			config,
@@ -276,6 +308,36 @@ export class LiveDiarizationSession {
 		};
 		this.recentTurns.push(summary);
 		if (this.recentTurns.length > MAX_RECENT_TURNS) this.recentTurns.shift();
+	}
+
+	/**
+	 * The far-end (agent TTS playback) reference aligned to a mic frame of
+	 * `samples` samples — the consumer's `echoReference` seam (#9455/#9583).
+	 * Reads the alignment buffer at the configured playback→mic delay; the slice
+	 * is zero-filled (⇒ NLMS passthrough) until the device streams playback.
+	 * Public so the wiring is unit-testable without the fused FFI.
+	 */
+	echoReferenceFrame(samples: number): Float32Array {
+		return this.echoBuffer.referenceFor(samples, this.echoDelaySamples);
+	}
+
+	/**
+	 * Feed a batch of agent-playback (far-end) frames for echo cancellation. The
+	 * device captures the agent's TTS output in the SAME base64 LE-s16 16 kHz
+	 * mono wire format as the mic and POSTs it in real time as it renders; we
+	 * decode + append to the alignment buffer. The device MUST also call
+	 * {@link resetPlayback} when playback stops (or on barge-in) so the canceller
+	 * never aligns a later mic frame to stale, no-longer-playing audio.
+	 */
+	pushPlayback(frames: AudioFrameEvent[]): void {
+		for (const frame of frames) {
+			this.echoBuffer.push(decodeAudioFramePcm(frame));
+		}
+	}
+
+	/** Drop buffered far-end playback (playback stopped / barge-in). */
+	resetPlayback(): void {
+		this.echoBuffer.reset();
 	}
 
 	/** Feed a batch of WebView-captured frames; resolves once VAD has processed them. */


### PR DESCRIPTION
## What

The fused live diarization path (`LiveDiarizationSession`) constructed its `AudioFrameConsumer` **without** an `echoReference` provider, so the already-landed AEC primitives never engaged on-device:

- `NlmsEchoCanceller` (#9575)
- `EchoReferenceBuffer` alignment (#9596)
- `estimateEchoDelaySamples` delay primitive (#9586)
- the `EchoReferenceProvider` seam in `audio-frame-consumer.ts`

Result: on the live path the agent could still transcribe its own TTS playback (the exact failure #9583 tracks).

## Change (agent-side seam)

- `LiveDiarizationSession` now owns an `EchoReferenceBuffer` and passes the consumer an `echoReference` closure (`echoReferenceFrame`) that reads the time-aligned far-end slice at a device-tunable delay (`ELIZA_VOICE_ECHO_DELAY_MS`). The slice is zero-filled until playback is pushed, so wiring it **never regresses the no-playback case** (zero far-end ⇒ NLMS passthrough).
- New `POST /api/voice/playback-frames` ingests the agent's own TTS playback (far-end) in the **same** base64 LE-s16 16 kHz mono wire format as the mic path, with `reset: true` for playback-stop / barge-in.

## Tests

No fused FFI required (decode + buffer only):

- **Session seam** (`live-diarization-session.echo.test.ts`): zero reference before playback; aligned to pushed far-end; trailing-window slice; reset drops the buffer.
- **Route** (`live-diarization-route.test.ts`): accepts/validates playback frames + reset; rejects malformed / non-array.

`15/15` pass; `tsc --noEmit` clean for the package.

## Remaining (hardware-gated, out of scope here)

- The **device-side producer**: tap the agent's rendered TTS PCM and stream it to `POST /api/voice/playback-frames` in real time (symmetric to the proven mic-capture path).
- **On-device delay calibration** via `estimateEchoDelaySamples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)