### PR TITLE
feat(plugin-embeddings): add first-party registry entry (#9567)

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2152,6 +2152,79 @@
       "subtype": "other"
     },
     {
+      "id": "embeddings",
+      "name": "Embeddings",
+      "description": "Provider-agnostic (bring-your-own) TEXT_EMBEDDING provider. Point EMBEDDING_BASE_URL / EMBEDDING_API_KEY at any OpenAI-compatible /embeddings endpoint (a personal OpenAI key, Eliza Cloud, Voyage, Together, or a local TEI/Infinity/vLLM/LM Studio server) to get real memory/RAG embeddings independently of the chat brain. Registers ONLY the embedding slot — no text/image/audio handlers.",
+      "npmName": "@elizaos/plugin-embeddings",
+      "version": "2.0.0-beta.0",
+      "source": "bundled",
+      "tags": ["ai-provider", "llm", "embedding", "embeddings"],
+      "config": {
+        "EMBEDDING_BASE_URL": {
+          "type": "url",
+          "required": false,
+          "sensitive": false,
+          "label": "Embedding Base Url",
+          "help": "Base URL of an OpenAI-compatible /embeddings endpoint (e.g. https://api.openai.com/v1, an Eliza Cloud URL, a Voyage proxy, or a local TEI/Infinity/vLLM server). Setting this (or the API key) activates the plugin.",
+          "placeholder": "e.g., https://api.openai.com/v1",
+          "advanced": false
+        },
+        "EMBEDDING_API_KEY": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "Embedding Api Key",
+          "help": "Bearer token for the embedding endpoint. Setting this (or the base URL) activates the plugin. Omit for local servers that need no auth.",
+          "advanced": false
+        },
+        "EMBEDDING_MODEL": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "default": "text-embedding-3-small",
+          "label": "Embedding Model",
+          "help": "Embedding model identifier sent as the request `model` field.",
+          "placeholder": "e.g., text-embedding-3-small",
+          "advanced": false
+        },
+        "EMBEDDING_DIMENSIONS": {
+          "type": "number",
+          "required": false,
+          "sensitive": false,
+          "default": "1536",
+          "label": "Embedding Dimensions",
+          "help": "Vector width. Must be one of 384, 512, 768, 1024, 1536, 2048, 3072. Keep this stable for the lifetime of a database — changing it invalidates stored vectors.",
+          "advanced": false
+        },
+        "EMBEDDING_BROWSER_URL": {
+          "type": "url",
+          "required": false,
+          "sensitive": false,
+          "label": "Embedding Browser Url",
+          "help": "Browser-only server-side proxy URL for /embeddings. In a browser build the Authorization header is never sent unless this is set, so the API key stays server-side.",
+          "advanced": true
+        }
+      },
+      "render": {
+        "visible": true,
+        "pinTo": [],
+        "style": "card",
+        "icon": "Boxes",
+        "group": "ai-provider",
+        "groupOrder": 0,
+        "actions": ["enable", "configure"]
+      },
+      "resources": {
+        "homepage": "https://github.com/elizaOS/eliza/tree/HEAD/plugins/plugin-embeddings",
+        "repository": "https://github.com/elizaOS/eliza",
+        "setupGuideUrl": "https://docs.eliza.ai/plugin-setup-guide#embeddings"
+      },
+      "dependsOn": [],
+      "channels": [],
+      "kind": "plugin",
+      "subtype": "ai-provider"
+    },
+    {
       "id": "evm",
       "name": "Evm",
       "description": "This plugin enables interaction with EVM-compatible chains, supporting token transfers, cross-chain bridging, and swaps via LiFi integration.",

--- a/plugins/plugin-embeddings/registry-entry.json
+++ b/plugins/plugin-embeddings/registry-entry.json
@@ -1,0 +1,72 @@
+{
+  "id": "embeddings",
+  "name": "Embeddings",
+  "description": "Provider-agnostic (bring-your-own) TEXT_EMBEDDING provider. Point EMBEDDING_BASE_URL / EMBEDDING_API_KEY at any OpenAI-compatible /embeddings endpoint (a personal OpenAI key, Eliza Cloud, Voyage, Together, or a local TEI/Infinity/vLLM/LM Studio server) to get real memory/RAG embeddings independently of the chat brain. Registers ONLY the embedding slot — no text/image/audio handlers.",
+  "npmName": "@elizaos/plugin-embeddings",
+  "version": "2.0.0-beta.0",
+  "source": "bundled",
+  "tags": ["ai-provider", "llm", "embedding", "embeddings"],
+  "config": {
+    "EMBEDDING_BASE_URL": {
+      "type": "url",
+      "required": false,
+      "sensitive": false,
+      "label": "Embedding Base Url",
+      "help": "Base URL of an OpenAI-compatible /embeddings endpoint (e.g. https://api.openai.com/v1, an Eliza Cloud URL, a Voyage proxy, or a local TEI/Infinity/vLLM server). Setting this (or the API key) activates the plugin.",
+      "placeholder": "e.g., https://api.openai.com/v1",
+      "advanced": false
+    },
+    "EMBEDDING_API_KEY": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "Embedding Api Key",
+      "help": "Bearer token for the embedding endpoint. Setting this (or the base URL) activates the plugin. Omit for local servers that need no auth.",
+      "advanced": false
+    },
+    "EMBEDDING_MODEL": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "default": "text-embedding-3-small",
+      "label": "Embedding Model",
+      "help": "Embedding model identifier sent as the request `model` field.",
+      "placeholder": "e.g., text-embedding-3-small",
+      "advanced": false
+    },
+    "EMBEDDING_DIMENSIONS": {
+      "type": "number",
+      "required": false,
+      "sensitive": false,
+      "default": "1536",
+      "label": "Embedding Dimensions",
+      "help": "Vector width. Must be one of 384, 512, 768, 1024, 1536, 2048, 3072. Keep this stable for the lifetime of a database — changing it invalidates stored vectors.",
+      "advanced": false
+    },
+    "EMBEDDING_BROWSER_URL": {
+      "type": "url",
+      "required": false,
+      "sensitive": false,
+      "label": "Embedding Browser Url",
+      "help": "Browser-only server-side proxy URL for /embeddings. In a browser build the Authorization header is never sent unless this is set, so the API key stays server-side.",
+      "advanced": true
+    }
+  },
+  "render": {
+    "visible": true,
+    "pinTo": [],
+    "style": "card",
+    "icon": "Boxes",
+    "group": "ai-provider",
+    "groupOrder": 0,
+    "actions": ["enable", "configure"]
+  },
+  "resources": {
+    "homepage": "https://github.com/elizaOS/eliza/tree/HEAD/plugins/plugin-embeddings",
+    "repository": "https://github.com/elizaOS/eliza",
+    "setupGuideUrl": "https://docs.eliza.ai/plugin-setup-guide#embeddings"
+  },
+  "dependsOn": [],
+  "kind": "plugin",
+  "subtype": "ai-provider"
+}


### PR DESCRIPTION
## What

Adds the **registry entry** for `@elizaos/plugin-embeddings` — the last unshipped deliverable from issue #9567.

[PR #9572](https://github.com/elizaOS/eliza/pull/9572) landed the standalone provider-agnostic `TEXT_EMBEDDING` plugin (raw `fetch(${EMBEDDING_BASE_URL}/embeddings)`, embedding-only registration, throws-never-zero, full unit tests) but did **not** add a `registry-entry.json`. As a result the plugin was absent from the curated first-party registry (`packages/registry/src/first-party/generated.json`) and therefore invisible / unconfigurable in the dashboard plugin catalog — unlike every peer ai-provider (`openai`, `anthropic`, `groq`, `elizacloud`), each of which ships one.

The issue spec explicitly listed *"Add a registry entry + a unit test"*. The unit test shipped in #9572; this PR closes out the registry entry.

## Changes

- **`plugins/plugin-embeddings/registry-entry.json`** (new) — `kind: plugin`, `subtype: ai-provider`, exposing the five provider-neutral config fields (`EMBEDDING_BASE_URL`, `EMBEDDING_API_KEY`, `EMBEDDING_MODEL` default `text-embedding-3-small`, `EMBEDDING_DIMENSIONS` default `1536`, `EMBEDDING_BROWSER_URL`), mirroring the shape/labels/help of the `openai`/`groq`/`anthropic` entries and the descriptions already in `package.json#agentConfig.pluginParameters`.
- **`packages/registry/src/first-party/generated.json`** — regenerated via the first-party generator. The embeddings entry declares no `curatedApp` and no `channels`, so `curated-app-definitions.json` and `channel-plugin-map.json` are untouched; **only** `generated.json` changes (+73 lines).

Purely additive: the registry entry controls catalog **visibility/config UI**, not auto-enable. The plugin still load-gates on `EMBEDDING_BASE_URL` / `EMBEDDING_API_KEY` via `auto-enable.ts`, so existing deployments are unaffected.

## Verification

```
# drift gate (the one CI runs)
$ bun run --cwd packages/registry generate:first-party:check
[registry/generate] generated artifacts are up to date.

# registry schema/loader tests
$ bun run --cwd packages/registry test
Test Files  4 passed (4) | Tests  23 passed (23)

# plugin unit tests (unchanged, sanity)
$ bun run --cwd plugins/plugin-embeddings test
Test Files  3 passed (3) | Tests  27 passed (27)

# biome
$ bunx @biomejs/biome check plugins/plugin-embeddings/registry-entry.json packages/registry/src/first-party/generated.json
Checked 2 files. No fixes applied.

# loader surfaces the entry
id=embeddings kind=plugin subtype=ai-provider npmName=@elizaos/plugin-embeddings
configKeys=EMBEDDING_BASE_URL,EMBEDDING_API_KEY,EMBEDDING_MODEL,EMBEDDING_DIMENSIONS,EMBEDDING_BROWSER_URL
```

Refs #9567. Follow-up to #9572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)