### PR TITLE
Add plugin-raven-verify to third-party registry

### DIFF
--- a/packages/registry/entries/third-party/plugin-raven-verify.json
+++ b/packages/registry/entries/third-party/plugin-raven-verify.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-raven-verify",
+  "repository": "github:billybotticelli4u-collab/plugin-raven-verify",
+  "kind": "plugin",
+  "description": "Pre-action Solana token verification via Raven — signed, scope-bounded on-chain evidence receipts (checks performed, checks NOT performed, coverage gaps, ed25519 signature). Reports evidence, not a safe/unsafe verdict.",
+  "homepage": "https://ravenattest.com",
+  "version": "0.1.0",
+  "tags": ["solana", "token", "verification", "attestation", "raven", "signed-receipt"]
+}


### PR DESCRIPTION
Adds a third-party registry entry for `plugin-raven-verify` (live on npm, v0.1.0): a thin ElizaOS client exposing a `VERIFY_TOKEN` action that fetches signed, scope-bounded on-chain evidence receipts for a Solana mint via the Raven hosted verifier. It reports evidence (checks performed/not performed, coverage gaps, ed25519 signature) — never a safe/unsafe verdict or trading advice.