### PR TITLE
fix(computeruse): add Wayland portal screenshot capture

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3839,6 +3839,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
+        "@elizaos/plugin-scheduling": "workspace:*",
         "@types/node": "^25.6.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",

--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -21,7 +21,10 @@ async function makeRuntimeWithService(tasks: Task[]): Promise<{
   const baseRuntime = {
     agentId: AGENT_ID,
     getTasks: vi.fn(
-      async (params: { tags?: string[]; agentIds: UUID[] }): Promise<Task[]> => {
+      async (params: {
+        tags?: string[];
+        agentIds: UUID[];
+      }): Promise<Task[]> => {
         if (!params.agentIds.includes(AGENT_ID)) return [];
         const wanted = new Set(params.tags ?? []);
         return tasks.filter((task) =>
@@ -30,9 +33,7 @@ async function makeRuntimeWithService(tasks: Task[]): Promise<{
       },
     ),
   } as unknown as IAgentRuntime;
-  const service = (await ApprovalService.start(
-    baseRuntime,
-  )) as ApprovalService;
+  const service = (await ApprovalService.start(baseRuntime)) as ApprovalService;
   const runtime = {
     getService: (t: string) => (t === ServiceType.APPROVAL ? service : null),
   };

--- a/packages/agent/src/api/approval-routes.ts
+++ b/packages/agent/src/api/approval-routes.ts
@@ -87,7 +87,7 @@ export function approvalTaskToPendingAction(
 }
 
 export async function handleApprovalRoute(
-  req: http.IncomingMessage,
+  _req: http.IncomingMessage,
   res: http.ServerResponse,
   pathname: string,
   method: string,

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   CAPABILITY_ROUTER_SERVICE_TYPE,
   CapabilityError,
   type ElizaCapabilityRouter,
+  type EventPayload,
   type IAgentRuntime,
   type Plugin,
   type PluginCallAppBridgeResult,
@@ -23,7 +24,6 @@ import {
   type RemotePluginModuleManifest,
   type Service,
   type UUID,
-  type EventPayload,
 } from "@elizaos/core";
 import { build as esbuild } from "esbuild";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
@@ -40,9 +40,7 @@ export function deploymentIdFor(app: {
   // deploy-status route (the real-staging deploy bug behind #9300).
   last_deployed_at: Date | string | null;
 }): string {
-  const ts = app.last_deployed_at
-    ? new Date(app.last_deployed_at).toISOString()
-    : "0";
+  const ts = app.last_deployed_at ? new Date(app.last_deployed_at).toISOString() : "0";
   return `${app.id}:${ts}`;
 }
 

--- a/packages/cloud-shared/src/lib/services/app-image-resolver.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-resolver.ts
@@ -70,10 +70,7 @@ export function makePrebuiltImageMapResolver(
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     entries = Object.entries(parsed).filter(
       (e): e is [string, string] =>
-        typeof e[0] === "string" &&
-        e[0].length > 0 &&
-        typeof e[1] === "string" &&
-        e[1].length > 0,
+        typeof e[0] === "string" && e[0].length > 0 && typeof e[1] === "string" && e[1].length > 0,
     );
   } catch {
     logger.warn(
@@ -115,9 +112,7 @@ export function composeImageResolvers(
 }
 
 /** A `resolveImage` that builds + pushes the app image from its repo. */
-export function makeBuildFromRepoResolver(
-  deps: BuildFromRepoResolverDeps,
-): AppImageResolver {
+export function makeBuildFromRepoResolver(deps: BuildFromRepoResolverDeps): AppImageResolver {
   return async (app) => {
     const metaRepo = typeof app.metadata?.repoUrl === "string" ? app.metadata.repoUrl : undefined;
     const repo = app.repoUrl ?? metaRepo;

--- a/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
@@ -9,12 +9,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listPendingActionsMock, publishHomeAttentionSpy, dispatchChatPrefillSpy } =
-  vi.hoisted(() => ({
-    listPendingActionsMock: vi.fn(),
-    publishHomeAttentionSpy: vi.fn(),
-    dispatchChatPrefillSpy: vi.fn(),
-  }));
+const {
+  listPendingActionsMock,
+  publishHomeAttentionSpy,
+  dispatchChatPrefillSpy,
+} = vi.hoisted(() => ({
+  listPendingActionsMock: vi.fn(),
+  publishHomeAttentionSpy: vi.fn(),
+  dispatchChatPrefillSpy: vi.fn(),
+}));
 
 // The widget reads the canonical surface through the typed client; mock only
 // the one method it calls.
@@ -42,9 +45,11 @@ import type { WidgetProps } from "../../../widgets/types";
 import { NeedsAttentionWidget, STALE_PENDING_AGE_MS } from "./needs-attention";
 
 function pending(
-  patch: { id: string; title?: string; ageMs?: number } & Partial<
-    PendingUserAction
-  >,
+  patch: {
+    id: string;
+    title?: string;
+    ageMs?: number;
+  } & Partial<PendingUserAction>,
 ): PendingUserAction {
   return {
     id: patch.id as PendingUserAction["id"],
@@ -93,7 +98,9 @@ describe("NeedsAttentionWidget (#9449)", () => {
     expect(widget.textContent).toContain("Send the contract");
     expect(widget.textContent).not.toContain("Confirm the deploy");
     // The full meaning lives in the aria-label since visible text is minimal.
-    expect(widget.getAttribute("aria-label")).toMatch(/2 actions need your response/i);
+    expect(widget.getAttribute("aria-label")).toMatch(
+      /2 actions need your response/i,
+    );
     expect(widget.getAttribute("aria-label")).toMatch(/Send the contract/);
   });
 
@@ -125,7 +132,11 @@ describe("NeedsAttentionWidget (#9449)", () => {
 
   it("escalates the weight once the oldest decision goes stale", async () => {
     mockPending([
-      pending({ id: "a-1", title: "Old decision", ageMs: STALE_PENDING_AGE_MS + 60_000 }),
+      pending({
+        id: "a-1",
+        title: "Old decision",
+        ageMs: STALE_PENDING_AGE_MS + 60_000,
+      }),
     ]);
 
     render(<NeedsAttentionWidget {...fetchProps} />);
@@ -143,7 +154,9 @@ describe("NeedsAttentionWidget (#9449)", () => {
   });
 
   it("routes back to the handler by prefilling chat with an approval on click", async () => {
-    mockPending([pending({ id: "a-1", title: "Send the contract", ageMs: 5_000 })]);
+    mockPending([
+      pending({ id: "a-1", title: "Send the contract", ageMs: 5_000 }),
+    ]);
 
     render(<NeedsAttentionWidget {...fetchProps} />);
     await waitFor(() => {

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -98,7 +98,9 @@ export function NeedsAttentionWidget(_props: Partial<WidgetProps>) {
   const weight = useMemo(() => {
     if (top == null) return null;
     const stale = Date.now() - top.createdAt >= STALE_PENDING_AGE_MS;
-    return stale ? HOME_SIGNAL_WEIGHTS.escalation : HOME_SIGNAL_WEIGHTS.approval;
+    return stale
+      ? HOME_SIGNAL_WEIGHTS.escalation
+      : HOME_SIGNAL_WEIGHTS.approval;
   }, [top]);
   usePublishHomeAttention(NEEDS_ATTENTION_WIDGET_KEY, weight);
 

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -444,7 +444,9 @@ function buildSegmentedUserContentFromSegments(
 function buildSegmentedUserContentForMessages(
   params: GenerateTextParamsWithProviderOptions
 ): UserContent | undefined {
-  const dynamicSegments = (params.promptSegments ?? []).filter((segment: PromptSegment) => !segment.stable);
+  const dynamicSegments = (params.promptSegments ?? []).filter(
+    (segment: PromptSegment) => !segment.stable
+  );
   if (dynamicSegments.length === 0 && (params.attachments?.length ?? 0) === 0) {
     return undefined;
   }

--- a/plugins/plugin-capacitor-bridge/tsconfig.json
+++ b/plugins/plugin-capacitor-bridge/tsconfig.json
@@ -67,6 +67,8 @@
 			],
 			"@elizaos/plugin-browser": ["../../plugins/plugin-browser/src/index.ts"],
 			"@elizaos/plugin-browser/*": ["../../plugins/plugin-browser/src/*"],
+			"@elizaos/plugin-capacitor-bridge": ["./src/index.ts"],
+			"@elizaos/plugin-capacitor-bridge/*": ["./src/*"],
 			"@elizaos/plugin-commands": [
 				"../../plugins/plugin-commands/src/index.ts"
 			],

--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -84,6 +84,7 @@ src/
     clipboard.ts             OS clipboard read/write
     a11y.ts                  Accessibility tree query
     coords.ts                localToGlobal coordinate translation
+    wayland-portal.ts        xdg-desktop-portal screenshot sidecar for Wayland
     capabilities.ts          detectPlatformCapabilities
     desktop.ts               High-level desktop helpers
     helpers.ts               Shared platform utilities

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -84,6 +84,7 @@ src/
     clipboard.ts             OS clipboard read/write
     a11y.ts                  Accessibility tree query
     coords.ts                localToGlobal coordinate translation
+    wayland-portal.ts        xdg-desktop-portal screenshot sidecar for Wayland
     capabilities.ts          detectPlatformCapabilities
     desktop.ts               High-level desktop helpers
     helpers.ts               Shared platform utilities

--- a/plugins/plugin-computeruse/docs/MULTI_MONITOR.md
+++ b/plugins/plugin-computeruse/docs/MULTI_MONITOR.md
@@ -119,5 +119,5 @@ manual rig:
 | `screencapture -D 2`                  | macOS   | dual display rig, capture each independently         |
 | Retina backing-store scale            | macOS   | scaleFactor=2, capture is 2× logical bounds          |
 | WGC / DXGI vs PerMonitorV2 DPI        | Windows | per-monitor DPI mix, click lands on correct pixel    |
-| Wayland portal capture                | Linux   | GNOME 45+ / KDE 6 — needs a portal-based sidecar     |
+| Wayland portal capture                | Linux   | GNOME 45+ / KDE 6 — `platform/wayland-portal.ts` captures through xdg-desktop-portal; per-display crop still depends on compositor support |
 | Hyprland / Sway parser                | Linux   | run `hyprctl monitors -j` against live compositor    |

--- a/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
+++ b/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
@@ -87,7 +87,7 @@ constant there (see #9165).
 |----|---------|-------|-----|-------|
 | **Windows** | PowerShell / nutjs | nutjs (SendInput) or legacy PowerShell | **`Windows.Media.Ocr`** (WinRT via `powershell` 5.1, **not** pwsh 7) — 0 tokens | **Input needs an interactive desktop** (see gotcha). Read/clipboard/OCR work headless. |
 | **macOS** | `screencapture -D` (retina 2× backing store) | nutjs or `cliclick` | Apple Vision | Needs Accessibility + Screen Recording grants; headful. |
-| **Linux** | X11 `import`/`scrot` (Xvfb headful) | nutjs or `xdotool` | docTR / PaddleOCR | Wayland lacks AT-SPI → OCR-only grounding; clipboard needs `wl-clipboard`/`xclip`. |
+| **Linux** | X11 `import`/`scrot` (Xvfb headful); Wayland `xdg-desktop-portal` screenshot sidecar | nutjs or `xdotool` on X11 | docTR / PaddleOCR | Wayland capture uses `python3` + `gdbus`; Wayland still lacks AT-SPI in many compositors, so grounding can be OCR-only. Clipboard needs `wl-clipboard`/`xclip`. |
 | **AOSP** | MediaProjection | privileged input bridge | Paddle-Lite | Emulator + system-app path. See `AOSP_SYSTEM_APP.md`. |
 
 ## ⚠️ Windows non-interactive-session gotcha (verified 2026-06-23)

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -14,9 +14,9 @@
  *   - macOS uses `screencapture -D <displayIndex+1>` to pick a specific
  *     display (1-indexed). For ScreenCaptureKit follow-up, replace this
  *     dispatch with the Swift sidecar.
- *   - Linux/X11 uses `import` (ImageMagick) or `scrot` cropped to the
- *     display's xrandr rect. Wayland-only environments need a portal-based
- *     sidecar — out of scope for v1.
+ *   - Linux/Wayland prefers the xdg-desktop-portal screenshot sidecar. X11
+ *     uses `import` (ImageMagick) or `scrot` cropped to the display's xrandr
+ *     rect.
  *   - Windows uses PowerShell + System.Drawing to crop the virtual desktop
  *     to the screen bounds.
  *
@@ -38,6 +38,11 @@ import {
   createPermissionDeniedError,
   isPermissionDeniedError,
 } from "./permissions.js";
+import {
+  canUseWaylandScreenshotPortal,
+  captureWaylandPortalScreenshot,
+  isWaylandSession,
+} from "./wayland-portal.js";
 
 const SCREEN_RECORDING_OPERATION_MESSAGE =
   "macOS Screen Recording permission is required for screenshots. Grant access in System Settings > Privacy & Security > Screen Recording, then retry.";
@@ -192,6 +197,7 @@ function captureRegionDarwin(tmpFile: string, region: ScreenRegion): void {
 
 function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
   const [x, y, w, h] = display.bounds;
+  if (tryCaptureWaylandPortal(tmpFile)) return;
   if (commandExists("import")) {
     runCommandBuffer(
       "import",
@@ -210,7 +216,9 @@ function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
     return;
   }
   throw new Error(
-    "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
+    isWaylandSession()
+      ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, or gnome-screenshot for X11 fallback."
+      : "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
   );
 }
 
@@ -242,6 +250,17 @@ function captureRegionLinux(tmpFile: string, region: ScreenRegion): void {
     return;
   }
   throw new Error("No screenshot tool available for region capture.");
+}
+
+function tryCaptureWaylandPortal(tmpFile: string): boolean {
+  if (!canUseWaylandScreenshotPortal()) return false;
+  try {
+    captureWaylandPortalScreenshot(tmpFile);
+    return true;
+  } catch (error) {
+    if (isPermissionDeniedError(error)) throw error;
+    return false;
+  }
 }
 
 // ── Windows ─────────────────────────────────────────────────────────────────

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -21,6 +21,11 @@ import {
   isPermissionDeniedError,
 } from "./permissions.js";
 import { tagScreenshotError } from "./screenshot-errors.js";
+import {
+  canUseWaylandScreenshotPortal,
+  captureWaylandPortalScreenshot,
+  isWaylandSession,
+} from "./wayland-portal.js";
 
 const SCREEN_RECORDING_OPERATION_MESSAGE =
   "macOS Screen Recording permission is required for screenshots. Grant access in System Settings > Privacy & Security > Screen Recording, then retry.";
@@ -115,6 +120,8 @@ function captureDarwin(tmpFile: string, region?: ScreenRegion): void {
 // ── Linux ───────────────────────────────────────────────────────────────────
 
 function captureLinux(tmpFile: string, region?: ScreenRegion): void {
+  if (!region && tryCaptureWaylandPortal(tmpFile)) return;
+
   // Try tools in preference order
   if (commandExists("import")) {
     if (region) {
@@ -138,8 +145,21 @@ function captureLinux(tmpFile: string, region?: ScreenRegion): void {
     runCommandBuffer("gnome-screenshot", ["-f", tmpFile], 10000);
   } else {
     throw new Error(
-      "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
+      isWaylandSession()
+        ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, or gnome-screenshot for X11 fallback."
+        : "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
     );
+  }
+}
+
+function tryCaptureWaylandPortal(tmpFile: string): boolean {
+  if (!canUseWaylandScreenshotPortal()) return false;
+  try {
+    captureWaylandPortalScreenshot(tmpFile);
+    return true;
+  } catch (error) {
+    if (isPermissionDeniedError(error)) throw error;
+    return false;
   }
 }
 

--- a/plugins/plugin-computeruse/src/platform/wayland-portal.test.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWaylandSession,
+  parsePortalRequestHandle,
+  parsePortalScreenshotResponse,
+  portalFileUriToPath,
+  WAYLAND_PORTAL_DBUS_TARGET,
+} from "./wayland-portal.js";
+
+describe("wayland screenshot portal helpers", () => {
+  it("detects Wayland sessions from either standard environment hint", () => {
+    expect(isWaylandSession({ XDG_SESSION_TYPE: "wayland" })).toBe(true);
+    expect(isWaylandSession({ WAYLAND_DISPLAY: "wayland-0" })).toBe(true);
+    expect(
+      isWaylandSession({ XDG_SESSION_TYPE: "x11", WAYLAND_DISPLAY: "" }),
+    ).toBe(false);
+  });
+
+  it("declares the standard xdg-desktop-portal screenshot target", () => {
+    expect(WAYLAND_PORTAL_DBUS_TARGET).toEqual({
+      busName: "org.freedesktop.portal.Desktop",
+      objectPath: "/org/freedesktop/portal/desktop",
+      method: "org.freedesktop.portal.Screenshot.Screenshot",
+    });
+  });
+
+  it("parses the gdbus request handle returned by Screenshot", () => {
+    expect(
+      parsePortalRequestHandle(
+        "(objectpath '/org/freedesktop/portal/desktop/request/1_123/eliza_abc',)",
+      ),
+    ).toBe("/org/freedesktop/portal/desktop/request/1_123/eliza_abc");
+    expect(parsePortalRequestHandle("()")).toBeNull();
+  });
+
+  it("parses a successful screenshot response signal", () => {
+    const handle = "/org/freedesktop/portal/desktop/request/1_123/eliza_abc";
+    const output = `
+${handle}: org.freedesktop.portal.Request::Response (uint32 0, {'uri': <'file:///run/user/501/doc/shot.png'>})
+`;
+    expect(parsePortalScreenshotResponse(output, handle)).toEqual({
+      responseCode: 0,
+      uri: "file:///run/user/501/doc/shot.png",
+    });
+  });
+
+  it("parses a denied screenshot response without a uri", () => {
+    expect(
+      parsePortalScreenshotResponse(
+        "org.freedesktop.portal.Request::Response (uint32 1, {})",
+      ),
+    ).toEqual({ responseCode: 1 });
+  });
+
+  it("converts portal file uris to local paths", () => {
+    expect(portalFileUriToPath("file:///tmp/wayland%20shot.png")).toBe(
+      "/tmp/wayland shot.png",
+    );
+    expect(() => portalFileUriToPath("document://portal/shot.png")).toThrow(
+      /non-file URI/i,
+    );
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/wayland-portal.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.ts
@@ -1,0 +1,235 @@
+import { execFileSync } from "node:child_process";
+import { copyFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { commandExists } from "./helpers.js";
+import { createPermissionDeniedError } from "./permissions.js";
+
+const PORTAL_BUS_NAME = "org.freedesktop.portal.Desktop";
+const PORTAL_OBJECT_PATH = "/org/freedesktop/portal/desktop";
+const PORTAL_SCREENSHOT_METHOD = "org.freedesktop.portal.Screenshot.Screenshot";
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const WAYLAND_PORTAL_HELPER = String.raw`
+import os
+import re
+import select
+import subprocess
+import sys
+import time
+import uuid
+
+bus_name = "org.freedesktop.portal.Desktop"
+object_path = "/org/freedesktop/portal/desktop"
+method = "org.freedesktop.portal.Screenshot.Screenshot"
+timeout_ms = int(os.environ.get("ELIZA_WAYLAND_PORTAL_TIMEOUT_MS", "15000"))
+interactive = os.environ.get("ELIZA_WAYLAND_PORTAL_INTERACTIVE", "0") == "1"
+token = "eliza_" + str(os.getpid()) + "_" + uuid.uuid4().hex
+options = "{'handle_token': <'" + token + "'>, 'interactive': <" + ("true" if interactive else "false") + ">}"
+
+monitor = subprocess.Popen(
+    ["gdbus", "monitor", "--session", "--dest", bus_name],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    bufsize=1,
+)
+
+try:
+    time.sleep(0.05)
+    call = subprocess.run(
+        [
+            "gdbus",
+            "call",
+            "--session",
+            "--dest",
+            bus_name,
+            "--object-path",
+            object_path,
+            "--method",
+            method,
+            "",
+            options,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=max(1, timeout_ms / 1000),
+    )
+    if call.returncode != 0:
+        print(call.stderr.strip() or call.stdout.strip() or "portal screenshot call failed", file=sys.stderr)
+        sys.exit(2)
+
+    match = re.search(r"objectpath '([^']+)'", call.stdout)
+    if not match:
+        print("portal screenshot call did not return a request handle: " + call.stdout.strip(), file=sys.stderr)
+        sys.exit(3)
+
+    handle = match.group(1)
+    deadline = time.monotonic() + (timeout_ms / 1000)
+    buffer = ""
+
+    while time.monotonic() < deadline:
+        remaining = max(0, min(0.5, deadline - time.monotonic()))
+        ready, _, _ = select.select([monitor.stdout], [], [], remaining)
+        if not ready:
+            continue
+        line = monitor.stdout.readline()
+        if not line:
+            continue
+        buffer += line
+        if len(buffer) > 65536:
+            buffer = buffer[-65536:]
+        if handle not in buffer:
+            continue
+        tail = buffer[buffer.rfind(handle):]
+        response = re.search(r"uint32\s+(\d+)", tail)
+        if not response:
+            continue
+        response_code = int(response.group(1))
+        if response_code != 0:
+            print("portal screenshot request was denied or cancelled (response=%d)" % response_code, file=sys.stderr)
+            sys.exit(10 + response_code)
+        uri = re.search(r"['\"]uri['\"]\s*:\s*<['\"]([^'\"]+)['\"]>", tail)
+        if uri:
+            print(uri.group(1))
+            sys.exit(0)
+
+    print("timed out waiting for portal screenshot response", file=sys.stderr)
+    sys.exit(4)
+finally:
+    monitor.terminate()
+    try:
+        monitor.wait(timeout=1)
+    except Exception:
+        monitor.kill()
+`;
+
+export interface WaylandPortalCaptureOptions {
+  readonly interactive?: boolean;
+  readonly timeoutMs?: number;
+}
+
+export interface PortalScreenshotResponse {
+  readonly responseCode: number;
+  readonly uri?: string;
+}
+
+interface WaylandSessionEnv {
+  readonly WAYLAND_DISPLAY?: string;
+  readonly XDG_SESSION_TYPE?: string;
+}
+
+export function isWaylandSession(env?: WaylandSessionEnv): boolean {
+  const sessionType = (env?.XDG_SESSION_TYPE ?? process.env.XDG_SESSION_TYPE)
+    ?.trim()
+    .toLowerCase();
+  const waylandDisplay =
+    (env?.WAYLAND_DISPLAY ?? process.env.WAYLAND_DISPLAY)?.trim() ?? "";
+  return sessionType === "wayland" || waylandDisplay.length > 0;
+}
+
+export function canUseWaylandScreenshotPortal(): boolean {
+  return (
+    isWaylandSession() && commandExists("python3") && commandExists("gdbus")
+  );
+}
+
+export function captureWaylandPortalScreenshot(
+  tmpFile: string,
+  options: WaylandPortalCaptureOptions = {},
+): void {
+  if (!isWaylandSession()) {
+    throw new Error(
+      "Wayland screenshot portal requested outside a Wayland session.",
+    );
+  }
+  if (!commandExists("python3") || !commandExists("gdbus")) {
+    throw new Error(
+      "Wayland screenshot portal requires python3 and gdbus on PATH.",
+    );
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let uri: string;
+  try {
+    uri = execFileSync("python3", ["-c", WAYLAND_PORTAL_HELPER], {
+      encoding: "utf-8",
+      timeout: timeoutMs + 2000,
+      env: {
+        ...process.env,
+        ELIZA_WAYLAND_PORTAL_INTERACTIVE: options.interactive ? "1" : "0",
+        ELIZA_WAYLAND_PORTAL_TIMEOUT_MS: String(timeoutMs),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    const message = commandErrorMessage(error);
+    if (/denied|cancelled|canceled/i.test(message)) {
+      throw createPermissionDeniedError({
+        permissionType: "screen_recording",
+        operation: "screenshot_capture",
+        message:
+          "Wayland screenshot permission was denied or cancelled by the portal.",
+        details: message,
+      });
+    }
+    throw error;
+  }
+
+  const sourcePath = portalFileUriToPath(uri);
+  copyFileSync(sourcePath, tmpFile);
+}
+
+function commandErrorMessage(error: unknown): string {
+  if (!error || typeof error !== "object") return String(error);
+  const parts: string[] = [];
+  const candidate = error as {
+    message?: unknown;
+    stderr?: unknown;
+    stdout?: unknown;
+  };
+  for (const value of [candidate.message, candidate.stderr, candidate.stdout]) {
+    if (typeof value === "string" && value.length > 0) {
+      parts.push(value);
+    } else if (Buffer.isBuffer(value) && value.length > 0) {
+      parts.push(value.toString("utf-8"));
+    }
+  }
+  return parts.join("\n") || String(error);
+}
+
+export function parsePortalRequestHandle(output: string): string | null {
+  return output.match(/objectpath '([^']+)'/)?.[1] ?? null;
+}
+
+export function parsePortalScreenshotResponse(
+  output: string,
+  handle?: string,
+): PortalScreenshotResponse | null {
+  const source =
+    handle && output.includes(handle)
+      ? output.slice(output.lastIndexOf(handle))
+      : output;
+  const responseCodeText = source.match(/uint32\s+(\d+)/)?.[1];
+  if (!responseCodeText) return null;
+
+  const responseCode = Number.parseInt(responseCodeText, 10);
+  const uri = source.match(/['"]uri['"]\s*:\s*<['"]([^'"]+)['"]>/)?.[1];
+  return Number.isFinite(responseCode)
+    ? { responseCode, ...(uri ? { uri } : {}) }
+    : null;
+}
+
+export function portalFileUriToPath(uri: string): string {
+  if (!uri.startsWith("file://")) {
+    throw new Error(
+      `Wayland screenshot portal returned a non-file URI: ${uri}`,
+    );
+  }
+  return fileURLToPath(uri);
+}
+
+export const WAYLAND_PORTAL_DBUS_TARGET = {
+  busName: PORTAL_BUS_NAME,
+  objectPath: PORTAL_OBJECT_PATH,
+  method: PORTAL_SCREENSHOT_METHOD,
+} as const;

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -1,11 +1,11 @@
 import {
 	type IAgentRuntime,
+	type IMessageService,
 	logger,
 	type Media,
 	ModelType,
 	type ReplyToMode,
 	trimTokens,
-	IMessageService,
 } from "@elizaos/core";
 import {
 	ActionRowBuilder,

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -25,7 +25,6 @@ import {
 	ChannelType as DiscordChannelType,
 	type Guild,
 	type GuildMember,
-	type VoiceChannel,
 	type VoiceState,
 } from "discord.js";
 import prism from "prism-media";

--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -451,7 +451,9 @@ async function syncFitbit(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
     path: "/1/user/-/profile.json",
   });
   const profileUser = getRecord(identityJson, "user");
-  const distanceUnit = profileUser ? getText(profileUser, "distanceUnit") : null;
+  const distanceUnit = profileUser
+    ? getText(profileUser, "distanceUnit")
+    : null;
   const weightUnit = profileUser ? getText(profileUser, "weightUnit") : null;
   const samples: LifeOpsHealthMetricSample[] = [];
   const sleepEpisodes: LifeOpsHealthSleepEpisode[] = [];

--- a/plugins/plugin-linear/src/actions/clearActivity.ts
+++ b/plugins/plugin-linear/src/actions/clearActivity.ts
@@ -11,6 +11,7 @@ import {
 } from "@elizaos/core";
 import type { LinearService } from "../services/linear";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
 const CLEAR_ACTIVITY_TIMEOUT_MS = 10_000;
@@ -98,7 +99,7 @@ export const clearActivityAction: Action = {
       }
       if (decision.status === "cancelled") {
         const cancelMessage = "Clear of Linear activity cancelled.";
-        await callback?.({ text: cancelMessage, source: message.content.source });
+        await callback?.({ text: cancelMessage, source: getMessageSource(message) });
         return {
           text: cancelMessage,
           success: true,
@@ -119,7 +120,7 @@ export const clearActivityAction: Action = {
       const successMessage = "✅ Linear activity log has been cleared.";
       await callback?.({
         text: successMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -127,11 +128,11 @@ export const clearActivityAction: Action = {
         success: true,
       };
     } catch (error) {
-      logger.error("Failed to clear Linear activity:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to clear Linear activity:", formatUnknownError(error));
       const errorMessage = `❌ Failed to clear Linear activity: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/createComment.ts
+++ b/plugins/plugin-linear/src/actions/createComment.ts
@@ -13,6 +13,7 @@ import { createCommentTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import type { CreateCommentParameters } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { getStringValue, parseLinearPromptResponse } from "./parseLinearPrompt.js";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
@@ -118,7 +119,7 @@ export const createCommentAction: Action = {
         const errorMessage = "Please provide a message with the issue and comment content.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -182,7 +183,7 @@ export const createCommentAction: Action = {
                 const errorMessage = `No issues found matching "${issueDescription}". Please provide a specific issue ID.`;
                 await callback?.({
                   text: errorMessage,
-                  source: message.content.source,
+                  source: getMessageSource(message),
                 });
                 return {
                   text: errorMessage,
@@ -204,7 +205,7 @@ export const createCommentAction: Action = {
                 const clarifyMessage = `Found multiple issues matching "${issueDescription}":\n${issueList.join("\n")}\n\nPlease specify which issue to comment on by its ID.`;
                 await callback?.({
                   text: clarifyMessage,
-                  source: message.content.source,
+                  source: getMessageSource(message),
                 });
 
                 return {
@@ -230,7 +231,10 @@ export const createCommentAction: Action = {
               commentBody = `[${commentType.toUpperCase()}] ${commentBody}`;
             }
           } catch (parseError) {
-            logger.warn("Failed to parse LLM response, falling back to regex:", parseError instanceof Error ? parseError.message : String(parseError));
+            logger.warn(
+              "Failed to parse LLM response, falling back to regex:",
+              formatUnknownError(parseError)
+            );
             const issueMatch = content.match(
               /(?:comment on|add.*comment.*to|reply to|tell)\s+(\w+-\d+):?\s*(.*)/i
             );
@@ -240,7 +244,7 @@ export const createCommentAction: Action = {
                 'Please specify the issue ID and comment content. Example: "Comment on ENG-123: This looks good"';
               await callback?.({
                 text: errorMessage,
-                source: message.content.source,
+                source: getMessageSource(message),
               });
               return {
                 text: errorMessage,
@@ -258,7 +262,7 @@ export const createCommentAction: Action = {
         const errorMessage = "Please provide the comment content.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -279,7 +283,7 @@ export const createCommentAction: Action = {
       const successMessage = `✅ Comment added to issue ${issue.identifier}: "${commentBody}"`;
       await callback?.({
         text: successMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -296,11 +300,11 @@ export const createCommentAction: Action = {
         },
       };
     } catch (error) {
-      logger.error("Failed to create comment:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to create comment:", formatUnknownError(error));
       const errorMessage = `❌ Failed to create comment: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/createIssue.ts
+++ b/plugins/plugin-linear/src/actions/createIssue.ts
@@ -13,6 +13,7 @@ import { createIssueTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import type { CreateIssueParameters, LinearIssueInput } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import {
   getPriorityNumberValue,
   getStringArrayValue,
@@ -108,7 +109,7 @@ export const createIssueAction: Action = {
         const errorMessage = "Please provide a description for the issue.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -216,7 +217,7 @@ export const createIssueAction: Action = {
             }
           }
         } catch (parseError) {
-          logger.error("Failed to parse LLM response:", parseError instanceof Error ? parseError.message : String(parseError));
+          logger.error("Failed to parse LLM response:", formatUnknownError(parseError));
           issueData = {
             title: content.length > 100 ? `${content.substring(0, 100)}...` : content,
             description: content,
@@ -250,7 +251,7 @@ export const createIssueAction: Action = {
         const errorMessage = "Could not determine issue title. Please provide more details.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -263,7 +264,7 @@ export const createIssueAction: Action = {
           "No Linear teams found. Please ensure at least one team exists in your Linear workspace.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -276,7 +277,7 @@ export const createIssueAction: Action = {
       const successMessage = `✅ Created Linear issue: ${issue.title} (${issue.identifier})\n\nView it at: ${issue.url}`;
       await callback?.({
         text: successMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -290,11 +291,11 @@ export const createIssueAction: Action = {
         },
       };
     } catch (error) {
-      logger.error("Failed to create issue:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to create issue:", formatUnknownError(error));
       const errorMessage = `❌ Failed to create issue: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/deleteComment.ts
+++ b/plugins/plugin-linear/src/actions/deleteComment.ts
@@ -11,6 +11,7 @@ import {
 import type { LinearService } from "../services/linear";
 import type { DeleteCommentParameters } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
 export const deleteCommentAction: Action = {
@@ -73,23 +74,23 @@ export const deleteCommentAction: Action = {
 
       if (!commentId) {
         const errorMessage = "Please provide a commentId to delete.";
-        await callback?.({ text: errorMessage, source: message.content.source });
+        await callback?.({ text: errorMessage, source: getMessageSource(message) });
         return { text: errorMessage, success: false };
       }
 
       await linearService.deleteComment(commentId, accountId);
 
       const successMessage = `Deleted comment ${commentId}.`;
-      await callback?.({ text: successMessage, source: message.content.source });
+      await callback?.({ text: successMessage, source: getMessageSource(message) });
       return {
         text: successMessage,
         success: true,
         data: { commentId, accountId },
       };
     } catch (error) {
-      logger.error("Failed to delete comment:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to delete comment:", formatUnknownError(error));
       const errorMessage = `Failed to delete comment: ${error instanceof Error ? error.message : "Unknown error"}`;
-      await callback?.({ text: errorMessage, source: message.content.source });
+      await callback?.({ text: errorMessage, source: getMessageSource(message) });
       return { text: errorMessage, success: false };
     }
   },

--- a/plugins/plugin-linear/src/actions/deleteIssue.ts
+++ b/plugins/plugin-linear/src/actions/deleteIssue.ts
@@ -14,6 +14,7 @@ import { deleteIssueTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import type { DeleteIssueParameters } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { getStringValue, parseLinearPromptResponse } from "./parseLinearPrompt.js";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
@@ -116,7 +117,7 @@ export const deleteIssueAction: Action = {
         const errorMessage = "Please specify which issue to delete.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -159,14 +160,17 @@ export const deleteIssueAction: Action = {
             throw new Error("Issue ID not found in parsed response");
           }
         } catch (parseError) {
-          logger.warn("Failed to parse LLM response, falling back to regex parsing:", parseError instanceof Error ? parseError.message : String(parseError));
+          logger.warn(
+            "Failed to parse LLM response, falling back to regex parsing:",
+            formatUnknownError(parseError)
+          );
 
           const issueMatch = content.match(/(\w+-\d+)/);
           if (!issueMatch) {
             const errorMessage = "Please specify an issue ID (e.g., ENG-123) to delete.";
             await callback?.({
               text: errorMessage,
-              source: message.content.source,
+              source: getMessageSource(message),
             });
             return {
               text: errorMessage,
@@ -201,7 +205,7 @@ export const deleteIssueAction: Action = {
       }
       if (decision.status === "cancelled") {
         const cancelMessage = `Archive of ${issueIdentifier} cancelled.`;
-        await callback?.({ text: cancelMessage, source: message.content.source });
+        await callback?.({ text: cancelMessage, source: getMessageSource(message) });
         return {
           text: cancelMessage,
           success: true,
@@ -216,7 +220,7 @@ export const deleteIssueAction: Action = {
       const successMessage = `✅ Successfully archived issue ${issueIdentifier}: "${issueTitle}"\n\nThe issue has been moved to the archived state and will no longer appear in active views.`;
       await callback?.({
         text: successMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -231,11 +235,11 @@ export const deleteIssueAction: Action = {
         },
       };
     } catch (error) {
-      logger.error("Failed to delete issue:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to delete issue:", formatUnknownError(error));
       const errorMessage = `❌ Failed to delete issue: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/getActivity.ts
+++ b/plugins/plugin-linear/src/actions/getActivity.ts
@@ -12,6 +12,7 @@ import {
 import { getActivityTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import {
   getNumberValue,
   getRecordValue,
@@ -219,7 +220,7 @@ export const getActivityAction: Action = {
 
             limit = getNumberValue(parsed.limit) || 10;
           } catch (parseError) {
-            logger.warn("Failed to parse activity filters:", parseError instanceof Error ? parseError.message : String(parseError));
+            logger.warn("Failed to parse activity filters:", formatUnknownError(parseError));
           }
         }
       }
@@ -248,7 +249,7 @@ export const getActivityAction: Action = {
           : "No recent Linear activity found.";
         await callback?.({
           text: noActivityMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: noActivityMessage,
@@ -280,7 +281,7 @@ export const getActivityAction: Action = {
       const resultMessage = `${headerText}\n\n${activityText}`;
       await callback?.({
         text: resultMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -315,11 +316,11 @@ export const getActivityAction: Action = {
         },
       };
     } catch (error) {
-      logger.error("Failed to get activity:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to get activity:", formatUnknownError(error));
       const errorMessage = `❌ Failed to get activity: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/getIssue.ts
+++ b/plugins/plugin-linear/src/actions/getIssue.ts
@@ -13,6 +13,7 @@ import type { Issue, IssueLabel } from "@linear/sdk";
 import { getIssueTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { getRecordValue, getStringValue, parseLinearPromptResponse } from "./parseLinearPrompt.js";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
@@ -125,7 +126,7 @@ export const getIssueAction: Action = {
         const errorMessage = "Please specify which issue you want to see.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -225,7 +226,7 @@ export const getIssueAction: Action = {
             const noResultsMessage = "No issues found matching your criteria.";
             await callback?.({
               text: noResultsMessage,
-              source: message.content.source,
+              source: getMessageSource(message),
             });
             return {
               text: noResultsMessage,
@@ -257,7 +258,7 @@ export const getIssueAction: Action = {
           const clarifyMessage = `Found ${issues.length} issues matching your criteria:\n${issueList.join("\n")}\n\nPlease specify which one you want to see by its ID.`;
           await callback?.({
             text: clarifyMessage,
-            source: message.content.source,
+            source: getMessageSource(message),
           });
 
           return {
@@ -274,7 +275,10 @@ export const getIssueAction: Action = {
           };
         }
       } catch (parseError) {
-        logger.warn("Failed to parse LLM response, falling back to regex:", parseError instanceof Error ? parseError.message : String(parseError));
+        logger.warn(
+          "Failed to parse LLM response, falling back to regex:",
+          formatUnknownError(parseError)
+        );
         const issueMatch = content.match(/(\w+-\d+)/);
         if (issueMatch) {
           const issue = await linearService.getIssue(issueMatch[1], accountId);
@@ -286,18 +290,18 @@ export const getIssueAction: Action = {
         "Could not understand which issue you want to see. Please provide an issue ID (e.g., ENG-123) or describe it more specifically.";
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,
         success: false,
       };
     } catch (error) {
-      logger.error("Failed to get issue:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to get issue:", formatUnknownError(error));
       const errorMessage = `❌ Failed to get issue: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,
@@ -390,7 +394,7 @@ View in Linear: ${issue.url}`;
 
   await callback?.({
     text: issueMessage,
-    source: message.content.source,
+    source: getMessageSource(message),
   });
 
   const serializedIssue = {

--- a/plugins/plugin-linear/src/actions/listComments.ts
+++ b/plugins/plugin-linear/src/actions/listComments.ts
@@ -11,6 +11,7 @@ import {
 import type { LinearService } from "../services/linear";
 import type { ListCommentsParameters } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import { validateLinearActionIntent } from "./validate-linear-intent";
 
 export const listCommentsAction: Action = {
@@ -85,7 +86,7 @@ export const listCommentsAction: Action = {
           const errorMessage = "Please provide an issueId to list comments for.";
           await callback?.({
             text: errorMessage,
-            source: message.content.source,
+            source: getMessageSource(message),
           });
           return { text: errorMessage, success: false };
         }
@@ -97,9 +98,9 @@ export const listCommentsAction: Action = {
       const comments = await linearService.listComments(issueId, limit, accountId);
       return formatCommentResult(issueId, comments, message, callback);
     } catch (error) {
-      logger.error("Failed to list comments:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to list comments:", formatUnknownError(error));
       const errorMessage = `Failed to list comments: ${error instanceof Error ? error.message : "Unknown error"}`;
-      await callback?.({ text: errorMessage, source: message.content.source });
+      await callback?.({ text: errorMessage, source: getMessageSource(message) });
       return { text: errorMessage, success: false };
     }
   },
@@ -113,7 +114,7 @@ async function formatCommentResult(
 ): Promise<ActionResult> {
   if (comments.length === 0) {
     const text = `No comments on issue ${issueId}.`;
-    await callback?.({ text, source: message.content.source });
+    await callback?.({ text, source: getMessageSource(message) });
     return { text, success: true, data: { issueId, comments: [] } };
   }
 
@@ -128,7 +129,7 @@ async function formatCommentResult(
   );
 
   const text = `${comments.length} comment(s) on ${issueId}:\n${lines.join("\n")}`;
-  await callback?.({ text, source: message.content.source });
+  await callback?.({ text, source: getMessageSource(message) });
   return {
     text,
     success: true,

--- a/plugins/plugin-linear/src/actions/message-source.ts
+++ b/plugins/plugin-linear/src/actions/message-source.ts
@@ -1,0 +1,16 @@
+import type { Memory } from "@elizaos/core";
+
+export function getMessageSource(message: Memory): string | undefined {
+  const source = message.content.source;
+  return typeof source === "string" ? source : undefined;
+}
+
+export function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) return error.stack ?? error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/plugins/plugin-linear/src/actions/searchIssues.ts
+++ b/plugins/plugin-linear/src/actions/searchIssues.ts
@@ -13,6 +13,7 @@ import { searchIssuesTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import type { LinearSearchFilters, SearchIssuesParameters } from "../types/index.js";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import {
   getBooleanValue,
   getNumberValue,
@@ -126,7 +127,7 @@ export const searchIssuesAction: Action = {
         const errorMessage = "Please provide search criteria for issues.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -225,7 +226,7 @@ export const searchIssuesAction: Action = {
               }
             });
           } catch (parseError) {
-            logger.error("Failed to parse search filters:", parseError instanceof Error ? parseError.message : String(parseError));
+            logger.error("Failed to parse search filters:", formatUnknownError(parseError));
             // Fallback to simple search
             filters = { query: content };
           }
@@ -258,7 +259,7 @@ export const searchIssuesAction: Action = {
         const noResultsMessage = "No issues found matching your search criteria.";
         await callback?.({
           text: noResultsMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: noResultsMessage,
@@ -287,7 +288,7 @@ export const searchIssuesAction: Action = {
       const resultMessage = `📋 Found ${issues.length} issue${issues.length === 1 ? "" : "s"}:\n\n${issueText}`;
       await callback?.({
         text: resultMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
 
       return {
@@ -322,11 +323,11 @@ export const searchIssuesAction: Action = {
         },
       };
     } catch (error) {
-      logger.error("Failed to search issues:", error instanceof Error ? error.message : String(error));
+      logger.error("Failed to search issues:", formatUnknownError(error));
       const errorMessage = `❌ Failed to search issues: ${error instanceof Error ? error.message : "Unknown error"}`;
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,

--- a/plugins/plugin-linear/src/actions/updateComment.ts
+++ b/plugins/plugin-linear/src/actions/updateComment.ts
@@ -10,6 +10,7 @@ import {
 import type { LinearService } from "../services/linear";
 import type { UpdateCommentParameters } from "../types/index.js";
 import { getLinearAccountId } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 
 export async function handleUpdateComment(
   runtime: IAgentRuntime,
@@ -31,23 +32,23 @@ export async function handleUpdateComment(
 
     if (!commentId || !body) {
       const errorMessage = "Please provide both commentId and body to update a comment.";
-      await callback?.({ text: errorMessage, source: message.content.source });
+      await callback?.({ text: errorMessage, source: getMessageSource(message) });
       return { text: errorMessage, success: false };
     }
 
     const comment = await linearService.updateComment(commentId, body, accountId);
 
     const successMessage = `Updated comment ${commentId}.`;
-    await callback?.({ text: successMessage, source: message.content.source });
+    await callback?.({ text: successMessage, source: getMessageSource(message) });
     return {
       text: successMessage,
       success: true,
       data: { commentId: comment.id, accountId },
     };
   } catch (error) {
-    logger.error("Failed to update comment:", error instanceof Error ? error.message : String(error));
+    logger.error("Failed to update comment:", formatUnknownError(error));
     const errorMessage = `Failed to update comment: ${error instanceof Error ? error.message : "Unknown error"}`;
-    await callback?.({ text: errorMessage, source: message.content.source });
+    await callback?.({ text: errorMessage, source: getMessageSource(message) });
     return { text: errorMessage, success: false };
   }
 }

--- a/plugins/plugin-linear/src/actions/updateIssue.ts
+++ b/plugins/plugin-linear/src/actions/updateIssue.ts
@@ -13,6 +13,7 @@ import { updateIssueTemplate } from "../prompts.js";
 import type { LinearService } from "../services/linear";
 import type { LinearIssueInput } from "../types";
 import { getLinearAccountId, linearAccountIdParameter } from "./account-options";
+import { formatUnknownError, getMessageSource } from "./message-source";
 import {
   getPriorityNumberValue,
   getRecordValue,
@@ -44,7 +45,7 @@ export async function handleUpdateIssue(
       const errorMessage = "Please provide update instructions for the issue.";
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,
@@ -177,14 +178,17 @@ export async function handleUpdateIssue(
         updates.labelIds = labelIds;
       }
     } catch (parseError) {
-      logger.warn("Failed to parse LLM response, falling back to regex parsing:", parseError instanceof Error ? parseError.message : String(parseError));
+      logger.warn(
+        "Failed to parse LLM response, falling back to regex parsing:",
+        formatUnknownError(parseError)
+      );
 
       const issueMatch = content.match(/(\w+-\d+)/);
       if (!issueMatch) {
         const errorMessage = "Please specify an issue ID (e.g., ENG-123) to update.";
         await callback?.({
           text: errorMessage,
-          source: message.content.source,
+          source: getMessageSource(message),
         });
         return {
           text: errorMessage,
@@ -220,7 +224,7 @@ export async function handleUpdateIssue(
         "No valid updates found. Please specify what to update (e.g., \"Update issue ENG-123 title to 'New Title'\")";
       await callback?.({
         text: errorMessage,
-        source: message.content.source,
+        source: getMessageSource(message),
       });
       return {
         text: errorMessage,
@@ -242,7 +246,7 @@ export async function handleUpdateIssue(
     const successMessage = `✅ Updated issue ${updatedIssue.identifier}: ${updateSummary.join(", ")}\n\nView it at: ${updatedIssue.url}`;
     await callback?.({
       text: successMessage,
-      source: message.content.source,
+      source: getMessageSource(message),
     });
 
     return {
@@ -264,11 +268,11 @@ export async function handleUpdateIssue(
       },
     };
   } catch (error) {
-    logger.error("Failed to update issue:", error instanceof Error ? error.message : String(error));
+    logger.error("Failed to update issue:", formatUnknownError(error));
     const errorMessage = `❌ Failed to update issue: ${error instanceof Error ? error.message : "Unknown error"}`;
     await callback?.({
       text: errorMessage,
-      source: message.content.source,
+      source: getMessageSource(message),
     });
     return {
       text: errorMessage,

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
@@ -23,7 +23,10 @@ function fakeRuntime(): RuntimeEventSink {
 }
 
 /** Build a well-formed playback frame from Float32 [-1,1] samples. */
-function playbackFrame(samples: Float32Array, frameIndex: number): AudioFrameEvent {
+function playbackFrame(
+	samples: Float32Array,
+	frameIndex: number,
+): AudioFrameEvent {
 	const buf = Buffer.alloc(samples.length * 2);
 	for (let i = 0; i < samples.length; i += 1) {
 		const clamped = Math.max(-1, Math.min(1, samples[i] ?? 0));
@@ -43,7 +46,7 @@ function playbackFrame(samples: Float32Array, frameIndex: number): AudioFrameEve
 /** A deterministic ramp in [-0.5, 0.5]. */
 function ramp(n: number): Float32Array {
 	const out = new Float32Array(n);
-	for (let i = 0; i < n; i += 1) out[i] = (i / n) - 0.5;
+	for (let i = 0; i < n; i += 1) out[i] = i / n - 0.5;
 	return out;
 }
 

--- a/plugins/plugin-social-alpha/src/types.ts
+++ b/plugins/plugin-social-alpha/src/types.ts
@@ -1,6 +1,7 @@
 import type {
 	Content,
 	UUID as CoreUUID,
+	HandlerCallback,
 	IAgentRuntime,
 	Memory,
 	MetadataValue,
@@ -1044,9 +1045,6 @@ export interface ICommunityInvestorService {
 export interface MessageReceivedHandlerParams {
 	runtime: IAgentRuntime;
 	message: Memory;
-	callback: (
-		response: string | Record<string, unknown>,
-		metadata?: Record<string, unknown>,
-	) => Promise<void>;
+	callback?: HandlerCallback;
 	onComplete?: () => void;
 }

--- a/plugins/plugin-wallet/src/chains/evm/tsconfig.json
+++ b/plugins/plugin-wallet/src/chains/evm/tsconfig.json
@@ -3,10 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": [
-      "ES2022",
-      "DOM"
-    ],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
@@ -21,18 +18,9 @@
     "noUnusedParameters": false,
     "noImplicitReturns": false,
     "noImplicitAny": false,
-    "types": [
-      "node",
-      "bun-types"
-    ],
+    "types": ["node", "bun-types"],
     "allowImportingTsExtensions": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "build.ts"
-  ]
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist", "build.ts"]
 }

--- a/plugins/plugin-wallet/src/chains/solana/tsconfig.json
+++ b/plugins/plugin-wallet/src/chains/solana/tsconfig.json
@@ -3,10 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": [
-      "ES2022",
-      "DOM"
-    ],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
@@ -21,18 +18,9 @@
     "noUnusedParameters": false,
     "noImplicitReturns": false,
     "noImplicitAny": false,
-    "types": [
-      "node",
-      "bun-types"
-    ],
+    "types": ["node", "bun-types"],
     "allowImportingTsExtensions": true
   },
-  "include": [
-    "./**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "build.ts"
-  ]
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist", "build.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -110,6 +110,9 @@
       "@elizaos/plugin-capacitor-bridge": [
         "./plugins/plugin-capacitor-bridge/src/index.ts"
       ],
+      "@elizaos/plugin-capacitor-bridge/*": [
+        "./plugins/plugin-capacitor-bridge/src/*"
+      ],
       "@elizaos/plugin-coding-tools": [
         "./plugins/plugin-coding-tools/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- Adds a Linux Wayland full-display screenshot path for `plugin-computeruse` using xdg-desktop-portal Screenshot over `gdbus`.
- Keeps existing X11 capture fallbacks and maps portal denial/cancel to the existing permission-denied error path.
- Adds parser/unit coverage and updates computeruse Linux/multi-monitor docs.
- Includes verify-unblocking strictness/formatter fixes found while rebasing onto current `develop`:
  - Linear callback source/error logging strictness.
  - social-alpha event callback type aligned with core `HandlerCallback`.
  - capacitor bridge subpath type resolution for `mobile-device-bridge-bootstrap`.
  - formatter/lockfile reconciliation from `bun run verify`.
  - cloud-shared image resolver formatting needed after the upstream helper restore landed.
  - wallet chain tsconfig formatting after upstream strictness changes.

## Evidence
- `bun install`
- `bun run --cwd plugins/plugin-computeruse test -- src/platform/wayland-portal.test.ts src/__tests__/capture-region.test.ts` (2 files / 12 tests)
- `bun run --cwd plugins/plugin-computeruse typecheck`
- `bun run --cwd plugins/plugin-computeruse build`
- `bun run --cwd plugins/plugin-computeruse test` (80 passed | 1 skipped; 692 passed | 14 skipped)
- `bun run --cwd plugins/plugin-linear typecheck`
- `bun run --cwd plugins/plugin-linear test` (5 files / 22 tests)
- `bun run --cwd plugins/plugin-linear build`
- `bun run --cwd packages/cloud-shared typecheck`
- `bun test packages/cloud-shared/src/lib/services/app-image-resolver.test.ts` (7 tests)
- `bun run --cwd packages/cloud-shared lint`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/agent lint`
- `bun run --cwd plugins/plugin-discord lint`
- `bun run --cwd plugins/plugin-social-alpha typecheck`
- `bun run --cwd plugins/plugin-social-alpha lint`
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck`
- `bun run --cwd plugins/plugin-wallet lint`
- `git diff --check`
- `bun run verify` (510 successful / 510 total, 5m38.743s, after rebasing onto `38856e0dd7`)

## Limitations
- Refs #9581; follow-up to closed epic #9105.
- I could not capture a live GNOME/KDE Wayland portal trajectory on this macOS host. The portal flow is unit/parser-tested and documented, but live compositor evidence is still required before marking the Linux Wayland portion of the cross-platform tail fully proven.
