### PR TITLE
docs(vision): update OCR backend README

### DIFF
--- a/plugins/plugin-vision/README.md
+++ b/plugins/plugin-vision/README.md
@@ -7,7 +7,7 @@ Visual perception plugin for elizaOS — gives Eliza agents real-time awareness 
 - Captures frames from a connected camera (macOS/Linux/Windows) or the host screen.
 - Describes scenes by routing images through `runtime.useModel(IMAGE_DESCRIPTION)` — compatible with any registered VLM (local or cloud).
 - Detects and tracks people, objects, and faces across frames with persistent entity IDs.
-- Reads text on screen via Apple Vision (darwin, when a provider is registered) falling through to a doCTR ggml backend (`native/doctr.cpp`) — no ONNX or Tesseract path.
+- Reads text on screen through the generic Apple Vision/doCTR OCR service and the coordinate-aware OCR registry used by computeruse: Windows.Media.Ocr on Windows, Tesseract on Linux when available, and the RapidOCR adapter as the portable fallback.
 - Exposes all capabilities through a single `VISION` action and a `VISION_PERCEPTION` context provider.
 
 ## Installation
@@ -94,7 +94,7 @@ The plugin registers a single `VISION` action that routes to one of these sub-op
 | Scene description | VLM via `runtime.useModel(IMAGE_DESCRIPTION)` | Any registered IMAGE_DESCRIPTION provider |
 | Object detection | YOLOv8n ggml via `native/yolo.cpp` (`src/yolo-detector.ts`); build with `bun run build:native` + `bun run build:weights`. Service degrades to motion/heuristic + VLM when the lib/GGUF are absent. | — (TensorFlow.js path removed) |
 | Pose detection | Heuristic person detection (motion-derived) | Planned ggml MoveNet port |
-| OCR | Apple Vision (darwin, when a provider is registered) → doCTR ggml (`native/doctr.cpp`) | No ONNX or Tesseract path |
+| OCR | Generic OCR uses Apple Vision (darwin, when a provider is registered) → doCTR ggml (`native/doctr.cpp`). Coordinate OCR for computeruse prefers Windows.Media.Ocr (Windows) → Tesseract CLI or vendored bundle (Linux) → RapidOCR adapter. | Native/mobile bridges can register platform OCR providers; no ONNX OCR path. |
 | Set-of-Marks grounding | `src/som.ts` fuses GGUF YOLO icon boxes + OCR text boxes into a deduplicated, 1-indexed numbered set (icon-over-text suppression + NMS) and renders a numbered-overlay PNG via `sharp`. `src/set-of-marks-provider.ts` registers it into plugin-computeruse's `detect_elements` seam at boot (best-effort; degrades to text-only marks when the GGUF detector is absent). | trycua/cua OmniParser parity (#9170 M9) |
 | Face recognition | Native ggml BlazeFace + 128-d embed (`face-detector-ggml.ts`, `face-recognition-ggml.ts`, `native/face-cpp`); disabled until the lib/GGUF artifacts land. No tfjs/face-api.js path. | MediaPipe BlazeFace migration shim is deprecated. |
 
@@ -102,7 +102,7 @@ The plugin registers a single `VISION` action that routes to one of these sub-op
 
 - **Node.js only.** Mobile (iOS, Android) registers a `MobileCameraSource` (`src/mobile/capacitor-camera.ts`) bridged by plugin-ios / plugin-aosp.
 - **Camera tools** (`imagesnap` / `fswebcam` / `ffmpeg`) are required for camera mode; screen capture and OCR work without them.
-- **Native detectors** (`native/yolo.cpp`, `native/doctr.cpp`) run via `bun:ffi`; they require their compiled libraries and GGUF artifacts to be present, and throw clearly when missing rather than silently falling back.
+- **Native detectors and OCR** (`native/yolo.cpp`, `native/doctr.cpp`, and the coordinate-OCR providers) run through the available host backend. YOLO/doCTR require compiled libraries and GGUF artifacts; Tesseract requires a binary plus traineddata resolved from the vendored bundle or PATH.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
- Updates plugin-vision README OCR docs to match the current backend split.
- Documents generic Apple Vision/doCTR OCR separately from coordinate OCR used by computeruse.
- Notes Windows.Media.Ocr, Linux Tesseract, and RapidOCR coordinate-OCR paths instead of the stale "no Tesseract path" text.

## Evidence
- `git diff --check HEAD~1..HEAD`
- `bun install`
- `bun run verify` (510/510 tasks successful on current `origin/develop` / 920d40c919)

Refs #9581; follow-up to closed #9105.