### PR TITLE
test(kokoro): add ASR/WER audio-correctness gate to the real-voice smoke (#9588)

### DIFF
--- a/plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts
+++ b/plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts
@@ -41,6 +41,34 @@ function fail(msg: string): never {
 	process.exit(1);
 }
 
+/** Word-level error rate (Levenshtein over normalized word tokens). */
+function wordErrorRate(reference: string, hypothesis: string): number {
+	const norm = (s: string) =>
+		s
+			.toLowerCase()
+			.replace(/[^a-z0-9\s]/g, " ")
+			.split(/\s+/)
+			.filter(Boolean);
+	const r = norm(reference);
+	const h = norm(hypothesis);
+	if (r.length === 0) return h.length === 0 ? 0 : 1;
+	const d: number[][] = Array.from({ length: r.length + 1 }, () =>
+		new Array<number>(h.length + 1).fill(0),
+	);
+	for (let i = 0; i <= r.length; i++) d[i]![0] = i;
+	for (let j = 0; j <= h.length; j++) d[0]![j] = j;
+	for (let i = 1; i <= r.length; i++) {
+		for (let j = 1; j <= h.length; j++) {
+			d[i]![j] =
+				r[i - 1] === h[j - 1]
+					? d[i - 1]![j - 1]!
+					: 1 +
+						Math.min(d[i - 1]![j - 1]!, d[i - 1]![j]!, d[i]![j - 1]!);
+		}
+	}
+	return d[r.length]![h.length]! / r.length;
+}
+
 if (typeof (globalThis as { Bun?: unknown }).Bun === "undefined") {
 	skip("not running under bun (bun:ffi required) — invoke with `bun`");
 }
@@ -89,6 +117,7 @@ try {
 	let firstAudibleMs: number | null = null;
 	let totalSamples = 0;
 	let sampleRate = 0;
+	const pcmChunks: Float32Array[] = [];
 	await backend.synthesizeStream({
 		phrase,
 		preset,
@@ -98,6 +127,7 @@ try {
 				if (firstAudibleMs === null) firstAudibleMs = performance.now() - start;
 				totalSamples += c.pcm.length;
 				sampleRate = c.sampleRate;
+				pcmChunks.push(c.pcm);
 			}
 			return undefined;
 		},
@@ -111,6 +141,54 @@ try {
 	if (totalSamples === 0) fail("empty PCM — Kokoro produced no audio");
 	if (sampleRate !== 24_000) fail(`expected 24 kHz PCM, got ${sampleRate}`);
 	if (firstAudibleMs === null) fail("no audible chunk was emitted");
+
+	// Audio-CORRECTNESS gate (run BEFORE the TTFA perf gate — "is it speech" is a
+	// stricter, more important question than "is it fast", and TTFA is slow on
+	// desktop CPU even when the audio is perfect). The non-empty/sample-rate
+	// checks above pass even on noise/garbage (the exact gap that let a loader
+	// regression ship inaudible audio). When an ASR bundle is staged, transcribe
+	// the synthesized speech with the fused Qwen3-ASR and gate on WER against the
+	// input text, so "it produced audio" can't masquerade as "it produced
+	// speech". Without the bundle the gate is skipped with a loud warning (audio
+	// remains UNVERIFIED), preserving the lighter dev lane.
+	const asrBundle = process.env.ELIZA_ASR_BUNDLE?.trim();
+	if (!asrBundle) {
+		console.warn(
+			"[kokoro-real-smoke] WARN: ELIZA_ASR_BUNDLE not set — audio CORRECTNESS is UNVERIFIED " +
+				"(non-empty PCM only). Set it to a dir with asr/eliza-1-asr.gguf + -mmproj.gguf to gate intelligibility (WER).",
+		);
+	} else {
+		const pcm = new Float32Array(totalSamples);
+		let off = 0;
+		for (const ch of pcmChunks) {
+			pcm.set(ch, off);
+			off += ch.length;
+		}
+		const asrCtx = ffi.create(asrBundle);
+		let transcript: string;
+		try {
+			ffi.mmapAcquire(asrCtx, "asr");
+			transcript = ffi
+				.asrTranscribe({ ctx: asrCtx, pcm, sampleRateHz: sampleRate })
+				.trim();
+		} finally {
+			ffi.mmapEvict(asrCtx, "asr");
+			ffi.destroy(asrCtx);
+		}
+		const wer = wordErrorRate(phrase.text, transcript);
+		const WER_BUDGET = 0.5;
+		console.log(
+			`[kokoro-real-smoke] ASR transcript: "${transcript}" — WER ${wer.toFixed(2)} vs "${phrase.text}"`,
+		);
+		if (wer > WER_BUDGET) {
+			fail(
+				`synthesized audio is not intelligible: ASR WER ${wer.toFixed(2)} > ${WER_BUDGET} ` +
+					`(transcript "${transcript}" vs reference "${phrase.text}")`,
+			);
+		}
+	}
+
+	// Perf gate last: mobile-class time-to-first-audio budget.
 	if (firstAudibleMs > KOKORO_MOBILE_TTFA_BUDGET_MS) {
 		fail(
 			`TTFA ${ttfa}ms exceeds the mobile budget ${KOKORO_MOBILE_TTFA_BUDGET_MS}ms`,


### PR DESCRIPTION
Hardens `kokoro-real-smoke.ts` to catch a class of bug it was blind to: **inaudible/garbage audio that still passes**.

## Why
The smoke asserted only non-empty 24kHz PCM + a prompt first chunk. That **passes on noise**. While root-causing #9588 I got the full Kokoro pipeline running end-to-end (3.17s PCM) but the output was constant HF noise (spectral centroid 7.3kHz, flat envelope) — and this lane would have **green-lit it**. A TTS smoke that can't tell speech from noise isn't a correctness gate.

## What
An **optional ASR/WER correctness gate**:
- When `ELIZA_ASR_BUNDLE` is staged (`asr/eliza-1-asr.gguf` + `-mmproj.gguf`), transcribe the synthesized PCM with the fused Qwen3-ASR (`ffi.asrTranscribe`) and **fail when WER vs the input text > 0.5**.
- Without the bundle, the gate is **skipped with a loud `UNVERIFIED` warning** (preserves the lighter dev lane; no new hard dependency).
- Runs the correctness gate **before** the TTFA perf gate — intelligibility is the stricter question, and TTFA legitimately exceeds the mobile budget on desktop CPU.
- Reuses the exact ASR lifecycle from `asr-real-smoke.ts` (`create`/`mmapAcquire("asr")`/`asrTranscribe`/`mmapEvict`/`destroy`) + a small word-level Levenshtein WER.

## Verification (Linux x64)
Against the noise audio: ASR transcript `""` → **WER 1.00 → FAIL** with a clear diagnostic. The prior non-empty-PCM check passed the same noise. Typecheck clean.

Part of #9588 (the loader/bundle fixes are tracked separately on the `elizaOS/llama.cpp` fork branch); this is the verification infrastructure so the audio fixes can't regress to garbage unseen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)