### PR TITLE
fix(smartglasses): sort simulator smoke imports

### DIFF
--- a/packages/examples/smartglasses/simulator-automation-smoke.ts
+++ b/packages/examples/smartglasses/simulator-automation-smoke.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import { type ChildProcessByStdio, spawn } from "node:child_process";
-import type { Readable } from "node:stream";
 import { dirname } from "node:path";
+import type { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { PNG } from "pngjs";
 


### PR DESCRIPTION
## Summary
- Sort `simulator-automation-smoke.ts` imports to satisfy Biome on current `develop`.

## Verification
- `bun install`
- `bun run --cwd packages/examples/smartglasses lint`
- `bun run verify` (510/510 successful, 3.147s after rebase onto `8a15da17b218bdc33fca663322797b38b8f72da5`)

## Notes
- This repairs the `develop` lint failure introduced after #9474 so dependent PRs can rebase and pass verification.