### PR TITLE
[codex] expose lightweight install path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ say **Eliza agents**. Exception: the **Eliza Classic** plugin keeps `Eliza`
 
 ```bash
 bun install            # workspace install (runs postinstall: submodules, patches)
+bun run install:light  # install without downloading the large artifact bundle
 bun run dev            # boot the API + dashboard UI (packages/app-core dev-ui)
 bun run build          # turbo build across the workspace
 bun run verify         # typecheck + lint (alias: bun run check) — run before "done"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ say **Eliza agents**. Exception: the **Eliza Classic** plugin keeps `Eliza`
 
 ```bash
 bun install            # workspace install (runs postinstall: submodules, patches)
+bun run install:light  # install without downloading the large artifact bundle
 bun run dev            # boot the API + dashboard UI (packages/app-core dev-ui)
 bun run build          # turbo build across the workspace
 bun run verify         # typecheck + lint (alias: bun run check) — run before "done"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The runbook for orchestrator-driven benchmark runs is [`packages/benchmarks/ORCH
 
 ```bash
 bun install            # workspace install
+bun run install:light  # skip the large artifact download when disk or time is tight
 bun run dev            # API + Vite UI for apps/app
 bun run build          # turbo build across the workspace
 bun run lint           # turbo lint across the workspace

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "postinstall": "bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs && bun packages/scripts/sync-artifacts.mjs",
+    "install:light": "ELIZA_SKIP_ARTIFACT_SYNC=1 bun install",
     "cloud:mock": "bun scripts/cloud/mock-stack-up.mjs",
     "cloud:mock:fresh": "bun scripts/cloud/mock-stack-up.mjs --reset",
     "fix-deps": "bun packages/scripts/fix-workspace-deps.mjs",


### PR DESCRIPTION
## Summary

- Add `bun run install:light` as a documented root command.
- Wire it to the existing `ELIZA_SKIP_ARTIFACT_SYNC=1` postinstall escape hatch so disk-constrained local checks can skip the 971 MiB artifact bundle.
- Document the command in the root agent guide and README.

## Why

CI janitor checks on `develop` found that a normal install path enters `sync-artifacts` and starts downloading a 971 MiB bundle. The skip flag already existed, but it was not exposed in the root command list, so lightweight checks had to know the env var by memory.

## Verification

- `bun run install:light` finished successfully and logged `[sync-artifacts] skipped (ELIZA_SKIP_ARTIFACT_SYNC=1)`.
- `bun run build` completed successfully: `Tasks: 236 successful, 236 total` plus examples/benchmarks and view bundles.
- `bunx --bun biome check package.json README.md CLAUDE.md AGENTS.md` completed with no fixes.

## Follow-up observations

Not fixed in this scoped PR:

- `bun install --frozen-lockfile` on local Bun canary still reports `lockfile had changes, but lockfile is frozen` without a resulting `bun.lock` diff. CI's setup action already has a fallback for this canary behavior.
- Build warnings include Turbo circular dependency detection and repeated Vite `INEFFECTIVE_DYNAMIC_IMPORT` warnings in app/electrobun bundles.
- A fresh `LOG_LEVEL=debug bun run start` with isolated `ELIZA_STATE_DIR` boots but emits missing provider/embedding warnings and many stale `VIEW_ACTION_MAP` entries; default state with prior Ollama config failed on an Ollama embedding `Not Implemented` error.
