### PR TITLE
fix(os): make the release/TEE script pipeline runnable on Windows (file URL derivation)

### DIFF
--- a/packages/os/scripts/__tests__/os-release-scripts.test.mjs
+++ b/packages/os/scripts/__tests__/os-release-scripts.test.mjs
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
   defaultManifestPath,
@@ -20,7 +21,9 @@ import {
 } from "../tee-evidence-bridge.mjs";
 
 const execFileAsync = promisify(execFile);
-const repoRoot = path.resolve(new URL("../../../..", import.meta.url).pathname);
+const repoRoot = path.resolve(
+  fileURLToPath(new URL("../../../..", import.meta.url)),
+);
 const confidentialManifestPath = path.join(
   repoRoot,
   "packages/os/release/confidential-2026-05-21/manifest.json",
@@ -187,7 +190,7 @@ releaseFixtureTest(
     const tmp = await mkdtemp(path.join(os.tmpdir(), "elizaos-release-"));
     const manifestPath = path.join(tmp, "manifest.json");
     const artifactRoot = path.join(tmp, "artifacts");
-    await execFileAsync("mkdir", ["-p", artifactRoot]);
+    await mkdir(artifactRoot, { recursive: true });
 
     const fixtureArtifacts = [
       sourceManifest.artifacts.find(

--- a/packages/os/scripts/__tests__/tee-evidence-bridge.test.mjs
+++ b/packages/os/scripts/__tests__/tee-evidence-bridge.test.mjs
@@ -17,13 +17,16 @@ import assert from "node:assert/strict";
 import { access } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { readJson } from "../os-release-lib.mjs";
 import {
   buildBoundEvidence,
   goldenMeasurementsOf,
 } from "../tee-evidence-bridge.mjs";
 
-const repoRoot = path.resolve(new URL("../../../..", import.meta.url).pathname);
+const repoRoot = path.resolve(
+  fileURLToPath(new URL("../../../..", import.meta.url)),
+);
 const confidentialManifestPath = path.join(
   repoRoot,
   "packages/os/release/confidential-2026-05-21/manifest.json",
@@ -91,11 +94,7 @@ function assertAcceptedByConsumerContract(evidence) {
   }
   if (evidence.claims !== undefined) {
     for (const [claim, value] of Object.entries(evidence.claims)) {
-      assert.equal(
-        typeof value,
-        "boolean",
-        `claim ${claim} must be boolean`,
-      );
+      assert.equal(typeof value, "boolean", `claim ${claim} must be boolean`);
     }
   }
 }

--- a/packages/os/scripts/check-confidential-artifacts.mjs
+++ b/packages/os/scripts/check-confidential-artifacts.mjs
@@ -18,6 +18,7 @@
 //   node packages/os/scripts/check-confidential-artifacts.mjs
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   expectedCmdlineTokens,
   expectedMaskedUnits,
@@ -132,6 +133,6 @@ async function main() {
 
 export { ARTIFACT_PATHS, loadArtifacts };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/check-confidential-image-manifest.mjs
+++ b/packages/os/scripts/check-confidential-image-manifest.mjs
@@ -16,6 +16,7 @@
 // Runner: plain `node` (no third-party deps).
 //   node packages/os/scripts/check-confidential-image-manifest.mjs
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { validateAgainstSchema } from "./json-schema-lite.mjs";
 import { parseArgs, readJson, repoRoot } from "./os-release-lib.mjs";
 
@@ -94,6 +95,6 @@ async function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/check-confidential-layer.mjs
+++ b/packages/os/scripts/check-confidential-layer.mjs
@@ -19,6 +19,7 @@
 //   node packages/os/scripts/check-confidential-layer.mjs
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { fileExists, repoRoot } from "./os-release-lib.mjs";
 
 const LAYER_DIR = path.join(
@@ -138,6 +139,6 @@ async function main() {
 
 export { extractFileUris, LAYER_DIR };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/check-confidential-policy.mjs
+++ b/packages/os/scripts/check-confidential-policy.mjs
@@ -11,6 +11,7 @@
 // Runner: plain `node` (no third-party deps).
 //   node packages/os/scripts/check-confidential-policy.mjs
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { validateAgainstSchema } from "./json-schema-lite.mjs";
 import {
   parseArgs,
@@ -294,6 +295,6 @@ async function main() {
   console.log(`  policy digest: ${digestResult.expected}`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/check-confidential-profile.mjs
+++ b/packages/os/scripts/check-confidential-profile.mjs
@@ -41,6 +41,7 @@
 const FLOOR_GATES = new Set(["confidential-image-reproducibility"]);
 
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   checkConfidentialArtifacts,
   loadArtifacts,
@@ -195,6 +196,6 @@ async function main() {
   console.log("check-confidential-profile: ALL GATES PASS");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/check-dstack-pins.mjs
+++ b/packages/os/scripts/check-dstack-pins.mjs
@@ -23,6 +23,7 @@
 // Runner: plain `node` (no third-party deps).
 //   node packages/os/scripts/check-dstack-pins.mjs
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { validateAgainstSchema } from "./json-schema-lite.mjs";
 import { parseArgs, readJson, repoRoot } from "./os-release-lib.mjs";
 
@@ -108,7 +109,7 @@ export function checkDstackPins(pins, schema, manifest) {
     pin.confirmed === true && typeof pin.tag === "string" && pin.tag.length > 0;
   if (!trackLatestValid && !frozenTagValid) {
     errors.push(
-      "pinnedRelease is INVALID: provide either a track-latest pin (track=\"latest\", reverifyOnUpdate=true, minReleaseDate set) or a confirmed frozen tag (confirmed=true, tag set). FAIL-CLOSED (§2.3/§8.3).",
+      'pinnedRelease is INVALID: provide either a track-latest pin (track="latest", reverifyOnUpdate=true, minReleaseDate set) or a confirmed frozen tag (confirmed=true, tag set). FAIL-CLOSED (§2.3/§8.3).',
     );
   }
 
@@ -156,6 +157,6 @@ async function main() {
   console.log(`dstack-pins-check: PASS (${input})`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/generate-confidential-artifacts.mjs
+++ b/packages/os/scripts/generate-confidential-artifacts.mjs
@@ -17,6 +17,7 @@
 //   node packages/os/scripts/generate-confidential-artifacts.mjs
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   ARTIFACT_HEADER,
   expectedCmdlineTokens,
@@ -76,6 +77,6 @@ async function main() {
   console.log(`  ${ARTIFACT_PATHS.masked}`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/os-release-lib.mjs
+++ b/packages/os/scripts/os-release-lib.mjs
@@ -2,9 +2,10 @@ import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const repoRoot = path.resolve(
-  new URL("../../..", import.meta.url).pathname,
+  fileURLToPath(new URL("../../..", import.meta.url)),
 );
 export const defaultManifestPath = path.join(
   repoRoot,

--- a/packages/os/scripts/tee-evidence-bridge.mjs
+++ b/packages/os/scripts/tee-evidence-bridge.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { pathToFileURL } from "node:url";
 // OS-side runtime-evidence exposure bridge (plan OS-2, contract "Runtime
 // Evidence Bridge"). Transforms a platform quote into the normalized TeeEvidence
 // document consumed by packages/agent/src/services/dstack-tee-provider.ts and
@@ -136,6 +137,6 @@ async function main() {
   console.log(`TEE evidence (mock) written and bound to golden: ${output}`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/tee-state-volume-mount.mjs
+++ b/packages/os/scripts/tee-state-volume-mount.mjs
@@ -33,6 +33,7 @@
 // exercise the logic off-hardware.
 
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 export const STATE_VOLUME_KEY_ID = "state-volume";
 
@@ -179,6 +180,6 @@ async function main() {
   process.exit(2);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }

--- a/packages/os/scripts/verify-image-reproducibility.mjs
+++ b/packages/os/scripts/verify-image-reproducibility.mjs
@@ -36,6 +36,7 @@
 //   node packages/os/scripts/verify-image-reproducibility.mjs --input <manifest>
 //   node packages/os/scripts/verify-image-reproducibility.mjs --build-a A --build-b B
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   fileExists,
   parseArgs,
@@ -218,12 +219,17 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const allowAbsent = args["allow-absent"] === true;
 
-  if (typeof args["build-a"] === "string" || typeof args["build-b"] === "string") {
+  if (
+    typeof args["build-a"] === "string" ||
+    typeof args["build-b"] === "string"
+  ) {
     if (
       typeof args["build-a"] !== "string" ||
       typeof args["build-b"] !== "string"
     ) {
-      console.error("error: double-build mode needs both --build-a and --build-b");
+      console.error(
+        "error: double-build mode needs both --build-a and --build-b",
+      );
       process.exit(2);
     }
     const [manifestA, manifestB] = await Promise.all([
@@ -243,7 +249,9 @@ async function main() {
     });
     if (!result.ok) {
       for (const error of result.errors) console.error(`error: ${error}`);
-      console.error("confidential-image-reproducibility (double-build): FAIL-CLOSED");
+      console.error(
+        "confidential-image-reproducibility (double-build): FAIL-CLOSED",
+      );
       process.exit(1);
     }
     console.log(
@@ -266,7 +274,9 @@ async function main() {
           "packages/os/linux/confidential/image-manifest.example.json",
         );
   const componentsDir =
-    typeof args["components-dir"] === "string" ? args["components-dir"] : undefined;
+    typeof args["components-dir"] === "string"
+      ? args["components-dir"]
+      : undefined;
   const manifest = await readJson(input);
   const result = await verifyManifest(manifest, componentsDir, { allowAbsent });
 
@@ -278,7 +288,9 @@ async function main() {
   if (result.blocked) {
     for (const error of result.errors) console.error(`  ${error}`);
     if (result.verified.length > 0) {
-      console.error(`  (recomputed-and-matched: ${result.verified.join(", ")})`);
+      console.error(
+        `  (recomputed-and-matched: ${result.verified.join(", ")})`,
+      );
     }
     console.error("confidential-image-reproducibility: BLOCKED (exit 3)");
     process.exit(3);
@@ -289,6 +301,6 @@ async function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main();
 }


### PR DESCRIPTION
## Problem

The `packages/os/scripts` release / confidential-image / TEE pipeline is broken on Windows in two systematic ways:

1. **`repoRoot` doubles the drive letter.** `os-release-lib.mjs` (and 2 test files) derive the repo root via `path.resolve(new URL("../../..", import.meta.url).pathname)`. On Windows `.pathname` is `/C:/Users/.../eliza`, so `path.resolve` yields `C:\C:\Users\...` — every one of the **16 scripts** importing this lib then opens manifests at a non-existent doubled-drive path (`ENOENT`). Verified live: `node validate-release-manifest.mjs` → `ENOENT … open 'C:\C:\Users\...\manifest.json'`.
2. **Entry-point guard never matches.** **10 CLI scripts** guard `main()` with ``if (import.meta.url === `file://${process.argv[1]}`)``. On Windows `import.meta.url` is `file:///C:/…` (forward slashes, 3 slashes) while ``file://${argv[1]}`` is `file://C:\…` (backslashes, 2 slashes) — they never match, so `main()` is **silently skipped and the CLI exits 0 as a no-op**. Verified: `tee-evidence-bridge.mjs --quote-source tappd` exited 0 (should fail-closed with exit 2) before the fix.

Net effect: the entire OS release/TEE validation pipeline is a no-op-or-crash on Windows, and its test suite fails (3 pass / 4 fail).

## Fix (mechanical, two patterns)

- **`repoRoot`**: `import { fileURLToPath } from "node:url"` and use `path.resolve(fileURLToPath(new URL(...)))` in `os-release-lib.mjs` + the 2 test files. (Imports re-sorted by Biome.)
- **Entry-point guard**: `import { pathToFileURL } from "node:url"` and use `if (import.meta.url === pathToFileURL(process.argv[1]).href)` across all 10 CLI scripts (`tee-evidence-bridge`, `tee-state-volume-mount`, `verify-image-reproducibility`, `generate-confidential-artifacts`, `check-dstack-pins`, `check-confidential-{artifacts,image-manifest,layer,policy,profile}`).
- **Test-only**: replaced a POSIX `execFileAsync("mkdir", ["-p", …])` (no such binary under Windows `cmd`) with `fs/promises` `mkdir(recursive: true)`.

`pathToFileURL(...).href` / `fileURLToPath(...)` are the canonical, host-agnostic forms and are byte-identical to the old behavior on POSIX (no Linux/macOS change).

## Evidence (verified on Windows 11)

```
# release pipeline path is now correct (no doubled drive; remaining ENOENT is just the un-checked-in fixture)
validate-release-manifest.mjs -> opens C:\Users\...\manifest.json   (was C:\C:\Users\...)

# TEE CLI now fail-closes instead of no-op
tee-evidence-bridge.mjs --quote-source tappd -> EXIT 2 + "real quote collection is BLOCKED ..."   (was EXIT 0, no output)

# test suite
node --test os-release-scripts.test.mjs -> tests 19, pass 7, fail 0, skipped 12   (was pass 3 / fail 4)
```

`biome check` clean (no errors); `node --check` passes on all 11 scripts.

Note: `tee-evidence-bridge.test.mjs` still requires the un-checked-in confidential manifest fixture (red on all platforms without it); its `repoRoot` is fixed here so it works on Windows once that fixture exists.

Found by an adversarially-verified cross-platform build audit (the mac/iOS/Linux/Android findings are filed separately as an issue).
