### PR TITLE
fix(build): resolve tsc via bunx in 3 plugin build.ts (silent no-.d.ts on Windows)

### DIFF
--- a/plugins/plugin-embeddings/build.ts
+++ b/plugins/plugin-embeddings/build.ts
@@ -61,15 +61,12 @@ await build({
 console.log("Generating TypeScript declarations...");
 const { mkdir, writeFile } = await import("node:fs/promises");
 const { $ } = await import("bun");
-const tscPath = join(
-  ROOT,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "tsc.exe" : "tsc"
-);
-
 try {
-  await $`${tscPath} --project tsconfig.build.json`;
+  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
+  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
+  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
+  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
+  await $`bunx tsc --project tsconfig.build.json`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."

--- a/plugins/plugin-lmstudio/build.ts
+++ b/plugins/plugin-lmstudio/build.ts
@@ -61,15 +61,12 @@ await build({
 console.log("Generating TypeScript declarations...");
 const { mkdir, writeFile } = await import("node:fs/promises");
 const { $ } = await import("bun");
-const tscPath = join(
-  ROOT,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "tsc.exe" : "tsc"
-);
-
 try {
-  await $`${tscPath} --project tsconfig.build.json`;
+  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
+  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
+  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
+  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
+  await $`bunx tsc --project tsconfig.build.json`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."

--- a/plugins/plugin-ollama/build.ts
+++ b/plugins/plugin-ollama/build.ts
@@ -59,15 +59,12 @@ await build({
 console.log("Generating TypeScript declarations...");
 const { mkdir, writeFile } = await import("node:fs/promises");
 const { $ } = await import("bun");
-const tscPath = join(
-  ROOT,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "tsc.exe" : "tsc"
-);
-
 try {
-  await $`${tscPath} --project tsconfig.build.json`;
+  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
+  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
+  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
+  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
+  await $`bunx tsc --project tsconfig.build.json`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."


### PR DESCRIPTION
## Problem

`plugin-embeddings`, `plugin-lmstudio`, and `plugin-ollama` each generate declarations in `build.ts` by spawning a **hardcoded per-plugin** tsc path:

```ts
const tscPath = join(ROOT, "node_modules", ".bin", process.platform === "win32" ? "tsc.exe" : "tsc");
try { await $`${tscPath} --project tsconfig.build.json`; } catch { /* warn, continue */ }
```

`ROOT` is the plugin dir, but Bun **hoists** `tsc` to the **repo-root** `node_modules/.bin`, so `plugins/<plugin>/node_modules/.bin/tsc.exe` does not exist. On Windows the spawn throws `command not found: …\tsc.exe`, the `catch` swallows it with a warning, and **the build reports success while emitting no fresh `.d.ts`**. Verified live in a full `bun run build`: `@elizaos/plugin-embeddings:build: bun: command not found: C:\...\plugins\plugin-embeddings\node_modules\.bin\tsc.exe` → `Build complete!` with stale/absent declarations. (`lmstudio`/`ollama` happen to pass today only because Bun also created a local `.bin/tsc.exe` for them — latent, breaks if hoisting changes.)

## Fix

Resolve tsc through Bun's PATH resolution with `bunx` instead of a hardcoded `.bin` path:

```ts
await $`bunx tsc --project tsconfig.build.json`;
```

`bunx tsc` finds the hoisted compiler on every platform. (A bare `$`tsc …`` does **not** work — Bun's `$` doesn't search `node_modules/.bin` directly — so `bunx` is required.) The `join`/`ROOT`/`process.platform` branch is removed.

## Evidence (verified on Windows 11)

```
before: @elizaos/plugin-embeddings:build -> 'command not found: ...tsc.exe' (swallowed) -> no fresh dist/node/index.d.ts
after:  bun run --cwd plugins/plugin-embeddings build -> 'Build complete!' (no 'command not found') -> dist/node/index.d.ts EMITTED
bunx tsc --project tsconfig.build.json  -> exit 0
```

`biome check` clean on all 3 files. Found by an adversarially-verified cross-platform build audit.