### PR TITLE
fix(mobile): unblock the Android build on Windows (gradlew.bat + Windows SDK/JDK auto-detect)

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -314,8 +314,23 @@ function withMobileBuildNodeOptions(env = process.env) {
 }
 
 function run(command, args, { cwd, env = process.env } = {}) {
+  // Windows: gradlew is gradlew.bat, and Node cannot spawn `./gradlew` (ENOENT)
+  // nor a .bat/.cmd directly (EINVAL since CVE-2024-27980). Translate
+  // ./gradlew -> the sibling gradlew.bat (resolved against cwd) and run any
+  // .bat/.cmd through cmd.exe with args as separate argv (no shell:true).
+  let spawnCmd = command;
+  let spawnArgs = args;
+  if (process.platform === "win32") {
+    if (command === "./gradlew" || command === "gradlew") {
+      spawnCmd = path.join(cwd || process.cwd(), "gradlew.bat");
+    }
+    if (/.(?:bat|cmd)$/i.test(spawnCmd)) {
+      spawnArgs = ["/d", "/s", "/c", spawnCmd, ...args];
+      spawnCmd = process.env.ComSpec || "cmd.exe";
+    }
+  }
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env, stdio: "inherit" });
+    const child = spawn(spawnCmd, spawnArgs, { cwd, env, stdio: "inherit" });
     child.on("exit", (code, signal) => {
       if (signal) return reject(new Error(`${command} killed by ${signal}`));
       if ((code ?? 1) !== 0)
@@ -409,6 +424,11 @@ function resolveAndroidSdkRoot() {
     process.env.ANDROID_HOME,
     path.join(os.homedir(), "Library", "Android", "sdk"),
     path.join(os.homedir(), "Android", "Sdk"),
+    path.join(
+      process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"),
+      "Android",
+      "Sdk",
+    ),
   ]);
 }
 
@@ -469,6 +489,17 @@ function resolveJavaHome() {
     for (const name of fs.readdirSync(jvmRoot)) {
       const full = path.join(jvmRoot, name);
       if ((javaMajorVersion(full) ?? 0) >= 21) return full;
+    }
+  }
+  if (process.platform === "win32") {
+    const programFiles = process.env.ProgramFiles || "C:\Program Files";
+    for (const vendor of ["Eclipse Adoptium", "Microsoft", "Java", "Zulu"]) {
+      const vendorRoot = path.join(programFiles, vendor);
+      if (!fs.existsSync(vendorRoot)) continue;
+      for (const name of fs.readdirSync(vendorRoot)) {
+        const full = path.join(vendorRoot, name);
+        if ((javaMajorVersion(full) ?? 0) >= 21) return full;
+      }
     }
   }
   // Nothing >= 21 found — return the first path that exists so the caller's


### PR DESCRIPTION
## Problem

The mobile build orchestrator (`packages/app-core/scripts/run-mobile-build.mjs`) cannot run the Android native build on Windows:

1. **`./gradlew` spawn → ENOENT.** All Android targets shell out to `./gradlew` (8 sites) through `run()`, which does `spawn(command, args, { stdio: "inherit" })` with no shell. `gradlew.bat` ships next to `gradlew` in `platforms/android/`, but Node can't spawn `./gradlew` on Windows (ENOENT) and can't spawn a `.bat` directly either (EINVAL since CVE-2024-27980). Empirically verified on Windows 11: `spawn('./gradlew', ['--version'])` → `ENOENT`. There's no `win32` guard in any `buildAndroid*`, so every Android target dies at the native phase.
2. **`resolveAndroidSdkRoot()` / `resolveJavaHome()` only probe mac/Linux paths.** SDK auto-detect checks `~/Library/Android/sdk` (mac) and `~/Android/Sdk` (Linux) but never the Windows default `%LOCALAPPDATA%\Android\Sdk`. JDK auto-detect probes `/opt/homebrew/...`, `/usr/lib/jvm/...` only. So on Windows the build only works if `ANDROID_SDK_ROOT`/`JAVA_HOME` are both pre-set — the "just works" convenience is mac/Linux-only.

## Fix

- **Centralized in `run()`** (so all 8 gradlew sites are fixed at once, no per-call-site churn): on win32, translate `./gradlew`/`gradlew` → the sibling `gradlew.bat` (resolved absolute against `cwd`), and run any `.bat`/`.cmd` through `cmd.exe /d /s /c <bat> <args...>` with args passed as **separate argv** (no `shell:true`, so args aren't re-parsed/concatenated). POSIX behavior is unchanged.
- **`resolveAndroidSdkRoot()`**: append `%LOCALAPPDATA%\Android\Sdk` to the candidate list (append-only — mac/Linux paths still checked first).
- **`resolveJavaHome()`**: after the `/usr/lib/jvm` scan, add a Windows scan of `%ProgramFiles%\{Eclipse Adoptium,Microsoft,Java,Zulu}` for a JDK ≥ 21 (mirrors the existing Linux jvm-root scan; append-only, falls through unchanged if none found).

All three changes are additive on POSIX (no behavior change on mac/Linux).

## Evidence (verified on Windows 11)

`run()`'s new win32 path was exercised with a dummy `gradlew.bat` (exact replica of the patched logic):

```
run("./gradlew", ["assembleRelease"], { cwd })  ->  GRADLEW_BAT_RAN arg=assembleRelease   (PASS: ./gradlew -> gradlew.bat via cmd.exe)
```

(The full Android assemble needs an installed SDK/JDK + emulator, which this box lacks; the verified-broken element was the spawn, which this fixes. The SDK/JDK path additions are append-only and cannot regress the existing mac/Linux resolution.) `node --check` parses; `biome check` clean (no errors). Found by an adversarially-verified cross-platform build audit.