### PR TITLE
chore(types): strict-TS Phases 1–4 — noExplicitAny everywhere, close strict opt-outs, real typechecks, −21 casts (#9474)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -166,10 +166,7 @@
       }
     },
     {
-      "includes": [
-        "plugins/**/src/**/*.ts",
-        "!plugins/plugin-personal-assistant/**"
-      ],
+      "includes": ["plugins/**/src/**/*.ts"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/packages/agent/src/api/hono-adapter.ts
+++ b/packages/agent/src/api/hono-adapter.ts
@@ -189,7 +189,7 @@ export function mountRoutesOnHono(
           headers.set("content-type", "text/plain; charset=utf-8");
         }
       } else if (result.body instanceof Uint8Array) {
-        bodyOut = result.body as unknown as BodyInit;
+        bodyOut = result.body as BodyInit;
         if (!headers.has("content-type")) {
           headers.set("content-type", "application/octet-stream");
         }

--- a/packages/agent/tsconfig.bundle.json
+++ b/packages/agent/tsconfig.bundle.json
@@ -19,7 +19,7 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "strict": false,
+    "strict": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,

--- a/packages/app-core/src/api/training-benchmarks.ts
+++ b/packages/app-core/src/api/training-benchmarks.ts
@@ -280,11 +280,11 @@ export function openBenchmarkResultsReader(
         modelId,
         benchmark,
         limit,
-      ) as unknown as DbRunRow[];
+      ) as DbRunRow[];
       return rows.map(rowToDto);
     },
     getLatest({ modelId, benchmark }): BenchmarkRunDTO | null {
-      const rows = latestStmt.all(modelId, benchmark) as unknown as DbRunRow[];
+      const rows = latestStmt.all(modelId, benchmark) as DbRunRow[];
       if (rows.length === 0) return null;
       return rowToDto(rows[0]);
     },

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -1212,7 +1212,7 @@ async function startDeferredVoiceWarmup(runtime: AgentRuntime): Promise<void> {
   }
   logger.info("[eliza] Starting deferred voice warmup");
   await warmVoiceModels(
-    runtime as unknown as Parameters<typeof warmVoiceModels>[0],
+    runtime as Parameters<typeof warmVoiceModels>[0],
     {
       ttsType: ModelType.TEXT_TO_SPEECH,
       transcriptionType: ModelType.TRANSCRIPTION,

--- a/packages/app-core/src/runtime/tts-cache-wiring.ts
+++ b/packages/app-core/src/runtime/tts-cache-wiring.ts
@@ -83,7 +83,7 @@ export async function wrapEdgeTtsHandlerWithFirstLineCache(
   // requires `input: TtsHandlerInput` (concrete union). They are structurally
   // compatible at runtime — the cast bridges the static mismatch.
   const wrapped = wrapWithFirstLineCache(
-    inner as unknown as Parameters<typeof wrapWithFirstLineCache>[0],
+    inner as Parameters<typeof wrapWithFirstLineCache>[0],
     {
       resolveContext: (runtime: IAgentRuntime, input: unknown) => {
         const requestedVoice =
@@ -168,5 +168,5 @@ export async function wrapEdgeTtsHandlerWithFirstLineCache(
 
   // TtsHandler (stricter input) → EdgeTtsHandler (looser input: unknown).
   // Structurally compatible at runtime; cast bridges the static mismatch.
-  return wrapped as unknown as EdgeTtsHandler;
+  return wrapped as EdgeTtsHandler;
 }

--- a/packages/app-core/tsconfig.typecheck.json
+++ b/packages/app-core/tsconfig.typecheck.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
-    "noImplicitAny": false
+    "noEmit": true
   },
   "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"],
   "include": ["src", "test"]

--- a/packages/cloud-shared/src/db/repositories/agents/memories.ts
+++ b/packages/cloud-shared/src/db/repositories/agents/memories.ts
@@ -413,7 +413,7 @@ export class MemoriesRepository {
       })
       // Drizzle's .returning() infers the insert model type, not InferSelectModel.
       // The DB returns all columns; the cast to MemoryRow is safe.
-      .returning()) as unknown as MemoryRow[];
+      .returning()) as MemoryRow[];
     const memoryResult = memoryResults[0];
 
     if (!memoryResult) {

--- a/packages/cloud-shared/src/lib/services/agents/rooms.ts
+++ b/packages/cloud-shared/src/lib/services/agents/rooms.ts
@@ -270,7 +270,7 @@ export class RoomsService {
         } as typeof roomTable.$inferInsert)
         // Drizzle's .returning() infers the insert model type, not the select
         // model / elizaOS Room shape. The DB returns all columns; the cast is safe.
-        .returning()) as unknown as Room[];
+        .returning()) as Room[];
       const room = rows[0];
 
       // Create entity (upsert - ignore if exists)

--- a/packages/feed/apps/web/src/contexts/EmbedContext.tsx
+++ b/packages/feed/apps/web/src/contexts/EmbedContext.tsx
@@ -109,7 +109,7 @@ export function EmbedModeProvider({ children }: { children: ReactNode }) {
 
       if (id) {
         setAgentId(id);
-        (window as unknown as Record<string, unknown>).__feedEmbedAgentId = id;
+        (window as Record<string, unknown>).__feedEmbedAgentId = id;
       }
       setParentOrigin(event.origin);
 
@@ -118,14 +118,14 @@ export function EmbedModeProvider({ children }: { children: ReactNode }) {
         void authenticateWithCredentials(id, secret).then((sessionToken) => {
           if (sessionToken) {
             setAgentSessionToken(sessionToken);
-            (window as unknown as Record<string, unknown>).__feedEmbedToken =
+            (window as Record<string, unknown>).__feedEmbedToken =
               sessionToken;
           }
         });
       } else if (secret) {
         // Fallback: use the token directly (pre-authenticated session token)
         setAgentSessionToken(secret);
-        (window as unknown as Record<string, unknown>).__feedEmbedToken =
+        (window as Record<string, unknown>).__feedEmbedToken =
           secret;
       }
     }

--- a/packages/feed/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/feed/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -350,7 +350,7 @@ export class AutonomousCoordinator {
     if (recordTrajectories) {
       // Enrich NPC trajectories with world state context
       // Derive archetype from character sheet metadata
-      const feedMeta = (runtime.character as unknown as Record<string, unknown>)
+      const feedMeta = (runtime.character as Record<string, unknown>)
         ?.feed as Record<string, unknown> | undefined;
       const archetype = feedMeta
         ? deriveArchetype(

--- a/packages/feed/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/feed/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -324,7 +324,7 @@ export class MultiStepExecutor {
       const autonomy = (runtime.character as unknown as Record<string, unknown>)
         ?.feed
         ? (
-            (runtime.character as unknown as Record<string, unknown>).feed as {
+            (runtime.character as Record<string, unknown>).feed as {
               autonomy?: {
                 trading: boolean;
                 posting: boolean;

--- a/packages/feed/packages/agents/src/autonomous/agent-identity-map.ts
+++ b/packages/feed/packages/agents/src/autonomous/agent-identity-map.ts
@@ -35,7 +35,7 @@ export async function buildAgentIdentityMap(): Promise<
   try {
     const allActors = StaticDataRegistry.getAllActors();
     for (const actor of allActors) {
-      const feed = (actor as unknown as Record<string, unknown>).feed as
+      const feed = (actor as Record<string, unknown>).feed as
         | Record<string, unknown>
         | undefined;
       if (!feed) continue;
@@ -90,7 +90,7 @@ export async function populateIdentityMapOnRuntime(
   // Store this agent's own alignment for downstream use
   if (isNpc) {
     const feed = (
-      runtime.character as unknown as { feed?: Record<string, unknown> }
+      runtime.character as { feed?: Record<string, unknown> }
     ).feed;
     (runtime as { _agentTeam?: string })._agentTeam =
       (feed?.team as string) ?? "gray";

--- a/packages/feed/packages/agents/src/plugins/feed/integration-a2a-sdk.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/integration-a2a-sdk.ts
@@ -242,10 +242,10 @@ function createAuthenticatedFetchForAgent(
   };
 
   // Bun may expose a non-standard `fetch.preconnect`; preserve it when present.
-  const maybePreconnect = (fetch as unknown as { preconnect?: unknown })
+  const maybePreconnect = (fetch as { preconnect?: unknown })
     .preconnect;
   if (maybePreconnect) {
-    (customFetch as unknown as { preconnect?: unknown }).preconnect =
+    (customFetch as { preconnect?: unknown }).preconnect =
       maybePreconnect;
   }
 

--- a/packages/feed/packages/api/src/sse/event-broadcaster.ts
+++ b/packages/feed/packages/api/src/sse/event-broadcaster.ts
@@ -103,7 +103,7 @@ export async function broadcastChatMessage(
   // Cast to JsonValue for type compatibility - metadata may contain complex nested types
   await broadcastToChannel(`chat:${chatId}`, {
     type: "new_message",
-    message: message as unknown as JsonValue,
+    message: message as JsonValue,
   });
 }
 
@@ -122,7 +122,7 @@ export async function broadcastChatMessageReaction(
 ): Promise<void> {
   await broadcastToChannel(`chat:${chatId}`, {
     type: "message_reaction",
-    reaction: reaction as unknown as JsonValue,
+    reaction: reaction as JsonValue,
   });
 }
 
@@ -224,7 +224,7 @@ export async function broadcastAgentActivity(
   // Cast to Record<string, JsonValue> for type compatibility with broadcastToChannel
   await broadcastToChannel(`agent:${agentId}`, {
     type: `agent_${activityType}`,
-    activity: activity as unknown as JsonValue,
+    activity: activity as JsonValue,
   });
 }
 

--- a/packages/feed/packages/engine/src/GameGenerator.ts
+++ b/packages/feed/packages/engine/src/GameGenerator.ts
@@ -1565,7 +1565,7 @@ REMINDER: Generate SCENARIOS only. Do NOT generate questions.`;
           }
 
           return {
-            ...(question as unknown as Record<string, unknown>),
+            ...(question as Record<string, unknown>),
             __groupedScenarioHint: groupIndex + 1,
           };
         });

--- a/packages/feed/packages/sim/cli/commands/dev.ts
+++ b/packages/feed/packages/sim/cli/commands/dev.ts
@@ -116,7 +116,7 @@ export default defineCommand({
       watchState.systemsWatcher = watch(nextDir, {
         ignoreInitial: true,
         awaitWriteFinish: { stabilityThreshold: 200 },
-      }) as unknown as SystemsWatcher;
+      }) as SystemsWatcher;
 
       watchState.systemsWatcher.on("all", (event, path) => {
         consola.info(`System ${event}: ${path}`);

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-25T05:27:06.748Z",
+  "updatedAt": "2026-06-25T08:25:06.946Z",
   "scope": {
     "trackedOnly": true,
     "globs": [
@@ -36,10 +36,10 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 320,
+    "asUnknownAs": 299,
     "asAny": 0,
     "tsSuppress": 0,
     "nonNullAssertion": 577
   },
-  "filesScanned": 9982
+  "filesScanned": 9985
 }

--- a/plugins/plugin-hyperliquid-app/package.json
+++ b/plugins/plugin-hyperliquid-app/package.json
@@ -51,6 +51,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "bun run build:js && bun run build:views && bun run build:types",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "test": "vitest run --config vitest.config.ts",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",

--- a/plugins/plugin-polymarket-app/package.json
+++ b/plugins/plugin-polymarket-app/package.json
@@ -51,6 +51,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "bun run build:js && bun run build:views && bun run build:types",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "test": "vitest run --config vitest.config.ts",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",

--- a/plugins/plugin-task-coordinator/package.json
+++ b/plugins/plugin-task-coordinator/package.json
@@ -50,6 +50,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "bun run build:js && bun run build:views && bun run build:types",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",


### PR DESCRIPTION
Advances #9474 across four phases, each commit independently verified.

## Phase 1 — `noExplicitAny: error` everywhere (`3780d3670d`)
`plugin-personal-assistant` was the last production-source opt-out (excluded via `!plugins/plugin-personal-assistant/**`). biome confirms PA src has **0** explicit-any, so the exclusion was stale. Dropping it makes `noExplicitAny: error` cover **all** `packages/**/src` + `plugins/**/src`. ✅ *Done-when: no production package opts out of the explicit-any gate.*

## Phase 2 — close the strict / noImplicitAny opt-outs (`932d8f6e00`)
- `packages/app-core/tsconfig.typecheck.json`: drop `noImplicitAny: false` — the lane is already clean (`tsc -p tsconfig.typecheck.json` = **0 errors** with deps built).
- `packages/agent/tsconfig.bundle.json`: `strict: false → true` (bundler-only config; `Bun.build` ignores strictness, so inert but closes the listed gap). The real agent typecheck (`tsgo -p tsconfig.json`) was already `strict:true` on develop and stays at **0 errors**.

## Phase 3 — real typechecks for `--noCheck`-only plugins (`15b61dd8fd`)
`plugin-polymarket-app`, `plugin-task-coordinator`, `plugin-hyperliquid-app` had only `build:types` (`tsc --noCheck`) and no `typecheck`, so turbo skipped them. Each is type-clean → added `typecheck: tsc --noEmit -p tsconfig.build.json` (verified **0 errors** each). Now covered by `bun run typecheck`.

## Phase 4 — drop 21 redundant `as unknown as` double-casts (`49538eed41`)
Downgraded double-casts to a single assertion ONLY where tsc proves the `unknown` step is noise (feed widening casts, agent `Uint8Array→BodyInit`, app-core SQLite/TTS/warm-args, cloud-shared drizzle `.returning()`). **Ratchet baseline 320 → 299**; as-any stays 0.

> The cast burn-down was driven by a 10-package parallel analysis. Of ~51 proposed removals, **~30 were rejected here** because tsc proved the `unknown` step is *required* (specific→specific narrowings: TS2352) — they are genuine boundary casts needing validators, not sweepable. Every kept removal is verified at 0 real errors in its package.

## Verification
- `type-safety-ratchet`: **299/299** as-unknown-as, **0/0** as-any (exit 0) + self-test passes.
- Per-package `tsc --noEmit`: agent / app-core / cloud-shared / feed / the 3 new-typecheck plugins all **0 real errors** (deps built; `TS2307` module-resolution noise excluded).
- biome lint clean on all changed source.

## Remaining (documented on the issue — large/multi-session)
- **Phase 3 tail**: `plugin-shopify-ui` (needs `@types/node` devDep), `plugin-training` (TS6059 cross-package rootDir restructure), `plugin-personal-assistant` (dirty baseline).
- **Phase 5**: typed `createMockRuntime(): IAgentRuntime` — IAgentRuntime is **256 members**; **310 test files / 430 casts** to migrate.
- **Phase 6**: `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` in `tsconfig.base.json` (widest blast radius — last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)