### PR TITLE
docs: point visual audit docs at app package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ packages/        framework, shared libraries, and product surfaces
   scenario-runner/ scenario + eval harness
   sweagent/      SWE-bench style coding-agent harness
   cloud-api/     managed backend API (Hono on Cloudflare Workers)
-  cloud-frontend/ cloud dashboard (Vite + React) — see visual-review gate below
+  app/           web + desktop dashboard; also hosts the current cloud apex UI
   cloud-shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud-sdk/ cloud-routing/ cloud-infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
@@ -133,26 +133,25 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
-## Cloud frontend visual review — REQUIRED for any UI change in `packages/cloud-frontend/`
+## App visual review — REQUIRED for UI changes in `packages/app/`
 
-Any change in `packages/cloud-frontend/` (or a shared package whose UI bleeds
-into it) MUST pass the screenshot + manual-review loop before it is "done":
+Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST
+pass the screenshot + manual-review loop before it is "done":
 
 ```bash
-bun run --cwd packages/cloud-frontend audit:cloud
+bun run --cwd packages/app audit:app
 ```
 
-This walks every route in `src/App.tsx` (desktop + mobile, rest + hover), logs
-in with the synthetic injected-ethereum JWT, captures the populated UI, and
-auto-stubs `aesthetic-audit-output/manual-review/<slug>.md` per route. Fill in
-the verdict (`good` · `needs-work` · `needs-eyeball` · `broken`) for every page
-you touched or can reach via shared layout/theme/components.
+This walks the app views (desktop + mobile, rest + hover), captures the
+populated UI, and auto-stubs `aesthetic-audit-output/manual-review/<slug>.md`
+per view. Fill in the verdict (`good` · `needs-work` · `needs-eyeball` ·
+`broken`) for every page you touched or can reach via shared
+layout/theme/components.
 
 - No page may stay `needs-work` / `broken` when a UI task is declared done.
 - Iterate the loop ≥5× for any meaningful redesign.
 - Orange is accent only; no blue anywhere; orange-resting → darker-orange hover
-  (never orange→black). Full rules: `packages/cloud-frontend/AGENTS.md`,
-  `packages/cloud-frontend/docs/HOVER_SYSTEM.md`.
+  (never orange→black). Full package rules: `packages/app/AGENTS.md`.
 
 ## LifeOps + health: one scheduler, structural behavior
 
@@ -209,8 +208,8 @@ be able to confirm it works **without reading the code**. Full standard:
   - **Backend logs** (structured `[ClassName] …`) and **frontend logs**
     (console + network) showing the actual code path.
   - **Before/after full-page screenshots** + a **video walkthrough** of the
-    flow — `bun run test:e2e:record`; for cloud-frontend,
-    `bun run --cwd packages/cloud-frontend audit:cloud`.
+    flow — `bun run test:e2e:record`; for app UI,
+    `bun run --cwd packages/app audit:app`.
   - **Audio + narrated walkthrough** for voice/transcript/TTS/STT changes.
   - Artifacts land in `.github/issue-evidence/<issue#>-<slug>.<ext>` (see that
     dir's `README.md`). Each evidence type is attached **or** explicitly marked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ packages/        framework, shared libraries, and product surfaces
   scenario-runner/ scenario + eval harness
   sweagent/      SWE-bench style coding-agent harness
   cloud-api/     managed backend API (Hono on Cloudflare Workers)
-  cloud-frontend/ cloud dashboard (Vite + React) — see visual-review gate below
+  app/           web + desktop dashboard; also hosts the current cloud apex UI
   cloud-shared/  shared cloud backend: db (Drizzle), billing, services, types
   cloud-sdk/ cloud-routing/ cloud-infra/  cloud client SDK, model routing, IaC
   contracts/     on-chain contracts + ABIs
@@ -133,26 +133,25 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
-## Cloud frontend visual review — REQUIRED for any UI change in `packages/cloud-frontend/`
+## App visual review — REQUIRED for UI changes in `packages/app/`
 
-Any change in `packages/cloud-frontend/` (or a shared package whose UI bleeds
-into it) MUST pass the screenshot + manual-review loop before it is "done":
+Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST
+pass the screenshot + manual-review loop before it is "done":
 
 ```bash
-bun run --cwd packages/cloud-frontend audit:cloud
+bun run --cwd packages/app audit:app
 ```
 
-This walks every route in `src/App.tsx` (desktop + mobile, rest + hover), logs
-in with the synthetic injected-ethereum JWT, captures the populated UI, and
-auto-stubs `aesthetic-audit-output/manual-review/<slug>.md` per route. Fill in
-the verdict (`good` · `needs-work` · `needs-eyeball` · `broken`) for every page
-you touched or can reach via shared layout/theme/components.
+This walks the app views (desktop + mobile, rest + hover), captures the
+populated UI, and auto-stubs `aesthetic-audit-output/manual-review/<slug>.md`
+per view. Fill in the verdict (`good` · `needs-work` · `needs-eyeball` ·
+`broken`) for every page you touched or can reach via shared
+layout/theme/components.
 
 - No page may stay `needs-work` / `broken` when a UI task is declared done.
 - Iterate the loop ≥5× for any meaningful redesign.
 - Orange is accent only; no blue anywhere; orange-resting → darker-orange hover
-  (never orange→black). Full rules: `packages/cloud-frontend/AGENTS.md`,
-  `packages/cloud-frontend/docs/HOVER_SYSTEM.md`.
+  (never orange→black). Full package rules: `packages/app/AGENTS.md`.
 
 ## LifeOps + health: one scheduler, structural behavior
 
@@ -209,8 +208,8 @@ be able to confirm it works **without reading the code**. Full standard:
   - **Backend logs** (structured `[ClassName] …`) and **frontend logs**
     (console + network) showing the actual code path.
   - **Before/after full-page screenshots** + a **video walkthrough** of the
-    flow — `bun run test:e2e:record`; for cloud-frontend,
-    `bun run --cwd packages/cloud-frontend audit:cloud`.
+    flow — `bun run test:e2e:record`; for app UI,
+    `bun run --cwd packages/app audit:app`.
   - **Audio + narrated walkthrough** for voice/transcript/TTS/STT changes.
   - Artifacts land in `.github/issue-evidence/<issue#>-<slug>.<ext>` (see that
     dir's `README.md`). Each evidence type is attached **or** explicitly marked

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Full reference: `elizaos --help` or `elizaos <command> --help`.
 
 ## Local mock stack
 
-One command boots the full local cloud stack with mocks (Hetzner + control-plane + cloud-api with `MOCK_REDIS` + PGlite, plus cloud-frontend):
+One command boots the local cloud backend stack with mocks (Hetzner + control-plane + cloud-api with `MOCK_REDIS` + PGlite). The standalone `packages/cloud-frontend` app was consolidated into `packages/app`, so the mock stack skips frontend boot when that removed package is absent.
 
 ```bash
 bun run cloud:mock          # boot with existing PGlite data

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -84,6 +84,7 @@ bun run --cwd packages/app typecheck                  # tsc --noEmit
 bun run --cwd packages/app test                       # Vitest unit tests
 bun run --cwd packages/app test:watch                 # Vitest watch mode
 bun run --cwd packages/app test:e2e                   # Playwright UI smoke (ui-smoke config)
+bun run --cwd packages/app audit:app                  # All-views visual audit + manual-review stubs
 bun run --cwd packages/app test:dev-smoke             # Playwright dev-smoke config
 bun run --cwd packages/app test:hmr                   # HMR smoke tests
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -84,6 +84,7 @@ bun run --cwd packages/app typecheck                  # tsc --noEmit
 bun run --cwd packages/app test                       # Vitest unit tests
 bun run --cwd packages/app test:watch                 # Vitest watch mode
 bun run --cwd packages/app test:e2e                   # Playwright UI smoke (ui-smoke config)
+bun run --cwd packages/app audit:app                  # All-views visual audit + manual-review stubs
 bun run --cwd packages/app test:dev-smoke             # Playwright dev-smoke config
 bun run --cwd packages/app test:hmr                   # HMR smoke tests
 


### PR DESCRIPTION
## Summary
- replace stale root `packages/cloud-frontend` visual-review guidance with the current `packages/app audit:app` flow
- add `audit:app` to the package-local app command guide
- clarify that `cloud:mock` now boots the backend mock stack and skips the removed standalone cloud frontend

## Scan notes
- dependency drift exists across shared dev/runtime dependencies (`typescript`, `@types/node`, `vitest`, `react`, `bun-types`, `hono`, `@electric-sql/pglite`, etc.), but broad version alignment would require lockfile churn and package-owner review
- command-doc mismatch scan found the removed `packages/cloud-frontend audit:cloud` guidance as a scoped stale-doc/DX issue

## Verification
- `git diff --check`
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/app/package.json','utf8')); if(!p.scripts['audit:app']) process.exit(1); console.log(p.scripts['audit:app'])"`
- `cmp -s CLAUDE.md AGENTS.md && echo root-agent-docs-identical`
- `rg -n "bun run --cwd packages/cloud-frontend audit:cloud|cloud-frontend/ cloud dashboard|Cloud frontend visual review" CLAUDE.md AGENTS.md README.md packages/app/CLAUDE.md packages/app/AGENTS.md || true`
