### PR TITLE
perf(turbo): scope build `inputs` so test/doc edits don't bust the build cache (#9626)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,15 @@
     "build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "env": ["LOG_LEVEL"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/__tests__/**",
+        "!**/*.md"
+      ]
     },
     "@elizaos-benchmarks/lib#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],


### PR DESCRIPTION
Part of #9626 (TL;DR #1 — Turbo caching).

## Problem

The generic `build` task declared no `inputs`, so Turbo's default hash includes **every** tracked file in a package. Editing a co-located test, a `__tests__/` fixture, or a markdown doc invalidates that package's `build` cache even though the build only consumes `src/` + build config. (Only `@elizaos/core#build` scoped its inputs.)

## Fix

Add `inputs` to the generic `build` task using `$TURBO_DEFAULT$` + exclusions for files that provably cannot affect build output:

```json
"inputs": ["$TURBO_DEFAULT$", "!**/*.test.ts", "!**/*.test.tsx", "!**/*.spec.ts", "!**/__tests__/**", "!**/*.md"]
```

Starting from `$TURBO_DEFAULT$` (the full default set) and only **excluding** test/markdown files means this cannot accidentally narrow away a real build input — it strictly removes build-irrelevant files from the cache key.

## Scope / limitation

This applies to every package whose `build` task **inherits** the generic task (the ~80 packages without a `#build` override in `turbo.json`). The ~68 packages that carry an explicit `#build` override don't inherit it; bringing them in is entangled with the `dependsOn`-drift + circular-dependency cleanup (also in #9626) and is intentionally left for that follow-up rather than bolted on here.

## Evidence (verified on this box, Turbo 2.9.18)

`turbo run build --filter=@elizaos/plugin-music --dry-run=json` (an override-less package):

```
resolved inputs: ["!**/*.md", "!**/*.spec.ts", "!**/*.test.ts", "!**/*.test.tsx", "!**/__tests__/**", "$TURBO_DEFAULT$"]
hashed files: 83   |   .test/.spec/.md files still hashed: 0   (was: included)
```

turbo.json remains valid JSON and Turbo accepts the config (dry-run clean).