### PR TITLE
fix(turbo): scope generic build inputs + stop caching prompts cross-package gen (#9626)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,25 @@
     "build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "env": ["LOG_LEVEL"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": [
+        "src/**",
+        "index.ts",
+        "index.node.ts",
+        "index.browser.ts",
+        "build.ts",
+        "build.mjs",
+        "tsup.config.ts",
+        "tsup.config.*.ts",
+        "tsdown.config.ts",
+        "vite.config.ts",
+        "vite.config.*.ts",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json",
+        "assets/**",
+        "public/**"
+      ]
     },
     "@elizaos-benchmarks/lib#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
@@ -34,7 +52,8 @@
     },
     "@elizaos/prompts#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
-      "outputs": []
+      "outputs": [],
+      "cache": false
     },
     "eliza-vrm-demo#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],


### PR DESCRIPTION
First slice of the build audit #9626 — the TL;DR #1 caching wins that are safe + verifiable:

**1. Generic `build` task now scopes `inputs`.** 73 of 75 build tasks declared no `inputs`, so any tracked-file change (README, test, fixture, docs) busted the build cache. Added a shared `inputs` glob to the generic `build` task — `src/**` + root `index.{ts,node.ts,browser.ts}` + the build-config files (`build.ts`/`build.mjs`/`tsup`/`tsdown`/`vite`/`tsconfig*`/`package.json`) + `assets`/`public`. Mirrors the proven `@elizaos/core#build` scoping. (This helps the ~28 packages on the generic task; deleting the 74 `#build` overrides so the rest inherit it is the follow-up gated on the circular-dep break, per the issue.)

**2. `@elizaos/prompts#build` → `cache: false` (correctness).** Confirmed its `generate-action-docs.js` writes **cross-package** into `packages/core/src/generated/action-docs.ts` (consumed by `@elizaos/core`) — which Turbo can't capture as a package-local output. With `outputs:[]`, a cache **hit** skipped regeneration and could leave core's generated file stale. `cache:false` guarantees it always regenerates (the issue's offered option).

**Verified:** `turbo run build --dry-run=json` — config parses (only the pre-existing bun.lock-v2 + circular-dep warnings remain), `prompts#build` resolves to `cache:false`, and generic-build packages (e.g. `@elizaos/ui`) now hash the scoped input set instead of all files. The build commands themselves are unchanged (this only narrows cache-key hashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
