### PR TITLE
chore(types): real typechecks for shopify-ui + training (#9474 Phase 3 cont.)

### DIFF
--- a/plugins/plugin-shopify-ui/package.json
+++ b/plugins/plugin-shopify-ui/package.json
@@ -50,6 +50,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "bun run build:js && bun run build:views && bun run build:types",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "test": "vitest run --config vitest.config.ts",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",

--- a/plugins/plugin-shopify-ui/tsconfig.build.json
+++ b/plugins/plugin-shopify-ui/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.build.shared.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node", "react", "react-dom"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]

--- a/plugins/plugin-training/package.json
+++ b/plugins/plugin-training/package.json
@@ -41,6 +41,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build": "bun run build:js && bun run build:views && bun run build:types",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "clean": "rm -rf dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",

--- a/plugins/plugin-training/tsconfig.typecheck.json
+++ b/plugins/plugin-training/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  // Type-check only (no emit). Unlike tsconfig.build.json, this does NOT pin
+  // `rootDir` to ./src: the training CLI legitimately `typeof import()`s a
+  // cross-package helper, and rootDir is an emit-layout constraint that has no
+  // bearing on type safety. Widening rootDir to the repo root keeps every
+  // referenced file in-bounds so type-checking runs without spurious TS6059.
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  }
+}


### PR DESCRIPTION
Continues #9474 Phase 3 — gives two more `--noCheck`-only plugins a real typecheck (now run by turbo).

- **plugin-shopify-ui**: its server routes use `node:http`/`process`/`Buffer`, but the shared build tsconfig left node types out → 7× TS2591. Added `types: ["node","react","react-dom"]` to `tsconfig.build.json` (node for the routes, react for the 17 `.tsx` views) + a `typecheck` script. **0 errors.**
- **plugin-training**: the training CLI legitimately `typeof import()`s a cross-package helper, which tripped `rootDir: ./src` (TS6059). `rootDir` is an emit-layout constraint, not type safety — added a `tsconfig.typecheck.json` that drops it + a `typecheck` script. **0 errors.**

Verified: `bun run typecheck` green for both. Ratchet unaffected (299/299).

Brings real-typecheck-wired `--noCheck` plugins to **5** (with polymarket-app / task-coordinator / hyperliquid-app from #9627).

### Remaining Phase 3 tail
`plugin-personal-assistant` — diagnosed: **26 real errors, not the ~475 in the issue body** (develop improved it massively). Of those, **15** are a plugin-discord emitted-`.d.ts` barrel-resolution issue (the `user-account-scraper` re-export chain resolves file-by-file yet its symbols don't surface to consumers — a plugin-discord packaging bug, not PA), and **11** are real PA type issues (6 cross-plugin service/type mismatches, 4 runtime-service casts needing `as unknown as`, 1 duplicate-type-identity). PA's green typecheck is blocked on the plugin-discord declaration fix → tracked as a scoped follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)