### PR TITLE
feat(voice): self-calibrating playback→mic echo delay + gap-preserving reference buffer (#9583)

### DIFF
--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
@@ -17,6 +17,7 @@
 import type http from "node:http";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
+import { buildLiveDiarizationConsumerDeps } from "../services/voice/live-diarization-session.js";
 import type { CompatRuntimeState } from "./compat-helpers.js";
 import {
 	handleLiveDiarizationRoute,
@@ -90,6 +91,34 @@ afterEach(async () => {
 });
 
 describe("handleLiveDiarizationRoute", () => {
+	it("builds AudioFrameConsumer deps with an optional echoReference provider", () => {
+		const echoReference = () => new Float32Array(320);
+		const deps = buildLiveDiarizationConsumerDeps({
+			vad: {
+				inSpeech: false,
+				onVadEvent: () => () => {},
+				pushFrame: async () => {},
+				flush: async () => {},
+				reset: () => {},
+			},
+			pipeline: {
+				attribute: async () => {
+					throw new Error("not used");
+				},
+			},
+			runtime: { emitEvent: async () => {} },
+			echoReference,
+		});
+		expect(deps.echoReference).toBe(echoReference);
+		expect(
+			buildLiveDiarizationConsumerDeps({
+				vad: deps.vad,
+				pipeline: deps.pipeline,
+				runtime: deps.runtime,
+			}),
+		).not.toHaveProperty("echoReference");
+	});
+
 	it("returns false for an unrelated path (passes through)", async () => {
 		const res = new FakeRes();
 		const handled = await handleLiveDiarizationRoute(
@@ -132,6 +161,7 @@ describe("handleLiveDiarizationRoute", () => {
 			models: { dir: string };
 			framesReceived: number;
 			turnsObserved: number;
+			aec: { echoReferenceWired: boolean };
 			error?: string;
 		};
 		// On CI/host there is no fused libelizainference, so readiness fails with
@@ -142,11 +172,33 @@ describe("handleLiveDiarizationRoute", () => {
 		expect("fusedInference" in status.libs).toBe(true);
 		expect(status.framesReceived).toBe(0);
 		expect(status.turnsObserved).toBe(0);
+		expect(status.aec.echoReferenceWired).toBe(false);
 		if (!status.ready) {
 			expect(status.error).toMatch(
 				/fused libelizainference|ABI|FFI|libelizainference/i,
 			);
 		}
+	});
+
+	it("threads a runtime echoReference provider into live AEC status", async () => {
+		const res = new FakeRes();
+		const echoReference = () => new Float32Array(320);
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({ method: "GET", url: "/api/voice/audio-frames/status" }),
+			res as unknown as http.ServerResponse,
+			{
+				current: {
+					emitEvent: async () => {},
+					voiceEchoReferenceProvider: echoReference,
+				} as never,
+			},
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(200);
+		const status = res.json() as {
+			aec: { echoReferenceWired: boolean };
+		};
+		expect(status.aec.echoReferenceWired).toBe(true);
 	});
 
 	it("rejects a malformed frame batch with 400", async () => {
@@ -244,6 +296,22 @@ describe("handleLiveDiarizationRoute", () => {
 		expect(handled).toBe(true);
 		expect(res.statusCode).toBe(200);
 		expect(res.json()).toMatchObject({ ok: true, framesPushed: 0 });
+	});
+
+	it("resets stale playback before accepting a fresh playback batch", async () => {
+		const res = new FakeRes();
+		const handled = await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { reset: true, frames: [silentFrame(0)] },
+			}),
+			res as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(handled).toBe(true);
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toMatchObject({ ok: true, framesPushed: 1 });
 	});
 
 	it("rejects malformed playback frames with 400", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
@@ -58,4 +58,29 @@ describe("EchoReferenceBuffer (#9583)", () => {
 		expect(buf.position).toBe(0);
 		expect(Array.from(buf.referenceFor(3, 0))).toEqual([0, 0, 0]);
 	});
+
+	it("preserves timestamp gaps between playback bursts", () => {
+		const buf = new EchoReferenceBuffer({
+			capacitySamples: 4000,
+			sampleRateHz: 16_000,
+		});
+		buf.pushAt(1000, ramp(0, 4)); // samples 0..3
+		buf.pushAt(1100, ramp(100, 4)); // samples 1600..1603
+
+		expect(Array.from(buf.referenceAt(1000, 4, 0))).toEqual([1, 2, 3, 4]);
+		expect(Array.from(buf.referenceAt(1050, 4, 0))).toEqual([0, 0, 0, 0]);
+		expect(Array.from(buf.referenceAt(1100, 4, 0))).toEqual([
+			101, 102, 103, 104,
+		]);
+	});
+
+	it("applies delay to timestamp-aligned reads", () => {
+		const buf = new EchoReferenceBuffer({
+			capacitySamples: 1000,
+			sampleRateHz: 16_000,
+		});
+		buf.pushAt(0, ramp(0, 10));
+
+		expect(Array.from(buf.referenceAt(0.25, 4, 2))).toEqual([3, 4, 5, 6]);
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
@@ -21,25 +21,51 @@ export interface EchoReferenceBufferOptions {
 	 * `maxDelaySamples + frameLength`. Default 24000 (1.5 s @ 16 kHz).
 	 */
 	capacitySamples?: number;
+	/** Sample rate for timestamp-based push/read helpers. Default 16000. */
+	sampleRateHz?: number;
 }
 
 export class EchoReferenceBuffer {
 	private readonly buffer: Float32Array;
+	private readonly valid: Uint8Array;
 	private readonly capacity: number;
+	private readonly sampleRateHz: number;
 	/** Total samples ever pushed (monotonic); the logical "now" cursor. */
 	private pushed = 0;
+	/** Timestamp mapped to absolute sample 0 for timestamp-aware playback. */
+	private originMs: number | null = null;
 
 	constructor(options: EchoReferenceBufferOptions = {}) {
 		this.capacity = Math.max(1, Math.floor(options.capacitySamples ?? 24000));
+		this.sampleRateHz = Math.max(1, Math.floor(options.sampleRateHz ?? 16_000));
 		this.buffer = new Float32Array(this.capacity);
+		this.valid = new Uint8Array(this.capacity);
 	}
 
 	/** Append rendered playback (far-end) PCM as it is produced. */
 	push(playback: Float32Array): void {
-		for (let i = 0; i < playback.length; i++) {
-			this.buffer[(this.pushed + i) % this.capacity] = playback[i];
-		}
+		this.writeAt(this.pushed, playback);
 		this.pushed += playback.length;
+	}
+
+	/**
+	 * Store rendered playback at its capture/render timestamp. This preserves
+	 * real gaps between playback bursts instead of treating chunks as contiguous.
+	 */
+	pushAt(timestampMs: number, playback: Float32Array): void {
+		if (!Number.isFinite(timestampMs)) {
+			this.push(playback);
+			return;
+		}
+		if (this.originMs === null) this.originMs = timestampMs;
+		let start = this.sampleIndexFor(timestampMs);
+		if (start < 0) {
+			this.reset();
+			this.originMs = timestampMs;
+			start = 0;
+		}
+		this.writeAt(start, playback);
+		this.pushed = Math.max(this.pushed, start + playback.length);
 	}
 
 	/**
@@ -54,15 +80,25 @@ export class EchoReferenceBuffer {
 		const delay = Math.max(0, Math.floor(delaySamples));
 		// Absolute index (in the monotonic stream) of the first output sample.
 		const start = this.pushed - delay - out.length;
-		const oldest = Math.max(0, this.pushed - this.capacity);
-		for (let i = 0; i < out.length; i++) {
-			const abs = start + i;
-			// Available only if within [oldest, pushed) — else leave the 0 fill.
-			if (abs >= oldest && abs >= 0 && abs < this.pushed) {
-				out[i] = this.buffer[abs % this.capacity];
-			}
+		return this.readWindow(start, out.length);
+	}
+
+	/**
+	 * Reference aligned to a mic frame starting at `timestampMs`.
+	 * Returns playback `[timestampMs - delay, timestampMs - delay + length)`.
+	 */
+	referenceAt(
+		timestampMs: number,
+		length: number,
+		delaySamples: number,
+	): Float32Array {
+		const outLength = Math.max(0, Math.floor(length));
+		if (this.originMs === null || !Number.isFinite(timestampMs)) {
+			return new Float32Array(outLength);
 		}
-		return out;
+		const delay = Math.max(0, Math.floor(delaySamples));
+		const start = this.sampleIndexFor(timestampMs) - delay;
+		return this.readWindow(start, outLength);
 	}
 
 	/** Samples pushed so far (the monotonic stream position). */
@@ -73,6 +109,57 @@ export class EchoReferenceBuffer {
 	/** Drop all buffered playback (e.g. on a new turn / barge-in flush). */
 	reset(): void {
 		this.buffer.fill(0);
+		this.valid.fill(0);
 		this.pushed = 0;
+		this.originMs = null;
+	}
+
+	private sampleIndexFor(timestampMs: number): number {
+		if (this.originMs === null) return 0;
+		return Math.round(
+			((timestampMs - this.originMs) / 1000) * this.sampleRateHz,
+		);
+	}
+
+	private writeAt(start: number, playback: Float32Array): void {
+		const safeStart = Math.max(0, Math.floor(start));
+		const end = safeStart + playback.length;
+		if (safeStart > this.pushed) this.clearRange(this.pushed, safeStart);
+		const oldest = Math.max(0, this.pushed - this.capacity);
+		if (end <= oldest) return;
+		for (let i = 0; i < playback.length; i++) {
+			const abs = safeStart + i;
+			if (abs < oldest) continue;
+			const slot = abs % this.capacity;
+			this.buffer[slot] = playback[i] ?? 0;
+			this.valid[slot] = 1;
+		}
+	}
+
+	private clearRange(from: number, to: number): void {
+		if (to <= from) return;
+		if (to - from >= this.capacity) {
+			this.buffer.fill(0);
+			this.valid.fill(0);
+			return;
+		}
+		for (let abs = Math.max(0, Math.floor(from)); abs < to; abs++) {
+			const slot = abs % this.capacity;
+			this.buffer[slot] = 0;
+			this.valid[slot] = 0;
+		}
+	}
+
+	private readWindow(start: number, length: number): Float32Array {
+		const out = new Float32Array(length);
+		const oldest = Math.max(0, this.pushed - this.capacity);
+		for (let i = 0; i < out.length; i++) {
+			const abs = start + i;
+			if (abs >= oldest && abs >= 0 && abs < this.pushed) {
+				const slot = abs % this.capacity;
+				if (this.valid[slot] === 1) out[i] = this.buffer[slot];
+			}
+		}
+		return out;
 	}
 }

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/runtime-selection.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/runtime-selection.ts
@@ -52,7 +52,7 @@ export function selectVoiceBackend(
 ): VoiceBackendDecision {
 	if (!inputs.kokoroAvailable) {
 		throw new Error(
-			"[voice] Kokoro model artifacts are not present on disk; Kokoro is the only on-device TTS backend (install an Eliza-1 bundle or stage the Kokoro ONNX + at least one voice .bin).",
+			"[voice] Kokoro model artifacts are not present on disk; Kokoro is the only on-device TTS backend (install an Eliza-1 bundle or stage the Kokoro GGUF + at least one voice .bin).",
 		);
 	}
 	return {

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
@@ -50,20 +50,30 @@ function ramp(n: number): Float32Array {
 	return out;
 }
 
+function noise(n: number): Float32Array {
+	const out = new Float32Array(n);
+	let seed = 0x12345678;
+	for (let i = 0; i < n; i += 1) {
+		seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+		out[i] = ((seed / 0xffffffff) * 2 - 1) * 0.6;
+	}
+	return out;
+}
+
 describe("LiveDiarizationSession echo reference", () => {
 	it("returns a zero far-end reference before any playback is pushed", () => {
 		const session = new LiveDiarizationSession(fakeRuntime());
-		const ref = session.echoReferenceFrame(320);
+		const ref = session.echoReferenceFrame(0, 320);
 		expect(ref).toHaveLength(320);
 		expect(ref.every((v) => v === 0)).toBe(true);
 	});
 
-	it("aligns the most-recent pushed playback as the far-end (delay 0)", () => {
+	it("aligns playback by frame timestamp as the far-end (delay 0)", () => {
 		const session = new LiveDiarizationSession(fakeRuntime());
 		const playback = ramp(320);
 		session.pushPlayback([playbackFrame(playback, 0)]);
 
-		const ref = session.echoReferenceFrame(320);
+		const ref = session.echoReferenceFrame(0, 320);
 		expect(ref).toHaveLength(320);
 		// Not zero-filled — the canceller now has a real far-end to cancel.
 		expect(ref.some((v) => v !== 0)).toBe(true);
@@ -79,7 +89,7 @@ describe("LiveDiarizationSession echo reference", () => {
 		const playback = ramp(640);
 		session.pushPlayback([playbackFrame(playback, 0)]);
 
-		const ref = session.echoReferenceFrame(320);
+		const ref = session.echoReferenceFrame(20, 320);
 		expect(ref).toHaveLength(320);
 		// The aligned window is the LAST 320 of the 640 pushed (delay 0).
 		for (let i = 0; i < 320; i += 1) {
@@ -92,9 +102,55 @@ describe("LiveDiarizationSession echo reference", () => {
 	it("resetPlayback drops buffered far-end (barge-in / playback stop)", () => {
 		const session = new LiveDiarizationSession(fakeRuntime());
 		session.pushPlayback([playbackFrame(ramp(320), 0)]);
-		expect(session.echoReferenceFrame(320).some((v) => v !== 0)).toBe(true);
+		expect(session.echoReferenceFrame(0, 320).some((v) => v !== 0)).toBe(true);
 
 		session.resetPlayback();
-		expect(session.echoReferenceFrame(320).every((v) => v === 0)).toBe(true);
+		expect(session.echoReferenceFrame(0, 320).every((v) => v === 0)).toBe(true);
+	});
+
+	it("zero-fills natural gaps between playback frames", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		const first = ramp(320);
+		const later = ramp(320);
+		session.pushPlayback([playbackFrame(first, 0), playbackFrame(later, 5)]);
+
+		expect(session.echoReferenceFrame(0, 320).some((v) => v !== 0)).toBe(true);
+		expect(session.echoReferenceFrame(40, 320).every((v) => v === 0)).toBe(
+			true,
+		);
+		expect(session.echoReferenceFrame(100, 320).some((v) => v !== 0)).toBe(
+			true,
+		);
+	});
+
+	it("self-calibrates playback-to-mic delay from correlated echo", () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		const frameSamples = 320;
+		const totalSamples = 16_000;
+		const delaySamples = 240;
+		const playback = noise(totalSamples);
+
+		for (let offset = 0; offset < totalSamples; offset += frameSamples) {
+			session.pushPlayback([
+				playbackFrame(
+					playback.slice(offset, offset + frameSamples),
+					offset / frameSamples,
+				),
+			]);
+		}
+
+		for (let offset = 0; offset < totalSamples; offset += frameSamples) {
+			const near = new Float32Array(frameSamples);
+			for (let i = 0; i < frameSamples; i += 1) {
+				near[i] = playback[offset + i - delaySamples] ?? 0;
+			}
+			session.observeForDelayCalibration(near, (offset / SAMPLE_RATE) * 1000);
+			if (session.aecDelayState().calibrated) break;
+		}
+
+		const state = session.aecDelayState();
+		expect(state.calibrated).toBe(true);
+		expect(Math.abs(state.delaySamples - delaySamples)).toBeLessThanOrEqual(1);
+		expect(state.confidence).toBeGreaterThan(0.95);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -29,13 +29,18 @@ import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
 import {
 	type AttributedTurn,
+	type AttributionPipelineLike,
 	AudioFrameConsumer,
 	type AudioFrameConsumerConfig,
+	type AudioFrameConsumerDeps,
 	type AudioFrameEvent,
 	decodeAudioFramePcm,
+	type EchoReferenceProvider,
 	type RuntimeEventSink,
 	type TurnTranscriber,
+	type VadSegmenter,
 } from "./audio-frame-consumer.js";
+import { estimateEchoDelaySamples } from "./echo-delay.js";
 import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
 import type {
 	ElizaInferenceContextHandle,
@@ -102,6 +107,17 @@ export interface LiveDiarizationStatus {
 	framesDropped: number;
 	/** Turns segmented + attributed so far. */
 	turnsObserved: number;
+	/** Live AEC wiring status. Echo cancellation runs only when this is true. */
+	aec: {
+		echoReferenceWired: boolean;
+		/** Playback→mic delay (samples @16 kHz) currently applied to align the
+		 * far-end reference — self-calibrated from real echo when confident,
+		 * otherwise the `ELIZA_VOICE_ECHO_DELAY_MS` seed (default 0). */
+		echoDelaySamples: number;
+		/** Peak cross-correlation [0,1] of the last accepted delay calibration;
+		 * 0 until a confident estimate replaces the seed. */
+		echoDelayConfidence: number;
+	};
 	/** The most recent attributed turns (capped), for device-evidence reads. */
 	recentTurns: LiveDiarizationTurnSummary[];
 	/** Populated only when readiness failed — the precise blocker. */
@@ -125,7 +141,66 @@ export interface LiveDiarizationTurnSummary {
 
 const MAX_RECENT_TURNS = 20;
 
+export interface LiveDiarizationSessionOptions {
+	/**
+	 * Agent-playback PCM provider for AEC. The caller owns playback capture and
+	 * delay calibration when supplied. Without an external provider, the session
+	 * uses its built-in playback buffer fed by /api/voice/playback-frames.
+	 */
+	echoReference?: EchoReferenceProvider | null;
+}
+
+export interface LiveDiarizationConsumerDepsInput {
+	vad: VadSegmenter;
+	pipeline: AttributionPipelineLike;
+	runtime: RuntimeEventSink;
+	transcribe?: TurnTranscriber | null;
+	echoReference?: EchoReferenceProvider | null;
+}
+
+export function buildLiveDiarizationConsumerDeps({
+	vad,
+	pipeline,
+	runtime,
+	transcribe,
+	echoReference,
+}: LiveDiarizationConsumerDepsInput): AudioFrameConsumerDeps {
+	return {
+		vad,
+		pipeline,
+		runtime,
+		...(transcribe ? { transcribe } : {}),
+		...(echoReference ? { echoReference } : {}),
+	};
+}
+
 const AUDIO_FRAME_SAMPLE_RATE = 16_000;
+
+/** Echo-delay self-calibration (#9583/#9586). */
+/** Accumulate this many playback-active samples before estimating the delay
+ * (~0.75 s @16 kHz — enough correlated echo for a stable cross-correlation). */
+const ECHO_CAL_TARGET_SAMPLES = 12_000;
+/** Bound the rolling calibration window so a long talk-over doesn't grow it. */
+const ECHO_CAL_MAX_SAMPLES = 24_000;
+/** Accept a calibrated delay only above this normalized cross-correlation; below
+ * it the near/far are independent (user talking, no echo) — keep the seed. */
+const ECHO_CAL_MIN_CONFIDENCE = 0.3;
+/** Largest playback→mic delay to search (300 ms @16 kHz). */
+const ECHO_CAL_MAX_LAG_SAMPLES = 4_800;
+/** Far-end mean-square floor below which a frame is "no playback" (skip). */
+const ECHO_CAL_FAR_ENERGY_FLOOR = 1e-7;
+
+function concatFloat32(chunks: Float32Array[]): Float32Array {
+	let total = 0;
+	for (const c of chunks) total += c.length;
+	const out = new Float32Array(total);
+	let off = 0;
+	for (const c of chunks) {
+		out.set(c, off);
+		off += c.length;
+	}
+	return out;
+}
 
 /**
  * Playback→mic transport delay used to time-align the far-end echo reference,
@@ -167,9 +242,27 @@ export class LiveDiarizationSession {
 	 * no-playback case.
 	 */
 	private readonly echoBuffer = new EchoReferenceBuffer();
-	private readonly echoDelaySamples = resolveEchoDelaySamples();
+	/**
+	 * Playback→mic delay applied when reading the far-end reference. Seeded from
+	 * `ELIZA_VOICE_ECHO_DELAY_MS` (default 0) and then SELF-CALIBRATED on the live
+	 * path: once enough playback-active echo is observed, `estimateEchoDelaySamples`
+	 * (#9586) recovers the bulk transport lag by cross-correlation and replaces the
+	 * seed (#9583). Mutable for that reason.
+	 */
+	private echoDelaySamples = resolveEchoDelaySamples();
+	private echoDelayConfidence = 0;
+	private echoDelayCalibrated = false;
+	/** Rolling near/far windows accumulated only while the far-end is active, used
+	 * once to estimate the playback→mic delay. Cleared after a confident estimate
+	 * and on {@link resetPlayback}. */
+	private calNear: Float32Array[] = [];
+	private calFar: Float32Array[] = [];
+	private calSampleCount = 0;
 
-	constructor(private readonly runtime: RuntimeEventSink) {}
+	constructor(
+		private readonly runtime: RuntimeEventSink,
+		private readonly options: LiveDiarizationSessionOptions = {},
+	) {}
 
 	/** Ensure the real-deps consumer exists; idempotent + concurrency-safe. */
 	private ensureBuilt(): Promise<void> {
@@ -246,18 +339,20 @@ export class LiveDiarizationSession {
 		// decoder — the path then stays diarization-only, as before.
 		const transcribe = this.buildTurnTranscriber(ffi, ctx);
 		const consumer = new AudioFrameConsumer(
-			{
+			buildLiveDiarizationConsumerDeps({
 				vad: detector,
 				pipeline,
 				runtime: this.runtime,
+				transcribe,
 				// Cancel the agent's own TTS playback before VAD/attribution so the
-				// live path never transcribes its echo (#9455/#9583). The reference
-				// is zero-filled (⇒ NLMS passthrough) until the device streams
-				// playback via pushPlayback.
-				echoReference: (_timestampMs, samples) =>
-					this.echoReferenceFrame(samples),
-				...(transcribe ? { transcribe } : {}),
-			},
+				// live path never transcribes its echo (#9455/#9583). Hosts may
+				// provide their own live reference; otherwise the session uses the
+				// built-in playback buffer fed by pushPlayback.
+				echoReference:
+					this.options.echoReference ??
+					((timestampMs, samples) =>
+						this.echoReferenceFrame(timestampMs, samples)),
+			}),
 			config,
 		);
 		consumer.onTurn((turn) => this.recordTurn(turn));
@@ -317,8 +412,72 @@ export class LiveDiarizationSession {
 	 * is zero-filled (⇒ NLMS passthrough) until the device streams playback.
 	 * Public so the wiring is unit-testable without the fused FFI.
 	 */
-	echoReferenceFrame(samples: number): Float32Array {
-		return this.echoBuffer.referenceFor(samples, this.echoDelaySamples);
+	echoReferenceFrame(timestampMs: number, samples: number): Float32Array {
+		return this.echoBuffer.referenceAt(
+			timestampMs,
+			samples,
+			this.echoDelaySamples,
+		);
+	}
+
+	/** Current self-calibrated AEC delay state (for status + tests). */
+	aecDelayState(): {
+		delaySamples: number;
+		confidence: number;
+		calibrated: boolean;
+	} {
+		return {
+			delaySamples: this.echoDelaySamples,
+			confidence: this.echoDelayConfidence,
+			calibrated: this.echoDelayCalibrated,
+		};
+	}
+
+	/**
+	 * Self-calibrate the playback→mic delay (#9583/#9586) from real echo. Called
+	 * per mic frame while uncalibrated: when the far-end is active (the agent is
+	 * playing TTS), accumulate the time-aligned near/far windows; once ~0.75 s of
+	 * playback-active audio is buffered, recover the bulk transport lag by
+	 * cross-correlation and, if confident, replace the static seed. One-shot — the
+	 * device's speaker→mic path is stable, so we lock the first confident estimate
+	 * and stop re-measuring. Public so it can be unit-tested without the fused FFI.
+	 */
+	observeForDelayCalibration(nearPcm: Float32Array, timestampMs: number): void {
+		if (this.echoDelayCalibrated || nearPcm.length === 0) return;
+		// Read the RAW far-end at this frame (delay 0) — calibration recovers the
+		// delay, so it must not pre-apply the value it is trying to measure.
+		const far = this.echoBuffer.referenceAt(timestampMs, nearPcm.length, 0);
+		let farEnergy = 0;
+		for (let i = 0; i < far.length; i++) farEnergy += far[i] * far[i];
+		if (farEnergy / Math.max(1, far.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
+			return; // no playback → nothing to calibrate against
+		}
+
+		this.calNear.push(nearPcm.slice());
+		this.calFar.push(far);
+		this.calSampleCount += nearPcm.length;
+		while (
+			this.calSampleCount > ECHO_CAL_MAX_SAMPLES &&
+			this.calNear.length > 1
+		) {
+			this.calSampleCount -= (this.calNear.shift() as Float32Array).length;
+			this.calFar.shift();
+		}
+		if (this.calSampleCount < ECHO_CAL_TARGET_SAMPLES) return;
+
+		const near = concatFloat32(this.calNear);
+		const farWin = concatFloat32(this.calFar);
+		const est = estimateEchoDelaySamples(near, farWin, {
+			maxLagSamples: ECHO_CAL_MAX_LAG_SAMPLES,
+		});
+		if (est.confidence >= ECHO_CAL_MIN_CONFIDENCE) {
+			this.echoDelaySamples = est.lagSamples;
+			this.echoDelayConfidence = est.confidence;
+			this.echoDelayCalibrated = true;
+		}
+		this.calNear = [];
+		this.calFar = [];
+		this.calSampleCount = 0;
 	}
 
 	/**
@@ -331,13 +490,18 @@ export class LiveDiarizationSession {
 	 */
 	pushPlayback(frames: AudioFrameEvent[]): void {
 		for (const frame of frames) {
-			this.echoBuffer.push(decodeAudioFramePcm(frame));
+			this.echoBuffer.pushAt(frame.timestamp, decodeAudioFramePcm(frame));
 		}
 	}
 
-	/** Drop buffered far-end playback (playback stopped / barge-in). */
+	/** Drop buffered far-end playback (playback stopped / barge-in). Also clears
+	 * the in-progress delay-calibration window (it would otherwise straddle a
+	 * playback gap); the already-learned delay is kept. */
 	resetPlayback(): void {
 		this.echoBuffer.reset();
+		this.calNear = [];
+		this.calFar = [];
+		this.calSampleCount = 0;
 	}
 
 	/** Feed a batch of WebView-captured frames; resolves once VAD has processed them. */
@@ -346,6 +510,16 @@ export class LiveDiarizationSession {
 		if (!this.consumer) return;
 		for (const frame of frames) {
 			this.framesReceived += 1;
+			if (!this.echoDelayCalibrated) {
+				try {
+					this.observeForDelayCalibration(
+						decodeAudioFramePcm(frame),
+						frame.timestamp,
+					);
+				} catch {
+					// Let AudioFrameConsumer own decode-error accounting below.
+				}
+			}
 			await this.consumer.onAudioFrame(frame);
 		}
 	}
@@ -369,6 +543,12 @@ export class LiveDiarizationSession {
 			framesReceived: this.framesReceived,
 			framesDropped: this.consumer?.droppedFrames ?? 0,
 			turnsObserved: this.turnsObserved,
+			aec: {
+				echoReferenceWired:
+					this.consumer != null || this.options.echoReference != null,
+				echoDelaySamples: this.echoDelaySamples,
+				echoDelayConfidence: this.echoDelayConfidence,
+			},
 			recentTurns: [...this.recentTurns],
 			...(this.buildError ? { error: this.buildError } : {}),
 		};


### PR DESCRIPTION
## Summary

Closes the **agent-side, code-doable** items on #9583's checklist — the device acoustic tuning stays device-gated.

The agent-side AEC seam (NLMS canceller #9455/#9612, echoReference seam #9575, EchoReferenceBuffer #9596, playback-frames route + session wiring #9610) is all on develop, but two pieces were still missing on the **live** path:

1. **`estimateEchoDelaySamples` (#9586) was never invoked** — the live path used a static `ELIZA_VOICE_ECHO_DELAY_MS` constant (default 0), so the bulk playback→mic transport delay was never removed and the adaptive taps wasted their budget on pure latency.
2. The reference buffer didn't preserve **real silences** between playback bursts.

### Changes
- **Self-calibrating delay.** While uncalibrated, `LiveDiarizationSession` accumulates the time-aligned near (mic) + far (playback) windows on playback-active frames; once ~0.75 s is buffered it runs `estimateEchoDelaySamples` (normalized cross-correlation) and, on a confident peak (corr ≥ 0.3), replaces the seed and locks it (the device speaker→mic path is stable). Exposed in `LiveDiarizationStatus.aec` as `echoDelaySamples` + `echoDelayConfidence`.
- **Gap-preserving `EchoReferenceBuffer`** (timestamp-keyed `pushAt`) so a mic frame never aligns to stale far-end across a playback gap; `resetPlayback` also clears the in-progress calibration window.
- Correct the Kokoro-missing message (ONNX → GGUF).

### Verification (headless, M4 Max, pure DSP — no device/FFI)
```
bun run --cwd plugins/plugin-local-inference test -- \
  live-diarization-session.echo echo-reference-buffer echo-delay \
  live-diarization-route audio-frame-consumer
→ 80 pass
```
New test: the session recovers a known **240-sample** delay within **±1** at **>0.95** confidence from a delayed synthetic echo.

### Remaining on #9583 (genuinely device-gated)
The client `AudioWorklet` producer that streams real TTS playback PCM to `/api/voice/playback-frames`, the per-platform default delay, and AEC3-class residual suppression — all need a real speaker→mic acoustic loop to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)