### PR TITLE
perf(computeruse): parallelize CUA region capture + per-region OCR, memoize commandExists

### DIFF
--- a/plugins/plugin-computeruse/src/platform/helpers.ts
+++ b/plugins/plugin-computeruse/src/platform/helpers.ts
@@ -12,15 +12,32 @@ import { platform } from "node:os";
 
 /**
  * Check if a CLI tool is available on the system.
+ *
+ * Memoized: tool availability on PATH does not change within a process run, and
+ * the hot CUA paths call this per click/op (e.g. `commandExists("cliclick")` on
+ * every macOS click) — each uncached call spawns `which`/`where` (~50-100ms, and
+ * far worse on Defender-heavy Windows where any spawn is ~10s). Caching collapses
+ * it to a single probe per tool. `clearCommandExistsCache()` resets it for tests.
  */
+const commandExistsCache = new Map<string, boolean>();
 export function commandExists(cmd: string): boolean {
+  const cached = commandExistsCache.get(cmd);
+  if (cached !== undefined) return cached;
+  let exists = false;
   try {
     const which = platform() === "win32" ? "where" : "which";
     execSync(`${which} ${cmd}`, { stdio: "ignore", timeout: 3000 });
-    return true;
+    exists = true;
   } catch {
-    return false;
+    exists = false;
   }
+  commandExistsCache.set(cmd, exists);
+  return exists;
+}
+
+/** Reset the {@link commandExists} memo (test-only / PATH change). */
+export function clearCommandExistsCache(): void {
+  commandExistsCache.clear();
 }
 
 /**

--- a/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
+++ b/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
@@ -149,30 +149,39 @@ export async function runOcrOnRegions(
 ): Promise<SceneOcrBox[]> {
   const coord = getCoordOcrProvider();
   if (coord) {
-    const out: SceneOcrBox[] = [];
-    for (const crop of crops) {
-      try {
-        // The coord provider shifts block bboxes by sourceX/sourceY, so the
-        // returned coordinates are already in display-local source space.
-        const result = await coord.describe({
-          displayId: String(displayId),
-          sourceX: crop.bbox[0] ?? 0,
-          sourceY: crop.bbox[1] ?? 0,
-          pngBytes: new Uint8Array(
-            crop.png.buffer,
-            crop.png.byteOffset,
-            crop.png.byteLength,
-          ),
-        });
-        for (const block of result.blocks) {
-          out.push(coordBlockToSceneBox(block, displayId, idState));
+    // OCR each dirty region concurrently (independent calls), then assign ids
+    // sequentially. Promise.all preserves input order, so ocr ids stay stable
+    // turn-to-turn regardless of which region's OCR finishes first.
+    const perCrop = await Promise.all(
+      crops.map(async (crop) => {
+        try {
+          // The coord provider shifts block bboxes by sourceX/sourceY, so the
+          // returned coordinates are already in display-local source space.
+          const result = await coord.describe({
+            displayId: String(displayId),
+            sourceX: crop.bbox[0] ?? 0,
+            sourceY: crop.bbox[1] ?? 0,
+            pngBytes: new Uint8Array(
+              crop.png.buffer,
+              crop.png.byteOffset,
+              crop.png.byteLength,
+            ),
+          });
+          return result.blocks;
+        } catch (err) {
+          logFn(
+            `[scene-builder] CoordOcr region failed at ${crop.bbox.join(",")}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          return [];
         }
-      } catch (err) {
-        logFn(
-          `[scene-builder] CoordOcr region failed at ${crop.bbox.join(",")}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
+      }),
+    );
+    const out: SceneOcrBox[] = [];
+    for (const blocks of perCrop) {
+      for (const block of blocks) {
+        out.push(coordBlockToSceneBox(block, displayId, idState));
       }
     }
     return out;
@@ -180,38 +189,46 @@ export async function runOcrOnRegions(
 
   const provider = pickProvider();
   if (!provider) return [];
-  const out: SceneOcrBox[] = [];
-  for (const crop of crops) {
-    try {
-      const result = await provider.recognize({
-        kind: "bytes",
-        data: new Uint8Array(
-          crop.png.buffer,
-          crop.png.byteOffset,
-          crop.png.byteLength,
-        ),
-      });
-      for (const line of result.lines) {
-        const offset = crop.bbox;
-        out.push({
-          id: nextOcrId(idState, displayId),
-          text: line.text,
-          bbox: [
-            (offset[0] ?? 0) + line.boundingBox.x,
-            (offset[1] ?? 0) + line.boundingBox.y,
-            line.boundingBox.width,
-            line.boundingBox.height,
-          ],
-          conf: line.confidence,
-          displayId,
+  // Same concurrency pattern as the coord path: recognize regions in parallel,
+  // assign ids in input order afterward (Promise.all preserves order).
+  const perCrop = await Promise.all(
+    crops.map(async (crop) => {
+      try {
+        const result = await provider.recognize({
+          kind: "bytes",
+          data: new Uint8Array(
+            crop.png.buffer,
+            crop.png.byteOffset,
+            crop.png.byteLength,
+          ),
         });
+        return { crop, lines: result.lines };
+      } catch (err) {
+        logFn(
+          `[scene-builder] OCR region failed at ${crop.bbox.join(",")}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        return { crop, lines: [] };
       }
-    } catch (err) {
-      logFn(
-        `[scene-builder] OCR region failed at ${crop.bbox.join(",")}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+    }),
+  );
+  const out: SceneOcrBox[] = [];
+  for (const { crop, lines } of perCrop) {
+    const offset = crop.bbox;
+    for (const line of lines) {
+      out.push({
+        id: nextOcrId(idState, displayId),
+        text: line.text,
+        bbox: [
+          (offset[0] ?? 0) + line.boundingBox.x,
+          (offset[1] ?? 0) + line.boundingBox.y,
+          line.boundingBox.width,
+          line.boundingBox.height,
+        ],
+        conf: line.confidence,
+        displayId,
+      });
     }
   }
   return out;

--- a/plugins/plugin-computeruse/src/scene/scene-builder.ts
+++ b/plugins/plugin-computeruse/src/scene/scene-builder.ts
@@ -292,28 +292,34 @@ export class SceneBuilder extends EventEmitter {
             dims.width,
             dims.height,
           );
-          const crops: Array<{
+          // Capture all dirty regions concurrently — they are independent OS
+          // grabs, so wall-clock is max(region) not sum(region). If ANY region
+          // fails we drop to full-frame OCR for this display (unchanged
+          // semantics). Promise.all preserves order, so OCR id assignment
+          // downstream stays deterministic.
+          let crops: Array<{
             png: Buffer;
             bbox: [number, number, number, number];
           }> = [];
-          for (const rect of rects) {
-            try {
-              const regionCapture = await this.deps.captureRegion(displayId, {
-                x: rect.bbox[0],
-                y: rect.bbox[1],
-                width: rect.bbox[2],
-                height: rect.bbox[3],
-              });
-              crops.push({ png: regionCapture.frame, bbox: rect.bbox });
-            } catch (err) {
-              this.deps.log(
-                `[scene-builder] captureRegion(${displayId}, ${rect.bbox.join(",")}) failed: ${
-                  err instanceof Error ? err.message : String(err)
-                } — falling back to full-frame OCR for this display`,
-              );
-              crops.length = 0;
-              break;
-            }
+          try {
+            crops = await Promise.all(
+              rects.map(async (rect) => {
+                const regionCapture = await this.deps.captureRegion(displayId, {
+                  x: rect.bbox[0],
+                  y: rect.bbox[1],
+                  width: rect.bbox[2],
+                  height: rect.bbox[3],
+                });
+                return { png: regionCapture.frame, bbox: rect.bbox };
+              }),
+            );
+          } catch (err) {
+            this.deps.log(
+              `[scene-builder] captureRegion(${displayId}) failed: ${
+                err instanceof Error ? err.message : String(err)
+              } — falling back to full-frame OCR for this display`,
+            );
+            crops = [];
           }
           if (crops.length > 0) {
             const refreshed = await this.deps.runOcrOnCrops(


### PR DESCRIPTION
## What

Three low-risk, semantics-preserving performance wins in the CUA scene pipeline. These are pure latency reductions on the per-turn hot path — no behavior change.

### 1. Memoize `commandExists` (`platform/helpers.ts`)
Tool availability on PATH does not change within a process run, yet the hot CUA paths call `commandExists()` per click/op (e.g. `commandExists("cliclick")` on every macOS click). Each uncached call spawns `which`/`where` (~50-100ms on POSIX, and **~10s on Defender-heavy Windows** where any fresh process spawn is scanned). Memoizing collapses it to a single probe per tool for the life of the process. `clearCommandExistsCache()` resets it for tests.

### 2. Parallelize dirty-region capture (`scene/scene-builder.ts`)
The dirty-block re-capture loop grabbed each region sequentially (`for (const rect of rects) await captureRegion(...)`). Regions are independent OS grabs, so wall-clock was `sum(region)`. Switched to `Promise.all` → wall-clock is now `max(region)`. Failure semantics are unchanged: any region failing drops the whole display to full-frame OCR (the prior `break` + `crops.length = 0`). `Promise.all` preserves input order, so downstream OCR id assignment stays deterministic turn-to-turn.

### 3. Parallelize per-region OCR (`scene/ocr-adapter.ts`)
`runOcrOnRegions` OCR'd each dirty crop sequentially on **both** the coord-provider path and the line-provider fallback. Switched both to `Promise.all` over the crops, then assign stable `t<displayId>-<seq>` ids sequentially in input order afterward (`Promise.all` preserves order → ids stay stable regardless of which crop's OCR resolves first).

## Why this matters
Dirty-block OCR fires every turn the screen changes; a typical scrolled/edited screen has several dirty regions. Serial capture + serial OCR meant per-turn scene latency scaled linearly with region count. With native WinRT OCR (~free, per-region) the dominant cost was the awaits stacking — now they overlap.

## Evidence
- `bun run --cwd plugins/plugin-computeruse typecheck` → exit 0
- `vitest run` over the affected suites: `ocr-adapter-coord-seam`, `ocr-provider-registry`, `set-of-marks-seam`, `scene-builder`, `helpers` → **46 passed** (16 + 30)
- biome check clean on all three files (the single pre-existing `noUnusedImports` warning at `scene-builder.ts:36` is on develop already, untouched here)

## Risk
Low. No new dependencies, no signature changes, ordering preserved, failure paths preserved. The memo is process-scoped and test-resettable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)