### PR TITLE
chore(electrobun): remove duplicate @elizaos/plugin-local-inference bundle external (#9626)

### DIFF
--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -547,7 +547,6 @@ export function createElectrobunConfig(): ElectrobunConfig {
           // Plugins — initialized by the API subprocess, never the bun shell.
           "@elizaos/plugin-sql",
           "@elizaos/plugin-local-inference",
-          "@elizaos/plugin-local-inference",
           // Database stack pulled in by plugin-sql.
           "@electric-sql/pglite",
           "drizzle-orm",


### PR DESCRIPTION
Part of #9626 (desktop/Electrobun cleanups).

`electrobun.config.ts` lists `@elizaos/plugin-local-inference` twice in `build.bun.external` (lines 549–550). esbuild/bun dedups it so it's harmless at runtime, but it signals the hand-maintained externals list is unreviewed. Removes the duplicate line — pure dedup of an array literal, no behavior change.