### PR TITLE
feat(computeruse): hamming-tolerant Brain describe-cache — continuous-understanding tuning (#9581)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/brain-dhash-cache.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/brain-dhash-cache.test.ts
@@ -9,8 +9,9 @@
 
 import { deflateSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
-import { Brain } from "../actor/brain.js";
+import { BRAIN_DHASH_HAMMING_THRESHOLD, Brain } from "../actor/brain.js";
 import type { DisplayCapture } from "../platform/capture.js";
+import { frameDhash, hamming } from "../scene/dhash.js";
 import type { Scene } from "../scene/scene-types.js";
 
 // ── minimal PNG synthesizer (16x16 RGB) ──────────────────────────────────────
@@ -40,6 +41,47 @@ function makeTinyPng(seed = 0): Buffer {
     rows.push(0);
     for (let x = 0; x < w; x += 1) {
       const v = ((x + seed) * 16) % 255;
+      rows.push(v, v, v);
+    }
+  }
+  const idat = deflateSync(Buffer.from(rows));
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 2;
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  return Buffer.concat([
+    sig,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", idat),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+/** 32×32 2-D pattern PNG with an optional rectangular perturbation, so a small
+ * localized change flips only a few dHash bits (unlike the flat 16×16 gradient,
+ * where a change flips a whole bit-column across every identical row). */
+function make2dPng(
+  seed: number,
+  rect?: { x: number; y: number; w: number; h: number; delta: number },
+): Buffer {
+  const w = 32;
+  const h = 32;
+  const rows: number[] = [];
+  for (let y = 0; y < h; y += 1) {
+    rows.push(0);
+    for (let x = 0; x < w; x += 1) {
+      let v = (x * 37 + y * 101 + seed * 53) % 256;
+      if (
+        rect &&
+        x >= rect.x &&
+        x < rect.x + rect.w &&
+        y >= rect.y &&
+        y < rect.y + rect.h
+      ) {
+        v = (v + rect.delta) % 256;
+      }
       rows.push(v, v, v);
     }
   }
@@ -131,6 +173,43 @@ describe("Brain frame-dHash describe cache (M3)", () => {
       imagelessCalls: 0,
       estImageTokensSaved: 0,
     });
+  });
+
+  it("serves a NEAR-identical frame (cosmetic churn) from cache (#9581 tuning)", async () => {
+    // Two frames differing by a small rect → a few dHash bits, the way a cursor
+    // blink / caret / anti-aliasing perturbs a real screen. Self-validate the
+    // fixture is genuinely near-identical-but-not-equal before asserting the hit.
+    const base = make2dPng(5);
+    const nudged = make2dPng(5, { x: 24, y: 24, w: 8, h: 8, delta: 128 });
+    const dhA = frameDhash(base);
+    const dhB = frameDhash(nudged);
+    expect(dhA).not.toBeNull();
+    expect(dhB).not.toBeNull();
+    const dist = hamming(dhA as bigint, dhB as bigint);
+    expect(dist).toBeGreaterThan(0); // not byte-identical (exact cache would still hit)
+    expect(dist).toBeLessThanOrEqual(BRAIN_DHASH_HAMMING_THRESHOLD);
+
+    let calls = 0;
+    const brain = new Brain(null, {
+      imagePolicy: "always",
+      invokeModel: async () => {
+        calls += 1;
+        return VALID;
+      },
+    });
+    const first = await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "click save",
+      captures: captures(base),
+    });
+    const second = await brain.observeAndPlan({
+      scene: dummyScene(),
+      goal: "click save",
+      captures: captures(nudged), // near-identical → reuse the plan, skip the model
+    });
+    expect(calls).toBe(1);
+    expect(second).toEqual(first);
+    expect(brain.getStats().cacheHits).toBe(1);
   });
 
   it("re-invokes for a visually different frame", async () => {

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -44,7 +44,7 @@ import {
   ModelType,
 } from "@elizaos/core";
 import type { DisplayCapture } from "../platform/capture.js";
-import { frameDhash, pngDimensions } from "../scene/dhash.js";
+import { frameDhash, hamming, pngDimensions } from "../scene/dhash.js";
 import type { Scene } from "../scene/scene-types.js";
 import { serializeSceneForPrompt } from "../scene/serialize.js";
 import { resolveReference } from "./actor.js";
@@ -54,6 +54,16 @@ export const BRAIN_MAX_PIXELS = 1_310_720; // 1280 * 32 * 32 ≈ 1.3 MP cap
 export const BRAIN_MAX_ROIS = 2;
 /** Bound on the per-Brain dHash→BrainOutput cache (LRU-ish, oldest evicted). */
 export const BRAIN_DHASH_CACHE_MAX = 16;
+/**
+ * Max dHash Hamming distance for a cached plan to be reused for a new frame
+ * (#9581 continuous-understanding tuning). Exact-equality (distance 0) re-burned
+ * the IMAGE_DESCRIPTION model on cosmetically-identical frames — cursor jitter,
+ * a blinking caret, anti-aliasing, a 1-px scroll all flip a few dHash bits.
+ * Matches `SCREEN_STATE_HAMMING_THRESHOLD` (the same 64-bit dHash drives
+ * ScreenStateStore's change detection), so "the screen didn't meaningfully
+ * change" means the same thing to the cache and to the change detector.
+ */
+export const BRAIN_DHASH_HAMMING_THRESHOLD = 5;
 /**
  * Image-token estimate per source pixel for a vision model with the Qwen3-VL /
  * OS-Atlas `max_pixels` convention: one visual token ≈ a 28×28 (≈750 px) patch.
@@ -173,7 +183,11 @@ export class Brain {
    * skips the model entirely when the same frame is observed for the same goal,
    * cutting the dominant CUA-loop token cost regardless of backend (#9105 M3).
    */
-  private readonly dhashCache = new Map<string, BrainOutput>();
+  private readonly dhashCache: Array<{
+    dh: bigint;
+    goal: string;
+    output: BrainOutput;
+  }> = [];
   private readonly imagePolicy: BrainImagePolicy;
   private invocations = 0;
   private cacheHits = 0;
@@ -197,19 +211,45 @@ export class Brain {
     };
   }
 
-  private cacheKey(frame: Buffer, goal: string): string | null {
+  private cacheKey(
+    frame: Buffer,
+    goal: string,
+  ): { dh: bigint; goal: string } | null {
     const dh = frameDhash(frame);
-    return dh === null ? null : `${dh.toString()}::${goal}`;
+    return dh === null ? null : { dh, goal };
   }
 
-  private rememberOutput(key: string | null, output: BrainOutput): BrainOutput {
+  /**
+   * Return a cached plan for the same goal whose frame is within
+   * `BRAIN_DHASH_HAMMING_THRESHOLD` bits of `dh` — a near-identical screen, not
+   * just a byte-identical one. On a hit the entry is moved to the end (LRU), so
+   * a steadily-evolving screen keeps its most-recent close match warm.
+   */
+  private findCached(dh: bigint, goal: string): BrainOutput | null {
+    for (let i = this.dhashCache.length - 1; i >= 0; i--) {
+      const entry = this.dhashCache[i]!;
+      if (
+        entry.goal === goal &&
+        hamming(entry.dh, dh) <= BRAIN_DHASH_HAMMING_THRESHOLD
+      ) {
+        this.dhashCache.splice(i, 1);
+        this.dhashCache.push(entry);
+        return entry.output;
+      }
+    }
+    return null;
+  }
+
+  private rememberOutput(
+    key: { dh: bigint; goal: string } | null,
+    output: BrainOutput,
+  ): BrainOutput {
     if (key) {
       // Evict oldest to bound memory.
-      if (this.dhashCache.size >= BRAIN_DHASH_CACHE_MAX) {
-        const oldest = this.dhashCache.keys().next().value;
-        if (oldest !== undefined) this.dhashCache.delete(oldest);
+      if (this.dhashCache.length >= BRAIN_DHASH_CACHE_MAX) {
+        this.dhashCache.shift();
       }
-      this.dhashCache.set(key, output);
+      this.dhashCache.push({ dh: key.dh, goal: key.goal, output });
     }
     return output;
   }
@@ -231,11 +271,12 @@ export class Brain {
       throw new Error("[computeruse/brain] could not pick a target capture");
     }
 
-    // Frame-dHash cache: identical screen + goal → reuse the prior plan, skip
-    // the (possibly remote) IMAGE_DESCRIPTION call.
+    // Frame-dHash cache: a near-identical screen + same goal → reuse the prior
+    // plan, skip the (possibly remote) IMAGE_DESCRIPTION call. Tolerant to a few
+    // dHash bits so cosmetic churn (cursor, caret, anti-aliasing) still hits.
     const key = this.cacheKey(targetCapture.frame, input.goal);
     if (key) {
-      const cached = this.dhashCache.get(key);
+      const cached = this.findCached(key.dh, key.goal);
       if (cached) {
         this.cacheHits += 1;
         return cached;


### PR DESCRIPTION
## Summary

The **continuous-understanding tuning** slice of #9581.

The Brain frame-dHash describe-cache (#9105 M3) keyed on **exact** dHash equality (`${dh}::${goal}`), so the (often remote) `IMAGE_DESCRIPTION` model was re-invoked on **cosmetically-identical** frames — a blinking caret, cursor jitter, anti-aliasing, or a 1-px scroll each flip a few dHash bits and missed the cache. On the cloud vision path that's the dominant CUA-loop token cost (the WS2 MemoryArbiter only dedups *local* backends).

### Change
Reuse a cached plan when the new frame is within **`BRAIN_DHASH_HAMMING_THRESHOLD` (= 5)** bits of a cached frame for the same goal — the same 64-bit dHash + threshold `ScreenStateStore`/`SceneBuilder` already use for change detection, so "the screen didn't meaningfully change" means the same thing to the describe-cache and the change detector. The cache becomes a bounded LRU list (scan newest-first, move-to-end on hit) instead of an exact-key `Map`.

### Verification (headless, M4 Max — real synthesized PNGs → real `frameDhash`)
```
bun run --cwd plugins/plugin-computeruse test -- brain-dhash-cache  → 4 pass
```
New **self-validating** test: two frames a *measured* 1–5 dHash bits apart (a small rect perturbation, dist asserted in range before the cache assertion) hit the cache (1 model call, `cacheHits=1`). The existing exact-identical, goal-change, and visually-different (hamming 43 → re-invoke) cases are unchanged.

### Context
Other #9581 tails verified this session on this M4 Max: Kokoro/vision build green, the 3 macOS evidence checks remain Accessibility-TCC-gated (GUI grant, not code), and Windows was verified by the maintainer. This PR is the headless, code-doable tuning piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)