### PR TITLE
fix(typecheck): make 5 plugins' typecheck actually check (drop no-op --noEmit --noCheck) (#9626)

### DIFF
--- a/plugins/plugin-embeddings/package.json
+++ b/plugins/plugin-embeddings/package.json
@@ -68,7 +68,7 @@
     "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsc --noEmit --noCheck -p tsconfig.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts __tests__/",
     "test:unit": "vitest run --config ./vitest.config.ts __tests__/",
     "lint:check": "bunx @biomejs/biome check .",

--- a/plugins/plugin-lmstudio/package.json
+++ b/plugins/plugin-lmstudio/package.json
@@ -73,7 +73,7 @@
     "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsc --noEmit --noCheck -p tsconfig.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts __tests__/",
     "test:unit": "vitest run --config ./vitest.config.ts __tests__/",
     "lint:check": "bunx @biomejs/biome check .",

--- a/plugins/plugin-mysticism/package.json
+++ b/plugins/plugin-mysticism/package.json
@@ -62,7 +62,7 @@
     "build": "bun run build.ts",
     "dev": "bun --hot build.ts",
     "test": "vitest run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit --noCheck",
+    "typecheck": "tsgo --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "clean": "rm -rf dist .turbo",

--- a/plugins/plugin-ollama/package.json
+++ b/plugins/plugin-ollama/package.json
@@ -74,7 +74,7 @@
     "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsc --noEmit --noCheck -p tsconfig.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts __tests__/",
     "test:unit": "vitest run --config ./vitest.config.ts __tests__/",
     "lint:check": "bunx @biomejs/biome check .",

--- a/plugins/plugin-openrouter/package.json
+++ b/plugins/plugin-openrouter/package.json
@@ -79,7 +79,7 @@
     "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsc --noEmit --noCheck -p tsconfig.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts",
     "test:harness": "bunx vitest run --config vitest.harness.config.ts",
     "test:unit": "vitest run __tests__/ --config ./vitest.config.ts",


### PR DESCRIPTION
Part of #9626 (TypeScript strategy).

## Problem

Five plugins' `typecheck` script combines `--noEmit` **and** `--noCheck`:

```
plugin-embeddings / -ollama / -openrouter / -lmstudio:  tsc --noEmit --noCheck -p tsconfig.json
plugin-mysticism:                                       tsc --noEmit --noCheck
```

`--noEmit` says "don't emit files" and `--noCheck` says "don't type-check" — together the command does **nothing useful** and always exits 0. So `bun run typecheck` for these packages asserts nothing; a type error here is never caught.

## Fix

Switch each to the repo's canonical checker, matching the ~130 other packages:

```
tsgo --noEmit [-p tsconfig.json]
```

## Safety (verified on this box)

Before flipping, I ran a **real** `bunx tsgo --noEmit -p tsconfig.json` in each of the 5 plugins — all report **0 type errors**, so the `--noCheck` was gratuitous (copy-paste), not masking real errors. Flipping the script therefore turns on real checking without turning CI red.

```
plugin-embeddings  0 errors
plugin-ollama      0 errors
plugin-openrouter  0 errors
plugin-mysticism   0 errors
plugin-lmstudio    0 errors
```

(The `packages/feed/{a2a,mcp}` matches in the audit are false positives — their `--noCheck` is on a dependency `--emitDeclarationOnly` step; the final `-p <pkg> --noEmit` does check the target. Left unchanged.)