### PR TITLE
fix(types): type window startup-trace keys, drop 4 as-unknown-as casts (#9474)

### DIFF
--- a/packages/ui/src/state/startup-telemetry.ts
+++ b/packages/ui/src/state/startup-telemetry.ts
@@ -40,6 +40,15 @@ export const STARTUP_TRACE_WINDOW_KEY = "__ELIZA_STARTUP_TRACE__";
 /** Window key a native host (Electrobun/Capacitor) may inject to share its id. */
 export const STARTUP_TRACE_ID_WINDOW_KEY = "__ELIZA_STARTUP_TRACE_ID__";
 
+declare global {
+  interface Window {
+    /** Renderer startup trace mirrored for out-of-band harness capture. */
+    [STARTUP_TRACE_WINDOW_KEY]?: StartupTrace;
+    /** Native-host-injected trace id, shared across host ↔ renderer. */
+    [STARTUP_TRACE_ID_WINDOW_KEY]?: string;
+  }
+}
+
 // One boot == one module evaluation, so module-level state is the trace.
 let traceId = "";
 const marks: StartupMark[] = [];
@@ -61,15 +70,13 @@ function originMs(): number {
 
 function readInjectedTraceId(): string | undefined {
   if (typeof window === "undefined") return undefined;
-  const value = (window as unknown as Record<string, unknown>)[
-    STARTUP_TRACE_ID_WINDOW_KEY
-  ];
+  const value = window[STARTUP_TRACE_ID_WINDOW_KEY];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function mirrorToWindow(): void {
   if (typeof window === "undefined") return;
-  (window as unknown as Record<string, unknown>)[STARTUP_TRACE_WINDOW_KEY] = {
+  window[STARTUP_TRACE_WINDOW_KEY] = {
     traceId,
     timeOrigin: originMs(),
     marks,
@@ -170,11 +177,7 @@ export function __resetStartupTraceForTests(): void {
   marks.length = 0;
   recorded.clear();
   if (typeof window !== "undefined") {
-    delete (window as unknown as Record<string, unknown>)[
-      STARTUP_TRACE_WINDOW_KEY
-    ];
-    delete (window as unknown as Record<string, unknown>)[
-      STARTUP_TRACE_ID_WINDOW_KEY
-    ];
+    delete window[STARTUP_TRACE_WINDOW_KEY];
+    delete window[STARTUP_TRACE_ID_WINDOW_KEY];
   }
 }


### PR DESCRIPTION
## Problem — develop is red on the type-safety ratchet (blocks every PR)

`origin/develop` currently fails the **Format + Type Safety Ratchet** CI job:

```
[type-safety-ratchet] as unknown as: 303 / 299
[type-safety-ratchet] unsafe cast baseline exceeded
  - as unknown as: 303 current > 299 baseline
```

Root cause is a **baseline race**: #9627 tightened the baseline to 299, but #9595 (`startup-telemetry.ts`) had already added 4 `(window as unknown as Record<string, unknown>)[KEY]` casts that landed afterward → 303. So the ratchet now fails on `develop` itself, failing the job on *every* open PR.

## Fix — type the window keys properly (no baseline bump)

Both keys are string-literal `const`s, so a module-scoped `declare global` augmentation types them and the casts collapse to direct access:

```ts
declare global {
  interface Window {
    [STARTUP_TRACE_WINDOW_KEY]?: StartupTrace;     // "__ELIZA_STARTUP_TRACE__"
    [STARTUP_TRACE_ID_WINDOW_KEY]?: string;        // "__ELIZA_STARTUP_TRACE_ID__"
  }
}
// window[STARTUP_TRACE_WINDOW_KEY]  — no cast
```

Runtime behavior is **byte-identical** (`window[KEY]` emits the same JS); only the types change. This removes 4 real casts rather than accepting them via `--update-baseline`.

## Verification (Linux x64)
- `type-safety-ratchet` → **299 / 299** (green)
- `@elizaos/ui` typecheck → **19/19 successful**
- `biome format` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)