### PR TITLE
fix(training): align trajectory targets with Gemma

### DIFF
--- a/packages/training/config/eliza1_trajectory_record.schema.json
+++ b/packages/training/config/eliza1_trajectory_record.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://elizaos.github.io/schemas/eliza1-trajectory-record.schema.json",
   "title": "Eliza-1 trajectory SFT record",
-  "$comment": "DERIVED ChatML-SFT schema — NOT the canonical Eliza-1 corpus record. The canonical corpus record is eliza_native_v1 (one row per Vercel AI SDK model boundary); see packages/training/docs/dataset/CANONICAL_RECORD.md. scripts/prepare_eliza1_trajectory_dataset.py writes eliza_native_v1 rows for the default train/val/test splits; this rendered shape is produced only with --output-format trajectory-record.",
+  "$comment": "DERIVED messages-SFT schema — NOT the canonical Eliza-1 corpus record. The canonical corpus record is eliza_native_v1 (one row per Vercel AI SDK model boundary); see packages/training/docs/dataset/CANONICAL_RECORD.md. scripts/prepare_eliza1_trajectory_dataset.py writes eliza_native_v1 rows for the default train/val/test splits; this rendered shape is produced only with --output-format trajectory-record.",
   "type": "object",
   "required": [
     "schema",
@@ -39,7 +39,7 @@
       "additionalProperties": false,
       "properties": {
         "modelFamily": {
-          "const": "qwen"
+          "const": "gemma"
         },
         "baseModel": {
           "type": "string",
@@ -49,7 +49,7 @@
           "const": "messages"
         },
         "chatTemplate": {
-          "const": "chatml"
+          "const": "gemma4"
         }
       }
     },

--- a/packages/training/config/gpu_profiles/12gb.json
+++ b/packages/training/config/gpu_profiles/12gb.json
@@ -1,11 +1,10 @@
 {
   "name": "12GB GPU (RTX 3060/4070)",
-  "description": "Optimized for 12GB VRAM - uses 0.5B model with minimal vLLM memory",
-  "model": "Qwen/Qwen2.5-0.5B-Instruct",
+  "description": "Optimized for 12GB VRAM - uses Gemma 4 E2B with minimal vLLM memory",
+  "model": "google/gemma-4-E2B",
   "vllm_gpu_memory": 0.25,
   "batch_size": 1,
   "max_token_length": 2048,
   "group_size": 4,
   "notes": "Training uses ~6GB, vLLM uses ~1.5GB, leaving headroom for activations"
 }
-

--- a/packages/training/config/gpu_profiles/16gb.json
+++ b/packages/training/config/gpu_profiles/16gb.json
@@ -1,11 +1,10 @@
 {
   "name": "16GB GPU (RTX 4080/A4000)",
-  "description": "Mid-range setup - can use 1.5B model",
-  "model": "Qwen/Qwen2.5-1.5B-Instruct",
+  "description": "Mid-range setup - uses the Gemma 4 E2B entry target",
+  "model": "google/gemma-4-E2B",
   "vllm_gpu_memory": 0.35,
   "batch_size": 1,
   "max_token_length": 4096,
   "group_size": 4,
   "notes": "Training uses ~12GB with gradient checkpointing, vLLM uses ~4GB"
 }
-

--- a/packages/training/config/gpu_profiles/24gb.json
+++ b/packages/training/config/gpu_profiles/24gb.json
@@ -1,7 +1,7 @@
 {
   "name": "24GB GPU (RTX 4090/A5000)",
-  "description": "High-end consumer/prosumer - can use Qwen3.5-4B",
-  "model": "Qwen/Qwen3.5-4B",
+  "description": "High-end consumer/prosumer - can use Gemma 4 E4B",
+  "model": "google/gemma-4-E4B",
   "vllm_gpu_memory": 0.40,
   "batch_size": 2,
   "max_token_length": 4096,

--- a/packages/training/config/gpu_profiles/48gb.json
+++ b/packages/training/config/gpu_profiles/48gb.json
@@ -1,7 +1,7 @@
 {
   "name": "48GB GPU (A40/A6000)",
-  "description": "Datacenter/workstation - can use Qwen3.5-9B",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Datacenter/workstation - can use Gemma 4 E4B",
+  "model": "google/gemma-4-E4B",
   "vllm_gpu_memory": 0.45,
   "batch_size": 4,
   "max_token_length": 8192,

--- a/packages/training/config/gpu_profiles/a100-2gpu.json
+++ b/packages/training/config/gpu_profiles/a100-2gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "2x A100 GPUs (160GB total)",
-  "description": "Dual A100 profile with dedicated inference and training GPUs for 7B-9B RL runs",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Dual A100 profile with dedicated inference and training GPUs for Gemma 4 12B RL runs",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.7,
   "vllm_gpu": "0",
   "training_gpu": "1",
@@ -16,5 +16,5 @@
   "warmup_steps": 150,
   "kl_coefficient": 0.05,
   "use_flash_attention": true,
-  "notes": "Recommended value profile for 7B-9B RL runs: GPU 0 serves vLLM, GPU 1 trains the policy."
+  "notes": "Recommended value profile for Gemma 4 12B RL runs: GPU 0 serves vLLM, GPU 1 trains the policy."
 }

--- a/packages/training/config/gpu_profiles/a100-4gpu.json
+++ b/packages/training/config/gpu_profiles/a100-4gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "4x A100 80GB GPUs (320GB total)",
-  "description": "Production A100 cluster: 2x for vLLM, 2x for training. Best value for 30B.",
-  "model": "Qwen/Qwen3-30B-A3B",
+  "description": "Production A100 cluster: 2x for vLLM, 2x for training. Best value for Gemma 4 31B.",
+  "model": "google/gemma-4-31B",
   "vllm_gpu_memory": 0.80,
   "vllm_gpu": "0,1",
   "training_gpu": "2,3",
@@ -19,4 +19,3 @@
   "fsdp_enabled": true,
   "notes": "A100 80GB SXM. vLLM on GPUs 0-1 (tensor parallel), training on GPUs 2-3 (FSDP). ~3-4 hours for 5000 steps. RunPod cost ~$8/hr."
 }
-

--- a/packages/training/config/gpu_profiles/a100.json
+++ b/packages/training/config/gpu_profiles/a100.json
@@ -1,7 +1,7 @@
 {
   "name": "A100 GPU (80GB)",
-  "description": "Single A100 80GB profile for 7B-9B training and co-hosted inference",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Single A100 80GB profile for Gemma 4 12B training and co-hosted inference",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.45,
   "batch_size": 8,
   "max_token_length": 8192,
@@ -12,5 +12,5 @@
   "learning_rate": 1e-5,
   "warmup_steps": 100,
   "use_flash_attention": true,
-  "notes": "Single A100 80GB. Best-value single GPU profile for 7B-9B experimentation when vLLM and training must share one card."
+  "notes": "Single A100 80GB. Best-value single GPU profile for Gemma 4 12B experimentation when vLLM and training must share one card."
 }

--- a/packages/training/config/gpu_profiles/cpu.json
+++ b/packages/training/config/gpu_profiles/cpu.json
@@ -1,7 +1,7 @@
 {
   "name": "CPU Only (No GPU)",
   "description": "For testing without GPU - very slow, not for real training",
-  "model": "Qwen/Qwen2.5-0.5B-Instruct",
+  "model": "google/gemma-4-E2B",
   "vllm_gpu_memory": 0,
   "batch_size": 1,
   "max_token_length": 1024,
@@ -9,4 +9,3 @@
   "skip_vllm": true,
   "notes": "Use external inference server or mock mode"
 }
-

--- a/packages/training/config/gpu_profiles/h100-2gpu.json
+++ b/packages/training/config/gpu_profiles/h100-2gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "2x H100 GPUs (160GB total)",
-  "description": "Dual H100 profile with dedicated inference and training GPUs for 7B-9B RL runs",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Dual H100 profile with dedicated inference and training GPUs for Gemma 4 12B RL runs",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.75,
   "vllm_gpu": "0",
   "training_gpu": "1",
@@ -16,5 +16,5 @@
   "warmup_steps": 150,
   "kl_coefficient": 0.05,
   "use_flash_attention": true,
-  "notes": "Balanced large-box profile for 7B-9B RL: dedicated vLLM on GPU 0, dedicated trainer on GPU 1."
+  "notes": "Balanced large-box profile for Gemma 4 12B RL: dedicated vLLM on GPU 0, dedicated trainer on GPU 1."
 }

--- a/packages/training/config/gpu_profiles/h100-4gpu.json
+++ b/packages/training/config/gpu_profiles/h100-4gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "4x H100 GPUs (320GB total)",
-  "description": "High-performance H100 cluster: 2x for vLLM, 2x for training. Fastest option for 30B.",
-  "model": "Qwen/Qwen3-30B-A3B",
+  "description": "High-performance H100 cluster: 2x for vLLM, 2x for training. Fastest option for Gemma 4 31B.",
+  "model": "google/gemma-4-31B",
   "vllm_gpu_memory": 0.80,
   "vllm_gpu": "0,1",
   "training_gpu": "2,3",
@@ -19,4 +19,3 @@
   "fsdp_enabled": true,
   "notes": "H100 SXM 80GB. vLLM on GPUs 0-1 (tensor parallel), training on GPUs 2-3 (FSDP). ~2-3 hours for 5000 steps. RunPod cost ~$14/hr."
 }
-

--- a/packages/training/config/gpu_profiles/h100.json
+++ b/packages/training/config/gpu_profiles/h100.json
@@ -1,7 +1,7 @@
 {
   "name": "H100 GPU (80GB)",
   "description": "NVIDIA H100 SXM - High-performance single GPU training",
-  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.50,
   "batch_size": 16,
   "max_token_length": 8192,
@@ -12,6 +12,5 @@
   "learning_rate": 1e-5,
   "warmup_steps": 100,
   "use_flash_attention": true,
-  "notes": "H100 SXM 80GB. Can handle 14B model comfortably. For 30B+ models, use h100-4gpu profile."
+  "notes": "H100 SXM 80GB. Can handle Gemma 4 12B comfortably. For 31B models, use h100-4gpu profile."
 }
-

--- a/packages/training/config/gpu_profiles/h200-2gpu.json
+++ b/packages/training/config/gpu_profiles/h200-2gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "2x H200 GPUs (282GB total)",
-  "description": "Dual H200 profile with dedicated inference and training GPUs for the fastest 7B-9B runs",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Dual H200 profile with dedicated inference and training GPUs for the fastest Gemma 4 12B runs",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.75,
   "vllm_gpu": "0",
   "training_gpu": "1",
@@ -16,5 +16,5 @@
   "warmup_steps": 150,
   "kl_coefficient": 0.05,
   "use_flash_attention": true,
-  "notes": "Fastest single-node profile for 7B-9B RL runs: dedicated vLLM on GPU 0 and dedicated trainer on GPU 1."
+  "notes": "Fastest single-node profile for Gemma 4 12B RL runs: dedicated vLLM on GPU 0 and dedicated trainer on GPU 1."
 }

--- a/packages/training/config/gpu_profiles/h200.json
+++ b/packages/training/config/gpu_profiles/h200.json
@@ -1,7 +1,7 @@
 {
   "name": "H200 GPU (141GB)",
-  "description": "Single H200 141GB profile for 7B-9B training with co-hosted inference",
-  "model": "Qwen/Qwen3.5-9B",
+  "description": "Single H200 141GB profile for Gemma 4 12B training with co-hosted inference",
+  "model": "google/gemma-4-12B",
   "vllm_gpu_memory": 0.5,
   "batch_size": 12,
   "max_token_length": 8192,
@@ -12,5 +12,5 @@
   "learning_rate": 8e-6,
   "warmup_steps": 120,
   "use_flash_attention": true,
-  "notes": "Safest single-GPU profile for 7B-9B models when you want to co-host vLLM and training on one H200."
+  "notes": "Safest single-GPU profile for Gemma 4 12B when you want to co-host vLLM and training on one H200."
 }

--- a/packages/training/config/gpu_profiles/l40-2gpu-safe.json
+++ b/packages/training/config/gpu_profiles/l40-2gpu-safe.json
@@ -1,7 +1,7 @@
 {
   "name": "2x L40 GPUs - Safe (96GB total)",
   "description": "Conservative 2x L40 config with smaller model. vLLM on GPU 0, training on GPU 1",
-  "model": "Qwen/Qwen2.5-7B-Instruct",
+  "model": "google/gemma-4-E4B",
   "vllm_gpu_memory": 0.50,
   "vllm_gpu": "0",
   "training_gpu": "1",
@@ -14,7 +14,6 @@
   "gradient_accumulation_steps": 2,
   "learning_rate": 1e-5,
   "warmup_steps": 100,
-  "notes": "Safe 2x L40 profile: vLLM gets dedicated GPU 0 (~24GB for 7B), training gets GPU 1. No OOM conflicts."
+  "notes": "Safe 2x L40 profile: vLLM gets dedicated GPU 0 for Gemma 4 E4B, training gets GPU 1. No OOM conflicts."
 }
-
 

--- a/packages/training/config/gpu_profiles/l40-2gpu.json
+++ b/packages/training/config/gpu_profiles/l40-2gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "2x L40 GPUs (96GB total)",
-  "description": "Dual L40 with vLLM on GPU 0, training on GPU 1 (for 14B models)",
-  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "description": "Dual L40 with vLLM on GPU 0, training on GPU 1 (for Gemma 4 E4B)",
+  "model": "google/gemma-4-E4B",
   "vllm_gpu_memory": 0.85,
   "vllm_gpu": "0",
   "training_gpu": "1",
@@ -16,7 +16,6 @@
   "warmup_steps": 150,
   "kl_coefficient": 0.05,
   "use_flash_attention": true,
-  "notes": "vLLM on GPU 0 (48GB for 14B model), training on GPU 1. No OOM conflicts."
+  "notes": "vLLM on GPU 0 for Gemma 4 E4B, training on GPU 1. No OOM conflicts."
 }
-
 

--- a/packages/training/config/gpu_profiles/l40-4gpu.json
+++ b/packages/training/config/gpu_profiles/l40-4gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "4x L40 GPUs (192GB total)",
-  "description": "Multi-GPU L40 cluster for production Qwen3 30B training",
-  "model": "Qwen/Qwen3-30B-A3B",
+  "description": "Multi-GPU L40 cluster for production Gemma 4 31B training",
+  "model": "google/gemma-4-31B",
   "vllm_gpu_memory": 0.45,
   "tensor_parallel_size": 4,
   "batch_size": 16,
@@ -15,7 +15,6 @@
   "kl_coefficient": 0.05,
   "use_flash_attention": true,
   "fsdp_enabled": true,
-  "notes": "4x L40 with tensor parallelism. Target for Qwen3 30B production runs. Adjust model to Qwen/Qwen3-30B when available."
+  "notes": "4x L40 with tensor parallelism. Target for Gemma 4 31B production runs."
 }
-
 

--- a/packages/training/config/gpu_profiles/l40-8gpu.json
+++ b/packages/training/config/gpu_profiles/l40-8gpu.json
@@ -1,7 +1,7 @@
 {
   "name": "8x L40 GPUs (384GB total)",
-  "description": "Large L40 cluster: 4x for vLLM, 4x for training. Maximum parallelism for 30B.",
-  "model": "Qwen/Qwen3-30B-A3B",
+  "description": "Large L40 cluster: 4x for vLLM, 4x for training. Maximum parallelism for Gemma 4 31B.",
+  "model": "google/gemma-4-31B",
   "vllm_gpu_memory": 0.85,
   "vllm_gpu": "0,1,2,3",
   "training_gpu": "4,5,6,7",
@@ -19,4 +19,3 @@
   "fsdp_enabled": true,
   "notes": "8x L40 48GB. vLLM on GPUs 0-3 (tensor parallel), training on GPUs 4-7 (FSDP). ~4-5 hours for 5000 steps. RunPod cost ~$10/hr."
 }
-

--- a/packages/training/config/gpu_profiles/l40.json
+++ b/packages/training/config/gpu_profiles/l40.json
@@ -1,7 +1,7 @@
 {
   "name": "L40 GPU (48GB)",
   "description": "NVIDIA L40 - Optimized for production training with larger models",
-  "model": "Qwen/Qwen2.5-14B-Instruct",
+  "model": "google/gemma-4-E4B",
   "vllm_gpu_memory": 0.50,
   "batch_size": 8,
   "max_token_length": 8192,
@@ -11,7 +11,6 @@
   "gradient_accumulation_steps": 4,
   "learning_rate": 1e-5,
   "warmup_steps": 100,
-  "notes": "L40 has 48GB VRAM. Uses 14B model for quality. Increase batch_size to 16 for faster training if stable."
+  "notes": "L40 has 48GB VRAM. Uses Gemma 4 E4B for quality. Increase batch_size to 16 for faster training if stable."
 }
-
 

--- a/packages/training/config/tinker.yaml
+++ b/packages/training/config/tinker.yaml
@@ -73,8 +73,8 @@ inference:
   max_tokens: 512
   temperature: 0.7
   stop_sequences:
-    - "<|im_end|>"
-    - "<|endoftext|>"
+    - "<end_of_turn>"
+    - "<eos>"
 
 # =============================================================================
 # Logging

--- a/packages/training/scripts/prepare_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/prepare_eliza1_trajectory_dataset.py
@@ -19,7 +19,7 @@ Outputs:
   * `manifest.json` with split counts, source counts, action counts, and
     privacy redaction totals.
 
-The internal trajectory record is provider-agnostic: a Qwen/ChatML-oriented
+The internal trajectory record is provider-agnostic: a Gemma 4-oriented
 `messages` array, OpenAI-style function `tools`, canonicalized `actions`, and
 source/quality metadata. The default disk splits are converted back to the
 existing `eliza_native_v1` training row shape because `train_local.py` loads
@@ -46,6 +46,9 @@ DEFAULT_ALIAS_PATH = TRAINING_ROOT / "config" / "eliza1_action_aliases.json"
 
 SCHEMA_VERSION = "eliza.eliza1_trajectory_record.v1"
 MANIFEST_SCHEMA = "eliza.eliza1_trajectory_dataset_manifest.v1"
+DEFAULT_BASE_MODEL = "google/gemma-4-E2B"
+TARGET_MODEL_FAMILY = "gemma"
+TARGET_CHAT_TEMPLATE = "gemma4"
 NATIVE_FORMAT = "eliza_native_v1"
 NATIVE_BOUNDARIES = {"vercel_ai_sdk.generateText", "vercel_ai_sdk.streamText"}
 TRAINING_BOUNDARY = "vercel_ai_sdk.generateText"
@@ -675,10 +678,10 @@ def quality_block(success: bool, score: float, reasons: list[str]) -> dict[str, 
 
 def target_block(base_model: str) -> dict[str, str]:
     return {
-        "modelFamily": "qwen",
+        "modelFamily": TARGET_MODEL_FAMILY,
         "baseModel": base_model,
         "sftFormat": "messages",
-        "chatTemplate": "chatml",
+        "chatTemplate": TARGET_CHAT_TEMPLATE,
     }
 
 
@@ -1500,7 +1503,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Input JSON/JSONL file or directory. Repeatable.",
     )
     parser.add_argument("--output-dir", required=True)
-    parser.add_argument("--base-model", default="Qwen3.5/3.6")
+    parser.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
     parser.add_argument("--val-ratio", type=float, default=0.05)
     parser.add_argument("--test-ratio", type=float, default=0.05)
     parser.add_argument("--seed", default="eliza1-trajectory-sft-v1")

--- a/packages/training/scripts/publish_eliza1_dataset_candidate.py
+++ b/packages/training/scripts/publish_eliza1_dataset_candidate.py
@@ -978,13 +978,13 @@ def _render_readme(manifest: dict[str, Any]) -> str:
         )
     elif contract["trainLocalReady"]:
         training_note = (
-            "This candidate is train-local ready for the current Qwen path as "
+            "This candidate is train-local ready for the current Eliza-1 path as "
             f"`{contract['trainingReadySchema']}`."
         )
     else:
         training_note = (
             "This candidate is not directly train-local ready for the current "
-            "Qwen path; convert it to `eliza_native_v1` before training."
+            "Eliza-1 path; convert it to `eliza_native_v1` before training."
         )
     return (
         "---\n"

--- a/packages/training/scripts/test_prepare_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/test_prepare_eliza1_trajectory_dataset.py
@@ -10,7 +10,12 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from format_for_training import format_record  # noqa: E402
-from prepare_eliza1_trajectory_dataset import main as prepare_main  # noqa: E402
+from prepare_eliza1_trajectory_dataset import (  # noqa: E402
+    DEFAULT_BASE_MODEL,
+    TARGET_CHAT_TEMPLATE,
+    TARGET_MODEL_FAMILY,
+    main as prepare_main,
+)
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> None:
@@ -115,6 +120,12 @@ def test_prepare_native_rows_canonicalizes_aliases_and_splits_failures(tmp_path:
     assert trajectory_train[0]["actions"] == [
         {"name": "SHELL", "originalName": "SHELL_COMMAND", "arguments": {"command": "pwd"}}
     ]
+    assert trajectory_train[0]["target"] == {
+        "modelFamily": TARGET_MODEL_FAMILY,
+        "baseModel": DEFAULT_BASE_MODEL,
+        "sftFormat": "messages",
+        "chatTemplate": TARGET_CHAT_TEMPLATE,
+    }
     assert trajectory_train[0]["messages"][-1]["tool_calls"][0]["function"]["name"] == "SHELL"
     assert "<REDACTED:openai-key>" in train[0]["request"]["messages"][0]["content"]
     assert manifest["recordSchema"] == "eliza_native_v1"

--- a/packages/training/scripts/test_publish_eliza1_dataset_candidate.py
+++ b/packages/training/scripts/test_publish_eliza1_dataset_candidate.py
@@ -8,6 +8,13 @@ from pathlib import Path
 import pytest
 
 SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+from prepare_eliza1_trajectory_dataset import (  # noqa: E402
+    DEFAULT_BASE_MODEL,
+    TARGET_CHAT_TEMPLATE,
+    TARGET_MODEL_FAMILY,
+)
 
 
 def _load():
@@ -95,10 +102,10 @@ def eliza1_trajectory_record(split: str, *, success: bool = True) -> dict:
         "split": split,
         "task": "lifeops_trajectory_turn",
         "target": {
-            "modelFamily": "qwen",
-            "baseModel": "Qwen3.5/3.6",
+            "modelFamily": TARGET_MODEL_FAMILY,
+            "baseModel": DEFAULT_BASE_MODEL,
             "sftFormat": "messages",
-            "chatTemplate": "chatml",
+            "chatTemplate": TARGET_CHAT_TEMPLATE,
         },
         "messages": [
             {"role": "user", "content": "hello"},

--- a/packages/training/scripts/test_validate_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/test_validate_eliza1_trajectory_dataset.py
@@ -7,7 +7,12 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from prepare_eliza1_trajectory_dataset import main as prepare_main  # noqa: E402
+from prepare_eliza1_trajectory_dataset import (  # noqa: E402
+    DEFAULT_BASE_MODEL,
+    TARGET_CHAT_TEMPLATE,
+    TARGET_MODEL_FAMILY,
+    main as prepare_main,
+)
 from validate_eliza1_trajectory_dataset import main as validate_main  # noqa: E402
 
 
@@ -281,10 +286,10 @@ def test_validate_rejects_trajectory_record_without_user_turn(tmp_path: Path) ->
         "split": "train",
         "task": "response",
         "target": {
-            "modelFamily": "qwen",
-            "baseModel": "Qwen3.5/3.6",
+            "modelFamily": TARGET_MODEL_FAMILY,
+            "baseModel": DEFAULT_BASE_MODEL,
             "sftFormat": "messages",
-            "chatTemplate": "chatml",
+            "chatTemplate": TARGET_CHAT_TEMPLATE,
         },
         "messages": [{"role": "assistant", "content": "Hello."}],
         "tools": [],
@@ -320,3 +325,54 @@ def test_validate_rejects_trajectory_record_without_user_turn(tmp_path: Path) ->
     assert code == 1
     assert parsed["errorsByCode"]["messages_missing_user"] == 1
     assert parsed["errorsByCode"]["trajectory_not_train_local_convertible"] == 1
+
+
+def test_validate_rejects_legacy_qwen_target_metadata(tmp_path: Path) -> None:
+    row = {
+        "schema": "eliza.eliza1_trajectory_record.v1",
+        "id": "legacy-qwen-target-1",
+        "split": "train",
+        "task": "response",
+        "target": {
+            "modelFamily": "qwen",
+            "baseModel": "Qwen3.5/3.6",
+            "sftFormat": "messages",
+            "chatTemplate": "chatml",
+        },
+        "messages": [
+            {"role": "user", "content": "Hello."},
+            {"role": "assistant", "content": "Hi."},
+        ],
+        "tools": [],
+        "actions": [],
+        "quality": {
+            "success": True,
+            "score": 1.0,
+            "weight": 1.0,
+            "rating": "gold",
+            "requiresRepair": False,
+            "reasons": [],
+        },
+        "source": {
+            "kind": "eliza_native_v1",
+            "dataset": "unit",
+            "path": "unit.jsonl",
+            "rowIndex": 0,
+            "sourceId": None,
+            "trajectoryId": None,
+            "scenarioId": None,
+            "turnIndex": None,
+            "format": "eliza_native_v1",
+        },
+        "metadata": {},
+    }
+    bad = tmp_path / "train.jsonl"
+    _write_jsonl(bad, [row])
+    report = tmp_path / "legacy-target-report.json"
+
+    code = validate_main(["--input", str(bad), "--report", str(report), "--strict"])
+
+    parsed = json.loads(report.read_text(encoding="utf-8"))
+    assert code == 1
+    assert parsed["errorsByCode"]["target_model_family_invalid"] == 1
+    assert parsed["errorsByCode"]["target_chat_template_invalid"] == 1

--- a/packages/training/scripts/validate_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/validate_eliza1_trajectory_dataset.py
@@ -24,6 +24,8 @@ DEFAULT_ALIAS_PATH = TRAINING_ROOT / "config" / "eliza1_action_aliases.json"
 
 sys.path.insert(0, str(SCRIPT_DIR))
 from prepare_eliza1_trajectory_dataset import (  # noqa: E402
+    TARGET_CHAT_TEMPLATE,
+    TARGET_MODEL_FAMILY,
     NATIVE_BOUNDARIES,
     NATIVE_FORMAT,
     SCHEMA_VERSION,
@@ -392,12 +394,22 @@ def validate_record(
     target = record.get("target")
     errs.extend(_check_keyset(target, REQUIRED_TARGET, path="target", allow_extra=False))
     if isinstance(target, dict):
-        if target.get("modelFamily") != "qwen":
-            errs.append(("target_model_family_invalid", "target.modelFamily must be qwen"))
+        if target.get("modelFamily") != TARGET_MODEL_FAMILY:
+            errs.append(
+                (
+                    "target_model_family_invalid",
+                    f"target.modelFamily must be {TARGET_MODEL_FAMILY}",
+                )
+            )
         if target.get("sftFormat") != "messages":
             errs.append(("target_sft_format_invalid", "target.sftFormat must be messages"))
-        if target.get("chatTemplate") != "chatml":
-            errs.append(("target_chat_template_invalid", "target.chatTemplate must be chatml"))
+        if target.get("chatTemplate") != TARGET_CHAT_TEMPLATE:
+            errs.append(
+                (
+                    "target_chat_template_invalid",
+                    f"target.chatTemplate must be {TARGET_CHAT_TEMPLATE}",
+                )
+            )
 
     messages = record.get("messages")
     if not isinstance(messages, list) or not messages:


### PR DESCRIPTION
## Summary
- Switch Eliza-1 trajectory target metadata from legacy Qwen/ChatML to Gemma 4 (`google/gemma-4-E2B`, `modelFamily=gemma`, `chatTemplate=gemma4`).
- Update the trajectory-record JSON schema, validator, publisher fixture/copy, and regression tests so legacy Qwen target metadata is rejected.
- Update training GPU profiles and Tinker stop tokens away from Qwen/ChatML defaults.

## Evidence
- Rebasing/sync: branch rebased on latest `origin/develop` before push.
- `uv run --directory packages/training --with pytest python -m pytest scripts/test_prepare_eliza1_trajectory_dataset.py scripts/test_validate_eliza1_trajectory_dataset.py scripts/test_publish_eliza1_dataset_candidate.py` -> 36 passed, 1 existing pytest config warning (`asyncio_mode`).
- Python JSON parse check over `packages/training/config/gpu_profiles/*.json` and `packages/training/config/eliza1_trajectory_record.schema.json` -> ok.
- `rg` scan over touched training config/schema/prepare/validate paths for `Qwen3.5`, `Qwen2.5`, `Qwen/Qwen`, `qwen35`, `ChatML`, `chatml`, `<|im_end|>`, `<|endoftext|>` -> no matches.
- `git diff --check origin/develop...HEAD` -> clean.

## Notes
- This is a training metadata/config chunk for #9588's broader Gemma cutover. It does not regenerate or publish the Kokoro GGUF/HF bundle.
- Full repo `bun run verify` was not run in this isolated worktree; the focused Python/config gates above cover the changed files.

Part of #9588.
