### PR TITLE
fix(local-inference): wire staged LiteRT bundle selection

### DIFF
--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -590,14 +590,14 @@ function textQuantizationMatrix(args: {
   const variants: CatalogQuantizationVariant[] = [
     mk("q3_k_m", "3-bit", 0.76, 0.85, "planned"),
     // Gemma-4 QAT Q4_0: same ~4-bit footprint as q4_k_m but the official
-    // quantization-aware-trained checkpoint — ~2x faster on the mobile NPU
-    // and 40-50% lighter on memory, so it is the on-device-preferred quant.
+    // quantization-aware-trained checkpoint. Keep this planned until the
+    // tier-specific `*-Q4_0.gguf` artifacts are present in the hosted bundle.
     mk(
       "q4_0",
       "4-bit",
       0.94,
       0.95,
-      "published",
+      "planned",
       args.onDevice ? { mobilePreferred: true } : undefined,
     ),
     mk("q4_k_m", "4-bit", 1, 1, "published"),

--- a/plugins/plugin-local-inference/src/services/catalog.test.ts
+++ b/plugins/plugin-local-inference/src/services/catalog.test.ts
@@ -177,13 +177,15 @@ describe("local inference catalog", () => {
 		for (const id of ELIZA_1_TIER_IDS) {
 			const model = findCatalogModel(id);
 			expect(model?.quantization?.defaultVariantId).toBe("q4_k_m");
-			expect(model?.quantization?.variants.map((v) => v.id)).toEqual([
-				"q3_k_m",
-				"q4_k_m",
-				"q5_k_m",
-				"q6_k",
-				"q8_0",
-			]);
+			const variantIds = model?.quantization?.variants.map((v) => v.id);
+			const expected = ["q3_k_m", "q4_0", "q4_k_m", "q5_k_m", "q6_k", "q8_0"];
+			if (id === "eliza-1-2b" || id === "eliza-1-4b") {
+				expected.push("wna8o8");
+			}
+			expect(variantIds).toEqual(expected);
+			expect(
+				model?.quantization?.variants.find((v) => v.id === "q4_0")?.status,
+			).toBe("planned");
 		}
 
 		// Mobile-class tiers (2b/4b) ship Kokoro only — it is smaller +

--- a/plugins/plugin-local-inference/src/services/engine-direct-bundle.test.ts
+++ b/plugins/plugin-local-inference/src/services/engine-direct-bundle.test.ts
@@ -28,6 +28,9 @@ describe("LocalInferenceEngine direct Eliza-1 bundle loads", () => {
 		};
 
 		const bundleRoot = path.join(root, "eliza-1-2b.bundle");
+		const litertPath = path.join(bundleRoot, "text", "eliza-1-2b.litertlm");
+		fs.mkdirSync(path.dirname(litertPath), { recursive: true });
+		fs.writeFileSync(litertPath, "fake litert bundle");
 		const modelPath = path.join(bundleRoot, "text", "eliza-1-2b-128k.gguf");
 		await engine.load(modelPath, {
 			modelPath,
@@ -42,6 +45,7 @@ describe("LocalInferenceEngine direct Eliza-1 bundle loads", () => {
 		expect(captured?.overrides?.manifestPath).toBe(
 			path.join(bundleRoot, "eliza-1.manifest.json"),
 		);
+		expect(captured?.overrides?.litertModelPath).toBe(litertPath);
 		expect(
 			(
 				engine as unknown as {

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -13,6 +13,7 @@
  *      `ensure-local-inference-handler.ts`).
  */
 
+import { existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import {
 	logger,
@@ -217,6 +218,32 @@ function estimateTextResidentMb(
 	return baseMb > 0 ? baseMb + TEXT_RESIDENT_OVERHEAD_MB : 0;
 }
 
+function stagedLitertModelPath(
+	bundleRoot: string,
+	modelId: string | undefined,
+): string | undefined {
+	const textDir = path.join(bundleRoot, "text");
+	if (!existsSync(textDir) || !statSync(textDir).isDirectory()) {
+		return undefined;
+	}
+
+	if (modelId?.startsWith("eliza-1-")) {
+		const expected = path.join(textDir, `${modelId}.litertlm`);
+		if (existsSync(expected) && statSync(expected).isFile()) {
+			return expected;
+		}
+	}
+
+	const candidates = readdirSync(textDir)
+		.filter((name) => name.endsWith(".litertlm"))
+		.sort();
+	if (candidates.length === 1) {
+		const candidate = path.join(textDir, candidates[0]);
+		if (statSync(candidate).isFile()) return candidate;
+	}
+	return undefined;
+}
+
 /**
  * Project a fully-resolved `LocalInferenceLoadArgs` onto the subset that
  * the dispatcher cares about. Keeps `BackendLoadOverrides` framework-free
@@ -246,6 +273,8 @@ function toBackendLoadOverrides(
 		const bundleRoot = path.dirname(path.dirname(args.modelPath));
 		overrides.bundleRoot = bundleRoot;
 		overrides.manifestPath = path.join(bundleRoot, "eliza-1.manifest.json");
+		const litertModelPath = stagedLitertModelPath(bundleRoot, args.modelId);
+		if (litertModelPath) overrides.litertModelPath = litertModelPath;
 	}
 	return overrides;
 }


### PR DESCRIPTION
## Summary
- wires staged `<bundleRoot>/text/*.litertlm` artifacts into `BackendPlan.overrides.litertModelPath` so merged #9640's LiteRT dispatcher path is reachable from normal Eliza-1 engine loads
- keeps `q4_0` quant variants as `planned` until the hosted `*-Q4_0.gguf` files exist in `elizaos/eliza-1`
- updates the local-inference catalog test for the new `q4_0` and mobile-only `wna8o8` variants

## Evidence
- `bun run --cwd plugins/plugin-local-inference test -- src/services/catalog.test.ts src/services/engine-direct-bundle.test.ts`
- `bun run --cwd packages/shared test -- src/local-inference/catalog.test.ts`
- `bunx @biomejs/biome check packages/shared/src/local-inference/catalog.ts plugins/plugin-local-inference/src/services/engine.ts plugins/plugin-local-inference/src/services/catalog.test.ts plugins/plugin-local-inference/src/services/engine-direct-bundle.test.ts`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `git diff --check`

## Notes
- `bun install --frozen-lockfile --ignore-scripts` currently reports that the lockfile would change on this base, so I used `bun install --no-save --ignore-scripts` in the clean worktree and generated the skipped keyword data with `node packages/shared/scripts/generate-keywords.mjs --target ts` before running plugin tests.
- Current HF API listings for `elizaos/eliza-1` text bundle directories do not include `*-Q4_0.gguf` or `*.litertlm`; this PR avoids marking Q4_0 as published until that artifact publish step lands.

Refs #9588, #9640.
