### PR TITLE
chore(types): ratchet as-unknown-as baseline 299 -> 296 (#9474)

### DIFF
--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-25T08:25:06.946Z",
+  "updatedAt": "2026-06-25T09:54:09.690Z",
   "scope": {
     "trackedOnly": true,
     "globs": [
@@ -36,10 +36,10 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 299,
+    "asUnknownAs": 296,
     "asAny": 0,
     "tsSuppress": 0,
     "nonNullAssertion": 577
   },
-  "filesScanned": 9985
+  "filesScanned": 9990
 }


### PR DESCRIPTION
Locks in the 3-cast reduction from #9644 (local-inference catalog/engine wiring). `develop` now measures **296** `as unknown as` vs a 299 baseline; this tightens the baseline to 296 so it can't regress.

Down-only ratchet (the script's intended direction). All other metrics unchanged (`as any` 0, `@ts-*` 0, non-null `!` 577).

Verified: `node packages/scripts/type-safety-ratchet.mjs` → 296/296 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)