### PR TITLE
fix(local-inference): reject Qwen ASR release provenance

### DIFF
--- a/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
@@ -489,6 +489,39 @@ describe("validateManifest — contract rejections", () => {
 		}
 	});
 
+	it("rejects strict/defaultEligible Qwen ASR provenance", () => {
+		const m = baseManifest();
+		m.lineage.asr = {
+			base: "ggml-org/Qwen3-ASR-0.6B",
+			license: "apache-2.0",
+		};
+		m.provenance = {
+			releaseState: "base-v1",
+			finetuned: false,
+			sourceModels: {
+				text: { repo: "google/gemma-4-12B-base" },
+				voice: { repo: "Serveurperso/OmniVoice-GGUF" },
+				drafter: { repo: "elizaos/eliza-1" },
+				asr: { repo: "ggml-org/Qwen3-ASR-GGUF" },
+				embedding: { repo: "google/gemma-4-12B-base" },
+				imagegen: { repo: "elizaos/eliza-1-imagegen" },
+				vad: { repo: "onnx-community/silero-vad" },
+				vision: { repo: "unsloth/gemma-4-12B-GGUF" },
+			},
+		};
+
+		const result = validateManifest(m);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.errors).toEqual(
+				expect.arrayContaining([
+					expect.stringContaining("lineage.asr.base"),
+					expect.stringContaining("provenance.sourceModels.asr.repo"),
+				]),
+			);
+		}
+	});
+
 	it("rejects expressive voice capabilities without expressive eval", () => {
 		const m = baseManifest();
 		m.voice = {

--- a/plugins/plugin-local-inference/src/services/manifest/validator.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/validator.ts
@@ -206,6 +206,8 @@ const STAGING_VERSION_TOKENS: ReadonlySet<string> = new Set([
 	"local",
 ]);
 
+const QWEN_PROVENANCE_RE = /\bqwen/i;
+
 function isStagingManifestVersion(version: string): boolean {
 	const prerelease = version.match(
 		/^[0-9]+\.[0-9]+\.[0-9]+-([^+]+)(?:\+.*)?$/,
@@ -237,9 +239,24 @@ function collectContractErrors(
 	// pre-cutover bundles shipped. Block a stand-in from defining the default.
 	if (strictRelease) {
 		const textBase = m.lineage.text.base;
-		if (/^local-standin:/i.test(textBase) || /\bqwen/i.test(textBase)) {
+		if (
+			/^local-standin:/i.test(textBase) ||
+			QWEN_PROVENANCE_RE.test(textBase)
+		) {
 			errors.push(
 				`lineage.text.base: a strict/defaultEligible release must ship the real Gemma-4 base, not a stand-in (${textBase})`,
+			);
+		}
+		const asrBase = m.lineage.asr?.base;
+		if (asrBase && QWEN_PROVENANCE_RE.test(asrBase)) {
+			errors.push(
+				`lineage.asr.base: a strict/defaultEligible Gemma-4 release must not ship Qwen ASR provenance (${asrBase})`,
+			);
+		}
+		const asrRepo = m.provenance?.sourceModels?.asr?.repo;
+		if (asrRepo && QWEN_PROVENANCE_RE.test(asrRepo)) {
+			errors.push(
+				`provenance.sourceModels.asr.repo: a strict/defaultEligible Gemma-4 release must not source ASR from Qwen (${asrRepo})`,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary
- adds a strict/defaultEligible manifest contract gate that rejects Qwen-derived ASR lineage/provenance for Gemma-4 Eliza-1 releases
- keeps candidate/staging manifests able to carry legacy Qwen ASR provenance while the actual Gemma ASR backend/artifacts are being staged
- adds a regression test covering both `lineage.asr.base` and `provenance.sourceModels.asr.repo`

## Why
Gemma 4 supports audio input / ASR directly, so a release-shaped Gemma cutover bundle should not pass validation while still claiming Qwen3-ASR provenance. This makes the remaining ASR cutover visible at bundle validation time instead of allowing a Qwen ASR bundle to be marked default-eligible.

## Evidence
- `bun run --cwd plugins/plugin-local-inference test -- src/services/manifest/manifest.test.ts` — 1 file / 53 tests passed
- `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/manifest/validator.ts plugins/plugin-local-inference/src/services/manifest/manifest.test.ts` — passed
- `bun run --cwd plugins/plugin-local-inference typecheck` — passed
- `git diff --check` — clean

Refs #9588.
