### PR TITLE
perf(boot): subdivide svc:pre-init boot lap to attribute the 15s cost (#9565)

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4775,7 +4775,9 @@ export async function startEliza(
   // requested). The runtime is reported ready as soon as this resolves.
   const initializeRuntimeServices = async (): Promise<void> => {
     await runStewardEvmPreBoot();
+    bootTimer.lap("svc:steward-evm");
     await registerConnectorSetupService();
+    bootTimer.lap("svc:connector-setup");
     await registerRemoteCodingRunner();
     bootTimer.lap("svc:pre-init");
 
@@ -5022,6 +5024,12 @@ export async function startEliza(
   };
 
   try {
+    // Time from the register-sql lap up to entering service init (roles
+    // capability registration + any blocking pre-init work). Split out so a
+    // device boot can attribute the dominant cost instead of lumping it into
+    // svc:pre-init (issue #9565): on a bundled mobile runtime the three hooks
+    // below are each fast/no-op, yet svc:pre-init was ~15s of a 16s cold boot.
+    bootTimer.lap("svc:boot-prep");
     await initializeRuntimeServices();
   } catch (err) {
     const pgliteDataDir = resolveActivePgliteDataDir(config);


### PR DESCRIPTION
## Why
Pulled the boot telemetry (from #9595) off a connected **Pixel 9a**: cold boot **16.1s**, with **15.07s (93%) in one coarse `svc:pre-init` lap**. But every named call in that bucket is fast/no-op on a bundled mobile runtime:
- `runStewardEvmPreBoot()` early-returns unless signing-ready
- `ConnectorSetupService.start()` is trivial (`new …` + debug log)
- `registerRemoteCodingRunner()` early-returns on `isBundledMobileRuntime()`
- the embedding/skills warmups are `void …().catch()` (deferred)

So the dominant 15s is **unattributed** — the lap is too coarse to act on.

## What
Add finer boot laps (pure additive instrumentation, zero behavior change) so the next device boot localizes the cost:
- `svc:boot-prep` — register-sql → entering service init (roles capability + any blocking pre-init)
- `svc:steward-evm` / `svc:connector-setup` — each hook
- `svc:pre-init` — remaining hook

## Verification
- `@elizaos/agent` typecheck **55/55**
- type-safety ratchet **296/296**
- biome format clean
- no test asserts boot-lap names (grep clean)

On-device breakdown will follow once a mobile build picks this up (the lap mechanism itself is the same plumbing already proven by the telemetry above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)