### PR TITLE
refactor(workflow): replace as-unknown-as CatalogLike cast with type guard (#9474)

### DIFF
--- a/plugins/plugin-workflow/src/routes/workflow-routes.ts
+++ b/plugins/plugin-workflow/src/routes/workflow-routes.ts
@@ -73,10 +73,13 @@ function getWorkflowService(ctx: WorkflowRouteContext): WorkflowService | null {
   return (ctx.runtime?.getService?.(WORKFLOW_SERVICE_TYPE) as WorkflowService | null) ?? null;
 }
 
+function isCatalogLike(value: unknown): value is CatalogLike {
+  return isRecord(value) && typeof value.listGroups === 'function';
+}
+
 function getConnectorTargetCatalog(ctx: WorkflowRouteContext): CatalogLike | null {
   const raw = ctx.runtime?.getService?.('connector_target_catalog');
-  const candidate = raw as unknown as CatalogLike | undefined;
-  return candidate && typeof candidate.listGroups === 'function' ? candidate : null;
+  return isCatalogLike(raw) ? raw : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
Part of #9474 (eliminate `any`/`unknown`/unsafe casts). Removes one production `as unknown as` from `plugin-workflow`.

`getConnectorTargetCatalog` cast a `getService()` result via `raw as unknown as CatalogLike | undefined`, then inline-checked `typeof candidate.listGroups === 'function'`. `CatalogLike` is a **single-method interface** (`listGroups` only), so an `isCatalogLike` type guard validates **exactly** the required member — the same runtime check, with no `as unknown as` escape — matching the file's existing `isRecord` / `isWorkflowDefinition` / `asClarificationResolution` guard idiom.

```diff
-  const candidate = raw as unknown as CatalogLike | undefined;
-  return candidate && typeof candidate.listGroups === 'function' ? candidate : null;
+function isCatalogLike(value: unknown): value is CatalogLike {
+  return isRecord(value) && typeof value.listGroups === 'function';
+}
+  return isCatalogLike(raw) ? raw : null;
```

## Verification
- `as unknown as` count in `workflow-routes.ts`: **1 → 0** (no fake precision — the guard checks the type's single member).
- `tsgo --noEmit` on `plugin-workflow`: **zero errors referencing the changed file** (remaining module-resolution errors are pre-existing/env, unrelated).
- Behavior unchanged: same null-on-missing-or-wrong-shape semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)