### PR TITLE
perf(vision): persistent WinRT OCR host — kill the per-region cold-spawn tax on Windows

### DIFF
--- a/plugins/plugin-vision/src/ocr-host-windows.real.test.ts
+++ b/plugins/plugin-vision/src/ocr-host-windows.real.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Real verification of the persistent WinRT OCR host (#9105 / #9581 follow-up).
+ * Gated: runs only on Windows (the host is win32-only; elsewhere
+ * `ocrHostAvailable()` is false and `describe()` uses its one-shot path).
+ *
+ * Renders a high-contrast text PNG with System.Drawing, then OCRs it through the
+ * warm host and asserts: valid JSON of the expected shape, the host is fast once
+ * warm (only achievable without per-call cold spawns), a nonexistent image is
+ * answered (error-JSON, no hang), and the host survives an error.
+ *
+ * See `src/ocr-host-windows.ts`. Cold-vs-warm latency evidence is in the PR.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  ocrHostAvailable,
+  runOcrHost,
+  shutdownOcrHost,
+} from "./ocr-host-windows.js";
+
+const RUN = platform() === "win32";
+
+function makeTextPng(text: string): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), "ocrhost-test-"));
+  const p = join(dir, "text.png").replace(/\//g, "\\");
+  const ps = [
+    "Add-Type -AssemblyName System.Drawing",
+    "$b = New-Object System.Drawing.Bitmap(640, 200)",
+    "$g = [System.Drawing.Graphics]::FromImage($b)",
+    "$g.Clear([System.Drawing.Color]::White)",
+    "$f = New-Object System.Drawing.Font('Arial', 48)",
+    `$g.DrawString('${text}', $f, [System.Drawing.Brushes]::Black, 20, 60)`,
+    "$g.Dispose()",
+    `$b.Save('${p}')`,
+    "$b.Dispose()",
+  ].join("; ");
+  execSync(`powershell -NoProfile -Command "${ps}"`, {
+    timeout: 60_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return { dir, path: p };
+}
+
+describe("ocr-host-windows (warm WinRT OCR host, Windows)", () => {
+  afterAll(() => {
+    shutdownOcrHost();
+  });
+
+  it.skipIf(!RUN)("is reported available on win32", () => {
+    expect(ocrHostAvailable()).toBe(true);
+  });
+
+  it.skipIf(!RUN)(
+    "recognizes text and returns the expected JSON shape",
+    async () => {
+      const { dir, path } = makeTextPng("INVOICE 4096");
+      try {
+        const json = await runOcrHost(path);
+        const parsed = JSON.parse(json);
+        expect(parsed.width).toBeGreaterThan(0);
+        expect(parsed.height).toBeGreaterThan(0);
+        expect(Array.isArray(parsed.lines)).toBe(true);
+        const allText = (parsed.lines ?? [])
+          .map((l: { text: string }) => l.text)
+          .join(" ");
+        // OCR is not byte-exact, but it should recover a distinctive token.
+        expect(allText).toMatch(/4096|INVOICE/i);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it.skipIf(!RUN)(
+    "is fast once warm (no per-call cold spawn / WinRT reload)",
+    async () => {
+      const { dir, path } = makeTextPng("WARM 7");
+      try {
+        await runOcrHost(path); // warm
+        const start = Date.now();
+        for (let i = 0; i < 3; i++) await runOcrHost(path);
+        const perCall = (Date.now() - start) / 3;
+        // A cold spawn + WinRT load alone is ~10-16s; only the persistent host
+        // can hold this ceiling.
+        expect(perCall).toBeLessThan(4_000);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it.skipIf(!RUN)(
+    "answers a nonexistent image with error-JSON and stays usable",
+    async () => {
+      const bad = await runOcrHost(
+        join(tmpdir(), "ocrhost-nope-zzz-does-not-exist.png"),
+      );
+      const parsed = JSON.parse(bad);
+      expect(Array.isArray(parsed.lines)).toBe(true);
+      expect(parsed.lines.length).toBe(0);
+      const { dir, path } = makeTextPng("ALIVE");
+      try {
+        const ok = JSON.parse(await runOcrHost(path));
+        expect(Array.isArray(ok.lines)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/plugins/plugin-vision/src/ocr-host-windows.ts
+++ b/plugins/plugin-vision/src/ocr-host-windows.ts
@@ -1,0 +1,251 @@
+/**
+ * Persistent WinRT OCR host (Windows-only) — kills the per-OCR cold-spawn tax.
+ *
+ * `WindowsMediaOcrService.describe()` previously ran `powershell -File
+ * windows-ocr.ps1` for EVERY recognized region. On Defender-heavy hosts a cold
+ * `powershell.exe` spawn is ~10-16s (#9581), and OCR fires on every dirty region
+ * every turn — and the scene pipeline OCRs regions in parallel, so a turn would
+ * spawn N cold processes at once and thrash the AV scanner.
+ *
+ * This keeps ONE long-lived `powershell.exe` that loads the (expensive) WinRT
+ * projection + `OcrEngine` ONCE in its parent scope, then loops: read an image
+ * path on stdin, recognize, emit one compact JSON line on stdout. So each call
+ * pays neither the process spawn NOR the WinRT type-load — only the recognize
+ * (~0.3-1s). Requests are serialized over the one pipe (fine — each is fast).
+ *
+ * It is a pure latency optimization: `describe()` falls back to the original
+ * one-shot `-File` spawn whenever the host is unavailable / disabled / errors,
+ * so output is unchanged. No-op off Windows. Disable with `ELIZA_VISION_OCR_HOST=0`.
+ *
+ * Protocol: JS writes `<absolute-image-path>\n`; the host writes exactly one
+ * line of compact JSON (`{width,height,lines}` — same shape as the one-shot
+ * script). base64 isn't needed: temp image paths never contain newlines, and
+ * `ConvertTo-Json -Compress` output is always a single physical line.
+ */
+
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { unlinkSync, writeFileSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const STARTUP_TIMEOUT_MS = 25_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_START_FAILURES = 2;
+
+let host: ChildProcessWithoutNullStreams | null = null;
+let starting: Promise<void> | null = null;
+let startFailures = 0;
+let loopScriptPath: string | null = null;
+let stdoutBuf = "";
+let stderrRing = "";
+let pending: {
+  resolve: (line: string) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+} | null = null;
+let chain: Promise<unknown> = Promise.resolve();
+
+// One-time preamble loads the WinRT projection + OcrEngine in the parent scope;
+// the loop reuses them per request. Mirrors the recognition logic of the
+// one-shot `WIN_OCR_PS1` exactly so output is identical — only the spawn + the
+// type-load are amortized. Streams/bitmaps are disposed each iteration (a
+// long-lived session must not leak handles or keep temp PNGs locked).
+const OCR_SERVER_PS1 =
+  String.raw`$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Add-Type -AssemblyName System.Runtime.WindowsRuntime
+$asTaskGeneric = ([System.WindowsRuntimeSystemExtensions].GetMethods() | Where-Object {
+  $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and
+  $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation` +
+  "`" +
+  String.raw`1'
+})[0]
+function Await($op, $resultType) {
+  $m = $asTaskGeneric.MakeGenericMethod($resultType)
+  $t = $m.Invoke($null, @($op))
+  $t.Wait(-1) | Out-Null
+  $t.Result
+}
+[Windows.Media.Ocr.OcrEngine, Windows.Media.Ocr, ContentType = WindowsRuntime] | Out-Null
+[Windows.Graphics.Imaging.BitmapDecoder, Windows.Graphics.Imaging, ContentType = WindowsRuntime] | Out-Null
+[Windows.Storage.StorageFile, Windows.Storage, ContentType = WindowsRuntime] | Out-Null
+$engine = [Windows.Media.Ocr.OcrEngine]::TryCreateFromUserProfileLanguages()
+while ($true) {
+  $ImagePath = [Console]::In.ReadLine()
+  if ($null -eq $ImagePath) { break }
+  if ($ImagePath.Length -eq 0) { continue }
+  try {
+    if ($null -eq $engine) { [Console]::Out.WriteLine('{"width":0,"height":0,"lines":[]}'); [Console]::Out.Flush(); continue }
+    $file = Await ([Windows.Storage.StorageFile]::GetFileFromPathAsync($ImagePath)) ([Windows.Storage.StorageFile])
+    $stream = Await ($file.OpenAsync([Windows.Storage.FileAccessMode]::Read)) ([Windows.Storage.Streams.IRandomAccessStream])
+    $decoder = Await ([Windows.Graphics.Imaging.BitmapDecoder]::CreateAsync($stream)) ([Windows.Graphics.Imaging.BitmapDecoder])
+    $bitmap = Await ($decoder.GetSoftwareBitmapAsync()) ([Windows.Graphics.Imaging.SoftwareBitmap])
+    $result = Await ($engine.RecognizeAsync($bitmap)) ([Windows.Media.Ocr.OcrResult])
+    $lines = @()
+    foreach ($line in $result.Lines) {
+      $words = @()
+      foreach ($w in $line.Words) {
+        $r = $w.BoundingRect
+        $words += [pscustomobject]@{ text = $w.Text; x = [int]$r.X; y = [int]$r.Y; width = [int]$r.Width; height = [int]$r.Height }
+      }
+      $lines += [pscustomobject]@{ text = $line.Text; words = $words }
+    }
+    $out = [pscustomobject]@{ width = [int]$bitmap.PixelWidth; height = [int]$bitmap.PixelHeight; lines = $lines } | ConvertTo-Json -Depth 6 -Compress
+    $bitmap.Dispose()
+    $stream.Dispose()
+    [Console]::Out.WriteLine($out)
+  } catch {
+    [Console]::Out.WriteLine('{"width":0,"height":0,"lines":[],"error":"ocr-host"}')
+  }
+  [Console]::Out.Flush()
+}`;
+
+export function ocrHostAvailable(): boolean {
+  if (platform() !== "win32") return false;
+  if (process.env.ELIZA_VISION_OCR_HOST === "0") return false;
+  if (startFailures >= MAX_START_FAILURES) return false;
+  return true;
+}
+
+function onStdout(chunk: Buffer): void {
+  stdoutBuf += chunk.toString("utf8");
+  if (!pending) return;
+  const nl = stdoutBuf.indexOf("\n");
+  if (nl === -1) return;
+  const line = stdoutBuf.slice(0, nl).replace(/\r$/, "");
+  stdoutBuf = stdoutBuf.slice(nl + 1);
+  const p = pending;
+  pending = null;
+  clearTimeout(p.timer);
+  p.resolve(line);
+}
+
+function onExit(): void {
+  host = null;
+  starting = null;
+  stdoutBuf = "";
+  if (pending) {
+    const p = pending;
+    pending = null;
+    clearTimeout(p.timer);
+    p.reject(new Error("ocr-host exited unexpectedly"));
+  }
+}
+
+export function shutdownOcrHost(): void {
+  if (host) {
+    try {
+      host.stdin.end();
+    } catch {
+      /* best effort */
+    }
+    try {
+      host.kill();
+    } catch {
+      /* best effort */
+    }
+  }
+  if (loopScriptPath) {
+    try {
+      unlinkSync(loopScriptPath);
+    } catch {
+      /* best effort */
+    }
+    loopScriptPath = null;
+  }
+  onExit();
+}
+
+async function ensureHost(): Promise<void> {
+  if (host) return;
+  if (starting) return starting;
+  starting = (async () => {
+    const scriptPath = join(tmpdir(), `eliza-ocr-host-${process.pid}.ps1`);
+    writeFileSync(scriptPath, OCR_SERVER_PS1, "utf8");
+    loopScriptPath = scriptPath;
+    const child = spawn(
+      "powershell",
+      [
+        "-NoProfile",
+        "-NoLogo",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        scriptPath,
+      ],
+      { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+    );
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", (c: Buffer) => {
+      stderrRing = (stderrRing + c.toString("utf8")).slice(-2048);
+    });
+    child.once("exit", onExit);
+    child.once("error", onExit);
+    host = child;
+    // Probe: a blank line is ignored by the loop, so prove readiness by sending
+    // a path we expect to fail recognition — the loop always answers one JSON
+    // line (the error branch), which confirms the preamble loaded and the loop
+    // is reading.
+    await sendRaw(
+      join(tmpdir(), `eliza-ocr-probe-nonexistent-${process.pid}.png`),
+      STARTUP_TIMEOUT_MS,
+    );
+  })();
+  try {
+    await starting;
+    startFailures = 0;
+  } catch (err) {
+    startFailures += 1;
+    shutdownOcrHost();
+    throw err;
+  } finally {
+    starting = null;
+  }
+}
+
+function sendRaw(imagePath: string, timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    if (!host) {
+      reject(new Error("ocr-host not running"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      pending = null;
+      shutdownOcrHost();
+      reject(
+        new Error(
+          `ocr-host timeout after ${timeoutMs}ms${stderrRing ? ` (stderr: ${stderrRing.trim().slice(-200)})` : ""}`,
+        ),
+      );
+    }, timeoutMs);
+    pending = { resolve, reject, timer };
+    host.stdin.write(`${imagePath}\n`);
+  });
+}
+
+/**
+ * Recognize the image at `imagePath` via the warm host, returning the raw JSON
+ * line (same shape the one-shot script emits). Serialized against other calls.
+ * Rejects (so the caller can fall back to a one-shot spawn) on host-start
+ * failure, timeout, or unexpected exit.
+ */
+export function runOcrHost(imagePath: string): Promise<string> {
+  const task = async (): Promise<string> => {
+    await ensureHost();
+    return sendRaw(imagePath, REQUEST_TIMEOUT_MS);
+  };
+  const run = chain.then(task, task);
+  chain = run.catch(() => {});
+  return run;
+}
+
+process.once("exit", () => {
+  if (host) {
+    try {
+      host.kill();
+    } catch {
+      /* best effort */
+    }
+  }
+});

--- a/plugins/plugin-vision/src/ocr-service-windows.ts
+++ b/plugins/plugin-vision/src/ocr-service-windows.ts
@@ -16,10 +16,11 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
+import { ocrHostAvailable, runOcrHost } from "./ocr-host-windows.js";
 import {
   computeSemanticPosition,
   type OcrWithCoordsBlock,
@@ -232,8 +233,18 @@ export class WindowsMediaOcrService implements OcrWithCoordsService {
     const imgPath = join(dir, "frame.png");
     writeFileSync(imgPath, Buffer.from(input.pngBytes));
     try {
-      const scriptPath = ensureScriptOnDisk();
-      const stdout = await runPowerShell(scriptPath, imgPath);
+      // Prefer the warm OCR host (no per-call cold `powershell.exe` spawn nor
+      // WinRT type-load); fall back to the one-shot `-File` spawn on any failure.
+      let stdout: string;
+      if (ocrHostAvailable()) {
+        try {
+          stdout = await runOcrHost(imgPath);
+        } catch {
+          stdout = await runPowerShell(ensureScriptOnDisk(), imgPath);
+        }
+      } else {
+        stdout = await runPowerShell(ensureScriptOnDisk(), imgPath);
+      }
       const raw = JSON.parse(
         stdout.trim() || '{"width":0,"height":0,"lines":[]}',
       ) as WinOcrRaw;
@@ -243,6 +254,16 @@ export class WindowsMediaOcrService implements OcrWithCoordsService {
         `[WindowsMediaOcr] OCR failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       return { blocks: [] };
+    } finally {
+      // Clean up the per-call temp image. The warm host disposes its file
+      // handle each iteration and the one-shot process has exited, so the file
+      // is unlocked — important now that frequent OCR through the host would
+      // otherwise accumulate temp dirs.
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
     }
   }
 }


### PR DESCRIPTION
## What

`WindowsMediaOcrService.describe()` (the zero-token native `Windows.Media.Ocr` path, #9105 M4a) ran `powershell -File windows-ocr.ps1` for **every recognized region**. On Defender-heavy hosts a cold `powershell.exe` spawn is ~10-16s (#9581), and the scene pipeline OCRs dirty regions **every turn, in parallel** — so a single turn could fire N cold processes at once and thrash the AV scanner.

This adds a **persistent OCR host** (`ocr-host-windows.ts`) that keeps one `powershell.exe` alive, loads the (expensive) WinRT projection + `OcrEngine` **once** in its parent scope, then loops: read an image path on stdin → recognize → emit one compact JSON line. Each call pays neither the process spawn **nor** the WinRT type-load — only the recognize. `describe()` falls back to the original one-shot `-File` spawn on any host failure, so output is unchanged.

- Self-contained in plugin-vision (no cross-plugin coupling).
- Newline-delimited protocol: write `<image-path>\n`, read one JSON line (`ConvertTo-Json -Compress` is always single-line; temp paths never contain newlines).
- Recognition logic mirrors the one-shot `WIN_OCR_PS1` **exactly** (identical JSON shape) — only the spawn + type-load are amortized. Streams/bitmaps are disposed each iteration so the long-lived session never leaks handles or locks temp PNGs.
- Requests serialized over the one pipe (fine — each is ~1s). Kill switch: `ELIZA_VISION_OCR_HOST=0`.
- Bonus: `describe()` now cleans up its per-call temp image dir (the old path leaked one temp dir per OCR — harmless when spawns were rare, but the fast host makes OCR frequent).

## Evidence (measured on this Windows box, Defender active)

- **Warm OCR: ~0.8-1.6s/call** (824, 1086, 1188, 1598 ms) vs a cold `powershell.exe` spawn ~12-16s + WinRT type-load — a **~10×+** drop, and it removes the N-concurrent-cold-spawn Defender thrash on multi-region turns.
- One-time warmup (cold spawn + WinRT load): ~18s, paid once.
- Correctness: read **69 lines** off the live desktop, sample word `"Recycle"` — accurate. Nonexistent image → clean error-JSON (no hang); host stays usable after an error.

## Tests
- New win32-gated real test `src/ocr-host-windows.real.test.ts` (4 tests, all pass on Windows): availability, text recognition + JSON shape (recovers `INVOICE`/`4096` from a rendered PNG), warm-latency ceiling (<4s/call — only the persistent host holds this), error-JSON + survival.
- Build: worker bundle OK. (The repo-wide `.d.ts` step fails only on the unrelated, pre-existing missing `jimp` dep in `src/image/sharp-compat.ts` — present on develop too.)
- biome: no errors/warnings; the `noUselessStringRaw` infos match the existing `WIN_OCR_PS1` sibling style on develop.

## Risk
Low. Pure latency optimization with a transparent one-shot fallback. Off-Windows it is a no-op (`ocrHostAvailable()` false). Disable with `ELIZA_VISION_OCR_HOST=0`. Host torn down on process exit.

Follow-up #9105 / #9581 (Windows on-device CUA×Vision). Companion to the computeruse warm-PowerShell-host PR (#9645).

🤖 Generated with [Claude Code](https://claude.com/claude-code)