### PR TITLE
fix(voice): per-platform echo-delay seed for on-device AEC (opt-in, #9583)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { estimateEchoDelaySamples } from "./echo-delay.ts";
+import {
+	DEFAULT_PLAYBACK_DELAY_MS,
+	estimateEchoDelaySamples,
+	PLATFORM_PLAYBACK_DELAY_DEFAULTS,
+	platformPlaybackDelayMs,
+	platformPlaybackDelaySamples,
+} from "./echo-delay.ts";
 
 /** Deterministic PRNG so fixtures are reproducible across runs/CI. */
 function mulberry32(seed: number): () => number {
@@ -74,5 +80,39 @@ describe("estimateEchoDelaySamples (#9583)", () => {
 			maxLagSamples: 400,
 		});
 		expect(est.lagSamples).toBeGreaterThanOrEqual(100);
+	});
+});
+
+describe("platformPlaybackDelaySamples seed (#9583)", () => {
+	it("maps known platforms to their seed delay (ms)", () => {
+		expect(platformPlaybackDelayMs("darwin")).toBe(20);
+		expect(platformPlaybackDelayMs("ios")).toBe(25);
+		expect(platformPlaybackDelayMs("android")).toBe(45);
+		expect(platformPlaybackDelayMs("win32")).toBe(30);
+		expect(platformPlaybackDelayMs("linux")).toBe(30);
+	});
+
+	it("falls back to the default seed for an unrecognized platform", () => {
+		expect(platformPlaybackDelayMs("haiku")).toBe(DEFAULT_PLAYBACK_DELAY_MS);
+		// The table must not accidentally carry the unknown key.
+		expect("haiku" in PLATFORM_PLAYBACK_DELAY_DEFAULTS).toBe(false);
+	});
+
+	it("converts the seed to samples at 16 kHz by default", () => {
+		// 20 ms * 16000 / 1000 = 320 samples
+		expect(platformPlaybackDelaySamples("darwin")).toBe(320);
+		// unknown → 25 ms default → 400 samples
+		expect(platformPlaybackDelaySamples("unknown")).toBe(400);
+	});
+
+	it("honours a custom sample rate", () => {
+		// 30 ms * 48000 / 1000 = 1440 samples
+		expect(platformPlaybackDelaySamples("win32", 48_000)).toBe(1440);
+	});
+
+	it("never returns a negative seed", () => {
+		for (const p of ["darwin", "ios", "android", "win32", "linux", "??"]) {
+			expect(platformPlaybackDelaySamples(p)).toBeGreaterThanOrEqual(0);
+		}
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
@@ -80,3 +80,53 @@ export function estimateEchoDelaySamples(
 		confidence: bestCorr === -Infinity ? 0 : Math.max(0, Math.min(1, bestCorr)),
 	};
 }
+
+/**
+ * Per-platform SEED playback→mic delay, in milliseconds. This is the initial
+ * pre-alignment applied *before* any echo has been observed; the adaptive
+ * {@link estimateEchoDelaySamples} cross-correlation refines it at runtime once
+ * enough playback-active audio is seen. Until then a platform-appropriate seed
+ * converges faster than starting from zero — most visibly on iOS/macOS, where
+ * the CoreAudio / AVAudioEngine transport delay is small but non-zero and a
+ * 0-sample seed leaves the first barge-in's echo un-aligned.
+ *
+ * These are conservative starting points (they still benefit from per-device
+ * tuning); the goal is only to put the adaptive filter in the right ballpark on
+ * the first turn, not to be exact.
+ */
+export const PLATFORM_PLAYBACK_DELAY_DEFAULTS: Readonly<Record<string, number>> =
+	{
+		/** macOS CoreAudio — low, stable hardware path. */
+		darwin: 20,
+		/** iOS AVAudioEngine (when its voice-processing IO AEC is not the source). */
+		ios: 25,
+		/** Android AudioTrack/AudioRecord — variable; a mid seed. */
+		android: 45,
+		/** Windows WASAPI shared-mode. */
+		win32: 30,
+		/** Desktop Linux ALSA/PulseAudio/PipeWire. */
+		linux: 30,
+	};
+
+/** Fallback seed (ms) for an unrecognized platform id. */
+export const DEFAULT_PLAYBACK_DELAY_MS = 25;
+
+/**
+ * Seed playback→mic delay in milliseconds for a platform id (e.g.
+ * `process.platform`, or the `"ios"` / `"android"` ids the mobile shells
+ * report). Unknown ids fall back to {@link DEFAULT_PLAYBACK_DELAY_MS}.
+ */
+export function platformPlaybackDelayMs(platform: string): number {
+	return PLATFORM_PLAYBACK_DELAY_DEFAULTS[platform] ?? DEFAULT_PLAYBACK_DELAY_MS;
+}
+
+/**
+ * Seed playback→mic delay in samples for a platform id. `sampleRate` defaults to
+ * the 16 kHz voice-pipeline rate.
+ */
+export function platformPlaybackDelaySamples(
+	platform: string,
+	sampleRate = 16_000,
+): number {
+	return Math.round((platformPlaybackDelayMs(platform) / 1000) * sampleRate);
+}

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -50,9 +50,13 @@ export {
 	mergeContext,
 } from "./eager-context-builder";
 export {
+	DEFAULT_PLAYBACK_DELAY_MS,
 	type EchoDelayEstimate,
 	type EchoDelayOptions,
 	estimateEchoDelaySamples,
+	PLATFORM_PLAYBACK_DELAY_DEFAULTS,
+	platformPlaybackDelayMs,
+	platformPlaybackDelaySamples,
 } from "./echo-delay";
 export {
 	EchoReferenceBuffer,

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { AudioFrameEvent } from "./audio-frame-consumer.js";
+import { platformPlaybackDelaySamples } from "./echo-delay.js";
 import {
 	LiveDiarizationSession,
 	type RuntimeEventSink,
@@ -152,5 +153,34 @@ describe("LiveDiarizationSession echo reference", () => {
 		expect(state.calibrated).toBe(true);
 		expect(Math.abs(state.delaySamples - delaySamples)).toBeLessThanOrEqual(1);
 		expect(state.confidence).toBeGreaterThan(0.95);
+	});
+
+	it("seeds the echo delay from the platform default when ELIZA_VOICE_ECHO_DELAY_MS=auto", () => {
+		const prev = process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+		process.env.ELIZA_VOICE_ECHO_DELAY_MS = "auto";
+		try {
+			const session = new LiveDiarizationSession(fakeRuntime());
+			// Seed comes straight from the per-platform table (#9583); runtime
+			// calibration would refine it later, but at construction it equals the
+			// platform default for the host the test runs on.
+			expect(session.aecDelayState().delaySamples).toBe(
+				platformPlaybackDelaySamples(process.platform, SAMPLE_RATE),
+			);
+		} finally {
+			if (prev === undefined) delete process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+			else process.env.ELIZA_VOICE_ECHO_DELAY_MS = prev;
+		}
+	});
+
+	it("defaults the echo delay seed to 0 when no override is set", () => {
+		const prev = process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+		delete process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+		try {
+			const session = new LiveDiarizationSession(fakeRuntime());
+			expect(session.aecDelayState().delaySamples).toBe(0);
+		} finally {
+			if (prev === undefined) delete process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+			else process.env.ELIZA_VOICE_ECHO_DELAY_MS = prev;
+		}
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -40,7 +40,10 @@ import {
 	type TurnTranscriber,
 	type VadSegmenter,
 } from "./audio-frame-consumer.js";
-import { estimateEchoDelaySamples } from "./echo-delay.js";
+import {
+	estimateEchoDelaySamples,
+	platformPlaybackDelaySamples,
+} from "./echo-delay.js";
 import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
 import type {
 	ElizaInferenceContextHandle,
@@ -204,13 +207,26 @@ function concatFloat32(chunks: Float32Array[]): Float32Array {
 
 /**
  * Playback→mic transport delay used to time-align the far-end echo reference,
- * in samples @ 16 kHz. Device-tunable via `ELIZA_VOICE_ECHO_DELAY_MS`; the
- * on-device calibration (`estimateEchoDelaySamples`, #9586) is the device-side
- * follow-up. Default 0 — the canceller aligns to the most-recently-rendered
- * playback and the NLMS filter adapts the residual.
+ * in samples @ 16 kHz. Device-tunable via `ELIZA_VOICE_ECHO_DELAY_MS`:
+ *   - a positive number → that many milliseconds, exactly;
+ *   - the literal `"auto"` → seed from a per-platform default
+ *     (`platformPlaybackDelaySamples`, #9583), useful on iOS/macOS where the
+ *     CoreAudio / AVAudioEngine transport delay is small but non-zero;
+ *   - unset / anything else → 0 (the default — the canceller aligns to the
+ *     most-recently-rendered playback and the NLMS filter adapts the residual).
+ *
+ * Either way the on-device calibration (`estimateEchoDelaySamples`, #9586)
+ * refines this seed at runtime once enough correlated echo is observed.
  */
 function resolveEchoDelaySamples(): number {
-	const ms = Number(process.env.ELIZA_VOICE_ECHO_DELAY_MS);
+	const raw = process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+	if (raw && raw.trim().toLowerCase() === "auto") {
+		return platformPlaybackDelaySamples(
+			process.platform,
+			AUDIO_FRAME_SAMPLE_RATE,
+		);
+	}
+	const ms = Number(raw);
 	if (!Number.isFinite(ms) || ms <= 0) return 0;
 	return Math.round((ms / 1000) * AUDIO_FRAME_SAMPLE_RATE);
 }


### PR DESCRIPTION
## Per-platform echo-delay seed for on-device AEC (opt-in)

Salvages the one genuinely-novel, develop-absent idea from the closed PR #9603 / `opt/ios-mac-aec-9583` branch — a per-platform playback→mic delay seed — re-done the right way: in the existing `echo-delay.ts` (no duplicate `echo-delay-calibrator.ts` module), **opt-in** (no default-behavior change), and unit-tested. Addresses the open issue #9583 ("on-device echoReference wiring + delay calibration") and `echo-delay.ts`'s own standing TODO ("the per-platform default delay still needs to be tuned on hardware").

### Why
`resolveEchoDelaySamples()` seeds the AEC playback→mic delay to **0** unless `ELIZA_VOICE_ECHO_DELAY_MS` is set. On iOS/macOS (CoreAudio / AVAudioEngine) the transport delay is small but non-zero, so a 0-sample seed leaves the first barge-in's echo un-aligned until the runtime cross-correlation calibrator (`estimateEchoDelaySamples`, #9586) converges. A sane per-platform seed shortens that.

### What
- `echo-delay.ts`: new `PLATFORM_PLAYBACK_DELAY_DEFAULTS` (darwin 20 / ios 25 / android 45 / win32 30 / linux 30 ms), `DEFAULT_PLAYBACK_DELAY_MS = 25`, and pure helpers `platformPlaybackDelayMs()` / `platformPlaybackDelaySamples(platform, sampleRate=16000)`.
- `live-diarization-session.ts`: `resolveEchoDelaySamples()` now also accepts `ELIZA_VOICE_ECHO_DELAY_MS=auto` → seed from the platform table. **A numeric value and the unset default are unchanged** (default stays 0), so no existing behavior or test shifts.
- Exported from `services/voice/index.ts`.

### Behavior matrix (`ELIZA_VOICE_ECHO_DELAY_MS`)
| value | seed |
|---|---|
| unset / non-positive / junk | `0` (unchanged) |
| positive number `N` | `N` ms (unchanged) |
| `auto` | per-platform default (new) |

The runtime calibrator still refines the seed once correlated echo is observed, regardless of source.

### Tests
- `echo-delay.test.ts`: table mapping, unknown-platform fallback (and no accidental key), ms→samples at 16 kHz and a custom 48 kHz rate, non-negative invariant.
- `live-diarization-session.echo.test.ts`: `auto` seeds `aecDelayState().delaySamples` to the platform default; the unset default is still `0`. Both run without the fused FFI (via `fakeRuntime()`).

### Evidence
Pure-DSP logic verified locally with a standalone Bun harness (all assertions pass, incl. an `estimateEchoDelaySamples` regression check). The wiring tests assert the session seam equals the helper for `auto` and `0` for the default. Default path is untouched → existing `echo-delay` / echo-reference suites unaffected.

Refs #9583. Salvaged from `opt/ios-mac-aec-9583` (closed #9603) per the branch-cleanup sweep (#9649).
