### PR TITLE
perf(build): fill 2 Turbo build-cache input gaps + clone-ur-crush outputs (#9626)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,8 @@
         "index.browser.ts",
         "build.ts",
         "build.mjs",
+        "build.config.ts",
+        "scripts/**",
         "tsup.config.ts",
         "tsup.config.*.ts",
         "tsdown.config.ts",
@@ -44,7 +46,7 @@
     },
     "@elizaos/example-clone-ur-crush#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
-      "outputs": []
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "@elizaos/ios-native-deps#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],


### PR DESCRIPTION
Small, conservative follow-up to the #9626 build audit's Turbo-caching findings.

develop already landed the generic-`build` `inputs` glob and `@elizaos/prompts#build` `cache:false`. Comparing that version against the audit, it **misses two genuine stale-artifact gaps** + one uncached example:

- **`build.config.ts`** added to the `build` task `inputs` — tsdown's config file; a change to it currently doesn't bust the build cache (stale artifact).
- **`scripts/**`** added — the existing root-relative `build.mjs` glob misses `scripts/` subdir build inputs (e.g. `@elizaos/shared`'s `scripts/generate-keywords.mjs`, packages with `scripts/build.mjs`).
- **`@elizaos/example-clone-ur-crush#build`** `outputs: []` → `[".next/**","!.next/cache/**"]` — it emits a Next.js build but was uncached (mirrors `eliza-next-example#build`).

turbo.json only, additive, valid JSON, `turbo run build --dry-run` clean. Part of #9626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
