### PR TITLE
refactor(orchestrator): drop as-unknown-as in readLastChangeSet, match provider pattern (#9474)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -288,10 +288,11 @@ function readLastChangeSet(
   metadata: Record<string, unknown> | undefined,
 ): WorkspaceChangeSet | undefined {
   const raw = metadata?.lastChangeSet;
-  if (!isRecord(raw)) return undefined;
-  if (!Array.isArray(raw.changedFiles)) return undefined;
-  if (typeof raw.capturedAt !== "number") return undefined;
-  return raw as unknown as WorkspaceChangeSet;
+  if (!raw || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<WorkspaceChangeSet>;
+  if (!Array.isArray(candidate.changedFiles)) return undefined;
+  if (typeof candidate.capturedAt !== "number") return undefined;
+  return candidate as WorkspaceChangeSet;
 }
 
 /** Render an event's `data` payload to a bounded scannable string so the


### PR DESCRIPTION
## Summary
Part of #9474 — removes one production `as unknown as` in plugin-agent-orchestrator.

`readLastChangeSet` cast a persisted `lastChangeSet` via `raw as unknown as WorkspaceChangeSet`. Its own doc says it validates *"the same way the CODING_SESSION_CHANGES provider does"* — and that provider (`coding-session-changes.ts`) already uses the clean `Partial<WorkspaceChangeSet>` + plain-`as` pattern with **no** `as unknown as`. This change matches it:

```diff
-  if (!isRecord(raw)) return undefined;
-  if (!Array.isArray(raw.changedFiles)) return undefined;
-  if (typeof raw.capturedAt !== "number") return undefined;
-  return raw as unknown as WorkspaceChangeSet;
+  if (!raw || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<WorkspaceChangeSet>;
+  if (!Array.isArray(candidate.changedFiles)) return undefined;
+  if (typeof candidate.capturedAt !== "number") return undefined;
+  return candidate as WorkspaceChangeSet;
```

## Verification
- **Behavior-identical:** same 2-field validation (changedFiles array + capturedAt number); an array/primitive/null still returns undefined.
- `as unknown as WorkspaceChangeSet` in the file: **1 → 0**.
- `tsgo --noEmit` on plugin-agent-orchestrator: **0 real errors** (deps built; only env dep-resolution noise).
- `isRecord` still used 9× elsewhere — no dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)