### PR TITLE
refactor(agent): replace as-unknown-as IPermissionsRegistry with type guard (#9474)

### DIFF
--- a/packages/agent/src/api/permissions-routes.ts
+++ b/packages/agent/src/api/permissions-routes.ts
@@ -59,17 +59,23 @@ function currentPlatform(): "darwin" | "win32" | "linux" {
   return p === "darwin" || p === "win32" || p === "linux" ? p : "linux";
 }
 
+function isPermissionsRegistry(
+  service: unknown,
+): service is IPermissionsRegistry {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    "get" in service &&
+    "check" in service &&
+    "request" in service
+  );
+}
+
 function getPermissionRegistry(
   runtime: AgentRuntime | null,
 ): IPermissionsRegistry | null {
   const service = runtime?.getService(PERMISSIONS_REGISTRY_SERVICE);
-  return service &&
-    typeof service === "object" &&
-    "get" in service &&
-    "check" in service &&
-    "request" in service
-    ? (service as unknown as IPermissionsRegistry)
-    : null;
+  return isPermissionsRegistry(service) ? service : null;
 }
 
 function unavailableWebsiteBlockingPermission(): PermissionState {


### PR DESCRIPTION
Part of #9474. `getPermissionRegistry` duck-typed a `getService()` result (object with `get`/`check`/`request`) then cast via `as unknown as IPermissionsRegistry`. Extracted an `isPermissionsRegistry` type guard with the same existence checks — it narrows the value, so the cast is removed.

**Behavior-identical** (same 3 checks). `as unknown as IPermissionsRegistry`: 1 → 0. `tsgo --noEmit` on packages/agent: 0 real errors (deps built; only env dep-resolution noise), unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)