### PR TITLE
fix(computeruse,vision): harden the warm PowerShell/OCR hosts — crash-safety, respawn races, handle leaks

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/ps-host.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/ps-host.real.test.ts
@@ -16,6 +16,7 @@
 import { platform } from "node:os";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+  disposePsHost,
   psHostAvailable,
   runPsHost,
   shutdownPsHost,
@@ -81,6 +82,23 @@ describe("ps-host (warm PowerShell host, Windows)", () => {
       await expect(runPsHost("throw 'boom'", 30_000)).rejects.toThrow();
       const out = await runPsHost("Write-Output 'still-alive'", 30_000);
       expect(out).toContain("still-alive");
+    },
+    60_000,
+  );
+
+  it.skipIf(!RUN)(
+    "disposePsHost latches spawning off until re-warmed",
+    async () => {
+      await warmPsHost();
+      // After an owner dispose, a fresh call must NOT resurrect the host (so a
+      // late fire-and-forget continuation can't leak a process post-stop). The
+      // caller sees a rejection and falls back to a one-shot spawn.
+      disposePsHost();
+      await expect(runPsHost("Write-Output 'nope'", 30_000)).rejects.toThrow();
+      // An explicit warm re-enables a fresh session.
+      await warmPsHost();
+      const out = await runPsHost("Write-Output 're-enabled'", 30_000);
+      expect(out).toContain("re-enabled");
     },
     60_000,
   );

--- a/plugins/plugin-computeruse/src/platform/clipboard.ts
+++ b/plugins/plugin-computeruse/src/platform/clipboard.ts
@@ -138,7 +138,12 @@ export async function writeClipboard(text: string): Promise<void> {
   // Windows: prefer the warm PowerShell host. The value is base64-encoded into
   // the command (no stdin pipe needed), then decoded host-side, so it round-trips
   // any UTF-8 text safely. Falls back to the one-shot stdin-piped spawn.
-  if (psHostAvailable()) {
+  //
+  // Empty string is routed to the fallback path deliberately: `Set-Clipboard
+  // -Value ''` rejects an empty value, and base64('') would otherwise let the
+  // host "succeed" where the one-shot spawn fails — a non-transparent
+  // divergence. Routing both through the same path keeps the behavior identical.
+  if (psHostAvailable() && text.length > 0) {
     try {
       const b64 = Buffer.from(text, "utf-8").toString("base64");
       await runPsHost(

--- a/plugins/plugin-computeruse/src/platform/ps-host.ts
+++ b/plugins/plugin-computeruse/src/platform/ps-host.ts
@@ -58,6 +58,11 @@ let host: ChildProcessWithoutNullStreams | null = null;
 let starting: Promise<void> | null = null;
 let startFailures = 0;
 let loopScriptPath: string | null = null;
+// Gate against respawning after an owner-initiated dispose. `shutdownPsHost()`
+// (timeout / test cleanup) leaves this true so the next call can respawn;
+// `disposePsHost()` (service stop) sets it false so a fire-and-forget warm
+// continuation can't resurrect a host after the service has stopped.
+let spawnAllowed = true;
 let stdoutBuf = "";
 let stderrRing = "";
 let pending: {
@@ -169,6 +174,9 @@ export function shutdownPsHost(): void {
 
 async function ensureHost(): Promise<void> {
   if (host) return;
+  // Owner disposed the host (service stopped); refuse to resurrect it from a
+  // late fire-and-forget continuation. Callers fall back to one-shot spawns.
+  if (!spawnAllowed) throw new Error("ps-host disposed");
   if (starting) return starting;
   starting = (async () => {
     // Write the server loop to disk and run it with `-File` so stdin stays free
@@ -199,8 +207,20 @@ async function ensureHost(): Promise<void> {
     child.stderr.on("data", (c: Buffer) => {
       stderrRing = (stderrRing + c.toString("utf8")).slice(-2048);
     });
-    child.once("exit", onExit);
-    child.once("error", onExit);
+    // Swallow stdin pipe errors (EPIPE when the host dies between requests).
+    // Without this listener Node throws the 'error' as an uncaught exception
+    // and crashes the whole process — defeating the transparent-fallback
+    // contract. The dead pipe surfaces via onExit → a normal rejection instead.
+    child.stdin.on("error", () => {});
+    // Bind exit/error to THIS child: a previously-killed host's late 'exit'
+    // event must not tear down a freshly respawned host or reject its pending
+    // request. Stale events are ignored.
+    const onChildGone = () => {
+      if (host !== child) return;
+      onExit();
+    };
+    child.once("exit", onChildGone);
+    child.once("error", onChildGone);
     host = child;
     // Warmup ping — proves the loop is reading and the process is hot.
     await sendRaw("$null", STARTUP_TIMEOUT_MS);
@@ -239,7 +259,16 @@ function sendRaw(script: string, timeoutMs: number): Promise<string> {
       );
     }, timeoutMs);
     pending = { token, resolve, reject, timer };
-    host.stdin.write(`${token} ${b64}\n`);
+    try {
+      host.stdin.write(`${token} ${b64}\n`);
+    } catch (err) {
+      // Synchronous write failure (e.g. dead pipe). Surface as a rejection so
+      // the caller falls back, and tear the host down so the next call respawns.
+      clearTimeout(timer);
+      pending = null;
+      shutdownPsHost();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
   });
 }
 
@@ -269,11 +298,26 @@ export function runPsHost(script: string, timeoutMs: number): Promise<string> {
  * start, callers transparently fall back to one-shot spawns.
  */
 export function warmPsHost(): Promise<void> {
+  // Re-enable spawning: an explicit warm is a fresh intent to use the host
+  // (e.g. a service (re)start after a prior dispose).
+  spawnAllowed = true;
   if (!psHostAvailable()) return Promise.resolve();
   return runPsHost("$null", STARTUP_TIMEOUT_MS).then(
     () => {},
     () => {},
   );
+}
+
+/**
+ * Owner-initiated dispose (service stop). Unlike {@link shutdownPsHost} (which
+ * leaves the host respawnable for the next call — used by the timeout path),
+ * this latches spawning OFF so an in-flight fire-and-forget warm continuation
+ * cannot resurrect a powershell.exe after the service has stopped. A later
+ * {@link warmPsHost} re-enables it.
+ */
+export function disposePsHost(): void {
+  spawnAllowed = false;
+  shutdownPsHost();
 }
 
 /** Test-only: reset failure latch so a fresh attempt can be made. */

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -78,7 +78,7 @@ import {
 import { commandExists, currentPlatform } from "../platform/helpers.js";
 import { killApp, launchApp, openTarget } from "../platform/launch.js";
 import { classifyPermissionDeniedError } from "../platform/permissions.js";
-import { shutdownPsHost, warmPsHost } from "../platform/ps-host.js";
+import { disposePsHost, warmPsHost } from "../platform/ps-host.js";
 import {
   clearTerminal,
   closeAllTerminalSessions,
@@ -278,8 +278,9 @@ export class ComputerUseService extends Service {
     } catch {
       // ignore browser shutdown failures
     }
-    // Tear down the persistent PowerShell host so we don't leak the process.
-    shutdownPsHost();
+    // Tear down the persistent PowerShell host and latch spawning off so a
+    // late fire-and-forget warm continuation can't resurrect it post-stop.
+    disposePsHost();
     logger.info("[computeruse] Service stopped");
   }
 

--- a/plugins/plugin-vision/src/ocr-host-windows.ts
+++ b/plugins/plugin-vision/src/ocr-host-windows.ts
@@ -74,6 +74,8 @@ while ($true) {
   $ImagePath = [Console]::In.ReadLine()
   if ($null -eq $ImagePath) { break }
   if ($ImagePath.Length -eq 0) { continue }
+  $stream = $null
+  $bitmap = $null
   try {
     if ($null -eq $engine) { [Console]::Out.WriteLine('{"width":0,"height":0,"lines":[]}'); [Console]::Out.Flush(); continue }
     $file = Await ([Windows.Storage.StorageFile]::GetFileFromPathAsync($ImagePath)) ([Windows.Storage.StorageFile])
@@ -91,11 +93,15 @@ while ($true) {
       $lines += [pscustomobject]@{ text = $line.Text; words = $words }
     }
     $out = [pscustomobject]@{ width = [int]$bitmap.PixelWidth; height = [int]$bitmap.PixelHeight; lines = $lines } | ConvertTo-Json -Depth 6 -Compress
-    $bitmap.Dispose()
-    $stream.Dispose()
     [Console]::Out.WriteLine($out)
   } catch {
     [Console]::Out.WriteLine('{"width":0,"height":0,"lines":[],"error":"ocr-host"}')
+  } finally {
+    # Always release the file handle + bitmap, even on a mid-iteration throw —
+    # otherwise the handle leaks and keeps the temp PNG locked so the caller's
+    # rmSync cannot delete it (this is a long-lived session).
+    if ($null -ne $bitmap) { try { $bitmap.Dispose() } catch {} }
+    if ($null -ne $stream) { try { $stream.Dispose() } catch {} }
   }
   [Console]::Out.Flush()
 }`;
@@ -180,8 +186,18 @@ async function ensureHost(): Promise<void> {
     child.stderr.on("data", (c: Buffer) => {
       stderrRing = (stderrRing + c.toString("utf8")).slice(-2048);
     });
-    child.once("exit", onExit);
-    child.once("error", onExit);
+    // Swallow stdin pipe errors (EPIPE when the host dies between requests) so
+    // Node doesn't throw an uncaught exception and crash the process; the dead
+    // pipe surfaces via onExit → a normal rejection the caller falls back from.
+    child.stdin.on("error", () => {});
+    // Bind exit/error to THIS child so a previously-killed host's late 'exit'
+    // can't tear down a freshly respawned host or reject its pending request.
+    const onChildGone = () => {
+      if (host !== child) return;
+      onExit();
+    };
+    child.once("exit", onChildGone);
+    child.once("error", onChildGone);
     host = child;
     // Probe: a blank line is ignored by the loop, so prove readiness by sending
     // a path we expect to fail recognition — the loop always answers one JSON
@@ -220,7 +236,14 @@ function sendRaw(imagePath: string, timeoutMs: number): Promise<string> {
       );
     }, timeoutMs);
     pending = { resolve, reject, timer };
-    host.stdin.write(`${imagePath}\n`);
+    try {
+      host.stdin.write(`${imagePath}\n`);
+    } catch (err) {
+      clearTimeout(timer);
+      pending = null;
+      shutdownOcrHost();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
   });
 }
 


### PR DESCRIPTION
## What

Follow-up hardening to the warm-host perf work (#9645 ps-host, #9651 OCR host). An adversarial code review of those two merged changes surfaced **5 real bugs** (and correctly dismissed 5 false positives). All are fixed here and re-validated live on Windows.

### Fixes

**1. [HIGH] Unhandled `stdin` 'error' crashed the whole process** (`ps-host.ts`, `ocr-host-windows.ts`)
Neither host had an `'error'` listener on the child's `stdin`. When the host dies *between* requests (AV kills powershell.exe, OS reap, user close) the cached `host` ref is still non-null and the `'exit'` event hasn't been delivered yet — so the next `sendRaw` writes to a dead pipe → `EPIPE` → Node throws it as an **uncaught exception and terminates the agent process**, defeating the whole transparent-fallback contract. Fix: attach a swallowing `child.stdin.on('error', () => {})`, and wrap the `write` in try/catch (reject + teardown on synchronous throw). The dead pipe now surfaces as a normal promise rejection the caller falls back from.

**2. [HIGH] A killed host's late `exit` tore down a freshly respawned host** (`ps-host.ts`, `ocr-host-windows.ts`)
The module-level `onExit` was bound to *every* spawned child. After a timeout-kill, the dead child's `'exit'` event fires *later* — by then a new host may already be spawned — and `onExit` clobbered the new `host`, wiped its `stdoutBuf`, and rejected its in-flight probe, bumping `startFailures` toward the latch that disables the host for the rest of the run. Fix: bind exit/error to the specific child and ignore the event when `host !== child`.

**3. [MED] OCR loop leaked the file handle on a mid-iteration throw** (`ocr-host-windows.ts`)
The happy path disposed the stream/bitmap but the `catch` branch didn't, so any recognition error in the long-lived session leaked the WinRT file handle — locking the temp PNG so the caller's `rmSync` couldn't delete it. Fix: dispose `$stream`/`$bitmap` in a PowerShell `finally` inside the loop body.

**4. [MED] `writeClipboard("")` succeeded via host but threw via fallback** (`clipboard.ts`)
Non-transparent divergence: `Set-Clipboard -Value ''` rejects an empty value, but the base64-inlined host path "succeeded". Fix: route empty strings through the one-shot fallback path so host and fallback behave identically.

**5. [MED] Post-stop respawn leaked a powershell.exe** (`ps-host.ts`, `computer-use-service.ts`)
`start()`'s fire-and-forget `warmPsHost().then(warmDisplaysCache)` could, if `stop()` ran during the warm chain, resurrect a host (+ temp `.ps1`) *after* the service stopped. Fix: a `spawnAllowed` latch — `shutdownPsHost()` (timeout/test) leaves it respawnable; new `disposePsHost()` (called by `stop()`) latches spawning OFF; `warmPsHost()` re-enables it for a fresh session. `ensureHost()` refuses to spawn when disposed.

## Validation (live on Windows)
- Killed each host out-of-band, then called again: **process survived** (graceful rejection, exit 0), then **auto-recovered** on the next call. Confirms #1 + #2.
- OCR: repeated recognition on one file with no handle-leak lockup; reads `LEDGER 8192` / `INVOICE 4096` accurately after the `finally`-dispose change. Confirms #3.
- `disposePsHost()` → next `runPsHost` rejects (`ps-host disposed`); `warmPsHost()` re-enables. Confirms #5.
- ps-host real test: **6 pass** (added a dispose-semantics test). OCR host real test: **4 pass**. typecheck (computeruse) exit 0; biome clean on changed code (the one pre-existing `set_value` formatter note + `noUselessStringRaw` infos are on develop already, untouched).

## Risk
Low and strictly safety-improving: every change makes the existing transparent-fallback contract actually hold under failure. No behavior change on the happy path. Off-Windows remains a no-op.

Follow-up to #9645 / #9651; #9105 / #9581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)