### PR TITLE
fix(local-inference): clean up Gemma draft MTP cutover defaults

### DIFF
--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -1,7 +1,7 @@
 import type http from "node:http";
-import { createMockRuntime } from "@elizaos/core/testing";
-import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
+import type { Task, UUID } from "@elizaos/core";
 import { ApprovalService, ServiceType } from "@elizaos/core";
+import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   approvalTaskToPendingAction,

--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -1,6 +1,5 @@
 import type http from "node:http";
 import { createMockRuntime } from "@elizaos/core/testing";
-import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPushService } from "../services/push/notification-push-service.ts";
 import type { PushTokenRegistry } from "../services/push/push-token-registry.ts";

--- a/packages/agent/src/services/proactive-interaction-decider.test.ts
+++ b/packages/agent/src/services/proactive-interaction-decider.test.ts
@@ -1,4 +1,3 @@
-import { createMockRuntime } from "@elizaos/core/testing";
 import type {
   IAgentRuntime,
   ShortcutFiredPayload,
@@ -6,6 +5,7 @@ import type {
   ViewSwitchedPayload,
 } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
+import { createMockRuntime } from "@elizaos/core/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildProactiveJudgePrompt,

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -836,7 +836,7 @@ export class RemotePluginBridge {
         const memory = await this.runtime.getMemoryById(
           memoryId as Parameters<IAgentRuntime["getMemoryById"]>[0],
         );
-        return JSON.parse(JSON.stringify((memory ?? null))) as JsonValue;
+        return JSON.parse(JSON.stringify(memory ?? null)) as JsonValue;
       }
       case "createMemory": {
         const memory = args.memory as JsonValue;
@@ -882,7 +882,7 @@ export class RemotePluginBridge {
       case "composeState": {
         const memory = args.message as unknown as Memory;
         const result = await this.runtime.composeState(memory);
-        return JSON.parse(JSON.stringify((result ?? null))) as JsonValue;
+        return JSON.parse(JSON.stringify(result ?? null)) as JsonValue;
       }
       default:
         throw new Error(

--- a/packages/app-core/platforms/electrobun/src/native/remote-plugin-host.ts
+++ b/packages/app-core/platforms/electrobun/src/native/remote-plugin-host.ts
@@ -1218,7 +1218,9 @@ export class RemotePluginHost {
   ): Promise<JsonValue> {
     switch (method) {
       case "list-remote-plugins":
-        return JSON.parse(JSON.stringify(this.listRemotePlugins())) as JsonValue;
+        return JSON.parse(
+          JSON.stringify(this.listRemotePlugins()),
+        ) as JsonValue;
       case "start-remote-plugin": {
         this.requireManageRemotePlugins(callerId, "start-remote-plugin");
         const targetId = hostRequestStringField(params, "id");
@@ -1233,18 +1235,26 @@ export class RemotePluginHost {
       }
       case "agent-manager-start":
         this.requireManageRemotePlugins(callerId, "agent-manager-start");
-        return JSON.parse(JSON.stringify((await getAgentManager().start()))) as JsonValue;
+        return JSON.parse(
+          JSON.stringify(await getAgentManager().start()),
+        ) as JsonValue;
       case "agent-manager-stop": {
         this.requireManageRemotePlugins(callerId, "agent-manager-stop");
         await getAgentManager().stop();
-        return JSON.parse(JSON.stringify(getAgentManager().getStatus())) as JsonValue;
+        return JSON.parse(
+          JSON.stringify(getAgentManager().getStatus()),
+        ) as JsonValue;
       }
       case "agent-manager-restart":
         this.requireManageRemotePlugins(callerId, "agent-manager-restart");
-        return JSON.parse(JSON.stringify((await getAgentManager().restart()))) as JsonValue;
+        return JSON.parse(
+          JSON.stringify(await getAgentManager().restart()),
+        ) as JsonValue;
       case "agent-manager-status":
         this.requireManageRemotePlugins(callerId, "agent-manager-status");
-        return JSON.parse(JSON.stringify(getAgentManager().getStatus())) as JsonValue;
+        return JSON.parse(
+          JSON.stringify(getAgentManager().getStatus()),
+        ) as JsonValue;
       case "agent-manager-health":
         this.requireManageRemotePlugins(callerId, "agent-manager-health");
         return this.readAgentManagerHealth();

--- a/packages/app-core/src/api/training-benchmarks.ts
+++ b/packages/app-core/src/api/training-benchmarks.ts
@@ -276,15 +276,11 @@ export function openBenchmarkResultsReader(
   return {
     ready: true,
     getHistory({ modelId, benchmark, limit }): BenchmarkRunDTO[] {
-      const rows = historyStmt.all(
-        modelId,
-        benchmark,
-        limit,
-      ) as DbRunRow[];
+      const rows = historyStmt.all(modelId, benchmark, limit).map(readDbRunRow);
       return rows.map(rowToDto);
     },
     getLatest({ modelId, benchmark }): BenchmarkRunDTO | null {
-      const rows = latestStmt.all(modelId, benchmark) as DbRunRow[];
+      const rows = latestStmt.all(modelId, benchmark).map(readDbRunRow);
       if (rows.length === 0) return null;
       return rowToDto(rows[0]);
     },
@@ -292,6 +288,40 @@ export function openBenchmarkResultsReader(
       db.close();
     },
   };
+}
+
+function readDbRunRow(row: Record<string, unknown>): DbRunRow {
+  return {
+    id: readIntegerLike(row.id, "id"),
+    model_id: readString(row.model_id, "model_id"),
+    benchmark: readString(row.benchmark, "benchmark"),
+    score: readFiniteNumber(row.score, "score"),
+    ts: readIntegerLike(row.ts, "ts"),
+    dataset_version: readString(row.dataset_version, "dataset_version"),
+    code_commit: readString(row.code_commit, "code_commit"),
+  };
+}
+
+function readIntegerLike(value: unknown, field: string): number | bigint {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "bigint") return value;
+  throw new Error(
+    `[TrainingBenchmarks] Invalid benchmark row: ${field} must be an integer`,
+  );
+}
+
+function readFiniteNumber(value: unknown, field: string): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  throw new Error(
+    `[TrainingBenchmarks] Invalid benchmark row: ${field} must be a finite number`,
+  );
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value === "string") return value;
+  throw new Error(
+    `[TrainingBenchmarks] Invalid benchmark row: ${field} must be a string`,
+  );
 }
 
 function rowToDto(row: DbRunRow): BenchmarkRunDTO {

--- a/packages/core/src/__tests__/provisioning.test.ts
+++ b/packages/core/src/__tests__/provisioning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMockRuntime } from "../testing/mock-runtime";
 import { ensureEmbeddingDimension } from "../provisioning";
+import { createMockRuntime } from "../testing/mock-runtime";
 import type { IAgentRuntime } from "../types/runtime";
 
 /**

--- a/packages/core/src/__tests__/voice-text-parity-pipeline.test.ts
+++ b/packages/core/src/__tests__/voice-text-parity-pipeline.test.ts
@@ -21,7 +21,6 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createMockRuntime } from "../testing/mock-runtime";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
@@ -29,6 +28,7 @@ import {
 	BUILTIN_RESPONSE_HANDLER_EVALUATORS,
 	runV5MessageRuntimeStage1,
 } from "../services/message";
+import { createMockRuntime } from "../testing/mock-runtime";
 import type { Memory } from "../types/memory";
 import { ChannelType, type UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";

--- a/packages/core/src/features/autonomy/service.test.ts
+++ b/packages/core/src/features/autonomy/service.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
-import { createMockRuntime } from "../../testing/mock-runtime";
 import {
 	OPTIMIZED_PROMPT_SERVICE,
 	type OptimizedPromptArtifact,
 	OptimizedPromptService,
 } from "../../services/optimized-prompt";
+import { createMockRuntime } from "../../testing/mock-runtime";
 import type { IAgentRuntime, Memory, UUID } from "../../types";
 import { AutonomyService } from "./service";
 
@@ -40,14 +40,15 @@ describe("AutonomyService optimized prompt integration", () => {
 			"GEPA autonomy prompt\ncontext={{targetRoomContext}}\nlast={{lastThought}}",
 		);
 		const service = new AutonomyService();
-		(service as unknown as { runtime: IAgentRuntime }).runtime = createMockRuntime({
-			getService<T>(name: string): T | null {
-				if (name === OPTIMIZED_PROMPT_SERVICE) {
-					return optimizedPromptService as T;
-				}
-				return null;
-			},
-		});
+		(service as unknown as { runtime: IAgentRuntime }).runtime =
+			createMockRuntime({
+				getService<T>(name: string): T | null {
+					if (name === OPTIMIZED_PROMPT_SERVICE) {
+						return optimizedPromptService as T;
+					}
+					return null;
+				},
+			});
 
 		const output = (
 			service as unknown as {
@@ -70,15 +71,16 @@ describe("AutonomyService optimized prompt integration", () => {
 		const service = new AutonomyService();
 		const agentId = "00000000-0000-0000-0000-000000000020" as UUID;
 		const cache = new Map<string, unknown>();
-		(service as unknown as { runtime: IAgentRuntime }).runtime = createMockRuntime({
-			agentId,
-			getCache: async <T>(key: string): Promise<T | undefined> =>
-				cache.get(key) as T | undefined,
-			setCache: async (key: string, value: unknown): Promise<boolean> => {
-				cache.set(key, value);
-				return true;
-			},
-		});
+		(service as unknown as { runtime: IAgentRuntime }).runtime =
+			createMockRuntime({
+				agentId,
+				getCache: async <T>(key: string): Promise<T | undefined> =>
+					cache.get(key) as T | undefined,
+				setCache: async (key: string, value: unknown): Promise<boolean> => {
+					cache.set(key, value);
+					return true;
+				},
+			});
 
 		const memories = Array.from({ length: 18 }, (_, index) => ({
 			id: `00000000-0000-0000-0000-${String(index + 100).padStart(
@@ -143,12 +145,13 @@ describe("AutonomyService optimized prompt integration", () => {
 		const getRoomsForParticipant = vi.fn(async () => {
 			throw new Error("should not enumerate rooms by default");
 		});
-		(service as unknown as { runtime: IAgentRuntime }).runtime = createMockRuntime({
-			agentId: "00000000-0000-0000-0000-000000000020" as UUID,
-			getSetting: () => null,
-			getRoomsForParticipant,
-			getMemories: async () => [],
-		});
+		(service as unknown as { runtime: IAgentRuntime }).runtime =
+			createMockRuntime({
+				agentId: "00000000-0000-0000-0000-000000000020" as UUID,
+				getSetting: () => null,
+				getRoomsForParticipant,
+				getMemories: async () => [],
+			});
 
 		const output = await (
 			service as unknown as {

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockRuntime } from "../../../testing/mock-runtime";
 import { ChannelTopicsService } from "../../../services/channel-topics";
+import { createMockRuntime } from "../../../testing/mock-runtime";
 import type {
 	IAgentRuntime,
 	Memory,

--- a/packages/core/src/runtime/__tests__/schema-validation-reroll.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-validation-reroll.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createMockRuntime } from "../../testing/mock-runtime";
 import type { JsonSchema } from "../../actions/validate-tool-args";
+import { createMockRuntime } from "../../testing/mock-runtime";
 import type { ModelHandler } from "../../types/model";
 import { ModelType } from "../../types/model";
 import type { IAgentRuntime } from "../../types/runtime";

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -50,7 +50,6 @@ export {
 } from "./browser-mocks";
 // Conditional test helpers (describeIf, itIf, testIf)
 export { describeIf, itIf, testIf } from "./conditional-tests";
-export { createMockRuntime, MOCK_AGENT_ID } from "./mock-runtime";
 // Package path resolution for monorepo tests
 export {
 	getAppCoreSourceRoot,
@@ -99,6 +98,7 @@ export {
 } from "./live-provider";
 // Loopback port availability checker
 export { canBindLoopback } from "./loopback";
+export { createMockRuntime, MOCK_AGENT_ID } from "./mock-runtime";
 // Ollama model handlers (for local inference)
 export {
 	createOllamaModelHandlers,

--- a/packages/examples/app/electron/backend/src/runtimeManager.ts
+++ b/packages/examples/app/electron/backend/src/runtimeManager.ts
@@ -139,8 +139,7 @@ async function buildPlugins(mode: ProviderMode): Promise<Plugin[]> {
     case "anthropic":
       return [
         ...base,
-        (await import("@elizaos/plugin-anthropic"))
-          .default as Plugin,
+        (await import("@elizaos/plugin-anthropic")).default as Plugin,
       ];
     case "xai":
       return [
@@ -150,8 +149,7 @@ async function buildPlugins(mode: ProviderMode): Promise<Plugin[]> {
     case "gemini":
       return [
         ...base,
-        (await import("@elizaos/plugin-google-genai"))
-          .default as Plugin,
+        (await import("@elizaos/plugin-google-genai")).default as Plugin,
       ];
     case "groq":
       return [
@@ -161,8 +159,7 @@ async function buildPlugins(mode: ProviderMode): Promise<Plugin[]> {
     case "openrouter":
       return [
         ...base,
-        (await import("@elizaos/plugin-openrouter"))
-          .default as Plugin,
+        (await import("@elizaos/plugin-openrouter")).default as Plugin,
       ];
     case "ollama":
       return [

--- a/packages/examples/smartglasses/tsconfig.json
+++ b/packages/examples/smartglasses/tsconfig.json
@@ -22,7 +22,9 @@
       // dist/index lets each tool append its own extension: tsc resolves .d.ts
       // (strict-clean), bun resolves .js (no "facewearPlugin is not defined").
       // Do NOT pin to .d.ts (breaks the test) or .js (tsc 6.0.3 → 58 implicit-any).
-      "@elizaos/plugin-facewear": ["../../../plugins/plugin-facewear/dist/index"]
+      "@elizaos/plugin-facewear": [
+        "../../../plugins/plugin-facewear/dist/index"
+      ]
     }
   },
   "include": [

--- a/packages/os/setup/src/backend/http-backend.ts
+++ b/packages/os/setup/src/backend/http-backend.ts
@@ -94,7 +94,10 @@ function validateBuild(v: unknown): AospBuild {
   if (!isString(v.id)) throw new Error("build.id must be a string");
   if (!isString(v.label)) throw new Error("build.label must be a string");
   if (!isString(v.version)) throw new Error("build.version must be a string");
-  if (!isString(v.channel) || !["stable", "beta", "nightly"].includes(v.channel))
+  if (
+    !isString(v.channel) ||
+    !["stable", "beta", "nightly"].includes(v.channel)
+  )
     throw new Error("build.channel must be one of stable|beta|nightly");
   if (!isString(v.targetDevice))
     throw new Error("build.targetDevice must be a string");
@@ -102,7 +105,9 @@ function validateBuild(v: unknown): AospBuild {
     !isString(v.architecture) ||
     !["arm64-v8a", "x86_64", "riscv64"].includes(v.architecture)
   )
-    throw new Error("build.architecture must be one of arm64-v8a|x86_64|riscv64");
+    throw new Error(
+      "build.architecture must be one of arm64-v8a|x86_64|riscv64",
+    );
   if (!isString(v.publishedAt))
     throw new Error("build.publishedAt must be a string");
   if (!isString(v.manifestUrl))

--- a/packages/plugin-worker-runtime/src/bootstrap.ts
+++ b/packages/plugin-worker-runtime/src/bootstrap.ts
@@ -212,7 +212,9 @@ export async function bootstrap(
       channel.send({
         type: "event",
         name: "plugin.init.failed",
-        payload: { error: JSON.parse(JSON.stringify(toWireError(error))) as JsonValue },
+        payload: {
+          error: JSON.parse(JSON.stringify(toWireError(error))) as JsonValue,
+        },
       } as RemotePluginWorkerMessage);
       throw error;
     }

--- a/packages/scripts/local-inference-ablation.config.json
+++ b/packages/scripts/local-inference-ablation.config.json
@@ -24,17 +24,17 @@
     },
     {
       "name": "mtp_only",
-      "label": "MTP, f16 KV",
+      "label": "draft-MTP, f16 KV",
       "needsDrafter": true,
-      "args": ["--spec-type", "mtp"]
+      "args": ["--spec-type", "draft-mtp"]
     },
     {
       "name": "mtp_turbo4_polar",
-      "label": "MTP + Turbo/Polar KV turbo4",
+      "label": "draft-MTP + Turbo/Polar KV turbo4",
       "needsDrafter": true,
       "args": [
         "--spec-type",
-        "mtp",
+        "draft-mtp",
         "--cache-type-k",
         "tbq4_0",
         "--cache-type-v",
@@ -47,11 +47,11 @@
     },
     {
       "name": "all_mtp_qjl_tcq",
-      "label": "MTP + forced QJL/TCQ turbo3_tcq",
+      "label": "draft-MTP + forced QJL/TCQ turbo3_tcq",
       "needsDrafter": true,
       "args": [
         "--spec-type",
-        "mtp",
+        "draft-mtp",
         "--cache-type-k",
         "tbq3_tcq",
         "--cache-type-v",

--- a/packages/scripts/local-inference-ablation.mjs
+++ b/packages/scripts/local-inference-ablation.mjs
@@ -44,17 +44,17 @@ const DEFAULT_VARIANTS = [
   },
   {
     name: "mtp_only",
-    label: "MTP, f16 KV",
+    label: "draft-MTP, f16 KV",
     needsDrafter: true,
-    args: ["--spec-type", "mtp"],
+    args: ["--spec-type", "draft-mtp"],
   },
   {
     name: "mtp_turbo4_polar",
-    label: "MTP + Turbo/Polar KV turbo4",
+    label: "draft-MTP + Turbo/Polar KV turbo4",
     needsDrafter: true,
     args: [
       "--spec-type",
-      "mtp",
+      "draft-mtp",
       "--cache-type-k",
       "tbq4_0",
       "--cache-type-v",
@@ -67,11 +67,11 @@ const DEFAULT_VARIANTS = [
   },
   {
     name: "all_mtp_qjl_tcq",
-    label: "MTP + forced QJL/TCQ turbo3_tcq",
+    label: "draft-MTP + forced QJL/TCQ turbo3_tcq",
     needsDrafter: true,
     args: [
       "--spec-type",
-      "mtp",
+      "draft-mtp",
       "--cache-type-k",
       "tbq3_tcq",
       "--cache-type-v",
@@ -123,6 +123,10 @@ function defaultModelPath(name) {
   return path.join(stateDir(), "local-inference", "models", name);
 }
 
+function defaultBundlePath(tierSlug, ...parts) {
+  return defaultModelPath(path.join(`eliza-1-${tierSlug}.bundle`, ...parts));
+}
+
 function parseArgs(argv) {
   const backend = detectBackend();
   let gpuLayersExplicit = false;
@@ -130,8 +134,8 @@ function parseArgs(argv) {
   const args = {
     backend,
     binary: defaultBinary(backend),
-    model: defaultModelPath("qwen3.5-4b-mtp.gguf"),
-    drafter: defaultModelPath("qwen3.5-4b-mtp-drafter-q4.repaired.gguf"),
+    model: defaultBundlePath("2b", "text", "eliza-1-2b-128k.gguf"),
+    drafter: defaultBundlePath("2b", "mtp", "drafter-2b.gguf"),
     runs: 3,
     warmupTokens: 32,
     maxTokens: 256,
@@ -291,7 +295,12 @@ function missingVariantKernels(variant, capabilities) {
   for (let i = 0; i < args.length; i += 1) {
     const flag = args[i];
     const value = args[i + 1];
-    if (flag === "--spec-type" && value === "mtp") required.add("mtp");
+    if (
+      flag === "--spec-type" &&
+      (value === "mtp" || value === "draft-mtp")
+    ) {
+      required.add("mtp");
+    }
     if (
       flag === "--cache-type-k" ||
       flag === "--cache-type-v" ||

--- a/packages/shared/src/local-inference-gpu/profiles/h200.yaml
+++ b/packages/shared/src/local-inference-gpu/profiles/h200.yaml
@@ -28,7 +28,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 780
     estimated_prefill_tps: 56000
-    notes: "Smallest/entry active Qwen3.5 local tier; smoke/default fallback."
+    notes: "Smallest/entry active Gemma 4 local tier; smoke/default fallback."
   eliza-1-4b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -40,7 +40,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 440
     estimated_prefill_tps: 34000
-    notes: "Balanced Qwen3.5 tier for dense batch serving."
+    notes: "Balanced Gemma 4 tier for dense batch serving."
   eliza-1-9b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -52,7 +52,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 270
     estimated_prefill_tps: 21000
-    notes: "High-quality Qwen3.5 tier with large HBM headroom."
+    notes: "High-quality Gemma 4 tier with large HBM headroom."
   eliza-1-27b:
     n_gpu_layers: -1
     ctx_size: 131072
@@ -64,7 +64,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 160
     estimated_prefill_tps: 9200
-    notes: "High-quality Qwen3.5 27B tier for Hopper."
+    notes: "High-quality Gemma 4 27B tier for Hopper."
   eliza-1-27b-256k:
     n_gpu_layers: -1
     ctx_size: 262144
@@ -76,7 +76,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 130
     estimated_prefill_tps: 7200
-    notes: "Long-context Qwen3.5 27B tier for single H200."
+    notes: "Long-context Gemma 4 27B tier for single H200."
 mtp:
   enabled: true
   draft_min: 8

--- a/packages/shared/src/local-inference-gpu/profiles/rtx-3090.yaml
+++ b/packages/shared/src/local-inference-gpu/profiles/rtx-3090.yaml
@@ -29,7 +29,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 280
     estimated_prefill_tps: 9000
-    notes: "Smallest/entry active Qwen3.5 local tier; smoke/default fallback."
+    notes: "Smallest/entry active Gemma 4 local tier; smoke/default fallback."
   eliza-1-4b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -41,7 +41,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 150
     estimated_prefill_tps: 5200
-    notes: "Balanced Qwen3.5 tier; all layers fit on 24 GiB with 64k context."
+    notes: "Balanced Gemma 4 tier; all layers fit on 24 GiB with 64k context."
   eliza-1-9b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -53,7 +53,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 70
     estimated_prefill_tps: 3600
-    notes: "Best-fit Qwen3.5 tier for RTX 3090; keep 27B on larger cards."
+    notes: "Best-fit Gemma 4 tier for RTX 3090; keep 27B on larger cards."
 
 mtp:
   enabled: true

--- a/packages/shared/src/local-inference-gpu/profiles/rtx-4090.yaml
+++ b/packages/shared/src/local-inference-gpu/profiles/rtx-4090.yaml
@@ -29,7 +29,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 310
     estimated_prefill_tps: 11000
-    notes: "Smallest/entry active Qwen3.5 local tier; smoke/default fallback."
+    notes: "Smallest/entry active Gemma 4 local tier; smoke/default fallback."
   eliza-1-4b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -41,7 +41,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 175
     estimated_prefill_tps: 6800
-    notes: "Balanced Qwen3.5 tier with Ada tensor-core KV path."
+    notes: "Balanced Gemma 4 tier with Ada tensor-core KV path."
   eliza-1-9b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -53,7 +53,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 110
     estimated_prefill_tps: 4600
-    notes: "High-quality Qwen3.5 tier that leaves comfortable 24 GiB headroom."
+    notes: "High-quality Gemma 4 tier that leaves comfortable 24 GiB headroom."
   eliza-1-27b:
     n_gpu_layers: -1
     ctx_size: 131072

--- a/packages/shared/src/local-inference-gpu/profiles/rtx-5090.yaml
+++ b/packages/shared/src/local-inference-gpu/profiles/rtx-5090.yaml
@@ -30,7 +30,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 460
     estimated_prefill_tps: 18000
-    notes: "Smallest/entry active Qwen3.5 local tier; smoke/default fallback."
+    notes: "Smallest/entry active Gemma 4 local tier; smoke/default fallback."
   eliza-1-4b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -42,7 +42,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 260
     estimated_prefill_tps: 12000
-    notes: "Balanced Qwen3.5 tier for high-throughput local serving."
+    notes: "Balanced Gemma 4 tier for high-throughput local serving."
   eliza-1-9b:
     n_gpu_layers: -1
     ctx_size: 65536
@@ -54,7 +54,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 180
     estimated_prefill_tps: 7600
-    notes: "High-quality Qwen3.5 tier with Blackwell headroom."
+    notes: "High-quality Gemma 4 tier with Blackwell headroom."
   eliza-1-27b:
     n_gpu_layers: -1
     ctx_size: 131072
@@ -66,7 +66,7 @@ bundle_recommendations:
     flash_attention: true
     estimated_decode_tps: 95
     estimated_prefill_tps: 3900
-    notes: "High-quality Qwen3.5 27B tier for RTX 5090."
+    notes: "High-quality Gemma 4 27B tier for RTX 5090."
   eliza-1-27b-256k:
     n_gpu_layers: -1
     ctx_size: 262144

--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   defaultVoiceQuantForTier,
   ELIZA_1_HOSTED_MTP_TIER_IDS,
-  ELIZA_1_ON_DEVICE_TIER_IDS,
   ELIZA_1_MTP_TIER_IDS,
+  ELIZA_1_ON_DEVICE_TIER_IDS,
   ELIZA_1_TIER_IDS,
   ELIZA_1_VISION_TIER_IDS,
   isOnDeviceTier,
@@ -222,5 +222,4 @@ describe("Eliza-1 runtime quant metadata", () => {
       expect(q4_0?.mobilePreferred).toBeUndefined();
     }
   });
-
 });

--- a/packages/shared/src/voice.ts
+++ b/packages/shared/src/voice.ts
@@ -318,8 +318,8 @@ export const VOICE_PROVIDERS: Array<{
  * ASR (automatic speech recognition) provider catalogue. Mirrors
  * `VOICE_PROVIDERS` so the settings UI can render a provider picker for
  * speech-to-text. The legacy whisper.cpp pipeline has been retired —
- * on-device transcription now runs through the local-inference Qwen3-ASR
- * bundle instead.
+ * on-device transcription now runs through the local-inference ASR bundle.
+ * Release catalog checks gate the bundle lineage before it can be selected.
  */
 export const ASR_PROVIDERS: Array<{
   id: "local-inference" | "eliza-cloud" | "openai";
@@ -333,7 +333,7 @@ export const ASR_PROVIDERS: Array<{
     id: "local-inference",
     label: "Local inference",
     labelKey: "asr.provider.localInference",
-    hint: "On-device Qwen3-ASR",
+    hint: "On-device local ASR",
     hintKey: "asr.provider.localInference.hint",
     needsKey: false,
   },

--- a/plugins/plugin-discord/__tests__/outbound-attachment.test.ts
+++ b/plugins/plugin-discord/__tests__/outbound-attachment.test.ts
@@ -6,8 +6,8 @@
  * to a plain URL attachment, and non-video/audio media is never fetched.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { ContentType, type Media } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOutboundDiscordAttachment } from "../utils.ts";
 
 function media(overrides: Partial<Media>): Media {
@@ -40,9 +40,11 @@ describe("buildOutboundDiscordAttachment", () => {
 	});
 
 	it("falls back to a URL attachment when the fetch is not ok", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue({ ok: false, status: 502, arrayBuffer: async () => new ArrayBuffer(0) });
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 502,
+			arrayBuffer: async () => new ArrayBuffer(0),
+		});
 		vi.stubGlobal("fetch", fetchMock);
 
 		const url = "http://127.0.0.1:8080/v1/media/x/content";

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -1,165 +1,165 @@
 {
-  "name": "@elizaos/plugin-discord",
-  "version": "2.0.3-beta.2",
-  "description": "",
-  "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "sideEffects": false,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/elizaos-plugins/plugin-discord.git"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./*.css": "./dist/*.css",
-    "./user-account-scraper": {
-      "types": "./dist/user-account-scraper/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
-    }
-  },
-  "files": [
-    "registry-entry.json",
-    "dist"
-  ],
-  "keywords": [],
-  "author": "elizaOS",
-  "license": "MIT",
-  "scripts": {
-    "build": "bun run build.ts",
-    "build:ts": "bun run build.ts",
-    "dev": "bun --hot build.ts",
-    "clean": "rm -rf dist .turbo && node ../../packages/scripts/clean-stray-dts.mjs",
-    "test": "vitest run",
-    "test:harness": "vitest run --config ./vitest.harness.config.ts",
-    "typecheck": "tsc --noEmit",
-    "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check .",
-    "format": "bunx @biomejs/biome format --write .",
-    "format:check": "bunx @biomejs/biome format .",
-    "test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",
-    "test:live": "bun run test:e2e"
-  },
-  "dependencies": {
-    "@discordjs/builders": "^1.14.1",
-    "@discordjs/collection": "2.1.1",
-    "@discordjs/formatters": "^0.6.2",
-    "@discordjs/opus": "^0.10.0",
-    "@discordjs/rest": "^2.6.1",
-    "@discordjs/util": "^1.2.0",
-    "@discordjs/voice": "^0.19.2",
-    "@discordjs/ws": "^1.2.3",
-    "@elizaos/core": "workspace:*",
-    "@elizaos/plugin-browser": "workspace:*",
-    "@elizaos/plugin-commands": "workspace:*",
-    "@sapphire/snowflake": "3.5.5",
-    "discord-api-types": "^0.38.0",
-    "discord.js": "^14.26.4",
-    "fast-deep-equal": "3.1.3",
-    "fast-levenshtein": "^3.0.0",
-    "fluent-ffmpeg": "^2.1.3",
-    "get-func-name": "^3.0.0",
-    "libsodium-wrappers": "^0.8.0",
-    "lodash.snakecase": "4.1.1",
-    "magic-bytes.js": "^1.13.0",
-    "opusscript": "^0.1.1",
-    "prism-media": "1.3.5",
-    "tslib": "^2.6.3",
-    "undici": "8.5.0",
-    "zod": "^4.4.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.14",
-    "@elizaos/test-harness": "workspace:*",
-    "@types/node": "^25.0.3",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.4"
-  },
-  "peerDependencies": {
-    "@elizaos/core": "workspace:*"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "agentConfig": {
-    "pluginType": "elizaos:plugin:1.0.0",
-    "pluginParameters": {
-      "DISCORD_API_TOKEN": {
-        "type": "string",
-        "description": "Discord API token used to authenticate and log in the Discord client/service.",
-        "required": true,
-        "sensitive": true
-      },
-      "DISCORD_APPLICATION_ID": {
-        "type": "string",
-        "description": "Discord application ID for the bot",
-        "required": true,
-        "sensitive": false
-      },
-      "CHANNEL_IDS": {
-        "type": "string",
-        "description": "Comma-separated list of Discord channel IDs that will be parsed into an array if provided.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_TEST_CHANNEL_ID": {
-        "type": "string",
-        "description": "Discord channel ID used during test suite to locate the test channel for sending messages, voice interactions, and other test operations.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_VOICE_CHANNEL_ID": {
-        "type": "string",
-        "description": "ID of the Discord voice channel the bot should join when scanning a guild. If not supplied, the bot selects a channel based on member activity.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_SHOULD_IGNORE_BOT_MESSAGES": {
-        "type": "boolean",
-        "description": "If true, the bot will ignore messages from other bots. Can be overridden by character settings.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES": {
-        "type": "boolean",
-        "description": "If true, the bot will ignore direct messages. Can be overridden by character settings.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS": {
-        "type": "boolean",
-        "description": "If true, the bot will only respond when explicitly mentioned. Can be overridden by character settings.",
-        "required": false,
-        "sensitive": false
-      },
-      "DISCORD_LISTEN_CHANNEL_IDS": {
-        "type": "string",
-        "description": "Comma-separated list of Discord channel IDs where the bot will only listen (not respond).",
-        "required": false,
-        "sensitive": false
-      }
-    }
-  },
-  "eliza": {
-    "platforms": [
-      "node"
-    ],
-    "runtime": "node",
-    "platformDetails": {
-      "node": "Default export (Node.js)"
-    }
-  },
-  "gitHead": "05d4ca11d769db8c7f54a722ee24b2ce2b951543"
+	"name": "@elizaos/plugin-discord",
+	"version": "2.0.3-beta.2",
+	"description": "",
+	"type": "module",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/elizaos-plugins/plugin-discord.git"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./*.css": "./dist/*.css",
+		"./user-account-scraper": {
+			"types": "./dist/user-account-scraper/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./*": {
+			"types": "./dist/*.d.ts",
+			"import": "./dist/*.js",
+			"default": "./dist/*.js"
+		}
+	},
+	"files": [
+		"registry-entry.json",
+		"dist"
+	],
+	"keywords": [],
+	"author": "elizaOS",
+	"license": "MIT",
+	"scripts": {
+		"build": "bun run build.ts",
+		"build:ts": "bun run build.ts",
+		"dev": "bun --hot build.ts",
+		"clean": "rm -rf dist .turbo && node ../../packages/scripts/clean-stray-dts.mjs",
+		"test": "vitest run",
+		"test:harness": "vitest run --config ./vitest.harness.config.ts",
+		"typecheck": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome check --write --unsafe .",
+		"lint:check": "bunx @biomejs/biome check .",
+		"format": "bunx @biomejs/biome format --write .",
+		"format:check": "bunx @biomejs/biome format .",
+		"test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",
+		"test:live": "bun run test:e2e"
+	},
+	"dependencies": {
+		"@discordjs/builders": "^1.14.1",
+		"@discordjs/collection": "2.1.1",
+		"@discordjs/formatters": "^0.6.2",
+		"@discordjs/opus": "^0.10.0",
+		"@discordjs/rest": "^2.6.1",
+		"@discordjs/util": "^1.2.0",
+		"@discordjs/voice": "^0.19.2",
+		"@discordjs/ws": "^1.2.3",
+		"@elizaos/core": "workspace:*",
+		"@elizaos/plugin-browser": "workspace:*",
+		"@elizaos/plugin-commands": "workspace:*",
+		"@sapphire/snowflake": "3.5.5",
+		"discord-api-types": "^0.38.0",
+		"discord.js": "^14.26.4",
+		"fast-deep-equal": "3.1.3",
+		"fast-levenshtein": "^3.0.0",
+		"fluent-ffmpeg": "^2.1.3",
+		"get-func-name": "^3.0.0",
+		"libsodium-wrappers": "^0.8.0",
+		"lodash.snakecase": "4.1.1",
+		"magic-bytes.js": "^1.13.0",
+		"opusscript": "^0.1.1",
+		"prism-media": "1.3.5",
+		"tslib": "^2.6.3",
+		"undici": "8.5.0",
+		"zod": "^4.4.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.14",
+		"@elizaos/test-harness": "workspace:*",
+		"@types/node": "^25.0.3",
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.4"
+	},
+	"peerDependencies": {
+		"@elizaos/core": "workspace:*"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"agentConfig": {
+		"pluginType": "elizaos:plugin:1.0.0",
+		"pluginParameters": {
+			"DISCORD_API_TOKEN": {
+				"type": "string",
+				"description": "Discord API token used to authenticate and log in the Discord client/service.",
+				"required": true,
+				"sensitive": true
+			},
+			"DISCORD_APPLICATION_ID": {
+				"type": "string",
+				"description": "Discord application ID for the bot",
+				"required": true,
+				"sensitive": false
+			},
+			"CHANNEL_IDS": {
+				"type": "string",
+				"description": "Comma-separated list of Discord channel IDs that will be parsed into an array if provided.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_TEST_CHANNEL_ID": {
+				"type": "string",
+				"description": "Discord channel ID used during test suite to locate the test channel for sending messages, voice interactions, and other test operations.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_VOICE_CHANNEL_ID": {
+				"type": "string",
+				"description": "ID of the Discord voice channel the bot should join when scanning a guild. If not supplied, the bot selects a channel based on member activity.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_SHOULD_IGNORE_BOT_MESSAGES": {
+				"type": "boolean",
+				"description": "If true, the bot will ignore messages from other bots. Can be overridden by character settings.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES": {
+				"type": "boolean",
+				"description": "If true, the bot will ignore direct messages. Can be overridden by character settings.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS": {
+				"type": "boolean",
+				"description": "If true, the bot will only respond when explicitly mentioned. Can be overridden by character settings.",
+				"required": false,
+				"sensitive": false
+			},
+			"DISCORD_LISTEN_CHANNEL_IDS": {
+				"type": "string",
+				"description": "Comma-separated list of Discord channel IDs where the bot will only listen (not respond).",
+				"required": false,
+				"sensitive": false
+			}
+		}
+	},
+	"eliza": {
+		"platforms": [
+			"node"
+		],
+		"runtime": "node",
+		"platformDetails": {
+			"node": "Default export (Node.js)"
+		}
+	},
+	"gitHead": "05d4ca11d769db8c7f54a722ee24b2ce2b951543"
 }

--- a/plugins/plugin-google/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google/src/lifeops-message-adapter.ts
@@ -126,9 +126,20 @@ function toGmailOperation(op: ManageOperation): {
 
 function getGoogleService(runtime: IAgentRuntime): IGoogleGmailService | null {
   const service = runtime.getService("google");
-  return service && typeof service === "object"
-    ? (service as IGoogleGmailService)
-    : null;
+  return isGoogleGmailService(service) ? service : null;
+}
+
+function isGoogleGmailService(service: unknown): service is IGoogleGmailService {
+  if (service === null || typeof service !== "object") {
+    return false;
+  }
+  return [
+    "createGmailFilterForSender",
+    "listGmailTriageMessages",
+    "modifyGmailMessages",
+    "searchGmailMessages",
+    "sendGmailReply",
+  ].every((method) => typeof Reflect.get(service, method) === "function");
 }
 
 function messageAccountId(message: MessageRef | null | undefined): string {

--- a/plugins/plugin-local-inference/scripts/local-inference-ablation.config.json
+++ b/plugins/plugin-local-inference/scripts/local-inference-ablation.config.json
@@ -22,17 +22,17 @@
     },
     {
       "name": "mtp_only",
-      "label": "MTP, f16 KV",
+      "label": "draft-MTP, f16 KV",
       "needsDrafter": true,
-      "args": ["--spec-type", "mtp"]
+      "args": ["--spec-type", "draft-mtp"]
     },
     {
       "name": "mtp_turbo4_polar",
-      "label": "MTP + Turbo/Polar KV turbo4",
+      "label": "draft-MTP + Turbo/Polar KV turbo4",
       "needsDrafter": true,
       "args": [
         "--spec-type",
-        "mtp",
+        "draft-mtp",
         "--cache-type-k",
         "tbq4_0",
         "--cache-type-v",
@@ -45,11 +45,11 @@
     },
     {
       "name": "all_mtp_qjl_tcq",
-      "label": "MTP + QJL K + TBQ3 V",
+      "label": "draft-MTP + QJL K + TBQ3 V",
       "needsDrafter": true,
       "args": [
         "--spec-type",
-        "mtp",
+        "draft-mtp",
         "--cache-type-k",
         "qjl1_256",
         "--cache-type-v",

--- a/plugins/plugin-local-inference/scripts/local-inference-ablation.mjs
+++ b/plugins/plugin-local-inference/scripts/local-inference-ablation.mjs
@@ -42,17 +42,17 @@ const DEFAULT_VARIANTS = [
   },
   {
     name: "mtp_only",
-    label: "MTP, f16 KV",
+    label: "draft-MTP, f16 KV",
     needsDrafter: true,
-    args: ["--spec-type", "mtp"],
+    args: ["--spec-type", "draft-mtp"],
   },
   {
     name: "mtp_turbo4_polar",
-    label: "MTP + Turbo/Polar KV turbo4",
+    label: "draft-MTP + Turbo/Polar KV turbo4",
     needsDrafter: true,
     args: [
       "--spec-type",
-      "mtp",
+      "draft-mtp",
       "--cache-type-k",
       "tbq4_0",
       "--cache-type-v",
@@ -65,11 +65,11 @@ const DEFAULT_VARIANTS = [
   },
   {
     name: "all_mtp_qjl_tcq",
-    label: "MTP + QJL K + TBQ3 V",
+    label: "draft-MTP + QJL K + TBQ3 V",
     needsDrafter: true,
     args: [
       "--spec-type",
-      "mtp",
+      "draft-mtp",
       "--cache-type-k",
       "qjl1_256",
       "--cache-type-v",
@@ -183,7 +183,8 @@ function variantRequiredKernels(variant) {
     const arg = argv[i];
     if (arg === "--spec-type" || arg.startsWith("--spec-type=")) {
       const parsed = optionValue(argv, i);
-      if (parsed.value && normalizeKernelArg(parsed.value) === "mtp") {
+      const specType = parsed.value ? normalizeKernelArg(parsed.value) : "";
+      if (specType === "mtp" || specType === "draft_mtp") {
         required.add("mtp");
       }
       i += parsed.consumed;
@@ -219,6 +220,10 @@ function missingVariantKernels(variant, capabilities) {
 
 function defaultModelPath(name) {
   return path.join(stateDir(), "local-inference", "models", name);
+}
+
+function defaultBundlePath(tierSlug, ...parts) {
+  return defaultModelPath(path.join(`eliza-1-${tierSlug}.bundle`, ...parts));
 }
 
 const QUICK_VARIANTS = [
@@ -270,8 +275,8 @@ function defaultArgsForBackend(backend) {
   return {
     backend,
     binary: null,
-    model: defaultModelPath("eliza-1-2b.gguf"),
-    drafter: defaultModelPath("eliza-1-2b-drafter-q4.repaired.gguf"),
+    model: defaultBundlePath("2b", "text", "eliza-1-2b-128k.gguf"),
+    drafter: defaultBundlePath("2b", "mtp", "drafter-2b.gguf"),
     runs: 3,
     warmupTokens: 32,
     maxTokens: 256,

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
@@ -94,19 +94,20 @@ export function estimateEchoDelaySamples(
  * tuning); the goal is only to put the adaptive filter in the right ballpark on
  * the first turn, not to be exact.
  */
-export const PLATFORM_PLAYBACK_DELAY_DEFAULTS: Readonly<Record<string, number>> =
-	{
-		/** macOS CoreAudio — low, stable hardware path. */
-		darwin: 20,
-		/** iOS AVAudioEngine (when its voice-processing IO AEC is not the source). */
-		ios: 25,
-		/** Android AudioTrack/AudioRecord — variable; a mid seed. */
-		android: 45,
-		/** Windows WASAPI shared-mode. */
-		win32: 30,
-		/** Desktop Linux ALSA/PulseAudio/PipeWire. */
-		linux: 30,
-	};
+export const PLATFORM_PLAYBACK_DELAY_DEFAULTS: Readonly<
+	Record<string, number>
+> = {
+	/** macOS CoreAudio — low, stable hardware path. */
+	darwin: 20,
+	/** iOS AVAudioEngine (when its voice-processing IO AEC is not the source). */
+	ios: 25,
+	/** Android AudioTrack/AudioRecord — variable; a mid seed. */
+	android: 45,
+	/** Windows WASAPI shared-mode. */
+	win32: 30,
+	/** Desktop Linux ALSA/PulseAudio/PipeWire. */
+	linux: 30,
+};
 
 /** Fallback seed (ms) for an unrecognized platform id. */
 export const DEFAULT_PLAYBACK_DELAY_MS = 25;
@@ -117,7 +118,9 @@ export const DEFAULT_PLAYBACK_DELAY_MS = 25;
  * report). Unknown ids fall back to {@link DEFAULT_PLAYBACK_DELAY_MS}.
  */
 export function platformPlaybackDelayMs(platform: string): number {
-	return PLATFORM_PLAYBACK_DELAY_DEFAULTS[platform] ?? DEFAULT_PLAYBACK_DELAY_MS;
+	return (
+		PLATFORM_PLAYBACK_DELAY_DEFAULTS[platform] ?? DEFAULT_PLAYBACK_DELAY_MS
+	);
 }
 
 /**

--- a/plugins/plugin-xr/src/routes/xr-view-host.ts
+++ b/plugins/plugin-xr/src/routes/xr-view-host.ts
@@ -33,8 +33,7 @@ export const xrViewHostRoute: Route = {
     }
 
     // Resolve the agent origin so the page can load the bundle
-    const agentPort =
-      (ctx.runtime as { port?: number }).port ?? 31337;
+    const agentPort = (ctx.runtime as { port?: number }).port ?? 31337;
     const agentOrigin =
       process.env.XR_AGENT_URL ?? `http://localhost:${agentPort}`;
     const bundleUrl = `${agentOrigin}/api/views/${viewId}/bundle.js`;

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -125,9 +125,7 @@ async function generateTextWithModel(
     ...(typeof resolved.maxTokens === "number" ? { maxTokens: resolved.maxTokens } : {}),
   };
 
-  const { text, usage } = await generateText(
-    generateParams as Parameters<typeof generateText>[0]
-  );
+  const { text, usage } = await generateText(generateParams as Parameters<typeof generateText>[0]);
 
   if (usage) {
     emitModelUsageEvent(runtime, modelType, usage);


### PR DESCRIPTION
Refs #9588

## Summary
- Point local-inference ablation defaults at the release-shaped Gemma bundle paths: `eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf` and `eliza-1-2b.bundle/mtp/drafter-2b.gguf`.
- Rename built-in/config MTP variants to draft-MTP and pass `--spec-type draft-mtp`; the runners still gate these variants on MTP kernel support and drafter presence.
- Remove the user-facing Qwen ASR label from shared voice provider copy, and update GPU profile notes from Qwen3.5 to Gemma 4.
- Include formatter/type-safety fixes needed for a clean root `bun run verify` on this branch.

## Artifact status checked
- Gemma docs indicate Gemma 4 uses dedicated draft models for speculative decoding, with llama.cpp routing through quantized primary GGUF plus an assistant/drafter model.
- Hugging Face `elizaos/eliza-1` currently has public `bundles/<tier>/asr/...` files, but active public bundle manifests still have `defaultEligible: false` and Qwen/local-standin lineage, so ASR remains gated by the prior catalog/runtime checks.
- Hugging Face `bundles/2b/mtp/drafter-2b.gguf` still returns 404, and the candidate MTP `MISSING.txt` still says no GGUF drafter is staged; this PR prepares tooling defaults but does not activate MTP catalog/runtime paths.

## Verification
- Rebased onto `origin/develop` at `ec338f6aa0` before the final root gate.
- `bun install`
- `bun run --cwd packages/shared build:i18n`
- `node --check packages/scripts/local-inference-ablation.mjs`
- `node --check plugins/plugin-local-inference/scripts/local-inference-ablation.mjs`
- `jq empty packages/scripts/local-inference-ablation.config.json plugins/plugin-local-inference/scripts/local-inference-ablation.config.json`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bun run --cwd packages/shared lint`
- `bun run --cwd plugins/plugin-local-inference lint:check`
- `bun run --cwd packages/shared test -- src/local-inference/catalog.test.ts src/local-inference-gpu/__tests__/gpu-profile-loader.test.ts`
- `bun run --cwd plugins/plugin-local-inference test -- src/services/voice/echo-delay.test.ts`
- `bun run --cwd packages/plugin-worker-runtime lint`
- `bun run --cwd packages/app-core lint`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/agent lint`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd plugins/plugin-google typecheck`
- `bun run --cwd plugins/plugin-google lint:check`
- `bun run --cwd plugins/plugin-calendar typecheck`
- `bun run --cwd plugins/plugin-xr lint`
- `bun run --cwd packages/app-core/platforms/electrobun lint`
- `bun run --cwd packages/app-core/platforms/electrobun typecheck`
- `bun run --cwd packages/os/setup lint`
- `bun run --cwd packages/os/setup typecheck`
- `bun run --cwd packages/core lint` (passes with existing unused-import warnings)
- `bun run --cwd packages/core typecheck`
- `git diff --check`
- `bun run verify` passed after rebase: 515/515 tasks, 3m6.791s
