### PR TITLE
fix(app-core): remove Qwen ASR labels from local voice surfaces

### DIFF
--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -155,7 +155,7 @@ android {
     }
 }
 // Bundle the MTP Android llama.cpp stack into the APK so mobile
-// gets Eliza-1/Qwen3.5 support across every supported Android ABI
+// gets Eliza-1/Gemma 4 support across every supported Android ABI
 // (arm64-v8a, x86_64, riscv64). The arm64-v8a slice is mandatory for
 // local-agent capable builds; x86_64 and riscv64 ship when their
 // per-ABI artifacts exist (Wave 2 cross-compiles land them

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
@@ -595,7 +595,7 @@ final class ElizaBionicInferenceServer {
 
     /**
      * On-device STT: decode the base64 little-endian fp32 PCM, run the fused
-     * Qwen3-ASR batch transcribe on the resident context (it mmap-acquires the
+     * local ASR batch transcribe on the resident context (it mmap-acquires the
      * {@code asr/} weights on first use), and return {ok, text}. The agent's
      * TRANSCRIPTION delegate routes here over UDS (op="asr"); the musl agent
      * can't reach the fused lib itself. Reuses the ONE resident context like

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoiceNative.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoiceNative.java
@@ -233,7 +233,7 @@ final class ElizaVoiceNative {
 
     /**
      * Transcribe {@code pcm} (16 kHz mono fp32) → UTF-8 transcript via the fused
-     * Qwen3-ASR head ({@code eliza_inference_asr_transcribe}). VAD-free: the
+     * local ASR head ({@code eliza_inference_asr_transcribe}). VAD-free: the
      * resident context mmap-acquires the {@code asr/} weights on first use. The
      * bionic host's op="asr" calls this so the agent TRANSCRIPTION delegate gets
      * a real on-device transcript without the full attribution pipeline.

--- a/packages/app-core/scripts/aosp/deploy-pixel.mjs
+++ b/packages/app-core/scripts/aosp/deploy-pixel.mjs
@@ -326,7 +326,7 @@ async function main(argv = process.argv.slice(2)) {
     if (args.voice) {
       console.log(
         "[deploy-pixel] (dry-run) would run the on-device voice round-trip check " +
-          "(mic→VAD→Qwen3-ASR→MTP text→OmniVoice TTS) via the local-inference voice endpoint, " +
+          "(mic→VAD→local ASR→MTP text→OmniVoice TTS) via the local-inference voice endpoint, " +
           "reporting TTFT-from-utterance-end.",
       );
     }

--- a/packages/app-core/scripts/build-llama-cpp-mtp.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-mtp.mjs
@@ -63,7 +63,13 @@ const DEPLOYMENT_TARGET =
 //    ios-deps tree is the historical fallback. Both carry the eliza kernels.
 const FORK_SRC_CANDIDATES = [
   process.env.ELIZA_MTP_LLAMA_CPP_SRC?.trim(),
-  path.join(repoRoot, "plugins", "plugin-local-inference", "native", "llama.cpp"),
+  path.join(
+    repoRoot,
+    "plugins",
+    "plugin-local-inference",
+    "native",
+    "llama.cpp",
+  ),
   path.join(repoRoot, "packages", "native", "ios-deps", "llama.cpp", "src"),
 ].filter(Boolean);
 
@@ -75,7 +81,7 @@ const SUPPORTED_TARGETS = [
 ];
 
 /** Per-target recipe. The iOS device + simulator slices differ only by SDK.
- *  The `-fused` variants additionally build the OmniVoice TTS + Qwen3-ASR FFI
+ *  The `-fused` variants additionally build the OmniVoice TTS + local ASR FFI
  *  (the eliza_inference_* voice ABI = libelizainference) and libmtmd into the
  *  slice, so the iOS XCFramework carries the real voice runtime instead of the
  *  fail-closed runtime-symbol shim. */
@@ -105,7 +111,7 @@ const REQUIRED_KERNELS = [
   { id: "turbo4", pattern: /turbo4/i },
 ];
 
-// ── Fused-only: the OmniVoice TTS + Qwen3-ASR FFI symbol set that distinguishes
+// ── Fused-only: the OmniVoice TTS + local ASR FFI symbol set that distinguishes
 //    a real libelizainference (ABI v4) from the fail-closed runtime shim. These
 //    mirror the eliza_inference_* half of ios-xcframework/build-xcframework.mjs
 //    REQUIRED_IOS_KERNEL_SYMBOLS plus an mtmd presence probe (the ASR path wraps
@@ -219,7 +225,7 @@ function collectArchives(buildDir, outDir) {
     .map((s) => s.trim())
     .filter(Boolean)
     .filter((p) =>
-      // Fused slices also stage libmtmd*.a (Qwen3-ASR projector),
+      // Fused slices also stage libmtmd*.a (local ASR projector),
       // libkokoro_lib*.a (Kokoro-82M TTS, ABI v10), and libelizainference*.a
       // (the eliza_inference_* voice ABI). NOT libomnivoice*.a —
       // elizainference_static already compiles the omnivoice CORE sources, so
@@ -276,12 +282,7 @@ function buildTarget(target) {
   log(`target=${target} sdk=${t.sdk} fork=${revision}`);
   log(`source: ${srcDir}`);
 
-  const buildDir = path.join(
-    STATE_DIR,
-    "local-inference",
-    "mtp-build",
-    target,
-  );
+  const buildDir = path.join(STATE_DIR, "local-inference", "mtp-build", target);
   if (process.env.ELIZA_MTP_FORCE_REBUILD === "1") {
     fs.rmSync(buildDir, { recursive: true, force: true });
   }
@@ -319,7 +320,7 @@ function buildTarget(target) {
     "-DLLAMA_BUILD_TESTS=OFF",
     "-DLLAMA_BUILD_SERVER=OFF",
     "-DLLAMA_CURL=OFF",
-    // Fused voice slice: build the standalone libmtmd (the Qwen3-ASR audio
+    // Fused voice slice: build the standalone libmtmd (the local ASR audio
     // projector the eliza_inference ASR path wraps). The omnivoice subtree is
     // already configured (LLAMA_BUILD_OMNIVOICE defaults ON); we only need the
     // elizainference_static + mtmd targets, built by name below.
@@ -341,7 +342,7 @@ function buildTarget(target) {
   // library targets carry the full kernel set and need no signing.
   const buildTargets = ["llama", "ggml", "ggml-base", "ggml-cpu", "ggml-metal"];
   if (t.fused) {
-    // mtmd (Qwen3-ASR projector) + kokoro_lib (Kokoro-82M TTS, ABI v10) + the
+    // mtmd (local ASR projector) + kokoro_lib (Kokoro-82M TTS, ABI v10) + the
     // STATIC eliza_inference_* FFI archive. kokoro_lib must build before
     // elizainference_static links so the `if(TARGET kokoro_lib)` fold resolves.
     // NOT omnivoice-tts / omnivoice-codec: those CLIs include audio-io.h
@@ -352,7 +353,7 @@ function buildTarget(target) {
   }
   log(
     `cmake build (static libraries only) — compiles the Metal kernel set${
-      t.fused ? " + OmniVoice/Qwen3-ASR voice FFI" : ""
+      t.fused ? " + OmniVoice/local-ASR voice FFI" : ""
     }`,
   );
   run("cmake", [
@@ -381,7 +382,7 @@ function buildTarget(target) {
     );
   }
 
-  // Fused-only: prove the REAL OmniVoice TTS + Qwen3-ASR FFI (the eliza_inference_*
+  // Fused-only: prove the REAL OmniVoice TTS + local ASR FFI (the eliza_inference_*
   // voice ABI v4) and the mtmd projector are present in the staged archives, so
   // the xcframework assembler's real-vs-fail-closed-shim decision (keyed off
   // CAPABILITIES.omnivoice != null) is backed by actual symbols. The fork at
@@ -414,7 +415,7 @@ function buildTarget(target) {
     archives: archives.map((a) => path.basename(a)),
     // The xcframework assembler reads `omnivoice == null` as "use the
     // fail-closed runtime symbol shim". Fused slices carry the real
-    // libelizainference (OmniVoice TTS + Qwen3-ASR FFI), so they advertise a
+    // libelizainference (OmniVoice TTS + local ASR FFI), so they advertise a
     // non-null capability object → the assembler compiles the shim with
     // -DELIZA_IOS_REAL_ELIZAINFERENCE=1 (dropping the stub voice bodies) and the
     // real symbols resolve from the staged archive.
@@ -434,7 +435,7 @@ function buildTarget(target) {
               : 4,
           library: "libelizainference",
           tts: "omnivoice",
-          asr: "qwen3-asr",
+          asr: "local-asr",
           vad: "silero",
           kokoro: /(?:^|\s)_?eliza_inference_kokoro_synthesize\b/m.test(
             symbolsText,

--- a/packages/app-core/scripts/lib/duet-bridge.mjs
+++ b/packages/app-core/scripts/lib/duet-bridge.mjs
@@ -8,7 +8,7 @@
  *   A.scheduler.sink ── DuetSink(aToB) ──→ PcmRingBuffer ──→ B.micSource.push
  *   B.scheduler.sink ── DuetSink(bToA) ──→ PcmRingBuffer ──→ A.micSource.push
  *
- * The TTS emits 24 kHz mono; the VAD + Qwen3-ASR want 16 kHz mono — one
+ * The TTS emits 24 kHz mono; the VAD + local ASR want 16 kHz mono — one
  * linear-interpolation resample in the `DuetSink`, zero file writes.
  *
  * `DuetSink` also reports the **`peer-utterance-end`** instant: when the

--- a/packages/app-core/scripts/stage-desktop-fused-lib.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib.mjs
@@ -280,7 +280,7 @@ const jobs =
 // (so the GPU backend can load the system driver at runtime) and matches the
 // dlopen()-able sibling set the runtime resolves. LLAMA_BUILD_OMNIVOICE +
 // LLAMA_BUILD_MTMD + LLAMA_BUILD_KOKORO are required for the fused
-// `elizainference` SHARED target (TTS + Qwen3-ASR + Kokoro). GGML_NATIVE=ON tunes
+// `elizainference` SHARED target (TTS + local ASR + Kokoro). GGML_NATIVE=ON tunes
 // the CPU backend to the build host — correct for a local/dev build; a
 // redistributable build should pin explicit CPU features instead.
 run("cmake", [

--- a/packages/app-core/scripts/voice-duet.mjs
+++ b/packages/app-core/scripts/voice-duet.mjs
@@ -789,7 +789,7 @@ async function main() {
     let perceived = null;
     if (perceivedRaw) {
       perceived = asrEmotionToTag(perceivedRaw) ?? null;
-      emotionPerceiver = "qwen3-asr-emotion";
+      emotionPerceiver = "local-asr-emotion";
     } else {
       emotionPerceiver = "fallback-classifier:unavailable";
     }
@@ -1039,7 +1039,7 @@ async function main() {
         },
         notes:
           accuracy == null
-            ? "emotionFidelity.accuracy is null — the GGUF-converted Qwen3-ASR did not surface an emotion label in this run and no fallback emotion-from-audio classifier was available; recorded as null per the honesty contract, not fabricated. structured-decode token-savings % is null when the running llama-server's /metrics did not expose the guided-decode counter."
+            ? "emotionFidelity.accuracy is null — the GGUF-converted local ASR did not surface an emotion label in this run and no fallback emotion-from-audio classifier was available; recorded as null per the honesty contract, not fabricated. structured-decode token-savings % is null when the running llama-server's /metrics did not expose the guided-decode counter."
             : `emotionFidelity perceiver: ${emotionPerceiver}.`,
         turns: turnLog,
       };
@@ -1098,7 +1098,7 @@ async function main() {
 }
 
 // ---------------------------------------------------------------------------
-// Best-effort transcript emotion extraction (Qwen3-ASR `<emotion>…</emotion>`
+// Best-effort transcript emotion extraction (local ASR `<emotion>…</emotion>`
 // or a `[emotion:happy]`-style tag, if the GGUF-ASR surfaces one). Returns the
 // raw label or null. Honest: if the transcript has no emotion marker, null —
 // the fidelity metric records "perceiver: fallback-classifier (unavailable)".

--- a/packages/app-core/scripts/voice-interactive.mjs
+++ b/packages/app-core/scripts/voice-interactive.mjs
@@ -5,7 +5,7 @@
  * Send a voice message, get a voice response back — the full optimized
  * voice-assistant loop the W1–W13 swarm landed, run interactively:
  *
- *   mic → VAD (RMS + Silero v5 GGUF) → streaming ASR (fused Qwen3-ASR)
+ *   mic → VAD (RMS + Silero v5 GGUF) → streaming local ASR
  *      → turn controller (prewarm-on-speech-start, speculative-on-pause,
  *        abort-on-resume, promote-or-rerun on speech-end)
  *      → runtime message handler (Stage-1 forced-JSON grammar, streamed)
@@ -281,12 +281,12 @@ async function inspectActiveOptimizations(args) {
     active.push({
       name: "streaming OmniVoice TTS",
       on: true,
-      detail: `fused libelizainference at ${ttsLibPath} (OmniVoice TTS + Qwen3-ASR); streaming LLM→TTS via the voice scheduler. On macOS-Metal this is the full graph; on a CPU fused build it runs but slower.`,
+      detail: `fused libelizainference at ${ttsLibPath} (OmniVoice TTS + local ASR); streaming LLM→TTS via the voice scheduler. On macOS-Metal this is the full graph; on a CPU fused build it runs but slower.`,
     });
   } else {
     missing.push({
       what: "no real TTS backend — interactive voice needs the fused libelizainference build (the stub backend emits silence and is rejected)",
-      fix: "build it: see packages/app-core/scripts/omnivoice-merged/README.md (the fused build ships real OmniVoice TTS + Qwen3-ASR on macOS-Metal; stub elsewhere)",
+      fix: "build it: see packages/app-core/scripts/omnivoice-merged/README.md (the fused build ships real OmniVoice TTS + local ASR on macOS-Metal; stub elsewhere)",
     });
     active.push({
       name: "streaming OmniVoice TTS",
@@ -296,17 +296,17 @@ async function inspectActiveOptimizations(args) {
     });
   }
 
-  // ── ASR backend (fused Qwen3-ASR via libelizainference only) ───────────
+  // ── ASR backend (eligible local ASR via libelizainference only) ─────────
   let asrBackend = null;
   if (bundleRoot && existsSync(path.join(bundleRoot, "asr"))) {
-    asrBackend = "fused (Qwen3-ASR region in the bundle)";
+    asrBackend = "fused (local ASR region in the bundle)";
   }
   if (asrBackend) {
     active.push({ name: "streaming ASR", on: true, detail: asrBackend });
   } else {
     missing.push({
-      what: "no ASR backend (no fused Qwen3-ASR region in the bundle)",
-      fix: "rebuild or download a libelizainference bundle that ships the Qwen3-ASR region (asr/ subdirectory).",
+      what: "no ASR backend (no fused local ASR region in the bundle)",
+      fix: "rebuild or download a libelizainference bundle that ships an eligible local ASR region (asr/ subdirectory).",
     });
   }
 
@@ -637,7 +637,7 @@ const PLATFORM_MATRIX = [
           "sox/play — or ffplay — (afplay needs a file, not used) — or renderer AudioContext",
         vad: "fused libelizainference Silero v5 (arm64)",
         ttsAsr:
-          "fused libelizainference.dylib (real OmniVoice TTS + Qwen3-ASR, full graph)",
+          "fused libelizainference.dylib (real OmniVoice TTS + local ASR, full graph)",
         verified:
           "Metal kernels hardware-verified on M4 Max; needs a macOS arm64 host to build",
       },


### PR DESCRIPTION
Refs #9588

## Summary
- Replaces stale app-core operator-facing Qwen3-ASR labels with neutral local ASR wording in voice scripts, Android docs/comments, bridge logs, and report labels.
- Updates the staged iOS fused-library `CAPABILITIES.json` ASR marker from `qwen3-asr` to `local-asr` so generated desktop/mobile bundle metadata no longer advertises Qwen ASR as the active surface.
- Leaves low-level `qwen3a` compatibility/backport references intact where they still describe concrete FFI/projector implementation details until verified Gemma ASR artifacts or replacement fused code exist.

## Verification
- `git fetch origin develop --prune`
- `git rebase origin/develop`
- `bun install`
- `node --check packages/app-core/scripts/voice-interactive.mjs packages/app-core/scripts/build-llama-cpp-mtp.mjs packages/app-core/scripts/aosp/deploy-pixel.mjs packages/app-core/scripts/stage-desktop-fused-lib.mjs packages/app-core/scripts/lib/duet-bridge.mjs packages/app-core/scripts/voice-duet.mjs`
- `bunx @biomejs/biome check packages/app-core/scripts/voice-interactive.mjs packages/app-core/scripts/build-llama-cpp-mtp.mjs packages/app-core/scripts/aosp/deploy-pixel.mjs packages/app-core/scripts/stage-desktop-fused-lib.mjs packages/app-core/scripts/lib/duet-bridge.mjs packages/app-core/scripts/voice-duet.mjs` (passes with the pre-existing `voice-duet.mjs` unused `modelId` warning)
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app-core lint`
- `git diff --check`
- `bun run verify` (515 tasks passed in 2m17.281s)
