### PR TITLE
docs(local-inference): align ASR guide with Gemma gating

### DIFF
--- a/plugins/plugin-local-inference/README.md
+++ b/plugins/plugin-local-inference/README.md
@@ -5,12 +5,12 @@ Eliza-1 local inference provider for elizaOS. Serves text generation, embeddings
 ## What it does
 
 - **Text generation** (`TEXT_SMALL`, `TEXT_LARGE`) via an in-process llama.cpp FFI binding. There are two text runtime classes, picked per model by the dispatcher (`services/backend.ts`):
-  - **fused Eliza-1 bundles** (`runtimeClass: "fused-eliza1"`) run through the fused `libelizainference` (`desktop-fused-ffi-backend-runtime.ts`) — the full local pipeline: same-file MTP speculative decoding, fork KV kernels (TurboQuant/QJL/PolarQuant), native tokenization over the resident Qwen3.5 vocab, and fused voice/vision. This is the default/recommended path.
+  - **fused Eliza-1 bundles** (`runtimeClass: "fused-eliza1"`) run through the fused `libelizainference` (`desktop-fused-ffi-backend-runtime.ts`) — the full local pipeline: manifest-gated MTP speculative decoding, fork kernels where applicable, native tokenization over the active Eliza-1 bundle tokenizer, and fused voice/vision/ASR. This is the default/recommended path.
   - **generic single-file GGUF** (`runtimeClass: "generic-gguf"`) — a model you downloaded/scanned (Hugging Face / ModelScope / LM Studio / Ollama) loaded from an explicit `modelPath` with stock f16 KV and *reduced optimizations* (no MTP, no fork kernels, no fused voice/vision). The explicit-`modelPath` binding ships on mobile (`llama-cpp-capacitor`); on desktop it is not yet built into the shipping `libelizainference`, so an assigned generic model is rejected at the assignment boundary with a typed reason rather than failing silently at load.
 - `node-llama-cpp` has been retired; there is no node-llama-cpp fallback.
 - **Text embeddings** (`TEXT_EMBEDDING`) via a dedicated embedding GGUF loaded separately from the chat model.
-- **Text-to-speech** (`TEXT_TO_SPEECH`) via the Kokoro TTS engine (ONNX-based, runs locally).
-- **Automatic speech recognition** (`TRANSCRIPTION`) via whisper.cpp (GGML-based).
+- **Text-to-speech** (`TEXT_TO_SPEECH`) via the local Kokoro/OmniVoice runtime selected by tier and policy.
+- **Automatic speech recognition** (`TRANSCRIPTION`) via the eligible bundled local ASR head in fused `libelizainference`; there is no whisper.cpp fallback.
 - **Image generation** (`IMAGE`) via sd.cpp, CoreML (Apple Silicon), mflux, TensorRT, or AOSP backends; selected by hardware and catalog entry.
 - **Image description / vision** (`IMAGE_DESCRIPTION`) via the Qwen3-VL multimodal projector attached to the active text model.
 - **Model catalog, download management, and hardware-fit recommendation** exposed as HTTP routes for the elizaOS dashboard.
@@ -23,8 +23,8 @@ Eliza-1 local inference provider for elizaOS. Serves text generation, embeddings
 | `GENERATE_MEDIA` action | Agent responds to "draw me a ...", "say ...", "speak ...", etc. by calling the local image or TTS backend. |
 | `TEXT_SMALL` / `TEXT_LARGE` handler | Agent uses the active Eliza-1 text model for all reasoning and response generation. |
 | `TEXT_EMBEDDING` handler | Agent embeds memories using the local embedding GGUF; avoids cloud API calls for RAG. |
-| `TEXT_TO_SPEECH` handler | Agent converts text to audio using Kokoro (or another registered TTS backend). |
-| `TRANSCRIPTION` handler | Agent transcribes audio using whisper.cpp. |
+| `TEXT_TO_SPEECH` handler | Agent converts text to audio using the selected local TTS backend. |
+| `TRANSCRIPTION` handler | Agent transcribes audio using the eligible bundled local ASR runtime. |
 | `IMAGE` handler | Agent generates images using the active local diffusion backend. |
 | `IMAGE_DESCRIPTION` handler | Agent describes images using the active multimodal model. |
 
@@ -32,7 +32,7 @@ Eliza-1 local inference provider for elizaOS. Serves text generation, embeddings
 
 - Node.js 20+ or Bun runtime.
 - The fused `libelizainference` native library for the desktop text/voice/vision path (built from `tools/omnivoice`; resolved via `ELIZA_INFERENCE_LIBRARY` / `ELIZA_INFERENCE_LIB_DIR` or the bundle's `lib/` dir). Generic single-file GGUF additionally needs the explicit-`modelPath` binding (`llama-cpp-capacitor` on mobile).
-- Native binaries for optional capabilities: `sd.cpp` for image-gen on Linux/Windows, `mflux` for Apple Silicon image-gen, `whisper.cpp` built with the shared library flag for ASR.
+- Native binaries for optional capabilities: `sd.cpp` for image-gen on Linux/Windows and `mflux` for Apple Silicon image-gen.
 - An Eliza-1 GGUF bundle downloaded via the model catalog (dashboard → Models, or `POST /api/local-inference/downloads`).
 
 ## Enabling the plugin
@@ -68,7 +68,6 @@ Key environment variables (all optional unless noted):
 | `SD_CPP_BIN` | Absolute path to sd.cpp binary |
 | `MFLUX_BIN` | Absolute path to mflux binary |
 | `ELIZA_KOKORO_DEFAULT_VOICE_ID` | Default Kokoro TTS voice |
-| `ELIZA_WHISPER_USE_GPU` | Enable GPU for Whisper ASR |
 
 ## Architecture notes
 

--- a/plugins/plugin-local-inference/docs/memory-and-e2e-latency-review.md
+++ b/plugins/plugin-local-inference/docs/memory-and-e2e-latency-review.md
@@ -31,7 +31,7 @@ Approx wall-clock for first audio (2B entry tier, from harness defaults + code):
 | Stage | Span | Typical | Blocking? |
 |---|---|---|---|
 | VAD endpoint | mic → asr start | ~32 ms hop | gates ASR |
-| **ASR** | `pipeline.ts:317-480` feed+flush | 100 ms (whisper) / ~300 ms (Qwen3-ASR) | **fully blocks** drafter |
+| **ASR** | `pipeline.ts:317-480` feed+flush | ~300 ms fused local ASR budget | **fully blocks** drafter |
 | drafter round-1 | `pipeline.ts:350-358` | ~50–100 ms | awaited |
 | verifier | `pipeline.ts:386` | ~50–100 ms | overlapped w/ next draft |
 | phrase boundary | `phrase-chunker.ts:39-46` | 0–**700 ms** (time-budget flush) | **gates first TTS** |

--- a/plugins/plugin-local-inference/docs/per-platform-backend-strategy.md
+++ b/plugins/plugin-local-inference/docs/per-platform-backend-strategy.md
@@ -63,7 +63,7 @@ profile, and it's verified:
 | Model | Cadence | Backend | Right call |
 |---|---|---|---|
 | LLM (Gemma) decode | per-token, dynamic KV | **Metal** | ANE can't do dynamic decode |
-| Vision mmproj / Qwen3-ASR | bursty | **Metal** | GPU-sized bursty work |
+| Vision mmproj / local ASR | bursty | **Metal** | GPU-sized bursty work |
 | Kokoro TTS | per-utterance | **CoreML** (`kokoro_5s.mlmodelc`) | larger fixed-graph → ANE helps |
 | **Silero VAD** | always-on | **native CPU** | tiny LSTM → CPU fastest+lowest-power (measured; ANE 3.5× slower) |
 | **openWakeWord** | always-on | **native CPU** | same |

--- a/plugins/plugin-local-inference/native/AGENTS.md
+++ b/plugins/plugin-local-inference/native/AGENTS.md
@@ -131,14 +131,18 @@ Backbones (do not change without explicit human approval):
   (`kokoro|omnivoice|auto`), voice-cloning requirements, and measured
   RTF / TTFB.
 
-- **ASR:** Qwen3-ASR via the fused FFI on every tier. Source artifacts:
-  `ggml-org/Qwen3-ASR-0.6B-GGUF` for lite/mobile/desktop tiers,
-  `ggml-org/Qwen3-ASR-1.7B-GGUF` for pro/server. Bundled as
-  `asr/eliza-1-asr.gguf` + `asr/eliza-1-asr-mmproj.gguf` (mmproj
-  sidecar is REQUIRED — Qwen3-ASR is a multimodal audio-in / text-out
-  model). Activated through `libelizainference`'s
-  `eliza_pick_asr_files()`. OmniVoice has no ASR head — do not route
-  ASR through it. The standalone `plugin-omnivoice`'s
+- **ASR:** Local ASR is fused-FFI only and artifact-gated. A
+  default-eligible Gemma 4 release must record real Gemma ASR lineage
+  in the manifest and must not ship Qwen ASR provenance; the runtime and
+  manifest validator reject strict/defaultEligible Qwen ASR stand-ins.
+  Bundled files remain `asr/eliza-1-asr.gguf` +
+  `asr/eliza-1-asr-mmproj.gguf` (mmproj sidecar is REQUIRED for the
+  audio-in / text-out path). Activated through `libelizainference`'s
+  `eliza_pick_asr_files()`. The public Qwen3-ASR artifacts and the
+  `qwen3a` mtmd backport are compatibility/scaffolding only until
+  verified Gemma ASR artifacts are staged; do not expose them as
+  default/recommended. OmniVoice has no ASR head — do not route ASR
+  through it. The standalone `plugin-omnivoice`'s
   `ModelType.TRANSCRIPTION` handler throws
   `OmnivoiceTranscriptionNotSupported` to make that explicit.
 
@@ -249,8 +253,8 @@ elizaos/eliza-1/
       omnivoice-base-<quant>.gguf
       omnivoice-tokenizer-<quant>.gguf
     asr/
-      eliza-1-asr.gguf             # Qwen3-ASR text head, every tier
-      eliza-1-asr-mmproj.gguf      # mmproj audio projector sidecar, every tier
+      eliza-1-asr.gguf             # eligible local ASR text head
+      eliza-1-asr-mmproj.gguf      # local ASR audio projector sidecar
     vad/
       silero-vad-v5.gguf           # native silero-vad-cpp, every tier
     vision/
@@ -721,7 +725,7 @@ deprecated and will be removed from the runtime path once all native ports land.
 | OmniVoice TTS | fork FFI `libelizainference` (`tools/omnivoice/`) | DONE (W3-3) |
 | Silero VAD | standalone `silero-vad-cpp` FFI `libsilero_vad` + `vad/silero-vad-v5.gguf` | DONE (I1/K7 verified) — vad.ts imports zero onnxruntime-node |
 | hey-eliza wakeword | fork FFI `eliza_inference_wakeword_*` | DONE (I1/K7 verified) — wake-word.ts imports zero onnxruntime-node |
-| ASR (Qwen3-ASR) | fork FFI `eliza_pick_asr_files()` | DONE (T-asr) |
+| ASR (eligible local ASR) | fork FFI `eliza_pick_asr_files()` | DONE (runtime) / GATED (Gemma artifacts) |
 | MTP speculative decoding | fork `llama-server` `--spec-type mtp` | DONE |
 | Text EOT (Eliza1EotClassifier) | fork `node-llama-cpp` P(`<|im_end|>`) | DONE (preferred path when text model loaded) |
 | LiveKit EOT (GGUF) | `eot-classifier-ggml.ts::LiveKitGgmlTurnDetector` | DONE (J1.d) — preferred over ONNX when GGUF on disk |

--- a/plugins/plugin-local-inference/native/CLAUDE.md
+++ b/plugins/plugin-local-inference/native/CLAUDE.md
@@ -131,14 +131,18 @@ Backbones (do not change without explicit human approval):
   (`kokoro|omnivoice|auto`), voice-cloning requirements, and measured
   RTF / TTFB.
 
-- **ASR:** Qwen3-ASR via the fused FFI on every tier. Source artifacts:
-  `ggml-org/Qwen3-ASR-0.6B-GGUF` for lite/mobile/desktop tiers,
-  `ggml-org/Qwen3-ASR-1.7B-GGUF` for pro/server. Bundled as
-  `asr/eliza-1-asr.gguf` + `asr/eliza-1-asr-mmproj.gguf` (mmproj
-  sidecar is REQUIRED — Qwen3-ASR is a multimodal audio-in / text-out
-  model). Activated through `libelizainference`'s
-  `eliza_pick_asr_files()`. OmniVoice has no ASR head — do not route
-  ASR through it. The standalone `plugin-omnivoice`'s
+- **ASR:** Local ASR is fused-FFI only and artifact-gated. A
+  default-eligible Gemma 4 release must record real Gemma ASR lineage
+  in the manifest and must not ship Qwen ASR provenance; the runtime and
+  manifest validator reject strict/defaultEligible Qwen ASR stand-ins.
+  Bundled files remain `asr/eliza-1-asr.gguf` +
+  `asr/eliza-1-asr-mmproj.gguf` (mmproj sidecar is REQUIRED for the
+  audio-in / text-out path). Activated through `libelizainference`'s
+  `eliza_pick_asr_files()`. The public Qwen3-ASR artifacts and the
+  `qwen3a` mtmd backport are compatibility/scaffolding only until
+  verified Gemma ASR artifacts are staged; do not expose them as
+  default/recommended. OmniVoice has no ASR head — do not route ASR
+  through it. The standalone `plugin-omnivoice`'s
   `ModelType.TRANSCRIPTION` handler throws
   `OmnivoiceTranscriptionNotSupported` to make that explicit.
 
@@ -249,8 +253,8 @@ elizaos/eliza-1/
       omnivoice-base-<quant>.gguf
       omnivoice-tokenizer-<quant>.gguf
     asr/
-      eliza-1-asr.gguf             # Qwen3-ASR text head, every tier
-      eliza-1-asr-mmproj.gguf      # mmproj audio projector sidecar, every tier
+      eliza-1-asr.gguf             # eligible local ASR text head
+      eliza-1-asr-mmproj.gguf      # local ASR audio projector sidecar
     vad/
       silero-vad-v5.gguf           # native silero-vad-cpp, every tier
     vision/
@@ -721,7 +725,7 @@ deprecated and will be removed from the runtime path once all native ports land.
 | OmniVoice TTS | fork FFI `libelizainference` (`tools/omnivoice/`) | DONE (W3-3) |
 | Silero VAD | standalone `silero-vad-cpp` FFI `libsilero_vad` + `vad/silero-vad-v5.gguf` | DONE (I1/K7 verified) — vad.ts imports zero onnxruntime-node |
 | hey-eliza wakeword | fork FFI `eliza_inference_wakeword_*` | DONE (I1/K7 verified) — wake-word.ts imports zero onnxruntime-node |
-| ASR (Qwen3-ASR) | fork FFI `eliza_pick_asr_files()` | DONE (T-asr) |
+| ASR (eligible local ASR) | fork FFI `eliza_pick_asr_files()` | DONE (runtime) / GATED (Gemma artifacts) |
 | MTP speculative decoding | fork `llama-server` `--spec-type mtp` | DONE |
 | Text EOT (Eliza1EotClassifier) | fork `node-llama-cpp` P(`<|im_end|>`) | DONE (preferred path when text model loaded) |
 | LiveKit EOT (GGUF) | `eot-classifier-ggml.ts::LiveKitGgmlTurnDetector` | DONE (J1.d) — preferred over ONNX when GGUF on disk |

--- a/plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts
+++ b/plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts
@@ -205,7 +205,7 @@ try {
 	// desktop CPU even when the audio is perfect). The non-empty/sample-rate
 	// checks above pass even on noise/garbage (the exact gap that let a loader
 	// regression ship inaudible audio). When an ASR bundle is staged, transcribe
-	// the synthesized speech with the fused Qwen3-ASR and gate on WER against the
+	// the synthesized speech with eligible fused local ASR and gate on WER against the
 	// input text, so "it produced audio" can't masquerade as "it produced
 	// speech". Without the bundle the gate is skipped with a loud warning (audio
 	// remains UNVERIFIED), preserving the lighter dev lane.

--- a/plugins/plugin-local-inference/src/services/voice/expressive-tags.asr.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/expressive-tags.asr.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the ASR-emotion → expressive-tag helpers (#9147 voice).
  *
  * normalizeAsrEmotionLabel / asrEmotionToTag / expressiveTagPromptClause are
- * pure mappers between the Qwen3 ASR emotion labels and the TTS expressive-tag
+ * pure mappers between local ASR emotion labels and the TTS expressive-tag
  * vocabulary; they were untested (the parse/strip helpers in the same file are
  * covered separately). No GGUF / audio.
  */


### PR DESCRIPTION
Refs #9588

## Summary
- Updates the local-inference README and native CLAUDE/AGENTS guide so ASR is described as an eligible, fused local ASR path gated on real Gemma ASR artifacts instead of an always-active Qwen3-ASR path.
- Removes stale README references to Whisper ASR fallback and Qwen3.5 tokenizer defaults in the fused Eliza-1 bundle path.
- Refreshes adjacent planning/test comments to say local ASR while leaving explicit Qwen ASR provenance rejection tests and the low-level `qwen3a` compatibility/backport implementation untouched.

## Verification
- `git fetch origin develop --prune`
- `git rebase origin/develop`
- `bun install`
- `bunx @biomejs/biome check plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts plugins/plugin-local-inference/src/services/voice/expressive-tags.asr.test.ts`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bun run --cwd plugins/plugin-local-inference test src/services/voice/expressive-tags.asr.test.ts` (1 file / 8 tests passed)
- `git diff --check`
- `bun run verify` (515 tasks passed in 1m59.573s)
