### PR TITLE
feat(core): add buildAccessContext to resolve a requester's access context

### DIFF
--- a/packages/core/src/access-context.test.ts
+++ b/packages/core/src/access-context.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildAccessContext } from "./access-context";
+import type { IAgentRuntime, Memory, UUID } from "./types";
+
+/**
+ * buildAccessContext resolves the requester's identity, world, and role from a
+ * message by running the real checkSenderRole against the world's role config.
+ * Outside a world (no resolvable worldId) role/owner are undefined — callers
+ * must read that as "no elevated access", never "unrestricted".
+ */
+
+const AGENT = "00000000-0000-0000-0000-0000000000a9" as UUID;
+const USER = "00000000-0000-0000-0000-0000000000u5" as UUID;
+const WORLD = "00000000-0000-0000-0000-00000000w012" as UUID;
+const ROOM = "00000000-0000-0000-0000-00000000r001" as UUID;
+
+function runtimeWithRoles(
+	roles: Record<string, string>,
+	roomWorldId: UUID | undefined,
+): IAgentRuntime {
+	return {
+		agentId: AGENT,
+		getRoom: async (roomId: UUID) => ({ id: roomId, worldId: roomWorldId }),
+		getWorld: async (id: UUID) => ({
+			id,
+			agentId: AGENT,
+			serverId: "server-1",
+			metadata: { roles },
+		}),
+		getSetting: () => undefined,
+		getCache: async () => undefined,
+		getComponents: async () => [],
+		getEntityById: async () => null,
+	} as unknown as IAgentRuntime;
+}
+
+const message = (source?: string): Memory =>
+	({
+		entityId: USER,
+		roomId: ROOM,
+		content: source ? { text: "hi", source } : { text: "hi" },
+	}) as Memory;
+
+describe("buildAccessContext", () => {
+	it("resolves an OWNER requester with world + source", async () => {
+		const ctx = await buildAccessContext(
+			runtimeWithRoles({ [USER]: "OWNER" }, WORLD),
+			message("discord"),
+		);
+
+		expect(ctx.requesterEntityId).toBe(USER);
+		expect(ctx.worldId).toBe(WORLD);
+		expect(ctx.role).toBe("OWNER");
+		expect(ctx.isOwner).toBe(true);
+		expect(ctx.source).toBe("discord");
+	});
+
+	it("resolves a plain USER (not owner)", async () => {
+		const ctx = await buildAccessContext(
+			runtimeWithRoles({ [USER]: "USER" }, WORLD),
+			message(),
+		);
+
+		expect(ctx.role).toBe("USER");
+		expect(ctx.isOwner).toBe(false);
+		expect(ctx.source).toBeUndefined();
+	});
+
+	it("leaves role/owner undefined outside a world", async () => {
+		const ctx = await buildAccessContext(
+			runtimeWithRoles({ [USER]: "OWNER" }, undefined),
+			message("discord"),
+		);
+
+		expect(ctx.requesterEntityId).toBe(USER);
+		expect(ctx.worldId).toBeUndefined();
+		expect(ctx.role).toBeUndefined();
+		expect(ctx.isOwner).toBeUndefined();
+	});
+});

--- a/packages/core/src/access-context.ts
+++ b/packages/core/src/access-context.ts
@@ -1,0 +1,27 @@
+import { checkSenderRole } from "./roles";
+import type { AccessContext, IAgentRuntime, Memory } from "./types";
+
+/**
+ * Build the {@link AccessContext} for a message-driven read: who is asking, in
+ * which world, and with what role. `role`/`isOwner` come from the world's role
+ * config via {@link checkSenderRole} and are left undefined outside a world
+ * (DMs, or worlds with no role metadata), which callers must treat as "no
+ * elevated access" rather than "unrestricted".
+ */
+export async function buildAccessContext(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<AccessContext> {
+	const [roleResult, room] = await Promise.all([
+		checkSenderRole(runtime, message),
+		runtime.getRoom(message.roomId),
+	]);
+	const source = message.content?.source;
+	return {
+		requesterEntityId: message.entityId,
+		worldId: room?.worldId,
+		role: roleResult?.role,
+		isOwner: roleResult?.isOwner,
+		source: typeof source === "string" ? source : undefined,
+	};
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -6,6 +6,7 @@
  * Streaming context manager is auto-detected at runtime.
  */
 
+export * from "./access-context";
 export * from "./actions";
 export * from "./activity-plaintext";
 export * from "./api/http-helpers";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -8,6 +8,7 @@
  * in code that would fail at runtime.
  */
 
+export * from "./access-context";
 export * from "./actions";
 export * from "./activity-plaintext";
 export * from "./capabilities";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -6,6 +6,7 @@
  * Streaming context manager is auto-detected at runtime.
  */
 
+export * from "./access-context";
 export * from "./actions";
 export * from "./activity-plaintext";
 export * from "./api/http-helpers";


### PR DESCRIPTION
## What

Adds `buildAccessContext(runtime, message)` — resolves who is asking (entity), in which world, and with what role — and exports it from all three core entries.

## Why

Second step toward permission-aware retrieval, building on the merged no-op seam (#9414). Enforcement needs the requester's context at the read site; this lands the resolver. `role`/`isOwner` come from the world's role config via the real `checkSenderRole`, and are left **undefined outside a world** (DMs, or worlds with no role metadata) — callers must read that as "no elevated access", never "unrestricted".

## No caller yet — on purpose

The providers get wired onto this **together with enforcement** in the next PR. Wiring it now, while the `accessContext` field is still ignored, would pay role resolution (room + world lookups) on the hot read path for zero benefit. So this PR is just the resolver + its tests.

## Tests

Sociable test against the real `checkSenderRole`: resolves an OWNER (with world + connector source), a plain USER (not owner), and leaves role/owner undefined outside a world.

typecheck: `core` ✓ · tests 3/3 ✓