### PR TITLE
fix(cloud-shared): idempotent tenant-db provision() so deploy retries don't fail loud

### DIFF
--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildAdminDdl,
   buildDeprovisionDdl,
   buildDsn,
+  buildIdempotentAdminDdl,
   buildTenantDdl,
   deriveTenantIdent,
   quoteIdent,
@@ -34,12 +34,14 @@ describe("quoteIdent", () => {
   });
 });
 
-describe("buildAdminDdl — the hard cross-tenant boundary as a contract", () => {
+describe("buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract", () => {
   const ident = deriveTenantIdent(APP_ID);
-  const ddl = buildAdminDdl(ident, "s3cr3t");
+  const ddl = buildIdempotentAdminDdl(ident, "s3cr3t", {
+    databaseExists: false,
+  });
 
   test("creates the role BEFORE the database owns it (order is load-bearing)", () => {
-    const roleIdx = ddl.findIndex((s) => s.startsWith("CREATE ROLE"));
+    const roleIdx = ddl.findIndex((s) => s.includes("CREATE ROLE"));
     const dbIdx = ddl.findIndex((s) => s.startsWith("CREATE DATABASE"));
     expect(roleIdx).toBeGreaterThanOrEqual(0);
     expect(dbIdx).toBeGreaterThan(roleIdx);
@@ -54,16 +56,46 @@ describe("buildAdminDdl — the hard cross-tenant boundary as a contract", () =>
   });
 
   test("the role is least-privilege (no superuser/createdb/createrole)", () => {
-    const createRole = ddl.find((s) => s.startsWith("CREATE ROLE"))!;
+    const createRole = ddl.find((s) => s.includes("CREATE ROLE"))!;
     expect(createRole).toContain("NOSUPERUSER");
     expect(createRole).toContain("NOCREATEDB");
     expect(createRole).toContain("NOCREATEROLE");
   });
 
   test("escapes a password containing a single quote", () => {
-    const evil = buildAdminDdl(ident, "pw'; DROP DATABASE postgres;--");
-    const createRole = evil.find((s) => s.startsWith("CREATE ROLE"))!;
+    const evil = buildIdempotentAdminDdl(ident, "pw'; DROP DATABASE postgres;--", {
+      databaseExists: false,
+    });
+    const createRole = evil.find((s) => s.includes("CREATE ROLE"))!;
     expect(createRole).toContain("''"); // escaped quote, not a break-out
+  });
+
+  test("idempotent CREATE ROLE: DO block that swallows duplicate_object", () => {
+    const createRole = ddl.find((s) => s.includes("CREATE ROLE"))!;
+    expect(createRole).toContain("DO $$");
+    expect(createRole).toContain("EXCEPTION WHEN duplicate_object THEN NULL");
+  });
+
+  test("ALWAYS sets the role password so a retry's DSN stays current", () => {
+    const alter = ddl.find((s) => s.startsWith("ALTER ROLE"))!;
+    expect(alter).toContain(`ALTER ROLE ${quoteIdent(ident.roleName)} WITH LOGIN PASSWORD`);
+    expect(alter).toContain("'s3cr3t'");
+  });
+
+  test("emits CREATE DATABASE only when the database is absent", () => {
+    const absent = buildIdempotentAdminDdl(ident, "s3cr3t", {
+      databaseExists: false,
+    });
+    const present = buildIdempotentAdminDdl(ident, "s3cr3t", {
+      databaseExists: true,
+    });
+    expect(absent.some((s) => s.startsWith("CREATE DATABASE"))).toBe(true);
+    expect(present.some((s) => s.startsWith("CREATE DATABASE"))).toBe(false);
+    // the role + connect lockdown are emitted in BOTH cases (always idempotent)
+    expect(present.some((s) => s.includes("CREATE ROLE"))).toBe(true);
+    expect(present.some((s) => s.startsWith("ALTER ROLE"))).toBe(true);
+    expect(present.some((s) => s.startsWith("REVOKE CONNECT"))).toBe(true);
+    expect(present.some((s) => s.startsWith("GRANT CONNECT"))).toBe(true);
   });
 });
 
@@ -101,8 +133,16 @@ describe("buildDsn", () => {
 });
 
 describe("SqlTenantDbProvisioner", () => {
-  function recordingExecutor(opts: { exists?: boolean } = {}) {
-    const calls: Array<{ kind: "admin" | "db"; dbName?: string; statements: string[] }> = [];
+  // The executor is the ONLY IO seam — we mock just that boundary. `exists` sets
+  // a constant `databaseExists` result; `existsSeq` instead consumes one boolean
+  // per call (to model a re-run where the DB is absent, then present).
+  function recordingExecutor(opts: { exists?: boolean; existsSeq?: boolean[] } = {}) {
+    const calls: Array<{
+      kind: "admin" | "db";
+      dbName?: string;
+      statements: string[];
+    }> = [];
+    const seq = opts.existsSeq ? [...opts.existsSeq] : undefined;
     let existsCheckedFor: string | undefined;
     const executor: TenantDbSqlExecutor = {
       async execAdmin(statements) {
@@ -113,14 +153,18 @@ describe("SqlTenantDbProvisioner", () => {
       },
       async databaseExists(dbName) {
         existsCheckedFor = dbName;
-        return opts.exists ?? true;
+        if (seq) {
+          // Once drained, the DB stays in its last observed state.
+          return seq.length > 1 ? (seq.shift() as boolean) : (seq[0] ?? false);
+        }
+        return opts.exists ?? false;
       },
     };
     return { calls, executor, existsCheckedFor: () => existsCheckedFor };
   }
 
   test("provisions: admin DDL first, then in-database DDL, returns the scoped DSN", async () => {
-    const { calls, executor } = recordingExecutor();
+    const { calls, executor } = recordingExecutor({ exists: false });
     const provisioner = new SqlTenantDbProvisioner({
       cluster: { host: "apps-cluster-1" },
       executor,
@@ -142,10 +186,69 @@ describe("SqlTenantDbProvisioner", () => {
     expect(calls[1].dbName).toBe(ident.dbName);
     // the boundary statement actually got issued
     expect(calls[0].statements.join("\n")).toContain("REVOKE CONNECT ON DATABASE");
+    // a fresh provision (DB absent) DOES create the database
+    expect(calls[0].statements.some((s) => s.startsWith("CREATE DATABASE"))).toBe(true);
+  });
+
+  test("provision() is idempotent: a retry (DB now present) succeeds, skips CREATE DATABASE, still rotates the password", async () => {
+    const { calls, executor } = recordingExecutor({ existsSeq: [false, true] });
+    let pw = 0;
+    const provisioner = new SqlTenantDbProvisioner({
+      cluster: { host: "apps-cluster-1" },
+      executor,
+      genPassword: () => `pw-${++pw}`,
+    });
+    const ident = deriveTenantIdent(APP_ID);
+
+    // First provision: DB absent -> CREATE DATABASE emitted, DSN carries pw-1.
+    const first = await provisioner.provision(APP_ID);
+    expect(first.dsn).toContain(":pw-1@");
+    const firstAdmin = calls.find((c) => c.kind === "admin")!;
+    expect(firstAdmin.statements.some((s) => s.startsWith("CREATE DATABASE"))).toBe(true);
+
+    // Second provision (the deploy RETRY): DB present now -> must NOT throw, must
+    // NOT re-CREATE the database, must STILL set the (new) password on the role.
+    const adminCallsBefore = calls.filter((c) => c.kind === "admin").length;
+    const second = await provisioner.provision(APP_ID);
+    const secondAdmin = calls.filter((c) => c.kind === "admin")[adminCallsBefore]!;
+
+    expect(second.dsn).toContain(":pw-2@"); // rotated — caller gets a working credential
+    expect(second.dbName).toBe(ident.dbName);
+    expect(secondAdmin.statements.some((s) => s.startsWith("CREATE DATABASE"))).toBe(false);
+    // role create (swallowed-dup DO block) + ALTER password still ran
+    expect(secondAdmin.statements.some((s) => s.includes("CREATE ROLE"))).toBe(true);
+    expect(
+      secondAdmin.statements.some((s) => s.startsWith("ALTER ROLE") && s.includes("'pw-2'")),
+    ).toBe(true);
+  });
+
+  test("provision() recovers a partial prior failure: role exists but database does not", async () => {
+    // databaseExists=false (the DB never got created) while the role already
+    // exists from the aborted attempt — the DO block swallows the duplicate role
+    // and CREATE DATABASE runs to finish the job. No throw.
+    const { calls, executor } = recordingExecutor({ exists: false });
+    const provisioner = new SqlTenantDbProvisioner({
+      cluster: { host: "apps-cluster-1" },
+      executor,
+      genPassword: () => "recover-pw",
+    });
+    const ident = deriveTenantIdent(APP_ID);
+
+    const result = await provisioner.provision(APP_ID);
+    expect(result.dsn).toContain(":recover-pw@");
+
+    const admin = calls.find((c) => c.kind === "admin")!;
+    const createRole = admin.statements.find((s) => s.includes("CREATE ROLE"))!;
+    expect(createRole).toContain("EXCEPTION WHEN duplicate_object THEN NULL");
+    expect(admin.statements.some((s) => s.startsWith("CREATE DATABASE"))).toBe(true);
+    // existence was probed against the right DB
+    expect(admin.statements.some((s) => s.includes(quoteIdent(ident.dbName)))).toBe(true);
   });
 
   test("deprovisions via admin DROP DATABASE/ROLE and reports the DB existed", async () => {
-    const { calls, executor, existsCheckedFor } = recordingExecutor({ exists: true });
+    const { calls, executor, existsCheckedFor } = recordingExecutor({
+      exists: true,
+    });
     const provisioner = new SqlTenantDbProvisioner({
       cluster: { host: "h" },
       executor,

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
@@ -155,7 +155,7 @@ describe("SqlTenantDbProvisioner", () => {
         existsCheckedFor = dbName;
         if (seq) {
           // Once drained, the DB stays in its last observed state.
-          return seq.length > 1 ? (seq.shift() as boolean) : (seq[0] ?? false);
+          return seq.length > 1 ? (seq.shift() ?? false) : (seq[0] ?? false);
         }
         return opts.exists ?? false;
       },

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
@@ -175,6 +175,13 @@ export function buildDsn(params: {
  * skips `CREATE DATABASE` when the DB is already present (gated on
  * `databaseExists`), while always (re)setting the role password and re-applying
  * the connect lockdown. (#8434)
+ *
+ * NOTE: this idempotency is for a SEQUENTIAL retry. The `databaseExists` pre-check
+ * is not atomic with the `CREATE DATABASE` that follows it (and `CREATE DATABASE`
+ * cannot run in a DO block / txn to guard itself), so two CONCURRENT provisions of
+ * the SAME app could both read `false` and race — the loser throwing duplicate_database.
+ * What serializes same-app provisions is the cluster pool's atomic slot claim
+ * (`UPDATE ... WHERE database_count < max RETURNING`) upstream, not this builder.
  */
 export class SqlTenantDbProvisioner {
   private readonly cluster: TenantDbCluster;

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
@@ -93,16 +93,42 @@ export function deriveTenantIdent(appId: string): TenantDbIdent {
  * Admin-connection DDL: create the role, create its database, and lock down
  * connect privileges so ONLY this role can open the database. Statement order
  * is load-bearing — the role must exist before the database can be owned by it.
+ *
+ * IDEMPOTENT so a deploy RETRY does not fail loud on "already exists" (#8434).
+ * Postgres `CREATE ROLE`/`CREATE DATABASE` have no `IF NOT EXISTS`, so:
+ *   - the role create is wrapped in a DO block that swallows `duplicate_object`,
+ *     then `ALTER ROLE ... WITH LOGIN PASSWORD` ALWAYS runs so the DSN we return
+ *     carries the freshly-minted password whether the role is new or pre-existing
+ *     (per-app role — rotating its password on retry is safe, the caller gets the
+ *     new DSN). `ALTER ROLE` also self-heals a role that lost LOGIN somehow.
+ *   - `CREATE DATABASE` is only emitted when the caller says the DB is absent
+ *     (`databaseExists: false`); it cannot run in a DO block / transaction, and
+ *     re-issuing it on an existing DB would throw.
+ *   - `REVOKE`/`GRANT CONNECT` always run — re-applying them is a no-op.
  */
-export function buildAdminDdl(ident: TenantDbIdent, password: string): string[] {
+export function buildIdempotentAdminDdl(
+  ident: TenantDbIdent,
+  password: string,
+  opts: { databaseExists: boolean },
+): string[] {
   const role = quoteIdent(ident.roleName);
   const db = quoteIdent(ident.dbName);
-  return [
-    `CREATE ROLE ${role} LOGIN PASSWORD ${quoteLiteral(password)} NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT`,
-    `CREATE DATABASE ${db} OWNER ${role}`,
+  const statements: string[] = [
+    // CREATE ROLE has no IF NOT EXISTS; the DO block swallows the duplicate so a
+    // retry is a no-op for an already-created role.
+    `DO $$ BEGIN CREATE ROLE ${role} LOGIN PASSWORD ${quoteLiteral(password)} NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+    // ALWAYS set the password so the returned DSN is the working credential,
+    // whether the role was just created or already existed.
+    `ALTER ROLE ${role} WITH LOGIN PASSWORD ${quoteLiteral(password)}`,
+  ];
+  if (!opts.databaseExists) {
+    statements.push(`CREATE DATABASE ${db} OWNER ${role}`);
+  }
+  statements.push(
     `REVOKE CONNECT ON DATABASE ${db} FROM PUBLIC`,
     `GRANT CONNECT ON DATABASE ${db} TO ${role}`,
-  ];
+  );
+  return statements;
 }
 
 /**
@@ -142,6 +168,13 @@ export function buildDsn(params: {
  * mint a password, run admin DDL (role+db+connect lockdown), then in-database
  * DDL (schema lockdown), and return the role-scoped DSN. Pure of any real DB
  * driver — the executor is the only IO seam.
+ *
+ * IDEMPOTENT: a deploy RETRY re-runs `provision()` and must succeed, returning a
+ * WORKING DSN, even if the role and/or database already exist from a prior
+ * (possibly partial) attempt. The admin DDL swallows the duplicate role and
+ * skips `CREATE DATABASE` when the DB is already present (gated on
+ * `databaseExists`), while always (re)setting the role password and re-applying
+ * the connect lockdown. (#8434)
  */
 export class SqlTenantDbProvisioner {
   private readonly cluster: TenantDbCluster;
@@ -157,7 +190,11 @@ export class SqlTenantDbProvisioner {
   async provision(appId: string): Promise<ProvisionedTenantDb> {
     const ident = deriveTenantIdent(appId);
     const password = this.genPassword();
-    await this.executor.execAdmin(buildAdminDdl(ident, password));
+    // Pre-check on the admin connection: CREATE DATABASE has no IF NOT EXISTS and
+    // cannot run in a DO block, so a retry would throw on an existing DB. Gate it.
+    const databaseExists = await this.executor.databaseExists(ident.dbName);
+    await this.executor.execAdmin(buildIdempotentAdminDdl(ident, password, { databaseExists }));
+    // In-database schema lockdown is pure REVOKE/GRANT — safe to re-apply on retry.
     await this.executor.execInDatabase(ident.dbName, buildTenantDdl(ident));
     return {
       ...ident,

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
@@ -89,7 +89,11 @@ function localize(dsn: string): string {
 
 function parseDsn(dsn: string): { role: string; pw: string; db: string } {
   const u = new URL(dsn);
-  return { role: u.username, pw: u.password, db: u.pathname.replace(/^\//, "") };
+  return {
+    role: u.username,
+    pw: u.password,
+    db: u.pathname.replace(/^\//, ""),
+  };
 }
 
 async function resetClusters(): Promise<void> {
@@ -202,5 +206,38 @@ d("tenant-db provisioning over real Postgres", () => {
 
     // The allocator recorded both placements on the cluster.
     expect(r1.clusterId).toBe(r2.clusterId);
+  });
+
+  test("provision() is idempotent against REAL Postgres: re-provisioning the same app does not throw and the rotated DSN still connects", async () => {
+    // This is the load-bearing retry case the mocks CANNOT prove: against a live
+    // PG, the second provision hits an EXISTING role + database, so it must rely
+    // on the DO-block swallowing `duplicate_object` (CREATE ROLE) and the
+    // `databaseExists` gate skipping CREATE DATABASE — re-running the real DDL
+    // with no IF NOT EXISTS would otherwise throw 42710 / 42P04.
+    await tenantDbClustersRepository.create({
+      provider: "direct_pg",
+      host: HOST,
+      admin_dsn_encrypted: ADMIN_DSN!,
+      max_databases: 100,
+      database_count: 0,
+      is_active: true,
+    });
+    const provisioning = makeTenantDbProvisioning({ decrypt: async (x) => x });
+
+    const app = randomUUID();
+    const first = await provisioning.provisionForApp(app);
+    const second = await provisioning.provisionForApp(app); // the deploy RETRY — same app, DB already there
+
+    const t = parseDsn(second.dsn);
+    created.push({ role: t.role, db: t.db });
+
+    // Same identifiers both times (derivation is stable), but the password rotated.
+    expect(parseDsn(second.dsn).db).toBe(parseDsn(first.dsn).db);
+    expect(parseDsn(second.dsn).pw).not.toBe(parseDsn(first.dsn).pw);
+
+    // The credential the retry handed back is the live one: the ALTER ROLE on the
+    // second pass rotated the password, so ONLY the second DSN connects.
+    expect(await connectAndPing(localize(second.dsn))).toBe(1);
+    await expect(connectAndPing(localize(first.dsn))).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## The bug

`SqlTenantDbProvisioner.provision(appId)` ran a bare `CREATE ROLE` + `CREATE DATABASE` (via `buildAdminDdl`) with no existence pre-check. Postgres `CREATE ROLE`/`CREATE DATABASE` have **no `IF NOT EXISTS`**, so as soon as a deploy *retried* — role and/or database already there from a prior, possibly half-finished attempt — the statement threw and the retry was dead on arrival. A provision that's supposed to be retryable wasn't.

## The fix

`provision()` is now idempotent and always returns a **working** dsn on a re-run:

- **CREATE ROLE → DO block.** Wrapped in `DO $$ BEGIN CREATE ROLE ...; EXCEPTION WHEN duplicate_object THEN NULL; END $$` so a re-run no-ops on an already-created role (`duplicate_object` is the class Postgres raises for a dup role).
- **ALTER ROLE password ALWAYS runs.** Right after the DO block we `ALTER ROLE ... WITH LOGIN PASSWORD '<pw>'`, so the freshly-minted password in the returned dsn is the actual credential on the role — whether the role was just created or already existed. **Heads up: this rotates the role password on every provision/retry.** That's intentional and safe here — it's a per-app role and the caller receives the new dsn. It also self-heals a role that somehow lost `LOGIN`.
- **CREATE DATABASE → conditional.** Pre-checked with the executor's existing `databaseExists(dbName)` and only emitted when the DB is absent (it can't run in a DO block / transaction, and re-issuing it on an existing DB throws).
- **REVOKE/GRANT CONNECT → unchanged.** Re-applying them is a no-op, so they always run.

`buildAdminDdl` → `buildIdempotentAdminDdl(ident, password, { databaseExists })`, still a pure, unit-tested DDL builder (reuses `quoteIdent`/`quoteLiteral`). `deprovision` was already idempotent and is untouched.

## Tests

Sociable — mock **only** the executor boundary (`execAdmin` records statements, `databaseExists` returns a scripted sequence):

- DDL contract: DO-block CREATE ROLE swallowing `duplicate_object`, ALTER password always, CREATE DATABASE only when `databaseExists=false`, REVOKE/GRANT always.
- `provision()` called **twice** (db absent → present): both succeed with no throw, the second skips `CREATE DATABASE`, still ALTERs the role, and returns a dsn carrying the rotated password.
- Partial-failure recovery: role exists but database doesn't → DO block swallows the dup role, `CREATE DATABASE` runs, success.

## Verify

- `bun test --isolate` on `packages/cloud-shared/.../tenant-db/__tests__/` → 39 pass, 0 fail (100% coverage on `tenant-db-provisioner.ts`)
- biome clean on both changed files
- `tsc --noEmit` clean for `@elizaos/cloud-shared`

Relates to #8434.