### PR TITLE
fix(training): use official Gemma MTP sources

### DIFF
--- a/packages/training/scripts/manifest/stage_eliza1_source_weights.py
+++ b/packages/training/scripts/manifest/stage_eliza1_source_weights.py
@@ -137,41 +137,64 @@ TEXT_SOURCES: Final[dict[str, SourceArtifact]] = {
 
 DRAFTER_SOURCES: Final[dict[str, SourceArtifact | None]] = {
     "0_8b": None,
-    "2b": None,
-    "4b": SourceArtifact(
+    "2b": SourceArtifact(
         kind="mtp",
-        repo="z-lab/gemma-4-E4B-MTP",
+        repo="google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
         filename="model.safetensors",
-        destination="source/mtp/gemma4-e4b-mtp.safetensors",
-        license="mit",
+        destination="source/mtp/gemma4-e2b-assistant.safetensors",
+        license="gemma",
         status="source-safetensors",
         notes=(
-            "Official upstream MTP drafter source for google/gemma-4-E4B.",
-            "Final Eliza-1 4B still needs tokenizer merge, GGUF conversion, quantization, and MTP acceptance against the Eliza-1 text checkpoint.",
+            "Official Google Gemma 4 E2B assistant source for MTP/speculative "
+            "decoding.",
+            "Final Eliza-1 2B still needs tokenizer merge, mtp-draft GGUF "
+            "conversion, quantization, and acceptance against the Eliza-1 text "
+            "checkpoint.",
+        ),
+    ),
+    "4b": SourceArtifact(
+        kind="mtp",
+        repo="google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant",
+        filename="model.safetensors",
+        destination="source/mtp/gemma4-e4b-assistant.safetensors",
+        license="gemma",
+        status="source-safetensors",
+        notes=(
+            "Official Google Gemma 4 E4B assistant source for MTP/speculative "
+            "decoding.",
+            "Final Eliza-1 4B still needs tokenizer merge, mtp-draft GGUF "
+            "conversion, quantization, and acceptance against the Eliza-1 text "
+            "checkpoint.",
         ),
     ),
     "9b": SourceArtifact(
         kind="mtp",
-        repo="z-lab/gemma-4-12B-MTP",
+        repo="google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
         filename="model.safetensors",
-        destination="source/mtp/gemma4-12b-mtp.safetensors",
-        license="mit",
+        destination="source/mtp/gemma4-12b-assistant.safetensors",
+        license="gemma",
         status="source-safetensors",
         notes=(
-            "Official upstream MTP drafter source for google/gemma-4-12B.",
-            "Final Eliza-1 9B still needs tokenizer merge, GGUF conversion, quantization, and MTP acceptance against the Eliza-1 text checkpoint.",
+            "Official Google Gemma 4 12B assistant source for MTP/speculative "
+            "decoding.",
+            "Final Eliza-1 9B still needs tokenizer merge, mtp-draft GGUF "
+            "conversion, quantization, and acceptance against the Eliza-1 text "
+            "checkpoint.",
         ),
     ),
     "27b": SourceArtifact(
         kind="mtp",
-        repo="spiritbuun/gemma-4-31B-MTP-GGUF",
-        filename="mtp-draft-3.6-q8_0.gguf",
-        destination="source/mtp/gemma4-31b-mtp-q8_0.gguf",
-        license="mit",
-        status="source-gguf",
+        repo="google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+        filename="model.safetensors",
+        destination="source/mtp/gemma4-31b-assistant.safetensors",
+        license="gemma",
+        status="source-safetensors",
         notes=(
-            "GGUF quantization of z-lab/gemma-4-31B-MTP; Q8_0 is the upstream recommended quant for the Gemma 4 drafter.",
-            "Final Eliza-1 27B still needs MTP acceptance against the Eliza-1 text checkpoint before publish.",
+            "Official Google Gemma 4 31B assistant source for MTP/speculative "
+            "decoding.",
+            "Final Eliza-1 27B still needs tokenizer merge, mtp-draft GGUF "
+            "conversion, quantization, and acceptance against the Eliza-1 text "
+            "checkpoint.",
         ),
     ),
 }
@@ -460,7 +483,11 @@ def stage_sources(args: argparse.Namespace) -> dict[str, Any]:
         )
     elif not drafter_source.filename.lower().endswith(".gguf"):
         blockers.append(
-            f"Upstream MTP source for tier {args.tier} is {drafter_source.repo}/{drafter_source.filename}, not a final GGUF; final mtp/drafter-{args.tier}.gguf still needs tokenizer merge, GGUF conversion, quantization, and acceptance."
+            f"Upstream MTP source for tier {args.tier} is "
+            f"{drafter_source.repo}/{drafter_source.filename}, not a final "
+            f"GGUF; final mtp/drafter-{args.tier}.gguf still needs tokenizer "
+            "merge, GGUF conversion, quantization, and acceptance against the "
+            "Eliza-1 text checkpoint."
         )
     else:
         blockers.append(

--- a/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
@@ -73,10 +73,20 @@ LOCAL_MODEL_ROOT: Final[Path] = (
 )
 DEFAULT_BUNDLE_DIR: Final[Path] = LOCAL_MODEL_ROOT / "eliza-1-2b.bundle"
 DEFAULT_TEXT_STANDIN_CANDIDATES: Final[tuple[Path, ...]] = (
+    LOCAL_MODEL_ROOT / "gemma4-e2b-official" / "gemma-4-E2B_q4_0-it.gguf",
+    LOCAL_MODEL_ROOT / "gemma4-e2b-official" / "gemma-4-E2B-it-Q8_0.gguf",
+    LOCAL_MODEL_ROOT / "gemma-4-E2B_q4_0-it.gguf",
+    # Legacy local cache names from the pre-official-source Gemma smoke runs.
     LOCAL_MODEL_ROOT / "gemma4-e4b-mtp" / "Qwen_gemma-4-E4B-Q4_K_M.gguf",
     LOCAL_MODEL_ROOT / "gemma4-e4b-mtp.gguf",
 )
 DEFAULT_DRAFTER_STANDIN_CANDIDATES: Final[tuple[Path, ...]] = (
+    LOCAL_MODEL_ROOT / "gemma4-e2b-assistant-mtp" / "drafter-2b.gguf",
+    LOCAL_MODEL_ROOT
+    / "gemma4-e2b-assistant-mtp"
+    / "gemma-4-E2B-mtp-draft.gguf",
+    LOCAL_MODEL_ROOT / "gemma4-e2b-assistant-mtp.gguf",
+    # Legacy local cache names from the pre-official-source Gemma smoke runs.
     LOCAL_MODEL_ROOT
     / "gemma4-e4b-mtp-drafter-q4"
     / "gemma-4-E4B-MTP-Q4_K_M.repaired.gguf",

--- a/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
+++ b/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
@@ -53,8 +53,12 @@ def test_mobile_tier_uses_gemma4_e2b_source(
     report = stage.stage_sources(_args(tmp_path, "2b"))
 
     assert "unsloth/gemma-4-E2B-GGUF" in report["sources"]
-    assert stage.DRAFTER_SOURCES["2b"] is None
-    assert any("No upstream MTP drafter" in b for b in report["blockers"])
+    assert (
+        "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
+        in report["sources"]
+    )
+    assert stage.DRAFTER_SOURCES["2b"] is not None
+    assert any("not a final GGUF" in b for b in report["blockers"])
 
 
 def test_4b_tier_records_text_mtp_and_vision_sources(
@@ -67,7 +71,10 @@ def test_4b_tier_records_text_mtp_and_vision_sources(
 
     assert [f["kind"] for f in report["files"]] == ["text", "mtp", "vision"]
     assert "unsloth/gemma-4-E4B-GGUF" in report["sources"]
-    assert "z-lab/gemma-4-E4B-MTP" in report["sources"]
+    assert (
+        "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant"
+        in report["sources"]
+    )
     assert any("not a final GGUF" in b for b in report["blockers"])
     assert all("final Eliza-1" not in f["destination"] for f in report["files"])
 
@@ -81,7 +88,10 @@ def test_stage_sources_accepts_large_active_tier(
     report = stage.stage_sources(_args(tmp_path, "27b"))
 
     assert "unsloth/gemma-4-31B-GGUF" in report["sources"]
-    assert "spiritbuun/gemma-4-31B-MTP-GGUF" in report["sources"]
+    assert (
+        "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
+        in report["sources"]
+    )
 
 
 def test_27b_class_tiers_use_gemma4_31b_source(
@@ -94,7 +104,10 @@ def test_27b_class_tiers_use_gemma4_31b_source(
     report = stage.stage_sources(_args(tmp_path, tier))
 
     assert "unsloth/gemma-4-31B-GGUF" in report["sources"]
-    assert "spiritbuun/gemma-4-31B-MTP-GGUF" in report["sources"]
+    assert (
+        "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
+        in report["sources"]
+    )
     # The 27b tier must use the 31B Gemma 4 source, never a smaller-tier base.
     assert all(
         not any(
@@ -108,17 +121,17 @@ def test_27b_class_tiers_use_gemma4_31b_source(
     assert drafter_files == [
         {
             "kind": "mtp",
-            "repo": "spiritbuun/gemma-4-31B-MTP-GGUF",
-            "filename": "mtp-draft-3.6-q8_0.gguf",
-            "destination": f"source/mtp/gemma4-31b-mtp-q8_0.gguf",
-            "license": "mit",
-            "status": "source-gguf",
+            "repo": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+            "filename": "model.safetensors",
+            "destination": f"source/mtp/gemma4-31b-assistant.safetensors",
+            "license": "gemma",
+            "status": "source-safetensors",
             "notes": tuple(stage.DRAFTER_SOURCES[tier].notes),
-            "revision": "sha-spiritbuun/gemma-4-31B-MTP-GGUF",
+            "revision": "sha-google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
             "path": str(
                 tmp_path
                 / f"eliza-1-{tier}.bundle"
-                / f"source/mtp/gemma4-31b-mtp-q8_0.gguf"
+                / f"source/mtp/gemma4-31b-assistant.safetensors"
             ),
             "dryRun": True,
         }
@@ -128,22 +141,34 @@ def test_27b_class_tiers_use_gemma4_31b_source(
 
 def test_known_mtp_sources_are_wired_without_faking_small_tiers() -> None:
     assert stage.DRAFTER_SOURCES["0_8b"] is None
-    assert stage.DRAFTER_SOURCES["2b"] is None
 
-    assert stage.DRAFTER_SOURCES["4b"].repo == "z-lab/gemma-4-E4B-MTP"
+    assert (
+        stage.DRAFTER_SOURCES["2b"].repo
+        == "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
+    )
+    assert stage.DRAFTER_SOURCES["2b"].filename == "model.safetensors"
+    assert stage.DRAFTER_SOURCES["2b"].license == "gemma"
+
+    assert (
+        stage.DRAFTER_SOURCES["4b"].repo
+        == "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant"
+    )
     assert stage.DRAFTER_SOURCES["4b"].filename == "model.safetensors"
-    assert stage.DRAFTER_SOURCES["4b"].license == "mit"
+    assert stage.DRAFTER_SOURCES["4b"].license == "gemma"
 
-    assert stage.DRAFTER_SOURCES["9b"].repo == "z-lab/gemma-4-12B-MTP"
+    assert (
+        stage.DRAFTER_SOURCES["9b"].repo
+        == "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant"
+    )
     assert stage.DRAFTER_SOURCES["9b"].filename == "model.safetensors"
-    assert stage.DRAFTER_SOURCES["9b"].license == "mit"
+    assert stage.DRAFTER_SOURCES["9b"].license == "gemma"
 
     for tier in ("27b",):
         artifact = stage.DRAFTER_SOURCES[tier]
         assert artifact is not None
-        assert artifact.repo == "spiritbuun/gemma-4-31B-MTP-GGUF"
-        assert artifact.filename == "mtp-draft-3.6-q8_0.gguf"
-        assert artifact.status == "source-gguf"
+        assert artifact.repo == "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
+        assert artifact.filename == "model.safetensors"
+        assert artifact.status == "source-safetensors"
 
 
 def test_every_active_tier_has_vision_source() -> None:

--- a/packages/training/scripts/publish/assemble_local_gemma_bundle.py
+++ b/packages/training/scripts/publish/assemble_local_gemma_bundle.py
@@ -72,17 +72,25 @@ RAM_BUDGET_MB = {
     "27b": (32000, 48000),
     "27b-256k": (32000, 48000),
 }
-# The E2B local drafter is the E4B-extracted MTP head (tier-mismatched smoke
-# drafter). Larger tiers have real per-tier MTP sources.
+# Official Gemma 4 assistant source repos. These publish safetensors sources;
+# a runtime bundle still needs a converted `mtp-draft` GGUF plus acceptance
+# against the exact Eliza-1 text checkpoint.
 DRAFTER_SOURCE_BY_TIER = {
-    "2b": "shadowlilac/gemma-4-e4b-mtp-extraction-effort",
-    "4b": "z-lab/gemma-4-E4B-MTP",
-    "9b": "z-lab/gemma-4-12B-MTP",
-    "27b": "spiritbuun/gemma-4-31B-MTP-GGUF",
-    "27b-256k": "spiritbuun/gemma-4-31B-MTP-GGUF",
+    "2b": "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
+    "4b": "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant",
+    "9b": "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
+    "27b": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+    "27b-256k": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
 }
-# E2B stages the E4B drafter (head dim mismatch); not a checkpoint match.
-DRAFTER_MATCHES_TARGET = {"2b": False, "4b": True, "9b": True, "27b": True, "27b-256k": True}
+# Source assistant drafters are not checkpoint-matched to fine-tuned Eliza-1
+# text weights until the Eliza training pipeline records that match.
+DRAFTER_MATCHES_TARGET = {
+    "2b": False,
+    "4b": False,
+    "9b": False,
+    "27b": False,
+    "27b-256k": False,
+}
 
 MIN_TEXT_CONTEXT = 131_072
 
@@ -195,9 +203,10 @@ def assemble(args: argparse.Namespace) -> dict[str, Any]:
         )
         if not matches:
             note += (
-                f" SMOKE drafter: the E4B-extracted head ({source}) staged on "
-                "the E2B target (tier mismatch). Candidate-only; never "
-                "defaultEligible."
+                f" Candidate drafter: the upstream assistant source is {source}, "
+                "but this local GGUF has not been recorded as trained/distilled "
+                "against the exact Eliza-1 text checkpoint. Candidate-only; "
+                "never defaultEligible."
             )
         drafter_block = {
             "path": drafter_rel,
@@ -227,9 +236,9 @@ def assemble(args: argparse.Namespace) -> dict[str, Any]:
     else:
         # Leave a sentinel so the missing-drafter case is explicit, not silent.
         (out / "mtp" / "MISSING.txt").write_text(
-            "No MTP drafter staged. The only local 2b drafter "
-            "(shadowlilac/gemma-4-e4b-mtp-extraction-effort) is a .safetensors "
-            "file and needs conversion to the `mtp-draft` GGUF arch first. "
+            f"No MTP drafter staged. The official assistant source for this tier "
+            f"({DRAFTER_SOURCE_BY_TIER[tier]}) is a .safetensors file and needs "
+            "conversion to the `mtp-draft` GGUF arch first. "
             "This bundle is text+vision only and is NOT release-shaped "
             "(AGENTS.md §1 requires MTP on every tier).\n"
         )

--- a/packages/training/scripts/publish/stage_base_v1_candidate.py
+++ b/packages/training/scripts/publish/stage_base_v1_candidate.py
@@ -67,18 +67,14 @@ TEXT_CTX_BY_TIER = {
     tier: M.parse_ctx_string(ctx)
     for tier, ctx in TEXT_CONTEXT_BY_TIER.items()
 }
-# The only local 2b drafter is the Gemma-4 E4B MTP drafter extracted from
-# LiteRT (`shadowlilac/gemma-4-e4b-mtp-extraction-effort`). It shares the
-# 262144-token Gemma-4 tokenizer with the E2B text target so speculative
-# decoding is correct, but it is the E4B head (external_hidden_size 2560),
-# not an E2B-matched drafter — a tokenizer-compatible *smoke* drafter only.
-# That tier mismatch makes the bundle candidate-only (defaultEligible=False);
-# the orchestrator's `drafter.matchesTargetCheckpoint` gate is FALSE here.
+# Official Gemma 4 assistant source repos. These publish safetensors sources;
+# a runtime bundle still needs a converted `mtp-draft` GGUF plus acceptance
+# against the exact Eliza-1 text checkpoint before it can be defaultEligible.
 DRAFTER_SOURCE_BY_TIER = {
-    "2b": "shadowlilac/gemma-4-e4b-mtp-extraction-effort",
-    "4b": "z-lab/gemma-4-E4B-MTP",
-    "9b": "z-lab/gemma-4-12B-MTP",
-    "27b": "spiritbuun/gemma-4-31B-MTP-GGUF",
+    "2b": "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
+    "4b": "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant",
+    "9b": "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
+    "27b": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
 }
 
 # Frozen tier-agnostic voice/ASR/VAD/cache bytes live in the canonical model repo.
@@ -164,7 +160,16 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Upstream HF repo the drafter GGUF was converted from (provenance). "
             "Defaults to the tier's known MTP source when one exists; required "
-            "for 0_8b/2b until a license-reviewed upstream source is wired."
+            "when staging a nonstandard or locally trained drafter."
+        ),
+    )
+    ap.add_argument(
+        "--drafter-matches-target",
+        action="store_true",
+        help=(
+            "Set only when the supplied drafter was trained/distilled against "
+            "the exact text checkpoint being staged. Defaults false for "
+            "official upstream assistant sources."
         ),
     )
     ap.add_argument("--out", required=True, type=Path)
@@ -183,6 +188,11 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(
             f"--drafter-source is required for tier {tier}; no license-reviewed "
             "upstream MTP source is wired for this tier yet."
+        )
+    if args.drafter_matches_target and not args.drafter_source:
+        raise SystemExit(
+            "--drafter-matches-target requires --drafter-source naming the "
+            "matched Eliza-1 drafter run, not just the default upstream source."
         )
     out = args.out.resolve()
     text_rel = PP.text_artifact_name(tier, TEXT_CONTEXT_BY_TIER[tier])
@@ -229,29 +239,24 @@ def main(argv: list[str] | None = None) -> int:
     drafter_dest = out / "mtp" / f"drafter-{tier}.gguf"
     shutil.copy2(args.drafter_gguf, drafter_dest)
     drafter_sha = sha256_file(drafter_dest)
-    # The only local 2b drafter is the E4B-extracted MTP head, staged on the
-    # E2B text target: a tokenizer-compatible *smoke* drafter, not an
-    # E2B-matched one. Record the tier mismatch so the orchestrator's
-    # `matchesTargetCheckpoint` gate stays FALSE (candidate-only).
-    drafter_is_smoke = tier == "2b"
+    drafter_matches_target = bool(args.drafter_matches_target)
     drafter_note = (
         f"MTP drafter for the {tier} Gemma 4 text target. "
         "It must share the 262144-token Gemma 4 tokenizer with the target "
         "so speculative decoding is correct. "
     )
-    if drafter_is_smoke:
+    if drafter_matches_target:
         drafter_note += (
-            "This is the E4B-extracted MTP drafter "
-            f"({drafter_source}, external_hidden_size 2560) staged on the E2B "
-            "text target as a tokenizer-compatible SMOKE drafter — a tier "
-            "mismatch, NOT an E2B-matched release drafter. The bundle is "
-            "candidate-only (defaultEligible=false); a real release needs an "
-            "E2B-matched drafter."
+            "The caller attests this drafter was trained/distilled against "
+            "the exact text checkpoint being staged; publish gates still must "
+            "verify MTP acceptance before default eligibility."
         )
     else:
         drafter_note += (
-            "See the drafter source repo for whether this candidate is distilled "
-            "or a tokenizer-compatible smoke artifact."
+            "This is an upstream/base assistant-derived candidate or otherwise "
+            "unmatched drafter. The bundle is candidate-only "
+            "(defaultEligible=false); a real release needs an Eliza-1-matched "
+            "drafter plus acceptance evidence."
         )
     (out / "mtp" / "target-meta.json").write_text(json.dumps({
         "schemaVersion": 2,
@@ -268,7 +273,7 @@ def main(argv: list[str] | None = None) -> int:
             "path": f"mtp/drafter-{tier}.gguf",
             "sha256": drafter_sha,
             "source": drafter_source,
-            "matchesTargetCheckpoint": not drafter_is_smoke,
+            "matchesTargetCheckpoint": drafter_matches_target,
             "tokenizerVocabSize": 262144,
             "note": drafter_note,
         },
@@ -407,8 +412,11 @@ def main(argv: list[str] | None = None) -> int:
         ),
         "voice": M.LineageEntry(base=voice_source_note(tier), license="apache-2.0"),
         "drafter": M.LineageEntry(
-            base=f"{drafter_source} (upstream MTP source; used as self/cross-drafter — not distilled)",
-            license="mit",
+            base=(
+                f"{drafter_source} (upstream MTP source; used as "
+                "self/cross-drafter — not distilled)"
+            ),
+            license="gemma; verify converted derivative license before release",
         ),
         "vision": M.LineageEntry(
             base=f"{TEXT_BASE_BY_TIER[tier]} vision projector",
@@ -616,12 +624,13 @@ release bar (every supported backend kernel-verified, every eval green) is met.
 
 {text_para}
 - **Voice / ASR / VAD / cache**: frozen upstream assets —
-  {", ".join(M.VOICE_BACKENDS_BY_TIER[tier])} TTS, Qwen3-ASR, native
-  Silero-VAD v5.1.2, and the default speaker preset. Not fine-tuned.
+  {", ".join(M.VOICE_BACKENDS_BY_TIER[tier])} TTS, local ASR placeholder
+  assets, native Silero-VAD v5.1.2, and the default speaker preset. Not
+  fine-tuned.
   Licenses in `licenses/`.
 - **MTP drafter** (`mtp/drafter-{tier}.gguf`): the **upstream
   `{drafter_source}` artifact** — it must share the Gemma 4 tokenizer with the
-  text target so speculative decoding is correct. The exact distilled-vs-standin
+  text target so speculative decoding is correct. Its target-checkpoint match
   status is recorded in `mtp/target-meta.json` and
   `provenance.sourceModels.drafter`.
 


### PR DESCRIPTION
Refs #9588

## Summary
- Replace old third-party drafter source/provenance entries with official Google Gemma assistant source repos for 2b, 4b, 9b, and 27b staging paths.
- Make candidate and local bundle assembly fail closed: upstream assistant-derived drafters are not marked checkpoint-matched unless an explicit matched Eliza-1 drafter source is provided.
- Try official E2B-style local cache filenames before legacy local smoke-test names in the local staging helper.

## Official sources checked
- https://ai.google.dev/gemma/docs/core
- https://huggingface.co/google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant
- https://huggingface.co/google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant
- https://huggingface.co/google/gemma-4-12B-it-qat-q4_0-unquantized-assistant
- https://huggingface.co/google/gemma-4-31B-it-qat-q4_0-unquantized-assistant

## Evidence
- `bun install`
- `python -m pytest packages/training/scripts/manifest/test_stage_eliza1_source_weights.py packages/training/scripts/manifest/test_stage_local_eliza1_bundle.py` -> 11 passed
- `python -m compileall packages/training/scripts/manifest/stage_eliza1_source_weights.py packages/training/scripts/manifest/stage_local_eliza1_bundle.py packages/training/scripts/publish/assemble_local_gemma_bundle.py packages/training/scripts/publish/stage_base_v1_candidate.py && git diff --check`
- `bun run verify` -> 515/515 tasks successful

## Evidence N/A
- UI screenshots/video: no UI change.
- Real-LLM trajectory: training/provenance manifest script changes only; no runtime agent/action/prompt/model invocation behavior changed.
- Backend/frontend logs: no server or browser code path changed.
