### PR TITLE
docs(local-inference): remove stale Qwen defaults

### DIFF
--- a/plugins/plugin-local-inference/README.md
+++ b/plugins/plugin-local-inference/README.md
@@ -12,7 +12,7 @@ Eliza-1 local inference provider for elizaOS. Serves text generation, embeddings
 - **Text-to-speech** (`TEXT_TO_SPEECH`) via the local Kokoro/OmniVoice runtime selected by tier and policy.
 - **Automatic speech recognition** (`TRANSCRIPTION`) via the eligible bundled local ASR head in fused `libelizainference`; there is no whisper.cpp fallback.
 - **Image generation** (`IMAGE`) via sd.cpp, CoreML (Apple Silicon), mflux, TensorRT, or AOSP backends; selected by hardware and catalog entry.
-- **Image description / vision** (`IMAGE_DESCRIPTION`) via the Qwen3-VL multimodal projector attached to the active text model.
+- **Image description / vision** (`IMAGE_DESCRIPTION`) via the tier-matched Eliza-1 multimodal projector attached to the active text model.
 - **Model catalog, download management, and hardware-fit recommendation** exposed as HTTP routes for the elizaOS dashboard.
 - **Voice pipeline**: barge-in, VAD, speaker imprint, phrase streaming, voice profiles, and first-run onboarding.
 

--- a/plugins/plugin-local-inference/native/AGENTS.md
+++ b/plugins/plugin-local-inference/native/AGENTS.md
@@ -536,7 +536,7 @@ catalogs drift from it — generate them.
   "version": "1.0.0",
   "publishedAt": "2026-MM-DDTHH:MM:SSZ",
   "lineage": {
-    "text": { "base": "qwen3.5-4b", "license": "..." },
+    "text": { "base": "gemma-4-E4B", "license": "..." },
     "voice": { "base": "omnivoice-base-Q4_K_M", "license": "..." },
     "drafter": { "base": "mtp-4b-drafter", "license": "..." }
   },

--- a/plugins/plugin-local-inference/native/CLAUDE.md
+++ b/plugins/plugin-local-inference/native/CLAUDE.md
@@ -536,7 +536,7 @@ catalogs drift from it — generate them.
   "version": "1.0.0",
   "publishedAt": "2026-MM-DDTHH:MM:SSZ",
   "lineage": {
-    "text": { "base": "qwen3.5-4b", "license": "..." },
+    "text": { "base": "gemma-4-E4B", "license": "..." },
     "voice": { "base": "omnivoice-base-Q4_K_M", "license": "..." },
     "drafter": { "base": "mtp-4b-drafter", "license": "..." }
   },

--- a/plugins/plugin-local-inference/native/configs/gpu/SPECS.md
+++ b/plugins/plugin-local-inference/native/configs/gpu/SPECS.md
@@ -66,7 +66,8 @@ Two budgets dominate every choice:
 Transformer KV cost: `bytes/token = 2 × n_layers × n_kv_heads × head_dim × bytes_per_element`
 (factor of 2 = K and V).
 
-Eliza-1 bundles (Qwen3.5 / 3.6 base):
+Legacy Eliza-1 KV baseline (retired Qwen-shaped tiers; active Gemma tiers use
+manifest-declared stock Gemma KV plus MTP):
 
 | Bundle | n_layers | n_kv_heads | head_dim | FP16 KiB/tok | Q8K/Q4V KiB/tok | QJL+Polar KiB/tok |
 |---|---|---|---|---|---|---|


### PR DESCRIPTION
## Summary

- Remove stale Qwen-facing wording from the local-inference README vision notes.
- Update mirrored native docs so the manifest example uses `gemma-4-E4B` instead of `qwen3.5-4b`.
- Mark the GPU KV math section as a legacy retired Qwen-shaped baseline, with active Gemma tiers using manifest-declared stock Gemma KV plus MTP.

## Evidence

- Synced with `origin/develop` via `git fetch origin develop` and `git rebase origin/develop`.
- `bun install`
- `bun run verify` -> `515 successful, 515 total`
- `git diff --check`
- `cmp -s plugins/plugin-local-inference/native/CLAUDE.md plugins/plugin-local-inference/native/AGENTS.md`
- `rg -n "qwen3\.5-4b|Qwen3-VL multimodal projector|Qwen3\.5 / 3\.6 base" plugins/plugin-local-inference/README.md plugins/plugin-local-inference/native/CLAUDE.md plugins/plugin-local-inference/native/AGENTS.md plugins/plugin-local-inference/native/configs/gpu/SPECS.md` -> no matches

## Evidence N/A

- UI screenshots/video: docs-only change with no UI behavior.
- Runtime logs or real-LLM trajectory: docs-only change with no runtime path.
