### PR TITLE
fix(training): fail closed on retired Qwen voice assets

### DIFF
--- a/packages/training/scripts/manifest/stage_eliza1_bundle_assets.py
+++ b/packages/training/scripts/manifest/stage_eliza1_bundle_assets.py
@@ -9,7 +9,8 @@ publish orchestrator can hash and validate the final bundle.
 
 Default sources:
   - TTS: Serveurperso/OmniVoice-GGUF, Apache-2.0 GGUF artifacts.
-  - ASR: ggml-org/Qwen3-ASR-0.6B-GGUF / Qwen3-ASR-1.7B-GGUF, GGUF artifacts.
+  - ASR: no default. Qwen3-ASR is retired for the Gemma cutover; pass an
+    explicit verified Gemma ASR-capable repo/file pair once artifacts exist.
   - VAD: the Eliza-1 release repo's voice/vad/silero-vad-v5.gguf, native
     silero-vad-cpp Silero VAD v5 model.
     The legacy onnx-community/silero-vad int8 ONNX fallback can still be
@@ -62,13 +63,18 @@ except ImportError:  # pragma: no cover - script execution path
 VOICE_REPO: Final[str] = "Serveurperso/OmniVoice-GGUF"
 VAD_NATIVE_REPO: Final[str] = ELIZA_1_HF_REPO
 VAD_ONNX_REPO: Final[str] = "onnx-community/silero-vad"
-ASR_REPO_BY_TIER: Final[dict[str, str]] = {
+RETIRED_QWEN_ASR_REPO_BY_TIER: Final[dict[str, str]] = {
     "0_8b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "2b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "4b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "9b": "ggml-org/Qwen3-ASR-1.7B-GGUF",
     "27b": "ggml-org/Qwen3-ASR-1.7B-GGUF",
 }
+GEMMA_ASR_REQUIRED_MESSAGE: Final[str] = (
+    "Gemma ASR artifacts are not configured for Eliza-1 staging. "
+    "Qwen3-ASR defaults were retired; pass --asr-repo, --asr-file, and "
+    "--asr-mmproj-file for a verified Gemma ASR-capable bundle once hosted."
+)
 
 # Voice Wave 2 (2026-05-14): semantic end-of-turn detector — `livekit/turn-detector`
 # is the default ship target; `latishab/turnsense` is the Apache-2.0 fallback
@@ -100,13 +106,7 @@ GGUF_QUANT_PREFERENCE: Final[tuple[str, ...]] = (
     "Q5_K_M",
     "Q8_0",
 )
-ASR_REQUANTIZE_BY_TIER: Final[dict[str, str]] = {
-    # The upstream Qwen3-ASR-0.6B GGUF repo publishes Q8_0/BF16 only.
-    # The 0.8B voice-loop memory gate needs the exact 752M ASR model
-    # requantized to Q4_K_M to keep ASR + mmproj + text + MTP + Kokoro
-    # resident under the 3.7 GB small-tier budget.
-    "0_8b": "Q4_K_M",
-}
+ASR_REQUANTIZE_BY_TIER: Final[dict[str, str]] = {}
 
 VAD_NATIVE_FILES: Final[tuple[tuple[str, str], ...]] = (
     ("voice/vad/silero-vad-v5.gguf", "vad/silero-vad-v5.gguf"),
@@ -786,9 +786,10 @@ def write_license_notes(
     licenses = {
         "LICENSE.voice": voice_note,
         "LICENSE.asr": (
-            "ASR GGUF assets staged from ggml-org/Qwen3-ASR-0.6B-GGUF "
-            "or ggml-org/Qwen3-ASR-1.7B-GGUF.\n"
-            "Review upstream Apache-2.0 license and model card before release.\n"
+            "ASR GGUF assets must be staged from a verified Gemma ASR-capable "
+            "source repo. The previous ggml-org/Qwen3-ASR assets are retired "
+            "for active Eliza-1 Gemma bundles and may only be used for explicit "
+            "legacy reproduction.\n"
         ),
         "LICENSE.vad": (
             "VAD assets staged from the Eliza-1 release repo as native silero-vad-cpp "
@@ -844,11 +845,34 @@ def resolve_revisions(api: Any, repos: tuple[str, ...]) -> dict[str, str]:
     return out
 
 
+def _repo_is_retired_qwen_asr(repo: str) -> bool:
+    lowered = repo.lower()
+    return "qwen" in lowered and "asr" in lowered
+
+
+def resolve_asr_repo(args: argparse.Namespace, tier: str) -> str:
+    """Return an explicit ASR repo, failing closed on retired Qwen defaults."""
+
+    explicit = getattr(args, "asr_repo", None)
+    allow_retired = bool(getattr(args, "allow_retired_qwen_asr", False))
+    if explicit:
+        if _repo_is_retired_qwen_asr(explicit) and not allow_retired:
+            raise SystemExit(
+                f"{explicit} is a retired Qwen ASR source; Gemma cutover staging "
+                "requires a verified Gemma ASR-capable repo. Re-run with "
+                "--allow-retired-qwen-asr only for legacy bundle reproduction."
+            )
+        return explicit
+    if allow_retired:
+        return RETIRED_QWEN_ASR_REPO_BY_TIER[tier]
+    raise SystemExit(GEMMA_ASR_REQUIRED_MESSAGE)
+
+
 def stage_assets(args: argparse.Namespace) -> dict[str, Any]:
     tier = args.tier
     quant = VOICE_QUANT_BY_TIER[tier]
     bundle_dir = args.bundle_dir.resolve()
-    asr_repo = args.asr_repo or ASR_REPO_BY_TIER[tier]
+    asr_repo = resolve_asr_repo(args, tier)
     HfApi, _ = require_hf_hub()
     api = HfApi()
     voice_backends = VOICE_BACKENDS_BY_TIER[tier]
@@ -1201,7 +1225,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     ap.add_argument(
         "--asr-repo",
         default=None,
-        help="Override ASR GGUF model repo. Defaults by tier.",
+        help=(
+            "ASR GGUF model repo. Required for active Gemma staging because "
+            "Qwen3-ASR defaults are retired."
+        ),
+    )
+    ap.add_argument(
+        "--allow-retired-qwen-asr",
+        action="store_true",
+        help=(
+            "Allow retired Qwen3-ASR repos for explicit legacy bundle reproduction. "
+            "Do not use for active Gemma Eliza-1 releases."
+        ),
     )
     ap.add_argument(
         "--asr-file",
@@ -1221,7 +1256,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
         help=(
             "Requantize the staged canonical ASR GGUF to this llama.cpp quant "
-            "type. Defaults to Q4_K_M for 0_8b; pass 'none' to disable."
+            "type. No active Gemma tier has a default; pass 'none' to disable."
         ),
     )
     ap.add_argument(

--- a/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
@@ -98,9 +98,9 @@ from benchmarks.eliza1_gates import apply_gates  # noqa: E402
 
 VISION_TIERS: Final[set[str]] = set(ELIZA_1_VISION_TIERS)
 MTP_TIERS: Final[set[str]] = set(ELIZA_1_MTP_TIERS)
-EMBEDDING_TIERS: Final[set[str]] = {"4b"}
-EMBEDDING_REPO: Final[str] = "Qwen/Qwen3-Embedding-0.6B-GGUF"
-EMBEDDING_FILE: Final[str] = "Qwen3-Embedding-0.6B-Q8_0.gguf"
+EMBEDDING_TIERS: Final[set[str]] = set()
+RETIRED_QWEN_EMBEDDING_REPO: Final[str] = "Qwen/Qwen3-Embedding-0.6B-GGUF"
+RETIRED_QWEN_EMBEDDING_FILE: Final[str] = "Qwen3-Embedding-0.6B-Q8_0.gguf"
 
 DEFAULT_RAM_BUDGET_MB: Final[Mapping[str, tuple[int, int]]] = {
     "0_8b": (2500, 3700),
@@ -354,8 +354,8 @@ def _write_licenses(
     if tier in EMBEDDING_TIERS:
         texts["LICENSE.embedding"] = (
             "Eliza-1 embedding model license notice.\n\n"
-            "The text-embedding artifact is Qwen3-Embedding-0.6B (Apache-2.0, 1024-dim Matryoshka, 32k ctx). "
-            "Lineage recorded in eliza-1.manifest.json's lineage.embedding block.\n\n"
+            "A dedicated embedding artifact is active for this tier. Lineage is "
+            "recorded in eliza-1.manifest.json's lineage.embedding block.\n\n"
             "Apache License 2.0 — https://www.apache.org/licenses/LICENSE-2.0\n"
         )
     for name, text in texts.items():
@@ -836,7 +836,10 @@ def _write_lineage(
             "license": "apache-2.0",
         }
     if has_embedding:
-        data["embedding"] = {"base": EMBEDDING_REPO, "license": "apache-2.0"}
+        data["embedding"] = {
+            "base": "configured-dedicated-gemma-compatible-embedding",
+            "license": "apache-2.0",
+        }
     _json_write(path, data)
     out: dict[str, LineageEntry] = {}
     for slot, spec in data.items():
@@ -1024,9 +1027,10 @@ def stage_real_bundle(args: argparse.Namespace) -> dict[str, Any]:
             bundle_dir=bundle_dir,
             dry_run=False,
             link_mode="copy",
-            asr_repo=None,
-            asr_file=None,
-            asr_mmproj_file=None,
+            asr_repo=getattr(args, "asr_repo", None),
+            asr_file=getattr(args, "asr_file", None),
+            asr_mmproj_file=getattr(args, "asr_mmproj_file", None),
+            allow_retired_qwen_asr=getattr(args, "allow_retired_qwen_asr", False),
             upload_repo=None,
             upload_prefix="",
             public=False,
@@ -1038,31 +1042,22 @@ def stage_real_bundle(args: argparse.Namespace) -> dict[str, Any]:
         )
         assets_mod.stage_assets(assets_args)
 
-    # 2. Stage embedding (non-lite) — Qwen3-Embedding-0.6B GGUF.
+    # 2. Dedicated embedding artifacts are disabled until a Gemma-compatible
+    # source is published. Active tiers reuse the text backbone for embeddings.
     has_embedding = tier in EMBEDDING_TIERS
     if has_embedding and not args.skip_assets:
-        try:
-            from huggingface_hub import HfApi, hf_hub_download
-
-            api = HfApi()
-            rev = str(api.model_info(EMBEDDING_REPO).sha)
-            cached = Path(
-                hf_hub_download(
-                    repo_id=EMBEDDING_REPO,
-                    filename=EMBEDDING_FILE,
-                    revision=rev,
-                    repo_type="model",
-                )
-            )
-            dest = bundle_dir / "embedding" / "eliza-1-embedding.gguf"
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if dest.exists():
-                dest.unlink()
-            shutil.copy2(cached, dest)
-        except Exception as exc:  # pragma: no cover - network path
-            raise SystemExit(
-                f"failed to stage embedding GGUF for {tier}: {exc}"
-            ) from exc
+        raise SystemExit(
+            "dedicated embedding staging is disabled until a verified "
+            "Gemma-compatible embedding artifact is configured"
+        )
+    stale_embedding_files = sorted((bundle_dir / "embedding").glob("*"))
+    if stale_embedding_files:
+        raise SystemExit(
+            "retired Qwen embedding artifacts are present in the bundle; remove "
+            f"{bundle_dir / 'embedding'} before staging active Gemma bundles. "
+            f"Retired source: {RETIRED_QWEN_EMBEDDING_REPO}/"
+            f"{RETIRED_QWEN_EMBEDDING_FILE}"
+        )
 
     text_substituted = bool(args.text_substituted)
     drafter_stamp_only = bool(args.drafter_stamp_only)
@@ -1392,6 +1387,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--skip-assets",
         action="store_true",
         help="Skip the HF asset stage (voice/ASR/VAD already present in --bundle-dir).",
+    )
+    ap.add_argument(
+        "--asr-repo",
+        default=None,
+        help=(
+            "ASR GGUF model repo passed through to stage_eliza1_bundle_assets. "
+            "Required unless --skip-assets is set."
+        ),
+    )
+    ap.add_argument(
+        "--asr-file",
+        default=None,
+        help="Exact ASR GGUF file path inside --asr-repo.",
+    )
+    ap.add_argument(
+        "--asr-mmproj-file",
+        default=None,
+        help="Exact ASR mmproj GGUF file path inside --asr-repo.",
+    )
+    ap.add_argument(
+        "--allow-retired-qwen-asr",
+        action="store_true",
+        help=(
+            "Allow retired Qwen3-ASR repos for explicit legacy bundle reproduction. "
+            "Do not use for active Gemma Eliza-1 releases."
+        ),
     )
     ap.add_argument(
         "--skip-wakeword",

--- a/packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py
+++ b/packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 _TRAINING_ROOT = Path(__file__).resolve().parents[2]
 if str(_TRAINING_ROOT) not in sys.path:
     sys.path.insert(0, str(_TRAINING_ROOT))
@@ -47,6 +49,7 @@ def _args(tmp_path: Path, tier: str) -> argparse.Namespace:
         asr_repo=None,
         asr_file=None,
         asr_mmproj_file=None,
+        allow_retired_qwen_asr=False,
         asr_requantize=None,
         llama_quantize_bin=None,
         include_vad_onnx_fallback=False,
@@ -64,12 +67,27 @@ def _args(tmp_path: Path, tier: str) -> argparse.Namespace:
     )
 
 
-def test_stage_dry_run_uses_qwen_asr_gguf_and_native_vad(
+def _legacy_qwen_args(tmp_path: Path, tier: str) -> argparse.Namespace:
+    args = _args(tmp_path, tier)
+    args.allow_retired_qwen_asr = True
+    return args
+
+
+def test_stage_dry_run_requires_explicit_gemma_asr_source_by_default(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    report = stage.stage_assets(_args(tmp_path, "4b"))
+    with pytest.raises(SystemExit, match="Gemma ASR artifacts are not configured"):
+        stage.stage_assets(_args(tmp_path, "4b"))
+
+
+def test_legacy_stage_dry_run_uses_qwen_asr_only_with_opt_in(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(stage, "HfApi", FakeHfApi)
+    report = stage.stage_assets(_legacy_qwen_args(tmp_path, "4b"))
 
     staged = {
         (f["repo"], f["remotePath"], Path(f["path"]).as_posix())
@@ -119,12 +137,13 @@ def test_stage_dry_run_uses_qwen_asr_gguf_and_native_vad(
         assert ww[dst].startswith(stage.WAKEWORD_RELEASE)
 
 
-def test_stage_0_8b_dry_run_records_asr_q4_requantize_plan(
+def test_stage_dry_run_records_explicit_asr_q4_requantize_plan(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    args = _args(tmp_path, "0_8b")
+    args = _legacy_qwen_args(tmp_path, "2b")
+    args.asr_requantize = "Q4_K_M"
     report = stage.stage_assets(args)
 
     req = report["asrRequantize"]
@@ -133,7 +152,7 @@ def test_stage_0_8b_dry_run_records_asr_q4_requantize_plan(
     assert req["allowRequantize"] is True
     assert req["sourceRepo"] == "ggml-org/Qwen3-ASR-0.6B-GGUF"
     assert req["sourceRemotePath"] == "Qwen3-ASR-0.6B-Q8_0.gguf"
-    assert req["path"] == (tmp_path / "0_8b" / "asr" / "eliza-1-asr.gguf").as_posix()
+    assert req["path"] == (tmp_path / "2b" / "asr" / "eliza-1-asr.gguf").as_posix()
 
 
 def test_stage_asr_requantize_can_be_disabled(
@@ -141,14 +160,14 @@ def test_stage_asr_requantize_can_be_disabled(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    args = _args(tmp_path, "0_8b")
+    args = _legacy_qwen_args(tmp_path, "2b")
     args.asr_requantize = "none"
     report = stage.stage_assets(args)
 
     assert report["asrRequantize"] is None
 
 
-def test_real_stage_requantizes_0_8b_asr_when_quantizer_is_supplied(
+def test_real_stage_requantizes_asr_when_quantizer_is_supplied(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -198,17 +217,18 @@ def test_real_stage_requantizes_0_8b_asr_when_quantizer_is_supplied(
     monkeypatch.setattr(stage, "requantize_gguf_file", fake_requantize_gguf_file)
     monkeypatch.setattr(stage, "validate_manifest", lambda *args, **kwargs: ())
 
-    args = _args(tmp_path, "0_8b")
+    args = _legacy_qwen_args(tmp_path, "2b")
     args.dry_run = False
     args.llama_quantize_bin = tmp_path / "llama-quantize"
-    bundle = tmp_path / "0_8b"
+    args.asr_requantize = "Q4_K_M"
+    bundle = tmp_path / "2b"
     (bundle / "evidence").mkdir(parents=True)
     (bundle / "eliza-1.manifest.json").write_text(
-        json.dumps({"id": "eliza-1-0_8b", "tier": "0_8b", "files": {}}) + "\n",
+        json.dumps({"id": "eliza-1-2b", "tier": "2b", "files": {}}) + "\n",
         encoding="utf-8",
     )
     (bundle / "evidence" / "release.json").write_text(
-        json.dumps({"schemaVersion": 1, "tier": "0_8b", "weights": []}) + "\n",
+        json.dumps({"schemaVersion": 1, "tier": "2b", "weights": []}) + "\n",
         encoding="utf-8",
     )
 
@@ -226,7 +246,7 @@ def test_real_stage_requantizes_0_8b_asr_when_quantizer_is_supplied(
 
 def test_skip_wakeword_omits_wake_graphs(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    args = _args(tmp_path, "4b")
+    args = _legacy_qwen_args(tmp_path, "4b")
     args.skip_wakeword = True
     report = stage.stage_assets(args)
     assert not any("url" in f for f in report["files"])
@@ -237,7 +257,7 @@ def test_stage_dry_run_can_include_legacy_onnx_vad_fallback(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    args = _args(tmp_path, "4b")
+    args = _legacy_qwen_args(tmp_path, "4b")
     args.include_vad_onnx_fallback = True
     report = stage.stage_assets(args)
     staged = {
@@ -254,14 +274,14 @@ def test_stage_dry_run_can_include_legacy_onnx_vad_fallback(
     assert report["vad"]["onnxFallbackRepo"] == "onnx-community/silero-vad"
 
 
-def test_stage_dry_run_accepts_lite_active_tier(
+def test_legacy_stage_dry_run_accepts_active_tier(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
-    report = stage.stage_assets(_args(tmp_path, "0_8b"))
+    report = stage.stage_assets(_legacy_qwen_args(tmp_path, "2b"))
 
-    assert report["tier"] == "0_8b"
+    assert report["tier"] == "2b"
     assert report["asrRepo"] == "ggml-org/Qwen3-ASR-0.6B-GGUF"
 
 
@@ -272,7 +292,9 @@ def test_non_dry_run_writes_asr_vad_and_wakeword_license_notes(
     assert (tmp_path / "licenses" / "LICENSE.asr").is_file()
     assert (tmp_path / "licenses" / "LICENSE.vad").is_file()
     assert (tmp_path / "licenses" / "LICENSE.wakeword").is_file()
-    assert "Qwen3-ASR" in (tmp_path / "licenses" / "LICENSE.asr").read_text()
+    assert "Qwen3-ASR assets are retired" in (
+        tmp_path / "licenses" / "LICENSE.asr"
+    ).read_text()
     vad = (tmp_path / "licenses" / "LICENSE.vad").read_text()
     assert "GGUF" in vad
     assert "vad/silero-vad-v5.gguf" in vad
@@ -324,16 +346,16 @@ def test_real_stage_writes_evidence_report_without_downloading(
     monkeypatch.setattr(stage, "copy_hf_file", fake_copy_hf_file)
     monkeypatch.setattr(stage, "download_url_file", fake_download_url_file)
     monkeypatch.setattr(stage, "validate_manifest", lambda *args, **kwargs: ())
-    args = _args(tmp_path, "0_8b")
+    args = _legacy_qwen_args(tmp_path, "2b")
     args.dry_run = False
     args.asr_requantize = "none"
-    bundle = tmp_path / "0_8b"
+    bundle = tmp_path / "2b"
     (bundle / "evidence").mkdir(parents=True)
     (bundle / "eliza-1.manifest.json").write_text(
         json.dumps(
             {
-                "id": "eliza-1-0_8b",
-                "tier": "0_8b",
+                    "id": "eliza-1-2b",
+                    "tier": "2b",
                 "files": {
                     "voice": [],
                     "asr": [],
@@ -350,7 +372,7 @@ def test_real_stage_writes_evidence_report_without_downloading(
         json.dumps(
             {
                 "schemaVersion": 1,
-                "tier": "0_8b",
+                    "tier": "2b",
                 "repoId": "old/repo",
                 "weights": [],
                 "hf": {"repoId": "old/repo"},
@@ -364,7 +386,7 @@ def test_real_stage_writes_evidence_report_without_downloading(
 
     assert report["dryRun"] is False
     assert copied
-    assert (tmp_path / "0_8b" / "wake" / "hey-eliza.onnx").is_file()
+    assert (tmp_path / "2b" / "wake" / "hey-eliza.onnx").is_file()
     manifest = json.loads((bundle / "eliza-1.manifest.json").read_text())
     voice_paths = {entry["path"] for entry in manifest["files"]["voice"]}
     assert "tts/omnivoice-base-Q4_K_M.gguf" in voice_paths
@@ -379,6 +401,6 @@ def test_real_stage_writes_evidence_report_without_downloading(
     assert report["releaseEvidenceUpdate"]["weights"]
     assert report["checksumManifest"]["entryCount"] > 0
     evidence = json.loads(
-        (tmp_path / "0_8b" / "evidence" / "bundle-assets.json").read_text()
+        (tmp_path / "2b" / "evidence" / "bundle-assets.json").read_text()
     )
     assert evidence["asrRepo"] == "ggml-org/Qwen3-ASR-0.6B-GGUF"

--- a/packages/training/scripts/manifest/test_stage_real_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/test_stage_real_eliza1_bundle.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _TRAINING_ROOT = Path(__file__).resolve().parents[2]
 if str(_TRAINING_ROOT) not in sys.path:
     sys.path.insert(0, str(_TRAINING_ROOT))
@@ -149,9 +151,11 @@ def test_stage_real_bundle_offline_layout(tmp_path: Path, monkeypatch) -> None:
         }
 
 
-def test_stage_real_bundle_embedding_tier_keeps_embedding_lineage(tmp_path: Path, monkeypatch) -> None:
-    """4b ships a separate embedding artifact; if present, its lineage entry
-    must survive (the bundle stager places it before lineage)."""
+def test_stage_real_bundle_rejects_retired_qwen_embedding_artifact(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Active Gemma bundles must not carry the retired Qwen embedding artifact."""
     monkeypatch.setattr(stage, "_repo_root", lambda: tmp_path)
     bundle = tmp_path / "eliza-1-4b.bundle"
     bundle.mkdir(parents=True)
@@ -169,14 +173,8 @@ def test_stage_real_bundle_embedding_tier_keeps_embedding_lineage(tmp_path: Path
         skip_assets=True, skip_wakeword=True, link_mode="copy",
         version="1.0.0-staged.1", generated_at="2026-05-11T00:00:00Z", force=False,
     )
-    report = stage.stage_real_bundle(args)
-    assert report["checksumValidation"]["ok"] is True
-    manifest = json.loads((bundle / "eliza-1.manifest.json").read_text())
-    assert manifest["lineage"]["embedding"]["base"] == "Qwen/Qwen3-Embedding-0.6B-GGUF"
-    assert manifest["files"]["embedding"][0]["path"] == "embedding/eliza-1-embedding.gguf"
-    # 4b ships both half-context and native-context variants.
-    ctxs = sorted(f["ctx"] for f in manifest["files"]["text"])
-    assert ctxs == [131072, 262144]
+    with pytest.raises(SystemExit, match="retired Qwen embedding artifacts"):
+        stage.stage_real_bundle(args)
 
 
 def test_remove_stale_text_variants_handles_27b_256k_bundle_names(tmp_path: Path) -> None:

--- a/packages/training/scripts/publish/stage_base_v1_candidate.py
+++ b/packages/training/scripts/publish/stage_base_v1_candidate.py
@@ -16,6 +16,9 @@ Usage:
         --text-sidecar checkpoints/eliza-1-2b-apollo-<run>/eliza1-optimized/gguf/final-Q4_POLAR.gguf.eliza1.json \
         --drafter-gguf /tmp/eliza1-eval-models/gemma4-mtp-drafter-2b.gguf \
         --drafter-source <license-reviewed drafter source> \
+        --asr-repo <verified Gemma ASR-capable repo> \
+        --asr-file <asr model gguf path> \
+        --asr-mmproj-file <asr projector gguf path> \
         --vision-gguf /tmp/eliza1-eval-models/mmproj-2b.gguf \
         --out /tmp/eliza1-stage/eliza-1-2b
 """
@@ -77,7 +80,9 @@ DRAFTER_SOURCE_BY_TIER = {
     "27b": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
 }
 
-# Frozen tier-agnostic voice/ASR/VAD/cache bytes live in the canonical model repo.
+# Frozen tier-agnostic VAD/cache bytes live in the canonical model repo.
+# ASR is supplied explicitly so candidate staging cannot silently inherit
+# retired Qwen assets from an older bundle.
 ASSETS_REPO = "elizaos/eliza-1"
 ASSETS_TIER = "2b"
 
@@ -172,6 +177,32 @@ def main(argv: list[str] | None = None) -> int:
             "official upstream assistant sources."
         ),
     )
+    ap.add_argument(
+        "--asr-repo",
+        default=None,
+        help=(
+            "Verified Gemma ASR-capable HF repo for the ASR GGUF assets. "
+            "Required; retired Qwen ASR repos require --allow-retired-qwen-asr."
+        ),
+    )
+    ap.add_argument(
+        "--asr-file",
+        default=None,
+        help="Exact ASR model GGUF path inside --asr-repo.",
+    )
+    ap.add_argument(
+        "--asr-mmproj-file",
+        default=None,
+        help="Exact ASR mmproj/projector GGUF path inside --asr-repo.",
+    )
+    ap.add_argument(
+        "--allow-retired-qwen-asr",
+        action="store_true",
+        help=(
+            "Allow retired Qwen3-ASR repos for explicit legacy candidate "
+            "reproduction. Do not use for active Gemma Eliza-1 releases."
+        ),
+    )
     ap.add_argument("--out", required=True, type=Path)
     ap.add_argument("--licenses-from", type=Path, default=None,
                     help="Dir of LICENSE.* files to copy into licenses/.")
@@ -193,6 +224,18 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(
             "--drafter-matches-target requires --drafter-source naming the "
             "matched Eliza-1 drafter run, not just the default upstream source."
+        )
+    asr_repo = A.resolve_asr_repo(
+        argparse.Namespace(
+            asr_repo=args.asr_repo,
+            allow_retired_qwen_asr=args.allow_retired_qwen_asr,
+        ),
+        tier,
+    )
+    if not args.asr_file or not args.asr_mmproj_file:
+        raise SystemExit(
+            "candidate staging requires --asr-file and --asr-mmproj-file for "
+            "the verified ASR source"
         )
     out = args.out.resolve()
     text_rel = PP.text_artifact_name(tier, TEXT_CONTEXT_BY_TIER[tier])
@@ -293,21 +336,58 @@ def main(argv: list[str] | None = None) -> int:
     # Native VAD is the release artifact; the ONNX file is a legacy fallback and
     # is intentionally not listed in the manifest.
     asset_map = [
-        (ASSETS_REPO, f"{ASSETS_TIER}/asr/eliza-1-asr.gguf", out / "asr" / "eliza-1-asr.gguf"),
-        (ASSETS_REPO, f"{ASSETS_TIER}/asr/eliza-1-asr-mmproj.gguf", out / "asr" / "eliza-1-asr-mmproj.gguf"),
+        (asr_repo, args.asr_file, out / "asr" / "eliza-1-asr.gguf"),
+        (asr_repo, args.asr_mmproj_file, out / "asr" / "eliza-1-asr-mmproj.gguf"),
         (A.VAD_NATIVE_REPO, "voice/vad/silero-vad-v5.gguf", out / "vad" / "silero-vad-v5.gguf"),
         (ASSETS_REPO, f"{ASSETS_TIER}/cache/voice-preset-default.bin", out / "cache" / "voice-preset-default.bin"),
-        (ASSETS_REPO, f"{ASSETS_TIER}/licenses/LICENSE.asr", out / "licenses" / "LICENSE.asr"),
         (ASSETS_REPO, f"{ASSETS_TIER}/licenses/LICENSE.vad", out / "licenses" / "LICENSE.vad"),
         (ASSETS_REPO, f"{ASSETS_TIER}/licenses/LICENSE.voice", out / "licenses" / "LICENSE.voice"),
-        (ASSETS_REPO, f"{ASSETS_TIER}/lineage.json", out / "evidence" / "assets-lineage.json"),
-        (ASSETS_REPO, f"{ASSETS_TIER}/evidence/bundle-assets.json", out / "evidence" / "bundle-assets.json"),
     ]
     for rel in M.required_voice_artifacts_for_tier(tier):
         repo, remote, dest = voice_asset_source(tier, rel)
         asset_map.append((repo, remote, out / dest))
     for repo, remote, dest in asset_map:
         download_asset(repo, remote, dest)
+    (out / "licenses" / "LICENSE.asr").write_text(
+        "Eliza-1 ASR model license notice.\n\n"
+        f"ASR GGUF assets staged from {asr_repo}:\n"
+        f"- {args.asr_file}\n"
+        f"- {args.asr_mmproj_file}\n\n"
+        "Review the upstream model card and license before release.\n"
+    )
+    asset_lineage = {
+        "schemaVersion": 1,
+        "tier": tier,
+        "generatedAt": generated_at,
+        "voice": {"base": voice_source_note(tier), "license": "apache-2.0"},
+        "asr": {
+            "base": asr_repo,
+            "files": [args.asr_file, args.asr_mmproj_file],
+            "license": "review upstream model card before release",
+        },
+        "vad": {"base": A.VAD_NATIVE_REPO, "license": "mit"},
+        "cache": {"base": ASSETS_REPO, "license": "apache-2.0"},
+    }
+    (out / "evidence" / "assets-lineage.json").write_text(
+        json.dumps(asset_lineage, indent=2) + "\n"
+    )
+    (out / "evidence" / "bundle-assets.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "tier": tier,
+                "generatedAt": generated_at,
+                "asrRepo": asr_repo,
+                "asrRemotePath": args.asr_file,
+                "asrMmprojRemotePath": args.asr_mmproj_file,
+                "voiceBackends": list(M.VOICE_BACKENDS_BY_TIER[tier]),
+                "vadRepo": A.VAD_NATIVE_REPO,
+                "cacheRepo": ASSETS_REPO,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
 
     # extra licenses (text / mtp / vision / eliza-1) from a local bundle dir if given
     if args.licenses_from and args.licenses_from.is_dir():
@@ -422,7 +502,10 @@ def main(argv: list[str] | None = None) -> int:
             base=f"{TEXT_BASE_BY_TIER[tier]} vision projector",
             license="apache-2.0; review upstream model card before release",
         ),
-        "asr": M.LineageEntry(base=A.ASR_REPO_BY_TIER[tier], license="apache-2.0; review upstream model card before release"),
+        "asr": M.LineageEntry(
+            base=asr_repo,
+            license="review upstream model card before release",
+        ),
         "vad": M.LineageEntry(base=A.VAD_NATIVE_REPO, license="mit"),
     }
 
@@ -470,7 +553,11 @@ def main(argv: list[str] | None = None) -> int:
                 "files": list(M.required_voice_artifacts_for_tier(tier)),
                 "note": "frozen TTS assets, not fine-tuned",
             },
-            "asr": {"repo": A.ASR_REPO_BY_TIER[tier], "note": "frozen, not fine-tuned"},
+            "asr": {
+                "repo": asr_repo,
+                "files": [args.asr_file, args.asr_mmproj_file],
+                "note": "frozen, not fine-tuned",
+            },
             "vad": {"repo": A.VAD_NATIVE_REPO, "note": "frozen native Silero v5 GGUF"},
             "drafter": {
                 "repo": drafter_source,
@@ -556,12 +643,14 @@ def main(argv: list[str] | None = None) -> int:
     # --- README ---
     (out / "README.md").write_text(
         _render_readme(tier, manifest, drafter_source, optimized=optimized,
-                       eval_results=eval_results, text_rel=text_rel)
+                       eval_results=eval_results, text_rel=text_rel,
+                       asr_repo=asr_repo)
     )
 
     print(f"staged {tier} bundle at {out}")
     print(f"  text sha256={text_sha}")
     print(f"  drafter sha256={drafter_sha} (source {drafter_source})")
+    print(f"  asr source={asr_repo}")
     return 0
 
 
@@ -573,6 +662,7 @@ def _render_readme(
     optimized: bool,
     eval_results: dict[str, Any],
     text_rel: str,
+    asr_repo: str,
 ) -> str:
     base_repo = TEXT_BASE_BY_TIER[tier]
     if optimized:
@@ -624,9 +714,8 @@ release bar (every supported backend kernel-verified, every eval green) is met.
 
 {text_para}
 - **Voice / ASR / VAD / cache**: frozen upstream assets —
-  {", ".join(M.VOICE_BACKENDS_BY_TIER[tier])} TTS, local ASR placeholder
-  assets, native Silero-VAD v5.1.2, and the default speaker preset. Not
-  fine-tuned.
+  {", ".join(M.VOICE_BACKENDS_BY_TIER[tier])} TTS, ASR from `{asr_repo}`,
+  native Silero-VAD v5.1.2, and the default speaker preset. Not fine-tuned.
   Licenses in `licenses/`.
 - **MTP drafter** (`mtp/drafter-{tier}.gguf`): the **upstream
   `{drafter_source}` artifact** — it must share the Gemma 4 tokenizer with the

--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -112,7 +112,7 @@ src/
     tts/                          TTS pipeline helpers and audio cache
     asr/                          ASR backend interface and capability registration
     vision/                       Vision-describe backend interface and capability registration
-    voice/                        Full voice pipeline: Kokoro TTS, Whisper ASR, VAD, barge-in, speaker imprint, profiles
+    voice/                        Full voice pipeline: Kokoro/OmniVoice TTS, fused local ASR, VAD, barge-in, speaker imprint, profiles
 ```
 
 ## Commands
@@ -165,7 +165,6 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `LOCAL_INFERENCE_IMAGE_MODEL_KEY` | No | Pin a specific image-gen model key |
 | `LOCAL_INFERENCE_ACTIVE_TIER` | No | Pin a specific Eliza-1 tier (e.g. `eliza-1-4b`) |
 | `ELIZA_LOCAL_INFERENCE_ENABLE_EXTERNAL_SCAN` | No | Developer-only diagnostic opt-in; set `1`/`true`/`yes` to include external GGUF files in installed-model inventory. Default product setup is curated Eliza-1 only. |
-| `ELIZA_WHISPER_USE_GPU` | No | Enable GPU acceleration for Whisper ASR |
 | `LOCAL_EMBEDDING_MODEL` | No | Override embedding model filename |
 | `LOCAL_EMBEDDING_GPU_LAYERS` | No | GPU layers for embedding model |
 | `LOCAL_EMBEDDING_CONTEXT_SIZE` | No | Context size for embedding model |
@@ -199,7 +198,7 @@ Call `arbiter.registerCapability({ capability, residentRole, load, unload, run }
 - **Text runs through the in-process FFI llama.cpp backend only** (`node-llama-cpp` has been retired). The engine checks the dispatcher's `available()`/FFI probe before using it; an absent/unsupported FFI runtime produces a clean `LocalInferenceUnavailableError` rather than a crash. There is no `node-llama-cpp` fallback.
 - **Two text runtime classes — branch on `runtimeClass`, never on the id prefix.** Every `CatalogModel` / `InstalledModel` carries a `runtimeClass: "fused-eliza1" | "generic-gguf"` discriminator (canonical helpers in `@elizaos/shared/local-inference/runtime-class.ts`; populated by the catalog factory + hub-search synthesizers, and backfilled once at the registry-read boundary in `registry.ts listInstalledModels`). The dispatcher (`backend.ts decideBackend` / `BackendDispatcher.decide`) routes `fused-eliza1` → the fused `libelizainference` (`desktop-fused-ffi-backend-runtime.ts`, full pipeline) and `generic-gguf` → the explicit-`modelPath` runtime (`generic-gguf-backend.ts`, stock f16 KV, reduced optimizations). eliza-1 stays the default/recommended path; `buildRecommendedAssignments` / `autoAssignAtBoot` stay eliza-1-only and never auto-assign a generic blob. Generic single-file GGUF needs the explicit-`modelPath` binding (`llama-cpp-capacitor` on mobile); on desktop it is not built into the shipping fused lib, so a generic load raises a typed `GenericRuntimeUnavailableError` and `setAssignment` rejects it at the boundary with `AssignmentNotServableError` (route → 422) — never a silent deferred load failure. Generic-model search/download/assignment is an Advanced/Developer-mode surface in the UI; eliza-1 is the only thing shown by default.
 - **`TEXT_EMBEDDING` is NOT in the static plugin `models` map.** It is wired by `ensureLocalInferenceHandler()` at boot to avoid claiming the embedding slot before an Eliza-1 bundle is active. Do not add it to the static plugin object.
-- **Native binary deps** (sd.cpp, mflux, whisper.cpp, Kokoro GGUF/fused lib) must be present on the host or downloaded separately. The plugin does not bundle them; `probe:sd-cpp` checks for sd.cpp.
+- **Native binary deps** (sd.cpp, mflux, Kokoro GGUF/fused `libelizainference`) must be present on the host or downloaded separately. The plugin does not bundle them; `probe:sd-cpp` checks for sd.cpp.
 - **MemoryArbiter (WS1)** is the coordination point for all modalities on memory-constrained devices. Cross-plugin consumers (vision, image-gen, ASR, TTS) must go through the arbiter — never load models independently.
 - **Catalog source of truth** lives in `@elizaos/shared` (`MODEL_CATALOG`, tier ids, HuggingFace URL builders). `src/services/catalog.ts` is a thin re-export shim.
 - **Type source of truth** for `CatalogModel`, `InstalledModel`, `AgentModelSlot`, etc. also lives in `@elizaos/shared`. `src/services/types.ts` re-exports them.

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -112,7 +112,7 @@ src/
     tts/                          TTS pipeline helpers and audio cache
     asr/                          ASR backend interface and capability registration
     vision/                       Vision-describe backend interface and capability registration
-    voice/                        Full voice pipeline: Kokoro TTS, Whisper ASR, VAD, barge-in, speaker imprint, profiles
+    voice/                        Full voice pipeline: Kokoro/OmniVoice TTS, fused local ASR, VAD, barge-in, speaker imprint, profiles
 ```
 
 ## Commands
@@ -165,7 +165,6 @@ bun run --cwd plugins/plugin-local-inference clean        # rm dist .turbo node_
 | `LOCAL_INFERENCE_IMAGE_MODEL_KEY` | No | Pin a specific image-gen model key |
 | `LOCAL_INFERENCE_ACTIVE_TIER` | No | Pin a specific Eliza-1 tier (e.g. `eliza-1-4b`) |
 | `ELIZA_LOCAL_INFERENCE_ENABLE_EXTERNAL_SCAN` | No | Developer-only diagnostic opt-in; set `1`/`true`/`yes` to include external GGUF files in installed-model inventory. Default product setup is curated Eliza-1 only. |
-| `ELIZA_WHISPER_USE_GPU` | No | Enable GPU acceleration for Whisper ASR |
 | `LOCAL_EMBEDDING_MODEL` | No | Override embedding model filename |
 | `LOCAL_EMBEDDING_GPU_LAYERS` | No | GPU layers for embedding model |
 | `LOCAL_EMBEDDING_CONTEXT_SIZE` | No | Context size for embedding model |
@@ -199,7 +198,7 @@ Call `arbiter.registerCapability({ capability, residentRole, load, unload, run }
 - **Text runs through the in-process FFI llama.cpp backend only** (`node-llama-cpp` has been retired). The engine checks the dispatcher's `available()`/FFI probe before using it; an absent/unsupported FFI runtime produces a clean `LocalInferenceUnavailableError` rather than a crash. There is no `node-llama-cpp` fallback.
 - **Two text runtime classes — branch on `runtimeClass`, never on the id prefix.** Every `CatalogModel` / `InstalledModel` carries a `runtimeClass: "fused-eliza1" | "generic-gguf"` discriminator (canonical helpers in `@elizaos/shared/local-inference/runtime-class.ts`; populated by the catalog factory + hub-search synthesizers, and backfilled once at the registry-read boundary in `registry.ts listInstalledModels`). The dispatcher (`backend.ts decideBackend` / `BackendDispatcher.decide`) routes `fused-eliza1` → the fused `libelizainference` (`desktop-fused-ffi-backend-runtime.ts`, full pipeline) and `generic-gguf` → the explicit-`modelPath` runtime (`generic-gguf-backend.ts`, stock f16 KV, reduced optimizations). eliza-1 stays the default/recommended path; `buildRecommendedAssignments` / `autoAssignAtBoot` stay eliza-1-only and never auto-assign a generic blob. Generic single-file GGUF needs the explicit-`modelPath` binding (`llama-cpp-capacitor` on mobile); on desktop it is not built into the shipping fused lib, so a generic load raises a typed `GenericRuntimeUnavailableError` and `setAssignment` rejects it at the boundary with `AssignmentNotServableError` (route → 422) — never a silent deferred load failure. Generic-model search/download/assignment is an Advanced/Developer-mode surface in the UI; eliza-1 is the only thing shown by default.
 - **`TEXT_EMBEDDING` is NOT in the static plugin `models` map.** It is wired by `ensureLocalInferenceHandler()` at boot to avoid claiming the embedding slot before an Eliza-1 bundle is active. Do not add it to the static plugin object.
-- **Native binary deps** (sd.cpp, mflux, whisper.cpp, Kokoro GGUF/fused lib) must be present on the host or downloaded separately. The plugin does not bundle them; `probe:sd-cpp` checks for sd.cpp.
+- **Native binary deps** (sd.cpp, mflux, Kokoro GGUF/fused `libelizainference`) must be present on the host or downloaded separately. The plugin does not bundle them; `probe:sd-cpp` checks for sd.cpp.
 - **MemoryArbiter (WS1)** is the coordination point for all modalities on memory-constrained devices. Cross-plugin consumers (vision, image-gen, ASR, TTS) must go through the arbiter — never load models independently.
 - **Catalog source of truth** lives in `@elizaos/shared` (`MODEL_CATALOG`, tier ids, HuggingFace URL builders). `src/services/catalog.ts` is a thin re-export shim.
 - **Type source of truth** for `CatalogModel`, `InstalledModel`, `AgentModelSlot`, etc. also lives in `@elizaos/shared`. `src/services/types.ts` re-exports them.


### PR DESCRIPTION
## Summary
- retire Qwen3-ASR as the default ASR source for Eliza-1 asset staging; active Gemma staging now requires explicit ASR repo/file/mmproj inputs and rejects Qwen ASR unless the legacy reproduction flag is set
- disable the Qwen embedding default in the real bundle stager and reject stale embedding artifacts in active Gemma bundles
- update the base-v1 candidate publisher so it no longer copies ASR bytes, ASR license text, or ASR evidence from the old canonical bundle; it now records the explicit ASR source in license, lineage, provenance, and README output
- remove stale Whisper ASR / whisper.cpp docs from plugin-local-inference package docs

Refs #9588
Refs #9583

## Evidence
- `git fetch origin develop && git rebase origin/develop --autostash`
- `bun install`
- `bun run verify` -> 515 successful / 515 total
- `python3 -m pytest packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py packages/training/scripts/manifest/test_stage_real_eliza1_bundle.py packages/training/scripts/manifest/test_stage_turn_detector.py -q` -> 23 passed
- `python3 -m py_compile packages/training/scripts/manifest/stage_eliza1_bundle_assets.py packages/training/scripts/manifest/stage_real_eliza1_bundle.py packages/training/scripts/publish/stage_base_v1_candidate.py`
- `git diff --check`
- `cmp -s plugins/plugin-local-inference/CLAUDE.md plugins/plugin-local-inference/AGENTS.md` -> 0

## Notes
- This is a fail-closed staging and docs chunk. It does not create or upload the final Gemma ASR GGUFs or checkpoint-matched Gemma MTP drafter GGUFs.
- Remaining Qwen references in validators/platform plans/ASR training scaffolds need follow-up cleanup once the replacement artifact sources are finalized.