### PR TITLE
fix(training): retire Qwen release provenance

### DIFF
--- a/packages/training/scripts/manifest/eliza1_licenses.py
+++ b/packages/training/scripts/manifest/eliza1_licenses.py
@@ -100,14 +100,14 @@ class LicenseAttestation:
         return header + body
 
 
-# The text backbone, the MTP drafter (distilled from the text
-# backbone) and the embedding model are all Apache-2.0 (Qwen3 family on
-# HuggingFace ships the Apache-2.0 LICENSE). Voice artifacts are tiered:
+# The text backbone and the MTP drafter (distilled from the text
+# backbone) are Apache-2.0 Gemma-derived artifacts. Voice artifacts are tiered:
 # 2b/4b/9b ship OmniVoice first with Kokoro fallback, and 27B-class
 # tiers ship OmniVoice only. Kokoro and OmniVoice weights both declare
 # Apache-2.0; omnivoice.cpp C++ glue is MIT but is a code dependency, not a
-# shipped weight. Qwen3-ASR is Apache-2.0. Silero VAD is MIT. openWakeWord
-# code + feature models are Apache-2.0; the pre-trained wake-phrase head is
+# shipped weight. ASR and any dedicated embedding artifact must be recorded
+# from the verified per-bundle source. Silero VAD is MIT. openWakeWord code
+# + feature models are Apache-2.0; the pre-trained wake-phrase head is
 # CC-BY-NC-SA-4.0 (the bundle only ships the head as an opt-in experimental
 # upstream wake-word head — see wakeword-head-plan.md).
 _APACHE = "Apache-2.0.txt"
@@ -118,8 +118,9 @@ _CC_BY_NC_SA = "CC-BY-NC-SA-4.0.txt"
 # Each entry's upstream is the *v1 source repo* recorded in
 # ELIZA_1_RELEASE_ASSET_STATUS.md ("v1 source repos per tier /
 # component"). Text tiers use Gemma 4 E2B / E4B / 12B / 31B.
-# ASR and embedding are deliberate upstream exceptions: they remain published
-# Qwen3-ASR / Qwen3-Embedding artifacts rather than being rebased onto Gemma 4.
+# ASR and dedicated embedding sources are no longer Qwen exceptions; active
+# bundles must record verified Gemma-compatible sources in manifest lineage /
+# provenance before they can become base-v1 releases.
 ATTESTATIONS: Final[tuple[LicenseAttestation, ...]] = (
     LicenseAttestation(
         bundle_file="LICENSE.text",
@@ -170,17 +171,19 @@ ATTESTATIONS: Final[tuple[LicenseAttestation, ...]] = (
     ),
     LicenseAttestation(
         bundle_file="LICENSE.asr",
-        component="ASR (Qwen3-ASR)",
+        component="ASR (Gemma-compatible local ASR)",
         spdx="Apache-2.0",
         text_file=_APACHE,
-        upstream_repo="ggml-org/Qwen3-ASR-0.6B-GGUF / ggml-org/Qwen3-ASR-1.7B-GGUF (base: Qwen/Qwen3-ASR-0.6B / Qwen/Qwen3-ASR-1.7B)",
-        upstream_url="https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF",
-        copyright_holder="Alibaba Cloud (Qwen team) and contributors",
+        upstream_repo="configured per bundle in lineage.asr / provenance.sourceModels.asr; Qwen3-ASR is retired",
+        upstream_url="https://huggingface.co/elizaos/eliza-1",
+        copyright_holder="source-specific; see the bundle manifest and upstream model card",
         note=(
-            "ASR weights are Qwen3-ASR, GGUF-converted upstream. This is a "
-            "deliberate Qwen3 upstream exception to the Gemma 4 text-tier "
-            "lineage; do not rebase it onto Gemma 4. Declared upstream "
-            "license: Apache-2.0."
+            "ASR weights must come from the verified source recorded in the "
+            "bundle manifest. Qwen3-ASR GGUF artifacts are retired for active "
+            "Gemma Eliza-1 bundles; a base-v1 release remains blocked until "
+            "Gemma-compatible ASR model/projector GGUF artifacts are hosted "
+            "and reviewed. Declared upstream license must be verified before "
+            "release."
         ),
     ),
     LicenseAttestation(
@@ -210,7 +213,7 @@ ATTESTATIONS: Final[tuple[LicenseAttestation, ...]] = (
         text_file=_APACHE,
         upstream_repo="elizaos/eliza-1/bundles/<tier> (distilled from the text backbone)",
         upstream_url="https://huggingface.co/elizaos/eliza-1",
-        copyright_holder="elizaOS / Eliza Labs (drafter); Alibaba Cloud (Qwen team) (text lineage)",
+        copyright_holder="elizaOS / Eliza Labs (drafter); Google DeepMind and contributors (text lineage)",
         note=(
             "The MTP drafter is a small student model aligned to the Eliza-1 "
             "text checkpoint (target sha256 recorded in mtp/target-meta.json). "
@@ -222,20 +225,19 @@ ATTESTATIONS: Final[tuple[LicenseAttestation, ...]] = (
     ),
     LicenseAttestation(
         bundle_file="LICENSE.embedding",
-        component="embedding (Qwen3-Embedding)",
+        component="embedding (Gemma-compatible dedicated embedding)",
         spdx="Apache-2.0",
         text_file=_APACHE,
-        upstream_repo="Qwen/Qwen3-Embedding-0.6B-GGUF",
-        upstream_url="https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF",
-        copyright_holder="Alibaba Cloud (Qwen team) and contributors",
+        upstream_repo="configured per bundle in lineage.embedding / provenance.sourceModels.embedding; Qwen3-Embedding is retired",
+        upstream_url="https://huggingface.co/elizaos/eliza-1",
+        copyright_holder="source-specific; see the bundle manifest and upstream model card",
         note=(
-            "Qwen3-Embedding-0.6B (1024-dim, Matryoshka, 32k ctx), shipped as a "
-            "separate embedding/ artifact on tiers that need it. On tiers without "
-            "a separate embedding artifact, the embedding model IS the text backbone "
-            "with --pooling last — no duplicate weights are shipped. "
-            "Declared upstream license: Apache-2.0."
+            "Dedicated embedding artifacts are disabled until a verified "
+            "Gemma-compatible source is configured. Active tiers pool "
+            "embeddings from the text backbone instead of shipping retired "
+            "Qwen3-Embedding weights. Declared upstream license must be "
+            "verified before any dedicated embedding artifact is released."
         ),
-        tiers=("4b",),
     ),
     LicenseAttestation(
         bundle_file="LICENSE.vision",

--- a/packages/training/scripts/manifest/eliza1_manifest.py
+++ b/packages/training/scripts/manifest/eliza1_manifest.py
@@ -121,18 +121,18 @@ ELIZA_1_PROVENANCE_SLOTS: Final[tuple[str, ...]] = (
     "vision",
     "drafter",
 )
-QWEN3_ASR_GGUF_REPOS: Final[tuple[str, ...]] = (
+RETIRED_QWEN3_ASR_GGUF_REPOS: Final[tuple[str, ...]] = (
     "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "ggml-org/Qwen3-ASR-1.7B-GGUF",
 )
-QWEN3_EMBEDDING_GGUF_REPOS: Final[tuple[str, ...]] = (
+RETIRED_QWEN3_EMBEDDING_GGUF_REPOS: Final[tuple[str, ...]] = (
     "Qwen/Qwen3-Embedding-0.6B-GGUF",
     "Qwen/Qwen3-Embedding-4B-GGUF",
     "Qwen/Qwen3-Embedding-8B-GGUF",
 )
-QWEN3_CANONICAL_SOURCE_REPOS_BY_SLOT: Final[Mapping[str, tuple[str, ...]]] = {
-    "asr": QWEN3_ASR_GGUF_REPOS,
-    "embedding": QWEN3_EMBEDDING_GGUF_REPOS,
+RETIRED_QWEN3_SOURCE_REPOS_BY_SLOT: Final[Mapping[str, tuple[str, ...]]] = {
+    "asr": RETIRED_QWEN3_ASR_GGUF_REPOS,
+    "embedding": RETIRED_QWEN3_EMBEDDING_GGUF_REPOS,
 }
 CANONICAL_TEXT_SOURCE_REPOS_BY_TIER: Final[Mapping[str, tuple[str, ...]]] = {
     "2b": (
@@ -1445,16 +1445,30 @@ def canonical_source_repo_error(
 ) -> str | None:
     """Return an error for non-canonical base-v1 source repositories.
 
-    All text tiers (2b/4b/9b/27b) are Gemma 4. ASR and embedding are separate
-    Qwen3 components with their own published GGUF repos. The release pipeline
-    must not invent matching Gemma 4 ASR/embedding names.
+    All text tiers (2b/4b/9b/27b) are Gemma 4. ASR and dedicated embedding
+    release sources are deliberately fail-closed until verified
+    Gemma-compatible GGUF artifacts are configured.
     """
 
     if slot == "text" and isinstance(tier, str):
         allowed = CANONICAL_TEXT_SOURCE_REPOS_BY_TIER.get(tier)
     else:
-        allowed = QWEN3_CANONICAL_SOURCE_REPOS_BY_SLOT.get(slot)
+        allowed = None
     if allowed is None or repo in allowed:
+        if slot in RETIRED_QWEN3_SOURCE_REPOS_BY_SLOT:
+            retired = RETIRED_QWEN3_SOURCE_REPOS_BY_SLOT[slot]
+            if repo in retired or "qwen" in repo.lower():
+                retired_list = ", ".join(retired)
+                return (
+                    f"uses retired Qwen {slot} provenance [{retired_list}], "
+                    f"got {repo!r}; active Gemma base-v1 releases require a "
+                    "verified Gemma-compatible source"
+                )
+            return (
+                f"has no canonical Gemma-compatible {slot} source configured "
+                f"yet, got {repo!r}; keep this bundle as base-v1-candidate "
+                "until release-shaped artifacts are hosted and verified"
+            )
         return None
     allowed_list = ", ".join(allowed)
     return (

--- a/packages/training/scripts/manifest/eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/eliza1_platform_plan.py
@@ -521,11 +521,12 @@ def render_readiness(
         "readiness path.",
         "- Canonical active text tiers are Gemma 4 E2B (`2b`), "
         "Gemma 4 E4B (`4b`), Gemma 4 12B (`9b`), "
-        "and Gemma 4 31B (`27b`). ASR and embedding are real Qwen3 upstream "
-        "exceptions: use the published Qwen3-ASR "
-        "0.6B / 1.7B GGUF repos and Qwen3-Embedding 0.6B / 4B / 8B GGUF "
-        "repos; do not invent gemma-4-ASR, gemma-4-Embedding, "
-        "Qwen3-ASR-0.8B/2B, or Qwen3-Embedding-0.8B/2B repo IDs.",
+        "and Gemma 4 31B (`27b`). Qwen3-ASR and Qwen3-Embedding are retired "
+        "for active Gemma bundles. Base-v1 release readiness remains blocked "
+        "until verified Gemma-compatible ASR GGUF/model-projector artifacts "
+        "and any dedicated embedding artifacts are configured, hosted, and "
+        "recorded in `sourceModels`; base-v1-candidate bundles may record "
+        "explicit experimental sources without becoming default-eligible.",
         "- v1 release shape (`releaseState=base-v1`): the upstream BASE models "
         "— GGUF-converted via the elizaOS/llama.cpp fork and fully "
         "Eliza-optimized (every quant/kernel trick in `packages/inference/AGENTS.md` "

--- a/packages/training/scripts/manifest/hydrate_voice_submodel_assets.py
+++ b/packages/training/scripts/manifest/hydrate_voice_submodel_assets.py
@@ -9,6 +9,8 @@ and patches the local voice manifests with real ``sha256`` / ``sizeBytes``.
 Custom Eliza-only assets remain explicit gaps until their build pipelines
 produce files:
 
+* Gemma-compatible ASR model/projector GGUFs (Qwen3-ASR is retired)
+* dedicated embedding GGUFs (disabled; active bundles pool the text backbone)
 * ``voices/af_same.bin`` (Kokoro same preset)
 * ``presets/voice-preset-same.bin`` (OmniVoice same-voice preset)
 * ``hey-eliza-int8.onnx`` (trained wake-word head)
@@ -48,24 +50,6 @@ ASSETS: Final[tuple[AssetSpec, ...]] = (
         "wespeaker-resnet34-lm.onnx",
         "Wespeaker/wespeaker-voxceleb-resnet34-LM",
         "voxceleb_resnet34_LM.onnx",
-    ),
-    AssetSpec(
-        "embedding",
-        "eliza-1-embedding-q8_0.gguf",
-        "Qwen/Qwen3-Embedding-0.6B-GGUF",
-        "Qwen3-Embedding-0.6B-Q8_0.gguf",
-    ),
-    AssetSpec(
-        "asr",
-        "eliza-1-asr-q8_0.gguf",
-        "ggml-org/Qwen3-ASR-1.7B-GGUF",
-        "Qwen3-ASR-1.7B-Q8_0.gguf",
-    ),
-    AssetSpec(
-        "asr",
-        "eliza-1-asr-mmproj.gguf",
-        "ggml-org/Qwen3-ASR-1.7B-GGUF",
-        "mmproj-Qwen3-ASR-1.7B-Q8_0.gguf",
     ),
     AssetSpec(
         "diarizer",

--- a/packages/training/scripts/manifest/test_eliza1_licenses.py
+++ b/packages/training/scripts/manifest/test_eliza1_licenses.py
@@ -89,15 +89,15 @@ def test_eliza_1_umbrella_is_cc_by_nc_sa() -> None:
     assert "Attribution-NonCommercial-ShareAlike 4.0 International" in rendered
 
 
-def test_qwen3_asr_and_embedding_remain_upstream_exceptions() -> None:
+def test_qwen3_asr_and_embedding_are_retired_sources() -> None:
     asr = next(a for a in ATTESTATIONS if a.bundle_file == "LICENSE.asr")
     embedding = next(a for a in ATTESTATIONS if a.bundle_file == "LICENSE.embedding")
 
-    assert "Qwen3-ASR-0.6B-GGUF" in asr.upstream_repo
-    assert "Qwen3-ASR-1.7B-GGUF" in asr.upstream_repo
-    assert "Qwen3 upstream exception" in asr.render()
+    assert "Qwen3-ASR is retired" in asr.upstream_repo
+    assert "Qwen3-ASR GGUF artifacts are retired" in asr.render()
     assert "Qwen3.5-ASR" not in asr.render()
-    assert "Qwen3-Embedding-0.6B-GGUF" in embedding.upstream_repo
+    assert "Qwen3-Embedding is retired" in embedding.upstream_repo
+    assert "Qwen3-Embedding weights" in embedding.render()
     assert "Qwen3.5-Embedding" not in embedding.render()
 
 

--- a/packages/training/scripts/manifest/test_eliza1_manifest.py
+++ b/packages/training/scripts/manifest/test_eliza1_manifest.py
@@ -712,34 +712,45 @@ def _base_v1_provenance() -> dict:
     }
 
 
-def test_base_v1_manifest_validates_and_is_default_eligible():
+def test_base_v1_manifest_blocks_until_gemma_asr_source_is_configured():
     kwargs = base_kwargs("4b")
     kwargs["provenance"] = _base_v1_provenance()
-    # base-v1 evals are runnable on base weights: text perplexity vs the
-    # upstream GGUF passes, RTF / WER / VAD / mtp / e2e / 30-turn pass.
+    with pytest.raises(Eliza1ManifestError) as exc:
+        build_manifest(**kwargs)
+
+    assert any("retired Qwen asr provenance" in e for e in exc.value.errors)
+
+
+def test_base_v1_candidate_accepts_explicit_non_qwen_asr_source():
+    kwargs = base_kwargs("4b")
+    kwargs["default_eligible"] = False
+    prov = _base_v1_provenance()
+    prov["releaseState"] = "base-v1-candidate"
+    prov["sourceModels"]["asr"] = {
+        "repo": "example/gemma-compatible-asr-gguf",
+        "file": "asr/eliza-1-asr.gguf",
+    }
+    kwargs["provenance"] = prov
     manifest = build_manifest(**kwargs)
-    assert manifest["defaultEligible"] is True
-    assert manifest["provenance"]["releaseState"] == "base-v1"
+    assert manifest["defaultEligible"] is False
+    assert manifest["provenance"]["releaseState"] == "base-v1-candidate"
     assert manifest["provenance"]["finetuned"] is False
-    assert manifest["provenance"]["sourceModels"]["text"]["repo"].endswith(
-        "gemma-4-E4B-GGUF"
-    )
+    assert manifest["provenance"]["sourceModels"]["asr"]["repo"].startswith("example/")
     assert validate_manifest(manifest) == ()
 
 
 def test_base_v1_27b_provenance_requires_gemma4_text_source():
-    kwargs = base_kwargs("27b")
-    prov = _base_v1_provenance()
-    prov["sourceModels"]["text"] = {"repo": "google/gemma-4-31B"}
-    kwargs["provenance"] = prov
-    assert validate_manifest(build_manifest(**kwargs)) == ()
-
-    prov = _base_v1_provenance()
-    prov["sourceModels"]["text"] = {"repo": "Qwen/Qwen3-4B"}
-    kwargs["provenance"] = prov
-    with pytest.raises(Eliza1ManifestError) as exc:
-        build_manifest(**kwargs)
-    assert any("Qwen/Qwen3-4B" in e for e in exc.value.errors)
+    assert (
+        manifest_mod.canonical_source_repo_error(
+            "text", "google/gemma-4-31B", tier="27b"
+        )
+        is None
+    )
+    error = manifest_mod.canonical_source_repo_error(
+        "text", "Qwen/Qwen3-4B", tier="27b"
+    )
+    assert error is not None
+    assert "Qwen/Qwen3-4B" in error
 
 
 def test_base_v1_provenance_requires_finetuned_false():
@@ -764,7 +775,7 @@ def test_base_v1_provenance_requires_coverage_for_shipped_components():
     assert any("provenance.sourceModels.vision" in e for e in exc.value.errors)
 
 
-def test_base_v1_provenance_rejects_fake_qwen_asr_and_embedding_repos():
+def test_base_v1_provenance_rejects_retired_qwen_asr_and_embedding_repos():
     kwargs = base_kwargs("4b")
     kwargs["lineage"] = {
         **kwargs["lineage"],
@@ -777,17 +788,31 @@ def test_base_v1_provenance_rejects_fake_qwen_asr_and_embedding_repos():
     kwargs["embed_mteb_score"] = 0.62
     kwargs["embed_mteb_passed"] = True
     prov = _base_v1_provenance()
-    prov["sourceModels"]["asr"] = {"repo": "ggml-org/Qwen3-ASR-1.8B-GGUF"}
+    prov["sourceModels"]["asr"] = {"repo": "ggml-org/Qwen3-ASR-1.7B-GGUF"}
     prov["sourceModels"]["embedding"] = {
-        "repo": "Qwen/Qwen3-Embedding-1.7B-GGUF"
+        "repo": "Qwen/Qwen3-Embedding-0.6B-GGUF"
     }
     kwargs["provenance"] = prov
 
     with pytest.raises(Eliza1ManifestError) as exc:
         build_manifest(**kwargs)
 
-    assert any("Qwen3-ASR-1.8B-GGUF" in e for e in exc.value.errors)
-    assert any("Qwen3-Embedding-1.7B-GGUF" in e for e in exc.value.errors)
+    assert any("retired Qwen asr provenance" in e for e in exc.value.errors)
+    assert any("retired Qwen embedding provenance" in e for e in exc.value.errors)
+
+
+def test_base_v1_provenance_rejects_unconfigured_gemma_asr_repo():
+    kwargs = base_kwargs("4b")
+    prov = _base_v1_provenance()
+    prov["sourceModels"]["asr"] = {
+        "repo": "example/gemma-compatible-asr-gguf"
+    }
+    kwargs["provenance"] = prov
+
+    with pytest.raises(Eliza1ManifestError) as exc:
+        build_manifest(**kwargs)
+
+    assert any("no canonical Gemma-compatible asr source" in e for e in exc.value.errors)
 
 
 def test_provenance_rejects_unknown_release_state():

--- a/packages/training/scripts/manifest/test_eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/test_eliza1_platform_plan.py
@@ -124,8 +124,8 @@ def test_readiness_mentions_vad_native_gguf_caveat() -> None:
     assert "Gemma 4 E2B (`2b`)" in text
     assert "Gemma 4 E4B (`4b`)" in text
     assert "Gemma 4 12B (`9b`)" in text
-    assert "published Qwen3-ASR 0.6B / 1.7B GGUF repos" in text
-    assert "Qwen3-Embedding 0.6B / 4B / 8B GGUF repos" in text
+    assert "Qwen3-ASR and Qwen3-Embedding are retired" in text
+    assert "Base-v1 release readiness remains blocked" in text
     assert "not evaluated in plan-only mode" in text
     assert "VAD latency/boundary/endpoint/false-barge-in" in text
     assert "Release evidence must use real final hashes" in text
@@ -175,7 +175,7 @@ def test_release_status_blockers_detect_local_standin_evidence(tmp_path: Path) -
     assert "Publish-blocking status:" in text
 
 
-def test_release_status_blockers_accept_base_v1_uploaded_evidence(
+def test_release_status_blockers_reject_base_v1_retired_qwen_sources(
     tmp_path: Path,
 ) -> None:
     """A `base-v1` bundle (upstream base models, GGUF + fully optimized,
@@ -245,7 +245,10 @@ def test_release_status_blockers_accept_base_v1_uploaded_evidence(
         )
     )
     blockers = release_status_blockers(tmp_path / "bundles", plan)
-    assert blockers["2b"] == []
+    assert any("retired Qwen asr provenance" in item for item in blockers["2b"])
+    assert any(
+        "retired Qwen embedding provenance" in item for item in blockers["2b"]
+    )
 
 
 def test_release_status_blockers_rejects_incomplete_uploaded_paths(
@@ -361,7 +364,7 @@ def test_release_status_blockers_base_v1_blocks_pending_upload(
     assert any("hf.uploadEvidence missing" in item for item in blockers["2b"])
 
 
-def test_release_status_blockers_base_v1_rejects_fake_qwen_component_repos(
+def test_release_status_blockers_base_v1_rejects_qwen_component_repos(
     tmp_path: Path,
 ) -> None:
     plan = build_plan()
@@ -399,8 +402,10 @@ def test_release_status_blockers_base_v1_rejects_fake_qwen_component_repos(
 
     blockers = release_status_blockers(tmp_path / "bundles", plan)
 
-    assert any("Qwen3-ASR-2B-GGUF" in item for item in blockers["2b"])
-    assert any("Qwen3-Embedding-2B-GGUF" in item for item in blockers["2b"])
+    assert any("retired Qwen asr provenance" in item for item in blockers["2b"])
+    assert any(
+        "retired Qwen embedding provenance" in item for item in blockers["2b"]
+    )
 
 
 def test_release_status_blockers_base_v1_requires_finetuned_false(

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -1030,7 +1030,7 @@ def test_final_release_state_requires_hf_upload_evidence(tmp_path: Path) -> None
     assert rc == EXIT_RELEASE_EVIDENCE_FAIL
 
 
-def test_base_v1_release_evidence_is_allowed_and_writes_manifest_provenance(
+def test_base_v1_release_evidence_rejects_retired_qwen_asr_provenance(
     tmp_path: Path,
 ) -> None:
     bundle = _build_fixture_bundle(tmp_path, release_state="base-v1")
@@ -1043,16 +1043,7 @@ def test_base_v1_release_evidence_is_allowed_and_writes_manifest_provenance(
 
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
 
-    assert rc == EXIT_OK
-    manifest = json.loads((bundle / "eliza-1.manifest.json").read_text())
-    assert manifest["provenance"]["releaseState"] == "base-v1"
-    assert manifest["provenance"]["finetuned"] is False
-    assert manifest["provenance"]["sourceModels"]["text"]["repo"] == (
-        "unsloth/gemma-4-E4B-GGUF"
-    )
-    assert manifest["provenance"]["sourceModels"]["vision"]["repo"] == (
-        "unsloth/gemma-4-E4B-GGUF"
-    )
+    assert rc == EXIT_RELEASE_EVIDENCE_FAIL
 
 
 def test_base_v1_release_evidence_requires_source_models(tmp_path: Path) -> None:
@@ -1069,7 +1060,7 @@ def test_base_v1_release_evidence_requires_source_models(tmp_path: Path) -> None
     assert rc == EXIT_RELEASE_EVIDENCE_FAIL
 
 
-def test_base_v1_release_evidence_rejects_fake_qwen_component_repos(
+def test_base_v1_release_evidence_rejects_qwen_component_repos(
     tmp_path: Path,
 ) -> None:
     bundle = _build_fixture_bundle(tmp_path, release_state="base-v1")
@@ -1359,7 +1350,7 @@ def test_finalize_release_evidence_sets_size_first_from_upload_evidence(
     assert release["final"]["sizeFirstRepoIds"] is True
 
 
-def test_real_base_v1_publish_preserves_release_state(
+def test_real_base_v1_publish_rejects_retired_qwen_asr_provenance(
     tmp_path: Path, monkeypatch
 ) -> None:
     import scripts.publish.orchestrator as orchestrator  # noqa: PLC0415
@@ -1395,11 +1386,7 @@ def test_real_base_v1_publish_preserves_release_state(
 
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=False))
 
-    assert rc == EXIT_OK
-    release = json.loads((bundle / "evidence" / "release.json").read_text())
-    assert release["releaseState"] == "base-v1"
-    assert release["hf"]["status"] == "uploaded"
-    assert release["hf"]["uploadEvidence"]["commit"] == "basev1"
+    assert rc == EXIT_RELEASE_EVIDENCE_FAIL
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make base-v1 release provenance fail closed for ASR and dedicated embedding sources until verified Gemma-compatible artifacts are configured
- explicitly reject retired Qwen3-ASR / Qwen3-Embedding provenance in manifest validation and platform release-readiness blockers
- update release readiness and license attestation text so Qwen ASR/embedding are no longer documented as canonical upstream exceptions
- stop `hydrate_voice_submodel_assets.py` from actively downloading retired Qwen ASR/embedding payloads
- update orchestrator/platform/manifest/license tests around the new base-v1 blocker behavior

Refs #9588
Refs #9583

## Evidence
- `git fetch origin develop && git rebase origin/develop --autostash`
- `bun install`
- `bun run verify` -> 515 successful / 515 total
- `python3 -m pytest packages/training/scripts/manifest/test_eliza1_manifest.py packages/training/scripts/manifest/test_eliza1_platform_plan.py packages/training/scripts/manifest/test_eliza1_licenses.py -q`
- `python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q -k "base_v1_release_evidence or real_base_v1"`
- `python3 -m py_compile packages/training/scripts/manifest/eliza1_manifest.py packages/training/scripts/manifest/eliza1_platform_plan.py packages/training/scripts/manifest/eliza1_licenses.py packages/training/scripts/manifest/hydrate_voice_submodel_assets.py packages/training/scripts/publish/test_orchestrator.py`
- `git diff --check`

## Notes
- This does not claim Gemma ASR/MTP artifacts exist yet. It prevents base-v1 release readiness from passing on Qwen or arbitrary replacement ASR/embedding repos.
- Candidate/non-final staging can still record explicit experimental ASR sources while the hosted release-shaped artifacts are produced and verified.