### PR TITLE
fix(scripts): retire riscv whisper smoke lane

### DIFF
--- a/scripts/README.riscv64-smoke.md
+++ b/scripts/README.riscv64-smoke.md
@@ -52,11 +52,6 @@ The smoke harness writes a machine-readable report to
   `plugins/plugin-local-inference/native/build-omnivoice.mjs` with
   `OMNIVOICE_TARGET=linux-riscv64-cpu`.
 
-- **`libwhisper.so` + `libwhisper_eliza_adapter.so`** —
-  `plugins/plugin-local-inference/native/build-whisper.mjs` with
-  `WHISPER_TARGET=linux-riscv64-cpu` (Task 25 — replaces the
-  OpenVINO-Whisper path that had no riscv64 backend).
-
 - **`libsigsys-handler.so`** for riscv64 — the Bun seccomp shim,
   built by `packages/app-core/scripts/aosp/compile-shim.mjs --abi
   riscv64` into `~/.cache/eliza-android-agent/seccomp-shim/riscv64/`.

--- a/scripts/build-riscv64-artifacts.sh
+++ b/scripts/build-riscv64-artifacts.sh
@@ -14,7 +14,7 @@
 #   - zig 0.14+        (Zig toolchain; provides riscv64-linux-musl — every
 #                       cross-build here is zig/musl, so no Android NDK is needed)
 #   - cmake 3.21+      (drives every package's cross-build)
-#   - node 20+         (drives compile-libllama.mjs / build-omnivoice.mjs / build-whisper.mjs)
+#   - node 20+         (drives compile-libllama.mjs / build-omnivoice.mjs)
 #
 # Usage:
 #   ELIZA_RISCV64_SMOKE=1 bash scripts/build-riscv64-artifacts.sh
@@ -237,29 +237,9 @@ else
     fi
 fi
 
-# ── libwhisper (Task 25) ─────────────────────────────────────────────
-echo
-echo "── Step 4: libwhisper + libwhisper_eliza_adapter ──"
-BUILD_WHISPER="$repo_root/plugins/plugin-local-inference/native/build-whisper.mjs"
-if [ ! -f "$BUILD_WHISPER" ]; then
-    echo "  ✗ build-whisper.mjs missing at $BUILD_WHISPER"
-    FAIL_N=$((FAIL_N+1))
-else
-    wh_sentinel="$repo_root/plugins/plugin-local-inference/native/build-whisper-linux-riscv64-cpu/libwhisper_eliza_adapter.so"
-    if should_build "$wh_sentinel"; then
-        echo "→ Building libwhisper (linux-riscv64-cpu) …"
-        if WHISPER_TARGET=linux-riscv64-cpu "$NODE_BIN" "$BUILD_WHISPER" >"$repo_root/build/libwhisper-linux-riscv64.log" 2>&1; then
-            echo "  ✓ libwhisper linux-riscv64-cpu"
-        else
-            echo "  ✗ libwhisper linux-riscv64-cpu (see build/libwhisper-linux-riscv64.log)"
-            FAIL_N=$((FAIL_N+1))
-        fi
-    fi
-fi
-
 # ── sigsys-handler-riscv64 ───────────────────────────────────────────
 echo
-echo "── Step 5: libsigsys-handler-riscv64 (Bun seccomp shim) ──"
+echo "── Step 4: libsigsys-handler-riscv64 (Bun seccomp shim) ──"
 COMPILE_SHIM="$repo_root/packages/app-core/scripts/aosp/compile-shim.mjs"
 if [ ! -f "$COMPILE_SHIM" ]; then
     echo "  ✗ compile-shim.mjs missing at $COMPILE_SHIM"

--- a/scripts/check-riscv64-artifacts.sh
+++ b/scripts/check-riscv64-artifacts.sh
@@ -3,8 +3,8 @@
 # native artifact this repo cross-compiles.
 #
 # One-shot harness: walks the known cross-build outputs (native plugins
-# + libllama / libggml family + libomnivoice + libwhisper_eliza_adapter
-# + libsigsys-handler-riscv64), confirms each is an ELF UCB RISC-V
+# + libllama / libggml family + libomnivoice + libsigsys-handler-riscv64),
+# confirms each is an ELF UCB RISC-V
 # 64-bit double-float-ABI object, and exercises every executable smoke
 # under qemu-riscv64-static. Shared libraries are dlopen-verified via a
 # tiny C harness (also run under QEMU).
@@ -144,7 +144,7 @@ echo "[check-riscv64-artifacts] qemu_bin=${QEMU_BIN:-<elf-tag only>}  timeout=${
 is_riscv64_elf() {
     local f="$1"
     local info
-    # `-L` dereferences symlinks (libwhisper.so → libwhisper.so.1, etc.).
+    # `-L` dereferences symlinks (libfoo.so → libfoo.so.1, etc.).
     info="$(file -L -b "$f" 2>/dev/null || true)"
     case "$info" in
         *"UCB RISC-V"*"double-float ABI"*) return 0;;
@@ -391,13 +391,6 @@ OMNIVOICE_SEARCH=(
     "plugins/plugin-local-inference/native/build-omnivoice-android-riscv64-cpu/libomnivoice.so"
 )
 
-WHISPER_SEARCH=(
-    "plugins/plugin-local-inference/native/build-whisper-linux-riscv64-cpu/libwhisper_eliza_adapter.so"
-    "plugins/plugin-local-inference/native/build-whisper-linux-riscv64-cpu/whisper-cpp-build/src/libwhisper.so"
-    "plugins/plugin-local-inference/native/build-whisper-android-riscv64-cpu/libwhisper_eliza_adapter.so"
-    "plugins/plugin-local-inference/native/build-whisper-android-riscv64-cpu/whisper-cpp-build/src/libwhisper.so"
-)
-
 SIGSYS_SEARCH=(
     "${HOME}/.cache/eliza-android-agent/seccomp-shim/riscv64/libsigsys-handler.so"
 )
@@ -441,17 +434,6 @@ if [ -n "$o_found" ]; then
 else
     emit_record "$repo_root/${OMNIVOICE_SEARCH[0]}" "shared-library" "SKIP" \
         "not built; run \`OMNIVOICE_TARGET=linux-riscv64-cpu node plugins/plugin-local-inference/native/build-omnivoice.mjs\`" "0"
-fi
-
-echo
-echo "── libwhisper + libwhisper_eliza_adapter ──"
-w_found=""
-for p in "${WHISPER_SEARCH[@]}"; do
-    if [ -e "$repo_root/$p" ]; then w_found="$repo_root/$p"; verify_artifact "$w_found"; fi
-done
-if [ -z "$w_found" ]; then
-    emit_record "$repo_root/${WHISPER_SEARCH[0]}" "shared-library" "SKIP" \
-        "not built; run \`WHISPER_TARGET=linux-riscv64-cpu node plugins/plugin-local-inference/native/build-whisper.mjs\`" "0"
 fi
 
 echo


### PR DESCRIPTION
## Summary
- remove the retired `libwhisper` / `libwhisper_eliza_adapter` lane from the RISC-V artifact build driver
- remove the matching RISC-V verification inventory and skip hint from the smoke harness
- update the RISC-V smoke README so it only documents the currently active native plugin, MTP llama.cpp, OmniVoice, and seccomp shim artifacts

This is part of the Gemma migration cleanup: the local Whisper ASR path is retired, so RISC-V smoke should not keep advertising or trying to build its old adapter.

## Evidence
- `git fetch origin develop && git rebase origin/develop --autostash`
- `bun install`
- `bash -n scripts/build-riscv64-artifacts.sh`
- `bash -n scripts/check-riscv64-artifacts.sh`
- `bash scripts/build-riscv64-artifacts.sh` with `ELIZA_RISCV64_SMOKE` unset -> clean no-op
- `bash scripts/check-riscv64-artifacts.sh --out /tmp/eliza-riscv64-artifacts-skip.json` with `ELIZA_RISCV64_SMOKE` unset -> clean SKIP report
- `rg -n "build-whisper|libwhisper|WHISPER_TARGET|whisper_eliza|Whisper path|OpenVINO-Whisper" scripts/build-riscv64-artifacts.sh scripts/check-riscv64-artifacts.sh scripts/README.riscv64-smoke.md` -> no matches
- `git diff --check`
- `bun run verify` -> 515/515 successful

## Issue Evidence
- UI screenshots/video: N/A, script/doc cleanup only
- Real-LLM trajectory: N/A, no prompt/model behavior changed in this chunk
- Backend/frontend logs: N/A, no runtime server/client path exercised

Refs #9588
Refs #9583
