### PR TITLE
docs: retire stale desktop ASR docs

### DIFF
--- a/packages/docs/apps/dashboard/talk-mode.md
+++ b/packages/docs/apps/dashboard/talk-mode.md
@@ -1,10 +1,10 @@
 ---
 title: Talk Mode
 sidebarTitle: Talk Mode
-description: Full voice conversation with your Eliza agent using offline speech recognition, text-to-speech, and voice activity detection.
+description: Full voice conversation with your Eliza agent using renderer speech recognition, text-to-speech, and voice activity detection.
 ---
 
-Talk Mode provides a full voice conversation pipeline for the Eliza desktop app. It combines offline speech-to-text (Whisper.cpp), streaming text-to-speech (ElevenLabs), and voice activity detection into a seamless hands-free experience.
+Talk Mode provides a full voice conversation pipeline for the Eliza desktop app. The current Electrobun bridge uses renderer speech recognition for speech-to-text, streaming text-to-speech through ElevenLabs when configured, and voice activity detection for turn boundaries.
 
 <Info>
 Talk Mode is a native desktop feature. It requires the Electrobun desktop app — it is not available in the web dashboard or mobile app.
@@ -13,7 +13,7 @@ Talk Mode is a native desktop feature. It requires the Electrobun desktop app �
 ## How It Works
 
 1. **You speak** — the microphone captures audio and streams PCM samples to the main process
-2. **Speech recognition** — Whisper.cpp transcribes your speech to text offline
+2. **Speech recognition** — the desktop bridge delegates transcription to the renderer speech recognizer
 3. **Agent processes** — the transcript is sent to the agent as a message
 4. **Agent speaks** — the response is converted to speech via ElevenLabs and played back
 
@@ -38,11 +38,11 @@ Talk Mode is configured through the `TalkModeConfig` interface:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `engine` | string | `"whisper"` | `"whisper"` for offline Whisper.cpp, `"web"` for browser Web Speech API |
-| `modelSize` | string | `"base"` | Whisper model size: `"tiny"`, `"base"`, `"small"`, `"medium"`, `"large"` |
+| `engine` | string | `"web"` | Active desktop speech recognizer. The current Electrobun RPC schema supports `"web"`. |
+| `modelSize` | string | `"base"` | Legacy compatibility field; ignored by the Web Speech path |
 | `language` | string | — | Optional language code for transcription |
 
-Larger Whisper models are more accurate but require more memory and processing time. If Whisper is unavailable, Talk Mode falls back to the Web Speech API automatically.
+Local-inference ASR is configured separately through the voice/local models path and requires an explicitly verified Gemma ASR bundle.
 
 ### Text-to-Speech (TTS)
 
@@ -83,19 +83,16 @@ Talk Mode communicates between the renderer and main process via IPC:
 | `talkmode:getState` | Query current state |
 | `talkmode:isEnabled` | Check if Talk Mode is available |
 | `talkmode:updateConfig` | Update configuration |
-| `talkmode:isWhisperAvailable` | Check Whisper.cpp availability |
-| `talkmode:getWhisperInfo` | Get Whisper model info |
+| `talkmode:audioChunk` | Submit a base64-encoded audio chunk while listening |
 
 ### Events (Main → Renderer)
 
 | Channel | Description |
 |---------|-------------|
 | `talkmode:transcript` | Transcription result with `isFinal` flag |
-| `talkmode:speaking` | Speaking state changed |
 | `talkmode:speakComplete` | Playback finished |
-| `talkmode:audioChunk` | Base64-encoded audio chunk for playback |
-| `talkmode:audioComplete` | All audio chunks sent |
-| `talkmode:stateChange` | State machine transition |
+| `talkmode:audioChunkPush` | Base64-encoded audio chunk for playback or renderer-side recognition |
+| `talkmode:stateChanged` | State machine transition |
 | `talkmode:error` | Error with diagnostic `code` |
 
 ## Related

--- a/packages/docs/apps/desktop.md
+++ b/packages/docs/apps/desktop.md
@@ -223,8 +223,8 @@ Discovered gateways include metadata from TXT records: stable ID, TLS configurat
 Full conversation mode via the `TalkModeManager` class, integrating speech-to-text (STT) and text-to-speech (TTS).
 
 **STT Engines:**
-- **Whisper** (default) -- Offline speech recognition routed through `@elizaos/plugin-local-inference` (Qwen3-ASR via libelizainference / llama.cpp). Supports streaming transcription.
-- **Web Speech API** -- Falls back to the browser's built-in speech recognition when Whisper is unavailable.
+- **Web Speech API** (desktop default) -- The Electrobun native module forwards audio chunks to the renderer, where the browser speech recognizer handles transcription.
+- **Local-inference ASR** -- Available only when a verified Gemma ASR bundle is explicitly configured for `@elizaos/plugin-local-inference` through the fused `libelizainference` path.
 
 **TTS Engines:**
 - **ElevenLabs** -- High-quality streaming TTS via the ElevenLabs API. Configurable voice ID, model ID (default: `eleven_v3`), stability, similarity boost, and speed. Audio chunks are streamed to the renderer as base64-encoded data.
@@ -244,13 +244,13 @@ Audio data flows from the renderer to the main process via `talkmode:audioChunk`
 
 ### Swabble (Voice Wake)
 
-Wake word detection for hands-free activation via the `SwabbleManager` class. Uses Whisper for continuous speech transcription combined with a `WakeWordGate` that performs timing-based wake word matching.
+Wake word detection for hands-free activation via the `SwabbleManager` class. The Electrobun native module forwards microphone chunks to the renderer, where Web Speech transcription is combined with a `WakeWordGate` that performs timing-based wake word matching.
 
 **Configuration:**
 - `triggers` -- Array of wake word phrases (e.g., `["eliza", "hey eliza"]`)
 - `minPostTriggerGap` -- Minimum pause (seconds) after the wake word before the command starts (default: 0.45s)
 - `minCommandLength` -- Minimum number of words in the command after the wake word (default: 1)
-- `modelSize` -- Whisper model size to use
+- `modelSize` -- Legacy compatibility field; ignored by the Web Speech desktop path
 
 The wake word gate includes **fuzzy matching** for common transcription variations (e.g., "melody" matches "eliza", "okay" matches "ok").
 

--- a/packages/docs/apps/desktop/native-modules.md
+++ b/packages/docs/apps/desktop/native-modules.md
@@ -213,9 +213,9 @@ Scans the local network for `_eliza._tcp` services using mDNS/Bonjour and surfac
 
 ## Talk Mode
 
-**Class**: `TalkModeManager` | **Channels**: 10 invoke, 7 events
+**Class**: `TalkModeManager` | **Channels**: 9 invoke, 5 events
 
-Manages the full speech pipeline: speech-to-text via Whisper or the Web Speech API, and text-to-speech via ElevenLabs or the system TTS engine.
+Manages the full speech pipeline: speech-to-text through renderer Web Speech, and text-to-speech via ElevenLabs or the system TTS engine.
 
 | Channel | Direction | Description |
 |---|---|---|
@@ -227,23 +227,20 @@ Manages the full speech pipeline: speech-to-text via Whisper or the Web Speech A
 | `talkmode:getState` | invoke | Returns the current Talk Mode state object. |
 | `talkmode:isEnabled` | invoke | Returns `true` if Talk Mode is enabled in settings. |
 | `talkmode:updateConfig` | invoke | Updates Talk Mode configuration at runtime. |
-| `talkmode:isWhisperAvailable` | invoke | Returns `true` if the local Whisper model is available. |
-| `talkmode:getWhisperInfo` | invoke | Returns metadata about the loaded Whisper model. |
+| `talkmode:audioChunk` | invoke | Accepts a base64-encoded Float32 PCM chunk while listening. |
 | `talkmode:transcript` | event | Pushed when a speech-to-text transcript is ready. |
-| `talkmode:speaking` | event | Pushed when TTS playback starts. |
 | `talkmode:speakComplete` | event | Pushed when TTS playback finishes. |
-| `talkmode:audioChunk` | event | Pushed with raw PCM audio chunks during recording. |
-| `talkmode:audioComplete` | event | Pushed when audio recording ends. |
-| `talkmode:stateChange` | event | Pushed whenever the Talk Mode state changes. |
+| `talkmode:audioChunkPush` | event | Pushed with base64 audio chunks for playback or renderer-side recognition. |
+| `talkmode:stateChanged` | event | Pushed whenever the Talk Mode state changes. |
 | `talkmode:error` | event | Pushed when a speech pipeline error occurs. |
 
 ---
 
 ## Swabble
 
-**Class**: `SwabbleManager` | **Channels**: 6 invoke, 3 events
+**Class**: `SwabbleManager` | **Channels**: 6 invoke, 5 events
 
-Runs continuous wake-word detection in the background using fuzzy phrase matching. Whisper is used for transcription when available.
+Runs continuous wake-word detection in the background using fuzzy phrase matching. The desktop native module forwards audio chunks to renderer-side speech recognition.
 
 | Channel | Direction | Description |
 |---|---|---|
@@ -252,10 +249,12 @@ Runs continuous wake-word detection in the background using fuzzy phrase matchin
 | `swabble:isListening` | invoke | Returns `true` if the listener is active. |
 | `swabble:getConfig` | invoke | Returns the current wake-word configuration. |
 | `swabble:updateConfig` | invoke | Updates the wake-word phrases and sensitivity at runtime. |
-| `swabble:isWhisperAvailable` | invoke | Returns `true` if Whisper is available for transcription. |
+| `swabble:audioChunk` | invoke | Accepts a base64-encoded Float32 PCM chunk while listening. |
 | `swabble:stateChange` | event | Pushed when the listener starts or stops. |
 | `swabble:transcript` | event | Pushed with the transcribed phrase that was detected. |
 | `swabble:wakeWord` | event | Pushed when a configured wake-word is matched. |
+| `swabble:error` | event | Pushed when speech recognition or wake-word detection fails. |
+| `swabble:audioChunkPush` | event | Pushed with base64 audio chunks for renderer-side recognition. |
 
 ---
 

--- a/packages/docs/apps/mobile.md
+++ b/packages/docs/apps/mobile.md
@@ -275,7 +275,7 @@ Connects the mobile app to a Eliza agent running elsewhere on the network.
 Voice wake-word detection for hands-free activation.
 
 - **Wake words:** Configurable trigger words (e.g., `["eliza"]`) with post-trigger gap detection and minimum command length.
-- **Continuous listening:** Only available on native platforms (iOS/Android). Uses the native Speech framework on iOS, SpeechRecognizer on Android, and Whisper.cpp on desktop.
+- **Continuous listening:** Available on native mobile platforms and desktop app surfaces. Uses the native Speech framework on iOS and `SpeechRecognizer` on Android; desktop and web surfaces use Web Speech or explicitly configured local-inference ASR.
 - **Audio levels:** Streams real-time audio level events for visualization.
 - **Transcript events:** Provides speech segments with timing information and confidence scores.
 - On web, falls back to the Web Speech API (`SpeechRecognition` / `webkitSpeechRecognition`) if available.
@@ -284,7 +284,7 @@ Voice wake-word detection for hands-free activation.
 
 Full speech pipeline: speech-to-text, chat with agent, text-to-speech response.
 
-- **STT engines:** Native speech recognition or Whisper (configurable model sizes: tiny, base, small, medium, large).
+- **STT engines:** Native speech recognition on mobile, Web Speech on web/desktop, or local-inference ASR when a verified Gemma bundle is configured.
 - **ElevenLabs TTS:** Available on all platforms with configurable voice ID, model, speed, stability, similarity boost, style exaggeration, language, and latency tier.
 - **System TTS:** Native speech synthesis on iOS/Android; Web Speech Synthesis API on web. Used as automatic fallback if ElevenLabs is unavailable.
 - **Interrupt on speech:** Stops TTS playback when the user starts speaking.

--- a/packages/docs/apps/mobile/capacitor-plugins.md
+++ b/packages/docs/apps/mobile/capacitor-plugins.md
@@ -69,7 +69,7 @@ WebSocket RPC connection to a Eliza gateway with mDNS/Bonjour discovery of local
 
 ## @elizaos/capacitor-swabble
 
-Continuous background wake-word detection. Uses the native Speech framework on iOS, `SpeechRecognizer` on Android, or Whisper.cpp on desktop. Falls back to the Web Speech API in browser environments.
+Continuous background wake-word detection. Uses the native Speech framework on iOS and `SpeechRecognizer` on Android. Desktop and browser environments use Web Speech or explicitly configured local-inference ASR.
 
 ### Methods
 
@@ -99,7 +99,7 @@ Continuous background wake-word detection. Uses the native Speech framework on i
 
 ## @elizaos/capacitor-talkmode
 
-Full speech pipeline integrating STT, chat relay to the agent, and TTS output. STT uses native recognition or Whisper; TTS uses ElevenLabs streaming or native speech synthesis. The pipeline is stateful — only one phase is active at a time.
+Full speech pipeline integrating STT, chat relay to the agent, and TTS output. STT uses native recognition on mobile, Web Speech on web/desktop, or local-inference ASR when a verified Gemma bundle is configured; TTS uses ElevenLabs streaming or native speech synthesis. The pipeline is stateful — only one phase is active at a time.
 
 ### Methods
 

--- a/packages/docs/voice-e2e-gap-analysis.md
+++ b/packages/docs/voice-e2e-gap-analysis.md
@@ -114,8 +114,8 @@ real speaker identity, and are not valid.
 
 | Engine | Model Files | Status |
 |--------|------------|--------|
-| Eliza-1 ASR (Qwen3-based) | `eliza-1-asr.gguf` + `eliza-1-asr-mmproj.gguf` in 9b/27b bundles | ✅ Installed, loads in llama-server |
-| Whisper.cpp | External whisper model | ✅ FFI adapter built |
+| Gemma ASR | `eliza-1-asr.gguf` + `eliza-1-asr-mmproj.gguf` from a verified Gemma source | ⚠️ Pending explicit hosted source and bundle staging |
+| Legacy external ASR backend | External model | Retired; current desktop paths use Web Speech or fused local-inference ASR |
 
 ### 1.3 Voice Processing Models
 


### PR DESCRIPTION
## Summary
- replace stale desktop/mobile docs that described bundled Whisper/Qwen ASR as active
- align Talk Mode and Swabble docs with the current Electrobun Web Speech/audio passthrough path
- update the voice gap analysis so Gemma ASR remains an explicit verified-source/staging blocker

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run --cwd packages/docs test` (15/15 passed)
- `bun run verify` (515/515 passed)
- `git diff --check`
- `rg -n "Qwen|Qwen3|Whisper|whisper|whisper\.cpp|isWhisperAvailable|getWhisperInfo" packages/docs/apps packages/docs/voice-e2e-gap-analysis.md` (no matches)

Refs #9588
Refs #9583
