### PR TITLE
fix(native-talkmode): retire whisper stt config

### DIFF
--- a/plugins/plugin-native-talkmode/AGENTS.md
+++ b/plugins/plugin-native-talkmode/AGENTS.md
@@ -76,8 +76,8 @@ Config is passed at runtime via `TalkMode.start({ config })` or `TalkMode.update
 | `tts.outputFormat` | `string` | e.g. `"pcm_24000"`, `"mp3_44100"` |
 | `tts.interruptOnSpeech` | `boolean` | Stop TTS when mic detects speech |
 | `tts.voiceAliases` | `Record<string,string>` | Alias → voiceId mapping |
-| `stt.engine` | `"whisper"` \| `"web"` | STT backend preference |
-| `stt.modelSize` | `"tiny"` \| `"base"` \| `"small"` \| `"medium"` \| `"large"` | Whisper model |
+| `stt.engine` | `"native"` \| `"web"` | STT backend preference |
+| `stt.modelSize` | `"tiny"` \| `"base"` \| `"small"` \| `"medium"` \| `"large"` | Legacy compatibility field; ignored by current recognizers |
 | `stt.language` | `string` | BCP-47 language code (e.g. `"en"`) |
 | `stt.sampleRate` | `number` | Audio sample rate in Hz (default 16000) |
 | `silenceWindowMs` | `number` | Silence gap before finalising transcript (ms) |

--- a/plugins/plugin-native-talkmode/CLAUDE.md
+++ b/plugins/plugin-native-talkmode/CLAUDE.md
@@ -76,8 +76,8 @@ Config is passed at runtime via `TalkMode.start({ config })` or `TalkMode.update
 | `tts.outputFormat` | `string` | e.g. `"pcm_24000"`, `"mp3_44100"` |
 | `tts.interruptOnSpeech` | `boolean` | Stop TTS when mic detects speech |
 | `tts.voiceAliases` | `Record<string,string>` | Alias → voiceId mapping |
-| `stt.engine` | `"whisper"` \| `"web"` | STT backend preference |
-| `stt.modelSize` | `"tiny"` \| `"base"` \| `"small"` \| `"medium"` \| `"large"` | Whisper model |
+| `stt.engine` | `"native"` \| `"web"` | STT backend preference |
+| `stt.modelSize` | `"tiny"` \| `"base"` \| `"small"` \| `"medium"` \| `"large"` | Legacy compatibility field; ignored by current recognizers |
 | `stt.language` | `string` | BCP-47 language code (e.g. `"en"`) |
 | `stt.sampleRate` | `number` | Audio sample rate in Hz (default 16000) |
 | `silenceWindowMs` | `number` | Silence gap before finalising transcript (ms) |

--- a/plugins/plugin-native-talkmode/README.md
+++ b/plugins/plugin-native-talkmode/README.md
@@ -112,8 +112,8 @@ All config is passed to `start()` or `updateConfig()` — no process env vars ar
 | `tts.outputFormat` | No | e.g. `"pcm_24000"`, `"mp3_44100"` |
 | `tts.interruptOnSpeech` | No | Cut TTS when mic detects speech |
 | `tts.voiceAliases` | No | Name → voiceId mapping |
-| `stt.engine` | No | `"whisper"` or `"web"` |
-| `stt.modelSize` | No | Whisper model size |
+| `stt.engine` | No | `"native"` or `"web"` |
+| `stt.modelSize` | No | Legacy compatibility field; ignored by current recognizers |
 | `stt.language` | No | BCP-47 language code |
 | `stt.sampleRate` | No | Hz, default 16000 |
 | `silenceWindowMs` | No | Silence gap before finalising transcript |

--- a/plugins/plugin-native-talkmode/android/AUDIO_FRAMES.md
+++ b/plugins/plugin-native-talkmode/android/AUDIO_FRAMES.md
@@ -19,7 +19,7 @@ parallel `AudioRecord` while `SpeechRecognizer` holds the mic does not get the
 mic — `AudioRecord` either fails to reach `RECORDSTATE_RECORDING` or reads
 silence. The three options from the brief:
 
-- (a) AudioRecord-only mode replacing SpeechRecognizer (PCM → whisper/local ASR).
+- (a) AudioRecord-only mode replacing SpeechRecognizer (PCM -> local-inference ASR).
 - (b) Coexistence, if the device permits it.
 - (c) A distinct "diarization mode" that suspends SpeechRecognizer while
   AudioRecord runs.
@@ -36,9 +36,9 @@ Coexistence (b) was **measured infeasible on the Pixel 9a** (see verification):
 `AudioRecord` reaches `RECORDING` and frames flow only AFTER STT is suspended;
 the design proactively suspends rather than relying on concurrent capture.
 
-Option (a) — AudioRecord-only + whisper transcription — is a strict superset of
+Option (a) — AudioRecord-only + local transcription — is a strict superset of
 this PCM capture (the PCM produced here is exactly what a local-ASR consumer
-would feed whisper). It is left to the JS consumer: this layer's job is to
+would feed to local ASR). It is left to the JS consumer: this layer's job is to
 deliver verified PCM frames; transcription backend choice lives above it.
 
 ## API (added)

--- a/plugins/plugin-native-talkmode/src/definitions.ts
+++ b/plugins/plugin-native-talkmode/src/definitions.ts
@@ -139,11 +139,11 @@ export interface TalkModeConfig {
   sessionKey?: string;
   /** TTS configuration */
   tts?: TTSConfig;
-  /** STT configuration (desktop whisper/web) */
+  /** STT configuration (platform recognizer/Web Speech) */
   stt?: {
     /** STT engine preference */
-    engine?: "whisper" | "web";
-    /** Whisper model size */
+    engine?: "native" | "web";
+    /** Legacy compatibility field; ignored by current recognizers */
     modelSize?: "tiny" | "base" | "small" | "medium" | "large";
     /** Language code (e.g., "en", "es") */
     language?: string;


### PR DESCRIPTION
## Summary
- remove the retired `"whisper"` STT engine from `@elizaos/capacitor-talkmode`'s public `TalkModeConfig` type
- document `stt.modelSize` as a legacy/no-op compatibility field for the current platform/Web recognizers
- update mirrored package guides, README, and Android raw-frame notes to stop naming the retired backend

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run --cwd plugins/plugin-native-talkmode build`
- `bun run --cwd packages/ui typecheck`
- `bun run verify` (515/515 passed)
- `git diff --check`
- `rg -n "whisper|Whisper|Qwen3-ASR|Qwen ASR" plugins/plugin-native-talkmode` (no matches)
- `diff -u plugins/plugin-native-talkmode/CLAUDE.md plugins/plugin-native-talkmode/AGENTS.md` (no diff)

Refs #9588
Refs #9583
