### PR TITLE
fix(local-inference): retire Qwen voice internals

### DIFF
--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1376,7 +1376,7 @@ export class LocalInferenceEngine {
 		// Voice Wave 2 (2026-05-14): tier-aware turn-detector revision selection.
 		// `2b` (the entry tier) ships the ~66 MB EN-only SmolLM2-135M distill
 		// (`v1.2.2-en`); `4b`+ ship the ~396 MB multilingual pruned
-		// Qwen2.5-0.5B (`v0.4.1-intl`). The on-disk layout is per-tier so the
+		// semantic detector (`v0.4.1-intl`). The on-disk layout is per-tier so the
 		// bundle dir already contains the matching ONNX — `revision` here is a
 		// telemetry label (the upstream tag the bundle was staged from). When no
 		// active bundle is resolvable we omit the hint and the resolver falls

--- a/plugins/plugin-local-inference/src/services/manifest/schema.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/schema.ts
@@ -142,7 +142,7 @@ export type Eliza1Backend = (typeof ELIZA_1_BACKENDS)[number];
 //   that are head_dim-coupled. They do NOT match Gemma's MQA geometry
 //   (n_head_kv=1) with dual head dims (512 global / 256 SWA), so Gemma 4
 //   ships stock q8_0 KV and these kernels are OPTIONAL, never required.
-//   They stay compiled into the shared lib for the legacy Qwen tiers and the
+//   They stay compiled into the shared lib for legacy non-Gemma tiers and the
 //   shared OmniVoice/ASR FFI symbols, but no Gemma tier declares them
 //   required.
 export const REQUIRED_KERNELS_BY_TIER: Readonly<
@@ -210,7 +210,7 @@ export const Eliza1LineageSchema = z.object({
 	// Voice Wave 2 (2026-05-14): semantic end-of-turn detector lineage. When
 	// `files.turn` ships the bundled `livekit/turn-detector` ONNX (the
 	// ≤1.7B-tier `v1.2.2-en` SmolLM2 distill or the ≥4B-tier `v0.4.1-intl`
-	// pruned Qwen2.5-0.5B), this records the upstream repo + license. Apache-2.0
+	// multilingual detector), this records the upstream repo + license. Apache-2.0
 	// fallback path is `latishab/turnsense`.
 	turn: lineageEntry.optional(),
 	// Voice Wave 2 (2026-05-14): acoustic-prosody emotion classifier lineage.
@@ -281,12 +281,11 @@ export const Eliza1FilesSchema = z.object({
 	mtp: z.array(Eliza1FileEntrySchema),
 	cache: z.array(Eliza1FileEntrySchema).min(1),
 	// Wave-6 (2026-05-10): the omni bundle ships a per-bundle dedicated
-	// embedding model (Qwen3-Embedding-GGUF on non-lite tiers), a
-	// Silero-VAD GGUF, and an optional openWakeWord GGUF (the combined GGUF
-	// carries the mel filterbank + speech embedding model + every per-phrase
-	// head). All three are optional in the schema — the 2b entry tier
-	// intentionally omits the dedicated embedding (pools from text backbone)
-	// and a tier may ship without wake-word support.
+	// embedding model on non-lite tiers, a Silero-VAD GGUF, and an optional
+	// openWakeWord GGUF (the combined GGUF carries the mel filterbank + speech
+	// embedding model + every per-phrase head). All three are optional in the
+	// schema — the 2b entry tier intentionally omits the dedicated embedding
+	// (pools from text backbone) and a tier may ship without wake-word support.
 	//
 	// Schema-level optionality: empty array = "this bundle does not
 	// ship this component"; the validator enforces tier-specific
@@ -309,7 +308,7 @@ export const Eliza1FilesSchema = z.object({
 	// `stage_turn_detector` in
 	// `packages/training/scripts/manifest/stage_eliza1_bundle_assets.py`):
 	// 2b ships the EN-only SmolLM2-135M distill; 4b/9b/27b ship the
-	// multilingual pruned Qwen2.5-0.5B.
+	// multilingual detector.
 	turn: z.array(Eliza1FileEntrySchema).optional(),
 	// Eliza-1 EOT LoRA adapter — optional, complements `turn`. When
 	// present, the runtime layers this adapter onto the in-process

--- a/plugins/plugin-local-inference/src/services/memory-arbiter.ts
+++ b/plugins/plugin-local-inference/src/services/memory-arbiter.ts
@@ -46,7 +46,7 @@
  *   arbiter.registerCapability({
  *     capability: "vision-describe",
  *     residentRole: "vision",
- *     load: async (modelKey) => loadQwen3VL(modelKey),
+ *     load: async (modelKey) => loadVisionModel(modelKey),
  *     unload: async (handle) => handle.dispose(),
  *     run: async (handle, req) => handle.describe(req.imageBytes),
  *   });

--- a/plugins/plugin-local-inference/src/services/voice/embedding.ts
+++ b/plugins/plugin-local-inference/src/services/voice/embedding.ts
@@ -110,9 +110,8 @@ export type LocalEmbeddingSource =
 			/**
 			 * The dedicated model already ships a contrastive `last`-token
 			 * pooling head — `--pooling last` is still passed so llama-server
-			 * doesn't fall back to the GGUF's metadata default (which for a raw
-			 * Qwen3 base is `mean`). The model's own pooling layer dominates;
-			 * this just pins the read.
+			 * doesn't fall back to the GGUF's metadata default. The model's own
+			 * pooling layer dominates; this just pins the read.
 			 */
 			readonly poolingType: "last";
 	  };

--- a/plugins/plugin-local-inference/src/services/voice/eot-classifier-ggml.ts
+++ b/plugins/plugin-local-inference/src/services/voice/eot-classifier-ggml.ts
@@ -18,9 +18,9 @@
  * (`.swarm/impl/I1-single-runtime.md` §B), the turn-detector was the
  * cheapest of the four remaining ONNX surfaces to retire — the GGUF
  * artifact was already published by H4 (see commit history), and the
- * detector's architecture (Qwen2-style small decoder + classification
- * head on the `<end_of_turn>` logit) is exactly what `LLM_ARCH_QWEN2`
- * already implements in the fork. The work is wiring, not porting.
+ * detector's architecture (a small decoder + classification head on the
+ * `<end_of_turn>` logit) is already implemented in the fork. The work is
+ * wiring, not porting.
  *
  * No silent fallback (AGENTS.md §3): when `capacitor-llama` is
  * unavailable, the GGUF is missing, or the model load fails, this
@@ -277,8 +277,8 @@ export interface LiveKitGgmlTurnDetectorOptions {
 
 /**
  * Local GGUF-backed LiveKit turn-detector. Uses a `capacitor-llama`
- * evaluation of the Qwen2-style decoder, reading `P(<end_of_turn>)` from the
- * next-token distribution after the truncated user-template prefix.
+ * evaluation of the decoder, reading `P(<end_of_turn>)` from the next-token
+ * distribution after the truncated user-template prefix.
  *
  * One detector instance owns one `LlamaModel` + one `LlamaContext` +
  * one `LlamaSequence`. `score()` resets the sequence between calls —

--- a/plugins/plugin-local-inference/src/services/voice/expressive-tags.ts
+++ b/plugins/plugin-local-inference/src/services/voice/expressive-tags.ts
@@ -308,7 +308,7 @@ export function enumToEmotion(
  * as model-native emotion recognition unless that backend explicitly advertises
  * such a field; callers should record heuristic attribution separately.
  */
-export const QWEN3_ASR_EMOTION_LABELS = [
+export const ASR_EMOTION_LABELS = [
 	"surprise",
 	"calm",
 	"happiness",
@@ -318,7 +318,7 @@ export const QWEN3_ASR_EMOTION_LABELS = [
 	"fear",
 ] as const;
 
-export type Qwen3AsrEmotionLabel = (typeof QWEN3_ASR_EMOTION_LABELS)[number];
+export type AsrEmotionLabel = (typeof ASR_EMOTION_LABELS)[number];
 
 /**
  * Explicit mapping from an ASR-perceived emotion label to the tag vocab the
@@ -328,7 +328,7 @@ export type Qwen3AsrEmotionLabel = (typeof QWEN3_ASR_EMOTION_LABELS)[number];
  * `null` (counted as "no agreement" rather than forced).
  */
 export const ASR_LABEL_TO_EMOTION_TAG: Readonly<
-	Record<Qwen3AsrEmotionLabel, ExpressiveEmotion | null>
+	Record<AsrEmotionLabel, ExpressiveEmotion | null>
 > = {
 	happiness: "happy",
 	sadness: "sad",
@@ -340,18 +340,18 @@ export const ASR_LABEL_TO_EMOTION_TAG: Readonly<
 };
 
 /** Normalize an arbitrary ASR-emitted emotion string (any casing, possibly an
- *  adjective form) to a `Qwen3AsrEmotionLabel` if it matches, else `null`. */
+ *  adjective form) to an `AsrEmotionLabel` if it matches, else `null`. */
 export function normalizeAsrEmotionLabel(
 	raw: string | null | undefined,
-): Qwen3AsrEmotionLabel | null {
+): AsrEmotionLabel | null {
 	if (!raw) return null;
 	const v = raw.trim().toLowerCase();
 	// Direct hit.
-	if ((QWEN3_ASR_EMOTION_LABELS as readonly string[]).includes(v)) {
-		return v as Qwen3AsrEmotionLabel;
+	if ((ASR_EMOTION_LABELS as readonly string[]).includes(v)) {
+		return v as AsrEmotionLabel;
 	}
 	// Common adjective forms → noun labels.
-	const ADJ: Record<string, Qwen3AsrEmotionLabel> = {
+	const ADJ: Record<string, AsrEmotionLabel> = {
 		happy: "happiness",
 		sad: "sadness",
 		angry: "anger",

--- a/plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts
+++ b/plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts
@@ -242,7 +242,7 @@ export interface LlmStreamConfig {
 	 * path. `null`/empty disables grammar constraint.
 	 */
 	gbnfGrammar?: string | null;
-	/** Qwen3-style thinking-tag suppression passthrough (v1 no-op). */
+	/** Thinking-tag suppression passthrough (v1 no-op). */
 	disableThinking?: boolean;
 	/**
 	 * Per-load GPU offload (ABI v8). Number of model layers to place on GPU.

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -360,9 +360,9 @@ export * from "./types";
 export {
 	createSileroVadDetector,
 	createVadDetector,
+	type ExternalVadAdapter,
 	GgmlSileroVad,
 	NativeSileroVad,
-	type QwenToolkitVadAdapter,
 	type ResolvedVadProvider,
 	RmsEnergyGate,
 	type RmsEnergyGateConfig,

--- a/plugins/plugin-local-inference/src/services/voice/types.ts
+++ b/plugins/plugin-local-inference/src/services/voice/types.ts
@@ -682,7 +682,7 @@ export type VoiceSchedulerTelemetryListener = (
 // ---------------------------------------------------------------------------
 
 /** Minimal VAD model contract consumed by the fused `GgmlSileroVad` and the
- *  optional injected qwen-toolkit adapter. */
+ *  optional injected external adapter. */
 export interface VadLike {
 	readonly windowSamples: number;
 	readonly sampleRate: number;

--- a/plugins/plugin-local-inference/src/services/voice/vad.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/vad.test.ts
@@ -324,11 +324,11 @@ describe("VadDetector", () => {
 });
 
 describe("GgmlSileroVad", () => {
-	it("documents the auto provider order: optional Qwen toolkit adapter → fused native Silero", () => {
+	it("documents the auto provider order: optional external VAD adapter → fused native Silero", () => {
 		// Fused `silero-ggml` (the one libelizainference handle) is the sole
-		// on-device VAD runtime; the optional injected `qwen-toolkit` adapter is
+		// on-device VAD runtime; the optional injected `external-vad` adapter is
 		// tried first only when a caller supplies one.
-		expect(vadProviderOrder()).toEqual(["qwen-toolkit", "silero-ggml"]);
+		expect(vadProviderOrder()).toEqual(["external-vad", "silero-ggml"]);
 		expect(vadProviderOrder("silero-ggml")).toEqual(["silero-ggml"]);
 	});
 
@@ -336,8 +336,8 @@ describe("GgmlSileroVad", () => {
 		expect(NativeSileroVad).toBe(GgmlSileroVad);
 	});
 
-	it("prefers a supplied Qwen toolkit VAD adapter over the native provider", async () => {
-		const qwenVad = new ScriptedSilero([
+	it("prefers a supplied external VAD adapter over the native provider", async () => {
+		const externalVad = new ScriptedSilero([
 			0.01, 0.9, 0.9, 0.02, 0.02, 0.02, 0.02, 0.02,
 		]);
 		const ffi = fakeFfi("x", {
@@ -345,20 +345,20 @@ describe("GgmlSileroVad", () => {
 			vadProbs: [0.01],
 		});
 		const resolved = await resolveVadProvider({
-			qwenToolkitVad: {
+			externalVad: {
 				isAvailable: () => true,
-				loadVad: async () => qwenVad,
+				loadVad: async () => externalVad,
 			},
 			ffi,
 			ctx: 1n,
 		});
 
-		expect(resolved.id).toBe("qwen-toolkit");
-		expect(resolved.vad).toBe(qwenVad);
+		expect(resolved.id).toBe("external-vad");
+		expect(resolved.vad).toBe(externalVad);
 
 		const det = await createVadDetector({
-			qwenToolkitVad: {
-				loadVad: async () => qwenVad,
+			externalVad: {
+				loadVad: async () => externalVad,
 			},
 			ffi,
 			ctx: 1n,
@@ -388,15 +388,15 @@ describe("GgmlSileroVad", () => {
 	});
 
 	it("createSileroVadDetector goes through the unified resolver", async () => {
-		// The Qwen toolkit adapter short-circuits resolution before any
+		// The external adapter short-circuits resolution before any
 		// FFI / model-file checks run, which exercises the unified resolver
 		// end-to-end without needing a libelizainference build.
-		const qwenVad = new ScriptedSilero([
+		const externalVad = new ScriptedSilero([
 			0.01, 0.9, 0.9, 0.02, 0.02, 0.02, 0.02, 0.02,
 		]);
 		const det = await createSileroVadDetector({
-			qwenToolkitVad: {
-				loadVad: async () => qwenVad,
+			externalVad: {
+				loadVad: async () => externalVad,
 			},
 			config: {
 				onsetThreshold: 0.5,

--- a/plugins/plugin-local-inference/src/services/voice/vad.ts
+++ b/plugins/plugin-local-inference/src/services/voice/vad.ts
@@ -9,7 +9,7 @@
  *            acoustic activity right now".
  *
  *   Tier 2 — a model VAD provider. Resolver order is an optional injected
- *            Qwen toolkit adapter when supplied, otherwise the fused
+ *            external VAD adapter when supplied, otherwise the fused
  *            `libelizainference` Silero v5 VAD ABI (`eliza_inference_vad_*`,
  *            backend id `silero-ggml`). 512-sample windows at 16 kHz (32 ms
  *            hop), one speech probability per window. This is the
@@ -376,10 +376,10 @@ export type { VadLike } from "./types.js";
 
 import type { VadLike } from "./types.js";
 
-export type VadProviderId = "qwen-toolkit" | "silero-ggml";
+export type VadProviderId = "external-vad" | "silero-ggml";
 export type VadProviderPreference = "auto" | VadProviderId;
 
-export interface QwenToolkitVadAdapter {
+export interface ExternalVadAdapter {
 	isAvailable?(): boolean | Promise<boolean>;
 	loadVad(opts: { sampleRate: number }): Promise<VadLike>;
 }
@@ -394,7 +394,7 @@ export interface CreateVadDetectorOptions {
 	bundleRoot?: string;
 	ffi?: ElizaInferenceFfi | null;
 	ctx?: ElizaInferenceContextHandle | (() => ElizaInferenceContextHandle);
-	qwenToolkitVad?: QwenToolkitVadAdapter | null;
+	externalVad?: ExternalVadAdapter | null;
 	config?: VadDetectorConfig;
 	prefer?: VadProviderPreference;
 }
@@ -404,10 +404,10 @@ export function vadProviderOrder(
 ): VadProviderId[] {
 	if (prefer !== "auto") return [prefer];
 	// `silero-ggml` is the fused `libelizainference` VAD ABI — the sole
-	// on-device VAD runtime. The optional injected `qwen-toolkit` adapter is
+	// on-device VAD runtime. The optional injected `external-vad` adapter is
 	// tried first only when a caller supplies one; otherwise the fused engine
 	// is the single path, and an unavailable fused VAD fails fast.
-	return ["qwen-toolkit", "silero-ggml"];
+	return ["external-vad", "silero-ggml"];
 }
 
 export async function resolveVadProvider(
@@ -419,20 +419,20 @@ export async function resolveVadProvider(
 
 	for (const provider of vadProviderOrder(opts.prefer)) {
 		switch (provider) {
-			case "qwen-toolkit": {
+			case "external-vad": {
 				tried.push(provider);
-				if (!opts.qwenToolkitVad) {
-					reasons.push("qwen-toolkit: no adapter supplied");
+				if (!opts.externalVad) {
+					reasons.push("external-vad: no adapter supplied");
 					break;
 				}
-				const available = (await opts.qwenToolkitVad.isAvailable?.()) ?? true;
+				const available = (await opts.externalVad.isAvailable?.()) ?? true;
 				if (!available) {
-					reasons.push("qwen-toolkit: adapter reported unavailable");
+					reasons.push("external-vad: adapter reported unavailable");
 					break;
 				}
 				return {
 					id: provider,
-					vad: await opts.qwenToolkitVad.loadVad({ sampleRate }),
+					vad: await opts.externalVad.loadVad({ sampleRate }),
 				};
 			}
 			case "silero-ggml": {

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget.ts
@@ -237,11 +237,11 @@ export interface VoiceEnsembleBudget {
  * the largest co-resident knob is the LM itself.
  */
 export type VoiceTierSlot =
-	| "mobile-2b" // mobile profile: kokoro-q8 + turnsense + ASR-0.6B + LM-2B (entry tier), no dedicated embedding
+	| "mobile-2b" // mobile profile: kokoro-q8 + turnsense + entry ASR + LM-2B (entry tier), no dedicated embedding
 	| "desktop-2b" // 2b LM (entry tier) + full voice stack + embedding
 	| "desktop-4b" // 4b LM + full voice stack + embedding
-	| "workstation-9b" // 9b LM + omnivoice-Q8 + ASR-0.6B + embedding
-	| "workstation-27b"; // 27b LM + omnivoice-Q8 + ASR-1.7B + embedding
+	| "workstation-9b" // 9b LM + omnivoice-Q8 + entry ASR + embedding
+	| "workstation-27b"; // 27b LM + omnivoice-Q8 + large ASR + embedding
 
 const _MB = 1; // alias for readability inside the table
 const _GB = 1024;
@@ -256,7 +256,7 @@ export const VOICE_ENSEMBLE_BUDGETS: Readonly<
 		lmKvMb: 0.075 * _GB,
 		drafterMb: 0.5 * _GB,
 		ttsMb: 0.08 * _GB, // kokoro-q8 ONNX
-		asrMb: 0.4 * _GB, // qwen3-asr-0.6B documented Q4-equiv
+		asrMb: 0.4 * _GB, // entry Gemma-compatible ASR placeholder budget
 		asrMmprojMb: 0.2 * _GB,
 		embeddingMb: 0, // pools from the text backbone on the 2b entry tier
 		vadMb: 2 * _MB, // silero-vad documented baseline
@@ -293,7 +293,7 @@ export const VOICE_ENSEMBLE_BUDGETS: Readonly<
 		embeddingMb: 0.4 * _GB,
 		vadMb: 2 * _MB,
 		wakeWordMb: 4 * _MB,
-		turnDetectorMb: 400 * _MB, // livekit/turn-detector v0.4.1-intl Qwen2.5-0.5B
+		turnDetectorMb: 400 * _MB, // livekit/turn-detector v0.4.1-intl semantic model
 		emotionMb: 40 * _MB,
 		speakerEncoderMb: 10 * _MB,
 		transientTtsBufferMb: 1.17 * _GB,
@@ -320,7 +320,7 @@ export const VOICE_ENSEMBLE_BUDGETS: Readonly<
 		lmKvMb: 2.75 * _GB,
 		drafterMb: 2.6 * _GB,
 		ttsMb: 1.28 * _GB,
-		asrMb: 1.1 * _GB, // qwen3-asr-1.7B on the 27B tier
+		asrMb: 1.1 * _GB, // large Gemma-compatible ASR placeholder budget
 		asrMmprojMb: 0.3 * _GB,
 		embeddingMb: 0.4 * _GB,
 		vadMb: 2 * _MB,


### PR DESCRIPTION
## Summary
- rename the optional VAD adapter surface from Qwen toolkit wording to generic external VAD wording
- make ASR emotion label exports model-neutral
- remove stale Qwen-family wording from active local-inference voice/manifest comments while keeping intentional Qwen provenance blockers

## Evidence
- git fetch origin && git rebase origin/develop
- bun install
- bun run --cwd plugins/plugin-local-inference test src/services/voice/vad.test.ts src/services/voice/expressive-tags.asr.test.ts
- bun run --cwd plugins/plugin-local-inference lint:check
- bun run --cwd plugins/plugin-local-inference typecheck
- bun run verify (515/515 tasks)
- git diff --check
- rg qwenToolkitVad/QwenToolkitVadAdapter/qwen-toolkit/QWEN3_ASR_EMOTION_LABELS/Qwen3AsrEmotionLabel over plugin-local-inference active docs/src: no matches

Refs #9588
Refs #9583