### PR TITLE
fix(training): retire qwen asr scaffold defaults

### DIFF
--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -457,10 +457,9 @@ function sourceModelForTier(id: Eliza1TierId): CatalogModel["sourceModel"] {
     vad: bundleComponent(id, "vad/silero-vad-v5.gguf"),
   };
 
-  // Gemma ASR artifacts are not hosted yet. The public `asr/eliza-1-asr.gguf`
-  // files currently staged under the tier bundles are Qwen3-ASR stand-ins, so
-  // do not advertise them as active tier components. Runtime ASR remains gated
-  // by bundle manifest provenance until Gemma ASR files are published.
+  // Gemma ASR artifacts are not hosted yet. Do not advertise retired pre-Gemma
+  // ASR files as active tier components. Runtime ASR remains gated by bundle
+  // manifest provenance until Gemma ASR files are published.
 
   // LiteRT-LM single-file bundle for the on-device runtime: text + vision +
   // audio + MTP packed into one QAT (.litertlm) artifact, parallel to the

--- a/packages/shared/src/local-inference/voice-models.ts
+++ b/packages/shared/src/local-inference/voice-models.ts
@@ -823,7 +823,7 @@ export const VOICE_MODEL_VERSIONS: ReadonlyArray<VoiceModelVersion> = [
     ],
     evalDeltas: { netImprovement: true },
     changelogEntry:
-      "Gemma ASR cutover placeholder — Qwen ASR assets retired; downloads stay disabled until Gemma ASR artifacts are published.",
+      "Gemma ASR cutover placeholder — pre-Gemma ASR assets retired; downloads stay disabled until Gemma ASR artifacts are published.",
     minBundleVersion: "1.0.0",
   },
   {
@@ -850,7 +850,7 @@ export const VOICE_MODEL_VERSIONS: ReadonlyArray<VoiceModelVersion> = [
     ],
     evalDeltas: { netImprovement: true },
     changelogEntry:
-      "Initial release — Eliza-1 ASR (Qwen3-ASR base) streaming transcriber Q8_0.",
+      "Retired pre-Gemma ASR release — streaming transcriber Q8_0.",
     minBundleVersion: "0.0.0",
   },
   {
@@ -898,7 +898,7 @@ export const VOICE_MODEL_VERSIONS: ReadonlyArray<VoiceModelVersion> = [
     ],
     evalDeltas: { netImprovement: true },
     changelogEntry:
-      "K-quant ladder: Q3_K_M, Q4_K_M, Q5_K_M, Q6_K added for Eliza-1 ASR (Qwen3-ASR-1.7B base). Enables memory-tier selection. mmproj stays Q8_0 per R8 §3.6.",
+      "Retired pre-Gemma ASR K-quant ladder: Q3_K_M, Q4_K_M, Q5_K_M, Q6_K. Kept only as historical release metadata; active downloads remain on the Gemma ASR placeholder until verified artifacts are hosted.",
     minBundleVersion: "0.0.0",
   },
 ];

--- a/packages/training/docs/training/eliza1-smallest-finetunes.md
+++ b/packages/training/docs/training/eliza1-smallest-finetunes.md
@@ -9,9 +9,9 @@ passes base-vs-finetuned evals and bundle gates.
 
 | family | fine-tune target | base artifact | publish target |
 | --- | --- | --- | --- |
-| text | `eliza-1-2b` | `Qwen/Qwen3.5-2B-Base` | `bundles/2b/text/` |
+| text | `eliza-1-2b` | `google/gemma-4-E2B` via `gemma4-e2b` | `bundles/2b/text/` |
 | drafter | `drafter-2b` | 2B text target features | `bundles/2b/mtp/` |
-| ASR | `eliza-1-asr` | `ggml-org/Qwen3-ASR-0.6B-GGUF` | `bundles/2b/asr/` |
+| ASR | frozen until verified Gemma ASR artifacts exist | no active base configured | `bundles/2b/asr/` |
 | TTS voice | default Kokoro/voice adapter | `hexgrad/Kokoro-82M` / default voice corpus | `bundles/2b/tts/` |
 | turn detector | smallest turn detector head | active turn detector base config | `bundles/2b/turn/` |
 | image generation | SD 1.5 adapter only | `imagegen/sd-1.5-Q5_0.gguf` lineage | `bundles/2b/imagegen/` |
@@ -35,7 +35,7 @@ hf download elizaos/eliza-1-training \
   --local-dir /tmp/eliza-1-training
 
 uv run --extra train python scripts/run_pipeline.py \
-  --registry-key qwen3.5-2b \
+  --registry-key gemma4-e2b \
   --train-file /tmp/eliza-1-training/sft/2b/train.jsonl \
   --val-file /tmp/eliza-1-training/sft/2b/val.jsonl \
   --test-file /tmp/eliza-1-training/sft/2b/test.jsonl \
@@ -76,12 +76,17 @@ validation targets the native 256k text artifact.
 
 ## ASR
 
-Use the smallest Qwen3 ASR lineage and a real-recorded labelled corpus:
+ASR is frozen for the active Gemma cutover. Do not launch real ASR
+fine-tuning until a verified Gemma-compatible ASR checkpoint and matching
+projector are hosted and wired into the bundle staging scripts. The legacy
+ASR scaffold remains available for synthetic CI shape checks only; real
+train/eval fails closed when no active Gemma-compatible `base_model` is
+configured.
 
 ```bash
 uv run --extra train python scripts/asr/finetune_asr.py \
   --config scripts/asr/configs/base.yaml \
-  --model ggml-org/Qwen3-ASR-0.6B-GGUF
+  --synthetic-smoke
 ```
 
 The publish WER must come from explicit real-recorded provenance, not a TTS

--- a/packages/training/scripts/asr/README.md
+++ b/packages/training/scripts/asr/README.md
@@ -1,10 +1,13 @@
-# ASR fine-tune scaffold — Qwen3-ASR (eliza-1)
+# ASR fine-tune scaffold — frozen during Gemma cutover
 
 This directory contains the fine-tune scaffold for the **eliza-1 ASR model**
-(`Qwen/Qwen3-ASR-0.6B` or `Qwen/Qwen3-ASR-1.7B`).
+while ASR artifacts are frozen. Real training and real eval are blocked until
+a verified Gemma-compatible ASR checkpoint and matching projector are
+configured.
 
-Per the W3-11 scope: real training is out of scope for Wave 3 (compute), but
-the scaffold, eval script, manifest entry, and CI smoke tests land here.
+The scaffold, eval script, manifest entry, and CI smoke tests remain here so
+publish tooling can exercise file shapes without downloading or training a
+retired ASR model.
 
 ---
 
@@ -29,10 +32,10 @@ python3 packages/training/scripts/asr/finetune_asr.py \
     --config packages/training/scripts/asr/configs/asr_same.yaml \
     --synthetic-smoke
 
-# Real training (RTX 5080 / H200):
+# Real training once a verified Gemma-compatible ASR base is configured:
 python3 packages/training/scripts/asr/finetune_asr.py \
     --run-dir /tmp/asr-runs/same \
-    --config packages/training/scripts/asr/configs/asr_same.yaml \
+    --config /path/to/gemma-asr.yaml \
     --data-dir packages/training/data/voice/same \
     --real-train
 
@@ -41,13 +44,13 @@ python3 packages/training/scripts/asr/eval_asr.py \
     --run-dir /tmp/asr-runs/same \
     --checkpoint /tmp/asr-runs/same/checkpoints/best.pt \
     --data-dir packages/training/data/voice/same \
-    --config packages/training/scripts/asr/configs/asr_same.yaml \
+    --config /path/to/gemma-asr.yaml \
     --baseline-eval artifacts/voice-fine-tune/asr-baseline/eval.json
 
 # HF push (gated on beats-baseline + operator sign-off):
 python3 packages/training/scripts/asr/finetune_asr.py \
     --run-dir /tmp/asr-runs/same \
-    --config packages/training/scripts/asr/configs/asr_same.yaml \
+    --config /path/to/gemma-asr.yaml \
     --data-dir packages/training/data/voice/same \
     --real-train \
     --baseline-eval artifacts/voice-fine-tune/asr-baseline/eval.json \
@@ -60,17 +63,18 @@ python3 packages/training/scripts/asr/finetune_asr.py \
 
 ## Architecture
 
-Qwen3-ASR is a **Qwen3 text backbone + audio mmproj projector**:
+The active Gemma-compatible ASR architecture is intentionally not assumed by
+this scaffold until the verified checkpoint/projector pair is selected:
 
-- **Audio front-end**: WhisperFeatureExtractor (80-bin log-mel at 16 kHz,
-  n_fft=400, hop=160).
-- **Projection head**: maps mel frames to Qwen3 hidden space (1024 or 2048 dim).
-- **Text backbone**: Qwen3 decoder, trained to generate transcripts auto-regressively.
-- **Loss**: cross-entropy on the generated token sequence (teacher-forcing).
+- **Audio front-end**: configured by the selected ASR base.
+- **Projection head**: configured by the selected ASR base and staged as a
+  matching projector artifact.
+- **Text/audio backbone**: must be Gemma-compatible for active Eliza-1 bundles.
+- **Loss**: scaffold supports CTC primary loss plus optional LM-head
+  cross-entropy, subject to the selected model class.
 
 GGUF conversion: `packages/training/scripts/quantization/gguf_asr_apply.py`
-handles the two-stage convert (HF safetensors → f16 GGUF → Q4_K_M GGUF) for
-both the text body and the audio mmproj sidecar.
+is also blocked on a verified Gemma-compatible ASR checkpoint/projector pair.
 
 ---
 

--- a/packages/training/scripts/asr/__init__.py
+++ b/packages/training/scripts/asr/__init__.py
@@ -1,1 +1,1 @@
-# ASR fine-tune scaffolding for Qwen3-ASR (eliza-1 ASR model).
+# ASR fine-tune scaffolding for frozen eliza-1 ASR artifacts.

--- a/packages/training/scripts/asr/__tests__/test_asr_pipeline.py
+++ b/packages/training/scripts/asr/__tests__/test_asr_pipeline.py
@@ -1,4 +1,4 @@
-"""Tests for the Qwen3-ASR fine-tune scaffold.
+"""Tests for the eliza-1 ASR fine-tune scaffold.
 
 Three suites:
 1. Synthetic-smoke pipeline shape (no torch, no GPU).
@@ -20,6 +20,7 @@ sys.path.insert(0, str(ASR_DIR))
 
 import finetune_asr  # noqa: E402
 import eval_asr  # noqa: E402
+import push_asr_gguf_to_hf  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +130,7 @@ def test_eval_synthetic_smoke_writes_eval_json(tmp_path: Path) -> None:
 def test_config_defaults() -> None:
     """Load config with no file — should return default dict."""
     cfg = finetune_asr._load_config("")
+    assert cfg["base_model"] == ""
     assert cfg["optimizer"] == "apollo_mini"
     assert cfg["sample_rate"] == 16000
     assert cfg["mel_bins"] == 80
@@ -231,3 +233,33 @@ def test_cli_smoke_default_no_real_train(tmp_path: Path) -> None:
     rc = finetune_asr.main(["--run-dir", str(run_dir)])
     assert rc == 0
     assert (run_dir / "checkpoints" / "train_manifest.json").exists()
+
+
+def test_real_train_requires_active_gemma_asr_source(tmp_path: Path) -> None:
+    """Real training fails closed until a verified Gemma-compatible ASR base exists."""
+    with pytest.raises(SystemExit, match="Gemma-compatible ASR"):
+        finetune_asr.main(["--run-dir", str(tmp_path / "run"), "--real-train"])
+
+
+def test_real_eval_rejects_retired_qwen_asr_source(tmp_path: Path) -> None:
+    """Real eval refuses retired ASR source configs before importing model deps."""
+    cfg_path = tmp_path / "qwen-retired.yaml"
+    cfg_path.write_text('base_model: "Qwen/Qwen3-ASR-0.6B"\n')
+    with pytest.raises(SystemExit, match="retired"):
+        eval_asr.main(
+            [
+                "--run-dir",
+                str(tmp_path / "eval"),
+                "--config",
+                str(cfg_path),
+                "--data-dir",
+                str(tmp_path / "data"),
+            ]
+        )
+
+
+def test_push_helper_rejects_retired_asr_sidecar(tmp_path: Path) -> None:
+    """HF publish helper blocks sidecars that still point at retired ASR sources."""
+    sidecar = tmp_path / "gguf_asr.json"
+    sidecar.write_text(json.dumps({"sourceModel": "Qwen/Qwen3-ASR-0.6B"}))
+    assert push_asr_gguf_to_hf._contains_retired_asr_source(sidecar) is True

--- a/packages/training/scripts/asr/configs/asr_same.yaml
+++ b/packages/training/scripts/asr/configs/asr_same.yaml
@@ -1,4 +1,4 @@
-# Qwen3-ASR fine-tune on the `same` voice from lalalune/ai_voices.
+# Synthetic ASR fine-tune shape check on the `same` voice from lalalune/ai_voices.
 #
 # The same corpus (58 clips, ~3.5 min, 44.1 kHz) is small for ASR
 # fine-tuning; it is primarily useful for voice-adapted language model
@@ -9,10 +9,9 @@
 # the scaffold + eval + manifest must land. Run with --synthetic-smoke in CI.
 # Run with --real-train on an RTX 5080 / H200 for actual training.
 #
-# Expected outcome: WER on same val set should beat the baseline
-# (Qwen3-ASR-0.6B zero-shot) by 5–15% relative on in-domain prompts.
-# Out-of-domain WER is expected to be unchanged (the model is pretrained on
-# large-scale diverse speech).
+# Expected outcome for future real runs: WER on same val set should beat the
+# selected Gemma-compatible ASR baseline on in-domain prompts without regressing
+# out-of-domain WER.
 
 extends: base.yaml
 

--- a/packages/training/scripts/asr/configs/base.yaml
+++ b/packages/training/scripts/asr/configs/base.yaml
@@ -1,12 +1,13 @@
-# Base config for Qwen3-ASR fine-tuning.
+# Base config for ASR fine-tuning.
 # All corpus-specific configs extend this via `extends: base.yaml`.
 #
-# Model: Qwen/Qwen3-ASR-0.6B (default) or Qwen/Qwen3-ASR-1.7B.
+# Model: intentionally blank until a verified Gemma-compatible ASR checkpoint
+# and matching projector are hosted. Real train/eval fails closed without it.
 # Optimizer: APOLLO-Mini (repo policy — APOLLO-only, no AdamW fallback).
 # Mixed precision: bf16 on CUDA, fp32 on CPU/MPS.
 
-base_model: Qwen/Qwen3-ASR-0.6B
-sample_rate: 16000        # WhisperFeatureExtractor native rate
+base_model: ""
+sample_rate: 16000        # selected ASR front-end native rate
 mel_bins: 80              # 80-bin log-mel
 max_audio_seconds: 30.0
 min_audio_seconds: 0.5

--- a/packages/training/scripts/asr/eval_asr.py
+++ b/packages/training/scripts/asr/eval_asr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Evaluate a Qwen3-ASR checkpoint.
+"""Evaluate an eliza-1 ASR checkpoint.
 
 Computes WER + RTF against a corpus of WAV+transcript pairs and writes
 ``<run-dir>/eval.json``. Matches the eval contract in W3-11:
@@ -57,7 +57,7 @@ log = logging.getLogger("asr.eval")
 def _load_config(config_arg: str) -> dict[str, Any]:
     """Load YAML config; fallback to defaults."""
     defaults: dict[str, Any] = {
-        "base_model": "Qwen/Qwen3-ASR-0.6B",
+        "base_model": "",
         "sample_rate": 16000,
         "mel_bins": 80,
         "voice_name": "custom",
@@ -90,6 +90,28 @@ def _load_config(config_arg: str) -> dict[str, Any]:
             defaults.update(base_cfg)
     defaults.update(user_cfg)
     return defaults
+
+
+def _asr_source_blocker(cfg: dict[str, Any]) -> str | None:
+    base_model = str(cfg.get("base_model", "")).strip()
+    if not base_model:
+        return (
+            "ASR real eval is disabled until a verified Gemma-compatible "
+            "ASR base_model and projector are configured."
+        )
+    lowered = base_model.lower()
+    if "qwen" in lowered and "asr" in lowered:
+        return (
+            f"{base_model} is retired for active Eliza-1 Gemma ASR eval; "
+            "configure a verified Gemma-compatible ASR base_model instead."
+        )
+    return None
+
+
+def _require_active_asr_source(cfg: dict[str, Any]) -> None:
+    blocker = _asr_source_blocker(cfg)
+    if blocker:
+        raise SystemExit(blocker)
 
 
 def _apply_gates(metrics: dict[str, float], gates: dict[str, float]) -> dict[str, Any]:
@@ -156,6 +178,8 @@ def _run_synthetic_smoke(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
 
 def _real_eval(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     """Run real WER + RTF eval against a checkpoint."""
+    _require_active_asr_source(cfg)
+
     try:
         import torch  # noqa: PLC0415
     except ImportError as exc:
@@ -272,7 +296,7 @@ def _real_eval(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Evaluate a Qwen3-ASR fine-tune checkpoint.",
+        description="Evaluate an eliza-1 ASR fine-tune checkpoint.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--run-dir", required=True)

--- a/packages/training/scripts/asr/eval_asr_wer.py
+++ b/packages/training/scripts/asr/eval_asr_wer.py
@@ -126,8 +126,8 @@ def _transcribe(
         )
         return ""
     out = proc.stdout.strip()
-    # Qwen3-ASR wraps its transcript with `language English<asr_text>...`
-    # plus an optional `</asr_text>` close tag.
+    # Some ASR chat-template paths wrap transcripts with
+    # `language English<asr_text>...` plus an optional `</asr_text>` close tag.
     out = _LANG_TAG_RE.sub("", out).strip()
     out = _CLOSE_TAG_RE.sub("", out).strip()
     # Drop common chat-template artifacts.

--- a/packages/training/scripts/asr/finetune_asr.py
+++ b/packages/training/scripts/asr/finetune_asr.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python3
-"""Fine-tune scaffold for Qwen3-ASR (eliza-1 ASR model).
+"""Fine-tune scaffold for the frozen eliza-1 ASR model.
 
-Qwen3-ASR-{0.6B,1.7B} is a Qwen3 text backbone + HuBERT-derived audio
-mmproj projector. The upstream HuggingFace checkpoints
-(``Qwen/Qwen3-ASR-0.6B``, ``Qwen/Qwen3-ASR-1.7B``) use a
-WhisperFeatureExtractor front-end plus a projection head that maps 80-bin
-mel frames to the Qwen3 hidden space.
+The active Gemma cutover has no verified ASR checkpoint/projector pair yet.
+Synthetic smoke remains available for CI shape checks, but real train/eval
+must fail closed until a Gemma-compatible ASR base is explicitly configured.
 
 Why this scaffold exists
 ------------------------
 
-Wave 3 (W3-11) requires a fine-tune pipeline scaffold for Qwen3-ASR with
-real training out of scope (compute budget). This module provides:
+Wave 3 (W3-11) required a fine-tune pipeline scaffold with real training out
+of scope (compute budget). This module provides:
 
 - A working **data pipeline**: LJSpeech / Librispeech / custom corpus →
   HuggingFace ``DatasetDict`` format, with 80-bin log-mel feature
-  extraction matching the upstream WhisperFeatureExtractor parameters.
+  extraction matching the configured ASR front-end parameters.
 - A configurable **training loop** with:
   - CTC loss (the upstream model's head) as the primary loss.
   - Optional cross-entropy on the LM head (for encoder-decoder fine-tune).
@@ -103,8 +101,8 @@ log = logging.getLogger("asr.finetune")
 # ---------------------------------------------------------------------------
 
 DEFAULT_CONFIG: dict[str, Any] = {
-    "base_model": "Qwen/Qwen3-ASR-0.6B",
-    "sample_rate": 16000,          # WhisperFeatureExtractor expects 16 kHz
+    "base_model": "",
+    "sample_rate": 16000,          # configured ASR front-end rate
     "mel_bins": 80,
     "max_audio_seconds": 30.0,
     "min_audio_seconds": 0.5,
@@ -130,6 +128,28 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "rtf_min": 2.0,            # RTF ≥ 2× realtime
     },
 }
+
+
+def _asr_source_blocker(cfg: dict[str, Any]) -> str | None:
+    base_model = str(cfg.get("base_model", "")).strip()
+    if not base_model:
+        return (
+            "ASR real train/eval is disabled until a verified "
+            "Gemma-compatible ASR base_model and projector are configured."
+        )
+    lowered = base_model.lower()
+    if "qwen" in lowered and "asr" in lowered:
+        return (
+            f"{base_model} is retired for active Eliza-1 Gemma ASR work; "
+            "configure a verified Gemma-compatible ASR base_model instead."
+        )
+    return None
+
+
+def _require_active_asr_source(cfg: dict[str, Any]) -> None:
+    blocker = _asr_source_blocker(cfg)
+    if blocker:
+        raise SystemExit(blocker)
 
 
 # ---------------------------------------------------------------------------
@@ -477,8 +497,8 @@ def _load_corpus(data_dir: Path, cfg: dict[str, Any]) -> tuple[list[dict[str, An
 def _extract_features(wav_path: str, *, target_sr: int, mel_bins: int) -> Any:
     """Load WAV, resample to target_sr, compute 80-bin log-mel features.
 
-    Uses librosa for loading + resampling. The mel parameters match the
-    WhisperFeatureExtractor used by Qwen3-ASR upstream:
+    Uses librosa for loading + resampling. The default mel parameters match
+    the legacy 80-bin ASR front-end shape:
 
         n_fft=400, hop_length=160, n_mels=80, fmin=0, fmax=8000 at 16 kHz.
 
@@ -519,7 +539,7 @@ def _real_train(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
         pip install torch transformers datasets jiwer librosa apollo-torch
 
     Training steps:
-    1. Load Qwen3-ASR from HuggingFace (base_model).
+    1. Load the configured Gemma-compatible ASR base from HuggingFace.
     2. Load and split corpus (train/val).
     3. Compute mel features for each clip.
     4. Minimize CTC loss (+ optional LM-head CE) using APOLLO-Mini.
@@ -527,6 +547,8 @@ def _real_train(args: argparse.Namespace, cfg: dict[str, Any]) -> int:
     6. Save best checkpoint (lowest val WER).
     7. Emit eval.json + train_manifest.json + artifact receipt.
     """
+    _require_active_asr_source(cfg)
+
     try:
         import torch  # noqa: PLC0415
     except ImportError as exc:
@@ -894,7 +916,7 @@ def _push_to_hf(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Fine-tune scaffold for Qwen3-ASR (eliza-1 ASR model).",
+        description="Fine-tune scaffold for the frozen eliza-1 ASR model.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/packages/training/scripts/asr/push_asr_gguf_to_hf.py
+++ b/packages/training/scripts/asr/push_asr_gguf_to_hf.py
@@ -1,4 +1,4 @@
-"""Publish the Qwen3-ASR K-quant ladder + Q8_0 mmproj to HuggingFace.
+"""Publish a verified ASR K-quant ladder + Q8_0 projector to HuggingFace.
 
 Target: ``elizaos/eliza-1-training`` (Apache-2.0, public) under ``voice/asr/``.
 
@@ -24,6 +24,7 @@ The wrapper:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -31,6 +32,19 @@ from pathlib import Path
 
 log = logging.getLogger("push_asr_gguf_to_hf")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def _contains_retired_asr_source(sidecar: Path) -> bool:
+    try:
+        text = sidecar.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = text
+    normalized = json.dumps(payload, sort_keys=True).lower()
+    return "qwen" in normalized and "asr" in normalized
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -74,6 +88,15 @@ def main(argv: list[str] | None = None) -> int:
     missing = [str(p) for p, _ in expected if not p.exists()]
     if missing:
         log.error("missing files:\n  %s", "\n  ".join(missing))
+        return 2
+
+    sidecar = quant_dir / "gguf_asr.json"
+    if _contains_retired_asr_source(sidecar):
+        log.error(
+            "%s contains retired ASR provenance; publish only verified "
+            "Gemma-compatible ASR artifacts.",
+            sidecar,
+        )
         return 2
 
     if args.dry_run:


### PR DESCRIPTION
## Summary
- freeze training ASR real train/eval defaults until a verified Gemma-compatible ASR checkpoint/projector is hosted
- reject retired Qwen ASR sources in real train/eval and GGUF publish helpers
- update shared local-inference ASR catalog/version metadata and training docs to stop advertising Qwen ASR as active Gemma replacement work

## Evidence
- git fetch origin && git rebase origin/develop
- bun install
- python3 -m pytest packages/training/scripts/asr/__tests__/test_asr_pipeline.py -q
- python3 -m py_compile packages/training/scripts/asr/finetune_asr.py packages/training/scripts/asr/eval_asr.py packages/training/scripts/asr/eval_asr_wer.py packages/training/scripts/asr/push_asr_gguf_to_hf.py
- bun run --cwd packages/shared typecheck
- bun run --cwd packages/shared lint
- bun run verify
- git diff --check

## Notes
- This is part of #9588 / #9583 Gemma cutover work.
- Real ASR training remains fail-closed until verified Gemma-compatible ASR artifacts exist; synthetic shape tests remain available.
