### PR TITLE
fix(training): queue Gemma fine-tune verification

### DIFF
--- a/packages/training/scripts/manifest/release_verification_queue.py
+++ b/packages/training/scripts/manifest/release_verification_queue.py
@@ -15,7 +15,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Final, Mapping
 
 try:
     from scripts.manifest.audit_hf_eliza1_release import audit_hf_release
@@ -29,6 +29,14 @@ except ImportError:  # pragma: no cover - script execution path
 TIER_ORDER: tuple[str, ...] = ELIZA_1_TIERS
 BACKEND_ORDER: tuple[str, ...] = ("cpu", "metal", "vulkan", "cuda", "rocm")
 IMAGEGEN_ACCELERATOR_ORDER: tuple[str, ...] = ("cpu", "metal", "vulkan", "cuda")
+REGISTRY_KEY_BY_TIER: Final[Mapping[str, str]] = {
+    "2b": "gemma4-e2b",
+    "4b": "gemma4-e4b",
+    "9b": "gemma4-12b",
+    "27b": "gemma4-31b",
+    "27b-256k": "gemma4-31b",
+}
+FINE_TUNE_TIER: Final[str] = TIER_ORDER[0]
 _TIER_CHECK_RE = re.compile(r"^(?P<tier>\S+) (?P<kind>.+)$")
 _PLATFORM_TARGET_RE = re.compile(r"\b([a-z0-9]+(?:-[a-z0-9]+)+):\s*status='(?:pending|fail|skipped)'")
 
@@ -235,23 +243,24 @@ def _mtp_command(bundle_root: str, tier: str, eval_python: str) -> str:
     )
 
 
-def _finetune_command(eval_python: str) -> str:
+def _finetune_command(eval_python: str, tier: str = FINE_TUNE_TIER) -> str:
+    registry_key = REGISTRY_KEY_BY_TIER[tier]
     return _guarded(
         eval_python,
-        "hf download elizaos/eliza-1-training --type dataset --include 'sft/0_8b/*' "
+        f"hf download elizaos/eliza-1-training --type dataset --include 'sft/{tier}/*' "
         "--local-dir /tmp/eliza-1-training && "
         "cd packages/training && "
         "uv run --extra train python scripts/run_pipeline.py "
-        "--registry-key gemma4-e2b "
-        "--train-file /tmp/eliza-1-training/sft/0_8b/train.jsonl "
-        "--val-file /tmp/eliza-1-training/sft/0_8b/val.jsonl "
-        "--test-file /tmp/eliza-1-training/sft/0_8b/test.jsonl "
-        "--epochs 1 --run-name eliza-1-0_8b-finetuned-v2 && "
+        f"--registry-key {registry_key} "
+        f"--train-file /tmp/eliza-1-training/sft/{tier}/train.jsonl "
+        f"--val-file /tmp/eliza-1-training/sft/{tier}/val.jsonl "
+        f"--test-file /tmp/eliza-1-training/sft/{tier}/test.jsonl "
+        f"--epochs 1 --run-name eliza-1-{tier}-finetuned-v2 && "
         "uv run --extra train python scripts/benchmark/native_tool_call_bench.py "
-        "--model checkpoints/eliza-1-0_8b-finetuned-v2/final "
-        "--test-file /tmp/eliza-1-training/sft/0_8b/test.jsonl "
+        f"--model checkpoints/eliza-1-{tier}-finetuned-v2/final "
+        f"--test-file /tmp/eliza-1-training/sft/{tier}/test.jsonl "
         "--out-dir /tmp/eliza-1-finetune-native-tool-call && "
-        "publish bundles/0_8b/finetuned-v2/eliza-1-0_8b-sft.gguf plus "
+        f"publish bundles/{tier}/finetuned-v2/eliza-1-{tier}-sft.gguf plus "
         "evidence/training/fine-tune-comparison.json only after baseline-vs-finetuned "
         "eliza_bench, native_tool_call, and structured_response reports pass",
     )
@@ -505,17 +514,17 @@ def build_queue(
         detail = str(check.get("detail", ""))
         items.append(
             QueueItem(
-                id="0_8b:fine-tune-comparison",
-                tier="0_8b",
+                id=f"{FINE_TUNE_TIER}:fine-tune-comparison",
+                tier=FINE_TUNE_TIER,
                 category="fineTuneComparison",
                 priority=500,
                 requires_hardware=True,
-                command=_finetune_command(eval_python),
+                command=_finetune_command(eval_python, FINE_TUNE_TIER),
                 evidence=(
-                    "bundles/0_8b/finetuned-v2/eliza-1-0_8b-sft.gguf",
-                    "evidence/training/0_8b/eliza-bench.json",
-                    "evidence/training/0_8b/native-tool-call.json",
-                    "evidence/training/0_8b/structured-response.json",
+                    f"bundles/{FINE_TUNE_TIER}/finetuned-v2/eliza-1-{FINE_TUNE_TIER}-sft.gguf",
+                    f"evidence/training/{FINE_TUNE_TIER}/eliza-bench.json",
+                    f"evidence/training/{FINE_TUNE_TIER}/native-tool-call.json",
+                    f"evidence/training/{FINE_TUNE_TIER}/structured-response.json",
                     "evidence/training/fine-tune-comparison.json",
                 ),
                 source=name,

--- a/packages/training/scripts/manifest/test_release_verification_queue.py
+++ b/packages/training/scripts/manifest/test_release_verification_queue.py
@@ -36,13 +36,13 @@ def test_build_queue_expands_grouped_audit_failures() -> None:
             ],
             "backendVerification": [
                 {
-                    "name": "0_8b required backend verification passed",
+                    "name": "2b required backend verification passed",
                     "detail": "metal: fail, vulkan: fail, cpu: fail",
                 }
             ],
             "manifestEvalGates": [
                 {
-                    "name": "0_8b manifest eval gates passed",
+                    "name": "2b manifest eval gates passed",
                     "detail": "evals.textEval.passed: False",
                 }
             ],
@@ -55,10 +55,10 @@ def test_build_queue_expands_grouped_audit_failures() -> None:
         "4b:missing-release-files",
         "4b:manifest-runtime-surface",
         "4b:checksum-surface",
-        "0_8b:backend:cpu",
-        "0_8b:backend:metal",
-        "0_8b:backend:vulkan",
-        "0_8b:eval-suite",
+        "2b:backend:cpu",
+        "2b:backend:metal",
+        "2b:backend:vulkan",
+        "2b:eval-suite",
     ]
     missing = items[0]
     assert missing.requires_hardware is True
@@ -77,7 +77,7 @@ def test_build_queue_expands_grouped_audit_failures() -> None:
     assert cpu.requires_hardware is False
     assert cpu.command.startswith("python3 packages/training/scripts/manifest/release_process_guard.py && ")
     assert "ELIZA_EVAL_ALLOW_CONCURRENT_LLM=0" in cpu.command
-    assert "--bundle-dir /bundles/eliza-1-0_8b.bundle" in cpu.command
+    assert "--bundle-dir /bundles/eliza-1-2b.bundle" in cpu.command
     assert "make -C plugins/plugin-local-inference/native/verify reference-test" in cpu.command
     assert "evals/cpu_reference.json" in cpu.evidence[1]
     metal = items[4]
@@ -115,17 +115,17 @@ def test_filter_queue_selects_next_local_item() -> None:
         "failuresByCategory": {
             "backendVerification": [
                 {
-                    "name": "0_8b required backend verification passed",
+                    "name": "2b required backend verification passed",
                     "detail": "metal: fail, vulkan: fail, cpu: fail",
                 },
                 {
-                    "name": "2b required backend verification passed",
+                    "name": "4b required backend verification passed",
                     "detail": "metal: fail, cpu: fail",
                 },
             ],
             "manifestEvalGates": [
                 {
-                    "name": "0_8b manifest eval gates passed",
+                    "name": "2b manifest eval gates passed",
                     "detail": "evals.textEval.passed: False",
                 }
             ],
@@ -135,7 +135,7 @@ def test_filter_queue_selects_next_local_item() -> None:
 
     selected = filter_queue(items, local_only=True, limit=1)
 
-    assert [item.id for item in selected] == ["0_8b:backend:cpu"]
+    assert [item.id for item in selected] == ["2b:backend:cpu"]
 
 
 def test_filter_queue_can_select_hardware_for_tier_and_category() -> None:
@@ -174,7 +174,7 @@ def test_build_queue_accepts_custom_verify_dir() -> None:
         "failuresByCategory": {
             "backendVerification": [
                 {
-                    "name": "0_8b required backend verification passed",
+                    "name": "2b required backend verification passed",
                     "detail": "cpu: fail",
                 }
             ],
@@ -272,7 +272,7 @@ def test_build_queue_expands_platform_evidence_blockers() -> None:
         "failuresByCategory": {
             "platformEvidence": [
                 {
-                    "name": "0_8b required platform evidence passed",
+                    "name": "2b required platform evidence passed",
                     "detail": (
                         "ios-arm64-metal: status='pending', ios-arm64-metal: report='not-run', "
                         "linux-x64-vulkan: status='pending', linux-x64-vulkan: report='not-run', "
@@ -286,13 +286,13 @@ def test_build_queue_expands_platform_evidence_blockers() -> None:
     items = build_queue(summary, bundle_root="/bundles", eval_python="python3")
 
     assert [item.id for item in items] == [
-        "0_8b:platform:ios-arm64-metal",
-        "0_8b:platform:linux-x64-vulkan",
-        "0_8b:platform:android-adreno-vulkan",
+        "2b:platform:ios-arm64-metal",
+        "2b:platform:linux-x64-vulkan",
+        "2b:platform:android-adreno-vulkan",
     ]
     assert all(item.requires_hardware for item in items)
     assert all(item.category == "platformEvidence" for item in items)
-    assert "bundles/0_8b/evidence/platform/ios-arm64-metal.json" in items[0].evidence
+    assert "bundles/2b/evidence/platform/ios-arm64-metal.json" in items[0].evidence
     assert "real device/host identifier" in items[0].command
 
 
@@ -342,7 +342,7 @@ def test_build_queue_expands_mtp_and_finetune_blockers() -> None:
 
     items = build_queue(summary, bundle_root="/bundles", eval_python="python3")
 
-    assert [item.id for item in items] == ["4b:mtp-drafter", "0_8b:fine-tune-comparison"]
+    assert [item.id for item in items] == ["4b:mtp-drafter", "2b:fine-tune-comparison"]
     mtp = items[0]
     assert mtp.requires_hardware is True
     assert mtp.category == "mtpDrafter"
@@ -362,10 +362,13 @@ def test_build_queue_expands_mtp_and_finetune_blockers() -> None:
     assert finetune.category == "fineTuneComparison"
     assert "scripts/run_pipeline.py" in finetune.command
     assert "scripts/benchmark/native_tool_call_bench.py" in finetune.command
-    assert "--model checkpoints/eliza-1-0_8b-finetuned-v2/final" in finetune.command
-    assert "--test-file /tmp/eliza-1-training/sft/0_8b/test.jsonl" in finetune.command
+    assert "--registry-key gemma4-e2b" in finetune.command
+    assert "--model checkpoints/eliza-1-2b-finetuned-v2/final" in finetune.command
+    assert "--test-file /tmp/eliza-1-training/sft/2b/test.jsonl" in finetune.command
     assert "--out-dir /tmp/eliza-1-finetune-native-tool-call" in finetune.command
-    assert "bundles/0_8b/finetuned-v2/eliza-1-0_8b-sft.gguf" in finetune.evidence
+    assert "0_8b" not in finetune.command
+    assert "bundles/2b/finetuned-v2/eliza-1-2b-sft.gguf" in finetune.evidence
+    assert all("0_8b" not in evidence for evidence in finetune.evidence)
 
 
 def test_build_queue_maps_27b_256k_mtp_to_validation_tier_27b() -> None:


### PR DESCRIPTION
## Summary
- retarget the release verification queue fine-tune item from retired `0_8b` paths to the smallest active Gemma tier, `2b` / `gemma4-e2b`
- derive the fine-tune queue item from the active tier list instead of hardcoding `0_8b`
- update queue tests so stale `0_8b` audit fixtures do not get treated as active release work

Part of #9588 and #9583.

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/manifest/test_release_verification_queue.py -q` -> 15 passed
- `python3 -m py_compile packages/training/scripts/manifest/release_verification_queue.py packages/training/scripts/manifest/test_release_verification_queue.py`
- `git diff --check`
- `bun run verify` -> 515/515 tasks successful

## PR Evidence Checklist
- Real-LLM trajectories: N/A, release queue metadata helper only
- Backend logs: N/A, no runtime backend path
- Frontend logs/screenshots/video: N/A, no UI path
- Audio walkthrough: N/A, no voice runtime path
- Cloud audit: N/A, no `packages/cloud-frontend` change