### PR TITLE
fix(training): route cloud launchers to Gemma tiers

### DIFF
--- a/packages/training/scripts/cloud/README.md
+++ b/packages/training/scripts/cloud/README.md
@@ -10,10 +10,10 @@ This wraps existing primitives — it does not duplicate them:
 
 | Provider | What it uses |
 |---|---|
-| `vast` | the `vastai` CLI (`pip install --user vastai`), `VAST_API_KEY` — implemented here for `build` / `kernel-verify` / `bench` |
+| `vast` | [`dispatch-vast.sh`](dispatch-vast.sh), the `vastai` CLI (`pip install --user vastai`), `VAST_API_KEY` |
 | `--task train --provider vast` | delegates to [`../train_vast.sh provision-and-train`](../CLOUD_VAST.md) (its GPU mapping, checkpoint pull, teardown) |
-| `--task train --provider nebius` | delegates to [`../train_nebius.sh full`](../train_nebius.sh) — H200 (`gpu-h200x1` for 0.6b/1.7b/9b, `gpu-h200x2` + FSDP for 27b); requires `NEBIUS_PROJECT_ID`. Emergency fallback; Vast is canonical. |
-| `nebius` + `kernel-verify`/`bench` | not wired yet (extend `../lib/backends/nebius.py` + the `kernel-verify`/`bench` branch in `run-on-cloud.sh`) |
+| `--task train --provider nebius` | delegates to [`../train_nebius.sh full`](../train_nebius.sh) — H200 (`gpu-h200x1` for 2b/4b/9b, `gpu-h200x2` + FSDP for 27b/27b-256k); requires `NEBIUS_PROJECT_ID`. Emergency fallback; Vast is canonical. |
+| `nebius` + `kernel-verify`/`bench` | [`dispatch-nebius.sh`](dispatch-nebius.sh), delegating VM lifecycle to `../train_nebius.sh` |
 
 The existing cloud backend abstraction (`../lib/backends/base.py`,
 `../cloud_run.py`) is the place to add Nebius/RunPod/Lambda for the
@@ -50,21 +50,21 @@ bash packages/training/scripts/cloud/run-on-cloud.sh \
   --provider vast --task kernel-verify --gpu h100 \
   --smoke-model /models/eliza-1-smoke.gguf --yes-i-will-pay
 
-# CUDA e2e bench for the 0.8B tier on an RTX 4090:
+# CUDA e2e bench for the 2B tier on an RTX 4090:
 bash packages/training/scripts/cloud/run-on-cloud.sh \
-  --provider vast --task bench --gpu rtx4090 --tier 0_8b --yes-i-will-pay
+  --provider vast --task bench --gpu rtx4090 --tier 2b --yes-i-will-pay
 
 # Train the 27B tier on 2x B200 (delegates to train_vast.sh provision-and-train):
 bash packages/training/scripts/cloud/run-on-cloud.sh \
   --provider vast --task train --gpu b200 --tier 27b --yes-i-will-pay
 
-# Train the 0.8B tier on a Nebius H200 (delegates to train_nebius.sh full):
+# Train the 2B tier on a Nebius H200 (delegates to train_nebius.sh full):
 NEBIUS_PROJECT_ID=project-… HUGGING_FACE_HUB_TOKEN=… \
 bash packages/training/scripts/cloud/run-on-cloud.sh \
-  --provider nebius --task train --gpu h200 --tier 0_8b --yes-i-will-pay
+  --provider nebius --task train --gpu h200 --tier 2b --yes-i-will-pay
 # Plan only (no spend):
 bash packages/training/scripts/cloud/run-on-cloud.sh \
-  --provider nebius --task train --gpu h200 --tier 0_8b --dry-run
+  --provider nebius --task train --gpu h200 --tier 2b --dry-run
 
 # Plan only — prints what it WOULD provision, spends nothing:
 bash packages/training/scripts/cloud/run-on-cloud.sh \
@@ -75,10 +75,10 @@ bash packages/training/scripts/cloud/run-on-cloud.sh \
 
 | Flag | Values | Default |
 |---|---|---|
-| `--provider` | `vast` \| `nebius` | (required) |
+| `--provider` | `vast` \| `nebius` | auto from `tier-routing.json` |
 | `--task` | `build` \| `kernel-verify` \| `bench` \| `train` | (required) |
 | `--gpu` | `h100` `h200` `a100` `a100-80` `rtx4090` `rtx5090` `l40s` `b200` `blackwell6000` | `h100` |
-| `--tier` | `0_8b` `2b` `4b` `9b` `27b`  | `0_8b` |
+| `--tier` | `2b` `4b` `9b` `27b` `27b-256k` | `2b` |
 | `--ssh-pubkey` | path | `~/.ssh/id_ed25519.pub` |
 | `--smoke-model` | path to a GGUF | none (parity-only) |
 | `--yes-i-will-pay` | (gate) — required for any real provisioning | off |

--- a/packages/training/scripts/cloud/dispatch-nebius.sh
+++ b/packages/training/scripts/cloud/dispatch-nebius.sh
@@ -13,7 +13,7 @@
 # --dry-run prints the provisioning plan and spends nothing.
 #
 # Usage (forwarded straight from run-on-cloud.sh; see also that script's --help):
-#   dispatch-nebius.sh --task train         --tier 0_8b [--yes-i-will-pay]
+#   dispatch-nebius.sh --task train         --tier 2b   [--yes-i-will-pay]
 #   dispatch-nebius.sh --task train         --tier 9b   [--yes-i-will-pay]
 #   dispatch-nebius.sh --task train         --tier 27b  [--yes-i-will-pay]   # 8xH200, expensive
 #   dispatch-nebius.sh --task kernel-verify --gpu h200  [--yes-i-will-pay]
@@ -24,7 +24,7 @@
 #   NEBIUS_PROJECT_ID       required for any real provisioning (the project ==
 #                            --parent-id for `nebius compute v1 instance create`)
 #   HUGGING_FACE_HUB_TOKEN  forwarded by train_nebius.sh for gated repos
-#   NEBIUS_VM_PRESET        gpu-h200x1 (default for 0_8b/2b/4b/9b) | gpu-h200x2 (27b)
+#   NEBIUS_VM_PRESET        gpu-h200x1 (default for 2b/4b/9b) | gpu-h200x2 (27b/27b-256k)
 #   SSH_PUBKEY              path to your ssh pubkey (default ~/.ssh/id_ed25519.pub)
 #   ELIZA_MTP_SMOKE_MODEL  optional GGUF for the kernel-verify graph smoke
 set -euo pipefail
@@ -39,7 +39,7 @@ TIER_ROUTING_JSON="$HERE/tier-routing.json"
 
 TASK="train"
 GPU=""
-TIER="0_8b"
+TIER="2b"
 PAY=0
 DRYRUN=0
 SSH_PUBKEY="${SSH_PUBKEY:-$HOME/.ssh/id_ed25519.pub}"
@@ -65,7 +65,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$TASK" in build|kernel-verify|bench|train) ;; *) die "unknown task '$TASK' (build|kernel-verify|bench|train)" ;; esac
-case "$TIER" in 0_8b|2b|4b|9b|27b) ;; *) die "unknown tier '$TIER' (0_8b|2b|4b|9b|27b)" ;; esac
+case "$TIER" in 2b|4b|9b|27b|27b-256k) ;; *) die "unknown tier '$TIER' (2b|4b|9b|27b|27b-256k)" ;; esac
 
 # --- tier -> defaults from tier-routing.json ----------------------------------
 read_tier_field() {
@@ -79,8 +79,8 @@ DEFAULT_PRESET="$(read_tier_field default_nebius_preset)"
 # only; there is no 2gpu preset. 27b therefore rents 8x H200.
 tier_to_preset() {
   case "$1" in
-    0_8b|2b|4b|9b)  echo "${DEFAULT_PRESET:-gpu-h200x1}" ;;
-    27b)             echo "${DEFAULT_PRESET:-gpu-h200x2}" ;;
+    2b|4b|9b)        echo "${DEFAULT_PRESET:-gpu-h200x1}" ;;
+    27b|27b-256k)    echo "${DEFAULT_PRESET:-gpu-h200x2}" ;;
   esac
 }
 NEBIUS_VM_PRESET="$(tier_to_preset "$TIER")"
@@ -88,11 +88,10 @@ NEBIUS_VM_PRESET="$(tier_to_preset "$TIER")"
 # Map --tier to model_registry.py REGISTRY key (matches dispatch-vast's mapping).
 tier_to_registry_key() {
   case "$1" in
-    0_8b) echo gemma4-e2b ;;
-    2b)   echo gemma4-e2b ;;
-    4b)   echo gemma4-e4b ;;
-    9b)   echo gemma4-12b ;;
-    27b) echo gemma4-31b ;;
+    2b)        echo gemma4-e2b ;;
+    4b)        echo gemma4-e4b ;;
+    9b)        echo gemma4-12b ;;
+    27b|27b-256k) echo gemma4-31b ;;
   esac
 }
 
@@ -122,7 +121,7 @@ if [[ "$TASK" == "train" ]]; then
   fi
   [[ "$PAY" == 1 ]] || die "refusing to provision without --yes-i-will-pay (train runs cost real money -- 8xH200 is ~\$240+/hr; see ../train_nebius.sh)"
   [[ -n "${NEBIUS_PROJECT_ID:-}" ]] || die "NEBIUS_PROJECT_ID not set -- fail-closed"
-  if [[ "$TIER" == "27b" ]]; then
+  if [[ "$TIER" == 27b* ]]; then
     log "WARNING: $TIER on Nebius rents 8x H200 (~\$240+/hr). Prefer dispatch-vast for 2-4 GPU configurations."
   fi
   exec env NEBIUS_VM_PRESET="$NEBIUS_VM_PRESET" REGISTRY_KEY="$REG_KEY" "${CMD[@]}"

--- a/packages/training/scripts/cloud/dispatch-vast.sh
+++ b/packages/training/scripts/cloud/dispatch-vast.sh
@@ -15,7 +15,7 @@
 # Usage (forwarded straight from run-on-cloud.sh; see also that script's --help):
 #   dispatch-vast.sh --task build         --gpu h100   [--yes-i-will-pay]
 #   dispatch-vast.sh --task kernel-verify --gpu h100   [--yes-i-will-pay]
-#   dispatch-vast.sh --task bench         --gpu rtx4090 --tier 0_8b [--yes-i-will-pay]
+#   dispatch-vast.sh --task bench         --gpu rtx4090 --tier 2b [--yes-i-will-pay]
 #   dispatch-vast.sh --task train         --gpu b200    --tier 27b  [--yes-i-will-pay]
 #   dispatch-vast.sh --task kernel-verify --gpu h100   --dry-run
 #   dispatch-vast.sh --tier 9b            --dry-run                   # task defaults to train
@@ -39,7 +39,7 @@ TIER_ROUTING_JSON="$HERE/tier-routing.json"
 
 TASK="train"
 GPU=""
-TIER="0_8b"
+TIER="2b"
 PAY=0
 DRYRUN=0
 SSH_PUBKEY="${SSH_PUBKEY:-$HOME/.ssh/id_ed25519.pub}"
@@ -72,7 +72,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$TASK" in build|kernel-verify|bench|train) ;; *) die "unknown task '$TASK' (build|kernel-verify|bench|train)" ;; esac
-case "$TIER" in 0_8b|2b|4b|9b|27b) ;; *) die "unknown tier '$TIER' (0_8b|2b|4b|9b|27b)" ;; esac
+case "$TIER" in 2b|4b|9b|27b|27b-256k) ;; *) die "unknown tier '$TIER' (2b|4b|9b|27b|27b-256k)" ;; esac
 
 # --- tier → defaults from tier-routing.json -----------------------------------
 # Use the routing table to pick a default GPU + min VRAM when --gpu is not set.
@@ -109,11 +109,10 @@ gpu_to_train_vast_token() {
 }
 tier_to_registry_key() {
   case "$1" in
-    0_8b) echo gemma4-e2b ;;
-    2b)   echo gemma4-e2b ;;
-    4b)   echo gemma4-e4b ;;
-    9b)   echo gemma4-12b ;;
-    27b) echo gemma4-31b ;;
+    2b)        echo gemma4-e2b ;;
+    4b)        echo gemma4-e4b ;;
+    9b)        echo gemma4-12b ;;
+    27b|27b-256k) echo gemma4-31b ;;
   esac
 }
 

--- a/packages/training/scripts/cloud/run-on-cloud.sh
+++ b/packages/training/scripts/cloud/run-on-cloud.sh
@@ -4,18 +4,17 @@
 # instance unless you pass --yes-i-will-pay AND the relevant API-key env var is
 # set. --dry-run prints the provisioning plan and spends nothing.
 #
-# This wraps the existing primitives instead of duplicating them:
-#   * vast.ai      → the `vastai` CLI (VAST_API_KEY)  [implemented here]
-#   * nebius       → `train_nebius.sh` (NEBIUS_*)     [delegated for --task train;
-#                                                      kernel-verify/bench stay vast-only here]
-#   * --task train → delegates to ../train_vast.sh provision-and-train
+# This is the selector front door. If --provider is omitted, tier-routing.json
+# chooses vast.ai or Nebius, then this script forwards every operational flag to
+# dispatch-vast.sh or dispatch-nebius.sh.
 #
 # Usage:
+#   run-on-cloud.sh --task train --tier 9b --dry-run                         # auto-routes
 #   run-on-cloud.sh --provider vast   --task build         --gpu h100 --yes-i-will-pay
 #   run-on-cloud.sh --provider vast   --task kernel-verify --gpu h100 [--yes-i-will-pay]
-#   run-on-cloud.sh --provider vast   --task bench         --gpu rtx4090 --tier 0_8b --yes-i-will-pay
+#   run-on-cloud.sh --provider vast   --task bench         --gpu rtx4090 --tier 2b --yes-i-will-pay
 #   run-on-cloud.sh --provider vast   --task train         --gpu b200 --tier 27b --yes-i-will-pay
-#   run-on-cloud.sh --provider nebius --task train         --gpu h200 --tier 0_8b --yes-i-will-pay
+#   run-on-cloud.sh --provider nebius --task train         --gpu h200 --tier 2b --yes-i-will-pay
 #   run-on-cloud.sh --provider vast   --task kernel-verify --gpu h100 --dry-run     # no spend
 #
 # Tasks:
@@ -24,15 +23,15 @@
 #                  pulls JSON to packages/inference/verify/hardware-results/.
 #   bench          build linux-x64-cuda, run the e2e CUDA bench harness for the
 #                  given --tier; pulls JSON to packages/inference/verify/bench_results/.
-#   train          delegates to ../train_vast.sh provision-and-train (uses that
-#                  script's own GPU mapping + checkpoint pull + teardown).
+#   train          delegates to the selected provider dispatcher, which then
+#                  calls ../train_vast.sh or ../train_nebius.sh.
 #
 # GPU friendly names (mapped to vastai search filters / train_vast GPU tokens):
 #   h100 | h200 | a100 | a100-80 | rtx4090 | rtx5090 | b200 | l40s | blackwell6000
 #
 # Tiers (informational for kernel-verify; sizes the model for bench/train):
-#   0_8b | 2b | 4b | 9b | 27b
-# The legacy Qwen3 tiers (0_6b / 1_7b) were dropped 2026-05-12 — those bases
+#   2b | 4b | 9b | 27b | 27b-256k
+# The legacy pre-Gemma tiers (0_6b / 1_7b) were dropped 2026-05-12 — those bases
 # don't work with the eliza-1 mtp spec-decode path.
 #
 # Required env per provider:
@@ -52,10 +51,11 @@ DATE_TAG="$(date -u +%Y-%m-%d)"
 GIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 GIT_REMOTE="$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null || echo 'https://github.com/elizaOS/eliza.git')"
 
+ORIGINAL_ARGS=("$@")
 PROVIDER=""
 TASK=""
 GPU="h100"
-TIER="0_8b"
+TIER="2b"
 PAY=0
 DRYRUN=0
 SSH_PUBKEY="${SSH_PUBKEY:-$HOME/.ssh/id_ed25519.pub}"
@@ -79,11 +79,26 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$PROVIDER" ]] || die "--provider {vast,nebius} is required"
 [[ -n "$TASK" ]]     || die "--task {kernel-verify,bench,train} is required"
-case "$PROVIDER" in vast|nebius) ;; *) die "unknown provider '$PROVIDER'" ;; esac
 case "$TASK" in build|kernel-verify|bench|train) ;; *) die "unknown task '$TASK'" ;; esac
-case "$TIER" in 0_8b|2b|4b|9b|27b) ;; *) die "unknown tier '$TIER'" ;; esac
+case "$TIER" in 2b|4b|9b|27b|27b-256k) ;; *) die "unknown tier '$TIER'" ;; esac
+
+TIER_ROUTING_JSON="$HERE/tier-routing.json"
+if [[ -z "$PROVIDER" ]]; then
+  PROVIDER="$(python3 -c "import json; d=json.load(open('$TIER_ROUTING_JSON')); print(d['tiers']['$TIER'].get('recommended_provider','vast'))" 2>/dev/null || echo vast)"
+fi
+case "$PROVIDER" in vast|nebius) ;; *) die "unknown provider '$PROVIDER'" ;; esac
+
+FORWARD_ARGS=()
+for ((i=0; i<${#ORIGINAL_ARGS[@]}; i++)); do
+  arg="${ORIGINAL_ARGS[$i]}"
+  case "$arg" in
+    --provider) i=$((i+1)) ;;
+    --provider=*) ;;
+    *) FORWARD_ARGS+=("$arg") ;;
+  esac
+done
+exec bash "$HERE/dispatch-${PROVIDER}.sh" "${FORWARD_ARGS[@]}"
 
 # --------------------------------------------------------------------------
 # GPU friendly name → vastai search clause + train_vast token.
@@ -116,11 +131,10 @@ tier_to_registry_key() {
   # fused paths. The 0_6b/1_7b legacy tier ids in the runtime
   # manifest stay addressable but no longer route to a registry key.
   case "$1" in
-    0_8b) echo gemma4-e2b ;;
-    2b)   echo gemma4-e2b ;;
-    4b)   echo gemma4-e4b ;;
-    9b)   echo gemma4-12b ;;
-    27b) echo gemma4-31b ;;
+    2b)        echo gemma4-e2b ;;
+    4b)        echo gemma4-e4b ;;
+    9b)        echo gemma4-12b ;;
+    27b|27b-256k) echo gemma4-31b ;;
   esac
 }
 

--- a/packages/training/scripts/cloud/test_dispatch_dryrun.sh
+++ b/packages/training/scripts/cloud/test_dispatch_dryrun.sh
@@ -46,7 +46,7 @@ assert_contains() {
 }
 
 # --- dispatch-vast.sh, train task, multiple tiers ------------------------------
-for TIER in 0_8b 2b 4b 9b 27b; do
+for TIER in 2b 4b 9b 27b 27b-256k; do
   out="$(bash "$HERE/dispatch-vast.sh" --task train --tier "$TIER" --dry-run 2>&1 || true)"
   assert_contains "vast/train/$TIER plan-banner"  "[dispatch-vast] === PLAN ==="  "$out"
   assert_contains "vast/train/$TIER tier-line"    "tier: $TIER"                   "$out"
@@ -64,9 +64,9 @@ assert_contains "vast/kernel-verify create-cmd"  "vastai create instance"       
 assert_contains "vast/kernel-verify destroy-cmd" "vastai destroy instance"       "$out"
 
 # --- dispatch-vast.sh, bench task ----------------------------------------------
-out="$(bash "$HERE/dispatch-vast.sh" --task bench --gpu rtx4090 --tier 0_8b --dry-run 2>&1 || true)"
+out="$(bash "$HERE/dispatch-vast.sh" --task bench --gpu rtx4090 --tier 2b --dry-run 2>&1 || true)"
 assert_contains "vast/bench plan-banner"     "[dispatch-vast] === PLAN ===" "$out"
-assert_contains "vast/bench tier-line"       "tier: 0_8b"                    "$out"
+assert_contains "vast/bench tier-line"       "tier: 2b"                      "$out"
 assert_contains "vast/bench gpu-line"        "gpu          : rtx4090"        "$out"
 
 # --- dispatch-vast.sh, min-VRAM gate -- 9b on rtx4090 24GB must FAIL -----------
@@ -89,7 +89,7 @@ else
 fi
 
 # --- dispatch-nebius.sh, train task, multiple tiers ----------------------------
-for TIER in 0_8b 2b 4b 9b 27b; do
+for TIER in 2b 4b 9b 27b 27b-256k; do
   out="$(bash "$HERE/dispatch-nebius.sh" --task train --tier "$TIER" --dry-run 2>&1 || true)"
   assert_contains "nebius/train/$TIER plan-banner"  "[dispatch-nebius] === PLAN ===" "$out"
   assert_contains "nebius/train/$TIER tier-line"    "tier: $TIER"                    "$out"
@@ -118,6 +118,10 @@ fi
 # --- run-on-cloud.sh routing -- tier 27b without --provider should pick nebius -
 out="$(bash "$HERE/run-on-cloud.sh" --task train --tier 27b --dry-run 2>&1 || true)"
 assert_contains "selector/27b auto-route-to-nebius" "[dispatch-nebius] === PLAN ===" "$out"
+
+# --- run-on-cloud.sh routing -- tier 27b-256k should pick nebius --------------
+out="$(bash "$HERE/run-on-cloud.sh" --task train --tier 27b-256k --dry-run 2>&1 || true)"
+assert_contains "selector/27b-256k auto-route-to-nebius" "[dispatch-nebius] === PLAN ===" "$out"
 
 # --- run-on-cloud.sh routing -- tier 9b without --provider -> recommended=vast -
 out="$(bash "$HERE/run-on-cloud.sh" --task train --tier 9b --dry-run 2>&1 || true)"

--- a/packages/training/scripts/cloud/tier-routing.json
+++ b/packages/training/scripts/cloud/tier-routing.json
@@ -37,6 +37,13 @@
       "default_vast_gpu": "h200",
       "default_nebius_preset": "gpu-h200x2",
       "notes": "27B fp16 SFT needs 141GB+ for activations + optimizer state. H200 141GB single, or 2x H100 80GB with FSDP. Nebius 8x H200 preset is the no-fuss path; expensive."
+    },
+    "27b-256k": {
+      "min_vram_gb": 190,
+      "recommended_provider": "nebius",
+      "default_vast_gpu": "b200",
+      "default_nebius_preset": "gpu-h200x2",
+      "notes": "Long-context 27B release tier uses the Gemma 4 31B base with the 256k runtime profile. Prefer 2x B200 on Vast or Nebius gpu-h200x2 for budget headroom."
     }
   }
 }

--- a/packages/training/scripts/publish/eliza1-hf-push.sh
+++ b/packages/training/scripts/publish/eliza1-hf-push.sh
@@ -22,7 +22,7 @@
 #       (no args → prints would-be commands, exits non-zero)
 #
 #   HF_TOKEN=hf_xxx bash packages/training/scripts/publish/eliza1-hf-push.sh \
-#       --yes-i-will-pay [--bundles-root DIR] [--tier 0_8b ...]
+#       --yes-i-will-pay [--bundles-root DIR] [--tier 2b ...]
 #
 # Other flags (passed through to publish_eliza1_model_repo):
 #   --bundles-root DIR      Default: ~/.eliza/local-inference/models

--- a/packages/training/scripts/publish/eliza1-hf-stage.mjs
+++ b/packages/training/scripts/publish/eliza1-hf-stage.mjs
@@ -13,7 +13,7 @@
 //   node packages/training/scripts/publish/eliza1-hf-stage.mjs --dry-run
 //   node packages/training/scripts/publish/eliza1-hf-stage.mjs --bundles-root ~/staging
 //   node packages/training/scripts/publish/eliza1-hf-stage.mjs --report /tmp/plan.json
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --tier 0_8b --tier 2b
+//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --tier 2b --tier 4b
 //
 // Exit codes mirror the Python publisher:
 //   0 — every tier uploadable (or --allow-missing was passed)

--- a/packages/training/scripts/publish_custom_kokoro_voice.sh
+++ b/packages/training/scripts/publish_custom_kokoro_voice.sh
@@ -17,7 +17,7 @@
 #   scripts/publish_custom_kokoro_voice.sh \
 #       --release-dir /tmp/kokoro-runs/my_voice/release/my_voice \
 #       --bundles-root ./bundles \
-#       --tier 0_8b
+#       --tier 2b
 #
 #   # Skip the eval gate (requires a written justification per AGENTS.md §6):
 #   scripts/publish_custom_kokoro_voice.sh \
@@ -26,7 +26,7 @@
 #       --tier 9b \
 #       --allow-gate-fail "tracked under <issue/PR url>"
 #
-# Tiers must match the Eliza-1 catalog set: 0_8b 2b 4b 9b 27b.
+# Tiers must match the Eliza-1 catalog set: 2b 4b 9b 27b 27b-256k.
 
 set -euo pipefail
 
@@ -37,7 +37,7 @@ readonly TRAINING_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # `packages/shared/src/local-inference/catalog.ts` and with the manifest
 # module at `packages/training/scripts/manifest/eliza1_manifest.py:38-46`.
 # R7 §"side bugs" flagged the prior `4b` omission as a publish-blocking bug.
-readonly VALID_TIERS=("0_8b" "2b" "4b" "9b" "27b")
+readonly VALID_TIERS=("2b" "4b" "9b" "27b" "27b-256k")
 
 RELEASE_DIR=""
 BUNDLES_ROOT=""

--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -216,8 +216,9 @@ def _format_ok_rate(summary: dict | None) -> float | None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--registry-key", required=True,
-                    help="One of: gemma4-e2b, gemma4-e4b, "
-                         "eliza-1-0_8b, eliza-1-2b, eliza-1-4b. "
+                    help="One of: gemma4-e2b, gemma4-e4b, gemma4-12b, "
+                         "gemma4-31b, eliza-1-2b, eliza-1-4b, eliza-1-9b, "
+                         "eliza-1-27b. "
                          "Internal upstream keys are aliases.")
     ap.add_argument("--run-name", default=None,
                     help="Default: <registry-key>-apollo-<unix-ts>.")

--- a/packages/training/scripts/test_train_nebius_smoke_all_tiers.py
+++ b/packages/training/scripts/test_train_nebius_smoke_all_tiers.py
@@ -210,7 +210,8 @@ def test_smoke_all_help_lists_tiers():
     assert "TIERS" in out, f"help output missing TIERS doc:\n{out}"
     assert "SMOKE_MAX_STEPS" in out
     assert "SMOKE_DATA_DIR" in out
-    assert "0_8b" in out and "27b" in out
+    assert "2b" in out and "27b" in out
+    assert "0_8b" not in out
 
 
 # ---------- run_pipeline.py end-to-end skip-everything smoke ----------------

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -12,13 +12,13 @@ Usage:
     # Smoke test on the smallest eliza-1 tier
     uv run --extra train python scripts/train_local.py \
         --registry-key gemma4-e2b \
-        --max-samples 256 --epochs 1 --run-name eliza-1-0_8b-smoke
+        --max-samples 256 --epochs 1 --run-name eliza-1-2b-smoke
 
     # Real run
     uv run --extra train python scripts/train_local.py \
         --registry-key gemma4-e2b \
         --epochs 3 --batch-size 4 --grad-accum 8 \
-        --run-name eliza-1-0_8b-eliza-native-v1
+        --run-name eliza-1-2b-eliza-native-v1
 """
 
 from __future__ import annotations
@@ -309,7 +309,7 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--resume-from-checkpoint", default=None,
         help="Resume SFT from an existing checkpoint dir (e.g. "
-             "checkpoints/eliza-1-0_8b-apollo-fullcorpus-h200-1778619044/"
+             "checkpoints/eliza-1-2b-apollo-fullcorpus-h200-1778619044/"
              "checkpoint-1000). The Trainer restores model + optimizer + LR "
              "scheduler + global_step from the checkpoint; combine with "
              "--max-steps to extend training past the original cap. Path "
@@ -322,7 +322,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-seq-len", type=int, default=None,
         help="Training sequence length. When `--registry-key` is set and the "
              "user did not pass `--max-seq-len`, the registry's `seq_len` "
-             "default is used (e.g. 4k for 0.8B, 8k for 2B, 16k for 4B). "
+             "default is used (8k for 2B/4B, 16k for 9B, 64k for 27B). "
              "Default None falls back to 4096 when no registry key is set. "
              "Pass `--max-seq-len <N>` to override the registry default for "
              "a single run — useful for long-context experiments "
@@ -417,8 +417,9 @@ def apply_resolved_defaults(args: argparse.Namespace) -> None:
                 f"--registry-key {args.registry_key!r} → hf_id {entry.hf_id!r} "
                 "is an UNVERIFIED registry entry with no published checkpoint as of "
                 "2026-05; loading it will fail. Use a real key "
-                "(gemma4-e2b / gemma4-e2b / gemma4-e4b → eliza-1-0_8b / eliza-1-2b / "
-                "eliza-1-4b), pass an explicit --model <real-hf-id>, or set "
+                "(gemma4-e2b / gemma4-e4b / gemma4-12b / gemma4-31b → "
+                "eliza-1-2b / eliza-1-4b / eliza-1-9b / eliza-1-27b), "
+                "pass an explicit --model <real-hf-id>, or set "
                 "ELIZA_ALLOW_UNVERIFIED_BASE=1 to override."
             )
         if not user_passed["model"]:

--- a/packages/training/scripts/train_nebius_smoke_all_tiers.sh
+++ b/packages/training/scripts/train_nebius_smoke_all_tiers.sh
@@ -6,7 +6,7 @@
 # `full` provisions+trains+fetches+tears-down ONE tier per VM lifecycle, this
 # driver loops over EVERY eliza-1 tier on a SINGLE VM lifecycle (~$30-40 on H200
 # at ~10h end-to-end) so a single billing window validates the full
-# 0.8B → 27B chain on a small smoke corpus.
+# 2B → 27B chain on a small smoke corpus.
 #
 # CONTROL FLOW (5 lines, matches the EXIT-trap pattern at line 615 of train_nebius.sh):
 #   1) provision (or reuse) ONE Nebius H200 VM
@@ -33,16 +33,15 @@
 #                                  (auto-detected at startup, snapshotted into
 #                                  REUSE_EXISTING_VM for the EXIT trap).
 #   TIERS                        space-separated tier list. Default:
-#                                  "0_8b 2b 4b 9b 27b"
+#                                  "2b 4b 9b 27b"
 #                                  Each token maps to a registry key + optional
 #                                  --max-seq-len override:
-#                                    0_8b      → gemma4-e2b   (registry seq_len)
-#                                    2b        → gemma4-e2b
+#                                    2b        → gemma4-e2b   (registry seq_len)
 #                                    4b        → gemma4-e4b
 #                                    9b        → gemma4-12b
 #                                    27b       → gemma4-31b
 #                                  Use a smaller list to test a subset:
-#                                    TIERS="0_8b 2b" bash ... smoke-all
+#                                    TIERS="2b 4b" bash ... smoke-all
 #   SMOKE_MAX_STEPS              hard step cap per tier. Default 50 (smoke).
 #                                  Set 0 to use --epochs 1 (real run).
 #   SMOKE_DATA_DIR               relative to packages/training/. Default
@@ -51,7 +50,7 @@
 #                                    $SMOKE_DATA_DIR/{train,val,test}.jsonl
 #                                  (~10 records each is enough — this is a
 #                                  pipeline smoke, not a quality run).
-#   HUGGING_FACE_HUB_TOKEN       for gated Qwen access (forwarded to remote).
+#   HUGGING_FACE_HUB_TOKEN       for gated Gemma access (forwarded to remote).
 #   ELIZA_SMOKE_RUN_TAG          stem for per-tier run names. Default
 #                                  "smoke-all-$(date +%s)". Final run name per
 #                                  tier is "<eliza-public-name>-<tag>-<tier>".
@@ -90,7 +89,7 @@ fi
 
 : "${NEBIUS_PROJECT_ID:?must export NEBIUS_PROJECT_ID}"
 : "${NEBIUS_VM_NAME:=eliza-train-h200-smoke-all}"
-: "${TIERS:=0_8b 2b 4b 9b 27b}"
+: "${TIERS:=2b 4b 9b 27b}"
 : "${SMOKE_MAX_STEPS:=50}"
 : "${SMOKE_DATA_DIR:=data/final-eliza1-smoke}"
 : "${ELIZA_SMOKE_RUN_TAG:=smoke-all-$(date +%s)}"
@@ -123,7 +122,6 @@ _tier_args() {
   # carves out the 27B tier by default — the smoke still exercises
   # base-bench + quant + bundle + publish for that tier.
   case "$1" in
-    0_8b)     echo "gemma4-e2b" ;;
     2b)       echo "gemma4-e2b" ;;
     4b)       echo "gemma4-e4b" ;;
     9b)       echo "gemma4-12b" ;;
@@ -465,7 +463,7 @@ smoke_all() {
 case "$cmd" in
   smoke-all) smoke_all ;;
   fetch)
-    tier="${2:?fetch needs a tier token (e.g. 0_8b)}"
+    tier="${2:?fetch needs a tier token (e.g. 2b)}"
     _fetch_one_tier "$tier"
     ;;
   teardown)


### PR DESCRIPTION
## Summary
- retarget cloud launcher defaults from retired `0_8b` to active Gemma tiers, including `27b-256k` routing
- make `run-on-cloud.sh` auto-select Vast/Nebius from `tier-routing.json` and forward to provider dispatchers
- update Nebius smoke, publish helper, and local training CLI text so active paths no longer advertise retired Qwen-era tiers

Refs #9588
Refs #9583

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bash packages/training/scripts/cloud/test_dispatch_dryrun.sh` (76 passed, 0 failed)
- `python3 -m pytest packages/training/scripts/test_train_nebius_smoke_all_tiers.py -q` (11 passed)
- `python3 -m py_compile packages/training/scripts/run_pipeline.py packages/training/scripts/train_local.py`
- `node --check packages/training/scripts/publish/eliza1-hf-stage.mjs`
- `git diff --check`
- `bun run verify` (515/515 tasks successful)
