### PR TITLE
fix(training): stage source weights for active Gemma tiers

### DIFF
--- a/packages/training/scripts/manifest/stage_eliza1_source_weights.py
+++ b/packages/training/scripts/manifest/stage_eliza1_source_weights.py
@@ -79,18 +79,6 @@ class SourceArtifact:
 
 
 TEXT_SOURCES: Final[dict[str, SourceArtifact]] = {
-    "0_8b": SourceArtifact(
-        kind="text",
-        repo="unsloth/gemma-4-E2B-GGUF",
-        filename="gemma-4-E2B-Q8_0.gguf",
-        destination="source/text/gemma4-0_8b-q8_0.gguf",
-        license="apache-2.0",
-        status="source-only",
-        notes=(
-            "GGUF mirror of the official google/gemma-4-E2B base.",
-            "Final Eliza-1 0.8B still needs training plus Q4_K_M quantization.",
-        ),
-    ),
     "2b": SourceArtifact(
         kind="text",
         repo="unsloth/gemma-4-E2B-GGUF",
@@ -133,10 +121,21 @@ TEXT_SOURCES: Final[dict[str, SourceArtifact]] = {
         status="source-only",
         notes=("Final Eliza-1 27B uses Gemma 4 31B and still needs training plus Q4_K_M quantization.",),
     ),
+    "27b-256k": SourceArtifact(
+        kind="text",
+        repo="unsloth/gemma-4-31B-GGUF",
+        filename="gemma-4-31B-Q8_0.gguf",
+        destination="source/text/gemma4-31b-q8_0.gguf",
+        license="apache-2.0",
+        status="source-only",
+        notes=(
+            "Final Eliza-1 27B-256k uses Gemma 4 31B and still needs training "
+            "plus Q4_K_M quantization.",
+        ),
+    ),
 }
 
 DRAFTER_SOURCES: Final[dict[str, SourceArtifact | None]] = {
-    "0_8b": None,
     "2b": SourceArtifact(
         kind="mtp",
         repo="google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
@@ -197,23 +196,33 @@ DRAFTER_SOURCES: Final[dict[str, SourceArtifact | None]] = {
             "checkpoint.",
         ),
     ),
+    "27b-256k": SourceArtifact(
+        kind="mtp",
+        repo="google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+        filename="model.safetensors",
+        destination="source/mtp/gemma4-31b-assistant.safetensors",
+        license="gemma",
+        status="source-safetensors",
+        notes=(
+            "Official Google Gemma 4 31B assistant source for MTP/speculative "
+            "decoding.",
+            "Final Eliza-1 27B-256k still needs tokenizer merge, mtp-draft "
+            "GGUF conversion, quantization, and acceptance against the Eliza-1 "
+            "text checkpoint.",
+        ),
+    ),
 }
 
 # mmproj-F16 sources per tier. Every active Gemma 4 base
-# (0.8B/2B/4B/9B) ships its own `mmproj-F16.gguf` in the matching unsloth
-# repo. The Gemma 4 31B projector is also published in the matching
-# unsloth/gemma-4-31B-GGUF repo.
+# (2B/4B/9B/27B/27B-256k) ships or reuses the matching Gemma 4
+# `mmproj-F16.gguf` from the corresponding unsloth repo.
 #
 # Per-tier quantization (handled downstream by `llama-quantize` against the
 # fork at `plugins/plugin-local-inference/native/llama.cpp/`):
-#   0_8b              -> Q4_K_M
 #   2b / 4b / 9b      -> Q8_0
-#   27b               -> Q8_0
-# The full canonical chain and the architectural reasoning for why
-# TurboQuant / PolarQuant / QJL are NOT applied to mmproj projectors are
-# documented in the 2026-05-14 plan memo cited above and in
-# `packages/training/release-staging/mmproj/manifest.json` once Phase 2
-# has executed.
+#   27b / 27b-256k    -> Q8_0
+# The source manifest emitted under `packages/training/release-staging/mmproj/`
+# records the final per-tier projector provenance once Phase 2 has executed.
 def _vision_source(tier: str, family: str, size: str) -> SourceArtifact:
     family_slug = family.lower()
     return SourceArtifact(
@@ -225,29 +234,28 @@ def _vision_source(tier: str, family: str, size: str) -> SourceArtifact:
         status="source-only",
         notes=(
             f"Upstream mmproj-F16 for the {family}-{size} projector; quantized to "
-            f"{'Q4_K_M' if tier == '0_8b' else 'Q8_0'} during Phase 2 staging.",
+            "Q8_0 during Phase 2 staging.",
         ),
     )
 
 
 VISION_SOURCES: Final[dict[str, SourceArtifact | None]] = {
-    "0_8b": _vision_source("0_8b", "gemma-4", "E2B"),
     "2b": _vision_source("2b", "gemma-4", "E2B"),
     "4b": _vision_source("4b", "gemma-4", "E4B"),
     "9b": _vision_source("9b", "gemma-4", "12B"),
     "27b": _vision_source("27b", "gemma-4", "31B"),
+    "27b-256k": _vision_source("27b-256k", "gemma-4", "31B"),
 }
 
 # Per-tier mmproj quantization target. Authoritative source: the live
 # contract in `docs/ELIZA_1_BUNDLE_EXTRAS.json#vision.perTier` plus the
-# plan memo at
-# `plugins/plugin-local-inference/native/reports/porting/2026-05-14/mmproj-qwen35vl-plan.md`.
+# source manifest emitted under `packages/training/release-staging/mmproj/`.
 MMPROJ_QUANT_BY_TIER: Final[dict[str, str]] = {
-    "0_8b": "Q4_K_M",
     "2b": "Q8_0",
     "4b": "Q8_0",
     "9b": "Q8_0",
     "27b": "Q8_0",
+    "27b-256k": "Q8_0",
 }
 
 # Per-tier tensor-type overrides passed to `llama-quantize --tensor-type`.
@@ -263,7 +271,6 @@ MMPROJ_QUANT_BY_TIER: Final[dict[str, str]] = {
 #     uses hidden_dim=4304 (4304 mod 32 == 16), so every ffn_down row in
 #     every vision block must stay F16 in the Q8_0 output.
 MMPROJ_QUANT_TENSOR_OVERRIDES: Final[dict[str, dict[str, str]]] = {
-    "0_8b": {"v\\.patch_embd\\.weight": "f16"},
     "2b": {"v\\.patch_embd\\.weight": "f16"},
     "4b": {"v\\.patch_embd\\.weight": "f16"},
     "9b": {
@@ -271,6 +278,10 @@ MMPROJ_QUANT_TENSOR_OVERRIDES: Final[dict[str, dict[str, str]]] = {
         "v\\.blk\\.[0-9]+\\.ffn_down\\.weight": "f16",
     },
     "27b": {
+        "v\\.patch_embd\\.weight": "f16",
+        "v\\.blk\\.[0-9]+\\.ffn_down\\.weight": "f16",
+    },
+    "27b-256k": {
         "v\\.patch_embd\\.weight": "f16",
         "v\\.blk\\.[0-9]+\\.ffn_down\\.weight": "f16",
     },
@@ -536,7 +547,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help=(
             "After staging the F16 mmproj source, run `llama-quantize` to "
             "produce bundles/<tier>/vision/mmproj-<tier>.gguf at the "
-            "per-tier canonical quant (Q4_K_M for 0_8b, Q8_0 elsewhere). "
+            "per-tier canonical quant (Q8_0 for all active Gemma tiers). "
             "Requires the elizaOS/llama.cpp fork's llama-quantize binary."
         ),
     )

--- a/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
+++ b/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
@@ -29,19 +29,20 @@ def _args(tmp_path: Path, tier: str) -> argparse.Namespace:
     )
 
 
-def test_lite_tiers_are_source_only_and_keep_mtp_missing(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    monkeypatch.setattr(stage, "HfApi", FakeHfApi)
+def test_active_tiers_have_source_weight_entries() -> None:
+    active_tiers = set(stage.ELIZA_1_TIERS)
+    assert set(stage.TEXT_SOURCES) == active_tiers
+    assert set(stage.DRAFTER_SOURCES) == active_tiers
+    assert set(stage.VISION_SOURCES) == active_tiers
+    assert set(stage.MMPROJ_QUANT_BY_TIER) == active_tiers
+    assert set(stage.MMPROJ_QUANT_TENSOR_OVERRIDES) == active_tiers
 
-    report = stage.stage_sources(_args(tmp_path, "0_8b"))
-
-    kinds = [f["kind"] for f in report["files"]]
-    assert "text" in kinds
-    assert "mtp" not in kinds
-    assert "unsloth/gemma-4-E2B-GGUF" in report["sources"]
-    assert any("No upstream MTP drafter" in b for b in report["blockers"])
+    for tier in stage.ELIZA_1_TIERS:
+        assert tier in stage.TEXT_SOURCES
+        assert tier in stage.DRAFTER_SOURCES
+        assert tier in stage.VISION_SOURCES
+        assert tier in stage.MMPROJ_QUANT_BY_TIER
+        assert tier in stage.MMPROJ_QUANT_TENSOR_OVERRIDES
 
 
 def test_mobile_tier_uses_gemma4_e2b_source(
@@ -52,11 +53,24 @@ def test_mobile_tier_uses_gemma4_e2b_source(
 
     report = stage.stage_sources(_args(tmp_path, "2b"))
 
+    kinds = [f["kind"] for f in report["files"]]
+    assert "text" in kinds
+    assert "mtp" in kinds
     assert "unsloth/gemma-4-E2B-GGUF" in report["sources"]
     assert (
         "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
         in report["sources"]
     )
+
+
+def test_2b_tier_records_mtp_conversion_blocker(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(stage, "HfApi", FakeHfApi)
+
+    report = stage.stage_sources(_args(tmp_path, "2b"))
+
     assert stage.DRAFTER_SOURCES["2b"] is not None
     assert any("not a final GGUF" in b for b in report["blockers"])
 
@@ -100,48 +114,50 @@ def test_27b_class_tiers_use_gemma4_31b_source(
 ) -> None:
     monkeypatch.setattr(stage, "HfApi", FakeHfApi)
 
-    tier = "27b"
-    report = stage.stage_sources(_args(tmp_path, tier))
+    for tier in ("27b", "27b-256k"):
+        report = stage.stage_sources(_args(tmp_path, tier))
 
-    assert "unsloth/gemma-4-31B-GGUF" in report["sources"]
-    assert (
-        "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
-        in report["sources"]
-    )
-    # The 27b tier must use the 31B Gemma 4 source, never a smaller-tier base.
-    assert all(
-        not any(
-            small in f["repo"]
-            for small in ("gemma-4-E2B", "gemma-4-E4B", "gemma-4-12B")
+        assert "unsloth/gemma-4-31B-GGUF" in report["sources"]
+        assert (
+            "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
+            in report["sources"]
         )
-        for f in report["files"]
-        if f["kind"] in {"text", "mtp", "vision"}
-    )
-    drafter_files = [f for f in report["files"] if f["kind"] == "mtp"]
-    assert drafter_files == [
-        {
-            "kind": "mtp",
-            "repo": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
-            "filename": "model.safetensors",
-            "destination": f"source/mtp/gemma4-31b-assistant.safetensors",
-            "license": "gemma",
-            "status": "source-safetensors",
-            "notes": tuple(stage.DRAFTER_SOURCES[tier].notes),
-            "revision": "sha-google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
-            "path": str(
-                tmp_path
-                / f"eliza-1-{tier}.bundle"
-                / f"source/mtp/gemma4-31b-assistant.safetensors"
-            ),
-            "dryRun": True,
-        }
-    ]
-    assert any("acceptance against the Eliza-1 text checkpoint" in b for b in report["blockers"])
+        # The 27b-family tiers must use the 31B Gemma 4 source, never a
+        # smaller-tier base.
+        assert all(
+            not any(
+                small in f["repo"]
+                for small in ("gemma-4-E2B", "gemma-4-E4B", "gemma-4-12B")
+            )
+            for f in report["files"]
+            if f["kind"] in {"text", "mtp", "vision"}
+        )
+        drafter_files = [f for f in report["files"] if f["kind"] == "mtp"]
+        assert drafter_files == [
+            {
+                "kind": "mtp",
+                "repo": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+                "filename": "model.safetensors",
+                "destination": f"source/mtp/gemma4-31b-assistant.safetensors",
+                "license": "gemma",
+                "status": "source-safetensors",
+                "notes": tuple(stage.DRAFTER_SOURCES[tier].notes),
+                "revision": "sha-google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
+                "path": str(
+                    tmp_path
+                    / f"eliza-1-{tier}.bundle"
+                    / f"source/mtp/gemma4-31b-assistant.safetensors"
+                ),
+                "dryRun": True,
+            }
+        ]
+        assert any(
+            "acceptance against the Eliza-1 text checkpoint" in b
+            for b in report["blockers"]
+        )
 
 
 def test_known_mtp_sources_are_wired_without_faking_small_tiers() -> None:
-    assert stage.DRAFTER_SOURCES["0_8b"] is None
-
     assert (
         stage.DRAFTER_SOURCES["2b"].repo
         == "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
@@ -163,7 +179,7 @@ def test_known_mtp_sources_are_wired_without_faking_small_tiers() -> None:
     assert stage.DRAFTER_SOURCES["9b"].filename == "model.safetensors"
     assert stage.DRAFTER_SOURCES["9b"].license == "gemma"
 
-    for tier in ("27b",):
+    for tier in ("27b", "27b-256k"):
         artifact = stage.DRAFTER_SOURCES[tier]
         assert artifact is not None
         assert artifact.repo == "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
@@ -172,13 +188,8 @@ def test_known_mtp_sources_are_wired_without_faking_small_tiers() -> None:
 
 
 def test_every_active_tier_has_vision_source() -> None:
-    """Every active release tier must source its own mmproj-F16.gguf.
-
-    The 27b tier uses the `unsloth/gemma-4-31B-GGUF` projector. The
-    0_8b/2b/4b/9b tiers each source the matching Gemma 4 projector. The
-    0_8b tier ships Q4_K_M; every other tier ships Q8_0.
-    """
-    for tier in ("0_8b", "2b", "4b", "9b", "27b"):
+    """Every active release tier must source its own mmproj-F16.gguf."""
+    for tier in stage.ELIZA_1_TIERS:
         assert stage.VISION_SOURCES[tier] is not None, tier
         artifact = stage.VISION_SOURCES[tier]
         assert artifact.kind == "vision"
@@ -189,9 +200,7 @@ def test_every_active_tier_has_vision_source() -> None:
             assert artifact.repo.startswith("unsloth/gemma-4-")
         assert tier in stage.MMPROJ_QUANT_BY_TIER
         assert tier in stage.MMPROJ_QUANT_TENSOR_OVERRIDES
-        assert stage.MMPROJ_QUANT_BY_TIER["0_8b"] == "Q4_K_M"
-        if tier != "0_8b":
-            assert stage.MMPROJ_QUANT_BY_TIER[tier] == "Q8_0"
+        assert stage.MMPROJ_QUANT_BY_TIER[tier] == "Q8_0"
 
 
 def test_large_projector_tiers_carry_ffn_down_override() -> None:
@@ -199,14 +208,14 @@ def test_large_projector_tiers_carry_ffn_down_override() -> None:
 
     Their hidden_dim (4304) is not divisible by 32, which is the row
     alignment Q8_0 requires; without the override `llama-quantize` bails
-    with "Unsupported tensor size encountered" mid-stream. The 0_8b/2b/4b
-    mid+small projectors do not need that override.
+    with "Unsupported tensor size encountered" mid-stream. The 2b/4b mid+small
+    projectors do not need that override.
     """
-    for tier in ("9b", "27b"):
+    for tier in ("9b", "27b", "27b-256k"):
         overrides = stage.MMPROJ_QUANT_TENSOR_OVERRIDES[tier]
         assert "v\\.blk\\.[0-9]+\\.ffn_down\\.weight" in overrides
         assert "v\\.patch_embd\\.weight" in overrides
-    for tier in ("0_8b", "2b", "4b"):
+    for tier in ("2b", "4b"):
         overrides = stage.MMPROJ_QUANT_TENSOR_OVERRIDES[tier]
         assert "v\\.patch_embd\\.weight" in overrides
         assert "v\\.blk\\.[0-9]+\\.ffn_down\\.weight" not in overrides


### PR DESCRIPTION
## Summary
- remove retired `0_8b` from Eliza-1 source-weight staging tables
- add `27b-256k` text, MTP drafter, vision source, quant, and tensor-override entries using the Gemma 4 31B source family
- strengthen source-weight staging tests so every table exactly matches `ELIZA_1_TIERS`

Refs #9588
Refs #9583

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/manifest/test_stage_eliza1_source_weights.py packages/training/scripts/manifest/test_eliza1_manifest.py -q` (79 passed)
- `python3 -m py_compile packages/training/scripts/manifest/stage_eliza1_source_weights.py`
- `git diff --check`
- `bun run verify` (515/515 tasks successful)
