### PR TITLE
fix(training): align bundle staging RAM tiers

### DIFF
--- a/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
@@ -77,7 +77,6 @@ DEFAULT_TEXT_STANDIN_CANDIDATES: Final[tuple[Path, ...]] = (
     LOCAL_MODEL_ROOT / "gemma4-e2b-official" / "gemma-4-E2B-it-Q8_0.gguf",
     LOCAL_MODEL_ROOT / "gemma-4-E2B_q4_0-it.gguf",
     # Legacy local cache names from the pre-official-source Gemma smoke runs.
-    LOCAL_MODEL_ROOT / "gemma4-e4b-mtp" / "Qwen_gemma-4-E4B-Q4_K_M.gguf",
     LOCAL_MODEL_ROOT / "gemma4-e4b-mtp.gguf",
 )
 DEFAULT_DRAFTER_STANDIN_CANDIDATES: Final[tuple[Path, ...]] = (
@@ -100,7 +99,6 @@ VISION_TIERS: Final[set[str]] = set(ELIZA_1_VISION_TIERS)
 MTP_TIERS: Final[set[str]] = set(ELIZA_1_MTP_TIERS)
 
 DEFAULT_RAM_BUDGET_MB: Final[Mapping[str, tuple[int, int]]] = {
-    "0_8b": (2500, 3700),
     "2b": (4000, 5500),
     "4b": (6000, 8000),
     "9b": (10000, 14000),

--- a/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
@@ -103,7 +103,6 @@ RETIRED_QWEN_EMBEDDING_REPO: Final[str] = "Qwen/Qwen3-Embedding-0.6B-GGUF"
 RETIRED_QWEN_EMBEDDING_FILE: Final[str] = "Qwen3-Embedding-0.6B-Q8_0.gguf"
 
 DEFAULT_RAM_BUDGET_MB: Final[Mapping[str, tuple[int, int]]] = {
-    "0_8b": (2500, 3700),
     "2b": (4000, 5500),
     "4b": (6000, 8000),
     "9b": (10000, 14000),
@@ -249,7 +248,7 @@ def _remove_stale_text_variants(
     """Remove stale text variants from an existing bundle restage.
 
     Restaging a bundle in place can leave older release-label files such as
-    ``eliza-1-0_8b-32k.gguf`` next to the newly staged 128k file. The manifest
+    ``eliza-1-27b-64k.gguf`` next to the newly staged 128k file. The manifest
     collector must only see the current tier matrix files, otherwise publish
     validation fails closed on the stale filename even when the GGUF metadata
     advertises a larger native context.

--- a/packages/training/scripts/manifest/test_ram_budget_calibration.py
+++ b/packages/training/scripts/manifest/test_ram_budget_calibration.py
@@ -1,12 +1,12 @@
 """Calibration invariants for the per-tier RAM budgets.
 
-`packages/inference/AGENTS.md` §8 + §6: the manifest `ramBudgetMb.recommended`
+`packages/inference/AGENTS.md` section 8 + section 6: the manifest `ramBudgetMb.recommended`
 is what the 30-turn endurance gate (`thirtyTurnOk`) compares the fused
 llama-server's peak RSS against. The 2026-05-11 e2e voice-loop benchmark
 (`packages/inference/verify/bench_results/e2e_loop_2026-05-11.json`) measured
-~3132 MB (0_8b) and ~4828 MB (2b) server peak RSS in voice-on mode — the
+~4828 MB (2b) server peak RSS in voice-on mode — the
 fused process keeps text + MTP drafter + OmniVoice (base/tokenizer/DAC/
-HuBERT/sem-enc) + Qwen3-ASR + mmproj all resident. The budgets in
+HuBERT/sem-enc) + ASR + mmproj all resident. The budgets in
 `DEFAULT_RAM_BUDGET_MB` must therefore (a) be identical across the three
 staging entry points that emit a manifest, and (b) leave headroom above the
 measured peak so `thirtyTurnOk` is achievable on the bench host.
@@ -25,22 +25,24 @@ if str(_TRAINING_ROOT) not in sys.path:
 
 from scripts.manifest import stage_local_eliza1_bundle as stage_local  # noqa: E402
 from scripts.manifest import stage_real_eliza1_bundle as stage_real  # noqa: E402
+from scripts.manifest.eliza1_manifest import ELIZA_1_TIERS  # noqa: E402
 
 # Measured server peak RSS (MB) from the 2026-05-11 e2e voice-loop bench.
 # Source: packages/inference/verify/bench_results/e2e_loop_2026-05-11.json
 #         (30-turn run for each tier).
-_E2E_PEAK_RSS_MB = {"0_8b": 3132, "2b": 4828}
+_E2E_PEAK_RSS_MB = {"2b": 4828}
 
 
 def test_default_ram_budget_is_consistent_across_staging_entry_points() -> None:
     """stage_local + stage_real must agree tier-for-tier."""
     local = dict(stage_local.DEFAULT_RAM_BUDGET_MB)
     real = dict(stage_real.DEFAULT_RAM_BUDGET_MB)
+    assert set(local) == set(ELIZA_1_TIERS)
     assert local == real
 
 
 def test_voice_tier_budgets_clear_the_measured_e2e_peak_rss() -> None:
-    """recommended >= measured fused-server peak RSS (+ headroom) for 0_8b/2b.
+    """recommended >= measured fused-server peak RSS (+ headroom) for active tiers.
 
     This is the invariant that makes the 30-turn `thirtyTurnOk` gate
     achievable: the bench derives it from `peakRss <= ramBudgetMb.recommended`.


### PR DESCRIPTION
## Summary
- remove the retired `0_8b` RAM budget row from local and real eliza-1 bundle staging
- keep bundle staging RAM budget keys tied to the active `ELIZA_1_TIERS` matrix
- remove a stale local stand-in path that still referenced a Qwen-prefixed Gemma cache artifact

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/manifest/test_stage_local_eliza1_bundle.py packages/training/scripts/manifest/test_stage_real_eliza1_bundle.py packages/training/scripts/manifest/test_ram_budget_calibration.py -q` (7 passed)
- `python3 -m py_compile packages/training/scripts/manifest/stage_local_eliza1_bundle.py packages/training/scripts/manifest/stage_real_eliza1_bundle.py`
- `git diff --check`
- `rg -n "0_8b|0\\.8B|Qwen|qwen3|qwen35" packages/training/scripts/manifest/stage_local_eliza1_bundle.py packages/training/scripts/manifest/stage_real_eliza1_bundle.py packages/training/scripts/manifest/test_ram_budget_calibration.py` (only intentional retired-Qwen rejection/provenance guards remain)
- `bun run verify` (515/515 tasks)

Contributes to #9588 and #9583.
