### PR TITLE
fix(training): align turn detector asset tiers

### DIFF
--- a/packages/training/scripts/manifest/stage_eliza1_bundle_assets.py
+++ b/packages/training/scripts/manifest/stage_eliza1_bundle_assets.py
@@ -46,6 +46,7 @@ except ModuleNotFoundError:  # pragma: no cover - env-only path
 try:
     from .eliza1_manifest import (
         ELIZA_1_HF_REPO,
+        ELIZA_1_TIERS,
         VOICE_BACKENDS_BY_TIER,
         VOICE_QUANT_BY_TIER,
         VOICE_QUANT_LADDER_BY_TIER,
@@ -54,6 +55,7 @@ try:
 except ImportError:  # pragma: no cover - script execution path
     from eliza1_manifest import (
         ELIZA_1_HF_REPO,
+        ELIZA_1_TIERS,
         VOICE_BACKENDS_BY_TIER,
         VOICE_QUANT_BY_TIER,
         VOICE_QUANT_LADDER_BY_TIER,
@@ -64,11 +66,11 @@ VOICE_REPO: Final[str] = "Serveurperso/OmniVoice-GGUF"
 VAD_NATIVE_REPO: Final[str] = ELIZA_1_HF_REPO
 VAD_ONNX_REPO: Final[str] = "onnx-community/silero-vad"
 RETIRED_QWEN_ASR_REPO_BY_TIER: Final[dict[str, str]] = {
-    "0_8b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "2b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "4b": "ggml-org/Qwen3-ASR-0.6B-GGUF",
     "9b": "ggml-org/Qwen3-ASR-1.7B-GGUF",
     "27b": "ggml-org/Qwen3-ASR-1.7B-GGUF",
+    "27b-256k": "ggml-org/Qwen3-ASR-1.7B-GGUF",
 }
 GEMMA_ASR_REQUIRED_MESSAGE: Final[str] = (
     "Gemma ASR artifacts are not configured for Eliza-1 staging. "
@@ -80,15 +82,15 @@ GEMMA_ASR_REQUIRED_MESSAGE: Final[str] = (
 # is the default ship target; `latishab/turnsense` is the Apache-2.0 fallback
 # routed via `--turn-license=apache`. Per-tier revision matches the runtime
 # resolver in `plugins/plugin-local-inference/src/services/voice/eot-classifier.ts`
-# (`turnDetectorRevisionForTier`): EN-only SmolLM2 distill on `0_8b` / `2b`,
+# (`turnDetectorRevisionForTier`): EN-only SmolLM2 distill on `2b`,
 # multilingual pruned Qwen2.5 elsewhere.
 TURN_DETECTOR_LIVEKIT_REPO: Final[str] = "livekit/turn-detector"
 TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER: Final[dict[str, str]] = {
-    "0_8b": "v1.2.2-en",
     "2b": "v1.2.2-en",
     "4b": "v0.4.1-intl",
     "9b": "v0.4.1-intl",
     "27b": "v0.4.1-intl",
+    "27b-256k": "v0.4.1-intl",
 }
 TURN_DETECTOR_TURNSENSE_REPO: Final[str] = "latishab/turnsense"
 TURN_DETECTOR_LIVEKIT_ONNX_REMOTE: Final[str] = "onnx/model_q8.onnx"
@@ -579,7 +581,7 @@ def stage_turn_detector(
     fold into manifest/lineage/release-evidence.
 
     ``license="livekit"`` ships ``livekit/turn-detector`` at the tier-matched
-    revision (``v1.2.2-en`` for 0_8b/2b, ``v0.4.1-intl`` elsewhere).
+    revision (``v1.2.2-en`` for 2b, ``v0.4.1-intl`` elsewhere).
     ``license="apache"`` ships the Apache-2.0 ``latishab/turnsense`` fallback
     (English-only binary classifier; same bundle path so the runtime resolver
     is license-agnostic).
@@ -810,7 +812,7 @@ def write_license_notes(
     if turn_license == "livekit":
         licenses["LICENSE.turn"] = (
             "Turn-detector ONNX staged from livekit/turn-detector (HF revision "
-            "v1.2.2-en for 0_8b/2b tiers, v0.4.1-intl elsewhere).\n"
+            "v1.2.2-en for the 2b tier, v0.4.1-intl elsewhere).\n"
             "Declared upstream license: LiveKit Model License "
             "(https://huggingface.co/livekit/turn-detector/blob/main/LICENSE).\n"
             "Use --turn-license=apache to ship latishab/turnsense (Apache-2.0).\n"
@@ -1209,7 +1211,7 @@ def upload_assets(args: argparse.Namespace) -> None:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--tier", required=True, choices=tuple(VOICE_QUANT_BY_TIER))
+    ap.add_argument("--tier", required=True, choices=ELIZA_1_TIERS)
     ap.add_argument("--bundle-dir", required=True, type=Path)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument(

--- a/packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py
+++ b/packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py
@@ -15,6 +15,7 @@ if str(_TRAINING_ROOT) not in sys.path:
     sys.path.insert(0, str(_TRAINING_ROOT))
 
 from scripts.manifest import stage_eliza1_bundle_assets as stage  # noqa: E402
+from scripts.manifest.eliza1_manifest import ELIZA_1_TIERS  # noqa: E402
 
 
 class FakeHfApi:
@@ -38,6 +39,17 @@ class FakeHfApi:
         if repo_id == stage.ELIZA_1_HF_REPO:
             return ["voice/vad/silero-vad-v5.gguf"]
         return []
+
+
+def test_retired_qwen_and_turn_detector_maps_match_active_tiers() -> None:
+    active = set(ELIZA_1_TIERS)
+    assert set(stage.RETIRED_QWEN_ASR_REPO_BY_TIER) == active
+    assert set(stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER) == active
+    assert "0_8b" not in stage.RETIRED_QWEN_ASR_REPO_BY_TIER
+    assert "0_8b" not in stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER
+    assert stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER["2b"] == "v1.2.2-en"
+    for tier in active - {"2b"}:
+        assert stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER[tier] == "v0.4.1-intl"
 
 
 def _args(tmp_path: Path, tier: str) -> argparse.Namespace:

--- a/packages/training/scripts/manifest/test_stage_turn_detector.py
+++ b/packages/training/scripts/manifest/test_stage_turn_detector.py
@@ -19,6 +19,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.manifest import stage_eliza1_bundle_assets as stage  # noqa: E402
+from scripts.manifest.eliza1_manifest import ELIZA_1_TIERS  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -81,13 +82,21 @@ def test_stage_turn_detector_livekit_en_for_small_tiers(
     assert {c["revision"] for c in _patch_copy} == {"v1.2.2-en"}
 
 
+def test_stage_turn_detector_revision_map_matches_active_tiers() -> None:
+    active = set(ELIZA_1_TIERS)
+    assert set(stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER) == active
+    assert stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER["2b"] == "v1.2.2-en"
+    for tier in active - {"2b"}:
+        assert stage.TURN_DETECTOR_LIVEKIT_REVISION_BY_TIER[tier] == "v0.4.1-intl"
+
+
 def test_stage_turn_detector_livekit_intl_for_desktop_tiers(
     tmp_path: Path,
     _patch_copy: list[dict[str, Any]],
 ) -> None:
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir()
-    for tier in ("4b", "9b", "27b"):
+    for tier in ("4b", "9b", "27b", "27b-256k"):
         _patch_copy.clear()
         report = stage.stage_turn_detector(
             tier=tier,

--- a/packages/training/scripts/turn_detector/README.md
+++ b/packages/training/scripts/turn_detector/README.md
@@ -7,8 +7,8 @@ Per device tier:
 
 | Tier              | Bundle revision      | Backbone                       | On-disk (Q8 ONNX) | Languages |
 | ----------------- | -------------------- | ------------------------------ | ----------------- | --------- |
-| `0_8b`, `2b`      | `v1.2.2-en`          | SmolLM2-135M distilled         | ~66 MB            | EN only   |
-| `4b`+             | `v0.4.1-intl`        | Pruned Qwen2.5-0.5B            | ~396 MB           | 14 langs  |
+| `2b`              | `v1.2.2-en`          | SmolLM2-135M distilled         | ~66 MB            | EN only   |
+| `4b` / `9b` / `27b` / `27b-256k` | `v0.4.1-intl` | Pruned Qwen2.5-0.5B | ~396 MB | 14 langs |
 | `--turn-license=apache` (override) | n/a | SmolLM2-135M binary head (`latishab/turnsense`) | ~176 MB | EN only |
 
 This directory hosts the **fine-tune + eval pipeline** for those models:

--- a/packages/training/scripts/turn_detector/configs/turn_detector_en.yaml
+++ b/packages/training/scripts/turn_detector/configs/turn_detector_en.yaml
@@ -1,8 +1,8 @@
-# Turn detector fine-tune config — English tier (0_8b / 2b).
+# Turn detector fine-tune config - English tier (2b).
 #
 # Targets the LiveKit `v1.2.2-en` revision (SmolLM2-135M-distilled, 4-layer
 # Llama, EN only). Bundle target is ~66 MB Q8 ONNX, fits the mobile /
-# 0.6B / 1.7B tier memory budgets per .swarm/research/R1-turn.md §3.
+# 2b tier memory budget per .swarm/research/R1-turn.md section 3.
 #
 # Per repo policy (packages/training/AGENTS.md §1): APOLLO optimizer only.
 # AdamW / Muon are not accepted.

--- a/packages/training/scripts/turn_detector/configs/turn_detector_intl.yaml
+++ b/packages/training/scripts/turn_detector/configs/turn_detector_intl.yaml
@@ -1,4 +1,4 @@
-# Turn detector fine-tune config — multilingual tier (4b / 9b / 27b).
+# Turn detector fine-tune config - multilingual tier (4b / 9b / 27b / 27b-256k).
 #
 # Targets the LiveKit `v0.4.1-intl` revision (Qwen2-0.5B, 14 languages).
 # Bundle target is ~396 MB Q8 ONNX in upstream; the APOLLO-Mini fine-tune

--- a/packages/training/scripts/turn_detector/convert_to_gguf.py
+++ b/packages/training/scripts/turn_detector/convert_to_gguf.py
@@ -4,8 +4,8 @@
 The two ship targets for the semantic end-of-turn detector are:
 
   - ``livekit/turn-detector`` — SmolLM2-135M distill (EN) at revision
-    ``v1.2.2-en`` for the 0_8b / 2b tiers; pruned Qwen2.5-0.5B at
-    ``v0.4.1-intl`` for ≥4b tiers.
+    ``v1.2.2-en`` for the 2b tier; pruned Qwen2.5-0.5B at
+    ``v0.4.1-intl`` for 4b / 9b / 27b / 27b-256k tiers.
   - ``latishab/turnsense`` — Apache-2.0 fallback (binary classifier on a
     SmolLM2-135M head).
 
@@ -294,8 +294,9 @@ def main(argv: list[str] | None = None) -> int:
         "notes": (
             "Turn-detector GGUF conversion via the in-repo llama.cpp fork. "
             "Supports the LiveKit Turn Detector lineage (SmolLM2-135M @ "
-            "v1.2.2-en for 0_8b/2b tiers; pruned Qwen2.5-0.5B @ v0.4.1-intl "
-            "for >=4b tiers) and the Apache-2.0 latishab/turnsense fallback. "
+            "v1.2.2-en for the 2b tier; pruned Qwen2.5-0.5B @ v0.4.1-intl "
+            "for 4b / 9b / 27b / 27b-256k tiers) and the Apache-2.0 "
+            "latishab/turnsense fallback. "
             "Both lineages are Llama-shaped or qwen2-shaped and ride the "
             "fork's existing LM arch tags without any new ops."
         ),

--- a/packages/training/scripts/turn_detector/finetune_turn_detector.py
+++ b/packages/training/scripts/turn_detector/finetune_turn_detector.py
@@ -98,7 +98,7 @@ def default_revision_for_tier(tier: str) -> str:
     prefixed (``"eliza-1-4b"``) tier ids.
     """
     bare = tier[len("eliza-1-") :] if tier.startswith("eliza-1-") else tier
-    if bare in ("0_8b", "2b"):
+    if bare == "2b":
         return DEFAULT_REVISION_EN
     return DEFAULT_REVISION_INTL
 

--- a/packages/training/scripts/turn_detector/test_turn_detector_pipeline.py
+++ b/packages/training/scripts/turn_detector/test_turn_detector_pipeline.py
@@ -33,14 +33,14 @@ from scripts.turn_detector import finetune_turn_detector as fld
 @pytest.mark.parametrize(
     ("tier", "expected"),
     [
-        ("0_8b", "v1.2.2-en"),
         ("2b", "v1.2.2-en"),
-        ("eliza-1-0_8b", "v1.2.2-en"),
         ("eliza-1-2b", "v1.2.2-en"),
         ("4b", "v0.4.1-intl"),
         ("9b", "v0.4.1-intl"),
         ("27b", "v0.4.1-intl"),
+        ("27b-256k", "v0.4.1-intl"),
         ("eliza-1-4b", "v0.4.1-intl"),
+        ("eliza-1-27b-256k", "v0.4.1-intl"),
     ],
 )
 def test_default_revision_for_tier(tier: str, expected: str) -> None:


### PR DESCRIPTION
## Summary
- remove retired `0_8b` from bundle asset staging ASR fallback and LiveKit turn-detector tier maps
- add active `27b-256k` coverage to those release-facing maps
- make staging and turn-detector tests assert tier maps match `ELIZA_1_TIERS`
- update turn-detector docs/config comments so the EN route is `2b` only and larger active Gemma tiers use the multilingual route

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py packages/training/scripts/manifest/test_stage_turn_detector.py packages/training/scripts/turn_detector/test_turn_detector_pipeline.py -q` (46 passed)
- `python3 -m py_compile packages/training/scripts/manifest/stage_eliza1_bundle_assets.py packages/training/scripts/turn_detector/finetune_turn_detector.py packages/training/scripts/turn_detector/convert_to_gguf.py`
- `git diff --check`
- `rg -n "0_8b|0\\.8B|0\.8B" packages/training/scripts/manifest/stage_eliza1_bundle_assets.py packages/training/scripts/manifest/test_stage_eliza1_bundle_assets.py packages/training/scripts/manifest/test_stage_turn_detector.py packages/training/scripts/turn_detector/finetune_turn_detector.py packages/training/scripts/turn_detector/test_turn_detector_pipeline.py packages/training/scripts/turn_detector/README.md packages/training/scripts/turn_detector/convert_to_gguf.py packages/training/scripts/turn_detector/configs/turn_detector_en.yaml packages/training/scripts/turn_detector/configs/turn_detector_intl.yaml` (only negative assertions remain)
- `bun run verify` (515/515 tasks)

Contributes to #9588 and #9583.
