### PR TITLE
fix(training): align in-agent verifier tiers

### DIFF
--- a/packages/training/cloud/README.md
+++ b/packages/training/cloud/README.md
@@ -87,7 +87,6 @@ See `packages/inference/AGENTS.md §2` for the full bundle contract.
 
 | Tier      | Path inside `elizaos/eliza-1`                                    |
 |-----------|------------------------------------------------------------------|
-| 0_8b      | `bundles/0_8b/`                                                  |
 | 2b        | `bundles/2b/`                                                    |
 | 4b        | `bundles/4b/`                                                    |
 | 9b        | `bundles/9b/`                                                    |

--- a/packages/training/scripts/test_inagent_eliza.py
+++ b/packages/training/scripts/test_inagent_eliza.py
@@ -6,7 +6,7 @@ engine eliza uses locally) to load the fine-tuned GGUF and verify it produces
 valid eliza_native_v1 formatted responses.
 
 Usage:
-    python scripts/test_inagent_eliza.py --tier 0_8b [--max-samples 20]
+    python scripts/test_inagent_eliza.py --tier 2b [--max-samples 20]
     python scripts/test_inagent_eliza.py --tiers all [--hf-token TOKEN]
     python scripts/test_inagent_eliza.py --local-gguf /path/to/model.gguf
 
@@ -28,6 +28,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
+from manifest.eliza1_manifest import ELIZA_1_TIERS
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -38,7 +40,8 @@ HF_REPO = "elizaos/eliza-1"
 TEST_FILE = ROOT / "data" / "final" / "test.jsonl"
 CACHE_DIR = Path.home() / ".cache" / "eliza-1-ggufs"
 
-ALL_TIERS = ["0_8b", "2b", "4b", "9b"]
+ALL_TIERS = list(ELIZA_1_TIERS)
+ACTIVE_TIER_SET = set(ALL_TIERS)
 
 ELIZA_SYSTEM_PROMPT = "You are Eliza, an AI assistant. Help the user with their request."
 
@@ -85,6 +88,34 @@ TEXT_PROMPTS = [
     "Explain what an API is in one sentence.",
     "Write a haiku about programming.",
 ]
+
+
+def _active_tier_help() -> str:
+    return ", ".join(ALL_TIERS)
+
+
+def _split_tiers(value: str) -> list[str]:
+    if value == "all":
+        return list(ALL_TIERS)
+    return [tier.strip() for tier in value.split(",") if tier.strip()]
+
+
+def resolve_requested_tiers(tier: str | None, tiers: str | None) -> list[str]:
+    if tier:
+        requested = [tier]
+    elif tiers:
+        requested = _split_tiers(tiers)
+    else:
+        requested = list(ALL_TIERS)
+    if not requested:
+        raise SystemExit(f"no tiers requested; active tiers: {_active_tier_help()}")
+    invalid = [candidate for candidate in requested if candidate not in ACTIVE_TIER_SET]
+    if invalid:
+        raise SystemExit(
+            "unknown or retired eliza-1 tier(s): "
+            f"{', '.join(invalid)}; active tiers: {_active_tier_help()}"
+        )
+    return requested
 
 
 def _download_gguf(tier: str, hf_token: str | None) -> Path | None:
@@ -343,7 +374,11 @@ def push_report_to_hf(tier: str, report: dict, hf_token: str | None) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="In-agent eliza-1 verification via llama.cpp")
-    parser.add_argument("--tier", default=None, help="Single tier to test (0_8b, 2b, 4b, 9b)")
+    parser.add_argument(
+        "--tier",
+        default=None,
+        help=f"Single active tier to test ({_active_tier_help()})",
+    )
     parser.add_argument("--tiers", default=None, help="Comma-separated tiers or 'all'")
     parser.add_argument("--local-gguf", default=None, help="Path to local GGUF (skips HF download)")
     parser.add_argument("--hf-token", default=os.environ.get("HF_TOKEN"), help="HuggingFace token")
@@ -359,13 +394,7 @@ def main() -> int:
         print(json.dumps(report, indent=2))
         return 0 if report.get("passed") else 1
 
-    tiers: list[str] = []
-    if args.tier:
-        tiers = [args.tier]
-    elif args.tiers:
-        tiers = ALL_TIERS if args.tiers == "all" else [t.strip() for t in args.tiers.split(",")]
-    else:
-        tiers = ALL_TIERS
+    tiers = resolve_requested_tiers(args.tier, args.tiers)
 
     out_dir = Path(args.output_dir) if args.output_dir else ROOT / "reports" / "inagent"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/training/scripts/test_inagent_eliza_tiers.py
+++ b/packages/training/scripts/test_inagent_eliza_tiers.py
@@ -1,0 +1,30 @@
+"""Tier-list invariants for the in-agent Eliza-1 verifier."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TRAINING_ROOT = Path(__file__).resolve().parents[1]
+if str(_TRAINING_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TRAINING_ROOT))
+
+from scripts import test_inagent_eliza as inagent  # noqa: E402
+from scripts.manifest.eliza1_manifest import ELIZA_1_TIERS  # noqa: E402
+
+
+def test_inagent_default_tiers_match_active_eliza1_matrix() -> None:
+    assert inagent.ALL_TIERS == list(ELIZA_1_TIERS)
+    assert "0_8b" not in inagent.ALL_TIERS
+    assert "27b-256k" in inagent.ALL_TIERS
+
+
+def test_inagent_rejects_retired_tier_requests() -> None:
+    with pytest.raises(SystemExit, match="unknown or retired"):
+        inagent.resolve_requested_tiers("0_8b", None)
+
+
+def test_inagent_expands_all_to_active_tiers() -> None:
+    assert inagent.resolve_requested_tiers(None, "all") == list(ELIZA_1_TIERS)

--- a/packages/training/scripts/train_nebius.sh
+++ b/packages/training/scripts/train_nebius.sh
@@ -25,7 +25,6 @@
 # can target a 2× or 4× H200/B200 box.
 #
 # eliza-1 cloud-tier targets (model_registry.py REGISTRY keys):
-#   REGISTRY_KEY=gemma4-e2b → eliza-1-0_8b   (single H200 — overkill, ~2 GPU-h)
 #   REGISTRY_KEY=gemma4-e2b   → eliza-1-2b     (single H200 — fits seq 8k)
 #   REGISTRY_KEY=gemma4-e4b   → eliza-1-4b     (single H200)
 #   REGISTRY_KEY=gemma4-12b   → eliza-1-9b     (single H200, ~80 GB peak)
@@ -439,7 +438,7 @@ echo "RUN_PIPELINE_DONE_OK"
 EOF
   # NOTE: `bash ... 2>&1 | tee $log` makes `$?` reflect `tee`'s exit (always 0)
   # — masking real failures. Use ${PIPESTATUS[0]} to capture the script's
-  # actual rc. Without this, a 0.8B SFT crash (chat-template TypeError,
+  # actual rc. Without this, a pre-Gemma SFT crash (chat-template TypeError,
   # 2026-05-12 incident) emitted `RUN_PIPELINE_EXIT=0`, the launcher saw
   # "success", and ran fetch + teardown over an empty checkpoint dir.
   ssh -o StrictHostKeyChecking=no "$target" "chmod +x $REMOTE_TRAIN_DIR/.run_pipeline.sh; tmux kill-session -t elizatrain 2>/dev/null || true; tmux new-session -d -s elizatrain \"bash $REMOTE_TRAIN_DIR/.run_pipeline.sh 2>&1 | tee $log; echo RUN_PIPELINE_EXIT=\\\${PIPESTATUS[0]} >> $log\""
@@ -480,8 +479,8 @@ fetch() {
 # --- MTP drafter distillation (distill_mtp_drafter.py) ----------------
 # Env knobs (defaults frugal — a small KD job, not a full pipeline):
 #   MTP_TIER              tier the drafter ships for. Active tiers (per
-#                            distill_mtp_drafter.py::ACTIVE_TIERS): 0_8b,
-#                            2b, 4b, 9b, 27b. Default: 2b.
+#                            distill_mtp_drafter.py::ACTIVE_TIERS): 2b,
+#                            4b, 9b, 27b, 27b-256k. Default: 2b.
 #   MTP_TARGET_CHECKPOINT remote path (relative to $REMOTE_TRAIN_DIR) to the
 #                            SFT'd target text HF checkpoint directory. The
 #                            distiller loads the target via

--- a/plugins/plugin-training/README.md
+++ b/plugins/plugin-training/README.md
@@ -25,7 +25,7 @@ requiring live model endpoints:
 ```bash
 bun run --cwd plugins/plugin-training src/core/cli.ts run-collection \
   -o /tmp/eliza-training-run \
-  --tiers 0_8b,2b
+  --tiers 2b,4b
 ```
 
 Useful live-readiness checks:


### PR DESCRIPTION
## Summary
- derive the in-agent verifier default tier list from `ELIZA_1_TIERS`
- reject retired or unknown tier requests before attempting HF bundle downloads
- add focused tests for active tier expansion and retired `0_8b` rejection
- remove active `0_8b` examples from adjacent cloud/plugin-training/Nebius docs and comments

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/test_inagent_eliza_tiers.py -q` (3 passed)
- `python3 -m py_compile packages/training/scripts/test_inagent_eliza.py packages/training/scripts/test_inagent_eliza_tiers.py`
- `git diff --check`
- `rg -n "0_8b|0\\.8B|0\.8B|eliza-1-0_8b|--tiers 0_8b" packages/training/scripts/test_inagent_eliza.py packages/training/scripts/test_inagent_eliza_tiers.py packages/training/cloud/README.md plugins/plugin-training/README.md packages/training/scripts/train_nebius.sh` (only negative tests remain)
- `bun run verify` (515/515 tasks)

Contributes to #9588 and #9583.
