### PR TITLE
fix(training): align catalog emitter tiers

### DIFF
--- a/packages/training/scripts/emit_eliza1_catalog.py
+++ b/packages/training/scripts/emit_eliza1_catalog.py
@@ -29,13 +29,13 @@ Usage::
 
     # Print the entry + where to put it (recommended):
     uv run python scripts/emit_eliza1_catalog.py \\
-        --manifest checkpoints/eliza-1-0_8b/gguf/eliza1_manifest.json
+        --manifest checkpoints/eliza-1-2b/gguf/eliza1_manifest.json
 
     # Also produce a unified diff against the canonical shared catalog:
     uv run python scripts/emit_eliza1_catalog.py \\
-        --manifest checkpoints/eliza-1-0_8b/gguf/eliza1_manifest.json \\
+        --manifest checkpoints/eliza-1-2b/gguf/eliza1_manifest.json \\
         --catalog packages/shared/src/local-inference/catalog.ts \\
-        --output reports/training/catalog-eliza-1-0_8b.diff
+        --output reports/training/catalog-eliza-1-2b.diff
 
 Notes:
   * Eliza-1 tiers are *default-eligible* models. The tier ids and the
@@ -63,6 +63,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from manifest.eliza1_manifest import ELIZA_1_TIERS
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -76,52 +78,59 @@ log = logging.getLogger("emit_eliza1_catalog")
 CANONICAL_CATALOG_PATH = "packages/shared/src/local-inference/catalog.ts"
 
 
+def _bundle_repo(tier: str) -> str:
+    return f"elizaos/eliza-1/bundles/{tier}"
+
+
+ACTIVE_BUNDLE_REPOS = tuple(_bundle_repo(tier) for tier in ELIZA_1_TIERS)
+
+
 # Heuristic mapping from base model name → catalog metadata. New
 # entries go here when adding a new optimization target.
 KNOWN_BASE_MODELS = {
-    "elizaos/eliza-1/bundles/0_8b": {
-        "params": "0.8B",
-        "context_length": 131072,
-        "tokenizer_family": "eliza1",
-        "category": "chat",
-        "bucket": "small",
-        "min_ram_gb": 2,
-        "size_gb_estimate": 0.5,  # Q4_K_M 0.8B ≈ 530 MB with metadata.
-    },
-    "elizaos/eliza-1/bundles/2b": {
+    _bundle_repo("2b"): {
         "params": "2B",
         "context_length": 131072,
-        "tokenizer_family": "eliza1",
+        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "small",
         "min_ram_gb": 4,
         "size_gb_estimate": 1.4,
     },
-    "elizaos/eliza-1/bundles/4b": {
+    _bundle_repo("4b"): {
         "params": "4B",
         "context_length": 131072,
-        "tokenizer_family": "eliza1",
+        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "mid",
-        "min_ram_gb": 10,
+        "min_ram_gb": 6,
         "size_gb_estimate": 2.6,
     },
-    "elizaos/eliza-1/bundles/9b": {
+    _bundle_repo("9b"): {
         "params": "9B",
         "context_length": 131072,
-        "tokenizer_family": "eliza1",
+        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "large",
         "min_ram_gb": 12,
         "size_gb_estimate": 5.4,
     },
-    "elizaos/eliza-1/bundles/27b": {
+    _bundle_repo("27b"): {
         "params": "27B",
         "context_length": 131072,
-        "tokenizer_family": "eliza1",
+        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "large",
         "min_ram_gb": 32,
+        "size_gb_estimate": 16.8,
+    },
+    _bundle_repo("27b-256k"): {
+        "params": "27B",
+        "context_length": 262144,
+        "tokenizer_family": "gemma4",
+        "category": "chat",
+        "bucket": "large",
+        "min_ram_gb": 48,
         "size_gb_estimate": 16.8,
     },
 }
@@ -232,8 +241,8 @@ def build_catalog_entry(manifest: dict[str, object]) -> Eliza1CatalogEntry:
         raise SystemExit("manifest.runtime must be an object")
     args_list = runtime.get("args") or []
 
-    cache_type_k = "qjl1_256"
-    cache_type_v = "tbq3_0"
+    cache_type_k = "q8_0"
+    cache_type_v = "q8_0"
     spec_type: str | None = "mtp"
     drafter_model_id: str | None = None
     if isinstance(args_list, list):

--- a/packages/training/scripts/test_emit_eliza1_catalog.py
+++ b/packages/training/scripts/test_emit_eliza1_catalog.py
@@ -1,0 +1,44 @@
+"""Tests for the Eliza-1 catalog emitter tier matrix."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TRAINING_ROOT = Path(__file__).resolve().parents[1]
+if str(_TRAINING_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TRAINING_ROOT))
+if str(_TRAINING_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_TRAINING_ROOT / "scripts"))
+
+from scripts import emit_eliza1_catalog as emit  # noqa: E402
+from scripts.manifest.eliza1_manifest import ELIZA_1_TIERS  # noqa: E402
+
+
+def test_known_base_models_match_active_eliza1_tiers() -> None:
+    expected = {f"elizaos/eliza-1/bundles/{tier}" for tier in ELIZA_1_TIERS}
+    assert set(emit.ACTIVE_BUNDLE_REPOS) == expected
+    assert set(emit.KNOWN_BASE_MODELS) == expected
+    assert "elizaos/eliza-1/bundles/0_8b" not in emit.KNOWN_BASE_MODELS
+    assert all(
+        meta["tokenizer_family"] == "gemma4"
+        for meta in emit.KNOWN_BASE_MODELS.values()
+    )
+
+
+def test_27b_256k_catalog_defaults_match_gemma_cutover() -> None:
+    entry = emit.build_catalog_entry(
+        {
+            "base_model": "elizaos/eliza-1/bundles/27b-256k",
+            "target_repo": "elizaos/eliza-1/bundles/27b-256k",
+            "gguf": {"filename": "text/eliza-1-27b-256k.gguf"},
+            "runtime": {"args": []},
+        }
+    )
+
+    assert entry.id == "eliza-1-27b-256k"
+    assert entry.context_length == 262144
+    assert entry.min_ram_gb == 48
+    assert entry.tokenizer_family == "gemma4"
+    assert entry.cache_type_k == "q8_0"
+    assert entry.cache_type_v == "q8_0"


### PR DESCRIPTION
## Summary
- derive catalog-emitter bundle coverage from `ELIZA_1_TIERS`
- remove retired `0_8b` catalog defaults and add active `27b-256k`
- mark emitted catalog tokenizer metadata as Gemma and use Gemma-compatible KV cache defaults

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/scripts/test_emit_eliza1_catalog.py -q` (2 passed)
- `python3 -m py_compile packages/training/scripts/emit_eliza1_catalog.py packages/training/scripts/test_emit_eliza1_catalog.py`
- `git diff --check`
- targeted `rg "0_8b|0\\.8B|0\.8B|eliza-1-0_8b|QJL|qjl1_256|tbq3_0|tokenizer_family.*eliza1" packages/training/scripts/emit_eliza1_catalog.py packages/training/scripts/test_emit_eliza1_catalog.py` (only the negative retired-tier assertion remains)
- `bun run verify` (515 successful, 515 total)

Refs #9588
Refs #9583
