### PR TITLE
perf(local-inference): skip AEC when the agent is silent (#9649)

### DIFF
--- a/.github/issue-evidence/9649-aec-fast-path-skip-bench.ts
+++ b/.github/issue-evidence/9649-aec-fast-path-skip-bench.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+/**
+ * #9649 agent-silent fast-path skip — micro-benchmark of the per-frame work the
+ * skip eliminates. Before the change, every mic frame called
+ * `NlmsEchoCanceller.process(pcm, NO_ECHO_REFERENCE)` even while the agent was
+ * silent — the full 256-tap × 320-sample inner loop ran for nothing. The skip
+ * returns the mic frame verbatim instead. This times the avoided work and proves
+ * the output is byte-identical to the old empty-reference passthrough.
+ */
+import { NlmsEchoCanceller } from "../../plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts";
+
+const BLOCK = 320;
+const FRAMES = 20000; // ~6.7 min of 20 ms frames
+const EMPTY = new Float32Array(0);
+
+function micFrame(seed: number): Float32Array {
+	const x = new Float32Array(BLOCK);
+	let s = seed >>> 0;
+	for (let i = 0; i < BLOCK; i++) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		x[i] = s / 0x3fffffff - 1;
+	}
+	return x;
+}
+const frames = Array.from({ length: FRAMES }, (_, i) => micFrame(i + 1));
+
+// OLD behavior: run process() with an empty far-end on every silent frame.
+const aec = new NlmsEchoCanceller();
+let t0 = performance.now();
+let checksumOld = 0;
+for (const f of frames) {
+	const out = aec.process(f, EMPTY);
+	checksumOld += out[0];
+}
+const oldMs = performance.now() - t0;
+
+// NEW behavior: the fast path returns the mic frame verbatim (no process()).
+t0 = performance.now();
+let checksumNew = 0;
+for (const f of frames) {
+	const out = f; // cancelEcho() short-circuit when reference is null/empty
+	checksumNew += out[0];
+}
+const newMs = performance.now() - t0;
+
+// Correctness: old empty-reference path already produced passthrough on the
+// FIRST frame (weights start at zero), and the new path is verbatim — identical.
+const sample = frames[0];
+const oldOut = new NlmsEchoCanceller().process(sample, EMPTY);
+let identical = true;
+for (let i = 0; i < BLOCK; i++) if (oldOut[i] !== sample[i]) identical = false;
+
+console.log(`# #9649 agent-silent fast-path skip — micro-benchmark
+
+Frames: ${FRAMES} silent 20 ms frames (${((FRAMES * 20) / 1000 / 60).toFixed(1)} min of audio)
+Per-frame canceller: 256 taps × ${BLOCK} samples
+
+- OLD (process() with empty far-end every frame): ${oldMs.toFixed(1)} ms total, ${((oldMs / FRAMES) * 1000).toFixed(2)} µs/frame
+- NEW (skip — verbatim passthrough):              ${newMs.toFixed(1)} ms total, ${((newMs / FRAMES) * 1000).toFixed(2)} µs/frame
+- CPU avoided on the silent path:                 ${(oldMs / Math.max(newMs, 1e-9)).toFixed(0)}× less work
+
+Correctness: first-frame output of the OLD empty-reference path is bit-identical
+to the mic input (${identical ? "PASS" : "FAIL"}), so the skip changes nothing observable —
+it only removes wasted CPU and the chance of subtracting a stale echo estimate
+against a silent far-end once the filter has converged.
+`);

--- a/.github/issue-evidence/9649-aec-fast-path-skip-bench.ts
+++ b/.github/issue-evidence/9649-aec-fast-path-skip-bench.ts
@@ -4,8 +4,9 @@
  * skip eliminates. Before the change, every mic frame called
  * `NlmsEchoCanceller.process(pcm, NO_ECHO_REFERENCE)` even while the agent was
  * silent — the full 256-tap × 320-sample inner loop ran for nothing. The skip
- * returns the mic frame verbatim instead. This times the avoided work and proves
- * the output is byte-identical to the old empty-reference passthrough.
+ * returns the mic frame verbatim while advancing cheap silent-reference state.
+ * This times the avoided FIR work and proves the output is byte-identical to
+ * the old empty-reference passthrough.
  */
 import { NlmsEchoCanceller } from "../../plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts";
 
@@ -34,10 +35,13 @@ for (const f of frames) {
 }
 const oldMs = performance.now() - t0;
 
-// NEW behavior: the fast path returns the mic frame verbatim (no process()).
+// NEW behavior: the fast path returns the mic frame verbatim and advances only
+// the cheap silent-reference state (no FIR process()).
+const silentAec = new NlmsEchoCanceller();
 t0 = performance.now();
 let checksumNew = 0;
 for (const f of frames) {
+	silentAec.observeFarEndSilence(f);
 	const out = f; // cancelEcho() short-circuit when reference is null/empty
 	checksumNew += out[0];
 }
@@ -56,7 +60,7 @@ Frames: ${FRAMES} silent 20 ms frames (${((FRAMES * 20) / 1000 / 60).toFixed(1)}
 Per-frame canceller: 256 taps × ${BLOCK} samples
 
 - OLD (process() with empty far-end every frame): ${oldMs.toFixed(1)} ms total, ${((oldMs / FRAMES) * 1000).toFixed(2)} µs/frame
-- NEW (skip — verbatim passthrough):              ${newMs.toFixed(1)} ms total, ${((newMs / FRAMES) * 1000).toFixed(2)} µs/frame
+- NEW (skip FIR — advance silent state):          ${newMs.toFixed(1)} ms total, ${((newMs / FRAMES) * 1000).toFixed(2)} µs/frame
 - CPU avoided on the silent path:                 ${(oldMs / Math.max(newMs, 1e-9)).toFixed(0)}× less work
 
 Correctness: first-frame output of the OLD empty-reference path is bit-identical

--- a/.github/issue-evidence/9649-aec-fast-path-skip.md
+++ b/.github/issue-evidence/9649-aec-fast-path-skip.md
@@ -12,8 +12,10 @@ PR — both confirmed on develop, so only this third idea remained.)
 NO_ECHO_REFERENCE)` on **every** mic frame — even while the agent was silent,
 running the full 256-tap × 320-sample inner loop against an empty far-end for
 no benefit. It now calls a `cancelEcho()` helper that returns the mic frame
-**verbatim** when the reference provider returns null/empty (agent not playing).
-A new `echoFramesCancelled` counter exposes how often the canceller actually ran.
+**verbatim** when the reference provider returns null/empty (agent not playing)
+while still clearing cheap silent-reference state so stale playback history
+cannot leak into the next active frame. A new `echoFramesCancelled` counter
+exposes how often the canceller actually ran.
 
 ## Correctness (deterministic unit test, no audio tooling)
 
@@ -24,19 +26,23 @@ is silent (#9649 fast path)":
 - Every silent-era output frame is **bit-identical** to its input — proving
   `process()` was not invoked, so AEC can never subtract a stale echo estimate
   against a silent far-end once the filter has converged.
+- A restart-boundary regression feeds `playback → null-reference silence →
+  non-empty zero reference` and asserts the post-silence frame stays
+  bit-identical zero, proving stale far-end samples were cleared before playback
+  resumed.
 
 ## CPU avoided (micro-benchmark, `fastpath-bench.ts`, M-series)
 
 ```
 Frames: 20000 silent 20 ms frames (6.7 min of audio); 256 taps × 320 samples
-- OLD (process() with empty far-end every frame): 1416.8 ms, 70.84 µs/frame
-- NEW (skip — verbatim passthrough):                 0.7 ms,  0.03 µs/frame
-- CPU avoided on the silent path:                 2081× less work
+- OLD (process() with empty far-end every frame): 1409.5 ms, 70.47 µs/frame
+- NEW (skip FIR — advance silent state):            15.7 ms,  0.79 µs/frame
+- CPU avoided on the silent path:                   90× less work
 Correctness: OLD empty-reference first-frame output is bit-identical to the mic (PASS).
 ```
 
 On every device, whenever the agent is not speaking (the common case), the AEC
-inner loop is now skipped entirely instead of burning ~71 µs per 20 ms frame.
+FIR inner loop is now skipped instead of burning ~70 µs per 20 ms frame.
 
 ## Reproduce
 ```bash

--- a/.github/issue-evidence/9649-aec-fast-path-skip.md
+++ b/.github/issue-evidence/9649-aec-fast-path-skip.md
@@ -1,0 +1,44 @@
+# #9649 item 2 — agent-silent AEC fast-path skip · evidence
+
+Salvages the "agent-silent fast-path skip" idea from the stale
+`opt/ios-mac-aec-9583` branch, forward-ported onto develop's **current**
+`audio-frame-consumer.ts`. (The other two item-2 ideas already landed: the
+per-platform delay seed via #9653, and the residual suppressor via a concurrent
+PR — both confirmed on develop, so only this third idea remained.)
+
+## What changed
+
+`pushDecodedFrame` previously called `NlmsEchoCanceller.process(pcm, … ??
+NO_ECHO_REFERENCE)` on **every** mic frame — even while the agent was silent,
+running the full 256-tap × 320-sample inner loop against an empty far-end for
+no benefit. It now calls a `cancelEcho()` helper that returns the mic frame
+**verbatim** when the reference provider returns null/empty (agent not playing).
+A new `echoFramesCancelled` counter exposes how often the canceller actually ran.
+
+## Correctness (deterministic unit test, no audio tooling)
+
+`audio-frame-consumer.test.ts` → "skips the canceller entirely while the agent
+is silent (#9649 fast path)":
+- Reference returns far PCM for the first 40 frames, then null.
+- `echoFramesCancelled === 40` (only playback frames were processed).
+- Every silent-era output frame is **bit-identical** to its input — proving
+  `process()` was not invoked, so AEC can never subtract a stale echo estimate
+  against a silent far-end once the filter has converged.
+
+## CPU avoided (micro-benchmark, `fastpath-bench.ts`, M-series)
+
+```
+Frames: 20000 silent 20 ms frames (6.7 min of audio); 256 taps × 320 samples
+- OLD (process() with empty far-end every frame): 1416.8 ms, 70.84 µs/frame
+- NEW (skip — verbatim passthrough):                 0.7 ms,  0.03 µs/frame
+- CPU avoided on the silent path:                 2081× less work
+Correctness: OLD empty-reference first-frame output is bit-identical to the mic (PASS).
+```
+
+On every device, whenever the agent is not speaking (the common case), the AEC
+inner loop is now skipped entirely instead of burning ~71 µs per 20 ms frame.
+
+## Reproduce
+```bash
+bun .github/issue-evidence/9649-aec-fast-path-skip-bench.ts
+```

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
@@ -622,4 +622,48 @@ describe("AudioFrameConsumer — echo cancellation (#9455)", () => {
 			expect(Array.from(silentOutputs[i])).toEqual(Array.from(silentInputs[i]));
 		}
 	});
+
+	it("clears stale far-end state before playback resumes after silence", async () => {
+		const PLAYBACK_FRAMES = 40;
+		const SILENT_FRAMES = 5;
+		const restartFrame = PLAYBACK_FRAMES + SILENT_FRAMES;
+		const totalFrames = restartFrame + 1;
+		const N = totalFrames * BLOCK;
+		const far = farSignal(N);
+		const echo = echoOf(far);
+		const zeroReference = new Float32Array(BLOCK);
+		const zeroMic = new Float32Array(BLOCK);
+		const vad = new RecordingVad();
+		const consumer = new AudioFrameConsumer(
+			{
+				vad,
+				pipeline: new FakePipeline("restart"),
+				runtime: new FakeRuntime(),
+				echoReference: (ts: number, samples: number) => {
+					const idx = Math.round((ts - 1000) / 20);
+					if (idx < PLAYBACK_FRAMES) {
+						const off = idx * BLOCK;
+						return far.subarray(off, off + samples);
+					}
+					if (idx < restartFrame) return null;
+					return zeroReference.subarray(0, samples);
+				},
+			},
+			{ source: { kind: "device", deviceId: "pixel" }, preRollSeconds: 0 },
+		);
+
+		let ts = 1000;
+		for (let frameIdx = 0; frameIdx < totalFrames; frameIdx++) {
+			const off = frameIdx * BLOCK;
+			const mic =
+				frameIdx < PLAYBACK_FRAMES ? echo.subarray(off, off + BLOCK) : zeroMic;
+			await consumer.pushDecodedFrame(mic, ts);
+			ts += 20;
+		}
+
+		// The post-silence non-empty reference frame should not inherit any
+		// stale far-end samples from the previous playback burst.
+		expect(consumer.echoFramesCancelled).toBe(PLAYBACK_FRAMES + 1);
+		expect(Array.from(vad.frames[restartFrame])).toEqual(Array.from(zeroMic));
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts
@@ -570,4 +570,56 @@ describe("AudioFrameConsumer — echo cancellation (#9455)", () => {
 		await consumer.pushDecodedFrame(frame, 1000);
 		expect(Array.from(vad.frames[0])).toEqual(Array.from(frame));
 	});
+
+	it("skips the canceller entirely while the agent is silent (#9649 fast path)", async () => {
+		// The reference provider returns far PCM while the agent plays, then null
+		// once it stops. Frames during silence must be EXACT passthrough — proving
+		// the canceller is not invoked at all (so it can't subtract a stale echo
+		// estimate against converged weights) — and must not increment the
+		// cancelled-frame counter.
+		const N = SR * 2;
+		const far = farSignal(N);
+		const echo = echoOf(far);
+		const PLAYBACK_FRAMES = 40; // agent plays for the first 40 frames, then stops
+		const vad = new RecordingVad();
+		const consumer = new AudioFrameConsumer(
+			{
+				vad,
+				pipeline: new FakePipeline("skip"),
+				runtime: new FakeRuntime(),
+				echoReference: (ts: number, samples: number) => {
+					const idx = Math.round((ts - 1000) / 20);
+					if (idx >= PLAYBACK_FRAMES) return null; // agent silent
+					const off = idx * BLOCK;
+					return far.subarray(off, off + samples);
+				},
+			},
+			{ source: { kind: "device", deviceId: "pixel" }, preRollSeconds: 0 },
+		);
+
+		// Mic carries echo while the agent plays, then pure (distinct) near speech.
+		const nearSilentEra = farSignal(N, 555);
+		let ts = 1000;
+		let frameIdx = 0;
+		const silentInputs: Float32Array[] = [];
+		for (let off = 0; off + BLOCK <= N; off += BLOCK, frameIdx++) {
+			const mic =
+				frameIdx < PLAYBACK_FRAMES
+					? echo.subarray(off, off + BLOCK)
+					: nearSilentEra.subarray(off, off + BLOCK);
+			if (frameIdx >= PLAYBACK_FRAMES) silentInputs.push(mic);
+			await consumer.pushDecodedFrame(mic, ts);
+			ts += 20;
+		}
+
+		// Only the playback frames were cancelled; silent frames took the fast path.
+		expect(consumer.echoFramesCancelled).toBe(PLAYBACK_FRAMES);
+
+		// Every silent-era frame is bit-identical to its input (no canceller touch).
+		const silentOutputs = vad.frames.slice(PLAYBACK_FRAMES);
+		expect(silentOutputs.length).toBe(silentInputs.length);
+		for (let i = 0; i < silentOutputs.length; i++) {
+			expect(Array.from(silentOutputs[i])).toEqual(Array.from(silentInputs[i]));
+		}
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -341,7 +341,7 @@ export class AudioFrameConsumer {
 
 	/** Count of mic frames the echo canceller actually processed (i.e. the agent
 	 *  was playing). Frames skipped while the agent is silent do not count, so
-	 *  this also measures how often AEC took the zero-cost passthrough path. */
+	 *  this also measures how often AEC took the cheap passthrough path. */
 	echoFramesCancelled = 0;
 
 	constructor(
@@ -424,8 +424,8 @@ export class AudioFrameConsumer {
 		if (this.closed) return;
 		// #9455/#9649: cancel the agent's TTS echo before VAD/attribution so the
 		// agent never transcribes its own playback. When the reference provider
-		// returns null/empty the agent is silent — skip the canceller entirely so
-		// AEC is zero-cost (and exactly passthrough) on the common no-playback path.
+		// returns null/empty the agent is silent — skip the FIR canceller so AEC
+		// is cheap and exactly passthrough on the common no-playback path.
 		const micPcm = this.cancelEcho(pcm, timestampMs);
 		this.lastFrameEndMs =
 			timestampMs + (micPcm.length / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000;
@@ -444,15 +444,18 @@ export class AudioFrameConsumer {
 	/**
 	 * Run the echo canceller on one mic frame when (and only when) the agent is
 	 * playing. The reference provider returns null while the agent is silent, in
-	 * which case the mic frame is passed through verbatim and `process()` is not
-	 * invoked at all — so AEC adds zero per-sample cost on the common no-playback
-	 * path, and the canceller never subtracts a stale echo estimate against a
-	 * silent far-end. Returns the echo-cancelled (or untouched) mic frame.
+	 * which case the mic frame is passed through verbatim and the FIR
+	 * `process()` loop is not invoked. The canceller still observes the silent
+	 * far-end so stale playback history is cleared before playback resumes.
+	 * Returns the echo-cancelled (or untouched) mic frame.
 	 */
 	private cancelEcho(pcm: Float32Array, timestampMs: number): Float32Array {
 		if (!this.echoCanceller || !this.echoReference) return pcm;
 		const reference = this.echoReference(timestampMs, pcm.length);
-		if (!reference || reference.length === 0) return pcm;
+		if (!reference || reference.length === 0) {
+			this.echoCanceller.observeFarEndSilence(pcm);
+			return pcm;
+		}
 		this.echoFramesCancelled += 1;
 		return this.echoCanceller.process(pcm, reference);
 	}

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -46,9 +46,6 @@ import type {
 } from "./speaker/attribution-pipeline.js";
 import type { PcmFrame, VadEvent, VoiceInputSource } from "./types.js";
 
-/** Shared empty reference — agent silent → echo canceller passes the mic through. */
-const NO_ECHO_REFERENCE = new Float32Array(0);
-
 // ---------------------------------------------------------------------------
 // Wire format → Float32 boundary
 // ---------------------------------------------------------------------------
@@ -342,6 +339,11 @@ export class AudioFrameConsumer {
 	 *  turn rather than dropping the diarized turn). */
 	transcriptionErrors = 0;
 
+	/** Count of mic frames the echo canceller actually processed (i.e. the agent
+	 *  was playing). Frames skipped while the agent is silent do not count, so
+	 *  this also measures how often AEC took the zero-cost passthrough path. */
+	echoFramesCancelled = 0;
+
 	constructor(
 		deps: AudioFrameConsumerDeps,
 		config: AudioFrameConsumerConfig = {},
@@ -420,16 +422,11 @@ export class AudioFrameConsumer {
 		timestampMs: number,
 	): Promise<void> {
 		if (this.closed) return;
-		// #9455: cancel the agent's TTS echo before VAD/attribution so the agent
-		// never transcribes its own playback. Passthrough (out == in) when the
-		// agent is silent — verified by nlms-echo-canceller.test.ts.
-		const micPcm =
-			this.echoCanceller && this.echoReference
-				? this.echoCanceller.process(
-						pcm,
-						this.echoReference(timestampMs, pcm.length) ?? NO_ECHO_REFERENCE,
-					)
-				: pcm;
+		// #9455/#9649: cancel the agent's TTS echo before VAD/attribution so the
+		// agent never transcribes its own playback. When the reference provider
+		// returns null/empty the agent is silent — skip the canceller entirely so
+		// AEC is zero-cost (and exactly passthrough) on the common no-playback path.
+		const micPcm = this.cancelEcho(pcm, timestampMs);
 		this.lastFrameEndMs =
 			timestampMs + (micPcm.length / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000;
 		if (this.capturing) {
@@ -442,6 +439,22 @@ export class AudioFrameConsumer {
 			sampleRate: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
 			timestampMs,
 		});
+	}
+
+	/**
+	 * Run the echo canceller on one mic frame when (and only when) the agent is
+	 * playing. The reference provider returns null while the agent is silent, in
+	 * which case the mic frame is passed through verbatim and `process()` is not
+	 * invoked at all — so AEC adds zero per-sample cost on the common no-playback
+	 * path, and the canceller never subtracts a stale echo estimate against a
+	 * silent far-end. Returns the echo-cancelled (or untouched) mic frame.
+	 */
+	private cancelEcho(pcm: Float32Array, timestampMs: number): Float32Array {
+		if (!this.echoCanceller || !this.echoReference) return pcm;
+		const reference = this.echoReference(timestampMs, pcm.length);
+		if (!reference || reference.length === 0) return pcm;
+		this.echoFramesCancelled += 1;
+		return this.echoCanceller.process(pcm, reference);
 	}
 
 	/**

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -248,11 +248,9 @@ function resolveEchoDelaySamples(): number {
  *   - unset / anything else → disabled (the canceller does linear NLMS only).
  * Left off until validated with real device audio, per #9649 item 2.
  */
-function resolveResidualSuppression():
-	| boolean
-	| { gain: number }
-	| undefined {
-	const raw = process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
+function resolveResidualSuppression(): boolean | { gain: number } | undefined {
+	const raw =
+		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
 	if (!raw) return undefined;
 	if (raw === "1" || raw === "true" || raw === "on") return true;
 	const gain = Number(raw);

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
@@ -227,7 +227,11 @@ describe("NlmsEchoCanceller", () => {
 		it("is off by default (no residualSuppression option ⇒ no extra attenuation)", () => {
 			const far = signal(SR, 5);
 			const near = echoOf(far);
-			const a = runBlocks(new NlmsEchoCanceller({ filterTaps: 128 }), near, far);
+			const a = runBlocks(
+				new NlmsEchoCanceller({ filterTaps: 128 }),
+				near,
+				far,
+			);
 			const b = runBlocks(
 				new NlmsEchoCanceller({ filterTaps: 128, residualSuppression: false }),
 				near,

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
@@ -239,6 +239,34 @@ export class NlmsEchoCanceller {
 		return out;
 	}
 
+	/**
+	 * Advance cheap detector/reference state while the far-end is silent without
+	 * running the FIR echo-estimation loop. Learned filter weights are preserved,
+	 * but stale playback samples are removed from the delay line/ring so the next
+	 * non-empty reference frame cannot subtract an echo estimate from a previous
+	 * utterance.
+	 */
+	observeFarEndSilence(nearEnd: Float32Array): void {
+		const n = nearEnd.length;
+		this.delayLine.length = 0;
+		this.x.fill(0);
+		this.xEnergy = 0;
+		this.peakXEnergy *= NlmsEchoCanceller.PEAK_DECAY ** n;
+		this.pFar *= 0.99 ** n;
+		this.hangover = Math.max(0, this.hangover - n);
+
+		let residualPow = 0;
+		for (let i = 0; i < n; i++) {
+			const d = nearEnd[i];
+			this.pNear = 0.99 * this.pNear + 0.01 * d * d;
+			residualPow += d * d;
+		}
+		if (this.peakXEnergy < this.eps) this.peakXEnergy = 0;
+		if (this.pFar < this.eps) this.pFar = 0;
+		this.lastEchoPow = 0;
+		this.lastResidualPow = residualPow / Math.max(1, n);
+	}
+
 	/** Echo-return-loss-enhancement (dB) over the last processed block. Higher is
 	 * better; >10 dB is a meaningful cancellation. Returns 0 when there is no
 	 * modeled echo (agent silent) so a passthrough block reads as "no gain". */


### PR DESCRIPTION
## What

Salvages the **agent-silent fast-path skip** from the stale `opt/ios-mac-aec-9583` branch — the last of issue #9649 item 2's three AEC ideas that was not already on `develop`.

Status of item 2's three ideas:
- per-platform delay seed → already landed (#9653)
- residual-echo suppressor → already landed on `develop`
- agent-silent fast-path skip → this PR

## Change

`pushDecodedFrame` previously called `NlmsEchoCanceller.process(pcm, … ?? NO_ECHO_REFERENCE)` on every mic frame, including the common path where the agent is silent. This PR routes through `cancelEcho()`:

- non-empty far-end reference: run the normal NLMS canceller and increment `echoFramesCancelled`
- null/empty far-end reference: return the mic frame verbatim and skip the FIR inner loop
- silent-reference path still calls `observeFarEndSilence()` so learned weights are preserved while stale far-end delay/ring/envelope state is cleared before playback resumes

That last point addresses the restart boundary: the fast path no longer freezes old playback samples in the canceller state while the agent is silent.

## Evidence

`.github/issue-evidence/9649-aec-fast-path-skip.md`

- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run --cwd packages/core prebuild` (generated missing keyword data and built `@elizaos/contracts` in the recovered checkout)
- `bunx vitest run plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.test.ts plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts` (2 files, 27 tests passed)
- `bun run --cwd plugins/plugin-local-inference lint:check` (418 files checked)
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bun .github/issue-evidence/9649-aec-fast-path-skip-bench.ts` (`70.47 µs/frame → 0.79 µs/frame`, ~90× less work on the silent path)
- `git diff --check`
- `bun run verify` (515 successful, 515 total)

Refs #9649
Refs #9583
