### PR TITLE
fix(cloud): make headscale pre-auth TTL env-overridable (default 60min) — Gate A repo durability

### DIFF
--- a/packages/cloud-shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-client.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePreAuthTtlMs } from "./headscale-client";
+
+/**
+ * The headscale pre-auth key TTL gates the provisioning-E2E reachable path: the
+ * key must outlive container boot + VPN enrollment. A 10-min hardcoded window
+ * was too tight on slow boots — the key expired mid-registration and the
+ * container looped on re-auth (one prod agent hit 176 restarts). The box was
+ * bumped to 60 min via HEADSCALE_PREAUTH_TTL_MIN, but the source still hardcoded
+ * 10 min, so a daemon redeploy would regress it. This locks the durable repo
+ * behavior: 60-min default + the env override that survives a redeploy.
+ */
+describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
+  const original = process.env.HEADSCALE_PREAUTH_TTL_MIN;
+  afterEach(() => {
+    if (original === undefined) delete process.env.HEADSCALE_PREAUTH_TTL_MIN;
+    else process.env.HEADSCALE_PREAUTH_TTL_MIN = original;
+  });
+
+  it("defaults to 60 minutes (prod-verified; 10 min looped slow boots)", () => {
+    delete process.env.HEADSCALE_PREAUTH_TTL_MIN;
+    expect(resolvePreAuthTtlMs()).toBe(60 * 60 * 1000);
+  });
+
+  it("honors HEADSCALE_PREAUTH_TTL_MIN so the box override survives a redeploy", () => {
+    process.env.HEADSCALE_PREAUTH_TTL_MIN = "90";
+    expect(resolvePreAuthTtlMs()).toBe(90 * 60 * 1000);
+  });
+
+  it("falls back to the 60-min default for non-positive / non-numeric values", () => {
+    for (const bad of ["0", "-5", "abc", "", "  "]) {
+      process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
+      expect(resolvePreAuthTtlMs()).toBe(60 * 60 * 1000);
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-client.ts
@@ -19,6 +19,19 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 /** Timeout for health checks (ms) */
 const HEALTH_TIMEOUT_MS = 5_000;
 
+/**
+ * Pre-auth key TTL window (ms): how long a freshly-created key stays valid for a
+ * container to boot AND finish VPN enrollment. 10 min proved too tight on slow
+ * boots — the key could expire before headscale registration completed, looping
+ * the container on re-auth (one prod agent hit 176 restarts before this was
+ * raised on the box). Default 60 min (verified healthy in prod); env-overridable
+ * via `HEADSCALE_PREAUTH_TTL_MIN` so it survives a daemon redeploy.
+ */
+export function resolvePreAuthTtlMs(): number {
+  const minutes = Number.parseInt(process.env.HEADSCALE_PREAUTH_TTL_MIN ?? "", 10);
+  return (Number.isFinite(minutes) && minutes > 0 ? minutes : 60) * 60 * 1000;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -165,7 +178,7 @@ export class HeadscaleClient {
    *
    * @param opts.reusable   Allow the key to be used more than once (default false)
    * @param opts.ephemeral  Node will be removed once it goes offline (default false)
-   * @param opts.expiration ISO-8601 expiration timestamp (default: 10 min from now)
+   * @param opts.expiration ISO-8601 expiration timestamp (default: now + HEADSCALE_PREAUTH_TTL_MIN, 60 min)
    * @param opts.aclTags    ACL tags to attach to the key (default: ["tag:agent"])
    */
   async createPreAuthKey(opts?: {
@@ -185,9 +198,11 @@ export class HeadscaleClient {
       ensureUser = false,
     } = opts ?? {};
 
-    // 10-minute window is sufficient for container boot + VPN enrollment.
-    // Previous 24h was unnecessarily large for single-use ephemeral keys.
-    const expirationTime = expiration ?? new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    // The key must stay valid long enough for the container to boot AND finish
+    // VPN enrollment; 10 min was too tight on slow boots (key expired mid-
+    // registration -> container re-auth loop). Default 60 min, env-overridable
+    // via HEADSCALE_PREAUTH_TTL_MIN (see resolvePreAuthTtlMs).
+    const expirationTime = expiration ?? new Date(Date.now() + resolvePreAuthTtlMs()).toISOString();
 
     const userId = ensureUser ? await this.ensureUser(user) : await this.resolveUserId(user);
 


### PR DESCRIPTION
## Why
The **provisioning-E2E reachable gate (Gate A)** was crash-looping: a fresh agent on a slow boot hit ~176 restarts because the **hardcoded 10-min** pre-auth key window (`headscale-client.ts`) expired before the container finished headscale/VPN registration → re-auth loop.

@0xSolace fixed it **on the box** (TTL 10→60min via `HEADSCALE_PREAUTH_TTL_MIN` + image bump) and prod is now **10/10 healthy**. But the **source still hardcoded `10 * 60 * 1000` and never read the env var**, so the next daemon redeploy from the repo would **silently regress the gate** — exactly the durability hole flagged in the launch-readiness review.

## What
- `resolvePreAuthTtlMs()` reads `HEADSCALE_PREAUTH_TTL_MIN` (per-call, so the daemon env applies without a rebuild), defaults to the **prod-verified 60 min**, and falls back to 60 on non-positive/non-numeric input.
- Mirrors the established env-override pattern from #9326 (`VPN_REGISTRATION_TIMEOUT_MS`, `PROVISION_JOB_TIMEOUT_MS`).
- Regression test (`headscale-client.test.ts`) locks the 60-min default + the env override (so the box setting survives a redeploy) + invalid handling. **3/3 green; typecheck + biome clean.**
- No behavior change for callers passing an explicit `expiration`.

## Lane / ownership
This is the **cloud/VPS lane** (@0xSolace's provisioning chain). I authored it as the **source fix-forward of the on-box fix** so Gate A is durable in the repo before any redeploy — review, adjust the default, or take it over as you see fit. Pairs with the on-box `HEADSCALE_PREAUTH_TTL_MIN=60` already set.

cc @standujar @0xSolace — surfaced by the launch-readiness assessment on #8434.