### PR TITLE
fix(ui): wrap Storybook stories in TranslationProvider (browser Story Gate crash)

### DIFF
--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@elizaos/ui/components/ui/tooltip";
+import { TranslationProvider } from "@elizaos/ui/state";
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react";
 import type { ReactNode } from "react";
@@ -81,13 +82,20 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => (
-      <TooltipProvider delayDuration={200} skipDelayDuration={100}>
-        <StorybookThemeSurface
-          theme={resolveStorybookTheme(context.globals.theme)}
-        >
-          <Story />
-        </StorybookThemeSurface>
-      </TooltipProvider>
+      // TranslationProvider so stories whose components call useTranslation()
+      // (e.g. MessageAttachments' PdfDownloadFallback) render in the browser
+      // Story Gate. useTranslation only returns a test fallback under
+      // NODE_ENV=test (the jsdom story-smoke), and THROWS "must be used within
+      // TranslationProvider" in the real browser — which crashed those stories.
+      <TranslationProvider>
+        <TooltipProvider delayDuration={200} skipDelayDuration={100}>
+          <StorybookThemeSurface
+            theme={resolveStorybookTheme(context.globals.theme)}
+          >
+            <Story />
+          </StorybookThemeSurface>
+        </TooltipProvider>
+      </TranslationProvider>
     ),
     // Light/dark by toggling the `dark` class on the preview root — matches how
     // the app themes (the design tokens key off it).


### PR DESCRIPTION
## Why
The **browser UI Story Gate** is red on stories whose components call `useTranslation()` — notably `MessageAttachments`' `PdfDownloadFallback`. `useTranslation()` (`TranslationContext.hooks`) returns a **test fallback only under `NODE_ENV=test`**, so the offline **jsdom story-smoke (138 green) MASKS it** — but in the real browser Storybook it **throws** `useTranslation must be used within TranslationProvider` and crashes the story. That's one source of the growing Story Gate regression count flagged in the launch-readiness review.

## What
Add `TranslationProvider` to the global `preview.tsx` decorator chain (alongside the existing `TooltipProvider` + theme). `TranslationProvider` needs only `children` and defaults to the persisted/detected UI language, so this fixes the **whole class** of translation-using stories, not just `MessageAttachments`.

## Verification
- typecheck + biome clean; `@elizaos/ui/state` export resolves `TranslationProvider`.
- jsdom story-smoke unaffected (it uses the portable-stories harness, not `preview.tsx`).
- **The browser Story Gate in CI is the authoritative confirmation** (this is exactly the lane that was red). Static root cause is unambiguous: the component throws without the provider, and the global decorator now provides it.

cc @lalalune — this is your UI lane; surfaced by the launch-readiness assessment on #8434. There were *more* Story Gate regressions flagged (count 22→27→30) — this fixes the translation-provider class; the rest are separate.