### PR TITLE
fix(vision): describe-backpressure RSS cap measures growth over baseline, not absolute (#9581)

### DIFF
--- a/plugins/plugin-vision/src/describe-backpressure.test.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.test.ts
@@ -75,26 +75,45 @@ describe("DescribeBackpressureController", () => {
     expect(d.transitionedTo).toBe("active");
   });
 
-  it("pauses on local RSS over the cap and self-recovers when RSS drops", () => {
-    let rss = 100 * 1024 * 1024; // 100 MB
-    const cap = 500 * 1024 * 1024; // 500 MB
+  it("pauses on RSS GROWTH over the cap and self-recovers when RSS drops back", () => {
+    // Baseline 1500 MB (a local agent with multi-GB GGUF models resident),
+    // cap = 500 MB of vision-attributable growth.
+    let rss = 1500 * 1024 * 1024;
+    const cap = 500 * 1024 * 1024;
     const ctrl = new DescribeBackpressureController({
       memoryCapBytes: cap,
       sampleRssBytes: () => rss,
     });
 
+    // First call captures the baseline → growth 0 → describes.
     expect(ctrl.evaluate().describe).toBe(true);
 
-    rss = 600 * 1024 * 1024; // over cap
+    rss = 2100 * 1024 * 1024; // +600 MB growth, over the 500 MB cap
     const over = ctrl.evaluate();
     expect(over.describe).toBe(false);
     expect(over.reason).toBe("memory-cap");
     expect(over.transitionedTo).toBe("paused");
 
-    rss = 200 * 1024 * 1024; // back under cap
+    rss = 1700 * 1024 * 1024; // +200 MB growth, back within cap
     const under = ctrl.evaluate();
     expect(under.describe).toBe(true);
     expect(under.transitionedTo).toBe("active");
+  });
+
+  it("does NOT pause on a high steady-state RSS (regression: absolute-RSS cap permanently blocked describing)", () => {
+    // A real vision-enabled local agent mmaps multi-GB GGUF models; whole-process
+    // RSS sits well above any MB cap. The growth-relative cap must NOT pause.
+    const steadyRss = 4 * 1024 * 1024 * 1024; // 4 GB, constant
+    const ctrl = new DescribeBackpressureController({
+      memoryCapBytes: 2000 * 1024 * 1024, // documented MAX_MEMORY_USAGE_MB default
+      sampleRssBytes: () => steadyRss,
+    });
+    for (let i = 0; i < 10; i++) {
+      const d = ctrl.evaluate();
+      expect(d.describe).toBe(true);
+      expect(d.reason).toBeNull();
+    }
+    expect(ctrl.stats().describesSkipped).toBe(0);
   });
 
   it("disables the local cap when memoryCapBytes is 0", () => {
@@ -107,13 +126,17 @@ describe("DescribeBackpressureController", () => {
 
   it("reports arbiter pressure as the reason when both signals are active", () => {
     let now = 0;
+    let rss = 100 * 1024 * 1024;
     const ctrl = new DescribeBackpressureController({
-      memoryCapBytes: 1,
-      sampleRssBytes: () => 1024, // always over the tiny cap
+      memoryCapBytes: 1, // 1-byte growth cap
+      sampleRssBytes: () => rss,
       now: () => now,
     });
 
-    // Cap alone first.
+    // First call captures baseline (100 MB) → no growth yet.
+    expect(ctrl.evaluate().reason).toBeNull();
+    // Grow RSS so the cap trips alone.
+    rss = 200 * 1024 * 1024;
     expect(ctrl.evaluate().reason).toBe("memory-cap");
 
     // Arbiter pressure should now take precedence in the reported reason.

--- a/plugins/plugin-vision/src/describe-backpressure.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.ts
@@ -59,9 +59,12 @@ export interface DescribeBackpressureDecision {
 
 export interface DescribeBackpressureConfig {
   /**
-   * RSS cap in bytes. While sampled RSS exceeds it the describe step pauses.
-   * `0` or negative disables the local check — only the arbiter signal can
-   * pause describing.
+   * Cap in bytes on **vision-attributable RSS growth** over the baseline
+   * captured on the first describe tick. While `rss - baseline` exceeds it the
+   * describe step pauses. `0` or negative disables the local check — only the
+   * arbiter signal can pause describing. (Deliberately growth-relative, not
+   * absolute: a local agent's steady-state RSS includes multi-GB mmap'd GGUF
+   * models, so an absolute comparison would pause describing permanently.)
    */
   memoryCapBytes?: number;
   /**
@@ -91,6 +94,9 @@ export class DescribeBackpressureController {
   private paused = false;
   private describesSkipped = 0;
   private pauseTransitions = 0;
+  // RSS baseline captured on the first cap evaluation; the cap measures growth
+  // over this, not absolute RSS (see config.memoryCapBytes). null until set.
+  private baselineRssBytes: number | null = null;
 
   constructor(config: DescribeBackpressureConfig = {}) {
     this.memoryCapBytes =
@@ -132,8 +138,7 @@ export class DescribeBackpressureController {
    */
   evaluate(): DescribeBackpressureDecision {
     const arbiterPaused = this.now() < this.pauseUntilMs;
-    const overCap =
-      this.memoryCapBytes > 0 && this.sampleRssBytes() > this.memoryCapBytes;
+    const overCap = this.isOverGrowthCap();
     const paused = arbiterPaused || overCap;
 
     let transitionedTo: "paused" | "active" | null = null;
@@ -151,6 +156,22 @@ export class DescribeBackpressureController {
         : "memory-cap";
 
     return { describe: !paused, transitionedTo, reason };
+  }
+
+  /**
+   * Has vision-attributable RSS grown past the cap? Captures the baseline on
+   * the first call (the first describe tick, when the loop's models are already
+   * resident) so the steady-state model footprint is absorbed rather than
+   * counted as over-cap. A transient growth that drops back resumes describing.
+   */
+  private isOverGrowthCap(): boolean {
+    if (this.memoryCapBytes <= 0) return false;
+    const rss = this.sampleRssBytes();
+    if (this.baselineRssBytes === null) {
+      this.baselineRssBytes = rss;
+      return false;
+    }
+    return rss - this.baselineRssBytes > this.memoryCapBytes;
   }
 
   stats(): DescribeBackpressureStats {

--- a/plugins/plugin-vision/src/service-backpressure-wiring.test.ts
+++ b/plugins/plugin-vision/src/service-backpressure-wiring.test.ts
@@ -1,0 +1,94 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { IModelArbiter } from "./lifecycle";
+import { VisionService } from "./service";
+
+// Integration coverage for the VisionService ↔ DescribeBackpressureController
+// wiring shipped in PR #9688 (#9581 / #9105 M8). The pure controller is unit-
+// tested in describe-backpressure.test.ts and the WS1 bridge in
+// ws1-arbiter-bridge.test.ts; this file exercises the service glue itself:
+// attachMemoryArbiter() resolving + subscribing the arbiter, the onPressure →
+// setPressure("critical") cascade, resumeDescribeLoop(), getBackpressureStats(),
+// idempotent re-attach, and unsubscribe on stop().
+
+type PressureCb = (holders: string[]) => void;
+
+function makeRuntime(arbiter: IModelArbiter | null) {
+  return Object.assign(Object.create(null) as IAgentRuntime, {
+    agentId: "agent",
+    character: {},
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn((name: string) =>
+      name === "MEMORY_ARBITER" ? arbiter : null,
+    ),
+    getServicesByType: vi.fn(() => []),
+  });
+}
+
+function makeArbiter() {
+  let pressureCb: PressureCb | null = null;
+  const unsubscribe = vi.fn();
+  const arbiter: IModelArbiter = {
+    acquire: vi.fn(() => true),
+    release: vi.fn(),
+    onPressure: vi.fn((cb: PressureCb) => {
+      pressureCb = cb;
+      return unsubscribe;
+    }),
+  };
+  return {
+    arbiter,
+    unsubscribe,
+    fire: (holders: string[] = []) => pressureCb?.(holders),
+  };
+}
+
+const attach = (svc: VisionService) =>
+  (svc as unknown as { attachMemoryArbiter(): void }).attachMemoryArbiter();
+
+describe("VisionService ↔ DescribeBackpressureController wiring (#9688)", () => {
+  it("cascades arbiter pressure into the controller and resumes explicitly", () => {
+    const { arbiter, fire } = makeArbiter();
+    const svc = new VisionService(makeRuntime(arbiter));
+
+    attach(svc);
+    expect(arbiter.onPressure).toHaveBeenCalledTimes(1);
+    expect(svc.getBackpressureStats().pressureLevel).toBe("nominal");
+
+    // A pressure event flips the controller to critical (paused only flips
+    // inside evaluate(), which getBackpressureStats does not call — assert the
+    // pressure level, not `paused`).
+    fire();
+    expect(svc.getBackpressureStats().pressureLevel).toBe("critical");
+
+    svc.resumeDescribeLoop();
+    expect(svc.getBackpressureStats().pressureLevel).toBe("nominal");
+  });
+
+  it("does not double-subscribe on re-attach: the prior subscription is released first", () => {
+    const { arbiter, unsubscribe } = makeArbiter();
+    const svc = new VisionService(makeRuntime(arbiter));
+
+    attach(svc);
+    attach(svc);
+    expect(arbiter.onPressure).toHaveBeenCalledTimes(2);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the arbiter subscription on stop()", async () => {
+    const { arbiter, unsubscribe } = makeArbiter();
+    const svc = new VisionService(makeRuntime(arbiter));
+
+    attach(svc);
+    await svc.stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when no arbiter is registered (standalone path stays usable)", () => {
+    const svc = new VisionService(makeRuntime(null));
+    expect(() => attach(svc)).not.toThrow();
+    expect(svc.getBackpressureStats().pressureLevel).toBe("nominal");
+    svc.resumeDescribeLoop();
+    expect(svc.getBackpressureStats().paused).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Follow-up fix on top of the memory-pressure pause-loop owner that landed on develop (`6bb403b`, #9581 / #9105 M8).

That code's local RSS guard compares **whole-process** `process.memoryUsage().rss` against the `MAX_MEMORY_USAGE_MB` default (2000 MB) — even though its own doc comment already says *"growth over a baseline"*. A real vision-enabled local agent mmaps multi-GB GGUF text + vision models, so its steady-state RSS sits well above any MB cap: the guard pauses describing on the **first tick and never recovers** (`reason="memory-cap"` forever), defeating the feature. (Caught by adversarial self-review.)

## Change

Make the code match the documented intent: the cap now measures **vision-attributable RSS growth over a baseline** captured lazily on the first describe tick (`isOverGrowthCap()`). A large-but-steady model footprint is absorbed into the baseline and never trips the guard; a genuine runaway still does; it self-recovers when RSS drops back within `baseline + cap`. The `MAX_MEMORY_USAGE_MB` knob name + MB units are unchanged. `service.ts` is unchanged (already on develop).

## Tests

- **regression**: a constant 4 GB RSS with the 2000 MB cap no longer pauses describing (the exact bug);
- the cap pause/resume test updated to growth semantics;
- **`service-backpressure-wiring.test.ts`** (new): integration coverage for the VisionService glue that previously had **zero** service-level tests — `attachMemoryArbiter` resolve+subscribe, `onPressure → setPressure("critical")` cascade, `resumeDescribeLoop`, `getBackpressureStats`, idempotent re-attach (prior sub released), unsubscribe on `stop()`, no-arbiter standalone path.

`bun run --cwd plugins/plugin-vision test` green; `tsc` 0; biome clean.

(Supersedes #9688, whose first commit already landed as `6bb403b`; that branch now conflicts and is closed in favor of this clean delta.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)