### PR TITLE
fix(vision): growth-over-baseline describe-backpressure + escalation + stale flag (#9693)

### DIFF
--- a/plugins/plugin-vision/src/describe-backpressure.test.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.test.ts
@@ -75,26 +75,64 @@ describe("DescribeBackpressureController", () => {
     expect(d.transitionedTo).toBe("active");
   });
 
-  it("pauses on local RSS over the cap and self-recovers when RSS drops", () => {
-    let rss = 100 * 1024 * 1024; // 100 MB
-    const cap = 500 * 1024 * 1024; // 500 MB
+  it("pauses on local RSS GROWTH past the cap and self-recovers when RSS drops", () => {
+    let rss = 100 * 1024 * 1024; // 100 MB baseline (captured on the first tick)
+    const cap = 500 * 1024 * 1024; // 500 MB of growth allowed
     const ctrl = new DescribeBackpressureController({
       memoryCapBytes: cap,
       sampleRssBytes: () => rss,
     });
 
-    expect(ctrl.evaluate().describe).toBe(true);
+    expect(ctrl.evaluate().describe).toBe(true); // baseline = 100 MB
 
-    rss = 600 * 1024 * 1024; // over cap
+    rss = 700 * 1024 * 1024; // growth 600 MB > 500 MB cap
     const over = ctrl.evaluate();
     expect(over.describe).toBe(false);
     expect(over.reason).toBe("memory-cap");
     expect(over.transitionedTo).toBe("paused");
 
-    rss = 200 * 1024 * 1024; // back under cap
+    rss = 300 * 1024 * 1024; // growth 200 MB back under cap
     const under = ctrl.evaluate();
     expect(under.describe).toBe(true);
     expect(under.transitionedTo).toBe("active");
+  });
+
+  it("does NOT pause forever on a large-but-steady RSS (the #9693 regression)", () => {
+    // A device that mmaps a multi-GB local model sits at ~3 GB RSS from tick 1.
+    // With an absolute cap this paused describing on every tick forever; with
+    // the growth-over-baseline cap a steady footprint never trips the guard.
+    const steady = 3 * 1024 * 1024 * 1024; // 3 GB, constant
+    const ctrl = new DescribeBackpressureController({
+      memoryCapBytes: 2000 * 1024 * 1024, // the default 2000 MB cap
+      sampleRssBytes: () => steady,
+    });
+    for (let i = 0; i < 100; i++) {
+      expect(ctrl.evaluate().describe).toBe(true);
+    }
+    expect(ctrl.stats().describesSkipped).toBe(0);
+  });
+
+  it("escalates to an observable signal once a pause persists past warnAfterMs", () => {
+    let now = 0;
+    const ctrl = new DescribeBackpressureController({
+      arbiterPauseCooldownMs: 10_000_000, // keep it paused for the whole test
+      warnAfterMs: 60_000,
+      warnRepeatMs: 60_000,
+      now: () => now,
+    });
+    ctrl.setPressure("critical");
+    // Just-paused: edge fires, but no escalation yet.
+    expect(ctrl.evaluate().escalate).toBe(false);
+    now = 30_000;
+    expect(ctrl.evaluate().escalate).toBe(false); // 30s < 60s
+    now = 61_000;
+    const first = ctrl.evaluate();
+    expect(first.escalate).toBe(true); // crossed 60s
+    expect(first.continuousPauseMs).toBe(61_000);
+    now = 90_000;
+    expect(ctrl.evaluate().escalate).toBe(false); // within the repeat window
+    now = 122_000;
+    expect(ctrl.evaluate().escalate).toBe(true); // repeat after 60s
   });
 
   it("disables the local cap when memoryCapBytes is 0", () => {
@@ -107,12 +145,15 @@ describe("DescribeBackpressureController", () => {
 
   it("reports arbiter pressure as the reason when both signals are active", () => {
     let now = 0;
+    let rss = 0;
     const ctrl = new DescribeBackpressureController({
       memoryCapBytes: 1,
-      sampleRssBytes: () => 1024, // always over the tiny cap
+      sampleRssBytes: () => rss,
       now: () => now,
     });
 
+    ctrl.evaluate(); // baseline tick (rss = 0)
+    rss = 1024; // grow past the 1-byte cap
     // Cap alone first.
     expect(ctrl.evaluate().reason).toBe("memory-cap");
 

--- a/plugins/plugin-vision/src/describe-backpressure.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.ts
@@ -46,6 +46,8 @@ export interface DescribeBackpressureStats {
   describesSkipped: number;
   /** Count of paused<->active edges (telemetry / test signal). */
   pauseTransitions: number;
+  /** How long the describe has been continuously paused, in ms (0 if active). */
+  continuousPauseMs: number;
 }
 
 export interface DescribeBackpressureDecision {
@@ -55,13 +57,25 @@ export interface DescribeBackpressureDecision {
   transitionedTo: "paused" | "active" | null;
   /** Why we are paused (only meaningful when `describe === false`). */
   reason: DescribePauseReason;
+  /** How long the describe has been continuously paused, in ms (0 if active). */
+  continuousPauseMs: number;
+  /**
+   * True on the tick the caller should emit an escalation `warn` — set once the
+   * continuous pause first crosses `warnAfterMs` and again every `warnRepeatMs`
+   * thereafter while it persists, so a stuck loop is observable (#9693).
+   */
+  escalate: boolean;
 }
 
 export interface DescribeBackpressureConfig {
   /**
-   * RSS cap in bytes. While sampled RSS exceeds it the describe step pauses.
-   * `0` or negative disables the local check — only the arbiter signal can
-   * pause describing.
+   * Vision-attributable RSS GROWTH cap in bytes — the describe step pauses
+   * while `sampledRss - baseline` exceeds it, where `baseline` is the RSS
+   * captured on the first `evaluate()` tick (after the local model is already
+   * mmapped). Comparing GROWTH (not absolute RSS) is what stops the loop from
+   * pausing forever on a device whose steady-state RSS already exceeds any
+   * reasonable MB cap — see #9693. `0` or negative disables the local check —
+   * only the arbiter signal can pause describing.
    */
   memoryCapBytes?: number;
   /**
@@ -75,22 +89,44 @@ export interface DescribeBackpressureConfig {
    * auto-clears after this window of silence. Default 15_000.
    */
   arbiterPauseCooldownMs?: number;
+  /**
+   * Escalate from edge-only logging to a repeated warning once the describe has
+   * been paused continuously for this long, so a permanently-stuck loop becomes
+   * observable instead of silent (#9693). Default 60_000. `0`/negative disables.
+   */
+  warnAfterMs?: number;
+  /**
+   * Minimum gap between escalation warnings while a continuous pause persists,
+   * in ms. Default 60_000.
+   */
+  warnRepeatMs?: number;
   /** Clock, injectable for tests. Defaults to `Date.now`. */
   now?: () => number;
 }
 
 const DEFAULT_ARBITER_PAUSE_COOLDOWN_MS = 15_000;
+const DEFAULT_WARN_AFTER_MS = 60_000;
+const DEFAULT_WARN_REPEAT_MS = 60_000;
 
 export class DescribeBackpressureController {
   private readonly memoryCapBytes: number;
   private readonly sampleRssBytes: () => number;
   private readonly arbiterPauseCooldownMs: number;
+  private readonly warnAfterMs: number;
+  private readonly warnRepeatMs: number;
   private readonly now: () => number;
   private pressureLevel: MemoryPressureLevel = "nominal";
   private pauseUntilMs = 0;
   private paused = false;
   private describesSkipped = 0;
   private pauseTransitions = 0;
+  /** RSS captured on the first evaluate() tick; the growth cap is measured against it. */
+  private rssBaseline = 0;
+  private rssBaselineCaptured = false;
+  /** `now()` when the current continuous pause began (0 while active). */
+  private pausedSinceMs = 0;
+  /** `now()` of the last escalation warn emitted for the current pause (0 if none). */
+  private lastWarnMs = 0;
 
   constructor(config: DescribeBackpressureConfig = {}) {
     this.memoryCapBytes =
@@ -104,6 +140,14 @@ export class DescribeBackpressureController {
       config.arbiterPauseCooldownMs > 0
         ? config.arbiterPauseCooldownMs
         : DEFAULT_ARBITER_PAUSE_COOLDOWN_MS;
+    this.warnAfterMs =
+      typeof config.warnAfterMs === "number" && config.warnAfterMs > 0
+        ? config.warnAfterMs
+        : DEFAULT_WARN_AFTER_MS;
+    this.warnRepeatMs =
+      typeof config.warnRepeatMs === "number" && config.warnRepeatMs > 0
+        ? config.warnRepeatMs
+        : DEFAULT_WARN_REPEAT_MS;
     this.now = config.now ?? (() => Date.now());
   }
 
@@ -131,9 +175,19 @@ export class DescribeBackpressureController {
    * the reported `reason` is the more authoritative one.
    */
   evaluate(): DescribeBackpressureDecision {
-    const arbiterPaused = this.now() < this.pauseUntilMs;
+    const nowMs = this.now();
+    // Capture the RSS baseline on the first tick — by now the local model is
+    // mmapped, so the cap measures only the vision loop's own growth on top of
+    // a large-but-steady footprint instead of tripping on absolute RSS forever.
+    if (!this.rssBaselineCaptured) {
+      this.rssBaseline = this.sampleRssBytes();
+      this.rssBaselineCaptured = true;
+    }
+
+    const arbiterPaused = nowMs < this.pauseUntilMs;
     const overCap =
-      this.memoryCapBytes > 0 && this.sampleRssBytes() > this.memoryCapBytes;
+      this.memoryCapBytes > 0 &&
+      this.sampleRssBytes() - this.rssBaseline > this.memoryCapBytes;
     const paused = arbiterPaused || overCap;
 
     let transitionedTo: "paused" | "active" | null = null;
@@ -141,8 +195,24 @@ export class DescribeBackpressureController {
       transitionedTo = paused ? "paused" : "active";
       this.paused = paused;
       this.pauseTransitions += 1;
+      this.pausedSinceMs = paused ? nowMs : 0;
+      this.lastWarnMs = 0;
     }
     if (paused) this.describesSkipped += 1;
+
+    const continuousPauseMs = paused ? nowMs - this.pausedSinceMs : 0;
+    // Escalate to a repeated warn once a pause persists past warnAfterMs, so a
+    // permanently-stuck describe loop is observable rather than silent (#9693).
+    let escalate = false;
+    if (
+      paused &&
+      this.warnAfterMs > 0 &&
+      continuousPauseMs >= this.warnAfterMs &&
+      nowMs - this.lastWarnMs >= this.warnRepeatMs
+    ) {
+      escalate = true;
+      this.lastWarnMs = nowMs;
+    }
 
     const reason: DescribePauseReason = !paused
       ? null
@@ -150,7 +220,13 @@ export class DescribeBackpressureController {
         ? "arbiter-pressure"
         : "memory-cap";
 
-    return { describe: !paused, transitionedTo, reason };
+    return {
+      describe: !paused,
+      transitionedTo,
+      reason,
+      continuousPauseMs,
+      escalate,
+    };
   }
 
   stats(): DescribeBackpressureStats {
@@ -159,6 +235,7 @@ export class DescribeBackpressureController {
       pressureLevel: this.pressureLevel,
       describesSkipped: this.describesSkipped,
       pauseTransitions: this.pauseTransitions,
+      continuousPauseMs: this.paused ? this.now() - this.pausedSinceMs : 0,
     };
   }
 }

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -154,7 +154,13 @@ export const visionProvider: Provider = {
           const ageInSeconds = (Date.now() - sceneDescription.timestamp) / 1000;
           const secondsAgo = Math.round(ageInSeconds);
 
-          perceptionText += `Camera view (${secondsAgo}s ago):\n${sceneDescription.description}`;
+          // When the describe step was paused under backpressure the prose is
+          // reused/stale even though the frame is fresh — flag it so the agent
+          // doesn't treat the description as a current observation (#9693).
+          const staleNote = sceneDescription.describePaused
+            ? " — description below is reused (VLM paused under memory pressure); objects/people are current"
+            : "";
+          perceptionText += `Camera view (${secondsAgo}s ago${staleNote}):\n${sceneDescription.description}`;
 
           if (sceneDescription.people.length > 0) {
             perceptionText += `\n\nPeople detected: ${sceneDescription.people.length}`;

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -1101,6 +1101,16 @@ export class VisionService extends Service {
       } else if (describeGate?.transitionedTo === "active") {
         logger.info("[VisionService] VLM describe resumed");
       }
+      if (describeGate?.escalate) {
+        // The pause has persisted — escalate from the one-shot pause-edge info
+        // log to a repeated warn so a permanently-stuck describe loop is
+        // observable (the prose is stale while OCR/YOLO keep running) (#9693).
+        logger.warn(
+          `[VisionService] VLM describe still paused (${describeGate.reason}) after ${Math.round(
+            describeGate.continuousPauseMs / 1000,
+          )}s — ${this.describeBackpressure.stats().describesSkipped} describes skipped; scene prose is stale (OCR/YOLO still fresh)`,
+        );
+      }
       if (shouldUpdateVlm && describeGate?.describe) {
         // Prefer the change-gated per-tile describe on incremental updates: once
         // a prior scene description exists we only re-describe the tiles that
@@ -1158,6 +1168,11 @@ export class VisionService extends Service {
         people,
         sceneChanged: shouldUpdateVlm || shouldUpdateTf,
         changePercentage,
+        // A VLM update was due but the describe was skipped under backpressure:
+        // the prose is the reused stale one even though the frame is fresh (#9693).
+        describePaused: Boolean(
+          shouldUpdateVlm && describeGate && !describeGate.describe,
+        ),
       };
 
       // Enhanced logging

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -22,6 +22,13 @@ export interface SceneDescription {
   sceneChanged: boolean;
   changePercentage: number;
   audioTranscription?: string;
+  /**
+   * True when this tick's pixels/objects/OCR are fresh but the VLM `description`
+   * prose was NOT re-run (the describe step was paused under memory/RSS
+   * backpressure) — so the prose is stale even though `sceneChanged` is true.
+   * Consumers must not present the description as freshly generated (#9693).
+   */
+  describePaused?: boolean;
 }
 
 export interface DetectedObject {


### PR DESCRIPTION
Fixes #9693 — the two consequence-level bugs from the `DescribeBackpressureController` review.

## 1. Permanent silent describe-pause (higher priority)
The controller's header described a **growth-over-baseline** RSS cap, but `evaluate()` compared **absolute** `process.memoryUsage().rss` to `memoryCapBytes`, and `VisionService` injected no baseline sampler. On a device that mmaps a multi-GB eliza-1 model, absolute RSS exceeds the default 2000 MB cap on **every** tick → the VLM describe pauses **forever**, silently (a single `info` log on the pause edge).

**Fix:** capture an RSS baseline on the first `evaluate()` tick and gate on **growth** (`sampledRss − baseline > cap`), so a large-but-steady footprint never trips the guard while a genuine runaway still does. Added **escalating telemetry** — a repeated `warn` once a pause persists past `warnAfterMs` (default 60s, repeat 60s) so a stuck loop is observable instead of silent.

## 2. Stale scene reported as fresh
While paused, `lastSceneDescription` was rebuilt with a fresh `frame.timestamp` + `sceneChanged: true` but the **reused stale** prose, so `VISION_PERCEPTION` surfaced *"Camera view (0s ago): \<stale\>"*. Added a `describePaused` flag (set when a describe was due but skipped); the provider now labels the prose *"reused (VLM paused under memory pressure); objects/people are current"*.

## Tests
Controller stays pure/injectable. **9/9** unit tests, including a regression test (constant 3 GB RSS → 0 describes skipped — the exact permanent-pause scenario) and escalation timing. Both consumers (`service.ts`, `provider.ts`) updated; `types.ts` gains the optional `describePaused` field (backward-compatible — the provider note is empty unless set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
