### PR TITLE
fix(release): mark third-party plugin-undesirables private (unblock NPM Release E403)

### DIFF
--- a/plugins/plugin-undesirables/package.json
+++ b/plugins/plugin-undesirables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "plugin-undesirables",
   "version": "2.0.3-beta.4",
+  "private": true,
   "description": "ElizaOS plugin — Personality-as-Code for AI agents. Live TCG market data from 370K+ products, passive market intelligence evaluator, 24 skills, 9 actions, and zero-config demo soul. NFT holders get unique Big Five psychology profiles. Oracle API integration for card grading, Monte Carlo simulations, and arbitrage scanning.",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Problem

The **NPM Release** workflow fails at `Publish to NPM` and ships **none** of the `@elizaos/*` packages:

```
lerna verb publish plugin-undesirables
lerna WARN notice Package failed to publish: plugin-undesirables
lerna ERR! E403 You do not have permission to publish "plugin-undesirables". Are you logged in as the correct user?
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
❌ Error: Failed to publish to NPM
```
(run [28188512842](https://github.com/elizaOS/eliza/actions/runs/28188512842))

## Root cause

`plugins/plugin-undesirables` is a **vendored third-party plugin** (BUSL-1.1, `author: The Undesirables LLC (sailorpepe)`, `repository: github.com/sailorpepe/plugin-undesirables`). Its package name is the **unscoped** `plugin-undesirables` — not `@elizaos/*` — and that name is owned on npm by `sailorpepe <kobumining@gmail.com>` (currently at `2.5.0`). `@elizaos/plugin-undesirables` does not exist.

`lerna publish from-package` enumerates the publish set via the `plugins/*` glob in `lerna.json`, so it tries to publish `plugin-undesirables` to a name our automation token has no rights to → **E403**, which aborts the whole release.

It is the only foreign-owned name in the publish set — `elizaos` (the CLI) is intentionally unscoped and org-owned, every other entry is `@elizaos/*`.

## Fix

Mark the package `"private": true`. Lerna excludes private packages from both `version` and `publish`, so the `@elizaos/*` release set is unblocked. The plugin:
- is **not** a workspace dependency of anything (verified),
- has **no** registry entry,
- is published by its own author from their repo,

so it should never have been in our publish set. It still builds/tests as part of the monorepo.

## Alternative considered

Removing the vendored plugin outright (it is the lone BUSL-1.1 / non-`@elizaos` tree under `plugins/`). Left as a maintainer decision — `private: true` is the minimal, reversible CI fix and keeps the plugin functional in the workspace.

## Evidence
- npm ownership: `npm view plugin-undesirables maintainers` → `sailorpepe <kobumining@gmail.com>`; `npm view @elizaos/plugin-undesirables` → E404.
- No `@elizaos/*` package depends on it; only `packages/scripts/e2e-coverage/keyless-e2e-baseline.json` lists the dir name (unaffected by `private`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)