### PR TITLE
fix(lifeops): green Client Tests — resolve unbuilt-plugin subpaths + sleep-recap baseline

### DIFF
--- a/plugins/plugin-personal-assistant/test/health-default-packs-runner.test.ts
+++ b/plugins/plugin-personal-assistant/test/health-default-packs-runner.test.ts
@@ -70,6 +70,11 @@ function makeRunner(gates: TaskGateRegistry): ScheduledTaskRunnerHandle {
     timezone: "UTC",
     morningWindow: { start: "07:00", end: "10:00" },
     eveningWindow: { start: "21:00", end: "23:30" },
+    // sleep-recap's `personal_baseline_sufficient` gate (minSamples: 5) denies
+    // with "sample count unavailable" unless the owner has a projected baseline;
+    // give the modelled owner a sufficient sample window so the pack reaches a
+    // real fire decision instead of skipping on missing baseline.
+    personalBaseline: { sampleCount: 14, windowDays: 30 },
   };
   const globalPause: GlobalPauseView = {
     current: async () => ({ active: false }),

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -349,8 +349,21 @@ export default defineConfig({
           "index.ts",
         ),
       },
-      // Further lifeops carves p-a imports as bare barrels (data-layer plugins not
-      // in build:core, no eliza-source condition) — anchor each to source too.
+      // Further lifeops carves p-a imports as bare barrels AND deep subpaths
+      // (data-layer plugins not in build:core, no eliza-source condition) — the
+      // package `exports` map only sends subpaths to ./src under the eliza-source
+      // condition, so without dist they resolve to missing ./dist/*.js. Anchor
+      // both the barrel and every subpath to source, same as plugin-blocker.
+      {
+        find: /^@elizaos\/plugin-finances\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-finances",
+          "src",
+          "$1.ts",
+        ),
+      },
       {
         find: /^@elizaos\/plugin-finances$/,
         replacement: path.join(
@@ -359,6 +372,16 @@ export default defineConfig({
           "plugin-finances",
           "src",
           "index.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-goals\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-goals",
+          "src",
+          "$1.ts",
         ),
       },
       {
@@ -508,6 +531,15 @@ export default defineConfig({
       {
         find: /^@elizaos\/plugin-elizacloud$/,
         replacement: path.join(lifeopsTestStubsRoot, "plugin-elizacloud.ts"),
+      },
+      {
+        // service-mixin-discord imports the browser-scraper helpers from the
+        // `/user-account-scraper` subpath; discord isn't in build:core so there
+        // is no dist, and the bare alias below only catches the barrel. Point the
+        // subpath at the same stub (it exports probeDiscordTab et al.) so the
+        // suite never pulls the real browser-automation module.
+        find: /^@elizaos\/plugin-discord\/user-account-scraper$/,
+        replacement: path.join(lifeopsTestStubsRoot, "plugin-discord.ts"),
       },
       {
         find: /^@elizaos\/plugin-discord$/,


### PR DESCRIPTION
## Problem

The **Tests → Client Tests** job has been red on develop. The entire `plugin-personal-assistant` suite failed to load:

```
Error: Cannot find package '@elizaos/plugin-finances/plugin' imported from .../src/plugin.ts
Error: Cannot find package '@elizaos/plugin-finances/finances-service'
Error: Cannot find package '@elizaos/plugin-goals/goals-service'
```
(run [28188511637](https://github.com/elizaOS/eliza/actions/runs/28188511637))

## Root cause — unbuilt-plugin subpath resolution

`test:client` runs **only** `build:core`, which does **not** build the data-layer carve plugins (`plugin-finances`, `plugin-goals`) or `plugin-discord`. Each package's `exports` map only routes subpaths to `./src` under the `eliza-source` condition, which this vitest config does **not** set — so it already aliases the **bare** specifier (to source for finances/goals, to a test stub for discord), but **deep subpath imports** fall through to the missing `./dist/*.js`:

| import | needed by |
|---|---|
| `@elizaos/plugin-finances/plugin`, `/finances-service`, … | `src/plugin.ts`, `src/actions/brief.ts` |
| `@elizaos/plugin-goals/goals-service`, `/plugin` | `src/lifeops/service-mixin-goals.ts` |
| `@elizaos/plugin-discord/user-account-scraper` | `src/lifeops/service-mixin-discord.ts` |

The finances/goals errors hit first and **masked** the discord one in CI.

## Fixes

1. **Subpath aliases** (`vitest.config.ts`) — anchor every subpath the same way the bare specifier already is: finances/goals → source (matching the existing plugin-blocker/-inbox/-health pattern), discord's `/user-account-scraper` → the existing discord stub (it already exports `probeDiscordTab` et al., so the suite never pulls the real browser-automation module).
2. **sleep-recap baseline** (`health-default-packs-runner.test.ts`) — once the suite loads, the #9600 test asserting sleep-recap reaches `fired` failed: its `makeRunner` never wired `personalBaseline`, so the `personal_baseline_sufficient` gate (minSamples 5) denied with "sample count unavailable" (the documented deny-until-available behavior) and the pack skipped. Model an owner with a sufficient baseline (`sampleCount: 14`).

## Verification

Reproduced the exact CI failures locally by shadowing the unbuilt plugin copies (no dist), confirmed each fix resolves them, and ran the full suite under that CI-faithful setup:

```
Test Files  98 passed (98)
     Tests  772 passed | 2 skipped (774)
```

The PR's own **Tests** run is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)