### PR TITLE
fix(lifeops): unbreak Plugin Tests — keep keyless data-layer graph off the plugin-health barrel

### DIFF
--- a/plugins/plugin-goals/vitest.config.ts
+++ b/plugins/plugin-goals/vitest.config.ts
@@ -38,6 +38,14 @@ export default defineConfig({
         ),
       },
       {
+        // PA's telemetry-mapping (pulled in via lifeops/repository.ts) reads the
+        // activity-signal reliability helper from this server-safe leaf module.
+        find: /^@elizaos\/plugin-health\/sleep\/source-reliability$/,
+        replacement: sourceOf(
+          "../plugin-health/src/sleep/source-reliability.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/plugin-browser\/schema$/,
         replacement: sourceOf("../plugin-browser/src/schema.ts"),
       },

--- a/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
@@ -9,7 +9,11 @@
  */
 
 import crypto from "node:crypto";
-import { resolveActivitySignalReliability } from "@elizaos/plugin-health";
+// Import the leaf module, not the `@elizaos/plugin-health` barrel: this file is
+// in the data-layer graph that `lifeops/repository.ts` pulls into the keyless
+// node test lane (goals.real-db), where the barrel (→ React views → @elizaos/ui)
+// must never enter and has no dist entry to resolve.
+import { resolveActivitySignalReliability } from "@elizaos/plugin-health/sleep/source-reliability";
 import type {
   LifeOpsActivitySignal,
   LifeOpsTelemetryEvent,

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -218,6 +218,16 @@ export default defineConfig({
         find: /^@elizaos\/tui$/,
         replacement: path.join(elizaRoot, "packages", "tui", "src", "index.ts"),
       },
+      {
+        find: /^@elizaos\/vault$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "vault",
+          "src",
+          "index.ts",
+        ),
+      },
       // These packages are imported by @elizaos/core while this suite inlines
       // core. Resolve them through Bun's real package-store path so their own
       // nested dependencies remain visible with preserveSymlinks enabled.


### PR DESCRIPTION
## Problem

The **Tests → Plugin Tests** job fails on `plugins/plugin-goals/test/goals.real-db.test.ts`:

```
Error: Failed to resolve entry for package "@elizaos/plugin-health".
  The package may have incorrect main/module/exports specified in its package.json.
```
(run [28188511637](https://github.com/elizaOS/eliza/actions/runs/28188511637))

## Root cause

`goals.real-db.test.ts` drives PA's `lifeops/repository.ts`, which is **deliberately barrel-free**: it imports plugin-health/-finances/-inbox **leaf subpaths** so the `@elizaos/plugin-health` barrel (which re-exports React views → `@elizaos/ui` → react-router) never enters the keyless node lane, and so the graph needs no `dist` entry (plugin-health is **not** in `build:core`).

But `repository.ts` pulls in `telemetry-mapping.ts`, which imported the **bare** `@elizaos/plugin-health` barrel — re-contaminating the graph. With no plugin-health `dist` in CI, vite can't resolve the barrel entry → the whole Plugin Tests job dies.

## Fix

- `telemetry-mapping.ts`: import `resolveActivitySignalReliability` from its server-safe leaf, `@elizaos/plugin-health/sleep/source-reliability` (only a type dep on `contracts/health`), instead of the barrel — restoring the barrel-free invariant the file's neighbours already keep.
- `plugin-goals/vitest.config.ts`: add the matching source alias for that leaf (PA's own config already has a generic plugin-health subpath alias).

## Verification

Reproduced the exact failure by shadowing an **unbuilt** plugin-health (no dist): bare barrel → `Failed to resolve entry`; with the fix → `goals.real-db 5/5 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)