### PR TITLE
fix(feed): point client Steward fallback at canonical eliza.steward.fi

### DIFF
--- a/packages/feed/apps/web/src/components/auth/LoginModal.tsx
+++ b/packages/feed/apps/web/src/components/auth/LoginModal.tsx
@@ -53,10 +53,14 @@ interface LoginModalProps {
 }
 
 function getStewardApiUrl(): string {
-  if (typeof window === "undefined") {
-    return process.env.NEXT_PUBLIC_STEWARD_API_URL ?? "http://localhost:3200";
+  const envUrl = process.env.NEXT_PUBLIC_STEWARD_API_URL;
+  if (envUrl) return envUrl;
+  // No build-time env: use the canonical Steward host in production,
+  // the local docker Steward (:3200) during development.
+  if (typeof window !== "undefined" && window.location.hostname !== "localhost") {
+    return "https://eliza.steward.fi";
   }
-  return process.env.NEXT_PUBLIC_STEWARD_API_URL ?? "http://localhost:3200";
+  return "http://localhost:3200";
 }
 
 const STEWARD_TENANT_ID = process.env.NEXT_PUBLIC_STEWARD_TENANT_ID ?? "feed";

--- a/packages/feed/apps/web/src/components/providers/StewardAuthProvider.tsx
+++ b/packages/feed/apps/web/src/components/providers/StewardAuthProvider.tsx
@@ -20,7 +20,7 @@ function getOrCreateStewardAuth(): StewardAuth {
   const baseUrl =
     process.env.NEXT_PUBLIC_STEWARD_API_URL ??
     (typeof window !== "undefined" && window.location.hostname !== "localhost"
-      ? "https://auth.elizacloud.ai"
+      ? "https://eliza.steward.fi"
       : "http://localhost:3200");
   _stewardAuthInstance = new StewardAuth({
     baseUrl,


### PR DESCRIPTION
## Problem

`feed.elizacloud.ai` Google login returned:
```
{"ok":false,"error":"Google OAuth not configured: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are required"}
```

There is only **one** Steward server (`eliza.steward.fi`, the `steward-api` Railway service — has Google creds). The feed app was never running a second Steward; the issue is that the **client** resolved the Steward base URL incorrectly when `NEXT_PUBLIC_STEWARD_API_URL` wasn't baked into the build:

- `StewardAuthProvider` fell back to `https://auth.elizacloud.ai` — that host is the **cloud-api Cloudflare worker** (`{"success":false,...,"resource_not_found"}`), not Steward.
- `LoginModal.getStewardApiUrl()` fell back to `http://localhost:3200` even in production, so browser-initiated OAuth never reached a real Steward.

## Change

Both client fallbacks now resolve to the canonical Steward host `https://eliza.steward.fi` on production hostnames, keeping the local docker Steward (`:3200`) for development. The primary fix is still baking `NEXT_PUBLIC_STEWARD_API_URL` into the deploy; this is defense-in-depth so a missing build env can't silently route auth at a non-Steward host.

## Evidence

Steward side verified live (after adding the `feed` tenant's redirect allowlist):
```
GET https://eliza.steward.fi/auth/oauth/google/authorize?tenant=feed&...&redirect_uri=https://feed.elizacloud.ai/auth/callback/google
→ 302 https://accounts.google.com/o/oauth2/v2/auth?client_id=721050741977-...&scope=openid+email+profile
```

## Notes / out of band (Railway, not in this diff)
- Added `feed` tenant `allowed_redirect_urls` in Steward for `feed.elizacloud.ai` + `feed-web-production.up.railway.app` callbacks (google/discord/twitter). The global `STEWARD_OAUTH_ALLOWED_REDIRECTS` is intentionally skipped when an explicit tenant id is sent, so per-tenant config is the only mechanism that applies to feed.
- `feed-web` must be rebuilt so `NEXT_PUBLIC_STEWARD_API_URL=https://eliza.steward.fi` is baked into the client bundle (the live build predates that env).