### PR TITLE
test(lifeops): stub optional core plugins in PA vitest

### DIFF
--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -46,10 +46,27 @@ const escapedAgentSourceRoot = agentSourceRoot.replace(
   /[.*+?^${}()|[\]\\]/g,
   "\\$&",
 );
+const optionalCorePluginStubPrefix = "\0lifeops-optional-core-plugin-stub:";
+const optionalCorePluginStubPackages = new Set([
+  "@elizaos/plugin-agent-orchestrator",
+  "@elizaos/plugin-task-coordinator",
+  "@elizaos/plugin-app-control",
+  "@elizaos/plugin-shell",
+  "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-commands",
+  "@elizaos/plugin-video",
+  "@elizaos/plugin-background-runner",
+  "@elizaos/plugin-ollama",
+  "@elizaos/plugin-anthropic",
+  "@elizaos/plugin-openai",
+]);
 const agentSourceJsToTsPlugin = {
   name: "lifeops-agent-source-js-to-ts",
   enforce: "pre" as const,
   resolveId(source: string, importer?: string) {
+    if (optionalCorePluginStubPackages.has(source)) {
+      return `${optionalCorePluginStubPrefix}${source}`;
+    }
     if (source === "@elizaos/agent") {
       return path.join(lifeopsTestStubsRoot, "agent.ts");
     }
@@ -76,6 +93,23 @@ const agentSourceJsToTsPlugin = {
     }
 
     return null;
+  },
+  load(id: string) {
+    if (!id.startsWith(optionalCorePluginStubPrefix)) return null;
+    const packageName = id.slice(optionalCorePluginStubPrefix.length);
+    const name = `${packageName.slice("@elizaos/".length)}-test-stub`;
+    return [
+      `const plugin = ${JSON.stringify({
+        name,
+        description: `Test stub for ${packageName}`,
+        actions: [],
+        providers: [],
+        evaluators: [],
+        services: [],
+      })};`,
+      "export { plugin };",
+      "export default plugin;",
+    ].join("\n");
   },
 };
 function resolveNodePackageRoot(packageName: string): string {


### PR DESCRIPTION
## Summary

- Stubs optional core plugin dynamic imports in the personal-assistant Vitest config so keyless prompt-benchmark runs do not require unrelated optional plugin dist entries.
- Keeps the stubs virtual and scoped to the PA test config; direct PA test stubs for google/elizacloud/discord remain unchanged.

## Verification

- `LIFEOPS_PROMPT_BENCHMARK_LIVE=0 LIFEOPS_PROMPT_BENCHMARK_CASE_LIMIT=15 bun run --cwd plugins/plugin-personal-assistant test -- test/lifeops-prompt-benchmark.test.ts`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/vitest.config.ts`

Follow-up to #9700 after its prompt-benchmark job revealed @elizaos/plugin-video as the next unbuilt optional package.