### PR TITLE
fix(plugins): real typecheck for 5 --noCheck-only plugins + fix latent wallet ReferenceError (#9474)

### DIFF
--- a/plugins/plugin-elizamaker/package.json
+++ b/plugins/plugin-elizamaker/package.json
@@ -55,7 +55,8 @@
     "build": "bun run build:js && bun run build:types",
     "clean": "rm -rf dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
-    "build:types": "tsc --noCheck -p tsconfig.build.json"
+    "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "files": [
     "dist"

--- a/plugins/plugin-steward-app/package.json
+++ b/plugins/plugin-steward-app/package.json
@@ -62,6 +62,7 @@
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "build:types": "tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "test:e2e:manual": "vitest run --config ../../vitest.config.ts test/*.real.e2e.test.ts test/*.live.e2e.test.ts"
   },
   "files": [

--- a/plugins/plugin-steward-app/src/api/wallet.env-sentinel.test.ts
+++ b/plugins/plugin-steward-app/src/api/wallet.env-sentinel.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getWalletAddresses, syncSolanaPublicKeyEnv } from "./wallet";
+
+/**
+ * Regression test for the `PLACEHOLDER_RE is not defined` bug.
+ *
+ * The sentinel regex was renamed to `ENV_SENTINEL_RE`, but three call sites in
+ * `wallet.ts` still referenced the old `PLACEHOLDER_RE` name. Because the
+ * package built with `tsc --noCheck`, the undefined identifier was never caught
+ * and every one of these wallet-key code paths threw `ReferenceError` at runtime
+ * whenever a non-empty key (or any private-key env var) was present.
+ *
+ * Each assertion below exercises one of the three previously-broken sites: it
+ * reaches the sentinel regex with a non-empty value and must return cleanly
+ * instead of throwing.
+ */
+describe("wallet env-sentinel handling (PLACEHOLDER_RE regression)", () => {
+  const SAVED = {
+    EVM_PRIVATE_KEY: process.env.EVM_PRIVATE_KEY,
+    SOLANA_PRIVATE_KEY: process.env.SOLANA_PRIVATE_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.EVM_PRIVATE_KEY;
+    delete process.env.SOLANA_PRIVATE_KEY;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(SAVED)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("syncSolanaPublicKeyEnv treats a sentinel value as unset (line 364 path)", () => {
+    // Non-empty sentinel reaches the regex test; must return null, not throw.
+    expect(() => syncSolanaPublicKeyEnv("REDACTED")).not.toThrow();
+    expect(syncSolanaPublicKeyEnv("REDACTED")).toBeNull();
+    expect(syncSolanaPublicKeyEnv("[PLACEHOLDER]")).toBeNull();
+    expect(syncSolanaPublicKeyEnv(undefined)).toBeNull();
+  });
+
+  it("getWalletAddresses skips sentinel private-key env vars (lines 586/597 path)", () => {
+    process.env.EVM_PRIVATE_KEY = "REDACTED";
+    process.env.SOLANA_PRIVATE_KEY = "CHANGEME";
+
+    // Before the fix this threw `ReferenceError: PLACEHOLDER_RE is not defined`
+    // the moment a non-empty private key was present.
+    expect(() => getWalletAddresses()).not.toThrow();
+
+    const addrs = getWalletAddresses();
+    // Sentinel keys are not real keys, so no address is derived from them.
+    expect(addrs.evmAddress).toBeNull();
+    expect(addrs.solanaAddress).toBeNull();
+  });
+});

--- a/plugins/plugin-steward-app/src/api/wallet.ts
+++ b/plugins/plugin-steward-app/src/api/wallet.ts
@@ -361,7 +361,7 @@ export function syncSolanaPublicKeyEnv(
   privateKey = process.env.SOLANA_PRIVATE_KEY,
 ): string | null {
   const trimmed = privateKey?.trim();
-  if (!trimmed || PLACEHOLDER_RE.test(trimmed)) {
+  if (!trimmed || ENV_SENTINEL_RE.test(trimmed)) {
     return null;
   }
 
@@ -583,7 +583,7 @@ export function getWalletAddresses(): WalletAddresses {
   // ── 2. Local private key derivation (fallback) ─────────────────────
   if (!evmAddress) {
     const evmKey = process.env.EVM_PRIVATE_KEY;
-    if (evmKey && !PLACEHOLDER_RE.test(evmKey)) {
+    if (evmKey && !ENV_SENTINEL_RE.test(evmKey)) {
       try {
         evmAddress = deriveEvmAddress(evmKey);
       } catch (e) {
@@ -594,7 +594,7 @@ export function getWalletAddresses(): WalletAddresses {
 
   if (!solanaAddress) {
     const solKey = process.env.SOLANA_PRIVATE_KEY;
-    if (solKey && !PLACEHOLDER_RE.test(solKey)) {
+    if (solKey && !ENV_SENTINEL_RE.test(solKey)) {
       try {
         solanaAddress = deriveSolanaAddress(solKey);
       } catch (e) {

--- a/plugins/plugin-waifu-imagegen-app/package.json
+++ b/plugins/plugin-waifu-imagegen-app/package.json
@@ -57,7 +57,8 @@
     "test": "vitest run --config vitest.config.ts",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
-    "build:types": "tsc --noCheck -p tsconfig.build.json"
+    "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "files": [
     "assets",

--- a/plugins/plugin-waifu-swap-app/package.json
+++ b/plugins/plugin-waifu-swap-app/package.json
@@ -57,7 +57,8 @@
     "test": "vitest run --config vitest.config.ts",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
-    "build:types": "tsc --noCheck -p tsconfig.build.json"
+    "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "files": [
     "assets",

--- a/plugins/plugin-wallet-ui/package.json
+++ b/plugins/plugin-wallet-ui/package.json
@@ -58,6 +58,7 @@
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "test": "bunx vitest run --config ./vitest.config.ts"
   },
   "files": [


### PR DESCRIPTION
Part of #9474 (Phase 3 — "every package has a real typecheck in CI; no `--noCheck`-only `verify`").

## What

Five plugins emitted declarations with `tsc --noCheck` and had **no `typecheck` script**, so their source was never type-checked anywhere in CI. Added a real `typecheck: "tsc --noEmit -p tsconfig.build.json"` to each (Turbo's generic `typecheck` task auto-discovers it, so they're now checked by root `bun run verify` and CI):

- `@elizaos/plugin-elizamaker`
- `@elizaos/plugin-waifu-imagegen-app`
- `@elizaos/plugin-waifu-swap-app`
- `@elizaos/plugin-wallet-ui`
- `@elizaos/plugin-steward-app`

## Real bug this caught

Turning the check on for **plugin-steward-app** surfaced a latent runtime bug `--noCheck` had been hiding. `src/api/wallet.ts` referenced an undefined `PLACEHOLDER_RE` at three sites — the sentinel regex had been renamed to `ENV_SENTINEL_RE` (line 225) but the call sites weren't updated:

- `syncSolanaPublicKeyEnv()` (line 364)
- `getWalletAddresses()` EVM key check (line 586)
- `getWalletAddresses()` Solana key check (line 597)

Every one of those wallet-key paths threw `ReferenceError: PLACEHOLDER_RE is not defined` at runtime the moment a non-empty private-key env var (or non-empty argument) was present. Fixed all three references to `ENV_SENTINEL_RE` (identical "skip sentinel/placeholder env value" semantics) and added a regression test.

## Evidence

- `tsc --noEmit -p tsconfig.build.json` for all 5 plugins → **0 errors** each.
- New `wallet.env-sentinel.test.ts` exercises all 3 fixed sites; **verified it fails on the pre-fix code** with `AssertionError: expected [Function] to not throw an error but 'ReferenceError: PLACEHOLDER_RE is not…' was thrown`, and passes after.
- `plugin-steward-app` full unit suite: **63/63 passing** (8 files).
- `biome check` clean on all changed files.
- Type-safety ratchet unchanged (no new casts): `asUnknownAs 143/143, asAny 0/0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)