### PR TITLE
fix(plugins): wire real typecheck for plugin-documents + plugin-vincent (#9474)

### DIFF
--- a/plugins/plugin-documents/package.json
+++ b/plugins/plugin-documents/package.json
@@ -63,6 +63,7 @@
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run --config ./vitest.config.ts",
     "test:e2e:manual": "vitest run --config ../../vitest.config.ts test/*.live.e2e.test.ts"
   },

--- a/plugins/plugin-documents/tsconfig.build.json
+++ b/plugins/plugin-documents/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.build.shared.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node", "react", "react-dom"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]

--- a/plugins/plugin-vincent/package.json
+++ b/plugins/plugin-vincent/package.json
@@ -56,6 +56,7 @@
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "test:e2e:manual": "vitest run --config ../../vitest.config.ts test/*.real.e2e.test.ts"
   },
   "files": [

--- a/plugins/plugin-vincent/tsconfig.build.json
+++ b/plugins/plugin-vincent/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.build.shared.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node", "react", "react-dom"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]


### PR DESCRIPTION
Part of #9474 (Phase 3 — "every package has a real typecheck in CI; no `--noCheck`-only `verify`"). Follow-up to #9705.

## What
`plugin-documents` and `plugin-vincent` emitted declarations with `tsc --noCheck` and had **no `typecheck` script** — their source was never type-checked. Both import `@elizaos/agent` subpath declarations (`@elizaos/agent/api/documents-service-loader`, `@elizaos/agent/config/config`) that reference node/react ambient globals, so a bare check couldn't resolve them. Declaring the ambient type set explicitly — `"types": ["node", "react", "react-dom"]`, matching the existing `plugin-shopify-ui` convention — resolves them, then wired `typecheck: "tsc --noEmit -p tsconfig.build.json"`.

## Evidence
- Both typecheck **0 errors**.
- Declaration **emit unchanged**: `tsc --noCheck` still produces `.d.ts` (10 files documents, 22 vincent), 0 errors — `types` restriction does not regress the build output.
- Unit tests green: `plugin-documents` 41/41, `plugin-vincent` 32/32.
- `biome check` clean on all 4 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)