### PR TITLE
fix(training): replace Qwen capacity planner with Gemma

### DIFF
--- a/packages/training/scripts/kokoro/coreml/diag_stages.py
+++ b/packages/training/scripts/kokoro/coreml/diag_stages.py
@@ -17,7 +17,6 @@ OUT = Path("/tmp/kokoro-coreml-work/out")
 BUCKET = 160
 
 def reg_ops():
-    import coremltools as ct
     from coremltools.converters.mil.frontend.torch.ops import _get_inputs, logical_and as _la  # noqa
     from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op, _TORCH_OPS_REGISTRY
     from coremltools.converters.mil import Builder as mb

--- a/packages/training/scripts/rl/gemma_capacity.py
+++ b/packages/training/scripts/rl/gemma_capacity.py
@@ -9,9 +9,9 @@ BYTES_PER_GIB = 1024**3
 BF16_BITS = 16.0
 FP32_BITS = 32.0
 NF4_BITS = 4.0
-DEFAULT_FULL_ATTENTION_PERIOD = 4
 DEFAULT_ACTIVATION_MULTIPLIER_CHECKPOINTED = 6.0
 DEFAULT_ACTIVATION_MULTIPLIER_UNCHECKPOINTED = 12.0
+DEFAULT_GEMMA_VOCAB_SIZE = 262_144
 
 
 def _gib(num_bytes: float) -> float:
@@ -31,160 +31,176 @@ class NebiusVmShape:
 
 
 @dataclass(frozen=True)
-class QwenModelSpec:
+class GemmaModelSpec:
     key: str
     slug: str
     display_name: str
     model_id: str
+    eliza_tier: str
     total_params: int
-    active_params: int
     hidden_size: int
     num_hidden_layers: int
+    full_attention_layers: int
+    sliding_attention_layers: int
+    sliding_window: int
     num_attention_heads: int
     num_key_value_heads: int
+    num_global_key_value_heads: int | None
+    num_kv_shared_layers: int
     head_dim: int
+    global_head_dim: int
     max_context_tokens: int
+    train_mem_gb_budget: float
+    default_apollo_rank: int
     intermediate_size: int | None = None
-    moe_intermediate_size: int | None = None
-    shared_expert_intermediate_size: int | None = None
-    num_experts: int | None = None
-    num_experts_per_tok: int | None = None
-    full_attention_period: int = DEFAULT_FULL_ATTENTION_PERIOD
-    text_only_ready: bool = False
+    vocab_size: int = DEFAULT_GEMMA_VOCAB_SIZE
+    text_only_ready: bool = True
     notes: str = ""
 
     @property
-    def is_moe(self) -> bool:
-        return self.active_params < self.total_params
+    def effective_sliding_kv_layers(self) -> int:
+        return max(0, self.sliding_attention_layers - self.num_kv_shared_layers)
 
     @property
-    def full_attention_layers(self) -> int:
-        return max(1, self.num_hidden_layers // self.full_attention_period)
-
-    @property
-    def linear_attention_layers(self) -> int:
-        return max(0, self.num_hidden_layers - self.full_attention_layers)
-
-    @property
-    def dense_ratio(self) -> float:
-        return self.active_params / self.total_params
+    def effective_kv_layers(self) -> int:
+        return self.full_attention_layers + self.effective_sliding_kv_layers
 
 
-QWEN_MODEL_SPECS: tuple[QwenModelSpec, ...] = (
-    QwenModelSpec(
-        key="qwen35_4b",
-        slug="qwen35-4b",
-        display_name="Qwen 3.5 4B",
-        model_id="Qwen/Qwen3.5-4B",
-        total_params=4_000_000_000,
-        active_params=4_000_000_000,
+GEMMA_MODEL_SPECS: tuple[GemmaModelSpec, ...] = (
+    GemmaModelSpec(
+        key="gemma4_e2b",
+        slug="gemma4-e2b",
+        display_name="Gemma 4 E2B",
+        model_id="google/gemma-4-E2B",
+        eliza_tier="eliza-1-2b",
+        total_params=2_300_000_000,
+        hidden_size=1536,
+        intermediate_size=6144,
+        num_hidden_layers=35,
+        full_attention_layers=7,
+        sliding_attention_layers=28,
+        sliding_window=512,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        num_global_key_value_heads=None,
+        num_kv_shared_layers=20,
+        head_dim=256,
+        global_head_dim=512,
+        max_context_tokens=131_072,
+        train_mem_gb_budget=15.5,
+        default_apollo_rank=1,
+        notes=(
+            "Entry local tier. HF config: 35 layers, 7 full-attention layers, "
+            "512-token sliding window, shared KV."
+        ),
+    ),
+    GemmaModelSpec(
+        key="gemma4_e4b",
+        slug="gemma4-e4b",
+        display_name="Gemma 4 E4B",
+        model_id="google/gemma-4-E4B",
+        eliza_tier="eliza-1-4b",
+        total_params=4_500_000_000,
         hidden_size=2560,
-        intermediate_size=9216,
-        num_hidden_layers=32,
-        num_attention_heads=16,
-        num_key_value_heads=4,
-        head_dim=256,
-        max_context_tokens=262_144,
-        text_only_ready=False,
-        notes="Official checkpoint is Qwen 3.5 multimodal/hybrid; text-only fallback should be verified separately.",
-    ),
-    QwenModelSpec(
-        key="qwen35_9b",
-        slug="qwen35-9b",
-        display_name="Qwen 3.5 9B",
-        model_id="Qwen/Qwen3.5-9B",
-        total_params=9_000_000_000,
-        active_params=9_000_000_000,
-        hidden_size=4096,
-        intermediate_size=12288,
-        num_hidden_layers=32,
-        num_attention_heads=16,
-        num_key_value_heads=4,
-        head_dim=256,
-        max_context_tokens=262_144,
-        text_only_ready=False,
-        notes="Official checkpoint is Qwen 3.5 multimodal/hybrid; text-only fallback should be verified separately.",
-    ),
-    QwenModelSpec(
-        key="qwen35_27b",
-        slug="qwen35-27b",
-        display_name="Qwen 3.5 27B",
-        model_id="Qwen/Qwen3.5-27B",
-        total_params=27_000_000_000,
-        active_params=27_000_000_000,
-        hidden_size=5120,
-        intermediate_size=17408,
-        num_hidden_layers=64,
-        num_attention_heads=24,
-        num_key_value_heads=4,
-        head_dim=256,
-        max_context_tokens=262_144,
-        text_only_ready=False,
-        notes="Large dense Qwen 3.5 medium checkpoint.",
-    ),
-    QwenModelSpec(
-        key="qwen35_35b_a3b",
-        slug="qwen35-35b-a3b",
-        display_name="Qwen 3.5 35B-A3B",
-        model_id="Qwen/Qwen3.5-35B-A3B",
-        total_params=35_000_000_000,
-        active_params=3_000_000_000,
-        hidden_size=2048,
-        num_hidden_layers=40,
-        num_attention_heads=16,
+        intermediate_size=10240,
+        num_hidden_layers=42,
+        full_attention_layers=7,
+        sliding_attention_layers=35,
+        sliding_window=512,
+        num_attention_heads=8,
         num_key_value_heads=2,
+        num_global_key_value_heads=None,
+        num_kv_shared_layers=18,
         head_dim=256,
-        max_context_tokens=262_144,
-        moe_intermediate_size=512,
-        shared_expert_intermediate_size=512,
-        num_experts=256,
-        num_experts_per_tok=8,
-        text_only_ready=False,
-        notes="Sparse MoE checkpoint; active-parameter and total-parameter planning differ materially.",
+        global_head_dim=512,
+        max_context_tokens=131_072,
+        train_mem_gb_budget=28.0,
+        default_apollo_rank=1,
+        notes=(
+            "Local tier. HF config: 42 layers, 7 full-attention layers, "
+            "512-token sliding window, shared KV."
+        ),
     ),
-    QwenModelSpec(
-        key="qwen35_122b_a10b",
-        slug="qwen35-122b-a10b",
-        display_name="Qwen 3.5 122B-A10B",
-        model_id="Qwen/Qwen3.5-122B-A10B",
-        total_params=122_000_000_000,
-        active_params=10_000_000_000,
-        hidden_size=3072,
+    GemmaModelSpec(
+        key="gemma4_12b",
+        slug="gemma4-12b",
+        display_name="Gemma 4 12B",
+        model_id="google/gemma-4-12B",
+        eliza_tier="eliza-1-9b",
+        total_params=12_000_000_000,
+        hidden_size=3840,
+        intermediate_size=15360,
         num_hidden_layers=48,
-        num_attention_heads=32,
-        num_key_value_heads=2,
+        full_attention_layers=8,
+        sliding_attention_layers=40,
+        sliding_window=1024,
+        num_attention_heads=16,
+        num_key_value_heads=8,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=0,
         head_dim=256,
+        global_head_dim=512,
         max_context_tokens=262_144,
-        moe_intermediate_size=1024,
-        shared_expert_intermediate_size=1024,
-        num_experts=256,
-        num_experts_per_tok=8,
-        text_only_ready=False,
-        notes="Sparse MoE checkpoint; 122B planning should be treated as cluster-first.",
+        train_mem_gb_budget=80.0,
+        default_apollo_rank=512,
+        notes=(
+            "Workstation tier. HF config: unified dense model with 256k context "
+            "and 1024-token sliding window."
+        ),
+    ),
+    GemmaModelSpec(
+        key="gemma4_31b",
+        slug="gemma4-31b",
+        display_name="Gemma 4 31B",
+        model_id="google/gemma-4-31B",
+        eliza_tier="eliza-1-27b",
+        total_params=31_000_000_000,
+        hidden_size=5376,
+        intermediate_size=21504,
+        num_hidden_layers=60,
+        full_attention_layers=10,
+        sliding_attention_layers=50,
+        sliding_window=1024,
+        num_attention_heads=32,
+        num_key_value_heads=16,
+        num_global_key_value_heads=4,
+        num_kv_shared_layers=0,
+        head_dim=256,
+        global_head_dim=512,
+        max_context_tokens=262_144,
+        train_mem_gb_budget=210.0,
+        default_apollo_rank=512,
+        notes=(
+            "Cloud tier for the eliza-1-27b release family. HF config: "
+            "60 layers, 10 full-attention layers."
+        ),
     ),
 )
 
 
-MODEL_BY_KEY = {spec.key: spec for spec in QWEN_MODEL_SPECS}
-MODEL_BY_ID = {spec.model_id.lower(): spec for spec in QWEN_MODEL_SPECS}
+MODEL_BY_KEY = {spec.key: spec for spec in GEMMA_MODEL_SPECS}
+MODEL_BY_ID = {spec.model_id.lower(): spec for spec in GEMMA_MODEL_SPECS}
 MODEL_ALIASES = {
-    "4b": "qwen35_4b",
-    "9b": "qwen35_9b",
-    "27b": "qwen35_27b",
-    "35b": "qwen35_35b_a3b",
-    "35b-a3b": "qwen35_35b_a3b",
-    "122b": "qwen35_122b_a10b",
-    "122b-a10b": "qwen35_122b_a10b",
-    "qwen35-4b": "qwen35_4b",
-    "qwen35-9b": "qwen35_9b",
-    "qwen35-27b": "qwen35_27b",
-    "qwen35-35b-a3b": "qwen35_35b_a3b",
-    "qwen35-122b-a10b": "qwen35_122b_a10b",
-    "qwen/qwen3.5-4b": "qwen35_4b",
-    "qwen/qwen3.5-9b": "qwen35_9b",
-    "qwen/qwen3.5-27b": "qwen35_27b",
-    "qwen/qwen3.5-35b-a3b": "qwen35_35b_a3b",
-    "qwen/qwen3.5-122b-a10b": "qwen35_122b_a10b",
+    "2b": "gemma4_e2b",
+    "e2b": "gemma4_e2b",
+    "gemma4-e2b": "gemma4_e2b",
+    "eliza-1-2b": "gemma4_e2b",
+    "google/gemma-4-e2b": "gemma4_e2b",
+    "4b": "gemma4_e4b",
+    "e4b": "gemma4_e4b",
+    "gemma4-e4b": "gemma4_e4b",
+    "eliza-1-4b": "gemma4_e4b",
+    "google/gemma-4-e4b": "gemma4_e4b",
+    "9b": "gemma4_12b",
+    "12b": "gemma4_12b",
+    "gemma4-12b": "gemma4_12b",
+    "eliza-1-9b": "gemma4_12b",
+    "google/gemma-4-12b": "gemma4_12b",
+    "27b": "gemma4_31b",
+    "31b": "gemma4_31b",
+    "gemma4-31b": "gemma4_31b",
+    "eliza-1-27b": "gemma4_31b",
+    "google/gemma-4-31b": "gemma4_31b",
 }
 
 
@@ -221,7 +237,7 @@ def slugify_model_name(model_name: str) -> str:
     return normalized
 
 
-def resolve_model_spec(value: str) -> QwenModelSpec | None:
+def resolve_model_spec(value: str) -> GemmaModelSpec | None:
     normalized = normalize_model_lookup_key(value)
     if normalized in MODEL_ALIASES:
         return MODEL_BY_KEY[MODEL_ALIASES[normalized]]
@@ -236,78 +252,44 @@ def parse_context_length(value: str) -> int:
     return int(cleaned)
 
 
-def estimate_embedding_params(spec: QwenModelSpec) -> int:
-    vocab_params = 248_320 * spec.hidden_size
-    if spec.is_moe:
-        return vocab_params
+def estimate_embedding_params(spec: GemmaModelSpec) -> int:
+    vocab_params = spec.vocab_size * spec.hidden_size
     return vocab_params * 2
 
 
-def estimate_core_linear_params(spec: QwenModelSpec) -> int:
+def estimate_core_linear_params(spec: GemmaModelSpec) -> int:
     h = spec.hidden_size
     layers = spec.num_hidden_layers
     attention_params = layers * (4 * h * h)
-    if spec.is_moe:
-        moe_i = spec.moe_intermediate_size or 0
-        shared_i = spec.shared_expert_intermediate_size or 0
-        experts = spec.num_experts or 0
-        expert_params = layers * experts * (3 * h * moe_i)
-        shared_params = layers * (3 * h * shared_i)
-        router_params = layers * (h * experts)
-        return (
-            attention_params
-            + expert_params
-            + shared_params
-            + router_params
-            + estimate_embedding_params(spec)
-        )
     dense_i = spec.intermediate_size or 0
     mlp_params = layers * (3 * h * dense_i)
     return attention_params + mlp_params + estimate_embedding_params(spec)
 
 
-def model_overhead_factor(spec: QwenModelSpec) -> float:
+def model_overhead_factor(spec: GemmaModelSpec) -> float:
     estimated = estimate_core_linear_params(spec)
     if estimated <= 0:
         return 1.0
     return spec.total_params / estimated
 
 
-def estimate_lora_trainable_params(spec: QwenModelSpec, rank: int) -> int:
+def estimate_lora_trainable_params(spec: GemmaModelSpec, rank: int) -> int:
     h = spec.hidden_size
     layers = spec.num_hidden_layers
     attention = layers * (4 * rank * (h + h))
-    if spec.is_moe:
-        experts = spec.num_experts or 0
-        moe_i = spec.moe_intermediate_size or 0
-        shared_i = spec.shared_expert_intermediate_size or 0
-        expert = layers * experts * (3 * rank * (h + moe_i))
-        shared = layers * (3 * rank * (h + shared_i))
-        router = layers * rank * (h + experts)
-        raw = attention + expert + shared + router
-    else:
-        dense_i = spec.intermediate_size or 0
-        mlp = layers * (3 * rank * (h + dense_i))
-        raw = attention + mlp
+    dense_i = spec.intermediate_size or 0
+    mlp = layers * (3 * rank * (h + dense_i))
+    raw = attention + mlp
     return math.ceil(raw * model_overhead_factor(spec))
 
 
-def estimate_apollo_optimizer_state_bytes(spec: QwenModelSpec, rank: int) -> float:
+def estimate_apollo_optimizer_state_bytes(spec: GemmaModelSpec, rank: int) -> float:
     h = spec.hidden_size
     layers = spec.num_hidden_layers
     attention = layers * (4 * 8 * rank * (h + h))
-    if spec.is_moe:
-        experts = spec.num_experts or 0
-        moe_i = spec.moe_intermediate_size or 0
-        shared_i = spec.shared_expert_intermediate_size or 0
-        expert = layers * experts * (3 * 8 * rank * (h + moe_i))
-        shared = layers * (3 * 8 * rank * (h + shared_i))
-        router = layers * (8 * rank * (h + experts))
-        raw_bytes = attention + expert + shared + router
-    else:
-        dense_i = spec.intermediate_size or 0
-        mlp = layers * (3 * 8 * rank * (h + dense_i))
-        raw_bytes = attention + mlp
+    dense_i = spec.intermediate_size or 0
+    mlp = layers * (3 * 8 * rank * (h + dense_i))
+    raw_bytes = attention + mlp
     return raw_bytes * model_overhead_factor(spec)
 
 
@@ -319,7 +301,7 @@ def estimate_adamw_state_bytes(trainable_params: int, *, include_master_weights:
 
 
 def estimate_training_activation_bytes(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     sequence_length: int,
     micro_batch_size: int,
@@ -342,39 +324,47 @@ def estimate_training_activation_bytes(
 
 
 def estimate_kv_cache_bytes(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     context_tokens: int,
     batch_size: int,
     kv_bits: float = BF16_BITS,
 ) -> float:
-    return (
+    full_heads = spec.num_global_key_value_heads or spec.num_key_value_heads
+    full_bytes = (
         batch_size
         * context_tokens
         * spec.full_attention_layers
+        * full_heads
+        * spec.global_head_dim
+        * 2
+        * _bits_to_bytes(kv_bits)
+    )
+    sliding_tokens = min(context_tokens, spec.sliding_window)
+    sliding_bytes = (
+        batch_size
+        * sliding_tokens
+        * spec.effective_sliding_kv_layers
         * spec.num_key_value_heads
         * spec.head_dim
         * 2
         * _bits_to_bytes(kv_bits)
     )
+    return full_bytes + sliding_bytes
 
 
 def estimate_full_training_memory(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     optimizer: Literal["adamw", "apollo"],
     sequence_length: int,
     micro_batch_size: int,
     checkpointed: bool,
-    sparse_policy: Literal["total", "active"],
     apollo_rank: int,
     weight_bits: float = BF16_BITS,
     gradient_bits: float = BF16_BITS,
 ) -> dict[str, float]:
-    trainable_params = (
-        spec.total_params if sparse_policy == "total" or not spec.is_moe else spec.active_params
-    )
-    scaling = trainable_params / spec.total_params
+    trainable_params = spec.total_params
     weights_bytes = spec.total_params * _bits_to_bytes(weight_bits)
     gradients_bytes = trainable_params * _bits_to_bytes(gradient_bits)
     master_weights_bytes = trainable_params * _bits_to_bytes(FP32_BITS)
@@ -384,7 +374,7 @@ def estimate_full_training_memory(
             include_master_weights=False,
         )
     else:
-        optimizer_bytes = estimate_apollo_optimizer_state_bytes(spec, apollo_rank) * scaling
+        optimizer_bytes = estimate_apollo_optimizer_state_bytes(spec, apollo_rank)
     activation_bytes = estimate_training_activation_bytes(
         spec,
         sequence_length=sequence_length,
@@ -405,7 +395,7 @@ def estimate_full_training_memory(
 
 
 def estimate_adapter_memory(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     sequence_length: int,
     micro_batch_size: int,
@@ -450,7 +440,7 @@ def estimate_adapter_memory(
 
 
 def estimate_lora_memory(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     sequence_length: int,
     micro_batch_size: int,
@@ -469,7 +459,7 @@ def estimate_lora_memory(
 
 
 def estimate_qlora_memory(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     sequence_length: int,
     micro_batch_size: int,
@@ -490,18 +480,13 @@ def estimate_qlora_memory(
 
 
 def estimate_chinchilla_budget(
-    spec: QwenModelSpec,
-    *,
-    policy: Literal["total", "active"],
+    spec: GemmaModelSpec,
 ) -> dict[str, int]:
-    effective_params = (
-        spec.total_params if policy == "total" or not spec.is_moe else spec.active_params
-    )
-    tokens = effective_params * 20
-    flops_per_token = 6 * effective_params
+    tokens = spec.total_params * 20
+    flops_per_token = 6 * spec.total_params
     total_flops = flops_per_token * tokens
     return {
-        "effective_params": effective_params,
+        "effective_params": spec.total_params,
         "tokens": tokens,
         "flops_per_token": flops_per_token,
         "total_training_flops": total_flops,
@@ -509,7 +494,7 @@ def estimate_chinchilla_budget(
 
 
 def recommend_nebius_vm_shape(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     gpu: Literal["h100", "h200"],
     sequence_length: int = 8192,
@@ -523,7 +508,6 @@ def recommend_nebius_vm_shape(
         sequence_length=sequence_length,
         micro_batch_size=micro_batch_size,
         checkpointed=True,
-        sparse_policy="active" if spec.is_moe else "total",
         apollo_rank=apollo_rank,
     )
     if estimate["total_gib"] <= shape.gpu_memory_gib * 0.92:
@@ -532,14 +516,14 @@ def recommend_nebius_vm_shape(
 
 
 def build_capacity_report(
-    spec: QwenModelSpec,
+    spec: GemmaModelSpec,
     *,
     contexts: list[int],
     training_sequence_length: int,
     micro_batch_size: int,
     apollo_rank: int,
     lora_rank: int,
-    turboquant_bits: float,
+    kv_bits: float,
 ) -> dict[str, Any]:
     adamw_total = estimate_full_training_memory(
         spec,
@@ -547,7 +531,6 @@ def build_capacity_report(
         sequence_length=training_sequence_length,
         micro_batch_size=micro_batch_size,
         checkpointed=True,
-        sparse_policy="total",
         apollo_rank=apollo_rank,
     )
     apollo_total = estimate_full_training_memory(
@@ -556,20 +539,8 @@ def build_capacity_report(
         sequence_length=training_sequence_length,
         micro_batch_size=micro_batch_size,
         checkpointed=True,
-        sparse_policy="total",
         apollo_rank=apollo_rank,
     )
-    apollo_active = None
-    if spec.is_moe:
-        apollo_active = estimate_full_training_memory(
-            spec,
-            optimizer="apollo",
-            sequence_length=training_sequence_length,
-            micro_batch_size=micro_batch_size,
-            checkpointed=True,
-            sparse_policy="active",
-            apollo_rank=apollo_rank,
-        )
 
     lora_bf16 = estimate_lora_memory(
         spec,
@@ -594,20 +565,25 @@ def build_capacity_report(
             batch_size=1,
             kv_bits=BF16_BITS,
         )
-        kv_turbo = estimate_kv_cache_bytes(
+        kv_planned = estimate_kv_cache_bytes(
             spec,
             context_tokens=context,
             batch_size=1,
-            kv_bits=turboquant_bits,
+            kv_bits=kv_bits,
         )
         context_reports.append(
             {
                 "context_tokens": context,
                 "full_attention_layers": spec.full_attention_layers,
+                "sliding_attention_layers": spec.sliding_attention_layers,
+                "effective_sliding_kv_layers": spec.effective_sliding_kv_layers,
+                "sliding_window": spec.sliding_window,
                 "kv_cache_bf16_gib": _gib(kv_bf16),
-                "kv_cache_turboquant_gib": _gib(kv_turbo),
-                "turboquant_bits": turboquant_bits,
-                "compression_ratio_vs_bf16": round(kv_bf16 / kv_turbo, 3) if kv_turbo else None,
+                "kv_cache_planned_gib": _gib(kv_planned),
+                "kv_bits": kv_bits,
+                "compression_ratio_vs_bf16": round(kv_bf16 / kv_planned, 3)
+                if kv_planned
+                else None,
             }
         )
 
@@ -636,9 +612,14 @@ def build_capacity_report(
         "model": asdict(spec),
         "notes": {
             "apollo": "APOLLO figures estimate trainer optimizer-state memory for CUDA full-parameter fine-tuning.",
-            "turboquant": "TurboQuant figures estimate inference-side KV-cache compression and are available in the Transformers generation path; they are not a trainer-side optimization.",
+            "kv": (
+                "Gemma KV estimates include full-attention context plus the "
+                "sliding-window cache. GGUF weight quantization and MTP drafting "
+                "are release artifacts; QJL/Polar/TurboQuant sidecars are not "
+                "required Gemma release gates."
+            ),
         },
-        "chinchilla_total": estimate_chinchilla_budget(spec, policy="total"),
+        "chinchilla_total": estimate_chinchilla_budget(spec),
         "training_memory": {
             "adamw_total_gib": adamw_total,
             "apollo_total_gib": apollo_total,
@@ -656,9 +637,4 @@ def build_capacity_report(
             "recommended_nebius_vm": "h100" if h100_fit else ("h200" if h200_fit else None),
         },
     }
-    if apollo_active is not None:
-        report["chinchilla_active"] = estimate_chinchilla_budget(spec, policy="active")
-        report["training_memory"]["apollo_active_gib"] = apollo_active
-        report["single_gpu_fit"]["h100_apollo_active"] = apollo_active["total_gib"] <= 80.0 * 0.92
-        report["single_gpu_fit"]["h200_apollo_active"] = apollo_active["total_gib"] <= 141.0 * 0.92
     return report

--- a/packages/training/scripts/rl/plan_gemma_training.py
+++ b/packages/training/scripts/rl/plan_gemma_training.py
@@ -6,10 +6,10 @@ import json
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "training"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from qwen_capacity import (
-    QWEN_MODEL_SPECS,
+from gemma_capacity import (
+    GEMMA_MODEL_SPECS,
     build_capacity_report,
     parse_context_length,
     resolve_model_spec,
@@ -18,13 +18,16 @@ from qwen_capacity import (
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Compute Qwen scaling-law, memory, and Nebius capacity plans.",
+        description="Compute Gemma scaling-law, memory, and Nebius capacity plans.",
     )
     parser.add_argument(
         "--model",
         action="append",
         dest="models",
-        help="Model id or alias. Repeat to plan multiple models. Defaults to all canonical Qwen 3.5 targets.",
+        help=(
+            "Model id or alias. Repeat to plan multiple models. Defaults to all "
+            "canonical Gemma 4 text targets."
+        ),
     )
     parser.add_argument(
         "--contexts",
@@ -46,8 +49,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--apollo-rank",
         type=int,
-        default=64,
-        help="APOLLO rank used for optimizer-state estimates.",
+        default=None,
+        help=(
+            "APOLLO rank used for optimizer-state estimates. Defaults to the "
+            "Gemma tier registry value."
+        ),
     )
     parser.add_argument(
         "--lora-rank",
@@ -56,10 +62,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="LoRA rank used for QLoRA adapter-memory estimates.",
     )
     parser.add_argument(
-        "--turboquant-bits",
+        "--kv-bits",
         type=float,
-        default=4.0,
-        help="Effective KV-cache precision used for TurboQuant planning.",
+        default=16.0,
+        help="Effective KV-cache precision used for Gemma KV planning.",
     )
     parser.add_argument(
         "--format",
@@ -72,10 +78,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 def render_markdown(reports: list[dict[str, object]]) -> str:
     lines = [
-        "# Qwen Capacity Plan",
+        "# Gemma Capacity Plan",
         "",
-        "| Model | AdamW total | APOLLO total | APOLLO active | QLoRA NF4 | H100 APOLLO | H200 APOLLO |",
-        "|---|---:|---:|---:|---:|---|---|",
+        "| Model | Eliza tier | AdamW total | APOLLO total | QLoRA NF4 | H100 APOLLO | H200 APOLLO |",
+        "|---|---|---:|---:|---:|---|---|",
     ]
     for report in reports:
         model = report["model"]
@@ -84,19 +90,17 @@ def render_markdown(reports: list[dict[str, object]]) -> str:
         lines.append(
             "| "
             f"{model['display_name']} | "
+            f"{model['eliza_tier']} | "
             f"{training['adamw_total_gib']['total_gib']:.3f} GiB | "
             f"{training['apollo_total_gib']['total_gib']:.3f} GiB | "
-            f"{training.get('apollo_active_gib', {}).get('total_gib', '-')} | "
             f"{training['qlora_nf4_gib']['total_gib']:.3f} GiB | "
-            f"{fit.get('h100_apollo_active', fit['h100_apollo_total'])} | "
-            f"{fit.get('h200_apollo_active', fit['h200_apollo_total'])} |"
+            f"{fit['h100_apollo_total']} | "
+            f"{fit['h200_apollo_total']} |"
         )
         lines.append("")
         lines.append("## " + model["display_name"])
         lines.append("")
         lines.append(f"- Chinchilla total tokens: `{report['chinchilla_total']['tokens']:,}`")
-        if "chinchilla_active" in report:
-            lines.append(f"- Chinchilla active tokens: `{report['chinchilla_active']['tokens']:,}`")
         lines.append(
             f"- Adapter memory: LoRA bf16 `{training['lora_bf16_gib']['total_gib']:.3f} GiB`, "
             f"QLoRA NF4 `{training['qlora_nf4_gib']['total_gib']:.3f} GiB`"
@@ -105,8 +109,10 @@ def render_markdown(reports: list[dict[str, object]]) -> str:
             lines.append(
                 f"- Context `{context['context_tokens']:,}`: "
                 f"KV bf16 `{context['kv_cache_bf16_gib']:.3f} GiB`, "
-                f"TurboQuant `{context['kv_cache_turboquant_gib']:.3f} GiB` "
-                f"at {context['turboquant_bits']}-bit"
+                f"planned `{context['kv_cache_planned_gib']:.3f} GiB` "
+                f"at {context['kv_bits']}-bit; full layers "
+                f"`{context['full_attention_layers']}`, effective sliding KV layers "
+                f"`{context['effective_sliding_kv_layers']}`"
             )
         lines.append("")
     return "\n".join(lines)
@@ -122,23 +128,29 @@ def main() -> None:
         for value in args.models:
             spec = resolve_model_spec(value)
             if spec is None:
-                raise ValueError(f"Unknown Qwen model alias or id: {value}")
+                raise ValueError(f"Unknown Gemma model alias or id: {value}")
             specs.append(spec)
     else:
-        specs = list(QWEN_MODEL_SPECS)
+        specs = list(GEMMA_MODEL_SPECS)
 
-    reports = [
-        build_capacity_report(
-            spec,
-            contexts=contexts,
-            training_sequence_length=args.training_seq_length,
-            micro_batch_size=args.micro_batch_size,
-            apollo_rank=args.apollo_rank,
-            lora_rank=args.lora_rank,
-            turboquant_bits=args.turboquant_bits,
+    reports = []
+    for spec in specs:
+        apollo_rank = (
+            args.apollo_rank
+            if args.apollo_rank is not None
+            else spec.default_apollo_rank
         )
-        for spec in specs
-    ]
+        reports.append(
+            build_capacity_report(
+                spec,
+                contexts=contexts,
+                training_sequence_length=args.training_seq_length,
+                micro_batch_size=args.micro_batch_size,
+                apollo_rank=apollo_rank,
+                lora_rank=args.lora_rank,
+                kv_bits=args.kv_bits,
+            )
+        )
 
     if args.format == "markdown":
         print(render_markdown(reports))

--- a/packages/training/tests/rl/test_gemma_capacity.py
+++ b/packages/training/tests/rl/test_gemma_capacity.py
@@ -1,9 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src" / "training"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "rl"))
 
-from qwen_capacity import (
+from gemma_capacity import (
     BF16_BITS,
     build_capacity_report,
     estimate_apollo_optimizer_state_bytes,
@@ -18,17 +18,17 @@ from qwen_capacity import (
 
 def test_resolve_model_spec_accepts_alias_and_model_id():
     alias = resolve_model_spec("9b")
-    direct = resolve_model_spec("Qwen/Qwen3.5-9B")
+    direct = resolve_model_spec("google/gemma-4-12B")
 
     assert alias is not None
     assert direct is not None
-    assert alias.key == "qwen35_9b"
+    assert alias.key == "gemma4_12b"
     assert direct.key == alias.key
 
 
-def test_slugify_model_name_prefers_canonical_qwen_slug():
-    assert slugify_model_name("Qwen/Qwen3.5-122B-A10B") == "qwen35-122b-a10b"
-    assert slugify_model_name("9B") == "qwen35-9b"
+def test_slugify_model_name_prefers_canonical_gemma_slug():
+    assert slugify_model_name("google/gemma-4-31B") == "gemma4-31b"
+    assert slugify_model_name("9B") == "gemma4-12b"
 
 
 def test_parse_context_length_supports_k_suffix():
@@ -36,7 +36,7 @@ def test_parse_context_length_supports_k_suffix():
     assert parse_context_length("4096") == 4096
 
 
-def test_apollo_memory_is_lower_than_adamw_for_9b():
+def test_apollo_memory_is_lower_than_adamw_for_12b():
     spec = resolve_model_spec("9b")
     assert spec is not None
 
@@ -46,7 +46,6 @@ def test_apollo_memory_is_lower_than_adamw_for_9b():
         sequence_length=8192,
         micro_batch_size=1,
         checkpointed=True,
-        sparse_policy="total",
         apollo_rank=64,
     )
     apollo = estimate_full_training_memory(
@@ -55,7 +54,6 @@ def test_apollo_memory_is_lower_than_adamw_for_9b():
         sequence_length=8192,
         micro_batch_size=1,
         checkpointed=True,
-        sparse_policy="total",
         apollo_rank=64,
     )
 
@@ -63,7 +61,7 @@ def test_apollo_memory_is_lower_than_adamw_for_9b():
     assert apollo["total_gib"] < adamw["total_gib"]
 
 
-def test_lora_memory_is_lower_than_full_adamw_for_9b():
+def test_lora_memory_is_lower_than_full_adamw_for_12b():
     spec = resolve_model_spec("9b")
     assert spec is not None
 
@@ -73,7 +71,6 @@ def test_lora_memory_is_lower_than_full_adamw_for_9b():
         sequence_length=8192,
         micro_batch_size=1,
         checkpointed=True,
-        sparse_policy="total",
         apollo_rank=64,
     )
     lora = estimate_lora_memory(
@@ -88,8 +85,8 @@ def test_lora_memory_is_lower_than_full_adamw_for_9b():
     assert lora["total_gib"] < adamw["total_gib"]
 
 
-def test_kv_cache_scales_linearly_with_context_and_turboquant_bits():
-    spec = resolve_model_spec("4b")
+def test_gemma_kv_cache_uses_full_context_and_sliding_window_components():
+    spec = resolve_model_spec("12b")
     assert spec is not None
 
     kv_128k = estimate_kv_cache_bytes(
@@ -104,19 +101,20 @@ def test_kv_cache_scales_linearly_with_context_and_turboquant_bits():
         batch_size=1,
         kv_bits=BF16_BITS,
     )
-    kv_turbo = estimate_kv_cache_bytes(
+    kv_q4 = estimate_kv_cache_bytes(
         spec,
         context_tokens=131072,
         batch_size=1,
         kv_bits=4.0,
     )
 
-    assert round(kv_256k / kv_128k, 5) == 2.0
-    assert kv_turbo < kv_128k
+    assert kv_256k > kv_128k
+    assert round(kv_256k / kv_128k, 5) < 2.0
+    assert kv_q4 < kv_128k
 
 
-def test_capacity_report_includes_sparse_active_budget_for_moe():
-    spec = resolve_model_spec("122b")
+def test_capacity_report_includes_gemma_kv_metadata():
+    spec = resolve_model_spec("e2b")
     assert spec is not None
 
     report = build_capacity_report(
@@ -126,17 +124,18 @@ def test_capacity_report_includes_sparse_active_budget_for_moe():
         micro_batch_size=1,
         apollo_rank=64,
         lora_rank=64,
-        turboquant_bits=4.0,
+        kv_bits=16.0,
     )
 
-    assert "chinchilla_active" in report
-    assert report["chinchilla_total"]["tokens"] > report["chinchilla_active"]["tokens"]
-    assert "apollo_active_gib" in report["training_memory"]
-    assert "inference-side KV-cache compression" in report["notes"]["turboquant"]
+    assert report["model"]["model_id"] == "google/gemma-4-E2B"
+    assert report["context_memory"][0]["sliding_window"] == 512
+    assert report["context_memory"][0]["effective_sliding_kv_layers"] == 8
+    assert "Gemma KV estimates" in report["notes"]["kv"]
 
 
-def test_apollo_optimizer_estimate_is_positive_for_sparse_model():
-    spec = resolve_model_spec("35b-a3b")
+def test_apollo_optimizer_estimate_is_positive_for_cloud_tier():
+    spec = resolve_model_spec("27b")
     assert spec is not None
 
-    assert estimate_apollo_optimizer_state_bytes(spec, 64) > 0
+    assert spec.key == "gemma4_31b"
+    assert estimate_apollo_optimizer_state_bytes(spec, 512) > 0


### PR DESCRIPTION
## Summary
- rename the active RL capacity planner from Qwen to Gemma and update the CLI/test names to match
- replace Qwen 3.5/MoE model specs with Gemma 4 text tiers for E2B, E4B, 12B, and 31B mapped to the Eliza release tiers
- update KV planning for Gemma full-attention plus sliding-window cache behavior and remove TurboQuant/Qwen active-parameter planner fields from the active CLI

## Evidence
- `python3 -m pytest packages/training/tests/rl/test_gemma_capacity.py -q` -> 8 passed
- `python3 -m py_compile packages/training/scripts/rl/gemma_capacity.py packages/training/scripts/rl/plan_gemma_training.py packages/training/tests/rl/test_gemma_capacity.py` -> passed
- `python3 packages/training/scripts/rl/plan_gemma_training.py --model 9b --format markdown` -> emitted a Gemma 4 12B / eliza-1-9b capacity plan with Gemma KV metadata
- `git diff --check` -> passed
- `git fetch origin && git rebase origin/develop` -> clean final rebase
- `bun install` -> no dependency changes, artifacts already synced
- `bun run verify` -> 522 successful / 522 total, final post-rebase run passed

## Notes
- The Gemma specs follow the Gemma Core documentation and HF config fields for text-tier planner sizing.
- During verification, initial full-run attempts exposed generated declaration ordering races in unrelated packages (`@elizaos/plugin-commands` and `@elizaos/plugin-personal-assistant`). Targeted rebuild/typecheck of the affected packages passed, and the final full `bun run verify` passed after generated declarations existed.

Related: #9588, #9583