### PR TITLE
perf(build): DTS emit-only (--noCheck) for 22 plugins with a separate typecheck (#9626)

### DIFF
--- a/plugins/plugin-agent-orchestrator/build.ts
+++ b/plugins/plugin-agent-orchestrator/build.ts
@@ -73,7 +73,7 @@ async function build() {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   const nodeDir = join(distDir, "node");
   const cjsDir = join(distDir, "cjs");

--- a/plugins/plugin-anthropic-proxy/build.ts
+++ b/plugins/plugin-anthropic-proxy/build.ts
@@ -88,7 +88,7 @@ async function build() {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   const nodeDir = join(distDir, "node");
   const browserDir = join(distDir, "browser");

--- a/plugins/plugin-anthropic/build.ts
+++ b/plugins/plugin-anthropic/build.ts
@@ -82,7 +82,7 @@ async function build() {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   // Ensure directories exist
   const nodeDir = join(distDir, "node");

--- a/plugins/plugin-benchmarks/build.ts
+++ b/plugins/plugin-benchmarks/build.ts
@@ -33,7 +33,8 @@ async function build() {
   console.log("Generating TypeScript declarations...");
   const { $ } = await import("bun");
   try {
-    if (existsSync("tsconfig.build.json")) await $`tsc --project tsconfig.build.json`.quiet();
+    if (existsSync("tsconfig.build.json"))
+      await $`tsc --project tsconfig.build.json --noCheck`.quiet();
     console.log(`Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
   } catch (_error) {
     console.warn(

--- a/plugins/plugin-bluesky/build.ts
+++ b/plugins/plugin-bluesky/build.ts
@@ -114,7 +114,7 @@ async function build(): Promise<void> {
 	const dtsStart = Date.now();
 	console.log("📝 Generating TypeScript declarations...");
 	const { $ } = await import("bun");
-	await $`tsc --project tsconfig.build.json`;
+	await $`tsc --project tsconfig.build.json --noCheck`;
 
 	// Ensure directories exist
 	const nodeDir = join(distDir, "node");

--- a/plugins/plugin-cli-inference/build.ts
+++ b/plugins/plugin-cli-inference/build.ts
@@ -45,7 +45,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { mkdir, writeFile } = await import("node:fs/promises");
-  await Bun.$`tsc --project tsconfig.build.json`;
+  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
   await mkdir("dist/node", { recursive: true });
   await mkdir("dist/browser", { recursive: true });
   const reexportDeclaration = `export * from '../index';\nexport { default } from '../index';\n`;

--- a/plugins/plugin-codex-cli/build.ts
+++ b/plugins/plugin-codex-cli/build.ts
@@ -45,7 +45,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { mkdir, writeFile } = await import("node:fs/promises");
-  await Bun.$`tsc --project tsconfig.build.json`;
+  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
   await mkdir("dist/node", { recursive: true });
   await mkdir("dist/browser", { recursive: true });
   const reexportDeclaration = `export * from '../index';\nexport { default } from '../index';\n`;

--- a/plugins/plugin-edge-tts/build.ts
+++ b/plugins/plugin-edge-tts/build.ts
@@ -83,7 +83,7 @@ async function build() {
   console.log("📝 Generating TypeScript declarations...");
   const { mkdir, writeFile } = await import("node:fs/promises");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
   await mkdir("dist/node", { recursive: true });
   await mkdir("dist/browser", { recursive: true });
   await writeFile(

--- a/plugins/plugin-elizacloud/build.ts
+++ b/plugins/plugin-elizacloud/build.ts
@@ -122,7 +122,7 @@ async function build() {
 
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
-  await Bun.$`tsc --project tsconfig.build.json`;
+  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
   await mkdir("dist/node", { recursive: true });
   await mkdir("dist/browser", { recursive: true });
   await mkdir("dist/cjs", { recursive: true });

--- a/plugins/plugin-embeddings/build.ts
+++ b/plugins/plugin-embeddings/build.ts
@@ -66,7 +66,7 @@ try {
   // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
   // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
   // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json`;
+  await $`bunx tsc --project tsconfig.build.json --noCheck`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."

--- a/plugins/plugin-farcaster/build.ts
+++ b/plugins/plugin-farcaster/build.ts
@@ -96,7 +96,7 @@ async function build() {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   const nodeDir = join(distDir, "node");
   const browserDir = join(distDir, "browser");

--- a/plugins/plugin-google-genai/build.ts
+++ b/plugins/plugin-google-genai/build.ts
@@ -81,7 +81,7 @@ async function build() {
   console.log("Generating TypeScript declarations...");
   const { $ } = await import("bun");
   try {
-    await $`tsc --project tsconfig.build.json`;
+    await $`tsc --project tsconfig.build.json --noCheck`;
   } catch (_e) {
     console.warn("TypeScript declaration generation had errors");
   }

--- a/plugins/plugin-groq/build.ts
+++ b/plugins/plugin-groq/build.ts
@@ -79,7 +79,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   // Top-level `dist/index.d.ts` aggregates the node entrypoint declarations.
   // We re-export from the tsc-emitted `./node/index.node` rather than `./node/index`

--- a/plugins/plugin-lmstudio/build.ts
+++ b/plugins/plugin-lmstudio/build.ts
@@ -66,7 +66,7 @@ try {
   // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
   // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
   // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json`;
+  await $`bunx tsc --project tsconfig.build.json --noCheck`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."

--- a/plugins/plugin-local-storage/build.ts
+++ b/plugins/plugin-local-storage/build.ts
@@ -33,7 +33,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
   console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
 
   console.log(`🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);

--- a/plugins/plugin-minecraft/build.ts
+++ b/plugins/plugin-minecraft/build.ts
@@ -41,7 +41,7 @@ async function build(): Promise<void> {
   }
 
   try {
-    await $`tsc --project tsconfig.build.json`;
+    await $`tsc --project tsconfig.build.json --noCheck`;
   } catch {
     // declaration generation is best-effort
   }

--- a/plugins/plugin-mysticism/build.ts
+++ b/plugins/plugin-mysticism/build.ts
@@ -33,7 +33,8 @@ async function build() {
   console.log("Generating TypeScript declarations...");
   const { $ } = await import("bun");
   try {
-    if (existsSync("tsconfig.build.json")) await $`tsc --project tsconfig.build.json`.quiet();
+    if (existsSync("tsconfig.build.json"))
+      await $`tsc --project tsconfig.build.json --noCheck`.quiet();
     console.log(`Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
   } catch (_error) {
     console.warn(

--- a/plugins/plugin-ollama/build.ts
+++ b/plugins/plugin-ollama/build.ts
@@ -64,7 +64,7 @@ try {
   // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
   // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
   // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json`;
+  await $`bunx tsc --project tsconfig.build.json --noCheck`;
 } catch {
   console.warn(
     "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."

--- a/plugins/plugin-openai/build.ts
+++ b/plugins/plugin-openai/build.ts
@@ -63,7 +63,7 @@ async function build(): Promise<void> {
 
   const { mkdir, writeFile } = await import("node:fs/promises");
 
-  await Bun.$`tsc --project tsconfig.build.json`;
+  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
 
   // Create output directories
   await mkdir("dist/node", { recursive: true });

--- a/plugins/plugin-pdf/build.ts
+++ b/plugins/plugin-pdf/build.ts
@@ -56,7 +56,7 @@ async function build(): Promise<void> {
 
   const { mkdir, writeFile } = await import("node:fs/promises");
   const { $ } = await import("bun");
-  await $`bunx tsc --project tsconfig.build.json`;
+  await $`bunx tsc --project tsconfig.build.json --noCheck`;
 
   await mkdir("dist/node", { recursive: true });
   await mkdir("dist/browser", { recursive: true });

--- a/plugins/plugin-roblox/build.ts
+++ b/plugins/plugin-roblox/build.ts
@@ -33,7 +33,7 @@ async function build() {
   }
 
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 }
 
 build().catch((err) => {

--- a/plugins/plugin-xai/build.ts
+++ b/plugins/plugin-xai/build.ts
@@ -122,7 +122,7 @@ async function build(): Promise<void> {
   const { writeFile } = await import("node:fs/promises");
   const { $ } = await import("bun");
 
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   // Create re-export declaration files for each entry point
   const reexportDeclaration = `export * from '../index';


### PR DESCRIPTION
Part of #9626, TL;DR #3 ("double type-check" / DTS-emit-only sweep).

## Problem
~50 `build.ts` run `tsc --project tsconfig.build.json` **without `--noCheck`** during `build` — a full redundant type-check on top of the separate `typecheck` task (tsgo). DTS generation dominates build time.

## Change
Adds `--noCheck` to the declaration-emit step of **22 plugins** that both (a) use the uniform `tsc --project tsconfig.build.json` invocation and (b) already have a separate `typecheck` script — so the error gate is preserved (tsgo/`tsc --noEmit` still type-checks; the build just stops re-checking and becomes emit-only).

## Verification (the audit explicitly requires per-package proof)
For **every one of the 22**, `tsc --project tsconfig.build.json` vs `... --noCheck` emit **byte-identical `.d.ts`** (full-tree sha compared). End-to-end `bun build.ts` confirmed for a sample (plugin-groq: declarations generated, js+d.ts emitted).

The underlying invariant (`--noCheck` ⇒ identical declarations for valid code) was also confirmed independently on plugin-anthropic / plugin-openai / plugin-farcaster.

## Deliberately excluded (conservative)
- **plugin-vision** — `--noCheck` reorders one inferred union member (`info: "info"`); functionally equivalent but **not** byte-identical, so left as full-check.
- **plugin-nearai, plugin-zai** — could not byte-verify locally; left for a separately-verified pass.
- Any build.ts with **no** separate typecheck (e.g. `plugin-minecraft/mineflayer-server`) — converting would remove its only type-check (a #9474 regression).

`biome check` clean on all 22 (2 long lines auto-wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)