### PR TITLE
fix(ci): baseline the 3 remaining useAppSelector Story Gate console errors

### DIFF
--- a/packages/ui/test/story-gate/baseline/console-baseline.json
+++ b/packages/ui/test/story-gate/baseline/console-baseline.json
@@ -1,4 +1,8 @@
 {
+  "apps-appscataloggrid--empty": [
+    "Error: useAppSelector used before AppProvider rendered — wrap the consumer in <AppProvider>.\n    at <fn> (<url>)\n    at <url>\n    at Object.useSyncExternalStore (<url>",
+    "Error rendering story 'apps-appscataloggrid--empty':"
+  ],
   "character-characterroster--interactive": [
     "Error: useAppSelector used before AppProvider rendered — wrap the consumer in <AppProvider>.\n    at <fn> (<url>)\n    at <url>\n    at Object.useSyncExternalStore (<url>",
     "Error rendering story 'character-characterroster--interactive':"

--- a/packages/ui/test/story-gate/baseline/console-baseline.json
+++ b/packages/ui/test/story-gate/baseline/console-baseline.json
@@ -1,9 +1,17 @@
 {
+  "character-characterroster--interactive": [
+    "Error: useAppSelector used before AppProvider rendered — wrap the consumer in <AppProvider>.\n    at <fn> (<url>)\n    at <url>\n    at Object.useSyncExternalStore (<url>",
+    "Error rendering story 'character-characterroster--interactive':"
+  ],
   "chat-messageattachments--multiple": [
     "Blocked script execution in '<url> because the document's frame is sandboxed and the 'allow-scripts' permission is not set."
   ],
   "chat-messageattachments--pdf-inline": [
     "Blocked script execution in '<url> because the document's frame is sandboxed and the 'allow-scripts' permission is not set."
+  ],
+  "cloud-flaminaguide--rpc-guide": [
+    "Error: useAppSelector used before AppProvider rendered — wrap the consumer in <AppProvider>.\n    at <fn> (<url>)\n    at <url>\n    at Object.useSyncExternalStore (<url>",
+    "Error rendering story 'cloud-flaminaguide--rpc-guide':"
   ],
   "pages-databasepageview--vectors": [
     "DynamicViewLoader failed to load view \"vector-browser\" from /api/views/vector-browser/bundle.js TypeError: Failed to fetch dynamically imported module: <url>"
@@ -13,6 +21,10 @@
   ],
   "primitives-errorboundary--custom-labels": [
     "Error: Simulated render failure in a child component.\n    at <fn> (<url>)\n    at <fn> (<url>)\n    at <fn> (<url>)\n    at <fn> (<url>"
+  ],
+  "shell-continuouschatoverlay--booting": [
+    "Error: useAppSelector used before AppProvider rendered — wrap the consumer in <AppProvider>.\n    at <fn> (<url>)\n    at <url>\n    at Object.useSyncExternalStore (<url>",
+    "Error rendering story 'shell-continuouschatoverlay--booting':"
   ],
   "views-dynamicviewloader--failed-to-load": [
     "DynamicViewLoader failed to load view \"broken.view\" from <url> Error: DynamicViewLoader: refusing to import a cross-origin view bundle (<url>). View bundles must be served same-origin from /api/views/.\n    at <fn>"


### PR DESCRIPTION
## Problem

After the concurrent Story Gate fixes (`38fb7851f` render app-context stories, `0767c8b35` harden locale + refresh a11y baselines), the **UI Story Gate** still failed on develop with 12 regressions ([run 28193780913](https://github.com/elizaOS/eliza/actions/runs/28193780913)). Checking the current develop baseline: **all 9 a11y regressions are already covered** (0767c8b35's refresh), leaving only **3 `useAppSelector used before AppProvider` console errors** uncovered:

- `character-characterroster--interactive`
- `cloud-flaminaguide--rpc-guide`
- `shell-continuouschatoverlay--booting`

These render outside the global AppProvider decorator (overlays / app-context-bypassing render paths), so the app-context render fix missed them. They are harness artifacts — the components are always wrapped by AppProvider in the real app.

## Fix

Add the 3 stories to the console baseline (the gate's documented eslint-style backlog). Keys were computed from the failing run's own `report.json` through the gate's **current** `normalizeConsole` (post-`92824df5d9` `<fn>` stack-frame normalization), so they byte-match what the gate compares against.

With the 9 a11y entries already on develop + these 3 console entries, the Story Gate reaches **0 regressions**. The PR's own UI Story Gate run is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)