### PR TITLE
feat(vision): generic IMAGE_DESCRIPTION fusion seam — ground Gemma-4 describe in OCR/YOLO/face (#9105)

### DIFF
--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -17,6 +17,7 @@ import {
 
 import { generateMediaAction } from "./actions/generate-media.js";
 import { identifySpeakerAction } from "./actions/identify-speaker.js";
+import { augmentVisionRequest } from "./services/vision/augmenter.js";
 import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
@@ -821,6 +822,7 @@ function createImageDescriptionHandler() {
 					? modelKeyCandidate
 					: "gemma-vl";
 			const request = paramsToVisionRequest(params);
+			await augmentVisionRequest(request);
 			const result = await arbiter.requestVisionDescribe<
 				typeof request,
 				ImageDescriptionResult | string

--- a/plugins/plugin-local-inference/src/services/index.ts
+++ b/plugins/plugin-local-inference/src/services/index.ts
@@ -25,6 +25,13 @@ export {
 	MODEL_CATALOG,
 } from "./catalog";
 export {
+	getVisionContextAugmenter,
+	registerVisionContextAugmenter,
+	type VisionAugmentResult,
+	type VisionContextAugmenter,
+	type VisionFusedContext,
+} from "./vision/augmenter";
+export {
 	type CloudCandidate,
 	type CloudFallbackOptions,
 	classifyLocalError,

--- a/plugins/plugin-local-inference/src/services/vision/augmenter.test.ts
+++ b/plugins/plugin-local-inference/src/services/vision/augmenter.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	augmentVisionRequest,
+	getVisionContextAugmenter,
+	registerVisionContextAugmenter,
+	type VisionContextAugmenter,
+} from "./augmenter";
+
+afterEach(() => registerVisionContextAugmenter(null));
+
+const IMAGE = {
+	kind: "dataUrl" as const,
+	dataUrl: "data:image/png;base64,AAAA",
+};
+
+describe("vision context augmenter registry", () => {
+	it("registers and clears", () => {
+		const a: VisionContextAugmenter = {
+			name: "x",
+			async augmentImagePrompt() {
+				return null;
+			},
+		};
+		registerVisionContextAugmenter(a);
+		expect(getVisionContextAugmenter()).toBe(a);
+		registerVisionContextAugmenter(null);
+		expect(getVisionContextAugmenter()).toBeNull();
+	});
+});
+
+describe("augmentVisionRequest", () => {
+	it("rewrites the prompt with the augmenter output", async () => {
+		registerVisionContextAugmenter({
+			name: "fused",
+			async augmentImagePrompt({ basePrompt }) {
+				return {
+					prompt: `${basePrompt ?? "Describe."}\n\nDetected context\n- Text (OCR): "HELLO 42"`,
+					fused: { ocrText: '"HELLO 42"' },
+				};
+			},
+		});
+		const request = { image: IMAGE, prompt: "Describe this." };
+		await augmentVisionRequest(request);
+		expect(request.prompt).toContain("Describe this.");
+		expect(request.prompt).toContain('Text (OCR): "HELLO 42"');
+	});
+
+	it("is a no-op when no augmenter is registered", async () => {
+		const request = { image: IMAGE, prompt: "unchanged" };
+		await augmentVisionRequest(request);
+		expect(request.prompt).toBe("unchanged");
+	});
+
+	it("leaves the prompt unchanged when the augmenter returns null", async () => {
+		registerVisionContextAugmenter({
+			name: "empty",
+			async augmentImagePrompt() {
+				return null;
+			},
+		});
+		const request = { image: IMAGE, prompt: "keep me" };
+		await augmentVisionRequest(request);
+		expect(request.prompt).toBe("keep me");
+	});
+
+	it("swallows augmenter failures and keeps the original prompt (best-effort)", async () => {
+		registerVisionContextAugmenter({
+			name: "boom",
+			async augmentImagePrompt() {
+				throw new Error("detector crashed");
+			},
+		});
+		const request = { image: IMAGE, prompt: "survive" };
+		await expect(augmentVisionRequest(request)).resolves.toBeUndefined();
+		expect(request.prompt).toBe("survive");
+	});
+});

--- a/plugins/plugin-local-inference/src/services/vision/augmenter.ts
+++ b/plugins/plugin-local-inference/src/services/vision/augmenter.ts
@@ -1,0 +1,103 @@
+/**
+ * Vision-context augmentation seam (issue #9105).
+ *
+ * The on-device VL model (Gemma-4 vision) describes raw image pixels. This
+ * seam lets a higher-level plugin (plugin-vision) run lightweight, token-free
+ * pre-vision detectors over the same image — OCR (tesseract), object detection
+ * (YOLO), face detection — and fold their results into the describe prompt as
+ * structured text context. The VL model then grounds its description in real
+ * extracted signals instead of guessing at small text or object identity.
+ *
+ * Layering: the IMAGE_DESCRIPTION handler (this package) is the *consumer*; it
+ * owns the registry and reads whatever augmenter is registered. plugin-vision
+ * is the *provider*; it registers its implementation at boot via a best-effort
+ * dynamic import (no hard dependency in either direction — mirrors the
+ * coord-OCR bridge plugin-vision already uses for plugin-computeruse). When no
+ * augmenter is registered the handler describes the image unaugmented.
+ */
+
+import { logger } from "@elizaos/core";
+import type { VisionImageInput } from "./types";
+
+/**
+ * Raw pre-vision signals extracted from an image. Every field is optional —
+ * a detector that is unavailable (no model artifact, wrong platform) simply
+ * contributes nothing rather than failing the describe.
+ */
+export interface VisionFusedContext {
+	/** OCR text blocks, newest-distilled into one prompt-ready string. */
+	ocrText?: string;
+	/** Detected objects as a prompt-ready string (e.g. `person (0.94), laptop (0.81)`). */
+	objects?: string;
+	/** Face summary (e.g. `2 faces`). */
+	faces?: string;
+}
+
+/** Result of augmenting a describe prompt with fused pre-vision context. */
+export interface VisionAugmentResult {
+	/** The base prompt with the fused-context block appended. */
+	prompt: string;
+	/** The raw signals that produced the block (for telemetry / enrichment). */
+	fused: VisionFusedContext;
+}
+
+/**
+ * A provider that runs pre-vision detectors over an image and returns an
+ * augmented describe prompt. Returns `null` when nothing useful was detected
+ * (so the handler keeps the original prompt unchanged).
+ */
+export interface VisionContextAugmenter {
+	/** Stable identifier, surfaced in logs. */
+	readonly name: string;
+	augmentImagePrompt(input: {
+		image: VisionImageInput;
+		basePrompt?: string;
+	}): Promise<VisionAugmentResult | null>;
+}
+
+let registered: VisionContextAugmenter | null = null;
+
+/**
+ * Register (or clear, with `null`) the process-wide vision-context augmenter.
+ * Last writer wins — a native provider can override an earlier registration.
+ */
+export function registerVisionContextAugmenter(
+	augmenter: VisionContextAugmenter | null,
+): void {
+	registered = augmenter;
+}
+
+/** The currently registered augmenter, or `null` when none is wired. */
+export function getVisionContextAugmenter(): VisionContextAugmenter | null {
+	return registered;
+}
+
+/**
+ * Fold pre-vision detector signals into a describe request's prompt, in place,
+ * when an augmenter is registered. Best-effort: a missing or failing augmenter
+ * leaves the request unchanged so the VL model still describes the raw image —
+ * the augmentation is extra grounding context, never a hard dependency of
+ * IMAGE_DESCRIPTION. Used by the IMAGE_DESCRIPTION handler in `provider.ts`.
+ */
+export async function augmentVisionRequest(request: {
+	image: VisionImageInput;
+	prompt?: string;
+}): Promise<void> {
+	const augmenter = registered;
+	if (!augmenter) return;
+	try {
+		const augmented = await augmenter.augmentImagePrompt({
+			image: request.image,
+			basePrompt: request.prompt,
+		});
+		if (augmented?.prompt) {
+			request.prompt = augmented.prompt;
+		}
+	} catch (err) {
+		logger.warn(
+			`[local-inference] vision context augmenter '${augmenter.name}' failed; describing unaugmented: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	}
+}

--- a/plugins/plugin-local-inference/src/services/vision/index.ts
+++ b/plugins/plugin-local-inference/src/services/vision/index.ts
@@ -36,6 +36,13 @@ export {
 	loadAospVisionBackend,
 } from "./aosp-unavailable";
 export {
+	getVisionContextAugmenter,
+	registerVisionContextAugmenter,
+	type VisionAugmentResult,
+	type VisionContextAugmenter,
+	type VisionFusedContext,
+} from "./augmenter";
+export {
 	type CapacitorLlamaMtmdBinding,
 	type CapacitorLlamaMtmdHandle,
 	type CapacitorLlamaVisionBackendOptions,

--- a/plugins/plugin-vision/src/index.ts
+++ b/plugins/plugin-vision/src/index.ts
@@ -72,6 +72,32 @@ export const visionPlugin: Plugin = {
         registerOcrWithCoordsService(new RapidOcrCoordAdapter());
       }
     }
+    // Vision-context fusion (#9105): register an augmenter that runs OCR +
+    // object/face detection over describe-image inputs and folds the results
+    // into the Gemma-4 VL prompt. plugin-local-inference owns the registry; we
+    // wire into it via a best-effort dynamic import (no hard dep — skipped
+    // cleanly when local-inference is not installed), same as the OCR bridge.
+    try {
+      const li = (await import("@elizaos/plugin-local-inference/services")) as {
+        registerVisionContextAugmenter?: (augmenter: unknown) => void;
+      };
+      if (typeof li.registerVisionContextAugmenter === "function") {
+        const { createDefaultVisionAugmenter } = await import(
+          "./vision-context-augmenter.js"
+        );
+        li.registerVisionContextAugmenter(createDefaultVisionAugmenter());
+        logger.info(
+          "[vision] registered vision-context augmenter (OCR+object+face fusion) into IMAGE_DESCRIPTION",
+        );
+      }
+    } catch (err) {
+      logger.debug(
+        `[vision] local-inference vision-augment seam not available; describe runs unaugmented (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+    }
+
     try {
       const mod = (await import(
         "@elizaos/plugin-computeruse/mobile/ocr-provider"

--- a/plugins/plugin-vision/src/vision-context-augmenter.test.ts
+++ b/plugins/plugin-vision/src/vision-context-augmenter.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   buildAugmentedPrompt,
   FusedVisionContextAugmenter,
+  isMeaningfulOcrText,
 } from "./vision-context-augmenter.js";
 
 /** A coord-OCR service that returns fixed blocks — no tesseract binary. */
@@ -52,7 +53,33 @@ describe("buildAugmentedPrompt", () => {
   });
 });
 
+describe("isMeaningfulOcrText", () => {
+  it("keeps real words/labels and drops photo-OCR noise", () => {
+    for (const good of ["Bus", "RID", "10", "STOP", "Avani"]) {
+      expect(isMeaningfulOcrText(good)).toBe(true);
+    }
+    for (const noise of ["|", "—", "=", ":", "a", "\\", "‘"]) {
+      expect(isMeaningfulOcrText(noise)).toBe(false);
+    }
+  });
+});
+
 describe("FusedVisionContextAugmenter", () => {
+  it("drops noisy single-glyph OCR fragments, keeps real text", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () =>
+        fakeOcr([
+          { text: "|" },
+          { text: "Bus" },
+          { text: "—" },
+          { text: "RID" },
+          { text: "a" },
+        ]),
+    });
+    const out = await aug.augmentImagePrompt({ image: IMAGE });
+    expect(out?.fused.ocrText).toBe('"Bus", "RID"');
+  });
+
   it("fuses OCR text into the prompt", async () => {
     const aug = new FusedVisionContextAugmenter({
       getOcr: () => fakeOcr([{ text: "ELIZA OCR TEST 1234" }]),

--- a/plugins/plugin-vision/src/vision-context-augmenter.test.ts
+++ b/plugins/plugin-vision/src/vision-context-augmenter.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type {
+  OcrWithCoordsResult,
+  OcrWithCoordsService,
+} from "./ocr-with-coords.js";
+import {
+  buildAugmentedPrompt,
+  FusedVisionContextAugmenter,
+} from "./vision-context-augmenter.js";
+
+/** A coord-OCR service that returns fixed blocks — no tesseract binary. */
+function fakeOcr(blocks: Array<{ text: string }>): OcrWithCoordsService {
+  return {
+    name: "fake-ocr",
+    async describe(): Promise<OcrWithCoordsResult> {
+      return {
+        blocks: blocks.map((b) => ({
+          text: b.text,
+          bbox: { x: 0, y: 0, width: 10, height: 10 },
+          words: [],
+          semantic_position: "center" as const,
+        })),
+      };
+    },
+  };
+}
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+const IMAGE = { kind: "bytes" as const, bytes: PNG_BYTES };
+
+describe("buildAugmentedPrompt", () => {
+  it("appends a delimited detected-context block with all three signals", () => {
+    const out = buildAugmentedPrompt("What is this?", {
+      ocrText: '"ELIZA OCR TEST 1234"',
+      objects: "person (0.94), laptop (0.81)",
+      faces: "2 faces",
+    });
+    expect(out).toContain("What is this?");
+    expect(out).toContain("Detected context");
+    expect(out).toContain('- Text (OCR): "ELIZA OCR TEST 1234"');
+    expect(out).toContain("- Objects: person (0.94), laptop (0.81)");
+    expect(out).toContain("- Faces: 2 faces");
+  });
+
+  it("falls back to the default describe prompt when no base is given", () => {
+    const out = buildAugmentedPrompt(undefined, { ocrText: '"hi"' });
+    expect(out.startsWith("Describe what is in this image.")).toBe(true);
+  });
+
+  it("returns the bare base prompt when there are no signals", () => {
+    expect(buildAugmentedPrompt("base", {})).toBe("base");
+  });
+});
+
+describe("FusedVisionContextAugmenter", () => {
+  it("fuses OCR text into the prompt", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([{ text: "ELIZA OCR TEST 1234" }]),
+    });
+    const out = await aug.augmentImagePrompt({
+      image: IMAGE,
+      basePrompt: "Describe the image.",
+    });
+    expect(out).not.toBeNull();
+    expect(out?.fused.ocrText).toBe('"ELIZA OCR TEST 1234"');
+    expect(out?.prompt).toContain("ELIZA OCR TEST 1234");
+    expect(out?.prompt).toContain("Describe the image.");
+  });
+
+  it("fuses OCR + objects + faces from all detectors", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([{ text: "SALE 50% OFF" }]),
+      detectObjects: async () => [
+        { type: "person", confidence: 0.94 },
+        { type: "handbag", confidence: 0.7 },
+      ],
+      detectFaces: async () => 1,
+    });
+    const out = await aug.augmentImagePrompt({ image: IMAGE });
+    expect(out?.fused.ocrText).toBe('"SALE 50% OFF"');
+    expect(out?.fused.objects).toBe("person (0.94), handbag (0.70)");
+    expect(out?.fused.faces).toBe("1 face");
+    expect(out?.prompt).toContain("- Objects: person (0.94), handbag (0.70)");
+    expect(out?.prompt).toContain("- Faces: 1 face");
+  });
+
+  it("returns null when no detector produces a signal (so the prompt is left unchanged)", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([]),
+      detectObjects: async () => [],
+      detectFaces: async () => 0,
+    });
+    expect(await aug.augmentImagePrompt({ image: IMAGE })).toBeNull();
+  });
+
+  it("degrades gracefully when a detector throws (OCR still fuses)", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([{ text: "STILL WORKS" }]),
+      detectObjects: async () => {
+        throw new Error("yolo native lib missing");
+      },
+      detectFaces: async () => {
+        throw new Error("blazeface weights missing");
+      },
+    });
+    const out = await aug.augmentImagePrompt({ image: IMAGE });
+    expect(out?.fused.ocrText).toBe('"STILL WORKS"');
+    expect(out?.fused.objects).toBeUndefined();
+    expect(out?.fused.faces).toBeUndefined();
+  });
+
+  it("is idempotent — skips a prompt that already carries a fused-context block", async () => {
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([{ text: "AGAIN" }]),
+    });
+    const once = await aug.augmentImagePrompt({
+      image: IMAGE,
+      basePrompt: "Describe.",
+    });
+    // Feeding the already-augmented prompt back in must not stack a 2nd block.
+    const twice = await aug.augmentImagePrompt({
+      image: IMAGE,
+      basePrompt: once?.prompt,
+    });
+    expect(twice).toBeNull();
+  });
+
+  it("decodes a data-URL image input", async () => {
+    const b64 = Buffer.from(PNG_BYTES).toString("base64");
+    const aug = new FusedVisionContextAugmenter({
+      getOcr: () => fakeOcr([{ text: "FROM DATAURL" }]),
+    });
+    const out = await aug.augmentImagePrompt({
+      image: { kind: "dataUrl", dataUrl: `data:image/png;base64,${b64}` },
+    });
+    expect(out?.fused.ocrText).toBe('"FROM DATAURL"');
+  });
+});

--- a/plugins/plugin-vision/src/vision-context-augmenter.ts
+++ b/plugins/plugin-vision/src/vision-context-augmenter.ts
@@ -1,0 +1,250 @@
+/**
+ * Vision-context augmenter (issue #9105).
+ *
+ * Runs the token-free pre-vision detectors plugin-vision owns — OCR
+ * (tesseract / native OS engines), object detection (YOLO), face detection —
+ * over an image and folds their results into the describe prompt as structured
+ * text. The on-device Gemma-4 VL model then grounds its description in real
+ * extracted signals (small text it would otherwise misread, object identity,
+ * presence of people) instead of guessing.
+ *
+ * This is the *provider* half of the seam. plugin-local-inference owns the
+ * registry (`registerVisionContextAugmenter`); this class is registered into it
+ * at boot via a best-effort dynamic import (see `index.ts`), mirroring the
+ * coord-OCR bridge into plugin-computeruse. Every detector is optional and
+ * best-effort: an unavailable or failing detector contributes nothing rather
+ * than failing the describe.
+ */
+
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { logger } from "@elizaos/core";
+import {
+  getOcrWithCoordsService,
+  type OcrWithCoordsService,
+} from "./ocr-with-coords.js";
+
+/** Raw signals extracted from an image, joined into prompt-ready strings. */
+export interface FusedVisionSignals {
+  ocrText?: string;
+  objects?: string;
+  faces?: string;
+}
+
+/** Image wrapper accepted by the augmenter — matches the handler's request shape. */
+export type AugmenterImageInput =
+  | { kind: "bytes"; bytes: Uint8Array; mimeType?: string }
+  | { kind: "base64"; base64: string; mimeType?: string }
+  | { kind: "dataUrl"; dataUrl: string }
+  | { kind: "url"; url: string; mimeType?: string };
+
+export interface VisionAugmentInput {
+  image: AugmenterImageInput;
+  basePrompt?: string;
+}
+
+export interface VisionAugmentOutput {
+  prompt: string;
+  fused: FusedVisionSignals;
+}
+
+/**
+ * Injectable detector hooks. OCR defaults to the registered coord-OCR service;
+ * object/face detection are wired only when their native artifacts are present.
+ * Exposed so tests can drive the fusion with deterministic fakes (no native
+ * libs, no real tesseract).
+ */
+export interface VisionAugmenterDetectors {
+  getOcr?: () => OcrWithCoordsService | null;
+  detectObjects?: (
+    imageBytes: Buffer,
+  ) => Promise<ReadonlyArray<{ type: string; confidence: number }>>;
+  detectFaces?: (imageBytes: Buffer) => Promise<number>;
+}
+
+const DEFAULT_DESCRIBE_PROMPT = "Describe what is in this image.";
+const MAX_OBJECTS = 12;
+
+/**
+ * Sentinel that marks an already-augmented prompt. Lets the augmenter stay
+ * idempotent — if a prompt that already carries a fused-context block is fed
+ * back in (re-describe, retry), we skip rather than stacking a second block.
+ */
+const FUSED_CONTEXT_MARKER = "Detected context — pre-extracted from this image";
+
+export class FusedVisionContextAugmenter {
+  readonly name = "vision-fused-context";
+
+  constructor(private readonly deps: VisionAugmenterDetectors = {}) {}
+
+  async augmentImagePrompt(
+    input: VisionAugmentInput,
+  ): Promise<VisionAugmentOutput | null> {
+    if (input.basePrompt?.includes(FUSED_CONTEXT_MARKER)) return null;
+    const bytes = resolveImageBytes(input.image);
+    if (!bytes || bytes.byteLength === 0) return null;
+
+    const fused: FusedVisionSignals = {};
+
+    const ocr = (this.deps.getOcr ?? getOcrWithCoordsService)();
+    if (ocr) {
+      try {
+        const res = await ocr.describe({
+          displayId: "vision-describe",
+          sourceX: 0,
+          sourceY: 0,
+          pngBytes: new Uint8Array(bytes),
+        });
+        const lines = res.blocks
+          .map((b) => b.text.trim())
+          .filter((t) => t.length > 0);
+        if (lines.length > 0) {
+          fused.ocrText = lines.map((t) => `"${t}"`).join(", ");
+        }
+      } catch (err) {
+        logger.debug(`[vision-augment] OCR skipped: ${messageOf(err)}`);
+      }
+    }
+
+    if (this.deps.detectObjects) {
+      try {
+        const objs = await this.deps.detectObjects(bytes);
+        if (objs.length > 0) {
+          fused.objects = objs
+            .slice(0, MAX_OBJECTS)
+            .map((o) => `${o.type} (${o.confidence.toFixed(2)})`)
+            .join(", ");
+        }
+      } catch (err) {
+        logger.debug(
+          `[vision-augment] object detection skipped: ${messageOf(err)}`,
+        );
+      }
+    }
+
+    if (this.deps.detectFaces) {
+      try {
+        const n = await this.deps.detectFaces(bytes);
+        if (n > 0) fused.faces = `${n} ${n === 1 ? "face" : "faces"}`;
+      } catch (err) {
+        logger.debug(
+          `[vision-augment] face detection skipped: ${messageOf(err)}`,
+        );
+      }
+    }
+
+    if (!fused.ocrText && !fused.objects && !fused.faces) return null;
+    return {
+      prompt: buildAugmentedPrompt(input.basePrompt, fused),
+      fused,
+    };
+  }
+}
+
+/**
+ * Compose the final prompt: the caller's prompt (or a default) followed by a
+ * clearly-delimited block of detected signals. Pure — exported for tests so the
+ * prompt contract has a single source of truth.
+ */
+export function buildAugmentedPrompt(
+  basePrompt: string | undefined,
+  fused: FusedVisionSignals,
+): string {
+  const base = basePrompt?.trim() || DEFAULT_DESCRIBE_PROMPT;
+  const lines: string[] = [];
+  if (fused.ocrText) lines.push(`Text (OCR): ${fused.ocrText}`);
+  if (fused.objects) lines.push(`Objects: ${fused.objects}`);
+  if (fused.faces) lines.push(`Faces: ${fused.faces}`);
+  if (lines.length === 0) return base;
+  return [
+    base,
+    "",
+    `${FUSED_CONTEXT_MARKER} to ground your answer. Use these signals; correct them only if the image clearly contradicts them.`,
+    ...lines.map((l) => `- ${l}`),
+  ].join("\n");
+}
+
+/**
+ * Resolve an image wrapper to encoded image bytes. Handles inline shapes
+ * (bytes / base64 / data URL) and `file://` + local-path URLs. Remote
+ * (`http(s)://`) URLs return `null` — the describe backend fetches those
+ * through the SSRF guard; the augmenter does not perform network I/O.
+ */
+function resolveImageBytes(image: AugmenterImageInput): Buffer | null {
+  switch (image.kind) {
+    case "bytes":
+      return Buffer.from(image.bytes);
+    case "base64":
+      return Buffer.from(image.base64, "base64");
+    case "dataUrl": {
+      const comma = image.dataUrl.indexOf(",");
+      if (comma < 0) return null;
+      return Buffer.from(image.dataUrl.slice(comma + 1), "base64");
+    }
+    case "url": {
+      const { url } = image;
+      if (url.startsWith("file://")) {
+        return readFileSync(fileURLToPath(url));
+      }
+      if (url.startsWith("http://") || url.startsWith("https://")) {
+        return null;
+      }
+      // Bare filesystem path.
+      return readFileSync(url);
+    }
+  }
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The production augmenter: OCR via the registered coord-OCR service, plus YOLO
+ * object detection and BlazeFace face detection wired lazily and gated on their
+ * `isAvailable()` probe. Until those native artifacts ship, the gate is false
+ * and they contribute nothing — OCR alone augments the prompt. When the
+ * artifacts land the same fusion point activates them with no further wiring.
+ */
+export function createDefaultVisionAugmenter(): FusedVisionContextAugmenter {
+  return new FusedVisionContextAugmenter({
+    detectObjects: lazyObjectDetector(),
+    detectFaces: lazyFaceDetector(),
+  });
+}
+
+function lazyObjectDetector(): (
+  bytes: Buffer,
+) => Promise<ReadonlyArray<{ type: string; confidence: number }>> {
+  let detector: import("./yolo-detector.js").YOLODetector | null = null;
+  let resolved = false;
+  return async (bytes) => {
+    if (!resolved) {
+      resolved = true;
+      const { YOLODetector } = await import("./yolo-detector.js");
+      if (await YOLODetector.isAvailable()) detector = new YOLODetector();
+    }
+    if (!detector) return [];
+    const objs = await detector.detect(bytes);
+    return objs.map((o) => ({ type: o.type, confidence: o.confidence }));
+  };
+}
+
+function lazyFaceDetector(): (bytes: Buffer) => Promise<number> {
+  let detector: import("./face-detector-ggml.js").BlazeFaceGgmlDetector | null =
+    null;
+  let resolved = false;
+  return async (bytes) => {
+    if (!resolved) {
+      resolved = true;
+      const { BlazeFaceGgmlDetector } = await import("./face-detector-ggml.js");
+      if (await BlazeFaceGgmlDetector.isAvailable()) {
+        detector = new BlazeFaceGgmlDetector();
+      }
+    }
+    if (!detector) return 0;
+    const faces = await detector.detect(bytes);
+    return faces.length;
+  };
+}

--- a/plugins/plugin-vision/src/vision-context-augmenter.ts
+++ b/plugins/plugin-vision/src/vision-context-augmenter.ts
@@ -65,6 +65,18 @@ export interface VisionAugmenterDetectors {
 
 const DEFAULT_DESCRIBE_PROMPT = "Describe what is in this image.";
 const MAX_OBJECTS = 12;
+const MAX_OCR_BLOCKS = 24;
+
+/**
+ * Keep only OCR fragments that carry real signal. Tesseract run over a natural
+ * photo (vs a clean document) emits per-glyph noise — `|`, `=`, `—`, stray
+ * single letters — that would pollute the prompt and waste tokens. Require at
+ * least two alphanumeric characters so genuine words/labels survive and noise
+ * is dropped. Pure — exported for tests.
+ */
+export function isMeaningfulOcrText(text: string): boolean {
+  return (text.match(/[A-Za-z0-9]/g)?.length ?? 0) >= 2;
+}
 
 /**
  * Sentinel that marks an already-augmented prompt. Lets the augmenter stay
@@ -98,7 +110,8 @@ export class FusedVisionContextAugmenter {
         });
         const lines = res.blocks
           .map((b) => b.text.trim())
-          .filter((t) => t.length > 0);
+          .filter(isMeaningfulOcrText)
+          .slice(0, MAX_OCR_BLOCKS);
         if (lines.length > 0) {
           fused.ocrText = lines.map((t) => `"${t}"`).join(", ");
         }


### PR DESCRIPTION
## What

Adds the missing **fusion seam** so the on-device Gemma-4 VL model grounds its `IMAGE_DESCRIPTION` output in the OCR / YOLO / face signals plugin-vision already extracts (today they exist but have no path into the describe flow).

- `plugin-local-inference` owns a generic `VisionContextAugmenter` registry + `augmentVisionRequest()` that the `IMAGE_DESCRIPTION` handler calls **before** dispatching to the VL backend. Best-effort: a missing/failing augmenter describes the raw image unchanged (no hard dep, no regression).
- `plugin-vision` registers `FusedVisionContextAugmenter` via a best-effort dynamic import (mirrors the existing coord-OCR bridge): runs tesseract OCR + lazily-gated YOLO + BlazeFace, folds the results into a delimited context block appended to the describe prompt.
- Photo-OCR noise filter: drops sub-2-alphanumeric fragments and caps at 24 blocks, so real labels survive while per-glyph noise (`|`, `=`, `—`, stray letters) is dropped.

## Why this slice / why now

This is the genuinely-novel, self-contained vision-fusion work salvaged from the stale `feat/9105-image-description-fusion` branch (729 commits behind develop, no PR). It is **distinct from** the already-landed #9574 fusion, which fuses into the `plugin-computeruse` scene-description prompt — this adds a *generic* `IMAGE_DESCRIPTION` model-handler seam that any caller benefits from. Verified absent on develop (`git grep VisionContextAugmenter origin/develop` → nothing).

The rest of that branch (on-device Android YOLO/face via bionic JNI; OmniVoice→TtsBackend voice refactors) is intentionally **not** included here — the Android slice is device-gated and the voice refactor is a stale-revert trap against develop's live voice path. Those are flagged separately for a human call.

## Evidence

Cherry-picked cleanly onto current develop (auto-merged `provider.ts` + `index.ts`, zero conflicts).

- **16/16 unit tests pass** off a fresh worktree on current develop:
  - `plugin-local-inference` `augmenter.test.ts` — 5 passed (handler consumption)
  - `plugin-vision` `vision-context-augmenter.test.ts` — 11 passed (8 fusion + 3 photo-OCR noise filter)
- **Typecheck clean**: `tsc --noEmit` on both `plugin-local-inference` and `plugin-vision` → 0 errors.
- Original-author end-to-end notes (on the source branch): real tesseract OCR (`ELIZAOCRTEST 1234`) → augmenter fusion → Gemma-4 E2B grounded its answer in the OCR'd text; real YOLO (`yolov8n.gguf`, bus.jpg: 4 person + bus) verified on Linux CPU and RTX 5080 CUDA.

Refs #9105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
