### PR TITLE
feat(computeruse): ffmpeg x11grab screenshot fallback for X11 hosts (#9105)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
@@ -70,6 +70,19 @@ describe("cross-platform computer-use capabilities", () => {
     });
   });
 
+  it("falls back to ffmpeg x11grab for screenshots when no dedicated tool is present (#9105)", () => {
+    const caps = detectFor("linux", ["ffmpeg"]);
+    expect(caps.screenshot).toMatchObject({
+      available: true,
+      tool: "ffmpeg x11grab",
+    });
+  });
+
+  it("reports no screenshot tool when none of import/scrot/gnome/ffmpeg exist", () => {
+    const caps = detectFor("linux", []);
+    expect(caps.screenshot.available).toBe(false);
+  });
+
   it("reports Windows desktop control through built-in PowerShell capabilities", () => {
     const caps = detectFor("win32", [], false);
 
@@ -98,7 +111,7 @@ describe("cross-platform computer-use capabilities", () => {
 
     expect(caps.screenshot).toMatchObject({
       available: false,
-      tool: "none (install ImageMagick, scrot, or gnome-screenshot)",
+      tool: "none (install ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
     });
     expect(caps.computerUse).toMatchObject({
       available: false,

--- a/plugins/plugin-computeruse/src/platform/capabilities.ts
+++ b/plugins/plugin-computeruse/src/platform/capabilities.ts
@@ -122,10 +122,12 @@ export function detectPlatformCapabilities(
       caps.screenshot = { available: true, tool: "scrot" };
     } else if (options.commandExists("gnome-screenshot")) {
       caps.screenshot = { available: true, tool: "gnome-screenshot" };
+    } else if (options.commandExists("ffmpeg")) {
+      caps.screenshot = { available: true, tool: "ffmpeg x11grab" };
     } else {
       caps.screenshot = {
         available: false,
-        tool: "none (install ImageMagick, scrot, or gnome-screenshot)",
+        tool: "none (install ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
       };
     }
 

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -216,10 +216,32 @@ function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
     runCommandBuffer("gnome-screenshot", ["-f", tmpFile], 10000);
     return;
   }
+  if (commandExists("ffmpeg")) {
+    const displayEnv = process.env.DISPLAY || ":0";
+    runCommandBuffer(
+      "ffmpeg",
+      [
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "x11grab",
+        "-video_size",
+        `${w}x${h}`,
+        "-i",
+        `${displayEnv}+${x},${y}`,
+        "-frames:v",
+        "1",
+        tmpFile,
+      ],
+      10000,
+    );
+    return;
+  }
   throw new Error(
     isWaylandSession()
-      ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, or gnome-screenshot for X11 fallback."
-      : "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
+      ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
+      : "No screenshot tool available. Install ImageMagick (import), scrot, gnome-screenshot, or ffmpeg.",
   );
 }
 
@@ -244,6 +266,28 @@ function captureRegionLinux(tmpFile: string, region: ScreenRegion): void {
       [
         "-a",
         `${region.x},${region.y},${region.width},${region.height}`,
+        tmpFile,
+      ],
+      10000,
+    );
+    return;
+  }
+  if (commandExists("ffmpeg")) {
+    const display = process.env.DISPLAY || ":0";
+    runCommandBuffer(
+      "ffmpeg",
+      [
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "x11grab",
+        "-video_size",
+        `${region.width}x${region.height}`,
+        "-i",
+        `${display}+${region.x},${region.y}`,
+        "-frames:v",
+        "1",
         tmpFile,
       ],
       10000,

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -143,11 +143,37 @@ function captureLinux(tmpFile: string, region?: ScreenRegion): void {
     runCommandBuffer("scrot", [tmpFile], 10000);
   } else if (commandExists("gnome-screenshot")) {
     runCommandBuffer("gnome-screenshot", ["-f", tmpFile], 10000);
+  } else if (commandExists("ffmpeg")) {
+    // x11grab fallback for X11 hosts that ship ffmpeg but none of the dedicated
+    // screenshot tools (common on dev/server boxes). Writes a single PNG frame.
+    const display = process.env.DISPLAY || ":0";
+    const size = region
+      ? `${region.width}x${region.height}`
+      : detectX11ScreenSize();
+    const input = region ? `${display}+${region.x},${region.y}` : display;
+    runCommandBuffer(
+      "ffmpeg",
+      [
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "x11grab",
+        "-video_size",
+        size,
+        "-i",
+        input,
+        "-frames:v",
+        "1",
+        tmpFile,
+      ],
+      10000,
+    );
   } else {
     throw new Error(
       isWaylandSession()
-        ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, or gnome-screenshot for X11 fallback."
-        : "No screenshot tool available. Install ImageMagick (import), scrot, or gnome-screenshot.",
+        ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
+        : "No screenshot tool available. Install ImageMagick (import), scrot, gnome-screenshot, or ffmpeg.",
     );
   }
 }
@@ -161,6 +187,18 @@ function tryCaptureWaylandPortal(tmpFile: string): boolean {
     if (isPermissionDeniedError(error)) throw error;
     return false;
   }
+}
+
+/** Full X11 screen size ("WxH") from xdpyinfo; a sane default if unavailable. */
+function detectX11ScreenSize(): string {
+  try {
+    const out = execSync("xdpyinfo", { encoding: "utf8", timeout: 5000 });
+    const m = out.match(/dimensions:\s+(\d+)x(\d+)/);
+    if (m) return `${m[1]}x${m[2]}`;
+  } catch {
+    // fall through to the default below
+  }
+  return "1920x1080";
 }
 
 // ── Windows ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds **ffmpeg `x11grab`** as the final Linux screenshot fallback in all three computeruse capture paths (`screenshot.ts` `captureLinux`, `capture.ts` `captureDisplayLinux` + `captureRegionLinux`), with `xdpyinfo`-derived full-screen size, and surfaces it in the capability detector (`"ffmpeg x11grab"`).

`GET_SCREEN` previously failed on X11 hosts that ship ffmpeg but none of `import` / `scrot` / `gnome-screenshot` — common on dev/server boxes. ffmpeg is tried *after* the dedicated tools, so existing setups are unaffected.

## Why this slice

Salvaged from the stale, no-PR `feat/9105-tesseract-ship` branch (913 commits behind develop). This is the small, self-contained, independently-useful half. The other half of that branch — the on-device **Android Tesseract OCR stack** — ships ~11 MB of vendored `.so`/`.jar`/`.traineddata` binaries into git and is gated on a physical Pixel device, so it's a separate binary-policy + device decision and is **not** included here.

## Conflict resolution (vs develop)

develop added Wayland-portal screenshot support (`tryCaptureWaylandPortal`, `isWaylandSession()`-aware error messages) in the same regions. Resolved by **keeping all of develop's Wayland work intact** and only:
- appending `ffmpeg` to the "no tool available" guidance (both the Wayland and X11 branches),
- keeping both helper functions (`tryCaptureWaylandPortal` *and* the new `detectX11ScreenSize`).

The Wayland portal remains the first thing tried in `captureLinux`; ffmpeg is strictly an added X11 fallback.

## Evidence

- Cherry-picked onto current develop, 2 conflicts resolved as above; **no Wayland behavior dropped**.
- **10/10** `platform-capabilities.test.ts` pass off a fresh worktree on current develop (includes the +2 new x11grab capability tests).
- **Typecheck clean**: `tsc --noEmit` on `plugin-computeruse` → 0 errors.
- Original-author note (source branch): verified on a headful X11 host (`DISPLAY=:0`, 2560x1600) — ffmpeg captured the live desktop → bundled tesseract OCR'd 151 real text blocks with coords.

Refs #9105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
