### PR TITLE
refactor(core): drop redundant `as unknown as` in two @elizaos/core casts (#9474)

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -962,7 +962,7 @@ const connectorMessageReceivedEvents = Object.fromEntries(
 			},
 		],
 	]),
-) as unknown as PluginEvents;
+) as PluginEvents;
 
 const events: PluginEvents = {
 	...connectorMessageReceivedEvents,

--- a/packages/core/src/services/agent-event-bridge.ts
+++ b/packages/core/src/services/agent-event-bridge.ts
@@ -129,7 +129,7 @@ function resolveNotificationService(
 ): NotificationServiceLike | null {
 	try {
 		const service = runtime.getService(ServiceType.NOTIFICATION);
-		const candidate = service as unknown as Partial<NotificationServiceLike>;
+		const candidate = service as Partial<NotificationServiceLike>;
 		if (candidate && typeof candidate.notify === "function") {
 			return candidate as NotificationServiceLike;
 		}


### PR DESCRIPTION
Part of #9474 (strict-TypeScript: eliminate `as unknown as`).

Two casts in `@elizaos/core` had an unnecessary `unknown` step:

- `packages/core/src/services/agent-event-bridge.ts`: `service as unknown as Partial<NotificationServiceLike>` → `service as Partial<NotificationServiceLike>`. The sibling `resolveAgentEventService` 6 lines up already uses a plain `service as AgentEventService`; `Service` overlaps `Partial<NotificationServiceLike>` so the intermediate `unknown` was dead.
- `packages/core/src/features/basic-capabilities/index.ts`: `Object.fromEntries(...) as unknown as PluginEvents` → `... as PluginEvents`. The `Object.fromEntries` result overlaps `PluginEvents`, so plain `as` compiles.

No semantic change, no fake precision — purely removes a redundant widening step.

**Verification:** `tsgo --noEmit` on `@elizaos/core` is byte-identical before/after (48 pre-existing standalone-typecheck errors, all module-resolution noise; error sets diff to empty; no error references either changed file). `as unknown as` count in core drops by 2.

This only helps the type-safety ratchet (`asUnknownAs` count goes down).