### PR TITLE
perf(build): finish DTS emit-only sweep — plugin-nearai + plugin-zai (#9626)

### DIFF
--- a/plugins/plugin-nearai/build.ts
+++ b/plugins/plugin-nearai/build.ts
@@ -79,7 +79,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   await writeFile(
     join(distDir, "index.d.ts"),

--- a/plugins/plugin-zai/build.ts
+++ b/plugins/plugin-zai/build.ts
@@ -79,7 +79,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`;
+  await $`tsc --project tsconfig.build.json --noCheck`;
 
   await writeFile(
     join(distDir, "index.d.ts"),


### PR DESCRIPTION
Finishes the DTS emit-only sweep started in #9708.

#9708 converted 22 plugins on the uniform `tsc --project tsconfig.build.json` build step to `--noCheck` (emit-only DTS; the separate `typecheck` task remains the type-error gate, so DTS generation stops doing a full redundant re-check on top of `tsgo`). It deliberately deferred **plugin-nearai** and **plugin-zai** because their emitted DTS could not be byte-verified locally at the time.

This PR converts those two. Both:
- use the **identical** uniform invocation #9708 converted (`tsc --project tsconfig.build.json`), and
- keep a real `tsgo --noEmit -p tsconfig.json` `typecheck` script — so the error gate is fully preserved; `--noCheck` only stops `build` from re-checking what `typecheck` already checks.

### Verification (audit requirement: byte-verify per package)
Ran each plugin's **real `build.ts`** with and without `--noCheck` and `diff -r` the **full emitted `dist` tree**:

| plugin | with-check | --noCheck | dist diff |
|---|---|---|---|
| plugin-nearai | exit 0, 4 `.d.ts` | exit 0, 4 `.d.ts` | **byte-identical** |
| plugin-zai | exit 0, 4 `.d.ts` | exit 0, 4 `.d.ts` | **byte-identical** |

`turbo run build --filter=@elizaos/plugin-nearai --filter=@elizaos/plugin-zai --dry-run=json` resolves both `#build` tasks cleanly (outputs `dist/**`). Build re-run after the edit succeeds and emits the same 4 `.d.ts` each.

### Not touched
- **plugin-vision** stays full-check on purpose: its `typecheck` is a no-op `echo "Typecheck skipped for release"`, so `--noCheck` there would remove its only type-check (a #9474-class regression). #9708 excluded it for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)