### PR TITLE
fix(plugin-personal-assistant): wire real typecheck + fix the strict-null bug it surfaced (#9474)

### DIFF
--- a/plugins/plugin-personal-assistant/package.json
+++ b/plugins/plugin-personal-assistant/package.json
@@ -56,7 +56,8 @@
     "build": "bun run build:js && bun run build:types",
     "clean": "rm -rf dist",
     "build:js": "bun run clean && tsup --config tsup.config.ts",
-    "build:types": "tsc --noCheck -p tsconfig.build.json"
+    "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "dependencies": {
     "@capacitor/core": "8.4.0",

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -154,7 +154,7 @@ function defaultOwnerFactsProvider(
       if (typeof sampleCount === "number" && Number.isFinite(sampleCount)) {
         view.personalBaseline = {
           sampleCount,
-          windowDays: effective.baseline?.windowDays,
+          windowDays: effective?.baseline?.windowDays,
         };
       }
     } catch (error) {


### PR DESCRIPTION
Closes the **last `--noCheck`-only-with-no-typecheck package** in #9474 Phase 3.

## What
`plugin-personal-assistant` ran `build:types` as `tsc --noCheck` with **no `typecheck` script** — its source was type-checked nowhere in CI. Adding the real check surfaced one genuine strictNullChecks error it had been hiding:

`src/lifeops/scheduled-task/runtime-wiring.ts:157` read `effective.baseline?.windowDays`, but `effective: LifeOpsScheduleMergedState | null` (from `preferEffectiveMergedState`) is not narrowed by the preceding `sampleCount` check → **TS18047 `'effective' is possibly 'null'`**. Optional-chained to `effective?.baseline?.windowDays` (behavior-identical), then wired `typecheck: "tsc --noEmit -p tsconfig.build.json"`.

## Evidence
Verified with a real **`turbo run typecheck --filter=@elizaos/plugin-personal-assistant`** (full `^build` of all deps, on develop's exact source incl. the `@elizaos/plugin-health/sleep/source-reliability` subpath import):

```
@elizaos/plugin-personal-assistant:typecheck: $ tsc --noEmit -p tsconfig.build.json
 Tasks:    73 successful, 73 total
```

0 errors. (Note: this required a consistent fresh `^build` — readings taken against churning/partial dist were false-zeros from broken program construction; with fresh dist the result is deterministically 0 after the line-157 fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)