### PR TITLE
perf(turbo): key generic build task on shared cross-package build configs (#9626)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,10 @@
         "tsconfig.*.json",
         "package.json",
         "assets/**",
-        "public/**"
+        "public/**",
+        "$TURBO_ROOT$/plugins/tsup.plugin-packages.shared.ts",
+        "$TURBO_ROOT$/packages/scripts/view-bundle-vite.config.ts",
+        "$TURBO_ROOT$/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs"
       ]
     },
     "@elizaos-benchmarks/lib#build": {


### PR DESCRIPTION
Closes another under-keyed-`inputs` gap from the #9626 audit (TL;DR #1), same class as #9654.

### The gap
The generic `build` task's `inputs` only listed **package-local** files. But three **shared** build-config files live *outside* any package, are imported by many packages' build configs, and were in **no** Turbo cache key. Editing one and rebuilding replayed **stale cached output**:

| shared file | imported by | affects |
|---|---|---|
| `plugins/tsup.plugin-packages.shared.ts` | every app-plugin `tsup.config.ts` (~20) | their `dist/**` |
| `packages/scripts/view-bundle-vite.config.ts` | all 31 `vite.config.views.ts` | every `dist/views` bundle |
| `packages/scripts/rewrite-dist-relative-imports-node-esm.mjs` | build.ts DTS post-processing | NodeNext `.d.ts` rewrite |

`packages/scripts/` is **not** a workspace package (no `package.json`), so it is covered by neither `^build` nor any package's local `inputs`.

### Fix
Add the three files to the generic `build` task `inputs` using the `$TURBO_ROOT$/` convention **already established on `@elizaos/core#build`**. Scoping to the `build` task is strictly tighter than `globalDependencies` (which would also bust lint/test/format on these edits).

`inputs`-only change — **no build logic touched**, so output is unchanged; only cache invalidation widened to cover a previously-missed correctness gap. `globalDependencies`-style additions can only ever *add* invalidation, never serve stale cache.

### Verification
- `turbo run build --dry-run=json` over the whole graph: **all 263 build tasks resolve**; the 3 shared files appear as tracked inputs on every plugin `#build` (e.g. `../../packages/scripts/view-bundle-vite.config.ts`).
- **Hash proof:** companion `#build` hash is stable, **changes** when `view-bundle-vite.config.ts` is edited, and **reverts** to the original hash on revert. Same proven for `tsup.plugin-packages.shared.ts` → `@elizaos/plugin-calendar#build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)