### PR TITLE
refactor(cloud-api): single domainField schema for /apps/:id/domains/*

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/buy/route.ts
@@ -14,7 +14,6 @@
 
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { z } from "zod";
 import { dbRead, dbWrite } from "@/db/client";
 import { domainPurchaseIdempotency } from "@/db/schemas/domain-purchase-idempotency";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -39,18 +38,7 @@ import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
-
-const BuySchema = z.object({
-  domain: z
-    .string()
-    .min(4)
-    .max(253)
-    .regex(
-      /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i,
-      "Invalid domain format",
-    )
-    .transform((d) => d.toLowerCase().trim()),
-});
+import { domainBodySchema as BuySchema } from "../schemas";
 
 /**
  * Idempotency claim lifetime. A claim that never reaches `completed` within this

--- a/packages/cloud-api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/check/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
@@ -14,18 +13,7 @@ import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar"
 import { computeDomainPrice } from "@/lib/services/domain-pricing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
-
-const CheckSchema = z.object({
-  domain: z
-    .string()
-    .min(4)
-    .max(253)
-    .regex(
-      /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i,
-      "Invalid domain format",
-    )
-    .transform((d) => d.toLowerCase().trim()),
-});
+import { domainBodySchema as CheckSchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 

--- a/packages/cloud-api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/route.ts
@@ -10,7 +10,6 @@
 
 import crypto from "node:crypto";
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
@@ -19,18 +18,7 @@ import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-
-const DomainSchema = z.object({
-  domain: z
-    .string()
-    .min(4)
-    .max(253)
-    .regex(
-      /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i,
-      "Invalid domain format",
-    )
-    .transform((d) => d.toLowerCase().trim()),
-});
+import { domainBodySchema as DomainSchema } from "./schemas";
 
 const app = new Hono<AppEnv>();
 

--- a/packages/cloud-api/v1/apps/[id]/domains/schemas.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * Canonical domain-name field shared by every `/apps/:id/domains/*` route.
+ *
+ * One definition keeps the acceptance criteria identical across attach, buy,
+ * check, status and verify: bounded length, hostname format, and a
+ * lowercase/trim normalization applied before the value reaches a service.
+ */
+export const domainField = z
+  .string()
+  .min(4)
+  .max(253)
+  .regex(/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i, "Invalid domain format")
+  .transform((d) => d.toLowerCase().trim());
+
+export const domainBodySchema = z.object({ domain: domainField });

--- a/packages/cloud-api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/status/route.ts
@@ -6,21 +6,13 @@
  */
 
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import type { AppEnv } from "@/types/cloud-worker-env";
-
-const StatusSchema = z.object({
-  domain: z
-    .string()
-    .min(4)
-    .max(253)
-    .transform((d) => d.toLowerCase().trim()),
-});
+import { domainBodySchema as StatusSchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 

--- a/packages/cloud-api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/domains/verify/route.ts
@@ -11,7 +11,6 @@
 
 import { promises as dns } from "node:dns";
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
@@ -19,14 +18,7 @@ import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
-
-const VerifySchema = z.object({
-  domain: z
-    .string()
-    .min(4)
-    .max(253)
-    .transform((d) => d.toLowerCase().trim()),
-});
+import { domainBodySchema as VerifySchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 


### PR DESCRIPTION
## What

The domain-name field validation was copy-pasted across five sibling routes under `v1/apps/[id]/domains/` (attach `route.ts`, `buy`, `check`, `status`, `verify`). This consolidates them onto one canonical `domainField` / `domainBodySchema` colocated in `domains/schemas.ts`, matching the existing `v1/api-keys/schemas.ts` pattern.

## Why this is more than dedup

`attach`/`buy`/`check` enforced the hostname regex `/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i`; `status`/`verify` silently dropped it (`.min(4).max(253).transform(...)` only). So the same `domain` field on the same app had **two different acceptance criteria** — status/verify accepted malformed domains the other three rejected. That is the single-source-of-truth / dual-validation-path anti-pattern called out in the cleanup mandate.

Routing all five through one schema fixes the divergence (status/verify gain the regex guard) as a free side effect of dedup. No behavior change for valid input.

## Change

- New `packages/cloud-api/v1/apps/[id]/domains/schemas.ts` exporting `domainField` + `domainBodySchema`.
- All five routes import it (aliased to their existing local name so call sites are untouched), drop the inline `z.object({...})` and the now-unused `z` import.
- Net **-35 lines** (22 ins / 57 del).

## Verification

- `tsgo --noEmit` on `@elizaos/cloud-api`: **1 error before, 1 error after** — the single error is the pre-existing `@cloudflare/workers-types` type-lib env artifact (unrelated, present on clean `develop`). Zero new errors reference this change.
- No tests reference these schemas/routes (grep-confirmed), so the status/verify tightening breaks nothing.
- Base-drift guard: zero changes to the `domains/` directory on `develop` between branch base and tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)