### PR TITLE
perf(build): DTS emit-only (--noCheck) for 8 more plugins (#9626)

### DIFF
--- a/plugins/plugin-device-filesystem/build.ts
+++ b/plugins/plugin-device-filesystem/build.ts
@@ -25,7 +25,14 @@ await build({
 console.log("Build complete.");
 
 const proc = Bun.spawn(
-	["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly"],
+	[
+		"bunx",
+		"tsc",
+		"-p",
+		"tsconfig.build.json",
+		"--emitDeclarationOnly",
+		"--noCheck",
+	],
 	{
 		cwd: import.meta.dir,
 		stdio: ["inherit", "inherit", "inherit"],

--- a/plugins/plugin-instagram/build.ts
+++ b/plugins/plugin-instagram/build.ts
@@ -11,7 +11,7 @@ await build({
 });
 
 // Generate type declarations
-const proc = Bun.spawn(["tsc", "--emitDeclarationOnly", "-p", "tsconfig.build.json"], {
+const proc = Bun.spawn(["tsc", "--emitDeclarationOnly", "--noCheck", "-p", "tsconfig.build.json"], {
   stdout: "inherit",
   stderr: "inherit",
 });

--- a/plugins/plugin-matrix/build.ts
+++ b/plugins/plugin-matrix/build.ts
@@ -12,6 +12,6 @@ await build({
 // Also emit declarations with tsc
 import { spawnSync } from "node:child_process";
 
-spawnSync("bunx", ["tsc", "--emitDeclarationOnly"], { stdio: "inherit" });
+spawnSync("bunx", ["tsc", "--emitDeclarationOnly", "--noCheck"], { stdio: "inherit" });
 
 console.log("Build complete");

--- a/plugins/plugin-remote-desktop/build.ts
+++ b/plugins/plugin-remote-desktop/build.ts
@@ -32,7 +32,14 @@ if (!result.success) {
 console.log("Build complete.");
 
 const proc = Bun.spawn(
-  ["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly"],
+  [
+    "bunx",
+    "tsc",
+    "-p",
+    "tsconfig.build.json",
+    "--emitDeclarationOnly",
+    "--noCheck",
+  ],
   {
     cwd: import.meta.dir,
     stdio: ["inherit", "inherit", "inherit"],

--- a/plugins/plugin-shell/build.ts
+++ b/plugins/plugin-shell/build.ts
@@ -24,10 +24,13 @@ await build({
 
 console.log("Build complete!");
 
-const proc = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly"], {
-  cwd: import.meta.dir,
-  stdio: ["inherit", "inherit", "inherit"],
-});
+const proc = Bun.spawn(
+  ["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly", "--noCheck"],
+  {
+    cwd: import.meta.dir,
+    stdio: ["inherit", "inherit", "inherit"],
+  }
+);
 
 const exitCode = await proc.exited;
 

--- a/plugins/plugin-slack/build.ts
+++ b/plugins/plugin-slack/build.ts
@@ -13,7 +13,14 @@ await build({
 
 // Generate type declarations
 const proc = Bun.spawn(
-  ["bunx", "tsc", "--emitDeclarationOnly", "--declaration", "--declarationMap"],
+  [
+    "bunx",
+    "tsc",
+    "--emitDeclarationOnly",
+    "--noCheck",
+    "--declaration",
+    "--declarationMap",
+  ],
   {
     cwd: import.meta.dir,
     stdout: "inherit",

--- a/plugins/plugin-todos/build.ts
+++ b/plugins/plugin-todos/build.ts
@@ -25,7 +25,14 @@ await build({
 console.log("Build complete.");
 
 const proc = Bun.spawn(
-  ["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly"],
+  [
+    "bunx",
+    "tsc",
+    "-p",
+    "tsconfig.build.json",
+    "--emitDeclarationOnly",
+    "--noCheck",
+  ],
   {
     cwd: import.meta.dir,
     stdio: ["inherit", "inherit", "inherit"],

--- a/plugins/plugin-twitch/build.ts
+++ b/plugins/plugin-twitch/build.ts
@@ -12,6 +12,8 @@ await build({
 // Also emit declarations with tsc
 import { spawnSync } from "node:child_process";
 
-spawnSync("bunx", ["tsc", "--emitDeclarationOnly"], { stdio: "inherit" });
+spawnSync("bunx", ["tsc", "--emitDeclarationOnly", "--noCheck"], {
+  stdio: "inherit",
+});
 
 console.log("Build complete");


### PR DESCRIPTION
Second verified batch of the DTS emit-only sweep (#9626 TL;DR #3), after #9708.

Adds `--noCheck` to the declaration step of 8 plugins using the array / `Bun.spawn` / `spawnSync` `tsc … --emitDeclarationOnly` form, each with a separate `typecheck` script (error gate preserved):
`plugin-device-filesystem`, `plugin-instagram`, `plugin-matrix`, `plugin-remote-desktop`, `plugin-shell`, `plugin-slack`, `plugin-todos`, `plugin-twitch`.

**Each byte-verified**: full-check vs `--noCheck` emit byte-identical `.d.ts` (sha of the full tree). `plugin-coding-tools` was a candidate but `--noCheck` reorders an inferred member (functionally equal, not byte-identical) → **excluded**, same handling as `plugin-vision` in #9708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)