### PR TITLE
Add @xynqai/plugin-eliza to community registry

### DIFF
--- a/packages/registry/entries/third-party/xynqai__plugin-eliza.json
+++ b/packages/registry/entries/third-party/xynqai__plugin-eliza.json
@@ -1,0 +1,10 @@
+{
+  "package": "@xynqai/plugin-eliza",
+  "repository": "github:visionsXBT/xynq",
+  "kind": "plugin",
+  "description": "XYNQ decentralized inference for ElizaOS — OpenAI-compatible models, live GPU mesh status, USDC worker earnings, and Solana credit top-ups.",
+  "homepage": "https://github.com/visionsXBT/xynq/tree/main/plugin-eliza",
+  "version": "0.1.1",
+  "directory": "plugin-eliza",
+  "tags": ["llm", "inference", "decentralized", "solana", "gpu", "crypto", "usdc"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -373,6 +373,53 @@
       "registryKind": "plugin",
       "directory": "packages/eliza-rollout-plugin"
     },
+    "@xynqai/plugin-eliza": {
+      "git": {
+        "repo": "visionsXBT/xynq",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@xynqai/plugin-eliza",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "XYNQ decentralized inference for ElizaOS — OpenAI-compatible models, live GPU mesh status, USDC worker earnings, and Solana credit top-ups.",
+      "homepage": "https://github.com/visionsXBT/xynq/tree/main/plugin-eliza",
+      "topics": [
+        "llm",
+        "inference",
+        "decentralized",
+        "solana",
+        "gpu",
+        "crypto",
+        "usdc"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "plugin-eliza"
+    },
     "blackwall-eliza-guardrail": {
       "git": {
         "repo": "bluetieroperations-create/blackwall-eliza-guardrail",


### PR DESCRIPTION
List XYNQ decentralized inference plugin for ElizaOS discoverability.

## Summary
- Adds `@xynqai/plugin-eliza` to the community plugin registry
- Regenerates `generated-registry.json`
## Plugin
- npm: `@xynqai/plugin-eliza@0.1.1`
- repo: https://github.com/visionsXBT/xynq/tree/main/plugin-eliza
- XYNQ decentralized inference — OpenAI-compatible models, live GPU mesh status, USDC worker earnings, Solana credit top-ups
## Test plan
- [x] `validate` passes (16 third-party entries)
- [x] `generate` updated `generated-registry.json`
