### PR TITLE
perf(build): DTS emit-only (--noCheck) for 4 more plugins (#9626)

### DIFF
--- a/plugins/plugin-discord-local/build.ts
+++ b/plugins/plugin-discord-local/build.ts
@@ -52,7 +52,7 @@ if (!result.success) {
 
 // Emit real declaration files via tsc
 try {
-  execSync("bunx tsc -p tsconfig.build.json", { stdio: "inherit" });
+  execSync("bunx tsc -p tsconfig.build.json --noCheck", { stdio: "inherit" });
 } catch {
   // Non-fatal — plugin works at runtime without .d.ts files
   console.warn("[plugin-discord-local] tsc declaration emit failed (non-fatal)");

--- a/plugins/plugin-elevenlabs/build.ts
+++ b/plugins/plugin-elevenlabs/build.ts
@@ -88,10 +88,14 @@ async function build() {
   // TypeScript declarations
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
-  const tsc = spawnSync("bunx", ["tsc", "--project", "tsconfig.build.json"], {
-    stdio: "inherit",
-    shell: false,
-  });
+  const tsc = spawnSync(
+    "bunx",
+    ["tsc", "--project", "tsconfig.build.json", "--noCheck"],
+    {
+      stdio: "inherit",
+      shell: false,
+    },
+  );
   if (tsc.status !== 0) {
     throw new Error("TypeScript declaration emit failed");
   }

--- a/plugins/plugin-linear/build.ts
+++ b/plugins/plugin-linear/build.ts
@@ -40,7 +40,7 @@ async function buildPlugin() {
   console.log(`✅ Built ${buildResult.outputs.length} file(s)`);
 
   console.log("📝 Generating type declarations...");
-  const tscProcess = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json"], {
+  const tscProcess = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"], {
     stdout: "inherit",
     stderr: "inherit",
   });

--- a/plugins/plugin-tee/build.ts
+++ b/plugins/plugin-tee/build.ts
@@ -54,10 +54,13 @@ async function buildPlugin() {
 
   console.log(`Built ${buildResult.outputs.length} file(s)`);
 
-  const tscProcess = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json"], {
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+  const tscProcess = Bun.spawn(
+    ["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"],
+    {
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
   await tscProcess.exited;
 
   if (tscProcess.exitCode !== 0) {


### PR DESCRIPTION
Third verified batch of the DTS emit-only sweep (#9626 TL;DR #3), after #9708 + #9719.

`--noCheck` on the declaration step of `plugin-discord-local`, `plugin-elevenlabs`, `plugin-linear`, `plugin-tee` — each with a separate `typecheck` script (error gate preserved) and **byte-verified** (full-check vs `--noCheck` → byte-identical `.d.ts`).

With this, **all safely-convertible plugin `build.ts` are emit-only** (34 plugins across the 3 batches). Remaining full-check `build.ts` are intentionally left:
- `@elizaos/core` — sensitive foundation build;
- the `elizaos`/`examples` scaffold templates — must not depend on the tsgo preview;
- `plugin-coding-tools` + `plugin-vision` — `--noCheck` reorders an inferred member (not byte-identical);
- `plugin-inmemorydb` — tsc is behind a `generateDts()` helper;
- `cloud-sdk` — `tsconfig.json --noEmit false` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)