### PR TITLE
fix(core): preserve model lookup attribution for installed packages

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4641,7 +4641,9 @@ export class AgentRuntime implements IAgentRuntime {
 		params: ModelParamsMap[T],
 		provider?: string,
 	): Promise<R> {
-		const lookupCaller = captureModelLookupCaller(this.logger.level);
+		const lookupCaller = RUNTIME_DEBUG_LOG_ENABLED
+			? captureModelLookupCaller()
+			: undefined;
 		// Per-action model routing seam (closes A5 / W1-R2). If the call
 		// originates inside an action handler that declared a `modelClass`, and
 		// the requested model type is a text-generation model, we resolve

--- a/packages/core/src/utils/model-lookup-caller.test.ts
+++ b/packages/core/src/utils/model-lookup-caller.test.ts
@@ -1,42 +1,64 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { captureModelLookupCaller } from "./model-lookup-caller.js";
+import { describe, expect, it } from "vitest";
+import {
+	captureModelLookupCaller,
+	captureModelLookupCallerFromStack,
+} from "./model-lookup-caller.js";
 
-function probeLookupCaller(
-	logLevel: string | undefined,
-): ReturnType<typeof captureModelLookupCaller> {
-	return captureModelLookupCaller(logLevel);
+function probeLookupCaller(): ReturnType<typeof captureModelLookupCaller> {
+	return captureModelLookupCaller();
 }
 
-function nestedLookupCaller(
-	logLevel: string | undefined,
-): ReturnType<typeof captureModelLookupCaller> {
-	return probeLookupCaller(logLevel);
+function nestedLookupCaller(): ReturnType<typeof captureModelLookupCaller> {
+	return probeLookupCaller();
 }
 
 describe("captureModelLookupCaller", () => {
-	const previousLogLevel = process.env.LOG_LEVEL;
-
-	afterEach(() => {
-		if (previousLogLevel === undefined) {
-			delete process.env.LOG_LEVEL;
-		} else {
-			process.env.LOG_LEVEL = previousLogLevel;
-		}
-	});
-
-	it("returns undefined when the runtime log level is above debug", () => {
-		process.env.LOG_LEVEL = "debug";
-		expect(probeLookupCaller("info")).toBeUndefined();
-	});
-
-	it("returns package names when the runtime log level is debug", () => {
-		delete process.env.LOG_LEVEL;
-		const trace = nestedLookupCaller("debug");
+	it("returns package names when capturing the current stack", () => {
+		const trace = nestedLookupCaller();
 		expect(trace).toBeDefined();
 		expect(trace?.caller).toBe("core");
 		expect(trace?.callerStack).toEqual(["core"]);
 		expect(trace?.callerStack.every((entry) => !entry.includes("/"))).toBe(
 			true,
 		);
+	});
+
+	it("keeps installed elizaOS package attribution under node_modules", () => {
+		const stack = [
+			"Error: model lookup",
+			"    at captureModelLookupCaller (/app/node_modules/@elizaos/core/dist/utils/model-lookup-caller.js:70:12)",
+			"    at AgentRuntime.useModel (/app/node_modules/@elizaos/core/dist/runtime.js:4644:24)",
+			"    at textHandler (/app/node_modules/@elizaos/plugin-openai/dist/models/text.js:42:18)",
+		].join("\n");
+
+		expect(captureModelLookupCallerFromStack(stack)).toEqual({
+			caller: "plugin-openai",
+			callerStack: ["plugin-openai"],
+		});
+	});
+
+	it("keeps installed elizaOS package attribution under pnpm virtual store paths", () => {
+		const stack = [
+			"Error: model lookup",
+			"    at captureModelLookupCaller (/app/node_modules/.pnpm/@elizaos+core@1.5.0/node_modules/@elizaos/core/dist/utils/model-lookup-caller.js:70:12)",
+			"    at AgentRuntime.useModel (/app/node_modules/.pnpm/@elizaos+core@1.5.0/node_modules/@elizaos/core/dist/runtime.js:4644:24)",
+			"    at route (/app/node_modules/.pnpm/@elizaos+plugin-groq@1.5.0/node_modules/@elizaos/plugin-groq/dist/models/text.js:28:11)",
+		].join("\n");
+
+		expect(captureModelLookupCallerFromStack(stack)).toEqual({
+			caller: "plugin-groq",
+			callerStack: ["plugin-groq"],
+		});
+	});
+
+	it("continues to ignore third-party node_modules frames", () => {
+		const stack = [
+			"Error: model lookup",
+			"    at captureModelLookupCaller (/app/node_modules/@elizaos/core/dist/utils/model-lookup-caller.js:70:12)",
+			"    at AgentRuntime.useModel (/app/node_modules/@elizaos/core/dist/runtime.js:4644:24)",
+			"    at callProvider (/app/node_modules/some-sdk/dist/index.js:11:9)",
+		].join("\n");
+
+		expect(captureModelLookupCallerFromStack(stack)).toBeUndefined();
 	});
 });

--- a/packages/core/src/utils/model-lookup-caller.ts
+++ b/packages/core/src/utils/model-lookup-caller.ts
@@ -1,6 +1,3 @@
-/** Log levels at or below debug, matching @elizaos/logger filtering. */
-const DEBUG_OR_TRACE_LEVELS = new Set(["trace", "verbose", "debug"]);
-
 export type ModelLookupCallerTrace = {
 	/** Outermost plugin or package that triggered the lookup. */
 	caller?: string;
@@ -9,14 +6,10 @@ export type ModelLookupCallerTrace = {
 };
 
 const INTERNAL_FRAME_RE =
-	/model-lookup-caller\.(?:ts|js)(?::|$)|(?:^|[/\\])runtime\.(?:ts|js)|(?:^|[/\\])getModel|(?:^|[/\\])useModel|resolveModelRegistration|node:internal|node_modules|@vitest\/|vitest\/|\/bun:/;
+	/model-lookup-caller\.(?:ts|js)(?::|$)|(?:^|[/\\])runtime\.(?:ts|js)|(?:^|[/\\])getModel|(?:^|[/\\])useModel|resolveModelRegistration|node:internal|@vitest\/|vitest\/|\/bun:/;
 
 const STACK_FRAME_WITH_FN_RE = /^(?:async )?(.+?) \((.+?):(\d+):(\d+)\)$/;
 const STACK_FRAME_FILE_ONLY_RE = /^(.+?):(\d+):(\d+)$/;
-
-function isDebugOrTraceLogLevel(logLevel: string | undefined): boolean {
-	return DEBUG_OR_TRACE_LEVELS.has(String(logLevel ?? "info").toLowerCase());
-}
 
 function parseFrameOrigin(line: string): string | null {
 	const trimmed = line.trim();
@@ -35,6 +28,16 @@ function parseFrameOrigin(line: string): string | null {
 
 	if (INTERNAL_FRAME_RE.test(framePath)) return null;
 	if (withFn?.[1] && INTERNAL_FRAME_RE.test(withFn[1])) return null;
+
+	// Installed elizaOS packages live under node_modules in package-mode
+	// deployments, so classify them before dropping unrelated dependencies.
+	const installedPackageMatch =
+		/(?:^|\/)node_modules\/(?:\.pnpm\/[^/]+\/node_modules\/)?@elizaos\/([^/]+)\//.exec(
+			framePath,
+		);
+	if (installedPackageMatch?.[1]) return installedPackageMatch[1];
+
+	if (/(?:^|\/)node_modules\//.test(framePath)) return null;
 
 	const pluginMatch = /(?:^|\/)plugins\/([^/]+)\//.exec(framePath);
 	if (pluginMatch?.[1]) return pluginMatch[1];
@@ -55,16 +58,13 @@ function dedupeConsecutive(names: string[]): string[] {
 }
 
 /**
- * Capture a trimmed stack for `runtime.useModel()` calls.
+ * Extract a trimmed caller trace from a stack captured for `runtime.useModel()`.
  * Returns plugin or package names only: no file paths or line numbers.
  */
-export function captureModelLookupCaller(
-	logLevel: string | undefined,
+export function captureModelLookupCallerFromStack(
+	stack: string | undefined,
 	maxFrames = 4,
 ): ModelLookupCallerTrace | undefined {
-	if (!isDebugOrTraceLogLevel(logLevel)) return undefined;
-
-	const stack = new Error("model lookup").stack;
 	if (!stack) return undefined;
 
 	const origins: string[] = [];
@@ -82,4 +82,18 @@ export function captureModelLookupCaller(
 		caller: callerStack[0],
 		callerStack,
 	};
+}
+
+/**
+ * Capture a trimmed stack for `runtime.useModel()` calls.
+ * Caller gates this behind debug logging because stack capture walks the hot
+ * model path and should stay free when debug logs are disabled.
+ */
+export function captureModelLookupCaller(
+	maxFrames = 4,
+): ModelLookupCallerTrace | undefined {
+	return captureModelLookupCallerFromStack(
+		new Error("model lookup").stack,
+		maxFrames,
+	);
 }


### PR DESCRIPTION
## Summary
- keep @elizaos/* package attribution when model lookup stacks come from installed node_modules packages
- support both direct npm-style installs and pnpm virtual-store paths
- move the stack-capture cost gate back to the runtime debug guard so the helper does not duplicate log-level policy

## Why
The previous parser filtered every node_modules frame before trying to classify callers. That made model lookup attribution useful in the monorepo but inert for package-mode deployments where plugins run from node_modules.

## Tests
- bun run --cwd packages/core test src/utils/model-lookup-caller.test.ts
- bunx biome check packages/core/src/utils/model-lookup-caller.ts packages/core/src/utils/model-lookup-caller.test.ts packages/core/src/runtime.ts
- bun run --cwd packages/core typecheck
- bun run --cwd packages/core build:node

Note: I ran bun install in the clean worktree to set up deps, then stopped during the 971 MiB sync-artifacts download after dependency resolution/builds completed because this fix does not require the large artifact payload.