### PR TITLE
perf(local-inference): lazy-load active-model/engine off the boot path (#9565)

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -25,10 +25,6 @@ import {
 	LOCAL_INFERENCE_PROVIDER_ID,
 	LOCAL_INFERENCE_TEXT_MODEL_TYPES,
 } from "./provider.js";
-import {
-	assertManifestEvalsPassed,
-	CandidateModelActivationError,
-} from "./services/active-model.js";
 import { classifyDeviceTier } from "./services/device-tier.js";
 
 // Lazy service handle. Importing `./services/service.js` eagerly evaluates the
@@ -1525,6 +1521,11 @@ export async function handleLocalInferenceRoutes(
 		// `eliza-1.manifest.json` is reachable next to the installed bundle
 		// (see `defaultManifestLoader`); external-scan / non-bundle installs
 		// are passed through.
+		// Lazy: active-model.js pulls the engine (~545ms). Load it here, on the
+		// model-activation path (the engine is needed to activate anyway), so it
+		// stays off the boot-blocking plugin import (issue #9565).
+		const { assertManifestEvalsPassed, CandidateModelActivationError } =
+			await import("./services/active-model.js");
 		try {
 			assertManifestEvalsPassed(installed);
 		} catch (err) {


### PR DESCRIPTION
Follow-up to #9727. `local-inference-routes.ts` still eagerly imported `active-model.js` for two engine-free symbols (`assertManifestEvalsPassed`, `CandidateModelActivationError`), but active-model top-level-imports the FFI **engine (~545ms)**. Because the root plugin entry re-exports this module, the boot-blocking import paid the engine eval.

**Fix:** lazy `await import("./services/active-model.js")` at the single use site — the async model-activation route handler, which needs the engine to activate a model anyway, so the engine eval is deferred to where it's actually used (off boot). `instanceof` still works (class comes from the same lazy import).

**Measured:** plugin root source import **570ms → ~280-394ms** (cumulative with #9727: **940 → ~280, ~70%**); boot `readyMs` trends lower (~3.3s → ~2.7-3.0s). The prod static-plugins lap is noisy (esbuild pre-parses the bundle); the win is deferred engine **eval**, which helps mobile's slower CPU most — the #9565 target.

**Verified:** typecheck 56/56, `local-inference-routes` + `local-inference-compat-routes` tests 19/19, ratchet 141/141, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)