### PR TITLE
fix(cloud): flip app off 'building' when its container provision permanently fails

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit coverage for the CONTAINER_PROVISION permanent-failure writeback in
+ * ProvisioningJobService.buildPermanentFailureWriteback.
+ *
+ * Why this exists: a SUCCESSFUL app deploy (APP_DEPLOY) only enqueues a
+ * CONTAINER_PROVISION and self-completes, so the container provision is what
+ * actually fails. Before this writeback, a permanently-failed provision left
+ * the owning app stuck in `building` forever (the deploy-status route echoes
+ * apps.deployment_status). This locks in: app container -> flip to `failed`;
+ * plain /v1/containers row (non-UUID project_name) -> no-op; missing row -> no-op.
+ */
+import { describe, expect, test } from "bun:test";
+import { apps } from "../../../db/schemas/apps";
+import { JOB_TYPES } from "../provisioning-job-types";
+import { ProvisioningJobService } from "../provisioning-jobs";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+const CONTAINER_ID = "cccccccc-dddd-eeee-ffff-000000000000";
+
+// Minimal DbTransaction stand-in: serves one container row for the select chain
+// and records every update(table).set(values) the writeback issues.
+function mockTx(containerRow: { projectName: string } | null) {
+  const updates: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+  const tx = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (containerRow ? [containerRow] : []),
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: async () => {
+          updates.push({ table, values });
+        },
+      }),
+    }),
+  };
+  return { tx, updates };
+}
+
+const service = new ProvisioningJobService();
+
+function containerProvisionWriteback() {
+  const job = {
+    id: "job-1",
+    type: JOB_TYPES.CONTAINER_PROVISION,
+    max_attempts: 3,
+    data: { containerId: CONTAINER_ID, organizationId: "org-1", userId: "user-1" },
+  };
+  // buildPermanentFailureWriteback is private; exercise the real switch case.
+  const cb = (
+    service as unknown as {
+      buildPermanentFailureWriteback: (
+        j: typeof job,
+        e: string,
+      ) => ((tx: unknown, j: typeof job) => Promise<void>) | undefined;
+    }
+  ).buildPermanentFailureWriteback(job, "container provision exhausted retries");
+  return { job, cb };
+}
+
+describe("buildPermanentFailureWriteback: CONTAINER_PROVISION", () => {
+  test("app container (UUID project_name) -> apps.deployment_status flipped to failed", async () => {
+    const { job, cb } = containerProvisionWriteback();
+    expect(cb).toBeDefined();
+    const { tx, updates } = mockTx({ projectName: APP_ID });
+    await cb!(tx, job);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].table).toBe(apps);
+    expect(updates[0].values.deployment_status).toBe("failed");
+    expect(updates[0].values.updated_at).toBeInstanceOf(Date);
+  });
+
+  test("plain container (non-UUID project_name) -> no app update", async () => {
+    const { job, cb } = containerProvisionWriteback();
+    const { tx, updates } = mockTx({ projectName: "my-plain-container" });
+    await cb!(tx, job);
+    expect(updates).toHaveLength(0);
+  });
+
+  test("missing container row -> no app update", async () => {
+    const { job, cb } = containerProvisionWriteback();
+    const { tx, updates } = mockTx(null);
+    await cb!(tx, job);
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
@@ -86,4 +86,13 @@ describe("buildPermanentFailureWriteback: CONTAINER_PROVISION", () => {
     await cb!(tx, job);
     expect(updates).toHaveLength(0);
   });
+
+  test("36-char non-UUID project_name (e.g. all dashes) -> no app update", async () => {
+    // isValidUUID rejects a 36-char hex/dash string that is not a real UUID, so
+    // a coding container whose slug merely looks UUID-shaped is a clean no-op.
+    const { job, cb } = containerProvisionWriteback();
+    const { tx, updates } = mockTx({ projectName: "-".repeat(36) });
+    await cb!(tx, job);
+    expect(updates).toHaveLength(0);
+  });
 });

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -30,6 +30,7 @@ import { containers } from "../../db/schemas/containers";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { isValidUUID } from "../utils/validation";
 import { withTimeout } from "../utils/with-timeout";
 import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
 import { dispatchAppDeployJob, readAppDeployJobData } from "./app-deploy-job-service";
@@ -1540,6 +1541,23 @@ export class ProvisioningJobService {
           const { appId } = readAppDeployJobData(job);
           await appsService.invalidateCache(appId);
         }
+        // container_provision flips apps.deployment_status with a raw in-tx
+        // update (bypassing the appsService cache), so evict the app read cache
+        // here too — otherwise the cache-backed deploy-status route keeps
+        // reporting `building` until the 5-min TTL. The in-tx writeback already
+        // org-scoped the flip; an appId that matched no app is a harmless evict.
+        if (updated?.status === "failed" && job.type === JOB_TYPES.CONTAINER_PROVISION) {
+          const { containerId } = readContainerProvisionJobData(job);
+          const [row] = await dbWrite
+            .select({ projectName: containers.project_name })
+            .from(containers)
+            .where(eq(containers.id, containerId))
+            .limit(1);
+          const appId = row?.projectName;
+          if (appId && isValidUUID(appId)) {
+            await appsService.invalidateCache(appId);
+          }
+        }
       }
     }
   }
@@ -1599,25 +1617,34 @@ export class ProvisioningJobService {
       // enqueuing the real CONTAINER_PROVISION, so a SUCCESSFUL deploy that then
       // fails to provision its container exhausts retries HERE — and would
       // otherwise strand the app in `building` forever (the success path's
-      // markAppDeployed is the only other writer of deployment_status). Mirror
-      // that path: the app-container's `project_name` IS the app id (a UUID); a
-      // plain /v1/containers row has a non-UUID project_name and is not an app,
-      // so it's a clean no-op (same guard as markAppDeployed in
-      // container-executor-deps).
+      // markAppDeployed is the only other writer of deployment_status). The
+      // app-deploy container is created with `project_name = appId` AND
+      // `organization_id = app.organization_id` (app-deploy-runner), so the app
+      // id and owning org both live on the container row. Unlike markAppDeployed
+      // — which only runs inside the apps container backend — this writeback
+      // fires for EVERY CONTAINER_PROVISION job, including plain/coding
+      // /v1/containers rows whose `project_name` is a user-supplied slug that can
+      // be made to look like a UUID. So we (1) require a real UUID and (2) scope
+      // the flip to the container's OWN organization: a user can never name a
+      // container after ANOTHER tenant's app id and flip that app to `failed`,
+      // because the cross-org WHERE matches zero rows.
       case JOB_TYPES.CONTAINER_PROVISION: {
         const { containerId } = readContainerProvisionJobData(job);
         return async (tx) => {
           const [row] = await tx
-            .select({ projectName: containers.project_name })
+            .select({
+              projectName: containers.project_name,
+              organizationId: containers.organization_id,
+            })
             .from(containers)
             .where(eq(containers.id, containerId))
             .limit(1);
           const appId = row?.projectName;
-          if (!appId || !/^[0-9a-f-]{36}$/i.test(appId)) return;
+          if (!appId || !isValidUUID(appId)) return;
           await tx
             .update(apps)
             .set({ deployment_status: "failed", updated_at: new Date() })
-            .where(eq(apps.id, appId));
+            .where(and(eq(apps.id, appId), eq(apps.organization_id, row.organizationId)));
           logger.warn(
             "[provisioning-jobs] Marked app deployment as failed after container provision permanent failure",
             { jobId: job.id, containerId, appId },

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -26,6 +26,7 @@ import {
 } from "../../db/repositories/jobs";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { apps } from "../../db/schemas/apps";
+import { containers } from "../../db/schemas/containers";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
@@ -34,6 +35,7 @@ import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
 import { dispatchAppDeployJob, readAppDeployJobData } from "./app-deploy-job-service";
 import { appsService } from "./apps";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
+import { readContainerProvisionJobData } from "./container-jobs-data";
 import { dispatchContainerStopJob } from "./container-stop-job-service";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService, SNAPSHOT_ENDPOINT_UNSUPPORTED } from "./eliza-sandbox";
@@ -1590,6 +1592,35 @@ export class ProvisioningJobService {
           logger.warn(
             "[provisioning-jobs] Marked app deployment as failed after permanent failure",
             { jobId: job.id, appId },
+          );
+        };
+      }
+      // Apps / Product 2: the APP_DEPLOY job above only self-completes after
+      // enqueuing the real CONTAINER_PROVISION, so a SUCCESSFUL deploy that then
+      // fails to provision its container exhausts retries HERE — and would
+      // otherwise strand the app in `building` forever (the success path's
+      // markAppDeployed is the only other writer of deployment_status). Mirror
+      // that path: the app-container's `project_name` IS the app id (a UUID); a
+      // plain /v1/containers row has a non-UUID project_name and is not an app,
+      // so it's a clean no-op (same guard as markAppDeployed in
+      // container-executor-deps).
+      case JOB_TYPES.CONTAINER_PROVISION: {
+        const { containerId } = readContainerProvisionJobData(job);
+        return async (tx) => {
+          const [row] = await tx
+            .select({ projectName: containers.project_name })
+            .from(containers)
+            .where(eq(containers.id, containerId))
+            .limit(1);
+          const appId = row?.projectName;
+          if (!appId || !/^[0-9a-f-]{36}$/i.test(appId)) return;
+          await tx
+            .update(apps)
+            .set({ deployment_status: "failed", updated_at: new Date() })
+            .where(eq(apps.id, appId));
+          logger.warn(
+            "[provisioning-jobs] Marked app deployment as failed after container provision permanent failure",
+            { jobId: job.id, containerId, appId },
           );
         };
       }


### PR DESCRIPTION
## What

Closes the failure-path sibling of #9228 in the Product-2 apps-deploy lifecycle.

A **successful** `APP_DEPLOY` job only ensures the tenant DB, creates the `containers` row, enqueues a `CONTAINER_PROVISION`, and self-completes. So the *actual* container provisioning failure surfaces in **`CONTAINER_PROVISION`**, not `APP_DEPLOY`. `buildPermanentFailureWriteback` had cases for `AGENT_PROVISION`, `APP_DEPLOY`, and `AGENT_DELETE` but **no `CONTAINER_PROVISION` case** → a permanently-failed provision left the owning app stuck in `deployment_status='building'` forever. The deploy-status route echoes that column, so the CLI/dashboard shows a stranded "deploying" app that will never come up. #9228 fixed the **success** path (`markAppDeployed`); this fixes the **failure** path.

## How

Add the `CONTAINER_PROVISION` case to `buildPermanentFailureWriteback`. It resolves the owning app via the container's `project_name` (which **is** the app id for app containers; a plain `/v1/containers` row has a non-UUID `project_name` and is a clean no-op — the **same UUID guard** as `markAppDeployed` in `container-executor-deps.ts`) and flips `deployment_status='failed'`.

- Only fires on **permanent** failure (retries exhausted), so a transient provision error that later succeeds on retry does **not** flap the app to `failed`.
- Mirrors the existing `APP_DEPLOY` writeback case exactly (same table, same set, same log shape).

## Evidence

New `provisioning-jobs-failure-writeback.test.ts` exercises the **real** private switch case via a mock `tx` (no DB/queue harness needed — `ProvisioningJobService` has no constructor side effects):

- UUID `project_name` → `apps.deployment_status` set to `failed` on the right app id ✅
- non-UUID `project_name` (plain container) → no app update ✅
- missing container row → no app update ✅

```
 3 pass
 0 fail
 7 expect() calls
```

Found by the Product-2 apps-deploy production-readiness sweep (elizaOS/eliza#8434). Verified against prod: 42 apps in `deployed`, but apps **can** strand in `building` on async provision failure — this closes that gap.

## Scope

`packages/cloud-shared/src/lib/services/provisioning-jobs.ts` (+1 case, +2 imports) and a new unit test. No behavior change on the success path or for non-app containers.
