### PR TITLE
chore(core): surface facts/relationships dedup read failures instead of silently swallowing

### DIFF
--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -2,6 +2,7 @@ import {
 	buildFactKeywordsForStorage,
 	scoreFactKeywordRelevance,
 } from "../features/advanced-capabilities/fact-keywords.ts";
+import { logger } from "../logger";
 import { isMobilePlatform } from "../runtime-env";
 import type {
 	MessageHandlerExtract,
@@ -368,7 +369,15 @@ async function searchSimilarFacts(
 			.sort((left, right) => right.relevance - left.relevance)
 			.slice(0, 8)
 			.map((entry) => entry.memory);
-	} catch {
+	} catch (error) {
+		// Failing to load existing facts disables dedup for this turn, which
+		// risks duplicate facts in the knowledge graph. Degrade to no dedup, but
+		// surface the read failure so a broken `getMemories` pipeline is visible.
+		logger.warn(
+			`[FactsAndRelationships] searchSimilarFacts read failed; skipping fact dedup: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
 		return [];
 	}
 }
@@ -389,7 +398,15 @@ async function fetchExistingRelationships(
 			limit: 16,
 		});
 		return Array.isArray(results) ? results : [];
-	} catch {
+	} catch (error) {
+		// Failing to load existing relationships disables dedup for this turn,
+		// risking duplicate relationships. Degrade to no dedup, but surface the
+		// read failure so a broken `getRelationships` pipeline is visible.
+		logger.warn(
+			`[FactsAndRelationships] fetchExistingRelationships read failed; skipping relationship dedup: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
 		return [];
 	}
 }


### PR DESCRIPTION
## What

`searchSimilarFacts` and `fetchExistingRelationships` (in `packages/core/src/runtime/facts-and-relationships.ts`) load existing facts/relationships so the model can deduplicate before writing new ones. Both wrapped the DB read in a bare `catch { return []; }` with **no logging**.

## Why this is a problem

A broken `getMemories`/`getRelationships` pipeline (DB down, adapter error) was silently swallowed: dedup degraded to comparing against zero records, so the model wrote **duplicate facts/relationships into the knowledge graph** with no observable signal. This is exactly the silent-swallow-masking-a-broken-pipeline pattern.

## Change

- Keep the graceful degradation (return `[]` so the facts-and-relationships evaluator stage still completes on a transient read error — throwing would regress the whole memory-extraction turn).
- Add a `logger.warn` in each catch so the read failure is **surfaced and observable** instead of silent.
- Success path is byte-for-byte unchanged.

## Behavior

| | Before | After |
|---|---|---|
| Read succeeds | dedup against loaded records | unchanged |
| Read throws | silently dedup against `[]` → duplicate facts, no log | log `[FactsAndRelationships] … read failed; skipping dedup`, then degrade to `[]` |

## Verification

- `bun run turbo build --filter=@elizaos/core --filter=@elizaos/shared` — green.
- `tsgo --noEmit` in `packages/core` — 0 errors.
- `vitest run src/runtime/__tests__/facts-and-relationships.test.ts` — 15/15 passed.
- Rebased onto latest `origin/develop`; target file had no base drift.

Part of the AGENTS.md error-handling cleanup (area 6: remove swallows that mask broken pipelines).