### PR TITLE
fix(ci): stop the UI Story Gate flaking on useAppSelector harness throws

### DIFF
--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -231,6 +231,25 @@ function normalizeConsole(text) {
   ) {
     return "";
   }
+  // useAppSelector throws in the headless Story Gate for any story that renders
+  // an app-state consumer without mounting the real AppProvider — a harness
+  // artifact (the app always mounts AppProvider), caught by the story error
+  // boundary so the story still renders `good`. It surfaces FLAKILY: a given
+  // consumer story is classified `needs-runtime` one run and renders-with-throw
+  // the next, which makes per-story baselining a perpetual moving target across
+  // the ~127 app-selector consumers. Drop it (and Storybook's paired "Error
+  // rendering story" wrapper) globally instead. A genuinely broken story is
+  // still caught by the broken verdict (the DOM error display), and a real
+  // (non-useAppSelector) render throw keeps its own specific message — only this
+  // generic wrapper is dropped.
+  if (
+    normalized.startsWith(
+      "Error: useAppSelector used before AppProvider rendered",
+    ) ||
+    /^Error rendering story '[^']*':/.test(normalized)
+  ) {
+    return "";
+  }
   return normalized;
 }
 


### PR DESCRIPTION
## Problem

The UI Story Gate kept failing on a **moving** set of `useAppSelector used before AppProvider rendered` console errors (27 → 12 → 3 → 1 across recent runs, a *different* subset each run). The headless gate renders every story without mounting the real `AppProvider`, so any story that renders one of the **~127** `useAppSelector` consumers throws — caught by the story error boundary, so the story still renders `good`. **Which** consumers surface it is timing-dependent (`needs-runtime` one run, renders-with-throw the next), so per-story console baselining is a perpetual moving target.

## Fix

Drop the artifact at the source: `normalizeConsole` now returns `""` for the `useAppSelector` error and Storybook's paired `Error rendering story '<id>'` wrapper — exactly the existing pattern used for the generic-404 message.

## Safety (verified locally — pure string logic, no build needed)

Ran the modified `normalizeConsole` over the **real captured console output** from two failed runs:
- all **8** `useAppSelector` + **4** `Error rendering story` messages drop;
- **every real error is preserved** — including the intentional `Error: Simulated render failure in a child component` and `DynamicViewLoader failed to load view` messages, plus a control `TypeError`;
- in both reports, the `Error rendering story` wrapper *only ever* paired with the useAppSelector artifact (never a real bug), all on `good`-verdict stories.

Genuinely broken stories are still caught by the **broken verdict** (the DOM error display), which is independent of console classification. No rendering or a11y change. The per-story useAppSelector console-baseline entries (incl. #9709's) become inert but harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)