### PR TITLE
fix(training): accept 27b-256k Gemma tier aliases

### DIFF
--- a/packages/training/scripts/rl/gemma_capacity.py
+++ b/packages/training/scripts/rl/gemma_capacity.py
@@ -197,9 +197,11 @@ MODEL_ALIASES = {
     "eliza-1-9b": "gemma4_12b",
     "google/gemma-4-12b": "gemma4_12b",
     "27b": "gemma4_31b",
+    "27b-256k": "gemma4_31b",
     "31b": "gemma4_31b",
     "gemma4-31b": "gemma4_31b",
     "eliza-1-27b": "gemma4_31b",
+    "eliza-1-27b-256k": "gemma4_31b",
     "google/gemma-4-31b": "gemma4_31b",
 }
 

--- a/packages/training/scripts/training/model_registry.py
+++ b/packages/training/scripts/training/model_registry.py
@@ -459,6 +459,8 @@ REGISTRY: dict[str, ModelEntry] = {
 
 ELIZA_1_27B_VARIANT_ALIASES: dict[str, str] = {
     "27b": "gemma4-31b",
+    "27b-256k": "gemma4-31b",
+    "eliza-1-27b-256k": "gemma4-31b",
 }
 
 # Map the size-first eliza-1 tier ids (and common Gemma 4 base spellings) onto

--- a/packages/training/scripts/training/test_model_registry.py
+++ b/packages/training/scripts/training/test_model_registry.py
@@ -116,6 +116,8 @@ def test_lookup_by_hf_id_short_name_or_eliza_name() -> None:
     assert get("google/gemma-4-31B").short_name == "gemma4-31b"
     assert get("eliza-1-27b").short_name == "gemma4-31b"
     assert get("27b").short_name == "gemma4-31b"
+    assert get("27b-256k").short_name == "gemma4-31b"
+    assert get("eliza-1-27b-256k").short_name == "gemma4-31b"
 
 
 def test_no_qwen3_6_fallback_aliases() -> None:

--- a/packages/training/tests/rl/test_gemma_capacity.py
+++ b/packages/training/tests/rl/test_gemma_capacity.py
@@ -29,6 +29,17 @@ def test_resolve_model_spec_accepts_alias_and_model_id():
 def test_slugify_model_name_prefers_canonical_gemma_slug():
     assert slugify_model_name("google/gemma-4-31B") == "gemma4-31b"
     assert slugify_model_name("9B") == "gemma4-12b"
+    assert slugify_model_name("27b-256k") == "gemma4-31b"
+
+
+def test_resolve_model_spec_accepts_active_27b_256k_tier_alias():
+    variant = resolve_model_spec("27b-256k")
+    public_name = resolve_model_spec("eliza-1-27b-256k")
+
+    assert variant is not None
+    assert public_name is not None
+    assert variant.key == "gemma4_31b"
+    assert public_name.key == variant.key
 
 
 def test_parse_context_length_supports_k_suffix():


### PR DESCRIPTION
## Summary
- accept the active `27b-256k` and `eliza-1-27b-256k` release-tier aliases in the Gemma RL capacity planner
- align `model_registry.get(...)` so the active 256k 27B variant resolves to the Gemma 4 31B registry entry
- add planner and registry tests covering both active 27b-256k aliases

Follow-up found while reviewing the merged Gemma capacity planner work from #9707 in the #9583 thread.

## Evidence
- `bun install` -> no dependency changes
- `python3 -m pytest packages/training/tests/rl/test_gemma_capacity.py packages/training/scripts/training/test_model_registry.py -q` -> 27 passed
- `python3 -m py_compile packages/training/scripts/rl/gemma_capacity.py packages/training/scripts/rl/plan_gemma_training.py packages/training/tests/rl/test_gemma_capacity.py packages/training/scripts/training/model_registry.py packages/training/scripts/training/test_model_registry.py`
- `python3 packages/training/scripts/rl/plan_gemma_training.py --model 27b-256k --contexts 256k --format json` -> resolves `gemma4_31b`, `google/gemma-4-31B`, `262144`
- `git diff --check`
- `bun run verify` -> 523 tasks successful, 523 total

## UI
N/A: Python training planner and registry alias coverage only.
