### PR TITLE
fix(training): switch RL defaults to Gemma

### DIFF
--- a/packages/training/scripts/rl/ab_testing.py
+++ b/packages/training/scripts/rl/ab_testing.py
@@ -7,7 +7,7 @@ Usage:
     from training.ab_testing import ABTestRunner
 
     runner = ABTestRunner(
-        model_a="Qwen/Qwen3-30B",  # Baseline
+        model_a="google/gemma-4-31B",  # Baseline
         model_b="./trained_models/final_model",  # Trained
         scenarios=EVAL_SCENARIOS,
     )

--- a/packages/training/scripts/rl/compare_kondo_rates.py
+++ b/packages/training/scripts/rl/compare_kondo_rates.py
@@ -16,7 +16,7 @@ Then compares: reward trajectory, delight distribution, compute savings.
 
 Usage:
     python scripts/compare_kondo_rates.py --mock --ticks 30
-    python scripts/compare_kondo_rates.py --mock --model Qwen/Qwen3-4B --ticks 50
+    python scripts/compare_kondo_rates.py --mock --model google/gemma-4-E4B --ticks 50
 """
 
 from __future__ import annotations
@@ -278,7 +278,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Compare Kondo gate rates")
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--agents-per-team", type=int, default=5)
     parser.add_argument("--ticks", type=int, default=30)

--- a/packages/training/scripts/rl/demo_continuous_rl.py
+++ b/packages/training/scripts/rl/demo_continuous_rl.py
@@ -13,7 +13,7 @@ Demonstrates:
 
 Usage:
     python scripts/demo_continuous_rl.py
-    python scripts/demo_continuous_rl.py --num-agents 2 --ticks 30 --model Qwen/Qwen3-0.6B
+    python scripts/demo_continuous_rl.py --num-agents 2 --ticks 30 --model google/gemma-4-E2B
 """
 
 from __future__ import annotations
@@ -548,7 +548,7 @@ async def run_demo(args: argparse.Namespace) -> dict[str, Any]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Multi-agent continuous RL demo")
-    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--model", default="google/gemma-4-E2B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--num-agents", type=int, default=2)
     parser.add_argument("--ticks", type=int, default=20)

--- a/packages/training/scripts/rl/diagnose_learning.py
+++ b/packages/training/scripts/rl/diagnose_learning.py
@@ -12,7 +12,7 @@ eval prompt response at baseline, post-SFT, and post-RL. Then analyzes:
   - Signs of underfitting (still ignoring format)
 
 Usage:
-    python scripts/diagnose_learning.py --model Qwen/Qwen3-4B --ticks 30
+    python scripts/diagnose_learning.py --model google/gemma-4-E4B --ticks 30
 """
 
 from __future__ import annotations
@@ -414,7 +414,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--agents", type=int, default=5)
     parser.add_argument("--ticks", type=int, default=30)

--- a/packages/training/scripts/rl/feed_env.py
+++ b/packages/training/scripts/rl/feed_env.py
@@ -259,7 +259,7 @@ class FeedRLAIFEnv(BaseEnv):
     def config_init(cls) -> tuple[FeedEnvConfig, list[APIServerConfig]]:
         """Initialize configuration with defaults"""
         env_config = FeedEnvConfig(
-            tokenizer_name="Qwen/Qwen2.5-3B-Instruct",
+            tokenizer_name="google/gemma-4-E2B",
             group_size=4,  # Match Atropos default for stable GRPO training
             use_wandb=True,
             max_num_workers=64,
@@ -277,7 +277,7 @@ class FeedRLAIFEnv(BaseEnv):
         # Server config for the training model (will be updated by vLLM)
         server_configs = [
             APIServerConfig(
-                model_name="Qwen/Qwen2.5-3B-Instruct",
+                model_name="google/gemma-4-E2B",
                 base_url="http://localhost:9001/v1",
                 api_key="x",
                 num_requests_for_eval=64,

--- a/packages/training/scripts/rl/hybrid_env.py
+++ b/packages/training/scripts/rl/hybrid_env.py
@@ -112,7 +112,7 @@ class FeedHybridEnv(BaseEnv):
     def config_init(cls) -> tuple[FeedHybridEnvConfig, list[APIServerConfig]]:
         """Create default config"""
         env_config = FeedHybridEnvConfig(
-            tokenizer_name="Qwen/Qwen2.5-3B-Instruct",
+            tokenizer_name="google/gemma-4-E2B",
             rollout_server_url="http://localhost:8000",
             total_steps=1000,
             batch_size=16,
@@ -124,7 +124,7 @@ class FeedHybridEnv(BaseEnv):
 
         server_configs = [
             APIServerConfig(
-                model_name="Qwen/Qwen2.5-3B-Instruct",
+                model_name="google/gemma-4-E2B",
                 base_url="http://localhost:9001/v1",
             )
         ]

--- a/packages/training/scripts/rl/kl_controller.py
+++ b/packages/training/scripts/rl/kl_controller.py
@@ -15,7 +15,7 @@ Features:
 - Integration with reward function
 
 Usage:
-    kl_controller = KLController("Qwen/Qwen2.5-3B-Instruct")
+    kl_controller = KLController("google/gemma-4-E2B")
 
     # During reward computation
     penalty, mean_kl = kl_controller.get_penalty(

--- a/packages/training/scripts/rl/measure_learning.py
+++ b/packages/training/scripts/rl/measure_learning.py
@@ -9,7 +9,7 @@ This is the science: baseline eval → SFT warmup → online RL ticks with
 periodic eval → plot improvement trajectory.
 
 Usage:
-    python scripts/measure_learning.py --mock --model Qwen/Qwen3-4B --ticks 40
+    python scripts/measure_learning.py --mock --model google/gemma-4-E4B --ticks 40
 """
 
 from __future__ import annotations
@@ -364,7 +364,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Measure learning with periodic eval")
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--agents-per-team", type=int, default=5)
     parser.add_argument("--ticks", type=int, default=40)

--- a/packages/training/scripts/rl/online_env.py
+++ b/packages/training/scripts/rl/online_env.py
@@ -514,7 +514,7 @@ class FeedOnlineEnv(BaseEnv):
     def config_init(cls) -> tuple[FeedOnlineEnvConfig, list[APIServerConfig]]:
         """Initialize configuration with defaults"""
         env_config = FeedOnlineEnvConfig(
-            tokenizer_name="Qwen/Qwen2.5-3B-Instruct",
+            tokenizer_name="google/gemma-4-E2B",
             group_size=4,  # Generate 4 responses per scenario for GRPO
             use_wandb=True,
             max_num_workers=64,
@@ -531,7 +531,7 @@ class FeedOnlineEnv(BaseEnv):
 
         server_configs = [
             APIServerConfig(
-                model_name="Qwen/Qwen2.5-3B-Instruct",
+                model_name="google/gemma-4-E2B",
                 base_url="http://localhost:9001/v1",
                 api_key="x",
                 num_requests_for_eval=64,

--- a/packages/training/scripts/rl/red_team_gym.py
+++ b/packages/training/scripts/rl/red_team_gym.py
@@ -2,7 +2,7 @@
 Red Team Gym: Train attackers against frontier models + blue team.
 
 Architecture:
-  - Red team model (Qwen3-4B with APOLLO) learns to social-engineer targets
+  - Red team model (Gemma 4 E4B with APOLLO) learns to social-engineer targets
   - Targets are: our blue team model, Claude Sonnet, GPT-5.4, Groq models
   - Reward: did the target leak secrets / comply / fail to detect?
   - Blue team model also trains on red team's best attacks (co-evolution)
@@ -15,7 +15,7 @@ The GAN-like loop:
   5. Repeat — both improve
 
 Targets:
-  - "local" — our own Qwen3-4B model (fast, free, trainable)
+  - "local" — our own Gemma 4 E4B model (fast, free, trainable)
   - "sonnet" — Claude Sonnet via Anthropic API
   - "gpt" — GPT-5.4 via OpenAI API
   - "groq" — fast inference via Groq API

--- a/packages/training/scripts/rl/run_ab_test.py
+++ b/packages/training/scripts/rl/run_ab_test.py
@@ -7,19 +7,19 @@ Compares a trained model against a baseline model using standardized evaluation 
 Usage:
     # Compare trained model against baseline
     python scripts/run_ab_test.py \
-        --model-a Qwen/Qwen3-30B \
+        --model-a google/gemma-4-31B \
         --model-b ./trained_models/final_model \
         --archetypes trader degen
 
     # Quick test with fewer scenarios
     python scripts/run_ab_test.py \
-        --model-a Qwen/Qwen2.5-0.5B-Instruct \
+        --model-a google/gemma-4-E2B \
         --model-b ./trained_models/final_model \
         --num-runs 1
 
     # Full test suite
     python scripts/run_ab_test.py \
-        --model-a Qwen/Qwen3-30B \
+        --model-a google/gemma-4-31B \
         --model-b ./trained_models/final_model \
         --num-runs 5 \
         --output-dir ./ab_results

--- a/packages/training/scripts/rl/run_adversarial_eval.py
+++ b/packages/training/scripts/rl/run_adversarial_eval.py
@@ -9,8 +9,8 @@ Tests:
   4. Trained model (defender) vs scripted ScamBench attacks
 
 Usage:
-    python scripts/run_adversarial_eval.py --model Qwen/Qwen3-4B
-    python scripts/run_adversarial_eval.py --model Qwen/Qwen3-4B --num-episodes 20
+    python scripts/run_adversarial_eval.py --model google/gemma-4-E4B
+    python scripts/run_adversarial_eval.py --model google/gemma-4-E4B --num-episodes 20
 """
 
 from __future__ import annotations
@@ -184,7 +184,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Adversarial model-vs-model evaluation")
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--num-episodes", type=int, default=10)
     parser.add_argument("--num-legit", type=int, default=5)

--- a/packages/training/scripts/rl/run_adversarial_training.py
+++ b/packages/training/scripts/rl/run_adversarial_training.py
@@ -280,7 +280,7 @@ async def run_episode(
                 config.attacker_model, attacker_messages,
                 temperature=0.7, max_tokens=500,
             )
-            # Strip <think> tokens that Qwen3 models produce
+            # Strip private thinking traces emitted by reasoning-capable models.
             attack_text = THINK_PATTERN.sub("", attacker_resp["content"]).strip()
             # Also strip any meta-commentary the model might add
             if attack_text.startswith('"') and attack_text.endswith('"'):

--- a/packages/training/scripts/rl/run_nebius_continuous_rl.sh
+++ b/packages/training/scripts/rl/run_nebius_continuous_rl.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # Defaults
 HOST=""
 USER="ubuntu"
-MODEL="Qwen/Qwen3-4B"
+MODEL="google/gemma-4-E4B"
 TICKS=200
 AGENTS_PER_TEAM=10
 KONDO_RATE=0.03
@@ -41,7 +41,7 @@ usage() {
   echo "Options:"
   echo "  --host HOST          Nebius VM IP address"
   echo "  --user USER          SSH username (default: ubuntu)"
-  echo "  --model MODEL        Model name (default: Qwen/Qwen3-4B)"
+  echo "  --model MODEL        Model name (default: google/gemma-4-E4B)"
   echo "  --ticks N            Training ticks (default: 200)"
   echo "  --agents N           Agents per team (default: 10)"
   echo "  --kondo-rate R       Kondo gate rate (default: 0.03)"

--- a/packages/training/scripts/rl/run_red_team_gym.py
+++ b/packages/training/scripts/rl/run_red_team_gym.py
@@ -209,7 +209,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Red Team Gym")
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--targets", default="local", help="Comma-separated: local,groq,gpt,sonnet")
     parser.add_argument("--episodes", type=int, default=5)

--- a/packages/training/scripts/rl/run_shared_model_rl.py
+++ b/packages/training/scripts/rl/run_shared_model_rl.py
@@ -14,7 +14,7 @@ Usage:
     python scripts/run_shared_model_rl.py --bridge-url http://localhost:3001 --ticks 100
 
     # Custom configuration
-    python scripts/run_shared_model_rl.py --model Qwen/Qwen3-4B --agents-per-team 15 \\
+    python scripts/run_shared_model_rl.py --model google/gemma-4-E4B --agents-per-team 15 \\
         --kondo-rate 0.03 --ticks 200 --mock
 """
 
@@ -353,7 +353,11 @@ def main():
         description="Shared-model continuous RL training",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--model", default="google/gemma-4-12B", help="Model name (9B for Nebius H100)")
+    parser.add_argument(
+        "--model",
+        default="google/gemma-4-12B",
+        help="Model name (Gemma 4 12B / Eliza-1 9B tier for Nebius H100)",
+    )
     parser.add_argument("--device", default="cuda", help="Device (cuda/cpu)")
     parser.add_argument("--agents-per-team", type=int, default=10, help="Agents per team")
     parser.add_argument("--optimizer", default="apollo", choices=["apollo", "adamw"])

--- a/packages/training/scripts/rl/run_team_rl.py
+++ b/packages/training/scripts/rl/run_team_rl.py
@@ -294,7 +294,7 @@ async def main_async(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Team-based continuous RL")
-    parser.add_argument("--model", default="Qwen/Qwen3-4B")
+    parser.add_argument("--model", default="google/gemma-4-E4B")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--agents-per-team", type=int, default=10)
     parser.add_argument("--ticks", type=int, default=50)

--- a/packages/training/scripts/rl/run_tinker_training.py
+++ b/packages/training/scripts/rl/run_tinker_training.py
@@ -83,7 +83,7 @@ Examples:
   # Basic training run
   python scripts/run_tinker_training.py --steps 100
 
-  # Use a larger Qwen model
+  # Use a larger Gemma model
   python scripts/run_tinker_training.py --model google/gemma-4-31B
 
   # Adjust hyperparameters

--- a/packages/training/scripts/rl/team_rl.py
+++ b/packages/training/scripts/rl/team_rl.py
@@ -175,7 +175,7 @@ class TeamConfig:
 class TeamRLConfig:
     """Configuration for the full team-based training run."""
 
-    model_name: str = "Qwen/Qwen3-4B"
+    model_name: str = "google/gemma-4-E4B"
     device: str = "cuda"
 
     teams: list[TeamConfig] = field(

--- a/packages/training/scripts/rl/tinker/tinker_client.py
+++ b/packages/training/scripts/rl/tinker/tinker_client.py
@@ -37,9 +37,11 @@ TINKER_API_KEY_ENV_VARS = (
     "TM_API_KEY",
     "THINKINGMACHINES_API_KEY",
 )
-STALE_TINKER_MODEL_ALIASES = {
-    "Qwen/Qwen3-30B-A3B-Instruct": "Qwen/Qwen3-30B-A3B-Instruct-2507",
-    "Qwen/Qwen3-4B-Instruct": "Qwen/Qwen3-4B-Instruct-2507",
+TINKER_MODEL_ALIASES = {
+    "elizaos/eliza-1-2b": "google/gemma-4-E2B",
+    "elizaos/eliza-1-4b": "google/gemma-4-E4B",
+    "elizaos/eliza-1-9b": "google/gemma-4-12B",
+    "elizaos/eliza-1-27b": "google/gemma-4-31B",
 }
 
 # Lazy import tinker to allow graceful degradation
@@ -77,7 +79,7 @@ def resolve_tinker_base_model(
     if requested_model in available_models:
         return requested_model
 
-    alias = STALE_TINKER_MODEL_ALIASES.get(requested_model)
+    alias = TINKER_MODEL_ALIASES.get(requested_model)
     if alias in available_models:
         return alias
 
@@ -89,8 +91,10 @@ def resolve_tinker_base_model(
     if len(dated_matches) == 1:
         return dated_matches[0]
 
-    qwen_models = [model_name for model_name in available_models if "qwen" in model_name.lower()]
-    suggested_models = qwen_models[:5] if qwen_models else list(available_models[:5])
+    gemma_models = [
+        model_name for model_name in available_models if "gemma" in model_name.lower()
+    ]
+    suggested_models = gemma_models[:5] if gemma_models else list(available_models[:5])
     suggestion_text = ", ".join(suggested_models)
     raise RuntimeError(
         f"Tinker base model {requested_model} is not supported. "

--- a/packages/training/scripts/rl/tinker/tinker_trainer.py
+++ b/packages/training/scripts/rl/tinker/tinker_trainer.py
@@ -12,7 +12,7 @@ This trainer:
 
 Benefits over local training:
 - No local GPU required
-- Access to larger models (Qwen3-235B)
+- Access to the larger Gemma 4 training tiers
 - Faster weight sync (no vLLM restarts)
 - Better on-policy training with low staleness
 - Pay only for training time, not idle GPU

--- a/packages/training/tests/rl/test_tinker_client.py
+++ b/packages/training/tests/rl/test_tinker_client.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    fake_numpy = ModuleType("numpy")
+    fake_numpy.ndarray = object
+    fake_numpy.float64 = float
+    fake_numpy.int64 = int
+    fake_numpy.bool_ = bool
+    fake_numpy.number = (int, float)
+    fake_numpy.object_ = object
+    fake_numpy.array = lambda *args, **kwargs: list(args)
+    fake_numpy.mean = lambda *_args, **_kwargs: 0.0
+    fake_numpy.zeros = lambda *_args, **_kwargs: []
+    fake_numpy.ones = lambda *_args, **_kwargs: []
+    fake_numpy.random = SimpleNamespace(default_rng=lambda seed=None: SimpleNamespace())
+    sys.modules["numpy"] = fake_numpy
+
+
+def load_tinker_client_module():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "rl"
+        / "tinker"
+        / "tinker_client.py"
+    )
+    spec = importlib.util.spec_from_file_location("tinker_client_under_test", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tinker_client_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tinker_client = load_tinker_client_module()
+
+
+def test_resolve_tinker_base_model_accepts_eliza_tier_alias() -> None:
+    assert (
+        tinker_client.resolve_tinker_base_model(
+            "elizaos/eliza-1-4b",
+            ["google/gemma-4-E2B", "google/gemma-4-E4B"],
+        )
+        == "google/gemma-4-E4B"
+    )
+
+
+def test_resolve_tinker_base_model_accepts_single_dated_gemma_match() -> None:
+    assert (
+        tinker_client.resolve_tinker_base_model(
+            "google/gemma-4-E4B",
+            ["google/gemma-4-E4B-20260618"],
+        )
+        == "google/gemma-4-E4B-20260618"
+    )
+
+
+def test_resolve_tinker_base_model_suggests_gemma_before_other_models() -> None:
+    try:
+        tinker_client.resolve_tinker_base_model(
+            "missing/model",
+            [
+                "other/vendor-model",
+                "google/gemma-4-E2B",
+                "google/gemma-4-E4B",
+            ],
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected unsupported model to raise RuntimeError")
+
+    assert "google/gemma-4-E2B" in message
+    assert "google/gemma-4-E4B" in message
+    assert "other/vendor-model" not in message


### PR DESCRIPTION
## Summary
- Switch active RL scripts, Atropos environments, and Tinker examples from Qwen model names to Gemma 4 E2B/E4B/12B/31B tiers.
- Add Tinker base-model alias resolution for Eliza tier names onto Gemma upstream model IDs.
- Prefer Gemma model suggestions when Tinker rejects an unsupported base model.
- Add focused resolver tests for Gemma aliases and dated Gemma model matches.

Related: #9588, #9583

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m pytest packages/training/tests/rl/test_tinker_client.py -q`
- `python3 -m py_compile packages/training/scripts/rl/ab_testing.py packages/training/scripts/rl/compare_kondo_rates.py packages/training/scripts/rl/demo_continuous_rl.py packages/training/scripts/rl/diagnose_learning.py packages/training/scripts/rl/feed_env.py packages/training/scripts/rl/hybrid_env.py packages/training/scripts/rl/kl_controller.py packages/training/scripts/rl/measure_learning.py packages/training/scripts/rl/online_env.py packages/training/scripts/rl/red_team_gym.py packages/training/scripts/rl/run_ab_test.py packages/training/scripts/rl/run_adversarial_eval.py packages/training/scripts/rl/run_adversarial_training.py packages/training/scripts/rl/run_red_team_gym.py packages/training/scripts/rl/run_shared_model_rl.py packages/training/scripts/rl/run_team_rl.py packages/training/scripts/rl/run_tinker_training.py packages/training/scripts/rl/team_rl.py packages/training/scripts/rl/tinker/tinker_client.py packages/training/scripts/rl/tinker/tinker_trainer.py packages/training/tests/rl/test_tinker_client.py`
- `bash -n packages/training/scripts/rl/run_nebius_continuous_rl.sh`
- `git diff --check`
- `bun run verify` (523 successful, 523 total)

## N/A
- Real-LLM trajectories: N/A, this changes training/RL defaults and resolver logic only.
- UI screenshots/video: N/A, no UI surface changed.
- Voice/audio walkthrough: N/A, no voice path changed.
