### PR TITLE
feat(cloud): "*" wildcard opens apps-deploy to every org (full-launch posture)

### DIFF
--- a/packages/cloud-api/__tests__/apps-deploy-gate.test.ts
+++ b/packages/cloud-api/__tests__/apps-deploy-gate.test.ts
@@ -62,4 +62,36 @@ describe("apps deploy production gate", () => {
       reason: "organization_not_allowlisted",
     });
   });
+
+  test('"*" opens deploys to every production org (full launch)', () => {
+    const env = {
+      APPS_DEPLOY_ENABLED: "1",
+      ENVIRONMENT: "production",
+      APPS_DEPLOY_ALLOWED_ORG_IDS: "*",
+    };
+
+    expect(appsDeployTriggerDecision(env)).toEqual({ enabled: true });
+    expect(appsDeployOrganizationDecision(env, "org-a")).toEqual({
+      allowed: true,
+    });
+    expect(appsDeployOrganizationDecision(env, "any-other-org")).toEqual({
+      allowed: true,
+    });
+    // wildcard does not depend on a caller org being present
+    expect(appsDeployOrganizationDecision(env, null)).toEqual({
+      allowed: true,
+    });
+  });
+
+  test('"*" mixed with explicit ids still allows every org', () => {
+    const env = {
+      APPS_DEPLOY_ENABLED: "1",
+      ENVIRONMENT: "production",
+      APPS_DEPLOY_ALLOWED_ORG_IDS: "org-a, *",
+    };
+
+    expect(appsDeployOrganizationDecision(env, "org-z")).toEqual({
+      allowed: true,
+    });
+  });
 });

--- a/packages/cloud-api/src/lib/apps-deploy-gate.ts
+++ b/packages/cloud-api/src/lib/apps-deploy-gate.ts
@@ -70,6 +70,14 @@ export function appsDeployOrganizationDecision(
     return { allowed: false, reason: "production_allowlist_missing" };
   }
 
+  // "*" opens deploys to every org — the full-launch posture. Kept as an
+  // explicit opt-in token (not "empty allowlist = all") so a missing/unset
+  // config still fails closed: you open to everyone on purpose, never by
+  // forgetting to configure the allowlist.
+  if (allowedOrgIds.has("*")) {
+    return { allowed: true };
+  }
+
   if (!organizationId || !allowedOrgIds.has(organizationId)) {
     return { allowed: false, reason: "organization_not_allowlisted" };
   }


### PR DESCRIPTION
## What

Adds an explicit `"*"` wildcard to the production apps-deploy gate so we can open app deploys to **every org** (the actual launch posture) with one config value, instead of enumerating org ids.

## Why

`apps-deploy-gate.ts` was a strict per-org allowlist with **no all-orgs mode**. In production, the only way to let everyone deploy was to list every org id — absurd for a real launch. This was an over-cautious bring-up gate, not a launch posture.

## How

In `appsDeployOrganizationDecision`, if `APPS_DEPLOY_ALLOWED_ORG_IDS` contains `"*"`, every org is allowed (when `APPS_DEPLOY_ENABLED=1` + production).

- Kept as an **explicit opt-in token**, not "empty allowlist = all", so a missing/unset config still **fails closed** — you open to everyone on purpose, never by forgetting to configure it.
- Staged rollout (listing specific org ids) is unchanged.
- `appsDeployTriggerDecision` needs no change: `"*"` makes the parsed set non-empty, so the trigger enables.

## Evidence

`packages/cloud-api/__tests__/apps-deploy-gate.test.ts` (extended):
- `"*"` → any org allowed, incl. a `null` caller org
- `"*"` mixed with explicit ids → still allows every org
- empty/unset still fails closed (existing cases)

```
 5 pass
 0 fail
```

## Rollout note

Once merged + deployed to the API Worker, set the prod CF secret `APPS_DEPLOY_ALLOWED_ORG_IDS=*` to open apps-deploy to all orgs. (Container provisioning consumes shared node capacity, so this is a capacity/cost decision — the wildcard just makes "open to everyone" a one-value flip instead of impossible.) Context: elizaOS/eliza#8434.
