### PR TITLE
fix(ui): redirect unauthenticated apex visitors to /login instead of 401-walling (Gate B)

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppCatchAllRoute } from "./CloudRouterShell";
+
+/**
+ * Gate B regression. elizacloud.ai (an apex control-plane host) serves
+ * packages/app but has no same-origin agent backend, so an UNAUTHENTICATED
+ * visitor used to hit the agent shell and 401-wall on /api/*. The catch-all now
+ * redirects apex+unauthenticated → the Steward /login page, while every other
+ * host (per-agent subdomains, localhost) and any authenticated session falls
+ * through to the agent app unchanged.
+ */
+
+function base64url(value: unknown): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// A minimally-valid Steward JWT: readStewardSessionFromStorage only base64-decodes
+// the payload (needs userId + a future exp); there is no signature verification.
+function stewardToken(expSeconds: number): string {
+  return [
+    base64url({ alg: "none", typ: "JWT" }),
+    base64url({ userId: "u1", email: "a@b.test", exp: expSeconds }),
+    "sig",
+  ].join(".");
+}
+const FUTURE_EXP = Math.floor(Date.now() / 1000) + 3600;
+
+const realLocation = window.location;
+function setHostname(hostname: string): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...realLocation, hostname },
+  });
+}
+
+function renderCatchAll(): void {
+  render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/login" element={<div data-testid="login-page" />} />
+        <Route
+          path="*"
+          element={
+            <AppCatchAllRoute appElement={<div data-testid="agent-app" />} />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("CloudRouterShell apex catch-all (Gate B)", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
+  });
+
+  it("redirects an unauthenticated apex visitor (elizacloud.ai) to /login", () => {
+    setHostname("elizacloud.ai");
+    renderCatchAll();
+    expect(screen.getByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
+  it("renders the agent app on apex when a valid Steward session exists", () => {
+    setHostname("elizacloud.ai");
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll();
+    expect(screen.getByTestId("agent-app")).toBeTruthy();
+    expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+
+  it("does NOT redirect a per-agent subdomain (it boots its real runtime)", () => {
+    setHostname("abc123def.elizacloud.ai");
+    renderCatchAll();
+    expect(screen.getByTestId("agent-app")).toBeTruthy();
+    expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+
+  it("does NOT redirect on localhost (dev / native builds fall through)", () => {
+    setHostname("localhost");
+    renderCatchAll();
+    expect(screen.getByTestId("agent-app")).toBeTruthy();
+    expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -36,7 +36,9 @@ import {
   useLocation,
   useParams,
 } from "react-router-dom";
+import { ELIZA_CLOUD_CONTROL_PLANE_HOSTS } from "../../utils/cloud-agent-base";
 import { queryClient } from "../lib/query-client";
+import { useSessionAuth } from "../lib/use-session-auth";
 import {
   CloudI18nProvider,
   resolveInitialCloudLang,
@@ -155,6 +157,50 @@ export interface CloudRouterShellProps {
 }
 
 /**
+ * Apex control-plane hosts that serve THIS console UI but have no same-origin
+ * agent backend — so an unauthenticated visitor must land on the Steward
+ * `/login` page, not the agent shell (which 401-walls on `/api/*`).
+ * `api.elizacloud.ai` is the API origin (it never serves this shell); per-agent
+ * `<id>.elizacloud.ai` subdomains are NOT in the control-plane set and boot
+ * their real runtime, so they fall through untouched.
+ */
+const APEX_UI_CONTROL_PLANE_HOSTS = new Set(
+  [...ELIZA_CLOUD_CONTROL_PLANE_HOSTS].filter((h) => h !== "api.elizacloud.ai"),
+);
+
+function isApexControlPlaneHost(): boolean {
+  if (typeof window === "undefined") return false;
+  return APEX_UI_CONTROL_PLANE_HOSTS.has(
+    window.location.hostname.toLowerCase(),
+  );
+}
+
+/**
+ * Catch-all element. Renders the agent app exactly as before, EXCEPT on an apex
+ * control-plane host where the Steward session is resolved-and-unauthenticated —
+ * there it redirects to the registered cloud `/login` page (`returnTo`
+ * preserved) instead of booting the agent shell that would 401-wall. The apex
+ * 401-wall was a router fall-through: no route registers the apex root `/`, so
+ * an unauthenticated apex visitor hit this catch-all and booted the agent
+ * runtime against a backend that isn't there.
+ */
+export function AppCatchAllRoute({
+  appElement,
+}: {
+  appElement: ReactNode;
+}): React.JSX.Element {
+  const { ready, authenticated } = useSessionAuth();
+  const location = useLocation();
+  if (isApexControlPlaneHost() && ready && !authenticated) {
+    const returnTo = encodeURIComponent(
+      `${location.pathname}${location.search}`,
+    );
+    return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
+  }
+  return <>{appElement}</>;
+}
+
+/**
  * The shell. Mounts the registered cloud routes + the `/dashboard/*` compat
  * redirects, and renders {@link CloudRouterShellProps.appElement} for every
  * other path so chat stays home and the tab system is untouched.
@@ -195,8 +241,13 @@ export function CloudRouterShell({
            */}
           <Route path="dashboard/*" element={<CloudNotFound />} />
 
-          {/* Catch-all: the existing tab/view app. Chat is home. */}
-          <Route path="*" element={appElement} />
+          {/* Catch-all: the existing tab/view app (chat is home) — except an
+              unauthenticated visit to an apex control-plane host, which
+              redirects to /login instead of 401-walling. See AppCatchAllRoute. */}
+          <Route
+            path="*"
+            element={<AppCatchAllRoute appElement={appElement} />}
+          />
         </Routes>
       </CloudProviders>
     </BrowserRouter>


### PR DESCRIPTION
## The bug (Gate B — the last launch hold)
`elizacloud.ai` (the apex control-plane host) serves `packages/app` via `CloudRouterShell`, but has **no same-origin agent backend**. The shell registers explicit cloud/auth routes but **nothing for the apex root `/`**, so an unauthenticated visitor fell through to the `path="*"` catch-all → booted the full agent shell → its same-origin `/api/views|config|first-run|auth/me|…` all **401** → a hard 401 wall with no login fallback.

cloud-agent is currently holding prod green with a **temporary CF Pages rollback + ~20-min watchdog**. This is the **durable fix-forward** of the `cloud-frontend → packages/app` console migration (#9093), *not* a revert.

It's a **react-router fall-through, not an auth bug** — confirmed by a 3-agent map of the apex boot path, the auth surface, and the gap.

## The fix (one file + one test)
Gate the catch-all with `AppCatchAllRoute`: renders the agent app exactly as before **except** when the host is an apex control-plane host **and** the Steward session is resolved-and-unauthenticated → `<Navigate to="/login?returnTo=…">` to the already-registered cloud `/login` page. Reuses in-repo machinery (`useSessionAuth`, `ELIZA_CLOUD_CONTROL_PLANE_HOSTS`, the `/login` route).

**Scoped to apex only:** `elizacloud.ai` / `www` / `dev` redirect when unauth; **per-agent `<id>.elizacloud.ai` subdomains, `localhost`, and native/desktop builds (which never mount this shell) fall through untouched** — verified by tests.

## Tests
`CloudRouterShell.test.tsx` (4, all green): apex+unauth → `/login`; apex+valid-session → agent app; per-agent subdomain → agent app; localhost → agent app. typecheck + biome clean.

## ⚠️ Two staging checks before prod (flagged by the map; for @lalalune / @cloud-agent)
1. **`dev.elizacloud.ai`** is in `ELIZA_CLOUD_CONTROL_PLANE_HOSTS`, so it's the natural staging target for this redirect — confirm it serves the **console UI** (not a bare agent origin). If it's agent-only, drop it from `APEX_UI_CONTROL_PLANE_HOSTS`.
2. **Authenticated-apex** must have somewhere sane to land — this PR only removes the *unauth* wall. Verify a signed-in apex user doesn't hit a *different* (authenticated) 401 wall; if they do, that's a **separate** follow-up (the apex root may need its own authenticated landing route), out of scope for Gate B.

## Rollout
@cloud-agent owns the live console redeploy — please deploy this to **staging** first, then prod, and **keep the rollback + watchdog up until it's verified**. Once live + confirmed, you can drop both. cc @lalalune (migration owner). Tracking on #8434.