### PR TITLE
fix(steward): declare personal assistant dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5103,6 +5103,7 @@
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-personal-assistant": "workspace:*",
         "@elizaos/plugin-wallet": "workspace:*",
         "@elizaos/ui": "workspace:*",
         "@noble/curves": "2.2.0",

--- a/plugins/plugin-steward-app/package.json
+++ b/plugins/plugin-steward-app/package.json
@@ -35,6 +35,7 @@
     "@elizaos/agent": "workspace:*",
     "@elizaos/app-core": "workspace:*",
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-personal-assistant": "workspace:*",
     "@elizaos/plugin-wallet": "workspace:*",
     "@elizaos/ui": "workspace:*",
     "@noble/curves": "2.2.0",


### PR DESCRIPTION
## Summary
- declare `@elizaos/plugin-personal-assistant` as a workspace dependency of `@elizaos/plugin-steward-app`
- keep `bun.lock` in sync so Turbo/Bun can order and resolve the dynamic BLOCK fallback import

## Why
`plugin-steward-app/src/api/binance-skill-helpers.ts` dynamically imports `@elizaos/plugin-personal-assistant`, but the package did not declare that dependency. A full verify on another branch failed at `@elizaos/plugin-steward-app#typecheck` with TS2307 for that import because Turbo could schedule steward before the personal-assistant package was available.

## Evidence
- `bun install` after rebasing onto current `origin/develop`
- `bun run verify` -> 523 successful / 523 total
- `git diff --check origin/develop..HEAD`
