### PR TITLE
fix(nearai): default direct routing to Gemma

### DIFF
--- a/packages/agent/src/api/model-provider-helpers.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchNearAIModels } from "./model-provider-helpers";
+
+describe("fetchNearAIModels", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches the current NEAR AI /models catalog and skips not-ready models", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "google/gemma-4-31B-it",
+              name: "Gemma 4 31B Instruct",
+              output_modalities: ["text"],
+              is_ready: true,
+            },
+            {
+              id: "legacy/not-ready",
+              name: "Not Ready",
+              output_modalities: ["text"],
+              is_ready: false,
+            },
+            {
+              id: "nearai/image-model",
+              name: "Image Model",
+              architecture: { outputModalities: ["image"] },
+              is_ready: true,
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchNearAIModels("near-key", "https://cloud-api.near.ai/v1/"),
+    ).resolves.toEqual([
+      {
+        id: "google/gemma-4-31B-it",
+        name: "Gemma 4 31B Instruct",
+        category: "chat",
+      },
+      {
+        id: "nearai/image-model",
+        name: "Image Model",
+        category: "image",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud-api.near.ai/v1/models",
+      { headers: { Authorization: "Bearer near-key" } },
+    );
+  });
+
+  it("continues to tolerate the legacy NEAR AI model-list response shape", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          models: [
+            {
+              modelId: "legacy/text-model",
+              metadata: {
+                modelDisplayName: "Legacy Text Model",
+                architecture: { outputModalities: ["text"] },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchNearAIModels("", "https://cloud-api.near.ai/v1"),
+    ).resolves.toEqual([
+      {
+        id: "legacy/text-model",
+        name: "Legacy Text Model",
+        category: "chat",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud-api.near.ai/v1/models",
+      { headers: {} },
+    );
+  });
+});

--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -539,34 +539,60 @@ export async function fetchNearAIModels(
   baseUrl: string,
 ): Promise<CachedModel[]> {
   try {
-    const url = `${baseUrl.replace(/\/+$/, "")}/model/list`;
+    type NearAIModelEntry = {
+      id?: string;
+      modelId?: string;
+      name?: string;
+      type?: string;
+      is_ready?: boolean;
+      output_modalities?: string[];
+      architecture?: {
+        outputModalities?: string[];
+        output_modalities?: string[];
+      };
+      metadata?: {
+        modelDisplayName?: string;
+        architecture?: {
+          outputModalities?: string[];
+          output_modalities?: string[];
+        };
+      };
+    };
+
+    const url = `${baseUrl.replace(/\/+$/, "")}/models`;
     const headers: Record<string, string> = {};
     if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
     const res = await fetch(url, { headers });
     if (!res.ok) return [];
     const data = (await res.json()) as {
-      models?: Array<{
-        modelId: string;
-        metadata?: {
-          modelDisplayName?: string;
-          architecture?: { outputModalities?: string[] };
-        };
-      }>;
+      data?: NearAIModelEntry[];
+      models?: NearAIModelEntry[];
     };
-    return (data.models ?? [])
+    return (data.data ?? data.models ?? [])
+      .filter((model) => model.is_ready !== false)
       .map((model) => {
-        const outputs = model.metadata?.architecture?.outputModalities ?? [];
-        const category = outputs.some(
-          (output) => output.toLowerCase() === "image",
-        )
+        const id = model.id ?? model.modelId;
+        if (!id) return null;
+        const outputs =
+          model.output_modalities ??
+          model.architecture?.outputModalities ??
+          model.architecture?.output_modalities ??
+          model.metadata?.architecture?.outputModalities ??
+          model.metadata?.architecture?.output_modalities ??
+          [];
+        const normalizedOutputs = outputs.map((output) => output.toLowerCase());
+        const category = normalizedOutputs.includes("image")
           ? "image"
-          : classifyModel(model.modelId);
+          : model.type
+            ? restTypeToCategory(model.type)
+            : classifyModel(id);
         return {
-          id: model.modelId,
-          name: model.metadata?.modelDisplayName ?? model.modelId,
+          id,
+          name: model.name ?? model.metadata?.modelDisplayName ?? id,
           category,
         };
       })
+      .filter((model): model is CachedModel => model !== null)
       .sort((a, b) => a.id.localeCompare(b.id));
   } catch (e: unknown) {
     logger.warn(

--- a/packages/agent/src/api/provider-switch-config.test.ts
+++ b/packages/agent/src/api/provider-switch-config.test.ts
@@ -73,6 +73,8 @@ describe("clearPersistedFirstRunConfig (reset everything)", () => {
     "OPENAI_LARGE_MODEL",
     "CEREBRAS_MODEL",
     "GROQ_LARGE_MODEL",
+    "NEARAI_SMALL_MODEL",
+    "NEARAI_LARGE_MODEL",
   ] as const;
 
   afterEach(() => {
@@ -311,5 +313,40 @@ describe("applyFirstRunConnectionConfig (Cerebras local provider)", () => {
     const vars = (config.env as { vars?: Record<string, string> } | undefined)
       ?.vars;
     expect(vars?.CEREBRAS_API_KEY).toBeUndefined();
+  });
+});
+
+describe("applyFirstRunConnectionConfig (NEAR AI local provider)", () => {
+  const NEARAI_ENV = [
+    "NEARAI_API_KEY",
+    "NEARAI_SMALL_MODEL",
+    "NEARAI_LARGE_MODEL",
+  ] as const;
+
+  beforeEach(() => {
+    for (const key of NEARAI_ENV) delete process.env[key];
+  });
+  afterEach(() => {
+    for (const key of NEARAI_ENV) delete process.env[key];
+  });
+
+  it("sets NEAR AI Gemma defaults for both text tiers", async () => {
+    const config: Partial<ElizaConfig> = {};
+
+    await applyFirstRunConnectionConfig(config, {
+      kind: "local-provider",
+      provider: "nearai",
+      apiKey: "near-test-123",
+    });
+
+    const vars = (config.env as { vars?: Record<string, string> } | undefined)
+      ?.vars;
+    expect(vars?.NEARAI_API_KEY).toBe("near-test-123");
+    expect(vars?.NEARAI_SMALL_MODEL).toBe("google/gemma-4-31B-it");
+    expect(vars?.NEARAI_LARGE_MODEL).toBe("google/gemma-4-31B-it");
+    expect(process.env.NEARAI_SMALL_MODEL).toBe("google/gemma-4-31B-it");
+    expect(process.env.NEARAI_LARGE_MODEL).toBe("google/gemma-4-31B-it");
+    expect(config.serviceRouting?.llmText?.backend).toBe("nearai");
+    expect(config.serviceRouting?.llmText?.transport).toBe("direct");
   });
 });

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -437,9 +437,9 @@ const PROVIDER_DEFAULT_MODELS: Record<
   },
   nearai: {
     smallKey: "NEARAI_SMALL_MODEL",
-    smallVal: "Qwen/Qwen3.6-35B-A3B-FP8",
+    smallVal: "google/gemma-4-31B-it",
     largeKey: "NEARAI_LARGE_MODEL",
-    largeVal: "zai-org/GLM-5.1-FP8",
+    largeVal: "google/gemma-4-31B-it",
   },
 };
 

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -5060,20 +5060,20 @@
           "type": "string",
           "required": false,
           "sensitive": false,
-          "default": "Qwen/Qwen3.6-35B-A3B-FP8",
+          "default": "google/gemma-4-31B-it",
           "label": "Small Model",
           "help": "Override the default NEAR AI small text model identifier.",
-          "placeholder": "e.g., Qwen/Qwen3.6-35B-A3B-FP8",
+          "placeholder": "e.g., google/gemma-4-31B-it",
           "advanced": false
         },
         "NEARAI_LARGE_MODEL": {
           "type": "string",
           "required": false,
           "sensitive": false,
-          "default": "zai-org/GLM-5.1-FP8",
+          "default": "google/gemma-4-31B-it",
           "label": "Large Model",
           "help": "Override the default NEAR AI large text model identifier.",
-          "placeholder": "e.g., zai-org/GLM-5.1-FP8",
+          "placeholder": "e.g., google/gemma-4-31B-it",
           "advanced": false
         },
         "NEARAI_EXPERIMENTAL_TELEMETRY": {

--- a/plugins/plugin-nearai/AGENTS.md
+++ b/plugins/plugin-nearai/AGENTS.md
@@ -18,8 +18,8 @@ model handlers:
 
 | Model type | Handler | Default model |
 |---|---|---|
-| `ModelType.TEXT_SMALL` | `handleTextSmall` | `Qwen/Qwen3.6-35B-A3B-FP8` |
-| `ModelType.TEXT_LARGE` | `handleTextLarge` | `zai-org/GLM-5.1-FP8` |
+| `ModelType.TEXT_SMALL` | `handleTextSmall` | `google/gemma-4-31B-it` |
+| `ModelType.TEXT_LARGE` | `handleTextLarge` | `google/gemma-4-31B-it` |
 
 Both handlers emit a `EventType.MODEL_USED` event after each successful inference call
 (token counts included).
@@ -71,11 +71,11 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `NEARAI_API_KEY` | Yes (Node) | — | Authentication token for NEAR AI Cloud |
 | `NEARAI_BASE_URL` | No | `https://cloud-api.near.ai/v1` | OpenAI-compatible API base URL (Node) |
 | `NEARAI_BROWSER_BASE_URL` | No | — | Proxy URL used in browser builds instead of base URL (do not expose API keys in-browser) |
-| `NEARAI_SMALL_MODEL` | No | `Qwen/Qwen3.6-35B-A3B-FP8` | Model identifier for `TEXT_SMALL` |
-| `NEARAI_LARGE_MODEL` | No | `zai-org/GLM-5.1-FP8` | Model identifier for `TEXT_LARGE` |
+| `NEARAI_SMALL_MODEL` | No | `google/gemma-4-31B-it` | Model identifier for `TEXT_SMALL` |
+| `NEARAI_LARGE_MODEL` | No | `google/gemma-4-31B-it` | Model identifier for `TEXT_LARGE` |
 | `NEARAI_EXPERIMENTAL_TELEMETRY` | No | `false` | Set `"true"` to enable Vercel AI SDK telemetry |
 
-Model identifiers must match the NEAR AI catalog: `GET https://cloud-api.near.ai/v1/model/list`.
+Model identifiers must match the NEAR AI catalog: `GET https://cloud-api.near.ai/v1/models`.
 
 ## How to extend
 

--- a/plugins/plugin-nearai/CLAUDE.md
+++ b/plugins/plugin-nearai/CLAUDE.md
@@ -18,8 +18,8 @@ model handlers:
 
 | Model type | Handler | Default model |
 |---|---|---|
-| `ModelType.TEXT_SMALL` | `handleTextSmall` | `Qwen/Qwen3.6-35B-A3B-FP8` |
-| `ModelType.TEXT_LARGE` | `handleTextLarge` | `zai-org/GLM-5.1-FP8` |
+| `ModelType.TEXT_SMALL` | `handleTextSmall` | `google/gemma-4-31B-it` |
+| `ModelType.TEXT_LARGE` | `handleTextLarge` | `google/gemma-4-31B-it` |
 
 Both handlers emit a `EventType.MODEL_USED` event after each successful inference call
 (token counts included).
@@ -71,11 +71,11 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `NEARAI_API_KEY` | Yes (Node) | — | Authentication token for NEAR AI Cloud |
 | `NEARAI_BASE_URL` | No | `https://cloud-api.near.ai/v1` | OpenAI-compatible API base URL (Node) |
 | `NEARAI_BROWSER_BASE_URL` | No | — | Proxy URL used in browser builds instead of base URL (do not expose API keys in-browser) |
-| `NEARAI_SMALL_MODEL` | No | `Qwen/Qwen3.6-35B-A3B-FP8` | Model identifier for `TEXT_SMALL` |
-| `NEARAI_LARGE_MODEL` | No | `zai-org/GLM-5.1-FP8` | Model identifier for `TEXT_LARGE` |
+| `NEARAI_SMALL_MODEL` | No | `google/gemma-4-31B-it` | Model identifier for `TEXT_SMALL` |
+| `NEARAI_LARGE_MODEL` | No | `google/gemma-4-31B-it` | Model identifier for `TEXT_LARGE` |
 | `NEARAI_EXPERIMENTAL_TELEMETRY` | No | `false` | Set `"true"` to enable Vercel AI SDK telemetry |
 
-Model identifiers must match the NEAR AI catalog: `GET https://cloud-api.near.ai/v1/model/list`.
+Model identifiers must match the NEAR AI catalog: `GET https://cloud-api.near.ai/v1/models`.
 
 ## How to extend
 

--- a/plugins/plugin-nearai/README.md
+++ b/plugins/plugin-nearai/README.md
@@ -19,13 +19,13 @@ eliza plugins install @elizaos/plugin-nearai
 | `NEARAI_API_KEY` | Yes | - | NEAR AI API key (not needed in browser; use a proxy) |
 | `NEARAI_BASE_URL` | No | `https://cloud-api.near.ai/v1` | OpenAI-compatible API base URL (Node only) |
 | `NEARAI_BROWSER_BASE_URL` | No | - | Proxy base URL for browser builds (omit API key in-browser) |
-| `NEARAI_SMALL_MODEL` | No | `Qwen/Qwen3.6-35B-A3B-FP8` | Small model id |
-| `NEARAI_LARGE_MODEL` | No | `zai-org/GLM-5.1-FP8` | Large model id |
+| `NEARAI_SMALL_MODEL` | No | `google/gemma-4-31B-it` | Small model id |
+| `NEARAI_LARGE_MODEL` | No | `google/gemma-4-31B-it` | Large model id |
 | `NEARAI_EXPERIMENTAL_TELEMETRY` | No | `false` | Set `true` to enable Vercel AI SDK telemetry |
 
 Model ids come from the public NEAR AI catalog at
-`https://cloud-api.near.ai/v1/model/list`. The default models were selected
-from TEE-verifiable text models in that catalog.
+`https://cloud-api.near.ai/v1/models`. The default model was selected from
+ready TEE-verifiable Gemma text models in that catalog.
 
 ## Usage
 

--- a/plugins/plugin-nearai/__tests__/config.test.ts
+++ b/plugins/plugin-nearai/__tests__/config.test.ts
@@ -48,8 +48,8 @@ describe("NEAR AI config", () => {
     const runtime = runtimeWith({});
 
     expect(getBaseURL(runtime)).toBe("https://cloud-api.near.ai/v1");
-    expect(getSmallModel(runtime)).toBe("Qwen/Qwen3.6-35B-A3B-FP8");
-    expect(getLargeModel(runtime)).toBe("zai-org/GLM-5.1-FP8");
+    expect(getSmallModel(runtime)).toBe("google/gemma-4-31B-it");
+    expect(getLargeModel(runtime)).toBe("google/gemma-4-31B-it");
   });
 
   it("normalizes trailing slashes without appending /v1", () => {

--- a/plugins/plugin-nearai/__tests__/text-params.test.ts
+++ b/plugins/plugin-nearai/__tests__/text-params.test.ts
@@ -69,7 +69,7 @@ describe("NEAR AI text parameter resolution", () => {
     await fetcher("https://cloud-api.near.ai/v1/chat/completions", {
       method: "POST",
       body: JSON.stringify({
-        model: "Qwen/Qwen3.6-35B-A3B-FP8",
+        model: "google/gemma-4-31B-it",
         messages: [{ role: "developer", content: "follow policy" }],
         max_completion_tokens: 1024,
         store: true,
@@ -80,7 +80,7 @@ describe("NEAR AI text parameter resolution", () => {
 
     const forwardedInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(String(forwardedInit.body))).toEqual({
-      model: "Qwen/Qwen3.6-35B-A3B-FP8",
+      model: "google/gemma-4-31B-it",
       messages: [{ role: "system", content: "follow policy" }],
       max_tokens: 1024,
     });

--- a/plugins/plugin-nearai/package.json
+++ b/plugins/plugin-nearai/package.json
@@ -103,14 +103,14 @@
         "type": "string",
         "description": "Override the default NEAR AI small model identifier.",
         "required": false,
-        "default": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "default": "google/gemma-4-31B-it",
         "sensitive": false
       },
       "NEARAI_LARGE_MODEL": {
         "type": "string",
         "description": "Override the default NEAR AI large model identifier.",
         "required": false,
-        "default": "zai-org/GLM-5.1-FP8",
+        "default": "google/gemma-4-31B-it",
         "sensitive": false
       },
       "NEARAI_EXPERIMENTAL_TELEMETRY": {

--- a/plugins/plugin-nearai/registry-entry.json
+++ b/plugins/plugin-nearai/registry-entry.json
@@ -28,20 +28,20 @@
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "Qwen/Qwen3.6-35B-A3B-FP8",
+      "default": "google/gemma-4-31B-it",
       "label": "Small Model",
       "help": "Override the default NEAR AI small text model identifier.",
-      "placeholder": "e.g., Qwen/Qwen3.6-35B-A3B-FP8",
+      "placeholder": "e.g., google/gemma-4-31B-it",
       "advanced": false
     },
     "NEARAI_LARGE_MODEL": {
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "zai-org/GLM-5.1-FP8",
+      "default": "google/gemma-4-31B-it",
       "label": "Large Model",
       "help": "Override the default NEAR AI large text model identifier.",
-      "placeholder": "e.g., zai-org/GLM-5.1-FP8",
+      "placeholder": "e.g., google/gemma-4-31B-it",
       "advanced": false
     },
     "NEARAI_EXPERIMENTAL_TELEMETRY": {

--- a/plugins/plugin-nearai/utils/config.ts
+++ b/plugins/plugin-nearai/utils/config.ts
@@ -2,8 +2,9 @@ import type { IAgentRuntime } from "@elizaos/core";
 import type { ModelName, ValidatedApiKey } from "../types";
 import { assertValidApiKey, createModelName } from "../types";
 
-const DEFAULT_SMALL_MODEL = "Qwen/Qwen3.6-35B-A3B-FP8";
-const DEFAULT_LARGE_MODEL = "zai-org/GLM-5.1-FP8";
+const DEFAULT_GEMMA_MODEL = "google/gemma-4-31B-it";
+const DEFAULT_SMALL_MODEL = DEFAULT_GEMMA_MODEL;
+const DEFAULT_LARGE_MODEL = DEFAULT_GEMMA_MODEL;
 
 const DEFAULT_BASE_URL = "https://cloud-api.near.ai/v1";
 


### PR DESCRIPTION
## Summary
- Switch NEAR AI direct-account small/large defaults to `google/gemma-4-31B-it` across plugin config, registry metadata, generated first-party registry output, docs, and agent first-run provider switching.
- Update the NEAR model catalog helper to fetch the current `/v1/models` endpoint, parse the OpenAI-style `data` response, preserve legacy `models` support, and skip models that report `is_ready: false`.
- Add regression coverage for NEAR first-run routing defaults and current/legacy NEAR model catalog responses.

## Evidence
- Live catalog check: `https://cloud-api.near.ai/v1/models` lists `google/gemma-4-31B-it` as ready, owned by `nearai`, HF id `google/gemma-4-31B-it`, bf16, context length `262144`, max output `8192`, text+image input, text output, with tools/reasoning/structured_outputs/json_mode/logprobs support.
- `bunx vitest run packages/agent/src/api/model-provider-helpers.test.ts packages/agent/src/api/provider-switch-config.test.ts --coverage.enabled=false` passed, 2 files / 28 tests.
- `bun run --cwd plugins/plugin-nearai test` passed, 4 files / 17 tests.
- `bun run --cwd packages/registry generate:first-party:check` passed.
- `bun run --cwd packages/registry test` passed, 4 files / 23 tests.
- `bun run --cwd plugins/plugin-nearai typecheck` passed.
- `bun run --cwd packages/agent typecheck` passed.
- `bun run --cwd packages/agent lint` passed.
- `bun run verify` passed after rebasing onto `origin/develop` at `42985713d8`: `523 successful, 523 total`, time `4m40.297s`.
- Grep check found no remaining `Qwen/Qwen3.6-35B-A3B-FP8`, `zai-org/GLM-5.1-FP8`, or `/model/list` references in the touched NEAR/agent/registry surfaces.

## Notes
- No UI changes; `packages/cloud-frontend` visual audit is N/A.
- Real-LLM trajectory evidence is N/A for this chunk because this changes defaults/catalog routing, not an agent action, prompt, or scenario path.