### PR TITLE
fix(training): satisfy training stack ruff lint

### DIFF
--- a/packages/training/scripts/kokoro/coreml/diag_stages.py
+++ b/packages/training/scripts/kokoro/coreml/diag_stages.py
@@ -23,14 +23,17 @@ def reg_ops():
     if "new_ones" not in _TORCH_OPS_REGISTRY.name_to_func_mapping:
         @register_torch_op
         def new_ones(context, node):
-            inputs = _get_inputs(context, node); shape = inputs[1]
-            if isinstance(shape, list): shape = mb.concat(values=shape, axis=0)
+            inputs = _get_inputs(context, node)
+            shape = inputs[1]
+            if isinstance(shape, list):
+                shape = mb.concat(values=shape, axis=0)
             shape = mb.cast(x=shape, dtype="int32")
             context.add(mb.fill(shape=shape, value=1.0, name=node.name))
     @register_torch_op(torch_alias=["and"], override=True)
     def bitwise_and(context, node):
         a, b = _get_inputs(context, node, expected=2)
-        a = mb.cast(x=a, dtype="bool"); b = mb.cast(x=b, dtype="bool")
+        a = mb.cast(x=a, dtype="bool")
+        b = mb.cast(x=b, dtype="bool")
         context.add(mb.logical_and(x=a, y=b, name=node.name))
 
 def main():
@@ -39,16 +42,19 @@ def main():
     voice = json.loads((OUT / "kokoro-coreml/voices/af_heart.json").read_text())["embedding"]
     ps = "həlˈoʊ, ðɪs ɪz ɪlˈaɪzə spˈiːkɪŋ ɑn dəvˈaɪs."
     ids = [0] + [vocab[c] for c in ps if c in vocab] + [0]
-    n = len(ids); ids = ids + [0] * (128 - n)
+    n = len(ids)
+    ids = ids + [0] * (128 - n)
     ids_t = torch.tensor([ids], dtype=torch.int32)
-    mask = torch.zeros(1, 128, dtype=torch.int32); mask[0, :n] = 1
+    mask = torch.zeros(1, 128, dtype=torch.int32)
+    mask[0, :n] = 1
     ref_s = torch.tensor(voice, dtype=torch.float32).view(1, 256)
     phases = torch.rand(1, 9, generator=torch.Generator().manual_seed(7), dtype=torch.float32)
     speed = torch.tensor([1.0], dtype=torch.float32)
 
     m = E.load_model()
     e2e = E.KokoroE2E(m, BUCKET).eval()
-    for mod in e2e.modules(): mod.eval()
+    for mod in e2e.modules():
+        mod.eval()
     e2e._diag = True
     with torch.no_grad():
         a_t, alen_t, pdur_t, f0_t, har_t = e2e(ids_t, mask, ref_s, phases, speed)
@@ -73,8 +79,10 @@ def main():
     pred = ml.predict({"input_ids": ids_t.numpy(), "attention_mask": mask.numpy(),
                        "ref_s": ref_s.numpy(), "random_phases": phases.numpy(), "speed": speed.numpy()})
     def corr(a, b):
-        a = np.asarray(a).reshape(-1).astype(np.float64); b = np.asarray(b).reshape(-1).astype(np.float64)
-        k = min(len(a), len(b)); a, b = a[:k], b[:k]
+        a = np.asarray(a).reshape(-1).astype(np.float64)
+        b = np.asarray(b).reshape(-1).astype(np.float64)
+        k = min(len(a), len(b))
+        a, b = a[:k], b[:k]
         return float(np.corrcoef(a, b)[0, 1]) if k > 1 else 0.0
     f0c = corr(pred["F0_pred"], f0_t.numpy())
     harc = corr(pred["har_source"], har_t.numpy())

--- a/packages/training/scripts/kokoro/coreml/export_e2e_coreml.py
+++ b/packages/training/scripts/kokoro/coreml/export_e2e_coreml.py
@@ -17,7 +17,9 @@ The graph fuses duration + in-graph fixed-bucket alignment + real F0/N
 prosody + real AdaIN decoder + hn-NSF (injected phase) + CustomSTFT iSTFT.
 """
 from __future__ import annotations
-import argparse, importlib.util, json, os, sys
+import argparse
+import importlib.util
+import os
 from pathlib import Path
 import numpy as np
 import torch
@@ -31,7 +33,8 @@ SAMPLES_PER_FRAME = 600  # measured: audio.numel() / pred_dur.sum()
 
 def load_kokoro():
     spec = importlib.util.spec_from_file_location("k_eu", REF / "kokoro/_export_utils.py")
-    eu = importlib.util.module_from_spec(spec); spec.loader.exec_module(eu)
+    eu = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(eu)
     return eu.load_kokoro_for_export(repo_root=str(REF), suffix="_e2e")
 
 ISTFT, MODS, MDL = load_kokoro()
@@ -150,32 +153,40 @@ class MaskedBidirectionalLSTM(nn.Module):
     def _cell(self, x_t, h, c, wih, whh, bih, bhh):
         g = F.linear(x_t, wih, bih) + F.linear(h, whh, bhh)
         i, f, gg, o = g.chunk(4, dim=1)
-        i = torch.sigmoid(i); f = torch.sigmoid(f); gg = torch.tanh(gg); o = torch.sigmoid(o)
+        i = torch.sigmoid(i)
+        f = torch.sigmoid(f)
+        gg = torch.tanh(gg)
+        o = torch.sigmoid(o)
         c_new = f * c + i * gg
         return o * torch.tanh(c_new), c_new
     def forward(self, x, attention_mask):
         b, steps, _ = x.shape
         m = attention_mask.to(dtype=x.dtype)
-        hf = x.new_zeros((b, self.hidden_size)); cf = x.new_zeros((b, self.hidden_size))
+        hf = x.new_zeros((b, self.hidden_size))
+        cf = x.new_zeros((b, self.hidden_size))
         fout = []
         for t in range(steps):
             a = m[:, t].unsqueeze(1)
             h_new, c_new = self._cell(x[:, t, :], hf, cf, self.weight_ih_l0, self.weight_hh_l0, self.bias_ih_l0, self.bias_hh_l0)
-            hf = h_new * a + hf * (1 - a); cf = c_new * a + cf * (1 - a)
+            hf = h_new * a + hf * (1 - a)
+            cf = c_new * a + cf * (1 - a)
             fout.append(hf * a)
-        hb = x.new_zeros((b, self.hidden_size)); cb = x.new_zeros((b, self.hidden_size))
+        hb = x.new_zeros((b, self.hidden_size))
+        cb = x.new_zeros((b, self.hidden_size))
         brev = []
         for t in range(steps - 1, -1, -1):
             a = m[:, t].unsqueeze(1)
             h_new, c_new = self._cell(x[:, t, :], hb, cb, self.weight_ih_l0_reverse, self.weight_hh_l0_reverse, self.bias_ih_l0_reverse, self.bias_hh_l0_reverse)
-            hb = h_new * a + hb * (1 - a); cb = c_new * a + cb * (1 - a)
+            hb = h_new * a + hb * (1 - a)
+            cb = c_new * a + cb * (1 - a)
             brev.append(hb * a)
         return torch.cat([torch.stack(fout, 1), torch.stack(list(reversed(brev)), 1)], dim=2)
 
 class CMLTextEncoder(nn.Module):
     def __init__(self, enc):
         super().__init__()
-        self.embedding = enc.embedding; self.cnn = enc.cnn
+        self.embedding = enc.embedding
+        self.cnn = enc.cnn
         self.lstm = MaskedBidirectionalLSTM(enc.lstm)
     def forward(self, x, input_lengths, m):
         valid = (~m).to(torch.long)
@@ -183,7 +194,8 @@ class CMLTextEncoder(nn.Module):
         m1 = m.unsqueeze(1)
         x = x.masked_fill(m1, 0.0)
         for c in self.cnn:
-            x = c(x); x = x.masked_fill(m1, 0.0)
+            x = c(x)
+            x = x.masked_fill(m1, 0.0)
         x = x.transpose(1, 2)
         x = self.lstm(x, valid)
         x = x.transpose(-1, -2)
@@ -196,7 +208,8 @@ class CMLDurationEncoder(nn.Module):
             MaskedBidirectionalLSTM(b) if isinstance(b, nn.LSTM) else b for b in enc.lstms)
         self.dropout = enc.dropout
     def forward(self, x, style, text_lengths, m):
-        masks = m; valid = (~masks).to(torch.long)
+        masks = m
+        valid = (~masks).to(torch.long)
         x = x.permute(2, 0, 1)
         seq_len = x.shape[0]
         s = style.unsqueeze(0).repeat(seq_len, 1, 1)
@@ -323,8 +336,10 @@ def spectral_parity(a1, a2):
     """Phase-invariant parity: STFT magnitude correlation + log-mel L1."""
     import numpy as _np
     n = min(len(a1), len(a2))
-    a1 = a1[:n].astype(_np.float64); a2 = a2[:n].astype(_np.float64)
-    win = 1024; hop = 256
+    a1 = a1[:n].astype(_np.float64)
+    a2 = a2[:n].astype(_np.float64)
+    win = 1024
+    hop = 256
     w = _np.hanning(win)
     def mag(a):
         frames = [a[i:i+win] * w for i in range(0, len(a) - win, hop)]
@@ -351,9 +366,11 @@ def rep_voice_embedding(voice_pt: Path, n_avg=64) -> np.ndarray:
 def make_inputs(T, n_tokens, ref_s_vec, seed=0):
     g = torch.Generator().manual_seed(seed)
     ids = torch.zeros(1, T, dtype=torch.int32)
-    ids[0, 0] = 0; ids[0, n_tokens-1] = 0
+    ids[0, 0] = 0
+    ids[0, n_tokens-1] = 0
     ids[0, 1:n_tokens-1] = torch.randint(1, 170, (n_tokens-2,), generator=g, dtype=torch.int32)
-    mask = torch.zeros(1, T, dtype=torch.int32); mask[0, :n_tokens] = 1
+    mask = torch.zeros(1, T, dtype=torch.int32)
+    mask[0, :n_tokens] = 1
     ref_s = torch.tensor(ref_s_vec, dtype=torch.float32).view(1, 256)
     phases = torch.rand(1, 9, generator=g, dtype=torch.float32)
     speed = torch.tensor([1.0], dtype=torch.float32)
@@ -396,10 +413,12 @@ def main():
     print(f"[torch] e2e audio={tuple(a_e2e.shape)} valid_len={valid} pred_sum={int(pdur.sum())} "
           f"ref_len={a_ref.numel()} pdur_e2e={pdur[0,:n_tokens].tolist()} pdur_ref={pdur_ref.reshape(-1).tolist()}")
     n = min(valid, a_ref.numel())
-    a1 = a_e2e[0, :n].numpy(); a2 = a_ref.reshape(-1)[:n].numpy()
+    a1 = a_e2e[0, :n].numpy()
+    a2 = a_ref.reshape(-1)[:n].numpy()
     mae = float(_np.mean(_np.abs(a1 - a2)))
     corr = float(_np.corrcoef(a1, a2)[0, 1]) if n > 1 else 0.0
-    rms1 = float(_np.sqrt(_np.mean(a1**2))); rms2 = float(_np.sqrt(_np.mean(a2**2)))
+    rms1 = float(_np.sqrt(_np.mean(a1**2)))
+    rms2 = float(_np.sqrt(_np.mean(a2**2)))
     print(f"[parity torch fused-vs-truth] n={n} MAE={mae:.5f} wav_corr={corr:.5f} rms_fused={rms1:.4f} rms_ref={rms2:.4f}")
     sc, ld = spectral_parity(a1, a2)
     print(f"[spectral parity] stft_mag_corr={sc:.5f} logmel_L1={ld:.5f}")
@@ -419,7 +438,6 @@ def main():
     from coremltools.converters.mil.frontend.torch.ops import _get_inputs
     from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op, _TORCH_OPS_REGISTRY
     from coremltools.converters.mil import Builder as mb
-    from coremltools.converters.mil.frontend.torch.ops import logical_and as _logical_and
     if "new_ones" not in _TORCH_OPS_REGISTRY.name_to_func_mapping:
         @register_torch_op
         def new_ones(context, node):
@@ -462,7 +480,8 @@ def main():
         compute_precision=(ct.precision.FLOAT32 if args.precision == "fp32" else ct.precision.FLOAT16),
         compute_units=ct.ComputeUnit.ALL,
     )
-    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
     pkg = out / f"kokoro_{args.seconds}s.mlpackage"
     mlmodel.save(str(pkg))
     print(f"[saved] {pkg}")

--- a/packages/training/scripts/kokoro/coreml/gen_assets.py
+++ b/packages/training/scripts/kokoro/coreml/gen_assets.py
@@ -8,7 +8,9 @@ Voice embedding = mean of the first N ref_s rows of the Kokoro voice pack
 ([510,1,256]); a single stable speaker vector since the Swift engine uses one
 fixed ref_s per voice across all chunk lengths.
 """
-import json, os, sys
+import json
+import os
+import sys
 from pathlib import Path
 import torch
 
@@ -18,7 +20,8 @@ STYLE_DIM = 256
 N_AVG = 64
 
 def main(out_dir):
-    out = Path(out_dir); (out / "voices").mkdir(parents=True, exist_ok=True)
+    out = Path(out_dir)
+    (out / "voices").mkdir(parents=True, exist_ok=True)
     cfg = json.loads((REF / "checkpoints/config.json").read_text())
     vocab = cfg["vocab"]
     (out / "vocab_index.json").write_text(json.dumps({"vocab": vocab}, ensure_ascii=False))

--- a/packages/training/scripts/kokoro/coreml/validate_e2e_coreml.py
+++ b/packages/training/scripts/kokoro/coreml/validate_e2e_coreml.py
@@ -5,7 +5,9 @@ CoreML kokoro_5s -> audio, compared against torch ground truth.
 Validates that the converted model + vocab_index.json + voices/*.json work
 together to produce intelligible speech.
 """
-import json, os, sys
+import json
+import os
+import sys
 from pathlib import Path
 import numpy as np
 import torch
@@ -50,7 +52,8 @@ def main():
     ids_list, n = ids_from_phonemes(ps, vocab)
     print(f"[tokens] n={n}")
     ids = torch.tensor([ids_list], dtype=torch.int32)
-    mask = torch.zeros(1, 128, dtype=torch.int32); mask[0, :n] = 1
+    mask = torch.zeros(1, 128, dtype=torch.int32)
+    mask[0, :n] = 1
     ref_s = torch.tensor(voice, dtype=torch.float32).view(1, 256)
     phases = torch.rand(1, 9, generator=torch.Generator().manual_seed(7), dtype=torch.float32)
     speed = torch.tensor([1.0], dtype=torch.float32)

--- a/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
+++ b/packages/training/scripts/manifest/test_stage_eliza1_source_weights.py
@@ -138,7 +138,7 @@ def test_27b_class_tiers_use_gemma4_31b_source(
                 "kind": "mtp",
                 "repo": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
                 "filename": "model.safetensors",
-                "destination": f"source/mtp/gemma4-31b-assistant.safetensors",
+                "destination": "source/mtp/gemma4-31b-assistant.safetensors",
                 "license": "gemma",
                 "status": "source-safetensors",
                 "notes": tuple(stage.DRAFTER_SOURCES[tier].notes),
@@ -146,7 +146,7 @@ def test_27b_class_tiers_use_gemma4_31b_source(
                 "path": str(
                     tmp_path
                     / f"eliza-1-{tier}.bundle"
-                    / f"source/mtp/gemma4-31b-assistant.safetensors"
+                    / "source/mtp/gemma4-31b-assistant.safetensors"
                 ),
                 "dryRun": True,
             }


### PR DESCRIPTION
## Summary
- Split one-line statements in Kokoro CoreML helper scripts so the Training Stack ruff lint lane passes on current develop.
- Remove extraneous f-string prefixes from the Eliza-1 source-weight staging test.
- No behavior changes; this unblocks Training Stack CPU smoke for #9734.

## Evidence
- `ruff check packages/training/scripts/` - passed
- `python3 -m py_compile packages/training/scripts/kokoro/coreml/diag_stages.py packages/training/scripts/kokoro/coreml/export_e2e_coreml.py packages/training/scripts/kokoro/coreml/gen_assets.py packages/training/scripts/kokoro/coreml/validate_e2e_coreml.py packages/training/scripts/manifest/test_stage_eliza1_source_weights.py` - passed
- `git diff --check` - passed
- `bun install` - passed
- `bun run verify` - passed, 523/523 tasks successful