### PR TITLE
fix(ui): use the story MockTranslationProvider (not the production provider) in the Storybook decorator

### DIFF
--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -1,9 +1,9 @@
 import { TooltipProvider } from "@elizaos/ui/components/ui/tooltip";
-import { TranslationProvider } from "@elizaos/ui/state";
 import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
+import { MockTranslationProvider } from "../src/storybook/mock-providers";
 
 // The bundled UI stylesheets (tokens, base, brand) — the renderer entry, so the
 // catalog looks exactly like the app.
@@ -82,12 +82,15 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => (
-      // TranslationProvider so stories whose components call useTranslation()
+      // MockTranslationProvider so stories whose components call useTranslation()
       // (e.g. MessageAttachments' PdfDownloadFallback) render in the browser
       // Story Gate. useTranslation only returns a test fallback under
-      // NODE_ENV=test (the jsdom story-smoke), and THROWS "must be used within
-      // TranslationProvider" in the real browser — which crashed those stories.
-      <TranslationProvider>
+      // NODE_ENV=test (the jsdom story-smoke) and THROWS in the real browser —
+      // which crashed those stories. The MOCK provides the same `en` context
+      // with NO network sync; the production TranslationProvider fires
+      // fetchSuggestedLanguage()/updateConfig() on mount, which would be failing
+      // calls on every story in the headless gate.
+      <MockTranslationProvider>
         <TooltipProvider delayDuration={200} skipDelayDuration={100}>
           <StorybookThemeSurface
             theme={resolveStorybookTheme(context.globals.theme)}
@@ -95,7 +98,7 @@ const preview: Preview = {
             <Story />
           </StorybookThemeSurface>
         </TooltipProvider>
-      </TranslationProvider>
+      </MockTranslationProvider>
     ),
     // Light/dark by toggling the `dark` class on the preview root — matches how
     // the app themes (the design tokens key off it).


### PR DESCRIPTION
**Deepscan follow-up** to de017a9ac0 (the Story Gate `TranslationProvider` fix).

That fix wrapped every story in the **production** `TranslationProvider` (`@elizaos/ui/state`), which fires `fetchSuggestedLanguage()` (GET `/api/i18n/locale`) on first-visit mount and `client.updateConfig({ui:{language}})` on change. In the **headless browser Story Gate** (`NODE_ENV != test`) those are failing network calls on every story → spurious gate failures + needless runtime.

A purpose-built **`MockTranslationProvider`** already exists for exactly this (`packages/ui/src/storybook/mock-providers.tsx`) — a real `en` translator with the **same `useTranslation()` context and NO network** (its own doc-comment contrasts itself with the production provider's API calls). This PR reuses it in the global decorator instead of the production provider.

- **Code-quality rule 2** (don't bypass the symbol built for this).
- Components reading `useTranslation()` still render cleanly; the on-mount API calls are gone.
- typecheck + biome clean.

cc @lalalune (owns the Storybook lane). Surfaced by a session-code deepscan.