### PR TITLE
test(cloud): fix red failure-writeback test (invalid UUID fixture after #9730 hardening)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
@@ -14,7 +14,10 @@ import { apps } from "../../../db/schemas/apps";
 import { JOB_TYPES } from "../provisioning-job-types";
 import { ProvisioningJobService } from "../provisioning-jobs";
 
-const APP_ID = "11111111-2222-3333-4444-555555555555";
+// A real v4 UUID (version "4", variant "8") so it passes isValidUUID — the
+// guard the writeback uses to tell an app container's project_name (the app id)
+// from a plain /v1/containers slug.
+const APP_ID = "11111111-2222-4333-8444-555555555555";
 const CONTAINER_ID = "cccccccc-dddd-eeee-ffff-000000000000";
 
 // Minimal DbTransaction stand-in: serves one container row for the select chain


### PR DESCRIPTION
## What

Fixes a **red test on `develop`** in `provisioning-jobs-failure-writeback.test.ts`.

## Why

#9730 was hardened during merge: the CONTAINER_PROVISION failure writeback now guards the resolved app id with the canonical `isValidUUID` (v1-5) + an org-scoped `WHERE` — both good improvements over my original loose `/^[0-9a-f-]{36}$/` regex. But the test's `APP_ID` fixture `11111111-2222-3333-4444-555555555555` is **not a valid UUID** (variant nibble `4` ∉ `[89ab]`). The loose regex accepted it; `isValidUUID` correctly rejects it. So the `"app container -> flipped to failed"` case asserts a flip that never happens:

```
(fail) buildPermanentFailureWriteback: CONTAINER_PROVISION > app container (UUID project_name) -> flipped to failed
 3 pass / 1 fail
```

## Fix

Use a real v4 UUID fixture (`11111111-2222-4333-8444-555555555555`, version `4` / variant `8`) so the test exercises the real flip path through `isValidUUID`.

```
 4 pass
 0 fail
```

cc the #9730 reviewer — the hardening was right, just left the fixture stale. Context: elizaOS/eliza#8434.
