### PR TITLE
fix(local-inference): remove Qwen imagegen defaults

### DIFF
--- a/packages/chip/ELIZA_1_BUNDLE_EXTRAS.json
+++ b/packages/chip/ELIZA_1_BUNDLE_EXTRAS.json
@@ -25,73 +25,34 @@
       },
       "eliza-1-9b": {
         "default": {
-          "id": "imagegen-z-image-turbo-q4_k_m",
-          "file": "imagegen/z-image-turbo-Q4_K_M.gguf",
-          "splitDiffusionModel": true,
-          "companionAssets": [
-            {
-              "role": "vae",
-              "file": "imagegen/vae/ae.safetensors",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/9b/imagegen/vae/ae.safetensors"
-            },
-            {
-              "role": "llm",
-              "file": "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/9b/imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
-            }
-          ],
-          "estimatedSizeBytes": 5017613376,
-          "license": "Apache-2.0",
-          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/9b/imagegen/z-image-turbo-Q4_K_M.gguf",
-          "sha256": "e6494f87de6abaf6a561924f50317a5f271fc34bb4222aabbd801197df8f7daa"
+          "id": "imagegen-sd-1_5-q5_0",
+          "file": "imagegen/sd-1.5-Q5_0.gguf",
+          "estimatedSizeBytes": 1615967904,
+          "license": "CreativeML Open RAIL-M",
+          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/imagegen/sd-1.5-Q5_0.gguf",
+          "sha256": "5d0dce31ee69e5c2e8f0e63f42e6da2ab932ce3b7c8799e3dd85c86c7337dff1"
         },
         "optional": []
       },
       "eliza-1-27b": {
         "default": {
-          "id": "imagegen-z-image-turbo-q4_k_m",
-          "file": "imagegen/z-image-turbo-Q4_K_M.gguf",
-          "splitDiffusionModel": true,
-          "companionAssets": [
-            {
-              "role": "vae",
-              "file": "imagegen/vae/ae.safetensors",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b/imagegen/vae/ae.safetensors"
-            },
-            {
-              "role": "llm",
-              "file": "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b/imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
-            }
-          ],
-          "estimatedSizeBytes": 5017613376,
-          "license": "Apache-2.0",
-          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b/imagegen/z-image-turbo-Q4_K_M.gguf",
-          "sha256": "e6494f87de6abaf6a561924f50317a5f271fc34bb4222aabbd801197df8f7daa"
+          "id": "imagegen-sd-1_5-q5_0",
+          "file": "imagegen/sd-1.5-Q5_0.gguf",
+          "estimatedSizeBytes": 1615967904,
+          "license": "CreativeML Open RAIL-M",
+          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/imagegen/sd-1.5-Q5_0.gguf",
+          "sha256": "5d0dce31ee69e5c2e8f0e63f42e6da2ab932ce3b7c8799e3dd85c86c7337dff1"
         },
         "optional": []
       },
       "eliza-1-27b-256k": {
         "default": {
-          "id": "imagegen-z-image-turbo-q4_k_m",
-          "file": "imagegen/z-image-turbo-Q4_K_M.gguf",
-          "splitDiffusionModel": true,
-          "companionAssets": [
-            {
-              "role": "vae",
-              "file": "imagegen/vae/ae.safetensors",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b-256k/imagegen/vae/ae.safetensors"
-            },
-            {
-              "role": "llm",
-              "file": "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-              "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b-256k/imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
-            }
-          ],
-          "estimatedSizeBytes": 5017613376,
-          "license": "Apache-2.0",
-          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/27b-256k/imagegen/z-image-turbo-Q4_K_M.gguf",
-          "sha256": "e6494f87de6abaf6a561924f50317a5f271fc34bb4222aabbd801197df8f7daa"
+          "id": "imagegen-sd-1_5-q5_0",
+          "file": "imagegen/sd-1.5-Q5_0.gguf",
+          "estimatedSizeBytes": 1615967904,
+          "license": "CreativeML Open RAIL-M",
+          "url": "https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/imagegen/sd-1.5-Q5_0.gguf",
+          "sha256": "5d0dce31ee69e5c2e8f0e63f42e6da2ab932ce3b7c8799e3dd85c86c7337dff1"
         },
         "optional": []
       }

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -225,11 +225,10 @@ interface TierSpec {
   hasVision?: boolean;
   /**
    * WS3: whether this tier ships a default image-gen model in the bundle
-   * extras (`ELIZA_1_BUNDLE_EXTRAS.json#imagegen.perTier`). Mobile-class
-   * tiers (2b/4b) default to SD 1.5 Q5_0 (~1.0 GB); desktop-class
-   * tiers (9b/27b) default to Z-Image-Turbo Q4_K_M
-   * (~3.4 GB). The diffusion weights are runtime-downloaded — they are
-   * NOT part of the base-v1 bundle.
+   * extras (`ELIZA_1_BUNDLE_EXTRAS.json#imagegen.perTier`). All active
+   * tiers default to SD 1.5 Q5_0 until a legacy-free split-diffusion text
+   * encoder is available. The diffusion weights are runtime-downloaded —
+   * they are NOT part of the base-v1 bundle.
    */
   hasImageGen?: boolean;
 }
@@ -250,8 +249,7 @@ const TIER_SPECS: Readonly<Record<Eliza1TierId, TierSpec>> = {
     // 361,518,784 bytes, published 2026-05-14); the arbiter owns the
     // swap with the text weights under pressure.
     hasVision: true,
-    // WS3: image-gen on the standard small-phone default uses SD 1.5
-    // Q5_0 too; tier-up to Z-Image-Turbo at 9B.
+    // WS3: image-gen on the standard small-phone default uses SD 1.5 Q5_0.
     hasImageGen: true,
   },
   "eliza-1-4b": {
@@ -271,8 +269,8 @@ const TIER_SPECS: Readonly<Record<Eliza1TierId, TierSpec>> = {
     textFile: "text/eliza-1-4b-128k.gguf",
     hasEmbedding: true,
     hasVision: true,
-    // WS3: 4B is the last tier that defaults to SD 1.5; flagship-phone
-    // optional path can upgrade to SDXL-Turbo Q4_0.
+    // WS3: 4B uses the same monolithic SD 1.5 default as the rest of the
+    // Gemma cutover catalog.
     hasImageGen: true,
   },
   "eliza-1-9b": {
@@ -287,9 +285,8 @@ const TIER_SPECS: Readonly<Record<Eliza1TierId, TierSpec>> = {
     gpuProfile: "rtx-3090",
     hasEmbedding: true,
     hasVision: true,
-    // WS3: 9B is the boundary tier where Z-Image-Turbo Q4_K_M (~3.4 GB)
-    // becomes the default. FLUX.1 schnell remains opt-in for >=24 GB
-    // shared RAM / >=12 GB VRAM.
+    // WS3: keep 9B on the monolithic SD 1.5 default until a legacy-free
+    // split-diffusion text encoder is available.
     hasImageGen: true,
   },
   "eliza-1-27b": {

--- a/packages/training/scripts/benchmark/__init__.py
+++ b/packages/training/scripts/benchmark/__init__.py
@@ -1,1 +1,1 @@
-"""Benchmark suite for elizaOS-trained Qwen models."""
+"""Benchmark suite for elizaOS-trained Gemma / Eliza-1 models."""

--- a/packages/training/scripts/benchmark/native_tool_call_bench.py
+++ b/packages/training/scripts/benchmark/native_tool_call_bench.py
@@ -4,7 +4,8 @@ The input is `eliza_native_v1` JSONL (legacy flat `ElizaRecord` rows and
 chatml `{messages,tools}` rows are coerced to that shape automatically — see
 _to_native). For each row, the benchmark renders the
 request side with the tokenizer chat template, generates from a base or tuned
-Qwen checkpoint, and compares the decoded output to the native response side.
+Gemma / Eliza-1 checkpoint, and compares the decoded output to the native
+response side.
 
 Primary score:
   - tool_call_structure: expected native tool names and argument keys appear
@@ -120,8 +121,8 @@ def _parse_json_object(text: str) -> dict[str, Any] | None:
     if start < 0:
         return None
     # Walk forward to find the balanced closing brace. Using rfind would
-    # corrupt the slice when the model appends trailing XML (Qwen <tool_call>
-    # blocks) after the eliza JSON object.
+    # corrupt the slice when the model appends trailing tool-call markup after
+    # the eliza JSON object.
     depth = 0
     in_str = False
     escape = False

--- a/packages/training/scripts/format_for_training.py
+++ b/packages/training/scripts/format_for_training.py
@@ -1,4 +1,4 @@
-"""Render Eliza-1 training rows for Qwen chat-template training.
+"""Render Eliza-1 training rows for Gemma chat-template training.
 
 The primary input is `eliza_native_v1`: one row per Vercel AI SDK model
 boundary with the exact request sent to the provider and the exact normalized

--- a/packages/training/scripts/inference/serve_vllm.py
+++ b/packages/training/scripts/inference/serve_vllm.py
@@ -87,7 +87,7 @@ GPU_TARGETS: dict[str, dict] = {
         "tp": 2,
         "gpu_memory_utilization": 0.92,
         "default_weight_quant": "fp8",  # block-wise FP8 W8A8 on Hopper
-        # turboquant_4bit_nc, not 3bit. Per PR #38479 numbers (Qwen3-4B):
+        # turboquant_4bit_nc, not 3bit. Per PR #38479 4B stress-test numbers:
         # 3bit_nc costs ~20pp absolute on GSM8K and +20.59% PPL; 4bit_nc costs
         # only +2.71% PPL. 4bit also matches our vendored fused_turboquant V
         # bit-width (4-bit RHT+Lloyd-Max), so served-vs-local-debug parity is

--- a/packages/training/scripts/manifest/audit_hf_eliza1_release.py
+++ b/packages/training/scripts/manifest/audit_hf_eliza1_release.py
@@ -159,12 +159,10 @@ FINETUNE_REQUIRED_METRICS = frozenset(
 IMAGEGEN_REQUIRED_MODELS = frozenset(
     {
         "imagegen-sd-1_5-q5_0",
-        "imagegen-z-image-turbo-q4_k_m",
     }
 )
 IMAGEGEN_REQUIRED_MODEL_SMOKES = {
     "imagegen-sd-1_5-q5_0": "2b/sd-1.5-Q5_0.gguf",
-    "imagegen-z-image-turbo-q4_k_m": "9b/z-image-turbo-Q4_K_M.gguf",
 }
 IMAGEGEN_REQUIRED_ACCELERATORS = frozenset({"cpu", "cuda", "vulkan", "metal"})
 IMAGEGEN_REQUIRED_MEMORY_FEATURES = frozenset({"mmap", "maxVramAuto", "segmentedOffload"})

--- a/packages/training/scripts/manifest/eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/eliza1_platform_plan.py
@@ -76,16 +76,12 @@ VAD_ARTIFACTS: Final[tuple[str, ...]] = ("vad/silero-vad-v5.gguf",)
 VAD_OPTIONAL_FALLBACK_ARTIFACTS: Final[tuple[str, ...]] = (
     "vad/silero-vad-int8.onnx",
 )
-Z_IMAGE_COMPANION_ARTIFACTS: Final[tuple[str, ...]] = (
-    "imagegen/vae/ae.safetensors",
-    "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-)
 IMAGEGEN_ARTIFACTS_BY_TIER: Final[Mapping[str, tuple[str, ...]]] = {
     "2b": ("imagegen/sd-1.5-Q5_0.gguf",),
     "4b": ("imagegen/sd-1.5-Q5_0.gguf",),
-    "9b": ("imagegen/z-image-turbo-Q4_K_M.gguf", *Z_IMAGE_COMPANION_ARTIFACTS),
-    "27b": ("imagegen/z-image-turbo-Q4_K_M.gguf", *Z_IMAGE_COMPANION_ARTIFACTS),
-    "27b-256k": ("imagegen/z-image-turbo-Q4_K_M.gguf", *Z_IMAGE_COMPANION_ARTIFACTS),
+    "9b": ("imagegen/sd-1.5-Q5_0.gguf",),
+    "27b": ("imagegen/sd-1.5-Q5_0.gguf",),
+    "27b-256k": ("imagegen/sd-1.5-Q5_0.gguf",),
 }
 VISION_TIERS: Final[frozenset[str]] = ELIZA_1_VISION_TIERS
 MTP_TIERS: Final[frozenset[str]] = ELIZA_1_MTP_TIERS

--- a/packages/training/scripts/manifest/test_audit_hf_eliza1_release.py
+++ b/packages/training/scripts/manifest/test_audit_hf_eliza1_release.py
@@ -362,7 +362,6 @@ def _passing_imagegen_runtime() -> str:
                 "available": True,
                 "supportedModels": [
                     "imagegen-sd-1_5-q5_0",
-                    "imagegen-z-image-turbo-q4_k_m",
                 ],
                 "accelerators": ["cpu", "cuda", "vulkan", "metal"],
             },
@@ -383,10 +382,6 @@ def _passing_imagegen_runtime() -> str:
                     "2b/sd-1.5-Q5_0.gguf": {
                         "status": "pass",
                         "report": "evidence/imagegen/sd15-2b-metal-smoke.json",
-                    },
-                    "9b/z-image-turbo-Q4_K_M.gguf": {
-                        "status": "pass",
-                        "report": "evidence/imagegen/zimage-9b-metal-smoke.json",
                     },
                 },
             },
@@ -765,6 +760,13 @@ def _passing_release_evidence(tier: str) -> str:
 
 
 def _passing_model_manifest(tier: str) -> str:
+    text_base_by_tier = {
+        "2b": "google/gemma-4-E2B",
+        "4b": "google/gemma-4-E4B",
+        "9b": "google/gemma-4-12B",
+        "27b": "google/gemma-4-31B",
+        "27b-256k": "google/gemma-4-31B",
+    }
     files_by_dir: dict[str, list[dict[str, object]]] = {}
     for rel in build_plan()[tier].required_files:
         root = rel.split("/", 1)[0]
@@ -778,19 +780,15 @@ def _passing_model_manifest(tier: str) -> str:
         {
             "tier": tier,
             "lineage": {
-                "text": {"base": f"Qwen/{tier}", "license": "apache-2.0"},
-                "voice": {"base": "Qwen/Qwen3-TTS", "license": "apache-2.0"},
-                "asr": {"base": "ggml-org/Qwen3-ASR-0.6B-GGUF", "license": "apache-2.0"},
+                "text": {"base": text_base_by_tier[tier], "license": "apache-2.0"},
+                "voice": {"base": "Serveurperso/OmniVoice-GGUF", "license": "cc-by-nc-sa-4.0"},
+                "asr": {"base": "elizaos/eliza-1-asr", "license": "apache-2.0"},
                 "vad": {"base": "voice/vad/silero-vad-v5.gguf", "license": "mit"},
                 "imagegen": {
-                    "base": (
-                        "second-state/stable-diffusion-v1-5-GGUF"
-                        if tier in {"2b", "4b"}
-                        else "city96/z-image-turbo-gguf"
-                    ),
+                    "base": "second-state/stable-diffusion-v1-5-GGUF",
                     "license": "model license",
                 },
-                "vision": {"base": "Qwen/Qwen3-VL", "license": "apache-2.0"},
+                "vision": {"base": "elizaos/eliza-1-vision-mmproj", "license": "apache-2.0"},
                 "drafter": {"base": f"eliza-1-{tier}-drafter", "license": "apache-2.0"},
             },
             "files": files_by_dir,
@@ -1048,7 +1046,7 @@ def test_hf_release_audit_blocks_required_file_missing_from_manifest_files() -> 
     failed = [check for check in report.checks if not check["ok"]]
     assert any(
         check["name"] == "9b manifest files cover required runtime artifacts"
-        and "imagegen/z-image-turbo-Q4_K_M.gguf" in check["detail"]
+        and "imagegen/sd-1.5-Q5_0.gguf" in check["detail"]
         for check in failed
     )
 
@@ -1157,7 +1155,7 @@ def test_hf_release_audit_requires_release_upload_evidence() -> None:
 
 def test_hf_release_audit_requires_imagegen_release_payload_weight() -> None:
     bad_evidence = __import__("json").loads(_passing_release_evidence("9b"))
-    bad_evidence["weights"].remove("imagegen/z-image-turbo-Q4_K_M.gguf")
+    bad_evidence["weights"].remove("imagegen/sd-1.5-Q5_0.gguf")
 
     report = audit_hf_release(
         fetch_json=_fetcher(),
@@ -1168,30 +1166,7 @@ def test_hf_release_audit_requires_imagegen_release_payload_weight() -> None:
     failed = [check for check in report.checks if not check["ok"]]
     assert any(
         check["name"] == "9b release evidence is publishable"
-        and "weights.imagegen/z-image-turbo-Q4_K_M.gguf: missing" in check["detail"]
-        for check in failed
-    )
-
-
-def test_hf_release_audit_requires_zimage_companion_release_payload_weights() -> None:
-    bad_evidence = __import__("json").loads(_passing_release_evidence("9b"))
-    bad_evidence["weights"].remove("imagegen/vae/ae.safetensors")
-    bad_evidence["weights"].remove(
-        "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
-    )
-
-    report = audit_hf_release(
-        fetch_json=_fetcher(),
-        fetch_text=_text_fetcher(release_evidence={"9b": __import__("json").dumps(bad_evidence)}),
-    )
-
-    assert not report.ok
-    failed = [check for check in report.checks if not check["ok"]]
-    assert any(
-        check["name"] == "9b release evidence is publishable"
-        and "weights.imagegen/vae/ae.safetensors: missing" in check["detail"]
-        and "weights.imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf: missing"
-        in check["detail"]
+        and "weights.imagegen/sd-1.5-Q5_0.gguf: missing" in check["detail"]
         for check in failed
     )
 
@@ -1393,18 +1368,18 @@ def test_hf_release_audit_blocks_incomplete_imagegen_runtime_evidence() -> None:
         and "runtime.upstreamCommit: missing" in check["detail"]
         and "runtime.binaryVersion: missing" in check["detail"]
         and "probe.available: False" in check["detail"]
-        and "probe.supportedModels.imagegen-z-image-turbo-q4_k_m: missing" in check["detail"]
+        and "memory.maxVramAuto: False" in check["detail"]
         for check in failed
     )
 
 
 def test_hf_release_audit_blocks_failed_required_imagegen_model_smoke() -> None:
     bad = __import__("json").loads(_passing_imagegen_runtime())
-    bad["smoke"]["models"]["9b/z-image-turbo-Q4_K_M.gguf"] = {
+    bad["smoke"]["models"]["2b/sd-1.5-Q5_0.gguf"] = {
         "status": "fail",
-        "report": "evidence/imagegen/zimage-9b-cpu-smoke.json",
+        "report": "evidence/imagegen/sd15-2b-cpu-smoke.json",
         "error": "get sd version from file failed",
-        "architecture": "lumina2",
+        "architecture": "sd1.5",
     }
 
     report = audit_hf_release(
@@ -1416,7 +1391,7 @@ def test_hf_release_audit_blocks_failed_required_imagegen_model_smoke() -> None:
     failed = [check for check in report.checks if not check["ok"]]
     assert any(
         check["name"] == "imagegen runtime evidence passed"
-        and "smoke.models.imagegen-z-image-turbo-q4_k_m.status: 'fail'" in check["detail"]
+        and "smoke.models.imagegen-sd-1_5-q5_0.status: 'fail'" in check["detail"]
         and "get sd version from file failed" in check["detail"]
         for check in failed
     )

--- a/packages/training/scripts/manifest/test_eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/test_eliza1_platform_plan.py
@@ -77,17 +77,10 @@ def test_text_contexts_ship_half_and_native_contexts() -> None:
 
 def test_imagegen_required_files_match_tier_defaults() -> None:
     plan = build_plan()
-    for tier in ("2b", "4b"):
+    for tier in ("2b", "4b", "9b", "27b", "27b-256k"):
         assert "imagegen/sd-1.5-Q5_0.gguf" in plan[tier].required_files
         assert "imagegen/z-image-turbo-Q4_K_M.gguf" not in plan[tier].required_files
-    for tier in ("9b", "27b", "27b-256k"):
-        assert "imagegen/z-image-turbo-Q4_K_M.gguf" in plan[tier].required_files
-        assert "imagegen/vae/ae.safetensors" in plan[tier].required_files
-        assert (
-            "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
-            in plan[tier].required_files
-        )
-        assert "imagegen/sd-1.5-Q5_0.gguf" not in plan[tier].required_files
+        assert "imagegen/vae/ae.safetensors" not in plan[tier].required_files
 
 
 def test_voice_artifacts_follow_kokoro_omnivoice_boundary() -> None:

--- a/packages/training/scripts/synth/together_synth.py
+++ b/packages/training/scripts/synth/together_synth.py
@@ -15,7 +15,7 @@ Usage:
         --scenarios scripts/synth/scenarios/all.jsonl \\
         --max 5000 \\
         --concurrency 8 \\
-        --model Qwen/Qwen3-235B-A22B-Instruct-2507-tput
+        --model google/gemma-4-31B-it
 """
 from __future__ import annotations
 
@@ -30,6 +30,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 OUT_DIR = ROOT / "data" / "synthesized" / "together-synth"
+DEFAULT_TOGETHER_MODEL = "google/gemma-4-31B-it"
 
 
 def system_prompt_for(scenario: dict) -> str:
@@ -155,8 +156,7 @@ def main() -> int:
                     default=ROOT / "scripts/synth/scenarios/all.jsonl")
     ap.add_argument("--max", type=int, default=0)
     ap.add_argument("--concurrency", type=int, default=8)
-    ap.add_argument("--model", type=str,
-                    default="Qwen/Qwen3-235B-A22B-Instruct-2507-tput")
+    ap.add_argument("--model", type=str, default=DEFAULT_TOGETHER_MODEL)
     args = ap.parse_args()
 
     if not os.environ.get("TOGETHER_API_KEY"):

--- a/packages/training/scripts/to_together_format.py
+++ b/packages/training/scripts/to_together_format.py
@@ -53,8 +53,8 @@ from typing import Any, Iterator
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
-# Re-use the Qwen-side prompt resolver so Together training sees the same
-# conditioning surface as the Qwen / Gemini formatters.
+# Re-use the canonical prompt resolver so Together training sees the same
+# conditioning surface as the Gemma / Gemini formatters.
 from format_for_training import system_prompt_for  # noqa: E402
 
 # --------------------------------------------------------------------------- #
@@ -147,7 +147,7 @@ def build_together_record(eliza: dict[str, Any]) -> TogetherBuildResult:
     if not cm_text:
         return TogetherBuildResult(None, "empty_currentMessage")
 
-    # 1. System prompt (same resolver as the Qwen/Gemini formatters).
+    # 1. System prompt (same resolver as the Gemma/Gemini formatters).
     system_text = system_prompt_for(eliza).rstrip()
 
     md = eliza.get("metadata") or {}

--- a/packages/training/scripts/train_nebius.sh
+++ b/packages/training/scripts/train_nebius.sh
@@ -29,12 +29,10 @@
 #   REGISTRY_KEY=gemma4-e4b   → eliza-1-4b     (single H200)
 #   REGISTRY_KEY=gemma4-12b   → eliza-1-9b     (single H200, ~80 GB peak)
 #   REGISTRY_KEY=gemma4-31b  → eliza-1-27b    (8× H200 fallback; prefer Vast)
-#   (legacy Qwen3 line: qwen3-0.6b, qwen3-1.7b, qwen3-4b — kept addressable for
-#   compatibility but the eliza-1 fused-kernel stack only validates Gemma 4.)
 #
 # Required env:
 #   NEBIUS_PROJECT_ID          # the project (== parent-id), e.g. project-e00kfz6cpr00q21z892vec
-#   HUGGING_FACE_HUB_TOKEN     # for gated Qwen access + pushing results
+#   HUGGING_FACE_HUB_TOKEN     # for gated Gemma access + pushing results
 # Optional env:
 #   REGISTRY_KEY               # default: gemma4-e2b
 #   RUN_NAME                   # default: <registry-key>-apollo-<unix-ts>

--- a/packages/training/scripts/verify_optimization_stack.py
+++ b/packages/training/scripts/verify_optimization_stack.py
@@ -13,11 +13,10 @@ Asserts on a staged/published Eliza-1 bundle dir (or the raw
   * The stage sidecar files exist and the recorded SHA matches the
     safetensors blob.
   * ``qjl_config.json`` + ``turboquant.json`` shape against the model arch
-    (``num_hidden_layers``, ``n_full_attention_layers`` — for Qwen3.5 that's
-    6 of 24, NOT 24 of 24).
-  * For hybrid linear-attn models, ``turboquant.linear_attention_layers_skipped``
-    is the complement of ``turboquant.full_attention_layers`` and the union
-    covers every decoder index.
+    (``num_hidden_layers`` plus full/global-attention metadata when present).
+  * For hybrid/windowed-attention models, skipped/local layers and full/global
+    layers are disjoint and cover every decoder index when the sidecar records
+    both lists.
 
 Run on a staged bundle:
     uv run python scripts/verify_optimization_stack.py \\

--- a/plugins/plugin-local-inference/__tests__/imagegen-publishing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-publishing.test.ts
@@ -250,39 +250,20 @@ describe("WS3 imagegen publishing pipeline", () => {
 		}
 	});
 
-	it("split Z-Image defaults declare required companion assets", () => {
+	it("default imagegen tiers do not require split companion assets", () => {
 		const extras = loadExtras();
 		const failures: string[] = [];
-		for (const tierId of [
-			"eliza-1-9b",
-			"eliza-1-27b",
-			"eliza-1-27b-256k",
-		]) {
+		for (const tierId of Object.keys(extras.imagegen.perTier)) {
 			const entry = extras.imagegen.perTier[tierId]?.default;
 			const where = `imagegen.perTier.${tierId}.default`;
-			if (entry?.id !== "imagegen-z-image-turbo-q4_k_m") {
-				failures.push(`${where}: expected z-image default`);
-				continue;
+			if (entry?.id !== "imagegen-sd-1_5-q5_0") {
+				failures.push(`${where}: expected SD 1.5 default`);
 			}
-			if (entry.splitDiffusionModel !== true) {
-				failures.push(`${where}: missing splitDiffusionModel:true`);
+			if (entry?.splitDiffusionModel === true) {
+				failures.push(`${where}: default must be monolithic`);
 			}
-			const companions = entry.companionAssets ?? [];
-			const byRole = new Map(companions.map((asset) => [asset.role, asset]));
-			for (const [role, file] of [
-				["vae", "imagegen/vae/ae.safetensors"],
-				[
-					"llm",
-					"imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-				],
-			] as const) {
-				const asset = byRole.get(role);
-				if (asset?.file !== file) {
-					failures.push(`${where}: ${role} companion file missing`);
-				}
-				if (!isHttpsUrl(asset?.url)) {
-					failures.push(`${where}: ${role} companion url missing`);
-				}
+			if ((entry?.companionAssets ?? []).length > 0) {
+				failures.push(`${where}: default must not require companion assets`);
 			}
 		}
 		expect(failures, failures.join("\n")).toHaveLength(0);

--- a/plugins/plugin-local-inference/__tests__/imagegen-routing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-routing.test.ts
@@ -8,9 +8,8 @@
  *   1. `services/imagegen/backend-selector.ts#TIER_TO_DEFAULT_IMAGE_MODEL`
  *   2. `eliza/packages/chip/ELIZA_1_BUNDLE_EXTRAS.json#imagegen.perTier`
  *
- * This test asserts they agree, plus that the small/desktop split lands
- * where the bundle plan expects (sd-1.5 for 2b/4b; z-image-turbo
- * for 9b/27b/27b-256k).
+ * This test asserts they agree, plus that every tier lands on the SD 1.5
+ * default until a legacy-free split-diffusion encoder is available.
  */
 
 import { describe, expect, it } from "vitest";
@@ -42,23 +41,17 @@ interface ExtrasShape {
 }
 
 describe("WS3 routing — tier → default image-gen model", () => {
-	it("mobile tiers default to sd-1.5 Q5_0", () => {
-		for (const tier of ["eliza-1-2b", "eliza-1-4b"]) {
-			const entry = TIER_TO_DEFAULT_IMAGE_MODEL[tier];
-			expect(entry?.modelId).toBe("imagegen-sd-1_5-q5_0");
-			expect(entry?.file).toBe("imagegen/sd-1.5-Q5_0.gguf");
-		}
-	});
-
-	it("desktop tiers default to z-image-turbo Q4_K_M", () => {
+	it("all tiers default to sd-1.5 Q5_0", () => {
 		for (const tier of [
+			"eliza-1-2b",
+			"eliza-1-4b",
 			"eliza-1-9b",
 			"eliza-1-27b",
 			"eliza-1-27b-256k",
 		]) {
 			const entry = TIER_TO_DEFAULT_IMAGE_MODEL[tier];
-			expect(entry?.modelId).toBe("imagegen-z-image-turbo-q4_k_m");
-			expect(entry?.file).toBe("imagegen/z-image-turbo-Q4_K_M.gguf");
+			expect(entry?.modelId).toBe("imagegen-sd-1_5-q5_0");
+			expect(entry?.file).toBe("imagegen/sd-1.5-Q5_0.gguf");
 		}
 	});
 
@@ -67,7 +60,7 @@ describe("WS3 routing — tier → default image-gen model", () => {
 			"imagegen-sd-1_5-q5_0",
 		);
 		expect(resolveDefaultImageGenModel("eliza-1-9b")?.modelId).toBe(
-			"imagegen-z-image-turbo-q4_k_m",
+			"imagegen-sd-1_5-q5_0",
 		);
 	});
 
@@ -75,9 +68,6 @@ describe("WS3 routing — tier → default image-gen model", () => {
 		expect(resolveDefaultImageGenModel("imagegen-sd-1_5-q5_0")?.modelId).toBe(
 			"imagegen-sd-1_5-q5_0",
 		);
-		expect(
-			resolveDefaultImageGenModel("imagegen-z-image-turbo-q4_k_m")?.modelId,
-		).toBe("imagegen-z-image-turbo-q4_k_m");
 	});
 
 	it("resolveDefaultImageGenModel returns null on unknown input", () => {

--- a/plugins/plugin-local-inference/__tests__/imagegen-sd-cpp-probe.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-sd-cpp-probe.test.ts
@@ -478,7 +478,7 @@ describe("WS3 sd-cpp backend — CLI argument contract", () => {
 			modelPath: "/models/imagegen/z-image-turbo-Q4_K_M.gguf",
 			splitDiffusionModel: true,
 			vae: "/models/imagegen/vae/ae.safetensors",
-			llm: "/models/imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+			llm: "/models/imagegen/text-encoders/split-llm-text-encoder-Q4_K_M.gguf",
 		});
 		expect(args.slice(0, 2)).toEqual([
 			"--diffusion-model",
@@ -488,7 +488,7 @@ describe("WS3 sd-cpp backend — CLI argument contract", () => {
 		expect(args).toContain("/models/imagegen/vae/ae.safetensors");
 		expect(args).toContain("--llm");
 		expect(args).toContain(
-			"/models/imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+			"/models/imagegen/text-encoders/split-llm-text-encoder-Q4_K_M.gguf",
 		);
 		expect(args).not.toContain("--model");
 	});

--- a/plugins/plugin-local-inference/__tests__/text-bundle.test.ts
+++ b/plugins/plugin-local-inference/__tests__/text-bundle.test.ts
@@ -128,7 +128,7 @@ describe("per-tier text + embedding bundle resolution", () => {
 			});
 
 			it("does not declare a default KV-cache override for shipped tiers", () => {
-				// Shipped qwen35 tiers stay on F16 KV by default. QJL/TBQ cache
+				// Shipped Gemma tiers stay on F16 KV by default. QJL/TBQ cache
 				// experiments are opt-in per runtime/backend, not catalog defaults.
 				expect(model?.runtime?.kvCache).toBeUndefined();
 			});

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -1030,9 +1030,9 @@ function resolveImageGenModelKeyFromRuntime(runtime: IAgentRuntime): string {
 const TIER_TO_DEFAULT_IMAGE_MODEL_KEY: Readonly<Record<string, string>> = {
 	"eliza-1-2b": "imagegen-sd-1_5-q5_0",
 	"eliza-1-4b": "imagegen-sd-1_5-q5_0",
-	"eliza-1-9b": "imagegen-z-image-turbo-q4_k_m",
-	"eliza-1-27b": "imagegen-z-image-turbo-q4_k_m",
-	"eliza-1-27b-256k": "imagegen-z-image-turbo-q4_k_m",
+	"eliza-1-9b": "imagegen-sd-1_5-q5_0",
+	"eliza-1-27b": "imagegen-sd-1_5-q5_0",
+	"eliza-1-27b-256k": "imagegen-sd-1_5-q5_0",
 };
 
 export function createLocalInferenceModelHandlers(): NonNullable<

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
@@ -168,12 +168,10 @@ describe("resolveDefaultImageGenModel", () => {
 		});
 	});
 
-	it("resolves a large tier to the split Z-Image diffusion bundle", () => {
-		expect(resolveDefaultImageGenModel("eliza-1-9b")).toMatchObject({
-			modelId: "imagegen-z-image-turbo-q4_k_m",
-			file: "imagegen/z-image-turbo-Q4_K_M.gguf",
-			splitDiffusionModel: true,
-			vae: "imagegen/vae/ae.safetensors",
+	it("resolves a large tier to the SD-1.5 file while split encoders are not default-eligible", () => {
+		expect(resolveDefaultImageGenModel("eliza-1-9b")).toEqual({
+			modelId: "imagegen-sd-1_5-q5_0",
+			file: "imagegen/sd-1.5-Q5_0.gguf",
 		});
 	});
 

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
@@ -232,25 +232,16 @@ export const TIER_TO_DEFAULT_IMAGE_MODEL: Readonly<
 		file: "imagegen/sd-1.5-Q5_0.gguf",
 	},
 	"eliza-1-9b": {
-		modelId: "imagegen-z-image-turbo-q4_k_m",
-		file: "imagegen/z-image-turbo-Q4_K_M.gguf",
-		splitDiffusionModel: true,
-		vae: "imagegen/vae/ae.safetensors",
-		llm: "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+		modelId: "imagegen-sd-1_5-q5_0",
+		file: "imagegen/sd-1.5-Q5_0.gguf",
 	},
 	"eliza-1-27b": {
-		modelId: "imagegen-z-image-turbo-q4_k_m",
-		file: "imagegen/z-image-turbo-Q4_K_M.gguf",
-		splitDiffusionModel: true,
-		vae: "imagegen/vae/ae.safetensors",
-		llm: "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+		modelId: "imagegen-sd-1_5-q5_0",
+		file: "imagegen/sd-1.5-Q5_0.gguf",
 	},
 	"eliza-1-27b-256k": {
-		modelId: "imagegen-z-image-turbo-q4_k_m",
-		file: "imagegen/z-image-turbo-Q4_K_M.gguf",
-		splitDiffusionModel: true,
-		vae: "imagegen/vae/ae.safetensors",
-		llm: "imagegen/text-encoders/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+		modelId: "imagegen-sd-1_5-q5_0",
+		file: "imagegen/sd-1.5-Q5_0.gguf",
 	},
 };
 

--- a/plugins/plugin-local-inference/src/services/imagegen/types.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/types.ts
@@ -116,9 +116,9 @@ export interface ImageGenResult {
  * `ELIZA_1_BUNDLE_EXTRAS.json`.
  *
  * Some diffusion families are single-file GGUFs once quantized, such as
- * SD 1.5 Q5_0. Others stay split: stable-diffusion.cpp runs Z-Image
- * with `--diffusion-model` plus separate Qwen LLM text encoder and VAE
- * files. The optional paths below carry those companion assets.
+ * SD 1.5 Q5_0. Others stay split: stable-diffusion.cpp runs some diffusion
+ * families with `--diffusion-model` plus separate text encoder and VAE files.
+ * The optional paths below carry those companion assets.
  */
 export interface ImageGenLoadArgs {
 	/** Absolute path to the primary diffusion weights (GGUF / mlpackage / engine). */
@@ -135,7 +135,7 @@ export interface ImageGenLoadArgs {
 	clip?: string;
 	/** Optional split T5 / Gemma text encoder path. */
 	t5?: string;
-	/** Optional split LLM text encoder path, e.g. Qwen3 for Z-Image. */
+	/** Optional split LLM text encoder path for split diffusion bundles. */
 	llm?: string;
 	/**
 	 * Backend-specific acceleration hint. Accepts:


### PR DESCRIPTION
## Summary
- Move every Eliza-1 imagegen tier default and publish requirement to the monolithic `imagegen-sd-1_5-q5_0` GGUF instead of the Qwen-backed Z-Image split bundle.
- Switch Together synthetic-data generation defaults from Qwen to `google/gemma-4-31B-it`.
- Refresh training/local-inference tests and docs around Gemma defaults while preserving retired-Qwen ASR/embedding provenance guardrails.

Refs #9588
Refs #9583

## Evidence
- `git fetch origin && git rebase origin/develop`: clean rebase onto `7eaaaf16ef`.
- `bun install`: passed, no lockfile changes.
- `bun test plugins/plugin-local-inference/__tests__/imagegen-routing.test.ts plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts plugins/plugin-local-inference/__tests__/imagegen-publishing.test.ts plugins/plugin-local-inference/__tests__/text-bundle.test.ts`: 58 pass / 0 fail.
- `bun test plugins/plugin-local-inference/__tests__/imagegen-sd-cpp-probe.test.ts`: 18 pass / 0 fail.
- `pytest -q packages/training/scripts/manifest/test_eliza1_platform_plan.py packages/training/scripts/manifest/test_audit_hf_eliza1_release.py`: 81 pass.
- `pytest -q packages/training/scripts/inference/test_serve_vllm.py packages/training/scripts/training/test_model_registry.py`: 21 pass.
- `bun run --cwd plugins/plugin-local-inference typecheck`: passed.
- `bun run --cwd packages/shared typecheck`: passed.
- `python -m compileall -q <changed training scripts>`: passed.
- `git diff --check`: passed.
- `bun run verify`: passed, 523 successful / 523 total.

## URL probes
- Together Gemma default: `https://www.together.ai/models/gemma-4-31b` returned HTTP 200.
- Existing shared SD 1.5 GGUF: `https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/imagegen/sd-1.5-Q5_0.gguf?download=true` returned HTTP 302.
- Tier-local SD 1.5 GGUF paths for `9b`, `27b`, and `27b-256k` returned HTTP 404, so the bundle extras intentionally point those tiers at the already-published 2b SD 1.5 artifact URL.

## PR Evidence Checklist
- Real-LLM trajectories: N/A, this changes static defaults/manifests/tests and does not change agent prompts or model behavior generation paths directly.
- Backend/frontend logs: N/A, no runtime route/UI path changed.
- Screenshots/video: N/A, no UI changed.
- Audio walkthrough: N/A, no voice/TTS/STT behavior changed.
