### PR TITLE
ci: fail Hetzner E2E on invalid cloud auth

### DIFF
--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -5,6 +5,8 @@ name: Hetzner Agent E2E
 # staging API, runs a single bridge-ping healthcheck, then tears
 # everything down. Gracefully skips when the required secrets are
 # unset (so this workflow can land on develop and be activated later).
+# Once secrets are configured, bad cloud auth must fail loudly; otherwise the
+# launch-critical provision path can silently stop exercising Headscale.
 #
 # Required secrets / config (GitHub environment: ci-hetzner-e2e):
 #   HCLOUD_TOKEN_CI        - Hetzner Cloud API token (CI-scoped project)
@@ -142,18 +144,17 @@ jobs:
           status_code="$(printf '%s' "$response" | bun -e 'const chunks=[]; for await (const chunk of Bun.stdin.stream()) chunks.push(Buffer.from(chunk)); const data = JSON.parse(Buffer.concat(chunks).toString() || "{}"); console.log(data.status ?? "");')"
           if [ "$status_code" = "401" ] || [ "$status_code" = "403" ]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Cloud API rejected CLOUD_E2E_API_KEY with HTTP $status_code; skipping Hetzner E2E before provisioning."
+            echo "::error::Cloud API rejected CLOUD_E2E_API_KEY with HTTP $status_code; Hetzner E2E is configured but cannot provision."
             {
-              echo "### Hetzner E2E skipped"
+              echo "### Hetzner E2E failed before provisioning"
               echo ""
               echo "Cloud API rejected \`CLOUD_E2E_API_KEY\` with HTTP \`$status_code\` before provisioning Hetzner capacity."
               echo ""
-              echo "Refresh the \`CLOUD_E2E_API_KEY\` / \`ELIZACLOUD_API_KEY\` secret in the \`ci-hetzner-e2e\` environment, or check the staging API-key lookup path."
+              echo "The \`ci-hetzner-e2e\` environment is configured, so this is a real gate failure rather than an intentional skip."
+              echo ""
+              echo "Refresh the \`CLOUD_E2E_API_KEY\` / \`ELIZACLOUD_API_KEY\` secret with a staging key that can list and provision agents, or check the staging API-key lookup path."
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              exit 1
-            fi
-            exit 0
+            exit 1
           fi
 
           if [ "${status_code#2}" != "$status_code" ]; then

--- a/packages/scripts/cloud/admin/hetzner-e2e/README.md
+++ b/packages/scripts/cloud/admin/hetzner-e2e/README.md
@@ -7,7 +7,10 @@ sweeps any servers older than 60 minutes every half hour as a safety
 net.
 
 The workflow gracefully skips when secrets are unset, so it can land
-on `develop` and be activated later by adding secrets.
+on `develop` and be activated later by adding secrets. Once secrets
+are present, the Cloud API auth preflight is a real gate: a 401/403
+from `CLOUD_E2E_API_KEY` fails the run instead of reporting a skip,
+because an invalid key would otherwise hide provisioning regressions.
 
 ## One-time setup
 


### PR DESCRIPTION
## What
- Keep Hetzner E2E skips for truly missing secrets.
- Fail the workflow when configured `CLOUD_E2E_API_KEY` auth returns 401/403.
- Document the difference between unconfigured skips and configured bad-auth failures.

## Why
#8434 called out that Hetzner E2E could false-green when the staging key was rejected, which meant the launch-critical provision/headscale path was not actually being exercised. A configured-but-invalid key should be a red gate, not an intentional skip.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hetzner-e2e.yml"); puts "yaml ok"'`
