### PR TITLE
fix(local-inference): align vision fixtures with Gemma

### DIFF
--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -1,9 +1,9 @@
 /**
  * WS7 — Brain (full-screen reasoning).
  *
- * Sends one image per display (each downscaled to ~1.3 MP, the OS-Atlas /
- * Qwen3-VL `max_pixels` convention) to `runtime.useModel(IMAGE_DESCRIPTION,
- * ...)`. The model is prompted to emit a JSON `BrainOutput` describing:
+ * Sends one image per display (each downscaled to ~1.3 MP, the local Gemma
+ * vision / OS-Atlas image budget) to `runtime.useModel(IMAGE_DESCRIPTION, ...)`.
+ * The model is prompted to emit a JSON `BrainOutput` describing:
  *   - the scene in one paragraph,
  *   - which display to act on,
  *   - up to N ROIs the Actor should zoom into,
@@ -65,9 +65,9 @@ export const BRAIN_DHASH_CACHE_MAX = 16;
  */
 export const BRAIN_DHASH_HAMMING_THRESHOLD = 5;
 /**
- * Image-token estimate per source pixel for a vision model with the Qwen3-VL /
- * OS-Atlas `max_pixels` convention: one visual token ≈ a 28×28 (≈750 px) patch.
- * Used only to quantify the saving when a frame is *not* attached (#9105).
+ * Image-token estimate per source pixel for the local Gemma vision / OS-Atlas
+ * budget: one visual token ≈ a 28×28 (≈750 px) patch. Used only to quantify
+ * the saving when a frame is *not* attached (#9105).
  */
 export const BRAIN_PIXELS_PER_IMAGE_TOKEN = 750;
 
@@ -327,11 +327,7 @@ export class Brain {
     // plan, skip the (possibly remote) IMAGE_DESCRIPTION call. Tolerant to a few
     // dHash bits so cosmetic churn (cursor, caret, anti-aliasing) still hits.
     const sceneSignature = sceneCacheSignature(input.scene);
-    const key = this.cacheKey(
-      targetCapture.frame,
-      input.goal,
-      sceneSignature,
-    );
+    const key = this.cacheKey(targetCapture.frame, input.goal, sceneSignature);
     if (key) {
       const cached = this.findCached(key.dh, key.goal, key.sceneSignature);
       if (cached) {

--- a/plugins/plugin-local-inference/__tests__/imagegen-handler.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-handler.test.ts
@@ -265,7 +265,7 @@ describe("WS3 image-gen — coexistence with vision-describe", () => {
 					visState.loaded += 1;
 					return makeFakeVisionBackend(visState);
 				},
-				modelFamily: "qwen3-vl",
+				modelFamily: "gemma-vl",
 			}),
 		);
 
@@ -280,7 +280,7 @@ describe("WS3 image-gen — coexistence with vision-describe", () => {
 			{ image: { kind: "bytes"; bytes: Uint8Array }; prompt: string },
 			{ title: string; description: string }
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: {
 				image: { kind: "bytes", bytes: new Uint8Array([1, 2, 3]) },
 				prompt: "describe",

--- a/plugins/plugin-local-inference/__tests__/imagegen-vision-coexist.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-vision-coexist.test.ts
@@ -146,7 +146,7 @@ describe("WS3 ↔ WS2 shared vision residentRole — reverse swap direction", ()
 					visState.loaded += 1;
 					return makeFakeVisionBackend(visState);
 				},
-				modelFamily: "qwen3-vl",
+				modelFamily: "gemma-vl",
 			}),
 		);
 		arbiter.registerCapability(
@@ -163,7 +163,7 @@ describe("WS3 ↔ WS2 shared vision residentRole — reverse swap direction", ()
 			{ image: { kind: "bytes"; bytes: Uint8Array }; prompt: string },
 			{ title: string; description: string }
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: {
 				image: { kind: "bytes", bytes: new Uint8Array([9, 9, 9]) },
 				prompt: "what is this",
@@ -210,7 +210,7 @@ describe("WS3 cache namespace separation", () => {
 		// computes.
 		const visionHash = hashVisionInput(
 			{ kind: "bytes", bytes: new Uint8Array([1, 2, 3, 4]) },
-			"qwen3-vl",
+			"gemma-vl",
 		);
 		expect(typeof visionHash).toBe("string");
 		expect(visionHash).toMatch(/^[0-9a-f]+$/);
@@ -288,7 +288,7 @@ describe("WS3 ↔ WS2 swap refcount-awareness", () => {
 					visState.loaded += 1;
 					return makeFakeVisionBackend(visState);
 				},
-				modelFamily: "qwen3-vl",
+				modelFamily: "gemma-vl",
 			}),
 		);
 		arbiter.registerCapability(
@@ -303,7 +303,7 @@ describe("WS3 ↔ WS2 swap refcount-awareness", () => {
 		// Acquire a long-lived vision handle (refCount=1).
 		const handle = await arbiter.acquire<VisionDescribeBackend>(
 			"vision-describe",
-			"qwen3-vl-2b",
+			"gemma-vl-2b",
 		);
 		expect(visState.loaded).toBe(1);
 

--- a/plugins/plugin-local-inference/__tests__/memory-arbiter.test.ts
+++ b/plugins/plugin-local-inference/__tests__/memory-arbiter.test.ts
@@ -104,7 +104,7 @@ function makeArbiter(opts: { capacitorBridge?: ReturnType<typeof capacitorPressu
 describe("MemoryArbiter — registration and acquire", () => {
 	it("rejects acquire when no capability is registered", async () => {
 		const { arbiter } = makeArbiter();
-		await expect(arbiter.acquire("vision-describe", "qwen3-vl-4b")).rejects.toThrow(
+		await expect(arbiter.acquire("vision-describe", "gemma-vl-4b")).rejects.toThrow(
 			/no capability registered/,
 		);
 	});
@@ -209,7 +209,7 @@ describe("MemoryArbiter — swap on conflicting role", () => {
 		arbiter.registerCapability(text.registration);
 		arbiter.registerCapability(vision.registration);
 		const t = await arbiter.acquire<FakeBackend>("text", "tier-2b");
-		const v = await arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const v = await arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		expect(text.unloaded).toEqual([]);
 		expect(vision.unloaded).toEqual([]);
 		await t.release();
@@ -232,7 +232,7 @@ describe("MemoryArbiter — memory pressure", () => {
 		arbiter.registerCapability(text.registration);
 		arbiter.registerCapability(vision.registration);
 		const t = await arbiter.acquire<FakeBackend>("text", "tier-2b");
-		const v = await arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const v = await arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		await t.release();
 		await v.release();
 		// Vision is priority 20 (cheaper) than text-target (100); pressure
@@ -240,7 +240,7 @@ describe("MemoryArbiter — memory pressure", () => {
 		bridge.dispatch("low");
 		// Allow the async handler to drain.
 		await new Promise<void>((r) => setTimeout(r, 5));
-		expect(vision.unloaded).toEqual(["qwen3-vl-4b"]);
+		expect(vision.unloaded).toEqual(["gemma-vl-4b"]);
 		expect(text.unloaded).toEqual([]);
 		const pressureEvents = events.filter((e) => e.type === "memory_pressure");
 		expect(pressureEvents.at(-1)?.level).toBe("low");
@@ -261,14 +261,14 @@ describe("MemoryArbiter — memory pressure", () => {
 		arbiter.registerCapability(vision.registration);
 		arbiter.registerCapability(embedding.registration);
 		const t = await arbiter.acquire<FakeBackend>("text", "tier-2b");
-		const v = await arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const v = await arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		const e = await arbiter.acquire<FakeBackend>("embedding", "embedding-small");
 		await t.release();
 		await v.release();
 		await e.release();
 		bridge.dispatch("critical");
 		await new Promise<void>((r) => setTimeout(r, 5));
-		expect(vision.unloaded).toEqual(["qwen3-vl-4b"]);
+		expect(vision.unloaded).toEqual(["gemma-vl-4b"]);
 		expect(embedding.unloaded).toEqual(["embedding-small"]);
 		// text-target survives critical
 		expect(text.unloaded).toEqual([]);
@@ -284,7 +284,7 @@ describe("MemoryArbiter — memory pressure", () => {
 		bridge.dispatch("critical");
 		await new Promise<void>((r) => setTimeout(r, 5));
 		await expect(
-			arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b"),
+			arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b"),
 		).rejects.toThrow(/critical/);
 	});
 
@@ -309,7 +309,7 @@ describe("MemoryArbiter — memory pressure", () => {
 		arbiter.registerCapability(text.registration);
 		arbiter.registerCapability(vision.registration);
 		const t = await arbiter.acquire<FakeBackend>("text", "tier-2b");
-		const v = await arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const v = await arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		// Hold onto vision (refcount=1)
 		await t.release();
 		bridge.dispatch("critical");
@@ -530,13 +530,13 @@ describe("MemoryArbiter — concurrency edge cases", () => {
 				payload: { x: "slow" },
 			}),
 			arbiter.requestVisionDescribe<{ x: string }, string>({
-				modelKey: "qwen3-vl-4b",
+				modelKey: "gemma-vl-4b",
 				payload: { x: "fast" },
 			}),
 		]);
 		const elapsed = Date.now() - start;
 		expect(t).toBe("tier-2b:slow");
-		expect(v).toBe("qwen3-vl-4b:fast");
+		expect(v).toBe("gemma-vl-4b:fast");
 		// If queues were shared, total would be ~30ms (text) + ~0ms (vision) =
 		// 30ms. With separate queues we expect at most max(loadtimes)+max(runtimes),
 		// still bounded — assert specifically that vision did not block on text.
@@ -554,13 +554,13 @@ describe("MemoryArbiter — concurrency edge cases", () => {
 		arbiter.registerCapability(text.registration);
 		arbiter.registerCapability(vision.registration);
 		// Start a slow vision load.
-		const visionAcquire = arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const visionAcquire = arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		// While it's mid-flight, dispatch low pressure. The arbiter should
 		// process the event without crashing the load.
 		bridge.dispatch("low");
 		await new Promise<void>((r) => setTimeout(r, 5));
 		const handle = await visionAcquire;
-		expect(handle.backend.id).toBe("qwen3-vl-4b");
+		expect(handle.backend.id).toBe("gemma-vl-4b");
 		await handle.release();
 	});
 
@@ -602,12 +602,12 @@ describe("MemoryArbiter — shutdown", () => {
 		arbiter.registerCapability(text.registration);
 		arbiter.registerCapability(vision.registration);
 		const t = await arbiter.acquire<FakeBackend>("text", "tier-2b");
-		const v = await arbiter.acquire<FakeBackend>("vision-describe", "qwen3-vl-4b");
+		const v = await arbiter.acquire<FakeBackend>("vision-describe", "gemma-vl-4b");
 		await t.release();
 		await v.release();
 		await arbiter.shutdown();
 		expect(text.unloaded).toContain("tier-2b");
-		expect(vision.unloaded).toContain("qwen3-vl-4b");
+		expect(vision.unloaded).toContain("gemma-vl-4b");
 		await expect(arbiter.acquire("text", "tier-2b")).rejects.toThrow(/shutting down/);
 	});
 });

--- a/plugins/plugin-local-inference/__tests__/vision-describe.test.ts
+++ b/plugins/plugin-local-inference/__tests__/vision-describe.test.ts
@@ -17,10 +17,10 @@
  *     `/completion` payload shape.
  *
  * On-device GPU validation notes (not exercised here; no GPU on this host):
- *   - Metal:  load qwen3-vl-2b on M-series mac; the encode path goes
+ *   - Metal:  load gemma-vl-2b on M-series mac; the encode path goes
  *     through `mtmd_encode_chunks` and lands on the Metal compute
  *     encoder. Validate: a 1024×1024 frame describes in <1.5s end-to-end.
- *   - CUDA:   load qwen3-vl-9b on RTX 3090; same path through cuBLAS.
+ *   - CUDA:   load gemma-vl-9b on RTX 3090; same path through cuBLAS.
  *     Validate: a 1024×1024 frame describes in <0.8s end-to-end.
  *   - QNN:    on Snapdragon 8 Gen 3, validate that
  *     `eliza_llama_mtmd_describe` succeeds with the Q4_K_M 0.8B mmproj,
@@ -109,14 +109,14 @@ function newArbiter(): MemoryArbiter {
 describe("vision/hash", () => {
 	it("hashes the same bytes deterministically", () => {
 		const bytes = tinyPngBytes();
-		const a = hashImageBytes(bytes, "qwen3-vl");
-		const b = hashImageBytes(bytes, "qwen3-vl");
+		const a = hashImageBytes(bytes, "gemma-vl");
+		const b = hashImageBytes(bytes, "gemma-vl");
 		expect(a).toBe(b);
 	});
 
 	it("namespaces by model family", () => {
 		const bytes = tinyPngBytes();
-		const a = hashImageBytes(bytes, "qwen3-vl");
+		const a = hashImageBytes(bytes, "gemma-vl");
 		const b = hashImageBytes(bytes, "florence-2");
 		expect(a).not.toBe(b);
 	});
@@ -125,14 +125,14 @@ describe("vision/hash", () => {
 		const bytes = tinyPngBytes();
 		const base64 = Buffer.from(bytes).toString("base64");
 		const dataUrl = `data:image/png;base64,${base64}`;
-		const fromBytes = hashVisionInput({ kind: "bytes", bytes }, "qwen3-vl");
+		const fromBytes = hashVisionInput({ kind: "bytes", bytes }, "gemma-vl");
 		const fromBase64 = hashVisionInput(
 			{ kind: "base64", base64 },
-			"qwen3-vl",
+			"gemma-vl",
 		);
 		const fromDataUrl = hashVisionInput(
 			{ kind: "dataUrl", dataUrl },
-			"qwen3-vl",
+			"gemma-vl",
 		);
 		expect(fromBase64).toBe(fromBytes);
 		expect(fromDataUrl).toBe(fromBytes);
@@ -183,13 +183,13 @@ describe("vision/capability registration", () => {
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: {
 				image: { kind: "bytes", bytes: tinyPngBytes() },
 				prompt: "what",
 			},
 		});
-		expect(state.loaded).toEqual(["qwen3-vl"]);
+		expect(state.loaded).toEqual(["gemma-vl"]);
 		expect(state.described).toBe(1);
 		expect(state.receivedProjected[0]).toBe(false);
 		expect(result.description).toBe("described what");
@@ -229,7 +229,7 @@ describe("vision/capability registration", () => {
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: {
 				image: { kind: "bytes", bytes },
 				prompt: "what",
@@ -260,7 +260,7 @@ describe("vision/capability registration", () => {
 		);
 		await expect(
 			arbiter.requestVisionDescribe<VisionDescribeRequest, VisionDescribeResult>({
-				modelKey: "qwen3-vl",
+				modelKey: "gemma-vl",
 				payload: {
 					image: { kind: "bytes", bytes: tinyPngBytes() },
 					prompt: "boom",
@@ -289,7 +289,7 @@ describe("vision/capability registration", () => {
 			>,
 		);
 		await arbiter.requestVisionDescribe<VisionDescribeRequest, VisionDescribeResult>({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: {
 				image: { kind: "bytes", bytes: tinyPngBytes() },
 			},
@@ -329,7 +329,7 @@ describe("vision/capability registration", () => {
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: { image: { kind: "bytes", bytes }, prompt: "frame" },
 		});
 		expect(r1.cacheHit).toBe(false);
@@ -349,7 +349,7 @@ describe("vision/capability registration", () => {
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: { image: { kind: "bytes", bytes }, prompt: "frame" },
 		});
 		expect(r2.cacheHit).toBe(true);

--- a/plugins/plugin-local-inference/__tests__/vl-cross-eviction.test.ts
+++ b/plugins/plugin-local-inference/__tests__/vl-cross-eviction.test.ts
@@ -178,7 +178,7 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: {
 				image: { kind: "bytes", bytes: tinyPngBytes() },
 				prompt: "describe",
@@ -212,7 +212,7 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: {
 				image: { kind: "bytes", bytes: tinyPngBytes() },
 				prompt: "describe-again",
@@ -249,14 +249,14 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-4b",
+			modelKey: "gemma-vl-4b",
 			payload: { image: { kind: "bytes", bytes: tinyPngBytes() } },
 		});
 		await arbiter.requestVisionDescribe<
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: { image: { kind: "bytes", bytes: tinyPngBytes() } },
 		});
 
@@ -265,7 +265,7 @@ describe("WS2 cross-modality eviction — vision-describe ↔ image-gen (same `v
 		expect(arbiter.residentSnapshot()).toHaveLength(1);
 		expect(
 			arbiter.residentSnapshot()[0].modelKey,
-		).toBe("qwen3-vl-2b");
+		).toBe("gemma-vl-2b");
 
 		await arbiter.shutdown();
 	});
@@ -300,7 +300,7 @@ describe("WS2 text+vision coexistence — different resident-role slots", () => 
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: { image: { kind: "bytes", bytes: tinyPngBytes() } },
 		});
 		expect(vis.loaded).toBe(1);
@@ -336,7 +336,7 @@ describe("WS2 text+vision coexistence — different resident-role slots", () => 
 			VisionDescribeRequest,
 			VisionDescribeResult
 		>({
-			modelKey: "qwen3-vl-2b",
+			modelKey: "gemma-vl-2b",
 			payload: { image: { kind: "bytes", bytes: tinyPngBytes() } },
 		});
 		expect(vis.loaded).toBe(1);

--- a/plugins/plugin-local-inference/__tests__/ws1-ws2-seam.test.ts
+++ b/plugins/plugin-local-inference/__tests__/ws1-ws2-seam.test.ts
@@ -321,7 +321,7 @@ describe("WS1↔WS2 seam — mobile pressure dispatch evicts non-text roles", ()
 		arbiter.registerCapability(visionReg);
 
 		const tHandle = await arbiter.acquire("text", "eliza-1-2b");
-		const vHandle = await arbiter.acquire("vision-describe", "qwen3-vl");
+		const vHandle = await arbiter.acquire("vision-describe", "gemma-vl");
 		await tHandle.release();
 		await vHandle.release();
 
@@ -340,7 +340,7 @@ describe("WS1↔WS2 seam — mobile pressure dispatch evicts non-text roles", ()
 		expect(evictions).toHaveLength(1);
 		expect(evictions[0]).toMatchObject({
 			capability: "vision-describe",
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			reason: "pressure",
 		});
 	});
@@ -372,7 +372,7 @@ describe("WS1↔WS2 seam — mobile pressure dispatch evicts non-text roles", ()
 		);
 
 		const t = await arbiter.acquire("text", "eliza-1-2b");
-		const v = await arbiter.acquire("vision-describe", "qwen3-vl");
+		const v = await arbiter.acquire("vision-describe", "gemma-vl");
 		await t.release();
 		await v.release();
 
@@ -384,7 +384,7 @@ describe("WS1↔WS2 seam — mobile pressure dispatch evicts non-text roles", ()
 
 		// And per docs: while critical, further non-text acquires throw.
 		await expect(
-			arbiter.acquire("vision-describe", "qwen3-vl"),
+			arbiter.acquire("vision-describe", "gemma-vl"),
 		).rejects.toThrow(/critical/);
 	});
 
@@ -412,7 +412,7 @@ describe("WS1↔WS2 seam — mobile pressure dispatch evicts non-text roles", ()
 				loader: async () => makeFakeBackend(visionState),
 			}),
 		);
-		const v = await arbiter.acquire("vision-describe", "qwen3-vl");
+		const v = await arbiter.acquire("vision-describe", "gemma-vl");
 		await v.release();
 
 		// Desktop reports nominal; mobile dispatches critical via the
@@ -458,7 +458,7 @@ describe("WS1↔WS2 seam — eviction order uses real WS2 wrapper", () => {
 		// Order is intentional: text first, then vision. We are testing
 		// that priority (not insertion order) drives the pressure pick.
 		const t = await arbiter.acquire("text", "eliza-1-2b");
-		const v = await arbiter.acquire("vision-describe", "qwen3-vl");
+		const v = await arbiter.acquire("vision-describe", "gemma-vl");
 		await t.release();
 		await v.release();
 
@@ -512,7 +512,7 @@ describe("WS1↔WS2 seam — AOSP backend unavailable surfaces cleanly", () => {
 		);
 		await expect(
 			arbiter.requestVisionDescribe({
-				modelKey: "qwen3-vl",
+				modelKey: "gemma-vl",
 				payload: {
 					image: { kind: "bytes", bytes: tinyPngBytes() },
 					prompt: "x",
@@ -524,7 +524,7 @@ describe("WS1↔WS2 seam — AOSP backend unavailable surfaces cleanly", () => {
 		// return stale data.
 		await expect(
 			arbiter.requestVisionDescribe({
-				modelKey: "qwen3-vl",
+				modelKey: "gemma-vl",
 				payload: {
 					image: { kind: "bytes", bytes: tinyPngBytes() },
 					prompt: "x",
@@ -620,7 +620,7 @@ describe("WS1↔WS2 seam — in-flight vision-describe + pressure", () => {
 
 		// Fire a describe in the background; it holds the vision refcount.
 		const inflight = arbiter.requestVisionDescribe({
-			modelKey: "qwen3-vl",
+			modelKey: "gemma-vl",
 			payload: {
 				image: { kind: "bytes", bytes: tinyPngBytes() },
 				prompt: "x",

--- a/plugins/plugin-vision/src/screen-capture.ts
+++ b/plugins/plugin-vision/src/screen-capture.ts
@@ -16,8 +16,8 @@ const execAsync = promisify(exec);
 
 // `tileSize` in VisionConfig is the legacy fixed-grid edge. The new tiler
 // treats it as `maxEdge` — the largest dimension a single tile may have. The
-// tiler's defaults are tuned for Qwen3.5-VL; respect the config override only
-// when it stays in the model-sweet-spot range.
+// tiler's defaults target local Gemma vision OCR detail; respect the config
+// override only when it stays in a practical local-VLM range.
 const MIN_TILER_EDGE = 64;
 const SINGLE_DISPLAY_ID = "primary";
 
@@ -161,8 +161,8 @@ export class ScreenCaptureService {
       const width = metadata.width || 1920;
       const height = metadata.height || 1080;
 
-      // Hand layout to the overlap-aware tiler. It sizes tiles to the model
-      // sweet spot (Qwen3.5-VL) and seams them with overlap so glyphs that
+      // Hand layout to the overlap-aware tiler. It sizes tiles to the local
+      // Gemma vision budget and seams them with overlap so glyphs that
       // straddle a boundary still appear intact in at least one tile.
       const maxEdge = Math.max(
         MIN_TILER_EDGE,

--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -227,7 +227,7 @@ describe("reconstructAbsoluteCoords", () => {
 });
 
 describe("tileScreenshot — defaults", () => {
-  it("exports DEFAULT_MAX_EDGE in the Qwen3.5-VL sweet spot", () => {
+  it("exports DEFAULT_MAX_EDGE in the local-VLM tile budget window", () => {
     expect(DEFAULT_MAX_EDGE).toBeGreaterThanOrEqual(1024);
     expect(DEFAULT_MAX_EDGE).toBeLessThanOrEqual(1568);
   });

--- a/plugins/plugin-vision/src/screen-tiler.ts
+++ b/plugins/plugin-vision/src/screen-tiler.ts
@@ -1,14 +1,13 @@
 /**
- * Overlap-aware screen tiler for the eliza-1 (Qwen3.5-VL) vision pipeline.
+ * Overlap-aware screen tiler for the eliza-1 local Gemma vision pipeline.
  *
  * Why this exists:
- *   Qwen3.5-VL has a sweet-spot input edge of ~1024-1568 px. A native ultra-
- *   wide or DPI-dense capture (e.g. 5120x2160 or a Retina 6K panel) gets
- *   resized down by the model preprocessor, which destroys small UI text and
- *   makes OCR-class detail unreadable in a single pass. We instead split the
- *   capture into a grid of tiles, each at or below the model's optimal edge,
- *   with a configurable pixel overlap so words/glyphs that straddle a seam
- *   still appear intact in at least one tile.
+ *   Native ultra-wide or DPI-dense captures (e.g. 5120x2160 or a Retina 6K
+ *   panel) get resized down by the model preprocessor, which destroys small UI
+ *   text and makes OCR-class detail unreadable in a single pass. We instead
+ *   split the capture into a grid of local-VLM-sized tiles with a configurable
+ *   pixel overlap so words/glyphs that straddle a seam still appear intact in
+ *   at least one tile.
  *
  * Coordinates:
  *   Every emitted tile carries `sourceX/sourceY` in the source display's
@@ -62,19 +61,19 @@ export interface TileScreenshotOptions {
   maxEdge: number;
   /**
    * Fraction of `tileSize` that adjacent tiles overlap. 0.12 (default) is
-   * tuned for Qwen3.5-VL — large enough to keep multi-glyph tokens intact
-   * across seams, small enough to keep tile count near minimum.
+   * large enough to keep multi-glyph tokens intact across seams, small enough
+   * to keep tile count near minimum.
    */
   overlapFraction: number;
 }
 
-/** Default Qwen3.5-VL-friendly tile budget. */
+/** Default local-VLM tile budget for Gemma vision. */
 export const DEFAULT_MAX_EDGE = 1280;
 /** Default seam overlap (12%). */
 export const DEFAULT_OVERLAP_FRACTION = 0.12;
 
 /**
- * Tile a captured screenshot into Qwen3.5-VL-sized PNG patches with
+ * Tile a captured screenshot into local-VLM-sized PNG patches with
  * pixel-overlap between neighbours.
  *
  * Single-tile fast path: when both dims fit within `maxEdge`, the input is

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -1452,7 +1452,7 @@ export class VisionService extends Service {
       }
 
       // Route every VLM call through the runtime IMAGE_DESCRIPTION handler.
-      // When eliza-1 (Qwen3.5-VL) is registered locally it owns this slot;
+      // When eliza-1 local Gemma vision is registered it owns this slot;
       // otherwise the runtime rotates to whichever cloud/remote provider
       // has registered IMAGE_DESCRIPTION. plugin-vision no longer ships its
       // own VLM.


### PR DESCRIPTION
## Summary

- Renames active local-inference vision fixture keys from `qwen3-vl*` to `gemma-vl*`.
- Aligns test fixture `modelFamily` values with the runtime `gemma-vl` default.
- Replaces Qwen-specific local VLM comments in `plugin-vision` and `plugin-computeruse` with Gemma/local-VLM wording.

Refs #9588
Refs #9583

## Evidence

- Synced with `develop`: `git fetch origin && git rebase origin/develop` completed cleanly.
- Dependencies refreshed: `bun install` completed with no lockfile changes.
- `bun test plugins/plugin-local-inference/__tests__/memory-arbiter.test.ts plugins/plugin-local-inference/__tests__/vision-describe.test.ts plugins/plugin-local-inference/__tests__/imagegen-handler.test.ts plugins/plugin-local-inference/__tests__/imagegen-vision-coexist.test.ts plugins/plugin-local-inference/__tests__/vl-cross-eviction.test.ts plugins/plugin-local-inference/__tests__/ws1-ws2-seam.test.ts` passed: 72 tests, 195 assertions.
- `bun test plugins/plugin-vision/src/screen-tiler.test.ts` passed: 12 tests, 100 assertions.
- `bun run --cwd plugins/plugin-local-inference typecheck` passed.
- `bun run --cwd plugins/plugin-computeruse typecheck` passed.
- `bunx @biomejs/biome check <edited files>` passed with only pre-existing non-null assertion warnings.
- `git diff --check` passed.
- `bun run verify` passed: 523/523 tasks.

## PR evidence checklist

- Real-LLM trajectory: N/A, test fixture key/comment alignment only; no prompt/action/model-runtime behavior added.
- Backend logs: N/A, no runtime backend path changed.
- Frontend logs/screenshots/video: N/A, no UI changes.
- Audio/TTS/STT evidence: N/A, no voice path changed.
