### PR TITLE
fix(ui): drop blue from memory-type badge + a couple cloud surfaces

### DIFF
--- a/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
+++ b/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
@@ -41,7 +41,8 @@ function methodBadgeClass(method: HttpMethod) {
     case "GET":
       return `${base} bg-emerald-500/10 text-emerald-400 border-emerald-500/30 `;
     case "POST":
-      return `${base} bg-blue-500/10 text-blue-400 border-blue-500/30 `;
+      // Brand rule: no blue. Slate keeps POST distinct from the amber PUT.
+      return `${base} bg-slate-500/10 text-slate-300 border-slate-500/30 `;
     case "PUT":
       return `${base} bg-amber-500/10 text-amber-400 border-amber-500/30 `;
     case "PATCH":

--- a/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.tsx
+++ b/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.tsx
@@ -35,7 +35,9 @@ interface DashboardRoutePageProps {
 }
 
 const bannerTones: Record<DashboardRoutePageBannerTone, string> = {
-  info: "border-blue-400/30 bg-blue-400/10 text-blue-100",
+  // Brand rule: no blue. Slate reads as neutral "info" alongside the
+  // emerald/amber/red tones below.
+  info: "border-slate-400/30 bg-slate-400/10 text-slate-100",
   success: "border-emerald-400/30 bg-emerald-400/10 text-emerald-100",
   warning: "border-amber-400/30 bg-amber-400/10 text-amber-100",
   error: "border-red-500/40 bg-red-500/10 text-red-400",

--- a/packages/ui/src/styles/brand-gold.css
+++ b/packages/ui/src/styles/brand-gold.css
@@ -406,11 +406,12 @@
  * literals at the component layer.
  */
 :root {
-  /* On-brand memory-type cues: gold (focal) + blue (info) + neutral grays.
-     No decorative indigo/purple/green/amber; the per-type icon carries the rest
-     of the distinction. */
-  --memory-type-messages-bg: rgba(29, 145, 232, 0.14);
-  --memory-type-messages-fg: rgb(29, 145, 232);
+  /* On-brand memory-type cues: gold (focal) + neutral slate/stone grays.
+     No decorative blue/indigo/purple/green/amber; the per-type icon carries the
+     rest of the distinction. Messages use a darker slate so they read distinct
+     from facts (slate-500) without grabbing the gold primary accent. */
+  --memory-type-messages-bg: rgba(71, 85, 105, 0.14);
+  --memory-type-messages-fg: rgb(71, 85, 105);
   --memory-type-memories-bg: rgba(240, 185, 11, 0.16);
   --memory-type-memories-fg: rgb(240, 185, 11);
   --memory-type-facts-bg: rgba(100, 116, 139, 0.14);


### PR DESCRIPTION
## What

The shared message-type memory badge was painted a saturated blue (`--memory-type-messages-fg: rgb(29, 145, 232)`, hue ~210) in `packages/ui/src/styles/brand-gold.css`. That breaks the no-blue brand rule and fails the aesthetic audit on **every** route that renders a message-type memory badge — chat, messages, transcripts, memories.

Swapped it (and its matching `-bg`) for a darker slate (`rgb(71, 85, 105)`, slate-600). That keeps messages **distinct-but-muted**: it reads apart from the slate-500 `facts` badge right below it, and never competes with the gold primary accent.

While in the styles, fixed two more clear blue offenders in the cloud UI, both moved to slate to match the existing no-blue convention already documented in `cloud/instances/lib/sandbox-status.ts`:

- **api-explorer POST method badge** (`api-route-explorer-client.tsx`) — `bg-blue-500/10 text-blue-400` → slate, still distinct from the amber PUT.
- **dashboard `info` banner tone** (`dashboard-route-page.tsx`) — `border-blue-400/30 bg-blue-400/10 text-blue-100` → slate, reads neutral alongside the emerald/amber/red tones.

## Out of scope (deliberately left)

- Chain-logo colors (`--color-chain-base` etc.) — those are external network brand identities, not decorative UI blue.
- curl/prism syntax-highlight palettes — self-consistent code-token coloring, not a UI accent.

## How

Token-driven only. No inline styles, no arbitrary values — just the brand-gold CSS custom properties and standard Tailwind slate utilities (slate already used across the package).

## Verify

- `bunx biome check` on the touched files — clean.
- `bun run typecheck` (tsgo) on `@elizaos/ui` — 0 errors. (Had to build `@elizaos/core` + `@elizaos/plugin-sql` first so project refs resolved.)

No brand-token unit test exists in the package, so nothing added there.