### PR TITLE
fix(app-core): remove Qwen Cerebras autowire case

### DIFF
--- a/packages/app-core/src/benchmark/__tests__/cerebras-endpoint.test.ts
+++ b/packages/app-core/src/benchmark/__tests__/cerebras-endpoint.test.ts
@@ -43,6 +43,8 @@ const ENV_KEYS = [
   "OPENAI_LARGE_MODEL",
   "OPENAI_SMALL_MODEL",
   "ELIZA_PROVIDER",
+  "BENCHMARK_MODEL_NAME",
+  "BENCHMARK_MODEL_PROVIDER",
 ] as const;
 
 describe("bench-server Cerebras autowiring", () => {
@@ -95,16 +97,36 @@ describe("bench-server Cerebras autowiring", () => {
 
   it("respects an explicit CEREBRAS_MODEL override", () => {
     process.env.CEREBRAS_API_KEY = "csk-test";
-    process.env.CEREBRAS_MODEL = "qwen-3-235b-a22b-instruct-2507";
+    process.env.CEREBRAS_MODEL = "gemma-4-31b";
 
     autoWireCerebras();
 
-    expect(process.env.OPENAI_LARGE_MODEL).toBe(
-      "qwen-3-235b-a22b-instruct-2507",
-    );
-    expect(process.env.OPENAI_SMALL_MODEL).toBe(
-      "qwen-3-235b-a22b-instruct-2507",
-    );
+    expect(process.env.OPENAI_LARGE_MODEL).toBe("gemma-4-31b");
+    expect(process.env.OPENAI_SMALL_MODEL).toBe("gemma-4-31b");
+  });
+
+  it("treats an explicit Gemma 4 benchmark model as Cerebras intent", () => {
+    process.env.CEREBRAS_API_KEY = "csk-test";
+    process.env.OPENAI_API_KEY = "sk-real-openai";
+    process.env.BENCHMARK_MODEL_NAME = "Gemma-4-31B";
+
+    autoWireCerebras();
+
+    expect(process.env.OPENAI_BASE_URL).toBe("https://api.cerebras.ai/v1");
+    expect(process.env.OPENAI_API_KEY).toBe("csk-test");
+    expect(process.env.ELIZA_PROVIDER).toBe("cerebras");
+  });
+
+  it("treats the public GLM preview model as Cerebras intent", () => {
+    process.env.CEREBRAS_API_KEY = "csk-test";
+    process.env.OPENAI_BASE_URL = "https://api.openrouter.ai/api/v1";
+    process.env.BENCHMARK_MODEL_NAME = "zai-glm-4.7";
+
+    autoWireCerebras();
+
+    expect(process.env.OPENAI_BASE_URL).toBe("https://api.cerebras.ai/v1");
+    expect(process.env.OPENAI_API_KEY).toBe("csk-test");
+    expect(process.env.ELIZA_PROVIDER).toBe("cerebras");
   });
 
   it("is a no-op when CEREBRAS_API_KEY is unset", () => {

--- a/packages/app-core/src/benchmark/cerebras-autowire.ts
+++ b/packages/app-core/src/benchmark/cerebras-autowire.ts
@@ -1,5 +1,15 @@
 import { elizaLogger } from "@elizaos/core";
 
+const KNOWN_CEREBRAS_BARE_MODELS = new Set([
+  "gpt-oss-120b",
+  "zai-glm-4.7",
+  "gemma-4-31b",
+]);
+
+function isKnownCerebrasBareModel(model: string): boolean {
+  return KNOWN_CEREBRAS_BARE_MODELS.has(model.trim().toLowerCase());
+}
+
 /**
  * Auto-wire the `@elizaos/plugin-openai` env keys from a `CEREBRAS_API_KEY`
  * when no competing OpenAI-compat configuration is present.
@@ -35,9 +45,7 @@ export function autoWireCerebras(): void {
     process.env.BENCHMARK_MODEL_NAME?.trim() ||
     process.env.CEREBRAS_MODEL?.trim() ||
     "";
-  const modelIsCerebras =
-    selectedModel === "gpt-oss-120b" ||
-    selectedModel === "qwen-3-235b-a22b-instruct-2507";
+  const modelIsCerebras = isKnownCerebrasBareModel(selectedModel);
   const explicitCerebras =
     process.env.BENCHMARK_MODEL_PROVIDER?.trim().toLowerCase() === "cerebras" ||
     process.env.ELIZA_PROVIDER?.trim().toLowerCase() === "cerebras" ||


### PR DESCRIPTION
## Summary

- Removes the Qwen model id from Cerebras benchmark autowire intent detection.
- Replaces the hard-coded two-model comparison with a normalized bare Cerebras model allowlist.
- Keeps the default Cerebras benchmark model on `gpt-oss-120b` while allowing explicit `gemma-4-31b` benchmark selections to opt into Cerebras autowiring.
- Extends the regression test to cover explicit Gemma 4 and GLM Cerebras selections, and resets `BENCHMARK_MODEL_NAME` / `BENCHMARK_MODEL_PROVIDER` between cases.

Refs #9588
Refs #9583

## Notes

Cerebras' current public model catalog still documents `gpt-oss-120b` and `zai-glm-4.7`; Cerebras' Gemma 4 announcement describes Gemma 4 31B as available via preview / staged rollout. This PR removes the Qwen shortcut without making an announced-but-not-universally-public Gemma endpoint the implicit default.

Docs checked:

- https://inference-docs.cerebras.ai/models/model-catalog
- https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal

## Evidence

- Synced with `develop`: `git fetch origin && git rebase origin/develop` completed cleanly.
- Dependencies refreshed: `bun install` completed with no effective dependency changes.
- `bun test packages/app-core/src/benchmark/__tests__/cerebras-endpoint.test.ts` passed: 11 tests, 34 assertions.
- `bun run --cwd packages/app-core typecheck` passed.
- `bunx @biomejs/biome check packages/app-core/src/benchmark/cerebras-autowire.ts packages/app-core/src/benchmark/__tests__/cerebras-endpoint.test.ts` passed.
- `git diff --check` passed.
- `bun run verify` passed: 523/523 tasks.

## PR evidence checklist

- Real-LLM trajectory: N/A, env autowire selection/test cleanup only; no prompt/action/model-runtime behavior added.
- Backend logs: N/A beyond test logger output; no runtime server route changed.
- Frontend logs/screenshots/video: N/A, no UI changes.
- Audio/TTS/STT evidence: N/A, no voice path changed.
