### PR TITLE
fix(agent-orchestrator): align opencode local fixtures

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
@@ -287,12 +287,12 @@ describe("model-chooser contract: opencode provider/model resolution (pure)", ()
     const config = buildOpencodeSpawnConfig(settingsRuntime(), {
       ELIZA_OPENCODE_LOCAL: "1",
       ELIZA_OPENCODE_BASE_URL: "http://localhost:11434/v1",
-      ELIZA_OPENCODE_MODEL_POWERFUL: "qwen2.5-coder",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "eliza-1-4b",
     });
     expect({
       provider: config?.providerId,
       model: config?.model,
-    }).toEqual({ provider: "eliza-local", model: "eliza-local/qwen2.5-coder" });
+    }).toEqual({ provider: "eliza-local", model: "eliza-local/eliza-1-4b" });
     const parsed = JSON.parse(config?.configContent ?? "{}");
     expect(parsed.provider["eliza-local"].npm).toBe(
       "@ai-sdk/openai-compatible",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -80,10 +80,10 @@ describe("buildOpencodeSpawnConfig", () => {
     const result = buildOpencodeSpawnConfig(runtime(), {
       ELIZA_OPENCODE_LOCAL: "1",
       ELIZA_OPENCODE_BASE_URL: "http://localhost:11434/v1",
-      ELIZA_OPENCODE_MODEL_POWERFUL: "qwen2.5-coder",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "eliza-1-4b",
     });
     expect(result?.providerId).toBe("eliza-local");
-    expect(result?.model).toBe("eliza-local/qwen2.5-coder");
+    expect(result?.model).toBe("eliza-local/eliza-1-4b");
     const config = JSON.parse(result?.configContent ?? "{}");
     expect(config.provider["eliza-local"].options.baseURL).toBe(
       "http://localhost:11434/v1",


### PR DESCRIPTION
## Summary

- Replaces remaining plugin-agent-orchestrator `qwen2.5-coder` local opencode test fixtures with the shipped local `eliza-1-4b` model name.
- Keeps the tests focused on local OpenAI-compatible routing and no-key-leak behavior; no production opencode config logic changes.

Refs #9588
Refs #9583

## Evidence

- Synced with `develop`: `git fetch origin && git rebase origin/develop` completed cleanly.
- Dependencies refreshed: `bun install` completed with no effective dependency changes.
- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts` passed: 28 tests, 79 assertions.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` passed.
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts` passed.
- `git diff --check` passed.
- `bun run verify` passed: 523/523 tasks.

## PR evidence checklist

- Real-LLM trajectory: N/A, unit-test fixture alignment only; no prompt/action/model-runtime behavior added.
- Backend logs: N/A, no runtime backend path changed.
- Frontend logs/screenshots/video: N/A, no UI changes.
- Audio/TTS/STT evidence: N/A, no voice path changed.
