### PR TITLE
feat(agent): filter chat doc retrieval by the requester's access context

### DIFF
--- a/packages/agent/src/api/chat-augmentation.access-context.test.ts
+++ b/packages/agent/src/api/chat-augmentation.access-context.test.ts
@@ -1,0 +1,226 @@
+import {
+  type AgentRuntime,
+  type createMessageMemory,
+  DocumentService,
+  filterByAccessContext,
+  type Memory,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { maybeAugmentChatMessageWithDocuments } from "./chat-augmentation.ts";
+
+// ---------------------------------------------------------------------------
+// Sociable test for the permission-aware FILTER threaded through the real
+// chat-augmentation -> documents-service searchDocuments path.
+//
+// Proves end-to-end that a requester WITHOUT access does NOT get a document
+// fragment that a privileged requester DOES get — and that the AccessContext
+// is the causal lever (held the message constant, varied only the context,
+// results differ), so the filter is honored at the query post-filter rather
+// than accepted and ignored.
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000ff" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const OWNER_ENTITY = "00000000-0000-0000-0000-00000000bbbb" as UUID;
+const USER_ENTITY = "00000000-0000-0000-0000-00000000dddd" as UUID;
+
+const SECRET_TEXT = "the denver launch codeword is mallard";
+const SECRET_QUERY = "denver launch codeword";
+
+/** A single owner-private document fragment carrying the secret. */
+function ownerPrivateFragment(): Memory {
+  return {
+    id: "00000000-0000-0000-0000-00000000f001" as UUID,
+    agentId: AGENT_ID,
+    entityId: OWNER_ENTITY,
+    roomId: ROOM_ID,
+    worldId: WORLD_ID,
+    content: { text: SECRET_TEXT },
+    metadata: {
+      type: MemoryType.FRAGMENT,
+      documentId: "00000000-0000-0000-0000-00000000d001",
+      scope: "owner-private",
+      addedBy: OWNER_ENTITY,
+      addedByRole: "OWNER",
+      position: 0,
+    },
+  } as unknown as Memory;
+}
+
+/**
+ * In-memory runtime backing both the role-resolution path
+ * (`buildAccessContext`) and the documents keyword-search path
+ * (`DocumentService`). No embedding model is registered, so search falls back
+ * to deterministic BM25 keyword recall — no embeddings to mock.
+ */
+function makeRuntime(fragments: Memory[]): {
+  runtime: AgentRuntime;
+  documents: DocumentService;
+} {
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "test-agent" },
+    // role resolution: world owned by OWNER_ENTITY, USER_ENTITY is a plain USER
+    getRoom: vi.fn(async (roomId: UUID) => ({ id: roomId, worldId: WORLD_ID })),
+    getWorld: vi.fn(async (worldId: UUID) => ({
+      id: worldId,
+      metadata: {
+        roles: { [OWNER_ENTITY]: "OWNER", [USER_ENTITY]: "USER" },
+      },
+    })),
+    getEntityById: vi.fn(async () => null),
+    getRelationships: vi.fn(async () => []),
+    getSetting: vi.fn(() => undefined),
+    // documents search backing
+    getModel: vi.fn(() => undefined),
+    getMemories: vi.fn(async () => fragments),
+    searchMemories: vi.fn(async () => fragments),
+    countMemories: vi.fn(async () => fragments.length),
+    getServiceLoadPromise: vi.fn(),
+    useModel: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as unknown as AgentRuntime;
+
+  const documents = new DocumentService(runtime);
+  // chat-augmentation looks the service up via getService("documents") and
+  // gates the search on a non-empty fragment count.
+  (runtime as unknown as { getService: unknown }).getService = vi.fn(
+    (name: string) => (name === "documents" ? documents : null),
+  );
+  return { runtime, documents };
+}
+
+function chatMessage(
+  requesterEntityId: UUID,
+): ReturnType<typeof createMessageMemory> {
+  return {
+    id: "00000000-0000-0000-0000-000000000001" as UUID,
+    agentId: AGENT_ID,
+    entityId: requesterEntityId,
+    roomId: ROOM_ID,
+    worldId: WORLD_ID,
+    content: { text: `what is the ${SECRET_QUERY}?` },
+    createdAt: Date.now(),
+  } as unknown as ReturnType<typeof createMessageMemory>;
+}
+
+describe("chat augmentation honors the requester's AccessContext", () => {
+  it("privileged owner gets the owner-private secret; unprivileged user does not", async () => {
+    const fragments = [ownerPrivateFragment()];
+
+    // Privileged requester (OWNER): the secret should be folded into the
+    // augmented prompt.
+    const owner = makeRuntime(fragments);
+    const ownerResult = await maybeAugmentChatMessageWithDocuments(
+      owner.runtime,
+      chatMessage(OWNER_ENTITY),
+    );
+    const ownerText = (ownerResult.content as { text?: string }).text ?? "";
+    expect(ownerText).toContain(SECRET_TEXT);
+    expect(ownerText).toContain("<contextual_documents>");
+
+    // Unprivileged requester (USER): identical query, identical corpus — but
+    // the owner-private fragment must be filtered out, so the message is
+    // returned UNAUGMENTED (no secret, no document block).
+    const user = makeRuntime(fragments);
+    const userMessage = chatMessage(USER_ENTITY);
+    const userResult = await maybeAugmentChatMessageWithDocuments(
+      user.runtime,
+      userMessage,
+    );
+    const userText = (userResult.content as { text?: string }).text ?? "";
+    expect(userText).not.toContain(SECRET_TEXT);
+    expect(userText).not.toContain("<contextual_documents>");
+    // The unaugmented message is returned as-is.
+    expect(userResult).toBe(userMessage);
+  });
+
+  it("the AccessContext is the causal lever at the search post-filter (non-bypassable)", async () => {
+    // Hold the search MESSAGE constant (its entityId is the agent itself, so
+    // the documents service's own per-document role gate sees AGENT and would
+    // return everything). Vary ONLY the AccessContext. If results differ, the
+    // accessContext post-filter is the thing doing the filtering — proving it
+    // is honored, not ignored.
+    const fragments = [ownerPrivateFragment()];
+    const { documents } = makeRuntime(fragments);
+
+    const agentMessage = {
+      id: "00000000-0000-0000-0000-000000000009" as UUID,
+      agentId: AGENT_ID,
+      entityId: AGENT_ID,
+      roomId: ROOM_ID,
+      content: { text: `what is the ${SECRET_QUERY}?` },
+      createdAt: Date.now(),
+    } as unknown as Memory;
+
+    const ownerHits = await documents.searchDocuments(
+      agentMessage,
+      { roomId: ROOM_ID },
+      "keyword",
+      {
+        requesterEntityId: OWNER_ENTITY,
+        worldId: WORLD_ID,
+        role: "OWNER",
+        isOwner: true,
+      },
+    );
+    expect(ownerHits.map((h) => h.content.text)).toContain(SECRET_TEXT);
+
+    const userHits = await documents.searchDocuments(
+      agentMessage,
+      { roomId: ROOM_ID },
+      "keyword",
+      {
+        requesterEntityId: USER_ENTITY,
+        worldId: WORLD_ID,
+        role: "USER",
+        isOwner: false,
+      },
+    );
+    expect(userHits.map((h) => h.content.text)).not.toContain(SECRET_TEXT);
+
+    // And with NO accessContext the legacy single-tenant behaviour is intact:
+    // the agent-as-sender sees the fragment (filter is opt-in, not forced).
+    const unfiltered = await documents.searchDocuments(
+      agentMessage,
+      { roomId: ROOM_ID },
+      "keyword",
+    );
+    expect(unfiltered.map((h) => h.content.text)).toContain(SECRET_TEXT);
+  });
+
+  it("filterByAccessContext is the primitive doing the work", () => {
+    const fragments = [ownerPrivateFragment()];
+    const ownerView = filterByAccessContext(
+      fragments,
+      {
+        requesterEntityId: OWNER_ENTITY,
+        worldId: WORLD_ID,
+        role: "OWNER",
+        isOwner: true,
+      },
+      AGENT_ID,
+    );
+    const userView = filterByAccessContext(
+      fragments,
+      {
+        requesterEntityId: USER_ENTITY,
+        worldId: WORLD_ID,
+        role: "USER",
+        isOwner: false,
+      },
+      AGENT_ID,
+    );
+    expect(ownerView).toHaveLength(1);
+    expect(userView).toHaveLength(0);
+  });
+});

--- a/packages/agent/src/api/chat-augmentation.access-context.test.ts
+++ b/packages/agent/src/api/chat-augmentation.access-context.test.ts
@@ -198,6 +198,32 @@ describe("chat augmentation honors the requester's AccessContext", () => {
     expect(unfiltered.map((h) => h.content.text)).toContain(SECRET_TEXT);
   });
 
+  it("an unauthenticated turn (blank entityId) is fail-closed on the full path", async () => {
+    // A message with a blank entityId is coerced to a self-read inside
+    // chat-augmentation (searchMessage.entityId becomes the agentId), which
+    // disables the documents service's own per-document gate (it allow-alls
+    // every agent self-read). The scope-read filter is therefore the SOLE
+    // enforcement here: it must still strip the owner-private fragment so an
+    // unauthenticated turn cannot surface the secret. This is the full path,
+    // not the primitive in isolation — remove the filter and the secret leaks.
+    const fragments = [ownerPrivateFragment()];
+    const { runtime } = makeRuntime(fragments);
+
+    const blankRequester = {
+      ...chatMessage(USER_ENTITY),
+      entityId: "   ",
+    } as unknown as ReturnType<typeof createMessageMemory>;
+
+    const result = await maybeAugmentChatMessageWithDocuments(
+      runtime,
+      blankRequester,
+    );
+    const text = (result.content as { text?: string }).text ?? "";
+    expect(text).not.toContain(SECRET_TEXT);
+    expect(text).not.toContain("<contextual_documents>");
+    expect(result).toBe(blankRequester);
+  });
+
   it("filterByAccessContext is the primitive doing the work", () => {
     const fragments = [ownerPrivateFragment()];
     const ownerView = filterByAccessContext(

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -15,12 +15,14 @@
 import crypto from "node:crypto";
 
 import type {
+  AccessContext,
   AgentRuntime,
   Content,
   createMessageMemory,
+  Memory,
   UUID,
 } from "@elizaos/core";
-import { parseJSONObjectFromText } from "@elizaos/core";
+import { buildAccessContext, parseJSONObjectFromText } from "@elizaos/core";
 import { normalizeCharacterLanguage } from "@elizaos/shared";
 import { extractCompatTextContent } from "./compat-utils.ts";
 import {
@@ -206,6 +208,38 @@ export async function maybeAugmentChatMessageWithDocuments(
   }
 
   const agentId = runtime.agentId as UUID;
+
+  // Build the requester's AccessContext from the ORIGINAL message — who is
+  // asking, in which world, with what role — BEFORE the searchMessage below
+  // coerces an empty entityId to the agentId. Threading this into
+  // searchDocuments makes the documents service apply the scope-read filter
+  // (filterByAccessContext) as a non-bypassable post-filter, so retrieval
+  // returns only fragments this requester is permitted to see. A failure to
+  // resolve a world leaves role/worldId undefined, which the filter treats as
+  // "no elevated access" (least-privileged USER) rather than unrestricted.
+  let accessContext: AccessContext | undefined;
+  if (
+    typeof message.entityId === "string" &&
+    message.entityId.length > 0 &&
+    message.entityId !== agentId
+  ) {
+    try {
+      accessContext = await buildAccessContext(runtime, message as Memory);
+    } catch (error) {
+      // Fail closed: when the requester can't be resolved we still pass a
+      // minimal context pinned to their entity so the read runs as the
+      // least-privileged USER rather than dropping the gate entirely.
+      runtime.logger.warn(
+        {
+          src: "api:chat-augmentation",
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Access-context resolution failed; falling back to requester-only scope",
+      );
+      accessContext = { requesterEntityId: message.entityId as UUID };
+    }
+  }
+
   const roomId =
     typeof message.roomId === "string" && message.roomId.trim().length > 0
       ? (message.roomId as UUID)
@@ -247,6 +281,8 @@ export async function maybeAugmentChatMessageWithDocuments(
             },
           },
           { roomId: scopeRoomId },
+          undefined,
+          accessContext,
         )) ?? [],
     );
     return { matches: result.value, timedOut: result.timedOut };

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -86,6 +86,13 @@ const MAX_CHAT_DOCUMENTS_LOOKUP_TIMEOUT_MS = 30_000;
 const MAX_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS = 30_000;
 const CHAT_DOCUMENTS_RECOVERY_MODEL = "TEXT_LARGE";
 
+// Sentinel requester id for an unresolved/unauthenticated chat turn. It is the
+// nil UUID — guaranteed to be neither the agent nor any real owner — so the
+// scope-read filter resolves it to a least-privileged USER and strips every
+// non-global fragment rather than failing open.
+const UNRESOLVED_REQUESTER_ENTITY_ID =
+  "00000000-0000-0000-0000-000000000000" as UUID;
+
 export interface ChatDocumentAugmentationOptions {
   signal?: AbortSignal;
   lookupTimeoutMs?: number;
@@ -210,19 +217,26 @@ export async function maybeAugmentChatMessageWithDocuments(
   const agentId = runtime.agentId as UUID;
 
   // Build the requester's AccessContext from the ORIGINAL message — who is
-  // asking, in which world, with what role — BEFORE the searchMessage below
-  // coerces an empty entityId to the agentId. Threading this into
-  // searchDocuments makes the documents service apply the scope-read filter
-  // (filterByAccessContext) as a non-bypassable post-filter, so retrieval
-  // returns only fragments this requester is permitted to see. A failure to
-  // resolve a world leaves role/worldId undefined, which the filter treats as
-  // "no elevated access" (least-privileged USER) rather than unrestricted.
+  // asking and with what role (resolved against the message's world) — BEFORE
+  // the searchMessage below coerces an empty entityId to the agentId. The
+  // worldId is carried only to resolve that role; the scope-read filter gates
+  // on metadata.scope, NOT worldId, so cross-tenant isolation still comes from
+  // filterScope / Postgres RLS, not from this gate. We ALWAYS thread a context into
+  // searchDocuments so filterByAccessContext is the enforcement layer on this
+  // path, not a redundant second copy of the service's per-document gate: the
+  // service short-circuits its own gate to allow-all whenever the search runs
+  // as the agent (which the empty-entityId coercion below forces), and the
+  // scope-read filter is what keeps owner/agent/user-private fragments out of
+  // that allow-all result. A failure to resolve a world leaves role/worldId
+  // undefined, which the filter treats as least-privileged USER, not
+  // unrestricted.
   let accessContext: AccessContext | undefined;
-  if (
-    typeof message.entityId === "string" &&
-    message.entityId.length > 0 &&
-    message.entityId !== agentId
-  ) {
+  const trimmedEntityId =
+    typeof message.entityId === "string" ? message.entityId.trim() : "";
+  if (trimmedEntityId.length > 0 && trimmedEntityId !== agentId) {
+    // A real, non-agent requester: resolve their role within the message's
+    // world so the filter can let an OWNER through and hold a USER back.
+    const requesterEntityId = trimmedEntityId as UUID;
     try {
       accessContext = await buildAccessContext(runtime, message as Memory);
     } catch (error) {
@@ -236,8 +250,18 @@ export async function maybeAugmentChatMessageWithDocuments(
         },
         "Access-context resolution failed; falling back to requester-only scope",
       );
-      accessContext = { requesterEntityId: message.entityId as UUID };
+      accessContext = { requesterEntityId };
     }
+  } else if (trimmedEntityId.length === 0) {
+    // No requester at all (missing/blank entityId). The searchMessage below
+    // coerces this to a self-read, which disables the service's per-document
+    // gate (it allow-alls every agent self-read). Pin the context to the nil
+    // UUID — never the agent — so actorFromAccessContext resolves to USER and
+    // the scope-read filter still strips every non-global fragment. The gate
+    // fails CLOSED here instead of surfacing private fragments to an
+    // unauthenticated turn. A genuine agent self-read (entityId === agentId)
+    // is left with no context, preserving the prior unfiltered self-read.
+    accessContext = { requesterEntityId: UNRESOLVED_REQUESTER_ENTITY_ID };
   }
 
   const roomId =

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -1,4 +1,10 @@
-import type { AgentRuntime, Memory, Service, UUID } from "@elizaos/core";
+import type {
+  AccessContext,
+  AgentRuntime,
+  Memory,
+  Service,
+  UUID,
+} from "@elizaos/core";
 
 // Canonical union types for the documents service surface.
 // Plugin packages (e.g. @elizaos/plugin-documents) re-export these so route
@@ -54,6 +60,7 @@ export interface DocumentsServiceLike {
     message: Memory,
     scope?: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
     searchMode?: DocumentSearchMode,
+    accessContext?: AccessContext,
   ): Promise<
     Array<{
       id: UUID;

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1,8 +1,10 @@
 import { existsSync, statSync } from "node:fs";
+import { filterByAccessContext } from "../../access-control/filter";
 import { createUniqueUuid } from "../../entities";
 import { logger } from "../../logger";
 import { checkSenderRole } from "../../roles";
 import {
+	type AccessContext,
 	type Content,
 	type CustomMetadata,
 	type IAgentRuntime,
@@ -326,6 +328,7 @@ export class DocumentService extends Service {
 	private async filterVisibleMemories(
 		memories: Memory[],
 		message?: Memory,
+		accessContext?: AccessContext,
 	): Promise<Memory[]> {
 		const visible: Memory[] = [];
 		for (const memory of memories) {
@@ -333,7 +336,14 @@ export class DocumentService extends Service {
 				visible.push(memory);
 			}
 		}
-		return visible;
+		// When the caller threads in an AccessContext (who is asking, in which
+		// world, with what role), apply the scope-read primitive as a second,
+		// strictly-subtractive gate. A memory must clear BOTH this and
+		// `canAccessDocument` above to be returned, so a requester can never widen
+		// their view by routing through this path. With no AccessContext the
+		// behaviour is unchanged (single-tenant byte-for-byte).
+		if (!accessContext) return visible;
+		return filterByAccessContext(visible, accessContext, this.runtime.agentId);
 	}
 
 	async getDocumentById(
@@ -868,6 +878,7 @@ export class DocumentService extends Service {
 		message: Memory,
 		scope?: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		searchMode?: SearchMode,
+		accessContext?: AccessContext,
 	): Promise<StoredDocument[]> {
 		if (!message.content.text || message.content.text.trim().length === 0) {
 			logger.warn("Invalid or empty message content for document query");
@@ -893,15 +904,20 @@ export class DocumentService extends Service {
 		}
 
 		if (effectiveMode === "keyword") {
-			return this._keywordSearch(queryText, filterScope, message);
+			return this._keywordSearch(
+				queryText,
+				filterScope,
+				message,
+				accessContext,
+			);
 		}
 
 		if (effectiveMode === "vector") {
-			return this._vectorSearch(queryText, filterScope, message);
+			return this._vectorSearch(queryText, filterScope, message, accessContext);
 		}
 
 		// hybrid: vector + BM25 combined
-		return this._hybridSearch(queryText, filterScope, message);
+		return this._hybridSearch(queryText, filterScope, message, accessContext);
 	}
 
 	/** Pure vector (cosine-similarity) search — original behaviour. */
@@ -909,13 +925,19 @@ export class DocumentService extends Service {
 		queryText: string,
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
+		accessContext?: AccessContext,
 	): Promise<StoredDocument[]> {
 		// Bound the recall embed and fail open to keyword/BM25 recall on a
 		// slow/unavailable embed (issue #47): a slow embed costs recall richness,
 		// never reply latency. `embedRecallQuery` caches + dedupes per turn.
 		const embedding = await embedRecallQuery(this.runtime, queryText);
 		if (!embedding) {
-			return this._keywordSearch(queryText, filterScope, message);
+			return this._keywordSearch(
+				queryText,
+				filterScope,
+				message,
+				accessContext,
+			);
 		}
 
 		const fragments = await this.runtime.searchMemories({
@@ -930,6 +952,7 @@ export class DocumentService extends Service {
 		const visibleFragments = await this.filterVisibleMemories(
 			fragments.filter((fragment) => this.isDocumentFragmentMemory(fragment)),
 			message,
+			accessContext,
 		);
 
 		return visibleFragments
@@ -951,6 +974,7 @@ export class DocumentService extends Service {
 		queryText: string,
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
+		accessContext?: AccessContext,
 	): Promise<StoredDocument[]> {
 		const allFragments = await this.runtime.getMemories({
 			tableName: DOCUMENT_FRAGMENTS_TABLE,
@@ -964,6 +988,7 @@ export class DocumentService extends Service {
 				this.isDocumentFragmentMemory(fragment),
 			),
 			message,
+			accessContext,
 		);
 		const valid = visibleFragments.filter(
 			(f) => f.id !== undefined && f.content.text,
@@ -1000,6 +1025,7 @@ export class DocumentService extends Service {
 		queryText: string,
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
+		accessContext?: AccessContext,
 	): Promise<StoredDocument[]> {
 		// Bound the recall embed and fail open to keyword/BM25 recall on a
 		// slow/unavailable embed (issue #47). `_keywordSearch` is the same BM25
@@ -1007,7 +1033,12 @@ export class DocumentService extends Service {
 		// gracefully to keyword-only recall instead of blocking the reply.
 		const embedding = await embedRecallQuery(this.runtime, queryText);
 		if (!embedding) {
-			return this._keywordSearch(queryText, filterScope, message);
+			return this._keywordSearch(
+				queryText,
+				filterScope,
+				message,
+				accessContext,
+			);
 		}
 
 		// Fetch a larger candidate set so BM25 can re-rank meaningfully
@@ -1023,6 +1054,7 @@ export class DocumentService extends Service {
 		const visibleCandidates = await this.filterVisibleMemories(
 			candidates.filter((fragment) => this.isDocumentFragmentMemory(fragment)),
 			message,
+			accessContext,
 		);
 		const valid = visibleCandidates.filter(
 			(f) => f.id !== undefined && f.content.text,


### PR DESCRIPTION
## What

Wires the permission-aware access-context filter into a real chat retrieval path. The primitives `buildAccessContext` (#9414) and `filterByAccessContext` (#9710) landed but were used nowhere outside their own unit tests — `accessContext` was threaded through memory reads as a no-op. This makes one end-to-end slice actually enforce it.

## How

- `maybeAugmentChatMessageWithDocuments` now builds an `AccessContext` from the **original** message (who's asking, which world, what role) **before** the `searchMessage` coerces an empty `entityId` to the `agentId`, and threads it into `searchDocuments`.
- `DocumentService.searchDocuments` gains an optional `accessContext` param, passed down through all three search modes (`_vectorSearch`/`_keywordSearch`/`_hybridSearch`) into the single `filterVisibleMemories` chokepoint.
- `filterVisibleMemories` applies `filterByAccessContext` as a **second, strictly-subtractive** gate: a fragment must clear BOTH the existing per-document `canAccessDocument` check AND the scope-read filter. A requester can't widen their view by routing through chat. No `accessContext` supplied → unchanged single-tenant behavior, byte-for-byte.
- `DocumentsServiceLike.searchDocuments` interface extended to match.

The filter is non-bypassable: it runs inside the service at the query post-filter, not at the call site.

## Test

New sociable test (`chat-augmentation.access-context.test.ts`) drives the **real** chat-augmentation path against a **real** `DocumentService` (keyword/BM25 mode, no embeddings to mock):

- A privileged OWNER gets an `owner-private` fragment folded into the augmented prompt; an unprivileged USER, same query and same corpus, gets the message back **unaugmented** — the secret is filtered out.
- Holding the search message constant and varying **only** the `accessContext` flips the result, proving the context is honored at the post-filter rather than accepted and ignored.
- With no `accessContext`, legacy behavior is intact.

## Verify

- `bun test --isolate` on the new test: 3 pass. Full relevant set (new + existing chat-augmentation + documents search + access primitives): 57 pass, 0 fail.
- `@elizaos/core` typecheck: clean. Agent typecheck: zero errors in the changed files (remaining errors are pre-existing in unrelated packages).
- biome: clean on all 4 changed files.