### PR TITLE
fix(core): remove Qwen runtime examples

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
@@ -1,8 +1,8 @@
 /**
  * Refusal-suppression regression for `parseMessageHandlerOutput`.
  *
- * The fix for elizaOS/eliza#7620 — Cerebras-hosted `gpt-oss-120b` and
- * `qwen-3-235b-a22b-instruct-2507` emit identical refusal text in Stage-1
+ * The fix for elizaOS/eliza#7620 — Cerebras-hosted `gpt-oss-120b` and other
+ * safety-tuned hosted models emit identical refusal text in Stage-1
  * `replyText` even on turns whose `contexts` / `candidateActions` route to
  * the planner. The runtime previously shipped that refusal to the user. We
  * blank `plan.reply` when:

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -539,7 +539,7 @@ describe("JsonFileTrajectoryRecorder", () => {
 			latencyMs: 100,
 			model: {
 				modelType: "ACTION_PLANNER",
-				modelName: "qwen-2.5-14b-q5_k_m",
+				modelName: "eliza-1-4b-q4_k_m",
 				provider: "ollama",
 				prompt: "p",
 				response: "r",

--- a/packages/core/src/runtime/cutoff-leak-detector.ts
+++ b/packages/core/src/runtime/cutoff-leak-detector.ts
@@ -8,8 +8,8 @@
  * updated", "the latest information I have is from". The agent has a character
  * (a name, a role, a persona); the model beneath it does not exist to the user.
  * Weaker / safety-tuned hosted planner models (Cerebras-served `gpt-oss-120b`,
- * `qwen-3-235b-a22b-instruct-2507`) still emit these phrases even with the
- * prompt rule in place — the same class of prompt-contract violation that
+ * GLM/Gemma-class dedicated endpoints, etc.) still emit these phrases even
+ * with the prompt rule in place — the same class of prompt-contract violation that
  * motivated `looksLikeRefusal` (see `refusal-detector.ts`).
  *
  * This detector is the structural net for that rule: a closed, distinctive set

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -27,7 +27,7 @@ export interface ChainingLoopConfig {
 	 * window (and a 20%-of-window reserve floor) at compaction-budget time
 	 * via `lookupModelContextWindow`. When set and the lookup hits, this
 	 * wins over `contextWindowTokens` — letting tight-context models
-	 * (Cerebras llama3.1-8b at 32k, qwen at 64k, gpt-oss-120b at 131k) get
+	 * (Cerebras llama3.1-8b at 32k, compact local tiers at 64k, gpt-oss-120b at 131k) get
 	 * a budget sized to their real ceiling instead of the 128k default.
 	 *
 	 * Optional and additive: when unset, the existing

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -75,8 +75,8 @@ export function parseMessageHandlerOutput(
 	// actions, the planner stage will produce the user-facing message and the
 	// Stage-1 `replyText` is intended to be a brief acknowledgement. Some
 	// safety-tuned hosted models (Cerebras-served `gpt-oss-120b`,
-	// `qwen-3-235b-a22b-instruct-2507`) still emit a prompt-contract violation
-	// here even with the system-prompt rules in place: a refusal, a
+	// GLM/Gemma-class dedicated endpoints, etc.) still emit a prompt-contract
+	// violation here even with the system-prompt rules in place: a refusal, a
 	// training-metadata/knowledge-cutoff leak, or a fabricated-moderation claim.
 	// We blank the reply when it matches any of these and route through planning
 	// for non-refusal honesty violations, so the user sees a fresh planner

--- a/packages/core/src/runtime/refusal-detector.ts
+++ b/packages/core/src/runtime/refusal-detector.ts
@@ -2,8 +2,8 @@
  * Detect refusal-shaped openings in model-generated replyText.
  *
  * Background: weaker / safety-tuned planner models (Cerebras-hosted
- * `gpt-oss-120b`, `qwen-3-235b-a22b-instruct-2507`, etc.) sometimes emit a
- * refusal in Stage-1 `replyText` even when the same turn correctly populates
+ * `gpt-oss-120b`, GLM/Gemma-class dedicated endpoints, etc.) sometimes emit
+ * a refusal in Stage-1 `replyText` even when the same turn correctly populates
  * `candidateActionNames` and routes to a planning context. The refusal text
  * then ships to the user via the early-reply path and contradicts the
  * planner's subsequent action call. See elizaOS/eliza#7620.

--- a/packages/core/src/runtime/validated-model-call.ts
+++ b/packages/core/src/runtime/validated-model-call.ts
@@ -3,7 +3,7 @@
  * {@link IAgentRuntime.useModel}.
  *
  * WHY THIS EXISTS:
- * For local models (e.g. eliza-1, 0.8B Qwen 3.5) we constrain output at the
+ * For local models (e.g. Eliza-1/Gemma local tiers) we constrain output at the
  * sampler with GBNF grammars, so the model *cannot* emit out-of-schema values.
  * For remote models (Anthropic, OpenAI, Cerebras llama3.1-8b, etc.) we have no
  * such guarantee — a parse-valid response can still contain out-of-enum values


### PR DESCRIPTION
## Summary
- replace Qwen-specific runtime comments with provider-neutral GLM/Gemma-class wording
- rename the local trajectory recorder fixture from a Qwen-style model id to the current Eliza/Gemma local tier fixture
- keep refusal/cutoff/validated-call behavior unchanged; this is comments and test fixture wording only

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun test packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts packages/core/src/runtime/__tests__/trajectory-recorder.test.ts` (51 pass, 162 assertions)
- `bun run --cwd packages/core typecheck`
- `bunx @biomejs/biome check packages/core/src/runtime/message-handler.ts packages/core/src/runtime/cutoff-leak-detector.ts packages/core/src/runtime/refusal-detector.ts packages/core/src/runtime/validated-model-call.ts packages/core/src/runtime/limits.ts packages/core/src/runtime/__tests__/trajectory-recorder.test.ts packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts`
- `git diff --check`
- `bun run verify` (523/523 successful)

## PR evidence
- UI/screenshots: N/A, no UI change
- Video walkthrough: N/A, comment/test-fixture wording only
- Real LLM trajectory: N/A, no agent/action/prompt/model runtime behavior change
- Backend/frontend logs: N/A, no runtime request path change
- Audio/TTS/STT: N/A

Refs #9588
Refs #9583