### PR TITLE
fix(local-inference): remove stale Qwen wording

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1369,7 +1369,7 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
 
     if (hubInstalled.length === 0) {
       throw new Error(
-        "local-inference hub had no installed Qwen3.5 GGUF model; full-Bun smoke requires a staged local model",
+        "local-inference hub had no installed Eliza-1 GGUF model; full-Bun smoke requires a staged local model",
       );
     }
 

--- a/packages/core/src/actions/promote-subactions.ts
+++ b/packages/core/src/actions/promote-subactions.ts
@@ -125,9 +125,9 @@ function findDiscriminatorParameter(
  * already implies which subaction it dispatches. The model sees
  * `TASKS_SPAWN_AGENT(action: enum[14 values], task, agentType, ...)` and
  * is asked to set `action` to a value — but `action` is meant to be
- * implicit from the virtual name. With weaker LLMs (Cerebras-hosted
- * gpt-oss / qwen-instruct, native function-calling planners that have to
- * fill structured args), this is the dominant cause of "TASKS umbrella
+ * implicit from the virtual name. With weaker LLMs (hosted small instruct
+ * models, native function-calling planners that have to fill structured args),
+ * this is the dominant cause of "TASKS umbrella
  * called with no sub-action" retry loops: the model picks the parent
  * because the virtual's schema looks more complex than the parent's.
  *

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -6,9 +6,8 @@
  * and eliza-1-27b-256k.
  * These ship Gemma 4 bases: E2B/E4B/12B/31B mapped onto the
  * 2B/4B/9B/27B release tiers (the 2026-06-22 cutover from the legacy
- * Qwen3.5/3.6 line — see #9033 and
- * packages/training/scripts/training/model_registry.py for the active
- * registry). Gemma 4 is a dense SWA + shared-KV + per-layer-embedding
+ * hybrid line — see #9033 and packages/training/scripts/training/model_registry.py
+ * for the active registry). Gemma 4 is a dense SWA + shared-KV + per-layer-embedding
  * (PLE) + MQA architecture; KV is already minimal so the legacy
  * QJL/PolarQuant KV kernels are not used (stock KV), while TurboQuant
  * weight-quant remains active. External Hub search remains custom/opt-in and
@@ -381,7 +380,7 @@ function bundleComponent(
  *
  * R8 §2 + omnivoice.cpp/AGENTS.md PolarQuant note: the K-quant family
  * (Q3..Q6) is the only weight-quant currently wired for OmniVoice's
- * Qwen3-shaped LM head — PolarQuant / TurboQuant for the LM weight bank
+ * MaskGIT LM weight bank — PolarQuant / TurboQuant for that LM bank
  * is *plausible* (same arch) but no recipe wires it yet; QJL is N/A
  * (OmniVoice has no KV cache between MaskGIT steps); V-cache PolarQuant
  * is N/A for the same reason. See `docs/inference/voice-quant-matrix.md`.

--- a/plugins/plugin-sql/src/schema/embedding.ts
+++ b/plugins/plugin-sql/src/schema/embedding.ts
@@ -8,9 +8,9 @@ export const VECTOR_DIMS = {
   LARGE: 768,
   XL: 1024,
   XXL: 1536,
-  // 2048: native embedding width of the on-device eliza-1-2b model (qwen3.5
-  // n_embd=2048). Without this column the 2b's embeddings have no storable
-  // dimension and are silently dropped (broken on-device memory/RAG).
+  // 2048: retained for local Eliza-1 pooled-text embeddings and other
+  // 2048-wide local providers. Without this column those embeddings have no
+  // storable dimension and are silently dropped (broken on-device memory/RAG).
   XXL2: 2048,
   XXXL: 3072,
 } as const;


### PR DESCRIPTION
## Summary
- replace a stale iOS full-Bun smoke error that still asked for a Qwen3.5 GGUF with Eliza-1 wording
- update local-inference catalog and SQL embedding comments so active Eliza-1/Gemma paths are not described as Qwen
- replace a core subaction-planner comment with provider-neutral wording; no runtime behavior, schema, or enum values changed

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bunx @biomejs/biome check packages/app/src/main.tsx plugins/plugin-sql/src/schema/embedding.ts packages/shared/src/local-inference/catalog.ts packages/core/src/actions/promote-subactions.ts`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd plugins/plugin-sql typecheck`
- `git diff --check`
- `bun run verify` (523/523 successful)

## PR evidence
- UI/screenshots: N/A, wording-only non-visual change
- Video walkthrough: N/A, no user flow changed
- Real LLM trajectory: N/A, no agent/action/prompt/model runtime behavior change
- Backend/frontend logs: N/A, no request path behavior changed
- Audio/TTS/STT: N/A

Refs #9588
Refs #9583