### PR TITLE
fix(openai): remove Qwen Cerebras live fixture

### DIFF
--- a/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
@@ -2,16 +2,16 @@
  * Live Cerebras regression test for the "spawn sub-agent" Stage-1 refusal
  * documented in elizaOS/eliza#7620.
  *
- * What was broken: Cerebras-hosted `gpt-oss-120b` and
- * `qwen-3-235b-a22b-instruct-2507` occasionally emit a refusal in Stage-1
+ * What was broken: Cerebras-hosted reasoning models occasionally emit a
+ * refusal in Stage-1
  * `replyText` ("I'm unable to spawn a sub-agent in this context. I can
  * create /tmp/foo.py directly...") even on turns whose
  * `candidateActionNames` correctly include `TASKS_SPAWN_AGENT`. The
  * refusal then ships to the user via the early-reply path and contradicts
  * the planner's subsequent action call.
  *
- * This test runs the EXACT user prompt from #7620 against both reported
- * Cerebras models across N trials and asserts:
+ * This test runs the EXACT user prompt from #7620 against representative
+ * public Cerebras reasoning models across N trials and asserts:
  *
  *   (a) After parsing through `parseMessageHandlerOutput` (which applies
  *       the refusal-suppression fix), no trial that routed to a planning
@@ -280,9 +280,10 @@ Sample leaked refusal: ${bucket.samples.leak ? `"${bucket.samples.leak}"` : "(no
 
 const TRIALS = Number.parseInt(process.env.CEREBRAS_REFUSAL_TRIALS ?? "20", 10);
 const TIMEOUT_MS = TRIALS * 20_000 + 30_000;
+const CEREBRAS_REFUSAL_MODELS = ["gpt-oss-120b", "zai-glm-4.7"] as const;
 
 liveDescribe("Cerebras `spawn sub-agent` Stage-1 refusal suppression — elizaOS/eliza#7620", () => {
-  for (const model of ["gpt-oss-120b", "qwen-3-235b-a22b-instruct-2507"]) {
+  for (const model of CEREBRAS_REFUSAL_MODELS) {
     it(
       `${model}: planning-path replies never leak refusal text after parsing`,
       async () => {
@@ -364,7 +365,7 @@ async function callAdversarialStage1(model: string): Promise<{ rawArgs: string }
 adversarialDescribe(
   "Cerebras adversarial — parser suppresses refusals even when prompt does not discourage them",
   () => {
-    for (const model of ["gpt-oss-120b", "qwen-3-235b-a22b-instruct-2507"]) {
+    for (const model of CEREBRAS_REFUSAL_MODELS) {
       it(
         `${model}: every wire refusal that lands on a planning context is suppressed`,
         async () => {

--- a/plugins/plugin-openai/__tests__/cloud-streaming.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cloud-streaming.live.test.ts
@@ -10,8 +10,8 @@ import { openaiPlugin } from "../index";
  * firing `params.onStreamChunk` once per decoded chunk as it is generated.
  *
  * Run against any OpenAI-compatible endpoint by setting `OPENAI_BASE_URL`,
- * `OPENAI_API_KEY`, and `OPENAI_SMALL_MODEL` (e.g. Together AI +
- * `Qwen/Qwen2.5-7B-Instruct-Turbo`). Skips with a warning when unset.
+ * `OPENAI_API_KEY`, and `OPENAI_SMALL_MODEL` to a compatible chat model.
+ * Skips with a warning when unset.
  */
 describeLive(
   "Cloud token-by-token streaming (#9174)",

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -249,14 +249,14 @@ function resolvePromptCacheOptions(params: GenerateTextParams): OpenAIPromptCach
  * Forward `OPENAI_REASONING_EFFORT` (runtime setting / process.env) as
  * `reasoning_effort` on the outbound chat completions request. This is
  * the OpenAI-spec knob for reasoning-capable models (`o1-*`, `o3-*`,
- * `gpt-oss-*`, `deepseek-r1`, `qwen-3-thinking`, etc.) — including
+ * `gpt-oss-*`, `deepseek-r1`, and similar families) — including
  * Cerebras and OpenRouter, which honor the same field. `"low"` keeps
  * reasoning short enough that visible content always fits inside
  * `max_tokens`, which is the failure mode on Cerebras gpt-oss-120b when
  * left unset.
  *
  * In Cerebras mode the field defaults to `"low"` when unset, but ONLY for
- * reasoning-capable models (e.g. gpt-oss-*, deepseek-r1, qwen-3-thinking):
+ * reasoning-capable models (e.g. gpt-oss-* and deepseek-r1):
  * gpt-oss-120b emits a separate reasoning channel and, left unbounded, spends
  * the whole token budget reasoning — returning empty visible content, which
  * makes the agent fall back to "I don't have a reply for that". `"low"` keeps
@@ -510,7 +510,7 @@ function normalizeNativeMessage(message: unknown): ModelMessage {
  * Strip reasoning-only parts from outbound assistant content.
  *
  * OpenAI-spec reasoning models (Cerebras gpt-oss-120b, OpenAI o1/o3,
- * DeepSeek R1, Qwen-3-thinking, etc.) return reasoning in the assistant
+ * DeepSeek R1, and similar families) return reasoning in the assistant
  * response — either as a separate `reasoning` / `reasoning_content`
  * field, or as content parts with `type: "reasoning"`. Echoing those
  * back to the next turn is wrong on both ends:


### PR DESCRIPTION
## Summary
- replace the stale Cerebras Qwen live-test model with the current public Cerebras reasoning fixture `zai-glm-4.7`
- keep the Cerebras refusal regression matrix shared between primary and adversarial probes
- remove Qwen-only examples from OpenAI-compatible streaming/reasoning comments without changing provider support logic

## Evidence
- `bunx @biomejs/biome check plugins/plugin-openai/__tests__/cloud-streaming.live.test.ts plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts plugins/plugin-openai/models/text.ts`
- `bun run --cwd plugins/plugin-openai typecheck`
- `bun test plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts` (live cases skipped without `CEREBRAS_API_KEY` + `ELIZA_RUN_LIVE_TESTS=1`; skip output includes `gpt-oss-120b` and `zai-glm-4.7`)
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` (523/523 tasks successful)

## Notes
- No `packages/cloud-frontend` changes; `audit:cloud` is N/A.
- This PR does not remove generic OpenAI-compatible support for user-provided reasoning models; it only removes the stale Qwen live fixture and comments.

Refs #9588
Refs #9583