### PR TITLE
fix(benchmarks): remove stale Qwen Cerebras model

### DIFF
--- a/packages/benchmarks/eliza-adapter/eliza_adapter/server_manager.py
+++ b/packages/benchmarks/eliza-adapter/eliza_adapter/server_manager.py
@@ -73,6 +73,9 @@ def _server_command(server_script: Path) -> list[str]:
     return ["node", "--import", "tsx", str(server_script)]
 
 
+CEREBRAS_OPENAI_MODEL_IDS = {"gpt-oss-120b", "zai-glm-4.7"}
+
+
 def _normalize_model_env(env: dict[str, str]) -> None:
     """Expose benchmark provider/model settings to the TypeScript bridge.
 
@@ -92,7 +95,7 @@ def _normalize_model_env(env: dict[str, str]) -> None:
     ).strip()
     if provider == "cerebras" and model.startswith("openai/"):
         model = model.split("/", 1)[1]
-    model_is_cerebras = model in {"gpt-oss-120b", "qwen-3-235b-a22b-instruct-2507"}
+    model_is_cerebras = model in CEREBRAS_OPENAI_MODEL_IDS
 
     cerebras_key = env.get("CEREBRAS_API_KEY", "").strip()
     if cerebras_key and (

--- a/packages/benchmarks/eliza-adapter/tests/test_server_manager.py
+++ b/packages/benchmarks/eliza-adapter/tests/test_server_manager.py
@@ -159,6 +159,44 @@ def test_server_manager_maps_cerebras_env_to_openai_compatible_settings(
     assert env["OPENAI_ACTION_PLANNER_MODEL"] == "gpt-oss-120b"
 
 
+def test_server_manager_autowires_current_cerebras_model_without_provider(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    server = tmp_path / "packages" / "app-core" / "src" / "benchmark" / "server.ts"
+    server.parent.mkdir(parents=True)
+    server.write_text("console.log('fake benchmark server')\n", encoding="utf-8")
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return _FakeProcess()
+
+    manager = ElizaServerManager(repo_root=tmp_path, port=0)
+    monkeypatch.setattr(manager.client, "is_ready", lambda: True)
+    monkeypatch.setattr(manager.client, "health", lambda **_kwargs: {"status": "ready"})
+    monkeypatch.setattr(manager.client, "reset", lambda *args, **kwargs: None)
+    monkeypatch.setattr("eliza_adapter.server_manager.subprocess.Popen", fake_popen)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("BENCHMARK_MODEL_PROVIDER", raising=False)
+    monkeypatch.setenv("CEREBRAS_API_KEY", "csk-test")
+    monkeypatch.setenv("BENCHMARK_MODEL_NAME", "zai-glm-4.7")
+
+    manager.start()
+    manager._proc = None
+
+    env = captured["kwargs"]["env"]
+    assert env["ELIZA_PROVIDER"] == "cerebras"
+    assert env["OPENAI_API_KEY"] == "csk-test"
+    assert env["OPENAI_BASE_URL"] == "https://api.cerebras.ai/v1"
+    assert env["CEREBRAS_MODEL"] == "zai-glm-4.7"
+    assert env["OPENAI_SMALL_MODEL"] == "zai-glm-4.7"
+    assert env["OPENAI_LARGE_MODEL"] == "zai-glm-4.7"
+    assert env["OPENAI_RESPONSE_HANDLER_MODEL"] == "zai-glm-4.7"
+    assert env["OPENAI_ACTION_PLANNER_MODEL"] == "zai-glm-4.7"
+
+
 def test_server_manager_maps_elizaos_task_agent_to_native_adapter(
     monkeypatch,
     tmp_path: Path,
@@ -199,7 +237,7 @@ def test_server_manager_prefers_bun_for_typescript_server(monkeypatch, tmp_path:
     monkeypatch.delenv("ELIZA_BENCH_SERVER_CMD", raising=False)
     monkeypatch.setattr("eliza_adapter.server_manager.shutil.which", lambda name: "/usr/bin/bun" if name == "bun" else None)
 
-    assert _server_command(server) == ["bun", "run", str(server)]
+    assert _server_command(server) == ["bun", "--no-env-file", "run", str(server)]
 
 
 def test_server_manager_falls_back_to_node_tzx(monkeypatch, tmp_path: Path) -> None:

--- a/packages/benchmarks/framework/typescript/src/bench.ts
+++ b/packages/benchmarks/framework/typescript/src/bench.ts
@@ -62,8 +62,9 @@ interface ResolvedLlm {
  * Real-LLM mode accepts either OPENAI_API_KEY or CEREBRAS_API_KEY. When the
  * Cerebras key is present (and OPENAI_API_KEY is not), the OpenAI plugin is
  * auto-configured to point at Cerebras's OpenAI-compatible endpoint with a
- * default Cerebras model — Cerebras serves Llama / Qwen / GPT-OSS at very
- * high tokens/sec, so it's well-suited to live-agent benchmarking.
+ * default Cerebras model. Cerebras serves several OpenAI-compatible model
+ * families at very high tokens/sec, so it's well-suited to live-agent
+ * benchmarking.
  */
 async function resolveLlmPlugin(useRealLlm: boolean): Promise<ResolvedLlm> {
   if (!useRealLlm) {


### PR DESCRIPTION
## Summary
- replace the retired `qwen-3-235b-a22b-instruct-2507` benchmark Cerebras detection entry with a named current Cerebras OpenAI-compatible model set
- add pure-Python coverage proving `zai-glm-4.7` autowires to the Cerebras OpenAI-compatible endpoint when only `CEREBRAS_API_KEY` + model are supplied
- remove Qwen-only wording from the shared TypeScript benchmark real-LLM comment
- update an existing server-manager assertion to match the current `bun --no-env-file run` fallback

## Evidence
- `python -m pytest packages/benchmarks/eliza-adapter/tests/test_server_manager.py -q` (9 passed)
- `bunx @biomejs/biome check packages/benchmarks/framework/typescript/src/bench.ts`
- touched-file Qwen scan: no matches in `server_manager.py`, `test_server_manager.py`, or `bench.ts`
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` (523/523 tasks successful)

## Notes
- No `packages/cloud-frontend` changes; `audit:cloud` is N/A.
- Benchmark suites and baseline datasets that explicitly model Qwen or QwenClawBench remain untouched.

Refs #9588
Refs #9583