### PR TITLE
fix(mobile): remove stale Qwen wording

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -405,7 +405,7 @@ function buildAndroidLocalDirectChatPrompt(args: {
     escapeAndroidLocalChatTemplateTokens(args.userText),
     "<|im_end|>",
     "<|im_start|>assistant",
-    // Match llama.cpp's Qwen3 `enable_thinking=false` chat-template shape.
+    // Match llama.cpp's thinking-disabled chat-template shape.
     // The direct mobile path is for short voice/chat replies; pre-filling an
     // empty think block prevents the model from spending its first tokens on
     // hidden `<think>...</think>` scaffolding before any speakable text.

--- a/packages/app/test/ui-smoke/tts-stt-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/tts-stt-e2e.spec.ts
@@ -34,7 +34,7 @@
  *      in the chat composer. This is the contract the chat composer relies
  *      on to populate the input from voice.
  *
- * The TTS/STT backends themselves (ElevenLabs cloud, Qwen3-ASR, omnivoice)
+ * The TTS/STT backends themselves (ElevenLabs cloud, local ASR, omnivoice)
  * are NOT exercised here — those are integration territory and require
  * credentials + heavy local models (see
  * `packages/app-core/src/services/phrase-chunked-tts.test.ts` for the

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -126,7 +126,7 @@ function buildProviderBillingFields(
  * Computes effective max_tokens, reserving response capacity for reasoning models.
  *
  * Reasoning models (Anthropic extended-thinking, OpenAI o-series, DeepSeek R,
- * MiniMax M, Qwen think, etc.) spend output tokens on hidden chain-of-thought
+ * MiniMax M, and similar families) spend output tokens on hidden chain-of-thought
  * BEFORE emitting any visible answer. If max_tokens only covers the reasoning,
  * the model truncates mid-thought and returns empty content while still billing
  * the consumed tokens. To prevent that:

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -67,7 +67,7 @@ const ELIZA_1_LOAD_METADATA: Record<
 	// 2B is the smallest/entry tier (the small-phone default). Every shipped
 	// tier can use a Gemma 4 assistant drafter when that companion GGUF is
 	// staged next to the bundle. The bridge never falls back to same-file MTP
-	// because that was the retired Qwen contract.
+	// because that belonged to the retired pre-Gemma contract.
 	"eliza-1-2b": {
 		contextSize: 131072,
 		mtp: { drafterFile: "mtp/drafter-2b.gguf", ...GEMMA_MTP_DRAFT },

--- a/plugins/plugin-computeruse/docs/IOS_CONSTRAINTS.md
+++ b/plugins/plugin-computeruse/docs/IOS_CONSTRAINTS.md
@@ -98,8 +98,8 @@ read another app's UIAccessibility tree.
 
 Apple ships an on-device LLM under the `FoundationModels` framework when
 Apple Intelligence is enabled. We expose this as an *opportunistic*
-fast-path. If unavailable, the existing llama-cpp-capacitor (Qwen3-VL-2B)
-local-inference path stays as the default.
+fast-path. If unavailable, the existing llama-cpp-capacitor local Eliza-1
+vision path stays as the default.
 
 Entitlement and Info.plist updates are listed below.
 


### PR DESCRIPTION
## Summary
- Remove remaining stale Qwen mentions from comments and docs that now describe generic thinking-disabled or local Eliza-1 paths.
- Keep the change wording-only across API comments, mobile bridge wording, app smoke-test comments, and iOS constraints docs.

## Evidence
- `bunx @biomejs/biome check packages/agent/src/api/chat-routes.ts packages/cloud-api/v1/chat/completions/route.ts plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts packages/app/test/ui-smoke/tts-stt-e2e.spec.ts plugins/plugin-computeruse/docs/IOS_CONSTRAINTS.md`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/cloud-api typecheck`
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck`
- `bun run --cwd packages/app typecheck`
- touched-file `rg -i qwen` scan clean
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` — 523/523 successful tasks

Cloud frontend visual review: N/A, no `packages/cloud-frontend` changes.