### PR TITLE
fix(ui): align local inference fixtures with Gemma

### DIFF
--- a/packages/ui/src/services/local-inference/hf-search.test.ts
+++ b/packages/ui/src/services/local-inference/hf-search.test.ts
@@ -14,7 +14,7 @@ describe("local model hub compatibility search", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(searchHuggingFaceGguf("qwen", 4)).resolves.toEqual([]);
+    await expect(searchHuggingFaceGguf("custom-model", 4)).resolves.toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -22,7 +22,7 @@ describe("local model hub compatibility search", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(searchModelScopeGguf("qwen", 4)).resolves.toEqual([]);
+    await expect(searchModelScopeGguf("custom-model", 4)).resolves.toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -30,12 +30,12 @@ describe("local model hub compatibility search", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(searchModelHubGguf("qwen", "huggingface", 4)).resolves.toEqual(
-      [],
-    );
-    await expect(searchModelHubGguf("qwen", "modelscope", 4)).resolves.toEqual(
-      [],
-    );
+    await expect(
+      searchModelHubGguf("custom-model", "huggingface", 4),
+    ).resolves.toEqual([]);
+    await expect(
+      searchModelHubGguf("custom-model", "modelscope", 4),
+    ).resolves.toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/stories/src/stories/feature-surfaces.tsx
+++ b/packages/ui/stories/src/stories/feature-surfaces.tsx
@@ -118,9 +118,9 @@ const runningApps: AppRunSummary[] = [
 
 const installedModels: InstalledModel[] = [
   {
-    id: "qwen3-4b-instruct-q4",
-    displayName: "Qwen3 4B Instruct Q4",
-    path: "/models/qwen3-4b-instruct-q4.gguf",
+    id: "eliza-1-4b",
+    displayName: "eliza-1-4B",
+    path: "/models/eliza-1-4b.gguf",
     sizeBytes: 2_680_000_000,
     installedAt: "2026-06-01T08:00:00.000Z",
     lastUsedAt: "2026-06-03T11:55:00.000Z",
@@ -129,14 +129,14 @@ const installedModels: InstalledModel[] = [
 ];
 
 const activeModel: ActiveModelState = {
-  modelId: "qwen3-4b-instruct-q4",
+  modelId: "eliza-1-4b",
   loadedAt: "2026-06-03T11:55:00.000Z",
   status: "ready",
 };
 
 const downloadJob: DownloadJob = {
-  jobId: "job-qwen3",
-  modelId: "qwen3-8b-instruct-q4",
+  jobId: "job-eliza-1-9b",
+  modelId: "eliza-1-9b",
   state: "downloading",
   received: 1_740_000_000,
   total: 4_200_000_000,

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
@@ -218,7 +218,7 @@ describe("CapacitorLlamaAdapter context-id allocation (issue #7681)", () => {
     const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
 
     const adapter = new CapacitorLlamaAdapter();
-    await adapter.load({ modelPath: "/tmp/android-qwen.gguf" });
+    await adapter.load({ modelPath: "/tmp/android-eliza-1.gguf" });
 
     expect(state.initContextCalls).toHaveLength(1);
     expect(state.initContextCalls[0].params.n_gpu_layers).toBe(0);

--- a/plugins/plugin-native-llama/src/definitions.ts
+++ b/plugins/plugin-native-llama/src/definitions.ts
@@ -282,7 +282,7 @@ export interface LlamaAdapter {
    * Apply the loaded model's native chat template to a list of
    * `{role, content}` messages and return the rendered prompt string.
    * Backed by llama.cpp's `llama_chat_apply_template` which uses the
-   * GGUF's own Jinja template — handles Llama-3, Qwen, Mistral, Phi,
+   * GGUF's own Jinja template — handles Gemma, Llama-3, Mistral, Phi,
    * etc. without per-model code on the caller side. Returns null when
    * the loaded GGUF has no chat template baked in.
    */


### PR DESCRIPTION
## Summary
- Replace stale Qwen fixture model IDs in local-inference UI stories with Eliza-1 tier IDs.
- Use neutral custom-model search terms in no-network local model hub tests.
- Update the native llama adapter example comment/test path to Gemma/Eliza-1 wording.

## Evidence
- `bunx @biomejs/biome check packages/ui/src/services/local-inference/hf-search.test.ts packages/ui/stories/src/stories/feature-surfaces.tsx plugins/plugin-native-llama/src/definitions.ts plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts`
- `bun run --cwd packages/ui test -- src/services/local-inference/hf-search.test.ts src/services/local-inference/catalog.test.ts` — 15/15 passed
- `bun run --cwd plugins/plugin-native-llama test -- src/capacitor-llama-adapter.test.ts` — 13/13 passed
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd plugins/plugin-native-llama build`
- touched-file `rg -i qwen` scan clean
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` — 523/523 successful tasks

Cloud frontend visual review: N/A; this changes UI story/test fixtures plus native adapter test/comment only, with no `packages/cloud-frontend` or cloud-reachable runtime UI change.