### PR TITLE
fix(ui): add staging.elizacloud.ai to control-plane hosts so the apex /login redirect fires on staging (Gate B follow-up)

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -81,6 +81,15 @@ describe("CloudRouterShell apex catch-all (Gate B)", () => {
     expect(screen.queryByTestId("login-page")).toBeNull();
   });
 
+  it("redirects an unauthenticated staging apex visitor to /login", () => {
+    // staging.elizacloud.ai is a control-plane apex too — it must behave like
+    // prod (redirect to /login), so staging can validate the fix before prod.
+    setHostname("staging.elizacloud.ai");
+    renderCatchAll();
+    expect(screen.getByTestId("login-page")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
+
   it("does NOT redirect a per-agent subdomain (it boots its real runtime)", () => {
     setHostname("abc123def.elizacloud.ai");
     renderCatchAll();

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -165,7 +165,8 @@ export interface CloudRouterShellProps {
  * their real runtime, so they fall through untouched.
  */
 const APEX_UI_CONTROL_PLANE_HOSTS = new Set(
-  [...ELIZA_CLOUD_CONTROL_PLANE_HOSTS].filter((h) => h !== "api.elizacloud.ai"),
+  // Exclude the API origins (api. / api-staging.) — they never serve this shell.
+  [...ELIZA_CLOUD_CONTROL_PLANE_HOSTS].filter((h) => !/^api[.-]/.test(h)),
 );
 
 function isApexControlPlaneHost(): boolean {

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -55,6 +55,12 @@ export const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   "elizacloud.ai",
   "www.elizacloud.ai",
   "dev.elizacloud.ai",
+  // Staging apex + API. Without these, `staging.elizacloud.ai` ends with
+  // `.elizacloud.ai` but isn't in the set, so isDedicatedCloudAgentBase
+  // mis-classifies the staging console as a per-agent subdomain (and the apex
+  // login redirect never fires on staging — so staging can't validate it).
+  "staging.elizacloud.ai",
+  "api-staging.elizacloud.ai",
 ]);
 
 /**


### PR DESCRIPTION
Follow-up to #9737, surfaced by @cloud-agent's staging validation: the apex `/login` redirect **did not fire on `staging.elizacloud.ai`** — it booted the agent-app first-run chooser instead.

## Root cause
`staging.elizacloud.ai` was missing from `ELIZA_CLOUD_CONTROL_PLANE_HOSTS`. So:
1. `isApexControlPlaneHost()` → false on staging → my apex-unauth `/login` redirect never fired → the agent app booted (first-run chooser).
2. **Separately**, `isDedicatedCloudAgentBase()` (`host.endsWith(".elizacloud.ai") && !CONTROL_PLANE_HOSTS.has(host)`) **mis-classified the staging console apex as a per-agent `<id>.elizacloud.ai` subdomain.**

On **prod** (`elizacloud.ai` *is* in the set) the redirect would have fired correctly — but staging couldn't validate it, which is exactly why holding the prod deploy was the right call.

## Fix
- Add `staging.elizacloud.ai` + `api-staging.elizacloud.ai` to `ELIZA_CLOUD_CONTROL_PLANE_HOSTS` (mirrors the prod `elizacloud.ai` + `api.elizacloud.ai` pair).
- Harden the apex-UI host filter to exclude API origins by the `api.` / `api-` prefix (so `api-staging` is excluded, like `api.`).
- New test: `staging.elizacloud.ai` + unauth → `/login` (5/5 green). typecheck + biome clean.

Now staging behaves like prod (apex+unauth → Steward `/login`), so the console UX can be validated on staging before the prod deploy. cc @cloud-agent — re-run your staging check after this lands and it should redirect to `/login`.