### PR TITLE
docs(training): align Gemma bundle assembler contract

### DIFF
--- a/packages/training/scripts/publish/assemble_local_gemma_bundle.py
+++ b/packages/training/scripts/publish/assemble_local_gemma_bundle.py
@@ -20,13 +20,12 @@ network and does NOT publish. It only assembles the text/vision/(mtp) core
 from local files and validates the result, so M8's "assemble a loadable E2B
 bundle from local artifacts" goal can be proven offline.
 
-The manifest schema here is the GEMMA cutover shape described in the M8 plan
-(`schema.ts`: tiers 2b/4b/9b/27b/27b-256k, tokenizerFamily "gemma", vocab
-262144, REQUIRED_KERNELS = turboquant_q4 + turbo3_tcq, separate-drafter MTP,
-stock q8_0 KV). It is written directly rather than via
-`scripts/manifest/eliza1_manifest.py`, which is still the pre-Gemma version
-(lists 0_8b, requires qjl+polar, has no tokenizer/kv/mtp fields) and would
-emit a non-Gemma contract until its own M8 workstream lands.
+The manifest schema here is the Gemma 4 cutover shape described in the M8 plan
+and now mirrored by `scripts/manifest/eliza1_manifest.py` (`schema.ts`: tiers
+2b/4b/9b/27b/27b-256k, tokenizerFamily "gemma4", vocab 262144,
+REQUIRED_KERNELS = turboquant_q4 + turbo3_tcq, separate-drafter MTP, stock q8_0
+KV). This standalone assembler keeps the same contract local so it can prove a
+loadable core bundle without running the full publish pipeline.
 
 Usage:
     cd packages/training


### PR DESCRIPTION
## Summary
- update the local Gemma bundle assembler header to say tokenizerFamily `gemma4`
- remove the stale note that `eliza1_manifest.py` was still pre-Gemma and missing tokenizer/KV/MTP fields
- point the standalone assembler docs at the current Gemma 4 manifest contract while keeping the offline-bundle behavior unchanged

## Evidence
- `python -m py_compile packages/training/scripts/publish/assemble_local_gemma_bundle.py`
- `rg -n -i 'tokenizerFamily "gemma"|pre-Gemma|lists 0_8b|qjl\\+polar|non-Gemma contract|Qwen' packages/training/scripts/publish/assemble_local_gemma_bundle.py` returned no matches\n- `git diff --check`\n- `git fetch origin && git rebase origin/develop`\n- `bun install`\n- `bun run verify` (523/523 tasks)\n\n## UI / media evidence\n- N/A: comment-only training publish-script documentation; no runtime UI, cloud frontend, audio, model behavior, or media path changed.