### PR TITLE
fix(training): derive publish kernel proofs from Gemma tiers

### DIFF
--- a/packages/training/scripts/manifest/eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/eliza1_platform_plan.py
@@ -21,6 +21,7 @@ try:
         ELIZA_1_PUBLISHABLE_RELEASE_STATES,
         ELIZA_1_TIERS,
         ELIZA_1_VISION_TIERS,
+        REQUIRED_KERNELS_BY_TIER,
         SUPPORTED_BACKENDS_BY_TIER,
         VOICE_BACKENDS_BY_TIER,
         VOICE_PRESET_CACHE_PATH,
@@ -35,6 +36,7 @@ except ImportError:  # pragma: no cover - script execution path
         ELIZA_1_PUBLISHABLE_RELEASE_STATES,
         ELIZA_1_TIERS,
         ELIZA_1_VISION_TIERS,
+        REQUIRED_KERNELS_BY_TIER,
         SUPPORTED_BACKENDS_BY_TIER,
         VOICE_BACKENDS_BY_TIER,
         VOICE_PRESET_CACHE_PATH,
@@ -85,6 +87,19 @@ IMAGEGEN_ARTIFACTS_BY_TIER: Final[Mapping[str, tuple[str, ...]]] = {
 }
 VISION_TIERS: Final[frozenset[str]] = ELIZA_1_VISION_TIERS
 MTP_TIERS: Final[frozenset[str]] = ELIZA_1_MTP_TIERS
+
+QUANTIZATION_SIDECARS_BY_REQUIRED_KERNEL: Final[Mapping[str, tuple[str, ...]]] = {
+    "turboquant_q4": (
+        "quantization/turboquant.json",
+        "quantization/fused_turboquant.json",
+    ),
+    "turbo3_tcq": (
+        "quantization/turboquant.json",
+        "quantization/fused_turboquant.json",
+    ),
+    "qjl": ("quantization/qjl_config.json",),
+    "polarquant": ("quantization/polarquant_config.json",),
+}
 
 COMPONENT_LICENSES_BY_TIER: Final[Mapping[str, tuple[str, ...]]] = {
     tier: (
@@ -189,6 +204,18 @@ def text_artifact_name(tier: str, ctx: str) -> str:
     return f"text/eliza-1-{tier}-{ctx}.gguf"
 
 
+def required_quantization_sidecars_for_tier(tier: str) -> tuple[str, ...]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for kernel in REQUIRED_KERNELS_BY_TIER[tier]:
+        for rel_path in QUANTIZATION_SIDECARS_BY_REQUIRED_KERNEL.get(kernel, ()):
+            if rel_path in seen:
+                continue
+            out.append(rel_path)
+            seen.add(rel_path)
+    return tuple(out)
+
+
 def required_files_for_tier(tier: str) -> tuple[str, ...]:
     text_files = tuple(text_artifact_name(tier, ctx) for ctx in CONTEXTS_BY_TIER[tier])
     voice_files = tuple(f"tts/{name}" for name in required_voice_artifacts_for_tier(tier))
@@ -226,10 +253,7 @@ def required_files_for_tier(tier: str) -> tuple[str, ...]:
         *COMPONENT_LICENSES_BY_TIER[tier],
         "checksums/SHA256SUMS",
         "evidence/release.json",
-        "quantization/turboquant.json",
-        "quantization/fused_turboquant.json",
-        "quantization/qjl_config.json",
-        "quantization/polarquant_config.json",
+        *required_quantization_sidecars_for_tier(tier),
     )
 
 

--- a/packages/training/scripts/manifest/test_eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/test_eliza1_platform_plan.py
@@ -64,6 +64,15 @@ def test_mtp_required_files_match_bundle_layout() -> None:
     assert "licenses/LICENSE.mtp" in small_plan.required_files
 
 
+def test_gemma_quantization_sidecars_follow_required_kernels() -> None:
+    plan = build_plan()
+    for tier_plan in plan.values():
+        assert "quantization/turboquant.json" in tier_plan.required_files
+        assert "quantization/fused_turboquant.json" in tier_plan.required_files
+        assert "quantization/qjl_config.json" not in tier_plan.required_files
+        assert "quantization/polarquant_config.json" not in tier_plan.required_files
+
+
 def test_text_contexts_ship_half_and_native_contexts() -> None:
     plan = build_plan()
     for tier in ("2b", "4b", "9b", "27b"):

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -155,6 +155,15 @@ REQUIRED_QUANTIZATION_SIDECARS: Mapping[str, tuple[str, ...]] = {
     "qjl": ("qjl_config.json",),
     "polarquant": ("polarquant_config.json",),
 }
+REQUIRED_QUANTIZATION_SIDECARS_BY_KERNEL: Mapping[str, tuple[str, ...]] = {
+    # turboquant_q4 is the Gemma weight-quant proof. The fused sidecar is still
+    # required because it carries the runtime kernel layout pins consumed by the
+    # manifest builder.
+    "turboquant_q4": ("turboquant.json", "fused_turboquant.json"),
+    "turbo3_tcq": ("turboquant.json", "fused_turboquant.json"),
+    "qjl": ("qjl_config.json",),
+    "polarquant": ("polarquant_config.json",),
+}
 REQUIRED_KERNEL_MANIFEST_KEYS: tuple[str, ...] = (
     "kernel_target",
     "block_layout_version",
@@ -188,13 +197,13 @@ REQUIRED_RELEASE_FINAL_FLAGS: tuple[str, ...] = (
 BASE_V1_RELEASE_FINAL_FLAGS: tuple[str, ...] = tuple(
     flag for flag in REQUIRED_RELEASE_FINAL_FLAGS if flag != "weights"
 )
-REQUIRED_GRAPH_CACHE_FAMILIES: tuple[str, ...] = (
-    "turbo3",
-    "turbo4",
-    "turbo3_tcq",
-    "qjl",
-    "polar",
-)
+REQUIRED_GRAPH_CACHE_FAMILIES_BY_KERNEL: Mapping[str, tuple[str, ...]] = {
+    "turbo3": ("turbo3",),
+    "turbo4": ("turbo4",),
+    "turbo3_tcq": ("turbo3_tcq",),
+    "qjl": ("qjl",),
+    "polarquant": ("polar",),
+}
 # Tier matrix — tagline + lineage taken from inference/AGENTS.md §2.
 TIER_TAGLINES: Mapping[str, str] = {
     "2b": "modern phones",
@@ -322,100 +331,135 @@ def _kernel_targets(kernel_manifest: Mapping[str, Any]) -> set[str]:
     return set()
 
 
-def _validate_quantization_sidecars(bundle: Path) -> list[Path]:
+def _unique_preserving_order(values: Sequence[str]) -> tuple[str, ...]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        out.append(value)
+        seen.add(value)
+    return tuple(out)
+
+
+def _required_quantization_sidecar_names_for_tier(tier: str) -> tuple[str, ...]:
+    names: list[str] = []
+    for kernel in REQUIRED_KERNELS_BY_TIER[tier]:
+        names.extend(REQUIRED_QUANTIZATION_SIDECARS_BY_KERNEL.get(kernel, ()))
+    return _unique_preserving_order(names)
+
+
+def _known_quantization_sidecar_names() -> tuple[str, ...]:
+    return _unique_preserving_order(
+        name
+        for names in REQUIRED_QUANTIZATION_SIDECARS.values()
+        for name in names
+    )
+
+
+def _required_graph_cache_families_for_tier(tier: str) -> tuple[str, ...]:
+    families: list[str] = []
+    for kernel in REQUIRED_KERNELS_BY_TIER[tier]:
+        families.extend(REQUIRED_GRAPH_CACHE_FAMILIES_BY_KERNEL.get(kernel, ()))
+    return _unique_preserving_order(families)
+
+
+def _validate_quantization_sidecars(bundle: Path, *, tier: str) -> list[Path]:
     found: list[Path] = []
-    for method, names in REQUIRED_QUANTIZATION_SIDECARS.items():
-        for name in names:
-            sidecar = _find_sidecar_by_name(bundle, name)
-            if sidecar is None:
+    required_names = set(_required_quantization_sidecar_names_for_tier(tier))
+    for name in _known_quantization_sidecar_names():
+        sidecar = _find_sidecar_by_name(bundle, name)
+        if sidecar is None:
+            if name in required_names:
+                method = REQUIRED_METHOD_BY_SIDECAR[name]
                 raise OrchestratorError(
                     "bundle layout: missing quantization sidecar for "
                     f"{method}; expected {name} in bundle root, text/, "
                     "mtp/, evals/, or quantization/",
                     EXIT_MISSING_FILE,
                 )
-            data = _read_sidecar(sidecar)
-            kernel_manifest = data.get("kernel_manifest")
-            if not isinstance(kernel_manifest, dict):
+            continue
+
+        data = _read_sidecar(sidecar)
+        kernel_manifest = data.get("kernel_manifest")
+        if not isinstance(kernel_manifest, dict):
+            raise OrchestratorError(
+                f"quantization sidecar {sidecar} missing kernel_manifest object",
+                EXIT_BUNDLE_LAYOUT_FAIL,
+            )
+        expected_method = REQUIRED_METHOD_BY_SIDECAR[name]
+        if data.get("method") != expected_method:
+            raise OrchestratorError(
+                f"quantization sidecar {sidecar} method must be "
+                f"{expected_method!r}; got {data.get('method')!r}",
+                EXIT_BUNDLE_LAYOUT_FAIL,
+            )
+        missing_keys = [
+            key for key in REQUIRED_KERNEL_MANIFEST_KEYS if key not in kernel_manifest
+        ]
+        if missing_keys:
+            raise OrchestratorError(
+                f"quantization sidecar {sidecar} has partial "
+                f"kernel_manifest; missing {missing_keys}",
+                EXIT_BUNDLE_LAYOUT_FAIL,
+            )
+        targets = _kernel_targets(kernel_manifest)
+        if not targets:
+            raise OrchestratorError(
+                f"quantization sidecar {sidecar} kernel_manifest.kernel_target "
+                "must be a non-empty array",
+                EXIT_BUNDLE_LAYOUT_FAIL,
+            )
+        expected_targets = set(REQUIRED_KERNEL_TARGETS_BY_SIDECAR[name])
+        missing_targets = sorted(expected_targets - targets)
+        if missing_targets:
+            raise OrchestratorError(
+                f"quantization sidecar {sidecar} targets {sorted(targets)} "
+                f"but must cover {sorted(expected_targets)}; missing "
+                f"{missing_targets}",
+                EXIT_BUNDLE_LAYOUT_FAIL,
+            )
+        for manifest_field in (
+            "block_layout_version",
+            "codebook_hash",
+            "per_block_tolerance",
+        ):
+            section = kernel_manifest.get(manifest_field)
+            if not isinstance(section, dict):
                 raise OrchestratorError(
-                    f"quantization sidecar {sidecar} missing kernel_manifest object",
+                    f"quantization sidecar {sidecar} kernel_manifest.{manifest_field} "
+                    "must be an object",
                     EXIT_BUNDLE_LAYOUT_FAIL,
                 )
-            expected_method = REQUIRED_METHOD_BY_SIDECAR[name]
-            if data.get("method") != expected_method:
+            missing_field_targets = sorted(expected_targets - set(section))
+            if missing_field_targets:
                 raise OrchestratorError(
-                    f"quantization sidecar {sidecar} method must be "
-                    f"{expected_method!r}; got {data.get('method')!r}",
+                    f"quantization sidecar {sidecar} kernel_manifest.{manifest_field} "
+                    f"missing target metadata for {missing_field_targets}",
                     EXIT_BUNDLE_LAYOUT_FAIL,
                 )
-            missing_keys = [
-                key
-                for key in REQUIRED_KERNEL_MANIFEST_KEYS
-                if key not in kernel_manifest
-            ]
-            if missing_keys:
-                raise OrchestratorError(
-                    f"quantization sidecar {sidecar} has partial "
-                    f"kernel_manifest; missing {missing_keys}",
-                    EXIT_BUNDLE_LAYOUT_FAIL,
-                )
-            targets = _kernel_targets(kernel_manifest)
-            if not targets:
-                raise OrchestratorError(
-                    f"quantization sidecar {sidecar} kernel_manifest.kernel_target "
-                    "must be a non-empty array",
-                    EXIT_BUNDLE_LAYOUT_FAIL,
-                )
-            expected_targets = set(REQUIRED_KERNEL_TARGETS_BY_SIDECAR[name])
-            missing_targets = sorted(expected_targets - targets)
-            if missing_targets:
-                raise OrchestratorError(
-                    f"quantization sidecar {sidecar} targets {sorted(targets)} "
-                    f"but must cover {sorted(expected_targets)}; missing "
-                    f"{missing_targets}",
-                    EXIT_BUNDLE_LAYOUT_FAIL,
-                )
-            for manifest_field in (
-                "block_layout_version",
-                "codebook_hash",
-                "per_block_tolerance",
-            ):
-                section = kernel_manifest.get(manifest_field)
-                if not isinstance(section, dict):
-                    raise OrchestratorError(
-                        f"quantization sidecar {sidecar} kernel_manifest.{manifest_field} "
-                        "must be an object",
-                        EXIT_BUNDLE_LAYOUT_FAIL,
-                    )
-                missing_field_targets = sorted(expected_targets - set(section))
-                if missing_field_targets:
-                    raise OrchestratorError(
-                        f"quantization sidecar {sidecar} kernel_manifest.{manifest_field} "
-                        f"missing target metadata for {missing_field_targets}",
-                        EXIT_BUNDLE_LAYOUT_FAIL,
-                    )
-                for target in expected_targets:
-                    value = section.get(target)
-                    if manifest_field == "per_block_tolerance":
-                        if (
-                            not isinstance(value, (int, float))
-                            or isinstance(value, bool)
-                            or value <= 0
-                        ):
-                            raise OrchestratorError(
-                                f"quantization sidecar {sidecar} "
-                                f"kernel_manifest.{manifest_field}.{target} must be a "
-                                "positive number",
-                                EXIT_BUNDLE_LAYOUT_FAIL,
-                            )
-                    elif not isinstance(value, str) or not value:
+            for target in expected_targets:
+                value = section.get(target)
+                if manifest_field == "per_block_tolerance":
+                    if (
+                        not isinstance(value, (int, float))
+                        or isinstance(value, bool)
+                        or value <= 0
+                    ):
                         raise OrchestratorError(
                             f"quantization sidecar {sidecar} "
                             f"kernel_manifest.{manifest_field}.{target} must be a "
-                            "non-empty string",
+                            "positive number",
                             EXIT_BUNDLE_LAYOUT_FAIL,
                         )
-            found.append(sidecar)
+                elif not isinstance(value, str) or not value:
+                    raise OrchestratorError(
+                        f"quantization sidecar {sidecar} "
+                        f"kernel_manifest.{manifest_field}.{target} must be a "
+                        "non-empty string",
+                        EXIT_BUNDLE_LAYOUT_FAIL,
+                    )
+        found.append(sidecar)
     return found
 
 
@@ -942,7 +986,10 @@ def validate_bundle_layout(ctx: PublishContext) -> dict[str, list[Path]]:
             EXIT_MISSING_FILE,
         )
 
-    out["quantization_sidecars"] = _validate_quantization_sidecars(bundle)
+    out["quantization_sidecars"] = _validate_quantization_sidecars(
+        bundle,
+        tier=ctx.tier,
+    )
 
     missing_platform_files = sorted(
         rel for rel in required_files_for_tier(ctx.tier) if not (bundle / rel).is_file()
@@ -1130,6 +1177,7 @@ def _require_existing_json_report(
     rel_path: str,
     require_runtime_ready: bool,
     model_sha256s: set[str] | None = None,
+    required_cache_families: Sequence[str] = (),
 ) -> Mapping[str, Any]:
     if not rel_path.startswith(("evals/", "evidence/")):
         raise OrchestratorError(
@@ -1180,6 +1228,7 @@ def _require_existing_json_report(
             rel_path,
             data,
             model_sha256s=model_sha256s,
+            required_cache_families=required_cache_families,
         )
     else:
         _validate_platform_report(rel_path, data, target=target)
@@ -1258,6 +1307,7 @@ def _validate_runtime_dispatch_report(
     data: Mapping[str, Any],
     *,
     model_sha256s: set[str] | None = None,
+    required_cache_families: Sequence[str] = (),
 ) -> None:
     errors: list[str] = []
     if data.get("runtimeReady") is not True:
@@ -1282,7 +1332,7 @@ def _validate_runtime_dispatch_report(
     ):
         errors.append("kernelSet must be an array of strings")
     else:
-        missing = sorted(set(REQUIRED_GRAPH_CACHE_FAMILIES) - set(kernel_set))
+        missing = sorted(set(required_cache_families) - set(kernel_set))
         if missing:
             errors.append(f"kernelSet missing {missing}")
     graph = data.get("graphDispatch")
@@ -1295,7 +1345,7 @@ def _validate_runtime_dispatch_report(
         ):
             errors.append("graphDispatch.cacheFamilies must be an array of strings")
         else:
-            missing = sorted(set(REQUIRED_GRAPH_CACHE_FAMILIES) - set(families))
+            missing = sorted(set(required_cache_families) - set(families))
             if missing:
                 errors.append(f"graphDispatch.cacheFamilies missing {missing}")
         command = graph.get("command")
@@ -1514,6 +1564,9 @@ def validate_release_evidence(
             rel_path=dispatch_path,
             require_runtime_ready=True,
             model_sha256s=text_model_sha256s,
+            required_cache_families=_required_graph_cache_families_for_tier(
+                ctx.tier,
+            ),
         )
 
     for target in REQUIRED_PLATFORM_EVIDENCE_BY_TIER[ctx.tier]:

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -376,7 +376,7 @@ def _build_fixture_bundle(
             }
         ),
     )
-    graph_kernel_set = ["turbo3", "turbo4", "turbo3_tcq", "qjl", "polar"]
+    graph_kernel_set = ["turbo3_tcq"]
     for backend in ("metal", "vulkan", "cuda", "rocm", "cpu"):
         _write(
             bundle / "evals" / f"{backend}_dispatch.json",
@@ -914,12 +914,16 @@ def test_wrong_hf_org_fails_before_publish(tmp_path: Path) -> None:
     assert rc == EXIT_USAGE
 
 
-def test_missing_quantization_sidecar_fails(tmp_path: Path) -> None:
+def test_gemma_bundle_does_not_require_legacy_qjl_or_polar_sidecars(
+    tmp_path: Path,
+) -> None:
     bundle = _build_fixture_bundle(tmp_path)
     (bundle / "quantization" / "qjl_config.json").unlink()
+    (bundle / "quantization" / "polarquant_config.json").unlink()
+    _write_checksums(bundle)
     metal = _metal_report(tmp_path)
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
-    assert rc == EXIT_MISSING_FILE
+    assert rc == EXIT_OK
 
 
 def test_missing_fused_turboquant_sidecar_fails(tmp_path: Path) -> None:
@@ -1143,6 +1147,21 @@ def test_runtime_dispatch_report_requires_graph_evidence(tmp_path: Path) -> None
     _write_checksums(bundle)
     metal = _metal_report(tmp_path)
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
+    assert rc == EXIT_RELEASE_EVIDENCE_FAIL
+
+
+def test_runtime_dispatch_report_requires_gemma_cache_family(tmp_path: Path) -> None:
+    bundle = _build_fixture_bundle(tmp_path)
+    report_path = bundle / "evals" / "metal_dispatch.json"
+    report = json.loads(report_path.read_text())
+    report["kernelSet"] = []
+    report["graphDispatch"]["cacheFamilies"] = []
+    report_path.write_text(json.dumps(report, indent=2))
+    _write_checksums(bundle)
+    metal = _metal_report(tmp_path)
+
+    rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
+
     assert rc == EXIT_RELEASE_EVIDENCE_FAIL
 
 


### PR DESCRIPTION
## Summary
- derive required publish quantization sidecars from `REQUIRED_KERNELS_BY_TIER` instead of requiring legacy QJL/Polar sidecars for every bundle
- make runtime dispatch report cache-family validation tier-aware, so Gemma reports only need the cache families implied by the active Gemma kernel set
- align the generated platform plan with the same Gemma tier kernel matrix and add regression coverage

## Evidence
- `uv run --with jinja2 python -m pytest packages/training/scripts/publish/test_orchestrator.py packages/training/scripts/manifest/test_eliza1_platform_plan.py -q` (68/68 passed; existing pytest-asyncio deprecation warning only)
- `python -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py packages/training/scripts/manifest/eliza1_platform_plan.py packages/training/scripts/manifest/test_eliza1_platform_plan.py`
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` (523/523 tasks)

## UI / media evidence
- N/A: training publish-pipeline and manifest-plan validation only; no runtime UI, cloud frontend, audio, media serving, or model trajectory changed.