### PR TITLE
fix(training): align quantization scripts with Gemma

### DIFF
--- a/packages/training/scripts/quantization/fp8_apply.py
+++ b/packages/training/scripts/quantization/fp8_apply.py
@@ -1,4 +1,4 @@
-"""Apply FP8 (E4M3) weight quantization to a fine-tuned Qwen checkpoint.
+"""Apply FP8 (E4M3) weight quantization to a fine-tuned Eliza-1/Gemma checkpoint.
 
 Wraps :mod:`torchao.float8` per the recipe in
 https://pytorch.org/torchao/main/api_ref_quantization.html — converts every

--- a/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
@@ -1,4 +1,4 @@
-"""Apply GGUF Q3_K_M K-quant to a fine-tuned Qwen checkpoint.
+"""Apply GGUF Q3_K_M K-quant to a fine-tuned Eliza-1/Gemma checkpoint.
 
 Wraps llama.cpp's two-stage GGUF conversion:
 

--- a/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
@@ -1,4 +1,4 @@
-"""Apply GGUF Q4_K_M K-quant to a fine-tuned Qwen checkpoint.
+"""Apply GGUF Q4_K_M K-quant to a fine-tuned Eliza-1/Gemma checkpoint.
 
 Wraps llama.cpp's two-stage GGUF conversion:
 

--- a/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
@@ -1,4 +1,4 @@
-"""Apply GGUF Q5_K_M K-quant to a fine-tuned Qwen checkpoint.
+"""Apply GGUF Q5_K_M K-quant to a fine-tuned Eliza-1/Gemma checkpoint.
 
 Wraps llama.cpp's two-stage GGUF conversion:
 

--- a/packages/training/scripts/quantization/gguf-q6_k_apply.py
+++ b/packages/training/scripts/quantization/gguf-q6_k_apply.py
@@ -1,4 +1,4 @@
-"""Apply GGUF Q6_K K-quant to a fine-tuned Qwen checkpoint.
+"""Apply GGUF Q6_K K-quant to a fine-tuned Eliza-1/Gemma checkpoint.
 
 Wraps llama.cpp's two-stage GGUF conversion:
 

--- a/packages/training/scripts/quantization/polarquant_apply.py
+++ b/packages/training/scripts/quantization/polarquant_apply.py
@@ -53,7 +53,7 @@ logger = logging.getLogger("polarquant_apply")
 
 # Architectures we have explicitly verified against the standard
 # ``self_attn.{q,k,v,o}_proj`` / ``mlp.{gate,up,down}_proj`` linear layout.
-_KNOWN_GOOD_ARCH_SUBSTRINGS = ("qwen2", "qwen3", "llama", "mistral", "phi3")
+_KNOWN_GOOD_ARCH_SUBSTRINGS = ("gemma", "llama", "mistral", "phi3")
 
 
 @dataclass(frozen=True)
@@ -87,7 +87,7 @@ def _iter_linears(
     """Linears we want to quantize, in deterministic order.
 
     Skips small projections / MoE routers (``min_numel``), the LM head
-    (weight-tied on Qwen-family models), and embedding tables (lookups,
+    (weight-tied on many causal-LM models), and embedding tables (lookups,
     not multiplies).
     """
     out: list[tuple[str, nn.Linear]] = []

--- a/packages/training/scripts/quantization/turboquant_apply.py
+++ b/packages/training/scripts/quantization/turboquant_apply.py
@@ -1,4 +1,4 @@
-"""Apply TurboQuant KV-cache quantization to a fine-tuned Qwen checkpoint.
+"""Apply TurboQuant KV-cache quantization to a fine-tuned Eliza-1/Gemma checkpoint.
 
 TurboQuant
     Zandieh, Daliri, Hadian, Mirrokni. *TurboQuant: Online Random

--- a/packages/training/scripts/train_vast.sh
+++ b/packages/training/scripts/train_vast.sh
@@ -59,7 +59,7 @@
 #                                pass it through the env. ``vastai set
 #                                api-key`` also works (writes to
 #                                ~/.config/vastai/vast_api_key).
-#   HUGGING_FACE_HUB_TOKEN     # for gated Qwen access
+#   HUGGING_FACE_HUB_TOKEN     # for gated Gemma access
 #
 # Optional env:
 #   REGISTRY_KEY               # default: gemma4-31b
@@ -132,7 +132,7 @@
 # Pipeline-specific examples (--pipeline / PIPELINE env defaults to sft):
 #   bash scripts/train_vast.sh --pipeline grpo provision-and-train \
 #       --registry-key gemma4-e2b --dry-run
-#   PIPELINE=grpo DPO_CHECKPOINT=checkpoints/qwen3-5-9b-dpo/final \
+#   PIPELINE=grpo DPO_CHECKPOINT=checkpoints/gemma4-12b-dpo/final \
 #       bash scripts/train_vast.sh provision-and-train --registry-key gemma4-12b
 #
 # Or `bash scripts/train_vast.sh full` for the whole flow.


### PR DESCRIPTION
## Summary
- update active training quantization wrapper descriptions from Qwen checkpoint wording to Eliza-1/Gemma checkpoint wording
- mark Gemma as the known-compatible PolarQuant architecture family and remove the stale Qwen-specific LM-head comment
- update Vast training operator comments/examples from gated Qwen/DPO checkpoint wording to Gemma

## Evidence
- touched-file Qwen scan returned no matches for the edited quantization scripts and `train_vast.sh`
- `uv run python -m py_compile packages/training/scripts/quantization/gguf-q3_k_m_apply.py packages/training/scripts/quantization/gguf-q4_k_m_apply.py packages/training/scripts/quantization/gguf-q5_k_m_apply.py packages/training/scripts/quantization/gguf-q6_k_apply.py packages/training/scripts/quantization/fp8_apply.py packages/training/scripts/quantization/turboquant_apply.py packages/training/scripts/quantization/polarquant_apply.py`
- `bash -n packages/training/scripts/train_vast.sh`
- `uv run python -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q` passed: 35 passed, expected skips only
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` passed: 523/523 tasks

## UI / media / LLM evidence
- N/A: training script wording/compatibility cleanup only; no app UI, media, audio, prompt, model behavior, or runtime trajectory changed.