### PR TITLE
fix(plugin-elizacloud): de-double Cerebras streamed tool-call args (terse-prompt dead-end)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -200,6 +200,83 @@ describe("streamed tool-call delta assembly", () => {
     accumulateToolCallDeltas(acc, [{ index: 0, function: { arguments: "{}" } }]);
     expect(finalizeStreamedToolCalls(acc)).toEqual([]);
   });
+
+  it("does NOT double when Cerebras re-sends the complete args in a final aggregated frame", () => {
+    // Cerebras streams the args incrementally, then emits a FINAL frame that
+    // re-carries id + name + the COMPLETE arguments object. Appending that
+    // re-send would yield `{"replyText":"PONG"}{"replyText":"PONG"}` (doubled).
+    const acc = new Map();
+    accumulateToolCallDeltas(acc, [
+      { index: 0, id: "call_1", function: { name: "HANDLE_RESPONSE", arguments: "" } },
+    ]);
+    accumulateToolCallDeltas(acc, [{ index: 0, function: { arguments: '{"replyText":"PO' } }]);
+    accumulateToolCallDeltas(acc, [{ index: 0, function: { arguments: 'NG"}' } }]);
+    // Aggregated re-send of the whole object (re-carries id + name).
+    accumulateToolCallDeltas(acc, [
+      {
+        index: 0,
+        id: "call_1",
+        function: { name: "HANDLE_RESPONSE", arguments: '{"replyText":"PONG"}' },
+      },
+    ]);
+    expect(finalizeStreamedToolCalls(acc)).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "HANDLE_RESPONSE",
+        input: { replyText: "PONG" },
+      },
+    ]);
+  });
+
+  it("takes the authoritative re-send even when it diverges from the incremental copy", () => {
+    // The cloud character ("lowercase naturally") can make the model emit a
+    // different casing in the aggregated re-send than in the streamed fragments.
+    // The re-send is the authoritative full copy — keep a single, valid object.
+    const acc = new Map();
+    accumulateToolCallDeltas(acc, [
+      {
+        index: 0,
+        id: "call_1",
+        function: { name: "HANDLE_RESPONSE", arguments: '{"replyText":"PONG"}' },
+      },
+    ]);
+    accumulateToolCallDeltas(acc, [
+      {
+        index: 0,
+        id: "call_1",
+        function: { name: "HANDLE_RESPONSE", arguments: '{"replyText":"pong"}' },
+      },
+    ]);
+    expect(finalizeStreamedToolCalls(acc)).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "HANDLE_RESPONSE",
+        input: { replyText: "pong" },
+      },
+    ]);
+  });
+
+  it("does NOT replace mid-stream when a nested inner object closes early", () => {
+    // Regression guard for the resend detector: a fragment can transiently
+    // contain a closed INNER object (`{"a":{"b":1}`) while the OUTER object is
+    // still open. JSON.parse rejects that prefix (a brace counter would not),
+    // so the fragments must keep appending — never replace mid-object.
+    const acc = new Map();
+    accumulateToolCallDeltas(acc, [
+      { index: 0, id: "call_1", function: { name: "set_filter", arguments: '{"a":{"b":1}' } },
+    ]);
+    accumulateToolCallDeltas(acc, [{ index: 0, function: { arguments: ',"c":2}' } }]);
+    expect(finalizeStreamedToolCalls(acc)).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "set_filter",
+        input: { a: { b: 1 }, c: 2 },
+      },
+    ]);
+  });
 });
 
 describe("streamNativeChatCompletion", () => {

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1245,6 +1245,31 @@ interface StreamingToolCallAcc {
   args: string;
 }
 
+/**
+ * True when `value` is one complete, self-contained JSON object (it parses and
+ * is a plain object — not an array or scalar). Used to recognise Cerebras's
+ * final aggregated tool-call frame, which re-sends the whole arguments object
+ * rather than the next incremental fragment.
+ *
+ * Parsing (not brace-counting) is load-bearing: a proper prefix of a single
+ * JSON object never itself parses as complete — the outer `{` stays open even
+ * when an inner `}` arrives mid-stream (e.g. `{"a":{"b":1}`) — so this only
+ * becomes true once the WHOLE object has arrived, which is exactly the resend
+ * boundary. A brace counter would be fooled by that inner close.
+ */
+function isCompleteJsonObject(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{")) return false;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return (
+      parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Fold one SSE `delta.tool_calls[]` array into the per-index accumulator. */
 export function accumulateToolCallDeltas(
   acc: Map<number, StreamingToolCallAcc>,
@@ -1260,7 +1285,22 @@ export function accumulateToolCallDeltas(
     const fn = recordAt(d, "function");
     const name = firstString(fn.name);
     if (name) cur.name = name;
-    if (typeof fn.arguments === "string") cur.args += fn.arguments;
+    if (typeof fn.arguments === "string") {
+      // Cerebras streams the tool-call arguments incrementally, then emits a
+      // FINAL aggregated frame that re-sends the COMPLETE arguments object
+      // (re-carrying id + name). Blindly appending that re-send doubles the
+      // JSON (`{…}{…}`); downstream parsing can only recover when both copies
+      // are byte-identical, and the cloud character ("lowercase naturally")
+      // makes the copies diverge on casing — dead-ending terse replies. When
+      // the accumulated args AND the incoming fragment are each a complete,
+      // self-contained object the incoming is the authoritative full copy:
+      // replace rather than concatenate.
+      if (isCompleteJsonObject(cur.args) && isCompleteJsonObject(fn.arguments)) {
+        cur.args = fn.arguments;
+      } else {
+        cur.args += fn.arguments;
+      }
+    }
     acc.set(index, cur);
   }
 }


### PR DESCRIPTION
## The launch blocker

Dedicated cloud agents dead-ended on **terse / imperative prompts**: `Say PONG`, `Reply with OK`, etc. returned the **"I'm not sure how to answer that."** fallback, while natural-language prompts (`what's 2+2?` → `4`) worked fine. This blocks the 10-user dedicated-agent launch.

## Root cause (reproduced live, raw SSE captured)

Cerebras (gpt-oss-120b) streams a tool-call's `arguments` **incrementally**, then emits a **final aggregated frame that re-sends the COMPLETE arguments object** — re-carrying `id` + `name`, like the opening frame, but with the whole JSON body:

```
delta.tool_calls[0]  id=call_x name=HANDLE_RESPONSE arguments=""
delta.tool_calls[0]                                  arguments='{"replyText":"PO'
delta.tool_calls[0]                                  arguments='NG"}'
delta.tool_calls[0]  id=call_x name=HANDLE_RESPONSE arguments='{"replyText":"PONG"}'   ← aggregated re-send
```

`accumulateToolCallDeltas` blindly **appended every fragment** (`cur.args += fn.arguments`), so the re-send **doubled** the JSON:

```
{"replyText":"PONG"}{"replyText":"PONG"}
```

Core's `parseToolArgumentsString` has duplicated-streaming recovery, but it only salvages **byte-identical** copies (by design — on conflict it triggers a stage-1 retry rather than guess). The default cloud character says *"lowercase naturally"*, so the model varies casing **across the two emissions** (`PONG` vs `pong`). The copies diverge → recovery bails → `replyText` is empty → the **"I'm not sure how to answer that."** fallback fires.

Natural-language replies (`4`) survive only because they're identical in both copies, so recovery picks the first.

## The fix (at the source, correct layer)

The doubling is a Cerebras-streaming artifact, so it's fixed at the Cerebras accumulator — **not** by loosening core's generic conflict policy. When the already-accumulated args **and** the incoming fragment are **each a complete, self-contained JSON object**, the incoming is the authoritative full copy → **replace rather than concatenate**. Incremental fragments (partial JSON like `{"replyText":"PO`) don't parse as complete objects, so they still append unchanged.

```ts
if (isCompleteJsonObject(cur.args) && isCompleteJsonObject(fn.arguments)) {
  cur.args = fn.arguments;   // aggregated re-send → authoritative full copy
} else {
  cur.args += fn.arguments;  // normal incremental fragment
}
```

One file changed (`plugins/plugin-elizacloud/src/models/text.ts`) + tests. **No core change** — the retried-stream path also de-doubles now, so core's existing retry-on-conflict policy (and its test) stays intact.

## Evidence

- **Unit** — `__tests__/text-streaming.test.ts`, 2 new cases feeding the exact 3-frame Cerebras pattern (incremental fragments + final id+name+full-args frame): asserts a single **un-doubled** `input`, including when the re-send diverges in casing. `29/29` pass.
- **Typecheck** — `plugin-elizacloud` tsgo clean; `core` tsgo clean.
- **Core regression** — `message.stage1-retry` / `message-runtime-stage1` / `message-handler-output` = `87/87` pass (confirms the deliberate retry-on-conflict policy is untouched).
- **Live E2E** — root-caused on a real prod dedicated agent (provision → `Say PONG` → fallback reproduced; container logs + raw SSE captured). Final live re-confirmation pending a develop agent-image build carrying this commit → fresh provision → `Say PONG` returns verbatim. Will attach.

Tracking: elizaOS/eliza#8434
