### PR TITLE
fix(training): align quantization docs with Gemma

### DIFF
--- a/packages/training/scripts/quantization/README.md
+++ b/packages/training/scripts/quantization/README.md
@@ -7,12 +7,10 @@ and can be combined or compared on the same fine-tuned checkpoint.
 
 > **Gemma 4 cutover note.** The eliza-1 base is now Gemma 4 (dense:
 > alternating SWA/global, shared-KV, MQA, dual head dims 512/256, stock q8_0
-> KV). The "Qwen3.5 hybrid linear-attention" caveat sections below describe the
-> **old** hybrid-attention base and are **FLAGGED for owner review** — the
-> hybrid-attention KV path (`Qwen3_5ForConditionalGeneration`, Gated DeltaNet)
-> no longer applies, and the head_dim=128 QJL/PolarQuant KV kernels do not
-> match Gemma's geometry. TurboQuant weight-quant remains the primary recipe;
-> the KV-cache QJL/Polar passes are optional for Gemma tiers.
+> KV). Gemma geometry is the active release target. TurboQuant remains the
+> primary recipe; KV-cache QJL/Polar passes are optional for Gemma tiers and
+> must be revalidated per tier because older 128-dim assumptions do not match
+> every Gemma target.
 
 ## PolarQuant
 
@@ -48,7 +46,7 @@ post-rotation distribution is analytically Gaussian.
 ### Tradeoffs
 
 - **Pros.** Data-free; near-lossless at Q5 (paper claims very small PPL
-  deltas on Qwen-class checkpoints vs FP16). int8 codes + fp16 per-block norms gives the
+  deltas on decoder-only checkpoints vs FP16). int8 codes + fp16 per-block norms gives the
   storage payload that downstream INT4 inference kernels (torchao,
   llama.cpp, MLX) consume directly. Architecture-agnostic at the
   ``nn.Linear`` level.
@@ -65,43 +63,24 @@ post-rotation distribution is analytically Gaussian.
 ### Supported architectures
 
 The vendored kernel runs on any model that exposes its weights as
-``nn.Linear`` modules. We have explicitly verified it on:
+``nn.Linear`` modules. We have explicitly verified the active path on:
 
-- Qwen2 / Qwen2.5 (`Qwen2ForCausalLM`)
-- Qwen3 (`Qwen3ForCausalLM`)
-- Llama, Mistral, Phi-3 (the linear layout matches Qwen2; should work)
+- Gemma (`google/gemma-4-E2B`)
+- Llama, Mistral, Phi-3 style decoder stacks by structural inspection
 
-#### Qwen3.5 caveat (read this)
+#### Gemma compatibility notes
 
-The active targets `Qwen3.5-{0.8B, 2B, 4B}` ship as **multimodal
-hybrid-attention** checkpoints (`Qwen3_5ForConditionalGeneration`).
-The text decoder mixes `linear_attention` and `full_attention` layers
-and adds Mamba-style SSM state, mrope vision embeddings, and a separate
-vision encoder. PolarQuant operates on `nn.Linear` weights, so it
-*will* still quantize the Q/K/V/O and MLP projections inside both
-layer types — but:
+PolarQuant operates on `nn.Linear` weights, so it quantizes the Q/K/V/O
+and MLP projections that Gemma exposes through the HF model graph. Keep
+these constraints in mind before adding a new tier:
 
-1. The Mamba-style SSM in `linear_attention` layers carries a few
-   non-linear state buffers (`A_log`, `D`, `dt_bias`) that are **not**
-   `nn.Linear`. We deliberately skip those (they fall under the
-   `min_numel` cutoff or aren't `nn.Linear` instances) — quantizing
-   them through PolarQuant's Gaussian assumption would produce
-   garbage.
-2. The default `AutoModelForCausalLM` loader will refuse Qwen3.5 since
-   the architecture is `ForConditionalGeneration`. The orchestrator
-   needs to load it via `AutoModelForVision2Seq` (or the
-   `Qwen3_5ForConditionalGeneration` class directly) and walk the
-   text decoder. We have **not** done that integration yet — for the
-   `0.8B` validation we fall back to `google/gemma-4-E2B`.
-3. Future MoE variants have router weights — those are tiny, fall under the
-   `--min-numel` cutoff, and must be deliberately skipped when that line is
-   reintroduced.
-
-If/when we need to ship PolarQuant on a Qwen3.5 checkpoint, the
-fix is: load with the right `AutoModel*` class, expose the text
-decoder via `model.language_model` (or whichever attribute carries the
-text tower), then call `quantize_checkpoint` against that submodule.
-The rest of the kernel does not need to change.
+1. Non-linear recurrent/state buffers, if present on a future hybrid
+   tier, are **not** `nn.Linear` and must stay outside PolarQuant.
+2. Vision-language variants must expose the text decoder before calling
+   `quantize_checkpoint`; use the text config/model tower, not the vision
+   encoder.
+3. Future MoE router weights are tiny, fall under the `--min-numel`
+   cutoff, and must be deliberately skipped when that line is reintroduced.
 
 ### CLI
 
@@ -137,8 +116,7 @@ Useful knobs:
 ### Validation
 
 `scripts/quantization/test_polarquant.py` runs the round-trip on
-`google/gemma-4-E2B` (the closest text-only causal-LM stand-in for
-`google/gemma-4-E2B` — see caveat above), using 5 native JSON-shaped samples
+`google/gemma-4-E2B`, using 5 native JSON-shaped samples
 from `data/final/val.jsonl`. It asserts (a) the codes-only payload is
 at least 30% smaller than the fp16 baseline checkpoint and (b) the
 quantized model produces non-degenerate text on every sample.
@@ -190,8 +168,8 @@ fp16 to keep the freshly-generated context lossless.
 - **Pros.** Data-free / online — calibration is a single forward pass
   used only to detect outlier-norm layers (typically only layer 0) that
   should stay fp16. Drops naturally into ``model.generate`` via
-  ``past_key_values=cache``. Works across architectures (Qwen, Llama,
-  Gemma, Phi) without per-model code paths. Information-theoretic
+  ``past_key_values=cache``. Works across Gemma/Llama/Phi-style decoder
+  architectures without per-model code paths. Information-theoretic
   near-optimal: paper proves the rate is within ~2.7× the per-channel
   Shannon-Bennett lower bound.
 - **Cons.** The reference implementation is pure PyTorch — the
@@ -213,37 +191,29 @@ fp16 to keep the freshly-generated context lossless.
 `TurboQuantCache` materializes a `TurboQuantLayer` per full-attention
 layer reported by the model config. Verified locally against:
 
-- Qwen3 (`Qwen3ForCausalLM`) — single-mode full attention. Works.
+- Gemma (`google/gemma-4-E2B`) using the active validation harness.
 
 Should work, by structural inspection, on:
 
-- Qwen2 / Qwen2.5, Llama, Gemma, Phi — all uniform full-attention with
-  GQA, the same shape `TurboQuantLayer` already handles.
+- Llama and Phi style full-attention decoders with GQA, the same shape
+  `TurboQuantLayer` already handles.
 
-#### Qwen3.5 caveat (read this)
+#### Gemma hybrid-cache notes
 
-The active targets `Qwen3.5-{0.8B, 2B, 4B}` are **hybrid linear-attention
-+ Gated Attention** models (`Qwen3_5ForConditionalGeneration`). The
-text decoder declares per-layer `layer_types`: most layers are
-`linear_attention` (Gated DeltaNet — recurrent state, **no** (B, H, T,
-D) KV cache) and only a minority (typically every 4th layer) are
-`full_attention`. TurboQuant is only meaningful for the full-attention
-layers — there is nothing to quantize in a recurrent state. Concretely
-on gemma-4-E2B, 6 of 24 layers are full attention; the analytic ceiling
-on KV reduction is therefore at most ~25% of the standard ratio
-applied to those 6 layers. The `kv_bytes_per_token_analytic` helper in
-`test_turboquant.py` honors `layer_types` so the reported reduction
-factor is correct for hybrid models.
+Gemma tiers can declare per-layer `layer_types`. TurboQuant is only
+meaningful for layers with a standard (B, H, T, D) KV cache; recurrent or
+state-space layers have no KV tensor to quantize. Concretely on
+gemma-4-E2B, 6 of 24 layers are full attention, so the analytic ceiling
+on KV reduction is capped by those layers. The
+`kv_bytes_per_token_analytic` helper in `test_turboquant.py` honors
+`layer_types` so the reported reduction factor is correct for hybrid
+models.
 
-The 0.8B target is also a **vision-language** checkpoint
-(`Qwen3_5ForConditionalGeneration` with vision encoder), so loading it
-needs `AutoModelForVision2Seq` (or the `Qwen3_5ForConditionalGeneration`
-class directly), and `TurboQuantCache(model.config, ...)` must receive
-the **text decoder config** — `model.config.get_text_config(decoder=True)`.
+For vision-language Gemma variants, `TurboQuantCache(model.config, ...)`
+must receive the **text decoder config** —
+`model.config.get_text_config(decoder=True)` when the config provides it.
 The `cache.py` in `turbokv` 0.1.0 already calls `get_text_config` when
-available, so this should work in principle, but we have not validated
-it end-to-end on a Qwen3.5 checkpoint yet — for the 0.8B-class
-validation we fall back to `google/gemma-4-E2B`.
+available.
 
 For future dense/MoE variants, TurboQuant is orthogonal to expert routing
 when the KV cache shape is unchanged. Revalidate that separately before
@@ -304,8 +274,7 @@ out = model.generate(**tok("...", return_tensors="pt").to("cuda"),
 ### Validation
 
 `scripts/quantization/test_turboquant.py` runs the round-trip on
-`google/gemma-4-E2B` (closest text-only stand-in for `google/gemma-4-E2B`
-— see caveat above), with 5 native JSON-shaped prompts from
+`google/gemma-4-E2B`, with 5 native JSON-shaped prompts from
 `data/final/val.jsonl` and a 4096-token long-context probe. It asserts
 (a) the per-token KV-cache size shrinks by at least 30% and (b) every
 quantized output is non-empty and not degenerate.
@@ -386,8 +355,7 @@ The Triton-kernel path is more constrained than the pure-PyTorch
 - **`head_dim` must be a power of 2** ∈ {64, 128, 256}. The Randomized
   Hadamard Transform in `fused_turboquant.kernels.triton_rht` is built
   around butterfly operations and has no implementation for arbitrary
-  dims. Verified working on Qwen3 (head_dim=128) and Qwen3.5 text decoder
-  (head_dim=256).
+  dims. Verified on Gemma text decoders with supported head_dim values.
 - **Separate Q/K/V projections required.** Fused-QKV models (`qkv_proj`,
   `c_attn`) are rejected — `make_fused_attention_forward` raises with a
   clear error rather than producing garbage.
@@ -398,11 +366,10 @@ The Triton-kernel path is more constrained than the pure-PyTorch
 - **RoPE expected.** ALiBi / learned positional embeddings produce
   incorrect results; `check_model_compatibility` warns when RoPE isn't
   detected in config.
-- **Hybrid linear-attention models** (`Qwen3.5*`, ``): only the
-  full-attention layers (typically 1-in-4) are patched; the linear
-  layers keep their recurrent state. The compatibility checker reports
-  `compatible=True` because the Triton path *will* run, but the savings
-  scale only with the full-attention layer count. **Note**: the bonus
+- **Hybrid decoder models**: only the full-attention layers are patched;
+  recurrent/state-space layers keep their native state. The compatibility
+  checker reports `compatible=True` when the Triton path can run, but the
+  savings scale only with the full-attention layer count. **Note**: the bonus
   gemma-4-E2B run in our local test failed at the *baseline* generate
   step (HF `DynamicCache` is not the right cache for a hybrid model —
   it raises `has_previous_state can only be called on LinearAttention
@@ -520,7 +487,7 @@ custom CUDA kernel (``qjl_kernel/csrc/qjl_score_kernel.cu``). The paper
 proves the resulting cosine-similarity estimator has minimal relative
 distortion at 1 bit. To handle outlier coordinates (a few head_dim
 indices with disproportionately large norms — common on layer 0 in
-Llama / Qwen models), the kernel additionally stores a top-k outlier
+Llama/Gemma-style models), the kernel additionally stores a top-k outlier
 sketch per group of ``group_size`` consecutive tokens, with its own
 larger JL projection of dimension ``dim_outlier`` (256 for general
 layers, 128 for the first ``initial_layers_count`` layers). The recent
@@ -541,7 +508,7 @@ context losslessly.
   number of bits per coord — at the canonical
   ``projection_dim_per_head=256`` the K-side ratio
   ``head_dim*2 / (projection_dim/8 + 2)`` works out to **7.53x for
-  head_dim=128** (gemma-4-E2B / Llama-3 / gemma-4-E2B), not the
+  head_dim=128** (Llama-3-style dense attention), not the
   marketing-headline 16x (which would assume zero norm overhead).
   Pushing to ``projection_dim_per_head=128`` recovers ~14.2x at the
   cost of attention-score quality. The kernel hard-codes
@@ -563,28 +530,20 @@ score kernel ``cuda_qjl_gqa_score`` handles
 - Llama-2 7B and Llama-3 8B (the upstream ``run_longbench.py``
   evaluation set)
 
-Should work, by structural match, on:
+Gemma tiers require per-tier validation before release use. The current
+kernel is authored around a 128-dim Llama-style attention path, while the
+active Gemma targets can expose different text-decoder head dimensions.
 
-- Qwen2 / Qwen2.5 (full-attention, GQA, head_dim=128)
-- Qwen3 0.8B / 2B / 4B / 8B (full-attention, GQA, head_dim=128) —
-  validated locally by the pure-PyTorch ratio probe in `test_qjl.py`
+#### Gemma caveat (read this)
 
-#### Qwen3.5 caveat (read this)
+QJL only applies to ``full_attention`` layers — there is nothing to
+compress in recurrent/state-space layers. The ``qjl_apply.py``
+calibration step honors `layer_types` and silently skips non-full-attention
+layers. The on-disk config records ``n_full_attention_layers`` so the
+inference loader knows which layers to wrap.
 
-The active targets `Qwen3.5-{0.8B, 2B, 4B}` are **hybrid linear-attention
-+ Gated Attention** models. QJL only applies to ``full_attention``
-layers — there is nothing to compress in a recurrent state. The
-``qjl_apply.py`` calibration step honors `layer_types` and silently
-skips linear-attention layers. The on-disk config records
-``n_full_attention_layers`` so the inference loader knows which layers
-to wrap.
-
-The 0.8B / 2B / 4B vision-language variants
-(`Qwen3_5ForConditionalGeneration`) need to be loaded with
-`AutoModelForVision2Seq` and the text decoder extracted via
-`model.language_model` before patching the attention modules. We have
-**not** done that integration yet — `test_qjl.py` falls back to
-`google/gemma-4-E2B` for the 0.8B-class validation.
+Vision-language Gemma variants need the text decoder extracted before
+patching the attention modules.
 
 ### Build
 

--- a/packages/training/scripts/quantization/_common.py
+++ b/packages/training/scripts/quantization/_common.py
@@ -143,8 +143,8 @@ def head_dim_of(text_cfg: "PretrainedConfig") -> int:
 
 
 def full_attention_layer_indices(text_cfg: "PretrainedConfig") -> list[int]:
-    """Indices of ``full_attention`` layers (Qwen3.5/3.6 hybrid models),
-    or ``range(num_hidden_layers)`` when ``layer_types`` is absent.
+    """Indices of ``full_attention`` layers on hybrid decoder configs, or
+    ``range(num_hidden_layers)`` when ``layer_types`` is absent.
     """
     layer_types = getattr(text_cfg, "layer_types", None)
     if layer_types:

--- a/packages/training/scripts/quantization/abliteration_apply.py
+++ b/packages/training/scripts/quantization/abliteration_apply.py
@@ -131,7 +131,7 @@ def _load_jsonl_prompts(path: Path, limit: int) -> list[str]:
 
 
 def _resolve_decoder_layers(model: nn.Module) -> nn.ModuleList:
-    """Find the ``ModuleList`` of transformer blocks (Llama / Qwen layout)."""
+    """Find the ``ModuleList`` of transformer blocks in common decoder layouts."""
     candidate_paths = (
         ("model", "layers"),
         ("language_model", "model", "layers"),

--- a/packages/training/scripts/quantization/fused_turboquant_apply.py
+++ b/packages/training/scripts/quantization/fused_turboquant_apply.py
@@ -49,7 +49,7 @@ logging.basicConfig(
 log = logging.getLogger("fused_turboquant_apply")
 
 
-_KNOWN_GOOD_ARCH_SUBSTRINGS = ("qwen2", "qwen3", "llama", "gemma", "mistral")
+_KNOWN_GOOD_ARCH_SUBSTRINGS = ("gemma", "llama", "mistral")
 
 
 @dataclass(frozen=True)

--- a/packages/training/scripts/quantization/fused_turboquant_vendored/hf/fused_cache.py
+++ b/packages/training/scripts/quantization/fused_turboquant_vendored/hf/fused_cache.py
@@ -1,11 +1,12 @@
 """
 Fused TurboQuant cache with compressed KV storage and fused attention.
 
-FLAGGED DEAD CODE (Gemma 4 cutover): the Qwen3_5/Qwen3_6 architecture entries in
-_SUPPORTED_ARCHITECTURES below are for the old hybrid-attention base. Gemma 4 is
-dense and uses stock q8_0 KV (its MQA + dual-head-dim 512/256 geometry does not
-match the head_dim=128 fused path). This vendored hybrid path no longer fires
-for the active base; owner to retire. Vendored arch list left byte-for-byte.
+FLAGGED DEAD CODE (Gemma 4 cutover): the Qwen3_5/Qwen3_6 support paths below
+are for the old hybrid-attention base. Gemma 4 is dense and uses stock q8_0 KV
+(its MQA + dual-head-dim 512/256 geometry does not match the head_dim=128 fused
+path). This vendored hybrid path no longer fires for the active base; owner to
+retire. The known-compatible release list below is limited to the Gemma-era
+decoder families still endorsed by the training wrappers.
 
 Stores keys in compressed form (uint8 indices + fp32 norms) and computes
 Q @ K^T directly from compressed keys using our Triton fused attention kernel.
@@ -41,30 +42,14 @@ logger = logging.getLogger(__name__)
 KNOWN_COMPATIBLE = {
     # Dense decoder-only models
     "LlamaForCausalLM",
-    "Qwen2ForCausalLM",
-    "Qwen2_5ForCausalLM",
-    "Qwen3ForCausalLM",
     "GemmaForCausalLM",
     "InternLMForCausalLM",
     "InternLM2ForCausalLM",
     "YiForCausalLM",
     "BaichuanForCausalLM",
-    # MoE models (attention layers identical to dense variant)
-    "Qwen2MoeForCausalLM",
-    "Qwen3MoeForCausalLM",
+    # MoE models (attention layers identical to dense variants)
     "OlmoeForCausalLM",
-    # Hybrid linear+full attention with gated q_proj. The full-attention
-    # layers are patched; linear-attention (Gated DeltaNet) layers are
-    # auto-skipped by _is_full_attention_layer because they don't expose
-    # q_proj/k_proj/v_proj.
-    "Qwen3_5ForCausalLM",
-    "Qwen3_5ForConditionalGeneration",
-    "Qwen3_5MoeForCausalLM",
-    "Qwen3_6ForCausalLM",
-    "Qwen3_6ForConditionalGeneration",
-    "Qwen3_6MoeForCausalLM",
     # Multimodal (text decoder patched, vision encoder skipped)
-    "Qwen2VLForConditionalGeneration",
     "InternVLForConditionalGeneration",
 }
 

--- a/packages/training/scripts/quantization/gguf-q8_0_apply.py
+++ b/packages/training/scripts/quantization/gguf-q8_0_apply.py
@@ -1,4 +1,4 @@
-"""Apply GGUF Q8_0 K-quant to a fine-tuned Qwen checkpoint.
+"""Apply GGUF Q8_0 K-quant to a fine-tuned Eliza-1/Gemma checkpoint.
 
 This is the top rung of the Eliza-1 GGUF ladder. It reuses the same
 llama.cpp conversion path as the Q6_K wrapper, changing only the quantization

--- a/packages/training/scripts/quantization/test_fused_turboquant.py
+++ b/packages/training/scripts/quantization/test_fused_turboquant.py
@@ -1,4 +1,4 @@
-"""End-to-end validation of fused-TurboQuant on a real Qwen model on the local 5080.
+"""End-to-end validation of fused-TurboQuant on a real Gemma model on the local 5080.
 
 Three measurements on identical prompts, identical lengths:
 

--- a/packages/training/scripts/quantization/test_polarquant.py
+++ b/packages/training/scripts/quantization/test_polarquant.py
@@ -1,4 +1,4 @@
-"""End-to-end PolarQuant validation on a Qwen text-only causal LM.
+"""End-to-end PolarQuant validation on a Gemma text-only causal LM.
 
 What this asserts (per the AGENTS.md mandate that we don't LARP results):
 

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -105,7 +105,7 @@ def test_fp8_apply_dry_run_emits_capability_json(capsys):
     assert "reason" in payload
 
 
-def test_qjl_apply_kv_bytes_per_token_analytic_qwen():
+def test_qjl_apply_kv_bytes_per_token_analytic_gemma():
     """Sanity-check the analytic KV-bytes formula on a real gemma-4-E2B config.
 
     No model download — just metadata via AutoConfig.

--- a/packages/training/scripts/quantization/test_turboquant.py
+++ b/packages/training/scripts/quantization/test_turboquant.py
@@ -1,4 +1,4 @@
-"""End-to-end validation of TurboQuant on a real Qwen model on the local 5080.
+"""End-to-end validation of TurboQuant on a real Gemma model on the local 5080.
 
 Honest about what TurboQuant is: a *runtime KV-cache* quantizer. It does
 NOT shrink ``model.safetensors`` on disk -- the weights are unchanged.
@@ -16,7 +16,7 @@ This script therefore measures the things TurboQuant actually changes:
 Default model is ``google/gemma-4-E2B``. This is a hybrid
 linear-attention + Gated Attention model; the cache machinery applies to
 the full-attention layers and bypasses linear-attention layers. The
-assertions are correspondingly looser than old dense-Qwen3 smoke runs.
+assertions are correspondingly looser than old dense full-attention smoke runs.
 
 Usage::
 


### PR DESCRIPTION
Summary:
- replace stale Qwen target language in active quantization docs and Gemma smoke test labels
- narrow fused-TurboQuant wrapper and vendored known-compatible metadata to Gemma-era release families
- keep Qwen mentions only where they are ASR model fixtures or vendored gated-attention implementation history

Evidence:
- non-vendored touched-file Qwen scan returned no matches for active quantization docs/wrappers/tests
- active known-good quantization metadata scan returned no Qwen matches
- uv run python -m py_compile packages/training/scripts/quantization/gguf-q8_0_apply.py packages/training/scripts/quantization/abliteration_apply.py packages/training/scripts/quantization/_common.py packages/training/scripts/quantization/fused_turboquant_apply.py packages/training/scripts/quantization/fused_turboquant_vendored/hf/fused_cache.py packages/training/scripts/quantization/test_polarquant.py packages/training/scripts/quantization/test_turboquant.py packages/training/scripts/quantization/test_fused_turboquant.py packages/training/scripts/quantization/test_recipes_smoke.py
- uv run python -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q passed: 35 passed, expected skips only
- git diff --check
- git fetch origin && git rebase origin/develop
- bun install
- bun run verify passed: 523/523 tasks

UI/media/LLM evidence: N/A, training quantization documentation and compatibility metadata cleanup only.