### PR TITLE
fix(training): align vendored quantization notes with Gemma

### DIFF
--- a/packages/training/scripts/quantization/__init__.py
+++ b/packages/training/scripts/quantization/__init__.py
@@ -1,4 +1,4 @@
-"""Post-training quantization + abliteration for Qwen checkpoints.
+"""Post-training quantization + abliteration for Eliza-1/Gemma checkpoints.
 
 Members:
     polarquant_apply        — weight-side Gaussian quantization (data-free).

--- a/packages/training/scripts/quantization/fused_turboquant_vendored/NOTICE.md
+++ b/packages/training/scripts/quantization/fused_turboquant_vendored/NOTICE.md
@@ -1,8 +1,8 @@
 # fused_turboquant vendor notice
 
 This directory vendors the upstream `fused-turboquant` package so we can
-patch it in-place to support active Qwen3.5 gated attention without
-waiting on an upstream release.
+patch it in-place for Eliza-1 training experiments while preserving the
+old Qwen3.5 gated-attention compatibility work for legacy reproduction.
 
 ## Source
 
@@ -36,7 +36,7 @@ Per Apache 2.0 §4(b), the changes made on top of upstream `0.1.0` are:
 
 * **`hf/fused_cache.py` — gated-attention support.** The upstream
   `make_fused_attention_forward` assumes a vanilla `q_proj` of shape
-  `num_heads * head_dim`. Active Qwen3.5 models use a gated variant:
+  `num_heads * head_dim`. The retired Qwen3.5 line used a gated variant:
   `q_proj.out_features == 2 * num_heads * head_dim` (chunked along the
   last dim into `(query, gate)`) and the post-attention output is
   multiplied by `sigmoid(gate)` before `o_proj`. Three changes:
@@ -58,20 +58,22 @@ Per Apache 2.0 §4(b), the changes made on top of upstream `0.1.0` are:
            `sigmoid(gate)` (reshaped to `(B, T, n_heads*head_dim)`)
            before `o_proj`.
          - When non-gated: behavior unchanged.
-    3. `KNOWN_COMPATIBLE` now includes the hybrid Qwen3.5
-       text decoders (`Qwen3_5ForCausalLM`, `Qwen3_5MoeForCausalLM`,
-       `Qwen3_5ForConditionalGeneration`).
+    3. The Gemma cutover narrowed `KNOWN_COMPATIBLE` back to the
+       Gemma-era decoder families endorsed by the training wrappers.
+       The gated branch remains in code for explicit legacy reproduction,
+       but the retired Qwen3.5 classes are no longer advertised as
+       known-compatible release targets.
 
   The K/V projection paths are untouched — gating affects only Q in the
-  Qwen3.5 layout, and `cache.store_compressed_key` /
+  retired Qwen3.5 layout, and `cache.store_compressed_key` /
   `cache.store_compressed_value` operate on K/V which retain their
   vanilla `(B, T, n_kv_heads * head_dim)` shape.
 
-* **`hf/fused_cache.py` — partial-rotary RoPE.** Qwen3.5 uses partial
+* **`hf/fused_cache.py` — partial-rotary RoPE.** The retired Qwen3.5 line uses partial
   rotary embeddings (only the first `cos.shape[-1]` coordinates of each
   head are rotated, the rest pass through). The upstream
   `_apply_rotary_pos_emb` assumed full-head RoPE and crashed with a
-  shape mismatch on Qwen3.5 (`rotary_dim=64` vs `head_dim=256`). The
+  shape mismatch on that layout (`rotary_dim=64` vs `head_dim=256`). The
   vendored version now branches: if `cos.shape[-1] == q.shape[-1]` the
   fast path is unchanged; otherwise it splits Q/K into `(rot, pass)`,
   rotates only the leading slice, and concatenates them back. This

--- a/packages/training/scripts/quantization/fused_turboquant_vendored/cache/kv_cache.py
+++ b/packages/training/scripts/quantization/fused_turboquant_vendored/cache/kv_cache.py
@@ -3,7 +3,7 @@ TurboQuant-compressed KV cache for HuggingFace transformers.
 
 Patches a standard DynamicCache to transparently compress key/value tensors
 on every cache.update() call. Works with any model that uses DynamicCache,
-including Qwen3.5's hybrid attention layers.
+including hybrid decoder layers with a standard full-attention KV cache.
 
 Two integration strategies:
 1. Full compression: store compressed, decompress on read (real memory savings)
@@ -26,9 +26,9 @@ class TurboQuantKVCache:
     Stores keys and values in compressed form (uint8 indices + fp32 norms)
     and decompresses on-the-fly when attention reads them.
 
-    For active Qwen3.5 models, only full_attention layers use this cache.
-    Linear attention (DeltaNet) layers have a different state representation
-    and are not affected.
+    For hybrid decoder models, only full_attention layers use this cache.
+    Recurrent/state-space layers have a different state representation and
+    are not affected.
 
     Usage:
         cache = TurboQuantKVCache(head_dim=256, num_layers=8, bits=4, device="cuda")

--- a/packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/__init__.py
+++ b/packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/__init__.py
@@ -5,7 +5,7 @@ Provides the FUSED_TURBOQUANT attention backend that stores KV cache
 in compressed packed uint8 format, achieving 3.8-7.1x memory reduction.
 
 Usage:
-    vllm serve Qwen/Qwen3-8B --attention-backend FUSED_TURBOQUANT
+    vllm serve google/gemma-4-E2B --attention-backend FUSED_TURBOQUANT
 
 Configuration (environment variables):
     TURBOQUANT_BITS=4           Quantization bits (2, 3, or 4)

--- a/packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/backend.py
+++ b/packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/backend.py
@@ -12,7 +12,7 @@ Compressed KV cache layout (per position per head):
     2-bit, head_dim=128: 32 + 4 = 36 bytes   (vs 256B fp16 → 7.11x savings)
 
 Architecture-aware: only compresses full-attention layers in hybrid models
-like Qwen3.5 (skips DeltaNet/linear attention layers automatically).
+(skips recurrent/state-space attention layers automatically).
 
 Configuration:
     TURBOQUANT_BITS=4       Quantization bits (2, 3, or 4)
@@ -53,11 +53,11 @@ class FusedTurboQuantBackend(_AttentionBackendBase):
     attention (fused QK from packed indices).
 
     Usage:
-        vllm serve Qwen/Qwen3-8B --attention-backend FUSED_TURBOQUANT
+        vllm serve google/gemma-4-E2B --attention-backend FUSED_TURBOQUANT
 
         # Or with Python API:
         from vllm import LLM
-        llm = LLM("Qwen/Qwen3-8B", attention_backend="FUSED_TURBOQUANT")
+        llm = LLM("google/gemma-4-E2B", attention_backend="FUSED_TURBOQUANT")
     """
 
     name = "FUSED_TURBOQUANT"

--- a/packages/training/scripts/quantization/polarquant/LICENSE.md
+++ b/packages/training/scripts/quantization/polarquant/LICENSE.md
@@ -18,7 +18,7 @@ PolarQuant author Caio Vicentino. Upstream details:
 As of the pinned commit the upstream repository ships **no LICENSE file** and
 GitHub's license API returns `false`. We have not received an explicit grant
 from the author. We vendor these two source files for the limited purpose of
-running PolarQuant on our own fine-tuned Qwen checkpoints inside this
+running PolarQuant on our own fine-tuned Eliza-1/Gemma checkpoints inside this
 research training pipeline, and we cite the upstream source and authors here
 and in `polar_quant.py`'s module docstring.
 

--- a/packages/training/scripts/quantization/qjl/NOTICE.md
+++ b/packages/training/scripts/quantization/qjl/NOTICE.md
@@ -25,7 +25,7 @@ Per Apache 2.0 §4(b), the changes made on top of upstream
 * **Parameterized `EMB_DIM` (head_dim) as a C++ template parameter.**
   Upstream hard-codes `#define EMB_DIM 128` at the top of every kernel.
   This is correct for Llama 2/3 and older 128-dim heads but fails to
-  compile/run for active Qwen3.5 text models with head_dim=256. We changed:
+  compile/run for 256-dim text-decoder heads. We changed:
 
     - `csrc/qjl_quant_kernel.cu`:
       `quantize_with_outliers_kernel` and `QJLQuantCudaTemplate` are now

--- a/packages/training/scripts/quantization/qjl/csrc/qjl_gqa_score_kernel.cu
+++ b/packages/training/scripts/quantization/qjl/csrc/qjl_gqa_score_kernel.cu
@@ -6,7 +6,7 @@
 #define WARPS_PER_BLOCK 8
 // EMB_DIM is a compile-time template parameter on the kernel and host
 // wrapper. Upstream hard-coded EMB_DIM=128. We instantiate {128, 256}
-// to support active Qwen3.5 text models (head_dim=256).
+// to support Gemma-era 256-dim text-decoder validation.
 #define GQA_GROUP_SIZE 4
 #define FULL_MASK 0xffffffff
 
@@ -238,7 +238,7 @@ torch::Tensor QJLGQAScoreCudaTemplate(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    // EMB_DIM=128 (Llama/Qwen3 sub-9B, Qwen2/2.5)
+    // EMB_DIM=128 (Llama-style dense attention)
     m.def("qjl_gqa_score_cuda_half_half_h128", &QJLGQAScoreCudaTemplate<c10::Half, c10::Half, 128>, "GQA score kernel using Half precision (head_dim=128)",
           py::arg("key_quant"),
           py::arg("key_outlier_quant"),
@@ -289,7 +289,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("query_states"),
           py::arg("rand_prj"));
 
-    // EMB_DIM=256 (active Qwen3.5 text head_dim=256)
+    // EMB_DIM=256 (Gemma-era text-decoder validation)
     m.def("qjl_gqa_score_cuda_half_half_h256", &QJLGQAScoreCudaTemplate<c10::Half, c10::Half, 256>, "GQA score kernel using Half precision (head_dim=256)",
           py::arg("key_quant"),
           py::arg("key_outlier_quant"),

--- a/packages/training/scripts/quantization/qjl/csrc/qjl_quant_kernel.cu
+++ b/packages/training/scripts/quantization/qjl/csrc/qjl_quant_kernel.cu
@@ -5,8 +5,8 @@
 #define WARP_SIZE 32
 #define WARPS_PER_BLOCK 32
 // EMB_DIM is a compile-time template parameter on the kernel and the
-// host wrapper below. Upstream hard-coded EMB_DIM=128. Active Qwen3.5
-// text models use head_dim=256, so we instantiate {128, 256}.
+// host wrapper below. Upstream hard-coded EMB_DIM=128. Gemma-era
+// validation also needs head_dim=256, so we instantiate {128, 256}.
 
 template <typename T>
 __device__ float convert_to_float(T value) {
@@ -262,7 +262,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> QJLQuantCudaTemplate(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    // EMB_DIM=128 (Llama/Qwen3 sub-9B, Qwen2/2.5)
+    // EMB_DIM=128 (Llama-style dense attention)
     m.def("qjl_quant_half_half_h128", &QJLQuantCudaTemplate<c10::Half, c10::Half, 128>, "Quantize using Half precision (head_dim=128)",
     py::arg("key_states"),
     py::arg("outlier_indices"),
@@ -293,7 +293,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     py::arg("rand_prj"),
     py::arg("outlier_sketch_dim"));
 
-    // EMB_DIM=256 (active Qwen3.5 text head_dim=256)
+    // EMB_DIM=256 (Gemma-era text-decoder validation)
     m.def("qjl_quant_half_half_h256", &QJLQuantCudaTemplate<c10::Half, c10::Half, 256>, "Quantize using Half precision (head_dim=256)",
     py::arg("key_states"),
     py::arg("outlier_indices"),

--- a/packages/training/scripts/quantization/qjl/csrc/qjl_quant_values_kernel.cu
+++ b/packages/training/scripts/quantization/qjl/csrc/qjl_quant_values_kernel.cu
@@ -6,7 +6,7 @@
 #define WARPS_PER_BLOCK 32
 // EMB_DIM is a compile-time template parameter on the kernel and host
 // wrapper. Upstream hard-coded EMB_DIM=128. We instantiate {128, 256}
-// to support active Qwen3.5 text models (head_dim=256).
+// to support Gemma-era 256-dim text-decoder validation.
 //
 // NOTE: this file has multiple upstream bugs (typos like `sketched_vaues`,
 // undefined `quantize_value_kernel` symbol, returning wrong tensors) and

--- a/packages/training/scripts/quantization/qjl/csrc/qjl_score_kernel.cu
+++ b/packages/training/scripts/quantization/qjl/csrc/qjl_score_kernel.cu
@@ -6,7 +6,7 @@
 #define WARPS_PER_BLOCK 8
 // EMB_DIM is a compile-time template parameter on the kernel and host
 // wrapper. Upstream hard-coded EMB_DIM=128. We instantiate {128, 256}
-// to support active Qwen3.5 text models (head_dim=256) alongside the legacy
+// to support Gemma-era 256-dim text-decoder validation alongside the legacy
 // 128-dim head path.
 #define FULL_MASK 0xffffffff
 
@@ -217,7 +217,7 @@ torch::Tensor QJLScoreCudaTemplate(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    // EMB_DIM=128 (Llama/Qwen3 sub-9B, Qwen2/2.5)
+    // EMB_DIM=128 (Llama-style dense attention)
     m.def("qjl_score_cuda_half_half_h128", &QJLScoreCudaTemplate<c10::Half, c10::Half, 128>, "Cuda kernel to calculate scores fully parallel using Half precision (head_dim=128)",
           py::arg("key_quant"),
           py::arg("key_outlier_quant"),
@@ -268,7 +268,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("query_states"),
           py::arg("rand_prj"));
 
-    // EMB_DIM=256 (active Qwen3.5 text head_dim=256)
+    // EMB_DIM=256 (Gemma-era text-decoder validation)
     m.def("qjl_score_cuda_half_half_h256", &QJLScoreCudaTemplate<c10::Half, c10::Half, 256>, "Cuda kernel to calculate scores fully parallel using Half precision (head_dim=256)",
           py::arg("key_quant"),
           py::arg("key_outlier_quant"),

--- a/packages/training/scripts/quantization/qjl/qjl_kernel.py
+++ b/packages/training/scripts/quantization/qjl/qjl_kernel.py
@@ -1,8 +1,8 @@
 """Python dispatch layer for the vendored QJL CUDA extensions.
 
 The CUDA kernels are compiled per (head_dim in {128, 256}) instantiation --
-upstream hard-coded EMB_DIM=128, while active Qwen3.5 text models use
-head_dim=256. The wrappers below pick the right
+upstream hard-coded EMB_DIM=128, while Gemma-era validation needs a
+256-dim specialization. The wrappers below pick the right
 specialization at call-time based on the input tensor shape, so
 downstream callers (e.g. ``LlamaAttention_QJL``) never have to know.
 

--- a/packages/training/scripts/quantization/test_abliteration.py
+++ b/packages/training/scripts/quantization/test_abliteration.py
@@ -118,7 +118,7 @@ def test_abliterate_tiny_gpt2_endtoend():
     # tiny-gpt2's resolver lives at ``transformer.h``; inject a Llama-shaped
     # alias so ``_resolve_decoder_layers`` finds the layer list. (We don't
     # patch the production code to know about GPT-2 — the abliterator only
-    # ever runs on Llama/Qwen-shaped models in real use.)
+    # ever runs on Gemma/Llama-shaped decoder models in real use.)
     model.model = nn.Module()
     model.model.layers = model.transformer.h
     _shim_gpt2_for_abliteration(model)

--- a/packages/training/scripts/quantization/test_qjl.py
+++ b/packages/training/scripts/quantization/test_qjl.py
@@ -1,4 +1,4 @@
-"""End-to-end validation of QJL on a real Qwen3 model on the local 5080.
+"""End-to-end validation of QJL on a real Gemma model on the local 5080.
 
 Honest about what QJL is: a *runtime KV-cache* quantizer for the **K
 (keys) side** of attention. It does NOT shrink ``model.safetensors`` on


### PR DESCRIPTION
Summary:
- update quantization package docstrings, QJL smoke labels, and PolarQuant license usage text from Qwen target wording to Eliza-1/Gemma wording
- mark fused-TurboQuant Qwen3.5 gated-attention notes as retired legacy compatibility instead of active release guidance
- swap vLLM fused-TurboQuant examples to the Gemma validation model and replace active-Qwen QJL kernel comments with generic 128/256-head wording

Evidence:
- active-Qwen wording scan over touched files returned no matches
- uv run python -m py_compile packages/training/scripts/quantization/__init__.py packages/training/scripts/quantization/test_qjl.py packages/training/scripts/quantization/test_abliteration.py packages/training/scripts/quantization/fused_turboquant_vendored/cache/kv_cache.py packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/backend.py packages/training/scripts/quantization/fused_turboquant_vendored/vllm_plugin/__init__.py packages/training/scripts/quantization/qjl/qjl_kernel.py
- uv run python -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q passed: 35 passed, expected skips only
- git diff --check
- git fetch origin && git rebase origin/develop
- bun install
- bun run verify passed: 523/523 tasks

UI/media/LLM evidence: N/A, training quantization documentation/comment cleanup only.