### PR TITLE
fix(cloud): repo app must not silently deploy APP_DEFAULT_IMAGE when build-from-repo is off

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { containerNameForApp } from "../app-deploy-runner";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AppDeployRunnerDeps } from "../app-deploy-runner";
+import { containerNameForApp, resolveImageRef } from "../app-deploy-runner";
 
 // #9145 — container names must be stable + DNS/Docker-safe regardless of app id.
 describe("containerNameForApp (#9145)", () => {
@@ -21,5 +22,48 @@ describe("containerNameForApp (#9145)", () => {
     const id = "550e8400-e29b-41d4-a716-446655440000";
     expect(containerNameForApp(id)).toBe("app-550e8400e29b");
     expect(containerNameForApp(id)).toBe(containerNameForApp(id));
+  });
+});
+
+// build-from-repo is intentionally deferred (prebuilt-image only). A repo-configured
+// app must NOT silently deploy APP_DEFAULT_IMAGE in place of the user's code when the
+// build resolver is off — that would be a silent wrong deploy.
+describe("resolveImageRef: build-from-repo-disabled guard", () => {
+  const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
+  const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
+  const REPO = "https://github.com/u/repo.git";
+
+  afterEach(() => {
+    delete process.env.APP_DEFAULT_IMAGE;
+  });
+
+  test("repo app + build off + no imageTag -> throws, does NOT fall back to APP_DEFAULT_IMAGE", async () => {
+    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
+    await expect(resolveImageRef(buildOff, { ...baseApp, repoUrl: REPO })).rejects.toThrow(
+      /build-from-repo is disabled/,
+    );
+  });
+
+  test("repo app + build off + explicit imageTag -> uses the prebuilt image", async () => {
+    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      repoUrl: REPO,
+      metadata: { imageTag: "ghcr.io/u/myapp:v1" },
+    });
+    expect(img).toBe("ghcr.io/u/myapp:v1");
+  });
+
+  test("repo app + build on -> uses the built image", async () => {
+    const buildOn = {
+      resolveImage: async () => "ghcr.io/elizaos/app-built:abc",
+    } as unknown as AppDeployRunnerDeps;
+    const img = await resolveImageRef(buildOn, { ...baseApp, repoUrl: REPO });
+    expect(img).toBe("ghcr.io/elizaos/app-built:abc");
+  });
+
+  test("non-repo app still falls back to APP_DEFAULT_IMAGE (unchanged)", async () => {
+    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
+    expect(await resolveImageRef(buildOff, baseApp)).toBe("ghcr.io/elizaos/app-default:smoke");
   });
 });

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -110,15 +110,26 @@ export function toNewContainer(row: NewAppContainerRow): NewContainer {
   };
 }
 
-async function resolveImageRef(
+export async function resolveImageRef(
   deps: AppDeployRunnerDeps,
   app: { id: string; name: string; metadata: Record<string, unknown>; repoUrl?: string },
 ): Promise<string> {
   const fromResolver = deps.resolveImage ? await deps.resolveImage(app) : undefined;
   const fromMetadata =
     typeof app.metadata?.imageTag === "string" ? (app.metadata.imageTag as string) : undefined;
-  const fromEnv = process.env.APP_DEFAULT_IMAGE;
-  const image = fromResolver ?? fromMetadata ?? fromEnv;
+  // A repo-configured app whose build-from-repo is disabled (no resolver wired,
+  // i.e. APPS_IMAGE_REGISTRY unset) must NOT silently fall back to
+  // APP_DEFAULT_IMAGE — that would deploy a default/smoke image in place of the
+  // user's code (a silent wrong deploy). Require an explicit prebuilt image
+  // instead. (build-from-repo is intentionally deferred — prebuilt-image only.)
+  if (app.repoUrl && !fromResolver && !fromMetadata) {
+    throw new Error(
+      `App ${app.id} builds from a git repo, but build-from-repo is disabled ` +
+        `(no APPS_IMAGE_REGISTRY). Set a prebuilt image via metadata.imageTag, ` +
+        `or enable build-from-repo.`,
+    );
+  }
+  const image = fromResolver ?? fromMetadata ?? process.env.APP_DEFAULT_IMAGE;
   if (!image) {
     throw new Error(
       `No image to deploy for app ${app.id}: pass resolveImage, set app.metadata.imageTag, or APP_DEFAULT_IMAGE`,


### PR DESCRIPTION
## What

Hardens the **prebuilt-image-only** apps posture (build-from-repo is intentionally deferred — see #9768): a repo-configured app must **not silently deploy `APP_DEFAULT_IMAGE`** in place of the user's code when build-from-repo is off.

## Why

`resolveImageRef` resolved `resolver → metadata.imageTag → APP_DEFAULT_IMAGE`. So an app with a `github_repo` but **no build resolver wired** (`APPS_IMAGE_REGISTRY` unset) and **no explicit `imageTag`** would fall through to `APP_DEFAULT_IMAGE` — deploying a default/smoke image **instead of** the user's app. That's a silent wrong deploy.

Not reachable in prod *today* (`APP_DEFAULT_IMAGE` is unset there), but it's a latent footgun the instant a default is configured (defaults are a documented option, used for smoke tests).

## How

If `app.repoUrl` is set but the resolver produced nothing **and** there's no explicit `imageTag`, throw a clear error ("build-from-repo is disabled — set a prebuilt image via `metadata.imageTag`, or enable build-from-repo") instead of falling through to `APP_DEFAULT_IMAGE`.

- Non-repo apps still use `APP_DEFAULT_IMAGE` (unchanged).
- Repo apps with an explicit `imageTag` still use it (intentional prebuilt fallback).
- Build-on still uses the built image.

## Evidence

Exported `resolveImageRef` (mirrors `containerNameForApp` beside it) + 4 focused tests:

```
 8 pass  (4 existing containerNameForApp + 4 new guard)
 0 fail
```

- repo + build-off + no tag → throws, does NOT return the default ✅
- repo + explicit imageTag → uses it ✅
- repo + build-on → uses the built image ✅
- non-repo → still falls back to `APP_DEFAULT_IMAGE` ✅

Lint clean, typecheck clean on the changed file. Context: elizaOS/eliza#8434, decision #9768.
