### PR TITLE
fix(local-inference): align verify defaults with Gemma

### DIFF
--- a/plugins/plugin-local-inference/native/verify/embedding_bench.mjs
+++ b/plugins/plugin-local-inference/native/verify/embedding_bench.mjs
@@ -4,9 +4,9 @@
  * harness.
  *
  * Per `packages/inference/AGENTS.md` §1 the embedding model is either the
- * text backbone with `--pooling last` (`0_8b` / `2b`) or a dedicated
- * `embedding/eliza-1-embedding.gguf` on the larger
- * tiers. This harness drives a `llama-server --embeddings --pooling last`
+ * text backbone with `--pooling last` (`2b`) or a dedicated
+ * `embedding/eliza-1-embedding.gguf` on the larger tiers. This harness
+ * drives a `llama-server --embeddings --pooling last`
  * over a GGUF and measures:
  *   - cold-load time of the embedding region (spawn → /health),
  *   - single-text embed latency (median over N runs),
@@ -93,7 +93,7 @@ function resolveModel(opts) {
   const modelsRoot = path.join(home, ".eliza", "local-inference", "models");
   const candidates = [];
   // A real dedicated embedding region, if any bundle ships it.
-  for (const tier of ["0_8b", "2b", "4b", "9b", "27b"]) {
+  for (const tier of ["2b", "4b", "9b", "27b", "27b-256k"]) {
     const dir = path.join(modelsRoot, `eliza-1-${tier}.bundle`, "embedding");
     if (fs.existsSync(dir)) {
       for (const f of fs.readdirSync(dir)) {
@@ -101,9 +101,8 @@ function resolveModel(opts) {
       }
     }
   }
-  // Eliza-1 pooled-text stand-in (the 0_8b text backbone base).
-  candidates.push(path.join("/tmp", "eliza1-eval-models", "Qwen3.5-0.8B-Q8_0.gguf"));
-  candidates.push(path.join(modelsRoot, "eliza-1-0_8b.bundle", "text", "eliza-1-0_8b-32k.gguf"));
+  // Eliza-1 pooled-text stand-in (the current 2b text backbone base).
+  candidates.push(path.join(modelsRoot, "eliza-1-2b.bundle", "text", "eliza-1-2b-128k.gguf"));
   candidates.push(path.join(modelsRoot, "SmolLM2-360M-Instruct-Q4_K_M.gguf"));
   return firstExisting(...candidates);
 }
@@ -233,7 +232,7 @@ async function main() {
       status: "skipped",
       reason: !bin
         ? "no llama-server binary found (build one: node packages/app-core/scripts/build-llama-cpp-mtp.mjs --target linux-x64-cpu)"
-        : "no embedding GGUF found (point --model at an embedding/ GGUF or an Eliza-1 pooled-text backbone such as Qwen3.5-0.8B)",
+        : "no embedding GGUF found (point --model at an embedding/ GGUF or an Eliza-1 pooled-text backbone such as eliza-1-2b)",
       resolved: { bin, model },
     };
     fs.writeFileSync(reportPath, JSON.stringify(skipped, null, 2));
@@ -401,7 +400,7 @@ async function main() {
       note:
         "Server: llama-server --embeddings --pooling last over the GGUF. " +
         "`pairwise_ranking_pearson_vs_full` is the Pearson correlation between the corpus's pairwise-cosine matrix at the truncated width and at the full width — a cheap offline proxy for retrieval-ranking preservation when MTEB isn't available. " +
-        "On 0_8b/2b the GGUF may be the text backbone (pooled-text mode); on larger tiers it should be the dedicated embedding/eliza-1-embedding.gguf.",
+        "On 2b the GGUF may be the text backbone (pooled-text mode); on larger tiers it should be the dedicated embedding/eliza-1-embedding.gguf.",
     };
   } catch (err) {
     result = {

--- a/plugins/plugin-local-inference/native/verify/metal_upscale_probe.cpp
+++ b/plugins/plugin-local-inference/native/verify/metal_upscale_probe.cpp
@@ -40,7 +40,7 @@ static const char * usage() {
         "Usage: ./metal_upscale_probe [options]\n"
         "\n"
         "Builds a GGML graph containing one GGML_OP_UPSCALE and probes Metal support.\n"
-        "The default shape mirrors Qwen3-VL CLIP warmup: src=[48 48 1152 1], dst=[92 92 1152 1].\n"
+        "The default shape mirrors the Eliza-1 vision-projector CLIP warmup: src=[48 48 1152 1], dst=[92 92 1152 1].\n"
         "\n"
         "Options:\n"
         "  --mode nearest|bilinear|bilinear-aa|bicubic  Upscale mode; default bilinear-aa\n"

--- a/plugins/plugin-local-inference/native/verify/mmproj_verify.py
+++ b/plugins/plugin-local-inference/native/verify/mmproj_verify.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Eliza-1 mmproj header verifier.
 
-Validates each staged Qwen3.5 mmproj GGUF in
+Validates each staged Eliza-1 mmproj GGUF described by the manifest in
 ``packages/training/release-staging/mmproj/`` and reports:
 
   - file size matches the manifest entry,


### PR DESCRIPTION
Summary:
- update local-inference verify helper wording from Qwen/0_8b defaults to current Eliza-1/Gemma tiers
- move embedding_bench fallback from retired Qwen3.5/0_8b pooled text to the current eliza-1-2b pooled-text backbone
- keep mmproj verification manifest-driven while removing Qwen-specific operator wording

Evidence:
- `uv run python -m py_compile plugins/plugin-local-inference/native/verify/mmproj_verify.py`
- `node --check plugins/plugin-local-inference/native/verify/embedding_bench.mjs`
- touched-file stale scan returned no matches for `qwen`, `0_8b`, or `1_7b`
- `git diff --check`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run verify` passed: 523/523 tasks

Unavailable:
- C++ syntax probe for `metal_upscale_probe.cpp` could not run because this worktree lacks the native llama.cpp `ggml.h` headers.

UI/media/LLM evidence: N/A, local-inference verify helper default cleanup only.