### PR TITLE
chore(cloud,personal-assistant): surface silently-swallowed failures that masked broken pipelines

### DIFF
--- a/packages/cloud-shared/src/db/repositories/webhook-events.ts
+++ b/packages/cloud-shared/src/db/repositories/webhook-events.ts
@@ -52,27 +52,26 @@ export class WebhookEventsRepository {
   async tryCreate(
     data: NewWebhookEvent,
   ): Promise<{ created: true; event: WebhookEvent } | { created: false }> {
-    try {
-      const [event] = await dbWrite
-        .insert(webhookEvents)
-        .values({
-          ...data,
-          processed_at: new Date(),
-        })
-        .onConflictDoNothing({ target: webhookEvents.event_id })
-        .returning();
+    // `onConflictDoNothing` makes the unique-constraint race a no-op (returns
+    // no row), so a genuine duplicate is the `!event` branch below. A real
+    // write failure (connection/permission/schema) must propagate so the
+    // webhook handler fails loudly (5xx → provider retries) instead of
+    // masquerading as a duplicate and silently dropping the event.
+    const [event] = await dbWrite
+      .insert(webhookEvents)
+      .values({
+        ...data,
+        processed_at: new Date(),
+      })
+      .onConflictDoNothing({ target: webhookEvents.event_id })
+      .returning();
 
-      // If no row returned, it means conflict (duplicate)
-      if (!event) {
-        return { created: false };
-      }
-
-      return { created: true, event };
-    } catch {
-      // Fallback for databases that don't support onConflictDoNothing well
-      // or if there's a race condition with unique constraint
+    // No row returned ⇒ the event_id already existed (duplicate delivery).
+    if (!event) {
       return { created: false };
     }
+
+    return { created: true, event };
   }
 
   /**

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1319,9 +1319,19 @@ export class DockerSandboxProvider implements SandboxProvider {
         .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
         .catch(() => {});
 
-      // Rollback allocated_count on failure
+      // Rollback allocated_count on failure. This is the only place the slot
+      // reserved by incrementAllocated() is released after a failed provision,
+      // so a silent failure here leaks node capacity permanently. Keep the
+      // rollback best-effort (we are already failing and about to rethrow), but
+      // surface the leak so it is observable instead of a mysteriously-full node.
       if (dbNode) {
-        await dockerNodesRepository.decrementAllocated(nodeId).catch(() => {});
+        await dockerNodesRepository
+          .decrementAllocated(nodeId)
+          .catch((rollbackErr) => {
+            logger.error(
+              `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+            );
+          });
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {

--- a/plugins/plugin-personal-assistant/src/provider.ts
+++ b/plugins/plugin-personal-assistant/src/provider.ts
@@ -1,10 +1,11 @@
 import { hasOwnerAccess } from "@elizaos/agent";
-import type {
-  IAgentRuntime,
-  Memory,
-  Provider,
-  ProviderResult,
-  State,
+import {
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type Provider,
+  type ProviderResult,
+  type State,
 } from "@elizaos/core";
 import type { LifeOpsBrowserSession } from "@elizaos/shared";
 import { LifeOpsService } from "./lifeops/service.js";
@@ -116,7 +117,15 @@ export const lifeOpsBrowserProvider: Provider = {
           sessions: activeSessions,
         },
       };
-    } catch {
+    } catch (error) {
+      // A LifeOpsService read failure makes the browser bridge appear disabled.
+      // Degrade to the disabled-context result so composeState still completes,
+      // but surface the read failure so a broken pipeline is observable.
+      logger.warn(
+        `[BrowserBridgeProvider] failed to load browser bridge context; reporting disabled: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
       return {
         text: "",
         values: {


### PR DESCRIPTION
## What

Three `catch` sites swallowed real failures with **no log**, masking broken pipelines. Each fix preserves the success path and only changes the failure path from silent-swallow to surfaced/propagated. Part of the AGENTS.md error-handling cleanup (area 6).

## Findings & fixes

### 1. `cloud-shared` — `WebhookEventsRepository.tryCreate` dropped payment webhooks on DB error (highest severity)
`packages/cloud-shared/src/db/repositories/webhook-events.ts`

```ts
} catch {
  // Fallback for databases that don't support onConflictDoNothing well …
  return { created: false };
}
```

The Stripe and crypto webhook handlers treat `created: false` as "duplicate → return 200, skip enqueue". So **any** insert failure (connection/permission/schema) was swallowed and reported as a duplicate, **silently dropping the payment webhook**. The schema is `pgTable`, where `onConflictDoNothing` reliably no-ops the unique-constraint race — the genuine-duplicate path is the existing `!event` branch, so the catch only hid genuine DB errors. **Removed the catch** so real failures propagate → 5xx → the provider retries (correct at-least-once delivery). The Stripe handler calls `tryCreate` outside any try/catch (Hono surfaces it as 5xx); the crypto handler already has an outer `try/catch → 500`.

### 2. `cloud-shared` — docker-sandbox provision rollback leaked node capacity silently
`packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts`

`decrementAllocated(nodeId).catch(() => {})` is the **only** place a reserved node-capacity slot is released after a failed provision. A silent failure leaked the slot permanently (node appears full with no containers, no trace). Kept it best-effort (we are already failing and about to rethrow) but **log the leak** — matching the sibling Headscale-cleanup logging in the same block.

### 3. `plugin-personal-assistant` — browser-bridge provider hid LifeOps read failures
`plugins/plugin-personal-assistant/src/provider.ts`

Empty `catch` returned the disabled-browser context with no log, so a failed `LifeOpsService` DB read made the bridge **silently appear disabled** in the agent's prompt. Kept the degraded result (so `composeState` still completes) but **log the read failure**.

## Behavior table

| Site | Before (failure path) | After (failure path) |
|---|---|---|
| webhook `tryCreate` | DB error → `{created:false}` → 200 "duplicate", event dropped | DB error propagates → 5xx → provider retries |
| sandbox rollback | decrement throws → silent, slot leaked | decrement throws → `logger.error` "capacity slot leaked", still best-effort |
| browser provider | read throws → disabled context, no log | read throws → `logger.warn`, still degrades to disabled |

Success paths are unchanged in all three.

## Verification

- `turbo build --filter=@elizaos/core --filter=@elizaos/shared` — green.
- `tsgo --noEmit`: **0 new errors** in both touched packages (HEAD baseline captured by reverting + re-running: plugin-personal-assistant 4→4, cloud-shared 184→184; pre-existing errors are an unrelated bad benchmark fixture / Workers ambient types and reference none of the changed files).
- Tests (load-bearing paths): `stripe-webhook-route.test.ts` 4/4, `browser-helpers-security`+`package-boundaries` 17/17, `docker-sandbox-utils`+`provision-reachability-regression` 22/22 — all pass.
- Rebased onto latest `origin/develop`; no base drift on any touched file.

## Considered but intentionally left
- `plugin-feed/src/routes.ts:852` `readJsonBody().catch(() => ({}))` — a BFF proxy forwarding an **optional** follow-request body (the action is path-identified `/users/:id/follow`); empty body is a valid request and the backend validates. Not a broken pipeline.