### PR TITLE
fix(core): web-lookup helper resolves MESSAGE_SEARCH; surface WEB_FETCH for live-info

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -5,6 +5,7 @@ import {
 	actionResultsSuppressPostActionContinuation,
 	extractPlannerActionNames,
 	findWebLookupActionName,
+	findWebLookupActionNames,
 	inferDirectCurrentRequestCandidateActions,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
@@ -177,6 +178,28 @@ describe("live routing regressions", () => {
 			similes: ["LOOKUP_WEB"],
 		};
 		expect(findWebLookupActionName([simileAction])).toBe("SOME_FETCH");
+	});
+
+	it("surfaces BOTH web tools to the planner, WEB_FETCH first", () => {
+		// The planner-surfacing path offers WEB_FETCH (a constructible live API)
+		// ahead of WEB_SEARCH (open-ended discovery) so a price/weather ask is
+		// fetched live inline rather than answered from a stale search result.
+		expect(
+			findWebLookupActionNames([{ name: "WEB_SEARCH" }, { name: "WEB_FETCH" }]),
+		).toEqual(["WEB_FETCH", "WEB_SEARCH"]);
+		// Only one web tool registered → exactly that one is surfaced.
+		expect(findWebLookupActionNames([{ name: "WEB_SEARCH" }])).toEqual([
+			"WEB_SEARCH",
+		]);
+		// A single action that resolves via BOTH a fetch name and a search simile
+		// must surface ONCE (the searchAction !== fetchAction dedupe guard).
+		expect(
+			findWebLookupActionNames([
+				{ name: "WEB_FETCH", similes: ["WEB_SEARCH"] },
+			]),
+		).toEqual(["WEB_FETCH"]);
+		// No web backend → empty, so the turn is not forced toward a web tool.
+		expect(findWebLookupActionNames([{ name: "SHELL" }])).toEqual([]);
 	});
 
 	it("does not promote a coding/spawn request to a web-lookup (stays TASKS)", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -238,6 +238,7 @@ import { runPostTurnEvaluators } from "./evaluator";
 import {
 	findAvailableActionName,
 	findWebLookupActionName,
+	findWebLookupActionNames,
 	inferDirectCurrentRequestCandidateActions as inferDirectCurrentRequestCandidateActionsFromHeuristics,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
@@ -262,6 +263,7 @@ import {
 
 export {
 	findWebLookupActionName,
+	findWebLookupActionNames,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 };
@@ -4206,8 +4208,8 @@ function inferAckIntentCandidateActions(
 		if (codingAction) return [codingAction];
 	}
 	if (looksLikeWebSearchRequest(actionText)) {
-		const lookupAction = findWebLookupActionName(actions);
-		if (lookupAction) return [lookupAction];
+		const lookupActions = findWebLookupActionNames(actions);
+		if (lookupActions.length > 0) return lookupActions;
 	}
 	return [];
 }

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -149,8 +149,9 @@ export function findAvailableActionName(
 ): string | undefined {
 	// Resolve in `names` PRIORITY order, not action-registration order: for each
 	// wanted name in turn, return the first action whose name or simile matches.
-	// The leading preference wins — e.g. WEB_SEARCH (listed ahead of WEB_FETCH)
-	// is chosen for a web lookup even though WEB_FETCH registers first.
+	// The leading preference wins — the first name in `names` that matches any
+	// registered action (by name or simile) is returned, regardless of
+	// registration order.
 	for (const want of names) {
 		const wanted = normalizeActionIdentifier(want);
 		const match = actions.find((action) => {
@@ -194,30 +195,64 @@ export function inferDirectCurrentRequestCandidateActions(
 	);
 	if (viewCapabilityAction) return [viewCapabilityAction];
 	if (looksLikeWebSearchRequest(messageText)) {
-		const lookupAction = findWebLookupActionName(actions);
-		if (lookupAction) return [lookupAction];
+		const lookupActions = findWebLookupActionNames(actions);
+		if (lookupActions.length > 0) return lookupActions;
 	}
 	return [];
 }
 
+// Specific web-tool action names, split by capability. A bare "SEARCH" must NOT
+// appear in either list: it loosely matches MESSAGE_SEARCH / CONTACT_SEARCH /
+// LOGS_SEARCH via their "search" simile (findAvailableActionName matches name OR
+// simile) and would resolve a non-web action.
+const WEB_FETCH_ACTION_NAMES = [
+	"WEB_FETCH",
+	"LOOKUP_WEB",
+	"WEB_LOOKUP",
+	"FETCH_URL",
+] as const;
+const WEB_SEARCH_ACTION_NAMES = [
+	"WEB_SEARCH",
+	"SEARCH_WEB",
+	"BRAVE_SEARCH",
+	"INTERNET_SEARCH",
+	"SEARCH_INTERNET",
+	"GOOGLE",
+] as const;
+
 /**
- * Resolve the action that satisfies a web / live-info lookup, or undefined when
- * the runtime has no real search backend registered.
+ * Resolve ONE web/live-info lookup action, or undefined when the runtime has no
+ * web backend. Prefers WEB_SEARCH — the general fallback used by the
+ * rescue/existence checks, where a broad search satisfies any query without
+ * needing a constructible URL. The planner-surfacing path uses
+ * findWebLookupActionNames (WEB_FETCH-first) instead.
  */
 export function findWebLookupActionName(
-	actions: ReadonlyArray<Pick<Action, "name">>,
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 ): string | undefined {
-	return findAvailableActionName(actions, [
-		"SEARCH",
-		"WEB_SEARCH",
-		"SEARCH_WEB",
-		"BRAVE_SEARCH",
-		"INTERNET_SEARCH",
-		"SEARCH_INTERNET",
-		"LOOKUP_WEB",
-		"WEB_FETCH",
-		"GOOGLE",
-	]);
+	return (
+		findAvailableActionName(actions, WEB_SEARCH_ACTION_NAMES) ??
+		findAvailableActionName(actions, WEB_FETCH_ACTION_NAMES)
+	);
+}
+
+/**
+ * Resolve EVERY web/live-info lookup action the runtime exposes, in planner
+ * preference order: WEB_FETCH first (a constructible live API/URL — e.g.
+ * coingecko or wttr.in — returns deterministic JSON the planner can use inline),
+ * then WEB_SEARCH (open-ended discovery). Surfacing BOTH lets the planner fetch
+ * a live source itself instead of settling for a stale search result or spawning
+ * a sub-agent just to webfetch a URL it already knows.
+ */
+export function findWebLookupActionNames(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+): string[] {
+	const fetchAction = findAvailableActionName(actions, WEB_FETCH_ACTION_NAMES);
+	const searchAction = findAvailableActionName(actions, WEB_SEARCH_ACTION_NAMES);
+	const names: string[] = [];
+	if (fetchAction) names.push(fetchAction);
+	if (searchAction && searchAction !== fetchAction) names.push(searchAction);
+	return names;
 }
 
 const VIEW_REQUEST_OPERATION_GROUPS = {


### PR DESCRIPTION
## Problem

`findWebLookupActionName` — which routes live-info / web-lookup turns to the right action — led its priority list with a bare `"SEARCH"`. `findAvailableActionName` matches by **name OR simile**, and `MESSAGE_SEARCH` / `CONTACT_SEARCH` / `LOGS_SEARCH` all carry a `"search"` simile, so for any web turn the helper resolved a **memory-search** action *before* `WEB_SEARCH` was ever considered. The planner was handed the wrong tool for a live-info ask.

Separately, retrieval never surfaces `WEB_FETCH` for a bare live-info query (it scores too low), so even when the helper resolved correctly the planner only ever saw `WEB_SEARCH`. For a price/weather ask a general web search returns a stale news article, whereas the live API (`WEB_FETCH` of e.g. `api.coingecko.com/.../simple/price` or `wttr.in`) returns a deterministic current value — but the planner was never offered it.

## Fix

- Drop the bare `"SEARCH"`; split the lookup names into `WEB_FETCH_ACTION_NAMES` / `WEB_SEARCH_ACTION_NAMES` (shared by both helpers).
- `findWebLookupActionName` (singular) now prefers `WEB_SEARCH` — the safe general fallback used by the rescue / existence checks, where a broad search works for any query without a constructible URL.
- New `findWebLookupActionNames` (plural) surfaces **both** tools, `WEB_FETCH` first, so the planner can fetch a live API inline for prices/weather and search for open-ended discovery. Both candidate-inference paths use it.
- Widen the helper's `Pick` to `name | similes` (`findAvailableActionName` matches on similes; the name-only `Pick` was under-typed).

## Evidence

**Unit** (`message-routing-live-regression.test.ts`): added ordering + dedupe coverage for the new plural (`WEB_FETCH` first; a single action resolving via both a fetch name and a search simile surfaces once; no backend → empty). Existing `findWebLookupActionName` expectations are unchanged (`BRAVE_SEARCH` resolves, `WEB_FETCH` / `LOOKUP_WEB`-simile resolve, shell-only → `undefined`).

**Behavioral** (live agent running this routing, trajectory-verified):

| Ask | Routed to | Result |
| --- | --- | --- |
| `current btc price` | `WEB_FETCH api.coingecko.com/.../simple/price?ids=bitcoin&vs_currencies=usd` | live `$59,334` |
| `weather in tokyo` | `WEB_FETCH wttr.in/Tokyo?format=j1` | live `24°C` |
| `good italian place in williamsburg` | `WEB_SEARCH` (discovery) | real recommendations |
| `17 times 23` | no web tool surfaced | answered directly |

Before the fix the price ask was either mis-routed to `MESSAGE_SEARCH` or answered from a months-old `WEB_SEARCH` article.

## Scope

Deliberately narrow: only the web-lookup helper plus its two candidate-inference call sites. The gate (`looksLikeWebSearchRequest`) and the view-vs-web ordering are untouched — those are separate concerns.
