### PR TITLE
chore: remove slop comments and dead commented-out code

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -2219,17 +2219,19 @@ export async function writeCompressedJsonlRows(
 }
 
 /**
- * Trajectory persistence is unconditionally on. The only paths that disable it:
+ * Resolves whether trajectory persistence is on by default:
  *
- *   1. `NODE_ENV === "test"` — keeps the test runner free of background DB writes.
- *   2. `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` — explicit operator opt-out.
+ *   1. `NODE_ENV === "test"` — off (keeps the test runner free of background
+ *      DB writes).
+ *   2. `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` — off (explicit operator opt-out).
+ *   3. `NODE_ENV === "production"` — off by default; operators must opt in with
+ *      `ELIZA_TRAJECTORY_LOGGING=1` (SOC2 O-5).
+ *   4. Otherwise (dev / unset `NODE_ENV`) — on, for the local debugging workflow.
  *
- * We deliberately stopped honoring the legacy `ENABLE_TRAJECTORIES`,
- * `ELIZA_TRAJECTORY_LOGGING`, `TRAJECTORY_LOGGING_ENABLED`, and
- * `ELIZA_CLOUD_PROVISIONED` knobs: each represented a different historical
+ * The other legacy knobs (`ENABLE_TRAJECTORIES`, `TRAJECTORY_LOGGING_ENABLED`,
+ * `ELIZA_CLOUD_PROVISIONED`) are not honored: each was a different historical
  * attempt to gate persistence, and shipping multiple opt-in paths produced
- * silent gaps where debugging and training data went missing. One opt-out,
- * otherwise on.
+ * silent gaps where debugging and training data went missing.
  */
 export function shouldEnableTrajectoryLoggingByDefault(
   env: NodeJS.ProcessEnv = process.env,

--- a/packages/core/src/features/advanced-capabilities/providers/settings.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/settings.ts
@@ -1,6 +1,3 @@
-// File: /swarm/shared/settings/provider.ts
-// Updated to use world metadata instead of cache
-
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import { findWorldsForOwner } from "../../../roles.ts";

--- a/plugins/plugin-social-alpha/src/service.ts
+++ b/plugins/plugin-social-alpha/src/service.ts
@@ -2808,15 +2808,8 @@ ${report.tokenReports.join("\n")}
 				return null;
 			}
 
-			// This check is now effectively handled by returning null in the SOLANA block if all sources fail.
-			// if (chain === SupportedChain.SOLANA && Object.keys(tokenData).length === 0) {
-			//   logger.debug(`[CommunityInvestorService] TokenData for SOLANA token ${address} is empty after all attempts, returning null.`);
-			//   return null;
-			// }
-
-			// Set defaults for missing values if tokenData was populated by non-SOLANA chain logic or partially by SOLANA.
+			// Fill in derived defaults when at least one source populated tokenData.
 			if (Object.keys(tokenData).length > 0) {
-				// Ensure tokenData is not empty before defaulting
 				if (!tokenData.ath && tokenData.currentPrice) {
 					tokenData.ath = tokenData.currentPrice * 1.1; // Assume current price is close to ATH if unknown
 				}

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/loadWallet.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/loadWallet.ts
@@ -23,28 +23,8 @@ export async function loadWallet(
   const rpcUrl = getRuntimeStringSetting(runtime, "SOLANA_RPC_URL") ?? DEFAULT_SOLANA_RPC_URL;
   const connection = new Connection(rpcUrl, "confirmed");
 
-  // TEE mode remains disabled until DeriveKeyProvider is available.
-  // const teeMode = runtime.getSetting('TEE_MODE') || TEEMode.OFF;
-
-  // if (teeMode !== TEEMode.OFF) {
-  //   const walletSecretSalt = runtime.getSetting('WALLET_SECRET_SALT');
-  //   if (!walletSecretSalt) {
-  //     throw new Error('WALLET_SECRET_SALT required when TEE_MODE is enabled');
-  //   }
-
-  //   const deriveKeyProvider = new DeriveKeyProvider(teeMode);
-  //   const deriveKeyResult = await deriveKeyProvider.deriveEd25519Keypair(
-  //     '/',
-  //     walletSecretSalt,
-  //     runtime.agentId
-  //   );
-
-  //   return requirePrivateKey
-  //     ? { signer: deriveKeyResult.keypair }
-  //     : { address: deriveKeyResult.keypair.publicKey };
-  // }
-
-  // TEE mode is OFF
+  // TEE-derived keys are not wired up here yet (no DeriveKeyProvider); the
+  // wallet is always loaded from the configured private/public key settings.
   if (requirePrivateKey) {
     const privateKeyString =
       getRuntimeStringSetting(runtime, "SOLANA_PRIVATE_KEY") ??


### PR DESCRIPTION
## What

Comment-only cleanup of AI-slop, stale, and dead-code comments. **No behavior change** — each touched package was typechecked with an identical error set before and after, and `biome format` is clean on all four files.

## Changes

| File | Slop category | Action |
|------|---------------|--------|
| `packages/agent/src/runtime/trajectory-internals.ts` | **Stale comment contradicting code** | Rewrote the `shouldEnableTrajectoryLoggingByDefault` docblock. It claimed persistence was "unconditionally on" with "one opt-out" and that `ELIZA_TRAJECTORY_LOGGING` was no longer honored — but the SOC2 O-5 code directly below honors `ELIZA_TRAJECTORY_LOGGING=1` as a production opt-in. The doc now matches the actual behavior. |
| `packages/core/src/features/advanced-capabilities/providers/settings.ts` | **Stale path header + churn** | Removed `// File: /swarm/shared/settings/provider.ts` (points at a non-existent file) and `// Updated to use world metadata instead of cache`. |
| `plugins/plugin-social-alpha/src/service.ts` | **Dead commented-out code + churn explainer** | Removed a dead commented-out `if`-block and its "this check is now effectively handled by…" narration; kept one factual comment on the surviving defaulting block. |
| `plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/loadWallet.ts` | **Dead commented-out code block** | Removed an 18-line commented-out TEE-derivation block; kept a one-line note explaining why TEE-derived keys aren't wired up yet. |

Net: **+13 / -41**, comment-only (the only non-comment hunk lines are blank lines that surrounded the removed comments).

## Verification

Each package was typechecked before and after applying the change; the error set is byte-identical (all pre-existing module-resolution errors, none in the touched files), proving these comment-only edits introduce nothing new:

- `packages/core` — `tsgo --noEmit`: clean (exit 0) before and after.
- `packages/agent` — same 3 pre-existing `@elizaos/plugin-streaming` resolution errors before/after; none in `trajectory-internals.ts`.
- `plugins/plugin-social-alpha` — same 5 pre-existing `@elizaos/ui` resolution errors before/after; none in `service.ts`.
- `plugins/plugin-wallet` — same 1 pre-existing `@elizaos/plugin-elizacloud` resolution error before/after; none in `loadWallet.ts`.
- `biome format` — clean on all four files (no fixes).

## Scope notes

Deliberately **left alone** (conservative — over-deleting comments destroys knowledge):
- `packages/cloud-shared/.../direct-wallet-payments.ts` — a "BSC promo redemption check temporarily disabled" block carries clear, restorable business semantics in a payments path.
- `packages/feed/**` import-comment slop — `packages/feed` is explicitly excluded from the root workspace (`!packages/feed`) with its own toolchain, so it can't be verified by this repo's typecheck lane; deferred rather than ship an unverifiable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
