### PR TITLE
fix: restore develop verify gates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,7 @@
         "@elizaos/plugin-remote-manifest": "workspace:*",
         "@elizaos/plugin-shell": "workspace:*",
         "@elizaos/plugin-signal": "workspace:*",
+        "@elizaos/plugin-simple-views": "workspace:*",
         "@elizaos/plugin-sql": "workspace:*",
         "@elizaos/plugin-streaming": "workspace:*",
         "@elizaos/plugin-task-coordinator": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -302,6 +302,7 @@
     "@elizaos/plugin-remote-manifest": "workspace:*",
     "@elizaos/security": "workspace:*",
     "@elizaos/plugin-shell": "workspace:*",
+    "@elizaos/plugin-simple-views": "workspace:*",
     "@elizaos/plugin-worker-runtime": "workspace:*",
     "@elizaos/plugin-signal": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -761,11 +761,7 @@ function isInternalStructuredStreamPayload(value: unknown): boolean {
   if (!record) return false;
 
   const type = typeof record.type === "string" ? record.type : "";
-  if (
-    type === "tool_call" ||
-    type === "tool_result" ||
-    type === "tool_error"
-  ) {
+  if (type === "tool_call" || type === "tool_result" || type === "tool_error") {
     return true;
   }
 

--- a/packages/agent/src/api/lifeops-inbox-fallback-routes.ts
+++ b/packages/agent/src/api/lifeops-inbox-fallback-routes.ts
@@ -30,20 +30,19 @@ function emptyChannelCounts(): Record<
   { total: number; unread: number }
 > {
   return Object.fromEntries(
-    LIFEOPS_INBOX_CHANNELS.map((channel) => [
-      channel,
-      { total: 0, unread: 0 },
-    ]),
+    LIFEOPS_INBOX_CHANNELS.map((channel) => [channel, { total: 0, unread: 0 }]),
   ) as Record<LifeOpsInboxChannel, { total: number; unread: number }>;
 }
 
-function parseChannels(raw: string | null): {
-  ok: true;
-  channels: LifeOpsInboxChannel[] | undefined;
-} | {
-  ok: false;
-  message: string;
-} {
+function parseChannels(raw: string | null):
+  | {
+      ok: true;
+      channels: LifeOpsInboxChannel[] | undefined;
+    }
+  | {
+      ok: false;
+      message: string;
+    } {
   if (raw === null || raw.trim().length === 0) {
     return { ok: true, channels: undefined };
   }
@@ -80,10 +79,7 @@ export function tryHandleLifeOpsInboxFallback(options: {
   url: URL;
   res: ServerResponse;
 }): boolean {
-  if (
-    options.method !== "GET" ||
-    options.pathname !== "/api/lifeops/inbox"
-  ) {
+  if (options.method !== "GET" || options.pathname !== "/api/lifeops/inbox") {
     return false;
   }
 

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -478,7 +478,9 @@ export async function tryHandleMusicPlayerStatusFallbackLazy(
 type LifeOpsInboxFallbackModule =
   typeof import("./lifeops-inbox-fallback-routes.ts");
 export async function tryHandleLifeOpsInboxFallbackLazy(
-  ...args: Parameters<LifeOpsInboxFallbackModule["tryHandleLifeOpsInboxFallback"]>
+  ...args: Parameters<
+    LifeOpsInboxFallbackModule["tryHandleLifeOpsInboxFallback"]
+  >
 ): Promise<boolean> {
   const options = args[0] as { pathname?: string } | undefined;
   if (options?.pathname !== "/api/lifeops/inbox") return false;

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -368,9 +368,8 @@ const loadOptionalPlugin = async (packageName: string): Promise<unknown> => {
       );
     }
     if (packageName === "@elizaos/plugin-simple-views") {
-      return await import(
-        /* @vite-ignore */ "@elizaos/plugin-simple-views/plugin"
-      );
+      const simpleViewsPackageName = packageName;
+      return await import(/* @vite-ignore */ simpleViewsPackageName);
     }
     if (packageName === "@elizaos/plugin-anthropic") {
       return await import(/* @vite-ignore */ "@elizaos/plugin-anthropic");

--- a/packages/app-core/src/api/i18n-locale-routes.test.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.test.ts
@@ -20,9 +20,7 @@ function fakeReq(opts: {
   req.url = opts.pathname ?? "/api/i18n/locale";
   req.headers = {
     host: "localhost:2138",
-    ...(opts.acceptLanguage
-      ? { "accept-language": opts.acceptLanguage }
-      : {}),
+    ...(opts.acceptLanguage ? { "accept-language": opts.acceptLanguage } : {}),
   };
   return req;
 }

--- a/packages/app-core/src/api/i18n-locale-routes.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.ts
@@ -25,7 +25,7 @@ function parseAcceptLanguage(value: string | string[] | undefined): string[] {
       return { index, q, tag };
     })
     .filter((candidate): candidate is LanguageCandidate => candidate != null)
-    .toSorted((left, right) => right.q - left.q || left.index - right.index)
+    .sort((left, right) => right.q - left.q || left.index - right.index)
     .map((candidate) => candidate.tag);
 }
 

--- a/packages/app-core/src/runtime/app-route-plugin-skip.test.ts
+++ b/packages/app-core/src/runtime/app-route-plugin-skip.test.ts
@@ -144,8 +144,9 @@ describe("__loadAppRoutePluginFromSpecifierForTest", () => {
     );
 
     expect(plugin.name).toBe("@elizaos/plugin-agent-orchestrator-routes");
-    expect(plugin.routes?.some((route) => route.path === "/api/coding-agents"))
-      .toBe(true);
+    expect(
+      plugin.routes?.some((route) => route.path === "/api/coding-agents"),
+    ).toBe(true);
     expect(
       plugin.routes?.some((route) => route.path === "/api/orchestrator/status"),
     ).toBe(true);

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -216,7 +216,10 @@ const bufferEntry: string | undefined = (() => {
   }
   return undefined;
 })();
-const bufferBase64JsEntry = resolveBunStorePackageEntry("base64-js", "index.js");
+const bufferBase64JsEntry = resolveBunStorePackageEntry(
+  "base64-js",
+  "index.js",
+);
 const bufferIeee754Entry = resolveBunStorePackageEntry("ieee754", "index.js");
 const BUFFER_ESM_SHIM_ID = "virtual:eliza-buffer-esm-shim";
 const BUFFER_ESM_SHIM_RESOLVED = `\0${BUFFER_ESM_SHIM_ID}`;

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1325,13 +1325,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       // rollback best-effort (we are already failing and about to rethrow), but
       // surface the leak so it is observable instead of a mysteriously-full node.
       if (dbNode) {
-        await dockerNodesRepository
-          .decrementAllocated(nodeId)
-          .catch((rollbackErr) => {
-            logger.error(
-              `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-            );
-          });
+        await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
+          logger.error(
+            `[docker-sandbox] Failed to roll back allocation for node ${nodeId}; capacity slot leaked: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+          );
+        });
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -248,7 +248,10 @@ export function findWebLookupActionNames(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 ): string[] {
 	const fetchAction = findAvailableActionName(actions, WEB_FETCH_ACTION_NAMES);
-	const searchAction = findAvailableActionName(actions, WEB_SEARCH_ACTION_NAMES);
+	const searchAction = findAvailableActionName(
+		actions,
+		WEB_SEARCH_ACTION_NAMES,
+	);
 	const names: string[] = [];
 	if (fetchAction) names.push(fetchAction);
 	if (searchAction && searchAction !== fetchAction) names.push(searchAction);

--- a/plugins/plugin-coding-tools/build.ts
+++ b/plugins/plugin-coding-tools/build.ts
@@ -31,7 +31,14 @@ await build({
 console.log("Build complete.");
 
 const proc = Bun.spawn(
-  ["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly", "--noCheck"],
+  [
+    "bunx",
+    "tsc",
+    "-p",
+    "tsconfig.build.json",
+    "--emitDeclarationOnly",
+    "--noCheck",
+  ],
   {
     cwd: import.meta.dir,
     stdio: ["inherit", "inherit", "inherit"],

--- a/plugins/plugin-commands/package.json
+++ b/plugins/plugin-commands/package.json
@@ -1,117 +1,117 @@
 {
-  "name": "@elizaos/plugin-commands",
-  "version": "2.0.3-beta.4",
-  "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "sideEffects": false,
-  "description": "Chat command system for Eliza agents (/help, /status, /reset, etc.)",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/elizaos/eliza.git"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "eliza-source": {
-        "types": "./src/index.ts",
-        "import": "./src/index.ts",
-        "default": "./src/index.ts"
-      },
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "./*.css": "./dist/*.css",
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "eliza-source": {
-        "types": "./src/*.ts",
-        "import": "./src/*.ts",
-        "default": "./src/*.ts"
-      },
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
-    }
-  },
-  "files": [
-    "registry-entry.json",
-    "dist",
-    "auto-enable.ts"
-  ],
-  "elizaos": {
-    "plugin": {
-      "autoEnableModule": "./auto-enable.ts",
-      "capabilities": [
-        "chat-commands"
-      ]
-    }
-  },
-  "dependencies": {
-    "@elizaos/core": "workspace:*"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.14",
-    "@types/bun": "^1.2.22",
-    "@types/node": "^24.5.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.0.18"
-  },
-  "scripts": {
-    "build": "bun run build.ts && tsc --emitDeclarationOnly --noCheck",
-    "dev": "bun --hot build.ts",
-    "test": "vitest run",
-    "clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
-    "format": "bunx @biomejs/biome format --write .",
-    "format:check": "bunx @biomejs/biome format .",
-    "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "agentConfig": {
-    "pluginType": "elizaos:plugin:1.0.0",
-    "pluginParameters": {
-      "COMMANDS_CONFIG_ENABLED": {
-        "type": "boolean",
-        "description": "Enable /config command",
-        "required": false,
-        "default": "false",
-        "sensitive": false
-      },
-      "COMMANDS_DEBUG_ENABLED": {
-        "type": "boolean",
-        "description": "Enable /debug command",
-        "required": false,
-        "default": "false",
-        "sensitive": false
-      },
-      "COMMANDS_BASH_ENABLED": {
-        "type": "boolean",
-        "description": "Enable /bash command (elevated)",
-        "required": false,
-        "default": "false",
-        "sensitive": false
-      },
-      "COMMANDS_RESTART_ENABLED": {
-        "type": "boolean",
-        "description": "Enable /restart command",
-        "required": false,
-        "default": "true",
-        "sensitive": false
-      }
-    }
-  },
-  "eliza": {
-    "platforms": [
-      "node"
-    ],
-    "runtime": "node",
-    "platformDetails": {
-      "node": "Default export (Node.js)"
-    }
-  }
+	"name": "@elizaos/plugin-commands",
+	"version": "2.0.3-beta.4",
+	"type": "module",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"sideEffects": false,
+	"description": "Chat command system for Eliza agents (/help, /status, /reset, etc.)",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/elizaos/eliza.git"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"eliza-source": {
+				"types": "./src/index.ts",
+				"import": "./src/index.ts",
+				"default": "./src/index.ts"
+			},
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./*.css": "./dist/*.css",
+		"./*": {
+			"types": "./dist/*.d.ts",
+			"eliza-source": {
+				"types": "./src/*.ts",
+				"import": "./src/*.ts",
+				"default": "./src/*.ts"
+			},
+			"import": "./dist/*.js",
+			"default": "./dist/*.js"
+		}
+	},
+	"files": [
+		"registry-entry.json",
+		"dist",
+		"auto-enable.ts"
+	],
+	"elizaos": {
+		"plugin": {
+			"autoEnableModule": "./auto-enable.ts",
+			"capabilities": [
+				"chat-commands"
+			]
+		}
+	},
+	"dependencies": {
+		"@elizaos/core": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.14",
+		"@types/bun": "^1.2.22",
+		"@types/node": "^24.5.2",
+		"typescript": "^6.0.3",
+		"vitest": "^4.0.18"
+	},
+	"scripts": {
+		"build": "bun run build.ts && tsc --emitDeclarationOnly --noCheck",
+		"dev": "bun --hot build.ts",
+		"test": "vitest run",
+		"clean": "rm -rf dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
+		"format": "bunx @biomejs/biome format --write .",
+		"format:check": "bunx @biomejs/biome format .",
+		"lint": "bunx @biomejs/biome check --write --unsafe .",
+		"lint:check": "bunx @biomejs/biome check .",
+		"typecheck": "tsgo --noEmit"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"agentConfig": {
+		"pluginType": "elizaos:plugin:1.0.0",
+		"pluginParameters": {
+			"COMMANDS_CONFIG_ENABLED": {
+				"type": "boolean",
+				"description": "Enable /config command",
+				"required": false,
+				"default": "false",
+				"sensitive": false
+			},
+			"COMMANDS_DEBUG_ENABLED": {
+				"type": "boolean",
+				"description": "Enable /debug command",
+				"required": false,
+				"default": "false",
+				"sensitive": false
+			},
+			"COMMANDS_BASH_ENABLED": {
+				"type": "boolean",
+				"description": "Enable /bash command (elevated)",
+				"required": false,
+				"default": "false",
+				"sensitive": false
+			},
+			"COMMANDS_RESTART_ENABLED": {
+				"type": "boolean",
+				"description": "Enable /restart command",
+				"required": false,
+				"default": "true",
+				"sensitive": false
+			}
+		}
+	},
+	"eliza": {
+		"platforms": [
+			"node"
+		],
+		"runtime": "node",
+		"platformDetails": {
+			"node": "Default export (Node.js)"
+		}
+	}
 }

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -611,7 +611,10 @@ export class SlackService extends Service implements ISlackService {
               ? { accountId: normalizedAccountId }
               : {}),
           }),
-        reactHandler: (handlerRuntime, params: ConnectorMessageMutationParams) =>
+        reactHandler: (
+          handlerRuntime,
+          params: ConnectorMessageMutationParams,
+        ) =>
           serviceInstance.reactConnectorMessage(handlerRuntime, {
             ...params,
             ...(normalizedAccountId && !params.accountId
@@ -625,7 +628,10 @@ export class SlackService extends Service implements ISlackService {
               ? { accountId: normalizedAccountId }
               : {}),
           }),
-        deleteHandler: (handlerRuntime, params: ConnectorMessageMutationParams) =>
+        deleteHandler: (
+          handlerRuntime,
+          params: ConnectorMessageMutationParams,
+        ) =>
           serviceInstance.deleteConnectorMessage(handlerRuntime, {
             ...params,
             ...(normalizedAccountId && !params.accountId

--- a/plugins/plugin-sql/src/schema/agent.ts
+++ b/plugins/plugin-sql/src/schema/agent.ts
@@ -32,10 +32,7 @@ export const agentTable = pgTable("agents", {
     .default(sql`'[]'::jsonb`)
     .notNull(),
   plugins: jsonb("plugins").$type<string[]>().default(sql`'[]'::jsonb`).notNull(),
-  settings: jsonb("settings")
-    .$type<CharacterSettings>()
-    .default(sql`'{}'::jsonb`)
-    .notNull(),
+  settings: jsonb("settings").$type<CharacterSettings>().default(sql`'{}'::jsonb`).notNull(),
   style: jsonb("style")
     .$type<{
       all?: string[];

--- a/plugins/plugin-sql/src/stores/entity.store.ts
+++ b/plugins/plugin-sql/src/stores/entity.store.ts
@@ -1,5 +1,5 @@
-import { type Component, type Entity, logger, type UUID } from "@elizaos/core";
 import { randomUUID } from "node:crypto";
+import { type Component, type Entity, logger, type UUID } from "@elizaos/core";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { componentTable, entityTable, participantTable } from "../schema/index";
 import type { DrizzleDatabase } from "../types";
@@ -102,12 +102,14 @@ export class EntityStore implements Store {
     return this.ctx.withRetry(async () => {
       try {
         return await this.db.transaction(async (tx) => {
-          const normalizedEntities: (typeof entityTable.$inferInsert)[] = entities.map((entity) => ({
-            id: entity.id ?? randomUUID(),
-            agentId: entity.agentId,
-            names: this.normalizeNames(entity.names),
-            metadata: entity.metadata || {},
-          }));
+          const normalizedEntities: (typeof entityTable.$inferInsert)[] = entities.map(
+            (entity) => ({
+              id: entity.id ?? randomUUID(),
+              agentId: entity.agentId,
+              names: this.normalizeNames(entity.names),
+              metadata: entity.metadata || {},
+            })
+          );
 
           await tx.insert(entityTable).values(normalizedEntities).onConflictDoNothing();
           return true;

--- a/plugins/plugin-whatsapp/src/qrcode-terminal-types.ts
+++ b/plugins/plugin-whatsapp/src/qrcode-terminal-types.ts
@@ -1,0 +1,7 @@
+declare module "qrcode-terminal" {
+  export function generate(
+    input: string,
+    options?: { small?: boolean },
+    callback?: (qrcode: string) => void
+  ): void;
+}


### PR DESCRIPTION
Summary:
- apply Biome formatting fixes that were blocking repo verify across cloud-shared, core, app-core, agent, app config, plugin-coding-tools, plugin-commands, plugin-sql, and plugin-slack
- declare the new simple-views plugin as an agent workspace dependency and load it through its root package entrypoint
- add a local WhatsApp qrcode-terminal module declaration so plugin-whatsapp typecheck is standalone-clean
- use an ES2022-compatible sort in app-core locale parsing instead of toSorted

Evidence:
- `bun run --cwd plugins/plugin-registry typecheck`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/agent lint`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app-core lint`
- `bun run --cwd packages/app lint`
- `bun run --cwd plugins/plugin-coding-tools lint:check`
- `bun run --cwd plugins/plugin-commands lint:check`
- `bun run --cwd plugins/plugin-slack lint:check`
- `bun run --cwd plugins/plugin-sql lint`
- `bun run --cwd plugins/plugin-whatsapp typecheck`
- `bun run --cwd plugins/plugin-whatsapp lint:check`
- `git diff --check`
- `git fetch origin`
- `git rebase origin/develop`
- `bun install`
- `bun run verify` passed: 528/528 tasks

UI/media/LLM evidence: N/A, verify-gate formatting/typecheck fixes only; the packages/app change is Vite config formatting with no UI behavior change.