### PR TITLE
fix(core): wrap over-long line in findWebLookupActionNames (biome follow-up to #9775)

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -248,7 +248,10 @@ export function findWebLookupActionNames(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 ): string[] {
 	const fetchAction = findAvailableActionName(actions, WEB_FETCH_ACTION_NAMES);
-	const searchAction = findAvailableActionName(actions, WEB_SEARCH_ACTION_NAMES);
+	const searchAction = findAvailableActionName(
+		actions,
+		WEB_SEARCH_ACTION_NAMES,
+	);
 	const names: string[] = [];
 	if (fetchAction) names.push(fetchAction);
 	if (searchAction && searchAction !== fetchAction) names.push(searchAction);


### PR DESCRIPTION
#9775 merged with a `findAvailableActionName` call in `findWebLookupActionNames` on a single line that exceeds biome's line width, so the **Format + Type Safety Ratchet** check is red on `develop`. This wraps it per biome 2.5.0.

Formatting only — no behavior change. `bunx @biomejs/biome@2.5.0 check` is clean and the helper's unit assertions (ordering + dedupe) still pass.

@lalalune quick follow-up to green develop after the #9775 merge.