### PR TITLE
fix: make discord typecheck wait for sql build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -463,6 +463,10 @@
       ],
       "outputs": []
     },
+    "@elizaos/plugin-discord#typecheck": {
+      "dependsOn": ["@elizaos/plugin-sql#build", "^build"],
+      "outputs": []
+    },
     "@elizaos/plugin-contacts#typecheck": {
       "dependsOn": [
         "@elizaos/capacitor-contacts#build",


### PR DESCRIPTION
Summary:
- add a targeted Turbo dependency so `@elizaos/plugin-discord#typecheck` waits for `@elizaos/plugin-sql#build`
- prevents the core PGLite test helper from resolving `@elizaos/plugin-sql` while SQL declarations are being rebuilt

Evidence:
- `git fetch origin`
- `git rebase origin/develop`
- `bun install` completed with no dependency changes
- `bun run verify` passed: 528/528 tasks

UI/media/LLM evidence: N/A, build graph configuration only.