### PR TITLE
fix(training): align eval suite defaults with Gemma tiers

### DIFF
--- a/packages/training/scripts/eval/eliza1_eval_suite.py
+++ b/packages/training/scripts/eval/eliza1_eval_suite.py
@@ -30,8 +30,8 @@ Honesty rules (mirrors AGENTS.md §3/§7 — no fabricated passes):
 Run it::
 
     uv run --extra train python -m scripts.eval.eliza1_eval_suite \
-        --bundle-dir ~/.eliza/local-inference/models/eliza-1-0_8b.bundle \
-        --tier 0_8b
+        --bundle-dir ~/.eliza/local-inference/models/eliza-1-2b.bundle \
+        --tier 2b
 
 Or against the in-repo defaults (auto-discovers the engine bin dir and the
 held-out text-eval corpus).
@@ -74,9 +74,8 @@ _LLAMA_PROCESS_RE = re.compile(
 
 # Held-out text-eval corpus.
 #
-# Source of truth: the eliza-1 training dataset's held-out test split at
-# ``packages/training/datasets/eliza1-sft-0_8b/test.jsonl`` (also published as
-# ``elizaos/eliza-1-training/test.jsonl``). The eval suite reads it at boot,
+# Source of truth: the eliza-1 training dataset's held-out test split (also
+# published as ``elizaos/eliza-1-training/test.jsonl``). The eval suite reads it at boot,
 # extracts the assistant-turn text from each ``{"messages":[...]}`` row, and
 # uses that concatenation as the perplexity corpus.
 #
@@ -87,10 +86,10 @@ _LLAMA_PROCESS_RE = re.compile(
 # the real publish-time eval.
 
 _DATASET_TEST_RELATIVES: tuple[Path, ...] = (
-    Path("datasets/eliza1-sft-0_8b/test.jsonl"),
-    # The staged training dataset was renamed from the historical 0.6B tier to
-    # 0.8B for release. Keep the old path as a canonical local fallback so
-    # publish evals do not silently degrade to the hand-written mini corpus.
+    Path("data/final/test.jsonl"),
+    Path("data/final-eliza1-smoke/test.jsonl"),
+    # Keep the old 0.6B path as a canonical local fallback so older worktrees
+    # do not silently degrade to the hand-written mini corpus.
     Path("datasets/eliza1-sft-0_6b/test.jsonl"),
 )
 
@@ -178,8 +177,8 @@ def _dataset_test_jsonl() -> Path | None:
     Search order:
       1. ``ELIZA_EVAL_TEXT_CORPUS`` env var (explicit operator override).
       2. The in-repo eliza1 SFT ``test.jsonl`` split next to the training
-         package. ``0_8b`` is preferred; ``0_6b`` is the historical pre-rename
-         path still present in older worktrees.
+         package. Active final data is preferred; ``0_6b`` is retained only as
+         a historical fallback path still present in older worktrees.
     """
     override = os.environ.get("ELIZA_EVAL_TEXT_CORPUS")
     if override:
@@ -216,7 +215,7 @@ DEFAULT_TEXT_EVAL_CORPUS: tuple[str, ...] = _default_text_eval_corpus()
 # Map mean per-token negative log-likelihood to a 0..1 "text quality" score:
 # score = exp(-_NLL_DECAY * meanNll). Lower NLL → higher score. Calibrated so a
 # competent fine-tuned small model (meanNll ≈ 2.0 nats/token ≈ ppl 7.4) lands
-# around the 0_8b gate threshold (0.55), an un-fine-tuned base model
+# around the 2b gate threshold (0.55), an un-fine-tuned base model
 # (meanNll ≈ 4 nats ≈ ppl 55) lands ≈ 0.37, and a strong model (meanNll ≈ 1.3
 # ≈ ppl 3.7) lands ≈ 0.72. The decay is the only knob; the per-tier gate
 # thresholds in eliza1_gates.yaml are what actually decide pass/fail.
@@ -817,7 +816,7 @@ def _kokoro_e2e_loop_bench_path() -> Path | None:
 
 
 def _uses_kokoro_e2e_harness(tier: str) -> bool:
-    return normalize_tier(tier) in {"0_8b", "2b", "4b"}
+    return normalize_tier(tier) in {"2b", "4b"}
 
 
 def _normalize_backend_for_harness(backend: str | None) -> str:
@@ -2101,9 +2100,9 @@ def build_context(args: argparse.Namespace) -> EvalContext:
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--bundle-dir", type=Path, required=True, help="Staged Eliza-1 bundle directory.")
-    ap.add_argument("--tier", required=True, help="Tier id (0_8b / 2b / 9b / ...) or eliza-1-<tier>.")
+    ap.add_argument("--tier", required=True, help="Tier id (2b / 4b / 9b / 27b / 27b-256k) or eliza-1-<tier>.")
     ap.add_argument("--backend", default=None, help="Prefer this engine backend dir (cpu / vulkan / ...).")
-    ap.add_argument("--text-eval-model", type=Path, default=None, help="Override text GGUF used for the perplexity eval (e.g. a small reference Qwen3 GGUF when the bundle text artifact is a stand-in).")
+    ap.add_argument("--text-eval-model", type=Path, default=None, help="Override text GGUF used for the perplexity eval (e.g. a small reference Gemma GGUF when the bundle text artifact is a stand-in).")
     ap.add_argument("--text-corpus", type=Path, default=None, help="Held-out text-eval corpus (.txt one-per-line or .jsonl with a 'text' field). Defaults to the bundled small set.")
     ap.add_argument("--asr-corpus", type=Path, default=None, help="Directory of labelled ASR test clips: <id>.wav (16 kHz mono PCM) + <id>.txt (ground-truth transcript). When set, the ASR-WER eval transcribes these real clips (a valid WER) instead of the TTS round-trip. Also picked up from ELIZA_EVAL_ASR_CORPUS.")
     ap.add_argument("--threads", type=int, default=min(os.cpu_count() or 4, 8))

--- a/packages/training/scripts/eval/test_eliza1_eval_suite.py
+++ b/packages/training/scripts/eval/test_eliza1_eval_suite.py
@@ -30,16 +30,16 @@ from scripts.eval import eliza1_eval_suite as suite
 
 
 def _make_standin_bundle(root: Path) -> Path:
-    bundle = root / "eliza-1-0_8b.bundle"
+    bundle = root / "eliza-1-2b.bundle"
     for sub in ("text", "tts", "asr", "vad", "mtp", "cache", "evals"):
         (bundle / sub).mkdir(parents=True, exist_ok=True)
     # Tiny stand-in artifacts (NOT real GGUFs).
-    (bundle / "text" / "eliza-1-0_8b-32k.gguf").write_text("standin")
+    (bundle / "text" / "eliza-1-2b-32k.gguf").write_text("standin")
     (bundle / "tts" / "omnivoice-base.gguf").write_text("standin")
     (bundle / "tts" / "omnivoice-tokenizer.gguf").write_text("standin")
     (bundle / "asr" / "asr.gguf").write_text("standin")
     (bundle / "vad" / "silero-vad.onnx").write_text("standin")
-    (bundle / "mtp" / "drafter-0_8b.gguf").write_text("standin")
+    (bundle / "mtp" / "drafter-2b.gguf").write_text("standin")
     (bundle / "cache" / "voice-preset-default.bin").write_text("standin")
     return bundle
 
@@ -61,7 +61,7 @@ def _run(bundle: Path, monkeypatch, *, text_eval_model: Path | None = None):
     )
     args = suite.argparse.Namespace(
         bundle_dir=bundle,
-        tier="0_8b",
+        tier="2b",
         backend=None,
         text_eval_model=text_eval_model,
         text_corpus=None,
@@ -90,7 +90,7 @@ def test_writes_all_eval_blobs(tmp_path: Path, monkeypatch) -> None:
         "aggregate.json",
     ):
         assert (evals / name).is_file(), f"missing {name}"
-    assert agg["tier"] == "0_8b"
+    assert agg["tier"] == "2b"
     assert agg["mode"] == "full"
     assert "results" in agg
     assert agg["bundleIsLocalStandin"] is True
@@ -113,7 +113,7 @@ def test_run_suite_writes_backend_verify_alias_for_metal(tmp_path: Path, monkeyp
     )
     args = suite.argparse.Namespace(
         bundle_dir=bundle,
-        tier="0_8b",
+        tier="2b",
         backend="metal",
         text_eval_model=None,
         text_corpus=None,
@@ -174,8 +174,8 @@ def test_find_verify_dir_prefers_native_plugin_verify() -> None:
 
 
 def test_e2e_harness_selection_routes_small_tiers_to_kokoro() -> None:
-    assert suite._uses_kokoro_e2e_harness("0_8b") is True
     assert suite._uses_kokoro_e2e_harness("2b") is True
+    assert suite._uses_kokoro_e2e_harness("eliza-1-2b") is True
     assert suite._uses_kokoro_e2e_harness("4b") is True
     assert suite._uses_kokoro_e2e_harness("9b") is False
     assert suite._uses_kokoro_e2e_harness("27b-256k") is False
@@ -227,7 +227,7 @@ def test_e2e_bench_guard_records_not_run_before_launch(tmp_path: Path, monkeypat
     bundle = _make_real_bundle(tmp_path)
     ctx = suite.EvalContext(
         bundle_dir=bundle,
-        tier="0_8b",
+        tier="2b",
         engine=_fake_engine(tmp_path / "bin"),
         text_model=None,
         text_eval_model=None,
@@ -311,8 +311,8 @@ def test_aggregate_is_consumable_by_gate_engine(tmp_path: Path, monkeypatch) -> 
     agg = _run(bundle, monkeypatch)
     from benchmarks.eliza1_gates import apply_gates
 
-    rep = apply_gates(agg, "0_8b", mode="full")
-    assert rep.tier == "0_8b"
+    rep = apply_gates(agg, "2b", mode="full")
+    assert rep.tier == "2b"
     assert rep.passed is False  # stand-in bundle never passes
 
 
@@ -323,17 +323,17 @@ def _make_real_bundle(root: Path) -> Path:
     discovery + the e2e bench bridge, so no real runtime is invoked. They only
     exercise the not-run-vs-ok branching of the bench-bridge runners.
     """
-    bundle = root / "eliza-1-0_8b.bundle"
+    bundle = root / "eliza-1-2b.bundle"
     for sub in ("text", "tts", "asr", "vad", "mtp", "cache", "evals"):
         (bundle / sub).mkdir(parents=True, exist_ok=True)
     big = b"GGUF" + b"\0" * (2 * 1024 * 1024)
     drafter_big = b"GGUF" + b"\0" * (12 * 1024 * 1024)
-    (bundle / "text" / "eliza-1-0_8b-32k.gguf").write_bytes(big)
+    (bundle / "text" / "eliza-1-2b-32k.gguf").write_bytes(big)
     (bundle / "tts" / "omnivoice-base-Q4_K_M.gguf").write_bytes(big)
     (bundle / "tts" / "omnivoice-tokenizer-Q4_K_M.gguf").write_bytes(big)
     (bundle / "asr" / "eliza-1-asr.gguf").write_bytes(big)
     (bundle / "vad" / "silero-vad-v5.gguf").write_bytes(big)
-    (bundle / "mtp" / "drafter-0_8b.gguf").write_bytes(drafter_big)
+    (bundle / "mtp" / "drafter-2b.gguf").write_bytes(drafter_big)
     (bundle / "cache" / "voice-preset-default.bin").write_text("standin")
     return bundle
 
@@ -372,7 +372,7 @@ def _run_real(bundle: Path, monkeypatch, *, bench_report: dict | None, bench_rep
         return (bench_report_30 if (turns >= 8 and bench_report_30 is not None) else bench_report)
 
     monkeypatch.setattr(suite, "_run_e2e_loop_bench", _fake_bench)
-    args = suite.argparse.Namespace(bundle_dir=bundle, tier="0_8b", backend=None, text_eval_model=None, text_corpus=None, threads=2, timeout=30)
+    args = suite.argparse.Namespace(bundle_dir=bundle, tier="2b", backend=None, text_eval_model=None, text_corpus=None, threads=2, timeout=30)
     ctx = suite.build_context(args)
     return suite.run_suite(ctx)
 
@@ -449,7 +449,7 @@ def test_precomputed_e2e_reports_feed_eval_blobs(tmp_path: Path, monkeypatch) ->
     monkeypatch.setattr(suite, "eval_vad", lambda ctx: {"schemaVersion": suite.SCHEMA_VERSION, "metric": "vad_latency_ms", "op": "<=", "status": "not-run", "median": None, "passed": None, "reason": "skipped in test"})
     monkeypatch.setattr(suite, "_BUN", "/bin/false")
     monkeypatch.setattr(suite.subprocess, "run", _no_bench)
-    args = suite.argparse.Namespace(bundle_dir=bundle, tier="0_8b", backend=None, text_eval_model=None, text_corpus=None, threads=2, timeout=30)
+    args = suite.argparse.Namespace(bundle_dir=bundle, tier="2b", backend=None, text_eval_model=None, text_corpus=None, threads=2, timeout=30)
     agg = suite.run_suite(suite.build_context(args))
 
     e2e = json.loads((bundle / "evals" / "e2e-loop.json").read_text())
@@ -477,14 +477,14 @@ def test_bench_bridge_runners_record_not_run_when_bench_fails(tmp_path: Path, mo
 
 
 def test_real_text_model_override_produces_real_score(tmp_path: Path, monkeypatch) -> None:
-    """If a real Qwen3 GGUF is on disk, the text eval produces a real 0..1 score."""
+    """If a real Gemma GGUF is on disk, the text eval produces a real 0..1 score."""
     candidates = [
-        Path("/tmp/eliza1-eval-models/Qwen3-0.8B-Q8_0.gguf"),
-        Path("/tmp/eliza1-eval-models/Qwen3-2B-Q8_0.gguf"),
+        Path("/tmp/eliza1-eval-models/gemma-2b-Q8_0.gguf"),
+        Path("/tmp/eliza1-eval-models/gemma-4b-Q8_0.gguf"),
     ]
     model = next((p for p in candidates if suite._is_real_gguf(p)), None)
     if model is None:
-        pytest.skip("no real Qwen3 GGUF on disk; run the suite live to exercise this path")
+        pytest.skip("no real Gemma GGUF on disk; run the suite live to exercise this path")
     try:
         import llama_cpp  # noqa: F401
     except ImportError:


### PR DESCRIPTION
Summary:
- move Eliza-1 eval suite examples, CLI help, and unit-test fixtures from retired 0_8b/Qwen text defaults to active 2b/Gemma tiers
- prefer active final training test splits for held-out text eval while retaining the committed 0_6b dataset only as a legacy fallback
- route Kokoro e2e harness selection through active 2b/4b tiers and keep Qwen3-ASR references limited to intentional ASR artifact wording

Evidence:
- `git fetch origin`
- `git rebase origin/develop`
- `bun install` completed with no dependency changes
- `uv run python -m py_compile scripts/eval/eliza1_eval_suite.py scripts/eval/test_eliza1_eval_suite.py`
- `uv run pytest scripts/eval/test_eliza1_eval_suite.py` passed: 20 passed, 1 skipped
- touched-file stale scan only finds intentional Qwen3-ASR lines; no retired `0_8b`/`1_7b` text-tier defaults remain
- `git diff --check`
- `bun run verify` passed: 528/528 tasks

UI/media/LLM evidence: N/A, training eval-suite defaults and unit fixtures only.