### PR TITLE
fix: remove retired Eliza-1 tiers from local model remote

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1589,7 +1589,7 @@ public class ElizaAgentService extends Service {
 
                 // Keep decode chunks bounded for stock APK runs while avoiding
                 // unnecessary multi-chunk prompt prefill. Pixel validation on
-                // eliza-1-0_8b showed 256-token chunks reduce native prefill
+                // eliza-1-2b showed 256-token chunks reduce native prefill
                 // time versus the older 64-token default, without blocking
                 // health/startup probes because the HTTP server binds after
                 // model prewarm. Branded AOSP keeps the historical 512-token

--- a/packages/app-core/platforms/electrobun/remotes/local-model/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/README.md
@@ -4,18 +4,15 @@
 
 ## Eliza-1 Source
 
-Phase 8 is Eliza-1 first. The canonical model repository is `elizaos/eliza-1`; runtime bundles live under `bundles/<tier>/`. The Remote represents the HF-visible bundle tiers:
+Phase 8 is Eliza-1 first. The canonical model repository is `elizaos/eliza-1`; runtime bundles live under `bundles/<tier>/`. The Remote exposes the active runtime bundle tiers:
 
-- `0_6b`
-- `0_8b`
-- `1_7b`
 - `2b`
 - `4b`
 - `9b`
 - `27b`
 - `27b-256k`
 
-The local app catalog currently marks the active Eliza-1 line as `0_8b`, `2b`, `4b`, `9b`, `27b`, and `27b-256k`. The HF-visible `0_6b` and `1_7b` tiers remain represented as visible remote tiers until the local catalog activates them.
+The local app catalog marks the active Eliza-1 line as `2b`, `4b`, `9b`, `27b`, and `27b-256k`. Historical `0_6b`, `0_8b`, and `1_7b` bundle experiments are not exposed by this Remote.
 
 The default published runtime artifact is `Q4_K_M`. `Q6_K` and `Q8_0` are tracked as higher-precision variants when the repo or local catalog reports them.
 

--- a/packages/app-core/platforms/electrobun/remotes/local-model/src/bun/eliza1-catalog.ts
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/src/bun/eliza1-catalog.ts
@@ -28,22 +28,6 @@ const LOCAL_CATALOG_PATH = resolveLocalCatalogPath();
 
 const TIER_SNAPSHOTS: TierSnapshot[] = [
   {
-    tier: "0_6b",
-    params: "0.6B",
-    displayName: "Eliza-1 0.6B",
-    activeTier: false,
-    roles: ["chat"],
-    capabilities: ["text-generation"],
-  },
-  {
-    tier: "1_7b",
-    params: "1.7B",
-    displayName: "Eliza-1 1.7B",
-    activeTier: false,
-    roles: ["chat"],
-    capabilities: ["text-generation"],
-  },
-  {
     tier: "2b",
     params: "2B",
     displayName: "Eliza-1 2B",

--- a/packages/app-core/platforms/electrobun/remotes/local-model/src/dev/phase8-smoke.ts
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/src/dev/phase8-smoke.ts
@@ -4,8 +4,6 @@ import { ModelRemoteService } from "../bun/model-service.ts";
 process.env.ELIZA_MODEL_HF_DISABLE_NETWORK ??= "1";
 
 const REQUIRED_TIERS = [
-  "0_6b",
-  "1_7b",
   "2b",
   "4b",
   "9b",

--- a/packages/training/scripts/test_build_eliza1_benchmark_matrix.py
+++ b/packages/training/scripts/test_build_eliza1_benchmark_matrix.py
@@ -92,7 +92,7 @@ def test_build_artifact_marks_dry_run_comparisons() -> None:
             {
                 "modelId": "google/gemma-4-E2B-Base",
                 "variant": "base",
-                "tier": "0_8b",
+                "tier": "2b",
                 "benchmark": "eliza_harness_action_selection",
                 "score": 0.0,
                 "metrics": {"dryRun": True},


### PR DESCRIPTION
Summary:
- expose only the active Gemma-backed Eliza-1 tiers from the Electrobun local-model remote
- update the local-model smoke/README and Android tuning comment away from retired 0_6b/0_8b/1_7b tier names
- align the benchmark matrix dry-run fixture with the active 2b tier

Evidence:
- `git fetch origin`
- `git rebase origin/develop`
- `bun install` completed with no dependency changes
- `bun run --cwd packages/app-core/platforms/electrobun/remotes/local-model typecheck`
- `bun run --cwd packages/app-core/platforms/electrobun/remotes/local-model smoke` passed with 5 active tiers: 2b, 4b, 9b, 27b, 27b-256k
- `uv run pytest scripts/test_build_eliza1_benchmark_matrix.py` passed: 4 passed
- `git diff --check`
- `bun run verify` passed: 528 successful, 528 total

UI/media/LLM evidence: N/A, local model catalog/docs/tests and Android runtime comment only.