### PR TITLE
docs: remove retired 0.8B training tier

### DIFF
--- a/packages/docs/tracks/training/eliza-1.mdx
+++ b/packages/docs/tracks/training/eliza-1.mdx
@@ -20,7 +20,7 @@ All sizes are published under the [`elizaos/eliza-1`](https://huggingface.co/eli
 
 **APOLLO is locked.** Memory-efficient, no alternatives ship.
 
-- 0.8B / 2B / 4B — `apollo_mini` (rank=1)
+- 2B / 4B — `apollo_mini` (rank=1)
 - 9B / 27B — `apollo`
 
 ## Quantization


### PR DESCRIPTION
Summary:
- remove the retired 0.8B size from the public Eliza-1 optimizer tier split
- keep the active Gemma tier split aligned with the shipping table: `2B / 4B` use `apollo_mini`, `9B / 27B` use `apollo`

Evidence:
- `rg -n "0\.8B|0_8b|eliza-1-0_8b|Hermes|NousResearch" packages/docs/tracks/training/eliza-1.mdx` returned no matches
- `bun run --cwd packages/docs test` passed: 15 pass, 0 fail
- `git diff --check`
- `git fetch origin`
- `git rebase origin/develop`
- `bun install` completed with no artifact churn
- `bun run verify` passed: 530 successful, 530 total; build/typecheck audit passed

UI/media/LLM evidence: N/A, public docs copy-only cleanup.
