### PR TITLE
chore(cloud): open apps-deploy to all orgs in prod (APPS_DEPLOY_ALLOWED_ORG_IDS=*)

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -371,8 +371,13 @@ NODE_ENV = "production"
 # the route-level org allowlist (apps-deploy-gate.ts): without APPS_DEPLOY_ALLOWED_ORG_IDS the
 # deploy POST fails closed with 403 even when this flag is "1".
 APPS_DEPLOY_ENABLED = "1"
-# Set as a Cloudflare secret/var with comma-separated org UUIDs before piloting/widening:
-# APPS_DEPLOY_ALLOWED_ORG_IDS = "00000000-0000-0000-0000-000000000000"
+# Org allowlist for apps-deploy (apps-deploy-gate.ts). "*" = open to ALL orgs —
+# the launch posture so any user can deploy an app. Set here as a COMMITTED var,
+# NOT a Cloudflare secret: secrets get wiped on Worker redeploys, which already
+# silently re-closed apps-deploy in prod once. Requires the "*" wildcard support
+# in apps-deploy-gate.ts (#9735). To pilot a narrower cohort instead, replace "*"
+# with comma/space-separated org UUIDs.
+APPS_DEPLOY_ALLOWED_ORG_IDS = "*"
 NEXT_PUBLIC_APP_URL = "https://elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://elizacloud.ai"


### PR DESCRIPTION
## What

Opens **apps-deploy to all orgs in prod** by setting `APPS_DEPLOY_ALLOWED_ORG_IDS = "*"` as a committed `[env.production].vars` value.

## Why this is needed

Apps-deploy is the launch product, but **no real user can deploy an app right now**:
- The prod gate (`apps-deploy-gate.ts`) **fails closed** without an org allowlist.
- The allowlist was only ever set as a **Cloudflare secret**, which gets **wiped on Worker redeploys**. That already happened — the prod Worker currently has **`secrets: []`**, so apps-deploy is fail-closed for **every** org, including the showcase. (Discovered while validating the launch state.)
- Everything else is ready: the route is live (`401`s, not `404`), the daemon side is armed, and prebuilt-image deploys are **proven in prod** (scoped canary). It's purely the allowlist that's shut.

## How

Set `APPS_DEPLOY_ALLOWED_ORG_IDS = "*"` as a **committed var** (durable across redeploys, unlike the wiped secret). `"*"` opens to all orgs via the wildcard support landed in **#9735** — both ride the same prod deploy.

## Heads-up (intentional, for reviewer + nubs)

- This opens **container provisioning to every org** on the shared node pool — a real capacity/cost lever, requested for launch. To pilot a narrower cohort, swap `"*"` for specific org UUIDs (one-line change).
- The existing cutover caveat in the file still applies: **deploy to prod only once staging QA is green** (the prod deploy is bundled with the console fix currently in staging validation).

## Refs
elizaOS/eliza#8434, wildcard #9735.
