### PR TITLE
fix(training): update active script examples to 2b

### DIFF
--- a/packages/training/scripts/day0_smoke.sh
+++ b/packages/training/scripts/day0_smoke.sh
@@ -6,18 +6,18 @@
 #
 # Required env: VAST_API_KEY, instance id in .vast_instance_id
 #
-# Optional env (parametrized so the same script smokes 0.8B / 2B / 4B):
+# Optional env (parametrized so the same script smokes 2B / 4B):
 #   REGISTRY_KEY      default: gemma4-e2b
-#                     supported: gemma4-e2b | gemma4-e2b | gemma4-e4b
+#                     supported: gemma4-e2b | gemma4-e4b
 #   FSDP_WORLD_SIZE   default: matches the registry's recommended world size
 #                     (1 for all active tiers on a single GPU).
-#   SMOKE_MAX_SAMPLES default: 48 (0.8B), 32 (2B), 16 (4B)
-#   SMOKE_MAX_SEQ_LEN default: 2048 (0.8B/2B), 4096 (4B)
+#   SMOKE_MAX_SAMPLES default: 32 (2B), 16 (4B)
+#   SMOKE_MAX_SEQ_LEN default: 2048 (2B), 4096 (4B)
 #   SMOKE_BENCH_PER_BUCKET  default: 32
 #
 # Usage:
 #   bash scripts/day0_smoke.sh                            # 2B
-#   REGISTRY_KEY=gemma4-e2b bash scripts/day0_smoke.sh   # 0.8B
+#   REGISTRY_KEY=gemma4-e2b bash scripts/day0_smoke.sh     # 2B
 #   REGISTRY_KEY=gemma4-e4b bash scripts/day0_smoke.sh     # 4B (needs ~24 GB GPU)
 
 set -euo pipefail
@@ -30,14 +30,6 @@ REGISTRY_KEY="${REGISTRY_KEY:-gemma4-e2b}"
 
 # Per-size defaults (caller can override any of them via env).
 case "$REGISTRY_KEY" in
-  gemma4-e2b)
-    BASE_HF_ID="google/gemma-4-E2B"
-    DEFAULT_FSDP_WORLD_SIZE=1
-    DEFAULT_MAX_SAMPLES=48
-    DEFAULT_MAX_SEQ_LEN=2048
-    DEFAULT_BENCH_PER_BUCKET=32
-    DEFAULT_OPTIMIZER=apollo_mini
-    ;;
   gemma4-e2b)
     BASE_HF_ID="google/gemma-4-E2B"
     DEFAULT_FSDP_WORLD_SIZE=1

--- a/packages/training/scripts/nebius_watcher.sh
+++ b/packages/training/scripts/nebius_watcher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Canonical backstop watcher for Nebius H200 SFT runs launched via
 # train_nebius.sh full. Codified from the v4b watcher that rescued the
-# 2026-05-13 0.8B SFT after the original watcher's nebius-CLI auth-check
+# 2026-05-13 retired small-tier SFT after the original watcher's nebius-CLI auth-check
 # false-positive teardown (incident: .swarm/STATUS.md, 2026-05-12 22:28Z).
 #
 # Design (corrects the v4 watcher bug):
@@ -17,8 +17,8 @@
 #
 # Required env / args:
 #   NEBIUS_PROJECT_ID            (export, e.g. project-e00kfz6cpr00q21z892vec)
-#   NEBIUS_VM_NAME               (export, e.g. eliza-train-h200-0_8b-v5)
-#   RUN_NAME                     (export, e.g. eliza-1-0_8b-apollo-...-v5-1234)
+#   NEBIUS_VM_NAME               (export, e.g. eliza-train-h200-2b-v5)
+#   RUN_NAME                     (export, e.g. eliza-1-2b-apollo-...-v5-1234)
 #   VM_IP                        (export OR auto-derive via vm_ip())
 #   $1 = FULL_PID                 (PID of `bash train_nebius.sh full`)
 #   $2 = DEADLINE_HOURS           (optional, default 12 to match the runner cap)

--- a/packages/training/scripts/optimize_for_eliza1.py
+++ b/packages/training/scripts/optimize_for_eliza1.py
@@ -17,7 +17,7 @@ Usage::
     # Dry-run on the smallest Eliza-1 tier.
     uv run python scripts/optimize_for_eliza1.py \\
         --base-model google/gemma-4-E2B-Base \\
-        --output-dir checkpoints/eliza-1-0_8b \\
+        --output-dir checkpoints/eliza-1-2b \\
         --apply polarquant qjl turboquant fused_turboquant \\
         --gguf-target packages/inference \\
         --hf-repo elizaos/eliza-1 \\
@@ -25,19 +25,19 @@ Usage::
 
     # Real run (needs the elizaOS/llama.cpp v1.0.0-eliza checkout
     # at $LLAMA_CPP_DIR for the convert step + a real HF token).
-    # Published artifacts land at elizaos/eliza-1/bundles/0_8b/.
+    # Published artifacts land at elizaos/eliza-1/bundles/2b/.
     HF_TOKEN=hf_xxx LLAMA_CPP_DIR=$HOME/src/eliza-llama.cpp \\
         uv run python scripts/optimize_for_eliza1.py \\
             --base-model google/gemma-4-E2B-Base \\
-            --output-dir checkpoints/eliza-1-0_8b \\
+            --output-dir checkpoints/eliza-1-2b \\
             --apply polarquant qjl turboquant fused_turboquant \\
             --hf-repo elizaos/eliza-1
 
 The downstream ``llama-server`` invocation that the published manifest
 documents looks like::
 
-    llama-server --model eliza-1-0_8b-Q4_POLAR.gguf \\
-                 --draft-model eliza-1-0_8b-drafter.gguf \\
+    llama-server --model eliza-1-2b-Q4_POLAR.gguf \\
+                 --draft-model eliza-1-2b-drafter.gguf \\
                  --spec-type mtp \\
                  --cache-type-k qjl1_256 \\
                  --cache-type-v tbq3_0
@@ -738,7 +738,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--base-model",
         required=True,
         help="HF repo id or local path to the base model "
-             "(e.g. google/gemma-4-E2B-Base for the 0_8b tier upstream base, "
+             "(e.g. google/gemma-4-E2B-Base for the 2b tier upstream base, "
              "or a local trained checkpoint path).",
     )
     p.add_argument(

--- a/packages/training/scripts/train_vast.sh
+++ b/packages/training/scripts/train_vast.sh
@@ -623,7 +623,7 @@ sync_tree() {
   # don't ship every old run to the remote. If RESUME_FROM_CHECKPOINT is set,
   # ship ONLY that one checkpoint dir on top so HF Trainer can pick it up via
   # --resume-from-checkpoint. The path is interpreted RELATIVE to packages/training/
-  # (e.g. checkpoints/eliza-1-0_8b-apollo-fullcorpus-h200-1778619044/checkpoint-1000).
+  # (e.g. checkpoints/eliza-1-2b-apollo-fullcorpus-h200-1778619044/checkpoint-1000).
   if [ -n "${RESUME_FROM_CHECKPOINT:-}" ]; then
     local _resume_local="$ROOT/$RESUME_FROM_CHECKPOINT"
     if [ ! -d "$_resume_local" ]; then

--- a/packages/training/scripts/verify_optimization_stack.py
+++ b/packages/training/scripts/verify_optimization_stack.py
@@ -20,10 +20,10 @@ Asserts on a staged/published Eliza-1 bundle dir (or the raw
 
 Run on a staged bundle:
     uv run python scripts/verify_optimization_stack.py \\
-        --bundle-dir /tmp/eliza1-stage/eliza-1-0_8b
+        --bundle-dir /tmp/eliza1-stage/eliza-1-2b
 On the orchestrator output:
     uv run python scripts/verify_optimization_stack.py \\
-        --opt-dir checkpoints/eliza-1-0_8b-apollo-1778551769/eliza1-optimized
+        --opt-dir checkpoints/eliza-1-2b-apollo-1778551769/eliza1-optimized
 Exits non-zero on a failed assertion (publish-blocking).
 """
 


### PR DESCRIPTION
Summary:
- remove the unreachable duplicate `gemma4-e2b` branch in `day0_smoke.sh` and keep the active 2B smoke defaults
- update optimization, resume, and Nebius watcher examples from retired `0_8b` paths to active `2b` paths
- align published bundle examples with `elizaos/eliza-1/bundles/2b`

Evidence:
- `bash -n packages/training/scripts/day0_smoke.sh packages/training/scripts/train_vast.sh packages/training/scripts/nebius_watcher.sh`
- `uv run python -m py_compile scripts/verify_optimization_stack.py scripts/optimize_for_eliza1.py`
- `rg -n "0_8b|0\.8B|eliza-1-0_8b|bundles/0_8b|qwen3-5-0-8b|qwen3_5_0_8b" packages/training/scripts/day0_smoke.sh packages/training/scripts/verify_optimization_stack.py packages/training/scripts/optimize_for_eliza1.py packages/training/scripts/train_vast.sh packages/training/scripts/nebius_watcher.sh` returned no matches
- `git diff --check`
- `git fetch origin`
- `git rebase origin/develop`
- `bun install` completed with no package changes
- `bun run verify` passed: 530 successful, 530 total; build/typecheck audit passed

UI/media/LLM evidence: N/A, training operator-script example/default cleanup only.
