### PR TITLE
docs: update Eliza-1 size range

### DIFF
--- a/packages/docs/index.mdx
+++ b/packages/docs/index.mdx
@@ -67,7 +67,7 @@ That gets you the **Runtime** dimension. See [Quickstart](/quickstart) for full 
     Eliza Cloud handles auth, hosting, billing, and domains when you want it — never required.
   </Card>
   <Card title="Trains on your data" icon="microchip">
-    Fine-tune Eliza-1 (0.8B–27B), evaluate against 70+ benchmarks, deploy on-device.
+    Fine-tune Eliza-1 (2B–27B), evaluate against 70+ benchmarks, deploy on-device.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Summary:
- update the public docs home page Eliza-1 training range from retired `0.8B-27B` to active `2B-27B`

Evidence:
- `rg -n "0\.8B|0_8b|eliza-1-0_8b" packages/docs/index.mdx` returned no matches
- `bun run --cwd packages/docs test` passed: 15 pass, 0 fail
- `git diff --check origin/develop...HEAD` passed
- `git fetch origin` completed
- `git rebase origin/develop` reported branch up to date
- `bun install` completed with no package changes
- `bun run verify` passed: type-safety ratchet, turbo typecheck/lint, and build model audit all passed

UI/media/LLM evidence: N/A, public docs copy-only cleanup.