### PR TITLE
fix(training): align active tier help text

### DIFF
--- a/packages/training/scripts/eval_checkpoint.py
+++ b/packages/training/scripts/eval_checkpoint.py
@@ -16,12 +16,12 @@ Args:
                           state). Step is parsed from the dir name:
                           `checkpoint-<N>` -> N; `final` -> max known step + 1.
   --registry-key <k>      Model registry key (gemma4-e2b / gemma4-e4b /
-                          gemma4-e4b). Recorded in the result JSON so the
-                          UI can pick the right axis labels.
+                          gemma4-12b / gemma4-31b). Recorded in the result
+                          JSON so the UI can pick the right axis labels.
   --val-jsonl <path>      Validation JSONL. Default: data/smoke/val.jsonl.
   --max-examples <n>      Per-bucket cap for the native benchmark. Default 50 — the
                           smoke val set is tiny on purpose so each scoring
-                          pass takes ~10s on a 0.8B and ~30s on a 2B (per
+                          pass stays practical on the 2B entry tier (per
                           AGENTS spec for this script).
   --out <path>            Where to write the per-checkpoint result JSON.
                           The eval loop also writes a sibling `_eval.json`

--- a/packages/training/scripts/eval_loop.sh
+++ b/packages/training/scripts/eval_loop.sh
@@ -38,7 +38,7 @@ on each, and appends the result to training/checkpoints/<run-name>/_progress.jso
 
 Required:
   --run-name <name>
-  --registry-key <k>            gemma4-e2b / gemma4-e4b / gemma4-e4b
+  --registry-key <k>            gemma4-e2b / gemma4-e4b / gemma4-12b / gemma4-31b
 
 Optional:
   --interval-seconds <n>        default 600 (10 min)

--- a/packages/training/scripts/manifest/eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/eliza1_platform_plan.py
@@ -531,7 +531,7 @@ def render_readiness(
         "Important caveats:",
         "",
         "- Text, ASR, MTP, vision mmproj, and OmniVoice TTS payloads are "
-        "GGUF artifacts when a tier ships them. 0.8B/2B/4B/9B carry Kokoro "
+        "GGUF artifacts when a tier ships them. 2B/4B/9B carry Kokoro "
         "plus OmniVoice; Kokoro is the fused GGUF runtime path. "
         "27B-class tiers ship OmniVoice GGUF only.",
         "- VAD is a native silero-vad-cpp GGUF artifact at "

--- a/packages/training/scripts/manifest/test_eliza1_platform_plan.py
+++ b/packages/training/scripts/manifest/test_eliza1_platform_plan.py
@@ -126,6 +126,8 @@ def test_readiness_mentions_vad_native_gguf_caveat() -> None:
     assert "Gemma 4 E2B (`2b`)" in text
     assert "Gemma 4 E4B (`4b`)" in text
     assert "Gemma 4 12B (`9b`)" in text
+    assert "0.8B/2B/4B/9B" not in text
+    assert "2B/4B/9B carry Kokoro" in text
     assert "Qwen3-ASR and Qwen3-Embedding are retired" in text
     assert "Base-v1 release readiness remains blocked" in text
     assert "not evaluated in plan-only mode" in text

--- a/packages/training/scripts/train_grpo_verl.sh
+++ b/packages/training/scripts/train_grpo_verl.sh
@@ -24,7 +24,7 @@ usage() {
 Usage: train_grpo_verl.sh [options]
 
 Required:
-  --registry-key KEY        e.g. gemma4-e2b, gemma4-e4b, gemma4-e4b
+  --registry-key KEY        e.g. gemma4-e2b, gemma4-e4b, gemma4-12b, gemma4-31b
   --dpo-checkpoint DIR      Path to SFT+DPO checkpoint (the `final/` subdir)
   --output-dir DIR          Where to write the GRPO checkpoint + JSONL traces
 


### PR DESCRIPTION
Summary:
- remove retired `0.8B` wording from the generated Eliza-1 platform readiness caveat
- correct active training CLI registry-key examples to `gemma4-e2b`, `gemma4-e4b`, `gemma4-12b`, and `gemma4-31b`
- add a platform-plan regression assertion for the active Kokoro tier list

Evidence:
- `python3 -m pytest packages/training/scripts/manifest/test_eliza1_platform_plan.py packages/training/scripts/test_eval_checkpoint.py` passed: 20 passed
- `bash -n packages/training/scripts/eval_loop.sh packages/training/scripts/train_grpo_verl.sh` passed
- `rg -n "0\.8B/2B/4B/9B|0\.8B and ~30s|gemma4-e2b / gemma4-e4b / gemma4-e4b|gemma4-e2b, gemma4-e4b, gemma4-e4b" packages/training/scripts` returns only the new negative test assertion
- `git diff --check` passed
- `git fetch origin` completed
- `git rebase origin/develop` completed cleanly
- `bun install` completed with no package changes
- `bun run verify` passed: type-safety ratchet, turbo typecheck/lint, and build model audit all passed

UI/media/LLM evidence: N/A, training CLI/help/readiness copy-only cleanup.