### PR TITLE
fix(local-inference): move active verifier defaults to 2b

### DIFF
--- a/plugins/plugin-local-inference/__tests__/vision-describe.test.ts
+++ b/plugins/plugin-local-inference/__tests__/vision-describe.test.ts
@@ -23,8 +23,9 @@
  *   - CUDA:   load gemma-vl-9b on RTX 3090; same path through cuBLAS.
  *     Validate: a 1024×1024 frame describes in <0.8s end-to-end.
  *   - QNN:    on Snapdragon 8 Gen 3, validate that
- *     `eliza_llama_mtmd_describe` succeeds with the Q4_K_M 0.8B mmproj,
- *     and that text+vision co-resident memory stays under 3.5 GB.
+ *     `eliza_llama_mtmd_describe` succeeds with the Q4_K_M 2B mmproj,
+ *     and that text+vision co-resident memory stays inside the active
+ *     mobile budget.
  */
 
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/native/verify/asr_bench_real_recorded_workflow.mjs
+++ b/plugins/plugin-local-inference/native/verify/asr_bench_real_recorded_workflow.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * No-model helper for the 0_8b real-recorded ASR WER gate.
+ * No-model helper for the 2b real-recorded ASR WER gate.
  *
  * This does not run ASR and never treats generated/synthetic audio as publish
  * evidence. It creates a tiny deterministic non-speech fixture corpus for
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = findRepoRoot(__dirname);
 const VERIFY_ROOT = __dirname;
 const REPORTS_ROOT = path.join(VERIFY_ROOT, "reports");
-const DEFAULT_TIER = "0_8b";
+const DEFAULT_TIER = "2b";
 const DEFAULT_MIN_UTTERANCES = 5;
 const DEFAULT_FIXTURE_DIR = path.join(
   VERIFY_ROOT,
@@ -28,7 +28,7 @@ const DEFAULT_REPORT_DATE = "2026-05-16";
 const DEFAULT_REPORT = path.join(
   REPORTS_ROOT,
   DEFAULT_REPORT_DATE,
-  "asr-wer-real-recorded-0_8b-needs-corpus-20260516.json",
+  "asr-wer-real-recorded-2b-needs-corpus-20260516.json",
 );
 
 const FIXTURE_UTTERANCES = [
@@ -59,7 +59,7 @@ function findRepoRoot(startDir) {
 function parseArgs(argv) {
   const args = {
     tier: DEFAULT_TIER,
-    bundle: "~/.eliza/local-inference/models/eliza-1-0_8b.bundle",
+    bundle: "~/.eliza/local-inference/models/eliza-1-2b.bundle",
     wavDir: "",
     fixtureDir: DEFAULT_FIXTURE_DIR,
     out: DEFAULT_REPORT,
@@ -107,11 +107,11 @@ function printHelp() {
   console.log(`Usage:
   node plugins/plugin-local-inference/native/verify/asr_bench_real_recorded_workflow.mjs \\
     --init-fixture \\
-    --out plugins/plugin-local-inference/native/reports/local-e2e/2026-05-16/asr-wer-real-recorded-0_8b-needs-corpus-20260516.json
+    --out plugins/plugin-local-inference/native/reports/local-e2e/2026-05-16/asr-wer-real-recorded-2b-needs-corpus-20260516.json
 
   # After recording real microphone/field audio:
   bun plugins/plugin-local-inference/native/verify/asr_bench.ts \\
-    --bundle ~/.eliza/local-inference/models/eliza-1-0_8b.bundle \\
+    --bundle ~/.eliza/local-inference/models/eliza-1-2b.bundle \\
     --wav-dir <real-recorded-wav-txt-dir> \\
     --real-recorded \\
     --min-real-recorded-utterances 5 \\
@@ -203,13 +203,13 @@ The WAV files are short generated tones, not speech and not TTS. They only prove
 that five WAV+.txt pairs can be carried through scripts without downloading
 models.
 
-Do not use this directory as publish evidence. The 0_8b ASR WER publish gate
+Do not use this directory as publish evidence. The 2b ASR WER publish gate
 requires at least five explicit real microphone or field recordings with matching
 transcripts, run through:
 
 \`\`\`sh
 bun plugins/plugin-local-inference/native/verify/asr_bench.ts \\
-  --bundle ~/.eliza/local-inference/models/eliza-1-0_8b.bundle \\
+  --bundle ~/.eliza/local-inference/models/eliza-1-2b.bundle \\
   --wav-dir <real-recorded-wav-txt-dir> \\
   --real-recorded \\
   --min-real-recorded-utterances 5
@@ -356,12 +356,12 @@ function buildReport(args, fixtureManifest) {
 
   const runRealRecordedWer = [
     "bun plugins/plugin-local-inference/native/verify/asr_bench.ts",
-    "--bundle ~/.eliza/local-inference/models/eliza-1-0_8b.bundle",
+    "--bundle ~/.eliza/local-inference/models/eliza-1-2b.bundle",
     `--wav-dir ${args.realRecorded ? rel(candidateDir) : "<real-recorded-wav-txt-dir>"}`,
     "--real-recorded",
     `--min-real-recorded-utterances ${args.minUtterances}`,
-    "--out plugins/plugin-local-inference/native/verify/reports/asr-bench-real-recorded-0_8b-<date>.json",
-    "--eval-out plugins/plugin-local-inference/native/verify/reports/asr-wer-real-recorded-0_8b-<date>.json",
+    "--out plugins/plugin-local-inference/native/verify/reports/asr-bench-real-recorded-2b-<date>.json",
+    "--eval-out plugins/plugin-local-inference/native/verify/reports/asr-wer-real-recorded-2b-<date>.json",
   ].join(" ");
 
   return {

--- a/plugins/plugin-local-inference/native/verify/bargein_endurance_harness.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/bargein_endurance_harness.test.mjs
@@ -9,9 +9,9 @@ import {
 
 function args(overrides = {}) {
   return {
-    tier: "0_8b",
+    tier: "2b",
     backend: "metal",
-    bundle: "/tmp/eliza-1-0_8b.bundle",
+    bundle: "/tmp/eliza-1-2b.bundle",
     maxCancelMs: 80,
     turns: 30,
     rssGrowthMb: 64,
@@ -31,13 +31,13 @@ function kokoroRun(overrides = {}) {
     e2eLoopOk: true,
     thirtyTurnOk: true,
     request: {
-      tier: "0_8b",
+      tier: "2b",
       backend: "metal",
       turns: 30,
     },
     bundle: {
-      dir: "/tmp/eliza-1-0_8b.bundle",
-      tier: "0_8b",
+      dir: "/tmp/eliza-1-2b.bundle",
+      tier: "2b",
     },
     voiceLoop: {
       backend: "kokoro",
@@ -70,7 +70,7 @@ function kokoroRun(overrides = {}) {
   };
 }
 
-test("records Kokoro 0_8b barge-in latency when MTP is disabled by policy", () => {
+test("records Kokoro 2B barge-in latency when MTP is disabled by policy", () => {
   const report = buildBargeInReportFromE2e({
     args: args(),
     e2eReport: kokoroRun(),
@@ -115,7 +115,7 @@ test("fails closed when a Kokoro barge-in run has no cancel metric", () => {
   );
 });
 
-test("records Kokoro 0_8b thirty-turn evidence without requiring a drafter", () => {
+test("records Kokoro 2B thirty-turn evidence when MTP is disabled by policy", () => {
   const report = buildThirtyTurnReportFromE2e({
     args: args(),
     e2eReport: kokoroRun(),

--- a/plugins/plugin-local-inference/native/verify/bargein_latency_harness.mjs
+++ b/plugins/plugin-local-inference/native/verify/bargein_latency_harness.mjs
@@ -20,8 +20,8 @@ const __dirname = path.dirname(__filename);
 const REPORTS_ROOT = path.join(__dirname, "..", "reports");
 const E2E_BENCH = path.join(__dirname, "e2e_loop_bench.mjs");
 const KOKORO_E2E_BENCH = path.join(__dirname, "kokoro_e2e_loop_bench.mjs");
-const KOKORO_TIERS = new Set(["0_8b", "2b", "4b"]);
-const NO_DRAFTER_TIERS = new Set(["0_8b"]);
+const KOKORO_TIERS = new Set(["2b", "4b"]);
+const NO_DRAFTER_TIERS = new Set([]);
 
 function timestamp() {
   return new Date()

--- a/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
+++ b/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
@@ -478,10 +478,10 @@ if (
   );
 }
 
-// 1_7b. Metal dispatch-ready capability bits must not be satisfied by shipped
-// symbols. The build script intentionally forces every non-runtime-ready Metal
-// kernel false until the evidence file records a numeric built-fork graph
-// dispatch smoke.
+// Metal dispatch-ready capability bits must not be satisfied by shipped symbols.
+// The build script intentionally forces every non-runtime-ready Metal kernel
+// false until the evidence file records a numeric built-fork graph dispatch
+// smoke.
 const metalHonestyMarker = "Honesty gate: Metal/Vulkan/CUDA standalone shaders";
 const metalHonestyIndex = buildScript.indexOf(metalHonestyMarker);
 const metalProbeMarker = 'if (backend === "metal")';

--- a/plugins/plugin-local-inference/native/verify/e2e_loop_bench.mjs
+++ b/plugins/plugin-local-inference/native/verify/e2e_loop_bench.mjs
@@ -34,8 +34,8 @@
  * with a reason and null metrics — never a fabricated pass.
  *
  *   bun packages/inference/verify/e2e_loop_bench.mjs \
- *     --bundle ~/.eliza/local-inference/models/eliza-1-0_8b.bundle \
- *     --tier 0_8b --backend cpu [--turns 1] [--wav a.wav,b.wav] [--report out.json]
+ *     --bundle ~/.eliza/local-inference/models/eliza-1-2b.bundle \
+ *     --tier 2b --backend cpu [--turns 1] [--wav a.wav,b.wav] [--report out.json]
  */
 
 import fs from "node:fs";

--- a/plugins/plugin-local-inference/native/verify/eagle3_drafter_runtime_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/eagle3_drafter_runtime_smoke.mjs
@@ -27,13 +27,13 @@ const MODELS_ROOT = path.join(
   "local-inference",
   "models",
 );
-const DEFAULT_BUNDLE = path.join(MODELS_ROOT, "eliza-1-0_8b.bundle");
+const DEFAULT_BUNDLE = path.join(MODELS_ROOT, "eliza-1-2b.bundle");
 const DEFAULT_TARGET = firstExisting(
-  path.join(DEFAULT_BUNDLE, "text", "eliza-1-0_8b-64k.gguf"),
-  path.join(DEFAULT_BUNDLE, "text", "eliza-1-0_8b-32k.gguf"),
+  path.join(DEFAULT_BUNDLE, "text", "eliza-1-2b-128k.gguf"),
+  path.join(DEFAULT_BUNDLE, "text", "eliza-1-2b-256k.gguf"),
 );
 const DEFAULT_DRAFTER = firstExisting(
-  path.join(DEFAULT_BUNDLE, "eagle3", "drafter-0_8b.gguf"),
+  path.join(DEFAULT_BUNDLE, "eagle3", "drafter-2b.gguf"),
   path.join(DEFAULT_BUNDLE, "eagle3", "drafter.gguf"),
 );
 const DEFAULT_BIN = path.join(
@@ -48,11 +48,11 @@ const DEFAULT_BIN = path.join(
 function inferTier(...values) {
   for (const value of values) {
     const match = String(value ?? "").match(
-      /eliza-1-(0_8b|2b|4b|9b|27b(?:-256k)?)/,
+      /eliza-1-(2b|4b|9b|27b(?:-256k)?)/,
     );
     if (match) return match[1];
     const drafterMatch = String(value ?? "").match(
-      /drafter-(0_8b|2b|4b|9b|27b(?:-256k)?)/,
+      /drafter-(2b|4b|9b|27b(?:-256k)?)/,
     );
     if (drafterMatch) return drafterMatch[1];
   }
@@ -114,7 +114,7 @@ function parseArgs(argv) {
   }
 
   args.tier =
-    args.tier || inferTier(args.targetModel, args.drafterModel) || "0_8b";
+    args.tier || inferTier(args.targetModel, args.drafterModel) || "2b";
   return args;
 }
 

--- a/plugins/plugin-local-inference/native/verify/eliza1_gates_collect.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_gates_collect.mjs
@@ -24,7 +24,7 @@
  *
  * Usage:
  *   node packages/inference/verify/eliza1_gates_collect.mjs \
- *     [--tier 0_8b|2b|4b|9b|27b|27b-256k] [--bundle PATH] \
+ *     [--tier 2b|4b|9b|27b|27b-256k] [--bundle PATH] \
  *     [--sync-bundle-manifest-evals] [--gates PATH] [--report PATH] [--json]
  */
 
@@ -72,7 +72,6 @@ const DEFAULT_GATES = path.join(
   "eliza1_gates.yaml",
 );
 const ACTIVE_VISION_TIERS = new Set([
-  "0_8b",
   "2b",
   "4b",
   "9b",

--- a/plugins/plugin-local-inference/native/verify/eliza1_memory_inventory.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_memory_inventory.mjs
@@ -105,7 +105,7 @@ function tierFromBundlePath(bundleDir) {
 }
 
 function tierSortKey(tier) {
-  const order = { "0_8b": "00", "2b": "01", "4b": "02", "9b": "03", "27b": "04", "27b-256k": "05", "27b-256k": "06" };
+  const order = { "2b": "00", "4b": "01", "9b": "02", "27b": "03", "27b-256k": "04" };
   return `${order[tier] ?? "99"}-${tier}`;
 }
 

--- a/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.mjs
@@ -14,7 +14,6 @@ const MODELS_ROOT = path.join(
 );
 
 const VISION_TIER_LIST = [
-  "0_8b",
   "2b",
   "4b",
   "9b",
@@ -117,7 +116,6 @@ function relativeFiles(bundleDir, dir) {
 function tierAliases(tier) {
   const aliases = new Set([tier]);
   if (tier.includes("_")) aliases.add(tier.replace("_", "."));
-  if (tier === "0_8b") aliases.add("0.8b");
   return [...aliases];
 }
 

--- a/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.test.mjs
@@ -119,8 +119,8 @@ test("resolves tier-compatible bundle mmproj artifacts from the vision directory
   }
 });
 
-test("0_8B and 2B require image-analysis vision artifacts; ASR mmproj is not enough", () => {
-  for (const tier of ["0_8b", "2b"]) {
+test("2B requires image-analysis vision artifacts; ASR mmproj is not enough", () => {
+  for (const tier of ["2b"]) {
     const dir = writeBundle(tier, {
       manifestVision: false,
       lineageVision: false,
@@ -141,8 +141,8 @@ test("0_8B and 2B require image-analysis vision artifacts; ASR mmproj is not eno
   }
 });
 
-test("0_8B and 2B accept tier-compatible image-analysis vision artifacts", () => {
-  for (const tier of ["0_8b", "2b"]) {
+test("active entry tiers accept tier-compatible image-analysis vision artifacts", () => {
+  for (const tier of ["2b"]) {
     const dir = writeBundle(tier, {
       manifestVision: true,
       lineageVision: true,
@@ -162,7 +162,7 @@ test("0_8B and 2B accept tier-compatible image-analysis vision artifacts", () =>
 });
 
 test("active vision tiers write fail evidence until image smoke passes", () => {
-  for (const tier of ["0_8b", "2b", "4b", "9b", "27b", "27b-256k"]) {
+  for (const tier of ["2b", "4b", "9b", "27b", "27b-256k"]) {
     const dir = writeBundle(tier);
     try {
       const report = buildReport(argsFor(dir));

--- a/plugins/plugin-local-inference/native/verify/kokoro_e2e_loop_bench.mjs
+++ b/plugins/plugin-local-inference/native/verify/kokoro_e2e_loop_bench.mjs
@@ -3,7 +3,7 @@
  * kokoro_e2e_loop_bench.mjs - small-tier Eliza-1 Kokoro voice-loop harness.
  *
  * This is intentionally separate from e2e_loop_bench.mjs, which drives the
- * fused OmniVoice TTS HTTP route. The small tiers (0_8b, 2b, 4b) are Kokoro
+ * fused OmniVoice TTS HTTP route. The small tiers (2b, 4b) are Kokoro
  * TTS tiers, so this harness measures the real path:
  *
  *   WAV mic input -> fused ASR FFI -> llama-server text generation
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const SMALL_TIERS = new Set(["0_8b", "2b", "4b"]);
+const SMALL_TIERS = new Set(["2b", "4b"]);
 const DEFAULT_PHRASES = [
   "hello there",
   "what is the capital of france",
@@ -52,7 +52,7 @@ const REPORTS_ROOT = path.join(__dirname, "..", "reports");
 function parseArgs(argv) {
   const defaultBackend = process.platform === "darwin" ? "metal" : "cpu";
   const args = {
-    tier: process.env.ELIZA_KOKORO_E2E_TIER || "0_8b",
+    tier: process.env.ELIZA_KOKORO_E2E_TIER || "2b",
     bundle: process.env.ELIZA_KOKORO_E2E_BUNDLE || "",
     backend: process.env.ELIZA_KOKORO_E2E_BACKEND || defaultBackend,
     binDir: process.env.ELIZA_KOKORO_E2E_BIN_DIR || "",
@@ -129,7 +129,7 @@ function parseArgs(argv) {
 function printHelp() {
   console.log(`Usage:
   bun plugins/plugin-local-inference/native/verify/kokoro_e2e_loop_bench.mjs \\
-    --tier 0_8b|2b|4b [--bundle <eliza-1-tier.bundle>] [--backend metal|cpu|vulkan|cuda]
+    --tier 2b|4b [--bundle <eliza-1-tier.bundle>] [--backend metal|cpu|vulkan|cuda]
 
 Options:
   --wav a.wav[,b.wav]     External mic WAV(s). Pair with --ref "text|text".

--- a/plugins/plugin-local-inference/native/verify/metal-perf-matrix.mjs
+++ b/plugins/plugin-local-inference/native/verify/metal-perf-matrix.mjs
@@ -28,9 +28,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 export const TIER_ORDER = [
-	"0_6b",
-	"0_8b",
-	"1_7b",
 	"2b",
 	"4b",
 	"9b",

--- a/plugins/plugin-local-inference/native/verify/mobile_peak_rss_harness.mjs
+++ b/plugins/plugin-local-inference/native/verify/mobile_peak_rss_harness.mjs
@@ -20,7 +20,7 @@
  *
  * Usage:
  *   node packages/inference/verify/mobile_peak_rss_harness.mjs \
- *     [--device <udid>] [--platform ios|android] [--tier 0_8b|2b|...] [--report PATH] [--json]
+ *     [--device <udid>] [--platform ios|android] [--tier 2b|4b|...] [--report PATH] [--json]
  */
 
 import fs from "node:fs";

--- a/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
@@ -144,7 +144,7 @@ function timestamp() {
 }
 
 function inferTier(value) {
-  const match = String(value ?? "").match(/eliza-1-(0_8b|2b|4b|9b|27b(?:-256k)?)/);
+  const match = String(value ?? "").match(/eliza-1-(2b|4b|9b|27b(?:-256k)?)/);
   return match?.[1] ?? "";
 }
 

--- a/plugins/plugin-local-inference/native/verify/speaker_imprint_diarization_harness.mjs
+++ b/plugins/plugin-local-inference/native/verify/speaker_imprint_diarization_harness.mjs
@@ -25,7 +25,7 @@ const DEFAULT_BUNDLE = path.join(
   ".eliza",
   "local-inference",
   "models",
-  "eliza-1-0_8b.bundle",
+  "eliza-1-2b.bundle",
 );
 const DEFAULT_WAV = "/tmp/omnivoice-metal-fused-codec-cpu-fallback.wav";
 const DEFAULT_REPORT = path.join(

--- a/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.test.mjs
@@ -15,7 +15,7 @@ test("builds the shared speculative report shape for each speculator", () => {
     const report = buildSpeculativeBenchmarkReport({
       speculator,
       verifier: "unit",
-      tier: "0_8b",
+      tier: "2b",
       specBinary: "/tmp/missing-spec-binary",
       withDrafter: { drafted: 4, accepted: 3, tokensPerSecond: 12 },
       withoutDrafter: { tokensPerSecond: 6 },
@@ -36,7 +36,7 @@ test("writes timestamped and latest report files", () => {
   const report = buildSpeculativeBenchmarkReport({
     speculator: "eagle3",
     verifier: "unit",
-    tier: "0_8b",
+    tier: "2b",
     status: "metadata-only",
   });
 

--- a/plugins/plugin-local-inference/native/verify/thirty_turn_endurance_harness.mjs
+++ b/plugins/plugin-local-inference/native/verify/thirty_turn_endurance_harness.mjs
@@ -20,8 +20,8 @@ const __dirname = path.dirname(__filename);
 const REPORTS_ROOT = path.join(__dirname, "..", "reports");
 const E2E_BENCH = path.join(__dirname, "e2e_loop_bench.mjs");
 const KOKORO_E2E_BENCH = path.join(__dirname, "kokoro_e2e_loop_bench.mjs");
-const KOKORO_TIERS = new Set(["0_8b", "2b", "4b"]);
-const NO_DRAFTER_TIERS = new Set(["0_8b"]);
+const KOKORO_TIERS = new Set(["2b", "4b"]);
+const NO_DRAFTER_TIERS = new Set([]);
 
 function timestamp() {
   return new Date()

--- a/plugins/plugin-local-inference/native/verify/voice_duet_sweep.mjs
+++ b/plugins/plugin-local-inference/native/verify/voice_duet_sweep.mjs
@@ -31,9 +31,9 @@
  * grid + the commands it would run, then exits.
  *
  *   bun packages/inference/verify/voice_duet_sweep.mjs \
- *     --model eliza-1-0_8b --turns 20 \
+ *     --model eliza-1-2b --turns 20 \
  *     --parallel 1,2 --draft-max 8,16 --ring-ms 160,200,240 \
- *     --out reports/porting/<date>/voice-duet-sweep-0_8b.csv
+ *     --out reports/porting/<date>/voice-duet-sweep-2b.csv
  */
 
 import { spawn } from "node:child_process";
@@ -58,7 +58,7 @@ const VOICE_DUET = path.join(
 
 function parseArgs(argv) {
   const out = {
-    model: "eliza-1-0_8b",
+    model: "eliza-1-2b",
     turns: 20,
     out: null,
     dryRun: false,
@@ -107,7 +107,7 @@ function parseArgs(argv) {
 
 const USAGE = `Usage: bun packages/inference/verify/voice_duet_sweep.mjs [options]
 
-  --model <id>            tier bundle (default eliza-1-0_8b)
+  --model <id>            tier bundle (default eliza-1-2b)
   --turns <N>             round-trips per cell (default 20)
   --out <path>            CSV output (default reports/porting/<date>/voice-duet-sweep-<model>.csv)
   --two-process           pass --two-process to voice-duet.mjs (1.7b RSS split)

--- a/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.mjs
+++ b/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.mjs
@@ -62,7 +62,7 @@ const REQUIRED_RUNTIME_SYMBOLS = [
 function parseArgs(argv) {
 	const date = new Date().toISOString().slice(0, 10);
 	const args = {
-		tier: process.env.ELIZA_VOICE_READINESS_TIER || "0_8b",
+		tier: process.env.ELIZA_VOICE_READINESS_TIER || "2b",
 		bundle: process.env.ELIZA_VOICE_READINESS_BUNDLE || null,
 		runtime: process.env.ELIZA_INFERENCE_LIBRARY || null,
 		out: null,
@@ -107,7 +107,7 @@ function printUsage() {
 		[
 			"Usage: node plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.mjs [options]",
 			"",
-			"  --tier TIER       Eliza-1 tier slug, default 0_8b.",
+			"  --tier TIER       Eliza-1 tier slug, default 2b.",
 			"  --bundle PATH     Installed bundle root.",
 			"  --runtime PATH    libelizainference shared library.",
 			"  --out PATH        Output JSON path.",

--- a/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.test.mjs
@@ -59,7 +59,7 @@ test("bundle asset inspection accepts the canonical Silero GGUF VAD artifact", (
 		);
 		const result = inspectBundleAssets({
 			bundleRoot: dir,
-			tier: "0_8b",
+			tier: "2b",
 			runtimePath: join(dir, "lib", "libelizainference.dylib"),
 		});
 		const vad = result.requirements.find((req) => req.key === "sileroVad");

--- a/plugins/plugin-local-inference/src/services/kv-spill.test.ts
+++ b/plugins/plugin-local-inference/src/services/kv-spill.test.ts
@@ -186,11 +186,8 @@ describe("residentKvBudgetFromRamBudget", () => {
 
 describe("estimateQuantizedKvBytesPerToken", () => {
 	it("returns the per-tier figure for known param strings", () => {
-		expect(estimateQuantizedKvBytesPerToken("0.8B")).toBeLessThan(
+		expect(estimateQuantizedKvBytesPerToken("2B")).toBeLessThan(
 			estimateQuantizedKvBytesPerToken("9B"),
-		);
-		expect(estimateQuantizedKvBytesPerToken("2B")).toBeGreaterThan(
-			estimateQuantizedKvBytesPerToken("0.8B"),
 		);
 		expect(estimateQuantizedKvBytesPerToken("4B")).toBeGreaterThan(
 			estimateQuantizedKvBytesPerToken("2B"),
@@ -201,6 +198,9 @@ describe("estimateQuantizedKvBytesPerToken", () => {
 	});
 
 	it("fails closed (largest tier) for unknown param strings", () => {
+		expect(estimateQuantizedKvBytesPerToken("0.8B")).toBe(
+			estimateQuantizedKvBytesPerToken("27B"),
+		);
 		expect(estimateQuantizedKvBytesPerToken("999B")).toBe(
 			estimateQuantizedKvBytesPerToken("27B"),
 		);

--- a/plugins/plugin-local-inference/src/services/kv-spill.ts
+++ b/plugins/plugin-local-inference/src/services/kv-spill.ts
@@ -105,7 +105,6 @@ export interface KvGeometry {
  */
 const QUANTIZED_KV_BYTES_PER_TOKEN_BY_PARAMS: Readonly<Record<string, number>> =
 	{
-		"0.8B": 1_400,
 		"2B": 2_400,
 		"4B": 4_800,
 		"9B": 9_000,


### PR DESCRIPTION
## Summary
- remove the retired 0.8B/legacy tier from local-inference active KV sizing and native verifier tier lists
- move native verifier defaults, examples, fixture reports, and Kokoro voice-loop harness tests to the active 2B tier
- keep legacy-size handling only as a fail-closed unknown-tier assertion in kv-spill tests

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun test plugins/plugin-local-inference/src/services/kv-spill.test.ts plugins/plugin-local-inference/__tests__/vision-describe.test.ts`
- `node --test plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.test.mjs plugins/plugin-local-inference/native/verify/speculative_benchmark_report.test.mjs plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.test.mjs plugins/plugin-local-inference/native/verify/bargein_endurance_harness.test.mjs`
- `git diff --name-only -- 'plugins/plugin-local-inference/native/verify/*.mjs' | xargs -n1 node --check`\n- `git diff --check`\n- `rg -n "0_6b|1_7b|0_8b|eliza-1-0_8b|0\\.8B|Qwen|qwen" plugins/plugin-local-inference/native/verify --glob "*.mjs" --glob "*.test.mjs"` returned no matches\n- `bun run verify` (530/530 Turbo tasks successful; build/typecheck audit passed)\n\n## PR evidence matrix\n- Real LLM trajectory: N/A, verifier/default metadata only\n- Backend logs: N/A, no runtime server path changed\n- Frontend logs/screenshots/video: N/A, no UI path changed\n- Audio/narration: N/A, no voice runtime behavior changed; verifier defaults and evidence wiring only\n