### PR TITLE
fix(training): reject retired Qwen benchmark aliases

### DIFF
--- a/packages/training/scripts/build_eliza1_sft_2b.py
+++ b/packages/training/scripts/build_eliza1_sft_2b.py
@@ -438,7 +438,7 @@ def _cerebras_assistant_and_refusals(client, n_batches: int, per_batch: int) -> 
 #    "contexts":[...],"contextSlices":[...],"candidateActions":[...],
 #    "parentActionHints":[...],"requiresTool":<bool>,"extract":{...}}
 # On the direct (DM/API/voice) path the same keys minus ``shouldRespond``,
-# starting at ``{"thought":...}``. These rows teach the 0.8b base to emit a
+# starting at ``{"thought":...}``. These rows teach the 2B base to emit a
 # well-formed envelope so the ``format_ok`` gate stops measuring 0%. They are
 # shaped to match the runtime grammar's fixed key order and value kinds. (A
 # byte-exact generator that calls ``buildResponseGrammar``+``compilePrefillPlan``

--- a/packages/training/scripts/finetune_all_tiers.py
+++ b/packages/training/scripts/finetune_all_tiers.py
@@ -256,7 +256,7 @@ def finetune_tier(
 
 def main() -> int:
     ap = argparse.ArgumentParser(
-        description="Fine-tune all eliza-1 tiers (0.8b → 27b) with APOLLO SFT.",
+        description="Fine-tune all active eliza-1 tiers (2B → 27B) with APOLLO SFT.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     ap.add_argument(

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -361,7 +361,7 @@ describe("view switching — VIEWS action resolver", () => {
 	});
 
 	describe("model param hallucination — user's words win over a wrong view param", () => {
-		// A weak/local planner (the 0.8B) frequently emits VIEWS with a WRONG view
+		// A weak local planner can emit VIEWS with a WRONG view
 		// param (e.g. view:"wallet" for "open my calendar"). The user's own words
 		// are authoritative when they name a registered domain surface, so the
 		// hallucinated param must not mis-navigate. This is the "structured

--- a/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.test.ts
+++ b/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.test.ts
@@ -84,6 +84,11 @@ describe("benchmark_vs_cerebras runner", () => {
     expect(benchmarkVsCerebrasTierList("google/gemma-4-E2B")).toBe(
       "gemma4-e2b",
     );
-    expect(benchmarkVsCerebrasTierList("qwen3.5-2b")).toBe("gemma4-e2b");
+  });
+
+  it("rejects retired Qwen tier aliases instead of remapping them", () => {
+    expect(() => benchmarkVsCerebrasTierList("qwen3.5-2b")).toThrow(
+      /Qwen tier aliases are retired/,
+    );
   });
 });

--- a/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.ts
+++ b/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.ts
@@ -69,16 +69,18 @@ const TRAINING_TIER_KEYS: Record<string, string> = {
   "google-gemma-4-e4b": "gemma4-e4b",
   "google-gemma-4-12b": "gemma4-12b",
   "google-gemma-4-31b": "gemma4-31b",
-  "qwen3.5-2b": "gemma4-e2b",
-  "qwen3.5-4b": "gemma4-e4b",
-  "qwen3.5-9b": "gemma4-12b",
-  "qwen3.5-27b": "gemma4-31b",
-  "qwen3.6-27b": "gemma4-31b",
 };
+
+const RETIRED_QWEN_TIER_ALIAS_RE = /\bqwen(?:\d+(?:\.\d+)?)?\b/i;
 
 function normalizeTrainingTierKey(value: string): string {
   const trimmed = value.trim();
   const key = trimmed.toLowerCase().replace(/_/g, "-");
+  if (RETIRED_QWEN_TIER_ALIAS_RE.test(key)) {
+    throw new Error(
+      `Qwen tier aliases are retired; use an active Gemma 4 tier key instead (${ELIZA_ONE_BENCHMARK_TIER_LIST}).`,
+    );
+  }
   return (
     TRAINING_TIER_KEYS[key] ??
     TRAINING_TIER_KEYS[key.replace(/\//g, "-")] ??

--- a/plugins/plugin-training/src/optimizers/scoring.test.ts
+++ b/plugins/plugin-training/src/optimizers/scoring.test.ts
@@ -128,7 +128,7 @@ describe("scorePlannerAction — view-aware (the fix)", () => {
   });
 
   it("gives partial credit (0.5) for the right action but the wrong view", () => {
-    // This is the gap that made the 0.8B's wrong-view output look perfect.
+    // This is the gap that made entry-tier wrong-view output look perfect.
     expect(
       scorePlannerAction(
         '{"action":"VIEWS","parameters":{"view":"wallet"}}',

--- a/plugins/plugin-training/src/optimizers/scoring.ts
+++ b/plugins/plugin-training/src/optimizers/scoring.ts
@@ -218,7 +218,7 @@ export function extractPlannerView(text: string): string | null {
  * navigation target), a matching action alone is NOT full credit — the view has
  * to match too. Without this the optimizer can never learn correct view
  * selection, because every `VIEWS/<anything>` would score 1.0 against a
- * `VIEWS/calendar` reference (the exact gap that made the 0.8B's wrong-view
+ * `VIEWS/calendar` reference (the exact gap that made entry-tier wrong-view
  * outputs look perfect). Partial credit (right action, wrong/missing view =
  * 0.5) keeps a usable gradient for the optimizer. Expected outputs without a
  * view (every non-navigation action) are scored action-only, unchanged.


### PR DESCRIPTION
## Summary
- stop silently mapping retired `qwen3.5-*`/`qwen3.6-*` benchmark tier aliases to Gemma registry keys
- make the benchmark runner fail with a Gemma-tier guidance error for Qwen-like tier input
- update active training/app-control comments and help text from retired 0.8B wording to active 2B/entry-tier wording

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun test plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.test.ts plugins/plugin-training/src/optimizers/scoring.test.ts`
- `bunx vitest run plugins/plugin-app-control/src/actions/views-switching.test.ts`
- `python3 -m py_compile packages/training/scripts/finetune_all_tiers.py packages/training/scripts/build_eliza1_sft_2b.py`
- `git diff --check`
- `bun run verify` (530/530 Turbo tasks successful; build/typecheck audit passed)

Note: an initial direct `bun test` invocation including `views-switching.test.ts` failed because that file uses Vitest-specific `vi.hoisted`; the package-correct Vitest invocation passed 157/157 tests.

## PR evidence matrix
- Real LLM trajectory: N/A, tier alias validation and comments/help text only
- Backend logs: N/A, no runtime server path changed
- Frontend logs/screenshots/video: N/A, no UI behavior changed
- Audio/narration: N/A, no voice/audio path changed
