### PR TITLE
fix(training): align EOT LoRA helpers with Gemma

### DIFF
--- a/packages/training/scripts/voice/eot/DATASETS.md
+++ b/packages/training/scripts/voice/eot/DATASETS.md
@@ -117,7 +117,7 @@ each training cycle — the catalog moves.
 
 ## Recommended composition
 
-For training a robust EOT LoRA on `eliza-1-{0_8b, 2b, 4b}`:
+For training a robust EOT LoRA on `eliza-1-{2b, 4b}`:
 
 | Source | Mix | Why |
 |---|---:|---|

--- a/packages/training/scripts/voice/eot/RUNBOOK.md
+++ b/packages/training/scripts/voice/eot/RUNBOOK.md
@@ -17,7 +17,6 @@ turn-detector on the voice-assistant use case.
 |-------------------------|---------------------------|--------------------------------------------|
 | dataset audit           | minutes                   | Read `DATASETS.md`; pick mix.              |
 | prep_eot_corpus.py      | 5-30 min per 100k turns   | CPU-bound (tokenize + privacy filter).     |
-| train_eot_lora.py 0_8b  | 15-45 min @ 2000 steps    | RTX 4090: 20 min.                          |
 | train_eot_lora.py 2b    | 30-90 min @ 2000 steps    | RTX 4090: 45 min.                          |
 | train_eot_lora.py 4b    | 60-180 min @ 2000 steps   | RTX 4090: 90 min; drop --batch-size 2 on 16 GB cards. |
 | eval_eot_lora.py        | 5-20 min per classifier   | GPU; loads base + adapter + LiveKit GGUF.  |
@@ -27,7 +26,6 @@ Disk: ~3 GB per training run (checkpoints + processed corpus +
 TensorBoard logs). The adapter itself is 5-10 MB.
 
 VRAM at defaults (rank 8, batch tier-default, seq 512):
-- 0.8B target → ~6 GB
 - 2B target → ~12 GB
 - 4B target → ~20 GB (fits 24 GB consumer GPU)
 
@@ -87,33 +85,33 @@ python3 packages/training/scripts/voice/eot/prep_eot_corpus.py \
 
 # 4. Train one tier at a time. Start with the smallest.
 python3 packages/training/scripts/voice/eot/train_eot_lora.py \
-    --tier 0_8b \
+    --tier 2b \
     --corpus "$RUN/corpus/train.parquet" \
-    --out-dir "$RUN/outputs/0_8b" \
+    --out-dir "$RUN/outputs/2b" \
     --epochs 1 \
-    --batch-size 8
+    --batch-size 4
 
 # 5. Eval against LiveKit baseline + heuristic.
 LIVEKIT_GGUF=~/.eliza/local-inference/models/voice/turn-detector/onnx/turn-detector-en-q8.gguf
 python3 packages/training/scripts/voice/eot/eval_eot_lora.py \
     --eval-corpus "$RUN/corpus/eval.parquet" \
-    --lora-adapter "$RUN/outputs/0_8b/checkpoint-final" \
-    --lora-base "Qwen/Qwen3.5-0.8B-Base" \
+    --lora-adapter "$RUN/outputs/2b/checkpoint-final" \
+    --lora-base "google/gemma-4-E2B" \
     --livekit-gguf "$LIVEKIT_GGUF" \
-    --out "$RUN/reports/eval-0_8b.json"
+    --out "$RUN/reports/eval-2b.json"
 
 # exit 0 = gates passed → publishable
-# exit 1 = gates failed → read $RUN/reports/eval-0_8b.json, iterate
+# exit 1 = gates failed → read $RUN/reports/eval-2b.json, iterate
 
 # 6. (Optional) publish adapter to HF. The HF_TOKEN at
 #    ~/.huggingface/token must have write scope to the elizaos org.
 huggingface-cli upload elizaos/eliza-1-voice-eot \
-    "$RUN/outputs/0_8b/checkpoint-final" \
-    "0_8b/" \
+    "$RUN/outputs/2b/checkpoint-final" \
+    "2b/" \
     --repo-type model
 ```
 
-Repeat steps 4-5 for tiers `2b` and `4b`.
+Repeat steps 4-5 for tier `4b`.
 
 ## Failure modes
 

--- a/packages/training/scripts/voice/eot/__init__.py
+++ b/packages/training/scripts/voice/eot/__init__.py
@@ -3,7 +3,7 @@
 End-to-end recipe for producing a tiny LoRA adapter that hot-swaps onto
 the already-loaded eliza-1 chat model at runtime. Reads the next-token
 distribution after the partial user transcript and uses
-P(`<|im_end|>`) as the turn-completion probability — same signal the
+P(`<end_of_turn>`) as the turn-completion probability — same signal the
 LiveKit ONNX turn-detector provides, but at zero extra RAM and zero
 extra download (the chat model is loaded anyway for conversation).
 

--- a/packages/training/scripts/voice/eot/eval_eot_lora.py
+++ b/packages/training/scripts/voice/eot/eval_eot_lora.py
@@ -279,7 +279,7 @@ def score_with_lora(
     base_id: str,
     adapter_path: Path,
 ) -> tuple[list[float], list[float]]:
-    """LoRA-on-eliza-1 path: load base + attach adapter, read P(im_end)."""
+    """LoRA-on-eliza-1 path: load base + attach adapter, read P(EOT)."""
     import torch  # type: ignore
     from peft import PeftModel  # type: ignore
     from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
@@ -294,10 +294,7 @@ def score_with_lora(
     model = PeftModel.from_pretrained(model, str(adapter_path))
     model.eval()
 
-    im_end_id = tokenizer.encode("<|im_end|>", add_special_tokens=False)
-    if len(im_end_id) != 1:
-        raise RuntimeError(f"expected <|im_end|> to be 1 token, got {len(im_end_id)}")
-    im_end_id = im_end_id[0]
+    eot_id = _resolve_eot_token_id(tokenizer)
 
     scores: list[float] = []
     latencies: list[float] = []
@@ -308,9 +305,24 @@ def score_with_lora(
             out = model(**encoded)
             logits = out.logits[0, -1]  # last-position
             probs = torch.softmax(logits, dim=-1)
-            scores.append(float(probs[im_end_id].item()))
+            scores.append(float(probs[eot_id].item()))
             latencies.append((time.perf_counter() - start) * 1000)
     return scores, latencies
+
+
+def _resolve_eot_token_id(tokenizer) -> int:
+    """Find the Gemma `<end_of_turn>` token id in the loaded tokenizer."""
+    for candidate in ("<end_of_turn>", "&lt;end_of_turn&gt;"):
+        ids = tokenizer.convert_tokens_to_ids(candidate)
+        if isinstance(ids, int) and ids >= 0:
+            return ids
+    encoded = tokenizer.encode("<end_of_turn>", add_special_tokens=False)
+    if encoded and len(encoded) == 1:
+        return encoded[0]
+    raise RuntimeError(
+        "could not resolve <end_of_turn> in tokenizer; ensure the base "
+        "model uses the Gemma chat template."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -367,7 +379,7 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--lora-base",
-        help="HF id of the base model the LoRA was trained on (e.g. Qwen/Qwen3.5-0.8B-Base).",
+        help="HF id of the base model the LoRA was trained on (e.g. google/gemma-4-E2B).",
     )
     parser.add_argument(
         "--livekit-gguf",

--- a/packages/training/scripts/voice/eot/prep_eot_corpus.py
+++ b/packages/training/scripts/voice/eot/prep_eot_corpus.py
@@ -3,13 +3,13 @@
 
 Reads conversations from canonical formats (subtitle SRT, JSONL with
 `turns: [...]`, scenario YAML, plain dialog), formats them with the
-Qwen-style chat template the LiveKit turn-detector uses, and emits
+Gemma chat template the eliza-1 chat model uses, and emits
 `(transcript_so_far, label_eot)` pairs:
 
   - positive (label=1): the transcript ends at a complete user turn
-    boundary (the natural place an `<|im_end|>` token would follow).
+    boundary (the natural place an `<end_of_turn>` token would follow).
   - negative (label=0): the transcript is chopped mid-token at a
-    random boundary inside a user turn (no `<|im_end|>` would follow).
+    random boundary inside a user turn (no `<end_of_turn>` would follow).
 
 Output: Parquet (preferred) or JSONL with columns
   `(text: str, label: int, source: str, conversation_id: str)`.
@@ -39,18 +39,18 @@ logger = logging.getLogger("eot.prep_eot_corpus")
 # Chat template
 # ---------------------------------------------------------------------------
 
-QWEN_USER_START = "<|im_start|>user\n"
-QWEN_USER_END = "<|im_end|>"
-QWEN_NL = "\n"
+GEMMA_USER_START = "<start_of_turn>user\n"
+GEMMA_USER_END = "<end_of_turn>"
+GEMMA_NL = "\n"
 
 
-def apply_qwen_user_template(text: str) -> str:
-    """Format `text` as the LiveKit turn-detector does.
+def apply_gemma_user_template(text: str) -> str:
+    """Format `text` as the Gemma chat model does.
 
-    The detector reads `P(<|im_end|>)` from the next-token distribution
-    *after* the trailing newline; do NOT append `<|im_end|>` here.
+    The detector reads `P(<end_of_turn>)` from the next-token distribution
+    *after* the trailing newline; do NOT append `<end_of_turn>` here.
     """
-    return f"{QWEN_USER_START}{text}{QWEN_NL}"
+    return f"{GEMMA_USER_START}{text}{GEMMA_NL}"
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +301,7 @@ def build_corpus(
                 # Positive: full turn, formatted with chat template.
                 out.append(
                     EotRecord(
-                        text=apply_qwen_user_template(turn),
+                        text=apply_gemma_user_template(turn),
                         label=1,
                         source=source_name,
                         conversation_id=convo_id,
@@ -321,7 +321,7 @@ def build_corpus(
                         continue
                     out.append(
                         EotRecord(
-                            text=apply_qwen_user_template(chopped),
+                            text=apply_gemma_user_template(chopped),
                             label=0,
                             source=source_name,
                             conversation_id=convo_id,

--- a/packages/training/scripts/voice/eot/test_eot_lora_gemma.py
+++ b/packages/training/scripts/voice/eot/test_eot_lora_gemma.py
@@ -1,0 +1,40 @@
+"""CPU-only invariants for the Gemma EOT LoRA helper scripts."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.voice.eot.prep_eot_corpus import apply_gemma_user_template
+from scripts.voice.eot.train_eot_lora import (
+    TIER_REGISTRY,
+    eot_loss_weights,
+    resolve_tier,
+)
+
+
+def test_eot_lora_tiers_are_active_gemma_bases() -> None:
+    assert set(TIER_REGISTRY) == {"2b", "4b"}
+    assert all(spec.base_id.startswith("google/gemma-4-") for spec in TIER_REGISTRY.values())
+    assert "0_8b" not in TIER_REGISTRY
+    with pytest.raises(SystemExit, match="unknown tier"):
+        resolve_tier("0_8b")
+
+
+def test_gemma_user_template_leaves_end_token_as_training_target() -> None:
+    text = apply_gemma_user_template("hello there")
+    assert text == "<start_of_turn>user\nhello there\n"
+    assert "<end_of_turn>" not in text
+    assert "<|im_" not in text
+
+
+def test_eot_loss_weights_target_gemma_end_of_turn_token() -> None:
+    assert eot_loss_weights(label=1, eot_token_id=42, vocab_size=100) == {
+        "target_token": 42.0,
+        "weight": 1.0,
+        "mode": "positive",
+    }
+    assert eot_loss_weights(label=0, eot_token_id=42, vocab_size=100) == {
+        "target_token": -1.0,
+        "weight": pytest.approx(1.0 / 99),
+        "mode": "negative",
+    }

--- a/packages/training/scripts/voice/eot/train_eot_lora.py
+++ b/packages/training/scripts/voice/eot/train_eot_lora.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 """Train an eliza-1 EOT LoRA adapter.
 
-Tiny LoRA (rank 8, alpha 16) on the eliza-1 chat target. The adapter
-hot-swaps onto the already-loaded chat model at runtime via llama.cpp's
-`--lora` flag; zero extra weights, zero extra RAM, zero extra download.
+Tiny LoRA (rank 8, alpha 16) on active Gemma 4 eliza-1 chat targets.
+The adapter hot-swaps onto the already-loaded chat model at runtime via
+llama.cpp's `--lora` flag; zero extra weights, zero extra RAM, zero extra
+download.
 
 Loss:
   - positive examples (label=1): cross-entropy maximizing the next-token
-    probability of `<|im_end|>` after the chat-template-formatted user
+    probability of `<end_of_turn>` after the chat-template-formatted user
     turn (= P(turn complete | transcript)).
-  - negative examples (label=0): cross-entropy minimizing P(<|im_end|>)
-    by maximizing the probability of any non-`<|im_end|>` continuation
+  - negative examples (label=0): cross-entropy minimizing P(<end_of_turn>)
+    by maximizing the probability of any non-`<end_of_turn>` continuation
     token. Implemented as cross-entropy against a uniform distribution
     over the non-eot logits (smoothed).
 
-Optimizer choice — APOLLO vs 8-bit AdamW:
+Optimizer choice — APOLLO vs plain AdamW:
 
   CLAUDE.md mandates APOLLO for training. APOLLO's win is memory:
   it stores low-rank projected optimizer state in place of the full
@@ -24,14 +25,13 @@ Optimizer choice — APOLLO vs 8-bit AdamW:
   for those params is also tiny, and APOLLO's projection overhead
   outweighs the memory saving.
 
-  Decision: use 8-bit AdamW for LoRA training. APOLLO is the right
+  Decision: use plain AdamW for LoRA training. APOLLO is the right
   call when --apollo is passed explicitly (preserved for benchmarking
-  / for future full-param fine-tunes). Default is 8-bit AdamW.
+  / for future full-param fine-tunes). Default is plain AdamW.
 
-Memory budget at default settings (rank 8, batch 4, seq 512):
-  - eliza-1-0_8b: ~6 GB VRAM
+Memory budget at default settings (rank 8, tier-default batch, seq 512):
   - eliza-1-2b:   ~12 GB VRAM
-  - eliza-1-4b:   ~20 GB VRAM (fits 24 GB consumer GPU)
+  - eliza-1-4b:   ~20 GB VRAM (fits 24 GB consumer GPU at batch 2)
 
 For 16 GB cards, drop `--batch-size 2` and `--gradient-accumulation 2`.
 """
@@ -47,6 +47,12 @@ from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger("eot.train_eot_lora")
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from training.model_registry import get as get_model_entry  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Target tier registry
@@ -70,22 +76,16 @@ class TierSpec:
 
 
 TIER_REGISTRY: dict[str, TierSpec] = {
-    "0_8b": TierSpec(
-        tier="0_8b",
-        base_id="Qwen/Qwen3.5-0.8B-Base",
-        default_batch_size=8,
-        default_seq_len=512,
-    ),
     "2b": TierSpec(
         tier="2b",
-        base_id="Qwen/Qwen3.5-2B-Base",
+        base_id=get_model_entry("eliza-1-2b").hf_id,
         default_batch_size=4,
         default_seq_len=512,
     ),
     "4b": TierSpec(
         tier="4b",
-        base_id="Qwen/Qwen3.5-4B-Base",
-        default_batch_size=4,
+        base_id=get_model_entry("eliza-1-4b").hf_id,
+        default_batch_size=2,
         default_seq_len=512,
     ),
 }
@@ -151,7 +151,7 @@ class TrainingConfig:
 
 def eot_loss_weights(
     label: int,
-    im_end_token_id: int,
+    eot_token_id: int,
     vocab_size: int,
 ) -> dict[str, float]:
     """Compute per-token weight scheme for the EOT objective.
@@ -160,23 +160,23 @@ def eot_loss_weights(
     example. Pure function — no torch import here so it can run in the
     pytest CPU lane.
 
-    For label=1 (positive): full weight on `im_end_token_id`. The
-    cross-entropy loss is `-log P(im_end_token_id | context)`.
+    For label=1 (positive): full weight on `eot_token_id`. The
+    cross-entropy loss is `-log P(eot_token_id | context)`.
 
-    For label=0 (negative): zero weight on `im_end_token_id` plus
+    For label=0 (negative): zero weight on `eot_token_id` plus
     uniform weight `1/(vocab_size-1)` over every other token. The
-    cross-entropy loss is `-mean log P(non-im-end | context)`, which
-    pushes probability mass away from `<|im_end|>`.
+    cross-entropy loss is `-mean log P(non-EOT | context)`, which
+    pushes probability mass away from `<end_of_turn>`.
     """
     if label not in (0, 1):
         raise ValueError(f"label must be 0 or 1, got {label}")
-    if im_end_token_id < 0 or im_end_token_id >= vocab_size:
+    if eot_token_id < 0 or eot_token_id >= vocab_size:
         raise ValueError(
-            f"im_end_token_id={im_end_token_id} out of range for vocab_size={vocab_size}"
+            f"eot_token_id={eot_token_id} out of range for vocab_size={vocab_size}"
         )
     if label == 1:
-        return {"target_token": float(im_end_token_id), "weight": 1.0, "mode": "positive"}
-    # Negative: smear over non-im-end vocabulary.
+        return {"target_token": float(eot_token_id), "weight": 1.0, "mode": "positive"}
+    # Negative: smear over non-EOT vocabulary.
     return {
         "target_token": -1.0,  # sentinel: not a single-token target
         "weight": 1.0 / (vocab_size - 1),
@@ -189,19 +189,19 @@ def eot_loss_weights(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_im_end_token_id(tokenizer) -> int:
-    """Find the `<|im_end|>` token id in the loaded tokenizer."""
-    for candidate in ("<|im_end|>", "&lt;|im_end|&gt;"):
+def _resolve_eot_token_id(tokenizer) -> int:
+    """Find the Gemma `<end_of_turn>` token id in the loaded tokenizer."""
+    for candidate in ("<end_of_turn>", "&lt;end_of_turn&gt;"):
         ids = tokenizer.convert_tokens_to_ids(candidate)
         if isinstance(ids, int) and ids >= 0:
             return ids
     # Fall back to the chat-template-specific encoding.
-    encoded = tokenizer.encode("<|im_end|>", add_special_tokens=False)
+    encoded = tokenizer.encode("<end_of_turn>", add_special_tokens=False)
     if encoded and len(encoded) == 1:
         return encoded[0]
     raise RuntimeError(
-        "could not resolve <|im_end|> in tokenizer; ensure the base "
-        "model uses the Qwen chat template (Qwen3.5 family)."
+        "could not resolve <end_of_turn> in tokenizer; ensure the base "
+        "model uses the Gemma chat template."
     )
 
 
@@ -262,9 +262,9 @@ def train(config: TrainingConfig) -> Path:
         trust_remote_code=False,
     ).to(device)
 
-    im_end_id = _resolve_im_end_token_id(tokenizer)
+    eot_id = _resolve_eot_token_id(tokenizer)
     vocab_size = int(model.config.vocab_size)
-    logger.info("<|im_end|> token id=%d vocab=%d", im_end_id, vocab_size)
+    logger.info("<end_of_turn> token id=%d vocab=%d", eot_id, vocab_size)
 
     lora_cfg = PeftLoraConfig(
         r=config.lora.rank,
@@ -316,7 +316,7 @@ def train(config: TrainingConfig) -> Path:
                 logits=logits,
                 last_token_idx=last_token_idx,
                 labels=labels,
-                im_end_id=im_end_id,
+                eot_id=eot_id,
                 vocab_size=vocab_size,
                 device=model.device,
             )
@@ -390,7 +390,7 @@ def _iter_batches(records, batch_size, tokenizer, seq_len):
         }
 
 
-def _eot_batch_loss(logits, last_token_idx, labels, im_end_id, vocab_size, device):
+def _eot_batch_loss(logits, last_token_idx, labels, eot_id, vocab_size, device):
     """Compute the EOT loss across a batch.
 
     bf16 logits can produce inf/nan through log_softmax — we cast to fp32
@@ -410,16 +410,16 @@ def _eot_batch_loss(logits, last_token_idx, labels, im_end_id, vocab_size, devic
     losses = []
     for i in range(batch_size):
         if labels[i].item() == 1:
-            # Positive: maximize log P(im_end). Clamp to avoid -inf when
+            # Positive: maximize log P(EOT). Clamp to avoid -inf when
             # the model assigns vanishing mass.
-            log_p_im_end = log_probs[i, im_end_id].clamp(min=-30.0)
-            losses.append(-log_p_im_end)
+            log_p_eot = log_probs[i, eot_id].clamp(min=-30.0)
+            losses.append(-log_p_eot)
         else:
-            # Negative: minimize P(im_end) by maximizing log P(not im_end).
-            #   log P(not im_end) = log(1 - exp(log_probs[im_end]))
-            log_p_im_end = log_probs[i, im_end_id].clamp(min=-30.0, max=-1e-6)
-            log_p_not_im_end = torch.log1p(-torch.exp(log_p_im_end).clamp(max=0.999999))
-            losses.append(-log_p_not_im_end)
+            # Negative: minimize P(EOT) by maximizing log P(not EOT).
+            #   log P(not EOT) = log(1 - exp(log_probs[EOT]))
+            log_p_eot = log_probs[i, eot_id].clamp(min=-30.0, max=-1e-6)
+            log_p_not_eot = torch.log1p(-torch.exp(log_p_eot).clamp(max=0.999999))
+            losses.append(-log_p_not_eot)
 
     stacked = torch.stack(losses)
     # Filter per-example non-finite losses; mean over the survivors.
@@ -497,7 +497,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         "batch_size": config.batch_size,
         "learning_rate": config.learning_rate,
         "seed": config.seed,
-        "optimizer": "APOLLOAdamW" if config.use_apollo else "AdamW8bit",
+        "optimizer": "APOLLOAdamW" if config.use_apollo else "AdamW",
     }
     (checkpoint / "eot_lora_manifest.json").write_text(
         json.dumps(manifest, indent=2), encoding="utf-8"


### PR DESCRIPTION
## Summary
- move the EOT LoRA training tier registry to active Gemma 4 2b/4b bases from the canonical model registry
- switch the LoRA training/eval objective and corpus prep template to Gemma `<end_of_turn>` / `<start_of_turn>` tokens
- update the EOT operator docs away from retired `0_8b` / Qwen examples and add CPU-only regression coverage

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m py_compile packages/training/scripts/voice/eot/train_eot_lora.py packages/training/scripts/voice/eot/eval_eot_lora.py packages/training/scripts/voice/eot/prep_eot_corpus.py packages/training/scripts/voice/eot/test_eot_lora_gemma.py`
- `python3 -m pytest packages/training/scripts/voice/eot/test_eot_lora_gemma.py -q`
- `git diff --check`
- `bun run verify` (530/530 Turbo tasks successful; build/typecheck audit passed)

UI/media evidence: N/A, training script/docs-only change outside `packages/app`.
