### PR TITLE
docs(training): refresh Gemma tier comments

### DIFF
--- a/packages/training/scripts/quantization/README.md
+++ b/packages/training/scripts/quantization/README.md
@@ -174,7 +174,7 @@ fp16 to keep the freshly-generated context lossless.
   Shannon-Bennett lower bound.
 - **Cons.** The reference implementation is pure PyTorch — the
   per-step quantize/dequantize is a Python-level operation per layer
-  per step, which costs throughput. On a 0.8B model on a 5080 we
+  per step, which costs throughput. On a gemma-4-E2B model on a 5080 we
   observed **~5× slowdown** vs the bf16 ``DynamicCache``
   (66.8 → 12.2 tok/s). The TurboQuant paper claims faster runtime than
   the bf16 baseline because it ships **Triton kernels**; those are not

--- a/packages/training/scripts/train_nebius.sh
+++ b/packages/training/scripts/train_nebius.sh
@@ -11,7 +11,7 @@
 # `"default"`-subnet shape is gone.
 #
 # Flow: provision a Nebius VM (single H200 SXM `gpu-h200-sxm` / `1gpu-16vcpu-200gb`
-# for the 0.6b/1.7b/4b/9b tiers; the 8×H200 `8gpu-128vcpu-1600gb` preset + FSDP
+# for the active 2b/4b/9b tiers; the 8×H200 `8gpu-128vcpu-1600gb` preset + FSDP
 # for 27b — that preset is expensive, see the note below), boot-disk from the
 # `mk8s-worker-node-v-1-31-ubuntu24.04-cuda12.8` public image (NVIDIA 570.x +
 # CUDA 12.8 preinstalled), rsync `packages/training/` + the training corpus,
@@ -380,7 +380,7 @@ export CUDA_VISIBLE_DEVICES=0
 # back to CPU placement (the model then trains single-threaded on CPU at ~10
 # s/it with the GPU at 0% util holding only unused optimizer states) — tell
 # train_local.py to skip device_map and .to() the GPU explicitly. (native_tool_call_bench.py
-# still runs on CPU here — see the §11 caveat in the 0_6b report; --skip-base-bench
+# still runs on CPU here — see the §11 caveat in the legacy CPU-bench report; --skip-base-bench
 # from BENCHMARK_AFTER=0 avoids the base pass, the finetuned pass is ~3h CPU.)
 export ELIZA_NO_DEVICE_MAP=1
 export HF_HOME=/opt/hf-cache


### PR DESCRIPTION
## Summary
- refresh stale training comments that still described retired 0.6B/0.8B sizing as active
- keep legacy-named dataset/report paths unchanged where they are compatibility inputs
- update quantization throughput wording to reference the active Gemma 2B tier

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bash -n packages/training/scripts/train_nebius.sh`
- `python3 -m pytest packages/training/scripts/test_train_nebius_smoke_all_tiers.py -q` (11 passed)
- `git diff --check`
- `bun run verify` (530/530 successful, audit-build-typecheck passed)

## UI evidence
N/A: documentation/comment-only training script cleanup; no `packages/app` UI behavior changed.
