### PR TITLE
docs(training): refresh active Gemma script wording

### DIFF
--- a/packages/training/scripts/dump_registry_json.py
+++ b/packages/training/scripts/dump_registry_json.py
@@ -3,7 +3,7 @@
 Imports ``model_registry`` (which has no torch/transformers deps) and writes
 the canonical fields the TypeScript runtime resolver mirrors. Keyed by the
 ``eliza_short_name`` so the consumer doesn't need to know our internal
-``qwenX.Y-Nb`` keys.
+``gemma4-*`` registry keys.
 
 Usage (from training/):
     uv run python scripts/dump_registry_json.py

--- a/packages/training/scripts/lib/adapters.py
+++ b/packages/training/scripts/lib/adapters.py
@@ -3713,7 +3713,7 @@ def claude_distill(records: Iterator[dict], *, slug: str, license: str,
 
     We preserve the assistant content **verbatim** in `expectedResponse`
     without re-encoding so the student model learns the exact `<think>`
-    surface that the active Qwen3.5/Qwopus generation pipeline expects.
+    surface that the active reasoning generation pipeline expects.
 
     The `messages` array is rendered into `memoryEntries` + `currentMessage`
     + `expectedResponse` so `tokenizer.apply_chat_template(...)` produces

--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -250,9 +250,9 @@ def main() -> int:
         "--micro-batch", type=int, default=0,
         help="Per-device micro-batch size for SFT (forwarded to "
              "train_local.py --batch-size). 0 = use the registry default for "
-             "the tier. Per benchmarks/APOLLO_TUNING.md, --micro-batch 2 "
-             "--grad-accum 4 keeps the 0.6B GPU occupied at zero quality cost "
-             "(same effective batch); validate VRAM with memory_calc.py first.",
+             "the tier. For Gemma E2B/E4B overrides, keep the effective batch "
+             "stable with --grad-accum and validate VRAM with memory_calc.py "
+             "first.",
     )
     ap.add_argument(
         "--grad-accum", type=int, default=0,


### PR DESCRIPTION
## Summary
- remove a stale 0.6B/APOLLO_TUNING reference from the active `run_pipeline.py` help text
- update the registry JSON dumper docstring to describe the active `gemma4-*` registry keys
- make the Claude distill adapter comment model-agnostic instead of naming the retired Qwen path

## Evidence
- `git fetch origin`
- `git rebase origin/develop`
- `bun install`
- `python3 -m py_compile packages/training/scripts/run_pipeline.py packages/training/scripts/dump_registry_json.py packages/training/scripts/lib/adapters.py`
- `python3 -m pytest packages/training/scripts/test_train_nebius_smoke_all_tiers.py packages/training/scripts/training/test_model_registry.py -q` (29 passed)
- `python3 packages/training/scripts/dump_registry_json.py` (emits Gemma-backed eliza-1 tiers)
- `git diff --check`
- `bun run verify` (530/530 successful, audit-build-typecheck passed)

## UI evidence
N/A: training script text/docstring cleanup only; no `packages/app` UI behavior changed.
