### PR TITLE
fix(agent): use Gemma turns for mobile local chat

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -385,6 +385,10 @@ describe("generateChatResponse token streaming", () => {
     const directParams = useModel.mock.calls[0]?.[1] as { prompt?: string };
     expect(directParams.prompt).not.toContain("/no_think");
     expect(directParams.prompt).toContain("can you hear me locally?");
+    expect(directParams.prompt).toContain("<start_of_turn>user\n");
+    expect(directParams.prompt).toContain("<end_of_turn>\n");
+    expect(directParams.prompt).toContain("<start_of_turn>model\n");
+    expect(directParams.prompt).not.toContain("<|im_start|>");
 
     expect(useModel).toHaveBeenCalledWith(
       expect.anything(),
@@ -392,6 +396,7 @@ describe("generateChatResponse token streaming", () => {
         stream: true,
         maxTokens: 20,
         prompt: expect.stringContaining("<think>\n\n</think>\n"),
+        stopSequences: ["<end_of_turn>", "<start_of_turn>"],
         providerOptions: expect.objectContaining({
           androidLocal: expect.objectContaining({
             minFirstSentenceChars: 12,

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -374,6 +374,8 @@ function shouldUseAndroidLocalDirectChat(
 
 function escapeAndroidLocalChatTemplateTokens(text: string): string {
   return text
+    .replaceAll("<start_of_turn>", "< start_of_turn >")
+    .replaceAll("<end_of_turn>", "< end_of_turn >")
     .replaceAll("<|im_start|>", "<| im_start |>")
     .replaceAll("<|im_end|>", "<| im_end |>")
     .replaceAll("<think>", "< think >")
@@ -398,14 +400,13 @@ function buildAndroidLocalDirectChatPrompt(args: {
     "No markdown, labels, tools, logs, or hidden reasoning.",
   ].join("\n");
   return [
-    "<|im_start|>system",
+    "<start_of_turn>user",
     systemText,
-    "<|im_end|>",
-    "<|im_start|>user",
+    "",
     escapeAndroidLocalChatTemplateTokens(args.userText),
-    "<|im_end|>",
-    "<|im_start|>assistant",
-    // Match llama.cpp's thinking-disabled chat-template shape.
+    "<end_of_turn>",
+    "<start_of_turn>model",
+    // Match the Gemma thinking-disabled chat-template shape.
     // The direct mobile path is for short voice/chat replies; pre-filling an
     // empty think block prevents the model from spending its first tokens on
     // hidden `<think>...</think>` scaffolding before any speakable text.
@@ -468,9 +469,11 @@ function stripAndroidLocalReasoning(text: string): string {
 function cleanAndroidLocalDirectChatReply(raw: unknown): string {
   let text = stripAndroidLocalReasoning(extractAndroidLocalModelText(raw));
   text = text
+    .split("<end_of_turn>")[0]
+    .split("<start_of_turn>")[0]
     .split("<|im_end|>")[0]
     .split("<|im_start|>")[0]
-    .replace(/^\s*(assistant|eliza)\s*:\s*/i, "")
+    .replace(/^\s*(assistant|model|eliza)\s*:\s*/i, "")
     .replace(/\bEliza-1\b/gi, "Eliza-1")
     .trim();
   text = truncateAndroidLocalReplyToFirstSentence(text);
@@ -612,7 +615,7 @@ async function maybeGenerateAndroidLocalDirectChatResponse(args: {
   const raw = await args.runtime.useModel(ModelType.TEXT_SMALL, {
     prompt,
     maxTokens,
-    stopSequences: ["<|im_end|>", "<|im_start|>"],
+    stopSequences: ["<end_of_turn>", "<start_of_turn>"],
     temperature: 0,
     providerOptions: {
       eliza: {


### PR DESCRIPTION
## Summary
- switch the mobile local direct chat fast path from hand-built ChatML tokens to Gemma `<start_of_turn>` / `<end_of_turn>` prompt turns
- update stop sequences to Gemma turn tokens while keeping old ChatML cleanup as defensive stale-output handling
- cover the Android streaming direct path so it asserts the Gemma prompt shape and stop tokens

## Evidence
- `git fetch origin`
- `git rebase origin/develop` (rebased cleanly after `origin/develop` advanced)
- `bun install`
- `bun test packages/agent/src/api/__tests__/conversation-streaming.test.ts` (15 passed)
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/agent lint`
- `git diff --check`
- `bun run verify` (530/530 successful, audit-build-typecheck passed) after the final rebase

## UI evidence
N/A: backend prompt-template change in `packages/agent`; no `packages/app` UI behavior changed.
