### PR TITLE
fix(app-core): use Gemma prompt for Android LLM self-test

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoicePlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaVoicePlugin.java
@@ -198,7 +198,7 @@ public class ElizaVoicePlugin extends Plugin {
         if (!ensureLoadedOrReject(call)) return;
         String bundleDir = resolveBundleDir(call.getString("bundleDir"));
         String prompt = call.getString("prompt",
-            "<|im_start|>user\nWrite one sentence about the ocean.<|im_end|>\n<|im_start|>assistant\n");
+            "<start_of_turn>user\nWrite one sentence about the ocean.<end_of_turn>\n<start_of_turn>model\n");
         Integer maxTokens = call.getInt("maxTokens", 48);
         try {
             String json = ElizaVoiceNative.nativeLlmSelfTest(


### PR DESCRIPTION
## Summary
- switch the Android native LLM self-test default prompt from ChatML to Gemma turn tokens
- keep the legacy Qwen-ASR/OmniVoice fusion path untouched because that code path is ASR-specific and opt-in/legacy

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app-core lint`
- `git diff --check`
- `bun run verify` (530/530 tasks successful; audit-build-typecheck passed)

UI evidence: N/A, Android native LLM self-test prompt only; no `packages/app` UI behavior changed.
