### PR TITLE
fix(training): use Gemma stops in Ollama Modelfiles

### DIFF
--- a/packages/training/cloud/ollama/Modelfile.eliza-1-27b-q4_k_m
+++ b/packages/training/cloud/ollama/Modelfile.eliza-1-27b-q4_k_m
@@ -24,8 +24,8 @@ FROM hf.co/elizaos/eliza-1:bundles/27b/text/eliza-1-27b-32k.gguf
 
 SYSTEM """You are Eliza, an autonomous AI agent powered by elizaOS. You are helpful, concise, and grounded in the user's task. Use tools when they make the task tractable; otherwise answer directly."""
 
-PARAMETER stop "<|im_start|>"
-PARAMETER stop "<|im_end|>"
+PARAMETER stop "<end_of_turn>"
+PARAMETER stop "<start_of_turn>"
 PARAMETER stop "<|endoftext|>"
 
 # 27B at 32k is the safe default for 32 GB cards; push to 64k on 48 GB+.

--- a/packages/training/cloud/ollama/Modelfile.eliza-1-2b-q4_k_m
+++ b/packages/training/cloud/ollama/Modelfile.eliza-1-2b-q4_k_m
@@ -25,9 +25,9 @@ FROM hf.co/elizaos/eliza-1:bundles/2b/text/eliza-1-2b-32k.gguf
 # bare `ollama run eliza-1-2b` returns sane behavior.
 SYSTEM """You are Eliza, an autonomous AI agent powered by elizaOS. You are helpful, concise, and grounded in the user's task. Use tools when they make the task tractable; otherwise answer directly."""
 
-# Eliza-1 chat template uses the standard ChatML stop tokens.
-PARAMETER stop "<|im_start|>"
-PARAMETER stop "<|im_end|>"
+# Eliza-1 Gemma chat template uses Gemma turn stop tokens.
+PARAMETER stop "<end_of_turn>"
+PARAMETER stop "<start_of_turn>"
 PARAMETER stop "<|endoftext|>"
 
 # Context: 32k is the comfortable serving target on a 16 GB GPU at

--- a/packages/training/cloud/ollama/Modelfile.eliza-1-9b-q4_k_m
+++ b/packages/training/cloud/ollama/Modelfile.eliza-1-9b-q4_k_m
@@ -22,8 +22,8 @@ FROM hf.co/elizaos/eliza-1:bundles/9b/text/eliza-1-9b-32k.gguf
 
 SYSTEM """You are Eliza, an autonomous AI agent powered by elizaOS. You are helpful, concise, and grounded in the user's task. Use tools when they make the task tractable; otherwise answer directly."""
 
-PARAMETER stop "<|im_start|>"
-PARAMETER stop "<|im_end|>"
+PARAMETER stop "<end_of_turn>"
+PARAMETER stop "<start_of_turn>"
 PARAMETER stop "<|endoftext|>"
 
 # 9B handles longer context comfortably on workstation cards; default to

--- a/packages/training/cloud/ollama/README.md
+++ b/packages/training/cloud/ollama/README.md
@@ -12,7 +12,7 @@ public consolidated `elizaos/eliza-1` bundle repo on HuggingFace.
 ## Build
 
 Each Modelfile ships with the canonical Eliza system prompt, the
-ChatML stop tokens used by Eliza-1, and per-size context /
+Gemma turn stop tokens used by Eliza-1, and per-size context /
 sampling defaults.
 
 ```bash


### PR DESCRIPTION
## Summary
- replace ChatML stop tokens in the Eliza-1 Ollama Modelfiles with Gemma turn stops
- update the Ollama README wording from ChatML stops to Gemma turn stops

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `rg -n "(ChatML|<\\|im_start\\||<\\|im_end\\|>)" packages/training/cloud/ollama` (no matches)
- `git diff --check origin/develop...HEAD`
- `bun run verify` (530/530 tasks successful; `audit-build-typecheck` passed)

UI evidence: N/A, training cloud Ollama text templates only; no `packages/app` UI behavior changed.
