### PR TITLE
fix(gemma): update native bun llama smoke prompt

### DIFF
--- a/plugins/plugin-native-bun-runtime/ios/Tests/llama-bridge-smoke-main.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Tests/llama-bridge-smoke-main.swift
@@ -65,11 +65,11 @@ struct LlamaSmoke {
         fflush(stdout)
         let genResult = impl.generate(
             contextId: contextId,
-            prompt: "<|im_start|>user\nSay hello in one short sentence.<|im_end|>\n<|im_start|>assistant\n",
+            prompt: "<start_of_turn>user\nSay hello in one short sentence.<end_of_turn>\n<start_of_turn>model\n",
             maxTokens: 64,
             temperature: 0.7,
             topP: 0.9,
-            stopSequences: ["<|im_end|>"],
+            stopSequences: ["<end_of_turn>", "<start_of_turn>"],
             onToken: { tok, last in
                 if !last {
                     print(tok, terminator: "")


### PR DESCRIPTION
## Summary
- update the native Bun runtime iOS `llama-bridge-smoke-main.swift` prompt from ChatML to Gemma turn tokens
- switch the manual smoke stop sequence from `<|im_end|>` to Gemma turn boundaries

## Evidence
- `git fetch origin`
- `git rebase origin/develop`
- `bun install`
- `bun run --cwd plugins/plugin-native-bun-runtime test` -> 1 file passed, 16 tests passed
- `bun run --cwd plugins/plugin-native-bun-runtime build`
- `swiftc -parse plugins/plugin-native-bun-runtime/ios/Tests/llama-bridge-smoke-main.swift`
- targeted stale-token scan over the edited smoke file (`<|im_start|>`, `<|im_end|>`, `User: Say hello`, `Assistant:`) -> no matches
- `git diff --check origin/develop...HEAD`
- `bun run verify`

## UI evidence
N/A: this changes a native iOS manual smoke script only; no `packages/app` UI behavior changed.
