### PR TITLE
fix(core): keep a terse reply the user explicitly asked the agent to say (Say PONG dead-end)

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -404,6 +404,31 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(useModelCalls(runtime).length).toBe(1);
 	});
 
+	it("keeps an all-caps reply the user explicitly asked the agent to say", async () => {
+		// "Say PONG" -> "PONG" used to dead-end into the fallback because
+		// isUnusableStage1Reply flags any non-allowlisted 2-8 char all-caps word.
+		// When the user explicitly requested that token, the reply is intentional.
+		for (const [ask, want] of [
+			["Say PONG", "PONG"],
+			["say HELLO", "HELLO"],
+			["please respond with the word PING", "PING"],
+		] as const) {
+			const runtime = makeRuntime([
+				stage1Response({ contexts: ["simple"], replyText: want }),
+			]);
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text: ask }),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000006" as UUID,
+			});
+			expect(result.kind).toBe("direct_reply");
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(want);
+			}
+		}
+	});
+
 	it("does not keep known-junk Stage 1 fragments when regeneration returns empty", async () => {
 		for (const badReply of ["RPPY", "{}", "aaaaa", "::::"]) {
 			const runtime = makeRuntime([

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3088,19 +3088,52 @@ function isRequestedTerseLiteralReply(args: {
 	return reply === stripIncidentalTerminalPeriod(requested);
 }
 
+/**
+ * Recognize a simple imperative to emit ONE specific literal token, e.g.
+ * "Say PONG", "say pong", "please say PONG", "can you say PONG", "reply with OK",
+ * "respond with the word HELLO", "output PONG!". The lightweight sibling of
+ * {@link parseExactWordsInstruction} (which requires the explicit
+ * "...with exactly N words: ..." form). Anchored to the whole message and a
+ * single word, so it only fires on a clear "say <token>" request — not
+ * "say something nice about cats". Returns the requested literal or null.
+ */
+function parseSayLiteralInstruction(
+	text: string | null | undefined,
+): string | null {
+	const input = text?.trim();
+	if (!input) return null;
+	const match = input.match(
+		/^(?:(?:can|could|would|will)\s+you\s+|please\s+|just\s+|kindly\s+){0,3}(?:say|reply|respond|answer|output|return|write|type|echo|print)(?:\s+(?:with|back|the\s+word|the\s+phrase)){0,2}\s*:?\s*["'“”‘’]?([\p{L}\p{N}]{1,40})["'“”‘’]?\s*[.!?]*$/iu,
+	);
+	return match ? match[1] : null;
+}
+
 function isTerseReplyWorthKeeping(args: {
 	reply: string | undefined;
 	messageText?: string | null;
 }): boolean {
 	const reply = args.reply;
 	const trimmed = typeof reply === "string" ? reply.trim() : "";
-	return (
-		/^\d+$/.test(trimmed) ||
-		isRequestedTerseLiteralReply({
-			reply,
-			messageText: args.messageText,
-		})
-	);
+	if (/^\d+$/.test(trimmed)) return true;
+	if (isRequestedTerseLiteralReply({ reply, messageText: args.messageText })) {
+		return true;
+	}
+	// The user explicitly asked the agent to say a specific token and it did
+	// (case-insensitive) — that reply is intentional, not the enum/scaffold
+	// leakage isUnusableStage1Reply guards against. Keep it instead of deferring,
+	// so "Say PONG"/"Say HELLO" don't dead-end into "I'm not sure how to answer
+	// that." just because the reply is an all-caps short word.
+	const requested = parseSayLiteralInstruction(args.messageText);
+	if (requested && trimmed) {
+		const norm = (s: string) =>
+			s
+				.trim()
+				.replace(/[.!?]+$/, "")
+				.trim()
+				.toLowerCase();
+		if (norm(trimmed) === norm(requested)) return true;
+	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
## The real terse-prompt launch blocker

Dedicated cloud agents dead-end on `Say PONG` → **"I'm not sure how to answer that."** (while `what is 2+2?` → "The answer is 4." works). This was mis-diagnosed earlier as a Cerebras streaming tool-call doubling issue (#9766) — **that was wrong**. The model returns a perfectly good reply; the agent **discards it**.

## Root cause (confirmed live on a prod dedicated agent)

`isUnusableStage1Reply` flags any non-allowlisted **2–8 char all-caps** word as unusable scaffold/enum leakage:

```js
if (/^[A-Z]{2,8}$/.test(trimmed)) {
  const allowed = new Set(["OK","YES","NO","STOP"]);
  return !allowed.has(trimmed);   // "PONG" → unusable
}
```

…and `isTerseReplyWorthKeeping` only rescued pure numbers or an explicit `"reply with exactly N words: X"` instruction — **not** a plain `Say PONG`. So when the model echoes the requested token in caps (`PONG`, `HELLO`, `PING`), the reply is thrown away → fallback. It only *intermittently* "worked" when the model happened to lowercase the reply (`pong` passes the gate).

**Live distinguishing test on a prod agent (`sha-ce1fd32`):**
| prompt | reply | before |
|---|---|---|
| `Say PONG` | `PONG` | ❌ fallback |
| `Say HELLO` | `HELLO` | ❌ fallback |
| `Say YES` | `YES` | ✅ (allowlisted) |
| `say banana` | `banana` | ✅ (lowercase) |
| `Say the number 7` | `7` | ✅ (number) |

## Fix

Add `parseSayLiteralInstruction` (lightweight sibling of `parseExactWordsInstruction`) and rescue a reply that exactly matches a token the user explicitly asked the agent to **say/reply/output**. The all-caps garbage filter is unchanged for replies the user did **not** request — a bare `RPPY` to `What is 2+2?` still defers (existing test stays green).

## Evidence
- Unit: `message-runtime-stage1` + `message.stage1-retry` `80/80` (new case: `Say PONG`/`say HELLO`/`respond with the word PING` are kept; the known-junk test still defers). Core typecheck + biome clean.
- Live: confirmed the before-table above on a real prod dedicated agent; after the fix `Say PONG` → `PONG`. Re-verification on a freshly-pinned prod image in progress (will attach a multi-trial `Say PONG` run).

Tracking: elizaOS/eliza#8434. Supersedes the misdiagnosed #9766 (which fixed a real but unrelated streaming-accumulator issue that does not affect the buffered cloud reply path).
