### PR TITLE
registry: add plugin-agentscoin (third-party)

### DIFF
--- a/packages/registry/entries/third-party/plugin-agentscoin.json
+++ b/packages/registry/entries/third-party/plugin-agentscoin.json
@@ -1,0 +1,16 @@
+{
+  "package": "plugin-agentscoin",
+  "repository": "github:axiosdevs/plugin-agentscoin",
+  "kind": "plugin",
+  "description": "Give your elizaOS agent an AgentsCoin wallet: create wallet, mine AGENT, check balance, send.",
+  "homepage": "https://agents-coin.com",
+  "version": "0.1.0",
+  "tags": [
+    "crypto",
+    "wallet",
+    "ai-agents",
+    "agentic-payments",
+    "evm",
+    "mcp"
+  ]
+}


### PR DESCRIPTION
Adds the AgentsCoin wallet plugin to the third-party registry.

- npm: plugin-agentscoin
- repo: github.com/axiosdevs/plugin-agentscoin
- Gives an elizaOS agent its own AgentsCoin wallet (create wallet, mine AGENT, balance, send).

Validated the entry against the schema. Happy to regenerate generated-registry.json if the maintainers prefer it in this PR.