### PR TITLE
fix(cloud-ui): drop useless row copy + optimistic delete on api keys page

### DIFF
--- a/packages/ui/src/cloud-ui/components/data-list/api-keys-table.stories.tsx
+++ b/packages/ui/src/cloud-ui/components/data-list/api-keys-table.stories.tsx
@@ -48,7 +48,6 @@ const meta = {
   tags: ["autodocs"],
   args: {
     keys: baseKeys,
-    onCopyKey: noop,
     onDisableKey: noop,
     onDeleteKey: noop,
     onRegenerateKey: noop,

--- a/packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx
+++ b/packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx
@@ -1,10 +1,4 @@
-import {
-  CalendarClock,
-  Copy,
-  RefreshCw,
-  ShieldOff,
-  Trash2,
-} from "lucide-react";
+import { CalendarClock, RefreshCw, ShieldOff, Trash2 } from "lucide-react";
 import { StatusBadge } from "../../../components/ui/status-badge";
 import {
   Table,
@@ -38,7 +32,6 @@ export interface ApiKeyDisplay {
 
 export interface ApiKeysTableProps {
   keys: ApiKeyDisplay[];
-  onCopyKey?: (id: string) => void;
   onDisableKey?: (id: string) => void;
   onDeleteKey?: (id: string) => void;
   onRegenerateKey?: (id: string) => void;
@@ -83,7 +76,7 @@ function renderActions(
   key: ApiKeyDisplay,
   handlers: Pick<
     ApiKeysTableProps,
-    "onCopyKey" | "onDisableKey" | "onDeleteKey" | "onRegenerateKey"
+    "onDisableKey" | "onDeleteKey" | "onRegenerateKey"
   >,
   triggerClassName?: string,
 ) {
@@ -92,11 +85,6 @@ function renderActions(
       label="Manage key"
       triggerClassName={triggerClassName}
       items={[
-        {
-          label: "Copy key",
-          icon: Copy,
-          onSelect: () => handlers.onCopyKey?.(key.id),
-        },
         {
           label: "Regenerate key",
           icon: RefreshCw,
@@ -121,7 +109,6 @@ function renderActions(
 
 export function ApiKeysTable({
   keys,
-  onCopyKey,
   onDisableKey,
   onDeleteKey,
   onRegenerateKey,
@@ -131,7 +118,6 @@ export function ApiKeysTable({
   }
 
   const handlers = {
-    onCopyKey,
     onDisableKey,
     onDeleteKey,
     onRegenerateKey,
@@ -169,15 +155,6 @@ export function ApiKeysTable({
               <span className="rounded-sm border border-white/10 bg-black/60 px-1.5 py-0.5 font-mono text-xs text-white">
                 {`${key.keyPrefix}.......`}
               </span>
-              <BrandButton
-                variant="ghost"
-                size="sm"
-                className="h-8 px-2"
-                onClick={() => onCopyKey?.(key.id)}
-              >
-                <Copy className="mr-1 h-3.5 w-3.5" />
-                Copy
-              </BrandButton>
               <BrandButton
                 variant="ghost"
                 size="sm"
@@ -244,15 +221,6 @@ export function ApiKeysTable({
                       <span className="rounded-sm border border-white/10 bg-black/60 px-1.5 py-0.5 font-mono text-xs text-white">
                         {`${key.keyPrefix}.......`}
                       </span>
-                      <BrandButton
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 px-2"
-                        onClick={() => onCopyKey?.(key.id)}
-                      >
-                        <Copy className="mr-1 h-3.5 w-3.5" />
-                        Copy
-                      </BrandButton>
                       <BrandButton
                         variant="ghost"
                         size="sm"

--- a/packages/ui/src/cloud/api-keys/ApiKeysView.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysView.tsx
@@ -13,9 +13,12 @@
  * - Mutations use the shared cloud `apiFetch` client (auth injection +
  *   structured `ApiError`) and invalidate the react-query key, replacing the
  *   raw `fetch` + manual `response.ok` plumbing.
- * - The dead "copy stored key" action (which imported a non-existent
- *   `@/lib/client/api-keys` module and could never fetch a hashed secret) now
- *   copies the public key prefix — the only identifier visible after creation.
+ * - There is no row-level "copy key" action: the full secret is only ever
+ *   shown once, in the post-create reveal dialog (copyable via `handleCopyKey`).
+ *   A stored key exposes only its public prefix, so copying it is pointless.
+ * - Delete optimistically removes the row from the `["api-keys"]` cache because
+ *   Hyperdrive caches the list GET, so the post-delete refetch can briefly
+ *   serve the deleted key; the invalidate reconciles once the cache expires.
  */
 
 import { useQueryClient } from "@tanstack/react-query";
@@ -61,7 +64,8 @@ import {
 import { Textarea } from "../../components/ui/textarea";
 import { ApiError, apiFetch } from "../lib/api-client";
 import { useCloudT } from "../shell/CloudI18nProvider";
-import { copyApiKeyPrefix, copyApiKeyToClipboard } from "./copy-api-key";
+import { copyApiKeyToClipboard } from "./copy-api-key";
+import type { ApiKeyRecord } from "./use-api-keys";
 
 interface ApiKeysViewProps {
   keys: ApiKeyDisplay[];
@@ -220,35 +224,6 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
     }
   };
 
-  // The full secret is hashed + KMS-encrypted at rest and only returned once
-  // (on create / regenerate). For a stored key the only copyable identifier is
-  // its public prefix.
-  const handleCopyStoredKey = async (id: string) => {
-    const key = keys.find((k) => k.id === id);
-    if (!key) return;
-    try {
-      await copyApiKeyPrefix(key.keyPrefix);
-      toast.success(
-        t("cloud.apiKeys.prefixCopied", {
-          defaultValue: "Key prefix copied",
-        }),
-        {
-          description: t("cloud.apiKeys.prefixCopiedDesc", {
-            defaultValue:
-              "The full key is only shown once, when it is created. Copied the public prefix instead.",
-          }),
-        },
-      );
-    } catch (error) {
-      toast.error(
-        t("cloud.apiKeys.copyFailed", {
-          defaultValue: "Failed to copy API key",
-        }),
-        { description: errorMessage(error) },
-      );
-    }
-  };
-
   const handleDisableKey = (id: string) => {
     const key = keys.find((k) => k.id === id);
     const isCurrentlyActive = key?.status === "active";
@@ -337,6 +312,15 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
     } else if (type === "delete") {
       try {
         await apiFetch(`/api/v1/api-keys/${id}`, { method: "DELETE" });
+        // Hyperdrive caches the GET, so the refetch below can still serve the
+        // just-deleted row for a while. Optimistically drop it from every
+        // cached `["api-keys", ...]` query (the key is partitioned per user, so
+        // match on the prefix) so it disappears immediately; the invalidate
+        // below reconciles once the cached GET expires.
+        queryClient.setQueriesData<ApiKeyRecord[]>(
+          { queryKey: ["api-keys"] },
+          (existing) => existing?.filter((key) => key.id !== id),
+        );
         toast.success(
           t("cloud.apiKeys.deleted", { defaultValue: "API key deleted" }),
           {
@@ -591,7 +575,6 @@ export function ApiKeysView({ keys, summary }: ApiKeysViewProps) {
         {hasKeys ? (
           <ApiKeysTable
             keys={keys}
-            onCopyKey={(id) => void handleCopyStoredKey(id)}
             onDisableKey={handleDisableKey}
             onDeleteKey={handleDeleteKey}
             onRegenerateKey={handleRegenerateKey}

--- a/packages/ui/src/cloud/api-keys/copy-api-key.ts
+++ b/packages/ui/src/cloud/api-keys/copy-api-key.ts
@@ -12,11 +12,9 @@
  *   endpoint that reveals the secret of an existing key, so "copy the stored
  *   secret" is impossible by design.
  *
- * So this exposes exactly two operations:
+ * So this exposes a single operation:
  *   - {@link copyApiKeyToClipboard} — copy a one-time plaintext key (the value
  *     shown in the post-create reveal dialog).
- *   - {@link copyApiKeyPrefix} — copy the public key prefix (the only visible
- *     identifier for a stored key) for the row-level "Copy key" action.
  */
 
 import { copyTextToClipboard } from "../../utils/clipboard";
@@ -27,12 +25,4 @@ import { copyTextToClipboard } from "../../utils/clipboard";
  */
 export async function copyApiKeyToClipboard(plainKey: string): Promise<void> {
   await copyTextToClipboard(plainKey);
-}
-
-/**
- * Copy the public key prefix for a stored key. The full secret cannot be
- * retrieved after creation, so the prefix is the only copyable identifier.
- */
-export async function copyApiKeyPrefix(keyPrefix: string): Promise<void> {
-  await copyTextToClipboard(keyPrefix);
 }

--- a/packages/ui/src/cloud/api-keys/index.ts
+++ b/packages/ui/src/cloud/api-keys/index.ts
@@ -28,7 +28,7 @@ import {
 export { ApiKeysSurface, default as ApiKeysRoute } from "./ApiKeysRoute";
 export { ApiKeysSection } from "./ApiKeysSection";
 export { ApiKeysView } from "./ApiKeysView";
-export { copyApiKeyPrefix, copyApiKeyToClipboard } from "./copy-api-key";
+export { copyApiKeyToClipboard } from "./copy-api-key";
 export {
   API_KEYS_QUERY_KEY,
   type ApiKeyRecord,


### PR DESCRIPTION
## What

Two fixes on the cloud-ui **API Keys** dashboard page.

### 1. Remove the useless row-level "Copy" button
The list-row copy action (`onCopyKey` → `handleCopyStoredKey`) only ever copied the **public key prefix** (`key.keyPrefix`), never the real key. The full secret is hashed + KMS-encrypted at rest and only returned once, on create/regenerate — there's no endpoint to reveal a stored key. So that button just tricked people into thinking they'd copied a usable key.

- Removed the inline Copy buttons on both the desktop table rows and the mobile cards.
- Removed the "Copy key" item from the manage-key dropdown.
- Dropped the `onCopyKey` prop from `ApiKeysTableProps` (+ destructure, handlers object, `renderActions` `Pick`), the now-unused `Copy` import, `handleCopyStoredKey` + its wiring, and the `copyApiKeyPrefix` import in the view.
- **Kept** the copy button in the post-create reveal dialog (`handleCopyKey` → `copyApiKeyToClipboard`) — that one copies the actual plaintext key and is the whole point of the dialog.
- Updated the table story args (`onCopyKey: noop` removed) so it still typechecks.

### 2. Fix "delete looks broken"
The delete path itself is correct: confirm dialog → `DELETE /api/v1/api-keys/:id` (org-scoped hard delete) → `invalidateQueries(["api-keys"])`. The visible bug is that the deleted row lingers, because **Hyperdrive caches the list GET**, so the post-delete refetch can briefly serve the just-deleted key right back.

Fix: after a successful DELETE, **optimistically remove** the row from the react-query cache so it disappears immediately, regardless of the cached GET. The invalidate/refetch stays as the reconcile once the cache expires.

Implementation detail worth flagging for review: the query key is **partitioned per user** — `useApiKeys` registers `["api-keys", "auth", <userId>]` via `authenticatedQueryKey`, not a bare `["api-keys"]`. `invalidateQueries({ queryKey: ["api-keys"] })` works because invalidation does prefix matching, but `setQueryData(["api-keys"], …)` would write to the wrong (non-existent) exact key and do nothing. So this uses `setQueriesData({ queryKey: ["api-keys"] }, …)` (prefix match) to hit the real partitioned entry. The cached data shape is a flat `ApiKeyRecord[]` (the `queryFn` returns `data.keys`), each item keyed by `id`, so the updater is `existing?.filter((key) => key.id !== id)`.

## Verification
- `@elizaos/ui` typecheck: **no errors in the touched files** (`api-keys-table.tsx`, `api-keys-table.stories.tsx`, `ApiKeysView.tsx`). The package surfaces pre-existing `AccountWithCredentialFlag` type-drift errors in unrelated accounts/chat/wallet files on `develop` — untouched here.
- biome `check` clean on all three touched files.
- `bun.lock` drift from the install reverted.

## Follow-up (not done here)
- The cloud-ui visual audit (`audit:cloud`) can't run fully headless in this environment, and driving the live page needs auth — **not** claiming a visual pass. Worth a quick manual look on a staging session: confirm the row no longer shows a Copy button, the dropdown has no "Copy key", the created-key dialog still copies the full key, and a delete makes the row vanish instantly.