### PR TITLE
fix(cloud): point cloud sign-in at the apex host, not www

### DIFF
--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -6,18 +6,21 @@ describe("Eliza Cloud base URL normalization", () => {
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
   });
 
-  it("normalizes the API host back to the browser site host", () => {
+  it("normalizes every cloud host alias to the apex origin", () => {
     expect(normalizeCloudSiteUrl("https://api.elizacloud.ai")).toBe(
-      "https://www.elizacloud.ai",
+      "https://elizacloud.ai",
     );
     expect(normalizeCloudSiteUrl("https://api.elizacloud.ai/api/v1")).toBe(
-      "https://www.elizacloud.ai",
+      "https://elizacloud.ai",
+    );
+    expect(normalizeCloudSiteUrl("https://www.elizacloud.ai")).toBe(
+      "https://elizacloud.ai",
     );
   });
 
   it("resolves canonical API paths from API host input", () => {
     expect(resolveCloudApiBaseUrl("https://api.elizacloud.ai")).toBe(
-      "https://www.elizacloud.ai/api/v1",
+      "https://elizacloud.ai/api/v1",
     );
   });
 

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -2,7 +2,7 @@
  * Pure URL normalizer for Eliza Cloud site/API base URLs. No host-layer deps.
  */
 
-const DEFAULT_CLOUD_SITE_URL = "https://www.elizacloud.ai";
+const DEFAULT_CLOUD_SITE_URL = "https://elizacloud.ai";
 
 const LEGACY_CLOUD_HOST_ALIASES = new Set([
   "api.elizacloud.ai",
@@ -60,7 +60,7 @@ export function normalizeCloudSiteUrl(rawUrl?: string): string {
     parsed.pathname = pathname;
 
     if (LEGACY_CLOUD_HOST_ALIASES.has(host)) {
-      parsed.hostname = "www.elizacloud.ai";
+      parsed.hostname = "elizacloud.ai";
       parsed.pathname = "";
     }
 

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -314,7 +314,7 @@ export interface AppBootConfig {
 
 export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
   branding: {},
-  cloudApiBase: "https://www.elizacloud.ai",
+  cloudApiBase: "https://elizacloud.ai",
 };
 
 // ---------------------------------------------------------------------------

--- a/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
@@ -299,7 +299,7 @@ describe("C1 — availability=true happy path", () => {
     expect(result?.apiKey).toBe("eliza_test_key_C1");
     expect(result?.agentId).toBe("agent-id-c1");
     expect(result?.bridgeUrl).toBe("https://bridge.example/agent-c1");
-    expect(result?.baseUrl).toMatch(/^https:\/\/www\.elizacloud\.ai/);
+    expect(result?.baseUrl).toMatch(/^https:\/\/elizacloud\.ai/);
 
     // Availability success surfaced via observer event.
     expect(observer.onAvailabilityChecked).toHaveBeenCalledWith({ ok: true });


### PR DESCRIPTION
## The bug (product-wide, blocks cloud sign-in for everyone)

Clicking **"Eliza Cloud"** in the app opens a **blank tab** instead of the login page.

## Root cause

The flow:

1. App POSTs `/api/cloud/login`
2. Server calls `${base}/api/auth/cli-session`
3. But `normalizeCloudSiteUrl` (`packages/shared/src/elizacloud/base-url.ts`) rewrites **every** cloud host alias (`api.elizacloud.ai`, `elizacloud.ai`, `www.elizacloud.ai`) to `www.elizacloud.ai`.
4. `www.elizacloud.ai` **308-redirects** `/api/auth/cli-session` to the apex (`elizacloud.ai`).
5. The app **rejects redirects** (`isRedirectResponse`) → 502 → empty login URL → `window.open("")` → **blank tab**.

## Proof (curl)

```
POST https://www.elizacloud.ai/api/auth/cli-session
  => 308 redirect -> https://elizacloud.ai/api/auth/cli-session

POST https://elizacloud.ai/api/auth/cli-session
  => 200 {"sessionId":"...","status":"pending"}   ✅ works

POST https://api.elizacloud.ai/api/auth/cli-session
  => 500
```

So the **apex `elizacloud.ai`** is the correct, working host — it serves both the API and the auth pages **without redirecting**. `www` redirects; `api` 500s.

## The fix

Move the normalizer rewrite **target** (and the client/default base) from `www` to the apex:

1. `packages/shared/src/elizacloud/base-url.ts`
   - `DEFAULT_CLOUD_SITE_URL`: `https://www.elizacloud.ai` → `https://elizacloud.ai`
   - `LEGACY_CLOUD_HOST_ALIASES` rewrite target: `parsed.hostname = "www.elizacloud.ai"` → `"elizacloud.ai"`
   - The alias **set** (`api` / apex / `www`) is unchanged — all three still normalize to one canonical host; only the canonical host is now the apex that actually serves the API + auth pages.
2. `packages/ui/src/config/boot-config-store.ts`
   - `DEFAULT_BOOT_CONFIG.cloudApiBase`: `https://www.elizacloud.ai` → `https://elizacloud.ai` (client default consistency)

Tests that encoded the old (buggy) target are updated to the apex:
- `packages/shared/src/elizacloud/base-url.test.ts` — normalizer output assertions
- `plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts` (C1) — the resolved-base assertion

## Verification

**Playwright-verified end to end:** with the rewrite pointed at the apex, clicking "Eliza Cloud" now opens the real **"CLI Authentication | Eliza Cloud"** page (`https://elizacloud.ai/auth/cli-login?session=...`) instead of `about:blank`.

Checks run locally:
- `@elizaos/shared` typecheck ✅
- `@elizaos/ui` typecheck ✅
- biome on the 4 touched files ✅
- `base-url.test.ts` (6/6) + `cloud-setup-failures.test.ts` (19/19) ✅

## Scope notes (intentionally NOT in this PR)

- `www.elizacloud.ai` stays a **valid first-party CORS origin** (`packages/cloud-shared/.../cloud-api-hono-cors`) — only the normalize target moves, accepting requests from www is still correct.
- `packages/app-core/src/cli/program/register.auth.ts` uses its **own, separate** normalizer that canonicalizes to `api.elizacloud.ai` for the SIWE/dev-login path. That's a different code path from the cli-session login bug here; left untouched to keep this PR tight. Worth a follow-up look given `api.*` currently 500s.

Draft — do not merge yet.