### PR TITLE
ci: move trusted CodeQL runs to robot runners

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: elizaOS CodeQL
+
+# Keep the default CodeQL query selection. This config only documents files
+# that are intentionally not parseable source.
+paths-ignore:
+  # WHY: this benchmark fixture is deliberately invalid TypeScript; the Solana
+  # runner test writes bad code here to assert syntax failures are reported
+  # cleanly. Analyzing it adds noisy parser diagnostics without adding security
+  # coverage.
+  - packages/benchmarks/solana/solana-gym-env/voyager/skill_runner/_test_bad.ts

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,6 +57,15 @@ conditional `runs-on` (GitHub-hosted for fork PRs, self-hosted otherwise) at
 that point, and keep the runner-agnostic step hardening (no `sudo`-only
 install/cleanup) so jobs run on either runner type.
 
+CodeQL is the current exception: trusted push, scheduled, and manual CodeQL
+runs use `self-hosted, Linux, X64, hetzner-robot` because full JavaScript
+analysis is disk-bound and has exhausted GitHub-hosted runners during the
+`PolynomialReDoS` dataflow query. Pull-request CodeQL remains GitHub-hosted so
+forked code never executes on self-hosted machines. Keep the full CodeQL query
+surface intact; move capacity around rather than weakening security coverage.
+The CodeQL config may ignore deliberately invalid negative-test fixtures, but
+not real source files; those fixtures should stay covered by their owning tests.
+
 GPU / KVM / macOS jobs (labels `gpu-cuda-12.6`, `kvm`, `eliza-e2e-macos`) are a
 separate purpose-built fleet and are unaffected by this policy.
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: ["main"]
   schedule:
     - cron: "29 8 * * 6"
+  workflow_dispatch:
 
 # Default to least privilege. Override per-job where needed.
 permissions:
@@ -15,7 +16,11 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    # WHY: whole-repo JS CodeQL can exhaust GitHub-hosted disk during the
+    # PolynomialReDoS dataflow query. Trusted events use the larger robot fleet;
+    # pull_request stays GitHub-hosted so forked code never runs on self-hosted.
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    timeout-minutes: 360
     permissions:
       # required for all workflows
       security-events: write
@@ -37,11 +42,33 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Report disk before CodeQL
+        shell: bash
+        run: |
+          df -h
+          du -sh "$GITHUB_WORKSPACE" 2>/dev/null || true
+
+      - name: Free GitHub-hosted runner disk
+        if: runner.environment == 'github-hosted'
+        shell: bash
+        run: |
+          # WHY: this preserves the full CodeQL query suite while giving the
+          # hosted fallback enough headroom for CodeQL's temporary databases.
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/go \
+            /opt/hostedtoolcache/Python \
+            /opt/hostedtoolcache/Ruby || true
+          df -h
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - if: matrix.build-mode == 'manual'
         shell: bash


### PR DESCRIPTION
## Summary
- run trusted CodeQL events on the `self-hosted, Linux, X64, hetzner-robot` pool so full JavaScript analysis has enough disk
- keep pull-request CodeQL on GitHub-hosted runners so forked code never runs on self-hosted machines
- add disk telemetry and hosted-runner cleanup without changing the CodeQL query surface
- add a CodeQL config that ignores one deliberately invalid negative-test fixture, not real source
- document the CodeQL runner/config exception and WHY in the workflow README

## Why
The scheduled develop run https://github.com/elizaOS/eliza/actions/runs/27867205502 was cancelled after roughly six hours in JavaScript CodeQL analysis. A nearby main run failed with only 98 MB free and `Severe disk cache trouble ... Failed to write item to disk` while evaluating `PolynomialReDoS`. This keeps the security gate intact and moves capacity around instead of dropping queries.

That same failed run also reported `Could not process some files due to syntax errors`. Reproducing locally with TypeScript parsing found all four diagnostics come from `packages/benchmarks/solana/solana-gym-env/voyager/skill_runner/_test_bad.ts`, which is intentionally invalid and used by `test_solana_benchmark.py::test_syntax_error_returns_error` to assert the runner reports syntax failures. The CodeQL config excludes only that fixture.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); YAML.load_file(".github/codeql/codeql-config.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql.yml`
- local TypeScript parser scan: `TOTAL 4, UNIGNORED 0` after applying the CodeQL ignore
- `git diff --check`
