### PR TITLE
fix(core): resolve raw model-slot names instead of leaking them

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
@@ -107,6 +107,34 @@ describe("runtimeModelContextProvider", () => {
 		}
 	});
 
+	it("omits an unresolvable slot instead of leaking its raw name", async () => {
+		// On a non-codex backend the resolver returns the raw slot name
+		// ("RESPONSE_HANDLER") for a slot it can't map. Resolve from the
+		// configured *_MODEL keys (LARGE/ACTION_PLANNER here) and OMIT a slot that
+		// stays unresolvable, rather than rendering its raw name to the user.
+		const runtime = makeRuntime(
+			{
+				ANTHROPIC_LARGE_MODEL: "claude-opus-4-8",
+				ANTHROPIC_ACTION_PLANNER_MODEL: "claude-opus-4-8",
+			},
+			{
+				resolveProviderModelString: (modelType: string) => modelType,
+				models: new Map([
+					[ModelType.RESPONSE_HANDLER, [{ provider: "anthropic" }]],
+					[ModelType.ACTION_PLANNER, [{ provider: "anthropic" }]],
+				]),
+			} as unknown as Partial<IAgentRuntime>,
+		);
+		const result = await runtimeModelContextProvider.get(
+			runtime,
+			makeMessage("what model are you running on?"),
+			{} as never,
+		);
+		expect(result.text).not.toContain("RESPONSE_HANDLER");
+		expect(result.text).toContain("claude-opus-4-8");
+		expect(result.data?.responseHandlerModel).toBeUndefined();
+	});
+
 	it("stays silent for unrelated live-data questions", async () => {
 		const runtime = makeRuntime({
 			OPENAI_LARGE_MODEL: "gpt-oss-120b",

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
@@ -108,25 +108,29 @@ function fallbackModelString(
 function configuredModelString(
 	runtime: RuntimeWithModelHelpers,
 	modelType: ModelTypeName,
-): string {
+): string | undefined {
 	const resolved =
 		typeof runtime.resolveProviderModelString === "function"
 			? runtime.resolveProviderModelString(modelType)
-			: fallbackModelString(runtime, modelType);
-	// Subscription backends (codex) register every model slot against one
-	// underlying model configured via their own setting (CODEX_MODEL) rather
-	// than the per-slot *_MODEL keys the resolver checks — so the resolver
-	// returns the raw slot name ("TEXT_LARGE"). Only fall back to the codex
-	// model when that slot is actually served by the codex-cli adapter, so a
-	// stale CODEX_MODEL env on a non-codex backend can't mislabel the slot.
-	if (!resolved || resolved === String(modelType)) {
-		const provider = registeredProviderFor(runtime, modelType);
-		if (provider === "codex-cli") {
-			const codexModel = readSetting(runtime, "CODEX_MODEL");
-			if (codexModel) return codexModel;
-		}
+			: undefined;
+	if (resolved && resolved !== String(modelType)) return resolved;
+	// The resolver is absent or returned the raw slot name ("RESPONSE_HANDLER").
+	// Subscription backends (codex) register every slot against one underlying
+	// model configured via their own setting (CODEX_MODEL); only trust it when
+	// the slot is actually served by the codex-cli adapter, so a stale
+	// CODEX_MODEL on a non-codex backend can't mislabel the slot.
+	const provider = registeredProviderFor(runtime, modelType);
+	if (provider === "codex-cli") {
+		const codexModel = readSetting(runtime, "CODEX_MODEL");
+		if (codexModel) return codexModel;
 	}
-	return resolved;
+	// Otherwise resolve from the configured *_MODEL keys along the fallback chain
+	// (e.g. ANTHROPIC_LARGE_MODEL). If still unresolvable, return undefined so the
+	// caller OMITS the line rather than leaking the raw slot name to the user.
+	const configured = fallbackModelString(runtime, modelType);
+	return configured && configured !== String(modelType)
+		? configured
+		: undefined;
 }
 
 function registeredProviderFor(
@@ -279,10 +283,10 @@ export const runtimeModelContextProvider: Provider = {
 		const lines = [
 			"# Runtime Model Context",
 			"Use these runtime facts when asked what model, provider, or coding agent is currently in use. Provider adapter names may identify compatibility layers; endpoint hosts identify the configured backend when present. Do not infer a different model or provider from training data or old chat history.",
-			`- Response handler model: ${responseHandlerModel}`,
-			`- Action planner model: ${actionPlannerModel}`,
-			`- Large text model: ${textLargeModel}`,
-			`- Small text model: ${textSmallModel}`,
+			optionalLine("Response handler model", responseHandlerModel),
+			optionalLine("Action planner model", actionPlannerModel),
+			optionalLine("Large text model", textLargeModel),
+			optionalLine("Small text model", textSmallModel),
 			optionalLine(
 				"Response handler provider adapter",
 				responseHandlerProvider,


### PR DESCRIPTION
## Problem

`runtimeModelContext` answers "what model are you?" by reading each slot through `resolveProviderModelString`, which returns the **raw slot name** (`"RESPONSE_HANDLER"`) for a slot it can't map. The only fallback was `codex-cli`, so on a non-codex backend (e.g. Anthropic) the agent **leaked the slot name to the user**:

> *"Running on the **RESPONSE_HANDLER** model via the Anthropic provider adapter."*

## Fix

`configuredModelString` now, when the resolver returns nothing usable or the raw slot name:
1. keeps the existing `codex-cli → CODEX_MODEL` special case, then
2. resolves from the configured `*_MODEL` keys along the fallback chain (e.g. `ANTHROPIC_LARGE_MODEL`) for **any** backend, and
3. returns `undefined` when a slot is genuinely unresolvable.

The four model lines render via the existing `optionalLine` helper, so an unresolvable slot is **omitted** rather than leaking its raw name.

## Evidence

- **Unit**: new regression test — resolver returns the raw slot name → that line is omitted, no `RESPONSE_HANDLER` in the output, and the real model (`claude-opus-4-8`) still surfaces. Existing 5 tests unchanged.
- **Behavioral** (live Anthropic agent): "what model are you running on" now replies *"claude-sonnet-4-6 (response handler), claude-opus-4-8 (action planner + large)"* — real names, zero raw-slot leak (was "RESPONSE_HANDLER model" before).

Formatting: `bunx @biomejs/biome@2.5.0 check` clean.
