### PR TITLE
fix(plugin-x): defer env account materialization until service start

### DIFF
--- a/plugins/plugin-x/src/connector-account-provider.ts
+++ b/plugins/plugin-x/src/connector-account-provider.ts
@@ -384,7 +384,19 @@ export async function materializeEnvAccountIfMissing(
     return;
   }
   const manager = getConnectorAccountManager(runtime);
-  const existing = await manager.getAccount(X_PROVIDER, DEFAULT_ACCOUNT_ID);
+  let existing: ConnectorAccount | null = null;
+  try {
+    existing = await manager.getAccount(X_PROVIDER, DEFAULT_ACCOUNT_ID);
+  } catch (err) {
+    logger.warn(
+      {
+        src: "plugin:x",
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Could not read X connector account; skipping env account materialization",
+    );
+    return;
+  }
   if (existing) {
     return;
   }

--- a/plugins/plugin-x/src/index.ts
+++ b/plugins/plugin-x/src/index.ts
@@ -6,7 +6,6 @@ import {
 } from "@elizaos/core";
 import {
   createXConnectorAccountProvider,
-  materializeEnvAccountIfMissing,
 } from "./connector-account-provider.js";
 
 export { XDmAdapter } from "./lifeops-message-adapter.js";
@@ -93,11 +92,7 @@ export const XPlugin: Plugin = {
       );
     }
 
-    // In env mode, materialize a synthetic `default` account so the rest of
-    // the runtime can address it through the connector account interface.
-    if (mode === "env") {
-      await materializeEnvAccountIfMissing(runtime);
-    }
+    // Env account materialization runs in XService.start (after plugin-sql migrations).
   },
   async dispose(runtime: IAgentRuntime) {
     const svc = runtime.getService<XService>(XService.serviceType);

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -28,6 +28,7 @@ import { TwitterPostClient } from "../post";
 import { TwitterTimelineClient } from "../timeline";
 import type { ITwitterClient, TwitterClientState } from "../types";
 import { getSetting } from "../utils/settings";
+import { materializeEnvAccountIfMissing } from "../connector-account-provider.js";
 import { TwitterPostService } from "./PostService";
 
 const X_CONNECTOR_CONTEXTS = ["social", "connectors"];
@@ -303,6 +304,13 @@ export class XService extends Service {
     service.runtime = runtime;
 
     try {
+      const authMode = (
+        getSetting(runtime, "TWITTER_AUTH_MODE") || "env"
+      ).toLowerCase();
+      if (authMode === "env") {
+        await materializeEnvAccountIfMissing(runtime);
+      }
+
       const defaultState = await resolveTwitterAccountConfig(runtime);
       await validateTwitterConfig(runtime, defaultState);
       service.defaultAccountId = resolveDefaultXAccountId(


### PR DESCRIPTION
## Summary

Fixes a fatal agent startup crash when `@elizaos/plugin-x` is loaded with env-mode OAuth 1.0a credentials (`TWITTER_AUTH_MODE=env`):
```
Fatal error: Failed query: select ... from "connector_accounts" where ... provider = $2 and account_key = $3 params: ,x,default,1
```

`materializeEnvAccountIfMissing()` was called from `XPlugin.init()`, which runs **before** `AgentRuntime.runPluginMigrations()`. The synthetic `default` X account lookup hits `connector_accounts` while that table may not exist yet — on **both** embedded PGlite and remote PostgreSQL (`POSTGRES_URL` / `DATABASE_URL`).

This PR moves env account materialization to `XService.start()` (after migrations) and adds a defensive try/catch around the initial `getAccount` lookup.

## Root cause

Runtime boot order in `@elizaos/core`:

1. Register plugins → run each `plugin.init()`
2. Start services (`XService.start`, Documents service, etc.)
3. `runPluginMigrations()` — `@elizaos/plugin-sql` creates/updates schema including `connector_accounts`

`plugin-x` step 1 queries `connector_accounts` for the synthetic `default` account (`provider=x`, `account_key=default`) via `ConnectorAccountManager.getAccount()`.

That races schema creation regardless of backend:

| Backend | When it fails |
|---------|----------------|
| **PGlite** (`PGLITE_DATA_DIR`, default `.eliza/.elizadb`) | Fresh or reset local dir; table not migrated yet |
| **PostgreSQL** (`POSTGRES_URL`) | Fresh remote DB, or DB where `connector_accounts` migration has not run before first agent boot |

This is **not** a `plugin-sql` migration bug — `drizzle/migrations/0001_connector_accounts.sql` is correct. The table simply does not exist at query time because `init()` runs too early.

## Observed failure modes (reporter log)

1. **PGlite corruption after partial failed boots** — repeated crashes can leave PGlite in a bad state (`Program terminated with exit(1)`), requiring manual deletion of the data dir. That is a separate recovery step, not the root cause of the `connector_accounts` query failure.
2. **`connector_accounts` query failure** — once the DB adapter is up (local or remote), agent dies during init/service startup with the Drizzle select shown above.

Both local PGlite paths (`.eliza/.elizadb`, `./data/pglite`) and PostgreSQL-backed runs exhibited the `connector_accounts` fatal query once the adapter initialized successfully.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-x/src/index.ts` | Remove `materializeEnvAccountIfMissing` from `init()` |
| `plugins/plugin-x/src/services/x.service.ts` | Call it at the start of `XService.start()` when `TWITTER_AUTH_MODE=env` |
| `plugins/plugin-x/src/connector-account-provider.ts` | Wrap `getAccount` in try/catch; warn and skip if lookup fails |

## Reproduction

1. Headless `AgentRuntime` with `plugin-sql` + `plugin-x`, env credentials configured.
2. Use either:
   - Fresh PGlite dir (`PGLITE_DATA_DIR`), or
   - Fresh PostgreSQL instance via `POSTGRES_URL` without pre-applied `connector_accounts` schema.
3. `bun run agent.ts` → fatal `connector_accounts` query during startup (often after "Starting Documents service").

## Verification

- [ ] Fresh PGlite: agent boots without `connector_accounts` query error
- [ ] Fresh PostgreSQL (`POSTGRES_URL`): agent boots; migrations create table before materialization
- [ ] Existing migrated DB: synthetic `default` X account still materialized in env mode
- [ ] OAuth mode (`TWITTER_AUTH_MODE=oauth`): unchanged — no env materialization in `init` or early `start`
- [ ] `bun run --cwd plugins/plugin-x test` passes

## Related

- Issue: https://github.com/elizaOS/eliza/issues/9816