### PR TITLE
fix(core): parse "say X" literal instructions through a leading @-mention

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -412,6 +412,9 @@ describe("runV5MessageRuntimeStage1", () => {
 			["Say PONG", "PONG"],
 			["say HELLO", "HELLO"],
 			["please respond with the word PING", "PING"],
+			// mention-prefixed (Discord/Telegram render the mention into the text)
+			["remilio (@1490833425802854491) Say PONG", "PONG"],
+			["<@1490833425802854491> say HELLO", "HELLO"],
 		] as const) {
 			const runtime = makeRuntime([
 				stage1Response({ contexts: ["simple"], replyText: want }),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3102,7 +3102,14 @@ function parseSayLiteralInstruction(
 ): string | null {
 	const input = text?.trim();
 	if (!input) return null;
-	const match = input.match(
+	// Strip a leading connector mention prefix ("Name (@123) ", "<@123> ",
+	// "@name ") so "say PONG" still parses when the user @-mentioned the agent
+	// first — Discord/Telegram render the mention into the message text, which
+	// the anchored matcher below would otherwise reject.
+	const body = input
+		.replace(/^\s*(?:<@!?\d+>\s*|@\S+\s+|[^()\n]{0,80}\(@\d+\)\s*)/u, "")
+		.trim();
+	const match = body.match(
 		/^(?:(?:can|could|would|will)\s+you\s+|please\s+|just\s+|kindly\s+){0,3}(?:say|reply|respond|answer|output|return|write|type|echo|print)(?:\s+(?:with|back|the\s+word|the\s+phrase)){0,2}\s*:?\s*["'“”‘’]?([\p{L}\p{N}]{1,40})["'“”‘’]?\s*[.!?]*$/iu,
 	);
 	return match ? match[1] : null;


### PR DESCRIPTION
Follow-up to #9807.

#9807 rescues a reply matching a token the user explicitly asked the agent to say (`Say PONG` → `PONG`), so it doesn't dead-end into the fallback. But `parseSayLiteralInstruction` is **anchored to the start** of the message — so on connectors that render the mention into the message text (Discord/Telegram: `remilio (@123) Say PONG`, `<@123> say HELLO`), it never matched and those replies still dead-ended.

**Fix:** strip a leading connector mention prefix (`Name (@123) `, `<@123> `, `@name `) before matching.

**Evidence:**
- Adds mention-prefixed cases to the existing terse-keep test (`message-runtime-stage1.test.ts`).
- Live-verified on a Discord agent: `Say HELLO` → `HELLO` (was "I'm not sure how to answer that."); negatives (`say something nice about cats`) reply normally.
- `bunx @biomejs/biome@2.5.0 check` clean.