### PR TITLE
ci(build): share Turbo remote cache in nightly/release + cache riscv64 outputs (#9626)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,14 @@ env:
   NODE_OPTIONS: "--max-old-space-size=4096"
   BUN_VERSION: "canary"
   NODE_VERSION: "24.15.0"
+  # Share Turbo's remote cache across the nightly build invocations
+  # (build-and-test, the desktop matrix, publish-npm) so unchanged packages
+  # replay from the same cache ci.yaml/test.yml populate. No-op on forks and
+  # when the secret is absent (Turbo falls back to the local .turbo cache that
+  # setup-bun-workspace already restores).
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_CACHE: remote:rw
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,14 @@ jobs:
         !(github.ref_type == 'tag' && contains(github.ref_name || '', '-alpha'))
       }}
 
+    env:
+      # Replay the publish-critical build graph from Turbo's remote cache
+      # instead of rebuilding it cold on every release. No-op when the secret
+      # is absent (Turbo falls back to the local .turbo cache restored below).
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_CACHE: remote:rw
+
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -106,6 +114,28 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "canary"
+
+      # release.yaml uses oven-sh/setup-bun directly (not setup-bun-workspace),
+      # so it gets no .turbo restore by default — the publish build was cold
+      # every run. Restore the local Turbo cache (shared with ci/test runs via
+      # the runner.os prefix) and the Bun install cache.
+      - name: Restore Turbo cache (GitHub Actions)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-release-${{ hashFiles('package.json', 'bun.lock', 'bunfig.toml', 'turbo.json') }}
+          restore-keys: |
+            turbo-${{ runner.os }}-release-
+            turbo-${{ runner.os }}-
+
+      - name: Cache Bun install
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-canary-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-canary-
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/riscv64-smoke.yml
+++ b/.github/workflows/riscv64-smoke.yml
@@ -67,6 +67,40 @@ jobs:
       - name: Install workspace deps
         run: bun install --frozen-lockfile
 
+      # Fingerprint the riscv64 build inputs from the git index (blob SHAs of
+      # tracked native sources + submodule pins). Fast (no byte reads), and it
+      # cannot self-pollute because build outputs land in gitignored build/
+      # dirs that `git ls-files` never lists.
+      - name: Compute riscv64 source fingerprint
+        id: riscv64-fp
+        run: |
+          set -euo pipefail
+          {
+            git submodule status --recursive
+            git ls-files -s \
+              packages/native/plugins \
+              scripts/build-riscv64-artifacts.sh \
+              packages/app-core/scripts/aosp/compile-libllama.mjs \
+              plugins/plugin-local-inference/native/build-omnivoice.mjs
+          } | sha256sum | awk '{ print "hash=" $1 }' >> "$GITHUB_OUTPUT"
+
+      # build-riscv64-artifacts.sh is idempotent via existence sentinels, but its
+      # outputs never persist across runs. Restore them so an unchanged native
+      # source tree replays from the sentinels instead of recompiling every
+      # artifact (~30 min). EXACT-MATCH ONLY (no restore-keys): a stale prefix
+      # restore would let should_build skip a needed rebuild and smoke a stale
+      # artifact — a false green. A source/submodule change busts the key and
+      # forces a full rebuild.
+      - name: Cache riscv64 build outputs
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8
+        with:
+          path: |
+            packages/native/plugins/*/build/riscv64
+            packages/app-core/platforms/android/app/src/main/assets/agent/riscv64
+            plugins/plugin-local-inference/native/build-omnivoice-linux-riscv64-cpu
+            ~/.cache/eliza-android-agent/seccomp-shim/riscv64
+          key: riscv64-out-${{ runner.os }}-${{ steps.riscv64-fp.outputs.hash }}
+
       - name: Build every riscv64 artifact (linux only; android skipped)
         run: |
           bun run build:riscv64-artifacts -- --skip-android


### PR DESCRIPTION
Part of #9626 (build audit). The `.turbo` github.sha key, build-agent-image turbo conversion, and Linux ISO buildx items the audit also listed were already fixed on develop; these three lanes still rebuilt cold:

- **nightly.yml** — add `TURBO_TOKEN`/`TURBO_TEAM`/`TURBO_CACHE` (matches ci.yaml/test.yml) so its build invocations replay from the shared Turbo remote cache. No-op on forks / when the secret is absent.
- **release.yaml** — it uses `oven-sh/setup-bun` directly (no `.turbo` restore), so the publish-critical graph built cold every release. Add the Turbo env + a `.turbo` GHA cache + a Bun install cache.
- **riscv64-smoke.yml** — Zig is already cached but native build outputs are not. Cache the per-plugin static libs, libllama, libomnivoice, and the seccomp shim, keyed on a **git-index fingerprint of tracked native sources + submodule pins**, **exact-match only** (no restore-keys) so a stale prefix restore can't let `should_build` skip a needed rebuild and smoke a stale artifact.

### Evidence
- All three workflows validated with `yaml.safe_load`.
- `secrets.TURBO_TOKEN` / `vars.TURBO_TEAM` / `TURBO_CACHE: remote:rw` match the exact names already used in ci.yaml (lines 27-29) and test.yml.
- riscv64 cache paths verified against `build-riscv64-artifacts.sh` sentinels (per-plugin `packages/native/plugins/*/build/riscv64`, libllama assets `…/android/app/src/main/assets/agent/riscv64`, omnivoice, seccomp-shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)