### PR TITLE
chore(electrobun): drop dead per-remote build scripts (#9626)

### DIFF
--- a/packages/app-core/platforms/electrobun/remotes/fs/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/fs/README.md
@@ -61,7 +61,6 @@ Environment overrides:
 ## Commands
 
 ```sh
-bun run --cwd elizalaunch/remotes/fs build
 bun run --cwd elizalaunch/remotes/fs smoke
 bun run --cwd elizalaunch/remotes/fs smoke:phase5
 bun run --cwd elizalaunch/remotes/fs typecheck

--- a/packages/app-core/platforms/electrobun/remotes/fs/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/fs/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase5-smoke.ts --outdir dist --target bun",
     "smoke": "bun run src/dev/phase5-smoke.ts",
     "smoke:phase5": "bun run src/dev/phase5-smoke.ts",
     "typecheck": "tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --lib ES2022,DOM --types bun-types --allowImportingTsExtensions src/bun/protocol.ts src/bun/errors.ts src/bun/file-limits.ts src/bun/path-guard.ts src/bun/fs-service.ts src/bun/worker.ts src/dev/phase5-smoke.ts"

--- a/packages/app-core/platforms/electrobun/remotes/git/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/git/README.md
@@ -57,11 +57,10 @@ Each operation includes:
 - `ELIZA_GIT_COMMAND_TIMEOUT_MS` defaults to `120000`
 - `ELIZA_GIT_MAX_OPERATIONS` defaults to `200`
 
-## Build And Smoke
+## Typecheck And Smoke
 
 ```sh
 bun run --cwd elizalaunch/remotes/git typecheck
-bun run --cwd elizalaunch/remotes/git build
 bun run --cwd elizalaunch/remotes/git smoke
 bun run --cwd elizalaunch/remotes/git smoke:phase7
 ```

--- a/packages/app-core/platforms/electrobun/remotes/git/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/git/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase7-smoke.ts --outdir dist --target bun",
     "smoke": "bun run src/dev/phase7-smoke.ts",
     "smoke:phase7": "bun run src/dev/phase7-smoke.ts",
     "typecheck": "tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --lib ES2022,DOM --types bun-types --allowImportingTsExtensions src/bun/protocol.ts src/bun/errors.ts src/bun/operation-history.ts src/bun/git-command.ts src/bun/git-service.ts src/bun/worker.ts src/dev/phase7-smoke.ts"

--- a/packages/app-core/platforms/electrobun/remotes/local-model/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/README.md
@@ -94,7 +94,6 @@ The current route file does not expose direct local generation or direct embeddi
 
 ```sh
 bun run --cwd elizalaunch/remotes/local-model typecheck
-bun run --cwd elizalaunch/remotes/local-model build
 bun run --cwd elizalaunch/remotes/local-model smoke
 bun run --cwd elizalaunch/remotes/local-model smoke:phase8
 ```

--- a/packages/app-core/platforms/electrobun/remotes/local-model/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase8-smoke.ts --outdir dist --target bun",
     "smoke": "bun run src/dev/phase8-smoke.ts",
     "smoke:phase8": "bun run src/dev/phase8-smoke.ts",
     "typecheck": "tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --lib ES2022,DOM --types bun-types --allowImportingTsExtensions src/bun/protocol.ts src/bun/errors.ts src/bun/eliza1-catalog.ts src/bun/hf-eliza1-client.ts src/bun/local-inference-api-client.ts src/bun/download-state.ts src/bun/model-service.ts src/bun/worker.ts src/dev/phase8-smoke.ts"

--- a/packages/app-core/platforms/electrobun/remotes/pty/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/pty/README.md
@@ -52,10 +52,9 @@ Output polling through `pty.session.output.tail` is sufficient for Phase 6 when 
 
 Session environment inherits `process.env` and merges per-session env overrides.
 
-## Build And Smoke
+## Smoke
 
 ```sh
-bun run --cwd elizalaunch/remotes/pty build
 bun run --cwd elizalaunch/remotes/pty smoke
 bun run --cwd elizalaunch/remotes/pty smoke:phase6
 ```

--- a/packages/app-core/platforms/electrobun/remotes/pty/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/pty/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase6-smoke.ts --outdir dist --target bun",
     "smoke": "bun run src/dev/phase6-smoke.ts",
     "smoke:phase6": "bun run src/dev/phase6-smoke.ts",
     "typecheck": "tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --lib ES2022,DOM --types bun-types --allowImportingTsExtensions src/bun/protocol.ts src/bun/errors.ts src/bun/output-buffer.ts src/bun/pty-service.ts src/bun/worker.ts src/dev/phase6-smoke.ts"

--- a/packages/app-core/platforms/electrobun/remotes/runtime/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/runtime/README.md
@@ -206,11 +206,7 @@ Git:
 
 ## Run
 
-Build:
-
-```sh
-bun run --cwd elizalaunch/remotes/runtime build
-```
+Remotes run from source (the runtime loads `src/bun/worker.ts` / `src/web/index.html` directly); there is no build step.
 
 Phase 1 smoke:
 

--- a/packages/app-core/platforms/electrobun/remotes/runtime/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/runtime/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase1-smoke.ts src/dev/phase2-smoke.ts src/dev/phase3-smoke.ts --outdir dist --target bun",
     "smoke": "bun src/dev/phase1-smoke.ts",
     "smoke:phase1": "bun src/dev/phase1-smoke.ts",
     "smoke:phase2": "bun src/dev/phase2-smoke.ts",

--- a/packages/app-core/platforms/electrobun/remotes/surface/README.md
+++ b/packages/app-core/platforms/electrobun/remotes/surface/README.md
@@ -106,10 +106,9 @@ It consumes:
 - `agent.message.stream.done`
 - `agent.message.stream.cancelled`
 
-## Build and Smoke
+## Smoke
 
 ```sh
-bun run --cwd elizalaunch/remotes/surface build
 bun run --cwd elizalaunch/remotes/surface smoke
 bun run --cwd elizalaunch/remotes/surface smoke:phase4
 ```

--- a/packages/app-core/platforms/electrobun/remotes/surface/package.json
+++ b/packages/app-core/platforms/electrobun/remotes/surface/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/bun/worker.ts src/dev/phase4-smoke.ts --outdir dist --target bun && bun build src/web/index.ts --outdir dist/web --target browser",
     "smoke": "bun run src/dev/phase4-smoke.ts",
     "smoke:phase4": "bun run src/dev/phase4-smoke.ts",
     "typecheck": "tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --lib ES2022,DOM,DOM.Iterable --types bun-types --allowImportingTsExtensions src/protocol/event-types.ts src/protocol/runtime-client.ts src/web/state.ts src/web/render.ts src/web/app.ts src/web/index.ts src/bun/worker.ts src/dev/phase4-smoke.ts"


### PR DESCRIPTION
Part of #9626 (build audit — macOS/iOS section: "dead per-remote `bun build` scripts; remotes ship as source").

The six electrobun remotes (runtime/fs/local-model/pty/git/surface) ship as **source**: `electrobun.config.ts` copies the whole `remotes/` tree verbatim, each `plugin.json` points its worker/view at `src/` files, and `dist` is in the remote-hash skip list. Their `bun build … --outdir dist` scripts emitted a `dist/` bundle nothing reads, were not workspace members (the workspace glob stops at `platforms/*`), and were invoked by no script or CI. Remove them and the matching README commands; `smoke`/`typecheck` (the real per-remote validation) are untouched.

### Evidence
- `git ls-files …/remotes/**/dist/**` → empty (no committed dist).
- Every `plugin.json` worker/view `relativePath` points at `src/…`.
- Repo-wide grep: nothing invokes the remote `build` script (only the per-remote READMEs documented it — those lines are updated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)