### PR TITLE
build(ts): make DTS emit-only for the last double-type-checkers (#9626)

### DIFF
--- a/packages/cloud-sdk/build.ts
+++ b/packages/cloud-sdk/build.ts
@@ -9,7 +9,10 @@ async function build() {
   }
   await mkdir("dist", { recursive: true });
 
-  await Bun.$`tsc --project tsconfig.json --noEmit false`;
+  // Emit declarations only — tsgo (`typecheck`) is the single type-checker.
+  // --noEmit false overrides tsconfig's noEmit; --noCheck skips the redundant
+  // re-check (#9626). Verified byte-identical .d.ts vs the full-check build.
+  await Bun.$`tsc --project tsconfig.json --noEmit false --noCheck`;
 }
 
 build().catch((error) => {

--- a/packages/scripts/audit-build-typecheck.mjs
+++ b/packages/scripts/audit-build-typecheck.mjs
@@ -24,7 +24,11 @@ const ALLOW = {
 	// @elizaos/core: build uses tsconfig.build.json but typecheck uses
 	// tsconfig.json — a possible coverage delta; converting needs a deliberate
 	// framework decision, not a blind --noCheck (issue #9626).
-	doubleCheck: new Set(["@elizaos/core"]),
+	// @elizaos/plugin-streaming: under --noCheck, tsc reorders an inferred
+	// union member in services/stream-manager.d.ts (functionally identical but
+	// not byte-identical), so its declaration emit deliberately keeps the full
+	// check to preserve byte-stable published types (#9626).
+	doubleCheck: new Set(["@elizaos/core", "@elizaos/plugin-streaming"]),
 	// These packages currently fail `tsgo` (it flags errors `tsc` does not);
 	// kept on `tsc` until those are resolved.
 	tscTypecheck: new Set([
@@ -75,7 +79,11 @@ function isFullTscEmit(script) {
 	const emits = /--emitDeclarationOnly|--declaration\b|-p\s+tsconfig|--project\s+tsconfig/.test(script);
 	if (!emits) return false;
 	if (/--noCheck/.test(script)) return false;
-	if (/--noEmit/.test(script)) return false; // that's a check, not an emit
+	// `--noEmit` means a pure check (no emit) — UNLESS it's `--noEmit false`,
+	// which re-enables emit to override a tsconfig `noEmit: true`. So
+	// `tsc --emitDeclarationOnly --noEmit false` (no --noCheck) is still a full
+	// type-check that emits, and must be flagged.
+	if (/--noEmit\b(?!\s+false)/.test(script)) return false;
 	return true;
 }
 

--- a/plugins/plugin-agent-skills/package.json
+++ b/plugins/plugin-agent-skills/package.json
@@ -65,7 +65,7 @@
     "vitest": "^4.0.0"
   },
   "scripts": {
-    "build": "tsup && tsc --declaration --emitDeclarationOnly --noEmit false",
+    "build": "tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck",
     "dev": "tsup --watch",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "lint": "bunx @biomejs/biome check --write --unsafe --config-path ./biome.json .",

--- a/plugins/plugin-app-control/package.json
+++ b/plugins/plugin-app-control/package.json
@@ -34,7 +34,7 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "node ../../packages/scripts/remove-source-build-artifacts.mjs src && tsup src/index.ts src/workers/app-worker-entry.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false -p tsconfig.json && node ../../packages/scripts/flatten-tsc-package-output.mjs plugins/plugin-app-control && bun run build:views",
+		"build": "node ../../packages/scripts/remove-source-build-artifacts.mjs src && tsup src/index.ts src/workers/app-worker-entry.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck -p tsconfig.json && node ../../packages/scripts/flatten-tsc-package-output.mjs plugins/plugin-app-control && bun run build:views",
 		"dev": "tsup src/index.ts src/workers/app-worker-entry.ts --format esm --dts --watch",
 		"test": "vitest run",
 		"clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",

--- a/plugins/plugin-calendly/package.json
+++ b/plugins/plugin-calendly/package.json
@@ -33,7 +33,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false",
+    "build": "tsup src/index.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo"


### PR DESCRIPTION
Part of #9626 (TL;DR #3 — "every package is type-checked twice"). The prior sweep converted ~74 packages; the model is now enforced by `audit:build-model` (in `verify`). But that audit had a blind spot: `isFullTscEmit` exempted any `--noEmit`, yet `--noEmit false` *re-enables* emit (to override a tsconfig `noEmit: true`). So `tsc --emitDeclarationOnly --noEmit false` (a full type-check that emits) alongside a separate tsgo `typecheck` slipped through as a redundant second full type-check.

- **Harden** the audit to treat `--noEmit false` as an emit, not a check.
- **Convert** the 4 it now catches whose declaration emit is **byte-identical** under `--noCheck`: `plugin-calendly`, `plugin-agent-skills`, `plugin-app-control`, `cloud-sdk`. tsgo remains the single type-checker for all four.
- **Allowlist** `plugin-streaming`: under `--noCheck` tsc reorders an inferred union member in `stream-manager.d.ts` (functionally identical, not byte-identical) — same class as the previously-excluded vision/coding-tools.

### Evidence
- Built each package's `.d.ts` both ways (full-check vs `--noCheck`) into temp dirs and `diff -rq`'d:
  - calendly (10 d.ts), cloud-sdk (17), agent-skills (32) → **byte-identical**.
  - app-control → **own output byte-identical** (the dep-source trees it also emits are discarded by `flatten-tsc-package-output.mjs`).
  - streaming → own output differs by one union-member reorder → excluded.
- `audit:build-model` passes after the change (4 converted + streaming allowlisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)