### PR TITLE
fix(gemma): align EOT turn detector target token

### DIFF
--- a/packages/training/scripts/turn_detector/README.md
+++ b/packages/training/scripts/turn_detector/README.md
@@ -78,7 +78,7 @@ slot the runtime validator enforces.
 of the eliza-1 drafter (the small model MTP already keeps warm for
 speculative decoding) instead of a standalone ONNX. The runtime layers
 the adapter onto a dedicated EOT context at voice-session start and
-reads P(`<|im_end|>`) directly off the live model — see
+reads P(`<end_of_turn>`) directly off the live model — see
 [`plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts`](../../../../plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts).
 
 ```bash

--- a/packages/training/scripts/turn_detector/configs/turn_detector_eliza1_drafter.yaml
+++ b/packages/training/scripts/turn_detector/configs/turn_detector_eliza1_drafter.yaml
@@ -3,7 +3,7 @@
 # Trains a LoRA adapter on top of the eliza-1 drafter (the same model
 # MTP already keeps warm for speculative decoding). The runtime
 # layers the resulting adapter onto a dedicated EOT context at voice
-# session start and reads P(`<|im_end|>`) directly off the live model —
+# session start and reads P(`<end_of_turn>`) directly off the live model —
 # see `plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts`.
 #
 # Compared with the LiveKit/Turnsense configs in this directory the

--- a/packages/training/scripts/turn_detector/configs/turn_detector_intl.yaml
+++ b/packages/training/scripts/turn_detector/configs/turn_detector_intl.yaml
@@ -3,7 +3,7 @@
 # Targets the LiveKit `v0.4.1-intl` revision (Qwen2-0.5B, 14 languages).
 # Bundle target is ~396 MB Q8 ONNX in upstream; the APOLLO-Mini fine-tune
 # re-exports a Q8 ONNX at the same shape (drop-in for runtime callers
-# that score `P(<|im_end|>)` at the last real-token position).
+# that score `P(<end_of_turn>)` at the last real-token position).
 #
 # Per repo policy (packages/training/AGENTS.md §1): APOLLO optimizer only.
 

--- a/packages/training/scripts/turn_detector/eval_turn_detector.py
+++ b/packages/training/scripts/turn_detector/eval_turn_detector.py
@@ -122,7 +122,7 @@ def gate_report(*, f1: float, mean_latency_ms: float) -> dict[str, Any]:
     }
 
 
-LIVEKIT_IM_END_TOKEN: Final[str] = "<|im_end|>"
+GEMMA_END_OF_TURN_TOKEN: Final[str] = "<end_of_turn>"
 
 
 def _format_livekit_prompt(tokenizer: Any, transcript: str) -> str:
@@ -135,7 +135,7 @@ def _format_livekit_prompt(tokenizer: Any, transcript: str) -> str:
         tokenize=False,
         add_special_tokens=False,
     )
-    ix = templated.rfind(LIVEKIT_IM_END_TOKEN)
+    ix = templated.rfind(GEMMA_END_OF_TURN_TOKEN)
     if ix >= 0:
         templated = templated[:ix]
     return templated
@@ -152,8 +152,8 @@ def run_onnx_eval(
 
     Scoring matches ``probabilityFromOnnxOutput`` in
     ``plugins/plugin-local-inference/src/services/voice/eot-classifier.ts``:
-    apply the chat template (minus trailing ``<|im_end|>``), forward,
-    then ``P(EOU) = softmax(logits[:, last_real_pos, :])[<|im_end|>]``.
+    apply the chat template (minus trailing ``<end_of_turn>``), forward,
+    then ``P(EOU) = softmax(logits[:, last_real_pos, :])[<end_of_turn>]``.
 
     When any record carries a non-``"und"`` ``lang`` field we additionally
     roll up ``f1ByLang[<lang>]`` into the report so the multilingual
@@ -172,12 +172,12 @@ def run_onnx_eval(
     tokenizer = AutoTokenizer.from_pretrained(str(tokenizer_path.parent))
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
-    im_end_ids = tokenizer(LIVEKIT_IM_END_TOKEN, add_special_tokens=False)[
+    eot_ids = tokenizer(GEMMA_END_OF_TURN_TOKEN, add_special_tokens=False)[
         "input_ids"
     ]
-    if not im_end_ids:
-        raise SystemExit("tokenizer did not produce an <|im_end|> id")
-    im_end_id = int(im_end_ids[0])
+    if not eot_ids:
+        raise SystemExit("tokenizer did not produce an <end_of_turn> id")
+    eot_id = int(eot_ids[0])
     session = onnxruntime.InferenceSession(
         str(model_path), providers=["CPUExecutionProvider"]
     )
@@ -202,7 +202,7 @@ def run_onnx_eval(
         last_logits = logits[0, -1, :].astype("float64")
         last_logits = last_logits - last_logits.max()
         probs = np.exp(last_logits) / np.exp(last_logits).sum()
-        probability = float(probs[im_end_id])
+        probability = float(probs[eot_id])
         predictions.append(1 if probability >= decision_threshold else 0)
         golds.append(r.label)
         langs.append(r.lang)

--- a/packages/training/scripts/turn_detector/finetune_turn_detector.py
+++ b/packages/training/scripts/turn_detector/finetune_turn_detector.py
@@ -52,7 +52,7 @@ DEFAULT_ELIZA1_REPO: Final[str] = "elizaos/eliza-1"
 # Supported teacher backends. `eliza-1-drafter` produces a GGUF LoRA
 # adapter the runtime layers onto the in-process drafter at voice
 # session start (`plugins/plugin-local-inference/src/services/voice/
-# eliza1-eot-scorer.ts`); the runtime reads P(`<|im_end|>`) directly off
+# eliza1-eot-scorer.ts`); the runtime reads P(`<end_of_turn>`) directly off
 # the live model, so the trained artifact is a LoRA adapter rather than
 # a standalone ONNX graph. `livekit` and `turnsense` retain the legacy
 # ONNX export path.
@@ -329,7 +329,7 @@ def build_eou_prefix_corpus(
     (EOU=0). This is the signal the LiveKit detector is trained on —
     "is this transcript a complete turn vs. a mid-utterance prefix?"
     — and it matches the runtime semantics (the streaming ASR feeds
-    growing prefixes; we score P(<|im_end|>) on each one).
+    growing prefixes; we score P(<end_of_turn>) on each one).
 
     Output JSONL schema mirrors ``build_pretrain_corpus``::
 
@@ -757,11 +757,11 @@ def build_sft_corpus(
 
         {
           "prompt": "<task instruction>\\n<utterance>",
-          "completion": "<|im_end|>" | "...",
+          "completion": "<end_of_turn>" | "...",
           "label": 0 | 1,
         }
 
-    The "completion" is the LiveKit-style next-token target: ``<|im_end|>``
+    The "completion" is the Gemma next-token target: ``<end_of_turn>``
     when the user is done speaking (`label=1`), and a continuation marker
     (``"..."``) otherwise. The prompt frames the task explicitly so the
     fine-tuned head learns to score next-token EOU under the chat template.
@@ -790,12 +790,12 @@ def build_sft_corpus(
                 neg.append(record)
     half = target_pairs // 2
     chosen = pos[:half] + neg[:half]
-    instruction = "Decide if the user is done speaking. Output <|im_end|> if done, otherwise continue."
+    instruction = "Decide if the user is done speaking. Output <end_of_turn> if done, otherwise continue."
 
     written = 0
     with out_path.open("w", encoding="utf-8") as fh:
         for record in chosen:
-            completion = "<|im_end|>" if record["eou_label"] == 1 else "..."
+            completion = "<end_of_turn>" if record["eou_label"] == 1 else "..."
             fh.write(
                 json.dumps(
                     {
@@ -810,16 +810,16 @@ def build_sft_corpus(
     return out_path
 
 
-LIVEKIT_IM_END_TOKEN: Final[str] = "<|im_end|>"
+GEMMA_END_OF_TURN_TOKEN: Final[str] = "<end_of_turn>"
 
 
 def _format_livekit_prompt(tokenizer: Any, utterance: str) -> str:
     """Replicate the runtime LiveKit prompt format.
 
-    Mirrors ``formatLiveKitTurnDetectorPrompt`` in
-    ``plugins/plugin-local-inference/src/services/voice/eot-classifier.ts``:
+    Mirrors ``formatEotPrompt`` in
+    ``plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts``:
     apply the tokenizer's chat template for ``[{role: user, content: ...}]``,
-    then strip the trailing ``<|im_end|>`` so the model's last-position
+    then strip the trailing ``<end_of_turn>`` so the model's last-position
     next-token distribution is what the runtime scores.
     """
     templated = tokenizer.apply_chat_template(
@@ -828,7 +828,7 @@ def _format_livekit_prompt(tokenizer: Any, utterance: str) -> str:
         tokenize=False,
         add_special_tokens=False,
     )
-    ix = templated.rfind(LIVEKIT_IM_END_TOKEN)
+    ix = templated.rfind(GEMMA_END_OF_TURN_TOKEN)
     if ix >= 0:
         templated = templated[:ix]
     return templated
@@ -848,11 +848,11 @@ def build_examples(
     Returns ``(input_ids, attention_mask, labels)`` numpy arrays.
     ``labels[i] == 1`` means EOU. Text is passed through the LiveKit chat
     template (mirroring ``formatLiveKitTurnDetectorPrompt``) with the
-    trailing ``<|im_end|>`` stripped. Right-padding (``attention_mask``
+    trailing ``<end_of_turn>`` stripped. Right-padding (``attention_mask``
     indicates which positions are real) so the runtime ONNX path
     (left-truncation, single-sample batch) and our training batch path
     agree on which logit corresponds to the next-token EOU prediction —
-    we pluck ``logits[i, last_real_pos, im_end_id]``.
+    we pluck ``logits[i, last_real_pos, eot_id]``.
     """
     try:
         from transformers import AutoTokenizer  # type: ignore[import-not-found]
@@ -915,15 +915,15 @@ def build_examples(
     )
 
 
-def im_end_token_id(tokenizer: Any) -> int:
-    """Resolve the ``<|im_end|>`` token id for the LiveKit tokenizer.
+def end_of_turn_token_id(tokenizer: Any) -> int:
+    """Resolve the Gemma ``<end_of_turn>`` token id.
 
-    Matches the runtime resolver: tokenize the literal ``<|im_end|>``
+    Matches the runtime resolver: tokenize the literal ``<end_of_turn>``
     sequence with ``add_special_tokens=False`` and take the first id.
     """
-    ids = tokenizer(LIVEKIT_IM_END_TOKEN, add_special_tokens=False)["input_ids"]
+    ids = tokenizer(GEMMA_END_OF_TURN_TOKEN, add_special_tokens=False)["input_ids"]
     if not ids:
-        raise RuntimeError("tokenizer did not produce an <|im_end|> id")
+        raise RuntimeError("tokenizer did not produce an <end_of_turn> id")
     return int(ids[0])
 
 
@@ -948,13 +948,13 @@ def train_step(
     model: Any,
     batch: "tuple[Any, Any, Any]",
     optimizer: Any,
-    im_end_id: int,
+    eot_id: int,
 ) -> float:
     """One APOLLO training step on (input_ids, attention_mask, labels).
 
-    Predicts EOU as ``softmax(logits[i, last_real_pos, :])[<|im_end|>]``,
+    Predicts EOU as ``softmax(logits[i, last_real_pos, :])[<end_of_turn>]``,
     where ``last_real_pos`` is derived from ``attention_mask``. Loss is
-    binary cross-entropy with logits between that scalar (the im_end
+    binary cross-entropy with logits between that scalar (the EOT
     logit minus the log-sum-exp of all other vocab logits at that
     position) and the EOU label. This is the same quantity the runtime
     scores in ``probabilityFromOnnxOutput``.
@@ -977,14 +977,14 @@ def train_step(
     last_pos = _last_real_position(attention_mask)
     batch_idx = torch.arange(logits.size(0), device=device)
     last_logits = logits[batch_idx, last_pos]  # [batch, vocab]
-    # log p(im_end) - log p(other) = im_end_logit - logsumexp(other_logits)
-    im_end_logit = last_logits[:, im_end_id]
+    # log p(EOT) - log p(other) = eot_logit - logsumexp(other_logits)
+    eot_logit = last_logits[:, eot_id]
     other_logits = torch.cat(
-        [last_logits[:, :im_end_id], last_logits[:, im_end_id + 1 :]],
+        [last_logits[:, :eot_id], last_logits[:, eot_id + 1 :]],
         dim=1,
     )
     other_lse = torch.logsumexp(other_logits, dim=1)
-    score = im_end_logit - other_lse  # binary logit for P(EOU)
+    score = eot_logit - other_lse  # binary logit for P(EOU)
     loss = F.binary_cross_entropy_with_logits(score, labels)
     loss.backward()
     optimizer.step()
@@ -1022,7 +1022,7 @@ def _eval_loop(
     eval_input_ids: Any,
     eval_attention_mask: Any,
     eval_labels: Any,
-    im_end_id: int,
+    eot_id: int,
     batch_size: int,
     decision_threshold: float = 0.5,
 ) -> "tuple[float, float]":
@@ -1049,7 +1049,7 @@ def _eval_loop(
             batch_idx = torch.arange(logits.size(0), device=device)
             last_logits = logits[batch_idx, last_pos]
             probs = torch.softmax(last_logits.float(), dim=-1)
-            eou_p = probs[:, im_end_id]
+            eou_p = probs[:, eot_id]
             preds.extend(
                 (eou_p >= decision_threshold).cpu().numpy().astype(int).tolist()
             )
@@ -1133,7 +1133,7 @@ def train_lora(
         tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "right"
     tokenizer.truncation_side = "left"
-    im_end_id = im_end_token_id(tokenizer)
+    eot_id = end_of_turn_token_id(tokenizer)
 
     input_ids, attention_mask, labels = build_examples(
         pretrain_jsonl,
@@ -1177,7 +1177,7 @@ def train_lora(
                 "f1": f1,
                 "teacher_repo": cfg.teacher_repo,
                 "teacher_revision": cfg.teacher_revision,
-                "im_end_id": im_end_id,
+                "end_of_turn_id": eot_id,
             },
             ckpt_path,
         )
@@ -1207,7 +1207,7 @@ def train_lora(
                 model=base_model,
                 batch=batch,
                 optimizer=optimizer,
-                im_end_id=im_end_id,
+                eot_id=eot_id,
             )
             step += 1
             if step % 25 == 0:
@@ -1219,7 +1219,7 @@ def train_lora(
                     eval_input_ids=eval_input_ids_t,
                     eval_attention_mask=eval_attention_mask_t,
                     eval_labels=eval_labels_t,
-                    im_end_id=im_end_id,
+                    eot_id=eot_id,
                     batch_size=batch_size,
                     decision_threshold=decision_threshold,
                 )
@@ -1258,7 +1258,7 @@ def train_lora(
             eval_input_ids=eval_input_ids_t,
             eval_attention_mask=eval_attention_mask_t,
             eval_labels=eval_labels_t,
-            im_end_id=im_end_id,
+            eot_id=eot_id,
             batch_size=batch_size,
             decision_threshold=decision_threshold,
         )
@@ -1275,7 +1275,7 @@ def train_lora(
         "last_mean_pos_score": last_mean_pos_score,
         "top_k": top_k,
         "f1_gate": cfg.f1_gate,
-        "im_end_id": im_end_id,
+        "end_of_turn_id": eot_id,
         "teacher_repo": cfg.teacher_repo,
         "teacher_revision": cfg.teacher_revision,
     }
@@ -1322,7 +1322,7 @@ def export_onnx(
     ``onnxruntime.quantization.quantize_dynamic``. Output shape is
     ``[batch, seq, vocab]`` matching the upstream LiveKit ONNX so the
     runtime's ``probabilityFromOnnxOutput`` (which extracts
-    ``softmax(logits[:, -1, :])[<|im_end|>]``) drops in.
+    ``softmax(logits[:, -1, :])[<end_of_turn>]``) drops in.
     """
     try:
         import torch

--- a/packages/training/scripts/turn_detector/push_to_hf.py
+++ b/packages/training/scripts/turn_detector/push_to_hf.py
@@ -155,7 +155,7 @@ mid-utterance prefix as a negative (EOU=0)).
 {arch_note} The runtime
 (`plugins/plugin-local-inference/src/services/voice/eot-classifier.ts`)
 scores end-of-turn probability as
-`softmax(logits[:, last_real_pos, :])[<|im_end|>]` — same shape as the
+`softmax(logits[:, last_real_pos, :])[<end_of_turn>]` — same shape as the
 upstream LiveKit ONNX, drop-in compatible.
 
 ## Files
@@ -172,7 +172,7 @@ fine-tune).
 - Optimizer: APOLLO-Mini (rank-1 tensor-wise scaling, smallest optimizer
   state — see `packages/training/AGENTS.md` §1).
 - Loss: binary cross-entropy on
-  `(im_end_logit - logsumexp(other_logits))` at the last real token
+  `(end_of_turn_logit - logsumexp(other_logits))` at the last real token
   position. This is the same quantity the runtime softmax-projects.
 {training_block}
 

--- a/packages/training/scripts/turn_detector/smoke_test_intl.py
+++ b/packages/training/scripts/turn_detector/smoke_test_intl.py
@@ -6,7 +6,7 @@ plus two non-English samples (Spanish, Japanese), covering complete
 utterances and mid-utterance prefixes for each. Runs against the same
 scoring path as ``probabilityFromOnnxOutput`` in the runtime:
 
-    P(EOU) = softmax(logits[:, last_real_pos, :])[<|im_end|>]
+    P(EOU) = softmax(logits[:, last_real_pos, :])[<end_of_turn>]
 
 Exit code:
   0 — every complete utterance scored ≥ ``--decision-threshold`` and
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Final
 
 
-LIVEKIT_IM_END_TOKEN: Final[str] = "<|im_end|>"
+GEMMA_END_OF_TURN_TOKEN: Final[str] = "<end_of_turn>"
 
 # Hand-crafted bilingual EOU / non-EOU pairs. Each row covers a single
 # "complete utterance vs. random mid-utterance prefix" comparison.
@@ -101,16 +101,16 @@ def _format_livekit_prompt(tokenizer: Any, transcript: str) -> str:
         tokenize=False,
         add_special_tokens=False,
     )
-    ix = templated.rfind(LIVEKIT_IM_END_TOKEN)
+    ix = templated.rfind(GEMMA_END_OF_TURN_TOKEN)
     if ix >= 0:
         templated = templated[:ix]
     return templated
 
 
-def _resolve_im_end_id(tokenizer: Any) -> int:
-    ids = tokenizer(LIVEKIT_IM_END_TOKEN, add_special_tokens=False)["input_ids"]
+def _resolve_end_of_turn_id(tokenizer: Any) -> int:
+    ids = tokenizer(GEMMA_END_OF_TURN_TOKEN, add_special_tokens=False)["input_ids"]
     if not ids:
-        raise SystemExit("tokenizer did not produce an <|im_end|> id")
+        raise SystemExit("tokenizer did not produce an <end_of_turn> id")
     return int(ids[0])
 
 
@@ -147,7 +147,7 @@ def smoke_test(
     tokenizer = AutoTokenizer.from_pretrained(str(tokenizer_path))
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
-    im_end_id = _resolve_im_end_id(tokenizer)
+    eot_id = _resolve_end_of_turn_id(tokenizer)
     session = onnxruntime.InferenceSession(
         str(model_path), providers=["CPUExecutionProvider"],
     )
@@ -169,7 +169,7 @@ def smoke_test(
         logits = outputs[0][0, -1, :].astype("float64")
         logits = logits - logits.max()
         probs = np.exp(logits) / np.exp(logits).sum()
-        return float(probs[im_end_id])
+        return float(probs[eot_id])
 
     for case in cases:
         lang = case["lang"]

--- a/packages/training/scripts/turn_detector/test_turn_detector_pipeline.py
+++ b/packages/training/scripts/turn_detector/test_turn_detector_pipeline.py
@@ -98,6 +98,68 @@ def test_load_config_rejects_missing_keys(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Gemma EOT token/template contract
+# ---------------------------------------------------------------------------
+
+
+class _FakeGemmaTokenizer:
+    def __init__(self) -> None:
+        self.token_requests: list[str] = []
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        add_generation_prompt: bool,
+        tokenize: bool,
+        add_special_tokens: bool,
+    ) -> str:
+        assert messages == [{"role": "user", "content": "hello there"}]
+        assert add_generation_prompt is False
+        assert tokenize is False
+        assert add_special_tokens is False
+        return "<start_of_turn>user\nhello there<end_of_turn>\n"
+
+    def __call__(self, text: str, *, add_special_tokens: bool) -> dict[str, list[int]]:
+        self.token_requests.append(text)
+        assert add_special_tokens is False
+        return {"input_ids": [42] if text == "<end_of_turn>" else [13]}
+
+
+def test_turn_detector_formats_gemma_prompt_without_end_token() -> None:
+    tokenizer = _FakeGemmaTokenizer()
+    prompt = fld._format_livekit_prompt(tokenizer, "hello there")
+    assert prompt == "<start_of_turn>user\nhello there"
+    assert "<end_of_turn>" not in prompt
+    assert "<|im_" not in prompt
+
+
+def test_turn_detector_resolves_gemma_end_of_turn_token() -> None:
+    tokenizer = _FakeGemmaTokenizer()
+    assert fld.end_of_turn_token_id(tokenizer) == 42
+    assert tokenizer.token_requests == ["<end_of_turn>"]
+
+
+def test_build_sft_corpus_targets_gemma_end_of_turn(tmp_path: Path) -> None:
+    pretrain = tmp_path / "pretrain.jsonl"
+    pretrain.write_text(
+        "\n".join(
+            [
+                json.dumps({"utterance": "done.", "eou_label": 1}),
+                json.dumps({"utterance": "not yet", "eou_label": 0}),
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out_path = fld.build_sft_corpus(pretrain, tmp_path / "sft", target_pairs=2)
+    rows = [json.loads(line) for line in out_path.read_text().splitlines()]
+    assert rows[0]["completion"] == "<end_of_turn>"
+    assert rows[1]["completion"] == "..."
+    assert "<|im_" not in out_path.read_text()
+
+
+# ---------------------------------------------------------------------------
 # stage_data
 # ---------------------------------------------------------------------------
 

--- a/packages/training/scripts/voice/eot/eval_eot_lora.py
+++ b/packages/training/scripts/voice/eot/eval_eot_lora.py
@@ -247,13 +247,13 @@ def score_with_livekit_gguf(
         ) from exc
 
     model = Llama(model_path=str(gguf_path), n_ctx=2048, verbose=False, logits_all=False)
-    # Find the <|im_end|> token id.
-    im_end_tokens = model.tokenize("<|im_end|>".encode("utf-8"), add_bos=False)
-    if len(im_end_tokens) != 1:
+    # Find the Gemma <end_of_turn> token id.
+    eot_tokens = model.tokenize("<end_of_turn>".encode("utf-8"), add_bos=False)
+    if len(eot_tokens) != 1:
         raise RuntimeError(
-            f"expected <|im_end|> to be 1 token in this GGUF, got {len(im_end_tokens)}"
+            f"expected <end_of_turn> to be 1 token in this GGUF, got {len(eot_tokens)}"
         )
-    im_end_id = im_end_tokens[0]
+    eot_id = eot_tokens[0]
 
     scores: list[float] = []
     latencies: list[float] = []
@@ -263,13 +263,13 @@ def score_with_livekit_gguf(
         model.reset()
         model.eval(tokens)
         logits = model.scores[len(tokens) - 1]  # last-position logits
-        # Softmax just over the relevant slice to get P(im_end).
+        # Softmax just over the relevant slice to get P(end_of_turn).
         import math
 
         max_logit = max(logits)
         exp_logits = [math.exp(x - max_logit) for x in logits]
         denom = sum(exp_logits)
-        scores.append(exp_logits[im_end_id] / denom)
+        scores.append(exp_logits[eot_id] / denom)
         latencies.append((time.perf_counter() - start) * 1000)
     return scores, latencies
 

--- a/plugins/plugin-local-inference/src/services/voice/eot-classifier.ts
+++ b/plugins/plugin-local-inference/src/services/voice/eot-classifier.ts
@@ -23,7 +23,7 @@
  *     fallback for a measured turn signal.
  *
  *   `Eliza1EotClassifier` — uses the already-loaded text model to compute
- *     P(`<|im_end|>` | partial transcript). Zero additional model weights.
+ *     P(`<end_of_turn>` | partial transcript). Zero additional model weights.
  *
  *   The GGUF-backed LiveKit detector lives in `eot-classifier-ggml.ts`.
  *
@@ -296,7 +296,7 @@ export type { Eliza1EotScoreResult, Eliza1EotScorerOptions };
 /**
  * Eliza-1 EOT classifier. Reuses the already-loaded text model (typically
  * the eliza-1 drafter — same model MTP keeps warm for speculative
- * decoding) to compute P(`<|im_end|>` | partial transcript). Optionally
+ * decoding) to compute P(`<end_of_turn>` | partial transcript). Optionally
  * loads a fine-tuned EOT LoRA adapter on top of the base weights — see
  * `packages/training/scripts/turn_detector/` for the training recipe.
  *
@@ -347,7 +347,7 @@ export const COMPOSITE_HEURISTIC_CONFIDENCE_CUTOFF = 0.6;
 
 /**
  * End-of-turn classifier that blends the fused semantic scorer
- * (P(`<|im_end|>`) over the loaded text model) with the heuristic syntactic
+ * (P(`<end_of_turn>`) over the loaded text model) with the heuristic syntactic
  * rules. The heuristic is NOT a fallback — it is a tuned co-signal: when it is
  * confident (clear punctuation / mid-clause conjunction / dangling preposition)
  * its verdict wins outright and the model pass is skipped; in the ambiguous


### PR DESCRIPTION
## Summary
- Switch the turn-detector training, eval, and smoke helpers from ChatML `<|im_end|>` to Gemma `<end_of_turn>`.
- Update the EOT LoRA GGUF evaluator and runtime/training comments so the training target matches the active Gemma scorer.
- Add CPU-only regression coverage for Gemma prompt stripping, token resolution, and SFT corpus completions.

## Evidence
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `python3 -m py_compile packages/training/scripts/turn_detector/finetune_turn_detector.py packages/training/scripts/turn_detector/eval_turn_detector.py packages/training/scripts/turn_detector/smoke_test_intl.py packages/training/scripts/turn_detector/push_to_hf.py packages/training/scripts/voice/eot/eval_eot_lora.py`
- `python3 -m pytest packages/training/scripts/turn_detector/test_turn_detector_pipeline.py packages/training/scripts/voice/eot/test_eot_lora_gemma.py -q`
- Targeted stale-token scan over patched surfaces returned no matches.
- `git diff --check origin/develop...HEAD`
- `bun run verify`
- `packages/app audit:app` N/A: no app UI changes.
