### PR TITLE
build: consolidate 6 more provider build.ts onto the shared driver (#9626)

### DIFF
--- a/plugins/plugin-anthropic-proxy/build.ts
+++ b/plugins/plugin-anthropic-proxy/build.ts
@@ -1,133 +1,44 @@
 #!/usr/bin/env bun
-
 /**
- * Build script for @elizaos/plugin-anthropic-proxy (Node + Browser).
+ * Build script for @elizaos/plugin-anthropic-proxy (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+const reexport = (from: string) =>
+  `export * from "${from}";\nexport { default } from "${from}";\n`;
 
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build() {
-  const totalStart = Date.now();
-  const distDir = join(process.cwd(), "dist");
-
-  // Node build
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-anthropic-proxy for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: join(distDir, "node"),
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node build failed:", nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(
-    `✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`,
-  );
-
-  // Browser build (unavailable entry)
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-anthropic-proxy for Browser...");
-  const browserResult = await Bun.build({
-    entrypoints: ["index.browser.ts"],
-    outdir: join(distDir, "browser"),
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error("Browser build failed:", browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(
-    `✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`,
-  );
-
-  // Node CJS build
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-anthropic-proxy for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: join(distDir, "cjs"),
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error("CJS build failed:", cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  try {
-    const { rename } = await import("node:fs/promises");
-    await rename(
-      join(distDir, "cjs", "index.node.js"),
-      join(distDir, "cjs", "index.node.cjs"),
-    );
-  } catch (e) {
-    console.warn("CJS rename step warning:", e);
-  }
-  console.log(
-    `✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`,
-  );
-
-  // Declarations
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json --noCheck`;
-
-  const nodeDir = join(distDir, "node");
-  const browserDir = join(distDir, "browser");
-  const cjsDir = join(distDir, "cjs");
-  if (!existsSync(nodeDir)) await mkdir(nodeDir, { recursive: true });
-  if (!existsSync(browserDir)) await mkdir(browserDir, { recursive: true });
-  if (!existsSync(cjsDir)) await mkdir(cjsDir, { recursive: true });
-
-  const rootIndexDtsPath = join(distDir, "index.d.ts");
-  await writeFile(
-    rootIndexDtsPath,
-    `export * from "./node/index";\nexport { default } from "./node/index";\n`,
-    "utf8",
-  );
-  await writeFile(
-    join(nodeDir, "index.d.ts"),
-    `export * from "./index.node";\nexport { default } from "./index.node";\n`,
-    "utf8",
-  );
-  await writeFile(
-    join(browserDir, "index.d.ts"),
-    `export * from "./index.browser";\nexport { default } from "./index.browser";\n`,
-    "utf8",
-  );
-  await writeFile(
-    join(cjsDir, "index.d.ts"),
-    `export * from "./index.node";\nexport { default } from "./index.node";\n`,
-    "utf8",
-  );
-
-  console.log(
-    `✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`,
-  );
-  console.log(
-    `🎉 All builds completed in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`,
-  );
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-anthropic-proxy",
+  targets: [
+    {
+      label: "Node",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+    },
+    {
+      label: "Browser",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+    },
+    {
+      label: "Node (CJS)",
+      entry: "index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      renames: [["index.node.js", "index.node.cjs"]],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "index.d.ts", content: reexport("./node/index") },
+    { path: "node/index.d.ts", content: reexport("./index.node") },
+    { path: "browser/index.d.ts", content: reexport("./index.browser") },
+    { path: "cjs/index.d.ts", content: reexport("./index.node") },
+  ],
 });

--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -59,6 +59,12 @@ export interface BuildPluginConfig {
   targets: readonly BuildTarget[];
   /** tsconfig project passed to `tsc` for declaration emit. */
   dtsProject?: string;
+  /**
+   * Tolerate a failed `tsc` declaration emit (warn + continue with JS-only
+   * outputs) instead of aborting. Mirrors the per-package fallback some plugins
+   * carried; default false (fail loud).
+   */
+  dtsTolerant?: boolean;
   /** Declaration-alias shim files to write after tsc. */
   dtsShims?: readonly DtsShim[];
 }
@@ -124,7 +130,17 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
   if (config.dtsProject) {
     console.log("📝 Generating TypeScript declarations…");
     const project = config.dtsProject;
-    await Bun.$`tsc --project ${project} --noCheck`;
+    if (config.dtsTolerant) {
+      try {
+        await Bun.$`tsc --project ${project} --noCheck`;
+      } catch {
+        console.warn(
+          "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only.",
+        );
+      }
+    } else {
+      await Bun.$`tsc --project ${project} --noCheck`;
+    }
   }
 
   for (const shim of config.dtsShims ?? []) {

--- a/plugins/plugin-edge-tts/build.ts
+++ b/plugins/plugin-edge-tts/build.ts
@@ -1,115 +1,45 @@
 #!/usr/bin/env bun
 /**
- * Dual build script for @elizaos/plugin-edge-tts (Node + Browser)
+ * Build script for @elizaos/plugin-edge-tts (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+const reexport = (from: string) => `export * from '${from}';\nexport { default } from '${from}';\n`;
 
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build() {
-  const totalStart = Date.now();
-
-  // Node build
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-edge-tts for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-    naming: {
-      entry: "index.node.js",
+await buildPlugin({
+  name: "@elizaos/plugin-edge-tts",
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      naming: { entry: "index.node.js" },
     },
-  });
-  if (!nodeResult.success) {
-    console.error(nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(`✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  // Browser build (unavailable entry - Edge TTS is Node-only)
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-edge-tts for Browser (unavailable entry)...");
-  const browserResult = await Bun.build({
-    entrypoints: ["src/index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error(browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  // Node CJS build
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-edge-tts for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/cjs",
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-    naming: {
-      entry: "index.node.js",
+    {
+      label: "Browser",
+      entry: "src/index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
     },
-  });
-  if (!cjsResult.success) {
-    console.error(cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  // Rename .js to .cjs for correct loading when package type is module
-  try {
-    const { rename } = await import("node:fs/promises");
-    await rename("dist/cjs/index.node.js", "dist/cjs/index.node.cjs");
-  } catch (error) {
-    // If file not found (different bundling output), surface the error
-    console.warn("CJS rename step warning:", error);
-  }
-  console.log(`✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`);
-
-  // TypeScript declarations
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json --noCheck`;
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-  await writeFile(
-    "dist/node/index.d.ts",
-    `export * from '../index.node';
-export { default } from '../index.node';
-`
-  );
-  await writeFile(
-    "dist/browser/index.d.ts",
-    `export * from '../index.browser';
-export { default } from '../index.browser';
-`
-  );
-  await writeFile(
-    "dist/cjs/index.d.ts",
-    `export * from '../index';
-export { default } from '../index';
-`
-  );
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  console.log(`🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+    {
+      label: "Node (CJS)",
+      entry: "src/index.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      naming: { entry: "index.node.js" },
+      renames: [["index.node.js", "index.node.cjs"]],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport("../index.node") },
+    { path: "browser/index.d.ts", content: reexport("../index.browser") },
+    { path: "cjs/index.d.ts", content: reexport("../index") },
+  ],
 });

--- a/plugins/plugin-elevenlabs/build.ts
+++ b/plugins/plugin-elevenlabs/build.ts
@@ -1,130 +1,48 @@
 #!/usr/bin/env bun
-
 /**
- * Dual build script for @elizaos/plugin-elevenlabs (Node + Browser)
+ * Build script for @elizaos/plugin-elevenlabs (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+const reexport = (from: string) =>
+  `export * from "${from}";\nexport { default } from "${from}";\n`;
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build() {
-  const totalStart = Date.now();
-  await rm("dist", { recursive: true, force: true });
-
-  // Node build
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-elevenlabs for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.node.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error(nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(
-    `✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`,
-  );
-
-  // Browser build
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-elevenlabs for Browser...");
-  const browserResult = await Bun.build({
-    entrypoints: ["src/index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error(browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(
-    `✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`,
-  );
-
-  // Node CJS build
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-elevenlabs for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["src/index.node.ts"],
-    outdir: "dist/cjs",
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error(cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  if (existsSync("dist/cjs/index.node.js")) {
-    await rename("dist/cjs/index.node.js", "dist/cjs/index.node.cjs");
-  }
-  if (existsSync("dist/cjs/index.node.js.map")) {
-    await rename("dist/cjs/index.node.js.map", "dist/cjs/index.node.cjs.map");
-  }
-  if (!existsSync("dist/cjs/index.node.cjs")) {
-    throw new Error("CJS build did not produce dist/cjs/index.node.cjs");
-  }
-  console.log(
-    `✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`,
-  );
-
-  // TypeScript declarations
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const tsc = spawnSync(
-    "bunx",
-    ["tsc", "--project", "tsconfig.build.json", "--noCheck"],
+await buildPlugin({
+  name: "@elizaos/plugin-elevenlabs",
+  clean: true,
+  targets: [
     {
-      stdio: "inherit",
-      shell: false,
+      label: "Node",
+      entry: "src/index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
     },
-  );
-  if (tsc.status !== 0) {
-    throw new Error("TypeScript declaration emit failed");
-  }
-
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-  await mkdir("dist/cjs", { recursive: true });
-
-  const nodeTypes = `export * from "../index.node";
-export { default } from "../index.node";
-`;
-  const browserTypes = `export * from "../index.browser";
-export { default } from "../index.browser";
-`;
-
-  await writeFile("dist/node/index.d.ts", nodeTypes);
-  await writeFile("dist/browser/index.d.ts", browserTypes);
-  await writeFile("dist/cjs/index.d.ts", nodeTypes);
-
-  console.log(
-    `✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`,
-  );
-
-  console.log(
-    `🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`,
-  );
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+    {
+      label: "Browser",
+      entry: "src/index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
+    },
+    {
+      label: "Node (CJS)",
+      entry: "src/index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      renames: [
+        ["index.node.js", "index.node.cjs"],
+        ["index.node.js.map", "index.node.cjs.map"],
+      ],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport("../index.node") },
+    { path: "browser/index.d.ts", content: reexport("../index.browser") },
+    { path: "cjs/index.d.ts", content: reexport("../index.node") },
+  ],
 });

--- a/plugins/plugin-embeddings/build.ts
+++ b/plugins/plugin-embeddings/build.ts
@@ -1,99 +1,50 @@
-import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-embeddings (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const ROOT = resolve(dirname(import.meta.path));
-const DIST = join(ROOT, "dist");
-const RM_RECURSIVE_SCRIPT = join(ROOT, "..", "..", "packages", "scripts", "rm-path-recursive.mjs");
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated plugin-embeddings build output ${targetPath}`);
-  }
-}
-
-rmRecursive(DIST);
-mkdirSync(DIST, { recursive: true });
-mkdirSync(join(DIST, "node"), { recursive: true });
-mkdirSync(join(DIST, "browser"), { recursive: true });
-mkdirSync(join(DIST, "cjs"), { recursive: true });
-
-const EXTERNAL = ["@elizaos/core"];
-
-console.log("Building Node.js ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "node"),
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.node.js",
-  },
+await buildPlugin({
+  name: "@elizaos/plugin-embeddings",
+  clean: true,
+  externals: ["@elizaos/core"],
+  targets: [
+    {
+      label: "Node ESM",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.node.js" },
+    },
+    {
+      label: "Browser ESM",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.browser.js" },
+    },
+    {
+      label: "CJS",
+      entry: "index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "linked",
+      naming: { entry: "index.node.cjs" },
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+    { path: "cjs/index.d.ts", content: reexport },
+  ],
 });
-
-console.log("Building Browser ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.browser.ts")],
-  outdir: join(DIST, "browser"),
-  target: "browser",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.browser.js",
-  },
-});
-
-console.log("Building CJS bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "cjs"),
-  target: "node",
-  format: "cjs",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.node.cjs",
-  },
-});
-
-console.log("Generating TypeScript declarations...");
-const { mkdir, writeFile } = await import("node:fs/promises");
-const { $ } = await import("bun");
-try {
-  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
-  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
-  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
-  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json --noCheck`;
-} catch {
-  console.warn(
-    "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."
-  );
-}
-
-await mkdir("dist/node", { recursive: true });
-await mkdir("dist/browser", { recursive: true });
-await mkdir("dist/cjs", { recursive: true });
-
-const reexportDeclaration = `export * from '../index';
-export { default } from '../index';
-`;
-
-await writeFile("dist/node/index.d.ts", reexportDeclaration);
-await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-await writeFile("dist/cjs/index.d.ts", reexportDeclaration);
-
-console.log("Build complete!");

--- a/plugins/plugin-embeddings/tsconfig.build.json
+++ b/plugins/plugin-embeddings/tsconfig.build.json
@@ -28,5 +28,5 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "__tests__", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "build.ts", "__tests__", "**/*.test.ts"]
 }

--- a/plugins/plugin-lmstudio/build.ts
+++ b/plugins/plugin-lmstudio/build.ts
@@ -1,88 +1,50 @@
-import { mkdirSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-lmstudio (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const ROOT = resolve(dirname(import.meta.path));
-const DIST = join(ROOT, "dist");
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-rmSync(DIST, { recursive: true, force: true });
-mkdirSync(DIST, { recursive: true });
-mkdirSync(join(DIST, "node"), { recursive: true });
-mkdirSync(join(DIST, "browser"), { recursive: true });
-mkdirSync(join(DIST, "cjs"), { recursive: true });
-
-const EXTERNAL = ["@elizaos/core", "ai", "@ai-sdk/openai-compatible"];
-
-console.log("Building Node.js ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "node"),
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.node.js",
-  },
+await buildPlugin({
+  name: "@elizaos/plugin-lmstudio",
+  clean: true,
+  externals: ["@elizaos/core", "ai", "@ai-sdk/openai-compatible"],
+  targets: [
+    {
+      label: "Node ESM",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.node.js" },
+    },
+    {
+      label: "Browser ESM",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.browser.js" },
+    },
+    {
+      label: "CJS",
+      entry: "index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "linked",
+      naming: { entry: "index.node.cjs" },
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+    { path: "cjs/index.d.ts", content: reexport },
+  ],
 });
-
-console.log("Building Browser ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.browser.ts")],
-  outdir: join(DIST, "browser"),
-  target: "browser",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.browser.js",
-  },
-});
-
-console.log("Building CJS bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "cjs"),
-  target: "node",
-  format: "cjs",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: EXTERNAL,
-  naming: {
-    entry: "index.node.cjs",
-  },
-});
-
-console.log("Generating TypeScript declarations...");
-const { mkdir, writeFile } = await import("node:fs/promises");
-const { $ } = await import("bun");
-try {
-  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
-  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
-  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
-  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json --noCheck`;
-} catch {
-  console.warn(
-    "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."
-  );
-}
-
-await mkdir("dist/node", { recursive: true });
-await mkdir("dist/browser", { recursive: true });
-await mkdir("dist/cjs", { recursive: true });
-
-const reexportDeclaration = `export * from '../index';
-export { default } from '../index';
-`;
-
-await writeFile("dist/node/index.d.ts", reexportDeclaration);
-await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-await writeFile("dist/cjs/index.d.ts", reexportDeclaration);
-
-console.log("Build complete!");

--- a/plugins/plugin-lmstudio/tsconfig.build.json
+++ b/plugins/plugin-lmstudio/tsconfig.build.json
@@ -28,5 +28,5 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "__tests__", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "build.ts", "__tests__", "**/*.test.ts"]
 }

--- a/plugins/plugin-ollama/build.ts
+++ b/plugins/plugin-ollama/build.ts
@@ -1,86 +1,50 @@
-import { mkdirSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-ollama (Node + Browser + CJS).
+ * Orchestration lives in the shared driver; this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const ROOT = resolve(dirname(import.meta.path));
-const DIST = join(ROOT, "dist");
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-rmSync(DIST, { recursive: true, force: true });
-mkdirSync(DIST, { recursive: true });
-mkdirSync(join(DIST, "node"), { recursive: true });
-mkdirSync(join(DIST, "browser"), { recursive: true });
-mkdirSync(join(DIST, "cjs"), { recursive: true });
-
-console.log("Building Node.js ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "node"),
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2", "zod"],
-  naming: {
-    entry: "index.node.js",
-  },
+await buildPlugin({
+  name: "@elizaos/plugin-ollama",
+  clean: true,
+  externals: ["@elizaos/core", "ai", "ollama-ai-provider-v2", "zod"],
+  targets: [
+    {
+      label: "Node ESM",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.node.js" },
+    },
+    {
+      label: "Browser ESM",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      sourcemap: "linked",
+      naming: { entry: "index.browser.js" },
+    },
+    {
+      label: "CJS",
+      entry: "index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "linked",
+      naming: { entry: "index.node.cjs" },
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+    { path: "cjs/index.d.ts", content: reexport },
+  ],
 });
-
-console.log("Building Browser ESM bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.browser.ts")],
-  outdir: join(DIST, "browser"),
-  target: "browser",
-  format: "esm",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2", "zod"],
-  naming: {
-    entry: "index.browser.js",
-  },
-});
-
-console.log("Building CJS bundle...");
-await build({
-  entrypoints: [join(ROOT, "index.node.ts")],
-  outdir: join(DIST, "cjs"),
-  target: "node",
-  format: "cjs",
-  splitting: false,
-  sourcemap: "linked",
-  minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2", "zod"],
-  naming: {
-    entry: "index.node.cjs",
-  },
-});
-
-console.log("Generating TypeScript declarations...");
-const { mkdir, writeFile } = await import("node:fs/promises");
-const { $ } = await import("bun");
-try {
-  // Resolve tsc via bun PATH resolution (bunx). bun hoists tsc to the
-  // REPO-ROOT node_modules/.bin, so the per-plugin `${ROOT}/node_modules/.bin/
-  // tsc.exe` path does not exist on Windows — the spawn failed and the plugin
-  // silently shipped with no fresh .d.ts. bunx resolves tsc on every platform.
-  await $`bunx tsc --project tsconfig.build.json --noCheck`;
-} catch {
-  console.warn(
-    "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only."
-  );
-}
-
-await mkdir("dist/node", { recursive: true });
-await mkdir("dist/browser", { recursive: true });
-await mkdir("dist/cjs", { recursive: true });
-
-const reexportDeclaration = `export * from '../index';
-export { default } from '../index';
-`;
-
-await writeFile("dist/node/index.d.ts", reexportDeclaration);
-await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-await writeFile("dist/cjs/index.d.ts", reexportDeclaration);
-
-console.log("Build complete!");

--- a/plugins/plugin-ollama/tsconfig.build.json
+++ b/plugins/plugin-ollama/tsconfig.build.json
@@ -28,5 +28,5 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "__tests__", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "build.ts", "__tests__", "**/*.test.ts"]
 }


### PR DESCRIPTION
Continues the `build.ts` consolidation (TL;DR #2) from #9826, completing the model/TTS-provider family the audit flagged as "near-identical copies": **lmstudio, ollama, embeddings, edge-tts, elevenlabs, anthropic-proxy** (14 providers total across both PRs).

Each becomes a declarative `buildPlugin({...})` call. Extends the shared driver with one option — `dtsTolerant` (warn+continue if the `tsc` d.ts emit fails, mirroring the JS-only fallback lmstudio/ollama/embeddings carried). Also excludes `build.ts` from those three packages' `tsconfig.build.json` so the build *script's* own dead declaration (`dist/{node,cjs}/build.d.ts`, never in `exports`) is no longer shipped — it was emitted only because their `include` is `**/*.ts`.

**−346 net LOC** (651 → 287 across the 6 build.ts, +18 in the driver).

### Evidence — byte-verified
Built original vs driver `dist/` and `diff -rq`'d the full tree for all 6:
- anthropic-proxy / edge-tts / elevenlabs → **fully byte-identical**.
- lmstudio / ollama / embeddings → identical except the intentionally-dropped dead `build.d.ts`.
Covers Bun `naming` output, single + double renames (`.js` + `.js.map`), `src/`-prefixed entries, and per-target alias shims. Confirmed no stray `plugin-build.d.ts` pollution (no-extension import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)