### PR TITLE
fix(feed): complete Steward OAuth login (read code from URL fragment) + remove Farcaster

### DIFF
--- a/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
+++ b/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
@@ -24,7 +24,8 @@ function isFeedOAuthProvider(value: string): value is FeedStewardOAuthProvider {
  * OAuth callback page for Steward OAuth providers (Google, Discord, Twitter/X).
  *
  * PKCE code flow (current):
- *   ?code=<nonce>  → POST /api/auth/steward/oauth/exchange → session cookies
+ *   #code=<nonce>  → POST /api/auth/steward/oauth/exchange → session cookies
+ *   (Steward returns the code in the URL fragment, not the query string.)
  *
  * Legacy token-in-URL flow (backward compat during rollout):
  *   ?token=<jwt>&refresh_token=<rt>
@@ -45,11 +46,18 @@ export default function OAuthCallbackPage() {
       return;
     }
 
-    const searchParams = new URLSearchParams(window.location.search);
-    const error = searchParams.get("error");
-    const code = searchParams.get("code");
-    const token = searchParams.get("token");
-    const refreshToken = searchParams.get("refresh_token") ?? undefined;
+    // Steward's PKCE flow returns the one-time code in the URL *fragment*
+    // (`#code=…&state=…`) — deliberately, so it stays out of server logs /
+    // Referer / browser history. Read the fragment first, then fall back to the
+    // query string for the legacy token-in-URL flow (`?token=…`).
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const queryParams = new URLSearchParams(window.location.search);
+    const pick = (key: string): string | null =>
+      hashParams.get(key) ?? queryParams.get(key);
+    const error = pick("error");
+    const code = pick("code");
+    const token = pick("token");
+    const refreshToken = pick("refresh_token") ?? undefined;
 
     window.history.replaceState(null, "", window.location.pathname);
 

--- a/packages/feed/apps/web/src/components/auth/LoginModal.tsx
+++ b/packages/feed/apps/web/src/components/auth/LoginModal.tsx
@@ -40,7 +40,6 @@ function buildFeedOAuthRedirectUri(
  * - Email magic link (no password)
  * - Passkey (WebAuthn)
  * - OAuth: Google, Discord, Twitter/X
- * - Farcaster SIWF
  */
 
 type Step = "idle" | "email-sent" | "loading" | "error";
@@ -250,13 +249,6 @@ export function LoginModal({
                 </Button>
               </div>
 
-              {/* Farcaster */}
-              <FarcasterSignInSection
-                onLoginSuccess={onLoginSuccess}
-                onClose={onClose}
-                loading={step === "loading"}
-              />
-
               <div className="relative flex items-center gap-3">
                 <div className="flex-1 border-t" />
                 <span className="text-muted-foreground text-xs">
@@ -318,85 +310,6 @@ export function LoginModal({
         </div>
       </DialogContent>
     </Dialog>
-  );
-}
-
-// ── Farcaster section ─────────────────────────────────────────────────────────
-
-function FarcasterSignInSection({
-  onLoginSuccess,
-  onClose,
-  loading,
-}: {
-  onLoginSuccess: (token: string) => Promise<void>;
-  onClose: () => void;
-  loading: boolean;
-}) {
-  const [error, setError] = useState("");
-  const [SignInButton, setSignInButton] = useState<React.ComponentType<{
-    onSuccess?: (res: unknown) => void;
-    onError?: (err: unknown) => void;
-  }> | null>(null);
-
-  useEffect(() => {
-    import("@farcaster/auth-kit")
-      .then((mod) => setSignInButton(() => mod.SignInButton))
-      .catch(() => {
-        // auth-kit unavailable — omit the button silently
-      });
-  }, []);
-
-  const handleSuccess = useCallback(
-    async (res: { message?: string; signature?: string; nonce?: string }) => {
-      setError("");
-      try {
-        const r = await fetch("/api/auth/farcaster", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({
-            message: res.message,
-            signature: res.signature,
-            nonce: res.nonce,
-          }),
-        });
-        const data = (await r.json()) as {
-          ok: boolean;
-          token?: string;
-          error?: string;
-        };
-        if (!data.ok || !data.token)
-          throw new Error(data.error ?? "Farcaster auth failed");
-        await onLoginSuccess(data.token);
-        onClose();
-      } catch (err) {
-        const msg =
-          err instanceof Error ? err.message : "Farcaster sign-in failed";
-        logger.warn("Farcaster SIWF failed", { error: msg }, "LoginModal");
-        setError(msg);
-      }
-    },
-    [onLoginSuccess, onClose],
-  );
-
-  if (!SignInButton) return null;
-
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <div className={loading ? "pointer-events-none opacity-50" : ""}>
-        <SignInButton
-          onSuccess={(res) =>
-            void handleSuccess(res as Parameters<typeof handleSuccess>[0])
-          }
-          onError={(err) => {
-            const msg =
-              err instanceof Error ? err.message : "Farcaster sign-in error";
-            setError(msg);
-          }}
-        />
-      </div>
-      {error && <p className="text-destructive text-xs">{error}</p>}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Login bounce fix
Steward's PKCE callback returns the one-time exchange code in the URL **fragment** (`setRedirectFragment` → `url.hash`: `#code=…&state=…`) to keep it out of server logs / Referer / history. The feed callback page read it from `window.location.search` (query), so `code` was always `null` → it redirected to `/?auth_error=missing_code` and **never called** `/api/auth/steward/oauth/exchange`. Net effect: Google sign-in returned to the login modal even though Steward issued a valid token.

Verified against steward-api logs: feed Google `callback` → **302**, but **no** `POST /auth/oauth/exchange` followed. Fix reads params from the fragment first (query fallback for the legacy `?token=` flow). Applies to all Steward OAuth providers (google/discord/twitter), which share the fragment-returning callback.

## Farcaster removal
Drops the Farcaster SIWF button + `FarcasterSignInSection` from `LoginModal` per request. Google/Discord/X OAuth, email magic link, and passkey remain.

Deployed to feed-web (Railway) alongside the already-applied Steward config fixes (feed tenant `join_mode=open` + OAuth redirect allowlist).