### PR TITLE
test(plugin-elizacloud): align cloud URL canonicalization

### DIFF
--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -43,7 +43,7 @@ describe("resolveHfDownloadBase", () => {
     process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.elizacloud.ai";
 
     expect(resolveHfDownloadBase()).toEqual({
-      base: "https://www.elizacloud.ai/api/v1/hf-proxy",
+      base: "https://elizacloud.ai/api/v1/hf-proxy",
       authHeader: { authorization: "Bearer key-123" },
       viaCloud: true,
     });

--- a/plugins/plugin-elizacloud/AGENTS.md
+++ b/plugins/plugin-elizacloud/AGENTS.md
@@ -200,7 +200,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 
 | Var | Default |
 |---|---|
-| `ELIZAOS_CLOUD_BASE_URL` | `https://www.elizacloud.ai/api/v1` |
+| `ELIZAOS_CLOUD_BASE_URL` | `https://elizacloud.ai/api/v1` |
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |

--- a/plugins/plugin-elizacloud/CLAUDE.md
+++ b/plugins/plugin-elizacloud/CLAUDE.md
@@ -200,7 +200,7 @@ All settings are optional except `ELIZAOS_CLOUD_API_KEY` (required for any authe
 
 | Var | Default |
 |---|---|
-| `ELIZAOS_CLOUD_BASE_URL` | `https://www.elizacloud.ai/api/v1` |
+| `ELIZAOS_CLOUD_BASE_URL` | `https://elizacloud.ai/api/v1` |
 | `ELIZAOS_CLOUD_ENABLED` | `false` — when true, enables container provisioning, device auth, bridge, and backup services |
 | `ELIZAOS_CLOUD_EXPERIMENTAL_TELEMETRY` | `false` |
 | `ELIZAOS_CLOUD_APP_VERSION` | `2.0.0-beta.0` |

--- a/plugins/plugin-elizacloud/README.md
+++ b/plugins/plugin-elizacloud/README.md
@@ -40,7 +40,7 @@ helpers in `src/utils/sdk-client.ts`:
 | `src/utils/cloud-api.ts` | Backwards-compatible re-export of SDK classes and types |
 
 `ELIZAOS_CLOUD_BASE_URL` remains the API base URL and defaults to
-`https://www.elizacloud.ai/api/v1`. `createElizaCloudClient` derives the site
+`https://elizacloud.ai/api/v1`. `createElizaCloudClient` derives the site
 root from that API URL when generated SDK route wrappers need `/api/v1/...`
 paths.
 
@@ -105,7 +105,7 @@ Get an API key from
 | Setting | Description | Default |
 | --- | --- | --- |
 | `ELIZAOS_CLOUD_API_KEY` | API key used for authenticated Cloud requests | Required |
-| `ELIZAOS_CLOUD_BASE_URL` | Eliza Cloud API base URL | `https://www.elizacloud.ai/api/v1` |
+| `ELIZAOS_CLOUD_BASE_URL` | Eliza Cloud API base URL | `https://elizacloud.ai/api/v1` |
 | `ELIZAOS_CLOUD_ENABLED` | Enables container provisioning, device auth, bridge, and backup services | `false` |
 | `ELIZAOS_CLOUD_NANO_MODEL` | Nano/cheapest model override | `NANO_MODEL` or `gpt-oss-120b` |
 | `ELIZAOS_CLOUD_SMALL_MODEL` | Small/fast model override | `SMALL_MODEL` or `gpt-oss-120b` |

--- a/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts
@@ -103,7 +103,7 @@ describe("handleCloudBillingRoute money proxies", () => {
       expect(response.headers.get("PAYMENT-REQUIRED")).toBe("encoded-payment-required");
       expect(upstreamRequest).toEqual({
         method: "POST",
-        url: "https://www.elizacloud.ai/api/v1/x402/requests",
+        url: "https://elizacloud.ai/api/v1/x402/requests",
         authorization: "Bearer eliza_test_key",
         body: {
           amountUsd: 5,

--- a/plugins/plugin-elizacloud/__tests__/unit/home-remote-runner-access-url.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/home-remote-runner-access-url.test.ts
@@ -14,7 +14,7 @@ describe("buildHomeRemoteRunnerAccessUrl", () => {
     const url = buildHomeRemoteRunnerAccessUrl({ sessionId: "session-123" });
 
     expect(url).toBe(
-      `https://www.elizacloud.ai/dashboard/app?${HOME_REMOTE_RUNNER_ACCESS_SESSION_PARAM}=session-123`
+      `https://elizacloud.ai/dashboard/app?${HOME_REMOTE_RUNNER_ACCESS_SESSION_PARAM}=session-123`
     );
   });
 
@@ -25,7 +25,7 @@ describe("buildHomeRemoteRunnerAccessUrl", () => {
     });
 
     expect(url).toBe(
-      `https://www.elizacloud.ai/dashboard/app?${HOME_REMOTE_RUNNER_ACCESS_SESSION_PARAM}=session-123`
+      `https://elizacloud.ai/dashboard/app?${HOME_REMOTE_RUNNER_ACCESS_SESSION_PARAM}=session-123`
     );
   });
 


### PR DESCRIPTION
## Summary
- Align stale shared/plugin test expectations with the current apex Eliza Cloud URL canonicalizer.
- Update plugin docs so the documented default Cloud API base matches the canonical apex URL.

## Why
Develop CI is failing shared/server/plugin lanes because several tests still expect `https://www.elizacloud.ai`, while the shared normalizer now canonicalizes Cloud aliases to `https://elizacloud.ai`.

## Verification
- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light`
- `bun test packages/shared/src/local-inference/hf-proxy.test.ts`
- `bunx --bun vitest run plugins/plugin-elizacloud/__tests__/unit/home-remote-runner-access-url.test.ts plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts`
- `bunx --bun biome check packages/shared/src/local-inference/hf-proxy.test.ts plugins/plugin-elizacloud/__tests__/unit/home-remote-runner-access-url.test.ts plugins/plugin-elizacloud/__tests__/cloud-billing-routes.test.ts`
- `cmp -s plugins/plugin-elizacloud/CLAUDE.md plugins/plugin-elizacloud/AGENTS.md`
- `git diff --check`

## Notes
- Skipped broad local build because the data volume remains at 99% capacity and this is a tests/docs-only patch.
- Fresh-state `LOG_LEVEL=debug bun run start` still shows separate startup warning clusters around missing embedding handler when local embeddings are disabled, stale `VIEW_ACTION_MAP` entries, and AgentSkills warm-up timeout.
