### PR TITLE
registry: add plugin-x402-endpoints (third-party)

### DIFF
--- a/packages/registry/entries/third-party/plugin-x402-endpoints.json
+++ b/packages/registry/entries/third-party/plugin-x402-endpoints.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-x402-endpoints",
+  "repository": "github:digitalweb33333-creator/plugin-x402-endpoints",
+  "kind": "plugin",
+  "description": "Exposes the x402-endpoints catalogue (28 paid data endpoints: official EU/global registries — GLEIF, VIES, BODACC, EUR-Lex, Companies House, EPO, sanctions, CVE, FDA — plus crypto pre-trade data) as native ElizaOS actions, billed per call via x402 (USDC on Base mainnet).",
+  "homepage": "https://github.com/digitalweb33333-creator/plugin-x402-endpoints",
+  "version": "0.1.0",
+  "tags": ["x402", "micropayments", "base", "usdc", "compliance", "crypto", "data", "kyb"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -787,6 +787,54 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": null
+    },
+    "plugin-x402-endpoints": {
+      "git": {
+        "repo": "digitalweb33333-creator/plugin-x402-endpoints",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-x402-endpoints",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Exposes the x402-endpoints catalogue (28 paid data endpoints: official EU/global registries — GLEIF, VIES, BODACC, EUR-Lex, Companies House, EPO, sanctions, CVE, FDA — plus crypto pre-trade data) as native ElizaOS actions, billed per call via x402 (USDC on Base mainnet).",
+      "homepage": "https://github.com/digitalweb33333-creator/plugin-x402-endpoints",
+      "topics": [
+        "x402",
+        "micropayments",
+        "base",
+        "usdc",
+        "compliance",
+        "crypto",
+        "data",
+        "kyb"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
Adds a third-party community registry entry for **plugin-x402-endpoints**.

**What it is:** an ElizaOS plugin exposing the x402-endpoints catalogue — 28 paid data endpoints (official EU/global registries: GLEIF, VIES, BODACC, EUR-Lex, Companies House, EPO, EU sanctions, CVE/NVD, FDA openFDA… + crypto pre-trade data: token-safety, derivatives-radar, wallet-xray, dex-cex-spread) — as native ElizaOS actions, billed per call via x402 (USDC on Base mainnet).

**Links**
- npm: https://www.npmjs.com/package/plugin-x402-endpoints (, unscoped, keywords include )
- repo: https://github.com/digitalweb33333-creator/plugin-x402-endpoints (plugin at root;  400x400 +  1280x640 present)

**Changes (only ):**
- new 
- regenerated  (, additive: +48 lines, 0 removed)

 passes (18 third-party entries).