### PR TITLE
feat(app): flag-gated shared-tier cloud agent on first-run

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -987,6 +987,12 @@ declare module "./client-base" {
       agentName: string;
       agentConfig?: Record<string, unknown>;
       environmentVars?: Record<string, string>;
+      /**
+       * Phase-0 tier flip. When true, omit `alwaysOn` so the backend derives a
+       * SHARED (container-free, instant) agent instead of a DEDICATED always-on
+       * one. Default (undefined/false) keeps the dedicated request unchanged.
+       */
+      preferSharedTier?: boolean;
     }): Promise<{
       success: boolean;
       data: {
@@ -1230,6 +1236,12 @@ declare module "./client-base" {
       preferAgentId?: string | null;
       /** Skip reuse and always create a new agent (explicit "Create new"). */
       forceCreate?: boolean;
+      /**
+       * Phase-0 tier flip. When true, a freshly created agent is requested as
+       * SHARED (instant, container-free) instead of DEDICATED always-on. Only
+       * affects the create branch; reuse of an existing agent is unaffected.
+       */
+      preferSharedTier?: boolean;
       onProgress?: (status: string, detail?: string) => void;
     }): Promise<{
       agentId: string;
@@ -1582,6 +1594,12 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
   this: ElizaClient,
   opts,
 ) {
+  // Phase-0 tier flip. The backend derives `execution_tier` from the request:
+  // `alwaysOn: true` → DEDICATED always-on container; omitting it (for a plain
+  // chat agent) → SHARED, container-free, instant. Default is dedicated — only
+  // the demo flag drops `alwaysOn` to request shared. `tierFields` is spread
+  // into both create bodies so the dedicated path stays byte-identical to before.
+  const tierFields = opts.preferSharedTier ? {} : { alwaysOn: true };
   const direct = await directCloudRequest<{
     success: boolean;
     data: unknown;
@@ -1594,7 +1612,9 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       // the full experience, and the paid tier. New users have the signup credit
       // grant so they get a real agent; out-of-credit users get the cloud's
       // 402 add-credits prompt (the monetization path) rather than a shared agent.
-      alwaysOn: true,
+      // (With the Phase-0 shared-tier flag on, `alwaysOn` is dropped so the
+      // backend derives a SHARED agent instead — see tierFields above.)
+      ...tierFields,
       ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
       ...(opts.environmentVars
         ? { environmentVars: opts.environmentVars }
@@ -1640,7 +1660,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       body: JSON.stringify({
         agentName: opts.agentName,
         // Dedicated (own-container, always-on) agent — see the direct-path note.
-        alwaysOn: true,
+        // The Phase-0 shared-tier flag drops `alwaysOn` here too (tierFields).
+        ...tierFields,
         ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
         ...(opts.environmentVars
           ? { environmentVars: opts.environmentVars }
@@ -2822,8 +2843,15 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   this: ElizaClient,
   options,
 ) {
-  const { cloudApiBase, authToken, name, bio, preferAgentId, forceCreate } =
-    options;
+  const {
+    cloudApiBase,
+    authToken,
+    name,
+    bio,
+    preferAgentId,
+    forceCreate,
+    preferSharedTier,
+  } = options;
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   // Ensure the direct-cloud requests below authenticate even on a cold boot,
@@ -2889,6 +2917,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   const created = await this.createCloudCompatAgent({
     agentName: name,
     ...(bio?.length ? { agentConfig: { bio } } : {}),
+    ...(preferSharedTier ? { preferSharedTier: true } : {}),
   });
   if (!created.success || !created.data.agentId) {
     throw new Error(created.data.message || "Failed to create cloud agent");

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -297,6 +297,16 @@ export interface AppBootConfig {
   shortcutFlags?: {
     naturalLanguage?: boolean;
   };
+  /**
+   * Phase-0 cloud tier flip (MVP). When true, the first-run cloud-create path
+   * requests a SHARED (container-free, in-Worker) agent so the user chats
+   * instantly with no provisioning wait, instead of the default DEDICATED
+   * always-on container. Off by default: the seamless shared→dedicated handoff
+   * is not built yet, so making everyone shared would strand them there — this
+   * flag is for the instant-shared demo only. When false the create request is
+   * byte-identical to the dedicated path (sends `alwaysOn: true`).
+   */
+  preferSharedCloudTier?: boolean;
   /** Character catalog data — replaces cross-package import of catalog.json. */
   characterCatalog?: CharacterCatalogData;
   /**

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -750,6 +750,12 @@ export function useFirstRunController(): FirstRunController {
         bio,
         ...(opts.preferAgentId ? { preferAgentId: opts.preferAgentId } : {}),
         ...(opts.forceCreate ? { forceCreate: true } : {}),
+        // Phase-0 MVP: when the boot-config flag is on, request a SHARED
+        // (instant, container-free) agent on create instead of a dedicated
+        // always-on container. Default off → unchanged dedicated behavior.
+        ...(getBootConfig().preferSharedCloudTier
+          ? { preferSharedTier: true }
+          : {}),
         onProgress: (status, detail) => setBusyText(detail ?? status),
       });
       const cloudAgentApiBase = selectedAgent.apiBase;

--- a/packages/ui/src/state/useFirstRunCallbacks.ts
+++ b/packages/ui/src/state/useFirstRunCallbacks.ts
@@ -674,6 +674,11 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
             name: firstRunName,
             bio: style?.bio ?? ["An autonomous AI agent."],
             ...(preferAgentId ? { preferAgentId } : {}),
+            // Phase-0 MVP: boot-config flag → request a SHARED (instant,
+            // container-free) agent on create. Default off → dedicated, unchanged.
+            ...(getBootConfig().preferSharedCloudTier
+              ? { preferSharedTier: true }
+              : {}),
             onProgress: () => {},
           });
 


### PR DESCRIPTION
## What
Phase 0 of the seamless-provision MVP: a **flag-gated tier flip** so the app can request a **SHARED** (container-free, in-Worker, instant) cloud agent on first-run instead of the default **DEDICATED always-on** one — the user chats instantly, no provisioning wait.

## How
The backend derives `execution_tier` from the create request: `alwaysOn: true` → `dedicated-always`; omitting it (plain chat agent, no persistent-connection plugin / docker image / stateful flag) → `shared` (`agent-tier.ts:57`). So Phase 0 just drops `alwaysOn` when the flag is on — no new API field.

- New boot-config flag `preferSharedCloudTier` (boolean, **default off** — not in `DEFAULT_BOOT_CONFIG`).
- ON → first-run cloud-create requests shared. OFF → **byte-identical** to today (`alwaysOn: true`, same position) — zero prod behavior change.
- Wired through `client-cloud.ts` create path + both first-run controllers. Reuse-existing-agent path untouched. In-settings "create agent" / join left dedicated (not the instant-chat path).

## Enable for the demo
Set `preferSharedCloudTier: true` in the host boot config (e.g. `setBootConfig({ ...getBootConfig(), preferSharedCloudTier: true })`).

## Not in this PR (next to make the demo actually work)
- **Shared chat must work e2e** — the flag flips the tier; verifying a shared agent serves a working chat is the next step.
- **Billing (Phase 0a):** shared inference is metered; a $0 user is rejected on msg #1 (`eliza-sandbox.ts:1767`). A fresh user has the $5 welcome grant (`DEFAULT_INITIAL_CREDITS`), so the demo works until spent — confirm prod `INITIAL_FREE_CREDITS ≥ $5`.
- The seamless shared→dedicated handoff (the upgrade) is the larger follow-up — that's why this is **flag-gated** (shared-only without the handoff would strand users).

## Risk
Default off → byte-identical request, no behavior change. CI covers types.
