### PR TITLE
fix(cloud): label the add-credits input + brand the buy-credits CTA

### DIFF
--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -12,7 +12,13 @@
 
 "use client";
 
-import { BrandCard, CornerBrackets, Input } from "@elizaos/ui/cloud-ui";
+import {
+  BrandButton,
+  BrandCard,
+  CornerBrackets,
+  Input,
+  Label,
+} from "@elizaos/ui/cloud-ui";
 import {
   AlertCircle,
   CheckCircle,
@@ -304,61 +310,61 @@ export function BillingTab({ user }: BillingTabProps) {
                   </div>
                 )}
 
-                <div className="flex flex-col sm:flex-row items-stretch gap-4">
-                  <div className="relative flex-1 max-w-xs">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#717171] font-mono z-10 pointer-events-none">
-                      $
-                    </span>
-                    <Input
-                      type="number"
-                      step="1"
-                      min={AMOUNT_LIMITS.MIN}
-                      max={AMOUNT_LIMITS.MAX}
-                      value={purchaseAmount}
-                      onChange={(e) => setPurchaseAmount(e.target.value)}
-                      className="pl-7 bg-[rgba(29,29,29,0.3)] border border-[rgba(255,255,255,0.15)] text-[#e1e1e1] h-11 font-mono"
-                      placeholder="0.00"
-                      disabled={isProcessingCheckout}
-                    />
+                <div className="flex flex-col sm:flex-row items-stretch sm:items-end gap-4">
+                  <div className="flex-1 max-w-xs">
+                    <Label
+                      htmlFor="purchase-amount"
+                      className="mb-1.5 block text-white/60 font-mono text-xs"
+                    >
+                      {t("cloud.billingTab.amountLabel", {
+                        defaultValue: "Amount (USD)",
+                      })}
+                    </Label>
+                    <div className="relative">
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#717171] font-mono z-10 pointer-events-none">
+                        $
+                      </span>
+                      <Input
+                        id="purchase-amount"
+                        type="number"
+                        step="1"
+                        min={AMOUNT_LIMITS.MIN}
+                        max={AMOUNT_LIMITS.MAX}
+                        value={purchaseAmount}
+                        onChange={(e) => setPurchaseAmount(e.target.value)}
+                        className="pl-7 bg-[rgba(29,29,29,0.3)] border border-[rgba(255,255,255,0.15)] text-[#e1e1e1] h-11 font-mono"
+                        placeholder="0.00"
+                        disabled={isProcessingCheckout}
+                      />
+                    </div>
                   </div>
 
                   {(paymentMethod !== "crypto" ||
                     !cryptoStatus?.directWallet?.enabled) && (
-                    <button
+                    <BrandButton
                       type="button"
+                      variant="primary"
                       onClick={handleBuyCredits}
                       disabled={!isValidAmount || isProcessingCheckout}
-                      className="relative bg-[#e1e1e1] px-6 py-2.5 overflow-hidden hover:bg-white transition-colors w-full sm:w-auto flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                      className="h-11 px-6 w-full sm:w-auto flex-shrink-0 font-mono text-base whitespace-nowrap"
                     >
-                      <div
-                        className="absolute inset-0 opacity-20 bg-repeat pointer-events-none"
-                        style={{
-                          backgroundImage: `url(/assets/settings/pattern-6px-flip.png)`,
-                          backgroundSize:
-                            "2.915576934814453px 2.915576934814453px",
-                        }}
-                      />
                       {isProcessingCheckout ? (
                         <>
-                          <Loader2 className="h-4 w-4 animate-spin text-black relative z-10" />
-                          <span className="relative z-10 text-black font-mono font-medium text-base whitespace-nowrap">
-                            {t("cloud.billingTab.redirecting", {
-                              defaultValue: "Redirecting...",
-                            })}
-                          </span>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          {t("cloud.billingTab.redirecting", {
+                            defaultValue: "Redirecting...",
+                          })}
                         </>
+                      ) : paymentMethod === "crypto" ? (
+                        t("cloud.billingTab.payWithCrypto", {
+                          defaultValue: "Pay with Crypto",
+                        })
                       ) : (
-                        <span className="relative z-10 text-black font-mono font-medium text-base whitespace-nowrap">
-                          {paymentMethod === "crypto"
-                            ? t("cloud.billingTab.payWithCrypto", {
-                                defaultValue: "Pay with Crypto",
-                              })
-                            : t("cloud.billingTab.buyCredits", {
-                                defaultValue: "Buy credits",
-                              })}
-                        </span>
+                        t("cloud.billingTab.buyCredits", {
+                          defaultValue: "Buy credits",
+                        })
                       )}
-                    </button>
+                    </BrandButton>
                   )}
                 </div>
 

--- a/packages/ui/src/cloud/organization/invite-member-dialog.tsx
+++ b/packages/ui/src/cloud/organization/invite-member-dialog.tsx
@@ -19,6 +19,7 @@
 import { AlertCircle, Loader2, Mail, UserCog } from "lucide-react";
 import { useState } from "react";
 import {
+  BrandButton,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -187,32 +188,24 @@ export function InviteMemberDialog({
             >
               Cancel
             </button>
-            <button
+            <BrandButton
               type="submit"
+              variant="primary"
               disabled={isSubmitting}
-              className="relative bg-[#e1e1e1] px-4 py-2 overflow-hidden hover:bg-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed order-1 sm:order-2"
+              className="font-mono text-sm order-1 sm:order-2"
             >
-              <div
-                className="absolute inset-0 opacity-20 bg-repeat pointer-events-none"
-                style={{
-                  backgroundImage: `url(/assets/settings/pattern-6px-flip.png)`,
-                  backgroundSize: "2.915576934814453px 2.915576934814453px",
-                }}
-              />
-              <span className="relative z-10 text-black font-mono font-medium text-sm flex items-center justify-center gap-2">
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Sending...
-                  </>
-                ) : (
-                  <>
-                    <Mail className="h-4 w-4" />
-                    Send Invitation
-                  </>
-                )}
-              </span>
-            </button>
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                <>
+                  <Mail className="h-4 w-4" />
+                  Send Invitation
+                </>
+              )}
+            </BrandButton>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/packages/ui/src/cloud/organization/members-tab.tsx
+++ b/packages/ui/src/cloud/organization/members-tab.tsx
@@ -23,6 +23,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  BrandButton,
 } from "../../cloud-ui";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import type {
@@ -151,25 +152,17 @@ export function MembersTab({ user }: MembersTabProps) {
             </p>
           </div>
           {canManageMembers && (
-            <button
+            <BrandButton
               type="button"
+              variant="primary"
               onClick={() => setIsInviteDialogOpen(true)}
-              className="relative bg-[#e1e1e1] px-3 py-2 overflow-hidden hover:bg-white transition-colors flex items-center gap-2 w-full sm:w-auto"
+              className="font-mono text-sm md:text-base w-full sm:w-auto"
             >
-              <div
-                className="absolute inset-0 opacity-20 bg-repeat pointer-events-none"
-                style={{
-                  backgroundImage: `url(/assets/settings/pattern-6px-flip.png)`,
-                  backgroundSize: "2.915576934814453px 2.915576934814453px",
-                }}
-              />
-              <UserPlus className="relative z-10 h-4 w-4 text-black" />
-              <span className="relative z-10 text-black font-mono font-medium text-sm md:text-base">
-                {t("cloud.membersTab.inviteMember", {
-                  defaultValue: "Invite Member",
-                })}
-              </span>
-            </button>
+              <UserPlus className="h-4 w-4" />
+              {t("cloud.membersTab.inviteMember", {
+                defaultValue: "Invite Member",
+              })}
+            </BrandButton>
           )}
         </div>
 


### PR DESCRIPTION
Cloud billing UX (the non-dev "paying feels broken" wall from the audit): add a visible `<Label>` to the add-credits amount input (was placeholder-only `0.00`), and route the grey `#e1e1e1` "Buy credits" + invite CTAs through `BrandButton variant="primary"` (elizaOS orange) so the highest-value action reads as clickable. 3 files; no contrast-sweep / no Shared-Dedicated relabel (separate).