### PR TITLE
fix(app): absolute Vite base for web SPA so deep cloud routes (/auth/cli-login, /app-auth, /payment/:id) load

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,7 +68,7 @@
     "cap:sync:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor sync android",
     "cap:open:ios": "node scripts/ensure-capacitor-platform.mjs ios && capacitor open ios",
     "cap:open:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor open android",
-    "build:web": "node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs",
+    "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs",
     "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos",
     "prebuild": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos"

--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -90,3 +90,43 @@ if (!cryptoChunkSeen) {
 console.log(
   `[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (${files.length} chunks scanned).`,
 );
+
+// ── Web SPA base regression guard ──
+// build:web sets ELIZA_WEB_ABSOLUTE_BASE=1 → Vite base "/". A relative base
+// ("./assets/…") boots fine at depth-1 routes (/, /login) but 404s its bundle
+// at depth-2+ routes (/auth/cli-login, /app-auth/authorize, /payment/:id):
+// "./assets/x.js" resolves to /<route-dir>/assets/x.js, which the SPA fallback
+// serves as text/html, so the module/stylesheet is refused and the page blanks.
+// This shipped to prod once (the cli-login device-login handoff). Fail the build
+// if the absolute-base web bundle still emitted relative asset refs. Native /
+// relative builds don't set the flag, so this guard is skipped for them — their
+// relative base is correct (Electrobun views:// / Capacitor file://).
+if (process.env.ELIZA_WEB_ABSOLUTE_BASE === "1") {
+  const indexHtmlPath = path.join(process.cwd(), "dist", "index.html");
+  let indexHtml;
+  try {
+    indexHtml = readFileSync(indexHtmlPath, "utf8");
+  } catch (err) {
+    console.error(
+      `[verify-chunk-safety] cannot read ${indexHtmlPath} for the web-base check: ${err.message}`,
+    );
+    process.exit(2);
+  }
+  const relativeAssetRefs = indexHtml.match(/(?:src|href)="\.\/assets\//g);
+  if (relativeAssetRefs) {
+    console.error(
+      `[verify-chunk-safety] FAIL: ELIZA_WEB_ABSOLUTE_BASE=1 but dist/index.html still has ${relativeAssetRefs.length} relative "./assets/" ref(s).`,
+    );
+    console.error(
+      "\nThe web SPA base regressed to relative. Depth-2+ routes (/auth/cli-login,\n" +
+        "/app-auth/authorize, /payment/:id) would resolve assets to /<route>/assets/…,\n" +
+        "which the SPA fallback serves as text/html → the bundle never boots → blank\n" +
+        'page. Keep `base` absolute for the web build (vite.config.ts:\n' +
+        '`process.env.ELIZA_WEB_ABSOLUTE_BASE === "1" ? "/" : "./"`). Do NOT deploy.',
+    );
+    process.exit(1);
+  }
+  console.log(
+    "[verify-chunk-safety] OK: web SPA uses an absolute base (no relative ./assets/ refs in index.html).",
+  );
+}

--- a/packages/app/src/renderer-build-stamp.ts
+++ b/packages/app/src/renderer-build-stamp.ts
@@ -43,10 +43,18 @@ export async function loadRendererBuildStamp(): Promise<RendererBuildStamp | nul
     return null;
   }
   try {
-    // Resolve against the document base so it works on web, Capacitor
-    // (https://localhost/ via the configured scheme), and Electrobun static
-    // hosting alike.
-    const url = new URL(MANIFEST_FILENAME, document.baseURI).toString();
+    // The manifest is emitted at the web root. On the absolute-base web build
+    // (ELIZA_WEB_ABSOLUTE_BASE=1 → Vite base "/"), `document.baseURI` points at
+    // the current deep SPA route (e.g. /auth/cli-login), so resolving against it
+    // would fetch /auth/eliza-renderer-build.json (404). Resolve from the origin
+    // root there. Native / relative-base builds (Capacitor https://localhost,
+    // Electrobun static hosting) keep resolving against the document base, where
+    // the document already lives at the root — so their behavior is unchanged.
+    const base = import.meta.env?.BASE_URL ?? "./";
+    const url =
+      base === "/"
+        ? new URL(MANIFEST_FILENAME, window.location.origin).toString()
+        : new URL(MANIFEST_FILENAME, document.baseURI).toString();
     const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) {
       window.__ELIZA_RENDERER_BUILD__ = null;

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1944,7 +1944,18 @@ function makeEsToolkitCompatEsmPlugin(
 export default defineConfig({
   root: here,
   customLogger: viteLogger,
-  base: "./",
+  // Native shells (Electrobun `views://`, Capacitor `file://`) load assets
+  // relative to the HTML document, so they need a relative base — keep "./".
+  // The web bundle (`build:web` → Cloudflare Pages, served from an origin root)
+  // is an SPA whose client-side routes go several segments deep
+  // (e.g. /auth/cli-login, /app-auth/authorize, /payment/:id). With a relative
+  // base, `./assets/x.js` resolves against the route directory (→
+  // /auth/assets/x.js), which the SPA catch-all returns as index.html
+  // (text/html). The browser then rejects the stylesheet/module and the bundle
+  // never boots — the page hangs on a blank/loading shell. `build:web` sets
+  // ELIZA_WEB_ABSOLUTE_BASE=1 so the deployed SPA uses an absolute "/" base and
+  // every route depth resolves assets to /assets/… correctly.
+  base: process.env.ELIZA_WEB_ABSOLUTE_BASE === "1" ? "/" : "./",
   // Keep pre-bundle cache under the app dir (not node_modules/.vite) so Bun
   // installs don't fight Vite, and `bun run clean` / docs can target one path.
   // ELIZA_VITE_CACHE_DIR lets a parallel dev/measurement server use an isolated


### PR DESCRIPTION
## The bug (live prod regression)

\`https://elizacloud.ai/auth/cli-login?session=…\` — the **"Sign in with Eliza Cloud"** device-login handoff from the Eliza app — renders only a blank/loading shell. Console shows:

\`\`\`
Refused to apply style from '…/auth/assets/index-*.css' (MIME 'text/html')
Failed to load module script … '…/auth/assets/index-*.js' (MIME 'text/html')
site.webmanifest: Syntax error
\`\`\`

## Root cause

\`packages/app\` is now the cloud apex console (\`build:web\` → Cloudflare Pages \`eliza-cloud\` + \`eliza-app\`). \`vite.config.ts\` hardcodes \`base: "./"\` — **required** by the native Electrobun (\`views://\`) and Capacitor (\`file://\`) shells, which load assets relative to the document.

But the web Pages deploy is an **SPA served at an origin root** whose client-side routes go several segments deep. At \`/auth/cli-login\`, the relative \`./assets/x.js\` resolves against the route directory → \`/auth/assets/x.js\`. The SPA catch-all returns \`index.html\` (\`text/html\`) for that path, the browser rejects the stylesheet/module, and the bundle never boots.

This breaks **every depth-2+ public route**: \`/auth/cli-login\`, \`/auth/success\`, \`/auth/callback/email\`, \`/app-auth/authorize\`, \`/payment/:id\`, \`/payment/app-charge/...\`, \`/invite/accept\`, etc. Depth-1 routes (\`/\`, \`/login\`) happen to work because \`./assets/\` resolves to \`/assets/\` there — which is why login looked fine while the CLI/device handoff was broken.

The deleted \`cloud-frontend\` was a dedicated SPA with an absolute base, so it never had this; the console migration to \`packages/app\` regressed it.

## Fix

\`build:web\` now sets \`ELIZA_WEB_ABSOLUTE_BASE=1\`, which switches the Vite base to \`"/"\` **for the web bundle only**. Native builds run \`vite build\` via \`desktop-build.mjs\` / \`run-mobile-build.mjs\` (never \`build:web\`), so they keep the relative \`"./"\` base — zero change to desktop/iOS/Android/APK.

One root cause → fixes the CSS, JS-module, webmanifest, and favicon errors together.

## Evidence

- **Before (live):** \`curl https://elizacloud.ai/auth/cli-login\` → \`src="./assets/index-*.js"\`; browser requests \`/auth/assets/*\` → \`200 text/html\` (SPA fallback) → blank page. (Headless Chrome: empty body, MIME errors, \`/auth/assets/*.css\` aborted.)
- **After:** the deployed \`index.html\` references absolute \`/assets/*\`, which resolve at every route depth → cli-login authorize UI renders. Verified on the live URL post-deploy (see PR thread / #8434).
- CI \`build:web\` exercises the new env path (full build); native lanes untouched.

Refs elizaOS/eliza#8434.