### PR TITLE
feat(handoff): create dedicated alongside shared + arm the existing handoff (PR1)

### DIFF
--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+import { ElizaClient } from "./client-base";
+// Side-effect import: patches startCloudAgentHandoff onto the prototype.
+import "./client-cloud";
+import type { CloudCompatAgent } from "./client-types-cloud";
+
+/**
+ * Phase 1 (create-both): the shared agent the user chats on is container-free
+ * and never grows a dedicated base, so the handoff readiness probe must poll a
+ * SEPARATE dedicated agent. `dedicatedAgentId` selects that target; omitting it
+ * keeps the pre-shared-tier behavior (poll the same `agentId`). These tests pin
+ * which agent id the probe reads from.
+ */
+
+function runningDedicated(
+  overrides: Partial<CloudCompatAgent> = {},
+): CloudCompatAgent {
+  return {
+    agent_id: "dedicated-1",
+    agent_name: "Eliza",
+    node_id: null,
+    container_id: null,
+    headscale_ip: null,
+    bridge_url: null,
+    web_ui_url: "https://dedicated-1.elizacloud.ai",
+    status: "running",
+    agent_config: {},
+    created_at: "2026-06-27T00:00:00.000Z",
+    updated_at: "2026-06-27T00:00:00.000Z",
+    containerUrl: "",
+    webUiUrl: "https://dedicated-1.elizacloud.ai",
+    database_status: "ok",
+    error_message: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+function fakeClient(detailById: Record<string, CloudCompatAgent>) {
+  const getCloudCompatAgent = vi.fn(async (id: string) => {
+    const data = detailById[id];
+    return data ? { success: true, data } : { success: false, data: null };
+  });
+  const client = Object.create(ElizaClient.prototype) as ElizaClient;
+  Object.assign(client, { getCloudCompatAgent });
+  return { client, getCloudCompatAgent };
+}
+
+const SHARED_BASE =
+  "https://www.elizacloud.ai/api/v1/eliza/agents/shared-1/api";
+
+describe("startCloudAgentHandoff — dedicated migration target", () => {
+  // The handoff reads the shared conversation over `fetch` (authedFetch). Stub
+  // it to an empty conversation so the flow reaches the switch without import —
+  // these tests only pin which agent the readiness probe targets.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        status: 200,
+        json: async () => ({ messages: [] }),
+      })),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("polls the SEPARATE dedicated agent, not the shared source", async () => {
+    // Only the dedicated agent ever exposes a base; the shared one stays
+    // container-free. The probe must read the dedicated id or it never resolves.
+    const { client, getCloudCompatAgent } = fakeClient({
+      "dedicated-1": runningDedicated(),
+    });
+
+    const onSwitch = vi.fn();
+    const result = await client.startCloudAgentHandoff({
+      agentId: "shared-1",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "shared-1",
+      dedicatedAgentId: "dedicated-1",
+      cloudApiBase: "https://www.elizacloud.ai",
+      authToken: "tok",
+      onSwitch,
+      intervalMs: 1,
+      timeoutMs: 200,
+      // No shared messages → switch without import; we only assert the target.
+      log: () => {},
+    });
+
+    expect(getCloudCompatAgent).toHaveBeenCalledWith("dedicated-1");
+    expect(getCloudCompatAgent).not.toHaveBeenCalledWith("shared-1");
+    expect(onSwitch).toHaveBeenCalledWith("https://dedicated-1.elizacloud.ai");
+    expect(
+      result.status === "switched" || result.status === "switched-empty",
+    ).toBe(true);
+  });
+
+  it("defaults to polling `agentId` when no dedicated target is given", async () => {
+    const { client, getCloudCompatAgent } = fakeClient({
+      "agent-self": runningDedicated({
+        agent_id: "agent-self",
+        web_ui_url: "https://agent-self.elizacloud.ai",
+        webUiUrl: "https://agent-self.elizacloud.ai",
+      }),
+    });
+
+    await client.startCloudAgentHandoff({
+      agentId: "agent-self",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "agent-self",
+      cloudApiBase: "https://www.elizacloud.ai",
+      authToken: "tok",
+      onSwitch: vi.fn(),
+      intervalMs: 1,
+      timeoutMs: 200,
+      log: () => {},
+    });
+
+    expect(getCloudCompatAgent).toHaveBeenCalledWith("agent-self");
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1263,6 +1263,13 @@ declare module "./client-base" {
       conversationId: string;
       cloudApiBase: string;
       authToken: string;
+      /**
+       * The SEPARATE dedicated agent to migrate onto. When set, the readiness
+       * probe polls THIS agent's record for its container base (the shared
+       * `agentId` is container-free and never exposes one). Omitted → the probe
+       * polls `agentId` itself, the pre-shared-tier behavior.
+       */
+      dedicatedAgentId?: string;
       onSwitch: (containerBase: string) => void | Promise<void>;
       intervalMs?: number;
       timeoutMs?: number;
@@ -2954,12 +2961,18 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
     conversationId,
     cloudApiBase,
     authToken,
+    dedicatedAgentId,
     onSwitch,
     intervalMs,
     timeoutMs,
     log,
   } = options;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
+  // Migration TARGET. With the shared tier, the user chats on `agentId` (a
+  // container-free shared agent that never gets a dedicated base), so the
+  // dedicated record we poll for readiness is a SEPARATE agent. Default to
+  // `agentId` so the pre-shared-tier single-agent flow is unchanged.
+  const readinessAgentId = dedicatedAgentId ?? agentId;
 
   // Authed JSON fetch against a specific agent base (shared adapter OR the
   // dedicated container subdomain). Both accept the cloud session token —
@@ -2986,7 +2999,9 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
 
   const readiness: AgentReadinessProbe = {
     resolveReadyBase: async () => {
-      const detail = await this.getCloudCompatAgent(agentId).catch(() => null);
+      const detail = await this.getCloudCompatAgent(readinessAgentId).catch(
+        () => null,
+      );
       const agent = detail?.success ? detail.data : null;
       if (!agent) return null;
       // The container is "ready" only once the record exposes a dedicated base
@@ -3000,7 +3015,7 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
       const base = resolveCloudAgentApiBase({
         bridgeUrl: agent.bridge_url,
         webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
-        agentId,
+        agentId: readinessAgentId,
         cloudApiBase: resolvedCloudApiBase,
       });
       // Never "switch" onto the shared adapter (no migration target there).

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -19,6 +19,9 @@ type ActiveServerRecord = {
 
 const mocks = vi.hoisted(() => ({
   cloudAuthenticated: false,
+  // Phase-1 shared-tier flag (boot-config). Default off → byte-identical to
+  // pre-Phase-1; the create-both test flips it on to exercise the handoff arm.
+  preferSharedCloudTier: false,
   addAgentProfile: vi.fn(),
   completeFirstRun: vi.fn(),
   createPersistedActiveServer: vi.fn(
@@ -72,6 +75,20 @@ const mocks = vi.hoisted(() => ({
     status: "switched-empty" as const,
     imported: 0,
   })),
+  // Phase-1 create-both: when the shared-tier flag is on, the controller
+  // provisions a SEPARATE dedicated agent (a plain create, no preferSharedTier)
+  // as the handoff target.
+  createCloudCompatAgent: vi.fn(async () => ({
+    success: true as const,
+    data: {
+      agentId: "dedicated-1",
+      agentName: "Demo Agent",
+      jobId: "",
+      status: "provisioning",
+      nodeId: null,
+      message: "Agent created",
+    },
+  })),
 }));
 
 type CompatAgent = {
@@ -107,6 +124,7 @@ vi.mock("../api", () => ({
     getCloudCompatAgents: mocks.getCloudCompatAgents,
     selectOrProvisionCloudAgent: mocks.selectOrProvisionCloudAgent,
     startCloudAgentHandoff: mocks.startCloudAgentHandoff,
+    createCloudCompatAgent: mocks.createCloudCompatAgent,
     setBaseUrl: mocks.setBaseUrl,
     setToken: mocks.setToken,
     getBaseUrl: () => "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
@@ -133,6 +151,7 @@ vi.mock("../config/boot-config", () => ({
   getBootConfig: () => ({
     branding: { cloudOnly: true },
     cloudApiBase: "https://www.elizacloud.ai",
+    preferSharedCloudTier: mocks.preferSharedCloudTier,
   }),
 }));
 
@@ -224,6 +243,8 @@ describe("useFirstRunController cloud first-run", () => {
   beforeEach(() => {
     localStorage.clear();
     mocks.cloudAuthenticated = false;
+    mocks.preferSharedCloudTier = false;
+    mocks.createCloudCompatAgent.mockClear();
     mocks.addAgentProfile.mockClear();
     mocks.completeFirstRun.mockClear();
     // mockReset (not mockClear): individual tests install custom
@@ -286,6 +307,10 @@ describe("useFirstRunController cloud first-run", () => {
   });
 
   it("continues into cloud agent provisioning after native login authenticates", async () => {
+    // Phase-1 create-both: the shared-tier flag is on, so the user lands on a
+    // shared agent AND a separate dedicated agent is provisioned as the handoff
+    // target.
+    mocks.preferSharedCloudTier = true;
     const { result } = renderHook(() => useFirstRunController());
 
     await act(async () => {
@@ -334,14 +359,24 @@ describe("useFirstRunController cloud first-run", () => {
     expect(mocks.completeFirstRun).toHaveBeenCalledWith("chat", {
       launchCompanionOverlay: true,
     });
-    // A freshly created agent (created, no bridge URL yet) is served by the
-    // shared adapter while its container boots — so the background shared→
-    // personal handoff is armed to migrate + switch once the container is ready.
+    // Create-both: a SEPARATE dedicated agent is provisioned as the migration
+    // target — a PLAIN create (no preferSharedTier, so the backend derives a
+    // dedicated always-on container, not another shared agent).
+    expect(mocks.createCloudCompatAgent).toHaveBeenCalledWith(
+      expect.not.objectContaining({ preferSharedTier: expect.anything() }),
+    );
+    expect(mocks.createCloudCompatAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: "Demo Agent" }),
+    );
+    // A freshly created SHARED agent is served by the shared adapter; the
+    // background handoff is armed to poll the dedicated agent, copy the
+    // conversation, and switch once the dedicated container is ready.
     expect(mocks.startCloudAgentHandoff).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "agent-1",
         sharedApiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
         conversationId: "agent-1",
+        dedicatedAgentId: "dedicated-1",
         authToken: "cloud-token",
         onSwitch: expect.any(Function),
       }),
@@ -400,6 +435,29 @@ describe("useFirstRunController cloud first-run", () => {
       await result.current.finishRuntime();
     });
 
+    expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+  });
+
+  it("flag OFF: a created shared agent neither provisions a dedicated agent nor arms the handoff", async () => {
+    // Phase-1 is gated on the boot-config flag. With it OFF (the default), even
+    // a shared-base create stays byte-identical to pre-Phase-1: no second
+    // (dedicated) create, no handoff. The demo turns the flag on.
+    mocks.preferSharedCloudTier = false;
+    mocks.selectOrProvisionCloudAgent.mockResolvedValue({
+      agentId: "agent-1",
+      agentName: "Demo Agent",
+      apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
+      bridgeUrl: null,
+      created: true,
+    });
+
+    const { result } = renderHook(() => useFirstRunController());
+
+    await act(async () => {
+      await result.current.finishRuntime();
+    });
+
+    expect(mocks.createCloudCompatAgent).not.toHaveBeenCalled();
     expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -799,52 +799,83 @@ export function useFirstRunController(): FirstRunController {
       setBusyText(null);
       completeFirstRun("chat", { launchCompanionOverlay: true });
 
-      // Seamless shared→personal handoff. A freshly created cloud agent serves
-      // the user from the shared REST adapter while its dedicated container
-      // boots (selectedAgent.created with no bridge URL yet). In the background,
-      // once the container is reachable, copy the conversation the user built on
-      // the shared adapter into it and switch the live client over — no waiting,
-      // no lost history. Best-effort: on failure the user stays on the shared
-      // adapter, which keeps working.
+      // Seamless shared→dedicated cloud-agent handoff (Phase 1). A freshly
+      // created SHARED agent serves the user instantly from the container-free
+      // REST adapter — but, being container-free, it never grows a dedicated
+      // base on its own. So when the shared-tier flag is on we ALSO provision a
+      // SEPARATE dedicated agent in the background and arm the existing handoff
+      // supervisor to poll IT, copy the conversation across, and switch over
+      // once it's running. Without that separate dedicated target the supervisor
+      // would poll the shared agent forever and time out (the reconciliation's
+      // "the branch fires but never resolves"). Best-effort: on failure the user
+      // stays on the (working) shared adapter.
+      //
+      // Flag OFF → `preferSharedTier` was never sent, so `selectedAgent` is the
+      // dedicated agent itself (not a shared base) and this branch is skipped:
+      // byte-identical to pre-Phase-1.
       if (
+        getBootConfig().preferSharedCloudTier &&
         selectedAgent.created &&
         isDirectCloudSharedAgentBase(cloudAgentApiBase)
       ) {
-        const handoffAgentId = selectedAgent.agentId;
-        // Surface the handoff lifecycle (migrating → switched | timed-out |
-        // failed) as typed phase events instead of swapping silently, and keep
-        // a `timed-out`/`failed` retryable rather than a silent permanent
-        // fallback. The supervisor's import is idempotent, so a retry just
-        // re-runs the same call.
-        runCloudAgentHandoff(handoffAgentId, () =>
-          client.startCloudAgentHandoff({
-            agentId: handoffAgentId,
-            sharedApiBase: cloudAgentApiBase,
-            // The shared adapter keeps one canonical conversation per agent id.
-            conversationId: handoffAgentId,
-            cloudApiBase:
-              getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
-            authToken,
-            onSwitch: (containerBase) => {
-              client.setBaseUrl(containerBase);
-              client.setToken(authToken);
-              const switched = createPersistedActiveServer({
-                kind: "cloud",
-                id: `cloud:${handoffAgentId}`,
-                apiBase: containerBase,
-                accessToken: authToken,
-              });
-              savePersistedActiveServer(switched);
-              const profile = addAgentProfile({
-                kind: "cloud",
-                label: switched.label,
-                apiBase: containerBase,
-                accessToken: authToken,
-              });
-              switchAgentProfile(profile.id);
-            },
-          }),
-        );
+        const sharedAgentId = selectedAgent.agentId;
+        // Provision the dedicated agent ONCE, here, so a handoff retry re-arms
+        // the supervisor against the same dedicated id instead of minting a new
+        // dedicated agent each time. A plain create (no `preferSharedTier`)
+        // yields the DEDICATED always-on container — the migration target.
+        const dedicated = await client
+          .createCloudCompatAgent({
+            agentName: name,
+            ...(bio.length ? { agentConfig: { bio } } : {}),
+          })
+          .catch(() => null);
+        const dedicatedAgentId =
+          dedicated?.success && dedicated.data.agentId
+            ? dedicated.data.agentId
+            : null;
+        if (dedicatedAgentId) {
+          // Surface the handoff lifecycle (migrating → switched | timed-out |
+          // failed) as typed phase events instead of swapping silently, and
+          // keep a `timed-out`/`failed` retryable rather than a silent permanent
+          // fallback. The supervisor's import is idempotent, so a retry just
+          // re-runs the same call against the same dedicated agent.
+          runCloudAgentHandoff(sharedAgentId, () =>
+            client.startCloudAgentHandoff({
+              // Source: the shared agent the user is chatting on right now.
+              agentId: sharedAgentId,
+              sharedApiBase: cloudAgentApiBase,
+              // The shared adapter keeps one canonical conversation per agent id.
+              conversationId: sharedAgentId,
+              // Target: the separate dedicated agent we just kicked off. The
+              // supervisor polls THIS record for its container base.
+              dedicatedAgentId,
+              cloudApiBase:
+                getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
+              authToken,
+              onSwitch: (containerBase) => {
+                client.setBaseUrl(containerBase);
+                client.setToken(authToken);
+                const switched = createPersistedActiveServer({
+                  kind: "cloud",
+                  // Persist by the dedicated id — that's the agent the user ends
+                  // up on, so a re-boot restores the dedicated, not the shared
+                  // bridge.
+                  id: `cloud:${dedicatedAgentId}`,
+                  apiBase: containerBase,
+                  accessToken: authToken,
+                });
+                savePersistedActiveServer(switched);
+                const profile = addAgentProfile({
+                  kind: "cloud",
+                  label: switched.label,
+                  apiBase: containerBase,
+                  accessToken: authToken,
+                });
+                switchAgentProfile(profile.id);
+              },
+            }),
+          );
+        }
       }
     },
     [completeFirstRun, switchAgentProfile, uiLanguage],


### PR DESCRIPTION
Builds on #9838 (the `preferSharedCloudTier` flag, now merged to develop).

PR1 of the seamless-provision handoff: when the app creates a SHARED bridge agent (behind `preferSharedCloudTier`), also background-provision a **separate dedicated** agent and arm the existing handoff to switch to it when ready.

## Bug this fixes (why the handoff never fired)
`startCloudAgentHandoff` keyed the readiness probe to the **same** agentId as the shared conversation source — but a shared agent is container-free and never grows a dedicated `bridge_url`, so the probe could never resolve (pre-#9838 the branch was skipped; post-#9838 it'd time out forever). Fix: a separate `dedicatedAgentId` target — the probe polls the dedicated agent, the conversation source stays the shared one.

## How
- `startCloudAgentHandoff` gains optional `dedicatedAgentId`; readiness probe polls `dedicatedAgentId ?? agentId`.
- When the flag is ON + a shared agent is created: background-create a dedicated agent (normal always-on create, once, outside the retry thunk), then arm the existing `runCloudAgentHandoff` with shared=source + dedicated=target.
- The handoff spine (`runConversationHandoff` / supervisor / import) is reused untouched. Switch stays the existing **visible** one — invisible re-point is a later PR.

## Safety
Flag OFF → byte-identical (no second create, no arm), locked by a flag-off test. `dedicatedAgentId` defaults to `agentId` so pre-existing callers are unchanged.

## Tests
48 pass (supervisor, select-or-provision, new handoff-target test, full first-run controller suite). Biome + tsgo clean on the 4 changed files.

Not in scope (later PRs): invisible re-point, freeze-on-shared, delete-shared, billing.
