### PR TITLE
feat(handoff): freeze + queue outgoing during the switch window so no message is lost (PR2)

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -9,8 +9,20 @@ import type {
   ConversationMessage,
   ImageAttachment,
 } from "../api";
+import { CLOUD_HANDOFF_PHASE_EVENT } from "../events";
 import type { LoadConversationMessagesResult } from "./internal";
 import { type UseChatSendDeps, useChatSend } from "./useChatSend";
+
+const SHARED_BASE = "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123";
+const DEDICATED_BASE = "https://agent-456.elizacloud.ai";
+
+function dispatchHandoffPhase(phase: string): void {
+  window.dispatchEvent(
+    new CustomEvent(CLOUD_HANDOFF_PHASE_EVENT, {
+      detail: { agentId: "agent-123", phase },
+    }),
+  );
+}
 
 const mocks = vi.hoisted(() => ({
   client: {
@@ -496,5 +508,136 @@ describe("useChatSend non-404 send failures", () => {
     );
     // Auth failures skip the reconcile reload (it would just fail again).
     expect(deps.loadConversationMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe("useChatSend freeze-on-shared during handoff (PR2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue(SHARED_BASE);
+    mocks.client.renameConversation.mockResolvedValue(undefined);
+  });
+
+  it("queues a message sent during the handoff window and delivers it to the dedicated agent after switch (not lost, not sent to shared)", async () => {
+    // The bug this proves we fixed: while the handoff is migrating the user is
+    // still on the SHARED agent, whose transcript was already snapshotted. The
+    // dedicated import is skip-all idempotent, so a message that reaches the
+    // shared history after the snapshot is silently lost. The freeze must hold
+    // the message off the shared agent and deliver it to the dedicated once the
+    // client has switched.
+    const basesSeenAtSend: string[] = [];
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => {
+      basesSeenAtSend.push(mocks.client.getBaseUrl());
+      return { text: "ack", completed: true };
+    });
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    // Handoff starts: the window opens.
+    act(() => dispatchHandoffPhase("migrating"));
+
+    // The user fires a message DURING the window. sendChatText resolves only
+    // once the message is actually delivered, so we don't await it here — it
+    // must stay pending (queued) until the switch settles.
+    let sendSettled = false;
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current
+        .sendChatText("during handoff", { conversationId: "conv-1" })
+        .then(() => {
+          sendSettled = true;
+        });
+      // Give the queued flush a chance to (not) run.
+      await Promise.resolve();
+    });
+
+    // GUARANTEE 1: nothing was dispatched to the shared agent — the message did
+    // not reach the post-snapshot shared history, so it can't be lost.
+    expect(mocks.client.sendConversationMessageStream).not.toHaveBeenCalled();
+    expect(sendSettled).toBe(false);
+
+    // The switch completes: onSwitch re-points the live client at the dedicated
+    // container BEFORE the `switched` phase is dispatched (mirrors the real
+    // handoff ordering), then the phase fires and unfreezes the queue.
+    mocks.client.getBaseUrl.mockReturnValue(DEDICATED_BASE);
+    await act(async () => {
+      dispatchHandoffPhase("switched");
+      await sendPromise;
+    });
+
+    // GUARANTEE 2: the queued message was delivered exactly once, and only after
+    // the client pointed at the dedicated container.
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+    const [convIdArg, textArg] =
+      mocks.client.sendConversationMessageStream.mock.calls[0];
+    expect(convIdArg).toBe("conv-1");
+    expect(textArg).toBe("during handoff");
+    expect(basesSeenAtSend).toEqual([DEDICATED_BASE]);
+    expect(sendSettled).toBe(true);
+  });
+
+  it("flushes the queue to the shared agent (no message lost) when the handoff times out", async () => {
+    // Fallback path: the dedicated container never became ready. No switch
+    // happened and no snapshot landed, so the user safely stays on the shared
+    // agent — the queued message must still be delivered there, never dropped.
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "ack",
+      completed: true,
+    });
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    act(() => dispatchHandoffPhase("migrating"));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("during handoff", {
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(mocks.client.sendConversationMessageStream).not.toHaveBeenCalled();
+
+    // Handoff gives up — unfreeze and drain to the (still-active) shared agent.
+    await act(async () => {
+      dispatchHandoffPhase("timed-out");
+      await sendPromise;
+    });
+
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+    const [convIdArg, textArg] =
+      mocks.client.sendConversationMessageStream.mock.calls[0];
+    expect(convIdArg).toBe("conv-1");
+    expect(textArg).toBe("during handoff");
+  });
+
+  it("does not freeze when no handoff is in flight — sends dispatch inline (flag-off parity)", async () => {
+    // With `preferSharedCloudTier` off no `migrating` phase ever fires, so the
+    // freeze flag stays false and the queue drains immediately, exactly as
+    // before this change.
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "ack",
+      completed: true,
+    });
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello", { conversationId: "conv-1" });
+    });
+
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -9,6 +9,10 @@ import { asRecord } from "@elizaos/shared";
 import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import type { Conversation, CustomActionDef } from "../api";
 import {
+  CLOUD_HANDOFF_PHASE_EVENT,
+  type CloudHandoffPhaseDetail,
+} from "../events";
+import {
   type ChatTurnStatus,
   type CodingAgentSession,
   type ConversationChannelType,
@@ -386,6 +390,19 @@ export function useChatSend(deps: UseChatSendDeps) {
 
   const chatSendQueueRef = useRef<QueuedChatSend[]>([]);
   const activeChatTurnRef = useRef<ActiveChatTurn | null>(null);
+
+  // Freeze-on-shared (cloud-agent handoff, PR2). While a shared→dedicated
+  // handoff is migrating, the user is still pointed at the SHARED agent but the
+  // shared transcript has already been (or is about to be) snapshotted. The
+  // import endpoint is populated-room skip-all idempotent, so any message that
+  // reaches the shared history AFTER the snapshot is silently lost — a re-import
+  // inserts zero. To guarantee no loss we DON'T send outgoing messages to the
+  // shared agent during the window: they sit in `chatSendQueueRef` (un-drained)
+  // and are flushed once `onSwitch` has re-pointed the client at the dedicated
+  // container (which already holds the copied history). When no handoff is in
+  // flight this stays false → the drain runs exactly as before (byte-identical
+  // when `preferSharedCloudTier` is off, since no `migrating` phase ever fires).
+  const handoffFrozenRef = useRef(false);
 
   // Streaming-commit throttle.
   // The SSE `onToken` callback fires once per token (often >60/sec on a fast
@@ -1203,6 +1220,17 @@ export function useChatSend(deps: UseChatSendDeps) {
 
   const flushQueuedChatSends = useCallback(async () => {
     if (chatSendBusyRef.current) return;
+    // Handoff in progress: hold the queue. We must NOT dispatch to the network
+    // here — the live client still points at the shared agent, and anything that
+    // lands on the shared history after its snapshot is lost to the skip-all
+    // import. The queued turns stay put and are drained when the switch settles
+    // (the freeze is cleared and this is re-invoked, now pointed at the
+    // dedicated container). The composer is already cleared + `setChatSending`
+    // is on, so the user sees their message accepted, not dropped.
+    if (handoffFrozenRef.current) {
+      setChatSending(true);
+      return;
+    }
     chatSendBusyRef.current = true;
     setChatSending(true);
 
@@ -1228,6 +1256,39 @@ export function useChatSend(deps: UseChatSendDeps) {
     setChatFirstTokenReceived,
     setChatSending,
   ]);
+
+  // Drive the freeze off the existing shared→dedicated handoff lifecycle
+  // (CLOUD_HANDOFF_PHASE_EVENT). `migrating` opens the window (stop draining to
+  // the shared agent); every terminal phase closes it and drains:
+  //   - `switched` / `switched-empty`: `onSwitch` has already re-pointed the
+  //     client at the dedicated container (it runs INSIDE the handoff before the
+  //     phase is dispatched), so the drain now delivers the queued messages to
+  //     the dedicated — exactly where the copied history lives.
+  //   - `timed-out` / `failed`: no switch happened, the user safely stays on the
+  //     working shared agent, so unfreeze and let the queue flow to the shared
+  //     agent as normal (the snapshot never landed, nothing to lose).
+  // Without a handoff this listener never fires, so the queue drains inline as
+  // before — no behavior change when the shared-tier flag is off.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPhase = (event: Event) => {
+      const detail = (event as CustomEvent<CloudHandoffPhaseDetail>).detail;
+      if (!detail) return;
+      if (detail.phase === "migrating") {
+        handoffFrozenRef.current = true;
+        return;
+      }
+      // Any terminal phase ends the window. Drain whatever queued up — by now
+      // the client base is the dedicated container (on a switch) or unchanged
+      // (on timeout/failure), so the flush targets the right agent either way.
+      if (handoffFrozenRef.current) {
+        handoffFrozenRef.current = false;
+        void flushQueuedChatSends();
+      }
+    };
+    window.addEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+    return () => window.removeEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+  }, [flushQueuedChatSends]);
 
   const sendChatText = useCallback(
     async (


### PR DESCRIPTION
Stacked on #9843 (PR1 create-both).

PR2 of the seamless-provision handoff — the **correctness-critical freeze**: GUARANTEE that no message the user sends during the handoff copy+switch window is lost.

## The bug
During the handoff the client snapshots the shared conversation then switches to the dedicated — but the user is on the SHARED agent until the switch completes. A message sent in that window lands on shared **after** the snapshot, and the import is **skip-all idempotent** (`conversation-routes.ts:1715`) → silently lost. Without a freeze, "invisible" silently means "lossy".

## How (queue + flush)
In `useChatSend.ts`: subscribe to `CLOUD_HANDOFF_PHASE_EVENT`.
- `migrating` → **freeze**: queued sends stay pending, the composer stays interactive with sending feedback, nothing hits the shared agent.
- terminal `switched` (the client base is already flipped to the dedicated) → **unfreeze + flush** the queue to the dedicated.
- `timed-out` / `failed` → flush to the still-active shared (no snapshot happened, so no loss either way).

## Guarantee + tests
No message reaches shared post-snapshot; all queued messages land on the dedicated after switch. 3 new tests (the core guarantee, timeout fallback, flag-off parity) → **12/12 useChatSend + 15/15 handoff suites + `tsc` clean**.

## Safety
Flag OFF → no `migrating` event → the freeze never activates → byte-identical (locked by the parity test). 204 insertions, 0 deletions, 2 files.

Not in scope (later PRs): invisible re-point (PR3), delete-shared (PR4), billing (PR5).
