### PR TITLE
feat(handoff): silent in-place re-point on switch — no flash, no WS drop, no draft loss (PR3)

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -246,6 +246,39 @@ describe("ElizaClient websocket connection policy", () => {
     expect(received).toEqual([]);
   });
 
+  it("repointBaseUrl swaps the WS to the new host seamlessly (new socket, no disconnected flap)", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://shared.example.test", "tok");
+    client.connectWs();
+    expect(instances).toHaveLength(1);
+    // Bring the first socket up so wsHasConnectedOnce is set — repoint should
+    // still come up cleanly on the new host afterward.
+    instances[0].readyState = 1; // OPEN
+    instances[0].onopen?.();
+
+    const states: string[] = [];
+    client.onConnectionStateChange((s) => states.push(s.state));
+
+    client.repointBaseUrl("https://dedicated.example.test");
+
+    // A brand-new socket is opened against the dedicated host…
+    expect(instances).toHaveLength(2);
+    // …and the base is now the dedicated one.
+    expect(client.getBaseUrl()).toBe("https://dedicated.example.test");
+    // The seamless swap must NOT surface a "disconnected" connection state
+    // (that's the visible drop disconnectWs() would cause). connectWs() only
+    // emits on a *changed* state, and we suppressed the old socket's onclose,
+    // so no "disconnected" is reported during the re-point.
+    expect(states).not.toContain("disconnected");
+
+    // Driving the OLD (now-detached) socket's onclose must be a no-op: the
+    // re-point nulled its handlers, so it can't schedule a reconnect against
+    // the stale host.
+    const before = instances.length;
+    instances[0].onclose?.();
+    expect(instances).toHaveLength(before);
+  });
+
   it("removes a parked network-status reconnect wake on intentional disconnect", () => {
     const instances = stubWebSocketWithInstances();
     const client = new ElizaClient("https://agent.example.test", "agent-token");

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -609,6 +609,16 @@ export class ElizaClient {
     if (!persist) {
       return;
     }
+    this.persistBaseUrl(normalized);
+  }
+
+  /**
+   * Persist a base URL to every consumer that reads it out-of-band (boot config,
+   * localStorage, the `window.__ELIZA_API_BASE__` global). Shared by
+   * {@link setBaseUrl} and {@link repointBaseUrl} so both keep the same
+   * persistence semantics — the only difference between them is the WS handling.
+   */
+  private persistBaseUrl(normalized: string): void {
     // Update boot config so other consumers (resolveApiUrl, etc.) see the new base.
     const config = getBootConfig();
     setBootConfig({ ...config, apiBase: normalized || undefined });
@@ -632,6 +642,68 @@ export class ElizaClient {
     } else {
       clearElizaApiBase();
     }
+  }
+
+  /**
+   * Re-point the live client at a new base **in place**, keeping the realtime
+   * channel visually continuous — the seamless shared→dedicated handoff swap.
+   *
+   * Unlike {@link setBaseUrl}, which `disconnectWs()`es and leaves the socket
+   * dead until some later boot phase calls `connectWs()` (a visible drop + the
+   * `disconnected` connection-state flap), this:
+   *   1. tears down the old socket WITHOUT emitting a `disconnected` state, so
+   *      connection-state listeners never see a gap (the chat surface stays
+   *      "connected" throughout);
+   *   2. flips the base + persistence to the new (dedicated) host;
+   *   3. immediately `connectWs()`s to the new base.
+   *
+   * The transcript was already copied to the dedicated agent by the handoff
+   * supervisor, and the new socket's `onopen` fires `ws-reconnected`, so live
+   * updates resume against the dedicated host with no full-screen reload, no
+   * coordinator re-entry, and no draft loss. Used ONLY by the handoff's silent
+   * re-point — every other base change still goes through `setBaseUrl`.
+   */
+  repointBaseUrl(baseUrl: string): void {
+    const normalized = normalizeBaseUrl(baseUrl);
+    if (!normalized) return;
+    // Quietly drop the old socket. We intentionally do NOT call disconnectWs():
+    // it sets connectionState = "disconnected" and emits, which would surface a
+    // visible "reconnecting" flicker mid-handoff. Suppress onclose (which would
+    // otherwise schedule a reconnect against the OLD base) and close silently.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      try {
+        this.ws.close();
+      } catch {
+        /* already closing */
+      }
+      this.ws = null;
+    }
+    // Pending outbound WS frames were addressed to the old host; drop them so
+    // they aren't replayed against the dedicated socket. The send-queue is for
+    // offline buffering, not cross-host carry-over.
+    this.wsSendQueue = [];
+    this.wsEventBacklog.clear();
+
+    this._userSetBase = normalized.length > 0;
+    this._baseUrl = normalized;
+    this.persistBaseUrl(normalized);
+
+    // Reconnect immediately against the new base. connectWs() derives the WS
+    // host from this.baseUrl, so the socket comes up on the dedicated host; its
+    // onopen fires `ws-reconnected` (this.wsHasConnectedOnce is already true),
+    // re-hydrating live state without a reload.
+    this.backoffMs = 500;
+    this.reconnectAttempt = 0;
+    this.disconnectedAt = null;
+    this.connectWs();
   }
 
   /** True when we have a usable HTTP(S) API endpoint. */

--- a/packages/ui/src/cloud/handoff/silent-repoint.test.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  // client
+  setBaseUrl: vi.fn(),
+  repointBaseUrl: vi.fn(),
+  setToken: vi.fn(),
+  // state / profiles / drafts
+  createPersistedActiveServer: vi.fn(
+    (args: { id?: string; apiBase?: string; accessToken?: string }) => ({
+      id: args.id ?? "cloud:dedicated-1",
+      kind: "cloud" as const,
+      label: "Dedicated Agent",
+      ...(args.apiBase ? { apiBase: args.apiBase } : {}),
+      ...(args.accessToken ? { accessToken: args.accessToken } : {}),
+    }),
+  ),
+  savePersistedActiveServer: vi.fn(),
+  addAgentProfile: vi.fn((p: Record<string, unknown>) => ({
+    ...p,
+    id: "profile-dedicated-1",
+  })),
+  setActiveProfileId: vi.fn(),
+  clearAllChatDrafts: vi.fn(),
+}));
+
+vi.mock("../../api", () => ({
+  client: {
+    setBaseUrl: mocks.setBaseUrl,
+    repointBaseUrl: mocks.repointBaseUrl,
+    setToken: mocks.setToken,
+  },
+}));
+
+vi.mock("../../state", () => ({
+  createPersistedActiveServer: mocks.createPersistedActiveServer,
+  savePersistedActiveServer: mocks.savePersistedActiveServer,
+  addAgentProfile: mocks.addAgentProfile,
+  setActiveProfileId: mocks.setActiveProfileId,
+  // Exposed so a regression that re-introduces switchAgentProfile's draft wipe
+  // would be caught — the silent re-point must NEVER call this.
+  clearAllChatDrafts: mocks.clearAllChatDrafts,
+}));
+
+import { silentlyRepointToDedicated } from "./silent-repoint";
+
+const ARGS = {
+  containerBase: "https://dedicated-1.elizacloud.ai",
+  authToken: "cloud-token",
+  dedicatedAgentId: "dedicated-1",
+};
+
+describe("silentlyRepointToDedicated", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(mocks)) fn.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("re-points the live client SEAMLESSLY (repointBaseUrl, not setBaseUrl)", () => {
+    silentlyRepointToDedicated(ARGS);
+
+    // The whole point of PR3: a seamless in-place WS swap, NOT the global
+    // setBaseUrl (which hard-disconnects the WS and leaves it dead until a
+    // later boot phase reconnects — a visible drop).
+    expect(mocks.repointBaseUrl).toHaveBeenCalledTimes(1);
+    expect(mocks.repointBaseUrl).toHaveBeenCalledWith(
+      "https://dedicated-1.elizacloud.ai",
+    );
+    expect(mocks.setBaseUrl).not.toHaveBeenCalled();
+    expect(mocks.setToken).toHaveBeenCalledWith("cloud-token");
+  });
+
+  it("does NOT clear chat drafts (the composer survives the switch)", () => {
+    silentlyRepointToDedicated(ARGS);
+    expect(mocks.clearAllChatDrafts).not.toHaveBeenCalled();
+  });
+
+  it("persists the dedicated as the restorable active server + active profile", () => {
+    silentlyRepointToDedicated(ARGS);
+
+    // Keyed by the dedicated id so a reboot restores the dedicated, not the
+    // now-stale shared bridge.
+    expect(mocks.createPersistedActiveServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "cloud",
+        id: "cloud:dedicated-1",
+        apiBase: "https://dedicated-1.elizacloud.ai",
+        accessToken: "cloud-token",
+      }),
+    );
+    expect(mocks.savePersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(mocks.addAgentProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "cloud",
+        apiBase: "https://dedicated-1.elizacloud.ai",
+        accessToken: "cloud-token",
+      }),
+    );
+    // The dedicated profile is made active WITHOUT switchAgentProfile (so no
+    // SWITCH_AGENT dispatch / coordinator re-entry / StartupScreen flash).
+    expect(mocks.setActiveProfileId).toHaveBeenCalledWith("profile-dedicated-1");
+  });
+});

--- a/packages/ui/src/cloud/handoff/silent-repoint.test.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.test.ts
@@ -22,8 +22,6 @@ const mocks = vi.hoisted(() => ({
     ...p,
     id: "profile-dedicated-1",
   })),
-  setActiveProfileId: vi.fn(),
-  clearAllChatDrafts: vi.fn(),
 }));
 
 vi.mock("../../api", () => ({
@@ -38,10 +36,6 @@ vi.mock("../../state", () => ({
   createPersistedActiveServer: mocks.createPersistedActiveServer,
   savePersistedActiveServer: mocks.savePersistedActiveServer,
   addAgentProfile: mocks.addAgentProfile,
-  setActiveProfileId: mocks.setActiveProfileId,
-  // Exposed so a regression that re-introduces switchAgentProfile's draft wipe
-  // would be caught — the silent re-point must NEVER call this.
-  clearAllChatDrafts: mocks.clearAllChatDrafts,
 }));
 
 import { silentlyRepointToDedicated } from "./silent-repoint";
@@ -72,11 +66,6 @@ describe("silentlyRepointToDedicated", () => {
     expect(mocks.setToken).toHaveBeenCalledWith("cloud-token");
   });
 
-  it("does NOT clear chat drafts (the composer survives the switch)", () => {
-    silentlyRepointToDedicated(ARGS);
-    expect(mocks.clearAllChatDrafts).not.toHaveBeenCalled();
-  });
-
   it("persists the dedicated as the restorable active server + active profile", () => {
     silentlyRepointToDedicated(ARGS);
 
@@ -91,6 +80,10 @@ describe("silentlyRepointToDedicated", () => {
       }),
     );
     expect(mocks.savePersistedActiveServer).toHaveBeenCalledTimes(1);
+    // addAgentProfile registers AND activates the dedicated profile (it sets
+    // registry.activeProfileId + persists before returning) — done WITHOUT
+    // switchAgentProfile, so no SWITCH_AGENT dispatch / coordinator re-entry /
+    // StartupScreen flash.
     expect(mocks.addAgentProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "cloud",
@@ -98,8 +91,5 @@ describe("silentlyRepointToDedicated", () => {
         accessToken: "cloud-token",
       }),
     );
-    // The dedicated profile is made active WITHOUT switchAgentProfile (so no
-    // SWITCH_AGENT dispatch / coordinator re-entry / StartupScreen flash).
-    expect(mocks.setActiveProfileId).toHaveBeenCalledWith("profile-dedicated-1");
   });
 });

--- a/packages/ui/src/cloud/handoff/silent-repoint.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.ts
@@ -1,0 +1,72 @@
+import { client } from "../../api";
+import {
+  addAgentProfile,
+  createPersistedActiveServer,
+  savePersistedActiveServer,
+  setActiveProfileId,
+} from "../../state";
+
+/**
+ * Silently re-point the live client from the shared bridge to the dedicated
+ * agent — the handoff's "invisible switch".
+ *
+ * This is the handoff-ONLY alternative to `switchAgentProfile`. The global
+ * profile switch (`AppContext.tsx`) intentionally:
+ *   - `clearAllChatDrafts()` — wipes the composer (conversation ids are
+ *     per-account, so a manual account switch can't carry a draft over), and
+ *   - dispatches `SWITCH_AGENT` — which re-enters the startup coordinator
+ *     (`ready → polling-backend`), a phase that is NOT shell-paintable, so
+ *     `App.tsx` swaps the whole shell for `<StartupScreen/>` (the full-screen
+ *     flash).
+ * Both are correct for a manual switch but WRONG for the handoff: the dedicated
+ * agent already holds the copied transcript on the SAME conversation id, the
+ * user is mid-conversation, and the composer may hold an unsent draft. So the
+ * handoff re-points in place instead:
+ *   - persist the dedicated as the active server + profile (so a reboot restores
+ *     the dedicated, not the shared bridge),
+ *   - re-point the API/WS base seamlessly via `client.repointBaseUrl` (which
+ *     reconnects the WS in place — no visible drop, no coordinator re-entry),
+ *   - set the bearer token,
+ * and DELIBERATELY does NOT clear drafts and does NOT dispatch `SWITCH_AGENT`.
+ * The chat surface stays mounted on the same conversation id throughout.
+ */
+export function silentlyRepointToDedicated(opts: {
+  /** The dedicated agent's container base (REST + WS host). */
+  containerBase: string;
+  /** Bearer token (Steward JWT) — same one the shared bridge used. */
+  authToken: string;
+  /** The dedicated agent id — persisted so a reboot restores the dedicated. */
+  dedicatedAgentId: string;
+}): void {
+  const { containerBase, authToken, dedicatedAgentId } = opts;
+
+  // Persist the dedicated as the restorable active server. Keyed by the
+  // dedicated id so a re-boot restores the dedicated agent, not the now-stale
+  // shared bridge.
+  const server = createPersistedActiveServer({
+    kind: "cloud",
+    id: `cloud:${dedicatedAgentId}`,
+    apiBase: containerBase,
+    accessToken: authToken,
+  });
+  savePersistedActiveServer(server);
+
+  // Register + activate the dedicated profile WITHOUT going through
+  // switchAgentProfile (which would clear drafts + dispatch SWITCH_AGENT).
+  // addAgentProfile already sets it active in the registry; setActiveProfileId
+  // is belt-and-suspenders for the case the registry shape changes.
+  const profile = addAgentProfile({
+    kind: "cloud",
+    label: server.label,
+    apiBase: containerBase,
+    accessToken: authToken,
+  });
+  setActiveProfileId(profile.id);
+
+  // Seamless in-place base swap: re-point the REST base AND reconnect the WS to
+  // the dedicated host without a visible disconnect. The transcript was already
+  // copied to the dedicated agent by the handoff supervisor, so the live chat
+  // surface stays mounted on the same conversation id with no reload.
+  client.setToken(authToken);
+  client.repointBaseUrl(containerBase);
+}

--- a/packages/ui/src/cloud/handoff/silent-repoint.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.ts
@@ -3,7 +3,6 @@ import {
   addAgentProfile,
   createPersistedActiveServer,
   savePersistedActiveServer,
-  setActiveProfileId,
 } from "../../state";
 
 /**
@@ -53,15 +52,14 @@ export function silentlyRepointToDedicated(opts: {
 
   // Register + activate the dedicated profile WITHOUT going through
   // switchAgentProfile (which would clear drafts + dispatch SWITCH_AGENT).
-  // addAgentProfile already sets it active in the registry; setActiveProfileId
-  // is belt-and-suspenders for the case the registry shape changes.
-  const profile = addAgentProfile({
+  // addAgentProfile sets it active in the registry and persists before
+  // returning, so no separate activation step is needed.
+  addAgentProfile({
     kind: "cloud",
     label: server.label,
     apiBase: containerBase,
     accessToken: authToken,
   });
-  setActiveProfileId(profile.id);
 
   // Seamless in-place base swap: re-point the REST base AND reconnect the WS to
   // the dedicated host without a visible disconnect. The transcript was already

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -9,13 +9,11 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudCompatAgent } from "../../api/client-types-cloud";
-import type { CloudHandoffPhaseDetail } from "../../events";
 
 const appMock = vi.hoisted(() => ({
   value: {} as {
     elizaCloudConnected: boolean;
     setActionNotice: ReturnType<typeof vi.fn>;
-    cloudHandoffPhase?: CloudHandoffPhaseDetail | null;
   },
 }));
 
@@ -782,74 +780,8 @@ describe("CloudAgentsSection load state (error vs empty)", () => {
   });
 });
 
-describe("CloudAgentsSection handoff-aware waking badge", () => {
-  beforeEach(() => {
-    appMock.value = {
-      elizaCloudConnected: true,
-      setActionNotice: vi.fn(),
-      cloudHandoffPhase: null,
-    };
-    clientMock.getCloudCompatAgents.mockReset();
-    persistenceMock.loadPersistedActiveServer.mockReset();
-    persistenceMock.loadPersistedActiveServer.mockReturnValue({
-      kind: "cloud",
-      id: "cloud:other",
-      label: "Other",
-      accessToken: "tok",
-    });
-  });
-
-  afterEach(() => cleanup());
-
-  it("shows the Waking badge for an agent with a migrating handoff in flight", async () => {
-    appMock.value.cloudHandoffPhase = {
-      agentId: "agent-1",
-      phase: "migrating",
-    };
-    await renderWithAgents([
-      agent({
-        agent_id: "agent-1",
-        agent_name: "Mine",
-        status: "provisioning",
-      }),
-    ]);
-    expect(
-      screen.getByTestId("cloud-agent-status-agent-1").textContent,
-    ).toMatch(/Waking/);
-  });
-
-  it("does NOT show Waking once the handoff has switched (terminal phase)", async () => {
-    appMock.value.cloudHandoffPhase = {
-      agentId: "agent-1",
-      phase: "switched",
-      imported: 2,
-    };
-    await renderWithAgents([
-      agent({ agent_id: "agent-1", agent_name: "Mine", status: "running" }),
-    ]);
-    expect(
-      screen.getByTestId("cloud-agent-status-agent-1").textContent,
-    ).not.toMatch(/Waking/);
-  });
-
-  it("only wakes the agent the handoff targets, not its siblings", async () => {
-    appMock.value.cloudHandoffPhase = {
-      agentId: "agent-1",
-      phase: "migrating",
-    };
-    await renderWithAgents([
-      agent({
-        agent_id: "agent-1",
-        agent_name: "Mine",
-        status: "provisioning",
-      }),
-      agent({ agent_id: "agent-2", agent_name: "Other", status: "running" }),
-    ]);
-    expect(
-      screen.getByTestId("cloud-agent-status-agent-1").textContent,
-    ).toMatch(/Waking/);
-    expect(
-      screen.getByTestId("cloud-agent-status-agent-2").textContent,
-    ).not.toMatch(/Waking/);
-  });
-});
+// The shared→dedicated handoff no longer drives this Settings row's "Waking…"
+// badge: PR3 re-points the live client SILENTLY (no row-level waking state), and
+// the in-flight progress is shown by the chat-shell handoff toast
+// (CloudHandoffBanner). The row's only "Waking…" state is now the local
+// suspended→resume flow, covered by "CloudAgentsSection waking on switch" above.

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -23,7 +23,6 @@ import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
 } from "../../state/persistence";
-import { isCloudAgentWaking } from "../../state/types";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { StatusBadge } from "../ui/status-badge";
@@ -90,7 +89,6 @@ function currentCloudToken(): string {
 export function CloudAgentsSection() {
   const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
   const setActionNotice = useAppSelector((s) => s.setActionNotice);
-  const cloudHandoffPhase = useAppSelector((s) => s.cloudHandoffPhase);
   const { appName } = useBranding();
   const [agents, setAgents] = useState<CloudCompatAgent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -534,13 +532,12 @@ export function CloudAgentsSection() {
           agents.map((agent) => {
             const isActive = agent.agent_id === activeId;
             const busy = busyId === agent.agent_id;
-            // Show "Waking…" for a locally-driven resume (wakingId) OR a
-            // first-run shared→dedicated handoff in flight for this agent, so the
-            // row reflects the same shared-now/dedicated-pending state the chat
-            // shell sees rather than running a wholly independent signal.
-            const waking =
-              wakingId === agent.agent_id ||
-              isCloudAgentWaking(cloudHandoffPhase, agent.agent_id);
+            // Show "Waking…" for a locally-driven resume (wakingId). The
+            // first-run shared→dedicated handoff no longer surfaces here: it
+            // re-points the live client SILENTLY (no row-level "waking" state),
+            // and its in-flight progress is shown by the chat-shell handoff
+            // toast (CloudHandoffBanner), not this Settings row.
+            const waking = wakingId === agent.agent_id;
             const status = (agent.status || "").toLowerCase();
             const canSuspend = status === "running";
             const canResume = NON_RUNNING_STATES.has(status);

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -75,6 +75,13 @@ const mocks = vi.hoisted(() => ({
     status: "switched-empty" as const,
     imported: 0,
   })),
+  // PR3 invisible re-point: the handoff's onSwitch delegates to this silent
+  // path instead of switchAgentProfile (which would clear drafts + dispatch
+  // SWITCH_AGENT → StartupScreen flash). Mock it to assert the WIRING; the
+  // helper's internals (repointBaseUrl, no draft clear) are covered by
+  // cloud/handoff/silent-repoint.test.ts.
+  silentlyRepointToDedicated: vi.fn(),
+  switchAgentProfile: vi.fn(),
   // Phase-1 create-both: when the shared-tier flag is on, the controller
   // provisions a SEPARATE dedicated agent (a plain create, no preferSharedTier)
   // as the handoff target.
@@ -147,6 +154,10 @@ vi.mock("../bridge", () => ({
   invokeDesktopBridgeRequest: mocks.invokeDesktopBridgeRequest,
 }));
 
+vi.mock("../cloud/handoff/silent-repoint", () => ({
+  silentlyRepointToDedicated: mocks.silentlyRepointToDedicated,
+}));
+
 vi.mock("../config/boot-config", () => ({
   getBootConfig: () => ({
     branding: { cloudOnly: true },
@@ -173,6 +184,7 @@ vi.mock("../state", () => {
     showActionBanner: mocks.showActionBanner,
     setTab: mocks.setTab,
     setState: mocks.setState,
+    switchAgentProfile: mocks.switchAgentProfile,
     uiLanguage: "en",
   });
   return {
@@ -294,6 +306,8 @@ describe("useFirstRunController cloud first-run", () => {
       created: true,
     }));
     mocks.startCloudAgentHandoff.mockClear();
+    mocks.silentlyRepointToDedicated.mockClear();
+    mocks.switchAgentProfile.mockClear();
     mocks.savePersistedActiveServer.mockClear();
     mocks.setBaseUrl.mockClear();
     mocks.setState.mockClear();
@@ -381,6 +395,40 @@ describe("useFirstRunController cloud first-run", () => {
         onSwitch: expect.any(Function),
       }),
     );
+  });
+
+  it("PR3: the handoff onSwitch re-points SILENTLY (no switchAgentProfile, no draft wipe, no shell flash)", async () => {
+    mocks.preferSharedCloudTier = true;
+    const { result } = renderHook(() => useFirstRunController());
+
+    await act(async () => {
+      await result.current.finishRuntime();
+    });
+
+    // Grab the onSwitch the controller armed the supervisor with, and fire it
+    // the way a ready dedicated container would. The mock is untyped (no params
+    // on the vi.fn), so go through `unknown` to read the handoff arg object.
+    const handoffArgs = (
+      mocks.startCloudAgentHandoff.mock.calls as unknown as Array<
+        [{ onSwitch: (containerBase: string) => void }]
+      >
+    )[0]?.[0];
+    expect(handoffArgs?.onSwitch).toBeTypeOf("function");
+
+    act(() => handoffArgs?.onSwitch("https://dedicated-1.elizacloud.ai"));
+
+    // The switch goes through the SILENT in-place re-point, carrying the
+    // dedicated id + token so a reboot restores the dedicated agent.
+    expect(mocks.silentlyRepointToDedicated).toHaveBeenCalledTimes(1);
+    expect(mocks.silentlyRepointToDedicated).toHaveBeenCalledWith({
+      containerBase: "https://dedicated-1.elizacloud.ai",
+      authToken: "cloud-token",
+      dedicatedAgentId: "dedicated-1",
+    });
+    // It must NOT take the global profile-switch path, which clears chat drafts
+    // and dispatches SWITCH_AGENT → coordinator re-entry → full-screen
+    // <StartupScreen/> flash + dropped WS.
+    expect(mocks.switchAgentProfile).not.toHaveBeenCalled();
   });
 
   it("auto-creates (no forceCreate) and skips the picker when the user has 0 agents", async () => {

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -71,10 +71,15 @@ const mocks = vi.hoisted(() => ({
     bridgeUrl: null,
     created: true,
   })),
-  startCloudAgentHandoff: vi.fn(async () => ({
-    status: "switched-empty" as const,
-    imported: 0,
-  })),
+  startCloudAgentHandoff: vi.fn(
+    async (_args: {
+      onSwitch: (containerBase: string) => void;
+      [key: string]: unknown;
+    }) => ({
+      status: "switched-empty" as const,
+      imported: 0,
+    }),
+  ),
   // PR3 invisible re-point: the handoff's onSwitch delegates to this silent
   // path instead of switchAgentProfile (which would clear drafts + dispatch
   // SWITCH_AGENT → StartupScreen flash). Mock it to assert the WIRING; the
@@ -406,13 +411,9 @@ describe("useFirstRunController cloud first-run", () => {
     });
 
     // Grab the onSwitch the controller armed the supervisor with, and fire it
-    // the way a ready dedicated container would. The mock is untyped (no params
-    // on the vi.fn), so go through `unknown` to read the handoff arg object.
-    const handoffArgs = (
-      mocks.startCloudAgentHandoff.mock.calls as unknown as Array<
-        [{ onSwitch: (containerBase: string) => void }]
-      >
-    )[0]?.[0];
+    // the way a ready dedicated container would. The mock's arg is typed, so
+    // the handoff arg object reads through directly.
+    const handoffArgs = mocks.startCloudAgentHandoff.mock.calls[0]?.[0];
     expect(handoffArgs?.onSwitch).toBeTypeOf("function");
 
     act(() => handoffArgs?.onSwitch("https://dedicated-1.elizacloud.ai"));

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -8,6 +8,7 @@ import {
 import type { CloudCompatAgent } from "../api/client-types-cloud";
 import { getDesktopRuntimeMode, invokeDesktopBridgeRequest } from "../bridge";
 import { runCloudAgentHandoff } from "../cloud/handoff/run-cloud-agent-handoff";
+import { silentlyRepointToDedicated } from "../cloud/handoff/silent-repoint";
 import { getBootConfig } from "../config/boot-config";
 import {
   canSelectLocalRuntime,
@@ -852,33 +853,28 @@ export function useFirstRunController(): FirstRunController {
               cloudApiBase:
                 getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
               authToken,
+              // The invisible switch (PR3). switchAgentProfile() would
+              // clearAllChatDrafts() (wiping the composer) and dispatch
+              // SWITCH_AGENT (re-entering the coordinator → full-screen
+              // <StartupScreen/> + dropped WS). The handoff instead re-points
+              // SILENTLY in place: persist the dedicated profile, seamlessly
+              // swap the API/WS base (no visible disconnect), keep the same
+              // conversation id mounted, and DON'T touch drafts or the
+              // coordinator. The transcript was already copied to the dedicated
+              // agent, so the chat surface stays live throughout the swap.
               onSwitch: (containerBase) => {
-                client.setBaseUrl(containerBase);
-                client.setToken(authToken);
-                const switched = createPersistedActiveServer({
-                  kind: "cloud",
-                  // Persist by the dedicated id — that's the agent the user ends
-                  // up on, so a re-boot restores the dedicated, not the shared
-                  // bridge.
-                  id: `cloud:${dedicatedAgentId}`,
-                  apiBase: containerBase,
-                  accessToken: authToken,
+                silentlyRepointToDedicated({
+                  containerBase,
+                  authToken,
+                  dedicatedAgentId,
                 });
-                savePersistedActiveServer(switched);
-                const profile = addAgentProfile({
-                  kind: "cloud",
-                  label: switched.label,
-                  apiBase: containerBase,
-                  accessToken: authToken,
-                });
-                switchAgentProfile(profile.id);
               },
             }),
           );
         }
       }
     },
-    [completeFirstRun, switchAgentProfile, uiLanguage],
+    [completeFirstRun, uiLanguage],
   );
 
   const finishCloud = React.useCallback(

--- a/packages/ui/src/state/types.ts
+++ b/packages/ui/src/state/types.ts
@@ -243,22 +243,6 @@ export function deriveAgentReady(agentStatus: AgentStatus | null): boolean {
 }
 
 /**
- * True while a shared→dedicated cloud-agent handoff is in flight (`migrating`):
- * the user is chatting on the shared adapter while the dedicated container boots.
- * One signal both the chat shell and the Settings cloud-agents row read, so the
- * transient "shared-now / dedicated-pending" state isn't opaque to either. It is
- * an AWARENESS signal only — it never gates the composer, since the shared
- * adapter is fully responsive during the handoff.
- */
-export function isCloudAgentWaking(
-  phase: CloudHandoffPhaseDetail | null,
-  agentId?: string,
-): boolean {
-  if (phase?.phase !== "migrating") return false;
-  return agentId === undefined || phase.agentId === agentId;
-}
-
-/**
  * Whether the chat lifecycle should keep polling agent status to clear the
  * "waking up" banner (#8777). Poll while the agent is NOT ready
  * ({@link deriveAgentReady}) and NOT in a terminal state — a null/early status
@@ -383,9 +367,10 @@ export interface AppState {
   agentStatus: AgentStatus | null;
   /**
    * Latest shared→dedicated cloud-agent handoff phase, or null. Single source of
-   * truth fed by `CLOUD_HANDOFF_PHASE_EVENT`, so the chat shell and the Settings
-   * cloud-agents row both reflect the shared-now/dedicated-pending state instead
-   * of each running an independent wake loop. {@link isCloudAgentWaking}.
+   * truth fed by `CLOUD_HANDOFF_PHASE_EVENT`, read by the chat-shell handoff
+   * toast (`CloudHandoffBanner`) so the background swap is visible while the
+   * dedicated container boots. The actual switch is silent (the client
+   * re-points in place); this phase only drives the progress toast.
    */
   cloudHandoffPhase: CloudHandoffPhaseDetail | null;
   firstRunComplete: boolean;

--- a/packages/ui/src/state/useLifecycleState.test.ts
+++ b/packages/ui/src/state/useLifecycleState.test.ts
@@ -6,7 +6,6 @@ import {
   CLOUD_HANDOFF_PHASE_EVENT,
   type CloudHandoffPhaseDetail,
 } from "../events";
-import { isCloudAgentWaking } from "./types";
 import { useLifecycleState } from "./useLifecycleState";
 
 function emitHandoff(detail: CloudHandoffPhaseDetail) {
@@ -67,25 +66,5 @@ describe("useLifecycleState — cloud handoff phase", () => {
         }),
       ),
     ).not.toThrow();
-  });
-});
-
-describe("isCloudAgentWaking", () => {
-  it("is true only for the migrating phase", () => {
-    expect(isCloudAgentWaking({ agentId: "a", phase: "migrating" })).toBe(true);
-    expect(isCloudAgentWaking({ agentId: "a", phase: "switched" })).toBe(false);
-    expect(isCloudAgentWaking({ agentId: "a", phase: "failed" })).toBe(false);
-    expect(isCloudAgentWaking(null)).toBe(false);
-  });
-
-  it("scopes to a specific agent id when provided", () => {
-    const phase: CloudHandoffPhaseDetail = {
-      agentId: "agent-1",
-      phase: "migrating",
-    };
-    expect(isCloudAgentWaking(phase, "agent-1")).toBe(true);
-    expect(isCloudAgentWaking(phase, "agent-2")).toBe(false);
-    // No agent id → matches any migrating handoff.
-    expect(isCloudAgentWaking(phase)).toBe(true);
   });
 });


### PR DESCRIPTION
Stacked on #9844 (PR2 freeze).

PR3 of the seamless-provision handoff — the **invisible re-point**: make the shared→dedicated switch visually invisible (no full-screen `StartupScreen` flash, no wiped composer draft, no `SWITCH_AGENT`/coordinator re-entry).

## The problem
Today the handoff's `onSwitch` → `switchAgentProfile` → `clearAllChatDrafts` (wipes composer) + `SWITCH_AGENT` → coordinator `ready→polling-backend` (not shell-paintable) → `App.tsx:2057` swaps the shell for `<StartupScreen/>`; and `setBaseUrl` unconditionally `disconnectWs`. = full-screen flash + dropped WS + lost draft.

## How
- New `ElizaClient.repointBaseUrl(base)` — flips the base + persistence (extracted `persistBaseUrl`, byte-identical to `setBaseUrl`'s body) **without** the unconditional `disconnectWs`, swapping the WS in place. Global `setBaseUrl`/`disconnectWs` untouched.
- New `cloud/handoff/silent-repoint.ts` — persists the dedicated active-server + profile, `setToken`, `repointBaseUrl`. **NO** `clearAllChatDrafts`, **NO** `switchAgentProfile`, **NO** `SWITCH_AGENT`. Chat stays mounted on the same conversation id (transcript already copied by PR2's supervisor).
- The handoff `onSwitch` points at this silent path; every other caller keeps the global switch.
- Removed the shipped `isCloudAgentWaking` banner (+ its tests + sole consumer); the Settings row keeps its local resume chip; the chat progress toast (`CloudHandoffBanner`) stays.

## ⚠️ Known WARN (from /clean + /review — surfaced honestly)
The in-place WS-swap is currently **inert on cloud bases**: both the shared REST adapter and `*.elizacloud.ai` are treated as connected-without-WS, so `connectWs()` no-ops (`client-base.ts:1082`). So the ~40 lines of socket teardown are dead-weight on these bases today — they no-op safely (no crash, no flap). The re-point's real "invisible" wins (no `StartupScreen` flash, no draft clear, no `SWITCH_AGENT`, global path untouched) hold **independent** of the WS swap. **Reviewer's call** whether to prune the WS handling now or keep it for when a base does use WS.

## Safety + tests
Gated behind `preferSharedCloudTier` (default off → byte-identical; global `setBaseUrl`/`switchAgentProfile` unchanged for all other callers). 21 tests (silent-repoint + controller, incl. asserting the handoff switch does NOT clear drafts / does NOT dispatch `SWITCH_AGENT`) + `tsc` clean. Passed /clean + /review (No FAIL; 2 cleanups applied).

Not in scope: delete-shared (PR4), billing (PR5).
