### PR TITLE
feat(handoff): delete the shared bridge after a successful switch (PR4)

### DIFF
--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1277,6 +1277,24 @@ declare module "./client-base" {
     }): Promise<
       import("../cloud/handoff/conversation-handoff").ConversationHandoffResult
     >;
+    /**
+     * Delete the transient SHARED bridge agent (+ its `shared_runtime_history`,
+     * cascaded server-side) once the user has been switched to their dedicated
+     * agent (PR4). MUST only be called after a confirmed-successful handoff —
+     * deleting the shared while the user is still served by it loses their
+     * conversation.
+     *
+     * Pins the request to the explicit `cloudApiBase` (NOT the client's mutable
+     * `baseUrl`): by the time the switch succeeds the client has already
+     * repointed onto the dedicated container, so the base-derived
+     * `deleteCloudCompatAgent` would no longer resolve the cloud API. Shared
+     * delete is synchronous server-side (no container teardown), so success
+     * means the row + history are gone.
+     */
+    deleteSharedBridgeAgent(
+      agentId: string,
+      options: { cloudApiBase: string; authToken: string },
+    ): Promise<{ success: boolean; error?: string }>;
     checkBugReportInfo(): Promise<{
       nodeVersion?: string;
       platform?: string;
@@ -3034,6 +3052,43 @@ ElizaClient.prototype.startCloudAgentHandoff = function (
     ...(typeof timeoutMs === "number" ? { timeoutMs } : {}),
     ...(log ? { log } : {}),
   });
+};
+
+ElizaClient.prototype.deleteSharedBridgeAgent = async function (
+  this: ElizaClient,
+  agentId,
+  options,
+) {
+  // Pin to the explicit cloud API base, not the client's (now repointed-to-
+  // dedicated) baseUrl. The shared-tier DELETE on `/api/v1/eliza/agents/:id`
+  // synchronously removes the shared `agent_sandboxes` row AND its
+  // `shared_runtime_history` (cascaded in `deleteAgent`); no container teardown.
+  const apiBase = resolveDirectCloudAuthApiBase(options.cloudApiBase);
+  try {
+    const res = await fetch(
+      `${apiBase}/api/v1/eliza/agents/${encodeURIComponent(agentId)}`,
+      {
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${options.authToken}`,
+        },
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (res.status < 200 || res.status >= 300) {
+      return {
+        success: false,
+        error: `shared bridge delete failed (HTTP ${res.status})`,
+      };
+    }
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
 };
 
 ElizaClient.prototype.checkBugReportInfo = async function (this: ElizaClient) {

--- a/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
@@ -31,12 +31,10 @@ describe("runCloudAgentHandoff", () => {
 
   it("dispatches migrating then the supervisor's terminal status", async () => {
     const { phases, stop } = collectPhases();
-    const start = vi.fn(
-      async (): Promise<ConversationHandoffResult> => ({
-        status: "switched",
-        imported: 3,
-      }),
-    );
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "switched",
+      imported: 3,
+    }));
 
     runCloudAgentHandoff("a1", start);
     await flush();
@@ -89,6 +87,123 @@ describe("runCloudAgentHandoff", () => {
       "migrating",
       "switched",
     ]);
+  });
+
+  // PR4 — the shared-bridge delete is a DESTRUCTIVE op, so its gating is
+  // safety-critical: it must fire ONLY on a confirmed-successful switch and
+  // NEVER on a non-success / uncertain terminal phase (the user is still on the
+  // shared bridge, so deleting it would lose their conversation).
+  it("fires onSwitchSucceeded on `switched` (success — safe to delete shared)", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "switched",
+      imported: 2,
+    }));
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a5", start, onSwitchSucceeded);
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onSwitchSucceeded on `switched-empty` (success, nothing to copy)", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "switched-empty",
+      imported: 0,
+    }));
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a6", start, onSwitchSucceeded);
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire onSwitchSucceeded on `timed-out` (user still on the shared bridge)", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "timed-out",
+      imported: 0,
+    }));
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a7", start, onSwitchSucceeded);
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onSwitchSucceeded on `failed`", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "failed",
+      imported: 0,
+      error: "import failed",
+    }));
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a8", start, onSwitchSucceeded);
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onSwitchSucceeded when the supervisor throws", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => {
+      throw new Error("container never came up");
+    });
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a9", start, onSwitchSucceeded);
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("swallows an onSwitchSucceeded rejection (a leaked-row delete never throws upward)", async () => {
+    const { stop } = collectPhases();
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => ({
+      status: "switched",
+      imported: 1,
+    }));
+    const onSwitchSucceeded = vi.fn(async () => {
+      throw new Error("delete failed");
+    });
+
+    expect(() =>
+      runCloudAgentHandoff("a10", start, onSwitchSucceeded),
+    ).not.toThrow();
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onSwitchSucceeded on the failed leg of a retry, only on the successful one", async () => {
+    const { stop } = collectPhases();
+    const start = vi
+      .fn<() => Promise<ConversationHandoffResult>>()
+      .mockResolvedValueOnce({ status: "timed-out", imported: 0 })
+      .mockResolvedValueOnce({ status: "switched", imported: 1 });
+    const onSwitchSucceeded = vi.fn();
+
+    runCloudAgentHandoff("a11", start, onSwitchSucceeded);
+    await flush();
+    expect(onSwitchSucceeded).not.toHaveBeenCalled();
+
+    dispatchCloudHandoffRetry({ agentId: "a11" });
+    await flush();
+    stop();
+
+    expect(onSwitchSucceeded).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-fire the retry listener more than once per failure", async () => {

--- a/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.ts
+++ b/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.ts
@@ -19,10 +19,20 @@ import type { ConversationHandoffResult } from "./conversation-handoff";
  *
  * `start` is a thunk so the caller owns the supervisor args (agent id, bases,
  * token, `onSwitch` rebind) and this module stays decoupled + unit-testable.
+ *
+ * `onSwitchSucceeded` is the gated success hook (PR4): it fires ONLY on a
+ * terminal `switched`/`switched-empty` — i.e. the dedicated is confirmed live
+ * and the transcript was copied + the client repointed onto it. It is the ONLY
+ * safe moment to delete the transient shared bridge; on `timed-out`/`failed`
+ * (or a thrown supervisor) the user is STILL on the shared adapter, so the hook
+ * is deliberately NOT called and the shared bridge is kept. Best-effort: a
+ * throw here is swallowed (a failed shared-delete just leaks a row — never
+ * un-switches the user).
  */
 export function runCloudAgentHandoff(
   agentId: string,
   start: () => Promise<ConversationHandoffResult>,
+  onSwitchSucceeded?: () => void | Promise<void>,
 ): void {
   dispatchCloudHandoffPhase({ agentId, phase: "migrating" });
   start()
@@ -34,8 +44,16 @@ export function runCloudAgentHandoff(
         ...(result.error ? { error: result.error } : {}),
       });
       if (result.status === "timed-out" || result.status === "failed") {
-        armRetry(agentId, start);
+        armRetry(agentId, start, onSwitchSucceeded);
+        return;
       }
+      // Terminal SUCCESS (`switched`/`switched-empty`): the dedicated is live,
+      // the transcript is on it, and the client already repointed. Now — and
+      // ONLY now — is the shared bridge safe to delete.
+      void Promise.resolve(onSwitchSucceeded?.()).catch(() => {
+        // Fire-and-forget: a failed shared-delete leaks a row, never strands
+        // the (already switched) user. The supervisor logs the detail.
+      });
     })
     .catch((err: unknown) => {
       dispatchCloudHandoffPhase({
@@ -43,20 +61,23 @@ export function runCloudAgentHandoff(
         phase: "failed",
         error: err instanceof Error ? err.message : String(err),
       });
-      armRetry(agentId, start);
+      armRetry(agentId, start, onSwitchSucceeded);
     });
 }
 
 function armRetry(
   agentId: string,
   start: () => Promise<ConversationHandoffResult>,
+  onSwitchSucceeded?: () => void | Promise<void>,
 ): void {
   if (typeof window === "undefined") return;
   const onRetry = (event: Event) => {
     const detail = (event as CustomEvent<CloudHandoffRetryDetail>).detail;
     if (detail?.agentId !== agentId) return;
     window.removeEventListener(CLOUD_HANDOFF_RETRY_EVENT, onRetry);
-    runCloudAgentHandoff(agentId, start);
+    // Thread the gated delete through the retry: a handoff that fails first and
+    // succeeds on retry must still delete the shared bridge on the success leg.
+    runCloudAgentHandoff(agentId, start, onSwitchSucceeded);
   };
   window.addEventListener(CLOUD_HANDOFF_RETRY_EVENT, onRetry);
 }

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -840,36 +840,59 @@ export function useFirstRunController(): FirstRunController {
           // keep a `timed-out`/`failed` retryable rather than a silent permanent
           // fallback. The supervisor's import is idempotent, so a retry just
           // re-runs the same call against the same dedicated agent.
-          runCloudAgentHandoff(sharedAgentId, () =>
-            client.startCloudAgentHandoff({
-              // Source: the shared agent the user is chatting on right now.
-              agentId: sharedAgentId,
-              sharedApiBase: cloudAgentApiBase,
-              // The shared adapter keeps one canonical conversation per agent id.
-              conversationId: sharedAgentId,
-              // Target: the separate dedicated agent we just kicked off. The
-              // supervisor polls THIS record for its container base.
-              dedicatedAgentId,
-              cloudApiBase:
-                getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
-              authToken,
-              // The invisible switch (PR3). switchAgentProfile() would
-              // clearAllChatDrafts() (wiping the composer) and dispatch
-              // SWITCH_AGENT (re-entering the coordinator → full-screen
-              // <StartupScreen/> + dropped WS). The handoff instead re-points
-              // SILENTLY in place: persist the dedicated profile, seamlessly
-              // swap the API/WS base (no visible disconnect), keep the same
-              // conversation id mounted, and DON'T touch drafts or the
-              // coordinator. The transcript was already copied to the dedicated
-              // agent, so the chat surface stays live throughout the swap.
-              onSwitch: (containerBase) => {
-                silentlyRepointToDedicated({
-                  containerBase,
+          const cloudApiBase =
+            getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
+          runCloudAgentHandoff(
+            sharedAgentId,
+            () =>
+              client.startCloudAgentHandoff({
+                // Source: the shared agent the user is chatting on right now.
+                agentId: sharedAgentId,
+                sharedApiBase: cloudAgentApiBase,
+                // The shared adapter keeps one canonical conversation per agent id.
+                conversationId: sharedAgentId,
+                // Target: the separate dedicated agent we just kicked off. The
+                // supervisor polls THIS record for its container base.
+                dedicatedAgentId,
+                cloudApiBase,
+                authToken,
+                // The invisible switch (PR3). switchAgentProfile() would
+                // clearAllChatDrafts() (wiping the composer) and dispatch
+                // SWITCH_AGENT (re-entering the coordinator → full-screen
+                // <StartupScreen/> + dropped WS). The handoff instead re-points
+                // SILENTLY in place: persist the dedicated profile, seamlessly
+                // swap the API/WS base (no visible disconnect), keep the same
+                // conversation id mounted, and DON'T touch drafts or the
+                // coordinator. The transcript was already copied to the dedicated
+                // agent, so the chat surface stays live throughout the swap.
+                onSwitch: (containerBase) => {
+                  silentlyRepointToDedicated({
+                    containerBase,
+                    authToken,
+                    dedicatedAgentId,
+                  });
+                },
+              }),
+            // Gated on switch-SUCCESS (`switched`/`switched-empty`): only once
+            // the user is on the dedicated and the transcript was copied is the
+            // transient shared bridge safe to delete. On `timed-out`/`failed`
+            // this never runs, so the user keeps the working shared bridge (and
+            // their conversation). Fire-and-forget: a failed delete just leaks a
+            // shared row — never blocks the (already switched) user.
+            () => {
+              void client
+                .deleteSharedBridgeAgent(sharedAgentId, {
+                  cloudApiBase,
                   authToken,
-                  dedicatedAgentId,
+                })
+                .then((res) => {
+                  if (!res.success) {
+                    console.warn(
+                      `[useFirstRunController] shared bridge delete failed (leaked row ${sharedAgentId}): ${res.error ?? "unknown"}`,
+                    );
+                  }
                 });
-              },
-            }),
+            },
           );
         }
       }


### PR DESCRIPTION
Stacked on #9845 (PR3 invisible re-point).

PR4 of the seamless-provision handoff — **delete the transient shared bridge after a SUCCESSFUL switch**.

## What
Once the user is switched to the dedicated and the transcript is copied, delete the shared agent + its `shared_runtime_history` (one DELETE cascades both — `eliza-sandbox.ts:867`). The shared was a transient bridge; this cleans it up so we don't leak a row per agent.

## The safety guarantee (it's destructive)
The delete fires **ONLY** on a confirmed successful switch — `switched`/`switched-empty`, which `runConversationHandoff` returns only AFTER both `await importToPersonal` + `await switchToPersonal` (the silent re-point) resolve. On `timed-out`/`failed`/thrown → the hook never fires (the user is still on the shared bridge). Threaded through the retry so only the success leg deletes. Fire-and-forget: a failed delete only logs a leaked-row warning — degrades to a leak, **never** to data loss or an un-switched user. **/review verdict: "provably gated — the shared is never deleted while the user still depends on it" (traced end-to-end).**

## Bug caught + fixed
`deleteCloudCompatAgent` resolves its base from the client's **mutable** `baseUrl` — but by delete-time the client already re-pointed to the dedicated → would mis-route. Fix: a **base-pinned** `deleteSharedBridgeAgent(agentId, { cloudApiBase, authToken })`.

## Tests
56/56 pass — delete fires on `switched`/`switched-empty`, does NOT fire on `timed-out`/`failed`/thrown, fires only on the retry success leg, swallows a delete rejection. Flag-off byte-identical.

## Known follow-ups (from /clean + /review, non-blocking)
- The delete uses bare `fetch()`, not the Capacitor native-HTTP path → on **mobile** builds the cleanup may fail and leak the shared row (harmless: fire-and-forget, user is on the dedicated). Worth fixing across the whole handoff `fetch` family.
- Non-2xx body discarded in the leaked-row warning; the exclusion-based success gate is open to future status members; one test under-proves the async rejection swallow.

Passed /clean + /review (No FAIL). Not in scope: billing (PR5), e2e mock (PR6).
