### PR TITLE
[codex] De-dupe local inference hub refreshes

### DIFF
--- a/packages/ui/src/api/client-base-timeout.test.ts
+++ b/packages/ui/src/api/client-base-timeout.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setBootConfig } from "../config/boot-config";
 import { ElizaClient } from "./client-base";
 import "./client-chat";
+import "./client-local-inference";
 import type { AgentRequestTransport } from "./transport";
 
 function makeClientWithTransport() {
@@ -15,6 +16,14 @@ function makeClientWithTransport() {
   const client = new ElizaClient("http://agent.example:2138", "token");
   client.setRequestTransport({ request });
   return { client, request };
+}
+
+function makeDeferredResponse() {
+  let resolve: (response: Response) => void = () => {};
+  const promise = new Promise<Response>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe("ElizaClient request timeout policy", () => {
@@ -61,5 +70,37 @@ describe("ElizaClient request timeout policy", () => {
       expect.any(Object),
       { timeoutMs: 10_000 },
     );
+  });
+
+  it("coalesces concurrent local inference hub reads with a longer timeout", async () => {
+    const response = makeDeferredResponse();
+    const request = vi.fn<AgentRequestTransport["request"]>(
+      async () => response.promise,
+    );
+    const client = new ElizaClient("http://agent.example:2138", "token");
+    client.setRequestTransport({ request });
+
+    const first = client.getLocalInferenceHub();
+    const second = client.getLocalInferenceHub();
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "http://agent.example:2138/api/local-inference/hub",
+      expect.any(Object),
+      { timeoutMs: 30_000 },
+    );
+
+    response.resolve(
+      new Response(JSON.stringify({ catalog: [], installed: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { catalog: [], installed: [] },
+      { catalog: [], installed: [] },
+    ]);
   });
 });

--- a/packages/ui/src/api/client-local-inference.ts
+++ b/packages/ui/src/api/client-local-inference.ts
@@ -26,6 +26,8 @@ import type {
 import type { VerifyResult } from "../services/local-inference/verify";
 import { ElizaClient } from "./client-base";
 
+let localInferenceHubRequest: Promise<ModelHubSnapshot> | null = null;
+
 export type {
   ActiveModelState,
   AgentModelSlot,
@@ -183,7 +185,14 @@ declare module "./client-base" {
 ElizaClient.prototype.getLocalInferenceHub = async function (
   this: ElizaClient,
 ) {
-  return this.fetch("/api/local-inference/hub");
+  localInferenceHubRequest ??= this.fetch<ModelHubSnapshot>(
+    "/api/local-inference/hub",
+    undefined,
+    { timeoutMs: 30_000 },
+  ).finally(() => {
+    localInferenceHubRequest = null;
+  });
+  return localInferenceHubRequest;
 };
 
 ElizaClient.prototype.getLocalInferenceHardware = async function (

--- a/plugins/plugin-local-inference/src/services/registry.ts
+++ b/plugins/plugin-local-inference/src/services/registry.ts
@@ -19,6 +19,16 @@ interface RegistryFile {
 	models: InstalledModel[];
 }
 
+const EXTERNAL_SCAN_CACHE_TTL_MS = 5_000;
+
+let externalScanCache:
+	| {
+			expiresAt: number;
+			models: InstalledModel[];
+	  }
+	| null = null;
+let externalScanPromise: Promise<InstalledModel[]> | null = null;
+
 async function ensureRootDir(): Promise<void> {
 	await fs.mkdir(localInferenceRoot(), { recursive: true });
 }
@@ -53,12 +63,33 @@ function externalScanEnabled(): boolean {
 	return value === "1" || value === "true" || value === "yes";
 }
 
+async function scanExternalModelsCached(): Promise<InstalledModel[]> {
+	const now = Date.now();
+	if (externalScanCache && externalScanCache.expiresAt > now) {
+		return externalScanCache.models;
+	}
+	externalScanPromise ??= scanExternalModels()
+		.then((models) => {
+			externalScanCache = {
+				expiresAt: Date.now() + EXTERNAL_SCAN_CACHE_TTL_MS,
+				models,
+			};
+			return models;
+		})
+		.finally(() => {
+			externalScanPromise = null;
+	});
+	return externalScanPromise;
+}
+
 /**
  * Return models currently usable by the curated local-inference path.
  *
  * Normal product behavior is Eliza-1 only. The external scan remains available
  * only to developers who explicitly opt into the old arbitrary-GGUF diagnostic
- * path with `ELIZA_LOCAL_INFERENCE_ENABLE_EXTERNAL_SCAN=1`.
+ * path with `ELIZA_LOCAL_INFERENCE_ENABLE_EXTERNAL_SCAN=1`. External scans are
+ * cached briefly and shared while in flight because model-hub UI refreshes can
+ * arrive in bursts during active downloads.
  */
 export async function listInstalledModels(): Promise<InstalledModel[]> {
 	const owned = await readElizaOwned();
@@ -66,7 +97,7 @@ export async function listInstalledModels(): Promise<InstalledModel[]> {
 
 	// Filter out Eliza-owned files that also survived a reboot of the local
 	// file and got re-detected by the scanner.
-	const external = await scanExternalModels();
+	const external = await scanExternalModelsCached();
 	const ownedPaths = new Set(owned.map((m) => path.resolve(m.path)));
 	const dedupedExternal = external.filter(
 		(m) => !ownedPaths.has(path.resolve(m.path)),

--- a/plugins/plugin-local-inference/src/services/registry.ts
+++ b/plugins/plugin-local-inference/src/services/registry.ts
@@ -21,12 +21,10 @@ interface RegistryFile {
 
 const EXTERNAL_SCAN_CACHE_TTL_MS = 5_000;
 
-let externalScanCache:
-	| {
-			expiresAt: number;
-			models: InstalledModel[];
-	  }
-	| null = null;
+let externalScanCache: {
+	expiresAt: number;
+	models: InstalledModel[];
+} | null = null;
 let externalScanPromise: Promise<InstalledModel[]> | null = null;
 
 async function ensureRootDir(): Promise<void> {
@@ -78,7 +76,7 @@ async function scanExternalModelsCached(): Promise<InstalledModel[]> {
 		})
 		.finally(() => {
 			externalScanPromise = null;
-	});
+		});
 	return externalScanPromise;
 }
 


### PR DESCRIPTION
## Summary
- coalesce concurrent local-inference hub refreshes so repeated callers share one in-flight request
- add timeout coverage for the local inference client path
- avoid duplicate registry refresh work in the app plugin registry service

## Why
Repeated renderer calls to /api/local-inference/hub can pile up and make startup/dev flows feel broken when one request is already in flight.

## Validation
- Not run in the PR worktree; branch was isolated from the local source commit and pushed as a draft for CI.
