### PR TITLE
[codex] Break agent app-core turbo build cycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -310,6 +310,7 @@
         "@capacitor/preferences": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.0",
         "@clack/prompts": "^1.0.0",
+        "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-anthropic": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -96,16 +96,6 @@
       "env": ["LOG_LEVEL"],
       "outputs": ["dist/**"]
     },
-    "@elizaos/agent#build": {
-      "dependsOn": [
-        "@elizaos/core#build",
-        "@elizaos/shared#build",
-        "@elizaos/skills#build",
-        "@elizaos/tui#build"
-      ],
-      "env": ["LOG_LEVEL"],
-      "outputs": ["dist/**"]
-    },
     "@elizaos/ui#build": {
       "dependsOn": [
         "@elizaos/cloud-sdk#build",

--- a/turbo.json
+++ b/turbo.json
@@ -96,6 +96,16 @@
       "env": ["LOG_LEVEL"],
       "outputs": ["dist/**"]
     },
+    "@elizaos/agent#build": {
+      "dependsOn": [
+        "@elizaos/core#build",
+        "@elizaos/shared#build",
+        "@elizaos/skills#build",
+        "@elizaos/tui#build"
+      ],
+      "env": ["LOG_LEVEL"],
+      "outputs": ["dist/**"]
+    },
     "@elizaos/ui#build": {
       "dependsOn": [
         "@elizaos/cloud-sdk#build",


### PR DESCRIPTION
## Summary
- add the missing package-task dependency edge needed for app-core/agent build ordering
- update the lock metadata touched by that dependency graph change

## Why
The agent/app-core turbo graph can otherwise form an ordering cycle or run before the required package output exists.

## Validation
- Not run in the PR worktree; branch was isolated from the local source commit and pushed as a draft for CI.
