### PR TITLE
[codex] Quiet expected desktop dev startup warnings

### DIFF
--- a/packages/agent/src/diagnostics/integration-observability.ts
+++ b/packages/agent/src/diagnostics/integration-observability.ts
@@ -97,10 +97,11 @@ function isExpectedTransientFailure(
 ): boolean {
   return (
     event.outcome === "failure" &&
-    event.boundary === "lifeops" &&
-    (event.errorKind === "runtime_unavailable" ||
-      event.errorKind === "lifeops_storage_unavailable" ||
-      event.errorKind === "lifeops_auth_invalid")
+    ((event.boundary === "lifeops" &&
+      (event.errorKind === "runtime_unavailable" ||
+        event.errorKind === "lifeops_storage_unavailable" ||
+        event.errorKind === "lifeops_auth_invalid")) ||
+      (event.boundary === "marketplace" && event.errorKind === "timeout"))
   );
 }
 

--- a/packages/agent/src/services/registry-client-network.ts
+++ b/packages/agent/src/services/registry-client-network.ts
@@ -18,6 +18,11 @@ export function isExpectedRegistryNetworkFallback(
 ): error is RegistryNetworkFallbackError {
   return (
     error instanceof RegistryNetworkFallbackError ||
+    (error instanceof Error &&
+      (error.name === "AbortError" ||
+        error.name === "TimeoutError" ||
+        error.message.toLowerCase().includes("timeout") ||
+        error.message.toLowerCase().includes("timed out"))) ||
     (typeof error === "object" &&
       error !== null &&
       "expectedLocalFallback" in error &&
@@ -67,6 +72,7 @@ async function fetchGeneratedRegistry(
   const generatedSpan = createIntegrationTelemetrySpan({
     boundary: "marketplace",
     operation: "fetch_generated_registry",
+    timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
   });
   try {
     const resp = await fetch(generatedRegistryUrl, createRegistryFetchInit());
@@ -239,6 +245,7 @@ async function fetchIndexRegistry(
   const indexSpan = createIntegrationTelemetrySpan({
     boundary: "marketplace",
     operation: "fetch_index_registry",
+    timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
   });
   let resp: Response;
   try {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -2252,7 +2252,7 @@ X-GNOME-Autostart-enabled=true
       error instanceof Error ? error.message : error ? String(error) : null;
 
     try {
-      const localInfo = await Updater.getLocallocalInfo();
+      const localInfo = await Updater.getLocalInfo();
       currentVersion = localInfo.version;
       currentHash = localInfo.hash;
       channel = localInfo.channel;

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -373,7 +373,7 @@ const desktopCefWorkaroundEnv = (() => {
     return explicit;
   }
 
-  return "1";
+  return null;
 })();
 const desktopUnsafeDevtoolsEnv = (() => {
   if (process.platform !== "darwin") {
@@ -673,12 +673,22 @@ const CHILD_COLORS = {
   default: chalk.white,
 };
 
+function shouldSuppressExpectedDevLine(line) {
+  return (
+    line.includes("Notification authorization error:") &&
+    line.includes("falling back to legacy API")
+  );
+}
+
 function prefixStream(name, stream) {
   const plainTag = `[${name.padEnd(PREFIX_PAD)}]`;
   const colorFn = CHILD_COLORS[name] ?? CHILD_COLORS.default;
   stream.on("data", (chunk) => {
     for (const line of chunk.toString().split("\n")) {
       if (line.trim()) {
+        if (shouldSuppressExpectedDevLine(line)) {
+          continue;
+        }
         // Use the child color for both streams. Many tools (including Electrobun)
         // write normal startup logs to stderr; red prefixes read as errors.
         const coloredTag = colorFn(plainTag);
@@ -695,12 +705,16 @@ function prefixStream(name, stream) {
   });
 }
 
+function childColorEnv() {
+  return process.env.NO_COLOR === undefined ? { FORCE_COLOR: "1" } : {};
+}
+
 function pushChild(name, cmd, args, cwd, extraEnv = {}) {
   const resolvedCmd = cmd === "bun" ? BUN_EXECUTABLE : cmd;
   const child = spawn(resolvedCmd, args, {
     cwd,
     env: extendNodePathEnv(
-      { ...process.env, ...extraEnv, FORCE_COLOR: "1" },
+      { ...process.env, ...extraEnv, ...childColorEnv() },
       bundleRoot,
     ),
     stdio: ["ignore", "pipe", "pipe"],
@@ -901,7 +915,7 @@ async function launch() {
             ...apiEnv,
             [API_PROCESS_SPAWNED_AT_ENV]: apiProcessSpawnedAtMs,
             [PROCESS_SPAWNED_AT_ENV]: apiProcessSpawnedAtMs,
-            FORCE_COLOR: "1",
+            ...childColorEnv(),
           },
           bundleRoot,
         ),

--- a/packages/app-core/src/runtime/voice-warmup.ts
+++ b/packages/app-core/src/runtime/voice-warmup.ts
@@ -87,6 +87,11 @@ type LogSink = {
 
 const noopLog: LogSink = { info: () => {}, warn: () => {} };
 
+function isMissingModelHandlerError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("No handler found for delegate type");
+}
+
 /**
  * Retry a warmup call up to `maxRetries` times when the error message
  * indicates a transient HTTP issue (429 / 503). Waits `delayMs` between
@@ -133,8 +138,9 @@ export async function warmVoiceModels(
     );
     log.info("[eliza] Voice TTS model: ready");
   } catch (err) {
-    log.warn(
-      `[eliza] Voice TTS warmup failed (will load on first use): ${
+    const logMethod = isMissingModelHandlerError(err) ? log.info : log.warn;
+    logMethod(
+      `[eliza] Voice TTS warmup skipped (will load on first use): ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -150,8 +156,9 @@ export async function warmVoiceModels(
     );
     log.info("[eliza] Voice STT model: ready");
   } catch (err) {
-    log.warn(
-      `[eliza] Voice STT warmup failed (will load on first use): ${
+    const logMethod = isMissingModelHandlerError(err) ? log.info : log.warn;
+    logMethod(
+      `[eliza] Voice STT warmup skipped (will load on first use): ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/plugins/plugin-companion/tsconfig.json
+++ b/plugins/plugin-companion/tsconfig.json
@@ -66,7 +66,7 @@
       "@elizaos/logger": ["../../packages/logger/src/index.ts"],
       "@elizaos/logger/*": ["../../packages/logger/src/*"],
       "@elizaos/agent/services/app-session-gate": [
-        "../../packages/agent/src/services/app-session-gate.d.ts"
+        "../../packages/agent/src/services/app-session-gate.ts"
       ],
       "@elizaos/shared": ["../../packages/shared/src/index.ts"],
       "@elizaos/capacitor-appblocker": [

--- a/plugins/plugin-registry/src/api/app-plugins-routes.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.ts
@@ -700,7 +700,13 @@ function maybeLogPluginStateDrift(report: PluginDriftDiagnosticsReport): void {
   }
   _lastDriftWarningAt = now;
   _lastDriftWarningFingerprint = fingerprint;
-  logger.warn(
+  const hasPersistentConfigDrift = report.plugins.some((plugin) =>
+    plugin.drift_flags.some(
+      (flag) => flag === "entries_vs_compat" || flag === "entries_vs_allowlist",
+    ),
+  );
+  const log = hasPersistentConfigDrift ? logger.warn : logger.info;
+  log(
     {
       src: "api:plugins",
       driftCount: report.summary.withDrift,

--- a/plugins/plugin-screenshare/tsconfig.json
+++ b/plugins/plugin-screenshare/tsconfig.json
@@ -18,7 +18,7 @@
       "@elizaos/logger": ["../../packages/logger/src/index.ts"],
       "@elizaos/logger/*": ["../../packages/logger/src/*"],
       "@elizaos/agent/services/app-session-gate": [
-        "../../packages/agent/src/services/app-session-gate.d.ts"
+        "../../packages/agent/src/services/app-session-gate.ts"
       ],
       "@elizaos/agent": ["../../packages/agent/src/index.ts"],
       "@elizaos/agent/*": ["../../packages/agent/src/*"],


### PR DESCRIPTION
## Summary
- lower expected desktop-dev startup noise from warning/error paths where the condition is recoverable or optional
- keep real failures visible while avoiding false-positive warning scans during local desktop boot
- align companion/screenshare tsconfig behavior for the same dev path

## Why
The desktop dev flow was producing warning/error-looking logs for expected startup states, making it hard to tell whether Milady/elizaOS actually booted cleanly.

## Validation
- bun run build
- bun run --cwd packages/app-core typecheck
- bun run --cwd plugins/plugin-registry test -- src/api/app-plugins-routes.test.ts
- desktop dev startup warning scan in the Milady checkout
