### PR TITLE
[codex] Simplify desktop dev env flags

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-pill-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-pill-config.ts
@@ -20,7 +20,7 @@ function parseFalsy(value: string | undefined): boolean {
  *   - After  PR #8175: pill is shown (opt-out, ON by default).
  *
  * To restore the previous hidden behaviour set either:
- *   ELIZA_DESKTOP_PILL=0            (standard off)
+ *   ELIZA_DESKTOP_PILL=0            (canonical off)
  *   ELIZA_DESKTOP_DISABLE_PILL=1    (legacy kill-switch; still respected)
  */
 export function shouldCreateDesktopPill(
@@ -35,6 +35,7 @@ export function shouldCreateDesktopPill(
   }
 
   // Default on: the pill window is the primary voice surface. Users can
-  // suppress it with ELIZA_DESKTOP_PILL=0 or ELIZA_DESKTOP_DISABLE_PILL=1.
+  // suppress it with ELIZA_DESKTOP_PILL=0. ELIZA_DESKTOP_DISABLE_PILL remains
+  // supported as a legacy alias.
   return true;
 }

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -325,15 +325,12 @@ const rendererBuildSkipRequested =
 const viteWatch = process.env.ELIZA_DESKTOP_VITE_WATCH === "1";
 const viteDepForceCli = process.argv.includes("--vite-force");
 const viteDepForce =
-  viteDepForceCli ||
-  process.env.ELIZA_VITE_FORCE === "1" ||
-  process.env.ELIZA_VITE_FORCE === "1";
+  viteDepForceCli || process.env.ELIZA_VITE_FORCE === "1";
 const viteRollupWatchCli = process.argv.includes("--rollup-watch");
 /** Legacy: Rollup `vite build --watch` (tens of seconds per edit on large graphs). */
 const viteRollupWatch =
   viteWatch &&
   (viteRollupWatchCli ||
-    process.env.ELIZA_DESKTOP_VITE_BUILD_WATCH === "1" ||
     process.env.ELIZA_DESKTOP_VITE_BUILD_WATCH === "1");
 /** Default when VITE_WATCH: Vite dev server + Electrobun ELIZA_RENDERER_URL (fast HMR). */
 const viteDevServer = viteWatch && !viteRollupWatch;


### PR DESCRIPTION
## Summary
- remove duplicate desktop dev env checks in dev-platform.mjs
- document ELIZA_DESKTOP_PILL as the canonical pill disable knob while keeping the legacy disable alias

## Why
Milady now bridges branded MILADY_DESKTOP_* variables before invoking app-core scripts, so app-core can stay on the canonical ELIZA_* env contract.

## Validation
- bun run --cwd packages/app-core/platforms/electrobun test src/desktop-pill-config.test.ts
- node --check packages/app-core/scripts/dev-platform.mjs
