### PR TITLE
Fix macOS traffic-light overlap on content pages

### DIFF
--- a/packages/ui/src/components/shell/ShellHeaderControls.tsx
+++ b/packages/ui/src/components/shell/ShellHeaderControls.tsx
@@ -243,6 +243,7 @@ export function ShellHeaderControls({
   return (
     <div
       className={`min-w-0 w-full overflow-visible flex items-center ${className ?? ""}`}
+      data-window-titlebar-padding="true"
       data-no-camera-drag="true"
     >
       {/* Left: shell view toggle (hidden outside companion overlay) */}

--- a/packages/ui/src/layouts/content-layout/content-layout.tsx
+++ b/packages/ui/src/layouts/content-layout/content-layout.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
 import { WorkspaceLayout } from "../workspace-layout";
 
 export interface ContentLayoutProps {
@@ -30,7 +31,7 @@ export function ContentLayout({
 }: ContentLayoutProps) {
   return (
     <WorkspaceLayout
-      className={className}
+      className={cn("eliza-content-layout", className)}
       contentClassName={contentClassName}
       contentHeader={contentHeader}
       contentPadding={!inModal}

--- a/packages/ui/src/layouts/content-layout/content-layout.tsx
+++ b/packages/ui/src/layouts/content-layout/content-layout.tsx
@@ -31,7 +31,7 @@ export function ContentLayout({
 }: ContentLayoutProps) {
   return (
     <WorkspaceLayout
-      className={cn("eliza-content-layout", className)}
+      className={cn(!inModal && "eliza-content-layout", className)}
       contentClassName={contentClassName}
       contentHeader={contentHeader}
       contentPadding={!inModal}

--- a/packages/ui/src/styles/electrobun-mac-window-drag.css
+++ b/packages/ui/src/styles/electrobun-mac-window-drag.css
@@ -57,6 +57,13 @@ html.eliza-electrobun-macos-titlebar [data-window-titlebar-padding] {
   );
 }
 
+html.eliza-electrobun-macos-titlebar [data-testid="ui-shell-toggle"] {
+  margin-inline-start: max(
+    env(safe-area-inset-left, 0px),
+    var(--eliza-macos-frame-left-inset)
+  );
+}
+
 html.eliza-electrobun-macos-titlebar [data-window-titlebar-banner="true"] {
   padding-inline-start: max(
     env(safe-area-inset-left, 0px),

--- a/packages/ui/src/styles/electrobun-mac-window-drag.css
+++ b/packages/ui/src/styles/electrobun-mac-window-drag.css
@@ -64,6 +64,13 @@ html.eliza-electrobun-macos-titlebar [data-window-titlebar-banner="true"] {
   );
 }
 
+html.eliza-electrobun-macos-titlebar .eliza-content-layout {
+  padding-inline-start: max(
+    env(safe-area-inset-left, 0px),
+    var(--eliza-macos-frame-left-inset)
+  );
+}
+
 html.eliza-electrobun-macos-titlebar a,
 html.eliza-electrobun-macos-titlebar button,
 html.eliza-electrobun-macos-titlebar input,

--- a/packages/ui/src/styles/electrobun-mac-window-drag.css
+++ b/packages/ui/src/styles/electrobun-mac-window-drag.css
@@ -57,13 +57,6 @@ html.eliza-electrobun-macos-titlebar [data-window-titlebar-padding] {
   );
 }
 
-html.eliza-electrobun-macos-titlebar [data-testid="ui-shell-toggle"] {
-  margin-inline-start: max(
-    env(safe-area-inset-left, 0px),
-    var(--eliza-macos-frame-left-inset)
-  );
-}
-
 html.eliza-electrobun-macos-titlebar [data-window-titlebar-banner="true"] {
   padding-inline-start: max(
     env(safe-area-inset-left, 0px),


### PR DESCRIPTION
## Summary
- mark content layout roots with a stable class for desktop shell CSS hooks
- inset page content in macOS Electrobun hidden-titlebar windows so headings clear traffic lights
- apply the existing titlebar-padding hook to ShellHeaderControls so the whole top control row clears the red/yellow/green window controls

## Verification
- Cherry-picked onto a clean branch from origin/develop
- git diff --check origin/develop...HEAD
- Milady integration PR covers the source hooks with package-mode regression tests

Milady integration PR: https://github.com/milady-ai/milady/pull/2200