### PR TITLE
fix(handoff): force a separate dedicated agent in create-both (honor forceCreate, bypass reuse guard)

### DIFF
--- a/packages/cloud-api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud-api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -177,4 +177,60 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(json.data.jobId).toBe("job-1");
     expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
   });
+
+  test("forceCreate:true bypasses the reuse guard → createAgent called with reuseExistingNonTerminal:false (mints a SEPARATE agent)", async () => {
+    // The org already has a non-terminal agent (the shared bridge). With
+    // forceCreate the route must NOT let createAgent reuse it — the dedicated
+    // handoff target has to be a distinct record, else dedicatedId === sharedId.
+    const agent = { ...pendingAgent(), id: "dedicated-fresh", status: "pending" };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+      forceCreate: true,
+    });
+
+    expect(res.status).toBe(202);
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    const passed = createAgent.mock.calls[0]?.[0] as {
+      reuseExistingNonTerminal?: boolean;
+    };
+    expect(passed.reuseExistingNonTerminal).toBe(false);
+    // A fresh create still provisions normally.
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+
+  test("default (no forceCreate) still reuses → createAgent called with reuseExistingNonTerminal:true (byte-identical to before)", async () => {
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(200);
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    const passed = createAgent.mock.calls[0]?.[0] as {
+      reuseExistingNonTerminal?: boolean;
+    };
+    expect(passed.reuseExistingNonTerminal).toBe(true);
+  });
+
+  test("forceCreate:false (explicit) is treated as the default → reuseExistingNonTerminal:true", async () => {
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+      forceCreate: false,
+    });
+
+    const passed = createAgent.mock.calls[0]?.[0] as {
+      reuseExistingNonTerminal?: boolean;
+    };
+    expect(passed.reuseExistingNonTerminal).toBe(true);
+  });
 });

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -61,6 +61,14 @@ const createAgentSchema = z.object({
   // S2S callers that want to create the record without spending can opt out
   // with `autoProvision: false` (or the `?autoProvision=false` query param).
   autoProvision: z.boolean().optional(),
+  // Bypass the org-scoped reuse guard and ALWAYS mint a fresh agent. Default
+  // (absent/false) keeps `reuseExistingNonTerminal: true` so every existing
+  // caller still reuses an org's live agent. The seamless shared→dedicated
+  // handoff sets this so the 2nd create (the DEDICATED migration target) is a
+  // SEPARATE record from the shared bridge it's handing off from — otherwise
+  // the reuse guard hands back the shared agent and the handoff probe polls a
+  // base that never grows a dedicated container (it times out, no switch).
+  forceCreate: z.boolean().optional(),
 });
 
 type Agent = Awaited<ReturnType<typeof elizaSandboxService.listAgents>>[number];
@@ -364,7 +372,11 @@ app.post("/", async (c) => {
       : sanitizedConfig,
     environmentVars: parsed.data.environmentVars,
     executionTier,
-    reuseExistingNonTerminal: true,
+    // Default reuses the org's existing non-terminal agent (idempotent create);
+    // `forceCreate` opts out so a caller that needs a SEPARATE record (the
+    // shared→dedicated handoff's migration target) mints a fresh agent instead
+    // of getting the shared one handed back.
+    reuseExistingNonTerminal: parsed.data.forceCreate ? false : true,
   });
 
   // Idempotent reuse: the org already had a non-terminal agent, so createAgent

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -263,6 +263,54 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expectNoLocalPersistOrStatusProbe();
   });
 
+  it("forwards forceCreate into the create POST body so the backend bypasses the reuse guard", async () => {
+    capacitorMocks.request.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        success: true,
+        data: { id: "dedicated-1", agentName: "My Agent", status: "pending" },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    await client.createCloudCompatAgent({
+      agentName: "My Agent",
+      forceCreate: true,
+    });
+
+    expect(capacitorMocks.request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/v1/eliza/agents",
+        method: "POST",
+        data: expect.objectContaining({
+          agentName: "My Agent",
+          forceCreate: true,
+        }),
+      }),
+    );
+    expectNoLocalPersistOrStatusProbe();
+  });
+
+  it("omits forceCreate from the body by default (request byte-identical for every existing caller)", async () => {
+    capacitorMocks.request.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        success: true,
+        data: { id: "agent-1", agentName: "My Agent", status: "pending" },
+      },
+    });
+
+    const client = new ElizaClient(undefined, "cloud-api-key");
+    await client.createCloudCompatAgent({ agentName: "My Agent" });
+
+    const body = capacitorMocks.request.mock.calls[0]?.[0]?.data as Record<
+      string,
+      unknown
+    >;
+    expect(body).not.toHaveProperty("forceCreate");
+  });
+
   it("accepts an async-provisioning create response that returns agentId without id", async () => {
     // The cloud agent-create async branch (202) returns the new agent's id
     // under `agentId` only — no `id` field. The client must read it instead of

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -993,6 +993,15 @@ declare module "./client-base" {
        * one. Default (undefined/false) keeps the dedicated request unchanged.
        */
       preferSharedTier?: boolean;
+      /**
+       * Bypass the backend's org-scoped reuse guard so a SEPARATE agent is
+       * minted even when the org already has a live one. The shared→dedicated
+       * handoff sets this for the dedicated migration target; without it the
+       * reuse guard hands back the shared bridge (dedicatedId === sharedId) and
+       * the handoff probe never resolves. Default (undefined/false) leaves the
+       * request byte-identical — every existing caller still reuses.
+       */
+      forceCreate?: boolean;
     }): Promise<{
       success: boolean;
       data: {
@@ -1640,6 +1649,9 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
       // (With the Phase-0 shared-tier flag on, `alwaysOn` is dropped so the
       // backend derives a SHARED agent instead — see tierFields above.)
       ...tierFields,
+      // Opt out of the backend reuse guard so a SEPARATE agent is minted (the
+      // shared→dedicated handoff target). Omitted by default → reuse unchanged.
+      ...(opts.forceCreate ? { forceCreate: true } : {}),
       ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
       ...(opts.environmentVars
         ? { environmentVars: opts.environmentVars }
@@ -1687,6 +1699,9 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
         // Dedicated (own-container, always-on) agent — see the direct-path note.
         // The Phase-0 shared-tier flag drops `alwaysOn` here too (tierFields).
         ...tierFields,
+        // Opt out of the backend reuse guard so a SEPARATE agent is minted (the
+        // shared→dedicated handoff target). Omitted by default → reuse unchanged.
+        ...(opts.forceCreate ? { forceCreate: true } : {}),
         ...(opts.agentConfig ? { agentConfig: opts.agentConfig } : {}),
         ...(opts.environmentVars
           ? { environmentVars: opts.environmentVars }

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -380,12 +380,14 @@ describe("useFirstRunController cloud first-run", () => {
     });
     // Create-both: a SEPARATE dedicated agent is provisioned as the migration
     // target — a PLAIN create (no preferSharedTier, so the backend derives a
-    // dedicated always-on container, not another shared agent).
+    // dedicated always-on container, not another shared agent) AND forceCreate
+    // so the backend reuse guard doesn't hand back the shared agent we already
+    // created (which would make dedicatedId === sharedId → the probe times out).
     expect(mocks.createCloudCompatAgent).toHaveBeenCalledWith(
       expect.not.objectContaining({ preferSharedTier: expect.anything() }),
     );
     expect(mocks.createCloudCompatAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ agentName: "Demo Agent" }),
+      expect.objectContaining({ agentName: "Demo Agent", forceCreate: true }),
     );
     // A freshly created SHARED agent is served by the shared adapter; the
     // background handoff is armed to poll the dedicated agent, copy the
@@ -400,6 +402,13 @@ describe("useFirstRunController cloud first-run", () => {
         onSwitch: expect.any(Function),
       }),
     );
+    // The whole point of forceCreate: the dedicated migration target is a
+    // DISTINCT agent from the shared bridge — not the same id handed back by
+    // the reuse guard. If these were equal the readiness probe would poll the
+    // shared base (which never grows a dedicated container) and time out.
+    const handoffArgs = mocks.startCloudAgentHandoff.mock.calls[0]?.[0];
+    expect(handoffArgs?.dedicatedAgentId).toBe("dedicated-1");
+    expect(handoffArgs?.dedicatedAgentId).not.toBe(handoffArgs?.agentId);
   });
 
   it("PR3: the handoff onSwitch re-points SILENTLY (no switchAgentProfile, no draft wipe, no shell flash)", async () => {

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -828,6 +828,12 @@ export function useFirstRunController(): FirstRunController {
           .createCloudCompatAgent({
             agentName: name,
             ...(bio.length ? { agentConfig: { bio } } : {}),
+            // Bypass the backend reuse guard: the org already has a non-terminal
+            // agent (the SHARED bridge we just created), so without forceCreate
+            // the server hands that one back and dedicatedAgentId === sharedId —
+            // the handoff probe then polls the shared base (which never grows a
+            // dedicated container) and times out, so the switch never fires.
+            forceCreate: true,
           })
           .catch(() => null);
         const dedicatedAgentId =


### PR DESCRIPTION
Stacked on #9846 (PR4).

Fix a load-bearing bug the e2e (PR6) surfaced: **the create-both flow couldn't actually create a SEPARATE dedicated agent.** `POST /api/v1/eliza/agents` hardcoded `reuseExistingNonTerminal: true`, so the 2nd create (the dedicated) returned the existing shared agent → `dedicatedAgentId === sharedAgentId` → the handoff readiness probe polled the shared (which, being container-free, never grows a dedicated base) → timed out → **no switch**. The handoff never actually fired in prod — the unit tests mock the create, so only the real-route e2e caught it.

## Fix
- **Server** (`route.ts`): add `forceCreate` to the create schema; `reuseExistingNonTerminal: parsed.data.forceCreate ? false : true` — **default unchanged** (every existing caller keeps reuse).
- **Client** (`client-cloud.ts` + `use-first-run-controller.ts`): thread `forceCreate` into `createCloudCompatAgent`; the create-both dedicated-create passes `forceCreate: true` so it mints a separate dedicated.

## Safety + tests
Default (no-forceCreate) path **byte-identical**; reuse intact for all 3 other `createAgent` callers (untouched). `forceCreate` is opt-in + the client change sits inside the flag-gated (`preferSharedCloudTier`) handoff branch. **84 tests** across route/client/controller, incl. explicit `forceCreate:false`→reuse and the `dedicated !== shared` invariant. Passed /clean + /review (PASS, push as-is).

## Follow-up (noted, out of scope)
`selectOrProvisionCloudAgent` skips the client reuse lookup but doesn't forward `forceCreate` to the backend, so the picker's "Create new" can still silently reuse — separate fix.
