### PR TITLE
fix(orchestrator): sub-agent build relay — single ack + don't drop deliverable on stopReason error

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -382,6 +382,37 @@ describe("emitProgress routing ladder + cadence", () => {
     await rt.dispose();
   });
 
+  it("ack mode does NOT re-ack a verify-retry re-dispatch, even past the room dedup window", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    // The original user-requested session acks exactly once.
+    seedSession(rt, "s-orig", "build-site");
+    await fire(rt, "s-orig", "ready");
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    // SubAgentRouter.retryIncompleteBuild re-dispatches a failed build under a
+    // FRESH sessionId minutes later, tagging it `buildVerifyRetryCount > 0`. By
+    // then the per-room ack dedup window (ACK_ROOM_DEDUP_MS, 60s) has expired, so
+    // without the buildVerifyRetryCount guard the retry posts another
+    // "working on it now." — the triple-ack users reported. Advance well past the
+    // dedup window so this asserts the guard, not the room-dedup.
+    await vi.advanceTimersByTimeAsync(120_000);
+    rt.sessions.set("s-retry", {
+      status: "running",
+      metadata: {
+        source: SOURCE,
+        roomId: ROOM,
+        label: "build-site",
+        buildVerifyRetryCount: 1,
+      },
+    });
+    await fire(rt, "s-retry", "ready");
+    // Still exactly ONE ack for the whole user request.
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    await rt.dispose();
+  });
+
   it("threaded mode creates exactly one thread per label and routes narration into it", async () => {
     process.env.ACPX_PROGRESS_MODE = "threaded";
     process.env.ACPX_PROGRESS_DELAY_MS = "0";

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -1574,9 +1574,21 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // on every backend (codex/opencode/claude). emitProgress ignores the
         // empty rawText for the ack first-post and the firstPostInFlight +
         // mainMessageId guards keep it to exactly one ack.
+        // A verification-retry re-dispatch (buildVerifyRetryCount > 0, set by
+        // SubAgentRouter.retryIncompleteBuild) is an INTERNAL continuation of the
+        // same user request, spawned under a fresh sessionId minutes later. The
+        // per-session ackedSessions/firstPostInFlight guards never see it, and the
+        // per-room ack dedup window (60s) has long expired — so without this gate
+        // each retry posts another "working on it now." (the triple-ack users
+        // reported). The original user-requested session has no
+        // buildVerifyRetryCount, so it still acks exactly once.
+        const isVerifyRetrySpawn =
+          typeof meta.buildVerifyRetryCount === "number" &&
+          meta.buildVerifyRetryCount > 0;
         if (
           progressPolicy.mode === "ack" &&
           !ackedSessions.has(sessionId) &&
+          !isVerifyRetrySpawn &&
           evName !== "task_complete" &&
           evName !== "turn_complete" &&
           evName !== "stopped" &&

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1321,7 +1321,7 @@ export class AcpService extends Service {
         durationMs: Date.now() - startedAt,
         exitCode: 0,
         signal: null,
-        ...(finalStopReason === "error"
+        ...(finalStopReason === "error" && !(finalText && finalText.trim())
           ? { error: "ACP prompt ended with stopReason error" }
           : {}),
       };
@@ -1329,7 +1329,14 @@ export class AcpService extends Service {
         await this.store.updateStatus(session.id, "stopped");
       } else if (cancelled) {
         await this.store.updateStatus(session.id, "cancelled");
-      } else if (finalStopReason === "error") {
+      } else if (
+        finalStopReason === "error" &&
+        !(finalText && finalText.trim())
+      ) {
+        // Mirror the handleAcpEvent guard: a stopReason-error session that still
+        // captured a real deliverable is relayed as a completion, so don't mark
+        // it errored in the durable store — that would show a false-failed task
+        // in history/providers while the user actually got the result.
         await this.store.updateStatus(
           session.id,
           "errored",
@@ -1959,7 +1966,16 @@ export class AcpService extends Service {
         // that hit token limits, ran out of turns, or stopped for any
         // other non-error reason — the sub-agent did real work (commits,
         // edits, deploys) and the user got nothing back.
-        if (stopReason === "error") {
+        // A terminal stopReason of `error` does NOT mean the work was lost: the
+        // sub-agent often wrote files, deployed, and printed a verified result
+        // before its LAST step errored (a flaky post-build verify, a lint exit,
+        // a model glitch). When real output was captured, relay it as a
+        // completion so the normal task_complete path (URL verification,
+        // deliverable capture, changeset narration) runs and can still downgrade
+        // to a failure if the claimed URLs are dead. Only a stopReason error with
+        // NO captured output is a true, user-facing failure — otherwise the user
+        // gets a false "hit a snag" for a build that actually succeeded.
+        if (stopReason === "error" && !(finalText && finalText.trim())) {
           this.emitSessionEvent(sessionId, "error", {
             message: "acpx prompt ended with stopReason error",
             stopReason,


### PR DESCRIPTION
Two fixes to the coding sub-agent build-relay path (native ACP transport), from a live incident where 'make a website' triple-posted 'working on it now.' then falsely said 'hit a snag' on a build that actually succeeded + published.

**1. Single spawn-ack.** A build that fails URL verification is re-dispatched by `retryIncompleteBuild` under a fresh sessionId tagged `buildVerifyRetryCount>0`; the per-session ack guards don't see the new id and the 60s per-room dedup has expired, so each retry re-posted "working on it now." Gate the spawn ack on the existing `buildVerifyRetryCount` marker; the original user session has no marker and still acks once. Adds a test asserting this past the dedup window.

**2. Don't drop the deliverable when the final stopReason is `error`.** A sub-agent often writes files / deploys / prints a verified result before its LAST step errors. The native transport discarded `finalText` and emitted a bare error, so a build that actually succeeded relayed a false failure. Route to `task_complete` when real output was captured (the dead-URL verify path still downgrades a genuinely broken build); mirror the guard on the durable status.

Testing: typecheck clean, plugin build clean, 1100 existing orchestrator tests pass + a new verify-retry ack test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>