### PR TITLE
test(handoff): e2e the success switch — mock import store + provision-to-running (PR6)

### DIFF
--- a/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
+++ b/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
@@ -222,10 +222,13 @@ async function main() {
   // that web_ui_url over the agent's `bridge_url`. There is no Worker-fronted
   // `*.elizacloud.ai` ingress in the local mock stack, so that subdomain is
   // unreachable — the dedicated agent's reachable base IS its `bridge_url` (the
-  // control-plane mock). A base domain that normalizes to empty makes
-  // `getElizaAgentPublicWebUiUrl` return null, so the reachable bridge wins and
-  // the shared→dedicated handoff import can complete. The apps domain
-  // (`CONTAINERS_PUBLIC_BASE_DOMAIN`) is a separate knob and is left untouched.
+  // control-plane mock). The detail route feeds `containersEnv.publicBaseDomain()`
+  // into `getElizaAgentPublicWebUiUrl` as the EXPLICIT `{baseDomain}` option; a
+  // value that normalizes to empty makes that explicit-option path return null, so
+  // the reachable bridge wins and the shared→dedicated handoff import can complete.
+  // (The compat-envelope no-option path keeps its default and is intentionally not
+  // neutralized.) The apps domain (`CONTAINERS_PUBLIC_BASE_DOMAIN`) is a separate
+  // knob and is left untouched.
   const agentBaseDomainOverride =
     process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN ?? "https://";
   const testModeVars = isE2eTestMode

--- a/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
+++ b/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
@@ -216,6 +216,18 @@ async function main() {
   // domain buy/check routes never hit the real Cloudflare API (overridable via
   // ELIZA_CF_REGISTRAR_DEV_STUB).
   const registrarStub = process.env.ELIZA_CF_REGISTRAR_DEV_STUB ?? "1";
+  // In e2e/test mode, neutralize the dedicated-agent public subdomain. The agent
+  // detail route synthesizes `web_ui_url = https://<id>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>`
+  // (wrangler.toml pins `elizacloud.ai`), and the client's readiness probe prefers
+  // that web_ui_url over the agent's `bridge_url`. There is no Worker-fronted
+  // `*.elizacloud.ai` ingress in the local mock stack, so that subdomain is
+  // unreachable — the dedicated agent's reachable base IS its `bridge_url` (the
+  // control-plane mock). A base domain that normalizes to empty makes
+  // `getElizaAgentPublicWebUiUrl` return null, so the reachable bridge wins and
+  // the shared→dedicated handoff import can complete. The apps domain
+  // (`CONTAINERS_PUBLIC_BASE_DOMAIN`) is a separate knob and is left untouched.
+  const agentBaseDomainOverride =
+    process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN ?? "https://";
   const testModeVars = isE2eTestMode
     ? [
         "--var",
@@ -224,6 +236,8 @@ async function main() {
         "ELIZA_KMS_BACKEND:memory",
         "--var",
         `ELIZA_CF_REGISTRAR_DEV_STUB:${registrarStub}`,
+        "--var",
+        `ELIZA_CLOUD_AGENT_BASE_DOMAIN:${agentBaseDomainOverride}`,
       ]
     : [];
   const appDeployDevVars = [

--- a/packages/test/cloud-e2e/tests/app-client-handoff-success.spec.ts
+++ b/packages/test/cloud-e2e/tests/app-client-handoff-success.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * App onboarding handoff — the SUCCESS switch, end to end.
+ *
+ * `app-client-onboarding.spec.ts` covers the NEGATIVE handoff contract: with no
+ * reachable dedicated container the orchestrator degrades gracefully (times out,
+ * never switches, user stays on the shared adapter). This spec closes the other
+ * half — the case the whole seamless-provision feature exists for: a real
+ * shared→dedicated SWITCH, with the transcript the user built on the shared
+ * agent copied into their freshly provisioned dedicated container.
+ *
+ * It runs the *real* `ElizaClient.startCloudAgentHandoff` against the *real*
+ * cloud-api router, with the dedicated agent provisioned-to-running through the
+ * mock control-plane (so it advertises a reachable base), and a real transcript
+ * seeded on the shared agent via the context-echo mock LLM. The previously
+ * missing fixtures (the dedicated agent's `/api/conversations/:id/import` +
+ * `/messages` routes, the conversation store) now live on the control-plane mock.
+ *
+ * Asserted:
+ *   - the handoff reaches `switched` (NOT `timed-out`),
+ *   - `onSwitch` fired with the dedicated container base (not the shared adapter),
+ *   - every shared turn was imported into the dedicated agent (`imported > 0`),
+ *   - the conversation id is stable across the switch,
+ *   - the dedicated agent's stored transcript matches what the user had, and
+ *   - re-running the handoff is idempotent (no duplicate import — `switched`
+ *     again, nothing re-inserted).
+ */
+
+import { ElizaClient } from "@elizaos/ui/api";
+import { getBootConfig, setBootConfig } from "@elizaos/ui/config";
+import { authedClient } from "../src/helpers/monetization";
+import {
+  pollSandboxStatus,
+  startAgentProvisioning,
+} from "../src/helpers/provisioning";
+import { seedModelPricing } from "../src/helpers/seed-pricing";
+import { expect, test } from "../src/helpers/test-fixtures";
+
+const CLOUD_TOKEN_GLOBAL = "__ELIZA_CLOUD_AUTH_TOKEN__";
+
+// Context-echo mock LLM so the shared turns produce a deterministic, real
+// transcript (reply derived from replayed history) — there must be something to
+// copy, otherwise the handoff only ever reaches `switched-empty`. API-only: no
+// browser is driven here, we exercise the client methods directly.
+test.use({ stackOptions: { frontend: false, mockLlmEchoContext: true } });
+
+const MODEL = "openai/gpt-4o-mini";
+
+test.describe("app onboarding handoff — success switch", () => {
+  test("provisions a dedicated agent, copies the shared transcript, and switches the client onto it", async ({
+    stack,
+    seededUser,
+  }) => {
+    const cloudApiBase = stack.urls.api;
+    const authToken = seededUser.apiKey;
+    const api = { apiUrl: cloudApiBase };
+    const c = authedClient(cloudApiBase, authToken);
+
+    const prevBoot = getBootConfig();
+    const prevToken = (globalThis as Record<string, unknown>)[
+      CLOUD_TOKEN_GLOBAL
+    ];
+    setBootConfig({ ...prevBoot, cloudApiBase });
+    (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = authToken;
+
+    // Price the shared turn's model so the in-Worker billing path can settle a
+    // real debit (no live BitRouter key). `openai/<model>` resolves billingSource
+    // `openai`→`bitrouter`; seed the `bitrouter` source the lookup short-circuits
+    // on. Without this the shared turn 500s before any transcript exists to copy.
+    await seedModelPricing({
+      model: MODEL,
+      billingSource: "bitrouter",
+      provider: "openai",
+    });
+
+    try {
+      const client = new ElizaClient(cloudApiBase, authToken);
+
+      // ── 1. The instant SHARED agent the user chats on. ───────────────────
+      // A plain chat agent (openai/<model> character) is a Tier-0 shared
+      // runtime — the container-free bridge that is always-available from turn 0.
+      const sharedCreate = await c<{
+        data?: { id?: string; agentId?: string; executionTier?: string };
+      }>("POST", "/api/v1/eliza/agents", {
+        agentName: `Shared Front ${Date.now().toString(36)}`,
+        agentConfig: {
+          character: {
+            name: "Front",
+            system: "You are the instant shared front agent.",
+            model: MODEL,
+          },
+        },
+      });
+      expect([200, 201]).toContain(sharedCreate.status);
+      const sharedAgentId =
+        sharedCreate.json.data?.id ?? sharedCreate.json.data?.agentId;
+      expect(sharedAgentId, "shared agent has an id").toBeTruthy();
+      if (!sharedAgentId) throw new Error("no shared agent id");
+      expect(
+        sharedCreate.json.data?.executionTier,
+        "the instant front is a shared-tier agent",
+      ).toBe("shared");
+
+      // Seed a REAL transcript on the shared agent (canonical conversation id ===
+      // agent id, the REST adapter's launch model). Two turns → four messages.
+      const convoUrl = `/api/v1/eliza/agents/${sharedAgentId}/api/conversations/${sharedAgentId}/messages`;
+      const FIRST = "Remember: my project is codenamed Aurora.";
+      const SECOND = "What is my project codenamed?";
+      const t1 = await c<{ text?: string }>("POST", convoUrl, { text: FIRST });
+      expect(t1.status, "first shared turn accepted").toBe(200);
+      const t2 = await c<{ text?: string }>("POST", convoUrl, { text: SECOND });
+      expect(t2.status, "second shared turn accepted").toBe(200);
+
+      const sharedHistory = await c<{
+        messages?: Array<{ role: string; text: string }>;
+      }>("GET", convoUrl);
+      expect(
+        sharedHistory.json.messages?.length,
+        "shared transcript has both turns (user+assistant ×2)",
+      ).toBe(4);
+
+      // ── 2. The SEPARATE dedicated agent, provisioned to running. ──────────
+      // The handoff target is a distinct `agent_sandboxes` row (the plan's model:
+      // a fresh dedicated alongside the shared, NOT an in-place tier re-key). The
+      // compat `POST /agents` create reuses the org's single non-terminal agent
+      // (one-agent-per-org guard), so insert the dedicated row directly — the same
+      // org so the user's token authorizes it — then drive its provision job
+      // through the mock control-plane until it's `running` with a reachable
+      // bridge base. That is what makes the already-wired handoff reachable.
+      const { agentSandboxesRepository } =
+        await import("@elizaos/cloud-shared/db/repositories/agent-sandboxes");
+      const dedicatedRow = await agentSandboxesRepository.create({
+        organization_id: seededUser.organizationId,
+        user_id: seededUser.userId,
+        agent_name: `Dedicated ${Date.now().toString(36)}`,
+        agent_config: {},
+        environment_vars: {},
+        status: "pending",
+        execution_tier: "dedicated-always",
+        database_status: "none",
+      });
+      const dedicatedSandboxId = dedicatedRow.id;
+      expect(
+        dedicatedSandboxId,
+        "dedicated agent is a separate record",
+      ).not.toBe(sharedAgentId);
+      await startAgentProvisioning(api, authToken, dedicatedSandboxId);
+      await pollSandboxStatus(api, authToken, dedicatedSandboxId, "running", {
+        timeoutMs: 30_000,
+        intervalMs: 250,
+        onTick: async () => {
+          const result = await stack.mocks.controlPlane.processDbBackedJobs(
+            stack.urls.pglite,
+          );
+          expect(result.failed, JSON.stringify(result.errors)).toBe(0);
+        },
+      });
+
+      // ── 3. Run the handoff: shared front → dedicated container. ───────────
+      const sharedApiBase = `${cloudApiBase.replace(/\/+$/, "")}/api/v1/eliza/agents/${sharedAgentId}`;
+      let switchedBase: string | null = null;
+      const handoff = await client.startCloudAgentHandoff({
+        agentId: sharedAgentId,
+        dedicatedAgentId: dedicatedSandboxId,
+        sharedApiBase,
+        conversationId: sharedAgentId,
+        cloudApiBase,
+        authToken,
+        onSwitch: (base: string) => {
+          switchedBase = base;
+        },
+        intervalMs: 200,
+        timeoutMs: 20_000,
+        log: (m) => console.log(`[handoff] ${m}`),
+      });
+
+      // ── 4. The success contract. ──────────────────────────────────────────
+      expect(
+        handoff.status,
+        `the handoff SWITCHED (did not time out): ${handoff.error ?? ""}`,
+      ).toBe("switched");
+      expect(
+        handoff.imported,
+        "every shared turn was imported into the dedicated agent",
+      ).toBe(4);
+      expect(
+        switchedBase,
+        "the client switched onto the dedicated container base",
+      ).toBeTruthy();
+      // Never switch onto the shared REST adapter — the migration target is the
+      // dedicated bridge.
+      expect(
+        switchedBase,
+        "switched onto the dedicated base, not the shared adapter",
+      ).not.toBe(sharedApiBase);
+      expect(
+        /\/api\/compat\/agents\//.test(switchedBase ?? ""),
+        `switched base is the dedicated container base (${switchedBase})`,
+      ).toBe(true);
+
+      // The dedicated agent actually received the transcript, in order, with the
+      // conversation id preserved across the switch.
+      const dedicatedTranscript =
+        stack.mocks.controlPlane.store.getConversationByAgent(
+          dedicatedSandboxId,
+          sharedAgentId,
+        );
+      expect(
+        dedicatedTranscript.map((m) => m.role),
+        "imported transcript preserves the user/assistant ordering",
+      ).toEqual(["user", "assistant", "user", "assistant"]);
+      expect(
+        dedicatedTranscript[0]?.text,
+        "the user's first message survived the copy",
+      ).toBe(FIRST);
+      expect(
+        dedicatedTranscript[2]?.text,
+        "the user's second message survived the copy",
+      ).toBe(SECOND);
+
+      // ── 5. Idempotency: re-running the handoff must not double-import. ─────
+      switchedBase = null;
+      const replay = await client.startCloudAgentHandoff({
+        agentId: sharedAgentId,
+        dedicatedAgentId: dedicatedSandboxId,
+        sharedApiBase,
+        conversationId: sharedAgentId,
+        cloudApiBase,
+        authToken,
+        onSwitch: (base: string) => {
+          switchedBase = base;
+        },
+        intervalMs: 200,
+        timeoutMs: 20_000,
+      });
+      expect(replay.status, "re-run still resolves to a switch").toBe(
+        "switched",
+      );
+      expect(
+        replay.imported,
+        "re-run inserts nothing (the import is idempotent per conversation)",
+      ).toBe(0);
+      expect(
+        stack.mocks.controlPlane.store.getConversationByAgent(
+          dedicatedSandboxId,
+          sharedAgentId,
+        ).length,
+        "the dedicated transcript is unchanged after the idempotent re-run",
+      ).toBe(4);
+    } finally {
+      setBootConfig(prevBoot);
+      if (prevToken === undefined) {
+        delete (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL];
+      } else {
+        (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = prevToken;
+      }
+    }
+  });
+});

--- a/packages/test/cloud-mocks/src/control-plane/server.ts
+++ b/packages/test/cloud-mocks/src/control-plane/server.ts
@@ -1,6 +1,11 @@
 import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { ControlPlaneStore, type Job, type Sandbox } from "./store";
+import {
+  ControlPlaneStore,
+  type ImportedMessage,
+  type Job,
+  type Sandbox,
+} from "./store";
 
 type DatabaseJob = {
   id: string;
@@ -1201,6 +1206,79 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
       },
     });
   });
+
+  // ── Dedicated-agent conversation surface (handoff import target) ───────
+  // A provisioned dedicated agent advertises its base as
+  // `<origin>/api/compat/agents/<sandboxId>`; the shared→personal handoff then
+  // POSTs the copied transcript to `<base>/api/conversations/:convId/import`
+  // and (after switching) reads it back at `<base>/api/conversations/:convId/
+  // messages`. These mock the agent-side primitives — a silent, idempotent
+  // bulk-insert with no inference (mirrors agent/src/api/conversation-routes.ts)
+  // — so the success handoff is reachable + assertable in e2e.
+  const normalizeImportMessages = (raw: unknown): ImportedMessage[] => {
+    if (!Array.isArray(raw)) return [];
+    const out: ImportedMessage[] = [];
+    for (const entry of raw) {
+      if (!entry || typeof entry !== "object") continue;
+      const rec = entry as Record<string, unknown>;
+      const role =
+        rec.role === "assistant"
+          ? "assistant"
+          : rec.role === "user"
+            ? "user"
+            : null;
+      const rawText =
+        typeof rec.text === "string"
+          ? rec.text
+          : typeof rec.content === "string"
+            ? rec.content
+            : "";
+      const text = rawText.trim();
+      if (!role || !text) continue;
+      out.push({
+        role,
+        text,
+        ...(typeof rec.timestamp === "number" && Number.isFinite(rec.timestamp)
+          ? { timestamp: rec.timestamp }
+          : {}),
+      });
+    }
+    return out;
+  };
+
+  app.post(
+    "/api/compat/agents/:id/api/conversations/:convId/import",
+    async (c) => {
+      await latency();
+      const sandboxId = c.req.param("id");
+      const conversationId = decodeURIComponent(c.req.param("convId"));
+      const body = (await c.req.json().catch(() => null)) as Record<
+        string,
+        unknown
+      > | null;
+      if (!body || !Array.isArray(body.messages)) {
+        return c.json({ error: "Body must include a `messages` array" }, 400);
+      }
+      const messages = normalizeImportMessages(body.messages);
+      const result = store.importConversation(
+        sandboxId,
+        conversationId,
+        messages,
+      );
+      return c.json(result);
+    },
+  );
+
+  app.get(
+    "/api/compat/agents/:id/api/conversations/:convId/messages",
+    async (c) => {
+      await latency();
+      const sandboxId = c.req.param("id");
+      const conversationId = decodeURIComponent(c.req.param("convId"));
+      const messages = store.getConversation(sandboxId, conversationId);
+      return c.json({ messages });
+    },
+  );
 
   async function hetznerFetch(
     path: string,

--- a/packages/test/cloud-mocks/src/control-plane/store.ts
+++ b/packages/test/cloud-mocks/src/control-plane/store.ts
@@ -51,12 +51,7 @@ export interface Job {
 }
 
 export type ContainerStatus =
-  | "pending"
-  | "running"
-  | "restarting"
-  | "deleting"
-  | "deleted"
-  | "error";
+  "pending" | "running" | "restarting" | "deleting" | "deleted" | "error";
 
 export interface Container {
   id: string;
@@ -101,12 +96,33 @@ export interface WarmPoolState {
   totalSandboxes: number;
 }
 
+/** A single message imported into a dedicated agent's conversation. */
+export interface ImportedMessage {
+  role: "user" | "assistant";
+  text: string;
+  timestamp?: number;
+}
+
+/** Outcome of importing a transcript into a dedicated agent's conversation. */
+export interface ConversationImportResult {
+  conversationId: string;
+  inserted: number;
+  skipped: number;
+  alreadyPopulated: boolean;
+}
+
 export class ControlPlaneStore {
   private readonly jobs = new Map<string, Job>();
   private readonly sandboxes = new Map<string, Sandbox>();
   private readonly containers = new Map<string, Container>();
   private readonly warmPool = new Map<string, WarmSandbox>();
   private readonly cronCounters = new Map<string, number>();
+  /**
+   * Per-(sandbox,conversation) message store backing the dedicated-agent
+   * conversation import/read routes — the mock stand-in for a real container's
+   * PGlite memories. Keyed `${sandboxId}::${conversationId}`.
+   */
+  private readonly conversations = new Map<string, ImportedMessage[]>();
   private hotPoolTarget = 0;
   private warmPoolState: WarmPoolState = {
     enabled: true,
@@ -292,6 +308,68 @@ export class ControlPlaneStore {
     const next: Sandbox = { ...existing, ...patch, id, updatedAt: this.now() };
     this.sandboxes.set(id, next);
     return next;
+  }
+
+  // ── Dedicated-agent conversation store (handoff import target) ─────────
+  private convKey(sandboxId: string, conversationId: string): string {
+    return `${sandboxId}::${conversationId}`;
+  }
+
+  /**
+   * Silently bulk-insert a transcript into a dedicated agent's conversation —
+   * the mock counterpart of the agent's `POST /api/conversations/:id/import`
+   * (no inference). Idempotent per conversation: importing into an already
+   * populated conversation inserts nothing and reports `alreadyPopulated`,
+   * matching the real skip-all behaviour.
+   */
+  importConversation(
+    sandboxId: string,
+    conversationId: string,
+    messages: ImportedMessage[],
+  ): ConversationImportResult {
+    const key = this.convKey(sandboxId, conversationId);
+    const existing = this.conversations.get(key);
+    if (existing && existing.length > 0) {
+      return {
+        conversationId,
+        inserted: 0,
+        skipped: messages.length,
+        alreadyPopulated: true,
+      };
+    }
+    this.conversations.set(key, [...messages]);
+    return {
+      conversationId,
+      inserted: messages.length,
+      skipped: 0,
+      alreadyPopulated: false,
+    };
+  }
+
+  /** Read back a dedicated agent's imported conversation transcript. */
+  getConversation(
+    sandboxId: string,
+    conversationId: string,
+  ): ImportedMessage[] {
+    return (
+      this.conversations.get(this.convKey(sandboxId, conversationId)) ?? []
+    );
+  }
+
+  /**
+   * Read back an imported transcript by the cloud `agentId` rather than the
+   * internal sandbox id (the import routes key on the sandbox id from the
+   * advertised bridge_url; callers that only know the agent id use this).
+   */
+  getConversationByAgent(
+    agentId: string,
+    conversationId: string,
+  ): ImportedMessage[] {
+    const sandbox = [...this.sandboxes.values()].find(
+      (s) => s.agentId === agentId,
+    );
+    if (!sandbox) return [];
+    return this.getConversation(sandbox.id, conversationId);
   }
 
   createJob(input: {

--- a/packages/test/cloud-mocks/src/control-plane/store.ts
+++ b/packages/test/cloud-mocks/src/control-plane/store.ts
@@ -51,7 +51,12 @@ export interface Job {
 }
 
 export type ContainerStatus =
-  "pending" | "running" | "restarting" | "deleting" | "deleted" | "error";
+  | "pending"
+  | "running"
+  | "restarting"
+  | "deleting"
+  | "deleted"
+  | "error";
 
 export interface Container {
   id: string;
@@ -103,12 +108,16 @@ export interface ImportedMessage {
   timestamp?: number;
 }
 
-/** Outcome of importing a transcript into a dedicated agent's conversation. */
+/**
+ * Outcome of importing a transcript into a dedicated agent's conversation.
+ * Byte-matches the real agent route's `POST /api/conversations/:id/import`:
+ * `alreadyPopulated` is present (and `true`) only on the idempotent skip path.
+ */
 export interface ConversationImportResult {
   conversationId: string;
   inserted: number;
   skipped: number;
-  alreadyPopulated: boolean;
+  alreadyPopulated?: boolean;
 }
 
 export class ControlPlaneStore {
@@ -342,7 +351,6 @@ export class ControlPlaneStore {
       conversationId,
       inserted: messages.length,
       skipped: 0,
-      alreadyPopulated: false,
     };
   }
 


### PR DESCRIPTION
Stacked on #9846 (PR4).

PR6 of the seamless-provision handoff — the **e2e**: make the SUCCESS handoff reachable + asserted in the cloud e2e harness. Previously the handoff e2e was unreachable (the mock control-plane served no `/conversations/import` route, and the existing spec asserted the handoff does NOT happen).

## How
- **cloud-mocks control-plane** (`server.ts` + `store.ts`): add a mock `/conversations/import|messages` store with idempotent skip-all import (mirrors the real agent route `conversation-routes.ts:1623`).
- **New `app-client-handoff-success.spec.ts`**: creates a shared front, seeds a 4-message transcript, provisions a separate dedicated to `running`, runs the **real** `startCloudAgentHandoff`, and asserts the success contract — `status==="switched"`, `imported===4`, `onSwitch` fired with the dedicated base, transcript copied in order, conversation id stable, + idempotent replay (re-run inserts 0).
- **`cloud-api-dev.mjs`**: an **e2e-scoped** `ELIZA_CLOUD_AGENT_BASE_DOMAIN` override nulling the unreachable dedicated subdomain so the reachable `bridge_url` wins in the local mock stack (gated by `isE2eTestMode`, no prod leak).

## What this e2e CAUGHT
It surfaced a **load-bearing prod bug** the unit tests (which mock the create) couldn't: `POST /agents` hardcoded `reuseExistingNonTerminal: true`, so create-both's 2nd create returned the shared instead of a separate dedicated → the handoff never actually fired in prod. **Fixed in #9854** (forceCreate). This is exactly why the e2e earns its keep.

## Tests
Ran green: `app-client-handoff-success` → `1 passed`, "imported 4/4 message(s)". Passed /clean + /review (PASS).

## Follow-up
With #9854 (forceCreate) landed, this spec can be updated to drive the **real** create-both path (instead of inserting the dedicated row directly) — proving the full prod path e2e.
