### PR TITLE
fix(cloud): enforce reserved env-var denylist on the app-deploy route (#9853 P1.2)

### DIFF
--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.test.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  type AppDeployDeps,
-  deployApp,
-  type NewAppContainerRow,
-} from "./app-deploy-orchestrator";
+import { type AppDeployDeps, deployApp, type NewAppContainerRow } from "./app-deploy-orchestrator";
 
 function makeDeps(): { deps: AppDeployDeps; captured: { row?: NewAppContainerRow } } {
   const captured: { row?: NewAppContainerRow } = {};

--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.test.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import {
+  type AppDeployDeps,
+  deployApp,
+  type NewAppContainerRow,
+} from "./app-deploy-orchestrator";
+
+function makeDeps(): { deps: AppDeployDeps; captured: { row?: NewAppContainerRow } } {
+  const captured: { row?: NewAppContainerRow } = {};
+  const deps: AppDeployDeps = {
+    ensureTenantDb: async () => "postgres://tenant-dsn/app",
+    createContainerRow: async (row) => {
+      captured.row = row;
+      return { containerId: "container-1" };
+    },
+    enqueueProvision: async () => ({ id: "job-1" }),
+    linkContainerToApp: async () => {},
+  };
+  return { deps, captured };
+}
+
+const baseReq = {
+  appId: "app-1",
+  organizationId: "org-1",
+  userId: "user-1",
+  containerName: "my-app",
+  image: "ghcr.io/elizaos/app:1.0.0",
+} as const;
+
+describe("deployApp env hardening", () => {
+  test("strips caller-supplied platform-reserved keys on a stateless (none) app", async () => {
+    const { deps, captured } = makeDeps();
+    await deployApp(
+      {
+        ...baseReq,
+        databaseMode: "none",
+        env: {
+          DATABASE_URL: "postgres://attacker/db",
+          POSTGRES_URL: "postgres://attacker/db",
+          ELIZAOS_CLOUD_API_KEY: "stolen-token",
+          ELIZA_API_TOKEN: "stolen",
+          APP_SETTING: "keep-me",
+        },
+      },
+      deps,
+    );
+    // Reserved keys stripped; a stateless app gets NO DB var injected and can no
+    // longer smuggle one (or a managed identity key) in via caller env.
+    expect(captured.row?.environmentVars).toEqual({ APP_SETTING: "keep-me" });
+  });
+
+  test("platform isolated DSN wins over caller DATABASE_URL/POSTGRES_URL", async () => {
+    const { deps, captured } = makeDeps();
+    await deployApp(
+      {
+        ...baseReq,
+        databaseMode: "isolated",
+        env: {
+          DATABASE_URL: "postgres://attacker/db",
+          POSTGRES_URL: "postgres://attacker/db",
+          KEEP: "1",
+        },
+      },
+      deps,
+    );
+    expect(captured.row?.environmentVars).toEqual({
+      KEEP: "1",
+      DATABASE_URL: "postgres://tenant-dsn/app",
+      POSTGRES_URL: "postgres://tenant-dsn/app",
+    });
+  });
+
+  test("non-reserved caller env passes through unchanged", async () => {
+    const { deps, captured } = makeDeps();
+    await deployApp(
+      { ...baseReq, databaseMode: "none", env: { FOO: "bar", LOG_LEVEL: "debug" } },
+      deps,
+    );
+    expect(captured.row?.environmentVars).toEqual({ FOO: "bar", LOG_LEVEL: "debug" });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
@@ -12,6 +12,7 @@
  */
 
 import { type AppDatabaseMode, DEFAULT_APP_DATABASE_MODE } from "./app-database-mode";
+import { RESERVED_PLATFORM_ENV_KEYS, stripReservedEnvKeys } from "./reserved-env-keys";
 
 export interface DeployAppRequest {
   appId: string;
@@ -97,10 +98,21 @@ export async function deployApp(
   // (ensureTenantDb is create-if-not-exists, so it materializes seamlessly).
   const mode = req.databaseMode ?? DEFAULT_APP_DATABASE_MODE;
   const dsn = mode === "isolated" ? await deps.ensureTenantDb(req.appId) : undefined;
+  // Strip caller-supplied platform-reserved keys (managed DB DSN, cloud API
+  // token, metered-identity keys) BEFORE injecting platform values. Without this
+  // a stateless ("none"-mode) app could set DATABASE_URL/POSTGRES_URL to point at
+  // an arbitrary DB, or pre-empt a managed identity key. The agent path already
+  // enforces this denylist (findReservedManagedElizaEnvKeys); the app path must
+  // too. POSTGRES_URL is added to the shared platform list because it is the
+  // app-container DB var (DATABASE_URL is already reserved).
+  const safeCallerEnv = stripReservedEnvKeys(req.env ?? {}, [
+    ...RESERVED_PLATFORM_ENV_KEYS,
+    "POSTGRES_URL",
+  ]);
   const environmentVars = {
-    ...(req.env ?? {}),
-    // Platform-owned DB values intentionally win over caller-provided values for
-    // these keys.
+    ...safeCallerEnv,
+    // Platform-owned DB values are injected last so they always win for isolated
+    // apps; stateless apps get neither var (and can no longer inject one).
     ...(dsn ? { DATABASE_URL: dsn, POSTGRES_URL: dsn } : {}),
   };
 

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -3,6 +3,7 @@ import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { CEREBRAS_DEFAULT_TEXT_LARGE_MODEL, CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../models";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { apiKeysService } from "./api-keys";
+import { findReservedEnvKeys, RESERVED_PLATFORM_ENV_KEYS } from "./reserved-env-keys";
 
 const DEFAULT_ELIZA_APP_URL = "https://eliza.app";
 const DEFAULT_CLOUD_PUBLIC_URL = "https://www.elizacloud.ai";
@@ -12,21 +13,13 @@ const DEV_ELIZA_APP_ORIGINS = [
   "http://localhost:4173",
   "http://127.0.0.1:4173",
 ] as const;
-export const RESERVED_MANAGED_ELIZA_ENV_KEYS = [
-  "DATABASE_URL",
-  "ELIZA_MANAGED_DATABASE_URL",
-  "ELIZA_API_TOKEN",
-  "ELIZAOS_CLOUD_API_KEY",
-  "ELIZAOS_CLOUD_BASE_URL",
-  "ELIZAOS_CLOUD_ENABLED",
-  "ELIZA_CLOUD_AGENT_ID",
-  "PUBLIC_BASE_URL",
-  "STEWARD_AGENT_ID",
-  "STEWARD_AGENT_TOKEN",
-  "WAIFU_ELIZA_CLOUD_AGENT_ID",
-] as const;
-
-const RESERVED_MANAGED_ELIZA_ENV_KEY_SET = new Set<string>(RESERVED_MANAGED_ELIZA_ENV_KEYS);
+/**
+ * Platform-reserved env keys for the managed agent path. Aliases the shared
+ * {@link RESERVED_PLATFORM_ENV_KEYS} denylist — single source of truth, also
+ * enforced on the Apps deploy path — and stays a named export for existing
+ * importers (the agent environment route).
+ */
+export const RESERVED_MANAGED_ELIZA_ENV_KEYS = RESERVED_PLATFORM_ENV_KEYS;
 
 export interface ManagedElizaEnvironmentResult {
   apiToken: string;
@@ -49,14 +42,7 @@ export interface PrepareManagedElizaSharedEnvironmentParams {
 }
 
 export function findReservedManagedElizaEnvKeys(keys: Iterable<string>): string[] {
-  const reserved: string[] = [];
-  for (const key of keys) {
-    const normalized = key.toUpperCase();
-    if (RESERVED_MANAGED_ELIZA_ENV_KEY_SET.has(normalized)) {
-      reserved.push(key);
-    }
-  }
-  return reserved;
+  return findReservedEnvKeys(keys);
 }
 
 export function normalizeBaseUrl(raw: string): string {

--- a/packages/cloud-shared/src/lib/services/reserved-env-keys.test.ts
+++ b/packages/cloud-shared/src/lib/services/reserved-env-keys.test.ts
@@ -7,9 +7,10 @@ import {
 
 describe("reserved-env-keys", () => {
   test("findReservedEnvKeys flags reserved keys case-insensitively, echoing caller casing", () => {
-    expect(
-      findReservedEnvKeys(["database_url", "ELIZAOS_CLOUD_API_KEY", "MY_VAR"]),
-    ).toEqual(["database_url", "ELIZAOS_CLOUD_API_KEY"]);
+    expect(findReservedEnvKeys(["database_url", "ELIZAOS_CLOUD_API_KEY", "MY_VAR"])).toEqual([
+      "database_url",
+      "ELIZAOS_CLOUD_API_KEY",
+    ]);
   });
 
   test("findReservedEnvKeys returns [] when no reserved keys present", () => {

--- a/packages/cloud-shared/src/lib/services/reserved-env-keys.test.ts
+++ b/packages/cloud-shared/src/lib/services/reserved-env-keys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import {
+  findReservedEnvKeys,
+  RESERVED_PLATFORM_ENV_KEYS,
+  stripReservedEnvKeys,
+} from "./reserved-env-keys";
+
+describe("reserved-env-keys", () => {
+  test("findReservedEnvKeys flags reserved keys case-insensitively, echoing caller casing", () => {
+    expect(
+      findReservedEnvKeys(["database_url", "ELIZAOS_CLOUD_API_KEY", "MY_VAR"]),
+    ).toEqual(["database_url", "ELIZAOS_CLOUD_API_KEY"]);
+  });
+
+  test("findReservedEnvKeys returns [] when no reserved keys present", () => {
+    expect(findReservedEnvKeys(["FOO", "BAR"])).toEqual([]);
+  });
+
+  test("POSTGRES_URL is not in the default platform list but can be added per-caller", () => {
+    expect(findReservedEnvKeys(["postgres_url"])).toEqual([]);
+    expect(
+      findReservedEnvKeys(["postgres_url"], [...RESERVED_PLATFORM_ENV_KEYS, "POSTGRES_URL"]),
+    ).toEqual(["postgres_url"]);
+  });
+
+  test("stripReservedEnvKeys removes reserved keys (case-insensitive) and keeps the rest", () => {
+    expect(
+      stripReservedEnvKeys({
+        DATABASE_URL: "postgres://evil",
+        database_url: "postgres://evil2",
+        ELIZAOS_CLOUD_API_KEY: "stolen",
+        APP_SECRET: "keep-me",
+        LOG_LEVEL: "debug",
+      }),
+    ).toEqual({ APP_SECRET: "keep-me", LOG_LEVEL: "debug" });
+  });
+
+  test("stripReservedEnvKeys with an extended set also strips POSTGRES_URL", () => {
+    expect(
+      stripReservedEnvKeys({ POSTGRES_URL: "postgres://evil", KEEP: "1" }, [
+        ...RESERVED_PLATFORM_ENV_KEYS,
+        "POSTGRES_URL",
+      ]),
+    ).toEqual({ KEEP: "1" });
+  });
+
+  test("stripReservedEnvKeys does not mutate its input", () => {
+    const input = { DATABASE_URL: "x", KEEP: "1" };
+    expect(stripReservedEnvKeys(input)).toEqual({ KEEP: "1" });
+    expect(input).toEqual({ DATABASE_URL: "x", KEEP: "1" });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/reserved-env-keys.ts
+++ b/packages/cloud-shared/src/lib/services/reserved-env-keys.ts
@@ -1,0 +1,65 @@
+/**
+ * Platform-reserved environment-variable keys for managed container deploys
+ * (dedicated agents AND Apps/Product-2 app containers).
+ *
+ * The platform injects/owns these — the managed Postgres DSN, the cloud API
+ * token, the metered-identity / cloud-agent keys. A caller's `environmentVars`
+ * must never set them: on the deploy path a caller-supplied value could shadow
+ * the platform-injected DB DSN or pre-empt a managed identity/token key. This is
+ * the single source of truth for that denylist, shared by the agent path
+ * (`managed-eliza-config`) and the app-deploy path (`app-deploy-orchestrator`).
+ *
+ * Intentionally dependency-free so both (deliberately pure, fake-tested) modules
+ * can import it without pulling in the DB / cloud-binding import graph.
+ */
+
+export const RESERVED_PLATFORM_ENV_KEYS = [
+  "DATABASE_URL",
+  "ELIZA_MANAGED_DATABASE_URL",
+  "ELIZA_API_TOKEN",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZA_CLOUD_AGENT_ID",
+  "PUBLIC_BASE_URL",
+  "STEWARD_AGENT_ID",
+  "STEWARD_AGENT_TOKEN",
+  "WAIFU_ELIZA_CLOUD_AGENT_ID",
+] as const;
+
+function toUpperSet(keys: Iterable<string>): Set<string> {
+  const set = new Set<string>();
+  for (const key of keys) set.add(key.toUpperCase());
+  return set;
+}
+
+/**
+ * Case-insensitive: the caller-supplied keys that collide with a reserved key.
+ * Returns the original (caller-cased) keys so an error can echo them back.
+ */
+export function findReservedEnvKeys(
+  keys: Iterable<string>,
+  reserved: Iterable<string> = RESERVED_PLATFORM_ENV_KEYS,
+): string[] {
+  const reservedSet = toUpperSet(reserved);
+  const hits: string[] = [];
+  for (const key of keys) {
+    if (reservedSet.has(key.toUpperCase())) hits.push(key);
+  }
+  return hits;
+}
+
+/**
+ * Case-insensitive: a copy of `env` with every reserved key removed. Used on the
+ * deploy path to strip caller-supplied reserved keys before the platform injects
+ * its own managed values.
+ */
+export function stripReservedEnvKeys(
+  env: Record<string, string>,
+  reserved: Iterable<string> = RESERVED_PLATFORM_ENV_KEYS,
+): Record<string, string> {
+  const reservedSet = toUpperSet(reserved);
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !reservedSet.has(key.toUpperCase())),
+  );
+}


### PR DESCRIPTION
**#9853 P1 — item 2 of the pre-GA apps hardening.** First of the small per-item PRs.

## Gap (confirmed against current develop)

The **dedicated-agent** deploy path enforces a platform-reserved env-var denylist — `findReservedManagedElizaEnvKeys` rejects them at `PATCH /eliza/agents/:id/environment`, and managed keys are force-overridden at create. The **Apps deploy** path does **not**: `deployApp()` (`app-deploy-orchestrator.ts`) forwarded the caller's `env` verbatim into the container row. So a stateless (`none`-mode) app could inject `DATABASE_URL`/`POSTGRES_URL` pointing at an arbitrary DB, or pre-empt a managed identity / cloud-token key.

> Current blast radius is low — the deploy route is gated (`503` unless `APPS_DEPLOY_ENABLED=1`, not armed in prod) and in isolated mode the platform DSN already wins — but the structural gap is real and this is a P1 gate item before opening Apps past the org allowlist.

## Fix

- Extract the reserved-key list + `findReservedEnvKeys`/`stripReservedEnvKeys` into a **dependency-free** `reserved-env-keys.ts` (single source of truth; keeps the deliberately-pure orchestrator decoupled from the agent module's DB/cloud-binding import graph).
- `managed-eliza-config` now **aliases** `RESERVED_MANAGED_ELIZA_ENV_KEYS` to the shared list and **delegates** `findReservedManagedElizaEnvKeys` — **agent path behavior unchanged**.
- `deployApp()` **strips** caller-supplied reserved keys before injecting platform values. `POSTGRES_URL` is added to the app-side denylist (`DATABASE_URL` was already reserved). The platform-injected isolated DSN still wins.

## Tests

- `reserved-env-keys.test.ts` — find/strip, case-insensitive, echoes caller casing, no input mutation, per-caller extension (`POSTGRES_URL`).
- `app-deploy-orchestrator.test.ts` — strips reserved keys on a `none`-mode app, platform isolated DSN wins over caller `DATABASE_URL`/`POSTGRES_URL`, non-reserved env passes through.

All four touched paths are fake-injected, so no staging daemon is needed to verify; `test:cloud` is the gate. Pure-logic + expectations were also validated standalone before pushing.

Refs #9853 (P1 item 2). Agent-path note (out of scope here, tracked): `STEWARD_AGENT_ID/TOKEN` are in the denylist but not re-overridden at agent create (the PATCH route still blocks them).