### PR TITLE
fix(cloud): fail-closed isolated-DB provisioning + remove dead silent-downgrade code (#9853 P1.4)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/user-database-provision-fail-closed.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/user-database-provision-fail-closed.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #9853 P1.4 — an "isolated" app deploy must FAIL CLOSED when no tenant-DB
+ * provisioning backend is wired (the provisioning daemon isn't armed), never
+ * silently fall back to the shared cloud DATABASE_URL. A bare UserDatabaseService
+ * (no backend) is exactly the unarmed-daemon case.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const findById = mock();
+const findStateByAppId = mock();
+const trySetProvisioning = mock();
+const updateState = mock();
+const findStateByAppIdForWrite = mock();
+
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: { findById },
+}));
+mock.module("../../../db/repositories/app-databases", () => ({
+  appDatabasesRepository: {
+    findStateByAppId,
+    trySetProvisioning,
+    updateState,
+    findStateByAppIdForWrite,
+  },
+}));
+mock.module("../field-encryption", () => ({
+  fieldEncryption: {
+    encrypt: mock(async (_org: string, value: string) => `enc:${value}`),
+    decryptIfNeeded: mock(async (value: string) => value),
+  },
+}));
+
+import { UserDatabaseService } from "../user-database";
+
+describe("provisionDatabase — fail closed without a tenant-DB backend", () => {
+  test("returns success:false and never the shared DATABASE_URL when no backend is wired", async () => {
+    findById.mockResolvedValue({ id: "app-1", organization_id: "org-1" });
+    findStateByAppId.mockResolvedValue(undefined);
+    trySetProvisioning.mockResolvedValue({ user_database_status: "provisioning" });
+    updateState.mockResolvedValue(undefined);
+    // A shared cloud DSN IS available — the fix must refuse to use it anyway.
+    process.env.DATABASE_URL = "postgres://shared-cloud-db/main";
+
+    // Bare service == no tenant-DB provisioning backend (the unarmed-daemon case).
+    const svc = new UserDatabaseService();
+    const result = await svc.provisionDatabase("app-1", "My App");
+
+    expect(result.success).toBe(false);
+    expect(result.connectionUri).toBeUndefined();
+    expect(result.error).toContain("no tenant-DB provisioning backend is wired");
+    // Persisted an error state rather than a (shared) "ready" — no silent downgrade.
+    expect(updateState).toHaveBeenCalledWith(
+      "app-1",
+      expect.objectContaining({ user_database_status: "error" }),
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -368,35 +368,11 @@ export function makeDirectAppDeployRunner(args: {
   });
 }
 
-/**
- * WORKER factory — `pg`-free. `ensureTenantDb` runs `provisionDatabase` over a
- * `userDatabaseService` constructed WITHOUT a tenant-DB provisioning backend, so
- * it takes the shared-DB fallback (returns process.env.DATABASE_URL; no DDL, no
- * `pg`). Isolation in this mode is by app/agent UUID scoping in plugin-sql, not
- * by REVOKE-CONNECT. Use this in cloud-api (workerd) until tenant-DB DDL is moved
- * into the CONTAINER_PROVISION executor (then this factory enqueues instead).
- *
- * The injected `userDatabaseService` here is the bare singleton (no provisioning
- * backend) — passing it explicitly keeps the dependency visible and testable.
- */
-export function makeWorkerAppDeployRunner(args: {
-  userDatabaseService: UserDatabaseService;
-  jobsWriter: ContainerJobsWriter;
-  resolveImage?: AppDeployRunnerDeps["resolveImage"];
-  port?: number;
-}): DefaultAppDeployRunner {
-  return new DefaultAppDeployRunner({
-    ensureTenantDb: async (appId, appName) => {
-      const provisioned = await args.userDatabaseService.provisionDatabase(appId, appName);
-      if (!provisioned.success || !provisioned.connectionUri) {
-        throw new Error(
-          `ensureTenantDb (shared) failed for app ${appId}: ${provisioned.error ?? "no connection URI"}`,
-        );
-      }
-      return provisioned.connectionUri;
-    },
-    jobsWriter: args.jobsWriter,
-    resolveImage: args.resolveImage,
-    port: args.port,
-  });
-}
+// NOTE: there used to be a `makeWorkerAppDeployRunner` here — a `pg`-free factory
+// that ran `provisionDatabase` over a backend-less `UserDatabaseService`, taking
+// the shared-DB fallback (no `CREATE ROLE`/`REVOKE CONNECT`, isolation by UUID
+// only) while still being used for "isolated" apps. It had zero callers (the live
+// path enqueues an APP_DEPLOY job → the node daemon runs `makeNodeAppDeployRunner`
+// with real per-tenant DDL, and an unarmed daemon hard-fails). It was removed so
+// nobody can re-wire a silent isolation downgrade; `provisionDatabase` now also
+// fail-closes when no provisioning backend is wired.

--- a/packages/cloud-shared/src/lib/services/user-database.ts
+++ b/packages/cloud-shared/src/lib/services/user-database.ts
@@ -92,16 +92,18 @@ export class UserDatabaseService {
   }
 
   /**
-   * Provision a database for an app.
+   * Provision an ISOLATED per-tenant database for an app.
    *
-   * Provisions an isolated per-tenant database when a tenant-DB backend is
-   * wired; otherwise falls back to the shared cloud DATABASE_URL. ElizaOS
-   * plugin-sql tables scope data by agent/app UUID so multiple apps safely
-   * coexist on the shared database.
+   * Called only for `databaseMode: "isolated"` apps. Requires a tenant-DB
+   * provisioning backend (the node daemon's real CREATE ROLE / REVOKE CONNECT).
+   * If no backend is wired this FAILS CLOSED (throws → ProvisionResult.success
+   * false) instead of silently falling back to the shared cloud DATABASE_URL —
+   * a degrade that would co-locate the app on the shared DB while reporting it as
+   * isolated.
    *
    * @param appId App ID
    * @param appName App name (used for logging)
-   * @param region Optional AWS region (ignored in shared-DB mode)
+   * @param region Optional AWS region for the provisioned tenant DB
    * @returns Provision result with connection URI
    */
   async provisionDatabase(
@@ -167,11 +169,11 @@ export class UserDatabaseService {
     }
 
     try {
-      // Per-tenant ISOLATED database (Apps / Product 2) when the provisioning
-      // backend is wired; otherwise fall back to the legacy shared cloud
-      // DATABASE_URL (plugin-sql tables scope by agent/app UUID, so the shared
-      // mode still coexists safely). The isolated path provisions the app its
-      // own DB + role and stores that real DSN — never the shared agent URL.
+      // Per-tenant ISOLATED database (Apps / Product 2): provision the app its
+      // own DB + role (real CREATE ROLE / REVOKE CONNECT) and store that DSN.
+      // This requires a tenant-DB provisioning backend (the node daemon); with
+      // none wired we FAIL CLOSED rather than silently using the shared cloud
+      // DATABASE_URL — see the else branch.
       let connectionUri: string;
       let clusterId: string | undefined;
       if (this.tenantDbProvisioning) {
@@ -179,11 +181,17 @@ export class UserDatabaseService {
         connectionUri = provisioned.dsn;
         clusterId = provisioned.clusterId;
       } else {
-        const sharedDbUrl = process.env.DATABASE_URL;
-        if (!sharedDbUrl) {
-          throw new Error("DATABASE_URL not configured in cloud environment");
-        }
-        connectionUri = sharedDbUrl;
+        // FAIL CLOSED. provisionDatabase is only called for mode==="isolated"
+        // apps; with no provisioning backend we'd silently co-locate the app on
+        // the shared cloud DATABASE_URL (isolation by UUID only) yet report it as
+        // isolated. Never silently degrade isolation — throw so the deploy fails
+        // loudly. The live path runs this in the node daemon (backend wired); an
+        // unarmed daemon must hard-fail, not downgrade.
+        throw new Error(
+          "Isolated database requested but no tenant-DB provisioning backend is wired " +
+            "(the provisioning daemon is not armed). Refusing to fall back to the shared " +
+            "cloud DATABASE_URL — arm the daemon (configureAppsDeployBackend) and retry.",
+        );
       }
 
       // Encrypt the connection URI before storing.
@@ -197,7 +205,7 @@ export class UserDatabaseService {
 
       logger.info("Database provisioned successfully", {
         appId,
-        mode: this.tenantDbProvisioning ? "isolated" : "shared",
+        mode: "isolated",
         clusterId,
       });
 


### PR DESCRIPTION
**#9853 P1 — item 4.** Audit verdict was *partial / already-fail-closed on the live path* — so this PR closes the **latent** re-introduction risk, not an exploitable live bug.

## Current state (confirmed)

The live deploy path is safe: `cloud-api` only **enqueues** an `APP_DEPLOY` job; the node daemon runs `makeNodeAppDeployRunner` with real per-tenant DDL (`CREATE ROLE` / `CREATE DATABASE` / `REVOKE CONNECT`), and an unarmed daemon **hard-fails** (`getAppDeployRunner()` throws). What remained were two **dormant** primitives that would silently re-introduce a shared-DB downgrade the moment anyone re-wired them:

1. `makeWorkerAppDeployRunner` — **zero callers**; provisioned a shared DB (isolation by UUID only) while being used for `isolated` apps.
2. `UserDatabaseService.provisionDatabase` — when no `tenantDbProvisioning` backend is wired, silently returned `process.env.DATABASE_URL` with `success:true` / `mode:"shared"`. Since `provisionDatabase` is **only** called for `isolated` apps, that else-branch was *always* an isolation downgrade.

## Fix

- **Delete** `makeWorkerAppDeployRunner` (left a short guardrail note so it isn't recreated). No callers, nothing else references it.
- **Fail closed** in `provisionDatabase`: throw instead of falling back to the shared DSN → the catch turns it into `success:false` + persists `user_database_status: "error"`. No silent degrade.
- Updated the now-inaccurate doc/inline comments that described shared-DB mode as a safe fallback; simplified the success-log `mode` (always `"isolated"` once the else throws).

## Test

`user-database-provision-fail-closed.test.ts` — with no backend wired, `provisionDatabase` returns `success:false`, **never** the shared `DATABASE_URL` (asserted even when one is set), and persists an `error` state. Verified the live path is untouched (no test exercised the dead factory or the fallback).

The *live* isolation proof (deploy an isolated app on an armed daemon → `psql` as `PUBLIC` denied) is a separate daemon-armed staging e2e, tracked under P2 item 9. Refs #9853 (P1 item 4).