### PR TITLE
fix: wrap cloud connectors settings section

### DIFF
--- a/packages/ui/src/cloud-ui/components/drawer.tsx
+++ b/packages/ui/src/cloud-ui/components/drawer.tsx
@@ -73,10 +73,10 @@ function DrawerContent({
           <button
             type="button"
             aria-label="Close drawer"
-            className="group mx-auto mb-2 mt-2 hidden h-8 w-32 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/45 group-data-[vaul-drawer-direction=bottom]/drawer-content:flex"
+            className="group mx-auto mb-2 mt-2 hidden h-8 w-32 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-white/10 group-data-[vaul-drawer-direction=bottom]/drawer-content:flex"
           >
             <span
-              className="h-1.5 w-[100px] rounded-full bg-white/15 transition-all group-hover:w-[112px] group-hover:bg-white/35 group-focus-visible:w-[112px] group-focus-visible:bg-white/45"
+              className="h-1.5 w-[100px] rounded-full bg-white/15 transition-all group-hover:w-[112px] group-hover:bg-white/35"
               aria-hidden
             />
           </button>

--- a/packages/ui/src/cloud-ui/components/drawer.tsx
+++ b/packages/ui/src/cloud-ui/components/drawer.tsx
@@ -69,7 +69,18 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 bg-white/15 group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <DrawerClose asChild>
+          <button
+            type="button"
+            aria-label="Close drawer"
+            className="group mx-auto mb-2 mt-2 hidden h-8 w-32 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/45 group-data-[vaul-drawer-direction=bottom]/drawer-content:flex"
+          >
+            <span
+              className="h-1.5 w-[100px] rounded-full bg-white/15 transition-all group-hover:w-[112px] group-hover:bg-white/35 group-focus-visible:w-[112px] group-focus-visible:bg-white/45"
+              aria-hidden
+            />
+          </button>
+        </DrawerClose>
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -1160,7 +1160,11 @@ export function DiscordGatewayConnection() {
               {t("cloud.discord.character", { defaultValue: "Character" })}
             </Label>
             <div className="flex gap-2">
-              <Select value={characterId} onValueChange={setCharacterId}>
+              <Select
+                key={characterId || "discord-gateway-character-unselected"}
+                value={characterId}
+                onValueChange={setCharacterId}
+              >
                 <SelectTrigger id="character" className="flex-1">
                   <SelectValue
                     placeholder={t("cloud.discord.selectCharacterPlaceholder", {

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -58,6 +58,31 @@ interface Character {
   name: string;
 }
 
+function normalizeCharacters(
+  agents: Array<{ id?: unknown; name?: unknown }> | undefined,
+): Character[] {
+  return (agents ?? []).flatMap((agent) => {
+    if (typeof agent.id !== "string" || agent.id.length === 0) return [];
+    return [
+      {
+        id: agent.id,
+        name:
+          typeof agent.name === "string" && agent.name.length > 0
+            ? agent.name
+            : agent.id,
+      },
+    ];
+  });
+}
+
+async function fetchRuntimeCharacters(signal?: AbortSignal): Promise<Character[]> {
+  const data = await api<{ agents?: Array<{ id?: unknown; name?: unknown }> }>(
+    "/api/agents",
+    { signal, skipAuth: true },
+  );
+  return normalizeCharacters(data.agents);
+}
+
 interface DiscordConnectionPatch {
   characterId: string | null;
   isActive: boolean;
@@ -205,20 +230,38 @@ export function DiscordGatewayConnection() {
       setIsLoadingCharacters(true);
       try {
         const data = await api<{
-          agents?: Array<{ id: string; name: string }>;
+          agents?: Array<{ id?: unknown; name?: unknown }>;
         }>("/api/v1/dashboard", { signal });
         if (!signal?.aborted) {
-          setCharacters(
-            data.agents?.map((a) => ({ id: a.id, name: a.name })) || [],
-          );
+          const nextCharacters = normalizeCharacters(data.agents);
+          const fallbackCharacters =
+            nextCharacters.length > 0
+              ? nextCharacters
+              : await fetchRuntimeCharacters(signal);
+          if (!signal?.aborted) {
+            setCharacters(fallbackCharacters);
+            setCharacterId(
+              (current) => current || fallbackCharacters[0]?.id || "",
+            );
+          }
         }
       } catch {
         if (!signal?.aborted) {
-          toast.error(
-            t("cloud.discord.fetchCharactersFailed", {
-              defaultValue: "Failed to fetch characters",
-            }),
-          );
+          try {
+            const fallbackCharacters = await fetchRuntimeCharacters(signal);
+            if (!signal?.aborted) {
+              setCharacters(fallbackCharacters);
+              setCharacterId(
+                (current) => current || fallbackCharacters[0]?.id || "",
+              );
+            }
+          } catch {
+            toast.error(
+              t("cloud.discord.fetchCharactersFailed", {
+                defaultValue: "Failed to fetch characters",
+              }),
+            );
+          }
         }
       } finally {
         if (!signal?.aborted) {

--- a/packages/ui/src/cloud/connectors/index.ts
+++ b/packages/ui/src/cloud/connectors/index.ts
@@ -26,7 +26,9 @@
  */
 
 import { Plug } from "lucide-react";
+import { createElement } from "react";
 import { registerSettingsSection } from "../../components/settings/settings-section-registry";
+import { CloudSettingsSectionShell } from "../settings/CloudSettingsSectionShell";
 import { registerCloudRoute } from "../shell/cloud-route-registry";
 import { CloudConnectorsSection } from "./CloudConnectorsSection";
 
@@ -53,6 +55,22 @@ export { WhatsAppConnection } from "./whatsapp-connection";
 export const CLOUD_CONNECTORS_SECTION_ID = "cloud-connectors";
 
 /**
+ * Settings-section adapter for the cloud connectors surface.
+ *
+ * The standalone cloud route is already rendered under CloudRouterShell, which
+ * supplies query/i18n/auth providers. Settings sections render inside the
+ * app-shell settings registry instead, so this adapter provides the cloud stack
+ * before mounting the canonical connectors body.
+ */
+export function CloudConnectorsSettingsSection(): React.JSX.Element {
+  return createElement(
+    CloudSettingsSectionShell,
+    null,
+    createElement(CloudConnectorsSection),
+  );
+}
+
+/**
  * Register the cloud connectors surface as a Settings section under the "agent"
  * group. Idempotent (the registry replaces by id). Call from the host's cloud
  * boot path; not invoked at import time so the settings IA stays the host's
@@ -69,7 +87,7 @@ export function registerCloudConnectorsSettingsSection(): void {
     group: "agent",
     titleKey: "settings.sections.cloudConnectors.title",
     defaultTitle: "Cloud Connectors",
-    Component: CloudConnectorsSection,
+    Component: CloudConnectorsSettingsSection,
   });
 }
 

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -20,19 +20,18 @@ import "./instances";
 import "./account-security";
 import "./billing/routes";
 import "./organization/routes";
-import "./settings";
 
 import { registerAdminCloudRoutes } from "./admin";
 import { registerApiExplorerCloudRoute } from "./api-explorer";
 import { registerApiKeysCloudRoute } from "./api-keys";
 import { registerApplicationsCloudRoutes } from "./applications";
 import { registerApprovalsCloudRoute } from "./approvals";
-import { registerCloudConnectorsSettingsSection } from "./connectors";
 import { registerDocumentsCloudRoute } from "./documents";
 import { registerJoinFlow } from "./join";
-import { registerMcpsCloudRoute, registerMcpsSettingsSection } from "./mcps";
+import { registerMcpsCloudRoute } from "./mcps";
 import { registerMonetizationCloudRoutes } from "./monetization";
 import { registerPublicPages } from "./public-pages";
+import { registerCloudSettingsSections } from "./settings";
 
 let registered = false;
 
@@ -56,6 +55,5 @@ export function registerAllCloudSurfaces(): void {
   registerAdminCloudRoutes();
   registerMcpsCloudRoute();
 
-  registerCloudConnectorsSettingsSection();
-  registerMcpsSettingsSection();
+  registerCloudSettingsSections();
 }

--- a/packages/ui/src/cloud/settings/index.ts
+++ b/packages/ui/src/cloud/settings/index.ts
@@ -1,14 +1,11 @@
 /**
  * In-app Eliza Cloud settings sections (re-IA Step 2).
  *
- * Importing this module registers the Cloud settings group + every cloud
- * settings section (and the two Security-group additions) via the side-effecting
- * {@link ./register-cloud-settings}. The Settings view imports it so the cloud
- * sections are present whenever settings render — web and native alike — the same
- * way the built-in sections register through `settings-sections.ts`.
+ * This barrel is intentionally side-effect free. Hosts that expose the Cloud
+ * dashboard inside Settings must call {@link registerCloudSettingsSections}
+ * from their cloud boot path; local-first shells can import Cloud helpers
+ * without surfacing Cloud-only tabs.
  */
-
-import "./register-cloud-settings";
 
 export { CloudSettingsSectionShell } from "./CloudSettingsSectionShell";
 export {
@@ -18,6 +15,7 @@ export {
   listExtraSettingsGroups,
   registerSettingsGroup,
 } from "./cloud-settings-group";
+export { registerCloudSettingsSections } from "./register-cloud-settings";
 export {
   CloudAccountSection,
   CloudApiKeysSection,

--- a/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
@@ -1,13 +1,12 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { listSettingsSections } from "../../components/settings/settings-section-registry";
 import {
   CLOUD_SETTINGS_GROUP_ID,
   listExtraSettingsGroups,
 } from "./cloud-settings-group";
-// Importing the barrel runs the side-effecting registration.
-import "./index";
+import { registerCloudSettingsSections } from "./register-cloud-settings";
 
 const CLOUD_SECTION_IDS = [
   "cloud-account",
@@ -24,6 +23,10 @@ const SECURITY_ADDITION_IDS = [
 ] as const;
 
 describe("register-cloud-settings", () => {
+  beforeAll(() => {
+    registerCloudSettingsSections();
+  });
+
   it("registers the Cloud group between System and Security", () => {
     const cloud = listExtraSettingsGroups().find(
       (g) => g.id === CLOUD_SETTINGS_GROUP_ID,

--- a/packages/ui/src/cloud/settings/register-cloud-settings.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.ts
@@ -2,7 +2,7 @@
  * Single registration barrel for the in-app Eliza Cloud settings sections
  * (re-IA Step 2).
  *
- * Importing this module (side effect) registers:
+ * Calling {@link registerCloudSettingsSections} registers:
  *  - a new **Cloud** settings group (between System and Security), and
  *  - the cloud sections that re-home the lifted cloud dashboard pages as in-app
  *    Settings sections, plus two additions to the existing **Security** group.
@@ -62,134 +62,141 @@ import {
  * The Cloud group sits between System (built-in order 1) and Security (built-in
  * order 2), matching the IA in `docs/cloud-into-eliza/PLAN.md` §4.3.
  */
-registerSettingsGroup({
-  id: CLOUD_SETTINGS_GROUP_ID,
-  label: "Cloud",
-  order: 1.5,
-});
+let cloudSettingsRegistered = false;
 
-// ── Cloud group ──────────────────────────────────────────────────────────────
+export function registerCloudSettingsSections(): void {
+  if (cloudSettingsRegistered) return;
+  cloudSettingsRegistered = true;
 
-registerSettingsSection({
-  id: "cloud-account",
-  label: "settings.sections.cloudAccount.label",
-  defaultLabel: "Account & Profile",
-  icon: User,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudAccount.title",
-  defaultTitle: "Account & Profile",
-  order: 0,
-  Component: CloudAccountSection,
-});
+  registerSettingsGroup({
+    id: CLOUD_SETTINGS_GROUP_ID,
+    label: "Cloud",
+    order: 1.5,
+  });
 
-registerSettingsSection({
-  id: "cloud-billing",
-  label: "settings.sections.cloudBilling.label",
-  defaultLabel: "Billing & Credits",
-  icon: CreditCard,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudBilling.title",
-  defaultTitle: "Billing & Credits",
-  order: 1,
-  Component: CloudBillingSection,
-});
+  // ── Cloud group ──────────────────────────────────────────────────────────────
 
-registerSettingsSection({
-  id: "cloud-api-keys",
-  label: "settings.sections.cloudApiKeys.label",
-  defaultLabel: "API Keys",
-  icon: KeyRound,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudApiKeys.title",
-  defaultTitle: "API Keys",
-  order: 2,
-  Component: CloudApiKeysSection,
-});
+  registerSettingsSection({
+    id: "cloud-account",
+    label: "settings.sections.cloudAccount.label",
+    defaultLabel: "Account & Profile",
+    icon: User,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudAccount.title",
+    defaultTitle: "Account & Profile",
+    order: 0,
+    Component: CloudAccountSection,
+  });
 
-registerSettingsSection({
-  id: "cloud-applications",
-  label: "settings.sections.cloudApplications.label",
-  defaultLabel: "Applications",
-  icon: Grid3x3,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudApplications.title",
-  defaultTitle: "Applications",
-  order: 3,
-  Component: CloudApplicationsSection,
-});
+  registerSettingsSection({
+    id: "cloud-billing",
+    label: "settings.sections.cloudBilling.label",
+    defaultLabel: "Billing & Credits",
+    icon: CreditCard,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudBilling.title",
+    defaultTitle: "Billing & Credits",
+    order: 1,
+    Component: CloudBillingSection,
+  });
 
-registerSettingsSection({
-  id: "cloud-monetization",
-  label: "settings.sections.cloudMonetization.label",
-  defaultLabel: "Monetization",
-  icon: TrendingUp,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudMonetization.title",
-  defaultTitle: "Monetization",
-  order: 4,
-  Component: CloudMonetizationSection,
-});
+  registerSettingsSection({
+    id: "cloud-api-keys",
+    label: "settings.sections.cloudApiKeys.label",
+    defaultLabel: "API Keys",
+    icon: KeyRound,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudApiKeys.title",
+    defaultTitle: "API Keys",
+    order: 2,
+    Component: CloudApiKeysSection,
+  });
 
-registerSettingsSection({
-  id: "cloud-organization",
-  label: "settings.sections.cloudOrganization.label",
-  defaultLabel: "Organization",
-  icon: Building2,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudOrganization.title",
-  defaultTitle: "Organization",
-  order: 5,
-  Component: CloudOrganizationSection,
-});
+  registerSettingsSection({
+    id: "cloud-applications",
+    label: "settings.sections.cloudApplications.label",
+    defaultLabel: "Applications",
+    icon: Grid3x3,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudApplications.title",
+    defaultTitle: "Applications",
+    order: 3,
+    Component: CloudApplicationsSection,
+  });
 
-// ── Security group (additions) ───────────────────────────────────────────────
-// Ordered after the built-in security sections (built-ins occupy meta indices
-// 12–15). High explicit order keeps them last within the Security group.
+  registerSettingsSection({
+    id: "cloud-monetization",
+    label: "settings.sections.cloudMonetization.label",
+    defaultLabel: "Monetization",
+    icon: TrendingUp,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudMonetization.title",
+    defaultTitle: "Monetization",
+    order: 4,
+    Component: CloudMonetizationSection,
+  });
 
-registerSettingsSection({
-  id: "cloud-security",
-  label: "settings.sections.cloudSecurity.label",
-  defaultLabel: "Sessions & Privacy",
-  icon: Lock,
-  tone: "warn",
-  hue: "amber",
-  group: "security",
-  titleKey: "settings.sections.cloudSecurity.title",
-  defaultTitle: "Sessions, Privacy & Audit",
-  order: 100,
-  Component: CloudSecuritySection,
-});
+  registerSettingsSection({
+    id: "cloud-organization",
+    label: "settings.sections.cloudOrganization.label",
+    defaultLabel: "Organization",
+    icon: Building2,
+    tone: "accent",
+    hue: "accent",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    titleKey: "settings.sections.cloudOrganization.title",
+    defaultTitle: "Organization",
+    order: 5,
+    Component: CloudOrganizationSection,
+  });
 
-registerSettingsSection({
-  id: "cloud-plugin-grants",
-  label: "settings.sections.cloudPluginGrants.label",
-  defaultLabel: "Plugin Grants",
-  icon: Workflow,
-  tone: "warn",
-  hue: "amber",
-  group: "security",
-  titleKey: "settings.sections.cloudPluginGrants.title",
-  defaultTitle: "Plugin Grants",
-  order: 101,
-  Component: CloudPluginGrantsSection,
-});
+  // ── Security group (additions) ───────────────────────────────────────────────
+  // Ordered after the built-in security sections (built-ins occupy meta indices
+  // 12–15). High explicit order keeps them last within the Security group.
 
-// ── Cloud connectors + MCPs ──────────────────────────────────────────────────
-// These domains own their own settings-section registration (they live outside
-// cloud/settings/). Invoke them here — from the barrel that SettingsView imports
-// on every platform — so the sections surface on web AND native/desktop, not
-// only inside the web-only route aggregator (register-all.ts).
-registerCloudConnectorsSettingsSection();
-registerMcpsSettingsSection();
+  registerSettingsSection({
+    id: "cloud-security",
+    label: "settings.sections.cloudSecurity.label",
+    defaultLabel: "Sessions & Privacy",
+    icon: Lock,
+    tone: "warn",
+    hue: "amber",
+    group: "security",
+    titleKey: "settings.sections.cloudSecurity.title",
+    defaultTitle: "Sessions, Privacy & Audit",
+    order: 100,
+    Component: CloudSecuritySection,
+  });
+
+  registerSettingsSection({
+    id: "cloud-plugin-grants",
+    label: "settings.sections.cloudPluginGrants.label",
+    defaultLabel: "Plugin Grants",
+    icon: Workflow,
+    tone: "warn",
+    hue: "amber",
+    group: "security",
+    titleKey: "settings.sections.cloudPluginGrants.title",
+    defaultTitle: "Plugin Grants",
+    order: 101,
+    Component: CloudPluginGrantsSection,
+  });
+
+  // ── Cloud connectors + MCPs ──────────────────────────────────────────────────
+  // These domains own their own settings-section registration (they live outside
+  // cloud/settings/). Invoke them here — from the barrel that SettingsView imports
+  // on every platform — so the sections surface on web AND native/desktop, not
+  // only inside the web-only route aggregator (register-all.ts).
+  registerCloudConnectorsSettingsSection();
+  registerMcpsSettingsSection();
+}

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -1401,10 +1401,10 @@ const DrawerComponent: ComponentFn = (props, children, ctx) => {
           type="button"
           aria-label="Close drawer"
           onClick={close}
-          className="group mx-auto mb-3 flex h-8 w-32 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-surface/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+          className="group mx-auto mb-3 flex h-8 w-32 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-surface/70"
         >
           <span
-            className="h-1 w-10 rounded-full bg-border transition-all group-hover:w-14 group-hover:bg-accent/70 group-focus-visible:w-14 group-focus-visible:bg-accent"
+            className="h-1 w-10 rounded-full bg-border transition-all group-hover:w-14 group-hover:bg-accent/70"
             aria-hidden
           />
         </button>

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -1397,7 +1397,17 @@ const DrawerComponent: ComponentFn = (props, children, ctx) => {
       aria-modal="true"
     >
       <div className="w-full max-h-[80vh] bg-card p-5 overflow-y-auto animate-[slide-up_200ms_ease]">
-        <div className="w-10 h-1 bg-border mx-auto mb-3 rounded-full" />
+        <button
+          type="button"
+          aria-label="Close drawer"
+          onClick={close}
+          className="group mx-auto mb-3 flex h-8 w-32 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-surface/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        >
+          <span
+            className="h-1 w-10 rounded-full bg-border transition-all group-hover:w-14 group-hover:bg-accent/70 group-focus-visible:w-14 group-focus-visible:bg-accent"
+            aria-hidden
+          />
+        </button>
         {props.title ? (
           <div className="font-bold text-sm">{String(props.title)}</div>
         ) : null}
@@ -1528,8 +1538,7 @@ function ElementRenderer({ elementId }: { elementId: string }) {
   // Handle repeat / list rendering
   if (el.repeat) {
     const listData = getByPath(ctx.state, el.repeat.path) as
-      | Array<Record<string, unknown>>
-      | undefined;
+      Array<Record<string, unknown>> | undefined;
     if (!Array.isArray(listData)) return null;
 
     const repeatKey = el.repeat.key;

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -3,10 +3,7 @@ import { ArrowLeft } from "lucide-react";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
-// Importing the cloud settings barrel registers the Cloud group + the cloud
-// settings sections (side effect), then exposes the extra-group list the
-// grouping below reads — so the cloud sections render whenever Settings mounts.
-import { listExtraSettingsGroups } from "../../cloud/settings";
+import { listExtraSettingsGroups } from "../../cloud/settings/cloud-settings-group";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ContentLayout } from "../../layouts/content-layout";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/settings/CloudOverviewSection.tsx
+++ b/packages/ui/src/components/settings/CloudOverviewSection.tsx
@@ -1,0 +1,147 @@
+import {
+  Bot,
+  Cloud,
+  CreditCard,
+  KeyRound,
+  Plug,
+  Rocket,
+  Store,
+} from "lucide-react";
+import { useCallback } from "react";
+import { useAgentElement } from "../../agent-surface";
+import { useAppSelectorShallow } from "../../state";
+import { Button } from "../ui/button";
+import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+
+const CLOUD_FEATURES = [
+  {
+    icon: Plug,
+    label: "Hosted connectors",
+    description:
+      "Run Discord, Telegram, Twilio, WhatsApp, Google, and Microsoft connections through hosted Cloud infrastructure.",
+  },
+  {
+    icon: Bot,
+    label: "Cloud agents",
+    description:
+      "Keep agents online when this Mac is asleep and switch between hosted agents from every device.",
+  },
+  {
+    icon: KeyRound,
+    label: "API keys and app publishing",
+    description:
+      "Create Cloud API keys, register apps, and connect external products to your agents.",
+  },
+  {
+    icon: CreditCard,
+    label: "Credits and billing",
+    description:
+      "Use shared Cloud inference, track spend, and configure top-ups from one account.",
+  },
+  {
+    icon: Store,
+    label: "Marketplace and monetization",
+    description:
+      "Publish apps, sell capabilities, and unlock creator revenue surfaces as they roll out.",
+  },
+] as const;
+
+export function CloudOverviewSection() {
+  const {
+    elizaCloudConnected,
+    elizaCloudLoginBusy,
+    handleCloudLogin,
+    setActionNotice,
+    t,
+  } = useAppSelectorShallow((s) => ({
+    elizaCloudConnected: s.elizaCloudConnected,
+    elizaCloudLoginBusy: s.elizaCloudLoginBusy,
+    handleCloudLogin: s.handleCloudLogin,
+    setActionNotice: s.setActionNotice,
+    t: s.t,
+  }));
+
+  const handleConnect = useCallback(() => {
+    void handleCloudLogin().catch((error) => {
+      setActionNotice(
+        error instanceof Error ? error.message : "Could not start Cloud login.",
+        "error",
+        5000,
+      );
+    });
+  }, [handleCloudLogin, setActionNotice]);
+
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "cloud-connect",
+    role: "button",
+    label: elizaCloudConnected ? "Open Eliza Cloud" : "Connect Eliza Cloud",
+    group: "cloud",
+    status: elizaCloudConnected ? "connected" : "available",
+    onActivate: elizaCloudLoginBusy ? undefined : handleConnect,
+  });
+
+  return (
+    <SettingsStack>
+      <SettingsGroup
+        title={t("settings.cloudOverview.title", {
+          defaultValue: "Eliza Cloud",
+        })}
+        description={t("settings.cloudOverview.description", {
+          defaultValue:
+            "Keep Milady local-first, then add hosted services when you want always-on agents, managed connectors, publishing, and account-backed inference.",
+        })}
+        action={
+          <Button
+            ref={ref}
+            size="sm"
+            onClick={handleConnect}
+            disabled={elizaCloudLoginBusy}
+            {...agentProps}
+          >
+            <Cloud className="h-4 w-4" aria-hidden />
+            {elizaCloudLoginBusy
+              ? t("settings.cloudOverview.connecting", {
+                  defaultValue: "Connecting...",
+                })
+              : elizaCloudConnected
+                ? t("settings.cloudOverview.connectedCta", {
+                    defaultValue: "Cloud connected",
+                  })
+                : t("settings.cloudOverview.connectCta", {
+                    defaultValue: "Connect Cloud",
+                  })}
+          </Button>
+        }
+      >
+        <SettingsRow
+          icon={Rocket}
+          label={t("settings.cloudOverview.localModeLabel", {
+            defaultValue: elizaCloudConnected
+              ? "Cloud is connected"
+              : "Local mode is active",
+          })}
+          description={t("settings.cloudOverview.localModeDescription", {
+            defaultValue: elizaCloudConnected
+              ? "Milady can use Cloud account features while keeping this local runtime available."
+              : "This build keeps agent runtime and local connectors on your machine unless you choose to connect Cloud.",
+          })}
+        />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={t("settings.cloudOverview.unlockTitle", {
+          defaultValue: "Unlock with Cloud",
+        })}
+      >
+        {CLOUD_FEATURES.map((feature) => (
+          <SettingsRow
+            key={feature.label}
+            icon={feature.icon}
+            label={feature.label}
+            description={feature.description}
+          />
+        ))}
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -2,6 +2,7 @@ import {
   Archive,
   Bot,
   Brain,
+  Cloud,
   KeyRound,
   LayoutGrid,
   Lock,
@@ -26,6 +27,7 @@ import { AppPermissionsSection } from "./AppPermissionsSection";
 import { AppsManagementSection } from "./AppsManagementSection";
 import { CapabilitiesSection } from "./CapabilitiesSection";
 import { CloudAgentsSection } from "./CloudAgentsSection";
+import { CloudOverviewSection } from "./CloudOverviewSection";
 import { ConnectorsSection } from "./ConnectorsSection";
 import { IdentitySettingsSection } from "./IdentitySettingsSection";
 import { PermissionsSection } from "./PermissionsSection";
@@ -34,6 +36,10 @@ import { RemotePluginHostSection } from "./RemotePluginHostSection";
 import { RuntimeSettingsSection } from "./RuntimeSettingsSection";
 import { SecretsManagerSection } from "./SecretsManagerSection";
 import { SecuritySettingsSection } from "./SecuritySettingsSection";
+import {
+  CLOUD_SETTINGS_GROUP_ID,
+  registerSettingsGroup,
+} from "../../cloud/settings/cloud-settings-group";
 import {
   SETTINGS_GROUP_LABEL,
   SETTINGS_GROUP_ORDER,
@@ -249,10 +255,32 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] =
 
 for (const section of SETTINGS_SECTIONS) registerSettingsSection(section);
 
+registerSettingsGroup({
+  id: CLOUD_SETTINGS_GROUP_ID,
+  label: "Cloud",
+  order: 1.5,
+});
+
+registerSettingsSection({
+  id: "cloud-overview",
+  label: "settings.sections.cloudOverview.label",
+  defaultLabel: "Overview",
+  icon: Cloud,
+  tone: "accent",
+  hue: "accent",
+  group: CLOUD_SETTINGS_GROUP_ID,
+  titleKey: "settings.sections.cloudOverview.title",
+  defaultTitle: "Eliza Cloud",
+  order: 1.45,
+  Component: CloudOverviewSection,
+});
+
 // Eliza Cloud agent manager — contributed through the pluggable registry rather
 // than the canonical META list, so it surfaces in Settings (list / switch /
 // create+name / delete agents) without changing the built-in section count that
-// the dev-route-catalog test pins. Ordered right after the AI Model section.
+// the dev-route-catalog test pins. It lives under the local Cloud group with the
+// upsell overview, while full Cloud-only account/billing/API surfaces remain
+// opt-in through registerCloudSettingsSections().
 registerSettingsSection({
   id: "cloud-agents",
   label: "settings.sections.cloudAgents.label",
@@ -260,10 +288,10 @@ registerSettingsSection({
   icon: Bot,
   tone: "accent",
   hue: "accent",
-  group: "agent",
+  group: CLOUD_SETTINGS_GROUP_ID,
   titleKey: "settings.sections.cloudAgents.title",
   defaultTitle: "Eliza Cloud Agents",
-  order: 1.5,
+  order: 1.55,
   Component: CloudAgentsSection,
 });
 


### PR DESCRIPTION
## Summary
- add a CloudConnectorsSettingsSection adapter for the in-app Settings registry
- keep the standalone dashboard/settings/connections cloud route on the raw CloudConnectorsSection because CloudRouterShell already provides query and cloud i18n there
- register the Settings section with the adapter so useCloudT resolves under CloudI18nProvider
- fall back from the cloud dashboard character list to local /api/agents in desktop/local mode, selecting the default running agent when available
- remount the Discord Gateway character select when the async fallback chooses a concrete character id
- make Cloud Settings registration explicit so local-first SettingsView does not mount endpoint-backed Cloud panels unless a Cloud host calls registerCloudSettingsSections()
- add a local Cloud Settings overview/upsell section so non-Cloud users still see what Cloud unlocks without triggering broken Cloud connector forms
- make bottom drawer grab handles visibly interactive with hover/focus affordances and click-to-close behavior

## Verification
- bun run --cwd eliza/packages/ui typecheck (run from /Users/user1/Sites/milady3, passed)
- bun run --cwd eliza/packages/ui test -- register-cloud-settings register-all settings-section (run from /Users/user1/Sites/milady3, passed; existing @stwd/react sourcemap warnings only)
- bunx vitest run apps/app/test/package-mode-aliases.test.ts (Milady integration regression, passed)
- git diff --check (run from /Users/user1/Sites/milady3 and eliza/, passed)
- built bundle contains the new Unlock with Cloud overview copy and drawer handle affordance strings, with no Settings chunk references to Cloud Connectors, cloud i18n provider errors, or cloud connector /api/v1 calls
- curl -fsS http://127.0.0.1:31337/api/agents returned running Eliza default agent
- curl -fsS http://127.0.0.1:31337/api/health returned ready true, runtime ok, plugins failed 0
- bun run dev:desktop:watch rebuilt and relaunched Electrobun after HMR could not reload the shared drawer modules in-place

Note: /tmp/eliza-cloud-connectors-i18n is a clean PR worktree without installed dependencies, so vitest/tsgo are unavailable there; checks above were run against the same patch in the dependency-installed Milady worktree.

Milady integration PR: https://github.com/milady-ai/milady/pull/2200