### PR TITLE
fix(discord): stop per-message guild REST fetch that stalls large servers

### DIFF
--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -573,7 +573,14 @@ export class MessageManager {
 		let messageServerId: string | undefined;
 
 		if (message.guild) {
-			const guild = await message.guild.fetch();
+			// Use the gateway-cached guild directly. The old `await message.guild.fetch()`
+			// issued a REST GET /guilds/{id} on EVERY message; in a large, busy guild
+			// (thousands of members) that per-message fetch storm saturates discord.js's
+			// REST queue and starves message handling — the bot goes silent in big
+			// servers while staying fine in small ones (rate-limits are queued, not
+			// thrown, so nothing shows in the logs). `guild.id` (all that's used below)
+			// is already on the cached object.
+			const guild = message.guild;
 			type = await this.getChannelType(message.channel as Channel);
 			if (type === null) {
 				// usually a forum type post


### PR DESCRIPTION
handleMessage did `await message.guild.fetch()` on every guild message — a REST GET /guilds/{id} per message when message.guild is already populated from the gateway. In a large, busy guild that per-message fetch storm saturates discord.js's REST queue (rate-limits are queued, not thrown, so it's silent in logs). Only `guild.id` was used, which the cached object already has. Use the cached guild directly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>