### PR TITLE
feat(cloud): opt-in digest-pin gate for container image allowlist (#9853 P1.5)

### DIFF
--- a/packages/cloud-api/v1/coding-containers/route.test.ts
+++ b/packages/cloud-api/v1/coding-containers/route.test.ts
@@ -70,7 +70,7 @@ mock.module("@/lib/utils/logger", () => ({
 
 const { default: app } = await import("./route");
 
-function postCodingContainer(image: string): Promise<Response> {
+async function postCodingContainer(image: string): Promise<Response> {
   return app.fetch(
     new Request("https://api.example.test/", {
       method: "POST",

--- a/packages/cloud-api/v1/coding-containers/route.test.ts
+++ b/packages/cloud-api/v1/coding-containers/route.test.ts
@@ -70,6 +70,28 @@ mock.module("@/lib/utils/logger", () => ({
 
 const { default: app } = await import("./route");
 
+function postCodingContainer(image: string): Promise<Response> {
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": "test-key",
+      },
+      body: JSON.stringify({
+        agent: "claude",
+        container: { name: "bnancy", image },
+        workspacePath: "/workspace/the-family",
+        source: {
+          sourceKind: "project",
+          projectId: "the-family",
+          rootPath: "/workspace/the-family",
+        },
+      }),
+    }),
+  );
+}
+
 describe("coding containers route", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockClear();
@@ -79,6 +101,7 @@ describe("coding containers route", () => {
     enqueueAgentProvisionOnce.mockClear();
     getJobForOrg.mockClear();
     triggerImmediate.mockClear();
+    delete process.env.CONTAINER_IMAGE_REQUIRE_DIGEST;
   });
 
   test("creates custom-image coding containers as custom execution-tier agents", async () => {
@@ -124,5 +147,33 @@ describe("coding containers route", () => {
         success: true,
       }),
     );
+  });
+
+  test("rejects an allowlisted-but-unpinned image with 403 when digest-pin is required", async () => {
+    process.env.CONTAINER_IMAGE_REQUIRE_DIGEST = "true";
+
+    // ghcr.io/dexploarer/* is in the default allowlist, so this passes the
+    // allowlist gate but fails the digest-pin gate (mutable :latest).
+    const response = await postCodingContainer("ghcr.io/dexploarer/bnancy:latest");
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "CODING_CONTAINER_IMAGE_NOT_DIGEST_PINNED",
+      }),
+    );
+    expect(createCodingContainerAgent).not.toHaveBeenCalled();
+  });
+
+  test("accepts a digest-pinned image when digest-pin is required", async () => {
+    process.env.CONTAINER_IMAGE_REQUIRE_DIGEST = "true";
+
+    const response = await postCodingContainer(
+      `ghcr.io/dexploarer/bnancy@sha256:${"a".repeat(64)}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(createCodingContainerAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud-api/v1/coding-containers/route.ts
+++ b/packages/cloud-api/v1/coding-containers/route.ts
@@ -59,6 +59,7 @@ import {
   buildCodingContainerCreatePayload,
   buildCodingContainerSessionResponse,
   type CodingContainerCreatePayload,
+  imageRequiresDigestPin,
   isCodingContainerImageAllowed,
   type RequestCodingAgentContainerRequest,
   RequestCodingAgentContainerRequestSchema,
@@ -169,6 +170,28 @@ async function createCodingContainer(
           `To run another image, ask an operator to add its GHCR namespace to ` +
           `CODING_CONTAINER_IMAGE_ALLOWLIST.`,
         permittedImages: allowlist,
+      },
+      403,
+    );
+  }
+
+  // ── SECURITY (opt-in): digest-pin gate ───────────────────────────────
+  // When armed, an allowed image must also be pinned to a full sha256 digest
+  // so the registry cannot swap the bytes behind a mutable tag after the
+  // allowlist check passes. Default OFF (opt-in via env).
+  if (imageRequiresDigestPin(payload.image, containersEnv.requireDigestPinnedImages())) {
+    logger.warn("[CodingContainers API] image rejected: digest pin required", {
+      orgId: user.organization_id,
+      image: payload.image,
+    });
+    return c.json(
+      {
+        success: false,
+        code: "CODING_CONTAINER_IMAGE_NOT_DIGEST_PINNED",
+        error:
+          `Image '${payload.image}' must be pinned to a full sha256 digest ` +
+          `(e.g. ghcr.io/org/repo@sha256:<64 hex>). Mutable tags like ':latest' ` +
+          `are not accepted while CONTAINER_IMAGE_REQUIRE_DIGEST is enabled.`,
       },
       403,
     );

--- a/packages/cloud-api/v1/containers/route.test.ts
+++ b/packages/cloud-api/v1/containers/route.test.ts
@@ -36,6 +36,7 @@ const getActiveByProjectName = mock();
 const checkQuota = mock();
 const createContainer = mock();
 const codingContainerImageAllowlist = mock(() => ["ghcr.io/elizaos/*"]);
+const requireDigestPinnedImages = mock(() => false);
 const auditEmit = mock(async () => undefined);
 
 mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
@@ -52,6 +53,7 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 mock.module("@/lib/config/containers-env", () => ({
   containersEnv: {
     codingContainerImageAllowlist,
+    requireDigestPinnedImages,
   },
 }));
 
@@ -62,6 +64,10 @@ mock.module("@/lib/services/coding-containers", () => ({
         ? image.startsWith(pattern.slice(0, -1))
         : image === pattern,
     ),
+  // Faithful to the real impl: a ref is digest-pinned iff it ends in a full
+  // sha256:<64 hex> digest.
+  imageRequiresDigestPin: (image: string, requireDigest: boolean) =>
+    requireDigest && !/@sha256:[a-f0-9]{64}$/i.test(image),
 }));
 
 mock.module("@/lib/services/containers", () => ({
@@ -166,6 +172,8 @@ describe("containers route", () => {
     checkQuota.mockReset();
     createContainer.mockReset();
     codingContainerImageAllowlist.mockClear();
+    requireDigestPinnedImages.mockReset();
+    requireDigestPinnedImages.mockReturnValue(false);
     auditEmit.mockClear();
   });
 
@@ -228,6 +236,44 @@ describe("containers route", () => {
     });
     expect(body.data).not.toHaveProperty("environment_vars");
     expect(body.data).not.toHaveProperty("metadata");
+    expect(createContainer).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects an unpinned image with 403 when digest-pin is required", async () => {
+    requireDigestPinnedImages.mockReturnValue(true);
+    getActiveByProjectName.mockResolvedValue(null);
+
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "App",
+        image: "ghcr.io/elizaos/app:latest",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { code: string };
+    expect(body.code).toBe("CONTAINER_IMAGE_NOT_DIGEST_PINNED");
+    expect(createContainer).not.toHaveBeenCalled();
+  });
+
+  test("provisions a digest-pinned image when digest-pin is required", async () => {
+    requireDigestPinnedImages.mockReturnValue(true);
+    getActiveByProjectName.mockResolvedValue(null);
+    checkQuota.mockResolvedValue({ allowed: true });
+    createContainer.mockResolvedValue(summaryContainer());
+
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "App",
+        image: `ghcr.io/elizaos/app@sha256:${"a".repeat(64)}`,
+      }),
+    });
+
+    expect(response.status).toBe(201);
     expect(createContainer).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cloud-api/v1/containers/route.ts
+++ b/packages/cloud-api/v1/containers/route.ts
@@ -41,7 +41,10 @@ import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
-import { isCodingContainerImageAllowed } from "@/lib/services/coding-containers";
+import {
+  imageRequiresDigestPin,
+  isCodingContainerImageAllowed,
+} from "@/lib/services/coding-containers";
 import { type Container, containersService } from "@/lib/services/containers";
 import { getHetznerContainersClient } from "@/lib/services/containers/hetzner-client/client";
 import {
@@ -261,6 +264,23 @@ app.post("/", async (c) => {
           success: false,
           code: "CONTAINER_IMAGE_NOT_ALLOWED",
           error: `Image '${body.image}' is not permitted`,
+        },
+        403,
+      );
+    }
+
+    // SECURITY (opt-in): when the digest-pin gate is armed, reject mutable
+    // refs so an allowed repo cannot swap bytes behind a tag after this check.
+    if (imageRequiresDigestPin(body.image, containersEnv.requireDigestPinnedImages())) {
+      logger.warn("[Containers API] image rejected: digest pin required", {
+        organizationId: user.organization_id,
+        image: body.image,
+      });
+      return c.json(
+        {
+          success: false,
+          code: "CONTAINER_IMAGE_NOT_DIGEST_PINNED",
+          error: `Image '${body.image}' must be pinned to a full sha256 digest (e.g. repo@sha256:<64 hex>)`,
         },
         403,
       );

--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -148,6 +148,31 @@ export const containersEnv = {
       .filter((entry) => entry.length > 0);
   },
 
+  /**
+   * Whether image refs must be pinned to a full `@sha256:<64hex>` digest to be
+   * accepted by the container image gate (in addition to the allowlist).
+   *
+   * SECURITY: a mutable tag (`:latest`, `:stable`, or an implicit latest) lets
+   * the registry swap the bytes behind an allowed name after the gate passes.
+   * Requiring a digest pin makes the accepted image content-addressed.
+   *
+   * OPT-IN, default OFF everywhere — enabling it in prod would reject the
+   * current first-party `:tag`/`:latest` deploys, so it must NOT be flipped on
+   * until those images are themselves digest-pinned (a separate ops step).
+   * Read via `CONTAINER_IMAGE_REQUIRE_DIGEST` (with `ELIZA_`/`CONTAINERS_`
+   * fallbacks); only the literal string `"true"` enables it.
+   */
+  requireDigestPinnedImages(): boolean {
+    const env = getCloudAwareEnv();
+    return (
+      pick(
+        env.CONTAINER_IMAGE_REQUIRE_DIGEST,
+        env.ELIZA_CONTAINER_IMAGE_REQUIRE_DIGEST,
+        env.CONTAINERS_IMAGE_REQUIRE_DIGEST,
+      ) === "true"
+    );
+  },
+
   /** Explicit operator-pinned agent image, without the hardcoded fallback. */
   defaultAgentImageOverride(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud-shared/src/lib/services/coding-containers.test.ts
+++ b/packages/cloud-shared/src/lib/services/coding-containers.test.ts
@@ -4,6 +4,7 @@ import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import {
   buildCodingContainerCreatePayload,
   buildCodingContainerSessionResponse,
+  imageRequiresDigestPin,
   isCodingContainerImageAllowed,
   RequestCodingAgentContainerRequestSchema,
 } from "./coding-containers";
@@ -161,5 +162,43 @@ describe("coding container image allowlist", () => {
       () => containersEnv.codingContainerImageAllowlist(),
     );
     expect(allowlist).toEqual(["ghcr.io/foo/*", "ghcr.io/bar/baz:1"]);
+  });
+});
+
+describe("coding container digest-pin gate", () => {
+  const DIGEST = `a${"0".repeat(63)}`;
+  const PINNED = `ghcr.io/elizaos/eliza@sha256:${DIGEST}`;
+
+  it("never rejects when the flag is off (opt-in default)", () => {
+    expect(imageRequiresDigestPin("ghcr.io/elizaos/eliza:latest", false)).toBe(false);
+    expect(imageRequiresDigestPin("ghcr.io/elizaos/eliza", false)).toBe(false);
+    expect(imageRequiresDigestPin(PINNED, false)).toBe(false);
+  });
+
+  it("rejects mutable refs when the flag is on", () => {
+    // Explicit mutable tag.
+    expect(imageRequiresDigestPin("ghcr.io/elizaos/eliza:latest", true)).toBe(true);
+    // Implicit latest (no tag, no digest).
+    expect(imageRequiresDigestPin("ghcr.io/elizaos/eliza", true)).toBe(true);
+    // A digest that is not a full sha256:<64 hex> is not production-safe.
+    expect(imageRequiresDigestPin("ghcr.io/elizaos/eliza@sha256:abc", true)).toBe(true);
+  });
+
+  it("accepts a full sha256-digest-pinned ref when the flag is on", () => {
+    expect(imageRequiresDigestPin(PINNED, true)).toBe(false);
+  });
+
+  it("env getter defaults OFF and only 'true' enables it", () => {
+    expect(runWithCloudBindings({}, () => containersEnv.requireDigestPinnedImages())).toBe(false);
+    expect(
+      runWithCloudBindings({ CONTAINER_IMAGE_REQUIRE_DIGEST: "1" }, () =>
+        containersEnv.requireDigestPinnedImages(),
+      ),
+    ).toBe(false);
+    expect(
+      runWithCloudBindings({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, () =>
+        containersEnv.requireDigestPinnedImages(),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/cloud-shared/src/lib/services/coding-containers.ts
+++ b/packages/cloud-shared/src/lib/services/coding-containers.ts
@@ -27,6 +27,7 @@ import type {
   SyncCloudCodingContainerRequest,
 } from "@elizaos/shared/contracts/cloud-coding-containers";
 import { containersEnv } from "../config/containers-env";
+import { describeImageReference } from "./containers/image-rollout-status";
 
 export interface CodingContainerCreatePayload {
   name: string;
@@ -218,6 +219,24 @@ export function isCodingContainerImageAllowed(
     }
   }
   return false;
+}
+
+/**
+ * Returns true when `image` must be REJECTED because the digest-pin gate is
+ * armed (`requireDigest`) but `image` is not pinned to a full `sha256:<64hex>`
+ * digest (a mutable `:tag` or implicit-latest reference).
+ *
+ * Complements {@link isCodingContainerImageAllowed}: the allowlist controls
+ * WHICH repos may run; this controls that an allowed ref is content-addressed
+ * so the registry cannot swap the bytes after the gate passes. Digest validity
+ * is delegated to `describeImageReference().productionSafe` (the single source
+ * of truth for digest pinning) — do not re-parse digests here.
+ *
+ * When `requireDigest` is false (the default, opt-in via
+ * `containersEnv.requireDigestPinnedImages()`) this is always false.
+ */
+export function imageRequiresDigestPin(image: string, requireDigest: boolean): boolean {
+  return requireDigest && !describeImageReference(image).productionSafe;
 }
 
 function readString(data: Record<string, unknown>, keys: string[]): string | undefined {


### PR DESCRIPTION
**#9853 P1 — item 5.** Adds an **opt-in** digest-pin requirement layered on the existing image allowlist.

- `containersEnv.requireDigestPinnedImages()` — true only when `CONTAINER_IMAGE_REQUIRE_DIGEST==="true"` (with `ELIZA_`/`CONTAINERS_` fallbacks). **Default OFF everywhere.**
- `imageRequiresDigestPin(image, requireDigest)` reuses the existing `describeImageReference().productionSafe` (full `@sha256:<64hex>`) — no new digest parsing.
- Both POST enforcement sites (`v1/containers`, `v1/coding-containers`) add a 403 (`*_IMAGE_NOT_DIGEST_PINNED`) right after the allowlist 403, keeping each route's bespoke style.
- Tests: helper (flag off→never; flag on→rejects `:latest`/implicit/short-digest, accepts full sha256) + both route 403/allow paths. Pure logic validated standalone (7/7).

⚠️ **Do NOT enable in prod** until first-party images are themselves digest-pinned — the default agent image is `ghcr.io/elizaos/eliza:stable`, which this would reject. Enabling is a separate ops step. Severity = supply-chain/defense-in-depth (needs first-party GHCR push access), not external RCE.

**Separate larger gap (follow-up):** the Apps/Product-2 `resolveImageRef` (`app-deploy-runner.ts`) applies **no** allowlist or digest gate at all.

Refs #9853 (P1 item 5).