### PR TITLE
fix(cloud): close rate-limit gaps + free-grant sybil cap (#9853 P1.1)

### DIFF
--- a/packages/cloud-api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud-api/auth/create-anonymous-session/route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Count how many anonymous users actually get minted (DB rows inserted).
+const createAnonymousUserAndSession = mock(async () => ({
+  newUser: { id: "anon-user" },
+  newSession: { id: "anon-session" },
+}));
+
+mock.module("@/lib/services/anonymous-session-creator", () => ({
+  createAnonymousUserAndSession,
+}));
+
+// In-memory Redis stand-in so the REAL rateLimit middleware enforces (it falls
+// open without a backing store). Implements the subset checkUpstash() uses.
+const store = new Map<string, { count: number; expireAt: number }>();
+const fakeRedis = {
+  async incr(key: string) {
+    const entry = store.get(key) ?? { count: 0, expireAt: Date.now() + 300_000 };
+    entry.count += 1;
+    store.set(key, entry);
+    return entry.count;
+  },
+  async pexpire(key: string, ms: number) {
+    const entry = store.get(key);
+    if (entry) entry.expireAt = Date.now() + ms;
+    return 1;
+  },
+  async pttl(key: string) {
+    const entry = store.get(key);
+    return entry ? Math.max(1, entry.expireAt - Date.now()) : -1;
+  },
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => fakeRedis,
+}));
+
+const { default: app } = await import("./route");
+
+const ENV = { REDIS_RATE_LIMITING: "true", NODE_ENV: "development" };
+
+function mint(ip: string) {
+  return app.fetch(
+    new Request("https://api.example.test/?returnUrl=/chat", {
+      headers: { "cf-connecting-ip": ip },
+    }),
+    ENV,
+  );
+}
+
+describe("create-anonymous-session anti-sybil rate limit", () => {
+  beforeEach(() => {
+    createAnonymousUserAndSession.mockClear();
+    store.clear();
+  });
+
+  test("caps anonymous mints per IP and stops creating users after the cap", async () => {
+    const ip = "203.0.113.7";
+    const statuses: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      statuses.push((await mint(ip)).status);
+    }
+
+    // CRITICAL preset = 5 per window: first 5 redirect (302), rest are 429.
+    expect(statuses.filter((s) => s === 302)).toHaveLength(5);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(2);
+
+    // The throttled requests never reached the handler, so no extra rows.
+    expect(createAnonymousUserAndSession).toHaveBeenCalledTimes(5);
+  });
+
+  test("a different IP gets its own fresh budget", async () => {
+    for (let i = 0; i < 6; i++) await mint("203.0.113.7");
+    expect((await mint("198.51.100.9")).status).toBe(302);
+  });
+});

--- a/packages/cloud-api/auth/create-anonymous-session/route.ts
+++ b/packages/cloud-api/auth/create-anonymous-session/route.ts
@@ -8,6 +8,11 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { nanoid } from "nanoid";
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createAnonymousUserAndSession } from "@/lib/services/anonymous-session-creator";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -34,6 +39,19 @@ function isValidReturnUrl(url: string): boolean {
 }
 
 const app = new Hono<AppEnv>();
+
+// Anti-sybil: this endpoint mints a brand-new anonymous user + session (→ free
+// metered inference) on every unauthenticated GET. Cap it tightly per source IP
+// (CRITICAL preset: 5 mints / 5 min) so it can't be used to farm anon accounts.
+// IP-keyed because there is no auth identity to key on. Enforced only when
+// REDIS_RATE_LIMITING=true (falls open otherwise — see ops note in #9853).
+app.use(
+  "*",
+  rateLimit({
+    ...RateLimitPresets.CRITICAL,
+    keyGenerator: (c) => `anon-mint:${getIpKey(c)}`,
+  }),
+);
 
 app.get("/", async (c) => {
   try {

--- a/packages/cloud-api/src/bootstrap-app.ts
+++ b/packages/cloud-api/src/bootstrap-app.ts
@@ -12,8 +12,14 @@ import { secureHeaders } from "hono/secure-headers";
 import { runWithDbCacheAsync } from "@/db/client";
 import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
+import {
+  getIpKey,
+  getRequestIp,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { runWithRequestContext } from "@/lib/runtime/request-context";
 import { configureAppsDeprovisionTrigger } from "@/lib/services/app-db-deprovision-job-service";
 import { configureAppsDeployTrigger } from "@/lib/services/app-deploy-job-service";
 import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
@@ -168,7 +174,12 @@ export function createApp(): Hono<AppEnv> {
     setRuntimeR2Bucket(c.env.BLOB);
     await runWithCloudBindingsAsync(
       c.env as Record<string, unknown>,
-      async () => runWithDbCacheAsync(async () => next()),
+      async () =>
+        // Expose the client IP to shared library code (anti-sybil grant checks)
+        // without threading it through every call site.
+        runWithRequestContext({ clientIp: getRequestIp(c) }, async () =>
+          runWithDbCacheAsync(async () => next()),
+        ),
     );
   });
 
@@ -246,6 +257,24 @@ export function createApp(): Hono<AppEnv> {
     );
   });
   app.route("/.well-known/jwks.json", jwksRoute);
+
+  // Global IP-keyed backstop limiter. Routes with their own (tighter) limiter
+  // still enforce it; this only guarantees that a route which forgot to add one
+  // is not completely unprotected against per-IP flooding. The ceiling is
+  // deliberately generous (10 req/s sustained) so it sits above every per-route
+  // policy and never interferes with legitimate traffic. Enforced only when
+  // REDIS_RATE_LIMITING=true (falls open otherwise). Registered before
+  // authMiddleware so unauthenticated routes are covered too.
+  app.use(
+    "*",
+    rateLimit({
+      windowMs: 60_000,
+      maxRequests: 600,
+      // Namespaced so this backstop counter never collides with a per-route
+      // IP-keyed limiter sharing the same `ip:<addr>` key.
+      keyGenerator: (c) => `global:${getIpKey(c)}`,
+    }),
+  );
 
   app.use("*", authMiddleware);
 

--- a/packages/cloud-shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud-shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -26,13 +26,22 @@ function getRedis(env: Bindings): CompatibleRedis | null {
   return buildRedisClient(env);
 }
 
-function getIpKey(c: Context): string {
-  const ip =
+/**
+ * Resolve the client IP, preferring `cf-connecting-ip` (set by Cloudflare and
+ * not spoofable by the client) over `x-forwarded-for` so a forged XFF header
+ * cannot evade IP-keyed limits. Returns `undefined` when no IP is known.
+ */
+function getRequestIp(c: Context): string | undefined {
+  return (
     c.req.header("cf-connecting-ip") ||
     c.req.header("x-real-ip") ||
     c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-    "unknown";
-  return `ip:${ip}`;
+    undefined
+  );
+}
+
+function getIpKey(c: Context): string {
+  return `ip:${getRequestIp(c) ?? "unknown"}`;
 }
 
 function getDefaultKey(c: AppContext): string {
@@ -196,5 +205,5 @@ export const RateLimitPresets = {
   AGGRESSIVE: { windowMs: 60_000, maxRequests: 100, keyGenerator: getIpKey },
 } as const;
 
-export { getDefaultKey, getIpKey };
+export { getDefaultKey, getIpKey, getRequestIp };
 export const _multiplier = multiplier;

--- a/packages/cloud-shared/src/lib/runtime/request-context.ts
+++ b/packages/cloud-shared/src/lib/runtime/request-context.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-request context for shared `packages/lib` code.
+ *
+ * The Cloud API wraps every request in `runWithRequestContext({ clientIp }, …)`
+ * so library code deep in the call tree (e.g. signup credit grants) can read the
+ * originating client IP for anti-sybil checks without threading it through every
+ * intermediate function. Mirrors the ambient pattern in `cloud-bindings.ts`.
+ *
+ * Outside a Worker request (no store), `getClientIp()` returns `undefined`.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface RequestContext {
+  clientIp?: string;
+}
+
+const als = new AsyncLocalStorage<RequestContext>();
+
+export async function runWithRequestContext<T>(
+  context: RequestContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await als.run(context, fn);
+}
+
+/** The originating client IP for the current request, or `undefined`. */
+export function getClientIp(): string | undefined {
+  return als.getStore()?.clientIp;
+}

--- a/packages/cloud-shared/src/lib/services/signup-grant-guard.test.ts
+++ b/packages/cloud-shared/src/lib/services/signup-grant-guard.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Each call to dbRead.execute returns the next queued count row.
+let nextCount = 0;
+const execute = mock(async () => ({ rows: [{ count: String(nextCount) }] }));
+
+mock.module("../../db/client", () => ({
+  dbRead: { execute },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { signupGrantAllowedForIp, FREE_GRANT_IP_LIMITS } = await import("./signup-grant-guard");
+
+const CAP = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
+
+describe("signupGrantAllowedForIp (anti-sybil free-grant cap)", () => {
+  beforeEach(() => {
+    execute.mockClear();
+    nextCount = 0;
+  });
+
+  test("falls open without querying when no IP is known", async () => {
+    expect(await signupGrantAllowedForIp(undefined)).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("allows grants below the daily cap", async () => {
+    nextCount = CAP - 1;
+    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  test("withholds the grant once the daily cap is reached", async () => {
+    nextCount = CAP;
+    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(false);
+  });
+
+  test("withholds the grant when the cap is exceeded", async () => {
+    nextCount = CAP + 5;
+    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud-shared/src/lib/services/signup-grant-guard.ts
@@ -44,11 +44,14 @@ export async function signupGrantAllowedForIp(ip: string | undefined): Promise<b
 
   const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
   if (granted >= FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY) {
-    logger.warn("[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus", {
-      ip: maskIp(ip),
-      granted,
-      cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
-    });
+    logger.warn(
+      "[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus",
+      {
+        ip: maskIp(ip),
+        granted,
+        cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
+      },
+    );
     return false;
   }
   return true;

--- a/packages/cloud-shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud-shared/src/lib/services/signup-grant-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * Anti-sybil guard for free welcome-bonus grants.
+ *
+ * New orgs receive INITIAL_FREE_CREDITS on signup (steward-sync + wallet-signup).
+ * Without a per-IP cap this is a free metered-inference faucet: an attacker can
+ * mint unlimited orgs from one host and farm the bonus. This caps the number of
+ * free grants per source IP per day, mirroring the IP_RATE_LIMITS anti-sybil
+ * pattern in `token-redemption-secure.ts` (which guards the redemption side).
+ *
+ * The grant sites record `metadata.ip_address` on each grant so this count is
+ * meaningful; when no IP is known the check falls open (cannot attribute).
+ */
+
+import { sql } from "drizzle-orm";
+import { dbRead } from "../../db/client";
+import { logger } from "../utils/logger";
+
+export const FREE_GRANT_IP_LIMITS = {
+  /** Max free welcome-bonus grants per source IP per rolling 24h. */
+  MAX_FREE_GRANTS_PER_IP_DAILY: 3,
+} as const;
+
+function maskIp(ip: string): string {
+  // IPv4: keep the first two octets; otherwise just the prefix.
+  const parts = ip.split(".");
+  return parts.length === 4 ? `${parts[0]}.${parts[1]}.x.x` : `${ip.slice(0, 4)}***`;
+}
+
+/**
+ * Returns `true` if a new-org welcome bonus may be granted for this IP, `false`
+ * if the per-IP daily cap is already reached. Falls open when `ip` is undefined.
+ */
+export async function signupGrantAllowedForIp(ip: string | undefined): Promise<boolean> {
+  if (!ip) return true;
+
+  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const result = await dbRead.execute(sql`
+    SELECT COUNT(*) AS count
+    FROM credit_transactions
+    WHERE metadata->>'ip_address' = ${ip}
+      AND metadata->>'type' IN ('initial_free_credits', 'wallet_signup')
+      AND created_at >= ${dayAgo}
+  `);
+
+  const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
+  if (granted >= FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY) {
+    logger.warn("[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus", {
+      ip: maskIp(ip),
+      granted,
+      cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
+    });
+    return false;
+  }
+  return true;
+}

--- a/packages/cloud-shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud-shared/src/lib/services/wallet-signup.ts
@@ -9,9 +9,11 @@ import type { Organization } from "../../db/repositories/organizations";
 import { organizationsRepository } from "../../db/repositories/organizations";
 import type { UserWithOrganization } from "../../db/repositories/users";
 import { usersRepository } from "../../db/repositories/users";
+import { getClientIp } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
 import { organizationsService } from "./organizations";
+import { signupGrantAllowedForIp } from "./signup-grant-guard";
 import { usersService } from "./users";
 
 export const INITIAL_FREE_CREDITS = ((): number => {
@@ -36,13 +38,20 @@ async function grantWalletSignupCredits(params: {
   requireInitialCredits: boolean;
 }): Promise<boolean> {
   if (params.amount <= 0) return false;
+
+  // Anti-sybil: withhold the bonus when this IP has hit the daily free-grant cap.
+  const signupIp = getClientIp();
+  if (!(await signupGrantAllowedForIp(signupIp))) {
+    return false;
+  }
+
   try {
     await creditsService.addCredits({
       organizationId: params.organizationId,
       amount: params.amount,
       description: "Wallet sign-up bonus",
       stripePaymentIntentId: params.idempotencyKey,
-      metadata: { type: "wallet_signup", chain: params.chain },
+      metadata: { type: "wallet_signup", chain: params.chain, ip_address: signupIp },
     });
     return true;
   } catch (err) {

--- a/packages/cloud-shared/src/lib/steward-sync.ts
+++ b/packages/cloud-shared/src/lib/steward-sync.ts
@@ -10,6 +10,7 @@
 
 import { organizationInvitesRepository } from "../db/repositories/organization-invites";
 import { usersRepository } from "../db/repositories/users";
+import { getClientIp } from "./runtime/request-context";
 import { apiKeysService } from "./services/api-keys";
 import { charactersService } from "./services/characters/characters";
 import { creditsService } from "./services/credits";
@@ -17,6 +18,7 @@ import { discordService } from "./services/discord";
 import { emailService } from "./services/email";
 import { invitesService } from "./services/invites";
 import { organizationsService } from "./services/organizations";
+import { signupGrantAllowedForIp } from "./services/signup-grant-guard";
 import { usersService } from "./services/users";
 import type { UserWithOrganization } from "./types";
 import { getDefaultElizaCharacterData } from "./utils/default-eliza-character";
@@ -421,10 +423,13 @@ export async function syncUserFromSteward(
     credit_balance: "0.00",
   });
 
-  // Add initial free credits
+  // Add initial free credits — withheld when this IP has already hit the daily
+  // free-grant cap (anti-sybil). Withholding is not a failure: the org is still
+  // created (at $0) and the signup proceeds.
   const initialCredits = getInitialCredits();
+  const signupIp = getClientIp();
 
-  if (initialCredits > 0) {
+  if (initialCredits > 0 && (await signupGrantAllowedForIp(signupIp))) {
     try {
       await creditsService.addCredits({
         organizationId: organization.id,
@@ -433,6 +438,7 @@ export async function syncUserFromSteward(
         metadata: {
           type: "initial_free_credits",
           source: "signup",
+          ip_address: signupIp,
         },
       });
     } catch (error) {


### PR DESCRIPTION
**#9853 P1 — item 1.** Closes the three confirmed gaps (code only; the prod `REDIS_RATE_LIMITING` flip is a separate ops step — limiters fall open until then).

1. **Global IP backstop** limiter in `createApp()` before `authMiddleware` (600/min/IP) so any route lacking its own limiter still gets per-IP flood protection.
2. **Anon-mint limiter** on `GET /api/auth/create-anonymous-session` (5/5min/IP) — the primary sybil vector into free metered inference (each mint = a fresh free-message allotment).
3. **Free-grant sybil cap**: per-IP daily cap (3/day) on the $5 welcome bonus at both grant sites (`steward-sync`, `wallet-signup`) via a new `signupGrantAllowedForIp` that counts prior free grants in `credit_transactions` (mirrors the `IP_RATE_LIMITS` pattern in `token-redemption-secure`). Client IP reaches the deep grant code via a request-context `AsyncLocalStorage` — **consistent with the existing `getCloudAwareEnv` ALS pattern**, no param threading. `getIpKey` confirmed to prefer `cf-connecting-ip` over `x-forwarded-for`.

Tests: anon-mint 7×→5×302+2×429 (real limiter + in-memory redis), grant-guard cap. Pure logic validated standalone.

**Reviewer caveats (from self-review):** (a) the anon test relies on `mock.module` intercepting the middleware's redis-factory import — CI confirms; (b) ALS only covers grant callers under `createApp`'s wrapper (paths outside fall open = safe-but-unprotected); (c) email-verified gating deferred (would deny wallet-only signups — product call); (d) `MAX_FREE_GRANTS_PER_IP_DAILY=3` may be low for shared NAT — tune pre-GA.

Refs #9853 (P1 item 1).