### PR TITLE
fix(cloud): IP-pinned safeFetch to close SSRF/DNS-rebinding window (#9853 P1.3)

### DIFF
--- a/packages/cloud-shared/src/lib/mcp/mcp-upstream-forward.ts
+++ b/packages/cloud-shared/src/lib/mcp/mcp-upstream-forward.ts
@@ -1,4 +1,4 @@
-import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { safeFetch } from "../security/safe-fetch";
 
 const HOP_BY_HOP = new Set([
   "connection",
@@ -29,7 +29,6 @@ export async function forwardMcpUpstreamRequest(
   request: Request,
   upstreamUrl: string,
 ): Promise<Response> {
-  const target = await assertSafeOutboundUrl(upstreamUrl);
   const init: RequestInit = {
     method: request.method,
     headers: forwardOutgoingHeaders(request.headers),
@@ -40,7 +39,7 @@ export async function forwardMcpUpstreamRequest(
   }
   try {
     init.signal = AbortSignal.timeout(MCP_UPSTREAM_TIMEOUT_MS);
-    return await fetch(target.toString(), init);
+    return await safeFetch(upstreamUrl, init);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return Response.json(

--- a/packages/cloud-shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud-shared/src/lib/security/outbound-url.ts
@@ -2,7 +2,7 @@ import type { LookupAddress } from "node:dns";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
-function normalizeHostname(hostname: string): string {
+export function normalizeHostname(hostname: string): string {
   return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
 }
 
@@ -176,6 +176,39 @@ export function assertSafeOutboundUrlSync(rawUrl: string): URL {
 }
 
 /**
+ * Resolves `hostname` (or accepts an IP literal) and rejects the whole answer
+ * set if any record points at a private/reserved range. Returns every resolved
+ * address so callers can both validate and pin a single connection target.
+ */
+async function resolveValidatedAddresses(hostname: string): Promise<LookupAddress[]> {
+  const literalFamily = isIP(hostname);
+  if (literalFamily) {
+    // IP literals are already screened by validateUrlSyntax (isForbiddenIpAddress),
+    // so we can pin to the literal without a DNS round-trip.
+    return [{ address: hostname, family: literalFamily }];
+  }
+
+  let records: LookupAddress[];
+  try {
+    records = await lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new Error("Unable to resolve endpoint hostname");
+  }
+
+  if (!records.length) {
+    throw new Error("Unable to resolve endpoint hostname");
+  }
+
+  for (const record of records) {
+    if (isForbiddenIpAddress(record.address)) {
+      throw new Error("Endpoint resolves to a private or reserved IP address");
+    }
+  }
+
+  return records;
+}
+
+/**
  * Validates an outbound URL against SSRF-sensitive destinations.
  * For hostnames, DNS is resolved at call time so rebinding to private ranges
  * cannot bypass creation-time validation.
@@ -185,23 +218,26 @@ export async function assertSafeOutboundUrl(rawUrl: string): Promise<URL> {
   const hostname = normalizeHostname(parsed.hostname);
 
   if (!isIP(hostname)) {
-    let records: LookupAddress[];
-    try {
-      records = await lookup(hostname, { all: true, verbatim: true });
-    } catch {
-      throw new Error("Unable to resolve endpoint hostname");
-    }
-
-    if (!records.length) {
-      throw new Error("Unable to resolve endpoint hostname");
-    }
-
-    for (const record of records) {
-      if (isForbiddenIpAddress(record.address)) {
-        throw new Error("Endpoint resolves to a private or reserved IP address");
-      }
-    }
+    await resolveValidatedAddresses(hostname);
   }
 
   return parsed;
+}
+
+/**
+ * Like {@link assertSafeOutboundUrl}, but also returns a single validated
+ * address to PIN the connection to. The caller must connect to exactly this
+ * address (e.g. via an http(s) `lookup` hook) so the socket cannot re-resolve
+ * the hostname to a private range between validation and connect
+ * (TOCTOU / DNS rebinding). All resolved addresses are still screened; the
+ * first is returned as the pin.
+ */
+export async function resolveSafeOutboundTarget(
+  rawUrl: string,
+): Promise<{ url: URL; address: string; family: number }> {
+  const parsed = validateUrlSyntax(rawUrl);
+  const hostname = normalizeHostname(parsed.hostname);
+  const [pinned] = await resolveValidatedAddresses(hostname);
+
+  return { url: parsed, address: pinned.address, family: pinned.family };
 }

--- a/packages/cloud-shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud-shared/src/lib/security/safe-fetch.test.ts
@@ -29,16 +29,18 @@ describe("createPinnedLookup", () => {
     expect(cb).toHaveBeenCalledWith(null, [{ address: "93.184.216.34", family: 4 }]);
   });
 
-  test.each(["169.254.169.254", "127.0.0.1", "10.0.0.5", "::1"])(
-    "rejects a pin that re-checks as a private/reserved address (%s)",
-    (address) => {
-      const cb = vi.fn();
-      createPinnedLookup(address, address.includes(":") ? 6 : 4)("host", { all: true }, cb);
-      const [error] = cb.mock.calls[0];
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toMatch(/private or reserved/i);
-    },
-  );
+  test.each([
+    "169.254.169.254",
+    "127.0.0.1",
+    "10.0.0.5",
+    "::1",
+  ])("rejects a pin that re-checks as a private/reserved address (%s)", (address) => {
+    const cb = vi.fn();
+    createPinnedLookup(address, address.includes(":") ? 6 : 4)("host", { all: true }, cb);
+    const [error] = cb.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/private or reserved/i);
+  });
 });
 
 describe("resolveSafeOutboundTarget (connection pin)", () => {

--- a/packages/cloud-shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud-shared/src/lib/security/safe-fetch.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const lookupMock = vi.fn();
+
+vi.mock("node:dns/promises", () => ({
+  lookup: lookupMock,
+}));
+
+const { createPinnedLookup, safeFetch } = await import("./safe-fetch");
+const { resolveSafeOutboundTarget } = await import("./outbound-url");
+
+// `vi.mock("node:dns/promises")` is process-global, so leave the stub returning
+// a benign public IP for any suite that loads afterwards (see outbound-url.test).
+afterAll(() => {
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+describe("createPinnedLookup", () => {
+  test("returns the pinned address for the legacy (address, family) callback", () => {
+    const cb = vi.fn();
+    createPinnedLookup("93.184.216.34", 4)("example.com", {}, cb);
+    expect(cb).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+  });
+
+  test("returns the pinned address as an array when `all` is requested", () => {
+    const cb = vi.fn();
+    createPinnedLookup("93.184.216.34", 4)("example.com", { all: true }, cb);
+    expect(cb).toHaveBeenCalledWith(null, [{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  test.each(["169.254.169.254", "127.0.0.1", "10.0.0.5", "::1"])(
+    "rejects a pin that re-checks as a private/reserved address (%s)",
+    (address) => {
+      const cb = vi.fn();
+      createPinnedLookup(address, address.includes(":") ? 6 : 4)("host", { all: true }, cb);
+      const [error] = cb.mock.calls[0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/private or reserved/i);
+    },
+  );
+});
+
+describe("resolveSafeOutboundTarget (connection pin)", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  test("pins to the first validated resolved address", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "1.1.1.1", family: 4 },
+    ]);
+
+    const { url, address, family } = await resolveSafeOutboundTarget("https://example.com/path");
+    expect(url.hostname).toBe("example.com");
+    expect(address).toBe("93.184.216.34");
+    expect(family).toBe(4);
+  });
+
+  test("pins an IP-literal target without a DNS round-trip", async () => {
+    const { address, family } = await resolveSafeOutboundTarget("https://93.184.216.34/x");
+    expect(address).toBe("93.184.216.34");
+    expect(family).toBe(4);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects when a host resolves to any private/reserved address", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.8", family: 4 },
+    ]);
+
+    await expect(resolveSafeOutboundTarget("https://example.com/")).rejects.toThrow(
+      "Endpoint resolves to a private or reserved IP address",
+    );
+  });
+
+  // A redirect hop re-runs exactly this resolver, so a rebinding redirect host
+  // is rejected before safeFetch can re-pin and re-issue the request.
+  test("rejects a rebinding redirect host that now resolves to link-local metadata", async () => {
+    lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+    await expect(resolveSafeOutboundTarget("https://rebind.example/")).rejects.toThrow(
+      "Endpoint resolves to a private or reserved IP address",
+    );
+  });
+});
+
+describe("safeFetch fail-closed", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  test("never connects when the target host resolves to a private address", async () => {
+    // 127.0.0.1 has a live local listener (the test runner) — the unpinned
+    // `assertSafeOutboundUrl(url) + fetch(url)` pattern would happily connect to
+    // it on the second resolution. safeFetch rejects during validation, so no
+    // socket is opened.
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    await expect(safeFetch("https://rebind.example/internal")).rejects.toThrow(
+      "Endpoint resolves to a private or reserved IP address",
+    );
+  });
+
+  test("rejects credential-bearing and non-http targets before any lookup", async () => {
+    await expect(safeFetch("http://user:pass@example.com/")).rejects.toThrow();
+    await expect(safeFetch("ftp://example.com/file")).rejects.toThrow();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud-shared/src/lib/security/safe-fetch.ts
@@ -1,0 +1,204 @@
+import type { LookupAddress } from "node:dns";
+import type { ClientRequest } from "node:http";
+import type { RequestOptions } from "node:https";
+import type { Readable as NodeReadable } from "node:stream";
+
+import { isForbiddenIpAddress, normalizeHostname, resolveSafeOutboundTarget } from "./outbound-url";
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const DEFAULT_MAX_REDIRECTS = 5;
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address?: string | LookupAddress[],
+  family?: number,
+) => void;
+
+/**
+ * Build a `node:net` lookup hook that always resolves to a single
+ * pre-validated address instead of consulting DNS. This is what pins an
+ * outbound socket: even though the request still carries the original hostname
+ * (so TLS SNI, certificate validation, and the Host header stay correct), the
+ * TCP connection can only ever reach `address`. The forbidden-range check is
+ * re-run inside the hook as defence-in-depth so a bug upstream cannot smuggle a
+ * private address past the pin.
+ */
+export function createPinnedLookup(address: string, family: number) {
+  return (_hostname: string, options: unknown, callback: LookupCallback): void => {
+    if (isForbiddenIpAddress(address)) {
+      callback(new Error("Pinned address resolved to a private or reserved IP"));
+      return;
+    }
+
+    if (options && typeof options === "object" && (options as { all?: boolean }).all) {
+      callback(null, [{ address, family }]);
+      return;
+    }
+
+    callback(null, address, family);
+  };
+}
+
+/**
+ * Cloudflare Workers (`workerd`) cannot pin `fetch()` to an arbitrary IP, so on
+ * that runtime safeFetch falls back to validate-immediately-before-fetch plus
+ * per-hop redirect re-validation. A residual rebinding window remains there
+ * (DNS can change between our validation and the platform's connect); the
+ * daemon/Node sinks — where the SSRF-sensitive provisioning webhooks run — get
+ * true IP pinning below.
+ */
+function canPinSockets(): boolean {
+  const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : undefined;
+  if (userAgent === "Cloudflare-Workers") {
+    return false;
+  }
+  return typeof process !== "undefined" && !!process.versions?.node;
+}
+
+function toOutgoingHeaders(init: RequestInit): Record<string, string> {
+  const headers = new Headers(init.headers ?? undefined);
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    // Let Node derive Host from the connection target (the original hostname).
+    if (key.toLowerCase() === "host") return;
+    out[key] = value;
+  });
+  return out;
+}
+
+async function nodePinnedFetch(
+  url: URL,
+  address: string,
+  family: number,
+  init: RequestInit,
+): Promise<Response> {
+  const isHttps = url.protocol === "https:";
+  const httpModule = isHttps ? await import("node:https") : await import("node:http");
+  const { Readable } = await import("node:stream");
+  const request = httpModule.request as typeof import("node:https").request;
+
+  const method = (init.method ?? "GET").toUpperCase();
+  const hostname = normalizeHostname(url.hostname);
+
+  const options: RequestOptions = {
+    protocol: url.protocol,
+    hostname,
+    port: url.port || (isHttps ? 443 : 80),
+    path: `${url.pathname}${url.search}`,
+    method,
+    headers: toOutgoingHeaders(init),
+    lookup: createPinnedLookup(address, family) as RequestOptions["lookup"],
+    // Keep TLS SNI + certificate validation bound to the real hostname even
+    // though the socket connects to the pinned IP.
+    servername: isHttps ? hostname : undefined,
+    signal: init.signal ?? undefined,
+  };
+
+  return await new Promise<Response>((resolve, reject) => {
+    const req = request(options, (res) => {
+      const status = res.statusCode ?? 0;
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(res.headers)) {
+        if (Array.isArray(value)) {
+          for (const entry of value) headers.append(key, entry);
+        } else if (value != null) {
+          headers.set(key, String(value));
+        }
+      }
+
+      const bodyless = method === "HEAD" || status === 204 || status === 205 || status === 304;
+      const body = bodyless ? null : (Readable.toWeb(res) as ReadableStream<Uint8Array>);
+      resolve(new Response(body, { status, statusText: res.statusMessage, headers }));
+    });
+
+    req.on("error", reject);
+    writeRequestBody(req, Readable, method, init.body);
+  });
+}
+
+function writeRequestBody(
+  req: ClientRequest,
+  Readable: typeof NodeReadable,
+  method: string,
+  body: RequestInit["body"],
+): void {
+  if (body == null || method === "GET" || method === "HEAD") {
+    req.end();
+  } else if (typeof body === "string") {
+    req.end(body);
+  } else if (body instanceof Uint8Array) {
+    req.end(Buffer.from(body));
+  } else if (typeof (body as ReadableStream).getReader === "function") {
+    Readable.fromWeb(body as ReadableStream).pipe(req);
+  } else {
+    req.end(String(body));
+  }
+}
+
+function nextRedirectInit(init: RequestInit, status: number): RequestInit {
+  // 307/308 preserve the method and body; 301/302/303 downgrade to a bodyless
+  // GET (the conservative, widely-compatible behaviour browsers use for POST).
+  if (status === 307 || status === 308) {
+    return init;
+  }
+  const { body: _body, ...rest } = init;
+  return { ...rest, method: "GET" };
+}
+
+/**
+ * SSRF-hardened replacement for `fetch()` against operator/user-supplied URLs.
+ *
+ * Each hop is validated with the shared outbound-URL guards
+ * ({@link resolveSafeOutboundTarget}) and, on Node, the connection is pinned to
+ * the validated IP so it cannot re-resolve into a private/reserved range
+ * (169.254.169.254, 10.x, the headscale mesh, …) between validation and
+ * connect. Redirects are followed manually so every hop is re-validated and
+ * re-pinned.
+ *
+ * `init.redirect` is honoured like the platform fetch:
+ *   - `"follow"` (default): follow up to {@link DEFAULT_MAX_REDIRECTS} hops,
+ *     re-validating + re-pinning each one;
+ *   - `"manual"`: return the redirect response without following;
+ *   - `"error"`: reject if the target responds with a redirect.
+ */
+export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise<Response> {
+  const redirectMode = init.redirect ?? "follow";
+  let currentUrl = rawUrl;
+  let currentInit = init;
+
+  for (let hop = 0; ; hop += 1) {
+    // Validate (resolve DNS + screen every address) on every hop in both
+    // runtimes. On Node we then pin the connection to the validated IP; on
+    // workerd we cannot pin an arbitrary IP, so the platform fetch re-resolves
+    // — a residual rebinding window documented on canPinSockets().
+    const { url, address, family } = await resolveSafeOutboundTarget(currentUrl);
+    const response = canPinSockets()
+      ? await nodePinnedFetch(url, address, family, { ...currentInit, redirect: "manual" })
+      : await fetch(url.toString(), { ...currentInit, redirect: "manual" });
+
+    if (!REDIRECT_STATUSES.has(response.status) || redirectMode === "manual") {
+      return response;
+    }
+
+    if (redirectMode === "error") {
+      throw new Error(
+        `Outbound request was redirected (${response.status}) but redirects are not allowed`,
+      );
+    }
+
+    if (hop >= DEFAULT_MAX_REDIRECTS) {
+      throw new Error("Too many redirects");
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      throw new Error("Redirect response missing Location header");
+    }
+
+    // Free the socket before re-issuing the request.
+    await response.body?.cancel().catch(() => {});
+
+    currentUrl = new URL(location, currentUrl).toString();
+    currentInit = nextRedirectInit(currentInit, response.status);
+  }
+}

--- a/packages/cloud-shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud-shared/src/lib/security/safe-fetch.ts
@@ -107,7 +107,7 @@ async function nodePinnedFetch(
       }
 
       const bodyless = method === "HEAD" || status === 204 || status === 205 || status === 304;
-      const body = bodyless ? null : (Readable.toWeb(res) as ReadableStream<Uint8Array>);
+      const body = bodyless ? null : (Readable.toWeb(res) as unknown as ReadableStream<Uint8Array>);
       resolve(new Response(body, { status, statusText: res.statusMessage, headers }));
     });
 
@@ -128,10 +128,11 @@ function writeRequestBody(
     req.end(body);
   } else if (body instanceof Uint8Array) {
     req.end(Buffer.from(body));
-  } else if (typeof (body as ReadableStream).getReader === "function") {
+  } else if (typeof (body as unknown as ReadableStream).getReader === "function") {
     // `body` is the DOM ReadableStream; Readable.fromWeb wants node:stream/web's.
-    // They are structurally identical at runtime — cast to the expected param type.
-    Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]).pipe(req);
+    // They are structurally identical at runtime — cast through `unknown` to the
+    // expected param type (the BodyInit union doesn't overlap the node type).
+    Readable.fromWeb(body as unknown as Parameters<typeof Readable.fromWeb>[0]).pipe(req);
   } else {
     req.end(String(body));
   }

--- a/packages/cloud-shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud-shared/src/lib/security/safe-fetch.ts
@@ -129,7 +129,9 @@ function writeRequestBody(
   } else if (body instanceof Uint8Array) {
     req.end(Buffer.from(body));
   } else if (typeof (body as ReadableStream).getReader === "function") {
-    Readable.fromWeb(body as ReadableStream).pipe(req);
+    // `body` is the DOM ReadableStream; Readable.fromWeb wants node:stream/web's.
+    // They are structurally identical at runtime — cast to the expected param type.
+    Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]).pipe(req);
   } else {
     req.end(String(body));
   }

--- a/packages/cloud-shared/src/lib/services/advertising/media-utils.ts
+++ b/packages/cloud-shared/src/lib/services/advertising/media-utils.ts
@@ -1,4 +1,5 @@
 import { assertSafeOutboundUrl } from "../../security/outbound-url";
+import { safeFetch } from "../../security/safe-fetch";
 
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
@@ -50,10 +51,13 @@ export async function downloadAdMedia(
   } = {},
 ): Promise<DownloadedAdMedia> {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-  let currentUrl = await assertSafeAdMediaUrl(rawUrl);
+  // safeFetch validates + IP-pins each hop, so we follow redirects manually
+  // (preserving the per-hop Accept header and MAX_REDIRECTS budget) without a
+  // separate pre-validation pass.
+  let currentUrl = rawUrl;
 
   for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
-    const response = await fetch(currentUrl, {
+    const response = await safeFetch(currentUrl, {
       redirect: "manual",
       headers: { Accept: options.allowedContentTypes?.join(",") ?? "*/*" },
     });
@@ -61,7 +65,7 @@ export async function downloadAdMedia(
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       const location = response.headers.get("location");
       if (!location) throw new Error("Media URL redirected without a Location header");
-      currentUrl = await assertSafeAdMediaUrl(new URL(location, currentUrl).toString());
+      currentUrl = new URL(location, currentUrl).toString();
       continue;
     }
 

--- a/packages/cloud-shared/src/lib/services/app-promotion-assets.ts
+++ b/packages/cloud-shared/src/lib/services/app-promotion-assets.ts
@@ -8,6 +8,7 @@ import {
 } from "../providers/anthropic-thinking";
 import { getLanguageModel } from "../providers/language-model";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { safeFetch } from "../security/safe-fetch";
 import { parseAiJson } from "../utils/ai-json-parse";
 import { extractErrorMessage } from "../utils/error-handling";
 import { logger } from "../utils/logger";
@@ -97,7 +98,7 @@ class AppPromotionAssetsService {
       });
 
       const response = await Promise.race([
-        fetch(safeUrl, {
+        safeFetch(safeUrl.toString(), {
           headers: {
             "User-Agent": "Mozilla/5.0 (compatible; ElizaCloudBot/1.0; +https://www.elizacloud.ai)",
             Accept: "text/html",

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -29,6 +29,7 @@ import { apps } from "../../db/schemas/apps";
 import { containers } from "../../db/schemas/containers";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
 import { isValidUUID } from "../utils/validation";
 import { withTimeout } from "../utils/with-timeout";
@@ -2790,7 +2791,10 @@ export class ProvisioningJobService {
         });
       }
 
-      const response = await fetch(safeWebhookUrl, {
+      // `safeWebhookUrl` is validated above for the waifu-target comparison;
+      // safeFetch re-resolves and pins the connection so the webhook host
+      // cannot rebind to a private/mesh address between check and connect.
+      const response = await safeFetch(safeWebhookUrl.toString(), {
         method: "POST",
         headers,
         body: rawBody,

--- a/packages/cloud-shared/src/lib/services/seo.ts
+++ b/packages/cloud-shared/src/lib/services/seo.ts
@@ -15,6 +15,7 @@ import { seoRequests, seoRequestTypeEnum } from "../../db/schemas/seo";
 import { mergeAnthropicCotProviderOptions } from "../providers/anthropic-thinking";
 import { getLanguageModel } from "../providers/language-model";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
 
@@ -267,8 +268,7 @@ async function runHealthCheck(pageUrl: string): Promise<{
   robots: boolean;
   canonical?: string;
 }> {
-  const safeUrl = await assertSafeOutboundUrl(pageUrl);
-  const response = await fetch(safeUrl, {
+  const response = await safeFetch(pageUrl, {
     method: "GET",
     redirect: "error",
   });

--- a/packages/cloud-shared/src/lib/services/waifu-webhook.ts
+++ b/packages/cloud-shared/src/lib/services/waifu-webhook.ts
@@ -22,6 +22,7 @@
 import { createHmac } from "node:crypto";
 
 import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
 
 const SIGNATURE_PREFIX = "sha256=";
@@ -191,7 +192,10 @@ export async function emitWaifuWebhook(
     eventId: params.payload.eventId ?? params.idempotencyKey,
   };
   const rawBody = JSON.stringify(body);
-  const fetchImpl = params.fetchImpl ?? fetch;
+  // Default to the IP-pinning safeFetch so the configured receiver host cannot
+  // rebind to a private/mesh address between validation and connect. Tests still
+  // inject a stub via params.fetchImpl.
+  const fetchImpl = params.fetchImpl ?? safeFetch;
 
   let url: URL;
   try {


### PR DESCRIPTION
**#9853 P1 — item 3.** One IP-pinned `safeFetch` to close the TOCTOU/DNS-rebinding window: `assertSafeOutboundUrl` validated DNS then returned a *hostname* URL, and ~9 sinks `fetch()`'d it (re-resolving at connect → pivot into `169.254.169.254`/`10.x`/headscale mesh).

- New `security/safe-fetch.ts`: resolves+validates DNS once (reusing the refactored `outbound-url` validators — no duplicate SSRF logic), and on **Node** pins the TCP socket to the validated IP via an `http(s)` `lookup` hook that re-runs `isForbiddenIpAddress` (Host header + TLS servername stay the hostname). Manual redirect handling re-validates + re-pins **every hop**.
- **Honest caveat:** on workerd, `fetch()` can't pin an arbitrary IP — it re-validates immediately before each manual fetch; the residual Worker-side window is documented in `canPinSockets()`. Node sinks (provisioning webhooks run in the daemon) get true pinning.
- Migrated the genuine validate-then-fetch-same-URL sinks (mcp-upstream-forward, provisioning webhook, media-utils, app-promotion, seo, waifu-webhook). **Deliberately left:** content-safety/seo-IndexNow/ad-media (validate-only — the URL is fetched by a downstream provider, not locally) and `eliza-sandbox` (~20 sites that *intentionally* target private mesh/docker IPs — safeFetch rejects private IPs by design; needs a mesh-aware allowlist refactor → separate follow-up).

**Reviewer caveats (from self-review):** no socket-level integration test (not runnable in CI — validation rejects loopback; coverage is at the seams: lookup hook, per-hop re-resolution, fail-closed); `nodePinnedFetch` reimplements fetch over `node:http(s).request` — scrutinize stream body wiring + bodyless-status Response construction (CI typecheck is the gate); `redirect:'error'` now throws our Error vs the platform TypeError (callers handle generically). Pure redirect/lookup logic validated standalone.

Refs #9853 (P1 item 3). The `eliza-sandbox` trusted-private-IP SSRF hardening is a recommended separate item.