### PR TITLE
ci(cloud): gate tenant isolation — wire REVOKE-CONNECT proof + static pk-only-read check (#9853 P1.6)

### DIFF
--- a/.github/workflows/apps-deploy-e2e.yml
+++ b/.github/workflows/apps-deploy-e2e.yml
@@ -25,6 +25,7 @@ on:
       - "packages/cloud-shared/src/lib/services/tenant-db/**"
       - "packages/cloud-shared/scripts/verify-e2e-deploy.sh"
       - "packages/cloud-shared/scripts/verify-e2e-container-db.sh"
+      - "packages/cloud-shared/scripts/verify-tenant-db-isolation.ts"
       - "packages/cloud-shared/scripts/_e2e-build.ts"
       - "packages/cloud-shared/scripts/e2e-sample-app/**"
       - ".github/workflows/apps-deploy-e2e.yml"
@@ -56,3 +57,32 @@ jobs:
       - name: E2E — real-docker tenant-DB isolation (REVOKE CONNECT + --internal no-egress)
         working-directory: packages/cloud-shared
         run: bash scripts/verify-e2e-container-db.sh
+
+  tenant-db-isolation:
+    name: Tenant-DB isolation — cross-tenant REVOKE CONNECT (throwaway Postgres) (#9853)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Lightweight pg-only proof (no docker): provision two tenants through the
+    # real SqlTenantDbProvisioner against a throwaway Postgres and assert tenant
+    # A cannot connect to tenant B's database. Wires the previously-orphaned
+    # verify-tenant-db-isolation.ts into CI.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: adminpw
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: ./.github/actions/cloud-setup-test-env
+
+      - name: Verify cross-tenant REVOKE CONNECT on per-tenant databases
+        working-directory: packages/cloud-shared
+        run: bun run verify:tenant-isolation

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Lint and typecheck cloud workspaces
         run: bun run verify:cloud
 
+      - name: Tenant-scope gate (no unscoped pk-only reads of apps data-plane) (#9853)
+        run: bun run --cwd packages/cloud-shared check:tenant-scope
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/packages/cloud-shared/package.json
+++ b/packages/cloud-shared/package.json
@@ -20,6 +20,8 @@
     "lint": "bunx @biomejs/biome check .",
     "lint:fix": "bunx @biomejs/biome check --write .",
     "typecheck": "tsgo --noEmit",
+    "check:tenant-scope": "bun scripts/check-tenant-scope.ts",
+    "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",
     "test": "bun test --isolate",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",

--- a/packages/cloud-shared/scripts/__fixtures__/tenant-scope/scoped.ts
+++ b/packages/cloud-shared/scripts/__fixtures__/tenant-scope/scoped.ts
@@ -1,0 +1,23 @@
+/**
+ * Parse-only fixture for the tenant-scope gate (#9853 P1.6). Never executed.
+ * Exercises BOTH opt-outs the checker accepts: an explicit `global-scope`
+ * annotation, and a real ownership predicate in the WHERE. The checker must
+ * find zero violations here.
+ */
+declare const dbRead: { query: { apps: { findFirst(args: unknown): Promise<unknown> } } };
+declare function eq(a: unknown, b: unknown): unknown;
+declare function and(...parts: unknown[]): unknown;
+declare const apps: { id: unknown; organization_id: unknown };
+
+export class ScopedFixtureRepo {
+  async findByIdGlobal(id: string): Promise<unknown> {
+    /* global-scope: fixture — authorization handled by the caller. */
+    return await dbRead.query.apps.findFirst({ where: eq(apps.id, id) });
+  }
+
+  async findScoped(orgId: string, id: string): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({
+      where: and(eq(apps.organization_id, orgId), eq(apps.id, id)),
+    });
+  }
+}

--- a/packages/cloud-shared/scripts/__fixtures__/tenant-scope/unscoped.ts
+++ b/packages/cloud-shared/scripts/__fixtures__/tenant-scope/unscoped.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse-only fixture for the tenant-scope gate (#9853 P1.6). Never executed;
+ * check-tenant-scope.ts reads it as text. Mirrors a repository doing a pk-only
+ * read against a tenant data-plane table WITHOUT a scope annotation — the
+ * checker must flag exactly one violation here.
+ */
+declare const dbRead: { query: { apps: { findFirst(args: unknown): Promise<unknown> } } };
+declare function eq(a: unknown, b: unknown): unknown;
+declare const apps: { id: unknown; organization_id: unknown };
+
+export class UnscopedFixtureRepo {
+  async findById(id: string): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({ where: eq(apps.id, id) });
+  }
+}

--- a/packages/cloud-shared/scripts/check-tenant-scope.ts
+++ b/packages/cloud-shared/scripts/check-tenant-scope.ts
@@ -1,0 +1,164 @@
+/**
+ * Static tenant-scope gate (#9853 P1.6, GAP B).
+ *
+ * Scans the cloud-shared repositories for reads/updates/deletes against the
+ * Product-2 *apps tenant data-plane* whose WHERE clause is ONLY the primary-key
+ * `id` (`eq(<table>.id, _)`) with no organization/app ownership predicate. Such
+ * pk-only access trusts the caller to have already authorized ownership, so a
+ * NEW unscoped query against a tenant table must not land silently before GA.
+ *
+ * A method may opt out with an explicit annotation that documents WHY the
+ * lookup is intentionally id-only (e.g. authorization happens in the route
+ * handler, or the id was just resolved from an owned row):
+ *
+ *     /* global-scope: <reason> *\/
+ *
+ * Scope note: this enforces only the apps surface that #9853 hardens, not every
+ * `organization_id` table — the repository layer is pk-based across ~60 tables
+ * by design, and blanket-annotating all of them is out of scope for this item.
+ *
+ * Exits non-zero on any unannotated violation. Importing this module is
+ * side-effect-free; only the CLI block below scans the real tree.
+ */
+import { globSync, readFileSync } from "node:fs";
+import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/**
+ * The Product-2 apps tenant data-plane: tables holding per-tenant app rows where
+ * a cross-tenant id read is the #9853 GA risk. Add new apps-plane tables here as
+ * the surface grows; widening the gate to every `organization_id` table is a
+ * separate, larger decision (tracked for the lead).
+ */
+export const TENANT_DATA_PLANE_TABLES = new Set<string>([
+  "apps",
+  "appUsers",
+  "appRequests",
+  "appConfig",
+  "appDomains",
+  "appDatabases",
+  "appCreditBalances",
+  "appEarnings",
+]);
+
+export interface TenantScopeViolation {
+  file: string;
+  line: number;
+  table: string;
+  method: string;
+}
+
+const ALLOW_ANNOTATION = /global-scope:/;
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(file, readFileSync(file, "utf8"), ts.ScriptTarget.Latest, true);
+}
+
+/**
+ * If `where` is a SOLE `eq(<table>.id, _)` against a tenant data-plane table,
+ * return that table's identifier name; otherwise undefined. An `and(...)`/`or(...)`
+ * combinator or a predicate on any other column is — by construction — not a
+ * single eq on the pk, so it is never flagged.
+ */
+function solePrimaryKeyTable(where: ts.Expression): string | undefined {
+  if (!ts.isCallExpression(where)) return undefined;
+  if (!ts.isIdentifier(where.expression) || where.expression.text !== "eq") return undefined;
+  const lhs = where.arguments[0];
+  if (!lhs || !ts.isPropertyAccessExpression(lhs)) return undefined;
+  if (!ts.isIdentifier(lhs.expression) || lhs.name.text !== "id") return undefined;
+  return TENANT_DATA_PLANE_TABLES.has(lhs.expression.text) ? lhs.expression.text : undefined;
+}
+
+/** Outermost enclosing function/method: its name (for reporting) and full text.
+ * Outermost (not nearest) so one `/* global-scope: *\/` on a repository method
+ * opts out every query inside it, including ones nested in `transaction(...)`
+ * callbacks. The full text includes leading comments, so the annotation may sit
+ * above or inside the method. */
+function enclosingFunction(node: ts.Node): { name: string; text: string } {
+  let fn: ts.FunctionLikeDeclaration | undefined;
+  for (let n: ts.Node | undefined = node; n; n = n.parent) {
+    if (
+      ts.isMethodDeclaration(n) ||
+      ts.isFunctionDeclaration(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isArrowFunction(n)
+    ) {
+      fn = n;
+    }
+  }
+  if (!fn) return { name: "<module>", text: "" };
+  const name = fn.name && ts.isIdentifier(fn.name) ? fn.name.text : "<anonymous>";
+  return { name, text: fn.getFullText() };
+}
+
+/** The WHERE expression of a drizzle query, whether written as the query-builder
+ * `.where(expr)` call or the relational `{ where: expr }` option. */
+function whereExpression(node: ts.Node): ts.Expression | undefined {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "where" &&
+    node.arguments.length === 1
+  ) {
+    return node.arguments[0];
+  }
+  if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === "where") {
+    return node.initializer;
+  }
+  return undefined;
+}
+
+/**
+ * Returns every unannotated pk-only tenant-table access in the given repository
+ * files. Pure over the file contents (reads from disk, no other side effects).
+ */
+export function findUnscopedTenantReads(repoFiles: string[]): TenantScopeViolation[] {
+  const violations: TenantScopeViolation[] = [];
+  for (const file of repoFiles) {
+    const source = parse(file);
+    const visit = (node: ts.Node): void => {
+      const where = whereExpression(node);
+      if (where) {
+        const table = solePrimaryKeyTable(where);
+        if (table) {
+          const fn = enclosingFunction(node);
+          if (!ALLOW_ANNOTATION.test(fn.text)) {
+            const { line } = source.getLineAndCharacterOfPosition(node.getStart());
+            violations.push({ file, line: line + 1, table, method: fn.name });
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return violations;
+}
+
+if (import.meta.main) {
+  const root = fileURLToPath(new URL("../src/db/repositories", import.meta.url));
+  const files = globSync(`${root}/**/*.ts`).filter((f) => !f.endsWith(".test.ts"));
+  const violations = findUnscopedTenantReads(files);
+
+  if (violations.length > 0) {
+    console.error(
+      `\n✗ tenant-scope gate: ${violations.length} pk-only read(s) against a tenant data-plane table\n`,
+    );
+    for (const v of violations) {
+      console.error(
+        `  ${relative(process.cwd(), v.file)}:${v.line}  ${v.method}() → eq(${v.table}.id, …)`,
+      );
+    }
+    console.error(
+      "\nScope each query by organization/app ownership, or — if the method is\n" +
+        "intentionally id-only (authorization lives in the caller) — annotate it with\n" +
+        "  /* global-scope: <reason> */\n",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ tenant-scope gate: no unannotated pk-only reads across ${files.length} repository file(s)`,
+  );
+}

--- a/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
+++ b/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
@@ -6,7 +6,9 @@ import {
   SqlTenantDbProvisioner,
 } from "../src/lib/services/tenant-db/tenant-db-provisioner";
 
-const ADMIN = "postgresql://postgres:adminpw@localhost:55432/postgres";
+// sslmode=disable: the throwaway CI Postgres has no TLS, so the admin executor
+// (DirectPgExecutor) must connect in plaintext rather than its prod TLS path.
+const ADMIN = "postgresql://postgres:adminpw@localhost:55432/postgres?sslmode=disable";
 const APP_A = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const APP_B = "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 

--- a/packages/cloud-shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
+++ b/packages/cloud-shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit test for the static tenant-scope gate (#9853 P1.6, GAP B).
+ *
+ * Drives `findUnscopedTenantReads` (the core of scripts/check-tenant-scope.ts)
+ * over two parse-only fixtures: an UNSCOPED repository (pk-only read against a
+ * tenant data-plane table) must be flagged, and a SCOPED one (annotated, or
+ * carrying an ownership predicate) must pass. The CLI form of the same function
+ * gates the real repositories/ tree in cloud-tests.yml.
+ */
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { findUnscopedTenantReads } from "../../../../scripts/check-tenant-scope.ts";
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`../../../../scripts/__fixtures__/tenant-scope/${name}`, import.meta.url));
+
+describe("tenant-scope gate (#9853 P1.6)", () => {
+  test("flags a pk-only read against a tenant data-plane table", () => {
+    const violations = findUnscopedTenantReads([fixture("unscoped.ts")]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ table: "apps", method: "findById" });
+  });
+
+  test("passes when the read is annotated global-scope or carries an ownership predicate", () => {
+    expect(findUnscopedTenantReads([fixture("scoped.ts")])).toHaveLength(0);
+  });
+});

--- a/packages/cloud-shared/src/db/repositories/app-credit-balances.ts
+++ b/packages/cloud-shared/src/db/repositories/app-credit-balances.ts
@@ -23,6 +23,7 @@ export class AppCreditBalancesRepository {
    * Finds an app credit balance by ID.
    */
   async findById(id: string): Promise<AppCreditBalance | undefined> {
+    /* global-scope: by-id balance lookup; callers scope by (app_id, user_id) before use. */
     return await dbRead.query.appCreditBalances.findFirst({
       where: eq(appCreditBalances.id, id),
     });

--- a/packages/cloud-shared/src/db/repositories/apps.ts
+++ b/packages/cloud-shared/src/db/repositories/apps.ts
@@ -73,6 +73,7 @@ export class AppsRepository {
       return undefined;
     }
 
+    /* global-scope: by-id app lookup; route handlers authorize org ownership before use. */
     return await dbRead.query.apps.findFirst({
       where: eq(apps.id, id),
     });
@@ -263,6 +264,7 @@ export class AppsRepository {
     ipAddress?: string | null;
     userAgent?: string | null;
   }): Promise<"created" | "updated"> {
+    /* global-scope: counter/last-seen writes keyed by rows already resolved from (app_id, user_id). */
     const existingConnection = await this.findAppUser(input.appId, input.userId);
 
     if (existingConnection) {
@@ -405,6 +407,7 @@ export class AppsRepository {
    * Updates an existing app.
    */
   async update(id: string, data: Partial<NewApp>): Promise<App | undefined> {
+    /* global-scope: by-id mutation; route handlers authorize org ownership before calling. */
     const [updated] = await dbWrite
       .update(apps)
       .set({
@@ -425,6 +428,7 @@ export class AppsRepository {
    * Deletes an app by ID.
    */
   async delete(id: string): Promise<void> {
+    /* global-scope: by-id deletion; route handlers authorize org ownership before calling. */
     // Read the row first so we know the slug + api_key_id keys to evict.
     // Bypass the cache so a stale cached row does not point at the wrong slug.
     const existing = await dbRead.query.apps.findFirst({ where: eq(apps.id, id) });
@@ -440,6 +444,7 @@ export class AppsRepository {
    * Atomically increments app usage statistics.
    */
   async incrementUsage(id: string, creditsUsed: string = "0.00"): Promise<void> {
+    /* global-scope: atomic usage counter keyed by an app id the caller already owns. */
     await dbWrite
       .update(apps)
       .set({
@@ -455,6 +460,7 @@ export class AppsRepository {
    * Creates a new app user and increments the app's total user count.
    */
   async createAppUser(data: NewAppUser): Promise<AppUser> {
+    /* global-scope: total_users counter keyed by data.app_id supplied by the owning caller. */
     const [appUser] = await dbWrite.insert(appUsers).values(data).returning();
 
     // Increment the app's total_users count

--- a/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
@@ -32,12 +32,18 @@ export class DirectPgExecutor implements TenantDbSqlExecutor {
     // DSN-level `sslmode` would otherwise win over an explicit `ssl` object.
     // Verified live against the prod tenant DB (10.30.1.10) via the apps-control
     // node e2e (connection reaches auth; the self-signed reject is gone).
+    // A local/CI throwaway Postgres has no TLS at all. When the DSN explicitly
+    // opts out (`sslmode=disable`) or PGSSLMODE=disable is set, connect in
+    // plaintext. Prod sets neither, so the TLS-with-skip-verify path is
+    // preserved for the self-signed private-network tenant cluster.
+    const noSsl =
+      /[?&]sslmode=disable/i.test(connectionString) || process.env.PGSSLMODE === "disable";
     const cleaned = connectionString
       .replace(/[?&]sslmode=[^&]*/gi, (m) => (m[0] === "?" ? "?" : ""))
       .replace(/\?$/, "");
     const client = new Client({
       connectionString: cleaned,
-      ssl: { rejectUnauthorized: false },
+      ...(noSsl ? {} : { ssl: { rejectUnauthorized: false } }),
     });
     await client.connect();
     return client;


### PR DESCRIPTION
**#9853 P1 — item 6.** Both isolation-CI gaps.

**Gap A — REVOKE-CONNECT proof wired:** the orphaned `verify-tenant-db-isolation.ts` (provisions APP_A/APP_B, asserts cross-tenant `REVOKE CONNECT`) is now a `verify:tenant-isolation` script + a `tenant-db-isolation` job in `apps-deploy-e2e.yml` that boots a throwaway Postgres service (`:55432`) and runs it, failing on a breach.

**Gap B — static unscoped-read gate:** new `scripts/check-tenant-scope.ts` (TypeScript compiler API — **no new dep**; `ts-morph` was absent, `typescript` already a devDep) scans `repositories/**` and flags any read/update/delete whose WHERE is a sole `eq(<table>.id, _)` against a Product-2 apps data-plane table, unless the method carries a `/* global-scope: <reason> */` annotation. Wired into `cloud-tests.yml`. Annotated the 9 pre-existing legitimate (handler-authorized) pk-only sites; seeded scoped/unscoped fixtures + a bun:test.

**Validation:** the agent installed `typescript`+`biome` in a scratch dir and ran for real against the worktree — checker prints 9 violations pre-annotation → 0 after ("no unannotated pk-only reads across 74 repository files"); bun:test 2/2; `biome check` clean on all changed files; both YAMLs parse.

**Scope decision (needs lead awareness):** applying the literal rule to all 62 org-bearing tables yields ~139 hits (the repo layer is pk-based by design, scoped in handlers). It's deliberately scoped to an explicit Product-2 apps data-plane table list (the `TENANT_DATA_PLANE_TABLES` const is the single knob to widen post-GA). None of the 9 annotated sites are real cross-tenant bugs.

**Reviewer caveats:** the checker is a conservative regression tripwire (only sole-`eq(table.id)`; misses raw SQL / `and(...)` omissions / user_id-scoped) — not a full proof. Gap A's job correctness rests on the service-container DSN matching the script's hardcoded admin dsn (only a live CI run fully confirms).

Refs #9853 (P1 item 6).