### PR TITLE
fix(cloud): env kill-switch for feature flags (#9853 P3.11)

### DIFF
--- a/packages/cloud-shared/src/lib/config/feature-flags.test.ts
+++ b/packages/cloud-shared/src/lib/config/feature-flags.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  getDisabledFeatures,
+  getEnabledFeatures,
+  isFeatureEnabled,
+  isRouteEnabled,
+} from "./feature-flags";
+
+const ENV_KEYS = ["FEATURE_FLAGS_DISABLED", "FEATURE_FLAGS_ENABLED"];
+
+function clearEnv() {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+describe("isFeatureEnabled env override", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  test("returns the compiled default when no env override is set", () => {
+    expect(isFeatureEnabled("billing")).toBe(true);
+  });
+
+  test("FEATURE_FLAGS_DISABLED force-disables a flag (kill switch)", () => {
+    process.env.FEATURE_FLAGS_DISABLED = "billing";
+    expect(isFeatureEnabled("billing")).toBe(false);
+    expect(isFeatureEnabled("mcp")).toBe(true);
+  });
+
+  test("disabled list accepts multiple comma/space separated flags", () => {
+    process.env.FEATURE_FLAGS_DISABLED = "billing, mcp ,";
+    expect(isFeatureEnabled("billing")).toBe(false);
+    expect(isFeatureEnabled("mcp")).toBe(false);
+    expect(isFeatureEnabled("gallery")).toBe(true);
+  });
+
+  test("FEATURE_FLAGS_ENABLED force-enables a flag", () => {
+    process.env.FEATURE_FLAGS_ENABLED = "gallery";
+    expect(isFeatureEnabled("gallery")).toBe(true);
+  });
+
+  test("disable wins over enable when a flag is in both lists", () => {
+    process.env.FEATURE_FLAGS_DISABLED = "billing";
+    process.env.FEATURE_FLAGS_ENABLED = "billing";
+    expect(isFeatureEnabled("billing")).toBe(false);
+  });
+
+  test("getEnabledFeatures and getDisabledFeatures honor the override", () => {
+    process.env.FEATURE_FLAGS_DISABLED = "billing";
+    expect(getEnabledFeatures()).not.toContain("billing");
+    expect(getDisabledFeatures()).toContain("billing");
+  });
+
+  test("isRouteEnabled honors the override for a mapped route", () => {
+    expect(isRouteEnabled("/api/billing/checkout")).toBe(true);
+    process.env.FEATURE_FLAGS_DISABLED = "billing";
+    expect(isRouteEnabled("/api/billing/checkout")).toBe(false);
+    expect(isRouteEnabled("/api/v1/gallery")).toBe(true);
+  });
+});

--- a/packages/cloud-shared/src/lib/config/feature-flags.ts
+++ b/packages/cloud-shared/src/lib/config/feature-flags.ts
@@ -1,3 +1,5 @@
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+
 export type FeatureFlag =
   | "mcp"
   | "containers"
@@ -47,16 +49,42 @@ export const FEATURE_FLAGS: FeatureFlagsMap = {
   },
 } as const;
 
+function parseFlagList(raw: string | undefined): Set<string> {
+  if (!raw) {
+    return new Set();
+  }
+  return new Set(
+    raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Resolve a flag, letting runtime env override the compiled default so a
+ * feature can be killed (or force-enabled) mid-incident without a deploy:
+ *   FEATURE_FLAGS_DISABLED="mcp,billing"  -> force off (kill switch)
+ *   FEATURE_FLAGS_ENABLED="gallery"       -> force on
+ * Disable wins over enable so the kill switch is always authoritative.
+ */
 export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  const env = getCloudAwareEnv();
+  if (parseFlagList(env.FEATURE_FLAGS_DISABLED).has(flag)) {
+    return false;
+  }
+  if (parseFlagList(env.FEATURE_FLAGS_ENABLED).has(flag)) {
+    return true;
+  }
   return FEATURE_FLAGS[flag].enabled;
 }
 
 export function getEnabledFeatures(): FeatureFlag[] {
-  return (Object.keys(FEATURE_FLAGS) as FeatureFlag[]).filter((key) => FEATURE_FLAGS[key].enabled);
+  return (Object.keys(FEATURE_FLAGS) as FeatureFlag[]).filter(isFeatureEnabled);
 }
 
 export function getDisabledFeatures(): FeatureFlag[] {
-  return (Object.keys(FEATURE_FLAGS) as FeatureFlag[]).filter((key) => !FEATURE_FLAGS[key].enabled);
+  return (Object.keys(FEATURE_FLAGS) as FeatureFlag[]).filter((key) => !isFeatureEnabled(key));
 }
 
 export const FEATURE_ROUTE_MAP: Record<FeatureFlag, { frontend: string[]; api: string[] }> = {
@@ -90,7 +118,7 @@ export function isRouteEnabled(pathname: string): boolean {
   for (const [flag, routes] of Object.entries(FEATURE_ROUTE_MAP)) {
     const allRoutes = [...routes.frontend, ...routes.api];
     if (allRoutes.some((route) => pathname.startsWith(route))) {
-      if (!FEATURE_FLAGS[flag as FeatureFlag].enabled) {
+      if (!isFeatureEnabled(flag as FeatureFlag)) {
         return false;
       }
     }


### PR DESCRIPTION
**#9853 P3 — item 11.** Cloud feature flags were hardcoded `enabled: true` with no runtime override (can't disable a feature mid-incident).

`isFeatureEnabled()` (the single central accessor in `feature-flags.ts`) now honors env overrides via `getCloudAwareEnv()` (same pattern as sibling `evm-rpc.ts`): `FEATURE_FLAGS_DISABLED="mcp,billing"` force-disables (the kill-switch), `FEATURE_FLAGS_ENABLED="gallery"` force-enables; **disable wins** (safety-authoritative). Default-on behavior unchanged when no env is set. Also routed `getEnabledFeatures`/`getDisabledFeatures`/`isRouteEnabled` through the accessor so the override is consistent and the duplicated direct `.enabled` reads are removed (no second flag system). Tests cover default/disable/enable/precedence. Pure logic validated standalone (6/6).

**Flag:** precedence (disable>enable) is a judgement call — one-line swap if the team prefers enable-wins.

Refs #9853 (P3 item 11).