### PR TITLE
fix(cloud): re-enable promo duplicate-redemption guard (#9853 P3.12)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -809,6 +809,83 @@ d.skipIf(!process.env.DATABASE_URL || !pgliteAvailable)(
       expect(row?.status).toBe("broadcast");
     });
 
+    test("BSC promo can only be redeemed once per organization", async () => {
+      await resetTable();
+      // First redemption applies the $5 bonus and records promo_code='bsc'.
+      const first = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+        promoCode: "bsc",
+      });
+      const firstMeta = first.payment.metadata as Record<string, unknown>;
+      expect(firstMeta.promo_code).toBe("bsc");
+      expect(firstMeta.bonus_credits).toBe(5);
+      expect(first.payment.credits_to_add).toBe("15.00");
+
+      // Second redemption for the same org is rejected by the guard — the prior
+      // pending promo payment already exists.
+      await expect(
+        service.createPayment(env, {
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          accountWalletAddress: null,
+          payerAddress: PAYER_EVM,
+          amountUsd: 10,
+          network: "bsc",
+          tokenSymbol: "USDT",
+          promoCode: "bsc",
+        }),
+      ).rejects.toThrow(/already been redeemed/);
+
+      // No second promo row was written.
+      const rows = await dbWrite.query.cryptoPayments.findMany();
+      expect(rows).toHaveLength(1);
+    });
+
+    test("BSC promo guard is org-scoped and ignores non-promo purchases", async () => {
+      await resetTable();
+      // A plain (non-promo) buy by ORG_ID must not consume the one-time bonus.
+      await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+      });
+      const promo = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+        promoCode: "bsc",
+      });
+      expect((promo.payment.metadata as Record<string, unknown>).promo_code).toBe("bsc");
+
+      // A different org's prior redemption does not block this org.
+      const OTHER_ORG = "00000000-0000-4000-8000-0000000000c0";
+      const other = await service.createPayment(env, {
+        organizationId: OTHER_ORG,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+        promoCode: "bsc",
+      });
+      expect((other.payment.metadata as Record<string, unknown>).promo_code).toBe("bsc");
+    });
+
     test("getPaymentStatusForUser refuses to disclose to a different user", async () => {
       await resetTable();
       const { payment } = await service.createPayment(env, {

--- a/packages/cloud-shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud-shared/src/lib/services/direct-wallet-payments.ts
@@ -843,25 +843,30 @@ export class DirectWalletPaymentsService {
     const now = new Date();
 
     const payment = await dbWrite.transaction(async (tx) => {
-      // BSC promo redemption check temporarily disabled — allow repeat $5 bonus on $10 buys.
-      // if (promoRequested) {
-      //   await tx.execute(sql`
-      //     SELECT pg_advisory_xact_lock(hashtext(${"crypto_direct_bsc_promo:" + params.organizationId}))
-      //   `);
-      //   const existingPromo = await tx
-      //     .select({ id: cryptoPayments.id })
-      //     .from(cryptoPayments)
-      //     .where(sql`
-      //       ${cryptoPayments.organization_id} = ${params.organizationId}
-      //       AND ${cryptoPayments.status} IN ('pending', 'confirmed')
-      //       AND ${cryptoPayments.metadata}->>'kind' = 'direct_wallet_credit_purchase'
-      //       AND ${cryptoPayments.metadata}->>'promo_code' = 'bsc'
-      //     `)
-      //     .limit(1);
-      //   if (existingPromo.length > 0) {
-      //     throw new Error("BSC promotion has already been redeemed for this organization");
-      //   }
-      // }
+      // Duplicate-redemption guard: the one-time BSC promo bonus must only ever
+      // be granted once per organization. Serialize concurrent attempts with a
+      // per-org advisory lock, then reject if any prior promo payment already
+      // exists in a non-terminal/successful state. 'broadcast' is included
+      // because such a payment is in-flight and will settle to 'confirmed' —
+      // omitting it would leave a window for a second bonus.
+      if (promoRequested) {
+        await tx.execute(sql`
+          SELECT pg_advisory_xact_lock(hashtext(${"crypto_direct_bsc_promo:" + params.organizationId}))
+        `);
+        const existingPromo = await tx
+          .select({ id: cryptoPayments.id })
+          .from(cryptoPayments)
+          .where(sql`
+            ${cryptoPayments.organization_id} = ${params.organizationId}
+            AND ${cryptoPayments.status} IN ('pending', 'broadcast', 'confirmed')
+            AND ${cryptoPayments.metadata}->>'kind' = 'direct_wallet_credit_purchase'
+            AND ${cryptoPayments.metadata}->>'promo_code' = 'bsc'
+          `)
+          .limit(1);
+        if (existingPromo.length > 0) {
+          throw new Error("BSC promotion has already been redeemed for this organization");
+        }
+      }
 
       const [created] = await tx
         .insert(cryptoPayments)


### PR DESCRIPTION
**#9853 P3 — item 12.** The per-org BSC promo duplicate-redemption guard in `direct-wallet-payments.ts` (`createPayment`) was **commented out** ("temporarily disabled — allow repeat $5 bonus on $10 buys"), so the one-time $5 promo bonus could be redeemed repeatedly.

Re-enabled the guard (per-org `pg_advisory_xact_lock` + a SELECT for any prior promo `crypto_payment` in an active status). All referenced APIs/columns/metadata keys still match the insert directly below it — no drift rewrite needed. **One correctness fix beyond the verbatim uncomment:** added `'broadcast'` to the active-status IN-list — a promo payment in-flight (`pending → broadcast → confirmed`) would otherwise not have blocked a second redemption (a residual duplicate window). Two integration tests: second redemption rejected (no second row); org-scoped + ignores non-promo buys.

Refs #9853 (P3 item 12).