### PR TITLE
docs(cloud): refresh stale build-service comments + public-path allowlist re-audit (#9853 P3.13)

### DIFF
--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -7,8 +7,11 @@
  * `production_url`, and `last_deployed_at` columns added in migration 0007.
  * A deployment is identified by `<appId>:<last_deployed_at_iso>` so the
  * CLI can correlate POST → GET polls without a separate `deployments` table.
- * When a real build/upload service (Vercel or otherwise) lands, this service
- * becomes the integration boundary — callers will not need to change.
+ * The real build/deploy pipeline has landed (Apps / Product 2): when a deploy
+ * runner or APP_DEPLOY enqueuer is wired, `createDeployment` triggers a real
+ * isolated provision (the daemon runs it — build-from-repo when armed, prebuilt
+ * image otherwise). This service is that integration boundary — callers keep
+ * polling `getLatestDeployment` regardless of which backend is wired.
  */
 import { logger } from "../utils/logger";
 import type { AppDeployRunner, AppDeployRunOptions } from "./app-deploy-orchestrator";
@@ -111,9 +114,10 @@ export class AppDeploymentsService {
   /**
    * Mark the app as building and stamp `last_deployed_at`.
    *
-   * Returns the new deployment record. The actual build/upload pipeline is
-   * out of scope for this service today; callers (CLI, dashboard) poll
-   * `getLatestDeployment` until status is `READY` or `ERROR`.
+   * Returns the new deployment record. The actual build/upload pipeline runs in
+   * the injected runner/daemon this service triggers, not inline here; callers
+   * (CLI, dashboard) poll `getLatestDeployment` until status is `READY` or
+   * `ERROR`.
    *
    * The route layer is responsible for verifying ownership before calling
    * this method (mirrors the pattern used by `managed-domains.ts`).


### PR DESCRIPTION
**#9853 P3 — item 13.** Two parts.

**(a) Stale comments refreshed** (`app-deployments.ts`): the "when a real build/upload service lands, this becomes the integration boundary" header was future-tense but the build/deploy pipeline has shipped (`AppImageBuilder` + `makeBuildFromRepoResolver`, and this service already delegates to a real `AppDeployRunner`). Comment-only; no logic touched. Other build-service-adjacent comments were checked and are accurate/conditional → left.

**(b) Public-path allowlist re-audit — SAFE, no change forced.** Verified `isPublicPath` (`cloud-api/src/middleware/auth.ts`): matching is **segment-bounded** (`pathname === p || pathname.startsWith(\`${p}/\`)`) — `/api/internalX`, `/api/internal-foo`, `/api/webhooksX` do **not** match (verified standalone). Path traversal is neutralized by WHATWG URL parsing before matching (`/api/internal/../admin` → `/api/admin`, not public). Every `/api/internal` handler enforces `requireInternalAuth` (constant-time secret/JWT); the bootstrap mint endpoint has its own `timingSafeEqual` gateway-secret check. Every `/api/webhooks` handler enforces its own signature/secret (bluebubbles, whatsapp HMAC, twilio, blooio). The audit's mis-scoping risk does **not** materialize — documented rather than forcing a cosmetic change.

Refs #9853 (P3 item 13).