### PR TITLE
feat(cloud): a deploy can't report success without a reachable public URL (#9853 P2.8)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-reachability.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-reachability.test.ts
@@ -1,0 +1,85 @@
+/**
+ * App public-URL reachability probe (#9853) — a deploy must not report success
+ * without a URL that actually answers. These tests pin the status classifier
+ * (auth gates count, gateway errors don't) and the bounded-retry poll (recovers
+ * once the URL starts answering; gives up after the window).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { isReachableStatus, probeUrlReachable, waitForUrlReachable } from "../app-reachability";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("isReachableStatus", () => {
+  test("2xx/3xx and auth gates (401/403) are reachable", () => {
+    for (const status of [200, 204, 301, 302, 401, 403, 404, 500]) {
+      expect(isReachableStatus(status)).toBe(true);
+    }
+  });
+
+  test("bad-gateway family (502/503/504) is NOT reachable", () => {
+    for (const status of [502, 503, 504]) {
+      expect(isReachableStatus(status)).toBe(false);
+    }
+  });
+});
+
+describe("probeUrlReachable", () => {
+  test("a completed 401 counts as reachable", async () => {
+    globalThis.fetch = (async () => new Response(null, { status: 401 })) as typeof fetch;
+    expect(await probeUrlReachable("https://x.apps.test", 1000)).toBe(true);
+  });
+
+  test("a 502 gateway error is NOT reachable", async () => {
+    globalThis.fetch = (async () => new Response(null, { status: 502 })) as typeof fetch;
+    expect(await probeUrlReachable("https://x.apps.test", 1000)).toBe(false);
+  });
+
+  test("a thrown request (connection refused / timeout) is NOT reachable", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    expect(await probeUrlReachable("https://x.apps.test", 1000)).toBe(false);
+  });
+});
+
+describe("waitForUrlReachable", () => {
+  test("returns true as soon as the URL answers", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    expect(
+      await waitForUrlReachable("https://x.apps.test", { maxAttempts: 5, retryDelayMs: 0 }),
+    ).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test("recovers once the upstream starts answering after a few 502s", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(null, { status: calls < 3 ? 502 : 200 });
+    }) as typeof fetch;
+    expect(
+      await waitForUrlReachable("https://x.apps.test", { maxAttempts: 5, retryDelayMs: 0 }),
+    ).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  test("gives up after the bounded window when never reachable", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(null, { status: 504 });
+    }) as typeof fetch;
+    expect(
+      await waitForUrlReachable("https://x.apps.test", { maxAttempts: 4, retryDelayMs: 0 }),
+    ).toBe(false);
+    expect(calls).toBe(4);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -192,6 +192,69 @@ describe("executeContainerProvision", () => {
       else process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = prev;
     }
   });
+
+  test("#9853: marks deployed only after the public URL is reachable", async () => {
+    const prev = process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+    process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = "apps.elizacloud.ai";
+    try {
+      const { store } = fakeStore();
+      const { provider } = fakeProvider();
+      const probed: string[] = [];
+      const deployed: string[] = [];
+      await executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        {
+          provider,
+          store,
+          probeAppReachable: async (url) => {
+            probed.push(url);
+            return true;
+          },
+          markAppDeployed: async (appId) => {
+            deployed.push(appId);
+          },
+        },
+      );
+      expect(probed).toHaveLength(1);
+      expect(probed[0]).toContain("apps.elizacloud.ai");
+      expect(deployed).toEqual([ROW.appId]);
+    } finally {
+      if (prev === undefined) delete process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+      else process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = prev;
+    }
+  });
+
+  test("#9853: an unreachable public URL throws and never marks deployed", async () => {
+    const prev = process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+    process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = "apps.elizacloud.ai";
+    try {
+      const { events, store } = fakeStore();
+      const { provider } = fakeProvider();
+      const deployed: string[] = [];
+      await expect(
+        executeContainerProvision(
+          job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+          {
+            provider,
+            store,
+            // Container is live and routed, but the app never answers.
+            probeAppReachable: async () => false,
+            markAppDeployed: async (appId) => {
+              deployed.push(appId);
+            },
+          },
+        ),
+      ).rejects.toThrow("not HTTP-reachable");
+      // Deploy NOT reported as success...
+      expect(deployed).toEqual([]);
+      // ...but the live container stays `running`, never flipped to `error`.
+      expect(events.some((e) => e.op === "running")).toBe(true);
+      expect(events.some((e) => e.op === "error")).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.CONTAINERS_PUBLIC_BASE_DOMAIN;
+      else process.env.CONTAINERS_PUBLIC_BASE_DOMAIN = prev;
+    }
+  });
 });
 
 describe("executeContainerDelete / restart / logs", () => {

--- a/packages/cloud-shared/src/lib/services/app-reachability.ts
+++ b/packages/cloud-shared/src/lib/services/app-reachability.ts
@@ -1,0 +1,80 @@
+/**
+ * App public-URL reachability probe (Apps / Product 2, #9853).
+ *
+ * A deploy must NOT report success until the app's public URL actually answers
+ * an HTTP request through the ingress. "Reachable" means the request COMPLETES
+ * with a status the app/ingress itself produced — a 2xx/3xx, or an auth gate
+ * (401/403) — and NOT:
+ *   - a connection refused / DNS failure / TLS error / per-attempt timeout, or
+ *   - a Caddy gateway error (502/503/504), which means the ingress is up but the
+ *     upstream container isn't answering yet.
+ * So a phantom-success deploy (container `running`, route registered, but the
+ * app never serving) is caught and surfaced instead of reported as `deployed`.
+ *
+ * NODE-ONLY: runs in the provisioning daemon (the CONTAINER_PROVISION executor),
+ * never the Worker deploy route. Uses global `fetch` + `AbortSignal.timeout` —
+ * the same primitive the warm-pool health probe uses — so it adds no new HTTP
+ * client.
+ */
+
+const DEFAULT_MAX_ATTEMPTS = 10;
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 5_000;
+const DEFAULT_RETRY_DELAY_MS = 3_000;
+
+/**
+ * Whether an HTTP status counts as "the app answered". The bad-gateway family
+ * (502 Bad Gateway / 503 Service Unavailable / 504 Gateway Timeout) means the
+ * ingress is up but the upstream app isn't serving yet, so it is NOT reachable.
+ * Every other completed status — incl. 2xx/3xx and auth gates (401/403) — is.
+ */
+export function isReachableStatus(status: number): boolean {
+  return status !== 502 && status !== 503 && status !== 504;
+}
+
+/** A single probe: true iff the URL completes a request with a non-gateway status. */
+export async function probeUrlReachable(url: string, timeoutMs: number): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      // Don't chase redirects (avoid loops / external hops); a 3xx already
+      // proves the app answered — `isReachableStatus` treats it as reachable.
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return isReachableStatus(response.status);
+  } catch {
+    // Connection refused, DNS/TLS failure, or the per-attempt timeout aborted.
+    return false;
+  }
+}
+
+export interface ReachabilityOptions {
+  /** Total probe attempts before giving up. Default 10. */
+  maxAttempts?: number;
+  /** Per-attempt request timeout (ms) — bounds each probe. Default 5000. */
+  attemptTimeoutMs?: number;
+  /** Delay between attempts (ms). Default 3000. */
+  retryDelayMs?: number;
+}
+
+/**
+ * Poll `url` until it is HTTP-reachable or the bounded window is exhausted. The
+ * window is `maxAttempts` probes, each capped at `attemptTimeoutMs`, with
+ * `retryDelayMs` between them — so it can never hang. Returns false when the URL
+ * never became reachable.
+ */
+export async function waitForUrlReachable(
+  url: string,
+  options: ReachabilityOptions = {},
+): Promise<boolean> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (await probeUrlReachable(url, attemptTimeoutMs)) return true;
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+  return false;
+}

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -24,6 +24,7 @@ import { decideBuilderArming, selectBuilderHost } from "./app-builder-host";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
 import type { BuildExec } from "./app-image-builder";
+import { waitForUrlReachable } from "./app-reachability";
 import { appsService } from "./apps";
 import { addAppRoute, removeAppRoute } from "./apps-ingress-provisioner";
 import type { ContainerExecutorDeps } from "./container-job-executors";
@@ -192,12 +193,19 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
 
   // Ingress route hooks — wired only when a Caddy admin URL is configured.
   // Otherwise routes are no-ops (the deploy still succeeds; the app just has no
-  // public URL until ingress is set up).
+  // public URL until ingress is set up). The reachability gate (#9853) is wired
+  // alongside the route hooks: a public URL only exists to probe once there's an
+  // ingress route to serve it, so an un-wired ingress skips the gate (no route =>
+  // nothing to verify) rather than failing every deploy on an unroutable URL.
   const caddyAdminUrl = containersEnv.caddyAdminUrl();
-  const ingress: Pick<ContainerExecutorDeps, "onRouteAdded" | "onRouteRemoved"> = caddyAdminUrl
+  const ingress: Pick<
+    ContainerExecutorDeps,
+    "onRouteAdded" | "onRouteRemoved" | "probeAppReachable"
+  > = caddyAdminUrl
     ? {
         onRouteAdded: (route) => addAppRoute({ ...route, adminBase: caddyAdminUrl }),
         onRouteRemoved: (route) => removeAppRoute({ ...route, adminBase: caddyAdminUrl }),
+        probeAppReachable: (url) => waitForUrlReachable(url),
       }
     : {};
 

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -83,6 +83,16 @@ export interface ContainerExecutorDeps {
    * here — a failure must surface so the deploy is retried, not silently stuck.
    */
   markAppDeployed?: (appId: string, productionUrl: string | null) => Promise<void>;
+  /**
+   * Probe whether the app's public URL is HTTP-reachable (#9853). Runs after the
+   * ingress route is registered and BEFORE the app is marked `deployed`, so a
+   * deploy never reports success without a URL that actually answers. Returns
+   * true once the URL completes an HTTP request (2xx/3xx/401/403), false on
+   * connection-refused/timeout/502/504 — with bounded retries inside. Optional:
+   * wired only alongside the ingress hooks (no ingress => no public route to
+   * probe), so when unset the reachability gate is skipped (local dev).
+   */
+  probeAppReachable?: (url: string) => Promise<boolean>;
 }
 
 async function requireRow(store: AppContainerStore, containerId: string): Promise<AppContainerRow> {
@@ -146,6 +156,24 @@ export async function executeContainerProvision(
         extraHostnames,
         hostPort: result.hostPort,
       });
+    }
+    // Reachability gate (#9853): a deploy must NOT report success without a
+    // public URL that actually answers. Once the route is registered, probe the
+    // app's public URL; if it never becomes HTTP-reachable within the bounded
+    // window, throw a clear error instead of marking `deployed`. The job then
+    // retries and, on retry exhaustion, `provisioning-jobs` flips the app to
+    // `failed` — so a phantom-success (live container, route added, app not
+    // serving) surfaces as a failure rather than a stranded "deployed". The
+    // container row stays `running` (it IS live; only the route isn't serving),
+    // same as a route-add failure.
+    if (endpoint && deps.probeAppReachable) {
+      const reachable = await deps.probeAppReachable(endpoint.url);
+      if (!reachable) {
+        throw new Error(
+          `App ${row.appId} container is running but its public URL ${endpoint.url} ` +
+            "is not HTTP-reachable — refusing to report deploy success.",
+        );
+      }
     }
     // Container is running and routable — flip the app to `deployed` so the
     // deploy-status route reports READY (instead of `building` forever).


### PR DESCRIPTION
**#9853 P2 — item 8.** A deploy could mark `apps.deployment_status='deployed'` even if the app's public URL wasn't actually serving (container up + Caddy route added ≠ app reachable).

- New `app-reachability.ts` (node-only): `isReachableStatus` (502/503/504 = not reachable; 2xx/3xx/401/403/404/500 = the app answered), `probeUrlReachable` (single fetch, `redirect:manual`, `AbortSignal.timeout`), `waitForUrlReachable` (bounded retries — default 10×5s/3s, can't hang). Reuses global `fetch`, no new HTTP client.
- The daemon's `CONTAINER_PROVISION` executor now **gates `markAppDeployed` on the URL being reachable**. If not reachable within the window it throws → the existing job-retry → retry-exhaustion → `apps.deployment_status='failed'` machinery (no new writer). So a phantom-success surfaces as `failed`, not a stranded `deployed`.
- Only place success is written is the node daemon (the Worker only sets `building`/enqueues), so there's no path that bypasses the gate.

**Reviewer notes:** when Caddy ingress isn't configured (`caddyAdminUrl` unset) the gate is skipped (no public route to probe — preserves local/no-ingress deploys); the "clear reason" is the thrown/logged error (no `deployment_error` column exists). Logic validated standalone + biome-clean; tsc is gated by CI (the executor/deps edits are simple structural additions).

Refs #9853 (P2 item 8).