### PR TITLE
feat(cloud): make a stale provisioning-daemon heartbeat LOUD, not silent (#9853 P2.7)

### DIFF
--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health-monitor.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health-monitor.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import type { ProvisioningWorkerHealth } from "./provisioning-worker-health";
+import {
+  HEARTBEAT_MAX_AGE_MS,
+  isHeartbeatStale,
+  monitorProvisioningWorkerHealth,
+} from "./provisioning-worker-health-monitor";
+
+const NOW = Date.parse("2026-06-28T00:00:00.000Z");
+
+describe("isHeartbeatStale", () => {
+  it("treats a fresh heartbeat as not stale", () => {
+    const fresh = new Date(NOW - 1_000).toISOString();
+    expect(isHeartbeatStale(fresh, NOW)).toBe(false);
+  });
+
+  it("treats a heartbeat older than the max age as stale", () => {
+    const old = new Date(NOW - HEARTBEAT_MAX_AGE_MS - 1).toISOString();
+    expect(isHeartbeatStale(old, NOW)).toBe(true);
+  });
+
+  it("treats an absent heartbeat as stale", () => {
+    expect(isHeartbeatStale(undefined, NOW)).toBe(true);
+  });
+
+  it("treats an unparseable heartbeat as stale", () => {
+    expect(isHeartbeatStale("not-a-date", NOW)).toBe(true);
+  });
+
+  it("does not flag a heartbeat exactly at the max age", () => {
+    const edge = new Date(NOW - HEARTBEAT_MAX_AGE_MS).toISOString();
+    expect(isHeartbeatStale(edge, NOW)).toBe(false);
+  });
+});
+
+function captureAlerts() {
+  const alerts: { title: string; details: Record<string, unknown> }[] = [];
+  return {
+    alerts,
+    alert: async (a: { title: string; details: Record<string, unknown> }) => {
+      alerts.push(a);
+    },
+  };
+}
+
+describe("monitorProvisioningWorkerHealth", () => {
+  it("is healthy and silent when the daemon is not required", async () => {
+    const { alerts, alert } = captureAlerts();
+    const health: ProvisioningWorkerHealth = { ok: true, required: false };
+    const result = await monitorProvisioningWorkerHealth({
+      check: async () => health,
+      alert,
+      now: () => NOW,
+    });
+    expect(result.healthy).toBe(true);
+    expect(result.stale).toBe(false);
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("is healthy and silent on a fresh heartbeat", async () => {
+    const { alerts, alert } = captureAlerts();
+    const health: ProvisioningWorkerHealth = {
+      ok: true,
+      required: true,
+      lastHeartbeatAt: new Date(NOW - 1_000).toISOString(),
+    };
+    const result = await monitorProvisioningWorkerHealth({
+      check: async () => health,
+      alert,
+      now: () => NOW,
+    });
+    expect(result.healthy).toBe(true);
+    expect(result.stale).toBe(false);
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("is unhealthy and alerts when the heartbeat is absent (gate failed closed)", async () => {
+    const { alerts, alert } = captureAlerts();
+    const health: ProvisioningWorkerHealth = {
+      ok: false,
+      required: true,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+      error: "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
+    };
+    const result = await monitorProvisioningWorkerHealth({
+      check: async () => health,
+      alert,
+      now: () => NOW,
+    });
+    expect(result.healthy).toBe(false);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].details.code).toBe("PROVISIONING_WORKER_UNHEALTHY");
+  });
+
+  it("is unhealthy and alerts when a present heartbeat is stale", async () => {
+    const { alerts, alert } = captureAlerts();
+    const health: ProvisioningWorkerHealth = {
+      ok: true,
+      required: true,
+      lastHeartbeatAt: new Date(NOW - HEARTBEAT_MAX_AGE_MS - 10_000).toISOString(),
+    };
+    const result = await monitorProvisioningWorkerHealth({
+      check: async () => health,
+      alert,
+      now: () => NOW,
+    });
+    expect(result.healthy).toBe(false);
+    expect(result.stale).toBe(true);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].details.code).toBe("PROVISIONING_WORKER_STALE_HEARTBEAT");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health-monitor.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health-monitor.ts
@@ -1,0 +1,167 @@
+/**
+ * Provisioning-worker health MONITOR (alerting layer).
+ *
+ * `provisioning-worker-health.ts` is the *gate*: the cloud-api Worker reads the
+ * daemon's Redis heartbeat on every provision/wake/resume request and fails
+ * CLOSED when it's stale. That protects correctness but is silent — a wedged
+ * daemon just turns every provision into a 503 with nobody paged, while
+ * container-stop billing cleanup and per-tenant DB isolation (both daemon jobs)
+ * quietly stop running.
+ *
+ * This module closes that gap: it observes the heartbeat and, when it is
+ * stale/absent, makes it LOUD (structured error log + the configured ops alert
+ * channels) and returns a queryable status the platform can gate on. Intended
+ * to be invoked on a schedule (separate from the daemon, which cannot alert
+ * about its own death) — wiring that schedule is infra, not this module.
+ */
+
+import { logger } from "../utils/logger";
+import {
+  checkProvisioningWorkerHealth,
+  PROVISIONING_WORKER_HEARTBEAT_TTL_S,
+  type ProvisioningWorkerHealth,
+} from "./provisioning-worker-health";
+
+/**
+ * Alert-channel env vars, mirroring the per-domain convention already used by
+ * `payout-alerts` (`REDEMPTION_ALERT_*`) and the social-media alerts
+ * (`SOCIAL_ALERTS_*`). Both optional: the structured error log always fires so
+ * the alert is never fully silent even with no channel configured.
+ */
+const ALERT_SLACK_WEBHOOK_ENV = "PROVISIONING_ALERT_SLACK_WEBHOOK";
+const ALERT_PAGERDUTY_KEY_ENV = "PROVISIONING_ALERT_PAGERDUTY_KEY";
+
+/**
+ * A heartbeat older than this is treated as stale even if the Redis key still
+ * exists. The gate relies on Redis TTL alone (key present == fresh); this
+ * age check is defense-in-depth against a misconfigured/over-long TTL or a
+ * clock-skewed daemon. Reuses the daemon's own TTL so the monitor and the
+ * gate agree on "fresh".
+ */
+export const HEARTBEAT_MAX_AGE_MS = PROVISIONING_WORKER_HEARTBEAT_TTL_S * 1000;
+
+interface DaemonHealthAlert {
+  title: string;
+  message: string;
+  details: Record<string, unknown>;
+}
+
+/**
+ * True when the heartbeat is absent, unparseable, or older than `maxAgeMs`.
+ * Pure logic, unit-tested in isolation.
+ */
+export function isHeartbeatStale(
+  lastHeartbeatAt: string | undefined,
+  nowMs: number,
+  maxAgeMs: number = HEARTBEAT_MAX_AGE_MS,
+): boolean {
+  if (!lastHeartbeatAt) return true;
+  const heartbeatMs = Date.parse(lastHeartbeatAt);
+  if (Number.isNaN(heartbeatMs)) return true;
+  return nowMs - heartbeatMs > maxAgeMs;
+}
+
+/**
+ * Emit a daemon-health alert. Always logs a structured error (loud even with
+ * no channel configured), then fans out to whatever ops channels are wired.
+ * PagerDuty uses a fixed dedup key so a sustained outage is ONE incident, not
+ * one per monitor tick.
+ */
+export async function sendProvisioningWorkerAlert(alert: DaemonHealthAlert): Promise<void> {
+  logger.error(`[ProvisioningWorkerHealth] ${alert.title}`, {
+    message: alert.message,
+    ...alert.details,
+  });
+
+  const slackWebhook = process.env[ALERT_SLACK_WEBHOOK_ENV];
+  const pagerDutyKey = process.env[ALERT_PAGERDUTY_KEY_ENV];
+
+  const sends: Promise<unknown>[] = [];
+
+  if (slackWebhook) {
+    sends.push(
+      fetch(slackWebhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: `🚨 *[elizaOS Provisioning]* ${alert.title}\n${alert.message}`,
+        }),
+      }),
+    );
+  }
+
+  if (pagerDutyKey) {
+    sends.push(
+      fetch("https://events.pagerduty.com/v2/enqueue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          routing_key: pagerDutyKey,
+          event_action: "trigger",
+          dedup_key: "provisioning-worker-unhealthy",
+          payload: {
+            summary: `[elizaOS Provisioning] ${alert.title}`,
+            severity: "critical",
+            source: "eliza-cloud-provisioning-worker",
+            custom_details: { message: alert.message, ...alert.details },
+          },
+        }),
+      }),
+    );
+  }
+
+  const results = await Promise.allSettled(sends);
+  const failures = results.filter((r) => r.status === "rejected").length;
+  if (failures > 0) {
+    logger.error(`[ProvisioningWorkerHealth] ${failures}/${results.length} alert channels failed`);
+  }
+}
+
+/**
+ * Observe the provisioning-worker heartbeat and alert when it is unhealthy.
+ *
+ * Healthy iff the daemon is not required, or the heartbeat is present AND
+ * fresh. An absent heartbeat (gate already 503s) or a present-but-stale one
+ * both fire an alert. Returns the underlying gate health plus a `stale` flag
+ * so callers can expose/gate on a queryable status without re-deriving it.
+ *
+ * `check`/`alert`/`now` are injectable for tests; production uses the real
+ * Redis-backed gate, the ops alert channels, and the wall clock.
+ */
+export async function monitorProvisioningWorkerHealth(
+  deps: {
+    check?: () => Promise<ProvisioningWorkerHealth>;
+    alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<{ healthy: boolean; stale: boolean; health: ProvisioningWorkerHealth }> {
+  const check = deps.check ?? checkProvisioningWorkerHealth;
+  const alert = deps.alert ?? sendProvisioningWorkerAlert;
+  const nowMs = (deps.now ?? Date.now)();
+
+  const health = await check();
+
+  if (!health.required) {
+    return { healthy: true, stale: false, health };
+  }
+
+  const stale = health.ok && isHeartbeatStale(health.lastHeartbeatAt, nowMs);
+  const healthy = health.ok && !stale;
+
+  if (!healthy) {
+    await alert({
+      title: "Provisioning worker is unhealthy",
+      message:
+        `${health.ok ? `Heartbeat is stale (last seen ${health.lastHeartbeatAt ?? "never"}).` : health.error} ` +
+        "Container-stop billing cleanup and per-tenant DB isolation depend on this daemon; " +
+        "provisioning is failing closed until it recovers.",
+      details: {
+        code: health.ok ? "PROVISIONING_WORKER_STALE_HEARTBEAT" : health.code,
+        lastHeartbeatAt: health.ok ? health.lastHeartbeatAt : undefined,
+        maxAgeMs: HEARTBEAT_MAX_AGE_MS,
+      },
+    });
+  }
+
+  return { healthy, stale, health };
+}


### PR DESCRIPTION
**#9853 P2 — item 7.** The provisioning daemon already writes a Redis heartbeat and cloud-api already **fails closed** when it's stale — but **silently**: nobody is paged, so container-stop billing cleanup and per-tenant DB isolation (both daemon jobs) quietly stop while provisions just 503.

New sibling module `provisioning-worker-health-monitor.ts` (doesn't touch the existing gate):
- `isHeartbeatStale(lastHeartbeatAt, now, maxAge)` — pure, unit-tested staleness detector (absent/unparseable/too-old = stale); reuses the daemon's own `PROVISIONING_WORKER_HEARTBEAT_TTL_S` (no new magic number).
- `monitorProvisioningWorkerHealth()` — runs the existing health check + age check, and on unhealthy makes it **loud** via an alert sink, returning a queryable `{healthy, stale, health}` status the platform can gate on.
- `sendProvisioningWorkerAlert()` — always emits a structured `logger.error` (loud even with no channel), then fans out to optional Slack + PagerDuty (fixed dedup key = one incident per outage), mirroring the codebase's existing per-domain alert convention (payout/social alerts).

**Note:** arming the daemon itself is separate infra (P2 #9 / VPS lane); this is the monitoring *code* so a down daemon can't fail silently. Real paging needs the `PROVISIONING_ALERT_*` env vars set.

Refs #9853 (P2 item 7).