### PR TITLE
fix(cloud): gate the Apps deploy image on the container allowlist (#9853 follow-up)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -49,9 +49,11 @@ describe("resolveImageRef: build-from-repo-disabled guard", () => {
     const img = await resolveImageRef(buildOff, {
       ...baseApp,
       repoUrl: REPO,
-      metadata: { imageTag: "ghcr.io/u/myapp:v1" },
+      // Allowlisted first-party namespace (the image allowlist gate runs on the
+      // resolved image — see the gate describe block below).
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
     });
-    expect(img).toBe("ghcr.io/u/myapp:v1");
+    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 
   test("repo app + build on -> uses the built image", async () => {
@@ -65,5 +67,61 @@ describe("resolveImageRef: build-from-repo-disabled guard", () => {
   test("non-repo app still falls back to APP_DEFAULT_IMAGE (unchanged)", async () => {
     process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/app-default:smoke";
     expect(await resolveImageRef(buildOff, baseApp)).toBe("ghcr.io/elizaos/app-default:smoke");
+  });
+});
+
+// #9853 — an app deploy runs an image on our shared docker nodes, so the resolved
+// image is gated on the same allowlist the coding-container routes use. Empty
+// allowlist is fail-closed; the default allowlist covers the first-party GHCR
+// namespaces (so the default agent image / APP_DEFAULT_IMAGE pass unchanged).
+describe("resolveImageRef: image allowlist gate", () => {
+  const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
+  const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
+
+  afterEach(() => {
+    delete process.env.APP_DEFAULT_IMAGE;
+    delete process.env.CODING_CONTAINER_IMAGE_ALLOWLIST;
+  });
+
+  test("rejects an imageTag outside the default allowlist", async () => {
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "docker.io/evil/pwn:latest" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("allows an imageTag inside the default first-party allowlist", async () => {
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+    });
+    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+  });
+
+  test("the default agent image passes the default allowlist", async () => {
+    process.env.APP_DEFAULT_IMAGE = "ghcr.io/elizaos/eliza:stable";
+    expect(await resolveImageRef(buildOff, baseApp)).toBe("ghcr.io/elizaos/eliza:stable");
+  });
+
+  test("a mis-set APP_DEFAULT_IMAGE outside the allowlist is rejected", async () => {
+    process.env.APP_DEFAULT_IMAGE = "docker.io/library/nginx:latest";
+    await expect(resolveImageRef(buildOff, baseApp)).rejects.toThrow(/is not permitted/);
+  });
+
+  test("honors an operator-narrowed allowlist (rejects an off-list image)", async () => {
+    process.env.CODING_CONTAINER_IMAGE_ALLOWLIST = "ghcr.io/onlyme/*";
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/elizaos/eliza:stable" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
+    });
+    expect(img).toBe("ghcr.io/onlyme/app:v1");
   });
 });

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -45,6 +45,7 @@
 import { appDatabasesRepository } from "../../db/repositories/app-databases";
 import { containersRepository } from "../../db/repositories/containers";
 import type { NewContainer } from "../../db/schemas/containers";
+import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { resolveAppDatabaseMode } from "./app-database-mode";
 import {
@@ -56,6 +57,7 @@ import {
 } from "./app-deploy-orchestrator";
 import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
+import { isCodingContainerImageAllowed } from "./coding-containers";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
 import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 import type { UserDatabaseService } from "./user-database";
@@ -133,6 +135,22 @@ export async function resolveImageRef(
   if (!image) {
     throw new Error(
       `No image to deploy for app ${app.id}: pass resolveImage, set app.metadata.imageTag, or APP_DEFAULT_IMAGE`,
+    );
+  }
+  // SECURITY: an app deploy runs an image on our shared docker nodes. Gate the
+  // resolved image on the same allowlist the coding-container routes use, so a
+  // caller-supplied `metadata.imageTag` (or a mis-set APP_DEFAULT_IMAGE) cannot
+  // run an arbitrary off-namespace image. Fail-closed: empty allowlist denies.
+  // The default allowlist covers the first-party GHCR namespaces, so the default
+  // agent image and APP_DEFAULT_IMAGE under those namespaces pass unchanged.
+  const allowlist = containersEnv.codingContainerImageAllowlist();
+  if (!isCodingContainerImageAllowed(image, allowlist)) {
+    const permitted = allowlist.length > 0 ? allowlist.join(", ") : "(none configured)";
+    throw new Error(
+      `Image '${image}' is not permitted for app ${app.id}: it is outside the ` +
+        `allowed image namespaces (${permitted}). Set app.metadata.imageTag (or ` +
+        `APP_DEFAULT_IMAGE) to an allowlisted image, or widen ` +
+        `CODING_CONTAINER_IMAGE_ALLOWLIST.`,
     );
   }
   return image;


### PR DESCRIPTION
**#9853 follow-up (surfaced in #9862's review).** The Apps/Product-2 deploy path `resolveImageRef` (`app-deploy-runner.ts`) resolved the deploy image from `app.metadata.imageTag` / `APP_DEFAULT_IMAGE` and ran it on shared docker nodes with **no allowlist** — unlike the coding-container routes.

- Added a fail-closed gate inside `resolveImageRef` (covers its sole caller): reuses the **existing** `containersEnv.codingContainerImageAllowlist()` + `isCodingContainerImageAllowed()` (no duplication) and throws a clear error naming the permitted namespaces when the image is off-list.
- Verified the **default agent image** `ghcr.io/elizaos/eliza:stable` and the e2e fixture pass the default first-party allowlist (so legit deploys aren't broken). Validated the matcher across 7 cases standalone.
- Gated **only on the allowlist** here — the digest-pin helpers live on the unmerged #9862; once that merges, a digest check folds into the same spot.

**Reviewer notes:** if an operator sets `APP_DEFAULT_IMAGE`/`metadata.imageTag` outside the first-party GHCR namespaces, the gate now rejects that deploy by design (keep it in an allowlisted namespace or widen `CODING_CONTAINER_IMAGE_ALLOWLIST`). One pre-existing test fixture image was retargeted to an allowlisted namespace (it'd now correctly be rejected). Tests: off-list rejected, allowlisted passes, default image passes, mis-set default rejected, operator-narrowed list honored.

Refs #9853.