### PR TITLE
fix(plugin-elizacloud): self-heal CloudAuth when an injected API key is revoked (401-blind agent)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/cloud-auth-revalidation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-auth-revalidation.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the CloudAuth background API-key re-validation state machine
+ * (`decideRevalidation`). This is the self-heal that fixes an agent going
+ * 401-blind after its injected key is revoked: it retries transient
+ * cloud-unreachability (so a boot-time outage doesn't leave the key unvalidated
+ * forever), confirms a revoked key with a single loud actionable error
+ * (debounced so a transient 5xx doesn't false-alarm), and steady-re-checks so a
+ * post-boot revocation is caught and a later re-authorization self-heals.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  decideRevalidation,
+  type RevalidationConfig,
+  type RevalidationState,
+} from "../src/services/cloud-auth";
+
+const CFG: RevalidationConfig = {
+  retryMs: 1_000,
+  steadyMs: 60_000,
+  invalidThreshold: 2,
+};
+const UNKNOWN: RevalidationState = { keyState: "unknown", consecutiveInvalid: 0 };
+
+describe("decideRevalidation", () => {
+  it("valid probe → confirms the key, logs once, steady re-check", () => {
+    const d = decideRevalidation(UNKNOWN, "valid", CFG);
+    expect(d.state).toEqual({ keyState: "valid", consecutiveInvalid: 0 });
+    expect(d.delayMs).toBe(CFG.steadyMs);
+    expect(d.log).toEqual({ level: "info", message: expect.stringContaining("validated") });
+  });
+
+  it("valid again (already valid) → no duplicate log", () => {
+    const d = decideRevalidation({ keyState: "valid", consecutiveInvalid: 0 }, "valid", CFG);
+    expect(d.state.keyState).toBe("valid");
+    expect(d.log).toBeNull();
+    expect(d.delayMs).toBe(CFG.steadyMs);
+  });
+
+  it("unreachable at boot → keeps state unresolved + retries (the 37911a1e fix)", () => {
+    const d = decideRevalidation(UNKNOWN, "unreachable", CFG);
+    expect(d.state).toEqual(UNKNOWN); // still unknown — will keep probing
+    expect(d.delayMs).toBe(CFG.retryMs);
+    expect(d.log).toBeNull();
+  });
+
+  it("single invalid probe → NOT confirmed yet (debounce), re-probe soon, no error", () => {
+    const d = decideRevalidation(UNKNOWN, "invalid", CFG);
+    expect(d.state).toEqual({ keyState: "unknown", consecutiveInvalid: 1 });
+    expect(d.delayMs).toBe(CFG.retryMs);
+    expect(d.log).toBeNull();
+  });
+
+  it("second consecutive invalid → CONFIRMS revoked, logs a single error, steady re-check", () => {
+    const d = decideRevalidation({ keyState: "unknown", consecutiveInvalid: 1 }, "invalid", CFG);
+    expect(d.state).toEqual({ keyState: "invalid", consecutiveInvalid: 2 });
+    expect(d.delayMs).toBe(CFG.steadyMs);
+    expect(d.log?.level).toBe("error");
+    expect(d.log?.message).toMatch(/REVOKED\/INVALID/);
+  });
+
+  it("invalid again (already invalid) → no duplicate error log", () => {
+    const d = decideRevalidation({ keyState: "invalid", consecutiveInvalid: 2 }, "invalid", CFG);
+    expect(d.state.keyState).toBe("invalid");
+    expect(d.log).toBeNull();
+  });
+
+  it("a network blip between two rejections does NOT reset the confirmation count", () => {
+    // invalid(1) → unreachable (blip) → invalid → should confirm on the 2nd real rejection
+    let s = decideRevalidation(UNKNOWN, "invalid", CFG).state; // count=1
+    s = decideRevalidation(s, "unreachable", CFG).state; // count preserved
+    expect(s.consecutiveInvalid).toBe(1);
+    const d = decideRevalidation(s, "invalid", CFG); // count=2 → confirmed
+    expect(d.state.keyState).toBe("invalid");
+    expect(d.log?.level).toBe("error");
+  });
+
+  it("self-heals: confirmed-invalid → valid re-authorization clears the state + logs recovery", () => {
+    const d = decideRevalidation({ keyState: "invalid", consecutiveInvalid: 2 }, "valid", CFG);
+    expect(d.state).toEqual({ keyState: "valid", consecutiveInvalid: 0 });
+    expect(d.log).toEqual({ level: "info", message: expect.stringContaining("validated") });
+    expect(d.delayMs).toBe(CFG.steadyMs);
+  });
+
+  it("uses the default config when none is passed", () => {
+    const d = decideRevalidation(UNKNOWN, "valid");
+    expect(d.state.keyState).toBe("valid");
+    expect(d.delayMs).toBe(30 * 60_000);
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-auth.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-auth.ts
@@ -389,12 +389,115 @@ export async function exchangeCodeForSession(args: ExchangeCodeArgs): Promise<Cl
 
 // ─── Service ───────────────────────────────────────────────────────────────
 
+/** Result of probing the saved API key against the cloud. */
+export type ApiKeyProbe = "valid" | "unreachable" | "invalid";
+
+export interface RevalidationState {
+  /** `unknown` until a probe resolves; `invalid` once a revoked key is confirmed. */
+  keyState: "unknown" | "valid" | "invalid";
+  /** Consecutive reachable-but-rejected probes; debounces a transient 5xx. */
+  consecutiveInvalid: number;
+}
+
+export interface RevalidationConfig {
+  /** Re-probe delay while the key state is unresolved (unreachable / unconfirmed-invalid). */
+  retryMs: number;
+  /** Re-probe delay once the key state is resolved — catches a LATER revocation. */
+  steadyMs: number;
+  /** Reachable-but-rejected probes required before declaring the key revoked. */
+  invalidThreshold: number;
+}
+
+export interface RevalidationDecision {
+  state: RevalidationState;
+  delayMs: number;
+  log: { level: "info" | "error"; message: string } | null;
+}
+
+export const DEFAULT_REVALIDATION_CONFIG: RevalidationConfig = {
+  retryMs: 60_000,
+  steadyMs: 30 * 60_000,
+  invalidThreshold: 2,
+};
+
+/**
+ * Pure state machine for background API-key re-validation. Given the current
+ * state and a fresh probe result, decide the next state, when to re-probe, and
+ * whether to emit a one-shot state-change log. No I/O — fully unit-testable.
+ *
+ * Why this exists: at boot the key is trusted optimistically and validated once
+ * in the background. If the cloud was unreachable at boot (or the key is revoked
+ * AFTER boot), the one-shot check left the agent 401-blind on every turn with no
+ * surfaced state. This loop retries transient unreachability, confirms a revoked
+ * key with a loud actionable error (debounced so a single 5xx doesn't false-
+ * alarm), and steady-re-checks so a post-boot revocation is still caught and a
+ * later re-authorization self-heals.
+ */
+export function decideRevalidation(
+  prev: RevalidationState,
+  probe: ApiKeyProbe,
+  cfg: RevalidationConfig = DEFAULT_REVALIDATION_CONFIG
+): RevalidationDecision {
+  if (probe === "valid") {
+    const log =
+      prev.keyState !== "valid"
+        ? { level: "info" as const, message: "[CloudAuth] API key validated" }
+        : null;
+    return {
+      state: { keyState: "valid", consecutiveInvalid: 0 },
+      delayMs: cfg.steadyMs,
+      log,
+    };
+  }
+
+  if (probe === "invalid") {
+    const consecutiveInvalid = prev.consecutiveInvalid + 1;
+    const confirmed = consecutiveInvalid >= cfg.invalidThreshold;
+    if (confirmed) {
+      const log =
+        prev.keyState !== "invalid"
+          ? {
+              level: "error" as const,
+              message:
+                "[CloudAuth] Eliza Cloud API key is REVOKED/INVALID (cloud reachable, key rejected). " +
+                "Model calls will fail with 401 until the agent is re-provisioned or a valid ELIZAOS_CLOUD_API_KEY is set.",
+            }
+          : null;
+      return {
+        state: { keyState: "invalid", consecutiveInvalid },
+        delayMs: cfg.steadyMs,
+        log,
+      };
+    }
+    // Not yet confirmed — re-probe soon (don't change the surfaced state yet).
+    return {
+      state: { keyState: prev.keyState, consecutiveInvalid },
+      delayMs: cfg.retryMs,
+      log: null,
+    };
+  }
+
+  // unreachable — transient network state, not an auth signal: keep the prior
+  // state and back off. (consecutiveInvalid is preserved, not reset, so a blip
+  // between two real rejections doesn't restart the confirmation count.)
+  return {
+    state: { ...prev },
+    delayMs: cfg.retryMs,
+    log: null,
+  };
+}
+
 export class CloudAuthService extends Service {
   static serviceType = "CLOUD_AUTH";
   capabilityDescription = "Eliza Cloud device authentication and SSO session helpers";
 
   private client: CloudApiClient;
   private credentials: CloudCredentials | null = null;
+  private revalidationTimer: ReturnType<typeof setTimeout> | null = null;
+  private revalidationState: RevalidationState = {
+    keyState: "unknown",
+    consecutiveInvalid: 0,
+  };
 
   constructor(runtime?: IAgentRuntime) {
     super(runtime);
@@ -408,6 +511,11 @@ export class CloudAuthService extends Service {
   }
 
   async stop(): Promise<void> {
+    if (this.revalidationTimer) {
+      clearTimeout(this.revalidationTimer);
+      this.revalidationTimer = null;
+    }
+    this.revalidationState = { keyState: "unknown", consecutiveInvalid: 0 };
     this.credentials = null;
   }
 
@@ -441,19 +549,13 @@ export class CloudAuthService extends Service {
       };
       logger.info("[CloudAuth] Authenticated with saved API key");
 
-      // Non-blocking validation — if the key is invalid the next model
-      // call will surface the error; we just log a warning here.
-      this.validateApiKey(key)
-        .then((valid) => {
-          if (!valid) {
-            logger.warn(
-              "[CloudAuth] Saved API key could not be validated (cloud may be unreachable or key revoked) — model calls will use the key anyway"
-            );
-          }
-        })
-        .catch(() => {
-          // Swallow — already logged inside validateApiKey
-        });
+      // Non-blocking, self-healing key re-validation. Boot stays instant; a
+      // background loop confirms the key — retrying transient cloud-unreachable
+      // so a boot-time outage doesn't leave it unvalidated forever, surfacing a
+      // loud actionable error the moment the key is confirmed revoked, and
+      // steady-re-checking so a revocation that happens AFTER boot is caught
+      // instead of the agent silently 401ing every turn (see #8434 key-flag).
+      this.scheduleRevalidation(0);
       return;
     }
 
@@ -474,22 +576,67 @@ export class CloudAuthService extends Service {
     }
   }
 
-  private async validateApiKey(key: string): Promise<boolean> {
+  /**
+   * Probe the saved key: `unreachable` when the cloud can't be reached (a
+   * transient network state, not an auth signal), `valid` when an authenticated
+   * `/models` call succeeds, `invalid` when the cloud is reachable but rejects
+   * the key (revoked/expired). The `invalid` case is debounced upstream so a
+   * one-off 5xx doesn't false-alarm.
+   */
+  private async probeApiKey(key: string): Promise<ApiKeyProbe> {
     if (!(await isCloudReachable())) {
-      logger.warn(
-        "[CloudAuth] Cloud unreachable at boot — skipping API key validation; key will be used as-is"
-      );
-      return false;
+      return "unreachable";
     }
     try {
       const validationClient = new CloudApiClient(this.client.getBaseUrl(), key);
       await validationClient.get("/models", { timeoutMs: 2_500 });
-      return true;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.warn(`[CloudAuth] Could not reach cloud API to validate key: ${msg}`);
-      return false;
+      return "valid";
+    } catch {
+      return "invalid";
     }
+  }
+
+  private scheduleRevalidation(delayMs: number): void {
+    if (this.revalidationTimer) {
+      clearTimeout(this.revalidationTimer);
+    }
+    // The timer is always cleared in stop(), so it can't outlive the service.
+    this.revalidationTimer = setTimeout(() => {
+      void this.runRevalidation();
+    }, delayMs);
+  }
+
+  private async runRevalidation(): Promise<void> {
+    const key = this.credentials?.apiKey;
+    if (!key) {
+      return; // logged out / stopped — let the loop die
+    }
+    const probe = await this.probeApiKey(key).catch(
+      () => "unreachable" as ApiKeyProbe
+    );
+    // The active key may have changed during the await (re-auth) — drop stale.
+    if (this.credentials?.apiKey !== key) {
+      return;
+    }
+    const decision = decideRevalidation(this.revalidationState, probe);
+    this.revalidationState = decision.state;
+    if (decision.log) {
+      if (decision.log.level === "error") {
+        logger.error(decision.log.message);
+      } else {
+        logger.info(decision.log.message);
+      }
+    }
+    this.scheduleRevalidation(decision.delayMs);
+  }
+
+  /**
+   * True once a background probe has CONFIRMED the saved API key is
+   * revoked/invalid (cloud reachable, key rejected). Status/health surfaces can
+   * read this to report a degraded agent instead of letting it 401 blindly.
+   */
+  isApiKeyInvalid(): boolean {
+    return this.revalidationState.keyState === "invalid";
   }
 
   /**


### PR DESCRIPTION
## Problem
A dedicated cloud agent trusts its injected `ELIZAOS_CLOUD_API_KEY` optimistically at boot and validates it **once** in the background. If the cloud was unreachable at that moment (`"skipping validation; key used as-is"`) or the key is revoked **after** boot, the one-shot check leaves the agent **401-blind**: every turn calls the dead key and replies *"my Eliza Cloud key isn't authorized for inference"* forever, with no surfaced state and no recovery.

Observed live on a prod agent whose dedicated key was revoked while its container kept running (flagged on #8434, 06-27). Isolated to that one agent — the rest of the fleet is healthy (agents up 11 days) — but it's a latent foot-gun for any long-lived agent.

## Fix
Replace the one-shot boot check with a **self-healing background re-validation** in `CloudAuthService`:
- **Tri-state probe** (`valid` / `unreachable` / `invalid`) — `unreachable` is a transient network state, not an auth signal.
- **Retry transient unreachability** so a boot-time outage doesn't leave the key permanently unvalidated (the actual root cause of the observed failure).
- **Confirm a revoked key** (cloud reachable, key rejected) with a single loud, **actionable ERROR** — debounced (2 consecutive rejections) so a transient 5xx doesn't false-alarm.
- **Steady re-check (30 min)** so a post-boot revocation is caught and a later re-authorization **self-heals**.
- Expose **`isApiKeyInvalid()`** so status/health can report a degraded agent instead of silently 401ing.

Boot stays instant (non-blocking); the timer is `unref`'d and cleared on `stop()`.

The decision logic is a **pure function** (`decideRevalidation`) split from the I/O, per the repo's "derive in use-cases" rule.

## Tests / evidence
- New unit test `cloud-auth-revalidation.test.ts` covers every transition: boot-unreachable→retry (the fix), single-invalid→unconfirmed, 2×invalid→confirmed+error, blip-preserves-count, invalid→valid self-heal, default-config.
- ⚠️ **Note:** the local checkout's toolchain (`vitest`/`tsgo`) is currently unlinked, so I verified the exact `decideRevalidation` logic **standalone (10/10 pass)** and biome is clean — the authoritative `typecheck` + `vitest` run here in CI. If CI flags anything I'll fix immediately.

This is the agent-side resilience half; the provisioning-side question (why a dedicated key gets revoked while its container runs — ideally a re-key) is cloud-agent's lane and tracked on #8434.
