### PR TITLE
[codex] restore real chat after restart

### DIFF
--- a/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
+++ b/packages/ui/src/state/useChatCallbacks.hydrate.test.ts
@@ -123,6 +123,53 @@ describe("hydrateInitialConversation — chat always has a chat (#1)", () => {
     expect(result).toBeNull(); // already has messages
   });
 
+  it("skips a saved greeting-only draft when a real conversation exists", async () => {
+    window.localStorage.setItem("eliza:chat:activeConversationId", "empty");
+    const realConversation = {
+      ...CONVERSATION,
+      id: "real",
+      title: "Real chat",
+      roomId: "real-room",
+      updatedAt: "2026-06-25T00:00:00.000Z",
+    };
+    const emptyConversation = {
+      ...CONVERSATION,
+      id: "empty",
+      title: "New Chat",
+      roomId: "empty-room",
+      updatedAt: "2026-06-26T00:00:00.000Z",
+    };
+    const client = makeFakeClient({
+      listConversations: vi.fn(async () => ({
+        conversations: [emptyConversation, realConversation],
+      })),
+      getConversationMessages: vi.fn(async (id: string) => ({
+        messages:
+          id === "empty"
+            ? [
+                {
+                  id: "greeting",
+                  role: "assistant",
+                  source: "agent_greeting",
+                  text: "hey",
+                  timestamp: 1,
+                },
+              ]
+            : [{ id: "m1", role: "user", text: "hello", timestamp: 2 }],
+      })),
+    });
+    const { deps, setActiveConversationId, setConversationMessages } =
+      makeDeps(client);
+
+    const result = await hydrateInitialConversation(deps);
+
+    expect(setActiveConversationId).toHaveBeenCalledWith("real");
+    expect(setConversationMessages.mock.calls.at(-1)?.[0]).toEqual([
+      { id: "m1", role: "user", text: "hello", timestamp: 2 },
+    ]);
+    expect(result).toBeNull();
+  });
+
   it("returns the new conversation id to backfill when created WITHOUT an inline greeting", async () => {
     const client = makeFakeClient({
       createConversation: vi.fn(async () => ({

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -92,6 +92,18 @@ function isPersistedGreetingMessage(message: ConversationMessage): boolean {
   );
 }
 
+function hasUserConversationMessage(messages: ConversationMessage[]): boolean {
+  return messages.some((message) => message.role === "user");
+}
+
+function isDraftOnlyConversationMessages(
+  messages: ConversationMessage[],
+): boolean {
+  if (hasUserConversationMessage(messages)) return false;
+  if (messages.length === 0) return true;
+  return messages.every(isPersistedGreetingMessage);
+}
+
 /** The subset of the API client the initial-conversation hydration needs.
  *  Injected (not the module singleton) so the policy below is unit-testable. */
 export type HydrateConversationClient = Pick<
@@ -112,6 +124,51 @@ export interface HydrateInitialConversationDeps {
   setActiveConversationId: (id: string | null) => void;
   setConversationMessages: (messages: ConversationMessage[]) => void;
   uiLanguage: string;
+}
+
+async function resolveRestoredConversationWithMessages(
+  api: HydrateConversationClient,
+  conversations: Conversation[],
+): Promise<{
+  conversation: Conversation;
+  messages: ConversationMessage[];
+}> {
+  const savedConversationId = loadActiveConversationId();
+  const restoredConversation =
+    conversations.find((conversation) => conversation.id === savedConversationId) ??
+    conversations[0];
+  let restoredMessages: ConversationMessage[] = [];
+  try {
+    restoredMessages = filterRenderableConversationMessages(
+      (await api.getConversationMessages(restoredConversation.id)).messages,
+    );
+  } catch {
+    return { conversation: restoredConversation, messages: [] };
+  }
+
+  if (
+    conversations.length <= 1 ||
+    !isDraftOnlyConversationMessages(restoredMessages)
+  ) {
+    return { conversation: restoredConversation, messages: restoredMessages };
+  }
+
+  for (const candidate of conversations) {
+    if (candidate.id === restoredConversation.id) continue;
+    let candidateMessages: ConversationMessage[];
+    try {
+      candidateMessages = filterRenderableConversationMessages(
+        (await api.getConversationMessages(candidate.id)).messages,
+      );
+    } catch {
+      continue;
+    }
+    if (hasUserConversationMessage(candidateMessages)) {
+      return { conversation: candidate, messages: candidateMessages };
+    }
+  }
+
+  return { conversation: restoredConversation, messages: restoredMessages };
 }
 
 /**
@@ -157,11 +214,8 @@ export async function hydrateInitialConversation(
     }
     setConversations(conversations);
     if (conversations.length > 0) {
-      const savedConversationId = loadActiveConversationId();
-      const restoredConversation =
-        conversations.find(
-          (conversation) => conversation.id === savedConversationId,
-        ) ?? conversations[0];
+      const { conversation: restoredConversation, messages: nextMessages } =
+        await resolveRestoredConversationWithMessages(api, conversations);
       if (!isCurrentHydration()) {
         return null;
       }
@@ -172,13 +226,6 @@ export async function hydrateInitialConversation(
         conversationId: restoredConversation.id,
       });
       try {
-        const { messages } = await api.getConversationMessages(
-          restoredConversation.id,
-        );
-        if (!isCurrentHydration()) {
-          return null;
-        }
-        const nextMessages = filterRenderableConversationMessages(messages);
         greetingFiredRef.current =
           hasConversationBootstrapMessage(nextMessages);
         conversationMessagesRef.current = nextMessages;


### PR DESCRIPTION
## Summary

Restore a real conversation after restart instead of landing on a greeting-only draft.

The backend can still have persisted conversations and messages, but the renderer hydration path restores the saved active conversation id first. If that saved id points at a bootstrap-only "New Chat" thread, restart appears to erase chat history even though older conversations are still in PGlite and the conversation API.

This PR:
- detects empty / greeting-only restored conversations during initial hydration
- scans existing conversations for the first thread with user messages
- restores that real conversation and its messages instead of the draft
- keeps the old fallback behavior when message fetches fail or no real conversation exists

## Impact

After restarting the local app, users are less likely to land on a blank-looking new chat while real history exists in the backend.

## Validation

Run on the source stack before splitting this focused PR:
- `bun run --cwd eliza/packages/ui test -- useChatCallbacks.hydrate`
- `bun run --cwd eliza/packages/ui typecheck`
- API check confirmed older persisted messages still existed in `/api/conversations/:id/messages`

This PR branch:
- `git diff --check`
