### PR TITLE
[codex] show cloud connectors upsell in settings

### DIFF
--- a/packages/ui/src/cloud/connectors/CloudConnectorsSection.tsx
+++ b/packages/ui/src/cloud/connectors/CloudConnectorsSection.tsx
@@ -10,7 +10,17 @@
 
 "use client";
 
+import { Bot, Cloud, MessageSquare, Plug, RadioTower } from "lucide-react";
+import { useCallback } from "react";
 import { DashboardSection } from "../../cloud-ui/components/brand/dashboard-section";
+import { useAgentElement } from "../../agent-surface";
+import { useAppSelectorShallow } from "../../state";
+import { Button } from "../../components/ui/button";
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStack,
+} from "../../components/settings/settings-layout";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { BlooioConnection } from "./blooio-connection";
 import { DiscordGatewayConnection } from "./discord-gateway-connection";
@@ -20,8 +30,130 @@ import { TelegramConnection } from "./telegram-connection";
 import { TwilioConnection } from "./twilio-connection";
 import { WhatsAppConnection } from "./whatsapp-connection";
 
+const CLOUD_CONNECTOR_FEATURES = [
+  {
+    icon: RadioTower,
+    label: "Always-on gateway hosting",
+    description:
+      "Keep Discord, Telegram, WhatsApp, Twilio, Google, and Microsoft routes online without depending on this Mac staying awake.",
+  },
+  {
+    icon: Bot,
+    label: "Agent routing",
+    description:
+      "Route each cloud connection to the right hosted agent or local app target as your setup grows.",
+  },
+  {
+    icon: MessageSquare,
+    label: "Shared messaging surfaces",
+    description:
+      "Use managed OAuth, webhooks, and bot gateways for teams and devices that cannot reach your local machine.",
+  },
+] as const;
+
+function CloudConnectorsUpsell() {
+  const {
+    elizaCloudConnected,
+    elizaCloudLoginBusy,
+    handleCloudLogin,
+    setActionNotice,
+    t,
+  } = useAppSelectorShallow((s) => ({
+    elizaCloudConnected: s.elizaCloudConnected,
+    elizaCloudLoginBusy: s.elizaCloudLoginBusy,
+    handleCloudLogin: s.handleCloudLogin,
+    setActionNotice: s.setActionNotice,
+    t: s.t,
+  }));
+
+  const handleConnect = useCallback(() => {
+    void handleCloudLogin().catch((error) => {
+      setActionNotice(
+        error instanceof Error ? error.message : "Could not start Cloud login.",
+        "error",
+        5000,
+      );
+    });
+  }, [handleCloudLogin, setActionNotice]);
+
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "cloud-connectors-connect-cloud",
+    role: "button",
+    label: "Connect Eliza Cloud",
+    group: "cloud-connectors",
+    status: elizaCloudConnected ? "connected" : "available",
+    onActivate: elizaCloudLoginBusy ? undefined : handleConnect,
+  });
+
+  return (
+    <SettingsStack>
+      <SettingsGroup
+        title={t("settings.cloudConnectorsUpsell.title", {
+          defaultValue: "Hosted connector gateways",
+        })}
+        description={t("settings.cloudConnectorsUpsell.description", {
+          defaultValue:
+            "Local connectors stay available in the regular Connectors tab. Cloud Connectors unlock hosted OAuth and bot gateways when you want messaging to keep working beyond this machine.",
+        })}
+        action={
+          <Button
+            ref={ref}
+            size="sm"
+            onClick={handleConnect}
+            disabled={elizaCloudLoginBusy}
+            {...agentProps}
+          >
+            <Cloud className="h-4 w-4" aria-hidden />
+            {elizaCloudLoginBusy
+              ? t("settings.cloudConnectorsUpsell.connecting", {
+                  defaultValue: "Connecting...",
+                })
+              : t("settings.cloudConnectorsUpsell.connectCta", {
+                  defaultValue: "Connect Cloud",
+                })}
+          </Button>
+        }
+      >
+        <SettingsRow
+          icon={Plug}
+          label={t("settings.cloudConnectorsUpsell.localModeLabel", {
+            defaultValue: "Cloud is not connected",
+          })}
+          description={t("settings.cloudConnectorsUpsell.localModeDescription", {
+            defaultValue:
+              "You can keep using local Discord, Telegram, Slack, iMessage, Signal, and WhatsApp connectors without Cloud.",
+          })}
+        />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={t("settings.cloudConnectorsUpsell.unlockTitle", {
+          defaultValue: "What Cloud Connectors unlock",
+        })}
+      >
+        {CLOUD_CONNECTOR_FEATURES.map((feature) => (
+          <SettingsRow
+            key={feature.label}
+            icon={feature.icon}
+            label={feature.label}
+            description={feature.description}
+          />
+        ))}
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}
+
 export function CloudConnectorsSection() {
   const t = useCloudT();
+  const elizaCloudConnected = useAppSelectorShallow(
+    (s) => s.elizaCloudConnected,
+  );
+
+  if (!elizaCloudConnected) {
+    return <CloudConnectorsUpsell />;
+  }
+
   return (
     <div className="space-y-8">
       {/* Messaging & Communication Section */}

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -19,6 +19,7 @@ import {
   Webhook,
 } from "lucide-react";
 import type { ComponentType } from "react";
+import { registerCloudConnectorsSettingsSection } from "../../cloud/connectors";
 import { ReleaseCenterView } from "../pages/ReleaseCenterView";
 import { AdvancedSection } from "./AdvancedSection";
 import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
@@ -266,6 +267,8 @@ registerSettingsSection({
   order: 1.5,
   Component: CloudAgentsSection,
 });
+
+registerCloudConnectorsSettingsSection();
 
 /** Every section the Settings view should render — built-ins plus any added by
  *  a host app / plugin through {@link registerSettingsSection}. */


### PR DESCRIPTION
## Summary

Show the Cloud Connectors Settings tab in local mode and render an upsell when Cloud is not connected.

Local Settings always registered Cloud Overview and Cloud Agents, but Cloud Connectors was only registered through the full Cloud settings bundle. Since local Settings intentionally does not import that full bundle, the Cloud Connectors tab was missing even though the desired local behavior is an upsell surface.

This PR:
- registers the Cloud Connectors Settings section from the local Settings registry path
- keeps the live cloud connector controls behind the existing Cloud-connected state
- shows a hosted connector gateway upsell when Cloud is disconnected
- links the CTA to the existing Cloud login flow

## Impact

Users in local mode can discover Cloud Connectors from Settings without connecting Cloud first. Connected users still see the live cloud connector controls.

## Validation

Run on the source stack before splitting this focused PR:
- `bun run --cwd eliza/packages/ui typecheck`
- `bunx vitest run apps/app/test/package-mode-aliases.test.ts`
- live browser check at `http://127.0.0.1:2138/settings#cloud-connectors`

This PR branch:
- `git diff --check`
