### PR TITLE
fix(cloud-frontend): mount StewardProvider on public /app-auth/authorize so sign-in doesn't crash (#9881)

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// --- collaborator doubles ---
+
+// The real StewardAuthProvider lazy-loads the heavy `@stwd/*` runtime and reads
+// router/location context. Stub it with a marker wrapper so we can assert the
+// authorize content is mounted INSIDE it (the #9881 fix: useAuth() needs the
+// Steward provider as an ancestor on this public route).
+vi.mock("../../../shell/StewardProvider", () => ({
+  StewardAuthProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="steward-auth-provider">{children}</div>
+  ),
+}));
+
+vi.mock("../../../../cloud-ui/components/auth/authorize-content", () => ({
+  AuthorizeContent: () => <div data-testid="authorize-content" />,
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import AppAuthAuthorizePage from "./app-authorize-page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AppAuthAuthorizePage", () => {
+  it("mounts AuthorizeContent inside StewardAuthProvider so useAuth() resolves on the public route (#9881)", () => {
+    render(<AppAuthAuthorizePage />);
+
+    const provider = screen.getByTestId("steward-auth-provider");
+    const content = screen.getByTestId("authorize-content");
+    expect(provider).toBeTruthy();
+    expect(content).toBeTruthy();
+    // The provider must be an ancestor of the authorize content, otherwise
+    // `useAuth()` throws "must be used within a <StewardProvider>".
+    expect(provider.contains(content)).toBe(true);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx
@@ -2,11 +2,21 @@
  * Third-party app OAuth-authorize page (public). Reuses the cloud-ui
  * `AuthorizeContent` component (the shared authorize UI). Ported from
  * `@elizaos/cloud-frontend/src/pages/app-auth/authorize/page.tsx`.
+ *
+ * `AuthorizeContent` calls `useAuth()` / renders `<StewardLogin>` from
+ * `@stwd/react`, both of which require an ancestor Steward `<StewardProvider>`.
+ * As a `public: true` route this page renders WITHOUT the per-route Steward
+ * wrapper (see `CloudRouteElement`), so it must mount the shell's
+ * `StewardAuthProvider` itself — otherwise `useAuth()` throws "must be used
+ * within a <StewardProvider>" and all monetized-app sign-in is blocked (#9881).
+ * `StewardAuthProvider` already lists `/app-auth` in its runtime route patterns,
+ * so it mounts the Steward runtime even for an unauthenticated visitor.
  */
 
 import { Suspense } from "react";
 import { AuthorizeContent } from "../../../../cloud-ui/components/auth/authorize-content";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
+import { StewardAuthProvider } from "../../../shell/StewardProvider";
 import { usePageTitle } from "../../lib/use-page-title";
 
 export default function AppAuthAuthorizePage() {
@@ -17,8 +27,10 @@ export default function AppAuthAuthorizePage() {
     }),
   );
   return (
-    <Suspense fallback={null}>
-      <AuthorizeContent />
-    </Suspense>
+    <StewardAuthProvider>
+      <Suspense fallback={null}>
+        <AuthorizeContent />
+      </Suspense>
+    </StewardAuthProvider>
   );
 }


### PR DESCRIPTION
**Fixes #9881 — P0, blocks all monetized-app OAuth sign-in.** Root-caused by vps-agent while testing the monetized-app flow end-to-end; confirmed live (headless render of prod `/app-auth/authorize` → "useAuth must be used within a `<StewardProvider>`" error boundary).

`AuthorizeContent` calls `@stwd/react`'s `useAuth()` / `<StewardLogin>`, which need an ancestor Steward `<StewardProvider>`. But `/app-auth/authorize` is a `public: true` route, so `CloudRouteElement` renders it **without** the per-route Steward wrapper → `useAuth()` throws → every unauthenticated user signing into a deployed app crashes.

**Fix (1 component + 1 test, minimal):** wrap the page's content in the shell's existing `StewardAuthProvider` (`shell/StewardProvider`). That provider **already whitelists `/app-auth`** in its runtime route patterns, so it lazy-mounts the Steward runtime (with the populated `auth` prop) even for an unauthenticated visitor — no new provider system, no duplication, no auth-infra change. Kept the route `public`. Added a render test (asserts `AuthorizeContent` mounts under `StewardAuthProvider`).

Verified: bug reproduced live on prod; fix diff reviewed. The live OAuth round-trip + `audit:cloud` proof rides the develop→staging deploy (I'll confirm the page renders the sign-in UI instead of crashing). Not currently hitting live prod users (no monetized apps deployed in prod yet), but it's the gate before opening monetized-app sign-in.