### PR TITLE
fix(cloud-shared): complete outbound-url mock so safe-fetch links in enqueue tests

### DIFF
--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -15,6 +15,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
+import * as realOutboundUrl from "../security/outbound-url";
 
 // ---- captured query state ----
 let capturedSelectWhere: SQL | undefined;
@@ -89,8 +90,13 @@ mock.module("../../db/helpers", () => ({
   writeTransaction: (fn: (t: typeof tx) => Promise<unknown>) => transaction(fn),
 }));
 
-// Avoid the real outbound-URL guard and job hydration/insert-prep pulling in DB.
+// Stub the outbound-URL guard the enqueue path calls so it can't reach out over
+// the network, but keep the module's full export surface intact — `safe-fetch`
+// (pulled in transitively) statically imports `isForbiddenIpAddress`,
+// `normalizeHostname`, and `resolveSafeOutboundTarget`, and a partial mock would
+// break that link with "Export named 'isForbiddenIpAddress' not found".
 mock.module("../security/outbound-url", () => ({
+  ...realOutboundUrl,
   assertSafeOutboundUrl: mock(async (u: string) => u),
 }));
 


### PR DESCRIPTION
## What

`cloud-tests › unit-tests` was red on `develop`: all 7 tests in
`provisioning-jobs-delete-enqueue.test.ts` failed with

```
SyntaxError: Export named 'isForbiddenIpAddress' not found in module
  packages/cloud-shared/src/lib/security/outbound-url.ts
```

(e.g. [run 28310367199](https://github.com/elizaOS/eliza/actions/runs/28310367199/job/83874080640)).

## Root cause

The test stubs `../security/outbound-url` with a `mock.module` factory that
exported **only** `assertSafeOutboundUrl`. The SSRF-guard PR
(#9853 / #9873) added `safe-fetch.ts`, which **statically** imports
`isForbiddenIpAddress`, `normalizeHostname`, and `resolveSafeOutboundTarget`
from that same module. When the enqueue tests transitively load `safe-fetch`
(via `provisioning-jobs`), Bun links those named imports against the partial
mock — which no longer exports them — and throws at link time. `outbound-url`
itself was unchanged and still exports `isForbiddenIpAddress`; the mock just
hid it.

## Fix

Spread the real module into the mock and override only the guard the enqueue
path calls. This keeps the full export surface so `safe-fetch` links, while
still stubbing `assertSafeOutboundUrl` so the enqueue path never reaches the
network. This is the same pattern already used in `user-mcps.test.ts`. The real
`outbound-url` module is side-effect free (only `node:dns` / `node:net`), so the
spread is safe.

One-line change to a single test file; no production code touched.

> Note: the sibling `Format + Type Safety Ratchet` failure from the same commit
> was an unbumped baseline; it is already fixed on `develop` by `465455f727`
> (`asUnknownAs` baseline 129 → 132), so this PR does not touch it.

## Evidence

Verified against the current `develop` tip in a worktree:

```
# before
$ bun test src/lib/services/provisioning-jobs-delete-enqueue.test.ts
 0 pass / 7 fail   (Export named 'isForbiddenIpAddress' not found)

# after
$ bun test src/lib/services/provisioning-jobs-delete-enqueue.test.ts
 7 pass / 0 fail

# no regression in the module's own tests
$ bun test src/lib/security/outbound-url.test.ts
 36 pass / 0 fail

# sibling provisioning-jobs suite, CI-equivalent (--isolate, as test-cloud-run.mjs uses)
$ bun test --isolate src/lib/services/provisioning-jobs
 26 pass / 0 fail

# type-safety ratchet
[type-safety-ratchet] as unknown as: 132 / 132   (green)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)