### PR TITLE
fix(core): structural planner-confabulation root-cause fixes (#9874)

### DIFF
--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -43,6 +43,50 @@ describe("formatMessages", () => {
 		);
 	});
 
+	it("preserves the full reacted-to message text in context (#9874)", () => {
+		// A reaction memory's `text` truncates the reacted-to content to a short
+		// stub; the untruncated original lives in `reactedMessageText`. Context
+		// formatting must surface the full statement so the planner does not
+		// back-rationalize a truncated fragment into a phantom task.
+		const full =
+			"can you pull the Q3 revenue numbers and compare them against Q2 for me";
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000021" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: {
+						text: `*Added 👍 to: "${full.slice(0, 50)}…"*`,
+						reactedMessageText: full,
+					},
+				} as Memory,
+			],
+			entities: [],
+		});
+
+		expect(rendered).toContain(full);
+		expect(rendered).toContain("reacted-to message in full");
+	});
+
+	it("omits the reacted-to context line when no reactedMessageText is set", () => {
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000022" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: { text: "just a normal message" },
+				} as Memory,
+			],
+			entities: [],
+		});
+
+		expect(rendered).not.toContain("reacted-to message in full");
+	});
+
 	it("advertises a stored-content read when readable text is stored", () => {
 		const rendered = formatMessages({
 			messages: [

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
+import { addresseeIsNonOwnerBot } from "../addressed-to.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const BOT_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const HUMAN_X = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+
+function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		character: { name: "MyAgent" },
+		getAgent: vi.fn(async () => null),
+		getEntitiesForRoom: vi.fn(async () => [] as Entity[]),
+		...overrides,
+	} as unknown as IAgentRuntime;
+}
+
+function makeMessage(metadata?: Record<string, unknown>): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000ee" as UUID,
+		entityId: SENDER_ID,
+		roomId: ROOM_ID,
+		content: { text: "do the thing" },
+		metadata,
+	} as Memory;
+}
+
+describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
+	it("returns false when there are no explicit addressees", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: [],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when addressed to this agent by name (case/@-insensitive)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["@myagent"],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when addressed to this agent by id", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: [AGENT_ID],
+			}),
+		).toBe(false);
+	});
+
+	it("returns true when a bot addresses someone other than us (sender fromBot)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["SomeOtherBot"],
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when an addressee resolves to a registered agent (no fromBot)", async () => {
+		const getAgent = vi.fn(async (id: UUID) =>
+			id === BOT_B ? ({ id: BOT_B } as unknown) : null,
+		);
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime({ getAgent } as Partial<IAgentRuntime>),
+				message: makeMessage(),
+				addressedTo: [BOT_B],
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when the addressee is a human (not a registered agent, not fromBot)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: [HUMAN_X],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when an addressed name cannot be resolved and the sender is not a bot", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: ["@ghost"],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when a BOT addresses us by a platform-handle ALIAS (not character.name)", async () => {
+		// Regression: the agent's room entity carries platform-handle aliases
+		// (e.g. samantha_ai_bot) that are not character.name. A bot addressing us
+		// by such an alias must be recognized as addressed-to-us and NOT have its
+		// tool request suppressed — the self-by-resolution check runs before the
+		// fromBot short-circuit.
+		const runtime = makeRuntime({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, names: ["samantha_ai_bot", "Samantha"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime,
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["@samantha_ai_bot"],
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -100,6 +100,64 @@ describe("v5 message handler routing", () => {
 		}
 	});
 
+	it("suppresses the simple→requiresTool promotion for bot-to-bot crosstalk (#9874)", () => {
+		// The inbound is addressed to another bot, not us; the caller resolved
+		// that and passes suppressToolPromotion. requiresTool would normally
+		// promote a simple-only turn to planning against general — here it must
+		// stay on the simple reply so we do not fabricate a phantom tool task.
+		const output = {
+			processMessage: "RESPOND" as const,
+			thought: "Overheard crosstalk.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: true,
+				reply: "got it",
+			},
+		};
+
+		const promoted = routeMessageHandlerOutput(output);
+		expect(promoted.type).toBe("planning_needed");
+
+		const suppressed = routeMessageHandlerOutput(output, {
+			suppressToolPromotion: true,
+		});
+		expect(suppressed.type).toBe("final_reply");
+		if (suppressed.type === "final_reply") {
+			expect(suppressed.reply).toBe("got it");
+		}
+	});
+
+	it("suppression also blocks the candidateActions promotion, but leaves explicit non-simple planning intact (#9874)", () => {
+		const candidatePromotion = {
+			processMessage: "RESPOND" as const,
+			thought: "candidate hint.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: true,
+				candidateActions: ["BASH"],
+				reply: "on it",
+			},
+		};
+		expect(
+			routeMessageHandlerOutput(candidatePromotion, {
+				suppressToolPromotion: true,
+			}).type,
+		).toBe("final_reply");
+
+		// Suppression only blocks the simple-path promotion; a turn that already
+		// selected a real non-simple context still plans against it.
+		const explicitPlanning = {
+			processMessage: "RESPOND" as const,
+			thought: "real context.",
+			plan: { contexts: ["general"], requiresTool: true },
+		};
+		expect(
+			routeMessageHandlerOutput(explicitPlanning, {
+				suppressToolPromotion: true,
+			}).type,
+		).toBe("planning_needed");
+	});
+
 	it("keeps simple route for explicit non-tool candidate hints", () => {
 		const output = {
 			processMessage: "RESPOND" as const,

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -763,6 +763,102 @@ describe("v5 planner loop skeleton", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 	});
 
+	it("captures a SAFE native-text refusal at required-tool exhaustion instead of a generic apology (#9874)", async () => {
+		// Companion to the guard above. When Stage 1 forced requiresTool but no
+		// exposed tool can satisfy the request, a native-mode model emits an
+		// honest refusal as `text` with no REPLY call / explicit messageToUser.
+		// That text is a genuine user-facing reply (not a pre-tool thought), so it
+		// must reach the user — gated through the user-safe refusal check — rather
+		// than throwing into the caller's generic "something went wrong".
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "I'm not able to search the chat history directly from here.",
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"I'm not able to search the chat history directly from here.",
+		);
+		// maxRequiredToolMisses=1: the 2nd miss exhausts the cap and returns the
+		// captured native refusal.
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("never surfaces a leaked tool-call as a native refusal at exhaustion (#9874)", async () => {
+		// Negative control: native text that is a reasoning/leak must be rejected
+		// by the user-safe gate, so the loop throws rather than leaking it.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "I need to call SEARCH_MESSAGES to find that.",
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it.each([
+		"Let me check the database for that information.",
+		"Let me pull up your recent messages.",
+		"I'm reviewing the conversation history to answer.",
+		"I'll look that up and get back to you.",
+		"Pulling up the info now, one sec.",
+	])("never surfaces native intent-narration as a refusal: %s (#9874)", async (text) => {
+		// Regression: a native pre-tool/intent-narration text carries no leak
+		// markup and no "thinking through" marker, so a denylist would let it
+		// through and the agent would falsely claim it is doing work it never
+		// did. The positive-allowlist gate (must read as an inability) rejects
+		// it → the loop throws → caller emits the generic apology, never the
+		// phantom action claim.
+		const runtime = {
+			useModel: vi.fn(async () => ({ text, toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+	});
+
 	it("retries planner calls to tools that are not exposed this turn", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -115,7 +115,87 @@ interface ResolveTargetsArgs {
 	addressedTo: readonly string[];
 }
 
-async function resolveAddressedTargets(
+/**
+ * Detects bot-to-bot crosstalk: the inbound message is directed at another
+ * participant that is NOT this agent, in a context where the agent is merely
+ * overhearing. Used to suppress the simple→requiresTool promotion so the agent
+ * does not fabricate a tool task from crosstalk it was not asked to act on
+ * (#9874 item 1).
+ *
+ * Returns true only when ALL hold:
+ *  - the message carries explicit `addressedTo` targets,
+ *  - none of them is this agent (by name or id) — i.e. it is not addressed to us,
+ *  - it is bot crosstalk: the SENDER is a bot (`metadata.fromBot`), OR a resolved
+ *    addressee is itself a registered agent (`getAgent`).
+ *
+ * A human owner addressed by name is never a registered agent and never carries
+ * `fromBot`, so owner-directed talk does not trip this. Fails SAFE (returns
+ * false) whenever it cannot positively confirm crosstalk — suppression is the
+ * conservative action and is only taken on a clear signal.
+ */
+export async function addresseeIsNonOwnerBot(
+	args: ApplyAddressedToArgs,
+): Promise<boolean> {
+	const { runtime, message, addressedTo } = args;
+	if (!addressedTo || addressedTo.length === 0) {
+		return false;
+	}
+
+	const normalize = (value: string) =>
+		value.trim().toLowerCase().replace(/^@/, "");
+	const self = new Set<string>();
+	const selfId = runtime.agentId;
+	if (selfId) self.add(selfId.toLowerCase());
+	const selfName = runtime.character?.name;
+	if (selfName) self.add(normalize(selfName));
+
+	const cleaned = addressedTo
+		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+		.filter((entry) => entry.length > 0);
+	if (cleaned.length === 0) {
+		return false;
+	}
+
+	// Addressed to us by literal name/id → handle normally, never suppress.
+	if (cleaned.some((entry) => self.has(normalize(entry)))) {
+		return false;
+	}
+
+	// Resolve names→ids against the room. This also maps the agent's OWN entity
+	// aliases (platform handles like @samantha_ai_bot that connectors store on the
+	// agent's entity) to selfId, so a turn addressed to us by an alias is NOT
+	// mistaken for crosstalk — even when the sender is a bot. We must do this
+	// BEFORE the fromBot short-circuit, otherwise an owner-run relay bot
+	// addressing us by our handle would have its legitimate request suppressed.
+	const targets = await resolveAddressedTargets({
+		runtime,
+		message,
+		addressedTo,
+	});
+	if (selfId && targets.some((id) => id === selfId)) {
+		return false;
+	}
+
+	// A bot talking to someone other than us is crosstalk we are overhearing.
+	const senderIsBot =
+		(message.metadata as { fromBot?: boolean } | undefined)?.fromBot === true;
+	if (senderIsBot) {
+		return true;
+	}
+
+	// Otherwise confirm at least one addressee resolves to a registered agent.
+	for (const targetId of targets) {
+		if (targetId === selfId) {
+			continue;
+		}
+		if (await runtime.getAgent(targetId)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export async function resolveAddressedTargets(
 	args: ResolveTargetsArgs,
 ): Promise<UUID[]> {
 	const { runtime, message, addressedTo } = args;

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -194,6 +194,7 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 
 export function routeMessageHandlerOutput(
 	output: V5MessageHandlerOutput,
+	options?: { suppressToolPromotion?: boolean },
 ): MessageHandlerRoute {
 	const processMessage = output.processMessage;
 	if (processMessage === "IGNORE") {
@@ -234,10 +235,15 @@ export function routeMessageHandlerOutput(
 	// routing layer.
 	const candidateActionsRequestPlanning =
 		hasCandidateActions && output.plan.requiresTool !== false;
-	if (
+	// #9874 item 1: when the caller has identified this turn as bot-to-bot
+	// crosstalk addressed to a non-owner bot, do NOT promote a simple-path turn
+	// into forced tool planning. The agent is overhearing talk it was not asked
+	// to act on; forcing a tool fabricates a phantom task (the false-ack seed).
+	// The Stage-1 simple reply still ships via the final_reply branch below.
+	const promotionRequested =
 		(requiresTool || candidateActionsRequestPlanning) &&
-		nonSimpleContexts.length === 0
-	) {
+		nonSimpleContexts.length === 0;
+	if (promotionRequested && !options?.suppressToolPromotion) {
 		return {
 			type: "planning_needed",
 			output,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -245,9 +245,17 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
-					const refusalCandidate = getNonEmptyString(
-						lastPlannerExplicitMessageToUser,
-					);
+					// Prefer the planner's EXPLICIT messageToUser refusal. When the
+					// model emitted only native free text (no explicit field, no REPLY
+					// call), fall back to that text ONLY if it survives the user-safe
+					// refusal gate — which rejects reasoning/leak/fabrication AND
+					// pre-tool deliberation — so an honest native-mode refusal reaches
+					// the user instead of the caller's generic apology, without ever
+					// surfacing a pre-tool thought (#9874 item 3; guarded by the "does
+					// not capture native text fallback" test).
+					const refusalCandidate =
+						getNonEmptyString(lastPlannerExplicitMessageToUser) ??
+						userSafeRefusalCandidate(plannerOutput.messageToUser);
 					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
 					requiredToolMisses++;
 					if (
@@ -2834,6 +2842,75 @@ function isUnsafeUserVisibleText(value: string | undefined): boolean {
 		/\b(?:MESSAGE\s+action|action=(?:draft_reply|respond|send_draft|triage|list_inbox))\b/i,
 		/\{\s*"parameters"\s*:/i,
 	].some((pattern) => pattern.test(text));
+}
+
+// Detects planner free-text that NARRATES the model's own deliberation / tool
+// selection rather than addressing the user — a pre-tool "thought". Kept as a
+// belt-and-braces reject alongside the positive allowlist below.
+function looksLikePreToolThought(value: string): boolean {
+	const text = value.trim();
+	if (!text) return false;
+	return [
+		/\bthink(?:ing)?\s+through\b/i,
+		/\btool\s+choice\b/i,
+		/\b(?:after|before|once)\s+(?:thinking|considering|deciding|choosing|reviewing|figuring)\b/i,
+		/\blet me (?:think|consider|figure|decide|choose)\b/i,
+		/\bI(?:'ll| will| should| need to| am going to| plan to)\s+(?:think|consider|figure|decide|choose)\b/i,
+	].some((pattern) => pattern.test(text));
+}
+
+// Positive markers that a native free-text is a genuine inability/refusal — the
+// ONLY shape we surface from an ambiguous native `text` field. An allowlist (not
+// a denylist of known-bad phrasings) is what makes this safe: intent-narration
+// like "Let me check the database" or "I'm reviewing the history" carries no
+// inability marker, so it is never surfaced and a pre-tool thought can't reach
+// the user as a fake "refusal" (#9874 item 3).
+const REFUSAL_MARKERS = [
+	/\b(?:can(?:'|no)?t|cannot)\b/i,
+	/\b(?:un)?able to\b/i,
+	/\bdon'?t (?:have|see)\b/i,
+	/\bno (?:access|way|ability|matching|such|suitable)\b/i,
+	/\bnot (?:available|possible|supported|something I can|wired|connected|set up)\b/i,
+	/\bisn'?t (?:available|possible|supported|something I can)\b/i,
+	/\bthere(?:'s| is| are) (?:no|nothing)\b/i,
+];
+
+// In-flight / imminent action narration — the confabulation shape ("Let me look
+// that up", "I'm pulling up your messages", "please hold"). Rejected even when a
+// refusal marker co-occurs, because once this iteration ends no further tool
+// work happens, so any "I'm doing X now" is a false promise.
+const IN_FLIGHT_ACTION_CLAIM = [
+	/\blet me\b/i,
+	/\bI(?:'ll| will| am going to|'m going to|'m gonna| am gonna)\b/i,
+	/\bI'?m\s+(?:checking|fetching|searching|looking|pulling|reviewing|gathering|working|getting|grabbing|loading|digging|querying)\b/i,
+	/\b(?:one|just a)\s+(?:sec|second|moment|min|minute)\b/i,
+	/\bplease (?:hold|wait)\b/i,
+	/\b(?:be right back|brb|hang on)\b/i,
+];
+
+// Gate for surfacing native planner free-text as a forced-tool-exhaustion
+// refusal (#9874 item 3). Returns the sanitized message ONLY when it POSITIVELY
+// reads as an inability statement (REFUSAL_MARKERS) and carries no leaked
+// tool-call/reasoning markup (isUnsafeUserVisibleText), no deliberation
+// (looksLikePreToolThought), and no in-flight action claim (IN_FLIGHT). When the
+// text is ambiguous (e.g. a bare native "Let me check…" thought) it returns
+// undefined and the caller falls back to its generic apology — the safe
+// direction. Stricter than userSafeFinalMessage's candidate check, which runs on
+// text already known to be user-directed.
+function userSafeRefusalCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (!REFUSAL_MARKERS.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (looksLikePreToolThought(candidate)) return undefined;
+	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	return candidate;
 }
 
 function preferRecommendedToolCall(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -41,7 +41,10 @@ import {
 import { retrieveActions } from "../runtime/action-retrieval";
 import { resolveActionRolePolicyRole } from "../runtime/action-role-policy";
 import { tierActionResults } from "../runtime/action-tiering";
-import { applyAddressedTo } from "../runtime/addressed-to";
+import {
+	addresseeIsNonOwnerBot,
+	applyAddressedTo,
+} from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
 import {
 	filterByContextGate,
@@ -5922,7 +5925,30 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler.plan.contexts,
 			availableContexts,
 		);
-		const route = routeMessageHandlerOutput(messageHandler);
+		// #9874 item 1: suppress the simple→requiresTool promotion when this turn
+		// is bot-to-bot crosstalk addressed to a non-owner bot — the agent is
+		// overhearing, not being asked to act, so forcing a tool fabricates a
+		// phantom task. Cheap-gated: only resolve addressees when a promotion could
+		// actually fire (requiresTool / candidateActions) and the message carries
+		// explicit addressees.
+		const mayPromoteToTool =
+			messageHandler.plan.requiresTool === true ||
+			(messageHandler.plan.candidateActions?.length ?? 0) > 0;
+		// Fail SAFE on any resolution error (DB hiccup in getEntitiesForRoom /
+		// getAgent): a transient failure must NOT convert a normal turn into the
+		// generic failure reply — it just means "don't suppress", matching the
+		// conservative contract and the fire-and-forget addressee handling above.
+		const suppressToolPromotion =
+			mayPromoteToTool && addressedTo.length > 0
+				? await addresseeIsNonOwnerBot({
+						runtime: args.runtime,
+						message: args.message,
+						addressedTo,
+					}).catch(() => false)
+				: false;
+		const route = routeMessageHandlerOutput(messageHandler, {
+			suppressToolPromotion,
+		});
 		if (route.type === "ignored" || route.type === "stopped") {
 			return {
 				kind: "terminal",

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -114,6 +114,15 @@ export interface Content {
 	/** UUID of parent message if this is a reply/thread */
 	inReplyTo?: UUID;
 
+	/**
+	 * Full, untruncated text of the message THIS message reacted to. Connectors
+	 * that record an emoji reaction as a short display stub in `text` (e.g.
+	 * `*Added 👍 to: "first 50 chars…"*`) set this so context-building can feed
+	 * the planner the complete reacted-to statement instead of a truncated
+	 * fragment it would otherwise back-rationalize into a phantom task (#9874).
+	 */
+	reactedMessageText?: string;
+
 	/** Array of media attachments */
 	attachments?: Media[];
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -499,6 +499,7 @@ export const formatMessages = ({
 		}
 
 		const messageText = (message.content as Content).text;
+		const reactedMessageText = (message.content as Content).reactedMessageText;
 		const messageActions = (message.content as Content).actions;
 		const messageThought = (message.content as Content).thought;
 		const foundEntity = entityById.get(message.entityId);
@@ -562,6 +563,13 @@ export const formatMessages = ({
 		const textString = messageText
 			? `${timestampString} ${formattedName}: ${messageText}`
 			: null;
+		// A reaction message's `text` is a short stub that truncates the reacted-to
+		// content; surface the full original so the planner reads the complete
+		// statement and does not back-rationalize a truncated fragment (#9874).
+		const reactedContextString =
+			typeof reactedMessageText === "string" && reactedMessageText.trim()
+				? `(reacted-to message in full: "${reactedMessageText.trim()}")`
+				: null;
 		const actionString =
 			messageActions && messageActions.length > 0
 				? `${
@@ -571,6 +579,7 @@ export const formatMessages = ({
 
 		const messageString = [
 			textString,
+			reactedContextString,
 			thoughtString,
 			actionString,
 			attachmentString,

--- a/plugins/plugin-discord/discord-reactions.ts
+++ b/plugins/plugin-discord/discord-reactions.ts
@@ -183,6 +183,11 @@ export async function handleReaction(
 				source: "discord",
 				inReplyTo,
 				channelType,
+				// `text` above truncates the reacted-to message to a 50-char display
+				// stub; preserve the full original so context-building feeds the
+				// planner the complete statement, not a fragment it back-rationalizes
+				// into a phantom task (#9874 item 2).
+				...(messageContent ? { reactedMessageText: messageContent } : {}),
 			},
 			metadata: {
 				accountId,


### PR DESCRIPTION
Closes the three deferred **structural** root-causes from the multi-bot arena confabulation incident (#9874). The shipped prompt patch (#9875) neutralized the *observed* failure; this PR fixes the durable class causes that produced the false-ack seed.

### 1. Bot-to-bot crosstalk no longer forces `requiresTool`
The false-ack seed fired because the `simple→requiresTool` promotion ran on a message addressed to **another bot** (not us/owner). The agent was overhearing crosstalk it was never asked to act on, but got pushed into the planner and fabricated a phantom task.

- **`addresseeIsNonOwnerBot()`** (`runtime/addressed-to.ts`): returns true **only** when the message carries explicit addressees, **none is this agent** (by name or id), and it is genuine bot crosstalk — the sender is a bot (`metadata.fromBot`) **or** an addressee resolves to a registered agent (`getAgent`). Fails **safe** (no suppression) whenever it can't positively confirm crosstalk. A human owner is never a registered agent and never carries `fromBot`, so owner-directed talk never trips it.
- **`routeMessageHandlerOutput(output, { suppressToolPromotion })`**: pure flag; when set, the simple-path promotion is skipped and the **Stage-1 simple reply still ships** (the agent stays conversational, it just doesn't force a tool). The message-service call site computes the flag, cheap-gated to the promotion path + explicit addressees only.

### 2. Reaction-stub truncation no longer drops reacted-to text in context
A reacted-to message was reduced to a 50-char stub (`*Added 👍 to: "…"*`), so the planner fused a dangling ack with a truncated statement and back-rationalized a task.

- New **`Content.reactedMessageText`** carries the untruncated original.
- **`formatMessages`** renders it (`(reacted-to message in full: "…")`) so the planner reads the complete statement. The short display stub is preserved for the transcript.
- Wired for the Discord reaction path (`plugin-discord/discord-reactions.ts`). Connector-agnostic: any connector can set the field.

### 3. Safe forced-tool-exhaustion reply (deferred Fix 2)
When a turn is forced to call a tool the model legitimately can't satisfy, it previously errored into a generic apology. Now an honest native-mode refusal is surfaced — but **gated** so a pre-tool thought is never leaked.

- New `userSafeRefusalCandidate()` / `looksLikePreToolThought()` in `planner-loop.ts`: the captured native fallback must pass `isUnsafeUserVisibleText` (rejects reasoning/leak/fabrication) **and** not be pre-tool deliberation. The existing `does not capture native text fallback` guard test still holds.

---

### Evidence
- **`bun run --cwd packages/core test` → 248 files, 2221 passed, 1 skipped, 0 failed** (full core suite, on top of `develop`).
- New/changed test coverage (11 new cases, all green):
  - `runtime/__tests__/addressed-to.test.ts` (new, 7): empty / addressed-to-self by name+id / bot-sender crosstalk / addressee-is-registered-agent / human addressee / unresolved name.
  - `runtime/__tests__/message-handler.test.ts` (+2): suppression flips promotion→`final_reply`; leaves explicit non-simple planning intact.
  - `runtime/__tests__/planner-loop.test.ts` (+2): safe native refusal captured + surfaced; negative control (leaked tool-call rejected, still throws).
  - `__tests__/messages-format.test.ts` (+2): full reacted text rendered; absent field renders nothing.
- `bun run --cwd packages/core typecheck` → clean. `bun run --cwd plugins/plugin-discord typecheck` → clean.

All changes are additive (new optional param defaulting to no-op; new optional field defaulting to no-op) — no behavior change for the non-crosstalk / non-reaction / non-exhaustion paths.
