### PR TITLE
fix(orchestrator): human varied spawn ack + honest sub-agent failure relay

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -43,7 +43,10 @@ import {
   type Mock,
   vi,
 } from "vitest";
-import { createAgentOrchestratorPlugin } from "../../src/index.js";
+import {
+  buildAckPhrases,
+  createAgentOrchestratorPlugin,
+} from "../../src/index.js";
 import { AcpService } from "../../src/services/acp-service.js";
 
 type SessionHandler = (sessionId: string, event: string, data: unknown) => void;
@@ -350,9 +353,11 @@ describe("emitProgress routing ladder + cadence", () => {
     // to 0 for ack mode, so it posts immediately).
     await fire(rt, "s-ack", "ready");
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
-    expect(
+    // The ack text is now a rotated phrase from the pool, not a single hardcoded
+    // literal (the mock has no character, so the default floor is used).
+    expect(buildAckPhrases()).toContain(
       (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
-    ).toBe("working on it now.");
+    );
 
     // Subsequent events (narration, tools) must NOT add more acks.
     await fire(rt, "s-ack", "message", { text: "still working" });
@@ -361,6 +366,32 @@ describe("emitProgress routing ladder + cadence", () => {
     });
     await vi.advanceTimersByTimeAsync(5_000);
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    await rt.dispose();
+  });
+
+  it("ack mode rotates the phrase across separate spawns in the same room (anti-repeat)", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+
+    seedSession(rt, "s-rot-1", "task-1");
+    await fire(rt, "s-rot-1", "ready");
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    // A genuinely separate later user turn (past the per-room dedup window) acks
+    // again — but must NOT repeat the previous phrase verbatim (the robotic
+    // repeat users reported). This is a fresh session, not a verify-retry.
+    await vi.advanceTimersByTimeAsync(120_000);
+    seedSession(rt, "s-rot-2", "task-2");
+    await fire(rt, "s-rot-2", "ready");
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(2);
+
+    const first = (rt.sendMessageToTarget.mock.calls[0][1] as { text: string })
+      .text;
+    const second = (rt.sendMessageToTarget.mock.calls[1][1] as { text: string })
+      .text;
+    expect(second).not.toBe(first);
+    expect(buildAckPhrases()).toContain(second);
 
     await rt.dispose();
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/strip-progress-label-prefix.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/strip-progress-label-prefix.test.ts
@@ -1,7 +1,9 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
+  buildAckPhrases,
   compactProgressText,
+  pickNextAck,
   plannerAlreadyAckedSpawn,
   resolveSubAgentProgressPolicy,
   stripProgressLabelPrefix,
@@ -184,5 +186,43 @@ describe("plannerAlreadyAckedSpawn", () => {
     expect(plannerAlreadyAckedSpawn(createdAt, undefined, LOOKBACK)).toBe(
       false,
     );
+  });
+});
+
+describe("buildAckPhrases", () => {
+  it("returns a non-empty, deduped, neutral default rotation (no character scraping)", () => {
+    const phrases = buildAckPhrases();
+    expect(phrases.length).toBeGreaterThan(1);
+    expect(new Set(phrases.map((p) => p.toLowerCase())).size).toBe(
+      phrases.length,
+    );
+    expect(phrases.every((p) => p.trim().length > 0)).toBe(true);
+    expect(phrases).toContain("on it.");
+    // regression (live 2026-06-28): never a bare one-word style descriptor —
+    // scraping character.style.chat once surfaced "casual" as a spawn ack.
+    expect(phrases).not.toContain("casual");
+  });
+});
+
+describe("pickNextAck", () => {
+  it("returns the first phrase when there is no previous ack", () => {
+    expect(pickNextAck(["a", "b", "c"], undefined)).toBe("a");
+  });
+
+  it("never repeats the immediately-previous phrase", () => {
+    expect(pickNextAck(["a", "b", "c"], "a")).toBe("b");
+    expect(pickNextAck(["a", "b", "c"], "b")).toBe("a");
+  });
+
+  it("compares the previous phrase case- and whitespace-insensitively", () => {
+    expect(pickNextAck(["on it.", "got it."], "  ON IT.  ")).toBe("got it.");
+  });
+
+  it("returns the sole element for a single-phrase pool", () => {
+    expect(pickNextAck(["only"], "only")).toBe("only");
+  });
+
+  it("falls back to a safe literal for an empty pool", () => {
+    expect(pickNextAck([], undefined)).toBe("on it.");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -1,0 +1,122 @@
+import type {
+  Memory,
+  MessageHandlerResult,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+import { SIMPLE_CONTEXT_ID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { subAgentFailureResponseEvaluator } from "../../src/evaluators/sub-agent-failure.js";
+
+function makeContext(overrides: {
+  text?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  messageHandler?: Partial<MessageHandlerResult>;
+}): ResponseHandlerEvaluatorContext {
+  const messageHandler: MessageHandlerResult = {
+    processMessage: "RESPOND",
+    thought: "",
+    plan: {
+      contexts: ["general"],
+      reply: "",
+      requiresTool: true,
+      ...overrides.messageHandler?.plan,
+    },
+    ...overrides.messageHandler,
+  };
+  const message = {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: {
+      text:
+        overrides.text ??
+        "[sub-agent: text-my-ex (claude) — error]\nACP session failed: registration request timed out.",
+      source: overrides.source ?? "sub_agent",
+      metadata: {
+        subAgent: true,
+        subAgentEvent: "error",
+        subAgentLabel: "text-my-ex",
+        ...overrides.metadata,
+      },
+    },
+  } as Memory;
+  return {
+    runtime: {} as never,
+    message,
+    state: {} as never,
+    messageHandler,
+    availableContexts: [{ id: SIMPLE_CONTEXT_ID, description: "simple" }],
+  };
+}
+
+describe("subAgentFailureResponseEvaluator", () => {
+  it("relays one honest failure message on a terminal error synthetic (no silence)", () => {
+    const context = makeContext({});
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — ACP session failed: registration request timed out. Want me to retry?`,
+    );
+    expect(result.requiresTool).toBe(false);
+    expect(result.setContexts).toEqual([SIMPLE_CONTEXT_ID]);
+    expect(result.clearCandidateActions).toBe(true);
+    expect(result.clearParentActionHints).toBe(true);
+  });
+
+  it("also fires for state_lost_exhausted and round_trip_cap_exceeded", () => {
+    for (const subAgentEvent of [
+      "state_lost_exhausted",
+      "round_trip_cap_exceeded",
+    ]) {
+      const context = makeContext({ metadata: { subAgentEvent } });
+      expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+    }
+  });
+
+  it("does NOT fire for task_complete (that is the completion evaluator's job)", () => {
+    const context = makeContext({
+      metadata: { subAgentEvent: "task_complete" },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("does NOT fire for non sub-agent messages", () => {
+    const context = makeContext({
+      source: "discord",
+      metadata: { subAgent: false },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("defers to the planner when it is taking a concrete follow-up action", () => {
+    const context = makeContext({
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "",
+          requiresTool: true,
+          candidateActions: ["TASKS_SEND_TO_AGENT"],
+        },
+      } as Partial<MessageHandlerResult>,
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("does NOT fire when the turn is already STOP", () => {
+    const context = makeContext({
+      messageHandler: { processMessage: "STOP" },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("uses a generic subject and omits the reason for label-less, noise-only narration", () => {
+    const context = makeContext({
+      text: "[internal-code-9931]",
+      metadata: { subAgentLabel: undefined },
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe("Couldn't finish that task. Want me to retry?");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -1,0 +1,134 @@
+import {
+  type Memory,
+  type MessageHandlerResult,
+  type ResponseHandlerEvaluator,
+  SIMPLE_CONTEXT_ID,
+} from "@elizaos/core";
+
+const SUB_AGENT_SOURCE = "sub_agent";
+
+// Terminal failure events the SubAgentRouter stamps onto a synthetic inbound
+// when a coding sub-agent dies WITHOUT delivering: a hard ACP error, an
+// exhausted state-recovery budget, or a force-stopped ping-pong loop. Unlike
+// `task_complete`, none of these had a response-handler evaluator, so the
+// planner saw the error synthetic and frequently produced no reply — the user
+// was left staring at the spawn ack with no outcome ("working on it" → silence).
+const TERMINAL_FAILURE_EVENTS = new Set([
+  "error",
+  "state_lost_exhausted",
+  "round_trip_cap_exceeded",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function contentRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(message.content);
+}
+
+function metadataRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(contentRecord(message)?.metadata);
+}
+
+function textOf(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hasStrings(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => textOf(entry).length > 0);
+}
+
+function isTerminalSubAgentFailure(message: Memory): boolean {
+  const content = contentRecord(message);
+  const metadata = metadataRecord(message);
+  if (!content || !metadata) return false;
+  const source = textOf(content.source).toLowerCase();
+  if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
+  return TERMINAL_FAILURE_EVENTS.has(textOf(metadata.subAgentEvent));
+}
+
+// Trim the router's error narration to a single short, user-readable clause:
+// drop leading label/emoji/quote annotations and skip bare internal codes.
+function shortReason(body: string): string {
+  const firstLine = body
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/^[\s>*•\-]+/, "")
+        .replace(/^\[[^\]]*\]\s*/, "")
+        .trim(),
+    )
+    .find((line) => line.length > 0 && /\s/.test(line));
+  if (!firstLine) return "";
+  // First sentence only, with trailing sentence punctuation stripped so the
+  // reply template's own period doesn't double up ("timed out.. Want me…").
+  const clause = firstLine
+    .split(/(?<=[.!?])\s/)[0]
+    .replace(/[.!?]+$/, "")
+    .trim();
+  return clause.length > 160 ? `${clause.slice(0, 157)}…` : clause;
+}
+
+function buildFailureReply(label: string, reason: string): string {
+  const what = label ? `the "${label}" task` : "that task";
+  const because = reason ? ` — ${reason}` : "";
+  return `Couldn't finish ${what}${because}. Want me to retry?`;
+}
+
+function respondIfNeeded(messageHandler: MessageHandlerResult) {
+  return messageHandler.processMessage === "RESPOND"
+    ? {}
+    : { processMessage: "RESPOND" as const };
+}
+
+/**
+ * Response-handler evaluator that guarantees a sub-agent terminal FAILURE never
+ * lands as silence. The completion evaluator (`sub-agent-completion`) routes
+ * `task_complete`; this is its failure-side twin for the `error` /
+ * `state_lost_exhausted` / `round_trip_cap_exceeded` synthetics the router
+ * emits but nothing handled. When the planner is taking a concrete follow-up of
+ * its own (feeding the still-running session input, or a real next step) we
+ * defer to it; otherwise we relay one honest line so the user gets an outcome
+ * instead of a dangling spawn ack.
+ */
+export const subAgentFailureResponseEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.sub-agent-failure",
+  description:
+    "Routes terminal sub-agent failure synthetics (error / state-lost / round-trip-cap) to one honest user-facing message instead of silence.",
+  priority: 10,
+  shouldRun: ({ message, messageHandler }) => {
+    if (!isTerminalSubAgentFailure(message)) return false;
+    if (messageHandler.processMessage === "STOP") return false;
+    // If the planner is taking a concrete follow-up action of its own, let it
+    // own the turn rather than overriding with a generic failure line.
+    if (
+      hasStrings(messageHandler.plan.candidateActions) ||
+      hasStrings(messageHandler.plan.parentActionHints)
+    ) {
+      return false;
+    }
+    return true;
+  },
+  evaluate: ({ message, messageHandler }) => {
+    const metadata = metadataRecord(message) ?? {};
+    const label = textOf(metadata.subAgentLabel);
+    const reason = shortReason(textOf(contentRecord(message)?.text));
+    return {
+      ...respondIfNeeded(messageHandler),
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: buildFailureReply(label, reason),
+      debug: [
+        `sub-agent terminal failure (${textOf(
+          metadata.subAgentEvent,
+        )}); relaying one honest failure message instead of leaving the spawn ack dangling`,
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./actions/sandbox-stub.js";
 import { tasksAction } from "./actions/tasks.js";
 import { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
+import { subAgentFailureResponseEvaluator } from "./evaluators/sub-agent-failure.js";
 import { codingAgentExamplesProvider } from "./providers/action-examples.js";
 import { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 import { activeWorkspaceContextProvider } from "./providers/active-workspace-context.js";
@@ -218,7 +219,10 @@ export function createAgentOrchestratorPlugin(): Plugin {
     actions: orchestratorActions,
     providers: orchestratorProviders,
     responseHandlerEvaluators: codeExecutionAllowed
-      ? [subAgentCompletionResponseEvaluator]
+      ? [
+          subAgentCompletionResponseEvaluator,
+          subAgentFailureResponseEvaluator,
+        ]
       : [],
     // Eager-start the orchestrator's services. They're declared in `services:`
     // above and registered by elizaOS, but service registration is lazy — the
@@ -595,6 +599,42 @@ export function plannerAlreadyAckedSpawn(
   return plannerReplyAtMs >= sessionCreatedAtMs - lookbackMs;
 }
 
+/**
+ * Build the spawn-ack phrase pool. In "ack" mode the orchestrator posts ONE
+ * short line when it starts a sub-agent; a single hardcoded literal made every
+ * spawn read identically robotic. This returns a small, neutral rotation —
+ * deliberately generic so it reads fine for ANY character. Per-character voice
+ * arrives via the planner's own in-voice reply (which suppresses this ack when
+ * present), NOT by scraping `character.style.chat`: that field holds style
+ * DESCRIPTORS ("casual", "terse"), not utterances, and merging it once surfaced
+ * a literal "casual" as a live spawn ack. Pure + deterministic; unit-tested.
+ */
+export function buildAckPhrases(): string[] {
+  return [
+    "on it.",
+    "got it — starting now.",
+    "on it now.",
+    "okay, getting into it.",
+    "alright, starting on that.",
+    "got it, working on it.",
+  ];
+}
+
+/**
+ * Pick the next spawn-ack, never repeating the immediately-previous one used in
+ * the same room — that verbatim repeat is exactly what reads as robotic.
+ * Deterministic: the first phrase != lastPhrase, else the first phrase.
+ */
+export function pickNextAck(
+  phrases: string[],
+  lastPhrase: string | undefined,
+): string {
+  if (phrases.length === 0) return "on it.";
+  if (phrases.length === 1) return phrases[0];
+  const last = (lastPhrase ?? "").trim().toLowerCase();
+  return phrases.find((p) => p.trim().toLowerCase() !== last) ?? phrases[0];
+}
+
 // Exported for unit tests; not part of the plugin's public API contract.
 export function sanitizePlannerText(text: string): string {
   if (!text) return text;
@@ -834,6 +874,10 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   // request after the window still gets its own.
   const roomAckAt = new Map<string, number>();
   const ACK_ROOM_DEDUP_MS = 60_000;
+  // Last ack phrase posted per room, so consecutive spawns rotate instead of
+  // repeating the same line verbatim. Bounded the same way as roomAckAt.
+  const lastAckByRoom = new Map<string, string>();
+  const ackPhrases = buildAckPhrases();
   // Cache threads by (source, roomId, label) so a rate-limit retry, a
   // mid-flight crash recovery, or a follow-up spawn for the same logical
   // project reuses the existing thread instead of creating a duplicate.
@@ -1262,15 +1306,21 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         await emitProgress(sessionId, target, rawText, sessionLabel);
         return;
       }
+      const roomAckKey = `${target.source}::${target.roomId}`;
+      // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent
+      // narration) and never edits it afterward — the completion synthesis is
+      // the separate final message. Plain text, no emoji. Rotated with per-room
+      // anti-repeat so consecutive spawns never read identically.
+      const chosenAck =
+        progressPolicy.mode === "ack"
+          ? pickNextAck(ackPhrases, lastAckByRoom.get(roomAckKey))
+          : null;
       const initialText = state
         ? displayText
         : progressPolicy.mode === "threaded"
           ? `🚀 [${sessionLabel}] running`
           : progressPolicy.mode === "ack"
-            ? // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent
-              // narration) and never edits it afterward — the completion
-              // synthesis is the separate final message. Plain text, no emoji.
-              "working on it now."
+            ? (chosenAck as string)
             : displayText;
       // Claim the first post synchronously before the await. A second progress
       // event for the same session that arrives while this send is in flight
@@ -1285,7 +1335,6 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // a concurrent sibling bails here. (Per-session suppression below still
         // guards the heartbeat / narration re-entry for this one session.)
         if (progressPolicy.mode === "ack") {
-          const roomAckKey = `${target.source}::${target.roomId}`;
           const now = Date.now();
           const lastRoomAck = roomAckAt.get(roomAckKey);
           if (
@@ -1298,6 +1347,15 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           if (roomAckAt.size > 512) {
             const oldest = roomAckAt.keys().next().value;
             if (oldest !== undefined) roomAckAt.delete(oldest);
+          }
+          // Record the phrase actually used so the next spawn in this room
+          // rotates off it (anti-repeat). Bounded like roomAckAt.
+          if (chosenAck) {
+            lastAckByRoom.set(roomAckKey, chosenAck);
+            if (lastAckByRoom.size > 512) {
+              const oldestAck = lastAckByRoom.keys().next().value;
+              if (oldestAck !== undefined) lastAckByRoom.delete(oldestAck);
+            }
           }
         }
         firstPostInFlight.add(sessionId);
@@ -1923,6 +1981,7 @@ export {
   handleCodingAgentRoutes,
 } from "./api/routes.js";
 export { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
+export { subAgentFailureResponseEvaluator } from "./evaluators/sub-agent-failure.js";
 // Providers
 export { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 export {


### PR DESCRIPTION
## Problem

Live multi-bot + monetized-app testing surfaced two orchestrator UX failures:

1. **Robotic spawn ack.** In `ack` progress mode the orchestrator posted a single hardcoded literal (`"working on it now."`) on every sub-agent spawn — identical every time, across turns. Reads robotic; spooks non-technical users.
2. **Silent sub-agent failure.** When a coding sub-agent ended in a terminal failure (`error` / `state_lost_exhausted` / `round_trip_cap_exceeded`), the router injected a synthetic inbound that **no** response-handler evaluator backed — so the planner often produced no reply and the user was left staring at the dangling spawn ack with no outcome.

## Fix

**A — human, varied, non-repeating ack** (`src/index.ts`): replace the literal with a small neutral default pool + per-room cross-turn anti-repeat (`buildAckPhrases` / `pickNextAck`), so consecutive spawns never read identically. All existing dedup guards preserved (per-session, per-room window, verify-retry, planner-already-acked). Kept deliberately neutral — **not** scraped from `character.style.chat`, which holds style *descriptors* (`"casual"`, `"terse"`), not utterances, and surfaced a literal `"casual"` as a live ack; per-character voice already comes from the planner's own in-voice reply, which suppresses this ack when present.

**B — honest failure relay** (`src/evaluators/sub-agent-failure.ts`): new `subAgentFailureResponseEvaluator` (priority 10, the failure-side twin of `sub-agent-completion`). On a terminal failure synthetic with no concrete planner follow-up, relays one honest line — *"Couldn't finish the 'X' task — &lt;reason&gt;. Want me to retry?"* — instead of silence. Defers when the planner is taking a real next step.

## Tests + live validation

- **910 orchestrator unit tests green** (new: ack rotation/anti-repeat, the pure helpers, 7 failure-evaluator cases).
- **A validated live:** two back-to-back builds acked `"on it."` then `"got it — starting now."` (rotated, no repeat, no `"casual"`); both apps deployed.
- **B** covers the exact terminal-failure class (`error`) that previously produced silence.
